### PR TITLE
sec: zero-trust Phase 1 quick wins — JWT iss/aud, min secret, token-file mode

### DIFF
--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -90,9 +90,14 @@ on the internal network. Land them first.
 
 ## Phase 1 — Identity & authorization hardening (weeks 2-4)
 
-- [ ] **1.1** Validate JWT `iss` and `aud` claims — `internal/auth/token.go:73-91` (**A-HIGH-1**)
+- [x] **1.1** Validate JWT `iss` and `aud` claims — `internal/auth/token.go:73-91` (**A-HIGH-1**)
+      — `ValidateToken` now passes `jwt.WithIssuer` + `jwt.WithAudience` parser options;
+        `GenerateToken` stamps both. Default audience `containarium-api`
+        (overridable via `CONTAINARIUM_JWT_AUDIENCE`).
 - [ ] **1.2** Add `jti` and a revocation list — `internal/auth/token.go` (**A-MED-1**)
-- [ ] **1.3** Require min 32-byte JWT secret in `NewTokenManager` — `internal/auth/token.go:24-45` (**A-MED-2**)
+- [x] **1.3** Require min 32-byte JWT secret in `NewTokenManager` — `internal/auth/token.go:24-45` (**A-MED-2**)
+      — `NewTokenManager` now returns `(*TokenManager, error)` and refuses
+        secrets shorter than 32 bytes. Fail-closed at daemon startup.
 - [~] **1.4** Per-RPC role enforcement (RBAC interceptor) — `internal/auth/`, all handlers (**A-MED-4**)
       — **Cluster-level ops done.** New `auth.RequireRole(ctx, role)`
         helper applied to GetSystemInfo, MoveContainer,
@@ -107,7 +112,10 @@ on the internal network. Land them first.
 - [ ] **1.5** Drop query-string token support; Authorization header only — `internal/gateway/gateway.go:392,512`, `audit_handler.go:19` (**A-MED-3**)
 - [ ] **1.6** Short-lived access tokens + refresh tokens — `internal/auth/token.go:14` (**C-MED-8**)
 - [ ] **1.7** Per-tool scopes for MCP — `internal/mcp/tools.go`, `internal/mcp/client.go`
-- [ ] **1.8** Refuse JWT token files with mode > 0600 — `internal/mcp/client.go:57-78` (**C-HIGH-7**)
+- [x] **1.8** Refuse JWT token files with mode > 0600 — `internal/mcp/client.go:57-78` (**C-HIGH-7**)
+      — `readToken` `os.Stat`s the file and refuses if any non-owner
+        read/write bit is set. Error message tells the operator the
+        actual mode so they can `chmod 0600` without guessing.
 - [ ] **1.9** Lock down `/wake/` and `/` (Caddy-only assumption) — `internal/gateway/gateway.go:480-491,641-643` (**A-MED-5**)
 - [ ] **1.10** Auth wrap on internal proxies (grafana/alertmanager/guacamole) — `internal/gateway/gateway.go:543-601` (**A-MED-6**)
 

--- a/internal/auth/alg_pinning_test.go
+++ b/internal/auth/alg_pinning_test.go
@@ -27,6 +27,8 @@ func mintToken(t *testing.T, method jwt.SigningMethod, secret interface{}) strin
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Issuer:    "containarium-test",
+			Audience:  jwt.ClaimStrings{DefaultAudience},
 		},
 	}
 	tok := jwt.NewWithClaims(method, claims)
