### PR TITLE
push v2: real git push over SSH + post-receive deploy hook

### DIFF
--- a/internal/cmd/push.go
+++ b/internal/cmd/push.go
@@ -15,20 +15,31 @@ var (
 	pushSentinelHost string
 	pushKeyPath      string
 	pushIncludeWIP   bool
+	pushDeployCmd    string
+	pushRemoteName   string
 	pushVerbose      bool
 )
 
 var pushCmd = &cobra.Command{
 	Use:   "push <username> [local-path]",
 	Short: "Push committed git history into a container",
-	Long: `Push committed git history into a container via the existing SSH path
-(laptop -> sentinel -> sshpiper -> container).
+	Long: `Push committed git history into a container via real ` + "`git push`" + ` over
+the SSH path (laptop -> sentinel -> sshpiper -> container).
 
-Ships only the delta since the last push to this container, using
-'git bundle' as the wire format. The local working tree must be clean
-unless --include-wip is set, in which case uncommitted + untracked
-changes are wrapped in a WIP commit and the local repo is rewound
-after the push.
+On first call, sets up a bare git repo at ~/work.git inside the
+container plus a post-receive hook that checks out the working tree
+to ~/work and optionally runs --deploy-cmd. On subsequent calls,
+just runs ` + "`git push`" + `; the hook fires server-side.
+
+The local working tree must be clean unless --include-wip is set, in
+which case uncommitted + untracked changes are wrapped in a WIP
+commit and the local repo is rewound after the push.
+
+After the first call, a local git remote (default
+"containarium-<username>") is configured. You can also bypass this
+CLI entirely and just run:
+  git push containarium-<username> <branch>
+from the same local clone — same plumbing.
 
 For mirror-semantics (uncommitted changes carried over as working-tree
 state, not as a commit), use ` + "`containarium sync`" + ` instead.
@@ -36,6 +47,9 @@ state, not as a commit), use ` + "`containarium sync`" + ` instead.
 Examples:
   # Push current branch from cwd to the container's default ~/work
   containarium push demo-blog
+
+  # Push and run a deploy command after each successful update
+  containarium push demo-blog --deploy-cmd "systemctl --user restart blog"
 
   # Push a specific branch with WIP autocommit-and-rewind
   containarium push demo-blog --branch feature/foo --include-wip
@@ -49,10 +63,12 @@ Examples:
 func init() {
 	rootCmd.AddCommand(pushCmd)
 	pushCmd.Flags().StringVar(&pushBranch, "branch", "", "Git branch to push (default: current HEAD branch)")
-	pushCmd.Flags().StringVar(&pushRemotePath, "remote-path", "", "Destination directory inside the container (default: ~/work)")
+	pushCmd.Flags().StringVar(&pushRemotePath, "remote-path", "", "Working-tree directory inside the container (default: ~/work). Bare repo lives at <remote-path>.git.")
 	pushCmd.Flags().StringVar(&pushSentinelHost, "sentinel", "", "Sentinel SSH host (default: $CONTAINARIUM_SENTINEL_HOST)")
 	pushCmd.Flags().StringVar(&pushKeyPath, "key", "", "SSH key path (default: ~/.containarium/keys/<username>)")
 	pushCmd.Flags().BoolVar(&pushIncludeWIP, "include-wip", false, "Auto-commit uncommitted changes as a WIP commit and rewind after push")
+	pushCmd.Flags().StringVar(&pushDeployCmd, "deploy-cmd", "", "Shell command to run on the container after each successful push (inside the work-tree directory)")
+	pushCmd.Flags().StringVar(&pushRemoteName, "remote-name", "", "Local git remote name to configure (default: containarium-<username>)")
 	pushCmd.Flags().BoolVarP(&pushVerbose, "verbose", "v", false, "Verbose progress on stderr")
 }
 
@@ -74,20 +90,23 @@ func runPush(cmd *cobra.Command, args []string) error {
 		},
 		Branch:     pushBranch,
 		IncludeWIP: pushIncludeWIP,
+		DeployCmd:  pushDeployCmd,
+		RemoteName: pushRemoteName,
 	})
 	if err != nil {
 		return err
 	}
 
