### PR TITLE
feat(api): add --pool selector for container placement

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -4307,6 +4307,10 @@
         "monitoringEnabled": {
           "type": "boolean",
           "description": "Whether application-emitted OpenTelemetry is enabled for this\ncontainer (mirrors the --monitoring flag passed at creation).\nWhen true, the LXC has OTEL_EXPORTER_OTLP_ENDPOINT and related\nenv vars stamped on it. Read-only — set at create time;\nchanging requires recreate (a ToggleMonitoring RPC may come\nlater, but doesn't exist in v1)."
+        },
+        "pool": {
+          "type": "string",
+          "description": "Pool tag of the backend hosting this container (e.g., \"prod\",\n\"demo\", \"lab\"). Mirrors the peer's --pool registration tag and\nis the discriminator used for placement and per-pool routing\n(such as base-domain selection). Empty for untagged backends."
         }
       },
       "title": "Container represents a complete container instance"
@@ -4497,6 +4501,10 @@
         "monitoring": {
           "type": "boolean",
           "description": "Enable application-emitted OpenTelemetry. When true, the daemon\nstamps the container with OTEL_EXPORTER_OTLP_ENDPOINT and\nrelated env vars pointing at the core OTel collector, so any\nOTel SDK inside the container ships telemetry to the platform's\nVictoriaMetrics without app-side configuration. Default false —\nopt-in matches the \"platform doesn't move data unless told to\"\nprinciple and avoids surprise telemetry from prototype\nworkloads. The daemon's own cgroup-level metrics for the\ncontainer are independent of this flag and continue regardless."
+        },
+        "pool": {
+          "type": "string",
+          "title": "Pool selector — when set and backend_id is empty, the daemon\npicks any healthy peer tagged with this pool"
         }
       },
       "title": "CreateContainerRequest is the request to create a new container"

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -127,7 +127,7 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 }
 
 // CreateContainer creates a container via gRPC
-func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool) (*incus.ContainerInfo, error) {
+func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute) // Container creation can take time (includes ultra-aggressive retry logic for google_guest_agent)
 	defer cancel()
 
@@ -145,6 +145,8 @@ func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, 
 		Gpu:          gpu,
 		OsType:       osType,
 		Monitoring:   monitoring,
+		Pool:         pool,
+		BackendId:    backendID,
 	}
 
 	resp, err := c.client.CreateContainer(ctx, req)

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -210,7 +210,7 @@ func (c *HTTPClient) ListContainers() ([]incus.ContainerInfo, error) {
 }
 
 // CreateContainer creates a container via HTTP
-func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool) (*incus.ContainerInfo, error) {
+func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
@@ -228,6 +228,8 @@ func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, 
 		"gpu":          gpu,
 		"osType":       osType,
 		"monitoring":   monitoring,
+		"pool":         pool,
+		"backendId":    backendID,
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/containers", reqBody)

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -28,6 +28,8 @@ var (
 	gpuDevice      string
 	osTypeStr      string
 	monitoring     bool
+	createPool     string
+	createBackendID string
 )
 
 var createCmd = &cobra.Command{
@@ -82,10 +84,19 @@ func init() {
 	createCmd.Flags().BoolVar(&forceRecreate, "force", false, "Delete and recreate if container already exists")
 	createCmd.Flags().StringVar(&osTypeStr, "os-type", "", "Container OS type: ubuntu, rocky9, rhel9 (overrides --image)")
 	createCmd.Flags().BoolVar(&monitoring, "monitoring", false, "Opt into application-emitted OpenTelemetry. When set, the daemon stamps the container with OTEL_EXPORTER_OTLP_ENDPOINT etc. pointing at the platform's OTel collector, so any OTel SDK inside the container ships telemetry without app-side config. Default off.")
+	createCmd.Flags().StringVar(&createPool, "pool", "", "Place the container on any healthy backend tagged with this pool (e.g., 'demo', 'lab'). Empty means the local/primary backend. Mutually exclusive with --backend-id unless the chosen backend is in the named pool.")
+	createCmd.Flags().StringVar(&createBackendID, "backend-id", "", "Place the container on a specific backend by ID (e.g., 'tunnel-fts-5900x-gpu'). Use 'containarium backends' to list available backend IDs.")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
 	username := args[0]
+
+	// --pool / --backend-id are placement directives that only the
+	// daemon's PeerPool can act on. Local mode (no --server) doesn't
+	// have a peer pool — fail fast rather than silently dropping them.
+	if (createPool != "" || createBackendID != "") && serverAddr == "" {
+		return fmt.Errorf("--pool and --backend-id require --server (cluster mode); they are not supported in local Incus mode")
+	}
 
 	// Parse labels from key=value format
 	parsedLabels := parseLabels(labels)
@@ -245,13 +256,13 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if httpMode && serverAddr != "" {
 		// Remote mode via HTTP
-		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring)
+		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID)
 		if err != nil {
 			return fmt.Errorf("failed to create container via HTTP API: %w", err)
 		}
 	} else if serverAddr != "" {
 		// Remote mode via gRPC
-		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring)
+		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID)
 		if err != nil {
 			return fmt.Errorf("failed to create container via remote server: %w", err)
 		}
