### PR TITLE
feat(secrets): phase 2 — Postgres-backed store

### DIFF
--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -1,0 +1,267 @@
+// Package secrets implements the daemon-side Postgres-backed store
+// for tenant secrets, layered on top of pkg/core/secrets crypto.
+// See docs/SECRETS-MANAGEMENT-DESIGN.md.
+package secrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	corecrypto "github.com/footprintai/containarium/pkg/core/secrets"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SecretMetadata is the public-safe view of a stored secret —
+// matches the proto message of the same name. The plaintext value
+// lives only in memory during Get and never in this struct.
+type SecretMetadata struct {
+	Username  string
+	Name      string
+	Version   int32
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Store handles per-tenant secret persistence. All on-disk data is
+// AES-256-GCM ciphertext bound to (username, name); the cipher
+// instance holds the master key in process memory and is reused
+// across calls.
+type Store struct {
+	pool   *pgxpool.Pool
+	cipher *corecrypto.Cipher
+}
+
+// ErrNotFound is returned by Get / Delete when the (username, name)
+// tuple has no row.
+var ErrNotFound = errors.New("secrets: not found")
+
+// NewStore opens the secrets store. Creates the `secrets` table on
+// first run; idempotent on every subsequent call.
+//
+// The cipher must already be constructed from the daemon's master
+// key (see pkg/core/secrets.LoadOrCreateMasterKey + NewCipher).
+func NewStore(ctx context.Context, pool *pgxpool.Pool, cipher *corecrypto.Cipher) (*Store, error) {
+	if pool == nil {
+		return nil, errors.New("secrets: pool is nil")
+	}
+	if cipher == nil {
+		return nil, errors.New("secrets: cipher is nil")
+	}
+	s := &Store{pool: pool, cipher: cipher}
+	if err := s.initSchema(ctx); err != nil {
+		return nil, fmt.Errorf("init schema: %w", err)
+	}
+	return s, nil
+}
+
+func (s *Store) initSchema(ctx context.Context) error {
+	schema := `
+		CREATE TABLE IF NOT EXISTS secrets (
+			id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			username     TEXT NOT NULL,
+			name         TEXT NOT NULL,
+			nonce        BYTEA NOT NULL,
+			ciphertext   BYTEA NOT NULL,
+			version      INT  NOT NULL DEFAULT 1,
+			created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			UNIQUE (username, name)
+		);
+
+		CREATE INDEX IF NOT EXISTS idx_secrets_username
+			ON secrets(username);
+	`
+	_, err := s.pool.Exec(ctx, schema)
+	return err
+}
+
+// Set creates or updates a secret. Idempotent — repeated calls with
+// the same (username, name) bump the version and replace the
+// ciphertext. Validates name + value at the API boundary before
+// touching crypto or the DB.
+func (s *Store) Set(ctx context.Context, username, name, value string) (*SecretMetadata, error) {
+	if username == "" {
+		return nil, fmt.Errorf("username is required")
+	}
+	if err := corecrypto.ValidateName(name); err != nil {
+		return nil, err
+	}
+	if err := corecrypto.ValidateValue(value); err != nil {
+		return nil, err
+	}
+
+	nonce, ct, err := s.cipher.Encrypt(username, name, []byte(value))
+	if err != nil {
+		return nil, fmt.Errorf("encrypt: %w", err)
+	}
+
+	// INSERT ... ON CONFLICT DO UPDATE handles both create and
+	// rotate in a single round-trip. The version bumps on every
+	// rotation; the row's created_at stays as the original
+	// (set-once-ever timestamp), updated_at moves to NOW().
+	const q = `
+		INSERT INTO secrets (username, name, nonce, ciphertext, version)
+		VALUES ($1, $2, $3, $4, 1)
+		ON CONFLICT (username, name)
+		DO UPDATE SET
+			nonce       = EXCLUDED.nonce,
+			ciphertext  = EXCLUDED.ciphertext,
+			version     = secrets.version + 1,
+			updated_at  = NOW()
+		RETURNING version, created_at, updated_at;
+	`
+	var version int32
+	var createdAt, updatedAt time.Time
+	if err := s.pool.QueryRow(ctx, q, username, name, nonce, ct).Scan(&version, &createdAt, &updatedAt); err != nil {
+		return nil, fmt.Errorf("upsert secret: %w", err)
+	}
+	return &SecretMetadata{
+		Username:  username,
+		Name:      name,
+		Version:   version,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}, nil
+}
+
+// Get reads a single secret's decrypted plaintext value. Returns
+// ErrNotFound if the (username, name) tuple isn't in the table.
+//
+// Failed decryption (wrong master key, tampered ciphertext) returns
+// the underlying crypto error so callers can distinguish "you
+// looked up something that exists but I can't decrypt it" from
+// "nothing here."
+func (s *Store) Get(ctx context.Context, username, name string) (meta *SecretMetadata, value string, err error) {
+	if username == "" {
+		return nil, "", fmt.Errorf("username is required")
+	}
+	if verr := corecrypto.ValidateName(name); verr != nil {
+		return nil, "", verr
+	}
+
+	const q = `
+		SELECT nonce, ciphertext, version, created_at, updated_at
+		FROM secrets
+		WHERE username = $1 AND name = $2
+	`
+	var nonce, ct []byte
+	var version int32
+	var createdAt, updatedAt time.Time
+	if err := s.pool.QueryRow(ctx, q, username, name).Scan(&nonce, &ct, &version, &createdAt, &updatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, "", ErrNotFound
+		}
+		return nil, "", fmt.Errorf("select secret: %w", err)
+	}
+
+	plaintext, err := s.cipher.Decrypt(username, name, nonce, ct)
+	if err != nil {
+		return nil, "", fmt.Errorf("decrypt secret: %w", err)
+	}
+	return &SecretMetadata{
+		Username:  username,
+		Name:      name,
+		Version:   version,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}, string(plaintext), nil
+}
+
+// List returns metadata for all secrets owned by the tenant.
+// Values are never returned by this path — only Get returns the
+// decrypted plaintext (and is audit-logged at the caller's layer).
+func (s *Store) List(ctx context.Context, username string) ([]SecretMetadata, error) {
+	if username == "" {
+		return nil, fmt.Errorf("username is required")
+	}
+	const q = `
+		SELECT username, name, version, created_at, updated_at
+		FROM secrets
+		WHERE username = $1
+		ORDER BY name
+	`
+	rows, err := s.pool.Query(ctx, q, username)
+	if err != nil {
+		return nil, fmt.Errorf("list secrets: %w", err)
+	}
+	defer rows.Close()
+
+	var out []SecretMetadata
+	for rows.Next() {
+		var m SecretMetadata
+		if err := rows.Scan(&m.Username, &m.Name, &m.Version, &m.CreatedAt, &m.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan secret row: %w", err)
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate secret rows: %w", err)
+	}
+	return out, nil
+}
+
+// Delete removes a single secret. Returns ErrNotFound if no such
+// row existed (so callers can return a clean 404 instead of a
+// generic 200).
+func (s *Store) Delete(ctx context.Context, username, name string) error {
+	if username == "" {
+		return fmt.Errorf("username is required")
+	}
+	if err := corecrypto.ValidateName(name); err != nil {
+		return err
+	}
+	const q = `DELETE FROM secrets WHERE username = $1 AND name = $2`
+	tag, err := s.pool.Exec(ctx, q, username, name)
+	if err != nil {
+		return fmt.Errorf("delete secret: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// LoadAllForUser returns the decrypted plaintext values for every
+// secret owned by the tenant. Used by the daemon's env-var
+// stamping path (CreateContainer / StartContainer / RefreshSecrets)
+// to build the map of environment.<NAME>=<value> assignments.
+//
+// This path is the hot one: returning N decrypted values in one
+// round-trip beats N Get calls. The caller is responsible for not
+// logging the map or persisting it outside the LXC config.
+func (s *Store) LoadAllForUser(ctx context.Context, username string) (map[string]string, error) {
+	if username == "" {
+		return nil, fmt.Errorf("username is required")
+	}
+	const q = `
+		SELECT name, nonce, ciphertext
+		FROM secrets
+		WHERE username = $1
+	`
+	rows, err := s.pool.Query(ctx, q, username)
+	if err != nil {
+		return nil, fmt.Errorf("load secrets for user: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]string)
+	for rows.Next() {
+		var name string
+		var nonce, ct []byte
+		if err := rows.Scan(&name, &nonce, &ct); err != nil {
+			return nil, fmt.Errorf("scan secret row: %w", err)
+		}
+		pt, decErr := s.cipher.Decrypt(username, name, nonce, ct)
+		if decErr != nil {
+			return nil, fmt.Errorf("decrypt secret %s/%s: %w", username, name, decErr)
+		}
+		out[name] = string(pt)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate secret rows: %w", err)
+	}
+	return out, nil
+}

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -1,0 +1,127 @@
+package secrets
+
+import (
+	"context"
+	"testing"
+
+	corecrypto "github.com/footprintai/containarium/pkg/core/secrets"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Integration-style test against a real Postgres. Follows the same
+// convention as internal/app/store_test.go: t.Skip in CI, runnable
+// locally with:
+//
+//   docker run -d -p 5432:5432 \
+//     -e POSTGRES_PASSWORD=test \
+//     -e POSTGRES_DB=containarium \
+//     postgres:16-alpine
+//
+//   go test -run TestSecretsStore ./internal/secrets/ -v
+//
+// The crypto layer is fully unit-tested in pkg/core/secrets;
+// this test exercises the SQL roundtrip + AAD binding through
+// the full Store API.
+func TestSecretsStore_Roundtrip(t *testing.T) {
+	t.Skip("requires Postgres at localhost:5432 — see comment for run instructions")
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, "postgres://containarium:test@localhost:5432/containarium?sslmode=disable")
+	if err != nil {
+		t.Fatalf("connect Postgres: %v", err)
+	}
+	defer pool.Close()
+
+	// 32-byte fixed key — only valid for tests; production uses
+	// LoadOrCreateMasterKey from a 0400 file.
+	key := make([]byte, corecrypto.MasterKeySize)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	cipher, err := corecrypto.NewCipher(key)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+
+	store, err := NewStore(ctx, pool, cipher)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	// Clean slate for this test user.
+	_, _ = pool.Exec(ctx, "DELETE FROM secrets WHERE username = $1", "store-test-user")
+
+	// Set, then Get, then List, then rotation (Set again), then
+	// Delete.
+	meta, err := store.Set(ctx, "store-test-user", "OPENAI_API_KEY", "sk-v1")
+	if err != nil {
+		t.Fatalf("Set first: %v", err)
+	}
+	if meta.Version != 1 {
+		t.Errorf("first version = %d, want 1", meta.Version)
+	}
+
+	gotMeta, gotValue, err := store.Get(ctx, "store-test-user", "OPENAI_API_KEY")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if gotValue != "sk-v1" {
+		t.Errorf("Get value = %q, want %q", gotValue, "sk-v1")
+	}
+	if gotMeta.Version != 1 {
+		t.Errorf("Get version = %d, want 1", gotMeta.Version)
+	}
+
+	// Rotation: same (username, name), new value, version should bump.
+	meta2, err := store.Set(ctx, "store-test-user", "OPENAI_API_KEY", "sk-v2")
+	if err != nil {
+		t.Fatalf("Set rotation: %v", err)
+	}
+	if meta2.Version != 2 {
+		t.Errorf("rotation version = %d, want 2", meta2.Version)
+	}
+
+	// LoadAllForUser returns a map of every secret decrypted.
+	all, err := store.LoadAllForUser(ctx, "store-test-user")
+	if err != nil {
+		t.Fatalf("LoadAllForUser: %v", err)
+	}
+	if all["OPENAI_API_KEY"] != "sk-v2" {
+		t.Errorf("LoadAllForUser[OPENAI_API_KEY] = %q, want sk-v2", all["OPENAI_API_KEY"])
+	}
+
+	// List returns metadata only.
+	list, err := store.List(ctx, "store-test-user")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 {
+		t.Errorf("List len = %d, want 1", len(list))
+	}
+
+	// Delete + verify it's gone.
+	if err := store.Delete(ctx, "store-test-user", "OPENAI_API_KEY"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, _, err := store.Get(ctx, "store-test-user", "OPENAI_API_KEY"); err != ErrNotFound {
+		t.Errorf("Get after delete: err = %v, want ErrNotFound", err)
+	}
+
+	// Delete-after-delete should also return ErrNotFound.
+	if err := store.Delete(ctx, "store-test-user", "OPENAI_API_KEY"); err != ErrNotFound {
+		t.Errorf("double delete: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSecretsStore_NilArgsRejected(t *testing.T) {
+	ctx := context.Background()
+	key := make([]byte, corecrypto.MasterKeySize)
+	cipher, _ := corecrypto.NewCipher(key)
+
+	if _, err := NewStore(ctx, nil, cipher); err == nil {
+		t.Error("NewStore should reject nil pool")
+	}
+	// nil cipher — needs a pool, so we can't actually call this
+	// without a Postgres. The pool == nil path is the cheap one to
+	// exercise; the cipher==nil path is symmetrical.
+}


### PR DESCRIPTION
## Summary

Phase 2 of the secrets implementation per [#195](https://github.com/FootprintAI/Containarium/pull/195)'s Approved design. Layered on top of phase 1's crypto helper ([#196](https://github.com/FootprintAI/Containarium/pull/196)).

### What this adds

- **`internal/secrets/Store`** — `Set` / `Get` / `List` / `Delete` / `LoadAllForUser`. Schema auto-migrates on first call (`secrets` table per the design doc spec).
- **`Set` is set-or-rotate** in a single SQL round-trip via `INSERT ... ON CONFLICT (username, name) DO UPDATE`. Version bumps on every rotation; `created_at` stays at the original.
- **`LoadAllForUser`** is the env-var stamping hot path used by `CreateContainer` / `StartContainer` / `RefreshSecrets`. One query, N decrypts, returns a `map[name]value`.
- **`ErrNotFound` sentinel** so the server impl can return a clean 404 on Get / Delete of a missing secret.

### Tests

- `TestSecretsStore_Roundtrip`: full lifecycle exercise (Set → Get → rotation → List → LoadAllForUser → Delete → double-delete). `t.Skip` in CI, runnable locally against `docker run postgres:16-alpine` (follows the existing `internal/app/store_test.go` convention).
- `TestSecretsStore_NilArgsRejected`: cheap unit test for the constructor's nil-arg guards.

Crypto layer stays unit-tested in `pkg/core/secrets` from phase 1 (9 tests).

### Next

- Phase 3: SecretsService server impl (5 RPCs)
- Phase 4: env-var stamping hooks in CreateContainer / StartContainer
- Phase 5: CLI subcommands
- Phase 6: MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)