### PR TITLE
sec: zero-trust Phase 4.1 Phase-C — GCP Cloud KMS backend

### DIFF
--- a/docs/security/OPERATOR-SECURITY-RUNBOOK.md
+++ b/docs/security/OPERATOR-SECURITY-RUNBOOK.md
@@ -420,6 +420,7 @@ Pick a backend via `CONTAINARIUM_KMS_BACKEND`. Supported:
 | `none`     | Default. No KMS; behaves identically to pre-4.1. |
 | `inproc`   | In-process wrap under the master key. Dev/test mostly — protection level is unchanged from legacy, but it writes envelope-shaped rows so a future cutover to a real KMS doesn't re-touch every row. |
 | `vault`    | Vault Transit secret engine over HTTP. See setup below. |
+| `gcp`      | Google Cloud KMS via the REST API. See setup below. |
 
 ### Vault Transit setup
 
@@ -556,6 +557,94 @@ containarium secrets migrate-to-envelope
 
 (Rewrap support is a future enhancement; today the migrator
 only converts legacy → envelope.)
+
+### GCP Cloud KMS setup
+
+Cloud KMS exposes per-key encrypt / decrypt REST endpoints;
+the named CryptoKey is the KEK. The key material never
+leaves Google's HSM-backed boundary — the daemon submits
+the plaintext DEK and gets back an opaque ciphertext.
+
+```bash
+# 1. Create the keyring + key in Cloud KMS. Pick a location
+#    in the same region as your daemon to minimize call
+#    latency. Algorithm `google-symmetric-encryption` is the
+#    one Cloud KMS exposes via :encrypt / :decrypt; rotated
+#    versions remain transparently decryptable.
+gcloud kms keyrings create containarium \
+    --location=us-west1
+gcloud kms keys create secrets \
+    --location=us-west1 \
+    --keyring=containarium \
+    --purpose=encryption
+
+# 2. Grant the daemon's service account the narrow IAM role
+#    that allows encrypt + decrypt against that one key
+#    (NOT Encrypter/Decrypter at project scope — the
+#    blast-radius matters).
+gcloud kms keys add-iam-policy-binding secrets \
+    --location=us-west1 \
+    --keyring=containarium \
+    --member="serviceAccount:containarium-daemon@$PROJECT.iam.gserviceaccount.com" \
+    --role=roles/cloudkms.cryptoKeyEncrypterDecrypter
+
+# 3. Set up token delivery. The daemon expects a static
+#    bearer token in CONTAINARIUM_GCP_KMS_TOKEN_FILE; a tiny
+#    sidecar refreshes it periodically. On GCE/GKE with
+#    workload identity, the metadata server is the source:
+#
+#    while true; do
+#      curl -sH 'Metadata-Flavor: Google' \
+#        'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token' \
+#        | jq -r .access_token \
+#        | install -m 0600 /dev/stdin /etc/containarium/gcp-kms.token
+#      sleep 1800
+#    done
+#
+#    Off-cloud: have an operator run
+#    `gcloud auth print-access-token | sudo tee /etc/containarium/gcp-kms.token`
+#    every ~50 minutes (gcloud tokens last 1h). Long-lived
+#    deployments should prefer Workload Identity Federation
+#    so the file is never stale.
+
+# 4. Configure the daemon. Add to systemd Environment=:
+CONTAINARIUM_KMS_BACKEND=gcp
+CONTAINARIUM_GCP_KMS_KEY_NAME=projects/$PROJECT/locations/us-west1/keyRings/containarium/cryptoKeys/secrets
+CONTAINARIUM_GCP_KMS_TOKEN_FILE=/etc/containarium/gcp-kms.token
+# Optional: CONTAINARIUM_GCP_KMS_ENDPOINT (override for
+#           private endpoint deployments).
+# Optional: CONTAINARIUM_GCP_KMS_TIMEOUT=5s
+
+# 5. Restart the daemon. Confirm the startup log shows:
+#    Secrets store ready (file-keyed AES-256-GCM, envelope: gcp cloud kms (key=...))
+sudo systemctl restart containarium
+```
+
+Migration and Phase E retirement work the same as the Vault
+path — `containarium secrets migrate-to-envelope` re-wraps
+legacy rows under the GCP KEK; `envelope-coverage` reports
+progress; `CONTAINARIUM_REQUIRE_ENVELOPE=true` rejects any
+remaining legacy rows.
+
+### Rotating the GCP Cloud KMS key
+
+```bash
+gcloud kms keys versions create \
+    --location=us-west1 \
+    --keyring=containarium \
+    --key=secrets \
+    --primary
+```
+
+Existing wrapped DEKs reference the prior key version (the
+version is baked into the ciphertext); Cloud KMS
+transparently decrypts under whichever version each row
+was wrapped against. To force re-wrap under the new
+primary:
+
+```bash
+containarium secrets migrate-to-envelope
+```
 
 ## Locking down `/wake/` to a known load balancer
 

--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -515,6 +515,26 @@ on the internal network. Land them first.
         single-row roundtrip-verify, verifier catches
         tampered ciphertext, options defaults, coverage
         zero-value).
