### PR TITLE
fix(gateway): JWT-authenticate /v1/backends

### DIFF
--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,93 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestHTTPMiddleware_AuthGate is the regression test for the
+// /v1/backends auth fix and any future endpoint that wraps a handler
+// with HTTPMiddleware. Proves the gate rejects missing / malformed /
+// invalid tokens, and lets through valid ones.
+//
+// Why this test lives here and not in internal/gateway: the wrapping
+// is one line in the gateway, and what's actually being verified is
+// the middleware's contract. A handler wrapped with HTTPMiddleware
+// MUST reject anonymous requests — every endpoint that relies on this
+// (containers, backends, audit logs, …) inherits the same protection.
+func TestHTTPMiddleware_AuthGate(t *testing.T) {
+	tm := NewTokenManager("test-secret-key-for-auth-middleware-test", "test-issuer")
+	mw := NewAuthMiddleware(tm)
+
+	// Stub handler that records whether it was called. If the auth
+	// middleware lets a request through unauthenticated, this flips
+	// true and the test fails.
+	called := false
+	stub := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	})
+	wrapped := mw.HTTPMiddleware(stub)
+
+	cases := []struct {
+		name      string
+		setup     func(r *http.Request)
+		wantCode  int
+		wantStub  bool // did the wrapped handler run?
+	}{
+		{
+			name:     "no auth header → 401",
+			setup:    func(r *http.Request) {},
+			wantCode: http.StatusUnauthorized,
+			wantStub: false,
+		},
+		{
+			name: "wrong scheme (Basic) → 401",
+			setup: func(r *http.Request) {
+				r.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+			},
+			wantCode: http.StatusUnauthorized,
+			wantStub: false,
+		},
+		{
+			name: "Bearer with junk token → 401",
+			setup: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer not.a.real.jwt")
+			},
+			wantCode: http.StatusUnauthorized,
+			wantStub: false,
+		},
+		{
+			name: "Bearer with valid token → 200, handler runs",
+			setup: func(r *http.Request) {
+				token, err := tm.GenerateToken("test-user", []string{"admin"}, 5*time.Minute)
+				if err != nil {
+					t.Fatalf("GenerateToken: %v", err)
+				}
+				r.Header.Set("Authorization", "Bearer "+token)
+			},
+			wantCode: http.StatusOK,
+			wantStub: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called = false
+			req := httptest.NewRequest("GET", "/v1/backends", nil)
+			tc.setup(req)
+			rec := httptest.NewRecorder()
+			wrapped.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Errorf("status = %d, want %d (body=%s)", rec.Code, tc.wantCode, rec.Body.String())
+			}
+			if called != tc.wantStub {
+				t.Errorf("inner handler called = %v, want %v", called, tc.wantStub)
+			}
+		})
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -584,10 +584,15 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 		log.Printf("Audit logs endpoint enabled at /v1/audit/logs")
 	}
 
-	// Backends endpoint (no auth — for web UI backend selector)
+	// Backends endpoint — JWT-authenticated, same as /v1/containers et al.
+	// Previously left open with the comment "for web UI backend selector",
+	// but the web UI never actually called this endpoint, and an
+	// unauthenticated /v1/backends leaks fleet topology (peer IDs,
+	// hostnames, GPU inventory) to anyone who can reach the gateway.
 	if gs.backendsHandler != nil {
-		httpMux.HandleFunc("/v1/backends/", gs.backendsHandler)
-		httpMux.HandleFunc("/v1/backends", gs.backendsHandler)
+		authed := gs.authMiddleware.HTTPMiddleware(http.HandlerFunc(gs.backendsHandler))
+		httpMux.Handle("/v1/backends/", authed)
+		httpMux.Handle("/v1/backends", authed)
 	}
 
 	// Cert export endpoint (no auth — only reachable within VPC)


### PR DESCRIPTION
## Why

`/v1/backends` was registered with the comment "no auth — for web UI backend selector", but the web UI never actually called this endpoint (zero references in `web-ui/`). The security exception bought nothing and leaked fleet topology — peer IDs, hostnames, GPU inventory, container counts — to anyone with network reach to the gateway port.

I've been flagging this as a follow-up on the last three PRs (#117 list_backends, #118 release workflow, #119 mcp-server version). Closing the loop now.

## Change

Wrap the handler with the same `authMiddleware.HTTPMiddleware` that guards `/v1/containers` and friends. JSON 401 on missing/malformed/invalid tokens; valid tokens pass through with claims in context.

## Backwards compatibility

- **MCP client** (`internal/mcp/client.go`) already sends `Authorization: Bearer <token>` via `doRequest` — works without code changes.
- **CLI** `containarium backends list` already accepts `--token` (a persistent flag from `root.go`) — works without code changes; `--token` is now effectively required where it was optional before.
- **Web UI**: no callers found in `web-ui/` for `/v1/backends`. No breakage.

If a deployment relied on this endpoint being open (e.g., scraping it from an unauthenticated monitor), they'll see 401 after upgrade. Worth calling out in v0.16.5 release notes.

## Test

`internal/auth/middleware_test.go` (new) — table-driven, four states:

| Setup | Expected |
|---|---|
| No `Authorization` header | 401, handler not called |
| Wrong scheme (`Basic ...`) | 401, handler not called |
| Bearer with junk token | 401, handler not called |
| Bearer with valid token | 200, handler called |

The test is on `HTTPMiddleware` (not just /v1/backends) because every wrapped endpoint inherits the same protection — pinning the contract here covers all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)