### PR TITLE
sec: zero-trust Phase 3.1 follow-up — operator-enforced image digest pinning (B-HIGH-1)

### DIFF
--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -358,8 +358,23 @@ on the internal network. Land them first.
         whose registry prefix isn't in the allowlist. Empty allowlist
         = pre-Phase-3 behavior with startup WARNING. Tests in
         `internal/server/image_allowlist_test.go`.
-      — Digest pinning is a follow-up — would require image-pull
-        side checks for SHA-256 manifests.
+      — **Digest enforcement landed (operator-side half).**
+        New `CONTAINARIUM_REQUIRE_IMAGE_DIGEST` env var
+        (default off). When `1`/`true`/`yes`/`on`,
+        CreateContainer refuses images that don't end with
+        `@sha256:<64 lowercase hex>`. sha256 only — the
+        algorithm-confusion surface that bit JWTs (see
+        Phase 1.1) is closed for image refs too. Tests in
+        `internal/server/image_digest_test.go` cover
+        enforcement on/off, bare-tag rejection, malformed
+        digests, uppercase-hex rejection, wrong-algo
+        rejection, empty-image bypass (default
+        substitution still works), and the "unrecognized
+        env stays OFF" fail-open on operator typos.
+      — **Future:** verify the digest against the
+        registry's content. That requires image-pull side
+        checks (Incus manifest verification) — significant
+        deeper work, tracked as a third pass on B-HIGH-1.
 - [x] **3.2** Split `enable_podman` from `enable_privileged`; gate latter on role — `internal/server/container_server.go:164`, `pkg/core/incus/client.go:458-459` (**A-HIGH-3**)
       — New `CONTAINARIUM_PRIVILEGED_PODMAN_POLICY` env var with
         three modes: `all` (default, backwards-compat), `admin-only`

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -176,6 +176,13 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	if err := validateImageRegistry(req.Image); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	// Phase 3.1 follow-up: when CONTAINARIUM_REQUIRE_IMAGE_DIGEST
+	// is on, every image reference must carry an `@sha256:<64hex>`
+	// suffix so the operator pins the exact image bytes. Disabled
+	// by default — opt-in for supply-chain-paranoid deployments.
+	if err := validateImageDigest(req.Image); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	// Audit A-HIGH-3: enable_podman=true implies privileged + apparmor=unconfined.
 	// Gate that elevation behind CONTAINARIUM_PRIVILEGED_PODMAN_POLICY so