+      — **Phase C landed (GCP Cloud KMS backend).**
+        `pkg/core/secrets/kms_gcp.go` implements
+        `KMSClient` against Cloud KMS via the JSON REST
+        API — no cloud.google.com/go/kms SDK dependency,
+        mirroring the Vault impl's "raw HTTP" stance.
+        Operator env: `CONTAINARIUM_GCP_KMS_KEY_NAME`
+        (full `projects/.../cryptoKeys/...` resource path),
+        `CONTAINARIUM_GCP_KMS_TOKEN_FILE` (or `_TOKEN`),
+        optional `_ENDPOINT` (private-endpoint override),
+        `_TIMEOUT`. kek_id encodes the key resource path
+        (`gcp:projects/.../cryptoKeys/...`) so cross-key
+        rows refuse cleanly. Token lifecycle is operator-
+        managed (workload-identity sidecar or
+        gcloud-tee), matching Vault Agent's stance.
+        Factory dispatch case added; 9 backend tests use
+        a fake `httptest.Server` to exercise round-trip,
+        bearer auth, kek_id routing, error propagation,
+        timeout enforcement; 6 factory tests cover the
+        env-var contract. Setup procedure documented in
+        [OPERATOR-SECURITY-RUNBOOK.md](OPERATOR-SECURITY-RUNBOOK.md#gcp-cloud-kms-setup).
 - [x] **4.2** Stat-check master-key file permissions at load — `pkg/core/secrets/crypto.go:47,109` (**C-HIGH-6**)
       — `LoadOrCreateMasterKey` now stats the file before reading
         and refuses if any non-owner bit is set (`mode & 0o077 != 0`).

--- a/pkg/core/secrets/kms_factory.go
+++ b/pkg/core/secrets/kms_factory.go
@@ -29,6 +29,7 @@ const (
 	KMSBackendNone   = "none"
 	KMSBackendInProc = "inproc"
 	KMSBackendVault  = "vault"
+	KMSBackendGCP    = "gcp"
 )
 
 // LoadKMSClient picks a backend based on
@@ -67,8 +68,18 @@ func LoadKMSClient(masterKey []byte) (KMSClient, string, error) {
 		}
 		return k, fmt.Sprintf("vault transit (addr=%s mount=%s key=%s)",
 			cfg.Address, cfg.Mount, cfg.KeyName), nil
+	case KMSBackendGCP:
+		cfg, err := gcpConfigFromEnv()
+		if err != nil {
+			return nil, "", fmt.Errorf("KMS backend gcp: %w", err)
+		}
+		k, err := NewGCPKMS(cfg)
+		if err != nil {
+			return nil, "", fmt.Errorf("KMS backend gcp: %w", err)
+		}
+		return k, fmt.Sprintf("gcp cloud kms (key=%s)", cfg.KeyName), nil
 	default:
-		return nil, "", fmt.Errorf("KMS backend: unrecognized value %q (expected: none, inproc, vault)", backend)
+		return nil, "", fmt.Errorf("KMS backend: unrecognized value %q (expected: none, inproc, vault, gcp)", backend)
 	}
 }
 
@@ -111,6 +122,47 @@ func vaultConfigFromEnv() (VaultConfig, error) {
 		d, err := time.ParseDuration(t)
 		if err != nil {
 			return cfg, fmt.Errorf("CONTAINARIUM_VAULT_TIMEOUT: %w", err)
+		}
+		cfg.Timeout = d
+	}
+	return cfg, nil
+}
+
+// gcpConfigFromEnv reads the Cloud KMS config from env.
+// Required: CONTAINARIUM_GCP_KMS_KEY_NAME and one of
+// CONTAINARIUM_GCP_KMS_TOKEN / _TOKEN_FILE. Optional:
+// CONTAINARIUM_GCP_KMS_ENDPOINT (private-endpoint deployments
+// override this), CONTAINARIUM_GCP_KMS_TIMEOUT (default 5s).
+func gcpConfigFromEnv() (GCPConfig, error) {
+	cfg := GCPConfig{
+		KeyName:  strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_KEY_NAME")),
+		Endpoint: strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_ENDPOINT")),
+	}
+	if cfg.KeyName == "" {
+		return cfg, fmt.Errorf("CONTAINARIUM_GCP_KMS_KEY_NAME is required (e.g. projects/<p>/locations/<l>/keyRings/<r>/cryptoKeys/<k>)")
+	}
+
+	// Token: env wins over file. File is the recommended
+	// long-lived path — a sidecar refreshes
+	// `gcloud auth print-access-token` or hits the GCE
+	// metadata server and writes the result atomically.
+	if tok := strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_TOKEN")); tok != "" {
+		cfg.Token = tok
+	} else if path := strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_TOKEN_FILE")); path != "" {
+		tok, err := readBearerLikeFile(path)
+		if err != nil {
+			return cfg, fmt.Errorf("read CONTAINARIUM_GCP_KMS_TOKEN_FILE: %w", err)
+		}
+		cfg.Token = tok
+	}
+	if cfg.Token == "" {
+		return cfg, fmt.Errorf("set either CONTAINARIUM_GCP_KMS_TOKEN or CONTAINARIUM_GCP_KMS_TOKEN_FILE")
+	}
+
+	if t := strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_TIMEOUT")); t != "" {
+		d, err := time.ParseDuration(t)
+		if err != nil {
+			return cfg, fmt.Errorf("CONTAINARIUM_GCP_KMS_TIMEOUT: %w", err)
 		}
 		cfg.Timeout = d
 	}

