### PR TITLE
chore: bump version to v0.18.0

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.17.0"
+	Version = "0.18.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary

- Bumps `pkg/version/version.go` from 0.17.0 → 0.18.0.

This release carries PR #215: pentest+ZAP API repair (int64 decode, container-finding filter, dropped invalid `username` field on scan triggers) and the new `container_name` scan-trigger scoping (with idempotent schema migrations on `pentest_scan_runs` / `zap_scan_runs`).

Minor bump (not patch) because the API gained a new field on TriggerPentestScanRequest / TriggerZapScanRequest / ListPentest/ZapScanRunsRequest. Backwards-compatible: empty `container_name` preserves the historical cluster-wide behavior.

## Test plan
- [x] One-line change, content-verified against `git log` convention (e.g. `c8aaf9e chore: bump version to v0.17.0`)
- [ ] After merge: tag `v0.18.0`, push, CI builds release binary
- [ ] terraform-apply in kafeido-infra: bump `containarium_version` → prod peers auto-update via sentinel within ~5min

🤖 Generated with [Claude Code](https://claude.com/claude-code)