### PR TITLE
sec: zero-trust Phase 1.7 — MCP per-tool scopes

### DIFF
--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -176,7 +176,39 @@ on the internal network. Land them first.
         for SSE — follow-up to rewrite with `fetch` +
         `ReadableStream` is tracked under [1.6 / refresh tokens].
 - [ ] **1.6** Short-lived access tokens + refresh tokens — `internal/auth/token.go:14` (**C-MED-8**)
-- [ ] **1.7** Per-tool scopes for MCP — `internal/mcp/tools.go`, `internal/mcp/client.go`
+- [x] **1.7** Per-tool scopes for MCP — `internal/mcp/tools.go`, `internal/mcp/client.go`
+      — New `scopes` claim on JWTs (variadic
+        `GenerateToken(..., scopes...)`) + OAuth2-style
+        taxonomy in `internal/auth/scopes.go`
+        (`containers:read|write`, `secrets:read|write`,
+        `routes:read|write`, `security:read|write`,
+        `code:write`, `ssh:write`, plus `*` wildcard).
+        Backwards-compat: nil/missing scopes claim →
+        unrestricted (existing tokens unaffected).
+      — Every MCP tool now carries a `RequiredScope`
+        (assigned in one auditable table in
+        `tools.go:toolScopeAssignments`). The MCP server
+        filters `tools/list` to the JWT's effective scope
+        set and rejects `tools/call` for tools the token
+        can't satisfy — fast local rejection before the
+        request even hits the network. Daemon-side checks
+        remain authoritative; this is defense in depth.
+      — CLI: `containarium token generate --scopes
+        containers:read,secrets:read` mints a
+        least-privilege token (e.g. for handing to an LLM
+        agent). Empty `--scopes` flag preserves pre-1.7
+        unrestricted issuance.
+      — Tests: `scopes_test.go` (HasScope semantics),
+        `scope_filter_test.go` (MCP JWT decode + per-tool
+        gating). `TestEveryToolHasScope` is a guard rail:
+        adding a new MCP tool without a scope assignment
+        fails CI.
+      — **Follow-up:** daemon-side server enforcement of
+        the scopes claim on each RPC. Today the MCP filter
+        catches agent abuse; a tenant calling REST/gRPC
+        directly with a scoped token still bypasses the
+        scope check (the role check still applies).
+        Tracked as a Phase 1.7b item.
 - [x] **1.8** Refuse JWT token files with mode > 0600 — `internal/mcp/client.go:57-78` (**C-HIGH-7**)
       — `readToken` `os.Stat`s the file and refuses if any non-owner
         read/write bit is set. Error message tells the operator the

