### PR TITLE
feat(scale-down): Phase 1 — per-container auto-sleep opt-in toggle

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -1243,6 +1243,47 @@
         ]
       }
     },
+    "/v1/containers/{username}/auto-sleep": {
+      "post": {
+        "summary": "Enable or disable auto-sleep on a container",
+        "description": "Writes the per-container auto-sleep opt-in metadata (Incus user.* keys). Does not itself stop the container — use stop_container for that. Phase 2 (the actual idle-tick) and Phase 3 (wake-on-HTTP) consume this flag.",
+        "operationId": "ContainerService_ToggleAutoSleep",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ToggleAutoSleepResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "description": "Username of the container.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ToggleAutoSleepBody"
+            }
+          }
+        ],
+        "tags": [
+          "Container Operations"
+        ]
+      }
+    },
     "/v1/containers/{username}/cleanup-disk": {
       "post": {
         "summary": "Clean up container disk space",
@@ -4325,6 +4366,15 @@
         "pool": {
           "type": "string",
           "description": "Pool tag of the backend hosting this container (e.g., \"prod\",\n\"demo\", \"lab\"). Mirrors the peer's --pool registration tag and\nis the discriminator used for placement and per-pool routing\n(such as base-domain selection). Empty for untagged backends."
+        },
+        "autoSleepEnabled": {
+          "type": "boolean",
+          "description": "Whether the container is opted into manual auto-sleep tracking\n(Phase 1 of the serverless feature). Read-only; toggled via\nToggleAutoSleep. Backed by the user.containarium.auto_sleep_enabled\nIncus config key."
+        },
+        "idleThresholdMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Idle minutes before the Phase 2 auto-sleep daemon would stop\nthe container. Defaults to 15 when unset. Backed by the\nuser.containarium.idle_threshold_minutes Incus config key."
         }
       },
       "title": "Container represents a complete container instance"
@@ -6578,6 +6628,17 @@
     },
     "StartContainerBody": {
       "type": "object",
+      "properties": {
+        "waitForReady": {
+          "type": "boolean",
+          "description": "When true, the server blocks until the container's primary TCP\nport (from its route record) is accepting connections, or\nready_timeout_seconds elapses. If the container has no route the\nprobe is skipped. Used by `containarium wake` to give callers an\n\"actually serving\" signal rather than just \"incus says started\"."
+        },
+        "readyTimeoutSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Timeout for the readiness probe in seconds. Zero falls back to\nthe server-side default (30s). Ignored when wait_for_ready is\nfalse."
+        }
+      },
       "title": "StartContainerRequest is the request to start a container"
     },
     "StartContainerResponse": {
@@ -6590,6 +6651,10 @@
         "container": {
           "$ref": "#/definitions/Container",
           "title": "Updated container state"
+        },
+        "readyTimedOut": {
+          "type": "boolean",
+          "description": "True when wait_for_ready was set but the readiness probe timed\nout before the primary port accepted. The container is started\neither way — the caller can retry the probe or accept the start\nas best-effort."
         }
       },
       "title": "StartContainerResponse is the response from starting a container"
@@ -6813,6 +6878,40 @@
         }
       },
       "title": "TestWebhookResponse returns the result of the test"
+    },
+    "ToggleAutoSleepBody": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Desired state. true → write user.containarium.auto_sleep_enabled\n= \"true\". false → write \"false\" (the threshold key is left in\nplace so a re-enable picks up the prior value)."
+        },
+        "idleThresholdMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Idle minutes before Phase 2 would stop the container. Ignored\nwhen enabled=false; 0 means \"use existing key or fall back to 15\"."
+        }
+      },
+      "description": "ToggleAutoSleepRequest opts a container into (or out of) auto-sleep\ntracking. The flag and threshold are stored as Incus user.* config\nkeys; the actual sleep tick (Phase 2) and HTTP wake (Phase 3) are\nseparate work. This RPC only writes the metadata."
+    },
+    "ToggleAutoSleepResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "Operator-facing summary (e.g. \"auto-sleep enabled at 15m\")."
+        },
+        "autoSleepEnabled": {
+          "type": "boolean",
+          "description": "The effective auto_sleep_enabled state after the toggle."
+        },
+        "idleThresholdMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The effective idle_threshold_minutes value (15 if defaulted)."
+        }
+      },
+      "description": "ToggleAutoSleepResponse reports the effective auto-sleep state."
     },
     "ToggleMonitoringBody": {
       "type": "object",

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -99,9 +99,11 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 	var containers []incus.ContainerInfo
 	for _, container := range resp.Containers {
 		info := incus.ContainerInfo{
-			Name:              container.Name,
-			State:             container.State.String(),
-			MonitoringEnabled: container.MonitoringEnabled,
+			Name:                 container.Name,
+			State:                container.State.String(),
+			MonitoringEnabled:    container.MonitoringEnabled,
+			AutoSleepEnabled:     container.AutoSleepEnabled,
+			IdleThresholdMinutes: container.IdleThresholdMinutes,
 		}
 
 		// Get IP address from network info
@@ -193,6 +195,63 @@ func (c *GRPCClient) ToggleMonitoring(username string, enabled bool) (string, bo
 		return "", false, fmt.Errorf("failed to toggle monitoring: %w", err)
 	}
 	return resp.Message, resp.MonitoringEnabled, nil
+}
+
+// ToggleAutoSleep writes the per-container auto-sleep opt-in metadata.
+// idleThresholdMinutes is ignored when enabled is false; 0 means
+// "leave the existing key or fall back to the 15-minute default".
+func (c *GRPCClient) ToggleAutoSleep(username string, enabled bool, idleThresholdMinutes int32) (*pb.ToggleAutoSleepResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req := &pb.ToggleAutoSleepRequest{
+		Username:             username,
+		Enabled:              enabled,
+		IdleThresholdMinutes: idleThresholdMinutes,
+	}
+	resp, err := c.client.ToggleAutoSleep(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to toggle auto-sleep: %w", err)
+	}
+	return resp, nil
+}
+
+// StartContainer starts a stopped container via gRPC. When
+// waitForReady is true the server blocks until the container's
+// primary TCP port accepts or readyTimeoutSeconds elapses (0 falls
+// back to the server-side 30s default).
+func (c *GRPCClient) StartContainer(username string, waitForReady bool, readyTimeoutSeconds int32) (*pb.StartContainerResponse, error) {
+	timeout := 60 * time.Second
+	if waitForReady && readyTimeoutSeconds > 0 {
+		timeout = time.Duration(readyTimeoutSeconds+10) * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	resp, err := c.client.StartContainer(ctx, &pb.StartContainerRequest{
+		Username:            username,
+		WaitForReady:        waitForReady,
+		ReadyTimeoutSeconds: readyTimeoutSeconds,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to start container: %w", err)
+	}
+	return resp, nil
+}
+
+// StopContainer stops a running container via gRPC.
+func (c *GRPCClient) StopContainer(username string, force bool) (*pb.StopContainerResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := c.client.StopContainer(ctx, &pb.StopContainerRequest{
+		Username: username,
+		Force:    force,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to stop container: %w", err)
+	}
+	return resp, nil
 }
 
 // DeleteContainer deletes a container via gRPC
@@ -314,8 +373,11 @@ func (c *GRPCClient) GetContainer(username string) (*incus.ContainerInfo, error)
 	// Convert protobuf Container to incus.ContainerInfo
 	container := resp.Container
 	info := &incus.ContainerInfo{
-		Name:  container.Name,
-		State: container.State.String(),
+		Name:                 container.Name,
+		State:                container.State.String(),
+		MonitoringEnabled:    container.MonitoringEnabled,
+		AutoSleepEnabled:     container.AutoSleepEnabled,
+		IdleThresholdMinutes: container.IdleThresholdMinutes,
 	}
 
 	if container.Network != nil {

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -102,17 +102,19 @@ func parseResponse[T any](resp *http.Response) (*T, error) {
 
 // Container response types matching the protobuf JSON output
 type containerResponse struct {
-	Name              string            `json:"name"`
-	Username          string            `json:"username"`
-	State             string            `json:"state"`
-	Resources         *resourceLimits   `json:"resources"`
-	Network           *networkInfo      `json:"network"`
-	CreatedAt         string            `json:"createdAt"`
-	Labels            map[string]string `json:"labels"`
-	Image             string            `json:"image"`
-	PodmanEnabled     bool              `json:"dockerEnabled"`
-	GpuDevice         string            `json:"gpuDevice"`
-	MonitoringEnabled bool              `json:"monitoringEnabled"`
+	Name                 string            `json:"name"`
+	Username             string            `json:"username"`
+	State                string            `json:"state"`
+	Resources            *resourceLimits   `json:"resources"`
+	Network              *networkInfo      `json:"network"`
+	CreatedAt            string            `json:"createdAt"`
+	Labels               map[string]string `json:"labels"`
+	Image                string            `json:"image"`
+	PodmanEnabled        bool              `json:"dockerEnabled"`
+	GpuDevice            string            `json:"gpuDevice"`
+	MonitoringEnabled    bool              `json:"monitoringEnabled"`
+	AutoSleepEnabled     bool              `json:"autoSleepEnabled"`
+	IdleThresholdMinutes int32             `json:"idleThresholdMinutes"`
 }
 
 type resourceLimits struct {
@@ -158,10 +160,12 @@ type systemInfo struct {
 // containerToIncusInfo converts API response to incus.ContainerInfo
 func containerToIncusInfo(c *containerResponse) incus.ContainerInfo {
 	info := incus.ContainerInfo{
-		Name:              c.Name,
-		State:             c.State,
-		Labels:            c.Labels,
-		MonitoringEnabled: c.MonitoringEnabled,
+		Name:                 c.Name,
+		State:                c.State,
+		Labels:               c.Labels,
+		MonitoringEnabled:    c.MonitoringEnabled,
+		AutoSleepEnabled:     c.AutoSleepEnabled,
+		IdleThresholdMinutes: c.IdleThresholdMinutes,
 	}
 
 	if c.Network != nil {
@@ -248,6 +252,112 @@ func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, 
 
 	info := containerToIncusInfo(result.Container)
 	return &info, nil
+}
+
+// ToggleAutoSleep writes the per-container auto-sleep opt-in
+// metadata via HTTP. See GRPCClient.ToggleAutoSleep for semantics.
+func (c *HTTPClient) ToggleAutoSleep(username string, enabled bool, idleThresholdMinutes int32) (*pb.ToggleAutoSleepResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/containers/%s/auto-sleep", url.PathEscape(username))
+	body := map[string]interface{}{
+		"enabled":                enabled,
+		"idle_threshold_minutes": idleThresholdMinutes,
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("toggle auto-sleep: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(bodyBytes, &errResp) == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("%s", errResp.Error)
+		}
+		return nil, fmt.Errorf("toggle auto-sleep: status %d", resp.StatusCode)
+	}
+
+	out := &pb.ToggleAutoSleepResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
+// StartContainer starts a stopped container via HTTP. When
+// waitForReady is true the daemon blocks until the container's
+// primary TCP port accepts (or readyTimeoutSeconds elapses).
+func (c *HTTPClient) StartContainer(username string, waitForReady bool, readyTimeoutSeconds int32) (*pb.StartContainerResponse, error) {
+	timeout := 60 * time.Second
+	if waitForReady && readyTimeoutSeconds > 0 {
+		timeout = time.Duration(readyTimeoutSeconds+10) * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/containers/%s/start", url.PathEscape(username))
+	body := map[string]interface{}{
+		"wait_for_ready":        waitForReady,
+		"ready_timeout_seconds": readyTimeoutSeconds,
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("start container: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(bodyBytes, &errResp) == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("%s", errResp.Error)
+		}
+		return nil, fmt.Errorf("start container: status %d", resp.StatusCode)
+	}
+
+	out := &pb.StartContainerResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
+// StopContainer stops a running container via HTTP.
+func (c *HTTPClient) StopContainer(username string, force bool) (*pb.StopContainerResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/containers/%s/stop", url.PathEscape(username))
+	body := map[string]interface{}{"force": force}
+	resp, err := c.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("stop container: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(bodyBytes, &errResp) == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("%s", errResp.Error)
+		}
+		return nil, fmt.Errorf("stop container: status %d", resp.StatusCode)
+	}
+
+	out := &pb.StopContainerResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
 }
 
 // ToggleMonitoring enables / disables OTel app telemetry on an

--- a/internal/cmd/scale_down.go
+++ b/internal/cmd/scale_down.go
@@ -1,0 +1,271 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/client"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/spf13/cobra"
+)
+
+var (
+	scaleDownEnableIdle string
+)
+
+var scaleDownCmd = &cobra.Command{
+	Use:   "scale-down",
+	Short: "Manage per-container auto-sleep opt-in (Phase 1)",
+	Long: `Manage the per-container auto-sleep flag. Phase 1 sets the metadata;
+Phase 2 (idle daemon) and Phase 3 (HTTP wake) consume it.`,
+}
+
+var scaleDownEnableCmd = &cobra.Command{
+	Use:   "enable <username>",
+	Short: "Opt a container into auto-sleep",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runScaleDownEnable,
+}
+
+var scaleDownDisableCmd = &cobra.Command{
+	Use:   "disable <username>",
+	Short: "Opt a container out of auto-sleep (idempotent)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runScaleDownDisable,
+}
+
+var scaleDownStatusCmd = &cobra.Command{
+	Use:   "status [username]",
+	Short: "Show auto-sleep status for one or all containers",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  runScaleDownStatus,
+}
+
+var sleepCmd = &cobra.Command{
+	Use:   "sleep <username>",
+	Short: "Stop a container (alias for stop, surfaces 'sleeping' messaging)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSleep,
+}
+
+var wakeCmd = &cobra.Command{
+	Use:   "wake <username>",
+	Short: "Start a container and wait for its primary port to accept",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runWake,
+}
+
+func init() {
+	rootCmd.AddCommand(scaleDownCmd)
+	scaleDownCmd.AddCommand(scaleDownEnableCmd)
+	scaleDownCmd.AddCommand(scaleDownDisableCmd)
+	scaleDownCmd.AddCommand(scaleDownStatusCmd)
+	rootCmd.AddCommand(sleepCmd)
+	rootCmd.AddCommand(wakeCmd)
+
+	scaleDownEnableCmd.Flags().StringVar(&scaleDownEnableIdle, "idle", "15m",
+		"Idle duration before sleep (Go duration, e.g. 15m, 1h). Minimum 1m.")
+}
+
+// parseIdleMinutes parses a Go duration string and converts to integer
+// minutes. Sub-minute precision is dropped (rounded up to 1m minimum).
+func parseIdleMinutes(s string) (int32, error) {
+	if s == "" {
+		return 15, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	if d < time.Minute {
+		return 0, fmt.Errorf("idle duration must be at least 1 minute, got %s", s)
+	}
+	mins := int32(d / time.Minute)
+	if mins < 1 {
+		mins = 1
+	}
+	return mins, nil
+}
+
+func runScaleDownEnable(cmd *cobra.Command, args []string) error {
+	username := args[0]
+	mins, err := parseIdleMinutes(scaleDownEnableIdle)
+	if err != nil {
+		return err
+	}
+	resp, err := toggleAutoSleepViaServer(username, true, mins)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ %s — auto_sleep_enabled=%v idle_threshold_minutes=%d\n",
+		resp.Message, resp.AutoSleepEnabled, resp.IdleThresholdMinutes)
+	return nil
+}
+
+func runScaleDownDisable(cmd *cobra.Command, args []string) error {
+	username := args[0]
+	resp, err := toggleAutoSleepViaServer(username, false, 0)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ %s — auto_sleep_enabled=%v\n", resp.Message, resp.AutoSleepEnabled)
+	return nil
+}
+
+func runScaleDownStatus(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required")
+	}
+	var containers []incus.ContainerInfo
+	var err error
+	if len(args) == 1 {
+		containers, err = fetchOneContainer(args[0])
+	} else {
+		containers, err = fetchAllContainers()
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%-25s %-8s %-12s %s\n", "USERNAME", "ENABLED", "THRESHOLD", "STATE")
+	fmt.Printf("%-25s %-8s %-12s %s\n", strings.Repeat("-", 25), strings.Repeat("-", 8), strings.Repeat("-", 12), strings.Repeat("-", 12))
+	for _, c := range containers {
+		username := strings.TrimSuffix(c.Name, "-container")
+		threshold := fmt.Sprintf("%dm", c.IdleThresholdMinutes)
+		fmt.Printf("%-25s %-8v %-12s %s\n", username, c.AutoSleepEnabled, threshold, c.State)
+	}
+	return nil
+}
+
+func runSleep(cmd *cobra.Command, args []string) error {
+	username := args[0]
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required")
+	}
+	if httpMode {
+		httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return err
+		}
+		defer httpClient.Close()
+		resp, err := httpClient.StopContainer(username, false)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("✓ Container %s is sleeping (%s)\n", username, resp.Message)
+		return nil
+	}
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return err
+	}
+	defer grpcClient.Close()
+	resp, err := grpcClient.StopContainer(username, false)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ Container %s is sleeping (%s)\n", username, resp.Message)
+	return nil
+}
+
+func runWake(cmd *cobra.Command, args []string) error {
+	username := args[0]
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required")
+	}
+	if httpMode {
+		httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return err
+		}
+		defer httpClient.Close()
+		resp, err := httpClient.StartContainer(username, true, 30)
+		if err != nil {
+			return err
+		}
+		printWakeResult(username, resp)
+		return nil
+	}
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return err
+	}
+	defer grpcClient.Close()
+	resp, err := grpcClient.StartContainer(username, true, 30)
+	if err != nil {
+		return err
+	}
+	printWakeResult(username, resp)
+	return nil
+}
+
+func printWakeResult(username string, resp *pb.StartContainerResponse) {
+	if resp.ReadyTimedOut {
+		fmt.Printf("⚠ Container %s started but readiness probe timed out\n", username)
+		return
+	}
+	fmt.Printf("✓ Container %s is awake (%s)\n", username, resp.Message)
+}
+
+func toggleAutoSleepViaServer(username string, enabled bool, idleMinutes int32) (*pb.ToggleAutoSleepResponse, error) {
+	if serverAddr == "" {
+		return nil, fmt.Errorf("--server is required")
+	}
+	if httpMode {
+		httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return nil, err
+		}
+		defer httpClient.Close()
+		return httpClient.ToggleAutoSleep(username, enabled, idleMinutes)
+	}
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return nil, err
+	}
+	defer grpcClient.Close()
+	return grpcClient.ToggleAutoSleep(username, enabled, idleMinutes)
+}
+
+func fetchAllContainers() ([]incus.ContainerInfo, error) {
+	if httpMode {
+		httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return nil, err
+		}
+		defer httpClient.Close()
+		return httpClient.ListContainers()
+	}
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return nil, err
+	}
+	defer grpcClient.Close()
+	return grpcClient.ListContainers()
+}
+
+func fetchOneContainer(username string) ([]incus.ContainerInfo, error) {
+	if httpMode {
+		httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return nil, err
+		}
+		defer httpClient.Close()
+		info, err := httpClient.GetContainer(username)
+		if err != nil {
+			return nil, err
+		}
+		return []incus.ContainerInfo{*info}, nil
+	}
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return nil, err
+	}
+	defer grpcClient.Close()
+	info, err := grpcClient.GetContainer(username)
+	if err != nil {
+		return nil, err
+	}
+	return []incus.ContainerInfo{*info}, nil
+}

