### PR TITLE
feat(terraform): gce-demo — reproducible demo cluster as a shipped artifact

### DIFF
--- a/terraform/gce-demo/.gitignore
+++ b/terraform/gce-demo/.gitignore
@@ -1,0 +1,10 @@
+# Local state — never commit (contains resource IDs, sometimes secrets).
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfstate.*.backup
+.terraform/
+.terraform.lock.hcl
+
+# Local secrets — only the .example version is tracked.
+terraform.tfvars
+*.auto.tfvars

--- a/terraform/gce-demo/README.md
+++ b/terraform/gce-demo/README.md
@@ -38,9 +38,10 @@ via Caddy's hostname routing.
 - `gcloud` CLI authenticated (`gcloud auth application-default login`)
 - An SSH key pair (one public key goes in tfvars; the private key
   stays on your laptop for sentinel access)
-- **Optional but recommended**: a Cloud DNS managed zone for a domain
-  you control. Without it, you'll have to set the wildcard A-record
-  yourself.
+- **A domain you control with DNS records you can edit.** Cloud DNS is
+  the integrated path (Terraform creates records for you); see
+  ["Without Cloud DNS"](#without-cloud-dns-godaddy-cloudflare-route-53-etc)
+  below if your domain lives on GoDaddy / Cloudflare / Route 53 / etc.
 
 ## Step-by-step
 
@@ -162,6 +163,80 @@ Most knobs are in `variables.tf`. Common changes:
 The Containarium module itself lives at `../modules/containarium/` —
 that's the actual implementation. This directory is a thin "consumer"
 on top of it tailored for the demo experience.
+
+## Without Cloud DNS (GoDaddy, Cloudflare, Route 53, etc.)
+
+If your domain isn't managed by Google Cloud DNS, leave
+`dns_managed_zone_name` and `dns_zone_domain` blank in tfvars. Run
+`terraform apply` as usual — it'll skip the DNS-record resources and
+emit `(set DNS manually)` for the `demo_base_domain` output.
+
+You then create two A records by hand on whichever provider hosts
+your domain:
+
+```
+terraform output -raw sentinel_ip
+# e.g. 34.123.45.67
+```
+
+| Type | Name (host) | Value | TTL |
+|---|---|---|---|
+| A | `*.demo` | sentinel IP | 600 |
+| A | `demo` | sentinel IP | 600 |
+
+The `*.demo` wildcard makes `anything.demo.<your-domain>` resolve to
+the sentinel — that's what makes `expose_port` work for arbitrary
+hostnames the agent picks. The plain `demo` record covers
+`demo.<your-domain>` directly so you can hit the platform API or web
+UI in a browser.
+
+### GoDaddy
+
+1. Sign in → **My Products** → your domain → **DNS** (or
+   `dcc.godaddy.com/manage/<your-domain>/dns`).
+2. **Add Record** → type `A`, name `*.demo`, value the sentinel IP,
+   TTL 600 seconds. Save.
+3. **Add Record** again → type `A`, name `demo`, same value, TTL 600.
+4. GoDaddy's UI calls out wildcard support directly (`Use * for
+   wildcards`); if it rejects `*.demo` for any reason, fall back to
+   creating one A record per app you'll demo (e.g., `blog.demo`,
+   `app.demo`) with the same IP.
+5. Note: **DNS records**, not **Forwarding** — those are different
+   tabs and "Forwarding" won't do what we need.
+
+### Cloudflare
+
+1. Sign in → your domain → **DNS** → **Records**.
+2. **Add record** → type `A`, name `*.demo`, IPv4 sentinel IP,
+   proxy status **DNS only** (the orange cloud OFF — Cloudflare's
+   proxy doesn't pass HTTP-routed domains through PROXY-protocol
+   correctly to our sentinel). TTL 5 min.
+3. Repeat for `demo` (same IP, DNS-only).
+
+### Route 53
+
+1. Open the hosted zone for your domain.
+2. **Create record** → record name `*.demo`, record type `A`, value
+   the sentinel IP, TTL 600.
+3. Repeat for `demo`.
+
+### Verify (any provider)
+
+```bash
+dig +short blog.demo.<your-domain>
+dig +short demo.<your-domain>
+# Both should return the sentinel IP.
+```
+
+Propagation: 5–60 minutes typically. If `dig` returns nothing, wait
+and retry; don't move on to the demo recording until both names
+resolve.
+
+### Tear-down
+
+After `terraform destroy`, the sentinel IP is released. Delete the
+two A records on your provider (otherwise they'll point at someone
+else's GCP IP next time someone gets that ephemeral IP).
 
 ## Troubleshooting
 

--- a/terraform/gce-demo/README.md
+++ b/terraform/gce-demo/README.md
@@ -72,6 +72,20 @@ Provisions ~10 GCP resources; takes 5–10 minutes. The output prints
 a `next_steps` block with copy-paste commands for the next stage —
 read it.
 
+### 2a. Smoke-test (recommended)
+
+Before committing to the demo recording, verify the cluster actually
+works:
+
+```bash
+./scripts/smoke-test.sh
+```
+
+Four checks: SSH to sentinel, daemon running on backend, JWT issuance,
+authenticated API call. Run after every `terraform apply`. Pass
+`--expected-version=0.16.4` to fail if the daemon is on a different
+version than you expected.
+
 ### 3. Issue a demo JWT
 
 ```bash

--- a/terraform/gce-demo/README.md
+++ b/terraform/gce-demo/README.md
@@ -1,0 +1,180 @@
+# Demo Deployment
+
+This directory provisions the smallest realistic Containarium cluster
+that supports the agent-native demo flow: an agent driving an MCP
+client (Claude Code, Cursor) creates a sandbox, installs an app,
+exposes it on a public hostname, and the URL works.
+
+If you watched the demo video and thought "I want to try that" — you're
+in the right place. Run `terraform apply` here and you'll have a
+working cluster in ~15 minutes. Cost is ~$30/month while running;
+`terraform destroy` tears it all down when you're done.
+
+## Architecture
+
+```
+Your laptop (Claude Code)
+      |
+      | MCP over stdio → SSH
+      v
+Sentinel VM (e2-micro, free tier)
+  ├── sshpiper :22       (routes SSH by username)
+  └── Caddy :443         (routes HTTPS by hostname → backend)
+      |
+      v
+Backend VM (e2-medium, spot)
+  ├── containarium daemon
+  ├── Incus (LXC)
+  └── containers ← agent operates here via agent-box MCP
+```
+
+Wildcard DNS (`*.demo.<your-zone>`) points at the sentinel. Apps the
+agent deploys (e.g. `blog.demo.<your-zone>`) reach the right container
+via Caddy's hostname routing.
+
+## Prerequisites
+
+- GCP project with billing enabled
+- `gcloud` CLI authenticated (`gcloud auth application-default login`)
+- An SSH key pair (one public key goes in tfvars; the private key
+  stays on your laptop for sentinel access)
+- **Optional but recommended**: a Cloud DNS managed zone for a domain
+  you control. Without it, you'll have to set the wildcard A-record
+  yourself.
+
+## Step-by-step
+
+### 1. Configure
+
+```bash
+cd terraform/gce-demo
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars
+```
+
+Required fields: `project_id`, `admin_ssh_keys`, `jwt_secret` (generate
+with `openssl rand -hex 32`).
+
+If you have a Cloud DNS zone for the domain you're demoing on, also
+fill in `dns_managed_zone_name`, `dns_zone_domain`, and optionally
+`demo_subdomain`. With these set, Terraform creates a wildcard A-record
+pointing at the sentinel — no manual DNS work.
+
+### 2. Apply
+
+```bash
+terraform init
+terraform apply
+```
+
+Provisions ~10 GCP resources; takes 5–10 minutes. The output prints
+a `next_steps` block with copy-paste commands for the next stage —
+read it.
+
+### 3. Issue a demo JWT
+
+```bash
+SENTINEL=$(terraform output -raw sentinel_vm_name)
+ZONE=$(terraform output -json | jq -r '.[].value' | grep -E "^[a-z0-9-]+-[a-z0-9]$" | head -1)
+gcloud compute ssh "$SENTINEL" --zone "$ZONE" \
+  --command='sudo /usr/local/bin/containarium token generate \
+              --username demo --roles admin --expiry 24h \
+              --secret-file /etc/containarium/jwt.secret 2>/dev/null \
+              | grep "^eyJ"' \
+  > ~/.containarium-demo-token.txt && chmod 600 ~/.containarium-demo-token.txt
+```
+
+`~/.containarium-demo-token.txt` now holds a 24-hour admin JWT. Anyone
+who reads the file can do anything to your demo cluster — keep it on
+disk only.
+
+### 4. Build and register the platform MCP
+
+```bash
+# From the repo root:
+make build-mcp
+
+# Wire it into Claude Code (or your MCP client of choice):
+SENTINEL_IP=$(terraform -chdir=terraform/gce-demo output -raw sentinel_ip)
+claude mcp add containarium-demo --scope user \
+  --env CONTAINARIUM_SERVER_URL=http://$SENTINEL_IP:8080 \
+  --env CONTAINARIUM_JWT_TOKEN="$(cat ~/.containarium-demo-token.txt)" \
+  -- $(pwd)/bin/mcp-server
+```
+
+Restart Claude Code so it loads the new server.
+
+### 5. Drive the demo
+
+In Claude Code, paste this prompt (substitute your domain):
+
+> Spin up a sandbox called `demo-blog`, install nginx, serve a hello-world page, and expose it at `demo-blog.demo.<your-zone>`.
+
+The agent should:
+
+1. Call `create_container demo-blog` (platform MCP)
+2. Configure SSH (you may need to run `containarium ssh-config sync`
+   between this step and the next so the in-the-box MCP wiring works)
+3. Call `shell_exec apt install nginx` (agent-box MCP)
+4. Call `write_file /var/www/html/index.html` with the hello page
+5. Call `process_start nginx` to run it in the background
+6. Call `tail_log` on the access log to confirm it's serving
+7. Call `expose_port demo-blog --container-port 80 --domain demo-blog.demo.<your-zone>`
+
+Then `curl https://demo-blog.demo.<your-zone>/` returns the hello page.
+
+### 6. Tear down
+
+```bash
+terraform destroy
+```
+
+Everything (VMs, disk, DNS records) goes away. The `~/.containarium-demo-token.txt`
+on your laptop is now invalid; delete it.
+
+## Cost
+
+| Resource | Cost / month |
+|---|---|
+| Sentinel VM (e2-micro) | $0 (free tier) |
+| Backend VM (e2-medium spot) | ~$10 |
+| 100 GB persistent disk (pd-balanced) | ~$10 |
+| Cloud NAT | ~$1 |
+| DNS records | ~$0.50 |
+| **Total** | **~$25–35** |
+
+Spot preemption can interrupt the backend; the persistent disk
+preserves containers across restarts. For a recording session, run
+`terraform apply` an hour beforehand so the cluster has time to
+stabilize.
+
+## Customization
+
+Most knobs are in `variables.tf`. Common changes:
+
+- **Bigger backend** for heavier workloads: set `machine_type =
+  "n2-standard-4"`. Cost roughly doubles.
+- **Different region**: set `region` and `zone` to anywhere with
+  Cloud DNS + spot VMs available.
+- **Specific containarium version**: set `containarium_version =
+  "0.16.5"` (or whatever's current).
+
+The Containarium module itself lives at `../modules/containarium/` —
+that's the actual implementation. This directory is a thin "consumer"
+on top of it tailored for the demo experience.
+
+## Troubleshooting
+
+**`terraform apply` fails with "Error 403: APIs not enabled"** — enable
+Compute Engine, Cloud DNS, and IAM APIs in your project.
+
+**Wildcard DNS doesn't resolve** — Cloud DNS has 5-minute TTLs;
+propagation isn't instant. `dig +short *.demo.<your-zone>` should
+eventually return the sentinel IP.
+
+**Agent's `expose_port` call fails with auth error** — your JWT may
+have expired (24h default). Re-issue per step 3.
+
+**`curl https://...` returns 502** — the sentinel hits the backend's
+Caddy via PROXY protocol. If the backend's Caddy isn't running yet
+(daemon still starting), retries within 30s usually clear it.

--- a/terraform/gce-demo/main.tf
+++ b/terraform/gce-demo/main.tf
@@ -1,0 +1,110 @@
+// Demo deployment for the agent-native sandbox walkthrough.
+//
+// Provisions a single-host Containarium cluster with:
+//   - Sentinel (e2-micro, free-tier) running sshpiper + Caddy
+//   - Spot VM (e2-medium) running the daemon + Incus
+//   - Persistent disk for container data
+//   - Optional wildcard DNS record (*.<demo_subdomain>.<zone>) → sentinel
+//
+// Designed to be the smallest realistic deployment that supports the
+// full agent-native demo flow (create → ssh → install → expose).
+// Costs ~$30/month while running; teardown via terraform destroy.
+//
+// State is local (terraform.tfstate in this directory). For a long-
+// lived demo cluster you may want to wire a GCS backend like the
+// production deployment does (see terraform/gce/backend-prod.tf.example
+// for the pattern).
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+module "containarium" {
+  source = "../modules/containarium"
+
+  // Identity
+  project_id    = var.project_id
+  region        = var.region
+  zone          = var.zone
+  instance_name = var.instance_name
+
+  // Sizing — small but real
+  machine_type   = var.machine_type
+  boot_disk_size = 30
+
+  // Spot + persistent disk: containers survive preemption. Demo
+  // viewers see real recovery if they hold the cluster for a few days.
+  use_spot_instance     = true
+  use_persistent_disk   = true
+  data_disk_size        = 100
+  data_disk_type        = "pd-balanced"
+  enable_disk_snapshots = false // optional; turn on if you keep the cluster around
+
+  // Sentinel — required for the agent-native demo (Caddy + sshpiper
+  // hostname routing live here).
+  enable_sentinel         = true
+  sentinel_machine_type   = "e2-micro"
+  sentinel_boot_disk_size = 10
+
+  // Daemon
+  enable_containarium_daemon = true
+  containarium_version       = var.containarium_version
+  containarium_binary_url    = var.containarium_binary_url
+
+  // Access
+  admin_ssh_keys      = var.admin_ssh_keys
+  allowed_ssh_sources = var.allowed_ssh_sources
+  jwt_secret          = var.jwt_secret
+
+  // Networking — no external IP on the spot VM by default; Cloud NAT
+  // handles outbound. The sentinel owns the external IP and DNS A-record.
+  spot_vm_external_ip = false
+  enable_iap_firewall = true
+
+  labels = merge({
+    environment = "demo"
+    managed_by  = "terraform"
+  }, var.labels)
+}
+
+// Wildcard DNS record (*.<demo_subdomain>.<zone>) → sentinel IP.
+// Skipped when dns_managed_zone_name is empty — set DNS manually in
+// that case.
+resource "google_dns_record_set" "demo_wildcard" {
+  count = var.dns_managed_zone_name == "" ? 0 : 1
+
+  project      = var.project_id
+  managed_zone = var.dns_managed_zone_name
+  name         = "*.${var.demo_subdomain}.${var.dns_zone_domain}."
+  type         = "A"
+  ttl          = 300
+
+  rrdatas = [module.containarium.jump_server_ip]
+}
+
+// Apex record for the demo subdomain itself (so demo.<zone> also
+// works, not just *.demo.<zone>). Useful for hitting the platform
+// API or web UI directly.
+resource "google_dns_record_set" "demo_apex" {
+  count = var.dns_managed_zone_name == "" ? 0 : 1
+
+  project      = var.project_id
+  managed_zone = var.dns_managed_zone_name
+  name         = "${var.demo_subdomain}.${var.dns_zone_domain}."
+  type         = "A"
+  ttl          = 300
+
+  rrdatas = [module.containarium.jump_server_ip]
+}

--- a/terraform/gce-demo/outputs.tf
+++ b/terraform/gce-demo/outputs.tf
@@ -1,0 +1,66 @@
+output "sentinel_ip" {
+  description = "External IP of the sentinel VM. Wildcard DNS records point here."
+  value       = module.containarium.jump_server_ip
+}
+
+output "sentinel_vm_name" {
+  description = "GCE instance name of the sentinel."
+  value       = module.containarium.sentinel_vm_name
+}
+
+output "spot_vm_name" {
+  description = "GCE instance name of the backend VM where the daemon + Incus run."
+  value       = module.containarium.spot_vm_name
+}
+
+output "demo_base_domain" {
+  description = "Base hostname for the demo. Apps deployed during the demo land at <name>.<this>."
+  value       = var.dns_managed_zone_name == "" ? "(set DNS manually)" : "${var.demo_subdomain}.${var.dns_zone_domain}"
+}
+
+output "ssh_command" {
+  description = "SSH command for the sentinel (admin shell access)."
+  value       = module.containarium.ssh_command
+}
+
+output "next_steps" {
+  description = "Copy-paste guide to issue a JWT and wire Claude Code's MCP server."
+  value       = <<-EOT
+
+    ─────────────────────────────────────────────────────────────────
+    Demo cluster ready. Next steps:
+    ─────────────────────────────────────────────────────────────────
+
+    1. Issue a 24h admin JWT (run on the sentinel via gcloud SSH):
+
+       gcloud compute ssh ${module.containarium.sentinel_vm_name} \
+           --project=${var.project_id} --zone=${var.zone} \
+           --command='sudo /usr/local/bin/containarium token generate \
+                       --username demo --roles admin --expiry 24h \
+                       --secret-file /etc/containarium/jwt.secret \
+                       2>/dev/null | grep "^eyJ"' \
+           > ~/.containarium-demo-token.txt && \
+       chmod 600 ~/.containarium-demo-token.txt
+
+    2. Build the platform MCP binary and wire Claude Code:
+
+       make build-mcp
+       claude mcp add containarium-demo --scope user \
+         --env CONTAINARIUM_SERVER_URL=http://${module.containarium.jump_server_ip}:8080 \
+         --env CONTAINARIUM_JWT_TOKEN="$(cat ~/.containarium-demo-token.txt)" \
+         -- $(pwd)/bin/mcp-server
+
+    3. Restart Claude Code so it picks up the new server.
+
+    4. Drive the demo with one prompt:
+
+       "Spin up a sandbox called 'demo-blog', install nginx, serve a
+        hello-world page, and expose it at demo-blog.${var.dns_managed_zone_name == "" ? "<your-domain>" : "${var.demo_subdomain}.${var.dns_zone_domain}"}."
+
+    5. When the recording is done:
+
+       terraform destroy
+
+    ─────────────────────────────────────────────────────────────────
+  EOT
+}

--- a/terraform/gce-demo/outputs.tf
+++ b/terraform/gce-demo/outputs.tf
@@ -13,6 +13,18 @@ output "spot_vm_name" {
   value       = module.containarium.spot_vm_name
 }
 
+// Echo the GCP coordinates so scripts can `terraform output -raw zone`
+// instead of parsing them out of other outputs.
+output "project_id" {
+  description = "GCP project ID for this deployment."
+  value       = var.project_id
+}
+
+output "zone" {
+  description = "GCP zone for this deployment."
+  value       = var.zone
+}
+
 output "demo_base_domain" {
   description = "Base hostname for the demo. Apps deployed during the demo land at <name>.<this>."
   value       = var.dns_managed_zone_name == "" ? "(set DNS manually)" : "${var.demo_subdomain}.${var.dns_zone_domain}"

--- a/terraform/gce-demo/scripts/smoke-test.sh
+++ b/terraform/gce-demo/scripts/smoke-test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Smoke-test a freshly-applied terraform/gce-demo cluster.
+#
+# Run AFTER `terraform apply`. Verifies four things in order:
+#
+#   1. gcloud SSH to the sentinel works.
+#   2. The containarium daemon is running on the backend at the
+#      expected version.
+#   3. A freshly-issued JWT actually authenticates against
+#      /v1/containers.
+#   4. The platform MCP HTTP API returns a sensible empty list.
+#
+# Doesn't touch DNS — that's manual on non-Cloud-DNS providers and
+# the script wants to work for everyone. Doesn't tear down — leave
+# that to the operator.
+#
+# Exit 0 if every check passes; 1 on the first failure (the rest are
+# typically already broken once an early check fails). Run from
+# terraform/gce-demo/ or pass --tf-dir=<path>.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TF_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+EXPECTED_VERSION="${EXPECTED_VERSION:-}"  # leave empty to skip version assertion
+
+# ---- argument parsing -----------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tf-dir=*)
+      TF_DIR="${1#--tf-dir=}"
+      shift
+      ;;
+    --expected-version=*)
+      EXPECTED_VERSION="${1#--expected-version=}"
+      shift
+      ;;
+    -h|--help)
+      cat <<EOF
+Usage: smoke-test.sh [--tf-dir=PATH] [--expected-version=X.Y.Z]
+
+  --tf-dir=PATH         Terraform working directory (default: parent of this script).
+  --expected-version    If set, fail when 'containarium version' on the backend
+                        doesn't match. Useful in CI; skip locally.
+
+Run AFTER 'terraform apply' has produced state in --tf-dir.
+EOF
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $1" >&2
+      exit 64
+      ;;
+  esac
+done
+
+# ---- helpers ---------------------------------------------------------
+
+CHECK_NUM=0
+fail() {
+  echo "  ✗ FAIL: $*" >&2
+  exit 1
+}
+
+check() {
+  CHECK_NUM=$((CHECK_NUM + 1))
+  echo
+  echo "──[$CHECK_NUM] $*"
+}
+
+ok() {
+  echo "  ✓ ok"
+}
+
+tf_out() {
+  terraform -chdir="$TF_DIR" output -raw "$1" 2>/dev/null \
+    || fail "terraform output '$1' missing — did you run 'terraform apply' first?"
+}
+
+# ---- preflight -------------------------------------------------------
+
+if [[ ! -f "$TF_DIR/terraform.tfstate" ]] && [[ ! -d "$TF_DIR/.terraform" ]]; then
+  fail "no Terraform state in $TF_DIR — run 'terraform apply' first"
+fi
+command -v gcloud >/dev/null || fail "gcloud not on PATH"
+command -v curl >/dev/null   || fail "curl not on PATH"
+
+PROJECT_ID="$(tf_out project_id)"
+ZONE="$(tf_out zone)"
+SENTINEL_IP="$(tf_out sentinel_ip)"
+SENTINEL_VM="$(tf_out sentinel_vm_name)"
+SPOT_VM="$(tf_out spot_vm_name)"
+
+echo "Targeting:"
+echo "  project: $PROJECT_ID"
+echo "  zone:    $ZONE"
+echo "  sentinel: $SENTINEL_VM ($SENTINEL_IP)"
+echo "  backend:  $SPOT_VM"
+
+# ---- 1. SSH to sentinel ---------------------------------------------
+
+check "SSH to the sentinel"
+gcloud compute ssh "$SENTINEL_VM" \
+  --project="$PROJECT_ID" --zone="$ZONE" \
+  --command='echo ok' --quiet 2>/dev/null \
+  | grep -q "^ok$" || fail "couldn't SSH to sentinel — check IAM and allowed_ssh_sources"
+ok
+
+# ---- 2. Daemon running on backend -----------------------------------
+
+check "Daemon is running on backend at expected version"
+ACTUAL_VERSION="$(gcloud compute ssh "$SPOT_VM" \
+  --project="$PROJECT_ID" --zone="$ZONE" --tunnel-through-iap \
+  --command='sudo /usr/local/bin/containarium version' --quiet 2>/dev/null \
+  | head -1 | tr -d '[:space:]')" || fail "couldn't reach the daemon binary"
+echo "  daemon reports: $ACTUAL_VERSION"
+if [[ -n "$EXPECTED_VERSION" ]] && [[ "$ACTUAL_VERSION" != *"$EXPECTED_VERSION"* ]]; then
+  fail "expected version to contain '$EXPECTED_VERSION', got '$ACTUAL_VERSION'"
+fi
+ok
+
+# ---- 3. JWT issuance + API auth -------------------------------------
+
+check "JWT issuance + authenticated API call"
+TOKEN_FILE="$(mktemp)"
+trap 'rm -f "$TOKEN_FILE"' EXIT
+
+gcloud compute ssh "$SENTINEL_VM" \
+  --project="$PROJECT_ID" --zone="$ZONE" \
+  --command='sudo /usr/local/bin/containarium token generate \
+              --username smoke --roles admin --expiry 1h \
+              --secret-file /etc/containarium/jwt.secret 2>/dev/null \
+              | grep -E "^eyJ"' --quiet 2>/dev/null \
+  > "$TOKEN_FILE"
+[[ -s "$TOKEN_FILE" ]] || fail "JWT issuance produced empty output"
+echo "  JWT issued ($(wc -c < "$TOKEN_FILE" | tr -d ' ') bytes)"
+
+# ---- 4. API answers --------------------------------------------------
+
+check "Authenticated API call returns JSON"
+RESPONSE="$(curl -sS --max-time 15 \
+  -H "Authorization: Bearer $(cat "$TOKEN_FILE")" \
+  "http://$SENTINEL_IP:8080/v1/containers" \
+  || fail "curl to http://$SENTINEL_IP:8080 failed — sentinel may still be initializing")"
+echo "$RESPONSE" | grep -q '"containers"' \
+  || fail "API responded but didn't contain a containers field; got: $RESPONSE"
+COUNT="$(echo "$RESPONSE" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("totalCount",0))' 2>/dev/null || echo "?")"
+echo "  API returned $COUNT container(s) — fresh cluster expected to be 0"
+ok
+
+# ---- summary ---------------------------------------------------------
+
+echo
+echo "All $CHECK_NUM checks passed. Cluster is ready for the demo flow."
+echo
+echo "Next: configure DNS (per README §'Without Cloud DNS' on GoDaddy /"
+echo "Cloudflare / Route 53), wire Claude Code with the JWT, and drive"
+echo "the demo prompt."

