### PR TITLE
sec: zero-trust — ListRevokedTokens admin enumeration

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -3161,6 +3161,54 @@
         ]
       }
     },
+    "/v1/tokens/revoked": {
+      "get": {
+        "summary": "List active token revocations",
+        "description": "Returns revocation rows ordered most-recent-first. Default scope is non-expired revocations only; pass include_expired=true for forensic enumeration. Admin-only with the tokens:write scope.",
+        "operationId": "TokensService_ListRevokedTokens",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListRevokedTokensResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "description": "Max rows to return. 0 → 100 default. Server caps at\n1000.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "includeExpired",
+            "description": "When true, include rows whose expires_at has already\npassed (default false — most operators only care\nabout active revocations).",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "jtiPrefix",
+            "description": "Narrow by jti prefix. Empty disables. Useful when an\noperator only remembers part of a leaked jti.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Tokens"
+        ]
+      }
+    },
     "/v1/traffic/subscribe": {
       "get": {
         "summary": "Subscribe to traffic events",
@@ -5694,6 +5742,18 @@
         }
       }
     },
+    "ListRevokedTokensResponse": {
+      "type": "object",
+      "properties": {
+        "revocations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Revocation"
+          }
+        }
+      }
+    },
     "ListSecretsResponse": {
       "type": "object",
       "properties": {
@@ -6530,6 +6590,28 @@
           "title": "Status message"
         }
       }
