### PR TITLE
sec: zero-trust Phase 2.1 + 4.2 — fail-closed startup checks

### DIFF
--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -136,7 +136,14 @@ on the internal network. Land them first.
 
 ## Phase 2 — Transport security & network segmentation (weeks 4-6)
 
-- [ ] **2.1** Fail-closed mTLS on gRPC (refuse plaintext fallback) — `internal/mtls/loader.go:14-51` (**C-HIGH-2**)
+- [x] **2.1** Fail-closed mTLS on gRPC (refuse plaintext fallback) — `internal/mtls/loader.go:14-51` (**C-HIGH-2**)
+      — New `auth.RequireMTLSUnaryInterceptor` /
+        `RequireMTLSStreamInterceptor` inspect `peer.AuthInfo` on
+        every call and reject anything that isn't a verified mTLS
+        connection with a client cert. Wired in when
+        `EnableMTLS=true`. The old JWT-passthrough interceptor
+        that accepted plaintext is gone from the mTLS path. Tests
+        in `internal/auth/mtls_interceptor_test.go`.
 - [ ] **2.2** MCP client requires HTTPS + CA pinning — `internal/mcp/client.go:46-48,82` (**C-HIGH-1**)
 - [ ] **2.3** Tighten SSH-port default in terraform — `terraform/modules/containarium/sentinel.tf:104-106` (**C-HIGH-3**)
 - [ ] **2.4** Explicit firewall rule for REST gateway (sentinel-only) — `terraform/modules/containarium/main.tf:65-73` (**C-HIGH-4**)
@@ -160,7 +167,13 @@ on the internal network. Land them first.
 ## Phase 4 — Secrets, audit & operational hardening (ongoing)
 
 - [ ] **4.1** Envelope encryption via external KMS (GCP KMS / Vault) — `pkg/core/secrets/crypto.go` (**C-HIGH-6** is partially addressed by 4.2 below)
-- [ ] **4.2** Stat-check master-key file permissions at load — `pkg/core/secrets/crypto.go:47,109` (**C-HIGH-6**)
+- [x] **4.2** Stat-check master-key file permissions at load — `pkg/core/secrets/crypto.go:47,109` (**C-HIGH-6**)
+      — `LoadOrCreateMasterKey` now stats the file before reading
+        and refuses if any non-owner bit is set (`mode & 0o077 != 0`).
+        Catches umask drift, ownership change, and backup-tool
+        side effects. Error message names the actual mode so the
+        operator can `chmod 0400` without guessing. Tests in
+        `pkg/core/secrets/master_key_perms_test.go`.
 - [ ] **4.3** Document container env-var introspection risk; explore tmpfs-mount alternative — `internal/server/secrets_server.go:133-155` (**C-MED-4**)
 - [ ] **4.4** Audit-log redaction policy + enforcement — `internal/audit/store.go:53-74` (**C-MED-5**)
 - [ ] **4.5** Audit-log tamper-evidence (hash chain or append-only sink) — `internal/audit/store.go`

--- a/internal/auth/mtls_interceptor.go
+++ b/internal/auth/mtls_interceptor.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	"google.golang.org/grpc/codes"
+)
+
+// RequireMTLSUnaryInterceptor refuses any unary RPC whose peer
+// wasn't authenticated via mTLS. Wire it onto the gRPC server when
+// EnableMTLS=true — without it, the existing JWT-passthrough
+// interceptor accepts a plaintext client just as readily as a
+// mutual-TLS one, defeating the daemon's "we rely on mTLS"
+// security model.
+//
+// Audit C-HIGH-2: the daemon's gRPC server promised mTLS via
+// configuration, but the auth interceptor was a passthrough that
+// didn't verify any peer-info. A client connecting with
+// `insecure.NewCredentials()` would breeze through.
+func RequireMTLSUnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if err := assertMTLSPeer(ctx); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// RequireMTLSStreamInterceptor is the streaming counterpart.
+func RequireMTLSStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := assertMTLSPeer(ss.Context()); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+}
+
+// assertMTLSPeer inspects the call's peer info and returns nil
+// only when the connection carries verified mTLS credentials with
+// at least one client cert. Returns Unauthenticated otherwise.
+func assertMTLSPeer(ctx context.Context) error {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p == nil {
+		return status.Error(codes.Unauthenticated, "no peer info on call")
+	}
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "non-TLS connection rejected (mTLS required)")
+	}
+	if len(tlsInfo.State.VerifiedChains) == 0 || len(tlsInfo.State.VerifiedChains[0]) == 0 {
+		return status.Error(codes.Unauthenticated, "no verified client cert on TLS connection (mTLS required)")
+	}
+	return nil
+}
+
+// MTLSPeerCN returns the Common Name of the verified client
+// certificate on the call's TLS peer, if any. Useful for logging
+// the identity of mTLS-authenticated callers. Returns empty
+// string + non-nil error if there's no verified mTLS peer.
+func MTLSPeerCN(ctx context.Context) (string, error) {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p == nil {
+		return "", fmt.Errorf("no peer info on call")
+	}
+	tlsInfo, ok := p.AuthInfo.(credentials.TLSInfo)
+	if !ok || len(tlsInfo.State.VerifiedChains) == 0 || len(tlsInfo.State.VerifiedChains[0]) == 0 {
+		return "", fmt.Errorf("no verified client cert on TLS peer")
+	}
+	return tlsInfo.State.VerifiedChains[0][0].Subject.CommonName, nil
+}

