### PR TITLE
chore: bump version to v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-05-08
+
+### Fixed
+- **`containarium-shell` breaks collaborator SSH logins** (`scripts/setup-peer-user.sh`): The shell script derived the target container as `${USERNAME}-container`, so a collaborator account `voice-dev-container-test` resolved to `voice-dev-container-test-container` (nonexistent), producing `Error: Container not found` on every login. Collaborator accounts follow the `<owner>-container-<collaborator>` naming pattern; the container is `<owner>-container`. Fix: if the primary container lookup fails, strip the trailing `-<collaborator>` suffix with `${USERNAME%-*}` and retry. Regular owner accounts (`voice-dev` → `voice-dev-container`) are unaffected. Existing deployments must re-push the script to each node (GCP spot VM and peer nodes).
+
 ## [0.16.1] - 2026-05-06
 
 ### Fixed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.16.1"
+	Version = "0.16.2"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""

--- a/scripts/setup-peer-user.sh
+++ b/scripts/setup-peer-user.sh
@@ -38,6 +38,15 @@ if [[ ! -f /usr/local/bin/containarium-shell ]]; then
 USERNAME="$(whoami)"
 CONTAINER="${USERNAME}-container"
 
+# Collaborator accounts use the pattern <owner>-container-<collaborator>.
+# If the derived container doesn't exist, try stripping the collaborator suffix.
+if ! sudo incus info "$CONTAINER" &>/dev/null; then
+    STRIPPED="${USERNAME%-*}"
+    if [ "$STRIPPED" != "$USERNAME" ] && sudo incus info "$STRIPPED" &>/dev/null; then
+        CONTAINER="$STRIPPED"
+    fi
+fi
+
 if ! sudo incus info "$CONTAINER" &>/dev/null; then
     echo "Error: Container $CONTAINER not found" >&2
     exit 1


### PR DESCRIPTION
## Summary
- Fix `containarium-shell` to handle collaborator SSH logins (`scripts/setup-peer-user.sh`)
- Bump version to v0.16.2
- Update CHANGELOG

## Root cause
Collaborator accounts follow the pattern `<owner>-container-<collaborator>` (e.g. `voice-dev-container-test`). The shell script derived the container as `${USERNAME}-container`, giving `voice-dev-container-test-container` which doesn't exist. The fix strips the collaborator suffix with `${USERNAME%-*}` and retries before failing.

## Deployment
The patched shell is already live on:
- ✅ `containarium-jump-usw1` (GCP spot VM)
- ⏳ `fts-5900x` — script staged at `/tmp/containarium-shell.new`, needs: `sudo cp /tmp/containarium-shell.new /usr/local/bin/containarium-shell`
- ⏳ `fts-13700k` — same

## Test plan
- [x] `ssh voice-dev-container-test 'whoami'` returns `voice-dev-container-test` on the GCP node
- [ ] Verify same on peer nodes after manual copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)