### PR TITLE
feat(mcp): security_scan + security_findings + security_remediate

### DIFF
--- a/internal/cmd/security.go
+++ b/internal/cmd/security.go
@@ -1,0 +1,205 @@
+// Security CLI subcommands — scan, findings, remediate. Same Go calls
+// the MCP tools use (one function, two surfaces per CLAUDE.md
+// CLI-first).
+//
+// Why one file for three commands: they share a tiny client and a
+// small set of helpers; splitting across three files would mostly
+// duplicate boilerplate. If any of them grows non-trivially, split.
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/mcp"
+	"github.com/spf13/cobra"
+)
+
+// --- containarium security-scan --------------------------------------------
+
+var (
+	scanUser string
+	scanKind string
+)
+
+var securityScanCmd = &cobra.Command{
+	Use:   "security-scan <username>",
+	Short: "Trigger one or more security scans on a container",
+	Long: `Trigger ClamAV (malware), pentest (CVE), or ZAP (DAST) scans on a
+container. Default --kind=all runs all three. Scans run asynchronously
+on the daemon; use 'security-findings' to read results.
+
+Typical durations:
+  - clamav: seconds
+  - pentest: tens of seconds
+  - zap: minutes
+
+For continuous/scheduled scans, see the cloud product's security-patch
+agent. This CLI command is the one-shot BYOA equivalent.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSecurityScan,
+}
+
+// --- containarium security-findings ----------------------------------------
+
+var (
+	findUser string
+	findKind string
+)
+
+var securityFindingsCmd = &cobra.Command{
+	Use:   "security-findings <username>",
+	Short: "List security findings for a container (normalized across scanners)",
+	Long: `List findings across ClamAV, pentest, and ZAP scanners, merged into a
+single normalized shape with a 'kind' label.
+
+Only findings with fixAvailable=true can be auto-remediated by
+'security-remediate'. Today that's pentest findings only (the daemon's
+RemediatePentestFinding runs a package upgrade).`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSecurityFindings,
+}
+
+// --- containarium security-remediate ---------------------------------------
+
+var securityRemediateCmd = &cobra.Command{
+	Use:   "security-remediate <finding-id>",
+	Short: "Apply the daemon's one-shot auto-fix for a security finding",
+	Long: `Attempt to remediate a security finding by its ID (from
+'security-findings'). Currently only pentest findings with
+fixAvailable=true are supported — the daemon upgrades the affected
+package.
+
+This is a one-shot operator action. Do NOT chain scan → pick →
+remediate in scripts without human confirmation; that's the cloud
+product's hosted security-patch agent territory.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSecurityRemediate,
+}
+
+func init() {
+	rootCmd.AddCommand(securityScanCmd)
+	securityScanCmd.Flags().StringVar(&scanKind, "kind", "all", "clamav | pentest | zap | all")
+
+	rootCmd.AddCommand(securityFindingsCmd)
+	securityFindingsCmd.Flags().StringVar(&findKind, "kind", "all", "clamav | pentest | zap | all")
+
+	rootCmd.AddCommand(securityRemediateCmd)
+}
+
+// runSecurityScan dispatches the scan via the same Go code path the
+// MCP tool uses. Reuses mcp.Client because the CLI talks to the daemon
+// over the same REST surface; no need for a parallel client layer.
+func runSecurityScan(_ *cobra.Command, args []string) error {
+	scanUser = args[0]
+	c, err := newSecurityClient()
+	if err != nil {
+		return err
+	}
+	resp, err := c.TriggerSecurityScan(strings.ToLower(scanKind), scanUser+"-container", scanUser)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Scan(s) queued: kind=%s queued=%d\n  %s\n  → %s\n",
+		resp.Kind, resp.Queued, resp.Message, resp.PollHint)
+	return nil
+}
+
+func runSecurityFindings(_ *cobra.Command, args []string) error {
+	findUser = args[0]
+	c, err := newSecurityClient()
+	if err != nil {
+		return err
+	}
+	findings, err := c.ListSecurityFindings(strings.ToLower(findKind), findUser+"-container")
+	if err != nil {
+		return err
+	}
+	if len(findings) == 0 {
+		fmt.Println("No findings.")
+		return nil
+	}
+	// One-line-per-finding for shell readability. Use --format=json if
+	// you need machine output (drop into jq).
+	if outputFormat == "json" {
+		out, _ := json.MarshalIndent(findings, "", "  ")
+		fmt.Println(string(out))
+		return nil
+	}
+	for _, f := range findings {
+		fix := " "
+		if f.FixAvailable {
+			fix = "F"
+		}
+		fmt.Printf("[%s] [%-8s] [%s] id=%d %s\n",
+			fix, f.Kind, padSeverity(f.Severity), f.ID, f.Title)
+	}
+	return nil
+}
+
+func runSecurityRemediate(_ *cobra.Command, args []string) error {
+	fid, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		return fmt.Errorf("finding-id must be an integer: %w", err)
+	}
+	c, err := newSecurityClient()
+	if err != nil {
+		return err
+	}
+	resp, err := c.RemediateSecurityFinding(fid)
+	if err != nil {
+		return err
+	}
+	if !resp.Success {
+		fmt.Printf("Remediation FAILED: %s\n", resp.Message)
+		return fmt.Errorf("remediation reported failure")
+	}
+	fmt.Printf("Remediation OK: %s\n", resp.Message)
+	if resp.PackageName != "" {
+		fmt.Printf("  package: %s   %s → %s\n", resp.PackageName, resp.OldVersion, resp.NewVersion)
+	}
+	return nil
+}
+
+// newSecurityClient builds an mcp.Client pointed at the configured
+// daemon. Reuses the same env vars the MCP server uses
+// (CONTAINARIUM_SERVER_URL, CONTAINARIUM_JWT_TOKEN) so operators
+// configure once.
+func newSecurityClient() (*mcp.Client, error) {
+	serverURL := os.Getenv("CONTAINARIUM_SERVER_URL")
+	if serverURL == "" && serverAddr != "" {
+		// Fall back to the global --server flag.
+		serverURL = serverAddr
+		if !strings.HasPrefix(serverURL, "http") {
+			serverURL = "http://" + serverURL
+		}
+	}
+	if serverURL == "" {
+		return nil, fmt.Errorf("set CONTAINARIUM_SERVER_URL or use --server")
+	}
+	token := os.Getenv("CONTAINARIUM_JWT_TOKEN")
+	if token == "" {
+		return nil, fmt.Errorf("set CONTAINARIUM_JWT_TOKEN to a daemon-issued JWT")
+	}
+	if _, err := url.Parse(serverURL); err != nil {
+		return nil, fmt.Errorf("invalid CONTAINARIUM_SERVER_URL: %w", err)
+	}
+	c := mcp.NewClient(serverURL, token)
+	_ = time.Second // placeholder for future timeout tuning
+	return c, nil
+}
+
+// padSeverity right-pads to 8 chars so the table aligns ("critical"
+// is the widest; "info" is 4).
+func padSeverity(s string) string {
+	const w = 8
+	if len(s) >= w {
+		return s[:w]
+	}
+	return s + strings.Repeat(" ", w-len(s))
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -274,6 +275,237 @@ func (c *Client) GetBackend(id string) (*Backend, error) {
 		}
 	}
 	return nil, fmt.Errorf("backend %q not found", id)
