### PR TITLE
docs(security): operator security runbook

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -105,7 +105,10 @@ git history. Major shipped items at the time of writing:
 - Wake-handler source-IP lockdown
   ([#244](https://github.com/FootprintAI/Containarium/pull/244)).
 
-For the full open / closed status, see the audit TODO doc.
+For the full open / closed status, see the audit TODO doc. For
+day-to-day operator procedures (token rotation, leak response,
+least-privilege agent tokens, audit-chain verification), see the
+[operator security runbook](docs/security/OPERATOR-SECURITY-RUNBOOK.md).
 
 ## Thank you
 

--- a/docs/security/OPERATOR-SECURITY-RUNBOOK.md
+++ b/docs/security/OPERATOR-SECURITY-RUNBOOK.md
@@ -1,0 +1,344 @@
+# Operator Security Runbook
+
+A "what do I do when X" reference for operators running Containarium
+in production. Engineering-facing detail lives in
+[ZERO-TRUST-AUDIT.md](ZERO-TRUST-AUDIT.md) and
+[ZERO-TRUST-TODO.md](ZERO-TRUST-TODO.md); this file is the
+operational counterpart — short procedures, the exact commands, and
+the rationale in one or two sentences.
+
+If you find yourself doing something here more than once, automate it.
+If a procedure here is wrong, update it.
+
+## Table of contents
+
+- [Token lifecycle](#token-lifecycle)
+- [Suspected credential leak](#suspected-credential-leak)
+- [Issuing least-privilege tokens for agents](#issuing-least-privilege-tokens-for-agents)
+- [Rotating the JWT signing secret](#rotating-the-jwt-signing-secret)
+- [Rotating Postgres credentials](#rotating-postgres-credentials)
+- [Locking down `/wake/` to a known load balancer](#locking-down-wake-to-a-known-load-balancer)
+- [Auditing recent administrative actions](#auditing-recent-administrative-actions)
+- [Verifying the audit-log hash chain](#verifying-the-audit-log-hash-chain)
+
+---
+
+## Token lifecycle
+
+Containarium issues JWTs in three forms (Phase 1.6):
+
+| Form          | `tt` claim   | Default TTL | What it can do                 |
+| ------------- | ------------ | ----------- | ------------------------------ |
+| **access**    | `access`     | 15 min      | Authenticate to the API        |
+| **refresh**   | `refresh`    | 30 days     | Exchange at `/v1/tokens/refresh` for a new access + refresh pair |
+| **legacy**    | (omitted)    | 24h (CLI default) | Behaves as access on the API surface — kept for backwards compat |
+
+A refresh token **cannot** authenticate to any API surface. Stealing
+one only buys the attacker one rotation cycle before the legitimate
+holder's next exchange revokes it.
+
+### Mint an operator access token (interactive)
+
+```bash
+containarium token generate \
+    --username "$YOUR_USERNAME" --roles admin \
+    --token-type access --expiry 8h \
+    --secret-file /etc/containarium/jwt.secret
+```
+
+15-minute defaults are aimed at agents. For an operator session,
+`--expiry 8h` is reasonable; the access token cannot be revoked
+mid-session except via the kill-switch below.
+
+### Mint a long-lived refresh + short-lived access pair
+
+```bash
+# Mint the refresh; store it somewhere only you can read.
+containarium token generate \
+    --username "$YOUR_USERNAME" --roles admin \
+    --token-type refresh --expiry 720h \
+    --secret-file /etc/containarium/jwt.secret \
+    --raw > ~/.containarium/refresh
+chmod 0600 ~/.containarium/refresh
+
+# Whenever you need a fresh access token (e.g. on session start):
+containarium token refresh \
+    --refresh-token-file ~/.containarium/refresh \
+    --server https://containarium.kafeido.app
+```
+
+`token refresh` prints the new access token (use for the next ~15
+minutes) and a new refresh token (replaces the old one — the prior
+file's contents are now revoked server-side).
+
+---
+
+## Suspected credential leak
+
+You believe a JWT, refresh token, or operator credential has been
+exposed (pushed to a public gist, leaked via a tenant logfile,
+present in a screen recording, …).
+
+### Step 1 — Find the `jti`
+
+Every authenticated request the leaked token made was audit-logged
+with its `jti` claim. Pull it from the audit log:
+
+```bash
+containarium audit query \
+    --username "$LEAKED_USERNAME" \
+    --from "2026-05-20T00:00:00Z" \
+    --limit 50
+```
+
+Each row carries the `jti` in the detail column. If you have the raw
+JWT, you can also base64-decode the payload segment:
+
+```bash
+echo "$LEAKED_TOKEN" | cut -d. -f2 | base64 -d | jq .
+```
+
+### Step 2 — Revoke
+
+```bash
+containarium token revoke \
+    --jti "$JTI" \
+    --reason "leaked_to_public_gist_$(date -u +%Y%m%d)" \
+    --server https://containarium.kafeido.app \
+    --token "$ADMIN_TOKEN"
+```
+
+Idempotent — running it twice with the same `jti` preserves the first
+reason. From this point on, any request bearing the revoked token
+gets `401 invalid token`.
+
+### Step 3 — If the leaked token was a refresh token
+
+The exchange endpoint won't accept it once revoked, BUT the
+attacker may already have exchanged it for a fresh pair before you
+caught the leak. To be safe:
+
+1. Revoke every refresh-token jti the user issued in the suspicious
+   window (filter audit by `action=token_refresh`).
+2. Force the user to re-mint at the daemon (`containarium token
+   generate --token-type refresh`).
+
+### Step 4 — Look for lateral movement
+
+```bash
+# Anything the leaked user did between issuance and revocation
+containarium audit query --username "$LEAKED_USERNAME" --from "$ISSUE_TIME"
+```
+
+Triage by action type: container create/delete, secret read,
+`expose_port`, `toggle_monitoring` — anything write-shaped is worth
+manual review.
+
+---
+
+## Issuing least-privilege tokens for agents
+
+LLM agents (Claude, Cursor, etc.) consuming the MCP server should
+NOT be carrying admin-role unrestricted tokens. The Phase 1.7 scope
+model (`internal/auth/scopes.go`) lets you mint narrow tokens:
+
+```bash
+# Read-only agent — can list and inspect, can't mutate
+containarium token generate \
+    --username "agent-claude-readonly" --roles user \
+    --scopes containers:read,secrets:read,routes:read \
+    --token-type access --expiry 24h \
+    --secret-file /etc/containarium/jwt.secret
+
+# Container-ops agent — can lifecycle containers but not touch secrets
+containarium token generate \
+    --username "agent-claude-ops" --roles user \
+    --scopes containers:read,containers:write,routes:read,routes:write,ssh:write \
+    --token-type access --expiry 24h \
+    --secret-file /etc/containarium/jwt.secret
+```
+
+Available scopes (full list in `internal/auth/scopes.go`):
+
+| Scope                | Tools                                                |
+| -------------------- | ---------------------------------------------------- |
+| `containers:read`    | list/get/debug containers, metrics, system info      |
+| `containers:write`   | create/delete/start/stop/resize/move containers      |
+| `secrets:read`       | get/list secrets                                     |
+| `secrets:write`      | set/delete/refresh secrets                           |
+| `routes:read`        | list routes                                          |
+| `routes:write`       | expose ports                                         |
+| `security:read`      | view findings                                        |
+| `security:write`     | trigger scans, remediate                             |
+| `alerts:read`        | view alert rules + webhook deliveries                |
+| `alerts:write`       | create/update/delete alert rules, webhook config     |
+| `traffic:read`       | query traffic history + subscribe to events          |
+| `ssh:write`          | add/remove SSH keys, sync ssh-config                 |
+| `code:write`         | `push`, `sync` developer-loop tools                  |
+| `tokens:write`       | revoke other JWTs                                    |
+| `*`                  | wildcard — everything (avoid for agent tokens)       |
+
+The MCP server filters `tools/list` to scopes the JWT grants and
+rejects out-of-scope `tools/call` locally before the request hits the
+network. The daemon enforces the same gates on REST/gRPC, so a
+non-MCP REST caller using a scoped token gets the same restrictions.
+
+---
+
+## Rotating the JWT signing secret
+
+The signing secret lives at `/etc/containarium/jwt.secret` (mode
+`0600`). Rotating it invalidates **every** issued token — operators
+included — so plan the cutover.
+
+```bash
+# 1. Generate a new secret (>=32 bytes for HMAC-SHA256 floor)
+openssl rand -base64 48 | sudo tee /etc/containarium/jwt.secret.new
+sudo chmod 0600 /etc/containarium/jwt.secret.new
+sudo chown root:root /etc/containarium/jwt.secret.new
+
+# 2. Swap atomically
+sudo mv /etc/containarium/jwt.secret.new /etc/containarium/jwt.secret
+
+# 3. Restart the daemon (token validation reads on each call but
+#    the secret is captured at NewTokenManager time, so a restart
+#    is required to pick it up)
+sudo systemctl restart containarium
+
+# 4. Re-mint your own admin token immediately (use the new secret)
+containarium token generate --username "$YOUR_USERNAME" --roles admin \
+    --token-type access --expiry 8h \
+    --secret-file /etc/containarium/jwt.secret
+```
+
+The audit-log entry for the restart will be missing the daemon's
+self-issued system token (which is re-minted on startup against the
+new secret); that's expected.
+
+---
+
+## Rotating Postgres credentials
+
+Containarium reads Postgres credentials from (in order):
+`CONTAINARIUM_POSTGRES_URL_FILE` → `CONTAINARIUM_POSTGRES_URL` →
+auto-detect with password from `CONTAINARIUM_POSTGRES_PASSWORD_FILE` /
+`CONTAINARIUM_POSTGRES_PASSWORD` / compiled-in dev default.
+
+### Recommended deployment shape
+
+```bash
+sudo install -m 0600 -o root -g root \
+    <(echo -n "$NEW_PG_PASSWORD") \
+    /etc/containarium/postgres.password
+```
+
+Set in the daemon's systemd unit:
+
+```ini
+Environment="CONTAINARIUM_POSTGRES_PASSWORD_FILE=/etc/containarium/postgres.password"
+```
+
+To rotate, update the file in place and restart the daemon. No code
+or config change required:
+
+```bash
+echo -n "$NEW_PG_PASSWORD" | sudo tee /etc/containarium/postgres.password > /dev/null
+sudo chmod 0600 /etc/containarium/postgres.password
+sudo systemctl restart containarium
+```
+
+The daemon refuses to start if the file is world-readable — same
+contract as the JWT token file (Phase C-HIGH-7).
+
+---
+
+## Locking down `/wake/` to a known load balancer
+
+The wake-on-HTTP handler (Phase 1.9) is reachable on the daemon's
+public HTTP port. Without an explicit allowlist, any source can
+trigger a container wake by crafting the `Host` header. In production
+where Caddy lives on the same host as the daemon, loopback is always
+trusted — but operators with off-host Caddy / GLB / sentinel paths
+should pin the source:
+
+```bash
+# Set in the daemon's systemd Environment=
+CONTAINARIUM_WAKE_TRUSTED_PROXIES=10.0.0.0/8,192.168.1.5,fd00::/8
+```
+
+The handler rejects any source not in the allowlist with `403 wake:
+source not permitted`. Wildcard `/0` prefixes are explicitly refused
+at load — defeating the gate would be worse than turning it off.
+
+If `CONTAINARIUM_WAKE_TRUSTED_PROXIES` is unset and Caddy is NOT on
+the same host, you'll see the startup `WARNING` log line and every
+non-loopback source will be accepted (pre-1.9 behavior). Setting the
+env var is the safe default.
+
+---
+
+## Auditing recent administrative actions
+
+Every authenticated request lands in the `audit_logs` table (Phase
+4.5) with timestamp, username, action, resource, source IP, and
+optional detail. The CLI can query directly:
+
+```bash
+# Everything an admin did in the last hour
+containarium audit query \
+    --username ops --from "$(date -u -d '1 hour ago' --iso-8601=seconds)" \
+    --limit 100
+
+# All token revocations this month
+containarium audit query \
+    --action token_revoke \
+    --from "$(date -u -d '1 month ago' --iso-8601=seconds)" \
+    --limit 200
+```
+
+The detail column carries the `jti`, request payload summary, and any
+audit-relevant context. **Tenant secrets values are scrubbed** by the
+`internal/audit/redact.go` redactor before write — operators reading
+the table never see plaintext credentials.
+
+---
+
+## Verifying the audit-log hash chain
+
+Each row's `row_hash` is a SHA-256 of its content + the previous
+row's hash (Phase 4.5). A tampered or inserted row breaks the chain
+at that point. The daemon does NOT auto-verify on every read; ops
+runs the verifier when forensics are needed:
+
+```bash
+# Verify from the chain start
+containarium audit verify
+
+# Verify from a specific row ID (faster for large tables)
+containarium audit verify --from-id 100000
+```
+
+The verifier reports the row ID where the chain breaks, or "intact"
+when every row's `row_hash` recomputes to its stored value.
+
+If the chain is broken:
+
+1. Note the `firstBad` ID. Everything before it is trusted; the row
+   at `firstBad` and everything after are suspect.
+2. Pull recent operator-shell history on the daemon host — only
+   someone with database write access to `audit_logs` can break the
+   chain, and that's a small list.
+3. Restore the table from the most recent verified backup (the
+   chain root from the backup is the authoritative "good" state).
+
+---
+
+## References
+
+- [Vulnerability disclosure policy](../../SECURITY.md)
+- [Zero-trust audit findings](ZERO-TRUST-AUDIT.md) — engineering detail
+- [Zero-trust remediation status](ZERO-TRUST-TODO.md) — phase tracker
+- [Phase 0 operator runbook](PHASE-0-OPERATOR-RUNBOOK.md) — bootstrap
+  steps for a fresh deployment (mTLS, sentinel HMAC, peer CA)
+- [Container env-var introspection risk](SECRETS-ENV-VAR-RISK.md) —
+  what stamping secrets via env actually exposes


### PR DESCRIPTION
## Summary

The audit doc ([\`ZERO-TRUST-AUDIT.md\`](docs/security/ZERO-TRUST-AUDIT.md)) is engineering-facing: findings, file:line references, technical context. This adds the operator-facing companion: short **"what do I do when X"** procedures with the exact commands.

## Sections

| Section | What it covers |
|---|---|
| Token lifecycle | access vs refresh vs legacy; mint procedures for interactive ops AND long-lived refresh/access pairs |
| Suspected credential leak | 4-step procedure: find jti in audit log → revoke → handle refresh-token rotation → audit lateral movement |
| Issuing least-privilege tokens for agents | Full Phase 1.7 scope table + sample mint commands for read-only and ops-shaped agent tokens |
| Rotating the JWT signing secret | Atomic swap + restart procedure |
| Rotating Postgres credentials | Uses the new \`CONTAINARIUM_POSTGRES_PASSWORD_FILE\` from PR #260 |
| Locking down \`/wake/\` to a known load balancer | Phase 1.9 \`CONTAINARIUM_WAKE_TRUSTED_PROXIES\` configuration |
| Auditing recent administrative actions | \`containarium audit query\` examples by user, action, time window |
| Verifying the audit-log hash chain | Phase 4.5 \`containarium audit verify\`; what to do when the chain breaks |

## Wiring

Cross-linked from \`SECURITY.md\` so an operator landing at the repo root sees both the disclosure policy and the runbook.

No code changes — pure documentation.

## Test plan

- [x] Markdown renders correctly in GitHub preview
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)