### PR TITLE
refactor: complete DI cleanup for incus.Backend (PRD follow-ups)

### DIFF
--- a/internal/cmd/recover.go
+++ b/internal/cmd/recover.go
@@ -408,7 +408,7 @@ func syncSSHAccounts() error {
 		}
 
 		// Extract SSH key
-		sshKey, err := container.ExtractSSHKeyFromContainer(c.Name, username, false)
+		sshKey, err := mgr.ExtractSSHKey(c.Name, username, false)
 		if err != nil || sshKey == "" {
 			failed++
 			continue

--- a/internal/cmd/sync_accounts.go
+++ b/internal/cmd/sync_accounts.go
@@ -95,7 +95,7 @@ func runSyncAccounts(cmd *cobra.Command, args []string) error {
 		}
 
 		// Extract SSH key from container
-		sshKey, err := container.ExtractSSHKeyFromContainer(c.Name, username, verbose)
+		sshKey, err := mgr.ExtractSSHKey(c.Name, username, verbose)
 		if err != nil {
 			fmt.Printf("  ⚠ Failed to extract SSH key: %v\n", err)
 			failed++

--- a/internal/server/core_services.go
+++ b/internal/server/core_services.go
@@ -66,7 +66,7 @@ type CoreServicesConfig struct {
 
 // CoreServices manages the core infrastructure containers (PostgreSQL, Caddy, VictoriaMetrics+Grafana)
 type CoreServices struct {
-	incusClient        *incus.Client
+	incusClient        incus.Backend
 	config             CoreServicesConfig
 	postgresIP         string
 	caddyIP            string
@@ -74,7 +74,7 @@ type CoreServices struct {
 }
 
 // NewCoreServices creates a new core services manager
-func NewCoreServices(incusClient *incus.Client, config CoreServicesConfig) *CoreServices {
+func NewCoreServices(incusClient incus.Backend, config CoreServicesConfig) *CoreServices {
 	if config.PostgresUser == "" {
 		config.PostgresUser = DefaultPostgresUser
 	}

--- a/pkg/core/container/jump_server.go
+++ b/pkg/core/container/jump_server.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/footprintai/containarium/pkg/core/incus"
 )
 
 // Note: As of Go 1.20, rand is automatically seeded
@@ -203,17 +201,11 @@ func UserExists(username string) bool {
 	return userExists(username)
 }
 
-// ExtractSSHKeyFromContainer extracts the SSH public key from inside a container
-// The key is read from /home/{username}/.ssh/authorized_keys inside the container
-func ExtractSSHKeyFromContainer(containerName, username string, verbose bool) (string, error) {
-	// Create Incus client
-	client, err := incus.New()
-	if err != nil {
-		return "", fmt.Errorf("failed to connect to Incus: %w", err)
-	}
-
+// ExtractSSHKey extracts the SSH public key from inside a container.
+// The key is read from /home/{username}/.ssh/authorized_keys inside the container.
+func (m *Manager) ExtractSSHKey(containerName, username string, verbose bool) (string, error) {
 	// Check if container is running
-	info, err := client.GetContainer(containerName)
+	info, err := m.incus.GetContainer(containerName)
 	if err != nil {
 		return "", fmt.Errorf("container not found: %w", err)
 	}
@@ -224,7 +216,7 @@ func ExtractSSHKeyFromContainer(containerName, username string, verbose bool) (s
 		if verbose {
 			fmt.Printf("       Starting container %s to extract SSH key...\n", containerName)
 		}
-		if err := client.StartContainer(containerName); err != nil {
+		if err := m.incus.StartContainer(containerName); err != nil {
 			return "", fmt.Errorf("failed to start container: %w", err)
 		}
 		wasStarted = true
@@ -239,17 +231,17 @@ func ExtractSSHKeyFromContainer(containerName, username string, verbose bool) (s
 		fmt.Printf("       Reading SSH key from %s:%s\n", containerName, authorizedKeysPath)
 	}
 
-	keyContent, err := client.ReadFile(containerName, authorizedKeysPath)
+	keyContent, err := m.incus.ReadFile(containerName, authorizedKeysPath)
 	if err != nil {
 		// Try root's authorized_keys as fallback
 		if verbose {
 			fmt.Printf("       Primary path failed, trying /root/.ssh/authorized_keys...\n")
 		}
-		keyContent, err = client.ReadFile(containerName, "/root/.ssh/authorized_keys")
+		keyContent, err = m.incus.ReadFile(containerName, "/root/.ssh/authorized_keys")
 		if err != nil {
 			// Stop container if we started it
 			if wasStarted {
-				_ = client.StopContainer(containerName, false)
+				_ = m.incus.StopContainer(containerName, false)
 			}
 			return "", fmt.Errorf("could not read SSH key from container: %w", err)
 		}
@@ -260,7 +252,7 @@ func ExtractSSHKeyFromContainer(containerName, username string, verbose bool) (s
 		if verbose {
 			fmt.Printf("       Stopping container %s...\n", containerName)
 		}
-		_ = client.StopContainer(containerName, false)
+		_ = m.incus.StopContainer(containerName, false)
 	}
 
 	// Parse the authorized_keys file - get the first valid SSH key

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -47,6 +47,8 @@ type Backend interface {
 	// Config & devices
 	SetConfig(containerName, key, value string) error
 	SetDeviceSize(containerName, deviceName, size string) error
+	UpdateContainerConfig(name, key, value string) error
+	GetRawInstance(name string) (map[string]string, string, error)
 	ResolveGPUInputToPCI(input string) (string, error)
 	CleanupDisk(containerName string) (string, int64, error)
 

--- a/pkg/core/incus/incustest/mock.go
+++ b/pkg/core/incus/incustest/mock.go
@@ -38,6 +38,8 @@ type MockBackend struct {
 	SetDeviceSizeFunc        func(containerName, deviceName, size string) error
 	ResolveGPUInputToPCIFunc func(input string) (string, error)
 	CleanupDiskFunc          func(containerName string) (string, int64, error)
+	UpdateContainerConfigFunc func(name, key, value string) error
+	GetRawInstanceFunc       func(name string) (map[string]string, string, error)
 	AddLabelFunc             func(containerName, key, value string) error
 	RemoveLabelFunc          func(containerName, key string) error
 	GetLabelsFunc            func(containerName string) (map[string]string, error)
@@ -227,6 +229,20 @@ func (m *MockBackend) GetContainerMetrics(name string) (*incus.ContainerMetrics,
 		return m.GetContainerMetricsFunc(name)
 	}
 	return nil, nil
+}
+
+func (m *MockBackend) UpdateContainerConfig(name, key, value string) error {
+	if m.UpdateContainerConfigFunc != nil {
+		return m.UpdateContainerConfigFunc(name, key, value)
+	}
+	return nil
+}
+
+func (m *MockBackend) GetRawInstance(name string) (map[string]string, string, error) {
+	if m.GetRawInstanceFunc != nil {
+		return m.GetRawInstanceFunc(name)
+	}
+	return nil, "", nil
 }
 
 // Compile-time assertion that *MockBackend satisfies incus.Backend.


### PR DESCRIPTION
## Summary

Closes the two out-of-scope items flagged in
`prd/oss/core-library-extraction.md` §"Out-of-scope discoveries"
during the recent extraction work:

- **`pkg/core/container/jump_server.go`** —
  `ExtractSSHKeyFromContainer` (a free function that called
  `incus.New()` internally) → `Manager.ExtractSSHKey` (method
  using the Manager's injected `Backend`). Both CLI callers
  (`sync_accounts.go`, `recover.go`) already create a
  `*container.Manager` — they now call the method directly.
  Now mockable via `incustest.MockBackend`.
- **`internal/server/core_services.go`** — `NewCoreServices` now
  takes `incus.Backend` instead of concrete `*incus.Client`. 7
  call sites in `dual_server.go` are unchanged (`*incus.Client`
  satisfies `Backend` structurally).
- **`pkg/core/incus`** — `Backend` interface extended with
  `UpdateContainerConfig` and `GetRawInstance` (the two methods
  `core_services` uses that weren't already in the interface).
  `incustest.MockBackend` gets matching `*Func` fields and stub
  implementations.

## Test plan
- [x] `go build ./...` exit 0
- [x] All `pkg/core/...`, `internal/server`, `internal/cmd` tests pass
- [x] No call-site behavior change — structural typing handles
  `*incus.Client` → `incus.Backend` transitions for `NewCoreServices`
- [x] `*container.Manager.ExtractSSHKey` exercised through the same
  CLI paths (`containarium sync-accounts`, `containarium recover`)
  that previously called the free function

🤖 Generated with [Claude Code](https://claude.com/claude-code)