### PR TITLE
sec: zero-trust Phase 4.1 Phase-E — master-key retirement gate (C-HIGH-6 closed)

### DIFF
--- a/docs/security/OPERATOR-SECURITY-RUNBOOK.md
+++ b/docs/security/OPERATOR-SECURITY-RUNBOOK.md
@@ -340,6 +340,55 @@ re-wrapped and the master key is no longer required for
 decryption (Phase E master-key retirement is then a safe
 operator decision).
 
+### Retiring the master key (Phase E)
+
+Once `envelope-coverage` reports `legacy = 0` and the
+daemon's reads have run cleanly for long enough to be
+confident, the master key file (`/etc/containarium/secrets.key`)
+is no longer used for any production decrypt. Phase E
+gates the cutover so the legacy path can't accidentally be
+re-touched.
+
+```bash
+# 1. Confirm 100% envelope coverage. Repeat over a few
+#    minutes if writes are ongoing; the count should
+#    stabilize at legacy=0.
+containarium secrets envelope-coverage
+
+# 2. Add to the daemon's systemd Environment=:
+CONTAINARIUM_REQUIRE_ENVELOPE=true
+
+# 3. Restart the daemon. The startup log line now ends
+#    "[legacy-rejected]" — that's the confirmation the
+#    gate is on.
+sudo systemctl restart containarium
+
+# 4. Smoke-test a Get; any legacy row that slipped through
+#    the migration surfaces here as an error rather than
+#    silently decrypting under the master key.
+containarium secrets get <user> <name>
+
+# 5. After a soak period (24h+ recommended for production),
+#    remove the master key file. The daemon still loads it
+#    at startup — Phase E doesn't yet remove the dependency
+#    — but every decrypt path goes through the KMS, so
+#    losing the file no longer means losing the data. Keep
+#    a backup off-host in case envelope-coverage was wrong.
+sudo mv /etc/containarium/secrets.key /etc/containarium/secrets.key.retired
+```
+
+If a row WAS missed (because the migrator ran with
+`--max-rows` and a chunk was forgotten, or because of a
+race during migration), Phase E rejects it with:
+
+```
+secret <user>/<name> is legacy-encrypted but
+require_envelope=true (run `containarium secrets
+migrate-to-envelope` before retiring the master key)
+```
+
+Re-run the migration, then retry the Get.
+
 ### Rotating the Vault Transit key
 
 ```bash

--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -426,7 +426,7 @@ on the internal network. Land them first.
 
 ## Phase 4 — Secrets, audit & operational hardening (ongoing)
 
-- [~] **4.1** Envelope encryption via external KMS (GCP KMS / Vault) — `pkg/core/secrets/crypto.go` (**C-HIGH-6** is partially addressed by 4.2 below)
+- [x] **4.1** Envelope encryption via external KMS (GCP KMS / Vault) — `pkg/core/secrets/crypto.go` (**C-HIGH-6** is partially addressed by 4.2 below)
       — **Design doc landed.**
         [`docs/security/KMS-ENVELOPE-DESIGN.md`](KMS-ENVELOPE-DESIGN.md)
         covers threat model (host-compromise resilience,
@@ -460,6 +460,20 @@ on the internal network. Land them first.
         (legacy row on KMS-store, envelope row on no-KMS
         store rejected), AAD binding preserved through
         envelope path.
+      — **Phase E landed (master-key retirement gate).**
+        New env `CONTAINARIUM_REQUIRE_ENVELOPE=true` +
+        `Store.WithRequireEnvelope(true)` option. When
+        enabled, the Store refuses legacy rows
+        (`wrapped_dek IS NULL`) at decrypt time with a
+        descriptive error pointing operators at
+        `containarium secrets migrate-to-envelope`. Daemon
+        refuses to wire the secrets store if the gate is
+        on but no KMS backend is configured — fail-closed
+        at startup. Tests in `retirement_test.go` cover
+        legacy rejected with gate on, envelope still
+        works with gate on, legacy still works with gate
+        off. Retirement cutover procedure documented in
+        [OPERATOR-SECURITY-RUNBOOK.md](OPERATOR-SECURITY-RUNBOOK.md#retiring-the-master-key-phase-e).
       — **Phase F landed (Vault Transit backend + factory).**
         `pkg/core/secrets/kms_vault.go` implements
         `KMSClient` against Vault's Transit engine using

--- a/internal/secrets/retirement_test.go
+++ b/internal/secrets/retirement_test.go
@@ -1,0 +1,105 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// Phase 4.1 Phase-E — master-key retirement gate.
+
+func TestWithRequireEnvelope_DefaultIsOff(t *testing.T) {
+	s := &Store{cipher: newCipher(t)}
+	if s.requireEnvelope {
+		t.Fatal("default requireEnvelope should be false")
+	}
+}
+
+func TestWithRequireEnvelope_TogglesField(t *testing.T) {
+	s := &Store{cipher: newCipher(t)}
+	WithRequireEnvelope(true)(s)
+	if !s.requireEnvelope {
+		t.Fatal("WithRequireEnvelope(true) didn't set the flag")
+	}
+	WithRequireEnvelope(false)(s)
+	if s.requireEnvelope {
+		t.Fatal("WithRequireEnvelope(false) didn't clear the flag")
+	}
+}
+
+func TestRetirement_LegacyRowRejected(t *testing.T) {
+	// Build a legacy row, then read it through a Store
+	// with requireEnvelope=true. Must fail with a clear
+	// "migrate before retiring" message — the operator
+	// flipped the gate too early.
+	cipher := newCipher(t)
+	plaintext := []byte("legacy-secret")
+	legacyNonce, legacyCT, err := cipher.Encrypt("alice", "FOO", plaintext)
+	if err != nil {
+		t.Fatalf("legacy encrypt: %v", err)
+	}
+
+	s := &Store{
+		cipher:          cipher,
+		kms:             newKMS(t),
+		requireEnvelope: true,
+	}
+	_, err = s.decryptFromStorage(context.Background(), "alice", "FOO",
+		legacyNonce, legacyCT, nil, "")
+	if err == nil {
+		t.Fatal("require_envelope=true must reject legacy rows")
+	}
+	if !strings.Contains(err.Error(), "migrate-to-envelope") {
+		t.Fatalf("error should name the recovery procedure; got %v", err)
+	}
+}
+
+func TestRetirement_EnvelopeRowStillWorks(t *testing.T) {
+	// Confirm requireEnvelope doesn't accidentally break
+	// the envelope path. Envelope rows must continue to
+	// decrypt cleanly.
+	s := &Store{
+		cipher:          newCipher(t),
+		kms:             newKMS(t),
+		requireEnvelope: true,
+	}
+	plaintext := []byte("envelope-secret")
+	nonce, ct, wrapped, kekID, err := s.encryptForStorage(
+		context.Background(), "alice", "FOO", plaintext,
+	)
+	if err != nil {
+		t.Fatalf("encryptForStorage: %v", err)
+	}
+	out, err := s.decryptFromStorage(context.Background(), "alice", "FOO",
+		nonce, ct, wrapped, kekID)
+	if err != nil {
+		t.Fatalf("envelope row should still decrypt with require_envelope=true; got %v", err)
+	}
+	if !bytes.Equal(out, plaintext) {
+		t.Fatal("envelope roundtrip altered plaintext")
+	}
+}
+
+func TestRetirement_OffAllowsLegacy(t *testing.T) {
+	// Sanity check: with the gate OFF, legacy rows still
+	// decrypt — the pre-retirement compat behavior is
+	// preserved.
+	cipher := newCipher(t)
+	plaintext := []byte("legacy-secret")
+	legacyNonce, legacyCT, _ := cipher.Encrypt("alice", "FOO", plaintext)
+
+	s := &Store{
+		cipher:          cipher,
+		kms:             newKMS(t),
+		requireEnvelope: false, // default
+	}
+	out, err := s.decryptFromStorage(context.Background(), "alice", "FOO",
+		legacyNonce, legacyCT, nil, "")
+	if err != nil {
+		t.Fatalf("with gate off, legacy decrypts fine; got %v", err)
+	}
+	if !bytes.Equal(out, plaintext) {
+		t.Fatal("legacy roundtrip altered plaintext")
+	}
+}

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -50,6 +50,16 @@ type Store struct {
 	pool   *pgxpool.Pool
 	cipher *corecrypto.Cipher
 	kms    corecrypto.KMSClient // optional; nil = legacy-only mode
+
+	// Phase 4.1 Phase-E — when true, the Store refuses
+	// to decrypt any row whose wrapped_dek IS NULL.
+	// Combined with KMS configured, this is the post-
+	// retirement contract: every secret MUST be in
+	// envelope form. Operators flip this after the
+	// migrator reports 100% coverage; from that point
+	// on, a legacy row hitting Get is a strong "you
+	// missed a migration" signal that should page.
+	requireEnvelope bool
 }
 
 // ErrNotFound is returned by Get / Delete when the (username, name)
@@ -71,6 +81,23 @@ func WithKMS(kms corecrypto.KMSClient) Option {
 		if kms != nil {
 			s.kms = kms
 		}
+	}
+}
+
+// WithRequireEnvelope enforces Phase-E retirement: every
+// read MUST go through the envelope path. Legacy rows
+// (wrapped_dek IS NULL) are rejected at Get / LoadAllForUser.
+// Operators flip this on once `containarium secrets
+// envelope-coverage` reports legacy=0 — at that point the
+// master key is unused for production decrypts and the
+// keyfile can be retired.
+//
+// Pairs with the daemon-side startup gate that refuses to
+// start when require_envelope=true but no KMS backend is
+// configured.
+func WithRequireEnvelope(require bool) Option {
+	return func(s *Store) {
+		s.requireEnvelope = require
 	}
 }
 