--- a/internal/cmd/scale_down_test.go
+++ b/internal/cmd/scale_down_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseIdleMinutes table-drives the CLI's duration→minutes helper.
+// Sub-minute durations and unparseable strings must return an error;
+// empty string is the special "use default 15" sentinel for the flag's
+// default value.
+func TestParseIdleMinutes(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    int32
+		wantErr bool
+	}{
+		{"empty → default 15", "", 15, false},
+		{"1m → 1", "1m", 1, false},
+		{"15m → 15", "15m", 15, false},
+		{"1h → 60", "1h", 60, false},
+		{"60m → 60 (same as 1h)", "60m", 60, false},
+		{"1h30m → 90", "1h30m", 90, false},
+		{"sub-minute rejected (30s)", "30s", 0, true},
+		{"zero rejected", "0", 0, true},
+		{"negative rejected", "-15m", 0, true},
+		{"non-duration rejected", "abc", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseIdleMinutes(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseIdleMinutes(%q) = %d, nil; want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseIdleMinutes(%q) unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseIdleMinutes(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseIdleMinutes_ErrorMessages locks the operator-facing error
+// text for the two distinct failure modes — bad duration syntax vs.
+// too-small magnitude. Operators grep these strings in CI / scripts.
+func TestParseIdleMinutes_ErrorMessages(t *testing.T) {
+	_, err := parseIdleMinutes("notaduration")
+	if err == nil || !strings.Contains(err.Error(), "invalid duration") {
+		t.Errorf("syntax error msg = %v, want contains 'invalid duration'", err)
+	}
+	_, err = parseIdleMinutes("30s")
+	if err == nil || !strings.Contains(err.Error(), "at least 1 minute") {
+		t.Errorf("sub-minute err = %v, want contains 'at least 1 minute'", err)
+	}
+}
+
+// TestScaleDownEnable_RequiresUsername verifies the cobra command
+// rejects a bare invocation. cobra.ExactArgs(1) ships the rejection
+// for us; the test guards against an accidental Args mutation.
+func TestScaleDownEnable_RequiresUsername(t *testing.T) {
+	err := scaleDownEnableCmd.Args(scaleDownEnableCmd, []string{})
+	if err == nil {
+		t.Fatal("expected Args validation error for zero positional args")
+	}
+}
+
+// TestScaleDownStatus_AllowsZeroOrOneArg mirrors the cobra MaximumNArgs(1)
+// contract — `scale-down status` (no args, all containers) is valid,
+// as is `scale-down status alice`, but two args is not.
+func TestScaleDownStatus_AllowsZeroOrOneArg(t *testing.T) {
+	if err := scaleDownStatusCmd.Args(scaleDownStatusCmd, []string{}); err != nil {
+		t.Errorf("zero args should be allowed: %v", err)
+	}
+	if err := scaleDownStatusCmd.Args(scaleDownStatusCmd, []string{"alice"}); err != nil {
+		t.Errorf("one arg should be allowed: %v", err)
+	}
+	if err := scaleDownStatusCmd.Args(scaleDownStatusCmd, []string{"alice", "bob"}); err == nil {
+		t.Error("two args should be rejected")
+	}
+}
+
+// TestSleepWakeCmd_RequireUsername guards the cobra contract on the
+// stop/start aliases — operator UX expectation is a clear cobra error
+// rather than `fmt.Errorf("--server is required")` when the username
+// is also missing.
+func TestSleepWakeCmd_RequireUsername(t *testing.T) {
+	if err := sleepCmd.Args(sleepCmd, []string{}); err == nil {
+		t.Error("sleep with no username should fail Args validation")
+	}
+	if err := wakeCmd.Args(wakeCmd, []string{}); err == nil {
+		t.Error("wake with no username should fail Args validation")
+	}
+}

--- a/internal/mcp/auto_sleep_tool_test.go
+++ b/internal/mcp/auto_sleep_tool_test.go
@@ -1,0 +1,157 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleToggleAutoSleep_RequiresUsername — missing or empty
+// username short-circuits before any HTTP call. Client URL points at
+// an unreachable address; reaching it would surface a different
+// error.
+func TestHandleToggleAutoSleep_RequiresUsername(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", "tok")
+	cases := []map[string]interface{}{
+		{},
+		{"enabled": true},
+		{"username": "", "enabled": true},
+	}
+	for _, args := range cases {
+		_, err := handleToggleAutoSleep(client, args)
+		if err == nil {
+			t.Errorf("expected error for args=%v", args)
+			continue
+		}
+		if !strings.Contains(err.Error(), "username") {
+			t.Errorf("err = %v, want mention of 'username'", err)
+		}
+	}
+}
+
+// TestHandleToggleAutoSleep_RequiresEnabledBool — `enabled` is a
+// required field; pass-through types other than bool (or absent) must
+// fail before the HTTP call.
+func TestHandleToggleAutoSleep_RequiresEnabledBool(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", "tok")
+	cases := []map[string]interface{}{
+		{"username": "alice"},                     // missing
+		{"username": "alice", "enabled": "true"},  // string, not bool
+		{"username": "alice", "enabled": 1},       // int, not bool
+	}
+	for _, args := range cases {
+		_, err := handleToggleAutoSleep(client, args)
+		if err == nil || !strings.Contains(err.Error(), "enabled") {
+			t.Errorf("args=%v: err = %v, want 'enabled' validation", args, err)
+		}
+	}
+}
+
+// TestHandleToggleAutoSleep_OmitsThresholdDefaultsToZero — when
+// idleThresholdMinutes is absent from args, the handler sends 0 over
+// the wire. The server side then applies its 15-minute default. This
+// is the contract between MCP and the daemon.
+func TestHandleToggleAutoSleep_OmitsThresholdDefaultsToZero(t *testing.T) {
+	var captured map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+		_, _ = w.Write([]byte(`{"message":"ok","autoSleepEnabled":true,"idleThresholdMinutes":15}`))
+	}))
+	defer srv.Close()
+	client := NewClient(srv.URL, "tok")
+
+	out, err := handleToggleAutoSleep(client, map[string]interface{}{
+		"username": "alice",
+		"enabled":  true,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out, "auto_sleep_enabled=true")
+	assert.EqualValues(t, 0, captured["idle_threshold_minutes"], "absent idleThresholdMinutes must wire as 0 so server applies default")
+}
+
+// TestHandleToggleAutoSleep_ThresholdPropagates — explicit
+// idleThresholdMinutes lands intact on the wire. Verifies JSON-number
+// (float64) decode path in getIntArg.
+func TestHandleToggleAutoSleep_ThresholdPropagates(t *testing.T) {
+	var captured map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+		_, _ = w.Write([]byte(`{"message":"ok","autoSleepEnabled":true,"idleThresholdMinutes":45}`))
+	}))
+	defer srv.Close()
+	client := NewClient(srv.URL, "tok")
+
+	_, err := handleToggleAutoSleep(client, map[string]interface{}{
+		"username":             "alice",
+		"enabled":              true,
+		"idleThresholdMinutes": float64(45), // JSON number arrives as float64
+	})
+	require.NoError(t, err)
+	assert.EqualValues(t, 45, captured["idle_threshold_minutes"])
+}
+
+// TestHandleStartContainer_WaitForReadyPropagates — the waitForReady
+// MCP arg must land in the request body as wait_for_ready.
+func TestHandleStartContainer_WaitForReadyPropagates(t *testing.T) {
+	var captured map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+		_, _ = w.Write([]byte(`{"message":"started","container":{"state":"Running"},"readyTimedOut":false}`))
+	}))
+	defer srv.Close()
+	client := NewClient(srv.URL, "tok")
+
+	_, err := handleStartContainer(client, map[string]interface{}{
+		"username":     "alice",
+		"waitForReady": true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, true, captured["wait_for_ready"])
+}
+
+// TestHandleStartContainer_DefaultWaitForReadyFalse — the boolean
+// default must be false (matches the proto's zero value); otherwise
+// every start_container without an explicit waitForReady would block
+// on the 30s probe.
+func TestHandleStartContainer_DefaultWaitForReadyFalse(t *testing.T) {
+	var captured map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+		_, _ = w.Write([]byte(`{"message":"started","container":{"state":"Running"},"readyTimedOut":false}`))
+	}))
+	defer srv.Close()
+	client := NewClient(srv.URL, "tok")
+
+	_, err := handleStartContainer(client, map[string]interface{}{"username": "alice"})
+	require.NoError(t, err)
+	assert.Equal(t, false, captured["wait_for_ready"])
+}
+
+// TestHandleStartContainer_RequiresUsername — handler validates
+// before hitting the wire.
+func TestHandleStartContainer_RequiresUsername(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", "tok")
+	_, err := handleStartContainer(client, map[string]interface{}{})
+	if err == nil || !strings.Contains(err.Error(), "username") {
+		t.Errorf("err = %v, want 'username is required'", err)
+	}
+}
+
+// TestHandleStartContainer_ShowsTimeoutWarning — when daemon reports
+// readyTimedOut=true, the response text includes a warning sigil
+// that operators recognise.
+func TestHandleStartContainer_ShowsTimeoutWarning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"message":"started","container":{"state":"Running"},"readyTimedOut":true}`))
+	}))
+	defer srv.Close()
+	client := NewClient(srv.URL, "tok")
+	out, err := handleStartContainer(client, map[string]interface{}{"username": "alice", "waitForReady": true})
+	require.NoError(t, err)
+	assert.Contains(t, out, "readiness probe timed out")
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -313,9 +313,13 @@ func (c *Client) DeleteContainer(username string, force bool) (*DeleteContainerR
 	return &resp, nil
 }
 
-// StartContainer starts a stopped container
-func (c *Client) StartContainer(username string) (*StartContainerResponse, error) {
-	respBody, err := c.doRequest("POST", "/v1/containers/"+username+"/start", nil)
+// StartContainer starts a stopped container. When waitForReady is
+// true the daemon blocks until the container's primary TCP port
+// accepts or the server-side default (30s) elapses; the response's
+// ReadyTimedOut field reports whether the probe gave up.
+func (c *Client) StartContainer(username string, waitForReady bool) (*StartContainerResponse, error) {
+	body := map[string]interface{}{"wait_for_ready": waitForReady}
+	respBody, err := c.doRequest("POST", "/v1/containers/"+username+"/start", body)
 	if err != nil {
 		return nil, err
 	}
@@ -325,6 +329,25 @@ func (c *Client) StartContainer(username string) (*StartContainerResponse, error
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
+	return &resp, nil
+}
+
+// ToggleAutoSleep writes the per-container auto-sleep opt-in flag.
+// idleThresholdMinutes is honored only when enabled is true; 0 means
+// "use the existing key or the daemon's 15-minute default".
+func (c *Client) ToggleAutoSleep(username string, enabled bool, idleThresholdMinutes int32) (*ToggleAutoSleepResponse, error) {
+	body := map[string]interface{}{
+		"enabled":                enabled,
+		"idle_threshold_minutes": idleThresholdMinutes,
+	}
+	respBody, err := c.doRequest("POST", "/v1/containers/"+username+"/auto-sleep", body)
+	if err != nil {
+		return nil, err
+	}
+	var resp ToggleAutoSleepResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
 	return &resp, nil
 }
 
@@ -815,8 +838,15 @@ type RefreshSecretsResponse struct {
 }
 
 type StartContainerResponse struct {
-	Message   string    `json:"message"`
-	Container Container `json:"container"`
+	Message       string    `json:"message"`
+	Container     Container `json:"container"`
+	ReadyTimedOut bool      `json:"readyTimedOut"`
+}
+
+type ToggleAutoSleepResponse struct {
+	Message              string `json:"message"`
+	AutoSleepEnabled     bool   `json:"autoSleepEnabled"`
+	IdleThresholdMinutes int32  `json:"idleThresholdMinutes"`
 }
 
 type StopContainerResponse struct {

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -480,6 +480,101 @@ func TestAddRoute_ServerError(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestToggleAutoSleep_WirePayload locks the on-wire request shape
+// (POST, path, JSON field names) and verifies the response decoded
+// from the daemon's gateway flows back through the typed struct.
+func TestToggleAutoSleep_WirePayload(t *testing.T) {
+	var captured map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/v1/containers/alice/auto-sleep", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+		_, _ = w.Write([]byte(`{"message":"auto-sleep enabled at 30m","autoSleepEnabled":true,"idleThresholdMinutes":30}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "tok")
+	resp, err := c.ToggleAutoSleep("alice", true, 30)
+	require.NoError(t, err)
+
+	// Field names must match the snake_case the grpc-gateway shim
+	// accepts on input — gateway auto-converts both spellings on
+	// decode, but locking snake_case here matches the literal client
+	// body and guards against accidental camelCase rewrites that
+	// older gateway builds reject.
+	assert.Equal(t, true, captured["enabled"])
+	assert.EqualValues(t, 30, captured["idle_threshold_minutes"])
+	// Response decode round-trips the camelCase JSON cleanly.
+	assert.True(t, resp.AutoSleepEnabled)
+	assert.Equal(t, int32(30), resp.IdleThresholdMinutes)
+}
+
+// TestToggleAutoSleep_WirePayload_DisableOmitsThreshold — disable
+// path still carries idle_threshold_minutes as 0 (Go zero value) over
+// the wire; the daemon ignores it when enabled=false.
+func TestToggleAutoSleep_WirePayload_DisableOmitsThreshold(t *testing.T) {
+	var captured map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+		_, _ = w.Write([]byte(`{"message":"auto-sleep disabled","autoSleepEnabled":false,"idleThresholdMinutes":15}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "tok")
+	_, err := c.ToggleAutoSleep("alice", false, 0)
+	require.NoError(t, err)
+	assert.Equal(t, false, captured["enabled"])
+	assert.EqualValues(t, 0, captured["idle_threshold_minutes"])
+}
+
+// TestStartContainer_WirePayload_WaitForReady — verify the new
+// waitForReady arg ships on the wire. Lock the JSON field name so a
+// later refactor doesn't silently break daemons expecting the
+// gateway-decoded request.
+func TestStartContainer_WirePayload_WaitForReady(t *testing.T) {
+	tests := []struct {
+		name              string
+		waitForReady      bool
+		wantWaitForReady  bool
+	}{
+		{"waitForReady=true", true, true},
+		{"waitForReady=false", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured map[string]interface{}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "POST", r.Method)
+				assert.Equal(t, "/v1/containers/alice/start", r.URL.Path)
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+				_, _ = w.Write([]byte(`{"message":"started","container":{"name":"alice-container","state":"Running"},"readyTimedOut":false}`))
+			}))
+			defer srv.Close()
+
+			c := NewClient(srv.URL, "tok")
+			resp, err := c.StartContainer("alice", tt.waitForReady)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantWaitForReady, captured["wait_for_ready"])
+			assert.False(t, resp.ReadyTimedOut)
+		})
+	}
+}
+
+// TestStartContainer_DecodesReadyTimedOut — when the daemon reports
+// ready_timed_out=true, the typed response struct must carry it
+// through so the MCP handler can show the warning emoji.
+func TestStartContainer_DecodesReadyTimedOut(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"message":"timed out","container":{"name":"alice-container","state":"Running"},"readyTimedOut":true}`))
+	}))
+	defer srv.Close()
+	c := NewClient(srv.URL, "tok")
+	resp, err := c.StartContainer("alice", true)
+	require.NoError(t, err)
+	assert.True(t, resp.ReadyTimedOut)
+}
+
 // TestTriggerSecurityScan_WirePayloads locks the wire body for each
 // scanner kind. All three protos now accept a container_name field,
 // and the MCP always operates on one container, so all three bodies

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,7 +22,7 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	assert.Len(t, server.tools, 27, "Should have 27 tools registered")
+	assert.Len(t, server.tools, 28, "Should have 28 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -126,7 +126,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	assert.Len(t, tools, 27)
+	assert.Len(t, tools, 28)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -419,7 +419,7 @@ func (s *Server) registerTools() {
 		},
 		{
 			Name:        "start_container",
-			Description: "Start a stopped container",
+			Description: "Start a stopped container. When waitForReady is true the daemon blocks until the container's primary TCP port (from its route record) accepts, or the 30s probe timeout elapses — the response then reports whether the probe timed out.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
@@ -427,10 +427,37 @@ func (s *Server) registerTools() {
 						"type":        "string",
 						"description": "Username of the container to start",
 					},
+					"waitForReady": map[string]interface{}{
+						"type":        "boolean",
+						"description": "If true, block until the container's primary TCP port accepts or 30s elapses (default false)",
+					},
 				},
 				"required": []string{"username"},
 			},
 			Handler: handleStartContainer,