-	previousNote := "first push"
-	if res.PreviousHead != "" {
-		previousNote = fmt.Sprintf("%s..%s", shortSha(res.PreviousHead), shortSha(res.NewHead))
+	if res.PreviousHead == "" {
+		fmt.Fprintf(os.Stdout, "pushed branch %s to %s (first push, head=%s)\n",
+			res.Branch, res.RemoteURL, shortSha(res.NewHead))
 	} else {
-		previousNote = fmt.Sprintf("first push to %s, head=%s", pushUser, shortSha(res.NewHead))
+		fmt.Fprintf(os.Stdout, "pushed branch %s: %s..%s -> %s\n",
+			res.Branch, shortSha(res.PreviousHead), shortSha(res.NewHead), res.RemoteURL)
 	}
-
-	fmt.Fprintf(os.Stdout, "pushed %d commit(s) on branch %s (%s), bundle=%d bytes\n",
-		res.Commits, res.Branch, previousNote, res.BundleBytes)
+	if res.DeployCmd != "" {
+		fmt.Fprintf(os.Stdout, "  deploy hook configured: %s\n", res.DeployCmd)
+	}
 	if res.WIPCommitMade {
 		fmt.Fprintln(os.Stdout, "  note: WIP commit shipped and local repo rewound to pre-WIP state")
 	}

--- a/internal/mcp/push.go
+++ b/internal/mcp/push.go
@@ -26,19 +26,24 @@ func handlePush(client *Client, args map[string]interface{}) (string, error) {
 		},
 		Branch:     getStringArg(args, "branch", ""),
 		IncludeWIP: getBoolArg(args, "include_wip", false),
+		DeployCmd:  getStringArg(args, "deploy_cmd", ""),
+		RemoteName: getStringArg(args, "remote_name", ""),
 	})
 	if err != nil {
 		return "", fmt.Errorf("push failed: %w", err)
 	}
 
