### PR TITLE
fix(web-ui): commit the Modal component (untracked since #103)

### DIFF
--- a/web-ui/src/components/ui/Modal.tsx
+++ b/web-ui/src/components/ui/Modal.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const sizeClass = { sm: 'max-w-sm', md: 'max-w-lg', lg: 'max-w-2xl' };
+
+export function Modal({ open, onClose, title, children, footer, size = 'md' }: ModalProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Content
+          className={`fixed left-1/2 top-1/2 z-50 w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-2xl ${sizeClass[size]} focus:outline-none`}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-[var(--border-subtle)] px-5 py-4">
+            <Dialog.Title className="text-sm font-semibold text-[var(--text)]">{title}</Dialog.Title>
+            <Dialog.Close asChild>
+              <button className="rounded p-1 text-[var(--text-muted)] hover:bg-[var(--surface-2)] hover:text-[var(--text)] transition-colors">
+                <X size={15} />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          {/* Body */}
+          <div className="px-5 py-4">{children}</div>
+
+          {/* Footer */}
+          {footer && (
+            <div className="flex items-center justify-end gap-2 border-t border-[var(--border-subtle)] px-5 py-4">
+              {footer}
+            </div>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+export function ModalBtn({
+  onClick, disabled, variant = 'ghost', children, type = 'button',
+}: {
+  onClick?: () => void;
+  disabled?: boolean;
+  variant?: 'ghost' | 'primary' | 'danger';
+  children: React.ReactNode;
+  type?: 'button' | 'submit';
+}) {
+  const cls = {
+    ghost: 'border border-[var(--border)] bg-transparent text-[var(--text-secondary)] hover:bg-[var(--surface-2)] hover:text-[var(--text)]',
+    primary: 'bg-[var(--accent)] text-white hover:bg-[var(--accent-hover)]',
+    danger: 'bg-red-600 text-white hover:bg-red-700',
+  }[variant];
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      className={`flex items-center gap-1.5 rounded-md px-3.5 py-2 text-xs font-medium transition-colors disabled:opacity-50 ${cls}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function FormField({ label, hint, error, children }: { label: string; hint?: string; error?: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-xs font-medium text-[var(--text-secondary)]">{label}</label>
+      {children}
+      {hint && !error && <p className="text-[10px] text-[var(--text-muted)]">{hint}</p>}
+      {error && <p className="text-[10px] text-[var(--c-red)]">{error}</p>}
+    </div>
+  );
+}
+
+export function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      {...props}
+      className={`w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-2)] px-3 py-2 text-xs text-[var(--text)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent)] focus:outline-none disabled:opacity-50 ${props.className || ''}`}
+    />
+  );
+}
+
+export function Textarea(props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      {...props}
+      className={`w-full rounded-md border border-[var(--border-subtle)] bg-[var(--surface-2)] px-3 py-2 text-xs text-[var(--text)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent)] focus:outline-none disabled:opacity-50 resize-none ${props.className || ''}`}
+    />
+  );
+}


### PR DESCRIPTION
Caught while trying to cut v0.16.4: the Tailwind migration in #103 wrote `web-ui/src/components/ui/Modal.tsx` and wired it into 6+ pages but never `git add`-ed the file. CI couldn't `npm run build` because Module not found.

This adds the missing file as-is from the working tree. After this lands, v0.16.4 re-cut should clear the web-ui step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)