### PR TITLE
fix(metrics): fall back to rootfs walk for disk usage on dir backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Per-container disk usage on the `dir` storage backend** — `containarium list`, MCP `get_metrics`, and the OTel collector all reported 0 B for disk usage on hosts that init Incus with the `dir` driver (e.g. lab boxes without a zpool). Incus only fills `state.Disk["root"].Usage` when the backend has filesystem-level quota accounting (zfs / btrfs); on dir backends the field stays empty and there was no fallback. `GetContainerMetrics` now walks the container's rootfs (`/var/lib/incus/storage-pools/<pool>/containers/<name>/rootfs`, same path `du -bs` would) and reports the sum. The walk runs only when Incus's native value is zero, so zfs / btrfs hosts pay nothing.
+
 ## [0.16.13] - 2026-05-16
 
 Ships the **tenant secrets management API** end-to-end (CLI + MCP + REST + gRPC), plus the documentation Approvals that landed alongside it.

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -1187,9 +1189,23 @@ func (c *Client) GetContainerMetrics(name string) (*ContainerMetrics, error) {
 		metrics.MemoryLimitBytes = state.Memory.UsagePeak
 	}
 
-	// Disk usage (root filesystem)
-	if rootDisk, ok := state.Disk["root"]; ok {
+	// Disk usage (root filesystem). The ZFS / btrfs backends report
+	// usage via state.Disk["root"].Usage natively. The "dir" backend
+	// — used on lab boxes that don't have a zpool — leaves that
+	// field at zero because the host filesystem has no per-container
+	// quota accounting. Without a fallback, every dir-backed deploy
+	// would show 0 B for disk usage in `list`, MCP `get_metrics`,
+	// and the OTel collector, which is misleading enough that
+	// operators stop trusting the field entirely. Walking the
+	// container's rootfs gives us the same number `du -bs` would
+	// (it IS what du does), at a cost that's acceptable for the
+	// list-containers cardinality we expect.
+	if rootDisk, ok := state.Disk["root"]; ok && rootDisk.Usage > 0 {
 		metrics.DiskUsageBytes = rootDisk.Usage
+	} else if rootfs := c.containerRootfsPath(name); rootfs != "" {
+		if bytes, err := dirSize(rootfs); err == nil {
+			metrics.DiskUsageBytes = bytes
+		}
 	}
 
 	// Network usage (sum all interfaces except lo)
@@ -1667,4 +1683,79 @@ func MatchLabels(containerLabels, filter map[string]string) bool {
 		}
 	}
 	return true
+}
+
+// containerRootfsPath resolves the on-disk rootfs directory for the
+// named container so dirSize can walk it. Returns "" when the path
+// can't be resolved or doesn't exist — callers treat empty as "skip
+// the fallback."
+//
+// Conventional layout (matches incus's "dir" + "zfs" mount layout):
+//
+//	<pool_source>/containers/<name>/rootfs
+//
+// When the pool has no explicit source config (the typical dir-
+// backend case) we fall back to incus's hard-coded default of
+// /var/lib/incus/storage-pools/<pool>.
+func (c *Client) containerRootfsPath(containerName string) string {
+	inst, _, err := c.server.GetInstance(containerName)
+	if err != nil {
+		return ""
+	}
+	pool := ""
+	if rootDev, ok := inst.ExpandedDevices["root"]; ok {
+		pool = rootDev["pool"]
+	}
+	if pool == "" {
+		pool = "default"
+	}
+	poolCfg, _, err := c.server.GetStoragePool(pool)
+	if err != nil {
+		return ""
+	}
+	path := buildContainerRootfsPath(pool, poolCfg.Config["source"], containerName)
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	return path
+}
+
+// buildContainerRootfsPath is the pure path-construction half of
+// containerRootfsPath — separated so it's easy to test without an
+// Incus server. The poolSource argument matches the value Incus
+// stores under `Config["source"]` on a storage pool; an absolute
+// path is used as-is, anything else falls through to the conventional
+// /var/lib/incus/storage-pools/<pool> default.
+func buildContainerRootfsPath(pool, poolSource, containerName string) string {
+	base := poolSource
+	if !filepath.IsAbs(base) {
+		base = filepath.Join("/var/lib/incus/storage-pools", pool)
+	}
+	return filepath.Join(base, "containers", containerName, "rootfs")
+}
+
+// dirSize returns the cumulative size of regular files under root.
+// Skips directories, symlinks, sockets, and unreadable entries —
+// matches `du -bs` semantics for the metric we surface. Used as a
+// fallback when Incus's per-container disk-usage field is zero
+// (dir backend has no quota accounting; see GetContainerMetrics).
+func dirSize(root string) (int64, error) {
+	var total int64
+	err := filepath.WalkDir(root, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Unreadable entry — skip rather than abort. A best-
+			// effort metric is more useful than no metric.
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		total += info.Size()
+		return nil
+	})
+	return total, err
 }

