### PR TITLE
chore: bump version to v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-05-06
+
+### Fixed
+- **Jump server account missing sudoers entry** (`internal/container/jump_server.go`): `CreateJumpServerAccount` (the path used when the daemon auto-creates a container's host user) wrote `useradd` and the SSH key but never wrote `/etc/sudoers.d/containarium-<user>`. The user's `containarium-shell` then hit a password prompt on every SSH because `sudo incus exec` had no NOPASSWD rule. `EnsureJumpServerAccount` (a separate entry point) already had the sudoers write; this brings the primary path to parity. Symptom: `ssh <user>` returned `[sudo] password for <user>:` and hung. Existing host users on running daemons stay broken until the operator writes the sudoers file manually (see `setup-peer-user.sh`) or the daemon recreates them.
+
 ## [0.16.0] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ It is intentionally simple.
 ## Status
 
 - Actively used in production (GCP + bare-metal GPU nodes)
-- v0.16.0 — multi-pool architecture, GPU-by-PCI, lab pool SSH
+- v0.16.1 — multi-pool architecture, GPU-by-PCI, lab pool SSH
 - APIs stable (protobuf-defined with gRPC-gateway)
 - Contributions and feedback welcome
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.16.0"
+	Version = "0.16.1"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary

Patch release for the sudoers fix shipped in PR #101 (`fix: write sudoers entry on jump server account create`).

## Changes since v0.16.0

- **Fixed**: `CreateJumpServerAccount` now writes `/etc/sudoers.d/containarium-<user>`, matching the existing behavior in `EnsureJumpServerAccount`. Daemon-auto-created container users no longer hit a password prompt on `ssh <user>`.

## Test plan

- [x] `go build ./...` — passes
- [x] `pkg/version/version.go` reads `0.16.1`
- [x] `CHANGELOG.md` headers: `[Unreleased]` → `[0.16.1] - 2026-05-06` → `[0.16.0] - 2026-05-06` → `[0.14.0] - 2026-03-28`
- [x] `README.md` status line says v0.16.1
- [ ] After merge: `git tag -a v0.16.1 -m "v0.16.1: jump server sudoers fix" && git push origin v0.16.1`
- [ ] Build + upload binaries (linux-amd64, darwin-amd64, darwin-arm64) to GitHub Release
- [ ] Update daemon binary on lab, fts-5900x, fts-13700k, prod spot VM (`systemctl restart containarium`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)