+}
+
+// TriggerSecurityScan posts to the daemon's scan-trigger endpoints. For
+// kind="all" it runs the three trigger endpoints sequentially and rolls
+// up the queued counts. Errors from individual triggers are collected
+// but don't abort the others — a partial scan is better than none.
+func (c *Client) TriggerSecurityScan(kind, containerName, username string) (*SecurityScanResponse, error) {
+	kinds := []string{kind}
+	if kind == scanKindAll {
+		kinds = []string{scanKindClamav, scanKindPentest, scanKindZap}
+	}
+
+	type triggerOk struct {
+		Message      string `json:"message"`
+		ScannedCount int    `json:"scannedCount"`
+	}
+
+	var msgs []string
+	var totalQueued int
+	for _, k := range kinds {
+		var path string
+		var body interface{}
+		switch k {
+		case scanKindClamav:
+			path = "/v1/security/clamav-scan"
+			body = map[string]string{"containerName": containerName}
+		case scanKindPentest:
+			path = "/v1/pentest/scan"
+			body = map[string]string{"username": username}
+		case scanKindZap:
+			path = "/v1/zap/scan"
+			body = map[string]string{"username": username}
+		}
+		respBody, err := c.doRequest("POST", path, body)
+		if err != nil {
+			msgs = append(msgs, fmt.Sprintf("%s: error: %v", k, err))
+			continue
+		}
+		var resp triggerOk
+		_ = json.Unmarshal(respBody, &resp)
+		if resp.Message != "" {
+			msgs = append(msgs, fmt.Sprintf("%s: %s", k, resp.Message))
+		} else {
+			msgs = append(msgs, fmt.Sprintf("%s: triggered", k))
+		}
+		totalQueued += resp.ScannedCount
+		if resp.ScannedCount == 0 {
+			totalQueued++ // some triggers don't return a count
+		}
+	}
+
+	poll := "Call security_findings in ~30s for ClamAV/pentest; ZAP runs minutes."
+	if kind == scanKindClamav {
+		poll = "ClamAV is fast — call security_findings in ~5s."
+	}
+	if kind == scanKindZap {
+		poll = "ZAP can take 1-5 minutes. Call security_findings periodically."
+	}
+	return &SecurityScanResponse{
+		Kind:     kind,
+		Message:  strings.Join(msgs, "; "),
+		Queued:   totalQueued,
+		PollHint: poll,
+	}, nil
+}
+
+// ListSecurityFindings fetches findings from one or all scanner kinds and
+// normalizes them into the unified SecurityFinding shape.
+func (c *Client) ListSecurityFindings(kind, containerName string) ([]SecurityFinding, error) {
+	kinds := []string{kind}
+	if kind == scanKindAll {
+		kinds = []string{scanKindClamav, scanKindPentest, scanKindZap}
+	}
+
+	var out []SecurityFinding
+	for _, k := range kinds {
+		rows, err := c.listOneScanner(k, containerName)
+		if err != nil {
+			// Per-scanner failures shouldn't abort the others — surface
+			// them as a synthetic "info" row so the agent sees why.
+			out = append(out, SecurityFinding{
+				Kind:        k,
+				Severity:    "info",
+				Title:       fmt.Sprintf("scanner %s unreachable", k),
+				Description: err.Error(),
+			})
+			continue
+		}
+		out = append(out, rows...)
+	}
+	return out, nil
+}
+
+// listOneScanner pulls + normalizes findings from one scanner.
+func (c *Client) listOneScanner(kind, containerName string) ([]SecurityFinding, error) {
+	switch kind {
+	case scanKindClamav:
+		path := "/v1/security/clamav-reports?containerName=" + containerName
+		body, err := c.doRequest("GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+		var resp struct {
+			Reports []struct {
+				ID            int64  `json:"id"`
+				ContainerName string `json:"containerName"`
+				Status        string `json:"status"`
+				FindingsCount int    `json:"findingsCount"`
+				Findings      string `json:"findings"`
+			} `json:"reports"`
+		}
+		_ = json.Unmarshal(body, &resp)
+		var out []SecurityFinding
+		for _, r := range resp.Reports {
+			if r.Status != "infected" || r.FindingsCount == 0 {
+				continue
+			}
+			out = append(out, SecurityFinding{
+				Kind:          scanKindClamav,
+				ID:            r.ID,
+				Severity:      "critical", // infected = critical by default
+				Title:         fmt.Sprintf("ClamAV found %d infected file(s)", r.FindingsCount),
+				Description:   r.Findings,
+				ContainerName: r.ContainerName,
+				FixAvailable:  false, // ClamAV findings require quarantine workflow, not auto-fix
+			})
+		}
+		return out, nil
+
+	case scanKindPentest:
+		path := "/v1/pentest/findings?containerName=" + containerName
+		body, err := c.doRequest("GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+		var resp struct {
+			Findings []struct {
+				ID                int64  `json:"id"`
+				Severity          string `json:"severity"`
+				Title             string `json:"title"`
+				Description       string `json:"description"`
+				Target            string `json:"target"`
+				RemediationActive bool   `json:"remediationActive"`
+				Suppressed        bool   `json:"suppressed"`
+			} `json:"findings"`
+		}
+		_ = json.Unmarshal(body, &resp)
+		var out []SecurityFinding
+		for _, f := range resp.Findings {
+			if f.Suppressed {
+				continue
+			}
+			out = append(out, SecurityFinding{
+				Kind:         scanKindPentest,
+				ID:           f.ID,
+				Severity:     f.Severity,
+				Title:        f.Title,
+				Description:  f.Description,
+				Target:       f.Target,
+				FixAvailable: true, // pentest is the one kind RemediatePentestFinding can act on
+			})
+		}
+		return out, nil
+
+	case scanKindZap:
+		path := "/v1/zap/alerts?containerName=" + containerName
+		body, err := c.doRequest("GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+		var resp struct {
+			Alerts []struct {
+				ID          int64  `json:"id"`
+				AlertName   string `json:"alertName"`
+				Risk        string `json:"risk"`
+				Description string `json:"description"`
+				URL         string `json:"url"`
+				Suppressed  bool   `json:"suppressed"`
+			} `json:"alerts"`
+		}
+		_ = json.Unmarshal(body, &resp)
+		var out []SecurityFinding
+		for _, a := range resp.Alerts {
+			if a.Suppressed {
+				continue
+			}
+			out = append(out, SecurityFinding{
+				Kind:         scanKindZap,
+				ID:           a.ID,
+				Severity:     normalizeZapRisk(a.Risk),
+				Title:        a.AlertName,
+				Description:  a.Description,
+				Target:       a.URL,
+				FixAvailable: false, // ZAP findings need web-app code fixes; no auto-remediation today
+			})
+		}
+		return out, nil
+	}
+	return nil, fmt.Errorf("unknown kind: %s", kind)
+}
+
+// normalizeZapRisk maps ZAP's "high|medium|low|informational" onto our
+// shared severity set.
+func normalizeZapRisk(r string) string {
+	switch strings.ToLower(r) {
+	case "high":
+		return "high"
+	case "medium":
+		return "medium"
+	case "low":
+		return "low"
+	case "informational", "info":
+		return "info"
+	}
+	return "info"
+}
+
+// RemediateSecurityFinding calls the daemon's RemediatePentestFinding
+// RPC. Only valid for pentest findings; ClamAV/ZAP findings are
+// rejected with FixAvailable=false at security_findings time.
+func (c *Client) RemediateSecurityFinding(findingID int64) (*SecurityRemediateResponse, error) {
+	path := fmt.Sprintf("/v1/pentest/findings/%d/remediate", findingID)
+	body, err := c.doRequest("POST", path, struct{}{})
+	if err != nil {
+		return nil, err
+	}
+	var resp SecurityRemediateResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse remediate response: %w", err)
+	}
+	return &resp, nil
 }
 
 // API Request/Response types

