### PR TITLE
feat: list_backends MCP tool + containarium backends list CLI

### DIFF
--- a/internal/cmd/backends.go
+++ b/internal/cmd/backends.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// backendsCmd is the parent for "containarium backends list" and any
+// future per-backend operations. Backends are the individual host
+// daemons (local + tunnel-connected peers) that make up a multi-host
+// Containarium fleet — exposed via /v1/backends on the platform daemon.
+var backendsCmd = &cobra.Command{
+	Use:   "backends",
+	Short: "Inspect cluster backends (local daemon + tunnel peers)",
+	Long: `Manage and inspect the backend hosts that make up a Containarium
+fleet. The "local" backend is the daemon you're talking to; "tunnel"
+backends are peer hosts connected via outbound tunnel (e.g. bare-metal
+GPU nodes, secondary regions).
+
+Examples:
+  # List all backends
+  containarium backends list --server <host:port>`,
+}
+
+func init() {
+	rootCmd.AddCommand(backendsCmd)
+}

--- a/internal/cmd/backends_list.go
+++ b/internal/cmd/backends_list.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	backendsListFormat string
+)
+
+var backendsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List backend hosts (local daemon + tunnel peers)",
+	Long: `List all backend hosts registered with the platform daemon. Returns
+id, type (local/tunnel), health, hostname, OS, container count, and
+GPU inventory per backend.
+
+The /v1/backends endpoint is HTTP-only (not gRPC), so this command
+requires --server pointing at the daemon's HTTP address.`,
+	Aliases: []string{"ls"},
+	RunE:    runBackendsList,
+}
+
+func init() {
+	backendsCmd.AddCommand(backendsListCmd)
+	backendsListCmd.Flags().StringVarP(&backendsListFormat, "format", "f", "table",
+		"Output format: table, json")
+}
+
+// backendInfo mirrors the /v1/backends response shape. Kept local to
+// the CLI so a server-side schema change shows up here as a decode
+// failure rather than a silent field-drop.
+type backendInfo struct {
+	ID             string       `json:"id"`
+	Type           string       `json:"type"`
+	Healthy        bool         `json:"healthy"`
+	Version        string       `json:"version,omitempty"`
+	Hostname       string       `json:"hostname,omitempty"`
+	UptimeSeconds  int64        `json:"uptimeSeconds,omitempty"`
+	LastSeenAt     string       `json:"lastSeenAt,omitempty"`
+	OS             string       `json:"os,omitempty"`
+	ContainerCount int32        `json:"containerCount"`
+	GPUs           []backendGPU `json:"gpus,omitempty"`
+}
+
+type backendGPU struct {
+	Vendor    string `json:"vendor,omitempty"`
+	ModelName string `json:"modelName,omitempty"`
+	VRAMBytes int64  `json:"vramBytes,omitempty"`
+}
+
+type backendsListResponse struct {
+	Backends []backendInfo `json:"backends"`
+}
+
+func runBackendsList(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (the platform daemon's HTTP address, e.g. http://host:8080)")
+	}
+	url := strings.TrimSuffix(serverAddr, "/") + "/v1/backends"
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("api error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var parsed backendsListResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	switch backendsListFormat {
+	case "json":
+		out, err := json.MarshalIndent(parsed, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(out))
+	case "table":
+		printBackendsTable(parsed.Backends)
+	default:
+		return fmt.Errorf("unknown format: %s (use: table, json)", backendsListFormat)
+	}
+	return nil
+}
+
+func printBackendsTable(backends []backendInfo) {
+	if len(backends) == 0 {
+		fmt.Println("No backends registered (running standalone, no peers).")
+		return
+	}
+	fmt.Printf("%-40s %-8s %-10s %-25s %-10s %s\n",
+		"BACKEND ID", "TYPE", "HEALTH", "HOSTNAME", "CONTAINERS", "GPUS")
+	fmt.Println(strings.Repeat("-", 110))
+	for _, b := range backends {
+		health := "✓"
+		if !b.Healthy {
+			health = "✗"
+		}
+		gpus := "-"
+		if len(b.GPUs) > 0 {
+			parts := make([]string, 0, len(b.GPUs))
+			for _, g := range b.GPUs {
+				parts = append(parts, g.ModelName)
+			}
+			gpus = strings.Join(parts, ", ")
+		}
+		hostname := b.Hostname
+		if hostname == "" {
+			hostname = "-"
+		}
+		fmt.Printf("%-40s %-8s %-10s %-25s %-10d %s\n",
+			b.ID, b.Type, health, hostname, b.ContainerCount, gpus)
+	}
+	fmt.Printf("\nTotal: %d backend(s)\n", len(backends))
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -213,6 +213,29 @@ func (c *Client) AddRoute(req AddRouteRequest) (*AddRouteResponse, error) {
 	return &resp, nil
 }
 
+// ListBackends returns the cluster topology — the local daemon plus any
+// tunnel-connected peers. Used by the list_backends MCP tool so an
+// agent can reason about peer health, container counts, and GPU
+// inventory without inferring topology from container IPs.
+//
+// Note: at the time of writing, /v1/backends is served by a hand-coded
+// handler (not grpc-gateway) and does NOT require authentication. The
+// MCP client still sends its JWT — server ignores it — so the day the
+// endpoint gains auth, this client doesn't need to change.
+func (c *Client) ListBackends() (*ListBackendsResponse, error) {
+	respBody, err := c.doRequest("GET", "/v1/backends", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ListBackendsResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	return &resp, nil
+}
+
 // API Request/Response types
 
 type CreateContainerRequest struct {
@@ -268,6 +291,34 @@ type GetMetricsResponse struct {
 
 type GetSystemInfoResponse struct {
 	Info SystemInfo `json:"info"`
+}
+
+// ListBackendsResponse mirrors the hand-coded /v1/backends handler. The
+// shape isn't proto-generated, so JSON tag conventions follow what the
+// handler emits (camelCase, not snake_case). int64 fields here are
+// emitted as numbers (the handler is hand-coded, not grpc-gateway), so
+// no `,string` tags needed.
+type ListBackendsResponse struct {
+	Backends []Backend `json:"backends"`
+}
+
+type Backend struct {
+	ID             string       `json:"id"`
+	Type           string       `json:"type"` // "local" or "tunnel"
+	Healthy        bool         `json:"healthy"`
+	Version        string       `json:"version,omitempty"`
+	Hostname       string       `json:"hostname,omitempty"`
+	UptimeSeconds  int64        `json:"uptimeSeconds,omitempty"`
+	LastSeenAt     string       `json:"lastSeenAt,omitempty"`
+	OS             string       `json:"os,omitempty"`
+	ContainerCount int32        `json:"containerCount"`
+	GPUs           []BackendGPU `json:"gpus,omitempty"`
+}
+
+type BackendGPU struct {
+	Vendor    string `json:"vendor,omitempty"`
+	ModelName string `json:"modelName,omitempty"`
+	VRAMBytes int64  `json:"vramBytes,omitempty"`
 }
 
 // AddRouteRequest mirrors network.proto's AddRouteRequest. JSON field

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -21,7 +21,7 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	assert.Len(t, server.tools, 9, "Should have 9 tools registered")
+	assert.Len(t, server.tools, 10, "Should have 10 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -122,7 +122,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	assert.Len(t, tools, 9)
+	assert.Len(t, tools, 10)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/testdata/list_backends_response.json
+++ b/internal/mcp/testdata/list_backends_response.json
@@ -1,0 +1,39 @@
+{
+  "backends": [
+    {
+      "id": "demo-backend-local.us-west1-a.c.example-project.internal",
+      "type": "local",
+      "healthy": true,
+      "version": "0.16.4",
+      "hostname": "demo-backend-local",
+      "uptimeSeconds": 345600,
+      "lastSeenAt": "2026-05-10T19:00:00Z",
+      "os": "Ubuntu 24.04.1 LTS",
+      "containerCount": 16
+    },
+    {
+      "id": "tunnel-fts-13700k-gpu",
+      "type": "tunnel",
+      "healthy": true,
+      "lastSeenAt": "2026-05-10T18:59:42Z",
+      "hostname": "fts-13700k",
+      "os": "Ubuntu 24.04.1 LTS",
+      "containerCount": 4,
+      "gpus": [
+        {"vendor": "NVIDIA", "modelName": "GeForce RTX 3090", "vramBytes": 25769803776}
+      ]
+    },
+    {
+      "id": "tunnel-fts-5900x-gpu",
+      "type": "tunnel",
+      "healthy": false,
+      "lastSeenAt": "2026-05-10T18:42:00Z",
+      "hostname": "fts-5900x",
+      "os": "Ubuntu 24.04.1 LTS",
+      "containerCount": 0,
+      "gpus": [
+        {"vendor": "NVIDIA", "modelName": "GeForce RTX 4090", "vramBytes": 25769803776}
+      ]
+    }
+  ]
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/footprintai/containarium/internal/expose"
 )
@@ -170,6 +171,19 @@ func (s *Server) registerTools() {
 				"properties": map[string]interface{}{},
 			},
 			Handler: handleGetSystemInfo,
+		},
+		{
+			Name: "list_backends",
+			Description: "List the cluster's backend hosts (the local daemon plus any " +
+				"tunnel-connected peers). Returns id, type (local/tunnel), health, " +
+				"hostname, OS, container count, and GPU inventory per backend. Use " +
+				"this when the agent needs to reason about peer topology — e.g. " +
+				"\"which host has GPU capacity?\" or \"is peer X healthy?\".",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+			Handler: handleListBackends,
 		},
 		{
 			Name: "expose_port",
@@ -395,6 +409,86 @@ func handleGetSystemInfo(client *Client, args map[string]interface{}) (string, e
 	result += fmt.Sprintf("  Total: %d\n", resp.Info.ContainersTotal)
 
 	return result, nil
+}
+
+func handleListBackends(client *Client, args map[string]interface{}) (string, error) {
+	resp, err := client.ListBackends()
+	if err != nil {
+		return "", fmt.Errorf("failed to list backends: %w", err)
+	}
+	if len(resp.Backends) == 0 {
+		return "No backends registered (running standalone, no peers).", nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Found %d backend(s):\n\n", len(resp.Backends))
+	for _, bk := range resp.Backends {
+		health := "✓ healthy"
+		if !bk.Healthy {
+			health = "✗ unhealthy"
+		}
+		fmt.Fprintf(&b, "🖥️  %s  (%s, %s)\n", bk.ID, bk.Type, health)
+		if bk.Hostname != "" {
+			fmt.Fprintf(&b, "   Hostname:   %s\n", bk.Hostname)
+		}
+		if bk.OS != "" {
+			fmt.Fprintf(&b, "   OS:         %s\n", bk.OS)
+		}
+		if bk.Version != "" {
+			fmt.Fprintf(&b, "   Version:    %s\n", bk.Version)
+		}
+		fmt.Fprintf(&b, "   Containers: %d running\n", bk.ContainerCount)
+		if bk.UptimeSeconds > 0 {
+			fmt.Fprintf(&b, "   Uptime:     %s\n", formatUptime(bk.UptimeSeconds))
+		}
+		if bk.LastSeenAt != "" && bk.Type != "local" {
+			fmt.Fprintf(&b, "   Last seen:  %s\n", bk.LastSeenAt)
+		}
+		if len(bk.GPUs) > 0 {
+			fmt.Fprintf(&b, "   GPUs:\n")
+			for _, g := range bk.GPUs {
+				vram := ""
+				if g.VRAMBytes > 0 {
+					vram = fmt.Sprintf(" — %s VRAM", humanBytes(g.VRAMBytes))
+				}
+				fmt.Fprintf(&b, "     - %s %s%s\n", g.Vendor, g.ModelName, vram)
+			}
+		}
+		b.WriteString("\n")
+	}
+	return b.String(), nil
+}
+
+// formatUptime converts seconds into a human string like "3d4h" or "1h30m".
+// Bias toward terse — agents render this verbatim.
+func formatUptime(seconds int64) string {
+	d := seconds / 86400
+	h := (seconds % 86400) / 3600
+	m := (seconds % 3600) / 60
+	switch {
+	case d > 0:
+		return fmt.Sprintf("%dd%dh", d, h)
+	case h > 0:
+		return fmt.Sprintf("%dh%dm", h, m)
+	default:
+		return fmt.Sprintf("%dm", m)
+	}
+}
+
+// humanBytes formats sizes like "24 GiB" for VRAM, where the source
+// is a power-of-two byte count.
+func humanBytes(n int64) string {
+	const k = 1024
+	switch {
+	case n >= k*k*k*k:
+		return fmt.Sprintf("%.1f TiB", float64(n)/float64(k*k*k*k))
+	case n >= k*k*k:
+		return fmt.Sprintf("%.0f GiB", float64(n)/float64(k*k*k))
+	case n >= k*k:
+		return fmt.Sprintf("%.0f MiB", float64(n)/float64(k*k))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }
 
 func handleExposePort(client *Client, args map[string]interface{}) (string, error) {

--- a/internal/mcp/wire_format_test.go
+++ b/internal/mcp/wire_format_test.go
@@ -122,6 +122,40 @@ func TestWireFormat_CreateContainer(t *testing.T) {
 	assert.Equal(t, int64(1771209160), resp.Container.CreatedAt)
 }
 
+func TestWireFormat_ListBackends(t *testing.T) {
+	var resp ListBackendsResponse
+	require.NoError(t, json.Unmarshal(loadFixture(t, "list_backends_response.json"), &resp))
+
+	require.Len(t, resp.Backends, 3)
+
+	// First backend is the local daemon — type "local", healthy, with version.
+	local := resp.Backends[0]
+	assert.Equal(t, "local", local.Type)
+	assert.True(t, local.Healthy)
+	assert.Equal(t, "0.16.4", local.Version)
+	assert.Equal(t, int32(16), local.ContainerCount)
+	// uptimeSeconds is int64 but emitted as a JSON NUMBER here (not a
+	// string) — the /v1/backends handler is hand-coded, not
+	// grpc-gateway, so it doesn't string-encode int64. Confirm decode.
+	assert.Equal(t, int64(345600), local.UptimeSeconds)
+
+	// Second backend is a tunnel peer with a GPU. VRAMBytes is also
+	// int64-as-number, not int64-as-string.
+	gpuPeer := resp.Backends[1]
+	assert.Equal(t, "tunnel", gpuPeer.Type)
+	assert.True(t, gpuPeer.Healthy)
+	require.Len(t, gpuPeer.GPUs, 1)
+	assert.Equal(t, "NVIDIA", gpuPeer.GPUs[0].Vendor)
+	assert.Equal(t, "GeForce RTX 3090", gpuPeer.GPUs[0].ModelName)
+	assert.Equal(t, int64(25769803776), gpuPeer.GPUs[0].VRAMBytes) // 24 GiB
+
+	// Third backend is unhealthy — health flag must round-trip false
+	// (no "omitempty" gotcha eating the field).
+	dead := resp.Backends[2]
+	assert.False(t, dead.Healthy)
+	assert.Equal(t, int32(0), dead.ContainerCount)
+}
+
 // TestWireFormat_AddRoute notes a known mismatch and documents it: our
 // AddRouteResponse.Route declares fields named Domain / ContainerName,
 // but the wire shape from grpc-gateway uses fullDomain / username


### PR DESCRIPTION
## Why

Today an agent talking to Containarium can list containers but has no way to ask about the underlying *cluster topology* — which hosts are running, which are healthy, which have GPU capacity. They infer it by squinting at container IPs (10.0.3.x vs 10.100.0.x = "probably two hosts?"). This adds a direct surface.

This is the answer to "should we have peers MCP?" — yes, and it's an OSS-scope feature per \`licensing.md\` (multi-backend is just self-hosting properly; multi-tenancy is the cloud premise).

## What's in it

CLI-first per CLAUDE.md. The CLI lands first; the MCP tool wraps the same data.

| Surface | What |
|---|---|
| \`containarium backends list\` | New CLI subcommand. \`--server\` required, table or JSON output. |
| \`list_backends\` MCP tool | Pretty-prints id, type (local/tunnel), health, hostname, OS, container count, GPUs with VRAM. |
| \`mcp.Client.ListBackends()\` | Calls \`GET /v1/backends\`, decodes into \`Backend{}\` / \`BackendGPU{}\` types matching the hand-coded handler shape. |
| Wire-format fixture + test | \`testdata/list_backends_response.json\` with local + healthy-GPU-peer + unhealthy-peer; test asserts decode behavior. |

Tool count bumped 9 → 10 in \`server_test.go\`.

## Note on int64 encoding

\`/v1/backends\` is hand-coded (not grpc-gateway), so int64 fields like \`uptimeSeconds\` and \`vramBytes\` come back as JSON **numbers**, not strings. That's the *opposite* of the regression in #116. The fixture pins this so future schema changes break loudly.

## Known gap (separate PR)

\`/v1/backends\` is currently **unauthenticated** on the platform daemon — flagged in project memory since the multi-backend work shipped. The MCP client sends its JWT anyway, so the day the endpoint gains auth, this code doesn't change. The auth fix touches the web UI's backend selector and is its own risk surface — splitting it out so this PR can land cleanly.

## Test plan

- [x] \`go test ./internal/mcp/...\` — all green, including the new \`TestWireFormat_ListBackends\`
- [x] \`go test ./internal/cmd/...\` — green
- [x] \`make build-mcp\` and \`go build ./cmd/containarium\` clean
- [x] \`containarium backends --help\` and \`containarium backends list --help\` render correctly
- [ ] Live test against prod: \`containarium backends list --server https://containarium.kafeido.app --token \$(cat ~/.containarium-prod-token.txt)\` should return the expected fleet
- [ ] Live MCP test from Claude Code: "list my Containarium backends" → tool call returns local + 2 tunnel peers

## Out of scope

- Auth fix for \`/v1/backends\` (separate PR; web UI dependency).
- Per-backend drilldown (\`get_backend <id>\`) — wait for usage signal.
- Per-backend metrics — \`get_metrics\` already exists for containers; backend-level metrics could come later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)