@@ -367,23 +378,23 @@ func parseLabels(labelSlice []string) map[string]string {
 }
 
 // createRemote creates a container using remote gRPC server
-func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool) (*incus.ContainerInfo, error) {
+func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string) (*incus.ContainerInfo, error) {
 	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
 		return nil, err
 	}
 	defer grpcClient.Close()
 
-	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring)
+	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID)
 }
 
 // createRemoteHTTP creates a container using remote HTTP API
-func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool) (*incus.ContainerInfo, error) {
+func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string) (*incus.ContainerInfo, error) {
 	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
 	if err != nil {
 		return nil, err
 	}
 	defer httpClient.Close()
 
-	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring)
+	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID)
 }

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -712,6 +712,17 @@ type CreateContainerRequest struct {
 	// collector. Default false (opt-in). See
 	// docs/OTEL-COLLECTOR-DESIGN.md for the full design.
 	Monitoring bool `json:"monitoring,omitempty"`
+
+	// Pool selects placement by pool tag. When set with an empty
+	// BackendID, the daemon picks any healthy backend in the pool.
+	// When set with BackendID, the daemon validates that BackendID
+	// belongs to this pool.
+	Pool string `json:"pool,omitempty"`
+
+	// BackendID pins the container to a specific peer. Use Pool
+	// when any backend in a group will do; use BackendID for an
+	// exact placement.
+	BackendID string `json:"backendId,omitempty"`
 }
 
 type ResourceLimits struct {
@@ -875,6 +886,8 @@ type Container struct {
 	Labels        map[string]string `json:"labels,omitempty"`
 	Image         string            `json:"image,omitempty"`
 	PodmanEnabled bool              `json:"podmanEnabled"`
+	BackendID     string            `json:"backendId,omitempty"`
+	Pool          string            `json:"pool,omitempty"`
 }
 
 type NetworkInfo struct {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -176,6 +176,14 @@ func (s *Server) registerTools() {
 						"type": "boolean",
 						"description": "Opt the container into application-emitted OpenTelemetry. When true, the daemon stamps the LXC with OTEL_EXPORTER_OTLP_ENDPOINT (and related env vars) pointing at the platform's core OTel collector, so any OTel SDK inside the container ships telemetry without app-side configuration. Default false. The daemon's own cgroup-level metrics for the container (CPU/mem/disk/net) are independent of this flag and continue for every container regardless.",
 					},
+					"pool": map[string]interface{}{
+						"type":        "string",
+						"description": "Place the container on any healthy backend tagged with this pool (e.g., 'demo', 'lab', 'prod'). When omitted, the request lands on the primary/local backend. Use list_backends to see available pools. Mutually exclusive with backend_id unless the chosen backend is already in this pool (the daemon validates consistency).",
+					},
+					"backend_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Place the container on a specific backend by ID (e.g., 'tunnel-fts-5900x-gpu'). Look up valid IDs via list_backends. Use pool instead when any backend in a pool will do.",
+					},
 				},
 				"required": []string{"username"},
 			},
@@ -840,6 +848,8 @@ func handleCreateContainer(client *Client, args map[string]interface{}) (string,
 		EnablePodman: getBoolArg(args, "enable_podman", true),
 		GPU:          getStringArg(args, "gpu", ""),
 		Monitoring:   getBoolArg(args, "monitoring", false),
+		Pool:         getStringArg(args, "pool", ""),
+		BackendID:    getStringArg(args, "backend_id", ""),
 	}
 
 	// Handle SSH keys. If the caller passes ssh_keys explicitly we use

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -109,6 +109,15 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		return nil, fmt.Errorf("username is required")
 	}
 
