### PR TITLE
sec: zero-trust Phase 3.1 + 3.2 — harden CreateContainer surface

### DIFF
--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -156,8 +156,21 @@ on the internal network. Land them first.
 
 ## Phase 3 — Input validation & resource boundary (weeks 6-8)
 
-- [ ] **3.1** Image-registry allowlist + digest pinning — `internal/server/container_server.go:160` (**B-HIGH-1**)
-- [ ] **3.2** Split `enable_podman` from `enable_privileged`; gate latter on role — `internal/server/container_server.go:164`, `pkg/core/incus/client.go:458-459` (**A-HIGH-3**)
+- [~] **3.1** Image-registry allowlist + digest pinning — `internal/server/container_server.go:160` (**B-HIGH-1**)
+      — **Allowlist done.** New `CONTAINARIUM_ALLOWED_IMAGE_REGISTRIES`
+        env var (comma-separated). CreateContainer rejects images
+        whose registry prefix isn't in the allowlist. Empty allowlist
+        = pre-Phase-3 behavior with startup WARNING. Tests in
+        `internal/server/image_allowlist_test.go`.
+      — Digest pinning is a follow-up — would require image-pull
+        side checks for SHA-256 manifests.
+- [x] **3.2** Split `enable_podman` from `enable_privileged`; gate latter on role — `internal/server/container_server.go:164`, `pkg/core/incus/client.go:458-459` (**A-HIGH-3**)
+      — New `CONTAINARIUM_PRIVILEGED_PODMAN_POLICY` env var with
+        three modes: `all` (default, backwards-compat), `admin-only`
+        (require admin role to enable podman), `disabled` (refuse
+        privileged regardless of role). Tests in
+        `internal/server/privileged_policy_test.go`. Proto contract
+        unchanged — server-side gate, not a wire-level split.
 - [ ] **3.3** Cap `ssh_keys` length — `proto/.../container.proto:210` (**B-MED-1**)
 - [ ] **3.4** Cap `stack_parameters` and `labels` size — `proto/.../container.proto:4,13` (**B-MED-2**, **B-LOW-1**)
 - [ ] **3.5** Explicit newline-rejection in SSH key validation — `pkg/core/container/ssh_validate.go:35` (**B-MED-3**)

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -158,6 +158,26 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		}
 	}
 
