### PR TITLE
fix(module): three startup-script bugs caught by gce-demo apply

### DIFF
--- a/terraform/modules/containarium/scripts/startup-spot.sh
+++ b/terraform/modules/containarium/scripts/startup-spot.sh
@@ -162,12 +162,16 @@ if [ "$USE_PERSISTENT_DISK" = "true" ]; then
     fi
 fi
 
-# Remove pre-installed Incus (if any) to avoid conflicts with Zabbly repo
-# Ubuntu 24.04 may have Incus 6.0.0 from default repos which conflicts
+# Remove pre-installed Incus (if any) to avoid conflicts with Zabbly repo.
+# Ubuntu 24.04 ships incus-tools 6.0.0 in the default repos which conflicts
+# with Zabbly's incus-base 6.19+. The previous detection regex
+# (`^ii.*incus `) only matched the exact `incus` binary, missing
+# default-installed packages like incus-tools / incus-client. Widened
+# to `^ii  incus` so any incus-* package triggers the cleanup.
 echo "==> Checking for pre-installed Incus..."
-if dpkg -l | grep -q "^ii.*incus " && ! grep -q zabbly /etc/apt/sources.list.d/*.list 2>/dev/null; then
-    echo "Removing pre-installed Incus (will reinstall from Zabbly)..."
-    DEBIAN_FRONTEND=noninteractive apt-get remove -y incus incus-client incus-tools 2>/dev/null || true
+if dpkg -l | grep -qE "^ii  incus" && ! grep -q zabbly /etc/apt/sources.list.d/*.list 2>/dev/null; then
+    echo "Removing pre-installed Incus packages (will reinstall from Zabbly)..."
+    DEBIAN_FRONTEND=noninteractive apt-get remove -y incus incus-base incus-client incus-tools 2>/dev/null || true
     echo "✓ Pre-installed Incus removed"
 fi
 
@@ -185,13 +189,23 @@ if [ ! -f /etc/apt/sources.list.d/zabbly-incus-stable.list ]; then
     echo "✓ Zabbly repository added"
 fi
 
-# Install or upgrade Incus
+# Install or upgrade Incus.
+#
+# Only request `incus` itself. Older versions of this script also asked
+# for `incus-tools` and `incus-client`, but those were the Ubuntu-style
+# names — the Zabbly 6.19+ repo subsumes them into `incus-base` and
+# the meta-package `incus`. Asking for `incus-tools` by name forces
+# apt to pull Ubuntu's 6.0.0-1ubuntu0.3 from the default repo, which
+# Breaks Zabbly's incus-base 6.19+ and produces:
+#   incus-base : Breaks: incus-tools but 6.0.0-1ubuntu0.3 is to be installed
+#   E: Unable to correct problems, you have held broken packages.
+# Just ask for `incus`; apt resolves the deps through Zabbly cleanly.
 if [ -n "$INCUS_VERSION" ]; then
     echo "Installing Incus version: $INCUS_VERSION"
-    DEBIAN_FRONTEND=noninteractive apt-get install -y incus="$INCUS_VERSION" incus-tools incus-client
+    DEBIAN_FRONTEND=noninteractive apt-get install -y incus="$INCUS_VERSION"
 else
     echo "Installing latest stable Incus (6.19+)..."
-    DEBIAN_FRONTEND=noninteractive apt-get install -y incus incus-tools incus-client
+    DEBIAN_FRONTEND=noninteractive apt-get install -y incus
 fi
 
 # Verify Incus installation and version
@@ -342,6 +356,22 @@ elif [ ! -f /var/lib/incus/.initialized ]; then
     # ==========================================================================
     # Initialize with ZFS storage if using persistent disk
     if [ "$USE_PERSISTENT_DISK" = "true" ] && zpool list incus-pool &>/dev/null; then
+        # Clean up any stale incus-pool/containers dataset from a previous
+        # failed init. Without this, `incus admin init --preseed` fails:
+        #   Error: Failed to create storage pool "default": Provided ZFS pool
+        #   (or dataset) isn't empty
+        # when a prior install crashed after creating the dataset but before
+        # finishing init (e.g., apt failure on a different package). We're
+        # safe to destroy here because the recovery branch above already ran
+        # — if real container data existed, ZFS_HAS_DATA would be true and
+        # we'd be in that branch, not here.
+        if zfs list incus-pool/containers &>/dev/null; then
+            echo "==> Found stale incus-pool/containers from a failed prior init; cleaning up..."
+            zfs destroy -r incus-pool/containers || {
+                echo "⚠ Could not destroy stale dataset; init will likely fail"
+            }
+        fi
+
         # Initialize with ZFS storage pool
         cat <<EOF | incus admin init --preseed
 config: {}


### PR DESCRIPTION
## Why

Live-applying the new `terraform/gce-demo/` against footprintai-dev surfaced three real bugs in the shared module's startup script. All affect fresh provisions on Ubuntu 24.04 with the current Zabbly Incus repo state; only the third has been hit before in production because long-lived deployments rarely re-bootstrap from scratch.

This is exactly what the gce-demo smoke test was supposed to catch — and it did.

## What's broken (and now fixed)

### 1. dpkg detection regex missed Ubuntu's pre-installed `incus-tools`

The "remove pre-installed Incus" path keyed on:

```bash
dpkg -l | grep "^ii.*incus "
```

Trailing space → only matched the bare `incus` package. Ubuntu 24.04 ships `incus-tools` 6.0.0 (without `incus`), so detection silently skipped, then the Zabbly install failed later with a `Breaks` conflict.

Widened to `^ii  incus` so any `incus-*` variant triggers cleanup.

### 2. apt asked for `incus-tools` and `incus-client` by name

Zabbly's 6.19+ packages refactored those into `incus-base` and the meta-package `incus`. Asking for `incus-tools` by name forces apt to pull Ubuntu's 6.0.0-1ubuntu0.3 from the default repo, which Breaks Zabbly's `incus-base` 6.19+:

```
incus-base : Breaks: incus-tools but 6.0.0-1ubuntu0.3 is to be installed
E: Unable to correct problems, you have held broken packages.
```

Now just requests `incus`; apt resolves the deps through Zabbly cleanly. **Verified live**: Incus 7.0.0 installs without conflict on 24.04 LTS.

### 3. Stale ZFS dataset from a failed prior init blocked re-runs

After bug #1 or #2 caused a partial install, the persistent disk's `incus-pool/containers` existed but was empty. The existing `ZFS_HAS_DATA` detection looks for `incus-pool/containers/containers` *subdatasets*, so the empty parent slipped through. The script then took the fresh-install branch and `incus admin init --preseed` failed:

```
Error: Failed to create storage pool "default":
Provided ZFS pool (or dataset) isn't empty
```

Operators retrying after any earlier failure would hit this indefinitely without manual `zfs destroy`. **The user explicitly flagged this** — it's worse than just blocking the demo: any fresh-install user who hits a transient bug, then re-applies, gets stuck.

Fix: in the fresh-install branch, before `incus admin init`, destroy any stale `incus-pool/containers`. Safe to do that here because the recovery branch above already ran first — real container data would have routed us through that branch, not this one.

## Production impact

- Production deployments are long-lived; spot recovery hits the recovery branch (line 290), not the fresh-install branch. Zero impact.
- Future production re-bootstraps benefit from #1, #2 if they're on Ubuntu 24.04 with Incus 7.x. No regressions for current Ubuntu/Zabbly state.
- #3 is purely additive — only fires in the fresh-install branch when a stale dataset is detected.

## Test plan

- [x] `bash -n` syntax check
- [x] Lived through bugs #1 and #2 in 4 separate `terraform apply` cycles against footprintai-dev (each surfaced a different bug)
- [ ] Will validate end-to-end against a fresh apply once this lands (then comes the gce-demo PR's apply attempt — same path, should now go green on first try)

## Out of scope

- Cloud NAT setup for the production-style `spot_vm_external_ip = false` path. The gce-demo PR (#127) chose to give the spot VM a public IP for simplicity rather than provision NAT — that's a config decision, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)