### PR TITLE
feat(platform-mcp): expose_port — make a container reachable on a public hostname

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# Containarium — guidance for Claude / AI assistants
+
+This file is a small set of durable conventions for AI assistants working
+on this repository. Keep it short — only rules whose violation we'd
+actually want to catch in review.
+
+## CLI-first, MCP wraps it
+
+When adding a new platform action (anything that mutates Containarium
+state — create, expose, route, deploy, etc.):
+
+1. Land it as a `containarium <verb>` cobra subcommand under
+   `internal/cmd/<verb>.go` first.
+2. The MCP tool in `internal/mcp/tools.go` is a **thin wrapper** over the
+   same underlying Go function used by the CLI handler. Don't have the
+   MCP tool call an HTTP endpoint that the CLI doesn't.
+
+**Why:** The CLI is the canonical interface. Humans, shell scripts, CI,
+and demo recordings all consume it; MCP is one specific consumer (AI
+agents). Building CLI-first means:
+
+- Anything an agent can do, a human can do via shell — symmetric surface
+  with no agent-only escape hatches.
+- Demo recordings are reproducible `bash` scripts, not "spin up an
+  agent + JWT token" rituals.
+- Tests focus on the CLI handler / shared client function; MCP correctness
+  follows for free.
+- The OSS community gets value from the CLI even without running an agent.
+
+**Anti-pattern:** an MCP tool that talks to an HTTP endpoint with no
+matching `containarium <verb>` subcommand. If you spot one, file a
+follow-up to add the CLI counterpart.
+
+## Two MCP servers, distinct surfaces
+
+- `cmd/mcp-server/` — **platform** MCP. Outside-the-box admin
+  operations: create container, list containers, expose port, etc.
+  Talks to the platform's REST/gRPC API.
+- `cmd/agent-box/` — **in-the-box** MCP. Linux-native operations
+  (shell, files) running *inside* a single Containarium box. Reached
+  over stdio, typically wrapped by SSH on the client side.
+
+Don't mix them. Tools that operate on a single box's filesystem belong
+in `agent-box`; tools that operate across boxes belong in the platform
+MCP.

