### PR TITLE
feat(sentinel): multi-domain primaries — Phase 3b

### DIFF
--- a/docs/PER-POOL-BASE-DOMAIN.md
+++ b/docs/PER-POOL-BASE-DOMAIN.md
@@ -1,131 +1,177 @@
-# Per-Pool Base Domain (Design)
+# Per-Pool Base Domain Routing
 
-**Status**: Draft — not yet implemented.
-**Depends on**: [MULTI-POOL.md](MULTI-POOL.md), [APP-HOSTING.md](APP-HOSTING.md).
-**Drives**: serving multiple base domains (e.g. `kafeido.app` and `containarium.dev`) from a single sentinel without per-container alias bookkeeping.
+**Status**: Shipped. Single-domain support landed in #205 (Phase 3); multi-domain support in #207 (Phase 3b).
+**Related**: [MULTI-POOL.md](MULTI-POOL.md), [APP-HOSTING.md](APP-HOSTING.md), [CUTOVER-DEMO-INTO-PROD-SENTINEL.md](CUTOVER-DEMO-INTO-PROD-SENTINEL.md), [PLAN-DEMO-CONTAINER-MIGRATION.md](PLAN-DEMO-CONTAINER-MIGRATION.md).
+**Enables**: serving multiple base domains (e.g. `example.com` and `example.org`) from a single sentinel without per-container alias bookkeeping; one backend hosting workloads under multiple parent domains.
 
 ## Problem
 
