### PR TITLE
sec: zero-trust Phase 1.4 (partial) — RBAC on cluster-level ops

### DIFF
--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -93,7 +93,17 @@ on the internal network. Land them first.
 - [ ] **1.1** Validate JWT `iss` and `aud` claims — `internal/auth/token.go:73-91` (**A-HIGH-1**)
 - [ ] **1.2** Add `jti` and a revocation list — `internal/auth/token.go` (**A-MED-1**)
 - [ ] **1.3** Require min 32-byte JWT secret in `NewTokenManager` — `internal/auth/token.go:24-45` (**A-MED-2**)
-- [ ] **1.4** Per-RPC role enforcement (RBAC interceptor) — `internal/auth/`, all handlers (**A-MED-4**)
+- [~] **1.4** Per-RPC role enforcement (RBAC interceptor) — `internal/auth/`, all handlers (**A-MED-4**)
+      — **Cluster-level ops done.** New `auth.RequireRole(ctx, role)`
+        helper applied to GetSystemInfo, MoveContainer,
+        AdoptMigratedContainer, and the `/v1/backends` HTTP
+        handler — all admin-only. Tests in
+        `internal/auth/require_role_test.go` and
+        `internal/server/admin_only_handlers_test.go`.
+      — Full per-RPC RBAC (every privileged handler explicitly
+        gated) is the remaining work. The pattern is now in place;
+        applying it to AddSSHKey/RemoveSSHKey, DeleteContainer,
+        and similar is a mechanical follow-up.
 - [ ] **1.5** Drop query-string token support; Authorization header only — `internal/gateway/gateway.go:392,512`, `audit_handler.go:19` (**A-MED-3**)
 - [ ] **1.6** Short-lived access tokens + refresh tokens — `internal/auth/token.go:14` (**C-MED-8**)
 - [ ] **1.7** Per-tool scopes for MCP — `internal/mcp/tools.go`, `internal/mcp/client.go`

--- a/internal/auth/authz.go
+++ b/internal/auth/authz.go
@@ -88,6 +88,26 @@ func HasRole(roles []string, wanted string) bool {
 	return false
 }
 
+// RequireRole returns nil if the authenticated subject holds
+// `role`. Returns Unauthenticated if no subject is in context,
+// PermissionDenied if the subject exists but lacks the role.
+//
+// Use at the top of handlers that should be admin-only — fleet
+// topology disclosure, cross-backend infrastructure operations,
+// peer-to-peer system endpoints. Tenant-scoped operations should
+// use AuthorizeTenant instead; this is for the strictly-narrower
+// class of cluster-wide ops. Tracks audit finding A-MED-4.
+func RequireRole(ctx context.Context, role string) error {
+	_, roles, ok := SubjectFromGRPCContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "no authenticated subject in request context")
+	}
+	if !HasRole(roles, role) {
+		return status.Error(codes.PermissionDenied, "role required: "+role)
+	}
+	return nil
+}
+
 // AuthorizeTenant returns nil if the authenticated subject is
 // allowed to act on `requestedUsername` — either because they are
 // that user, or because they hold the admin role. Returns a

--- a/internal/auth/require_role_test.go
+++ b/internal/auth/require_role_test.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// Phase 1.4 — RequireRole returns the right status code for the
+// three input shapes: no subject, subject without role, subject
+// with role. Tracks audit finding A-MED-4.
+
+func TestRequireRole_NoSubject(t *testing.T) {
+	err := RequireRole(context.Background(), RoleAdmin)
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want Unauthenticated, got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestRequireRole_MissingRole(t *testing.T) {
+	ctx := metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs(MDKeyUsername, "alice", MDKeyRoles, "user"))
+	err := RequireRole(ctx, RoleAdmin)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("want PermissionDenied, got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestRequireRole_HasRole(t *testing.T) {
+	ctx := metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs(MDKeyUsername, "_system", MDKeyRoles, "admin"))
+	if err := RequireRole(ctx, RoleAdmin); err != nil {
+		t.Fatalf("admin should be allowed: %v", err)
+	}
+}
+
+func TestRequireRole_MultipleRoles(t *testing.T) {
+	ctx := metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs(MDKeyUsername, "alice", MDKeyRoles, "user,viewer,admin,billing"))
+	if err := RequireRole(ctx, RoleAdmin); err != nil {
+		t.Fatalf("admin among multiple roles should be allowed: %v", err)
+	}
+}
+
+func TestRequireRole_FromContextFallback(t *testing.T) {
+	// In-process / direct gRPC case: no incoming metadata,
+	// claims live in plain context via ContextWithClaims.
+	claims := &Claims{Username: "alice", Roles: []string{"admin"}}
+	ctx := ContextWithClaims(context.Background(), claims)
+	if err := RequireRole(ctx, RoleAdmin); err != nil {
+		t.Fatalf("context-fallback admin should be allowed: %v", err)
+	}
+}