+	// Pool resolution — if a pool is requested, either validate that
+	// the explicit backend_id belongs to that pool, or pick any
+	// healthy backend in the pool when backend_id is empty.
+	if req.Pool != "" {
+		if err := s.resolvePoolPlacement(req); err != nil {
+			return nil, err
+		}
+	}
+
 	// Route to peer if backend_id specifies a remote backend
 	if req.BackendId != "" && s.peerPool != nil {
 		localID := s.peerPool.LocalBackendID()
@@ -278,6 +287,7 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 
 	// Convert to protobuf
 	protoContainer := toProtoContainer(info)
+	protoContainer.Pool = s.resolvePool(protoContainer.BackendId)
 
 	// Emit container created event
 	s.emitter.EmitContainerCreated(protoContainer)
@@ -380,7 +390,9 @@ func (s *ContainerServer) ListContainers(ctx context.Context, req *pb.ListContai
 	// Convert to protobuf
 	var protoContainers []*pb.Container
 	for i := range filtered {
-		protoContainers = append(protoContainers, toProtoContainer(&filtered[i]))
+		pc := toProtoContainer(&filtered[i])
+		pc.Pool = s.resolvePool(pc.BackendId)
+		protoContainers = append(protoContainers, pc)
 	}
 
 	// Add containers from peer backends
@@ -388,7 +400,9 @@ func (s *ContainerServer) ListContainers(ctx context.Context, req *pb.ListContai
 		authToken := extractAuthToken(ctx)
 		peerContainers := s.peerPool.ListContainers(authToken)
 		for i := range peerContainers {
-			protoContainers = append(protoContainers, toProtoContainer(&peerContainers[i]))
+			pc := toProtoContainer(&peerContainers[i])
+			pc.Pool = s.resolvePool(pc.BackendId)
+			protoContainers = append(protoContainers, pc)
 		}
 	}
 
@@ -447,6 +461,7 @@ func (s *ContainerServer) GetContainer(ctx context.Context, req *pb.GetContainer
 			for _, pc := range peerContainers {
 				if pc.Name == containerName {
 					proto := toProtoContainer(&pc)
+					proto.Pool = s.resolvePool(proto.BackendId)
 					return &pb.GetContainerResponse{
 						Container: proto,
 					}, nil
@@ -470,8 +485,10 @@ func (s *ContainerServer) GetContainer(ctx context.Context, req *pb.GetContainer
 		s.pendingMu.Unlock()
 	}
 
+	protoInfo := toProtoContainer(info)
+	protoInfo.Pool = s.resolvePool(protoInfo.BackendId)
 	return &pb.GetContainerResponse{
-		Container: toProtoContainer(info),
+		Container: protoInfo,
 		// TODO: Add metrics
 	}, nil
 }
@@ -1530,6 +1547,56 @@ func (s *ContainerServer) localBackendID() string {
 		return id
 	}
 	return "local"
+}
+
+// resolvePool returns the pool tag for the given backend_id. The local
+// backend's pool comes from the PeerPool's --pool configuration;
+// remote backends carry the tag they registered with the sentinel.
+// Returns "" when the peer pool isn't configured or the backend is
+// unknown.
+func (s *ContainerServer) resolvePool(backendID string) string {
+	if s.peerPool == nil {
+		return ""
+	}
+	if backendID == "" || backendID == s.peerPool.LocalBackendID() {
+		return s.peerPool.LocalPool()
+	}
+	if peer := s.peerPool.Get(backendID); peer != nil {
+		return peer.Pool
+	}
+	return ""
+}
+
+// resolvePoolPlacement validates or assigns req.BackendId based on
+// req.Pool. Called only when req.Pool is non-empty. When backend_id
+// is already set, it must belong to the requested pool. When empty,
+// any healthy backend in the pool (including the local one) is a
+// valid placement; the first healthy candidate wins. Returns an
+// error if no eligible backend can be found.
+func (s *ContainerServer) resolvePoolPlacement(req *pb.CreateContainerRequest) error {
+	if s.peerPool == nil {
+		return fmt.Errorf("pool=%q requested but peer pool is not configured on this daemon", req.Pool)
+	}
+
+	if req.BackendId != "" {
+		actual := s.resolvePool(req.BackendId)
+		if actual != req.Pool {
+			return fmt.Errorf("backend %q is in pool %q, not %q", req.BackendId, actual, req.Pool)
+		}
+		return nil
+	}
+
+	// No explicit backend_id — find a candidate in the requested pool.
+	if s.peerPool.LocalPool() == req.Pool {
+		req.BackendId = s.peerPool.LocalBackendID()
+		return nil
+	}
+	candidates := s.peerPool.HealthyPeersInPool(req.Pool)
+	if len(candidates) == 0 {
+		return fmt.Errorf("no healthy backend found in pool %q", req.Pool)
+	}
+	req.BackendId = candidates[0].ID
+	return nil
 }
 
 // SetRouteCleanupDeps wires the route store + proxy manager so

--- a/internal/server/peer.go
+++ b/internal/server/peer.go
@@ -22,6 +22,7 @@ import (
 type PeerClient struct {
 	ID         string
 	Addr       string // host:port of the remote daemon's REST API
+	Pool       string // pool tag from the peer's --pool registration (empty if untagged)
 	Healthy    bool
 	LastSeenAt time.Time // Timestamp of last successful health check
 	client     *http.Client
@@ -128,6 +129,7 @@ func (p *PeerPool) discover() {
 		Peers []struct {
 			ID        string `json:"id"`
 			ProxyPath string `json:"proxy_path"`
+			Pool      string `json:"pool,omitempty"`
 			Healthy   bool   `json:"healthy"`
 		} `json:"peers"`
 	}
@@ -155,6 +157,7 @@ func (p *PeerPool) discover() {
 
 		if existing, ok := p.peers[peer.ID]; ok {
 			existing.Addr = peerAddr
+			existing.Pool = peer.Pool
 			existing.Healthy = peer.Healthy
 			if peer.Healthy {
 				existing.LastSeenAt = time.Now()
@@ -163,6 +166,7 @@ func (p *PeerPool) discover() {
 			pc := &PeerClient{
 				ID:      peer.ID,
 				Addr:    peerAddr,
+				Pool:    peer.Pool,
 				Healthy: peer.Healthy,
 				client: &http.Client{
 					Timeout: 30 * time.Second,
@@ -172,7 +176,7 @@ func (p *PeerPool) discover() {
 				pc.LastSeenAt = time.Now()
 			}
 			p.peers[peer.ID] = pc
-			log.Printf("[peers] discovered new peer: %s via %s", peer.ID, peerAddr)
+			log.Printf("[peers] discovered new peer: %s pool=%q via %s", peer.ID, peer.Pool, peerAddr)
 		}
 	}
 
@@ -199,12 +203,38 @@ func (p *PeerPool) LocalBackendID() string {
 	return p.localBackendID
 }
 
+// LocalPool returns the pool tag this daemon's PeerPool was configured
+// with. The local backend is considered a member of this pool for the
+// purpose of pool-scoped placement decisions.
+func (p *PeerPool) LocalPool() string {
+	return p.pool
+}
+
 // Peers returns all current peers.
 func (p *PeerPool) Peers() []*PeerClient {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	result := make([]*PeerClient, 0, len(p.peers))
 	for _, peer := range p.peers {
+		result = append(result, peer)
+	}
+	return result
+}
+
+// HealthyPeersInPool returns healthy peers tagged with the given pool.
+// An empty pool argument matches peers whose Pool tag is also empty
+// (legacy untagged behavior).
+func (p *PeerPool) HealthyPeersInPool(pool string) []*PeerClient {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	result := make([]*PeerClient, 0, len(p.peers))
+	for _, peer := range p.peers {
+		if peer.Pool != pool {
+			continue
+		}
+		if !peer.Healthy {
+			continue
+		}
 		result = append(result, peer)
 	}
 	return result

--- a/internal/server/pool_placement_test.go
+++ b/internal/server/pool_placement_test.go
@@ -1,0 +1,213 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// TestPeerPool_LocalPool verifies LocalPool returns the configured tag.
+func TestPeerPool_LocalPool(t *testing.T) {
+	cases := []struct {
+		name string
+		pool string
+	}{
+		{"empty", ""},
+		{"prod", "prod"},
+		{"demo", "demo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewPeerPool("local", "", nil, tc.pool)
+			if got := p.LocalPool(); got != tc.pool {
+				t.Errorf("LocalPool() = %q, want %q", got, tc.pool)
+			}
+		})
+	}
+}
+
+// TestPeerPool_DiscoveryParsesPool verifies that the daemon parses the
+// per-peer pool tag from /sentinel/peers.
+func TestPeerPool_DiscoveryParsesPool(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"peers": []map[string]any{
+				{"id": "tunnel-demo-1", "proxy_path": "/peer/tunnel-demo-1", "pool": "demo", "healthy": true},
+				{"id": "tunnel-lab-1", "proxy_path": "/peer/tunnel-lab-1", "pool": "lab", "healthy": true},
+				{"id": "tunnel-untagged", "proxy_path": "/peer/tunnel-untagged", "healthy": true},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := NewPeerPool("local", srv.URL, nil, "")
+	p.discover()
+
+	demo := p.Get("tunnel-demo-1")
+	if demo == nil || demo.Pool != "demo" {
+		t.Errorf("tunnel-demo-1 pool: got %v, want demo", demo)
+	}
+	lab := p.Get("tunnel-lab-1")
+	if lab == nil || lab.Pool != "lab" {
+		t.Errorf("tunnel-lab-1 pool: got %v, want lab", lab)
+	}
+	un := p.Get("tunnel-untagged")
+	if un == nil || un.Pool != "" {
+		t.Errorf("tunnel-untagged pool: got %v, want empty", un)
+	}
+}
+
+// TestPeerPool_HealthyPeersInPool verifies pool filtering with health gating.
+func TestPeerPool_HealthyPeersInPool(t *testing.T) {
+	p := NewPeerPool("local", "", nil, "")
+	p.peers["a"] = &PeerClient{ID: "a", Pool: "demo", Healthy: true}
+	p.peers["b"] = &PeerClient{ID: "b", Pool: "demo", Healthy: false}
+	p.peers["c"] = &PeerClient{ID: "c", Pool: "lab", Healthy: true}
+	p.peers["d"] = &PeerClient{ID: "d", Pool: "", Healthy: true}
+
+	got := p.HealthyPeersInPool("demo")
+	if len(got) != 1 || got[0].ID != "a" {
+		t.Errorf("HealthyPeersInPool(demo): got %+v, want [a]", got)
+	}
+
+	got = p.HealthyPeersInPool("lab")
+	if len(got) != 1 || got[0].ID != "c" {
+		t.Errorf("HealthyPeersInPool(lab): got %+v, want [c]", got)
+	}
+
+	// Empty pool argument matches only untagged peers (legacy behavior).
+	got = p.HealthyPeersInPool("")
+	if len(got) != 1 || got[0].ID != "d" {
+		t.Errorf("HealthyPeersInPool(\"\"): got %+v, want [d]", got)
+	}
+
+	got = p.HealthyPeersInPool("nope")
+	if len(got) != 0 {
+		t.Errorf("HealthyPeersInPool(nope): got %+v, want empty", got)
+	}
+}
+
+// TestContainerServer_ResolvePool exercises the lookup that turns a
+// backend_id back into a pool tag for response decoration.
+func TestContainerServer_ResolvePool(t *testing.T) {
+	p := NewPeerPool("local-prod", "", nil, "prod")
+	p.peers["tunnel-demo-1"] = &PeerClient{ID: "tunnel-demo-1", Pool: "demo", Healthy: true}
+	p.peers["tunnel-lab-1"] = &PeerClient{ID: "tunnel-lab-1", Pool: "lab", Healthy: true}
+
+	s := &ContainerServer{peerPool: p}
+
+	cases := []struct {
+		backendID string
+		want      string
+	}{
+		{"", "prod"},                          // empty resolves to local pool
+		{"local-prod", "prod"},                // explicit local ID resolves to local pool
+		{"tunnel-demo-1", "demo"},             // known peer
+		{"tunnel-lab-1", "lab"},               // known peer
+		{"never-registered", ""},              // unknown peer → empty
+	}
+	for _, tc := range cases {
+		if got := s.resolvePool(tc.backendID); got != tc.want {
+			t.Errorf("resolvePool(%q) = %q, want %q", tc.backendID, got, tc.want)
+		}
+	}
+
+	// resolvePool with nil peerPool returns "".
+	empty := &ContainerServer{}
+	if got := empty.resolvePool("anything"); got != "" {
+		t.Errorf("resolvePool with nil peerPool: got %q, want empty", got)
+	}
+}
+
+// TestContainerServer_ResolvePoolPlacement exercises the placement
+// chooser used by CreateContainer when req.Pool is set.
+func TestContainerServer_ResolvePoolPlacement(t *testing.T) {
+	t.Run("nil peer pool fails", func(t *testing.T) {
+		s := &ContainerServer{}
+		req := &pb.CreateContainerRequest{Pool: "demo"}
+		if err := s.resolvePoolPlacement(req); err == nil {
+			t.Error("expected error for nil peer pool, got nil")
+		}
+	})
+
+	t.Run("backend_id consistency: matching pool", func(t *testing.T) {
+		p := NewPeerPool("local-prod", "", nil, "prod")
+		p.peers["tunnel-demo-1"] = &PeerClient{ID: "tunnel-demo-1", Pool: "demo", Healthy: true}
+		s := &ContainerServer{peerPool: p}
+
+		req := &pb.CreateContainerRequest{Pool: "demo", BackendId: "tunnel-demo-1"}
+		if err := s.resolvePoolPlacement(req); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if req.BackendId != "tunnel-demo-1" {
+			t.Errorf("BackendId changed: got %q", req.BackendId)
+		}
+	})
+
+	t.Run("backend_id consistency: mismatched pool", func(t *testing.T) {
+		p := NewPeerPool("local-prod", "", nil, "prod")
+		p.peers["tunnel-demo-1"] = &PeerClient{ID: "tunnel-demo-1", Pool: "demo", Healthy: true}
+		s := &ContainerServer{peerPool: p}
+
+		req := &pb.CreateContainerRequest{Pool: "lab", BackendId: "tunnel-demo-1"}
+		err := s.resolvePoolPlacement(req)
+		if err == nil {
+			t.Fatal("expected error for pool/backend mismatch, got nil")
+		}
+	})
+
+	t.Run("backend_id consistency: local backend in matching pool", func(t *testing.T) {
+		p := NewPeerPool("local-prod", "", nil, "prod")
+		s := &ContainerServer{peerPool: p}
+
+		req := &pb.CreateContainerRequest{Pool: "prod", BackendId: "local-prod"}
+		if err := s.resolvePoolPlacement(req); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("pool only: picks healthy peer", func(t *testing.T) {
+		p := NewPeerPool("local-prod", "", nil, "prod")
+		p.peers["tunnel-demo-1"] = &PeerClient{ID: "tunnel-demo-1", Pool: "demo", Healthy: true}
+		s := &ContainerServer{peerPool: p}
+
+		req := &pb.CreateContainerRequest{Pool: "demo"}
+		if err := s.resolvePoolPlacement(req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.BackendId != "tunnel-demo-1" {
+			t.Errorf("expected BackendId=tunnel-demo-1, got %q", req.BackendId)
+		}
+	})
+
+	t.Run("pool only: picks local when local matches", func(t *testing.T) {
+		p := NewPeerPool("local-prod", "", nil, "prod")
+		// Even with peers around, local is preferred when its pool matches.
+		p.peers["tunnel-prod-1"] = &PeerClient{ID: "tunnel-prod-1", Pool: "prod", Healthy: true}
+		s := &ContainerServer{peerPool: p}
+
+		req := &pb.CreateContainerRequest{Pool: "prod"}
+		if err := s.resolvePoolPlacement(req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.BackendId != "local-prod" {
+			t.Errorf("expected BackendId=local-prod, got %q", req.BackendId)
+		}
+	})
+
+	t.Run("pool only: no candidates errors", func(t *testing.T) {
+		p := NewPeerPool("local-prod", "", nil, "prod")
+		// Only an unhealthy peer in the requested pool.
+		p.peers["tunnel-demo-1"] = &PeerClient{ID: "tunnel-demo-1", Pool: "demo", Healthy: false}
+		s := &ContainerServer{peerPool: p}
+
+		req := &pb.CreateContainerRequest{Pool: "demo"}
+		err := s.resolvePoolPlacement(req)
+		if err == nil {
+			t.Fatal("expected error when no healthy peers in pool, got nil")
+		}
+	})
+}

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -391,8 +391,13 @@ type Container struct {
 	// changing requires recreate (a ToggleMonitoring RPC may come
 	// later, but doesn't exist in v1).
 	MonitoringEnabled bool `protobuf:"varint,18,opt,name=monitoring_enabled,json=monitoringEnabled,proto3" json:"monitoring_enabled,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// Pool tag of the backend hosting this container (e.g., "prod",
+	// "demo", "lab"). Mirrors the peer's --pool registration tag and
+	// is the discriminator used for placement and per-pool routing
+	// (such as base-domain selection). Empty for untagged backends.
+	Pool          string `protobuf:"bytes,19,opt,name=pool,proto3" json:"pool,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Container) Reset() {
@@ -551,6 +556,13 @@ func (x *Container) GetMonitoringEnabled() bool {
 	return false
 }
 
+func (x *Container) GetPool() string {
+	if x != nil {
+		return x.Pool
+	}
+	return ""
+}
+
 // ContainerMetrics contains runtime metrics for a container
 type ContainerMetrics struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -704,7 +716,13 @@ type CreateContainerRequest struct {
 	// principle and avoids surprise telemetry from prototype
 	// workloads. The daemon's own cgroup-level metrics for the
 	// container are independent of this flag and continue regardless.
-	Monitoring    bool `protobuf:"varint,14,opt,name=monitoring,proto3" json:"monitoring,omitempty"`
+	Monitoring bool `protobuf:"varint,14,opt,name=monitoring,proto3" json:"monitoring,omitempty"`
+	// Pool selector — when set and backend_id is empty, the daemon
+	// picks any healthy peer tagged with this pool (--pool=<name> on
+	// the peer's daemon). When both pool and backend_id are set, the
+	// chosen backend_id must belong to this pool or the request is
+	// rejected. Empty means "untagged backends only" (legacy behavior).
+	Pool          string `protobuf:"bytes,15,opt,name=pool,proto3" json:"pool,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -835,6 +853,13 @@ func (x *CreateContainerRequest) GetMonitoring() bool {
 		return x.Monitoring
 	}
 	return false
+}
+
+func (x *CreateContainerRequest) GetPool() string {
+	if x != nil {
+		return x.Pool
+	}
+	return ""
 }
 
 // CreateContainerResponse is the response from creating a container
@@ -3577,7 +3602,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\vmac_address\x18\x02 \x01(\tR\n" +
 	"macAddress\x12\x1c\n" +
 	"\tinterface\x18\x03 \x01(\tR\tinterface\x12\x16\n" +
-	"\x06bridge\x18\x04 \x01(\tR\x06bridge\"\x8e\x06\n" +
+	"\x06bridge\x18\x04 \x01(\tR\x06bridge\"\xa2\x06\n" +
 	"\tContainer\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x125\n" +
@@ -3603,7 +3628,8 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"accessType\x12\x1f\n" +
 	"\vrdp_address\x18\x11 \x01(\tR\n" +
 	"rdpAddress\x12-\n" +
-	"\x12monitoring_enabled\x18\x12 \x01(\bR\x11monitoringEnabled\x1a9\n" +
+	"\x12monitoring_enabled\x18\x12 \x01(\bR\x11monitoringEnabled\x12\x12\n" +
+	"\x04pool\x18\x13 \x01(\tR\x04pool\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xcf\x02\n" +
@@ -3615,7 +3641,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x10disk_usage_bytes\x18\x05 \x01(\x03R\x0ediskUsageBytes\x12(\n" +
 	"\x10network_rx_bytes\x18\x06 \x01(\x03R\x0enetworkRxBytes\x12(\n" +
 	"\x10network_tx_bytes\x18\a \x01(\x03R\x0enetworkTxBytes\x12#\n" +
-	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\xca\x05\n" +
+	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\xde\x05\n" +
 	"\x16CreateContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12=\n" +
 	"\tresources\x18\x02 \x01(\v2\x1f.containarium.v1.ResourceLimitsR\tresources\x12\x19\n" +
@@ -3634,7 +3660,8 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x10stack_parameters\x18\r \x03(\v2<.containarium.v1.CreateContainerRequest.StackParametersEntryR\x0fstackParameters\x12\x1e\n" +
 	"\n" +
 	"monitoring\x18\x0e \x01(\bR\n" +
-	"monitoring\x1a9\n" +
+	"monitoring\x12\x12\n" +
+	"\x04pool\x18\x0f \x01(\tR\x04pool\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aB\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -152,6 +152,12 @@ message Container {
   // changing requires recreate (a ToggleMonitoring RPC may come
   // later, but doesn't exist in v1).
   bool monitoring_enabled = 18;
+
+  // Pool tag of the backend hosting this container (e.g., "prod",
+  // "demo", "lab"). Mirrors the peer's --pool registration tag and
+  // is the discriminator used for placement and per-pool routing
+  // (such as base-domain selection). Empty for untagged backends.
+  string pool = 19;
 }
 
 // ContainerMetrics contains runtime metrics for a container
@@ -238,6 +244,13 @@ message CreateContainerRequest {
   // workloads. The daemon's own cgroup-level metrics for the
   // container are independent of this flag and continue regardless.
   bool monitoring = 14;
+
+  // Pool selector — when set and backend_id is empty, the daemon
+  // picks any healthy peer tagged with this pool (--pool=<name> on
+  // the peer's daemon). When both pool and backend_id are set, the
+  // chosen backend_id must belong to this pool or the request is
+  // rejected. Empty means "untagged backends only" (legacy behavior).
+  string pool = 15;
 }
 
 // CreateContainerResponse is the response from creating a container

--- a/test/integration/storage_test.go
+++ b/test/integration/storage_test.go
@@ -100,6 +100,8 @@ func testCreateContainerWithQuota(t *testing.T, ctx context.Context, grpcClient 
 		"",                             // No GPU
 		0,                              // Default OS type
 		false,                          // No monitoring
+		"",                             // No pool
+		"",                             // No backend ID
 	)
 	require.NoError(t, err, "Failed to create container")
 	require.NotNil(t, container)
@@ -145,6 +147,8 @@ func testQuotaEnforcement(t *testing.T, ctx context.Context, grpcClient *client.
 		"",
 		0, // Default OS type
 		false,
+		"", // No pool
+		"", // No backend ID
 	)
 	require.NoError(t, err)
 	require.NotNil(t, container)
@@ -181,11 +185,11 @@ func testMultiContainerIsolation(t *testing.T, ctx context.Context, grpcClient *
 	t.Log("Creating multiple containers to test quota isolation...")
 
 	// Create two containers with different quotas
-	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false)
+	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "")
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(user1, true)
 
-	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", "", 0, false)
+	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", "", 0, false, "", "")
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(user2, true)
 
@@ -211,7 +215,7 @@ func testCompression(t *testing.T, ctx context.Context, grpcClient *client.GRPCC
 
 	t.Log("Creating container to test compression...")
 
-	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false)
+	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "")
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(username, true)
 
@@ -234,7 +238,7 @@ func testPrepareRebootData(t *testing.T, ctx context.Context, grpcClient *client
 	t.Logf("Creating container for persistence test: %s", username)
 
 	// Create container
-	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", "", 0, false)
+	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", "", 0, false, "", "")
 	require.NoError(t, err)
 	require.NotNil(t, container)
 


### PR DESCRIPTION
## Summary
- Adds `--pool` (and `--backend-id`) placement selector to `containarium create`, the gRPC/HTTP/MCP `CreateContainer` API, and the proto contract. Resolves to any healthy backend tagged with that pool via the existing `--pool` peer registration.
- `Container` responses now round-trip the pool tag on Create/List/Get so callers can see which pool a container actually landed in.
- Foundation for moving the demo cluster onto the prod sentinel — once peers are tagged (`prod`/`demo`/`lab`) the workloads are physically separated even when they share a sentinel and base-domain plumbing.

## Behavior
- `--pool` + no `--backend-id`: daemon picks any healthy backend in the pool. Local backend wins when its pool matches; otherwise the first healthy peer in the pool.
- `--pool` + `--backend-id`: daemon validates the backend is in the named pool, errors out on mismatch instead of silently overriding.
- `--pool` with no eligible backend: clear error (`no healthy backend found in pool %q`) — not a silent fallback to the local backend.
- `--pool` / `--backend-id` in local Incus mode (no `--server`): rejected up-front (cluster-only directives).

## Test plan
- [x] Unit tests added (`internal/server/pool_placement_test.go`) — 7 cases covering pool parsing on discovery, healthy-peer filtering, `resolvePool` lookup, and four `resolvePoolPlacement` branches (matching/mismatched backend+pool, local-pool match, peer pick, no-candidates error)
- [x] `go test ./...` green across the whole repo
- [ ] Manual smoke after merge: prod sentinel + a peer registered with `--pool=demo`, `containarium create --pool=demo …` lands on the demo backend; `containarium get` shows `pool: demo`
- [ ] Manual: `containarium create --pool=lab --backend-id=tunnel-fts-5900x-gpu` succeeds (consistent), `--pool=demo --backend-id=tunnel-fts-5900x-gpu` errors with the mismatch message
- [ ] MCP smoke: `create_container` with `pool` arg routes correctly via `mcp__containarium-prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)