### PR TITLE
refactor(incus): remove dead helpers FindCoreContainers, HasRole

### DIFF
--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -851,28 +851,6 @@ func (c *Client) FindContainerByRole(role Role) (*ContainerInfo, error) {
 	return nil, fmt.Errorf("no running container found with role %s", role)
 }
 
-// FindCoreContainers returns all containers with a "core-*" role, sorted by
-// boot priority (highest first). Used to discover which containers must be
-// healthy before the daemon proceeds.
-func (c *Client) FindCoreContainers() ([]ContainerInfo, error) {
-	containers, err := c.ListContainers()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list containers: %w", err)
-	}
-
-	var core []ContainerInfo
-	for _, ct := range containers {
-		inst, _, err := c.server.GetInstance(ct.Name)
-		if err != nil {
-			continue
-		}
-		if r := inst.Config[RoleKey]; strings.HasPrefix(r, "core-") {
-			core = append(core, ct)
-		}
-	}
-	return core, nil
-}
-
 // UpdateContainerConfig sets a single config key on a container.
 func (c *Client) UpdateContainerConfig(name, key, value string) error {
 	inst, etag, err := c.server.GetInstance(name)
@@ -885,15 +863,6 @@ func (c *Client) UpdateContainerConfig(name, key, value string) error {
 		return fmt.Errorf("failed to update container config: %w", err)
 	}
 	return op.Wait()
-}
-
-// HasRole checks whether a container has a role label set (any core-* role).
-func (c *Client) HasRole(name string) bool {
-	inst, _, err := c.server.GetInstance(name)
-	if err != nil {
-		return false
-	}
-	return inst.Config[RoleKey] != ""
 }
 
 // GetRawInstance returns the raw config map for a container.


### PR DESCRIPTION
## Summary
- Remove two methods on `*incus.Client` that have **zero** external callers (`FindCoreContainers`, `HasRole`). Neither is part of the `Backend` interface — they only existed on the concrete `*Client` type.
- Closes the dead-method portion of the daemon-helpers audit row in `prd/oss/pkg-core-stability.md`. `FindCaddyContainerIP` (2 callers) and `FindContainerByRole` (5 callers) stay; moving them to `coresys` is a v1.x-prep item, not pre-v1.x cleanup.

## Test plan
- [x] `go build ./...` exit 0
- [x] `pkg/core/incus` tests pass
- [x] grep across whole tree confirms zero callers of either method

🤖 Generated with [Claude Code](https://claude.com/claude-code)