### PR TITLE
feat(daemon): caddy-l4 PROXY protocol — wrapping-aware lifecycle

### DIFF
--- a/internal/app/caddy_types.go
+++ b/internal/app/caddy_types.go
@@ -170,10 +170,15 @@ type CaddyL4TLSMatch struct {
 	SNI []string `json:"sni"`
 }
 
-// CaddyL4Handler represents a layer4 handler (proxy or subroute)
+// CaddyL4Handler represents a layer4 handler (proxy or subroute).
+// ProxyProtocol is set on the catchall's proxy handler to "v2" when the L4
+// server is in PROXY-aware mode — caddy-l4 then re-emits a PROXY v2 header
+// to the upstream HTTP server (srv0) so srv0's listener_wrapper can recover
+// the parsed source.
 type CaddyL4Handler struct {
-	Handler   string           `json:"handler"`
-	Upstreams []CaddyL4Upstream `json:"upstreams,omitempty"`
+	Handler       string            `json:"handler"`
+	Upstreams     []CaddyL4Upstream `json:"upstreams,omitempty"`
+	ProxyProtocol string            `json:"proxy_protocol,omitempty"`
 }
 
 // CaddyL4Upstream represents an upstream for layer4 proxy

--- a/internal/app/l4_proxy.go
+++ b/internal/app/l4_proxy.go
@@ -31,9 +31,19 @@ type L4Route struct {
 // L4ProxyManager manages Caddy L4 (TLS passthrough) routes via the admin API.
 // L4 is activated lazily — only when TLS passthrough routes exist in the database.
 // Activation uses Caddy's /load endpoint for atomic config replacement.
+//
+// When proxyProtocolTrusted is non-empty, the L4 server is structured per the
+// sandbox-tier-1-verified pattern B: a single outer route whose handlers are
+// (proxy_protocol, subroute), with the catchall inside the subroute tagged
+// with proxy_protocol: "v2" so caddy-l4 emits a PROXY header to srv0. SNI
+// passthrough routes live inside the subroute too — getRoutes/putRoutes
+// detect the wrapping and operate on the inner route list, so the existing
+// AddL4Route / RemoveL4Route / ListL4Routes flows continue to work without
+// changes.
 type L4ProxyManager struct {
-	caddyAdminURL string
-	httpClient    *http.Client
+	caddyAdminURL        string
+	httpClient           *http.Client
+	proxyProtocolTrusted []string // empty = no PROXY-protocol awareness
 }
 
 // NewL4ProxyManager creates a new L4 proxy manager.
@@ -44,6 +54,31 @@ func NewL4ProxyManager(caddyAdminURL string) *L4ProxyManager {
 			Timeout: 10 * time.Second,
 		},
 	}
+}
+
+// SetProxyProtocolTrusted records the CIDRs from which the L4 server will
+// accept PROXY v2 headers. Once set, every subsequent ActivateL4 produces the
+// wrapped pattern-B shape (and EnableL4ProxyProtocol can re-shape an already
+// active server).
+//
+// trustedSenderCIDRs MUST NOT be empty or wildcard.
+func (m *L4ProxyManager) SetProxyProtocolTrusted(trustedSenderCIDRs []string) error {
+	if len(trustedSenderCIDRs) == 0 {
+		return fmt.Errorf("L4ProxyManager.SetProxyProtocolTrusted: trustedSenderCIDRs must not be empty")
+	}
+	for _, c := range trustedSenderCIDRs {
+		if c == "0.0.0.0/0" || c == "::/0" {
+			return fmt.Errorf("L4ProxyManager.SetProxyProtocolTrusted: refusing wildcard CIDR %q", c)
+		}
+	}
+	m.proxyProtocolTrusted = trustedSenderCIDRs
+	return nil
+}
+
+// proxyProtocolEnabled reports whether the manager has been configured to
+// produce the wrapped shape. Used by ActivateL4 + helpers.
+func (m *L4ProxyManager) proxyProtocolEnabled() bool {
+	return len(m.proxyProtocolTrusted) > 0
 }
 
 // IsL4Active checks if the L4 layer4 app is configured in Caddy
