### PR TITLE
sec: zero-trust Phase 1.6 part B — RefreshToken RPC + single-use rotation

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -3091,6 +3091,41 @@
         ]
       }
     },
+    "/v1/tokens/refresh": {
+      "post": {
+        "summary": "Exchange a refresh token for a new (access, refresh) pair",
+        "description": "Validates the refresh token (signature + exp + tt='refresh' + not revoked), mints a new short-lived access token, mints a new long-lived refresh token, and revokes the input refresh token's jti. Refresh tokens are single-use; the new refresh token must be stored by the client for the next exchange.",
+        "operationId": "TokensService_RefreshToken",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/RefreshTokenResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "Phase 1.6 part B — exchange a refresh token for a new\n(access, refresh) pair. Rotates the refresh token:\nthe prior jti is revoked on success, so each refresh\ntoken is single-use. Replay = denied + audit signal.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RefreshTokenRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Tokens"
+        ]
+      }
+    },
     "/v1/tokens/revoke": {
       "post": {
         "summary": "Revoke a JWT by its jti",
@@ -6321,6 +6356,39 @@
           "type": "integer",
           "format": "int32",
           "description": "Count of env vars actually stamped (matches the number of\nsecrets owned by the tenant at refresh time)."
+        }
+      }
+    },
+    "RefreshTokenRequest": {
+      "type": "object",
+      "properties": {
+        "refreshToken": {
+          "type": "string",
+          "description": "The current refresh token. Must validate via\nValidateRefreshToken (signature + iss + aud + exp +\ntt == \"refresh\") AND not be in the revocation list."
+        }
+      },
+      "description": "Phase 1.6 part B — exchange a refresh token for a new\n(access, refresh) pair. Rotates the refresh token:\nthe prior jti is revoked on success, so each refresh\ntoken is single-use. Replay = denied + audit signal."
+    },
+    "RefreshTokenResponse": {
+      "type": "object",
+      "properties": {
+        "accessToken": {
+          "type": "string",
+          "description": "New short-lived access token, ready to use as\nAuthorization: Bearer."
+        },
+        "refreshToken": {
+          "type": "string",
+          "description": "New refresh token. Save this — the one you just sent\nin is now revoked and cannot be exchanged again."
+        },
+        "accessTokenExpiresAt": {
+          "type": "string",
+          "format": "int64",
+          "description": "Unix-seconds expiry of the access token, for clients\nthat want to refresh proactively before exp."
+        },
+        "refreshTokenExpiresAt": {
+          "type": "string",
+          "format": "int64",
+          "description": "Unix-seconds expiry of the refresh token."
         }
       }
     },

--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -180,7 +180,7 @@ on the internal network. Land them first.
         can't attach headers, so the webui still uses `?token=`
         for SSE — follow-up to rewrite with `fetch` +
         `ReadableStream` is tracked under [1.6 / refresh tokens].
-- [~] **1.6** Short-lived access tokens + refresh tokens — `internal/auth/token.go:14` (**C-MED-8**)
+- [x] **1.6** Short-lived access tokens + refresh tokens — `internal/auth/token.go:14` (**C-MED-8**)
       — **Part A landed.** New `tt` claim (access | refresh)
         on JWTs. Generators `GenerateAccessToken`
         (15min default) + `GenerateRefreshToken` (30d
@@ -191,12 +191,23 @@ on the internal network. Land them first.
         tokens (no tt claim) are still accepted as access
         for backwards compat. CLI gains `--token-type
         access|refresh|''` to choose at issuance time.
-      — **Follow-up (Part B):** add a `/v1/tokens/refresh`
-        RPC + CLI verb that takes a refresh token,
-        validates via `ValidateRefreshToken`, and mints a
-        new (access, refresh) pair. Refresh-token
-        rotation (single-use semantics, revoke the prior
-        on issuance) is the next slice.
+      — **Part B landed.** `TokensService.RefreshToken` RPC
+        + `POST /v1/tokens/refresh` REST + `containarium
+        token refresh` CLI verb. Mints a new (access,
+        refresh) pair from a valid refresh token; revokes
+        the prior refresh jti so refresh tokens are
+        SINGLE-USE (rotation). Replay → Unauthenticated.
+        The refresh endpoint is intentionally
+        unauthenticated (the refresh token in the body IS
+        the credential) — `unauthPaths` map in
+        `middleware.go` carries the path allowlist.
+      — `1.6` story now complete. Operators can mint a
+        short-lived access + long-lived refresh, store
+        refresh securely, and rotate via the endpoint.
+        Stolen refresh tokens get one shot at exchange
+        before the legitimate holder's next rotation
+        revokes them — and they can't be used directly on
+        the API surface at all.
 - [x] **1.7** Per-tool scopes for MCP — `internal/mcp/tools.go`, `internal/mcp/client.go`
       — New `scopes` claim on JWTs (variadic
         `GenerateToken(..., scopes...)`) + OAuth2-style

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -28,10 +28,30 @@ func NewAuthMiddleware(tokenManager *TokenManager) *AuthMiddleware {
 	}
 }
 
