### PR TITLE
fix(deploy): stop sentinel service before replacing its binary

### DIFF
--- a/scripts/deploy-binary.sh
+++ b/scripts/deploy-binary.sh
@@ -50,9 +50,12 @@ echo "==> Binary: $BINARY ($BINARY_SIZE)"
 echo "==> Uploading to sentinel..."
 gcloud compute scp "$BINARY" "$SENTINEL_VM:/tmp/containarium" \
     --zone="$ZONE" --project="$PROJECT" --tunnel-through-iap --scp-flag="-P 2222"
+# Sentinel daemon holds /usr/local/bin/containarium open, so a plain `cp`
+# fails with "Text file busy". Stop the service before copying, mirroring
+# the primary-VM pattern below.
 gcloud compute ssh "$SENTINEL_VM" --zone="$ZONE" --project="$PROJECT" \
     --tunnel-through-iap --ssh-flag="-p 2222" \
-    --command="sudo cp /tmp/containarium /usr/local/bin/containarium && sudo chmod +x /usr/local/bin/containarium && sudo systemctl restart containarium-sentinel"
+    --command="sudo systemctl stop containarium-sentinel && sleep 1 && sudo cp /tmp/containarium /usr/local/bin/containarium && sudo chmod +x /usr/local/bin/containarium && sudo systemctl start containarium-sentinel"
 echo "  Sentinel updated and restarted"
 
 # 3. Deploy on primary


### PR DESCRIPTION
## Summary

The sentinel step in `scripts/deploy-binary.sh` used `cp && systemctl restart` — Linux refuses to overwrite an executable while it's running, so `cp` fails with "Text file busy" and the new binary never lands.

Fix: mirror the primary-VM pattern (`stop && sleep 1 && cp && start`) — the restart was already going to bounce the daemon, so total downtime is unchanged.

## Repro

Hit during the v0.18.0 deploy:

```
==> Uploading to sentinel...
cp: cannot create regular file '/usr/local/bin/containarium': Text file busy
```

Worked around by running the stop/cp/start sequence manually after the script failed.

## Test plan
- [x] `bash -n scripts/deploy-binary.sh` syntax-clean
- [ ] Next deploy of `containarium-jump-usw1-sentinel` exercises the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)