### PR TITLE
fix(sec): inline #nosec so gosec sees G703 directive (follow-up to #238)

### DIFF
--- a/internal/mcp/client_tls.go
+++ b/internal/mcp/client_tls.go
@@ -69,7 +69,10 @@ func buildMCPTLSConfig(baseURL string) (*tls.Config, error) {
 		return nil, nil
 	}
 
-	caBytes, err := os.ReadFile(caFile) // #nosec G304 -- operator-controlled env var
+	// caFile is the operator-supplied CONTAINARIUM_MCP_TRUSTED_CA_FILE
+	// path. gosec emits both G304 and G703 for the same finding —
+	// the inline #nosec covers both.
+	caBytes, err := os.ReadFile(caFile) // #nosec G304 G703 -- operator config
 	if err != nil {
 		return nil, fmt.Errorf("read CA bundle %s: %w", caFile, err)
 	}


### PR DESCRIPTION
## Summary

PR #238 auto-merged before my gosec fix landed on its branch — the merge fired against the original commit that had `#nosec G304` (only) on the `os.ReadFile` in `internal/mcp/client_tls.go`. gosec emits **both** G304 and G703 for the same finding, so the directive was incomplete and main now carries an open G703 alert.

This PR is the one-line fix: switch to inline `// #nosec G304 G703 -- operator config` at the end of the offending statement, the unambiguous form gosec's parser honors.

Verified locally — `gosec -include G304,G703 ./internal/mcp/...` reports `Issues: 0, Nosec: 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)