+    },
+    "Revocation": {
+      "type": "object",
+      "properties": {
+        "jti": {
+          "type": "string",
+          "description": "The jti claim of the revoked token."
+        },
+        "expiresAt": {
+          "type": "string",
+          "description": "RFC3339 timestamp of the token's original `exp` claim.\nUsed as the cleanup horizon (rows past this can no\nlonger authenticate anyway, so the daemon prunes\nthem eventually)."
+        },
+        "revokedAt": {
+          "type": "string",
+          "description": "RFC3339 timestamp of when the revocation row was\nfirst inserted. Operators correlating an incident\nwindow use this column."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Free-form reason recorded at revoke time (e.g.\n\"operator_revoke\", \"refresh_rotation\", \"leak_2026_X\")."
+        }
+      },
+      "description": "Revocation is one row of the revocation list, surfaced\nby the admin listing path. The plaintext token itself is\nnot in the table — only the jti is."
     },
     "RevokeTokenRequest": {
       "type": "object",

--- a/docs/security/OPERATOR-SECURITY-RUNBOOK.md
+++ b/docs/security/OPERATOR-SECURITY-RUNBOOK.md
@@ -114,6 +114,17 @@ Idempotent — running it twice with the same `jti` preserves the first
 reason. From this point on, any request bearing the revoked token
 gets `401 invalid token`.
 
+Confirm the revoke landed (admin + `tokens:write` scope required):
+
+```bash
+containarium token list-revoked \
+    --jti-prefix "$JTI_FIRST_CHARS" \
+    --server https://containarium.kafeido.app \
+    --token "$ADMIN_TOKEN"
+```
+
+Pass `--include-expired` to enumerate the full history (forensic).
+
 ### Step 3 — If the leaked token was a refresh token
 
 The exchange endpoint won't accept it once revoked, BUT the

--- a/internal/auth/abuse_test.go
+++ b/internal/auth/abuse_test.go
@@ -268,3 +268,12 @@ func (a *abuseStore) Revoke(_ context.Context, jti string, _ time.Time, _ string
 func (a *abuseStore) CleanupExpired(_ context.Context, _ time.Time) (int64, error) {
 	return 0, nil
 }
+func (a *abuseStore) List(_ context.Context, _ ListRevocationsParams) ([]Revocation, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]Revocation, 0, len(a.revoked))
+	for jti := range a.revoked {
+		out = append(out, Revocation{JTI: jti})
+	}
+	return out, nil
+}

--- a/internal/auth/revocation.go
+++ b/internal/auth/revocation.go
@@ -49,4 +49,45 @@ type RevocationStore interface {
 	// pruned. Callers loop until the count is 0 (or until
 	// they hit their own time budget).
 	CleanupExpired(ctx context.Context, now time.Time) (int64, error)
+
+	// List returns revocation rows in reverse-chronological
+	// order (most recently revoked first), bounded by
+	// params.Limit. `params.IncludeExpired` toggles whether
+	// rows whose expires_at has already passed are returned
+	// — operators investigating a leak may want them; the
+	// default (false) only returns "still kill-switching
+	// something" rows.
+	//
+	// This is the admin-enumeration path; not on the
+	// authenticated-request hot path.
+	List(ctx context.Context, params ListRevocationsParams) ([]Revocation, error)
+}
+
+// Revocation is one row of the revocation list, exposed to
+// callers via List. Mirrors the schema; no encryption /
+// transformation needed.
+type Revocation struct {
+	JTI       string
+	ExpiresAt time.Time
+	RevokedAt time.Time
+	Reason    string
+}
+
+// ListRevocationsParams configures a List call.
+type ListRevocationsParams struct {
+	// Limit caps the returned rows. 0 → 100 default; max
+	// 1000 (enforced at the SQL layer too).
+	Limit int
+
+	// IncludeExpired returns rows whose expires_at is in
+	// the past. Default false — operators investigating a
+	// leak usually only want active revocations. Forensic
+	// queries asking "did we ever revoke this jti?" set it
+	// to true.
+	IncludeExpired bool
+
+	// JTIPrefix narrows the result to jtis starting with
+	// this prefix. Empty disables the filter. Useful when
+	// an operator only remembers part of a leaked jti.
+	JTIPrefix string
 }

--- a/internal/auth/revocation_store.go
+++ b/internal/auth/revocation_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -98,4 +99,52 @@ func (s *PgRevocationStore) CleanupExpired(ctx context.Context, now time.Time) (
 		return 0, fmt.Errorf("cleanup expired: %w", err)
 	}
 	return tag.RowsAffected(), nil
+}
+
+// List returns revocation rows. See RevocationStore.List
+// for semantics. Builds the WHERE clause dynamically based
+// on params; bind-variable indices are 1-based to match
+// pgx conventions.
+func (s *PgRevocationStore) List(ctx context.Context, params ListRevocationsParams) ([]Revocation, error) {
+	limit := params.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+
+	q := `SELECT jti, expires_at, revoked_at, reason FROM jwt_revocations`
+	var args []any
+	var conds []string
+
+	if !params.IncludeExpired {
+		conds = append(conds, fmt.Sprintf("expires_at > $%d", len(args)+1))
+		args = append(args, time.Now())
+	}
+	if params.JTIPrefix != "" {
+		conds = append(conds, fmt.Sprintf("jti LIKE $%d", len(args)+1))
+		args = append(args, params.JTIPrefix+"%")
+	}
+	if len(conds) > 0 {
+		q += " WHERE " + strings.Join(conds, " AND ")
+	}
+	q += fmt.Sprintf(" ORDER BY revoked_at DESC LIMIT $%d", len(args)+1)
+	args = append(args, limit)
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list revocations: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Revocation
+	for rows.Next() {
+		var r Revocation
+		if err := rows.Scan(&r.JTI, &r.ExpiresAt, &r.RevokedAt, &r.Reason); err != nil {
+			return nil, fmt.Errorf("scan revocation row: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
 }

--- a/internal/auth/revocation_test.go
+++ b/internal/auth/revocation_test.go
@@ -64,6 +64,19 @@ func (m *memRevocationStore) CleanupExpired(_ context.Context, now time.Time) (i
 	return pruned, nil
 }
 
+// List satisfies the RevocationStore interface. memRevocationStore
+// doesn't track revoked_at / reason; tests that exercise the
+// listing path use the Postgres-backed store.
+func (m *memRevocationStore) List(_ context.Context, _ ListRevocationsParams) ([]Revocation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []Revocation
+	for jti, exp := range m.rows {
+		out = append(out, Revocation{JTI: jti, ExpiresAt: exp})
+	}
+	return out, nil
+}
+
 const revTestSecret = "test-secret-must-be-at-least-32-bytes-long-ok"
 
 func newTestTM(t *testing.T) *TokenManager {

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -427,6 +427,55 @@ func (c *HTTPClient) RefreshToken(refreshTok string) (string, string, int64, int
 	return result.AccessToken, result.RefreshToken, result.AccessTokenExpiresAt, result.RefreshTokenExpiresAt, nil
 }
 
+// Revocation is the CLI-facing shape of one revocation
+// row returned by ListRevokedTokens. Timestamps are
+// RFC3339 strings, matching the wire format.
+type Revocation struct {
+	JTI       string `json:"jti"`
+	ExpiresAt string `json:"expiresAt"`
+	RevokedAt string `json:"revokedAt"`
+	Reason    string `json:"reason"`
+}
+
+// ListRevokedTokens enumerates active revocations.
+// Admin-only on the server side; the daemon checks role +
+// tokens:write scope. `limit` 0 → server default (100);
+// server caps at 1000.
+func (c *HTTPClient) ListRevokedTokens(limit int32, includeExpired bool, jtiPrefix string) ([]Revocation, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	q := url.Values{}
+	if limit > 0 {
+		q.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	if includeExpired {
+		q.Set("includeExpired", "true")
+	}
+	if jtiPrefix != "" {
+		q.Set("jtiPrefix", jtiPrefix)
+	}
+	path := "/v1/tokens/revoked"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list revoked tokens: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, parseErr(b, resp.StatusCode, "list revoked tokens")
+	}
+	var result struct {
+		Revocations []Revocation `json:"revocations"`
+	}
+	if err := json.Unmarshal(b, &result); err != nil {
+		return nil, fmt.Errorf("decode revocations: %w", err)
+	}
+	return result.Revocations, nil
+}
+
 // RevokeToken adds a JWT's jti to the daemon's revocation
 // list. Phase 1.2 follow-up — admin-only on the server side.
 // `reason` is free-form and recorded for forensics; pass ""

--- a/internal/cmd/token.go
+++ b/internal/cmd/token.go
@@ -29,6 +29,11 @@ var (
 	// `token refresh` flags (Phase 1.6 part B)
 	refreshTokenIn   string
 	refreshTokenFile string
+
+	// `token list-revoked` flags
+	listRevokedLimit          int32
+	listRevokedIncludeExpired bool
+	listRevokedJTIPrefix      string
 )
 
 var tokenCmd = &cobra.Command{
@@ -149,11 +154,36 @@ Use the access token in subsequent API calls:
 	RunE: runTokenRefresh,
 }
 
+// tokenListRevokedCmd implements `containarium token
+// list-revoked` — admin enumeration of the revocation
+// list. Confirms a revoke landed; surfaces what got killed
+// during an incident window.
+var tokenListRevokedCmd = &cobra.Command{
+	Use:   "list-revoked",
+	Short: "List active JWT revocations (admin-only)",
+	Long: `Enumerate the revocation list. By default returns only
+revocations whose token exp is still in the future ("active
+kill-switches"); pass --include-expired for forensic queries
+that need the full history.
+
+Admin role + tokens:write scope required.`,
+	Example: `  # Confirm the last revoke landed
+  containarium token list-revoked --server $S --token $T
+
+  # All revocations for a partial jti you remember
+  containarium token list-revoked --jti-prefix "AbCd" --server $S --token $T
+
+  # Forensic: every row, including expired
+  containarium token list-revoked --include-expired --limit 500 --server $S --token $T`,
+	RunE: runTokenListRevoked,
+}
+
 func init() {
 	rootCmd.AddCommand(tokenCmd)
 	tokenCmd.AddCommand(tokenGenerateCmd)
 	tokenCmd.AddCommand(tokenRevokeCmd)
 	tokenCmd.AddCommand(tokenRefreshCmd)
+	tokenCmd.AddCommand(tokenListRevokedCmd)
 
 	tokenRefreshCmd.Flags().StringVar(&refreshTokenIn, "refresh-token", "", "Refresh token to exchange (mutually exclusive with --refresh-token-file)")
 	tokenRefreshCmd.Flags().StringVar(&refreshTokenFile, "refresh-token-file", "", "Path to file containing the refresh token (mode 0600 recommended)")
@@ -162,6 +192,10 @@ func init() {
 	tokenRevokeCmd.MarkFlagRequired("jti")
 	tokenRevokeCmd.Flags().StringVar(&revokeReason, "reason", "", "Free-form reason recorded for forensics (default: 'operator_revoke')")
 	tokenRevokeCmd.Flags().StringVar(&revokeExpiresAt, "expires-at", "", "Token's own exp claim in RFC3339 (controls cleanup horizon; default: daemon max lifetime)")
+
+	tokenListRevokedCmd.Flags().Int32Var(&listRevokedLimit, "limit", 100, "Max rows to return (server caps at 1000)")
+	tokenListRevokedCmd.Flags().BoolVar(&listRevokedIncludeExpired, "include-expired", false, "Include rows whose token exp is already past (default: active only)")
+	tokenListRevokedCmd.Flags().StringVar(&listRevokedJTIPrefix, "jti-prefix", "", "Narrow results to jtis with this prefix (default: all)")
 
 	// Required flags
 	tokenGenerateCmd.Flags().StringVar(&tokenUsername, "username", "", "Username for the token (required)")
@@ -370,5 +404,37 @@ func runTokenRevoke(cmd *cobra.Command, args []string) error {
 		msg = "jti added to revocation list"
 	}
 	fmt.Printf("Revoked: %s\n%s\n", revokeJTI, msg)
+	return nil
+}
+
+// runTokenListRevoked GETs /v1/tokens/revoked and prints
+// the rows. Admin-only on the server side; the CLI does
+// the same flag-validation gate as runTokenRevoke.
+func runTokenListRevoked(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required")
+	}
+	if authToken == "" {
+		return fmt.Errorf("--token is required (must name an admin JWT)")
+	}
+
+	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+	if err != nil {
+		return fmt.Errorf("create http client: %w", err)
+	}
+	defer httpClient.Close()
+
+	revs, err := httpClient.ListRevokedTokens(listRevokedLimit, listRevokedIncludeExpired, listRevokedJTIPrefix)
+	if err != nil {
+		return err
+	}
+	if len(revs) == 0 {
+		fmt.Println("(no revocations match)")
+		return nil
+	}
+	fmt.Printf("%-24s  %-25s  %-25s  %s\n", "JTI", "REVOKED AT", "EXPIRES AT", "REASON")
+	for _, r := range revs {
+		fmt.Printf("%-24s  %-25s  %-25s  %s\n", r.JTI, r.RevokedAt, r.ExpiresAt, r.Reason)
+	}
 	return nil
 }

--- a/internal/server/tokens_server.go
+++ b/internal/server/tokens_server.go
@@ -202,3 +202,45 @@ func safeID(c *auth.Claims) string {
 	}
 	return c.ID
 }
+
+// ListRevokedTokens enumerates active revocations. Admin-
+// only + tokens:write scope (same surface as RevokeToken —
+// anyone who can revoke can confirm what was revoked).
+//
+// Default behavior is to return only non-expired
+// revocations. include_expired=true returns the full
+// forensic set (an operator chasing a leak after the fact
+// might want everything).
+func (s *TokensServer) ListRevokedTokens(ctx context.Context, req *pb.ListRevokedTokensRequest) (*pb.ListRevokedTokensResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeTokensWrite); err != nil {
+		return nil, err
+	}
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+	if s.store == nil {
+		return nil, status.Error(codes.Unavailable, "revocation list is not configured on this daemon")
+	}
+
+	rows, err := s.store.List(ctx, auth.ListRevocationsParams{
+		Limit:          int(req.Limit),
+		IncludeExpired: req.IncludeExpired,
+		JTIPrefix:      req.JtiPrefix,
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list revocations: %v", err)
+	}
+
+	out := &pb.ListRevokedTokensResponse{
+		Revocations: make([]*pb.Revocation, 0, len(rows)),
+	}
+	for _, r := range rows {
+		out.Revocations = append(out.Revocations, &pb.Revocation{
+			Jti:       r.JTI,
+			ExpiresAt: r.ExpiresAt.UTC().Format(time.RFC3339),
+			RevokedAt: r.RevokedAt.UTC().Format(time.RFC3339),
+			Reason:    r.Reason,
+		})
+	}
+	return out, nil
+}

--- a/internal/server/tokens_server_test.go
+++ b/internal/server/tokens_server_test.go
@@ -50,6 +50,15 @@ func (f *fakeRevocationStore) Revoke(_ context.Context, jti string, _ time.Time,
 func (f *fakeRevocationStore) CleanupExpired(_ context.Context, _ time.Time) (int64, error) {
 	return 0, nil
 }
+func (f *fakeRevocationStore) List(_ context.Context, _ auth.ListRevocationsParams) ([]auth.Revocation, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]auth.Revocation, 0, len(f.revoked))
+	for jti, reason := range f.revoked {
+		out = append(out, auth.Revocation{JTI: jti, Reason: reason})
+	}
+	return out, nil
+}
 
 func newTestTokensServer(t *testing.T, store auth.RevocationStore) *TokensServer {
 	t.Helper()
@@ -293,6 +302,68 @@ func TestRefreshToken_HappyPath_MintsNewPair(t *testing.T) {
 	}
 	if rc.TokenType != auth.TokenTypeRefresh {
 		t.Fatalf("new refresh tt=%q", rc.TokenType)
+	}
+}
+
+// --- ListRevokedTokens admin enumeration ---
+
+func TestListRevokedTokens_RejectsNoSubject(t *testing.T) {
+	srv := newTestTokensServer(t, newFakeRevocationStore())
+	_, err := srv.ListRevokedTokens(context.Background(), &pb.ListRevokedTokensRequest{})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("missing subject: got %v want Unauthenticated", err)
+	}
+}
+
+func TestListRevokedTokens_RejectsNonAdmin(t *testing.T) {
+	srv := newTestTokensServer(t, newFakeRevocationStore())
+	ctx := auth.ContextWithTestSubjectScopes(context.Background(),
+		"alice", []string{"user"}, []string{auth.ScopeTokensWrite},
+	)
+	_, err := srv.ListRevokedTokens(ctx, &pb.ListRevokedTokensRequest{})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin: got %v want PermissionDenied", err)
+	}
+}
+
+func TestListRevokedTokens_RejectsAdminMissingScope(t *testing.T) {
+	srv := newTestTokensServer(t, newFakeRevocationStore())
+	ctx := auth.ContextWithTestSubjectScopes(context.Background(),
+		"ops", []string{auth.RoleAdmin}, []string{auth.ScopeContainersRead},
+	)
+	_, err := srv.ListRevokedTokens(ctx, &pb.ListRevokedTokensRequest{})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("admin without tokens:write: got %v want PermissionDenied", err)
+	}
+}
+
+func TestListRevokedTokens_AdminWithScopeSucceeds(t *testing.T) {
+	store := newFakeRevocationStore()
+	_ = store.Revoke(context.Background(), "abc123", time.Now().Add(time.Hour), "test")
+	srv := newTestTokensServer(t, store)
+	ctx := auth.ContextWithTestSubjectScopes(context.Background(),
+		"ops", []string{auth.RoleAdmin}, []string{auth.ScopeTokensWrite},
+	)
+	resp, err := srv.ListRevokedTokens(ctx, &pb.ListRevokedTokensRequest{})
+	if err != nil {
+		t.Fatalf("ListRevokedTokens: %v", err)
+	}
+	if len(resp.Revocations) != 1 {
+		t.Fatalf("len(revocations) = %d, want 1", len(resp.Revocations))
+	}
+	if resp.Revocations[0].Jti != "abc123" {
+		t.Fatalf("jti = %q, want %q", resp.Revocations[0].Jti, "abc123")
+	}
+}
+
+func TestListRevokedTokens_UnavailableWhenStoreNil(t *testing.T) {
+	srv := newTestTokensServer(t, nil)
+	ctx := auth.ContextWithTestSubjectScopes(context.Background(),
+		"ops", []string{auth.RoleAdmin}, []string{auth.ScopeTokensWrite},
+	)
+	_, err := srv.ListRevokedTokens(ctx, &pb.ListRevokedTokensRequest{})
+	if status.Code(err) != codes.Unavailable {
+		t.Fatalf("nil store: got %v want Unavailable", err)
 	}
 }
 

