### PR TITLE
feat(agent-box): tail_log — watch a log file as it grows, bounded by follow_seconds

### DIFF
--- a/internal/agentbox/agentbox_test.go
+++ b/internal/agentbox/agentbox_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -404,5 +405,123 @@ func TestSandboxRoot_RejectsLookalikePrefix(t *testing.T) {
 	_, res := callTool(t, handleReadFile, map[string]interface{}{"path": target})
 	if !res.IsError {
 		t.Errorf("sandbox accepted lookalike-prefix escape")
+	}
+}
+
+// ----- tail_log --------------------------------------------------------
+
+func TestTailLog_DefaultStartIsEOF(t *testing.T) {
+	// Pre-existing content shouldn't be returned when start_offset is
+	// omitted — the tool defaults to "watch from now".
+	dir := t.TempDir()
+	p := filepath.Join(dir, "log")
+	if err := os.WriteFile(p, []byte("preexisting\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, _ := callTool(t, handleTailLog, map[string]interface{}{
+		"path":           p,
+		"follow_seconds": float64(0.3), // tight window — nothing else writes
+	})
+	if !strings.Contains(out, "bytes_returned: 0") {
+		t.Errorf("expected zero bytes (default starts at EOF):\n%s", out)
+	}
+	if !strings.Contains(out, "start_offset: 12") { // len("preexisting\n")
+		t.Errorf("start_offset should be initial file size (12):\n%s", out)
+	}
+}
+
+func TestTailLog_FollowsAppendedContent(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "log")
+	if err := os.WriteFile(p, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Append a line ~100ms after the call starts. The follow window
+	// is 1s, which is more than enough for the polling loop
+	// (200ms interval) to pick it up.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		f, err := os.OpenFile(p, os.O_APPEND|os.O_WRONLY, 0)
+		if err != nil {
+			return
+		}
+		defer f.Close()
+		_, _ = f.WriteString("hello from a goroutine\n")
+	}()
+
+	out, _ := callTool(t, handleTailLog, map[string]interface{}{
+		"path":           p,
+		"follow_seconds": float64(1.0),
+	})
+	if !strings.Contains(out, "hello from a goroutine") {
+		t.Errorf("expected appended content in:\n%s", out)
+	}
+	if !strings.Contains(out, "bytes_returned: 23") {
+		t.Errorf("expected 23 bytes_returned in:\n%s", out)
+	}
+}
+
+func TestTailLog_StartOffsetReturnsBackfill(t *testing.T) {
+	// start_offset=0 means "include preexisting content".
+	dir := t.TempDir()
+	p := filepath.Join(dir, "log")
+	if err := os.WriteFile(p, []byte("line1\nline2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, _ := callTool(t, handleTailLog, map[string]interface{}{
+		"path":           p,
+		"start_offset":   float64(0),
+		"follow_seconds": float64(0.3),
+	})
+	if !strings.Contains(out, "line1\nline2\n") {
+		t.Errorf("expected backfilled content:\n%s", out)
+	}
+	if !strings.Contains(out, "end_offset: 12") {
+		t.Errorf("expected end_offset 12:\n%s", out)
+	}
+}
+
+func TestTailLog_RefusesDirectory(t *testing.T) {
+	_, res := callTool(t, handleTailLog, map[string]interface{}{
+		"path":           t.TempDir(),
+		"follow_seconds": float64(0.1),
+	})
+	if !res.IsError {
+		t.Errorf("expected error tailing a directory")
+	}
+}
+
+func TestTailLog_MissingPath(t *testing.T) {
+	_, res := callTool(t, handleTailLog, map[string]interface{}{})
+	if !res.IsError {
+		t.Errorf("expected error when path missing")
+	}
+}
+
+func TestTailLog_NotFound(t *testing.T) {
+	_, res := callTool(t, handleTailLog, map[string]interface{}{
+		"path":           "/nonexistent/log/please-no",
+		"follow_seconds": float64(0.1),
+	})
+	if !res.IsError {
+		t.Errorf("expected error for missing file")
+	}
+}
+
+func TestTailLog_RespectsSandboxRoot(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(sandboxRootEnv, dir)
+	resetSandboxOnceForTest()
+
+	outside := filepath.Join(t.TempDir(), "log")
+	_ = os.WriteFile(outside, []byte("x"), 0o644)
+
+	_, res := callTool(t, handleTailLog, map[string]interface{}{
+		"path":           outside,
+		"follow_seconds": float64(0.1),
+	})
+	if !res.IsError {
+		t.Errorf("sandbox should reject path outside AGENTBOX_ROOT")
 	}
 }

