### PR TITLE
docs(security): Phase 4.7 deeper half — unix-socket Postgres auth (C-MED-6 closed)

### DIFF
--- a/docs/security/OPERATOR-SECURITY-RUNBOOK.md
+++ b/docs/security/OPERATOR-SECURITY-RUNBOOK.md
@@ -17,6 +17,7 @@ If a procedure here is wrong, update it.
 - [Issuing least-privilege tokens for agents](#issuing-least-privilege-tokens-for-agents)
 - [Rotating the JWT signing secret](#rotating-the-jwt-signing-secret)
 - [Rotating Postgres credentials](#rotating-postgres-credentials)
+- [Switching Postgres to unix-socket auth (no password on the wire)](#switching-postgres-to-unix-socket-auth-no-password-on-the-wire)
 - [Enabling KMS envelope encryption for secrets](#enabling-kms-envelope-encryption-for-secrets)
 - [Locking down `/wake/` to a known load balancer](#locking-down-wake-to-a-known-load-balancer)
 - [Auditing recent administrative actions](#auditing-recent-administrative-actions)
@@ -250,6 +251,134 @@ sudo systemctl restart containarium
 
 The daemon refuses to start if the file is world-readable — same
 contract as the JWT token file (Phase C-HIGH-7).
+
+---
+
+## Switching Postgres to unix-socket auth (no password on the wire)
+
+Phase 4.7 deeper half. The daemon's Postgres driver (`pgx`)
+already supports unix-socket connections out of the box —
+this is purely an operator-configuration change to remove
+the password from the connection string entirely, replacing
+network authentication with Postgres's filesystem-permission-
+based `peer` auth.
+
+Why bother:
+
+- **No shared secret on the wire.** Even with TLS, a
+  password is one substitution away from a credential leak;
+  unix-socket peer auth removes the secret entirely.
+- **Local-only by definition.** Anything that can reach
+  `/var/run/postgresql/.s.PGSQL.5432` is already root or in
+  the `postgres` group on the host — you've already lost.
+- **No password to rotate.** The deeper half of Phase 4.7
+  is just: don't have one.
+
+This only applies when Postgres runs **on the same host as
+the daemon**. Network-attached Postgres (managed RDS, Cloud
+SQL with a sidecar, etc.) keeps the password path.
+
+### Configure Postgres for peer auth
+
+Edit `pg_hba.conf` to permit peer auth from the daemon's
+Linux user:
+
+```
+# TYPE  DATABASE      USER          ADDRESS  METHOD
+local   containarium  containarium           peer
+```
+
+Then in `postgresql.conf` confirm the socket directory:
+
+```
+unix_socket_directories = '/var/run/postgresql'
+```
+
+Restart Postgres to pick up the change:
+
+```bash
+sudo systemctl restart postgresql
+```
+
+Confirm peer auth works for the daemon's user before
+flipping the daemon over:
+
+```bash
+sudo -u containarium psql -d containarium -c 'SELECT 1'
+```
+
+If that succeeds with no password prompt, peer auth is
+live.
+
+### Switch the daemon's connection string
+
+The daemon's connection string DSN supports the
+`host=/path` keyword that pgx routes to a unix socket
+instead of TCP. Two equivalent forms work:
+
+```bash
+# URI form — pass host as a query parameter
+CONTAINARIUM_POSTGRES_URL='postgres://containarium@/containarium?host=/var/run/postgresql&sslmode=disable'
+
+# Keyword form
+CONTAINARIUM_POSTGRES_URL='user=containarium dbname=containarium host=/var/run/postgresql sslmode=disable'
+```
+
+`sslmode=disable` is correct for a unix socket — TLS over
+a local filesystem socket is decorative; the socket itself
+is the authentication boundary.
+
+Apply via the daemon's systemd `Environment=`:
+
+```ini
+Environment="CONTAINARIUM_POSTGRES_URL=postgres://containarium@/containarium?host=/var/run/postgresql&sslmode=disable"
+```
+
+Drop any `CONTAINARIUM_POSTGRES_URL_FILE` /
+`CONTAINARIUM_POSTGRES_PASSWORD_FILE` from the unit — they
+override the URL and would re-add the password path.
+
+Restart:
+
+```bash
+sudo systemctl restart containarium
+```
+
+Daemon startup log should show:
+
+```
+[postgres] DSN source: env
+Detected PostgreSQL at: <auto-detect skipped, URL was provided>
+```
+
+If you see `Detected PostgreSQL at: 10.100.0.2 (password
+source: default)` instead, the URL didn't take — check the
+unit for stray `CONTAINARIUM_POSTGRES_*` overrides.
+
+### Verify the password is no longer on the wire
+
+A short loopback `tcpdump` confirms the daemon isn't
+opening TCP connections to port 5432:
+
+```bash
+sudo tcpdump -i lo -nn -c 5 'tcp port 5432'
+# Should produce 0 packets after the daemon has been
+# restarted and made a few queries. If it does produce
+# packets, the daemon is still using a TCP DSN somewhere.
+```
+
+The daemon's queries should now show up as unix-socket
+file accesses instead — verifiable via `strace -e connect`
+on the daemon PID.
+
+### Rolling back
+
+If anything misbehaves, the rollback is symmetric: restore
+the password-bearing URL (or `_FILE`) in the systemd unit,
+restart, and Postgres serves both paths concurrently while
+`pg_hba.conf` still has the `peer` line. Drop the `peer`
+line from `pg_hba.conf` and reload Postgres if you want
+to definitively cut off unix-socket access.
 
 ---
 

--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -550,7 +550,7 @@ on the internal network. Land them first.
         `r.Context()` via `audit.ContextWithRequestID`, recorded
         in audit detail as `request_id=<id>`. Tests in
         `internal/audit/request_id_test.go`.
-- [~] **4.7** Postgres credentials via secret manager / unix-socket auth — `internal/server/dual_server.go` (**C-MED-6**)
+- [x] **4.7** Postgres credentials via secret manager / unix-socket auth — `internal/server/dual_server.go` (**C-MED-6**)
       — **Secret-file path landed.** Two new env vars
         (mode-checked file pattern from PR #245 reused):
         `CONTAINARIUM_POSTGRES_URL_FILE` (full DSN) and
@@ -562,11 +562,18 @@ on the internal network. Land them first.
         the compiled-in dev default (with a startup
         WARNING). Tests in
         `internal/server/postgres_creds_test.go`.
-      — This is the K8s-Secret / Vault-Agent / GCP-Secret-
-        Manager-with-Workload-Identity path. The unix-
-        socket-auth alternative would also require trust
-        config in Postgres (`hba.conf`) and isn't tractable
-        as a same-PR change; tracked as the follow-up.
+      — **Unix-socket path documented.** The Go `pgx`
+        driver natively accepts `host=/path/to/socket` in
+        the DSN, so unix-socket peer auth requires no
+        daemon code changes — purely operator config.
+        Procedure documented in
+        [OPERATOR-SECURITY-RUNBOOK.md](OPERATOR-SECURITY-RUNBOOK.md#switching-postgres-to-unix-socket-auth-no-password-on-the-wire):
+        edit `pg_hba.conf` to add a `peer` line, confirm
+        with `sudo -u containarium psql`, then flip the
+        daemon's DSN to
+        `postgres://containarium@/containarium?host=/var/run/postgresql&sslmode=disable`.
+        No password on the wire, no shared secret to
+        rotate.
 - [x] **4.8** Stat-check TLS key directory at startup — `internal/hosting/caddy.go` (**C-MED-7**)
       — `/var/lib/caddy` created at 0750 (was 0755); existing
         directory chmod-tightened to 0750 idempotently. New


### PR DESCRIPTION
## Summary

Closes the last open half of audit **C-MED-6**. The Go \`pgx\` driver natively accepts \`host=/path/to/socket\` in the DSN, so unix-socket peer auth requires **no daemon code changes** — it's purely an operator config swap.

Documentation-only PR. Operator runbook gains a "Switching Postgres to unix-socket auth (no password on the wire)" section.

## What the section covers

- **Why bother**: no shared secret on the wire, no password to rotate, local-only by definition
- **When it applies**: Postgres on the same host as the daemon; managed RDS/Cloud SQL keeps the password path
- **\`pg_hba.conf\` edit** + \`postgresql.conf\` socket-directory config
- **Verification via \`sudo -u containarium psql\`** before flipping the daemon
- **Two equivalent DSN shapes** (URI form with \`?host=...\` and keyword form)
- **\`sslmode=disable\` rationale** — unix socket IS the auth boundary, TLS over a local socket is decorative
- **tcpdump verification** that the password is no longer on the wire
- **Symmetric rollback** procedure

## Audit status

**C-MED-6 fully closed** with this PR. Both halves shipped:

| Half | PR | What |
|---|---|---|
| Secret-file path | #260 | K8s Secret / Vault Agent / GCP Secret Manager with Workload Identity |
| **Unix-socket path** | **this PR** | No shared secret at all — peer auth via the local socket |

## Test plan

- [x] Markdown renders correctly in GitHub preview
- [ ] CI green
- [ ] Manual: follow the runbook procedure on a dev VM with co-located Postgres; confirm daemon connects without a password env var; verify tcpdump shows no traffic to :5432

🤖 Generated with [Claude Code](https://claude.com/claude-code)