### PR TITLE
fix(sentinel): userspace TCP forwarder for simple-proxy mode

### DIFF
--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -72,6 +72,13 @@ type Manager struct {
 	// Tunnel/hybrid mode: ConnMux-based HTTPS handling
 	httpsDispatch  *dispatchListener // from ConnMux, dispatches to proxy or maintenance
 
+	// Simple-proxy mode (no ConnMux): userspace TCP forwarder used when
+	// --proxy-protocol is set, so connections to :80/:443 traverse a Go
+	// process that can prepend a PROXY v2 header instead of going through
+	// kernel iptables DNAT (which can't inject headers and therefore
+	// destroys the real client IP via MASQUERADE).
+	userspaceFwd *userspaceForwarder
+
 	// Recovery tracking
 	outageStart    time.Time // when the current outage began
 	lastPreemption time.Time // when the last preemption event was detected
@@ -468,7 +475,29 @@ func (m *Manager) switchToProxy(backend *Backend) error {
 		m.startHTTPSProxy(backend.IP)
 	}
 
-	// Enable iptables forwarding to the primary backend
+	// Simple-proxy mode with --proxy-protocol: route :80/:443 through a
+	// userspace TCP forwarder that prepends a PROXY v2 header. Kernel
+	// iptables DNAT can't inject the frame, so without this path the
+	// downstream Caddy never sees the real client IP. Only applies in
+	// non-ConnMux mode — ConnMux already emits PROXY v2 via the SNI
+	// router for its own :443 traffic.
+	if m.config.ProxyProtocol && m.httpsDispatch == nil {
+		userspacePorts := []int{m.config.HTTPPort, m.config.HTTPSPort}
+		forwardedPorts = excludePort(forwardedPorts, m.config.HTTPPort)
+		forwardedPorts = excludePort(forwardedPorts, m.config.HTTPSPort)
+
+		fwd := newUserspaceForwarder(true)
+		if err := fwd.start(backend.IP, userspacePorts); err != nil {
+			fwd.stop()
+			return fmt.Errorf("userspace forwarder: %w", err)
+		}
+		m.userspaceFwd = fwd
+		log.Printf("[sentinel] userspace forwarder active for ports %v → %s (PROXY v2 enabled)",
+			userspacePorts, backend.IP)
+	}
+
+	// Enable iptables forwarding for any remaining ports (everything
+	// except the ones owned by ConnMux or the userspace forwarder).
 	if err := enableForwarding(backend.IP, forwardedPorts); err != nil {
 		return err
 	}
@@ -482,6 +511,14 @@ func (m *Manager) switchToProxy(backend *Backend) error {
 func (m *Manager) switchToMaintenance() error {
 	if err := disableForwarding(); err != nil {
 		log.Printf("[sentinel] warning: failed to disable forwarding: %v", err)
+	}
+
+	// Tear down the userspace forwarder if it was running. Safe to call
+	// even when it wasn't started — stop() on an empty listener list is
+	// a no-op.
+	if m.userspaceFwd != nil {
+		m.userspaceFwd.stop()
+		m.userspaceFwd = nil
 	}
 
 	m.mu.Lock()

--- a/internal/sentinel/userspace_forwarder.go
+++ b/internal/sentinel/userspace_forwarder.go
@@ -1,0 +1,127 @@
+package sentinel
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"sync"
+	"time"
+)
+
+// userspaceForwarder is a TCP proxy that runs on the sentinel host,
+// listening on a small set of ports and forwarding each accepted
+// connection to a fixed backend with an optional PROXY v2 header
+// prepended. It exists for the "simple proxy" sentinel mode (single
+// GCP spot VM behind the sentinel) — in that mode the legacy code
+// path uses kernel iptables DNAT, which cannot inject a PROXY v2
+// header because there is no userspace process in the hot path. With
+// PROXY v2 missing, the downstream Caddy sees the connection peer as
+// the sentinel-NAT'd address (a bridge gateway or sentinel IP, not
+// the real client), so visitor-IP-dependent features (logs, audit,
+// XFF-aware app code) all see the wrong IP.
+//
+// This forwarder is only activated when --proxy-protocol is set AND
+// the sentinel is NOT already running the multiplexed ConnMux path
+// (the multi-pool / tunnel-promoted-primary mode, which has its own
+// PROXY v2 emit via buildSNIRoutingHandler). The two paths are
+// mutually exclusive so we don't double-listen on :443.
+type userspaceForwarder struct {
+	mu        sync.Mutex
+	listeners []net.Listener
+	dialer    *net.Dialer
+	emitProxy bool
+}
+
+// newUserspaceForwarder constructs an idle forwarder. Call start()
+// once with the backend address and ports to serve.
+func newUserspaceForwarder(emitProxyV2 bool) *userspaceForwarder {
+	return &userspaceForwarder{
+		dialer:    &net.Dialer{Timeout: 5 * time.Second},
+		emitProxy: emitProxyV2,
+	}
+}
+
+// start binds listeners on each port and begins serving. Each
+// accepted connection dials backend:port (the same port — this is a
+// dumb port-for-port forwarder, not a port-remapping proxy), and if
+// emitProxy is true, prepends a PROXY v2 frame before the first byte
+// of payload. Repeat calls to start() append to the listener set; the
+// caller is responsible for calling stop() in between if reconfiguring.
+//
+// Returns an error if any port fails to bind — but it does NOT roll
+// back successfully-bound listeners on partial failure. The caller
+// should treat partial-success as an error and stop() everything.
+func (f *userspaceForwarder) start(backendIP string, ports []int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	for _, port := range ports {
+		listenAddr := fmt.Sprintf(":%d", port)
+		ln, err := net.Listen("tcp", listenAddr)
+		if err != nil {
+			return fmt.Errorf("listen %s: %w", listenAddr, err)
+		}
+		target := fmt.Sprintf("%s:%d", backendIP, port)
+		f.listeners = append(f.listeners, ln)
+		go f.serve(ln, target)
+		log.Printf("[sentinel] userspace forwarder listening on %s -> %s (proxy_v2=%v)",
+			listenAddr, target, f.emitProxy)
+	}
+	return nil
+}
+
+// stop closes every listener owned by this forwarder. In-flight
+// goroutines copying bytes will see Accept errors / read errors on
+// the closed listener and exit. Per-connection goroutines spawned by
+// serve() will continue until both io.Copy directions complete or one
+// side hangs up — that's intentional: stop() is for shutdown, not for
+// reaping live connections.
+func (f *userspaceForwarder) stop() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, ln := range f.listeners {
+		_ = ln.Close()
+	}
+	f.listeners = nil
+}
+
+func (f *userspaceForwarder) serve(ln net.Listener, target string) {
+	for {
+		client, err := ln.Accept()
+		if err != nil {
+			// Closed listener (during stop()) or transient accept error.
+			// In either case there's no useful retry — exit the goroutine.
+			return
+		}
+		go f.handle(client, target)
+	}
+}
+
+func (f *userspaceForwarder) handle(client net.Conn, target string) {
+	defer client.Close()
+
+	upstream, err := f.dialer.Dial("tcp", target)
+	if err != nil {
+		log.Printf("[sentinel] userspace forwarder: dial %s failed: %v", target, err)
+		return
+	}
+	defer upstream.Close()
+
+	// Prepend PROXY v2 frame BEFORE any payload bytes so the
+	// downstream peer's PROXY-aware parser reads it as the first
+	// thing on the wire. writeProxyHeader extracts the source from
+	// the client connection's RemoteAddr — that's the real client IP.
+	if f.emitProxy {
+		if err := writeProxyHeader(upstream, client); err != nil {
+			log.Printf("[sentinel] userspace forwarder: proxy-proto write to %s failed: %v", target, err)
+			return
+		}
+	}
+
+	// Bidirectional copy. Either direction's EOF tears the pair down.
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(upstream, client); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(client, upstream); done <- struct{}{} }()
+	<-done
+}