@@ -241,6 +268,9 @@ func (s *Store) encryptForStorage(ctx context.Context, username, name string, pl
 func (s *Store) decryptFromStorage(ctx context.Context, username, name string, nonce, ct, wrappedDEK []byte, kekID string) ([]byte, error) {
 	// Legacy row: wrapped_dek IS NULL, kek_id IS NULL.
 	if len(wrappedDEK) == 0 {
+		if s.requireEnvelope {
+			return nil, fmt.Errorf("secret %s/%s is legacy-encrypted but require_envelope=true (run `containarium secrets migrate-to-envelope` before retiring the master key)", username, name)
+		}
 		return s.cipher.Decrypt(username, name, nonce, ct)
 	}
 	// Envelope row.

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -471,16 +471,36 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 							kms = nil
 							kdesc = "disabled (config error)"
 						}
-						var opts []secretsstore.Option
-						if kms != nil {
-							opts = append(opts, secretsstore.WithKMS(kms))
-						}
-						if store, serr := secretsstore.NewStore(context.Background(), secretsPool, cipher, opts...); serr != nil {
-							log.Printf("Warning: Failed to init secrets store: %v. Secrets disabled.", serr)
+						// Phase 4.1 Phase-E — master-key retirement
+						// gate. CONTAINARIUM_REQUIRE_ENVELOPE=true
+						// means every decrypt must go through KMS;
+						// legacy rows are rejected. Refuse to wire
+						// the Store if the gate is on but no KMS
+						// backend is configured — fail-closed at
+						// startup is the only safe shape.
+						requireEnvelope := envBool("CONTAINARIUM_REQUIRE_ENVELOPE")
+						if requireEnvelope && kms == nil {
+							log.Printf("FATAL: CONTAINARIUM_REQUIRE_ENVELOPE=true but no KMS backend is configured. Set CONTAINARIUM_KMS_BACKEND=vault (or inproc for dev) before enabling retirement mode. Secrets disabled.")
 							secretsPool.Close()
 						} else {
-							containerServer.SetSecretsStore(store)
-							log.Printf("Secrets store ready (file-keyed AES-256-GCM, envelope: %s)", kdesc)
+							var opts []secretsstore.Option
+							if kms != nil {
+								opts = append(opts, secretsstore.WithKMS(kms))
+							}
+							if requireEnvelope {
+								opts = append(opts, secretsstore.WithRequireEnvelope(true))
+							}
+							if store, serr := secretsstore.NewStore(context.Background(), secretsPool, cipher, opts...); serr != nil {
+								log.Printf("Warning: Failed to init secrets store: %v. Secrets disabled.", serr)
+								secretsPool.Close()
+							} else {
+								containerServer.SetSecretsStore(store)
+								retirement := ""
+								if requireEnvelope {
+									retirement = " [legacy-rejected]"
+								}
+								log.Printf("Secrets store ready (file-keyed AES-256-GCM, envelope: %s%s)", kdesc, retirement)
+							}
 						}
 					}
 				}

