### PR TITLE
feat(sidecar): otel-sidecar image + daemon env stamping (Phase 1+2)

### DIFF
--- a/.github/workflows/sidecars.yml
+++ b/.github/workflows/sidecars.yml
@@ -1,0 +1,66 @@
+name: Build sidecar images
+
+# Triggered by the same Containarium release tags as the binary
+# release workflow. Per docs/PLATFORM-SIDECAR-DESIGN.md decision #4,
+# sidecar image versions track the Containarium project release —
+# every v*.*.* tag publishes matching sidecar tags.
+on:
+  push:
+    tags:
+      - 'v*'   # e.g. v0.16.11
+
+permissions:
+  contents: read
+  packages: write   # for GHCR push
+
+jobs:
+  otel-sidecar:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: tags
+        run: |
+          # Strip the leading 'v' from the tag to get e.g. 0.16.10
+          version="${GITHUB_REF#refs/tags/v}"
+          # Derive the minor-series moving tag: 0.16.10 -> v0.16
+          minor="v$(echo "$version" | cut -d. -f1-2)"
+
+          base="ghcr.io/footprintai/containarium-otel-sidecar"
+
+          {
+            echo "image=${base}"
+            echo "version=v${version}"
+            echo "minor=${minor}"
+            echo "tags=${base}:v${version},${base}:${minor},${base}:latest-stable"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push otel-sidecar
+        uses: docker/build-push-action@v6
+        with:
+          context: ./sidecars/otel-sidecar
+          file: ./sidecars/otel-sidecar/Dockerfile
+          # linux/amd64 only for v1 — bare-metal peers may want arm64
+          # later but our prod fleet is amd64 today.
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          # Build provenance + SBOM are GHA-default for buildx push;
+          # explicit so it's reviewable.
+          provenance: true
+          sbom: true

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -919,14 +919,21 @@ func (s *ContainerServer) AdoptMigratedContainer(ctx context.Context, req *pb.Ad
 	}, nil
 }
 
-// otelEnvKeys lists the four environment variables the toggle
-// path stamps / unsets. Centralized so a future change to the env
-// var set is one edit, not two.
+// otelEnvKeys lists the environment variables the toggle path
+// stamps / unsets. Includes both the legacy OTEL_* form (read by
+// OTel SDKs auto-discovering) and the split CONTAINARIUM_* form
+// (read by the platform sidecar's compose interpolation). Both
+// shapes have to be unset on disable so the LXC's env is fully
+// clean afterward; otherwise a leftover CONTAINARIUM_CONTAINER_ID
+// would still appear in `printenv` and confuse audit / debug.
 var otelEnvKeys = []string{
 	"OTEL_EXPORTER_OTLP_ENDPOINT",
 	"OTEL_EXPORTER_OTLP_PROTOCOL",
 	"OTEL_SERVICE_NAME",
 	"OTEL_RESOURCE_ATTRIBUTES",
+	"CONTAINARIUM_CONTAINER_ID",
+	"CONTAINARIUM_BACKEND_ID",
+	"CONTAINARIUM_TENANT_ID",
 }
 
 // ToggleMonitoring enables / disables app-emitted OTel on an existing

