### PR TITLE
fix(demo): unblock SSH with IdentitiesOnly, failtoban tuning, shell wrapper install

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -315,7 +315,7 @@ func TestToolDescriptions(t *testing.T) {
 			// create_container, expose_port) are valuable for agents
 			// and run >500 chars by design.
 			assert.Greater(t, len(tool.Description), 10, "Description should be descriptive")
-			assert.Less(t, len(tool.Description), 1500, "Description should be concise")
+			assert.Less(t, len(tool.Description), 2000, "Description should be concise")
 		})
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/footprintai/containarium/internal/expose"
+	"github.com/footprintai/containarium/pkg/core/expose"
 )
 
 // Tool represents an MCP tool (function)
@@ -38,8 +38,13 @@ func (s *Server) registerTools() {
 				"  1. Save the ephemeral private key (if generated) via Bash to\n" +
 				"     ~/.containarium/keys/<name> with mode 0600.\n" +
 				"  2. The tool response includes a ready-to-paste ssh command:\n" +
-				"       ssh -i ~/.containarium/keys/<name> <name>@<sentinel-host>\n" +
+				"       ssh -i ~/.containarium/keys/<name> \\\n" +
+				"           -o IdentitiesOnly=yes -o PreferredAuthentications=publickey \\\n" +
+				"           <name>@<sentinel-host>\n" +
 				"     Use Bash to run it. No edits to ~/.ssh/config required.\n" +
+				"     IdentitiesOnly=yes is REQUIRED — without it, ssh offers every\n" +
+				"     identity in ~/.ssh/, each of which sshpiper's failtoban counts\n" +
+				"     as a failed attempt. One careless ssh can burn the IP's ban quota.\n" +
 				"  3. Inside the container, apt install / write files / start services.\n" +
 				"  4. Call `expose_port` to make a container port reachable on a public hostname.\n\n" +
 				"Optional convenience (skip if you don't want to touch ~/.ssh/config):\n" +
@@ -378,8 +383,14 @@ func handleCreateContainer(client *Client, args map[string]interface{}) (string,
 		if sentinelHost == "" {
 			sentinelHost = "<sentinel-host>"
 		}
-		result += fmt.Sprintf("  ssh -i ~/.containarium/keys/%s %s@%s\n\n",
+		result += fmt.Sprintf("  ssh -i ~/.containarium/keys/%s \\\n"+
+			"      -o IdentitiesOnly=yes -o PreferredAuthentications=publickey \\\n"+
+			"      %s@%s\n\n",
 			resp.Container.Username, resp.Container.Username, sentinelHost)
+		result += "IdentitiesOnly=yes is REQUIRED — without it ssh offers every key in\n"
+		result += "~/.ssh/, and sshpiper's failtoban counts each rejected offer toward\n"
+		result += "the ban quota. Workstations with several keys can get banned on a\n"
+		result += "single ssh attempt.\n\n"
 		if client.SentinelHost == "" {
 			result += "(Sentinel host not configured — set CONTAINARIUM_SENTINEL_HOST in the\n"
 			result += "MCP server's env, or call sync_ssh_config for an alias-based setup.)\n\n"

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -376,7 +376,7 @@ func TestToolDescriptionQuality(t *testing.T) {
 			// for agents to learn affordances from the tool list itself —
 			// so the upper bound is generous.
 			assert.GreaterOrEqual(t, len(desc), 20, "Description too short")
-			assert.LessOrEqual(t, len(desc), 1500, "Description too long")
+			assert.LessOrEqual(t, len(desc), 2000, "Description too long")
 
 			// Description should not contain TODO or placeholders
 			assert.NotContains(t, desc, "TODO")

--- a/terraform/modules/containarium/scripts/startup-sentinel.sh
+++ b/terraform/modules/containarium/scripts/startup-sentinel.sh
@@ -108,8 +108,8 @@ ExecStart=/usr/local/bin/sshpiperd \
   --config /etc/sshpiper/config.yaml \
   -- \
   failtoban \
-  --max-failures 20 \
-  --ban-duration 1h
+  --max-failures 100 \
+  --ban-duration 5m
 Restart=always
 RestartSec=5
 

--- a/terraform/modules/containarium/scripts/startup-spot.sh
+++ b/terraform/modules/containarium/scripts/startup-spot.sh
@@ -632,6 +632,68 @@ else
     echo "✓ JWT secret already exists"
 fi
 
+# Install containarium-shell wrapper so sshd accepts logins for container
+# users. The daemon creates host accounts with shell=containarium-shell;
+# without this file present, sshd rejects every login with
+# "User X not allowed because shell /usr/local/bin/containarium-shell does
+# not exist". Mirrors scripts/setup-ssh-container-proxy.sh; keep in sync.
+echo "==> Installing containarium-shell wrapper..."
+cat > /usr/local/bin/containarium-shell <<'SHELLEOF'
+#!/bin/bash
+# containarium-shell: Proxy SSH sessions into Incus containers
+
+USERNAME="$(whoami)"
+CONTAINER="$${USERNAME}-container"
+
+if ! sudo incus info "$CONTAINER" &>/dev/null; then
+    echo "Error: Container $CONTAINER not found" >&2
+    exit 1
+fi
+
+STATE=$(sudo incus info "$CONTAINER" 2>/dev/null | grep "^Status:" | awk '{print $2}')
+if [ "$STATE" != "RUNNING" ]; then
+    echo "Error: Container $CONTAINER is not running (status: $STATE)" >&2
+    exit 1
+fi
+
+# Three invocation modes: SSH_ORIGINAL_COMMAND set, -c <cmd> arg, or
+# interactive.
+COMMAND="$${SSH_ORIGINAL_COMMAND}"
+if [ -z "$COMMAND" ] && [ "$1" = "-c" ]; then
+    COMMAND="$2"
+fi
+
+if [ -n "$COMMAND" ]; then
+    exec sudo incus exec "$CONTAINER" --mode non-interactive -- su - "$USERNAME" -c "$COMMAND"
+fi
+
+exec sudo incus exec "$CONTAINER" -t -- su -l "$USERNAME"
+SHELLEOF
+chmod 755 /usr/local/bin/containarium-shell
+
+# /etc/shells gate: sshd refuses any user whose shell is not listed here.
+if ! grep -qxF /usr/local/bin/containarium-shell /etc/shells 2>/dev/null; then
+    echo /usr/local/bin/containarium-shell >> /etc/shells
+fi
+
+# Sudoers for passwordless `incus exec/info`.
+cat > /etc/sudoers.d/containarium-incus <<'SUDOEOF'
+ALL ALL=(root) NOPASSWD: /usr/bin/incus exec *, /usr/bin/incus info *
+SUDOEOF
+chmod 0440 /etc/sudoers.d/containarium-incus
+
+# Suppress host MOTD for container users (admin users keep theirs).
+SSHD_DROPIN=/etc/ssh/sshd_config.d/containarium-motd.conf
+if [ -d /etc/ssh/sshd_config.d ]; then
+    cat > "$SSHD_DROPIN" <<'SSHDEOF'
+Match User *,!ubuntu,!root
+    PrintMotd no
+    PrintLastLog no
+SSHDEOF
+    systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null || true
+fi
+echo "✓ containarium-shell wrapper installed"
+
 # Install systemd service via the binary's built-in command if available,
 # otherwise create the service file directly.
 echo "==> Installing Containarium systemd service..."


### PR DESCRIPTION
## Summary

Three independent root causes were stacking and preventing the agent-driven demo SSH flow from ever completing. This PR fixes all three.

**Base note:** stacked on top of `extraction/phase-5-docs` because the MCP changes naturally extend the workflow-description work there (the create_container description was the original anchor point). If the extraction branch lands first, the diff vs. main is just these 80 lines.

## The three root causes

1. **MCP `create_container`'s ssh hint omitted `IdentitiesOnly=yes`.** OpenSSH then offered every key in `~/.ssh/` before the explicit `-i` key — sshpiper's failtoban counted each rejected offer toward the ban budget. A single careless `ssh` from a workstation with multiple keys could burn the IP's entire quota.

2. **sshpiperd's failtoban was tuned for an attacker's pace, not an agent's:** `--max-failures 20`, `--ban-duration 1h`. Combined with (1), an honest agent got banned in ~3 attempts and stayed banned for an hour.

3. **Backend's `startup-spot.sh` never installed `/usr/local/bin/containarium-shell`**, but the daemon creates user accounts with `shell=containarium-shell`. sshd refused every login with `User X not allowed because shell /usr/local/bin/containarium-shell does not exist`. This had been broken since the demo cluster was first deployed — failtoban noise was masking it.

## Changes

- `internal/mcp/tools.go` — `IdentitiesOnly=yes` + `PreferredAuthentications=publickey` in both the workflow description and the runtime response. Explicit note about why it's load-bearing.
- `internal/mcp/{server,tools}_test.go` — description length cap 1500 → 2000.
- `terraform/modules/containarium/scripts/startup-sentinel.sh` — `--max-failures 20→100`, `--ban-duration 1h→5m`.
- `terraform/modules/containarium/scripts/startup-spot.sh` — inline install of `containarium-shell` wrapper, `/etc/shells` entry, sudoers, sshd Match block (mirrors `scripts/setup-ssh-container-proxy.sh`).

## Verified end-to-end

Against the dev demo cluster (`footprintai-dev`, `containarium-demo` + `containarium-demo-sentinel`):
- Replaced sentinel via `terraform apply -replace`
- Replaced backend via `terraform apply -replace`
- Created a synthetic container `verify-rt` via REST API
- `ssh -i <key> -o IdentitiesOnly=yes verify-rt@34.42.156.100` → landed inside `verify-rt-container` (Ubuntu 24.04)

## Test plan

- [ ] `go test ./internal/mcp/...` (already green locally)
- [ ] CI lint/vet pass
- [ ] Manual: redeploy demo cluster from scratch, run the demo prompt, agent's SSH should succeed first try

## Follow-ups (filed as separate tasks)

- Daemon-side: rewrite existing containers' authorized_keys on sentinel upstream-key rotation (today, replacing the sentinel left every container stranded with the old upstream pubkey).
- New MCP `debug_hint` tool: one layer deeper than the agent's raw error message, surfaces stale-sync / ban state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)