### PR TITLE
fix(release): install buf in the workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,13 @@ jobs:
         with:
           go-version: '1.25.10'
 
+      - name: Install buf
+        # `make build-release` transitively runs `make proto`, which
+        # needs the buf CLI. Ubuntu runners don't have it preinstalled.
+        # The .pb.go files are already committed, but the dep chain
+        # still triggers buf generate; installing it satisfies that.
+        run: go install github.com/bufbuild/buf/cmd/buf@latest
+
       - name: Get version from tag
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
v0.16.4 release attempt failed because the runner doesn't have buf preinstalled. `make build-release` → `make build-all` → `make proto` → `buf is not installed`. The .pb.go files are committed (so this is technically a no-op for tagged releases), but the dep chain still fires.

`go install github.com/bufbuild/buf/cmd/buf@latest` before `make build-release` is the smallest fix.

After this lands, I'll delete the v0.16.4 tag (no Release object was created — only the tag exists, orphaned) and re-tag from new main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)