### PR TITLE
feat(install): pool-level ZFS native encryption (operator-managed keyfile)

### DIFF
--- a/docs/SECURITY-ENCRYPTION-AT-REST.md
+++ b/docs/SECURITY-ENCRYPTION-AT-REST.md
@@ -26,10 +26,11 @@ container data itself — protection comes from the underlying disk layer
   physical disks. If the operator did not configure LUKS, dm-crypt,
   or ZFS native encryption on the underlying storage themselves, the
   data is plaintext on disk. See "Self-hoster options" below.
-- **ZFS pool on the backend** (`incus-pool/containers/...`). The pool
-  is created without `encryption=on`. All container datasets are
-  plaintext at the ZFS layer; only the underlying disk encryption
-  protects them.
+- **ZFS pool on the backend** (`incus-pool/containers/...`) — by
+  default. The pool is created without `encryption=on` unless the
+  operator opts in by setting `zfs_encryption_keyfile` (terraform)
+  or `--zfs-encryption-keyfile` (bare-metal). See "Self-hoster
+  options" below for the opt-in path.
 - **Container memory, swap, and tmpfs** — at-rest encryption protects
   cold disk; live memory and swap are not in scope here. Standard
   Linux memory hardening (kernel ASLR, etc.) applies.
@@ -97,22 +98,82 @@ If you're self-hosting and want per-container encryption today, see
 ## Self-hoster options
 
 If you run Containarium on bare-metal or want stronger isolation than
-the GCP default, the OSS code paths don't get in your way — these are
-operator concerns, configured outside Containarium:
+the GCP default, the OSS install scripts now have first-class
+support for ZFS native encryption on the data pool. Other layers
+remain operator concerns:
 
 - **LUKS / dm-crypt** on the data disk before ZFS is created on top.
   Standard Linux distro tooling; Containarium doesn't care about the
   layer beneath the ZFS pool.
-- **ZFS native encryption** on the pool: create the pool with
-  `zpool create incus-pool -O encryption=on -O keyformat=passphrase ...`
-  and load the key at boot. The daemon expects the pool to be mounted
-  and writable by the time it starts; key custody is your problem.
+- **ZFS native encryption** on the pool — supported by the install
+  scripts via a keyfile flag (see next section).
 - **Hardware encryption** (TCG Opal SEDs, BitLocker on Windows) —
   transparent to Containarium.
 
-None of these are documented in the install scripts because they're
-operator policy, not platform feature. The platform does not assume
-any particular at-rest encryption layer.
+### Pool-level ZFS native encryption (operator-managed keyfile)
+
+Both install paths accept an opt-in flag that creates the `incus-pool`
+(GCE) or `incus-local` (bare-metal) data pool with `encryption=on`,
+`keyformat=raw`, and `keylocation=file://<path>`. Every container
+dataset inherits encryption from the parent pool. The daemon doesn't
+need to know — the kernel decrypts transparently as long as the key
+is loaded.
+
+**GCE (terraform module):**
+
+```hcl
+module "containarium" {
+  source                  = "../modules/containarium"
+  zfs_encryption_keyfile  = "/etc/containarium/zfs.key"
+  # ... other variables ...
+}
+```
+
+**Bare-metal:**
+
+```bash
+sudo ./scripts/setup-gpu-host.sh \
+  --data-disk nvme0n1 \
+  --zfs-encryption-keyfile /etc/containarium/zfs.key
+```
+
+On first boot the install script generates a random 32-byte keyfile
+(`dd if=/dev/urandom bs=32 count=1`, chmod `0400`). On subsequent
+boots ZFS reads the keyfile via `keylocation=file://`, so the pool
+mounts automatically with no operator intervention.
+
+**Threat model and limits.** The keyfile lives on the **boot disk**;
+the encrypted pool lives on the **data disk**. This protects:
+
+- Disk replacement / RMA — pulling the data disk and reading it on
+  another host yields ciphertext.
+- Cloud snapshot exfiltration of *only* the data PD.
+- Lost / stolen bare-metal data disks.
+
+It does **not** protect against:
+
+- Full-VM exfiltration (attacker gets both boot and data disks).
+- A privileged process on the running host — the kernel sees plaintext.
+- Memory / swap (out of scope for at-rest encryption).
+
+Pair with GCP CMEK on the boot disk (the `kms_key_self_link`
+variable) for defense in depth: an attacker now needs the GCP key
+to read the boot disk *and* the keyfile to decrypt the data disk.
+
+**Operator responsibilities — read before enabling:**
+
+- **Back the keyfile up off-host.** Losing it makes the pool
+  unrecoverable; ZFS does not store the key anywhere else.
+- **Restrict access** to the keyfile (`chmod 0400`, root-owned;
+  the install script enforces this on creation but won't fix it
+  later).
+- **Rotate** by destroying + recreating the pool (in-place rekeying
+  via `zfs change-key` is supported but operationally tricky;
+  out-of-scope here).
+- **Don't enable on an existing pool.** ZFS native encryption is a
+  pool-creation-time setting; flipping it later requires destroying
+  the pool. The install scripts skip the encryption block when the
+  pool already exists.
 
 ## Answering vendor security questionnaires
 
