### PR TITLE
feat(secrets): phase 5+6 — CLI + MCP

### DIFF
--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -210,6 +210,70 @@ func (c *GRPCClient) DeleteContainer(username string, force bool) error {
 	return nil
 }
 
+// SetSecret creates or updates a tenant secret via gRPC. Idempotent —
+// repeated calls with the same (username, name) bump the version.
+func (c *GRPCClient) SetSecret(username, name, value string) (*pb.SecretMetadata, string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := c.client.SetSecret(ctx, &pb.SetSecretRequest{
+		Username: username, Name: name, Value: value,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("set secret: %w", err)
+	}
+	return resp.Secret, resp.Message, nil
+}
+
+// GetSecret reads a single secret's plaintext value via gRPC.
+func (c *GRPCClient) GetSecret(username, name string) (*pb.SecretMetadata, string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := c.client.GetSecret(ctx, &pb.GetSecretRequest{
+		Username: username, Name: name,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("get secret: %w", err)
+	}
+	return resp.Secret, resp.Value, nil
+}
+
+// ListSecrets returns metadata for every secret owned by the tenant.
+func (c *GRPCClient) ListSecrets(username string) ([]*pb.SecretMetadata, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := c.client.ListSecrets(ctx, &pb.ListSecretsRequest{Username: username})
+	if err != nil {
+		return nil, fmt.Errorf("list secrets: %w", err)
+	}
+	return resp.Secrets, nil
+}
+
+// DeleteSecret removes a tenant secret via gRPC.
+func (c *GRPCClient) DeleteSecret(username, name string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := c.client.DeleteSecret(ctx, &pb.DeleteSecretRequest{
+		Username: username, Name: name,
+	})
+	if err != nil {
+		return "", fmt.Errorf("delete secret: %w", err)
+	}
+	return resp.Message, nil
+}
+
+// RefreshSecrets re-stamps the LXC's env from the current secret DB
+// state for the tenant. Running processes keep their old env; new
+// execs see the refreshed values.
+func (c *GRPCClient) RefreshSecrets(username string) (string, int32, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := c.client.RefreshSecrets(ctx, &pb.RefreshSecretsRequest{Username: username})
+	if err != nil {
+		return "", 0, fmt.Errorf("refresh secrets: %w", err)
+	}
+	return resp.Message, resp.Stamped, nil
+}
+
 // ResizeContainer changes a container's CPU / memory / disk via gRPC.
 // Empty string for any field means "no change". Disk can only grow —
 // the server rejects shrinks.

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -284,6 +284,127 @@ func (c *HTTPClient) ToggleMonitoring(username string, enabled bool) (string, bo
 	return result.Message, result.MonitoringEnabled, nil
 }
 
+// SetSecret creates or updates a tenant secret via HTTP.
+func (c *HTTPClient) SetSecret(username, name, value string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	body, _ := json.Marshal(map[string]string{
+		"username": username,
+		"name":     name,
+		"value":    value,
+	})
+	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/secrets", body)
+	if err != nil {
+		return "", fmt.Errorf("set secret: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return "", parseErr(b, resp.StatusCode, "set secret")
+	}
+	var result struct {
+		Message string `json:"message"`
+	}
+	_ = json.Unmarshal(b, &result)
+	return result.Message, nil
+}
+
+// GetSecret reads a single secret's plaintext value via HTTP.
+func (c *HTTPClient) GetSecret(username, name string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	path := fmt.Sprintf("/v1/secrets/%s/%s", url.PathEscape(username), url.PathEscape(name))
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return "", fmt.Errorf("get secret: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return "", parseErr(b, resp.StatusCode, "get secret")
+	}
+	var result struct {
+		Value string `json:"value"`
+	}
+	_ = json.Unmarshal(b, &result)
+	return result.Value, nil
+}
+
+// ListSecrets returns metadata for every secret owned by the tenant.
+// Each entry is the name/version/timestamps tuple — values are only
+// readable via GetSecret per-name.
+func (c *HTTPClient) ListSecrets(username string) ([]map[string]interface{}, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	path := fmt.Sprintf("/v1/secrets/%s", url.PathEscape(username))
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list secrets: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, parseErr(b, resp.StatusCode, "list secrets")
+	}
+	var result struct {
+		Secrets []map[string]interface{} `json:"secrets"`
+	}
+	_ = json.Unmarshal(b, &result)
+	return result.Secrets, nil
+}
+
+// DeleteSecret removes a tenant secret via HTTP.
+func (c *HTTPClient) DeleteSecret(username, name string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	path := fmt.Sprintf("/v1/secrets/%s/%s", url.PathEscape(username), url.PathEscape(name))
+	resp, err := c.doRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return fmt.Errorf("delete secret: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return parseErr(b, resp.StatusCode, "delete secret")
+	}
+	return nil
+}
+
+// RefreshSecrets re-stamps the tenant's secrets into the LXC env.
+func (c *HTTPClient) RefreshSecrets(username string) (string, int32, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	path := fmt.Sprintf("/v1/secrets/%s/refresh", url.PathEscape(username))
+	resp, err := c.doRequest(ctx, http.MethodPost, path, []byte("{}"))
+	if err != nil {
+		return "", 0, fmt.Errorf("refresh secrets: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return "", 0, parseErr(b, resp.StatusCode, "refresh secrets")
+	}
+	var result struct {
+		Message string `json:"message"`
+		Stamped int32  `json:"stamped"`
+	}
+	_ = json.Unmarshal(b, &result)
+	return result.Message, result.Stamped, nil
+}
+
+// parseErr is a tiny helper used across the secrets HTTP methods to
+// surface the server's structured error body (`{"error":"..."}`)
+// when present, falling back to the status code otherwise.
+func parseErr(body []byte, status int, op string) error {
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
+		return fmt.Errorf("%s", errResp.Error)
+	}
+	return fmt.Errorf("%s: status %d", op, status)
+}
+
 // ResizeContainer changes a container's CPU / memory / disk via HTTP.
 // Empty string for any field means "no change". Disk can only grow.
 func (c *HTTPClient) ResizeContainer(username, cpu, memory, disk string) (string, error) {

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -1,0 +1,276 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/footprintai/containarium/internal/client"
+	"github.com/spf13/cobra"
+)
+
+// Tenant secrets — daemon-managed, AES-256-GCM in Postgres,
+// stamped as environment.<NAME>=<value> on the LXC at container
+// start. See docs/SECRETS-MANAGEMENT-DESIGN.md.
+//
+// Remote-only — there's no local fallback because the daemon owns
+// the master key and the Postgres connection. Same pattern as
+// `containarium monitoring`.
+
+var secretsCmd = &cobra.Command{
+	Use:   "secrets",
+	Short: "Manage tenant secrets stored encrypted on the daemon",
+	Long: `Manage tenant secrets (API keys, DB passwords, etc.) stored
+encrypted at rest on the Containarium daemon. Values are stamped as
+environment.<NAME>=<value> on the LXC at container start, so apps
+inside docker read them via compose ${VAR} interpolation.
+
+See docs/SECRETS-MANAGEMENT-DESIGN.md.`,
+}
+
+var secretsSetCmd = &cobra.Command{
+	Use:   "set <username> <NAME> <value>",
+	Short: "Create or update a tenant secret",
+	Long: `Idempotent set-or-rotate. The first call creates the secret; later
+calls with the same (username, NAME) bump the version and replace the
+value. Names must match ^[A-Z_][A-Z0-9_]*$ (env-var convention);
+values are capped at 64 KiB.
+
+Containers stamp the new env on next CreateContainer / StartContainer.
+For rotation against a running container, call:
+  containarium secrets refresh <username>
+
+Examples:
+  containarium secrets set alice OPENAI_API_KEY sk-abc...
+  containarium secrets set alice DATABASE_URL "postgres://..."`,
+	Args: cobra.ExactArgs(3),
+	RunE: runSecretsSet,
+}
+
+var secretsGetCmd = &cobra.Command{
+	Use:   "get <username> <NAME>",
+	Short: "Read a tenant secret's plaintext value",
+	Long: `Returns the decrypted plaintext to stdout. Always audit-logged
+on the daemon. Be mindful where you redirect the output.`,
+	Args: cobra.ExactArgs(2),
+	RunE: runSecretsGet,
+}
+
+var secretsListCmd = &cobra.Command{
+	Use:   "list <username>",
+	Short: "List a tenant's secrets (metadata only)",
+	Long:  `Returns name/version/timestamps tuples. Values are only readable per-name via 'secrets get'.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSecretsList,
+}
+
+var secretsDeleteCmd = &cobra.Command{
+	Use:     "delete <username> <NAME>",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Delete a tenant secret",
+	Long: `Removes the secret from Postgres. Does NOT cascade to env-var
+stamps on running containers — call 'secrets refresh' separately if
+the change should reach the next exec without a container restart.`,
+	Args: cobra.ExactArgs(2),
+	RunE: runSecretsDelete,
+}
+
+var secretsRefreshCmd = &cobra.Command{
+	Use:   "refresh <username>",
+	Short: "Re-stamp env vars on the LXC from the current secrets store",
+	Long: `Reads all of the tenant's secrets, decrypts them, and updates the
+container's environment.<NAME> config keys to match. Running
+processes keep their old env (POSIX inherit-at-fork); new execs
+(including a fresh 'docker compose up') see the refreshed values.
+
+Use this after rotating a secret if you want the change to land
+without restarting the whole container.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSecretsRefresh,
+}
+
+func init() {
+	rootCmd.AddCommand(secretsCmd)
+	secretsCmd.AddCommand(secretsSetCmd)
+	secretsCmd.AddCommand(secretsGetCmd)
+	secretsCmd.AddCommand(secretsListCmd)
+	secretsCmd.AddCommand(secretsDeleteCmd)
+	secretsCmd.AddCommand(secretsRefreshCmd)
+}
+
+func runSecretsSet(cmd *cobra.Command, args []string) error {
+	username, name, value := args[0], args[1], args[2]
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required for secrets commands (daemon owns the master key)")
+	}
+
+	if httpMode {
+		h, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return err
+		}
+		defer h.Close()
+		msg, err := h.SetSecret(username, name, value)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("✓ %s\n", msg)
+		return nil
+	}
+	g, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return err
+	}
+	defer g.Close()
+	meta, msg, err := g.SetSecret(username, name, value)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ %s (version=%d)\n", msg, meta.Version)
+	return nil
+}
+
+func runSecretsGet(cmd *cobra.Command, args []string) error {
+	username, name := args[0], args[1]
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required for secrets commands")
+	}
+
+	if httpMode {
+		h, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return err
+		}
+		defer h.Close()
+		value, err := h.GetSecret(username, name)
+		if err != nil {
+			return err
+		}
+		// Print only the value, no trailing newline — so callers
+		// can `containarium secrets get ... | clip` cleanly.
+		fmt.Print(value)
+		return nil
+	}
+	g, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return err
+	}
+	defer g.Close()
+	_, value, err := g.GetSecret(username, name)
+	if err != nil {
+		return err
+	}
+	fmt.Print(value)
+	return nil
+}
+
+func runSecretsList(cmd *cobra.Command, args []string) error {
+	username := args[0]
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required for secrets commands")
+	}
+
+	if httpMode {
+		h, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return err
+		}
+		defer h.Close()
+		list, err := h.ListSecrets(username)
+		if err != nil {
+			return err
+		}
+		if len(list) == 0 {
+			fmt.Printf("(no secrets for %s)\n", username)
+			return nil
+		}
+		fmt.Printf("%-32s %-8s %s\n", "NAME", "VERSION", "UPDATED")
+		for _, row := range list {
+			fmt.Printf("%-32s %-8v %v\n", row["name"], row["version"], row["updated_at"])
+		}
+		return nil
+	}
+	g, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return err
+	}
+	defer g.Close()
+	list, err := g.ListSecrets(username)
+	if err != nil {
+		return err
+	}
+	if len(list) == 0 {
+		fmt.Printf("(no secrets for %s)\n", username)
+		return nil
+	}
+	fmt.Printf("%-32s %-8s %s\n", "NAME", "VERSION", "UPDATED")
+	for _, row := range list {
+		fmt.Printf("%-32s %-8d %s\n", row.Name, row.Version, strings.TrimSuffix(row.UpdatedAt, "Z"))
+	}
+	return nil
+}
+
+func runSecretsDelete(cmd *cobra.Command, args []string) error {
+	username, name := args[0], args[1]
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required for secrets commands")
+	}
+
+	if httpMode {
+		h, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return err
+		}
+		defer h.Close()
+		if err := h.DeleteSecret(username, name); err != nil {
+			return err
+		}
+		fmt.Printf("✓ secret %s deleted\n", name)
+		return nil
+	}
+	g, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return err
+	}
+	defer g.Close()
+	msg, err := g.DeleteSecret(username, name)
+	if err != nil {
+		return err
+	}
+	if msg == "" {
+		msg = fmt.Sprintf("secret %s deleted", name)
+	}
+	fmt.Printf("✓ %s\n", msg)
+	return nil
+}
+
+func runSecretsRefresh(cmd *cobra.Command, args []string) error {
+	username := args[0]
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required for secrets commands")
+	}
+
+	var msg string
+	var stamped int32
+	var err error
+
+	if httpMode {
+		h, herr := client.NewHTTPClient(serverAddr, authToken)
+		if herr != nil {
+			return herr
+		}
+		defer h.Close()
+		msg, stamped, err = h.RefreshSecrets(username)
+	} else {
+		g, gerr := client.NewGRPCClient(serverAddr, certsDir, insecure)
+		if gerr != nil {
+			return gerr
+		}
+		defer g.Close()
+		msg, stamped, err = g.RefreshSecrets(username)
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ %s (stamped=%d)\n", msg, stamped)
+	return nil
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -226,6 +226,77 @@ func (c *Client) ResizeContainer(username, cpu, memory, disk string) (*ResizeCon
 	return &resp, nil
 }
 
+// SetSecret creates or updates a tenant secret. Idempotent —
+// repeated calls with the same (username, name) bump the version.
+func (c *Client) SetSecret(username, name, value string) (*SecretResponse, error) {
+	body, err := json.Marshal(map[string]string{
+		"username": username, "name": name, "value": value,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	respBody, err := c.doRequest("POST", "/v1/secrets", body)
+	if err != nil {
+		return nil, err
+	}
+	var resp SecretResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	return &resp, nil
+}
+
+// GetSecret reads a single secret's plaintext value.
+func (c *Client) GetSecret(username, name string) (string, error) {
+	respBody, err := c.doRequest("GET", fmt.Sprintf("/v1/secrets/%s/%s", username, name), nil)
+	if err != nil {
+		return "", err
+	}
+	var resp struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return "", fmt.Errorf("decode: %w", err)
+	}
+	return resp.Value, nil
+}
+
+// ListSecrets returns metadata for every tenant secret.
+func (c *Client) ListSecrets(username string) ([]map[string]interface{}, error) {
+	respBody, err := c.doRequest("GET", fmt.Sprintf("/v1/secrets/%s", username), nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Secrets []map[string]interface{} `json:"secrets"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	return resp.Secrets, nil
+}
+
+// DeleteSecret removes a tenant secret.
+func (c *Client) DeleteSecret(username, name string) error {
+	if _, err := c.doRequest("DELETE", fmt.Sprintf("/v1/secrets/%s/%s", username, name), nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+// RefreshSecrets re-stamps env vars on the LXC.
+func (c *Client) RefreshSecrets(username string) (*RefreshSecretsResponse, error) {
+	respBody, err := c.doRequest("POST", fmt.Sprintf("/v1/secrets/%s/refresh", username), []byte("{}"))
+	if err != nil {
+		return nil, err
+	}
+	var resp RefreshSecretsResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	return &resp, nil
+}
+
 // DeleteContainer deletes a container
 func (c *Client) DeleteContainer(username string, force bool) (*DeleteContainerResponse, error) {
 	path := fmt.Sprintf("/v1/containers/%s?force=%v", username, force)
@@ -690,6 +761,16 @@ type ToggleMonitoringResponse struct {
 type ResizeContainerResponse struct {
 	Message   string    `json:"message"`
 	Container Container `json:"container"`
+}
+
+type SecretResponse struct {
+	Message string                 `json:"message"`
+	Secret  map[string]interface{} `json:"secret"`
+}
+
+type RefreshSecretsResponse struct {
+	Message string `json:"message"`
+	Stamped int32  `json:"stamped"`
 }
 
 type StartContainerResponse struct {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,7 +22,7 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	assert.Len(t, server.tools, 22, "Should have 22 tools registered")
+	assert.Len(t, server.tools, 27, "Should have 27 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -126,7 +126,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	assert.Len(t, tools, 22)
+	assert.Len(t, tools, 27)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -308,6 +308,70 @@ func (s *Server) registerTools() {
 			Handler: handleResizeContainer,
 		},
 		{
+			Name:        "set_secret",
+			Description: "Create or update a tenant secret stored encrypted (AES-256-GCM) on the daemon. The value will be stamped as environment.<NAME> on the LXC on next CreateContainer / StartContainer / refresh_secrets. Idempotent — repeated calls bump the version and replace the value. Names must be uppercase env-var-style (^[A-Z_][A-Z0-9_]*$, max 128 chars); values capped at 64 KiB.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{"type": "string", "description": "Tenant username owning the secret"},
+					"name":     map[string]interface{}{"type": "string", "description": "Env-var-style name (uppercase + digits + underscore, e.g. OPENAI_API_KEY)"},
+					"value":    map[string]interface{}{"type": "string", "description": "Plaintext value; the daemon encrypts before persisting"},
+				},
+				"required": []string{"username", "name", "value"},
+			},
+			Handler: handleSetSecret,
+		},
+		{
+			Name:        "get_secret",
+			Description: "Read a single tenant secret's plaintext value. Always audit-logged. Use this to verify what you just wrote or to hand a value to a script via stdout — be mindful where the output goes.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{"type": "string", "description": "Tenant username"},
+					"name":     map[string]interface{}{"type": "string", "description": "Secret name"},
+				},
+				"required": []string{"username", "name"},
+			},
+			Handler: handleGetSecret,
+		},
+		{
+			Name:        "list_secrets",
+			Description: "List a tenant's secret names + versions + timestamps. Never returns the plaintext values — use get_secret per-name for that (audit-logged separately).",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{"type": "string", "description": "Tenant username"},
+				},
+				"required": []string{"username"},
+			},
+			Handler: handleListSecrets,
+		},
+		{
+			Name:        "delete_secret",
+			Description: "Remove a tenant secret from the store. Does NOT cascade to env-var stamps on running containers — call refresh_secrets separately if the deletion should reach the next exec without a container restart.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{"type": "string", "description": "Tenant username"},
+					"name":     map[string]interface{}{"type": "string", "description": "Secret name"},
+				},
+				"required": []string{"username", "name"},
+			},
+			Handler: handleDeleteSecret,
+		},
+		{
+			Name:        "refresh_secrets",
+			Description: "Re-stamp env vars on the LXC from the current secret-store state. Useful after rotation when the next exec'd process should see the new value without a full container restart. Running processes keep their old env (POSIX inherit-at-fork); new execs see the refresh.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{"type": "string", "description": "Tenant username"},
+				},
+				"required": []string{"username"},
+			},
+			Handler: handleRefreshSecrets,
+		},
+		{
 			Name:        "toggle_monitoring",
 			Description: "Enable or disable application-emitted OpenTelemetry on an existing container without recreating it. When enabling, the daemon stamps OTEL_EXPORTER_OTLP_ENDPOINT + related env vars and restarts the container so the app picks them up. Use this to retrofit monitoring onto containers created before --monitoring was wired in. Requires the daemon to have an OTel collector endpoint configured.",
 			InputSchema: map[string]interface{}{
@@ -933,6 +997,76 @@ func handleDebugContainer(client *Client, args map[string]interface{}) (string, 
 	}
 
 	return string(jsonData), nil
+}
+
+func handleSetSecret(client *Client, args map[string]interface{}) (string, error) {
+	username, _ := args["username"].(string)
+	name, _ := args["name"].(string)
+	value, _ := args["value"].(string)
+	if username == "" || name == "" {
+		return "", fmt.Errorf("username and name are required")
+	}
+	resp, err := client.SetSecret(username, name, value)
+	if err != nil {
+		return "", fmt.Errorf("failed to set secret: %w", err)
+	}
+	return fmt.Sprintf("✅ %s", resp.Message), nil
+}
+
+func handleGetSecret(client *Client, args map[string]interface{}) (string, error) {
+	username, _ := args["username"].(string)
+	name, _ := args["name"].(string)
+	if username == "" || name == "" {
+		return "", fmt.Errorf("username and name are required")
+	}
+	value, err := client.GetSecret(username, name)
+	if err != nil {
+		return "", fmt.Errorf("failed to get secret: %w", err)
+	}
+	return value, nil
+}
+
+func handleListSecrets(client *Client, args map[string]interface{}) (string, error) {
+	username, _ := args["username"].(string)
+	if username == "" {
+		return "", fmt.Errorf("username is required")
+	}
+	list, err := client.ListSecrets(username)
+	if err != nil {
+		return "", fmt.Errorf("failed to list secrets: %w", err)
+	}
+	if len(list) == 0 {
+		return fmt.Sprintf("(no secrets for %s)", username), nil
+	}
+	b, err := json.MarshalIndent(list, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal: %w", err)
+	}
+	return string(b), nil
+}
+
+func handleDeleteSecret(client *Client, args map[string]interface{}) (string, error) {
+	username, _ := args["username"].(string)
+	name, _ := args["name"].(string)
+	if username == "" || name == "" {
+		return "", fmt.Errorf("username and name are required")
+	}
+	if err := client.DeleteSecret(username, name); err != nil {
+		return "", fmt.Errorf("failed to delete secret: %w", err)
+	}
+	return fmt.Sprintf("✅ secret %s deleted", name), nil
+}
+
+func handleRefreshSecrets(client *Client, args map[string]interface{}) (string, error) {
+	username, _ := args["username"].(string)
+	if username == "" {
+		return "", fmt.Errorf("username is required")
+	}
+	resp, err := client.RefreshSecrets(username)
+	if err != nil {
+		return "", fmt.Errorf("failed to refresh secrets: %w", err)
+	}
+	return fmt.Sprintf("✅ %s", resp.Message), nil
 }
 
 func handleResizeContainer(client *Client, args map[string]interface{}) (string, error) {


### PR DESCRIPTION
## Summary

Closes the OSS-side secrets implementation per the Approved design ([#195](https://github.com/FootprintAI/Containarium/pull/195)). Phases 1–4 ([#196](https://github.com/FootprintAI/Containarium/pull/196) / [#197](https://github.com/FootprintAI/Containarium/pull/197) / [#198](https://github.com/FootprintAI/Containarium/pull/198)) built the proto, crypto, store, server impl and env-var stamping. This PR adds the user-facing CLI + MCP surface.

### Phase 5 — CLI

```bash
containarium secrets set     alice OPENAI_API_KEY sk-abc...
containarium secrets get     alice OPENAI_API_KEY            # prints to stdout, no trailing newline
containarium secrets list    alice                            # name / version / updated_at table
containarium secrets delete  alice OPENAI_API_KEY
containarium secrets refresh alice                            # re-stamp LXC env without restart
```

Remote-only (daemon owns the master key + Postgres). Goes through gRPC by default; HTTPClient when `--http` is set. `parseErr` helper centralizes the `{"error": "..."}` body parsing across the HTTP paths.

### Phase 6 — MCP

5 new tools: `set_secret`, `get_secret`, `list_secrets`, `delete_secret`, `refresh_secrets`. Agents can rotate, verify, list, delete, and refresh tenant secrets via Claude Code / Cursor with the same wire surface as the CLI. Tool count bumped 22 → 27.

### Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/cmd/ ./internal/mcp/ ./internal/server/ ./pkg/core/secrets/ ./internal/secrets/` — all pass
- [ ] After v0.16.13 ships: end-to-end smoke on prod:
  - `containarium secrets set alice OPENAI_API_KEY sk-test --server ...`
  - `containarium secrets list alice` — shows the entry
  - SSH into `alice-container`, `printenv | grep OPENAI` — value present
  - Rotate via `set` again, `secrets refresh alice`, `incus config show` shows the new value
  - `delete` removes it from the store

### What's next

The OSS-side implementation is complete. Cloud-product follow-ups (KMS-backed master key, per-secret ACLs, sidecar resolver, structured audit pipeline) layer on top of this wire surface — same shape as the ZFS-encryption v1/v2 split. Time for v0.16.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)