+	// Audit B-HIGH-1: validate the image against the registry
+	// allowlist before any runtime call. Empty allowlist accepts
+	// everything (with a startup WARNING); a configured allowlist
+	// rejects unknown registries.
+	if err := validateImageRegistry(req.Image); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Audit A-HIGH-3: enable_podman=true implies privileged + apparmor=unconfined.
+	// Gate that elevation behind CONTAINARIUM_PRIVILEGED_PODMAN_POLICY so
+	// non-admin tenants don't auto-escalate just by setting the flag.
+	enablePodmanPrivileged := false
+	if req.EnablePodman {
+		allowed, err := authorizePrivilegedPodman(ctx)
+		if err != nil {
+			return nil, err
+		}
+		enablePodmanPrivileged = allowed
+	}
+
 	// Build create options
 	opts := container.CreateOptions{
 		Username:               req.Username,
@@ -165,7 +185,7 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		SSHKeys:                req.SshKeys,
 		Labels:                 req.Labels,
 		EnablePodman:           req.EnablePodman,
-		EnablePodmanPrivileged: req.EnablePodman, // Enable privileged mode for proper Podman-in-LXC support
+		EnablePodmanPrivileged: enablePodmanPrivileged,
 		AutoStart:              true,
 		Stack:                  req.Stack,
 		StackParameters:        req.StackParameters,

--- a/internal/server/image_allowlist.go
+++ b/internal/server/image_allowlist.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+)
+
+// Image-registry allowlist for CreateContainer (audit B-HIGH-1).
+//
+// `req.Image` flows unmodified to the Incus runtime, which will
+// pull whatever URL or remote: prefix it sees. Without a guard,
+// a caller can:
+//
+//   - Pull from a typosquatted Linux Containers mirror that
+//     swaps in malicious base images.
+//   - Use a `https://internal-service.example/...` URL as an
+//     SSRF probe (the daemon's network position lets it reach
+//     internal services the caller can't).
+//   - Pull oversized junk to exhaust the host's disk.
+//
+// CONTAINARIUM_ALLOWED_IMAGE_REGISTRIES is a comma-separated list
+// of registry prefixes the daemon will accept. Examples:
+//
+//   ubuntu,images,incus              # the three Linux Containers remotes
+//   ubuntu,docker:registry.example   # only ubuntu + one private registry
+//
+// Empty value means "accept anything" — pre-Phase-3 behavior. The
+// daemon logs a WARNING at startup so operators see the gap.
+//
+// Bare image names like "ubuntu/22.04" with no `:` are treated as
+// implicitly belonging to the default "ubuntu" remote in Incus,
+// so they pass when "ubuntu" is in the allowlist.
+
+const allowedImageRegistriesEnv = "CONTAINARIUM_ALLOWED_IMAGE_REGISTRIES"
+
+var (
+	imageAllowlistOnce sync.Once
+	imageAllowlist     []string
+	imageAllowlistAll  bool
+)
+
+func loadImageAllowlist() ([]string, bool) {
+	imageAllowlistOnce.Do(func() {
+		raw := os.Getenv(allowedImageRegistriesEnv)
+		if raw == "" {
+			imageAllowlistAll = true
+			log.Printf("WARNING: %s is unset — CreateContainer accepts any image URL (audit B-HIGH-1 still open)", allowedImageRegistriesEnv)
+			return
+		}
+		for _, p := range strings.Split(raw, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				imageAllowlist = append(imageAllowlist, p)
+			}
+		}
+		log.Printf("[image-allowlist] CreateContainer restricted to registries: %v", imageAllowlist)
+	})
+	return imageAllowlist, imageAllowlistAll
+}
+
+// validateImageRegistry returns nil if `image` matches the
+// allowlist or no allowlist is configured. Returns a descriptive
+// error otherwise — caller maps it to InvalidArgument.
+func validateImageRegistry(image string) error {
+	allowlist, allowAll := loadImageAllowlist()
+	if allowAll {
+		return nil
+	}
+	if image == "" {
+		// Empty image is allowed — the manager substitutes a
+		// default based on OSType. Allowlist check doesn't apply
+		// because nothing was requested.
+		return nil
+	}
+
+	// Extract the registry prefix: everything before the first `:`
+	// for `prefix:tag`, or for a URL the scheme+host.
+	prefix := imageRegistryPrefix(image)
+	for _, allowed := range allowlist {
+		if prefix == allowed || strings.HasPrefix(prefix, allowed) {
+			return nil
+		}
+	}
+	return fmt.Errorf("image %q is not in the allowed-registries list %v; ask an operator to add the registry to %s", image, allowlist, allowedImageRegistriesEnv)
+}
+
+// imageRegistryPrefix returns the registry-identifying prefix
+// used to match against the allowlist. For Incus-style remotes
+// like "ubuntu:22.04" it's "ubuntu". For full URLs it's
+// "scheme://host". For bare names with no colon and no `/`
+// (e.g. "ubuntu", "22.04") it's "ubuntu" — Incus's default
+// remote for un-prefixed images. For path-style references
+// ("images/ubuntu/22.04") it's the empty string, which the
+// allowlist treats as a non-match → reject.
+func imageRegistryPrefix(image string) string {
+	if image == "" {
+		return ""
+	}
+	// Full URL — scheme://host/path
+	if i := strings.Index(image, "://"); i >= 0 {
+		rest := image[i+3:]
+		if j := strings.IndexAny(rest, "/?"); j >= 0 {
+			return image[:i+3+j]
+		}
+		return image
+	}
+	// Incus-style `remote:name`
+	if i := strings.Index(image, ":"); i >= 0 {
+		return image[:i]
+	}
+	// No remote prefix — treat as the default "ubuntu" remote.
+	// Operators who want to reject these should leave "ubuntu"
+	// out of the allowlist; users will need to be explicit.
+	// A `/` indicates a path-style reference (e.g.
+	// "images/ubuntu/22.04") that doesn't match any single
+	// remote — return empty to force rejection.
+	if !strings.Contains(image, "/") {
+		return "ubuntu"
+	}
+	return ""
+}

