### PR TITLE
sec: zero-trust Phase 1.9 — lock down /wake/ to trusted proxies (A-MED-5)

### DIFF
--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -123,7 +123,16 @@ on the internal network. Land them first.
       — `readToken` `os.Stat`s the file and refuses if any non-owner
         read/write bit is set. Error message tells the operator the
         actual mode so they can `chmod 0600` without guessing.
-- [ ] **1.9** Lock down `/wake/` and `/` (Caddy-only assumption) — `internal/gateway/gateway.go:480-491,641-643` (**A-MED-5**)
+- [x] **1.9** Lock down `/wake/` and `/` (Caddy-only assumption) — `internal/gateway/gateway.go:480-491,641-643` (**A-MED-5**)
+      — `WakeProxy.ServeHTTP` now refuses requests whose
+        `RemoteAddr` isn't loopback or in the
+        `CONTAINARIUM_WAKE_TRUSTED_PROXIES` allowlist (CIDR or
+        bare IP, comma-separated). 403 is returned before any
+        route lookup or wake side-effect. Wildcard `/0` prefixes
+        are explicitly refused — defeating the gate would be
+        worse than turning it off. Empty allowlist preserves the
+        pre-1.9 behavior with a startup WARNING — the rollout
+        switch is operator-set, not flipped silently.
 - [x] **1.10** Auth wrap on internal proxies (grafana/alertmanager/guacamole) — `internal/gateway/gateway.go:543-601` (**A-MED-6**)
       — Each proxy now requires a valid JWT before forwarding.
         Backend's own auth still applies on top (defense in depth).

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1068,6 +1068,15 @@ skipAppHosting:
 				wakeAudit,
 				30*time.Second,
 			)
+			// Phase 1.9 — source-IP allowlist (audit A-MED-5).
+			// Loopback is always accepted; the env var adds
+			// remote Caddy hosts when the daemon and Caddy are
+			// on different VMs.
+			if trustedProxies, err := wake.LoadTrustedProxies(); err != nil {
+				log.Fatalf("wake: invalid CONTAINARIUM_WAKE_TRUSTED_PROXIES: %v", err)
+			} else {
+				wakeProxy.SetTrustedProxies(trustedProxies)
+			}
 			gatewayServer.SetWakeHandler(wakeProxy)
 			log.Printf("Wake-on-HTTP enabled (wakeHost=%s wakePort=%d)", config.HostIP, config.HTTPPort)
 		}

--- a/internal/wake/osenv.go
+++ b/internal/wake/osenv.go
@@ -1,0 +1,9 @@
+package wake
+
+import "os"
+
+// osGetenv is a tiny indirection so the trusted-proxies test can
+// stub the env-var read without globally clobbering os.Getenv.
+func osGetenv(key string) string {
+	return os.Getenv(key)
+}

--- a/internal/wake/proxy.go
+++ b/internal/wake/proxy.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"net/netip"
 	"net/url"
 	"strings"
 	"sync"
@@ -55,8 +56,21 @@ type WakeProxy struct {
 	audit       AuditLogger
 	waitTimeout time.Duration
 
+	// Phase 1.9 — source-IP allowlist for the wake handler.
+	// Empty == permissive rollout mode (loopback always
+	// accepted; everything else gated by a startup WARNING).
+	trustedProxies []netip.Prefix
+
 	inflightMu sync.Mutex
 	inflight   map[string]*inflightWake // key: containerName
+}
+
+// SetTrustedProxies configures the source-IP allowlist for the
+// wake handler. Pass nil/empty to keep rollout-mode permissive
+// (the constructor's default). Typically wired at dual-server
+// startup from LoadTrustedProxies().
+func (w *WakeProxy) SetTrustedProxies(p []netip.Prefix) {
+	w.trustedProxies = p
 }
 
 // RouteStore is the narrow interface WakeProxy needs to fetch a
