### PR TITLE
fix(mcp): auto-save ephemeral private key on create_container

### DIFF
--- a/internal/mcp/keystore_test.go
+++ b/internal/mcp/keystore_test.go
@@ -1,0 +1,125 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSaveEphemeralPrivateKey_WritesFileWithCorrectMode(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CONTAINARIUM_KEYS_DIR", tmp)
+
+	keyText := []byte("-----BEGIN OPENSSH PRIVATE KEY-----\nfakekeybytes\n-----END OPENSSH PRIVATE KEY-----\n")
+
+	got, err := saveEphemeralPrivateKey("alice", keyText)
+	if err != nil {
+		t.Fatalf("saveEphemeralPrivateKey err = %v", err)
+	}
+	if got != filepath.Join(tmp, "alice") {
+		t.Errorf("path = %q, want %q", got, filepath.Join(tmp, "alice"))
+	}
+
+	contents, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("readback err = %v", err)
+	}
+	if string(contents) != string(keyText) {
+		t.Errorf("file contents differ:\nwant %q\ngot  %q", keyText, contents)
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(got)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if mode := info.Mode().Perm(); mode != 0o600 {
+			t.Errorf("file mode = %o, want 0600 (the agent's later ssh -i will reject otherwise)", mode)
+		}
+	}
+}
+
+func TestSaveEphemeralPrivateKey_CreatesParentDir(t *testing.T) {
+	tmp := t.TempDir()
+	// Use a nested path that doesn't exist yet; the helper must mkdir -p.
+	nested := filepath.Join(tmp, "does", "not", "exist", "yet")
+	t.Setenv("CONTAINARIUM_KEYS_DIR", nested)
+
+	if _, err := saveEphemeralPrivateKey("bob", []byte("k")); err != nil {
+		t.Fatalf("saveEphemeralPrivateKey err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(nested, "bob")); err != nil {
+		t.Errorf("expected file at nested path, stat err = %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(nested)
+		if err != nil {
+			t.Fatalf("stat parent dir: %v", err)
+		}
+		if mode := info.Mode().Perm(); mode != 0o700 {
+			t.Errorf("parent dir mode = %o, want 0700", mode)
+		}
+	}
+}
+
+func TestSaveEphemeralPrivateKey_OverwritesExisting(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CONTAINARIUM_KEYS_DIR", tmp)
+
+	// First save — stale key.
+	if _, err := saveEphemeralPrivateKey("carol", []byte("OLD")); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	// Second save — fresh key. Last-create wins. We're idempotent on the
+	// rare retry path; we're authoritative when the daemon hands us a new
+	// ephemeral key (the old one is no longer authorized server-side).
+	if _, err := saveEphemeralPrivateKey("carol", []byte("NEW")); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(tmp, "carol"))
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if string(got) != "NEW" {
+		t.Errorf("contents = %q, want %q", got, "NEW")
+	}
+}
+
+func TestEphemeralKeyDir_PrefersExplicitOverride(t *testing.T) {
+	t.Setenv("CONTAINARIUM_KEYS_DIR", "/custom/path")
+	t.Setenv("HOME", "/some/home")
+	if got := ephemeralKeyDir(); got != "/custom/path" {
+		t.Errorf("override ignored: got %q, want /custom/path", got)
+	}
+}
+
+func TestEphemeralKeyDir_FallsBackToHome(t *testing.T) {
+	t.Setenv("CONTAINARIUM_KEYS_DIR", "")
+	t.Setenv("HOME", "/some/home")
+	want := "/some/home/.containarium/keys"
+	if got := ephemeralKeyDir(); got != want {
+		t.Errorf("home fallback wrong: got %q, want %q", got, want)
+	}
+}
+
+func TestEphemeralKeyDir_EmptyWhenNothingConfigured(t *testing.T) {
+	t.Setenv("CONTAINARIUM_KEYS_DIR", "")
+	t.Setenv("HOME", "")
+	if got := ephemeralKeyDir(); got != "" {
+		t.Errorf("expected empty when HOME and override both unset, got %q", got)
+	}
+}
+
+func TestSaveEphemeralPrivateKey_ReturnsErrorWhenNoDir(t *testing.T) {
+	t.Setenv("CONTAINARIUM_KEYS_DIR", "")
+	t.Setenv("HOME", "")
+	_, err := saveEphemeralPrivateKey("noone", []byte("k"))
+	if err == nil {
+		t.Fatal("expected error when no key dir is available, got nil")
+	}
+	if !strings.Contains(err.Error(), "no key directory") {
+		t.Errorf("error %q should mention 'no key directory' so the response text is actionable", err)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -4,10 +4,75 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/footprintai/containarium/pkg/core/expose"
 )
+
+// ephemeralKeyDir returns the directory the MCP server writes ephemeral
+// private keys to. Defaults to $HOME/.containarium/keys. Overridable via
+// CONTAINARIUM_KEYS_DIR for operators who want a non-default location.
+// Returns "" if no usable directory can be determined (HOME unset and no
+// override) — the caller should treat that as "skip the file write".
+func ephemeralKeyDir() string {
+	if d := os.Getenv("CONTAINARIUM_KEYS_DIR"); d != "" {
+		return d
+	}
+	home := os.Getenv("HOME")
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".containarium", "keys")
+}
+
+// saveEphemeralPrivateKey writes the freshly-minted private key to disk so
+// the operator doesn't have to lift it out of the tool response. Returns
+// the path it wrote to on success, or an error describing why it didn't.
+// On any error the caller should keep showing the key text in the response
+// so the agent at least has the option to save it itself.
+func saveEphemeralPrivateKey(username string, key []byte) (string, error) {
+	dir := ephemeralKeyDir()
+	if dir == "" {
+		return "", fmt.Errorf("no key directory available (HOME and CONTAINARIUM_KEYS_DIR both unset)")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, username)
+	// Write atomically: create at a temp name in the same dir, chmod, then
+	// rename. Avoids leaving a half-written 0600 file under the username
+	// path if the write is interrupted, and avoids ever leaving the key
+	// readable to other users on the filesystem.
+	f, err := os.CreateTemp(dir, "."+username+".tmp.*")
+	if err != nil {
+		return "", fmt.Errorf("create temp in %s: %w", dir, err)
+	}
+	tmpPath := f.Name()
+	// Best-effort cleanup if anything below fails before the rename.
+	defer func() {
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		return "", fmt.Errorf("chmod 0600 on %s: %w", tmpPath, err)
+	}
+	if _, err := f.Write(key); err != nil {
+		_ = f.Close()
+		return "", fmt.Errorf("write key bytes: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return "", fmt.Errorf("rename %s -> %s: %w", tmpPath, path, err)
+	}
+	tmpPath = "" // rename consumed it
+	return path, nil
+}
 
 // Tool represents an MCP tool (function)
 type Tool struct {
@@ -29,14 +94,15 @@ func (s *Server) registerTools() {
 				"name, IP address, and resources.\n\n" +
 				"SSH key handling: if you OMIT `ssh_keys`, an ephemeral ed25519 keypair is " +
 				"generated client-side. The public half is installed on the container; the " +
-				"private half comes back in this tool's response. Save it to " +
-				"`~/.containarium/keys/<username>` with mode 0600 — that's the standard " +
-				"path expected by the rest of the workflow. If you pass `ssh_keys`, those " +
-				"are used as-is and no ephemeral key is generated (useful when reusing an " +
+				"private half is auto-saved to `~/.containarium/keys/<username>` with mode " +
+				"0600 by this MCP server itself (no agent action required) and ALSO echoed " +
+				"into the tool response as a fallback. If you pass `ssh_keys`, those are " +
+				"used as-is and no ephemeral key is generated (useful when reusing an " +
 				"operator's existing key for SSH alias convenience).\n\n" +
 				"AFTER creation, to operate inside the container (simplest path):\n" +
-				"  1. Save the ephemeral private key (if generated) via Bash to\n" +
-				"     ~/.containarium/keys/<name> with mode 0600.\n" +
+				"  1. The private key is already on disk at ~/.containarium/keys/<name>.\n" +
+				"     (Only act on the key text in the response if the response says auto-\n" +
+				"     save failed.)\n" +
 				"  2. The tool response includes a ready-to-paste ssh command:\n" +
 				"       ssh -i ~/.containarium/keys/<name> \\\n" +
 				"           -o IdentitiesOnly=yes -o PreferredAuthentications=publickey \\\n" +
@@ -664,14 +730,27 @@ func handleCreateContainer(client *Client, args map[string]interface{}) (string,
 	result += fmt.Sprintf("\n%s", resp.Message)
 
 	if ephemeralPrivKey != nil {
+		// Write the key to the local filesystem ourselves rather than
+		// asking the agent to do it. The agent could forget the save step
+		// (or its context could be compacted between create_container and
+		// the next ssh call), at which point the key is gone — the daemon
+		// never stores a copy. Doing the write here makes "container
+		// created" and "key on disk" a single atomic-from-the-caller's-
+		// perspective operation.
+		savedPath, saveErr := saveEphemeralPrivateKey(resp.Container.Username, ephemeralPrivKey)
+
 		result += "\n\n--- EPHEMERAL SSH PRIVATE KEY ---\n"
 		result += "Caller did not provide ssh_keys, so an ed25519 keypair was\n"
-		result += "generated locally. The public half is already on the container;\n"
-		result += "save the private half below to a file with mode 0600 and use it\n"
-		result += "to SSH in.\n\n"
-		result += "Suggested save path:\n"
-		result += fmt.Sprintf("  ~/.containarium/keys/%s\n\n", resp.Container.Username)
-		result += "Then to SSH in:\n"
+		result += "generated locally. The public half is already on the container.\n\n"
+		if saveErr == nil {
+			result += fmt.Sprintf("✅ Private key saved: %s (mode 0600)\n\n", savedPath)
+		} else {
+			result += fmt.Sprintf("⚠️  Could not auto-save the private key: %v\n", saveErr)
+			result += "    Save the key text below to a file with mode 0600 yourself.\n\n"
+			result += "Suggested save path:\n"
+			result += fmt.Sprintf("  ~/.containarium/keys/%s\n\n", resp.Container.Username)
+		}
+		result += "To SSH in:\n"
 		sentinelHost := client.SentinelHost
 		if sentinelHost == "" {
 			sentinelHost = "<sentinel-host>"
@@ -688,6 +767,9 @@ func handleCreateContainer(client *Client, args map[string]interface{}) (string,
 			result += "(Sentinel host not configured — set CONTAINARIUM_SENTINEL_HOST in the\n"
 			result += "MCP server's env, or call sync_ssh_config for an alias-based setup.)\n\n"
 		}
+		// Include the key text regardless of save outcome — even on success
+		// it's useful for one-off copy to other machines (vendor laptop,
+		// CI runner, etc.) without re-exporting from the auto-saved file.
 		result += string(ephemeralPrivKey)
 	}
 


### PR DESCRIPTION
## Summary

Before: when an agent calls `create_container` without `ssh_keys`, the MCP server generates an ephemeral ed25519 keypair, embeds the private half in the tool response text, and tells the agent "save it to `~/.containarium/keys/<username>` with mode 0600 yourself." If the agent forgets the save step — or its context gets compacted between the `create_container` response and the next `ssh`/`push`/`sync` call — the key is gone. The daemon never persists a copy, and rightly so.

After: the MCP server writes the key to disk itself, atomically (`CreateTemp` + `chmod 0600` + `Rename`) into `$CONTAINARIUM_KEYS_DIR` (default `$HOME/.containarium/keys`). The key text still appears in the response (useful for one-off copy to other machines, and as a fallback if local write fails). The tool description is updated so agents stop trying to write the file themselves.

This bit us live on a demo today — a previous session's container had a saved key, the current session's didn't, and we hit "Permission denied (publickey)" with no clean recovery path (the supposed RPC fallback `POST /v1/containers/{name}/ssh-keys` returns 500 "not implemented yet", tracked separately).

## Why client-side auto-save and not server-side persistence?

The MCP server runs locally on the operator's machine — it has filesystem access. Server-side persistence of private keys would defeat the security model (key at rest on infrastructure that can't read its own user's filesystem). The fix is to move the write up one layer from "the agent maybe does it" to "the MCP process always does it."

## Test plan

- [x] `go test ./internal/mcp/ -run 'TestSaveEphemeralPrivateKey|TestEphemeralKeyDir' -count=1 -v` — 7 new tests pass
- [x] `go test ./internal/mcp/ -count=1` — full mcp suite still green
- [x] Manually verified on a real demo container after build: file lands at `~/.containarium/keys/<user>` with mode 0600
- [ ] After merge + release, rebuild the local `mcp-server` binary so future demos don't repeat the symptom