--- a/pkg/core/incus/disk_usage_test.go
+++ b/pkg/core/incus/disk_usage_test.go
@@ -1,0 +1,140 @@
+package incus
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestBuildContainerRootfsPath nails down the path-resolution
+// convention for the dir-backend disk-usage fallback. If incus
+// ever moves where it puts pool sources we want this test to fail
+// before the fallback silently starts looking at the wrong tree.
+func TestBuildContainerRootfsPath(t *testing.T) {
+	tests := []struct {
+		name          string
+		pool          string
+		poolSource    string
+		containerName string
+		want          string
+	}{
+		{
+			name:          "explicit absolute source (zfs pool source path)",
+			pool:          "default",
+			poolSource:    "/srv/containarium/storage",
+			containerName: "alice",
+			want:          "/srv/containarium/storage/containers/alice/rootfs",
+		},
+		{
+			name:          "empty source falls through to incus default",
+			pool:          "default",
+			poolSource:    "",
+			containerName: "alice",
+			want:          "/var/lib/incus/storage-pools/default/containers/alice/rootfs",
+		},
+		{
+			name:          "non-path source (e.g. zfs dataset name) falls through to default",
+			pool:          "fast",
+			poolSource:    "tank/incus",
+			containerName: "bob",
+			want:          "/var/lib/incus/storage-pools/fast/containers/bob/rootfs",
+		},
+		{
+			name:          "non-default pool name with explicit source",
+			pool:          "fast",
+			poolSource:    "/mnt/fast-pool",
+			containerName: "carol",
+			want:          "/mnt/fast-pool/containers/carol/rootfs",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildContainerRootfsPath(tc.pool, tc.poolSource, tc.containerName)
+			if got != tc.want {
+				t.Errorf("buildContainerRootfsPath(%q, %q, %q) = %q, want %q",
+					tc.pool, tc.poolSource, tc.containerName, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDirSize covers the cases the dir-backend fallback actually
+// hits: regular files at the top level, files inside subdirs,
+// symlinks (skipped), and a vanished path (we want a real error
+// surfaced so GetContainerMetrics knows to skip the field).
+func TestDirSize(t *testing.T) {
+	t.Run("sums regular file sizes recursively", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "a.txt"), 100)
+		writeFile(t, filepath.Join(root, "sub", "b.txt"), 250)
+		writeFile(t, filepath.Join(root, "sub", "deep", "c.txt"), 17)
+
+		got, err := dirSize(root)
+		if err != nil {
+			t.Fatalf("dirSize: %v", err)
+		}
+		const want = 100 + 250 + 17
+		if got != want {
+			t.Errorf("dirSize = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("ignores symlinks so we don't double-count the target", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "real.txt"), 50)
+		// Symlink to the file — its own size should NOT be added.
+		if err := os.Symlink("real.txt", filepath.Join(root, "link.txt")); err != nil {
+			t.Fatalf("symlink: %v", err)
+		}
+		// Symlink to a directory — its own size should also NOT be added.
+		if err := os.Symlink("..", filepath.Join(root, "loop")); err != nil {
+			t.Fatalf("symlink dir: %v", err)
+		}
+
+		got, err := dirSize(root)
+		if err != nil {
+			t.Fatalf("dirSize: %v", err)
+		}
+		if got != 50 {
+			t.Errorf("dirSize = %d, want 50 (only the regular file)", got)
+		}
+	})
+
+	t.Run("missing root yields zero, no error (best-effort metric)", func(t *testing.T) {
+		// containerRootfsPath() stats the path before calling
+		// dirSize, so dirSize on a non-existent root shouldn't
+		// happen in practice. But the contract callers depend on
+		// is "errors during the walk don't abort, they just leave
+		// the partial sum" — pin that here so a future refactor
+		// to WalkDir's error handling doesn't silently change
+		// the field to abort-on-error.
+		got, err := dirSize("/nonexistent/path/we/dont/expect")
+		if err != nil {
+			t.Errorf("expected no error on missing root, got %v", err)
+		}
+		if got != 0 {
+			t.Errorf("expected 0 bytes on missing root, got %d", got)
+		}
+	})
+
+	t.Run("empty directory is zero, not an error", func(t *testing.T) {
+		got, err := dirSize(t.TempDir())
+		if err != nil {
+			t.Fatalf("dirSize: %v", err)
+		}
+		if got != 0 {
+			t.Errorf("empty dir size = %d, want 0", got)
+		}
+	})
+}
+
+func writeFile(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes task #66: lab disk usage missing.

Incus's \`GetContainerMetrics\` relies on \`state.Disk[\"root\"].Usage\`, which only carries a value on backends with filesystem-level quota accounting (zfs, btrfs, lvm). On the \`dir\` backend — what \`incus admin init --auto --storage-backend=dir\` hands you on hosts without a zpool, including \`containarium-lab\` — that field stays zero. Every consumer (\`containarium list\`, MCP \`get_metrics\`, OTel collector, peer scraper) then dutifully reports 0 B forever.

## Change

\`pkg/core/incus/client.go: GetContainerMetrics\` now does:

\`\`\`go
if rootDisk, ok := state.Disk[\"root\"]; ok && rootDisk.Usage > 0 {
    metrics.DiskUsageBytes = rootDisk.Usage
} else if rootfs := c.containerRootfsPath(name); rootfs != \"\" {
    if bytes, err := dirSize(rootfs); err == nil {
        metrics.DiskUsageBytes = bytes
    }
}
\`\`\`

The fallback walks \`/var/lib/incus/storage-pools/<pool>/containers/<name>/rootfs\` (same path \`du -bs\` would) and sums regular file sizes, skipping symlinks so we don't double-count their targets. zfs / btrfs hosts pay nothing extra — the walk only fires when the native value is zero.

## Splits

- \`buildContainerRootfsPath(pool, source, container)\` — pure path-construction so the unit test doesn't need an Incus server.
- \`containerRootfsPath(name)\` — does the two Incus API lookups (instance → pool config) and delegates to the pure helper.
- \`dirSize(root)\` — walks + sums; standalone so it's testable with a tmpdir tree.

## Tests

\`pkg/core/incus/disk_usage_test.go\`:

| Test | What it pins |
|---|---|
| \`TestBuildContainerRootfsPath\` | Path-resolution convention (4 cases: explicit abs source, empty source, non-path source like a zfs dataset name, non-default pool). |
| \`TestDirSize/sums regular file sizes recursively\` | Files at the top level + nested subdirs. |
| \`TestDirSize/ignores symlinks so we don't double-count the target\` | Both file-symlinks and dir-symlinks are skipped. |
| \`TestDirSize/missing root yields zero, no error (best-effort metric)\` | Pins the \"don't abort on walk error\" contract — partial data beats no data for a metric. |
| \`TestDirSize/empty directory is zero, not an error\` | Sanity. |

## Trade-offs considered

- **ZFS migration of the lab** (alt fix) — out of scope here. Switching the lab's storage to zfs is a separate operational change; the daemon fallback is the right fix for the OSS posture regardless, because any user who picks \`dir\` (the incus default on hosts without a zpool) hits this.
- **Caching the walk result** — skipped in v1. The walk is i/o-bound and the kernel caches inode metadata, so for the cardinalities we see in practice (tens of containers, GBs each), it's acceptable. If \`list_containers\` becomes hot, add a sync.Map with a 30s TTL.
- **\`du -bs\` shellout** — same algorithm, but adds a subprocess per container per list call. The Go walk is cheaper.

## Test plan

- [x] \`go vet ./...\` — clean.
- [x] \`go test -race -count=1 ./pkg/core/incus/\` — all green including 5 new subtests.
- [ ] Manual lab smoke after deploy: ssh to lab, \`containarium list\` should show non-zero disk for at least one running container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)