### PR TITLE
feat(cli): env-var defaults + CLI-only install script (unblocks GHA Action)

### DIFF
--- a/hacks/README.md
+++ b/hacks/README.md
@@ -39,6 +39,42 @@ sudo ./install.sh
 
 ---
 
+### ⚙️ `install-cli.sh` - CLI-Only Installation
+
+Installs only the `containarium` CLI binary — no daemon, no Incus,
+no system service. Use this when you want to drive a *remote*
+Containarium server (CI runner, developer laptop, admin shell)
+instead of running one locally.
+
+**Quick install:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/footprintai/containarium/main/hacks/install-cli.sh | sudo bash
+```
+
+**User-local install (no sudo):**
+```bash
+curl -fsSL https://raw.githubusercontent.com/footprintai/containarium/main/hacks/install-cli.sh \
+  | INSTALL_DIR=$HOME/.local/bin bash
+```
+
+**Drive a remote server with env vars:**
+```bash
+export CONTAINARIUM_HTTP=true
+export CONTAINARIUM_SERVER=https://your-host:8080
+export CONTAINARIUM_TOKEN=<jwt>
+containarium list
+```
+
+The CLI's global flags (`--server`, `--token`, `--http`, `--insecure`,
+`--certs-dir`) all read defaults from matching `CONTAINARIUM_*` env
+vars, so CI workflows and scripts don't need to repeat flags on every
+invocation.
+
+**Supports:** `linux/amd64`, `darwin/amd64`, `darwin/arm64`.
+(`linux/arm64` binaries aren't built — use `make build` from source.)
+
+---
+
 ### 🗑️ `uninstall.sh` - Complete Removal
 
 Removes Containarium completely (keeps Incus by default).

--- a/hacks/install-cli.sh
+++ b/hacks/install-cli.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Install the Containarium CLI binary only — no daemon, no Incus,
+# no system service. Intended for:
+#
+#   - CI runners (GitHub Actions, etc.) that talk to a remote
+#     Containarium server via `--server` / `CONTAINARIUM_SERVER`
+#   - Developer laptops that need the CLI for client work
+#   - Lightweight admin shells that don't host any containers
+#
+# For the full server install (CLI + daemon + Incus + dependencies),
+# use install.sh instead.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/footprintai/containarium/main/hacks/install-cli.sh | sudo bash
+#
+#   # Specific version:
+#   curl -fsSL https://raw.githubusercontent.com/footprintai/containarium/main/hacks/install-cli.sh \
+#     | sudo CONTAINARIUM_VERSION=v0.18.0 bash
+#
+#   # Custom install dir (no sudo needed if writable):
+#   curl -fsSL https://raw.githubusercontent.com/footprintai/containarium/main/hacks/install-cli.sh \
+#     | INSTALL_DIR=$HOME/.local/bin bash
+
+set -euo pipefail
+
+VERSION="${CONTAINARIUM_VERSION:-latest}"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+# Detect OS
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$OS" in
+  linux|darwin) ;;
+  *) echo "Unsupported OS: $OS" >&2; exit 1 ;;
+esac
+
+# Detect architecture (release artifacts use amd64 / arm64)
+ARCH_RAW="$(uname -m)"
+case "$ARCH_RAW" in
+  x86_64|amd64) ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "Unsupported architecture: $ARCH_RAW" >&2; exit 1 ;;
+esac
+
+# Note: as of v0.18.0 the release publishes linux-amd64, darwin-amd64,
+# darwin-arm64. linux-arm64 is not built — surface that early instead
+# of 404ing the download.
+if [ "$OS" = "linux" ] && [ "$ARCH" = "arm64" ]; then
+  echo "Error: linux-arm64 binaries are not currently published." >&2
+  echo "Build from source via 'make build' or open an issue to request." >&2
+  exit 1
+fi
+
+BINARY="containarium-${OS}-${ARCH}"
+if [ "$VERSION" = "latest" ]; then
+  URL="https://github.com/footprintai/containarium/releases/latest/download/${BINARY}"
+else
+  URL="https://github.com/footprintai/containarium/releases/download/${VERSION}/${BINARY}"
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Downloading ${BINARY} from ${URL}"
+curl -fsSL -o "$TMP/containarium" "$URL"
+chmod +x "$TMP/containarium"
+
+# If INSTALL_DIR isn't writable, suggest sudo
+if [ ! -w "$INSTALL_DIR" ]; then
+  echo "Error: ${INSTALL_DIR} is not writable. Re-run with sudo, or set INSTALL_DIR=\$HOME/.local/bin" >&2
+  exit 1
+fi
+
+mv "$TMP/containarium" "${INSTALL_DIR}/containarium"
+echo "Installed: $(${INSTALL_DIR}/containarium --version 2>&1 | head -1)"
+echo
+echo "Talk to a remote Containarium server with:"
+echo "  export CONTAINARIUM_HTTP=true"
+echo "  export CONTAINARIUM_SERVER=https://your-host:8080"
+echo "  export CONTAINARIUM_TOKEN=<jwt>"
+echo "  containarium list"

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/footprintai/containarium/pkg/version"
 	"github.com/spf13/cobra"
@@ -90,14 +91,16 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.containarium.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 
-	// Remote server flags (gRPC mode)
-	rootCmd.PersistentFlags().StringVar(&serverAddr, "server", "", "remote server address (e.g., 35.229.246.67:50051 for gRPC, or http://host:8080 for HTTP)")
-	rootCmd.PersistentFlags().StringVar(&certsDir, "certs-dir", "", "directory containing mTLS certificates (default: ~/.config/containarium/certs)")
-	rootCmd.PersistentFlags().BoolVar(&insecure, "insecure", false, "connect without TLS (not recommended)")
+	// Remote server flags (gRPC mode). Env vars provide defaults so the
+	// CLI can be driven non-interactively (CI, scripts, GitHub Actions)
+	// without repeating flags on every invocation.
+	rootCmd.PersistentFlags().StringVar(&serverAddr, "server", os.Getenv("CONTAINARIUM_SERVER"), "remote server address (env: CONTAINARIUM_SERVER) — e.g., 35.229.246.67:50051 for gRPC, or http://host:8080 for HTTP")
+	rootCmd.PersistentFlags().StringVar(&certsDir, "certs-dir", os.Getenv("CONTAINARIUM_CERTS_DIR"), "directory containing mTLS certificates (env: CONTAINARIUM_CERTS_DIR; default: ~/.config/containarium/certs)")
+	rootCmd.PersistentFlags().BoolVar(&insecure, "insecure", os.Getenv("CONTAINARIUM_INSECURE") == "true", "connect without TLS (env: CONTAINARIUM_INSECURE=true; not recommended)")
 
 	// Remote server flags (HTTP mode)
-	rootCmd.PersistentFlags().BoolVar(&httpMode, "http", false, "use HTTP/REST API instead of gRPC")
-	rootCmd.PersistentFlags().StringVar(&authToken, "token", "", "JWT authentication token for HTTP API")
+	rootCmd.PersistentFlags().BoolVar(&httpMode, "http", os.Getenv("CONTAINARIUM_HTTP") == "true", "use HTTP/REST API instead of gRPC (env: CONTAINARIUM_HTTP=true)")
+	rootCmd.PersistentFlags().StringVar(&authToken, "token", os.Getenv("CONTAINARIUM_TOKEN"), "JWT authentication token for HTTP API (env: CONTAINARIUM_TOKEN)")
 
 	// Version command with verbose flag
 	versionCmd.Flags().BoolVar(&verboseVersion, "verbose", false, "show detailed version information")


### PR DESCRIPTION
## Summary

Two small unblockers for [`FootprintAI/containarium-run`](https://github.com/FootprintAI/containarium-run) (the upcoming GitHub Action that runs CI inside a Containarium box — see [scaffold PR](https://github.com/FootprintAI/containarium-run/pull/1) for context). Neither change affects existing behavior; they're opt-in additions.

### 1. Env-var defaults on the existing remote-targeting flags

The CLI already has \`--server\`, \`--token\`, \`--http\`, \`--insecure\`, \`--certs-dir\` as PersistentFlags on root. This PR makes each one default to its matching env var (\`CONTAINARIUM_SERVER\`, \`CONTAINARIUM_TOKEN\`, etc.) when unset on the command line.

Lets CI workflows do:
\`\`\`yaml
env:
  CONTAINARIUM_HTTP:   'true'
  CONTAINARIUM_SERVER: \${{ secrets.CONTAINARIUM_API_URL }}
  CONTAINARIUM_TOKEN:  \${{ secrets.CONTAINARIUM_TOKEN }}
run: |
  containarium create my-box
  containarium list
  containarium delete my-box -y
\`\`\`

…instead of repeating \`--server\` / \`--token\` on every invocation. Help text updated to document each env var inline.

### 2. \`hacks/install-cli.sh\` — CLI-only installer

\`hacks/install.sh\` installs CLI + daemon + Incus + systemd service — too heavy for CI runners and developer laptops that only need the client. New \`install-cli.sh\` pulls just the \`containarium\` binary from the latest (or specified) release, detects OS+arch, drops it in \`INSTALL_DIR\` (defaults to \`/usr/local/bin\`).

Quick install:
\`\`\`bash
curl -fsSL https://raw.githubusercontent.com/footprintai/containarium/main/hacks/install-cli.sh | sudo bash
\`\`\`

User-local (no sudo):
\`\`\`bash
curl -fsSL .../install-cli.sh | INSTALL_DIR=\$HOME/.local/bin bash
\`\`\`

Supports linux-amd64, darwin-amd64, darwin-arm64 (the platforms the release workflow currently publishes). linux-arm64 errors out early with a clear message since the release doesn't build it.

## Why this PR is small

I initially scoped a much bigger \"add remote-targeting to the CLI\" change before noticing those flags already exist. Real diff is 5 lines of Go + an 80-line shell script + a docs section.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`CONTAINARIUM_SERVER=foo go run ./cmd/containarium/ list --help\` shows env value as flag default
- [x] \`bash -n hacks/install-cli.sh\` syntax-clean
- [ ] Manual: \`curl ...install-cli.sh | sudo bash\` on a fresh Linux VM, verify \`containarium --version\` works
- [ ] Manual: same on macOS

## Follow-ups (not in this PR)

- \`containarium ttl set <box> <duration>\` verb — needed for the GHA Action's failure-mode \"keep box alive 1h\" feature. Tracked in [containarium-run/STATUS.md](https://github.com/FootprintAI/containarium-run/blob/main/STATUS.md).
- Cloud-side \"Connect GitHub\" page that issues a CI-scoped token. Owned by the Cloud team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)