### PR TITLE
fix(app): ensureHTTPApp must not strict-decode interface-typed routes

### DIFF
--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -553,9 +553,18 @@ func (p *ProxyManager) createTLSApp() error {
 	return nil
 }
 
-// ensureHTTPApp ensures the HTTP app and server exist in Caddy config
+// ensureHTTPApp ensures the HTTP app and server exist in Caddy config.
+//
+// We probe with a loose schema (map[string]json.RawMessage on servers) rather
+// than the typed CaddyHTTPApp. The full type transitively contains
+// []CaddyHandler — an interface slice — which encoding/json cannot decode
+// into, so a strict decode would always fail on any non-empty config and
+// fall through to createHTTPApp's PUT, which 409s because the http app
+// already exists. The result before this fix was that every daemon startup
+// logged "key already exists: http" and silently lost any subsequent route
+// updates the daemon tried to apply (e.g. registering a newly-connected
+// tunnel-promoted pool primary).
 func (p *ProxyManager) ensureHTTPApp() error {
-	// Check if HTTP app exists
 	url := fmt.Sprintf("%s/config/apps/http", p.caddyAdminURL)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -564,7 +573,6 @@ func (p *ProxyManager) ensureHTTPApp() error {
 
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
-		// HTTP app doesn't exist, create it with server
 		return p.createHTTPApp()
 	}
 	defer resp.Body.Close()
@@ -573,21 +581,24 @@ func (p *ProxyManager) ensureHTTPApp() error {
 		return p.createHTTPApp()
 	}
 
-	// HTTP app exists, check if it has the server configured
-	var httpApp CaddyHTTPApp
-	if err := json.NewDecoder(resp.Body).Decode(&httpApp); err != nil {
-		// Invalid config, recreate
+	body, _ := io.ReadAll(resp.Body)
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" || trimmed == "null" {
 		return p.createHTTPApp()
 	}
 
-	// Check if servers map exists and has our server
-	if httpApp.Servers == nil {
-		// No servers map, recreate
+	var probe struct {
+		Servers map[string]json.RawMessage `json:"servers,omitempty"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
 		return p.createHTTPApp()
 	}
 
-	if _, exists := httpApp.Servers[p.serverName]; !exists {
-		// Server doesn't exist, add it
+	if probe.Servers == nil {
+		return p.createHTTPApp()
+	}
+
+	if _, exists := probe.Servers[p.serverName]; !exists {
 		return p.createServerConfig()
 	}
 

--- a/internal/app/proxy_test.go
+++ b/internal/app/proxy_test.go
@@ -654,6 +654,44 @@ func TestProxyManager_EnableProxyProtocol_PreservesOtherFields(t *testing.T) {
 	}
 }
 
+// Regression: ensureHTTPApp used to strictly decode the response into
+// CaddyHTTPApp, whose Routes field transitively contains []CaddyHandler — an
+// interface slice — which encoding/json cannot unmarshal into. Any non-trivial
+// existing http app made the decode fail, the code path fell through to
+// createHTTPApp, the PUT 409'd because the http app already existed, and the
+// daemon silently lost every Caddy update that depended on EnsureServerConfig
+// having succeeded (e.g. registering a tunnel-promoted pool primary).
+func TestProxyManager_EnsureHTTPApp_AcceptsExistingConfigWithHandlers(t *testing.T) {
+	var putToHTTPApp int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/config/apps/http":
+			// Realistic Caddy response: a server with a route whose handle is a
+			// concrete reverse_proxy handler. The old decode failed here.
+			_, _ = w.Write([]byte(`{"servers":{"srv0":{"listen":[":80",":443"],"routes":[{"@id":"wordpress.kafeido.app","match":[{"host":["wordpress.kafeido.app"]}],"handle":[{"handler":"reverse_proxy","upstreams":[{"dial":"10.0.3.53:8888"}]}]}]}}}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/config/apps/http":
+			putToHTTPApp++
+			http.Error(w, `{"error":"[/config/apps/http] key already exists: http"}`, http.StatusConflict)
+		case r.Method == http.MethodGet && r.URL.Path == "/config/apps/tls":
+			_, _ = w.Write([]byte(`{"automation":{"policies":[]}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/config/apps/http/servers/srv0":
+			_, _ = w.Write([]byte(`{"listen":[":80",":443"]}`))
+		default:
+			t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	pm := NewProxyManager(srv.URL, "kafeido.app")
+	if err := pm.EnsureServerConfig(); err != nil {
+		t.Fatalf("EnsureServerConfig err = %v", err)
+	}
+	if putToHTTPApp != 0 {
+		t.Errorf("ensureHTTPApp made %d spurious PUT(s) to /config/apps/http — the interface-decode bug is back", putToHTTPApp)
+	}
+}
+
 func TestProxyManager_EnableProxyProtocol_RefusesEmpty(t *testing.T) {
 	pm := NewProxyManager("http://unreachable", "kafeido.app")
 	if err := pm.EnableProxyProtocol(nil); err == nil {


### PR DESCRIPTION
## Summary

- `ensureHTTPApp` strict-decoded the Caddy `/config/apps/http` response into the typed `CaddyHTTPApp`. That type transitively contains `Handle []CaddyHandler` — an interface slice — which `encoding/json` cannot unmarshal into. On every daemon startup where Caddy already had a non-empty http app, the decode errored out, the code fell through to `createHTTPApp`'s PUT, and Caddy returned `409 key already exists: http`.
- The daemon logged a warning and continued, but every subsequent Caddy update that depended on `EnsureServerConfig` having succeeded was silently lost.
- Symptom observed live: a tunnel-promoted pool primary registered fine in the backend pool (`tunnel-lab-primary-1` healthy in `/v1/backends`) but the new pool's TLS subject + `srv0` route never landed, so its HTTPS endpoint failed the TLS handshake. Restarting the daemon did not recover, because the bug fires on every startup.

Fix: probe with `map[string]json.RawMessage` on `servers` rather than the strict typed decode. The path that actually mutates Caddy already uses untyped maps via `getFullConfig` / `loadConfig`, so we're just bringing the read path into alignment.

Added a regression test `TestProxyManager_EnsureHTTPApp_AcceptsExistingConfigWithHandlers` that fails on the old code (asserts no PUT is issued to `/config/apps/http` when the response contains a typed `reverse_proxy` handler).

## Test plan

- [x] `go test ./internal/app/ -run TestProxyManager -count=1 -v` — all proxy tests pass including the new regression
- [x] Reproduces the live `Failed to ensure Caddy server config: ... status 409` warning in observed prod logs
- [ ] After merge + release, redeploy `containarium daemon` on `containarium-jump-usw1-sentinel` and verify `containarium-lab.kafeido.app` HTTPS returns the expected 404 (daemon's passthrough) instead of TLS handshake failure