### PR TITLE
fix(server): implement AddSSHKey / RemoveSSHKey RPCs

### DIFF
--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -786,7 +786,20 @@ func (s *ContainerServer) ListStacks(ctx context.Context, req *pb.ListStacksRequ
 	return &pb.ListStacksResponse{Stacks: out}, nil
 }
 
-// AddSSHKey adds an SSH key to a container
+// AddSSHKey appends an SSH public key to the user's host-side
+// authorized_keys file (/home/<username>/.ssh/authorized_keys).
+//
+// Scope note: this writes the host-side file, not the LXC-internal
+// one. That's the file sshpiper's keysync (running on the sentinel)
+// reads from via /authorized-keys to authenticate inbound SSH. Adding
+// only inside the LXC would not let anyone SSH in via the sentinel.
+//
+// The intended use case is recovery after a lost ephemeral key: an
+// agent or operator generates a fresh keypair locally, calls this RPC
+// with the public half, and within ~2 minutes (next sentinel keysync
+// tick) the new key is live for SSH access.
+//
+// Idempotent — a key already present is a no-op success.
 func (s *ContainerServer) AddSSHKey(ctx context.Context, req *pb.AddSSHKeyRequest) (*pb.AddSSHKeyResponse, error) {
 	if req.Username == "" {
 		return nil, fmt.Errorf("username is required")
@@ -795,11 +808,26 @@ func (s *ContainerServer) AddSSHKey(ctx context.Context, req *pb.AddSSHKeyReques
 		return nil, fmt.Errorf("ssh_public_key is required")
 	}
 
-	// TODO: Implement SSH key management
-	return nil, fmt.Errorf("not implemented yet")
+	if err := container.AddAuthorizedKey(req.Username, req.SshPublicKey); err != nil {
+		return nil, fmt.Errorf("add authorized key: %w", err)
+	}
+
+	total, err := container.CountAuthorizedKeys(req.Username)
+	if err != nil {
+		// Counting failed but the add succeeded — return success with
+		// zero so the caller still knows the add went through.
+		log.Printf("[add-ssh-key] count after add failed for %s: %v", req.Username, err)
+		total = 0
+	}
+
+	return &pb.AddSSHKeyResponse{
+		Message:   fmt.Sprintf("SSH key added for %s (sentinel keysync will propagate within ~2m)", req.Username),
+		TotalKeys: total,
+	}, nil
 }
 
-// RemoveSSHKey removes an SSH key from a container
+// RemoveSSHKey removes a specific SSH public key from the user's
+// host-side authorized_keys file. No-op if the key isn't present.
 func (s *ContainerServer) RemoveSSHKey(ctx context.Context, req *pb.RemoveSSHKeyRequest) (*pb.RemoveSSHKeyResponse, error) {
 	if req.Username == "" {
 		return nil, fmt.Errorf("username is required")
@@ -808,8 +836,20 @@ func (s *ContainerServer) RemoveSSHKey(ctx context.Context, req *pb.RemoveSSHKey
 		return nil, fmt.Errorf("ssh_public_key is required")
 	}
 
-	// TODO: Implement SSH key management
-	return nil, fmt.Errorf("not implemented yet")
+	if err := container.RemoveAuthorizedKey(req.Username, req.SshPublicKey); err != nil {
+		return nil, fmt.Errorf("remove authorized key: %w", err)
+	}
+
+	total, err := container.CountAuthorizedKeys(req.Username)
+	if err != nil {
+		log.Printf("[remove-ssh-key] count after remove failed for %s: %v", req.Username, err)
+		total = 0
+	}
+
+	return &pb.RemoveSSHKeyResponse{
+		Message:   fmt.Sprintf("SSH key removed for %s", req.Username),
+		TotalKeys: total,
+	}, nil
 }
 
 // GetMetrics gets runtime metrics for containers

--- a/pkg/core/container/authorized_keys_test.go
+++ b/pkg/core/container/authorized_keys_test.go
@@ -1,0 +1,197 @@
+package container
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// withTestHomeRoot overrides the package's home root + user-exists check
+// for a single test. Restores the originals via t.Cleanup so tests run
+// in any order without bleeding state.
+func withTestHomeRoot(t *testing.T, homeRoot string, userExistsFn func(string) bool) {
+	t.Helper()
+	origHome := authorizedKeysHomeRoot
+	origExists := authorizedKeysUserExists
+	authorizedKeysHomeRoot = homeRoot
+	authorizedKeysUserExists = userExistsFn
+	t.Cleanup(func() {
+		authorizedKeysHomeRoot = origHome
+		authorizedKeysUserExists = origExists
+	})
+}
+
+const validTestKey1 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBZkMdKTk8EXlTr5tlsIfAvlCi2iCl0YB/YDua3uMyDX test1"
+const validTestKey2 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDtmr5hyCwDmlxelT+dTGxmh8SpOObOWJIhoRa61oY2Q test2"
+
+func TestAddAuthorizedKey_CreatesDirAndFile(t *testing.T) {
+	tmp := t.TempDir()
+	withTestHomeRoot(t, tmp, func(string) bool { return true })
+
+	if err := AddAuthorizedKey("alice", validTestKey1); err != nil {
+		t.Fatalf("AddAuthorizedKey: %v", err)
+	}
+
+	akPath := filepath.Join(tmp, "alice", ".ssh", "authorized_keys")
+	content, err := os.ReadFile(akPath)
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if !strings.Contains(string(content), validTestKey1) {
+		t.Errorf("file missing the key:\n%s", content)
+	}
+	if !strings.HasSuffix(string(content), "\n") {
+		t.Errorf("file doesn't end in newline (sshd may reject)")
+	}
+
+	if runtime.GOOS != "windows" {
+		st, _ := os.Stat(akPath)
+		if mode := st.Mode().Perm(); mode != 0o600 {
+			t.Errorf("authorized_keys mode = %o, want 0600", mode)
+		}
+		stDir, _ := os.Stat(filepath.Dir(akPath))
+		if mode := stDir.Mode().Perm(); mode != 0o700 {
+			t.Errorf(".ssh dir mode = %o, want 0700", mode)
+		}
+	}
+}
+
+func TestAddAuthorizedKey_AppendsToExisting(t *testing.T) {
+	tmp := t.TempDir()
+	withTestHomeRoot(t, tmp, func(string) bool { return true })
+
+	if err := AddAuthorizedKey("bob", validTestKey1); err != nil {
+		t.Fatalf("add 1: %v", err)
+	}
+	if err := AddAuthorizedKey("bob", validTestKey2); err != nil {
+		t.Fatalf("add 2: %v", err)
+	}
+
+	content, _ := os.ReadFile(filepath.Join(tmp, "bob", ".ssh", "authorized_keys"))
+	if !strings.Contains(string(content), validTestKey1) {
+		t.Errorf("first key missing after second add")
+	}
+	if !strings.Contains(string(content), validTestKey2) {
+		t.Errorf("second key missing")
+	}
+	// Two lines + trailing newline.
+	nonEmpty := 0
+	for _, line := range strings.Split(string(content), "\n") {
+		if strings.TrimSpace(line) != "" {
+			nonEmpty++
+		}
+	}
+	if nonEmpty != 2 {
+		t.Errorf("expected 2 lines after two adds, got %d:\n%s", nonEmpty, content)
+	}
+}
+
+func TestAddAuthorizedKey_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	withTestHomeRoot(t, tmp, func(string) bool { return true })
+
+	if err := AddAuthorizedKey("carol", validTestKey1); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	// Same key again — no error, no duplicate.
+	if err := AddAuthorizedKey("carol", validTestKey1); err != nil {
+		t.Fatalf("second (idempotent): %v", err)
+	}
+
+	content, _ := os.ReadFile(filepath.Join(tmp, "carol", ".ssh", "authorized_keys"))
+	count := strings.Count(string(content), validTestKey1)
+	if count != 1 {
+		t.Errorf("expected key once after double-add, got %d times", count)
+	}
+}
+
+func TestAddAuthorizedKey_RejectsBadKey(t *testing.T) {
+	tmp := t.TempDir()
+	withTestHomeRoot(t, tmp, func(string) bool { return true })
+
+	if err := AddAuthorizedKey("dave", "not a real ssh key"); err == nil {
+		t.Errorf("expected error for invalid key, got nil")
+	}
+}
+
+func TestAddAuthorizedKey_RejectsUnknownUser(t *testing.T) {
+	tmp := t.TempDir()
+	withTestHomeRoot(t, tmp, func(string) bool { return false }) // user doesn't exist
+
+	err := AddAuthorizedKey("eve", validTestKey1)
+	if err == nil {
+		t.Fatal("expected error for nonexistent user, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error %q should mention nonexistence", err)
+	}
+}
+
+func TestRemoveAuthorizedKey_StripsAndPreservesOthers(t *testing.T) {
+	tmp := t.TempDir()
+	withTestHomeRoot(t, tmp, func(string) bool { return true })
+
+	if err := AddAuthorizedKey("frank", validTestKey1); err != nil {
+		t.Fatalf("add 1: %v", err)
+	}
+	if err := AddAuthorizedKey("frank", validTestKey2); err != nil {
+		t.Fatalf("add 2: %v", err)
+	}
+
+	if err := RemoveAuthorizedKey("frank", validTestKey1); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	content, _ := os.ReadFile(filepath.Join(tmp, "frank", ".ssh", "authorized_keys"))
+	if strings.Contains(string(content), validTestKey1) {
+		t.Errorf("removed key still present:\n%s", content)
+	}
+	if !strings.Contains(string(content), validTestKey2) {
+		t.Errorf("other key got removed too:\n%s", content)
+	}
+}
+
+func TestRemoveAuthorizedKey_NoOpWhenAbsent(t *testing.T) {
+	tmp := t.TempDir()
+	withTestHomeRoot(t, tmp, func(string) bool { return true })
+
+	if err := AddAuthorizedKey("greta", validTestKey1); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	// Remove a key that was never added — should succeed silently.
+	if err := RemoveAuthorizedKey("greta", validTestKey2); err != nil {
+		t.Errorf("removing non-present key should not error, got: %v", err)
+	}
+	// And the existing key must remain.
+	content, _ := os.ReadFile(filepath.Join(tmp, "greta", ".ssh", "authorized_keys"))
+	if !strings.Contains(string(content), validTestKey1) {
+		t.Errorf("existing key disappeared after no-op remove")
+	}
+}
+
+func TestCountAuthorizedKeys(t *testing.T) {
+	tmp := t.TempDir()
+	withTestHomeRoot(t, tmp, func(string) bool { return true })
+
+	// No file yet.
+	if n, err := CountAuthorizedKeys("henry"); err != nil || n != 0 {
+		t.Errorf("expected 0/nil for missing file, got %d / %v", n, err)
+	}
+
+	_ = AddAuthorizedKey("henry", validTestKey1)
+	if n, _ := CountAuthorizedKeys("henry"); n != 1 {
+		t.Errorf("expected 1 after add, got %d", n)
+	}
+
+	_ = AddAuthorizedKey("henry", validTestKey2)
+	if n, _ := CountAuthorizedKeys("henry"); n != 2 {
+		t.Errorf("expected 2 after second add, got %d", n)
+	}
+
+	_ = RemoveAuthorizedKey("henry", validTestKey1)
+	if n, _ := CountAuthorizedKeys("henry"); n != 1 {
+		t.Errorf("expected 1 after remove, got %d", n)
+	}
+}

--- a/pkg/core/container/jump_server.go
+++ b/pkg/core/container/jump_server.go
@@ -923,3 +923,201 @@ func disableGuestAgentAccountsDaemon(configPath string, _ bool) error {
 
 	return nil
 }
+
+// authorizedKeysHomeRoot is the host's home-directory root. Overridable
+// in tests so the authorized_keys helpers don't touch the real /home.
+// Production callers should never set this — they want /home.
+var authorizedKeysHomeRoot = "/home"
+
+// authorizedKeysUserExists wraps userExists so tests can opt out of the
+// "is this username a real host user?" check (test-side users don't
+// exist in the OS's passwd database). Production stays bound to
+// userExists — invalid usernames should be rejected.
+var authorizedKeysUserExists = userExists
+
+// AddAuthorizedKey appends a single SSH public key to the host-side
+// /home/<username>/.ssh/authorized_keys, creating the directory + file
+// with correct ownership and 0600 mode if missing. Idempotent —
+// returns nil without changes if the exact key is already present.
+//
+// Scope note: this writes the HOST-side keys file (consumed by the
+// sentinel's sshpiper keysync via /authorized-keys), not the
+// container-internal authorized_keys. For the demo / prod sshpiper
+// architecture, that's the right scope — sshpiper terminates the
+// client SSH session at the sentinel using these keys, then opens a
+// downstream connection to the backend host using its own upstream
+// key. Adding to the container-internal file would have no effect on
+// who can SSH in via sshpiper.
+func AddAuthorizedKey(username, pubKey string) error {
+	if !isValidUsername(username) {
+		return fmt.Errorf("invalid username: %s", username)
+	}
+	pubKey = strings.TrimSpace(pubKey)
+	if pubKey == "" {
+		return fmt.Errorf("empty public key")
+	}
+	if err := ValidateSSHPublicKey(pubKey); err != nil {
+		return fmt.Errorf("invalid public key: %w", err)
+	}
+	if !authorizedKeysUserExists(username) {
+		return fmt.Errorf("host user %q does not exist (was the container created?)", username)
+	}
+
+	sshDir := filepath.Join(authorizedKeysHomeRoot, username, ".ssh")
+	akPath := filepath.Join(sshDir, "authorized_keys")
+
+	// Ensure .ssh exists with 0700.
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", sshDir, err)
+	}
+
+	// Read existing content (file may not exist yet).
+	var existing []byte
+	if b, err := os.ReadFile(akPath); err == nil {
+		existing = b
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", akPath, err)
+	}
+
+	// Idempotency: skip if exact key is already a line.
+	for _, line := range strings.Split(string(existing), "\n") {
+		if strings.TrimSpace(line) == pubKey {
+			return nil
+		}
+	}
+
+	// Append + ensure trailing newline.
+	var buf strings.Builder
+	buf.Write(existing)
+	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		buf.WriteString("\n")
+	}
+	buf.WriteString(pubKey)
+	buf.WriteString("\n")
+
+	// Atomic write: temp file in same dir + rename.
+	tmp, err := os.CreateTemp(sshDir, ".authorized_keys.tmp.*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod tmp: %w", err)
+	}
+	if _, err := tmp.WriteString(buf.String()); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, akPath); err != nil {
+		return fmt.Errorf("rename tmp -> %s: %w", akPath, err)
+	}
+
+	// Best-effort chown so sshd reads the file as the user (it normally
+	// does, but if we created the file as root, the ownership matters
+	// for some configurations). Errors are non-fatal — sshd reads as
+	// root and the mode is 0600, so the worst case is a slightly
+	// surprising owner the operator may want to fix manually.
+	_ = exec.Command("chown", "-R", username+":"+username, sshDir).Run()
+
+	return nil
+}
+
+// RemoveAuthorizedKey strips a single SSH public key from the host-side
+// /home/<username>/.ssh/authorized_keys. No-op (returns nil) if the
+// key isn't there. Pairs with AddAuthorizedKey for the
+// container-server's add/remove RPCs.
+func RemoveAuthorizedKey(username, pubKey string) error {
+	if !isValidUsername(username) {
+		return fmt.Errorf("invalid username: %s", username)
+	}
+	pubKey = strings.TrimSpace(pubKey)
+	if pubKey == "" {
+		return fmt.Errorf("empty public key")
+	}
+	if !authorizedKeysUserExists(username) {
+		return fmt.Errorf("host user %q does not exist", username)
+	}
+
+	akPath := filepath.Join(authorizedKeysHomeRoot, username, ".ssh", "authorized_keys")
+	existing, err := os.ReadFile(akPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", akPath, err)
+	}
+
+	var out strings.Builder
+	changed := false
+	for _, line := range strings.Split(string(existing), "\n") {
+		if strings.TrimSpace(line) == pubKey {
+			changed = true
+			continue
+		}
+		out.WriteString(line)
+		out.WriteString("\n")
+	}
+	if !changed {
+		return nil
+	}
+
+	// Trim the extra trailing newline our reconstruction adds when the
+	// input had no terminating newline. Easier than tracking it.
+	result := strings.TrimRight(out.String(), "\n") + "\n"
+	if strings.TrimSpace(result) == "" {
+		result = ""
+	}
+
+	sshDir := filepath.Dir(akPath)
+	tmp, err := os.CreateTemp(sshDir, ".authorized_keys.tmp.*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod tmp: %w", err)
+	}
+	if _, err := tmp.WriteString(result); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, akPath); err != nil {
+		return fmt.Errorf("rename tmp -> %s: %w", akPath, err)
+	}
+	return nil
+}
+
+// CountAuthorizedKeys returns how many non-empty lines are in the
+// host-side authorized_keys file for the user. Used by AddSSHKeyResponse
+// so the caller can show "you now have N keys" feedback.
+func CountAuthorizedKeys(username string) (int32, error) {
+	if !isValidUsername(username) {
+		return 0, fmt.Errorf("invalid username: %s", username)
+	}
+	akPath := filepath.Join(authorizedKeysHomeRoot, username, ".ssh", "authorized_keys")
+	b, err := os.ReadFile(akPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("read %s: %w", akPath, err)
+	}
+	n := int32(0)
+	for _, line := range strings.Split(string(b), "\n") {
+		if strings.TrimSpace(line) != "" {
+			n++
+		}
+	}
+	return n, nil
+}


