### PR TITLE
feat(cli): containarium ssh-config — self-contained ssh_config generator

### DIFF
--- a/internal/cmd/ssh_config.go
+++ b/internal/cmd/ssh_config.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/footprintai/containarium/internal/incus"
+	"github.com/footprintai/containarium/internal/sshconfig"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sshConfigSentinel       string
+	sshConfigPort           int
+	sshConfigIdentity       string
+	sshConfigUser           string
+	sshConfigIncludeStopped bool
+	sshConfigOutPath        string
+)
+
+var sshConfigCmd = &cobra.Command{
+	Use:   "ssh-config",
+	Short: "Generate a self-contained ssh_config for your containers",
+	Long: `Generate an OpenSSH config file containing one Host block per container.
+
+The file is self-contained — it does NOT modify your ~/.ssh/config. Add a
+single line to ~/.ssh/config to wire it in once:
+
+    Include ~/.containarium/ssh_config
+
+After that, ` + "`ssh <container-name>`" + ` and ` + "`scp`" + ` work transparently.
+
+Two routing modes:
+
+  - Direct (default):    HostName=<container IP>; for LAN-reachable boxes.
+  - Via sentinel:        HostName=<sentinel>, User=<container-name>;
+                         sshpiper on the sentinel routes by username.
+
+Examples:
+
+  # Print to stdout — review before writing
+  containarium ssh-config show
+
+  # Write the file (default: ~/.containarium/ssh_config)
+  containarium ssh-config sync
+
+  # Behind a sentinel
+  containarium ssh-config sync --sentinel sentinel.example.com
+
+  # With a dedicated identity file
+  containarium ssh-config sync --identity ~/.ssh/containarium_ed25519`,
+}
+
+var sshConfigShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Print the generated ssh_config to stdout",
+	RunE:  runSSHConfigShow,
+}
+
+var sshConfigSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Write the generated ssh_config to disk",
+	RunE:  runSSHConfigSync,
+}
+
+func init() {
+	rootCmd.AddCommand(sshConfigCmd)
+	sshConfigCmd.AddCommand(sshConfigShowCmd, sshConfigSyncCmd)
+
+	for _, c := range []*cobra.Command{sshConfigShowCmd, sshConfigSyncCmd} {
+		c.Flags().StringVar(&sshConfigSentinel, "sentinel", "",
+			"Sentinel SSH endpoint (e.g. sentinel.example.com or sentinel.example.com:2222). "+
+				"When set, all entries route through it via sshpiper. Empty = direct mode.")
+		c.Flags().IntVar(&sshConfigPort, "sentinel-port", 22,
+			"SSH port on the sentinel (overridden by host:port form in --sentinel)")
+		c.Flags().StringVar(&sshConfigIdentity, "identity", "",
+			"IdentityFile to render in every Host block (omitted by default)")
+		c.Flags().StringVar(&sshConfigUser, "user", "",
+			"Override per-Host User (default: container name in sentinel mode, ubuntu in direct mode)")
+		c.Flags().BoolVar(&sshConfigIncludeStopped, "include-stopped", false,
+			"Include stopped containers (default: only running)")
+	}
+
+	sshConfigSyncCmd.Flags().StringVar(&sshConfigOutPath, "out", "",
+		"Output path (default: ~/.containarium/ssh_config)")
+}
+
+func runSSHConfigShow(cmd *cobra.Command, args []string) error {
+	containers, err := loadContainersForSSHConfig()
+	if err != nil {
+		return err
+	}
+	g := sshconfig.Generate(containers, sshConfigOptions())
+	fmt.Print(g.Content)
+	fmt.Fprintf(os.Stderr,
+		"\n# %d host(s) generated, %d skipped (stopped), %d skipped (no address)\n",
+		g.Count, g.SkippedStopped, g.SkippedNoAddr)
+	return nil
+}
+
+func runSSHConfigSync(cmd *cobra.Command, args []string) error {
+	containers, err := loadContainersForSSHConfig()
+	if err != nil {
+		return err
+	}
+	g := sshconfig.Generate(containers, sshConfigOptions())
+
+	out := sshConfigOutPath
+	if out == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("resolve home dir: %w", err)
+		}
+		out = filepath.Join(home, ".containarium", "ssh_config")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(out), 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(out), err)
+	}
+	// 0600 — the file lists every host the user can SSH to. Treat it as
+	// sensitive so it doesn't leak in a backup or shared shell.
+	if err := os.WriteFile(out, []byte(g.Content), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", out, err)
+	}
+
+	fmt.Printf("wrote %s (%d host(s), %d skipped stopped, %d skipped no-address)\n",
+		out, g.Count, g.SkippedStopped, g.SkippedNoAddr)
+	fmt.Println()
+	fmt.Println("If you haven't already, add this one line to ~/.ssh/config:")
+	fmt.Println()
+	fmt.Printf("    Include %s\n", out)
+	fmt.Println()
+	fmt.Println("Then `ssh <container-name>` will route correctly.")
+	return nil
+}
+
+func sshConfigOptions() sshconfig.Options {
+	return sshconfig.Options{
+		Sentinel:       sshConfigSentinel,
+		SentinelPort:   sshConfigPort,
+		IdentityFile:   sshConfigIdentity,
+		User:           sshConfigUser,
+		IncludeStopped: sshConfigIncludeStopped,
+	}
+}
+
+// loadContainersForSSHConfig pulls the container list using whichever
+// transport the global flags select — same logic as `containarium list`.
+// Reusing those helpers keeps the source-of-truth single.
+func loadContainersForSSHConfig() ([]incus.ContainerInfo, error) {
+	if httpMode && serverAddr != "" {
+		return listRemoteHTTP()
+	}
+	if serverAddr != "" {
+		return listRemote()
+	}
+	return listLocal()
+}

