### PR TITLE
sec: zero-trust — MCP revoke_token wrapper + tokens:write scope

### DIFF
--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -117,9 +117,14 @@ on the internal network. Land them first.
         `proto/containarium/v1/tokens.proto`,
         `internal/server/tokens_server.go`, and
         `internal/cmd/token.go`. 10 server-side tests.
-      — Follow-up: MCP tool wrapper for the same RPC (one
-        more `tools.go` registration; thin wrapper per the
-        CLI-first convention).
+      — **MCP wrapper landed.** New `revoke_token` tool in
+        `internal/mcp/tools.go`; thin wrapper over
+        `Client.RevokeToken` which POSTs the same REST
+        endpoint as the CLI. Requires admin role on the
+        server and the new `tokens:write` scope, so an
+        agent token without explicit grant can't kill
+        other tokens. Server-side test confirms
+        admin-without-scope is rejected.
 - [x] **1.3** Require min 32-byte JWT secret in `NewTokenManager` — `internal/auth/token.go:24-45` (**A-MED-2**)
       — `NewTokenManager` now returns `(*TokenManager, error)` and refuses
         secrets shorter than 32 bytes. Fail-closed at daemon startup.

--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -49,6 +49,12 @@ const (
 	// developer-loop tools (push, sync, sync_ssh_config)
 	ScopeCodeWrite = "code:write"
 	ScopeSSHWrite  = "ssh:write"
+
+	// JWT lifecycle (revoke). Admin role still required on
+	// the server side — this scope just narrows what an
+	// agent token CAN do; admin-on-paper agent tokens
+	// without `tokens:write` can't revoke either.
+	ScopeTokensWrite = "tokens:write"
 )
 
 // HasScope returns true when the granted-scopes set covers

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -276,6 +276,35 @@ func (c *Client) ResizeContainer(username, cpu, memory, disk string) (*ResizeCon
 
 // SetSecret creates or updates a tenant secret. Idempotent —
 // repeated calls with the same (username, name) bump the version.
+// RevokeToken adds a JWT's jti to the daemon's revocation
+// list via the canonical REST endpoint added in PR #249.
+// Admin-only on the server side. Pass empty strings for
+// `reason` / `expiresAt` to let the daemon default them.
+func (c *Client) RevokeToken(jti, reason, expiresAt string) (string, error) {
+	body := map[string]string{"jti": jti}
+	if reason != "" {
+		body["reason"] = reason
+	}
+	if expiresAt != "" {
+		body["expires_at"] = expiresAt
+	}
+	respBody, err := c.doRequest("POST", "/v1/tokens/revoke", body)
+	if err != nil {
+		return "", err
+	}
+	var resp struct {
+		NewlyRevoked bool   `json:"newlyRevoked"`
+		Message      string `json:"message"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return "", fmt.Errorf("decode: %w", err)
+	}
+	if resp.Message == "" {
+		resp.Message = "jti added to revocation list"
+	}
+	return resp.Message, nil
+}
+
 func (c *Client) SetSecret(username, name, value string) (*SecretResponse, error) {
 	body, err := json.Marshal(map[string]string{
 		"username": username, "name": name, "value": value,

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,7 +22,7 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	assert.Len(t, server.tools, 28, "Should have 28 tools registered")
+	assert.Len(t, server.tools, 29, "Should have 29 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -126,7 +126,7 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	assert.Len(t, tools, 28)
+	assert.Len(t, tools, 29)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -872,6 +872,36 @@ func (s *Server) registerTools() {
 			},
 			Handler: handleExposePort,
 		},
+		{
+			Name: "revoke_token",
+			Description: "Admin: revoke a JWT by its jti. The token is rejected " +
+				"on the next request that names it. Pairs with the daemon's " +
+				"revocation list (Phase 1.2). Idempotent — repeated revokes " +
+				"preserve the original reason. Use when a token leaks, when " +
+				"rotating an agent credential, or when terminating an active " +
+				"session. The jti is in the audit-log entry of any request the " +
+				"token made; you can also base64-decode the JWT payload to find " +
+				"it. Requires admin role AND tokens:write scope.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"jti": map[string]interface{}{
+						"type":        "string",
+						"description": "The token's jti claim (required).",
+					},
+					"reason": map[string]interface{}{
+						"type":        "string",
+						"description": "Free-form reason recorded for forensics (e.g. 'leaked_to_public_gist', 'rotate'). Default: 'operator_revoke'.",
+					},
+					"expires_at": map[string]interface{}{
+						"type":        "string",
+						"description": "RFC3339 timestamp matching the token's own exp claim. Sets the cleanup horizon so the revocation row prunes when the token would have naturally expired. Default: now + daemon max lifetime.",
+					},
+				},
+				"required": []string{"jti"},
+			},
+			Handler: handleRevokeToken,
+		},
 	}
 
 	// Phase 1.7 — assign required scope per tool. Done as a
@@ -925,6 +955,8 @@ func toolScopeAssignments() map[string]string {
 		"push":            auth.ScopeCodeWrite,
 		"sync":            auth.ScopeCodeWrite,
 		"sync_ssh_config": auth.ScopeSSHWrite,
+		// JWT lifecycle (admin)
+		"revoke_token": auth.ScopeTokensWrite,
 	}
 }
 
@@ -1106,6 +1138,20 @@ func handleDebugContainer(client *Client, args map[string]interface{}) (string, 
 	}
 
 	return string(jsonData), nil
+}
+
+func handleRevokeToken(client *Client, args map[string]interface{}) (string, error) {
+	jti, _ := args["jti"].(string)
+	if jti == "" {
+		return "", fmt.Errorf("jti is required")
+	}
+	reason, _ := args["reason"].(string)
+	expiresAt, _ := args["expires_at"].(string)
+	msg, err := client.RevokeToken(jti, reason, expiresAt)
+	if err != nil {
+		return "", fmt.Errorf("revoke token: %w", err)
+	}
+	return fmt.Sprintf("✅ revoked jti=%s — %s", jti, msg), nil
 }
 
 func handleSetSecret(client *Client, args map[string]interface{}) (string, error) {

--- a/internal/server/tokens_server.go
+++ b/internal/server/tokens_server.go
@@ -61,6 +61,9 @@ func NewTokensServer(tm *auth.TokenManager, store auth.RevocationStore, maxLifet
 //  2. now + daemon max token lifetime (worst-case fallback —
 //     the row eventually prunes itself).
 func (s *TokensServer) RevokeToken(ctx context.Context, req *pb.RevokeTokenRequest) (*pb.RevokeTokenResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeTokensWrite); err != nil {
+		return nil, err
+	}
 	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
 		return nil, err
 	}

--- a/internal/server/tokens_server_test.go
+++ b/internal/server/tokens_server_test.go
@@ -74,6 +74,37 @@ func TestRevokeToken_RejectsNonAdmin(t *testing.T) {
 	}
 }
 
+// Phase 1.7b — RevokeToken now requires the tokens:write
+// scope in addition to the admin role. Admin without the
+// scope must still be rejected (scopes are orthogonal).
+func TestRevokeToken_RejectsAdminMissingScope(t *testing.T) {
+	srv := newTestTokensServer(t, newFakeRevocationStore())
+	ctx := auth.ContextWithTestSubjectScopes(context.Background(),
+		"ops", []string{auth.RoleAdmin},
+		[]string{auth.ScopeContainersRead}, // no tokens:write
+	)
+	_, err := srv.RevokeToken(ctx, &pb.RevokeTokenRequest{Jti: "x"})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("admin without tokens:write: got %v want PermissionDenied", err)
+	}
+}
+
+func TestRevokeToken_AdminWithScopePasses(t *testing.T) {
+	store := newFakeRevocationStore()
+	srv := newTestTokensServer(t, store)
+	ctx := auth.ContextWithTestSubjectScopes(context.Background(),
+		"ops", []string{auth.RoleAdmin},
+		[]string{auth.ScopeTokensWrite},
+	)
+	resp, err := srv.RevokeToken(ctx, &pb.RevokeTokenRequest{Jti: "with-scope"})
+	if err != nil {
+		t.Fatalf("admin+tokens:write should pass; got %v", err)
+	}
+	if !resp.NewlyRevoked {
+		t.Fatal("expected NewlyRevoked=true")
+	}
+}
+
 func TestRevokeToken_RejectsNoSubject(t *testing.T) {
 	srv := newTestTokensServer(t, newFakeRevocationStore())
 	_, err := srv.RevokeToken(context.Background(), &pb.RevokeTokenRequest{Jti: "x"})


### PR DESCRIPTION
## Summary

Completes the Phase 1.2 revocation story end-to-end. The CLI verb landed in #249; this adds the MCP-side equivalent so an agent (with the right scope) can pull the kill-switch without leaving the conversation.

| Surface | Status |
|---|---|
| proto \`TokensService.RevokeToken\` | #249 |
| REST \`POST /v1/tokens/revoke\` | #249 |
| CLI \`containarium token revoke\` | #249 |
| **MCP tool \`revoke_token\`** | **this PR** |

## New scope

\`tokens:write\` — required by \`TokensServer.RevokeToken\` in addition to the existing admin role. Roles and scopes are orthogonal: an **admin** agent token **without** \`tokens:write\` is still rejected.

The CLI keeps working because operator tokens minted without \`--scopes\` have a nil grant (unrestricted, Phase 1.7 backwards compat).

## Files

- \`internal/auth/scopes.go\` — added \`ScopeTokensWrite\`.
- \`internal/server/tokens_server.go\` — \`RevokeToken\` gates on \`tokens:write\` before \`RoleAdmin\`.
- \`internal/mcp/tools.go\` — new \`revoke_token\` tool + scope assignment.
- \`internal/mcp/client.go\` — new \`Client.RevokeToken\` POSTs the same REST endpoint.
- \`internal/mcp/server_test.go\` — bumped tool-count expectation 28 → 29.
- \`internal/server/tokens_server_test.go\` — two new cases: admin-without-scope rejected; admin+scope passes.

## Test plan

- [x] Unit tests pass
- [x] \`go build ./...\` clean
- [ ] CI green
- [ ] Manual: from an MCP-connected agent, call \`revoke_token\` with an admin JWT that grants \`tokens:write\` — confirm success and that subsequent calls with the revoked jti fail 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)