### PR TITLE
feat(server): ToggleMonitoring RPC for live OTel enable/disable

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -1358,6 +1358,47 @@
         ]
       }
     },
+    "/v1/containers/{username}/monitoring": {
+      "post": {
+        "summary": "Enable or disable OTel monitoring on a container",
+        "description": "Live-flip OTEL_EXPORTER_OTLP_ENDPOINT and related env vars on an existing container and restart it so the change reaches the app. Use this to retrofit monitoring onto containers created before --monitoring was wired into create_container.",
+        "operationId": "ContainerService_ToggleMonitoring",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ToggleMonitoringResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "description": "Username of the container.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ToggleMonitoringBody"
+            }
+          }
+        ],
+        "tags": [
+          "Container Operations"
+        ]
+      }
+    },
     "/v1/containers/{username}/move": {
       "post": {
         "summary": "Migrate container to peer daemon",
@@ -6458,6 +6499,30 @@
         }
       },
       "title": "TestWebhookResponse returns the result of the test"
+    },
+    "ToggleMonitoringBody": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Desired state. true → stamp env vars + restart. false → unset\nenv vars + restart so the SDK falls back to its buffer+drop\ndefault."
+        }
+      },
+      "description": "ToggleMonitoringRequest enables / disables OTel app telemetry on\nan existing container. The four OTEL_* env vars are stamped (or\nunset) and the container is restarted so the new env reaches the\napp process."
+    },
+    "ToggleMonitoringResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "Operator-facing summary of what changed (e.g. \"monitoring\nenabled — container restarted\")."
+        },
+        "monitoringEnabled": {
+          "type": "boolean",
+          "description": "The effective monitoring_enabled state of the container after\nthe toggle (mirrors Container.monitoring_enabled in subsequent\nGetContainer responses)."
+        }
+      },
+      "description": "ToggleMonitoringResponse reports the new monitoring state."
     },
     "TrafficAggregate": {
       "type": "object",

--- a/docs/OTEL-COLLECTOR-DESIGN.md
+++ b/docs/OTEL-COLLECTOR-DESIGN.md
@@ -29,7 +29,7 @@ This doc designs a per-container, opt-in path for application-emitted OTel that 
 - Operator-tunable per-tenant rate limits / quotas (the cardinality guard is the only protection in v1).
 - Cross-VM metric query federation beyond what PeerPool already does for daemon metrics.
 - Hosted "Containarium-managed" external endpoint — everything stays inside the VM.
-- A `ToggleMonitoring` RPC for live-flipping the flag on an existing container. Operators can recreate or hand-edit the LXC env.
+- ~~A `ToggleMonitoring` RPC for live-flipping the flag on an existing container.~~ **Shipped 2026-05-15.** `containarium monitoring enable|disable <username>` (CLI) / `toggle_monitoring` (MCP) / `POST /v1/containers/{username}/monitoring` (REST). Stamps or unsets OTEL_* env vars and restarts the container.
 
 ## Architecture
 
@@ -289,7 +289,7 @@ When a real user needs them, layer these on:
 - **Traces pipeline** — add `otlp` traces receiver to the collector config; add Tempo container as a new core-services entry; add `otlphttp` traces exporter targeting Tempo. ~1 day.
 - **Logs pipeline** — same shape: add `otlp` logs receiver; add Loki container; add `otlphttp` logs exporter. (Or use Vector/Fluent Bit for log shipping if Loki proves heavy.) ~1 day.
 - **Per-tenant rate limits / quotas** — extend the cardinality guard with a `limit` processor keyed on `container.id`. Operators set per-tenant ingestion budgets. ~1 day.
-- **`ToggleMonitoring` RPC** — live-enable / live-disable on an existing container without recreate. Requires an env-var update + container restart. ~½ day.
+- ~~**`ToggleMonitoring` RPC**~~ — **Shipped 2026-05-15.** See above.
 - **Cross-VM Grafana data source federation** — query unified view across all peer VMs without each one needing its own dashboard URL. Reuses PeerPool. ~1-2 days.
 
 These are tracked in the project task list; this doc gets a follow-up edit when any of them ship.

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -174,6 +174,24 @@ func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, 
 	return info, nil
 }
 
+// ToggleMonitoring enables / disables OTel app telemetry on an
+// existing container. Returns the new monitoring_enabled state and
+// a human-readable summary of what changed.
+func (c *GRPCClient) ToggleMonitoring(username string, enabled bool) (string, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	req := &pb.ToggleMonitoringRequest{
+		Username: username,
+		Enabled:  enabled,
+	}
+	resp, err := c.client.ToggleMonitoring(ctx, req)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to toggle monitoring: %w", err)
+	}
+	return resp.Message, resp.MonitoringEnabled, nil
+}
+
 // DeleteContainer deletes a container via gRPC
 func (c *GRPCClient) DeleteContainer(username string, force bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -246,6 +246,44 @@ func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, 
 	return &info, nil
 }
 
