### PR TITLE
sec: zero-trust Phase 4.3 Phase B-2 — chown tmpfs secrets to container user

### DIFF
--- a/docs/security/SECRETS-ENV-VAR-RISK.md
+++ b/docs/security/SECRETS-ENV-VAR-RISK.md
@@ -120,30 +120,53 @@ not as a replacement. Operators choose per-tenant or per-secret. The
 default stays env-stamping for backwards compatibility; new
 deployments are encouraged to use file mode for high-risk values.
 
-### Status: shipped as Phase A + Phase B-1
+### Status: shipped through Phase B-2
 
 - **Phase A** (PR #274): the `delivery` field is plumbed
   through proto / Store / CLI. Operators can set it via
   `containarium secrets set <user> <NAME> <value> --delivery file`.
-- **Phase B-1** (this PR): `stampSecretsOnLXC` dispatches
+- **Phase B-1** (PR #275): `stampSecretsOnLXC` dispatches
   per-secret. `delivery="file"` rows are written to
   `/run/secrets/<NAME>` mode `0400`. Since `/run` is tmpfs
   on every systemd distro, file-mode secrets inherit the
   in-memory ephemeral-disposal property for free — the
   tmpfs evaporates when the container stops.
+- **Phase B-2** (this PR): tenant ownership. The
+  `/run/secrets` directory is now `0750 root:<username>`
+  and each file is `0440 root:<username>`. The app
+  process — running as the tenant user inside the
+  container, the convention since CreateContainer — can
+  read its own secrets without sudo. Fallback: if the
+  chown fails (early-boot race, user not in
+  /etc/passwd), the file stays mode `0400 root` and the
+  operator sees a WARNING log line.
 
-Open Phase B-2 work:
+Wire shape inside the container:
 
-- Per-container UID/GID for file ownership. Today files
-  are `0400` root-only; apps running as non-root in the
-  container can't read them without `sudo`. A future
-  pass resolves the tenant's container user and `chown`s
-  the file accordingly.
-- Re-stamp on container start. Currently the daemon stamps
-  on CreateContainer / StartContainer / RefreshSecrets;
-  the latter two cover the "container restart" case but a
-  bare `incus restart` not routed through the daemon
-  would lose file-mode secrets until the next refresh.
+```
+$ ls -ld /run/secrets
+drwxr-x---. 2 root alice 60 /run/secrets
+
+$ ls -l /run/secrets
+-r--r-----. 1 root alice  43 OPENAI_API_KEY
+-r--r-----. 1 root alice 128 DATABASE_URL
+```
+
+The app running as `alice` can `cat /run/secrets/OPENAI_API_KEY`;
+no other in-container user can.
+
+Open Phase B-3 work:
+
+- Re-stamp on bare `incus restart`. The daemon already
+  re-stamps on CreateContainer / StartContainer /
+  RefreshSecrets, so the canonical paths are covered.
+  But an operator who runs `incus restart` directly
+  loses file-mode secrets until the next daemon-routed
+  refresh. Options: a periodic reconciler, or a
+  container-side systemd unit that calls back to the
+  daemon at boot. Neither is shipped yet — operators
+  should use `containarium start` / `containarium stop`
+  routes today.
 
 ## References
 

--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -557,11 +557,20 @@ on the internal network. Land them first.
         `LoadAllForUserWithDelivery` returns per-secret
         delivery so the stamper can route correctly. Legacy
         `LoadAllForUser` kept as a backwards-compat shim.
-      — **Phase B-2 follow-up:** chown files to the
-        container's tenant UID/GID so non-root processes
-        can read them; re-stamp on bare `incus restart`
-        not routed through the daemon. The runbook
-        documents the current root-only-read constraint.
+      — **Phase B-2 landed (tenant ownership).**
+        `/run/secrets` is now `0750 root:<username>` and
+        each file is `0440 root:<username>`. The app
+        process running as the tenant user can read its
+        own secrets without sudo. chown is by name, so
+        the container's /etc/passwd is the source of
+        truth. Fallback: if the chown errors (early-boot
+        race, user not yet in passwd), the file stays
+        `0400 root` and the operator sees a WARNING log
+        line — file-mode secrets still work for
+        root-running apps.
+      — **Phase B-3 (open):** re-stamp on bare `incus
+        restart` not routed through the daemon.
+        Daemon-routed start/stop already re-stamp.
 - [x] **4.4** Audit-log redaction policy + enforcement — `internal/audit/store.go:53-74` (**C-MED-5**)
       — New `audit.Redact` / `audit.SanitizeDetail` scrubs JWTs
         (with or without Bearer prefix), password/api_key/secret

--- a/internal/server/secrets_server.go
+++ b/internal/server/secrets_server.go
@@ -220,15 +220,36 @@ func (s *ContainerServer) stampSecretsOnLXC(ctx context.Context, username string
 		}
 	}
 	if hasFileMode {
-		// mkdir + chmod is idempotent. mode 0700 root-only;
-		// individual files are 0400 with the same owner.
-		// /run is tmpfs on systemd distros so this dir
-		// vanishes on container stop — that's the design.
-		if err := s.manager.Exec(containerName, []string{"sh", "-c",
-			"mkdir -p /run/secrets && chmod 0700 /run/secrets",
-		}); err != nil {
-			log.Printf("[secrets] failed to prepare /run/secrets on %s: %v (file-mode rows will be skipped)", containerName, err)
-			hasFileMode = false
+		// mkdir + chmod is idempotent. Phase B-2 (audit
+		// C-MED-4 polish) — the dir is mode 0750
+		// root:<username> so the tenant's process group
+		// can traverse it but no other user can. /run is
+		// tmpfs on systemd distros so this dir vanishes on
+		// container stop — that's the design.
+		//
+		// Username lookup: the container's tenant user is
+		// `<username>` by convention (created at
+		// CreateContainer time). chown's by-name form
+		// resolves it via the container's /etc/passwd; if
+		// the user doesn't exist (e.g. early-boot race or
+		// a container provisioned outside the daemon) the
+		// chown errors and we fall back to root-only mode
+		// 0700 + file 0400, same as Phase B-1.
+		prepCmd := fmt.Sprintf(
+			"mkdir -p /run/secrets && chown root:%s /run/secrets && chmod 0750 /run/secrets",
+			username,
+		)
+		if err := s.manager.Exec(containerName, []string{"sh", "-c", prepCmd}); err != nil {
+			log.Printf("[secrets] tenant chown on /run/secrets failed for %s (%v) — falling back to root-only mode", containerName, err)
+			// Fallback: root-only dir. Files will be
+			// 0400 root, app must run as root or use
+			// sudo. Better than failing the whole stamp.
+			if err := s.manager.Exec(containerName, []string{"sh", "-c",
+				"mkdir -p /run/secrets && chmod 0700 /run/secrets",
+			}); err != nil {
+				log.Printf("[secrets] failed to prepare /run/secrets on %s: %v (file-mode rows will be skipped)", containerName, err)
+				hasFileMode = false
+			}
 		}
 	}
 
@@ -239,9 +260,29 @@ func (s *ContainerServer) stampSecretsOnLXC(ctx context.Context, username string
 				continue
 			}
 			path := "/run/secrets/" + k
+			// Write the file mode 0400 (root-only). The
+			// post-write chown/chmod below relaxes the
+			// group bit so the tenant user can read.
+			// We do that as a separate exec rather than
+			// passing uid/gid to WriteFile because the
+			// container's /etc/passwd is the source of
+			// truth for the UID; resolving it server-side
+			// would be fragile.
 			if err := s.manager.WriteFile(containerName, path, []byte(sv.Value), "0400"); err != nil {
 				log.Printf("[secrets] failed to write file-mode %s on %s: %v (continuing)", k, containerName, err)
 				continue
+			}
+			// Try the chown+chmod fix-up. Best-effort —
+			// if the tenant user doesn't exist, the
+			// stamp still succeeds at the file level
+			// (visible to root) and the operator can
+			// debug from the warning.
+			fixupCmd := fmt.Sprintf(
+				"chown root:%s %q && chmod 0440 %q",
+				username, path, path,
+			)
+			if err := s.manager.Exec(containerName, []string{"sh", "-c", fixupCmd}); err != nil {
+				log.Printf("[secrets] chown/chmod %s on %s failed (%v) — file stays root-only 0400", k, containerName, err)
 			}
 		default: // env (and any unknown future mode falls back to env semantics)
 			if err := s.manager.SetEnv(containerName, k, sv.Value); err != nil {


### PR DESCRIPTION
## Summary

Phase B-1 (#275) shipped tmpfs delivery but files were \`0400\` root-only — apps running as the tenant user inside the container couldn't read their own secrets without sudo. This pass relaxes ownership so non-root processes can access the files.

## Wire shape inside the container

\`\`\`
drwxr-x---. 2 root alice 60 /run/secrets
-r--r-----. 1 root alice 43 /run/secrets/OPENAI_API_KEY
-r--r-----. 1 root alice 128 /run/secrets/DATABASE_URL
\`\`\`

App running as \`alice\` can \`cat\` the file; no other in-container user can.

## Mechanics

- \`/run/secrets\` dir: mode \`0750\` owned \`root:<username>\`.
- Each file: mode \`0440\` owned \`root:<username>\`.
- chown is by **name** (container's \`/etc/passwd\` is the source of truth for the UID), keeping daemon-side resolution out of the loop.
- **Fallback**: if chown errors (early-boot race, user not in passwd yet), the file stays \`0400 root\` and the operator sees a WARNING log line. File-mode secrets still work for root-running apps; nothing breaks.

## Docs

- \`SECRETS-ENV-VAR-RISK.md\` shows the wire shape and lists Phase B-3 (re-stamp on bare \`incus restart\`) as the remaining open work.
- \`ZERO-TRUST-TODO.md\` marks Phase B-2 done.

## Roadmap

| Phase | PR |
|---|---|
| Design doc | #258 |
| A: field plumbing | #274 |
| B-1: file writer | #275 |
| **B-2: tenant ownership** | **this PR** |
| B-3: re-stamp on bare incus restart | future |

## Test plan

- [x] \`go build ./...\` clean
- [x] Unit tests pass (\`go test ./internal/... ./pkg/...\`)
- [ ] CI green
- [ ] Manual: \`containarium secrets set alice OPENAI_API_KEY sk-xyz --delivery file\`, restart container, \`incus exec alice-container -- ls -l /run/secrets/\` shows \`-r--r----- root alice\` ownership; \`incus exec alice-container -- su -c "cat /run/secrets/OPENAI_API_KEY" alice\` returns the value
- [ ] Manual: confirm the WARNING-fallback path by setting --delivery file before the tenant user exists (no recovery test needed — operators see the log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)