### PR TITLE
docs(sidecar): resolve open questions, flip both to Approved

### DIFF
--- a/docs/OTEL-AGENT-RELAY-DESIGN.md
+++ b/docs/OTEL-AGENT-RELAY-DESIGN.md
@@ -1,7 +1,7 @@
 # OTel sidecar image — design
 
-**Status:** Draft
-**Last updated:** 2026-05-16 (pivoted from "LXC-level systemd relay" to "docker-compose sidecar")
+**Status:** Approved
+**Last updated:** 2026-05-16 (pivoted from "LXC-level systemd relay" to "docker-compose sidecar"; open questions resolved)
 **Related:**
 - [`docs/PLATFORM-SIDECAR-DESIGN.md`](PLATFORM-SIDECAR-DESIGN.md) — the generic platform-sidecar pattern this is the first instance of. **Read this first.**
 - [`docs/OTEL-COLLECTOR-DESIGN.md`](OTEL-COLLECTOR-DESIGN.md) — the central gateway this sidecar forwards to.
@@ -162,18 +162,18 @@ Most failure modes are inherited from the [platform sidecar pattern](PLATFORM-SI
 | Two sidecars in one LXC point at different central collectors | Shouldn't happen — `OTEL_EXPORTER_OTLP_ENDPOINT` comes from the LXC env, single source. | Documented; if tenant hand-edits compose to point at a different collector, that's their choice. |
 | Sidecar's container.id env doesn't match the LXC's actual container name | Tenant edited the env in compose. Sidecar still works but `container.id` is whatever they wrote. | Documented; the sidecar trusts its env. Operators can audit via `docker compose config`. |
 
-## Open questions
+## Resolved decisions
 
-These are the OTel-sidecar-specific ones. The cross-cutting platform questions are in [platform-sidecar-design](PLATFORM-SIDECAR-DESIGN.md#open-questions).
+OTel-sidecar-specific. Cross-cutting platform decisions are in [platform-sidecar-design](PLATFORM-SIDECAR-DESIGN.md#resolved-decisions).
 
-| # | Question | Why it matters | Proposed answer |
-|---|---|---|---|
-| 1 | Image base: `otel/opentelemetry-collector-contrib` or custom-built `otel/builder`? | The contrib image is ~280MB; a custom minimal builder image with only the components we need is closer to 30MB. Pull-time-per-LXC matters when sidecars proliferate. | Contrib for v1 (less ceremony); switch to a custom-built minimal collector for v2 once we know what receivers/processors/exporters we actually need. |
-| 2 | OTLP/gRPC receiver: ship or skip? | Some OTel SDKs default to gRPC. HTTP is simpler in compose. | Ship both. gRPC is "free" in the contrib image; tenants pick one. |
-| 3 | `service.namespace` insert vs upsert? | If we insert (only-if-absent), apps can override per-service. If we upsert, apps can't claim a different namespace. | Insert. Apps overriding `service.namespace` to e.g. group services into "auth" / "payment" / "infra" is a legit use case. |
-| 4 | Should the sidecar also pin `service.version` from a compose env? | Useful for canary / rollback metric breakdowns. | Yes, as `service.version` `insert` from `${SERVICE_VERSION}` env. Tenant sets per service; sidecar doesn't override. |
-| 5 | What happens on `OTEL_RESOURCE_ATTRIBUTES` env unset but the three `CONTAINARIUM_*` envs set? | Backward compat: today's LXC env stamps `OTEL_RESOURCE_ATTRIBUTES` as the comma string; the sidecar wants three split values. | Daemon adds the three `CONTAINARIUM_*` env stamps alongside the existing `OTEL_RESOURCE_ATTRIBUTES`. Sidecar reads only the `CONTAINARIUM_*` ones; the comma string stays for non-sidecar apps that read it directly. |
-| 6 | Health-check endpoint exposure | Should the sidecar expose `:13133` to the tenant's other containers, or keep it internal? | Expose. Operators want to curl it from neighboring containers when debugging. |
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | **Image base for v1 is `otel/opentelemetry-collector-contrib`** (~280MB). v2 may switch to a custom-built minimal collector (~30MB) once the receiver/processor/exporter set stabilizes. | Less ceremony; we already vendor contrib for the central collector. Pull-bandwidth concerns are real but secondary until sidecars proliferate. |
+| 2 | **Ship both OTLP/HTTP and OTLP/gRPC receivers.** | gRPC is free in the contrib image; some OTel SDKs default to it. Tenants pick the protocol that fits their app. |
+| 3 | **`service.namespace` uses `insert` action** (only-if-absent). Apps can override per-service. | Grouping services into namespaces (`payment`, `auth`, `infra`) is a legit cross-cutting concern apps should control. Platform identity is `container.id` / `backend.id`; `service.namespace` is tenant-organizational. |
+| 4 | **`service.version` is `insert` from `${SERVICE_VERSION}` env.** Tenant sets per service in their compose; sidecar doesn't override. | Useful for canary / rollback breakdowns. Tenant-owned signal — sidecar shouldn't claim authority over what version their app is. |
+| 5 | **Daemon stamps the three `CONTAINARIUM_*` env vars alongside the existing `OTEL_RESOURCE_ATTRIBUTES`** (no replacement; both formats coexist). Sidecar reads the split form; non-sidecar apps that read `OTEL_RESOURCE_ATTRIBUTES` directly keep working. | Backward compat with v0.16.9 deployments. The OTel config language can't split a comma-separated string at config-load time, so splitting at the daemon is the practical move. |
+| 6 | **Health-check endpoint `:13133` is exposed** (binds `0.0.0.0:13133`), reachable from neighboring containers in the LXC. | Operators want to curl it from a debug container when investigating telemetry issues. The endpoint exposes only collector internals (queue depths, send failures), not tenant data. |
 
 ## Phased rollout
 
@@ -197,3 +197,4 @@ These phases nest under the [platform sidecar phased rollout](PLATFORM-SIDECAR-D
 |---|---|---|
 | 2026-05-16 | hsinhoyeh, drafted with Claude | Initial draft: per-LXC `otelcol-contrib` as a systemd unit installed by Containarium during `--monitoring` lifecycle hooks. Status: Draft. |
 | 2026-05-16 | hsinhoyeh, redrafted with Claude | Pivot from "platform installs systemd unit in LXC" to "platform publishes a docker sidecar image, tenant composes it in." Scope narrowed to the `containarium/otel-sidecar:v1` image specifically; generic platform pattern moved to `PLATFORM-SIDECAR-DESIGN.md`. Status: still Draft, now scoped. |
+| 2026-05-16 | hsinhoyeh | Resolved all 6 OTel-sidecar-specific open questions: contrib base for v1, ship both OTLP receivers, `service.namespace` `insert`, `service.version` `insert` from env, daemon stamps both old `OTEL_RESOURCE_ATTRIBUTES` AND new split `CONTAINARIUM_*` envs (backward compat), expose `:13133` health endpoint. Sidecar image versions track the Containarium project version per [[platform-sidecar-design]] decision #4. Status: Draft → Approved. |

--- a/docs/PLATFORM-SIDECAR-DESIGN.md
+++ b/docs/PLATFORM-SIDECAR-DESIGN.md
@@ -1,6 +1,6 @@
 # Platform sidecar pattern — design
 
-**Status:** Draft
+**Status:** Approved
 **Last updated:** 2026-05-16
 **Related:**
 - [`docs/OTEL-AGENT-RELAY-DESIGN.md`](OTEL-AGENT-RELAY-DESIGN.md) — the first concrete sidecar (OTel collector); now scoped to the `containarium/otel-sidecar` image
@@ -116,13 +116,15 @@ The convention is documentation, not enforced. Compose's `network_mode: "service
 
 ## Image registry and versioning
 
-Containarium-published sidecars live at `ghcr.io/footprintai/containarium-<purpose>-sidecar`. Image tags are immutable semver:
+Containarium-published sidecars live at `ghcr.io/footprintai/containarium-<purpose>-sidecar`. **Sidecar image versions track the Containarium project version** rather than maintaining independent semver — one release number per Containarium release covers daemon + every sidecar.
 
-- `:v1.2.3` — the canonical, pin-recommended tag.
-- `:v1` — moves with the latest v1.x.y, for tenants who want minor-version auto-update.
-- `:latest` — published but explicitly **not recommended** for compose; documented as "for ad-hoc local testing only."
+For Containarium `v0.16.10`, each published sidecar gets three tags:
 
-Each sidecar's GitHub release page documents the upstream version baked in (e.g. `otel-sidecar:v1.2.3` baked on `otelcol-contrib v0.110.0`). Tenants pin their compose to the sidecar version; we don't promise wire-compat between major sidecar versions but minor versions are backwards-compatible.
+- `:v0.16.10` — immutable, points at the exact build associated with that Containarium release. Pin here for paranoid stability.
+- `:v0.16` — moves with the latest `v0.16.X` release in the minor series. Recommended for compose; inherits security patches automatically.
+- `:latest-stable` — moves with the latest tagged Containarium release. Useful for local testing; not recommended for production compose.
+
+Each sidecar's GitHub release page documents the upstream binary version baked in (e.g. `containarium-otel-sidecar:v0.16.10` is built on `otelcol-contrib v0.110.0`). Operators inheriting a Containarium release inherit its sidecars — no separate compatibility matrix to manage.
 
 ## Future sidecars sketched
 
@@ -158,16 +160,16 @@ For reference, the trade-offs we considered (and rejected for v1):
 
 The LXC-level relay was rejected because it requires Containarium to install/manage processes inside tenant LXCs — an unwanted dependency direction. The sidecar pattern flips it: tenants choose what platform components they want, Containarium just publishes the images and stamps the identity env.
 
-## Open questions
+## Resolved decisions
 
-| # | Question | Why it matters | Proposed answer |
-|---|---|---|---|
-| 1 | Image registry: GHCR vs DockerHub vs Containarium-owned? | Pull bandwidth, supply-chain trust, mirror policy. | GHCR (`ghcr.io/footprintai/...`) — same registry as the main Containarium release artifacts; supports signed image attestations natively. |
-| 2 | Should the platform offer a `containarium sidecar list/install` CLI subcommand that prints suggested compose snippets? | Discoverability — tenants shouldn't have to grep docs to know what sidecars exist. | Yes, ship `containarium sidecar <name> compose` that prints a ready-to-paste compose block customized for the requesting LXC's identity. Tenant copies into their compose. No platform write to tenant files. |
-| 3 | How does the sidecar contract handle non-monitoring sidecars (log, scanner)? Same `--monitoring` gate or a separate flag set? | Telemetry is gated on `--monitoring`; what about logs/scanning? | One flag per concern (`--monitoring`, `--log-shipping`, `--audit-capture`). Each flag stamps the relevant env vars. Sidecars fail closed if their identity env is unset, so accidentally adding a `log-sidecar` to a `--monitoring=true --log-shipping=false` LXC errors clearly. |
-| 4 | Sidecar version pinning: minor-version moving tag (`:v1`) or strict semver (`:v1.2.3`)? | Tenants want stability AND security updates. | Both published; docs recommend `:v1` for stability + security-update inheritance, `:v1.2.3` for paranoid pinning. |
-| 5 | What about LXCs that don't run docker (rare today but possible)? | Native-binary LXCs (e.g. `argus-dev`) can't compose a sidecar. | They keep using the LXC-env stamping path (today's behavior). Sidecar pattern is a superset for docker LXCs, not a replacement for everything. |
-| 6 | Sidecar image vulnerability response. Who patches and when? | If `otelcol-contrib` has a CVE, do we rebuild and re-tag immediately? | Yes — Containarium maintains a "sidecar release calendar" tied to upstream CVE feeds. Auto-rebuild and re-push on upstream security release. Tenants on `:v1` pick it up automatically; tenants on `:v1.2.3` need to manually bump (we document the timeline). |
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | **Image registry is GHCR** (`ghcr.io/footprintai/containarium-<name>-sidecar`). | Same registry as the main Containarium release artifacts; supports signed image attestations natively; no new vendor dependency. |
+| 2 | **`containarium sidecar <name> compose <username>` CLI subcommand** that prints a ready-to-paste compose block customized for the requesting LXC's identity. Tenant copies into their compose. **No platform write to tenant files.** | Discoverability without intrusion. Tenants who want it grab the snippet; the platform never modifies tenant artifacts. |
+| 3 | **One gating flag per cross-cutting concern** (`--monitoring`, `--log-shipping`, `--audit-capture`, ...). Each stamps the relevant identity env on the LXC. Sidecars fail closed if their required env is unset. | Lets tenants opt-in granularly. A `log-sidecar` added to a `--monitoring=true --log-shipping=false` LXC errors clearly at compose-up. |
+| 4 | **Sidecar image versions track the Containarium project version**, not independent semver. Each Containarium release (`v0.16.10`, `v0.17.0`, ...) produces matching sidecar tags. Moving tags `:latest-stable` and `:v0.16` (the minor-series moving tag) also published. | One number to remember per release. Daemon and sidecars move together — no compat matrix to maintain across decoupled release streams. Operators inheriting a Containarium release inherit its sidecars. |
+| 5 | **Non-docker LXCs keep using the LXC-env stamping path** (today's behavior). Sidecar pattern is a *superset* for docker LXCs, not a replacement. | Backward-compatible. Native-binary LXCs (`argus-dev`, etc.) can't `network_mode: service:...` because they have no compose; they read OTEL_* from the LXC env directly, same as v0.16.9 shipped. |
+| 6 | **Containarium maintains a sidecar release calendar tied to upstream CVE feeds.** Auto-rebuild and re-push on upstream security release; tenants on `:v0.16` (moving) pick it up automatically; tenants on `:v0.16.10` (immutable) manually bump per the documented timeline. | Security updates inheritable without daemon redeploy. Pinned-version users get explicit timeline rather than silent regressions. |
 
 ## Phased rollout
 
@@ -188,3 +190,4 @@ The LXC-level relay was rejected because it requires Containarium to install/man
 | Date | Author | Change |
 |---|---|---|
 | 2026-05-16 | hsinhoyeh, drafted with Claude | Initial draft. Platform sidecar pattern as the model for cross-cutting concerns (telemetry, log, scanner, audit). OTel sidecar is the first instance. Replaces the prior "LXC-level relay" design. Status: Draft. |
+| 2026-05-16 | hsinhoyeh | Resolved all 6 open questions: GHCR registry, `containarium sidecar ... compose` CLI for discovery, per-concern gating flags, **sidecar versions track the Containarium project release version** (single number for daemon + sidecars), non-docker LXCs keep the legacy env path, CVE-driven auto-rebuild calendar. Status: Draft → Approved. |


### PR DESCRIPTION
## Summary

Locks in all 12 design decisions across the two sidecar docs ([#185](https://github.com/FootprintAI/Containarium/pull/185)). Same Draft → Approved flow as the OTel collector and ZFS encryption docs.

### Platform sidecar (6 decisions)

| # | Decision |
|---|---|
| P1 | Registry: `ghcr.io/footprintai/containarium-<name>-sidecar` |
| P2 | `containarium sidecar <name> compose <username>` CLI prints ready-to-paste snippets (read-only) |
| P3 | One gating flag per concern: `--monitoring`, future `--log-shipping`, `--audit-capture` |
| P4 | **Sidecar versions track the Containarium project release version** — `:v0.16.10` immutable, `:v0.16` minor-moving, `:latest-stable` for testing. Daemon + sidecars move together |
| P5 | Non-docker LXCs (`argus-dev`, etc.) keep the v0.16.9 env-stamping path |
| P6 | CVE-driven auto-rebuild calendar; tenants on moving tag inherit |

### OTel sidecar (6 decisions)

| # | Decision |
|---|---|
| O1 | `otel/opentelemetry-collector-contrib` base for v1; minimal-build v2 |
| O2 | Ship both OTLP/HTTP `:4318` + OTLP/gRPC `:4317` |
| O3 | `service.namespace` uses `insert` (tenant override allowed) |
| O4 | `service.version` `insert` from `${SERVICE_VERSION}` env |
| O5 | Daemon stamps split `CONTAINARIUM_*` envs alongside existing `OTEL_RESOURCE_ATTRIBUTES` (backward compat) |
| O6 | Expose `:13133` health endpoint to neighbor containers |

Implementation kicks off next: image repo + GH Actions for `containarium-otel-sidecar:v0.16.10`, then the `containarium sidecar otel compose` CLI subcommand, then daemon-side env stamping for the new `CONTAINARIUM_*` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)