### PR TITLE
fix: write sudoers entry on jump server account create

### DIFF
--- a/internal/container/jump_server.go
+++ b/internal/container/jump_server.go
@@ -60,8 +60,18 @@ func CreateJumpServerAccount(username string, sshPublicKey string, verbose bool)
 		return err
 	}
 
+	// Sudoers entry for incus access. Required when the user's login shell is
+	// containarium-shell (proxies into the container via `sudo incus exec`).
+	// Harmless when the shell is nologin (no login = no sudo).
+	sudoersEntry := fmt.Sprintf("%s ALL=(root) NOPASSWD: /usr/bin/incus\n", username)
+	sudoersPath := fmt.Sprintf("/etc/sudoers.d/containarium-%s", username)
+	if err := os.WriteFile(sudoersPath, []byte(sudoersEntry), 0440); err != nil { // #nosec G306 -- sudoers requires 0440
+		_ = exec.Command("userdel", "-r", username).Run()
+		return fmt.Errorf("failed to write sudoers: %w", err)
+	}
+
 	if verbose {
-		fmt.Printf("  ✓ Jump server account created: %s (no shell access, proxy-only)\n", username)
+		fmt.Printf("  ✓ Jump server account created: %s\n", username)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

`internal/container/jump_server.go:CreateJumpServerAccount` (the path used when the daemon auto-creates a container's host user — see `manager.go:184`, `cmd/create.go:229`, `collaborator.go:79,343`, `cmd/recover.go:418`, `cmd/sync_accounts.go:127`) only ran `useradd` + `setupUserSSHKey`. It never wrote `/etc/sudoers.d/containarium-<user>`, so the user's `containarium-shell` hit a password prompt on every SSH because `sudo incus exec` had no NOPASSWD rule.

The other entry point, `EnsureJumpServerAccount`, already wrote the sudoers entry (see line 154 pre-change). This fix brings `CreateJumpServerAccount` to parity.

**Symptom**: `ssh <user>` returned `[sudo] password for <user>:` and hung. Caught on lab pool with newly-created `hsinho` and `jyunfan` containers; `test01` worked because it had been bootstrapped via `setup-peer-user.sh`, which writes the sudoers entry directly.

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./internal/container/` — passes
- [x] `go test ./internal/container/` — passes
- [x] Manually verified on lab: writing the missing sudoers entries (`/etc/sudoers.d/containarium-hsinho`, `containarium-jyunfan`) → `ssh hsinho` lands cleanly inside `hsinho-container` without prompt
- [ ] After merge: existing host users on lab/fts-5900x with stale missing-sudoers state stay broken until the daemon recreates them or operator runs `setup-peer-user.sh`. Document in upgrade notes.

## Notes

- Sudoers entry is harmless when shell is `nologin` (no login = no sudo invocation), so we always write it without checking which shell the user was created with.
- On useradd success but sudoers write failure, we now `userdel -r` to roll back, mirroring the existing rollback for SSH-key write failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)