### PR TITLE
feat(agent-box): MCP Roots support — sandbox aligns with the client's workspace

### DIFF
--- a/internal/agentbox/agentbox_test.go
+++ b/internal/agentbox/agentbox_test.go
@@ -361,7 +361,7 @@ func TestDeleteFile_NotFound(t *testing.T) {
 func TestSandboxRoot_RejectsOutsidePath(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv(sandboxRootEnv, dir)
-	resetSandboxOnceForTest()
+	resetSandboxOnceForTest(); t.Cleanup(resetSandboxOnceForTest)
 
 	outside := filepath.Join(t.TempDir(), "evil") // different temp tree
 	_ = os.WriteFile(outside, []byte("x"), 0o644)
@@ -375,7 +375,7 @@ func TestSandboxRoot_RejectsOutsidePath(t *testing.T) {
 func TestSandboxRoot_AcceptsInsidePath(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv(sandboxRootEnv, dir)
-	resetSandboxOnceForTest()
+	resetSandboxOnceForTest(); t.Cleanup(resetSandboxOnceForTest)
 
 	inside := filepath.Join(dir, "ok.txt")
 	_ = os.WriteFile(inside, []byte("hi"), 0o644)
@@ -393,7 +393,7 @@ func TestSandboxRoot_RejectsLookalikePrefix(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv(sandboxRootEnv, root)
-	resetSandboxOnceForTest()
+	resetSandboxOnceForTest(); t.Cleanup(resetSandboxOnceForTest)
 
 	evil := root + "-evil"
 	if err := os.Mkdir(evil, 0o755); err != nil {
@@ -512,7 +512,7 @@ func TestTailLog_NotFound(t *testing.T) {
 func TestTailLog_RespectsSandboxRoot(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv(sandboxRootEnv, dir)
-	resetSandboxOnceForTest()
+	resetSandboxOnceForTest(); t.Cleanup(resetSandboxOnceForTest)
 
 	outside := filepath.Join(t.TempDir(), "log")
 	_ = os.WriteFile(outside, []byte("x"), 0o644)
@@ -523,5 +523,75 @@ func TestTailLog_RespectsSandboxRoot(t *testing.T) {
 	})
 	if !res.IsError {
 		t.Errorf("sandbox should reject path outside AGENTBOX_ROOT")
+	}
+}
+
+// ----- MCP Roots / sandbox helpers -------------------------------------
+
+func TestRootURIsToPaths_ParsesFileURIs(t *testing.T) {
+	roots := []mcp.Root{
+		{URI: "file:///home/alice/project"},
+		{URI: "file://localhost/srv/box"},
+		{URI: "https://example.com/oops"}, // non-file scheme: dropped
+		{URI: "not-a-uri-at-all"},          // unparseable: dropped
+		{URI: "file://"},                   // empty path: dropped
+	}
+	got := rootURIsToPaths(roots)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 paths, got %d: %v", len(got), got)
+	}
+	if got[0] != "/home/alice/project" {
+		t.Errorf("first path = %q, want /home/alice/project", got[0])
+	}
+	if got[1] != "/srv/box" {
+		t.Errorf("second path = %q, want /srv/box", got[1])
+	}
+}
+
+func TestPathUnderAny(t *testing.T) {
+	roots := []string{"/home/alice/project", "/srv/box"}
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"under first root", "/home/alice/project/file.txt", true},
+		{"equals first root", "/home/alice/project", true},
+		{"under second root", "/srv/box/data", true},
+		{"under no root", "/etc/passwd", false},
+		{"lookalike prefix", "/srv/box-evil/x", false},
+		{"close but no", "/home/alice/projects-other", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pathUnderAny(tc.path, roots); got != tc.want {
+				t.Errorf("pathUnderAny(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidatePathAgainstRoots(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		root    string
+		wantErr bool
+	}{
+		{"no root, any path ok", "/etc/passwd", "", false},
+		{"under explicit root", "/srv/box/file", "/srv/box", false},
+		{"equals explicit root", "/srv/box", "/srv/box", false},
+		{"outside explicit root", "/etc/passwd", "/srv/box", true},
+		{"lookalike prefix rejected", "/srv/box-evil/x", "/srv/box", true},
+		{"empty path rejected", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validatePathAgainstRoots(tc.path, tc.root)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validatePathAgainstRoots(%q, %q) err=%v, wantErr=%v",
+					tc.path, tc.root, err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/internal/agentbox/files.go
+++ b/internal/agentbox/files.go
@@ -61,13 +61,13 @@ func readFileTool() mcp.Tool {
 	)
 }
 
-func handleReadFile(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleReadFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 	rawPath, ok := args["path"].(string)
 	if !ok || rawPath == "" {
 		return mcp.NewToolResultError("read_file: 'path' is required"), nil
 	}
-	path, err := validatePath(rawPath)
+	path, err := validatePathCtx(ctx, rawPath)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("read_file: %v", err)), nil
 	}
@@ -232,13 +232,13 @@ func writeFileTool() mcp.Tool {
 	)
 }
 
-func handleWriteFile(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleWriteFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 	rawPath, ok := args["path"].(string)
 	if !ok || rawPath == "" {
 		return mcp.NewToolResultError("write_file: 'path' is required"), nil
 	}
-	path, err := validatePath(rawPath)
+	path, err := validatePathCtx(ctx, rawPath)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("write_file: %v", err)), nil
 	}
@@ -328,13 +328,13 @@ func listDirectoryTool() mcp.Tool {
 	)
 }
 
-func handleListDirectory(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleListDirectory(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 	rawPath, ok := args["path"].(string)
 	if !ok || rawPath == "" {
 		return mcp.NewToolResultError("list_directory: 'path' is required"), nil
 	}
-	path, err := validatePath(rawPath)
+	path, err := validatePathCtx(ctx, rawPath)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("list_directory: %v", err)), nil
 	}
@@ -393,18 +393,18 @@ func moveFileTool() mcp.Tool {
 	)
 }
 
-func handleMoveFile(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleMoveFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 	rawSrc, _ := args["source"].(string)
 	rawDst, _ := args["destination"].(string)
 	if rawSrc == "" || rawDst == "" {
 		return mcp.NewToolResultError("move_file: 'source' and 'destination' are required"), nil
 	}
-	src, err := validatePath(rawSrc)
+	src, err := validatePathCtx(ctx, rawSrc)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("move_file: source: %v", err)), nil
 	}
-	dst, err := validatePath(rawDst)
+	dst, err := validatePathCtx(ctx, rawDst)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("move_file: destination: %v", err)), nil
 	}