--- a/internal/cmd/expose_port.go
+++ b/internal/cmd/expose_port.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/footprintai/containarium/internal/client"
+	"github.com/footprintai/containarium/internal/expose"
+	"github.com/spf13/cobra"
+)
+
+var (
+	exposePortPort        int
+	exposePortDomain      string
+	exposePortDescription string
+)
+
+var exposePortCmd = &cobra.Command{
+	Use:   "expose-port <username>",
+	Short: "Expose a container's port on a public hostname",
+	Long: `Resolve a container's current LAN IP and register a domain → IP:port
+mapping in the sentinel reverse proxy. After this completes,
+https://<domain>/ reaches the container.
+
+This is a friendlier wrapper around 'containarium route add' that
+auto-resolves the container's IP from its name. Both this command and
+the platform MCP's expose_port tool delegate to the same Go function
+in internal/expose so the behavior can never drift.
+
+Example:
+  containarium expose-port alice \
+      --container-port 8080 \
+      --domain blog.example.com \
+      --server <host:port>`,
+	Args: cobra.ExactArgs(1),
+	RunE: runExposePort,
+}
+
+func init() {
+	rootCmd.AddCommand(exposePortCmd)
+
+	exposePortCmd.Flags().IntVar(&exposePortPort, "container-port", 0,
+		"Port the app listens on inside the container (required)")
+	exposePortCmd.Flags().StringVar(&exposePortDomain, "domain", "",
+		"Public hostname to route from, e.g. blog.example.com (required)")
+	exposePortCmd.Flags().StringVar(&exposePortDescription, "description", "",
+		"Optional human-readable note (shown in 'route list')")
+
+	_ = exposePortCmd.MarkFlagRequired("container-port")
+	_ = exposePortCmd.MarkFlagRequired("domain")
+}
+
+func runExposePort(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required")
+	}
+
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return fmt.Errorf("failed to connect to server: %w", err)
+	}
+	defer grpcClient.Close()
+
+	res, err := expose.Run(context.Background(), &grpcExposeAdapter{c: grpcClient}, expose.Options{
+		Username:      args[0],
+		ContainerPort: exposePortPort,
+		Domain:        exposePortDomain,
+		Description:   exposePortDescription,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("✓ Exposed %s:%d → %s\n", args[0], exposePortPort, res.Domain)
+	fmt.Printf("  Domain:    %s\n", res.Domain)
+	fmt.Printf("  Target:    %s:%d\n", res.ContainerIP, res.Port)
+	if res.ContainerName != "" {
+		fmt.Printf("  Container: %s\n", res.ContainerName)
+	}
+	if res.Message != "" {
+		fmt.Printf("\n%s\n", res.Message)
+	}
+	fmt.Printf("\nNext: confirm DNS for %s points at the sentinel,\n", res.Domain)
+	fmt.Printf("then `curl https://%s/` should reach the app.\n", res.Domain)
+	return nil
+}
+
+// grpcExposeAdapter implements expose.APIClient against the gRPC client.
+// LookupContainer is implemented via ListContainers + linear scan because
+// the gRPC surface doesn't expose a "by-name" lookup; this is fine for
+// the typical scale (tens of containers) and saves us a new RPC.
+type grpcExposeAdapter struct{ c *client.GRPCClient }
+
+func (a *grpcExposeAdapter) LookupContainer(_ context.Context, username string) (string, string, string, error) {
+	containers, err := a.c.ListContainers()
+	if err != nil {
+		return "", "", "", err
+	}
+	for _, ci := range containers {
+		// Container names follow the "<username>-container" convention
+		// per internal/cmd/list.go; accept either the full name or the
+		// bare username for ergonomic ergonomics.
+		if ci.Name == username || ci.Name == username+"-container" {
+			return ci.Name, ci.IPAddress, ci.State, nil
+		}
+	}
+	return "", "", "", fmt.Errorf("container %q not found", username)
+}
+
+func (a *grpcExposeAdapter) CreateRoute(_ context.Context, p expose.AddRouteParams) (*expose.RouteResult, error) {
+	route, err := a.c.AddRoute(p.Domain, p.TargetIP, p.TargetPort, p.ContainerName, p.Description)
+	if err != nil {
+		return nil, err
+	}
+	// The proto's ProxyRoute response doesn't echo ContainerName or
+	// the request's Domain field (it carries FullDomain); fall back to
+	// what the caller asked for so the result is always populated.
+	domain := route.FullDomain
+	if domain == "" {
+		domain = p.Domain
+	}
+	return &expose.RouteResult{
+		Domain:        domain,
+		ContainerName: p.ContainerName,
+		ContainerIP:   route.ContainerIp,
+		Port:          route.Port,
+	}, nil
+}

--- a/internal/expose/expose.go
+++ b/internal/expose/expose.go
@@ -92,6 +92,8 @@ func Run(ctx context.Context, c APIClient, opts Options) (*RouteResult, error) {
 	res, err := c.CreateRoute(ctx, AddRouteParams{
 		Domain:        opts.Domain,
 		TargetIP:      ip,
+		// #nosec G115 -- Options.Validate above bounds ContainerPort to
+		// 1..65535, well within int32 range.
 		TargetPort:    int32(opts.ContainerPort),
 		ContainerName: name,
 		Description:   opts.Description,

--- a/internal/expose/expose.go
+++ b/internal/expose/expose.go
@@ -1,0 +1,103 @@
+// Package expose holds the business logic for "make a container port
+// reachable on a public hostname." Both the `containarium expose-port`
+// CLI subcommand and the platform MCP's `expose_port` tool delegate to
+// this package — the CLI is the canonical surface, and the MCP tool is
+// a thin wrapper around the same Run() function via a transport-specific
+// adapter implementing APIClient.
+//
+// Adding a new transport (e.g. CLI HTTP mode) is one adapter type with
+// two methods. The validation, IP-resolution, and orchestration stay
+// here so behavior can never drift between CLI and MCP.
+package expose
+
+import (
+	"context"
+	"fmt"
+)
+
+// APIClient is the minimal transport surface this package needs. The
+// CLI implements it against client.GRPCClient; the MCP tool implements
+// it against mcp.Client (HTTP). Tests use a fake.
+type APIClient interface {
+	// LookupContainer finds a container by its identifier (the same
+	// "username" used by create_container / get_container) and returns
+	// the canonical container name plus its current LAN IP. State is
+	// returned for error messages when the IP isn't yet assigned.
+	LookupContainer(ctx context.Context, username string) (name, ip, state string, err error)
+
+	// CreateRoute registers a domain → IP:port mapping in the sentinel
+	// reverse proxy.
+	CreateRoute(ctx context.Context, p AddRouteParams) (*RouteResult, error)
+}
+
+// Options is what the caller (CLI or MCP) gathers from its surface.
+type Options struct {
+	Username      string
+	ContainerPort int
+	Domain        string
+	Description   string
+}
+
+// Validate fails fast on bad caller input. Both surfaces should call
+// this before doing any network round-trips so error messages are
+// transport-agnostic.
+func (o Options) Validate() error {
+	if o.Username == "" {
+		return fmt.Errorf("username is required")
+	}
+	if o.ContainerPort <= 0 || o.ContainerPort > 65535 {
+		return fmt.Errorf("container_port must be in 1..65535 (got %d)", o.ContainerPort)
+	}
+	if o.Domain == "" {
+		return fmt.Errorf("domain is required")
+	}
+	return nil
+}
+
+// AddRouteParams is the shape passed to APIClient.CreateRoute. Mirrors
+// the AddRouteRequest proto fields, but kept transport-agnostic so the
+// HTTP/JSON and gRPC adapters each marshal in their own way.
+type AddRouteParams struct {
+	Domain        string
+	TargetIP      string
+	TargetPort    int32
+	ContainerName string
+	Description   string
+}
+
+// RouteResult is the success response. Empty Message is fine.
+type RouteResult struct {
+	Domain        string
+	ContainerName string
+	ContainerIP   string
+	Port          int32
+	Message       string
+}
+
+// Run is the orchestrator. Resolves the container's current IP via
+// LookupContainer (we never trust a caller-supplied IP — recreated
+// containers shift IPs and a stale value would silently break the
+// route), then registers the route via CreateRoute.
+func Run(ctx context.Context, c APIClient, opts Options) (*RouteResult, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	name, ip, state, err := c.LookupContainer(ctx, opts.Username)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up container %q: %w", opts.Username, err)
+	}
+	if ip == "" {
+		return nil, fmt.Errorf("container %q has no IP address yet (state: %s)", opts.Username, state)
+	}
+	res, err := c.CreateRoute(ctx, AddRouteParams{
+		Domain:        opts.Domain,
+		TargetIP:      ip,
+		TargetPort:    int32(opts.ContainerPort),
+		ContainerName: name,
+		Description:   opts.Description,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add route: %w", err)
+	}
+	return res, nil
+}

--- a/internal/expose/expose_test.go
+++ b/internal/expose/expose_test.go
@@ -1,0 +1,138 @@
+package expose
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeClient is a minimal APIClient for unit-testing Run() without a
+// real transport. Each test sets the desired LookupContainer response
+// and CreateRoute response (or error) up front.
+type fakeClient struct {
+	// LookupContainer behavior
+	lookupName, lookupIP, lookupState string
+	lookupErr                         error
+	lookupCalls                       int
+
+	// CreateRoute behavior
+	createResult *RouteResult
+	createErr    error
+	createCalls  int
+	lastParams   AddRouteParams
+}
+
+func (f *fakeClient) LookupContainer(_ context.Context, _ string) (string, string, string, error) {
+	f.lookupCalls++
+	return f.lookupName, f.lookupIP, f.lookupState, f.lookupErr
+}
+
+func (f *fakeClient) CreateRoute(_ context.Context, p AddRouteParams) (*RouteResult, error) {
+	f.createCalls++
+	f.lastParams = p
+	return f.createResult, f.createErr
+}
+
+func TestRun_HappyPath(t *testing.T) {
+	c := &fakeClient{
+		lookupName:   "alice-container",
+		lookupIP:     "10.0.3.42",
+		lookupState:  "Running",
+		createResult: &RouteResult{Domain: "blog.example.com", ContainerIP: "10.0.3.42", Port: 8080, Message: "ok"},
+	}
+	got, err := Run(context.Background(), c, Options{
+		Username:      "alice",
+		ContainerPort: 8080,
+		Domain:        "blog.example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.lookupCalls != 1 || c.createCalls != 1 {
+		t.Errorf("call counts: lookup=%d create=%d (want 1/1)", c.lookupCalls, c.createCalls)
+	}
+	// Run must use the resolved IP, not anything caller-supplied.
+	if c.lastParams.TargetIP != "10.0.3.42" {
+		t.Errorf("CreateRoute got TargetIP=%q, want resolved 10.0.3.42", c.lastParams.TargetIP)
+	}
+	if c.lastParams.TargetPort != 8080 {
+		t.Errorf("CreateRoute got TargetPort=%d, want 8080", c.lastParams.TargetPort)
+	}
+	if c.lastParams.ContainerName != "alice-container" {
+		t.Errorf("CreateRoute got ContainerName=%q, want alice-container", c.lastParams.ContainerName)
+	}
+	if got.Domain != "blog.example.com" {
+		t.Errorf("result Domain=%q, want blog.example.com", got.Domain)
+	}
+}
+
+func TestRun_RejectsBadOptions(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"no username", Options{ContainerPort: 80, Domain: "x.example"}},
+		{"no domain", Options{Username: "alice", ContainerPort: 80}},
+		{"port zero", Options{Username: "alice", ContainerPort: 0, Domain: "x.example"}},
+		{"port too big", Options{Username: "alice", ContainerPort: 65536, Domain: "x.example"}},
+		{"port negative", Options{Username: "alice", ContainerPort: -1, Domain: "x.example"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &fakeClient{}
+			_, err := Run(context.Background(), c, tc.opts)
+			if err == nil {
+				t.Errorf("expected error for invalid options")
+			}
+			if c.lookupCalls != 0 || c.createCalls != 0 {
+				t.Errorf("validation must short-circuit; saw lookup=%d create=%d",
+					c.lookupCalls, c.createCalls)
+			}
+		})
+	}
+}
+
+func TestRun_RejectsNoIP(t *testing.T) {
+	c := &fakeClient{
+		lookupName:  "alice-container",
+		lookupIP:    "",
+		lookupState: "Stopped",
+	}
+	_, err := Run(context.Background(), c, Options{
+		Username: "alice", ContainerPort: 8080, Domain: "x.example",
+	})
+	if err == nil {
+		t.Fatal("expected error when container has no IP")
+	}
+	if c.createCalls != 0 {
+		t.Errorf("must not call CreateRoute when IP unresolved")
+	}
+}
+
+func TestRun_PropagatesLookupError(t *testing.T) {
+	c := &fakeClient{lookupErr: errors.New("not found")}
+	_, err := Run(context.Background(), c, Options{
+		Username: "alice", ContainerPort: 8080, Domain: "x.example",
+	})
+	if err == nil {
+		t.Fatal("expected lookup error to propagate")
+	}
+	if c.createCalls != 0 {
+		t.Errorf("must not call CreateRoute when lookup fails")
+	}
+}
+
+func TestRun_PropagatesCreateError(t *testing.T) {
+	c := &fakeClient{
+		lookupName:  "alice-container",
+		lookupIP:    "10.0.3.42",
+		lookupState: "Running",
+		createErr:   errors.New("domain already exists"),
+	}
+	_, err := Run(context.Background(), c, Options{
+		Username: "alice", ContainerPort: 8080, Domain: "x.example",
+	})
+	if err == nil {
+		t.Fatal("expected create error to propagate")
+	}
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -196,6 +196,23 @@ func (c *Client) GetSystemInfo() (*GetSystemInfoResponse, error) {
 	return &resp, nil
 }
 
+// AddRoute creates a domain → container:port mapping in the sentinel
+// reverse proxy. Used by the expose_port tool to make a container
+// reachable on the public internet under a chosen hostname.
+func (c *Client) AddRoute(req AddRouteRequest) (*AddRouteResponse, error) {
+	respBody, err := c.doRequest("POST", "/v1/network/routes", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp AddRouteResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &resp, nil
+}
+
 // API Request/Response types
 
 type CreateContainerRequest struct {
@@ -251,6 +268,32 @@ type GetMetricsResponse struct {
 
 type GetSystemInfoResponse struct {
 	Info SystemInfo `json:"info"`
+}
+
+// AddRouteRequest mirrors network.proto's AddRouteRequest. JSON field
+// names match the grpc-gateway HTTP shape (camelCase) so requests
+// serialized with encoding/json land at /v1/network/routes correctly.
+type AddRouteRequest struct {
+	Domain        string `json:"domain"`
+	TargetIP      string `json:"targetIp"`
+	TargetPort    int32  `json:"targetPort"`
+	ContainerName string `json:"containerName,omitempty"`
+	Description   string `json:"description,omitempty"`
+	// Protocol is "ROUTE_PROTOCOL_HTTP" by default on the server side;
+	// expose_port doesn't surface it because the demo path is HTTP.
+}
+
+type AddRouteResponse struct {
+	Route   ProxyRoute `json:"route"`
+	Message string     `json:"message,omitempty"`
+}
+
+type ProxyRoute struct {
+	Domain        string `json:"domain"`
+	ContainerIP   string `json:"containerIp"`
+	Port          int32  `json:"port"`
+	ContainerName string `json:"containerName,omitempty"`
+	Description   string `json:"description,omitempty"`
 }
 
 type Container struct {

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -375,3 +375,60 @@ func TestClientErrorHandling(t *testing.T) {
 		})
 	}
 }
+
+// TestAddRoute verifies the wire format and response handling for the
+// AddRoute method. Confirms the request body shape matches what the
+// grpc-gateway HTTP layer expects (camelCase fields).
+func TestAddRoute(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "POST", r.Method)
+		require.Equal(t, "/v1/network/routes", r.URL.Path)
+		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var req AddRouteRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "blog.example.com", req.Domain)
+		assert.Equal(t, "10.0.3.42", req.TargetIP)
+		assert.Equal(t, int32(8080), req.TargetPort)
+		assert.Equal(t, "alice-container", req.ContainerName)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"route": {
+				"domain": "blog.example.com",
+				"containerIp": "10.0.3.42",
+				"port": 8080,
+				"containerName": "alice-container"
+			},
+			"message": "route added"
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	resp, err := client.AddRoute(AddRouteRequest{
+		Domain:        "blog.example.com",
+		TargetIP:      "10.0.3.42",
+		TargetPort:    8080,
+		ContainerName: "alice-container",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "blog.example.com", resp.Route.Domain)
+	assert.Equal(t, "10.0.3.42", resp.Route.ContainerIP)
+	assert.Equal(t, int32(8080), resp.Route.Port)
+	assert.Equal(t, "route added", resp.Message)
+}
+
+func TestAddRoute_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"domain already exists"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	_, err := client.AddRoute(AddRouteRequest{Domain: "x", TargetIP: "y", TargetPort: 1})
+	require.Error(t, err)
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -21,7 +21,7 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	assert.Len(t, server.tools, 8, "Should have 8 tools registered")
+	assert.Len(t, server.tools, 9, "Should have 9 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -122,7 +122,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	assert.Len(t, tools, 8)
+	assert.Len(t, tools, 9)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -168,6 +168,37 @@ func (s *Server) registerTools() {
 			},
 			Handler: handleGetSystemInfo,
 		},
+		{
+			Name: "expose_port",
+			Description: "Expose a container's port on a public hostname. Resolves the " +
+				"container's IP, then registers a domain → container:port route in the " +
+				"sentinel reverse proxy. After this completes, https://<domain>/ " +
+				"reaches the container's port. Use for the 'make it online' demo step " +
+				"after the agent has installed something listening inside the box.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":        "string",
+						"description": "Container identifier (same value used by create_container / get_container).",
+					},
+					"container_port": map[string]interface{}{
+						"type":        "integer",
+						"description": "Port the app listens on inside the container, e.g. 8080.",
+					},
+					"domain": map[string]interface{}{
+						"type":        "string",
+						"description": "Public hostname to route from, e.g. 'blog.example.com'. The sentinel must already be DNS-pointed at this hostname or a wildcard parent.",
+					},
+					"description": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional human-readable note for the route (shown in route_list).",
+					},
+				},
+				"required": []string{"username", "container_port", "domain"},
+			},
+			Handler: handleExposePort,
+		},
 	}
 }
 