+		},
+		{
+			Name:        "toggle_auto_sleep",
+			Description: "Opt a container into auto-sleep. Enabled containers are stopped after `idleThresholdMinutes` of network inactivity, which frees their RAM and CPU. They are restarted on the next HTTP request (Phase 3, coming). This sets a per-container metadata flag; it doesn't sleep the container itself — use `stop_container` if you want to sleep it now.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"username": map[string]interface{}{
+						"type":        "string",
+						"description": "Username of the container",
+					},
+					"enabled": map[string]interface{}{
+						"type":        "boolean",
+						"description": "true to opt in, false to opt out",
+					},
+					"idleThresholdMinutes": map[string]interface{}{
+						"type":        "integer",
+						"description": "Idle minutes before Phase 2 would sleep the container. Default 15. Ignored when enabled=false.",
+					},
+				},
+				"required": []string{"username", "enabled"},
+			},
+			Handler: handleToggleAutoSleep,
 		},
 		{
 			Name:        "stop_container",
@@ -1141,13 +1168,39 @@ func handleStartContainer(client *Client, args map[string]interface{}) (string, 
 	if !ok || username == "" {
 		return "", fmt.Errorf("username is required")
 	}
+	waitForReady := getBoolArg(args, "waitForReady", false)
 
-	resp, err := client.StartContainer(username)
+	resp, err := client.StartContainer(username, waitForReady)
 	if err != nil {
 		return "", fmt.Errorf("failed to start container: %w", err)
 	}
 
+	if resp.ReadyTimedOut {
+		return fmt.Sprintf("⚠ %s (readiness probe timed out)\nContainer state: %s", resp.Message, resp.Container.State), nil
+	}
 	return fmt.Sprintf("✅ %s\nContainer state: %s", resp.Message, resp.Container.State), nil
+}
+
+func handleToggleAutoSleep(client *Client, args map[string]interface{}) (string, error) {
+	username, ok := args["username"].(string)
+	if !ok || username == "" {
+		return "", fmt.Errorf("username is required")
+	}
+	enabled, ok := args["enabled"].(bool)
+	if !ok {
+		return "", fmt.Errorf("enabled (bool) is required")
+	}
+	idle := int32(0)
+	if n, ok := getIntArg(args, "idleThresholdMinutes"); ok {
+		idle = int32(n)
+	}
+
+	resp, err := client.ToggleAutoSleep(username, enabled, idle)
+	if err != nil {
+		return "", fmt.Errorf("failed to toggle auto-sleep: %w", err)
+	}
+	return fmt.Sprintf("✅ %s (auto_sleep_enabled=%v, idle_threshold_minutes=%d)",
+		resp.Message, resp.AutoSleepEnabled, resp.IdleThresholdMinutes), nil
 }
 
 func handleStopContainer(client *Client, args map[string]interface{}) (string, error) {

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -62,7 +62,7 @@ type ContainerServer struct {
 	// the daemon was started without --app-hosting). Used by DeleteContainer
 	// to cascade-remove the routes / TLS-automation subjects a container
 	// owned, so deleting an LXC actually deletes the public hostname too.
-	routeStore           *app.RouteStore
+	routeStore           routeLister
 	proxyManager         *app.ProxyManager
 
 	// moveRunner shells out to `incus snapshot/copy/stop/start` for the

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -621,7 +623,11 @@ func (s *ContainerServer) StartContainer(ctx context.Context, req *pb.StartConta
 			authToken := extractAuthToken(ctx)
 			peer := s.peerPool.FindContainerPeer(req.Username, authToken)
 			if peer != nil {
-				_, _, fwdErr := peer.ForwardRequest("POST", fmt.Sprintf("/v1/containers/%s/start", req.Username), authToken, nil)
+				body, _ := json.Marshal(map[string]interface{}{
+					"wait_for_ready":        req.WaitForReady,
+					"ready_timeout_seconds": req.ReadyTimeoutSeconds,
+				})
+				_, _, fwdErr := peer.ForwardRequest("POST", fmt.Sprintf("/v1/containers/%s/start", req.Username), authToken, body)
 				if fwdErr == nil {
 					return &pb.StartContainerResponse{
 						Message: fmt.Sprintf("Container for user %s started on backend %s", req.Username, peer.ID),
@@ -649,12 +655,63 @@ func (s *ContainerServer) StartContainer(ctx context.Context, req *pb.StartConta
 		return nil, fmt.Errorf("container started but failed to get info: %w", err)
 	}
 
+	timedOut := false
+	if req.WaitForReady {
+		timeoutSec := req.ReadyTimeoutSeconds
+		if timeoutSec <= 0 {
+			timeoutSec = 30
+		}
+		timedOut = s.waitForContainerReady(ctx, req.Username, info.IPAddress, time.Duration(timeoutSec)*time.Second)
+	}
+
 	s.emitter.EmitContainerStarted(toProtoContainer(info))
 
+	msg := fmt.Sprintf("Container for user %s started successfully", req.Username)
+	if req.WaitForReady && timedOut {
+		msg = fmt.Sprintf("Container for user %s started but readiness probe timed out", req.Username)
+	}
+
 	return &pb.StartContainerResponse{
-		Message:   fmt.Sprintf("Container for user %s started successfully", req.Username),
-		Container: toProtoContainer(info),
+		Message:       msg,
+		Container:     toProtoContainer(info),
+		ReadyTimedOut: timedOut,
 	}, nil
+}
+
+// waitForContainerReady polls a TCP dial against the container's
+// primary exposed port until it accepts or the deadline elapses.
+// Returns true when the probe timed out. A nil routeStore, an absent
+// route record, an empty container IP, or a non-positive port all
+// short-circuit to "ready immediately" — the probe is opportunistic.
+func (s *ContainerServer) waitForContainerReady(ctx context.Context, username, containerIP string, total time.Duration) bool {
+	if s.routeStore == nil || containerIP == "" {
+		return false
+	}
+	containerName := username + "-container"
+	routes, err := s.routeStore.ListByContainer(ctx, containerName)
+	if err != nil || len(routes) == 0 {
+		return false
+	}
+	port := routes[0].TargetPort
+	if port <= 0 {
+		return false
+	}
+
+	addr := net.JoinHostPort(containerIP, strconv.Itoa(port))
+	deadline := time.Now().Add(total)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return true
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+	return true
 }
 
 // StopContainer stops a running container
@@ -1069,6 +1126,62 @@ func (s *ContainerServer) ToggleMonitoring(ctx context.Context, req *pb.ToggleMo
 	}, nil
 }
 
+// ToggleAutoSleep writes the per-container auto-sleep opt-in flag
+// (Phase 1 of the serverless feature). Works on running or stopped
+// containers; Incus accepts config updates in either state.
+//
+// On enable, both the flag and the threshold key are written. The
+// threshold key persists across disables so a re-enable restores
+// the prior value; an explicit idle_threshold_minutes > 0 always
+// overwrites, otherwise the existing key or the 15-minute default
+// applies. Core containers are refused — they don't represent user
+// workloads and shouldn't be sleeping.
+func (s *ContainerServer) ToggleAutoSleep(ctx context.Context, req *pb.ToggleAutoSleepRequest) (*pb.ToggleAutoSleepResponse, error) {
+	if req.Username == "" {
+		return nil, status.Error(codes.InvalidArgument, "username is required")
+	}
+
+	info, err := s.manager.Get(req.Username)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "container for user %s not found: %v", req.Username, err)
+	}
+	if info.Role.IsCoreRole() {
+		return nil, status.Errorf(codes.InvalidArgument, "container %s is a core container; auto-sleep is for user containers only", info.Name)
+	}
+
+	containerName := info.Name
+	effectiveThreshold := info.IdleThresholdMinutes
+	if req.IdleThresholdMinutes > 0 {
+		effectiveThreshold = req.IdleThresholdMinutes
+	}
+	if effectiveThreshold < 1 {
+		effectiveThreshold = incus.DefaultIdleThresholdMinutes
+	}
+
+	enabledStr := "false"
+	if req.Enabled {
+		enabledStr = "true"
+	}
+	if err := s.manager.SetConfig(containerName, incus.AutoSleepEnabledKey, enabledStr); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to set %s: %v", incus.AutoSleepEnabledKey, err)
+	}
+	if req.Enabled || req.IdleThresholdMinutes > 0 {
+		if err := s.manager.SetConfig(containerName, incus.IdleThresholdMinutesKey, strconv.Itoa(int(effectiveThreshold))); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to set %s: %v", incus.IdleThresholdMinutesKey, err)
+		}
+	}
+
+	msg := "auto-sleep disabled"
+	if req.Enabled {
+		msg = fmt.Sprintf("auto-sleep enabled at %dm", effectiveThreshold)
+	}
+	return &pb.ToggleAutoSleepResponse{
+		Message:              msg,
+		AutoSleepEnabled:     req.Enabled,
+		IdleThresholdMinutes: effectiveThreshold,
+	}, nil
+}
+
 // AddSSHKey appends an SSH public key to the user's host-side
 // authorized_keys file (/home/<username>/.ssh/authorized_keys).
 //
@@ -1445,16 +1558,18 @@ func toProtoContainer(info *incus.ContainerInfo) *pb.Container {
 		Network: &pb.NetworkInfo{
 			IpAddress: info.IPAddress,
 		},
-		Labels:            info.Labels,
-		CreatedAt:         info.CreatedAt.Unix(),
-		PodmanEnabled:     true,  // TODO: Get from container config
-		Stack:             "",    // TODO: Get from container labels
-		GpuDevice:         info.GPU,
-		BackendId:         info.BackendID,
-		OsType:            osTypeEnum,
-		AccessType:        accessType,
-		RdpAddress:        rdpAddress,
-		MonitoringEnabled: info.MonitoringEnabled,
+		Labels:               info.Labels,
+		CreatedAt:            info.CreatedAt.Unix(),
+		PodmanEnabled:        true,  // TODO: Get from container config
+		Stack:                "",    // TODO: Get from container labels
+		GpuDevice:            info.GPU,
+		BackendId:            info.BackendID,
+		OsType:               osTypeEnum,
+		AccessType:           accessType,
+		RdpAddress:           rdpAddress,
+		MonitoringEnabled:    info.MonitoringEnabled,
+		AutoSleepEnabled:     info.AutoSleepEnabled,
+		IdleThresholdMinutes: info.IdleThresholdMinutes,
 	}
 }
 

--- a/internal/server/route_lister.go
+++ b/internal/server/route_lister.go
@@ -1,0 +1,21 @@
+package server
+
+import (
+	"context"
+
+	"github.com/footprintai/containarium/internal/app"
+)
+
+// routeLister is the subset of *app.RouteStore that ContainerServer
+// touches. Introduced so waitForContainerReady's dial loop can be
+// unit-tested with an in-memory fake (no pgx pool, no postgres).
+//
+// Method set covers exactly the production call sites in this package
+// (cascadeContainerCleanup, MoveContainer cutover, waitForContainerReady):
+// nothing more. Adding a method here only when a new call site needs it
+// keeps the test surface minimal.
+type routeLister interface {
+	ListByContainer(ctx context.Context, containerName string) ([]*app.RouteRecord, error)
+	Delete(ctx context.Context, fullDomain string) error
+	Save(ctx context.Context, route *app.RouteRecord) error
+}

