### PR TITLE
fix(transfer): expand leading ~/ in RemotePath + exclude .env* by default

### DIFF
--- a/internal/transfer/sync.go
+++ b/internal/transfer/sync.go
@@ -24,6 +24,12 @@ type SyncOptions struct {
 
 // DefaultSyncExcludes is the noise filter applied when SyncOptions.Excludes
 // is empty. Substring match, not glob.
+//
+// .env* is excluded by default because env files are per-environment
+// secrets — clobbering a container's .env with a laptop's .env is a
+// classic footgun (surfaced 2026-05-12 via agent feedback). If a caller
+// genuinely wants to ship env files they can pass Excludes explicitly
+// to override.
 var DefaultSyncExcludes = []string{
 	"node_modules/",
 	".terraform/",
@@ -34,6 +40,9 @@ var DefaultSyncExcludes = []string{
 	".DS_Store",
 	".idea/",
 	".vscode/",
+	".env",
+	".env.",
+	".envrc",
 }
 
 // SyncResult summarizes what changed.

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Options carries the inputs both Push and Sync need.
@@ -90,6 +91,17 @@ func (o *Options) resolve() error {
 	}
 	if o.RemotePath == "" {
 		o.RemotePath = "/home/" + o.Username + "/work"
+	}
+	// Expand a leading "~/" or bare "~" into /home/<Username>/. The remote
+	// shell only expands `~` outside of quotes, but our remote scripts
+	// shQuote every path → the tilde survives literally, and we end up
+	// creating a directory called "~" in the user's cwd. Substitute here
+	// so callers can write "~/work" and have it mean what they expect.
+	switch {
+	case o.RemotePath == "~":
+		o.RemotePath = "/home/" + o.Username
+	case strings.HasPrefix(o.RemotePath, "~/"):
+		o.RemotePath = "/home/" + o.Username + "/" + strings.TrimPrefix(o.RemotePath, "~/")
 	}
 	return nil
 }

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -1,0 +1,87 @@
+package transfer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// keyFile is a minimal test helper: writes a file at path so the
+// readability check in Options.resolve() passes.
+func writeKey(t *testing.T) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "key-*")
+	require.NoError(t, err)
+	_, _ = f.WriteString("not a real ssh key — just satisfying the readability check\n")
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+func TestResolve_TildePrefixExpands(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// "~" alone → /home/alice
+		{"~", "/home/alice"},
+		// "~/work" → /home/alice/work — the agent-feedback case
+		{"~/work", "/home/alice/work"},
+		// "~/nested/path" → /home/alice/nested/path
+		{"~/nested/path", "/home/alice/nested/path"},
+		// Absolute path stays absolute
+		{"/srv/app", "/srv/app"},
+		// "/home/alice/work" stays as-is
+		{"/home/alice/work", "/home/alice/work"},
+		// Tilde in the middle is NOT expanded — only a leading "~" or "~/".
+		{"/srv/~/app", "/srv/~/app"},
+	}
+	keyPath := writeKey(t)
+	cwd, _ := os.Getwd()
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			opt := &Options{
+				Username:     "alice",
+				SentinelHost: "host.example.com",
+				KeyPath:      keyPath,
+				LocalPath:    cwd,
+				RemotePath:   c.in,
+			}
+			require.NoError(t, opt.resolve())
+			assert.Equal(t, c.want, opt.RemotePath)
+		})
+	}
+}
+
+func TestResolve_DefaultRemotePathIsAbsolute(t *testing.T) {
+	keyPath := writeKey(t)
+	cwd, _ := os.Getwd()
+	opt := &Options{
+		Username:     "alice",
+		SentinelHost: "host.example.com",
+		KeyPath:      keyPath,
+		LocalPath:    cwd,
+	}
+	require.NoError(t, opt.resolve())
+	assert.Equal(t, "/home/alice/work", opt.RemotePath, "default must already be absolute")
+}
+
+func TestDefaultSyncExcludes_BlocksEnvFiles(t *testing.T) {
+	// The agent-feedback case: sync silently clobbered the container's
+	// .env with the laptop's .env. Defaults must catch the common
+	// env-file shapes.
+	for _, p := range []string{".env", ".env.local", ".env.production", ".envrc"} {
+		assert.True(t, matchesAny(p, DefaultSyncExcludes),
+			"DefaultSyncExcludes must filter %q", p)
+	}
+	// Don't over-block: a file containing "env" in its name should be fine.
+	for _, p := range []string{"environment.go", "envoy/config.yaml", "test_env_helper.go"} {
+		assert.False(t, matchesAny(p, DefaultSyncExcludes),
+			"DefaultSyncExcludes should not filter %q", p)
+	}
+}
+
+// keep these vars used so go vet doesn't complain
+var _ = filepath.Separator


### PR DESCRIPTION
## Summary

Two UX bugs surfaced by **agent feedback** during a real use of the new push/sync tools:

> 2. Both push and sync don't expand `~` on the remote — passed `~/work` and it created a literal `~/work/` directory. Use absolute paths like `/home/voice-dev/work` for `remote_path`.
> 3. sync doesn't exclude `.env*` by default — happily clobbered voice-dev's environment config with my laptop's.

## Fix 1: tilde expansion

`Options.resolve()` now substitutes a leading `~/` (or bare `~`) with `/home/<Username>/`. The remote shell's tilde expansion never fired because our remote scripts wrap paths in `shQuote`; the tilde survived literally and the SSH script created a directory named `~` in the user's cwd. Now `~/work` means what callers expect.

| Input | Before | After |
|---|---|---|
| `\"~/work\"` | literal `~` directory created | `/home/<user>/work` |
| `\"~\"` alone | literal | `/home/<user>` |
| `\"/srv/app\"` | unchanged | unchanged |
| `\"/srv/~/app\"` (tilde in middle) | unchanged | unchanged (only leading `~` is expanded) |

## Fix 2: `.env*` excluded by default in `sync`

`DefaultSyncExcludes` gains `.env`, `.env.`, `.envrc`. Catches `.env.local`, `.env.production`, etc. via substring match. Doesn't over-block files that happen to contain \"env\" in the name (e.g. `environment.go`, `envoy/config.yaml`).

If a caller genuinely wants to ship env files they can override with explicit `Excludes`.

## Test plan

- [x] `TestResolve_TildePrefixExpands` — 6 cases (`~`, `~/work`, `~/nested/path`, absolute paths, mid-path `~`)
- [x] `TestResolve_DefaultRemotePathIsAbsolute` — empty RemotePath defaults to `/home/<user>/work`
- [x] `TestDefaultSyncExcludes_BlocksEnvFiles` — positive + negative cases
- [x] `go test ./internal/transfer/...` green
- [x] `go vet ./internal/transfer/...` clean

## Related agent-feedback items NOT in this PR

| # | Issue | Status |
|---|---|---|
| 1 | `push` docstring promised auto-bootstrap but bare repo wasn't created | PR #152 (push v2 with real `git push` + bare repo + post-receive hook) |
| 4 | `-32603 Tool execution failed` with no body | PR #153 (surface err in JSON-RPC `message`) |

After all three merge + a `bin/mcp-server` rebuild + a Claude Code MCP re-add, the agent gets:
- Auto-bootstrapped bare repos + post-receive hook on first push (#152)
- Informative tool-error messages (#153)
- Sensible `~/` expansion and `.env*` exclusion (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)