--- a/internal/agentbox/server.go
+++ b/internal/agentbox/server.go
@@ -10,12 +10,13 @@
 //   - list_directory  — enumerate a directory's entries
 //   - move_file       — rename/move a file or directory
 //   - delete_file     — remove a single file (refuses directories)
+//   - tail_log        — watch a file for new appends, bounded by follow_seconds
 //
 // All file paths can be confined to a project root via the AGENTBOX_ROOT
 // env var; unset means no constraint.
 //
-// More tools (tail_log, provision_postgres, deploy_app, snapshot, etc.)
-// land in subsequent commits.
+// More tools (provision_postgres, deploy_app, snapshot, etc.) land in
+// subsequent commits.
 package agentbox
 
 import "github.com/mark3labs/mcp-go/server"
@@ -27,4 +28,5 @@ import "github.com/mark3labs/mcp-go/server"
 func RegisterTools(s *server.MCPServer) {
 	registerShellTool(s)
 	registerFileTools(s)
+	registerTailLogTool(s)
 }

--- a/internal/agentbox/tail_log.go
+++ b/internal/agentbox/tail_log.go
@@ -1,0 +1,166 @@
+package agentbox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// tail_log lets an agent watch a file as new content is appended,
+// bounded by a wall-clock follow window. The MCP transport is
+// request/response (no streaming), so this tool is the request/response
+// equivalent of "tail -f for N seconds": collect what arrived during
+// the window and return it.
+//
+// Typical use: after `shell_exec systemctl start caddy`, the agent
+// calls tail_log on /var/log/caddy/access.log with follow_seconds=10
+// to confirm the service actually started serving (or to capture the
+// crash message if it didn't).
+const (
+	tailLogDefaultFollowSec = 10
+	tailLogMaxFollowSec     = 60
+	tailLogOutputLimit      = 256 * 1024 // 256 KiB — same as shell_exec
+	tailLogPollInterval     = 200 * time.Millisecond
+)
+
+func registerTailLogTool(s *server.MCPServer) {
+	s.AddTool(tailLogTool(), handleTailLog)
+}
+
+func tailLogTool() mcp.Tool {
+	return mcp.NewTool(
+		"tail_log",
+		mcp.WithDescription(
+			"Watch a file as new content is appended, bounded by follow_seconds. "+
+				"Returns the bytes written to the file during the window plus a new "+
+				"end_offset suitable for resuming on the next call. If start_offset "+
+				"is omitted, watching begins at the current end-of-file (\"tail -f "+
+				"from now\"). Capped at 256 KiB output; longer streams set the "+
+				"truncated flag — the agent can resume by passing the returned "+
+				"end_offset as start_offset on the next call.",
+		),
+		mcp.WithString("path",
+			mcp.Description("Absolute or relative path to the log file."),
+			mcp.Required(),
+		),
+		mcp.WithNumber("start_offset",
+			mcp.Description("Byte offset to start reading from. Default: file size at call time (i.e. only new content)."),
+		),
+		mcp.WithNumber("follow_seconds",
+			mcp.Description(fmt.Sprintf("How long to watch for new content. Default %d, max %d.",
+				tailLogDefaultFollowSec, tailLogMaxFollowSec)),
+			mcp.DefaultNumber(float64(tailLogDefaultFollowSec)),
+		),
+	)
+}
+
+func handleTailLog(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	args := req.GetArguments()
+	rawPath, ok := args["path"].(string)
+	if !ok || rawPath == "" {
+		return mcp.NewToolResultError("tail_log: 'path' is required"), nil
+	}
+	path, err := validatePath(rawPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("tail_log: %v", err)), nil
+	}
+
+	followSec := float64(tailLogDefaultFollowSec)
+	if v, ok := args["follow_seconds"].(float64); ok && v > 0 {
+		followSec = v
+		if followSec > tailLogMaxFollowSec {
+			followSec = tailLogMaxFollowSec
+		}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("tail_log: %v", err)), nil
+	}
+	if info.IsDir() {
+		return mcp.NewToolResultError(fmt.Sprintf("tail_log: %s is a directory", path)), nil
+	}
+
+	// Default start_offset is the file's current size — "tail -f from
+	// now". If the caller wants to backfill, they pass start_offset=0
+	// (or any earlier offset) explicitly. We don't reject offsets past
+	// EOF; they just mean "wait for the file to grow that far," which
+	// is fine for the use case but documented as agent-suspect.
+	startOffset := info.Size()
+	if v, ok := args["start_offset"].(float64); ok && v >= 0 {
+		startOffset = int64(v)
+	}
+
+	// #nosec G304 -- path was sanitized by validatePath; tail_log's
+	// contract is to read agent-supplied paths.
+	f, err := os.Open(path)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("tail_log: %v", err)), nil
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(startOffset, io.SeekStart); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("tail_log: seek to %d: %v", startOffset, err)), nil
+	}
+
+	deadline := time.Now().Add(time.Duration(followSec * float64(time.Second)))
+	var buf bytes.Buffer
+	truncated := false
+	chunk := make([]byte, 64*1024)
+
+	for time.Now().Before(deadline) {
+		// Honor an outer cancellation (e.g. MCP transport closed) so
+		// we don't block past the host's wishes.
+		select {
+		case <-ctx.Done():
+			return mcp.NewToolResultError(fmt.Sprintf("tail_log: cancelled: %v", ctx.Err())), nil
+		default:
+		}
+
+		remaining := tailLogOutputLimit - buf.Len()
+		if remaining <= 0 {
+			truncated = true
+			break
+		}
+		readSize := len(chunk)
+		if readSize > remaining {
+			readSize = remaining
+		}
+		n, err := f.Read(chunk[:readSize])
+		if n > 0 {
+			buf.Write(chunk[:n])
+		}
+		if err == io.EOF {
+			// No more content available right now — sleep briefly,
+			// then retry. The Read returned io.EOF without a fatal
+			// error; the file descriptor is still good and the file
+			// may grow before the deadline.
+			//
+			// We don't seek to End here: the kernel keeps the file
+			// position, and io.EOF leaves it at the current size.
+			// When the file grows, the next Read picks up new bytes.
+			select {
+			case <-ctx.Done():
+				return mcp.NewToolResultError(fmt.Sprintf("tail_log: cancelled: %v", ctx.Err())), nil
+			case <-time.After(tailLogPollInterval):
+			}
+			continue
+		}
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("tail_log: read: %v", err)), nil
+		}
+	}
+
+	endOffset := startOffset + int64(buf.Len())
+	body := fmt.Sprintf(
+		"path: %s\nstart_offset: %d\nend_offset: %d\nbytes_returned: %d\ntruncated: %v\nfollow_seconds: %v\n--- content ---\n%s",
+		path, startOffset, endOffset, buf.Len(), truncated, followSec, buf.String(),
+	)
+	return mcp.NewToolResultText(body), nil
+}


