### PR TITLE
fix(gateway): rotate sentinel upstream key in authorized_keys (don't accumulate stale entries)

### DIFF
--- a/internal/gateway/keys_handler.go
+++ b/internal/gateway/keys_handler.go
@@ -69,9 +69,18 @@ func ServeAuthorizedKeys() http.HandlerFunc {
 	}
 }
 
-// ServeSentinelKey returns an HTTP handler that accepts a POST with the sentinel's
-// public key and appends it to all jump server users' authorized_keys files.
-// This allows sshpiper on the sentinel to authenticate to the spot VM.
+// sentinelKeyMarker is the comment line that flags the next line as the
+// sentinel's current upstream pubkey in a user's authorized_keys file.
+// applySentinelKey uses this marker to find and replace stale entries on
+// rotation (sentinel VM replacement → new upstream keypair → old marker
+// block must go, new one must take its place).
+const sentinelKeyMarker = "# sshpiper sentinel upstream key"
+
+// ServeSentinelKey returns an HTTP handler that accepts a POST with the
+// sentinel's current upstream public key and installs it in every jump
+// server user's authorized_keys file. Replaces any prior sentinel-marker
+// block so that rotating the sentinel doesn't leave containers stranded
+// with the old upstream key.
 func ServeSentinelKey() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -91,55 +100,131 @@ func ServeSentinelKey() http.HandlerFunc {
 			return
 		}
 
-		entries, err := os.ReadDir("/home")
+		updated, rotated, err := applySentinelKey("/home", pubKey)
 		if err != nil {
-			log.Printf("[keys] failed to read /home: %v", err)
-			http.Error(w, `{"error":"failed to read home directories"}`, http.StatusInternalServerError)
+			log.Printf("[keys] sentinel-key apply failed: %v", err)
+			http.Error(w, `{"error":"failed to apply sentinel key"}`, http.StatusInternalServerError)
 			return
 		}
 
-		var updated int
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			username := entry.Name()
-			sshDir := filepath.Join("/home", username, ".ssh")
-			if _, err := os.Stat(sshDir); os.IsNotExist(err) {
-				continue // no .ssh directory, skip
-			}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]int{
+			"updated": updated,
+			"rotated": rotated,
+		})
+	}
+}
 
-			akPath := filepath.Join(sshDir, "authorized_keys")
-			// Read existing content to check for duplicates
-			existing, _ := os.ReadFile(akPath)
-			if strings.Contains(string(existing), pubKey) {
-				updated++
-				continue // key already present
-			}
+// applySentinelKey rewrites every user's authorized_keys under homeRoot so
+// the current sentinel upstream pubkey is installed exactly once, replacing
+// any prior sentinel-marker block.
+//
+// Returns:
+//
+//   - updated: number of users whose authorized_keys now contains pubKey
+//     (includes both first-install and rotation cases).
+//   - rotated: number of users where a *different* prior sentinel key was
+//     replaced. Useful for observability of rotation events.
+func applySentinelKey(homeRoot, pubKey string) (updated, rotated int, err error) {
+	entries, err := os.ReadDir(homeRoot)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read %s: %w", homeRoot, err)
+	}
 
-			// Append the sentinel key
-			f, err := os.OpenFile(akPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-			if err != nil {
-				log.Printf("[keys] failed to open %s: %v", akPath, err)
-				continue
-			}
-			fmt.Fprintf(f, "\n# sshpiper sentinel upstream key\n%s\n", pubKey)
-			f.Close()
-
-			// Fix ownership — the file should be owned by the user
-			// We use Lchown-compatible approach: look up the dir owner
-			info, err := os.Stat(sshDir)
-			if err == nil {
-				if stat, ok := fileOwner(info); ok {
-					os.Chown(akPath, stat.uid, stat.gid)
-				}
-			}
-
-			updated++
-			log.Printf("[keys] added sentinel key to %s", akPath)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		username := entry.Name()
+		sshDir := filepath.Join(homeRoot, username, ".ssh")
+		if _, statErr := os.Stat(sshDir); os.IsNotExist(statErr) {
+			continue
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]int{"updated": updated})
+		akPath := filepath.Join(sshDir, "authorized_keys")
+		existing, _ := os.ReadFile(akPath)
+
+		newContent, hadPriorKey, priorKeyDiffers := rewriteSentinelBlock(string(existing), pubKey)
+		if newContent == string(existing) {
+			// Already in the desired shape; count as updated since the
+			// key IS present.
+			updated++
+			continue
+		}
+
+		if writeErr := writeAuthorizedKeys(akPath, sshDir, newContent); writeErr != nil {
+			log.Printf("[keys] failed to write %s: %v", akPath, writeErr)
+			continue
+		}
+
+		updated++
+		if hadPriorKey && priorKeyDiffers {
+			rotated++
+			log.Printf("[keys] rotated sentinel key in %s", akPath)
+		} else {
+			log.Printf("[keys] added sentinel key to %s", akPath)
+		}
 	}