--- a/pkg/core/secrets/kms_factory_test.go
+++ b/pkg/core/secrets/kms_factory_test.go
@@ -20,6 +20,11 @@ func clearKMSEnv(t *testing.T) {
 		"CONTAINARIUM_VAULT_TRANSIT_MOUNT",
 		"CONTAINARIUM_VAULT_TRANSIT_KEY",
 		"CONTAINARIUM_VAULT_TIMEOUT",
+		"CONTAINARIUM_GCP_KMS_KEY_NAME",
+		"CONTAINARIUM_GCP_KMS_TOKEN",
+		"CONTAINARIUM_GCP_KMS_TOKEN_FILE",
+		"CONTAINARIUM_GCP_KMS_ENDPOINT",
+		"CONTAINARIUM_GCP_KMS_TIMEOUT",
 	} {
 		t.Setenv(k, "")
 	}
@@ -168,6 +173,94 @@ func TestLoadKMSClient_VaultTimeoutParse(t *testing.T) {
 	}
 
 	t.Setenv("CONTAINARIUM_VAULT_TIMEOUT", "not-a-duration")
+	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
+		t.Fatal("malformed duration should error")
+	}
+}
+
+// --- GCP KMS factory cases ---
+
+const factoryTestKeyName = "projects/p/locations/us-west1/keyRings/r/cryptoKeys/k"
+
+func TestLoadKMSClient_GCPFromEnvSucceeds(t *testing.T) {
+	clearKMSEnv(t)
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "gcp")
+	t.Setenv("CONTAINARIUM_GCP_KMS_KEY_NAME", factoryTestKeyName)
+	t.Setenv("CONTAINARIUM_GCP_KMS_TOKEN", "access-token-xyz")
+	c, desc, err := LoadKMSClient(mkMaster(t))
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil GCPKMS client")
+	}
+	if desc == "" || desc[:3] != "gcp" {
+		t.Fatalf("description should announce gcp backend; got %q", desc)
+	}
+}
+
+func TestLoadKMSClient_GCPRequiresKeyName(t *testing.T) {
+	clearKMSEnv(t)
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "gcp")
+	t.Setenv("CONTAINARIUM_GCP_KMS_TOKEN", "access-token-xyz")
+	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
+		t.Fatal("missing GCP_KMS_KEY_NAME should error")
+	}
+}
+
+func TestLoadKMSClient_GCPRequiresToken(t *testing.T) {
+	clearKMSEnv(t)
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "gcp")
+	t.Setenv("CONTAINARIUM_GCP_KMS_KEY_NAME", factoryTestKeyName)
+	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
+		t.Fatal("missing GCP token should error")
+	}
+}
+
+func TestLoadKMSClient_GCPTokenFromFile(t *testing.T) {
+	clearKMSEnv(t)
+	dir := t.TempDir()
+	tokPath := filepath.Join(dir, "gcp.token")
+	if err := os.WriteFile(tokPath, []byte("access-token-xyz\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "gcp")
+	t.Setenv("CONTAINARIUM_GCP_KMS_KEY_NAME", factoryTestKeyName)
+	t.Setenv("CONTAINARIUM_GCP_KMS_TOKEN_FILE", tokPath)
+	c, _, err := LoadKMSClient(mkMaster(t))
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected client from token-file path")
+	}
+}
+
+func TestLoadKMSClient_GCPTokenFileWithBadPerms(t *testing.T) {
+	clearKMSEnv(t)
+	dir := t.TempDir()
+	tokPath := filepath.Join(dir, "gcp.token")
+	if err := os.WriteFile(tokPath, []byte("access-token-xyz\n"), 0o644); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "gcp")
+	t.Setenv("CONTAINARIUM_GCP_KMS_KEY_NAME", factoryTestKeyName)
+	t.Setenv("CONTAINARIUM_GCP_KMS_TOKEN_FILE", tokPath)
+	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
+		t.Fatal("0644 token file should be rejected (defense-in-depth, same as Vault path)")
+	}
+}
+
+func TestLoadKMSClient_GCPTimeoutParse(t *testing.T) {
+	clearKMSEnv(t)
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "gcp")
+	t.Setenv("CONTAINARIUM_GCP_KMS_KEY_NAME", factoryTestKeyName)
+	t.Setenv("CONTAINARIUM_GCP_KMS_TOKEN", "access-token-xyz")
+	t.Setenv("CONTAINARIUM_GCP_KMS_TIMEOUT", "10s")
+	if _, _, err := LoadKMSClient(mkMaster(t)); err != nil {
+		t.Fatalf("valid duration should parse; got %v", err)
+	}
+	t.Setenv("CONTAINARIUM_GCP_KMS_TIMEOUT", "garbage")
 	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
 		t.Fatal("malformed duration should error")
 	}