### PR DESCRIPTION
## Summary

The proto declares `POST /v1/containers/{username}/ssh-keys` and `DELETE /v1/containers/{username}/ssh-keys/{ssh_public_key}` — both routed to `ContainerServer.AddSSHKey` / `RemoveSSHKey` — but the implementations were stubs returning `not implemented yet` (500).

Discovered during demo recording on 2026-05-14 when an ephemeral key was lost. The intended recovery path (generate new keypair locally → POST the pub half → save private → ssh in) couldn't actually be used; we ended up doing host-level `userdel`/`useradd`/`authorized_keys` edits via gcloud ssh and waited 2 minutes for sentinel keysync.

## Change

New helpers in `pkg/core/container/jump_server.go`:
- `AddAuthorizedKey(username, pubkey)` — host-side append, 0600 mode, atomic temp+rename. Idempotent.
- `RemoveAuthorizedKey(username, pubkey)` — symmetric strip. No-op when absent.
- `CountAuthorizedKeys(username)` — used for `TotalKeys` in responses.

Wire `ContainerServer.AddSSHKey` and `RemoveSSHKey` through to those.

Scope: deliberately the **host-side** `authorized_keys` file (which the sentinel's sshpiper keysync reads from via `/authorized-keys`), not the LXC-internal one. SSH terminates at the sentinel — the container-internal `authorized_keys` is never the auth target in this architecture.

## Test plan

- [x] 8 new tests in `pkg/core/container/authorized_keys_test.go`, all green
- [x] `go test ./internal/server/ ./pkg/core/container/ -count=1` green
- [x] `go build ./...` green
- [ ] After merge + release: live test against demo backend — `POST /v1/containers/admin/ssh-keys` should append, `DELETE /v1/containers/admin/ssh-keys/<urlencoded-key>` should remove, both return updated `TotalKeys`

Closes #67.