### PR TITLE
sec: zero-trust Phase 4.3 Phase A — tmpfs delivery field plumbing (C-MED-4)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -6656,6 +6656,10 @@
         },
         "updatedAt": {
           "type": "string"
+        },
+        "delivery": {
+          "type": "string",
+          "description": "Phase 4.3 — how the secret is delivered into the container.\n\"env\" (default): stamped as environment.\u003cNAME\u003e=\u003cvalue\u003e on the LXC,\nvisible to every process in the container via /proc/\u003cpid\u003e/environ.\n\"file\": (planned) written to a per-container tmpfs at\n/run/secrets/\u003cNAME\u003e, file mode 0400 owned by the app user. Same\ntenant isolation, narrower in-container access surface. See\ndocs/security/SECRETS-ENV-VAR-RISK.md.\n\nRead-only on the API surface today — Phase A lands the field\nshape; the file delivery path is wired in Phase B."
         }
       },
       "description": "SecretMetadata is the public-safe view of a stored secret.\n`value` is never returned by `ListSecrets` — only per-name `GetSecret`."
@@ -6674,6 +6678,10 @@
         "value": {
           "type": "string",
           "description": "Plaintext value the daemon will encrypt with its master key\nbefore persisting. Server enforces a 64 KiB hard cap\n(decision #2). Never logged."
+        },
+        "delivery": {
+          "type": "string",
+          "description": "Phase 4.3 — delivery mode for the secret. Accepts \"env\"\n(default; same behavior as pre-4.3) or \"file\" (planned;\ntmpfs-mounted per-file delivery). Unknown values are\nrejected at the API boundary. Phase A allows setting the\nmode but the daemon still stamps env vars for everyone;\nPhase B switches behavior based on this field."
         }
       },
       "description": "SetSecretRequest creates or updates a tenant secret. Idempotent —\nrepeated calls with the same (username, name) bump the version and\nreplace the value."

--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -530,11 +530,25 @@ on the internal network. Land them first.
         var semantics), mitigations operators can apply
         today, and the tmpfs-mount alternative we plan to
         offer as opt-in.