@@ -109,6 +123,17 @@ func NewWakeProxy(
 // `Upgrade: websocket` requests — they just work.
 func (w *WakeProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	start := time.Now()
+
+	// Phase 1.9: source-IP gate. Only loopback (Caddy on the
+	// same host, the production shape) or explicitly trusted
+	// proxies may invoke /wake/. Other sources see 403 — the
+	// wake handler is not a public primitive.
+	if !isTrustedSource(req, w.trustedProxies) {
+		log.Printf("[wake] refused: remote=%s host=%q (not in trusted-proxy allowlist)", req.RemoteAddr, req.Host)
+		http.Error(rw, "wake: source not permitted", http.StatusForbidden)
+		return
+	}
+
 	host := req.Host
 	// Strip the daemon-test prefix if present. Caddy proxies the
 	// original path through unchanged, but humans hitting the daemon

--- a/internal/wake/trusted_proxies.go
+++ b/internal/wake/trusted_proxies.go
@@ -1,0 +1,117 @@
+package wake
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+// Phase 1.9 — trusted-proxy gate on the wake handler
+// (audit A-MED-5).
+//
+// /wake/ and the root catch-all are intentionally outside the
+// JWT auth middleware — Caddy forwards arbitrary user traffic
+// to the wake handler when a container is in scale-to-zero
+// state, and that traffic doesn't carry a daemon JWT.
+//
+// But "outside auth" means an attacker who can reach the
+// daemon port directly (bypassing Caddy via a misrouted
+// firewall, a leaked internal IP, an SSRF chain) can wake any
+// container by crafting the Host header. The wake itself isn't
+// directly destructive, but it triggers container starts that
+// consume real CPU/disk/network — fine as a side effect of
+// genuine user traffic, dangerous as a primitive an attacker
+// can repeatedly invoke.
+//
+// The fix is a source-IP allowlist. The wake handler now
+// accepts requests only from:
+//   - loopback (127.0.0.0/8, ::1) — Caddy on the same host,
+//     the production deployment shape
+//   - any prefix in CONTAINARIUM_WAKE_TRUSTED_PROXIES — for
+//     deployments where Caddy lives on a different VM
+//
+// An empty trust list with the env var unset preserves the
+// pre-Phase-1.9 behavior with a startup WARNING — a backwards-
+// compatible rollout step. Once operators have set the env
+// var on every deployment that needs it, the warning branch
+// can be removed.
+
+const trustedProxiesEnv = "CONTAINARIUM_WAKE_TRUSTED_PROXIES"
+
+// LoadTrustedProxies reads the env var, parses CIDR/IP entries,
+// and returns the resulting prefix list. Empty list means
+// "accept anything" (with a one-shot warning). Errors at parse
+// time abort the load — better to log + return nil than to
+// silently degrade.
+func LoadTrustedProxies() ([]netip.Prefix, error) {
+	raw := strings.TrimSpace(getEnv(trustedProxiesEnv))
+	if raw == "" {
+		log.Printf("WARNING: %s is unset — wake handler accepts requests from any source IP (audit A-MED-5)", trustedProxiesEnv)
+		return nil, nil
+	}
+	var out []netip.Prefix
+	for _, e := range strings.Split(raw, ",") {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		// Accept bare IPs as /32 (/128 for v6) for convenience.
+		if !strings.Contains(e, "/") {
+			addr, err := netip.ParseAddr(e)
+			if err != nil {
+				return nil, fmt.Errorf("invalid IP %q in %s: %w", e, trustedProxiesEnv, err)
+			}
+			out = append(out, netip.PrefixFrom(addr, addr.BitLen()))
+			continue
+		}
+		p, err := netip.ParsePrefix(e)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR %q in %s: %w", e, trustedProxiesEnv, err)
+		}
+		if p.Bits() == 0 {
+			return nil, fmt.Errorf("wildcard CIDR %q in %s would defeat the gate; refuse", e, trustedProxiesEnv)
+		}
+		out = append(out, p)
+	}
+	log.Printf("[wake] trusted proxies: %v", out)
+	return out, nil
+}
+
+// isTrustedSource returns true if `r.RemoteAddr` is loopback or
+// matches one of the configured trusted prefixes. When the
+// allowlist is empty (env unset), returns true — backwards-
+// compatible fail-open for the rollout window.
+func isTrustedSource(r *http.Request, allowlist []netip.Prefix) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		// Unparseable RemoteAddr — fail closed.
+		return false
+	}
+	if addr.IsLoopback() {
+		return true
+	}
+	if len(allowlist) == 0 {
+		return true // rollout-mode permissive default
+	}
+	for _, p := range allowlist {
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+// getEnv is overridable in tests; default reads from os.Getenv.
+var getEnv = func(key string) string {
+	// imported here so tests can swap it out without pulling
+	// the os package into every callsite. The whole file uses
+	// this single seam.
+	return osGetenv(key)
+}

--- a/internal/wake/trusted_proxies_test.go
+++ b/internal/wake/trusted_proxies_test.go
@@ -1,0 +1,234 @@
+package wake
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Phase 1.9 — tests for the wake source-IP gate (audit A-MED-5).
+
+func withEnv(t *testing.T, val string) {
+	t.Helper()
+	prev := getEnv
+	getEnv = func(string) string { return val }
+	t.Cleanup(func() { getEnv = prev })
+}
+
+func TestLoadTrustedProxies_EmptyWarnsAndReturnsNil(t *testing.T) {
+	withEnv(t, "")
+	got, err := LoadTrustedProxies()
+	if err != nil {
+		t.Fatalf("unset env should not error, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("unset env should return nil, got %v", got)
+	}
+}
+
+func TestLoadTrustedProxies_ParsesCIDR(t *testing.T) {
+	withEnv(t, "10.0.0.0/8, 192.168.1.0/24")
+	got, err := LoadTrustedProxies()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 prefixes, got %d", len(got))
+	}
+	if got[0].String() != "10.0.0.0/8" {
+		t.Fatalf("first prefix: got %s", got[0])
+	}
+	if got[1].String() != "192.168.1.0/24" {
+		t.Fatalf("second prefix: got %s", got[1])
+	}
+}
+
+func TestLoadTrustedProxies_BareIPBecomesHostPrefix(t *testing.T) {
+	withEnv(t, "192.168.1.5, ::1")
+	got, err := LoadTrustedProxies()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 prefixes, got %d", len(got))
+	}
+	if got[0].String() != "192.168.1.5/32" {
+		t.Fatalf("bare v4 should become /32, got %s", got[0])
+	}
+	if got[1].String() != "::1/128" {
+		t.Fatalf("bare v6 should become /128, got %s", got[1])
+	}
+}
+
+func TestLoadTrustedProxies_RejectsWildcard(t *testing.T) {
+	withEnv(t, "0.0.0.0/0")
+	_, err := LoadTrustedProxies()
+	if err == nil {
+		t.Fatal("wildcard /0 should be refused")
+	}
+	if !strings.Contains(err.Error(), "wildcard") {
+		t.Fatalf("error should mention wildcard: %v", err)
+	}
+}
+
+func TestLoadTrustedProxies_RejectsMalformed(t *testing.T) {
+	cases := []string{
+		"not-an-ip",
+		"10.0.0.0/garbage",
+		"999.999.999.999",
+		"10.0.0.0/33",
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			withEnv(t, c)
+			_, err := LoadTrustedProxies()
+			if err == nil {
+				t.Fatalf("malformed entry %q should error", c)
+			}
+		})
+	}
+}
+
+func TestLoadTrustedProxies_IgnoresEmptyElements(t *testing.T) {
+	withEnv(t, "10.0.0.0/8,,, ,192.168.0.0/16")
+	got, err := LoadTrustedProxies()
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 prefixes after dropping empties, got %d", len(got))
+	}
+}
+
+func mkReq(remote string) *http.Request {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = remote
+	return r
+}
+
+func TestIsTrustedSource_LoopbackAlwaysAllowed(t *testing.T) {
+	// Even with a non-empty allowlist that excludes loopback,
+	// loopback must always be accepted — Caddy on the same host
+	// is the canonical production shape.
+	allow := []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}
+	cases := []string{"127.0.0.1:54321", "[::1]:54321"}
+	for _, rem := range cases {
+		t.Run(rem, func(t *testing.T) {
+			if !isTrustedSource(mkReq(rem), allow) {
+				t.Fatalf("%s should be trusted (loopback)", rem)
+			}
+		})
+	}
+}
+
+func TestIsTrustedSource_EmptyAllowlistPermissive(t *testing.T) {
+	// Rollout mode: no allowlist configured -> accept anything
+	// (with the startup WARNING from LoadTrustedProxies).
+	if !isTrustedSource(mkReq("203.0.113.5:1234"), nil) {
+		t.Fatal("empty allowlist should be permissive (rollout mode)")
+	}
+}
+
+func TestIsTrustedSource_AllowlistMatches(t *testing.T) {
+	allow := []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.0/8"),
+		netip.MustParsePrefix("192.168.1.5/32"),
+	}
+	cases := map[string]bool{
+		"10.0.0.5:1234":      true,
+		"10.255.255.255:80":  true,
+		"192.168.1.5:1234":   true,
+		"192.168.1.6:1234":   false,
+		"203.0.113.5:1234":   false,
+	}
+	for rem, want := range cases {
+		t.Run(rem, func(t *testing.T) {
+			got := isTrustedSource(mkReq(rem), allow)
+			if got != want {
+				t.Fatalf("%s: got %v want %v", rem, got, want)
+			}
+		})
+	}
+}
+
+func TestIsTrustedSource_UnparseableRemoteAddrFailsClosed(t *testing.T) {
+	// Loopback always-allow happens before the parse, so use a
+	// genuinely unparseable RemoteAddr (no host part, no IP).
+	allow := []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}
+	if isTrustedSource(mkReq("garbage"), allow) {
+		t.Fatal("unparseable RemoteAddr must fail closed")
+	}
+}
+
+func TestIsTrustedSource_HostOnlyRemoteAddr(t *testing.T) {
+	// SplitHostPort fails when there's no port — the code falls
+	// back to using the whole RemoteAddr as the host. Make sure
+	// that path still parses real IPs correctly.
+	allow := []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}
+	if !isTrustedSource(mkReq("10.0.0.5"), allow) {
+		t.Fatal("host-only RemoteAddr should still be parsed and matched")
+	}
+}
+
+// TestServeHTTP_RejectsUntrustedSource validates that the gate
+// short-circuits ServeHTTP with 403 before any route lookup or
+// wake side-effect. Uses the same fake harness as proxy_test.go;
+// the test runs with an allowlist that excludes RemoteAddr.
+func TestServeHTTP_RejectsUntrustedSource(t *testing.T) {
+	const fullDomain = "alice-web.example.test"
+	proxy := NewWakeProxy(
+		&fakeStarter{ready: true},
+		&fakeLookup{fullDomain: fullDomain, containerName: "alice-container"},
+		&fakeRouteStore{},
+		nil,
+		nil,
+		1*time.Second,
+	)
+	// Allowlist contains only 10.0.0.0/8; httptest.NewRequest's
+	// default RemoteAddr is 192.0.2.1 (TEST-NET-1), which won't
+	// match and isn't loopback.
+	proxy.SetTrustedProxies([]netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")})
+
+	req := httptest.NewRequest(http.MethodGet, "http://"+fullDomain+"/", nil)
+	req.Host = fullDomain
+	rec := httptest.NewRecorder()
+	proxy.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("untrusted source: got %d, want 403; body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// TestServeHTTP_AcceptsLoopbackEvenWithAllowlist confirms the
+// loopback exemption — production deployments have Caddy on the
+// same host as the daemon, so 127.0.0.1 must always work even
+// when operators have set a strict allowlist that doesn't
+// include loopback.
+func TestServeHTTP_AcceptsLoopbackEvenWithAllowlist(t *testing.T) {
+	const fullDomain = "alice-web.example.test"
+	proxy := NewWakeProxy(
+		&fakeStarter{ready: false, err: nil}, // wake will time-out → 503
+		&fakeLookup{fullDomain: fullDomain, containerName: "alice-container"},
+		&fakeRouteStore{},
+		nil,
+		nil,
+		10*time.Millisecond,
+	)
+	proxy.SetTrustedProxies([]netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")})
+
+	req := httptest.NewRequest(http.MethodGet, "http://"+fullDomain+"/", nil)
+	req.Host = fullDomain
+	req.RemoteAddr = "127.0.0.1:54321"
+	rec := httptest.NewRecorder()
+	proxy.ServeHTTP(rec, req)
+
+	// Loopback should pass the gate. Past the gate, the
+	// (failing) wake takes over — anything other than 403 means
+	// the gate let us through.
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("loopback should bypass the gate even with strict allowlist; got 403 body=%q", rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- **Source-IP gate on `WakeProxy.ServeHTTP`.** `/wake/` no longer accepts requests from arbitrary sources — only loopback (Caddy on the same host) or `CONTAINARIUM_WAKE_TRUSTED_PROXIES` allowlist members. Untrusted sources get **403 before any route lookup or wake side-effect** — they can't trigger container starts by crafting Host headers.
- **Backwards-compatible rollout.** Empty env preserves pre-1.9 behavior with a startup `WARNING` log. Once operators have set the env var on every deployment that needs it, the warning branch can be removed.
- **Anti-foot-gun.** Wildcard `/0` prefixes are explicitly refused at load — defeating the gate would be worse than turning it off. Bare IPs become `/32`/`/128` automatically for ergonomic configs.

Addresses audit finding **A-MED-5** (Phase 1.9 in `docs/security/ZERO-TRUST-TODO.md`).

## Files

- `internal/wake/trusted_proxies.go` — `LoadTrustedProxies()` + `isTrustedSource(r, allowlist)`
- `internal/wake/osenv.go` — env-var seam for testability
- `internal/wake/proxy.go` — gate wired at top of `ServeHTTP`; `SetTrustedProxies` setter; new `trustedProxies` field
- `internal/server/dual_server.go` — `LoadTrustedProxies()` called at WakeProxy construction
- `internal/wake/trusted_proxies_test.go` — env parsing + gate semantics (loopback exemption, allowlist match/miss, malformed entries, wildcard refusal)
- `docs/security/ZERO-TRUST-TODO.md` — 1.9 marked complete

## Operator note

Set `CONTAINARIUM_WAKE_TRUSTED_PROXIES` if Caddy lives on a different host from the daemon:

```bash
# Same-host Caddy (production default): no env needed — loopback always accepted
# Remote Caddy on 10.0.0.0/8:
CONTAINARIUM_WAKE_TRUSTED_PROXIES=10.0.0.0/8

# Multiple sources:
CONTAINARIUM_WAKE_TRUSTED_PROXIES=10.0.0.0/8,192.168.1.5,fd00::/8
```

If unset, you'll see this WARNING at startup:
```
WARNING: CONTAINARIUM_WAKE_TRUSTED_PROXIES is unset — wake handler accepts requests from any source IP (audit A-MED-5)
```

## Test plan

- [x] Unit tests pass (`go test ./internal/wake/...`)
- [x] `go build ./...` clean
- [ ] CI green
- [ ] Manual: confirm 403 on a non-trusted IP with the allowlist set
- [ ] Manual: confirm WARNING logged on startup when env unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)