### PR TITLE
fix(mcp): decode int64 fields as JSON strings (grpc-gateway shape)

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -297,14 +297,18 @@ type ProxyRoute struct {
 }
 
 type Container struct {
-	Name          string            `json:"name"`
-	Username      string            `json:"username"`
-	State         string            `json:"state"`
-	Resources     *ResourceLimits   `json:"resources,omitempty"`
-	SSHKeys       []string          `json:"sshKeys,omitempty"`
-	Network       *NetworkInfo      `json:"network,omitempty"`
-	CreatedAt     int64             `json:"createdAt"`
-	UpdatedAt     int64             `json:"updatedAt,omitempty"`
+	Name      string          `json:"name"`
+	Username  string          `json:"username"`
+	State     string          `json:"state"`
+	Resources *ResourceLimits `json:"resources,omitempty"`
+	SSHKeys   []string        `json:"sshKeys,omitempty"`
+	Network   *NetworkInfo    `json:"network,omitempty"`
+	// CreatedAt / UpdatedAt come back as JSON strings from the platform's
+	// grpc-gateway HTTP layer — int64 protobuf scalars are emitted as
+	// strings to avoid JavaScript number-precision loss. The `,string`
+	// tag makes encoding/json round-trip them correctly on both sides.
+	CreatedAt     int64             `json:"createdAt,string"`
+	UpdatedAt     int64             `json:"updatedAt,string,omitempty"`
 	Labels        map[string]string `json:"labels,omitempty"`
 	Image         string            `json:"image,omitempty"`
 	PodmanEnabled bool              `json:"podmanEnabled"`
@@ -318,14 +322,17 @@ type NetworkInfo struct {
 }
 
 type ContainerMetrics struct {
-	Name             string `json:"name"`
-	CPUUsageSeconds  int64  `json:"cpuUsageSeconds"`
-	MemoryUsageBytes int64  `json:"memoryUsageBytes"`
-	MemoryPeakBytes  int64  `json:"memoryPeakBytes"`
-	DiskUsageBytes   int64  `json:"diskUsageBytes"`
-	NetworkRxBytes   int64  `json:"networkRxBytes"`
-	NetworkTxBytes   int64  `json:"networkTxBytes"`
-	ProcessCount     int32  `json:"processCount"`
+	Name string `json:"name"`
+	// All int64 fields below come back as JSON strings from grpc-gateway
+	// (see Container.CreatedAt for rationale). int32 fields like
+	// ProcessCount stay numeric.
+	CPUUsageSeconds  int64 `json:"cpuUsageSeconds,string"`
+	MemoryUsageBytes int64 `json:"memoryUsageBytes,string"`
+	MemoryPeakBytes  int64 `json:"memoryPeakBytes,string"`
+	DiskUsageBytes   int64 `json:"diskUsageBytes,string"`
+	NetworkRxBytes   int64 `json:"networkRxBytes,string"`
+	NetworkTxBytes   int64 `json:"networkTxBytes,string"`
+	ProcessCount     int32 `json:"processCount"`
 }
 
 type SystemInfo struct {

--- a/internal/mcp/testdata/add_route_response.json
+++ b/internal/mcp/testdata/add_route_response.json
@@ -1,0 +1,14 @@
+{
+  "route": {
+    "subdomain": "blog",
+    "fullDomain": "blog.example.com",
+    "containerIp": "10.0.0.10",
+    "port": 8080,
+    "active": true,
+    "appId": "",
+    "appName": "",
+    "username": "alice",
+    "protocol": "ROUTE_PROTOCOL_HTTP"
+  },
+  "message": "route added"
+}

--- a/internal/mcp/testdata/create_container_response.json
+++ b/internal/mcp/testdata/create_container_response.json
@@ -1,0 +1,20 @@
+{
+  "container": {
+    "name": "alice-container",
+    "username": "alice",
+    "state": "CONTAINER_STATE_RUNNING",
+    "resources": {"cpu": "4", "memory": "8GB", "disk": "50GB", "gpu": ""},
+    "sshKeys": ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI... alice@laptop"],
+    "network": {"ipAddress": "10.0.0.10", "macAddress": "00:16:3e:aa:bb:cc", "interface": "eth0", "bridge": "incusbr0"},
+    "createdAt": "1771209160",
+    "updatedAt": "0",
+    "labels": {"team": "demo"},
+    "image": "images:ubuntu/24.04",
+    "podmanEnabled": true,
+    "backendId": "backend-a",
+    "osType": "OS_TYPE_UBUNTU_2404",
+    "accessType": "ACCESS_TYPE_SSH"
+  },
+  "message": "Container created successfully",
+  "sshCommand": "ssh alice@10.0.0.10"
+}

--- a/internal/mcp/testdata/get_container_response.json
+++ b/internal/mcp/testdata/get_container_response.json
@@ -1,0 +1,28 @@
+{
+  "container": {
+    "name": "alice-container",
+    "username": "alice",
+    "state": "CONTAINER_STATE_RUNNING",
+    "resources": {"cpu": "4", "memory": "8GB", "disk": "50GB", "gpu": ""},
+    "sshKeys": ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI... alice@laptop"],
+    "network": {"ipAddress": "10.0.0.10", "macAddress": "00:16:3e:aa:bb:cc", "interface": "eth0", "bridge": "incusbr0"},
+    "createdAt": "1771122760",
+    "updatedAt": "1771209160",
+    "labels": {"team": "demo", "project": "blog"},
+    "image": "images:ubuntu/24.04",
+    "podmanEnabled": true,
+    "backendId": "backend-a",
+    "osType": "OS_TYPE_UBUNTU_2404",
+    "accessType": "ACCESS_TYPE_SSH"
+  },
+  "metrics": {
+    "name": "alice-container",
+    "cpuUsageSeconds": "1234",
+    "memoryUsageBytes": "536870912",
+    "memoryPeakBytes": "1073741824",
+    "diskUsageBytes": "5368709120",
+    "networkRxBytes": "104857600",
+    "networkTxBytes": "52428800",
+    "processCount": 42
+  }
+}

--- a/internal/mcp/testdata/get_metrics_response.json
+++ b/internal/mcp/testdata/get_metrics_response.json
@@ -1,0 +1,24 @@
+{
+  "metrics": [
+    {
+      "name": "alice-container",
+      "cpuUsageSeconds": "1234",
+      "memoryUsageBytes": "536870912",
+      "memoryPeakBytes": "1073741824",
+      "diskUsageBytes": "5368709120",
+      "networkRxBytes": "104857600",
+      "networkTxBytes": "52428800",
+      "processCount": 42
+    },
+    {
+      "name": "bob-gpu-container",
+      "cpuUsageSeconds": "98765",
+      "memoryUsageBytes": "34359738368",
+      "memoryPeakBytes": "51539607552",
+      "diskUsageBytes": "214748364800",
+      "networkRxBytes": "10737418240",
+      "networkTxBytes": "5368709120",
+      "processCount": 187
+    }
+  ]
+}

--- a/internal/mcp/testdata/get_system_info_response.json
+++ b/internal/mcp/testdata/get_system_info_response.json
@@ -1,0 +1,11 @@
+{
+  "info": {
+    "incusVersion": "6.23.0",
+    "os": "Ubuntu 24.04.1 LTS",
+    "kernelVersion": "6.8.0-49-generic",
+    "containersRunning": 22,
+    "containersStopped": 2,
+    "containersTotal": 24,
+    "hostname": "demo-backend.example.internal"
+  }
+}

--- a/internal/mcp/testdata/list_containers_response.json
+++ b/internal/mcp/testdata/list_containers_response.json
@@ -1,0 +1,62 @@
+{
+  "containers": [
+    {
+      "name": "alice-container",
+      "username": "alice",
+      "state": "CONTAINER_STATE_RUNNING",
+      "resources": {"cpu": "4", "memory": "8GB", "disk": "50GB", "gpu": ""},
+      "sshKeys": [],
+      "network": {"ipAddress": "10.0.0.10", "macAddress": "", "interface": "", "bridge": ""},
+      "createdAt": "1771122760",
+      "updatedAt": "0",
+      "labels": {"team": "demo"},
+      "image": "",
+      "podmanEnabled": true,
+      "stack": "",
+      "gpuDevice": "",
+      "backendId": "backend-a",
+      "osType": "OS_TYPE_UBUNTU_2404",
+      "accessType": "ACCESS_TYPE_SSH",
+      "rdpAddress": ""
+    },
+    {
+      "name": "bob-gpu-container",
+      "username": "bob-gpu",
+      "state": "CONTAINER_STATE_RUNNING",
+      "resources": {"cpu": "16", "memory": "64GB", "disk": "500GB", "gpu": ""},
+      "sshKeys": [],
+      "network": {"ipAddress": "10.0.0.20", "macAddress": "", "interface": "", "bridge": ""},
+      "createdAt": "1771606611",
+      "updatedAt": "0",
+      "labels": {"team": "ml"},
+      "image": "",
+      "podmanEnabled": true,
+      "stack": "",
+      "gpuDevice": "01:00.0",
+      "backendId": "backend-gpu",
+      "osType": "OS_TYPE_UNSPECIFIED",
+      "accessType": "ACCESS_TYPE_SSH",
+      "rdpAddress": ""
+    },
+    {
+      "name": "ws2022",
+      "username": "ws2022",
+      "state": "CONTAINER_STATE_STOPPED",
+      "resources": {"cpu": "4", "memory": "8GiB", "disk": "50GiB", "gpu": ""},
+      "sshKeys": [],
+      "network": {"ipAddress": "", "macAddress": "", "interface": "", "bridge": ""},
+      "createdAt": "-62135596800",
+      "updatedAt": "0",
+      "labels": {},
+      "image": "",
+      "podmanEnabled": true,
+      "stack": "",
+      "gpuDevice": "",
+      "backendId": "backend-windows",
+      "osType": "OS_TYPE_UNSPECIFIED",
+      "accessType": "ACCESS_TYPE_SSH",
+      "rdpAddress": ""
+    }
+  ],
+  "totalCount": 3
+}

--- a/internal/mcp/wire_format_test.go
+++ b/internal/mcp/wire_format_test.go
@@ -1,0 +1,146 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Wire-format regression tests.
+//
+// These tests decode hand-built JSON fixtures that match the shape
+// grpc-gateway actually emits — in particular int64 protobuf scalars
+// serialized as JSON strings ("createdAt": "1771122760", not
+// "createdAt": 1771122760). Symmetric httptest mocks where we encode
+// our own structs as the response would round-trip cleanly under any
+// tag scheme; only fixtures that mirror the real wire shape catch
+// divergence between client and server.
+//
+// Background: a missing `,string` tag on Container.CreatedAt and the
+// ContainerMetrics int64 fields shipped to main and broke every
+// list_containers / get_container / get_metrics call against a real
+// deployment. These tests hold the line so it can't happen again.
+//
+// To refresh a fixture, capture a real response with curl, scrub
+// hostnames / IPs / customer container names down to demo values
+// (alice/bob), and replace it. Don't check in raw production data.
+
+const fixtureDir = "testdata"
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(fixtureDir, name))
+	require.NoError(t, err, "read fixture %s", name)
+	return data
+}
+
+// TestWireFormat_ListContainers is the regression test for the bug
+// fixed in PR #116. The fixture has int64 fields encoded as strings
+// (the real grpc-gateway shape); without `,string` tags on the client
+// struct, this test panics on json.Unmarshal.
+func TestWireFormat_ListContainers(t *testing.T) {
+	var resp ListContainersResponse
+	require.NoError(t, json.Unmarshal(loadFixture(t, "list_containers_response.json"), &resp))
+
+	assert.Equal(t, 3, resp.TotalCount)
+	require.Len(t, resp.Containers, 3)
+
+	// alice — running, has a real createdAt timestamp
+	alice := resp.Containers[0]
+	assert.Equal(t, "alice-container", alice.Name)
+	assert.Equal(t, "alice", alice.Username)
+	assert.Equal(t, "CONTAINER_STATE_RUNNING", alice.State)
+	assert.NotNil(t, alice.Network)
+	assert.Equal(t, "10.0.0.10", alice.Network.IPAddress)
+	// THE bug-prevention assertion: createdAt must round-trip from
+	// string-encoded JSON into a positive int64.
+	assert.Equal(t, int64(1771122760), alice.CreatedAt)
+
+	// ws2022 — Windows container with the cosmetic zero-time epoch
+	// (-62135596800 = year 0001, what the server emits for
+	// time.IsZero()). The decoder must accept it without error even
+	// though it's nonsense.
+	ws := resp.Containers[2]
+	assert.Equal(t, "ws2022", ws.Name)
+	assert.Equal(t, "CONTAINER_STATE_STOPPED", ws.State)
+	assert.Equal(t, int64(-62135596800), ws.CreatedAt)
+}
+
+func TestWireFormat_GetContainer(t *testing.T) {
+	var resp GetContainerResponse
+	require.NoError(t, json.Unmarshal(loadFixture(t, "get_container_response.json"), &resp))
+
+	assert.Equal(t, "alice-container", resp.Container.Name)
+	assert.Equal(t, int64(1771122760), resp.Container.CreatedAt)
+	assert.Equal(t, int64(1771209160), resp.Container.UpdatedAt)
+
+	// Embedded metrics must also decode the int64-as-string fields.
+	require.NotNil(t, resp.Metrics)
+	assert.Equal(t, "alice-container", resp.Metrics.Name)
+	assert.Equal(t, int64(1234), resp.Metrics.CPUUsageSeconds)
+	assert.Equal(t, int64(536870912), resp.Metrics.MemoryUsageBytes)
+	assert.Equal(t, int32(42), resp.Metrics.ProcessCount) // int32 stays numeric
+}
+
+func TestWireFormat_GetMetrics(t *testing.T) {
+	var resp GetMetricsResponse
+	require.NoError(t, json.Unmarshal(loadFixture(t, "get_metrics_response.json"), &resp))
+
+	require.Len(t, resp.Metrics, 2)
+	// Spot-check the GPU container's larger numbers — well above 2^32
+	// so any accidental int32 truncation would show up as a parse
+	// error or negative value.
+	bob := resp.Metrics[1]
+	assert.Equal(t, "bob-gpu-container", bob.Name)
+	assert.Equal(t, int64(34359738368), bob.MemoryUsageBytes) // 32 GiB
+	assert.Equal(t, int64(214748364800), bob.DiskUsageBytes)  // 200 GiB
+}
+
+func TestWireFormat_GetSystemInfo(t *testing.T) {
+	var resp GetSystemInfoResponse
+	require.NoError(t, json.Unmarshal(loadFixture(t, "get_system_info_response.json"), &resp))
+
+	assert.Equal(t, "6.23.0", resp.Info.IncusVersion)
+	assert.Equal(t, "Ubuntu 24.04.1 LTS", resp.Info.OS)
+	// container counts are int (not int64), no string-encoding
+	assert.Equal(t, 22, resp.Info.ContainersRunning)
+	assert.Equal(t, 24, resp.Info.ContainersTotal)
+}
+
+func TestWireFormat_CreateContainer(t *testing.T) {
+	var resp CreateContainerResponse
+	require.NoError(t, json.Unmarshal(loadFixture(t, "create_container_response.json"), &resp))
+
+	assert.Equal(t, "alice-container", resp.Container.Name)
+	assert.Equal(t, "Container created successfully", resp.Message)
+	assert.Equal(t, "ssh alice@10.0.0.10", resp.SSHCommand)
+	// createdAt must decode even on a freshly-created container
+	assert.Equal(t, int64(1771209160), resp.Container.CreatedAt)
+}
+
+// TestWireFormat_AddRoute notes a known mismatch and documents it: our
+// AddRouteResponse.Route declares fields named Domain / ContainerName,
+// but the wire shape from grpc-gateway uses fullDomain / username
+// (the proto's actual field names — see ProxyRoute in
+// proto/containarium/v1/network.proto). The current handler in
+// expose_port falls back to caller-supplied values when these decode
+// as empty; this test pins that behavior so a future refactor that
+// "fixes" the field names without updating the fallback breaks loudly.
+func TestWireFormat_AddRoute(t *testing.T) {
+	var resp AddRouteResponse
+	require.NoError(t, json.Unmarshal(loadFixture(t, "add_route_response.json"), &resp))
+
+	// These DON'T populate from the wire shape — different field names —
+	// so the handler must fall back. Document the gap.
+	assert.Empty(t, resp.Route.Domain, "Domain field doesn't exist in proto; fullDomain does. Handler must fall back.")
+	assert.Empty(t, resp.Route.ContainerName, "ContainerName field doesn't exist in proto; username does. Handler must fall back.")
+
+	// These DO populate — common ground between client struct and proto.
+	assert.Equal(t, "10.0.0.10", resp.Route.ContainerIP)
+	assert.Equal(t, int32(8080), resp.Route.Port)
+	assert.Equal(t, "route added", resp.Message)
+}


