### PR TITLE
feat(sidecar): local-build path while GHCR is org-private

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help proto build clean clean-ui clean-all install test lint fmt run-local web-ui swagger-ui build-mcp build-mcp-linux install-mcp build-agent-box build-agent-box-linux build-agent-box-all install-agent-box build-release
+.PHONY: help proto build clean clean-ui clean-all install test lint fmt run-local web-ui swagger-ui build-mcp build-mcp-linux install-mcp build-agent-box build-agent-box-linux build-agent-box-all install-agent-box build-release sidecar-build-otel
 
 # Variables
 BINARY_NAME=containarium
@@ -137,6 +137,20 @@ install-agent-box: build-agent-box ## Install agent-box to /usr/local/bin (requi
 	@echo "==> Installing $(AGENTBOX_BINARY_NAME) to /usr/local/bin..."
 	@sudo cp $(BUILD_DIR)/$(AGENTBOX_BINARY_NAME) /usr/local/bin/
 	@echo "==> Installed. Wire it into Claude Code/Cursor with: ssh user@box agent-box"
+
+# Sidecar image build. Per docs/PLATFORM-SIDECAR-DESIGN.md, sidecar
+# images live at ghcr.io/footprintai/containarium-*-sidecar; on
+# FootprintAI's GitHub org public-package visibility is admin-locked,
+# so for now operators build the image themselves from the bundled
+# source. The tag tracks pkg/version.Version (decision P4).
+sidecar-build-otel: ## Build the otel-sidecar Docker image locally (tag = pkg/version)
+	$(eval SIDECAR_VERSION := $(shell grep '^[[:space:]]*Version = ' pkg/version/version.go | head -1 | sed -E 's/.*"([^"]+)".*/\1/'))
+	@echo "==> Building containarium-otel-sidecar:v$(SIDECAR_VERSION) from sidecars/otel-sidecar/..."
+	@docker build \
+		--tag containarium-otel-sidecar:v$(SIDECAR_VERSION) \
+		--tag containarium-otel-sidecar:latest \
+		sidecars/otel-sidecar/
+	@echo "==> Built. The compose snippet from \`containarium sidecar otel compose <user>\` references this tag."
 
 # build-release produces every release artifact for every supported
 # platform: containarium + mcp-server + agent-box, each for

--- a/docs/OTEL-AGENT-RELAY-DESIGN.md
+++ b/docs/OTEL-AGENT-RELAY-DESIGN.md
@@ -17,7 +17,7 @@ This doc specifies the `containarium/otel-sidecar` Docker image — the first in
 
 ## Image contract
 
