### PR TITLE
feat(mcp): CONTAINARIUM_JWT_TOKEN_FILE for restart-free token rotation

### DIFF
--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -21,9 +21,9 @@ func main() {
 		printUsage()
 		log.Fatal("CONTAINARIUM_SERVER_URL environment variable is required")
 	}
-	if config.JWTToken == "" {
+	if config.JWTToken == "" && config.JWTTokenFile == "" {
 		printUsage()
-		log.Fatal("CONTAINARIUM_JWT_TOKEN environment variable is required")
+		log.Fatal("either CONTAINARIUM_JWT_TOKEN or CONTAINARIUM_JWT_TOKEN_FILE environment variable is required")
 	}
 
 	// Create MCP server with protobuf-defined contracts
@@ -50,11 +50,15 @@ func printUsage() {
 	log.Println("=== Containarium MCP Server Configuration ===")
 	log.Println("")
 	log.Println("Required environment variables:")
-	log.Println("  CONTAINARIUM_SERVER_URL - URL of the Containarium REST API (e.g., http://localhost:8080)")
-	log.Println("  CONTAINARIUM_JWT_TOKEN  - JWT token for authentication")
+	log.Println("  CONTAINARIUM_SERVER_URL      - URL of the Containarium REST API (e.g., http://localhost:8080)")
+	log.Println("  CONTAINARIUM_JWT_TOKEN       - JWT token for authentication  (use one or the other)")
+	log.Println("  CONTAINARIUM_JWT_TOKEN_FILE  - Path to a file with the JWT — re-read on every request,")
+	log.Println("                                 so rotating the token is `mv newtoken oldpath`. Prefer this")
+	log.Println("                                 for long-running MCP processes that need to survive rotation.")
 	log.Println("")
 	log.Println("Optional environment variables:")
-	log.Println("  CONTAINARIUM_DEBUG      - Enable debug logging (true/false)")
+	log.Println("  CONTAINARIUM_DEBUG           - Enable debug logging (true/false)")
+	log.Println("  CONTAINARIUM_SENTINEL_HOST   - Public SSH endpoint, shown in create_container responses")
 	log.Println("")
 	log.Println("Example usage:")
 	log.Println("  export CONTAINARIUM_SERVER_URL='http://localhost:8080'")

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
@@ -14,8 +15,19 @@ import (
 // of non-HTTP deployment metadata (SentinelHost) so tool handlers that
 // need it can read it without a separate config plumbing layer.
 type Client struct {
-	baseURL    string
-	jwtToken   string
+	baseURL string
+
+	// jwtToken is the static token used when jwtTokenFile is empty.
+	// Captured at NewClient time; doesn't survive operator-side
+	// rotation without an MCP restart.
+	jwtToken string
+
+	// jwtTokenFile, when set, is the path the client reads the JWT
+	// from on every request. Operators rotating the token can just
+	// overwrite the file in place — the next call picks up the new
+	// content. Empty falls back to jwtToken.
+	jwtTokenFile string
+
 	httpClient *http.Client
 
 	// SentinelHost, when set, is the public SSH endpoint for this
@@ -37,6 +49,34 @@ func NewClient(baseURL, jwtToken string) *Client {
 	}
 }
 
+// SetTokenFile switches the client to file-based token mode: every
+// request re-reads `path` to get the current JWT. Empty disables
+// file mode and falls back to the static jwtToken captured at
+// NewClient time. Used by the MCP server when the operator set
+// CONTAINARIUM_JWT_TOKEN_FILE.
+func (c *Client) SetTokenFile(path string) {
+	c.jwtTokenFile = path
+}
+
+// readToken returns the JWT to use for the next request. When a
+// tokenFile is configured, reads it fresh from disk (whitespace
+// trimmed) on every call so token rotation works without a restart.
+// Otherwise returns the static token captured at construction.
+func (c *Client) readToken() (string, error) {
+	if c.jwtTokenFile == "" {
+		return c.jwtToken, nil
+	}
+	b, err := os.ReadFile(c.jwtTokenFile)
+	if err != nil {
+		return "", fmt.Errorf("read JWT from %s: %w", c.jwtTokenFile, err)
+	}
+	token := strings.TrimSpace(string(b))
+	if token == "" {
+		return "", fmt.Errorf("JWT file %s is empty", c.jwtTokenFile)
+	}
+	return token, nil
+}
+
 // doRequest performs an HTTP request with JWT authentication
 func (c *Client) doRequest(method, path string, body interface{}) ([]byte, error) {
 	url := c.baseURL + path
@@ -55,8 +95,13 @@ func (c *Client) doRequest(method, path string, body interface{}) ([]byte, error
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// Add JWT token
-	req.Header.Set("Authorization", "Bearer "+c.jwtToken)
+	// Add JWT token. readToken() may re-read from disk if a token file
+	// was configured — that's the file-rotation-without-restart path.
+	token, err := c.readToken()
+	if err != nil {
+		return nil, fmt.Errorf("authenticate: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -11,8 +11,19 @@ type Config struct {
 	// Example: http://localhost:8080 or https://containarium.example.com
 	ServerURL string
 
-	// JWTToken is the JWT token for authentication
+	// JWTToken is the JWT token for authentication. Either this or
+	// JWTTokenFile must be set. JWTToken is captured once at MCP
+	// server start; it can't reflect a rotation without a restart.
+	// For long-running MCP processes that need to survive token
+	// rotation, prefer JWTTokenFile.
 	JWTToken string
+
+	// JWTTokenFile, when set, points to a file containing the JWT
+	// token. The file is re-read on every request to the Containarium
+	// API, so rotating the token is a single `mv newtoken oldpath`
+	// step — no MCP restart needed. Empty means use JWTToken instead.
+	// Whitespace around the token in the file is trimmed.
+	JWTTokenFile string
 
 	// SentinelHost is the public SSH endpoint for the deployment.
 	// When set, create_container's response includes a ready-to-paste
@@ -36,6 +47,7 @@ func LoadConfig() *Config {
 	return &Config{
 		ServerURL:    os.Getenv("CONTAINARIUM_SERVER_URL"),
 		JWTToken:     os.Getenv("CONTAINARIUM_JWT_TOKEN"),
+		JWTTokenFile: os.Getenv("CONTAINARIUM_JWT_TOKEN_FILE"),
 		SentinelHost: os.Getenv("CONTAINARIUM_SENTINEL_HOST"),
 		Debug:        debug,
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -20,6 +20,9 @@ type Server struct {
 // NewServer creates a new MCP server
 func NewServer(config *Config) (*Server, error) {
 	client := NewClient(config.ServerURL, config.JWTToken)
+	if config.JWTTokenFile != "" {
+		client.SetTokenFile(config.JWTTokenFile)
+	}
 	client.SentinelHost = config.SentinelHost
 
 	server := &Server{

--- a/internal/mcp/token_file_test.go
+++ b/internal/mcp/token_file_test.go
@@ -1,0 +1,139 @@
+package mcp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestClient_TokenFile_ReadAtRequestTime is the headline behavior of
+// the CONTAINARIUM_JWT_TOKEN_FILE feature: rewriting the file is
+// enough to start using a new token, no Client / MCP-server restart.
+func TestClient_TokenFile_ReadAtRequestTime(t *testing.T) {
+	tmp := t.TempDir()
+	tokenPath := filepath.Join(tmp, "jwt")
+	if err := os.WriteFile(tokenPath, []byte("token-A"), 0o600); err != nil {
+		t.Fatalf("write initial: %v", err)
+	}
+
+	var seenTokens []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		seenTokens = append(seenTokens, strings.TrimPrefix(auth, "Bearer "))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "ignored-static-token")
+	c.SetTokenFile(tokenPath)
+
+	// First request: server should see token-A.
+	if _, err := c.doRequest("GET", "/anything", nil); err != nil {
+		t.Fatalf("first req: %v", err)
+	}
+
+	// Rotate: overwrite the file (no Client recreated, no restart).
+	if err := os.WriteFile(tokenPath, []byte("token-B\n"), 0o600); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+
+	// Second request: server should see token-B with whitespace trimmed.
+	if _, err := c.doRequest("GET", "/anything", nil); err != nil {
+		t.Fatalf("second req: %v", err)
+	}
+
+	if len(seenTokens) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(seenTokens))
+	}
+	if seenTokens[0] != "token-A" {
+		t.Errorf("first req token = %q, want %q", seenTokens[0], "token-A")
+	}
+	if seenTokens[1] != "token-B" {
+		t.Errorf("second req token = %q, want %q (file rotation didn't take effect)", seenTokens[1], "token-B")
+	}
+}
+
+// TestClient_NoTokenFile_UsesStaticToken confirms the file path is
+// strictly opt-in. With no file configured, the static token captured
+// at NewClient time is used.
+func TestClient_NoTokenFile_UsesStaticToken(t *testing.T) {
+	var seen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "static-only")
+	if _, err := c.doRequest("GET", "/x", nil); err != nil {
+		t.Fatalf("req: %v", err)
+	}
+	if seen != "static-only" {
+		t.Errorf("seen = %q, want %q", seen, "static-only")
+	}
+}
+
+// TestClient_TokenFile_MissingFile_PropagatesError ensures a deleted /
+// unreadable token file surfaces as an actionable error to the caller,
+// not a silent empty token sent to the server.
+func TestClient_TokenFile_MissingFile_PropagatesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Should never be hit — readToken should fail first.
+		t.Error("server should not have been reached when token file is missing")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "")
+	c.SetTokenFile(filepath.Join(t.TempDir(), "nonexistent"))
+
+	_, err := c.doRequest("GET", "/x", nil)
+	if err == nil {
+		t.Fatal("expected error when token file is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "JWT") {
+		t.Errorf("error should mention JWT/token, got: %v", err)
+	}
+}
+
+// TestClient_TokenFile_EmptyFile_PropagatesError covers the case
+// where a rotation truncates the file but doesn't write the new
+// token yet. Sending an empty Bearer token to the server would
+// surface as a generic 401; an explicit pre-flight error is more
+// useful to the operator.
+func TestClient_TokenFile_EmptyFile_PropagatesError(t *testing.T) {
+	tmp := t.TempDir()
+	tokenPath := filepath.Join(tmp, "empty")
+	if err := os.WriteFile(tokenPath, []byte("   \n  \n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	c := NewClient("http://unreachable.invalid", "")
+	c.SetTokenFile(tokenPath)
+
+	_, err := c.doRequest("GET", "/x", nil)
+	if err == nil {
+		t.Fatal("expected error on empty/whitespace-only token file, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention emptiness, got: %v", err)
+	}
+}
+
+// TestLoadConfig_TokenFile_ReadFromEnv verifies the env-var wiring.
+// (LoadConfig is a thin wrapper over os.Getenv but it's the surface
+// the operator actually configures, so it's worth a regression test.)
+func TestLoadConfig_TokenFile_ReadFromEnv(t *testing.T) {
+	t.Setenv("CONTAINARIUM_SERVER_URL", "http://x")
+	t.Setenv("CONTAINARIUM_JWT_TOKEN_FILE", "/some/path/to/token")
+	t.Setenv("CONTAINARIUM_JWT_TOKEN", "")
+	c := LoadConfig()
+	if c.JWTTokenFile != "/some/path/to/token" {
+		t.Errorf("JWTTokenFile = %q, want %q", c.JWTTokenFile, "/some/path/to/token")
+	}
+}


### PR DESCRIPTION
## Summary

Adds an alternative to `CONTAINARIUM_JWT_TOKEN` (static, captured at start): `CONTAINARIUM_JWT_TOKEN_FILE` points to a file the Client re-reads on every API request. Rotating the token is `mv newtoken oldpath` — the MCP server picks up the new value on the next call, no restart needed.

Long-running MCP processes (Claude Code, Cursor, etc.) typically outlive a token's 30-day lifetime. Without this, every rotation forces an MCP-client restart.

## Change

- `Config.JWTTokenFile` + `LoadConfig()` reads `CONTAINARIUM_JWT_TOKEN_FILE`
- `Client.SetTokenFile(path)` / `Client.readToken()` — file mode trims whitespace and errors on empty file (vs. sending empty Bearer + getting an opaque 401)
- `main.go`: accept either env var; require at least one
- Usage banner updated

## Test plan

- [x] 5 new tests in `internal/mcp/token_file_test.go`:
  - file is re-read between requests (rotation works)
  - no file → static token still used
  - missing file → pre-flight error, server never reached
  - empty/whitespace-only file → pre-flight error
  - `LoadConfig` wires the env var correctly
- [x] `go test ./internal/mcp/ -count=1` green

Closes #61.