### PR TITLE
fix(mcp): surface tool-execution errors in JSON-RPC message field

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -156,7 +156,15 @@ func (s *Server) handleToolsCall(req *MCPRequest) *MCPResponse {
 	// Execute tool
 	result, err := tool.Handler(s.client, params.Arguments)
 	if err != nil {
-		return s.createErrorResponse(req.ID, -32603, "Tool execution failed", err.Error())
+		// Surface the actual error message in `message` so it reaches MCP
+		// clients that only render the top-level `message` field (most do,
+		// including Claude Code). The full err string also lands in `data`
+		// for clients that show both. Constant "Tool execution failed"
+		// alone was a UX deadend — every failure looked identical from
+		// the agent's POV.
+		return s.createErrorResponse(req.ID, -32603,
+			fmt.Sprintf("Tool execution failed: %v", err),
+			err.Error())
 	}
 
 	return &MCPResponse{

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -233,6 +234,50 @@ func TestHandleToolsCallToolNotFound(t *testing.T) {
 	assert.NotNil(t, resp.Error)
 	assert.Equal(t, -32602, resp.Error.Code)
 	assert.Contains(t, resp.Error.Data, "not found")
+}
+
+// TestHandleToolsCallSurfacesHandlerError verifies that when a tool's
+// handler returns an error, the error string lands in JSON-RPC `message`
+// (not only in `data`). MCP clients vary on which field they render;
+// putting the diagnostic in `message` ensures every client sees it.
+func TestHandleToolsCallSurfacesHandlerError(t *testing.T) {
+	config := &Config{
+		ServerURL: "http://localhost:8080",
+		JWTToken:  "test-token",
+	}
+	server, err := NewServer(config)
+	require.NoError(t, err)
+
+	// Replace one tool's handler with a deterministic failure so we can
+	// assert on the surfaced message.
+	const sentinel = "ssh key not readable at ~/.containarium/keys/voice-dev"
+	for i := range server.tools {
+		if server.tools[i].Name == "push" {
+			server.tools[i].Handler = func(_ *Client, _ map[string]interface{}) (string, error) {
+				return "", fmt.Errorf(sentinel)
+			}
+			break
+		}
+	}
+
+	req := &MCPRequest{
+		JSONRPC: "2.0",
+		ID:      7,
+		Method:  "tools/call",
+		Params: map[string]interface{}{
+			"name":      "push",
+			"arguments": map[string]interface{}{"username": "voice-dev"},
+		},
+	}
+	resp := server.handleRequest(req)
+
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, -32603, resp.Error.Code)
+	// The real diagnostic must appear in `message`, not only `data`.
+	assert.Contains(t, resp.Error.Message, sentinel,
+		"error message must include the underlying error for clients that only render `message`")
+	// `data` should still carry it too (for clients that render both).
+	assert.Contains(t, resp.Error.Data, sentinel)
 }
 
 // TestErrorResponse tests error response creation


### PR DESCRIPTION
## Summary

`handleToolsCall` was returning a constant \"Tool execution failed\" string in JSON-RPC's `message` field and putting the actual `err.Error()` in `data`. Most MCP clients (including Claude Code) only render `message` by default, so every tool failure looked identical to the operator and the agent.

Surfaced 2026-05-12: `push` against a container called `voice-dev` failed because the container's key wasn't at the conventional `~/.containarium/keys/<user>` path; the user had to manually deduce the cause from a generic `-32603 Tool execution failed` with no detail. The actual error message from `transfer.Push` was *correct* (it said exactly what was wrong) — it was just invisible.

## Fix

Include the wrapped err string in `message` while keeping `data` for clients that show both:

```diff
- return s.createErrorResponse(req.ID, -32603, "Tool execution failed", err.Error())
+ return s.createErrorResponse(req.ID, -32603,
+     fmt.Sprintf("Tool execution failed: %v", err),
+     err.Error())
```

## Why this matters for agent UX

The recent enrichment of `create_container`'s tool description (PR #147) pointed agents at `debug_container` for failure diagnosis. But when the failure is in the tool *call itself* (not in the container's state), `debug_container` doesn't help. The agent has only the tool-call error to work with. Without a useful `message`, the agent's next step is a guess.

## Test plan

- [x] New `TestHandleToolsCallSurfacesHandlerError` asserts the err string lands in both `message` and `data`
- [x] Existing `TestHandleToolsCallInvalidParams` and `TestHandleToolsCallToolNotFound` still pass
- [x] `go build` green
- [ ] Manual: hit a tool failure from Claude Code, confirm the message is now informative

🤖 Generated with [Claude Code](https://claude.com/claude-code)