### PR TITLE
sec: zero-trust Phase 2.3 + 2.4 — tighten terraform firewall defaults

### DIFF
--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -145,8 +145,20 @@ on the internal network. Land them first.
         that accepted plaintext is gone from the mTLS path. Tests
         in `internal/auth/mtls_interceptor_test.go`.
 - [ ] **2.2** MCP client requires HTTPS + CA pinning — `internal/mcp/client.go:46-48,82` (**C-HIGH-1**)
-- [ ] **2.3** Tighten SSH-port default in terraform — `terraform/modules/containarium/sentinel.tf:104-106` (**C-HIGH-3**)
-- [ ] **2.4** Explicit firewall rule for REST gateway (sentinel-only) — `terraform/modules/containarium/main.tf:65-73` (**C-HIGH-4**)
+- [x] **2.3** Tighten SSH-port default in terraform — `terraform/modules/containarium/sentinel.tf:104-106` (**C-HIGH-3**)
+      — New variable `allowed_management_sources` defaulting to
+        RFC-1918 (10/8 + 172.16/12 + 192.168/16). Applied to
+        operator-only ports: jump-server SSH :22, gRPC :50051,
+        sentinel management SSH :2222. `allowed_ssh_sources`
+        stays at 0.0.0.0/0 for user-facing services on the
+        sentinel (sshpiper :22, HTTP :80, HTTPS :443) — those
+        legitimately need to accept user traffic.
+- [x] **2.4** Explicit firewall rule for REST gateway (sentinel-only) — `terraform/modules/containarium/main.tf:65-73` (**C-HIGH-4**)
+      — Sentinel→spot rule split: user traffic (22/80/443) and
+        the REST API (:8080) are now separate firewall resources
+        with distinct descriptions. An operator can't widen API
+        exposure by editing the user-traffic rule without seeing
+        the implication.
 - [ ] **2.5** OTel collector: loopback bind + auth on OTLP — `internal/server/core_otel_collector.go` (**C-HIGH-5**)
 - [ ] **2.6** PROXY v2 trust list required at startup — `internal/server/dual_server.go` (**C-MED-1**)
 - [ ] **2.7** Pin Caddy to TLS 1.3, restrict ciphers — `internal/hosting/caddy.go` (**C-MED-2**)

