### PR TITLE
sec: zero-trust 3.1 follow-up — TTL cache for simplestreams resolver

### DIFF
--- a/docs/security/OPERATOR-SECURITY-RUNBOOK.md
+++ b/docs/security/OPERATOR-SECURITY-RUNBOOK.md
@@ -846,6 +846,19 @@ case the gate exists to catch:
 - The daemon's view of the registry has been MITM'd.
   Investigate TLS / DNS for the daemon's outbound path.
 
+### Index caching
+
+The resolver caches each registry's `streams/v1/images.json`
+for 5 minutes by default. A fleet rollout that creates
+50 containers against `images.linuxcontainers.org` in
+quick succession collapses into a single index fetch.
+
+The TTL is short enough that a freshly-published image
+becomes verifiable within one pull cycle. If you've just
+published a new image and want the daemon to see it
+immediately, restart the daemon (clears the in-process
+cache).
+
 ### Limits
 
 - The gate does NOT catch cache tampering between pull

--- a/pkg/core/incus/streams.go
+++ b/pkg/core/incus/streams.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -71,27 +72,68 @@ const indexPath = "/streams/v1/images.json"
 // StreamsResolver fetches and caches the simplestreams
 // index for one or more registry servers. Construction is
 // cheap; the network call lands on the first Resolve.
+//
+// Phase B+ follow-up: the resolver now caches each
+// fetched index in memory for `cacheTTL`. A CreateContainer
+// burst against the same registry (e.g., 50 containers
+// pulled from images.linuxcontainers.org during a fleet
+// rollout) collapses into a single index fetch. TTL
+// defaults to 5 minutes — a window short enough that a
+// freshly-published image becomes verifiable within one
+// pull cycle, but long enough to absorb operator bursts.
+//
+// Cache is keyed by server URL. Each entry holds the raw
+// imagesIndex plus its fetch time. Expired entries are
+// re-fetched on the next Resolve; a parallel re-fetch
+// during expiry is acceptable (worst case: one extra
+// network call) and avoids the singleflight machinery
+// that would otherwise be needed.
 type StreamsResolver struct {
 	client *http.Client
-	// cache + cacheTTL would normally live here. Phase A
-	// intentionally skips caching — the first wire-in
-	// (Phase B) will surface call-rate numbers in the
-	// daemon log and a cache, with a chosen TTL, lands as
-	// a Phase B+ follow-up if warranted. Premature caching
-	// hides correctness bugs.
+
+	cacheTTL time.Duration
+
+	mu    sync.Mutex
+	cache map[string]cachedIndex
 }
+
+type cachedIndex struct {
+	idx        imagesIndex
+	fetchedAt  time.Time
+}
+
+// defaultCacheTTL is the cache horizon when callers don't
+// override it. Five minutes balances "operator burst
+// absorption" against "freshly-published image visibility."
+const defaultCacheTTL = 5 * time.Minute
 
 // NewStreamsResolver builds a resolver. timeout caps every
 // network call to the registry index; 10s is the
 // suggested default (matches Vault/GCP KMS timeouts and
 // gives room for simplestreams indexes that have grown to
 // a few MB).
+//
+// Cache TTL defaults to 5 minutes. Use NewStreamsResolverWithCacheTTL
+// to override (tests pass 0 to disable caching).
 func NewStreamsResolver(timeout time.Duration) *StreamsResolver {
+	return NewStreamsResolverWithCacheTTL(timeout, defaultCacheTTL)
+}
+
+// NewStreamsResolverWithCacheTTL is the full constructor
+// — same as NewStreamsResolver but lets callers control
+// cache TTL. Pass 0 to disable caching (each Resolve
+// fetches fresh).
+func NewStreamsResolverWithCacheTTL(timeout, cacheTTL time.Duration) *StreamsResolver {
 	if timeout <= 0 {
 		timeout = 10 * time.Second
 	}
+	if cacheTTL < 0 {
+		cacheTTL = 0
+	}
 	return &StreamsResolver{
-		client: &http.Client{Timeout: timeout},
+		client:   &http.Client{Timeout: timeout},
+		cacheTTL: cacheTTL,
+		cache:    make(map[string]cachedIndex),
 	}
 }
 