--- a/internal/server/env_helpers.go
+++ b/internal/server/env_helpers.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"os"
+	"strings"
+)
+
+// envBool reads the named env var and returns true when
+// it's set to a recognized truthy value (case-insensitive
+// `1`, `true`, `yes`, `on`). Anything else — including the
+// unset case, an empty string, or an unrecognized value
+// like `maybe` — returns false.
+//
+// Fail-off semantics by design: a typo on a security-
+// affecting toggle (CONTAINARIUM_REQUIRE_ENVELOPE,
+// CONTAINARIUM_OTEL_REQUIRE_AUTH) shouldn't silently flip
+// the daemon into a state it can't actually serve. The
+// surrounding callsite is responsible for logging the
+// active state at startup so operators can confirm the
+// flag took effect.
+func envBool(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}

--- a/internal/server/env_helpers_test.go
+++ b/internal/server/env_helpers_test.go
@@ -1,0 +1,32 @@
+package server
+
+import "testing"
+
+func TestEnvBool(t *testing.T) {
+	cases := map[string]bool{
+		"":         false,
+		"  ":       false,
+		"0":        false,
+		"false":    false,
+		"no":       false,
+		"off":      false,
+		"maybe":    false,
+		"true":     true,
+		"TRUE":     true,
+		"True":     true,
+		"1":        true,
+		"yes":      true,
+		"YES":      true,
+		"on":       true,
+		"  true  ": true,
+	}
+	for val, want := range cases {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv("CONTAINARIUM_ENV_BOOL_TEST", val)
+			got := envBool("CONTAINARIUM_ENV_BOOL_TEST")
+			if got != want {
+				t.Fatalf("envBool(%q) = %v; want %v", val, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes the last open slice of the KMS envelope rollout. With this gate enabled, the master key file (\`/etc/containarium/secrets.key\`) is no longer used for any production decrypt — every read goes through the KMS-mediated envelope path. Pairs with the migration tool (#270) and the Vault Transit backend (#271).

**Audit C-HIGH-6 fully closed** with this PR. Phases A–F all shipped:

| Phase | PR |
|---|---|
| design doc | #267 |
| A: \`KMSClient\` + \`InProcKMS\` | #268 |
| B: Store envelope wiring | #269 |
| D: migration + coverage CLI | #270 |
| F: Vault Transit backend + factory | #271 |
| **E: master-key retirement gate** | **this PR** |

## New env

\`CONTAINARIUM_REQUIRE_ENVELOPE=true\`

When set:
- Store rejects legacy rows (\`wrapped_dek IS NULL\`) at decrypt with a descriptive error pointing operators at \`containarium secrets migrate-to-envelope\`.
- Daemon refuses to wire the Store if gate is on but **no KMS backend** is configured — fail-closed at startup, not silently broken.
- Startup log line ends \` [legacy-rejected]\` so operators can confirm the flag took effect.

## Files

| Path | Change |
|---|---|
| \`internal/secrets/store.go\` | New \`requireEnvelope\` field + \`WithRequireEnvelope(bool)\` option; \`decryptFromStorage\` gates the legacy fallback on this flag. |
| \`internal/server/dual_server.go\` | Reads the env via \`envBool\`; fail-closed startup; appended " [legacy-rejected]" to the log line. |
| \`internal/server/env_helpers.go\` | New \`envBool\` helper (1/true/yes/on, case+whitespace-insensitive). Already matches the \`CONTAINARIUM_OTEL_REQUIRE_AUTH\` pattern from #264. |
| \`docs/security/OPERATOR-SECURITY-RUNBOOK.md\` | New "Retiring the master key (Phase E)" section walks the 5-step cutover + missed-row recovery. |

## Tests (4 retirement + 16 envBool)

- \`retirement_test.go\`: default off, option toggles the flag, legacy row rejected with gate on, envelope row still works with gate on, legacy still works with gate off.
- \`env_helpers_test.go\`: the truthy/falsy table — typos stay OFF (fail-off for security toggles).

\`\`\`
ok  github.com/footprintai/containarium/internal/secrets  0.788s
ok  github.com/footprintai/containarium/internal/server   1.461s
\`\`\`

## Operator cutover (from the runbook)

\`\`\`bash
# 1. Confirm 100% envelope coverage
containarium secrets envelope-coverage

# 2. Add to systemd Environment=
CONTAINARIUM_REQUIRE_ENVELOPE=true

# 3. Restart daemon. Startup log ends "[legacy-rejected]".
sudo systemctl restart containarium

# 4. Smoke-test a Get.
containarium secrets get <user> <name>

# 5. After soak (24h+), retire the keyfile.
sudo mv /etc/containarium/secrets.key /etc/containarium/secrets.key.retired
\`\`\`

If a row was missed by the migration, Phase E surfaces it with a clear error rather than silently mis-decrypting:

\`\`\`
secret <user>/<name> is legacy-encrypted but require_envelope=true
(run \`containarium secrets migrate-to-envelope\` before retiring the master key)
\`\`\`

## Test plan

- [x] Unit tests pass
- [x] \`go build ./...\` clean
- [ ] CI green
- [ ] Manual: deploy with WithKMS=vault, migrate, set the env, confirm startup log shows [legacy-rejected]; introduce a legacy row directly in DB, confirm Get returns the descriptive error

🤖 Generated with [Claude Code](https://claude.com/claude-code)