--- a/internal/server/start_container_wait_test.go
+++ b/internal/server/start_container_wait_test.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/events"
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// newStartContainerTestServer wires a ContainerServer with just enough
+// dependencies for StartContainer to run end-to-end: a mocked backend
+// + the real Manager + a no-op emitter. routeStore is intentionally
+// nil so waitForContainerReady takes its short-circuit fast-path,
+// which lets the test reason about wall-clock without a TCP listener.
+func newStartContainerTestServer(t *testing.T, seed map[string]*incus.ContainerInfo) *ContainerServer {
+	t.Helper()
+	mock := incustest.NewMockBackend()
+	for n, info := range seed {
+		mock.Containers[n] = info
+	}
+	return &ContainerServer{
+		manager: container.NewWithBackend(mock),
+		emitter: events.NewEmitter(events.NewBus()),
+	}
+}
+
+// TestStartContainer_NoWaitDefault — WaitForReady defaults to false;
+// the handler must complete near-instantly without consulting the
+// probe.
+func TestStartContainer_NoWaitDefault(t *testing.T) {
+	s := newStartContainerTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Stopped", IPAddress: "10.0.0.42"},
+	})
+	start := time.Now()
+	resp, err := s.StartContainer(context.Background(), &pb.StartContainerRequest{Username: "alice"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.ReadyTimedOut {
+		t.Errorf("default (no wait) must not report timeout")
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Errorf("no-wait path took %v, expected near-instant", elapsed)
+	}
+}
+
+// TestStartContainer_WaitForReady_NilRouteStoreShortCircuits —
+// wait_for_ready=true with a nil routeStore must still be near-
+// instant (the probe short-circuits to "ready"). Prevents accidental
+// deadlock on daemons that lack --app-hosting.
+func TestStartContainer_WaitForReady_NilRouteStoreShortCircuits(t *testing.T) {
+	s := newStartContainerTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Stopped", IPAddress: "10.0.0.42"},
+	})
+	start := time.Now()
+	resp, err := s.StartContainer(context.Background(), &pb.StartContainerRequest{
+		Username:     "alice",
+		WaitForReady: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.ReadyTimedOut {
+		t.Errorf("nil routeStore must short-circuit, got ReadyTimedOut=true")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("nil routeStore probe took %v, expected near-instant", elapsed)
+	}
+}
+
+// TestStartContainer_WaitForReady_EmptyIPShortCircuits — even with a
+// non-nil routeStore (we still leave it nil here, but the impl checks
+// IP before consulting the store), an empty IP must not stall.
+func TestStartContainer_WaitForReady_EmptyIPShortCircuits(t *testing.T) {
+	s := newStartContainerTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Stopped", IPAddress: ""},
+	})
+	start := time.Now()
+	resp, err := s.StartContainer(context.Background(), &pb.StartContainerRequest{
+		Username:            "alice",
+		WaitForReady:        true,
+		ReadyTimeoutSeconds: 1,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.ReadyTimedOut {
+		t.Errorf("empty IP must short-circuit, got ReadyTimedOut=true")
+	}
+	if elapsed := time.Since(start); elapsed > 300*time.Millisecond {
+		t.Errorf("empty-IP probe took %v, expected near-instant", elapsed)
+	}
+}
+
+// TestStartContainer_MissingUsername — request validation.
+func TestStartContainer_MissingUsername(t *testing.T) {
+	s := newStartContainerTestServer(t, nil)
+	_, err := s.StartContainer(context.Background(), &pb.StartContainerRequest{})
+	if err == nil {
+		t.Fatal("expected error for empty username")
+	}
+}
+
+// TestStartContainer_StartFailureSurfaces — when manager.Start fails
+// and there's no peer pool, the error propagates rather than getting
+// silently swallowed.
+func TestStartContainer_StartFailureSurfaces(t *testing.T) {
+	mock := incustest.NewMockBackend()
+	mock.StartContainerFunc = func(_ string) error {
+		return errors.New("incus refused")
+	}
+	s := &ContainerServer{
+		manager: container.NewWithBackend(mock),
+		emitter: events.NewEmitter(events.NewBus()),
+	}
+	_, err := s.StartContainer(context.Background(), &pb.StartContainerRequest{Username: "alice"})
+	if err == nil {
+		t.Fatal("expected error when manager.Start fails")
+	}
+}
+
+// TestStartContainer_ResponsePopulatesContainerName — the response
+// must include the *toProtoContainer* shape so MCP/CLI callers can
+// display state, not just the message.
+func TestStartContainer_ResponsePopulatesContainerName(t *testing.T) {
+	s := newStartContainerTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Stopped", IPAddress: "10.0.0.99"},
+	})
+	resp, err := s.StartContainer(context.Background(), &pb.StartContainerRequest{Username: "alice"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Container == nil {
+		t.Fatal("response.Container must be populated")
+	}
+	if resp.Container.Name != "alice-container" {
+		t.Errorf("Container.Name = %q, want alice-container", resp.Container.Name)
+	}
+}

--- a/internal/server/toggle_auto_sleep_test.go
+++ b/internal/server/toggle_auto_sleep_test.go
@@ -1,0 +1,266 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// setConfigCall captures the args of one mocked SetConfig invocation.
+type setConfigCall struct {
+	name  string
+	key   string
+	value string
+}
+
+// newAutoSleepTestServer builds a ContainerServer wired to a mock
+// incus.Backend + a real Manager, returning a slice the caller can
+// inspect after handler invocation. seed populates the mock with
+// initial container state.
+func newAutoSleepTestServer(t *testing.T, seed map[string]*incus.ContainerInfo) (*ContainerServer, *[]setConfigCall, *incustest.MockBackend) {
+	t.Helper()
+	mock := incustest.NewMockBackend()
+	for name, info := range seed {
+		mock.Containers[name] = info
+	}
+	var mu sync.Mutex
+	calls := make([]setConfigCall, 0, 4)
+	mock.SetConfigFunc = func(name, key, value string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, setConfigCall{name: name, key: key, value: value})
+		// Also persist into the mock state so subsequent Get() reflects
+		// the change — mirrors real Incus semantics.
+		if c, ok := mock.Containers[name]; ok {
+			if key == incus.AutoSleepEnabledKey {
+				c.AutoSleepEnabled = value == "true"
+			}
+			if key == incus.IdleThresholdMinutesKey {
+				if n, err := strconv.Atoi(value); err == nil {
+					c.IdleThresholdMinutes = int32(n)
+				}
+			}
+		}
+		return nil
+	}
+	mgr := container.NewWithBackend(mock)
+	return &ContainerServer{manager: mgr}, &calls, mock
+}
+
+// TestToggleAutoSleep_EnableSetsFlagsAndThreshold — happy path: both
+// the flag and an explicit threshold land in two SetConfig calls.
+func TestToggleAutoSleep_EnableSetsFlagsAndThreshold(t *testing.T) {
+	s, calls, _ := newAutoSleepTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Running"},
+	})
+	resp, err := s.ToggleAutoSleep(context.Background(), &pb.ToggleAutoSleepRequest{
+		Username:             "alice",
+		Enabled:              true,
+		IdleThresholdMinutes: 30,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.AutoSleepEnabled || resp.IdleThresholdMinutes != 30 {
+		t.Errorf("response = %+v, want enabled=true, threshold=30", resp)
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("expected 2 SetConfig calls, got %d: %+v", len(*calls), *calls)
+	}
+	wantPairs := map[string]string{
+		incus.AutoSleepEnabledKey:     "true",
+		incus.IdleThresholdMinutesKey: "30",
+	}
+	for _, c := range *calls {
+		if c.name != "alice-container" {
+			t.Errorf("SetConfig name = %q, want alice-container", c.name)
+		}
+		if want, ok := wantPairs[c.key]; ok {
+			if c.value != want {
+				t.Errorf("SetConfig(%q) = %q, want %q", c.key, c.value, want)
+			}
+			delete(wantPairs, c.key)
+		} else {
+			t.Errorf("unexpected SetConfig key: %q", c.key)
+		}
+	}
+	if len(wantPairs) != 0 {
+		t.Errorf("missing SetConfig calls for: %v", wantPairs)
+	}
+}
+
+// TestToggleAutoSleep_DisableSetsFlagOnly — disable writes only the
+// enabled key. Threshold key is omitted so a re-enable restores
+// whatever value the operator previously set.
+func TestToggleAutoSleep_DisableSetsFlagOnly(t *testing.T) {
+	s, calls, _ := newAutoSleepTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {
+			Name: "alice-container", State: "Running",
+			AutoSleepEnabled: true, IdleThresholdMinutes: 30,
+		},
+	})
+	resp, err := s.ToggleAutoSleep(context.Background(), &pb.ToggleAutoSleepRequest{
+		Username: "alice",
+		Enabled:  false,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.AutoSleepEnabled {
+		t.Errorf("response.AutoSleepEnabled = true, want false")
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 SetConfig call on disable, got %d: %+v", len(*calls), *calls)
+	}
+	if (*calls)[0].key != incus.AutoSleepEnabledKey || (*calls)[0].value != "false" {
+		t.Errorf("disable call = %+v, want %s=false", (*calls)[0], incus.AutoSleepEnabledKey)
+	}
+}
+
+// TestToggleAutoSleep_DefaultThreshold — enable with idle=0 should
+// apply the existing key (if present) or the package default.
+func TestToggleAutoSleep_DefaultThreshold(t *testing.T) {
+	s, calls, _ := newAutoSleepTestServer(t, map[string]*incus.ContainerInfo{
+		// IdleThresholdMinutes set to default by parseIdleThresholdMinutes
+		// when the mock omits the key — mirror that by setting the field.
+		"alice-container": {
+			Name: "alice-container", State: "Running",
+			IdleThresholdMinutes: incus.DefaultIdleThresholdMinutes,
+		},
+	})
+	resp, err := s.ToggleAutoSleep(context.Background(), &pb.ToggleAutoSleepRequest{
+		Username:             "alice",
+		Enabled:              true,
+		IdleThresholdMinutes: 0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.IdleThresholdMinutes != incus.DefaultIdleThresholdMinutes {
+		t.Errorf("response threshold = %d, want default %d",
+			resp.IdleThresholdMinutes, incus.DefaultIdleThresholdMinutes)
+	}
+	// Find the threshold SetConfig call — must encode the default.
+	var sawThresholdSet bool
+	for _, c := range *calls {
+		if c.key == incus.IdleThresholdMinutesKey {
+			sawThresholdSet = true
+			if c.value != strconv.Itoa(incus.DefaultIdleThresholdMinutes) {
+				t.Errorf("threshold SetConfig value = %q, want %d", c.value, incus.DefaultIdleThresholdMinutes)
+			}
+		}
+	}
+	if !sawThresholdSet {
+		t.Errorf("expected threshold SetConfig with default; calls = %+v", *calls)
+	}
+}
+
+// TestToggleAutoSleep_CoreContainerRejected — core containers are not
+// user workloads; the handler must refuse and not call SetConfig.
+func TestToggleAutoSleep_CoreContainerRejected(t *testing.T) {
+	s, calls, _ := newAutoSleepTestServer(t, map[string]*incus.ContainerInfo{
+		"caddy-container": {
+			Name: "caddy-container", State: "Running",
+			Role: incus.RoleCaddy,
+		},
+	})
+	_, err := s.ToggleAutoSleep(context.Background(), &pb.ToggleAutoSleepRequest{
+		Username: "caddy",
+		Enabled:  true,
+	})
+	if err == nil {
+		t.Fatal("expected error for core container")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("error = %v, want InvalidArgument status", err)
+	}
+	if len(*calls) != 0 {
+		t.Errorf("core container rejection must not call SetConfig, got %d calls", len(*calls))
+	}
+}
+
+// TestToggleAutoSleep_NoSuchContainer — unknown username maps to a
+// NotFound gRPC status code.
+func TestToggleAutoSleep_NoSuchContainer(t *testing.T) {
+	mock := incustest.NewMockBackend()
+	mock.GetContainerFunc = func(name string) (*incus.ContainerInfo, error) {
+		return nil, errors.New("container not found: " + name)
+	}
+	s := &ContainerServer{manager: container.NewWithBackend(mock)}
+	_, err := s.ToggleAutoSleep(context.Background(), &pb.ToggleAutoSleepRequest{
+		Username: "ghost",
+		Enabled:  true,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing container")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.NotFound {
+		t.Errorf("error = %v, want NotFound status", err)
+	}
+}
+
+// TestToggleAutoSleep_MissingUsername — universal precondition check.
+func TestToggleAutoSleep_MissingUsername(t *testing.T) {
+	s := &ContainerServer{}
+	_, err := s.ToggleAutoSleep(context.Background(), &pb.ToggleAutoSleepRequest{Enabled: true})
+	if err == nil {
+		t.Fatal("expected error for empty username")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("error = %v, want InvalidArgument status", err)
+	}
+}
+
+// TestToggleAutoSleep_AcceptsStoppedContainer locks the brief's
+// requirement: the toggle works on stopped containers too (Incus
+// accepts config updates in either state).
+func TestToggleAutoSleep_AcceptsStoppedContainer(t *testing.T) {
+	s, calls, _ := newAutoSleepTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Stopped"},
+	})
+	resp, err := s.ToggleAutoSleep(context.Background(), &pb.ToggleAutoSleepRequest{
+		Username:             "alice",
+		Enabled:              true,
+		IdleThresholdMinutes: 20,
+	})
+	if err != nil {
+		t.Fatalf("stopped container must be accepted, got error: %v", err)
+	}
+	if !resp.AutoSleepEnabled || resp.IdleThresholdMinutes != 20 {
+		t.Errorf("response = %+v, want enabled=true threshold=20", resp)
+	}
+	if len(*calls) != 2 {
+		t.Errorf("stopped container should still trigger both SetConfig calls, got %d", len(*calls))
+	}
+}
+
+// TestToggleAutoSleep_NegativeThresholdClampsToDefault — current
+// impl: negative `idle_threshold_minutes` falls through the `> 0`
+// gate, so the stored container threshold (or default) wins. Lock
+// that behavior.
+func TestToggleAutoSleep_NegativeThresholdClampsToDefault(t *testing.T) {
+	s, _, _ := newAutoSleepTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Running",
+			IdleThresholdMinutes: incus.DefaultIdleThresholdMinutes},
+	})
+	resp, err := s.ToggleAutoSleep(context.Background(), &pb.ToggleAutoSleepRequest{
+		Username:             "alice",
+		Enabled:              true,
+		IdleThresholdMinutes: -5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.IdleThresholdMinutes != incus.DefaultIdleThresholdMinutes {
+		t.Errorf("threshold = %d, want default %d", resp.IdleThresholdMinutes, incus.DefaultIdleThresholdMinutes)
+	}
+}

--- a/internal/server/wait_for_ready_test.go
+++ b/internal/server/wait_for_ready_test.go
@@ -2,9 +2,49 @@ package server
 
 import (
 	"context"
+	"errors"
+	"net"
+	"strconv"
 	"testing"
 	"time"
+
+	"github.com/footprintai/containarium/internal/app"
 )
+
+type fakeRouteLister struct {
+	routes []*app.RouteRecord
+	err    error
+}
+
+func (f *fakeRouteLister) ListByContainer(ctx context.Context, name string) ([]*app.RouteRecord, error) {
+	return f.routes, f.err
+}
+
+func (f *fakeRouteLister) Delete(ctx context.Context, fullDomain string) error { return nil }
+
+func (f *fakeRouteLister) Save(ctx context.Context, r *app.RouteRecord) error { return nil }
+
+func listenLocal(t *testing.T) (net.Listener, int) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	return ln, ln.Addr().(*net.TCPAddr).Port
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	return port
+}
 
 // TestWaitForContainerReady_NilRouteStore — when the daemon was
 // started without --app-hosting, routeStore is nil and the probe must
@@ -55,3 +95,96 @@ func TestWaitForContainerReady_CtxCancelledBeforeStart(t *testing.T) {
 		t.Fatal("waitForContainerReady did not return on cancelled ctx within 1s")
 	}
 }
+
+func TestWaitForContainerReady_ListenerImmediatelyOpen(t *testing.T) {
+	ln, port := listenLocal(t)
+	defer ln.Close()
+	s := &ContainerServer{
+		routeStore: &fakeRouteLister{routes: []*app.RouteRecord{{TargetPort: port}}},
+	}
+	start := time.Now()
+	timedOut := s.waitForContainerReady(context.Background(), "alice", "127.0.0.1", 5*time.Second)
+	elapsed := time.Since(start)
+	if timedOut {
+		t.Errorf("open listener should not time out")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("immediate-success probe took %v, want <500ms", elapsed)
+	}
+}
+
+func TestWaitForContainerReady_ListenerOpensAfterDelay(t *testing.T) {
+	port := freePort(t)
+	openAt := 600 * time.Millisecond
+	go func() {
+		time.Sleep(openAt)
+		ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		if err != nil {
+			return
+		}
+		// Hold the listener open long enough for the probe to dial it.
+		time.AfterFunc(3*time.Second, func() { _ = ln.Close() })
+	}()
+	s := &ContainerServer{
+		routeStore: &fakeRouteLister{routes: []*app.RouteRecord{{TargetPort: port}}},
+	}
+	start := time.Now()
+	timedOut := s.waitForContainerReady(context.Background(), "alice", "127.0.0.1", 5*time.Second)
+	elapsed := time.Since(start)
+	if timedOut {
+		t.Errorf("delayed listener should not time out")
+	}
+	// Probe polls every ~250ms after a near-instant loopback RST; first
+	// successful dial lands shortly after openAt. Allow CI jitter.
+	if elapsed < 500*time.Millisecond || elapsed > 1500*time.Millisecond {
+		t.Errorf("elapsed = %v, want roughly %v ± 500ms", elapsed, openAt)
+	}
+}
+
+func TestWaitForContainerReady_NeverOpens(t *testing.T) {
+	port := freePort(t)
+	s := &ContainerServer{
+		routeStore: &fakeRouteLister{routes: []*app.RouteRecord{{TargetPort: port}}},
+	}
+	start := time.Now()
+	timedOut := s.waitForContainerReady(context.Background(), "alice", "127.0.0.1", 1*time.Second)
+	elapsed := time.Since(start)
+	if !timedOut {
+		t.Errorf("no listener should time out")
+	}
+	if elapsed < 900*time.Millisecond || elapsed > 1500*time.Millisecond {
+		t.Errorf("elapsed = %v, want ~1s", elapsed)
+	}
+}
+
+func TestWaitForContainerReady_ExplicitTimeoutHonored(t *testing.T) {
+	port := freePort(t)
+	s := &ContainerServer{
+		routeStore: &fakeRouteLister{routes: []*app.RouteRecord{{TargetPort: port}}},
+	}
+	start := time.Now()
+	timedOut := s.waitForContainerReady(context.Background(), "alice", "127.0.0.1", 2*time.Second)
+	elapsed := time.Since(start)
+	if !timedOut {
+		t.Errorf("no listener should time out")
+	}
+	if elapsed < 1900*time.Millisecond || elapsed > 2500*time.Millisecond {
+		t.Errorf("elapsed = %v, want ~2s", elapsed)
+	}
+}
+
+func TestWaitForContainerReady_ListByContainerErrors(t *testing.T) {
+	s := &ContainerServer{
+		routeStore: &fakeRouteLister{err: errors.New("db down")},
+	}
+	start := time.Now()
+	timedOut := s.waitForContainerReady(context.Background(), "alice", "127.0.0.1", 5*time.Second)
+	elapsed := time.Since(start)
+	if timedOut {
+		t.Errorf("route-lookup error should short-circuit to ready, got timedOut=true")
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("error path should return immediately, took %v", elapsed)
+	}
+}
+

--- a/internal/server/wait_for_ready_test.go
+++ b/internal/server/wait_for_ready_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestWaitForContainerReady_NilRouteStore — when the daemon was
+// started without --app-hosting, routeStore is nil and the probe must
+// short-circuit to "ready" (false = not timed out). Anything else
+// would block start_container against daemons with no route store.
+func TestWaitForContainerReady_NilRouteStore(t *testing.T) {
+	s := &ContainerServer{} // routeStore deliberately nil
+	start := time.Now()
+	timedOut := s.waitForContainerReady(context.Background(), "alice", "10.0.0.1", 5*time.Second)
+	if timedOut {
+		t.Errorf("nil routeStore should short-circuit to ready, got timedOut=true")
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("nil routeStore should return immediately, took %v", elapsed)
+	}
+}
+
+// TestWaitForContainerReady_EmptyContainerIP — same fast-path when
+// the container has no IP yet. The probe has nothing to dial against
+// so it returns "ready" rather than blocking for the full timeout.
+func TestWaitForContainerReady_EmptyContainerIP(t *testing.T) {
+	s := &ContainerServer{} // also exercises nil routeStore path, but the IP check would also short-circuit.
+	start := time.Now()
+	timedOut := s.waitForContainerReady(context.Background(), "alice", "", 5*time.Second)
+	if timedOut {
+		t.Errorf("empty containerIP should short-circuit to ready, got timedOut=true")
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("empty IP should return immediately, took %v", elapsed)
+	}
+}
+
+// TestWaitForContainerReady_CtxCancelledBeforeStart — even when both
+// fast-paths trip, the helper must complete; this guards against a
+// regression where someone adds a long-running operation before the
+// nil/IP checks.
+func TestWaitForContainerReady_CtxCancelledBeforeStart(t *testing.T) {
+	s := &ContainerServer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan bool, 1)
+	go func() {
+		done <- s.waitForContainerReady(ctx, "alice", "", 5*time.Second)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("waitForContainerReady did not return on cancelled ctx within 1s")
+	}
+}

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -663,6 +663,13 @@ func (m *Manager) UnsetEnv(containerName, key string) error {
 	return fmt.Errorf("UnsetEnv not supported on this incus backend (mock?)")
 }
 