--- a/pkg/pb/containarium/v1/tokens.pb.go
+++ b/pkg/pb/containarium/v1/tokens.pb.go
@@ -277,6 +277,198 @@ func (x *RefreshTokenResponse) GetRefreshTokenExpiresAt() int64 {
 	return 0
 }
 
+// Revocation is one row of the revocation list, surfaced
+// by the admin listing path. The plaintext token itself is
+// not in the table — only the jti is.
+type Revocation struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The jti claim of the revoked token.
+	Jti string `protobuf:"bytes,1,opt,name=jti,proto3" json:"jti,omitempty"`
+	// RFC3339 timestamp of the token's original `exp` claim.
+	// Used as the cleanup horizon (rows past this can no
+	// longer authenticate anyway, so the daemon prunes
+	// them eventually).
+	ExpiresAt string `protobuf:"bytes,2,opt,name=expires_at,json=expiresAt,proto3" json:"expires_at,omitempty"`
+	// RFC3339 timestamp of when the revocation row was
+	// first inserted. Operators correlating an incident
+	// window use this column.
+	RevokedAt string `protobuf:"bytes,3,opt,name=revoked_at,json=revokedAt,proto3" json:"revoked_at,omitempty"`
+	// Free-form reason recorded at revoke time (e.g.
+	// "operator_revoke", "refresh_rotation", "leak_2026_X").
+	Reason        string `protobuf:"bytes,4,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Revocation) Reset() {
+	*x = Revocation{}
+	mi := &file_containarium_v1_tokens_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Revocation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Revocation) ProtoMessage() {}
+
+func (x *Revocation) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_tokens_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Revocation.ProtoReflect.Descriptor instead.
+func (*Revocation) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_tokens_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *Revocation) GetJti() string {
+	if x != nil {
+		return x.Jti
+	}
+	return ""
+}
+
+func (x *Revocation) GetExpiresAt() string {
+	if x != nil {
+		return x.ExpiresAt
+	}
+	return ""
+}
+
+func (x *Revocation) GetRevokedAt() string {
+	if x != nil {
+		return x.RevokedAt
+	}
+	return ""
+}
+
+func (x *Revocation) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+type ListRevokedTokensRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Max rows to return. 0 → 100 default. Server caps at
+	// 1000.
+	Limit int32 `protobuf:"varint,1,opt,name=limit,proto3" json:"limit,omitempty"`
+	// When true, include rows whose expires_at has already
+	// passed (default false — most operators only care
+	// about active revocations).
+	IncludeExpired bool `protobuf:"varint,2,opt,name=include_expired,json=includeExpired,proto3" json:"include_expired,omitempty"`
+	// Narrow by jti prefix. Empty disables. Useful when an
+	// operator only remembers part of a leaked jti.
+	JtiPrefix     string `protobuf:"bytes,3,opt,name=jti_prefix,json=jtiPrefix,proto3" json:"jti_prefix,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRevokedTokensRequest) Reset() {
+	*x = ListRevokedTokensRequest{}
+	mi := &file_containarium_v1_tokens_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRevokedTokensRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRevokedTokensRequest) ProtoMessage() {}
+
+func (x *ListRevokedTokensRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_tokens_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRevokedTokensRequest.ProtoReflect.Descriptor instead.
+func (*ListRevokedTokensRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_tokens_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ListRevokedTokensRequest) GetLimit() int32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListRevokedTokensRequest) GetIncludeExpired() bool {
+	if x != nil {
+		return x.IncludeExpired
+	}
+	return false
+}
+
+func (x *ListRevokedTokensRequest) GetJtiPrefix() string {
+	if x != nil {
+		return x.JtiPrefix
+	}
+	return ""
+}
+
+type ListRevokedTokensResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Revocations   []*Revocation          `protobuf:"bytes,1,rep,name=revocations,proto3" json:"revocations,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRevokedTokensResponse) Reset() {
+	*x = ListRevokedTokensResponse{}
+	mi := &file_containarium_v1_tokens_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRevokedTokensResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRevokedTokensResponse) ProtoMessage() {}
+
+func (x *ListRevokedTokensResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_tokens_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRevokedTokensResponse.ProtoReflect.Descriptor instead.
+func (*ListRevokedTokensResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_tokens_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ListRevokedTokensResponse) GetRevocations() []*Revocation {
+	if x != nil {
+		return x.Revocations
+	}
+	return nil
+}
+
 var File_containarium_v1_tokens_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_tokens_proto_rawDesc = "" +
@@ -296,12 +488,29 @@ const file_containarium_v1_tokens_proto_rawDesc = "" +
 	"\faccess_token\x18\x01 \x01(\tR\vaccessToken\x12#\n" +
 	"\rrefresh_token\x18\x02 \x01(\tR\frefreshToken\x125\n" +
 	"\x17access_token_expires_at\x18\x03 \x01(\x03R\x14accessTokenExpiresAt\x127\n" +
-	"\x18refresh_token_expires_at\x18\x04 \x01(\x03R\x15refreshTokenExpiresAt2\x8a\a\n" +
+	"\x18refresh_token_expires_at\x18\x04 \x01(\x03R\x15refreshTokenExpiresAt\"t\n" +
+	"\n" +
+	"Revocation\x12\x10\n" +
+	"\x03jti\x18\x01 \x01(\tR\x03jti\x12\x1d\n" +
+	"\n" +
+	"expires_at\x18\x02 \x01(\tR\texpiresAt\x12\x1d\n" +
+	"\n" +
+	"revoked_at\x18\x03 \x01(\tR\trevokedAt\x12\x16\n" +
+	"\x06reason\x18\x04 \x01(\tR\x06reason\"x\n" +
+	"\x18ListRevokedTokensRequest\x12\x14\n" +
+	"\x05limit\x18\x01 \x01(\x05R\x05limit\x12'\n" +
+	"\x0finclude_expired\x18\x02 \x01(\bR\x0eincludeExpired\x12\x1d\n" +
+	"\n" +
+	"jti_prefix\x18\x03 \x01(\tR\tjtiPrefix\"Z\n" +
+	"\x19ListRevokedTokensResponse\x12=\n" +
+	"\vrevocations\x18\x01 \x03(\v2\x1b.containarium.v1.RevocationR\vrevocations2\xff\t\n" +
 	"\rTokensService\x12\x85\x03\n" +
 	"\vRevokeToken\x12#.containarium.v1.RevokeTokenRequest\x1a$.containarium.v1.RevokeTokenResponse\"\xaa\x02\x92A\x8a\x02\n" +
 	"\x06Tokens\x12\x17Revoke a JWT by its jti\x1a\xe6\x01Adds the token's jti to the revocation list. The token will be rejected on the next request that tries to use it. Admin-only. Idempotent — revoking an already-revoked jti is a no-op (the original revocation reason is preserved).\x82\xd3\xe4\x93\x02\x16:\x01*\"\x11/v1/tokens/revoke\x12\xf0\x03\n" +
 	"\fRefreshToken\x12$.containarium.v1.RefreshTokenRequest\x1a%.containarium.v1.RefreshTokenResponse\"\x92\x03\x92A\xf1\x02\n" +
-	"\x06Tokens\x129Exchange a refresh token for a new (access, refresh) pair\x1a\xab\x02Validates the refresh token (signature + exp + tt='refresh' + not revoked), mints a new short-lived access token, mints a new long-lived refresh token, and revokes the input refresh token's jti. Refresh tokens are single-use; the new refresh token must be stored by the client for the next exchange.\x82\xd3\xe4\x93\x02\x17:\x01*\"\x12/v1/tokens/refreshBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
+	"\x06Tokens\x129Exchange a refresh token for a new (access, refresh) pair\x1a\xab\x02Validates the refresh token (signature + exp + tt='refresh' + not revoked), mints a new short-lived access token, mints a new long-lived refresh token, and revokes the input refresh token's jti. Refresh tokens are single-use; the new refresh token must be stored by the client for the next exchange.\x82\xd3\xe4\x93\x02\x17:\x01*\"\x12/v1/tokens/refresh\x12\xf2\x02\n" +
+	"\x11ListRevokedTokens\x12).containarium.v1.ListRevokedTokensRequest\x1a*.containarium.v1.ListRevokedTokensResponse\"\x85\x02\x92A\xe7\x01\n" +
+	"\x06Tokens\x12\x1dList active token revocations\x1a\xbd\x01Returns revocation rows ordered most-recent-first. Default scope is non-expired revocations only; pass include_expired=true for forensic enumeration. Admin-only with the tokens:write scope.\x82\xd3\xe4\x93\x02\x14\x12\x12/v1/tokens/revokedBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
 
 var (
 	file_containarium_v1_tokens_proto_rawDescOnce sync.Once
@@ -315,23 +524,29 @@ func file_containarium_v1_tokens_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_tokens_proto_rawDescData
 }
 
-var file_containarium_v1_tokens_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_containarium_v1_tokens_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_containarium_v1_tokens_proto_goTypes = []any{
-	(*RevokeTokenRequest)(nil),   // 0: containarium.v1.RevokeTokenRequest
-	(*RevokeTokenResponse)(nil),  // 1: containarium.v1.RevokeTokenResponse
-	(*RefreshTokenRequest)(nil),  // 2: containarium.v1.RefreshTokenRequest
-	(*RefreshTokenResponse)(nil), // 3: containarium.v1.RefreshTokenResponse
+	(*RevokeTokenRequest)(nil),        // 0: containarium.v1.RevokeTokenRequest
+	(*RevokeTokenResponse)(nil),       // 1: containarium.v1.RevokeTokenResponse
+	(*RefreshTokenRequest)(nil),       // 2: containarium.v1.RefreshTokenRequest
+	(*RefreshTokenResponse)(nil),      // 3: containarium.v1.RefreshTokenResponse
+	(*Revocation)(nil),                // 4: containarium.v1.Revocation
+	(*ListRevokedTokensRequest)(nil),  // 5: containarium.v1.ListRevokedTokensRequest
+	(*ListRevokedTokensResponse)(nil), // 6: containarium.v1.ListRevokedTokensResponse
 }
 var file_containarium_v1_tokens_proto_depIdxs = []int32{
-	0, // 0: containarium.v1.TokensService.RevokeToken:input_type -> containarium.v1.RevokeTokenRequest
-	2, // 1: containarium.v1.TokensService.RefreshToken:input_type -> containarium.v1.RefreshTokenRequest
-	1, // 2: containarium.v1.TokensService.RevokeToken:output_type -> containarium.v1.RevokeTokenResponse
-	3, // 3: containarium.v1.TokensService.RefreshToken:output_type -> containarium.v1.RefreshTokenResponse
-	2, // [2:4] is the sub-list for method output_type
-	0, // [0:2] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	4, // 0: containarium.v1.ListRevokedTokensResponse.revocations:type_name -> containarium.v1.Revocation
+	0, // 1: containarium.v1.TokensService.RevokeToken:input_type -> containarium.v1.RevokeTokenRequest
+	2, // 2: containarium.v1.TokensService.RefreshToken:input_type -> containarium.v1.RefreshTokenRequest
+	5, // 3: containarium.v1.TokensService.ListRevokedTokens:input_type -> containarium.v1.ListRevokedTokensRequest
+	1, // 4: containarium.v1.TokensService.RevokeToken:output_type -> containarium.v1.RevokeTokenResponse
+	3, // 5: containarium.v1.TokensService.RefreshToken:output_type -> containarium.v1.RefreshTokenResponse
+	6, // 6: containarium.v1.TokensService.ListRevokedTokens:output_type -> containarium.v1.ListRevokedTokensResponse
+	4, // [4:7] is the sub-list for method output_type
+	1, // [1:4] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_tokens_proto_init() }
@@ -345,7 +560,7 @@ func file_containarium_v1_tokens_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_tokens_proto_rawDesc), len(file_containarium_v1_tokens_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/pb/containarium/v1/tokens.pb.gw.go
+++ b/pkg/pb/containarium/v1/tokens.pb.gw.go
@@ -89,6 +89,41 @@ func local_request_TokensService_RefreshToken_0(ctx context.Context, marshaler r
 	return msg, metadata, err
 }
 
+var filter_TokensService_ListRevokedTokens_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_TokensService_ListRevokedTokens_0(ctx context.Context, marshaler runtime.Marshaler, client TokensServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListRevokedTokensRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_TokensService_ListRevokedTokens_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.ListRevokedTokens(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_TokensService_ListRevokedTokens_0(ctx context.Context, marshaler runtime.Marshaler, server TokensServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListRevokedTokensRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_TokensService_ListRevokedTokens_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListRevokedTokens(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterTokensServiceHandlerServer registers the http handlers for service TokensService to "mux".
 // UnaryRPC     :call TokensServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -134,6 +169,26 @@ func RegisterTokensServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 			return
 		}
 		forward_TokensService_RefreshToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_TokensService_ListRevokedTokens_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.TokensService/ListRevokedTokens", runtime.WithHTTPPathPattern("/v1/tokens/revoked"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_TokensService_ListRevokedTokens_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_TokensService_ListRevokedTokens_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -209,15 +264,34 @@ func RegisterTokensServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_TokensService_RefreshToken_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_TokensService_ListRevokedTokens_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.TokensService/ListRevokedTokens", runtime.WithHTTPPathPattern("/v1/tokens/revoked"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_TokensService_ListRevokedTokens_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_TokensService_ListRevokedTokens_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_TokensService_RevokeToken_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "revoke"}, ""))
-	pattern_TokensService_RefreshToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "refresh"}, ""))
+	pattern_TokensService_RevokeToken_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "revoke"}, ""))
+	pattern_TokensService_RefreshToken_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "refresh"}, ""))
+	pattern_TokensService_ListRevokedTokens_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "tokens", "revoked"}, ""))
 )
 
 var (
-	forward_TokensService_RevokeToken_0  = runtime.ForwardResponseMessage
-	forward_TokensService_RefreshToken_0 = runtime.ForwardResponseMessage
+	forward_TokensService_RevokeToken_0       = runtime.ForwardResponseMessage
+	forward_TokensService_RefreshToken_0      = runtime.ForwardResponseMessage
+	forward_TokensService_ListRevokedTokens_0 = runtime.ForwardResponseMessage
 )

--- a/pkg/pb/containarium/v1/tokens_grpc.pb.go
+++ b/pkg/pb/containarium/v1/tokens_grpc.pb.go
@@ -19,8 +19,9 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	TokensService_RevokeToken_FullMethodName  = "/containarium.v1.TokensService/RevokeToken"
-	TokensService_RefreshToken_FullMethodName = "/containarium.v1.TokensService/RefreshToken"
+	TokensService_RevokeToken_FullMethodName       = "/containarium.v1.TokensService/RevokeToken"
+	TokensService_RefreshToken_FullMethodName      = "/containarium.v1.TokensService/RefreshToken"
+	TokensService_ListRevokedTokens_FullMethodName = "/containarium.v1.TokensService/ListRevokedTokens"
 )
 
 // TokensServiceClient is the client API for TokensService service.
@@ -48,6 +49,12 @@ type TokensServiceClient interface {
 	// itself IS the credential. Don't wrap with the access-
 	// token middleware.
 	RefreshToken(ctx context.Context, in *RefreshTokenRequest, opts ...grpc.CallOption) (*RefreshTokenResponse, error)
+	// ListRevokedTokens enumerates active revocations.
+	// Operators use this to confirm a revoke landed or to
+	// investigate "what got killed during the incident window."
+	// Admin-only + tokens:write scope (same surface as
+	// RevokeToken — anyone who can revoke can enumerate).
+	ListRevokedTokens(ctx context.Context, in *ListRevokedTokensRequest, opts ...grpc.CallOption) (*ListRevokedTokensResponse, error)
 }
 
 type tokensServiceClient struct {
@@ -72,6 +79,16 @@ func (c *tokensServiceClient) RefreshToken(ctx context.Context, in *RefreshToken
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(RefreshTokenResponse)
 	err := c.cc.Invoke(ctx, TokensService_RefreshToken_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *tokensServiceClient) ListRevokedTokens(ctx context.Context, in *ListRevokedTokensRequest, opts ...grpc.CallOption) (*ListRevokedTokensResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListRevokedTokensResponse)
+	err := c.cc.Invoke(ctx, TokensService_ListRevokedTokens_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -103,6 +120,12 @@ type TokensServiceServer interface {
 	// itself IS the credential. Don't wrap with the access-
 	// token middleware.
 	RefreshToken(context.Context, *RefreshTokenRequest) (*RefreshTokenResponse, error)
+	// ListRevokedTokens enumerates active revocations.
+	// Operators use this to confirm a revoke landed or to
+	// investigate "what got killed during the incident window."
+	// Admin-only + tokens:write scope (same surface as
+	// RevokeToken — anyone who can revoke can enumerate).
+	ListRevokedTokens(context.Context, *ListRevokedTokensRequest) (*ListRevokedTokensResponse, error)
 	mustEmbedUnimplementedTokensServiceServer()
 }
 
@@ -118,6 +141,9 @@ func (UnimplementedTokensServiceServer) RevokeToken(context.Context, *RevokeToke
 }
 func (UnimplementedTokensServiceServer) RefreshToken(context.Context, *RefreshTokenRequest) (*RefreshTokenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RefreshToken not implemented")
+}
+func (UnimplementedTokensServiceServer) ListRevokedTokens(context.Context, *ListRevokedTokensRequest) (*ListRevokedTokensResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListRevokedTokens not implemented")
 }
 func (UnimplementedTokensServiceServer) mustEmbedUnimplementedTokensServiceServer() {}
 func (UnimplementedTokensServiceServer) testEmbeddedByValue()                       {}
@@ -176,6 +202,24 @@ func _TokensService_RefreshToken_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TokensService_ListRevokedTokens_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListRevokedTokensRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TokensServiceServer).ListRevokedTokens(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TokensService_ListRevokedTokens_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TokensServiceServer).ListRevokedTokens(ctx, req.(*ListRevokedTokensRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // TokensService_ServiceDesc is the grpc.ServiceDesc for TokensService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -190,6 +234,10 @@ var TokensService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RefreshToken",
 			Handler:    _TokensService_RefreshToken_Handler,
+		},
+		{
+			MethodName: "ListRevokedTokens",
+			Handler:    _TokensService_ListRevokedTokens_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/containarium/v1/tokens.proto
+++ b/proto/containarium/v1/tokens.proto
@@ -71,6 +71,48 @@ message RefreshTokenResponse {
   int64 refresh_token_expires_at = 4;
 }
 
+// Revocation is one row of the revocation list, surfaced
+// by the admin listing path. The plaintext token itself is
+// not in the table — only the jti is.
+message Revocation {
+  // The jti claim of the revoked token.
+  string jti = 1;
+
+  // RFC3339 timestamp of the token's original `exp` claim.
+  // Used as the cleanup horizon (rows past this can no
+  // longer authenticate anyway, so the daemon prunes
+  // them eventually).
+  string expires_at = 2;
+
+  // RFC3339 timestamp of when the revocation row was
+  // first inserted. Operators correlating an incident
+  // window use this column.
+  string revoked_at = 3;
+
+  // Free-form reason recorded at revoke time (e.g.
+  // "operator_revoke", "refresh_rotation", "leak_2026_X").
+  string reason = 4;
+}
+
+message ListRevokedTokensRequest {
+  // Max rows to return. 0 → 100 default. Server caps at
+  // 1000.
+  int32 limit = 1;
+
+  // When true, include rows whose expires_at has already
+  // passed (default false — most operators only care
+  // about active revocations).
+  bool include_expired = 2;
+
+  // Narrow by jti prefix. Empty disables. Useful when an
+  // operator only remembers part of a leaked jti.
+  string jti_prefix = 3;
+}
+
+message ListRevokedTokensResponse {
+  repeated Revocation revocations = 1;
+}
+
 // TokensService is the admin surface for JWT lifecycle.
 //
 // RevokeToken requires an admin role + tokens:write scope;
@@ -110,6 +152,22 @@ service TokensService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Exchange a refresh token for a new (access, refresh) pair";
       description: "Validates the refresh token (signature + exp + tt='refresh' + not revoked), mints a new short-lived access token, mints a new long-lived refresh token, and revokes the input refresh token's jti. Refresh tokens are single-use; the new refresh token must be stored by the client for the next exchange.";
+      tags: "Tokens";
+    };
+  }
+
+  // ListRevokedTokens enumerates active revocations.
+  // Operators use this to confirm a revoke landed or to
+  // investigate "what got killed during the incident window."
+  // Admin-only + tokens:write scope (same surface as
+  // RevokeToken — anyone who can revoke can enumerate).
+  rpc ListRevokedTokens(ListRevokedTokensRequest) returns (ListRevokedTokensResponse) {
+    option (google.api.http) = {
+      get: "/v1/tokens/revoked"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List active token revocations";
+      description: "Returns revocation rows ordered most-recent-first. Default scope is non-expired revocations only; pass include_expired=true for forensic enumeration. Admin-only with the tokens:write scope.";
       tags: "Tokens";
     };
   }


### PR DESCRIPTION
## Summary

Operators could revoke a jti (#249) but couldn't **enumerate** the revocation list to confirm a revoke landed or see what got killed during an incident window. The only recovery path was \`audit query\` filtering by \`action=token_revoke\`, which works but isn't where operators look first.

This adds the missing path:

| Layer | New |
|---|---|
| proto | \`TokensService.ListRevokedTokens\` |
| REST | \`GET /v1/tokens/revoked?limit=N&includeExpired=true&jtiPrefix=AbCd\` |
| CLI | \`containarium token list-revoked [--limit N] [--include-expired] [--jti-prefix str]\` |

## Surface

- \`RevocationStore.List(ctx, ListRevocationsParams)\` added to the interface; \`PgRevocationStore\` implements with \`ORDER BY revoked_at DESC\` + dynamic WHERE for the two filter knobs.
- In-memory test stubs (\`memRevocationStore\`, \`abuseStore\`, \`fakeRevocationStore\`) gain trivial \`List\` implementations so the interface stays single-typed.
- New proto \`Revocation\` message + \`ListRevokedTokensRequest/Response\`. RFC3339 timestamps to match the existing \`SecretMetadata\` pattern.
- Server gates: admin role + \`tokens:write\` scope (same surface as RevokeToken — anyone who can revoke can confirm).

## CLI usage

\`\`\`bash
# Confirm the last revoke landed
containarium token list-revoked --server $S --token $T

# All revocations for a partial jti you remember
containarium token list-revoked --jti-prefix "AbCd" --server $S --token $T

# Forensic: every row, including expired
containarium token list-revoked --include-expired --limit 500 \\
    --server $S --token $T
\`\`\`

## Operator runbook

The "Suspected credential leak" section now points operators at \`list-revoked\` to confirm the revoke landed.

## Tests (5 server-side cases)

- Missing subject → Unauthenticated
- Non-admin → PermissionDenied
- Admin missing \`tokens:write\` scope → PermissionDenied (orthogonal-axis check)
- Admin with scope → success, returns the row
- Nil store → Unavailable

\`\`\`
ok  github.com/footprintai/containarium/internal/server  1.470s
\`\`\`

## Test plan

- [x] Unit tests pass
- [x] \`go build ./...\` clean
- [x] \`make proto\` regenerated stubs (committed)
- [ ] CI green
- [ ] Manual: revoke a jti, then \`containarium token list-revoked\` confirms the row; \`--jti-prefix\` narrows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)