@@ -126,7 +187,7 @@ any particular at-rest encryption layer.
 | Key rotation? | Manual (re-`terraform apply -replace`). Automatic rotation is a cloud-product feature, not in OSS. |
 | What about backups? | GCP disk snapshots inherit the source disk's encryption. If you use CMEK on the live disks, snapshots use CMEK. |
 | Are memory or swap encrypted? | No. At-rest scope is cold disk only. |
-| What's not encrypted? | Bare-metal peer disks (unless operator-configured); ZFS pool itself (only the underlying PD is encrypted). |
+| What's not encrypted? | Bare-metal peer disks (unless operator opts into `--zfs-encryption-keyfile`); ZFS pool itself by default (operator opt-in via `zfs_encryption_keyfile` terraform variable or the bare-metal flag). |
 
 ## References
 

--- a/scripts/setup-gpu-host.sh
+++ b/scripts/setup-gpu-host.sh
@@ -10,12 +10,16 @@
 #   5. Kernel modules and sysctl for containers
 #
 # Usage:
-#   sudo ./setup-gpu-host.sh [--skip-reboot] [--yes] [--data-disk DISK] [--backup-disks DISK1,DISK2]
+#   sudo ./setup-gpu-host.sh [--skip-reboot] [--yes] [--data-disk DISK] [--backup-disks DISK1,DISK2] [--zfs-encryption-keyfile PATH]
 #
 # Disk layout (auto-detected if not specified):
-#   --data-disk     Fastest unused disk for container storage (e.g., nvme0n1)
-#   --backup-disks  Rotational disks for ZFS mirror backup pool (e.g., sda,sdb)
-#   --yes           Skip confirmation prompt (for automation)
+#   --data-disk                 Fastest unused disk for container storage (e.g., nvme0n1)
+#   --backup-disks              Rotational disks for ZFS mirror backup pool (e.g., sda,sdb)
+#   --yes                       Skip confirmation prompt (for automation)
+#   --zfs-encryption-keyfile    Enable ZFS native encryption on the main pool, reading a 32-byte raw key
+#                               from the given path. The keyfile is generated on first run if missing.
+#                               Operators MUST back this file up off-host — loss = unrecoverable pool.
+#                               See docs/SECURITY-ENCRYPTION-AT-REST.md.
 #   If no unused disks are found, falls back to file-backed 50GB pool.
 #
 # After running, reboot the machine if the NVIDIA driver was freshly installed.
@@ -40,14 +44,16 @@ SKIP_REBOOT=false
 AUTO_YES=false
 DATA_DISK=""
 BACKUP_DISKS=""
+ZFS_ENCRYPTION_KEYFILE=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --skip-reboot) SKIP_REBOOT=true; shift ;;
         --yes|-y) AUTO_YES=true; shift ;;
         --data-disk) DATA_DISK="$2"; shift 2 ;;
         --backup-disks) BACKUP_DISKS="$2"; shift 2 ;;
