### PR TITLE
docs(pkg/core): add package-level doc.go for 7 packages

### DIFF
--- a/pkg/core/container/doc.go
+++ b/pkg/core/container/doc.go
@@ -1,0 +1,8 @@
+// Package container provides the high-level container lifecycle Manager
+// used by both the OSS daemon and any future cloud daemon: create, start,
+// stop, delete, resize, label, plus jump-server SSH provisioning and
+// collaborator-account management.
+//
+// Manager wraps an incus.Backend; production code uses container.New(),
+// tests use container.NewWithBackend(mock).
+package container

--- a/pkg/core/coresys/doc.go
+++ b/pkg/core/coresys/doc.go
@@ -1,0 +1,6 @@
+// Package coresys manages the _containarium-core system container, which
+// hosts the daemon's internal services (PostgreSQL, Redis, Caddy,
+// VictoriaMetrics). It is *not* a generic infrastructure abstraction —
+// the contained services and their layout are specific to the Containarium
+// daemon. A self-hosted user gets one core container per host.
+package coresys

--- a/pkg/core/incus/doc.go
+++ b/pkg/core/incus/doc.go
@@ -1,0 +1,9 @@
+// Package incus wraps the Incus/LXC API used to drive container lifecycle,
+// networking, and storage on a Containarium host. It exposes a concrete
+// production *Client and a Backend interface that consumers depend on for
+// mocking (see pkg/core/incus/incustest.MockBackend).
+//
+// Most consumers should depend on Backend, not *Client. Methods that exist
+// only on *Client (not in Backend) tend to be daemon-shape helpers rather
+// than reusable primitives.
+package incus

--- a/pkg/core/network/doc.go
+++ b/pkg/core/network/doc.go
@@ -1,0 +1,8 @@
+// Package network provides network primitives for Containarium hosts:
+// passthrough TCP/UDP routing via iptables, port-forwarding setup, and
+// PostgreSQL-backed persistence of route definitions.
+//
+// PassthroughRecord is the persistence view (source of truth);
+// PassthroughRoute is the runtime/iptables view. See each type's doc
+// comment for the projection between them.
+package network

--- a/pkg/core/ospkg/doc.go
+++ b/pkg/core/ospkg/doc.go
@@ -1,0 +1,4 @@
+// Package ospkg abstracts over Linux package managers (apt on Debian /
+// Ubuntu, dnf on RHEL / Fedora) so installer logic can target a single
+// PackageManager interface regardless of the container's OS family.
+package ospkg

--- a/pkg/core/ostype/doc.go
+++ b/pkg/core/ostype/doc.go
@@ -1,0 +1,4 @@
+// Package ostype detects the OS family of a container (Debian, RHEL, etc.)
+// and maps Containarium's logical OSType to concrete Incus image names.
+// Used by the container Manager during Create to resolve the right image.
+package ostype

--- a/pkg/core/stacks/doc.go
+++ b/pkg/core/stacks/doc.go
@@ -1,0 +1,6 @@
+// Package stacks defines reusable software stacks (Node.js, Python, etc.)
+// that can be installed inside a Containarium container as part of
+// provisioning. A stack is a YAML document specifying base packages,
+// pre/post install commands per OS family, and parameters consumers can
+// pass through.
+package stacks


### PR DESCRIPTION
## Summary
- Adds a `doc.go` with a package-level godoc comment to each `pkg/core/*` package that was missing one: `incus`, `container`, `coresys`, `network`, `ospkg`, `ostype`, `stacks`. (`expose` and `incus/incustest` already had one.)
- Each doc states what the package is for, who consumes it, and any non-obvious split (e.g. `PassthroughRecord` vs `PassthroughRoute`, `Backend` vs `Client`).
- 7 small new files, no code changed.

Closes the package-level half of audit Item 2 in `prd/oss/pkg-core-stability.md`. Per-export godoc (every exported type / method) remains to be done in a follow-up — that's much bigger.

## Test plan
- [x] `go build ./...` exit 0
- [x] `go vet ./pkg/core/...` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)