### PR TITLE
feat(mcp): ephemeral SSH keypair for create_container + tool description workflow hints

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -9,11 +9,20 @@ import (
 	"time"
 )
 
-// Client is a REST API client for Containarium
+// Client is a REST API client for Containarium. Carries a small amount
+// of non-HTTP deployment metadata (SentinelHost) so tool handlers that
+// need it can read it without a separate config plumbing layer.
 type Client struct {
 	baseURL    string
 	jwtToken   string
 	httpClient *http.Client
+
+	// SentinelHost, when set, is the public SSH endpoint for this
+	// deployment (e.g. "sentinel.example.com" or "34.42.156.100").
+	// create_container's response uses it to construct a complete
+	// ready-to-paste ssh command. Empty means the response falls
+	// back to a placeholder.
+	SentinelHost string
 }
 
 // NewClient creates a new Containarium REST API client

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -14,6 +14,14 @@ type Config struct {
 	// JWTToken is the JWT token for authentication
 	JWTToken string
 
+	// SentinelHost is the public SSH endpoint for the deployment.
+	// When set, create_container's response includes a ready-to-paste
+	// `ssh -i <key> <user>@<sentinel-host>` command — agents don't have
+	// to figure out hostnames or modify ~/.ssh/config. Empty means
+	// the response falls back to a placeholder.
+	// Example: sentinel.example.com or 34.42.156.100
+	SentinelHost string
+
 	// Debug enables debug logging
 	Debug bool
 }
@@ -26,8 +34,9 @@ func LoadConfig() *Config {
 	}
 
 	return &Config{
-		ServerURL: os.Getenv("CONTAINARIUM_SERVER_URL"),
-		JWTToken:  os.Getenv("CONTAINARIUM_JWT_TOKEN"),
-		Debug:     debug,
+		ServerURL:    os.Getenv("CONTAINARIUM_SERVER_URL"),
+		JWTToken:     os.Getenv("CONTAINARIUM_JWT_TOKEN"),
+		SentinelHost: os.Getenv("CONTAINARIUM_SENTINEL_HOST"),
+		Debug:        debug,
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -20,6 +20,7 @@ type Server struct {
 // NewServer creates a new MCP server
 func NewServer(config *Config) (*Server, error) {
 	client := NewClient(config.ServerURL, config.JWTToken)
+	client.SentinelHost = config.SentinelHost
 
 	server := &Server{
 		config: config,

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -21,7 +21,7 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	assert.Len(t, server.tools, 11, "Should have 11 tools registered")
+	assert.Len(t, server.tools, 12, "Should have 12 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -125,7 +125,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	assert.Len(t, tools, 11)
+	assert.Len(t, tools, 12)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -310,9 +310,12 @@ func TestToolDescriptions(t *testing.T) {
 			assert.NotEmpty(t, tool.Description, "Tool description should not be empty")
 			assert.NotNil(t, tool.Handler, "Tool handler should not be nil")
 
-			// Description should be reasonable length
+			// Description should be reasonable length. Generous upper
+			// bound — multi-step workflow descriptions (see
+			// create_container, expose_port) are valuable for agents
+			// and run >500 chars by design.
 			assert.Greater(t, len(tool.Description), 10, "Description should be descriptive")
-			assert.Less(t, len(tool.Description), 500, "Description should be concise")
+			assert.Less(t, len(tool.Description), 1500, "Description should be concise")
 		})
 	}
 }

--- a/internal/mcp/sshkey.go
+++ b/internal/mcp/sshkey.go
@@ -1,0 +1,47 @@
+package mcp
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// generateEphemeralSSHKey creates an ed25519 keypair client-side and
+// returns the OpenSSH-formatted public key (authorized_keys line) plus
+// the OpenSSH PEM-encoded private key.
+//
+// Generating on the MCP client side rather than server-side means the
+// private key never traverses the network — it stays on the operator's
+// laptop where it was created. The daemon only ever sees the public key
+// (via the standard ssh_keys field on CreateContainerRequest), so the
+// rest of the platform doesn't need to know about ephemeral keys at all.
+//
+// Used by create_container when the caller doesn't pass ssh_keys: a
+// fresh per-container keypair is generated, the public half goes into
+// the container's authorized_keys, and the private half is returned to
+// the agent with instructions to save it.
+func generateEphemeralSSHKey(label string) (publicKeyAuthorizedKeys string, privateKeyPEM []byte, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", nil, fmt.Errorf("generate ed25519: %w", err)
+	}
+
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return "", nil, fmt.Errorf("wrap public key: %w", err)
+	}
+	publicKeyAuthorizedKeys = string(ssh.MarshalAuthorizedKey(sshPub))
+
+	// MarshalPrivateKey returns a *pem.Block. pem.EncodeToMemory turns
+	// it into the file-on-disk form (`-----BEGIN OPENSSH PRIVATE KEY-----...`).
+	pemBlock, err := ssh.MarshalPrivateKey(priv, label)
+	if err != nil {
+		return "", nil, fmt.Errorf("marshal private key: %w", err)
+	}
+	privateKeyPEM = pem.EncodeToMemory(pemBlock)
+
+	return publicKeyAuthorizedKeys, privateKeyPEM, nil
+}