+        --zfs-encryption-keyfile) ZFS_ENCRYPTION_KEYFILE="$2"; shift 2 ;;
         --help|-h)
-            echo "Usage: sudo $0 [--skip-reboot] [--yes] [--data-disk DISK] [--backup-disks DISK1,DISK2]"
+            echo "Usage: sudo $0 [--skip-reboot] [--yes] [--data-disk DISK] [--backup-disks DISK1,DISK2] [--zfs-encryption-keyfile PATH]"
             exit 0
             ;;
         *) echo "Unknown option: $1"; exit 1 ;;
@@ -299,6 +305,25 @@ if ! command -v zpool &>/dev/null; then
 fi
 
 if [ ! -f /var/lib/incus/.initialized ]; then
+    # ZFS native encryption is opt-in via --zfs-encryption-keyfile.
+    # The keyfile lives on the boot disk (separate from the data
+    # disk holding the encrypted pool). Loss of the keyfile makes
+    # the pool unrecoverable — operators MUST back it up off-host.
+    # See docs/SECURITY-ENCRYPTION-AT-REST.md.
+    ENCRYPT_OPTS=()
+    if [ -n "$ZFS_ENCRYPTION_KEYFILE" ]; then
+        mkdir -p "$(dirname "$ZFS_ENCRYPTION_KEYFILE")"
+        if [ ! -f "$ZFS_ENCRYPTION_KEYFILE" ]; then
+            echo "  Generating ZFS encryption keyfile at $ZFS_ENCRYPTION_KEYFILE"
+            dd if=/dev/urandom of="$ZFS_ENCRYPTION_KEYFILE" bs=32 count=1 status=none
+            chmod 0400 "$ZFS_ENCRYPTION_KEYFILE"
+            echo "  WARNING: back up $ZFS_ENCRYPTION_KEYFILE off-host. Loss = unrecoverable pool."
+        else
+            echo "  Reusing existing ZFS encryption keyfile at $ZFS_ENCRYPTION_KEYFILE"
+        fi
+        ENCRYPT_OPTS=(-O encryption=on -O keyformat=raw -O keylocation="file://$ZFS_ENCRYPTION_KEYFILE")
+    fi
+
     # --- Main storage pool (incus-local) ---
     if ! zpool list incus-local &>/dev/null; then
         if [ -n "$DATA_DISK" ]; then
@@ -319,9 +344,14 @@ if [ ! -f /var/lib/incus/.initialized ]; then
                 -O atime=off \
                 -O xattr=sa \
                 -O recordsize=128k \
+                "${ENCRYPT_OPTS[@]}" \
                 -m /var/lib/incus/storage \
                 incus-local "$DISK_PATH"