@@ -38,7 +40,7 @@ func mintToken(t *testing.T, method jwt.SigningMethod, secret interface{}) strin
 }
 
 func TestValidateToken_AcceptsHS256(t *testing.T) {
-	tm := NewTokenManager("a-secret-that-is-at-least-32-bytes-long!!", "containarium-test")
+	tm, _ := NewTokenManager("a-secret-that-is-at-least-32-bytes-long!!", "containarium-test")
 	tok := mintToken(t, jwt.SigningMethodHS256, []byte("a-secret-that-is-at-least-32-bytes-long!!"))
 
 	claims, err := tm.ValidateToken(tok)
@@ -51,7 +53,7 @@ func TestValidateToken_AcceptsHS256(t *testing.T) {
 }
 
 func TestValidateToken_RejectsHS512(t *testing.T) {
-	tm := NewTokenManager("a-secret-that-is-at-least-32-bytes-long!!", "containarium-test")
+	tm, _ := NewTokenManager("a-secret-that-is-at-least-32-bytes-long!!", "containarium-test")
 	// Signed with the SAME secret but a different alg — the library
 	// would accept it under the old "any HMAC" rule.
 	tok := mintToken(t, jwt.SigningMethodHS512, []byte("a-secret-that-is-at-least-32-bytes-long!!"))
@@ -63,7 +65,7 @@ func TestValidateToken_RejectsHS512(t *testing.T) {
 }
 
 func TestValidateToken_RejectsHS384(t *testing.T) {
-	tm := NewTokenManager("a-secret-that-is-at-least-32-bytes-long!!", "containarium-test")
+	tm, _ := NewTokenManager("a-secret-that-is-at-least-32-bytes-long!!", "containarium-test")
 	tok := mintToken(t, jwt.SigningMethodHS384, []byte("a-secret-that-is-at-least-32-bytes-long!!"))
 
 	_, err := tm.ValidateToken(tok)
@@ -73,7 +75,7 @@ func TestValidateToken_RejectsHS384(t *testing.T) {
 }
 
 func TestValidateToken_RejectsRS256(t *testing.T) {
-	tm := NewTokenManager("a-secret-that-is-at-least-32-bytes-long!!", "containarium-test")
+	tm, _ := NewTokenManager("a-secret-that-is-at-least-32-bytes-long!!", "containarium-test")
 
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -87,7 +89,7 @@ func TestValidateToken_RejectsRS256(t *testing.T) {
 }
 
 func TestValidateToken_RejectsNone(t *testing.T) {
-	tm := NewTokenManager("a-secret-that-is-at-least-32-bytes-long!!", "containarium-test")
+	tm, _ := NewTokenManager("a-secret-that-is-at-least-32-bytes-long!!", "containarium-test")
 
 	claims := Claims{
 		Username: "attacker",
@@ -111,7 +113,7 @@ func TestValidateToken_ErrorIsGeneric(t *testing.T) {
 	// Defense against reconnaissance — the error returned to clients
 	// must not leak the algorithm name, expiry-vs-signature reason,
 	// or library-level parse detail.
-	tm := NewTokenManager("a-secret-that-is-at-least-32-bytes-long!!", "containarium-test")
+	tm, _ := NewTokenManager("a-secret-that-is-at-least-32-bytes-long!!", "containarium-test")
 	tok := mintToken(t, jwt.SigningMethodHS512, []byte("a-secret-that-is-at-least-32-bytes-long!!"))
 
 	_, err := tm.ValidateToken(tok)

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -18,7 +18,7 @@ import (
 // MUST reject anonymous requests — every endpoint that relies on this
 // (containers, backends, audit logs, …) inherits the same protection.
 func TestHTTPMiddleware_AuthGate(t *testing.T) {
-	tm := NewTokenManager("test-secret-key-for-auth-middleware-test", "test-issuer")
+	tm, _ := NewTokenManager("test-secret-key-for-auth-middleware-test", "test-issuer")
 	mw := NewAuthMiddleware(tm)
 
 	// Stub handler that records whether it was called. If the auth

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -13,6 +13,20 @@ import (
 // DefaultMaxTokenExpiry is the default maximum token expiry (30 days)
 const DefaultMaxTokenExpiry = 30 * 24 * time.Hour
 
+// MinSecretKeyLen is the smallest acceptable JWT signing key.
+// HMAC-SHA256 expects a key with at least 32 bytes of entropy for
+// the security level it claims; weaker keys are brute-forceable
+// offline within practical compute budgets. Tracks audit finding
+// A-MED-2.
+const MinSecretKeyLen = 32
+
+// DefaultAudience is the audience claim Containarium-issued tokens
+// carry by default. Validators reject tokens whose `aud` doesn't
+// include this string, so a token minted for an unrelated service
+// (or by a future tool that shares the same signing key) can't be
+// replayed against the daemon. Tracks audit finding A-HIGH-1.
+const DefaultAudience = "containarium-api"
+
 // Claims represents the JWT claims for authentication
 type Claims struct {
 	Username string   `json:"username"`
@@ -24,11 +38,22 @@ type Claims struct {
 type TokenManager struct {
 	secretKey      []byte
 	issuer         string
+	audience       string
 	maxTokenExpiry time.Duration
 }
 
-// NewTokenManager creates a new token manager
-func NewTokenManager(secretKey string, issuer string) *TokenManager {
+// NewTokenManager creates a new token manager. Returns an error if
+// the secret key is shorter than MinSecretKeyLen — fail-closed
+// rather than silently accepting weak crypto (audit finding
+// A-MED-2).
+//
+// The default audience is DefaultAudience; override via
+// CONTAINARIUM_JWT_AUDIENCE for cross-tenant token issuance.
+func NewTokenManager(secretKey string, issuer string) (*TokenManager, error) {
+	if len(secretKey) < MinSecretKeyLen {
+		return nil, fmt.Errorf("JWT secret is %d bytes, want >=%d (HMAC-SHA256 minimum); generate with `openssl rand -base64 48`", len(secretKey), MinSecretKeyLen)
+	}
+
 	maxExpiry := DefaultMaxTokenExpiry
 
 	// Allow override via environment variable (in hours)
@@ -38,11 +63,17 @@ func NewTokenManager(secretKey string, issuer string) *TokenManager {
 		}
 	}
 
+	audience := DefaultAudience
+	if env := os.Getenv("CONTAINARIUM_JWT_AUDIENCE"); env != "" {
+		audience = env
+	}
+
 	return &TokenManager{
 		secretKey:      []byte(secretKey),
 		issuer:         issuer,
+		audience:       audience,
 		maxTokenExpiry: maxExpiry,
-	}
+	}, nil
 }
 
 // GenerateToken creates a JWT token for a user
@@ -62,6 +93,7 @@ func (tm *TokenManager) GenerateToken(username string, roles []string, expiresIn
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 			NotBefore: jwt.NewNumericDate(time.Now()),
 			Issuer:    tm.issuer,
+			Audience:  jwt.ClaimStrings{tm.audience},
 		},
 	}
 
@@ -96,7 +128,14 @@ func (tm *TokenManager) ValidateToken(tokenString string) (*Claims, error) {
 			return nil, errInvalidToken
 		}
 		return tm.secretKey, nil
-	})
+	},
+		// Audit A-HIGH-1: iss and aud must match this daemon's
+		// configuration. A token signed by the same key for a
+		// different deployment or with a different intended audience
+		// is now rejected.
+		jwt.WithIssuer(tm.issuer),
+		jwt.WithAudience(tm.audience),
+	)
 
 	if err != nil {
 		return nil, errInvalidToken

--- a/internal/auth/token_hardening_test.go
+++ b/internal/auth/token_hardening_test.go
@@ -1,0 +1,137 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// Phase 1.3 — minimum JWT secret length (audit A-MED-2).
+
+func TestNewTokenManager_RejectsShortSecret(t *testing.T) {
+	if _, err := NewTokenManager("too-short", "test-issuer"); err == nil {
+		t.Fatal("9-byte secret must be rejected")
+	}
+	if _, err := NewTokenManager("", "test-issuer"); err == nil {
+		t.Fatal("empty secret must be rejected")
+	}
+	// 31 bytes — one below the boundary.
+	if _, err := NewTokenManager(string(make([]byte, MinSecretKeyLen-1)), "test-issuer"); err == nil {
+		t.Fatal("31-byte secret must be rejected")
+	}
+}
+
+func TestNewTokenManager_AcceptsMinLengthSecret(t *testing.T) {
+	// Exactly MinSecretKeyLen bytes — should succeed.
+	tm, err := NewTokenManager(string(make([]byte, MinSecretKeyLen)), "test-issuer")
+	if err != nil {
+		t.Fatalf("MinSecretKeyLen-byte secret must be accepted: %v", err)
+	}
+	if tm == nil {
+		t.Fatal("nil manager with nil error")
+	}
+}
+
+// Phase 1.1 — JWT iss + aud validation (audit A-HIGH-1).
+
+func TestValidateToken_RejectsWrongIssuer(t *testing.T) {
+	// Both managers share the same secret + audience, but issue
+	// under different `iss` values. A token from `tm1` must not
+	// validate under `tm2`'s validator.
+	const secret = "a-secret-that-is-at-least-32-bytes-long!!"
+	tm1, err := NewTokenManager(secret, "containarium-prod")
+	if err != nil {
+		t.Fatalf("tm1: %v", err)
+	}
+	tm2, err := NewTokenManager(secret, "containarium-staging")
+	if err != nil {
+		t.Fatalf("tm2: %v", err)
+	}
+
+	tok, err := tm1.GenerateToken("alice", []string{"user"}, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	if _, err := tm2.ValidateToken(tok); err == nil {
+		t.Fatal("token signed by tm1 (containarium-prod) must not validate under tm2 (containarium-staging)")
+	}
+}
+
+func TestValidateToken_RejectsWrongAudience(t *testing.T) {
+	// Both managers share the same secret + issuer; only audience
+	// differs. Without aud enforcement, a token minted for an
+	// unrelated audience could be replayed against the daemon.
+	const secret = "a-secret-that-is-at-least-32-bytes-long!!"
+	t.Setenv("CONTAINARIUM_JWT_AUDIENCE", "containarium-api")
+	tm, err := NewTokenManager(secret, "containarium-test")
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+
+	// Mint a token by hand carrying a foreign audience but the
+	// expected issuer + secret — the only thing wrong is `aud`.
+	claims := Claims{
+		Username: "alice",
+		Roles:    []string{"user"},
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Issuer:    "containarium-test",
+			Audience:  jwt.ClaimStrings{"some-other-service"},
+		},
+	}
+	tokObj := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokStr, err := tokObj.SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	if _, err := tm.ValidateToken(tokStr); err == nil {
+		t.Fatal("token with foreign audience must not validate")
+	}
+}
+
+func TestGenerateToken_StampsIssAndAud(t *testing.T) {
+	const secret = "a-secret-that-is-at-least-32-bytes-long!!"
+	tm, err := NewTokenManager(secret, "containarium-test")
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+
+	tok, err := tm.GenerateToken("alice", []string{"user"}, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	claims, err := tm.ValidateToken(tok)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if claims.Issuer != "containarium-test" {
+		t.Fatalf("Issuer = %q, want containarium-test", claims.Issuer)
+	}
+	if len(claims.Audience) != 1 || claims.Audience[0] != DefaultAudience {
+		t.Fatalf("Audience = %v, want [%s]", claims.Audience, DefaultAudience)
+	}
+}
+
+func TestValidateToken_AudienceOverrideFromEnv(t *testing.T) {
+	const secret = "a-secret-that-is-at-least-32-bytes-long!!"
+	t.Setenv("CONTAINARIUM_JWT_AUDIENCE", "containarium-edge")
+
+	tm, err := NewTokenManager(secret, "containarium-test")
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	tok, err := tm.GenerateToken("alice", []string{"user"}, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	claims, err := tm.ValidateToken(tok)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if claims.Audience[0] != "containarium-edge" {
+		t.Fatalf("Audience override not applied: got %v", claims.Audience)
+	}
+}

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestNewTokenManager(t *testing.T) {
-	tm := NewTokenManager("test-secret", "test-issuer")
+	tm, _ := NewTokenManager("test-secret-must-be-at-least-32-bytes-long-ok", "test-issuer")
 
 	if tm == nil {
 		t.Fatal("NewTokenManager returned nil")
@@ -23,7 +23,7 @@ func TestNewTokenManager_WithEnvOverride(t *testing.T) {
 	os.Setenv("CONTAINARIUM_MAX_TOKEN_EXPIRY_HOURS", "48")
 	defer os.Unsetenv("CONTAINARIUM_MAX_TOKEN_EXPIRY_HOURS")
 
-	tm := NewTokenManager("test-secret", "test-issuer")
+	tm, _ := NewTokenManager("test-secret-must-be-at-least-32-bytes-long-ok", "test-issuer")
 
 	expected := 48 * time.Hour
 	if tm.maxTokenExpiry != expected {
@@ -32,7 +32,7 @@ func TestNewTokenManager_WithEnvOverride(t *testing.T) {
 }
 
 func TestGenerateToken_EnforcesMaxExpiry(t *testing.T) {
-	tm := NewTokenManager("test-secret", "test-issuer")
+	tm, _ := NewTokenManager("test-secret-must-be-at-least-32-bytes-long-ok", "test-issuer")
 
 	tests := []struct {
 		name           string
@@ -102,7 +102,7 @@ func TestGenerateToken_EnforcesMaxExpiry(t *testing.T) {
 
 func TestGenerateToken_NoNonExpiringTokens(t *testing.T) {
 	// This is a critical security test - ensure we never create tokens without expiry
-	tm := NewTokenManager("test-secret", "test-issuer")
+	tm, _ := NewTokenManager("test-secret-must-be-at-least-32-bytes-long-ok", "test-issuer")
 
 	// Try various ways to create a "non-expiring" token
 	testCases := []time.Duration{
@@ -130,7 +130,7 @@ func TestGenerateToken_NoNonExpiringTokens(t *testing.T) {
 }
 
 func TestValidateToken_RejectsExpiredTokens(t *testing.T) {
-	tm := NewTokenManager("test-secret", "test-issuer")
+	tm, _ := NewTokenManager("test-secret-must-be-at-least-32-bytes-long-ok", "test-issuer")
 
 	// Generate a token with very short expiry
 	tokenStr, err := tm.GenerateToken("testuser", []string{"admin"}, 1*time.Millisecond)
@@ -149,7 +149,7 @@ func TestValidateToken_RejectsExpiredTokens(t *testing.T) {
 }
 
 func TestValidateToken_RejectsInvalidTokens(t *testing.T) {
-	tm := NewTokenManager("test-secret", "test-issuer")
+	tm, _ := NewTokenManager("test-secret-must-be-at-least-32-bytes-long-ok", "test-issuer")
 
 	invalidTokens := []struct {
 		name  string
@@ -171,8 +171,8 @@ func TestValidateToken_RejectsInvalidTokens(t *testing.T) {
 }
 
 func TestValidateToken_RejectsWrongSecret(t *testing.T) {
-	tm1 := NewTokenManager("secret-1", "test-issuer")
-	tm2 := NewTokenManager("secret-2", "test-issuer")
+	tm1, _ := NewTokenManager("test-secret-1-must-be-at-least-32-bytes-long", "test-issuer")
+	tm2, _ := NewTokenManager("test-secret-2-must-be-at-least-32-bytes-long", "test-issuer")
 
 	// Generate token with tm1
 	tokenStr, err := tm1.GenerateToken("testuser", []string{"admin"}, 1*time.Hour)
@@ -188,7 +188,7 @@ func TestValidateToken_RejectsWrongSecret(t *testing.T) {
 }
 
 func TestTokenClaims(t *testing.T) {
-	tm := NewTokenManager("test-secret", "test-issuer")
+	tm, _ := NewTokenManager("test-secret-must-be-at-least-32-bytes-long-ok", "test-issuer")
 
 	username := "testuser"
 	roles := []string{"admin", "user"}

--- a/internal/cmd/token.go
+++ b/internal/cmd/token.go
@@ -112,7 +112,10 @@ func runTokenGenerate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create token manager
-	tm := auth.NewTokenManager(secret, "containarium")
+	tm, err := auth.NewTokenManager(secret, "containarium")
+	if err != nil {
+		return fmt.Errorf("token manager: %w", err)
+	}
 
 	// Generate token
 	token, err := tm.GenerateToken(tokenUsername, tokenRoles, expiresIn)

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -62,11 +62,23 @@ func (c *Client) SetTokenFile(path string) {
 // tokenFile is configured, reads it fresh from disk (whitespace
 // trimmed) on every call so token rotation works without a restart.
 // Otherwise returns the static token captured at construction.
+//
+// Audit C-HIGH-7: the file must be mode 0600 or stricter, otherwise
+// any unprivileged user on the host can read the admin JWT. Fail
+// closed and surface the actual mode in the error so an operator
+// can chmod it without guessing.
 func (c *Client) readToken() (string, error) {
 	if c.jwtTokenFile == "" {
 		return c.jwtToken, nil
 	}
-	b, err := os.ReadFile(c.jwtTokenFile)
+	info, err := os.Stat(c.jwtTokenFile)
+	if err != nil {
+		return "", fmt.Errorf("stat JWT file %s: %w", c.jwtTokenFile, err)
+	}
+	if mode := info.Mode().Perm(); mode&0o077 != 0 {
+		return "", fmt.Errorf("JWT file %s has insecure permissions %#o (any non-owner read/write bit set); chmod 0600 it", c.jwtTokenFile, mode)
+	}
+	b, err := os.ReadFile(c.jwtTokenFile) // #nosec G304 -- path is operator config (CONTAINARIUM_JWT_TOKEN_FILE), already perm-checked
 	if err != nil {
 		return "", fmt.Errorf("read JWT from %s: %w", c.jwtTokenFile, err)
 	}

--- a/internal/mcp/token_file_perms_test.go
+++ b/internal/mcp/token_file_perms_test.go
@@ -1,0 +1,92 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Phase 1.8 — refuse JWT token files with insecure permissions
+// (audit C-HIGH-7). A token file with mode > 0600 lets any
+// non-owner read the admin JWT off the host.
+
+func TestReadToken_RejectsWorldReadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file mode bits not meaningful on windows")
+	}
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "jwt")
+	// 0o644 = owner rw + world readable. The dangerous case.
+	if err := os.WriteFile(path, []byte("a-valid-jwt"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	c := NewClient("http://example.invalid", "ignored")
+	c.SetTokenFile(path)
+	_, err := c.readToken()
+	if err == nil {
+		t.Fatal("readToken must reject world-readable token file")
+	}
+	if !strings.Contains(err.Error(), "insecure permissions") {
+		t.Fatalf("error should mention permissions: %v", err)
+	}
+}
+
+func TestReadToken_RejectsGroupReadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file mode bits not meaningful on windows")
+	}
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "jwt")
+	// 0o640 = owner rw + group readable. Also unacceptable —
+	// a sibling daemon running as the same group could read.
+	if err := os.WriteFile(path, []byte("a-valid-jwt"), 0o640); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	c := NewClient("http://example.invalid", "ignored")
+	c.SetTokenFile(path)
+	if _, err := c.readToken(); err == nil {
+		t.Fatal("readToken must reject group-readable token file")
+	}
+}
+
+func TestReadToken_AcceptsMode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file mode bits not meaningful on windows")
+	}
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "jwt")
+	if err := os.WriteFile(path, []byte("a-valid-jwt"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	c := NewClient("http://example.invalid", "ignored")
+	c.SetTokenFile(path)
+	tok, err := c.readToken()
+	if err != nil {
+		t.Fatalf("0600 must be accepted: %v", err)
+	}
+	if tok != "a-valid-jwt" {
+		t.Fatalf("token = %q, want a-valid-jwt", tok)
+	}
+}
+
+func TestReadToken_AcceptsMode0400(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file mode bits not meaningful on windows")
+	}
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "jwt")
+	if err := os.WriteFile(path, []byte("a-valid-jwt"), 0o400); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	c := NewClient("http://example.invalid", "ignored")
+	c.SetTokenFile(path)
+	if _, err := c.readToken(); err != nil {
+		t.Fatalf("0400 must be accepted: %v", err)
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -165,8 +165,13 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 		return nil, fmt.Errorf("failed to create container server: %w", err)
 	}
 
-	// Create token manager
-	tokenManager := auth.NewTokenManager(config.JWTSecret, "containarium")
+	// Create token manager. Refuses to start if the JWT secret is
+	// shorter than auth.MinSecretKeyLen — fail-closed on weak crypto
+	// (audit finding A-MED-2).
+	tokenManager, err := auth.NewTokenManager(config.JWTSecret, "containarium")
+	if err != nil {
+		return nil, fmt.Errorf("token manager: %w", err)
+	}
 
 	// Create auth middleware
 	authMiddleware := auth.NewAuthMiddleware(tokenManager)


### PR DESCRIPTION
## Summary

Three small high-signal hardening items from Phase 1 of the zero-trust roadmap. All in `internal/auth/` and `internal/mcp/`, all with new test coverage, no rollout warnings needed.

## Changes

### 1.1 — JWT `iss` + `aud` validation (closes **A-HIGH-1**)

`ValidateToken` now passes `jwt.WithIssuer(tm.issuer)` and `jwt.WithAudience(tm.audience)` parser options; `GenerateToken` stamps both. Default audience is `containarium-api`, overridable via `CONTAINARIUM_JWT_AUDIENCE`. Without this a token signed by the same key for a different deployment — or with a different intended audience — was accepted verbatim.

### 1.3 — Minimum 32-byte JWT secret (closes **A-MED-2**)

`NewTokenManager` returns `(*TokenManager, error)` and refuses secrets shorter than 32 bytes. Fail-closed at daemon startup rather than silently accepting weak crypto. Production call sites (`internal/cmd/token.go`, `internal/server/dual_server.go`) propagate the error. Test secrets bumped to 40+ bytes.

### 1.8 — Refuse world/group-readable JWT token files (closes **C-HIGH-7**)

`readToken` now `os.Stat`s the file and rejects if any non-owner read/write bit is set (`mode & 0o077 != 0`). The error message includes the actual mode so the operator can `chmod 0600` without guessing. Existing rotation behavior (re-read on every request) is preserved.

## Operational impact

⚠ **Breaking for any deployment with a sub-32-byte JWT secret.** The daemon will refuse to start with a clear error message pointing at `openssl rand -base64 48`. Terraform already generates 32+ byte secrets by default; this only bites custom-configured tokens.

⚠ **Breaking for any JWT_TOKEN_FILE deployed with relaxed permissions.** The MCP client will refuse to load the file with a message telling the operator to `chmod 0600`. Any deployment that wrote the file via terraform / ansible / startup script with default umask should already be 0600 from #230's startup-script changes.

⚠ **Breaking for tokens minted by a different deployment.** Phase 1.1 enforces `iss` + `aud` matching — a token from staging won't work against prod even if they share a signing key (which they shouldn't, but defense in depth).

## Test plan

- [x] `go test ./internal/auth/...` — all green (incl. new hardening tests + updated alg_pinning helper)
- [x] `go test ./internal/mcp/...` — all green (incl. new file-perms tests)
- [x] `go build ./...` — clean
- [ ] Manual smoke after merge:
  - Start daemon with a short secret → confirm refusal with clear error
  - Issue a token under prod issuer, validate under staging issuer → confirm rejection
  - `chmod 0644 /path/to/jwt` → confirm MCP client refuses with a message naming the mode

## Remaining Phase 1 items

In `docs/security/ZERO-TRUST-TODO.md`:

- 1.2 `jti` + revocation list — needs persistence design, bigger lift
- 1.4 Per-RPC role enforcement (RBAC) — touches every handler, deserves its own PR
- 1.5 Drop query-string token support — breaking-change announcement worth planning
- 1.6 Short-lived access tokens + refresh — adds new endpoints
- 1.7 MCP per-tool scopes — needs scope taxonomy design
- 1.9 / 1.10 Lock down wake handler and internal proxies

🤖 Generated with [Claude Code](https://claude.com/claude-code)