@@ -70,6 +105,14 @@ func (m *L4ProxyManager) IsL4Active() bool {
 // L4 app on :443 with a catch-all route that proxies to localhost:8443,
 // and atomically applies the config via POST /load.
 //
+// When the manager has been configured with proxyProtocolTrusted (via
+// SetProxyProtocolTrusted or EnableL4ProxyProtocol), the L4 server is
+// produced in the sandbox-tier-1-verified pattern B shape: a single outer
+// route whose handlers are (proxy_protocol, subroute), with the catchall
+// inside the subroute tagged with `proxy_protocol: "v2"` so caddy-l4
+// re-emits a PROXY header to srv0. SNI passthrough routes (added later via
+// AddL4Route) live inside the same subroute.
+//
 // This is idempotent — if L4 is already active, it returns nil.
 func (m *L4ProxyManager) ActivateL4() error {
 	if m.IsL4Active() {
@@ -91,27 +134,10 @@ func (m *L4ProxyManager) ActivateL4() error {
 		return fmt.Errorf("failed to modify HTTP server: %w", err)
 	}
 
-	// Create L4 app with catch-all route to HTTP server
+	// Create L4 app with the appropriate route shape.
 	apps["layer4"] = map[string]interface{}{
 		"servers": map[string]interface{}{
-			L4ServerName: map[string]interface{}{
-				"listen": []interface{}{":443"},
-				"routes": []interface{}{
-					// Catch-all (no match): proxy to HTTP server on :8443
-					map[string]interface{}{
-						"handle": []interface{}{
-							map[string]interface{}{
-								"handler": "proxy",
-								"upstreams": []interface{}{
-									map[string]interface{}{
-										"dial": []interface{}{l4HTTPFallbackDial},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			L4ServerName: m.buildL4ServerConfig([]interface{}{m.buildCatchallRoute()}),
 		},
 	}
 
@@ -119,8 +145,170 @@ func (m *L4ProxyManager) ActivateL4() error {
 		return fmt.Errorf("failed to load config with L4: %w", err)
 	}
 
-	log.Printf("[L4ProxyManager] Activated: HTTP moved to %s, L4 owns :443", l4HTTPFallbackListen)
+	if m.proxyProtocolEnabled() {
+		log.Printf("[L4ProxyManager] Activated (PROXY-aware): HTTP moved to %s, L4 owns :443, allow=%v",
+			l4HTTPFallbackListen, m.proxyProtocolTrusted)
+	} else {
+		log.Printf("[L4ProxyManager] Activated: HTTP moved to %s, L4 owns :443", l4HTTPFallbackListen)
+	}
 	return nil
+}
+
+// buildL4ServerConfig returns an L4 server config map using the supplied
+// "effective" inner-route list (i.e. the SNI routes plus catchall in their
+// natural order). When proxyProtocolEnabled, wraps them in the pattern B
+// outer route. When not, returns the flat (legacy) shape.
+func (m *L4ProxyManager) buildL4ServerConfig(innerRoutes []interface{}) map[string]interface{} {
+	if !m.proxyProtocolEnabled() {
+		return map[string]interface{}{
+			"listen": []interface{}{":443"},
+			"routes": innerRoutes,
+		}
+	}
+	return map[string]interface{}{
+		"listen": []interface{}{":443"},
+		"routes": []interface{}{
+			map[string]interface{}{
+				"handle": []interface{}{
+					m.buildProxyProtocolHandler(),
+					map[string]interface{}{
+						"handler": "subroute",
+						"routes":  innerRoutes,
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildCatchallRoute returns the catchall (no-match) route that forwards to
+// the HTTP server. When proxyProtocolEnabled, the proxy handler emits a
+// PROXY v2 header to srv0 so srv0's listener_wrapper can recover the source.
+func (m *L4ProxyManager) buildCatchallRoute() map[string]interface{} {
+	handler := map[string]interface{}{
+		"handler": "proxy",
+		"upstreams": []interface{}{
+			map[string]interface{}{"dial": []interface{}{l4HTTPFallbackDial}},
+		},
+	}
+	if m.proxyProtocolEnabled() {
+		handler["proxy_protocol"] = "v2"
+	}
+	return map[string]interface{}{
+		"handle": []interface{}{handler},
+	}
+}
+
+// buildProxyProtocolHandler returns the proxy_protocol layer4 handler that
+// consumes the PROXY v2 header from connections in the trusted CIDR list.
+func (m *L4ProxyManager) buildProxyProtocolHandler() map[string]interface{} {
+	allow := make([]interface{}, len(m.proxyProtocolTrusted))
+	for i, c := range m.proxyProtocolTrusted {
+		allow[i] = c
+	}
+	return map[string]interface{}{
+		"handler": "proxy_protocol",
+		"allow":   allow,
+		"timeout": "5s",
+	}
+}
+
+// EnableL4ProxyProtocol records the trusted PROXY senders on this manager and,
+// if L4 is already active in Caddy, re-shapes its routes into the wrapped
+// (pattern B) topology atomically. Future ActivateL4 calls (e.g. by
+// RouteSyncJob when a passthrough route lands in the DB) will also produce
+// the wrapped shape.
+//
+// Idempotent: a second call with the same CIDRs is a no-op when the L4 server
+// is already in wrapped form.
+func (m *L4ProxyManager) EnableL4ProxyProtocol(trustedCIDRs []string) error {
+	if err := m.SetProxyProtocolTrusted(trustedCIDRs); err != nil {
+		return err
+	}
+	if !m.IsL4Active() {
+		log.Printf("[L4ProxyManager] PROXY protocol configured (allow=%v); L4 not active yet, will apply on activation", trustedCIDRs)
+		return nil
+	}
+	return m.reshapeL4()
+}
+
+// reshapeL4 reads the current L4 server config, extracts the effective inner
+// route list (whether the server is currently wrapped or flat), tags the
+// catchall with proxy_protocol: "v2", and writes back the wrapped shape.
+func (m *L4ProxyManager) reshapeL4() error {
+	config, err := m.getFullConfig()
+	if err != nil {
+		return fmt.Errorf("get full config: %w", err)
+	}
+	apps := getMapField(config, "apps")
+	layer4 := getMapField(apps, "layer4")
+	servers := getMapField(layer4, "servers")
+	srv := getMapField(servers, L4ServerName)
+	if srv == nil {
+		return fmt.Errorf("L4 server %q missing", L4ServerName)
+	}
+	outerRoutes, _ := srv["routes"].([]interface{})
+	innerRoutes := effectiveInnerRoutes(outerRoutes)
+
+	// Tag the catchall (last route, no `match`) with proxy_protocol: "v2".
+	if len(innerRoutes) > 0 {
+		if last, ok := innerRoutes[len(innerRoutes)-1].(map[string]interface{}); ok {
+			if _, hasMatch := last["match"]; !hasMatch {
+				if hs, ok := last["handle"].([]interface{}); ok {
+					for _, h := range hs {
+						if hm, ok := h.(map[string]interface{}); ok && hm["handler"] == "proxy" {
+							hm["proxy_protocol"] = "v2"
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Replace the L4 server config with the wrapped shape.
+	servers[L4ServerName] = m.buildL4ServerConfig(innerRoutes)
+
+	if err := m.loadConfig(config); err != nil {
+		return fmt.Errorf("load wrapped L4 config: %w", err)
+	}
+	log.Printf("[L4ProxyManager] PROXY protocol enabled: %d inner route(s), allow=%v", len(innerRoutes), m.proxyProtocolTrusted)
+	return nil
+}
+
+// effectiveInnerRoutes returns the inner subroute's route list when outer is
+// wrapped, otherwise outer unchanged. Recognises the pattern B shape: a
+// single outer route with handlers [proxy_protocol, subroute].
+func effectiveInnerRoutes(outerRoutes []interface{}) []interface{} {
+	if !isWrappedRouteList(outerRoutes) {
+		return outerRoutes
+	}
+	outer, _ := outerRoutes[0].(map[string]interface{})
+	handlers, _ := outer["handle"].([]interface{})
+	sub, _ := handlers[1].(map[string]interface{})
+	inner, _ := sub["routes"].([]interface{})
+	return inner
+}
+
+// isWrappedRouteList reports whether the given outer-routes list is in the
+// pattern B wrapped shape: exactly one route whose first handler is
+// proxy_protocol.
+func isWrappedRouteList(outerRoutes []interface{}) bool {
+	if len(outerRoutes) != 1 {
+		return false
+	}
+	r, ok := outerRoutes[0].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	hs, ok := r["handle"].([]interface{})
+	if !ok || len(hs) == 0 {
+		return false
+	}
+	h0, ok := hs[0].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	return h0["handler"] == "proxy_protocol"
 }
 
 // DeactivateL4 atomically deactivates L4 routing, restoring HTTP server to :443.
@@ -254,58 +442,75 @@ func (m *L4ProxyManager) ListL4Routes() ([]L4Route, error) {
 
 // --- Internal helpers ---
 
-// getRoutes fetches the current L4 routes from Caddy.
+// getRoutes fetches the effective L4 routes from Caddy via the atomic full-
+// config GET. Returns the inner subroute's routes when the server is in
+// wrapped (pattern B) form, the outer routes when flat. Returns nil when L4
+// isn't configured yet.
 func (m *L4ProxyManager) getRoutes() ([]CaddyL4Route, error) {
-	url := fmt.Sprintf("%s/config/apps/layer4/servers/%s/routes", m.caddyAdminURL, L4ServerName)
-	resp, err := m.httpClient.Get(url)
+	config, err := m.getFullConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get L4 routes: %w", err)
+		return nil, fmt.Errorf("failed to get full config: %w", err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusNotFound {
+	srv := getMapField(getMapField(getMapField(config, "apps"), "layer4"), "servers")
+	server := getMapField(srv, L4ServerName)
+	if server == nil {
 		return nil, nil
 	}
+	outerRoutes, _ := server["routes"].([]interface{})
+	inner := effectiveInnerRoutes(outerRoutes)
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("caddy returned error (status %d): %s", resp.StatusCode, string(body))
+	// Round-trip the raw maps into typed routes for the caller.
+	body, err := json.Marshal(inner)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshal effective routes: %w", err)
 	}
-
 	var routes []CaddyL4Route
-	if err := json.NewDecoder(resp.Body).Decode(&routes); err != nil {
-		return nil, fmt.Errorf("failed to decode L4 routes: %w", err)
+	if err := json.Unmarshal(body, &routes); err != nil {
+		return nil, fmt.Errorf("decode effective routes: %w", err)
 	}
-
 	return routes, nil
 }
 
-// putRoutes replaces all L4 routes via PATCH (Caddy returns 409 on PUT for existing keys).
+// putRoutes replaces the effective L4 route list atomically via /load. When
+// the server is wrapped (pattern B), the inner subroute's `routes` is
+// replaced; outer wrapping is left intact. When flat, the outer `routes` is
+// replaced. Either way, the rest of the Caddy config is preserved verbatim.
 func (m *L4ProxyManager) putRoutes(routes []CaddyL4Route) error {
-	routesJSON, err := json.Marshal(routes)
+	config, err := m.getFullConfig()
 	if err != nil {
-		return fmt.Errorf("failed to marshal routes: %w", err)
+		return fmt.Errorf("get full config: %w", err)
+	}
+	apps := getMapField(config, "apps")
+	layer4 := getMapField(apps, "layer4")
+	servers := getMapField(layer4, "servers")
+	server := getMapField(servers, L4ServerName)
+	if server == nil {
+		return fmt.Errorf("L4 server %q not active — call ActivateL4 first", L4ServerName)
 	}
 
-	url := fmt.Sprintf("%s/config/apps/layer4/servers/%s/routes", m.caddyAdminURL, L4ServerName)
-	req, err := http.NewRequest("PATCH", url, bytes.NewReader(routesJSON))
+	// Round-trip typed routes into raw maps for embedding into the config tree.
+	body, err := json.Marshal(routes)
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return fmt.Errorf("marshal routes: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := m.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to patch routes: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("caddy error (status %d): %s", resp.StatusCode, string(body))
+	var newInner []interface{}
+	if err := json.Unmarshal(body, &newInner); err != nil {
+		return fmt.Errorf("decode new routes: %w", err)
 	}
 
-	return nil
+	outerRoutes, _ := server["routes"].([]interface{})
+	if isWrappedRouteList(outerRoutes) {
+		// Replace only the subroute's inner routes; keep the proxy_protocol
+		// handler and the outer wrapper structure untouched.
+		outer, _ := outerRoutes[0].(map[string]interface{})
+		handlers, _ := outer["handle"].([]interface{})
+		sub, _ := handlers[1].(map[string]interface{})
+		sub["routes"] = newInner
+	} else {
+		server["routes"] = newInner
+	}
+
+	return m.loadConfig(config)
 }
 
 // routeMatchesSNI checks if a route matches the given SNI hostname.

--- a/internal/app/l4_proxy_test.go
+++ b/internal/app/l4_proxy_test.go
@@ -1,0 +1,272 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestL4ProxyManager_EnableL4ProxyProtocol_NotActive: when L4 is not yet
+// active, EnableL4ProxyProtocol must record the trusted CIDRs without error
+// — ActivateL4 will produce the wrapped shape later when called by
+// RouteSyncJob.
+func TestL4ProxyManager_EnableL4ProxyProtocol_NotActive(t *testing.T) {
+	srv := newFakeCaddy(map[string]interface{}{"apps": map[string]interface{}{}})
+	defer srv.Close()
+	m := NewL4ProxyManager(srv.URL)
+	if err := m.EnableL4ProxyProtocol([]string{"10.130.0.13/32"}); err != nil {
+		t.Fatalf("expected no-op when L4 inactive, got %v", err)
+	}
+	if !m.proxyProtocolEnabled() {
+		t.Errorf("manager should remember trusted CIDRs even when L4 inactive")
+	}
+}
+
+// TestL4ProxyManager_EnableL4ProxyProtocol_RejectsEmpty / _RejectsWildcard:
+// same safety guards as the HTTP-side variant — refuse to wrap with an
+// unrestricted allow list.
+func TestL4ProxyManager_EnableL4ProxyProtocol_RejectsEmpty(t *testing.T) {
+	m := NewL4ProxyManager("http://unreachable")
+	if err := m.EnableL4ProxyProtocol(nil); err == nil {
+		t.Errorf("expected error on empty CIDRs")
+	}
+}
+
+func TestL4ProxyManager_EnableL4ProxyProtocol_RejectsWildcard(t *testing.T) {
+	m := NewL4ProxyManager("http://unreachable")
+	if err := m.EnableL4ProxyProtocol([]string{"0.0.0.0/0"}); err == nil {
+		t.Errorf("expected error on 0.0.0.0/0")
+	}
+	if err := m.EnableL4ProxyProtocol([]string{"10.0.0.0/8", "::/0"}); err == nil {
+		t.Errorf("expected error on ::/0")
+	}
+}
+
+// TestL4ProxyManager_ActivateL4_WrappedWhenEnabled: when proxy-protocol is
+// configured before ActivateL4, the activated server uses the pattern B
+// shape directly.
+func TestL4ProxyManager_ActivateL4_WrappedWhenEnabled(t *testing.T) {
+	initial := map[string]interface{}{
+		"apps": map[string]interface{}{
+			"http": map[string]interface{}{
+				"servers": map[string]interface{}{
+					"srv0": map[string]interface{}{
+						"listen": []interface{}{":80", ":443"},
+						"routes": []interface{}{},
+					},
+				},
+			},
+		},
+	}
+	srv := newFakeCaddy(initial)
+	defer srv.Close()
+
+	m := NewL4ProxyManager(srv.URL)
+	if err := m.SetProxyProtocolTrusted([]string{"10.130.0.13/32"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ActivateL4(); err != nil {
+		t.Fatalf("ActivateL4: %v", err)
+	}
+
+	cfg := readConfig(t, srv.URL)
+	srvCfg := cfg["apps"].(map[string]interface{})["layer4"].(map[string]interface{})["servers"].(map[string]interface{})[L4ServerName].(map[string]interface{})
+	outer := srvCfg["routes"].([]interface{})
+	if len(outer) != 1 {
+		t.Fatalf("expected 1 outer route (wrapped shape), got %d", len(outer))
+	}
+	hs := outer[0].(map[string]interface{})["handle"].([]interface{})
+	if len(hs) != 2 || hs[0].(map[string]interface{})["handler"] != "proxy_protocol" {
+		t.Fatalf("expected outer handlers [proxy_protocol, subroute]; got %v", hs)
+	}
+	innerRoutes := hs[1].(map[string]interface{})["routes"].([]interface{})
+	if len(innerRoutes) != 1 {
+		t.Fatalf("expected 1 inner route (catchall); got %d", len(innerRoutes))
+	}
+	catchallHandler := innerRoutes[0].(map[string]interface{})["handle"].([]interface{})[0].(map[string]interface{})
+	if catchallHandler["proxy_protocol"] != "v2" {
+		t.Errorf("catchall must emit proxy_protocol: v2; got %v", catchallHandler["proxy_protocol"])
+	}
+}
+
+// TestL4ProxyManager_Lifecycle_WrappingSurvivesRouteSyncJob is the regression
+// test for the prod-broke-everything bug we hit in attempt 3:
+// EnableL4ProxyProtocol set up the wrap, then RouteSyncJob called
+// AddL4Route / RemoveL4Route which used the old flat-routes assumption and
+// clobbered the wrapping. This test simulates that exact sequence.
+func TestL4ProxyManager_Lifecycle_WrappingSurvivesRouteSyncJob(t *testing.T) {
+	initial := map[string]interface{}{
+		"apps": map[string]interface{}{
+			"http": map[string]interface{}{
+				"servers": map[string]interface{}{
+					"srv0": map[string]interface{}{
+						"listen": []interface{}{":80", ":443"},
+						"routes": []interface{}{},
+					},
+				},
+			},
+		},
+	}
+	srv := newFakeCaddy(initial)
+	defer srv.Close()
+
+	m := NewL4ProxyManager(srv.URL)
+	mustEnable(t, m, []string{"10.130.0.13/32"})
+	mustActivate(t, m)
+
+	// Three RouteSyncJob-style sync cycles, each adding then removing routes.
+	// In the old (broken) implementation, the first AddL4Route would unwrap
+	// the server (because getRoutes/putRoutes went straight to outer routes,
+	// not the inner subroute). After this test runs, the wrapping must still
+	// be intact and the SNI routes must be inside the subroute.
+	for i := 0; i < 3; i++ {
+		if err := m.AddL4Route("grpc.kafeido.app", "10.0.3.248", 50051); err != nil {
+			t.Fatalf("cycle %d AddL4Route grpc: %v", i, err)
+		}
+		if err := m.AddL4Route("grpc-dev.kafeido.app", "10.0.3.250", 50052); err != nil {
+			t.Fatalf("cycle %d AddL4Route grpc-dev: %v", i, err)
+		}
+		assertWrappedAndCatchallV2(t, srv.URL, i)
+	}
+
+	// Now remove one — wrapping must still hold.
+	if err := m.RemoveL4Route("grpc-dev.kafeido.app"); err != nil {
+		t.Fatalf("RemoveL4Route: %v", err)
+	}
+	assertWrappedAndCatchallV2(t, srv.URL, 99)
+
+	// ListL4Routes must see the 1 remaining SNI route (catchall is excluded).
+	listed, err := m.ListL4Routes()
+	if err != nil {
+		t.Fatalf("ListL4Routes: %v", err)
+	}
+	if len(listed) != 1 || listed[0].SNI != "grpc.kafeido.app" {
+		t.Errorf("ListL4Routes after Remove = %v, want 1 entry for grpc.kafeido.app", listed)
+	}
+}
+
+// TestL4ProxyManager_EnableL4ProxyProtocol_ReshapesActiveFlatServer: when L4
+// was already active in the legacy flat shape (e.g. an older daemon left it
+// running), EnableL4ProxyProtocol must atomically re-shape it without
+// dropping any pre-existing SNI routes.
+func TestL4ProxyManager_EnableL4ProxyProtocol_ReshapesActiveFlatServer(t *testing.T) {
+	flatRoutes := []interface{}{
+		map[string]interface{}{
+			"match": []interface{}{
+				map[string]interface{}{"tls": map[string]interface{}{"sni": []interface{}{"grpc.kafeido.app"}}},
+			},
+			"handle": []interface{}{
+				map[string]interface{}{"handler": "proxy", "upstreams": []interface{}{
+					map[string]interface{}{"dial": []interface{}{"10.0.3.248:50051"}},
+				}},
+			},
+		},
+		// catchall
+		map[string]interface{}{
+			"handle": []interface{}{
+				map[string]interface{}{"handler": "proxy", "upstreams": []interface{}{
+					map[string]interface{}{"dial": []interface{}{l4HTTPFallbackDial}},
+				}},
+			},
+		},
+	}
+	initial := map[string]interface{}{
+		"apps": map[string]interface{}{
+			"layer4": map[string]interface{}{
+				"servers": map[string]interface{}{
+					L4ServerName: map[string]interface{}{
+						"listen": []interface{}{":443"},
+						"routes": flatRoutes,
+					},
+				},
+			},
+		},
+	}
+	srv := newFakeCaddy(initial)
+	defer srv.Close()
+
+	m := NewL4ProxyManager(srv.URL)
+	if err := m.EnableL4ProxyProtocol([]string{"10.130.0.13/32"}); err != nil {
+		t.Fatalf("EnableL4ProxyProtocol: %v", err)
+	}
+
+	cfg := readConfig(t, srv.URL)
+	srvCfg := cfg["apps"].(map[string]interface{})["layer4"].(map[string]interface{})["servers"].(map[string]interface{})[L4ServerName].(map[string]interface{})
+	outer := srvCfg["routes"].([]interface{})
+	if len(outer) != 1 {
+		t.Fatalf("after reshape, expected 1 outer route (wrapped); got %d", len(outer))
+	}
+	inner := outer[0].(map[string]interface{})["handle"].([]interface{})[1].(map[string]interface{})["routes"].([]interface{})
+	if len(inner) != 2 {
+		t.Fatalf("after reshape, inner routes = %d, want 2 (grpc + catchall)", len(inner))
+	}
+	// grpc route preserved
+	grpc := inner[0].(map[string]interface{})
+	if matches, _ := grpc["match"].([]interface{}); len(matches) != 1 {
+		t.Errorf("grpc route lost its match clause after reshape")
+	}
+	// catchall now has proxy_protocol: v2
+	catchall := inner[1].(map[string]interface{})
+	catchallH := catchall["handle"].([]interface{})[0].(map[string]interface{})
+	if catchallH["proxy_protocol"] != "v2" {
+		t.Errorf("catchall after reshape proxy_protocol = %v, want v2", catchallH["proxy_protocol"])
+	}
+}
+
+// --- helpers ---
+
+func mustEnable(t *testing.T, m *L4ProxyManager, cidrs []string) {
+	t.Helper()
+	if err := m.EnableL4ProxyProtocol(cidrs); err != nil {
+		t.Fatalf("EnableL4ProxyProtocol: %v", err)
+	}
+}
+
+func mustActivate(t *testing.T, m *L4ProxyManager) {
+	t.Helper()
+	if err := m.ActivateL4(); err != nil {
+		t.Fatalf("ActivateL4: %v", err)
+	}
+}
+
+func readConfig(t *testing.T, baseURL string) map[string]interface{} {
+	t.Helper()
+	resp, err := http.Get(baseURL + "/config/")
+	if err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	defer resp.Body.Close()
+	var cfg map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	return cfg
+}
+
+// assertWrappedAndCatchallV2 verifies the L4 server is in pattern B shape and
+// the catchall (last inner route, no match clause) emits proxy_protocol: v2.
+func assertWrappedAndCatchallV2(t *testing.T, baseURL string, cycle int) {
+	t.Helper()
+	cfg := readConfig(t, baseURL)
+	srvCfg := cfg["apps"].(map[string]interface{})["layer4"].(map[string]interface{})["servers"].(map[string]interface{})[L4ServerName].(map[string]interface{})
+	outer, _ := srvCfg["routes"].([]interface{})
+	if len(outer) != 1 {
+		t.Fatalf("[cycle %d] expected 1 outer route (wrapping intact); got %d (%v)", cycle, len(outer), srvCfg["routes"])
+	}
+	hs := outer[0].(map[string]interface{})["handle"].([]interface{})
+	if hs[0].(map[string]interface{})["handler"] != "proxy_protocol" {
+		t.Fatalf("[cycle %d] outer handler 0 = %v, want proxy_protocol", cycle, hs[0])
+	}
+	inner := hs[1].(map[string]interface{})["routes"].([]interface{})
+	if len(inner) == 0 {
+		t.Fatalf("[cycle %d] inner subroute has no routes — wrapping was clobbered", cycle)
+	}
+	last := inner[len(inner)-1].(map[string]interface{})
+	if _, hasMatch := last["match"]; hasMatch {
+		t.Fatalf("[cycle %d] last inner route has a match clause — catchall is missing/displaced", cycle)
+	}
+	lastH := last["handle"].([]interface{})[0].(map[string]interface{})
+	if lastH["proxy_protocol"] != "v2" {
+		t.Errorf("[cycle %d] catchall proxy_protocol = %v, want v2", cycle, lastH["proxy_protocol"])
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -406,6 +406,11 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 
 						// Create L4ProxyManager for TLS passthrough (SNI-based) routing
 						l4ProxyManager := app.NewL4ProxyManager(caddyAdminURL)
+						if config.ProxyProtocol {
+							if err := l4ProxyManager.EnableL4ProxyProtocol(config.ProxyProtocolTrusted); err != nil {
+								log.Printf("Warning: Failed to enable PROXY protocol on caddy-l4: %v", err)
+							}
+						}
 
 						// Create RouteStore for persistent route storage
 						routeStore, err = app.NewRouteStore(context.Background(), appStore.Pool())
@@ -566,6 +571,11 @@ skipAppHosting:
 				// Create L4ProxyManager for TLS passthrough (SNI-based) routing.
 				// L4 is activated lazily by RouteSyncJob when passthrough routes exist.
 				l4ProxyManager := app.NewL4ProxyManager(caddyAdminURL)
+				if config.ProxyProtocol {
+					if err := l4ProxyManager.EnableL4ProxyProtocol(config.ProxyProtocolTrusted); err != nil {
+						log.Printf("Warning: Failed to enable PROXY protocol on caddy-l4: %v", err)
+					}
+				}
 
 				syncInterval := config.RouteSyncInterval
 				if syncInterval == 0 {

--- a/test/fixtures/tier2-l4-lifecycle/main.go
+++ b/test/fixtures/tier2-l4-lifecycle/main.go
@@ -1,0 +1,118 @@
+// tier2-l4-lifecycle: drives a real caddy-l4 server through the operations
+// the daemon performs at runtime (EnableL4ProxyProtocol → ActivateL4 →
+// AddL4Route * N → RemoveL4Route → ListL4Routes) and asserts the pattern B
+// wrapping is intact at every step. This is the regression test for the
+// prod-broke-everything bug from attempt 3, where RouteSyncJob's CRUD
+// undid the wrapping within seconds of daemon startup.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/footprintai/containarium/internal/app"
+)
+
+func main() {
+	adminURL := flag.String("admin", "http://127.0.0.1:2019", "Caddy admin URL")
+	trusted := flag.String("trusted", "127.0.0.0/8", "comma-separated trusted CIDRs")
+	flag.Parse()
+
+	cidrs := strings.Split(*trusted, ",")
+	m := app.NewL4ProxyManager(*adminURL)
+
+	log.Println("step 1: EnableL4ProxyProtocol (records trusted CIDRs)")
+	if err := m.EnableL4ProxyProtocol(cidrs); err != nil {
+		log.Fatalf("EnableL4ProxyProtocol: %v", err)
+	}
+
+	log.Println("step 2: ActivateL4 (must produce wrapped shape)")
+	if err := m.ActivateL4(); err != nil {
+		log.Fatalf("ActivateL4: %v", err)
+	}
+	if err := assertWrappedAndCatchallV2(*adminURL, "after-activate"); err != nil {
+		log.Fatalf("FAIL: %v", err)
+	}
+
+	log.Println("step 3: simulate 3 RouteSyncJob cycles of AddL4Route")
+	for cycle := 0; cycle < 3; cycle++ {
+		if err := m.AddL4Route("grpc.kafeido.app", "10.0.3.248", 50051); err != nil {
+			log.Fatalf("cycle %d AddL4Route grpc: %v", cycle, err)
+		}
+		if err := m.AddL4Route("grpc-dev.kafeido.app", "10.0.3.250", 50052); err != nil {
+			log.Fatalf("cycle %d AddL4Route grpc-dev: %v", cycle, err)
+		}
+		if err := assertWrappedAndCatchallV2(*adminURL, fmt.Sprintf("after-add-cycle-%d", cycle)); err != nil {
+			log.Fatalf("FAIL: %v", err)
+		}
+	}
+
+	log.Println("step 4: RemoveL4Route (must keep wrapping)")
+	if err := m.RemoveL4Route("grpc-dev.kafeido.app"); err != nil {
+		log.Fatalf("RemoveL4Route: %v", err)
+	}
+	if err := assertWrappedAndCatchallV2(*adminURL, "after-remove"); err != nil {
+		log.Fatalf("FAIL: %v", err)
+	}
+
+	log.Println("step 5: ListL4Routes (must see the surviving SNI route)")
+	routes, err := m.ListL4Routes()
+	if err != nil {
+		log.Fatalf("ListL4Routes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].SNI != "grpc.kafeido.app" {
+		log.Fatalf("FAIL: ListL4Routes = %v, want 1 entry for grpc.kafeido.app", routes)
+	}
+
+	log.Println("step 6: print full L4 server config")
+	resp, _ := http.Get(*adminURL + "/config/apps/layer4/servers/tls_passthrough")
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var pretty map[string]interface{}
+	_ = json.Unmarshal(body, &pretty)
+	out, _ := json.MarshalIndent(pretty, "", "  ")
+	fmt.Println(string(out))
+
+	log.Println("PASS: lifecycle complete, wrapping survived all 6 steps")
+}
+
+func assertWrappedAndCatchallV2(adminURL, label string) error {
+	resp, err := http.Get(adminURL + "/config/apps/layer4/servers/tls_passthrough")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var srv map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&srv); err != nil {
+		return err
+	}
+	outer, _ := srv["routes"].([]interface{})
+	if len(outer) != 1 {
+		return fmt.Errorf("[%s] expected 1 outer route (wrapped), got %d", label, len(outer))
+	}
+	hs, _ := outer[0].(map[string]interface{})["handle"].([]interface{})
+	if len(hs) != 2 {
+		return fmt.Errorf("[%s] expected 2 outer handlers, got %d", label, len(hs))
+	}
+	if hs[0].(map[string]interface{})["handler"] != "proxy_protocol" {
+		return fmt.Errorf("[%s] outer handler[0] must be proxy_protocol, got %v", label, hs[0])
+	}
+	inner, _ := hs[1].(map[string]interface{})["routes"].([]interface{})
+	if len(inner) == 0 {
+		return fmt.Errorf("[%s] inner subroute has no routes", label)
+	}
+	last := inner[len(inner)-1].(map[string]interface{})
+	if _, hasMatch := last["match"]; hasMatch {
+		return fmt.Errorf("[%s] last inner route has a match clause — catchall is missing/displaced", label)
+	}
+	lastH := last["handle"].([]interface{})[0].(map[string]interface{})
+	if lastH["proxy_protocol"] != "v2" {
+		return fmt.Errorf("[%s] catchall proxy_protocol = %v, want v2", label, lastH["proxy_protocol"])
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Closes the gRPC outage gap deferred from #106. Makes `L4ProxyManager` aware of the sandbox-tier-1-verified pattern B wrapping so:
- `ActivateL4` produces the wrapped shape directly when proxy-protocol is enabled
- `AddL4Route` / `RemoveL4Route` / `ListL4Routes` operate on the inner subroute, leaving the wrapper intact
- The previous attempt's regression (RouteSyncJob unwrapping the routes within seconds of daemon startup) can't happen

## What pattern B is

```
caddy-l4 server :443
└─ outer route (no match)
   ├─ handle 0: layer4.handlers.proxy_protocol  (allow=[<sentinel-IP>/32], timeout=5s)
   └─ handle 1: layer4.handlers.subroute
      ├─ SNI route passthrough-a.example      → 203.0.113.1:50051   (raw TLS — gRPC backend)
      ├─ SNI route passthrough-b.example  → 203.0.113.2:50052   (raw TLS — gRPC backend)
      └─ catchall (no match)             → localhost:8443     (with proxy_protocol: "v2", srv0)
```

The `proxy_protocol` handler consumes the leading PROXY v2 bytes (lenient if absent) so SNI matching inside the subroute sees the underlying TLS ClientHello cleanly. The catchall re-emits PROXY to srv0 so srv0's listener_wrapper recovers the source.

## How the lifecycle stays wrapping-aware

| Manager method | Behavior |
|---|---|
| `SetProxyProtocolTrusted(cidrs)` | Records CIDRs on the manager. Validates non-empty, no wildcards. |
| `EnableL4ProxyProtocol(cidrs)` | `SetProxyProtocolTrusted` + reshape if L4 already active. |
| `ActivateL4` | If proxy-protocol enabled, builds wrapped shape from the start; else flat (legacy). |
| `getRoutes` | Atomic GET of full config; returns inner subroute's routes when wrapped, outer otherwise. |
| `putRoutes` | Atomic POST `/load` with a config that **preserves** the wrapper structure — only the inner `routes` is replaced. |
| `AddL4Route` / `RemoveL4Route` / `ListL4Routes` | Unchanged — call `getRoutes`/`putRoutes`, work transparently in both states. |

Caddy admin's PATCH/replace semantics on the legacy `/config/.../routes` path can't accidentally wipe the outer wrapper because we never PATCH that path anymore — everything goes through atomic `/load`.

## Tests

### Unit (`internal/app/l4_proxy_test.go`)

- `_NotActive`: `EnableL4ProxyProtocol` on inactive L4 records CIDRs without error.
- `_RejectsEmpty` / `_RejectsWildcard`: same safety guards as the HTTP-side variant.
- `_ActivateL4_WrappedWhenEnabled`: `ActivateL4` with `SetProxyProtocolTrusted` set produces wrapped shape directly.
- **`_Lifecycle_WrappingSurvivesRouteSyncJob`** — the regression test for the prod outage 3 bug. Simulates 3 RouteSyncJob cycles of `AddL4Route` + a `RemoveL4Route` + `ListL4Routes`, asserts wrapping invariant at every step.
- `_ReshapesActiveFlatServer`: a flat-shape L4 server (e.g. left over from an older daemon) gets atomically reshaped without losing pre-existing SNI routes.

### Tier-2 lifecycle driver (`test/fixtures/tier2-l4-lifecycle/main.go`)

Cross-compiled binary that exercises the same lifecycle against a **real `caddy-l4` 2.11.2 binary** on the sandbox. Verified on sandbox:
- 6 add cycles, 1 remove, all preserve wrapping
- Curl-driven e2e for all 4 deploy-state scenarios (PROXY×catchall/SNI, no-PROXY×catchall/SNI) — all pass
- Final L4 config matches pattern B byte-for-byte

## What ships in `dual_server.go`

In both `EnsureServerConfig` call sites, after `EnableProxyProtocol(srv0)`, we now also call `l4ProxyManager.EnableL4ProxyProtocol(config.ProxyProtocolTrusted)` — same trusted CIDR list, same safety guards.

## Pre-deploy plan (when ready)

1. Merge this PR
2. Rebuild + ship daemon binary
3. Restart daemon (override already in place from #106 deploy — same flags work)
4. Verify Caddy admin shows wrapped L4 server (the lifecycle test gives us the exact expected shape)
5. Restart sentinel with `--proxy-protocol=true`
6. Verify wordpress XFF + gRPC route still works (= 415 to plain curl, valid TLS handshake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
