### PR TITLE
docs: link the new containarium.dev project site from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ curl https://blog.example.com → hello world
 
 [![Containarium demo: prompt → live HTTPS Python app](docs/images/demo-preview.gif)](https://youtu.be/IBDDD_tb8FY)
 
-🎬 **Watch the full 55s demo:** [youtu.be/IBDDD_tb8FY](https://youtu.be/IBDDD_tb8FY) · 🌐 **Live demo:** [helloworld.demo.containarium.dev](https://helloworld.demo.containarium.dev)
+🌐 **Project site:** [containarium.dev](https://containarium.dev) · 🎬 **55s demo:** [youtu.be/IBDDD_tb8FY](https://youtu.be/IBDDD_tb8FY) · 🚀 **Live app:** [helloworld.demo.containarium.dev](https://helloworld.demo.containarium.dev)
 
 ---
 
@@ -689,8 +689,9 @@ Apache License 2.0 — see [LICENSE](LICENSE).
 
 ## Support
 
+- **Project site**: [containarium.dev](https://containarium.dev) — overview, hosted cloud, GitHub Action for CI, PR previews.
 - **Documentation**: [docs/](docs/) directory.
 - **Issues**: [GitHub Issues](https://github.com/footprintai/Containarium/issues).
 - **Demo video**: [55s walkthrough on YouTube](https://youtu.be/IBDDD_tb8FY).
-- **Live demo**: [helloworld.demo.containarium.dev](https://helloworld.demo.containarium.dev).
+- **Live demo app**: [helloworld.demo.containarium.dev](https://helloworld.demo.containarium.dev).
 - **Organization**: [FootprintAI](https://github.com/footprintai).


### PR DESCRIPTION
## Summary

- Adds backlinks from the OSS README to https://containarium.dev/, the marketing landing page that just went live (built in the `containarium-cloud` repo, deployed to Cloudflare Pages).
- **Top-of-README links row**: prepend the project site; tighten the other two labels for parallel structure (\`project site / 55s demo / live app\`).
- **Support section**: add the project site as the first bullet with a short description of what's there; rename \"Live demo\" → \"Live demo app\" to disambiguate it from the project site.

The README's tagline + hero stay as-is — the OSS README's audience is developers landing on GitHub and the existing framing serves them well. The landing page covers the broader positioning (agents + CI + PR previews + hosted cloud) for non-dev visitors.

## Test plan

- [x] Markdown renders cleanly on GitHub (two-line diff, no structural changes)
- [ ] After merge: spot-check the rendered README on https://github.com/FootprintAI/Containarium/ and click both links
- [ ] Confirm containarium.dev still returns HTTP 200 (already verified at deploy time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)