+// SetConfig writes an arbitrary Incus config key on a container.
+// Used by ToggleAutoSleep to persist the user.containarium.* keys
+// that Phase 2 and Phase 3 will read.
+func (m *Manager) SetConfig(containerName, key, value string) error {
+	return m.incus.SetConfig(containerName, key, value)
+}
+
 func (m *Manager) Get(username string) (*incus.ContainerInfo, error) {
 	containerName := username + "-container"
 	return m.incus.GetContainer(containerName)

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -267,6 +267,40 @@ type ContainerInfo struct {
 	// the Incus config map rather than tracked as a separate
 	// flag — single source of truth.
 	MonitoringEnabled bool
+
+	// AutoSleepEnabled mirrors user.containarium.auto_sleep_enabled
+	// on the Incus config — opt-in flag for the serverless feature.
+	AutoSleepEnabled bool
+
+	// IdleThresholdMinutes mirrors user.containarium.idle_threshold_minutes;
+	// defaults to 15 when the key is missing or unparseable.
+	IdleThresholdMinutes int32
+}
+
+// AutoSleepEnabledKey is the Incus config key storing the per-container
+// auto-sleep opt-in flag (Phase 1 of the serverless feature).
+const AutoSleepEnabledKey = "user.containarium.auto_sleep_enabled"
+
+// IdleThresholdMinutesKey is the Incus config key storing the per-container
+// idle threshold in minutes consumed by the Phase 2 auto-sleep ticker.
+const IdleThresholdMinutesKey = "user.containarium.idle_threshold_minutes"
+
+// DefaultIdleThresholdMinutes is the fallback used when the threshold
+// config key is missing or unparseable.
+const DefaultIdleThresholdMinutes = 15
+
+// parseIdleThresholdMinutes reads the threshold key from an Incus
+// config map, falling back to the default for empty/garbage values.
+func parseIdleThresholdMinutes(cfg map[string]string) int32 {
+	raw, ok := cfg[IdleThresholdMinutesKey]
+	if !ok || raw == "" {
+		return DefaultIdleThresholdMinutes
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return DefaultIdleThresholdMinutes
+	}
+	return int32(n)
 }
 
 // ContainerMetrics holds runtime metrics for a container
@@ -520,13 +554,15 @@ func (c *Client) ListContainers() ([]ContainerInfo, error) {
 		}
 
 		info := ContainerInfo{
-			Name:              inst.Name,
-			State:             inst.Status,
-			InstanceType:      inst.Type,
-			CreatedAt:         inst.CreatedAt,
-			Labels:            extractLabelsFromConfig(inst.Config),
-			Role:              Role(inst.Config[RoleKey]),
-			MonitoringEnabled: inst.Config["environment.OTEL_EXPORTER_OTLP_ENDPOINT"] != "",
+			Name:                 inst.Name,
+			State:                inst.Status,
+			InstanceType:         inst.Type,
+			CreatedAt:            inst.CreatedAt,
+			Labels:               extractLabelsFromConfig(inst.Config),
+			Role:                 Role(inst.Config[RoleKey]),
+			MonitoringEnabled:    inst.Config["environment.OTEL_EXPORTER_OTLP_ENDPOINT"] != "",
+			AutoSleepEnabled:     inst.Config[AutoSleepEnabledKey] == "true",
+			IdleThresholdMinutes: parseIdleThresholdMinutes(inst.Config),
 		}
 
 		// Get CPU and memory limits from config
@@ -645,12 +681,14 @@ func (c *Client) GetContainer(name string) (*ContainerInfo, error) {
 	}
 
 	info := &ContainerInfo{
-		Name:              inst.Name,
-		State:             inst.Status,
-		CreatedAt:         inst.CreatedAt,
-		Labels:            extractLabelsFromConfig(inst.Config),
-		Role:              Role(inst.Config[RoleKey]),
-		MonitoringEnabled: inst.Config["environment.OTEL_EXPORTER_OTLP_ENDPOINT"] != "",
+		Name:                 inst.Name,
+		State:                inst.Status,
+		CreatedAt:            inst.CreatedAt,
+		Labels:               extractLabelsFromConfig(inst.Config),
+		Role:                 Role(inst.Config[RoleKey]),
+		MonitoringEnabled:    inst.Config["environment.OTEL_EXPORTER_OTLP_ENDPOINT"] != "",
+		AutoSleepEnabled:     inst.Config[AutoSleepEnabledKey] == "true",
+		IdleThresholdMinutes: parseIdleThresholdMinutes(inst.Config),
 	}
 
 	// Get resource limits

--- a/pkg/core/incus/scale_down_helpers_test.go
+++ b/pkg/core/incus/scale_down_helpers_test.go
@@ -1,0 +1,50 @@
+package incus
+
+import "testing"
+
+// parseIdleThresholdMinutes reads the per-container idle threshold
+// from the Incus config map. The helper falls back to
+// DefaultIdleThresholdMinutes (15) for any value that fails to parse
+// as a positive int — that includes missing keys, empty strings,
+// non-numeric junk, zero, and negative numbers. Values are returned
+// as int32 with no upper bound clamp.
+func TestParseIdleThresholdMinutes(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  map[string]string
+		want int32
+	}{
+		{"missing key falls back to default", map[string]string{}, DefaultIdleThresholdMinutes},
+		{"empty string falls back to default", map[string]string{IdleThresholdMinutesKey: ""}, DefaultIdleThresholdMinutes},
+		{"valid 15", map[string]string{IdleThresholdMinutesKey: "15"}, 15},
+		{"valid 1440 (one day)", map[string]string{IdleThresholdMinutesKey: "1440"}, 1440},
+		{"non-numeric garbage falls back", map[string]string{IdleThresholdMinutesKey: "abc"}, DefaultIdleThresholdMinutes},
+		{"negative value falls back", map[string]string{IdleThresholdMinutesKey: "-5"}, DefaultIdleThresholdMinutes},
+		{"zero falls back (n < 1)", map[string]string{IdleThresholdMinutesKey: "0"}, DefaultIdleThresholdMinutes},
+		// No upper-bound clamp today — large values pass through.
+		{"no upper bound clamp", map[string]string{IdleThresholdMinutesKey: "99999"}, 99999},
+		// Atoi does not trim whitespace — " 30 " is unparseable.
+		{"surrounding whitespace falls back", map[string]string{IdleThresholdMinutesKey: " 30 "}, DefaultIdleThresholdMinutes},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseIdleThresholdMinutes(tc.cfg); got != tc.want {
+				t.Errorf("parseIdleThresholdMinutes(%v) = %d, want %d", tc.cfg, got, tc.want)
+			}
+		})
+	}
+}
+
+// Constants used by the auto-sleep feature should be stable so
+// upgrade paths don't silently re-default operator config.
+func TestAutoSleepConstants(t *testing.T) {
+	if AutoSleepEnabledKey != "user.containarium.auto_sleep_enabled" {
+		t.Errorf("AutoSleepEnabledKey = %q, must remain stable across releases", AutoSleepEnabledKey)
+	}
+	if IdleThresholdMinutesKey != "user.containarium.idle_threshold_minutes" {
+		t.Errorf("IdleThresholdMinutesKey = %q, must remain stable across releases", IdleThresholdMinutesKey)
+	}
+	if DefaultIdleThresholdMinutes != 15 {
+		t.Errorf("DefaultIdleThresholdMinutes = %d, want 15", DefaultIdleThresholdMinutes)
+	}
+}

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -395,9 +395,18 @@ type Container struct {
 	// "demo", "lab"). Mirrors the peer's --pool registration tag and
 	// is the discriminator used for placement and per-pool routing
 	// (such as base-domain selection). Empty for untagged backends.
-	Pool          string `protobuf:"bytes,19,opt,name=pool,proto3" json:"pool,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Pool string `protobuf:"bytes,19,opt,name=pool,proto3" json:"pool,omitempty"`
+	// Whether the container is opted into manual auto-sleep tracking
+	// (Phase 1 of the serverless feature). Read-only; toggled via
+	// ToggleAutoSleep. Backed by the user.containarium.auto_sleep_enabled
+	// Incus config key.
+	AutoSleepEnabled bool `protobuf:"varint,20,opt,name=auto_sleep_enabled,json=autoSleepEnabled,proto3" json:"auto_sleep_enabled,omitempty"`
+	// Idle minutes before the Phase 2 auto-sleep daemon would stop
+	// the container. Defaults to 15 when unset. Backed by the
+	// user.containarium.idle_threshold_minutes Incus config key.
+	IdleThresholdMinutes int32 `protobuf:"varint,21,opt,name=idle_threshold_minutes,json=idleThresholdMinutes,proto3" json:"idle_threshold_minutes,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Container) Reset() {
@@ -561,6 +570,20 @@ func (x *Container) GetPool() string {
 		return x.Pool
 	}
 	return ""
+}
+
+func (x *Container) GetAutoSleepEnabled() bool {
+	if x != nil {
+		return x.AutoSleepEnabled
+	}
+	return false
+}
+
+func (x *Container) GetIdleThresholdMinutes() int32 {
+	if x != nil {
+		return x.IdleThresholdMinutes
+	}
+	return 0
 }
 
 // ContainerMetrics contains runtime metrics for a container
@@ -1438,9 +1461,19 @@ func (x *DeleteContainerResponse) GetContainerName() string {
 type StartContainerRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Username of the container to start
-	Username      string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
+	// When true, the server blocks until the container's primary TCP
+	// port (from its route record) is accepting connections, or
+	// ready_timeout_seconds elapses. If the container has no route the
+	// probe is skipped. Used by `containarium wake` to give callers an
+	// "actually serving" signal rather than just "incus says started".
+	WaitForReady bool `protobuf:"varint,2,opt,name=wait_for_ready,json=waitForReady,proto3" json:"wait_for_ready,omitempty"`
+	// Timeout for the readiness probe in seconds. Zero falls back to
+	// the server-side default (30s). Ignored when wait_for_ready is
+	// false.
+	ReadyTimeoutSeconds int32 `protobuf:"varint,3,opt,name=ready_timeout_seconds,json=readyTimeoutSeconds,proto3" json:"ready_timeout_seconds,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *StartContainerRequest) Reset() {
@@ -1480,13 +1513,32 @@ func (x *StartContainerRequest) GetUsername() string {
 	return ""
 }
 
+func (x *StartContainerRequest) GetWaitForReady() bool {
+	if x != nil {
+		return x.WaitForReady
+	}
+	return false
+}
+
+func (x *StartContainerRequest) GetReadyTimeoutSeconds() int32 {
+	if x != nil {
+		return x.ReadyTimeoutSeconds
+	}
+	return 0
+}
+
 // StartContainerResponse is the response from starting a container
 type StartContainerResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Success message
 	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
 	// Updated container state
-	Container     *Container `protobuf:"bytes,2,opt,name=container,proto3" json:"container,omitempty"`
+	Container *Container `protobuf:"bytes,2,opt,name=container,proto3" json:"container,omitempty"`
+	// True when wait_for_ready was set but the readiness probe timed
+	// out before the primary port accepted. The container is started
+	// either way — the caller can retry the probe or accept the start
+	// as best-effort.
+	ReadyTimedOut bool `protobuf:"varint,3,opt,name=ready_timed_out,json=readyTimedOut,proto3" json:"ready_timed_out,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1533,6 +1585,13 @@ func (x *StartContainerResponse) GetContainer() *Container {
 		return x.Container
 	}
 	return nil
+}
+
+func (x *StartContainerResponse) GetReadyTimedOut() bool {
+	if x != nil {
+		return x.ReadyTimedOut
+	}
+	return false
 }
 
 // StopContainerRequest is the request to stop a container
@@ -1772,6 +1831,140 @@ func (x *ToggleMonitoringResponse) GetMonitoringEnabled() bool {
 	return false
 }
 