-            echo "  ZFS pool created on $DISK_PATH ($(lsblk -n -o SIZE "$DISK_PATH" | head -1))"
+            if [ ${#ENCRYPT_OPTS[@]} -gt 0 ]; then
+                echo "  ZFS pool created on $DISK_PATH with native encryption ($(lsblk -n -o SIZE "$DISK_PATH" | head -1))"
+            else
+                echo "  ZFS pool created on $DISK_PATH ($(lsblk -n -o SIZE "$DISK_PATH" | head -1))"
+            fi
         else
             # Fallback: file-backed pool
             mkdir -p /var/lib/incus/disks
@@ -331,9 +361,14 @@ if [ ! -f /var/lib/incus/.initialized ]; then
                 -O compression=lz4 \
                 -O atime=off \
                 -O xattr=sa \
+                "${ENCRYPT_OPTS[@]}" \
                 -m /var/lib/incus/storage \
                 incus-local /var/lib/incus/disks/incus.img
-            echo "  ZFS pool created (file-backed, 50GB)"
+            if [ ${#ENCRYPT_OPTS[@]} -gt 0 ]; then
+                echo "  ZFS pool created (file-backed, 50GB, encrypted)"
+            else
+                echo "  ZFS pool created (file-backed, 50GB)"
+            fi
         fi
         zfs create incus-local/containers
     fi

--- a/terraform/modules/containarium/scripts/startup-spot.sh
+++ b/terraform/modules/containarium/scripts/startup-spot.sh
@@ -23,6 +23,13 @@ ENABLE_MONITORING="${enable_monitoring}"
 USE_PERSISTENT_DISK="${use_persistent_disk}"
 FAIL2BAN_WHITELIST="${fail2ban_whitelist_cidr}"
 JWT_SECRET="${jwt_secret}"
+# When non-empty, the data-disk ZFS pool is created with native
+# encryption=on, keyformat=raw, keylocation=file://$ZFS_ENCRYPTION_KEYFILE.
+# The keyfile is generated on first boot if missing (32 random bytes,
+# chmod 0400). Lost keyfile = lost pool — operators MUST back this up
+# off-host. See docs/SECURITY-ENCRYPTION-AT-REST.md for the full
+# custody story.
+ZFS_ENCRYPTION_KEYFILE="${zfs_encryption_keyfile}"
 
 # ==========================================================================
 # FAST PATH: If this is a restart (not first boot), skip software install.
@@ -240,6 +247,25 @@ if [ "$USE_PERSISTENT_DISK" = "true" ] && [ -d "/mnt/incus-data" ]; then
     DISK_DEVICE="/dev/disk/by-id/google-incus-data"
     ZFS_POOL="incus-pool"
 
+    # ZFS native encryption is opt-in via ZFS_ENCRYPTION_KEYFILE.
+    # The keyfile lives on the boot disk (so an attacker who exfils
+    # only the data disk can't decrypt); GCP CMEK on the boot disk
+    # still applies independently. Defense in depth, not a silver
+    # bullet — see docs/SECURITY-ENCRYPTION-AT-REST.md.
+    ENCRYPT_OPTS=""
+    if [ -n "$ZFS_ENCRYPTION_KEYFILE" ]; then
+        mkdir -p "$(dirname "$ZFS_ENCRYPTION_KEYFILE")"
+        if [ ! -f "$ZFS_ENCRYPTION_KEYFILE" ]; then
+            echo "==> Generating ZFS encryption keyfile at $ZFS_ENCRYPTION_KEYFILE"
+            dd if=/dev/urandom of="$ZFS_ENCRYPTION_KEYFILE" bs=32 count=1 status=none
+            chmod 0400 "$ZFS_ENCRYPTION_KEYFILE"
+            echo "==> WARNING: back up $ZFS_ENCRYPTION_KEYFILE off-host. Loss = unrecoverable pool."
+        else
+            echo "==> Reusing existing ZFS encryption keyfile at $ZFS_ENCRYPTION_KEYFILE"
+        fi
+        ENCRYPT_OPTS="-O encryption=on -O keyformat=raw -O keylocation=file://$ZFS_ENCRYPTION_KEYFILE"
+    fi
+
     if ! zpool list "$ZFS_POOL" &>/dev/null; then
         echo "Creating ZFS pool on persistent disk..."
 
@@ -248,6 +274,13 @@ if [ "$USE_PERSISTENT_DISK" = "true" ] && [ -d "/mnt/incus-data" ]; then
             echo "Importing existing ZFS pool..."
             # Use -f to force import (handles cases where pool was last used by different system)
             zpool import -f "$ZFS_POOL"
+            # If encryption was enabled at create time, the
+            # keyfile-backed key auto-loads via keylocation=file://;
+            # explicit load is a no-op but defensive against pools
+            # imported from a different ZFS_ENCRYPTION_KEYFILE path.
+            if [ -n "$ZFS_ENCRYPTION_KEYFILE" ] && zfs get -H -o value encryption "$ZFS_POOL" 2>/dev/null | grep -qv '^off$'; then
+                zfs load-key -L "file://$ZFS_ENCRYPTION_KEYFILE" "$ZFS_POOL" 2>/dev/null || true
+            fi
             echo "✓ ZFS pool imported"
         else
             # Create new ZFS pool
@@ -257,10 +290,15 @@ if [ "$USE_PERSISTENT_DISK" = "true" ] && [ -d "/mnt/incus-data" ]; then
                 -O atime=off \
                 -O xattr=sa \
                 -O dnodesize=auto \
+                $ENCRYPT_OPTS \
                 -m /mnt/incus-data/zfs \
                 "$ZFS_POOL" "$DISK_DEVICE"
 
-            echo "✓ ZFS pool created with compression enabled"
+            if [ -n "$ENCRYPT_OPTS" ]; then
+                echo "✓ ZFS pool created with compression + native encryption"
+            else
+                echo "✓ ZFS pool created with compression enabled"
+            fi
         fi
 
         # Create dataset for Incus containers

--- a/terraform/modules/containarium/spot-instance.tf
+++ b/terraform/modules/containarium/spot-instance.tf
@@ -152,6 +152,7 @@ resource "google_compute_instance" "jump_server_spot" {
       base_domain                  = var.base_domain
       enable_proxy_protocol        = var.enable_proxy_protocol
       proxy_protocol_trusted_cidrs = var.proxy_protocol_trusted_cidrs
+      zfs_encryption_keyfile       = var.zfs_encryption_keyfile
     })
   }
 

--- a/terraform/modules/containarium/variables.tf
+++ b/terraform/modules/containarium/variables.tf
@@ -345,3 +345,9 @@ variable "proxy_protocol_trusted_cidrs" {
   type        = list(string)
   default     = []
 }
+
+variable "zfs_encryption_keyfile" {
+  description = "Absolute path on the backend VM for the ZFS native encryption keyfile (e.g. /etc/containarium/zfs.key). When non-empty, the data-disk ZFS pool is created with encryption=on and reads the 32-byte raw key from this path on every boot. The keyfile is generated automatically on first boot if missing. Operators MUST back this file up off-host — losing it makes the pool unrecoverable. Empty (default) = no ZFS-layer encryption, relies on PD/CMEK only. See docs/SECURITY-ENCRYPTION-AT-REST.md."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Adds an opt-in flag to both install paths (GCE terraform + bare-metal script) that creates the data ZFS pool with native `encryption=on`, `keyformat=raw`, `keylocation=file://<path>`. Every container dataset inherits encryption from the parent pool. The daemon doesn't need any code change — the kernel decrypts transparently.

### Usage

**GCE (terraform):**

```hcl
module \"containarium\" {
  source                  = \"../modules/containarium\"
  zfs_encryption_keyfile  = \"/etc/containarium/zfs.key\"
}
```

**Bare-metal:**

```bash
sudo ./scripts/setup-gpu-host.sh \
  --data-disk nvme0n1 \
  --zfs-encryption-keyfile /etc/containarium/zfs.key
```

Both scripts auto-generate a 32-byte random keyfile (`chmod 0400`) on first run if it doesn't exist; later boots reuse it transparently.

### Threat model (documented in `docs/SECURITY-ENCRYPTION-AT-REST.md`)

- Keyfile on **boot disk**, encrypted pool on **data disk**.
- Protects against data-only exfil / disk RMA / lost bare-metal data disks.
- Does **not** protect against full-VM compromise or privileged host processes.
- Combine with GCP CMEK on the boot disk (`kms_key_self_link`) for defense in depth.

### Scope clarifications

- Per-container / per-tenant keys stay deferred to cloud multi-tenancy work (the Containarium-cloud PRD set). This is the OSS-scope pool-level feature only.
- Existing pools are untouched — the install scripts skip the encryption block when `zpool list` already shows the pool, because ZFS native encryption is a pool-creation-time setting.

## Test plan

- [x] `bash -n` on both scripts — syntax valid
- [x] `terraform validate` on both `terraform/gce/` and `terraform/modules/containarium/` — clean
- [x] `go build ./...` — clean
- [ ] Manual smoke (bare-metal): run setup with `--zfs-encryption-keyfile`, verify pool's `zfs get encryption` returns `aes-256-gcm`, reboot, verify pool auto-mounts
- [ ] Manual smoke (GCE): apply terraform with `zfs_encryption_keyfile` set, verify VM comes up clean and pool is encrypted

🤖 Generated with [Claude Code](https://claude.com/claude-code)