--- a/internal/auth/mtls_interceptor_test.go
+++ b/internal/auth/mtls_interceptor_test.go
@@ -1,0 +1,104 @@
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+// Phase 2.1 — RequireMTLSUnaryInterceptor must reject calls
+// without a verified mTLS peer. Audit finding C-HIGH-2.
+
+func TestAssertMTLSPeer_NoPeerInfo(t *testing.T) {
+	err := assertMTLSPeer(context.Background())
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want Unauthenticated, got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestAssertMTLSPeer_NonTLSPeer(t *testing.T) {
+	// peer with no AuthInfo (plaintext connection).
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		AuthInfo: nil,
+	})
+	err := assertMTLSPeer(ctx)
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("plaintext peer must be rejected; got %v", err)
+	}
+}
+
+func TestAssertMTLSPeer_TLSWithoutClientCert(t *testing.T) {
+	// TLS connection but no verified client cert — e.g. server-only
+	// TLS without mTLS. Must be rejected for the mTLS path.
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		AuthInfo: credentials.TLSInfo{
+			State: tls.ConnectionState{
+				// No VerifiedChains populated.
+			},
+		},
+	})
+	err := assertMTLSPeer(ctx)
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("TLS-without-client-cert must be rejected; got %v", err)
+	}
+}
+
+func TestAssertMTLSPeer_VerifiedClientCert(t *testing.T) {
+	// Synthesize a fake verified chain — the interceptor just
+	// checks for presence, doesn't re-verify (that's gRPC's job).
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-peer"},
+	}
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		AuthInfo: credentials.TLSInfo{
+			State: tls.ConnectionState{
+				VerifiedChains: [][]*x509.Certificate{{cert}},
+			},
+		},
+	})
+	if err := assertMTLSPeer(ctx); err != nil {
+		t.Fatalf("verified client cert must pass: %v", err)
+	}
+}
+
+func TestMTLSPeerCN_ReturnsCommonName(t *testing.T) {
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "tunnel-fts-5900x-gpu"},
+	}
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		AuthInfo: credentials.TLSInfo{
+			State: tls.ConnectionState{
+				VerifiedChains: [][]*x509.Certificate{{cert}},
+			},
+		},
+	})
+	cn, err := MTLSPeerCN(ctx)
+	if err != nil {
+		t.Fatalf("MTLSPeerCN: %v", err)
+	}
+	if cn != "tunnel-fts-5900x-gpu" {
+		t.Fatalf("CN = %q, want tunnel-fts-5900x-gpu", cn)
+	}
+}
+
+func TestMTLSPeerCN_NoPeerErrors(t *testing.T) {
+	_, err := MTLSPeerCN(context.Background())
+	if err == nil {
+		t.Fatal("MTLSPeerCN must error when no peer info")
+	}
+	if !errors.Is(err, err) { //nolint:gosimple // just a sanity reference
+		// keeps the variable from being flagged as unused if err
+		// shape changes later
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -176,7 +176,15 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	// Create auth middleware
 	authMiddleware := auth.NewAuthMiddleware(tokenManager)
 
-	// Create gRPC server with optional mTLS
+	// Create gRPC server with optional mTLS.
+	//
+	// Audit C-HIGH-2: when EnableMTLS=true the gRPC server must
+	// REJECT calls whose peer wasn't actually authenticated via
+	// mTLS — the JWT-passthrough interceptor that lived here
+	// before would happily forward an insecure-dialed client.
+	// auth.RequireMTLSUnaryInterceptor inspects peer.AuthInfo and
+	// returns Unauthenticated if no verified client cert is
+	// present.
 	var grpcServer *grpc.Server
 	if config.EnableMTLS {
 		certPaths := mtls.CertPathsFromDir(config.CertsDir)
@@ -191,10 +199,10 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 
 		grpcServer = grpc.NewServer(
 			grpc.Creds(creds),
-			grpc.UnaryInterceptor(authMiddleware.GRPCUnaryInterceptor()),
-			grpc.StreamInterceptor(authMiddleware.GRPCStreamInterceptor()),
+			grpc.UnaryInterceptor(auth.RequireMTLSUnaryInterceptor()),
+			grpc.StreamInterceptor(auth.RequireMTLSStreamInterceptor()),
 		)
-		log.Printf("gRPC server: mTLS enabled")
+		log.Printf("gRPC server: mTLS enabled (interceptor verifies peer cert on every call)")
 	} else {
 		grpcServer = grpc.NewServer(
 			grpc.UnaryInterceptor(authMiddleware.GRPCUnaryInterceptor()),

--- a/pkg/core/secrets/crypto.go
+++ b/pkg/core/secrets/crypto.go
@@ -90,16 +90,31 @@ func ValidateValue(value string) error {
 // #5; callers must log a loud back-it-up warning when the file is
 // newly created so operators know to copy it off-host.
 //
+// Audit C-HIGH-6: before returning the key, stat the file and refuse
+// if any non-owner permission bit is set. The key was originally
+// written with mode 0400, but umask drift, ownership change, or
+// backup-tool side effects can widen permissions silently — leaving
+// the master key readable by anyone who can land on the host.
+// Fail-closed at startup is the only way operators see the
+// regression.
+//
 // Returns (key, created, err) — created=true means the file did not
 // exist and a new key was written.
 func LoadOrCreateMasterKey(path string) (key []byte, created bool, err error) {
-	if data, readErr := os.ReadFile(path); readErr == nil {
+	if info, statErr := os.Stat(path); statErr == nil {
+		if perm := info.Mode().Perm(); perm&0o077 != 0 {
+			return nil, false, fmt.Errorf("master key %s has insecure permissions %#o (any non-owner read/write/exec bit set); chmod 0400 it and ensure root ownership", path, perm)
+		}
+		data, readErr := os.ReadFile(path) // #nosec G304 -- operator-controlled config path
+		if readErr != nil {
+			return nil, false, fmt.Errorf("read master key at %s: %w", path, readErr)
+		}
 		if len(data) != MasterKeySize {
 			return nil, false, fmt.Errorf("%w (file %s has %d bytes)", ErrKeyWrongSize, path, len(data))
 		}
 		return data, false, nil
-	} else if !errors.Is(readErr, os.ErrNotExist) {
-		return nil, false, fmt.Errorf("read master key at %s: %w", path, readErr)
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return nil, false, fmt.Errorf("stat master key at %s: %w", path, statErr)
 	}
 
 	newKey := make([]byte, MasterKeySize)

--- a/pkg/core/secrets/master_key_perms_test.go
+++ b/pkg/core/secrets/master_key_perms_test.go
@@ -1,0 +1,110 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Phase 4.2 — master key file must be 0400 (or stricter) at load
+// time. Audit finding C-HIGH-6: the file is created at 0400 but
+// umask drift, ownership change, or backup-tool side effects can
+// widen the permissions silently. LoadOrCreateMasterKey must
+// fail-closed if any non-owner bit is set.
+
+func TestLoadOrCreateMasterKey_RejectsWorldReadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file mode bits not meaningful on windows")
+	}
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "master.key")
+	if err := os.WriteFile(path, make([]byte, MasterKeySize), 0o444); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, _, err := LoadOrCreateMasterKey(path)
+	if err == nil {
+		t.Fatal("world-readable master key must be rejected")
+	}
+	if !strings.Contains(err.Error(), "insecure permissions") {
+		t.Fatalf("error should mention permissions: %v", err)
+	}
+}
+
+func TestLoadOrCreateMasterKey_RejectsGroupReadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file mode bits not meaningful on windows")
+	}
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "master.key")
+	if err := os.WriteFile(path, make([]byte, MasterKeySize), 0o440); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, _, err := LoadOrCreateMasterKey(path)
+	if err == nil {
+		t.Fatal("group-readable master key must be rejected")
+	}
+}
+
+func TestLoadOrCreateMasterKey_AcceptsMode0400(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file mode bits not meaningful on windows")
+	}
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "master.key")
+	wantKey := make([]byte, MasterKeySize)
+	for i := range wantKey {
+		wantKey[i] = byte(i)
+	}
+	if err := os.WriteFile(path, wantKey, 0o400); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, created, err := LoadOrCreateMasterKey(path)
+	if err != nil {
+		t.Fatalf("0400 master key must be accepted: %v", err)
+	}
+	if created {
+		t.Fatal("file existed; created should be false")
+	}
+	if len(got) != MasterKeySize {
+		t.Fatalf("got %d bytes, want %d", len(got), MasterKeySize)
+	}
+}
+
+func TestLoadOrCreateMasterKey_NewFileCreated0400(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file mode bits not meaningful on windows")
+	}
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "master.key")
+
+	_, created, err := LoadOrCreateMasterKey(path)
+	if err != nil {
+		t.Fatalf("LoadOrCreateMasterKey: %v", err)
+	}
+	if !created {
+		t.Fatal("expected created=true on fresh path")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != MasterKeyFileMode {
+		t.Fatalf("newly created key has mode %#o, want %#o", perm, MasterKeyFileMode)
+	}
+
+	// And subsequent loads should succeed — covers the
+	// create→load round trip.
+	_, created2, err := LoadOrCreateMasterKey(path)
+	if err != nil {
+		t.Fatalf("re-load after creation failed: %v", err)
+	}
+	if created2 {
+		t.Fatal("created flag should be false on re-load")
+	}
+}


