### PR TITLE
docs: design notes — ephemeral sandbox + eBPF network isolation

### DIFF
--- a/docs/EPHEMERAL-SANDBOX-DESIGN.md
+++ b/docs/EPHEMERAL-SANDBOX-DESIGN.md
@@ -1,0 +1,174 @@
+# Ephemeral Sandbox — Design Note
+
+> Status: **Exploration / not yet approved.** Filed in response to
+> the CubeSandbox comparison ([readme](https://github.com/TencentCloud/CubeSandbox))
+> — their `<60ms` MicroVM cold-start exposes a workload Containarium
+> doesn't serve today: short-lived per-task agent sandboxes.
+
+## Where we are today
+
+Every Containarium container is a **persistent LXC**: ZFS-backed
+rootfs, takes seconds-to-minutes to create (Incus pull + provision +
+SSH-key seeding), and is expected to live for the tenant's lifetime.
+This is the right shape for "alice has a dev box she SSHs into for a
+month" — the workload the platform was built for.
+
+It's the wrong shape for "alice's agent needs to run this Python
+snippet, in isolation, for 30 seconds." Today the agent's options
+are:
+
+1. **Run it in alice's persistent box.** Fastest, but no isolation
+   — a malicious snippet has alice's files and credentials.
+2. **Create a fresh container per task.** Strong isolation, but
+   `containarium create` takes ~30-90s; unusable in an agent inner
+   loop.
+3. **Plug an external service (e2b, CubeSandbox).** Solves the
+   problem outside Containarium; loses the unified auth surface and
+   per-tenant accounting.
+
+The gap is real and the workload is growing as agents move from
+"one-shot code-gen" to "loop-and-iterate."
+
+## Goal
+
+A new container class — **ephemeral sandbox** — that:
+
+- Starts in **single-digit seconds** (best-effort `<5s`; not aiming
+  for CubeSandbox's `<60ms` since LXC kernel-share has a different
+  cost model than MicroVM snapshot-clone).
+- Has **no persistent state**: rootfs is tmpfs / overlayfs-on-tmpfs;
+  destroyed on stop.
+- Is **claimed from a per-tenant warm pool** so per-tenant
+  provisioning costs amortize across many tasks.
+- Reuses the existing **JWT scope + ownership authz** surface — no
+  separate auth model.
+- Stays **LXC-based** for v1 (no MicroVM jump). The isolation gap
+  vs. CubeSandbox is acknowledged and documented; operators who
+  need MicroVM-grade isolation can run CubeSandbox alongside.
+
+## Threat model
+
+| Threat | Mitigated? |
+| --- | --- |
+| Sandbox-to-host escape via LXC | Same as today (unprivileged LXC + AppArmor). **No improvement.** |
+| Sandbox-to-sandbox leak via shared bridge | Out of scope here — covered by [`NETWORK-ISOLATION-DESIGN.md`](security/NETWORK-ISOLATION-DESIGN.md). |
+| Tenant-to-tenant leak via warm pool | Mitigated: each tenant has its own pool; sandboxes are destroyed on stop. |
+| Long-lived state survives an attack | Mitigated: no persistent rootfs. |
+| Resource exhaustion (DoS via spawn flood) | Per-tenant rate limit on `create-sandbox`; pool size caps total claim. |
+
+## Architecture sketch
+
+```
+                         ┌──────────────────────────────┐
+                         │   Tenant warm pool           │
+   POST /v1/sandboxes ──>│   (per-tenant, N pre-warmed) │
+   tenant=alice          │                              │
+                         │  [stopped]  [stopped]  ...   │
+                         └────┬─────────────────────────┘
+                              │ claim
+                              v
+                         ┌──────────────────────────────┐
+   <-- sandbox_id ------ │   alice-sb-7af3              │
+                         │   ephemeral=true             │
+                         │   rootfs: overlayfs(tmpfs)   │
+                         │   network: tenant netns      │
+                         └──────────────────────────────┘
+                              │
+                              │ POST /v1/sandboxes/<id>/exec
+                              v
+                         ┌──────────────────────────────┐
+                         │   {stdout, stderr, exit}     │
+                         └──────────────────────────────┘
+                              │
+                              │ DELETE /v1/sandboxes/<id>  (or TTL)
+                              v
+                         [destroyed; pool repopulates]
+```
+
+### Pieces to build
+
+1. **Sandbox lifecycle proto + handlers** — `CreateSandbox`,
+   `ExecInSandbox`, `WriteFileInSandbox`, `ReadFileInSandbox`,
+   `DeleteSandbox`. Mirror the e2b verb shape so an eventual
+   compat-shim is cheap.
+2. **Warm-pool reconciler** — a daemon goroutine that maintains
+   `min_warm` stopped sandboxes per tenant. Topped up on claim,
+   trimmed on idle.
+3. **Ephemeral LXC profile** — `ephemeral: true` + tmpfs rootfs
+   (Incus has both). Container-config keyed by `pool_owner=<tenant>`
+   so the reconciler can find them.
+4. **Claim path** — `sandbox.Claim(tenant)` grabs the next stopped
+   sandbox, renames it to a per-task name, starts it, returns
+   sandbox_id. Triggers async pool-replenish.
+5. **TTL sweeper** — sandboxes auto-deleted after `idle_ttl`
+   (default 5 minutes) to prevent leaks if the agent forgets to
+   delete.
+6. **MCP wrapper** — `mcp__containarium-prod__sandbox_create` /
+   `sandbox_exec` for the agent surface. Scope `sandboxes:write`.
+
+## Phased rollout
+
+| Phase | Scope | Bound |
+| --- | --- | --- |
+| **A** | Sandbox proto + CLI (`containarium sandbox {create,exec,delete}`). Pool size 0; create-on-demand only. Validates the API shape end-to-end. | 1 week |
+| **B** | Per-tenant warm pool reconciler. Configurable `min_warm` per tenant. First-claim latency drops from ~30s to single-digit seconds. | 1 week |
+| **C** | TTL sweeper + per-tenant rate limit on `create-sandbox`. Hardens DoS surface. | 3 days |
+| **D** | MCP `sandbox_*` tools + scope. Agent surface. | 3 days |
+| **E** | e2b-compatible shim at `/v1/sandboxes/e2b/*` (optional). Lets E2B-SDK users point at Containarium without code changes. | 1 week |
+
+Phase A is independently shippable as a primitive even if B-E never
+land — it gives operators a documented "fresh container per task"
+flow that didn't exist.
+
+## Performance budget
+
+Honest targets — not competing with CubeSandbox:
+
+| Metric | Today (`containarium create`) | Target (warm pool) |
+| --- | --- | --- |
+| First-byte to claim | 30-90s | < 5s |
+| Steady-state claim | 30-90s | < 2s |
+| Per-sandbox memory floor | ~80MB (LXC base) | Same |
+| Density per backend | dozens | hundreds |
+
+The two-orders-of-magnitude gap vs. CubeSandbox (`<60ms`) is the
+LXC-vs-MicroVM gap, not a Containarium implementation gap. Calling
+it out so we don't promise what the design can't deliver.
+
+## Open questions
+
+- **Pool sizing policy.** Static per-tenant `min_warm`? Or
+  workload-aware (track recent claim rate, auto-scale)? Static is
+  simpler; workload-aware avoids over-allocation on a quiet tenant.
+- **Cross-tenant pool sharing for cost savings.** Tempting on
+  bare-metal where a 10-tenant deployment with `min_warm=3`
+  pre-allocates 30 sandboxes. A shared pool with per-claim
+  reinitialization is the e2b model. Trade isolation for density.
+- **Image / template story.** v1 ships one ephemeral template
+  (probably python-data-science, mirroring CubeSandbox's
+  `sandbox-code` default). Multi-template needs the same
+  `CreateSandbox(template=...)` shape e2b uses.
+- **Network model.** New per-sandbox netns? Or share the tenant's
+  netns (so sandboxes see the tenant's persistent box)? The
+  eBPF design doc lands the answer.
+
+## Decision log
+
+- **LXC, not MicroVM, for v1.** Operational simplicity (no new
+  hypervisor binary, no kernel-version coordination) > the 100x
+  cold-start gap. Operators with the MicroVM workload can run
+  CubeSandbox alongside.
+- **Per-tenant pools, not shared pools.** Stronger isolation
+  default; cost can be revisited if real workloads show waste.
+- **e2b-compatibility as Phase E, not core.** The verb shape is
+  influenced by e2b but the wire format isn't promised yet; a
+  compat shim is opt-in.
+
+## What this is NOT
+
+- A replacement for the persistent-box default. Persistent boxes
+  remain the right answer for dev-environment workloads.
+- A MicroVM platform. CubeSandbox already exists for that workload
+  and does it well.
+- A code-execution-only product. The sandbox is a generic Linux
+  process surface; code-interp is one of many templates.

--- a/docs/security/NETWORK-ISOLATION-DESIGN.md
+++ b/docs/security/NETWORK-ISOLATION-DESIGN.md
@@ -1,0 +1,228 @@
+# Network Isolation — Design Note
+
+> Status: **Exploration / not yet approved.** Filed in response to
+> the CubeSandbox comparison ([readme](https://github.com/TencentCloud/CubeSandbox))
+> — their CubeVS (eBPF-based virtual switch) closes a gap
+> Containarium's zero-trust audit didn't flag: container-to-container
+> reachability on a shared bridge.
+
+## Where we are today
+
+Containarium creates containers on an Incus-managed bridge
+(default: `incusbr0`), one bridge per backend VM. Every container
+on a backend has an IP on that subnet (typically `10.0.3.0/24`).
+
+The egress path:
+
+- Outbound from a container goes through the bridge, through the
+  host's iptables NAT, out the host's default route. No
+  per-container egress policy.
+- Inbound from outside the backend lands on Caddy / sshpiper on the
+  sentinel and is reverse-proxied to the right container by hostname
+  / port. Caddy is the only inbound path from the public internet.
+
+The container-to-container path:
+
+- **Any container on the same backend can reach any other container
+  on the same backend.** `ping bob-container.lxd` works from
+  `alice-container` if both share the bridge.
+- **Cross-backend** container-to-container is currently blocked
+  because backend VMs don't gossip — each backend's bridge is an
+  island.
+
+This is **adequate for the current "trusted dev box" workload**
+(alice and bob are colleagues, both run their own code, neither has
+incentive to scan the other). It is **inadequate** for any threat
+model that includes a malicious tenant or a tenant whose container
+is compromised — there's no kernel-level fence stopping
+`alice-container` from scanning `bob-container:5432` for an open
+Postgres port.
+
+## Threat model
+
+| Threat | Mitigated today? |
+| --- | --- |
+| Cross-tenant network probe / port scan | **No.** Same-backend bridge is wide open. |
+| Cross-tenant connection (e.g. alice → bob's Postgres) | **No.** |
+| Container-to-internet exfil to attacker-controlled domain | **No.** No egress allowlist; ClamAV catches files-at-rest, not network exfil. |
+| Container-to-host metadata-service abuse (cloud) | **Partial.** Cloud metadata server filtering is host-firewall-dependent; Containarium doesn't enforce. |
+| Container forging source IP / MAC | Partial. Incus default profile restricts MAC; no IP-source-spoof check on the bridge. |
+| Inbound from outside the backend | **Mitigated.** Caddy + sshpiper are the only ingress; everything else is dropped at the cloud firewall. |
+
+The first three rows are the gap eBPF closes.
+
+## Goal
+
+Per-tenant network policy enforced at the **bridge data path**, not
+at the application:
+
+1. **Deny-by-default** container-to-container reachability on a
+   backend. Cross-container traffic only flows through explicitly
+   allowed routes.
+2. **Operator-defined egress allowlist** per tenant — DNS-resolvable
+   domain or CIDR-style IP allowlist; default is "no outbound except
+   to the platform's own DNS + apt mirrors + the operator's
+   declared list."
+3. **Cloud metadata-service block** by default. Containers shouldn't
+   reach `169.254.169.254` unless the operator explicitly opts in.
+4. **Observable** — every denied flow logs a structured event so
+   operators can investigate either a misconfigured allowlist or an
+   actual exfil attempt.
+
+## Prior art
+
+- **Cilium** — production-grade eBPF networking for k8s. Far more
+  than we need (full CNI, BPF dataplane replacing iptables); not
+  designed for non-k8s use.
+- **Tetragon** — Cilium's observability sibling. eBPF-attached
+  process / network event tracing. Useful for the "log denied flow"
+  half.
+- **bpfilter / nftables-bpf** — kernel-level packet filtering with
+  BPF. Less ecosystem, more raw control.
+- **CubeSandbox CubeVS** — purpose-built for sandbox-to-sandbox
+  isolation. Their architecture doc would be the right reference.
+
+Containarium isn't k8s and shouldn't pull Cilium. The right shape is
+**a small set of tc-bpf programs attached to `incusbr0`** that
+implement the policy from a per-tenant rule set the daemon
+maintains.
+
+## Architecture sketch
+
+```
+                  Tenant config (CONTAINARIUM_*_POLICY env / DB)
+                            │
+                            v
+                  ┌──────────────────────────────┐
+                  │  containarium daemon         │
+                  │   policy compiler            │
+                  │   (rules → BPF maps)         │
+                  └──────────────────────────────┘
+                            │
+                            │ bpf(MAP_UPDATE_ELEM)
+                            v
+                  ┌──────────────────────────────┐
+                  │  BPF maps in kernel          │
+                  │   ├── allow_egress_cidr      │
+                  │   ├── allow_egress_domain    │
+                  │   └── allow_intra_tenant     │
+                  └──────────────────────────────┘
+                            ▲
+                            │ tc-bpf (ingress + egress)
+                            │
+              incusbr0 ─────┴──── tenant containers
+                            │
+                            v
+                  ┌──────────────────────────────┐
+                  │  bpf_perf_event_output       │
+                  │   denied-flow log            │  ──> daemon collects
+                  └──────────────────────────────┘     ──> audit log row
+```
+
+### Pieces to build
+
+1. **Policy data model** — `NetworkPolicy { tenant, allow_intra_tenant: bool, egress_cidrs: [CIDR], egress_domains: [string] }`. Proto-first per the
+   project convention.
+2. **BPF programs** — small tc-bpf programs (~200-400 LOC C or Rust)
+   attached to `incusbr0` in TC_INGRESS and TC_EGRESS. Lookup
+   src/dst against BPF maps; pass on allow, drop + perf_event on
+   deny.
+3. **Map-update plumbing in the daemon** — Go side uses
+   `github.com/cilium/ebpf` (popular, well-maintained, no Cilium
+   runtime dependency) to load programs and update maps.
+4. **DNS resolver hook** — for `egress_domains`, periodically resolve
+   to current IPs and populate the CIDR map. Short TTL respect.
+5. **Denied-flow consumer** — daemon reads BPF perf_event ring,
+   writes structured rows to the audit log (`action=net_deny`,
+   `detail={src, dst, proto}`).
+6. **CLI / MCP surface** — `containarium network policy {get, set,
+   list}`; MCP `set_network_policy` scoped `network:write`.
+7. **Operator runbook section** — how to author a policy, how to
+   audit denied flows, how to test in dry-run.
+
+## Phased rollout
+
+| Phase | Scope | Bound |
+| --- | --- | --- |
+| **0 — discovery** | Stand up a throwaway tc-bpf program that counts cross-container packets on a test backend. Validate the assumption that the bridge is the right attach point. Not user-facing. | 1 week |
+| **A — observation only** | Land the BPF programs + map-update plumbing in `log_only` mode. Every denied flow would generate an audit row but no packets are actually dropped. Operators learn what real traffic looks like. | 2 weeks |
+| **B — policy enforcement** | Flip from log-only to drop on a per-tenant `CONTAINARIUM_ENFORCE_NETWORK_POLICY=true`. Default off until ≥1 production tenant has soaked it. | 1 week |
+| **C — egress allowlist** | Domain → CIDR resolver + DNS-TTL refresh loop. Egress now constrainable to a list. | 1 week |
+| **D — cloud metadata block** | Default-deny on `169.254.169.254/32` unless the tenant opts in. | 2 days |
+| **E — CLI / MCP / runbook** | Operator surface + docs. | 1 week |
+
+Total bounded estimate: **5-6 weeks** of focused work. Phase 0 is
+the load-bearing risk — if the bridge attach point doesn't work
+cleanly with Incus's network management, the design needs revisiting
+before any of the user-facing work starts.
+
+## Honest tradeoffs
+
+- **Kernel-version sensitivity.** tc-bpf with the features we want
+  (BPF_MAP_TYPE_LPM_TRIE for CIDR matching, perf_event output) needs
+  Linux ≥ 5.4. Ubuntu 24.04 is fine; the production-runbook needs
+  to call out the floor.
+- **Debuggability cost.** "Why doesn't my container reach X" becomes
+  a multi-layer question (cloud firewall, host iptables, BPF
+  policy). The denied-flow audit log is the load-bearing
+  investigation tool; if it's not good enough operators will just
+  flip enforcement off.
+- **Performance.** tc-bpf adds per-packet latency. On a single-NIC
+  small instance the overhead is <5%; on a high-throughput
+  workload it's more. Phase 0 should measure rather than guess.
+- **Doesn't help cross-backend.** The BPF programs are
+  per-bridge / per-backend. Cross-backend isolation is already
+  there (separate VMs, no inter-backend gossip), so this is mostly
+  fine; the daemon's RPC-over-mTLS path is the cross-backend
+  connection and stays as-is.
+- **Doesn't replace Caddy / sshpiper.** Inbound from the public
+  internet stays through the sentinel; this design is purely about
+  what happens once a packet is inside a backend.
+
+## Open questions
+
+- **Per-container vs per-tenant policy.** Probably per-tenant
+  (matches the existing authz model: tenant owns N containers, all
+  on the same backend). Per-container would be more flexible but
+  adds a level of nesting operators wouldn't use.
+- **Dry-run mode in production.** "Log but don't drop" should
+  probably stay available indefinitely — operators rolling out a
+  new allowlist want to see what would break before flipping
+  enforce. CONTAINARIUM_NETWORK_POLICY_MODE = `off | log | enforce`.
+- **Service discovery within a tenant.** If alice has a webapp
+  container and a postgres container, she wants webapp → postgres
+  to work. The `allow_intra_tenant` flag covers the broad case;
+  per-port allowlist within tenant is a v2.
+- **eBPF program signing.** Future kernel hardening may require
+  signed BPF programs. Land the build-pipeline scaffold now even if
+  signing isn't yet enforced.
+
+## Decision log
+
+- **tc-bpf on the bridge, not on container veth.** Bridge attach is
+  one program per backend, not one per container. Scales with
+  number of backends, not number of containers.
+- **`github.com/cilium/ebpf` for the Go side, not bpf2go from
+  scratch.** Mature library, no Cilium-runtime dependency, common
+  in production Go projects.
+- **Audit log is the policy-decision sink.** Reuses the SHA-256
+  hash-chained audit log shipped in Phase 4.5; no separate event
+  pipeline.
+- **Default OFF.** Same opt-in stance as the rest of the zero-trust
+  rollouts (KMS, image digest verify). No upgrade can degrade an
+  existing deployment.
+
+## What this is NOT
+
+- A k8s NetworkPolicy implementation. Different threat model
+  (multi-tenant SaaS, not multi-namespace inside one trust
+  boundary).
+- A CNI plugin. Incus owns the network; we attach to the bridge.
+- A firewall replacement for the cloud-edge filter. The cloud
+  firewall stays the perimeter; this is the per-tenant interior.
+
+## Related
+
+- [`security/OPERATOR-SECURITY-RUNBOOK.md`](OPERATOR-SECURITY-RUNBOOK.md) — operator-facing security ops; will get a "Pinning per-tenant network policy" section when this lands.
+- [`security/ZERO-TRUST-AUDIT.md`](ZERO-TRUST-AUDIT.md) — original audit; didn't flag this gap, would be amended on landing.
+- [`../EPHEMERAL-SANDBOX-DESIGN.md`](../EPHEMERAL-SANDBOX-DESIGN.md) — answers "what network does a sandbox get" (probably: tenant netns; this design covers what that netns can reach).


### PR DESCRIPTION
## Summary

Two design notes filed in response to the CubeSandbox comparison. Both are **exploration / not yet approved** — drafted in the same shape as the KMS-envelope and image-digest design docs, ready for review before any implementation work begins.

## [`docs/EPHEMERAL-SANDBOX-DESIGN.md`](docs/EPHEMERAL-SANDBOX-DESIGN.md)

Per-tenant warm pool of ephemeral LXCs claimed for short-lived agent tasks. Closes the workload gap where today's options are "run in alice's persistent box (no isolation)" or "spin up a fresh container (30-90s, unusable in an agent inner loop)" or "use e2b/CubeSandbox externally (loses unified auth)."

- Target: **single-digit-second cold start**, no persistent state.
- Stays LXC-based for v1 — no MicroVM jump. The 100x cold-start gap vs CubeSandbox (`<60ms`) is acknowledged as the LXC-vs-MicroVM gap, not a Containarium implementation gap.
- 5-phase rollout, Phase A independently shippable as a primitive.
- Phase E optionally adds an e2b-SDK-compatible shim.

## [`docs/security/NETWORK-ISOLATION-DESIGN.md`](docs/security/NETWORK-ISOLATION-DESIGN.md)

tc-bpf programs on the Incus bridge enforce per-tenant deny-by-default container-to-container reachability + operator-defined egress allowlist + cloud-metadata-service block. **Closes a gap the zero-trust audit didn't flag** — today any container on a backend can reach any other container on the same backend.

- Uses `github.com/cilium/ebpf` for the Go side; **no Cilium runtime dependency**.
- 6-phase rollout, 5-6 weeks bounded. **Phase 0 is load-bearing technical risk** — validate the bridge attach point with Incus before user-facing work starts.
- Default OFF; `log_only` mode kept available indefinitely for soak rollouts.
- Honest tradeoffs called out: kernel-version sensitivity (Linux ≥ 5.4), debuggability cost, performance impact, doesn't replace cloud-edge firewall.

## What this PR is NOT

- Code. Both are design notes only.
- A commitment to build. Both are explicitly "Exploration / not yet approved" — filed for review and to capture the analysis while the CubeSandbox comparison context is fresh.

## Test plan
- [x] Markdown renders cleanly in GitHub
- [x] All internal doc links resolve
- [x] Both docs follow the established pattern from `KMS-ENVELOPE-DESIGN.md` and `IMAGE-DIGEST-VERIFY-DESIGN.md` (where-we-are → threat model → goal → architecture → phased rollout → open questions → decision log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)