### PR TITLE
fix(server): cascade-clean routes + TLS + host user on DeleteContainer

### DIFF
--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -167,6 +167,76 @@ func (p *ProxyManager) addRouteWithProtocol(subdomain, containerIP string, port 
 	return nil
 }
 
+// RemoveTLSSubject strips `domain` from every TLS automation policy's
+// `subjects` list. Used by the container-delete cascade: once a container
+// is gone, Caddy should stop trying to ACME-renew its hostname's cert
+// (otherwise it'll keep hitting Let's Encrypt with no upstream to
+// challenge, slowly burning rate-limit budget).
+//
+// No-op if `domain` isn't in any subjects list. Leaves an empty policy
+// in place if `domain` was the only subject — that's harmless (Caddy
+// just has nothing to do for it) and avoids the complexity of deciding
+// whether to delete the entire policy entry (which might be the only
+// reference to the ACME issuers config).
+func (p *ProxyManager) RemoveTLSSubject(domain string) error {
+	url := fmt.Sprintf("%s/config/apps/tls/automation/policies", p.caddyAdminURL)
+	resp, err := p.httpClient.Get(url)
+	if err != nil {
+		return fmt.Errorf("get TLS policies: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest {
+		// No TLS app configured; nothing to remove.
+		return nil
+	}
+
+	var policies []CaddyTLSAutomationPolicy
+	body, _ := io.ReadAll(resp.Body)
+	if len(bytes.TrimSpace(body)) == 0 || string(bytes.TrimSpace(body)) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(body, &policies); err != nil {
+		return fmt.Errorf("decode TLS policies: %w", err)
+	}
+
+	changed := false
+	for i := range policies {
+		filtered := policies[i].Subjects[:0]
+		for _, s := range policies[i].Subjects {
+			if s == domain {
+				changed = true
+				continue
+			}
+			filtered = append(filtered, s)
+		}
+		policies[i].Subjects = filtered
+	}
+	if !changed {
+		return nil
+	}
+
+	out, err := json.Marshal(policies)
+	if err != nil {
+		return fmt.Errorf("marshal TLS policies: %w", err)
+	}
+	req, err := http.NewRequest("PATCH", url, bytes.NewReader(out))
+	if err != nil {
+		return fmt.Errorf("build PATCH request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	patchResp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("patch TLS policies: %w", err)
+	}
+	defer patchResp.Body.Close()
+	if patchResp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(patchResp.Body)
+		return fmt.Errorf("caddy returned %d patching TLS policies: %s", patchResp.StatusCode, string(errBody))
+	}
+	return nil
+}
+
 // ProvisionTLS provisions a TLS certificate for the given domain via Caddy's on-demand TLS
 // or by adding it to the TLS automation policy
 func (p *ProxyManager) ProvisionTLS(domain string) error {

--- a/internal/app/proxy_test.go
+++ b/internal/app/proxy_test.go
@@ -692,6 +692,98 @@ func TestProxyManager_EnsureHTTPApp_AcceptsExistingConfigWithHandlers(t *testing
 	}
 }
 
+// TestProxyManager_RemoveTLSSubject_StripsFromAllPolicies covers the
+// container-delete cascade case (#69): when a container is deleted, its
+// hostname must come out of Caddy's TLS automation subjects so Caddy
+// stops trying to ACME-renew an orphaned cert.
+func TestProxyManager_RemoveTLSSubject_StripsFromAllPolicies(t *testing.T) {
+	gone := "helloworld.demo.containarium.dev"
+	var gotPolicies []map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/config/apps/tls/automation/policies":
+			_, _ = w.Write([]byte(`[
+				{"subjects": ["keep.example.com", "helloworld.demo.containarium.dev", "also.example.com"]},
+				{"subjects": ["another.example.com", "helloworld.demo.containarium.dev"]}
+			]`))
+		case r.Method == http.MethodPatch && r.URL.Path == "/config/apps/tls/automation/policies":
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &gotPolicies)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	pm := NewProxyManager(srv.URL, "demo.containarium.dev")
+	if err := pm.RemoveTLSSubject(gone); err != nil {
+		t.Fatalf("RemoveTLSSubject err = %v", err)
+	}
+
+	if len(gotPolicies) != 2 {
+		t.Fatalf("expected 2 policies in PATCH body, got %d", len(gotPolicies))
+	}
+	for i, p := range gotPolicies {
+		subs, _ := p["subjects"].([]interface{})
+		for _, s := range subs {
+			if s == gone {
+				t.Errorf("policy %d still contains %q after RemoveTLSSubject", i, gone)
+			}
+		}
+	}
+	// First policy had 3 subjects originally with one to drop → expect 2 left
+	if subs, _ := gotPolicies[0]["subjects"].([]interface{}); len(subs) != 2 {
+		t.Errorf("first policy expected 2 subjects after, got %d (%v)", len(subs), subs)
+	}
+	// Second had 2 → expect 1 left
+	if subs, _ := gotPolicies[1]["subjects"].([]interface{}); len(subs) != 1 {
+		t.Errorf("second policy expected 1 subject after, got %d (%v)", len(subs), subs)
+	}
+}
+
+// TestProxyManager_RemoveTLSSubject_NoOpWhenAbsent covers the case
+// where the cascade is called for a container whose route was never
+// ACME-provisioned (e.g. expose_port was never called). Must not error
+// and must not PATCH (avoiding noise in the Caddy config history).
+func TestProxyManager_RemoveTLSSubject_NoOpWhenAbsent(t *testing.T) {
+	patchCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/config/apps/tls/automation/policies":
+			_, _ = w.Write([]byte(`[{"subjects": ["only.example.com"]}]`))
+		case r.Method == http.MethodPatch:
+			patchCount++
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	pm := NewProxyManager(srv.URL, "")
+	if err := pm.RemoveTLSSubject("not-present.example.com"); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if patchCount != 0 {
+		t.Errorf("expected no PATCH when subject is absent, got %d", patchCount)
+	}
+}
+
+// TestProxyManager_RemoveTLSSubject_HandlesNullConfig covers a fresh
+// Caddy with no TLS app configured yet. Should return nil silently.
+func TestProxyManager_RemoveTLSSubject_HandlesNullConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Caddy returns "null\n" for missing config paths
+		_, _ = w.Write([]byte("null\n"))
+	}))
+	defer srv.Close()
+
+	pm := NewProxyManager(srv.URL, "")
+	if err := pm.RemoveTLSSubject("anything.example.com"); err != nil {
+		t.Errorf("expected nil on null config, got %v", err)
+	}
+}
+
 func TestProxyManager_EnableProxyProtocol_RefusesEmpty(t *testing.T) {
 	pm := NewProxyManager("http://unreachable", "kafeido.app")
 	if err := pm.EnableProxyProtocol(nil); err == nil {

--- a/internal/app/route_store.go
+++ b/internal/app/route_store.go
@@ -274,6 +274,50 @@ func (s *RouteStore) Delete(ctx context.Context, fullDomain string) error {
 	return nil
 }
 
+// ListByContainer returns every route whose ContainerName matches.
+// Used by the container-delete cascade so a deleted container doesn't
+// leave dangling routes in the store (which RouteSyncJob would otherwise
+// keep re-installing into Caddy on its next tick, producing 502s on
+// the public hostname).
+func (s *RouteStore) ListByContainer(ctx context.Context, containerName string) ([]*RouteRecord, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, subdomain, full_domain, target_ip, target_port, protocol,
+			COALESCE(container_name, ''), app_id, COALESCE(description, ''), active,
+			created_by, created_at, updated_at
+		FROM routes
+		WHERE container_name = $1
+		ORDER BY created_at ASC
+	`, containerName)
+	if err != nil {
+		return nil, fmt.Errorf("query routes by container: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*RouteRecord
+	for rows.Next() {
+		route := &RouteRecord{}
+		if err := rows.Scan(
+			&route.ID,
+			&route.Subdomain,
+			&route.FullDomain,
+			&route.TargetIP,
+			&route.TargetPort,
+			&route.Protocol,
+			&route.ContainerName,
+			&route.AppID,
+			&route.Description,
+			&route.Active,
+			&route.CreatedBy,
+			&route.CreatedAt,
+			&route.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan route: %w", err)
+		}
+		out = append(out, route)
+	}
+	return out, rows.Err()
+}
+
 // DeleteByAppID removes all routes associated with an app
 func (s *RouteStore) DeleteByAppID(ctx context.Context, appID string) error {
 	query := "DELETE FROM routes WHERE app_id = $1"

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -53,6 +53,12 @@ type ContainerServer struct {
 	coreServices         *CoreServices
 	daemonConfigStore    *app.DaemonConfigStore
 	peerPool             *PeerPool
+	// Route / Caddy cleanup deps (set by DualServer wiring, may be nil if
+	// the daemon was started without --app-hosting). Used by DeleteContainer
+	// to cascade-remove the routes / TLS-automation subjects a container
+	// owned, so deleting an LXC actually deletes the public hostname too.
+	routeStore           *app.RouteStore
+	proxyManager         *app.ProxyManager
 	// Guacamole integration for Windows VM RDP access
 	guacamoleClient      *guacamole.Client
 	guacamoleUser        string // Guacamole admin username
@@ -458,6 +464,16 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 		return nil, fmt.Errorf("failed to delete container: %w", err)
 	}
 
+	// Cascade-clean the routes + TLS subjects + host user that this
+	// container owned. The LXC is gone above; without these steps the
+	// public hostname returns 502 (Caddy route still points at a
+	// deleted upstream IP) and Caddy keeps trying to ACME-renew an
+	// orphaned cert. All best-effort: any single failure logs a
+	// warning but doesn't block the response — the LXC delete already
+	// succeeded, and partial-cascade is better than telling the caller
+	// "delete failed" when the container is in fact gone.
+	s.cascadeContainerCleanup(ctx, containerName, req.Username)
+
 	// Emit container deleted event
 	s.emitter.EmitContainerDeleted(containerName)
 
@@ -465,6 +481,61 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 		Message:       fmt.Sprintf("Container for user %s deleted successfully", req.Username),
 		ContainerName: containerName,
 	}, nil
+}
+
+// cascadeContainerCleanup removes the resources that DeleteContainer's
+// LXC-delete leaves behind. Documented as #69 / verified live against
+// the demo cluster on 2026-05-14.
+//
+// Order is deliberate:
+//   1. Route store first — kills the source of truth so RouteSyncJob
+//      will reap the Caddy srv0 route on its next tick (5s). Deleting
+//      directly from Caddy without this step lets the sync job
+//      resurrect the route within seconds, producing the 502-after-
+//      delete trap.
+//   2. TLS subject removal — stops Caddy's ACME renewal loop for the
+//      dead hostname. Harmless to keep (no upstream to challenge) but
+//      wastes rate-limit budget over time.
+//   3. Host user (jump-server account) — removes the Linux user, home,
+//      and the containarium-shell wrapper. sshpiper auto-reaps the
+//      user from its own config on the next keysync (2 min).
+//
+// On-disk Caddy cert at /data/caddy/certificates/... is intentionally
+// left in place — it's harmless after step 2 (no renewal attempts) and
+// avoids a "force" mode that the caller probably doesn't want.
+func (s *ContainerServer) cascadeContainerCleanup(ctx context.Context, containerName, username string) {
+	// 1. Route store: enumerate this container's routes and drop each.
+	//    Skip if routeStore was never wired (daemon without app-hosting).
+	if s.routeStore != nil {
+		routes, err := s.routeStore.ListByContainer(ctx, containerName)
+		if err != nil {
+			log.Printf("[delete-cascade] list routes for %s failed: %v", containerName, err)
+		}
+		for _, r := range routes {
+			if err := s.routeStore.Delete(ctx, r.FullDomain); err != nil {
+				log.Printf("[delete-cascade] delete route %s failed: %v", r.FullDomain, err)
+				continue
+			}
+			log.Printf("[delete-cascade] removed route %s (RouteSyncJob will reap Caddy entry)", r.FullDomain)
+
+			// 2. TLS subject: only if we also have a proxy manager.
+			if s.proxyManager != nil {
+				if err := s.proxyManager.RemoveTLSSubject(r.FullDomain); err != nil {
+					log.Printf("[delete-cascade] remove TLS subject %s failed: %v", r.FullDomain, err)
+				} else {
+					log.Printf("[delete-cascade] removed TLS automation subject %s", r.FullDomain)
+				}
+			}
+		}
+	}
+
+	// 3. Host user. DeleteJumpServerAccount is idempotent (no-op if the
+	//    user doesn't exist), so calling it when there isn't one is fine.
+	if err := container.DeleteJumpServerAccount(username, false); err != nil {
+		log.Printf("[delete-cascade] delete host user %s failed: %v (manual: sudo userdel -r %s)", username, err, username)
+	} else {
+		log.Printf("[delete-cascade] removed host user %s", username)
+	}
 }
 
 // StartContainer starts a stopped container
@@ -1087,6 +1158,15 @@ func extractAuthToken(ctx context.Context) string {
 // SetPeerPool sets the peer pool for multi-backend support
 func (s *ContainerServer) SetPeerPool(pool *PeerPool) {
 	s.peerPool = pool
+}
+
+// SetRouteCleanupDeps wires the route store + proxy manager so
+// DeleteContainer can cascade-clean a container's routes + TLS
+// subjects. Both may be nil if the daemon was started without
+// --app-hosting; the cascade will skip those steps gracefully.
+func (s *ContainerServer) SetRouteCleanupDeps(routeStore *app.RouteStore, proxyManager *app.ProxyManager) {
+	s.routeStore = routeStore
+	s.proxyManager = proxyManager
 }
 
 // SetCollaboratorManager sets the collaborator manager for handling collaborator operations

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -432,6 +432,10 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 					networkServer.routeStore = routeStore
 					networkServer.baseDomain = config.BaseDomain
 					log.Printf("Network service updated with app hosting features")
+
+					// ContainerServer also needs route store + proxy
+					// manager so DeleteContainer can cascade-clean.
+					containerServer.SetRouteCleanupDeps(routeStore, proxyManager)
 				}
 
 				// Update TrafficCollector with store for persistence


### PR DESCRIPTION
## Summary

`DeleteContainer` used to kill the LXC and stop. Everything else (PostgreSQL route store, Caddy srv0 route, Caddy TLS automation subjects, host-side Linux user) was orphaned, producing two distinct user-visible bugs:

1. **Public hostname returns 502 after delete.** Route store still has the row → RouteSyncJob re-installs the Caddy route on its 5-second tick → Caddy proxies to a dead upstream IP.
2. **Caddy keeps ACME-renewing dead certs.** Hostnames stay in `tls.automation.policies[].subjects` forever, burning Let's Encrypt rate-limit budget over time.

Plus the host user with its `containarium-shell` wrapper sticks around (mostly cosmetic, but a future create with the same username collides until manually cleaned).

Diagnosed and hand-cleaned twice during the demo recording yesterday — task #69 documents the six-step manual recipe that this PR automates.

## Change shape

- `RouteStore.ListByContainer` — enumerate routes for cascade fan-out
- `ProxyManager.RemoveTLSSubject(domain)` — idempotent strip from all policies
- `ContainerServer.SetRouteCleanupDeps(routeStore, proxyManager)` — DualServer-wired
- `ContainerServer.cascadeContainerCleanup()` — the orchestration, ordered route-store → TLS subject → host user. Route-store-first matters: deleting from Caddy directly without removing the store row lets RouteSyncJob resurrect the route within 5s, which is exactly the 502-after-delete trap.

All cascade steps are best-effort with `log.Printf("[delete-cascade] ... failed: ...")` warnings. The LXC delete already succeeded; partial-cascade is better than telling the caller "delete failed."

## Test plan

- [x] `go test ./internal/app/ ./internal/server/ -count=1` green, including 3 new tests for `RemoveTLSSubject` (strips from all policies, no-op when absent, handles null config)
- [x] `go build ./...` green
- [ ] After merge + release: delete the helloworld container via REST API, confirm `/v1/network/routes` doesn't list it, `getent passwd helloworld` returns nothing, and `curl https://helloworld.demo.containarium.dev/` returns HTTP 000 (TLS handshake fails — correct "doesn't exist") within ~10 seconds

Closes #69.