### PR TITLE
feat(sentinel): per-pool base-domain suffix routing

### DIFF
--- a/docs/PER-POOL-BASE-DOMAIN.md
+++ b/docs/PER-POOL-BASE-DOMAIN.md
@@ -1,0 +1,131 @@
+# Per-Pool Base Domain (Design)
+
+**Status**: Draft — not yet implemented.
+**Depends on**: [MULTI-POOL.md](MULTI-POOL.md), [APP-HOSTING.md](APP-HOSTING.md).
+**Drives**: serving multiple base domains (e.g. `kafeido.app` and `containarium.dev`) from a single sentinel without per-container alias bookkeeping.
+
+## Problem
+
+Today, every app hostname a pool's Caddy serves must appear in that primary's `--public-aliases` ([MULTI-POOL.md:178](MULTI-POOL.md#app-domain-routing-via-aliases)). The sentinel's SNI router does exact-match against `Primary.Hostname` plus the alias list ([primary_registry.go:139-156](../internal/sentinel/primary_registry.go)) and falls back to the legacy single-backend forwarder on miss ([manager.go:608-611](../internal/sentinel/manager.go)).
+
+That works when app domains are a small fixed set (`api.kafeido.app`, `voice.kafeido.app`, …) registered once at primary startup. It breaks when:
+
+- **Containers create their own subdomains dynamically.** `expose_port blog` on the demo backend produces `blog.containarium.dev`. The container exists; the Caddy route exists on the backend; the cert ACMEs fine. But the sentinel doesn't know that name → demo-backend, so the SNI peek misses and falls back to the wrong backend.
+- **A single sentinel needs to serve two or more base domains.** Today prod's sentinel handles `*.kafeido.app` purely by the fallback path (single registered backend == prod). Adding `containarium.dev` for the demo backend means the fallback can no longer be "the one backend" — different SNI suffixes need to go to different backends.
+
+The workaround (register every container's hostname as an alias and update on every `expose_port`) is doable but ugly: it'd require a sentinel-API round-trip on every route mutation, with all the cache-invalidation pain that implies.
+
+## Proposal
+
+Add a **per-primary base domain** that the SNI router uses for **suffix matching** after exact-alias matching fails and before the legacy fallback.
+
+### Registry change
+
+`Primary` gains a `BaseDomain` field, populated from a new `--public-base-domain` daemon flag (default empty == legacy behavior):
+
+```go
+type Primary struct {
+    Pool       Pool      `json:"pool"`
+    Hostname   string    `json:"hostname"`
+    Aliases    []string  `json:"aliases,omitempty"`
+    BaseDomain string    `json:"base_domain,omitempty"` // NEW: suffix-match anchor
+    IP         string    `json:"ip"`
+    Port       int       `json:"port"`
+    BackendID  string    `json:"backend_id,omitempty"`
+    ...
+}
+```
+
+New lookup method:
+
+```go
+// LookupByBaseDomainSuffix returns the primary whose BaseDomain is a
+// proper DNS suffix of hostname. Returns nil if no primary matches or
+// if multiple primaries match (ambiguity is a configuration error;
+// fail closed rather than pick arbitrarily).
+func (r *PrimaryRegistry) LookupByBaseDomainSuffix(hostname string) *Primary
+```
+
+Suffix match means `strings.HasSuffix(hostname, "." + p.BaseDomain)` — *proper* suffix, so `containarium.dev` does NOT match the BaseDomain literally (only `something.containarium.dev`). This keeps `containarium.dev` itself usable as a primary `Hostname` for the apex.
+
+### SNI router precedence
+
+`buildSNIRoutingHandler` ([manager.go:582](../internal/sentinel/manager.go)) becomes:
+
+1. Exact hostname match (`LookupByHostname`) — current behavior, unchanged.
+2. **New**: BaseDomain suffix match (`LookupByBaseDomainSuffix`).
+3. Fallback to `fallbackTarget` — current behavior, unchanged.
+
+The fallback stays as a safety net for unpooled single-backend deployments (no `BaseDomain` configured → step 2 always returns nil → behavior identical to today).
+
+### Handshake change for tunneled primaries
+
+`TunnelHandshake` ([tunnel_auth.go](../internal/sentinel/tunnel_auth.go)) gains `PublicBaseDomain string`. The tunnel command picks it up from a new `--public-base-domain` flag in `internal/cmd/tunnel.go`. On `OnTunnelConnect` the value flows through to the `primaries.Register(...)` call (`manager.go:823-835`).
+
+### Daemon-side change
+
+`internal/cmd/daemon.go` already has `--base-domain` for the backend's own Caddy. Reuse it: if `--public-base-domain` isn't set explicitly, default to `--base-domain`. This means most operators set one flag, and the sentinel learns it automatically via the existing primary registration.
+
+## Worked example
+
+| Backend | `--pool` | `--public-hostname` | `--base-domain` (== `--public-base-domain` default) |
+|---|---|---|---|
+| prod | `prod` | `containarium-prod.kafeido.app` | `kafeido.app` |
+| demo | `demo` | `demo.containarium.dev` | `containarium.dev` |
+| lab | `lab` | `containarium-lab.kafeido.app` | `lab.kafeido.app` |
+
+Inbound SNI behavior on the prod sentinel:
+
+| SNI | Match path | Forwards to |
+|---|---|---|
+| `containarium-prod.kafeido.app` | exact (Hostname) | prod backend |
+| `api.kafeido.app` | exact (Aliases, if listed) | prod backend |
+| `blog.containarium.dev` | suffix (`.containarium.dev`) | demo backend |
+| `notebook.lab.kafeido.app` | suffix (`.lab.kafeido.app`) | lab backend — **NOT** prod (more-specific suffix wins) |
+| `kafeido.app` (apex) | none → fallback | legacy backend |
+
+The third row is the new capability; it removes the need to register `blog.containarium.dev` as an alias.
+
+## Edge cases & failure modes
+
+- **Overlapping base domains.** Two primaries register with `BaseDomain=kafeido.app` and `BaseDomain=lab.kafeido.app`. `notebook.lab.kafeido.app` matches both. **Resolution**: longest-suffix wins (the more-specific one). Implement by sorting candidates by `len(BaseDomain)` desc and returning the first match. Document that ambiguity ladder explicitly.
+- **Identical base domains across pools.** Two primaries register with `BaseDomain=kafeido.app` — a misconfiguration. **Resolution**: `LookupByBaseDomainSuffix` returns nil and logs a warning rather than picking arbitrarily. Fail closed.
+- **Suffix collides with an exact alias on a different primary.** E.g. prod's `Aliases=[blog.containarium.dev]` plus demo's `BaseDomain=containarium.dev`. **Resolution**: exact match wins (precedence step 1 runs before step 2). Operator's explicit choice overrides the implicit suffix routing.
+- **Tunneled primary disconnects.** Same as today — `UnregisterByBackendID` removes the entry, suffix lookups stop matching, suffix-matched SNI falls through to the legacy fallback. No new failure mode.
+- **PROXY-v2 framing.** Suffix-matched destinations go through the same dial-or-yamux path as exact matches, so the existing `m.config.ProxyProtocol` handling still applies. No new code needed.
+
+## Operational additions
+
+These are required regardless of the code design — listed here so the work isn't a surprise during rollout:
+
+1. **DNS.** `*.containarium.dev` A record → prod sentinel IP. Cloudflare-managed (separate provider from `kafeido.app`).
+2. **ACME for the second domain.** Each backend's Caddy ACMEs its own subdomains, so `--base-domain=containarium.dev` triggers DNS-01 against the containarium.dev provider. That means the **demo backend's daemon** needs DNS-01 creds for the containarium.dev provider in its environment, not the sentinel. Existing kafeido.app DNS-01 setup on the prod backend is untouched.
+3. **GLB cert SAN.** If the GLB does TLS termination (which prod does not — it's TCP passthrough — but confirm), add `*.containarium.dev` to the managed cert. For passthrough mode, no change.
+
+## What this does NOT change
+
+- ACME on the sentinel itself (sentinel doesn't terminate TLS for app traffic; passthrough only).
+- Caddy on any backend (each backend continues to own its own `--base-domain`; this design just makes the sentinel aware of that value).
+- The `--public-aliases` flag (still works for explicit per-domain routing; suffix match is additive).
+- Pool-aware container placement ([added in feat(api): --pool selector](../proto/containarium/v1/container.proto)) — that's the input side; this is the output side.
+
+## Test plan
+
+- Unit: `LookupByBaseDomainSuffix` returns nil for empty hostname, exact match, no-suffix, ambiguous (two equal-length matches), and picks longest suffix when nested base domains exist.
+- Unit: `buildSNIRoutingHandler` precedence — exact > suffix > fallback. Use the existing `httptest`/loopback patterns in `internal/sentinel/`.
+- Integration (real Caddy): two primaries registered with different `BaseDomain`, SNI for each routes to the correct one. The Real Caddy wire-compat e2e job in CI is the right home.
+- Manual: prod sentinel + a second backend with `--public-base-domain=containarium.dev`, `curl --resolve` a fake subdomain → confirm the right backend's logs see the request.
+
+## Rollout
+
+1. Land the proto + registry + SNI matcher changes behind the (default-empty) `--public-base-domain` flag. Zero behavior change for any existing deployment.
+2. Demo backend joins the prod sentinel with `--pool=demo --public-base-domain=containarium.dev`.
+3. DNS for `*.containarium.dev` cuts over.
+4. Verify with `curl --resolve` (no DNS dependency for the test).
+5. Demo container migration follows ([plan in Phase 4](MULTI-POOL.md#operator-workflow-adding-a-new-pool)).
+
+## Alternatives considered
+
+- **Push container hostnames to sentinel on every `expose_port`.** Workable but couples the route store to a remote API call on every mutation. Adds latency to route creation and a new failure mode (sentinel unreachable → can't expose a port). Suffix match keeps the contract one-way (daemon → sentinel at registration time, never per-route).
+- **Wildcard aliases (`*.containarium.dev` as an alias entry).** Same effect but harder to reason about: aliases are also matched against `Hostname` for non-wildcards, and mixing wildcards into a list invites accidental over-matching. A separate `BaseDomain` field makes the intent explicit.
+- **Caddy on the sentinel.** Would centralize routing but adds TLS termination on the sentinel (vs. today's passthrough), which breaks per-backend ACME, complicates client IP recovery, and adds another component to keep alive. Not worth it for this use case.

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -53,6 +53,7 @@ var (
 	pool               string
 	publicHostname     string
 	publicAliases      []string
+	publicBaseDomain   string
 	publicPort         int
 
 	proxyProtocol        bool
@@ -140,6 +141,7 @@ func init() {
 	daemonCmd.Flags().StringVar(&pool, "pool", "", "Pool name to scope sentinel peer discovery (empty = unscoped, see all peers)")
 	daemonCmd.Flags().StringVar(&publicHostname, "public-hostname", "", "Public hostname this primary serves (e.g. containarium-prod.kafeido.app); enables sentinel primary registration")
 	daemonCmd.Flags().StringSliceVar(&publicAliases, "public-aliases", nil, "Additional hostnames the primary's Caddy serves (e.g. api.kafeido.app,voice.kafeido.app); the sentinel SNI router treats these as aliases of --public-hostname")
+	daemonCmd.Flags().StringVar(&publicBaseDomain, "public-base-domain", "", "Suffix-match anchor advertised to the sentinel — inbound SNI of the form <anything>.<public-base-domain> routes here without each subdomain being a registered alias. Defaults to --base-domain when unset. See docs/PER-POOL-BASE-DOMAIN.md.")
 	daemonCmd.Flags().BoolVar(&proxyProtocol, "proxy-protocol", false, "Configure Caddy to accept PROXY v2 headers from --proxy-protocol-trusted CIDRs so containers receive the real client IP. Pair with --proxy-protocol on the sentinel.")
 	daemonCmd.Flags().StringSliceVar(&proxyProtocolTrusted, "proxy-protocol-trusted", []string{"127.0.0.0/8"}, "CIDRs allowed to send PROXY headers (typically the sentinel VPC IP/32). Wildcard 0.0.0.0/0 is rejected.")
 	daemonCmd.Flags().IntVar(&publicPort, "public-port", 443, "Public TLS port the sentinel forwards to (default 443)")
@@ -465,6 +467,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		Pool:                 pool,
 		PublicHostname:       publicHostname,
 		PublicAliases:        publicAliases,
+		PublicBaseDomain:     resolvePublicBaseDomain(publicBaseDomain, baseDomain),
 		PublicPort:           publicPort,
 		ProxyProtocol:        proxyProtocol,
 		ProxyProtocolTrusted: proxyProtocolTrusted,
@@ -694,6 +697,19 @@ func waitForCoreContainers(incusClient *incus.Client, timeout time.Duration) err
 
 		time.Sleep(2 * time.Second)
 	}
+}
+
+// resolvePublicBaseDomain returns the value to advertise to the
+// sentinel for suffix-match routing. When the operator passed
+// --public-base-domain explicitly, that wins; otherwise the value
+// falls back to --base-domain, which is already the suffix the
+// backend's own Caddy serves containers under. Empty in both cases
+// means suffix matching is disabled for this primary.
+func resolvePublicBaseDomain(public, base string) string {
+	if public != "" {
+		return public
+	}
+	return base
 }
 
 // saveRecoveryConfigToPersistentStorage saves recovery config to persistent disk

--- a/internal/cmd/tunnel.go
+++ b/internal/cmd/tunnel.go
@@ -18,9 +18,10 @@ var (
 	tunnelSpotID         string
 	tunnelPorts          string
 	tunnelPool           string
-	tunnelPublicHostname string
-	tunnelPublicAliases  []string
-	tunnelPublicPort     int
+	tunnelPublicHostname   string
+	tunnelPublicAliases    []string
+	tunnelPublicBaseDomain string
+	tunnelPublicPort       int
 )
 
 var tunnelCmd = &cobra.Command{
@@ -52,6 +53,7 @@ func init() {
 	tunnelCmd.Flags().StringVar(&tunnelPool, "pool", "", "Pool name to register this peer in (optional; empty = unpooled)")
 	tunnelCmd.Flags().StringVar(&tunnelPublicHostname, "public-hostname", "", "If set, sentinel registers this tunnel as the primary for its pool, serving the named hostname (requires --pool and --public-port)")
 	tunnelCmd.Flags().StringSliceVar(&tunnelPublicAliases, "public-aliases", nil, "Additional hostnames the primary's Caddy serves (e.g. api.kafeido.app,voice.kafeido.app)")
+	tunnelCmd.Flags().StringVar(&tunnelPublicBaseDomain, "public-base-domain", "", "Suffix-match anchor advertised to the sentinel — inbound SNI of the form <anything>.<public-base-domain> routes through this tunnel without each subdomain being a registered alias. See docs/PER-POOL-BASE-DOMAIN.md.")
 	tunnelCmd.Flags().IntVar(&tunnelPublicPort, "public-port", 0, "Public TLS port the sentinel forwards to via this tunnel (typically 443; required with --public-hostname)")
 }
 
@@ -89,14 +91,15 @@ func runTunnel(cmd *cobra.Command, args []string) error {
 	}()
 
 	client := &sentinel.TunnelClient{
-		SentinelAddr:   tunnelSentinelAddr,
-		Token:          token,
-		SpotID:         tunnelSpotID,
-		Ports:          ports,
-		Pool:           sentinel.Pool(tunnelPool),
-		PublicHostname: tunnelPublicHostname,
-		PublicAliases:  tunnelPublicAliases,
-		PublicPort:     tunnelPublicPort,
+		SentinelAddr:     tunnelSentinelAddr,
+		Token:            token,
+		SpotID:           tunnelSpotID,
+		Ports:            ports,
+		Pool:             sentinel.Pool(tunnelPool),
+		PublicHostname:   tunnelPublicHostname,
+		PublicAliases:    tunnelPublicAliases,
+		PublicBaseDomain: tunnelPublicBaseDomain,
+		PublicPort:       tunnelPublicPort,
 	}
 
 	log.Printf("[tunnel] connecting to sentinel at %s as %q (ports: %v, pool: %q, primary_host: %q)", tunnelSentinelAddr, tunnelSpotID, ports, tunnelPool, tunnelPublicHostname)

--- a/internal/sentinel/base_domain_test.go
+++ b/internal/sentinel/base_domain_test.go
@@ -1,0 +1,280 @@
+package sentinel
+
+import (
+	"crypto/tls"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrimaryRegistry_LookupByBaseDomainSuffix covers the suffix-match
+// path: containers exposed under a primary's BaseDomain (e.g.
+// blog.containarium.dev) route to that primary without each name
+// being a registered alias.
+func TestPrimaryRegistry_LookupByBaseDomainSuffix(t *testing.T) {
+	r := NewPrimaryRegistry()
+	r.Register(Primary{
+		Pool:       "prod",
+		Hostname:   "containarium-prod.kafeido.app",
+		BaseDomain: "kafeido.app",
+		IP:         "10.0.0.10",
+		Port:       443,
+	})
+	r.Register(Primary{
+		Pool:       "demo",
+		Hostname:   "demo.containarium.dev",
+		BaseDomain: "containarium.dev",
+		IP:         "10.0.0.20",
+		Port:       443,
+	})
+
+	t.Run("matches by suffix", func(t *testing.T) {
+		p := r.LookupByBaseDomainSuffix("blog.containarium.dev")
+		if assert.NotNil(t, p) {
+			assert.Equal(t, Pool("demo"), p.Pool)
+		}
+	})
+
+	t.Run("deeper subdomain also matches", func(t *testing.T) {
+		p := r.LookupByBaseDomainSuffix("a.b.c.containarium.dev")
+		if assert.NotNil(t, p) {
+			assert.Equal(t, Pool("demo"), p.Pool)
+		}
+	})
+
+	t.Run("base domain itself is not a match", func(t *testing.T) {
+		// "containarium.dev" is NOT "*.containarium.dev" — proper-suffix only.
+		// This keeps the apex hostname usable as a separate Hostname/Alias
+		// without ambiguity.
+		assert.Nil(t, r.LookupByBaseDomainSuffix("containarium.dev"))
+	})
+
+	t.Run("unrelated hostname returns nil", func(t *testing.T) {
+		assert.Nil(t, r.LookupByBaseDomainSuffix("evil.example.com"))
+	})
+
+	t.Run("empty hostname returns nil", func(t *testing.T) {
+		assert.Nil(t, r.LookupByBaseDomainSuffix(""))
+	})
+}
+
+// TestPrimaryRegistry_LookupByBaseDomainSuffix_LongestWins ensures that
+// when one BaseDomain is a tail of another (lab.kafeido.app vs
+// kafeido.app), the more-specific match wins.
+func TestPrimaryRegistry_LookupByBaseDomainSuffix_LongestWins(t *testing.T) {
+	r := NewPrimaryRegistry()
+	r.Register(Primary{
+		Pool:       "prod",
+		Hostname:   "containarium-prod.kafeido.app",
+		BaseDomain: "kafeido.app",
+		IP:         "10.0.0.10",
+		Port:       443,
+	})
+	r.Register(Primary{
+		Pool:       "lab",
+		Hostname:   "containarium-lab.kafeido.app",
+		BaseDomain: "lab.kafeido.app",
+		IP:         "10.0.0.30",
+		Port:       443,
+	})
+
+	// notebook.lab.kafeido.app could match both, but the longer suffix
+	// (lab.kafeido.app) is more specific and should win.
+	p := r.LookupByBaseDomainSuffix("notebook.lab.kafeido.app")
+	if assert.NotNil(t, p) {
+		assert.Equal(t, Pool("lab"), p.Pool, "longer suffix should win")
+	}
+
+	// A sibling that only matches the shorter suffix still routes correctly.
+	p = r.LookupByBaseDomainSuffix("api.kafeido.app")
+	if assert.NotNil(t, p) {
+		assert.Equal(t, Pool("prod"), p.Pool)
+	}
+}
+
+// TestPrimaryRegistry_LookupByBaseDomainSuffix_AmbiguousFailsClosed
+// asserts that two primaries advertising the SAME BaseDomain — a
+// configuration error — make suffix lookups return nil rather than
+// pick one arbitrarily.
+func TestPrimaryRegistry_LookupByBaseDomainSuffix_AmbiguousFailsClosed(t *testing.T) {
+	r := NewPrimaryRegistry()
+	r.Register(Primary{
+		Pool:       "a",
+		Hostname:   "a.kafeido.app",
+		BaseDomain: "kafeido.app",
+		IP:         "10.0.0.10",
+		Port:       443,
+	})
+	r.Register(Primary{
+		Pool:       "b",
+		Hostname:   "b.kafeido.app",
+		BaseDomain: "kafeido.app",
+		IP:         "10.0.0.11",
+		Port:       443,
+	})
+
+	assert.Nil(t, r.LookupByBaseDomainSuffix("blog.kafeido.app"),
+		"ambiguous suffix should fail closed, not pick arbitrarily")
+}
+
+// TestPrimaryRegistry_LookupByBaseDomainSuffix_EmptyBaseDomainSkipped
+// confirms that a primary with no BaseDomain is invisible to suffix
+// lookup. This keeps single-pool / legacy deployments unaffected.
+func TestPrimaryRegistry_LookupByBaseDomainSuffix_EmptyBaseDomainSkipped(t *testing.T) {
+	r := NewPrimaryRegistry()
+	r.Register(Primary{
+		Pool:     "legacy",
+		Hostname: "legacy.kafeido.app",
+		IP:       "10.0.0.10",
+		Port:     443,
+	})
+
+	assert.Nil(t, r.LookupByBaseDomainSuffix("blog.kafeido.app"),
+		"primary without BaseDomain must not match suffix lookups")
+}
+
+// TestPrimaryRegistry_ExactHostnameBeatsSuffix verifies that the SNI
+// router precedence works at the registry level: an exact-alias entry
+// on a different primary wins over a suffix match. The router is
+// expected to try LookupByHostname before LookupByBaseDomainSuffix;
+// these two methods are tested in isolation here, but the test asserts
+// both return what they should so the router can apply that precedence
+// straightforwardly.
+func TestPrimaryRegistry_ExactHostnameBeatsSuffix(t *testing.T) {
+	r := NewPrimaryRegistry()
+	r.Register(Primary{
+		Pool:     "prod",
+		Hostname: "containarium-prod.kafeido.app",
+		Aliases:  []string{"blog.containarium.dev"}, // explicit override
+		IP:       "10.0.0.10",
+		Port:     443,
+	})
+	r.Register(Primary{
+		Pool:       "demo",
+		Hostname:   "demo.containarium.dev",
+		BaseDomain: "containarium.dev",
+		IP:         "10.0.0.20",
+		Port:       443,
+	})
+
+	// Exact alias on prod points at prod.
+	p := r.LookupByHostname("blog.containarium.dev")
+	if assert.NotNil(t, p) {
+		assert.Equal(t, Pool("prod"), p.Pool)
+	}
+
+	// Suffix match would otherwise pick demo. Router runs exact first,
+	// so the alias override stands.
+	pSuffix := r.LookupByBaseDomainSuffix("blog.containarium.dev")
+	if assert.NotNil(t, pSuffix) {
+		assert.Equal(t, Pool("demo"), pSuffix.Pool,
+			"suffix lookup still resolves to demo in isolation; router precedence is what decides")
+	}
+}
+
+// TestSNIRouting_BaseDomainSuffix is an end-to-end check on the SNI
+// router: a BaseDomain-tagged primary captures inbound SNI for its
+// suffix without each subdomain being a registered alias, and an
+// explicit alias on a different primary still wins (exact > suffix
+// precedence). Uses the same dialThroughHandler / startEchoListener
+// harness as TestSNIRouting_DispatchToPrimaryOrFallback in sni_test.go.
+func TestSNIRouting_BaseDomainSuffix(t *testing.T) {
+	demoAddr, demoHits := startEchoListener(t, "DEMO")
+	prodAddr, prodHits := startEchoListener(t, "PROD")
+	fallbackAddr, fallbackHits := startEchoListener(t, "FALLBACK")
+
+	m := &Manager{primaries: NewPrimaryRegistry()}
+
+	demoHost, demoPortStr, err := net.SplitHostPort(demoAddr)
+	require.NoError(t, err)
+	m.primaries.Register(Primary{
+		Pool:       "demo",
+		Hostname:   "demo.containarium.dev",
+		BaseDomain: "containarium.dev",
+		IP:         demoHost,
+		Port:       mustAtoi(t, demoPortStr),
+	})
+
+	prodHost, prodPortStr, err := net.SplitHostPort(prodAddr)
+	require.NoError(t, err)
+	m.primaries.Register(Primary{
+		Pool:       "prod",
+		Hostname:   "containarium-prod.kafeido.app",
+		// Explicit alias for a name that ALSO matches demo's BaseDomain.
+		// Exact match must win — operator's explicit choice beats the
+		// implicit suffix routing.
+		Aliases:    []string{"override.containarium.dev"},
+		BaseDomain: "kafeido.app",
+		IP:         prodHost,
+		Port:       mustAtoi(t, prodPortStr),
+	})
+
+	handler := m.buildSNIRoutingHandler(fallbackAddr)
+
+	// Suffix match: any subdomain of containarium.dev → demo.
+	got := dialThroughHandler(t, handler, &tls.Config{
+		ServerName: "blog.containarium.dev", InsecureSkipVerify: true,
+	})
+	assert.Equal(t, "DEMO", got, "blog.containarium.dev should suffix-match demo")
+
+	// Suffix match: any subdomain of kafeido.app → prod.
+	got = dialThroughHandler(t, handler, &tls.Config{
+		ServerName: "api.kafeido.app", InsecureSkipVerify: true,
+	})
+	assert.Equal(t, "PROD", got, "api.kafeido.app should suffix-match prod")
+
+	// Exact alias wins over suffix: override.containarium.dev → prod
+	// even though containarium.dev is demo's BaseDomain.
+	got = dialThroughHandler(t, handler, &tls.Config{
+		ServerName: "override.containarium.dev", InsecureSkipVerify: true,
+	})
+	assert.Equal(t, "PROD", got, "exact alias must beat suffix match")
+
+	// Exact hostname still works.
+	got = dialThroughHandler(t, handler, &tls.Config{
+		ServerName: "containarium-prod.kafeido.app", InsecureSkipVerify: true,
+	})
+	assert.Equal(t, "PROD", got, "exact hostname must hit prod")
+
+	// Nothing matches → fallback.
+	got = dialThroughHandler(t, handler, &tls.Config{
+		ServerName: "evil.example.com", InsecureSkipVerify: true,
+	})
+	assert.Equal(t, "FALLBACK", got, "unrelated SNI must fall through")
+
+	assert.Equal(t, 1, demoHits(), "demo hit once (suffix)")
+	assert.Equal(t, 3, prodHits(), "prod hit thrice (suffix kafeido + exact alias + exact hostname)")
+	assert.Equal(t, 1, fallbackHits(), "fallback hit once (unmatched)")
+}
+
+// TestPrimaryRegistry_RegisterUpdatesBaseDomain ensures that a
+// re-registration with a different BaseDomain replaces the old value.
+// Otherwise stale base-domain bindings would persist across daemon
+// restarts. Uses disjoint old/new domains so a longer-suffix match on
+// either side can't muddy the assertion.
+func TestPrimaryRegistry_RegisterUpdatesBaseDomain(t *testing.T) {
+	r := NewPrimaryRegistry()
+	r.Register(Primary{
+		Pool:       "demo",
+		Hostname:   "demo.example.org",
+		BaseDomain: "example.org",
+		IP:         "10.0.0.20",
+		Port:       443,
+	})
+	r.Register(Primary{
+		Pool:       "demo",
+		Hostname:   "demo.example.org",
+		BaseDomain: "containarium.dev",
+		IP:         "10.0.0.20",
+		Port:       443,
+	})
+
+	assert.Nil(t, r.LookupByBaseDomainSuffix("blog.example.org"),
+		"old BaseDomain should be gone after re-register")
+	p := r.LookupByBaseDomainSuffix("blog.containarium.dev")
+	if assert.NotNil(t, p) {
+		assert.Equal(t, Pool("demo"), p.Pool)
+	}
+}

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -210,7 +210,7 @@ func (m *Manager) PrimariesHandler() http.HandlerFunc {
 				return
 			}
 			stored := m.primaries.Register(p)
-			log.Printf("[sentinel] primary registered: pool=%q host=%q ip=%s:%d", stored.Pool, stored.Hostname, stored.IP, stored.Port)
+			log.Printf("[sentinel] primary registered: pool=%q host=%q base_domain=%q ip=%s:%d", stored.Pool, stored.Hostname, stored.BaseDomain, stored.IP, stored.Port)
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(stored)
 
@@ -572,13 +572,18 @@ func (m *Manager) startHTTPSProxy(backendIP string) {
 // registered for that hostname, falling back to fallbackTarget on miss.
 //
 // Routing precedence:
-//  1. Primary with BackendID set (tunnel-promoted) → open a yamux stream
-//     directly to the primary's PublicPort via the tunnel registry. This
-//     avoids needing a sentinel-side TCP listener on the primary's port,
-//     which would collide with the sentinel's own ConnMux on :443.
-//  2. Primary without BackendID (in-VPC primary) → TCP-dial Primary.IP:Port.
-//  3. SNI doesn't match any primary → TCP-dial fallbackTarget (legacy
-//     single-backend behavior).
+//  1. Exact Hostname/Alias match (LookupByHostname).
+//  2. BaseDomain suffix match (LookupByBaseDomainSuffix) — routes ad-hoc
+//     container subdomains like "blog.containarium.dev" to whichever
+//     primary registered BaseDomain="containarium.dev". See
+//     docs/PER-POOL-BASE-DOMAIN.md.
+//  3. No primary match → TCP-dial fallbackTarget (legacy single-backend
+//     behavior).
+//
+// Inside each match path, the dial target depends on whether the primary
+// is tunnel-promoted: BackendID set → yamux stream via the tunnel
+// registry (avoids a sentinel-side TCP listener that would collide with
+// ConnMux on :443); BackendID empty → TCP dial to Primary.IP:Port.
 func (m *Manager) buildSNIRoutingHandler(fallbackTarget string) func(net.Conn) {
 	return func(conn net.Conn) {
 		defer conn.Close()
@@ -593,7 +598,11 @@ func (m *Manager) buildSNIRoutingHandler(fallbackTarget string) func(net.Conn) {
 			err error
 		)
 		if peekErr == nil && sni != "" {
-			if p := m.primaries.LookupByHostname(sni); p != nil {
+			p := m.primaries.LookupByHostname(sni)
+			if p == nil {
+				p = m.primaries.LookupByBaseDomainSuffix(sni)
+			}
+			if p != nil {
 				if p.BackendID != "" && m.tunnelRegistry != nil {
 					// Tunnel-promoted primary: yamux directly.
 					spotID := strings.TrimPrefix(p.BackendID, "tunnel-")
@@ -832,12 +841,13 @@ func (m *Manager) OnTunnelConnect(spot *TunnelSpot) {
 	// primary's hostname/aliases through the tunnel.
 	if spot.PublicHostname != "" && spot.PublicPort != 0 && m.primaries != nil {
 		m.primaries.Register(Primary{
-			Pool:      spot.Pool,
-			Hostname:  spot.PublicHostname,
-			Aliases:   spot.PublicAliases,
-			IP:        spot.LocalIP,
-			Port:      spot.PublicPort,
-			BackendID: b.ID,
+			Pool:       spot.Pool,
+			Hostname:   spot.PublicHostname,
+			Aliases:    spot.PublicAliases,
+			BaseDomain: spot.PublicBaseDomain,
+			IP:         spot.LocalIP,
+			Port:       spot.PublicPort,
+			BackendID:  b.ID,
 		})
 		log.Printf("[sentinel] tunnel-promoted primary: pool=%q hostname=%q aliases=%v -> %s:%d",
 			spot.Pool, spot.PublicHostname, spot.PublicAliases, spot.LocalIP, spot.PublicPort)

--- a/internal/sentinel/primary_registry.go
+++ b/internal/sentinel/primary_registry.go
@@ -1,6 +1,7 @@
 package sentinel
 
 import (
+	"strings"
 	"sync"
 	"time"
 )
@@ -14,6 +15,13 @@ type Primary struct {
 	Pool          Pool      `json:"pool"`
 	Hostname      string    `json:"hostname"` // primary's own subdomain (e.g. containarium-prod.kafeido.app)
 	Aliases       []string  `json:"aliases,omitempty"` // additional hostnames the primary's Caddy routes (e.g. api.kafeido.app, voice.kafeido.app)
+	// BaseDomain anchors suffix routing: any inbound SNI of the form
+	// "<anything>.<BaseDomain>" routes to this primary, so containers
+	// that get an ad-hoc subdomain via expose_port don't need to be
+	// re-registered as aliases. Empty (the default) disables suffix
+	// matching for this primary — exact Hostname/Aliases still work.
+	// See docs/PER-POOL-BASE-DOMAIN.md.
+	BaseDomain    string    `json:"base_domain,omitempty"`
 	IP            string    `json:"ip"`       // primary's reachable IP (typically internal VPC IP)
 	Port          int       `json:"port"`     // HTTPS port on the primary (typically 443)
 	BackendID     string    `json:"backend_id,omitempty"`
@@ -49,6 +57,7 @@ func (r *PrimaryRegistry) Register(p Primary) *Primary {
 		// Update fields that can change, keep original RegisteredAt
 		existing.Hostname = p.Hostname
 		existing.Aliases = p.Aliases
+		existing.BaseDomain = p.BaseDomain
 		existing.IP = p.IP
 		existing.Port = p.Port
 		existing.BackendID = p.BackendID
@@ -154,6 +163,54 @@ func (r *PrimaryRegistry) LookupByHostname(hostname string) *Primary {
 		}
 	}
 	return nil
+}
+
+// LookupByBaseDomainSuffix returns the primary whose BaseDomain is the
+// longest proper DNS suffix of hostname (i.e. hostname is of the form
+// "<sub>.<BaseDomain>"). The base domain itself is NOT a match — only
+// strict sub-hostnames — so a primary's BaseDomain can equal another
+// primary's Hostname without colliding here. Returns nil when no
+// primary's BaseDomain qualifies or when two primaries tie on suffix
+// length (ambiguity is a misconfiguration; fail closed rather than
+// pick one arbitrarily). Stale entries are skipped.
+//
+// Used by the SNI router after LookupByHostname misses, to route
+// ad-hoc container subdomains (e.g. blog.containarium.dev) without
+// each one being pre-registered as an alias.
+func (r *PrimaryRegistry) LookupByBaseDomainSuffix(hostname string) *Primary {
+	if hostname == "" {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	now := r.now()
+
+	var best *Primary
+	bestLen := 0
+	tie := false
+	for _, p := range r.primaries {
+		if r.isStale(p, now) {
+			continue
+		}
+		if p.BaseDomain == "" {
+			continue
+		}
+		if !strings.HasSuffix(hostname, "."+p.BaseDomain) {
+			continue
+		}
+		switch {
+		case len(p.BaseDomain) > bestLen:
+			best = p
+			bestLen = len(p.BaseDomain)
+			tie = false
+		case len(p.BaseDomain) == bestLen && best != nil && p != best:
+			tie = true
+		}
+	}
+	if tie {
+		return nil
+	}
+	return best
 }
 
 // All returns a snapshot of registered primaries. Stale entries are excluded

--- a/internal/sentinel/tunnel_auth.go
+++ b/internal/sentinel/tunnel_auth.go
@@ -93,9 +93,10 @@ type TunnelHandshake struct {
 	// pointing at the tunnel's loopback alias on the sentinel side. This
 	// avoids the daemon needing direct HTTP access to /sentinel/primaries
 	// from networks that can only reach the sentinel via the tunnel.
-	PublicHostname string   `json:"public_hostname,omitempty"`
-	PublicAliases  []string `json:"public_aliases,omitempty"`
-	PublicPort     int      `json:"public_port,omitempty"`
+	PublicHostname   string   `json:"public_hostname,omitempty"`
+	PublicAliases    []string `json:"public_aliases,omitempty"`
+	PublicBaseDomain string   `json:"public_base_domain,omitempty"`
+	PublicPort       int      `json:"public_port,omitempty"`
 }
 
 // TunnelHandshakeResponse is sent by the sentinel back to the spot after

--- a/internal/sentinel/tunnel_client.go
+++ b/internal/sentinel/tunnel_client.go
@@ -23,9 +23,10 @@ type TunnelClient struct {
 	// When PublicHostname is set, the sentinel auto-registers this tunnel
 	// as the primary for its pool. Saves the daemon from needing direct
 	// HTTP access to /sentinel/primaries.
-	PublicHostname string
-	PublicAliases  []string
-	PublicPort     int
+	PublicHostname   string
+	PublicAliases    []string
+	PublicBaseDomain string // suffix-match anchor; see docs/PER-POOL-BASE-DOMAIN.md
+	PublicPort       int
 }
 
 // Run connects to the sentinel and serves tunnel traffic.
@@ -73,13 +74,14 @@ func (tc *TunnelClient) connectAndServe(ctx context.Context) error {
 
 	// Send handshake
 	hs := &TunnelHandshake{
-		Token:          tc.Token,
-		SpotID:         tc.SpotID,
-		Ports:          tc.Ports,
-		Pool:           tc.Pool,
-		PublicHostname: tc.PublicHostname,
-		PublicAliases:  tc.PublicAliases,
-		PublicPort:     tc.PublicPort,
+		Token:            tc.Token,
+		SpotID:           tc.SpotID,
+		Ports:            tc.Ports,
+		Pool:             tc.Pool,
+		PublicHostname:   tc.PublicHostname,
+		PublicAliases:    tc.PublicAliases,
+		PublicBaseDomain: tc.PublicBaseDomain,
+		PublicPort:       tc.PublicPort,
 	}
 	if err := writeHandshake(conn, hs); err != nil {
 		return fmt.Errorf("write handshake: %w", err)

--- a/internal/sentinel/tunnel_registry.go
+++ b/internal/sentinel/tunnel_registry.go
@@ -29,9 +29,10 @@ type TunnelSpot struct {
 	// Primary self-registration via handshake (slice 6). Non-empty
 	// PublicHostname promotes this tunnel into a primary registry entry on
 	// connect; cleared on disconnect.
-	PublicHostname string
-	PublicAliases  []string
-	PublicPort     int
+	PublicHostname   string
+	PublicAliases    []string
+	PublicBaseDomain string
+	PublicPort       int
 }
 
 // TunnelRegistry tracks connected tunnel clients and assigns loopback aliases.
@@ -93,16 +94,17 @@ func (r *TunnelRegistry) Register(hs *TunnelHandshake, session *yamux.Session) (
 	externalPort := ExternalPortBase + int(octet)
 
 	spot := &TunnelSpot{
-		ID:             spotID,
-		Session:        session,
-		LocalIP:        localIP,
-		ExternalPort:   externalPort,
-		Ports:          hs.Ports,
-		Pool:           hs.Pool,
-		PublicHostname: hs.PublicHostname,
-		PublicAliases:  hs.PublicAliases,
-		PublicPort:     hs.PublicPort,
-		Connected:      time.Now(),
+		ID:               spotID,
+		Session:          session,
+		LocalIP:          localIP,
+		ExternalPort:     externalPort,
+		Ports:            hs.Ports,
+		Pool:             hs.Pool,
+		PublicHostname:   hs.PublicHostname,
+		PublicAliases:    hs.PublicAliases,
+		PublicBaseDomain: hs.PublicBaseDomain,
+		PublicPort:       hs.PublicPort,
+		Connected:        time.Now(),
 	}
 	r.spots[spotID] = spot
 

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -101,9 +101,10 @@ type DualServerConfig struct {
 
 	// Sentinel primary registration (multi-pool routing). Empty PublicHostname
 	// disables registration; the daemon still works as a single-pool primary.
-	PublicHostname string   // primary's own subdomain (e.g. containarium-prod.kafeido.app)
-	PublicAliases  []string // additional hostnames the primary's Caddy serves (e.g. api.kafeido.app, voice.kafeido.app)
-	PublicPort     int      // TLS port the sentinel forwards to (typically 443)
+	PublicHostname   string   // primary's own subdomain (e.g. containarium-prod.kafeido.app)
+	PublicAliases    []string // additional hostnames the primary's Caddy serves (e.g. api.kafeido.app, voice.kafeido.app)
+	PublicBaseDomain string   // suffix-match anchor advertised to the sentinel; <anything>.<PublicBaseDomain> routes here (see docs/PER-POOL-BASE-DOMAIN.md)
+	PublicPort       int      // TLS port the sentinel forwards to (typically 443)
 
 	// Alerting settings
 	AlertWebhookURL    string // Webhook URL for alert notifications (optional)
@@ -1210,12 +1211,13 @@ func (ds *DualServer) handleBackendSystemInfo(w http.ResponseWriter, r *http.Req
 func (ds *DualServer) Start(ctx context.Context) error {
 	// Register this primary with the sentinel (no-op if --public-hostname is unset).
 	runPrimaryRegistration(ctx, PrimaryRegisterConfig{
-		SentinelURL:    ds.config.SentinelURL,
-		Pool:           ds.config.Pool,
-		PublicHostname: ds.config.PublicHostname,
-		PublicAliases:  ds.config.PublicAliases,
-		Port:           ds.config.PublicPort,
-		BackendID:      ds.config.LocalBackendID,
+		SentinelURL:      ds.config.SentinelURL,
+		Pool:             ds.config.Pool,
+		PublicHostname:   ds.config.PublicHostname,
+		PublicAliases:    ds.config.PublicAliases,
+		PublicBaseDomain: ds.config.PublicBaseDomain,
+		Port:             ds.config.PublicPort,
+		BackendID:        ds.config.LocalBackendID,
 	})
 
 	// Start peer discovery for multi-backend support

--- a/internal/server/primary_register.go
+++ b/internal/server/primary_register.go
@@ -24,12 +24,13 @@ const primaryHeartbeatInterval = primaryRegisterTTL / 3
 // PrimaryRegisterConfig describes the inputs needed to advertise a primary
 // daemon to the sentinel registry.
 type PrimaryRegisterConfig struct {
-	SentinelURL    string   // e.g. http://10.128.0.5:8888
-	Pool           string   // pool name (must match peers' --pool)
-	PublicHostname string   // primary's own subdomain (e.g. containarium-prod.kafeido.app)
-	PublicAliases  []string // additional hostnames the primary's Caddy serves (e.g. api.kafeido.app, voice.kafeido.app)
-	Port           int      // public HTTPS port (typically 443 or 8443)
-	BackendID      string   // optional; for ops visibility in /sentinel/primaries
+	SentinelURL      string   // e.g. http://10.128.0.5:8888
+	Pool             string   // pool name (must match peers' --pool)
+	PublicHostname   string   // primary's own subdomain (e.g. containarium-prod.kafeido.app)
+	PublicAliases    []string // additional hostnames the primary's Caddy serves (e.g. api.kafeido.app, voice.kafeido.app)
+	PublicBaseDomain string   // suffix-match anchor: <anything>.<PublicBaseDomain> routes here (e.g. "containarium.dev")
+	Port             int      // public HTTPS port (typically 443 or 8443)
+	BackendID        string   // optional; for ops visibility in /sentinel/primaries
 }
 
 // runPrimaryRegistration registers with the sentinel, sends periodic
@@ -50,11 +51,12 @@ func runPrimaryRegistration(ctx context.Context, cfg PrimaryRegisterConfig) {
 	heartbeatURL := base + "/sentinel/primaries/" + cfg.Pool
 
 	body := map[string]any{
-		"pool":       cfg.Pool,
-		"hostname":   cfg.PublicHostname,
-		"aliases":    cfg.PublicAliases,
-		"port":       cfg.Port,
-		"backend_id": cfg.BackendID,
+		"pool":        cfg.Pool,
+		"hostname":    cfg.PublicHostname,
+		"aliases":     cfg.PublicAliases,
+		"base_domain": cfg.PublicBaseDomain,
+		"port":        cfg.Port,
+		"backend_id":  cfg.BackendID,
 		// IP intentionally omitted — sentinel infers from RemoteAddr.
 	}
 
@@ -64,7 +66,7 @@ func runPrimaryRegistration(ctx context.Context, cfg PrimaryRegisterConfig) {
 	if err := postJSON(ctx, client, registerURL, body); err != nil {
 		log.Printf("[primary-register] initial registration failed: %v (will retry)", err)
 	} else {
-		log.Printf("[primary-register] registered: pool=%q hostname=%q aliases=%v port=%d", cfg.Pool, cfg.PublicHostname, cfg.PublicAliases, cfg.Port)
+		log.Printf("[primary-register] registered: pool=%q hostname=%q aliases=%v base_domain=%q port=%d", cfg.Pool, cfg.PublicHostname, cfg.PublicAliases, cfg.PublicBaseDomain, cfg.Port)
 	}
 
 	go func() {


### PR DESCRIPTION
## Summary
Lets a single sentinel front multiple base domains by **suffix-matching inbound SNI** against each primary's advertised \`BaseDomain\`. Ad-hoc container subdomains (e.g. \`blog.containarium.dev\`) route to the right pool without each name being pre-registered as an alias.

This unblocks moving the demo cluster onto the prod sentinel: tag the demo backend with \`--pool=demo --public-base-domain=containarium.dev\` and the prod sentinel learns to forward \`*.containarium.dev\` traffic to it.

Builds on #204 (pool selector for placement). Together they cover the input side (where a container lands) and the output side (how its hostname routes back).

## Behavior
SNI router precedence becomes:
1. Exact \`Hostname\` / \`Alias\` match (unchanged).
2. **New**: \`BaseDomain\` suffix match (\`<anything>.<BaseDomain>\`).
3. Legacy single-backend fallback (unchanged).

Default \`--public-base-domain=\"\"\` → suffix match is invisible → existing single-pool deployments behave identically.

## Edge cases handled (with tests)
- **Longest suffix wins** — \`notebook.lab.kafeido.app\` goes to the primary with \`BaseDomain=lab.kafeido.app\`, not the one with \`BaseDomain=kafeido.app\`.
- **Ambiguous fails closed** — two primaries advertising the same \`BaseDomain\` cause \`LookupByBaseDomainSuffix\` to return nil rather than pick arbitrarily.
- **Base domain itself is NOT a match** — proper-suffix only, so the apex hostname (\`containarium.dev\`) can stay a separate \`Hostname\`/\`Alias\` entry without colliding.
- **Empty \`BaseDomain\` skipped** — pre-existing primaries are invisible to suffix lookup.
- **Exact alias beats suffix** — operator can override the implicit routing by listing a specific hostname in \`--public-aliases\`.
- **Re-registration replaces \`BaseDomain\`** — daemon restart with a different value doesn't leak the old binding.

## Operational notes (NOT in this PR)
These are still required before the demo backend can actually serve \`*.containarium.dev\`:
- [ ] Cloudflare DNS: \`*.containarium.dev\` A → prod sentinel IP
- [ ] Demo backend's Caddy needs DNS-01 creds for the containarium.dev provider (each backend ACMEs its own subdomains; sentinel does TLS passthrough)
- [ ] GLB cert SAN — only if your GLB terminates TLS; prod is passthrough so this is a no-op

Captured in [\`docs/PER-POOL-BASE-DOMAIN.md\`](docs/PER-POOL-BASE-DOMAIN.md) for the rollout runbook.

## Test plan
- [x] 9 new unit + e2e cases in \`internal/sentinel/base_domain_test.go\` — registry semantics + full SNI router test using the existing \`dialThroughHandler\` / \`startEchoListener\` harness from \`sni_test.go\`
- [x] \`go test ./... -short\` green across the repo
- [ ] Manual smoke after merge: prod sentinel + a backend with \`--pool=demo --public-base-domain=containarium.dev\`, \`curl --resolve fake.containarium.dev:443:<sentinel-ip>\` lands on the demo backend's logs
- [ ] Manual: verify \`--public-aliases override.containarium.dev\` on prod backend wins over demo's suffix match (exact-beats-suffix precedence in real traffic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)