-	previousNote := "first push"
-	if res.PreviousHead != "" {
-		previousNote = fmt.Sprintf("%s..%s", shortShaMCP(res.PreviousHead), shortShaMCP(res.NewHead))
+	var out string
+	if res.PreviousHead == "" {
+		out = fmt.Sprintf("pushed branch %s to %s (first push, head=%s)",
+			res.Branch, res.RemoteURL, shortShaMCP(res.NewHead))
+	} else {
+		out = fmt.Sprintf("pushed branch %s: %s..%s -> %s",
+			res.Branch, shortShaMCP(res.PreviousHead), shortShaMCP(res.NewHead), res.RemoteURL)
 	}
-	out := fmt.Sprintf(
-		"pushed %d commit(s) on branch %s (%s), bundle=%d bytes",
-		res.Commits, res.Branch, previousNote, res.BundleBytes,
-	)
+	if res.DeployCmd != "" {
+		out += fmt.Sprintf("\ndeploy hook configured: %s", res.DeployCmd)
+	}
 	if res.WIPCommitMade {
 		out += "\nWIP commit was shipped and the local repo was rewound to its pre-WIP state."
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -279,22 +279,27 @@ func (s *Server) registerTools() {
 		},
 		{
 			Name: "push",
-			Description: "Push committed git history from a local repository into a container, " +
-				"via the same SSH path you'd use to ssh in directly.\n\n" +
-				"Ships only the delta since the last push to this user (tracked in " +
-				"`.git/containarium-state.json` in the local repo). Uses `git bundle` as " +
-				"the wire format — git's pack-protocol-level delta compression, atomic " +
-				"per-call.\n\n" +
-				"This is the *commit-only* mode. Working-tree changes that aren't committed " +
-				"DO NOT ship by default — if the working tree has uncommitted or untracked " +
-				"files, the tool refuses with a clear error. Pass `include_wip=true` to " +
-				"auto-create a WIP commit, push, and rewind the local repo afterwards.\n\n" +
-				"If you want to mirror the entire local state (uncommitted changes + " +
-				"untracked files + stash refs) without commit ceremony, use the `sync` " +
-				"tool instead.\n\n" +
-				"On first push to a given `<username>`, the tool initializes a fresh git " +
-				"repo at the remote path; subsequent pushes fast-forward (or force) the " +
-				"branch and check it out.",
+			Description: "Push committed git history into a container via real `git push` over " +
+				"SSH (laptop -> sentinel -> sshpiper -> container). On first call, sets up a " +
+				"bare git repo at ~/work.git inside the container plus a post-receive hook " +
+				"that checks out the working tree to ~/work and optionally runs the configured " +
+				"deploy_cmd. On subsequent calls, just runs `git push` — the hook fires " +
+				"server-side.\n\n" +
+				"This is the *commit-only* + *release* mode. Working-tree changes that aren't " +
+				"committed DO NOT ship by default — if the working tree has uncommitted or " +
+				"untracked files, the tool refuses with a clear error. Pass `include_wip=true` " +
+				"to auto-create a WIP commit, push, and rewind the local repo afterwards.\n\n" +
+				"If you want to mirror the entire local state (uncommitted changes + untracked " +
+				"files + stash refs) without commit ceremony, use the `sync` tool instead.\n\n" +
+				"deploy_cmd: when set, the post-receive hook runs the given shell command " +
+				"inside the container's work-tree directory after each successful push. Use " +
+				"it for `systemctl restart`, `make build && systemctl restart`, etc. The hook " +
+				"is rewritten on every push, so changing deploy_cmd between calls just " +
+				"updates the hook.\n\n" +
+				"After the first push, a local git remote (default 'containarium-<username>') " +
+				"is configured on the local repo. From any clone with that remote, " +
+				"`git push containarium-<username> <branch>` works directly without invoking " +
+				"this tool — same plumbing.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
@@ -312,11 +317,19 @@ func (s *Server) registerTools() {
 					},
 					"remote_path": map[string]interface{}{
 						"type":        "string",
-						"description": "Destination directory inside the container (default: ~/work).",
+						"description": "Working-tree directory inside the container (default: ~/work). The bare repo lives at <remote_path>.git.",
 					},
 					"include_wip": map[string]interface{}{
 						"type":        "boolean",
 						"description": "If true and the working tree is dirty, auto-create a WIP commit, push, then rewind the local repo. Default false (refuse on dirty tree).",
+					},
+					"deploy_cmd": map[string]interface{}{
+						"type":        "string",
+						"description": "Shell command to run on the container after each successful push (inside the work-tree directory). Empty = no deploy hook command, but the working tree is still checked out.",
+					},
+					"remote_name": map[string]interface{}{
+						"type":        "string",
+						"description": "Local git remote name to configure. Default 'containarium-<username>'.",
 					},
 					"sentinel": map[string]interface{}{
 						"type":        "string",

--- a/internal/transfer/push.go
+++ b/internal/transfer/push.go
@@ -2,13 +2,13 @@ package transfer
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"text/template"
 )
 
 // PushOptions extends Options with push-specific knobs.
@@ -23,28 +23,43 @@ type PushOptions struct {
 	// matching the "git ideology" contract: commits ship, working tree
 	// changes don't.
 	IncludeWIP bool
+
+	// DeployCmd — when set, the container-side post-receive hook
+	// embeds this shell command and runs it (inside the container's
+	// work tree directory) after each successful push. Use it to
+	// restart the service, run migrations, rebuild artifacts, etc.
+	// Empty deploys the source but runs no command — operator can
+	// run anything manually via ssh.
+	DeployCmd string
+
+	// RemoteName — the local git remote name to (re)configure. Default
+	// "containarium-<username>" so multiple containers can be pushed
+	// to from the same local clone without colliding.
+	RemoteName string
 }
 
-// PushResult summarizes what was pushed.
+// PushResult summarizes the push.
 type PushResult struct {
 	Branch        string
-	Commits       int    // number of commits in the bundle
-	NewHead       string // sha pushed
-	PreviousHead  string // sha that was on the remote before this push, or "" for first push
-	BundleBytes   int64
+	NewHead       string // sha now at the remote tip
+	PreviousHead  string // sha that was at remote tip before this push; "" on first push
+	RemoteURL     string // ssh-style URL we pushed to, for the caller's records
 	WIPCommitMade bool
+	SetupRan      bool // true if we provisioned/refreshed the bare repo + hook this call
+	DeployCmd     string // echoed back so callers can audit
 }
 
-// pushState is the per-(local-repo, remote-user) state file.
-// Stored at .git/containarium-state.json in the local repo.
-type pushState struct {
-	Remotes map[string]map[string]string `json:"remotes"`
-	// Remotes[<username>][<branch>] = last-pushed sha
-}
-
-// Push ships committed git history to the container. Uses `git bundle`
-// for the wire format — git's pack-protocol-level delta compression
-// without needing the bidirectional protocol working over our shell stack.
+// Push ships committed git history to the container by running
+// `git push` against a container-hosted bare repo. The container side
+// installs a post-receive hook on first call (and rewrites it any time
+// DeployCmd changes) that checks out the working tree and optionally
+// runs DeployCmd.
+//
+// Why real git push and not a bundle: receive-pack works through our
+// SSH stack (sshpiper -> sshd -> containarium-shell -> su -c -> incus
+// exec) — empirically verified before this PR. Real git push gives the
+// agent + any vanilla git client the same single mechanism, and it
+// includes a post-receive hook execution surface for free.
 func Push(opt PushOptions) (*PushResult, error) {
 	if err := opt.resolve(); err != nil {
 		return nil, err
@@ -68,16 +83,16 @@ func Push(opt PushOptions) (*PushResult, error) {
 		}
 	}
 
-	// Reject dirty working tree unless IncludeWIP is set.
+	// Working-tree-dirty handling.
 	dirty, err := isWorkingTreeDirty(opt.LocalPath)
 	if err != nil {
 		return nil, fmt.Errorf("check working tree: %w", err)
 	}
 	wipCommitMade := false
+	var wipSha string
 	if dirty && !opt.IncludeWIP {
 		return nil, fmt.Errorf("working tree has uncommitted changes; commit first, or pass --include-wip to auto-create a WIP commit")
 	}
-	var wipSha string
 	if dirty && opt.IncludeWIP {
 		sha, err := makeWIPCommit(opt.LocalPath)
 		if err != nil {
@@ -86,149 +101,236 @@ func Push(opt PushOptions) (*PushResult, error) {
 		wipSha = sha
 		wipCommitMade = true
 		defer func() {
-			// Rewind the WIP commit after the push so the local repo
-			// stays clean. Files in the index/working tree are restored
-			// via `git reset --mixed`.
+			// Rewind the WIP commit so the local repo stays clean. Files
+			// in the index/working tree are restored via `git reset
+			// --mixed`.
 			_, _ = runGit(opt.LocalPath, "reset", "--mixed", wipSha+"^")
 		}()
 	}
 
-	// Load state — find the last sha we pushed for this (user, branch),
-	// if any.
-	state, _ := loadPushState(gitDir)
-	previousHead := state.lastFor(opt.Username, branch)
-
-	// Build the bundle.
-	bundlePath := filepath.Join(os.TempDir(), fmt.Sprintf("containarium-push-%d.bundle", os.Getpid()))
-	defer os.Remove(bundlePath) // #nosec G104 -- cleanup; not critical to error on.
-	if err := buildBundle(opt.LocalPath, bundlePath, branch, previousHead); err != nil {
-		return nil, fmt.Errorf("build bundle: %w", err)
+	// Provision (or refresh) the bare repo + post-receive hook on the
+	// container. Idempotent: re-running with the same DeployCmd is a
+	// no-op aside from rewriting the hook (cheap).
+	if err := ensureRemoteSetup(opt, branch); err != nil {
+		return nil, fmt.Errorf("remote setup: %w", err)
 	}
 
-	bundleInfo, err := os.Stat(bundlePath)
-	if err != nil {
-		return nil, fmt.Errorf("stat bundle: %w", err)
+	// Configure local git remote so subsequent ad-hoc `git push
+	// containarium-<user>` from the same clone works without involving
+	// the CLI.
+	remoteName := opt.RemoteName
+	if remoteName == "" {
+		remoteName = "containarium-" + opt.Username
+	}
+	remoteURL := remoteRepoSSHURL(opt)
+	if err := ensureLocalRemote(opt.LocalPath, remoteName, remoteURL); err != nil {
+		return nil, fmt.Errorf("configure local remote: %w", err)
 	}
 
-	// Count commits in the bundle (everything reachable from <branch>
-	// that's not reachable from <previousHead>).
-	commitCount, err := countCommits(opt.LocalPath, previousHead, branch)
-	if err != nil {
-		return nil, fmt.Errorf("count commits: %w", err)
+	// Capture the remote branch's current sha (if any) BEFORE the push,
+	// so we can report previousHead → newHead.
+	previousHead, _ := remoteHead(opt, branch)
+
+	// Actually push. Use GIT_SSH_COMMAND so git inherits our key +
+	// IdentitiesOnly + no-strict-host-key options. Without
+	// IdentitiesOnly, every key in ~/.ssh/ gets offered to sshpiper's
+	// failtoban — see PR #132 for the original symptom.
+	if err := gitPush(opt, remoteName, branch); err != nil {
+		return nil, fmt.Errorf("git push: %w", err)
 	}
 
+	// Capture new head.
 	newHead, err := runGit(opt.LocalPath, "rev-parse", branch)
 	if err != nil {
 		return nil, fmt.Errorf("resolve new head: %w", err)
 	}
-	newHead = strings.TrimSpace(newHead)
-
-	// Ship the bundle and apply it remotely.
-	if err := shipBundle(opt, bundlePath, branch); err != nil {
-		return nil, fmt.Errorf("ship bundle: %w", err)
-	}
-
-	// Update state file with the new head.
-	state.setLast(opt.Username, branch, newHead)
-	if err := state.save(gitDir); err != nil {
-		// State is a best-effort hint; if we can't write it the next
-		// push just re-bundles everything (still correct).
-		fmt.Fprintf(os.Stderr, "[push] warning: could not write state file: %v\n", err)
-	}
 
 	return &PushResult{
 		Branch:        branch,
-		Commits:       commitCount,
-		NewHead:       newHead,
+		NewHead:       strings.TrimSpace(newHead),
 		PreviousHead:  previousHead,
-		BundleBytes:   bundleInfo.Size(),
+		RemoteURL:     remoteURL,
 		WIPCommitMade: wipCommitMade,
+		SetupRan:      true,
+		DeployCmd:     opt.DeployCmd,
 	}, nil
 }
 
-// buildBundle creates a git bundle at outPath covering either everything
-// reachable from branch (if previousHead is empty) or the delta from
-// previousHead..branch.
-func buildBundle(repo, outPath, branch, previousHead string) error {
-	args := []string{"bundle", "create", outPath}
-	if previousHead == "" {
-		args = append(args, "--all")
-	} else {
-		args = append(args, fmt.Sprintf("%s..%s", previousHead, branch), branch)
+// remoteRepoSSHURL builds the ssh-style remote URL git push consumes.
+// Convention: bare repo lives at "<RemotePath>.git" inside the
+// container's home dir; the work tree is at "<RemotePath>" (the hook
+// checks out into it).
+func remoteRepoSSHURL(opt PushOptions) string {
+	// git accepts <user>@<host>:<path-relative-to-home>. So we strip a
+	// leading $HOME/ if the caller wrote an absolute path.
+	bare := strings.TrimPrefix(opt.RemotePath, "/home/"+opt.Username+"/")
+	bare = strings.TrimPrefix(bare, "~/")
+	if strings.HasPrefix(bare, "/") {
+		// Absolute path that's not under the user's home — pass through
+		// as-is.
+		return fmt.Sprintf("%s@%s:%s.git", opt.Username, opt.SentinelHost, bare)
 	}
-	_, err := runGit(repo, args...)
-	return err
+	return fmt.Sprintf("%s@%s:%s.git", opt.Username, opt.SentinelHost, bare)
 }
 
-// countCommits returns the number of commits between previousHead
-// (exclusive) and branch (inclusive). When previousHead is empty, counts
-// every commit reachable from branch.
-func countCommits(repo, previousHead, branch string) (int, error) {
-	args := []string{"rev-list", "--count"}
-	if previousHead == "" {
-		args = append(args, branch)
-	} else {
-		args = append(args, fmt.Sprintf("%s..%s", previousHead, branch))
-	}
-	out, err := runGit(repo, args...)
-	if err != nil {
-		return 0, err
-	}
-	var n int
-	_, _ = fmt.Sscanf(strings.TrimSpace(out), "%d", &n)
-	return n, nil
+// hookData feeds the post-receive template.
+type hookData struct {
+	Branch    string
+	BareRepo  string
+	WorkTree  string
+	DeployCmd string
 }
 
-// shipBundle uploads the bundle file via stdin to the container and
-// applies it: init-if-needed, fetch, update-ref, checkout.
-func shipBundle(opt PushOptions, bundlePath, branch string) error {
-	f, err := os.Open(bundlePath) // #nosec G304 -- bundlePath is constructed by us in TempDir.
-	if err != nil {
-		return err
-	}
-	defer f.Close()
+const hookTemplate = `#!/bin/sh
+set -e
+while read oldrev newrev refname; do
+    branch="${refname#refs/heads/}"
+    if [ "$branch" = "{{.Branch}}" ]; then
+        echo "[containarium] post-receive: $branch $oldrev..$newrev" >&2
+        GIT_WORK_TREE={{.WorkTree}} git --git-dir={{.BareRepo}} checkout -f "$branch"
+{{- if .DeployCmd}}
+        cd {{.WorkTree}}
+        {{.DeployCmd}}
+{{- end}}
+    fi
+done
+`
 
-	// Remote shell script:
-	//   1. ensure repo dir + git repo (init if missing)
-	//   2. receive bundle on stdin
-	//   3. fetch into a temporary remote ref to avoid clobbering the
-	//      working tree until the fetch succeeds
-	//   4. fast-forward update-ref (allow non-ff with -f to mirror local)
-	//   5. checkout the branch
-	//   6. cleanup tmp bundle
+// renderHook produces the post-receive hook body for the given options.
+// Split out for testability.
+func renderHook(d hookData) (string, error) {
+	t, err := template.New("hook").Parse(hookTemplate)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, d); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// ensureRemoteSetup creates the bare repo + post-receive hook + work
+// tree directory on the container if missing, and refreshes the hook
+// to reflect the current DeployCmd. Idempotent.
+//
+// One SSH connection per push for setup. The actual `git push` opens
+// its own SSH connection; we could share if we cared about latency,
+// but ~200ms once per push is fine for v1.
+func ensureRemoteSetup(opt PushOptions, branch string) error {
+	bareRepo := opt.RemotePath + ".git"
+	workTree := opt.RemotePath
+	hook, err := renderHook(hookData{
+		Branch:    branch,
+		BareRepo:  bareRepo,
+		WorkTree:  workTree,
+		DeployCmd: opt.DeployCmd,
+	})
+	if err != nil {
+		return fmt.Errorf("render hook: %w", err)
+	}
+
+	// Two-phase shell script: ensure repo + write hook from stdin.
+	// stdin is the hook content; the remote script reads it and chmods.
 	script := fmt.Sprintf(`
-		set -e
-		mkdir -p %s
-		cd %s
-		if [ ! -d .git ]; then
-			git init -q -b %s
-		fi
-		BUNDLE=$(mktemp)
-		trap 'rm -f "$BUNDLE"' EXIT
-		cat > "$BUNDLE"
-		git fetch -q "$BUNDLE" %s
-		git update-ref -f refs/heads/%s FETCH_HEAD
-		git checkout -f -q %s
-	`,
-		shQuote(opt.RemotePath),
-		shQuote(opt.RemotePath),
-		shQuote(branch),
-		shQuote(branch),
-		shQuote(branch),
-		shQuote(branch),
+set -e
+which git >/dev/null 2>&1 || { sudo apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git >/dev/null 2>&1; }
+mkdir -p %s
+if [ ! -f %s/HEAD ]; then
+    git init --bare -q %s
+fi
+mkdir -p %s
+cat > %s/hooks/post-receive
+chmod +x %s/hooks/post-receive
+`,
+		shQuote(bareRepo),
+		shQuote(bareRepo),
+		shQuote(bareRepo),
+		shQuote(workTree),
+		shQuote(bareRepo),
+		shQuote(bareRepo),
 	)
 
 	args := append(opt.sshBaseArgs(), opt.sshTarget(), script)
-	// #nosec G204 -- argv to ssh, not shell-evaluated locally; remote
-	// script's variables are shQuote'd.
+	// #nosec G204 -- argv to ssh, not shell-evaluated locally; embedded
+	// paths are shQuote'd. Hook content is package-controlled + a
+	// caller-supplied DeployCmd that goes directly into the user's
+	// container, not into our local shell.
 	cmd := exec.Command("ssh", args...)
-	cmd.Stdin = f
+	cmd.Stdin = strings.NewReader(hook)
 	cmd.Stderr = io.Discard
 	if opt.Verbose {
 		cmd.Stderr = os.Stderr
 	}
 	return cmd.Run()
 }
+
+// ensureLocalRemote sets remote.<name>.url to url, creating the remote
+// or updating its URL as needed.
+func ensureLocalRemote(repo, name, url string) error {
+	existing, err := runGit(repo, "remote", "get-url", name)
+	switch {
+	case err == nil:
+		if strings.TrimSpace(existing) == url {
+			return nil
+		}
+		_, err = runGit(repo, "remote", "set-url", name, url)
+		return err
+	default:
+		_, err = runGit(repo, "remote", "add", name, url)
+		return err
+	}
+}
+
+// remoteHead asks the remote what sha its <branch> currently points at.
+// Empty string when the branch doesn't exist yet (first push) or the
+// remote isn't reachable. Best-effort — failure here doesn't abort the
+// push.
+func remoteHead(opt PushOptions, branch string) (string, error) {
+	env := append(os.Environ(), "GIT_SSH_COMMAND="+gitSSHCommand(opt))
+	cmd := exec.Command("git", "ls-remote", remoteRepoSSHURL(opt), "refs/heads/"+branch) // #nosec G204 -- argv to git; URL built from validated config.
+	cmd.Env = env
+	cmd.Dir = opt.LocalPath
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) < 1 {
+		return "", nil
+	}
+	return fields[0], nil
+}
+
+// gitPush runs `git push <remote> <branch>` with GIT_SSH_COMMAND set to
+// pin our key + IdentitiesOnly + no strict host key checking. Stderr
+// is captured so a failed push surfaces a helpful error.
+func gitPush(opt PushOptions, remoteName, branch string) error {
+	env := append(os.Environ(), "GIT_SSH_COMMAND="+gitSSHCommand(opt))
+	cmd := exec.Command("git", "push", remoteName, branch) // #nosec G204 -- argv to git; remoteName + branch are package-validated.
+	cmd.Env = env
+	cmd.Dir = opt.LocalPath
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if opt.Verbose {
+		cmd.Stderr = io.MultiWriter(&stderr, os.Stderr)
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w (stderr: %s)", err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// gitSSHCommand returns a GIT_SSH_COMMAND value that pins our key + the
+// IdentitiesOnly flag. The same options sshBaseArgs uses, but compacted
+// into one space-separated string for env-var use.
+func gitSSHCommand(opt PushOptions) string {
+	parts := append([]string{"ssh"}, opt.sshBaseArgs()...)
+	return strings.Join(parts, " ")
+}
+
+// isWorkingTreeDirty / makeWIPCommit / runGit are unchanged from the
+// pre-rewrite version.
 
 // isWorkingTreeDirty returns true if there are uncommitted/unstaged
 // changes or untracked files.
@@ -260,9 +362,8 @@ func makeWIPCommit(repo string) (string, error) {
 // trims). Errors include stderr for easier debugging.
 func runGit(repo string, args ...string) (string, error) {
 	// args are package-internal git subcommands + values pre-validated
-	// elsewhere in this file (branch name from git rev-parse, bundle path
-	// from os.TempDir). git treats each argv element as one argument, not
-	// shell-evaluated.
+	// elsewhere in this file. git treats each argv element as one
+	// argument, not shell-evaluated.
 	cmd := exec.Command("git", args...) // #nosec G204 -- argv to git, not shell-evaluated.
 	cmd.Dir = repo
 	var stdout, stderr bytes.Buffer
@@ -272,47 +373,4 @@ func runGit(repo string, args ...string) (string, error) {
 		return "", fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
 	}
 	return stdout.String(), nil
-}
-
-// --- pushState persistence -------------------------------------------------
-
-const stateFile = "containarium-state.json"
-
-func loadPushState(gitDir string) (*pushState, error) {
-	st := &pushState{Remotes: map[string]map[string]string{}}
-	path := filepath.Join(gitDir, stateFile)
-	data, err := os.ReadFile(path) // #nosec G304 -- path is constructed from caller-supplied gitDir + a constant filename.
-	if err != nil {
-		return st, nil // missing file = empty state
-	}
-	if err := json.Unmarshal(data, st); err != nil {
-		return st, nil // unparsable = treat as empty
-	}
-	if st.Remotes == nil {
-		st.Remotes = map[string]map[string]string{}
-	}
-	return st, nil
-}
-
-func (s *pushState) lastFor(user, branch string) string {
-	if s.Remotes[user] == nil {
-		return ""
-	}
-	return s.Remotes[user][branch]
-}
-
-func (s *pushState) setLast(user, branch, sha string) {
-	if s.Remotes[user] == nil {
-		s.Remotes[user] = map[string]string{}
-	}
-	s.Remotes[user][branch] = sha
-}
-
-func (s *pushState) save(gitDir string) error {
-	path := filepath.Join(gitDir, stateFile)
-	data, err := json.MarshalIndent(s, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(path, data, 0o600)
 }

--- a/internal/transfer/push_test.go
+++ b/internal/transfer/push_test.go
@@ -1,46 +1,101 @@
 package transfer
 
 import (
-	"os"
-	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestPushState_RoundtripMissingFile(t *testing.T) {
-	dir := t.TempDir()
-	s, err := loadPushState(dir)
+func TestRenderHook_NoDeployCmd(t *testing.T) {
+	h, err := renderHook(hookData{
+		Branch:   "main",
+		BareRepo: "/home/alice/work.git",
+		WorkTree: "/home/alice/work",
+	})
 	require.NoError(t, err)
-	assert.Empty(t, s.lastFor("anyone", "main"))
+	assert.Contains(t, h, `branch="${refname#refs/heads/}"`)
+	assert.Contains(t, h, `if [ "$branch" = "main" ]; then`)
+	assert.Contains(t, h, `GIT_WORK_TREE=/home/alice/work git --git-dir=/home/alice/work.git checkout -f "$branch"`)
+	// No deploy block.
+	assert.NotContains(t, h, "cd /home/alice/work")
 }
 
-func TestPushState_SetGetSave(t *testing.T) {
-	dir := t.TempDir()
-	s, _ := loadPushState(dir)
-
-	s.setLast("alice", "main", "abc123")
-	s.setLast("alice", "feature/foo", "def456")
-	s.setLast("bob", "main", "ghi789")
-
-	require.NoError(t, s.save(dir))
-
-	// Roundtrip through disk.
-	s2, err := loadPushState(dir)
+func TestRenderHook_WithDeployCmd(t *testing.T) {
+	h, err := renderHook(hookData{
+		Branch:    "main",
+		BareRepo:  "/home/alice/work.git",
+		WorkTree:  "/home/alice/work",
+		DeployCmd: "systemctl --user restart app",
+	})
 	require.NoError(t, err)
-	assert.Equal(t, "abc123", s2.lastFor("alice", "main"))
-	assert.Equal(t, "def456", s2.lastFor("alice", "feature/foo"))
-	assert.Equal(t, "ghi789", s2.lastFor("bob", "main"))
-	assert.Empty(t, s2.lastFor("alice", "nope"))
-	assert.Empty(t, s2.lastFor("charlie", "main"))
+	assert.Contains(t, h, "cd /home/alice/work")
+	assert.Contains(t, h, "systemctl --user restart app")
+	// Order matters: cd should appear before the deploy_cmd.
+	cdIdx := strings.Index(h, "cd /home/alice/work")
+	cmdIdx := strings.Index(h, "systemctl")
+	assert.Less(t, cdIdx, cmdIdx, "cd into work tree should precede deploy_cmd")
 }
 
-func TestPushState_TombstonedJSONIsForgiving(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, stateFile), []byte("not-json"), 0o600))
-	// Should not error; just return empty state.
-	s, err := loadPushState(dir)
+func TestRenderHook_MultilineDeployCmd(t *testing.T) {
+	// Operator-supplied deploy commands can be multiple lines (e.g. a
+	// build step then a restart). Make sure they're emitted verbatim.
+	h, err := renderHook(hookData{
+		Branch:    "main",
+		BareRepo:  "/home/alice/work.git",
+		WorkTree:  "/home/alice/work",
+		DeployCmd: "make build\nsystemctl restart app",
+	})
 	require.NoError(t, err)
-	assert.Empty(t, s.lastFor("anyone", "main"))
+	assert.Contains(t, h, "make build")
+	assert.Contains(t, h, "systemctl restart app")
+}
+
+func TestRemoteRepoSSHURL_DefaultHomePath(t *testing.T) {
+	url := remoteRepoSSHURL(PushOptions{
+		Options: Options{
+			Username:     "alice",
+			SentinelHost: "sentinel.example.com",
+			RemotePath:   "/home/alice/work",
+		},
+	})
+	// "/home/<user>/" prefix is stripped because git remote URLs of the
+	// form "<user>@<host>:<rel>" are relative to the user's home dir on
+	// the remote.
+	assert.Equal(t, "alice@sentinel.example.com:work.git", url)
+}
+
+func TestRemoteRepoSSHURL_TildeAliasPath(t *testing.T) {
+	url := remoteRepoSSHURL(PushOptions{
+		Options: Options{
+			Username:     "alice",
+			SentinelHost: "sentinel.example.com",
+			RemotePath:   "~/work",
+		},
+	})
+	assert.Equal(t, "alice@sentinel.example.com:work.git", url)
+}
+
+func TestRemoteRepoSSHURL_AbsoluteOutsideHome(t *testing.T) {
+	url := remoteRepoSSHURL(PushOptions{
+		Options: Options{
+			Username:     "alice",
+			SentinelHost: "sentinel.example.com",
+			RemotePath:   "/srv/app",
+		},
+	})
+	// Absolute path outside user's home is passed through; git accepts it.
+	assert.Equal(t, "alice@sentinel.example.com:/srv/app.git", url)
+}
+
+func TestGitSSHCommand_HasIdentitiesOnly(t *testing.T) {
+	opt := PushOptions{Options: Options{KeyPath: "/tmp/key"}}
+	cmd := gitSSHCommand(opt)
+	// Must include IdentitiesOnly=yes — otherwise the SSH client offers
+	// every ~/.ssh/* key, burning sshpiper's failtoban budget (the
+	// load-bearing learning from PR #132).
+	assert.Contains(t, cmd, "IdentitiesOnly=yes")
+	assert.Contains(t, cmd, "-i /tmp/key")
+	assert.True(t, strings.HasPrefix(cmd, "ssh "), "must start with ssh")
 }


### PR DESCRIPTION
## Summary

PR #150's bundle-based `push` worked, but it sidestepped `git-receive-pack` out of fear that bidirectional git protocols wouldn't survive our SSH stack. **Empirical test on the live demo cluster this session proved that fear unfounded** — `git push <user>@<sentinel>:work.git main` works end-to-end, including delta packs and post-receive hooks (the verification log is in the session transcript).

This PR collapses the bundle machinery into a thin `git push` wrapper that gives us \"Heroku-style git-push-to-deploy\" for free.

## Behavior

### First call
`containarium push <user> [--deploy-cmd \"...\"]`
1. SSH in, `git init --bare ~/work.git`, install a post-receive hook that:
   - Checks out the pushed branch to `~/work`
   - Optionally runs `deploy_cmd` inside the work tree (e.g. `systemctl restart blog`)
2. `git remote add containarium-<user> <user>@<sentinel>:work.git` in the local clone
3. `git push containarium-<user> <branch>`

### Subsequent calls
Just `git push containarium-<user> <branch>`. The post-receive hook fires server-side. `deploy_cmd` changes (passed differently between calls) rewrite the hook.

### Vanilla git client compatibility
Any local clone with `containarium-<user>` configured as a remote can run `git push containarium-<user> main` directly without the CLI — same plumbing.

## Diff shape

| Removed (~300 lines) | Added (~250 lines) |
|---|---|
| Bundle build / ship code | `ensureRemoteSetup` (idempotent bare repo + hook write) |
| `.git/containarium-state.json` local state file (git's `refs/remotes/` tracks it natively now) | `renderHook` (text/template-based post-receive script) |
| Single-bundle-via-stdin SSH script | `ensureLocalRemote` (configure local git remote) |
| | `gitSSHCommand` (pinned GIT_SSH_COMMAND with IdentitiesOnly=yes — preserves PR #132's failtoban-budget protection) |

## New surface

| Flag | MCP arg | What |
|---|---|---|
| `--deploy-cmd` | `deploy_cmd` | Shell command in post-receive hook |
| `--remote-name` | `remote_name` | Defaults to `containarium-<username>` |

`--include-wip` carries over unchanged.

## Tests

- 7 new pure-Go tests on hook template + URL builder + SSH command construction
- 3 old state-file tests deleted (state file is gone)
- `go build ./...` green
- `go test ./internal/transfer/... ./internal/mcp/... ./internal/cmd/...` all green
- `go vet` clean

## Live-cluster validation

Done before this PR opened, on a `git-test` container:

```
$ git push git-test@34.42.156.100:work.git main
* [new branch]      main -> main

$ git push git-test@34.42.156.100:work.git main      # 2nd push (delta)
4cb6617..5e4bf88  main -> main

$ git push git-test@34.42.156.100:work.git main      # 3rd push w/ hook
remote: Switched to branch 'main'
5e4bf88..d7d16a0  main -> main
```

Hook log on container shows the post-receive fired and the working tree updated. Test container + artifacts cleaned up.

## Follow-ups (not in scope)

- HTTPS smart-protocol git through Caddy (alternative to SSH for users without ephemeral key access) — file as a future feature if/when needed
- A `containarium release <user> [--deploy-cmd]` separate verb for \"just update the deploy_cmd, don't push anything\" — small, can land later if operators ask

🤖 Generated with [Claude Code](https://claude.com/claude-code)