### PR TITLE
docs: PROXY protocol — preserving the real client IP

### DIFF
--- a/docs/PROXY-PROTOCOL.md
+++ b/docs/PROXY-PROTOCOL.md
@@ -1,0 +1,239 @@
+# PROXY protocol — preserving the real client IP
+
+## What this solves
+
+Before this work, containers behind the sentinel saw `X-Forwarded-For: ::1`
+(IPv6 loopback) regardless of who originated the request. The Containarium
+data path is TLS-passthrough at every hop: the sentinel does SNI peeking and
+forwards raw TCP, the backend's caddy-l4 does another SNI hop, and only at
+the daemon's HTTP server (`srv0`) does TLS terminate. None of those hops
+preserved the original client IP, because each one was opening a fresh TCP
+connection downstream.
+
+The PROXY protocol (HAProxy v2, binary) is the standard solution: every hop
+prepends a tiny header carrying the original source/destination addresses,
+and the receiver parses it before doing anything else. With the implementation
+in this codebase, a curl from `36.230.33.180` lands in the WordPress nginx
+access log as:
+
+```
+10.0.3.111 - - [...] "GET / HTTP/1.1" 200 ... "User-Agent" "36.230.33.180"
+                                                            ^^^^^^^^^^^^^^
+                                                X-Forwarded-For = real IP
+```
+
+## Architecture
+
+```
+                                          PROXY v2          PROXY v2
+                                        (sentinel emits)   (caddy-l4 emits)
+                                              │                   │
+client ──TLS──▶ sentinel ──TCP+PROXY──▶ caddy-l4 ──TCP+PROXY──▶ srv0 ──HTTP──▶ container
+              (SNI router)             (:443)                  (:8443)        (nginx)
+                                       parses PROXY            parses PROXY
+                                       routes by SNI           sets RemoteAddr
+                                       on post-strip bytes     reverse_proxy with XFF
+```
+
+Three hops, each protected by a different layer of caddy-l4 / Caddy
+configuration:
+
+1. **Sentinel** (`internal/sentinel/`)
+   - The SNI router (`buildSNIRoutingHandler` in `manager.go`) peeks the TLS
+     ClientHello, looks up the destination primary, and forwards raw TCP.
+   - When `--proxy-protocol` is enabled, it prepends a 28-byte (IPv4) PROXY v2
+     header before the first TLS byte. The header is encoded by
+     `WriteProxyV2` in `internal/sentinel/proxyproto.go`.
+
+2. **caddy-l4 server** (`tls_passthrough` on `:443`, configured by
+   `internal/app/l4_proxy.go`)
+   - When the daemon is started with `--proxy-protocol`, the L4 server is
+     produced in **pattern B** wrapped form: a single outer route whose
+     handlers are `(layer4.handlers.proxy_protocol, layer4.handlers.subroute)`.
+   - The `proxy_protocol` handler consumes the PROXY v2 bytes (lenient if
+     absent — passes through unchanged for deploy-gap safety), then the
+     `subroute` does SNI matching on the now-clean TLS bytes.
+   - SNI passthrough routes (e.g. `grpc.kafeido.app`) forward raw TLS to
+     their gRPC backends untouched.
+   - The catchall route (no `match`) re-emits a PROXY v2 header to
+     `localhost:8443` (`srv0`) using `proxy_protocol: "v2"` on its proxy
+     handler, so srv0 can recover the real client IP.
+
+3. **HTTP server `srv0`** (Caddy, configured by `internal/app/proxy.go`)
+   - When the daemon is started with `--proxy-protocol`,
+     `EnableProxyProtocol` installs a `[proxy_protocol, tls]`
+     `listener_wrappers` chain on srv0 plus `trusted_proxies` for the same
+     CIDRs. The wrapper consumes the PROXY header from caddy-l4 and updates
+     `conn.RemoteAddr`. The trusted_proxies setting then makes Caddy's
+     `reverse_proxy` use that as the source when emitting `X-Forwarded-For`.
+
+## Deploy state matrix
+
+The wrapper handlers are designed to be lenient on missing PROXY headers,
+so the system stays correct in every combination of deploy state:
+
+| Sentinel `--proxy-protocol` | Daemon `--proxy-protocol` | Wordpress XFF | gRPC | Notes |
+|---|---|---|---|---|
+| off | off | (n/a — Caddy doesn't add XFF on TLS-passthrough catchall path) | works | pre-rollout baseline |
+| off | on | `::1` (caddy-l4's loopback to srv0) | works | "armed" state — daemon ready but sentinel not flipped |
+| on | off | n/a — sentinel emits PROXY but srv0 has no wrapper, so Caddy treats PROXY bytes as part of the HTTP body and breaks | broken | **never deploy in this order** |
+| on | on | real client IP | works | end state |
+
+The two safe transitions are `off,off → off,on → on,on`. **Always deploy
+the daemon side first**, verify, then flip the sentinel.
+
+## Trust model
+
+The `--proxy-protocol-trusted` flag lists the CIDRs allowed to send PROXY
+headers. The same list is shared by both wrappers; extra entries on either
+side are harmless because each wrapper only sees its own kind of upstream
+peer.
+
+| Wrapper | Sees connections from | Allow CIDRs (prod) |
+|---|---|---|
+| caddy-l4 `proxy_protocol` handler | sentinel (via host iptables DNAT, source preserved) | `10.130.0.13/32` (sentinel VPC IP) |
+| srv0 `proxy_protocol` listener_wrapper | caddy-l4 (loopback dial to `localhost:8443`) | `127.0.0.0/8`, `::1/128` |
+
+Concretely the daemon is started with:
+```
+--proxy-protocol --proxy-protocol-trusted=10.130.0.13/32,127.0.0.0/8,::1/128
+```
+and the sentinel with:
+```
+--proxy-protocol
+```
+(the sentinel itself doesn't validate; it just emits.)
+
+`EnableProxyProtocol` and `EnableL4ProxyProtocol` both refuse empty or
+wildcard (`0.0.0.0/0`, `::/0`) CIDR lists at construction time. An
+unrestricted allow list lets any direct VPC peer spoof its source IP via a
+forged PROXY header.
+
+## Recommended rollout
+
+1. **Deploy daemon** (backend VM) with `--proxy-protocol` flags. The daemon
+   calls `EnableProxyProtocol` (srv0) and `EnableL4ProxyProtocol` (L4) at
+   startup; the L4 server is reshaped into pattern B and the listener
+   wrappers are armed. Both wrappers are lenient on missing PROXY, so
+   in-flight non-PROXY traffic still flows.
+2. **Verify** Caddy admin shows the wrapped L4 server and the srv0
+   listener_wrappers, and that all subdomains still serve traffic.
+3. **Restart sentinel** with `--proxy-protocol`. From now on every forwarded
+   HTTPS connection carries a PROXY v2 header.
+4. **Verify** with a known-IP curl + the destination container's access
+   log. For wordpress: `curl https://wordpress.kafeido.app/?ip-test=<marker>`,
+   then `ssh wordpress 'docker logs --tail 20 wordpress-nginx | grep <marker>'`
+   — the rightmost `"..."` field is the parsed source IP.
+
+## Rollback
+
+Either side can be reverted in isolation thanks to the lenient wrappers:
+
+- **Sentinel rollback**: remove the `--proxy-protocol` flag and restart.
+  The daemon-side wrappers see no PROXY header and pass through unchanged;
+  XFF reverts to `::1`. gRPC routes are unaffected.
+- **Daemon rollback**: restart the daemon without `--proxy-protocol` flags.
+  EnableProxyProtocol/EnableL4ProxyProtocol won't run; existing wrapping
+  stays in the running Caddy until something explicitly removes it. To
+  fully unwind, manually `DELETE /config/apps/http/servers/srv0` and the
+  L4 server, then restart the daemon to let it rebuild the legacy flat
+  shape.
+
+## Tests
+
+| Layer | File | What it validates |
+|---|---|---|
+| Encoder unit tests | `internal/sentinel/proxyproto_test.go` | byte-exact PROXY v2 IPv4/IPv6 header, payload preservation |
+| Sentinel SNI-router e2e | `internal/sentinel/proxyproto_e2e_test.go` | real TCP+TLS through `buildSNIRoutingHandler`; client source port reaches backend with flag on, doesn't with it off |
+| Sentinel real-Caddy e2e | `internal/sentinel/proxyproto_caddy_e2e_test.go` (build tag `proxyproto_real_caddy`) | spawns real Caddy 2.7+, drives TLS from 127.0.0.42, asserts X-Forwarded-For at backend |
+| HTTP-side regression | `internal/app/proxy_test.go::TestProxyManager_EnableProxyProtocol_PreservesOtherFields` | `EnableProxyProtocol` doesn't clobber listen/routes/automatic_https on srv0 (the bug from incident #2) |
+| L4 lifecycle regression | `internal/app/l4_proxy_test.go::TestL4ProxyManager_Lifecycle_WrappingSurvivesRouteSyncJob` | wrapping survives 3 RouteSyncJob-style add/remove cycles (the bug from incident #3) |
+| Tier-2 driver | `test/fixtures/tier2-l4-lifecycle/main.go` | full lifecycle against a real caddy-l4 binary; sandbox-validated |
+
+## Reference: pattern B caddy-l4 config
+
+The wrapped shape produced by `EnableL4ProxyProtocol`:
+
+```json
+{
+  "listen": [":443"],
+  "routes": [{
+    "handle": [
+      {
+        "handler": "proxy_protocol",
+        "allow":   ["10.130.0.13/32", "127.0.0.0/8", "::1/128"],
+        "timeout": "5s"
+      },
+      {
+        "handler": "subroute",
+        "routes": [
+          {"match": [{"tls": {"sni": ["grpc.kafeido.app"]}}],
+           "handle": [{"handler": "proxy", "upstreams": [{"dial": ["10.0.3.248:50051"]}]}]},
+          {"match": [{"tls": {"sni": ["grpc-dev.kafeido.app"]}}],
+           "handle": [{"handler": "proxy", "upstreams": [{"dial": ["10.0.3.250:50052"]}]}]},
+          {"handle": [{"handler": "proxy",
+                       "upstreams": [{"dial": ["localhost:8443"]}],
+                       "proxy_protocol": "v2"}]}
+        ]
+      }
+    ]
+  }]
+}
+```
+
+Things to know about this shape that aren't obvious:
+
+- **Single outer route, no `match`.** caddy-l4 evaluates routes top-to-bottom;
+  the outer route always matches.
+- **The `proxy_protocol` handler runs before any matcher in the subroute.**
+  This is why pattern B works where the `proxy_protocol` matcher form
+  doesn't — handlers run after route selection, so a matcher would have to
+  consume bytes during the SNI-matching phase, and caddy-l4 silently drops
+  malformed matcher chains.
+- **Only the catchall has `proxy_protocol: "v2"` on its proxy handler.**
+  gRPC routes leave it off because gRPC backends don't speak PROXY and
+  expect raw TLS.
+- **`allow` is required on the handler.** Without it, the handler errors
+  with `"unknown field"` (the matcher form has no `allow`).
+
+## Reference: srv0 (HTTP server) config
+
+Added by `ProxyManager.EnableProxyProtocol`:
+
+```json
+{
+  "apps": {
+    "http": {
+      "servers": {
+        "srv0": {
+          "listen": [":80", ":8443"],
+          "listener_wrappers": [
+            {"wrapper": "proxy_protocol", "allow": ["10.130.0.13/32", "127.0.0.0/8", "::1/128"], "timeout": "5s"},
+            {"wrapper": "tls"}
+          ],
+          "trusted_proxies": {"source": "static", "ranges": ["10.130.0.13/32", "127.0.0.0/8", "::1/128"]},
+          "routes": [...preserved verbatim...],
+          ...
+        }
+      }
+    }
+  }
+}
+```
+
+The wrapper chain order is **`[proxy_protocol, tls]`** — proxy_protocol must
+run first to consume the leading PROXY bytes, then the TLS terminator sees
+the underlying ClientHello at byte 0.
+
+The `trusted_proxies` setting is what makes Caddy's `reverse_proxy` populate
+`X-Forwarded-For` from the parsed source IP rather than ignoring it. Without
+this, the wrapper would correctly set `RemoteAddr` but `reverse_proxy` would
+fall back to the raw TCP peer (loopback) for the XFF value.
+
+## History
+
+| PR | Summary |
+|---|---|
+| [#105](https://github.com/FootprintAI/Containarium/pull/105) | Sentinel side: `WriteProxyV2` encoder, `--proxy-protocol` flag, header injected in `buildSNIRoutingHandler`. Includes the Go-level e2e and the real-Caddy e2e gated by build tag. |
+| [#106](https://github.com/FootprintAI/Containarium/pull/106) | Daemon side, srv0 only: `--proxy-protocol` and `--proxy-protocol-trusted` flags; `ProxyManager.EnableProxyProtocol` rewritten to use the atomic `getFullConfig`+`loadConfig` pattern (the previous PATCH-on-server form would clobber `listen`/`routes`). |
+| [#107](https://github.com/FootprintAI/Containarium/pull/107) | Daemon side, L4: pattern B wrapping; `L4ProxyManager` becomes wrapping-aware so `RouteSyncJob`'s CRUD operations on the inner route list don't undo the wrapper. Closes the gRPC-outage gap from #106. |

--- a/docs/PROXY-PROTOCOL.md
+++ b/docs/PROXY-PROTOCOL.md
@@ -13,11 +13,11 @@ connection downstream.
 The PROXY protocol (HAProxy v2, binary) is the standard solution: every hop
 prepends a tiny header carrying the original source/destination addresses,
 and the receiver parses it before doing anything else. With the implementation
-in this codebase, a curl from `36.230.33.180` lands in the WordPress nginx
+in this codebase, a curl from `203.0.113.42` lands in the WordPress nginx
 access log as:
 
 ```
-10.0.3.111 - - [...] "GET / HTTP/1.1" 200 ... "User-Agent" "36.230.33.180"
+10.0.3.111 - - [...] "GET / HTTP/1.1" 200 ... "User-Agent" "203.0.113.42"
                                                             ^^^^^^^^^^^^^^
                                                 X-Forwarded-For = real IP
 ```
@@ -53,7 +53,7 @@ configuration:
    - The `proxy_protocol` handler consumes the PROXY v2 bytes (lenient if
      absent — passes through unchanged for deploy-gap safety), then the
      `subroute` does SNI matching on the now-clean TLS bytes.
-   - SNI passthrough routes (e.g. `grpc.kafeido.app`) forward raw TLS to
+   - SNI passthrough routes (e.g. `passthrough-a.example`) forward raw TLS to
      their gRPC backends untouched.
    - The catchall route (no `match`) re-emits a PROXY v2 header to
      `localhost:8443` (`srv0`) using `proxy_protocol: "v2"` on its proxy
@@ -91,12 +91,12 @@ peer.
 
 | Wrapper | Sees connections from | Allow CIDRs (prod) |
 |---|---|---|
-| caddy-l4 `proxy_protocol` handler | sentinel (via host iptables DNAT, source preserved) | `10.130.0.13/32` (sentinel VPC IP) |
+| caddy-l4 `proxy_protocol` handler | sentinel (via host iptables DNAT, source preserved) | `<sentinel-VPC-IP>/32` (sentinel VPC IP) |
 | srv0 `proxy_protocol` listener_wrapper | caddy-l4 (loopback dial to `localhost:8443`) | `127.0.0.0/8`, `::1/128` |
 
 Concretely the daemon is started with:
 ```
---proxy-protocol --proxy-protocol-trusted=10.130.0.13/32,127.0.0.0/8,::1/128
+--proxy-protocol --proxy-protocol-trusted=<sentinel-VPC-IP>/32,127.0.0.0/8,::1/128
 ```
 and the sentinel with:
 ```
@@ -161,16 +161,16 @@ The wrapped shape produced by `EnableL4ProxyProtocol`:
     "handle": [
       {
         "handler": "proxy_protocol",
-        "allow":   ["10.130.0.13/32", "127.0.0.0/8", "::1/128"],
+        "allow":   ["<sentinel-VPC-IP>/32", "127.0.0.0/8", "::1/128"],
         "timeout": "5s"
       },
       {
         "handler": "subroute",
         "routes": [
-          {"match": [{"tls": {"sni": ["grpc.kafeido.app"]}}],
-           "handle": [{"handler": "proxy", "upstreams": [{"dial": ["10.0.3.248:50051"]}]}]},
-          {"match": [{"tls": {"sni": ["grpc-dev.kafeido.app"]}}],
-           "handle": [{"handler": "proxy", "upstreams": [{"dial": ["10.0.3.250:50052"]}]}]},
+          {"match": [{"tls": {"sni": ["passthrough-a.example"]}}],
+           "handle": [{"handler": "proxy", "upstreams": [{"dial": ["203.0.113.1:50051"]}]}]},
+          {"match": [{"tls": {"sni": ["passthrough-b.example"]}}],
+           "handle": [{"handler": "proxy", "upstreams": [{"dial": ["203.0.113.2:50052"]}]}]},
           {"handle": [{"handler": "proxy",
                        "upstreams": [{"dial": ["localhost:8443"]}],
                        "proxy_protocol": "v2"}]}
@@ -208,10 +208,10 @@ Added by `ProxyManager.EnableProxyProtocol`:
         "srv0": {
           "listen": [":80", ":8443"],
           "listener_wrappers": [
-            {"wrapper": "proxy_protocol", "allow": ["10.130.0.13/32", "127.0.0.0/8", "::1/128"], "timeout": "5s"},
+            {"wrapper": "proxy_protocol", "allow": ["<sentinel-VPC-IP>/32", "127.0.0.0/8", "::1/128"], "timeout": "5s"},
             {"wrapper": "tls"}
           ],
-          "trusted_proxies": {"source": "static", "ranges": ["10.130.0.13/32", "127.0.0.0/8", "::1/128"]},
+          "trusted_proxies": {"source": "static", "ranges": ["<sentinel-VPC-IP>/32", "127.0.0.0/8", "::1/128"]},
           "routes": [...preserved verbatim...],
           ...
         }

--- a/internal/app/l4_proxy_test.go
+++ b/internal/app/l4_proxy_test.go
@@ -14,7 +14,7 @@ func TestL4ProxyManager_EnableL4ProxyProtocol_NotActive(t *testing.T) {
 	srv := newFakeCaddy(map[string]interface{}{"apps": map[string]interface{}{}})
 	defer srv.Close()
 	m := NewL4ProxyManager(srv.URL)
-	if err := m.EnableL4ProxyProtocol([]string{"10.130.0.13/32"}); err != nil {
+	if err := m.EnableL4ProxyProtocol([]string{"192.0.2.13/32"}); err != nil {
 		t.Fatalf("expected no-op when L4 inactive, got %v", err)
 	}
 	if !m.proxyProtocolEnabled() {
@@ -62,7 +62,7 @@ func TestL4ProxyManager_ActivateL4_WrappedWhenEnabled(t *testing.T) {
 	defer srv.Close()
 
 	m := NewL4ProxyManager(srv.URL)
-	if err := m.SetProxyProtocolTrusted([]string{"10.130.0.13/32"}); err != nil {
+	if err := m.SetProxyProtocolTrusted([]string{"192.0.2.13/32"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := m.ActivateL4(); err != nil {
@@ -111,7 +111,7 @@ func TestL4ProxyManager_Lifecycle_WrappingSurvivesRouteSyncJob(t *testing.T) {
 	defer srv.Close()
 
 	m := NewL4ProxyManager(srv.URL)
-	mustEnable(t, m, []string{"10.130.0.13/32"})
+	mustEnable(t, m, []string{"192.0.2.13/32"})
 	mustActivate(t, m)
 
 	// Three RouteSyncJob-style sync cycles, each adding then removing routes.
@@ -120,17 +120,17 @@ func TestL4ProxyManager_Lifecycle_WrappingSurvivesRouteSyncJob(t *testing.T) {
 	// not the inner subroute). After this test runs, the wrapping must still
 	// be intact and the SNI routes must be inside the subroute.
 	for i := 0; i < 3; i++ {
-		if err := m.AddL4Route("grpc.kafeido.app", "10.0.3.248", 50051); err != nil {
+		if err := m.AddL4Route("passthrough-a.example", "203.0.113.1", 50051); err != nil {
 			t.Fatalf("cycle %d AddL4Route grpc: %v", i, err)
 		}
-		if err := m.AddL4Route("grpc-dev.kafeido.app", "10.0.3.250", 50052); err != nil {
+		if err := m.AddL4Route("passthrough-b.example", "203.0.113.2", 50052); err != nil {
 			t.Fatalf("cycle %d AddL4Route grpc-dev: %v", i, err)
 		}
 		assertWrappedAndCatchallV2(t, srv.URL, i)
 	}
 
 	// Now remove one — wrapping must still hold.
-	if err := m.RemoveL4Route("grpc-dev.kafeido.app"); err != nil {
+	if err := m.RemoveL4Route("passthrough-b.example"); err != nil {
 		t.Fatalf("RemoveL4Route: %v", err)
 	}
 	assertWrappedAndCatchallV2(t, srv.URL, 99)
@@ -140,8 +140,8 @@ func TestL4ProxyManager_Lifecycle_WrappingSurvivesRouteSyncJob(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListL4Routes: %v", err)
 	}
-	if len(listed) != 1 || listed[0].SNI != "grpc.kafeido.app" {
-		t.Errorf("ListL4Routes after Remove = %v, want 1 entry for grpc.kafeido.app", listed)
+	if len(listed) != 1 || listed[0].SNI != "passthrough-a.example" {
+		t.Errorf("ListL4Routes after Remove = %v, want 1 entry for passthrough-a.example", listed)
 	}
 }
 
@@ -153,11 +153,11 @@ func TestL4ProxyManager_EnableL4ProxyProtocol_ReshapesActiveFlatServer(t *testin
 	flatRoutes := []interface{}{
 		map[string]interface{}{
 			"match": []interface{}{
-				map[string]interface{}{"tls": map[string]interface{}{"sni": []interface{}{"grpc.kafeido.app"}}},
+				map[string]interface{}{"tls": map[string]interface{}{"sni": []interface{}{"passthrough-a.example"}}},
 			},
 			"handle": []interface{}{
 				map[string]interface{}{"handler": "proxy", "upstreams": []interface{}{
-					map[string]interface{}{"dial": []interface{}{"10.0.3.248:50051"}},
+					map[string]interface{}{"dial": []interface{}{"203.0.113.1:50051"}},
 				}},
 			},
 		},
@@ -186,7 +186,7 @@ func TestL4ProxyManager_EnableL4ProxyProtocol_ReshapesActiveFlatServer(t *testin
 	defer srv.Close()
 
 	m := NewL4ProxyManager(srv.URL)
-	if err := m.EnableL4ProxyProtocol([]string{"10.130.0.13/32"}); err != nil {
+	if err := m.EnableL4ProxyProtocol([]string{"192.0.2.13/32"}); err != nil {
 		t.Fatalf("EnableL4ProxyProtocol: %v", err)
 	}
 

--- a/test/fixtures/tier2-l4-lifecycle/main.go
+++ b/test/fixtures/tier2-l4-lifecycle/main.go
@@ -41,10 +41,10 @@ func main() {
 
 	log.Println("step 3: simulate 3 RouteSyncJob cycles of AddL4Route")
 	for cycle := 0; cycle < 3; cycle++ {
-		if err := m.AddL4Route("grpc.kafeido.app", "10.0.3.248", 50051); err != nil {
+		if err := m.AddL4Route("passthrough-a.example", "203.0.113.1", 50051); err != nil {
 			log.Fatalf("cycle %d AddL4Route grpc: %v", cycle, err)
 		}
-		if err := m.AddL4Route("grpc-dev.kafeido.app", "10.0.3.250", 50052); err != nil {
+		if err := m.AddL4Route("passthrough-b.example", "203.0.113.2", 50052); err != nil {
 			log.Fatalf("cycle %d AddL4Route grpc-dev: %v", cycle, err)
 		}
 		if err := assertWrappedAndCatchallV2(*adminURL, fmt.Sprintf("after-add-cycle-%d", cycle)); err != nil {
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	log.Println("step 4: RemoveL4Route (must keep wrapping)")
-	if err := m.RemoveL4Route("grpc-dev.kafeido.app"); err != nil {
+	if err := m.RemoveL4Route("passthrough-b.example"); err != nil {
 		log.Fatalf("RemoveL4Route: %v", err)
 	}
 	if err := assertWrappedAndCatchallV2(*adminURL, "after-remove"); err != nil {
@@ -65,8 +65,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("ListL4Routes: %v", err)
 	}
-	if len(routes) != 1 || routes[0].SNI != "grpc.kafeido.app" {
-		log.Fatalf("FAIL: ListL4Routes = %v, want 1 entry for grpc.kafeido.app", routes)
+	if len(routes) != 1 || routes[0].SNI != "passthrough-a.example" {
+		log.Fatalf("FAIL: ListL4Routes = %v, want 1 entry for passthrough-a.example", routes)
 	}
 
 	log.Println("step 6: print full L4 server config")


### PR DESCRIPTION
## Summary

Architecture document at `docs/PROXY-PROTOCOL.md` covering the three-PR chain that delivered real-client-IP propagation through the sentinel → caddy-l4 → srv0 stack.

Now that #105 + #106 + #107 are all merged and verified working in prod (`wordpress.kafeido.app` shows real `X-Forwarded-For` while `passthrough-a.example` continues to serve gRPC), this is the reference document for anyone who needs to understand, extend, or rollback the system.

## Sections

- **What this solves**: the pre-rollout baseline (`X-Forwarded-For: ::1`) and the canonical solution.
- **Architecture**: three-hop diagram (sentinel → caddy-l4 → srv0 → container), what each layer does.
- **Deploy state matrix**: sentinel × daemon flag combinations and which ones are safe. Calls out the one unsafe ordering (sentinel-on, daemon-off).
- **Trust model**: why two different allow-CIDR scopes are needed, why wildcards are refused, the exact prod values.
- **Recommended rollout**: daemon first, then sentinel, with verification recipes (curl + WordPress nginx access log inspection).
- **Rollback paths**: how to revert either side independently thanks to the lenient wrappers.
- **Test inventory**: pointers to the unit/e2e/lifecycle/tier-2 tests across packages.
- **Reference configs**: the verified pattern B caddy-l4 shape + the srv0 listener_wrappers + trusted_proxies, with notes on the non-obvious bits (why `proxy_protocol` handler not matcher, why `allow` is required, why only the catchall has `proxy_protocol: "v2"`).
- **History**: what each of #105/#106/#107 changed.

## Test plan

- [x] Renders correctly on GitHub
- [x] All cross-references to file paths still resolve in the codebase
- [x] Reflects the prod-verified state (re-checked end-to-end against wordpress + gRPC just now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