+	return updated, rotated, nil
+}
+
+// rewriteSentinelBlock returns authorized_keys content with the sentinel
+// marker + one current pubKey, replacing any prior sentinel marker block
+// (and the key line that follows it).
+//
+// Returns the new content, whether a prior sentinel block existed, and
+// whether the prior key (if any) differed from pubKey.
+func rewriteSentinelBlock(existing, pubKey string) (newContent string, hadPrior, priorDiffers bool) {
+	lines := strings.Split(existing, "\n")
+	out := make([]string, 0, len(lines)+2)
+
+	// Drop every "marker + next-non-empty-line" pair from the input.
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == sentinelKeyMarker {
+			hadPrior = true
+			// Find the next non-empty line — that's the prior key.
+			j := i + 1
+			for j < len(lines) && strings.TrimSpace(lines[j]) == "" {
+				j++
+			}
+			if j < len(lines) {
+				prior := strings.TrimSpace(lines[j])
+				if prior != pubKey {
+					priorDiffers = true
+				}
+				i = j // skip the prior key line as well
+			}
+			continue
+		}
+		out = append(out, line)
+	}
+
+	// Trim trailing empty lines for a clean append.
+	for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
+		out = out[:len(out)-1]
+	}
+
+	// Now append the canonical block.
+	out = append(out, "", sentinelKeyMarker, pubKey, "")
+
+	return strings.Join(out, "\n"), hadPrior, priorDiffers
+}
+
+// writeAuthorizedKeys writes content to akPath with mode 0600 and tries
+// to set ownership to match sshDir's owner. Writes via temp file + rename
+// so a partial write can't corrupt the file.
+func writeAuthorizedKeys(akPath, sshDir, content string) error {
+	tmp := akPath + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0600); err != nil {
+		return err
+	}
+
+	if info, statErr := os.Stat(sshDir); statErr == nil {
+		if stat, ok := fileOwner(info); ok {
+			_ = os.Chown(tmp, stat.uid, stat.gid)
+		}
+	}
+
+	return os.Rename(tmp, akPath)
 }

