### PR TITLE
sec: zero-trust Phase 4.1 Phase-A — KMS interface + in-process impl (C-HIGH-6)

### DIFF
--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -437,11 +437,17 @@ on the internal network. Land them first.
         retirement → other backends). Operators reading
         the current secrets code can see what's protected
         today and what isn't.
-      — **Implementation deferred.** Multi-PR effort —
-        starts with the `KMSClient` interface +
-        in-process no-op impl in `pkg/core/secrets/kms.go`,
-        then the schema migration, then per-backend
-        impls. Tracked as the C-HIGH-6 follow-up.
+      — **Phase A landed.** `KMSClient` interface +
+        `InProcKMS` no-op impl in
+        `pkg/core/secrets/kms.go`. The inproc backend uses
+        the existing master key with AES-GCM and the kek_id
+        sentinel `inproc:master` — cryptographically
+        equivalent to the legacy path. Phase B (two-write
+        Store flow, schema migration) is the next slice;
+        no callers wire this yet. 9 tests in `kms_test.go`
+        cover round-trip symmetry, kek_id routing,
+        DEK-size rejection, ciphertext tampering,
+        cross-deployment isolation.
 - [x] **4.2** Stat-check master-key file permissions at load — `pkg/core/secrets/crypto.go:47,109` (**C-HIGH-6**)
       — `LoadOrCreateMasterKey` now stats the file before reading
         and refuses if any non-owner bit is set (`mode & 0o077 != 0`).