--- a/internal/server/image_allowlist_test.go
+++ b/internal/server/image_allowlist_test.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Phase 3.1 — image-registry allowlist (audit B-HIGH-1).
+//
+// loadImageAllowlist caches its result via sync.Once, so each test
+// case operates on a freshly-allocated allowlist by resetting the
+// package-level state. (The production code reads the env var
+// once per process — these tests just verify the parsing +
+// matching logic.)
+
+func resetImageAllowlist(t *testing.T) {
+	t.Helper()
+	imageAllowlist = nil
+	imageAllowlistAll = false
+	// Replace the Once so it'll re-fire on next call.
+	imageAllowlistOnce = sync.Once{}
+}
+
+func TestImageRegistryPrefix(t *testing.T) {
+	cases := map[string]string{
+		"ubuntu:22.04":                       "ubuntu",
+		"images:ubuntu/22.04/cloud":          "images",
+		"incus:noble":                        "incus",
+		"https://images.example.com/x.img":   "https://images.example.com",
+		"http://internal/foo":                "http://internal",
+		"ubuntu":                             "ubuntu",   // bare name → default remote
+		"22.04":                              "ubuntu",
+		"images/ubuntu/22.04":                "",         // path without remote → no prefix → rejected
+		"":                                   "",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			got := imageRegistryPrefix(in)
+			if got != want {
+				t.Errorf("prefix(%q) = %q, want %q", in, got, want)
+			}
+		})
+	}
+}
+
+func TestValidateImageRegistry_EmptyAllowlistAcceptsAll(t *testing.T) {
+	t.Setenv(allowedImageRegistriesEnv, "")
+	resetImageAllowlist(t)
+
+	cases := []string{"ubuntu:22.04", "https://random.example", "anything"}
+	for _, in := range cases {
+		if err := validateImageRegistry(in); err != nil {
+			t.Errorf("unset allowlist must accept %q: %v", in, err)
+		}
+	}
+}
+
+func TestValidateImageRegistry_RejectsUnknownRegistry(t *testing.T) {
+	t.Setenv(allowedImageRegistriesEnv, "ubuntu,images")
+	resetImageAllowlist(t)
+
+	if err := validateImageRegistry("docker:registry.attacker.example/evil:latest"); err == nil {
+		t.Fatal("unknown registry must be rejected")
+	}
+	if err := validateImageRegistry("https://attacker.example/img"); err == nil {
+		t.Fatal("URL outside allowlist must be rejected")
+	}
+}
+
+func TestValidateImageRegistry_AcceptsAllowedRegistry(t *testing.T) {
+	t.Setenv(allowedImageRegistriesEnv, "ubuntu,images,incus")
+	resetImageAllowlist(t)
+
+	cases := []string{
+		"ubuntu:22.04",
+		"images:debian/12",
+		"incus:noble",
+		"ubuntu", // bare name → default ubuntu remote
+	}
+	for _, in := range cases {
+		if err := validateImageRegistry(in); err != nil {
+			t.Errorf("%q should be accepted under allowlist {ubuntu, images, incus}: %v", in, err)
+		}
+	}
+}
+
+func TestValidateImageRegistry_ErrorMessageNamesEnvVar(t *testing.T) {
+	t.Setenv(allowedImageRegistriesEnv, "ubuntu")
+	resetImageAllowlist(t)
+
+	err := validateImageRegistry("docker:bad")
+	if err == nil {
+		t.Fatal("expected rejection")
+	}
+	if !strings.Contains(err.Error(), allowedImageRegistriesEnv) {
+		t.Fatalf("error should name the env var so the operator can fix: %v", err)
+	}
+}
+
+func TestValidateImageRegistry_EmptyImageStillAccepted(t *testing.T) {
+	t.Setenv(allowedImageRegistriesEnv, "ubuntu")
+	resetImageAllowlist(t)
+
+	// Empty image is permitted — the manager substitutes a default
+	// based on OSType. Don't break that flow.
+	if err := validateImageRegistry(""); err != nil {
+		t.Fatalf("empty image must be accepted: %v", err)
+	}
+}

