### PR TITLE
feat(sidecar): revert compose snippet to GHCR pull (public now)

### DIFF
--- a/docs/OTEL-AGENT-RELAY-DESIGN.md
+++ b/docs/OTEL-AGENT-RELAY-DESIGN.md
@@ -17,7 +17,7 @@ This doc specifies the `containarium/otel-sidecar` Docker image — the first in
 
 ## Image contract
 
-`ghcr.io/footprintai/containarium-otel-sidecar:vX.Y.Z` is a thin wrapper over `otelcol-contrib`. The GHCR push runs on every release tag, but the package is currently org-private (see [platform-sidecar status note](PLATFORM-SIDECAR-DESIGN.md#image-registry-and-versioning)) — operators run `make sidecar-build-otel` from a checkout to produce the same image locally tagged `containarium-otel-sidecar:vX.Y.Z`. The compose snippet `containarium sidecar otel compose <username>` prints references the local tag form and reminds the operator to run the build target.
+`ghcr.io/footprintai/containarium-otel-sidecar:vX.Y.Z` is a thin wrapper over `otelcol-contrib`. The GHCR push runs on every release tag; the package is public, so tenants `docker pull` without auth. The compose snippet from `containarium sidecar otel compose <username>` references the GHCR path directly. The `make sidecar-build-otel` target stays for dev-loop iteration (build the image locally without round-tripping through CI).
 
 - **Base image:** the upstream `otel/opentelemetry-collector-contrib:0.110.0` (or whichever the central collector is also pinned to).
 - **Listening ports:** `0.0.0.0:4318` (OTLP/HTTP), `0.0.0.0:4317` (OTLP/gRPC), `0.0.0.0:13133` (health check).

--- a/docs/PLATFORM-SIDECAR-DESIGN.md
+++ b/docs/PLATFORM-SIDECAR-DESIGN.md
@@ -116,9 +116,7 @@ The convention is documentation, not enforced. Compose's `network_mode: "service
 
 ## Image registry and versioning
 
-Containarium-published sidecars live at `ghcr.io/footprintai/containarium-<purpose>-sidecar`. **Sidecar image versions track the Containarium project version** rather than maintaining independent semver — one release number per Containarium release covers daemon + every sidecar.
-
-> **Status note (2026-05-16):** GHCR public-package visibility is admin-locked on FootprintAI's GitHub org, so the GHCR-pushed images are not currently anonymously pullable. Operators build the image locally from `sidecars/otel-sidecar/` (see [OTel sidecar design § build](OTEL-AGENT-RELAY-DESIGN.md)). The `make sidecar-build-otel` target produces `containarium-otel-sidecar:vX.Y.Z` matching the local `pkg/version`. The GHCR pipeline keeps running so authenticated org users (and a future public flip) work without code changes.
+Containarium-published sidecars live at `ghcr.io/footprintai/containarium-<purpose>-sidecar`. **Sidecar image versions track the Containarium project version** rather than maintaining independent semver — one release number per Containarium release covers daemon + every sidecar. Packages are public on GHCR; tenants `docker pull` without auth.
 
 For Containarium `v0.16.10`, each published sidecar gets three tags:
 

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -129,17 +129,6 @@ func renderOTelComposeSnippet(in otelComposeInputs) string {
 # which Containarium stamps via --monitoring; the values shown in
 # comments below are what's currently stamped on this LXC.
 #
-# IMPORTANT — build the image first.
-# The platform sidecar registry (ghcr.io/footprintai/containarium-otel-sidecar)
-# is currently org-private on FootprintAI's GHCR (admin-locked
-# visibility), so the snippet below references a local image tag.
-# From a checkout of footprintai/Containarium, build it once with:
-#
-#   make sidecar-build-otel
-#
-# That produces a local `+"`containarium-otel-sidecar:%s`"+` image the
-# compose service below uses. Re-run on every Containarium upgrade.
-#
 # Reference the sidecar from each app service that should emit
 # telemetry via:
 #
@@ -155,7 +144,7 @@ func renderOTelComposeSnippet(in otelComposeInputs) string {
 
 services:
   %s:
-    image: containarium-otel-sidecar:%s
+    image: ghcr.io/footprintai/containarium-otel-sidecar:%s
     restart: unless-stopped
     environment:
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT}    # currently: %s
@@ -174,7 +163,6 @@ services:
       start_period: 5s
 `,
 		in.Username,
-		in.ImageTag,                       // build-step hint shows tag
 		in.ServiceName, in.ServiceName,
 		in.ServiceName,
 		in.ImageTag,

--- a/internal/cmd/sidecar_test.go
+++ b/internal/cmd/sidecar_test.go
@@ -17,11 +17,8 @@ func TestRenderOTelComposeSnippet_AllFieldsRendered(t *testing.T) {
 	})
 
 	mustContain := []string{
-		// Local image tag (GHCR is org-private; operator builds locally
-		// via `make sidecar-build-otel`).
-		"image: containarium-otel-sidecar:v0.16.11",
-		// Build-step reminder so operators know to run the make target.
-		"make sidecar-build-otel",
+		// GHCR image tag (public package; tenants `docker pull` directly).
+		"image: ghcr.io/footprintai/containarium-otel-sidecar:v0.16.11",
 		// Service name composed from username
 		"alice-otel:",
 		// network_mode hint references the same service name
@@ -64,7 +61,7 @@ func TestRenderOTelComposeSnippet_DoesNotLeakHardcodedTenantInImage(t *testing.T
 		// service-name baked in.
 		t.Errorf("image name should not include tenant; got snippet:\n%s", got)
 	}
-	if !strings.Contains(got, "image: containarium-otel-sidecar:v0.16.11") {
-		t.Errorf("expected canonical local image name, got:\n%s", got)
+	if !strings.Contains(got, "image: ghcr.io/footprintai/containarium-otel-sidecar:v0.16.11") {
+		t.Errorf("expected canonical GHCR image name, got:\n%s", got)
 	}
 }


### PR DESCRIPTION
## Summary

GHCR public-package visibility was admin-enabled on the FootprintAI org, and `ghcr.io/footprintai/containarium-otel-sidecar` was flipped to public. `docker manifest inspect` confirms anonymous pulls work for both `:v0.16.12` and the moving `:v0.16` tag.

Reverts [#190](https://github.com/FootprintAI/Containarium/pull/190)'s local-build stopgap:

- Compose snippet output: `image: ghcr.io/footprintai/containarium-otel-sidecar:vX.Y.Z` (was: bare local tag).
- Snippet preamble: drops the "build first via `make sidecar-build-otel`" warning.
- Docs: strip the "GHCR is org-private" status notes from both `PLATFORM-SIDECAR-DESIGN.md` and `OTEL-AGENT-RELAY-DESIGN.md`.

### Kept

- `make sidecar-build-otel` target — still useful for dev-loop iteration on the image (avoid round-tripping through CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)