### PR TITLE
fix(mcp-server): report pkg/version on startup and in MCP serverInfo

### DIFF
--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -5,9 +5,15 @@ import (
 	"os"
 
 	"github.com/footprintai/containarium/internal/mcp"
+	"github.com/footprintai/containarium/pkg/version"
 )
 
 func main() {
+	// Log to stderr so stdout stays clean for the MCP protocol stream.
+	// Set this BEFORE LoadConfig so any config-load logging lands on
+	// stderr too (the printUsage path logs to whatever's wired up).
+	log.SetOutput(os.Stderr)
+
 	// Read configuration from environment or config file
 	config := mcp.LoadConfig()
 
@@ -27,9 +33,8 @@ func main() {
 		log.Fatalf("Failed to create MCP server: %v", err)
 	}
 
-	// Log to stderr so stdout is clean for MCP protocol
-	log.SetOutput(os.Stderr)
-	log.Printf("Starting Containarium MCP Server")
+	log.Printf("Starting Containarium MCP Server (version %s, commit %s)",
+		version.GetVersion(), version.GetCommitHash())
 	log.Printf("Server URL: %s", config.ServerURL)
 	log.Printf("Debug mode: %v", config.Debug)
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+
+	"github.com/footprintai/containarium/pkg/version"
 )
 
 // Server implements the MCP (Model Context Protocol) server
@@ -94,7 +96,7 @@ func (s *Server) handleInitialize(req *MCPRequest) *MCPResponse {
 			},
 			"serverInfo": map[string]interface{}{
 				"name":    "containarium-mcp-server",
-				"version": "0.1.0",
+				"version": version.GetVersion(),
 			},
 		},
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -88,10 +88,13 @@ func TestHandleInitialize(t *testing.T) {
 	assert.NotNil(t, result["serverInfo"])
 	assert.NotNil(t, result["capabilities"])
 
-	// Check server info
+	// Check server info — version comes from pkg/version (settable
+	// via ldflags). Don't assert an exact value (would have to be
+	// bumped on every release). Just confirm a non-empty version
+	// string ships back.
 	serverInfo := result["serverInfo"].(map[string]interface{})
 	assert.Equal(t, "containarium-mcp-server", serverInfo["name"])
-	assert.Equal(t, "0.1.0", serverInfo["version"])
+	assert.NotEmpty(t, serverInfo["version"], "serverInfo.version must be set from pkg/version")
 }
 
 // TestHandleToolsList tests the tools/list method


### PR DESCRIPTION
## Why

Of the three release binaries (\`containarium\`, \`mcp-server\`, \`agent-box\`), \`mcp-server\` was the only one that didn't import \`pkg/version\` — so the ldflags-injected version was invisible at runtime. Released binaries had no way to say what version they were.

Two concrete gaps:

1. **Startup log**: \"Starting Containarium MCP Server\" with no version, no commit hash. A user filing a bug report can't paste a version string.
2. **MCP \`initialize\` handshake**: \`serverInfo.version\` hardcoded \`\"0.1.0\"\` in \`internal/mcp/server.go\`. Every released binary, at every tag, reports as 0.1.0 to every connecting client.

After this lands, every binary gets its version from the same source (\`pkg/version\` + ldflags) and the unified release workflow from #118 will produce binaries that can identify themselves.

## What's changed

| File | Change |
|---|---|
| \`cmd/mcp-server/main.go\` | Import \`pkg/version\`. Log \`Starting Containarium MCP Server (version X, commit Y)\` on startup. Move \`log.SetOutput(os.Stderr)\` earlier so config-load errors land on stderr consistently. |
| \`internal/mcp/server.go\` | \`serverInfo.version\` reads from \`version.GetVersion()\` instead of hardcoded \`\"0.1.0\"\`. |
| \`internal/mcp/server_test.go\` | \`TestHandleInitialize\` used to assert \`\"0.1.0\"\`; relaxed to \`assert.NotEmpty\` so the test doesn't have to be touched on every release. |

## Verified

\`\`\`
$ CONTAINARIUM_SERVER_URL=... CONTAINARIUM_JWT_TOKEN=dummy bin/mcp-server
Starting Containarium MCP Server (version 0.16.3, commit 32cf9d6...)
Server URL: ...

$ echo '{...initialize...}' | bin/mcp-server | jq .result.serverInfo
{\"name\":\"containarium-mcp-server\",\"version\":\"0.16.3\"}
\`\`\`

The 0.16.3 default comes from \`pkg/version.Version = \"0.16.3\"\` (a fallback for unreleased builds); ldflags override it on real releases.

## Test plan

- [x] \`go test ./internal/mcp/...\` clean
- [x] \`make build-mcp\` clean; runtime check confirms version surfaced
- [ ] After v0.16.4 ships via #118's workflow, confirm \`mcp-server-*-0.16.4\` reports \`version: \"0.16.4\"\` (not 0.16.3)

## Out of scope

- agent-box and containarium already report version correctly. No change.
- The \`pkg/version.Version = \"0.16.3\"\` fallback is now stale (it'll lag whatever the latest release is). Keeping it as a low-noise reminder rather than churning it on every bump; the ldflags path is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)