--- a/internal/gateway/keys_handler_test.go
+++ b/internal/gateway/keys_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -134,5 +135,227 @@ func TestSentinelKeyRequest_DuplicateDetection(t *testing.T) {
 
 	if !bytes.Contains(data, []byte(sentinelKey)) {
 		t.Error("sentinel key should already be present in authorized_keys")
+	}
+}
+
+func TestRewriteSentinelBlock_FirstInstall(t *testing.T) {
+	existing := "ssh-ed25519 AAAA_user_key user@laptop\n"
+	key := "ssh-ed25519 AAAA_new_sentinel sentinel@sshpiper"
+
+	out, hadPrior, priorDiffers := rewriteSentinelBlock(existing, key)
+	if hadPrior {
+		t.Error("did not expect a prior sentinel block")
+	}
+	if priorDiffers {
+		t.Error("priorDiffers should be false on first install")
+	}
+	if !strings.Contains(out, key) {
+		t.Errorf("output missing new key:\n%s", out)
+	}
+	if !strings.Contains(out, "ssh-ed25519 AAAA_user_key user@laptop") {
+		t.Errorf("output dropped existing user key:\n%s", out)
+	}
+	if strings.Count(out, sentinelKeyMarker) != 1 {
+		t.Errorf("expected exactly one sentinel marker, got %d:\n%s",
+			strings.Count(out, sentinelKeyMarker), out)
+	}
+}
+
+func TestRewriteSentinelBlock_Rotation(t *testing.T) {
+	oldKey := "ssh-ed25519 AAAA_OLD_sentinel_key sentinel@old"
+	newKey := "ssh-ed25519 AAAA_NEW_sentinel_key sentinel@new"
+	existing := "ssh-ed25519 AAAA_user_key user@laptop\n" +
+		sentinelKeyMarker + "\n" +
+		oldKey + "\n"
+
+	out, hadPrior, priorDiffers := rewriteSentinelBlock(existing, newKey)
+	if !hadPrior {
+		t.Error("expected hadPrior=true")
+	}
+	if !priorDiffers {
+		t.Error("expected priorDiffers=true")
+	}
+	if strings.Contains(out, oldKey) {
+		t.Errorf("rotation should have removed old sentinel key:\n%s", out)
+	}
+	if !strings.Contains(out, newKey) {
+		t.Errorf("rotation should have installed new sentinel key:\n%s", out)
+	}
+	if strings.Count(out, sentinelKeyMarker) != 1 {
+		t.Errorf("expected exactly one sentinel marker after rotation, got %d:\n%s",
+			strings.Count(out, sentinelKeyMarker), out)
+	}
+	if !strings.Contains(out, "ssh-ed25519 AAAA_user_key user@laptop") {
+		t.Errorf("rotation dropped user's own key:\n%s", out)
+	}
+}
+
+func TestRewriteSentinelBlock_Idempotent(t *testing.T) {
+	key := "ssh-ed25519 AAAA_sentinel sentinel@sshpiper"
+	existing := "ssh-ed25519 AAAA_user user@laptop\n\n" +
+		sentinelKeyMarker + "\n" +
+		key + "\n"
+
+	out, hadPrior, priorDiffers := rewriteSentinelBlock(existing, key)
+	if !hadPrior {
+		t.Error("expected hadPrior=true")
+	}
+	if priorDiffers {
+		t.Error("priorDiffers should be false when key is unchanged")
+	}
+	// Should remain idempotent — applying the same key twice produces
+	// the same content as applying once.
+	out2, _, _ := rewriteSentinelBlock(out, key)
+	if out != out2 {
+		t.Errorf("not idempotent:\nfirst:\n%s\nsecond:\n%s", out, out2)
+	}
+	if strings.Count(out, sentinelKeyMarker) != 1 {
+		t.Errorf("expected exactly one sentinel marker, got %d:\n%s",
+			strings.Count(out, sentinelKeyMarker), out)
+	}
+}
+
+func TestRewriteSentinelBlock_MultipleStaleMarkers(t *testing.T) {
+	// Defensive: an authorized_keys with two prior sentinel blocks (from a
+	// bug or manual edit) should be cleaned up — exactly one marker survives.
+	existing := sentinelKeyMarker + "\n" +
+		"ssh-ed25519 AAAA_stale_1\n" +
+		"ssh-ed25519 AAAA_user user@laptop\n" +
+		sentinelKeyMarker + "\n" +
+		"ssh-ed25519 AAAA_stale_2\n"
+	newKey := "ssh-ed25519 AAAA_current sentinel@new"
+
+	out, hadPrior, _ := rewriteSentinelBlock(existing, newKey)
+	if !hadPrior {
+		t.Error("expected hadPrior=true")
+	}
+	if strings.Contains(out, "AAAA_stale_1") || strings.Contains(out, "AAAA_stale_2") {
+		t.Errorf("output retained stale sentinel keys:\n%s", out)
+	}
+	if !strings.Contains(out, newKey) {
+		t.Errorf("output missing current key:\n%s", out)
+	}
+	if strings.Count(out, sentinelKeyMarker) != 1 {
+		t.Errorf("expected exactly one marker, got %d:\n%s",
+			strings.Count(out, sentinelKeyMarker), out)
+	}
+}
+
+func TestApplySentinelKey_FirstInstall(t *testing.T) {
+	tmpHome := t.TempDir()
+	mkUser(t, tmpHome, "alice", "ssh-ed25519 AAAA_alice alice@laptop\n")
+	mkUser(t, tmpHome, "bob", "ssh-ed25519 AAAA_bob bob@laptop\n")
+
+	newKey := "ssh-ed25519 AAAA_new_sentinel sentinel@new"
+	updated, rotated, err := applySentinelKey(tmpHome, newKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != 2 {
+		t.Errorf("expected updated=2, got %d", updated)
+	}
+	if rotated != 0 {
+		t.Errorf("expected rotated=0 on first install, got %d", rotated)
+	}
+
+	for _, u := range []string{"alice", "bob"} {
+		readAndAssert(t, tmpHome, u, newKey, true)
+	}
+}
+
+func TestApplySentinelKey_Rotation(t *testing.T) {
+	tmpHome := t.TempDir()
+	oldKey := "ssh-ed25519 AAAA_OLD_sentinel sentinel@old"
+	newKey := "ssh-ed25519 AAAA_NEW_sentinel sentinel@new"
+
+	mkUser(t, tmpHome, "alice",
+		"ssh-ed25519 AAAA_alice alice@laptop\n"+
+			sentinelKeyMarker+"\n"+oldKey+"\n")
+	mkUser(t, tmpHome, "bob",
+		"ssh-ed25519 AAAA_bob bob@laptop\n"+
+			sentinelKeyMarker+"\n"+oldKey+"\n")
+
+	updated, rotated, err := applySentinelKey(tmpHome, newKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != 2 {
+		t.Errorf("expected updated=2, got %d", updated)
+	}
+	if rotated != 2 {
+		t.Errorf("expected rotated=2 on key change, got %d", rotated)
+	}
+
+	for _, u := range []string{"alice", "bob"} {
+		readAndAssert(t, tmpHome, u, newKey, true)
+		readAndAssert(t, tmpHome, u, oldKey, false)
+	}
+}
+
+func TestApplySentinelKey_NoOpWhenIdentical(t *testing.T) {
+	tmpHome := t.TempDir()
+	key := "ssh-ed25519 AAAA_sentinel sentinel@sshpiper"
+
+	// User starts with the canonical layout — apply should produce the
+	// same content (no file write needed, but updated counter still bumps
+	// because the key IS present).
+	initial := "ssh-ed25519 AAAA_alice alice@laptop\n\n" +
+		sentinelKeyMarker + "\n" + key + "\n"
+	mkUser(t, tmpHome, "alice", initial)
+
+	updated, rotated, err := applySentinelKey(tmpHome, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != 1 {
+		t.Errorf("expected updated=1 (key is present), got %d", updated)
+	}
+	if rotated != 0 {
+		t.Errorf("expected rotated=0 on no-op, got %d", rotated)
+	}
+}
+
+func TestApplySentinelKey_SkipsUsersWithoutSshDir(t *testing.T) {
+	tmpHome := t.TempDir()
+	// alice has .ssh, bob does not — bob should be skipped, not errored.
+	mkUser(t, tmpHome, "alice", "ssh-ed25519 AAAA_alice alice@laptop\n")
+	if err := os.MkdirAll(filepath.Join(tmpHome, "bob"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	newKey := "ssh-ed25519 AAAA_sentinel sentinel@sshpiper"
+	updated, _, err := applySentinelKey(tmpHome, newKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated != 1 {
+		t.Errorf("expected updated=1 (alice only), got %d", updated)
+	}
+}
+
+// mkUser writes a user's authorized_keys under tmpHome and ensures the
+// .ssh dir exists.
+func mkUser(t *testing.T, tmpHome, username, akContent string) {
+	t.Helper()
+	sshDir := filepath.Join(tmpHome, username, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sshDir, "authorized_keys"), []byte(akContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// readAndAssert reads a user's authorized_keys and asserts substring presence.
+func readAndAssert(t *testing.T, tmpHome, username, substr string, wantContains bool) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(tmpHome, username, ".ssh", "authorized_keys"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	has := strings.Contains(string(data), substr)
+	if has != wantContains {
+		t.Errorf("user %s authorized_keys: substr %q contains=%v, want %v\nfile:\n%s",
+			username, substr, has, wantContains, string(data))
 	}
 }


### PR DESCRIPTION
## Summary

When the sentinel VM is replaced and pushes a new upstream pubkey to the backend (POST /authorized-keys/sentinel), the prior handler only appended-if-missing. That left every existing container's authorized_keys with the OLD sentinel pubkey alongside (or, in the live failure we hit today, INSTEAD of) the new one. Rotation was the demo session's #1 blocker: containers created before the sentinel replace couldn't be SSH'd to until they were deleted and recreated.

This PR teaches the handler to *replace* the sentinel marker block, not append.

## Behavior

The marker convention `# sshpiper sentinel upstream key` was already used by the prior code; this PR formalizes it as the rotation anchor.

| Initial authorized_keys | POSTed pubkey | Result |
|---|---|---|
| no sentinel block | new key | sentinel block appended at end |
| `# marker\n<old>\n` | new key | old block dropped, new block appended |
| `# marker\n<old>\n` | same as old | no file write (idempotent) |
| Two stale `# marker\n<X>\n` blocks (defensive) | new key | both stale blocks dropped, new appended |

Response body adds a `rotated` counter alongside `updated` so operators can observe rotation events.

## Test coverage

- `rewriteSentinelBlock` (pure function, no I/O): first install, rotation, idempotency, multiple stale markers — all four edge cases.
- `applySentinelKey` (helper against a tmpHome): first install across multiple users, rotation across multiple users, no-op when identical, skip users without `.ssh` dir.
- Existing `ServeSentinelKey_MethodNotAllowed` / `_EmptyKey` / `_InvalidJSON` continue to pass.

11 tests total, all green. Atomic write via temp + rename so a partial write can't corrupt the file.

## Test plan (live)

- [ ] Deploy this onto the demo cluster, replace the sentinel via `terraform apply -replace`, verify the previously-stranded `demo-blog`-style containers can SSH again without recreation.
- [ ] Verify the `/authorized-keys/sentinel` response carries the new `rotated` counter and matches reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)