--- a/pkg/core/secrets/kms.go
+++ b/pkg/core/secrets/kms.go
@@ -1,0 +1,178 @@
+package secrets
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Phase 4.1 Phase-A — KMS envelope-encryption interface +
+// in-process no-op impl. Audit C-HIGH-6. See
+// docs/security/KMS-ENVELOPE-DESIGN.md for the threat
+// model and the multi-phase rollout plan.
+//
+// THIS PR INTRODUCES THE INTERFACE ONLY. No callers wire
+// it yet — the existing Cipher path remains the canonical
+// encrypt/decrypt route. Subsequent phases wire envelope
+// rows alongside the legacy ciphertext (Phase B), add
+// real KMS backends (Phase C), and eventually retire the
+// master key (Phase E).
+//
+// Wire shape: every secret carries a per-row Data
+// Encryption Key (DEK). The DEK encrypts the plaintext via
+// AES-GCM the same way the master key does today. The
+// KMSClient.Wrap call encrypts the DEK under the
+// KMS-resident Key Encryption Key (KEK). Storage holds
+// (ciphertext, wrapped_dek, kek_id). On read, KMSClient.Unwrap
+// turns the wrapped DEK back into a plaintext DEK in
+// daemon memory; the daemon decrypts the value and zeroes
+// the DEK before returning.
+
+// KMSClient is the narrow envelope-encryption interface
+// the Store talks to. Implementations:
+//
+//   - kms_inproc.go (this file): no-op shim using the
+//     existing master key. Default for backwards compat;
+//     gets the schema migration in place without changing
+//     the cryptographic protection.
+//   - kms_gcp.go (future): GCP KMS via cloudkms.v1.
+//   - kms_vault.go (future): Vault Transit secret engine.
+//   - kms_aws.go (future): AWS KMS.
+//
+// The interface is intentionally tight: just Wrap and
+// Unwrap. Backends that need more state (versioning,
+// rotation hints) carry it inside the implementation, not
+// the contract.
+type KMSClient interface {
+	// Wrap encrypts a plaintext Data Encryption Key (DEK)
+	// under the KMS-resident Key Encryption Key (KEK).
+	// Returns the wrapped DEK and the KEK identifier
+	// (provider-specific — for GCP KMS it's the full
+	// resource name; for the inproc impl it's a sentinel).
+	// The wrapped DEK lands in the secrets row alongside
+	// the ciphertext.
+	Wrap(ctx context.Context, plaintextDEK []byte) (wrappedDEK []byte, kekID string, err error)
+
+	// Unwrap reverses Wrap. The kekID is the value returned
+	// by the original Wrap call — implementations use it to
+	// pick the right key version on the backend. Returns
+	// the plaintext DEK; callers MUST zero it after use.
+	Unwrap(ctx context.Context, wrappedDEK []byte, kekID string) (plaintextDEK []byte, err error)
+}
+
+// DEKSize is the size of a Data Encryption Key. AES-256
+// matches the existing master-key path.
+const DEKSize = 32
+
+// inprocKEKID is the sentinel kek_id stored by the in-
+// process KMS. Future per-row reads use this to route to
+// the inproc Unwrap; real KMS rows carry a real resource
+// path.
+const inprocKEKID = "inproc:master"
+
+// InProcKMS is the no-op envelope backend. It wraps DEKs
+// using the daemon's existing master key with AES-GCM.
+// Cryptographically equivalent to the legacy single-key
+// path — the protection level is the same, the storage
+// shape is just one indirection longer. The point is to
+// land the schema and the Store-side plumbing without
+// changing the threat model; switching to a real KMS later
+// is then a configuration change, not a code change at
+// every callsite.
+type InProcKMS struct {
+	aead cipher.AEAD
+}
+
+// NewInProcKMS builds an InProcKMS from the daemon's
+// master key (the same 32-byte key Cipher uses). The KMS
+// uses a different AEAD instance than Cipher so that even
+// a future bug in one path can't pollute the other.
+func NewInProcKMS(masterKey []byte) (*InProcKMS, error) {
+	if len(masterKey) != MasterKeySize {
+		return nil, ErrKeyWrongSize
+	}
+	block, err := aes.NewCipher(masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("aes.NewCipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("cipher.NewGCM: %w", err)
+	}
+	return &InProcKMS{aead: aead}, nil
+}
+
+// Wrap encrypts the DEK under the master key with a fresh
+// nonce. The output bytes are nonce || ciphertext-with-
+// tag, so Unwrap doesn't need to know the nonce
+// separately. Phase-A simplicity; Phase-B+ may attach
+// versioning bytes via a TLV envelope.
+func (k *InProcKMS) Wrap(_ context.Context, plaintextDEK []byte) ([]byte, string, error) {
+	if len(plaintextDEK) != DEKSize {
+		return nil, "", fmt.Errorf("DEK must be %d bytes; got %d", DEKSize, len(plaintextDEK))
+	}
+	nonce := make([]byte, NonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, "", fmt.Errorf("generate wrap nonce: %w", err)
+	}
+	// Use the literal kek-id as AAD so a wrapped DEK can't
+	// be replayed under a different KMS backend's row.
+	wrapped := k.aead.Seal(nil, nonce, plaintextDEK, []byte(inprocKEKID))
+	// Prepend the nonce so Unwrap doesn't need it
+	// separately. Layout: [12-byte nonce][ciphertext+tag].
+	out := make([]byte, 0, NonceSize+len(wrapped))
+	out = append(out, nonce...)
+	out = append(out, wrapped...)
+	return out, inprocKEKID, nil
+}
+
+// Unwrap reverses Wrap. The kekID must match the sentinel
+// or we refuse — that's how Phase-B+ readers know not to
+// route a real-KMS row through the inproc backend by
+// mistake.
+func (k *InProcKMS) Unwrap(_ context.Context, wrappedDEK []byte, kekID string) ([]byte, error) {
+	if kekID != inprocKEKID {
+		return nil, fmt.Errorf("InProcKMS: refusing to unwrap row whose kek_id=%q (not %q)", kekID, inprocKEKID)
+	}
+	if len(wrappedDEK) < NonceSize+1 {
+		return nil, errors.New("InProcKMS: wrapped DEK too short")
+	}
+	nonce := wrappedDEK[:NonceSize]
+	ct := wrappedDEK[NonceSize:]
+	pt, err := k.aead.Open(nil, nonce, ct, []byte(inprocKEKID))
+	if err != nil {
+		return nil, ErrAuthentication
+	}
+	if len(pt) != DEKSize {
+		// Shouldn't happen — every Wrap input is DEKSize —
+		// but a malformed row from a future bug shouldn't
+		// quietly truncate.
+		return nil, fmt.Errorf("InProcKMS: unwrapped DEK has %d bytes; want %d", len(pt), DEKSize)
+	}
+	return pt, nil
+}
+
+// NewDEK generates a 32-byte Data Encryption Key from
+// crypto/rand. Used at every Set call before the KMS Wrap.
+// Caller MUST zero the returned slice after use.
+func NewDEK() ([]byte, error) {
+	dek := make([]byte, DEKSize)
+	if _, err := io.ReadFull(rand.Reader, dek); err != nil {
+		return nil, fmt.Errorf("generate DEK: %w", err)
+	}
+	return dek, nil
+}
+
+// ZeroBytes overwrites the slice in place. Defense-in-
+// depth — the Go garbage collector may relocate the
+// backing array, but explicit zero closes the easy
+// memory-inspection paths.
+func ZeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/pkg/core/secrets/kms_test.go
+++ b/pkg/core/secrets/kms_test.go
@@ -1,0 +1,144 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"errors"
+	"io"
+	"testing"
+)
+
+// Phase 4.1 Phase-A — InProcKMS wrap/unwrap symmetry +
+// edge-case rejections.
+
+func makeMasterKey(t *testing.T) []byte {
+	t.Helper()
+	k := make([]byte, MasterKeySize)
+	if _, err := io.ReadFull(rand.Reader, k); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return k
+}
+
+func TestInProcKMS_WrapUnwrapSymmetry(t *testing.T) {
+	mk := makeMasterKey(t)
+	kms, err := NewInProcKMS(mk)
+	if err != nil {
+		t.Fatalf("NewInProcKMS: %v", err)
+	}
+
+	dek, err := NewDEK()
+	if err != nil {
+		t.Fatalf("NewDEK: %v", err)
+	}
+	if len(dek) != DEKSize {
+		t.Fatalf("DEK size = %d; want %d", len(dek), DEKSize)
+	}
+
+	wrapped, kekID, err := kms.Wrap(context.Background(), dek)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	if kekID != inprocKEKID {
+		t.Fatalf("kekID = %q; want %q", kekID, inprocKEKID)
+	}
+
+	unwrapped, err := kms.Unwrap(context.Background(), wrapped, kekID)
+	if err != nil {
+		t.Fatalf("Unwrap: %v", err)
+	}
+	if !bytes.Equal(unwrapped, dek) {
+		t.Fatal("round-trip altered the DEK")
+	}
+}
+
+func TestInProcKMS_RejectsWrongKEKID(t *testing.T) {
+	kms, _ := NewInProcKMS(makeMasterKey(t))
+	dek, _ := NewDEK()
+	wrapped, _, _ := kms.Wrap(context.Background(), dek)
+
+	_, err := kms.Unwrap(context.Background(), wrapped, "gcp-kms:projects/x/keys/y")
+	if err == nil {
+		t.Fatal("InProcKMS must refuse to unwrap a row addressed to a different KMS")
+	}
+}
+
+func TestInProcKMS_RejectsWrongDEKSize(t *testing.T) {
+	kms, _ := NewInProcKMS(makeMasterKey(t))
+	cases := [][]byte{
+		nil,
+		make([]byte, 16), // half size
+		make([]byte, 64), // double size
+	}
+	for _, c := range cases {
+		_, _, err := kms.Wrap(context.Background(), c)
+		if err == nil {
+			t.Fatalf("Wrap should reject DEK of size %d", len(c))
+		}
+	}
+}
+
+func TestInProcKMS_RejectsTamperedCiphertext(t *testing.T) {
+	kms, _ := NewInProcKMS(makeMasterKey(t))
+	dek, _ := NewDEK()
+	wrapped, kekID, _ := kms.Wrap(context.Background(), dek)
+
+	// Flip a byte in the ciphertext portion (after the
+	// 12-byte nonce prefix).
+	tampered := make([]byte, len(wrapped))
+	copy(tampered, wrapped)
+	tampered[NonceSize+1] ^= 0x01
+
+	_, err := kms.Unwrap(context.Background(), tampered, kekID)
+	if !errors.Is(err, ErrAuthentication) {
+		t.Fatalf("tampered ciphertext: got %v want ErrAuthentication", err)
+	}
+}
+
+func TestInProcKMS_DifferentDeploymentsCannotCrossDecrypt(t *testing.T) {
+	// Two different master keys (two daemon deployments).
+	// A row wrapped under one cannot be unwrapped under
+	// the other.
+	a, _ := NewInProcKMS(makeMasterKey(t))
+	b, _ := NewInProcKMS(makeMasterKey(t))
+
+	dek, _ := NewDEK()
+	wrapped, kekID, _ := a.Wrap(context.Background(), dek)
+	if _, err := b.Unwrap(context.Background(), wrapped, kekID); !errors.Is(err, ErrAuthentication) {
+		t.Fatalf("cross-deployment unwrap should fail; got %v", err)
+	}
+}
+
+func TestInProcKMS_RejectsShortWrappedDEK(t *testing.T) {
+	kms, _ := NewInProcKMS(makeMasterKey(t))
+	_, err := kms.Unwrap(context.Background(), []byte("too-short"), inprocKEKID)
+	if err == nil {
+		t.Fatal("short wrapped DEK should be rejected")
+	}
+}
+
+func TestZeroBytes(t *testing.T) {
+	b := []byte{1, 2, 3, 4, 5}
+	ZeroBytes(b)
+	for i, v := range b {
+		if v != 0 {
+			t.Fatalf("byte %d = %d; want 0", i, v)
+		}
+	}
+	// nil-safe (don't panic).
+	ZeroBytes(nil)
+}
+
+func TestNewDEK_FreshEachCall(t *testing.T) {
+	a, _ := NewDEK()
+	b, _ := NewDEK()
+	if bytes.Equal(a, b) {
+		t.Fatal("two NewDEK calls produced the same key — crypto/rand isn't")
+	}
+}
+
+// KMSClient interface conformance: InProcKMS satisfies the
+// contract. Compile-time check via a typed nil — if the
+// interface method set drifts, this won't compile.
+var _ KMSClient = (*InProcKMS)(nil)