--- a/internal/server/image_digest.go
+++ b/internal/server/image_digest.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Phase 3.1 follow-up — image digest pinning (audit
+// B-HIGH-1, supply-chain hardening half).
+//
+// The allowlist (image_allowlist.go) keeps the daemon from
+// pulling images from arbitrary registries. Digest pinning
+// adds a second axis: even within an allowed registry, the
+// operator forces every CreateContainer request to name
+// the EXACT image bytes — not "latest", not a tag that
+// could be re-pushed.
+//
+// Wire shape: operator sets
+//
+//   CONTAINARIUM_REQUIRE_IMAGE_DIGEST=true
+//
+// and from that point on the daemon refuses any image
+// reference that doesn't carry `@sha256:<64-hex>`. The
+// daemon doesn't verify the digest against the registry's
+// content (that requires Incus-side support and is the
+// "real" half of digest pinning, tracked separately) — but
+// it does force the operator to write a specific digest
+// down. The supply-chain attacker who hopes a tagged image
+// will quietly be re-pulled with malicious bytes is denied
+// the ambiguity they need.
+//
+// Default is off — turning enforcement on is a flag flip,
+// not a code change.
+
+const requireImageDigestEnv = "CONTAINARIUM_REQUIRE_IMAGE_DIGEST"
+
+var (
+	imageDigestOnce sync.Once
+	imageDigestReq  bool
+
+	// sha256Pattern matches a single base64-encoded SHA-256
+	// hex digest as it appears in an OCI image reference:
+	// 64 lowercase hex chars after a literal `sha256:`.
+	sha256Pattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+)
+
+func loadDigestRequired() bool {
+	imageDigestOnce.Do(func() {
+		raw := strings.TrimSpace(os.Getenv(requireImageDigestEnv))
+		if raw == "" {
+			imageDigestReq = false
+			return
+		}
+		switch strings.ToLower(raw) {
+		case "1", "true", "yes", "on":
+			imageDigestReq = true
+			log.Printf("[image-digest] required: every CreateContainer must name a `@sha256:<64hex>` digest (audit B-HIGH-1 follow-up)")
+		default:
+			imageDigestReq = false
+			log.Printf("WARNING: %s=%q is unrecognized (expected 1/true/yes/on); digest pinning STAYS OFF", requireImageDigestEnv, raw)
+		}
+	})
+	return imageDigestReq
+}
+
+// validateImageDigest returns nil if the image reference
+// carries a syntactically valid `@sha256:<64hex>` digest
+// suffix, or if digest enforcement is disabled. Returns a
+// descriptive error otherwise — caller maps to
+// InvalidArgument.
+//
+// Empty image is allowed when enforcement is on: the
+// daemon substitutes a known default later, and the
+// allowlist check already runs against the empty input
+// separately. Operators who want to forbid the default-
+// substitution path should set --os-type=... at the
+// callsite, not gate it here.
+func validateImageDigest(image string) error {
+	if !loadDigestRequired() {
+		return nil
+	}
+	if image == "" {
+		return nil
+	}
+	digest, ok := extractImageDigest(image)
+	if !ok {
+		return fmt.Errorf("image %q is missing a digest; %s=true requires every image reference to end with `@sha256:<64-lowercase-hex>` so the exact image bytes are pinned", image, requireImageDigestEnv)
+	}
+	if !sha256Pattern.MatchString(digest) {
+		return fmt.Errorf("image %q has an invalid digest %q; expected `sha256:` + 64 lowercase hex chars", image, digest)
+	}
+	return nil
+}
+
+// extractImageDigest splits an OCI image reference at the
+// `@` separator and returns the digest part. Returns
+// (digest, true) when an `@` is present; (empty, false)
+// otherwise. Does NOT validate the digest format — call
+// sha256Pattern.MatchString on the result.
+func extractImageDigest(image string) (string, bool) {
+	i := strings.LastIndex(image, "@")
+	if i < 0 {
+		return "", false
+	}
+	return image[i+1:], true
+}

--- a/internal/server/image_digest_test.go
+++ b/internal/server/image_digest_test.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Phase 3.1 follow-up — image-digest-pinning tests.
+
+// resetDigestOnce flips imageDigestOnce back to its zero
+// state so each test can drive a fresh env-var read. Tests
+// run sequentially via t.Setenv inside this package, so
+// no concurrent-init race.
+func resetDigestOnce(t *testing.T) {
+	t.Helper()
+	imageDigestOnce = sync.Once{}
+	imageDigestReq = false
+}
+
+func TestExtractImageDigest(t *testing.T) {
+	cases := map[string]struct {
+		want   string
+		wantOK bool
+	}{
+		"ubuntu:22.04@sha256:abc": {"sha256:abc", true},
+		"ubuntu:22.04":            {"", false},
+		"":                        {"", false},
+		"images:ubuntu/22.04@sha256:deadbeef": {"sha256:deadbeef", true},
+		// Multi-@ is unusual but the last `@` wins (matches
+		// OCI reference semantics for digest pinning).
+		"a@b@sha256:xyz": {"sha256:xyz", true},
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			got, ok := extractImageDigest(in)
+			if got != want.want || ok != want.wantOK {
+				t.Fatalf("extractImageDigest(%q) = (%q,%v); want (%q,%v)",
+					in, got, ok, want.want, want.wantOK)
+			}
+		})
+	}
+}
+
+// Valid digest passes regardless of env value (the env
+// only gates the requirement; never the format).
+func TestValidateImageDigest_DisabledByDefault(t *testing.T) {
+	resetDigestOnce(t)
+	t.Setenv(requireImageDigestEnv, "")
+	// No digest at all — accepted because enforcement off.
+	if err := validateImageDigest("ubuntu:22.04"); err != nil {
+		t.Fatalf("unenforced: should pass; got %v", err)
+	}
+}
+
+func TestValidateImageDigest_EnforcedRejectsBareTag(t *testing.T) {
+	resetDigestOnce(t)
+	t.Setenv(requireImageDigestEnv, "true")
+
+	err := validateImageDigest("ubuntu:22.04")
+	if err == nil {
+		t.Fatal("bare tag should be rejected when enforcement is on")
+	}
+	if !strings.Contains(err.Error(), "missing a digest") {
+		t.Fatalf("error should mention missing digest; got %v", err)
+	}
+}
+
+func TestValidateImageDigest_EnforcedAcceptsValidDigest(t *testing.T) {
+	resetDigestOnce(t)
+	t.Setenv(requireImageDigestEnv, "true")
+
+	good := "ubuntu:22.04@sha256:" + strings.Repeat("a", 64)
+	if err := validateImageDigest(good); err != nil {
+		t.Fatalf("valid digest: %v", err)
+	}
+}
+
+func TestValidateImageDigest_RejectsTooShortDigest(t *testing.T) {
+	resetDigestOnce(t)
+	t.Setenv(requireImageDigestEnv, "true")
+
+	short := "ubuntu:22.04@sha256:abc"
+	err := validateImageDigest(short)
+	if err == nil {
+		t.Fatal("short digest should be rejected")
+	}
+	if !strings.Contains(err.Error(), "64 lowercase hex") {
+		t.Fatalf("error should explain expected shape; got %v", err)
+	}
+}
+
+func TestValidateImageDigest_RejectsUppercaseHex(t *testing.T) {
+	// OCI digests are spec'd as lowercase; uppercase tokens
+	// are technically a different reference and reject is
+	// the safer call.
+	resetDigestOnce(t)
+	t.Setenv(requireImageDigestEnv, "true")
+
+	mixed := "ubuntu:22.04@sha256:" + strings.Repeat("A", 64)
+	if err := validateImageDigest(mixed); err == nil {
+		t.Fatal("uppercase hex should be rejected")
+	}
+}
+
+func TestValidateImageDigest_RejectsWrongAlgo(t *testing.T) {
+	resetDigestOnce(t)
+	t.Setenv(requireImageDigestEnv, "true")
+
+	// sha512 is fine in OCI but we accept only sha256 to
+	// avoid the algorithm-confusion surface that bit JWTs
+	// (the daemon validates one shape end-to-end).
+	wrong := "ubuntu:22.04@sha512:" + strings.Repeat("a", 128)
+	if err := validateImageDigest(wrong); err == nil {
+		t.Fatal("sha512 digest should be rejected (sha256-only policy)")
+	}
+}
+
+func TestValidateImageDigest_EnforcedAllowsEmptyImage(t *testing.T) {
+	// Empty req.Image means "use the daemon's default".
+	// The default substitution happens later in the
+	// pipeline; gating it here would block tenants who
+	// rely on the os_type-driven default.
+	resetDigestOnce(t)
+	t.Setenv(requireImageDigestEnv, "true")
+
+	if err := validateImageDigest(""); err != nil {
+		t.Fatalf("empty image with enforcement on should pass; got %v", err)
+	}
+}
+
+func TestValidateImageDigest_UnrecognizedEnvLeavesOff(t *testing.T) {
+	resetDigestOnce(t)
+	t.Setenv(requireImageDigestEnv, "maybe")
+
+	// Should not enforce — fail-open on bad config so a
+	// typo doesn't silently lock out every tenant.
+	if err := validateImageDigest("ubuntu:22.04"); err != nil {
+		t.Fatalf("unrecognized env should leave enforcement off; got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

The allowlist (already shipped) keeps the daemon from pulling images from arbitrary registries. This adds the second axis — **digest pinning** — so even within an allowed registry, the operator can force every \`CreateContainer\` to name the EXACT image bytes.

\`\`\`bash
CONTAINARIUM_REQUIRE_IMAGE_DIGEST=true
\`\`\`

From that point on, requests are rejected unless \`req.Image\` ends with \`@sha256:<64 lowercase hex>\`. **sha256 only** — the algorithm-confusion surface that bit JWTs (Phase 1.1) gets closed for image refs too.

## What this does NOT do

It does not verify the digest matches the registry's content. That requires Incus-side manifest verification and is the deeper half of B-HIGH-1 (tracked as a future pass).

## What this DOES do

Force the operator to write a specific digest down, denying the supply-chain attacker the ambiguity ("latest will be re-pulled with my bytes") they need.

## Defaults & policy

- **Default off** — operators opt in via the env var.
- Recognized "on" values: \`1\`, \`true\`, \`yes\`, \`on\` (case-insensitive). Anything else falls through to OFF with a WARNING log — a typo on a flag should never silently lock out every tenant.
- Empty image is allowed even under enforcement: the daemon substitutes a default later in the pipeline, and the allowlist already runs against the empty input separately.

## Wire shape

\`\`\`
images:ubuntu/22.04@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
                  ^^^^^^^^                                                                  
                  required when CONTAINARIUM_REQUIRE_IMAGE_DIGEST=true
\`\`\`

## Tests

8 cases in \`internal/server/image_digest_test.go\`:
- helper extraction (bare tag, no @, multi-@)
- enforcement off → bare tag allowed
- enforcement on → bare tag rejected with "missing a digest"
- enforcement on → valid sha256 accepted
- short digest rejected
- uppercase-hex rejected (OCI spec requires lowercase)
- sha512 rejected (sha256-only policy)
- empty image bypass
- unrecognized env value stays OFF

\`\`\`
ok  github.com/footprintai/containarium/internal/server  1.480s
\`\`\`

## Test plan

- [x] Unit tests pass
- [x] \`go build ./...\` clean
- [ ] CI green
- [ ] Manual: \`CONTAINARIUM_REQUIRE_IMAGE_DIGEST=true ./containarium daemon\`, then try \`create_container --image ubuntu:22.04\` → expect 400 with the digest-required error

🤖 Generated with [Claude Code](https://claude.com/claude-code)