### PR TITLE
sec: zero-trust 3.1 Phase C — post-pull image digest defense-in-depth

### DIFF
--- a/docs/security/OPERATOR-SECURITY-RUNBOOK.md
+++ b/docs/security/OPERATOR-SECURITY-RUNBOOK.md
@@ -859,18 +859,36 @@ published a new image and want the daemon to see it
 immediately, restart the daemon (clears the in-process
 cache).
 
-### Limits
+### Post-pull defense-in-depth (Phase C)
 
-- The gate does NOT catch cache tampering between pull
-  and start (an attacker who can write to Incus's local
-  image store after the pull). That's tracked as Phase C
-  defense-in-depth — a post-pull local-store fingerprint
-  re-check.
-- The gate does NOT catch registry-account compromise
-  where the attacker pushes new bytes AND updates the
-  index. Only out-of-band digest custody (signed release
-  records, the publisher's own announcement) catches that
-  class.
+When VERIFY is on, Containarium also re-checks the image
+*after* the pull. It reads the Incus-computed fingerprint
+from `volatile.base_image` and asserts it matches the
+operator's declared digest (with a registry-side
+"two faces of the same image" reconciliation step for the
+common case where the operator pinned one item type and
+Incus stored a different one).
+
+A mismatch deletes the just-created container and returns
+`FailedPrecondition` — the attacker's payload doesn't get
+to run.
+
+Practically: Phase B (pre-pull) catches a compromised
+registry; Phase C (post-pull) catches local-store
+tampering between pull and start. Both run for free when
+VERIFY is on.
+
+### Limits
+- The combined gates do NOT catch registry-account
+  compromise where the attacker pushes new bytes AND
+  updates the index. Only out-of-band digest custody
+  (signed release records, the publisher's own
+  announcement) catches that class.
+- Containers created via non-simplestreams paths (e.g.,
+  snapshot copy, image import) have no
+  `volatile.base_image` and skip the Phase C check;
+  Phase B still runs if VERIFY is on and the image string
+  carries a `@sha256:`.
 
 ## Locking down `/wake/` to a known load balancer
 

--- a/docs/security/ZERO-TRUST-TODO.md
+++ b/docs/security/ZERO-TRUST-TODO.md
@@ -447,13 +447,27 @@ on the internal network. Land them first.
         (gate doesn't catch local-cache tampering or
         registry-account compromise — those are Phase C
         and out-of-band-digest-custody respectively).