-      — **Implementation follow-up:** add
-        `--delivery=env|file` to `containarium secret set`
-        and wire a tmpfs mount + file writer. Targeted
-        for the next secrets pass; not gated on a specific
-        date.
+      — **Phase A landed (field plumbing).** `delivery`
+        column added to the secrets schema (default
+        `"env"`, non-destructive `ADD COLUMN IF NOT EXISTS`
+        on existing deployments). New `SecretMetadata.Delivery`
+        field; `Store.Set(ctx, user, name, value, delivery)`
+        accepts and validates it via the new
+        `ValidateDelivery` helper. Proto `SetSecretRequest`
+        and `SecretMetadata` gain the `delivery` field.
+        CLI: `containarium secrets set --delivery=env|file`.
+        **No behavior change yet** — Phase A is pure
+        data-model plumbing so the Phase B switch
+        (tmpfs file writer + per-container mount) lands as
+        a focused PR without touching every layer of the
+        secrets surface.
+      — **Phase B (implementation follow-up):** wire the
+        tmpfs mount setup at container create time, switch
+        `stampSecretsOnLXC` to write 0400-mode files to
+        `/run/secrets/<NAME>` for `delivery="file"` rows
+        (env rows keep their current behavior).
 - [x] **4.4** Audit-log redaction policy + enforcement — `internal/audit/store.go:53-74` (**C-MED-5**)
       — New `audit.Redact` / `audit.SanitizeDetail` scrubs JWTs
         (with or without Bearer prefix), password/api_key/secret

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -274,11 +274,13 @@ func (c *GRPCClient) DeleteContainer(username string, force bool) error {
 
 // SetSecret creates or updates a tenant secret via gRPC. Idempotent —
 // repeated calls with the same (username, name) bump the version.
-func (c *GRPCClient) SetSecret(username, name, value string) (*pb.SecretMetadata, string, error) {
+// `delivery` is "" (server normalizes to env), "env", or "file"
+// (Phase 4.3 — Phase A lands the field).
+func (c *GRPCClient) SetSecret(username, name, value, delivery string) (*pb.SecretMetadata, string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	resp, err := c.client.SetSecret(ctx, &pb.SetSecretRequest{
-		Username: username, Name: name, Value: value,
+		Username: username, Name: name, Value: value, Delivery: delivery,
 	})
 	if err != nil {
 		return nil, "", fmt.Errorf("set secret: %w", err)

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -458,14 +458,21 @@ func (c *HTTPClient) RevokeToken(jti, reason, expiresAt string) (string, error) 
 }
 
 // SetSecret creates or updates a tenant secret via HTTP.
-func (c *HTTPClient) SetSecret(username, name, value string) (string, error) {
+// `delivery` is one of "" (server normalizes to env), "env",
+// or "file" (Phase 4.3 — Phase A lands the field; Phase B
+// switches behavior on it).
+func (c *HTTPClient) SetSecret(username, name, value, delivery string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	body, _ := json.Marshal(map[string]string{
+	payload := map[string]string{
 		"username": username,
 		"name":     name,
 		"value":    value,
-	})
+	}
+	if delivery != "" {
+		payload["delivery"] = delivery
+	}
+	body, _ := json.Marshal(payload)
 	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/secrets", body)
 	if err != nil {
 		return "", fmt.Errorf("set secret: %w", err)

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -88,9 +88,20 @@ without restarting the whole container.`,
 	RunE: runSecretsRefresh,
 }
 
+// secretsDelivery is the value bound to `--delivery` on
+// `secrets set` (Phase 4.3 Phase A). Allowed values: "",
+// "env" (default; server normalizes ""→"env"), "file"
+// (planned tmpfs delivery, Phase B will wire behavior).
+var secretsDelivery string
+
 func init() {
 	rootCmd.AddCommand(secretsCmd)
 	secretsCmd.AddCommand(secretsSetCmd)
+	secretsSetCmd.Flags().StringVar(&secretsDelivery, "delivery", "",
+		`How the secret reaches the container. "env" (default) stamps `+
+			`environment.<NAME>=<value> on the LXC; "file" (Phase 4.3 — `+
+			`not yet wired) plans tmpfs-mount delivery for narrower `+
+			`in-container access. See docs/security/SECRETS-ENV-VAR-RISK.md.`)
 	secretsCmd.AddCommand(secretsGetCmd)
 	secretsCmd.AddCommand(secretsListCmd)
 	secretsCmd.AddCommand(secretsDeleteCmd)
@@ -109,7 +120,7 @@ func runSecretsSet(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		defer h.Close()
-		msg, err := h.SetSecret(username, name, value)
+		msg, err := h.SetSecret(username, name, value, secretsDelivery)
 		if err != nil {
 			return err
 		}
@@ -121,11 +132,15 @@ func runSecretsSet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer g.Close()
-	meta, msg, err := g.SetSecret(username, name, value)
+	meta, msg, err := g.SetSecret(username, name, value, secretsDelivery)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("✓ %s (version=%d)\n", msg, meta.Version)
+	deliverySuffix := ""
+	if meta != nil && meta.Delivery != "" && meta.Delivery != "env" {
+		deliverySuffix = fmt.Sprintf(" delivery=%s", meta.Delivery)
+	}
+	fmt.Printf("✓ %s (version=%d%s)\n", msg, meta.Version, deliverySuffix)
 	return nil
 }
 

--- a/internal/secrets/delivery_test.go
+++ b/internal/secrets/delivery_test.go
@@ -1,0 +1,50 @@
+package secrets
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Phase 4.3 Phase A — delivery-field validation tests.
+// The SQL roundtrip path lives in the integration suite
+// (needs Postgres); here we cover the pure-Go validator
+// + constant shape.
+
+func TestValidateDelivery(t *testing.T) {
+	cases := map[string]error{
+		"":      nil,
+		"env":   nil,
+		"file":  nil,
+		"ENV":   errors.New("any"), // case-sensitive — uppercase rejected
+		"tmpfs": errors.New("any"), // alternative names rejected
+		"none":  errors.New("any"),
+		"  env": errors.New("any"), // no trim — caller's responsibility
+	}
+	for in, wantErr := range cases {
+		t.Run(in, func(t *testing.T) {
+			got := ValidateDelivery(in)
+			if wantErr == nil {
+				if got != nil {
+					t.Fatalf("ValidateDelivery(%q): got %v, want nil", in, got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("ValidateDelivery(%q): got nil, want error", in)
+				}
+				if !strings.Contains(got.Error(), "delivery") {
+					t.Fatalf("error should name the field; got %v", got)
+				}
+			}
+		})
+	}
+}
+
+func TestDeliveryConstants(t *testing.T) {
+	if DeliveryEnv != "env" {
+		t.Fatalf("DeliveryEnv = %q; want %q", DeliveryEnv, "env")
+	}
+	if DeliveryFile != "file" {
+		t.Fatalf("DeliveryFile = %q; want %q", DeliveryFile, "file")
+	}
+}

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -23,6 +23,31 @@ type SecretMetadata struct {
 	Version   int32
 	CreatedAt time.Time
 	UpdatedAt time.Time
+
+	// Phase 4.3 — delivery mode. "env" (default) or "file".
+	// Phase A lands the field; Phase B switches the stamping
+	// path to honor it. See docs/security/SECRETS-ENV-VAR-RISK.md.
+	Delivery string
+}
+
+// Delivery-mode constants. The DB column stores these
+// strings literally; new values land here before the
+// schema is taught to validate them.
+const (
+	DeliveryEnv  = "env"
+	DeliveryFile = "file"
+)
+
+// ValidateDelivery returns nil for "" (defaults to env at
+// the storage layer), "env", or "file". Anything else is
+// caller-error and rejected at the API boundary.
+func ValidateDelivery(mode string) error {
+	switch mode {
+	case "", DeliveryEnv, DeliveryFile:
+		return nil
+	}
+	return fmt.Errorf("secrets: delivery must be %q or %q; got %q",
+		DeliveryEnv, DeliveryFile, mode)
 }
 
 // Store handles per-tenant secret persistence.
@@ -149,6 +174,13 @@ func (s *Store) initSchema(ctx context.Context) error {
 		ALTER TABLE secrets ADD COLUMN IF NOT EXISTS wrapped_dek BYTEA;
 		ALTER TABLE secrets ADD COLUMN IF NOT EXISTS kek_id      TEXT;
 
+		-- Phase 4.3 Phase A — delivery mode column.
+		-- "env" or "file"; defaults to "env" so pre-4.3 rows
+		-- and any future row that omits the field behave
+		-- exactly as before. Phase B switches the stamping
+		-- code to honor this value.
+		ALTER TABLE secrets ADD COLUMN IF NOT EXISTS delivery TEXT NOT NULL DEFAULT 'env';
+
 		CREATE INDEX IF NOT EXISTS idx_secrets_username
 			ON secrets(username);
 	`
@@ -166,7 +198,11 @@ func (s *Store) initSchema(ctx context.Context) error {
 // DEK is wrapped via the KMS, and wrapped_dek + kek_id are
 // populated. Otherwise it writes a legacy row exactly as before
 // Phase 4.1 — wrapped_dek and kek_id stay NULL.
-func (s *Store) Set(ctx context.Context, username, name, value string) (*SecretMetadata, error) {
+//
+// `delivery` (Phase 4.3) is one of "" (defaults to env on storage),
+// "env", "file". Validated at the API boundary; invalid values
+// reject before any DB work.
+func (s *Store) Set(ctx context.Context, username, name, value, delivery string) (*SecretMetadata, error) {
 	if username == "" {
 		return nil, fmt.Errorf("username is required")
 	}
@@ -175,6 +211,15 @@ func (s *Store) Set(ctx context.Context, username, name, value string) (*SecretM
 	}
 	if err := corecrypto.ValidateValue(value); err != nil {
 		return nil, err
+	}
+	if err := ValidateDelivery(delivery); err != nil {
+		return nil, err
+	}
+	// Storage layer normalizes "" → "env" so the column is
+	// always populated. Lets future migration code rely on
+	// the field being non-empty.
+	if delivery == "" {
+		delivery = DeliveryEnv
 	}
 
 	nonce, ct, wrappedDEK, kekID, err := s.encryptForStorage(ctx, username, name, []byte(value))
@@ -187,21 +232,22 @@ func (s *Store) Set(ctx context.Context, username, name, value string) (*SecretM
 	// rotation; the row's created_at stays as the original
 	// (set-once-ever timestamp), updated_at moves to NOW().
 	const q = `
-		INSERT INTO secrets (username, name, nonce, ciphertext, wrapped_dek, kek_id, version)
-		VALUES ($1, $2, $3, $4, $5, $6, 1)
+		INSERT INTO secrets (username, name, nonce, ciphertext, wrapped_dek, kek_id, delivery, version)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, 1)
 		ON CONFLICT (username, name)
 		DO UPDATE SET
 			nonce       = EXCLUDED.nonce,
 			ciphertext  = EXCLUDED.ciphertext,
 			wrapped_dek = EXCLUDED.wrapped_dek,
 			kek_id      = EXCLUDED.kek_id,
+			delivery    = EXCLUDED.delivery,
 			version     = secrets.version + 1,
 			updated_at  = NOW()
 		RETURNING version, created_at, updated_at;
 	`
 	var version int32
 	var createdAt, updatedAt time.Time
-	if err := s.pool.QueryRow(ctx, q, username, name, nonce, ct, wrappedDEK, kekID).Scan(&version, &createdAt, &updatedAt); err != nil {
+	if err := s.pool.QueryRow(ctx, q, username, name, nonce, ct, wrappedDEK, kekID, delivery).Scan(&version, &createdAt, &updatedAt); err != nil {
 		return nil, fmt.Errorf("upsert secret: %w", err)
 	}
 	return &SecretMetadata{
@@ -210,6 +256,7 @@ func (s *Store) Set(ctx context.Context, username, name, value string) (*SecretM
 		Version:   version,
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
+		Delivery:  delivery,
 	}, nil
 }
 
@@ -309,15 +356,16 @@ func (s *Store) Get(ctx context.Context, username, name string) (meta *SecretMet
 	}
 
 	const q = `
-		SELECT nonce, ciphertext, wrapped_dek, kek_id, version, created_at, updated_at
+		SELECT nonce, ciphertext, wrapped_dek, kek_id, delivery, version, created_at, updated_at
 		FROM secrets
 		WHERE username = $1 AND name = $2
 	`
 	var nonce, ct, wrappedDEK []byte
 	var kekID *string // nullable
+	var delivery string
 	var version int32
 	var createdAt, updatedAt time.Time
-	if err := s.pool.QueryRow(ctx, q, username, name).Scan(&nonce, &ct, &wrappedDEK, &kekID, &version, &createdAt, &updatedAt); err != nil {
+	if err := s.pool.QueryRow(ctx, q, username, name).Scan(&nonce, &ct, &wrappedDEK, &kekID, &delivery, &version, &createdAt, &updatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, "", ErrNotFound
 		}
@@ -338,6 +386,7 @@ func (s *Store) Get(ctx context.Context, username, name string) (meta *SecretMet
 		Version:   version,
 		CreatedAt: createdAt,
 		UpdatedAt: updatedAt,
+		Delivery:  delivery,
 	}, string(plaintext), nil
 }
 
@@ -349,7 +398,7 @@ func (s *Store) List(ctx context.Context, username string) ([]SecretMetadata, er
 		return nil, fmt.Errorf("username is required")
 	}
 	const q = `
-		SELECT username, name, version, created_at, updated_at
+		SELECT username, name, version, created_at, updated_at, delivery
 		FROM secrets
 		WHERE username = $1
 		ORDER BY name
@@ -363,7 +412,7 @@ func (s *Store) List(ctx context.Context, username string) ([]SecretMetadata, er
 	var out []SecretMetadata
 	for rows.Next() {
 		var m SecretMetadata
-		if err := rows.Scan(&m.Username, &m.Name, &m.Version, &m.CreatedAt, &m.UpdatedAt); err != nil {
+		if err := rows.Scan(&m.Username, &m.Name, &m.Version, &m.CreatedAt, &m.UpdatedAt, &m.Delivery); err != nil {
 			return nil, fmt.Errorf("scan secret row: %w", err)
 		}
 		out = append(out, m)

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -53,7 +53,7 @@ func TestSecretsStore_Roundtrip(t *testing.T) {
 
 	// Set, then Get, then List, then rotation (Set again), then
 	// Delete.
-	meta, err := store.Set(ctx, "store-test-user", "OPENAI_API_KEY", "sk-v1")
+	meta, err := store.Set(ctx, "store-test-user", "OPENAI_API_KEY", "sk-v1", "")
 	if err != nil {
 		t.Fatalf("Set first: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestSecretsStore_Roundtrip(t *testing.T) {
 	}
 
 	// Rotation: same (username, name), new value, version should bump.
-	meta2, err := store.Set(ctx, "store-test-user", "OPENAI_API_KEY", "sk-v2")
+	meta2, err := store.Set(ctx, "store-test-user", "OPENAI_API_KEY", "sk-v2", "")
 	if err != nil {
 		t.Fatalf("Set rotation: %v", err)
 	}

--- a/internal/server/secrets_server.go
+++ b/internal/server/secrets_server.go
@@ -38,13 +38,13 @@ func (s *ContainerServer) SetSecret(ctx context.Context, req *pb.SetSecretReques
 		return nil, err
 	}
 
-	meta, err := s.secretsStore.Set(ctx, req.Username, req.Name, req.Value)
+	meta, err := s.secretsStore.Set(ctx, req.Username, req.Name, req.Value, req.Delivery)
 	if err != nil {
 		return nil, mapSecretError(err)
 	}
 
 	// Audit. Never log the value.
-	log.Printf("[secrets] set %s/%s version=%d", req.Username, req.Name, meta.Version)
+	log.Printf("[secrets] set %s/%s version=%d delivery=%s", req.Username, req.Name, meta.Version, meta.Delivery)
 
 	msg := "secret created"
 	if meta.Version > 1 {
@@ -281,5 +281,6 @@ func toProtoSecretMetadata(m *secrets.SecretMetadata) *pb.SecretMetadata {
 		Version:   m.Version,
 		CreatedAt: m.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
 		UpdatedAt: m.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		Delivery:  m.Delivery,
 	}
 }

--- a/pkg/pb/containarium/v1/secrets.pb.go
+++ b/pkg/pb/containarium/v1/secrets.pb.go
@@ -35,8 +35,19 @@ type SecretMetadata struct {
 	// version=3, DB says version=4 → restart needed").
 	Version int32 `protobuf:"varint,3,opt,name=version,proto3" json:"version,omitempty"`
 	// RFC3339 timestamps.
-	CreatedAt     string `protobuf:"bytes,4,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	UpdatedAt     string `protobuf:"bytes,5,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	CreatedAt string `protobuf:"bytes,4,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	UpdatedAt string `protobuf:"bytes,5,opt,name=updated_at,json=updatedAt,proto3" json:"updated_at,omitempty"`
+	// Phase 4.3 — how the secret is delivered into the container.
+	// "env" (default): stamped as environment.<NAME>=<value> on the LXC,
+	// visible to every process in the container via /proc/<pid>/environ.
+	// "file": (planned) written to a per-container tmpfs at
+	// /run/secrets/<NAME>, file mode 0400 owned by the app user. Same
+	// tenant isolation, narrower in-container access surface. See
+	// docs/security/SECRETS-ENV-VAR-RISK.md.
+	//
+	// Read-only on the API surface today — Phase A lands the field
+	// shape; the file delivery path is wired in Phase B.
+	Delivery      string `protobuf:"bytes,6,opt,name=delivery,proto3" json:"delivery,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -106,6 +117,13 @@ func (x *SecretMetadata) GetUpdatedAt() string {
 	return ""
 }
 
+func (x *SecretMetadata) GetDelivery() string {
+	if x != nil {
+		return x.Delivery
+	}
+	return ""
+}
+
 // SetSecretRequest creates or updates a tenant secret. Idempotent —
 // repeated calls with the same (username, name) bump the version and
 // replace the value.
@@ -119,7 +137,14 @@ type SetSecretRequest struct {
 	// Plaintext value the daemon will encrypt with its master key
 	// before persisting. Server enforces a 64 KiB hard cap
 	// (decision #2). Never logged.
-	Value         string `protobuf:"bytes,3,opt,name=value,proto3" json:"value,omitempty"`
+	Value string `protobuf:"bytes,3,opt,name=value,proto3" json:"value,omitempty"`
+	// Phase 4.3 — delivery mode for the secret. Accepts "env"
+	// (default; same behavior as pre-4.3) or "file" (planned;
+	// tmpfs-mounted per-file delivery). Unknown values are
+	// rejected at the API boundary. Phase A allows setting the
+	// mode but the daemon still stamps env vars for everyone;
+	// Phase B switches behavior based on this field.
+	Delivery      string `protobuf:"bytes,4,opt,name=delivery,proto3" json:"delivery,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -171,6 +196,13 @@ func (x *SetSecretRequest) GetName() string {
 func (x *SetSecretRequest) GetValue() string {
 	if x != nil {
 		return x.Value
+	}
+	return ""
+}
+
+func (x *SetSecretRequest) GetDelivery() string {
+	if x != nil {
+		return x.Delivery
 	}
 	return ""
 }
@@ -641,7 +673,7 @@ var File_containarium_v1_secrets_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_secrets_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/secrets.proto\x12\x0fcontainarium.v1\"\x98\x01\n" +
+	"\x1dcontainarium/v1/secrets.proto\x12\x0fcontainarium.v1\"\xb4\x01\n" +
 	"\x0eSecretMetadata\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
@@ -649,11 +681,13 @@ const file_containarium_v1_secrets_proto_rawDesc = "" +
 	"\n" +
 	"created_at\x18\x04 \x01(\tR\tcreatedAt\x12\x1d\n" +
 	"\n" +
-	"updated_at\x18\x05 \x01(\tR\tupdatedAt\"X\n" +
+	"updated_at\x18\x05 \x01(\tR\tupdatedAt\x12\x1a\n" +
+	"\bdelivery\x18\x06 \x01(\tR\bdelivery\"t\n" +
 	"\x10SetSecretRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
-	"\x05value\x18\x03 \x01(\tR\x05value\"f\n" +
+	"\x05value\x18\x03 \x01(\tR\x05value\x12\x1a\n" +
+	"\bdelivery\x18\x04 \x01(\tR\bdelivery\"f\n" +
 	"\x11SetSecretResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x127\n" +
 	"\x06secret\x18\x02 \x01(\v2\x1f.containarium.v1.SecretMetadataR\x06secret\"B\n" +

--- a/proto/containarium/v1/secrets.proto
+++ b/proto/containarium/v1/secrets.proto
@@ -22,6 +22,18 @@ message SecretMetadata {
   // RFC3339 timestamps.
   string created_at = 4;
   string updated_at = 5;
+
+  // Phase 4.3 — how the secret is delivered into the container.
+  // "env" (default): stamped as environment.<NAME>=<value> on the LXC,
+  // visible to every process in the container via /proc/<pid>/environ.
+  // "file": (planned) written to a per-container tmpfs at
+  // /run/secrets/<NAME>, file mode 0400 owned by the app user. Same
+  // tenant isolation, narrower in-container access surface. See
+  // docs/security/SECRETS-ENV-VAR-RISK.md.
+  //
+  // Read-only on the API surface today — Phase A lands the field
+  // shape; the file delivery path is wired in Phase B.
+  string delivery = 6;
 }
 
 // SetSecretRequest creates or updates a tenant secret. Idempotent —
@@ -39,6 +51,14 @@ message SetSecretRequest {
   // before persisting. Server enforces a 64 KiB hard cap
   // (decision #2). Never logged.
   string value = 3;
+
+  // Phase 4.3 — delivery mode for the secret. Accepts "env"
+  // (default; same behavior as pre-4.3) or "file" (planned;
+  // tmpfs-mounted per-file delivery). Unknown values are
+  // rejected at the API boundary. Phase A allows setting the
+  // mode but the daemon still stamps env vars for everyone;
+  // Phase B switches behavior based on this field.
+  string delivery = 4;
 }
 
 message SetSecretResponse {


### PR DESCRIPTION
## Summary

First slice of the tmpfs secret-delivery rollout. **Phase B wires actual behavior**; this Phase A lands the data-model plumbing through every layer so Phase B is a focused PR that touches only \`stampSecretsOnLXC\` + container provisioning.

Audit **C-MED-4**. See [SECRETS-ENV-VAR-RISK.md](docs/security/SECRETS-ENV-VAR-RISK.md) for the threat model the tmpfs path mitigates.

## Schema

\`\`\`sql
ALTER TABLE secrets ADD COLUMN IF NOT EXISTS delivery
  TEXT NOT NULL DEFAULT 'env';
\`\`\`

Non-destructive; existing rows default to \`env\`.

## API surface

| Layer | Change |
|---|---|
| proto | \`SecretMetadata.delivery\` (read-only on wire) + \`SetSecretRequest.delivery\` (operator picks at set time) |
| \`ValidateDelivery()\` helper | Accepts \`""\`, \`"env"\`, \`"file"\`; rejects anything else (case-sensitive, no aliases) |
| \`Store.Set\` | Signature gains \`delivery\` param; normalizes \`""\` → \`"env"\` at the storage boundary |
| \`Store.Get\` / \`Store.List\` | Return the field in \`SecretMetadata\` |
| Server \`SetSecret\` | Passes \`req.Delivery\` through; audit log includes the mode |
| \`HTTPClient.SetSecret\` / \`GRPCClient.SetSecret\` | Signatures gain \`delivery\` param |
| CLI | \`containarium secrets set <user> <NAME> <value> --delivery env\|file\` |

## No behavior change

Phase A is **pure data-model plumbing**. The daemon still stamps env vars for every secret regardless of the \`delivery\` field. Phase B will switch \`stampSecretsOnLXC\` to write 0400-mode files to \`/run/secrets/<NAME>\` for \`delivery="file"\` rows.

## Tests

- \`delivery_test.go\`: ValidateDelivery happy + error cases (env/file pass; uppercase/aliases/whitespace rejected), constant shape.
- \`store_test.go\` integration test updated for the new \`Set\` signature.

\`\`\`
ok  github.com/footprintai/containarium/internal/secrets  0.895s
ok  github.com/footprintai/containarium/internal/server   5.010s
\`\`\`

## Roadmap

| Phase | Status |
|---|---|
| design doc | #258 |
| **A: field plumbing** | **this PR** |
| B: tmpfs mount + file writer | next |

## Test plan

- [x] Unit tests pass
- [x] \`go build ./...\` clean
- [x] \`make proto\` regenerated stubs (committed)
- [ ] CI green
- [ ] Manual: with integration test (live Postgres), \`containarium secrets set alice FOO bar --delivery file\` → confirm row has \`delivery='file'\`; \`secrets get\` echoes the mode in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)