--- a/internal/mcp/security.go
+++ b/internal/mcp/security.go
@@ -1,0 +1,159 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Security tool kinds — match the daemon's three scanner subsystems.
+// Used as the `kind` enum on security_scan and as the source label on
+// each row returned by security_findings.
+const (
+	scanKindClamav  = "clamav"
+	scanKindPentest = "pentest"
+	scanKindZap     = "zap"
+	scanKindAll     = "all"
+)
+
+// SecurityFinding is the normalized cross-scanner shape returned by
+// security_findings. The daemon emits three scanner-specific shapes
+// (ClamavReport, PentestFinding, ZapAlert); we map all three onto one
+// type so agents can reason about "what's wrong" without branching on
+// scanner. The `kind` field is the only thing that varies, plus
+// `fix_available` which lets the agent know whether security_remediate
+// can act on this row.
+type SecurityFinding struct {
+	Kind          string `json:"kind"`     // "clamav" | "pentest" | "zap"
+	ID            int64  `json:"id"`       // daemon-side row ID; pass to security_remediate
+	Severity      string `json:"severity"` // normalized to {"critical","high","medium","low","info"}
+	Title         string `json:"title"`
+	Description   string `json:"description,omitempty"`
+	ContainerName string `json:"containerName,omitempty"`
+	Target        string `json:"target,omitempty"`        // pentest/ZAP-side target (URL, IP:port)
+	FixAvailable  bool   `json:"fixAvailable"`            // true ↔ security_remediate can act
+}
+
+// SecurityScanResponse is what security_scan returns to the agent.
+type SecurityScanResponse struct {
+	Kind     string `json:"kind"`     // echoed request kind
+	Message  string `json:"message"`  // human-readable summary across the scanners that ran
+	Queued   int    `json:"queued"`   // total scan jobs queued (across scanners if kind=all)
+	PollHint string `json:"pollHint"` // advisory for the agent on when to call security_findings next
+}
+
+// SecurityRemediateResponse mirrors the daemon's
+// RemediatePentestFindingResponse but is exposed as a stable MCP shape.
+type SecurityRemediateResponse struct {
+	Success     bool   `json:"success"`
+	Message     string `json:"message"`
+	PackageName string `json:"packageName,omitempty"`
+	OldVersion  string `json:"oldVersion,omitempty"`
+	NewVersion  string `json:"newVersion,omitempty"`
+}
+
+// --- MCP handlers ----------------------------------------------------------
+
+// handleSecurityScan triggers one or more scanners against a container.
+// The work is asynchronous on the daemon side; this call returns once
+// the daemon has accepted the trigger(s). Agents should call
+// security_findings after a reasonable delay (scan durations vary —
+// ClamAV is fast, pentest tens of seconds, ZAP minutes).
+func handleSecurityScan(client *Client, args map[string]interface{}) (string, error) {
+	username := getStringArg(args, "username", "")
+	if username == "" {
+		return "", fmt.Errorf("username is required")
+	}
+	kind := strings.ToLower(getStringArg(args, "kind", scanKindAll))
+	switch kind {
+	case scanKindClamav, scanKindPentest, scanKindZap, scanKindAll:
+	default:
+		return "", fmt.Errorf("kind must be one of: clamav, pentest, zap, all (got %q)", kind)
+	}
+
+	containerName := username + "-container"
+	resp, err := client.TriggerSecurityScan(kind, containerName, username)
+	if err != nil {
+		return "", fmt.Errorf("trigger scan: %w", err)
+	}
+	out, _ := json.MarshalIndent(resp, "", "  ")
+	return string(out), nil
+}
+
+// handleSecurityFindings returns the normalized list of findings across
+// scanner kinds. By default it fetches findings for the username's
+// container; pass kind="all" (default) or restrict to one scanner.
+func handleSecurityFindings(client *Client, args map[string]interface{}) (string, error) {
+	username := getStringArg(args, "username", "")
+	if username == "" {
+		return "", fmt.Errorf("username is required")
+	}
+	kind := strings.ToLower(getStringArg(args, "kind", scanKindAll))
+	switch kind {
+	case scanKindClamav, scanKindPentest, scanKindZap, scanKindAll:
+	default:
+		return "", fmt.Errorf("kind must be one of: clamav, pentest, zap, all (got %q)", kind)
+	}
+
+	containerName := username + "-container"
+	findings, err := client.ListSecurityFindings(kind, containerName)
+	if err != nil {
+		return "", fmt.Errorf("list findings: %w", err)
+	}
+
+	// Wrap in a stable envelope so the agent can read counts without
+	// summing the array.
+	envelope := map[string]interface{}{
+		"kind":       kind,
+		"container":  containerName,
+		"totalCount": len(findings),
+		"findings":   findings,
+	}
+	out, _ := json.MarshalIndent(envelope, "", "  ")
+	return string(out), nil
+}
+
+// handleSecurityRemediate calls the daemon's RemediatePentestFinding
+// RPC. Today only pentest findings are auto-fixable (the daemon
+// upgrades the affected package). ClamAV/ZAP findings have
+// `fix_available=false` and will return an error here.
+//
+// IMPORTANT: this is a one-shot operator-invoked action. The MCP
+// description doesn't tell the agent to chain scan→pick→remediate
+// autonomously. Continuous/hosted remediation is a paywalled cloud
+// feature; see Containarium-cloud's prd/cloud/security-patch-agent.md.
+func handleSecurityRemediate(client *Client, args map[string]interface{}) (string, error) {
+	fid, ok := getInt64Arg(args, "finding_id")
+	if !ok {
+		return "", fmt.Errorf("finding_id is required")
+	}
+	resp, err := client.RemediateSecurityFinding(fid)
+	if err != nil {
+		return "", fmt.Errorf("remediate: %w", err)
+	}
+	out, _ := json.MarshalIndent(resp, "", "  ")
+	return string(out), nil
+}
+
+// getInt64Arg is the int sibling of getStringArg. JSON numbers decode
+// to float64 in map[string]interface{}, so we accept either int64,
+// float64, or a string parse.
+func getInt64Arg(args map[string]interface{}, key string) (int64, bool) {
+	v, ok := args[key]
+	if !ok {
+		return 0, false
+	}
+	switch x := v.(type) {
+	case int64:
+		return x, true
+	case int:
+		return int64(x), true
+	case float64:
+		return int64(x), true
+	case string:
+		var n int64
+		_, err := fmt.Sscanf(x, "%d", &n)
+		return n, err == nil
+	}
+	return 0, false
+}