### PR DESCRIPTION
## Summary

First slice of the KMS envelope-encryption rollout (see [docs/security/KMS-ENVELOPE-DESIGN.md](docs/security/KMS-ENVELOPE-DESIGN.md)).

This PR introduces the abstraction; **no callers wire it yet**. The existing Cipher path remains canonical for encrypt/decrypt. Phase B (Store-side two-write flow + schema migration) is the next slice.

## Surface

| Symbol | Purpose |
|---|---|
| \`KMSClient\` | Narrow Wrap/Unwrap interface implementations conform to (GCP KMS, Vault, AWS KMS, …) |
| \`InProcKMS\` | Backwards-compat impl wrapping DEKs under the existing master key. Uses kek_id sentinel \`"inproc:master"\` so Phase-B+ readers can distinguish legacy rows from real-KMS rows. |
| \`NewDEK\` | Fresh 32-byte data key from crypto/rand |
| \`ZeroBytes\` | Defense-in-depth wipe helper |

## Wire shape (per the design doc)

- Per-row DEK encrypts the plaintext via AES-GCM.
- \`KMSClient.Wrap\` encrypts the DEK under the KMS-resident KEK. The inproc impl uses the master key for now.
- Storage holds \`(ciphertext, wrapped_dek, kek_id)\`. The schema migration lands in **Phase B**.

\`InProcKMS\` is cryptographically equivalent to the legacy single-key path — protection level unchanged. The point of landing it now is to get the abstraction reviewed; the later wire-up surgery (Phase B+) is mechanical.

## Tests (9 cases)

- Wrap/Unwrap round-trip symmetry
- kek_id sentinel routing — refusing to unwrap rows addressed to a different KMS backend
- DEK-size rejection (nil, half, double)
- Ciphertext tampering surfaces \`ErrAuthentication\`
- Cross-deployment isolation — wrapping under master key A cannot be unwrapped under master key B
- Short wrapped-DEK rejection
- \`ZeroBytes\` nil-safety
- \`NewDEK\` uniqueness across calls
- Compile-time interface conformance check

\`\`\`
ok  github.com/footprintai/containarium/pkg/core/secrets  2.151s
\`\`\`

## Roadmap

| Phase | Status |
|---|---|
| **A** Interface + InProcKMS | this PR |
| B | Schema migration; \`Store.Set\` writes both old and new rows; \`Store.Get\` prefers envelope and falls back to legacy when \`wrapped_key IS NULL\` |
| C | GCP KMS impl (Workload Identity auth) |
| D | \`containarium secrets migrate-to-envelope\` tool |
| E | Master-key retirement after 100% wrapped |
| F | Vault Transit / AWS KMS / HashiCorp KMS impls |

## Test plan

- [x] Unit tests pass
- [x] \`go build ./...\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)