--- a/internal/mcp/sshkey_test.go
+++ b/internal/mcp/sshkey_test.go
@@ -1,0 +1,56 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestGenerateEphemeralSSHKey_ProducesUsablePair(t *testing.T) {
+	pubOpenSSH, privPEM, err := generateEphemeralSSHKey("test-label")
+	if err != nil {
+		t.Fatalf("generateEphemeralSSHKey: %v", err)
+	}
+
+	// Public key should look like an authorized_keys line: "ssh-ed25519 BASE64 [comment]\n"
+	if !strings.HasPrefix(pubOpenSSH, "ssh-ed25519 ") {
+		t.Errorf("public key doesn't start with ssh-ed25519: %q", pubOpenSSH)
+	}
+	if !strings.HasSuffix(pubOpenSSH, "\n") {
+		t.Errorf("public key should end with a newline so it appends cleanly to authorized_keys")
+	}
+
+	// Private key should be OpenSSH PEM-encoded.
+	if !strings.Contains(string(privPEM), "-----BEGIN OPENSSH PRIVATE KEY-----") {
+		t.Errorf("private key isn't OpenSSH PEM:\n%s", string(privPEM))
+	}
+
+	// Round-trip: the generated public key should parse back via ssh.ParseAuthorizedKey.
+	parsedPub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(pubOpenSSH))
+	if err != nil {
+		t.Fatalf("ParseAuthorizedKey on our own output: %v", err)
+	}
+	if parsedPub.Type() != ssh.KeyAlgoED25519 {
+		t.Errorf("expected ed25519 key, got %s", parsedPub.Type())
+	}
+
+	// And the private key should parse via ssh.ParseRawPrivateKey.
+	if _, err := ssh.ParseRawPrivateKey(privPEM); err != nil {
+		t.Fatalf("ParseRawPrivateKey on our own output: %v", err)
+	}
+}
+
+func TestGenerateEphemeralSSHKey_UniqueEachCall(t *testing.T) {
+	a, _, err := generateEphemeralSSHKey("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _, err := generateEphemeralSSHKey("b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Errorf("two separate calls produced identical keys — entropy issue?")
+	}
+}