@@ -439,13 +439,13 @@ func deleteFileTool() mcp.Tool {
 	)
 }
 
-func handleDeleteFile(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleDeleteFile(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := req.GetArguments()
 	rawPath, _ := args["path"].(string)
 	if rawPath == "" {
 		return mcp.NewToolResultError("delete_file: 'path' is required"), nil
 	}
-	path, err := validatePath(rawPath)
+	path, err := validatePathCtx(ctx, rawPath)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("delete_file: %v", err)), nil
 	}

--- a/internal/agentbox/sandbox.go
+++ b/internal/agentbox/sandbox.go
@@ -1,22 +1,45 @@
 package agentbox
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 )
 
 // AGENTBOX_ROOT, when set, restricts every file-ops tool to paths that
-// resolve under it. Unset means no constraint — the agent has the same
-// reach as the host process. Production deployments set it to the project
-// directory so a misbehaving agent can't touch /etc, $HOME/.ssh, etc.
+// resolve under it. It's the strict floor — even if the MCP client
+// advertises broader roots via roots/list, AGENTBOX_ROOT still wins.
+//
+// When AGENTBOX_ROOT is unset and the MCP client supports the roots
+// capability, agent-box asks the client (via roots/list) for the
+// directories it cares about and uses those as the effective sandbox.
+// This matches what filesystem MCP servers in the wild do — agents
+// running Cursor or Claude Code get a sandbox aligned with their
+// workspace without the operator setting AGENTBOX_ROOT manually.
+//
+// When neither AGENTBOX_ROOT is set NOR the client supports roots,
+// agent-box runs unconstrained (current behavior preserved).
 const sandboxRootEnv = "AGENTBOX_ROOT"
 
 var (
 	sandboxOnce sync.Once
-	sandboxRoot string // empty = unconstrained
+	sandboxRoot string // empty = no AGENTBOX_ROOT configured
+
+	// mcpServer is the *MCPServer instance set in RegisterTools. It's
+	// kept package-level rather than threaded through every handler
+	// because nearly every file-ops tool needs to call RequestRoots,
+	// and threading through 6 handlers + their tests for one optional
+	// call is more churn than it earns. nil when not registered (e.g.
+	// in unit tests that exercise handlers directly).
+	mcpServer *server.MCPServer
 )
 
 func resolvedSandboxRoot() string {
@@ -37,12 +60,19 @@ func resolvedSandboxRoot() string {
 	return sandboxRoot
 }
 
-// validatePath returns the cleaned absolute path if it is allowed under
-// the configured sandbox root (or any path, when no root is set). Returns
-// a structured error otherwise. Callers should pass the result back to
-// os.* operations — using the returned canonical path keeps later error
-// messages consistent.
+// validatePath is the legacy AGENTBOX_ROOT-only check. Kept for callers
+// (and tests) that don't have an MCP context — file ops invoked via
+// the package's tools should use validatePathCtx instead so client
+// roots are honored too.
 func validatePath(p string) (string, error) {
+	return validatePathAgainstRoots(p, "")
+}
+
+// validatePathCtx is the roots-aware path validator. AGENTBOX_ROOT is
+// the strict floor; if it's unset and the MCP client advertises roots
+// via roots/list, those become the sandbox. Falls back to no
+// constraint only when both are absent.
+func validatePathCtx(ctx context.Context, p string) (string, error) {
 	if p == "" {
 		return "", fmt.Errorf("path is empty")
 	}
@@ -52,25 +82,123 @@ func validatePath(p string) (string, error) {
 	}
 	abs = filepath.Clean(abs)
 
-	root := resolvedSandboxRoot()
+	// AGENTBOX_ROOT is the floor. If it's set, that's the only check.
+	// Client roots that fall outside it are intentionally ignored —
+	// the operator's intent overrides the client's hint.
+	if root := resolvedSandboxRoot(); root != "" {
+		if abs == root || strings.HasPrefix(abs, root+string(os.PathSeparator)) {
+			return abs, nil
+		}
+		return "", fmt.Errorf("path %q is outside AGENTBOX_ROOT (%s)", p, root)
+	}
+
+	// No AGENTBOX_ROOT — try client roots if the server reference is
+	// available and the client supports the capability.
+	roots := clientRoots(ctx)
+	if len(roots) == 0 {
+		// Neither AGENTBOX_ROOT nor client roots — unconstrained
+		// (preserves current behavior for clients that don't advertise
+		// roots).
+		return abs, nil
+	}
+	if pathUnderAny(abs, roots) {
+		return abs, nil
+	}
+	return "", fmt.Errorf("path %q is not under any client-advertised root: %s",
+		p, strings.Join(roots, ", "))
+}
+
+// clientRoots fetches the MCP client's roots, returning the list of
+// filesystem paths or an empty slice if anything goes wrong (no
+// session, client doesn't support roots, transport error, malformed
+// URI). Empty slice means "don't apply a client-roots constraint."
+//
+// We deliberately swallow errors here rather than propagate them to
+// the agent: the client either supports roots or it doesn't, and
+// failing every file op because the client speaks an older MCP version
+// is worse UX than just running unconstrained. The operator can still
+// set AGENTBOX_ROOT for a hard floor.
+func clientRoots(ctx context.Context) []string {
+	if mcpServer == nil {
+		return nil
+	}
+	res, err := mcpServer.RequestRoots(ctx, mcp.ListRootsRequest{})
+	if err != nil {
+		// ErrNoClientSession or ErrRootsNotSupported is the common case.
+		// Anything else (transport error) we also treat as "no roots."
+		if errors.Is(err, server.ErrNoClientSession) || errors.Is(err, server.ErrRootsNotSupported) {
+			return nil
+		}
+		return nil
+	}
+	return rootURIsToPaths(res.Roots)
+}
+
+// rootURIsToPaths converts a slice of mcp.Root (each carrying a file://
+// URI per the MCP spec) into clean absolute filesystem paths. URIs
+// that don't parse, or use a non-file scheme, are dropped — the spec
+// reserves space for other schemes but the only one defined today is
+// file://.
+func rootURIsToPaths(roots []mcp.Root) []string {
+	out := make([]string, 0, len(roots))
+	for _, r := range roots {
+		u, err := url.Parse(r.URI)
+		if err != nil || u.Scheme != "file" {
+			continue
+		}
+		// file:///abs/path → u.Path = /abs/path
+		// file://localhost/abs/path → also u.Path = /abs/path
+		p := u.Path
+		if p == "" {
+			continue
+		}
+		out = append(out, filepath.Clean(p))
+	}
+	return out
+}
+
+// pathUnderAny returns true if abs is equal to or contained within
+// any of the given roots. Boundary-aware (prefix + separator) so
+// /srv/box-evil isn't accidentally accepted under /srv/box.
+func pathUnderAny(abs string, roots []string) bool {
+	for _, r := range roots {
+		if abs == r || strings.HasPrefix(abs, r+string(os.PathSeparator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// validatePathAgainstRoots is the testable core: pure function over
+// (path, AGENTBOX_ROOT-or-empty). validatePath calls this with
+// AGENTBOX_ROOT resolved; tests can invoke it with a synthetic root.
+func validatePathAgainstRoots(p, root string) (string, error) {
+	if p == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("resolve %q: %w", p, err)
+	}
+	abs = filepath.Clean(abs)
+
+	if root == "" {
+		root = resolvedSandboxRoot()
+	}
 	if root == "" {
 		return abs, nil
 	}
-	if abs == root {
-		return abs, nil
-	}
-	// Boundary-aware prefix check: root="/srv/box", abs="/srv/box-evil"
-	// must not match. Append the separator before comparing.
-	if strings.HasPrefix(abs, root+string(os.PathSeparator)) {
+	if abs == root || strings.HasPrefix(abs, root+string(os.PathSeparator)) {
 		return abs, nil
 	}
 	return "", fmt.Errorf("path %q is outside AGENTBOX_ROOT (%s)", p, root)
 }
 
-// resetSandboxOnceForTest clears the cached resolution so a test that sets
-// AGENTBOX_ROOT via t.Setenv re-reads it on the next validatePath call.
-// Production code should never invoke this — sync.Once is intentional for
-// the runtime path so the env is read exactly once per process.
+// resetSandboxOnceForTest clears the cached resolution so a test that
+// sets AGENTBOX_ROOT via t.Setenv re-reads it on the next validatePath
+// call. Production code should never invoke this — sync.Once is
+// intentional for the runtime path so the env is read exactly once per
+// process.
 func resetSandboxOnceForTest() {
 	sandboxOnce = sync.Once{}
 	sandboxRoot = ""

--- a/internal/agentbox/server.go
+++ b/internal/agentbox/server.go
@@ -12,8 +12,12 @@
 //   - delete_file     — remove a single file (refuses directories)
 //   - tail_log        — watch a file for new appends, bounded by follow_seconds
 //
-// All file paths can be confined to a project root via the AGENTBOX_ROOT
-// env var; unset means no constraint.
+// File-ops tools enforce a sandbox in this order:
+//   1. AGENTBOX_ROOT env var (strict floor when set).
+//   2. MCP Roots advertised by the client via roots/list (used as the
+//      sandbox when AGENTBOX_ROOT is unset). Falls back gracefully if
+//      the client doesn't support the capability.
+//   3. Unconstrained (only when both are absent).
 //
 // More tools (provision_postgres, deploy_app, snapshot, etc.) land in
 // subsequent commits.
@@ -25,7 +29,12 @@ import "github.com/mark3labs/mcp-go/server"
 // once at startup by cmd/agent-box. Each tool is implemented in its own
 // file (shell.go, files.go, …) and registers itself via a Register*
 // function — keeping main.go declarative and the toolset easy to discover.
+//
+// The MCPServer reference is also stashed in the package so file-ops
+// handlers can call s.RequestRoots() to fetch the client's filesystem
+// roots when AGENTBOX_ROOT isn't set. See sandbox.go.
 func RegisterTools(s *server.MCPServer) {
+	mcpServer = s
 	registerShellTool(s)
 	registerFileTools(s)
 	registerTailLogTool(s)

--- a/internal/agentbox/tail_log.go
+++ b/internal/agentbox/tail_log.go
@@ -66,7 +66,7 @@ func handleTailLog(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolR
 	if !ok || rawPath == "" {
 		return mcp.NewToolResultError("tail_log: 'path' is required"), nil
 	}
-	path, err := validatePath(rawPath)
+	path, err := validatePathCtx(ctx, rawPath)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("tail_log: %v", err)), nil
 	}


### PR DESCRIPTION
## Why

When AGENTBOX_ROOT isn't set and the MCP client (Cursor, Claude Code) advertises filesystem roots, agent-box should use those as the effective sandbox automatically. Today it runs unconstrained — the agent can read/write anywhere on the box. Adopting the client's roots makes the demo cleaner ("the agent's editing reach matches the project I opened") without operators having to set AGENTBOX_ROOT manually.

## Three-tier validation

In order:

1. **AGENTBOX_ROOT** (strict floor when set). Client roots that fall outside are ignored — operator intent overrides.
2. **MCP client roots** via `mcpServer.RequestRoots(ctx)` when AGENTBOX_ROOT is unset and the client supports the capability.
3. **Unconstrained** when both are absent (preserves current behavior for clients that don't speak roots).

## Implementation

- `validatePathCtx(ctx, path)` replaces `validatePath()` in handlers. AGENTBOX_ROOT-only check is preserved as `validatePath()` for non-MCP callers.
- `clientRoots(ctx)` swallows `ErrNoClientSession` / `ErrRootsNotSupported` / transport errors as "no constraint." Failing every file op because the client speaks an older MCP version is worse UX than running unconstrained — operator can set AGENTBOX_ROOT for a hard floor.
- `RegisterTools` stashes the `*MCPServer` in a package var so handlers can call `RequestRoots` without threading it through every signature.
- URI handling: `file://` only per the MCP spec.

## Tests

- `TestRootURIsToPaths_ParsesFileURIs` — file://, non-file scheme, unparseable, empty path
- `TestPathUnderAny` — 6-case table with lookalike-prefix rejection
- `TestValidatePathAgainstRoots` — 6-case table covering all branches
- All existing tests still green after the `validatePath → validatePathCtx` swap. Sandbox tests gained `t.Cleanup(resetSandboxOnceForTest)` so cached state doesn't leak between tests (was a latent bug unmasked by adding new tests).

## What's NOT done (deferred)

- Dynamic root subscription (`roots/list_changed` notifications). Static-at-call-time is enough for v0; we re-fetch roots on every file-op call, which catches changes immediately at sub-ms cost over stdio.
- Live integration test with a real MCP client. The pure-function tests cover the validation logic; the round-trip with mcp-go's `RequestRoots` is the library's responsibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)