+// unauthPaths are HTTP endpoints that MUST skip the Bearer
+// token check on the API surface — the endpoint's own
+// payload IS the credential.
+//
+// /v1/tokens/refresh (Phase 1.6 part B): the request body
+// carries the refresh token. Requiring an access token in
+// the header on top would be silly — the whole point is
+// that the client doesn't have a fresh access token yet.
+var unauthPaths = map[string]bool{
+	"/v1/tokens/refresh": true,
+}
+
 // HTTPMiddleware is HTTP middleware for REST endpoints
 // It validates Bearer tokens and adds authentication info to the context
 func (am *AuthMiddleware) HTTPMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Phase 1.6 part B — skip auth for refresh
+		// exchange. The refresh-token in the body is the
+		// credential; the handler validates it.
+		if unauthPaths[r.URL.Path] {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		// Extract token from Authorization header
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "" {

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -398,6 +398,35 @@ func (c *HTTPClient) ToggleMonitoring(username string, enabled bool) (string, bo
 	return result.Message, result.MonitoringEnabled, nil
 }
 
+// RefreshToken exchanges a refresh token for a new
+// (access, refresh) pair. Unauthenticated endpoint —
+// the refresh token in the body IS the credential.
+// Returns (access, refresh, accessExpUnix, refreshExpUnix, error).
+func (c *HTTPClient) RefreshToken(refreshTok string) (string, string, int64, int64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	body := map[string]string{"refresh_token": refreshTok}
+	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/tokens/refresh", body)
+	if err != nil {
+		return "", "", 0, 0, fmt.Errorf("refresh token: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return "", "", 0, 0, parseErr(b, resp.StatusCode, "refresh token")
+	}
+	var result struct {
+		AccessToken           string `json:"accessToken"`
+		RefreshToken          string `json:"refreshToken"`
+		AccessTokenExpiresAt  int64  `json:"accessTokenExpiresAt,string"`
+		RefreshTokenExpiresAt int64  `json:"refreshTokenExpiresAt,string"`
+	}
+	if err := json.Unmarshal(b, &result); err != nil {
+		return "", "", 0, 0, fmt.Errorf("decode refresh response: %w", err)
+	}
+	return result.AccessToken, result.RefreshToken, result.AccessTokenExpiresAt, result.RefreshTokenExpiresAt, nil
+}
+
 // RevokeToken adds a JWT's jti to the daemon's revocation
 // list. Phase 1.2 follow-up — admin-only on the server side.
 // `reason` is free-form and recorded for forensics; pass ""

--- a/internal/cmd/token.go
+++ b/internal/cmd/token.go
@@ -25,6 +25,10 @@ var (
 	revokeJTI       string
 	revokeReason    string
 	revokeExpiresAt string
+
+	// `token refresh` flags (Phase 1.6 part B)
+	refreshTokenIn   string
+	refreshTokenFile string
 )
 
 var tokenCmd = &cobra.Command{
@@ -115,10 +119,44 @@ the JWT payload (the 'jti' claim).`,
 	RunE: runTokenRevoke,
 }
 
+// tokenRefreshCmd implements `containarium token refresh` —
+// Phase 1.6 part B. Exchanges a long-lived refresh token
+// for a new short-lived access token (and a new refresh
+// token, since refresh tokens are single-use). The old
+// refresh token is revoked server-side on success.
+var tokenRefreshCmd = &cobra.Command{
+	Use:   "refresh",
+	Short: "Exchange a refresh token for a new (access, refresh) pair",
+	Long: `Trade a long-lived refresh token for a new short-lived access
+token. The server also issues a fresh refresh token because
+refresh tokens are single-use (rotation) — save the new one
+for the next exchange.
+
+The refresh-exchange endpoint is unauthenticated: the
+refresh-token body IS the credential. Do not pass --token.
+
+Use the access token in subsequent API calls:
+  Authorization: Bearer <access_token>`,
+	Example: `  # From an environment variable
+  containarium token refresh \
+    --refresh-token "$REFRESH" \
+    --server https://containarium.kafeido.app
+
+  # From a file (mode 0600 recommended)
+  containarium token refresh \
+    --refresh-token-file ~/.containarium/refresh \
+    --server https://containarium.kafeido.app`,
+	RunE: runTokenRefresh,
+}
+
 func init() {
 	rootCmd.AddCommand(tokenCmd)
 	tokenCmd.AddCommand(tokenGenerateCmd)
 	tokenCmd.AddCommand(tokenRevokeCmd)
+	tokenCmd.AddCommand(tokenRefreshCmd)
+
+	tokenRefreshCmd.Flags().StringVar(&refreshTokenIn, "refresh-token", "", "Refresh token to exchange (mutually exclusive with --refresh-token-file)")
+	tokenRefreshCmd.Flags().StringVar(&refreshTokenFile, "refresh-token-file", "", "Path to file containing the refresh token (mode 0600 recommended)")
 
 	tokenRevokeCmd.Flags().StringVar(&revokeJTI, "jti", "", "jti claim of the token to revoke (required)")
 	tokenRevokeCmd.MarkFlagRequired("jti")
@@ -250,6 +288,58 @@ func runTokenGenerate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("═══════════════════════════════════════════════════════════════\n")
 	fmt.Printf("\n")
 
+	return nil
+}
+
+// runTokenRefresh POSTs the refresh token to /v1/tokens/refresh
+// and prints the new (access, refresh) pair. The endpoint is
+// unauthenticated — no --token flag needed.
+func runTokenRefresh(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (the daemon does the exchange)")
+	}
+
+	refresh := refreshTokenIn
+	if refreshTokenFile != "" {
+		if refresh != "" {
+			return fmt.Errorf("--refresh-token and --refresh-token-file are mutually exclusive")
+		}
+		b, err := os.ReadFile(refreshTokenFile)
+		if err != nil {
+			return fmt.Errorf("read refresh token file: %w", err)
+		}
+		refresh = strings.TrimSpace(string(b))
+	}
+	if refresh == "" {
+		return fmt.Errorf("--refresh-token or --refresh-token-file is required")
+	}
+
+	// The refresh endpoint is unauthenticated; create an
+	// HTTP client with an empty Authorization to avoid
+	// surprising header propagation.
+	httpClient, err := client.NewHTTPClient(serverAddr, "")
+	if err != nil {
+		return fmt.Errorf("create http client: %w", err)
+	}
+	defer httpClient.Close()
+
+	access, newRefresh, accessExp, refreshExp, err := httpClient.RefreshToken(refresh)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("\n═══════════════════════════════════════════════════════════════\n")
+	fmt.Printf("  Tokens rotated\n")
+	fmt.Printf("═══════════════════════════════════════════════════════════════\n\n")
+	fmt.Printf("Access token (use as Authorization: Bearer):\n%s\n\n", access)
+	if accessExp > 0 {
+		fmt.Printf("  Access expires:  %s\n", time.Unix(accessExp, 0).Format(time.RFC3339))
+	}
+	fmt.Printf("\nNEW refresh token (the one you sent is now revoked — save this):\n%s\n\n", newRefresh)
+	if refreshExp > 0 {
+		fmt.Printf("  Refresh expires: %s\n", time.Unix(refreshExp, 0).Format(time.RFC3339))
+	}
+	fmt.Printf("\n═══════════════════════════════════════════════════════════════\n\n")
 	return nil
 }
 

--- a/internal/server/tokens_server.go
+++ b/internal/server/tokens_server.go
@@ -109,3 +109,96 @@ func (s *TokensServer) RevokeToken(ctx context.Context, req *pb.RevokeTokenReque
 		Message:      "jti added to revocation list; token will be rejected on next use",
 	}, nil
 }
+
+// RefreshToken exchanges a valid refresh token for a new
+// (access, refresh) pair. Phase 1.6 part B.
+//
+// Single-use rotation: on success, the input refresh
+// token's jti is added to the revocation list. A replayed
+// refresh token (someone stole it AND the legitimate
+// holder already exchanged it) hits the revocation check
+// inside ValidateRefreshToken's path and is rejected.
+// This is a strong tamper signal — an audit hook should
+// page on it; today we just log + return Unauthenticated.
+//
+// Unauthenticated endpoint by design: the refresh token IS
+// the credential. Skip the access-token middleware on the
+// /v1/tokens/refresh path; the daemon's HTTP middleware
+// will need a route allowlist for this in a follow-up.
+func (s *TokensServer) RefreshToken(ctx context.Context, req *pb.RefreshTokenRequest) (*pb.RefreshTokenResponse, error) {
+	if req.RefreshToken == "" {
+		return nil, status.Error(codes.InvalidArgument, "refresh_token is required")
+	}
+	if s.tokenManager == nil {
+		return nil, status.Error(codes.Unavailable, "token manager not configured")
+	}
+
+	claims, err := s.tokenManager.ValidateRefreshToken(req.RefreshToken)
+	if err != nil {
+		log.Printf("[tokens] refresh denied: invalid token")
+		return nil, status.Error(codes.Unauthenticated, "invalid refresh token")
+	}
+
+	// Mint the new pair BEFORE revoking the prior. If
+	// minting fails the operator's session stays intact.
+	newAccess, err := s.tokenManager.GenerateAccessToken(
+		claims.Username, claims.Roles, 0, claims.Scopes...,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "mint access: %v", err)
+	}
+	newRefresh, err := s.tokenManager.GenerateRefreshToken(
+		claims.Username, claims.Roles, 0, claims.Scopes...,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "mint refresh: %v", err)
+	}
+
+	// Revoke the input refresh-token jti. If the store is
+	// unavailable, fail closed — without rotation a stolen
+	// refresh token gives the attacker permanent renewal.
+	if s.store != nil && claims.ID != "" {
+		exp := time.Time{}
+		if claims.ExpiresAt != nil {
+			exp = claims.ExpiresAt.Time
+		}
+		if err := s.store.Revoke(ctx, claims.ID, exp, "refresh_rotation"); err != nil {
+			log.Printf("[tokens] refresh rotation revoke failed for jti=%s: %v", claims.ID, err)
+			return nil, status.Errorf(codes.Internal, "rotate failed: %v", err)
+		}
+	}
+
+	// Parse the new exp timestamps from the just-minted
+	// tokens so the client knows when to refresh next.
+	newAccessClaims, _ := s.tokenManager.ValidateAccessToken(newAccess)
+	newRefreshClaims, _ := s.tokenManager.ValidateRefreshToken(newRefresh)
+
+	var accessExp, refreshExp int64
+	if newAccessClaims != nil && newAccessClaims.ExpiresAt != nil {
+		accessExp = newAccessClaims.ExpiresAt.Time.Unix()
+	}
+	if newRefreshClaims != nil && newRefreshClaims.ExpiresAt != nil {
+		refreshExp = newRefreshClaims.ExpiresAt.Time.Unix()
+	}
+
+	log.Printf("[tokens] refresh rotated: user=%s old_jti=%s new_access_jti=%s new_refresh_jti=%s",
+		claims.Username,
+		claims.ID,
+		safeID(newAccessClaims),
+		safeID(newRefreshClaims),
+	)
+
+	return &pb.RefreshTokenResponse{
+		AccessToken:           newAccess,
+		RefreshToken:          newRefresh,
+		AccessTokenExpiresAt:  accessExp,
+		RefreshTokenExpiresAt: refreshExp,
+	}, nil
+}
+
+func safeID(c *auth.Claims) string {
+	if c == nil {
+		return ""
+	}
+	return c.ID
+}