### PR DESCRIPTION
## Summary

Two related "fail loudly on misconfig" patches at the daemon's startup paths. Bundled because they share a theme (file mode / peer auth checks that the audit flagged as missing) and a single failure mode (security layer claims to be on but quietly degrades).

### 2.1 — gRPC mTLS peer verification (closes **C-HIGH-2**)

When `EnableMTLS=true` the daemon was loading server credentials correctly, but the unary/stream interceptors were plain passthroughs — a client that dialled with `insecure.NewCredentials()` bypassed the entire mTLS layer because nothing on the server side actually inspected `peer.AuthInfo`.

Fix: new `auth.RequireMTLSUnaryInterceptor` / `RequireMTLSStreamInterceptor` inspect `peer.AuthInfo`, require `credentials.TLSInfo`, require at least one verified client cert chain. Anything else returns `Unauthenticated`. Wired in `dual_server.go` when `EnableMTLS=true`.

Bonus helper `auth.MTLSPeerCN(ctx)` extracts the Common Name of the verified client cert — useful for future per-peer audit logging.

### 4.2 — Master-key file permission check (closes **C-HIGH-6**)

The master key for the tenant-secrets store was created at mode `0400` but never re-validated on subsequent loads. Umask drift, ownership change, or backup-tool side effects (`rsync` without `--perms`, an operator's `cp` that doesn't preserve mode) could silently widen permissions and leave the master key readable by anyone with shell access.