--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -1,0 +1,109 @@
+package auth
+
+import "strings"
+
+// Phase 1.7 — least-privilege scopes for MCP tools (audit
+// finding tracked under the 1.7 line in
+// docs/security/ZERO-TRUST-TODO.md).
+//
+// JWT scopes work the way OAuth2 scopes do: a token can
+// carry an array of granted scopes (`scopes` claim); the
+// receiver checks that the action's required scope is in
+// that list before allowing it. They're orthogonal to roles
+// — admin role + narrow scopes = "this LLM agent can act
+// on my containers but cannot touch secrets" — and the
+// least-privilege win is real for the MCP case where an
+// agent's JWT effectively grants every tool today.
+//
+// Backwards compat is preserved by treating a missing or
+// nil `scopes` claim as "no scope restriction" — existing
+// tokens behave exactly as before. Operators opt in by
+// minting tokens with the `--scopes` flag.
+//
+// Scope strings follow `<resource>:<action>`. The wildcard
+// scope `*` matches anything — useful for the daemon's
+// long-lived "service" tokens which need full surface
+// access. Avoid `*` for tokens handed to agents.
+
+// Scope constants. Keep this list short; new scopes need a
+// careful audit (each new scope is a new policy decision).
+const (
+	ScopeWildcard = "*"
+
+	// container management
+	ScopeContainersRead  = "containers:read"
+	ScopeContainersWrite = "containers:write"
+
+	// secrets (separate from containers — much higher risk)
+	ScopeSecretsRead  = "secrets:read"
+	ScopeSecretsWrite = "secrets:write"
+
+	// routes / expose (network surface)
+	ScopeRoutesRead  = "routes:read"
+	ScopeRoutesWrite = "routes:write"
+
+	// security findings + scanning
+	ScopeSecurityRead  = "security:read"
+	ScopeSecurityWrite = "security:write"
+
+	// developer-loop tools (push, sync, sync_ssh_config)
+	ScopeCodeWrite = "code:write"
+	ScopeSSHWrite  = "ssh:write"
+)
+
+// HasScope returns true when the granted-scopes set covers
+// the required scope. Semantics:
+//
+//   - `granted == nil` → no scope restriction. Returns true
+//     for any required scope. This is the backwards-compat
+//     path: tokens minted before Phase 1.7 don't carry a
+//     scopes claim, and they keep working.
+//   - `granted == []string{"*"}` (or includes "*") → any
+//     scope is allowed.
+//   - otherwise → exact membership check.
+//
+// Empty required scope is interpreted as "no scope needed"
+// (some MCP tools are pure-introspection — list_backends,
+// get_system_info — and don't gate on a resource); these
+// always return true. Use this sparingly; the explicit
+// catalog is the supply chain of trust.
+func HasScope(granted []string, required string) bool {
+	if required == "" {
+		return true
+	}
+	if granted == nil {
+		return true
+	}
+	for _, s := range granted {
+		s = strings.TrimSpace(s)
+		if s == ScopeWildcard || s == required {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseScopes normalizes a comma-separated scope string
+// into a []string suitable for the JWT claim. Whitespace
+// and empty elements are dropped; the order of remaining
+// entries is preserved.
+//
+// Returns nil for an empty or whitespace-only input — the
+// caller decides whether that means "no restriction" (omit
+// the claim) or "deny everything" (set an empty array).
+// HasScope treats nil as "no restriction".
+func ParseScopes(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/auth/scopes_test.go
+++ b/internal/auth/scopes_test.go
@@ -1,0 +1,90 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestHasScope_NilGrantedIsUnrestricted(t *testing.T) {
+	// Pre-1.7 token (no scopes claim). HasScope must let
+	// it through so existing deployments don't break.
+	if !HasScope(nil, ScopeContainersWrite) {
+		t.Fatal("nil granted should be treated as unrestricted")
+	}
+	if !HasScope(nil, "anything") {
+		t.Fatal("nil granted should be treated as unrestricted for any scope")
+	}
+}
+
+func TestHasScope_EmptyRequiredAlwaysAllowed(t *testing.T) {
+	// Some MCP tools are pure introspection — no scope
+	// required. Even an empty-scopes token can call them.
+	if !HasScope([]string{}, "") {
+		t.Fatal("empty required scope should always pass")
+	}
+	if !HasScope(nil, "") {
+		t.Fatal("empty required scope should always pass (nil grants)")
+	}
+}
+
+func TestHasScope_WildcardCoversAll(t *testing.T) {
+	if !HasScope([]string{ScopeWildcard}, ScopeContainersWrite) {
+		t.Fatal("'*' should cover containers:write")
+	}
+	if !HasScope([]string{"some-other", ScopeWildcard}, ScopeSecretsRead) {
+		t.Fatal("'*' anywhere in granted should cover any required")
+	}
+}
+
+func TestHasScope_ExactMatch(t *testing.T) {
+	granted := []string{ScopeContainersRead, ScopeSecretsRead}
+	if !HasScope(granted, ScopeContainersRead) {
+		t.Fatal("exact match should pass")
+	}
+	if HasScope(granted, ScopeContainersWrite) {
+		t.Fatal("missing scope should be rejected")
+	}
+	if HasScope(granted, ScopeSecretsWrite) {
+		t.Fatal("missing scope should be rejected")
+	}
+}
+
+func TestHasScope_EmptyGrantsExplicitDeny(t *testing.T) {
+	// A non-nil but empty granted list means "explicitly
+	// no scopes" — only empty-required tools pass.
+	if HasScope([]string{}, ScopeContainersRead) {
+		t.Fatal("explicit empty grant should deny scoped tools")
+	}
+}
+
+func TestHasScope_TrimsWhitespace(t *testing.T) {
+	// JWT shouldn't have whitespace in arrays, but tolerate
+	// it for hand-edited tokens / unusual issuers.
+	if !HasScope([]string{" containers:read "}, ScopeContainersRead) {
+		t.Fatal("whitespace in granted scope should be trimmed")
+	}
+}
+
+func TestParseScopes(t *testing.T) {
+	cases := map[string][]string{
+		"":                              nil,
+		"   ":                           nil,
+		",,,":                           nil,
+		"containers:read":               {"containers:read"},
+		"containers:read,secrets:read":  {"containers:read", "secrets:read"},
+		" containers:read , secrets:read,, ": {"containers:read", "secrets:read"},
+		"*":                             {"*"},
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			got := ParseScopes(in)
+			if len(got) != len(want) {
+				t.Fatalf("ParseScopes(%q) = %v, want %v", in, got, want)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("ParseScopes(%q)[%d] = %q, want %q", in, i, got[i], want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -30,10 +30,17 @@ const MinSecretKeyLen = 32
 // replayed against the daemon. Tracks audit finding A-HIGH-1.
 const DefaultAudience = "containarium-api"
 
-// Claims represents the JWT claims for authentication
+// Claims represents the JWT claims for authentication.
+//
+// Phase 1.7 — `Scopes` is the OAuth2-style scope list for
+// least-privilege tokens (typically agent-facing tokens).
+// `omitempty` keeps pre-1.7 tokens identical on the wire;
+// HasScope treats a nil/missing scopes array as "no
+// restriction" for backwards compat.
 type Claims struct {
 	Username string   `json:"username"`
 	Roles    []string `json:"roles"`
+	Scopes   []string `json:"scopes,omitempty"`
 	jwt.RegisteredClaims
 }
 
@@ -101,7 +108,13 @@ func NewTokenManager(secretKey string, issuer string) (*TokenManager, error) {
 // cryptographic-random 128-bit ID base64url-encoded. The
 // jti is the key the revocation list operates on, so a
 // token's lifetime can be cut short by writing one row.
-func (tm *TokenManager) GenerateToken(username string, roles []string, expiresIn time.Duration) (string, error) {
+//
+// Phase 1.7: the variadic `scopes` parameter sets the
+// least-privilege `scopes` claim. Pass nothing (or nil)
+// for a no-restriction token — matches pre-1.7 behavior.
+// Pass a list to mint a least-privilege token, e.g. for
+// an LLM agent that should only see read APIs.
+func (tm *TokenManager) GenerateToken(username string, roles []string, expiresIn time.Duration, scopes ...string) (string, error) {
 	// SECURITY FIX: Enforce maximum expiry - no more non-expiring tokens
 	if expiresIn <= 0 || expiresIn > tm.maxTokenExpiry {
 		expiresIn = tm.maxTokenExpiry
@@ -112,9 +125,15 @@ func (tm *TokenManager) GenerateToken(username string, roles []string, expiresIn
 		return "", fmt.Errorf("generate jti: %w", err)
 	}
 
+	var scopesClaim []string
+	if len(scopes) > 0 {
+		scopesClaim = scopes
+	}
+
 	claims := Claims{
 		Username: username,
 		Roles:    roles,
+		Scopes:   scopesClaim,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ID:        jti,
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiresIn)),

--- a/internal/cmd/token.go
+++ b/internal/cmd/token.go
@@ -14,6 +14,7 @@ import (
 var (
 	tokenUsername   string
 	tokenRoles      []string
+	tokenScopes     []string // Phase 1.7 — least-privilege scope list
 	tokenExpiry     string
 	tokenSecretFlag string
 	tokenSecretFile string
@@ -133,6 +134,7 @@ func init() {
 
 	// Optional flags
 	tokenGenerateCmd.Flags().StringSliceVar(&tokenRoles, "roles", []string{"user"}, "Roles for the token (comma-separated)")
+	tokenGenerateCmd.Flags().StringSliceVar(&tokenScopes, "scopes", nil, "Phase 1.7: least-privilege scopes (comma-separated; e.g. containers:read,secrets:read). Omit for an unrestricted token; pass '*' for the wildcard.")
 	tokenGenerateCmd.Flags().StringVar(&tokenExpiry, "expiry", "24h", "Token expiry duration (e.g., 24h, 168h, 720h, 0 for no expiry)")
 	tokenGenerateCmd.Flags().BoolVar(&tokenRaw, "raw", false, "Output only the raw token (for scripting)")
 }
@@ -168,8 +170,10 @@ func runTokenGenerate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("token manager: %w", err)
 	}
 
-	// Generate token
-	token, err := tm.GenerateToken(tokenUsername, tokenRoles, expiresIn)
+	// Generate token. Phase 1.7 — scopes pass through as a
+	// variadic; an empty slice (no --scopes) leaves the
+	// claim unset, matching pre-1.7 behavior.
+	token, err := tm.GenerateToken(tokenUsername, tokenRoles, expiresIn, tokenScopes...)
 	if err != nil {
 		return fmt.Errorf("failed to generate token: %w", err)
 	}
@@ -191,6 +195,11 @@ func runTokenGenerate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Details:\n")
 	fmt.Printf("  Username: %s\n", tokenUsername)
 	fmt.Printf("  Roles:    %v\n", tokenRoles)
+	if len(tokenScopes) > 0 {
+		fmt.Printf("  Scopes:   %v\n", tokenScopes)
+	} else {
+		fmt.Printf("  Scopes:   <none> (unrestricted)\n")
+	}
 	if expiresIn > 0 {
 		expiryTime := time.Now().Add(expiresIn)
 		fmt.Printf("  Expires:  %s (%s from now)\n", expiryTime.Format(time.RFC3339), expiresIn)

--- a/internal/mcp/scope_filter.go
+++ b/internal/mcp/scope_filter.go
@@ -1,0 +1,84 @@
+package mcp
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+// Phase 1.7 — MCP-side enforcement of least-privilege
+// scopes on the JWT.
+//
+// We decode the JWT payload WITHOUT verifying its signature.
+// Two reasons:
+//   1. The signature secret isn't on the MCP-server side —
+//      it lives on the daemon, which does the canonical
+//      check on every API call. The MCP server can't forge
+//      a token even if it lies about the scopes it sees.
+//   2. The point of the MCP-side filter is to refuse a
+//      tools/list / tools/call BEFORE we hit the network,
+//      so an agent that asks for an out-of-scope tool gets
+//      a clean rejection instead of a wire round-trip.
+//
+// Even if a malicious agent edited its JWT to claim broader
+// scopes, the daemon's verified check still gates the real
+// call. The MCP filter is defense in depth, not the
+// canonical authoritative layer.
+//
+// If the token can't be parsed (e.g. an opaque token, or
+// malformed JWT) we treat it as "no scope restriction" —
+// the daemon's check is still authoritative. We don't want
+// to lock operators out of MCP just because their token
+// shape is unusual.
+
+// scopesFromJWT decodes the payload segment of a JWT and
+// returns the `scopes` claim. Returns (nil, true) when the
+// claim is absent — caller should treat as "no restriction"
+// (HasScope's policy). Returns (nil, false) when the token
+// is unparseable (e.g. an opaque non-JWT bearer) — same
+// upstream policy.
+func scopesFromJWT(token string) (scopes []string, parsed bool) {
+	segments := strings.Split(token, ".")
+	if len(segments) != 3 {
+		return nil, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(segments[1])
+	if err != nil {
+		// Some JWT issuers pad; fall back.
+		payload, err = base64.URLEncoding.DecodeString(segments[1])
+		if err != nil {
+			return nil, false
+		}
+	}
+	var claims struct {
+		Scopes []string `json:"scopes"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, false
+	}
+	return claims.Scopes, true
+}
+
+// allowedScopes returns the effective scope set for the
+// MCP server's current JWT. Errors / no-token cases return
+// nil (== no restriction, matching HasScope semantics).
+func (s *Server) allowedScopes() []string {
+	if s == nil || s.client == nil {
+		return nil
+	}
+	token, err := s.client.readToken()
+	if err != nil || token == "" {
+		return nil
+	}
+	scopes, _ := scopesFromJWT(token)
+	return scopes
+}
+
+// toolAllowed returns true when the tool's required scope
+// is satisfied by the JWT's granted scopes. Wraps
+// auth.HasScope so the policy lives in one place.
+func toolAllowed(grantedScopes []string, tool *Tool) bool {
+	return auth.HasScope(grantedScopes, tool.RequiredScope)
+}

--- a/internal/mcp/scope_filter_test.go
+++ b/internal/mcp/scope_filter_test.go
@@ -1,0 +1,126 @@
+package mcp
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+// makeUnsignedJWT crafts a JWT with the given claims and a
+// dummy signature segment. scopesFromJWT doesn't verify the
+// signature (the daemon does that on the actual API call),
+// so this is enough for the MCP-side filter tests.
+func makeUnsignedJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	header := map[string]string{"alg": "HS256", "typ": "JWT"}
+	hb, _ := json.Marshal(header)
+	pb, _ := json.Marshal(claims)
+	enc := func(b []byte) string {
+		return base64.RawURLEncoding.EncodeToString(b)
+	}
+	return strings.Join([]string{enc(hb), enc(pb), "sig"}, ".")
+}
+
+func TestScopesFromJWT_PresentClaim(t *testing.T) {
+	tok := makeUnsignedJWT(t, map[string]interface{}{
+		"username": "alice",
+		"scopes":   []string{"containers:read", "secrets:read"},
+	})
+	got, ok := scopesFromJWT(tok)
+	if !ok {
+		t.Fatal("expected parsed=true")
+	}
+	if len(got) != 2 || got[0] != "containers:read" || got[1] != "secrets:read" {
+		t.Fatalf("scopes = %v", got)
+	}
+}
+
+func TestScopesFromJWT_AbsentClaim(t *testing.T) {
+	tok := makeUnsignedJWT(t, map[string]interface{}{
+		"username": "alice",
+	})
+	got, ok := scopesFromJWT(tok)
+	if !ok {
+		t.Fatal("expected parsed=true even without scopes claim")
+	}
+	if got != nil {
+		t.Fatalf("scopes should be nil when claim absent; got %v", got)
+	}
+}
+
+func TestScopesFromJWT_OpaqueToken(t *testing.T) {
+	// Not a JWT — caller should treat unparseable tokens as
+	// "no restriction" (the daemon's verified check still
+	// applies on the real call).
+	got, ok := scopesFromJWT("opaque-bearer-token")
+	if ok {
+		t.Fatal("expected parsed=false for non-JWT")
+	}
+	if got != nil {
+		t.Fatalf("scopes should be nil for non-JWT; got %v", got)
+	}
+}
+
+func TestToolAllowed_NilGrantsLetEverythingThrough(t *testing.T) {
+	tool := &Tool{Name: "create_container", RequiredScope: auth.ScopeContainersWrite}
+	if !toolAllowed(nil, tool) {
+		t.Fatal("nil grants should be unrestricted (backwards compat)")
+	}
+}
+
+func TestToolAllowed_RequiredScopeChecked(t *testing.T) {
+	tool := &Tool{Name: "create_container", RequiredScope: auth.ScopeContainersWrite}
+	if !toolAllowed([]string{auth.ScopeContainersWrite}, tool) {
+		t.Fatal("granted scope should pass")
+	}
+	if toolAllowed([]string{auth.ScopeContainersRead}, tool) {
+		t.Fatal("wrong scope should be rejected")
+	}
+}
+
+func TestToolAllowed_EmptyRequiredAlwaysPasses(t *testing.T) {
+	tool := &Tool{Name: "list_backends", RequiredScope: ""}
+	if !toolAllowed([]string{}, tool) {
+		t.Fatal("zero-scope tool should pass even on empty grants")
+	}
+}
+
+// TestEveryToolHasScope guards against regressions where a
+// new tool is added to registerTools without a scope
+// assignment. The mapping in toolScopeAssignments() must
+// list every registered tool. Compiles a fresh registry by
+// constructing a server with a minimal config and reading
+// its tools.
+func TestEveryToolHasScope(t *testing.T) {
+	// Tools with intentionally empty scope (zero-priv
+	// introspection that any token can call) go here. Keep
+	// this list narrow — adding tools to it widens the
+	// MCP-side blast radius.
+	exemptions := map[string]bool{}
+
+	assignments := toolScopeAssignments()
+	srv := &Server{}
+	srv.registerTools()
+	if len(srv.tools) == 0 {
+		t.Fatal("no tools registered — test harness broken")
+	}
+	for _, tool := range srv.tools {
+		if exemptions[tool.Name] {
+			continue
+		}
+		assigned, ok := assignments[tool.Name]
+		if !ok {
+			t.Errorf("tool %q has no entry in toolScopeAssignments() — add one before merging", tool.Name)
+			continue
+		}
+		if assigned == "" {
+			t.Errorf("tool %q maps to empty scope; either give it a real scope or add to exemptions", tool.Name)
+		}
+		if tool.RequiredScope != assigned {
+			t.Errorf("tool %q RequiredScope=%q but table says %q", tool.Name, tool.RequiredScope, assigned)
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -106,15 +106,24 @@ func (s *Server) handleInitialize(req *MCPRequest) *MCPResponse {
 	}
 }
 
-// handleToolsList handles the tools/list request
+// handleToolsList handles the tools/list request. Phase 1.7
+// — when the JWT carries a `scopes` claim we filter the
+// catalog down to tools whose RequiredScope the token can
+// satisfy. A nil/missing scopes claim is treated as "no
+// restriction" (backwards compat for pre-1.7 tokens), in
+// which case every registered tool is returned.
 func (s *Server) handleToolsList(req *MCPRequest) *MCPResponse {
-	tools := make([]map[string]interface{}, len(s.tools))
-	for i, tool := range s.tools {
-		tools[i] = map[string]interface{}{
-			"name":        tool.Name,
-			"description": tool.Description,
-			"inputSchema": tool.InputSchema,
+	granted := s.allowedScopes()
+	tools := make([]map[string]interface{}, 0, len(s.tools))
+	for i := range s.tools {
+		if !toolAllowed(granted, &s.tools[i]) {
+			continue
 		}
+		tools = append(tools, map[string]interface{}{
+			"name":        s.tools[i].Name,
+			"description": s.tools[i].Description,
+			"inputSchema": s.tools[i].InputSchema,
+		})
 	}
 
 	return &MCPResponse{
@@ -154,6 +163,16 @@ func (s *Server) handleToolsCall(req *MCPRequest) *MCPResponse {
 
 	if tool == nil {
 		return s.createErrorResponse(req.ID, -32602, "Tool not found", fmt.Sprintf("Tool '%s' not found", params.Name))
+	}
+
+	// Phase 1.7 — refuse calls to tools the JWT's scope set
+	// doesn't cover. Daemon-side gates still enforce the
+	// canonical check; this is a fast local rejection so
+	// out-of-scope tool calls don't even hit the network.
+	if !toolAllowed(s.allowedScopes(), tool) {
+		return s.createErrorResponse(req.ID, -32603,
+			fmt.Sprintf("Tool '%s' requires scope %q which the current token does not grant", tool.Name, tool.RequiredScope),
+			"insufficient scope")
 	}
 
 	// Execute tool

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/pkg/core/expose"
 )
 
@@ -74,12 +75,25 @@ func saveEphemeralPrivateKey(username string, key []byte) (string, error) {
 	return path, nil
 }
 
-// Tool represents an MCP tool (function)
+// Tool represents an MCP tool (function).
+//
+// Phase 1.7 — RequiredScope names the least-privilege scope
+// (`<resource>:<action>`) a JWT must carry to invoke this
+// tool. Empty string means "no scope needed" (introspection
+// helpers only). The MCP server filters tools/list and
+// rejects tools/call when the JWT's scope set doesn't cover
+// the requirement; see internal/auth/scopes.go for the
+// taxonomy and semantics.
+//
+// Backwards compat: tokens minted before Phase 1.7 have no
+// scopes claim. HasScope treats nil as "no restriction", so
+// existing tokens continue to see every tool.
 type Tool struct {
-	Name        string
-	Description string
-	InputSchema map[string]interface{}
-	Handler     ToolHandler
+	Name          string
+	Description   string
+	InputSchema   map[string]interface{}
+	Handler       ToolHandler
+	RequiredScope string
 }
 
 // ToolHandler is a function that handles a tool call
@@ -858,6 +872,59 @@ func (s *Server) registerTools() {
 			},
 			Handler: handleExposePort,
 		},
+	}
+
+	// Phase 1.7 — assign required scope per tool. Done as a
+	// post-pass so the slice literals above stay short and
+	// the security policy lives in one auditable spot. New
+	// tools added to the slice above MUST also gain an
+	// entry here or they default to `""` (no-scope, allowed
+	// to any token) — see TestEveryToolHasScope which
+	// enforces this in CI.
+	scopeByTool := toolScopeAssignments()
+	for i := range s.tools {
+		s.tools[i].RequiredScope = scopeByTool[s.tools[i].Name]
+	}
+}
+
+// toolScopeAssignments is the canonical scope-per-tool
+// table. Kept as a function so tests can assert
+// completeness against the registered tool list.
+func toolScopeAssignments() map[string]string {
+	return map[string]string{
+		// container lifecycle
+		"create_container":   auth.ScopeContainersWrite,
+		"delete_container":   auth.ScopeContainersWrite,
+		"start_container":    auth.ScopeContainersWrite,
+		"stop_container":     auth.ScopeContainersWrite,
+		"resize_container":   auth.ScopeContainersWrite,
+		"move_container":     auth.ScopeContainersWrite,
+		"toggle_monitoring":  auth.ScopeContainersWrite,
+		"toggle_auto_sleep":  auth.ScopeContainersWrite,
+		"list_containers":    auth.ScopeContainersRead,
+		"get_container":      auth.ScopeContainersRead,
+		"debug_container":    auth.ScopeContainersRead,
+		"get_metrics":        auth.ScopeContainersRead,
+		"get_system_info":    auth.ScopeContainersRead,
+		"list_backends":      auth.ScopeContainersRead,
+		"get_backend":        auth.ScopeContainersRead,
+		// secrets
+		"set_secret":      auth.ScopeSecretsWrite,
+		"delete_secret":   auth.ScopeSecretsWrite,
+		"refresh_secrets": auth.ScopeSecretsWrite,
+		"get_secret":      auth.ScopeSecretsRead,
+		"list_secrets":    auth.ScopeSecretsRead,
+		// routes / network exposure
+		"list_routes": auth.ScopeRoutesRead,
+		"expose_port": auth.ScopeRoutesWrite,
+		// security tools
+		"security_scan":      auth.ScopeSecurityWrite,
+		"security_remediate": auth.ScopeSecurityWrite,
+		"security_findings":  auth.ScopeSecurityRead,
+		// developer-loop tools
+		"push":            auth.ScopeCodeWrite,
+		"sync":            auth.ScopeCodeWrite,
+		"sync_ssh_config": auth.ScopeSSHWrite,
 	}
 }
 


### PR DESCRIPTION
## Summary

Least-privilege OAuth2-style scopes on the JWT, with MCP-side per-tool gating.

An operator can now mint a narrow token

\`\`\`bash
containarium token generate --username agent \\
    --scopes containers:read,secrets:read \\
    --expiry 24h --secret \$JWT
\`\`\`

hand it to an LLM agent, and the agent's MCP server will both:
1. **Hide every other tool** from \`tools/list\`.
2. **Refuse the call locally** (before the network round-trip) if the agent tries to invoke an out-of-scope tool.

The daemon's role-based check still applies on top — this is **defense in depth**, not the only gate.

## Scope taxonomy

\`internal/auth/scopes.go\`:

| Scope | Tools |
|---|---|
| \`containers:read\` | list_containers, get_container, debug_container, get_metrics, get_system_info, list_backends, get_backend |
| \`containers:write\` | create_container, delete_container, start_container, stop_container, resize_container, move_container, toggle_monitoring, toggle_auto_sleep |
| \`secrets:read\` | get_secret, list_secrets |
| \`secrets:write\` | set_secret, delete_secret, refresh_secrets |
| \`routes:read\` | list_routes |
| \`routes:write\` | expose_port |
| \`security:read\` | security_findings |
| \`security:write\` | security_scan, security_remediate |
| \`code:write\` | push, sync |
| \`ssh:write\` | sync_ssh_config |
| \`*\` | wildcard — everything |

## Backwards compatibility

| Token shape | Behavior |
|---|---|
| pre-1.7 (no \`scopes\` claim) | unrestricted (matches old behavior exactly) |
| \`scopes: ["*"]\` | unrestricted |
| \`scopes: ["containers:read"]\` | only containers:read tools |
| \`scopes: []\` (explicit empty) | tools with non-empty RequiredScope all denied |

## MCP enforcement (\`internal/mcp/scope_filter.go\`)

- \`scopesFromJWT\` decodes the payload segment **without** verifying the signature. The daemon does the canonical signed check on every real API call; the MCP filter is a fast local rejection so out-of-scope calls don't even hit the network.
- Opaque (non-JWT) tokens → treated as nil grants → unrestricted on the MCP side; the daemon's gate is still authoritative.
- \`handleToolsList\` filters by effective scope set.
- \`handleToolsCall\` rejects with JSON-RPC \`-32603\` if the JWT can't cover the tool's RequiredScope.

## Tests

- \`scopes_test.go\` — HasScope semantics (nil grants, wildcard, whitespace, explicit empty deny), ParseScopes
- \`scope_filter_test.go\` — JWT decode edge cases (absent claim, opaque non-JWT), per-tool gate behavior
- **\`TestEveryToolHasScope\`** — guard rail: adding a new MCP tool without a scope assignment breaks CI

\`\`\`
ok  github.com/footprintai/containarium/internal/auth  1.132s
ok  github.com/footprintai/containarium/internal/mcp   1.690s
\`\`\`

## Follow-up

**Phase 1.7b (next slice):** daemon-side enforcement of the \`scopes\` claim on each gRPC/REST RPC. Today a tenant with a scoped token calling REST directly still bypasses the scope check (only the role gate fires). The MCP filter catches the agent abuse vector; the daemon needs the same gate for completeness.

## Test plan

- [x] Unit tests pass
- [x] \`go build ./...\` clean
- [ ] CI green
- [ ] Manual: mint a token with \`--scopes containers:read,secrets:read\`, point an MCP client at it, confirm \`tools/list\` returns only the read tools
- [ ] Manual: try to invoke \`create_container\` from the same agent — confirm the MCP server returns -32603 with the scope-mismatch message

🤖 Generated with [Claude Code](https://claude.com/claude-code)