--- a/internal/sshconfig/generate.go
+++ b/internal/sshconfig/generate.go
@@ -1,0 +1,165 @@
+// Package sshconfig generates a self-contained OpenSSH config file for
+// every container the user can reach. The file is meant to be Include'd
+// from ~/.ssh/config — the user adds one line once, and we never touch
+// their primary config:
+//
+//	Include ~/.containarium/ssh_config
+//
+// After that, `ssh <container-name>` and `scp <container-name>:...` work
+// without any further setup.
+package sshconfig
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/incus"
+)
+
+// Options controls how Host blocks are rendered. The two routing modes
+// reflect the two ways a Containarium container is reachable:
+//
+//  1. Direct (Sentinel == ""): user is on the same network as the
+//     container; the Host block uses the container's IP directly. This
+//     is the local-Incus / dev workstation case.
+//  2. Via sentinel: every connection goes to the sentinel's SSH port
+//     and sshpiper routes by username to the right backend. The Host
+//     block sets HostName=<sentinel> and User=<container-name>.
+type Options struct {
+	// Sentinel is the public-facing SSH endpoint, e.g.
+	// "containarium.kafeido.app" or "sentinel.example.com:22". Empty
+	// means generate direct entries against each container's IP.
+	Sentinel string
+	// SentinelPort is the SSH port on the sentinel. Default 22.
+	SentinelPort int
+	// IdentityFile, if non-empty, is rendered as IdentityFile in every
+	// Host block. Leave empty to let the user manage keys via the
+	// agent / global config.
+	IdentityFile string
+	// User overrides the per-Host User. If empty: when Sentinel is set,
+	// User=container-name (sshpiper routes); otherwise User="ubuntu".
+	User string
+	// IncludeStopped emits Host blocks for stopped containers too. Off
+	// by default — if the container can't accept connections, an entry
+	// just produces confusing timeouts.
+	IncludeStopped bool
+}
+
+// Generated is the rendered config plus metadata for the caller (the CLI
+// uses Count / SkippedNoAddr in user-facing output).
+type Generated struct {
+	Content        string
+	Count          int
+	SkippedNoAddr  int
+	SkippedStopped int
+}
+
+// Header / footer markers delimit the section we own. If anyone ever
+// needs to merge into an existing file, scanning between these is the
+// supported way to find our block. Keep them stable.
+const (
+	beginMarker = "# >>> containarium ssh-config (managed) >>>"
+	endMarker   = "# <<< containarium ssh-config (managed) <<<"
+)
+
+// Generate renders a self-contained ssh_config from the given containers.
+// The output always includes the begin/end markers so callers writing
+// into a larger file can locate and replace just our block.
+func Generate(containers []incus.ContainerInfo, opts Options) Generated {
+	if opts.SentinelPort == 0 {
+		opts.SentinelPort = 22
+	}
+
+	var b strings.Builder
+	g := Generated{}
+
+	fmt.Fprintln(&b, beginMarker)
+	fmt.Fprintf(&b, "# generated %s by `containarium ssh-config sync`\n",
+		time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintln(&b, "# do not edit by hand — re-run sync to update")
+	fmt.Fprintln(&b)
+
+	// Sort by name so the file is stable across runs (avoids spurious
+	// diffs in users who track this file in dotfiles).
+	sorted := make([]incus.ContainerInfo, len(containers))
+	copy(sorted, containers)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+
+	for _, c := range sorted {
+		if !opts.IncludeStopped && c.State != "Running" {
+			g.SkippedStopped++
+			continue
+		}
+		if opts.Sentinel == "" && c.IPAddress == "" {
+			g.SkippedNoAddr++
+			continue
+		}
+		writeHost(&b, c, opts)
+		g.Count++
+	}
+
+	fmt.Fprintln(&b, endMarker)
+	g.Content = b.String()
+	return g
+}
+
+func writeHost(b *strings.Builder, c incus.ContainerInfo, opts Options) {
+	fmt.Fprintf(b, "Host %s\n", c.Name)
+
+	if opts.Sentinel != "" {
+		host, port := splitHostPort(opts.Sentinel, opts.SentinelPort)
+		fmt.Fprintf(b, "    HostName %s\n", host)
+		fmt.Fprintf(b, "    Port %d\n", port)
+		user := opts.User
+		if user == "" {
+			user = c.Name
+		}
+		fmt.Fprintf(b, "    User %s\n", user)
+	} else {
+		fmt.Fprintf(b, "    HostName %s\n", c.IPAddress)
+		fmt.Fprintf(b, "    Port 22\n")
+		user := opts.User
+		if user == "" {
+			user = "ubuntu"
+		}
+		fmt.Fprintf(b, "    User %s\n", user)
+	}
+
+	if opts.IdentityFile != "" {
+		fmt.Fprintf(b, "    IdentityFile %s\n", opts.IdentityFile)
+		// IdentitiesOnly prevents ssh-agent from trying every key it
+		// holds before the right one — useful when the user has many
+		// keys loaded and wants the file's identity to win.
+		fmt.Fprintln(b, "    IdentitiesOnly yes")
+	}
+
+	if c.BackendID != "" {
+		fmt.Fprintf(b, "    # backend: %s\n", c.BackendID)
+	}
+	fmt.Fprintln(b)
+}
+
+// splitHostPort accepts "host", "host:port", or "[ipv6]:port" and returns
+// the host and a port (falling back to the default if not specified).
+func splitHostPort(s string, defaultPort int) (string, int) {
+	if strings.HasPrefix(s, "[") {
+		if idx := strings.LastIndex(s, "]:"); idx > 0 {
+			var port int
+			fmt.Sscanf(s[idx+2:], "%d", &port)
+			if port > 0 {
+				return s[1:idx], port
+			}
+		}
+		return strings.TrimSuffix(strings.TrimPrefix(s, "["), "]"), defaultPort
+	}
+	if idx := strings.LastIndex(s, ":"); idx > 0 && !strings.Contains(s, "::") {
+		var port int
+		fmt.Sscanf(s[idx+1:], "%d", &port)
+		if port > 0 {
+			return s[:idx], port
+		}
+	}
+	return s, defaultPort
+}

--- a/internal/sshconfig/generate_test.go
+++ b/internal/sshconfig/generate_test.go
@@ -1,0 +1,147 @@
+package sshconfig
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/incus"
+)
+
+func TestGenerate_DirectMode(t *testing.T) {
+	cs := []incus.ContainerInfo{
+		{Name: "alice", State: "Running", IPAddress: "10.0.0.10"},
+		{Name: "bob", State: "Running", IPAddress: "10.0.0.11"},
+	}
+	g := Generate(cs, Options{})
+	if g.Count != 2 {
+		t.Fatalf("Count = %d, want 2", g.Count)
+	}
+	if !strings.Contains(g.Content, "Host alice") || !strings.Contains(g.Content, "HostName 10.0.0.10") {
+		t.Errorf("alice block missing or wrong:\n%s", g.Content)
+	}
+	if !strings.Contains(g.Content, "User ubuntu") {
+		t.Errorf("expected default User=ubuntu in direct mode")
+	}
+	if !strings.Contains(g.Content, beginMarker) || !strings.Contains(g.Content, endMarker) {
+		t.Errorf("missing managed-block markers")
+	}
+}
+
+func TestGenerate_SentinelMode_UsesContainerNameAsUser(t *testing.T) {
+	cs := []incus.ContainerInfo{
+		{Name: "alice", State: "Running", IPAddress: "10.0.0.10"},
+	}
+	g := Generate(cs, Options{Sentinel: "sentinel.example.com"})
+	if !strings.Contains(g.Content, "HostName sentinel.example.com") {
+		t.Errorf("expected sentinel host:\n%s", g.Content)
+	}
+	if !strings.Contains(g.Content, "User alice") {
+		t.Errorf("expected User=alice (container name as sshpiper route key):\n%s", g.Content)
+	}
+	if strings.Contains(g.Content, "10.0.0.10") {
+		t.Errorf("container LAN IP should not leak in sentinel mode:\n%s", g.Content)
+	}
+}
+
+func TestGenerate_SentinelMode_ExplicitPort(t *testing.T) {
+	cs := []incus.ContainerInfo{
+		{Name: "alice", State: "Running", IPAddress: "10.0.0.10"},
+	}
+	g := Generate(cs, Options{Sentinel: "sentinel.example.com:2222"})
+	if !strings.Contains(g.Content, "Port 2222") {
+		t.Errorf("expected Port 2222 from host:port form:\n%s", g.Content)
+	}
+}
+
+func TestGenerate_StoppedSkippedByDefault(t *testing.T) {
+	cs := []incus.ContainerInfo{
+		{Name: "alive", State: "Running", IPAddress: "10.0.0.1"},
+		{Name: "dead", State: "Stopped", IPAddress: "10.0.0.2"},
+	}
+	g := Generate(cs, Options{})
+	if g.Count != 1 || g.SkippedStopped != 1 {
+		t.Fatalf("Count=%d SkippedStopped=%d, want 1/1", g.Count, g.SkippedStopped)
+	}
+	if strings.Contains(g.Content, "Host dead") {
+		t.Errorf("stopped container should be skipped:\n%s", g.Content)
+	}
+}
+
+func TestGenerate_IncludeStopped(t *testing.T) {
+	cs := []incus.ContainerInfo{
+		{Name: "dead", State: "Stopped", IPAddress: "10.0.0.2"},
+	}
+	g := Generate(cs, Options{IncludeStopped: true})
+	if g.Count != 1 {
+		t.Errorf("expected stopped to be included, Count=%d", g.Count)
+	}
+}
+
+func TestGenerate_DirectModeSkipsNoAddr(t *testing.T) {
+	cs := []incus.ContainerInfo{
+		{Name: "ghost", State: "Running", IPAddress: ""},
+	}
+	g := Generate(cs, Options{})
+	if g.Count != 0 || g.SkippedNoAddr != 1 {
+		t.Errorf("Count=%d SkippedNoAddr=%d, want 0/1", g.Count, g.SkippedNoAddr)
+	}
+}
+
+func TestGenerate_StableOrder(t *testing.T) {
+	cs := []incus.ContainerInfo{
+		{Name: "zebra", State: "Running", IPAddress: "10.0.0.3"},
+		{Name: "alpha", State: "Running", IPAddress: "10.0.0.1"},
+		{Name: "mid", State: "Running", IPAddress: "10.0.0.2"},
+	}
+	g1 := Generate(cs, Options{})
+	g2 := Generate(cs, Options{})
+	if g1.Content != g2.Content {
+		// time.Now() is in the comment header — strip first two lines for stability.
+		strip := func(s string) string {
+			parts := strings.SplitN(s, "\n", 4)
+			return parts[3]
+		}
+		if strip(g1.Content) != strip(g2.Content) {
+			t.Errorf("output is not stable across runs")
+		}
+	}
+	idxA := strings.Index(g1.Content, "Host alpha")
+	idxM := strings.Index(g1.Content, "Host mid")
+	idxZ := strings.Index(g1.Content, "Host zebra")
+	if !(idxA < idxM && idxM < idxZ) {
+		t.Errorf("Host blocks not sorted alphabetically:\n%s", g1.Content)
+	}
+}
+
+func TestGenerate_IdentityFileEmitsIdentitiesOnly(t *testing.T) {
+	cs := []incus.ContainerInfo{
+		{Name: "alice", State: "Running", IPAddress: "10.0.0.1"},
+	}
+	g := Generate(cs, Options{IdentityFile: "~/.ssh/containarium_ed25519"})
+	if !strings.Contains(g.Content, "IdentityFile ~/.ssh/containarium_ed25519") {
+		t.Errorf("missing IdentityFile:\n%s", g.Content)
+	}
+	if !strings.Contains(g.Content, "IdentitiesOnly yes") {
+		t.Errorf("IdentityFile should imply IdentitiesOnly:\n%s", g.Content)
+	}
+}
+
+func TestSplitHostPort(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantHost string
+		wantPort int
+	}{
+		{"sentinel.example.com", "sentinel.example.com", 22},
+		{"sentinel.example.com:2222", "sentinel.example.com", 2222},
+		{"[2001:db8::1]:2222", "2001:db8::1", 2222},
+		{"[2001:db8::1]", "2001:db8::1", 22},
+	}
+	for _, tc := range cases {
+		h, p := splitHostPort(tc.in, 22)
+		if h != tc.wantHost || p != tc.wantPort {
+			t.Errorf("splitHostPort(%q) = (%q,%d), want (%q,%d)",
+				tc.in, h, p, tc.wantHost, tc.wantPort)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `containarium ssh-config show` / `containarium ssh-config sync` to generate a self-contained OpenSSH config covering every container the user can reach. The user wires it into their existing config with **one** line — we never touch `~/.ssh/config` directly:

```
Include ~/.containarium/ssh_config
```

After that, `ssh <container-name>`, `scp`, and any tool that calls plain `ssh` (including the agent-box MCP server in #110) work transparently.

## Two routing modes

| Mode | When to use | Generated entry |
|---|---|---|
| **Direct** (default) | LAN-reachable boxes (local Incus, dev workstation) | `HostName=<container-IP>`, `User=ubuntu` |
| **Via sentinel** (`--sentinel <host>`) | Production with sshpiper on the sentinel | `HostName=<sentinel>`, `User=<container-name>` (sshpiper routes by username) |

## Why a separate file (vs. mutating ~/.ssh/config)

- We never have to parse the user's config — no merge logic, no risk of clobbering.
- Uninstall = `rm ~/.containarium/ssh_config`. Single delete.
- Idempotent: full regenerate every sync, stable alphabetical order so dotfile-tracked configs don't churn.
- Marker-delimited block (`# >>> containarium ssh-config (managed) >>>`) leaves room to support an opt-in "merge into existing file" mode later without breaking anything.

## What's in it

- `internal/sshconfig/generate.go` — pure generator, no I/O. Easy to wrap from a future MCP tool.
- `internal/sshconfig/generate_test.go` — 9 tests: direct, sentinel, port parsing (bare host + host:port + IPv6), stopped-skip, include-stopped, no-address-skip, sorted output, identity-file → IdentitiesOnly.
- `internal/cmd/ssh_config.go` — cobra wiring; reuses the existing `listLocal`/`listRemote`/`listRemoteHTTP` source-of-truth.

## Test plan

- [x] `go test ./internal/sshconfig/...` — 9 passing
- [x] `go test ./internal/cmd/...` — passes
- [x] `go build ./cmd/containarium`
- [x] `containarium ssh-config --help` and subcommand help render cleanly
- [ ] Live sync against a deployment (local Incus, then footprintai-prod via `--server`)
- [ ] Add a future MCP tool wrapping the generator (deferred — depends on #110 landing)

## Out of scope

- MCP integration: deferred. The generator is pure, so wrapping it from a `setup_ssh` tool is a small follow-up after #110 (agent-box) merges.
- Merging into an existing file: deferred. Markers are in place if we ever need it.
- Multi-deployment / multi-account: a single sync targets a single deployment, same as `containarium list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)