### PR TITLE
fix(autosleep): swap Caddy to /wake/ before stopping the container

### DIFF
--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -795,28 +795,30 @@ func (s *ContainerServer) StopContainer(ctx context.Context, req *pb.StopContain
 // internal/server import graph.
 func (s *ContainerServer) StopForAutoSleep(ctx context.Context, username, reason string, idleMinutes int) error {
 	log.Printf("[autosleep] stopping username=%s reason=%q idle_minutes=%d", username, reason, idleMinutes)
-	if _, err := s.StopContainer(ctx, &pb.StopContainerRequest{Username: username, Force: false}); err != nil {
-		return err
-	}
 
-	// Post-stop: point this container's Caddy routes at the daemon's
-	// wake handler so the next HTTP request wakes the container
-	// instead of returning 502. Best-effort — a Caddy mutation
-	// failure shouldn't fail the stop (the container is already
-	// down), and RouteSyncJob will re-converge on the next tick if
-	// the tracker entry made it through.
+	// Swap Caddy routes to the wake handler BEFORE stopping the
+	// container. Doing the swap first means any request arriving in
+	// the brief stop-window lands on /wake/, which (since the
+	// container is still Running at that instant) returns ready=true
+	// immediately and proxies through — one extra hop, but no 502.
+	// The reverse order leaves Caddy pointing at a dead container
+	// for the duration of the graceful stop, which is a guaranteed
+	// 502 window on every auto-sleep event. See #224.
 	if s.wakeRouter != nil && s.routeStore != nil {
 		containerName := username + "-container"
 		routes, err := s.routeStore.ListByContainer(ctx, containerName)
 		if err != nil {
 			log.Printf("[autosleep] list routes for %s: %v (skipping swap-to-wake)", containerName, err)
-			return nil
-		}
-		if len(routes) > 0 {
+		} else if len(routes) > 0 {
 			if err := s.wakeRouter.SwapToWake(ctx, containerName, routes); err != nil {
 				log.Printf("[autosleep] swap-to-wake %s: %v", containerName, err)
+				// Don't fail the stop — RouteSyncJob will re-converge.
 			}
 		}
+	}
+
+	if _, err := s.StopContainer(ctx, &pb.StopContainerRequest{Username: username, Force: false}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/server/stop_for_autosleep_test.go
+++ b/internal/server/stop_for_autosleep_test.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/footprintai/containarium/internal/app"
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
@@ -125,5 +126,72 @@ func TestStopForAutoSleep_DoesNotInvokeAuditDirectly(t *testing.T) {
 	}
 	if stoppedEvents != 1 {
 		t.Errorf("expected exactly 1 stop event from wrapper, got %d", stoppedEvents)
+	}
+}
+
+// recordingWakeRouter / recordingRouteStore stamp a shared seq counter
+// when their tracked method is called, so the test can assert the
+// SwapToWake → StopContainer happens-before relationship.
+type recordingWakeRouter struct {
+	seq        *atomic.Int64
+	swapSeqAt  int64
+}
+
+func (r *recordingWakeRouter) SwapToWake(_ context.Context, _ string, _ []*app.RouteRecord) error {
+	r.swapSeqAt = r.seq.Add(1)
+	return nil
+}
+func (r *recordingWakeRouter) SwapToDirect(context.Context, string, []*app.RouteRecord) error {
+	return nil
+}
+
+type recordingRouteStore struct{}
+
+func (recordingRouteStore) ListByContainer(_ context.Context, _ string) ([]*app.RouteRecord, error) {
+	return []*app.RouteRecord{{FullDomain: "alice.example.test", TargetIP: "10.0.0.5", TargetPort: 8080}}, nil
+}
+func (recordingRouteStore) Delete(context.Context, string) error            { return nil }
+func (recordingRouteStore) Save(context.Context, *app.RouteRecord) error    { return nil }
+
+// TestStopForAutoSleep_SwapsBeforeStop pins the #224 fix: the Caddy
+// route swap MUST happen before the container is stopped, otherwise
+// any request hitting Caddy during the graceful-stop window gets a
+// 502 from a dead upstream. The recorded sequence numbers must show
+// SwapToWake < StopContainer.
+func TestStopForAutoSleep_SwapsBeforeStop(t *testing.T) {
+	var seq atomic.Int64
+	var stopSeqAt int64
+
+	mock := incustest.NewMockBackend()
+	mock.Containers["alice-container"] = &incus.ContainerInfo{Name: "alice-container", State: "Running"}
+	mock.StopContainerFunc = func(name string, force bool) error {
+		stopSeqAt = seq.Add(1)
+		if c, ok := mock.Containers[name]; ok {
+			c.State = "Stopped"
+		}
+		return nil
+	}
+
+	wakeRouter := &recordingWakeRouter{seq: &seq}
+	s := &ContainerServer{
+		manager:     container.NewWithBackend(mock),
+		emitter:     events.NewEmitter(events.NewBus()),
+		wakeRouter:  wakeRouter,
+		routeStore:  recordingRouteStore{},
+	}
+
+	if err := s.StopForAutoSleep(context.Background(), "alice", "idle 90m", 90); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if wakeRouter.swapSeqAt == 0 {
+		t.Fatal("SwapToWake was not called")
+	}
+	if stopSeqAt == 0 {
+		t.Fatal("StopContainer was not called")
+	}
+	if wakeRouter.swapSeqAt >= stopSeqAt {
+		t.Errorf("ordering bug (#224): SwapToWake seq=%d must be < StopContainer seq=%d; otherwise Caddy points at the dead container during the stop window and inbound requests 502",
+			wakeRouter.swapSeqAt, stopSeqAt)
 	}
 }


### PR DESCRIPTION
## Summary
Fixes #224. \`StopForAutoSleep\` stopped the container *before* swapping its Caddy route to the wake handler, leaving a window where Caddy still pointed at a dead container — every inbound HTTPS in that window got 502. Reverses the order.

## Diagnostic that found it
Observed on prod lab cluster (2026-05-19): \`helloworld\` container opted into auto-sleep with 15-min threshold, autosleep ticker logs \`[autosleep] stopping username=helloworld\` every cycle. Walking through the source: \`StopForAutoSleep\` first calls \`StopContainer\` (graceful, takes a few seconds), then queries the route store and calls \`SwapToWake\`. Between those two steps, Caddy's reverse_proxy upstream is the container's direct IP — and that IP's port is closed during/after the graceful stop. New requests in that window hit a dead upstream and Caddy returns 502.

## Fix
\`\`\`go
// before
StopContainer(...)
SwapToWake(...)

// after
SwapToWake(...)   // Caddy now points at /wake/
StopContainer(...)
\`\`\`

After the fix, a request in the brief stop window lands on \`/wake/\` → \`WakeForRequest\` → \`StartContainer\` (no-op since the container is still Running, returns ready=true immediately) → proxies through. One extra daemon hop, no 502.

## Test
Adds \`TestStopForAutoSleep_SwapsBeforeStop\` which uses a shared \`atomic.Int64\` seq counter stamped by both the wake-router mock (on SwapToWake) and the incus mock (on StopContainer), then asserts \`swap.seq < stop.seq\`. Would fail loudly on a regression of the order.

## Test plan
- [x] New test passes: \`go test ./internal/server/ -run TestStopForAutoSleep_SwapsBeforeStop\`
- [x] Existing StopForAutoSleep tests still pass (\`TestStopForAutoSleep_CallsStopContainer\`, \`TestStopForAutoSleep_PropagatesError\`, \`TestStopForAutoSleep_DoesNotInvokeAuditDirectly\`)
- [x] Full server package test suite green
- [ ] Manual: deploy to lab, watch the journal during the next auto-sleep tick — confirm no 502 spike vs. prior

🤖 Generated with [Claude Code](https://claude.com/claude-code)