### PR TITLE
fix(gce-demo): three live-test fixes that didn't make #127

### DIFF
--- a/terraform/gce-demo/main.tf
+++ b/terraform/gce-demo/main.tf
@@ -31,6 +31,15 @@ provider "google" {
   zone    = var.zone
 }
 
+// Derive the GitHub release URL when an explicit override isn't given.
+// The startup script otherwise has no source for the binary on a fresh
+// install (no file provisioner, no sentinel binary server set up yet).
+locals {
+  containarium_binary_url = var.containarium_binary_url != "" ? var.containarium_binary_url : (
+    "https://github.com/footprintai/Containarium/releases/download/v${var.containarium_version}/containarium-linux-amd64"
+  )
+}
+
 module "containarium" {
   source = "../modules/containarium"
 
@@ -61,16 +70,20 @@ module "containarium" {
   // Daemon
   enable_containarium_daemon = true
   containarium_version       = var.containarium_version
-  containarium_binary_url    = var.containarium_binary_url
+  containarium_binary_url    = local.containarium_binary_url
 
   // Access
   admin_ssh_keys      = var.admin_ssh_keys
   allowed_ssh_sources = var.allowed_ssh_sources
   jwt_secret          = var.jwt_secret
 
-  // Networking — no external IP on the spot VM by default; Cloud NAT
-  // handles outbound. The sentinel owns the external IP and DNS A-record.
-  spot_vm_external_ip = false
+  // Networking — for the demo we give the backend a public IP so apt
+  // can reach Ubuntu repos and the daemon binary download works without
+  // provisioning Cloud NAT separately. Production deploys typically run
+  // with spot_vm_external_ip=false + a separately-provisioned Cloud NAT
+  // (see footprintai-prod), but that's out of scope for a 15-min
+  // self-contained demo apply. ~$3/month extra for the static IP.
+  spot_vm_external_ip = true
   enable_iap_firewall = true
 
   labels = merge({

--- a/terraform/gce-demo/variables.tf
+++ b/terraform/gce-demo/variables.tf
@@ -24,9 +24,9 @@ variable "instance_name" {
 }
 
 variable "machine_type" {
-  description = "GCE machine type for the spot backend VM. e2-medium is enough for the demo container plus Incus overhead."
+  description = "GCE machine type for the spot backend VM. e2-standard-2 (2 vCPU, 8 GB) is enough for the demo container plus Incus overhead. Note: the upstream module's regex rejects shared-core types (e2-medium / e2-small / e2-micro)."
   type        = string
-  default     = "e2-medium"
+  default     = "e2-standard-2"
 }
 
 // Versioning ----------------------------------------------------------


### PR DESCRIPTION
Companion to #128. During the live `terraform apply` against footprintai-dev that surfaced #128's module bugs, three demo-side fixes were also needed but missed #127's push. Documenting and landing them here.

1. **`machine_type` default**: `e2-medium` → `e2-standard-2`. The shared module's regex rejects shared-core types; e2-standard-2 is the smallest allowed (~$15/mo spot).
2. **Auto-derive `containarium_binary_url`**: pulls the GitHub release URL from `var.containarium_version` when no override is given. Without this, the startup script bails with "⚠ No Containarium binary source available."
3. **`spot_vm_external_ip`**: `false` → `true`. Production-style "no external IP + Cloud NAT" doesn't work in a self-contained demo because no NAT is provisioned. Apt fails to reach Ubuntu repos otherwise. Costs ~$3/mo for the static IP.

After #128 + this PR merges, the gce-demo apply path should complete end-to-end on a fresh project. Will validate with another live apply against footprintai-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)