### PR DESCRIPTION
## Why

After `shell_exec systemctl start caddy`, an agent has no graceful way to confirm the service actually started serving. `shell_exec tail -f` blocks forever; `read_file tail=100` is a snapshot and easily misses the moment of truth. `tail_log` is the request/response equivalent of `tail -f for N seconds`.

Demo path:
1. Agent: `shell_exec systemctl start caddy`
2. Agent: `tail_log /var/log/caddy/access.log follow_seconds=10` → returns whatever Caddy logged in the next 10 seconds
3. Agent: parses output, decides next step

## Tool surface

| Field | Default | Notes |
|---|---|---|
| `path` | (required) | Honors AGENTBOX_ROOT sandbox |
| `start_offset` | file size at call time | Pass 0 to backfill; pass returned `end_offset` to resume |
| `follow_seconds` | 10 | Max 60 (clamped) |

Output text block:
```
path: /var/log/caddy/access.log
start_offset: 4096
end_offset: 5891
bytes_returned: 1795
truncated: false
follow_seconds: 10
--- content ---
{...log entries written during the window...}
```

## What's deliberately out of scope

- **Process-attached tail** (attaching to a managed PID's stdout). Belongs in tier-2 process management — needs `process_start` to land first to have a PID to attach to.
- **Log rotation detection**. Real `tail -f` handles rename/truncate; we don't. The agent can call again with a fresh `start_offset` if a rotation happens. Documented but unhandled.

## Tests (7)

- `TestTailLog_DefaultStartIsEOF` — pre-existing content NOT returned when start_offset is omitted
- `TestTailLog_FollowsAppendedContent` — goroutine writes mid-window; tool picks it up via the polling loop
- `TestTailLog_StartOffsetReturnsBackfill` — start_offset=0 includes pre-existing content
- `TestTailLog_RefusesDirectory` — same shape as read_file
- `TestTailLog_MissingPath` — input validation
- `TestTailLog_NotFound` — passes through filesystem errors
- `TestTailLog_RespectsSandboxRoot` — AGENTBOX_ROOT enforcement

## Test plan

- [x] All 7 unit tests pass
- [x] Build clean for both `go build ./internal/agentbox/...` and `go build ./cmd/agent-box`
- [ ] Live integration: drive tail_log from Claude Code against a real Containarium box on the next demo recording attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)