### PR TITLE
feat(mcp): list_routes tool — show registered domain → container mappings

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -240,6 +240,35 @@ func (c *Client) AddRoute(req AddRouteRequest) (*AddRouteResponse, error) {
 	return &resp, nil
 }
 
+// ListRoutes returns all proxy routes the sentinel currently serves. Both
+// filter params are optional — empty `username` or `activeOnly=false`
+// means "no filter on that dimension". Mirrors GET /v1/network/routes.
+func (c *Client) ListRoutes(username string, activeOnly bool) (*ListRoutesResponse, error) {
+	path := "/v1/network/routes"
+	q := ""
+	if username != "" {
+		q = "username=" + username
+	}
+	if activeOnly {
+		if q != "" {
+			q += "&"
+		}
+		q += "activeOnly=true"
+	}
+	if q != "" {
+		path += "?" + q
+	}
+	respBody, err := c.doRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp ListRoutesResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
 // ListBackends returns the cluster topology — the local daemon plus any
 // tunnel-connected peers. Used by the list_backends MCP tool so an
 // agent can reason about peer health, container counts, and GPU
@@ -624,11 +653,25 @@ type AddRouteResponse struct {
 }
 
 type ProxyRoute struct {
-	Domain        string `json:"domain"`
+	// Domain (the one expose_port sets) and the proto's richer fields
+	// (subdomain, fullDomain, active, appId, appName) — accept both shapes
+	// because AddRoute echoes one set and GetRoutes returns the other.
+	Domain        string `json:"domain,omitempty"`
+	Subdomain     string `json:"subdomain,omitempty"`
+	FullDomain    string `json:"fullDomain,omitempty"`
 	ContainerIP   string `json:"containerIp"`
 	Port          int32  `json:"port"`
+	Active        bool   `json:"active,omitempty"`
 	ContainerName string `json:"containerName,omitempty"`
 	Description   string `json:"description,omitempty"`
+	AppID         string `json:"appId,omitempty"`
+	AppName       string `json:"appName,omitempty"`
+}
+
+// ListRoutesResponse mirrors the daemon's GetRoutesResponse.
+type ListRoutesResponse struct {
+	Routes     []ProxyRoute `json:"routes"`
+	TotalCount int          `json:"totalCount"`
 }
 
 type Container struct {

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -113,6 +113,53 @@ func TestClientListContainers(t *testing.T) {
 	assert.Equal(t, "alice-container", resp.Containers[0].Name)
 }
 
+// TestClientListRoutes verifies the new list_routes tool's wire path:
+// correct method + path, query-string filter encoding, and that the
+// daemon's proto-shaped response parses into ProxyRoute.
+func TestClientListRoutes(t *testing.T) {
+	t.Run("no filters: bare GET /v1/network/routes", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, "/v1/network/routes", r.URL.Path)
+			assert.Empty(t, r.URL.RawQuery, "no filters → no query string")
+			_ = json.NewEncoder(w).Encode(ListRoutesResponse{
+				Routes: []ProxyRoute{
+					{
+						Subdomain:   "alice-web",
+						FullDomain:  "alice-web.example.com",
+						ContainerIP: "10.0.3.42",
+						Port:        80,
+						Active:      true,
+						AppName:     "alice-container",
+					},
+				},
+				TotalCount: 1,
+			})
+		}))
+		defer srv.Close()
+
+		c := NewClient(srv.URL, "t")
+		resp, err := c.ListRoutes("", false)
+		require.NoError(t, err)
+		require.Len(t, resp.Routes, 1)
+		assert.Equal(t, "alice-web.example.com", resp.Routes[0].FullDomain)
+		assert.True(t, resp.Routes[0].Active)
+	})
+
+	t.Run("with filters: both query params encoded", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "alice", r.URL.Query().Get("username"))
+			assert.Equal(t, "true", r.URL.Query().Get("activeOnly"))
+			_ = json.NewEncoder(w).Encode(ListRoutesResponse{Routes: nil, TotalCount: 0})
+		}))
+		defer srv.Close()
+
+		c := NewClient(srv.URL, "t")
+		_, err := c.ListRoutes("alice", true)
+		require.NoError(t, err)
+	})
+}
+
 // TestClientGetContainer tests get container API call
 func TestClientGetContainer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,7 +22,7 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	assert.Len(t, server.tools, 18, "Should have 18 tools registered")
