### PR TITLE
feat(secrets): phase 3+4 — server impl + env-var stamping + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Sidecar image is now public on GHCR** ([#193](https://github.com/FootprintAI/Containarium/pull/193)) — `ghcr.io/footprintai/containarium-otel-sidecar:vX.Y.Z` is anonymously pullable. The compose snippet from `containarium sidecar otel compose <user>` references GHCR directly again (no local-build step). `make sidecar-build-otel` stays for dev iteration.
+- **Platform sidecar pattern design** ([#185](https://github.com/FootprintAI/Containarium/pull/185), [#186](https://github.com/FootprintAI/Containarium/pull/186)) — `docs/PLATFORM-SIDECAR-DESIGN.md` (Approved) establishes the generic primitive: image contract, naming convention, GHCR registry, version-tracking-project policy. `log-sidecar` / `scanner-sidecar` / `audit-sidecar` follow this contract when shipped.
+- **Per-LXC OTel sidecar design** ([#184](https://github.com/FootprintAI/Containarium/pull/184), [#186](https://github.com/FootprintAI/Containarium/pull/186)) — `docs/OTEL-AGENT-RELAY-DESIGN.md` (Approved). Pivoted from "Containarium installs systemd unit inside each LXC" to "Containarium publishes containarium/otel-sidecar; tenants compose it in." Closes the docker-in-LXC env-passthrough gap discovered while rolling `--monitoring` to prod ([#183](https://github.com/FootprintAI/Containarium/pull/183)).
+- **Secrets management design** ([#194](https://github.com/FootprintAI/Containarium/pull/194), [#195](https://github.com/FootprintAI/Containarium/pull/195)) — `docs/SECRETS-MANAGEMENT-DESIGN.md` (Approved). Daemon-managed tenant-secrets API: file-based master key (same custody pattern as the ZFS keyfile), AES-256-GCM in Postgres, env-var stamping at container start, per-container scope, CLI + MCP from day one. Implementation in progress: phase 1 (proto + crypto) shipped in [#196](https://github.com/FootprintAI/Containarium/pull/196), phase 2 (Postgres store) in [#197](https://github.com/FootprintAI/Containarium/pull/197).
+- **Per-container ZFS encryption design** ([#178](https://github.com/FootprintAI/Containarium/pull/178), [#179](https://github.com/FootprintAI/Containarium/pull/179)) — `docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md` (Approved). Per-tenant `encryptionroot` model with pluggable `KeyProvider` (FileKeyProvider for OSS, KMS/Vault for cloud); five lifecycle hooks. Blocked on the cloud-side multi-tenancy work.
+- **Prod rollout of `--monitoring`** on api / facelabor / pes / voicegpt / wordpress containers (operator action 2026-05-16, captured in memory). All five services are docker-in-LXC, so the LXC env is stamped but per-service docker passthrough is still up to the team.
+
 ## [0.16.12] - 2026-05-16
 
 Two unrelated fills:

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/footprintai/containarium/internal/alert"
 	"github.com/footprintai/containarium/internal/app"
+	"github.com/footprintai/containarium/internal/secrets"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/guacamole"
@@ -66,6 +67,13 @@ type ContainerServer struct {
 	// MoveContainer migration flow. Nil on daemons that don't support
 	// migration (MoveContainer returns "not configured" then).
 	moveRunner           incus.MigrationRunner
+
+	// secretsStore is the tenant-secrets backend. Nil on daemons
+	// that don't have Postgres wired up (--standalone); the
+	// SecretsService RPCs return Unavailable in that case.
+	// CreateContainer / StartContainer call LoadAllForUser to
+	// stamp environment.<NAME>=<value> at LXC start time.
+	secretsStore         *secrets.Store
 
 	// otelCollectorEndpoint is the OTLP/HTTP URL of this daemon's
 	// core OTel collector LXC (e.g. "http://10.0.3.142:4318").
@@ -251,6 +259,17 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	info, err := s.manager.Create(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create container: %w", err)
+	}
+
+	// Stamp tenant secrets into the LXC's env (best-effort — a
+	// failure here doesn't fail the create; secrets can always be
+	// retried via RefreshSecrets).
+	if s.secretsStore != nil {
+		if n, err := s.stampSecretsOnLXC(ctx, req.Username); err != nil {
+			log.Printf("[secrets] failed to stamp on %s: %v (continuing)", info.Name, err)
+		} else if n > 0 {
+			log.Printf("[secrets] stamped %d secret(s) on %s at create time", n, info.Name)
+		}
 	}
 
 	// Refresh the collector's IP map so the new container's
@@ -594,6 +613,18 @@ func (s *ContainerServer) StartContainer(ctx context.Context, req *pb.StartConta
 			}
 		}
 		return nil, fmt.Errorf("failed to start container: %w", err)
+	}
+
+	// Re-stamp tenant secrets from the current DB state. Picks up
+	// any rotations that happened while the container was stopped;
+	// existing processes won't see the change (POSIX inherit-at-fork),
+	// but new execs will.
+	if s.secretsStore != nil {
+		if n, err := s.stampSecretsOnLXC(ctx, req.Username); err != nil {
+			log.Printf("[secrets] failed to re-stamp on start of %s-container: %v (continuing)", req.Username, err)
+		} else if n > 0 {
+			log.Printf("[secrets] re-stamped %d secret(s) on %s-container at start time", n, req.Username)
+		}
 	}
 
 	info, err := s.manager.Get(req.Username)

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -33,6 +33,8 @@ import (
 	"github.com/footprintai/containarium/pkg/core/network"
 	"github.com/footprintai/containarium/internal/pentest"
 	"github.com/footprintai/containarium/internal/security"
+	secretsstore "github.com/footprintai/containarium/internal/secrets"
+	corecryptosecrets "github.com/footprintai/containarium/pkg/core/secrets"
 	zapscanner "github.com/footprintai/containarium/internal/zap"
 	"github.com/footprintai/containarium/internal/traffic"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -402,6 +404,35 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 						containerServer.SetOTelCollectorEndpoint(endpoint)
 						containerServer.SetCoreServices(coreServices)
 						log.Printf("OTel collector ready: %s (drop-labels=%v)", endpoint, config.OTelDropLabels)
+					}
+				}
+			}
+
+			// Set up the tenant secrets store. Mirrors the
+			// app-store path: shares Postgres but holds its own
+			// pgxpool. Failure here only disables the secrets
+			// API; the rest of the daemon keeps running.
+			if secretsPool, secretsErr := connectToPostgres(postgresConnString, 5, 3*time.Second); secretsErr != nil {
+				log.Printf("Warning: Failed to connect to Postgres for secrets store: %v", secretsErr)
+			} else {
+				key, created, kerr := corecryptosecrets.LoadOrCreateMasterKey("/etc/containarium/secrets.key")
+				if kerr != nil {
+					log.Printf("Warning: Failed to load secrets master key: %v. Secrets disabled.", kerr)
+					secretsPool.Close()
+				} else {
+					if created {
+						log.Printf("[secrets] NEW MASTER KEY generated at /etc/containarium/secrets.key — back this up off-host, losing it means every stored secret is unrecoverable ciphertext")
+					}
+					cipher, cerr := corecryptosecrets.NewCipher(key)
+					if cerr != nil {
+						log.Printf("Warning: Failed to construct secrets cipher: %v. Secrets disabled.", cerr)
+						secretsPool.Close()
+					} else if store, serr := secretsstore.NewStore(context.Background(), secretsPool, cipher); serr != nil {
+						log.Printf("Warning: Failed to init secrets store: %v. Secrets disabled.", serr)
+						secretsPool.Close()
+					} else {
+						containerServer.SetSecretsStore(store)
+						log.Printf("Secrets store ready (file-keyed, AES-256-GCM)")
 					}
 				}
 			}

--- a/internal/server/secrets_server.go
+++ b/internal/server/secrets_server.go
@@ -1,0 +1,254 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/footprintai/containarium/internal/secrets"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// SetSecretsStore wires the tenant-secrets backend onto the server.
+// Called from dual_server.go after the Postgres connection + master
+// key have been resolved. Nil store keeps the SecretsService RPCs
+// returning Unavailable (--standalone daemons).
+func (s *ContainerServer) SetSecretsStore(store *secrets.Store) {
+	s.secretsStore = store
+}
+
+// SetSecret creates or updates a tenant secret. Idempotent —
+// repeated calls with the same (username, name) bump the version
+// and replace the value. Admin JWT required (design decision #3).
+func (s *ContainerServer) SetSecret(ctx context.Context, req *pb.SetSecretRequest) (*pb.SetSecretResponse, error) {
+	if s.secretsStore == nil {
+		return nil, status.Error(codes.Unavailable, "secrets store not configured on this daemon")
+	}
+	if req.Username == "" {
+		return nil, status.Error(codes.InvalidArgument, "username is required")
+	}
+
+	meta, err := s.secretsStore.Set(ctx, req.Username, req.Name, req.Value)
+	if err != nil {
+		return nil, mapSecretError(err)
+	}
+
+	// Audit. Never log the value.
+	log.Printf("[secrets] set %s/%s version=%d", req.Username, req.Name, meta.Version)
+
+	msg := "secret created"
+	if meta.Version > 1 {
+		msg = fmt.Sprintf("secret updated to version %d", meta.Version)
+	}
+	return &pb.SetSecretResponse{
+		Message: msg,
+		Secret:  toProtoSecretMetadata(meta),
+	}, nil
+}
+
+// GetSecret returns the decrypted plaintext value. Always
+// audit-logged. The agent / operator sees what they wrote (decision
+// #6); v2 layers a per-secret read_via_api flag for write-only
+// rotation.
+func (s *ContainerServer) GetSecret(ctx context.Context, req *pb.GetSecretRequest) (*pb.GetSecretResponse, error) {
+	if s.secretsStore == nil {
+		return nil, status.Error(codes.Unavailable, "secrets store not configured on this daemon")
+	}
+	if req.Username == "" {
+		return nil, status.Error(codes.InvalidArgument, "username is required")
+	}
+
+	meta, value, err := s.secretsStore.Get(ctx, req.Username, req.Name)
+	if err != nil {
+		return nil, mapSecretError(err)
+	}
+
+	log.Printf("[secrets] get %s/%s version=%d", req.Username, req.Name, meta.Version)
+	return &pb.GetSecretResponse{
+		Secret: toProtoSecretMetadata(meta),
+		Value:  value,
+	}, nil
+}
+
+// ListSecrets returns metadata for every secret owned by the
+// tenant. Values are never returned by this path.
+func (s *ContainerServer) ListSecrets(ctx context.Context, req *pb.ListSecretsRequest) (*pb.ListSecretsResponse, error) {
+	if s.secretsStore == nil {
+		return nil, status.Error(codes.Unavailable, "secrets store not configured on this daemon")
+	}
+	if req.Username == "" {
+		return nil, status.Error(codes.InvalidArgument, "username is required")
+	}
+
+	list, err := s.secretsStore.List(ctx, req.Username)
+	if err != nil {
+		return nil, mapSecretError(err)
+	}
+
+	out := make([]*pb.SecretMetadata, 0, len(list))
+	for i := range list {
+		out = append(out, toProtoSecretMetadata(&list[i]))
+	}
+	return &pb.ListSecretsResponse{Secrets: out}, nil
+}
+
+// DeleteSecret removes a single secret. Does NOT cascade-clean
+// env-var stamps on running containers — callers invoke
+// RefreshSecrets if they want the change to reach a running
+// process.
+func (s *ContainerServer) DeleteSecret(ctx context.Context, req *pb.DeleteSecretRequest) (*pb.DeleteSecretResponse, error) {
+	if s.secretsStore == nil {
+		return nil, status.Error(codes.Unavailable, "secrets store not configured on this daemon")
+	}
+	if req.Username == "" {
+		return nil, status.Error(codes.InvalidArgument, "username is required")
+	}
+
+	if err := s.secretsStore.Delete(ctx, req.Username, req.Name); err != nil {
+		return nil, mapSecretError(err)
+	}
+
+	log.Printf("[secrets] delete %s/%s", req.Username, req.Name)
+	return &pb.DeleteSecretResponse{
+		Message: fmt.Sprintf("secret %s deleted", req.Name),
+	}, nil
+}
+
+// RefreshSecrets re-stamps the LXC's environment.<NAME> config
+// keys from the current secret-store state for the tenant. Running
+// processes keep their old env (POSIX semantics); new execs see
+// the refreshed values.
+func (s *ContainerServer) RefreshSecrets(ctx context.Context, req *pb.RefreshSecretsRequest) (*pb.RefreshSecretsResponse, error) {
+	if s.secretsStore == nil {
+		return nil, status.Error(codes.Unavailable, "secrets store not configured on this daemon")
+	}
+	if req.Username == "" {
+		return nil, status.Error(codes.InvalidArgument, "username is required")
+	}
+
+	stamped, err := s.stampSecretsOnLXC(ctx, req.Username)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "refresh secrets: %v", err)
+	}
+
+	log.Printf("[secrets] refresh %s: stamped=%d", req.Username, stamped)
+	return &pb.RefreshSecretsResponse{
+		Message: fmt.Sprintf("re-stamped %d secret(s) on %s-container; new execs will see updated values", stamped, req.Username),
+		Stamped: int32(stamped),
+	}, nil
+}
+
+// stampSecretsOnLXC reads every secret owned by `username`,
+// decrypts, and `incus config set environment.<NAME>=<value>`s
+// each one onto `<username>-container`. Used by RefreshSecrets
+// directly and called from CreateContainer / StartContainer once
+// phase 4 wires them up.
+//
+// Best-effort on a per-key basis: if one SetEnv call fails (e.g.
+// container doesn't exist), the rest still proceed. Returns the
+// count of successfully-stamped vars.
+func (s *ContainerServer) stampSecretsOnLXC(ctx context.Context, username string) (int, error) {
+	if s.secretsStore == nil {
+		return 0, errors.New("secrets store not configured")
+	}
+	envMap, err := s.secretsStore.LoadAllForUser(ctx, username)
+	if err != nil {
+		return 0, fmt.Errorf("load secrets: %w", err)
+	}
+
+	containerName := username + "-container"
+	stamped := 0
+	for k, v := range envMap {
+		if err := s.manager.SetEnv(containerName, k, v); err != nil {
+			log.Printf("[secrets] failed to stamp %s on %s: %v (continuing)", k, containerName, err)
+			continue
+		}
+		stamped++
+	}
+	return stamped, nil
+}
+
+// mapSecretError maps store errors to gRPC status codes. Centralized
+// so the five RPC methods stay short.
+func mapSecretError(err error) error {
+	if errors.Is(err, secrets.ErrNotFound) {
+		return status.Error(codes.NotFound, "secret not found")
+	}
+	// pkg/core/secrets validation errors carry the right message for
+	// the caller — surface as InvalidArgument.
+	msg := err.Error()
+	if isValidationError(msg) {
+		return status.Error(codes.InvalidArgument, msg)
+	}
+	return status.Errorf(codes.Internal, "%v", err)
+}
+
+// isValidationError returns true for the small set of validation
+// errors from pkg/core/secrets. Cheap substring match — these
+// errors are stable strings.
+func isValidationError(msg string) bool {
+	keywords := []string{
+		"name must match",
+		"value exceeds",
+		"username is required",
+	}
+	for _, kw := range keywords {
+		if containsCI(msg, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsCI is a tiny case-insensitive substring check that avoids
+// pulling in strings.ToLower / Contains for one match each — keeps
+// this file's dep footprint local.
+func containsCI(haystack, needle string) bool {
+	if len(needle) > len(haystack) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if lowerEqual(haystack[i:i+len(needle)], needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func lowerEqual(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if 'A' <= ca && ca <= 'Z' {
+			ca += 32
+		}
+		if 'A' <= cb && cb <= 'Z' {
+			cb += 32
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}
+
+// toProtoSecretMetadata converts the storage-layer struct to the
+// proto-facing one. Times become RFC3339 strings (proto avoids
+// timestamppb for consistency with the rest of the secrets surface).
+func toProtoSecretMetadata(m *secrets.SecretMetadata) *pb.SecretMetadata {
+	if m == nil {
+		return nil
+	}
+	return &pb.SecretMetadata{
+		Username:  m.Username,
+		Name:      m.Name,
+		Version:   m.Version,
+		CreatedAt: m.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		UpdatedAt: m.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+	}
+}


### PR DESCRIPTION
## Summary

Phases 3 and 4 of the secrets implementation per [#195](https://github.com/FootprintAI/Containarium/pull/195)'s Approved design — combined into one PR since the RPCs (phase 3) and the env-var stamping (phase 4) share the same `stampSecretsOnLXC` helper.

### Phase 3 — RPC surface

`internal/server/secrets_server.go` adds the 5 RPC methods on `ContainerServer`:

| RPC | What it does |
|---|---|
| `SetSecret` | Encrypt + upsert in Postgres; version bumps on rotation |
| `GetSecret` | Decrypt + return plaintext; audit-logged |
| `ListSecrets` | Metadata only (name/version/timestamps) |
| `DeleteSecret` | Remove a single secret; `NotFound` if missing |
| `RefreshSecrets` | Re-stamp env vars on the LXC from current DB state |

`mapSecretError` centralizes `ErrNotFound` → `NotFound`, validation errors → `InvalidArgument`, else → `Internal`. Audit log lines on every mutation (never the value).

### Phase 4 — env-var stamping

`stampSecretsOnLXC` helper: `LoadAllForUser` → per-key `manager.SetEnv`. Best-effort per key — one bad Incus call doesn't abort the rest.

Hooked into:

- `CreateContainer` (sync path) — stamps after `manager.Create` succeeds.
- `StartContainer` — re-stamps from current DB state so rotations applied while stopped land on next start.
- `RefreshSecrets` — same path, exposed as an RPC for post-rotation refresh without restart.

### Wiring

`dual_server.go` opens a pgxpool, loads (or generates-on-first-start) `/etc/containarium/secrets.key` (mode 0400), builds the AES-GCM Cipher, constructs the `Store`, sets it on `containerServer`. Loud back-it-up warning on first-run generation. Failure at any step disables secrets only — the rest of the daemon keeps running.

### CHANGELOG

Unreleased section captures: sidecar GHCR public flip, platform-sidecar + OTel-sidecar design Approvals, secrets-management design Approval + in-progress implementation, per-container ZFS encryption design Approval, prod `--monitoring` rollout on the 5 services.

### Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — all unit tests pass; pre-existing integration-test connection-refused failures unrelated
- [ ] After v0.16.13 ships + lands on prod: `containarium secrets set alice OPENAI_API_KEY sk-test`, verify `incus config show alice-container | grep OPENAI` shows the env, restart the container, exec in, `printenv | grep OPENAI` shows the value

### Next

- Phase 5: CLI subcommands (`containarium secrets {set,get,list,delete,refresh}`)
- Phase 6: MCP tools (5)
- Phase 7: Operator docs
- v0.16.13 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)