+// ToggleMonitoring enables / disables OTel app telemetry on an
+// existing container via HTTP. Returns (message, monitoring_enabled, error).
+func (c *HTTPClient) ToggleMonitoring(username string, enabled bool) (string, bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/containers/%s/monitoring", url.PathEscape(username))
+	body, err := json.Marshal(map[string]bool{"enabled": enabled})
+	if err != nil {
+		return "", false, fmt.Errorf("marshal request: %w", err)
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return "", false, fmt.Errorf("toggle monitoring: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(bodyBytes, &errResp) == nil && errResp.Error != "" {
+			return "", false, fmt.Errorf("%s", errResp.Error)
+		}
+		return "", false, fmt.Errorf("toggle monitoring: status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Message           string `json:"message"`
+		MonitoringEnabled bool   `json:"monitoring_enabled"`
+	}
+	if err := json.Unmarshal(bodyBytes, &result); err != nil {
+		return "", false, fmt.Errorf("decode response: %w", err)
+	}
+	return result.Message, result.MonitoringEnabled, nil
+}
+
 // DeleteContainer deletes a container via HTTP
 func (c *HTTPClient) DeleteContainer(username string, force bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/cmd/monitoring.go
+++ b/internal/cmd/monitoring.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/footprintai/containarium/internal/client"
+	"github.com/spf13/cobra"
+)
+
+var monitoringCmd = &cobra.Command{
+	Use:     "monitoring",
+	Short:   "Enable or disable OTel app telemetry on a container",
+	Long:    `Manage application-emitted OpenTelemetry on existing containers without recreating them.`,
+	Aliases: []string{"monitor", "otel"},
+}
+
+var monitoringEnableCmd = &cobra.Command{
+	Use:   "enable <username>",
+	Short: "Enable OTel monitoring on an existing container",
+	Long: `Stamp OTEL_EXPORTER_OTLP_ENDPOINT and related env vars onto the container's
+LXC config and restart it so the app picks them up.
+
+Requires the daemon to have an OTel collector endpoint configured
+(auto-ensured at daemon startup when VictoriaMetrics is available, or
+explicitly via --otel-collector-endpoint).
+
+Examples:
+  containarium monitoring enable alice
+  containarium monitoring enable --server addr:port alice`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error { return runMonitoringToggle(args[0], true) },
+}
+
+var monitoringDisableCmd = &cobra.Command{
+	Use:   "disable <username>",
+	Short: "Disable OTel monitoring on an existing container",
+	Long: `Unset the OTEL_* env vars from the container's LXC config and restart it so
+the SDK falls back to its no-endpoint defaults.
+
+Examples:
+  containarium monitoring disable alice`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error { return runMonitoringToggle(args[0], false) },
+}
+
+func init() {
+	rootCmd.AddCommand(monitoringCmd)
+	monitoringCmd.AddCommand(monitoringEnableCmd)
+	monitoringCmd.AddCommand(monitoringDisableCmd)
+}
+
+func runMonitoringToggle(username string, enabled bool) error {
+	// Toggle requires server connectivity — there's no useful local
+	// equivalent (the LXC config update path lives on the daemon).
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required for monitoring toggle (no local fallback)")
+	}
+
+	var msg string
+	var nowEnabled bool
+	var err error
+
+	if httpMode {
+		httpClient, herr := client.NewHTTPClient(serverAddr, authToken)
+		if herr != nil {
+			return herr
+		}
+		defer httpClient.Close()
+		msg, nowEnabled, err = httpClient.ToggleMonitoring(username, enabled)
+	} else {
+		grpcClient, gerr := client.NewGRPCClient(serverAddr, certsDir, insecure)
+		if gerr != nil {
+			return gerr
+		}
+		defer grpcClient.Close()
+		msg, nowEnabled, err = grpcClient.ToggleMonitoring(username, enabled)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	state := "disabled"
+	if nowEnabled {
+		state = "enabled"
+	}
+	fmt.Printf("✓ Container %s: monitoring %s\n", username, state)
+	if msg != "" {
+		fmt.Println(msg)
+	}
+	return nil
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -184,6 +184,25 @@ func (c *Client) DebugContainer(username string) (*DebugContainerResponse, error
 	return &resp, nil
 }
 
+// ToggleMonitoring enables / disables OTel app telemetry on an
+// existing container. Returns the response with message +
+// monitoring_enabled state.
+func (c *Client) ToggleMonitoring(username string, enabled bool) (*ToggleMonitoringResponse, error) {
+	body, err := json.Marshal(map[string]bool{"enabled": enabled})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	respBody, err := c.doRequest("POST", fmt.Sprintf("/v1/containers/%s/monitoring", username), body)
+	if err != nil {
+		return nil, err
+	}
+	var resp ToggleMonitoringResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
 // DeleteContainer deletes a container
 func (c *Client) DeleteContainer(username string, force bool) (*DeleteContainerResponse, error) {
 	path := fmt.Sprintf("/v1/containers/%s?force=%v", username, force)
@@ -638,6 +657,11 @@ type DebugContainerResponse struct {
 type DeleteContainerResponse struct {
 	Message       string `json:"message"`
 	ContainerName string `json:"containerName"`
+}
+
+type ToggleMonitoringResponse struct {
+	Message           string `json:"message"`
+	MonitoringEnabled bool   `json:"monitoring_enabled"`
 }
 
 type StartContainerResponse struct {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,7 +22,7 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	assert.Len(t, server.tools, 20, "Should have 20 tools registered")
+	assert.Len(t, server.tools, 21, "Should have 21 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -126,7 +126,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	assert.Len(t, tools, 20)
+	assert.Len(t, tools, 21)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -281,6 +281,25 @@ func (s *Server) registerTools() {
 			Handler: handleMoveContainer,
 		},
 		{
+			Name:        "toggle_monitoring",
+			Description: "Enable or disable application-emitted OpenTelemetry on an existing container without recreating it. When enabling, the daemon stamps OTEL_EXPORTER_OTLP_ENDPOINT + related env vars and restarts the container so the app picks them up. Use this to retrofit monitoring onto containers created before --monitoring was wired in. Requires the daemon to have an OTel collector endpoint configured.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":        "string",
+						"description": "Username of the container",
+					},
+					"enabled": map[string]interface{}{
+						"type":        "boolean",
+						"description": "true to enable monitoring (stamp OTEL_* env + restart), false to disable (unset OTEL_* env + restart)",
+					},
+				},
+				"required": []string{"username", "enabled"},
+			},
+			Handler: handleToggleMonitoring,
+		},
+		{
 			Name:        "delete_container",
 			Description: "Delete a container permanently",
 			InputSchema: map[string]interface{}{
@@ -887,6 +906,23 @@ func handleDebugContainer(client *Client, args map[string]interface{}) (string, 
 	}
 
 	return string(jsonData), nil
+}
+
+func handleToggleMonitoring(client *Client, args map[string]interface{}) (string, error) {
+	username, ok := args["username"].(string)
+	if !ok || username == "" {
+		return "", fmt.Errorf("username is required")
+	}
+	enabled, ok := args["enabled"].(bool)
+	if !ok {
+		return "", fmt.Errorf("enabled (bool) is required")
+	}
+
+	resp, err := client.ToggleMonitoring(username, enabled)
+	if err != nil {
+		return "", fmt.Errorf("failed to toggle monitoring: %w", err)
+	}
+	return fmt.Sprintf("✅ %s (monitoring_enabled=%v)", resp.Message, resp.MonitoringEnabled), nil
 }
 
 func handleDeleteContainer(client *Client, args map[string]interface{}) (string, error) {

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -18,7 +18,9 @@ import (
 	"github.com/footprintai/containarium/pkg/core/ostype"
 	"github.com/footprintai/containarium/pkg/core/stacks"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -914,6 +916,101 @@ func (s *ContainerServer) AdoptMigratedContainer(ctx context.Context, req *pb.Ad
 	return &pb.AdoptMigratedContainerResponse{
 		Message:      fmt.Sprintf("Container %s adopted, ready at %s", req.Username, newIP),
 		NewIpAddress: newIP,
+	}, nil
+}
+
+// otelEnvKeys lists the four environment variables the toggle
+// path stamps / unsets. Centralized so a future change to the env
+// var set is one edit, not two.
+var otelEnvKeys = []string{
+	"OTEL_EXPORTER_OTLP_ENDPOINT",
+	"OTEL_EXPORTER_OTLP_PROTOCOL",
+	"OTEL_SERVICE_NAME",
+	"OTEL_RESOURCE_ATTRIBUTES",
+}
+
+// ToggleMonitoring enables / disables app-emitted OTel on an existing
+// container without recreating it. Per the OTel design doc's v2 TODO.
+//
+// Enable path: requires the daemon to have a collector endpoint
+// configured (FailedPrecondition if not). Stamps the four OTEL_*
+// env vars via incus config-update, then stops + starts the LXC so
+// the env reaches the app process — env-var changes don't take
+// effect on a running container's processes.
+//
+// Disable path: deletes the four OTEL_* env keys from the LXC's
+// Incus config (so the SDK falls back to its no-endpoint defaults
+// rather than seeing literal empty strings, which some SDKs flag
+// as misconfig), then stops + starts the LXC.
+//
+// Core containers are refused — they don't run user code and don't
+// need app-emitted telemetry.
+func (s *ContainerServer) ToggleMonitoring(ctx context.Context, req *pb.ToggleMonitoringRequest) (*pb.ToggleMonitoringResponse, error) {
+	if req.Username == "" {
+		return nil, status.Error(codes.InvalidArgument, "username is required")
+	}
+
+	info, err := s.manager.Get(req.Username)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "container for user %s not found: %v", req.Username, err)
+	}
+	if info.Role.IsCoreRole() {
+		return nil, status.Errorf(codes.InvalidArgument, "container %s is a core container; monitoring is for user containers only", info.Name)
+	}
+
+	containerName := info.Name
+
+	if req.Enabled {
+		if s.otelCollectorEndpoint == "" {
+			return nil, status.Error(codes.FailedPrecondition, "OTel collector endpoint is not configured on this daemon; cannot enable monitoring")
+		}
+		envVars := container.OTelEnvVarsForMigration(
+			req.Username, containerName, s.localBackendID(), s.otelCollectorEndpoint,
+		)
+		for k, v := range envVars {
+			if err := s.manager.SetEnv(containerName, k, v); err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to stamp %s: %v", k, err)
+			}
+		}
+	} else {
+		for _, k := range otelEnvKeys {
+			if err := s.manager.UnsetEnv(containerName, k); err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to unset %s: %v", k, err)
+			}
+		}
+	}
+
+	// Restart so the new env reaches the app. The container was
+	// running before — we ignore stop errors (LXC might be already
+	// stopped, in which case stop is a no-op).
+	wasRunning := info.State == "Running"
+	if wasRunning {
+		if err := s.manager.Stop(req.Username, false); err != nil {
+			log.Printf("[togglemonitor] %s stop returned %v (continuing)", containerName, err)
+		}
+		if err := s.manager.Start(req.Username); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to start container after env update: %v", err)
+		}
+	}
+
+	// Refresh the collector's IP map — the container may have a
+	// new IP after restart, and we want source-IP attribution to
+	// stay accurate.
+	s.refreshContainerIPMap()
+
+	msg := "monitoring disabled"
+	if req.Enabled {
+		msg = "monitoring enabled"
+	}
+	if wasRunning {
+		msg += " — container restarted"
+	} else {
+		msg += " — container was stopped; new env takes effect on next start"
+	}
+
+	return &pb.ToggleMonitoringResponse{
+		Message:           msg,
+		MonitoringEnabled: req.Enabled,
 	}, nil
 }
 

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -651,6 +651,18 @@ func (m *Manager) SetEnv(containerName, key, value string) error {
 	return fmt.Errorf("SetEnv not supported on this incus backend (mock?)")
 }
 
+// UnsetEnv removes an environment variable from an existing
+// container's Incus config (deletes the key rather than setting it
+// to empty — empty-string OTEL_* vars are treated as misconfigured
+// by some SDKs, so absence is the right "disabled" representation).
+// Idempotent. Used by ToggleMonitoring's disable path.
+func (m *Manager) UnsetEnv(containerName, key string) error {
+	if real, ok := m.incus.(*incus.Client); ok {
+		return real.UnsetEnv(containerName, key)
+	}
+	return fmt.Errorf("UnsetEnv not supported on this incus backend (mock?)")
+}
+
 func (m *Manager) Get(username string) (*incus.ContainerInfo, error) {
 	containerName := username + "-container"
 	return m.incus.GetContainer(containerName)

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -1041,6 +1041,30 @@ func (c *Client) SetEnv(containerName, key, value string) error {
 	return c.SetConfig(containerName, "environment."+key, value)
 }
 
+// UnsetEnv removes an environment variable from a container's Incus
+// config (i.e. deletes the `environment.<KEY>` config key entirely
+// rather than setting it to empty). Idempotent — missing keys are
+// not an error. Used by ToggleMonitoring's disable path so the SDK
+// inside the container sees an absent OTEL_EXPORTER_OTLP_ENDPOINT
+// (which makes it fall back to no-endpoint defaults) rather than
+// the literal empty string (which some SDKs treat as a misconfig).
+func (c *Client) UnsetEnv(containerName, key string) error {
+	inst, etag, err := c.server.GetInstance(containerName)
+	if err != nil {
+		return fmt.Errorf("failed to get container: %w", err)
+	}
+	configKey := "environment." + key
+	if _, present := inst.Config[configKey]; !present {
+		return nil
+	}
+	delete(inst.Config, configKey)
+	op, err := c.server.UpdateInstance(containerName, inst.Writable(), etag)
+	if err != nil {
+		return fmt.Errorf("failed to update container config: %w", err)
+	}
+	return op.Wait()
+}
+
 func (c *Client) SetConfig(containerName, key, value string) error {
 	// Get current container configuration
 	inst, etag, err := c.server.GetInstance(containerName)

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -1629,6 +1629,124 @@ func (x *StopContainerResponse) GetContainer() *Container {
 	return nil
 }
 
+// ToggleMonitoringRequest enables / disables OTel app telemetry on
+// an existing container. The four OTEL_* env vars are stamped (or
+// unset) and the container is restarted so the new env reaches the
+// app process.
+type ToggleMonitoringRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Username of the container.
+	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
+	// Desired state. true → stamp env vars + restart. false → unset
+	// env vars + restart so the SDK falls back to its buffer+drop
+	// default.
+	Enabled       bool `protobuf:"varint,2,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ToggleMonitoringRequest) Reset() {
+	*x = ToggleMonitoringRequest{}
+	mi := &file_containarium_v1_container_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ToggleMonitoringRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ToggleMonitoringRequest) ProtoMessage() {}
+
+func (x *ToggleMonitoringRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ToggleMonitoringRequest.ProtoReflect.Descriptor instead.
+func (*ToggleMonitoringRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ToggleMonitoringRequest) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *ToggleMonitoringRequest) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+// ToggleMonitoringResponse reports the new monitoring state.
+type ToggleMonitoringResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Operator-facing summary of what changed (e.g. "monitoring
+	// enabled — container restarted").
+	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	// The effective monitoring_enabled state of the container after
+	// the toggle (mirrors Container.monitoring_enabled in subsequent
+	// GetContainer responses).
+	MonitoringEnabled bool `protobuf:"varint,2,opt,name=monitoring_enabled,json=monitoringEnabled,proto3" json:"monitoring_enabled,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ToggleMonitoringResponse) Reset() {
+	*x = ToggleMonitoringResponse{}
+	mi := &file_containarium_v1_container_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ToggleMonitoringResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ToggleMonitoringResponse) ProtoMessage() {}
+
+func (x *ToggleMonitoringResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ToggleMonitoringResponse.ProtoReflect.Descriptor instead.
+func (*ToggleMonitoringResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *ToggleMonitoringResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *ToggleMonitoringResponse) GetMonitoringEnabled() bool {
+	if x != nil {
+		return x.MonitoringEnabled
+	}
+	return false
+}
+
 // AddSSHKeyRequest is the request to add an SSH key to a container
 type AddSSHKeyRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1642,7 +1760,7 @@ type AddSSHKeyRequest struct {
 
 func (x *AddSSHKeyRequest) Reset() {
 	*x = AddSSHKeyRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[18]
+	mi := &file_containarium_v1_container_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1654,7 +1772,7 @@ func (x *AddSSHKeyRequest) String() string {
 func (*AddSSHKeyRequest) ProtoMessage() {}
 
 func (x *AddSSHKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[18]
+	mi := &file_containarium_v1_container_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1667,7 +1785,7 @@ func (x *AddSSHKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddSSHKeyRequest.ProtoReflect.Descriptor instead.
 func (*AddSSHKeyRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{18}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *AddSSHKeyRequest) GetUsername() string {
@@ -1697,7 +1815,7 @@ type AddSSHKeyResponse struct {
 
 func (x *AddSSHKeyResponse) Reset() {
 	*x = AddSSHKeyResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[19]
+	mi := &file_containarium_v1_container_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1709,7 +1827,7 @@ func (x *AddSSHKeyResponse) String() string {
 func (*AddSSHKeyResponse) ProtoMessage() {}
 
 func (x *AddSSHKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[19]
+	mi := &file_containarium_v1_container_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1722,7 +1840,7 @@ func (x *AddSSHKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddSSHKeyResponse.ProtoReflect.Descriptor instead.
 func (*AddSSHKeyResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{19}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *AddSSHKeyResponse) GetMessage() string {
@@ -1752,7 +1870,7 @@ type RemoveSSHKeyRequest struct {
 
 func (x *RemoveSSHKeyRequest) Reset() {
 	*x = RemoveSSHKeyRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[20]
+	mi := &file_containarium_v1_container_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1764,7 +1882,7 @@ func (x *RemoveSSHKeyRequest) String() string {
 func (*RemoveSSHKeyRequest) ProtoMessage() {}
 
 func (x *RemoveSSHKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[20]
+	mi := &file_containarium_v1_container_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1777,7 +1895,7 @@ func (x *RemoveSSHKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSSHKeyRequest.ProtoReflect.Descriptor instead.
 func (*RemoveSSHKeyRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{20}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *RemoveSSHKeyRequest) GetUsername() string {
@@ -1807,7 +1925,7 @@ type RemoveSSHKeyResponse struct {
 
 func (x *RemoveSSHKeyResponse) Reset() {
 	*x = RemoveSSHKeyResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[21]
+	mi := &file_containarium_v1_container_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1819,7 +1937,7 @@ func (x *RemoveSSHKeyResponse) String() string {
 func (*RemoveSSHKeyResponse) ProtoMessage() {}
 
 func (x *RemoveSSHKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[21]
+	mi := &file_containarium_v1_container_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1832,7 +1950,7 @@ func (x *RemoveSSHKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSSHKeyResponse.ProtoReflect.Descriptor instead.
 func (*RemoveSSHKeyResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{21}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *RemoveSSHKeyResponse) GetMessage() string {
@@ -1860,7 +1978,7 @@ type GetMetricsRequest struct {
 
 func (x *GetMetricsRequest) Reset() {
 	*x = GetMetricsRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[22]
+	mi := &file_containarium_v1_container_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1872,7 +1990,7 @@ func (x *GetMetricsRequest) String() string {
 func (*GetMetricsRequest) ProtoMessage() {}
 
 func (x *GetMetricsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[22]
+	mi := &file_containarium_v1_container_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1885,7 +2003,7 @@ func (x *GetMetricsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMetricsRequest.ProtoReflect.Descriptor instead.
 func (*GetMetricsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{22}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetMetricsRequest) GetUsername() string {
@@ -1906,7 +2024,7 @@ type GetMetricsResponse struct {
 
 func (x *GetMetricsResponse) Reset() {
 	*x = GetMetricsResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[23]
+	mi := &file_containarium_v1_container_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1918,7 +2036,7 @@ func (x *GetMetricsResponse) String() string {
 func (*GetMetricsResponse) ProtoMessage() {}
 
 func (x *GetMetricsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[23]
+	mi := &file_containarium_v1_container_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1931,7 +2049,7 @@ func (x *GetMetricsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMetricsResponse.ProtoReflect.Descriptor instead.
 func (*GetMetricsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{23}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetMetricsResponse) GetMetrics() []*ContainerMetrics {
@@ -1959,7 +2077,7 @@ type ResizeContainerRequest struct {
 
 func (x *ResizeContainerRequest) Reset() {
 	*x = ResizeContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[24]
+	mi := &file_containarium_v1_container_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1971,7 +2089,7 @@ func (x *ResizeContainerRequest) String() string {
 func (*ResizeContainerRequest) ProtoMessage() {}
 
 func (x *ResizeContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[24]
+	mi := &file_containarium_v1_container_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1984,7 +2102,7 @@ func (x *ResizeContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResizeContainerRequest.ProtoReflect.Descriptor instead.
 func (*ResizeContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{24}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ResizeContainerRequest) GetUsername() string {
@@ -2028,7 +2146,7 @@ type ResizeContainerResponse struct {
 
 func (x *ResizeContainerResponse) Reset() {
 	*x = ResizeContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[25]
+	mi := &file_containarium_v1_container_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2040,7 +2158,7 @@ func (x *ResizeContainerResponse) String() string {
 func (*ResizeContainerResponse) ProtoMessage() {}
 
 func (x *ResizeContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[25]
+	mi := &file_containarium_v1_container_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2053,7 +2171,7 @@ func (x *ResizeContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResizeContainerResponse.ProtoReflect.Descriptor instead.
 func (*ResizeContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{25}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ResizeContainerResponse) GetMessage() string {
@@ -2099,7 +2217,7 @@ type Collaborator struct {
 
 func (x *Collaborator) Reset() {
 	*x = Collaborator{}
-	mi := &file_containarium_v1_container_proto_msgTypes[26]
+	mi := &file_containarium_v1_container_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2111,7 +2229,7 @@ func (x *Collaborator) String() string {
 func (*Collaborator) ProtoMessage() {}
 
 func (x *Collaborator) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[26]
+	mi := &file_containarium_v1_container_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2124,7 +2242,7 @@ func (x *Collaborator) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Collaborator.ProtoReflect.Descriptor instead.
 func (*Collaborator) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{26}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *Collaborator) GetId() string {
@@ -2216,7 +2334,7 @@ type AddCollaboratorRequest struct {
 
 func (x *AddCollaboratorRequest) Reset() {
 	*x = AddCollaboratorRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[27]
+	mi := &file_containarium_v1_container_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2228,7 +2346,7 @@ func (x *AddCollaboratorRequest) String() string {
 func (*AddCollaboratorRequest) ProtoMessage() {}
 
 func (x *AddCollaboratorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[27]
+	mi := &file_containarium_v1_container_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2241,7 +2359,7 @@ func (x *AddCollaboratorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddCollaboratorRequest.ProtoReflect.Descriptor instead.
 func (*AddCollaboratorRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{27}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *AddCollaboratorRequest) GetOwnerUsername() string {
@@ -2294,7 +2412,7 @@ type AddCollaboratorResponse struct {
 
 func (x *AddCollaboratorResponse) Reset() {
 	*x = AddCollaboratorResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[28]
+	mi := &file_containarium_v1_container_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2306,7 +2424,7 @@ func (x *AddCollaboratorResponse) String() string {
 func (*AddCollaboratorResponse) ProtoMessage() {}
 
 func (x *AddCollaboratorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[28]
+	mi := &file_containarium_v1_container_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2319,7 +2437,7 @@ func (x *AddCollaboratorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddCollaboratorResponse.ProtoReflect.Descriptor instead.
 func (*AddCollaboratorResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{28}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *AddCollaboratorResponse) GetMessage() string {
@@ -2356,7 +2474,7 @@ type RemoveCollaboratorRequest struct {
 
 func (x *RemoveCollaboratorRequest) Reset() {
 	*x = RemoveCollaboratorRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[29]
+	mi := &file_containarium_v1_container_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2368,7 +2486,7 @@ func (x *RemoveCollaboratorRequest) String() string {
 func (*RemoveCollaboratorRequest) ProtoMessage() {}
 
 func (x *RemoveCollaboratorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[29]
+	mi := &file_containarium_v1_container_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2381,7 +2499,7 @@ func (x *RemoveCollaboratorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCollaboratorRequest.ProtoReflect.Descriptor instead.
 func (*RemoveCollaboratorRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{29}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *RemoveCollaboratorRequest) GetOwnerUsername() string {
@@ -2409,7 +2527,7 @@ type RemoveCollaboratorResponse struct {
 
 func (x *RemoveCollaboratorResponse) Reset() {
 	*x = RemoveCollaboratorResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[30]
+	mi := &file_containarium_v1_container_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2421,7 +2539,7 @@ func (x *RemoveCollaboratorResponse) String() string {
 func (*RemoveCollaboratorResponse) ProtoMessage() {}
 
 func (x *RemoveCollaboratorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[30]
+	mi := &file_containarium_v1_container_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2434,7 +2552,7 @@ func (x *RemoveCollaboratorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCollaboratorResponse.ProtoReflect.Descriptor instead.
 func (*RemoveCollaboratorResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{30}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *RemoveCollaboratorResponse) GetMessage() string {
@@ -2455,7 +2573,7 @@ type ListCollaboratorsRequest struct {
 
 func (x *ListCollaboratorsRequest) Reset() {
 	*x = ListCollaboratorsRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[31]
+	mi := &file_containarium_v1_container_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2467,7 +2585,7 @@ func (x *ListCollaboratorsRequest) String() string {
 func (*ListCollaboratorsRequest) ProtoMessage() {}
 
 func (x *ListCollaboratorsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[31]
+	mi := &file_containarium_v1_container_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2480,7 +2598,7 @@ func (x *ListCollaboratorsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCollaboratorsRequest.ProtoReflect.Descriptor instead.
 func (*ListCollaboratorsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{31}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *ListCollaboratorsRequest) GetOwnerUsername() string {
@@ -2503,7 +2621,7 @@ type ListCollaboratorsResponse struct {
 
 func (x *ListCollaboratorsResponse) Reset() {
 	*x = ListCollaboratorsResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[32]
+	mi := &file_containarium_v1_container_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2515,7 +2633,7 @@ func (x *ListCollaboratorsResponse) String() string {
 func (*ListCollaboratorsResponse) ProtoMessage() {}
 
 func (x *ListCollaboratorsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[32]
+	mi := &file_containarium_v1_container_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2528,7 +2646,7 @@ func (x *ListCollaboratorsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCollaboratorsResponse.ProtoReflect.Descriptor instead.
 func (*ListCollaboratorsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{32}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ListCollaboratorsResponse) GetCollaborators() []*Collaborator {
@@ -2556,7 +2674,7 @@ type CleanupDiskRequest struct {
 
 func (x *CleanupDiskRequest) Reset() {
 	*x = CleanupDiskRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[33]
+	mi := &file_containarium_v1_container_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2568,7 +2686,7 @@ func (x *CleanupDiskRequest) String() string {
 func (*CleanupDiskRequest) ProtoMessage() {}
 
 func (x *CleanupDiskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[33]
+	mi := &file_containarium_v1_container_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2581,7 +2699,7 @@ func (x *CleanupDiskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CleanupDiskRequest.ProtoReflect.Descriptor instead.
 func (*CleanupDiskRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{33}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *CleanupDiskRequest) GetUsername() string {
@@ -2606,7 +2724,7 @@ type CleanupDiskResponse struct {
 
 func (x *CleanupDiskResponse) Reset() {
 	*x = CleanupDiskResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[34]
+	mi := &file_containarium_v1_container_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2618,7 +2736,7 @@ func (x *CleanupDiskResponse) String() string {
 func (*CleanupDiskResponse) ProtoMessage() {}
 
 func (x *CleanupDiskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[34]
+	mi := &file_containarium_v1_container_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2631,7 +2749,7 @@ func (x *CleanupDiskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CleanupDiskResponse.ProtoReflect.Descriptor instead.
 func (*CleanupDiskResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{34}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *CleanupDiskResponse) GetMessage() string {
@@ -2668,7 +2786,7 @@ type InstallStackRequest struct {
 
 func (x *InstallStackRequest) Reset() {
 	*x = InstallStackRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[35]
+	mi := &file_containarium_v1_container_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2680,7 +2798,7 @@ func (x *InstallStackRequest) String() string {
 func (*InstallStackRequest) ProtoMessage() {}
 
 func (x *InstallStackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[35]
+	mi := &file_containarium_v1_container_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2693,7 +2811,7 @@ func (x *InstallStackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InstallStackRequest.ProtoReflect.Descriptor instead.
 func (*InstallStackRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{35}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *InstallStackRequest) GetUsername() string {
@@ -2723,7 +2841,7 @@ type InstallStackResponse struct {
 
 func (x *InstallStackResponse) Reset() {
 	*x = InstallStackResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[36]
+	mi := &file_containarium_v1_container_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2735,7 +2853,7 @@ func (x *InstallStackResponse) String() string {
 func (*InstallStackResponse) ProtoMessage() {}
 
 func (x *InstallStackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[36]
+	mi := &file_containarium_v1_container_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2748,7 +2866,7 @@ func (x *InstallStackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InstallStackResponse.ProtoReflect.Descriptor instead.
 func (*InstallStackResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{36}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *InstallStackResponse) GetMessage() string {
@@ -2788,7 +2906,7 @@ type StackParameter struct {
 
 func (x *StackParameter) Reset() {
 	*x = StackParameter{}
-	mi := &file_containarium_v1_container_proto_msgTypes[37]
+	mi := &file_containarium_v1_container_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2800,7 +2918,7 @@ func (x *StackParameter) String() string {
 func (*StackParameter) ProtoMessage() {}
 
 func (x *StackParameter) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[37]
+	mi := &file_containarium_v1_container_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2813,7 +2931,7 @@ func (x *StackParameter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StackParameter.ProtoReflect.Descriptor instead.
 func (*StackParameter) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{37}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *StackParameter) GetName() string {
@@ -2872,7 +2990,7 @@ type StackInfo struct {
 
 func (x *StackInfo) Reset() {
 	*x = StackInfo{}
-	mi := &file_containarium_v1_container_proto_msgTypes[38]
+	mi := &file_containarium_v1_container_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2884,7 +3002,7 @@ func (x *StackInfo) String() string {
 func (*StackInfo) ProtoMessage() {}
 
 func (x *StackInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[38]
+	mi := &file_containarium_v1_container_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2897,7 +3015,7 @@ func (x *StackInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StackInfo.ProtoReflect.Descriptor instead.
 func (*StackInfo) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{38}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *StackInfo) GetId() string {
@@ -2944,7 +3062,7 @@ type ListStacksRequest struct {
 
 func (x *ListStacksRequest) Reset() {
 	*x = ListStacksRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[39]
+	mi := &file_containarium_v1_container_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2956,7 +3074,7 @@ func (x *ListStacksRequest) String() string {
 func (*ListStacksRequest) ProtoMessage() {}
 
 func (x *ListStacksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[39]
+	mi := &file_containarium_v1_container_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2969,7 +3087,7 @@ func (x *ListStacksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStacksRequest.ProtoReflect.Descriptor instead.
 func (*ListStacksRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{39}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{41}
 }
 
 // ListStacksResponse returns all configured software stacks.
@@ -2982,7 +3100,7 @@ type ListStacksResponse struct {
 
 func (x *ListStacksResponse) Reset() {
 	*x = ListStacksResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[40]
+	mi := &file_containarium_v1_container_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2994,7 +3112,7 @@ func (x *ListStacksResponse) String() string {
 func (*ListStacksResponse) ProtoMessage() {}
 
 func (x *ListStacksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[40]
+	mi := &file_containarium_v1_container_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3007,7 +3125,7 @@ func (x *ListStacksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStacksResponse.ProtoReflect.Descriptor instead.
 func (*ListStacksResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{40}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ListStacksResponse) GetStacks() []*StackInfo {
@@ -3026,7 +3144,7 @@ type GetMonitoringInfoRequest struct {
 
 func (x *GetMonitoringInfoRequest) Reset() {
 	*x = GetMonitoringInfoRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[41]
+	mi := &file_containarium_v1_container_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3038,7 +3156,7 @@ func (x *GetMonitoringInfoRequest) String() string {
 func (*GetMonitoringInfoRequest) ProtoMessage() {}
 
 func (x *GetMonitoringInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[41]
+	mi := &file_containarium_v1_container_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3051,7 +3169,7 @@ func (x *GetMonitoringInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMonitoringInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetMonitoringInfoRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{41}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{43}
 }
 
 // GetMonitoringInfoResponse is the response with monitoring configuration
@@ -3069,7 +3187,7 @@ type GetMonitoringInfoResponse struct {
 
 func (x *GetMonitoringInfoResponse) Reset() {
 	*x = GetMonitoringInfoResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[42]
+	mi := &file_containarium_v1_container_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3081,7 +3199,7 @@ func (x *GetMonitoringInfoResponse) String() string {
 func (*GetMonitoringInfoResponse) ProtoMessage() {}
 
 func (x *GetMonitoringInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[42]
+	mi := &file_containarium_v1_container_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3094,7 +3212,7 @@ func (x *GetMonitoringInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMonitoringInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetMonitoringInfoResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{42}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *GetMonitoringInfoResponse) GetEnabled() bool {
@@ -3153,7 +3271,7 @@ type MoveContainerRequest struct {
 
 func (x *MoveContainerRequest) Reset() {
 	*x = MoveContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[43]
+	mi := &file_containarium_v1_container_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3165,7 +3283,7 @@ func (x *MoveContainerRequest) String() string {
 func (*MoveContainerRequest) ProtoMessage() {}
 
 func (x *MoveContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[43]
+	mi := &file_containarium_v1_container_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3178,7 +3296,7 @@ func (x *MoveContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MoveContainerRequest.ProtoReflect.Descriptor instead.
 func (*MoveContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{43}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *MoveContainerRequest) GetUsername() string {
@@ -3241,7 +3359,7 @@ type MoveContainerResponse struct {
 
 func (x *MoveContainerResponse) Reset() {
 	*x = MoveContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[44]
+	mi := &file_containarium_v1_container_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3253,7 +3371,7 @@ func (x *MoveContainerResponse) String() string {
 func (*MoveContainerResponse) ProtoMessage() {}
 
 func (x *MoveContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[44]
+	mi := &file_containarium_v1_container_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3266,7 +3384,7 @@ func (x *MoveContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MoveContainerResponse.ProtoReflect.Descriptor instead.
 func (*MoveContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{44}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *MoveContainerResponse) GetMessage() string {
@@ -3327,7 +3445,7 @@ type AdoptMigratedContainerRequest struct {
 
 func (x *AdoptMigratedContainerRequest) Reset() {
 	*x = AdoptMigratedContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[45]
+	mi := &file_containarium_v1_container_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3339,7 +3457,7 @@ func (x *AdoptMigratedContainerRequest) String() string {
 func (*AdoptMigratedContainerRequest) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[45]
+	mi := &file_containarium_v1_container_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3352,7 +3470,7 @@ func (x *AdoptMigratedContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerRequest.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{45}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *AdoptMigratedContainerRequest) GetUsername() string {
@@ -3384,7 +3502,7 @@ type AdoptMigratedContainerResponse struct {
 
 func (x *AdoptMigratedContainerResponse) Reset() {
 	*x = AdoptMigratedContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[46]
+	mi := &file_containarium_v1_container_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3396,7 +3514,7 @@ func (x *AdoptMigratedContainerResponse) String() string {
 func (*AdoptMigratedContainerResponse) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[46]
+	mi := &file_containarium_v1_container_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3409,7 +3527,7 @@ func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerResponse.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{46}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *AdoptMigratedContainerResponse) GetMessage() string {
@@ -3578,7 +3696,13 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\atimeout\x18\x03 \x01(\x05R\atimeout\"k\n" +
 	"\x15StopContainerResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x128\n" +
-	"\tcontainer\x18\x02 \x01(\v2\x1a.containarium.v1.ContainerR\tcontainer\"T\n" +
+	"\tcontainer\x18\x02 \x01(\v2\x1a.containarium.v1.ContainerR\tcontainer\"O\n" +
+	"\x17ToggleMonitoringRequest\x12\x1a\n" +
+	"\busername\x18\x01 \x01(\tR\busername\x12\x18\n" +
+	"\aenabled\x18\x02 \x01(\bR\aenabled\"c\n" +
+	"\x18ToggleMonitoringResponse\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x12-\n" +
+	"\x12monitoring_enabled\x18\x02 \x01(\bR\x11monitoringEnabled\"T\n" +
 	"\x10AddSSHKeyRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12$\n" +
 	"\x0essh_public_key\x18\x02 \x01(\tR\fsshPublicKey\"L\n" +
@@ -3731,7 +3855,7 @@ func file_containarium_v1_container_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
+var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
 var file_containarium_v1_container_proto_goTypes = []any{
 	(OSType)(0),                            // 0: containarium.v1.OSType
 	(AccessType)(0),                        // 1: containarium.v1.AccessType
@@ -3754,55 +3878,57 @@ var file_containarium_v1_container_proto_goTypes = []any{
 	(*StartContainerResponse)(nil),         // 18: containarium.v1.StartContainerResponse
 	(*StopContainerRequest)(nil),           // 19: containarium.v1.StopContainerRequest
 	(*StopContainerResponse)(nil),          // 20: containarium.v1.StopContainerResponse
-	(*AddSSHKeyRequest)(nil),               // 21: containarium.v1.AddSSHKeyRequest
-	(*AddSSHKeyResponse)(nil),              // 22: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyRequest)(nil),            // 23: containarium.v1.RemoveSSHKeyRequest
-	(*RemoveSSHKeyResponse)(nil),           // 24: containarium.v1.RemoveSSHKeyResponse
-	(*GetMetricsRequest)(nil),              // 25: containarium.v1.GetMetricsRequest
-	(*GetMetricsResponse)(nil),             // 26: containarium.v1.GetMetricsResponse
-	(*ResizeContainerRequest)(nil),         // 27: containarium.v1.ResizeContainerRequest
-	(*ResizeContainerResponse)(nil),        // 28: containarium.v1.ResizeContainerResponse
-	(*Collaborator)(nil),                   // 29: containarium.v1.Collaborator
-	(*AddCollaboratorRequest)(nil),         // 30: containarium.v1.AddCollaboratorRequest
-	(*AddCollaboratorResponse)(nil),        // 31: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorRequest)(nil),      // 32: containarium.v1.RemoveCollaboratorRequest
-	(*RemoveCollaboratorResponse)(nil),     // 33: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsRequest)(nil),       // 34: containarium.v1.ListCollaboratorsRequest
-	(*ListCollaboratorsResponse)(nil),      // 35: containarium.v1.ListCollaboratorsResponse
-	(*CleanupDiskRequest)(nil),             // 36: containarium.v1.CleanupDiskRequest
-	(*CleanupDiskResponse)(nil),            // 37: containarium.v1.CleanupDiskResponse
-	(*InstallStackRequest)(nil),            // 38: containarium.v1.InstallStackRequest
-	(*InstallStackResponse)(nil),           // 39: containarium.v1.InstallStackResponse
-	(*StackParameter)(nil),                 // 40: containarium.v1.StackParameter
-	(*StackInfo)(nil),                      // 41: containarium.v1.StackInfo
-	(*ListStacksRequest)(nil),              // 42: containarium.v1.ListStacksRequest
-	(*ListStacksResponse)(nil),             // 43: containarium.v1.ListStacksResponse
-	(*GetMonitoringInfoRequest)(nil),       // 44: containarium.v1.GetMonitoringInfoRequest
-	(*GetMonitoringInfoResponse)(nil),      // 45: containarium.v1.GetMonitoringInfoResponse
-	(*MoveContainerRequest)(nil),           // 46: containarium.v1.MoveContainerRequest
-	(*MoveContainerResponse)(nil),          // 47: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerRequest)(nil),  // 48: containarium.v1.AdoptMigratedContainerRequest
-	(*AdoptMigratedContainerResponse)(nil), // 49: containarium.v1.AdoptMigratedContainerResponse
-	nil,                                    // 50: containarium.v1.Container.LabelsEntry
-	nil,                                    // 51: containarium.v1.CreateContainerRequest.LabelsEntry
-	nil,                                    // 52: containarium.v1.CreateContainerRequest.StackParametersEntry
-	nil,                                    // 53: containarium.v1.ListContainersRequest.LabelFilterEntry
-	(*descriptorpb.EnumValueOptions)(nil),  // 54: google.protobuf.EnumValueOptions
+	(*ToggleMonitoringRequest)(nil),        // 21: containarium.v1.ToggleMonitoringRequest
+	(*ToggleMonitoringResponse)(nil),       // 22: containarium.v1.ToggleMonitoringResponse
+	(*AddSSHKeyRequest)(nil),               // 23: containarium.v1.AddSSHKeyRequest
+	(*AddSSHKeyResponse)(nil),              // 24: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyRequest)(nil),            // 25: containarium.v1.RemoveSSHKeyRequest
+	(*RemoveSSHKeyResponse)(nil),           // 26: containarium.v1.RemoveSSHKeyResponse
+	(*GetMetricsRequest)(nil),              // 27: containarium.v1.GetMetricsRequest
+	(*GetMetricsResponse)(nil),             // 28: containarium.v1.GetMetricsResponse
+	(*ResizeContainerRequest)(nil),         // 29: containarium.v1.ResizeContainerRequest
+	(*ResizeContainerResponse)(nil),        // 30: containarium.v1.ResizeContainerResponse
+	(*Collaborator)(nil),                   // 31: containarium.v1.Collaborator
+	(*AddCollaboratorRequest)(nil),         // 32: containarium.v1.AddCollaboratorRequest
+	(*AddCollaboratorResponse)(nil),        // 33: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorRequest)(nil),      // 34: containarium.v1.RemoveCollaboratorRequest
+	(*RemoveCollaboratorResponse)(nil),     // 35: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsRequest)(nil),       // 36: containarium.v1.ListCollaboratorsRequest
+	(*ListCollaboratorsResponse)(nil),      // 37: containarium.v1.ListCollaboratorsResponse
+	(*CleanupDiskRequest)(nil),             // 38: containarium.v1.CleanupDiskRequest
+	(*CleanupDiskResponse)(nil),            // 39: containarium.v1.CleanupDiskResponse
+	(*InstallStackRequest)(nil),            // 40: containarium.v1.InstallStackRequest
+	(*InstallStackResponse)(nil),           // 41: containarium.v1.InstallStackResponse
+	(*StackParameter)(nil),                 // 42: containarium.v1.StackParameter
+	(*StackInfo)(nil),                      // 43: containarium.v1.StackInfo
+	(*ListStacksRequest)(nil),              // 44: containarium.v1.ListStacksRequest
+	(*ListStacksResponse)(nil),             // 45: containarium.v1.ListStacksResponse
+	(*GetMonitoringInfoRequest)(nil),       // 46: containarium.v1.GetMonitoringInfoRequest
+	(*GetMonitoringInfoResponse)(nil),      // 47: containarium.v1.GetMonitoringInfoResponse
+	(*MoveContainerRequest)(nil),           // 48: containarium.v1.MoveContainerRequest
+	(*MoveContainerResponse)(nil),          // 49: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerRequest)(nil),  // 50: containarium.v1.AdoptMigratedContainerRequest
+	(*AdoptMigratedContainerResponse)(nil), // 51: containarium.v1.AdoptMigratedContainerResponse
+	nil,                                    // 52: containarium.v1.Container.LabelsEntry
+	nil,                                    // 53: containarium.v1.CreateContainerRequest.LabelsEntry
+	nil,                                    // 54: containarium.v1.CreateContainerRequest.StackParametersEntry
+	nil,                                    // 55: containarium.v1.ListContainersRequest.LabelFilterEntry
+	(*descriptorpb.EnumValueOptions)(nil),  // 56: google.protobuf.EnumValueOptions
 }
 var file_containarium_v1_container_proto_depIdxs = []int32{
 	2,  // 0: containarium.v1.Container.state:type_name -> containarium.v1.ContainerState
 	3,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
 	4,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
-	50, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
+	52, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
 	0,  // 4: containarium.v1.Container.os_type:type_name -> containarium.v1.OSType
 	1,  // 5: containarium.v1.Container.access_type:type_name -> containarium.v1.AccessType
 	3,  // 6: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
-	51, // 7: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
+	53, // 7: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
 	0,  // 8: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
-	52, // 9: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
+	54, // 9: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
 	5,  // 10: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
 	2,  // 11: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
-	53, // 12: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
+	55, // 12: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
 	5,  // 13: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
 	5,  // 14: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
 	6,  // 15: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
@@ -3810,13 +3936,13 @@ var file_containarium_v1_container_proto_depIdxs = []int32{
 	5,  // 17: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
 	6,  // 18: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	5,  // 19: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
-	29, // 20: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
-	29, // 21: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
+	31, // 20: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
+	31, // 21: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
 	5,  // 22: containarium.v1.CleanupDiskResponse.container:type_name -> containarium.v1.Container
 	5,  // 23: containarium.v1.InstallStackResponse.container:type_name -> containarium.v1.Container
-	40, // 24: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
-	41, // 25: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
-	54, // 26: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
+	42, // 24: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
+	43, // 25: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
+	56, // 26: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
 	27, // [27:27] is the sub-list for method output_type
 	27, // [27:27] is the sub-list for method input_type
 	27, // [27:27] is the sub-list for extension type_name
@@ -3835,7 +3961,7 @@ func file_containarium_v1_container_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_container_proto_rawDesc), len(file_containarium_v1_container_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   51,
+			NumMessages:   53,
 			NumExtensions: 1,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xe3J\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xbcN\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -52,7 +52,9 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\rMoveContainer\x12%.containarium.v1.MoveContainerRequest\x1a&.containarium.v1.MoveContainerResponse\"\xe7\x02\x92A\xba\x02\n" +
 	"\x14Container Operations\x12 Migrate container to peer daemon\x1a\xff\x01Pre-copy snapshot-based migration to a peer daemon. Sub-second downtime on ZFS/btrfs storage with low write rate; up to minutes on dir-pool or active workloads. Caller must have incus remotes configured both directions between the source and target hosts.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/containers/{username}/move\x12\xdc\x03\n" +
 	"\x16AdoptMigratedContainer\x12..containarium.v1.AdoptMigratedContainerRequest\x1a/.containarium.v1.AdoptMigratedContainerResponse\"\xe0\x02\x92A\xb2\x02\n" +
-	"\x14Container Operations\x12%Adopt a migrated container (internal)\x1a\xf2\x01Called by the source daemon during MoveContainer after the LXC has been Incus-copied to this host. Registers the container's host-side accounts and route record so it's fully under Containarium's control. Not intended for direct operator use.\x82\xd3\xe4\x93\x02$:\x01*\"\x1f/v1/containers/{username}/adopt\x12\x9a\x02\n" +
+	"\x14Container Operations\x12%Adopt a migrated container (internal)\x1a\xf2\x01Called by the source daemon during MoveContainer after the LXC has been Incus-copied to this host. Registers the container's host-side accounts and route record so it's fully under Containarium's control. Not intended for direct operator use.\x82\xd3\xe4\x93\x02$:\x01*\"\x1f/v1/containers/{username}/adopt\x12\xd6\x03\n" +
+	"\x10ToggleMonitoring\x12(.containarium.v1.ToggleMonitoringRequest\x1a).containarium.v1.ToggleMonitoringResponse\"\xec\x02\x92A\xb9\x02\n" +
+	"\x14Container Operations\x120Enable or disable OTel monitoring on a container\x1a\xee\x01Live-flip OTEL_EXPORTER_OTLP_ENDPOINT and related env vars on an existing container and restart it so the change reaches the app. Use this to retrofit monitoring onto containers created before --monitoring was wired into create_container.\x82\xd3\xe4\x93\x02):\x01*\"$/v1/containers/{username}/monitoring\x12\x9a\x02\n" +
 	"\tAddSSHKey\x12!.containarium.v1.AddSSHKeyRequest\x1a\".containarium.v1.AddSSHKeyResponse\"\xc5\x01\x92A\x94\x01\n" +
 	"\x0eSSH Management\x12\vAdd SSH key\x1auAdds an SSH public key to a container's authorized_keys file, allowing SSH access with the corresponding private key.\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/containers/{username}/ssh-keys\x12\xce\x02\n" +
 	"\fRemoveSSHKey\x12$.containarium.v1.RemoveSSHKeyRequest\x1a%.containarium.v1.RemoveSSHKeyResponse\"\xf0\x01\x92A\xb1\x01\n" +
@@ -123,58 +125,60 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*ResizeContainerRequest)(nil),         // 7: containarium.v1.ResizeContainerRequest
 	(*MoveContainerRequest)(nil),           // 8: containarium.v1.MoveContainerRequest
 	(*AdoptMigratedContainerRequest)(nil),  // 9: containarium.v1.AdoptMigratedContainerRequest
-	(*AddSSHKeyRequest)(nil),               // 10: containarium.v1.AddSSHKeyRequest
-	(*RemoveSSHKeyRequest)(nil),            // 11: containarium.v1.RemoveSSHKeyRequest
-	(*AddCollaboratorRequest)(nil),         // 12: containarium.v1.AddCollaboratorRequest
-	(*RemoveCollaboratorRequest)(nil),      // 13: containarium.v1.RemoveCollaboratorRequest
-	(*ListCollaboratorsRequest)(nil),       // 14: containarium.v1.ListCollaboratorsRequest
-	(*GetMetricsRequest)(nil),              // 15: containarium.v1.GetMetricsRequest
-	(*CleanupDiskRequest)(nil),             // 16: containarium.v1.CleanupDiskRequest
-	(*InstallStackRequest)(nil),            // 17: containarium.v1.InstallStackRequest
-	(*ListStacksRequest)(nil),              // 18: containarium.v1.ListStacksRequest
-	(*GetSystemInfoRequest)(nil),           // 19: containarium.v1.GetSystemInfoRequest
-	(*GetMonitoringInfoRequest)(nil),       // 20: containarium.v1.GetMonitoringInfoRequest
-	(*CreateAlertRuleRequest)(nil),         // 21: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),          // 22: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),            // 23: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),         // 24: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),         // 25: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),         // 26: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),   // 27: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),    // 28: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),             // 29: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),   // 30: containarium.v1.ListWebhookDeliveriesRequest
-	(*CreateContainerResponse)(nil),        // 31: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),         // 32: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),           // 33: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),         // 34: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),        // 35: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),         // 36: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),          // 37: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),        // 38: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),          // 39: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerResponse)(nil), // 40: containarium.v1.AdoptMigratedContainerResponse
-	(*AddSSHKeyResponse)(nil),              // 41: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),           // 42: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),        // 43: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),     // 44: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),      // 45: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),             // 46: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),            // 47: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),           // 48: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),             // 49: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),          // 50: containarium.v1.GetSystemInfoResponse
-	(*GetMonitoringInfoResponse)(nil),      // 51: containarium.v1.GetMonitoringInfoResponse
-	(*CreateAlertRuleResponse)(nil),        // 52: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),         // 53: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),           // 54: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),        // 55: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),        // 56: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),        // 57: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),  // 58: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),   // 59: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),            // 60: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),  // 61: containarium.v1.ListWebhookDeliveriesResponse
+	(*ToggleMonitoringRequest)(nil),        // 10: containarium.v1.ToggleMonitoringRequest
+	(*AddSSHKeyRequest)(nil),               // 11: containarium.v1.AddSSHKeyRequest
+	(*RemoveSSHKeyRequest)(nil),            // 12: containarium.v1.RemoveSSHKeyRequest
+	(*AddCollaboratorRequest)(nil),         // 13: containarium.v1.AddCollaboratorRequest
+	(*RemoveCollaboratorRequest)(nil),      // 14: containarium.v1.RemoveCollaboratorRequest
+	(*ListCollaboratorsRequest)(nil),       // 15: containarium.v1.ListCollaboratorsRequest
+	(*GetMetricsRequest)(nil),              // 16: containarium.v1.GetMetricsRequest
+	(*CleanupDiskRequest)(nil),             // 17: containarium.v1.CleanupDiskRequest
+	(*InstallStackRequest)(nil),            // 18: containarium.v1.InstallStackRequest
+	(*ListStacksRequest)(nil),              // 19: containarium.v1.ListStacksRequest
+	(*GetSystemInfoRequest)(nil),           // 20: containarium.v1.GetSystemInfoRequest
+	(*GetMonitoringInfoRequest)(nil),       // 21: containarium.v1.GetMonitoringInfoRequest
+	(*CreateAlertRuleRequest)(nil),         // 22: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),          // 23: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),            // 24: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),         // 25: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),         // 26: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),         // 27: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),   // 28: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),    // 29: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),             // 30: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),   // 31: containarium.v1.ListWebhookDeliveriesRequest
+	(*CreateContainerResponse)(nil),        // 32: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),         // 33: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),           // 34: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),         // 35: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),        // 36: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),         // 37: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),          // 38: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),        // 39: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),          // 40: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerResponse)(nil), // 41: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),       // 42: containarium.v1.ToggleMonitoringResponse
+	(*AddSSHKeyResponse)(nil),              // 43: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),           // 44: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),        // 45: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),     // 46: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),      // 47: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),             // 48: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),            // 49: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),           // 50: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),             // 51: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),          // 52: containarium.v1.GetSystemInfoResponse
+	(*GetMonitoringInfoResponse)(nil),      // 53: containarium.v1.GetMonitoringInfoResponse
+	(*CreateAlertRuleResponse)(nil),        // 54: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),         // 55: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),           // 56: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),        // 57: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),        // 58: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),        // 59: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),  // 60: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),   // 61: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),            // 62: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),  // 63: containarium.v1.ListWebhookDeliveriesResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -187,60 +191,62 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	7,  // 7: containarium.v1.ContainerService.ResizeContainer:input_type -> containarium.v1.ResizeContainerRequest
 	8,  // 8: containarium.v1.ContainerService.MoveContainer:input_type -> containarium.v1.MoveContainerRequest
 	9,  // 9: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
-	10, // 10: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
-	11, // 11: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
-	12, // 12: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
-	13, // 13: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
-	14, // 14: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
-	15, // 15: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
-	16, // 16: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
-	17, // 17: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
-	18, // 18: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
-	19, // 19: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
-	20, // 20: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	21, // 21: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	22, // 22: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	23, // 23: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	24, // 24: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	25, // 25: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	26, // 26: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	27, // 27: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	28, // 28: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	29, // 29: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	30, // 30: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	31, // 31: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	32, // 32: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	33, // 33: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	34, // 34: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	35, // 35: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	36, // 36: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	37, // 37: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	38, // 38: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	39, // 39: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	40, // 40: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	41, // 41: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	42, // 42: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	43, // 43: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	44, // 44: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	45, // 45: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	46, // 46: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	47, // 47: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	48, // 48: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	49, // 49: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	50, // 50: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	51, // 51: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	52, // 52: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	53, // 53: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	54, // 54: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	55, // 55: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	56, // 56: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	57, // 57: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	58, // 58: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	59, // 59: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	60, // 60: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	61, // 61: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	31, // [31:62] is the sub-list for method output_type
-	0,  // [0:31] is the sub-list for method input_type
+	10, // 10: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
+	11, // 11: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
+	12, // 12: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
+	13, // 13: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
+	14, // 14: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
+	15, // 15: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
+	16, // 16: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
+	17, // 17: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
+	18, // 18: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
+	19, // 19: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
+	20, // 20: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
+	21, // 21: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	22, // 22: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	23, // 23: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	24, // 24: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	25, // 25: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	26, // 26: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	27, // 27: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	28, // 28: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	29, // 29: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	30, // 30: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	31, // 31: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	32, // 32: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	33, // 33: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	34, // 34: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	35, // 35: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	36, // 36: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	37, // 37: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	38, // 38: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	39, // 39: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	40, // 40: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	41, // 41: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	42, // 42: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	43, // 43: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	44, // 44: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	45, // 45: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	46, // 46: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	47, // 47: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	48, // 48: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	49, // 49: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	50, // 50: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	51, // 51: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	52, // 52: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	53, // 53: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	54, // 54: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	55, // 55: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	56, // 56: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	57, // 57: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	58, // 58: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	59, // 59: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	60, // 60: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	61, // 61: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	62, // 62: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	63, // 63: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	32, // [32:64] is the sub-list for method output_type
+	0,  // [0:32] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -453,6 +453,51 @@ func local_request_ContainerService_AdoptMigratedContainer_0(ctx context.Context
 	return msg, metadata, err
 }
 
+func request_ContainerService_ToggleMonitoring_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ToggleMonitoringRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	msg, err := client.ToggleMonitoring(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_ToggleMonitoring_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ToggleMonitoringRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	msg, err := server.ToggleMonitoring(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_AddSSHKey_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq AddSSHKeyRequest
@@ -1427,6 +1472,26 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_AdoptMigratedContainer_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_ToggleMonitoring_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/ToggleMonitoring", runtime.WithHTTPPathPattern("/v1/containers/{username}/monitoring"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_ToggleMonitoring_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_ToggleMonitoring_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_AddSSHKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2077,6 +2142,23 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_AdoptMigratedContainer_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_ToggleMonitoring_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/ToggleMonitoring", runtime.WithHTTPPathPattern("/v1/containers/{username}/monitoring"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_ToggleMonitoring_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_ToggleMonitoring_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_AddSSHKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2465,6 +2547,7 @@ var (
 	pattern_ContainerService_ResizeContainer_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "resize"}, ""))
 	pattern_ContainerService_MoveContainer_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "move"}, ""))
 	pattern_ContainerService_AdoptMigratedContainer_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "adopt"}, ""))
+	pattern_ContainerService_ToggleMonitoring_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "monitoring"}, ""))
 	pattern_ContainerService_AddSSHKey_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "ssh-keys"}, ""))
 	pattern_ContainerService_RemoveSSHKey_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"v1", "containers", "username", "ssh-keys", "ssh_public_key"}, ""))
 	pattern_ContainerService_AddCollaborator_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "owner_username", "collaborators"}, ""))
@@ -2500,6 +2583,7 @@ var (
 	forward_ContainerService_ResizeContainer_0        = runtime.ForwardResponseMessage
 	forward_ContainerService_MoveContainer_0          = runtime.ForwardResponseMessage
 	forward_ContainerService_AdoptMigratedContainer_0 = runtime.ForwardResponseMessage
+	forward_ContainerService_ToggleMonitoring_0       = runtime.ForwardResponseMessage
 	forward_ContainerService_AddSSHKey_0              = runtime.ForwardResponseMessage
 	forward_ContainerService_RemoveSSHKey_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_AddCollaborator_0        = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -29,6 +29,7 @@ const (
 	ContainerService_ResizeContainer_FullMethodName        = "/containarium.v1.ContainerService/ResizeContainer"
 	ContainerService_MoveContainer_FullMethodName          = "/containarium.v1.ContainerService/MoveContainer"
 	ContainerService_AdoptMigratedContainer_FullMethodName = "/containarium.v1.ContainerService/AdoptMigratedContainer"
+	ContainerService_ToggleMonitoring_FullMethodName       = "/containarium.v1.ContainerService/ToggleMonitoring"
 	ContainerService_AddSSHKey_FullMethodName              = "/containarium.v1.ContainerService/AddSSHKey"
 	ContainerService_RemoveSSHKey_FullMethodName           = "/containarium.v1.ContainerService/RemoveSSHKey"
 	ContainerService_AddCollaborator_FullMethodName        = "/containarium.v1.ContainerService/AddCollaborator"
@@ -92,6 +93,18 @@ type ContainerServiceClient interface {
 	// container's new local IP for the caller to wire into the route
 	// store cutover. Internal use only — operators don't call this.
 	AdoptMigratedContainer(ctx context.Context, in *AdoptMigratedContainerRequest, opts ...grpc.CallOption) (*AdoptMigratedContainerResponse, error)
+	// ToggleMonitoring enables or disables application-emitted OTel
+	// on an existing container without recreate. When enabling, the
+	// daemon stamps OTEL_EXPORTER_OTLP_ENDPOINT and related env vars
+	// pointing at this VM's core OTel collector LXC, then restarts
+	// the container so the new env reaches the app process. When
+	// disabling, the four OTEL_* env vars are unset and the container
+	// is restarted so the SDK falls back to its built-in "no endpoint,
+	// buffer + drop" behavior. Requires the daemon to be wired with
+	// a collector endpoint (--otel-collector-endpoint or auto-ensured
+	// core collector); without one, enabling fails with
+	// FAILED_PRECONDITION rather than silently writing dead env vars.
+	ToggleMonitoring(ctx context.Context, in *ToggleMonitoringRequest, opts ...grpc.CallOption) (*ToggleMonitoringResponse, error)
 	// AddSSHKey adds an SSH public key to a container
 	AddSSHKey(ctx context.Context, in *AddSSHKeyRequest, opts ...grpc.CallOption) (*AddSSHKeyResponse, error)
 	// RemoveSSHKey removes an SSH public key from a container
@@ -240,6 +253,16 @@ func (c *containerServiceClient) AdoptMigratedContainer(ctx context.Context, in 
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(AdoptMigratedContainerResponse)
 	err := c.cc.Invoke(ctx, ContainerService_AdoptMigratedContainer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) ToggleMonitoring(ctx context.Context, in *ToggleMonitoringRequest, opts ...grpc.CallOption) (*ToggleMonitoringResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ToggleMonitoringResponse)
+	err := c.cc.Invoke(ctx, ContainerService_ToggleMonitoring_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -496,6 +519,18 @@ type ContainerServiceServer interface {
 	// container's new local IP for the caller to wire into the route
 	// store cutover. Internal use only — operators don't call this.
 	AdoptMigratedContainer(context.Context, *AdoptMigratedContainerRequest) (*AdoptMigratedContainerResponse, error)
+	// ToggleMonitoring enables or disables application-emitted OTel
+	// on an existing container without recreate. When enabling, the
+	// daemon stamps OTEL_EXPORTER_OTLP_ENDPOINT and related env vars
+	// pointing at this VM's core OTel collector LXC, then restarts
+	// the container so the new env reaches the app process. When
+	// disabling, the four OTEL_* env vars are unset and the container
+	// is restarted so the SDK falls back to its built-in "no endpoint,
+	// buffer + drop" behavior. Requires the daemon to be wired with
+	// a collector endpoint (--otel-collector-endpoint or auto-ensured
+	// core collector); without one, enabling fails with
+	// FAILED_PRECONDITION rather than silently writing dead env vars.
+	ToggleMonitoring(context.Context, *ToggleMonitoringRequest) (*ToggleMonitoringResponse, error)
 	// AddSSHKey adds an SSH public key to a container
 	AddSSHKey(context.Context, *AddSSHKeyRequest) (*AddSSHKeyResponse, error)
 	// RemoveSSHKey removes an SSH public key from a container
@@ -579,6 +614,9 @@ func (UnimplementedContainerServiceServer) MoveContainer(context.Context, *MoveC
 }
 func (UnimplementedContainerServiceServer) AdoptMigratedContainer(context.Context, *AdoptMigratedContainerRequest) (*AdoptMigratedContainerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AdoptMigratedContainer not implemented")
+}
+func (UnimplementedContainerServiceServer) ToggleMonitoring(context.Context, *ToggleMonitoringRequest) (*ToggleMonitoringResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ToggleMonitoring not implemented")
 }
 func (UnimplementedContainerServiceServer) AddSSHKey(context.Context, *AddSSHKeyRequest) (*AddSSHKeyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddSSHKey not implemented")
@@ -840,6 +878,24 @@ func _ContainerService_AdoptMigratedContainer_Handler(srv interface{}, ctx conte
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ContainerServiceServer).AdoptMigratedContainer(ctx, req.(*AdoptMigratedContainerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_ToggleMonitoring_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ToggleMonitoringRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).ToggleMonitoring(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_ToggleMonitoring_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).ToggleMonitoring(ctx, req.(*ToggleMonitoringRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1268,6 +1324,10 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AdoptMigratedContainer",
 			Handler:    _ContainerService_AdoptMigratedContainer_Handler,
+		},
+		{
+			MethodName: "ToggleMonitoring",
+			Handler:    _ContainerService_ToggleMonitoring_Handler,
 		},
 		{
 			MethodName: "AddSSHKey",

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -386,6 +386,32 @@ message StopContainerResponse {
   Container container = 2;
 }
 
+// ToggleMonitoringRequest enables / disables OTel app telemetry on
+// an existing container. The four OTEL_* env vars are stamped (or
+// unset) and the container is restarted so the new env reaches the
+// app process.
+message ToggleMonitoringRequest {
+  // Username of the container.
+  string username = 1;
+
+  // Desired state. true → stamp env vars + restart. false → unset
+  // env vars + restart so the SDK falls back to its buffer+drop
+  // default.
+  bool enabled = 2;
+}
+
+// ToggleMonitoringResponse reports the new monitoring state.
+message ToggleMonitoringResponse {
+  // Operator-facing summary of what changed (e.g. "monitoring
+  // enabled — container restarted").
+  string message = 1;
+
+  // The effective monitoring_enabled state of the container after
+  // the toggle (mirrors Container.monitoring_enabled in subsequent
+  // GetContainer responses).
+  bool monitoring_enabled = 2;
+}
+
 // AddSSHKeyRequest is the request to add an SSH key to a container
 message AddSSHKeyRequest {
   // Username of the container

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -191,6 +191,29 @@ service ContainerService {
     };
   }
 
+  // ToggleMonitoring enables or disables application-emitted OTel
+  // on an existing container without recreate. When enabling, the
+  // daemon stamps OTEL_EXPORTER_OTLP_ENDPOINT and related env vars
+  // pointing at this VM's core OTel collector LXC, then restarts
+  // the container so the new env reaches the app process. When
+  // disabling, the four OTEL_* env vars are unset and the container
+  // is restarted so the SDK falls back to its built-in "no endpoint,
+  // buffer + drop" behavior. Requires the daemon to be wired with
+  // a collector endpoint (--otel-collector-endpoint or auto-ensured
+  // core collector); without one, enabling fails with
+  // FAILED_PRECONDITION rather than silently writing dead env vars.
+  rpc ToggleMonitoring(ToggleMonitoringRequest) returns (ToggleMonitoringResponse) {
+    option (google.api.http) = {
+      post: "/v1/containers/{username}/monitoring"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Enable or disable OTel monitoring on a container";
+      description: "Live-flip OTEL_EXPORTER_OTLP_ENDPOINT and related env vars on an existing container and restart it so the change reaches the app. Use this to retrofit monitoring onto containers created before --monitoring was wired into create_container.";
+      tags: "Container Operations";
+    };
+  }
+
   // AddSSHKey adds an SSH public key to a container
   rpc AddSSHKey(AddSSHKeyRequest) returns (AddSSHKeyResponse) {
     option (google.api.http) = {


### PR DESCRIPTION
## Summary

Closes the v2 TODO from the [approved OTel design](https://github.com/FootprintAI/Containarium/blob/main/docs/OTEL-COLLECTOR-DESIGN.md): a new RPC + CLI + MCP tool that flips application-emitted OTel on an existing container without recreate.

### Usage

**CLI:**
```bash
containarium monitoring enable alice --server addr:port
containarium monitoring disable alice --server addr:port
```

**REST:** `POST /v1/containers/{username}/monitoring  {"enabled": true|false}`

**MCP:** `toggle_monitoring(username, enabled)`

### What the server does

- **Enable**: requires `--otel-collector-endpoint` (auto-wired when VictoriaMetrics is up). Stamps the four `OTEL_*` env vars onto the LXC's Incus config, stops the container, starts it back up so the new env reaches the app process. Refreshes the collector's IP map.
- **Disable**: deletes the four `OTEL_*` env keys from the LXC's Incus config (the new `UnsetEnv` path — keys are removed entirely, not set to empty, because some OTel SDKs treat empty `OTEL_EXPORTER_OTLP_ENDPOINT` as misconfig). Stop + start. Refresh IP map.
- Refuses core containers (`containarium-core-*`) — they don't run user code.

### Motivation

Real prod containers exist that were created before `--monitoring` was wired into `create_container` (the ccu*, devbox, facelabor, pes containers visible on the v0.16.9 prod backend). Without this RPC, the only ways to retrofit monitoring on them are: recreate them (loses state) or hand-edit the LXC env via `incus config set` (untracked operator work).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/mcp/ ./internal/server/ ./pkg/core/container/` — pass (tool count bumped from 20 → 21)
- [x] `go test ./...` — all unit tests pass; integration tests fail only with "connection refused" (pre-existing, unrelated)
- [ ] Manual smoke after v0.17.0 lands on prod: pick one exposed-port container, `containarium monitoring enable <user>`, verify `incus config get <ct> environment.OTEL_EXPORTER_OTLP_ENDPOINT` returns the collector URL, exec in, `printenv | grep OTEL` — all four vars present, app restarted

🤖 Generated with [Claude Code](https://claude.com/claude-code)