### PR TITLE
feat(cli): surface MonitoringEnabled in containarium list

### DIFF
--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -99,8 +99,9 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 	var containers []incus.ContainerInfo
 	for _, container := range resp.Containers {
 		info := incus.ContainerInfo{
-			Name:  container.Name,
-			State: container.State.String(),
+			Name:              container.Name,
+			State:             container.State.String(),
+			MonitoringEnabled: container.MonitoringEnabled,
 		}
 
 		// Get IP address from network info

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -102,16 +102,17 @@ func parseResponse[T any](resp *http.Response) (*T, error) {
 
 // Container response types matching the protobuf JSON output
 type containerResponse struct {
-	Name          string            `json:"name"`
-	Username      string            `json:"username"`
-	State         string            `json:"state"`
-	Resources     *resourceLimits   `json:"resources"`
-	Network       *networkInfo      `json:"network"`
-	CreatedAt     string            `json:"createdAt"`
-	Labels        map[string]string `json:"labels"`
-	Image         string            `json:"image"`
-	PodmanEnabled bool              `json:"dockerEnabled"`
-	GpuDevice     string            `json:"gpuDevice"`
+	Name              string            `json:"name"`
+	Username          string            `json:"username"`
+	State             string            `json:"state"`
+	Resources         *resourceLimits   `json:"resources"`
+	Network           *networkInfo      `json:"network"`
+	CreatedAt         string            `json:"createdAt"`
+	Labels            map[string]string `json:"labels"`
+	Image             string            `json:"image"`
+	PodmanEnabled     bool              `json:"dockerEnabled"`
+	GpuDevice         string            `json:"gpuDevice"`
+	MonitoringEnabled bool              `json:"monitoringEnabled"`
 }
 
 type resourceLimits struct {
@@ -157,9 +158,10 @@ type systemInfo struct {
 // containerToIncusInfo converts API response to incus.ContainerInfo
 func containerToIncusInfo(c *containerResponse) incus.ContainerInfo {
 	info := incus.ContainerInfo{
-		Name:   c.Name,
-		State:  c.State,
-		Labels: c.Labels,
+		Name:              c.Name,
+		State:             c.State,
+		Labels:            c.Labels,
+		MonitoringEnabled: c.MonitoringEnabled,
 	}
 
 	if c.Network != nil {

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -162,12 +162,15 @@ func runList(cmd *cobra.Command, args []string) error {
 }
 
 func printTableFormat(containers []interface{}, running, stopped int, withLabels bool) {
+	// MON column: ✓ when the container has app-emitted OTel
+	// stamped in (environment.OTEL_EXPORTER_OTLP_ENDPOINT
+	// non-empty). 3-char column keeps the table compact.
 	if withLabels {
-		fmt.Printf("%-25s %-12s %-20s %-15s %s\n", "CONTAINER NAME", "STATUS", "IP ADDRESS", "CPU/MEMORY", "LABELS")
-		fmt.Printf("%-25s %-12s %-20s %-15s %s\n", strings.Repeat("-", 25), strings.Repeat("-", 12), strings.Repeat("-", 20), strings.Repeat("-", 15), strings.Repeat("-", 30))
+		fmt.Printf("%-25s %-12s %-3s %-20s %-15s %s\n", "CONTAINER NAME", "STATUS", "MON", "IP ADDRESS", "CPU/MEMORY", "LABELS")
+		fmt.Printf("%-25s %-12s %-3s %-20s %-15s %s\n", strings.Repeat("-", 25), strings.Repeat("-", 12), "---", strings.Repeat("-", 20), strings.Repeat("-", 15), strings.Repeat("-", 30))
 	} else {
-		fmt.Printf("%-25s %-12s %-20s %-15s\n", "CONTAINER NAME", "STATUS", "IP ADDRESS", "CPU/MEMORY")
-		fmt.Printf("%-25s %-12s %-20s %-15s\n", strings.Repeat("-", 25), strings.Repeat("-", 12), strings.Repeat("-", 20), strings.Repeat("-", 15))
+		fmt.Printf("%-25s %-12s %-3s %-20s %-15s\n", "CONTAINER NAME", "STATUS", "MON", "IP ADDRESS", "CPU/MEMORY")
+		fmt.Printf("%-25s %-12s %-3s %-20s %-15s\n", strings.Repeat("-", 25), strings.Repeat("-", 12), "---", strings.Repeat("-", 20), strings.Repeat("-", 15))
 	}
 
 	if len(containers) == 0 {
@@ -175,6 +178,7 @@ func printTableFormat(containers []interface{}, running, stopped int, withLabels
 		return
 	}
 
+	monCount := 0
 	for _, item := range containers {
 		c := item.(incus.ContainerInfo)
 		ip := c.IPAddress
@@ -187,16 +191,22 @@ func printTableFormat(containers []interface{}, running, stopped int, withLabels
 			resources = "-"
 		}
 
+		mon := "-"
+		if c.MonitoringEnabled {
+			mon = "✓"
+			monCount++
+		}
+
 		if withLabels {
 			labelStr := formatLabels(c.Labels)
-			fmt.Printf("%-25s %-12s %-20s %-15s %s\n", c.Name, c.State, ip, resources, labelStr)
+			fmt.Printf("%-25s %-12s %-3s %-20s %-15s %s\n", c.Name, c.State, mon, ip, resources, labelStr)
 		} else {
-			fmt.Printf("%-25s %-12s %-20s %-15s\n", c.Name, c.State, ip, resources)
+			fmt.Printf("%-25s %-12s %-3s %-20s %-15s\n", c.Name, c.State, mon, ip, resources)
 		}
 	}
 
 	fmt.Println()
-	fmt.Printf("Total: %d containers (%d running, %d stopped)\n", len(containers), running, stopped)
+	fmt.Printf("Total: %d containers (%d running, %d stopped, %d monitored)\n", len(containers), running, stopped, monCount)
 }
 
 // formatLabels formats labels as a comma-separated string
@@ -249,6 +259,7 @@ func printYAMLFormat(containers []interface{}) {
 		fmt.Printf("  - name: %s\n", c.Name)
 		fmt.Printf("    state: %s\n", c.State)
 		fmt.Printf("    ip_address: %s\n", c.IPAddress)
+		fmt.Printf("    monitoring_enabled: %t\n", c.MonitoringEnabled)
 		if c.CPU != "" {
 			fmt.Printf("    cpu: %s\n", c.CPU)
 		}


### PR DESCRIPTION
## Summary

You can't easily see at a glance which containers have monitoring enabled. The data was already loaded into `incus.ContainerInfo.MonitoringEnabled` (derived from `environment.OTEL_EXPORTER_OTLP_ENDPOINT` non-empty), but two layers dropped it on the way to the operator's eyes:

1. The gRPC client's `ListContainers` proto→ContainerInfo conversion didn't copy the field.
2. The HTTP client's `containerResponse` JSON struct didn't have it.
3. The `list` table didn't include the column at all.

This PR fixes all three.

### Output

```
CONTAINER NAME            STATUS       MON IP ADDRESS           CPU/MEMORY
------------------------- ------------ --- -------------------- ---------------
api-container             RUNNING      ✓   10.0.3.248           4c/16GB
devbox-container          RUNNING      ✓   10.0.3.250           8c/32GB
facelabor-container       RUNNING      ✓   10.0.3.15            8c/16GB
pes-container             RUNNING      ✓   10.0.3.136           4c/24GB
voicegpt-container        RUNNING      ✓   10.0.3.57            4c/16GB
wordpress-container       RUNNING      ✓   10.0.3.53            1c/4GB
ccu01-container           RUNNING      -   10.0.3.170           8c/16GB
…

Total: 17 containers (17 running, 0 stopped, 6 monitored)
```

YAML output picks up `monitoring_enabled: true|false` for scriptable consumers.

### Verified

Smoke-tested against prod's `containarium-jump-usw1` — the 6 containers that have monitoring enabled show ✓; the 11 that don't show `-`. Matches the on-disk Incus config.

### Out of scope

The `CONTAINER_STATE_RUNNING` instead of `Running` and miscounted running/stopped totals in the remote-mode list output — those are pre-existing display bugs unrelated to this column addition. File separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)