### PR DESCRIPTION
## What

Adds \`,string\` json tags to every \`int64\` field in \`Container\` and \`ContainerMetrics\`.

## Why

The platform daemon's HTTP layer is grpc-gateway, which serializes int64 protobuf scalars as **JSON strings** to avoid JavaScript number-precision loss. Our MCP client decoded them as numeric int64, so \`list_containers\` failed against any real deployment with:

\`\`\`
json: cannot unmarshal string into Go struct field Container.containers.createdAt of type int64
\`\`\`

The reason it only surfaces *now* is that earlier MCP work was exercised against \`httptest\` stubs that serialized our own structs back — both sides agreed on numeric, so the bug was invisible. Once Claude Code talked to production via the new MCP registration tonight, real wire shape diverged and every \`list_containers\` / \`get_container\` / \`create_container\` call broke.

## Verification

Drove a real MCP \`initialize → tools/call list_containers\` exchange against \`containarium.kafeido.app\` with the rebuilt binary. Returns \`Found 24 container(s)\` with the full pretty-printed list — same content the curl probe returned.

## What's NOT changed

- \`int32\` fields (ProcessCount, route Port, TargetPort) stay numeric. grpc-gateway only string-encodes 64-bit scalars.
- Tests still pass without modification: both encode and decode use the same struct, so they round-trip regardless of the \`,string\` flag.

## Test plan

- [x] \`go test ./internal/mcp/...\` passes
- [x] Live test against prod: \`list_containers\` returns 24 containers
- [ ] Live test of \`create_container\` / \`expose_port\` (deferred until prod daemon is bumped to v0.16.4-equivalent — \`expose_port\` doesn't exist on prod's v0.16.2 yet)
- [ ] Re-run Claude Code demo flow after this lands and the local binary is pulled

## Out of scope

- Investigating whether the \`createdAt\` field's negative-epoch values for some containers (\`-62135596800\`) are also a server-side issue — that's a date "0001-01-01" which suggests an empty timestamp being marshalled as \`-time.IsZero()\`-equivalent. Cosmetic, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)