--- a/internal/server/tokens_server_test.go
+++ b/internal/server/tokens_server_test.go
@@ -225,3 +225,96 @@ func TestRevokeToken_AcceptsRFC3339Expiry(t *testing.T) {
 		t.Fatalf("RFC3339 expiry should parse; got %v", err)
 	}
 }
+
+// --- Phase 1.6 part B — RefreshToken RPC ---
+
+func TestRefreshToken_RejectsEmpty(t *testing.T) {
+	srv := newTestTokensServer(t, newFakeRevocationStore())
+	_, err := srv.RefreshToken(context.Background(), &pb.RefreshTokenRequest{})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("empty refresh_token: got %v want InvalidArgument", err)
+	}
+}
+
+func TestRefreshToken_RejectsAccessToken(t *testing.T) {
+	// A request bearing an access token where a refresh is
+	// expected must be rejected with Unauthenticated.
+	srv := newTestTokensServer(t, newFakeRevocationStore())
+	access, err := srv.tokenManager.GenerateAccessToken("alice", []string{"user"}, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateAccessToken: %v", err)
+	}
+	_, err = srv.RefreshToken(context.Background(), &pb.RefreshTokenRequest{RefreshToken: access})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("access at refresh: got %v want Unauthenticated", err)
+	}
+}
+
+func TestRefreshToken_RejectsLegacyToken(t *testing.T) {
+	srv := newTestTokensServer(t, newFakeRevocationStore())
+	legacy, _ := srv.tokenManager.GenerateToken("alice", []string{"user"}, time.Hour)
+	_, err := srv.RefreshToken(context.Background(), &pb.RefreshTokenRequest{RefreshToken: legacy})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("legacy at refresh: got %v want Unauthenticated", err)
+	}
+}
+
+func TestRefreshToken_HappyPath_MintsNewPair(t *testing.T) {
+	store := newFakeRevocationStore()
+	srv := newTestTokensServer(t, store)
+	refresh, _ := srv.tokenManager.GenerateRefreshToken("alice", []string{"user"}, time.Hour, auth.ScopeContainersRead)
+
+	resp, err := srv.RefreshToken(context.Background(), &pb.RefreshTokenRequest{RefreshToken: refresh})
+	if err != nil {
+		t.Fatalf("RefreshToken: %v", err)
+	}
+	if resp.AccessToken == "" || resp.RefreshToken == "" {
+		t.Fatal("response should carry both new tokens")
+	}
+	if resp.AccessTokenExpiresAt == 0 || resp.RefreshTokenExpiresAt == 0 {
+		t.Fatal("response should carry expiry timestamps")
+	}
+
+	// New access token validates as access; new refresh
+	// validates as refresh. Scope passes through.
+	ac, err := srv.tokenManager.ValidateAccessToken(resp.AccessToken)
+	if err != nil {
+		t.Fatalf("new access invalid: %v", err)
+	}
+	if ac.TokenType != auth.TokenTypeAccess {
+		t.Fatalf("new access tt=%q", ac.TokenType)
+	}
+	if len(ac.Scopes) != 1 || ac.Scopes[0] != auth.ScopeContainersRead {
+		t.Fatalf("new access scopes=%v; should pass through", ac.Scopes)
+	}
+	rc, err := srv.tokenManager.ValidateRefreshToken(resp.RefreshToken)
+	if err != nil {
+		t.Fatalf("new refresh invalid: %v", err)
+	}
+	if rc.TokenType != auth.TokenTypeRefresh {
+		t.Fatalf("new refresh tt=%q", rc.TokenType)
+	}
+}
+
+func TestRefreshToken_RotationRevokesPriorJTI(t *testing.T) {
+	// Single-use semantics: after a successful exchange,
+	// replaying the same refresh token must fail.
+	store := newFakeRevocationStore()
+	srv := newTestTokensServer(t, store)
+	refresh, _ := srv.tokenManager.GenerateRefreshToken("alice", []string{"user"}, time.Hour)
+
+	// First exchange succeeds.
+	if _, err := srv.RefreshToken(context.Background(), &pb.RefreshTokenRequest{RefreshToken: refresh}); err != nil {
+		t.Fatalf("first exchange: %v", err)
+	}
+
+	// The prior jti is now revoked. Validate the old
+	// refresh token through the same path — the
+	// revocation list check inside ValidateRefreshToken's
+	// chain trips and returns invalid.
+	srv.tokenManager.SetRevocationStore(store)
+	_, err := srv.RefreshToken(context.Background(), &pb.RefreshTokenRequest{RefreshToken: refresh})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("replay should be rejected; got %v", err)
+	}
+}