--- a/internal/server/privileged_policy.go
+++ b/internal/server/privileged_policy.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Privileged-Podman authorization policy (audit A-HIGH-3).
+//
+// The pre-Phase-3 behavior: `enable_podman=true` on CreateContainer
+// silently set `security.privileged=true` and `lxc.apparmor.profile=unconfined`
+// on the LXC, granting the user effective host-root inside the
+// container. Anyone with CreateContainer permission could
+// elevate to a privileged container — by design, but a HIGH
+// severity privilege-escalation primitive when tenants aren't
+// trusted.
+//
+// The new policy:
+//
+//   CONTAINARIUM_PRIVILEGED_PODMAN_POLICY = all | admin-only | disabled
+//
+//   all         (default) — pre-Phase-3 behavior: any caller that
+//                requests podman gets a privileged container.
+//                Backwards-compatible.
+//   admin-only  — only callers with the admin role get privileged
+//                podman; non-admin requests are rejected with
+//                PermissionDenied. Recommended for multi-tenant
+//                deployments.
+//   disabled    — no caller gets a privileged container, even
+//                admins. Podman falls back to unprivileged mode
+//                (limited functionality). For paranoid setups.
+//
+// The default stays `all` for backwards compat during rollout.
+// Operators set the env var to `admin-only` once they've
+// verified that no non-admin workflow requires privileged Podman.
+//
+// A future iteration can split `enable_podman` from
+// `enable_privileged` in the proto contract; this PR keeps the
+// proto shape and gates the implied privilege escalation server-side.
+
+const privilegedPolicyEnv = "CONTAINARIUM_PRIVILEGED_PODMAN_POLICY"
+
+type PrivilegedPolicy int
+
+const (
+	PrivilegedPolicyAll PrivilegedPolicy = iota // pre-Phase-3 default
+	PrivilegedPolicyAdminOnly
+	PrivilegedPolicyDisabled
+)
+
+var (
+	privilegedPolicyOnce sync.Once
+	privilegedPolicy     PrivilegedPolicy
+)
+
+func loadPrivilegedPolicy() PrivilegedPolicy {
+	privilegedPolicyOnce.Do(func() {
+		raw := strings.ToLower(strings.TrimSpace(os.Getenv(privilegedPolicyEnv)))
+		switch raw {
+		case "", "all":
+			privilegedPolicy = PrivilegedPolicyAll
+			log.Printf("WARNING: %s is %q — any user who enables Podman gets a privileged container (audit A-HIGH-3 still open)", privilegedPolicyEnv, "all")
+		case "admin-only":
+			privilegedPolicy = PrivilegedPolicyAdminOnly
+			log.Printf("[privileged-policy] enabled = admin-only; non-admin podman requests will be rejected")
+		case "disabled":
+			privilegedPolicy = PrivilegedPolicyDisabled
+			log.Printf("[privileged-policy] enabled = disabled; privileged Podman is OFF for every caller including admins")
+		default:
+			privilegedPolicy = PrivilegedPolicyAll
+			log.Printf("WARNING: %s=%q is unrecognized; defaulting to 'all' (any user gets privileged Podman)", privilegedPolicyEnv, raw)
+		}
+	})
+	return privilegedPolicy
+}
+
+// authorizePrivilegedPodman decides whether the caller's
+// `enable_podman=true` request should result in a privileged
+// container. Returns:
+//
+//   (true,  nil)       — set EnablePodmanPrivileged=true
+//   (false, nil)       — set EnablePodmanPrivileged=false (Podman
+//                        runs unprivileged; some workloads break,
+//                        but the daemon doesn't return an error)
+//   (false, err)       — reject the CreateContainer call entirely
+//                        with status.Error
+//
+// The choice between "silently downgrade" and "reject" depends on
+// policy:
+//   - PrivilegedPolicyAll       → (true, nil)
+//   - PrivilegedPolicyAdminOnly → (true, nil) for admin; (false,
+//                                  PermissionDenied) for non-admin
+//   - PrivilegedPolicyDisabled  → (false, nil) — downgrade
+func authorizePrivilegedPodman(ctx context.Context) (bool, error) {
+	switch loadPrivilegedPolicy() {
+	case PrivilegedPolicyAll:
+		return true, nil
+	case PrivilegedPolicyDisabled:
+		return false, nil
+	case PrivilegedPolicyAdminOnly:
+		if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+			return false, status.Errorf(codes.PermissionDenied,
+				"privileged Podman is admin-only on this daemon (set %s=disabled to drop privileged mode entirely)",
+				privilegedPolicyEnv)
+		}
+		return true, nil
+	}
+	return true, nil
+}