--- a/internal/sentinel/userspace_forwarder_test.go
+++ b/internal/sentinel/userspace_forwarder_test.go
@@ -1,0 +1,205 @@
+package sentinel
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// (freePort lives in tunnel_test.go and is shared across the package.)
+
+// TestUserspaceForwarder_HandlerWritesProxyFrame is the focused unit
+// test: it calls handle() directly with a pre-built client conn pair
+// and a mock target backend, bypassing the listener / port-for-port
+// constraint. This is what actually matters — that handle() prepends
+// the frame when emitProxy=true and not otherwise.
+func TestUserspaceForwarder_HandlerWritesProxyFrame(t *testing.T) {
+	// Backend listener — independent port, no conflict.
+	backendLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("backend listen: %v", err)
+	}
+	defer backendLn.Close()
+	backendAddr := backendLn.Addr().String()
+
+	type fromBackend struct {
+		gotHeader bool
+		body      []byte
+		err       error
+	}
+	out := make(chan fromBackend, 1)
+	go func() {
+		c, err := backendLn.Accept()
+		if err != nil {
+			out <- fromBackend{err: err}
+			return
+		}
+		defer c.Close()
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+		// Peek the first 12 bytes — PROXY v2 signature is
+		// 0x0D 0x0A 0x0D 0x0A 0x00 0x0D 0x0A 0x51 0x55 0x49 0x54 0x0A
+		sig := []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+		first := make([]byte, len(sig))
+		if _, err := io.ReadFull(c, first); err != nil {
+			out <- fromBackend{err: err}
+			return
+		}
+		gotHeader := bytes.Equal(first, sig)
+		if gotHeader {
+			// drain the rest of the header — 4 fixed bytes + 2-byte length + payload-addrs
+			rest := make([]byte, 4)
+			if _, err := io.ReadFull(c, rest); err != nil {
+				out <- fromBackend{err: err}
+				return
+			}
+			addrLen := int(rest[2])<<8 | int(rest[3])
+			addrBuf := make([]byte, addrLen)
+			if _, err := io.ReadFull(c, addrBuf); err != nil {
+				out <- fromBackend{err: err}
+				return
+			}
+		}
+		body, _ := io.ReadAll(c)
+		out <- fromBackend{gotHeader: gotHeader, body: body}
+	}()
+
+	// Simulate a client conn by dialing the forwarder's "handle"
+	// directly. Easiest: use net.Pipe? No — net.Pipe doesn't have
+	// a TCP RemoteAddr / LocalAddr that writeProxyHeader needs.
+	// Instead, open a real TCP pair via a transient listener.
+	clientLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("client listen: %v", err)
+	}
+	defer clientLn.Close()
+
+	clientConnCh := make(chan net.Conn, 1)
+	go func() {
+		c, _ := clientLn.Accept()
+		clientConnCh <- c
+	}()
+	clientDial, err := net.Dial("tcp", clientLn.Addr().String())
+	if err != nil {
+		t.Fatalf("client dial: %v", err)
+	}
+	defer clientDial.Close()
+	clientAccepted := <-clientConnCh
+	defer clientAccepted.Close()
+
+	// Write some payload from "client" side so the forwarder has
+	// something to copy through.
+	go func() {
+		_, _ = clientDial.Write([]byte("hello"))
+		_ = clientDial.(*net.TCPConn).CloseWrite()
+	}()
+
+	// Run handle() with emit=true.
+	fwd := newUserspaceForwarder(true)
+	fwd.handle(clientAccepted, backendAddr)
+
+	r := <-out
+	if r.err != nil {
+		t.Fatalf("backend read err: %v", r.err)
+	}
+	if !r.gotHeader {
+		t.Errorf("expected PROXY v2 signature on the wire, didn't see it")
+	}
+	if string(r.body) != "hello" {
+		t.Errorf("payload not forwarded verbatim: got %q want %q", r.body, "hello")
+	}
+}
+
+// TestUserspaceForwarder_HandlerWritesNoFrameWhenDisabled is the
+// counterpart: emit=false means the wire has no PROXY frame, just
+// the payload.
+func TestUserspaceForwarder_HandlerWritesNoFrameWhenDisabled(t *testing.T) {
+	backendLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("backend listen: %v", err)
+	}
+	defer backendLn.Close()
+
+	out := make(chan []byte, 1)
+	go func() {
+		c, err := backendLn.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+		body, _ := io.ReadAll(c)
+		out <- body
+	}()
+
+	clientLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer clientLn.Close()
+	ch := make(chan net.Conn, 1)
+	go func() { c, _ := clientLn.Accept(); ch <- c }()
+	cd, _ := net.Dial("tcp", clientLn.Addr().String())
+	defer cd.Close()
+	ca := <-ch
+	defer ca.Close()
+	go func() {
+		_, _ = cd.Write([]byte("plain"))
+		_ = cd.(*net.TCPConn).CloseWrite()
+	}()
+
+	fwd := newUserspaceForwarder(false)
+	fwd.handle(ca, backendLn.Addr().String())
+
+	got := <-out
+	if string(got) != "plain" {
+		t.Errorf("payload not forwarded verbatim: got %q want %q", got, "plain")
+	}
+	// Make sure the signature is NOT at the start.
+	sig := []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+	if bytes.HasPrefix(got, sig) {
+		t.Error("PROXY v2 frame was emitted even though emitProxy=false")
+	}
+}
+
+// TestUserspaceForwarder_StartStopIsIdempotent makes sure stop() can
+// be called multiple times and on an empty forwarder without panicking,
+// since switchToMaintenance may call it before start() has run on the
+// first proxy switch.
+func TestUserspaceForwarder_StartStopIsIdempotent(t *testing.T) {
+	fwd := newUserspaceForwarder(true)
+	fwd.stop() // never started — must not panic
+
+	// Try starting then double-stopping.
+	port := freePort(t)
+	if err := fwd.start("127.0.0.1", []int{port}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	fwd.stop()
+	fwd.stop()
+}
+
+// TestUserspaceForwarder_BindFailureReturnsError verifies that a port
+// conflict surfaces as an error (so switchToProxy can roll back rather
+// than continue into a half-configured state). The forwarder binds
+// to ":<port>" (all interfaces), so the held listener must do the same
+// — on macOS, holding 127.0.0.1:<port> doesn't prevent 0.0.0.0:<port>
+// from binding.
+func TestUserspaceForwarder_BindFailureReturnsError(t *testing.T) {
+	hold, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("hold listen: %v", err)
+	}
+	defer hold.Close()
+	port := hold.Addr().(*net.TCPAddr).Port
+
+	fwd := newUserspaceForwarder(true)
+	defer fwd.stop()
+	err = fwd.start("127.0.0.1", []int{port})
+	if err == nil {
+		t.Fatal("expected start() to fail when port is already taken")
+	}
+	if !strings.Contains(err.Error(), "listen") {
+		t.Errorf("error should mention listen failure, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

The sentinel's `--proxy-protocol` flag claims to "prepend a PROXY v2 header to forwarded HTTPS streams so the backend Caddy sees the real client IP." That's true in **ConnMux mode** (multi-pool / tunnel-promoted-primary deployments — what lab and prod use), where the SNI router (`buildSNIRoutingHandler`) calls `writeProxyHeader` on every forwarded connection.

It's **not true in simple-proxy mode** (single GCP spot VM behind the sentinel — what the demo cluster uses). That mode uses `enableForwarding` to set up kernel iptables DNAT (`SENTINEL_PREROUTING` chain). The kernel can't inject a PROXY v2 frame, so the flag was silently a no-op — Caddy received bytes from a post-MASQUERADE source IP (the LXC bridge gateway, typically `10.0.3.1`) and dutifully set `X-Forwarded-For` to that.

Result on the demo today: any app that reads `X-Forwarded-For` sees `10.0.3.1`, not the real visitor IP. Diagnosed live by dumping headers from inside the helloworld container.

## Change

When `--proxy-protocol` is set AND `httpsDispatch == nil` (= simple-proxy mode, no ConnMux), `switchToProxy` now:

1. Spins up a userspace TCP forwarder on `:80` and `:443`
2. Excludes those ports from `enableForwarding`'s iptables rule set
3. Each accepted connection dials `backend.IP:<same-port>`, prepends a PROXY v2 frame via the existing `writeProxyHeader` helper, and `io.Copy`s the rest

`switchToMaintenance` and shutdown tear the forwarder back down. The lab/prod (ConnMux) path is untouched — they already had the PROXY v2 emit code via the SNI router.

## Test plan

- [x] `go test ./internal/sentinel/ -count=1` — all green including 4 new tests:
  - `TestUserspaceForwarder_HandlerWritesProxyFrame` — verifies the PROXY v2 signature appears on the wire when `emitProxy=true`
  - `TestUserspaceForwarder_HandlerWritesNoFrameWhenDisabled` — verifies bytes are forwarded verbatim when `emitProxy=false`
  - `TestUserspaceForwarder_StartStopIsIdempotent` — `stop()` is safe to call multiple times / before `start()`
  - `TestUserspaceForwarder_BindFailureReturnsError` — port conflict surfaces an error so `switchToProxy` can roll back
- [ ] After merge + release: deploy v0.16.7 to demo sentinel, verify `curl https://helloworld.demo.containarium.dev/_headers` shows the real client IP in `X-Forwarded-For`, and confirm lab pool's HTTPS still works (ConnMux path unchanged)