--- a/pkg/pb/containarium/v1/tokens.pb.go
+++ b/pkg/pb/containarium/v1/tokens.pb.go
@@ -151,6 +151,132 @@ func (x *RevokeTokenResponse) GetMessage() string {
 	return ""
 }
 
+// Phase 1.6 part B — exchange a refresh token for a new
+// (access, refresh) pair. Rotates the refresh token:
+// the prior jti is revoked on success, so each refresh
+// token is single-use. Replay = denied + audit signal.
+type RefreshTokenRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The current refresh token. Must validate via
+	// ValidateRefreshToken (signature + iss + aud + exp +
+	// tt == "refresh") AND not be in the revocation list.
+	RefreshToken  string `protobuf:"bytes,1,opt,name=refresh_token,json=refreshToken,proto3" json:"refresh_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RefreshTokenRequest) Reset() {
+	*x = RefreshTokenRequest{}
+	mi := &file_containarium_v1_tokens_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RefreshTokenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RefreshTokenRequest) ProtoMessage() {}
+
+func (x *RefreshTokenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_tokens_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RefreshTokenRequest.ProtoReflect.Descriptor instead.
+func (*RefreshTokenRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_tokens_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *RefreshTokenRequest) GetRefreshToken() string {
+	if x != nil {
+		return x.RefreshToken
+	}
+	return ""
+}
+
+type RefreshTokenResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// New short-lived access token, ready to use as
+	// Authorization: Bearer.
+	AccessToken string `protobuf:"bytes,1,opt,name=access_token,json=accessToken,proto3" json:"access_token,omitempty"`
+	// New refresh token. Save this — the one you just sent
+	// in is now revoked and cannot be exchanged again.
+	RefreshToken string `protobuf:"bytes,2,opt,name=refresh_token,json=refreshToken,proto3" json:"refresh_token,omitempty"`
+	// Unix-seconds expiry of the access token, for clients
+	// that want to refresh proactively before exp.
+	AccessTokenExpiresAt int64 `protobuf:"varint,3,opt,name=access_token_expires_at,json=accessTokenExpiresAt,proto3" json:"access_token_expires_at,omitempty"`
+	// Unix-seconds expiry of the refresh token.
+	RefreshTokenExpiresAt int64 `protobuf:"varint,4,opt,name=refresh_token_expires_at,json=refreshTokenExpiresAt,proto3" json:"refresh_token_expires_at,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *RefreshTokenResponse) Reset() {
+	*x = RefreshTokenResponse{}
+	mi := &file_containarium_v1_tokens_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RefreshTokenResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RefreshTokenResponse) ProtoMessage() {}
+
+func (x *RefreshTokenResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_tokens_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RefreshTokenResponse.ProtoReflect.Descriptor instead.
+func (*RefreshTokenResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_tokens_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *RefreshTokenResponse) GetAccessToken() string {
+	if x != nil {
+		return x.AccessToken
+	}
+	return ""
+}
+
+func (x *RefreshTokenResponse) GetRefreshToken() string {
+	if x != nil {
+		return x.RefreshToken
+	}
+	return ""
+}
+
+func (x *RefreshTokenResponse) GetAccessTokenExpiresAt() int64 {
+	if x != nil {
+		return x.AccessTokenExpiresAt
+	}
+	return 0
+}
+
+func (x *RefreshTokenResponse) GetRefreshTokenExpiresAt() int64 {
+	if x != nil {
+		return x.RefreshTokenExpiresAt
+	}
+	return 0
+}
+
 var File_containarium_v1_tokens_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_tokens_proto_rawDesc = "" +
@@ -163,10 +289,19 @@ const file_containarium_v1_tokens_proto_rawDesc = "" +
 	"expires_at\x18\x03 \x01(\tR\texpiresAt\"T\n" +
 	"\x13RevokeTokenResponse\x12#\n" +
 	"\rnewly_revoked\x18\x01 \x01(\bR\fnewlyRevoked\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage2\x97\x03\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\":\n" +
+	"\x13RefreshTokenRequest\x12#\n" +
+	"\rrefresh_token\x18\x01 \x01(\tR\frefreshToken\"\xce\x01\n" +
+	"\x14RefreshTokenResponse\x12!\n" +
+	"\faccess_token\x18\x01 \x01(\tR\vaccessToken\x12#\n" +
+	"\rrefresh_token\x18\x02 \x01(\tR\frefreshToken\x125\n" +
+	"\x17access_token_expires_at\x18\x03 \x01(\x03R\x14accessTokenExpiresAt\x127\n" +
+	"\x18refresh_token_expires_at\x18\x04 \x01(\x03R\x15refreshTokenExpiresAt2\x8a\a\n" +
 	"\rTokensService\x12\x85\x03\n" +
 	"\vRevokeToken\x12#.containarium.v1.RevokeTokenRequest\x1a$.containarium.v1.RevokeTokenResponse\"\xaa\x02\x92A\x8a\x02\n" +
-	"\x06Tokens\x12\x17Revoke a JWT by its jti\x1a\xe6\x01Adds the token's jti to the revocation list. The token will be rejected on the next request that tries to use it. Admin-only. Idempotent — revoking an already-revoked jti is a no-op (the original revocation reason is preserved).\x82\xd3\xe4\x93\x02\x16:\x01*\"\x11/v1/tokens/revokeBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
+	"\x06Tokens\x12\x17Revoke a JWT by its jti\x1a\xe6\x01Adds the token's jti to the revocation list. The token will be rejected on the next request that tries to use it. Admin-only. Idempotent — revoking an already-revoked jti is a no-op (the original revocation reason is preserved).\x82\xd3\xe4\x93\x02\x16:\x01*\"\x11/v1/tokens/revoke\x12\xf0\x03\n" +
+	"\fRefreshToken\x12$.containarium.v1.RefreshTokenRequest\x1a%.containarium.v1.RefreshTokenResponse\"\x92\x03\x92A\xf1\x02\n" +
+	"\x06Tokens\x129Exchange a refresh token for a new (access, refresh) pair\x1a\xab\x02Validates the refresh token (signature + exp + tt='refresh' + not revoked), mints a new short-lived access token, mints a new long-lived refresh token, and revokes the input refresh token's jti. Refresh tokens are single-use; the new refresh token must be stored by the client for the next exchange.\x82\xd3\xe4\x93\x02\x17:\x01*\"\x12/v1/tokens/refreshBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
 
 var (
 	file_containarium_v1_tokens_proto_rawDescOnce sync.Once
@@ -180,16 +315,20 @@ func file_containarium_v1_tokens_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_tokens_proto_rawDescData
 }
 
-var file_containarium_v1_tokens_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_containarium_v1_tokens_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_containarium_v1_tokens_proto_goTypes = []any{
-	(*RevokeTokenRequest)(nil),  // 0: containarium.v1.RevokeTokenRequest
-	(*RevokeTokenResponse)(nil), // 1: containarium.v1.RevokeTokenResponse
+	(*RevokeTokenRequest)(nil),   // 0: containarium.v1.RevokeTokenRequest
+	(*RevokeTokenResponse)(nil),  // 1: containarium.v1.RevokeTokenResponse
+	(*RefreshTokenRequest)(nil),  // 2: containarium.v1.RefreshTokenRequest
+	(*RefreshTokenResponse)(nil), // 3: containarium.v1.RefreshTokenResponse
 }
 var file_containarium_v1_tokens_proto_depIdxs = []int32{
 	0, // 0: containarium.v1.TokensService.RevokeToken:input_type -> containarium.v1.RevokeTokenRequest
-	1, // 1: containarium.v1.TokensService.RevokeToken:output_type -> containarium.v1.RevokeTokenResponse
-	1, // [1:2] is the sub-list for method output_type
-	0, // [0:1] is the sub-list for method input_type
+	2, // 1: containarium.v1.TokensService.RefreshToken:input_type -> containarium.v1.RefreshTokenRequest
+	1, // 2: containarium.v1.TokensService.RevokeToken:output_type -> containarium.v1.RevokeTokenResponse
+	3, // 3: containarium.v1.TokensService.RefreshToken:output_type -> containarium.v1.RefreshTokenResponse
+	2, // [2:4] is the sub-list for method output_type
+	0, // [0:2] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
@@ -206,7 +345,7 @@ func file_containarium_v1_tokens_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_tokens_proto_rawDesc), len(file_containarium_v1_tokens_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/pb/containarium/v1/tokens.pb.gw.go
+++ b/pkg/pb/containarium/v1/tokens.pb.gw.go
@@ -62,6 +62,33 @@ func local_request_TokensService_RevokeToken_0(ctx context.Context, marshaler ru
 	return msg, metadata, err
 }
 
+func request_TokensService_RefreshToken_0(ctx context.Context, marshaler runtime.Marshaler, client TokensServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RefreshTokenRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.RefreshToken(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_TokensService_RefreshToken_0(ctx context.Context, marshaler runtime.Marshaler, server TokensServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RefreshTokenRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.RefreshToken(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterTokensServiceHandlerServer registers the http handlers for service TokensService to "mux".
 // UnaryRPC     :call TokensServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -87,6 +114,26 @@ func RegisterTokensServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 			return
 		}
 		forward_TokensService_RevokeToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_TokensService_RefreshToken_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.TokensService/RefreshToken", runtime.WithHTTPPathPattern("/v1/tokens/refresh"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_TokensService_RefreshToken_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_TokensService_RefreshToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -145,13 +192,32 @@ func RegisterTokensServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_TokensService_RevokeToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_TokensService_RefreshToken_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.TokensService/RefreshToken", runtime.WithHTTPPathPattern("/v1/tokens/refresh"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_TokensService_RefreshToken_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_TokensService_RefreshToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_TokensService_RevokeToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "revoke"}, ""))
+	pattern_TokensService_RevokeToken_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "revoke"}, ""))
+	pattern_TokensService_RefreshToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "refresh"}, ""))
 )
 
 var (
-	forward_TokensService_RevokeToken_0 = runtime.ForwardResponseMessage
+	forward_TokensService_RevokeToken_0  = runtime.ForwardResponseMessage
+	forward_TokensService_RefreshToken_0 = runtime.ForwardResponseMessage
 )