--- a/internal/server/admin_only_handlers_test.go
+++ b/internal/server/admin_only_handlers_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Phase 1.4 — Cluster-level handlers must require the admin role
+// regardless of which tenant the JWT names. AuthorizeTenant alone
+// would let a user move / adopt their own container; RequireRole
+// closes that gap. Audit finding A-MED-4.
+
+func TestGetSystemInfo_RejectsNonAdmin(t *testing.T) {
+	srv := &ContainerServer{} // GetSystemInfo's authz fires before any field access
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "user")
+
+	_, err := srv.GetSystemInfo(ctx, &pb.GetSystemInfoRequest{})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin must be denied; got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestGetSystemInfo_RejectsNoSubject(t *testing.T) {
+	srv := &ContainerServer{}
+	_, err := srv.GetSystemInfo(context.Background(), &pb.GetSystemInfoRequest{})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("missing subject must be Unauthenticated; got %v", status.Code(err))
+	}
+}
+
+func TestMoveContainer_RejectsNonAdmin(t *testing.T) {
+	srv := &ContainerServer{}
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "user")
+
+	_, err := srv.MoveContainer(ctx, &pb.MoveContainerRequest{
+		Username:        "alice",
+		TargetBackendId: "tunnel-other",
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin must be denied even on own username; got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestAdoptMigratedContainer_RejectsNonAdmin(t *testing.T) {
+	srv := &ContainerServer{}
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "user")
+
+	_, err := srv.AdoptMigratedContainer(ctx, &pb.AdoptMigratedContainerRequest{
+		Username: "alice",
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin must be denied; got %v (%v)", status.Code(err), err)
+	}
+}
+
+// Positive coverage (admin token passes the gate) is exercised
+// indirectly by existing handler tests that use testCtx() — those
+// inject ContextWithSystemIdentity (admin role) and would fail
+// immediately at RequireRole if the gate were misconfigured.

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -1056,9 +1056,16 @@ func (s *ContainerServer) AdoptMigratedContainer(ctx context.Context, req *pb.Ad
 	if req.Username == "" {
 		return nil, fmt.Errorf("username is required")
 	}
-	// AdoptMigratedContainer is called peer-to-peer with the destination
-	// daemon's system token (admin role). Tenants must not be able to
-	// craft an adoption request for someone else's container.
+	// AdoptMigratedContainer is called peer-to-peer with the
+	// destination daemon's system token (admin role). It has no
+	// user-facing semantic — it's the receiving half of
+	// MoveContainer's handshake. Admin-only at both gates: the
+	// RequireRole check stops any user token from crafting an
+	// adoption request, even one that names their own username
+	// (which AuthorizeTenant would otherwise pass).
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
 	if err := auth.AuthorizeTenant(ctx, req.Username); err != nil {
 		return nil, err
 	}
@@ -1460,6 +1467,13 @@ func (s *ContainerServer) GetMetrics(ctx context.Context, req *pb.GetMetricsRequ
 
 // GetSystemInfo gets information about the Incus host
 func (s *ContainerServer) GetSystemInfo(ctx context.Context, req *pb.GetSystemInfoRequest) (*pb.GetSystemInfoResponse, error) {
+	// Admin-only: exposes fleet-internal details (hostname, OS,
+	// Incus version, container counts across tenants). A user
+	// token has no legitimate reason to read this — they care
+	// about their own container, not the daemon's identity.
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
 	// Get basic system info from container manager
 	containers, err := s.manager.List()
 	if err != nil {

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1089,8 +1089,19 @@ skipAppHosting:
 // Start starts both gRPC and HTTP servers
 // backendsHandler returns an HTTP handler for the /v1/backends endpoint.
 // It also handles /v1/backends/{id}/system-info for per-backend system info.
+//
+// Admin-only (Phase 1.4 / audit finding A-MED-4). The endpoint
+// discloses fleet topology — peer IDs, hostnames, OS versions,
+// GPU inventories — which is operator-grade info, not tenant-
+// grade. The wrapping JWT middleware already validates the
+// token; the inline RequireRole check refuses non-admin tokens
+// with 403 before any backend is even enumerated.
 func (ds *DualServer) backendsHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if err := auth.RequireRole(r.Context(), auth.RoleAdmin); err != nil {
+			http.Error(w, `{"error":"admin role required","code":403}`, http.StatusForbidden)
+			return
+		}
 		path := strings.TrimPrefix(r.URL.Path, "/v1/backends")
 		path = strings.TrimPrefix(path, "/")
 

--- a/internal/server/move_container.go
+++ b/internal/server/move_container.go
@@ -82,6 +82,15 @@ func (s *ContainerServer) MoveContainer(ctx context.Context, req *pb.MoveContain
 	if req.TargetBackendId == "" {
 		return nil, fmt.Errorf("target_backend_id is required")
 	}
+	// Admin-only: cross-backend migration is an infrastructure
+	// operation, not a tenant operation. A user owning a container
+	// has no legitimate need to relocate it across the fleet — that's
+	// an operator-driven concern (capacity balancing, drains, GPU
+	// scheduling). AuthorizeTenant alone would still let a tenant
+	// move their own container; require admin on top.
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
 	if err := auth.AuthorizeTenant(ctx, req.Username); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Closes the cluster-level half of audit finding **A-MED-4** (RBAC roles defined but never enforced). The full per-RPC RBAC sweep is a mechanical follow-up; this PR sets up the pattern and applies it to the four handlers that are unambiguously admin-only.

## Background

`AuthorizeTenant` (shipped in #227) catches the per-tenant case — one user can't act on another user's resources. But it does nothing to stop a user from invoking an operation that, despite naming their own username, should be restricted to operators: infrastructure migrations, fleet topology disclosure, peer-to-peer system endpoints.

This PR introduces `auth.RequireRole(ctx, role)` and applies it to those four handlers.

## Changes

### New helper

**`internal/auth/authz.go`**: `RequireRole(ctx, role) error`. Returns `Unauthenticated` if no subject is in context, `PermissionDenied` if the subject lacks the role, nil otherwise. Same shape as `AuthorizeTenant` — works for both gRPC and direct-HTTP contexts.

### Handlers gated

- **`GetSystemInfo`** (`container_server.go`) — daemon hostname, OS, Incus version, container counts. Operator info, not tenant info.
- **`MoveContainer`** (`move_container.go`) — cross-backend migration is an infrastructure operation (capacity rebalancing, drains, GPU scheduling), not tenant self-service. Both gates (`RequireRole` then `AuthorizeTenant`) for defense in depth.
- **`AdoptMigratedContainer`** (`container_server.go`) — the receiving half of `MoveContainer`'s handshake. Peer-to-peer only. No user-facing semantic.
- **`/v1/backends`** (`dual_server.go`) — fleet topology disclosure (peer IDs, hostnames, GPU inventories). Was JWT-gated but not role-gated.

## Tests

- `internal/auth/require_role_test.go` — no-subject Unauthenticated, missing-role PermissionDenied, role-present accepted (single + among multiple), context-fallback path.
- `internal/server/admin_only_handlers_test.go` — all three gRPC handlers reject a `user`-role token even when the request names the caller's own username. Positive (admin-passes) coverage is exercised indirectly by existing handler tests that use `testCtx()` — those would fail loudly if the gate were misconfigured.

## Operational impact

⚠ Existing user tokens lose access to `/v1/backends`, `MoveContainer`, `AdoptMigratedContainer`, and `GetSystemInfo`. The web UI shouldn't expose any of those to non-operators in the first place; if it does, that's a UX bug.

✅ Admin tokens (`containarium token generate --roles admin`) and the `_system` identity used by internal callers continue to work.

## Remaining work

Full per-RPC RBAC — every privileged handler explicitly gated by a role policy — is the bigger lift. Tracked in `docs/security/ZERO-TRUST-TODO.md`; the box is `[~]` rather than `[x]`. Examples of follow-up candidates: `AddSSHKey`/`RemoveSSHKey` (should they be admin-only for cross-user keys?), `DeleteContainer` (should non-admin be able to delete their own?).

🤖 Generated with [Claude Code](https://claude.com/claude-code)