### PR TITLE
sec: zero-trust Phase 5.1 — gate /swagger-ui/ behind admin role (A-LOW-1)

### DIFF
--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -441,7 +441,13 @@ on the internal network. Land them first.
 
 ## Phase 5 — Lower priority / process
 
-- [ ] **5.1** Gate `/swagger-ui/` behind admin role — `internal/gateway/gateway.go:535-540` (**A-LOW-1**)
+- [x] **5.1** Gate `/swagger-ui/` behind admin role — `internal/gateway/gateway.go:535-540` (**A-LOW-1**)
+      — Both `/swagger-ui/` and `/swagger.json` now run
+        through `HTTPMiddleware` (auth gate) +
+        `requireAdminFromContext` (role gate). Non-admin
+        callers see 403; unauthenticated callers see 401
+        from the prior middleware step. Tests in
+        `internal/gateway/swagger_gate_test.go`.
 - [ ] **5.2** Add `gosec`, `govulncheck`, `trivy` to CI
 - [ ] **5.3** Publish `SECURITY.md` with vulnerability-disclosure policy
 - [ ] **5.4** Abuse-case test suite: oversized payloads, replayed tokens, wrong-tenant access — all must fail closed

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -559,9 +559,15 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 	}))
 	httpMux.Handle("/v1/events/subscribe", eventsWithCORS)
 
-	// Swagger UI routes (no authentication required)
-	httpMux.Handle("/swagger-ui/", http.StripPrefix("/swagger-ui", http.HandlerFunc(ServeSwaggerUI(gs.swaggerDir))))
-	httpMux.HandleFunc("/swagger.json", ServeSwaggerSpec(gs.swaggerDir))
+	// Swagger UI routes. Phase 5.1 (audit A-LOW-1) — both
+	// the UI bundle and the spec discloses the full API
+	// surface (route paths, request shapes, security
+	// requirements). That's operator-tier knowledge, not
+	// public. Wrap with HTTPMiddleware (auth gate) AND
+	// requireAdminFromContext (role gate).
+	swaggerUI := http.StripPrefix("/swagger-ui", http.HandlerFunc(ServeSwaggerUI(gs.swaggerDir)))
+	httpMux.Handle("/swagger-ui/", gs.authMiddleware.HTTPMiddleware(requireAdminFromContext(swaggerUI)))
+	httpMux.Handle("/swagger.json", gs.authMiddleware.HTTPMiddleware(requireAdminFromContext(http.HandlerFunc(ServeSwaggerSpec(gs.swaggerDir)))))
 
 	// Web UI routes (no authentication required - auth handled client-side via tokens)
 	httpMux.HandleFunc("/webui/", ServeWebUI())
@@ -655,6 +661,23 @@ func customErrorHandler(ctx context.Context, mux *runtime.ServeMux, marshaler ru
 // gRPC metadata, where SubjectFromGRPCContext picks it up on the
 // server side. Without this, gRPC handlers cannot enforce
 // per-resource authorization.
+// requireAdminFromContext rejects requests whose authenticated
+// subject does not hold the admin role. Must run AFTER the
+// auth middleware (which stamps username + roles into the
+// request context). Phase 5.1 — used to gate /swagger-ui/
+// and /swagger.json so the full API surface isn't disclosed
+// to any reachable client.
+func requireAdminFromContext(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		roles, _ := auth.RolesFromContext(r.Context())
+		if !auth.HasRole(roles, auth.RoleAdmin) {
+			http.Error(w, `{"error":"admin role required","code":403}`, http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func annotateContext(ctx context.Context, req *http.Request) metadata.MD {
 	md := metadata.Pairs(
 		"x-forwarded-method", req.Method,

--- a/internal/gateway/swagger_gate_test.go
+++ b/internal/gateway/swagger_gate_test.go
@@ -1,0 +1,93 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+// Phase 5.1 — /swagger-ui and /swagger.json must require
+// the admin role. Exposing the full API surface to any
+// authenticated caller (let alone unauthenticated) is the
+// audit finding A-LOW-1; the gate closes it.
+//
+// We can't trivially exercise the full mux setup here, so
+// the test targets the requireAdminFromContext helper in
+// isolation. The auth-middleware step in front of it is
+// exercised by middleware_test.go in internal/auth.
+
+func TestRequireAdminFromContext_AllowsAdmin(t *testing.T) {
+	called := false
+	stub := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	wrapped := requireAdminFromContext(stub)
+
+	req := httptest.NewRequest("GET", "/swagger.json", nil)
+	ctx := auth.ContextWithClaims(req.Context(), &auth.Claims{
+		Username: "ops",
+		Roles:    []string{auth.RoleAdmin},
+	})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin: status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !called {
+		t.Fatal("admin: handler should have run")
+	}
+}
+
+func TestRequireAdminFromContext_RejectsNonAdmin(t *testing.T) {
+	called := false
+	stub := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	wrapped := requireAdminFromContext(stub)
+
+	req := httptest.NewRequest("GET", "/swagger.json", nil)
+	ctx := auth.ContextWithClaims(req.Context(), &auth.Claims{
+		Username: "alice",
+		Roles:    []string{"user"},
+	})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("non-admin: status = %d, want 403", rec.Code)
+	}
+	if called {
+		t.Fatal("non-admin: handler must NOT have run")
+	}
+}
+
+func TestRequireAdminFromContext_RejectsNoSubject(t *testing.T) {
+	// In production this path is unreachable because the
+	// auth middleware fires first and rejects unauthenticated
+	// requests with 401. But the gate must still fail-closed
+	// if someone wires it elsewhere without the middleware.
+	called := false
+	stub := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	wrapped := requireAdminFromContext(stub)
+
+	req := httptest.NewRequest("GET", "/swagger.json", nil)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("no subject: status = %d, want 403", rec.Code)
+	}
+	if called {
+		t.Fatal("no subject: handler must NOT have run")
+	}
+}


### PR DESCRIPTION
## Summary

The swagger bundle and spec disclose the full API surface: every route path, every request shape, every security requirement. That's operator-tier knowledge, not public.

Both \`/swagger-ui/\` and \`/swagger.json\` now run through:
1. \`HTTPMiddleware\` (auth gate — 401 if not authenticated)
2. \`requireAdminFromContext\` (role gate — 403 if not admin)

Non-admin tokens that previously navigated to the daemon's \`/swagger-ui/\` saw the entire API. They now see 403.

## Tests

\`internal/gateway/swagger_gate_test.go\` — 3 cases targeting the helper in isolation:
- admin role → handler runs, 200
- non-admin role → 403, handler does NOT run
- missing subject → fail-closed 403 (in case the helper is ever wired without the auth middleware in front)

## Test plan

- [x] Unit tests pass
- [x] \`go build ./...\` clean
- [ ] CI green
- [ ] Manual: try \`curl http://daemon/swagger-ui/\` → 401; with a non-admin Bearer → 403; with admin Bearer → swagger UI loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)