### PR TITLE
docs(network): clarify PassthroughRoute vs PassthroughRecord

### DIFF
--- a/pkg/core/network/passthrough_store.go
+++ b/pkg/core/network/passthrough_store.go
@@ -15,7 +15,13 @@ var (
 	ErrPassthroughNotFound = errors.New("passthrough route not found")
 )
 
-// PassthroughRecord represents a passthrough route stored in PostgreSQL (source of truth)
+// PassthroughRecord is the persistence view of a passthrough route: the
+// runtime fields (port/IP/protocol/etc., the same shape as PassthroughRoute
+// in portforward.go) plus DB metadata (ID, creator, timestamps). The Store
+// interface persists PassthroughRecord values; the sync job reads them and
+// projects them into PassthroughRoute values to drive iptables.
+//
+// PostgreSQL is the source of truth; iptables is the runtime mirror.
 type PassthroughRecord struct {
 	ID            string
 	ExternalPort  int

--- a/pkg/core/network/portforward.go
+++ b/pkg/core/network/portforward.go
@@ -262,7 +262,13 @@ func CheckIPTablesAvailable() bool {
 	return strings.Contains(string(output), "iptables")
 }
 
-// PassthroughRoute represents a TCP/UDP port forwarding rule
+// PassthroughRoute is the runtime view of a passthrough route: the minimum
+// data the iptables layer needs to forward packets. It does NOT carry
+// persistence metadata (ID, creator, timestamps); for the durable, DB-backed
+// view see PassthroughRecord in passthrough_store.go.
+//
+// The sync job projects PassthroughRecord values from the Store into
+// PassthroughRoute values to drive iptables.
 type PassthroughRoute struct {
 	ExternalPort  int
 	TargetIP      string


### PR DESCRIPTION
## Summary
- Two near-identical-looking types in `pkg/core/network/` serve distinct roles. Replace one-line comments with multi-line ones that explain the runtime-vs-persistence split and how they relate.
- Doc-only — no behavior change.

Resolves item **B-2** in `prd/oss/pkg-core-stability.md` (the pre-v1.x audit).

## Test plan
- [x] `go build ./...` exit 0 (sanity check; no code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)