-Today, every app hostname a pool's Caddy serves must appear in that primary's `--public-aliases` ([MULTI-POOL.md:178](MULTI-POOL.md#app-domain-routing-via-aliases)). The sentinel's SNI router does exact-match against `Primary.Hostname` plus the alias list ([primary_registry.go:139-156](../internal/sentinel/primary_registry.go)) and falls back to the legacy single-backend forwarder on miss ([manager.go:608-611](../internal/sentinel/manager.go)).
+Before this work, every app hostname a pool's Caddy served had to appear in that primary's `--public-aliases` ([MULTI-POOL.md:178](MULTI-POOL.md#app-domain-routing-via-aliases)). The sentinel's SNI router did exact-match against `Primary.Hostname` plus the alias list and fell back to the legacy single-backend forwarder on miss.
 
-That works when app domains are a small fixed set (`api.kafeido.app`, `voice.kafeido.app`, …) registered once at primary startup. It breaks when:
+That worked when app domains were a small fixed set (`api.example.com`, `voice.example.com`, …) registered once at primary startup. It broke when:
 
-- **Containers create their own subdomains dynamically.** `expose_port blog` on the demo backend produces `blog.containarium.dev`. The container exists; the Caddy route exists on the backend; the cert ACMEs fine. But the sentinel doesn't know that name → demo-backend, so the SNI peek misses and falls back to the wrong backend.
-- **A single sentinel needs to serve two or more base domains.** Today prod's sentinel handles `*.kafeido.app` purely by the fallback path (single registered backend == prod). Adding `containarium.dev` for the demo backend means the fallback can no longer be "the one backend" — different SNI suffixes need to go to different backends.
+- **Containers create their own subdomains dynamically.** `expose_port blog` on the demo backend produces `blog.example.org`. The container exists; the Caddy route exists on the backend; the cert ACMEs fine. But the sentinel didn't know that name → demo-backend, so the SNI peek missed and fell back to the wrong backend.
+- **A single sentinel needs to serve two or more base domains.** Prod's sentinel handled `*.example.com` purely by the fallback path (single registered backend == prod). Adding `example.org` for the demo backend meant the fallback could no longer be "the one backend" — different SNI suffixes needed to go to different backends.
+- **A single backend needs to host workloads under multiple parent domains.** The lab-hosts-demo pattern: the lab backend serves both `*.lab.example.com` (its own pool's workloads) and `*.demo.example.org` (migrated demo workloads). This is the Phase 4 / B2 path in [PLAN-DEMO-CONTAINER-MIGRATION.md](PLAN-DEMO-CONTAINER-MIGRATION.md).
 
-The workaround (register every container's hostname as an alias and update on every `expose_port`) is doable but ugly: it'd require a sentinel-API round-trip on every route mutation, with all the cache-invalidation pain that implies.
+The exact-alias workaround was doable for fixed app domains but doesn't scale to either dynamic subdomains or multi-tenant backends.
 
-## Proposal
+## Design
 
-Add a **per-primary base domain** that the SNI router uses for **suffix matching** after exact-alias matching fails and before the legacy fallback.
+A per-primary **list of base domains** that the SNI router uses for **suffix matching** after exact-alias matching fails and before the legacy fallback.
 
-### Registry change
-
-`Primary` gains a `BaseDomain` field, populated from a new `--public-base-domain` daemon flag (default empty == legacy behavior):
+### Registry
 
 ```go
 type Primary struct {
-    Pool       Pool      `json:"pool"`
-    Hostname   string    `json:"hostname"`
-    Aliases    []string  `json:"aliases,omitempty"`
-    BaseDomain string    `json:"base_domain,omitempty"` // NEW: suffix-match anchor
-    IP         string    `json:"ip"`
-    Port       int       `json:"port"`
-    BackendID  string    `json:"backend_id,omitempty"`
+    Pool        Pool     `json:"pool"`
+    Hostname    string   `json:"hostname"`
+    Aliases     []string `json:"aliases,omitempty"`
+    BaseDomains []string `json:"base_domains,omitempty"` // suffix-match anchors
+    IP          string   `json:"ip"`
+    Port        int      `json:"port"`
+    BackendID   string   `json:"backend_id,omitempty"`
     ...
 }
 ```
 
-New lookup method:
+Lookup method:
 
 ```go
-// LookupByBaseDomainSuffix returns the primary whose BaseDomain is a
-// proper DNS suffix of hostname. Returns nil if no primary matches or
-// if multiple primaries match (ambiguity is a configuration error;
-// fail closed rather than pick arbitrarily).
+// LookupByBaseDomainSuffix returns the primary whose BaseDomains contain
+// the longest proper DNS suffix of hostname. A primary may advertise
+// multiple base domains; each is considered independently. Returns nil
+// when no primary qualifies or when two primaries tie on suffix length
+// (ambiguity = misconfiguration; fail closed).
 func (r *PrimaryRegistry) LookupByBaseDomainSuffix(hostname string) *Primary
 ```
 
-Suffix match means `strings.HasSuffix(hostname, "." + p.BaseDomain)` — *proper* suffix, so `containarium.dev` does NOT match the BaseDomain literally (only `something.containarium.dev`). This keeps `containarium.dev` itself usable as a primary `Hostname` for the apex.
+Suffix match means `strings.HasSuffix(hostname, "." + bd)` for each `bd` in `BaseDomains` — *proper* suffix, so the base domain itself (`example.org`) does NOT match. This keeps the apex hostname usable as a separate `Hostname` or `Alias` for the apex.
 
 ### SNI router precedence
 
-`buildSNIRoutingHandler` ([manager.go:582](../internal/sentinel/manager.go)) becomes:
+`buildSNIRoutingHandler` in `internal/sentinel/manager.go`:
 
-1. Exact hostname match (`LookupByHostname`) — current behavior, unchanged.
-2. **New**: BaseDomain suffix match (`LookupByBaseDomainSuffix`).
-3. Fallback to `fallbackTarget` — current behavior, unchanged.
+1. Exact `Hostname` / `Alias` match (`LookupByHostname`) — unchanged from pre-Phase-3.
+2. `BaseDomains` suffix match (`LookupByBaseDomainSuffix`) — Phase 3 (single) / Phase 3b (multi).
+3. Legacy fallback to `fallbackTarget` — unchanged.
 
-The fallback stays as a safety net for unpooled single-backend deployments (no `BaseDomain` configured → step 2 always returns nil → behavior identical to today).
+The fallback stays as a safety net for unpooled single-backend deployments (no `BaseDomains` configured → step 2 always returns nil → behavior identical to pre-Phase-3).
 
-### Handshake change for tunneled primaries
+### Handshake + flag plumbing
 
-`TunnelHandshake` ([tunnel_auth.go](../internal/sentinel/tunnel_auth.go)) gains `PublicBaseDomain string`. The tunnel command picks it up from a new `--public-base-domain` flag in `internal/cmd/tunnel.go`. On `OnTunnelConnect` the value flows through to the `primaries.Register(...)` call (`manager.go:823-835`).
+`TunnelHandshake` gains `PublicBaseDomains []string`. Repeatable flag on both daemon and tunnel commands:
 
-### Daemon-side change
+```
+containarium daemon ... --public-base-domain lab.example.com --public-base-domain demo.example.org
+containarium tunnel ... --public-base-domain lab.example.com --public-base-domain demo.example.org
+```
 
-`internal/cmd/daemon.go` already has `--base-domain` for the backend's own Caddy. Reuse it: if `--public-base-domain` isn't set explicitly, default to `--base-domain`. This means most operators set one flag, and the sentinel learns it automatically via the existing primary registration.
+When unset, the daemon falls back to `[--base-domain]` (single-element list derived from the existing flag) so single-domain deployments need no extra config.
 
-## Worked example
+REST POST `/sentinel/primaries` body uses `base_domains: [...]`.
 
-| Backend | `--pool` | `--public-hostname` | `--base-domain` (== `--public-base-domain` default) |
+### Tie-breaking
+
+- **Longest suffix wins.** When two base domains both match (e.g. `example.com` and `lab.example.com` for SNI `notebook.lab.example.com`), the longer suffix is more specific and wins. Implemented in `LookupByBaseDomainSuffix` by tracking `bestLen` across all `(primary, base-domain)` pairs.
+- **Equal-length ties fail closed.** Two primaries advertising the *same* base domain is a misconfiguration; the lookup returns nil rather than picking arbitrarily. Caught regardless of which slot the duplicate lives in within each primary's `BaseDomains` list.
+- **Exact alias beats suffix.** Operator's explicit `--public-aliases` entry overrides the implicit suffix routing (step 1 runs before step 2 in the SNI router).
+
+## Worked examples
+
+### Example A — two backends, two base domains
+
+| Backend | `--pool` | `--public-hostname` | `--public-base-domain` (repeatable) |
 |---|---|---|---|
-| prod | `prod` | `containarium-prod.kafeido.app` | `kafeido.app` |
-| demo | `demo` | `demo.containarium.dev` | `containarium.dev` |
-| lab | `lab` | `containarium-lab.kafeido.app` | `lab.kafeido.app` |
+| prod | `prod` | `prod.example.com` | `example.com` |
+| demo | `demo` | `demo.example.org` | `example.org` |
 
-Inbound SNI behavior on the prod sentinel:
+Inbound SNI on the prod sentinel:
 
 | SNI | Match path | Forwards to |
 |---|---|---|
-| `containarium-prod.kafeido.app` | exact (Hostname) | prod backend |
-| `api.kafeido.app` | exact (Aliases, if listed) | prod backend |
-| `blog.containarium.dev` | suffix (`.containarium.dev`) | demo backend |
-| `notebook.lab.kafeido.app` | suffix (`.lab.kafeido.app`) | lab backend — **NOT** prod (more-specific suffix wins) |
-| `kafeido.app` (apex) | none → fallback | legacy backend |
+| `prod.example.com` | exact (Hostname) | prod backend |
+| `api.example.com` | exact (Aliases, if listed) | prod backend |
+| `blog.example.org` | suffix (`.example.org`) | demo backend |
+| `example.com` (apex) | none → fallback | legacy backend |
 
-The third row is the new capability; it removes the need to register `blog.containarium.dev` as an alias.
+### Example B — one backend, multiple base domains (lab-hosts-demo)
+
+The lab backend in the [demo container migration plan](PLAN-DEMO-CONTAINER-MIGRATION.md) hosts both its own pool's workloads and migrated demo workloads. One primary registration covers both surfaces:
+
+```
+containarium tunnel \
+  --pool lab \
+  --public-hostname lab-primary.example.com \
+  --public-base-domain lab.example.com \
+  --public-base-domain demo.example.org \
+  --public-port 443
+```
+
+| SNI | Match path | Forwards to |
+|---|---|---|
+| `notebook.lab.example.com` | suffix (`.lab.example.com`) | lab backend |
+| `blog.demo.example.org` | suffix (`.demo.example.org`) | lab backend (same!) |
+| `api.example.com` | none — `lab.example.com` is more specific than `example.com`, but neither prefix matches `api.example.com`. Falls through. | fallback |
+
+The pool tag stays `lab` — `demo.example.org` is just the routing surface, not a separate trust boundary. If you want demo containers to also be visible as `pool=demo` (for `containarium list --pool=demo` filtering, etc.), use container labels rather than splitting the backend.
+
+### Example C — longest-suffix wins across multi-domain primaries
+
+| Backend | `BaseDomains` |
+|---|---|
+| lab | `[example.com, demo.example.org]` |
+| lab2 | `[sub.example.com]` |
+
+SNI `notebook.sub.example.com` matches both lab's `example.com` (length 11) and lab2's `sub.example.com` (length 15). Lab2 wins — more-specific suffix is the user's intent.
 
 ## Edge cases & failure modes
 
-- **Overlapping base domains.** Two primaries register with `BaseDomain=kafeido.app` and `BaseDomain=lab.kafeido.app`. `notebook.lab.kafeido.app` matches both. **Resolution**: longest-suffix wins (the more-specific one). Implement by sorting candidates by `len(BaseDomain)` desc and returning the first match. Document that ambiguity ladder explicitly.
-- **Identical base domains across pools.** Two primaries register with `BaseDomain=kafeido.app` — a misconfiguration. **Resolution**: `LookupByBaseDomainSuffix` returns nil and logs a warning rather than picking arbitrarily. Fail closed.
-- **Suffix collides with an exact alias on a different primary.** E.g. prod's `Aliases=[blog.containarium.dev]` plus demo's `BaseDomain=containarium.dev`. **Resolution**: exact match wins (precedence step 1 runs before step 2). Operator's explicit choice overrides the implicit suffix routing.
-- **Tunneled primary disconnects.** Same as today — `UnregisterByBackendID` removes the entry, suffix lookups stop matching, suffix-matched SNI falls through to the legacy fallback. No new failure mode.
+- **Identical base domains across pools.** Two primaries advertise `BaseDomains` containing the same string. `LookupByBaseDomainSuffix` returns nil. Fail closed; surfaces the misconfig instead of silently picking the wrong backend.
+- **Suffix collides with exact alias on a different primary.** Exact wins (step 1 before step 2). Operator's explicit choice overrides implicit routing.
+- **Tunneled primary disconnects.** Same as pre-Phase-3 — `UnregisterByBackendID` removes the entry; suffix lookups stop matching for those base domains; suffix-matched SNI falls through to the legacy fallback.
 - **PROXY-v2 framing.** Suffix-matched destinations go through the same dial-or-yamux path as exact matches, so the existing `m.config.ProxyProtocol` handling still applies. No new code needed.
+- **Per-container base-domain selection.** Not a concept — the *backend* advertises its base domains, and the *container* publishes a route under whichever fits. The route-builder in `internal/app/proxy.go` already handles "FQDN that doesn't match the daemon's `--base-domain` → use as-is," so a lab container exposed as `blog.demo.example.org` (FQDN) Just Works even if the daemon's `--base-domain=lab.example.com`.
 
-## Operational additions
+## Operational additions (per cluster)
 
-These are required regardless of the code design — listed here so the work isn't a surprise during rollout:
+These are required regardless of the code; listed here so the work isn't a surprise during rollout.
 
-1. **DNS.** `*.containarium.dev` A record → prod sentinel IP. Cloudflare-managed (separate provider from `kafeido.app`).
-2. **ACME for the second domain.** Each backend's Caddy ACMEs its own subdomains, so `--base-domain=containarium.dev` triggers DNS-01 against the containarium.dev provider. That means the **demo backend's daemon** needs DNS-01 creds for the containarium.dev provider in its environment, not the sentinel. Existing kafeido.app DNS-01 setup on the prod backend is untouched.
-3. **GLB cert SAN.** If the GLB does TLS termination (which prod does not — it's TCP passthrough — but confirm), add `*.containarium.dev` to the managed cert. For passthrough mode, no change.
+1. **DNS.** Wildcard record for each base domain → sentinel IP. Cloudflare-managed for `example.org`, separate provider for `example.com`.
+2. **ACME on each backend.** Caddy on every backend that advertises a given base domain needs creds to mint certs for subdomains under it. HTTP-01 works transparently over sentinel passthrough; DNS-01 requires the relevant provider's API token in the backend's environment.
+3. **GLB cert SAN.** Only if the GLB terminates TLS (prod is passthrough, so this is a no-op).
 
 ## What this does NOT change
 
 - ACME on the sentinel itself (sentinel doesn't terminate TLS for app traffic; passthrough only).
-- Caddy on any backend (each backend continues to own its own `--base-domain`; this design just makes the sentinel aware of that value).
+- Caddy on any backend (each backend continues to own its own `--base-domain` for daemon-driven route naming; this design just makes the sentinel aware of additional suffix anchors).
 - The `--public-aliases` flag (still works for explicit per-domain routing; suffix match is additive).
-- Pool-aware container placement ([added in feat(api): --pool selector](../proto/containarium/v1/container.proto)) — that's the input side; this is the output side.
+- Pool-aware container placement (Phase 1 / #204 — that's the input side; this is the output side).
 
-## Test plan
+## Test coverage
 
-- Unit: `LookupByBaseDomainSuffix` returns nil for empty hostname, exact match, no-suffix, ambiguous (two equal-length matches), and picks longest suffix when nested base domains exist.
-- Unit: `buildSNIRoutingHandler` precedence — exact > suffix > fallback. Use the existing `httptest`/loopback patterns in `internal/sentinel/`.
-- Integration (real Caddy): two primaries registered with different `BaseDomain`, SNI for each routes to the correct one. The Real Caddy wire-compat e2e job in CI is the right home.
-- Manual: prod sentinel + a second backend with `--public-base-domain=containarium.dev`, `curl --resolve` a fake subdomain → confirm the right backend's logs see the request.
+`internal/sentinel/base_domain_test.go`:
 
-## Rollout
+| Test | What it pins |
+|---|---|
+| `LookupByBaseDomainSuffix` | basic suffix match, deeper subdomain, base-domain-itself-isn't-a-match, unrelated returns nil, empty input |
+| `LookupByBaseDomainSuffix_LongestWins` | nested base domains (`lab.example.com` beats `example.com` for the nested name) |
+| `LookupByBaseDomainSuffix_AmbiguousFailsClosed` | two primaries with the same `BaseDomains` entry → nil |
+| `LookupByBaseDomainSuffix_EmptyBaseDomainSkipped` | unconfigured primary is invisible to suffix lookup |
+| `ExactHostnameBeatsSuffix` | router precedence at registry level (alias vs suffix) |
+| `LookupByBaseDomainSuffix_MultipleOnOnePrimary` | **Phase 3b** — single primary advertises multiple base domains; both match |
+| `LookupByBaseDomainSuffix_MultiDomainLosesToMoreSpecific` | **Phase 3b** — longest-wins still applies across multi-domain primaries |
+| `LookupByBaseDomainSuffix_AmbiguousAcrossMultiDomain` | **Phase 3b** — same base domain on two primaries fails closed regardless of slot order |
+| `SNIRouting_BaseDomainSuffix` | end-to-end via SNI router harness — suffix match, exact-beats-suffix, fallback |
+| `SNIRouting_MultiBaseDomainOnOneBackend` | **Phase 3b** — end-to-end of lab-hosts-demo |
+| `RegisterUpdatesBaseDomain` | re-registration replaces the `BaseDomains` list |
 
-1. Land the proto + registry + SNI matcher changes behind the (default-empty) `--public-base-domain` flag. Zero behavior change for any existing deployment.
-2. Demo backend joins the prod sentinel with `--pool=demo --public-base-domain=containarium.dev`.
-3. DNS for `*.containarium.dev` cuts over.
-4. Verify with `curl --resolve` (no DNS dependency for the test).
-5. Demo container migration follows ([plan in Phase 4](MULTI-POOL.md#operator-workflow-adding-a-new-pool)).
+`internal/cmd/daemon_base_domains_test.go`:
+- `TestResolvePublicBaseDomains` — explicit values win, base-domain fallback when unset, empty in both yields nil.
 
 ## Alternatives considered
 
-- **Push container hostnames to sentinel on every `expose_port`.** Workable but couples the route store to a remote API call on every mutation. Adds latency to route creation and a new failure mode (sentinel unreachable → can't expose a port). Suffix match keeps the contract one-way (daemon → sentinel at registration time, never per-route).
-- **Wildcard aliases (`*.containarium.dev` as an alias entry).** Same effect but harder to reason about: aliases are also matched against `Hostname` for non-wildcards, and mixing wildcards into a list invites accidental over-matching. A separate `BaseDomain` field makes the intent explicit.
+- **Push container hostnames to the sentinel on every `expose_port`.** Workable but couples the route store to a remote API call on every mutation. Adds latency to route creation and a new failure mode (sentinel unreachable → can't expose a port). Suffix match keeps the contract one-way (daemon → sentinel at registration time, never per-route).
+- **Wildcard aliases (`*.example.org` as an alias entry).** Same effect but harder to reason about: aliases are also matched against `Hostname` for non-wildcards, and mixing wildcards into a list invites accidental over-matching. A separate `BaseDomains` field makes the intent explicit.
 - **Caddy on the sentinel.** Would centralize routing but adds TLS termination on the sentinel (vs. today's passthrough), which breaks per-backend ACME, complicates client IP recovery, and adds another component to keep alive. Not worth it for this use case.
+- **`BaseDomain string` (single, Phase 3) instead of `BaseDomains []string` (Phase 3b).** The single-domain version shipped first and was complete for the demo-via-prod-sentinel use case. Multi-domain landed when the Phase 4 plan revealed the need for one backend (the lab) to serve both `*.lab.example.com` and `*.demo.example.org`. Migration from singular → plural was a clean field rename across ~10 files with no semantic drift.

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -51,10 +51,10 @@ var (
 	peerAddrs          []string
 	localBackendID     string
 	pool               string
-	publicHostname     string
-	publicAliases      []string
-	publicBaseDomain   string
-	publicPort         int
+	publicHostname    string
+	publicAliases     []string
+	publicBaseDomains []string
+	publicPort        int
 
 	proxyProtocol        bool
 	proxyProtocolTrusted []string
@@ -127,7 +127,7 @@ func init() {
 	// App hosting settings
 	daemonCmd.Flags().BoolVar(&enableAppHosting, "app-hosting", false, "Enable app hosting feature (requires PostgreSQL)")
 	daemonCmd.Flags().StringVar(&postgresConnString, "postgres", "", "PostgreSQL connection string for app hosting (e.g., postgres://user:pass@host:5432/db)")
-	daemonCmd.Flags().StringVar(&baseDomain, "base-domain", "containarium.dev", "Base domain for app subdomains (e.g., containarium.dev)")
+	daemonCmd.Flags().StringVar(&baseDomain, "base-domain", "example.org", "Base domain for app subdomains (e.g., example.org)")
 	daemonCmd.Flags().StringVar(&caddyAdminURL, "caddy-admin-url", "", "Caddy admin API URL for reverse proxy configuration (leave empty for auto-setup with --app-hosting)")
 	daemonCmd.Flags().StringVar(&caddyCertDir, "caddy-cert-dir", "/var/lib/caddy/.local/share/caddy", "Caddy certificate directory (for sentinel cert sync via /certs endpoint)")
 
@@ -139,9 +139,9 @@ func init() {
 	daemonCmd.Flags().StringSliceVar(&peerAddrs, "peers", nil, "Static peer daemon addresses (e.g., 10.128.0.5:18001)")
 	daemonCmd.Flags().StringVar(&localBackendID, "backend-id", "", "This daemon's backend ID (defaults to hostname)")
 	daemonCmd.Flags().StringVar(&pool, "pool", "", "Pool name to scope sentinel peer discovery (empty = unscoped, see all peers)")
-	daemonCmd.Flags().StringVar(&publicHostname, "public-hostname", "", "Public hostname this primary serves (e.g. containarium-prod.kafeido.app); enables sentinel primary registration")
-	daemonCmd.Flags().StringSliceVar(&publicAliases, "public-aliases", nil, "Additional hostnames the primary's Caddy serves (e.g. api.kafeido.app,voice.kafeido.app); the sentinel SNI router treats these as aliases of --public-hostname")
-	daemonCmd.Flags().StringVar(&publicBaseDomain, "public-base-domain", "", "Suffix-match anchor advertised to the sentinel — inbound SNI of the form <anything>.<public-base-domain> routes here without each subdomain being a registered alias. Defaults to --base-domain when unset. See docs/PER-POOL-BASE-DOMAIN.md.")
+	daemonCmd.Flags().StringVar(&publicHostname, "public-hostname", "", "Public hostname this primary serves (e.g. prod.example.com); enables sentinel primary registration")
+	daemonCmd.Flags().StringSliceVar(&publicAliases, "public-aliases", nil, "Additional hostnames the primary's Caddy serves (e.g. api.example.com,voice.example.com); the sentinel SNI router treats these as aliases of --public-hostname")
+	daemonCmd.Flags().StringSliceVar(&publicBaseDomains, "public-base-domain", nil, "Suffix-match anchor advertised to the sentinel — inbound SNI of the form <anything>.<public-base-domain> routes here without each subdomain being a registered alias. Repeatable: list multiple to host workloads under different parent domains on the same backend (e.g. --public-base-domain lab.example.com --public-base-domain demo.example.org). Defaults to [--base-domain] when unset. See docs/PER-POOL-BASE-DOMAIN.md.")
 	daemonCmd.Flags().BoolVar(&proxyProtocol, "proxy-protocol", false, "Configure Caddy to accept PROXY v2 headers from --proxy-protocol-trusted CIDRs so containers receive the real client IP. Pair with --proxy-protocol on the sentinel.")
 	daemonCmd.Flags().StringSliceVar(&proxyProtocolTrusted, "proxy-protocol-trusted", []string{"127.0.0.0/8"}, "CIDRs allowed to send PROXY headers (typically the sentinel VPC IP/32). Wildcard 0.0.0.0/0 is rejected.")
 	daemonCmd.Flags().IntVar(&publicPort, "public-port", 443, "Public TLS port the sentinel forwards to (default 443)")
@@ -467,7 +467,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		Pool:                 pool,
 		PublicHostname:       publicHostname,
 		PublicAliases:        publicAliases,
-		PublicBaseDomain:     resolvePublicBaseDomain(publicBaseDomain, baseDomain),
+		PublicBaseDomains:    resolvePublicBaseDomains(publicBaseDomains, baseDomain),
 		PublicPort:           publicPort,
 		ProxyProtocol:        proxyProtocol,
 		ProxyProtocolTrusted: proxyProtocolTrusted,
@@ -699,17 +699,21 @@ func waitForCoreContainers(incusClient *incus.Client, timeout time.Duration) err
 	}
 }
 
-// resolvePublicBaseDomain returns the value to advertise to the
-// sentinel for suffix-match routing. When the operator passed
-// --public-base-domain explicitly, that wins; otherwise the value
-// falls back to --base-domain, which is already the suffix the
-// backend's own Caddy serves containers under. Empty in both cases
+// resolvePublicBaseDomains returns the list of base domains to
+// advertise to the sentinel for suffix-match routing. When the
+// operator passed one or more --public-base-domain values, those
+// win verbatim; otherwise the list falls back to a single entry
+// derived from --base-domain (which is already the suffix the
+// backend's own Caddy serves containers under). An empty result
 // means suffix matching is disabled for this primary.
-func resolvePublicBaseDomain(public, base string) string {
-	if public != "" {
+func resolvePublicBaseDomains(public []string, base string) []string {
+	if len(public) > 0 {
 		return public
 	}
-	return base
+	if base == "" {
+		return nil
+	}
+	return []string{base}
 }
 
 // saveRecoveryConfigToPersistentStorage saves recovery config to persistent disk

--- a/internal/cmd/daemon_base_domains_test.go
+++ b/internal/cmd/daemon_base_domains_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestResolvePublicBaseDomains pins the precedence: explicit
+// --public-base-domain values always win; otherwise the daemon's
+// --base-domain becomes a single-entry default; empty in both
+// yields nil (suffix matching disabled).
+func TestResolvePublicBaseDomains(t *testing.T) {
+	cases := []struct {
+		name   string
+		public []string
+		base   string
+		want   []string
+	}{
+		{
+			name:   "explicit single value wins",
+			public: []string{"lab.example.com"},
+			base:   "example.com",
+			want:   []string{"lab.example.com"},
+		},
+		{
+			name:   "explicit multi-value wins (lab-hosts-demo pattern)",
+			public: []string{"lab.example.com", "demo.example.org"},
+			base:   "example.com",
+			want:   []string{"lab.example.com", "demo.example.org"},
+		},
+		{
+			name:   "no explicit, base provides single fallback",
+			public: nil,
+			base:   "example.org",
+			want:   []string{"example.org"},
+		},
+		{
+			name:   "both empty → nil",
+			public: nil,
+			base:   "",
+			want:   nil,
+		},
+		{
+			name:   "explicit empty slice still falls back",
+			public: []string{},
+			base:   "example.org",
+			want:   []string{"example.org"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolvePublicBaseDomains(tc.public, tc.base)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("resolvePublicBaseDomains(%v, %q) = %v, want %v",
+					tc.public, tc.base, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/tunnel.go
+++ b/internal/cmd/tunnel.go
@@ -18,10 +18,10 @@ var (
 	tunnelSpotID         string
 	tunnelPorts          string
 	tunnelPool           string
-	tunnelPublicHostname   string
-	tunnelPublicAliases    []string
-	tunnelPublicBaseDomain string
-	tunnelPublicPort       int
+	tunnelPublicHostname    string
+	tunnelPublicAliases     []string
+	tunnelPublicBaseDomains []string
+	tunnelPublicPort        int
 )
 
 var tunnelCmd = &cobra.Command{
@@ -52,8 +52,8 @@ func init() {
 	tunnelCmd.Flags().StringVar(&tunnelPorts, "ports", "22,80,443,3389,8080", "Comma-separated local ports to expose through the tunnel")
 	tunnelCmd.Flags().StringVar(&tunnelPool, "pool", "", "Pool name to register this peer in (optional; empty = unpooled)")
 	tunnelCmd.Flags().StringVar(&tunnelPublicHostname, "public-hostname", "", "If set, sentinel registers this tunnel as the primary for its pool, serving the named hostname (requires --pool and --public-port)")
-	tunnelCmd.Flags().StringSliceVar(&tunnelPublicAliases, "public-aliases", nil, "Additional hostnames the primary's Caddy serves (e.g. api.kafeido.app,voice.kafeido.app)")
-	tunnelCmd.Flags().StringVar(&tunnelPublicBaseDomain, "public-base-domain", "", "Suffix-match anchor advertised to the sentinel — inbound SNI of the form <anything>.<public-base-domain> routes through this tunnel without each subdomain being a registered alias. See docs/PER-POOL-BASE-DOMAIN.md.")
+	tunnelCmd.Flags().StringSliceVar(&tunnelPublicAliases, "public-aliases", nil, "Additional hostnames the primary's Caddy serves (e.g. api.example.com,voice.example.com)")
+	tunnelCmd.Flags().StringSliceVar(&tunnelPublicBaseDomains, "public-base-domain", nil, "Suffix-match anchor advertised to the sentinel — inbound SNI of the form <anything>.<public-base-domain> routes through this tunnel without each subdomain being a registered alias. Repeatable: list multiple to host workloads under different parent domains on the same backend. See docs/PER-POOL-BASE-DOMAIN.md.")
 	tunnelCmd.Flags().IntVar(&tunnelPublicPort, "public-port", 0, "Public TLS port the sentinel forwards to via this tunnel (typically 443; required with --public-hostname)")
 }
 
@@ -91,15 +91,15 @@ func runTunnel(cmd *cobra.Command, args []string) error {
 	}()
 
 	client := &sentinel.TunnelClient{
-		SentinelAddr:     tunnelSentinelAddr,
-		Token:            token,
-		SpotID:           tunnelSpotID,
-		Ports:            ports,
-		Pool:             sentinel.Pool(tunnelPool),
-		PublicHostname:   tunnelPublicHostname,
-		PublicAliases:    tunnelPublicAliases,
-		PublicBaseDomain: tunnelPublicBaseDomain,
-		PublicPort:       tunnelPublicPort,
+		SentinelAddr:      tunnelSentinelAddr,
+		Token:             token,
+		SpotID:            tunnelSpotID,
+		Ports:             ports,
+		Pool:              sentinel.Pool(tunnelPool),
+		PublicHostname:    tunnelPublicHostname,
+		PublicAliases:     tunnelPublicAliases,
+		PublicBaseDomains: tunnelPublicBaseDomains,
+		PublicPort:        tunnelPublicPort,
 	}
 
 	log.Printf("[tunnel] connecting to sentinel at %s as %q (ports: %v, pool: %q, primary_host: %q)", tunnelSentinelAddr, tunnelSpotID, ports, tunnelPool, tunnelPublicHostname)

--- a/internal/sentinel/base_domain_test.go
+++ b/internal/sentinel/base_domain_test.go
@@ -11,48 +11,48 @@ import (
 
 // TestPrimaryRegistry_LookupByBaseDomainSuffix covers the suffix-match
 // path: containers exposed under a primary's BaseDomain (e.g.
-// blog.containarium.dev) route to that primary without each name
+// blog.example.org) route to that primary without each name
 // being a registered alias.
 func TestPrimaryRegistry_LookupByBaseDomainSuffix(t *testing.T) {
 	r := NewPrimaryRegistry()
 	r.Register(Primary{
-		Pool:       "prod",
-		Hostname:   "containarium-prod.kafeido.app",
-		BaseDomain: "kafeido.app",
-		IP:         "10.0.0.10",
-		Port:       443,
+		Pool:        "prod",
+		Hostname:    "prod.example.com",
+		BaseDomains: []string{"example.com"},
+		IP:          "10.0.0.10",
+		Port:        443,
 	})
 	r.Register(Primary{
-		Pool:       "demo",
-		Hostname:   "demo.containarium.dev",
-		BaseDomain: "containarium.dev",
-		IP:         "10.0.0.20",
-		Port:       443,
+		Pool:        "demo",
+		Hostname:    "demo.example.org",
+		BaseDomains: []string{"example.org"},
+		IP:          "10.0.0.20",
+		Port:        443,
 	})
 
 	t.Run("matches by suffix", func(t *testing.T) {
-		p := r.LookupByBaseDomainSuffix("blog.containarium.dev")
+		p := r.LookupByBaseDomainSuffix("blog.example.org")
 		if assert.NotNil(t, p) {
 			assert.Equal(t, Pool("demo"), p.Pool)
 		}
 	})
 
 	t.Run("deeper subdomain also matches", func(t *testing.T) {
-		p := r.LookupByBaseDomainSuffix("a.b.c.containarium.dev")
+		p := r.LookupByBaseDomainSuffix("a.b.c.example.org")
 		if assert.NotNil(t, p) {
 			assert.Equal(t, Pool("demo"), p.Pool)
 		}
 	})
 
 	t.Run("base domain itself is not a match", func(t *testing.T) {
-		// "containarium.dev" is NOT "*.containarium.dev" — proper-suffix only.
+		// "example.org" is NOT "*.example.org" — proper-suffix only.
 		// This keeps the apex hostname usable as a separate Hostname/Alias
 		// without ambiguity.
-		assert.Nil(t, r.LookupByBaseDomainSuffix("containarium.dev"))
+		assert.Nil(t, r.LookupByBaseDomainSuffix("example.org"))
 	})
 
 	t.Run("unrelated hostname returns nil", func(t *testing.T) {
-		assert.Nil(t, r.LookupByBaseDomainSuffix("evil.example.com"))
+		assert.Nil(t, r.LookupByBaseDomainSuffix("evil.invalid"))
 	})
 
 	t.Run("empty hostname returns nil", func(t *testing.T) {
@@ -61,34 +61,34 @@ func TestPrimaryRegistry_LookupByBaseDomainSuffix(t *testing.T) {
 }
 
 // TestPrimaryRegistry_LookupByBaseDomainSuffix_LongestWins ensures that
-// when one BaseDomain is a tail of another (lab.kafeido.app vs
-// kafeido.app), the more-specific match wins.
+// when one BaseDomain is a tail of another (lab.example.com vs
+// example.com), the more-specific match wins.
 func TestPrimaryRegistry_LookupByBaseDomainSuffix_LongestWins(t *testing.T) {
 	r := NewPrimaryRegistry()
 	r.Register(Primary{
-		Pool:       "prod",
-		Hostname:   "containarium-prod.kafeido.app",
-		BaseDomain: "kafeido.app",
-		IP:         "10.0.0.10",
-		Port:       443,
+		Pool:        "prod",
+		Hostname:    "prod.example.com",
+		BaseDomains: []string{"example.com"},
+		IP:          "10.0.0.10",
+		Port:        443,
 	})
 	r.Register(Primary{
-		Pool:       "lab",
-		Hostname:   "containarium-lab.kafeido.app",
-		BaseDomain: "lab.kafeido.app",
-		IP:         "10.0.0.30",
-		Port:       443,
+		Pool:        "lab",
+		Hostname:    "lab-primary.example.com",
+		BaseDomains: []string{"lab.example.com"},
+		IP:          "10.0.0.30",
+		Port:        443,
 	})
 
-	// notebook.lab.kafeido.app could match both, but the longer suffix
-	// (lab.kafeido.app) is more specific and should win.
-	p := r.LookupByBaseDomainSuffix("notebook.lab.kafeido.app")
+	// notebook.lab.example.com could match both, but the longer suffix
+	// (lab.example.com) is more specific and should win.
+	p := r.LookupByBaseDomainSuffix("notebook.lab.example.com")
 	if assert.NotNil(t, p) {
 		assert.Equal(t, Pool("lab"), p.Pool, "longer suffix should win")
 	}
 
 	// A sibling that only matches the shorter suffix still routes correctly.
-	p = r.LookupByBaseDomainSuffix("api.kafeido.app")
+	p = r.LookupByBaseDomainSuffix("api.example.com")
 	if assert.NotNil(t, p) {
 		assert.Equal(t, Pool("prod"), p.Pool)
 	}
@@ -101,38 +101,38 @@ func TestPrimaryRegistry_LookupByBaseDomainSuffix_LongestWins(t *testing.T) {
 func TestPrimaryRegistry_LookupByBaseDomainSuffix_AmbiguousFailsClosed(t *testing.T) {
 	r := NewPrimaryRegistry()
 	r.Register(Primary{
-		Pool:       "a",
-		Hostname:   "a.kafeido.app",
-		BaseDomain: "kafeido.app",
-		IP:         "10.0.0.10",
-		Port:       443,
+		Pool:        "a",
+		Hostname:    "a.example.com",
+		BaseDomains: []string{"example.com"},
+		IP:          "10.0.0.10",
+		Port:        443,
 	})
 	r.Register(Primary{
-		Pool:       "b",
-		Hostname:   "b.kafeido.app",
-		BaseDomain: "kafeido.app",
-		IP:         "10.0.0.11",
-		Port:       443,
+		Pool:        "b",
+		Hostname:    "b.example.com",
+		BaseDomains: []string{"example.com"},
+		IP:          "10.0.0.11",
+		Port:        443,
 	})
 
-	assert.Nil(t, r.LookupByBaseDomainSuffix("blog.kafeido.app"),
+	assert.Nil(t, r.LookupByBaseDomainSuffix("blog.example.com"),
 		"ambiguous suffix should fail closed, not pick arbitrarily")
 }
 
 // TestPrimaryRegistry_LookupByBaseDomainSuffix_EmptyBaseDomainSkipped
-// confirms that a primary with no BaseDomain is invisible to suffix
+// confirms that a primary with no BaseDomains is invisible to suffix
 // lookup. This keeps single-pool / legacy deployments unaffected.
 func TestPrimaryRegistry_LookupByBaseDomainSuffix_EmptyBaseDomainSkipped(t *testing.T) {
 	r := NewPrimaryRegistry()
 	r.Register(Primary{
 		Pool:     "legacy",
-		Hostname: "legacy.kafeido.app",
+		Hostname: "legacy.example.com",
 		IP:       "10.0.0.10",
 		Port:     443,
 	})
 
-	assert.Nil(t, r.LookupByBaseDomainSuffix("blog.kafeido.app"),
-		"primary without BaseDomain must not match suffix lookups")
+	assert.Nil(t, r.LookupByBaseDomainSuffix("blog.example.com"),
+		"primary without BaseDomains must not match suffix lookups")
 }
 
 // TestPrimaryRegistry_ExactHostnameBeatsSuffix verifies that the SNI
@@ -146,31 +146,136 @@ func TestPrimaryRegistry_ExactHostnameBeatsSuffix(t *testing.T) {
 	r := NewPrimaryRegistry()
 	r.Register(Primary{
 		Pool:     "prod",
-		Hostname: "containarium-prod.kafeido.app",
-		Aliases:  []string{"blog.containarium.dev"}, // explicit override
+		Hostname: "prod.example.com",
+		Aliases:  []string{"blog.example.org"}, // explicit override
 		IP:       "10.0.0.10",
 		Port:     443,
 	})
 	r.Register(Primary{
-		Pool:       "demo",
-		Hostname:   "demo.containarium.dev",
-		BaseDomain: "containarium.dev",
-		IP:         "10.0.0.20",
-		Port:       443,
+		Pool:        "demo",
+		Hostname:    "demo.example.org",
+		BaseDomains: []string{"example.org"},
+		IP:          "10.0.0.20",
+		Port:        443,
 	})
 
 	// Exact alias on prod points at prod.
-	p := r.LookupByHostname("blog.containarium.dev")
+	p := r.LookupByHostname("blog.example.org")
 	if assert.NotNil(t, p) {
 		assert.Equal(t, Pool("prod"), p.Pool)
 	}
 
 	// Suffix match would otherwise pick demo. Router runs exact first,
 	// so the alias override stands.
-	pSuffix := r.LookupByBaseDomainSuffix("blog.containarium.dev")
+	pSuffix := r.LookupByBaseDomainSuffix("blog.example.org")
 	if assert.NotNil(t, pSuffix) {
 		assert.Equal(t, Pool("demo"), pSuffix.Pool,
 			"suffix lookup still resolves to demo in isolation; router precedence is what decides")
+	}
+}
+
+// TestPrimaryRegistry_LookupByBaseDomainSuffix_MultipleOnOnePrimary
+// exercises the multi-domain feature: a single primary advertises
+// several base domains so one backend can host workloads under
+// different parent domains (the lab-hosts-demo use case from
+// docs/PLAN-DEMO-CONTAINER-MIGRATION.md).
+func TestPrimaryRegistry_LookupByBaseDomainSuffix_MultipleOnOnePrimary(t *testing.T) {
+	r := NewPrimaryRegistry()
+	r.Register(Primary{
+		Pool:     "lab",
+		Hostname: "lab-primary.example.com",
+		// Lab backend hosts both its own pool's workloads AND migrated
+		// demo workloads published under example.org.
+		BaseDomains: []string{"lab.example.com", "demo.example.org"},
+		IP:          "10.0.0.30",
+		Port:        443,
+	})
+
+	// First base domain matches.
+	p := r.LookupByBaseDomainSuffix("notebook.lab.example.com")
+	if assert.NotNil(t, p) {
+		assert.Equal(t, Pool("lab"), p.Pool)
+	}
+
+	// Second base domain matches the same primary.
+	p = r.LookupByBaseDomainSuffix("blog.demo.example.org")
+	if assert.NotNil(t, p) {
+		assert.Equal(t, Pool("lab"), p.Pool,
+			"demo subdomain should route to the lab primary that hosts it")
+	}
+
+	// Neither base domain matches → nil.
+	assert.Nil(t, r.LookupByBaseDomainSuffix("api.example.com"),
+		"only lab.example.com is advertised, not the parent example.com")
+}
+
+// TestPrimaryRegistry_LookupByBaseDomainSuffix_MultiDomainLosesToMoreSpecific
+// verifies the longest-wins rule still applies when one primary's
+// BaseDomain is the suffix of another primary's BaseDomain — even if
+// the latter has multiple base domains listed.
+func TestPrimaryRegistry_LookupByBaseDomainSuffix_MultiDomainLosesToMoreSpecific(t *testing.T) {
+	r := NewPrimaryRegistry()
+	r.Register(Primary{
+		Pool:        "lab",
+		Hostname:    "lab-primary.example.com",
+		BaseDomains: []string{"example.com", "demo.example.org"},
+		IP:          "10.0.0.30",
+		Port:        443,
+	})
+	r.Register(Primary{
+		Pool:        "lab2",
+		Hostname:    "lab2-primary.example.com",
+		BaseDomains: []string{"sub.example.com"},
+		IP:          "10.0.0.31",
+		Port:        443,
+	})
+
+	// "notebook.sub.example.com" matches both lab's "example.com" and
+	// lab2's "sub.example.com". Longer suffix wins.
+	p := r.LookupByBaseDomainSuffix("notebook.sub.example.com")
+	if assert.NotNil(t, p) {
+		assert.Equal(t, Pool("lab2"), p.Pool, "more-specific suffix wins across multi-domain primaries")
+	}
+
+	// "blog.example.com" only matches lab's first base domain.
+	p = r.LookupByBaseDomainSuffix("blog.example.com")
+	if assert.NotNil(t, p) {
+		assert.Equal(t, Pool("lab"), p.Pool)
+	}
+}
+
+// TestPrimaryRegistry_LookupByBaseDomainSuffix_AmbiguousAcrossMultiDomain
+// ensures that ambiguity detection still fires when the same base
+// domain appears on two primaries — even if it's only one entry in
+// each primary's multi-domain list.
+func TestPrimaryRegistry_LookupByBaseDomainSuffix_AmbiguousAcrossMultiDomain(t *testing.T) {
+	r := NewPrimaryRegistry()
+	r.Register(Primary{
+		Pool:        "a",
+		Hostname:    "a.example.com",
+		BaseDomains: []string{"example.com", "extra-a.example.net"},
+		IP:          "10.0.0.10",
+		Port:        443,
+	})
+	r.Register(Primary{
+		Pool:        "b",
+		Hostname:    "b.example.com",
+		BaseDomains: []string{"extra-b.example.net", "example.com"},
+		IP:          "10.0.0.11",
+		Port:        443,
+	})
+
+	assert.Nil(t, r.LookupByBaseDomainSuffix("blog.example.com"),
+		"shared base domain across primaries must still fail closed regardless of slot order")
+
+	// Each primary's unique domains still resolve cleanly.
+	p := r.LookupByBaseDomainSuffix("foo.extra-a.example.net")
+	if assert.NotNil(t, p) {
+		assert.Equal(t, Pool("a"), p.Pool)
+	}
+	p = r.LookupByBaseDomainSuffix("foo.extra-b.example.net")
+	if assert.NotNil(t, p) {
+		assert.Equal(t, Pool("b"), p.Pool)
 	}
 }
 
@@ -190,57 +295,57 @@ func TestSNIRouting_BaseDomainSuffix(t *testing.T) {
 	demoHost, demoPortStr, err := net.SplitHostPort(demoAddr)
 	require.NoError(t, err)
 	m.primaries.Register(Primary{
-		Pool:       "demo",
-		Hostname:   "demo.containarium.dev",
-		BaseDomain: "containarium.dev",
-		IP:         demoHost,
-		Port:       mustAtoi(t, demoPortStr),
+		Pool:        "demo",
+		Hostname:    "demo.example.org",
+		BaseDomains: []string{"example.org"},
+		IP:          demoHost,
+		Port:        mustAtoi(t, demoPortStr),
 	})
 
 	prodHost, prodPortStr, err := net.SplitHostPort(prodAddr)
 	require.NoError(t, err)
 	m.primaries.Register(Primary{
-		Pool:       "prod",
-		Hostname:   "containarium-prod.kafeido.app",
+		Pool:     "prod",
+		Hostname: "prod.example.com",
 		// Explicit alias for a name that ALSO matches demo's BaseDomain.
 		// Exact match must win — operator's explicit choice beats the
 		// implicit suffix routing.
-		Aliases:    []string{"override.containarium.dev"},
-		BaseDomain: "kafeido.app",
-		IP:         prodHost,
-		Port:       mustAtoi(t, prodPortStr),
+		Aliases:     []string{"override.example.org"},
+		BaseDomains: []string{"example.com"},
+		IP:          prodHost,
+		Port:        mustAtoi(t, prodPortStr),
 	})
 
 	handler := m.buildSNIRoutingHandler(fallbackAddr)
 
-	// Suffix match: any subdomain of containarium.dev → demo.
+	// Suffix match: any subdomain of example.org → demo.
 	got := dialThroughHandler(t, handler, &tls.Config{
-		ServerName: "blog.containarium.dev", InsecureSkipVerify: true,
+		ServerName: "blog.example.org", InsecureSkipVerify: true,
 	})
-	assert.Equal(t, "DEMO", got, "blog.containarium.dev should suffix-match demo")
+	assert.Equal(t, "DEMO", got, "blog.example.org should suffix-match demo")
 
-	// Suffix match: any subdomain of kafeido.app → prod.
+	// Suffix match: any subdomain of example.com → prod.
 	got = dialThroughHandler(t, handler, &tls.Config{
-		ServerName: "api.kafeido.app", InsecureSkipVerify: true,
+		ServerName: "api.example.com", InsecureSkipVerify: true,
 	})
-	assert.Equal(t, "PROD", got, "api.kafeido.app should suffix-match prod")
+	assert.Equal(t, "PROD", got, "api.example.com should suffix-match prod")
 
-	// Exact alias wins over suffix: override.containarium.dev → prod
-	// even though containarium.dev is demo's BaseDomain.
+	// Exact alias wins over suffix: override.example.org → prod
+	// even though example.org is demo's BaseDomain.
 	got = dialThroughHandler(t, handler, &tls.Config{
-		ServerName: "override.containarium.dev", InsecureSkipVerify: true,
+		ServerName: "override.example.org", InsecureSkipVerify: true,
 	})
 	assert.Equal(t, "PROD", got, "exact alias must beat suffix match")
 
 	// Exact hostname still works.
 	got = dialThroughHandler(t, handler, &tls.Config{
-		ServerName: "containarium-prod.kafeido.app", InsecureSkipVerify: true,
+		ServerName: "prod.example.com", InsecureSkipVerify: true,
 	})
 	assert.Equal(t, "PROD", got, "exact hostname must hit prod")
 
 	// Nothing matches → fallback.
 	got = dialThroughHandler(t, handler, &tls.Config{
-		ServerName: "evil.example.com", InsecureSkipVerify: true,
+		ServerName: "evil.invalid", InsecureSkipVerify: true,
 	})
 	assert.Equal(t, "FALLBACK", got, "unrelated SNI must fall through")
 
@@ -249,31 +354,66 @@ func TestSNIRouting_BaseDomainSuffix(t *testing.T) {
 	assert.Equal(t, 1, fallbackHits(), "fallback hit once (unmatched)")
 }
 
+// TestSNIRouting_MultiBaseDomainOnOneBackend is the end-to-end of the
+// lab-hosts-demo pattern: one backend, two base domains, both routed.
+func TestSNIRouting_MultiBaseDomainOnOneBackend(t *testing.T) {
+	labAddr, labHits := startEchoListener(t, "LAB")
+	fallbackAddr, _ := startEchoListener(t, "FALLBACK")
+
+	m := &Manager{primaries: NewPrimaryRegistry()}
+
+	labHost, labPortStr, err := net.SplitHostPort(labAddr)
+	require.NoError(t, err)
+	m.primaries.Register(Primary{
+		Pool:        "lab",
+		Hostname:    "lab-primary.example.com",
+		BaseDomains: []string{"lab.example.com", "demo.example.org"},
+		IP:          labHost,
+		Port:        mustAtoi(t, labPortStr),
+	})
+
+	handler := m.buildSNIRoutingHandler(fallbackAddr)
+
+	// Lab's own pool subdomain.
+	got := dialThroughHandler(t, handler, &tls.Config{
+		ServerName: "notebook.lab.example.com", InsecureSkipVerify: true,
+	})
+	assert.Equal(t, "LAB", got, "lab.example.com subdomain should hit lab")
+
+	// Migrated demo subdomain on the same backend.
+	got = dialThroughHandler(t, handler, &tls.Config{
+		ServerName: "blog.demo.example.org", InsecureSkipVerify: true,
+	})
+	assert.Equal(t, "LAB", got, "demo.example.org subdomain should also hit lab")
+
+	assert.Equal(t, 2, labHits(), "both SNI suffixes route to the same backend")
+}
+
 // TestPrimaryRegistry_RegisterUpdatesBaseDomain ensures that a
-// re-registration with a different BaseDomain replaces the old value.
-// Otherwise stale base-domain bindings would persist across daemon
-// restarts. Uses disjoint old/new domains so a longer-suffix match on
-// either side can't muddy the assertion.
+// re-registration with a different BaseDomains list replaces the old
+// value. Otherwise stale base-domain bindings would persist across
+// daemon restarts. Uses disjoint old/new domains so a longer-suffix
+// match on either side can't muddy the assertion.
 func TestPrimaryRegistry_RegisterUpdatesBaseDomain(t *testing.T) {
 	r := NewPrimaryRegistry()
 	r.Register(Primary{
-		Pool:       "demo",
-		Hostname:   "demo.example.org",
-		BaseDomain: "example.org",
-		IP:         "10.0.0.20",
-		Port:       443,
+		Pool:        "demo",
+		Hostname:    "demo.example.test",
+		BaseDomains: []string{"example.test"},
+		IP:          "10.0.0.20",
+		Port:        443,
 	})
 	r.Register(Primary{
-		Pool:       "demo",
-		Hostname:   "demo.example.org",
-		BaseDomain: "containarium.dev",
-		IP:         "10.0.0.20",
-		Port:       443,
+		Pool:        "demo",
+		Hostname:    "demo.example.test",
+		BaseDomains: []string{"example.org"},
+		IP:          "10.0.0.20",
+		Port:        443,
 	})
 
-	assert.Nil(t, r.LookupByBaseDomainSuffix("blog.example.org"),
-		"old BaseDomain should be gone after re-register")
-	p := r.LookupByBaseDomainSuffix("blog.containarium.dev")
+	assert.Nil(t, r.LookupByBaseDomainSuffix("blog.example.test"),
+		"old BaseDomains should be gone after re-register")
+	p := r.LookupByBaseDomainSuffix("blog.example.org")
 	if assert.NotNil(t, p) {
 		assert.Equal(t, Pool("demo"), p.Pool)
 	}

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -210,7 +210,7 @@ func (m *Manager) PrimariesHandler() http.HandlerFunc {
 				return
 			}
 			stored := m.primaries.Register(p)
-			log.Printf("[sentinel] primary registered: pool=%q host=%q base_domain=%q ip=%s:%d", stored.Pool, stored.Hostname, stored.BaseDomain, stored.IP, stored.Port)
+			log.Printf("[sentinel] primary registered: pool=%q host=%q base_domains=%v ip=%s:%d", stored.Pool, stored.Hostname, stored.BaseDomains, stored.IP, stored.Port)
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(stored)
 
@@ -841,16 +841,16 @@ func (m *Manager) OnTunnelConnect(spot *TunnelSpot) {
 	// primary's hostname/aliases through the tunnel.
 	if spot.PublicHostname != "" && spot.PublicPort != 0 && m.primaries != nil {
 		m.primaries.Register(Primary{
-			Pool:       spot.Pool,
-			Hostname:   spot.PublicHostname,
-			Aliases:    spot.PublicAliases,
-			BaseDomain: spot.PublicBaseDomain,
-			IP:         spot.LocalIP,
-			Port:       spot.PublicPort,
-			BackendID:  b.ID,
+			Pool:        spot.Pool,
+			Hostname:    spot.PublicHostname,
+			Aliases:     spot.PublicAliases,
+			BaseDomains: spot.PublicBaseDomains,
+			IP:          spot.LocalIP,
+			Port:        spot.PublicPort,
+			BackendID:   b.ID,
 		})
-		log.Printf("[sentinel] tunnel-promoted primary: pool=%q hostname=%q aliases=%v -> %s:%d",
-			spot.Pool, spot.PublicHostname, spot.PublicAliases, spot.LocalIP, spot.PublicPort)
+		log.Printf("[sentinel] tunnel-promoted primary: pool=%q hostname=%q aliases=%v base_domains=%v -> %s:%d",
+			spot.Pool, spot.PublicHostname, spot.PublicAliases, spot.PublicBaseDomains, spot.LocalIP, spot.PublicPort)
 	}
 
 	// Start sync loops for this tunnel backend

--- a/internal/sentinel/primary_registry.go
+++ b/internal/sentinel/primary_registry.go
@@ -12,18 +12,21 @@ const PrimaryTTL = 90 * time.Second
 
 // Primary represents a registered primary daemon serving one pool.
 type Primary struct {
-	Pool          Pool      `json:"pool"`
-	Hostname      string    `json:"hostname"` // primary's own subdomain (e.g. containarium-prod.kafeido.app)
-	Aliases       []string  `json:"aliases,omitempty"` // additional hostnames the primary's Caddy routes (e.g. api.kafeido.app, voice.kafeido.app)
-	// BaseDomain anchors suffix routing: any inbound SNI of the form
-	// "<anything>.<BaseDomain>" routes to this primary, so containers
-	// that get an ad-hoc subdomain via expose_port don't need to be
-	// re-registered as aliases. Empty (the default) disables suffix
-	// matching for this primary — exact Hostname/Aliases still work.
-	// See docs/PER-POOL-BASE-DOMAIN.md.
-	BaseDomain    string    `json:"base_domain,omitempty"`
-	IP            string    `json:"ip"`       // primary's reachable IP (typically internal VPC IP)
-	Port          int       `json:"port"`     // HTTPS port on the primary (typically 443)
+	Pool     Pool     `json:"pool"`
+	Hostname string   `json:"hostname"`          // primary's own subdomain (e.g. prod.example.com)
+	Aliases  []string `json:"aliases,omitempty"` // additional hostnames the primary's Caddy routes (e.g. api.example.com, voice.example.com)
+	// BaseDomains anchor suffix routing: any inbound SNI of the form
+	// "<anything>.<one-of-BaseDomains>" routes to this primary, so
+	// containers that get an ad-hoc subdomain via expose_port don't
+	// need to be re-registered as aliases. A primary can advertise
+	// multiple base domains so one backend can host workloads that
+	// publish under different parent domains (e.g. a lab backend
+	// serving both *.lab.example.com and *.demo.example.org).
+	// Empty (the default) disables suffix matching for this primary
+	// — exact Hostname/Aliases still work. See docs/PER-POOL-BASE-DOMAIN.md.
+	BaseDomains   []string  `json:"base_domains,omitempty"`
+	IP            string    `json:"ip"`   // primary's reachable IP (typically internal VPC IP)
+	Port          int       `json:"port"` // HTTPS port on the primary (typically 443)
 	BackendID     string    `json:"backend_id,omitempty"`
 	RegisteredAt  time.Time `json:"registered_at"`
 	LastHeartbeat time.Time `json:"last_heartbeat"`
@@ -57,7 +60,7 @@ func (r *PrimaryRegistry) Register(p Primary) *Primary {
 		// Update fields that can change, keep original RegisteredAt
 		existing.Hostname = p.Hostname
 		existing.Aliases = p.Aliases
-		existing.BaseDomain = p.BaseDomain
+		existing.BaseDomains = p.BaseDomains
 		existing.IP = p.IP
 		existing.Port = p.Port
 		existing.BackendID = p.BackendID
@@ -165,17 +168,19 @@ func (r *PrimaryRegistry) LookupByHostname(hostname string) *Primary {
 	return nil
 }
 
-// LookupByBaseDomainSuffix returns the primary whose BaseDomain is the
-// longest proper DNS suffix of hostname (i.e. hostname is of the form
-// "<sub>.<BaseDomain>"). The base domain itself is NOT a match — only
-// strict sub-hostnames — so a primary's BaseDomain can equal another
-// primary's Hostname without colliding here. Returns nil when no
-// primary's BaseDomain qualifies or when two primaries tie on suffix
-// length (ambiguity is a misconfiguration; fail closed rather than
-// pick one arbitrarily). Stale entries are skipped.
+// LookupByBaseDomainSuffix returns the primary whose BaseDomains
+// contain the longest proper DNS suffix of hostname (i.e. hostname is
+// of the form "<sub>.<one-of-BaseDomains>"). A primary may advertise
+// multiple base domains; each is considered independently. The base
+// domain itself is NOT a match — only strict sub-hostnames — so a
+// primary's BaseDomains can include another primary's Hostname
+// without colliding here. Returns nil when no primary qualifies or
+// when two primaries tie on suffix length (ambiguity is a
+// misconfiguration; fail closed rather than pick one arbitrarily).
+// Stale entries are skipped.
 //
 // Used by the SNI router after LookupByHostname misses, to route
-// ad-hoc container subdomains (e.g. blog.containarium.dev) without
+// ad-hoc container subdomains (e.g. blog.example.org) without
 // each one being pre-registered as an alias.
 func (r *PrimaryRegistry) LookupByBaseDomainSuffix(hostname string) *Primary {
 	if hostname == "" {
@@ -192,19 +197,21 @@ func (r *PrimaryRegistry) LookupByBaseDomainSuffix(hostname string) *Primary {
 		if r.isStale(p, now) {
 			continue
 		}
-		if p.BaseDomain == "" {
-			continue
-		}
-		if !strings.HasSuffix(hostname, "."+p.BaseDomain) {
-			continue
-		}
-		switch {
-		case len(p.BaseDomain) > bestLen:
-			best = p
-			bestLen = len(p.BaseDomain)
-			tie = false
-		case len(p.BaseDomain) == bestLen && best != nil && p != best:
-			tie = true
+		for _, bd := range p.BaseDomains {
+			if bd == "" {
+				continue
+			}
+			if !strings.HasSuffix(hostname, "."+bd) {
+				continue
+			}
+			switch {
+			case len(bd) > bestLen:
+				best = p
+				bestLen = len(bd)
+				tie = false
+			case len(bd) == bestLen && best != nil && p != best:
+				tie = true
+			}
 		}
 	}
 	if tie {

--- a/internal/sentinel/tunnel_auth.go
+++ b/internal/sentinel/tunnel_auth.go
@@ -93,10 +93,10 @@ type TunnelHandshake struct {
 	// pointing at the tunnel's loopback alias on the sentinel side. This
 	// avoids the daemon needing direct HTTP access to /sentinel/primaries
 	// from networks that can only reach the sentinel via the tunnel.
-	PublicHostname   string   `json:"public_hostname,omitempty"`
-	PublicAliases    []string `json:"public_aliases,omitempty"`
-	PublicBaseDomain string   `json:"public_base_domain,omitempty"`
-	PublicPort       int      `json:"public_port,omitempty"`
+	PublicHostname    string   `json:"public_hostname,omitempty"`
+	PublicAliases     []string `json:"public_aliases,omitempty"`
+	PublicBaseDomains []string `json:"public_base_domains,omitempty"`
+	PublicPort        int      `json:"public_port,omitempty"`
 }
 
 // TunnelHandshakeResponse is sent by the sentinel back to the spot after

--- a/internal/sentinel/tunnel_client.go
+++ b/internal/sentinel/tunnel_client.go
@@ -23,10 +23,10 @@ type TunnelClient struct {
 	// When PublicHostname is set, the sentinel auto-registers this tunnel
 	// as the primary for its pool. Saves the daemon from needing direct
 	// HTTP access to /sentinel/primaries.
-	PublicHostname   string
-	PublicAliases    []string
-	PublicBaseDomain string // suffix-match anchor; see docs/PER-POOL-BASE-DOMAIN.md
-	PublicPort       int
+	PublicHostname    string
+	PublicAliases     []string
+	PublicBaseDomains []string // suffix-match anchors; see docs/PER-POOL-BASE-DOMAIN.md
+	PublicPort        int
 }
 
 // Run connects to the sentinel and serves tunnel traffic.
@@ -74,14 +74,14 @@ func (tc *TunnelClient) connectAndServe(ctx context.Context) error {
 
 	// Send handshake
 	hs := &TunnelHandshake{
-		Token:            tc.Token,
-		SpotID:           tc.SpotID,
-		Ports:            tc.Ports,
-		Pool:             tc.Pool,
-		PublicHostname:   tc.PublicHostname,
-		PublicAliases:    tc.PublicAliases,
-		PublicBaseDomain: tc.PublicBaseDomain,
-		PublicPort:       tc.PublicPort,
+		Token:             tc.Token,
+		SpotID:            tc.SpotID,
+		Ports:             tc.Ports,
+		Pool:              tc.Pool,
+		PublicHostname:    tc.PublicHostname,
+		PublicAliases:     tc.PublicAliases,
+		PublicBaseDomains: tc.PublicBaseDomains,
+		PublicPort:        tc.PublicPort,
 	}
 	if err := writeHandshake(conn, hs); err != nil {
 		return fmt.Errorf("write handshake: %w", err)

--- a/internal/sentinel/tunnel_registry.go
+++ b/internal/sentinel/tunnel_registry.go
@@ -29,10 +29,10 @@ type TunnelSpot struct {
 	// Primary self-registration via handshake (slice 6). Non-empty
 	// PublicHostname promotes this tunnel into a primary registry entry on
 	// connect; cleared on disconnect.
-	PublicHostname   string
-	PublicAliases    []string
-	PublicBaseDomain string
-	PublicPort       int
+	PublicHostname    string
+	PublicAliases     []string
+	PublicBaseDomains []string
+	PublicPort        int
 }
 
 // TunnelRegistry tracks connected tunnel clients and assigns loopback aliases.
@@ -94,17 +94,17 @@ func (r *TunnelRegistry) Register(hs *TunnelHandshake, session *yamux.Session) (
 	externalPort := ExternalPortBase + int(octet)
 
 	spot := &TunnelSpot{
-		ID:               spotID,
-		Session:          session,
-		LocalIP:          localIP,
-		ExternalPort:     externalPort,
-		Ports:            hs.Ports,
-		Pool:             hs.Pool,
-		PublicHostname:   hs.PublicHostname,
-		PublicAliases:    hs.PublicAliases,
-		PublicBaseDomain: hs.PublicBaseDomain,
-		PublicPort:       hs.PublicPort,
-		Connected:        time.Now(),
+		ID:                spotID,
+		Session:           session,
+		LocalIP:           localIP,
+		ExternalPort:      externalPort,
+		Ports:             hs.Ports,
+		Pool:              hs.Pool,
+		PublicHostname:    hs.PublicHostname,
+		PublicAliases:     hs.PublicAliases,
+		PublicBaseDomains: hs.PublicBaseDomains,
+		PublicPort:        hs.PublicPort,
+		Connected:         time.Now(),
 	}
 	r.spots[spotID] = spot
 

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -101,10 +101,10 @@ type DualServerConfig struct {
 
 	// Sentinel primary registration (multi-pool routing). Empty PublicHostname
 	// disables registration; the daemon still works as a single-pool primary.
-	PublicHostname   string   // primary's own subdomain (e.g. containarium-prod.kafeido.app)
-	PublicAliases    []string // additional hostnames the primary's Caddy serves (e.g. api.kafeido.app, voice.kafeido.app)
-	PublicBaseDomain string   // suffix-match anchor advertised to the sentinel; <anything>.<PublicBaseDomain> routes here (see docs/PER-POOL-BASE-DOMAIN.md)
-	PublicPort       int      // TLS port the sentinel forwards to (typically 443)
+	PublicHostname    string   // primary's own subdomain (e.g. prod.example.com)
+	PublicAliases     []string // additional hostnames the primary's Caddy serves (e.g. api.example.com, voice.example.com)
+	PublicBaseDomains []string // suffix-match anchors advertised to the sentinel; <anything>.<one-of-these> routes here. List multiple to host workloads under different parent domains on the same backend (see docs/PER-POOL-BASE-DOMAIN.md)
+	PublicPort        int      // TLS port the sentinel forwards to (typically 443)
 
 	// Alerting settings
 	AlertWebhookURL    string // Webhook URL for alert notifications (optional)
@@ -1211,13 +1211,13 @@ func (ds *DualServer) handleBackendSystemInfo(w http.ResponseWriter, r *http.Req
 func (ds *DualServer) Start(ctx context.Context) error {
 	// Register this primary with the sentinel (no-op if --public-hostname is unset).
 	runPrimaryRegistration(ctx, PrimaryRegisterConfig{
-		SentinelURL:      ds.config.SentinelURL,
-		Pool:             ds.config.Pool,
-		PublicHostname:   ds.config.PublicHostname,
-		PublicAliases:    ds.config.PublicAliases,
-		PublicBaseDomain: ds.config.PublicBaseDomain,
-		Port:             ds.config.PublicPort,
-		BackendID:        ds.config.LocalBackendID,
+		SentinelURL:       ds.config.SentinelURL,
+		Pool:              ds.config.Pool,
+		PublicHostname:    ds.config.PublicHostname,
+		PublicAliases:     ds.config.PublicAliases,
+		PublicBaseDomains: ds.config.PublicBaseDomains,
+		Port:              ds.config.PublicPort,
+		BackendID:         ds.config.LocalBackendID,
 	})
 
 	// Start peer discovery for multi-backend support

--- a/internal/server/primary_register.go
+++ b/internal/server/primary_register.go
@@ -24,13 +24,13 @@ const primaryHeartbeatInterval = primaryRegisterTTL / 3
 // PrimaryRegisterConfig describes the inputs needed to advertise a primary
 // daemon to the sentinel registry.
 type PrimaryRegisterConfig struct {
-	SentinelURL      string   // e.g. http://10.128.0.5:8888
-	Pool             string   // pool name (must match peers' --pool)
-	PublicHostname   string   // primary's own subdomain (e.g. containarium-prod.kafeido.app)
-	PublicAliases    []string // additional hostnames the primary's Caddy serves (e.g. api.kafeido.app, voice.kafeido.app)
-	PublicBaseDomain string   // suffix-match anchor: <anything>.<PublicBaseDomain> routes here (e.g. "containarium.dev")
-	Port             int      // public HTTPS port (typically 443 or 8443)
-	BackendID        string   // optional; for ops visibility in /sentinel/primaries
+	SentinelURL       string   // e.g. http://10.128.0.5:8888
+	Pool              string   // pool name (must match peers' --pool)
+	PublicHostname    string   // primary's own subdomain (e.g. prod.example.com)
+	PublicAliases     []string // additional hostnames the primary's Caddy serves (e.g. api.example.com, voice.example.com)
+	PublicBaseDomains []string // suffix-match anchors: <anything>.<one-of-these> routes here. A single backend can host multiple parent domains by listing each.
+	Port              int      // public HTTPS port (typically 443 or 8443)
+	BackendID         string   // optional; for ops visibility in /sentinel/primaries
 }
 
 // runPrimaryRegistration registers with the sentinel, sends periodic
@@ -51,12 +51,12 @@ func runPrimaryRegistration(ctx context.Context, cfg PrimaryRegisterConfig) {
 	heartbeatURL := base + "/sentinel/primaries/" + cfg.Pool
 
 	body := map[string]any{
-		"pool":        cfg.Pool,
-		"hostname":    cfg.PublicHostname,
-		"aliases":     cfg.PublicAliases,
-		"base_domain": cfg.PublicBaseDomain,
-		"port":        cfg.Port,
-		"backend_id":  cfg.BackendID,
+		"pool":         cfg.Pool,
+		"hostname":     cfg.PublicHostname,
+		"aliases":      cfg.PublicAliases,
+		"base_domains": cfg.PublicBaseDomains,
+		"port":         cfg.Port,
+		"backend_id":   cfg.BackendID,
 		// IP intentionally omitted — sentinel infers from RemoteAddr.
 	}
 
@@ -66,7 +66,7 @@ func runPrimaryRegistration(ctx context.Context, cfg PrimaryRegisterConfig) {
 	if err := postJSON(ctx, client, registerURL, body); err != nil {
 		log.Printf("[primary-register] initial registration failed: %v (will retry)", err)
 	} else {
-		log.Printf("[primary-register] registered: pool=%q hostname=%q aliases=%v base_domain=%q port=%d", cfg.Pool, cfg.PublicHostname, cfg.PublicAliases, cfg.PublicBaseDomain, cfg.Port)
+		log.Printf("[primary-register] registered: pool=%q hostname=%q aliases=%v base_domains=%v port=%d", cfg.Pool, cfg.PublicHostname, cfg.PublicAliases, cfg.PublicBaseDomains, cfg.Port)
 	}
 
 	go func() {


### PR DESCRIPTION
## Summary
Lets a single primary advertise multiple `--public-base-domain` values so one backend can host workloads under different parent domains. Enables the **lab-hosts-demo** pattern from [`docs/PLAN-DEMO-CONTAINER-MIGRATION.md`](docs/PLAN-DEMO-CONTAINER-MIGRATION.md) without provisioning a new VM in production for the demo pool — the lab backend just registers a second base domain.

Builds directly on #205 (Phase 3 single-domain). Same SNI router precedence (exact → suffix → fallback), same fail-closed semantics, just one dimension wider.

## Behavior
- `--public-base-domain` on both `containarium daemon` and `containarium tunnel` is now repeatable:
  ```
  --public-base-domain lab.example.com --public-base-domain demo.example.org
  ```
- Unset → falls back to `[--base-domain]` (single-element list). Existing single-domain deployments need no config change.
- Suffix matching walks each base domain across each primary; longest suffix wins; ties fail closed regardless of which slot the duplicate lives in.

## Wire-format break
The REST POST `/sentinel/primaries` body field rename: `base_domain` (string) → `base_domains` (array). Phase 3 only merged today and there are no live deployments using it yet, so this is a clean cutover. Flagged in the commit message so it doesn't sneak past.

## Worked example: one backend, two parent domains
```
containarium tunnel \
  --pool lab \
  --public-hostname lab-primary.example.com \
  --public-base-domain lab.example.com \
  --public-base-domain demo.example.org \
  --public-port 443
```

| SNI | Routes to |
|---|---|
| `notebook.lab.example.com` | lab backend (own pool subdomain) |
| `blog.demo.example.org` | lab backend (migrated demo workload) |
| `api.example.com` | fallback (neither base domain matches) |

## Test plan
- [x] 3 new registry tests covering Phase 3b semantics: `MultipleOnOnePrimary`, `MultiDomainLosesToMoreSpecific`, `AmbiguousAcrossMultiDomain`
- [x] 1 new end-to-end SNI router test: `SNIRouting_MultiBaseDomainOnOneBackend`
- [x] 9 existing tests updated for the slice field
- [x] New unit test for `resolvePublicBaseDomains` helper (precedence between `--public-base-domain` and `--base-domain`)
- [x] `go test ./...` green across the repo
- [ ] Manual smoke after merge: lab backend re-registers with two `--public-base-domain` values; `curl --resolve` for a hostname under each base domain lands on the same backend's Caddy logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)