### PR TITLE
chore: cut v0.18.0 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-05-22
+
 Ships the **zero-trust security audit remediation** — 46 PRs across 5 phases closing all 41 numbered findings from the internal audit ([`docs/security/ZERO-TRUST-AUDIT.md`](docs/security/ZERO-TRUST-AUDIT.md)). The headline shifts: every API surface is now authenticated by scope, every secret is decryptable through a pluggable KMS, every audit log row is in a tamper-evident hash chain, and every container-image pull is verified against the registry's published digest. Operators get a full runbook at [`docs/security/OPERATOR-SECURITY-RUNBOOK.md`](docs/security/OPERATOR-SECURITY-RUNBOOK.md).
 
 ### Security — Authentication & RBAC


### PR DESCRIPTION
## Summary

Promote the `[Unreleased]` zero-trust rollup to a dated `[0.18.0] - 2026-05-22` section so the changelog matches the version constant.

`pkg/version.Version` was set to `0.18.0` ahead of time in #216; this PR is the docs side of the release cut.

## What's next (manual)

After this merges, the operator-side release work:

```bash
git checkout main && git pull --ff-only
git tag -a v0.18.0 -m "v0.18.0 — zero-trust audit remediation"
git push origin v0.18.0
gh release create v0.18.0 --notes-from-tag --title "Containarium v0.18.0"
```

(Or generate release notes from the CHANGELOG section via `gh release create v0.18.0 --notes "$(awk '/^## \[0\.18\.0\]/,/^## \[0\.17\.0\]/' CHANGELOG.md | sed '$d')"`.)

## Test plan
- [x] CHANGELOG renders cleanly with both `[Unreleased]` (empty) and `[0.18.0]` sections
- [x] Version constant in `pkg/version/version.go` already matches (`0.18.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)