### PR TITLE
feat(terraform): app-hosting + PROXY v2 module variables, demo wired

### DIFF
--- a/terraform/gce-demo/main.tf
+++ b/terraform/gce-demo/main.tf
@@ -72,6 +72,23 @@ module "containarium" {
   containarium_version       = var.containarium_version
   containarium_binary_url    = local.containarium_binary_url
 
+  // App-hosting: the demo serves customer apps at subdomains of
+  // base_domain (e.g. blog.demo.containarium.dev). Caddy ACMEs each
+  // hostname on demand. Wildcard DNS for *.<base_domain> must point
+  // at the sentinel's IP — Cloudflare-managed today.
+  enable_app_hosting = true
+  base_domain        = var.base_domain
+
+  // PROXY v2: have the sentinel emit a PROXY v2 header on each
+  // forwarded connection so the backend's Caddy sees the real client
+  // IP. Without this, the simple-proxy sentinel mode passes traffic
+  // through kernel iptables DNAT + MASQUERADE — the backend sees
+  // 10.0.3.1 (LXC bridge) as the source for every request. Trusted
+  // CIDR covers the GCP internal VPC + loopback; tighten to the
+  // sentinel's exact IP for prod-style deployments.
+  enable_proxy_protocol        = true
+  proxy_protocol_trusted_cidrs = ["10.0.0.0/8", "127.0.0.0/8"]
+
   // Access
   admin_ssh_keys      = var.admin_ssh_keys
   allowed_ssh_sources = var.allowed_ssh_sources

--- a/terraform/gce-demo/variables.tf
+++ b/terraform/gce-demo/variables.tf
@@ -32,9 +32,15 @@ variable "machine_type" {
 // Versioning ----------------------------------------------------------
 
 variable "containarium_version" {
-  description = "Containarium version to install on the demo VM. Should match a tagged release at https://github.com/footprintai/Containarium/releases."
+  description = "Containarium version to install on the demo VM. Should match a tagged release at https://github.com/footprintai/Containarium/releases. Note: --proxy-protocol on the sentinel requires v0.16.7+ — older versions silently no-op'd the flag in simple-proxy mode."
   type        = string
-  default     = "0.16.4"
+  default     = "0.16.7"
+}
+
+variable "base_domain" {
+  description = "Public hostname the demo daemon serves at. Containers exposed via `expose_port` get subdomains of this (e.g. blog.<base_domain>). The cluster must have wildcard DNS for *.<base_domain> pointing at the sentinel's IP — Cloudflare-managed for the production demo deployment. Empty disables app-hosting."
+  type        = string
+  default     = "demo.containarium.dev"
 }
 
 variable "containarium_binary_url" {

--- a/terraform/gce/examples/minimal-daemon-test.tfvars
+++ b/terraform/gce/examples/minimal-daemon-test.tfvars
@@ -3,21 +3,21 @@
 # Cost: ~$7-12/month spot
 
 # REQUIRED: Set your GCP project ID
-project_id = "your-gcp-project-id"  # CHANGE THIS
+project_id = "your-gcp-project-id" # CHANGE THIS
 
 # REQUIRED: Add your SSH public key
 admin_ssh_keys = {
-  admin = "ssh-ed25519 AAAAC3Nza... your-key-here"  # CHANGE THIS
+  admin = "ssh-ed25519 AAAAC3Nza... your-key-here" # CHANGE THIS
 }
 
 # Minimal instance - just to test daemon
-machine_type       = "e2-small"  # 2 vCPU, 2GB RAM
-use_spot_instance  = true        # 70% cheaper
+machine_type        = "e2-small" # 2 vCPU, 2GB RAM
+use_spot_instance   = true       # 70% cheaper
 use_persistent_disk = false      # Not needed for testing
 
 # Minimal disks
-boot_disk_size = 20   # GB - just OS + Incus + daemon
-data_disk_size = 20   # GB - minimal
+boot_disk_size = 20 # GB - just OS + Incus + daemon
+data_disk_size = 20 # GB - minimal
 
 # Security: Open for testing (change in production)
 allowed_ssh_sources = ["0.0.0.0/0"]
@@ -25,11 +25,11 @@ allowed_ssh_sources = ["0.0.0.0/0"]
 # Enable daemon
 enable_containarium_daemon = true
 containarium_version       = "dev"
-containarium_binary_url    = ""  # Use local binary
+containarium_binary_url    = "" # Use local binary
 
 # No scaling - single server
 enable_horizontal_scaling = false
-enable_load_balancer     = false
+enable_load_balancer      = false
 
 # No monitoring for minimal cost
 enable_monitoring = false

--- a/terraform/gce/examples/single-server-spot.tfvars
+++ b/terraform/gce/examples/single-server-spot.tfvars
@@ -7,21 +7,21 @@ region     = "us-central1"
 zone       = "us-central1-a"
 
 # Single Server Configuration
-enable_horizontal_scaling = false    # Single jump server
-instance_name = "containarium-jump"
-machine_type  = "n2-standard-8"      # 8 vCPU, 32GB RAM
+enable_horizontal_scaling = false # Single jump server
+instance_name             = "containarium-jump"
+machine_type              = "n2-standard-8" # 8 vCPU, 32GB RAM
 
 # Cost Optimization - Maximum Savings!
-use_spot_instance   = true           # 76% cheaper than regular VM
-use_persistent_disk = true           # Containers survive spot termination
+use_spot_instance   = true # 76% cheaper than regular VM
+use_persistent_disk = true # Containers survive spot termination
 
 # Storage
-boot_disk_size = 100                 # GB
-data_disk_size = 500                 # GB - all container data here
+boot_disk_size = 100 # GB
+data_disk_size = 500 # GB - all container data here
 data_disk_type = "pd-balanced"
 
 # Backup
-enable_disk_snapshots = true         # Daily snapshots
+enable_disk_snapshots = true # Daily snapshots
 
 # SSH Access
 admin_ssh_keys = {
@@ -30,7 +30,7 @@ admin_ssh_keys = {
 
 # Security
 allowed_ssh_sources = [
-  "0.0.0.0/0"  # WARNING: Restrict in production!
+  "0.0.0.0/0" # WARNING: Restrict in production!
 ]
 
 # Labels

--- a/terraform/gce/examples/test-daemon-spot.tfvars
+++ b/terraform/gce/examples/test-daemon-spot.tfvars
@@ -2,25 +2,25 @@
 # This is a minimal setup for testing the gRPC daemon
 
 # REQUIRED: Set your GCP project ID
-project_id = "your-gcp-project-id"  # CHANGE THIS
+project_id = "your-gcp-project-id" # CHANGE THIS
 
 # REQUIRED: Add your SSH public key for admin access
 admin_ssh_keys = {
-  admin = "ssh-ed25519 AAAAC3Nza... your-key-here"  # CHANGE THIS
+  admin = "ssh-ed25519 AAAAC3Nza... your-key-here" # CHANGE THIS
 }
 
 # Use small spot instance for testing (cheap!)
-machine_type       = "e2-standard-2"  # 2 vCPU, 8GB RAM - $14/month spot
-use_spot_instance  = true
+machine_type        = "e2-standard-2" # 2 vCPU, 8GB RAM - $14/month spot
+use_spot_instance   = true
 use_persistent_disk = true
 
 # Small disks for testing
-boot_disk_size = 100  # GB
-data_disk_size = 100  # GB
+boot_disk_size = 100 # GB
+data_disk_size = 100 # GB
 
 # Security: Restrict to your IP (recommended)
 # allowed_ssh_sources = ["YOUR.IP.ADDRESS/32"]  # Uncomment and set your IP
-allowed_ssh_sources = ["0.0.0.0/0"]  # WARNING: Open to all - OK for testing only
+allowed_ssh_sources = ["0.0.0.0/0"] # WARNING: Open to all - OK for testing only
 
 # Containarium daemon configuration
 enable_containarium_daemon = true
@@ -35,8 +35,8 @@ containarium_binary_url = ""
 
 # Single server (not scaling)
 enable_horizontal_scaling = false
-jump_server_count        = 1
-enable_load_balancer     = false
+jump_server_count         = 1
+enable_load_balancer      = false
 
 # Enable monitoring
 enable_monitoring = true

--- a/terraform/gce/main.tf
+++ b/terraform/gce/main.tf
@@ -51,10 +51,10 @@ module "containarium" {
   dns_zone_domain = var.dns_zone_domain
 
   # Spot instance & persistent disk
-  use_spot_instance    = var.use_spot_instance
-  use_persistent_disk  = var.use_persistent_disk
-  data_disk_size       = var.data_disk_size
-  data_disk_type       = var.data_disk_type
+  use_spot_instance     = var.use_spot_instance
+  use_persistent_disk   = var.use_persistent_disk
+  data_disk_size        = var.data_disk_size
+  data_disk_type        = var.data_disk_type
   enable_disk_snapshots = var.enable_disk_snapshots
 
   # Containarium daemon

--- a/terraform/modules/containarium/examples/production-consumer/main.tf
+++ b/terraform/modules/containarium/examples/production-consumer/main.tf
@@ -47,13 +47,13 @@ module "containarium" {
   # VPC networking
   network_self_link    = data.google_compute_network.vpc.self_link
   subnetwork_self_link = data.google_compute_subnetwork.subnet.self_link
-  spot_vm_external_ip  = false  # Cloud NAT only
+  spot_vm_external_ip  = false # Cloud NAT only
 
   # Production features
-  enable_iap_firewall          = true
-  jwt_secret                   = var.jwt_secret
-  fail2ban_whitelist_cidr      = "10.0.0.0/8"
-  instance_tags                = ["containarium-jump-server-usw1", "containarium-sentinel"]
+  enable_iap_firewall     = true
+  jwt_secret              = var.jwt_secret
+  fail2ban_whitelist_cidr = "10.0.0.0/8"
+  instance_tags           = ["containarium-jump-server-usw1", "containarium-sentinel"]
 
   # Standard config
   admin_ssh_keys          = var.admin_ssh_keys

--- a/terraform/modules/containarium/scripts/startup-sentinel.sh
+++ b/terraform/modules/containarium/scripts/startup-sentinel.sh
@@ -137,6 +137,27 @@ if [ -f /usr/local/bin/containarium ]; then
         --zone "$ZONE" \
         --project "$PROJECT_ID"
     echo "Sentinel service installed and running"
+
+    # Optional override.conf for --proxy-protocol on the sentinel.
+    #
+    # `sentinel service install` generates a fixed ExecStart without
+    # this flag. With --proxy-protocol the sentinel runs a userspace
+    # TCP forwarder on :80/:443 (Containarium v0.16.7+) that prepends
+    # a PROXY v2 frame to each connection, so the downstream Caddy
+    # sees the real client IP. Without the flag, the sentinel
+    # forwards via kernel iptables DNAT and the real source is lost
+    # to MASQUERADE — apps then see the bridge gateway IP.
+%{ if enable_proxy_protocol ~}
+    mkdir -p /etc/systemd/system/containarium-sentinel.service.d
+    cat > /etc/systemd/system/containarium-sentinel.service.d/proxyproto.conf <<EOF
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/containarium sentinel --spot-vm $SPOT_VM_NAME --zone $ZONE --project $PROJECT_ID --proxy-protocol
+EOF
+    echo "wrote proxyproto.conf for sentinel"
+    systemctl daemon-reload
+    systemctl restart containarium-sentinel.service
+%{ endif ~}
 else
     echo "WARNING: containarium binary not found, sentinel not started"
 fi

--- a/terraform/modules/containarium/scripts/startup-spot.sh
+++ b/terraform/modules/containarium/scripts/startup-spot.sh
@@ -740,6 +740,34 @@ SVCEOF
         echo "✓ Containarium daemon service created and started"
     fi
 
+    # ---------------------------------------------------------------
+    # Optional override.conf for --app-hosting and/or --proxy-protocol.
+    #
+    # We can't put these flags in the primary ExecStart written above,
+    # because `containarium service install` (the preferred install
+    # path, called at the top of this block) generates its own
+    # ExecStart and we shouldn't second-guess it. The systemd
+    # drop-in pattern (override.conf with `ExecStart=` to clear the
+    # parent, then a fresh `ExecStart=...`) is the supported way to
+    # extend it without forking the unit file.
+    #
+    # PROXY v2 trusted CIDRs: rejected by the daemon if any entry is
+    # 0.0.0.0/0 (anti-spoofing). Wildcards must be filtered out
+    # upstream — the module-level var.proxy_protocol_trusted_cidrs
+    # gets validated at apply time too via the daemon's startup logs.
+    # ---------------------------------------------------------------
+%{ if enable_app_hosting || enable_proxy_protocol ~}
+    mkdir -p /etc/systemd/system/containarium.service.d
+    cat > /etc/systemd/system/containarium.service.d/override.conf <<EOF
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/containarium daemon --address 0.0.0.0 --rest --http-port 8080 --jwt-secret-file /etc/containarium/jwt.secret%{ if enable_app_hosting } --app-hosting%{ if base_domain != "" } --base-domain ${base_domain}%{ endif }%{ endif }%{ if enable_proxy_protocol } --proxy-protocol --proxy-protocol-trusted=${join(",", proxy_protocol_trusted_cidrs)}%{ endif }
+EOF
+    echo "✓ wrote override.conf for app-hosting / proxy-protocol"
+    systemctl daemon-reload
+    systemctl restart containarium.service
+%{ endif ~}
+
     # Check status
     sleep 2
     if systemctl is-active --quiet containarium; then

--- a/terraform/modules/containarium/sentinel.tf
+++ b/terraform/modules/containarium/sentinel.tf
@@ -26,10 +26,10 @@ resource "google_compute_instance" "sentinel" {
 
   # Always-on: standard provisioning, live-migrate on maintenance
   scheduling {
-    preemptible                 = false
-    automatic_restart           = true
-    on_host_maintenance         = "MIGRATE"
-    provisioning_model          = "STANDARD"
+    preemptible         = false
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    provisioning_model  = "STANDARD"
   }
 
   boot_disk {
@@ -63,6 +63,7 @@ resource "google_compute_instance" "sentinel" {
       spot_vm_name            = local.spot_vm_name
       zone                    = var.zone
       project_id              = var.project_id
+      enable_proxy_protocol   = var.enable_proxy_protocol
     })
   }
 

--- a/terraform/modules/containarium/spot-instance.tf
+++ b/terraform/modules/containarium/spot-instance.tf
@@ -139,15 +139,19 @@ resource "google_compute_instance" "jump_server_spot" {
       "${user}:${key}"
     ])
     startup-script = templatefile("${path.module}/scripts/startup-spot.sh", {
-      incus_version           = var.incus_version
-      admin_users             = keys(var.admin_ssh_keys)
-      enable_monitoring       = var.enable_monitoring
-      use_persistent_disk     = var.use_persistent_disk
-      containarium_version    = var.containarium_version
-      containarium_binary_url = var.containarium_binary_url
-      sentinel_binary_url     = local.use_sentinel ? "http://${google_compute_instance.sentinel[0].network_interface[0].network_ip}:8888/containarium" : ""
-      jwt_secret              = var.jwt_secret
-      fail2ban_whitelist_cidr = var.fail2ban_whitelist_cidr
+      incus_version                = var.incus_version
+      admin_users                  = keys(var.admin_ssh_keys)
+      enable_monitoring            = var.enable_monitoring
+      use_persistent_disk          = var.use_persistent_disk
+      containarium_version         = var.containarium_version
+      containarium_binary_url      = var.containarium_binary_url
+      sentinel_binary_url          = local.use_sentinel ? "http://${google_compute_instance.sentinel[0].network_interface[0].network_ip}:8888/containarium" : ""
+      jwt_secret                   = var.jwt_secret
+      fail2ban_whitelist_cidr      = var.fail2ban_whitelist_cidr
+      enable_app_hosting           = var.enable_app_hosting
+      base_domain                  = var.base_domain
+      enable_proxy_protocol        = var.enable_proxy_protocol
+      proxy_protocol_trusted_cidrs = var.proxy_protocol_trusted_cidrs
     })
   }
 

--- a/terraform/modules/containarium/variables.tf
+++ b/terraform/modules/containarium/variables.tf
@@ -310,3 +310,38 @@ variable "spot_vm_name_suffix" {
   type        = string
   default     = ""
 }
+
+# -----------------------------------------------------------------------------
+# App hosting + PROXY v2 (real-client-IP preservation)
+#
+# These four variables form one logical feature: serving customer apps on
+# sentinel-fronted hostnames AND making sure the apps see real client IPs
+# instead of the sentinel/bridge gateway. They're independent (you can
+# enable app-hosting without PROXY v2 if you don't care about visitor IPs,
+# or PROXY v2 alone if you have your own routing on top) but in practice
+# the demo and prod clusters want both.
+# -----------------------------------------------------------------------------
+
+variable "enable_app_hosting" {
+  description = "Enable Containarium's app-hosting subsystem (Caddy reverse proxy, ACME, route store). Required for `expose_port` to provision public hostnames automatically."
+  type        = bool
+  default     = false
+}
+
+variable "base_domain" {
+  description = "Base domain for app-hosting. When set with enable_app_hosting=true, the daemon registers the management route at this hostname and Caddy ACMEs a cert for it; containers exposed via expose_port get subdomains of this base (e.g. blog.<base_domain>). Empty disables hostname-aware routing."
+  type        = string
+  default     = ""
+}
+
+variable "enable_proxy_protocol" {
+  description = "Have the sentinel emit PROXY v2 headers to the backend and have the backend's Caddy parse them so the real client IP propagates as X-Forwarded-For. In simple-proxy mode (single-spot-VM deployments) this also switches the sentinel from kernel iptables DNAT to a userspace TCP forwarder — iptables can't inject the header. Requires Containarium v0.16.7+ on both sentinel and backend."
+  type        = bool
+  default     = false
+}
+
+variable "proxy_protocol_trusted_cidrs" {
+  description = "CIDR blocks the backend's Caddy will trust as sources of PROXY v2 frames. Typically the sentinel's internal IP plus loopback. Required when enable_proxy_protocol=true. Wildcard 0.0.0.0/0 is rejected at startup to prevent IP spoofing."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

Moves the hand-written `override.conf` files on the live demo cluster (added during the `demo.kafeido.app` → `demo.containarium.dev` migration earlier today) into the shared `terraform/modules/containarium/` module so fresh provisions land with the right flags.

### Module changes

Four new variables, all default-off so existing consumers (`terraform/gce`, `kafeido-infra` prod) are unaffected:

| Variable | Type | Purpose |
|---|---|---|
| `enable_app_hosting` | bool | `--app-hosting` flag on the daemon |
| `base_domain` | string | `--base-domain` on the daemon |
| `enable_proxy_protocol` | bool | `--proxy-protocol` on both sentinel and daemon |
| `proxy_protocol_trusted_cidrs` | list(string) | Caddy listener_wrapper trusted-source allowlist |

`startup-spot.sh` writes `containarium.service.d/override.conf` when either app-hosting or proxy-protocol is on; `startup-sentinel.sh` writes `containarium-sentinel.service.d/proxyproto.conf` when proxy-protocol is on. Both use the systemd drop-in pattern (`ExecStart=` to clear the parent, then a fresh one) so `containarium service install` / `containarium sentinel service install` keep working unchanged.

### Demo consumer

`terraform/gce-demo/main.tf` passes the four inputs (`enable_app_hosting=true`, `base_domain=demo.containarium.dev`, `enable_proxy_protocol=true`, trusted CIDRs `[10.0.0.0/8, 127.0.0.0/8]`). Default `containarium_version` bumped from `0.16.4` → `0.16.7` (PROXY v2 on the sentinel needs the new userspace forwarder code in v0.16.7+).

### Closes / pairs with

- Closes #60 (demo deploy: enable --app-hosting + plumb base-domain in startup-spot.sh)
- Pairs with #161 (v0.16.7 sentinel userspace forwarder)

## Test plan

- [x] `terraform fmt -recursive terraform/` clean
- [x] `terraform validate` on `terraform/gce-demo/` passes
- [x] Module change is backwards-compatible (all new vars default off; existing `terraform/gce` and prod consumers see no behavior change)
- [ ] After merge, on next demo VM recreate (`terraform apply` with `replace`-marked instance, or full destroy+apply), confirm the override.conf files match what's currently on disk on the running demo cluster