### PR TITLE
feat(terraform/module): opt-in CMEK on backend, sentinel, and data disks

### DIFF
--- a/terraform/modules/containarium/main.tf
+++ b/terraform/modules/containarium/main.tf
@@ -106,6 +106,7 @@ resource "google_compute_instance" "jump_server" {
   tags = var.instance_tags
 
   boot_disk {
+    kms_key_self_link = var.kms_key_self_link == "" ? null : var.kms_key_self_link
     initialize_params {
       image = var.os_image
       size  = var.boot_disk_size

--- a/terraform/modules/containarium/sentinel.tf
+++ b/terraform/modules/containarium/sentinel.tf
@@ -33,7 +33,8 @@ resource "google_compute_instance" "sentinel" {
   }
 
   boot_disk {
-    auto_delete = true
+    auto_delete       = true
+    kms_key_self_link = var.kms_key_self_link == "" ? null : var.kms_key_self_link
     initialize_params {
       image = var.os_image
       size  = var.sentinel_boot_disk_size

--- a/terraform/modules/containarium/spot-instance.tf
+++ b/terraform/modules/containarium/spot-instance.tf
@@ -24,6 +24,13 @@ resource "google_compute_disk" "incus_data" {
     }
   )
 
+  dynamic "disk_encryption_key" {
+    for_each = var.kms_key_self_link == "" ? [] : [1]
+    content {
+      kms_key_self_link = var.kms_key_self_link
+    }
+  }
+
   lifecycle {
     prevent_destroy = true
   }
@@ -92,7 +99,8 @@ resource "google_compute_instance" "jump_server_spot" {
   }
 
   boot_disk {
-    auto_delete = true
+    auto_delete       = true
+    kms_key_self_link = var.kms_key_self_link == "" ? null : var.kms_key_self_link
     initialize_params {
       image = var.os_image
       size  = var.boot_disk_size

--- a/terraform/modules/containarium/variables.tf
+++ b/terraform/modules/containarium/variables.tf
@@ -74,6 +74,27 @@ variable "boot_disk_type" {
 }
 
 # -----------------------------------------------------------------------------
+# Encryption (CMEK)
+# -----------------------------------------------------------------------------
+
+variable "kms_key_self_link" {
+  description = <<-EOT
+    Optional customer-managed KMS key for encrypting the backend and sentinel
+    disks (boot + attached data disk). Provide a full self_link, e.g.
+    "projects/<project>/locations/<region>/keyRings/<ring>/cryptoKeys/<key>".
+
+    Default empty string keeps Google-managed encryption (the GCE default).
+    Set this for compliance-bound deployments that need customer-managed keys.
+
+    The compute service account on the project must have
+    roles/cloudkms.cryptoKeyEncrypterDecrypter on the named key before apply
+    succeeds, otherwise disk creation fails with a permission error.
+  EOT
+  type        = string
+  default     = ""
+}
+
+# -----------------------------------------------------------------------------
 # Networking
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a single module variable `kms_key_self_link` (default empty string) that wires customer-managed encryption keys to every disk the module creates. Opt-in for compliance-bound deployments; no behavior change for everyone else.

This is the OSS plumbing piece for the cloud product's at-rest encryption story. The cloud-side product surface (per-org dashboard for "bring your own KMS key", rotation workflows, per-org KMS scoping) is drafted in `Containarium-cloud/prd/cloud/at-rest-encryption.md` and lands separately.

## Verified no-op when unset

```
$ cd terraform/gce-demo && terraform plan
…
No changes. Your infrastructure matches the configuration.
```

Zero diff against the dev demo cluster's current state — existing
deployments don't churn on this PR.

## Wired through to

- `terraform/modules/containarium/main.tf` — non-spot instance `boot_disk`
- `terraform/modules/containarium/sentinel.tf` — sentinel `boot_disk`
- `terraform/modules/containarium/spot-instance.tf` — spot VM `boot_disk` + the persistent data PD (`google_compute_disk.incus_data`)

The data PD uses a `dynamic "disk_encryption_key"` block; the boot disks use the conditional `kms_key_self_link = var.kms_key_self_link == "" ? null : var.kms_key_self_link` pattern.

## Operator note

The compute service account on the project must have `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the named key before apply succeeds, otherwise disk creation fails with a permission error. Documented in the variable description.

## What this does NOT do

- No automatic key rotation
- No per-tenant key scoping (single key across all containers on the same backend)
- No bare-metal peer coverage (the GPU nodes have no PD layer)

Those are the cloud-product story; see `Containarium-cloud/prd/cloud/at-rest-encryption.md` for the full plan.

## Test plan

- [x] `terraform validate` passes
- [x] `terraform plan` with default = zero diff (verified above)
- [ ] Manual: deploy a test env with a real KMS key, verify `gcloud compute disks describe` reports the disk encrypted with the named key

🤖 Generated with [Claude Code](https://claude.com/claude-code)