Fix: `secrets.LoadOrCreateMasterKey` now stats the file before reading. If `perm & 0o077 != 0` — any non-owner bit set — it refuses the load with an error that names the actual mode.

## Operational impact

⚠ **mTLS deployments**: any client that connects to the daemon's gRPC port without mTLS will now be rejected. The grpc-gateway path uses mTLS via `mtls.LoadClientDialOptions` (unchanged), so it continues to work. Custom tooling that dialled with `insecure.NewCredentials()` against a daemon with `EnableMTLS=true` will start failing — that was never safe; this PR makes it visible.

⚠ **Existing deployments with widened master-key permissions** will refuse to load on next restart. The error message names the actual mode and the fix (`chmod 0400`). If your deployment was created via the terraform module, the key was written at 0400; this only bites if someone has manually `chmod`'d it.

## Test plan

- [x] `go test ./internal/auth/... ./pkg/core/secrets/... ./internal/server/...` — all green
- [x] New tests:
  - `mtls_interceptor_test.go` — four peer-info shapes (none / non-TLS / TLS-without-cert / TLS-with-verified-cert) plus CN extraction
  - `master_key_perms_test.go` — 0444 / 0440 rejected, 0400 accepted, fresh-file-created-at-0400 path
- [ ] Manual smoke after merge:
  - Start daemon with `EnableMTLS=true`, dial with `grpcurl --insecure` → expect `Unauthenticated`
  - `chmod 0644 /etc/containarium/master.key` → expect refuse-to-start with mode in error message

## Remaining HIGH-severity findings

After this lands, remaining `HIGH` items in the audit:

- A-HIGH-3 — Privileged Podman = single flag (3.2)
- B-HIGH-1 — Image URL injection (3.1)
- C-HIGH-1 — MCP client no TLS (2.2)
- C-HIGH-3 — SSH port 22 default `0.0.0.0/0` (2.3)
- C-HIGH-4 — REST gateway firewall not pinned (2.4)
- C-HIGH-5 — OTel collector unauth (2.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)