### PR TITLE
refactor(network): unexport postgresPassthroughStore

### DIFF
--- a/pkg/core/network/passthrough_store.go
+++ b/pkg/core/network/passthrough_store.go
@@ -31,7 +31,7 @@ type PassthroughRecord struct {
 }
 
 // PassthroughStore abstracts persistence of passthrough routes. The production
-// implementation is *PostgresPassthroughStore (PostgreSQL via pgxpool); tests
+// implementation is *postgresPassthroughStore (PostgreSQL via pgxpool); tests
 // or non-PG daemons can supply their own implementation.
 type PassthroughStore interface {
 	Save(ctx context.Context, route *PassthroughRecord) error
@@ -42,9 +42,9 @@ type PassthroughStore interface {
 	Count(ctx context.Context, activeOnly bool) (int32, error)
 }
 
-// PostgresPassthroughStore is the PostgreSQL-backed implementation of
+// postgresPassthroughStore is the PostgreSQL-backed implementation of
 // PassthroughStore.
-type PostgresPassthroughStore struct {
+type postgresPassthroughStore struct {
 	pool *pgxpool.Pool
 }
 
@@ -52,7 +52,7 @@ type PostgresPassthroughStore struct {
 // initializes its schema. Returns the PassthroughStore interface so callers
 // can swap implementations.
 func NewPassthroughStore(ctx context.Context, pool *pgxpool.Pool) (PassthroughStore, error) {
-	store := &PostgresPassthroughStore{pool: pool}
+	store := &postgresPassthroughStore{pool: pool}
 
 	if err := store.initSchema(ctx); err != nil {
 		return nil, fmt.Errorf("failed to initialize passthrough schema: %w", err)
@@ -62,7 +62,7 @@ func NewPassthroughStore(ctx context.Context, pool *pgxpool.Pool) (PassthroughSt
 }
 
 // initSchema creates the passthrough_routes table if it doesn't exist
-func (s *PostgresPassthroughStore) initSchema(ctx context.Context) error {
+func (s *postgresPassthroughStore) initSchema(ctx context.Context) error {
 	schema := `
 		CREATE TABLE IF NOT EXISTS passthrough_routes (
 			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -88,7 +88,7 @@ func (s *PostgresPassthroughStore) initSchema(ctx context.Context) error {
 }
 
 // Save saves or updates a passthrough route (upsert by external_port + protocol)
-func (s *PostgresPassthroughStore) Save(ctx context.Context, route *PassthroughRecord) error {
+func (s *postgresPassthroughStore) Save(ctx context.Context, route *PassthroughRecord) error {
 	query := `
 		INSERT INTO passthrough_routes (external_port, target_ip, target_port, protocol,
 			container_name, description, active, created_by, created_at, updated_at)
@@ -134,7 +134,7 @@ func (s *PostgresPassthroughStore) Save(ctx context.Context, route *PassthroughR
 }
 
 // GetByPortProtocol retrieves a passthrough route by external port and protocol
-func (s *PostgresPassthroughStore) GetByPortProtocol(ctx context.Context, externalPort int, protocol string) (*PassthroughRecord, error) {
+func (s *postgresPassthroughStore) GetByPortProtocol(ctx context.Context, externalPort int, protocol string) (*PassthroughRecord, error) {
 	query := `
 		SELECT id, external_port, target_ip, target_port, protocol,
 			COALESCE(container_name, ''), COALESCE(description, ''), active,
@@ -169,7 +169,7 @@ func (s *PostgresPassthroughStore) GetByPortProtocol(ctx context.Context, extern
 }
 
 // List retrieves all passthrough routes, optionally filtering by active status
-func (s *PostgresPassthroughStore) List(ctx context.Context, activeOnly bool) ([]*PassthroughRecord, error) {
+func (s *postgresPassthroughStore) List(ctx context.Context, activeOnly bool) ([]*PassthroughRecord, error) {
 	var query string
 
 	if activeOnly {
@@ -226,7 +226,7 @@ func (s *PostgresPassthroughStore) List(ctx context.Context, activeOnly bool) ([
 }
 
 // Delete removes a passthrough route by external port and protocol
-func (s *PostgresPassthroughStore) Delete(ctx context.Context, externalPort int, protocol string) error {
+func (s *postgresPassthroughStore) Delete(ctx context.Context, externalPort int, protocol string) error {
 	query := "DELETE FROM passthrough_routes WHERE external_port = $1 AND protocol = $2"
 	result, err := s.pool.Exec(ctx, query, externalPort, protocol)
 
@@ -242,7 +242,7 @@ func (s *PostgresPassthroughStore) Delete(ctx context.Context, externalPort int,
 }
 
 // SetActive sets the active status of a passthrough route
-func (s *PostgresPassthroughStore) SetActive(ctx context.Context, externalPort int, protocol string, active bool) error {
+func (s *postgresPassthroughStore) SetActive(ctx context.Context, externalPort int, protocol string, active bool) error {
 	query := "UPDATE passthrough_routes SET active = $1, updated_at = $2 WHERE external_port = $3 AND protocol = $4"
 	result, err := s.pool.Exec(ctx, query, active, time.Now(), externalPort, protocol)
 
@@ -258,7 +258,7 @@ func (s *PostgresPassthroughStore) SetActive(ctx context.Context, externalPort i
 }
 
 // Count returns the total number of passthrough routes
-func (s *PostgresPassthroughStore) Count(ctx context.Context, activeOnly bool) (int32, error) {
+func (s *postgresPassthroughStore) Count(ctx context.Context, activeOnly bool) (int32, error) {
 	var query string
 	if activeOnly {
 		query = "SELECT COUNT(*) FROM passthrough_routes WHERE active = true"
@@ -275,5 +275,5 @@ func (s *PostgresPassthroughStore) Count(ctx context.Context, activeOnly bool) (
 	return count, nil
 }
 
-// Compile-time assertion that *PostgresPassthroughStore satisfies PassthroughStore.
-var _ PassthroughStore = (*PostgresPassthroughStore)(nil)
+// Compile-time assertion that *postgresPassthroughStore satisfies PassthroughStore.
+var _ PassthroughStore = (*postgresPassthroughStore)(nil)


### PR DESCRIPTION
## Summary
- `NewPassthroughStore` already returns the `PassthroughStore` interface, and no caller type-asserts the concrete struct.
- Rename the concrete type + method receivers + compile-time assertion to lowercase so the package's exported surface stays focused on the interface + factory.

Resolves item **B-1** in `prd/oss/pkg-core-stability.md` (the pre-v1.x audit).

## Test plan
- [x] `go build ./...` exit 0
- [x] `internal/server` and `pkg/core/network` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)