--- a/terraform/gce-demo/terraform.tfvars.example
+++ b/terraform/gce-demo/terraform.tfvars.example
@@ -1,0 +1,48 @@
+// Copy this file to terraform.tfvars (gitignored) and fill in real values.
+//
+//   cp terraform.tfvars.example terraform.tfvars
+//   $EDITOR terraform.tfvars
+//   terraform init && terraform apply
+
+// REQUIRED: GCP project to create resources in.
+project_id = "your-gcp-project-id"
+
+// REQUIRED: SSH public key for the admin user. The admin can SSH into
+// the sentinel to issue JWTs. Add multiple keys if a team is recording.
+admin_ssh_keys = {
+  admin = "ssh-ed25519 AAAAC3Nz... admin@example.com"
+}
+
+// REQUIRED: random JWT signing secret. Generate with:
+//   openssl rand -hex 32
+// Keep this secret — anyone who has it can mint admin tokens.
+jwt_secret = "REPLACE_ME_WITH_OPENSSL_RAND_HEX_32"
+
+// Optional: lock down SSH to your egress IP for the recording window.
+// "0.0.0.0/0" is fine for a quick test; tighter is better.
+allowed_ssh_sources = ["0.0.0.0/0"]
+
+// Optional: GCP region/zone. Defaults to us-central1 / us-central1-a.
+// Pick whatever's closest to where you'll record.
+// region = "us-central1"
+// zone   = "us-central1-a"
+
+// Optional but recommended: provision DNS via Cloud DNS so demo URLs
+// resolve out of the box. Leave blank to set DNS manually.
+//
+// dns_managed_zone_name is the *Terraform name* of the Cloud DNS zone
+// resource — if you created it via `gcloud dns managed-zones create
+// kafeido-app --dns-name=kafeido.app.`, the name is "kafeido-app".
+//
+// dns_zone_domain is the DNS name without the trailing dot.
+//
+// demo_subdomain is what gets prepended; the demo's exposed apps will
+// land at <app>.<demo_subdomain>.<dns_zone_domain>.
+//
+// dns_managed_zone_name = "kafeido-app"
+// dns_zone_domain       = "kafeido.app"
+// demo_subdomain        = "demo"
+
+// Optional: which release version of containarium to install. Update
+// when a new release ships and you want to re-record against it.
+// containarium_version = "0.16.4"