@@ -153,10 +195,51 @@ func (r *StreamsResolver) ResolveImageDigests(ctx context.Context, server, alias
 	if alias == "" {
 		return nil, errors.New("simplestreams resolver: alias is required")
 	}
-	url := strings.TrimRight(server, "/") + indexPath
+	idx, err := r.fetchIndex(ctx, server)
+	if err != nil {
+		return nil, err
+	}
+	return collectDigests(idx, alias), nil
+}
+
+// fetchIndex returns the simplestreams index for `server`,
+// from the in-memory cache if fresh, or from the network
+// otherwise. The cache is best-effort: a concurrent
+// fetch-during-expiry produces at most one extra network
+// call, no correctness impact.
+func (r *StreamsResolver) fetchIndex(ctx context.Context, server string) (imagesIndex, error) {
+	key := strings.TrimRight(server, "/")
+
+	if r.cacheTTL > 0 {
+		r.mu.Lock()
+		entry, ok := r.cache[key]
+		r.mu.Unlock()
+		if ok && time.Since(entry.fetchedAt) < r.cacheTTL {
+			return entry.idx, nil
+		}
+	}
+
+	idx, err := r.fetchIndexFromNetwork(ctx, key)
+	if err != nil {
+		return imagesIndex{}, err
+	}
+
+	if r.cacheTTL > 0 {
+		r.mu.Lock()
+		r.cache[key] = cachedIndex{idx: idx, fetchedAt: time.Now()}
+		r.mu.Unlock()
+	}
+	return idx, nil
+}
+
+// fetchIndexFromNetwork performs the actual HTTP GET +
+// decode. Pulled out so the cache logic stays readable
+// and so tests can stub it via the public Resolve path.
+func (r *StreamsResolver) fetchIndexFromNetwork(ctx context.Context, server string) (imagesIndex, error) {
+	url := server + indexPath
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
+		return imagesIndex{}, fmt.Errorf("build request: %w", err)
 	}
 	// Identify ourselves to the registry. Helps operators
 	// chase down "where is this traffic from" questions
@@ -164,25 +247,35 @@ func (r *StreamsResolver) ResolveImageDigests(ctx context.Context, server, alias
 	req.Header.Set("User-Agent", "containarium-streams-resolver/1.0")
 	resp, err := r.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetch %s: %w", url, err)
+		return imagesIndex{}, fmt.Errorf("fetch %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("fetch %s: status %d: %s", url, resp.StatusCode, strings.TrimSpace(string(body)))
+		return imagesIndex{}, fmt.Errorf("fetch %s: status %d: %s", url, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	var idx imagesIndex
 	if err := json.NewDecoder(resp.Body).Decode(&idx); err != nil {
-		return nil, fmt.Errorf("decode index: %w", err)
+		return imagesIndex{}, fmt.Errorf("decode index: %w", err)
 	}
 	if idx.Format != "products:1.0" {
 		// The simplestreams ecosystem could ship a v2
 		// someday. Don't silently mis-parse — fail noisily
 		// so a Phase B+ follow-up can teach the resolver
 		// the new shape.
-		return nil, fmt.Errorf("unrecognized index format %q (want products:1.0)", idx.Format)
+		return imagesIndex{}, fmt.Errorf("unrecognized index format %q (want products:1.0)", idx.Format)
 	}
-	return collectDigests(idx, alias), nil
+	return idx, nil
+}
+
+// InvalidateCache clears any cached index entries. Useful
+// when the operator knows the registry has just published
+// a new image and wants the daemon to see it before the
+// TTL expires (e.g., after a release-ship workflow).
+func (r *StreamsResolver) InvalidateCache() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cache = make(map[string]cachedIndex)
 }
 
 // collectDigests walks products whose alias list contains

--- a/pkg/core/incus/streams_test.go
+++ b/pkg/core/incus/streams_test.go
@@ -341,3 +341,147 @@ func contains(haystack []string, needle string) bool {
 	}
 	return false
 }
