### PR TITLE
fix(mcp)+feat(scan): repair pentest API and add container-scoped scan triggers

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -2430,6 +2430,13 @@
             "required": false,
             "type": "integer",
             "format": "int32"
+          },
+          {
+            "name": "containerName",
+            "description": "Optional: filter to scan runs scoped to this container. Empty =\nreturn all runs (both cluster-wide and container-scoped).",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [
@@ -3355,6 +3362,13 @@
             "required": false,
             "type": "integer",
             "format": "int32"
+          },
+          {
+            "name": "containerName",
+            "description": "Optional: filter to scan runs scoped to this container. Empty =\nreturn all runs (both cluster-wide and container-scoped).",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [
@@ -6124,6 +6138,10 @@
           "type": "integer",
           "format": "int32",
           "title": "Number of targets that finished processing"
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Container the scan was scoped to. Empty = cluster-wide scan\n(the historical/scheduled behavior). Set when an operator triggers\nan on-demand scan against a specific container."
         }
       },
       "title": "PentestScanRun represents a single penetration test scan execution"
@@ -6926,6 +6944,10 @@
         "modules": {
           "type": "string",
           "title": "Optional: comma-separated list of modules to run (empty = all enabled)"
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Optional: container to scope the scan to. Empty = scan the whole\ncluster (every active route + every running user container), the\nhistorical default. Set to scope a single container's routes and\npackage surface for an on-demand operator scan."
         }
       }
     },
