### PR TITLE
fix(app): use --network=host instead of -p for podman run

### DIFF
--- a/internal/app/manager.go
+++ b/internal/app/manager.go
@@ -449,12 +449,27 @@ func (m *Manager) uploadSource(ctx context.Context, containerName, appDir string
 func (m *Manager) runContainer(ctx context.Context, containerName string, app *v1.App, envVars map[string]string) error {
 	podmanContainerName := m.podmanContainerName(app)
 
-	// Build podman run command
+	// Build podman run command.
+	//
+	// Networking note: --network=host, not -p <port>:<port>. The LXC
+	// container we run inside uses unprivileged user namespaces, which
+	// means rootless podman's port publishing (-p) only exposes the port
+	// inside the user's slirp4netns network namespace — it's invisible
+	// from the LXC's main netns. Caddy reverse-proxies via the LXC's eth0
+	// IP, so a -p-published port is unreachable and returns 502.
+	//
+	// --network=host makes the podman container share the LXC's main
+	// network namespace directly, so any bind to 0.0.0.0:<port> is
+	// reachable on the LXC's eth0 with no port-mapping layer in between.
+	// Trade-off: only one process can bind any given port inside the
+	// LXC. That's fine for Containarium's model (one app per LXC) — if
+	// we ever want multi-app-per-LXC we'd need a userspace port
+	// forwarder instead, which is a much bigger change.
 	args := []string{
 		"podman", "run", "-d",
 		"--name", podmanContainerName,
 		"--restart", "unless-stopped",
-		"-p", fmt.Sprintf("%d:%d", app.Port, app.Port),
+		"--network=host",
 	}
 
 	// Add environment variables


### PR DESCRIPTION
## Summary

Rootless podman inside an unprivileged LXC publishes `-p` ports only in the user's `slirp4netns` namespace. From the LXC's main netns — where Caddy lives — the port is invisible. Caddy proxies to the LXC's eth0 IP and gets connection-refused, returning 502.

Switching to `--network=host` puts the podman process directly on the LXC's main netns, so `0.0.0.0:<port>` is reachable to Caddy without a mapping layer.

## How it manifested

Diagnosed live on the demo's `helloworld` container yesterday:

```
podman ps:           0.0.0.0:8080->8080/tcp  Up 5 minutes
curl localhost:8080: HTML page ✓             (works inside user session)
ss -tlnp (LXC root): no listener on :8080    (rootless ns invisible)
curl from Caddy:     Connection refused      (proxies to 10.0.3.88:8080, nothing there)
public curl:         HTTP 502
```

Hand-patching the live container's hook from `-p 8080:8080` to `--network=host` made `ss` show the listener and the public URL return 200 within seconds.

## Trade-offs

- **Lose:** multi-app-per-LXC port isolation. With `--network=host`, two podman processes can't both bind `:8080` inside the same LXC.
- **Keep:** Containarium's actual model is one-app-per-LXC, so this isn't a regression.
- **If multi-app-per-LXC matters later:** a userspace port forwarder inside the LXC is the right answer, but that's a much bigger change and out of scope here.

## Test plan

- [x] `go build ./internal/app/` passes
- [x] Behavior verified live on demo cluster yesterday (hand-patched hook → public URL 200, real client IP via PROXY v2)
- No new automated tests — `internal/app/manager.go` has no existing test scaffolding (it's incus-bound). Adding a mock-incus harness for this single flag flip is out of scope.

Closes #68.