--- a/terraform/modules/containarium/main.tf
+++ b/terraform/modules/containarium/main.tf
@@ -38,7 +38,12 @@ resource "google_compute_address" "jump_server_ip" {
 # Firewall Rules
 # -----------------------------------------------------------------------------
 
-# Allow SSH to jump server
+# Operator SSH to jump server. Phase 2.3: sources now from
+# `allowed_management_sources` (defaults to VPC-only) rather than
+# `allowed_ssh_sources` (which still defaults to 0.0.0.0/0 for
+# user-facing services on the sentinel). Operators reach the
+# jump server via VPN / IAP / bastion, not by exposing :22 to
+# the internet.
 resource "google_compute_firewall" "allow_ssh" {
   name    = "${var.instance_name}-allow-ssh"
   network = local.network
@@ -49,13 +54,15 @@ resource "google_compute_firewall" "allow_ssh" {
     ports    = ["22"]
   }
 
-  source_ranges = var.allowed_ssh_sources
+  source_ranges = var.allowed_management_sources
   target_tags   = var.instance_tags
 
-  description = "Allow SSH access to Containarium jump server"
+  description = "Allow SSH access to Containarium jump server (operator-only, VPC default)"
 }
 
-# Allow gRPC daemon API
+# gRPC daemon API. Phase 2.3: same shift to allowed_management_sources.
+# The gRPC port is for daemon-to-daemon mTLS and operator CLI usage;
+# it is never user-facing.
 resource "google_compute_firewall" "allow_grpc" {
   count   = var.enable_containarium_daemon ? 1 : 0
   name    = "${var.instance_name}-allow-grpc"
@@ -67,10 +74,10 @@ resource "google_compute_firewall" "allow_grpc" {
     ports    = ["50051"]
   }
 
-  source_ranges = var.allowed_ssh_sources
+  source_ranges = var.allowed_management_sources
   target_tags   = var.instance_tags
 
-  description = "Allow gRPC API access to Containarium daemon"
+  description = "Allow gRPC API access to Containarium daemon (operator-only, VPC default)"
 }
 
 # IAP SSH firewall rule (needed in VPC environments for IAP tunneling)

--- a/terraform/modules/containarium/sentinel.tf
+++ b/terraform/modules/containarium/sentinel.tf
@@ -114,7 +114,9 @@ resource "google_compute_firewall" "sentinel_ingress" {
   description = "Allow SSH (sshpiper on :22) / HTTP / HTTPS to Containarium sentinel"
 }
 
-# Allow sentinel to reach spot VM on forwarded ports (internal network)
+# Allow sentinel to forward user traffic to the spot backend.
+# Carries SSH (sshpiper → backend per-user shell), HTTP, and HTTPS.
+# These are user-facing protocols proxied through the sentinel.
 resource "google_compute_firewall" "sentinel_to_spot" {
   count = local.use_sentinel ? 1 : 0
 
@@ -124,13 +126,41 @@ resource "google_compute_firewall" "sentinel_to_spot" {
 
   allow {
     protocol = "tcp"
-    ports    = ["22", "80", "443", "8080"]
+    ports    = ["22", "80", "443"]
   }
 
   source_tags = ["containarium-sentinel"]
   target_tags = ["containarium-spot-backend"]
 
-  description = "Allow sentinel to forward traffic to spot backend"
+  description = "Allow sentinel to forward user traffic (SSH/HTTP/HTTPS) to spot backend"
+}
+
+# Phase 2.4 — REST daemon API explicit pinning.
+# Port 8080 (the daemon's HTTP/REST gateway) is split out into its
+# own firewall rule so the audit trail makes clear: the API is
+# only reachable from the sentinel, not from any other source.
+# Audit C-HIGH-4 noted that 8080 wasn't explicitly pinned —
+# previously it shared a rule with user-facing 22/80/443 and
+# inherited the same tag scope, which is correct but inseparable
+# in `terraform plan` diffs. Splitting it out means an operator
+# can't accidentally widen the API exposure by editing one rule
+# without seeing the implication.
+resource "google_compute_firewall" "sentinel_to_spot_rest_api" {
+  count = local.use_sentinel ? 1 : 0
+
+  name    = "${var.instance_name}-sentinel-to-spot-rest-api"
+  network = local.network
+  project = var.project_id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["8080"]
+  }
+
+  source_tags = ["containarium-sentinel"]
+  target_tags = ["containarium-spot-backend"]
+
+  description = "Allow sentinel to reach daemon REST API on :8080 (sentinel-only, no other source)"
 }
 
 # Allow spot VM to reach the sentinel binary server: 8888 = legacy
@@ -156,7 +186,11 @@ resource "google_compute_firewall" "spot_to_sentinel_binary" {
   description = "Allow spot VM to reach sentinel binary server (HTTP 8888 + Phase 0.5 HTTPS 8889)"
 }
 
-# Allow SSH management on port 2222 (port 22 is handled by sshpiper)
+# Allow SSH management on port 2222 (port 22 is handled by sshpiper).
+# Phase 2.3: now sourced from `allowed_management_sources` (VPC-only
+# default) rather than `allowed_ssh_sources` — sentinel admin SSH is
+# an operator surface, not a user surface, and shouldn't default to
+# 0.0.0.0/0.
 resource "google_compute_firewall" "sentinel_mgmt_ssh" {
   count = local.use_sentinel ? 1 : 0
 
@@ -169,9 +203,9 @@ resource "google_compute_firewall" "sentinel_mgmt_ssh" {
     ports    = ["2222"]
   }
 
-  source_ranges = var.allowed_ssh_sources
+  source_ranges = var.allowed_management_sources
   target_tags   = ["containarium-sentinel"]
 
-  description = "Allow SSH management to sentinel on port 2222 (port 22 handled by sshpiper)"
+  description = "Allow SSH management to sentinel on port 2222 (operator-only, VPC default)"
 }
 

--- a/terraform/modules/containarium/variables.tf
+++ b/terraform/modules/containarium/variables.tf
@@ -127,9 +127,37 @@ variable "admin_ssh_keys" {
 }
 
 variable "allowed_ssh_sources" {
-  description = "List of CIDR blocks allowed to SSH to the jump server"
+  description = <<-EOT
+    CIDR blocks allowed to reach user-facing services on the
+    sentinel: sshpiper on :22 (the per-tenant SSH proxy), plus
+    HTTP :80 and HTTPS :443. Defaults to 0.0.0.0/0 because the
+    whole point of these services is to accept user traffic
+    from anywhere; sshpiper has fail2ban in front, and 80/443
+    front Caddy which handles its own TLS termination.
+
+    For operator-only ports (jump-server SSH :22, gRPC :50051,
+    sentinel management SSH :2222) use `allowed_management_sources`
+    instead — that defaults to VPC-only so operator surfaces
+    aren't world-reachable by accident. Audit C-HIGH-3.
+  EOT
   type        = list(string)
   default     = ["0.0.0.0/0"]
+}
+
+variable "allowed_management_sources" {
+  description = <<-EOT
+    CIDR blocks allowed to reach operator-only surfaces: jump-
+    server SSH :22, gRPC :50051, and sentinel management SSH
+    :2222. Defaults to RFC-1918 (10/8, 172.16/12, 192.168/16) so
+    operators reach them via VPN / IAP / bastion rather than via
+    open internet. Set to a narrower CIDR if your operator
+    network is more specific, or to ["0.0.0.0/0"] only when you
+    have a documented reason and other compensating controls.
+
+    Tracks audit finding C-HIGH-3.
+  EOT
+  type        = list(string)
+  default     = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
 }
 
 variable "fail2ban_whitelist_cidr" {


### PR DESCRIPTION
## Summary

Two HIGH-severity audit findings on the terraform module that share a root cause: operator-facing surfaces inheriting the same `0.0.0.0/0` default as user-facing surfaces, and the daemon REST API piggybacking on a multi-port firewall rule that mixed it with user traffic.

## 2.3 — Split user-facing vs operator-only source CIDRs (closes **C-HIGH-3**)

**Before**: `allowed_ssh_sources` (default `0.0.0.0/0`) gated five surfaces with very different threat models:

| Port | Role | Should default to |
|------|------|---|
| sentinel :22 (sshpiper) | user-facing SSH proxy | 0.0.0.0/0 (needs world) |
| sentinel :80 / :443 | user-facing HTTP(S) | 0.0.0.0/0 (needs world) |
| jump-server :22 | operator SSH | narrow |
| jump-server :50051 | operator gRPC | narrow |
| sentinel :2222 | sentinel management SSH | narrow |

The single-variable default opened the operator ports to public-internet brute force.

**After**: new variable `allowed_management_sources` (default RFC-1918: `10/8 + 172.16/12 + 192.168/16`) gates the three operator-only ports. `allowed_ssh_sources` keeps its current default and now only applies to the user-facing sentinel surfaces.

## 2.4 — Explicit firewall for the REST API (closes **C-HIGH-4**)

**Before**: `sentinel_to_spot` covered ports `22+80+443+8080` in one rule. The 8080 (REST API) inherited the right tag-based scoping but wasn't visibly distinct in `terraform plan` diffs — an operator editing the rule could widen API exposure unknowingly.

**After**: split into two resources — `sentinel_to_spot` (user traffic) and `sentinel_to_spot_rest_api` (`:8080` only). Each has a description that makes the intent obvious.

## Operational impact

⚠ **Breaking for any deployment whose operators reach the jump server / gRPC / sentinel-management SSH from a public-internet IP.** Those connections will start failing after `terraform apply` unless `allowed_management_sources` is set in `terraform.tfvars` to include the operator network. The change preserves user-facing services exactly.

✅ **Safe by default** for VPC-internal operators (the majority case). RFC-1918 covers GCE internal nets, on-prem VPNs, and most bastion setups.

To restore previous behavior:
```hcl
allowed_management_sources = ["0.0.0.0/0"]
```

The variable description explicitly recommends against this and points to VPN/IAP/bastion as preferred alternatives.

## Test plan

- [x] `terraform validate` clean on `terraform/modules/containarium/`
- [x] `terraform fmt -check -diff` clean
- [ ] After merge: operator should run `terraform plan` in their consumer module and confirm the diff matches expectations (one variable added, two firewall rules added/changed, one rule split)

## Remaining HIGH-severity work

After this lands plus #235 and #236:

| Finding | Status |
|---|---|
| A-HIGH-1 / 2 / 3 / 7 / B-HIGH-1 | ✅ closed |
| C-HIGH-2 / 6 | 🟡 in #235 |
| **C-HIGH-3 / 4** | 🟡 this PR |
| C-HIGH-1 MCP no TLS | open (code) |
| C-HIGH-5 OTel collector unauth | open (code) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)