### PR TITLE
sec: zero-trust Phase 1.6 part A — tt claim (access|refresh)

### DIFF
--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -180,7 +180,23 @@ on the internal network. Land them first.
         can't attach headers, so the webui still uses `?token=`
         for SSE — follow-up to rewrite with `fetch` +
         `ReadableStream` is tracked under [1.6 / refresh tokens].
-- [ ] **1.6** Short-lived access tokens + refresh tokens — `internal/auth/token.go:14` (**C-MED-8**)
+- [~] **1.6** Short-lived access tokens + refresh tokens — `internal/auth/token.go:14` (**C-MED-8**)
+      — **Part A landed.** New `tt` claim (access | refresh)
+        on JWTs. Generators `GenerateAccessToken`
+        (15min default) + `GenerateRefreshToken` (30d
+        default). `ValidateAccessToken` is now the HTTP
+        middleware path — it REJECTS refresh tokens, so a
+        stolen refresh token can't authenticate to any API
+        surface (gateway, terminal, audit, SSE). Pre-1.6
+        tokens (no tt claim) are still accepted as access
+        for backwards compat. CLI gains `--token-type
+        access|refresh|''` to choose at issuance time.
+      — **Follow-up (Part B):** add a `/v1/tokens/refresh`
+        RPC + CLI verb that takes a refresh token,
+        validates via `ValidateRefreshToken`, and mints a
+        new (access, refresh) pair. Refresh-token
+        rotation (single-use semantics, revoke the prior
+        on issuance) is the next slice.
 - [x] **1.7** Per-tool scopes for MCP — `internal/mcp/tools.go`, `internal/mcp/client.go`
       — New `scopes` claim on JWTs (variadic
         `GenerateToken(..., scopes...)`) + OAuth2-style

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -52,7 +52,14 @@ func (am *AuthMiddleware) HTTPMiddleware(next http.Handler) http.Handler {
 		// intentionally generic ("invalid token") so we don't leak
 		// reconnaissance details (algorithm name, expiry vs.
 		// signature failure, etc.) to clients. See finding A-MED-7.
-		claims, err := am.tokenManager.ValidateToken(token)
+		//
+		// Phase 1.6 — ValidateAccessToken rejects tokens with
+		// `tt: "refresh"`. A stolen refresh token can be exchanged
+		// at the (future) /v1/tokens/refresh endpoint but cannot
+		// authenticate to any API surface. Pre-1.6 tokens (no tt
+		// claim) are treated as access by ValidateAccessToken for
+		// backwards compat.
+		claims, err := am.tokenManager.ValidateAccessToken(token)
 		if err != nil {
 			// Audit C-MED-3: per-IP token-bucket on failed
 			// validations. Successful auth doesn't consume
@@ -111,7 +118,16 @@ func (am *AuthMiddleware) GRPCStreamInterceptor() grpc.StreamServerInterceptor {
 	}
 }
 
-// ValidateToken validates a JWT token and returns claims
+// ValidateToken validates a JWT and returns claims for use
+// on an API surface. Phase 1.6 — wraps ValidateAccessToken
+// so refresh tokens are rejected. Callers that legitimately
+// want any-token semantics (e.g. the refresh-exchange RPC
+// validating an incoming refresh token) should call the
+// TokenManager directly via ValidateRefreshToken.
+//
+// The name stays "ValidateToken" because every existing
+// callsite is on an API surface where access-only semantics
+// are the right policy.
 func (am *AuthMiddleware) ValidateToken(token string) (*Claims, error) {
-	return am.tokenManager.ValidateToken(token)
+	return am.tokenManager.ValidateAccessToken(token)
 }

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -72,6 +72,35 @@ func TestHTTPMiddleware_AuthGate(t *testing.T) {
 			wantCode: http.StatusOK,
 			wantStub: true,
 		},
+		{
+			// Phase 1.6 — refresh tokens must NOT authenticate
+			// API requests. They can only be exchanged at the
+			// (future) refresh RPC. A stolen refresh token is
+			// therefore unusable against the API directly.
+			name: "Bearer with refresh token → 401, handler does NOT run",
+			setup: func(r *http.Request) {
+				token, err := tm.GenerateRefreshToken("test-user", []string{"admin"}, 5*time.Minute)
+				if err != nil {
+					t.Fatalf("GenerateRefreshToken: %v", err)
+				}
+				r.Header.Set("Authorization", "Bearer "+token)
+			},
+			wantCode: http.StatusUnauthorized,
+			wantStub: false,
+		},
+		{
+			// Pre-1.6 tokens (no tt claim) must keep working.
+			name: "Bearer with access-typed token → 200",
+			setup: func(r *http.Request) {
+				token, err := tm.GenerateAccessToken("test-user", []string{"admin"}, 5*time.Minute)
+				if err != nil {
+					t.Fatalf("GenerateAccessToken: %v", err)
+				}
+				r.Header.Set("Authorization", "Bearer "+token)
+			},
+			wantCode: http.StatusOK,
+			wantStub: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -37,12 +37,43 @@ const DefaultAudience = "containarium-api"
 // `omitempty` keeps pre-1.7 tokens identical on the wire;
 // HasScope treats a nil/missing scopes array as "no
 // restriction" for backwards compat.
+//
+// Phase 1.6 — `TokenType` (claim `tt`) distinguishes access
+// tokens (used for API auth) from refresh tokens (used only
+// to exchange for new access tokens). `omitempty` keeps
+// pre-1.6 tokens identical on the wire; an empty / missing
+// tt is interpreted as TokenTypeAccess (backwards compat).
+// API auth (HTTP middleware) calls ValidateAccessToken,
+// which refuses any token whose tt is explicitly
+// "refresh" — so a stolen refresh token can't make API
+// calls even though it has a valid signature.
 type Claims struct {
-	Username string   `json:"username"`
-	Roles    []string `json:"roles"`
-	Scopes   []string `json:"scopes,omitempty"`
+	Username  string   `json:"username"`
+	Roles     []string `json:"roles"`
+	Scopes    []string `json:"scopes,omitempty"`
+	TokenType string   `json:"tt,omitempty"`
 	jwt.RegisteredClaims
 }
+
+// Token-type constants for the `tt` claim.
+const (
+	TokenTypeAccess  = "access"
+	TokenTypeRefresh = "refresh"
+)
+
+// DefaultRefreshTokenExpiry is the cap for refresh-token
+// lifetime when a caller passes zero. Long enough for a
+// CLI / agent session, short enough that a leaked token
+// has bounded blast radius. Capped at the same
+// maxTokenExpiry as access tokens — operators can shorten
+// either via CONTAINARIUM_MAX_TOKEN_EXPIRY_HOURS.
+const DefaultRefreshTokenExpiry = 30 * 24 * time.Hour
+
+// DefaultAccessTokenExpiry is the default for access tokens
+// minted via GenerateAccessToken when caller passes 0.
+// Short by design — that's the whole point of Phase 1.6;
+// the refresh token does the long-lived work.
+const DefaultAccessTokenExpiry = 15 * time.Minute
 
 // TokenManager handles JWT token generation and validation
 type TokenManager struct {
@@ -115,6 +146,43 @@ func NewTokenManager(secretKey string, issuer string) (*TokenManager, error) {
 // Pass a list to mint a least-privilege token, e.g. for
 // an LLM agent that should only see read APIs.
 func (tm *TokenManager) GenerateToken(username string, roles []string, expiresIn time.Duration, scopes ...string) (string, error) {
+	// Backwards-compatible shim. New code should call
+	// GenerateAccessToken / GenerateRefreshToken directly.
+	// Existing callers (CLI, daemon system tokens) keep
+	// minting access tokens with their current call sites
+	// because tt defaults to "" → access semantics.
+	return tm.generate(username, roles, scopes, "", expiresIn)
+}
+
+// GenerateAccessToken mints a short-lived access token.
+// Phase 1.6 — pass 0 for the daemon default
+// (DefaultAccessTokenExpiry). Carries `tt: "access"`;
+// ValidateAccessToken on the API surface enforces it.
+func (tm *TokenManager) GenerateAccessToken(username string, roles []string, expiresIn time.Duration, scopes ...string) (string, error) {
+	if expiresIn <= 0 {
+		expiresIn = DefaultAccessTokenExpiry
+	}
+	return tm.generate(username, roles, scopes, TokenTypeAccess, expiresIn)
+}
+
+// GenerateRefreshToken mints a long-lived refresh token.
+// Pass 0 for the daemon default (DefaultRefreshTokenExpiry).
+// Carries `tt: "refresh"`; ValidateAccessToken on the API
+// surface REJECTS this token, so a stolen refresh token
+// can't make API calls. Use ValidateRefreshToken when
+// implementing the exchange RPC (Phase 1.6 part B).
+func (tm *TokenManager) GenerateRefreshToken(username string, roles []string, expiresIn time.Duration, scopes ...string) (string, error) {
+	if expiresIn <= 0 {
+		expiresIn = DefaultRefreshTokenExpiry
+	}
+	return tm.generate(username, roles, scopes, TokenTypeRefresh, expiresIn)
+}
+
+// generate is the shared implementation. tt may be the
+// empty string for the legacy GenerateToken path; it
+// stays omitempty on the wire so pre-1.6 token shapes are
+// byte-identical for existing test fixtures.
+func (tm *TokenManager) generate(username string, roles, scopes []string, tt string, expiresIn time.Duration) (string, error) {
 	// SECURITY FIX: Enforce maximum expiry - no more non-expiring tokens
 	if expiresIn <= 0 || expiresIn > tm.maxTokenExpiry {
 		expiresIn = tm.maxTokenExpiry
@@ -131,9 +199,10 @@ func (tm *TokenManager) GenerateToken(username string, roles []string, expiresIn
 	}
 
 	claims := Claims{
-		Username: username,
-		Roles:    roles,
-		Scopes:   scopesClaim,
+		Username:  username,
+		Roles:     roles,
+		Scopes:    scopesClaim,
+		TokenType: tt,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ID:        jti,
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiresIn)),
@@ -224,6 +293,43 @@ func (tm *TokenManager) ValidateToken(tokenString string) (*Claims, error) {
 		}
 	}
 
+	return claims, nil
+}
+
+// ValidateAccessToken validates a token AND enforces that
+// the `tt` claim is either empty (pre-1.6 token, treated as
+// access for backwards compat) or "access". A token marked
+// "refresh" is REJECTED — it must not be usable for API
+// calls. Wire this in the HTTP middleware once the daemon
+// is ready to start enforcing the access/refresh split.
+//
+// Returns the same generic errInvalidToken on any failure
+// (signature, expiry, type mismatch) — no reconnaissance
+// detail leaks to the client.
+func (tm *TokenManager) ValidateAccessToken(tokenString string) (*Claims, error) {
+	claims, err := tm.ValidateToken(tokenString)
+	if err != nil {
+		return nil, err
+	}
+	if claims.TokenType != "" && claims.TokenType != TokenTypeAccess {
+		return nil, errInvalidToken
+	}
+	return claims, nil
+}
+
+// ValidateRefreshToken validates a token AND enforces that
+// `tt == "refresh"`. Used by the refresh-exchange RPC
+// (Phase 1.6 part B). Rejects access tokens and pre-1.6
+// tokens — only an explicit refresh token can be
+// exchanged.
+func (tm *TokenManager) ValidateRefreshToken(tokenString string) (*Claims, error) {
+	claims, err := tm.ValidateToken(tokenString)
+	if err != nil {
+		return nil, err
+	}
+	if claims.TokenType != TokenTypeRefresh {
+		return nil, errInvalidToken
+	}
 	return claims, nil
 }
 

--- a/internal/auth/token_type_test.go
+++ b/internal/auth/token_type_test.go
@@ -1,0 +1,164 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Phase 1.6 part A — `tt` claim + ValidateAccessToken /
+// ValidateRefreshToken semantics.
+
+func newTT(t *testing.T) *TokenManager {
+	t.Helper()
+	tm, err := NewTokenManager("test-secret-must-be-at-least-32-bytes-long-ok", "test")
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	return tm
+}
+
+// --- Generator output ---
+
+func TestGenerateAccessToken_HasAccessTT(t *testing.T) {
+	tm := newTT(t)
+	tok, err := tm.GenerateAccessToken("alice", []string{"user"}, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateAccessToken: %v", err)
+	}
+	claims, err := tm.ValidateToken(tok)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if claims.TokenType != TokenTypeAccess {
+		t.Fatalf("tt = %q, want %q", claims.TokenType, TokenTypeAccess)
+	}
+}
+
+func TestGenerateRefreshToken_HasRefreshTT(t *testing.T) {
+	tm := newTT(t)
+	tok, err := tm.GenerateRefreshToken("alice", []string{"user"}, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateRefreshToken: %v", err)
+	}
+	claims, err := tm.ValidateToken(tok)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if claims.TokenType != TokenTypeRefresh {
+		t.Fatalf("tt = %q, want %q", claims.TokenType, TokenTypeRefresh)
+	}
+}
+
+func TestGenerateToken_LegacyHasEmptyTT(t *testing.T) {
+	// The legacy GenerateToken path is the backwards-compat
+	// shim. Its output must NOT set tt — that way the wire
+	// format is byte-identical to pre-1.6 tokens.
+	tm := newTT(t)
+	tok, err := tm.GenerateToken("alice", []string{"user"}, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	claims, err := tm.ValidateToken(tok)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if claims.TokenType != "" {
+		t.Fatalf("legacy tt = %q, want empty", claims.TokenType)
+	}
+}
+
+// --- ValidateAccessToken ---
+
+func TestValidateAccessToken_AcceptsAccessToken(t *testing.T) {
+	tm := newTT(t)
+	tok, _ := tm.GenerateAccessToken("alice", []string{"user"}, time.Hour)
+	if _, err := tm.ValidateAccessToken(tok); err != nil {
+		t.Fatalf("access token should pass; got %v", err)
+	}
+}
+
+func TestValidateAccessToken_AcceptsLegacyToken(t *testing.T) {
+	// Pre-1.6 tokens have no tt. ValidateAccessToken treats
+	// the empty string as access (backwards compat).
+	tm := newTT(t)
+	tok, _ := tm.GenerateToken("alice", []string{"user"}, time.Hour)
+	if _, err := tm.ValidateAccessToken(tok); err != nil {
+		t.Fatalf("legacy token should pass ValidateAccessToken; got %v", err)
+	}
+}
+
+func TestValidateAccessToken_RejectsRefreshToken(t *testing.T) {
+	tm := newTT(t)
+	tok, _ := tm.GenerateRefreshToken("alice", []string{"user"}, time.Hour)
+	_, err := tm.ValidateAccessToken(tok)
+	if err == nil {
+		t.Fatal("refresh token must be rejected on the API surface")
+	}
+	if !strings.Contains(err.Error(), "invalid") {
+		t.Fatalf("error should be generic; got %v", err)
+	}
+}
+
+// --- ValidateRefreshToken ---
+
+func TestValidateRefreshToken_AcceptsRefreshToken(t *testing.T) {
+	tm := newTT(t)
+	tok, _ := tm.GenerateRefreshToken("alice", []string{"user"}, time.Hour)
+	claims, err := tm.ValidateRefreshToken(tok)
+	if err != nil {
+		t.Fatalf("refresh token should pass; got %v", err)
+	}
+	if claims.TokenType != TokenTypeRefresh {
+		t.Fatalf("tt = %q", claims.TokenType)
+	}
+}
+
+func TestValidateRefreshToken_RejectsAccessToken(t *testing.T) {
+	tm := newTT(t)
+	tok, _ := tm.GenerateAccessToken("alice", []string{"user"}, time.Hour)
+	_, err := tm.ValidateRefreshToken(tok)
+	if err == nil {
+		t.Fatal("access token must be rejected at the refresh path")
+	}
+}
+
+func TestValidateRefreshToken_RejectsLegacyToken(t *testing.T) {
+	// Legacy tokens (no tt) are NOT refresh tokens. The
+	// exchange path must refuse them — only an explicitly
+	// minted refresh can be exchanged.
+	tm := newTT(t)
+	tok, _ := tm.GenerateToken("alice", []string{"user"}, time.Hour)
+	_, err := tm.ValidateRefreshToken(tok)
+	if err == nil {
+		t.Fatal("legacy token must NOT be treated as a refresh token")
+	}
+}
+
+// --- TTL defaults ---
+
+func TestGenerateAccessToken_DefaultsToShortExpiry(t *testing.T) {
+	tm := newTT(t)
+	tok, _ := tm.GenerateAccessToken("alice", []string{"user"}, 0) // 0 → default
+	claims, err := tm.ValidateToken(tok)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	lifetime := claims.ExpiresAt.Sub(claims.IssuedAt.Time)
+	if lifetime != DefaultAccessTokenExpiry {
+		t.Fatalf("access default lifetime = %v, want %v", lifetime, DefaultAccessTokenExpiry)
+	}
+}
+
+func TestGenerateRefreshToken_DefaultsToLongExpiry(t *testing.T) {
+	tm := newTT(t)
+	tok, _ := tm.GenerateRefreshToken("alice", []string{"user"}, 0)
+	claims, err := tm.ValidateToken(tok)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	lifetime := claims.ExpiresAt.Sub(claims.IssuedAt.Time)
+	if lifetime != DefaultRefreshTokenExpiry {
+		t.Fatalf("refresh default lifetime = %v, want %v", lifetime, DefaultRefreshTokenExpiry)
+	}
+}

--- a/internal/cmd/token.go
+++ b/internal/cmd/token.go
@@ -15,6 +15,7 @@ var (
 	tokenUsername   string
 	tokenRoles      []string
 	tokenScopes     []string // Phase 1.7 — least-privilege scope list
+	tokenType       string   // Phase 1.6 — "access" (default) or "refresh"
 	tokenExpiry     string
 	tokenSecretFlag string
 	tokenSecretFile string
@@ -135,6 +136,7 @@ func init() {
 	// Optional flags
 	tokenGenerateCmd.Flags().StringSliceVar(&tokenRoles, "roles", []string{"user"}, "Roles for the token (comma-separated)")
 	tokenGenerateCmd.Flags().StringSliceVar(&tokenScopes, "scopes", nil, "Phase 1.7: least-privilege scopes (comma-separated; e.g. containers:read,secrets:read). Omit for an unrestricted token; pass '*' for the wildcard.")
+	tokenGenerateCmd.Flags().StringVar(&tokenType, "token-type", "", "Phase 1.6: 'access' (short-lived API token) or 'refresh' (long-lived token for exchange). Empty = legacy issuance (still acts as access on the API surface).")
 	tokenGenerateCmd.Flags().StringVar(&tokenExpiry, "expiry", "24h", "Token expiry duration (e.g., 24h, 168h, 720h, 0 for no expiry)")
 	tokenGenerateCmd.Flags().BoolVar(&tokenRaw, "raw", false, "Output only the raw token (for scripting)")
 }
@@ -172,8 +174,20 @@ func runTokenGenerate(cmd *cobra.Command, args []string) error {
 
 	// Generate token. Phase 1.7 — scopes pass through as a
 	// variadic; an empty slice (no --scopes) leaves the
-	// claim unset, matching pre-1.7 behavior.
-	token, err := tm.GenerateToken(tokenUsername, tokenRoles, expiresIn, tokenScopes...)
+	// claim unset, matching pre-1.7 behavior. Phase 1.6 —
+	// --token-type selects access/refresh; default is the
+	// legacy untagged path so existing scripts keep working.
+	var token string
+	switch tokenType {
+	case "", "any", "legacy":
+		token, err = tm.GenerateToken(tokenUsername, tokenRoles, expiresIn, tokenScopes...)
+	case auth.TokenTypeAccess:
+		token, err = tm.GenerateAccessToken(tokenUsername, tokenRoles, expiresIn, tokenScopes...)
+	case auth.TokenTypeRefresh:
+		token, err = tm.GenerateRefreshToken(tokenUsername, tokenRoles, expiresIn, tokenScopes...)
+	default:
+		return fmt.Errorf("invalid --token-type %q (expected: '', 'access', 'refresh')", tokenType)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to generate token: %w", err)
 	}
@@ -199,6 +213,9 @@ func runTokenGenerate(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  Scopes:   %v\n", tokenScopes)
 	} else {
 		fmt.Printf("  Scopes:   <none> (unrestricted)\n")
+	}
+	if tokenType != "" {
+		fmt.Printf("  Type:     %s\n", tokenType)
 	}
 	if expiresIn > 0 {
 		expiryTime := time.Now().Add(expiresIn)


### PR DESCRIPTION
## Summary

Tokens now carry a \`tt\` claim distinguishing **access** from **refresh**. The HTTP middleware uses \`ValidateAccessToken\` which **rejects refresh tokens**, so a stolen refresh token cannot authenticate to any API surface — gateway, terminal, SSE, audit — even though its signature is valid.

This is Part A of Phase 1.6. **Part B** (the actual \`RefreshToken\` RPC + rotation) is a follow-up.

## API

| Function | tt claim | Default TTL |
|---|---|---|
| \`GenerateAccessToken(user, roles, ttl, scopes...)\` | \`"access"\` | 15 min |
| \`GenerateRefreshToken(user, roles, ttl, scopes...)\` | \`"refresh"\` | 30 d |
| \`GenerateToken(...)\` (legacy) | \`""\` (omitted) | 24h via CLI default |
| \`ValidateAccessToken(tok)\` | accepts \`""\` or \`"access"\`; **rejects \`"refresh"\`** | |
| \`ValidateRefreshToken(tok)\` | accepts **only** \`"refresh"\` | |

## Backwards compatibility

Pre-1.6 tokens have no \`tt\` claim. \`ValidateAccessToken\` treats the empty string as access (rule documented inline), so they keep working. The wire format is byte-identical for legacy issuance — \`omitempty\` on the new field — so cached fixtures don't need re-minting.

## Daemon wiring

- \`AuthMiddleware.HTTPMiddleware\` now calls \`tokenManager.ValidateAccessToken\`.
- \`AuthMiddleware.ValidateToken\` wrapper (used by terminal, SSE, audit, security export handlers) also routes through \`ValidateAccessToken\` — refresh-rejection holds end-to-end.

## CLI

\`\`\`bash
# Mint a short-lived access token
containarium token generate \\
    --username alice --token-type access \\
    --expiry 15m --secret $JWT

# Mint a long-lived refresh token (cannot make API calls)
containarium token generate \\
    --username alice --token-type refresh \\
    --expiry 720h --secret $JWT

# Legacy issuance unchanged
containarium token generate --username alice --expiry 24h --secret $JWT
\`\`\`

## Tests

11 new cases in \`token_type_test.go\`:
- Generator tt-claim values (access / refresh / legacy-empty)
- ValidateAccessToken accepts access + legacy, rejects refresh
- ValidateRefreshToken accepts refresh, rejects access + legacy (legacy is NOT a refresh token)
- Default TTLs

2 new cases in \`middleware_test.go\`:
- HTTP middleware rejects a refresh token with 401 and does not invoke the wrapped handler
- HTTP middleware accepts an access-typed token with 200

\`\`\`
ok  github.com/footprintai/containarium/internal/auth  1.161s
\`\`\`

## Follow-up (Part B)

\`/v1/tokens/refresh\` RPC + CLI verb. Takes a refresh token, validates via \`ValidateRefreshToken\`, mints a new (access, refresh) pair. **Single-use rotation** (revoke the prior refresh on issuance) goes into the same PR.

## Test plan

- [x] Unit tests pass
- [x] \`go build ./...\` clean
- [ ] CI green
- [ ] Manual: mint a refresh token, try \`curl -H "Authorization: Bearer <refresh>" /v1/containers\` → expect 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)