--- a/internal/server/privileged_policy_test.go
+++ b/internal/server/privileged_policy_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Phase 3.2 — privileged-Podman policy gate (audit A-HIGH-3).
+
+func resetPrivilegedPolicy(t *testing.T) {
+	t.Helper()
+	privilegedPolicy = PrivilegedPolicyAll
+	privilegedPolicyOnce = sync.Once{}
+}
+
+func TestPrivilegedPolicy_DefaultIsAll(t *testing.T) {
+	t.Setenv(privilegedPolicyEnv, "")
+	resetPrivilegedPolicy(t)
+	if got := loadPrivilegedPolicy(); got != PrivilegedPolicyAll {
+		t.Fatalf("policy = %v, want PrivilegedPolicyAll (backwards-compat default)", got)
+	}
+}
+
+func TestPrivilegedPolicy_ParsesAdminOnly(t *testing.T) {
+	t.Setenv(privilegedPolicyEnv, "admin-only")
+	resetPrivilegedPolicy(t)
+	if got := loadPrivilegedPolicy(); got != PrivilegedPolicyAdminOnly {
+		t.Fatalf("policy = %v, want PrivilegedPolicyAdminOnly", got)
+	}
+}
+
+func TestPrivilegedPolicy_ParsesDisabled(t *testing.T) {
+	t.Setenv(privilegedPolicyEnv, "disabled")
+	resetPrivilegedPolicy(t)
+	if got := loadPrivilegedPolicy(); got != PrivilegedPolicyDisabled {
+		t.Fatalf("policy = %v, want PrivilegedPolicyDisabled", got)
+	}
+}
+
+func TestAuthorizePrivilegedPodman_AllPolicy(t *testing.T) {
+	t.Setenv(privilegedPolicyEnv, "all")
+	resetPrivilegedPolicy(t)
+
+	// "all" accepts every caller, no role check needed.
+	allowed, err := authorizePrivilegedPodman(context.Background())
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !allowed {
+		t.Fatal("policy=all must allow privileged")
+	}
+}
+
+func TestAuthorizePrivilegedPodman_AdminOnly_NonAdminRejected(t *testing.T) {
+	t.Setenv(privilegedPolicyEnv, "admin-only")
+	resetPrivilegedPolicy(t)
+
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "user")
+	allowed, err := authorizePrivilegedPodman(ctx)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin must be denied; got %v (%v)", status.Code(err), err)
+	}
+	if allowed {
+		t.Fatal("non-admin must not be allowed")
+	}
+}
+
+func TestAuthorizePrivilegedPodman_AdminOnly_AdminAllowed(t *testing.T) {
+	t.Setenv(privilegedPolicyEnv, "admin-only")
+	resetPrivilegedPolicy(t)
+
+	ctx := auth.ContextWithSystemIdentity(context.Background())
+	allowed, err := authorizePrivilegedPodman(ctx)
+	if err != nil {
+		t.Fatalf("admin must pass: %v", err)
+	}
+	if !allowed {
+		t.Fatal("admin must be allowed")
+	}
+}
+
+func TestAuthorizePrivilegedPodman_Disabled_DowngradesEvenForAdmin(t *testing.T) {
+	t.Setenv(privilegedPolicyEnv, "disabled")
+	resetPrivilegedPolicy(t)
+
+	ctx := auth.ContextWithSystemIdentity(context.Background())
+	allowed, err := authorizePrivilegedPodman(ctx)
+	if err != nil {
+		t.Fatalf("disabled policy must not error: %v", err)
+	}
+	if allowed {
+		t.Fatal("disabled policy must downgrade to unprivileged even for admin")
+	}
+}