+
+// --- Cache tests (Phase B+ follow-up) ---
+
+// countingServer wraps the fake index server with a
+// per-request hit counter so cache tests can assert
+// "second resolve didn't hit the network."
+func countingServer(t *testing.T) (*httptest.Server, *int) {
+	t.Helper()
+	count := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != indexPath {
+			http.NotFound(w, r)
+			return
+		}
+		count++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(fakeIndex())
+	}))
+	return srv, &count
+}
+
+func TestResolveImageDigests_CacheHitsAvoidNetwork(t *testing.T) {
+	srv, count := countingServer(t)
+	defer srv.Close()
+
+	// 1-hour TTL — both resolves should hit the cache.
+	r := NewStreamsResolverWithCacheTTL(0, time.Hour)
+
+	if _, err := r.ResolveImageDigests(context.Background(), srv.URL, "ubuntu/24.04"); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	if _, err := r.ResolveImageDigests(context.Background(), srv.URL, "alpine/3.19"); err != nil {
+		t.Fatalf("second resolve (different alias, same server): %v", err)
+	}
+	if _, err := r.ResolveImageDigests(context.Background(), srv.URL, "ubuntu/24.04"); err != nil {
+		t.Fatalf("third resolve: %v", err)
+	}
+	if *count != 1 {
+		t.Fatalf("expected 1 network fetch (subsequent resolves served from cache); got %d", *count)
+	}
+}
+
+func TestResolveImageDigests_CacheExpiryTriggersRefetch(t *testing.T) {
+	srv, count := countingServer(t)
+	defer srv.Close()
+
+	// Very short TTL so a sleep crosses expiry.
+	r := NewStreamsResolverWithCacheTTL(0, 30*time.Millisecond)
+
+	if _, err := r.ResolveImageDigests(context.Background(), srv.URL, "ubuntu/24.04"); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if _, err := r.ResolveImageDigests(context.Background(), srv.URL, "ubuntu/24.04"); err != nil {
+		t.Fatalf("post-expiry resolve: %v", err)
+	}
+	if *count != 2 {
+		t.Fatalf("expected 2 network fetches across expiry; got %d", *count)
+	}
+}
+
+func TestResolveImageDigests_ZeroTTLDisablesCache(t *testing.T) {
+	srv, count := countingServer(t)
+	defer srv.Close()
+
+	// TTL=0 → caching off; every resolve hits the
+	// network. Tests in pkg/core/incus that don't want
+	// the cache use this constructor form.
+	r := NewStreamsResolverWithCacheTTL(0, 0)
+
+	for i := 0; i < 3; i++ {
+		if _, err := r.ResolveImageDigests(context.Background(), srv.URL, "ubuntu/24.04"); err != nil {
+			t.Fatalf("resolve %d: %v", i, err)
+		}
+	}
+	if *count != 3 {
+		t.Fatalf("cache should be disabled with TTL=0; got %d fetches", *count)
+	}
+}
+
+func TestResolveImageDigests_CachePerServer(t *testing.T) {
+	srv1, count1 := countingServer(t)
+	defer srv1.Close()
+	srv2, count2 := countingServer(t)
+	defer srv2.Close()
+
+	// One resolver, two servers → each server's index
+	// is cached independently.
+	r := NewStreamsResolverWithCacheTTL(0, time.Hour)
+	for i := 0; i < 3; i++ {
+		_, _ = r.ResolveImageDigests(context.Background(), srv1.URL, "ubuntu/24.04")
+		_, _ = r.ResolveImageDigests(context.Background(), srv2.URL, "ubuntu/24.04")
+	}
+	if *count1 != 1 || *count2 != 1 {
+		t.Fatalf("each server should be fetched once; got srv1=%d srv2=%d", *count1, *count2)
+	}
+}
+
+func TestResolveImageDigests_InvalidateCacheForcesRefetch(t *testing.T) {
+	srv, count := countingServer(t)
+	defer srv.Close()
+	r := NewStreamsResolverWithCacheTTL(0, time.Hour)
+
+	if _, err := r.ResolveImageDigests(context.Background(), srv.URL, "ubuntu/24.04"); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	r.InvalidateCache()
+	if _, err := r.ResolveImageDigests(context.Background(), srv.URL, "ubuntu/24.04"); err != nil {
+		t.Fatalf("post-invalidate resolve: %v", err)
+	}
+	if *count != 2 {
+		t.Fatalf("InvalidateCache should force a refetch; got %d", *count)
+	}
+}
+
+func TestResolveImageDigests_NetworkFailureDoesNotPoisonCache(t *testing.T) {
+	// First call fails → no cache entry → next call
+	// retries the network. Caching a failure would mean
+	// a transient blip locks out CreateContainer for the
+	// full TTL, which is unacceptable.
+	failing := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if failing {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(fakeIndex())
+	}))
+	defer srv.Close()
+
+	r := NewStreamsResolverWithCacheTTL(0, time.Hour)
+	if _, err := r.ResolveImageDigests(context.Background(), srv.URL, "ubuntu/24.04"); err == nil {
+		t.Fatal("expected failure on first resolve")
+	}
+	failing = false
+	got, err := r.ResolveImageDigests(context.Background(), srv.URL, "ubuntu/24.04")
+	if err != nil {
+		t.Fatalf("second resolve should retry the network and succeed: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("retry should have populated the digest set")
+	}
+}


### PR DESCRIPTION
## Summary

- Add a TTL-based in-memory cache to the simplestreams resolver (Phase A landed without one by design; this is the "Phase B+ if warranted" follow-up the design doc anticipated).
- Default TTL 5 minutes — short enough that a freshly-published image becomes verifiable within one pull cycle; long enough to absorb operator bursts.
- A fleet rollout that creates 50 containers against `images.linuxcontainers.org` collapses from 50 index fetches into 1.

## Important properties

- **Failure not cached.** A 5xx blip just means the next resolve retries the network. We don't lock `CreateContainer` out for the full TTL on a transient registry blip.
- **Per-server keys.** `images.linuxcontainers.org` and `cloud-images.ubuntu.com` cached independently.
- **`InvalidateCache()`** for operators who need an immediate refetch (e.g., post-publish hook); runbook recommends `systemctl restart containarium` as the operator-side shortcut.
- **Backwards-compat constructor.** `NewStreamsResolver(timeout)` keeps the previous signature, just defaults to caching. New `NewStreamsResolverWithCacheTTL(timeout, ttl)` for callers who need control; pass `0` to disable.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./pkg/core/incus/...` — 16 tests, all green (10 existing + 6 new)
- [x] Vet clean

## Test highlights

- `CacheHitsAvoidNetwork` — 3 resolves against the same server hit the network once.
- `NetworkFailureDoesNotPoisonCache` — failed first call doesn't prevent a successful retry.
- `InvalidateCacheForcesRefetch` — explicit invalidation forces the next resolve to refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)