--- a/pkg/core/container/otel.go
+++ b/pkg/core/container/otel.go
@@ -23,6 +23,18 @@ import (
 // tell apart "monitoring off" from "monitoring on with zero vars."
 // The Incus config-map merge code treats both the same in practice,
 // but tests assert on the distinction.
+//
+// Two parallel env-var formats are stamped:
+//
+//   - The legacy OTEL_RESOURCE_ATTRIBUTES comma-string (for apps that
+//     read it directly via the OTel SDK env-discovery path).
+//   - Split CONTAINARIUM_CONTAINER_ID / CONTAINARIUM_BACKEND_ID /
+//     CONTAINARIUM_TENANT_ID for the platform-sidecar config language
+//     (otelcol's ${env:VAR} reference can't parse comma strings).
+//
+// Both forms encode the same information; see
+// docs/PLATFORM-SIDECAR-DESIGN.md decision #5 and
+// docs/OTEL-AGENT-RELAY-DESIGN.md decision #5.
 func otelEnvVars(opts CreateOptions, containerName string) map[string]string {
 	if !opts.Monitoring {
 		return nil
@@ -31,24 +43,7 @@ func otelEnvVars(opts CreateOptions, containerName string) map[string]string {
 		log.Printf("[otel] container %s requested monitoring=true but daemon has no collector endpoint configured; skipping env-var injection", containerName)
 		return nil
 	}
-
-	// OTEL_RESOURCE_ATTRIBUTES is the canonical way to attach
-	// resource-scoped labels that the receiving collector will see
-	// on every metric / span / log emitted by this app. We stamp
-	// container.id (so the collector's anti-spoofing processor can
-	// verify against source IP) and backend.id (so cross-VM
-	// Grafana dashboards can group by daemon).
-	resourceAttrs := strings.Join([]string{
-		"container.id=" + containerName,
-		"backend.id=" + opts.BackendID,
-	}, ",")
-
-	return map[string]string{
-		"OTEL_EXPORTER_OTLP_ENDPOINT": opts.OTelCollectorEndpoint,
-		"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
-		"OTEL_SERVICE_NAME":           opts.Username,
-		"OTEL_RESOURCE_ATTRIBUTES":    resourceAttrs,
-	}
+	return buildOTelEnvMap(opts.Username, containerName, opts.BackendID, opts.OTelCollectorEndpoint)
 }
 
 // OTelEnvVarsForMigration returns the same env-var set as
@@ -65,14 +60,39 @@ func OTelEnvVarsForMigration(username, containerName, backendID, collectorEndpoi
 	if collectorEndpoint == "" {
 		return nil
 	}
+	return buildOTelEnvMap(username, containerName, backendID, collectorEndpoint)
+}
+
+// buildOTelEnvMap is the single source of truth for what
+// monitoring-related env vars get stamped on a container. Both the
+// create-time and migration-time entry points return the same shape.
+//
+// OTEL_RESOURCE_ATTRIBUTES is the canonical comma-encoded form that
+// any OTel SDK auto-discovers. The three CONTAINARIUM_* keys are the
+// split form the platform sidecar's baked-in otelcol config reads
+// via ${env:CONTAINARIUM_CONTAINER_ID} etc. Keeping both means:
+//
+//   - Apps running directly in the LXC (non-docker) pick up the
+//     OTel SDK auto-config from OTEL_RESOURCE_ATTRIBUTES with no
+//     extra work.
+//   - The OTel sidecar (docker-compose service inside the LXC) reads
+//     the split form via `${VAR}` compose-interpolation, since the
+//     interpolation runs at compose-up time and feeds the env into
+//     the sidecar container.
+func buildOTelEnvMap(username, containerName, backendID, collectorEndpoint string) map[string]string {
 	resourceAttrs := strings.Join([]string{
 		"container.id=" + containerName,
 		"backend.id=" + backendID,
 	}, ",")
 	return map[string]string{
+		// Legacy / auto-discovered form
 		"OTEL_EXPORTER_OTLP_ENDPOINT": collectorEndpoint,
 		"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
 		"OTEL_SERVICE_NAME":           username,
 		"OTEL_RESOURCE_ATTRIBUTES":    resourceAttrs,
+		// Split form for sidecar compose-interpolation
+		"CONTAINARIUM_CONTAINER_ID": containerName,
+		"CONTAINARIUM_BACKEND_ID":   backendID,
+		"CONTAINARIUM_TENANT_ID":    username,
 	}
 }

--- a/pkg/core/container/otel_test.go
+++ b/pkg/core/container/otel_test.go
@@ -36,10 +36,11 @@ func TestOtelEnvVars_FullyConfigured(t *testing.T) {
 		OTelCollectorEndpoint: "http://10.0.0.1:4318",
 		BackendID:             "fts-5900x-gpu",
 	}
-	got := otelEnvVars(opts, "alice")
+	got := otelEnvVars(opts, "alice-container")
 	if got == nil {
 		t.Fatal("expected non-nil env vars when fully configured")
 	}
+	// Legacy OTEL_* form
 	if got["OTEL_EXPORTER_OTLP_ENDPOINT"] != "http://10.0.0.1:4318" {
 		t.Errorf("OTEL_EXPORTER_OTLP_ENDPOINT = %q, want %q", got["OTEL_EXPORTER_OTLP_ENDPOINT"], "http://10.0.0.1:4318")
 	}
@@ -50,11 +51,21 @@ func TestOtelEnvVars_FullyConfigured(t *testing.T) {
 		t.Errorf("OTEL_SERVICE_NAME = %q, want %q", got["OTEL_SERVICE_NAME"], "alice")
 	}
 	attrs := got["OTEL_RESOURCE_ATTRIBUTES"]
-	if !strings.Contains(attrs, "container.id=alice") {
+	if !strings.Contains(attrs, "container.id=alice-container") {
 		t.Errorf("OTEL_RESOURCE_ATTRIBUTES missing container.id: %q", attrs)
 	}
 	if !strings.Contains(attrs, "backend.id=fts-5900x-gpu") {
 		t.Errorf("OTEL_RESOURCE_ATTRIBUTES missing backend.id: %q", attrs)
+	}
+	// New split form for sidecar compose-interpolation
+	if got["CONTAINARIUM_CONTAINER_ID"] != "alice-container" {
+		t.Errorf("CONTAINARIUM_CONTAINER_ID = %q, want %q", got["CONTAINARIUM_CONTAINER_ID"], "alice-container")
+	}
+	if got["CONTAINARIUM_BACKEND_ID"] != "fts-5900x-gpu" {
+		t.Errorf("CONTAINARIUM_BACKEND_ID = %q, want %q", got["CONTAINARIUM_BACKEND_ID"], "fts-5900x-gpu")
+	}
+	if got["CONTAINARIUM_TENANT_ID"] != "alice" {
+		t.Errorf("CONTAINARIUM_TENANT_ID = %q, want %q", got["CONTAINARIUM_TENANT_ID"], "alice")
 	}
 }
 
@@ -65,7 +76,7 @@ func TestOTelEnvVarsForMigration_EmptyEndpoint(t *testing.T) {
 }
 
 func TestOTelEnvVarsForMigration_Populated(t *testing.T) {
-	got := OTelEnvVarsForMigration("alice", "alice", "fts-13700k-gpu", "http://10.0.0.2:4318")
+	got := OTelEnvVarsForMigration("alice", "alice-container", "fts-13700k-gpu", "http://10.0.0.2:4318")
 	if got == nil {
 		t.Fatal("expected non-nil map")
 	}
@@ -78,5 +89,15 @@ func TestOTelEnvVarsForMigration_Populated(t *testing.T) {
 	attrs := got["OTEL_RESOURCE_ATTRIBUTES"]
 	if !strings.Contains(attrs, "backend.id=fts-13700k-gpu") {
 		t.Errorf("expected backend.id in attrs, got %q", attrs)
+	}
+	// Split form must match the legacy comma-encoded form
+	if got["CONTAINARIUM_CONTAINER_ID"] != "alice-container" {
+		t.Errorf("split CONTAINARIUM_CONTAINER_ID = %q, want alice-container", got["CONTAINARIUM_CONTAINER_ID"])
+	}
+	if got["CONTAINARIUM_BACKEND_ID"] != "fts-13700k-gpu" {
+		t.Errorf("split CONTAINARIUM_BACKEND_ID = %q, want fts-13700k-gpu", got["CONTAINARIUM_BACKEND_ID"])
+	}
+	if got["CONTAINARIUM_TENANT_ID"] != "alice" {
+		t.Errorf("split CONTAINARIUM_TENANT_ID = %q, want alice", got["CONTAINARIUM_TENANT_ID"])
 	}
 }

--- a/sidecars/otel-sidecar/Dockerfile
+++ b/sidecars/otel-sidecar/Dockerfile
@@ -1,0 +1,45 @@
+# containarium-otel-sidecar
+#
+# Per docs/PLATFORM-SIDECAR-DESIGN.md + docs/OTEL-AGENT-RELAY-DESIGN.md.
+# Thin wrapper over otelcol-contrib with a fail-closed entrypoint that
+# validates Containarium identity env vars before starting the
+# collector. The upstream otel/opentelemetry-collector-contrib image
+# is distroless (no shell), so we build on a slim Debian base and
+# install the binary from the upstream release tarball — same result,
+# but with a /bin/sh for the entrypoint script.
+#
+# Image versions track the Containarium project release version per
+# platform-sidecar decision #4: each Containarium release publishes
+# matching tags ghcr.io/footprintai/containarium-otel-sidecar:vX.Y.Z.
+
+FROM debian:bookworm-slim
+
+# Pin to the same upstream collector version the central
+# containarium-core-otelcollector LXC runs (decision O1).
+ARG OTELCOL_VERSION=0.110.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -qO /tmp/otelcol.tar.gz \
+        "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${OTELCOL_VERSION}/otelcol-contrib_${OTELCOL_VERSION}_linux_amd64.tar.gz" \
+    && tar -xzf /tmp/otelcol.tar.gz -C /usr/local/bin/ otelcol-contrib \
+    && chmod +x /usr/local/bin/otelcol-contrib \
+    && rm /tmp/otelcol.tar.gz
+
+# Baked-in config (image is config-immutable per platform-sidecar
+# contract). Operators who want a different config write a different
+# image.
+COPY config.yaml /etc/otelcol-contrib/config.yaml
+
+# Entrypoint validates required identity env vars and fail-closes if
+# any are missing (platform-sidecar contract point 3). --chmod=0755
+# so we don't depend on the host's executable bit propagating.
+COPY --chmod=0755 entrypoint.sh /usr/local/bin/containarium-entrypoint.sh
+
+# Expose for documentation only — actual listening is controlled by
+# the config.
+EXPOSE 4317 4318 13133
+
+ENTRYPOINT ["/usr/local/bin/containarium-entrypoint.sh"]

--- a/sidecars/otel-sidecar/config.yaml
+++ b/sidecars/otel-sidecar/config.yaml
@@ -1,0 +1,63 @@
+# containarium-otel-sidecar collector config
+#
+# Per docs/OTEL-AGENT-RELAY-DESIGN.md. The resource processor stamps
+# platform-controlled identity attributes (container.id, backend.id)
+# from the CONTAINARIUM_* env vars Containarium puts on the LXC. The
+# entrypoint script validates those env vars before this config is
+# loaded.
+#
+# OTLP/HTTP + OTLP/gRPC receivers because some SDKs default to gRPC
+# (decision O2).
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  # Override app-claimed identity. The whole point of the sidecar.
+  resource:
+    attributes:
+      # Platform-controlled; upsert overrides whatever the app set.
+      - key: container.id
+        value: ${env:CONTAINARIUM_CONTAINER_ID}
+        action: upsert
+      - key: backend.id
+        value: ${env:CONTAINARIUM_BACKEND_ID}
+        action: upsert
+      # Tenant-organizational; insert only if the app didn't already
+      # set service.namespace (decision O3 — apps can override).
+      - key: service.namespace
+        value: ${env:CONTAINARIUM_TENANT_ID}
+        action: insert
+      # Tenant-controlled version label (decision O4).
+      - key: service.version
+        value: ${env:SERVICE_VERSION}
+        action: insert
+
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+
+extensions:
+  health_check:
+    # Exposed on 0.0.0.0 so neighboring containers in the LXC can
+    # curl it for debug (decision O6). Returns collector internals
+    # only, no tenant data.
+    endpoint: 0.0.0.0:13133
+
+exporters:
+  otlphttp:
+    endpoint: ${env:OTEL_EXPORTER_OTLP_ENDPOINT}
+    tls:
+      insecure: true
+
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [resource, batch]
+      exporters: [otlphttp]

--- a/sidecars/otel-sidecar/entrypoint.sh
+++ b/sidecars/otel-sidecar/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# containarium-otel-sidecar entrypoint
+#
+# Validates the identity env vars Containarium stamps via the LXC's
+# --monitoring flag before handing off to otelcol-contrib. Fail-closed
+# per the platform-sidecar contract: missing required env = exit
+# non-zero with a clear message, so `docker compose up` reports it.
+#
+# See docs/OTEL-AGENT-RELAY-DESIGN.md.
+
+set -eu
+
+missing=""
+for var in CONTAINARIUM_CONTAINER_ID CONTAINARIUM_BACKEND_ID CONTAINARIUM_TENANT_ID OTEL_EXPORTER_OTLP_ENDPOINT; do
+    eval "val=\${$var:-}"
+    if [ -z "$val" ]; then
+        missing="$missing $var"
+    fi
+done
+
+if [ -n "$missing" ]; then
+    cat >&2 <<EOF
+containarium-otel-sidecar: required identity env vars unset:$missing
+
+The platform stamps these on a --monitoring=true LXC. If you're
+seeing this from inside docker-compose, your compose service is
+missing the \${VAR} interpolation, e.g.:
+
+  payment-api-otel:
+    image: ghcr.io/footprintai/containarium-otel-sidecar:v0.16.10
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: \${OTEL_EXPORTER_OTLP_ENDPOINT}
+      CONTAINARIUM_CONTAINER_ID:   \${CONTAINARIUM_CONTAINER_ID}
+      CONTAINARIUM_BACKEND_ID:     \${CONTAINARIUM_BACKEND_ID}
+      CONTAINARIUM_TENANT_ID:      \${CONTAINARIUM_TENANT_ID}
+
+If the LXC itself is missing these, enable monitoring on it:
+  containarium monitoring enable <username>
+
+See docs/OTEL-AGENT-RELAY-DESIGN.md for the full contract.
+EOF
+    exit 64
+fi
+
+# SERVICE_VERSION is tenant-controlled and optional. We default to
+# "unset" here (rather than leaving the env unset and tripping the
+# OTel collector's "value must be specified" check on an empty
+# interpolation result) so the `insert` action in the resource
+# processor has something to write. Tenants who care about
+# canary/rollback breakdowns set their own SERVICE_VERSION in compose.
+: "${SERVICE_VERSION:=unset}"
+export SERVICE_VERSION
+
+exec /usr/local/bin/otelcol-contrib --config=/etc/otelcol-contrib/config.yaml


### PR DESCRIPTION
## Summary

Phase 1+2 of the platform-sidecar implementation per [#186](https://github.com/FootprintAI/Containarium/pull/186)'s Approved design.

### Phase 1 — image build

- `sidecars/otel-sidecar/Dockerfile`: debian-slim + otelcol-contrib 0.110.0 (matches central collector). Custom base instead of the upstream distroless image because the entrypoint script needs `/bin/sh`.
- `sidecars/otel-sidecar/config.yaml`: baked-in collector config. `resource` processor stamps `container.id`/`backend.id` via `upsert` (platform-controlled) and `service.namespace`/`service.version` via `insert` (tenant-overridable). `otlphttp` exporter targets `${OTEL_EXPORTER_OTLP_ENDPOINT}`.
- `sidecars/otel-sidecar/entrypoint.sh`: validates the four required identity env vars, fail-closes with a helpful "add this to compose" message if any are missing. Defaults `SERVICE_VERSION` so the OTel collector doesn't trip on unset env.
- `.github/workflows/sidecars.yml`: triggers on the same `v*` tags as the binary release. Publishes to `ghcr.io/footprintai/containarium-otel-sidecar` with three tags per release: `:v0.16.X` (immutable), `:v0.16` (minor moving), `:latest-stable`.

### Phase 2 — daemon env stamping

- `pkg/core/container/otel.go`: stamps `CONTAINARIUM_CONTAINER_ID` / `CONTAINARIUM_BACKEND_ID` / `CONTAINARIUM_TENANT_ID` alongside the existing `OTEL_RESOURCE_ATTRIBUTES` comma form. The split form feeds the sidecar's compose interpolation; the comma form keeps non-sidecar apps working unchanged.
- `internal/server/container_server.go`: `otelEnvKeys` (used by ToggleMonitoring disable) updated so the three new keys are also unset on disable.

### Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/core/container/ -run 'TestOtel|TestOTel'` — 5/5 pass (added assertions on the new `CONTAINARIUM_*` envs)
- [x] Local docker smoke (linux/amd64 emulated on darwin/arm64):
  - fail-closed: exit 64 + "add this to compose" message
  - healthy start: collector logs `Everything is ready. Begin running and processing data` with OTLP HTTP/gRPC + health_check listeners bound
- [ ] After merge + next `v*` tag: confirm `.github/workflows/sidecars.yml` publishes the three tags to GHCR
- [ ] Smoke on prod's devbox LXC: compose-in a sidecar + verify metric round-trips through to VictoriaMetrics with correct `container.id` / `backend.id` resource attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)