### PR TITLE
docs(examples): add Python hello-world MCP deploy example

### DIFF
--- a/examples/helloworld-python/README.md
+++ b/examples/helloworld-python/README.md
@@ -1,0 +1,60 @@
+# Demo: Python hello-world via the agent-native flow
+
+A tiny Python `http.server` that displays the visitor's IP, the deployed commit ID, and the current server time. It exists primarily to exercise — and demonstrate — the four-step deploy flow you'd use with any other app:
+
+1. **Create** a container
+2. **Push** code into it (git over SSH)
+3. **Expose** a port on a public hostname
+4. (no step 4 — Caddy ACMEs a cert on the first request)
+
+The deployment is live at **https://helloworld.demo.containarium.dev/**. Open it in a browser; refresh to see the time change.
+
+## What's in this folder
+
+| File | Role |
+|---|---|
+| `app.py` | The Python server. Uses stdlib `BaseHTTPServer` — no deps. Reads commit SHA from `commit.txt`, real client IP from the `X-Forwarded-For` header that Caddy populates from PROXY-v2. |
+| `deploy.sh` | Runs inside the container as a post-receive deploy hook. Writes `commit.txt`, installs the systemd unit, restarts the service. |
+| `helloworld.service` | systemd unit that runs `app.py` as the `helloworld` user, restarting on failure. |
+
+## Reproducing it
+
+Pre-requisites: a Containarium cluster you can talk to, the MCP server wired to it (or the `containarium` CLI configured with `--server`), and an admin JWT.
+
+### Via MCP (agent-native path)
+
+```text
+mcp__<your-cluster>__create_container(username="helloworld", cpu="1", memory="512MB", disk="10GB")
+
+mcp__<your-cluster>__push(
+  username="helloworld",
+  local_path="examples/helloworld-python",
+  deploy_cmd="bash deploy.sh",
+)
+
+mcp__<your-cluster>__expose_port(
+  username="helloworld",
+  container_port=8080,
+  domain="helloworld.demo.containarium.dev",
+)
+```
+
+That's it. The first request to `https://helloworld.demo.containarium.dev/` will trigger Caddy's ACME-on-demand to mint the cert, then proxy through to the Python server.
+
+### Via CLI
+
+```sh
+containarium create helloworld --ssh-key ~/.ssh/id_ed25519.pub
+# (push step needs the MCP push tool today; bare git-push works too if you set up the bare repo manually)
+containarium expose-port helloworld --container-port 8080 --hostname helloworld.demo.containarium.dev
+```
+
+## Notes
+
+- **Why systemd, not nohup?** The post-receive deploy hook needs to fully detach from the SSH session. systemd does this naturally and gives us free restart-on-failure + log capture in `journalctl`. The alternative (`nohup ... &`) leaves edge cases around tty hangups.
+- **Why does the `Your IP` field show your real IP?** The cluster's sentinel emits a PROXY-v2 header on the forwarded TCP stream; the destination Caddy is configured with `--proxy-protocol-trusted` covering the bridge subnet and decodes it, then sets `X-Forwarded-For`. Without that trust config, you'd see the LXC bridge gateway (`10.x.x.1`) instead. See [PROXY-PROTOCOL.md](../docs/PROXY-PROTOCOL.md).
+- **Auto-sleep?** This container is opted into auto-sleep (`user.containarium.auto_sleep_enabled=true`, 15-minute threshold). If nobody's hit the URL in 15 minutes, the autosleep ticker stops the container; the next request wakes it (~2s on this image). You can verify by curling, waiting 20 minutes, then timing another curl.
+
+## Verified against
+
+Containarium **v0.17.0** (May 2026). API/MCP surface may drift in later releases; check `docs/MCP-INTEGRATION.md` for the current tool schema if `push` or `expose_port` parameters look different.