--- a/pkg/core/secrets/kms_gcp.go
+++ b/pkg/core/secrets/kms_gcp.go
@@ -1,0 +1,249 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Phase 4.1 Phase-C — Google Cloud KMS implementation of
+// KMSClient. Audit C-HIGH-6.
+//
+// Cloud KMS exposes per-key encrypt / decrypt REST
+// endpoints; the named CryptoKey is the KEK. The key
+// material never leaves Google's HSM-backed boundary —
+// the daemon submits the plaintext DEK (base64) and gets
+// back an opaque ciphertext blob.
+//
+// We follow the Vault pattern and talk to the JSON REST
+// API directly rather than pulling in the cloud.google.com/
+// go/kms SDK. Reasons:
+//
+//   - The SDK transitive tree is large (gax, grpc, oauth2,
+//     metadata, …); govulncheck has to track it all.
+//   - Our usage is two endpoints — ~40 lines of HTTP.
+//   - Auth is a bearer access token, supplied by the
+//     operator the same way the Vault token is. Daemons
+//     on GKE/GCE can use a tiny token-refresh sidecar
+//     against the metadata server (workload identity);
+//     bare-metal can use a static service-account token
+//     refreshed by gcloud out-of-band. Either way the
+//     daemon only needs the file path.
+//
+// Wire shape:
+//
+//   POST <endpoint>/v1/<KEY_NAME>:encrypt
+//     Authorization: Bearer <access_token>
+//     {"plaintext": "<base64(DEK)>"}
+//   →  {"name": "<KEY_NAME>/cryptoKeyVersions/<N>",
+//       "ciphertext": "<base64>",
+//       "ciphertextCrc32c": "..."}
+//
+//   POST <endpoint>/v1/<KEY_NAME>:decrypt
+//     Authorization: Bearer <access_token>
+//     {"ciphertext": "<base64>"}
+//   →  {"plaintext": "<base64(DEK)>",
+//       "plaintextCrc32c": "..."}
+//
+// kek_id encodes the full resource name so a row migrated
+// under one project / key can't be unwrapped by a daemon
+// reconfigured against a different one. GCP's own key
+// version is opaque to us (baked into the ciphertext); on
+// rotation, decrypt requests for old ciphertext continue
+// to succeed automatically.
+
+// GCPConfig configures the GCP Cloud KMS backend.
+type GCPConfig struct {
+	// KeyName is the full Cloud KMS resource name of the
+	// CryptoKey, e.g.
+	// "projects/my-proj/locations/us-west1/keyRings/cont/cryptoKeys/secrets".
+	// Use the bare CryptoKey (not a CryptoKeyVersion) —
+	// encrypt always uses the key's primary version.
+	KeyName string
+
+	// Token is the OAuth2 access token used as
+	// `Authorization: Bearer`. Operators refresh this
+	// out-of-band (workload identity sidecar / gcloud
+	// auth print-access-token tee'd to a file / Vault
+	// Agent with the gcp secret engine).
+	Token string
+
+	// Endpoint is the Cloud KMS API base URL. Defaults to
+	// the public production endpoint; the field exists so
+	// tests can point at a httptest.Server and so
+	// air-gapped private-endpoint deployments can override.
+	Endpoint string
+
+	// Timeout caps every Cloud KMS HTTP call. Default 5s.
+	Timeout time.Duration
+}
+
+// GCPKMS implements KMSClient against Google Cloud KMS.
+type GCPKMS struct {
+	cfg    GCPConfig
+	client *http.Client
+	kekID  string // cached, set in NewGCPKMS
+}
+
+// gcpKEKPrefix labels a kek_id as "wrap was done by GCP
+// Cloud KMS." Future readers (an operator who migrated
+// from GCP to Vault, for instance) refuse rows that don't
+// match their backend's prefix.
+const gcpKEKPrefix = "gcp:"
+
+// gcpDefaultEndpoint is the public Cloud KMS endpoint.
+// Override via GCPConfig.Endpoint for private endpoints
+// or test doubles.
+const gcpDefaultEndpoint = "https://cloudkms.googleapis.com"
+
+// NewGCPKMS constructs the backend. Validates config shape
+// but does NOT call Cloud KMS — the first Wrap / Unwrap
+// surfaces a bad token / missing key / network outage as a
+// normal Wrap / Unwrap error. Lazy connection mirrors the
+// Vault backend so daemon startup can't be blocked by a
+// momentarily-unreachable KMS endpoint.
+func NewGCPKMS(cfg GCPConfig) (*GCPKMS, error) {
+	cfg.KeyName = strings.TrimSpace(cfg.KeyName)
+	if cfg.KeyName == "" {
+		return nil, errors.New("gcp KMS: key name required")
+	}
+	// Cheap sanity-check the resource path so a typo
+	// surfaces at construction time instead of being
+	// surfaced as a generic 400 from Cloud KMS on the
+	// first Wrap. The full Google resource grammar is
+	// stricter than this — we just want the leading
+	// shape to match.
+	if !strings.HasPrefix(cfg.KeyName, "projects/") ||
+		!strings.Contains(cfg.KeyName, "/cryptoKeys/") {
+		return nil, fmt.Errorf("gcp KMS: key name %q is not a CryptoKey resource path (want projects/.../cryptoKeys/...)", cfg.KeyName)
+	}
+	if cfg.Token == "" {
+		return nil, errors.New("gcp KMS: access token required")
+	}
+	cfg.Endpoint = strings.TrimRight(strings.TrimSpace(cfg.Endpoint), "/")
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = gcpDefaultEndpoint
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 5 * time.Second
+	}
+	// kek_id is fully determined by the key resource path.
+	// Rows wrapped under different keys (or different
+	// projects) get distinct kek_ids; cross-deployment
+	// confusion is structurally impossible.
+	kekID := gcpKEKPrefix + cfg.KeyName
+	return &GCPKMS{
+		cfg:    cfg,
+		client: &http.Client{Timeout: cfg.Timeout},
+		kekID:  kekID,
+	}, nil
+}
+
+// Wrap encrypts the DEK against the configured CryptoKey.
+// Cloud KMS returns an opaque base64 ciphertext we store
+// verbatim — like Vault's "vault:v<n>:..." blob it carries
+// enough self-description (within the bytes) for decrypt
+// to figure out which key version produced it.
+func (g *GCPKMS) Wrap(ctx context.Context, plaintextDEK []byte) ([]byte, string, error) {
+	if len(plaintextDEK) != DEKSize {
+		return nil, "", fmt.Errorf("DEK must be %d bytes; got %d", DEKSize, len(plaintextDEK))
+	}
+	body := map[string]string{
+		"plaintext": base64.StdEncoding.EncodeToString(plaintextDEK),
+	}
+	var resp struct {
+		Ciphertext string `json:"ciphertext"`
+	}
+	if err := g.do(ctx, "encrypt", body, &resp); err != nil {
+		return nil, "", fmt.Errorf("gcp kms encrypt: %w", err)
+	}
+	if resp.Ciphertext == "" {
+		return nil, "", errors.New("gcp kms encrypt: empty ciphertext in response")
+	}
+	// We store the base64 ciphertext string verbatim;
+	// Unwrap just passes it back to Cloud KMS as the
+	// decrypt-request payload. No re-encoding round-trip
+	// in the hot path.
+	return []byte(resp.Ciphertext), g.kekID, nil
+}
+
+// Unwrap reverses Wrap. The kek_id must start with the
+// gcp:-prefix; otherwise the row was wrapped by a
+// different backend (Vault, InProc, …) and we refuse
+// rather than spending a Cloud KMS call on a guaranteed
+// mismatch.
+func (g *GCPKMS) Unwrap(ctx context.Context, wrappedDEK []byte, kekID string) ([]byte, error) {
+	if !strings.HasPrefix(kekID, gcpKEKPrefix) {
+		return nil, fmt.Errorf("GCPKMS: refusing to unwrap row whose kek_id=%q (no %q prefix)", kekID, gcpKEKPrefix)
+	}
+	body := map[string]string{
+		"ciphertext": string(wrappedDEK),
+	}
+	var resp struct {
+		Plaintext string `json:"plaintext"`
+	}
+	if err := g.do(ctx, "decrypt", body, &resp); err != nil {
+		return nil, fmt.Errorf("gcp kms decrypt: %w", err)
+	}
+	dek, err := base64.StdEncoding.DecodeString(resp.Plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("gcp kms decrypt: base64: %w", err)
+	}
+	if len(dek) != DEKSize {
+		return nil, fmt.Errorf("gcp kms decrypt: DEK has %d bytes; want %d", len(dek), DEKSize)
+	}
+	return dek, nil
+}
+
+// do POSTs to the encrypt/decrypt endpoint and decodes
+// the JSON response. Centralized so error mapping and
+// future telemetry sit in one place.
+//
+// op is "encrypt" or "decrypt"; we suffix it onto the
+// CryptoKey resource path with Cloud KMS's `:verb` style.
+func (g *GCPKMS) do(ctx context.Context, op string, body, out any) error {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	url := fmt.Sprintf("%s/v1/%s:%s", g.cfg.Endpoint, g.cfg.KeyName, op)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+g.cfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		// GCP returns {"error":{"code":N,"message":"..."}}
+		// on failure.
+		var errResp struct {
+			Error struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+				Status  string `json:"status"`
+			} `json:"error"`
+		}
+		_ = json.Unmarshal(respBody, &errResp)
+		if errResp.Error.Message != "" {
+			return fmt.Errorf("status %d: %s", resp.StatusCode, errResp.Error.Message)
+		}
+		return fmt.Errorf("status %d: %s", resp.StatusCode, string(respBody))
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+	return nil
+}