--- a/internal/mcp/sync_ssh_config.go
+++ b/internal/mcp/sync_ssh_config.go
@@ -1,0 +1,88 @@
+package mcp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/footprintai/containarium/internal/incus"
+	"github.com/footprintai/containarium/internal/sshconfig"
+)
+
+// handleSyncSSHConfig is the agent-native version of `containarium
+// ssh-config sync`. It lets the agent wire SSH aliases without needing
+// the CLI binary installed on the operator's machine. Same internal
+// generator, different invocation surface — preserves the CLI-first
+// principle (one Go function, two surfaces) from CLAUDE.md.
+func handleSyncSSHConfig(client *Client, args map[string]interface{}) (string, error) {
+	// Resolve output path. Default lives under $HOME so it works the
+	// same way the CLI version does — both produce a file that the
+	// user's ~/.ssh/config can Include.
+	out := getStringArg(args, "out", "")
+	if out == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir: %w", err)
+		}
+		out = filepath.Join(home, ".containarium", "ssh_config")
+	}
+
+	containers, err := fetchContainersForSSHConfig(client)
+	if err != nil {
+		return "", err
+	}
+
+	opts := sshconfig.Options{
+		Sentinel:       getStringArg(args, "sentinel", ""),
+		IdentityFile:   getStringArg(args, "identity_file", ""),
+		IncludeStopped: getBoolArg(args, "include_stopped", false),
+	}
+	gen := sshconfig.Generate(containers, opts)
+
+	if err := os.MkdirAll(filepath.Dir(out), 0o700); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", filepath.Dir(out), err)
+	}
+	// 0600 — the file lists every host the user can SSH to. Sensitive
+	// in the same sense their ssh_config is.
+	if err := os.WriteFile(out, []byte(gen.Content), 0o600); err != nil {
+		return "", fmt.Errorf("write %s: %w", out, err)
+	}
+
+	result := fmt.Sprintf(
+		"✅ Wrote %s\n   %d host(s) generated, %d skipped (stopped), %d skipped (no address)\n",
+		out, gen.Count, gen.SkippedStopped, gen.SkippedNoAddr,
+	)
+	result += "\nIf this is the first run, add one line to your ~/.ssh/config:\n"
+	result += fmt.Sprintf("    Include %s\n", out)
+	result += "\nThen `ssh <container-name>` reaches the container."
+	return result, nil
+}
+
+// fetchContainersForSSHConfig pulls the container list via the MCP
+// client and translates from mcp.Container to incus.ContainerInfo —
+// the shape the shared sshconfig generator expects. Same logic the
+// CLI uses; just a different list source.
+func fetchContainersForSSHConfig(client *Client) ([]incus.ContainerInfo, error) {
+	resp, err := client.ListContainers()
+	if err != nil {
+		return nil, fmt.Errorf("list containers: %w", err)
+	}
+	out := make([]incus.ContainerInfo, 0, len(resp.Containers))
+	for _, c := range resp.Containers {
+		info := incus.ContainerInfo{
+			Name:  c.Name,
+			State: c.State,
+		}
+		if c.Network != nil {
+			info.IPAddress = c.Network.IPAddress
+		}
+		if c.Resources != nil {
+			info.CPU = c.Resources.CPU
+			info.Memory = c.Resources.Memory
+			info.Disk = c.Resources.Disk
+		}
+		info.Labels = c.Labels
+		out = append(out, info)
+	}
+	return out, nil
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -27,16 +27,20 @@ func (s *Server) registerTools() {
 			Name: "create_container",
 			Description: "Create a new LXC container under a username. Returns the container's " +
 				"name, IP address, and resources.\n\n" +
-				"IMPORTANT — pass `ssh_keys` containing the operator's public SSH key (read " +
-				"from `~/.ssh/id_ed25519.pub` or similar). Without it the new container has " +
-				"no SSH access and you won't be able to install software inside.\n\n" +
+				"SSH key handling: if you OMIT `ssh_keys`, an ephemeral ed25519 keypair is " +
+				"generated client-side. The public half is installed on the container; the " +
+				"private half comes back in this tool's response. Save it to " +
+				"`~/.containarium/keys/<username>` with mode 0600 — that's the standard " +
+				"path expected by the rest of the workflow. If you pass `ssh_keys`, those " +
+				"are used as-is and no ephemeral key is generated (useful when reusing an " +
+				"operator's existing key for SSH alias convenience).\n\n" +
 				"AFTER creation, to operate inside the container:\n" +
-				"  1. Use the Bash tool to wire SSH (one-time per session):\n" +
-				"     containarium ssh-config sync --server $CONTAINARIUM_SERVER_URL --token $CONTAINARIUM_JWT_TOKEN\n" +
-				"  2. Add `Include ~/.containarium/ssh_config` to `~/.ssh/config` if not present.\n" +
-				"  3. `ssh <username>` reaches the container via the sentinel's sshpiper.\n" +
+				"  1. Save the ephemeral private key (if generated) to ~/.containarium/keys/<name>.\n" +
+				"  2. Run `containarium ssh-config sync --server $CONTAINARIUM_SERVER_URL --token $CONTAINARIUM_JWT_TOKEN` to wire the SSH alias.\n" +
+				"  3. Add `Include ~/.containarium/ssh_config` to `~/.ssh/config` if not present.\n" +
+				"  4. `ssh -i ~/.containarium/keys/<name> <name>` reaches the container.\n" +
 				"     Use it via Bash to apt install, write files, start services.\n" +
-				"  4. Call expose_port to make a container port reachable on a public hostname.",
+				"  5. Call expose_port to make a container port reachable on a public hostname.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
@@ -276,13 +280,28 @@ func handleCreateContainer(client *Client, args map[string]interface{}) (string,
 		GPU:          getStringArg(args, "gpu", ""),
 	}
 
-	// Handle SSH keys
-	if sshKeys, ok := args["ssh_keys"].([]interface{}); ok {
+	// Handle SSH keys. If the caller passes ssh_keys explicitly we use
+	// them as-is. If they don't, we generate an ephemeral ed25519
+	// keypair CLIENT-SIDE (the private key never travels the network)
+	// and return it in the response. This is the common case for
+	// agent-driven workflows: the agent doesn't have to know about
+	// local file paths or the operator's existing keys.
+	var ephemeralPrivKey []byte
+	if sshKeys, ok := args["ssh_keys"].([]interface{}); ok && len(sshKeys) > 0 {
 		for _, key := range sshKeys {
 			if keyStr, ok := key.(string); ok {
 				req.SSHKeys = append(req.SSHKeys, keyStr)
 			}
 		}
+	} else {
+		pubKey, privKey, err := generateEphemeralSSHKey(
+			fmt.Sprintf("containarium-%s ephemeral key", username),
+		)
+		if err != nil {
+			return "", fmt.Errorf("generate ephemeral ssh key: %w", err)
+		}
+		req.SSHKeys = []string{pubKey}
+		ephemeralPrivKey = privKey
 	}
 
 	resp, err := client.CreateContainer(req)
@@ -303,6 +322,20 @@ func handleCreateContainer(client *Client, args map[string]interface{}) (string,
 		result += fmt.Sprintf("Disk: %s\n", resp.Container.Resources.Disk)
 	}
 	result += fmt.Sprintf("\n%s", resp.Message)
+
+	if ephemeralPrivKey != nil {
+		result += "\n\n--- EPHEMERAL SSH PRIVATE KEY ---\n"
+		result += "Caller did not provide ssh_keys, so an ed25519 keypair was\n"
+		result += "generated locally. The public half is already on the container;\n"
+		result += "save the private half below to a file with mode 0600 and use it\n"
+		result += "to SSH in.\n\n"
+		result += "Suggested save path:\n"
+		result += fmt.Sprintf("  ~/.containarium/keys/%s\n\n", resp.Container.Username)
+		result += "Then to SSH in:\n"
+		result += fmt.Sprintf("  ssh -i ~/.containarium/keys/%s %s@<sentinel-host>\n", resp.Container.Username, resp.Container.Username)
+		result += "(or run `containarium ssh-config sync` and `ssh " + resp.Container.Username + "` directly)\n\n"
+		result += string(ephemeralPrivKey)
+	}
 
 	return result, nil
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -34,16 +34,17 @@ func (s *Server) registerTools() {
 				"path expected by the rest of the workflow. If you pass `ssh_keys`, those " +
 				"are used as-is and no ephemeral key is generated (useful when reusing an " +
 				"operator's existing key for SSH alias convenience).\n\n" +
-				"AFTER creation, to operate inside the container:\n" +
+				"AFTER creation, to operate inside the container (simplest path):\n" +
 				"  1. Save the ephemeral private key (if generated) via Bash to\n" +
 				"     ~/.containarium/keys/<name> with mode 0600.\n" +
-				"  2. Call the `sync_ssh_config` MCP tool to wire the SSH alias.\n" +
-				"     Pass identity_file=~/.containarium/keys/<name> so ssh uses the new key.\n" +
-				"  3. Add `Include ~/.containarium/ssh_config` to ~/.ssh/config once per\n" +
-				"     machine (one-time operator step; agents should remind the user).\n" +
-				"  4. `ssh <name>` from Bash reaches the container. Use it to apt install,\n" +
-				"     write files, start services.\n" +
-				"  5. Call `expose_port` to make a container port reachable on a public hostname.",
+				"  2. The tool response includes a ready-to-paste ssh command:\n" +
+				"       ssh -i ~/.containarium/keys/<name> <name>@<sentinel-host>\n" +
+				"     Use Bash to run it. No edits to ~/.ssh/config required.\n" +
+				"  3. Inside the container, apt install / write files / start services.\n" +
+				"  4. Call `expose_port` to make a container port reachable on a public hostname.\n\n" +
+				"Optional convenience (skip if you don't want to touch ~/.ssh/config):\n" +
+				"  Call the `sync_ssh_config` MCP tool to generate a self-contained\n" +
+				"  ssh_config file and Include line. After that, `ssh <name>` works directly.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
@@ -373,8 +374,16 @@ func handleCreateContainer(client *Client, args map[string]interface{}) (string,
 		result += "Suggested save path:\n"
 		result += fmt.Sprintf("  ~/.containarium/keys/%s\n\n", resp.Container.Username)
 		result += "Then to SSH in:\n"
-		result += fmt.Sprintf("  ssh -i ~/.containarium/keys/%s %s@<sentinel-host>\n", resp.Container.Username, resp.Container.Username)
-		result += "(or run `containarium ssh-config sync` and `ssh " + resp.Container.Username + "` directly)\n\n"
+		sentinelHost := client.SentinelHost
+		if sentinelHost == "" {
+			sentinelHost = "<sentinel-host>"
+		}
+		result += fmt.Sprintf("  ssh -i ~/.containarium/keys/%s %s@%s\n\n",
+			resp.Container.Username, resp.Container.Username, sentinelHost)
+		if client.SentinelHost == "" {
+			result += "(Sentinel host not configured — set CONTAINARIUM_SENTINEL_HOST in the\n"
+			result += "MCP server's env, or call sync_ssh_config for an alias-based setup.)\n\n"
+		}
 		result += string(ephemeralPrivKey)
 	}
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -35,12 +35,15 @@ func (s *Server) registerTools() {
 				"are used as-is and no ephemeral key is generated (useful when reusing an " +
 				"operator's existing key for SSH alias convenience).\n\n" +
 				"AFTER creation, to operate inside the container:\n" +
-				"  1. Save the ephemeral private key (if generated) to ~/.containarium/keys/<name>.\n" +
-				"  2. Run `containarium ssh-config sync --server $CONTAINARIUM_SERVER_URL --token $CONTAINARIUM_JWT_TOKEN` to wire the SSH alias.\n" +
-				"  3. Add `Include ~/.containarium/ssh_config` to `~/.ssh/config` if not present.\n" +
-				"  4. `ssh -i ~/.containarium/keys/<name> <name>` reaches the container.\n" +
-				"     Use it via Bash to apt install, write files, start services.\n" +
-				"  5. Call expose_port to make a container port reachable on a public hostname.",
+				"  1. Save the ephemeral private key (if generated) via Bash to\n" +
+				"     ~/.containarium/keys/<name> with mode 0600.\n" +
+				"  2. Call the `sync_ssh_config` MCP tool to wire the SSH alias.\n" +
+				"     Pass identity_file=~/.containarium/keys/<name> so ssh uses the new key.\n" +
+				"  3. Add `Include ~/.containarium/ssh_config` to ~/.ssh/config once per\n" +
+				"     machine (one-time operator step; agents should remind the user).\n" +
+				"  4. `ssh <name>` from Bash reaches the container. Use it to apt install,\n" +
+				"     write files, start services.\n" +
+				"  5. Call `expose_port` to make a container port reachable on a public hostname.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
@@ -220,6 +223,44 @@ func (s *Server) registerTools() {
 				"required": []string{"id"},
 			},
 			Handler: handleGetBackend,
+		},
+		{
+			Name: "sync_ssh_config",
+			Description: "Generate a self-contained ssh_config covering every reachable container " +
+				"and write it to ~/.containarium/ssh_config. After this call, `ssh <username>` " +
+				"works from any shell — no CLI install required.\n\n" +
+				"Call this right after create_container so the new container's SSH alias is " +
+				"available immediately. The first time you use it, you also need to add a single " +
+				"line to your ~/.ssh/config to wire it in:\n" +
+				"  Include ~/.containarium/ssh_config\n" +
+				"That's a one-time setup; subsequent sync calls just refresh the file.\n\n" +
+				"Two modes:\n" +
+				"  - Direct (default): each container's IP is the SSH HostName. Works when the " +
+				"    container's LAN IP is reachable from where you're running ssh.\n" +
+				"  - Via sentinel (set `sentinel`): all containers route through the sentinel " +
+				"    via sshpiper. Use this when containers don't have public IPs.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"sentinel": map[string]interface{}{
+						"type":        "string",
+						"description": "Sentinel SSH endpoint (e.g. sentinel.example.com or sentinel.example.com:2222). Empty = direct mode.",
+					},
+					"identity_file": map[string]interface{}{
+						"type":        "string",
+						"description": "IdentityFile path to render in every Host block. For ephemeral-keypair containers, agents typically pass ~/.containarium/keys/<username>.",
+					},
+					"include_stopped": map[string]interface{}{
+						"type":        "boolean",
+						"description": "Include stopped containers in the config. Default false (only running containers).",
+					},
+					"out": map[string]interface{}{
+						"type":        "string",
+						"description": "Output path override. Default: ~/.containarium/ssh_config.",
+					},
+				},
+			},
+			Handler: handleSyncSSHConfig,
 		},
 		{
 			Name: "expose_port",

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -24,8 +24,19 @@ type ToolHandler func(client *Client, args map[string]interface{}) (string, erro
 func (s *Server) registerTools() {
 	s.tools = []Tool{
 		{
-			Name:        "create_container",
-			Description: "Create a new LXC container for a user with specified resources and SSH keys",
+			Name: "create_container",
+			Description: "Create a new LXC container under a username. Returns the container's " +
+				"name, IP address, and resources.\n\n" +
+				"IMPORTANT — pass `ssh_keys` containing the operator's public SSH key (read " +
+				"from `~/.ssh/id_ed25519.pub` or similar). Without it the new container has " +
+				"no SSH access and you won't be able to install software inside.\n\n" +
+				"AFTER creation, to operate inside the container:\n" +
+				"  1. Use the Bash tool to wire SSH (one-time per session):\n" +
+				"     containarium ssh-config sync --server $CONTAINARIUM_SERVER_URL --token $CONTAINARIUM_JWT_TOKEN\n" +
+				"  2. Add `Include ~/.containarium/ssh_config` to `~/.ssh/config` if not present.\n" +
+				"  3. `ssh <username>` reaches the container via the sentinel's sshpiper.\n" +
+				"     Use it via Bash to apt install, write files, start services.\n" +
+				"  4. Call expose_port to make a container port reachable on a public hostname.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
@@ -73,8 +84,10 @@ func (s *Server) registerTools() {
 			Handler: handleCreateContainer,
 		},
 		{
-			Name:        "list_containers",
-			Description: "List all containers with their status and resource usage",
+			Name: "list_containers",
+			Description: "List all containers with name, username, state, IP, and resources. " +
+				"Useful as a first step (\"what's already running?\") and after create_container " +
+				"to confirm the new container's IP. Read-only — no side effects.",
 			InputSchema: map[string]interface{}{
 				"type":       "object",
 				"properties": map[string]interface{}{},
@@ -208,9 +221,14 @@ func (s *Server) registerTools() {
 			Name: "expose_port",
 			Description: "Expose a container's port on a public hostname. Resolves the " +
 				"container's IP, then registers a domain → container:port route in the " +
-				"sentinel reverse proxy. After this completes, https://<domain>/ " +
-				"reaches the container's port. Use for the 'make it online' demo step " +
-				"after the agent has installed something listening inside the box.",
+				"sentinel reverse proxy. After this completes, https://<domain>/ reaches " +
+				"the container's port (the sentinel handles TLS via automatic ACME).\n\n" +
+				"This is typically the LAST step of a deploy flow:\n" +
+				"  create_container → ssh in via Bash → install/configure service → expose_port → curl the URL.\n\n" +
+				"Make sure DNS for <domain> already points at the sentinel (a wildcard A " +
+				"record for `*.<your-subdomain>.<your-zone>` covers all the apps you'll " +
+				"expose during a session). The agent doesn't have to wait for DNS; that's " +
+				"a one-time operator setup.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -370,9 +370,13 @@ func TestToolDescriptionQuality(t *testing.T) {
 			// Description should be non-empty
 			assert.NotEmpty(t, desc)
 
-			// Description should be reasonable length
+			// Lower bound catches "TODO"-style placeholders; upper bound
+			// catches runaway formatting. Rich descriptions with multi-step
+			// workflows (see create_container, expose_port) are valuable
+			// for agents to learn affordances from the tool list itself —
+			// so the upper bound is generous.
 			assert.GreaterOrEqual(t, len(desc), 20, "Description too short")
-			assert.LessOrEqual(t, len(desc), 500, "Description too long")
+			assert.LessOrEqual(t, len(desc), 1500, "Description too long")
 
 			// Description should not contain TODO or placeholders
 			assert.NotContains(t, desc, "TODO")


### PR DESCRIPTION
## Why

Dropping `Spin up a sandbox called 'demo-blog', serve a hello-world page with basic auth on port 80, expose it at blog.demo.kafeido.app` on the agent during demo prep, it stalled after `create_container` with:

> *"I need a way to install nginx inside. The MCP only exposes lifecycle + routing — actual install needs SSH."*

Two root causes:

1. **Workflow guidance was scattered** (CLAUDE.md, README, operator's head) but not in the place agents read every session: tool descriptions.
2. **The agent had no clean path to ssh into the new container** — needed to read the operator's `~/.ssh/id_ed25519.pub` from disk and pass it as `ssh_keys`, which is awkward.

## What's in it (two commits)

### 1. Enriched tool descriptions

- **`create_container`**: now spells out the full SSH-wiring workflow (sync, Include directive, ssh-in via Bash) and explains the ssh_keys behavior.
- **`list_containers`**: clarifies it's read-only and useful as a first step.
- **`expose_port`**: explicit "this is the LAST step" framing + DNS reminder.

Test cap on description length bumped 500 → 1500 chars.

### 2. Ephemeral SSH keypair when `ssh_keys` is omitted

The MCP server now generates an ed25519 keypair **client-side** when the caller doesn't pass `ssh_keys`. The public half goes into the standard request field; the private half is returned in the tool response with save-to-disk + ssh-in instructions.

**Security win**: private key never traverses the network. Daemon only sees the public key.

**Each container gets its own keypair**: revocation is per-container; destroying the container discards the key naturally.

Tests round-trip the generated key through `ssh.ParseAuthorizedKey` and `ssh.ParseRawPrivateKey`, plus a uniqueness check.

## After this lands

The same prompt that stalled before should now complete:

1. Agent calls `create_container demo-blog` (no ssh_keys) → response includes private key + save instructions
2. Agent uses Bash to save key to `~/.containarium/keys/demo-blog` chmod 600
3. Agent: `containarium ssh-config sync` to wire the alias
4. Agent: `ssh demo-blog 'apt install caddy && ... && systemctl start caddy'`
5. Agent calls `expose_port`
6. `curl https://blog.demo.kafeido.app` → hello with basic auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)