-`ghcr.io/footprintai/containarium-otel-sidecar:v1` is a thin wrapper over `otelcol-contrib`:
+`ghcr.io/footprintai/containarium-otel-sidecar:vX.Y.Z` is a thin wrapper over `otelcol-contrib`. The GHCR push runs on every release tag, but the package is currently org-private (see [platform-sidecar status note](PLATFORM-SIDECAR-DESIGN.md#image-registry-and-versioning)) — operators run `make sidecar-build-otel` from a checkout to produce the same image locally tagged `containarium-otel-sidecar:vX.Y.Z`. The compose snippet `containarium sidecar otel compose <username>` prints references the local tag form and reminds the operator to run the build target.
 
 - **Base image:** the upstream `otel/opentelemetry-collector-contrib:0.110.0` (or whichever the central collector is also pinned to).
 - **Listening ports:** `0.0.0.0:4318` (OTLP/HTTP), `0.0.0.0:4317` (OTLP/gRPC), `0.0.0.0:13133` (health check).

--- a/docs/PLATFORM-SIDECAR-DESIGN.md
+++ b/docs/PLATFORM-SIDECAR-DESIGN.md
@@ -118,6 +118,8 @@ The convention is documentation, not enforced. Compose's `network_mode: "service
 
 Containarium-published sidecars live at `ghcr.io/footprintai/containarium-<purpose>-sidecar`. **Sidecar image versions track the Containarium project version** rather than maintaining independent semver — one release number per Containarium release covers daemon + every sidecar.
 
+> **Status note (2026-05-16):** GHCR public-package visibility is admin-locked on FootprintAI's GitHub org, so the GHCR-pushed images are not currently anonymously pullable. Operators build the image locally from `sidecars/otel-sidecar/` (see [OTel sidecar design § build](OTEL-AGENT-RELAY-DESIGN.md)). The `make sidecar-build-otel` target produces `containarium-otel-sidecar:vX.Y.Z` matching the local `pkg/version`. The GHCR pipeline keeps running so authenticated org users (and a future public flip) work without code changes.
+
 For Containarium `v0.16.10`, each published sidecar gets three tags:
 
 - `:v0.16.10` — immutable, points at the exact build associated with that Containarium release. Pin here for paranoid stability.

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -129,6 +129,17 @@ func renderOTelComposeSnippet(in otelComposeInputs) string {
 # which Containarium stamps via --monitoring; the values shown in
 # comments below are what's currently stamped on this LXC.
 #
+# IMPORTANT — build the image first.
+# The platform sidecar registry (ghcr.io/footprintai/containarium-otel-sidecar)
+# is currently org-private on FootprintAI's GHCR (admin-locked
+# visibility), so the snippet below references a local image tag.
+# From a checkout of footprintai/Containarium, build it once with:
+#
+#   make sidecar-build-otel
+#
+# That produces a local `+"`containarium-otel-sidecar:%s`"+` image the
+# compose service below uses. Re-run on every Containarium upgrade.
+#
 # Reference the sidecar from each app service that should emit
 # telemetry via:
 #
@@ -144,7 +155,7 @@ func renderOTelComposeSnippet(in otelComposeInputs) string {
 
 services:
   %s:
-    image: ghcr.io/footprintai/containarium-otel-sidecar:%s
+    image: containarium-otel-sidecar:%s
     restart: unless-stopped
     environment:
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}    # currently: %s
@@ -163,6 +174,7 @@ services:
       start_period: 5s
 `,
 		in.Username,
+		in.ImageTag,                       // build-step hint shows tag
 		in.ServiceName, in.ServiceName,
 		in.ServiceName,
 		in.ImageTag,

--- a/internal/cmd/sidecar_test.go
+++ b/internal/cmd/sidecar_test.go
@@ -17,8 +17,11 @@ func TestRenderOTelComposeSnippet_AllFieldsRendered(t *testing.T) {
 	})
 
 	mustContain := []string{
-		// Image tag from project version
-		"ghcr.io/footprintai/containarium-otel-sidecar:v0.16.11",
+		// Local image tag (GHCR is org-private; operator builds locally
+		// via `make sidecar-build-otel`).
+		"image: containarium-otel-sidecar:v0.16.11",
+		// Build-step reminder so operators know to run the make target.
+		"make sidecar-build-otel",
 		// Service name composed from username
 		"alice-otel:",
 		// network_mode hint references the same service name
@@ -56,12 +59,12 @@ func TestRenderOTelComposeSnippet_DoesNotLeakHardcodedTenantInImage(t *testing.T
 		TenantEnvValue:    "wordpress",
 		CollectorEnvValue: "http://10.0.3.112:4318",
 	})
-	if strings.Contains(got, "wordpress-otel-sidecar") {
+	if strings.Contains(got, "wordpress-otel-sidecar:") {
 		// Catches a bug where the image name accidentally got the
 		// service-name baked in.
 		t.Errorf("image name should not include tenant; got snippet:\n%s", got)
 	}
-	if !strings.Contains(got, "ghcr.io/footprintai/containarium-otel-sidecar:v0.16.11") {
-		t.Errorf("expected canonical image name, got:\n%s", got)
+	if !strings.Contains(got, "image: containarium-otel-sidecar:v0.16.11") {
+		t.Errorf("expected canonical local image name, got:\n%s", got)
 	}
 }


### PR DESCRIPTION
## Summary

The first sidecar image went to GHCR per [#187](https://github.com/FootprintAI/Containarium/pull/187), but FootprintAI's GitHub org admin-locks public-package visibility, so `docker pull ghcr.io/footprintai/containarium-otel-sidecar:v0.16.11` returns 401 for anonymous users. This PR ships the local-build stopgap so the sidecar pattern works today.

### Changes

- **`make sidecar-build-otel`** — builds the sidecar locally from `sidecars/otel-sidecar/` and tags it `containarium-otel-sidecar:vX.Y.Z` matching `pkg/version`.
- **`containarium sidecar otel compose <user>`** — output now references the local tag (`image: containarium-otel-sidecar:vX.Y.Z`) instead of the GHCR path, and the preamble tells the operator to run `make sidecar-build-otel` first.
- **Design docs** — both `PLATFORM-SIDECAR-DESIGN.md` and `OTEL-AGENT-RELAY-DESIGN.md` note the GHCR-private status with a pointer to the local-build path.

### Kept

- The GHCR push in `.github/workflows/sidecars.yml` keeps running on every release. Org-authenticated users can still pull. When/if visibility flips to public (org admin change) or we add a Docker Hub mirror, no code change is needed — only a small revert of the compose snippet's image string.

### Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/cmd/ -run TestRender` — 2/2 pass (updated to assert on local tag + build hint)
- [x] `make sidecar-build-otel` produces `containarium-otel-sidecar:v0.16.11` (running locally now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)