### PR TITLE
feat: ResizeContainer end-to-end (gRPC + HTTP + remote CLI + MCP)

### DIFF
--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -210,6 +210,26 @@ func (c *GRPCClient) DeleteContainer(username string, force bool) error {
 	return nil
 }
 
+// ResizeContainer changes a container's CPU / memory / disk via gRPC.
+// Empty string for any field means "no change". Disk can only grow —
+// the server rejects shrinks.
+func (c *GRPCClient) ResizeContainer(username, cpu, memory, disk string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	req := &pb.ResizeContainerRequest{
+		Username: username,
+		Cpu:      cpu,
+		Memory:   memory,
+		Disk:     disk,
+	}
+	resp, err := c.client.ResizeContainer(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("failed to resize container: %w", err)
+	}
+	return resp.Message, nil
+}
+
 // GetContainer gets information about a specific container via gRPC
 func (c *GRPCClient) GetContainer(username string) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -284,6 +284,47 @@ func (c *HTTPClient) ToggleMonitoring(username string, enabled bool) (string, bo
 	return result.Message, result.MonitoringEnabled, nil
 }
 
+// ResizeContainer changes a container's CPU / memory / disk via HTTP.
+// Empty string for any field means "no change". Disk can only grow.
+func (c *HTTPClient) ResizeContainer(username, cpu, memory, disk string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/containers/%s/resize", url.PathEscape(username))
+	body, err := json.Marshal(map[string]string{
+		"cpu":    cpu,
+		"memory": memory,
+		"disk":   disk,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal request: %w", err)
+	}
+	resp, err := c.doRequest(ctx, http.MethodPut, path, body)
+	if err != nil {
+		return "", fmt.Errorf("resize container: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(bodyBytes, &errResp) == nil && errResp.Error != "" {
+			return "", fmt.Errorf("%s", errResp.Error)
+		}
+		return "", fmt.Errorf("resize container: status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(bodyBytes, &result); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+	return result.Message, nil
+}
+
 // DeleteContainer deletes a container via HTTP
 func (c *HTTPClient) DeleteContainer(username string, force bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/internal/cmd/resize.go
+++ b/internal/cmd/resize.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/footprintai/containarium/internal/client"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/spf13/cobra"
 )
@@ -117,10 +118,30 @@ func runResizeLocal(username, containerName string) error {
 }
 
 func runResizeRemote(username, containerName string) error {
-	// TODO: Implement remote resize via gRPC
-	// For now, return not implemented error
-	return fmt.Errorf("remote resize not yet implemented - please resize on the server directly:\n" +
-		"  ssh admin@%s\n" +
-		"  sudo containarium resize %s --cpu %s --memory %s --disk %s",
-		serverAddr, username, newCPU, newMemory, newDisk)
+	var msg string
+	var err error
+
+	if httpMode {
+		httpClient, herr := client.NewHTTPClient(serverAddr, authToken)
+		if herr != nil {
+			return herr
+		}
+		defer httpClient.Close()
+		msg, err = httpClient.ResizeContainer(username, newCPU, newMemory, newDisk)
+	} else {
+		grpcClient, gerr := client.NewGRPCClient(serverAddr, certsDir, insecure)
+		if gerr != nil {
+			return gerr
+		}
+		defer grpcClient.Close()
+		msg, err = grpcClient.ResizeContainer(username, newCPU, newMemory, newDisk)
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ Container %s resized\n", containerName)
+	if msg != "" {
+		fmt.Println(msg)
+	}
+	return nil
 }

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -203,6 +203,29 @@ func (c *Client) ToggleMonitoring(username string, enabled bool) (*ToggleMonitor
 	return &resp, nil
 }
 
+// ResizeContainer changes a container's CPU / memory / disk
+// allocation. Empty string for any field means "no change"; disk
+// can only grow (server rejects shrinks).
+func (c *Client) ResizeContainer(username, cpu, memory, disk string) (*ResizeContainerResponse, error) {
+	body, err := json.Marshal(map[string]string{
+		"cpu":    cpu,
+		"memory": memory,
+		"disk":   disk,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	respBody, err := c.doRequest("PUT", fmt.Sprintf("/v1/containers/%s/resize", username), body)
+	if err != nil {
+		return nil, err
+	}
+	var resp ResizeContainerResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
 // DeleteContainer deletes a container
 func (c *Client) DeleteContainer(username string, force bool) (*DeleteContainerResponse, error) {
 	path := fmt.Sprintf("/v1/containers/%s?force=%v", username, force)
@@ -662,6 +685,11 @@ type DeleteContainerResponse struct {
 type ToggleMonitoringResponse struct {
 	Message           string `json:"message"`
 	MonitoringEnabled bool   `json:"monitoring_enabled"`
+}
+
+type ResizeContainerResponse struct {
+	Message   string    `json:"message"`
+	Container Container `json:"container"`
 }
 
 type StartContainerResponse struct {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,7 +22,7 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	assert.Len(t, server.tools, 21, "Should have 21 tools registered")
+	assert.Len(t, server.tools, 22, "Should have 22 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -126,7 +126,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	assert.Len(t, tools, 21)
+	assert.Len(t, tools, 22)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -281,6 +281,33 @@ func (s *Server) registerTools() {
 			Handler: handleMoveContainer,
 		},
 		{
+			Name:        "resize_container",
+			Description: "Change a container's CPU / memory / disk allocation in place. At least one of cpu, memory, or disk must be provided; the others default to no change. Disk can only grow — the server rejects shrinks. The container stays running (no restart needed for CPU/memory; disk resize is online via ZFS).",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":        "string",
+						"description": "Username of the container to resize",
+					},
+					"cpu": map[string]interface{}{
+						"type":        "string",
+						"description": "New CPU limit (e.g. \"4\" for 4 cores, \"2-4\" for a range). Empty/omitted = no change.",
+					},
+					"memory": map[string]interface{}{
+						"type":        "string",
+						"description": "New memory limit (e.g. \"8GB\", \"4096MB\"). Empty/omitted = no change.",
+					},
+					"disk": map[string]interface{}{
+						"type":        "string",
+						"description": "New disk size (e.g. \"100GB\"). Can only grow — shrinks are rejected. Empty/omitted = no change.",
+					},
+				},
+				"required": []string{"username"},
+			},
+			Handler: handleResizeContainer,
+		},
+		{
 			Name:        "toggle_monitoring",
 			Description: "Enable or disable application-emitted OpenTelemetry on an existing container without recreating it. When enabling, the daemon stamps OTEL_EXPORTER_OTLP_ENDPOINT + related env vars and restarts the container so the app picks them up. Use this to retrofit monitoring onto containers created before --monitoring was wired in. Requires the daemon to have an OTel collector endpoint configured.",
 			InputSchema: map[string]interface{}{
@@ -906,6 +933,25 @@ func handleDebugContainer(client *Client, args map[string]interface{}) (string, 
 	}
 
 	return string(jsonData), nil
+}
+
+func handleResizeContainer(client *Client, args map[string]interface{}) (string, error) {
+	username, ok := args["username"].(string)
+	if !ok || username == "" {
+		return "", fmt.Errorf("username is required")
+	}
+	cpu, _ := args["cpu"].(string)
+	memory, _ := args["memory"].(string)
+	disk, _ := args["disk"].(string)
+	if cpu == "" && memory == "" && disk == "" {
+		return "", fmt.Errorf("at least one of cpu, memory, or disk must be provided")
+	}
+
+	resp, err := client.ResizeContainer(username, cpu, memory, disk)
+	if err != nil {
+		return "", fmt.Errorf("failed to resize container: %w", err)
+	}
+	return fmt.Sprintf("✅ %s", resp.Message), nil
 }
 
 func handleToggleMonitoring(client *Client, args map[string]interface{}) (string, error) {


### PR DESCRIPTION
## Summary

`ResizeContainer` has been server-implemented since v0.16.4 but the client side was a stub. This PR wires the full chain per the project's "CLI-first, MCP wraps it" rule:

| Layer | Before | After |
|---|---|---|
| gRPC server | ✅ | ✅ |
| HTTP REST gateway | ✅ | ✅ |
| `internal/client/grpc.go` wrapper | ❌ | ✅ |
| `internal/client/http.go` wrapper | ❌ | ✅ |
| Remote-mode CLI (`containarium resize --server ...`) | ❌ stub | ✅ |
| Local-mode CLI | ✅ | ✅ |
| MCP tool `resize_container` | ❌ | ✅ |

### MCP tool shape

```json
{
  "name": "resize_container",
  "args": {
    "username": "wordpress",
    "cpu": "4",         // optional
    "memory": "8GB",    // optional
    "disk": "100GB"     // optional, can only grow
  }
}
```

At least one of `cpu` / `memory` / `disk` must be set. Disk can only grow (the server rejects shrinks).

### Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/cmd/ ./internal/mcp/` — pass (tool count bumped 21 → 22)
- [x] `go test ./...` — all unit tests pass; only the pre-existing "needs live gRPC server" integration tests fail
- [ ] After v0.16.12 lands: `containarium resize <user> --memory 8GB --server <prod-backend>:50051 --insecure` to verify the remote path works end-to-end
- [ ] `resize_container` MCP tool callable from Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)