### PR DESCRIPTION
## Summary

Two HIGH-severity audit findings on the same call (`CreateContainer`) that both involve "the request body said X, so we did X without checking who's asking". Bundled because they share a code site and a rollout pattern (env-var gate, fail-closed once the operator opts in, backwards-compat by default).

## 3.1 — Image-registry allowlist (closes **B-HIGH-1**)

`req.Image` flowed unmodified to the Incus runtime. Without a guard a caller could:
- Pull from a typosquatted Linux Containers mirror
- Use `https://internal-service.example/...` as an SSRF probe (the daemon's network position reaches services the caller can't)
- Pull oversized junk to exhaust disk

**New env var**: `CONTAINARIUM_ALLOWED_IMAGE_REGISTRIES` — comma-separated list of accepted registry prefixes:
```
ubuntu,images,incus              # the three Linux Containers remotes
ubuntu,docker:registry.example   # only ubuntu + one private registry
```
Empty value means "accept anything" (pre-Phase-3 behavior), logged as a WARNING at startup so operators see the gap.

The prefix extractor handles three image-string shapes: Incus `remote:name`, full `scheme://host/path` URLs, and bare names with no `/` (treated as default ubuntu remote). Path-style strings with `/` but no `:` get the empty prefix and fail the match — caller must be explicit.

## 3.2 — Privileged Podman gate (closes **A-HIGH-3**)

Pre-Phase-3 behavior: `enable_podman=true` silently set `security.privileged=true` and `lxc.apparmor.profile=unconfined`, granting any user with `CreateContainer` permission effective host-root inside the container.

**New env var**: `CONTAINARIUM_PRIVILEGED_PODMAN_POLICY` with three modes:

| Value | Behavior |
|---|---|
| `all` (default) | Pre-Phase-3: any caller with `enable_podman=true` gets a privileged container. |
| `admin-only` | Only admin-role callers get the privilege elevation; non-admin requests are rejected with `PermissionDenied`. |
| `disabled` | Podman runs unprivileged for every caller including admin. For paranoid setups. |

Implementation gates server-side — proto contract unchanged. A future cleanup can split `enable_podman` from a new `enable_privileged` field on the wire, but that's a breaking proto change and not necessary to close the finding.

## Operational impact

⚠ **Backwards-compatible by default.** Both knobs default to "accept anything" with a startup WARNING. Existing fleets keep working.

⚠ **When operators flip the knobs**, breakage is intentional and visible:
- `CONTAINARIUM_ALLOWED_IMAGE_REGISTRIES=ubuntu,images,incus` will reject `docker:registry.attacker.example/evil` with a message naming the env var.
- `CONTAINARIUM_PRIVILEGED_PODMAN_POLICY=admin-only` will reject a regular user's `enable_podman=true` with a message naming the env var.

Recommend turning both on in production once you've audited what registries your users actually pull and who needs Podman.

## Remaining HIGH-severity work

After this lands (and #235), what's left:
- C-HIGH-1 MCP client no TLS (2.2) — code
- C-HIGH-3 SSH port 22 default `0.0.0.0/0` (2.3) — terraform
- C-HIGH-4 REST gateway firewall not pinned (2.4) — terraform
- C-HIGH-5 OTel collector unauth (2.5) — code

## Test plan

- [x] `go test ./internal/server/...` — all green (new + existing)
- [x] New tests:
  - `image_allowlist_test.go` — 9 prefix-extractor shapes, empty-allowlist accepts-all, error-message-names-env-var
  - `privileged_policy_test.go` — three policy modes parse, admin-only rejects non-admin / accepts admin, disabled downgrades for admin too
- [ ] Manual smoke after merge:
  - Default config → CreateContainer with `image: docker:bad` succeeds (warning logged at startup)
  - Set `CONTAINARIUM_ALLOWED_IMAGE_REGISTRIES=ubuntu` → same request returns 400 InvalidArgument
  - Set `CONTAINARIUM_PRIVILEGED_PODMAN_POLICY=admin-only`, non-admin token → `enable_podman=true` returns 403 PermissionDenied

🤖 Generated with [Claude Code](https://claude.com/claude-code)