--- a/examples/helloworld-python/app.py
+++ b/examples/helloworld-python/app.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Tiny hello-world server: shows visitor IP, commit ID, current time."""
+import datetime
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+COMMIT_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'commit.txt')
+try:
+    with open(COMMIT_FILE) as f:
+        COMMIT_ID = f.read().strip()
+except FileNotFoundError:
+    COMMIT_ID = 'unknown'
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        forwarded = self.headers.get('X-Forwarded-For', '')
+        ip = forwarded.split(',')[0].strip() if forwarded else self.client_address[0]
+        now = datetime.datetime.now().isoformat(timespec='seconds')
+
+        body = (
+            "<!DOCTYPE html>\n"
+            "<html><head><title>Hello</title></head><body>"
+            "<h1>Hello, world</h1>"
+            f"<p>Your IP: <code>{ip}</code></p>"
+            f"<p>Commit ID: <code>{COMMIT_ID}</code></p>"
+            f"<p>Server time: <code>{now}</code></p>"
+            "</body></html>"
+        )
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body.encode('utf-8'))
+
+    def log_message(self, fmt, *args):
+        pass
+
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', '8080'))
+    server = HTTPServer(('0.0.0.0', port), Handler)
+    print(f'helloworld listening on :{port}', flush=True)
+    server.serve_forever()

--- a/examples/helloworld-python/deploy.sh
+++ b/examples/helloworld-python/deploy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Runs inside the container as the post-receive deploy hook (configured
+# via mcp__push --deploy_cmd "bash deploy.sh"). Three jobs:
+#   1. Snapshot the current commit SHA so app.py can read it at request time.
+#   2. Install the systemd unit if it isn't installed yet.
+#   3. Restart the service so the new code takes effect.
+set -euo pipefail
+
+cd "$HOME/work"
+
+git --git-dir="$HOME/work.git" rev-parse HEAD > commit.txt
+
+sudo cp helloworld.service /etc/systemd/system/helloworld.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now helloworld.service
+sudo systemctl restart helloworld.service

--- a/examples/helloworld-python/helloworld.service
+++ b/examples/helloworld-python/helloworld.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=helloworld python app
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/python3 /home/helloworld/work/app.py
+WorkingDirectory=/home/helloworld/work
+User=helloworld
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Adds \`examples/helloworld-python/\` — a tiny, self-contained example of the four-step deploy flow (create_container → push → expose_port → live HTTPS). The deployment is publicly visible at **https://helloworld.demo.containarium.dev/** so anyone reading the repo can curl/open it and see the result without spinning up a cluster.

## Layout choice
\`examples/\` instead of \`demo/\` to avoid colliding with \`terraform/gce-demo/\` (which is *infra* for provisioning a demo cluster — different audience). OSS convention is \`examples/\` for runnable apps.

## Files
| File | Role |
|---|---|
| \`app.py\` | Stdlib \`http.server\`, no deps. Reads commit SHA from \`commit.txt\`; reads real client IP from \`X-Forwarded-For\`. |
| \`deploy.sh\` | Post-receive hook. Snapshots commit, installs unit, restarts service. |
| \`helloworld.service\` | systemd unit running \`app.py\` as user \`helloworld\`, restart-on-failure. |
| \`README.md\` | MCP + CLI walkthrough, plus the auto-sleep + wake-on-HTTP behavior visible at the URL. |

## Living example notes
- The README pins **\"Verified against v0.17.0\"** since the API/MCP tool surface is pre-1.0 and may drift.
- The auto-sleep / wake behavior at the live URL is described too — wait 20 minutes then \`time curl\` to see the wake latency (~2s).
- If the visitor IP doesn't show the real client IP, it's the cluster's \`--proxy-protocol-trusted\` config (see [PROXY-PROTOCOL.md](docs/PROXY-PROTOCOL.md)) — we hit that on lab and fixed it by adding the LXC bridge subnet to the trusted CIDR.

## Test plan
- [x] Folder + README render correctly on GitHub
- [x] The current live URL backs the README's claims (curl shows real IP + commit + time)
- [ ] After merge: anyone running the recipe against their own cluster ends up with a working \`/\` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)