### PR TITLE
feat: get_backend MCP tool + containarium backends get CLI

### DIFF
--- a/internal/cmd/backends_get.go
+++ b/internal/cmd/backends_get.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var backendsGetCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Show a single backend's details by ID",
+	Long: `Fetch one backend's metadata by ID — same shape as 'backends list'
+but filtered to a single host. Returns a clear "not found" if the ID
+doesn't match any registered backend.
+
+Use this when you have a backend ID from 'backends list' or from a
+container's BackendID field and want to drill down without paging
+through the full list.
+
+Example:
+  containarium backends get tunnel-fts-13700k-gpu --server <host:port>`,
+	Args: cobra.ExactArgs(1),
+	RunE: runBackendsGet,
+}
+
+func init() {
+	backendsCmd.AddCommand(backendsGetCmd)
+	backendsGetCmd.Flags().StringVarP(&backendsListFormat, "format", "f", "table",
+		"Output format: table, json")
+}
+
+func runBackendsGet(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (the platform daemon's HTTP address)")
+	}
+	id := args[0]
+
+	// Implementation note: the daemon doesn't have a /v1/backends/{id}
+	// route — only /v1/backends/{id}/system-info, which forwards to
+	// the peer for system info, not metadata. So we list-and-filter.
+	// Cheap (the list is small) and means the CLI stays in sync if a
+	// dedicated endpoint lands later.
+	url := strings.TrimSuffix(serverAddr, "/") + "/v1/backends"
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("api error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var parsed backendsListResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	for i := range parsed.Backends {
+		if parsed.Backends[i].ID == id {
+			switch backendsListFormat {
+			case "json":
+				out, err := json.MarshalIndent(parsed.Backends[i], "", "  ")
+				if err != nil {
+					return err
+				}
+				fmt.Println(string(out))
+			case "table":
+				printBackendsTable([]backendInfo{parsed.Backends[i]})
+			default:
+				return fmt.Errorf("unknown format: %s (use: table, json)", backendsListFormat)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("backend %q not found (got %d backend(s) total)", id, len(parsed.Backends))
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -217,11 +217,6 @@ func (c *Client) AddRoute(req AddRouteRequest) (*AddRouteResponse, error) {
 // tunnel-connected peers. Used by the list_backends MCP tool so an
 // agent can reason about peer health, container counts, and GPU
 // inventory without inferring topology from container IPs.
-//
-// Note: at the time of writing, /v1/backends is served by a hand-coded
-// handler (not grpc-gateway) and does NOT require authentication. The
-// MCP client still sends its JWT — server ignores it — so the day the
-// endpoint gains auth, this client doesn't need to change.
 func (c *Client) ListBackends() (*ListBackendsResponse, error) {
 	respBody, err := c.doRequest("GET", "/v1/backends", nil)
 	if err != nil {
@@ -234,6 +229,25 @@ func (c *Client) ListBackends() (*ListBackendsResponse, error) {
 	}
 
 	return &resp, nil
+}
+
+// GetBackend returns a single backend by ID. The daemon doesn't have a
+// dedicated /v1/backends/{id} endpoint (the only path-with-id route is
+// /v1/backends/{id}/system-info, which forwards to that backend), so
+// we implement it client-side as a list-and-filter. The list is small
+// (typically a handful of peers), and this keeps the wire surface
+// stable for now — easy to swap for a dedicated endpoint later.
+func (c *Client) GetBackend(id string) (*Backend, error) {
+	resp, err := c.ListBackends()
+	if err != nil {
+		return nil, err
+	}
+	for i := range resp.Backends {
+		if resp.Backends[i].ID == id {
+			return &resp.Backends[i], nil
+		}
+	}
+	return nil, fmt.Errorf("backend %q not found", id)
 }
 
 // API Request/Response types

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -21,7 +21,7 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	assert.Len(t, server.tools, 10, "Should have 10 tools registered")
+	assert.Len(t, server.tools, 11, "Should have 11 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -125,7 +125,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	assert.Len(t, tools, 10)
+	assert.Len(t, tools, 11)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -186,6 +186,25 @@ func (s *Server) registerTools() {
 			Handler: handleListBackends,
 		},
 		{
+			Name: "get_backend",
+			Description: "Get a single backend's details by ID — same fields as list_backends " +
+				"but for one host, plus an explicit \"not found\" error when the ID doesn't " +
+				"exist. Useful when an agent has a backend ID from list_backends or from a " +
+				"container's backendId field and wants to drill down (\"is this peer healthy?\", " +
+				"\"how many containers does it have?\", \"does it have a GPU?\").",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"id": map[string]interface{}{
+						"type":        "string",
+						"description": "Backend ID, as returned by list_backends or as a container's backendId field.",
+					},
+				},
+				"required": []string{"id"},
+			},
+			Handler: handleGetBackend,
+		},
+		{
 			Name: "expose_port",
 			Description: "Expose a container's port on a public hostname. Resolves the " +
 				"container's IP, then registers a domain → container:port route in the " +
@@ -422,41 +441,61 @@ func handleListBackends(client *Client, args map[string]interface{}) (string, er
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "Found %d backend(s):\n\n", len(resp.Backends))
-	for _, bk := range resp.Backends {
-		health := "✓ healthy"
-		if !bk.Healthy {
-			health = "✗ unhealthy"
-		}
-		fmt.Fprintf(&b, "🖥️  %s  (%s, %s)\n", bk.ID, bk.Type, health)
-		if bk.Hostname != "" {
-			fmt.Fprintf(&b, "   Hostname:   %s\n", bk.Hostname)
-		}
-		if bk.OS != "" {
-			fmt.Fprintf(&b, "   OS:         %s\n", bk.OS)
-		}
-		if bk.Version != "" {
-			fmt.Fprintf(&b, "   Version:    %s\n", bk.Version)
-		}
-		fmt.Fprintf(&b, "   Containers: %d running\n", bk.ContainerCount)
-		if bk.UptimeSeconds > 0 {
-			fmt.Fprintf(&b, "   Uptime:     %s\n", formatUptime(bk.UptimeSeconds))
-		}
-		if bk.LastSeenAt != "" && bk.Type != "local" {
-			fmt.Fprintf(&b, "   Last seen:  %s\n", bk.LastSeenAt)
-		}
-		if len(bk.GPUs) > 0 {
-			fmt.Fprintf(&b, "   GPUs:\n")
-			for _, g := range bk.GPUs {
-				vram := ""
-				if g.VRAMBytes > 0 {
-					vram = fmt.Sprintf(" — %s VRAM", humanBytes(g.VRAMBytes))
-				}
-				fmt.Fprintf(&b, "     - %s %s%s\n", g.Vendor, g.ModelName, vram)
-			}
-		}
+	for i := range resp.Backends {
+		writeBackendDetail(&b, &resp.Backends[i])
 		b.WriteString("\n")
 	}
 	return b.String(), nil
+}
+
+func handleGetBackend(client *Client, args map[string]interface{}) (string, error) {
+	id, ok := args["id"].(string)
+	if !ok || id == "" {
+		return "", fmt.Errorf("id is required")
+	}
+	bk, err := client.GetBackend(id)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	writeBackendDetail(&b, bk)
+	return b.String(), nil
+}
+
+// writeBackendDetail renders one Backend in the same shape used by both
+// list_backends and get_backend so the agent sees a consistent format.
+func writeBackendDetail(b *strings.Builder, bk *Backend) {
+	health := "✓ healthy"
+	if !bk.Healthy {
+		health = "✗ unhealthy"
+	}
+	fmt.Fprintf(b, "🖥️  %s  (%s, %s)\n", bk.ID, bk.Type, health)
+	if bk.Hostname != "" {
+		fmt.Fprintf(b, "   Hostname:   %s\n", bk.Hostname)
+	}
+	if bk.OS != "" {
+		fmt.Fprintf(b, "   OS:         %s\n", bk.OS)
+	}
+	if bk.Version != "" {
+		fmt.Fprintf(b, "   Version:    %s\n", bk.Version)
+	}
+	fmt.Fprintf(b, "   Containers: %d running\n", bk.ContainerCount)
+	if bk.UptimeSeconds > 0 {
+		fmt.Fprintf(b, "   Uptime:     %s\n", formatUptime(bk.UptimeSeconds))
+	}
+	if bk.LastSeenAt != "" && bk.Type != "local" {
+		fmt.Fprintf(b, "   Last seen:  %s\n", bk.LastSeenAt)
+	}
+	if len(bk.GPUs) > 0 {
+		fmt.Fprintf(b, "   GPUs:\n")
+		for _, g := range bk.GPUs {
+			vram := ""
+			if g.VRAMBytes > 0 {
+				vram = fmt.Sprintf(" — %s VRAM", humanBytes(g.VRAMBytes))
+			}
+			fmt.Fprintf(b, "     - %s %s%s\n", g.Vendor, g.ModelName, vram)
+		}
+	}
 }
 
 // formatUptime converts seconds into a human string like "3d4h" or "1h30m".

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -416,6 +416,48 @@ func TestToolParameterDescriptions(t *testing.T) {
 	}
 }
 
+// ----- get_backend ----------------------------------------------------
+
+func TestGetBackend_Found(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/backends", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"backends": [
+				{"id": "local-host", "type": "local", "healthy": true, "containerCount": 5},
+				{"id": "tunnel-gpu", "type": "tunnel", "healthy": true, "containerCount": 3,
+				 "gpus": [{"vendor": "NVIDIA", "modelName": "GeForce RTX 4090", "vramBytes": 25769803776}]}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	out, err := handleGetBackend(client, map[string]interface{}{"id": "tunnel-gpu"})
+	require.NoError(t, err)
+	assert.Contains(t, out, "tunnel-gpu")
+	assert.Contains(t, out, "GeForce RTX 4090")
+	assert.NotContains(t, out, "local-host", "should only print the requested backend")
+}
+
+func TestGetBackend_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"backends":[{"id":"alpha","type":"local","healthy":true,"containerCount":0}]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	_, err := handleGetBackend(client, map[string]interface{}{"id": "nope"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestGetBackend_RejectsMissingID(t *testing.T) {
+	client := NewClient("http://unused", "token")
+	_, err := handleGetBackend(client, map[string]interface{}{})
+	require.Error(t, err)
+}
+
 // ----- expose_port -----------------------------------------------------
 
 // TestGetIntArg tests the getIntArg helper across the JSON-decoded shapes


### PR DESCRIPTION
Drilldown counterpart to `list_backends` from #117. Pairs naturally — `list_backends` for fleet view, `get_backend` for one-host detail with an explicit "not found".

## Surface

| Layer | What |
|---|---|
| MCP tool | `get_backend` — required `id`, same fields as list_backends but for one host |
| CLI | `containarium backends get <id>` — table or JSON output |
| Client | `mcp.Client.GetBackend(id)` — returns `*Backend` or not-found error |

## Implementation note

The daemon doesn't have a `/v1/backends/{id}` endpoint (only `/v1/backends/{id}/system-info`, which forwards to that peer for system info, not metadata). So this lands as list-and-filter on the client side. Small lists, trivial bandwidth, no daemon protocol change. Easy to swap for a dedicated endpoint later.

## Refactor

`handleListBackends` and `handleGetBackend` now share `writeBackendDetail()` so the agent sees the same shape regardless of which tool it called.

Tool count: 10 → 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)