@@ -363,6 +394,58 @@ func handleGetSystemInfo(client *Client, args map[string]interface{}) (string, e
 	return result, nil
 }
 
+func handleExposePort(client *Client, args map[string]interface{}) (string, error) {
+	username, ok := args["username"].(string)
+	if !ok || username == "" {
+		return "", fmt.Errorf("username is required")
+	}
+	port, ok := getIntArg(args, "container_port")
+	if !ok || port <= 0 || port > 65535 {
+		return "", fmt.Errorf("container_port must be an integer in 1..65535")
+	}
+	domain := getStringArg(args, "domain", "")
+	if domain == "" {
+		return "", fmt.Errorf("domain is required")
+	}
+
+	// Resolve the container's current LAN IP. We don't trust an IP the
+	// caller might supply: if a container is recreated its IP can shift,
+	// and a stale value would cause the route to silently target nothing.
+	got, err := client.GetContainer(username)
+	if err != nil {
+		return "", fmt.Errorf("failed to look up container %q: %w", username, err)
+	}
+	if got.Container.Network == nil || got.Container.Network.IPAddress == "" {
+		return "", fmt.Errorf("container %q has no IP address yet (state: %s)",
+			username, got.Container.State)
+	}
+	ip := got.Container.Network.IPAddress
+
+	resp, err := client.AddRoute(AddRouteRequest{
+		Domain:        domain,
+		TargetIP:      ip,
+		TargetPort:    int32(port),
+		ContainerName: got.Container.Name,
+		Description:   getStringArg(args, "description", ""),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to add route: %w", err)
+	}
+
+	out := fmt.Sprintf("✅ Exposed %s:%d → %s\n\n", username, port, domain)
+	out += fmt.Sprintf("Domain:    %s\n", resp.Route.Domain)
+	out += fmt.Sprintf("Target:    %s:%d\n", resp.Route.ContainerIP, resp.Route.Port)
+	if resp.Route.ContainerName != "" {
+		out += fmt.Sprintf("Container: %s\n", resp.Route.ContainerName)
+	}
+	if resp.Message != "" {
+		out += fmt.Sprintf("\n%s", resp.Message)
+	}
+	out += "\n\nNext: confirm DNS for this hostname points at the sentinel, then\n"
+	out += fmt.Sprintf("`curl https://%s/` should reach the app inside %s.", domain, username)
+	return out, nil
+}
+
 // Helper functions
 
 func getStringArg(args map[string]interface{}, key, defaultValue string) string {
@@ -377,4 +460,23 @@ func getBoolArg(args map[string]interface{}, key string, defaultValue bool) bool
 		return val
 	}
 	return defaultValue
+}
+
+// getIntArg pulls an integer-shaped argument. JSON unmarshaling presents
+// integers as float64 by default, so we accept both. Returns ok=false when
+// the key is absent or the value is non-numeric — callers distinguish
+// "missing" from "set to zero" by inspecting ok.
+func getIntArg(args map[string]interface{}, key string) (int, bool) {
+	switch v := args[key].(type) {
+	case float64:
+		return int(v), true
+	case int:
+		return v, true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	default:
+		return 0, false
+	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,8 +1,11 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+
+	"github.com/footprintai/containarium/internal/expose"
 )
 
 // Tool represents an MCP tool (function)
@@ -395,55 +398,77 @@ func handleGetSystemInfo(client *Client, args map[string]interface{}) (string, e
 }
 
 func handleExposePort(client *Client, args map[string]interface{}) (string, error) {
-	username, ok := args["username"].(string)
-	if !ok || username == "" {
-		return "", fmt.Errorf("username is required")
-	}
-	port, ok := getIntArg(args, "container_port")
-	if !ok || port <= 0 || port > 65535 {
-		return "", fmt.Errorf("container_port must be an integer in 1..65535")
-	}
-	domain := getStringArg(args, "domain", "")
-	if domain == "" {
-		return "", fmt.Errorf("domain is required")
-	}
-
-	// Resolve the container's current LAN IP. We don't trust an IP the
-	// caller might supply: if a container is recreated its IP can shift,
-	// and a stale value would cause the route to silently target nothing.
-	got, err := client.GetContainer(username)
-	if err != nil {
-		return "", fmt.Errorf("failed to look up container %q: %w", username, err)
-	}
-	if got.Container.Network == nil || got.Container.Network.IPAddress == "" {
-		return "", fmt.Errorf("container %q has no IP address yet (state: %s)",
-			username, got.Container.State)
-	}
-	ip := got.Container.Network.IPAddress
-
-	resp, err := client.AddRoute(AddRouteRequest{
-		Domain:        domain,
-		TargetIP:      ip,
-		TargetPort:    int32(port),
-		ContainerName: got.Container.Name,
+	port, _ := getIntArg(args, "container_port")
+	res, err := expose.Run(context.Background(), &mcpExposeAdapter{c: client}, expose.Options{
+		Username:      getStringArg(args, "username", ""),
+		ContainerPort: port,
+		Domain:        getStringArg(args, "domain", ""),
 		Description:   getStringArg(args, "description", ""),
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to add route: %w", err)
+		return "", err
 	}
 
-	out := fmt.Sprintf("✅ Exposed %s:%d → %s\n\n", username, port, domain)
-	out += fmt.Sprintf("Domain:    %s\n", resp.Route.Domain)
-	out += fmt.Sprintf("Target:    %s:%d\n", resp.Route.ContainerIP, resp.Route.Port)
-	if resp.Route.ContainerName != "" {
-		out += fmt.Sprintf("Container: %s\n", resp.Route.ContainerName)
+	out := fmt.Sprintf("✅ Exposed %s:%d → %s\n\n",
+		getStringArg(args, "username", ""), port, res.Domain)
+	out += fmt.Sprintf("Domain:    %s\n", res.Domain)
+	out += fmt.Sprintf("Target:    %s:%d\n", res.ContainerIP, res.Port)
+	if res.ContainerName != "" {
+		out += fmt.Sprintf("Container: %s\n", res.ContainerName)
 	}
-	if resp.Message != "" {
-		out += fmt.Sprintf("\n%s", resp.Message)
+	if res.Message != "" {
+		out += fmt.Sprintf("\n%s", res.Message)
 	}
 	out += "\n\nNext: confirm DNS for this hostname points at the sentinel, then\n"
-	out += fmt.Sprintf("`curl https://%s/` should reach the app inside %s.", domain, username)
+	out += fmt.Sprintf("`curl https://%s/` should reach the app inside %s.",
+		res.Domain, getStringArg(args, "username", ""))
 	return out, nil
+}
+
+// mcpExposeAdapter implements expose.APIClient against this package's
+// HTTP Client. Identical responsibilities to the CLI's grpcExposeAdapter
+// in internal/cmd/expose_port.go — both transports speak through the
+// same expose.Run() so behavior can never drift.
+type mcpExposeAdapter struct{ c *Client }
+
+func (a *mcpExposeAdapter) LookupContainer(_ context.Context, username string) (string, string, string, error) {
+	got, err := a.c.GetContainer(username)
+	if err != nil {
+		return "", "", "", err
+	}
+	ip := ""
+	if got.Container.Network != nil {
+		ip = got.Container.Network.IPAddress
+	}
+	return got.Container.Name, ip, got.Container.State, nil
+}
+
+func (a *mcpExposeAdapter) CreateRoute(_ context.Context, p expose.AddRouteParams) (*expose.RouteResult, error) {
+	resp, err := a.c.AddRoute(AddRouteRequest{
+		Domain:        p.Domain,
+		TargetIP:      p.TargetIP,
+		TargetPort:    p.TargetPort,
+		ContainerName: p.ContainerName,
+		Description:   p.Description,
+	})
+	if err != nil {
+		return nil, err
+	}
+	domain := resp.Route.Domain
+	if domain == "" {
+		domain = p.Domain
+	}
+	containerName := resp.Route.ContainerName
+	if containerName == "" {
+		containerName = p.ContainerName
+	}
+	return &expose.RouteResult{
+		Domain:        domain,
+		ContainerName: containerName,
+		ContainerIP:   resp.Route.ContainerIP,
+		Port:          resp.Route.Port,
+		Message:       resp.Message,
+	}, nil
 }
 
 // Helper functions

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -412,4 +414,127 @@ func TestToolParameterDescriptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ----- expose_port -----------------------------------------------------
+
+// TestGetIntArg tests the getIntArg helper across the JSON-decoded shapes
+// agents tend to produce (float64 from encoding/json) plus native ints.
+func TestGetIntArg(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    map[string]interface{}
+		key     string
+		want    int
+		wantOK  bool
+	}{
+		{"float64 from JSON", map[string]interface{}{"p": float64(8080)}, "p", 8080, true},
+		{"native int", map[string]interface{}{"p": 8080}, "p", 8080, true},
+		{"missing", map[string]interface{}{}, "p", 0, false},
+		{"wrong type", map[string]interface{}{"p": "8080"}, "p", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := getIntArg(tc.args, tc.key)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestExposePort_HappyPath drives the full handler against an httptest
+// server that mocks both the GetContainer lookup and the AddRoute POST.
+// This catches wiring bugs (wrong path, wrong field name) the unit-only
+// tests for getIntArg can't.
+func TestExposePort_HappyPath(t *testing.T) {
+	addRouteCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/v1/containers/alice":
+			_, _ = w.Write([]byte(`{
+				"container": {
+					"name": "alice-container",
+					"username": "alice",
+					"state": "Running",
+					"network": {"ipAddress": "10.0.3.42"}
+				}
+			}`))
+		case r.Method == "POST" && r.URL.Path == "/v1/network/routes":
+			addRouteCalls++
+			var req AddRouteRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			// The handler must resolve the IP itself, not trust caller-supplied state.
+			assert.Equal(t, "10.0.3.42", req.TargetIP)
+			assert.Equal(t, int32(8080), req.TargetPort)
+			assert.Equal(t, "blog.example.com", req.Domain)
+			assert.Equal(t, "alice-container", req.ContainerName)
+			_, _ = w.Write([]byte(`{
+				"route": {
+					"domain": "blog.example.com",
+					"containerIp": "10.0.3.42",
+					"port": 8080,
+					"containerName": "alice-container"
+				},
+				"message": "route added"
+			}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	out, err := handleExposePort(client, map[string]interface{}{
+		"username":       "alice",
+		"container_port": float64(8080),
+		"domain":         "blog.example.com",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, addRouteCalls)
+	assert.Contains(t, out, "blog.example.com")
+	assert.Contains(t, out, "10.0.3.42:8080")
+}
+
+func TestExposePort_RejectsMissingArgs(t *testing.T) {
+	client := NewClient("http://unused", "token")
+	cases := []struct {
+		name string
+		args map[string]interface{}
+	}{
+		{"no username", map[string]interface{}{"container_port": float64(80), "domain": "x.example"}},
+		{"no port", map[string]interface{}{"username": "alice", "domain": "x.example"}},
+		{"no domain", map[string]interface{}{"username": "alice", "container_port": float64(80)}},
+		{"port out of range", map[string]interface{}{"username": "a", "container_port": float64(99999), "domain": "x.example"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := handleExposePort(client, tc.args)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestExposePort_RejectsContainerWithoutIP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Container exists but has no IP yet (e.g. still starting).
+		_, _ = w.Write([]byte(`{
+			"container": {
+				"name": "alice-container",
+				"username": "alice",
+				"state": "Stopped",
+				"network": {"ipAddress": ""}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	_, err := handleExposePort(client, map[string]interface{}{
+		"username":       "alice",
+		"container_port": float64(8080),
+		"domain":         "blog.example.com",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no IP address")
 }


### PR DESCRIPTION
## Summary

Adds the third leg of the demo flow. After **create_container** + **agent-box (#110)** + **ssh-config (#111)**, `expose_port` wires a hostname → container:port route in the sentinel reverse proxy so the box is reachable from the public internet.

## Demo flow now end-to-end

```
agent: "create me a sandbox called 'blog'"        → create_container
agent: "wire up SSH"                              → ssh-config sync (#111)
agent: "install Caddy on :8080 inside the box"    → shell_exec   (#110)
agent: "expose that on blog.example.com"          → expose_port  (this PR)

curl https://blog.example.com → hello world
```

## What's in it

- `Client.AddRoute` posting to `/v1/network/routes` (existing grpc-gateway endpoint wrapping the AddRoute gRPC method on NetworkServer). Field shape is camelCase to match grpc-gateway's HTTP contract.
- `expose_port` MCP tool that:
  1. Validates `username` / `container_port` (1..65535) / `domain`.
  2. Resolves the container's current LAN IP via `GetContainer` rather than trusting a caller-supplied value — recreated containers shift IPs, and a stale IP would leave the route pointing at nothing.
  3. POSTs the route, returns a follow-up hint for the agent (confirm DNS, then curl).

## Tests

Seven new + two updates:

- `TestAddRoute` — verifies wire shape (POST path, auth header, camelCase body fields) against an httptest server.
- `TestAddRoute_ServerError` — non-2xx propagates as Go error.
- `TestGetIntArg` — table-driven, covers float64 (the JSON case), native int, missing key, wrong type.
- `TestExposePort_HappyPath` — drives the full handler against an httptest stub of **both** `GetContainer` and `AddRoute`. Catches wiring bugs (path, field name, body shape) the unit tests can't.
- `TestExposePort_RejectsMissingArgs` — table-driven, four input-validation cases.
- `TestExposePort_RejectsContainerWithoutIP` — container exists but has no IP yet (e.g. still starting).
- `TestServerCreation` / `TestHandleToolsList` — tool-count bumped 8 → 9.

## Test plan

- [x] `go test ./internal/mcp/...` — all passing
- [x] `go build ./cmd/mcp-server`
- [ ] Live integration: drive `expose_port` from Claude Code against a real Containarium deployment, then `curl https://<domain>/`. Will be done when the demo recording starts.

## Out of scope

- `remove_route` / `list_routes` MCP tools — already exist as CLI subcommands (`route delete`, `route list`); MCP wrappers can ship in a follow-up. Not on the demo critical path.
- DNS provisioning — `expose_port` assumes the user has already pointed DNS at the sentinel (or has a wildcard). Automating Cloudflare/Route 53 is a bigger surface that doesn't belong in MCP itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)