--- a/internal/mcp/security_test.go
+++ b/internal/mcp/security_test.go
@@ -1,0 +1,47 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeZapRisk(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"High", "high"},
+		{"medium", "medium"},
+		{"LOW", "low"},
+		{"Informational", "info"},
+		{"Info", "info"},
+		{"unknown-stuff", "info"},
+		{"", "info"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, normalizeZapRisk(c.in), "input %q", c.in)
+	}
+}
+
+func TestGetInt64Arg(t *testing.T) {
+	cases := []struct {
+		name string
+		args map[string]interface{}
+		key  string
+		want int64
+		ok   bool
+	}{
+		{"missing", map[string]interface{}{}, "id", 0, false},
+		{"int64", map[string]interface{}{"id": int64(42)}, "id", 42, true},
+		{"int", map[string]interface{}{"id": 7}, "id", 7, true},
+		{"float64 (JSON shape)", map[string]interface{}{"id": float64(13)}, "id", 13, true},
+		{"string-parsable", map[string]interface{}{"id": "99"}, "id", 99, true},
+		{"string-unparseable", map[string]interface{}{"id": "abc"}, "id", 0, false},
+		{"wrong type", map[string]interface{}{"id": []int{1, 2}}, "id", 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := getInt64Arg(c.args, c.key)
+			assert.Equal(t, c.want, got)
+			assert.Equal(t, c.ok, ok)
+		})
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -21,7 +21,7 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	assert.Len(t, server.tools, 15, "Should have 15 tools registered")
+	assert.Len(t, server.tools, 18, "Should have 18 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -125,7 +125,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	assert.Len(t, tools, 15)
+	assert.Len(t, tools, 18)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -385,6 +385,101 @@ func (s *Server) registerTools() {
 			Handler: handleSync,
 		},
 		{
+			Name: "security_scan",
+			Description: "Run a security scan on a container. Triggers one or more of the daemon's " +
+				"three scanner subsystems: ClamAV (malware in container files), pentest " +
+				"(CVE-style vulnerabilities in installed packages), ZAP (web-app DAST against " +
+				"any exposed HTTP services).\n\n" +
+				"This is a one-shot operator-invoked action — call it when you suspect or " +
+				"need to confirm a container's security posture. The scans run asynchronously " +
+				"on the daemon; this tool returns once the trigger is accepted. After waiting " +
+				"(see `pollHint` in the response), call `security_findings` to read results.\n\n" +
+				"Typical durations:\n" +
+				"  - clamav: seconds (file walk + signature match)\n" +
+				"  - pentest: tens of seconds (per-target probe)\n" +
+				"  - zap: minutes (active spider + attack passes)\n\n" +
+				"For continuous/scheduled scanning, the cloud product offers a hosted " +
+				"security-patch agent (see the cloud roadmap). This OSS tool is the one-shot " +
+				"BYOA equivalent.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":        "string",
+						"description": "Container username (same value used by create_container).",
+					},
+					"kind": map[string]interface{}{
+						"type":        "string",
+						"enum":        []string{"clamav", "pentest", "zap", "all"},
+						"description": "Which scanner(s) to run. Default 'all' triggers all three.",
+					},
+				},
+				"required": []string{"username"},
+			},
+			Handler: handleSecurityScan,
+		},
+		{
+			Name: "security_findings",
+			Description: "List security findings for a container, normalized across the three " +
+				"scanner subsystems (ClamAV, pentest, ZAP). Returns a single shape per finding " +
+				"so the agent doesn't have to branch on scanner internals:\n" +
+				"  - kind:          'clamav' | 'pentest' | 'zap'\n" +
+				"  - id:            daemon-side row ID; pass to security_remediate\n" +
+				"  - severity:      'critical' | 'high' | 'medium' | 'low' | 'info'\n" +
+				"  - title:         short description\n" +
+				"  - description:   detail (optional)\n" +
+				"  - containerName: which container the finding pertains to\n" +
+				"  - target:        URL/IP:port for pentest+ZAP (optional)\n" +
+				"  - fixAvailable:  true → `security_remediate` can act on this row.\n\n" +
+				"Today only pentest findings have `fixAvailable=true` (the daemon's " +
+				"`RemediatePentestFinding` runs a package upgrade). ClamAV findings need " +
+				"a quarantine workflow; ZAP findings need web-app code fixes — neither has " +
+				"an auto-fix path yet. Filter to one scanner with `kind`.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":        "string",
+						"description": "Container username.",
+					},
+					"kind": map[string]interface{}{
+						"type":        "string",
+						"enum":        []string{"clamav", "pentest", "zap", "all"},
+						"description": "Restrict to one scanner. Default 'all' merges results.",
+					},
+				},
+				"required": []string{"username"},
+			},
+			Handler: handleSecurityFindings,
+		},
+		{
+			Name: "security_remediate",
+			Description: "Attempt to auto-fix a security finding. Currently only works on " +
+				"pentest-kind findings where `fixAvailable=true` (the daemon's " +
+				"`RemediatePentestFinding` runs a package upgrade). ClamAV and ZAP findings " +
+				"return an error here — they need different fix workflows that don't exist " +
+				"yet.\n\n" +
+				"This is a one-shot, operator-confirmed action. Do NOT chain " +
+				"`security_scan → security_findings → security_remediate` autonomously " +
+				"without user confirmation — surface the findings to the user first, let " +
+				"them decide which to fix.\n\n" +
+				"Returns `success`, `packageName`, `oldVersion`, `newVersion` on a successful " +
+				"package upgrade. A failed remediate doesn't put the finding into a wedged " +
+				"state — the same finding can be remediated again after fixing the underlying " +
+				"reason (locked package, missing apt index, etc.).",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"finding_id": map[string]interface{}{
+						"type":        "integer",
+						"description": "Finding ID from security_findings (`id` field).",
+					},
+				},
+				"required": []string{"finding_id"},
+			},
+			Handler: handleSecurityRemediate,
+		},
+		{
 			Name: "sync_ssh_config",
 			Description: "Generate a self-contained ssh_config covering every reachable container " +
 				"and write it to ~/.containarium/ssh_config. After this call, `ssh <username>` " +


### PR DESCRIPTION
## Summary

Three new MCP tools (and matching CLI subcommands) expose the daemon's existing scanner subsystems — ClamAV (malware), pentest (CVEs), ZAP (DAST) — to operator-driven agents. The underlying daemon RPCs all already exist in OSS code; this PR is the MCP/CLI exposure on top.

| Tool | What | Returns |
|---|---|---|
| `security_scan` | Trigger one or more scanner endpoints. `kind` enum: clamav, pentest, zap, all (default). | Queued count + `pollHint` for the agent. |
| `security_findings` | Normalized cross-scanner view. Each row has `kind`, `severity`, `title`, `description`, `target`, and `fixAvailable`. | Array of `SecurityFinding`. |
| `security_remediate` | Calls the daemon's `RemediatePentestFinding`. Pentest only at v1. | success + package_name + old/new version. |

Tool count 15 → 18. Same Go function backs each CLI subcommand + each MCP tool (CLI-first per CLAUDE.md).

## Licensing posture (deliberate)

`licensing.md` §70 reserves \"hosted auto-fix / security-patch agent\" for cloud, and `roadmap/2026-Q4.md` §AI features targets 2027. This PR is the OSS BYOA path: one-shot operator-invoked tools the user explicitly drives.

Tool descriptions:
- Emphasize one-shot use; explicitly tell the agent NOT to chain `scan → pick → remediate` autonomously
- Point at the cloud product for the continuous/hosted variant
- Reserve only `pentest` findings as `fixAvailable=true` — the daemon's existing one-shot package-upgrade RPC

The cloud differentiation (scheduler + agent + audit log + dashboard + per-tenant scoping) is drafted in Containarium-cloud PR #12 (`prd/cloud/security-patch-agent.md`).

## What's NOT in scope

- ClamAV/ZAP auto-remediation (no daemon RPC today; quarantine + sanitizer-hint flows are separate work)
- Suppression workflows (`SuppressPentestFinding`, `SuppressZapAlert`) — useful follow-up, separate tool
- `GetScanStatus` exposure — info duplicates `security_findings`; skip until needed
- A continuous scan agent — that's the cloud feature

## Test plan

- [x] `go build ./...` green
- [x] `go test ./internal/mcp/... ./internal/cmd/...` green (14 new test cases on pure helpers)
- [x] `go vet` clean
- [ ] Manual end-to-end on the live demo cluster: trigger a pentest scan against an installed-package container, list findings, remediate. Deferred to the next demo recording session — daemon RPCs are unchanged so this PR can't break anything that already worked.

## References

- Containarium-cloud PR #12 — `AI Security-Patch Agent` PRD (cloud-side continuous loop, 2027 target)
- `licensing.md` §70 — open-core line for security-patch agent
- `roadmap/2026-Q4.md` §AI features — 2027 timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)