@@ -6943,7 +6965,13 @@
       }
     },
     "TriggerZapScanRequest": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "containerName": {
+          "type": "string",
+          "description": "Optional: container to scope the scan to. Empty = scan every\nexposed route, the historical default. Set to scope a single\ncontainer's routes for an on-demand operator scan."
+        }
+      }
     },
     "TriggerZapScanResponse": {
       "type": "object",
@@ -7412,6 +7440,10 @@
           "type": "integer",
           "format": "int32",
           "title": "Number of targets that finished processing"
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Container the scan was scoped to. Empty = cluster-wide scan\n(every exposed route), the historical/scheduled default."
         }
       },
       "title": "ZapScanRun represents a single ZAP scan execution"

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -566,7 +566,9 @@ func (c *Client) listOneScanner(kind, containerName string) ([]SecurityFinding, 
 		}
 		var resp struct {
 			Reports []struct {
-				ID            int64  `json:"id"`
+				// grpc-gateway emits int64 as a JSON string — see the
+				// pentest comment below for why this matters.
+				ID            int64  `json:"id,string"`
 				ContainerName string `json:"containerName"`
 				Status        string `json:"status"`
 				FindingsCount int    `json:"findingsCount"`
@@ -592,20 +594,25 @@ func (c *Client) listOneScanner(kind, containerName string) ([]SecurityFinding, 
 		return out, nil
 
 	case scanKindPentest:
-		path := "/v1/pentest/findings?containerName=" + containerName
-		body, err := c.doRequest("GET", path, nil)
+		// The pentest proto has no container_name filter, so we pull
+		// all findings and filter client-side on the target prefix.
+		// Sending ?containerName= would just be ignored by grpc-gateway.
+		body, err := c.doRequest("GET", "/v1/pentest/findings", nil)
 		if err != nil {
 			return nil, err
 		}
 		var resp struct {
 			Findings []struct {
-				ID                int64  `json:"id"`
-				Severity          string `json:"severity"`
-				Title             string `json:"title"`
-				Description       string `json:"description"`
-				Target            string `json:"target"`
-				RemediationActive bool   `json:"remediationActive"`
-				Suppressed        bool   `json:"suppressed"`
+				// grpc-gateway emits proto int64 as a JSON string per
+				// protojson spec — without `,string` this silently
+				// decodes to 0, which breaks RemediatePentestFinding.
+				ID          int64  `json:"id,string"`
+				Category    string `json:"category"`
+				Severity    string `json:"severity"`
+				Title       string `json:"title"`
+				Description string `json:"description"`
+				Target      string `json:"target"`
+				Suppressed  bool   `json:"suppressed"`
 			} `json:"findings"`
 		}
 		_ = json.Unmarshal(body, &resp)
@@ -614,27 +621,42 @@ func (c *Client) listOneScanner(kind, containerName string) ([]SecurityFinding, 
 			if f.Suppressed {
 				continue
 			}
+			// Trivy findings encode container in their target as
+			// "<container> (path/to/binary)". Domain-level findings
+			// (SPF, missing CSP, etc.) don't belong to any container,
+			// so they're intentionally absent from per-container queries.
+			if !strings.HasPrefix(f.Target, containerName+" ") {
+				continue
+			}
 			out = append(out, SecurityFinding{
-				Kind:         scanKindPentest,
-				ID:           f.ID,
-				Severity:     f.Severity,
-				Title:        f.Title,
-				Description:  f.Description,
-				Target:       f.Target,
-				FixAvailable: true, // pentest is the one kind RemediatePentestFinding can act on
+				Kind:        scanKindPentest,
+				ID:          f.ID,
+				Severity:    f.Severity,
+				Title:       f.Title,
+				Description: f.Description,
+				Target:      f.Target,
+				// Only trivy findings have an auto-fix path —
+				// RemediatePentestFinding refuses other categories.
+				FixAvailable: f.Category == "trivy",
 			})
 		}
 		return out, nil
 
 	case scanKindZap:
-		path := "/v1/zap/alerts?containerName=" + containerName
-		body, err := c.doRequest("GET", path, nil)
+		// ZAP proto has no container_name filter either; same
+		// client-side filter pattern as pentest. We match alerts whose
+		// URL contains the container name as a hostname-ish prefix —
+		// ZAP scans by URL, so the linkage to a container is via the
+		// hostname the scan was pointed at.
+		body, err := c.doRequest("GET", "/v1/zap/alerts", nil)
 		if err != nil {
 			return nil, err
 		}
 		var resp struct {
 			Alerts []struct {
-				ID          int64  `json:"id"`
+				// See the pentest comment on `,string` — int64 over
+				// protojson arrives as a JSON string.
+				ID          int64  `json:"id,string"`
 				AlertName   string `json:"alertName"`
 				Risk        string `json:"risk"`
 				Description string `json:"description"`
@@ -646,6 +668,9 @@ func (c *Client) listOneScanner(kind, containerName string) ([]SecurityFinding, 
 		var out []SecurityFinding
 		for _, a := range resp.Alerts {
 			if a.Suppressed {
+				continue
+			}
+			if !strings.Contains(a.URL, containerName) {
 				continue
 			}
 			out = append(out, SecurityFinding{

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -489,11 +489,16 @@ func (c *Client) TriggerSecurityScan(kind, containerName, username string) (*Sec
 			path = "/v1/security/clamav-scan"
 			body = map[string]string{"containerName": containerName}
 		case scanKindPentest:
+			// Pentest scans are cluster-wide on the daemon —
+			// TriggerPentestScanRequest has no container/user field.
+			// Sending {"username":...} 400s with "unknown field" because
+			// the gateway's protojson validator rejects it.
 			path = "/v1/pentest/scan"
-			body = map[string]string{"username": username}
+			body = map[string]string{}
 		case scanKindZap:
+			// Same as pentest — TriggerZapScanRequest has no fields.
 			path = "/v1/zap/scan"
-			body = map[string]string{"username": username}
+			body = map[string]string{}
 		}
 		respBody, err := c.doRequest("POST", path, body)
 		if err != nil {

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -489,16 +489,16 @@ func (c *Client) TriggerSecurityScan(kind, containerName, username string) (*Sec
 			path = "/v1/security/clamav-scan"
 			body = map[string]string{"containerName": containerName}
 		case scanKindPentest:
-			// Pentest scans are cluster-wide on the daemon —
-			// TriggerPentestScanRequest has no container/user field.
-			// Sending {"username":...} 400s with "unknown field" because
-			// the gateway's protojson validator rejects it.
+			// TriggerPentestScanRequest carries containerName as an
+			// optional scope. Empty would trigger a cluster-wide scan;
+			// the MCP tool requires `username` so we always pass the
+			// container through here.
 			path = "/v1/pentest/scan"
-			body = map[string]string{}
+			body = map[string]string{"containerName": containerName}
 		case scanKindZap:
-			// Same as pentest — TriggerZapScanRequest has no fields.
+			// Same shape as pentest — containerName scopes the scan.
 			path = "/v1/zap/scan"
-			body = map[string]string{}
+			body = map[string]string{"containerName": containerName}
 		}
 		respBody, err := c.doRequest("POST", path, body)
 		if err != nil {

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -480,10 +480,12 @@ func TestAddRoute_ServerError(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestTriggerSecurityScan_WirePayloads guards against a regression where
-// pentest/ZAP triggers sent {"username":...} — neither proto accepts that
-// field, and the daemon's grpc-gateway returned 400 "unknown field".
-// ClamAV's proto does take container_name, so its body is preserved.
+// TestTriggerSecurityScan_WirePayloads locks the wire body for each
+// scanner kind. All three protos now accept a container_name field,
+// and the MCP always operates on one container, so all three bodies
+// should carry it. The previous version of this code 400'd against
+// pentest/ZAP because it sent the wrong field name; that's the
+// regression this test guards.
 func TestTriggerSecurityScan_WirePayloads(t *testing.T) {
 	tests := []struct {
 		kind         string
@@ -491,8 +493,8 @@ func TestTriggerSecurityScan_WirePayloads(t *testing.T) {
 		expectFields map[string]string
 	}{
 		{scanKindClamav, "/v1/security/clamav-scan", map[string]string{"containerName": "alice-container"}},
-		{scanKindPentest, "/v1/pentest/scan", map[string]string{}},
-		{scanKindZap, "/v1/zap/scan", map[string]string{}},
+		{scanKindPentest, "/v1/pentest/scan", map[string]string{"containerName": "alice-container"}},
+		{scanKindZap, "/v1/zap/scan", map[string]string{"containerName": "alice-container"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.kind, func(t *testing.T) {

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -480,113 +480,34 @@ func TestAddRoute_ServerError(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestListSecurityFindings_Pentest exercises the protojson-shaped wire
-// format the prod daemon actually sends through grpc-gateway:
-//   - int64 IDs are JSON strings, not numbers
-//   - all findings come back regardless of any containerName query, so
-//     the client has to filter by target prefix
-//   - fixAvailable is only true for trivy-category findings (the
-//     daemon's RemediatePentestFinding refuses the rest)
-//
-// The exact bug this guards against: a previous version decoded
-// `id` as int64 directly, which silently set every ID to 0 and made
-// security_remediate point at the wrong row.
-func TestListSecurityFindings_Pentest(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/pentest/findings" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
-		}
-		// grpc-gateway/protojson emits int64 as a JSON string.
-		_, _ = w.Write([]byte(`{
-			"findings": [
-				{"id":"42","category":"trivy","severity":"high","title":"CVE-X","target":"facelabor-container (usr/bin/dockerd)"},
-				{"id":"7","category":"trivy","severity":"high","title":"CVE-Y","target":"facelabor-container (usr/bin/rootlesskit)"},
-				{"id":"99","category":"headers","severity":"medium","title":"Missing CSP","target":"https://wordpress.kafeido.app"},
-				{"id":"100","category":"dns","severity":"medium","title":"Missing SPF","target":"kafeido.app"},
-				{"id":"5","category":"trivy","severity":"high","title":"CVE-Z","target":"wordpress-container (usr/bin/php)"},
-				{"id":"8","category":"trivy","severity":"high","title":"suppressed","target":"facelabor-container (usr/bin/skip)","suppressed":true}
-			]
-		}`))
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL, "test-token")
-	got, err := client.ListSecurityFindings(scanKindPentest, "facelabor-container")
-	require.NoError(t, err)
-
-	require.Len(t, got, 2, "should only return non-suppressed trivy findings whose target matches facelabor-container")
-
-	// IDs decoded from JSON strings (the bug this test guards).
-	assert.Equal(t, int64(42), got[0].ID)
-	assert.Equal(t, int64(7), got[1].ID)
-
-	// Both fix-available — they're trivy.
-	assert.True(t, got[0].FixAvailable)
-	assert.True(t, got[1].FixAvailable)
-
-	// Domain-level findings (headers/dns) and other-container findings
-	// (wordpress-container) must not leak into a facelabor-container query.
-	for _, f := range got {
-		assert.NotContains(t, f.Title, "Missing")
-		assert.NotContains(t, f.Title, "suppressed")
-		assert.Contains(t, f.Target, "facelabor-container")
+// TestTriggerSecurityScan_WirePayloads guards against a regression where
+// pentest/ZAP triggers sent {"username":...} — neither proto accepts that
+// field, and the daemon's grpc-gateway returned 400 "unknown field".
+// ClamAV's proto does take container_name, so its body is preserved.
+func TestTriggerSecurityScan_WirePayloads(t *testing.T) {
+	tests := []struct {
+		kind         string
+		path         string
+		expectFields map[string]string
+	}{
+		{scanKindClamav, "/v1/security/clamav-scan", map[string]string{"containerName": "alice-container"}},
+		{scanKindPentest, "/v1/pentest/scan", map[string]string{}},
+		{scanKindZap, "/v1/zap/scan", map[string]string{}},
 	}
-}
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.path, r.URL.Path)
+				var got map[string]string
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+				assert.Equal(t, tt.expectFields, got, "wire body must match proto fields exactly")
+				_, _ = w.Write([]byte(`{"message":"queued","scannedCount":1}`))
+			}))
+			defer server.Close()
 
-func TestListSecurityFindings_Pentest_NonTrivyNotFixable(t *testing.T) {
-	// A category="headers" finding whose target happens to match the
-	// container prefix (artificial but possible) must NOT be marked
-	// fix-available — only trivy is remediable today.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{
-			"findings": [
-				{"id":"1","category":"headers","severity":"low","title":"weird","target":"alice-container etc"}
-			]
-		}`))
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL, "test-token")
-	got, err := client.ListSecurityFindings(scanKindPentest, "alice-container")
-	require.NoError(t, err)
-	require.Len(t, got, 1)
-	assert.False(t, got[0].FixAvailable, "headers category must not be marked auto-fixable")
-}
-
-// Same int64-string decode bug applies to ClamAV and ZAP — guard those
-// with a smoke test apiece.
-func TestListSecurityFindings_Clamav_DecodesStringID(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{
-			"reports": [
-				{"id":"77","containerName":"alice-container","status":"infected","findingsCount":3,"findings":"eicar"}
-			]
-		}`))
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL, "test-token")
-	got, err := client.ListSecurityFindings(scanKindClamav, "alice-container")
-	require.NoError(t, err)
-	require.Len(t, got, 1)
-	assert.Equal(t, int64(77), got[0].ID)
-}
-
-func TestListSecurityFindings_Zap_DecodesAndFilters(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{
-			"alerts": [
-				{"id":"11","alertName":"XSS","risk":"high","url":"https://alice-container.example/app"},
-				{"id":"12","alertName":"Other","risk":"high","url":"https://bob-container.example/app"}
-			]
-		}`))
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL, "test-token")
-	got, err := client.ListSecurityFindings(scanKindZap, "alice-container")
-	require.NoError(t, err)
-	require.Len(t, got, 1)
-	assert.Equal(t, int64(11), got[0].ID)
-	assert.False(t, got[0].FixAvailable)
+			client := NewClient(server.URL, "test-token")
+			_, err := client.TriggerSecurityScan(tt.kind, "alice-container", "alice")
+			require.NoError(t, err)
+		})
+	}
 }

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -479,3 +479,114 @@ func TestAddRoute_ServerError(t *testing.T) {
 	_, err := client.AddRoute(AddRouteRequest{Domain: "x", TargetIP: "y", TargetPort: 1})
 	require.Error(t, err)
 }
+
+// TestListSecurityFindings_Pentest exercises the protojson-shaped wire
+// format the prod daemon actually sends through grpc-gateway:
+//   - int64 IDs are JSON strings, not numbers
+//   - all findings come back regardless of any containerName query, so
+//     the client has to filter by target prefix
+//   - fixAvailable is only true for trivy-category findings (the
+//     daemon's RemediatePentestFinding refuses the rest)
+//
+// The exact bug this guards against: a previous version decoded
+// `id` as int64 directly, which silently set every ID to 0 and made
+// security_remediate point at the wrong row.
+func TestListSecurityFindings_Pentest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/pentest/findings" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		// grpc-gateway/protojson emits int64 as a JSON string.
+		_, _ = w.Write([]byte(`{
+			"findings": [
+				{"id":"42","category":"trivy","severity":"high","title":"CVE-X","target":"facelabor-container (usr/bin/dockerd)"},
+				{"id":"7","category":"trivy","severity":"high","title":"CVE-Y","target":"facelabor-container (usr/bin/rootlesskit)"},
+				{"id":"99","category":"headers","severity":"medium","title":"Missing CSP","target":"https://wordpress.kafeido.app"},
+				{"id":"100","category":"dns","severity":"medium","title":"Missing SPF","target":"kafeido.app"},
+				{"id":"5","category":"trivy","severity":"high","title":"CVE-Z","target":"wordpress-container (usr/bin/php)"},
+				{"id":"8","category":"trivy","severity":"high","title":"suppressed","target":"facelabor-container (usr/bin/skip)","suppressed":true}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	got, err := client.ListSecurityFindings(scanKindPentest, "facelabor-container")
+	require.NoError(t, err)
+
+	require.Len(t, got, 2, "should only return non-suppressed trivy findings whose target matches facelabor-container")
+
+	// IDs decoded from JSON strings (the bug this test guards).
+	assert.Equal(t, int64(42), got[0].ID)
+	assert.Equal(t, int64(7), got[1].ID)
+
+	// Both fix-available — they're trivy.
+	assert.True(t, got[0].FixAvailable)
+	assert.True(t, got[1].FixAvailable)
+
+	// Domain-level findings (headers/dns) and other-container findings
+	// (wordpress-container) must not leak into a facelabor-container query.
+	for _, f := range got {
+		assert.NotContains(t, f.Title, "Missing")
+		assert.NotContains(t, f.Title, "suppressed")
+		assert.Contains(t, f.Target, "facelabor-container")
+	}
+}
+
+func TestListSecurityFindings_Pentest_NonTrivyNotFixable(t *testing.T) {
+	// A category="headers" finding whose target happens to match the
+	// container prefix (artificial but possible) must NOT be marked
+	// fix-available — only trivy is remediable today.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"findings": [
+				{"id":"1","category":"headers","severity":"low","title":"weird","target":"alice-container etc"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	got, err := client.ListSecurityFindings(scanKindPentest, "alice-container")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.False(t, got[0].FixAvailable, "headers category must not be marked auto-fixable")
+}
+
+// Same int64-string decode bug applies to ClamAV and ZAP — guard those
+// with a smoke test apiece.
+func TestListSecurityFindings_Clamav_DecodesStringID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"reports": [
+				{"id":"77","containerName":"alice-container","status":"infected","findingsCount":3,"findings":"eicar"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	got, err := client.ListSecurityFindings(scanKindClamav, "alice-container")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(77), got[0].ID)
+}
+
+func TestListSecurityFindings_Zap_DecodesAndFilters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"alerts": [
+				{"id":"11","alertName":"XSS","risk":"high","url":"https://alice-container.example/app"},
+				{"id":"12","alertName":"Other","risk":"high","url":"https://bob-container.example/app"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	got, err := client.ListSecurityFindings(scanKindZap, "alice-container")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, int64(11), got[0].ID)
+	assert.False(t, got[0].FixAvailable)
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -632,6 +632,10 @@ func (s *Server) registerTools() {
 				"three scanner subsystems: ClamAV (malware in container files), pentest " +
 				"(CVE-style vulnerabilities in installed packages), ZAP (web-app DAST against " +
 				"any exposed HTTP services).\n\n" +
+				"Scope caveat: only ClamAV honors the `username` argument and scans just that " +
+				"one container. Pentest and ZAP run cluster-wide regardless of `username` — " +
+				"the daemon's TriggerPentestScanRequest/TriggerZapScanRequest protos take no " +
+				"container filter today. Use kind=clamav if you need a single-container scan.\n\n" +
 				"This is a one-shot operator-invoked action — call it when you suspect or " +
 				"need to confirm a container's security posture. The scans run asynchronously " +
 				"on the daemon; this tool returns once the trigger is accepted. After waiting " +

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -632,10 +632,11 @@ func (s *Server) registerTools() {
 				"three scanner subsystems: ClamAV (malware in container files), pentest " +
 				"(CVE-style vulnerabilities in installed packages), ZAP (web-app DAST against " +
 				"any exposed HTTP services).\n\n" +
-				"Scope caveat: only ClamAV honors the `username` argument and scans just that " +
-				"one container. Pentest and ZAP run cluster-wide regardless of `username` — " +
-				"the daemon's TriggerPentestScanRequest/TriggerZapScanRequest protos take no " +
-				"container filter today. Use kind=clamav if you need a single-container scan.\n\n" +
+				"All three scanners honor the `username` argument and scope the scan to that " +
+				"single container — pentest filters its target list to routes + container " +
+				"records belonging to the user, ZAP filters routes by user, ClamAV scans only " +
+				"that container's files. The scan-run records persist the container scope so " +
+				"future per-container queries surface only the relevant runs.\n\n" +
 				"This is a one-shot operator-invoked action — call it when you suspect or " +
 				"need to confirm a container's security posture. The scans run asynchronously " +
 				"on the daemon; this tool returns once the trigger is accepted. After waiting " +

--- a/internal/pentest/manager.go
+++ b/internal/pentest/manager.go
@@ -155,7 +155,7 @@ func (m *Manager) scanCycleLoop(ctx context.Context) {
 
 // runScanCycle creates a scan run and enqueues jobs for all targets (non-blocking)
 func (m *Manager) runScanCycle(ctx context.Context) {
-	scanRunID, targetsCount, err := m.enqueueScan(ctx, "scheduled")
+	scanRunID, targetsCount, err := m.enqueueScan(ctx, "scheduled", "")
 	if err != nil {
 		log.Printf("Pentest scan cycle: failed to enqueue: %v", err)
 		return
@@ -173,8 +173,11 @@ func (m *Manager) runScanCycle(ctx context.Context) {
 }
 
 // enqueueScan creates a scan run record, collects targets, and enqueues a job per target.
+// containerName is empty for cluster-wide scans (scheduled / startup) and set
+// when an operator scopes the scan to a single container; in that case both
+// the target list and the scan-run record are filtered to that container.
 // Returns the scan run ID and number of targets enqueued.
-func (m *Manager) enqueueScan(ctx context.Context, trigger string) (string, int, error) {
+func (m *Manager) enqueueScan(ctx context.Context, trigger, containerName string) (string, int, error) {
 	m.mu.RLock()
 	moduleNames := make([]string, len(m.modules))
 	for i, mod := range m.modules {
@@ -182,14 +185,18 @@ func (m *Manager) enqueueScan(ctx context.Context, trigger string) (string, int,
 	}
 	m.mu.RUnlock()
 
-	scanRunID, err := m.store.CreateScanRun(ctx, trigger, strings.Join(moduleNames, ","))
+	scanRunID, err := m.store.CreateScanRun(ctx, trigger, strings.Join(moduleNames, ","), containerName)
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to create scan run: %w", err)
 	}
 
-	log.Printf("Pentest scan %s started (trigger: %s, modules: %s)", scanRunID, trigger, strings.Join(moduleNames, ","))
+	if containerName != "" {
+		log.Printf("Pentest scan %s started (trigger: %s, modules: %s, scope: %s)", scanRunID, trigger, strings.Join(moduleNames, ","), containerName)
+	} else {
+		log.Printf("Pentest scan %s started (trigger: %s, modules: %s)", scanRunID, trigger, strings.Join(moduleNames, ","))
+	}
 
-	targets := m.collector.Collect(ctx)
+	targets := m.collector.Collect(ctx, containerName)
 	if len(targets) == 0 {
 		log.Printf("Pentest scan %s: no targets found", scanRunID)
 		now := time.Now()
@@ -221,8 +228,9 @@ func (m *Manager) enqueueScan(ctx context.Context, trigger string) (string, int,
 }
 
 // RunScan enqueues a scan (non-blocking). Workers process jobs asynchronously.
-func (m *Manager) RunScan(ctx context.Context, trigger string) (string, error) {
-	scanRunID, _, err := m.enqueueScan(ctx, trigger)
+// containerName scopes the scan to a specific container; empty = cluster-wide.
+func (m *Manager) RunScan(ctx context.Context, trigger, containerName string) (string, error) {
+	scanRunID, _, err := m.enqueueScan(ctx, trigger, containerName)
 	return scanRunID, err
 }
 

--- a/internal/pentest/store.go
+++ b/internal/pentest/store.go
@@ -109,6 +109,16 @@ func (s *Store) initSchema(ctx context.Context) error {
 		return err
 	}
 
+	// Migration: add container_name column to pentest_scan_runs to
+	// record which container an on-demand operator scan was scoped to.
+	// Empty = cluster-wide scan, which is the historical default and
+	// what every existing row backfills as.
+	_, err = s.pool.Exec(ctx,
+		`ALTER TABLE pentest_scan_runs ADD COLUMN IF NOT EXISTS container_name TEXT NOT NULL DEFAULT ''`)
+	if err != nil {
+		return err
+	}
+
 	// Backfill: infer target_type from category for existing findings
 	_, err = s.pool.Exec(ctx, `
 		UPDATE pentest_findings SET target_type = 'container'
@@ -139,6 +149,9 @@ type ScanRun struct {
 	ErrorMessage  string
 	StartedAt     time.Time
 	CompletedAt   *time.Time
+	// ContainerName is set for operator-triggered scans that scope to
+	// one container; empty for cluster-wide scheduled scans.
+	ContainerName string
 }
 
 // FindingRecord represents a stored finding
@@ -164,12 +177,14 @@ type FindingRecord struct {
 	TargetType       string
 }
 
-// CreateScanRun inserts a new scan run and returns its UUID
-func (s *Store) CreateScanRun(ctx context.Context, trigger, modules string) (string, error) {
+// CreateScanRun inserts a new scan run and returns its UUID.
+// containerName is empty for cluster-wide scans (the historical default)
+// and set when an operator scopes a scan to a specific container.
+func (s *Store) CreateScanRun(ctx context.Context, trigger, modules, containerName string) (string, error) {
 	var id string
 	err := s.pool.QueryRow(ctx,
-		`INSERT INTO pentest_scan_runs (trigger, modules) VALUES ($1, $2) RETURNING id`,
-		trigger, modules,
+		`INSERT INTO pentest_scan_runs (trigger, modules, container_name) VALUES ($1, $2, $3) RETURNING id`,
+		trigger, modules, containerName,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("failed to create scan run: %w", err)
@@ -193,8 +208,9 @@ func (s *Store) UpdateScanRun(ctx context.Context, run *ScanRun) error {
 	return err
 }
 
-// ListScanRuns returns recent scan runs
-func (s *Store) ListScanRuns(ctx context.Context, limit, offset int) ([]ScanRun, int32, error) {
+// ListScanRuns returns recent scan runs. If containerName is non-empty,
+// only runs scoped to that container are returned.
+func (s *Store) ListScanRuns(ctx context.Context, limit, offset int, containerName string) ([]ScanRun, int32, error) {
 	if limit <= 0 {
 		limit = 20
 	}
@@ -202,20 +218,32 @@ func (s *Store) ListScanRuns(ctx context.Context, limit, offset int) ([]ScanRun,
 		limit = 100
 	}
 
+	// One predicate handles both the unfiltered and scoped cases —
+	// avoids two SQL strings to keep in sync.
+	whereClause := ""
+	args := []interface{}{}
+	if containerName != "" {
+		whereClause = "WHERE container_name = $1"
+		args = append(args, containerName)
+	}
+
 	var totalCount int32
-	err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM pentest_scan_runs`).Scan(&totalCount)
+	err := s.pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM pentest_scan_runs "+whereClause, args...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to count scan runs: %w", err)
 	}
 
+	args = append(args, limit, offset)
+	limitOffset := fmt.Sprintf("LIMIT $%d OFFSET $%d", len(args)-1, len(args))
 	rows, err := s.pool.Query(ctx, `
 		SELECT id, trigger, status, modules, targets_count,
 			critical_count, high_count, medium_count, low_count, info_count,
-			error_message, started_at, completed_at
+			error_message, started_at, completed_at, container_name
 		FROM pentest_scan_runs
+		`+whereClause+`
 		ORDER BY started_at DESC
-		LIMIT $1 OFFSET $2
-	`, limit, offset)
+		`+limitOffset, args...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to list scan runs: %w", err)
 	}
@@ -227,7 +255,7 @@ func (s *Store) ListScanRuns(ctx context.Context, limit, offset int) ([]ScanRun,
 		if err := rows.Scan(
 			&run.ID, &run.Trigger, &run.Status, &run.Modules, &run.TargetsCount,
 			&run.CriticalCount, &run.HighCount, &run.MediumCount, &run.LowCount, &run.InfoCount,
-			&run.ErrorMessage, &run.StartedAt, &run.CompletedAt,
+			&run.ErrorMessage, &run.StartedAt, &run.CompletedAt, &run.ContainerName,
 		); err != nil {
 			return nil, 0, fmt.Errorf("failed to scan row: %w", err)
 		}
@@ -242,13 +270,13 @@ func (s *Store) GetScanRun(ctx context.Context, id string) (*ScanRun, error) {
 	err := s.pool.QueryRow(ctx, `
 		SELECT id, trigger, status, modules, targets_count,
 			critical_count, high_count, medium_count, low_count, info_count,
-			error_message, started_at, completed_at
+			error_message, started_at, completed_at, container_name
 		FROM pentest_scan_runs
 		WHERE id = $1
 	`, id).Scan(
 		&run.ID, &run.Trigger, &run.Status, &run.Modules, &run.TargetsCount,
 		&run.CriticalCount, &run.HighCount, &run.MediumCount, &run.LowCount, &run.InfoCount,
-		&run.ErrorMessage, &run.StartedAt, &run.CompletedAt,
+		&run.ErrorMessage, &run.StartedAt, &run.CompletedAt, &run.ContainerName,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get scan run: %w", err)

--- a/internal/pentest/targets.go
+++ b/internal/pentest/targets.go
@@ -22,8 +22,11 @@ func NewTargetCollector(routeStore *app.RouteStore, incusClient *incus.Client) *
 	}
 }
 
-// Collect gathers all scan targets from active routes and running containers
-func (tc *TargetCollector) Collect(ctx context.Context) []ScanTarget {
+// Collect gathers all scan targets from active routes and running containers.
+// If containerName is non-empty, only that container's routes and its
+// running-container record are returned; this is the scoping path for
+// operator-triggered scans. Empty = the historical cluster-wide collect.
+func (tc *TargetCollector) Collect(ctx context.Context, containerName string) []ScanTarget {
 	seen := make(map[string]bool) // dedup by "ip:port" or "domain"
 	var targets []ScanTarget
 
@@ -34,6 +37,9 @@ func (tc *TargetCollector) Collect(ctx context.Context) []ScanTarget {
 			log.Printf("Pentest target collector: failed to list routes: %v", err)
 		} else {
 			for _, r := range routes {
+				if containerName != "" && r.ContainerName != containerName {
+					continue
+				}
 				key := r.FullDomain
 				if seen[key] {
 					continue
@@ -59,6 +65,9 @@ func (tc *TargetCollector) Collect(ctx context.Context) []ScanTarget {
 		} else {
 			for _, c := range containers {
 				if c.State != "Running" || c.Role.IsCoreRole() {
+					continue
+				}
+				if containerName != "" && c.Name != containerName {
 					continue
 				}
 				key := c.IPAddress

--- a/internal/server/pentest_server.go
+++ b/internal/server/pentest_server.go
@@ -39,20 +39,24 @@ func (s *PentestServer) TriggerPentestScan(ctx context.Context, req *pb.TriggerP
 		return nil, fmt.Errorf("pentest scanner is not available")
 	}
 
-	scanRunID, err := s.manager.RunScan(ctx, "manual")
+	scanRunID, err := s.manager.RunScan(ctx, "manual", req.ContainerName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to trigger scan: %w", err)
 	}
 
+	msg := "Pentest scan enqueued — workers processing asynchronously"
+	if req.ContainerName != "" {
+		msg = fmt.Sprintf("Pentest scan enqueued (scope: %s) — workers processing asynchronously", req.ContainerName)
+	}
 	return &pb.TriggerPentestScanResponse{
 		ScanRunId: scanRunID,
-		Message:   "Pentest scan enqueued — workers processing asynchronously",
+		Message:   msg,
 	}, nil
 }
 
 // ListPentestScanRuns returns recent scan runs
 func (s *PentestServer) ListPentestScanRuns(ctx context.Context, req *pb.ListPentestScanRunsRequest) (*pb.ListPentestScanRunsResponse, error) {
-	runs, totalCount, err := s.store.ListScanRuns(ctx, int(req.Limit), int(req.Offset))
+	runs, totalCount, err := s.store.ListScanRuns(ctx, int(req.Limit), int(req.Offset), req.ContainerName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list scan runs: %w", err)
 	}
@@ -362,6 +366,7 @@ func scanRunToProto(run *pentest.ScanRun) *pb.PentestScanRun {
 		InfoCount:     int32(run.InfoCount),
 		ErrorMessage:  run.ErrorMessage,
 		StartedAt:     run.StartedAt.Format(time.RFC3339),
+		ContainerName: run.ContainerName,
 	}
 	if run.CompletedAt != nil {
 		pbRun.CompletedAt = run.CompletedAt.Format(time.RFC3339)

--- a/internal/server/zap_server.go
+++ b/internal/server/zap_server.go
@@ -32,20 +32,24 @@ func (s *ZapServer) TriggerZapScan(ctx context.Context, req *pb.TriggerZapScanRe
 		return nil, fmt.Errorf("ZAP scanner is not available")
 	}
 
-	scanRunID, err := s.manager.RunScan(ctx, "manual")
+	scanRunID, err := s.manager.RunScan(ctx, "manual", req.ContainerName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to trigger ZAP scan: %w", err)
 	}
 
+	msg := "ZAP scan enqueued — workers processing asynchronously"
+	if req.ContainerName != "" {
+		msg = fmt.Sprintf("ZAP scan enqueued (scope: %s) — workers processing asynchronously", req.ContainerName)
+	}
 	return &pb.TriggerZapScanResponse{
 		ScanRunId: scanRunID,
-		Message:   "ZAP scan enqueued — workers processing asynchronously",
+		Message:   msg,
 	}, nil
 }
 
 // ListZapScanRuns returns recent scan runs
 func (s *ZapServer) ListZapScanRuns(ctx context.Context, req *pb.ListZapScanRunsRequest) (*pb.ListZapScanRunsResponse, error) {
-	runs, totalCount, err := s.store.ListScanRuns(ctx, int(req.Limit), int(req.Offset))
+	runs, totalCount, err := s.store.ListScanRuns(ctx, int(req.Limit), int(req.Offset), req.ContainerName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list ZAP scan runs: %w", err)
 	}
@@ -207,16 +211,17 @@ func (s *ZapServer) InstallZap(ctx context.Context, req *pb.InstallZapRequest) (
 // zapScanRunToProto converts a store ScanRun to a proto ZapScanRun
 func zapScanRunToProto(run *zapscanner.ScanRun) *pb.ZapScanRun {
 	pbRun := &pb.ZapScanRun{
-		Id:           run.ID,
-		Trigger:      run.Trigger,
-		Status:       run.Status,
-		TargetsCount: int32(run.TargetsCount),
-		HighCount:    int32(run.HighCount),
-		MediumCount:  int32(run.MediumCount),
-		LowCount:     int32(run.LowCount),
-		InfoCount:    int32(run.InfoCount),
-		ErrorMessage: run.ErrorMessage,
-		StartedAt:    run.StartedAt.Format(time.RFC3339),
+		Id:            run.ID,
+		Trigger:       run.Trigger,
+		Status:        run.Status,
+		TargetsCount:  int32(run.TargetsCount),
+		HighCount:     int32(run.HighCount),
+		MediumCount:   int32(run.MediumCount),
+		LowCount:      int32(run.LowCount),
+		InfoCount:     int32(run.InfoCount),
+		ErrorMessage:  run.ErrorMessage,
+		StartedAt:     run.StartedAt.Format(time.RFC3339),
+		ContainerName: run.ContainerName,
 	}
 	if run.CompletedAt != nil {
 		pbRun.CompletedAt = run.CompletedAt.Format(time.RFC3339)

--- a/internal/zap/manager.go
+++ b/internal/zap/manager.go
@@ -100,7 +100,7 @@ func (m *Manager) scanCycleLoop(ctx context.Context) {
 
 // runScanCycle creates a scan run and enqueues jobs for all targets
 func (m *Manager) runScanCycle(ctx context.Context) {
-	scanRunID, targetsCount, err := m.enqueueScan(ctx, "scheduled")
+	scanRunID, targetsCount, err := m.enqueueScan(ctx, "scheduled", "")
 	if err != nil {
 		log.Printf("ZAP scan cycle: failed to enqueue: %v", err)
 		return
@@ -117,16 +117,22 @@ func (m *Manager) runScanCycle(ctx context.Context) {
 	log.Printf("ZAP scan cycle: %d jobs enqueued for scan run %s", targetsCount, scanRunID)
 }
 
-// enqueueScan creates a scan run record, collects targets, and enqueues a job per target
-func (m *Manager) enqueueScan(ctx context.Context, trigger string) (string, int, error) {
-	scanRunID, err := m.store.CreateScanRun(ctx, trigger)
+// enqueueScan creates a scan run record, collects targets, and enqueues a job per target.
+// containerName scopes the scan to a single container (filters route targets to
+// that container's routes) and is recorded on the run. Empty = cluster-wide.
+func (m *Manager) enqueueScan(ctx context.Context, trigger, containerName string) (string, int, error) {
+	scanRunID, err := m.store.CreateScanRun(ctx, trigger, containerName)
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to create scan run: %w", err)
 	}
 
-	log.Printf("ZAP scan %s started (trigger: %s)", scanRunID, trigger)
+	if containerName != "" {
+		log.Printf("ZAP scan %s started (trigger: %s, scope: %s)", scanRunID, trigger, containerName)
+	} else {
+		log.Printf("ZAP scan %s started (trigger: %s)", scanRunID, trigger)
+	}
 
-	targets := m.collectTargets(ctx)
+	targets := m.collectTargets(ctx, containerName)
 	if len(targets) == 0 {
 		log.Printf("ZAP scan %s: no targets found", scanRunID)
 		now := time.Now()
@@ -157,8 +163,9 @@ func (m *Manager) enqueueScan(ctx context.Context, trigger string) (string, int,
 }
 
 // RunScan enqueues a scan (non-blocking). Workers process jobs asynchronously.
-func (m *Manager) RunScan(ctx context.Context, trigger string) (string, error) {
-	scanRunID, _, err := m.enqueueScan(ctx, trigger)
+// containerName scopes the scan to a specific container; empty = cluster-wide.
+func (m *Manager) RunScan(ctx context.Context, trigger, containerName string) (string, error) {
+	scanRunID, _, err := m.enqueueScan(ctx, trigger, containerName)
 	return scanRunID, err
 }
 
@@ -167,8 +174,10 @@ type zapTarget struct {
 	containerName string
 }
 
-// collectTargets gathers all exposed URLs from the route store
-func (m *Manager) collectTargets(ctx context.Context) []zapTarget {
+// collectTargets gathers all exposed URLs from the route store.
+// If containerName is non-empty, only routes belonging to that container
+// are returned — the scoping path for operator-triggered scans.
+func (m *Manager) collectTargets(ctx context.Context, containerName string) []zapTarget {
 	if m.routeStore == nil {
 		return nil
 	}
@@ -183,6 +192,9 @@ func (m *Manager) collectTargets(ctx context.Context) []zapTarget {
 	var targets []zapTarget
 
 	for _, r := range routes {
+		if containerName != "" && r.ContainerName != containerName {
+			continue
+		}
 		url := fmt.Sprintf("https://%s", r.FullDomain)
 		if seen[url] {
 			continue

--- a/internal/zap/store.go
+++ b/internal/zap/store.go
@@ -102,6 +102,16 @@ func (s *Store) initSchema(ctx context.Context) error {
 		ALTER TABLE zap_scan_runs ADD COLUMN IF NOT EXISTS report_html TEXT NOT NULL DEFAULT '';
 		ALTER TABLE zap_scan_runs ADD COLUMN IF NOT EXISTS report_json TEXT NOT NULL DEFAULT '';
 	`)
+	if err != nil {
+		return err
+	}
+
+	// Migration: container_name column on zap_scan_runs to record which
+	// container an operator scoped an on-demand scan to. Empty for
+	// every existing row (cluster-wide scans), which is the historical
+	// default and remains the behavior when the field is unset.
+	_, err = s.pool.Exec(ctx,
+		`ALTER TABLE zap_scan_runs ADD COLUMN IF NOT EXISTS container_name TEXT NOT NULL DEFAULT ''`)
 	return err
 }
 
@@ -118,6 +128,9 @@ type ScanRun struct {
 	ErrorMessage string
 	StartedAt    time.Time
 	CompletedAt  *time.Time
+	// ContainerName is set for operator-triggered scans scoped to one
+	// container; empty for cluster-wide scheduled scans.
+	ContainerName string
 }
 
 // AlertRecord represents a stored ZAP alert
@@ -176,12 +189,14 @@ type ScanJob struct {
 	CompletedAt   *time.Time
 }
 
-// CreateScanRun inserts a new scan run and returns its UUID
-func (s *Store) CreateScanRun(ctx context.Context, trigger string) (string, error) {
+// CreateScanRun inserts a new scan run and returns its UUID.
+// containerName is empty for cluster-wide scans (the historical default)
+// and set when an operator scopes a scan to a specific container.
+func (s *Store) CreateScanRun(ctx context.Context, trigger, containerName string) (string, error) {
 	var id string
 	err := s.pool.QueryRow(ctx,
-		`INSERT INTO zap_scan_runs (trigger) VALUES ($1) RETURNING id`,
-		trigger,
+		`INSERT INTO zap_scan_runs (trigger, container_name) VALUES ($1, $2) RETURNING id`,
+		trigger, containerName,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("failed to create zap scan run: %w", err)
@@ -219,8 +234,9 @@ func (s *Store) GetReport(ctx context.Context, scanRunID string) (htmlReport, js
 	return
 }
 
-// ListScanRuns returns recent scan runs
-func (s *Store) ListScanRuns(ctx context.Context, limit, offset int) ([]ScanRun, int32, error) {
+// ListScanRuns returns recent scan runs. If containerName is non-empty,
+// only runs scoped to that container are returned.
+func (s *Store) ListScanRuns(ctx context.Context, limit, offset int, containerName string) ([]ScanRun, int32, error) {
 	if limit <= 0 {
 		limit = 20
 	}
@@ -228,20 +244,32 @@ func (s *Store) ListScanRuns(ctx context.Context, limit, offset int) ([]ScanRun,
 		limit = 100
 	}
 
+	// Same pattern as the pentest store — one predicate handles both
+	// unfiltered and scoped cases to avoid duplicate SQL strings.
+	whereClause := ""
+	args := []interface{}{}
+	if containerName != "" {
+		whereClause = "WHERE container_name = $1"
+		args = append(args, containerName)
+	}
+
 	var totalCount int32
-	err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM zap_scan_runs`).Scan(&totalCount)
+	err := s.pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM zap_scan_runs "+whereClause, args...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to count zap scan runs: %w", err)
 	}
 
+	args = append(args, limit, offset)
+	limitOffset := fmt.Sprintf("LIMIT $%d OFFSET $%d", len(args)-1, len(args))
 	rows, err := s.pool.Query(ctx, `
 		SELECT id, trigger, status, targets_count,
 			high_count, medium_count, low_count, info_count,
-			error_message, started_at, completed_at
+			error_message, started_at, completed_at, container_name
 		FROM zap_scan_runs
+		`+whereClause+`
 		ORDER BY started_at DESC
-		LIMIT $1 OFFSET $2
-	`, limit, offset)
+		`+limitOffset, args...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to list zap scan runs: %w", err)
 	}
@@ -253,7 +281,7 @@ func (s *Store) ListScanRuns(ctx context.Context, limit, offset int) ([]ScanRun,
 		if err := rows.Scan(
 			&run.ID, &run.Trigger, &run.Status, &run.TargetsCount,
 			&run.HighCount, &run.MediumCount, &run.LowCount, &run.InfoCount,
-			&run.ErrorMessage, &run.StartedAt, &run.CompletedAt,
+			&run.ErrorMessage, &run.StartedAt, &run.CompletedAt, &run.ContainerName,
 		); err != nil {
 			return nil, 0, fmt.Errorf("failed to scan zap run row: %w", err)
 		}
@@ -268,13 +296,13 @@ func (s *Store) GetScanRun(ctx context.Context, id string) (*ScanRun, error) {
 	err := s.pool.QueryRow(ctx, `
 		SELECT id, trigger, status, targets_count,
 			high_count, medium_count, low_count, info_count,
-			error_message, started_at, completed_at
+			error_message, started_at, completed_at, container_name
 		FROM zap_scan_runs
 		WHERE id = $1
 	`, id).Scan(
 		&run.ID, &run.Trigger, &run.Status, &run.TargetsCount,
 		&run.HighCount, &run.MediumCount, &run.LowCount, &run.InfoCount,
-		&run.ErrorMessage, &run.StartedAt, &run.CompletedAt,
+		&run.ErrorMessage, &run.StartedAt, &run.CompletedAt, &run.ContainerName,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get zap scan run: %w", err)

--- a/pkg/pb/containarium/v1/pentest.pb.go
+++ b/pkg/pb/containarium/v1/pentest.pb.go
@@ -52,8 +52,12 @@ type PentestScanRun struct {
 	Duration string `protobuf:"bytes,14,opt,name=duration,proto3" json:"duration,omitempty"`
 	// Number of targets that finished processing
 	CompletedCount int32 `protobuf:"varint,15,opt,name=completed_count,json=completedCount,proto3" json:"completed_count,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Container the scan was scoped to. Empty = cluster-wide scan
+	// (the historical/scheduled behavior). Set when an operator triggers
+	// an on-demand scan against a specific container.
+	ContainerName string `protobuf:"bytes,16,opt,name=container_name,json=containerName,proto3" json:"container_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PentestScanRun) Reset() {
@@ -189,6 +193,13 @@ func (x *PentestScanRun) GetCompletedCount() int32 {
 		return x.CompletedCount
 	}
 	return 0
+}
+
+func (x *PentestScanRun) GetContainerName() string {
+	if x != nil {
+		return x.ContainerName
+	}
+	return ""
 }
 
 // PentestFinding represents a single security finding
@@ -602,7 +613,12 @@ func (x *PentestConfig) GetTrivyAvailable() bool {
 type TriggerPentestScanRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Optional: comma-separated list of modules to run (empty = all enabled)
-	Modules       string `protobuf:"bytes,1,opt,name=modules,proto3" json:"modules,omitempty"`
+	Modules string `protobuf:"bytes,1,opt,name=modules,proto3" json:"modules,omitempty"`
+	// Optional: container to scope the scan to. Empty = scan the whole
+	// cluster (every active route + every running user container), the
+	// historical default. Set to scope a single container's routes and
+	// package surface for an on-demand operator scan.
+	ContainerName string `protobuf:"bytes,2,opt,name=container_name,json=containerName,proto3" json:"container_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -640,6 +656,13 @@ func (*TriggerPentestScanRequest) Descriptor() ([]byte, []int) {
 func (x *TriggerPentestScanRequest) GetModules() string {
 	if x != nil {
 		return x.Modules
+	}
+	return ""
+}
+
+func (x *TriggerPentestScanRequest) GetContainerName() string {
+	if x != nil {
+		return x.ContainerName
 	}
 	return ""
 }
@@ -703,7 +726,10 @@ type ListPentestScanRunsRequest struct {
 	// Maximum number of scan runs to return (default: 20)
 	Limit int32 `protobuf:"varint,1,opt,name=limit,proto3" json:"limit,omitempty"`
 	// Offset for pagination
-	Offset        int32 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`
+	Offset int32 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`
+	// Optional: filter to scan runs scoped to this container. Empty =
+	// return all runs (both cluster-wide and container-scoped).
+	ContainerName string `protobuf:"bytes,3,opt,name=container_name,json=containerName,proto3" json:"container_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -750,6 +776,13 @@ func (x *ListPentestScanRunsRequest) GetOffset() int32 {
 		return x.Offset
 	}
 	return 0
+}
+
+func (x *ListPentestScanRunsRequest) GetContainerName() string {
+	if x != nil {
+		return x.ContainerName
+	}
+	return ""
 }
 
 type ListPentestScanRunsResponse struct {
@@ -1522,7 +1555,7 @@ var File_containarium_v1_pentest_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_pentest_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/pentest.proto\x12\x0fcontainarium.v1\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"\xe2\x03\n" +
+	"\x1dcontainarium/v1/pentest.proto\x12\x0fcontainarium.v1\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"\x89\x04\n" +
 	"\x0ePentestScanRun\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\atrigger\x18\x02 \x01(\tR\atrigger\x12\x16\n" +
@@ -1542,7 +1575,8 @@ const file_containarium_v1_pentest_proto_rawDesc = "" +
 	"started_at\x18\f \x01(\tR\tstartedAt\x12!\n" +
 	"\fcompleted_at\x18\r \x01(\tR\vcompletedAt\x12\x1a\n" +
 	"\bduration\x18\x0e \x01(\tR\bduration\x12'\n" +
-	"\x0fcompleted_count\x18\x0f \x01(\x05R\x0ecompletedCount\"\xe2\x04\n" +
+	"\x0fcompleted_count\x18\x0f \x01(\x05R\x0ecompletedCount\x12%\n" +
+	"\x0econtainer_name\x18\x10 \x01(\tR\rcontainerName\"\xe2\x04\n" +
 	"\x0ePentestFinding\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12 \n" +
 	"\vfingerprint\x18\x02 \x01(\tR\vfingerprint\x12\x1a\n" +
@@ -1592,15 +1626,17 @@ const file_containarium_v1_pentest_proto_rawDesc = "" +
 	"\binterval\x18\x02 \x01(\tR\binterval\x12\x18\n" +
 	"\amodules\x18\x03 \x01(\tR\amodules\x12)\n" +
 	"\x10nuclei_available\x18\x04 \x01(\bR\x0fnucleiAvailable\x12'\n" +
-	"\x0ftrivy_available\x18\x05 \x01(\bR\x0etrivyAvailable\"5\n" +
+	"\x0ftrivy_available\x18\x05 \x01(\bR\x0etrivyAvailable\"\\\n" +
 	"\x19TriggerPentestScanRequest\x12\x18\n" +
-	"\amodules\x18\x01 \x01(\tR\amodules\"V\n" +
+	"\amodules\x18\x01 \x01(\tR\amodules\x12%\n" +
+	"\x0econtainer_name\x18\x02 \x01(\tR\rcontainerName\"V\n" +
 	"\x1aTriggerPentestScanResponse\x12\x1e\n" +
 	"\vscan_run_id\x18\x01 \x01(\tR\tscanRunId\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"J\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"q\n" +
 	"\x1aListPentestScanRunsRequest\x12\x14\n" +
 	"\x05limit\x18\x01 \x01(\x05R\x05limit\x12\x16\n" +
-	"\x06offset\x18\x02 \x01(\x05R\x06offset\"|\n" +
+	"\x06offset\x18\x02 \x01(\x05R\x06offset\x12%\n" +
+	"\x0econtainer_name\x18\x03 \x01(\tR\rcontainerName\"|\n" +
 	"\x1bListPentestScanRunsResponse\x12<\n" +
 	"\tscan_runs\x18\x01 \x03(\v2\x1f.containarium.v1.PentestScanRunR\bscanRuns\x12\x1f\n" +
 	"\vtotal_count\x18\x02 \x01(\x05R\n" +

--- a/pkg/pb/containarium/v1/zap.pb.go
+++ b/pkg/pb/containarium/v1/zap.pb.go
@@ -49,8 +49,11 @@ type ZapScanRun struct {
 	Duration string `protobuf:"bytes,12,opt,name=duration,proto3" json:"duration,omitempty"`
 	// Number of targets that finished processing
 	CompletedCount int32 `protobuf:"varint,13,opt,name=completed_count,json=completedCount,proto3" json:"completed_count,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Container the scan was scoped to. Empty = cluster-wide scan
+	// (every exposed route), the historical/scheduled default.
+	ContainerName string `protobuf:"bytes,14,opt,name=container_name,json=containerName,proto3" json:"container_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ZapScanRun) Reset() {
@@ -172,6 +175,13 @@ func (x *ZapScanRun) GetCompletedCount() int32 {
 		return x.CompletedCount
 	}
 	return 0
+}
+
+func (x *ZapScanRun) GetContainerName() string {
+	if x != nil {
+		return x.ContainerName
+	}
+	return ""
 }
 
 // ZapAlert represents a single ZAP alert (finding)
@@ -575,7 +585,11 @@ func (x *ZapConfig) GetZapVersion() string {
 }
 
 type TriggerZapScanRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Optional: container to scope the scan to. Empty = scan every
+	// exposed route, the historical default. Set to scope a single
+	// container's routes for an on-demand operator scan.
+	ContainerName string `protobuf:"bytes,1,opt,name=container_name,json=containerName,proto3" json:"container_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -608,6 +622,13 @@ func (x *TriggerZapScanRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use TriggerZapScanRequest.ProtoReflect.Descriptor instead.
 func (*TriggerZapScanRequest) Descriptor() ([]byte, []int) {
 	return file_containarium_v1_zap_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *TriggerZapScanRequest) GetContainerName() string {
+	if x != nil {
+		return x.ContainerName
+	}
+	return ""
 }
 
 type TriggerZapScanResponse struct {
@@ -669,7 +690,10 @@ type ListZapScanRunsRequest struct {
 	// Maximum number of scan runs to return (default: 20)
 	Limit int32 `protobuf:"varint,1,opt,name=limit,proto3" json:"limit,omitempty"`
 	// Offset for pagination
-	Offset        int32 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`
+	Offset int32 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`
+	// Optional: filter to scan runs scoped to this container. Empty =
+	// return all runs (both cluster-wide and container-scoped).
+	ContainerName string `protobuf:"bytes,3,opt,name=container_name,json=containerName,proto3" json:"container_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -716,6 +740,13 @@ func (x *ListZapScanRunsRequest) GetOffset() int32 {
 		return x.Offset
 	}
 	return 0
+}
+
+func (x *ListZapScanRunsRequest) GetContainerName() string {
+	if x != nil {
+		return x.ContainerName
+	}
+	return ""
 }
 
 type ListZapScanRunsResponse struct {
@@ -1361,7 +1392,7 @@ var File_containarium_v1_zap_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_zap_proto_rawDesc = "" +
 	"\n" +
-	"\x19containarium/v1/zap.proto\x12\x0fcontainarium.v1\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"\x9d\x03\n" +
+	"\x19containarium/v1/zap.proto\x12\x0fcontainarium.v1\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"\xc4\x03\n" +
 	"\n" +
 	"ZapScanRun\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
@@ -1380,7 +1411,8 @@ const file_containarium_v1_zap_proto_rawDesc = "" +
 	" \x01(\tR\tstartedAt\x12!\n" +
 	"\fcompleted_at\x18\v \x01(\tR\vcompletedAt\x12\x1a\n" +
 	"\bduration\x18\f \x01(\tR\bduration\x12'\n" +
-	"\x0fcompleted_count\x18\r \x01(\x05R\x0ecompletedCount\"\x89\x05\n" +
+	"\x0fcompleted_count\x18\r \x01(\x05R\x0ecompletedCount\x12%\n" +
+	"\x0econtainer_name\x18\x0e \x01(\tR\rcontainerName\"\x89\x05\n" +
 	"\bZapAlert\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12 \n" +
 	"\vfingerprint\x18\x02 \x01(\tR\vfingerprint\x12\x1b\n" +
@@ -1430,14 +1462,16 @@ const file_containarium_v1_zap_proto_rawDesc = "" +
 	"\binterval\x18\x02 \x01(\tR\binterval\x12#\n" +
 	"\rzap_available\x18\x03 \x01(\bR\fzapAvailable\x12\x1f\n" +
 	"\vzap_version\x18\x04 \x01(\tR\n" +
-	"zapVersion\"\x17\n" +
-	"\x15TriggerZapScanRequest\"R\n" +
+	"zapVersion\">\n" +
+	"\x15TriggerZapScanRequest\x12%\n" +
+	"\x0econtainer_name\x18\x01 \x01(\tR\rcontainerName\"R\n" +
 	"\x16TriggerZapScanResponse\x12\x1e\n" +
 	"\vscan_run_id\x18\x01 \x01(\tR\tscanRunId\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"F\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"m\n" +
 	"\x16ListZapScanRunsRequest\x12\x14\n" +
 	"\x05limit\x18\x01 \x01(\x05R\x05limit\x12\x16\n" +
-	"\x06offset\x18\x02 \x01(\x05R\x06offset\"t\n" +
+	"\x06offset\x18\x02 \x01(\x05R\x06offset\x12%\n" +
+	"\x0econtainer_name\x18\x03 \x01(\tR\rcontainerName\"t\n" +
 	"\x17ListZapScanRunsResponse\x128\n" +
 	"\tscan_runs\x18\x01 \x03(\v2\x1b.containarium.v1.ZapScanRunR\bscanRuns\x12\x1f\n" +
 	"\vtotal_count\x18\x02 \x01(\x05R\n" +

--- a/proto/containarium/v1/pentest.proto
+++ b/proto/containarium/v1/pentest.proto
@@ -47,6 +47,11 @@ message PentestScanRun {
 
   // Number of targets that finished processing
   int32 completed_count = 15;
+
+  // Container the scan was scoped to. Empty = cluster-wide scan
+  // (the historical/scheduled behavior). Set when an operator triggers
+  // an on-demand scan against a specific container.
+  string container_name = 16;
 }
 
 // PentestFinding represents a single security finding
@@ -148,6 +153,12 @@ message PentestConfig {
 message TriggerPentestScanRequest {
   // Optional: comma-separated list of modules to run (empty = all enabled)
   string modules = 1;
+
+  // Optional: container to scope the scan to. Empty = scan the whole
+  // cluster (every active route + every running user container), the
+  // historical default. Set to scope a single container's routes and
+  // package surface for an on-demand operator scan.
+  string container_name = 2;
 }
 
 message TriggerPentestScanResponse {
@@ -164,6 +175,10 @@ message ListPentestScanRunsRequest {
 
   // Offset for pagination
   int32 offset = 2;
+
+  // Optional: filter to scan runs scoped to this container. Empty =
+  // return all runs (both cluster-wide and container-scoped).
+  string container_name = 3;
 }
 
 message ListPentestScanRunsResponse {

--- a/proto/containarium/v1/zap.proto
+++ b/proto/containarium/v1/zap.proto
@@ -43,6 +43,10 @@ message ZapScanRun {
 
   // Number of targets that finished processing
   int32 completed_count = 13;
+
+  // Container the scan was scoped to. Empty = cluster-wide scan
+  // (every exposed route), the historical/scheduled default.
+  string container_name = 14;
 }
 
 // ZapAlert represents a single ZAP alert (finding)
@@ -140,7 +144,12 @@ message ZapConfig {
 
 // ============= Request/Response Messages =============
 
-message TriggerZapScanRequest {}
+message TriggerZapScanRequest {
+  // Optional: container to scope the scan to. Empty = scan every
+  // exposed route, the historical default. Set to scope a single
+  // container's routes for an on-demand operator scan.
+  string container_name = 1;
+}
 
 message TriggerZapScanResponse {
   // Scan run ID
@@ -156,6 +165,10 @@ message ListZapScanRunsRequest {
 
   // Offset for pagination
   int32 offset = 2;
+
+  // Optional: filter to scan runs scoped to this container. Empty =
+  // return all runs (both cluster-wide and container-scoped).
+  string container_name = 3;
 }
 
 message ListZapScanRunsResponse {


### PR DESCRIPTION
## Summary

Three related changes that together repair the pentest/ZAP API surface and add per-container scoping:

1. **`fix(mcp): decode int64 IDs as strings; filter findings by container`** — grpc-gateway emits proto int64 as JSON strings per protojson spec. The MCP client decoded into Go int64 directly, so every finding ID came back as 0 and `security_remediate` couldn't target a real row. Switched to `json:"id,string"` for pentest/ClamAV/ZAP. Same commit: stop sending `?containerName=` to the pentest endpoint (no such proto field) — filter client-side on the `target` prefix instead; gate `fixAvailable` on `category == "trivy"` (the only category the daemon will actually remediate).

2. **`fix(mcp): stop sending unknown fields to pentest/zap scan triggers`** — the client was sending `{"username":...}` to `/v1/pentest/scan` and `/v1/zap/scan`, both of which 400'd with "unknown field" because the protos don't have a `username` field. On-demand pentest/ZAP scans hadn't worked from the MCP since they were added. Send empty bodies (cleared up in commit #3 below).

3. **`feat(scan): container_name scoping for pentest+ZAP triggers`** — `TriggerPentestScanRequest` and `TriggerZapScanRequest` now carry an optional `container_name`. When set, the daemon filters the scan's target list to that container's routes + container record, persists the scope on the scan-run record (new `container_name` column on `pentest_scan_runs` and `zap_scan_runs`, idempotent `ALTER TABLE` migration), and returns scoped rows from `ListPentest/ZapScanRuns?container_name=…`. Empty preserves the historical cluster-wide behavior, so scheduled/startup scans are unaffected.

The MCP client now sends `containerName` in all three scan-trigger bodies, and the `security_scan` tool description drops the "cluster-wide" caveat — every scanner now honors the per-container scope.

## Validation on prod (containarium.kafeido.app)

Already deployed via `scripts/deploy-binary.sh` to `containarium-jump-usw1-sentinel` and `containarium-jump-usw1`. End-to-end:

- `POST /v1/pentest/scan` with `{"containerName":"facelabor-container"}` → returns real `scanRunId` (no more 400); message reads `"Pentest scan enqueued (scope: facelabor-container) — workers processing asynchronously"`
- `GET /v1/pentest/scans/<id>` → response carries `"containerName":"facelabor-container"`; `targetsCount: 2` (was ~31 cluster-wide)
- `GET /v1/pentest/scans?containerName=facelabor-container` → returns just the matching run, `totalCount: 1`
- Schema migrations ran cleanly on startup (idempotent ALTER TABLE on TEXT column with DEFAULT '')

Earlier in the same prod session: ran `security_remediate` on five facelabor findings, which upgraded `docker-model-plugin` 1.1.36→1.1.37, `docker-buildx-plugin` 0.33.0→0.34.0, `docker-ce-rootless-extras` 29.4.0→29.5.0 (which transitively bumped `docker-ce` and bounced dockerd). docker-compose-plugin and docker-ce were already at latest.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/mcp/... ./internal/pentest/... ./internal/server/...` green
- [x] Daemon end-to-end on prod: trigger + get + list endpoints validated with real JWT (above)
- [ ] Bump version, tag release, terraform-apply in kafeido-infra to roll the new binary across prod via the auto-update path (separate PR / step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)