-      — **Phase C not yet landed (defense-in-depth).**
-        Post-pull local-store fingerprint re-check
-        deferred — Phase B closes the main threat, Phase
-        C marginal value is lower (would catch local-cache
-        tampering, which requires root on the daemon host
-        and so has other escalation paths). Tracked for a
-        future overnight pass.
+      — **Phase C landed (post-pull defense-in-depth).**
+        `verifyImageDigestPostPull` runs after
+        `s.manager.Create` succeeds in both the sync and
+        async paths. Reads Incus's `volatile.base_image`
+        fingerprint and asserts it matches the
+        operator-declared digest. Fast path: direct
+        equality. Slow path: re-resolve through the
+        registry index and require both digests to
+        co-publish under the same alias ("two faces of
+        the same image" — operator picked rootfs digest,
+        Incus stored combined-archive fingerprint).
+        Mismatch → delete the just-created container and
+        return FailedPrecondition. Skips when verification
+        is off, no `@sha256:` suffix, local alias, or
+        no `volatile.base_image` on the instance (non-
+        simplestreams create path). 6 tests in
+        `image_digest_verify_test.go` cover the skip
+        cases, fast-path equality, and fingerprint-read
+        failure surfacing. New
+        `incus.Backend.GetContainerImageFingerprint` +
+        mock implementation.
 - [x] **3.2** Split `enable_podman` from `enable_privileged`; gate latter on role — `internal/server/container_server.go:164`, `pkg/core/incus/client.go:458-459` (**A-HIGH-3**)
       — New `CONTAINARIUM_PRIVILEGED_PODMAN_POLICY` env var with
         three modes: `all` (default, backwards-compat), `admin-only`

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -301,6 +301,24 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		go func() {
 			info, err := s.manager.Create(opts)
 
+			// Phase 3.1 Phase-C: post-pull verification.
+			// In async mode the HTTP response has already
+			// returned with CREATING; mismatch detection
+			// here can't reach the caller via the response
+			// body, so we delete the container and record
+			// the error in the pending state. The operator
+			// polling for status sees a Done=true,
+			// Error=<digest-mismatch> result.
+			if err == nil && info != nil {
+				if verr := verifyImageDigestPostPull(context.Background(), req.Image, info.Name, s.manager); verr != nil {
+					if delErr := s.manager.Delete(req.Username, true); delErr != nil {
+						log.Printf("[image-digest] async post-pull mismatch: failed to delete container %q: %v", info.Name, delErr)
+					}
+					err = verr
+					info = nil
+				}
+			}
+
 			s.pendingMu.Lock()
 			if pending, exists := s.pendingCreations[req.Username]; exists {
 				pending.Done = true
@@ -339,6 +357,22 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	info, err := s.manager.Create(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create container: %w", err)
+	}
+
+	// Phase 3.1 Phase-C: post-pull defense-in-depth.
+	// Confirm the image landed on disk matches the digest
+	// the operator declared. Mismatch means cache tampering
+	// or an index race — delete the just-created container
+	// rather than leave the attacker's payload running.
+	if err := verifyImageDigestPostPull(ctx, req.Image, info.Name, s.manager); err != nil {
+		// Best-effort cleanup; the error we surface is the
+		// digest mismatch, which is the load-bearing
+		// signal. A failed delete is logged but doesn't
+		// shadow the security event.
+		if delErr := s.manager.Delete(req.Username, true); delErr != nil {
+			log.Printf("[image-digest] failed to delete container %q after post-pull mismatch: %v", info.Name, delErr)
+		}
+		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}
 
 	// Stamp tenant secrets into the LXC's env (best-effort — a

--- a/internal/server/image_digest_verify.go
+++ b/internal/server/image_digest_verify.go
@@ -156,6 +156,96 @@ func verifyImageDigestAgainstRegistry(ctx context.Context, image string) error {
 	return nil
 }
 
+// verifyImageDigestPostPull is the Phase C defense-in-
+// depth check (audit B-HIGH-1, deeper still). After the
+// container has been created, read the Incus-computed
+// fingerprint of the image actually used and assert it
+// matches the digest the operator declared.
+//
+// Catches:
+//   - Local image-store tampering between the registry
+//     pull and the container start (an attacker who can
+//     write to Incus's image cache).
+//   - Pre-pull-verifier index out-of-sync with the actual
+//     pull (e.g., a TTL window where the index was
+//     refreshed but a parallel pull caught the old bytes).
+//
+// Skip semantics match Phase B:
+//   - Verification off → nil.
+//   - No `@sha256:` suffix → nil.
+//   - Image is a local alias (Incus might not have a
+//     fingerprint) → nil with a debug log.
+//
+// On mismatch, the caller is expected to delete the
+// just-created container — leaving it running would
+// preserve the attacker's payload. Container deletion is
+// caller-side so this helper stays read-only.
+//
+// The local fingerprint is one specific SHA-256 (the
+// archive Incus pulled). The operator's digest can match
+// any of the index's published item digests; if the
+// fingerprint isn't directly equal to the operator's
+// digest, we re-resolve through the registry index and
+// check membership — that covers the case where the
+// operator picked the rootfs digest but Incus stored the
+// combined-archive fingerprint.
+func verifyImageDigestPostPull(ctx context.Context, image, containerName string, fpReader interface {
+	GetContainerImageFingerprint(string) (string, error)
+}) error {
+	if !loadDigestVerificationOn() {
+		return nil
+	}
+	declared, ok := extractImageDigest(image)
+	if !ok {
+		return nil
+	}
+	server, alias := splitServerAlias(image)
+	if server == "" {
+		log.Printf("[image-digest] post-pull verification skipped for %q (local alias)", image)
+		return nil
+	}
+
+	fingerprint, err := fpReader.GetContainerImageFingerprint(containerName)
+	if err != nil {
+		return fmt.Errorf("post-pull digest verification: read fingerprint for %q: %w", containerName, err)
+	}
+	if fingerprint == "" {
+		// Incus didn't record a base image — atypical but
+		// possible if the create path bypassed simplestreams
+		// (e.g., a copy-from-snapshot path). Surface as a
+		// log line but don't fail; nothing to compare
+		// against.
+		log.Printf("[image-digest] post-pull verification: container %q has no volatile.base_image; skipping", containerName)
+		return nil
+	}
+
+	// Fast path: Incus fingerprint matches the declared
+	// digest directly.
+	if incus.DigestMatchesSet(declared, []string{fingerprint}) {
+		return nil
+	}
+
+	// Slow path: re-resolve through the registry index.
+	// The operator's digest might match a different item
+	// type than the one Incus chose to store. Both must
+	// appear in the SAME product's index entry — if they
+	// do, that's a legitimate "two faces of the same
+	// image" match.
+	published, err := resolver().ResolveImageDigests(ctx, server, alias)
+	if err != nil {
+		return fmt.Errorf("post-pull digest verification: re-resolve %s/%s: %w", server, alias, err)
+	}
+	declaredMatches := incus.DigestMatchesSet(declared, published)
+	fingerprintMatches := incus.DigestMatchesSet(fingerprint, published)
+	if declaredMatches && fingerprintMatches {
+		// Both are valid items for the same alias —
+		// "two faces of the same image." Accept.
+		return nil
+	}
+	return fmt.Errorf("post-pull digest verification: container %q was created from fingerprint %s, but operator declared %s and the registry's current index for alias %q does not co-publish both digests (local-cache tampering, index race, or stale operator pin)",
+		containerName, fingerprint, declared, alias)
+}
+
 // splitServerAlias maps an image reference to its
 // (server URL, alias) tuple based on the same prefix
 // mapping `pkg/core/incus.parseImageSource` uses. We

--- a/internal/server/image_digest_verify_test.go
+++ b/internal/server/image_digest_verify_test.go
@@ -309,6 +309,110 @@ func pubContains(set []string, want string) bool {
 	return false
 }
 
+// --- Phase C post-pull verification ---
+//
+// The Phase C function takes a small interface
+// (GetContainerImageFingerprint(string) → (string, error))
+// so it can be tested without standing up a real Incus.
+// `fpStub` is the inline stub used by these tests.
+
+type fpStub struct {
+	fingerprint string
+	err         error
+}
+
+func (s *fpStub) GetContainerImageFingerprint(name string) (string, error) {
+	return s.fingerprint, s.err
+}
+
+func TestVerifyDigestPostPull_DefaultIsOff(t *testing.T) {
+	resetVerifyState()
+	t.Setenv(verifyImageDigestEnv, "")
+	stub := &fpStub{fingerprint: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}
+	err := verifyImageDigestPostPull(context.Background(),
+		"images:ubuntu/24.04@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		"alice-container", stub)
+	if err != nil {
+		t.Fatalf("verification OFF should never fail; got %v", err)
+	}
+}
+
+func TestVerifyDigestPostPull_NoDigestSkipped(t *testing.T) {
+	resetVerifyState()
+	t.Setenv(verifyImageDigestEnv, "true")
+	stub := &fpStub{fingerprint: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}
+	err := verifyImageDigestPostPull(context.Background(), "images:ubuntu/24.04", "alice-container", stub)
+	if err != nil {
+		t.Fatalf("no-digest image should pass Phase C; got %v", err)
+	}
+}
+
+func TestVerifyDigestPostPull_LocalAliasSkipped(t *testing.T) {
+	resetVerifyState()
+	t.Setenv(verifyImageDigestEnv, "true")
+	stub := &fpStub{}
+	err := verifyImageDigestPostPull(context.Background(),
+		"ubuntu@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		"alice-container", stub)
+	if err != nil {
+		t.Fatalf("local alias should skip Phase C; got %v", err)
+	}
+}
+
+func TestVerifyDigestPostPull_EmptyFingerprintSkipped(t *testing.T) {
+	// Containers created via non-simplestreams paths
+	// (snapshot copy, image import) won't have
+	// volatile.base_image. The check skips rather than
+	// failing — Phase C is defense-in-depth for the
+	// simplestreams pull path.
+	resetVerifyState()
+	t.Setenv(verifyImageDigestEnv, "true")
+	stub := &fpStub{fingerprint: ""}
+	err := verifyImageDigestPostPull(context.Background(),
+		"images:ubuntu/24.04@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		"alice-container", stub)
+	if err != nil {
+		t.Fatalf("empty fingerprint should skip; got %v", err)
+	}
+}
+
+func TestVerifyDigestPostPull_FastPathFingerprintMatch(t *testing.T) {
+	// When Incus's fingerprint equals the operator's
+	// declared digest directly, we accept without hitting
+	// the registry.
+	resetVerifyState()
+	t.Setenv(verifyImageDigestEnv, "true")
+	digest := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	stub := &fpStub{fingerprint: digest}
+	err := verifyImageDigestPostPull(context.Background(),
+		"images:ubuntu/24.04@sha256:"+digest, "alice-container", stub)
+	if err != nil {
+		t.Fatalf("fast-path direct match should pass; got %v", err)
+	}
+}
+
+func TestVerifyDigestPostPull_FingerprintReadFails(t *testing.T) {
+	resetVerifyState()
+	t.Setenv(verifyImageDigestEnv, "true")
+	stub := &fpStub{err: errStubFP}
+	err := verifyImageDigestPostPull(context.Background(),
+		"images:ubuntu/24.04@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		"alice-container", stub)
+	if err == nil {
+		t.Fatal("fingerprint-read failure should surface as error")
+	}
+	if !strings.Contains(err.Error(), "read fingerprint") {
+		t.Errorf("error should mention fingerprint read; got %v", err)
+	}
+}
+
+// errStubFP is a sentinel error for the read-fails test.
+var errStubFP = &stubFingerprintError{}
+
+type stubFingerprintError struct{}
+
+func (e *stubFingerprintError) Error() string { return "stub: incus unreachable" }
+
 // --- Two-gate misconfiguration warning ---
 //
 // VERIFY only kicks in for `@sha256:` requests. Without

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -679,6 +679,15 @@ func (m *Manager) SetConfig(containerName, key, value string) error {
 	return m.incus.SetConfig(containerName, key, value)
 }
 
+// GetContainerImageFingerprint returns the Incus-computed
+// fingerprint of the image the container was created from
+// (Phase 3.1 Phase-C). Thin delegate so the server-layer
+// digest verifier doesn't need a direct reference to the
+// incus backend.
+func (m *Manager) GetContainerImageFingerprint(containerName string) (string, error) {
+	return m.incus.GetContainerImageFingerprint(containerName)
+}
+
 // WriteFile writes a byte slice into the named container at
 // `path` with `mode` (e.g. "0400"). Used by the Phase 4.3
 // file-delivery secret stamper. Type-asserts to the concrete

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -63,6 +63,9 @@ type Backend interface {
 	// Server info & metrics
 	GetServerInfo() (*api.Server, error)
 	GetContainerMetrics(name string) (*ContainerMetrics, error)
+
+	// Image inspection (Phase 3.1 Phase-C)
+	GetContainerImageFingerprint(containerName string) (string, error)
 }
 
 // DiskDevice represents a disk device configuration
@@ -1131,6 +1134,28 @@ func (c *Client) UnsetEnv(containerName, key string) error {
 		return fmt.Errorf("failed to update container config: %w", err)
 	}
 	return op.Wait()
+}
+
+// GetContainerImageFingerprint returns the Incus-computed
+// fingerprint of the image the container was created from.
+// Incus stores this in `volatile.base_image` at create
+// time; the fingerprint is the SHA-256 of the unified
+// image archive.
+//
+// Phase 3.1 Phase-C uses this to assert that the image
+// landed on disk matches the digest the operator declared
+// at CreateContainer time — a defense-in-depth check
+// against local-cache tampering. Returns empty + nil when
+// the instance has no `volatile.base_image` (e.g., it was
+// created via an alternative path that doesn't go through
+// simplestreams pull). Returns an error only on Incus
+// communication failure.
+func (c *Client) GetContainerImageFingerprint(containerName string) (string, error) {
+	inst, _, err := c.server.GetInstance(containerName)
+	if err != nil {
+		return "", fmt.Errorf("get instance for fingerprint: %w", err)
+	}
+	return inst.Config["volatile.base_image"], nil
 }
 
 func (c *Client) SetConfig(containerName, key, value string) error {

--- a/pkg/core/incus/incustest/mock.go
+++ b/pkg/core/incus/incustest/mock.go
@@ -46,6 +46,9 @@ type MockBackend struct {
 	SetLabelsFunc            func(containerName string, labels map[string]string) error
 	GetServerInfoFunc        func() (*api.Server, error)
 	GetContainerMetricsFunc  func(name string) (*incus.ContainerMetrics, error)
+
+	// Phase 3.1 Phase-C — post-pull fingerprint check.
+	GetContainerImageFingerprintFunc func(name string) (string, error)
 }
 
 // NewMockBackend returns a ready-to-use MockBackend with an initialized
@@ -229,6 +232,13 @@ func (m *MockBackend) GetContainerMetrics(name string) (*incus.ContainerMetrics,
 		return m.GetContainerMetricsFunc(name)
 	}
 	return nil, nil
+}
+
+func (m *MockBackend) GetContainerImageFingerprint(name string) (string, error) {
+	if m.GetContainerImageFingerprintFunc != nil {
+		return m.GetContainerImageFingerprintFunc(name)
+	}
+	return "", nil
 }
 
 func (m *MockBackend) UpdateContainerConfig(name, key, value string) error {


### PR DESCRIPTION
## Summary

- Closes the last deferral in image-digest-verification work. **Every numbered audit item is now `[x]`.**
- Phase B (#284) catches a compromised registry pre-pull; Phase C catches local-image-store tampering between pull and start.
- After `Manager.Create` succeeds in both sync and async paths, read Incus's `volatile.base_image` fingerprint and assert it matches the operator-declared digest. Mismatch → delete the just-created container and return `FailedPrecondition`.

## Match logic

- **Fast path**: Incus fingerprint == operator digest → accept.
- **Slow path**: re-resolve the registry index and require BOTH digests to co-publish under the same alias. This handles the legitimate "operator pinned rootfs digest, Incus stored combined-archive fingerprint" case where two digests are different items of the same image.

## Skip semantics

| Condition | Reason |
| --- | --- |
| Verification off | Default behavior |
| Image has no `@sha256:` suffix | Nothing to verify against |
| Local alias (no resolvable registry) | Phase B already skipped here |
| Container has no `volatile.base_image` | Non-simplestreams create path; operator-visible log |

## Async path handling

The HTTP response has already returned with `CREATING` by the time the goroutine runs. A post-pull mismatch records the error on the pending state, so the operator polling for status sees `Done=true, Error=<mismatch>`.

## New API surface

- `incus.Backend.GetContainerImageFingerprint(name) (string, error)` + `Client` impl + `MockBackend` stub.
- `container.Manager.GetContainerImageFingerprint` thin delegate so the server-layer digest verifier doesn't need a direct backend reference.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/server/... ./pkg/core/container/... ./pkg/core/incus/...` — all green; 6 new Phase C tests
- [x] Vet clean
- [ ] Live registry smoke against `images.linuxcontainers.org` — deferred (needs a daemon + a deliberately tampered local image to exercise the mismatch path; not in CI scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)