--- a/pkg/pb/containarium/v1/tokens_grpc.pb.go
+++ b/pkg/pb/containarium/v1/tokens_grpc.pb.go
@@ -19,7 +19,8 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	TokensService_RevokeToken_FullMethodName = "/containarium.v1.TokensService/RevokeToken"
+	TokensService_RevokeToken_FullMethodName  = "/containarium.v1.TokensService/RevokeToken"
+	TokensService_RefreshToken_FullMethodName = "/containarium.v1.TokensService/RefreshToken"
 )
 
 // TokensServiceClient is the client API for TokensService service.
@@ -28,16 +29,25 @@ const (
 //
 // TokensService is the admin surface for JWT lifecycle.
 //
-// All RPCs require an admin role; tenants can't revoke other
-// tenants' tokens. Note that **a token CAN revoke itself**
-// regardless of role — that's how the operator's own logout
-// flow will eventually work — but a tenant calling revoke
-// for a jti they don't recognize still needs admin.
+// RevokeToken requires an admin role + tokens:write scope;
+// tenants can't revoke other tenants' tokens. RefreshToken
+// is open to any holder of a valid refresh token — that's
+// the whole point of the exchange flow.
 type TokensServiceClient interface {
 	// RevokeToken adds a token's jti to the revocation list,
 	// taking effect on the next authenticated request that
 	// names it. Idempotent — repeated revokes are safe.
 	RevokeToken(ctx context.Context, in *RevokeTokenRequest, opts ...grpc.CallOption) (*RevokeTokenResponse, error)
+	// RefreshToken exchanges a valid refresh token for a new
+	// (access, refresh) pair. The prior refresh token's jti is
+	// revoked on success — refresh tokens are SINGLE-USE.
+	// Replay of an already-exchanged refresh token returns
+	// Unauthenticated (it's now on the revocation list).
+	//
+	// Unauthenticated endpoint by design — the refresh token
+	// itself IS the credential. Don't wrap with the access-
+	// token middleware.
+	RefreshToken(ctx context.Context, in *RefreshTokenRequest, opts ...grpc.CallOption) (*RefreshTokenResponse, error)
 }
 
 type tokensServiceClient struct {
@@ -58,22 +68,41 @@ func (c *tokensServiceClient) RevokeToken(ctx context.Context, in *RevokeTokenRe
 	return out, nil
 }
 
+func (c *tokensServiceClient) RefreshToken(ctx context.Context, in *RefreshTokenRequest, opts ...grpc.CallOption) (*RefreshTokenResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RefreshTokenResponse)
+	err := c.cc.Invoke(ctx, TokensService_RefreshToken_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // TokensServiceServer is the server API for TokensService service.
 // All implementations must embed UnimplementedTokensServiceServer
 // for forward compatibility.
 //
 // TokensService is the admin surface for JWT lifecycle.
 //
-// All RPCs require an admin role; tenants can't revoke other
-// tenants' tokens. Note that **a token CAN revoke itself**
-// regardless of role — that's how the operator's own logout
-// flow will eventually work — but a tenant calling revoke
-// for a jti they don't recognize still needs admin.
+// RevokeToken requires an admin role + tokens:write scope;
+// tenants can't revoke other tenants' tokens. RefreshToken
+// is open to any holder of a valid refresh token — that's
+// the whole point of the exchange flow.
 type TokensServiceServer interface {
 	// RevokeToken adds a token's jti to the revocation list,
 	// taking effect on the next authenticated request that
 	// names it. Idempotent — repeated revokes are safe.
 	RevokeToken(context.Context, *RevokeTokenRequest) (*RevokeTokenResponse, error)
+	// RefreshToken exchanges a valid refresh token for a new
+	// (access, refresh) pair. The prior refresh token's jti is
+	// revoked on success — refresh tokens are SINGLE-USE.
+	// Replay of an already-exchanged refresh token returns
+	// Unauthenticated (it's now on the revocation list).
+	//
+	// Unauthenticated endpoint by design — the refresh token
+	// itself IS the credential. Don't wrap with the access-
+	// token middleware.
+	RefreshToken(context.Context, *RefreshTokenRequest) (*RefreshTokenResponse, error)
 	mustEmbedUnimplementedTokensServiceServer()
 }
 
@@ -86,6 +115,9 @@ type UnimplementedTokensServiceServer struct{}
 
 func (UnimplementedTokensServiceServer) RevokeToken(context.Context, *RevokeTokenRequest) (*RevokeTokenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RevokeToken not implemented")
+}
+func (UnimplementedTokensServiceServer) RefreshToken(context.Context, *RefreshTokenRequest) (*RefreshTokenResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RefreshToken not implemented")
 }
 func (UnimplementedTokensServiceServer) mustEmbedUnimplementedTokensServiceServer() {}
 func (UnimplementedTokensServiceServer) testEmbeddedByValue()                       {}
@@ -126,6 +158,24 @@ func _TokensService_RevokeToken_Handler(srv interface{}, ctx context.Context, de
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TokensService_RefreshToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RefreshTokenRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TokensServiceServer).RefreshToken(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TokensService_RefreshToken_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TokensServiceServer).RefreshToken(ctx, req.(*RefreshTokenRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // TokensService_ServiceDesc is the grpc.ServiceDesc for TokensService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -136,6 +186,10 @@ var TokensService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RevokeToken",
 			Handler:    _TokensService_RevokeToken_Handler,
+		},
+		{
+			MethodName: "RefreshToken",
+			Handler:    _TokensService_RefreshToken_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/containarium/v1/tokens.proto
+++ b/proto/containarium/v1/tokens.proto
@@ -43,13 +43,40 @@ message RevokeTokenResponse {
   string message = 2;
 }
 
+// Phase 1.6 part B — exchange a refresh token for a new
+// (access, refresh) pair. Rotates the refresh token:
+// the prior jti is revoked on success, so each refresh
+// token is single-use. Replay = denied + audit signal.
+message RefreshTokenRequest {
+  // The current refresh token. Must validate via
+  // ValidateRefreshToken (signature + iss + aud + exp +
+  // tt == "refresh") AND not be in the revocation list.
+  string refresh_token = 1;
+}
+
+message RefreshTokenResponse {
+  // New short-lived access token, ready to use as
+  // Authorization: Bearer.
+  string access_token = 1;
+
+  // New refresh token. Save this — the one you just sent
+  // in is now revoked and cannot be exchanged again.
+  string refresh_token = 2;
+
+  // Unix-seconds expiry of the access token, for clients
+  // that want to refresh proactively before exp.
+  int64 access_token_expires_at = 3;
+
+  // Unix-seconds expiry of the refresh token.
+  int64 refresh_token_expires_at = 4;
+}
+
 // TokensService is the admin surface for JWT lifecycle.
 //
-// All RPCs require an admin role; tenants can't revoke other
-// tenants' tokens. Note that **a token CAN revoke itself**
-// regardless of role — that's how the operator's own logout
-// flow will eventually work — but a tenant calling revoke
-// for a jti they don't recognize still needs admin.
+// RevokeToken requires an admin role + tokens:write scope;
+// tenants can't revoke other tenants' tokens. RefreshToken
+// is open to any holder of a valid refresh token — that's
+// the whole point of the exchange flow.
 service TokensService {
   // RevokeToken adds a token's jti to the revocation list,
   // taking effect on the next authenticated request that
@@ -62,6 +89,27 @@ service TokensService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Revoke a JWT by its jti";
       description: "Adds the token's jti to the revocation list. The token will be rejected on the next request that tries to use it. Admin-only. Idempotent — revoking an already-revoked jti is a no-op (the original revocation reason is preserved).";
+      tags: "Tokens";
+    };
+  }
+
+  // RefreshToken exchanges a valid refresh token for a new
+  // (access, refresh) pair. The prior refresh token's jti is
+  // revoked on success — refresh tokens are SINGLE-USE.
+  // Replay of an already-exchanged refresh token returns
+  // Unauthenticated (it's now on the revocation list).
+  //
+  // Unauthenticated endpoint by design — the refresh token
+  // itself IS the credential. Don't wrap with the access-
+  // token middleware.
+  rpc RefreshToken(RefreshTokenRequest) returns (RefreshTokenResponse) {
+    option (google.api.http) = {
+      post: "/v1/tokens/refresh"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Exchange a refresh token for a new (access, refresh) pair";
+      description: "Validates the refresh token (signature + exp + tt='refresh' + not revoked), mints a new short-lived access token, mints a new long-lived refresh token, and revokes the input refresh token's jti. Refresh tokens are single-use; the new refresh token must be stored by the client for the next exchange.";
       tags: "Tokens";
     };
   }


### PR DESCRIPTION
## Summary

Closes the Phase 1.6 story. Operators (and CLI / agents) can now exchange a long-lived refresh token for a fresh short-lived access token — without leaving the JWT secret on the client side, and with single-use rotation so a stolen refresh gets at most one redemption.

| Surface | Status |
|---|---|
| proto \`TokensService.RefreshToken\` | this PR |
| REST \`POST /v1/tokens/refresh\` (unauthenticated) | this PR |
| CLI \`containarium token refresh --refresh-token <tok>\` | this PR |

## Rotation — single-use semantics

1. Validate the input refresh token (signature + iss + aud + exp + \`tt=refresh\` + not revoked).
2. Mint NEW \`(access, refresh)\` pair **before** revoking the prior — if minting fails the operator's session stays intact.
3. Add the prior refresh-jti to the revocation list with \`reason="refresh_rotation"\`.
4. A replayed refresh token (attacker stole it; victim already exchanged) hits the revocation check inside \`ValidateRefreshToken\` and is rejected with \`Unauthenticated\` — strong tamper signal for the audit pipeline.
5. **Fail-closed** on revocation-store unavailable: a stolen refresh token without rotation gives the attacker permanent renewal, so we refuse rather than silently regress.

## Unauthenticated endpoint

The refresh-token body **is** the credential. Wrapping \`/v1/tokens/refresh\` with the access-token middleware would make exchange impossible (the client doesn't have a fresh access token by definition).

New \`unauthPaths\` map in \`internal/auth/middleware.go\` carries the allowlist; \`HTTPMiddleware\` short-circuits for entries.

## Scopes pass through

The new access token inherits the refresh token's \`scopes\` claim. A least-privilege agent token keeps its narrow grants across rotations.

## CLI

\`\`\`bash
# From an environment variable
containarium token refresh \\
    --refresh-token "\$REFRESH" \\
    --server https://containarium.kafeido.app

# From a file (mode 0600 recommended)
containarium token refresh \\
    --refresh-token-file ~/.containarium/refresh \\
    --server https://containarium.kafeido.app
\`\`\`

Output includes both new tokens + RFC3339 expiry timestamps for the client to schedule the next rotation.

## Tests

5 new cases in \`tokens_server_test.go\`:
- Empty \`refresh_token\` → InvalidArgument
- Access token at the refresh endpoint → Unauthenticated
- Legacy (untagged) token at the refresh endpoint → Unauthenticated
- Happy path → new pair, scopes pass through, expires-at populated
- Rotation replay → Unauthenticated (prior jti revoked)

\`\`\`
ok  github.com/footprintai/containarium/internal/server  8.161s
\`\`\`

## Test plan

- [x] Unit tests pass
- [x] \`go build ./...\` clean
- [x] \`make proto\` regenerated stubs (committed)
- [ ] CI green
- [ ] Manual: mint a refresh token, exchange once → succeeds; try to exchange the SAME token again → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)