### PR TITLE
refactor(container): take incus.Backend + extract MockBackend

### DIFF
--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -19,7 +19,7 @@ import (
 
 // Manager handles container lifecycle operations
 type Manager struct {
-	incus *incus.Client
+	incus incus.Backend
 }
 
 // CreateOptions holds options for creating a container
@@ -44,7 +44,7 @@ type CreateOptions struct {
 	RDPPassword            string    // Generated RDP password for Windows VMs (output, set by Create)
 }
 
-// New creates a new container manager
+// New creates a new container manager backed by a real Incus client.
 func New() (*Manager, error) {
 	client, err := incus.New()
 	if err != nil {
@@ -52,6 +52,12 @@ func New() (*Manager, error) {
 	}
 
 	return &Manager{incus: client}, nil
+}
+
+// NewWithBackend creates a new container manager backed by the given Incus
+// implementation. Used by tests to inject a mock; production code uses New.
+func NewWithBackend(backend incus.Backend) *Manager {
+	return &Manager{incus: backend}
 }
 
 // Create creates a new container with full setup

--- a/internal/core/manager_test.go
+++ b/internal/core/manager_test.go
@@ -3,156 +3,13 @@ package core
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/footprintai/containarium/internal/incus"
-	"github.com/lxc/incus/v6/shared/api"
+	"github.com/footprintai/containarium/internal/incus/incustest"
 )
 
-// mockIncusClient is a mock implementation of the incus.Client for testing
-type mockIncusClient struct {
-	containers      map[string]*incus.ContainerInfo
-	createErr       error
-	startErr        error
-	getErr          error
-	deleteErr       error
-	stopErr         error
-	execErr         error
-	waitNetworkIP   string
-	waitNetworkErr  error
-}
-
-func newMockIncusClient() *mockIncusClient {
-	return &mockIncusClient{
-		containers: make(map[string]*incus.ContainerInfo),
-	}
-}
-
-func (m *mockIncusClient) CreateContainer(config incus.ContainerConfig) error {
-	if m.createErr != nil {
-		return m.createErr
-	}
-	m.containers[config.Name] = &incus.ContainerInfo{
-		Name:      config.Name,
-		State:     "Stopped",
-		CPU:       config.CPU,
-		Memory:    config.Memory,
-		CreatedAt: time.Now(),
-	}
-	return nil
-}
-
-func (m *mockIncusClient) StartContainer(name string) error {
-	if m.startErr != nil {
-		return m.startErr
-	}
-	if container, ok := m.containers[name]; ok {
-		container.State = "Running"
-	}
-	return nil
-}
-
-func (m *mockIncusClient) StopContainer(name string, force bool) error {
-	if m.stopErr != nil {
-		return m.stopErr
-	}
-	if container, ok := m.containers[name]; ok {
-		container.State = "Stopped"
-	}
-	return nil
-}
-
-func (m *mockIncusClient) DeleteContainer(name string) error {
-	if m.deleteErr != nil {
-		return m.deleteErr
-	}
-	delete(m.containers, name)
-	return nil
-}
-
-func (m *mockIncusClient) GetContainer(name string) (*incus.ContainerInfo, error) {
-	if m.getErr != nil {
-		return nil, m.getErr
-	}
-	container, ok := m.containers[name]
-	if !ok {
-		return nil, nil
-	}
-	return container, nil
-}
-
-func (m *mockIncusClient) WaitForNetwork(name string, timeout time.Duration) (string, error) {
-	if m.waitNetworkErr != nil {
-		return "", m.waitNetworkErr
-	}
-	if container, ok := m.containers[name]; ok {
-		container.IPAddress = m.waitNetworkIP
-	}
-	return m.waitNetworkIP, nil
-}
-
-func (m *mockIncusClient) Exec(containerName string, command []string) error {
-	return m.execErr
-}
-
-func (m *mockIncusClient) ExecWithOutput(containerName string, command []string) (string, string, error) {
-	return "", "", m.execErr
-}
-
-func (m *mockIncusClient) WriteFile(containerName, path string, content []byte, mode string) error {
-	return nil
-}
-
-func (m *mockIncusClient) ReadFile(containerName, path string) ([]byte, error) {
-	return nil, nil
-}
-
-func (m *mockIncusClient) ListContainers() ([]incus.ContainerInfo, error) {
-	return nil, nil
-}
-
-func (m *mockIncusClient) SetConfig(containerName, key, value string) error {
-	return nil
-}
-
-func (m *mockIncusClient) SetDeviceSize(containerName, deviceName, size string) error {
-	return nil
-}
-
-func (m *mockIncusClient) ResolveGPUInputToPCI(input string) (string, error) {
-	return "", nil
-}
-
-func (m *mockIncusClient) CleanupDisk(containerName string) (string, int64, error) {
-	return "", 0, nil
-}
-
-func (m *mockIncusClient) AddLabel(containerName, key, value string) error {
-	return nil
-}
-
-func (m *mockIncusClient) RemoveLabel(containerName, key string) error {
-	return nil
-}
-
-func (m *mockIncusClient) GetLabels(containerName string) (map[string]string, error) {
-	return nil, nil
-}
-
-func (m *mockIncusClient) SetLabels(containerName string, labels map[string]string) error {
-	return nil
-}
-
-func (m *mockIncusClient) GetServerInfo() (*api.Server, error) {
-	return nil, nil
-}
-
-func (m *mockIncusClient) GetContainerMetrics(name string) (*incus.ContainerMetrics, error) {
-	return nil, nil
-}
-
 func TestNew(t *testing.T) {
-	mockClient := newMockIncusClient()
+	mockClient := incustest.NewMockBackend()
 
 	t.Run("with password", func(t *testing.T) {
 		manager := New(mockClient, "mypassword")
@@ -173,7 +30,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestGetConnectionStrings(t *testing.T) {
-	mockClient := newMockIncusClient()
+	mockClient := incustest.NewMockBackend()
 	manager := New(mockClient, "testpass")
 	manager.coreIP = "10.0.1.50"
 
@@ -211,11 +68,11 @@ func TestGetConnectionStrings(t *testing.T) {
 }
 
 func TestEnsureCoreContainer_ExistingContainer(t *testing.T) {
-	mockClient := newMockIncusClient()
+	mockClient := incustest.NewMockBackend()
 	manager := New(mockClient, "testpass")
 
 	// Pre-create the core container
-	mockClient.containers[CoreContainerName] = &incus.ContainerInfo{
+	mockClient.Containers[CoreContainerName] = &incus.ContainerInfo{
 		Name:      CoreContainerName,
 		State:     "Running",
 		IPAddress: "10.0.1.50",
@@ -237,8 +94,8 @@ func TestEnsureCoreContainer_ExistingContainer(t *testing.T) {
 }
 
 func TestEnsureCoreContainer_CreateNew(t *testing.T) {
-	mockClient := newMockIncusClient()
-	mockClient.waitNetworkIP = "10.0.1.50"
+	mockClient := incustest.NewMockBackend()
+	mockClient.WaitNetworkIP = "10.0.1.50"
 
 	manager := New(mockClient, "testpass")
 
@@ -276,7 +133,7 @@ func TestEnsureCoreContainer_CreateNew(t *testing.T) {
 }
 
 func TestEnsureCoreContainer_AutoCreateDisabled(t *testing.T) {
-	mockClient := newMockIncusClient()
+	mockClient := incustest.NewMockBackend()
 	manager := New(mockClient, "testpass")
 
 	ctx := context.Background()
@@ -291,8 +148,8 @@ func TestEnsureCoreContainer_AutoCreateDisabled(t *testing.T) {
 }
 
 func TestEnsureCoreContainer_DefaultResources(t *testing.T) {
-	mockClient := newMockIncusClient()
-	mockClient.waitNetworkIP = "10.0.1.50"
+	mockClient := incustest.NewMockBackend()
+	mockClient.WaitNetworkIP = "10.0.1.50"
 
 	manager := New(mockClient, "testpass")
 
@@ -322,12 +179,12 @@ func TestEnsureCoreContainer_DefaultResources(t *testing.T) {
 }
 
 func TestDestroy(t *testing.T) {
-	mockClient := newMockIncusClient()
+	mockClient := incustest.NewMockBackend()
 	manager := New(mockClient, "testpass")
 	manager.coreIP = "10.0.1.50"
 
 	// Pre-create the core container
-	mockClient.containers[CoreContainerName] = &incus.ContainerInfo{
+	mockClient.Containers[CoreContainerName] = &incus.ContainerInfo{
 		Name:      CoreContainerName,
 		State:     "Running",
 		IPAddress: "10.0.1.50",
@@ -351,13 +208,13 @@ func TestDestroy(t *testing.T) {
 }
 
 func TestIsHealthy(t *testing.T) {
-	mockClient := newMockIncusClient()
+	mockClient := incustest.NewMockBackend()
 	manager := New(mockClient, "testpass")
 
 	ctx := context.Background()
 
 	t.Run("healthy when container running", func(t *testing.T) {
-		mockClient.containers[CoreContainerName] = &incus.ContainerInfo{
+		mockClient.Containers[CoreContainerName] = &incus.ContainerInfo{
 			Name:      CoreContainerName,
 			State:     "Running",
 			IPAddress: "10.0.1.50",
@@ -369,7 +226,7 @@ func TestIsHealthy(t *testing.T) {
 	})
 
 	t.Run("unhealthy when container not running", func(t *testing.T) {
-		mockClient.containers[CoreContainerName].State = "Stopped"
+		mockClient.Containers[CoreContainerName].State = "Stopped"
 
 		if manager.IsHealthy(ctx) {
 			t.Error("IsHealthy() = true, want false")
@@ -377,7 +234,7 @@ func TestIsHealthy(t *testing.T) {
 	})
 
 	t.Run("unhealthy when container doesn't exist", func(t *testing.T) {
-		delete(mockClient.containers, CoreContainerName)
+		delete(mockClient.Containers, CoreContainerName)
 
 		if manager.IsHealthy(ctx) {
 			t.Error("IsHealthy() = true, want false")
@@ -386,13 +243,13 @@ func TestIsHealthy(t *testing.T) {
 }
 
 func TestHealthCheck(t *testing.T) {
-	mockClient := newMockIncusClient()
+	mockClient := incustest.NewMockBackend()
 	manager := New(mockClient, "testpass")
 
 	ctx := context.Background()
 
 	t.Run("pass when running", func(t *testing.T) {
-		mockClient.containers[CoreContainerName] = &incus.ContainerInfo{
+		mockClient.Containers[CoreContainerName] = &incus.ContainerInfo{
 			Name:      CoreContainerName,
 			State:     "Running",
 			IPAddress: "10.0.1.50",
@@ -409,7 +266,7 @@ func TestHealthCheck(t *testing.T) {
 	})
 
 	t.Run("fail when stopped", func(t *testing.T) {
-		mockClient.containers[CoreContainerName].State = "Stopped"
+		mockClient.Containers[CoreContainerName].State = "Stopped"
 
 		err := manager.healthCheck(ctx)
 		if err == nil {
@@ -418,7 +275,7 @@ func TestHealthCheck(t *testing.T) {
 	})
 
 	t.Run("fail when not found", func(t *testing.T) {
-		delete(mockClient.containers, CoreContainerName)
+		delete(mockClient.Containers, CoreContainerName)
 
 		err := manager.healthCheck(ctx)
 		if err == nil {
@@ -429,7 +286,7 @@ func TestHealthCheck(t *testing.T) {
 
 // Benchmark tests
 func BenchmarkGetConnectionStrings(b *testing.B) {
-	mockClient := newMockIncusClient()
+	mockClient := incustest.NewMockBackend()
 	manager := New(mockClient, "testpass")
 	manager.coreIP = "10.0.1.50"
 

--- a/internal/core/manager_test.go
+++ b/internal/core/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/footprintai/containarium/internal/incus"
+	"github.com/lxc/incus/v6/shared/api"
 )
 
 // mockIncusClient is a mock implementation of the incus.Client for testing
@@ -103,6 +104,50 @@ func (m *mockIncusClient) WriteFile(containerName, path string, content []byte, 
 }
 
 func (m *mockIncusClient) ReadFile(containerName, path string) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockIncusClient) ListContainers() ([]incus.ContainerInfo, error) {
+	return nil, nil
+}
+
+func (m *mockIncusClient) SetConfig(containerName, key, value string) error {
+	return nil
+}
+
+func (m *mockIncusClient) SetDeviceSize(containerName, deviceName, size string) error {
+	return nil
+}
+
+func (m *mockIncusClient) ResolveGPUInputToPCI(input string) (string, error) {
+	return "", nil
+}
+
+func (m *mockIncusClient) CleanupDisk(containerName string) (string, int64, error) {
+	return "", 0, nil
+}
+
+func (m *mockIncusClient) AddLabel(containerName, key, value string) error {
+	return nil
+}
+
+func (m *mockIncusClient) RemoveLabel(containerName, key string) error {
+	return nil
+}
+
+func (m *mockIncusClient) GetLabels(containerName string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (m *mockIncusClient) SetLabels(containerName string, labels map[string]string) error {
+	return nil
+}
+
+func (m *mockIncusClient) GetServerInfo() (*api.Server, error) {
+	return nil, nil
+}
+
+func (m *mockIncusClient) GetContainerMetrics(name string) (*incus.ContainerMetrics, error) {
 	return nil, nil
 }
 

--- a/internal/incus/client.go
+++ b/internal/incus/client.go
@@ -29,16 +29,36 @@ type Client struct {
 // Backend is the interface satisfied by *Client. Consumers depend on it (or a
 // narrower subset declared at the call site) so they can be mocked in tests.
 type Backend interface {
+	// Lifecycle
 	CreateContainer(config ContainerConfig) error
 	StartContainer(name string) error
 	StopContainer(name string, force bool) error
 	DeleteContainer(name string) error
 	GetContainer(name string) (*ContainerInfo, error)
+	ListContainers() ([]ContainerInfo, error)
+	WaitForNetwork(containerName string, timeout time.Duration) (string, error)
+
+	// Exec & file I/O
 	Exec(containerName string, command []string) error
 	ExecWithOutput(containerName string, command []string) (string, string, error)
 	WriteFile(containerName, path string, content []byte, mode string) error
 	ReadFile(containerName, path string) ([]byte, error)
-	WaitForNetwork(containerName string, timeout time.Duration) (string, error)
+
+	// Config & devices
+	SetConfig(containerName, key, value string) error
+	SetDeviceSize(containerName, deviceName, size string) error
+	ResolveGPUInputToPCI(input string) (string, error)
+	CleanupDisk(containerName string) (string, int64, error)
+
+	// Labels
+	AddLabel(containerName, key, value string) error
+	RemoveLabel(containerName, key string) error
+	GetLabels(containerName string) (map[string]string, error)
+	SetLabels(containerName string, labels map[string]string) error
+
+	// Server info & metrics
+	GetServerInfo() (*api.Server, error)
+	GetContainerMetrics(name string) (*ContainerMetrics, error)
 }
 
 // DiskDevice represents a disk device configuration

--- a/internal/incus/incustest/mock.go
+++ b/internal/incus/incustest/mock.go
@@ -1,0 +1,233 @@
+// Package incustest provides test doubles for the incus package.
+package incustest
+
+import (
+	"time"
+
+	"github.com/footprintai/containarium/internal/incus"
+	"github.com/lxc/incus/v6/shared/api"
+)
+
+// MockBackend is a test double for incus.Backend. Lifecycle methods
+// (Create/Start/Stop/Delete/Get/List/WaitForNetwork) provide stateful default
+// behavior via the Containers map; other methods return zero values by
+// default. Any method can be fully overridden by setting the corresponding
+// <Method>Func field.
+type MockBackend struct {
+	// Containers is the in-memory state used by default lifecycle methods.
+	Containers map[string]*incus.ContainerInfo
+
+	// WaitNetworkIP, if set, is returned by WaitForNetwork and written to
+	// the container's IPAddress field.
+	WaitNetworkIP string
+
+	// Override hooks. If non-nil, the method delegates to the function and
+	// the default behavior is skipped.
+	CreateContainerFunc      func(config incus.ContainerConfig) error
+	StartContainerFunc       func(name string) error
+	StopContainerFunc        func(name string, force bool) error
+	DeleteContainerFunc      func(name string) error
+	GetContainerFunc         func(name string) (*incus.ContainerInfo, error)
+	ListContainersFunc       func() ([]incus.ContainerInfo, error)
+	WaitForNetworkFunc       func(containerName string, timeout time.Duration) (string, error)
+	ExecFunc                 func(containerName string, command []string) error
+	ExecWithOutputFunc       func(containerName string, command []string) (string, string, error)
+	WriteFileFunc            func(containerName, path string, content []byte, mode string) error
+	ReadFileFunc             func(containerName, path string) ([]byte, error)
+	SetConfigFunc            func(containerName, key, value string) error
+	SetDeviceSizeFunc        func(containerName, deviceName, size string) error
+	ResolveGPUInputToPCIFunc func(input string) (string, error)
+	CleanupDiskFunc          func(containerName string) (string, int64, error)
+	AddLabelFunc             func(containerName, key, value string) error
+	RemoveLabelFunc          func(containerName, key string) error
+	GetLabelsFunc            func(containerName string) (map[string]string, error)
+	SetLabelsFunc            func(containerName string, labels map[string]string) error
+	GetServerInfoFunc        func() (*api.Server, error)
+	GetContainerMetricsFunc  func(name string) (*incus.ContainerMetrics, error)
+}
+
+// NewMockBackend returns a ready-to-use MockBackend with an initialized
+// Containers map.
+func NewMockBackend() *MockBackend {
+	return &MockBackend{
+		Containers: make(map[string]*incus.ContainerInfo),
+	}
+}
+
+func (m *MockBackend) CreateContainer(config incus.ContainerConfig) error {
+	if m.CreateContainerFunc != nil {
+		return m.CreateContainerFunc(config)
+	}
+	if m.Containers == nil {
+		m.Containers = make(map[string]*incus.ContainerInfo)
+	}
+	m.Containers[config.Name] = &incus.ContainerInfo{
+		Name:      config.Name,
+		State:     "Stopped",
+		CPU:       config.CPU,
+		Memory:    config.Memory,
+		CreatedAt: time.Now(),
+	}
+	return nil
+}
+
+func (m *MockBackend) StartContainer(name string) error {
+	if m.StartContainerFunc != nil {
+		return m.StartContainerFunc(name)
+	}
+	if c, ok := m.Containers[name]; ok {
+		c.State = "Running"
+	}
+	return nil
+}
+
+func (m *MockBackend) StopContainer(name string, force bool) error {
+	if m.StopContainerFunc != nil {
+		return m.StopContainerFunc(name, force)
+	}
+	if c, ok := m.Containers[name]; ok {
+		c.State = "Stopped"
+	}
+	return nil
+}
+
+func (m *MockBackend) DeleteContainer(name string) error {
+	if m.DeleteContainerFunc != nil {
+		return m.DeleteContainerFunc(name)
+	}
+	delete(m.Containers, name)
+	return nil
+}
+
+func (m *MockBackend) GetContainer(name string) (*incus.ContainerInfo, error) {
+	if m.GetContainerFunc != nil {
+		return m.GetContainerFunc(name)
+	}
+	c, ok := m.Containers[name]
+	if !ok {
+		return nil, nil
+	}
+	return c, nil
+}
+
+func (m *MockBackend) ListContainers() ([]incus.ContainerInfo, error) {
+	if m.ListContainersFunc != nil {
+		return m.ListContainersFunc()
+	}
+	out := make([]incus.ContainerInfo, 0, len(m.Containers))
+	for _, c := range m.Containers {
+		out = append(out, *c)
+	}
+	return out, nil
+}
+
+func (m *MockBackend) WaitForNetwork(containerName string, timeout time.Duration) (string, error) {
+	if m.WaitForNetworkFunc != nil {
+		return m.WaitForNetworkFunc(containerName, timeout)
+	}
+	if c, ok := m.Containers[containerName]; ok {
+		c.IPAddress = m.WaitNetworkIP
+	}
+	return m.WaitNetworkIP, nil
+}
+
+func (m *MockBackend) Exec(containerName string, command []string) error {
+	if m.ExecFunc != nil {
+		return m.ExecFunc(containerName, command)
+	}
+	return nil
+}
+
+func (m *MockBackend) ExecWithOutput(containerName string, command []string) (string, string, error) {
+	if m.ExecWithOutputFunc != nil {
+		return m.ExecWithOutputFunc(containerName, command)
+	}
+	return "", "", nil
+}
+
+func (m *MockBackend) WriteFile(containerName, path string, content []byte, mode string) error {
+	if m.WriteFileFunc != nil {
+		return m.WriteFileFunc(containerName, path, content, mode)
+	}
+	return nil
+}
+
+func (m *MockBackend) ReadFile(containerName, path string) ([]byte, error) {
+	if m.ReadFileFunc != nil {
+		return m.ReadFileFunc(containerName, path)
+	}
+	return nil, nil
+}
+
+func (m *MockBackend) SetConfig(containerName, key, value string) error {
+	if m.SetConfigFunc != nil {
+		return m.SetConfigFunc(containerName, key, value)
+	}
+	return nil
+}
+
+func (m *MockBackend) SetDeviceSize(containerName, deviceName, size string) error {
+	if m.SetDeviceSizeFunc != nil {
+		return m.SetDeviceSizeFunc(containerName, deviceName, size)
+	}
+	return nil
+}
+
+func (m *MockBackend) ResolveGPUInputToPCI(input string) (string, error) {
+	if m.ResolveGPUInputToPCIFunc != nil {
+		return m.ResolveGPUInputToPCIFunc(input)
+	}
+	return "", nil
+}
+
+func (m *MockBackend) CleanupDisk(containerName string) (string, int64, error) {
+	if m.CleanupDiskFunc != nil {
+		return m.CleanupDiskFunc(containerName)
+	}
+	return "", 0, nil
+}
+
+func (m *MockBackend) AddLabel(containerName, key, value string) error {
+	if m.AddLabelFunc != nil {
+		return m.AddLabelFunc(containerName, key, value)
+	}
+	return nil
+}
+
+func (m *MockBackend) RemoveLabel(containerName, key string) error {
+	if m.RemoveLabelFunc != nil {
+		return m.RemoveLabelFunc(containerName, key)
+	}
+	return nil
+}
+
+func (m *MockBackend) GetLabels(containerName string) (map[string]string, error) {
+	if m.GetLabelsFunc != nil {
+		return m.GetLabelsFunc(containerName)
+	}
+	return nil, nil
+}
+
+func (m *MockBackend) SetLabels(containerName string, labels map[string]string) error {
+	if m.SetLabelsFunc != nil {
+		return m.SetLabelsFunc(containerName, labels)
+	}
+	return nil
+}
+
+func (m *MockBackend) GetServerInfo() (*api.Server, error) {
+	if m.GetServerInfoFunc != nil {
+		return m.GetServerInfoFunc()
+	}
+	return nil, nil
+}
+
+func (m *MockBackend) GetContainerMetrics(name string) (*incus.ContainerMetrics, error) {
+	if m.GetContainerMetricsFunc != nil {
+		return m.GetContainerMetricsFunc(name)
+	}
+	return nil, nil
+}
+
+// Compile-time assertion that *MockBackend satisfies incus.Backend.
+var _ incus.Backend = (*MockBackend)(nil)


### PR DESCRIPTION
## Summary
- `container.Manager.incus` field switches from `*incus.Client` to `incus.Backend`.
- Add `container.NewWithBackend(b incus.Backend)` for test injection; `New()` unchanged for production.
- Extend `incus.Backend` from 10 to 21 methods (now covers everything `container`/`app`/`core` collectively need).
- Extract `incus/incustest.MockBackend` — reusable test double with stateful lifecycle defaults + per-method `*Func` override hooks.
- Migrate `core/manager_test.go` to the shared mock (drops ~140 LOC of duplicate stub methods).

## Test plan
- [x] `go build ./...` exit 0
- [x] All affected package tests pass
- [x] Existing `internal/container` tests run in <2s with no live Incus

## Stack
2 of 5 in the containarium-core extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)