+	assert.Len(t, server.tools, 19, "Should have 19 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -126,7 +126,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	assert.Len(t, tools, 18)
+	assert.Len(t, tools, 19)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -531,6 +531,37 @@ func (s *Server) registerTools() {
 			Handler: handleSyncSSHConfig,
 		},
 		{
+			Name: "list_routes",
+			Description: "List the proxy routes currently registered on the sentinel — the " +
+				"domain → container:port mappings that `expose_port` creates. Returns each " +
+				"route's domain (`fullDomain`), target container IP + port, active state, " +
+				"and any associated app metadata.\n\n" +
+				"Use this to:\n" +
+				"  - Audit what's currently exposed (e.g. before adding a new route, check " +
+				"    that the intended hostname isn't already claimed).\n" +
+				"  - Recover after a session loses track of which containers have which " +
+				"    public URLs.\n" +
+				"  - Filter by `username` to see only one container's routes, or " +
+				"    `active_only=true` to skip disabled ones.\n\n" +
+				"Read-only — no side effects. For TCP passthrough routes (raw L4, not HTTPS), " +
+				"those live on a different daemon endpoint and aren't included here yet — " +
+				"file a request if you need them surfaced.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":        "string",
+						"description": "Restrict to routes whose target container belongs to this username. Empty = no filter.",
+					},
+					"active_only": map[string]interface{}{
+						"type":        "boolean",
+						"description": "If true, omit disabled routes. Default false (include all).",
+					},
+				},
+			},
+			Handler: handleListRoutes,
+		},
+		{
 			Name: "expose_port",
 			Description: "Expose a container's port on a public hostname. Resolves the " +
 				"container's IP, then registers a domain → container:port route in the " +
@@ -921,6 +952,22 @@ func humanBytes(n int64) string {
 	default:
 		return fmt.Sprintf("%d B", n)
 	}
+}
+
+func handleListRoutes(client *Client, args map[string]interface{}) (string, error) {
+	username := getStringArg(args, "username", "")
+	activeOnly := getBoolArg(args, "active_only", false)
+
+	resp, err := client.ListRoutes(username, activeOnly)
+	if err != nil {
+		return "", fmt.Errorf("failed to list routes: %w", err)
+	}
+
+	out, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal response: %w", err)
+	}
+	return string(out), nil
 }
 
 func handleExposePort(client *Client, args map[string]interface{}) (string, error) {


### PR DESCRIPTION
## Summary

New MCP tool `list_routes` that wraps the daemon's existing `GET /v1/network/routes` endpoint. Closes the read-side gap alongside `expose_port` (write) and the daemon's existing `DELETE /v1/network/routes/{domain}`.

## Why

Agents and operators previously had no agent-facing way to check what was already exposed. Every \"is this hostname taken?\" or \"which containers have public URLs?\" workflow had to ssh in and curl Caddy's config, or rely on having recorded prior `expose_port` responses. Today's session's agent feedback included \"the working pattern was X, but had no way to audit prior state\" — this fixes the audit half.

## Tool shape

```jsonc
list_routes(username?, active_only?) → {
  \"routes\": [
    {
      \"subdomain\": \"alice-web\",
      \"fullDomain\": \"alice-web.example.com\",
      \"containerIp\": \"10.0.3.42\",
      \"port\": 80,
      \"active\": true,
      \"appName\": \"alice-container\"
      // ...
    }
  ],
  \"totalCount\": 1
}
```

Both filters optional. Read-only — no side effects.

## What's NOT in scope (deliberate)

- **Passthrough routes (TCP L4)** — different daemon endpoint (`ListPassthroughRoutes`); file a request if surfacing them via MCP is needed. Mentioned in the tool description so agents don't think `list_routes` covers them.
- **Route mutation (update / delete)** — daemon endpoints exist; not in this PR. The conservative path is to keep mutation through `expose_port` (add) until we have a clear agent need for an in-place edit / remove tool.
- **CLI changes** — `containarium route list` already exists and stays the canonical operator surface.

## Tool count

15 → 16 (from initial) … 18 → **19** now. Tests bumped to match.

## Test plan

- [x] `TestClientListRoutes` covers both no-filter and both-filters paths via httptest server (verifies method, path, query encoding, response unmarshaling)
- [x] `TestHandleToolsList` confirms the tool registers (count assertion)
- [x] `go build ./...` green
- [x] `go test ./internal/mcp/...` all green
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)