### PR TITLE
docs(readme): link the 55-second demo video on YouTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ curl https://blog.example.com → hello world
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Go](https://img.shields.io/badge/go-1.25-00ADD8.svg)](go.mod)
 
+🎬 **Watch (55s):** [Prompt → live HTTPS Python app](https://youtu.be/IBDDD_tb8FY)
 🌐 **Live demo:** [containarium.kafeido.app/webui/demo](https://containarium.kafeido.app/webui/demo)
 
 ---
@@ -623,5 +624,6 @@ Apache License 2.0 — see [LICENSE](LICENSE).
 
 - **Documentation**: [docs/](docs/) directory.
 - **Issues**: [GitHub Issues](https://github.com/footprintai/Containarium/issues).
+- **Demo video**: [55s walkthrough on YouTube](https://youtu.be/IBDDD_tb8FY).
 - **Live demo**: [containarium.kafeido.app/webui/demo](https://containarium.kafeido.app/webui/demo).
 - **Organization**: [FootprintAI](https://github.com/footprintai).


### PR DESCRIPTION
## Summary

Adds the [YouTube walkthrough](https://youtu.be/IBDDD_tb8FY) in two places:

- **Hero block** (top of README) — peer to the existing "Live demo" link, so first-time visitors see the 55s video option immediately
- **Support section** (bottom of README) — bullet alongside the other resources

Both call it "55s walkthrough" so visitors commit knowing it's a short watch.

## Test plan

- [x] `head -22 README.md` — both links render in the hero block
- [x] `tail -15 README.md` — Support section gets the new bullet