--- a/pkg/core/secrets/kms_gcp_test.go
+++ b/pkg/core/secrets/kms_gcp_test.go
@@ -1,0 +1,374 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Phase 4.1 Phase-C — GCP Cloud KMS backend tests.
+//
+// We stand up a fake Cloud KMS server with httptest that:
+//   - validates the Authorization: Bearer header
+//   - encrypts plaintext under a process-local AES key to
+//     produce a base64 ciphertext blob
+//   - reverses on the :decrypt verb
+//   - can be configured to return errors for negative
+//     cases
+//
+// This lets us exercise the request shape, the kek_id
+// encoding, the Authorization plumbing, the error
+// mapping, and the prefix-routing guard without needing
+// real Cloud KMS credentials.
+
+type fakeGCPKMS struct {
+	t          *testing.T
+	wantToken  string
+	encryptKey []byte
+	requireOp  string // if non-empty, fail unless URL ends with :<op>
+	statusCode int    // override status code (default 200)
+	errMsg     string // optional GCP-style error message
+}
+
+func newFakeGCPKMS(t *testing.T) (*httptest.Server, *fakeGCPKMS) {
+	t.Helper()
+	fk := &fakeGCPKMS{
+		t:          t,
+		wantToken:  "access-token-xyz",
+		encryptKey: make([]byte, 32),
+		statusCode: 200,
+	}
+	if _, err := io.ReadFull(rand.Reader, fk.encryptKey); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(fk.handle))
+	return srv, fk
+}
+
+func (f *fakeGCPKMS) handle(w http.ResponseWriter, r *http.Request) {
+	// Bearer token check up front so unauthenticated calls
+	// fail the same way Cloud KMS would.
+	authz := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authz, "Bearer ") || strings.TrimPrefix(authz, "Bearer ") != f.wantToken {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"code":401,"message":"missing or invalid token","status":"UNAUTHENTICATED"}}`))
+		return
+	}
+	if f.statusCode >= 400 {
+		w.WriteHeader(f.statusCode)
+		_, _ = w.Write([]byte(`{"error":{"code":` +
+			httpStatusJSON(f.statusCode) + `,"message":"` + f.errMsg + `"}}`))
+		return
+	}
+	// Path: /v1/<key_name>:<op>
+	// We don't validate the key_name; just extract op.
+	path := strings.Trim(r.URL.Path, "/")
+	idx := strings.LastIndex(path, ":")
+	if idx < 0 {
+		http.Error(w, `{"error":{"message":"missing :op suffix"}}`, http.StatusBadRequest)
+		return
+	}
+	op := path[idx+1:]
+	if f.requireOp != "" && op != f.requireOp {
+		http.Error(w, `{"error":{"message":"wrong op"}}`, http.StatusBadRequest)
+		return
+	}
+	body, _ := io.ReadAll(r.Body)
+	switch op {
+	case "encrypt":
+		var req struct {
+			Plaintext string `json:"plaintext"`
+		}
+		_ = json.Unmarshal(body, &req)
+		pt, err := base64.StdEncoding.DecodeString(req.Plaintext)
+		if err != nil {
+			http.Error(w, `{"error":{"message":"bad plaintext b64"}}`, http.StatusBadRequest)
+			return
+		}
+		ct := f.symEncrypt(pt)
+		resp := map[string]any{
+			"name":       path[:idx] + "/cryptoKeyVersions/1",
+			"ciphertext": base64.StdEncoding.EncodeToString(ct),
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	case "decrypt":
+		var req struct {
+			Ciphertext string `json:"ciphertext"`
+		}
+		_ = json.Unmarshal(body, &req)
+		raw, err := base64.StdEncoding.DecodeString(req.Ciphertext)
+		if err != nil {
+			http.Error(w, `{"error":{"message":"bad ciphertext b64"}}`, http.StatusBadRequest)
+			return
+		}
+		pt, err := f.symDecrypt(raw)
+		if err != nil {
+			http.Error(w, `{"error":{"message":"bad ciphertext"}}`, http.StatusBadRequest)
+			return
+		}
+		resp := map[string]any{
+			"plaintext": base64.StdEncoding.EncodeToString(pt),
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	default:
+		http.Error(w, `{"error":{"message":"unknown op"}}`, http.StatusBadRequest)
+	}
+}
+
+// httpStatusJSON renders the int as a JSON number-literal
+// for embedding in the error envelope. Keeps the fake
+// terse — proper printf would pull strconv into the test
+// import set for one call.
+func httpStatusJSON(code int) string {
+	switch code {
+	case 400:
+		return "400"
+	case 401:
+		return "401"
+	case 403:
+		return "403"
+	case 404:
+		return "404"
+	case 429:
+		return "429"
+	case 500:
+		return "500"
+	case 503:
+		return "503"
+	default:
+		return "0"
+	}
+}
+
+func (f *fakeGCPKMS) symEncrypt(pt []byte) []byte {
+	block, _ := aes.NewCipher(f.encryptKey)
+	gcm, _ := cipher.NewGCM(block)
+	nonce := make([]byte, gcm.NonceSize())
+	_, _ = io.ReadFull(rand.Reader, nonce)
+	return append(nonce, gcm.Seal(nil, nonce, pt, nil)...)
+}
+
+func (f *fakeGCPKMS) symDecrypt(blob []byte) ([]byte, error) {
+	block, _ := aes.NewCipher(f.encryptKey)
+	gcm, _ := cipher.NewGCM(block)
+	ns := gcm.NonceSize()
+	if len(blob) < ns {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return gcm.Open(nil, blob[:ns], blob[ns:], nil)
+}
+
+const testKeyName = "projects/test-proj/locations/us-west1/keyRings/r/cryptoKeys/k"
+
+// --- Tests ---
+
+func TestGCPKMS_WrapUnwrapRoundtrip(t *testing.T) {
+	srv, _ := newFakeGCPKMS(t)
+	defer srv.Close()
+
+	k, err := NewGCPKMS(GCPConfig{
+		KeyName:  testKeyName,
+		Token:    "access-token-xyz",
+		Endpoint: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewGCPKMS: %v", err)
+	}
+
+	dek, _ := NewDEK()
+	wrapped, kekID, err := k.Wrap(context.Background(), dek)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	if !strings.HasPrefix(kekID, "gcp:") {
+		t.Fatalf("kek_id missing gcp: prefix: %q", kekID)
+	}
+	if !strings.Contains(kekID, testKeyName) {
+		t.Fatalf("kek_id should encode key name; got %q", kekID)
+	}
+	if len(wrapped) == 0 {
+		t.Fatal("wrapped DEK is empty")
+	}
+
+	out, err := k.Unwrap(context.Background(), wrapped, kekID)
+	if err != nil {
+		t.Fatalf("Unwrap: %v", err)
+	}
+	if !bytes.Equal(out, dek) {
+		t.Fatal("round-trip altered DEK")
+	}
+}
+
+func TestGCPKMS_RejectsBadToken(t *testing.T) {
+	srv, _ := newFakeGCPKMS(t)
+	defer srv.Close()
+
+	k, _ := NewGCPKMS(GCPConfig{
+		KeyName:  testKeyName,
+		Token:    "wrong-token",
+		Endpoint: srv.URL,
+	})
+	dek, _ := NewDEK()
+	_, _, err := k.Wrap(context.Background(), dek)
+	if err == nil {
+		t.Fatal("Wrap with wrong token should fail")
+	}
+	if !strings.Contains(err.Error(), "missing or invalid token") {
+		t.Fatalf("error should pass through Cloud KMS message; got %v", err)
+	}
+}
+
+func TestGCPKMS_RejectsRowFromDifferentBackend(t *testing.T) {
+	srv, _ := newFakeGCPKMS(t)
+	defer srv.Close()
+
+	k, _ := NewGCPKMS(GCPConfig{
+		KeyName: testKeyName, Token: "access-token-xyz", Endpoint: srv.URL,
+	})
+
+	// kek_id from another backend (Vault).
+	_, err := k.Unwrap(context.Background(), []byte("opaque-base64-ciphertext"), "vault:https://v|transit|k")
+	if err == nil {
+		t.Fatal("GCPKMS must refuse non-gcp: kek_id")
+	}
+	if !strings.Contains(err.Error(), "no \"gcp:\" prefix") {
+		t.Fatalf("error should mention the missing prefix; got %v", err)
+	}
+}
+
+func TestGCPKMS_RejectsBadDEKSize(t *testing.T) {
+	srv, _ := newFakeGCPKMS(t)
+	defer srv.Close()
+	k, _ := NewGCPKMS(GCPConfig{
+		KeyName: testKeyName, Token: "access-token-xyz", Endpoint: srv.URL,
+	})
+	for _, badSize := range []int{0, 16, 64} {
+		dek := make([]byte, badSize)
+		_, _, err := k.Wrap(context.Background(), dek)
+		if err == nil {
+			t.Fatalf("Wrap with DEK size %d should fail", badSize)
+		}
+	}
+}
+
+func TestGCPKMS_KEKIDEncodesKeyIdentity(t *testing.T) {
+	// Two backends pointed at different CryptoKeys produce
+	// different kek_ids — a row from one can't silently
+	// route to the other.
+	srv, _ := newFakeGCPKMS(t)
+	defer srv.Close()
+	a, _ := NewGCPKMS(GCPConfig{
+		KeyName:  "projects/a/locations/us/keyRings/r/cryptoKeys/key-a",
+		Token:    "access-token-xyz",
+		Endpoint: srv.URL,
+	})
+	b, _ := NewGCPKMS(GCPConfig{
+		KeyName:  "projects/b/locations/us/keyRings/r/cryptoKeys/key-b",
+		Token:    "access-token-xyz",
+		Endpoint: srv.URL,
+	})
+	dek, _ := NewDEK()
+	_, kekA, _ := a.Wrap(context.Background(), dek)
+	_, kekB, _ := b.Wrap(context.Background(), dek)
+	if kekA == kekB {
+		t.Fatal("different CryptoKeys should produce different kek_ids")
+	}
+}
+
+func TestGCPKMS_RejectsEmptyConfig(t *testing.T) {
+	cases := []GCPConfig{
+		{KeyName: "", Token: "t"},
+		{KeyName: testKeyName, Token: ""},
+		{KeyName: "not/a/key/path", Token: "t"},
+		{KeyName: "projects/p/locations/l/keyRings/r", Token: "t"}, // missing /cryptoKeys/
+	}
+	for _, c := range cases {
+		if _, err := NewGCPKMS(c); err == nil {
+			t.Fatalf("NewGCPKMS should reject config %+v", c)
+		}
+	}
+}
+
+func TestGCPKMS_EndpointDefaultsToPublic(t *testing.T) {
+	// We can't hit the real public endpoint in tests; we
+	// confirm the field defaults to the public URL when
+	// left empty, by reading it back via the kek_id-
+	// independent path (a Wrap against a no-route server
+	// produces an http error containing the URL).
+	k, err := NewGCPKMS(GCPConfig{
+		KeyName: testKeyName,
+		Token:   "access-token-xyz",
+		// no Endpoint → defaults to gcpDefaultEndpoint
+		Timeout: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewGCPKMS: %v", err)
+	}
+	dek, _ := NewDEK()
+	_, _, err = k.Wrap(context.Background(), dek)
+	if err == nil {
+		t.Fatal("Wrap should fail (we can't actually reach Cloud KMS)")
+	}
+	// Best-effort: the default endpoint string should
+	// appear in the error chain. Network DNS failure or
+	// timeout — either way the URL we tried is in the err.
+	if !strings.Contains(err.Error(), "cloudkms.googleapis.com") {
+		t.Logf("err = %v (does not mention default endpoint, but that's OK on some networks)", err)
+	}
+}
+
+func TestGCPKMS_TimeoutAppliesToHTTP(t *testing.T) {
+	hang := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+	}))
+	defer hang.Close()
+
+	k, _ := NewGCPKMS(GCPConfig{
+		KeyName:  testKeyName,
+		Token:    "access-token-xyz",
+		Endpoint: hang.URL,
+		Timeout:  100 * time.Millisecond,
+	})
+	dek, _ := NewDEK()
+	start := time.Now()
+	_, _, err := k.Wrap(context.Background(), dek)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("Wrap should time out")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("timeout not honored; elapsed = %v", elapsed)
+	}
+}
+
+func TestGCPKMS_PassesCloudKMSErrorThrough(t *testing.T) {
+	srv, fk := newFakeGCPKMS(t)
+	defer srv.Close()
+	fk.statusCode = 403
+	fk.errMsg = "Permission cloudkms.cryptoKeyVersions.useToEncrypt denied"
+
+	k, _ := NewGCPKMS(GCPConfig{
+		KeyName: testKeyName, Token: "access-token-xyz", Endpoint: srv.URL,
+	})
+	dek, _ := NewDEK()
+	_, _, err := k.Wrap(context.Background(), dek)
+	if err == nil {
+		t.Fatal("Wrap should fail with 403")
+	}
+	if !strings.Contains(err.Error(), "Permission cloudkms") {
+		t.Fatalf("error should surface Cloud KMS message; got %v", err)
+	}
+}
+
+// Compile-time conformance.
+var _ KMSClient = (*GCPKMS)(nil)


### PR DESCRIPTION
## Summary

- Add a Google Cloud KMS implementation of the `KMSClient` envelope interface (audit C-HIGH-6, Phase 4.1 Phase-C). Vault Transit landed in Phase F (#271); this closes the GCP path.
- Mirrors the Vault impl's "raw HTTP, no SDK" stance: Cloud KMS REST is two endpoints, auth is a bearer access token, no `cloud.google.com/go/kms` dependency.
- `kek_id = gcp:<full key resource path>` so cross-key rows refuse cleanly at the prefix check rather than wasting a Cloud KMS round-trip on a guaranteed mismatch.
- Token-refresh is operator-managed via `CONTAINARIUM_GCP_KMS_TOKEN_FILE` (workload-identity sidecar on GKE/GCE, `gcloud auth print-access-token` tee'd to disk on bare-metal). Same stance as Vault Agent for long-lived daemons.

## Operator config

```
CONTAINARIUM_KMS_BACKEND=gcp
CONTAINARIUM_GCP_KMS_KEY_NAME=projects/<P>/locations/<L>/keyRings/<R>/cryptoKeys/<K>
CONTAINARIUM_GCP_KMS_TOKEN_FILE=/etc/containarium/gcp-kms.token   # or _TOKEN
# optional:
CONTAINARIUM_GCP_KMS_ENDPOINT=https://cloudkms.googleapis.com     # private endpoint override
CONTAINARIUM_GCP_KMS_TIMEOUT=5s
```

Migration and Phase E retirement work unchanged — `containarium secrets migrate-to-envelope` + `envelope-coverage` + `CONTAINARIUM_REQUIRE_ENVELOPE=true`.

## What's not in this PR

- **In-process token refresh.** Operators wire a sidecar today; an in-daemon refresher would be a follow-up if usage demand emerges.
- **CryptoKeyVersion pinning.** Encrypt always targets the key's primary version (Cloud KMS default). Existing-ciphertext decrypt is transparent across rotations.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./pkg/core/secrets/...` — 9 new backend tests + 6 new factory tests, all green
- [x] Vet clean
- [ ] Production smoke (operator runbook walkthrough; needs a GCP project — not run in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)