### PR TITLE
fix(traffic): skip conntrack UPDATE events to stop channel saturation

### DIFF
--- a/internal/traffic/conntrack_linux.go
+++ b/internal/traffic/conntrack_linux.go
@@ -46,12 +46,30 @@ func NewConntrackMonitor() (ConntrackMonitor, error) {
 	return m, nil
 }
 
-// listen subscribes to conntrack events via netlink
+// listen subscribes to conntrack events via netlink.
+//
+// We deliberately skip GroupCTUpdate. The kernel emits UPDATE events
+// for every accounting tick (~1Hz per active connection) and every TCP
+// state transition (SYN → ESTABLISHED → CLOSE_WAIT → ...), so a single
+// long-lived connection can generate tens to hundreds of events. On a
+// lab box with low flow count we still saw the 8192-buffered event
+// channel saturate from update floods alone — verified during the
+// daemon-on-lab investigation on 2026-05-13 (#63).
+//
+// The downstream collector only really needs to know "connection
+// started" (to attribute it to a container) and "connection ended"
+// (to capture final byte counts for accounting). Interim byte counts
+// for active connections are available via Snapshot() on demand.
+// Skipping UPDATE drops the event volume by ~100x in typical
+// workloads without losing observability.
 func (m *LinuxConntrackMonitor) listen() {
 	evCh := make(chan conntrack.Event, 8192)
 
-	// Subscribe to NEW, UPDATE, DESTROY events using netfilter.GroupsCT
-	errCh, err := m.conn.Listen(evCh, 1, netfilter.GroupsCT)
+	groups := []netfilter.NetlinkGroup{
+		netfilter.GroupCTNew,
+		netfilter.GroupCTDestroy,
+	}
+	errCh, err := m.conn.Listen(evCh, 1, groups)
 	if err != nil {
 		log.Printf("Failed to listen to conntrack events: %v", err)
 		return


### PR DESCRIPTION
## Summary

The conntrack monitor subscribed to NEW + UPDATE + DESTROY via `netfilter.GroupsCT`. UPDATE events arrive ~1Hz per active connection (accounting ticks) plus every TCP state transition, so even tens of connections produce thousands of events per second — enough to saturate the 8192-buffered channel within seconds. Observed on the lab box during the on-site investigation that filed #63, where flow count was <20 but the channel was full.

## Change

Subscribe to `GroupCTNew + GroupCTDestroy` only.

Why this is safe: the downstream collector (`Collector.processConntrackEvent`) only uses the event stream for "connection started" and "connection ended" signals. Interim byte counts for active connections come from `Snapshot()` on demand. The final byte counters land in the kernel's DESTROY notification (already captured by `processEvent`'s counter branch).

Expected reduction: ~100x event volume drop in typical workloads, no observability loss.

## Test plan

- [x] `GOOS=linux GOARCH=amd64 go build ./internal/traffic/` green
- [ ] After merge + redeploy on lab: confirm `journalctl -u containarium` no longer logs "conntrack event channel full, dropping events"

Closes #63.