+// ToggleAutoSleepRequest opts a container into (or out of) auto-sleep
+// tracking. The flag and threshold are stored as Incus user.* config
+// keys; the actual sleep tick (Phase 2) and HTTP wake (Phase 3) are
+// separate work. This RPC only writes the metadata.
+type ToggleAutoSleepRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Username of the container.
+	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
+	// Desired state. true → write user.containarium.auto_sleep_enabled
+	// = "true". false → write "false" (the threshold key is left in
+	// place so a re-enable picks up the prior value).
+	Enabled bool `protobuf:"varint,2,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// Idle minutes before Phase 2 would stop the container. Ignored
+	// when enabled=false; 0 means "use existing key or fall back to 15".
+	IdleThresholdMinutes int32 `protobuf:"varint,3,opt,name=idle_threshold_minutes,json=idleThresholdMinutes,proto3" json:"idle_threshold_minutes,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *ToggleAutoSleepRequest) Reset() {
+	*x = ToggleAutoSleepRequest{}
+	mi := &file_containarium_v1_container_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ToggleAutoSleepRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ToggleAutoSleepRequest) ProtoMessage() {}
+
+func (x *ToggleAutoSleepRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ToggleAutoSleepRequest.ProtoReflect.Descriptor instead.
+func (*ToggleAutoSleepRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *ToggleAutoSleepRequest) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *ToggleAutoSleepRequest) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *ToggleAutoSleepRequest) GetIdleThresholdMinutes() int32 {
+	if x != nil {
+		return x.IdleThresholdMinutes
+	}
+	return 0
+}
+
+// ToggleAutoSleepResponse reports the effective auto-sleep state.
+type ToggleAutoSleepResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Operator-facing summary (e.g. "auto-sleep enabled at 15m").
+	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	// The effective auto_sleep_enabled state after the toggle.
+	AutoSleepEnabled bool `protobuf:"varint,2,opt,name=auto_sleep_enabled,json=autoSleepEnabled,proto3" json:"auto_sleep_enabled,omitempty"`
+	// The effective idle_threshold_minutes value (15 if defaulted).
+	IdleThresholdMinutes int32 `protobuf:"varint,3,opt,name=idle_threshold_minutes,json=idleThresholdMinutes,proto3" json:"idle_threshold_minutes,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *ToggleAutoSleepResponse) Reset() {
+	*x = ToggleAutoSleepResponse{}
+	mi := &file_containarium_v1_container_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ToggleAutoSleepResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ToggleAutoSleepResponse) ProtoMessage() {}
+
+func (x *ToggleAutoSleepResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ToggleAutoSleepResponse.ProtoReflect.Descriptor instead.
+func (*ToggleAutoSleepResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *ToggleAutoSleepResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *ToggleAutoSleepResponse) GetAutoSleepEnabled() bool {
+	if x != nil {
+		return x.AutoSleepEnabled
+	}
+	return false
+}
+
+func (x *ToggleAutoSleepResponse) GetIdleThresholdMinutes() int32 {
+	if x != nil {
+		return x.IdleThresholdMinutes
+	}
+	return 0
+}
+
 // AddSSHKeyRequest is the request to add an SSH key to a container
 type AddSSHKeyRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1785,7 +1978,7 @@ type AddSSHKeyRequest struct {
 
 func (x *AddSSHKeyRequest) Reset() {
 	*x = AddSSHKeyRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[20]
+	mi := &file_containarium_v1_container_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1797,7 +1990,7 @@ func (x *AddSSHKeyRequest) String() string {
 func (*AddSSHKeyRequest) ProtoMessage() {}
 
 func (x *AddSSHKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[20]
+	mi := &file_containarium_v1_container_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1810,7 +2003,7 @@ func (x *AddSSHKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddSSHKeyRequest.ProtoReflect.Descriptor instead.
 func (*AddSSHKeyRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{20}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *AddSSHKeyRequest) GetUsername() string {
@@ -1840,7 +2033,7 @@ type AddSSHKeyResponse struct {
 
 func (x *AddSSHKeyResponse) Reset() {
 	*x = AddSSHKeyResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[21]
+	mi := &file_containarium_v1_container_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1852,7 +2045,7 @@ func (x *AddSSHKeyResponse) String() string {
 func (*AddSSHKeyResponse) ProtoMessage() {}
 
 func (x *AddSSHKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[21]
+	mi := &file_containarium_v1_container_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1865,7 +2058,7 @@ func (x *AddSSHKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddSSHKeyResponse.ProtoReflect.Descriptor instead.
 func (*AddSSHKeyResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{21}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *AddSSHKeyResponse) GetMessage() string {
@@ -1895,7 +2088,7 @@ type RemoveSSHKeyRequest struct {
 
 func (x *RemoveSSHKeyRequest) Reset() {
 	*x = RemoveSSHKeyRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[22]
+	mi := &file_containarium_v1_container_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1907,7 +2100,7 @@ func (x *RemoveSSHKeyRequest) String() string {
 func (*RemoveSSHKeyRequest) ProtoMessage() {}
 
 func (x *RemoveSSHKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[22]
+	mi := &file_containarium_v1_container_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1920,7 +2113,7 @@ func (x *RemoveSSHKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSSHKeyRequest.ProtoReflect.Descriptor instead.
 func (*RemoveSSHKeyRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{22}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *RemoveSSHKeyRequest) GetUsername() string {
@@ -1950,7 +2143,7 @@ type RemoveSSHKeyResponse struct {
 
 func (x *RemoveSSHKeyResponse) Reset() {
 	*x = RemoveSSHKeyResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[23]
+	mi := &file_containarium_v1_container_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1962,7 +2155,7 @@ func (x *RemoveSSHKeyResponse) String() string {
 func (*RemoveSSHKeyResponse) ProtoMessage() {}
 
 func (x *RemoveSSHKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[23]
+	mi := &file_containarium_v1_container_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1975,7 +2168,7 @@ func (x *RemoveSSHKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSSHKeyResponse.ProtoReflect.Descriptor instead.
 func (*RemoveSSHKeyResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{23}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *RemoveSSHKeyResponse) GetMessage() string {
@@ -2003,7 +2196,7 @@ type GetMetricsRequest struct {
 
 func (x *GetMetricsRequest) Reset() {
 	*x = GetMetricsRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[24]
+	mi := &file_containarium_v1_container_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2015,7 +2208,7 @@ func (x *GetMetricsRequest) String() string {
 func (*GetMetricsRequest) ProtoMessage() {}
 
 func (x *GetMetricsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[24]
+	mi := &file_containarium_v1_container_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2028,7 +2221,7 @@ func (x *GetMetricsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMetricsRequest.ProtoReflect.Descriptor instead.
 func (*GetMetricsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{24}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetMetricsRequest) GetUsername() string {
@@ -2049,7 +2242,7 @@ type GetMetricsResponse struct {
 
 func (x *GetMetricsResponse) Reset() {
 	*x = GetMetricsResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[25]
+	mi := &file_containarium_v1_container_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2061,7 +2254,7 @@ func (x *GetMetricsResponse) String() string {
 func (*GetMetricsResponse) ProtoMessage() {}
 
 func (x *GetMetricsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[25]
+	mi := &file_containarium_v1_container_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2074,7 +2267,7 @@ func (x *GetMetricsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMetricsResponse.ProtoReflect.Descriptor instead.
 func (*GetMetricsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{25}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetMetricsResponse) GetMetrics() []*ContainerMetrics {
@@ -2102,7 +2295,7 @@ type ResizeContainerRequest struct {
 
 func (x *ResizeContainerRequest) Reset() {
 	*x = ResizeContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[26]
+	mi := &file_containarium_v1_container_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2114,7 +2307,7 @@ func (x *ResizeContainerRequest) String() string {
 func (*ResizeContainerRequest) ProtoMessage() {}
 
 func (x *ResizeContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[26]
+	mi := &file_containarium_v1_container_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2127,7 +2320,7 @@ func (x *ResizeContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResizeContainerRequest.ProtoReflect.Descriptor instead.
 func (*ResizeContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{26}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ResizeContainerRequest) GetUsername() string {
@@ -2171,7 +2364,7 @@ type ResizeContainerResponse struct {
 
 func (x *ResizeContainerResponse) Reset() {
 	*x = ResizeContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[27]
+	mi := &file_containarium_v1_container_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2183,7 +2376,7 @@ func (x *ResizeContainerResponse) String() string {
 func (*ResizeContainerResponse) ProtoMessage() {}
 
 func (x *ResizeContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[27]
+	mi := &file_containarium_v1_container_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2196,7 +2389,7 @@ func (x *ResizeContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResizeContainerResponse.ProtoReflect.Descriptor instead.
 func (*ResizeContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{27}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ResizeContainerResponse) GetMessage() string {
@@ -2242,7 +2435,7 @@ type Collaborator struct {
 
 func (x *Collaborator) Reset() {
 	*x = Collaborator{}
-	mi := &file_containarium_v1_container_proto_msgTypes[28]
+	mi := &file_containarium_v1_container_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2254,7 +2447,7 @@ func (x *Collaborator) String() string {
 func (*Collaborator) ProtoMessage() {}
 
 func (x *Collaborator) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[28]
+	mi := &file_containarium_v1_container_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2267,7 +2460,7 @@ func (x *Collaborator) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Collaborator.ProtoReflect.Descriptor instead.
 func (*Collaborator) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{28}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *Collaborator) GetId() string {
@@ -2359,7 +2552,7 @@ type AddCollaboratorRequest struct {
 
 func (x *AddCollaboratorRequest) Reset() {
 	*x = AddCollaboratorRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[29]
+	mi := &file_containarium_v1_container_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2371,7 +2564,7 @@ func (x *AddCollaboratorRequest) String() string {
 func (*AddCollaboratorRequest) ProtoMessage() {}
 
 func (x *AddCollaboratorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[29]
+	mi := &file_containarium_v1_container_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2384,7 +2577,7 @@ func (x *AddCollaboratorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddCollaboratorRequest.ProtoReflect.Descriptor instead.
 func (*AddCollaboratorRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{29}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *AddCollaboratorRequest) GetOwnerUsername() string {
@@ -2437,7 +2630,7 @@ type AddCollaboratorResponse struct {
 
 func (x *AddCollaboratorResponse) Reset() {
 	*x = AddCollaboratorResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[30]
+	mi := &file_containarium_v1_container_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2449,7 +2642,7 @@ func (x *AddCollaboratorResponse) String() string {
 func (*AddCollaboratorResponse) ProtoMessage() {}
 
 func (x *AddCollaboratorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[30]
+	mi := &file_containarium_v1_container_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2462,7 +2655,7 @@ func (x *AddCollaboratorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddCollaboratorResponse.ProtoReflect.Descriptor instead.
 func (*AddCollaboratorResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{30}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *AddCollaboratorResponse) GetMessage() string {
@@ -2499,7 +2692,7 @@ type RemoveCollaboratorRequest struct {
 
 func (x *RemoveCollaboratorRequest) Reset() {
 	*x = RemoveCollaboratorRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[31]
+	mi := &file_containarium_v1_container_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2511,7 +2704,7 @@ func (x *RemoveCollaboratorRequest) String() string {
 func (*RemoveCollaboratorRequest) ProtoMessage() {}
 
 func (x *RemoveCollaboratorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[31]
+	mi := &file_containarium_v1_container_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2524,7 +2717,7 @@ func (x *RemoveCollaboratorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCollaboratorRequest.ProtoReflect.Descriptor instead.
 func (*RemoveCollaboratorRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{31}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *RemoveCollaboratorRequest) GetOwnerUsername() string {
@@ -2552,7 +2745,7 @@ type RemoveCollaboratorResponse struct {
 
 func (x *RemoveCollaboratorResponse) Reset() {
 	*x = RemoveCollaboratorResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[32]
+	mi := &file_containarium_v1_container_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2564,7 +2757,7 @@ func (x *RemoveCollaboratorResponse) String() string {
 func (*RemoveCollaboratorResponse) ProtoMessage() {}
 
 func (x *RemoveCollaboratorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[32]
+	mi := &file_containarium_v1_container_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2577,7 +2770,7 @@ func (x *RemoveCollaboratorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCollaboratorResponse.ProtoReflect.Descriptor instead.
 func (*RemoveCollaboratorResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{32}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *RemoveCollaboratorResponse) GetMessage() string {
@@ -2598,7 +2791,7 @@ type ListCollaboratorsRequest struct {
 
 func (x *ListCollaboratorsRequest) Reset() {
 	*x = ListCollaboratorsRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[33]
+	mi := &file_containarium_v1_container_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2610,7 +2803,7 @@ func (x *ListCollaboratorsRequest) String() string {
 func (*ListCollaboratorsRequest) ProtoMessage() {}
 
 func (x *ListCollaboratorsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[33]
+	mi := &file_containarium_v1_container_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2623,7 +2816,7 @@ func (x *ListCollaboratorsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCollaboratorsRequest.ProtoReflect.Descriptor instead.
 func (*ListCollaboratorsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{33}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ListCollaboratorsRequest) GetOwnerUsername() string {
@@ -2646,7 +2839,7 @@ type ListCollaboratorsResponse struct {
 
 func (x *ListCollaboratorsResponse) Reset() {
 	*x = ListCollaboratorsResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[34]
+	mi := &file_containarium_v1_container_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2658,7 +2851,7 @@ func (x *ListCollaboratorsResponse) String() string {
 func (*ListCollaboratorsResponse) ProtoMessage() {}
 
 func (x *ListCollaboratorsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[34]
+	mi := &file_containarium_v1_container_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2671,7 +2864,7 @@ func (x *ListCollaboratorsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCollaboratorsResponse.ProtoReflect.Descriptor instead.
 func (*ListCollaboratorsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{34}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ListCollaboratorsResponse) GetCollaborators() []*Collaborator {
@@ -2699,7 +2892,7 @@ type CleanupDiskRequest struct {
 
 func (x *CleanupDiskRequest) Reset() {
 	*x = CleanupDiskRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[35]
+	mi := &file_containarium_v1_container_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2711,7 +2904,7 @@ func (x *CleanupDiskRequest) String() string {
 func (*CleanupDiskRequest) ProtoMessage() {}
 
 func (x *CleanupDiskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[35]
+	mi := &file_containarium_v1_container_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2724,7 +2917,7 @@ func (x *CleanupDiskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CleanupDiskRequest.ProtoReflect.Descriptor instead.
 func (*CleanupDiskRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{35}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *CleanupDiskRequest) GetUsername() string {
@@ -2749,7 +2942,7 @@ type CleanupDiskResponse struct {
 
 func (x *CleanupDiskResponse) Reset() {
 	*x = CleanupDiskResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[36]
+	mi := &file_containarium_v1_container_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2761,7 +2954,7 @@ func (x *CleanupDiskResponse) String() string {
 func (*CleanupDiskResponse) ProtoMessage() {}
 
 func (x *CleanupDiskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[36]
+	mi := &file_containarium_v1_container_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2774,7 +2967,7 @@ func (x *CleanupDiskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CleanupDiskResponse.ProtoReflect.Descriptor instead.
 func (*CleanupDiskResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{36}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *CleanupDiskResponse) GetMessage() string {
@@ -2811,7 +3004,7 @@ type InstallStackRequest struct {
 
 func (x *InstallStackRequest) Reset() {
 	*x = InstallStackRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[37]
+	mi := &file_containarium_v1_container_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2823,7 +3016,7 @@ func (x *InstallStackRequest) String() string {
 func (*InstallStackRequest) ProtoMessage() {}
 
 func (x *InstallStackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[37]
+	mi := &file_containarium_v1_container_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2836,7 +3029,7 @@ func (x *InstallStackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InstallStackRequest.ProtoReflect.Descriptor instead.
 func (*InstallStackRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{37}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *InstallStackRequest) GetUsername() string {
@@ -2866,7 +3059,7 @@ type InstallStackResponse struct {
 
 func (x *InstallStackResponse) Reset() {
 	*x = InstallStackResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[38]
+	mi := &file_containarium_v1_container_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2878,7 +3071,7 @@ func (x *InstallStackResponse) String() string {
 func (*InstallStackResponse) ProtoMessage() {}
 
 func (x *InstallStackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[38]
+	mi := &file_containarium_v1_container_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2891,7 +3084,7 @@ func (x *InstallStackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InstallStackResponse.ProtoReflect.Descriptor instead.
 func (*InstallStackResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{38}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *InstallStackResponse) GetMessage() string {
@@ -2931,7 +3124,7 @@ type StackParameter struct {
 
 func (x *StackParameter) Reset() {
 	*x = StackParameter{}
-	mi := &file_containarium_v1_container_proto_msgTypes[39]
+	mi := &file_containarium_v1_container_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2943,7 +3136,7 @@ func (x *StackParameter) String() string {
 func (*StackParameter) ProtoMessage() {}
 
 func (x *StackParameter) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[39]
+	mi := &file_containarium_v1_container_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2956,7 +3149,7 @@ func (x *StackParameter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StackParameter.ProtoReflect.Descriptor instead.
 func (*StackParameter) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{39}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *StackParameter) GetName() string {
@@ -3015,7 +3208,7 @@ type StackInfo struct {
 
 func (x *StackInfo) Reset() {
 	*x = StackInfo{}
-	mi := &file_containarium_v1_container_proto_msgTypes[40]
+	mi := &file_containarium_v1_container_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3027,7 +3220,7 @@ func (x *StackInfo) String() string {
 func (*StackInfo) ProtoMessage() {}
 
 func (x *StackInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[40]
+	mi := &file_containarium_v1_container_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3040,7 +3233,7 @@ func (x *StackInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StackInfo.ProtoReflect.Descriptor instead.
 func (*StackInfo) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{40}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *StackInfo) GetId() string {
@@ -3087,7 +3280,7 @@ type ListStacksRequest struct {
 
 func (x *ListStacksRequest) Reset() {
 	*x = ListStacksRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[41]
+	mi := &file_containarium_v1_container_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3099,7 +3292,7 @@ func (x *ListStacksRequest) String() string {
 func (*ListStacksRequest) ProtoMessage() {}
 
 func (x *ListStacksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[41]
+	mi := &file_containarium_v1_container_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3112,7 +3305,7 @@ func (x *ListStacksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStacksRequest.ProtoReflect.Descriptor instead.
 func (*ListStacksRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{41}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{43}
 }
 
 // ListStacksResponse returns all configured software stacks.
@@ -3125,7 +3318,7 @@ type ListStacksResponse struct {
 
 func (x *ListStacksResponse) Reset() {
 	*x = ListStacksResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[42]
+	mi := &file_containarium_v1_container_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3137,7 +3330,7 @@ func (x *ListStacksResponse) String() string {
 func (*ListStacksResponse) ProtoMessage() {}
 
 func (x *ListStacksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[42]
+	mi := &file_containarium_v1_container_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3150,7 +3343,7 @@ func (x *ListStacksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStacksResponse.ProtoReflect.Descriptor instead.
 func (*ListStacksResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{42}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ListStacksResponse) GetStacks() []*StackInfo {
@@ -3169,7 +3362,7 @@ type GetMonitoringInfoRequest struct {
 
 func (x *GetMonitoringInfoRequest) Reset() {
 	*x = GetMonitoringInfoRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[43]
+	mi := &file_containarium_v1_container_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3181,7 +3374,7 @@ func (x *GetMonitoringInfoRequest) String() string {
 func (*GetMonitoringInfoRequest) ProtoMessage() {}
 
 func (x *GetMonitoringInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[43]
+	mi := &file_containarium_v1_container_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3194,7 +3387,7 @@ func (x *GetMonitoringInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMonitoringInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetMonitoringInfoRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{43}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{45}
 }
 
 // GetMonitoringInfoResponse is the response with monitoring configuration
@@ -3212,7 +3405,7 @@ type GetMonitoringInfoResponse struct {
 
 func (x *GetMonitoringInfoResponse) Reset() {
 	*x = GetMonitoringInfoResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[44]
+	mi := &file_containarium_v1_container_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3224,7 +3417,7 @@ func (x *GetMonitoringInfoResponse) String() string {
 func (*GetMonitoringInfoResponse) ProtoMessage() {}
 
 func (x *GetMonitoringInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[44]
+	mi := &file_containarium_v1_container_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3237,7 +3430,7 @@ func (x *GetMonitoringInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMonitoringInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetMonitoringInfoResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{44}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *GetMonitoringInfoResponse) GetEnabled() bool {
@@ -3296,7 +3489,7 @@ type MoveContainerRequest struct {
 
 func (x *MoveContainerRequest) Reset() {
 	*x = MoveContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[45]
+	mi := &file_containarium_v1_container_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3308,7 +3501,7 @@ func (x *MoveContainerRequest) String() string {
 func (*MoveContainerRequest) ProtoMessage() {}
 
 func (x *MoveContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[45]
+	mi := &file_containarium_v1_container_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3321,7 +3514,7 @@ func (x *MoveContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MoveContainerRequest.ProtoReflect.Descriptor instead.
 func (*MoveContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{45}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *MoveContainerRequest) GetUsername() string {
@@ -3384,7 +3577,7 @@ type MoveContainerResponse struct {
 
 func (x *MoveContainerResponse) Reset() {
 	*x = MoveContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[46]
+	mi := &file_containarium_v1_container_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3396,7 +3589,7 @@ func (x *MoveContainerResponse) String() string {
 func (*MoveContainerResponse) ProtoMessage() {}
 
 func (x *MoveContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[46]
+	mi := &file_containarium_v1_container_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3409,7 +3602,7 @@ func (x *MoveContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MoveContainerResponse.ProtoReflect.Descriptor instead.
 func (*MoveContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{46}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *MoveContainerResponse) GetMessage() string {
@@ -3470,7 +3663,7 @@ type AdoptMigratedContainerRequest struct {
 
 func (x *AdoptMigratedContainerRequest) Reset() {
 	*x = AdoptMigratedContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[47]
+	mi := &file_containarium_v1_container_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3482,7 +3675,7 @@ func (x *AdoptMigratedContainerRequest) String() string {
 func (*AdoptMigratedContainerRequest) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[47]
+	mi := &file_containarium_v1_container_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3495,7 +3688,7 @@ func (x *AdoptMigratedContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerRequest.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{47}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *AdoptMigratedContainerRequest) GetUsername() string {
@@ -3527,7 +3720,7 @@ type AdoptMigratedContainerResponse struct {
 
 func (x *AdoptMigratedContainerResponse) Reset() {
 	*x = AdoptMigratedContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[48]
+	mi := &file_containarium_v1_container_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3539,7 +3732,7 @@ func (x *AdoptMigratedContainerResponse) String() string {
 func (*AdoptMigratedContainerResponse) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[48]
+	mi := &file_containarium_v1_container_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3552,7 +3745,7 @@ func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerResponse.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{48}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *AdoptMigratedContainerResponse) GetMessage() string {
@@ -3602,7 +3795,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\vmac_address\x18\x02 \x01(\tR\n" +
 	"macAddress\x12\x1c\n" +
 	"\tinterface\x18\x03 \x01(\tR\tinterface\x12\x16\n" +
-	"\x06bridge\x18\x04 \x01(\tR\x06bridge\"\xa2\x06\n" +
+	"\x06bridge\x18\x04 \x01(\tR\x06bridge\"\x86\a\n" +
 	"\tContainer\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x125\n" +
@@ -3629,7 +3822,9 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\vrdp_address\x18\x11 \x01(\tR\n" +
 	"rdpAddress\x12-\n" +
 	"\x12monitoring_enabled\x18\x12 \x01(\bR\x11monitoringEnabled\x12\x12\n" +
-	"\x04pool\x18\x13 \x01(\tR\x04pool\x1a9\n" +
+	"\x04pool\x18\x13 \x01(\tR\x04pool\x12,\n" +
+	"\x12auto_sleep_enabled\x18\x14 \x01(\bR\x10autoSleepEnabled\x124\n" +
+	"\x16idle_threshold_minutes\x18\x15 \x01(\x05R\x14idleThresholdMinutes\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xcf\x02\n" +
@@ -3711,12 +3906,15 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x05force\x18\x02 \x01(\bR\x05force\"Z\n" +
 	"\x17DeleteContainerResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12%\n" +
-	"\x0econtainer_name\x18\x02 \x01(\tR\rcontainerName\"3\n" +
+	"\x0econtainer_name\x18\x02 \x01(\tR\rcontainerName\"\x8d\x01\n" +
 	"\x15StartContainerRequest\x12\x1a\n" +
-	"\busername\x18\x01 \x01(\tR\busername\"l\n" +
+	"\busername\x18\x01 \x01(\tR\busername\x12$\n" +
+	"\x0ewait_for_ready\x18\x02 \x01(\bR\fwaitForReady\x122\n" +
+	"\x15ready_timeout_seconds\x18\x03 \x01(\x05R\x13readyTimeoutSeconds\"\x94\x01\n" +
 	"\x16StartContainerResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x128\n" +
-	"\tcontainer\x18\x02 \x01(\v2\x1a.containarium.v1.ContainerR\tcontainer\"b\n" +
+	"\tcontainer\x18\x02 \x01(\v2\x1a.containarium.v1.ContainerR\tcontainer\x12&\n" +
+	"\x0fready_timed_out\x18\x03 \x01(\bR\rreadyTimedOut\"b\n" +
 	"\x14StopContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x14\n" +
 	"\x05force\x18\x02 \x01(\bR\x05force\x12\x18\n" +
@@ -3729,7 +3927,15 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\aenabled\x18\x02 \x01(\bR\aenabled\"c\n" +
 	"\x18ToggleMonitoringResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12-\n" +
-	"\x12monitoring_enabled\x18\x02 \x01(\bR\x11monitoringEnabled\"T\n" +
+	"\x12monitoring_enabled\x18\x02 \x01(\bR\x11monitoringEnabled\"\x84\x01\n" +
+	"\x16ToggleAutoSleepRequest\x12\x1a\n" +
+	"\busername\x18\x01 \x01(\tR\busername\x12\x18\n" +
+	"\aenabled\x18\x02 \x01(\bR\aenabled\x124\n" +
+	"\x16idle_threshold_minutes\x18\x03 \x01(\x05R\x14idleThresholdMinutes\"\x97\x01\n" +
+	"\x17ToggleAutoSleepResponse\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x12,\n" +
+	"\x12auto_sleep_enabled\x18\x02 \x01(\bR\x10autoSleepEnabled\x124\n" +
+	"\x16idle_threshold_minutes\x18\x03 \x01(\x05R\x14idleThresholdMinutes\"T\n" +
 	"\x10AddSSHKeyRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12$\n" +
 	"\x0essh_public_key\x18\x02 \x01(\tR\fsshPublicKey\"L\n" +
@@ -3882,7 +4088,7 @@ func file_containarium_v1_container_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
+var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 55)
 var file_containarium_v1_container_proto_goTypes = []any{
 	(OSType)(0),                            // 0: containarium.v1.OSType
 	(AccessType)(0),                        // 1: containarium.v1.AccessType
@@ -3907,55 +4113,57 @@ var file_containarium_v1_container_proto_goTypes = []any{
 	(*StopContainerResponse)(nil),          // 20: containarium.v1.StopContainerResponse
 	(*ToggleMonitoringRequest)(nil),        // 21: containarium.v1.ToggleMonitoringRequest
 	(*ToggleMonitoringResponse)(nil),       // 22: containarium.v1.ToggleMonitoringResponse
-	(*AddSSHKeyRequest)(nil),               // 23: containarium.v1.AddSSHKeyRequest
-	(*AddSSHKeyResponse)(nil),              // 24: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyRequest)(nil),            // 25: containarium.v1.RemoveSSHKeyRequest
-	(*RemoveSSHKeyResponse)(nil),           // 26: containarium.v1.RemoveSSHKeyResponse
-	(*GetMetricsRequest)(nil),              // 27: containarium.v1.GetMetricsRequest
-	(*GetMetricsResponse)(nil),             // 28: containarium.v1.GetMetricsResponse
-	(*ResizeContainerRequest)(nil),         // 29: containarium.v1.ResizeContainerRequest
-	(*ResizeContainerResponse)(nil),        // 30: containarium.v1.ResizeContainerResponse
-	(*Collaborator)(nil),                   // 31: containarium.v1.Collaborator
-	(*AddCollaboratorRequest)(nil),         // 32: containarium.v1.AddCollaboratorRequest
-	(*AddCollaboratorResponse)(nil),        // 33: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorRequest)(nil),      // 34: containarium.v1.RemoveCollaboratorRequest
-	(*RemoveCollaboratorResponse)(nil),     // 35: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsRequest)(nil),       // 36: containarium.v1.ListCollaboratorsRequest
-	(*ListCollaboratorsResponse)(nil),      // 37: containarium.v1.ListCollaboratorsResponse
-	(*CleanupDiskRequest)(nil),             // 38: containarium.v1.CleanupDiskRequest
-	(*CleanupDiskResponse)(nil),            // 39: containarium.v1.CleanupDiskResponse
-	(*InstallStackRequest)(nil),            // 40: containarium.v1.InstallStackRequest
-	(*InstallStackResponse)(nil),           // 41: containarium.v1.InstallStackResponse
-	(*StackParameter)(nil),                 // 42: containarium.v1.StackParameter
-	(*StackInfo)(nil),                      // 43: containarium.v1.StackInfo
-	(*ListStacksRequest)(nil),              // 44: containarium.v1.ListStacksRequest
-	(*ListStacksResponse)(nil),             // 45: containarium.v1.ListStacksResponse
-	(*GetMonitoringInfoRequest)(nil),       // 46: containarium.v1.GetMonitoringInfoRequest
-	(*GetMonitoringInfoResponse)(nil),      // 47: containarium.v1.GetMonitoringInfoResponse
-	(*MoveContainerRequest)(nil),           // 48: containarium.v1.MoveContainerRequest
-	(*MoveContainerResponse)(nil),          // 49: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerRequest)(nil),  // 50: containarium.v1.AdoptMigratedContainerRequest
-	(*AdoptMigratedContainerResponse)(nil), // 51: containarium.v1.AdoptMigratedContainerResponse
-	nil,                                    // 52: containarium.v1.Container.LabelsEntry
-	nil,                                    // 53: containarium.v1.CreateContainerRequest.LabelsEntry
-	nil,                                    // 54: containarium.v1.CreateContainerRequest.StackParametersEntry
-	nil,                                    // 55: containarium.v1.ListContainersRequest.LabelFilterEntry
-	(*descriptorpb.EnumValueOptions)(nil),  // 56: google.protobuf.EnumValueOptions
+	(*ToggleAutoSleepRequest)(nil),         // 23: containarium.v1.ToggleAutoSleepRequest
+	(*ToggleAutoSleepResponse)(nil),        // 24: containarium.v1.ToggleAutoSleepResponse
+	(*AddSSHKeyRequest)(nil),               // 25: containarium.v1.AddSSHKeyRequest
+	(*AddSSHKeyResponse)(nil),              // 26: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyRequest)(nil),            // 27: containarium.v1.RemoveSSHKeyRequest
+	(*RemoveSSHKeyResponse)(nil),           // 28: containarium.v1.RemoveSSHKeyResponse
+	(*GetMetricsRequest)(nil),              // 29: containarium.v1.GetMetricsRequest
+	(*GetMetricsResponse)(nil),             // 30: containarium.v1.GetMetricsResponse
+	(*ResizeContainerRequest)(nil),         // 31: containarium.v1.ResizeContainerRequest
+	(*ResizeContainerResponse)(nil),        // 32: containarium.v1.ResizeContainerResponse
+	(*Collaborator)(nil),                   // 33: containarium.v1.Collaborator
+	(*AddCollaboratorRequest)(nil),         // 34: containarium.v1.AddCollaboratorRequest
+	(*AddCollaboratorResponse)(nil),        // 35: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorRequest)(nil),      // 36: containarium.v1.RemoveCollaboratorRequest
+	(*RemoveCollaboratorResponse)(nil),     // 37: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsRequest)(nil),       // 38: containarium.v1.ListCollaboratorsRequest
+	(*ListCollaboratorsResponse)(nil),      // 39: containarium.v1.ListCollaboratorsResponse
+	(*CleanupDiskRequest)(nil),             // 40: containarium.v1.CleanupDiskRequest
+	(*CleanupDiskResponse)(nil),            // 41: containarium.v1.CleanupDiskResponse
+	(*InstallStackRequest)(nil),            // 42: containarium.v1.InstallStackRequest
+	(*InstallStackResponse)(nil),           // 43: containarium.v1.InstallStackResponse
+	(*StackParameter)(nil),                 // 44: containarium.v1.StackParameter
+	(*StackInfo)(nil),                      // 45: containarium.v1.StackInfo
+	(*ListStacksRequest)(nil),              // 46: containarium.v1.ListStacksRequest
+	(*ListStacksResponse)(nil),             // 47: containarium.v1.ListStacksResponse
+	(*GetMonitoringInfoRequest)(nil),       // 48: containarium.v1.GetMonitoringInfoRequest
+	(*GetMonitoringInfoResponse)(nil),      // 49: containarium.v1.GetMonitoringInfoResponse
+	(*MoveContainerRequest)(nil),           // 50: containarium.v1.MoveContainerRequest
+	(*MoveContainerResponse)(nil),          // 51: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerRequest)(nil),  // 52: containarium.v1.AdoptMigratedContainerRequest
+	(*AdoptMigratedContainerResponse)(nil), // 53: containarium.v1.AdoptMigratedContainerResponse
+	nil,                                    // 54: containarium.v1.Container.LabelsEntry
+	nil,                                    // 55: containarium.v1.CreateContainerRequest.LabelsEntry
+	nil,                                    // 56: containarium.v1.CreateContainerRequest.StackParametersEntry
+	nil,                                    // 57: containarium.v1.ListContainersRequest.LabelFilterEntry
+	(*descriptorpb.EnumValueOptions)(nil),  // 58: google.protobuf.EnumValueOptions
 }
 var file_containarium_v1_container_proto_depIdxs = []int32{
 	2,  // 0: containarium.v1.Container.state:type_name -> containarium.v1.ContainerState
 	3,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
 	4,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
-	52, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
+	54, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
 	0,  // 4: containarium.v1.Container.os_type:type_name -> containarium.v1.OSType
 	1,  // 5: containarium.v1.Container.access_type:type_name -> containarium.v1.AccessType
 	3,  // 6: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
-	53, // 7: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
+	55, // 7: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
 	0,  // 8: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
-	54, // 9: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
+	56, // 9: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
 	5,  // 10: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
 	2,  // 11: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
-	55, // 12: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
+	57, // 12: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
 	5,  // 13: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
 	5,  // 14: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
 	6,  // 15: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
@@ -3963,13 +4171,13 @@ var file_containarium_v1_container_proto_depIdxs = []int32{
 	5,  // 17: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
 	6,  // 18: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	5,  // 19: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
-	31, // 20: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
-	31, // 21: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
+	33, // 20: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
+	33, // 21: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
 	5,  // 22: containarium.v1.CleanupDiskResponse.container:type_name -> containarium.v1.Container
 	5,  // 23: containarium.v1.InstallStackResponse.container:type_name -> containarium.v1.Container
-	42, // 24: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
-	43, // 25: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
-	56, // 26: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
+	44, // 24: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
+	45, // 25: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
+	58, // 26: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
 	27, // [27:27] is the sub-list for method output_type
 	27, // [27:27] is the sub-list for method input_type
 	27, // [27:27] is the sub-list for extension type_name
@@ -3988,7 +4196,7 @@ func file_containarium_v1_container_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_container_proto_rawDesc), len(file_containarium_v1_container_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   53,
+			NumMessages:   55,
 			NumExtensions: 1,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xc4[\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\x80_\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -54,7 +54,9 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x16AdoptMigratedContainer\x12..containarium.v1.AdoptMigratedContainerRequest\x1a/.containarium.v1.AdoptMigratedContainerResponse\"\xe0\x02\x92A\xb2\x02\n" +
 	"\x14Container Operations\x12%Adopt a migrated container (internal)\x1a\xf2\x01Called by the source daemon during MoveContainer after the LXC has been Incus-copied to this host. Registers the container's host-side accounts and route record so it's fully under Containarium's control. Not intended for direct operator use.\x82\xd3\xe4\x93\x02$:\x01*\"\x1f/v1/containers/{username}/adopt\x12\xd6\x03\n" +
 	"\x10ToggleMonitoring\x12(.containarium.v1.ToggleMonitoringRequest\x1a).containarium.v1.ToggleMonitoringResponse\"\xec\x02\x92A\xb9\x02\n" +
-	"\x14Container Operations\x120Enable or disable OTel monitoring on a container\x1a\xee\x01Live-flip OTEL_EXPORTER_OTLP_ENDPOINT and related env vars on an existing container and restart it so the change reaches the app. Use this to retrofit monitoring onto containers created before --monitoring was wired into create_container.\x82\xd3\xe4\x93\x02):\x01*\"$/v1/containers/{username}/monitoring\x12\x9a\x02\n" +
+	"\x14Container Operations\x120Enable or disable OTel monitoring on a container\x1a\xee\x01Live-flip OTEL_EXPORTER_OTLP_ENDPOINT and related env vars on an existing container and restart it so the change reaches the app. Use this to retrofit monitoring onto containers created before --monitoring was wired into create_container.\x82\xd3\xe4\x93\x02):\x01*\"$/v1/containers/{username}/monitoring\x12\xb9\x03\n" +
+	"\x0fToggleAutoSleep\x12'.containarium.v1.ToggleAutoSleepRequest\x1a(.containarium.v1.ToggleAutoSleepResponse\"\xd2\x02\x92A\x9f\x02\n" +
+	"\x14Container Operations\x12+Enable or disable auto-sleep on a container\x1a\xd9\x01Writes the per-container auto-sleep opt-in metadata (Incus user.* keys). Does not itself stop the container — use stop_container for that. Phase 2 (the actual idle-tick) and Phase 3 (wake-on-HTTP) consume this flag.\x82\xd3\xe4\x93\x02):\x01*\"$/v1/containers/{username}/auto-sleep\x12\x9a\x02\n" +
 	"\tAddSSHKey\x12!.containarium.v1.AddSSHKeyRequest\x1a\".containarium.v1.AddSSHKeyResponse\"\xc5\x01\x92A\x94\x01\n" +
 	"\x0eSSH Management\x12\vAdd SSH key\x1auAdds an SSH public key to a container's authorized_keys file, allowing SSH access with the corresponding private key.\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/containers/{username}/ssh-keys\x12\xce\x02\n" +
 	"\fRemoveSSHKey\x12$.containarium.v1.RemoveSSHKeyRequest\x1a%.containarium.v1.RemoveSSHKeyResponse\"\xf0\x01\x92A\xb1\x01\n" +
@@ -136,69 +138,71 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*MoveContainerRequest)(nil),           // 8: containarium.v1.MoveContainerRequest
 	(*AdoptMigratedContainerRequest)(nil),  // 9: containarium.v1.AdoptMigratedContainerRequest
 	(*ToggleMonitoringRequest)(nil),        // 10: containarium.v1.ToggleMonitoringRequest
-	(*AddSSHKeyRequest)(nil),               // 11: containarium.v1.AddSSHKeyRequest
-	(*RemoveSSHKeyRequest)(nil),            // 12: containarium.v1.RemoveSSHKeyRequest
-	(*AddCollaboratorRequest)(nil),         // 13: containarium.v1.AddCollaboratorRequest
-	(*RemoveCollaboratorRequest)(nil),      // 14: containarium.v1.RemoveCollaboratorRequest
-	(*ListCollaboratorsRequest)(nil),       // 15: containarium.v1.ListCollaboratorsRequest
-	(*GetMetricsRequest)(nil),              // 16: containarium.v1.GetMetricsRequest
-	(*CleanupDiskRequest)(nil),             // 17: containarium.v1.CleanupDiskRequest
-	(*InstallStackRequest)(nil),            // 18: containarium.v1.InstallStackRequest
-	(*ListStacksRequest)(nil),              // 19: containarium.v1.ListStacksRequest
-	(*GetSystemInfoRequest)(nil),           // 20: containarium.v1.GetSystemInfoRequest
-	(*GetMonitoringInfoRequest)(nil),       // 21: containarium.v1.GetMonitoringInfoRequest
-	(*CreateAlertRuleRequest)(nil),         // 22: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),          // 23: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),            // 24: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),         // 25: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),         // 26: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),         // 27: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),   // 28: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),    // 29: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),             // 30: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),   // 31: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),               // 32: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),               // 33: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),             // 34: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),            // 35: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),          // 36: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),        // 37: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),         // 38: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),           // 39: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),         // 40: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),        // 41: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),         // 42: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),          // 43: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),        // 44: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),          // 45: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerResponse)(nil), // 46: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),       // 47: containarium.v1.ToggleMonitoringResponse
-	(*AddSSHKeyResponse)(nil),              // 48: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),           // 49: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),        // 50: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),     // 51: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),      // 52: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),             // 53: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),            // 54: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),           // 55: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),             // 56: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),          // 57: containarium.v1.GetSystemInfoResponse
-	(*GetMonitoringInfoResponse)(nil),      // 58: containarium.v1.GetMonitoringInfoResponse
-	(*CreateAlertRuleResponse)(nil),        // 59: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),         // 60: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),           // 61: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),        // 62: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),        // 63: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),        // 64: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),  // 65: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),   // 66: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),            // 67: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),  // 68: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),              // 69: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),              // 70: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),            // 71: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),           // 72: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),         // 73: containarium.v1.RefreshSecretsResponse
+	(*ToggleAutoSleepRequest)(nil),         // 11: containarium.v1.ToggleAutoSleepRequest
+	(*AddSSHKeyRequest)(nil),               // 12: containarium.v1.AddSSHKeyRequest
+	(*RemoveSSHKeyRequest)(nil),            // 13: containarium.v1.RemoveSSHKeyRequest
+	(*AddCollaboratorRequest)(nil),         // 14: containarium.v1.AddCollaboratorRequest
+	(*RemoveCollaboratorRequest)(nil),      // 15: containarium.v1.RemoveCollaboratorRequest
+	(*ListCollaboratorsRequest)(nil),       // 16: containarium.v1.ListCollaboratorsRequest
+	(*GetMetricsRequest)(nil),              // 17: containarium.v1.GetMetricsRequest
+	(*CleanupDiskRequest)(nil),             // 18: containarium.v1.CleanupDiskRequest
+	(*InstallStackRequest)(nil),            // 19: containarium.v1.InstallStackRequest
+	(*ListStacksRequest)(nil),              // 20: containarium.v1.ListStacksRequest
+	(*GetSystemInfoRequest)(nil),           // 21: containarium.v1.GetSystemInfoRequest
+	(*GetMonitoringInfoRequest)(nil),       // 22: containarium.v1.GetMonitoringInfoRequest
+	(*CreateAlertRuleRequest)(nil),         // 23: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),          // 24: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),            // 25: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),         // 26: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),         // 27: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),         // 28: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),   // 29: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),    // 30: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),             // 31: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),   // 32: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),               // 33: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),               // 34: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),             // 35: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),            // 36: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),          // 37: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),        // 38: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),         // 39: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),           // 40: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),         // 41: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),        // 42: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),         // 43: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),          // 44: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),        // 45: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),          // 46: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerResponse)(nil), // 47: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),       // 48: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),        // 49: containarium.v1.ToggleAutoSleepResponse
+	(*AddSSHKeyResponse)(nil),              // 50: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),           // 51: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),        // 52: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),     // 53: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),      // 54: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),             // 55: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),            // 56: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),           // 57: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),             // 58: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),          // 59: containarium.v1.GetSystemInfoResponse
+	(*GetMonitoringInfoResponse)(nil),      // 60: containarium.v1.GetMonitoringInfoResponse
+	(*CreateAlertRuleResponse)(nil),        // 61: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),         // 62: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),           // 63: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),        // 64: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),        // 65: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),        // 66: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),  // 67: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),   // 68: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),            // 69: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),  // 70: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),              // 71: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),              // 72: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),            // 73: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),           // 74: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),         // 75: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -212,71 +216,73 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	8,  // 8: containarium.v1.ContainerService.MoveContainer:input_type -> containarium.v1.MoveContainerRequest
 	9,  // 9: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
 	10, // 10: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
-	11, // 11: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
-	12, // 12: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
-	13, // 13: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
-	14, // 14: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
-	15, // 15: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
-	16, // 16: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
-	17, // 17: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
-	18, // 18: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
-	19, // 19: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
-	20, // 20: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
-	21, // 21: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	22, // 22: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	23, // 23: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	24, // 24: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	25, // 25: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	26, // 26: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	27, // 27: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	28, // 28: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	29, // 29: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	30, // 30: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	31, // 31: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	32, // 32: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	33, // 33: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	34, // 34: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	35, // 35: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	36, // 36: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	37, // 37: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	38, // 38: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	39, // 39: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	40, // 40: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	41, // 41: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	42, // 42: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	43, // 43: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	44, // 44: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	45, // 45: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	46, // 46: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	47, // 47: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	48, // 48: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	49, // 49: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	50, // 50: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	51, // 51: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	52, // 52: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	53, // 53: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	54, // 54: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	55, // 55: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	56, // 56: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	57, // 57: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	58, // 58: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	59, // 59: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	60, // 60: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	61, // 61: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	62, // 62: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	63, // 63: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	64, // 64: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	65, // 65: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	66, // 66: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	67, // 67: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	68, // 68: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	69, // 69: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	70, // 70: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	71, // 71: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	72, // 72: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	73, // 73: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	37, // [37:74] is the sub-list for method output_type
-	0,  // [0:37] is the sub-list for method input_type
+	11, // 11: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
+	12, // 12: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
+	13, // 13: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
+	14, // 14: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
+	15, // 15: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
+	16, // 16: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
+	17, // 17: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
+	18, // 18: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
+	19, // 19: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
+	20, // 20: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
+	21, // 21: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
+	22, // 22: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	23, // 23: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	24, // 24: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	25, // 25: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	26, // 26: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	27, // 27: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	28, // 28: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	29, // 29: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	30, // 30: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	31, // 31: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	32, // 32: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	33, // 33: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	34, // 34: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	35, // 35: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	36, // 36: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	37, // 37: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	38, // 38: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	39, // 39: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	40, // 40: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	41, // 41: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	42, // 42: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	43, // 43: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	44, // 44: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	45, // 45: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	46, // 46: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	47, // 47: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	48, // 48: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	49, // 49: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	50, // 50: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	51, // 51: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	52, // 52: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	53, // 53: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	54, // 54: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	55, // 55: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	56, // 56: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	57, // 57: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	58, // 58: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	59, // 59: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	60, // 60: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	61, // 61: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	62, // 62: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	63, // 63: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	64, // 64: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	65, // 65: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	66, // 66: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	67, // 67: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	68, // 68: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	69, // 69: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	70, // 70: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	71, // 71: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	72, // 72: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	73, // 73: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	74, // 74: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	75, // 75: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	38, // [38:76] is the sub-list for method output_type
+	0,  // [0:38] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -498,6 +498,51 @@ func local_request_ContainerService_ToggleMonitoring_0(ctx context.Context, mars
 	return msg, metadata, err
 }
 
+func request_ContainerService_ToggleAutoSleep_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ToggleAutoSleepRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	msg, err := client.ToggleAutoSleep(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_ToggleAutoSleep_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ToggleAutoSleepRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	msg, err := server.ToggleAutoSleep(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_AddSSHKey_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq AddSSHKeyRequest
@@ -1713,6 +1758,26 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_ToggleMonitoring_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_ToggleAutoSleep_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/ToggleAutoSleep", runtime.WithHTTPPathPattern("/v1/containers/{username}/auto-sleep"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_ToggleAutoSleep_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_ToggleAutoSleep_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_AddSSHKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2480,6 +2545,23 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_ToggleMonitoring_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_ToggleAutoSleep_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/ToggleAutoSleep", runtime.WithHTTPPathPattern("/v1/containers/{username}/auto-sleep"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_ToggleAutoSleep_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_ToggleAutoSleep_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_AddSSHKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2954,6 +3036,7 @@ var (
 	pattern_ContainerService_MoveContainer_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "move"}, ""))
 	pattern_ContainerService_AdoptMigratedContainer_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "adopt"}, ""))
 	pattern_ContainerService_ToggleMonitoring_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "monitoring"}, ""))
+	pattern_ContainerService_ToggleAutoSleep_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "auto-sleep"}, ""))
 	pattern_ContainerService_AddSSHKey_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "ssh-keys"}, ""))
 	pattern_ContainerService_RemoveSSHKey_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"v1", "containers", "username", "ssh-keys", "ssh_public_key"}, ""))
 	pattern_ContainerService_AddCollaborator_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "owner_username", "collaborators"}, ""))
@@ -2995,6 +3078,7 @@ var (
 	forward_ContainerService_MoveContainer_0          = runtime.ForwardResponseMessage
 	forward_ContainerService_AdoptMigratedContainer_0 = runtime.ForwardResponseMessage
 	forward_ContainerService_ToggleMonitoring_0       = runtime.ForwardResponseMessage
+	forward_ContainerService_ToggleAutoSleep_0        = runtime.ForwardResponseMessage
 	forward_ContainerService_AddSSHKey_0              = runtime.ForwardResponseMessage
 	forward_ContainerService_RemoveSSHKey_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_AddCollaborator_0        = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -30,6 +30,7 @@ const (
 	ContainerService_MoveContainer_FullMethodName          = "/containarium.v1.ContainerService/MoveContainer"
 	ContainerService_AdoptMigratedContainer_FullMethodName = "/containarium.v1.ContainerService/AdoptMigratedContainer"
 	ContainerService_ToggleMonitoring_FullMethodName       = "/containarium.v1.ContainerService/ToggleMonitoring"
+	ContainerService_ToggleAutoSleep_FullMethodName        = "/containarium.v1.ContainerService/ToggleAutoSleep"
 	ContainerService_AddSSHKey_FullMethodName              = "/containarium.v1.ContainerService/AddSSHKey"
 	ContainerService_RemoveSSHKey_FullMethodName           = "/containarium.v1.ContainerService/RemoveSSHKey"
 	ContainerService_AddCollaborator_FullMethodName        = "/containarium.v1.ContainerService/AddCollaborator"
@@ -110,6 +111,13 @@ type ContainerServiceClient interface {
 	// core collector); without one, enabling fails with
 	// FAILED_PRECONDITION rather than silently writing dead env vars.
 	ToggleMonitoring(ctx context.Context, in *ToggleMonitoringRequest, opts ...grpc.CallOption) (*ToggleMonitoringResponse, error)
+	// ToggleAutoSleep opts a container into manual auto-sleep tracking
+	// (Phase 1 of the serverless feature). Writes the per-container
+	// Incus user.* metadata keys; does NOT itself sleep or wake the
+	// container. The Phase 2 ticker (auto-sleep daemon) and Phase 3
+	// HTTP wake proxy are separate work — this RPC only sets the flag
+	// they will consume.
+	ToggleAutoSleep(ctx context.Context, in *ToggleAutoSleepRequest, opts ...grpc.CallOption) (*ToggleAutoSleepResponse, error)
 	// AddSSHKey adds an SSH public key to a container
 	AddSSHKey(ctx context.Context, in *AddSSHKeyRequest, opts ...grpc.CallOption) (*AddSSHKeyResponse, error)
 	// RemoveSSHKey removes an SSH public key from a container
@@ -288,6 +296,16 @@ func (c *containerServiceClient) ToggleMonitoring(ctx context.Context, in *Toggl
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ToggleMonitoringResponse)
 	err := c.cc.Invoke(ctx, ContainerService_ToggleMonitoring_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) ToggleAutoSleep(ctx context.Context, in *ToggleAutoSleepRequest, opts ...grpc.CallOption) (*ToggleAutoSleepResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ToggleAutoSleepResponse)
+	err := c.cc.Invoke(ctx, ContainerService_ToggleAutoSleep_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -606,6 +624,13 @@ type ContainerServiceServer interface {
 	// core collector); without one, enabling fails with
 	// FAILED_PRECONDITION rather than silently writing dead env vars.
 	ToggleMonitoring(context.Context, *ToggleMonitoringRequest) (*ToggleMonitoringResponse, error)
+	// ToggleAutoSleep opts a container into manual auto-sleep tracking
+	// (Phase 1 of the serverless feature). Writes the per-container
+	// Incus user.* metadata keys; does NOT itself sleep or wake the
+	// container. The Phase 2 ticker (auto-sleep daemon) and Phase 3
+	// HTTP wake proxy are separate work — this RPC only sets the flag
+	// they will consume.
+	ToggleAutoSleep(context.Context, *ToggleAutoSleepRequest) (*ToggleAutoSleepResponse, error)
 	// AddSSHKey adds an SSH public key to a container
 	AddSSHKey(context.Context, *AddSSHKeyRequest) (*AddSSHKeyResponse, error)
 	// RemoveSSHKey removes an SSH public key from a container
@@ -712,6 +737,9 @@ func (UnimplementedContainerServiceServer) AdoptMigratedContainer(context.Contex
 }
 func (UnimplementedContainerServiceServer) ToggleMonitoring(context.Context, *ToggleMonitoringRequest) (*ToggleMonitoringResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ToggleMonitoring not implemented")
+}
+func (UnimplementedContainerServiceServer) ToggleAutoSleep(context.Context, *ToggleAutoSleepRequest) (*ToggleAutoSleepResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ToggleAutoSleep not implemented")
 }
 func (UnimplementedContainerServiceServer) AddSSHKey(context.Context, *AddSSHKeyRequest) (*AddSSHKeyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddSSHKey not implemented")
@@ -1006,6 +1034,24 @@ func _ContainerService_ToggleMonitoring_Handler(srv interface{}, ctx context.Con
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ContainerServiceServer).ToggleMonitoring(ctx, req.(*ToggleMonitoringRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_ToggleAutoSleep_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ToggleAutoSleepRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).ToggleAutoSleep(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_ToggleAutoSleep_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).ToggleAutoSleep(ctx, req.(*ToggleAutoSleepRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1528,6 +1574,10 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ToggleMonitoring",
 			Handler:    _ContainerService_ToggleMonitoring_Handler,
+		},
+		{
+			MethodName: "ToggleAutoSleep",
+			Handler:    _ContainerService_ToggleAutoSleep_Handler,
 		},
 		{
 			MethodName: "AddSSHKey",

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -158,6 +158,17 @@ message Container {
   // is the discriminator used for placement and per-pool routing
   // (such as base-domain selection). Empty for untagged backends.
   string pool = 19;
+
+  // Whether the container is opted into manual auto-sleep tracking
+  // (Phase 1 of the serverless feature). Read-only; toggled via
+  // ToggleAutoSleep. Backed by the user.containarium.auto_sleep_enabled
+  // Incus config key.
+  bool auto_sleep_enabled = 20;
+
+  // Idle minutes before the Phase 2 auto-sleep daemon would stop
+  // the container. Defaults to 15 when unset. Backed by the
+  // user.containarium.idle_threshold_minutes Incus config key.
+  int32 idle_threshold_minutes = 21;
 }
 
 // ContainerMetrics contains runtime metrics for a container
@@ -367,6 +378,18 @@ message DeleteContainerResponse {
 message StartContainerRequest {
   // Username of the container to start
   string username = 1;
+
+  // When true, the server blocks until the container's primary TCP
+  // port (from its route record) is accepting connections, or
+  // ready_timeout_seconds elapses. If the container has no route the
+  // probe is skipped. Used by `containarium wake` to give callers an
+  // "actually serving" signal rather than just "incus says started".
+  bool wait_for_ready = 2;
+
+  // Timeout for the readiness probe in seconds. Zero falls back to
+  // the server-side default (30s). Ignored when wait_for_ready is
+  // false.
+  int32 ready_timeout_seconds = 3;
 }
 
 // StartContainerResponse is the response from starting a container
@@ -376,6 +399,12 @@ message StartContainerResponse {
 
   // Updated container state
   Container container = 2;
+
+  // True when wait_for_ready was set but the readiness probe timed
+  // out before the primary port accepted. The container is started
+  // either way — the caller can retry the probe or accept the start
+  // as best-effort.
+  bool ready_timed_out = 3;
 }
 
 // StopContainerRequest is the request to stop a container
@@ -423,6 +452,36 @@ message ToggleMonitoringResponse {
   // the toggle (mirrors Container.monitoring_enabled in subsequent
   // GetContainer responses).
   bool monitoring_enabled = 2;
+}
+
+// ToggleAutoSleepRequest opts a container into (or out of) auto-sleep
+// tracking. The flag and threshold are stored as Incus user.* config
+// keys; the actual sleep tick (Phase 2) and HTTP wake (Phase 3) are
+// separate work. This RPC only writes the metadata.
+message ToggleAutoSleepRequest {
+  // Username of the container.
+  string username = 1;
+
+  // Desired state. true → write user.containarium.auto_sleep_enabled
+  // = "true". false → write "false" (the threshold key is left in
+  // place so a re-enable picks up the prior value).
+  bool enabled = 2;
+
+  // Idle minutes before Phase 2 would stop the container. Ignored
+  // when enabled=false; 0 means "use existing key or fall back to 15".
+  int32 idle_threshold_minutes = 3;
+}
+
+// ToggleAutoSleepResponse reports the effective auto-sleep state.
+message ToggleAutoSleepResponse {
+  // Operator-facing summary (e.g. "auto-sleep enabled at 15m").
+  string message = 1;
+
+  // The effective auto_sleep_enabled state after the toggle.
+  bool auto_sleep_enabled = 2;
+
+  // The effective idle_threshold_minutes value (15 if defaulted).
+  int32 idle_threshold_minutes = 3;
 }
 
 // AddSSHKeyRequest is the request to add an SSH key to a container

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -215,6 +215,24 @@ service ContainerService {
     };
   }
 
+  // ToggleAutoSleep opts a container into manual auto-sleep tracking
+  // (Phase 1 of the serverless feature). Writes the per-container
+  // Incus user.* metadata keys; does NOT itself sleep or wake the
+  // container. The Phase 2 ticker (auto-sleep daemon) and Phase 3
+  // HTTP wake proxy are separate work — this RPC only sets the flag
+  // they will consume.
+  rpc ToggleAutoSleep(ToggleAutoSleepRequest) returns (ToggleAutoSleepResponse) {
+    option (google.api.http) = {
+      post: "/v1/containers/{username}/auto-sleep"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Enable or disable auto-sleep on a container";
+      description: "Writes the per-container auto-sleep opt-in metadata (Incus user.* keys). Does not itself stop the container — use stop_container for that. Phase 2 (the actual idle-tick) and Phase 3 (wake-on-HTTP) consume this flag.";
+      tags: "Container Operations";
+    };
+  }
+
   // AddSSHKey adds an SSH public key to a container
   rpc AddSSHKey(AddSSHKeyRequest) returns (AddSSHKeyResponse) {
     option (google.api.http) = {


### PR DESCRIPTION
## Summary

First of three phases for "serverless-style" container scale-down. **Phase 1 only**: the per-container opt-in toggle and manual sleep/wake plumbing. Auto-sleep ticker (Phase 2) and wake-on-HTTP (Phase 3) are deliberate follow-ups.

Containers opted into auto-sleep have two new Incus config keys set:
- `user.containarium.auto_sleep_enabled` — bool, default `false`
- `user.containarium.idle_threshold_minutes` — int, default `15`

Storage mirrors `MonitoringEnabled` exactly (Incus user.* namespace, no DB column added).

## What this PR ships

### New API
- `POST /v1/containers/{username}/auto-sleep` — `ToggleAutoSleep(username, enabled, idle_threshold_minutes)`. Works on running or stopped containers. Rejects core-role containers and unknown usernames.
- `StartContainerRequest.wait_for_ready` + `ready_timeout_seconds`; `StartContainerResponse.ready_timed_out`. When `wait_for_ready=true`, the server TCP-dials the container's primary route port at 250ms intervals up to `ready_timeout_seconds` (default 30). **Never fails the RPC on probe timeout** — just sets `ready_timed_out=true` so callers can decide.
- `Container.auto_sleep_enabled` and `Container.idle_threshold_minutes` — read-only fields populated from Incus on every `GetContainer` / `ListContainers`.

### New CLI
```
containarium scale-down enable <user> [--idle 15m]
containarium scale-down disable <user>           # idempotent
containarium scale-down status [user]            # tabular
containarium sleep <user>                        # alias: stop, message says "sleeping"
containarium wake <user>                         # alias: start --wait-for-ready
```
`--idle` accepts Go-duration; validated `>= 1 minute`, rounded to integer minutes.

### New MCP tool
- `toggle_auto_sleep(username, enabled, idleThresholdMinutes)` — thin wrapper over the daemon RPC.
- `start_container` gains optional `waitForReady` arg (backward-compatible).

## Storage choice

Zero new postgres tables. The two `user.containarium.*` keys live in Incus container config, persistent across restarts. Read paths (`ListContainers`, `GetContainer`) populate the new struct fields from `inst.Config[...]` exactly like `MonitoringEnabled` does today.

## What is NOT in this PR (deliberate)

- **Phase 2 (auto-sleep ticker)**: no background job that actually sleeps idle containers yet. Operators must call `containarium sleep <user>` manually.
- **Phase 3 (wake-on-HTTP)**: a stopped container does NOT wake on incoming HTTP request. The CLI `wake` command waits for TCP readiness, but Caddy still returns 502 if the container is stopped and somebody hits its hostname directly.
- **Cross-peer migration**: the toggle is stored in Incus on whichever node hosts the container. `MoveContainer` will need to re-stamp these keys on the destination (like it already does for OTel env vars) — filed as a follow-up note in the source.

## Test plan

- [x] `make proto` clean regen
- [x] `go build ./...` clean
- [x] `go vet ./...` clean for new code
- [x] Unit tests: 41 new test functions across 7 files, ~5s total wall-clock
  - Pure helpers: `parseIdleThresholdMinutes`, `parseIdleMinutes` (edge cases incl. malformed/negative/empty)
  - `ToggleAutoSleep` handler: enable/disable/threshold-default/core-rejected/no-such/negative/idempotent/response-shape
  - `waitForContainerReady` dial loop: immediate-open / opens-after-delay / never-opens / explicit-timeout-honored / list-by-container-errors. Made possible by a small package-private `routeLister` interface (3 methods, narrow on purpose) introduced in this PR.
  - `StartContainer` integration with wait: success / timeout / no-wait default / error propagation / response shape
  - Wire payloads: HTTP client + MCP tool send the right body shape (mirrors `TestTriggerSecurityScan_WirePayloads` pattern from PR #215)
  - CLI arg validation: required-username / status formatting / `--idle` parsing
- [ ] Manual E2E on prod (after deploy):
  - `containarium scale-down enable wordpress --idle 30m` → exit 0, status shows enabled
  - `containarium info wordpress` shows the new fields
  - `containarium scale-down disable wordpress` exits 0, second invocation also exits 0
  - `containarium sleep wordpress` → state STOPPED
  - `containarium wake wordpress` → state RUNNING; CLI blocks ~5–15s
  - `containarium scale-down enable containarium-core-postgres` → rejected
  - MCP `toggle_auto_sleep` round-trip works through Claude Code

## Follow-ups (filed for later)

- Phase 2 ticker can read `IdleThresholdMinutes`/`AutoSleepEnabled` from `ContainerInfo` produced by `ListContainers` — no extra Incus round-trips needed.
- `MoveContainer.AdoptMigratedContainer` should re-stamp the two `user.containarium.*` keys, parallel to how OTel env vars survive migration.
- The wait-for-ready probe currently uses `routes[0].TargetPort` (oldest route by `created_at`). If Phase 3 needs to wake on any of several exposed ports, the probe should switch to an explicit "primary port" notion.
- During an in-flight `net.DialTimeout` (up to 500ms), `ctx.Done()` is not observed. So cancellation latency is bounded at one polling attempt, never a hang — documented but not changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)