--- a/terraform/gce-demo/variables.tf
+++ b/terraform/gce-demo/variables.tf
@@ -1,0 +1,91 @@
+// Identity ------------------------------------------------------------
+
+variable "project_id" {
+  description = "GCP project ID. The cluster, DNS records, and IAM resources all live here."
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the spot VM and sentinel."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "GCP zone (single-AZ for the demo)."
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "instance_name" {
+  description = "Name prefix for the demo instances. The spot VM is <name>, the sentinel is <name>-sentinel."
+  type        = string
+  default     = "containarium-demo"
+}
+
+variable "machine_type" {
+  description = "GCE machine type for the spot backend VM. e2-medium is enough for the demo container plus Incus overhead."
+  type        = string
+  default     = "e2-medium"
+}
+
+// Versioning ----------------------------------------------------------
+
+variable "containarium_version" {
+  description = "Containarium version to install on the demo VM. Should match a tagged release at https://github.com/footprintai/Containarium/releases."
+  type        = string
+  default     = "0.16.4"
+}
+
+variable "containarium_binary_url" {
+  description = "Override the binary download URL. Empty means derive from containarium_version (the standard release URL pattern)."
+  type        = string
+  default     = ""
+}
+
+// Access --------------------------------------------------------------
+
+variable "admin_ssh_keys" {
+  description = "Map of admin username → SSH public key string. The admin can SSH into the sentinel for token issuance."
+  type        = map(string)
+}
+
+variable "allowed_ssh_sources" {
+  description = "CIDR blocks allowed to SSH to the sentinel on port 22. Restrict to your egress IP for a real demo; broad for a quick test."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "jwt_secret" {
+  description = "JWT signing secret used by the daemon. Anyone holding it can mint admin tokens, so generate a random one and don't commit it to public terraform.tfvars."
+  type        = string
+  sensitive   = true
+}
+
+// DNS -----------------------------------------------------------------
+
+variable "dns_managed_zone_name" {
+  description = "Cloud DNS managed-zone resource name (e.g. 'kafeido-app'). Empty disables DNS provisioning — set the *.<subdomain> A-record manually elsewhere in that case."
+  type        = string
+  default     = ""
+}
+
+variable "dns_zone_domain" {
+  description = "DNS zone's domain (e.g. 'kafeido.app'). Required only when dns_managed_zone_name is set."
+  type        = string
+  default     = ""
+}
+
+variable "demo_subdomain" {
+  description = "Subdomain for the demo deployment. The demo flow exposes apps at <whatever>.<demo_subdomain>.<dns_zone_domain>, e.g. blog.demo.kafeido.app."
+  type        = string
+  default     = "demo"
+}
+
+// Misc ----------------------------------------------------------------
+
+variable "labels" {
+  description = "Extra labels merged onto every resource."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Why

The demo recording will go further if the cluster behind it is *visible* — anyone who sees the video and thinks "I want to try that" can clone the repo and `terraform apply` to reach a working sandbox in 15 minutes.

Shifts the demo from "ephemeral cluster, recording-only" to "shipped artifact, self-documenting." The same config that drives the recording is the one OSS users get.

## What's in it

`terraform/gce-demo/` — the smallest realistic deployment that supports the agent-native flow (create → ssh → install → expose):

| Resource | Purpose |
|---|---|
| Sentinel VM (e2-micro, free tier) | sshpiper + Caddy; owns the public IP |
| Backend VM (e2-medium spot) | daemon + Incus; no external IP, Cloud NAT for egress |
| 100 GB persistent disk | container data survives spot preemption |
| Cloud DNS wildcard + apex A-records | optional; `*.demo.<your-zone>` → sentinel |
| JWT secret on the sentinel | so admin tokens can be issued post-apply |

**Cost: ~$25–35/mo while running.** `terraform destroy` tears it all down.

Files:

- `main.tf` — provider, containarium module, DNS records
- `variables.tf` — project, dns zone, admin keys, jwt_secret, version
- `outputs.tf` — sentinel_ip, demo_base_domain, plus a multiline `next_steps` that copy-pastes the post-apply flow (issue JWT, wire Claude Code, run the prompt)
- `terraform.tfvars.example` — template
- `README.md` — step-by-step walkthrough with cost table and troubleshooting
- `.gitignore` — state + non-example tfvars

## Why a separate directory (vs. another `terraform/gce/examples/*.tfvars`)

- **Separate state.** The dev cluster at `terraform/gce/` has its own long-lived state with backups; mixing demo state in there would pollute it.
- **Self-documenting.** Viewers landing here from the demo video see exactly the demo configuration without hunting through a generic dev directory.
- **Future demo-specific helpers** (DNS records, post-apply scripts) live here without affecting the production-leaning examples.

## Validated

- `terraform init -backend=false` clean
- `terraform fmt` clean
- `terraform validate` clean

(Live `terraform apply` requires real GCP credentials; that's the demo recording session itself.)

## Out of scope

- GCS state backend (matches the demo's local-state simplicity; production `terraform/gce/` shows the GCS pattern in `backend-prod.tf.example` if you want to copy it).
- Auto-issued JWT (we explicitly want the admin to SSH and mint one — leaving the JWT secret on disk to be machine-fetchable would be a worse default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)