### PR TITLE
feat(agent-box): expose ci-context as MCP resource for CI failure debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ SSH on the client side). Exposes Linux-native operations:
 | `move_file` | Atomic rename with `mkdirp` on destination |
 | `delete_file` | Single-file remove (refuses directories so recursive deletes go via `shell_exec` where blast radius is explicit) |
 
+Resources (read-only data the agent fetches via MCP `resources/read`):
+
+| URI | What it returns |
+|---|---|
+| `containarium://ci-context` | JSON metadata about the current CI run (PR number, commit SHA, failing test, etc.) when the box was kept alive by the FootprintAI/containarium-run GitHub Action after a failed CI run. Returns `{"available": false}` on non-CI boxes so callers never have to special-case errors. |
+
 Optional sandbox: when `AGENTBOX_ROOT` is set, every file-ops path is
 resolved against that root with a boundary-aware prefix check. Default
 unset = no constraint. See

--- a/cmd/agent-box/main.go
+++ b/cmd/agent-box/main.go
@@ -15,6 +15,15 @@
 //
 // The MCP transport is stdio; the SSH command on the user side wraps it.
 //
+// Tools (imperative): shell_exec, read_file, write_file, list_directory,
+// move_file, delete_file, tail_log, process_start, process_list,
+// process_kill. See internal/agentbox/server.go for the canonical list.
+//
+// Resources (read-only data): containarium://ci-context — JSON metadata
+// about the current CI run when the box is kept alive after a failed CI
+// run by the FootprintAI/containarium-run GitHub Action. Returns a stub
+// `{"available": false}` object when the box isn't a CI box.
+//
 // Distinct from cmd/mcp-server/, which is the *platform* MCP for outside-the-
 // box admin operations (create_container, list_containers, etc.). agent-box
 // is the *inside-the-box* MCP — agents working on a single project use this.
@@ -40,9 +49,14 @@ func main() {
 		"containarium-agent-box",
 		version.Version,
 		server.WithToolCapabilities(true),
+		// listChanged=false: our resource set is static for the lifetime
+		// of the process (ci-context is always advertised; its body just
+		// changes based on whether the file exists at read time).
+		server.WithResourceCapabilities(false, false),
 	)
 
 	agentbox.RegisterTools(mcpServer)
+	agentbox.RegisterResources(mcpServer)
 
 	log.Printf("[agent-box] starting MCP server on stdio (version %s)", version.Version)
 	if err := server.ServeStdio(mcpServer); err != nil {

--- a/internal/agentbox/resources.go
+++ b/internal/agentbox/resources.go
@@ -1,0 +1,94 @@
+package agentbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// ciContextResourceURI is the MCP URI agents read to discover what (if
+// anything) the box is being used for. Stable across the box's lifetime;
+// agents are expected to fetch it once on connect.
+const ciContextResourceURI = "containarium://ci-context"
+
+// ciContextPathEnv lets tests (and unusual deployments) point the resource
+// at a non-default path without recompiling. The default lives at the
+// well-known `/workspace/.containarium/` location that the
+// containarium-run GitHub Action writes to.
+const ciContextPathEnv = "CONTAINARIUM_CI_CONTEXT_PATH"
+
+// defaultCIContextPath is the canonical on-box location for the CI context
+// JSON file. Matches what the FootprintAI/containarium-run Action writes
+// when it keeps a failed CI run's box alive for debugging.
+const defaultCIContextPath = "/workspace/.containarium/ci-context.json"
+
+// ciContextAbsentBody is what we return when no ci-context.json exists on
+// the box. We deliberately return valid JSON instead of an error so that
+// agents can always parse the body — `available: false` is the documented
+// "this box isn't a CI box" sentinel.
+const ciContextAbsentBody = `{"schema_version":"1.0","platform":null,"available":false}`
+
+// ciContextPath returns the file path the ci-context resource reads from,
+// honoring the env-var override when set so tests can point it at a
+// tempdir without monkey-patching globals.
+func ciContextPath() string {
+	if p := os.Getenv(ciContextPathEnv); p != "" {
+		return p
+	}
+	return defaultCIContextPath
+}
+
+// registerCIContextResource wires the ci-context MCP resource onto the
+// given server. Mirrors the registerFoo pattern that tools follow in this
+// package so resources are discoverable alongside them.
+func registerCIContextResource(s *server.MCPServer) {
+	resource := mcp.NewResource(
+		ciContextResourceURI,
+		"CI context",
+		mcp.WithResourceDescription(
+			"JSON metadata about the current CI run (PR number, commit SHA, "+
+				"failing test, etc.) — populated by FootprintAI/containarium-run. "+
+				"Empty if the box is not being used for CI.",
+		),
+		mcp.WithMIMEType("application/json"),
+	)
+	s.AddResource(resource, handleCIContextRead)
+}
+
+// handleCIContextRead is the resource handler. The body is opaque
+// pass-through: we read whatever bytes the writer produced and hand them
+// back unparsed. If the file is missing we return a valid-JSON stub so
+// callers never have to special-case errors — an absent file is normal
+// (the box might not be a CI box).
+func handleCIContextRead(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	path := ciContextPath()
+
+	// #nosec G304 -- path comes from a compile-time constant or an
+	// operator-set env var, never from MCP request input.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return []mcp.ResourceContents{
+				mcp.TextResourceContents{
+					URI:      ciContextResourceURI,
+					MIMEType: "application/json",
+					Text:     ciContextAbsentBody,
+				},
+			}, nil
+		}
+		return nil, fmt.Errorf("read ci-context file %s: %w", path, err)
+	}
+
+	return []mcp.ResourceContents{
+		mcp.TextResourceContents{
+			URI:      ciContextResourceURI,
+			MIMEType: "application/json",
+			Text:     string(data),
+		},
+	}, nil
+}

--- a/internal/agentbox/resources_test.go
+++ b/internal/agentbox/resources_test.go
@@ -1,0 +1,117 @@
+package agentbox
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// callCIContextResource invokes the resource handler and returns the
+// (single) text body it produced. Mirrors callTool in agentbox_test.go.
+func callCIContextResource(t *testing.T) mcp.TextResourceContents {
+	t.Helper()
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = ciContextResourceURI
+	out, err := handleCIContextRead(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleCIContextRead: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 resource content, got %d", len(out))
+	}
+	trc, ok := out[0].(mcp.TextResourceContents)
+	if !ok {
+		t.Fatalf("expected TextResourceContents, got %T", out[0])
+	}
+	return trc
+}
+
+func TestCIContext_FilePresentReturnsExactBytes(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "ci-context.json")
+
+	payload := `{"schema_version":"1.0","platform":"github","pr_number":1234,"failing_test":"TestExposePort_TLSHandshake"}`
+	if err := os.WriteFile(p, []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(ciContextPathEnv, p)
+
+	trc := callCIContextResource(t)
+	if trc.URI != ciContextResourceURI {
+		t.Errorf("URI = %q, want %q", trc.URI, ciContextResourceURI)
+	}
+	if trc.MIMEType != "application/json" {
+		t.Errorf("MIMEType = %q, want application/json", trc.MIMEType)
+	}
+	if trc.Text != payload {
+		t.Errorf("Text = %q, want %q (must be byte-for-byte passthrough)", trc.Text, payload)
+	}
+}
+
+func TestCIContext_FileAbsentReturnsValidJSONStub(t *testing.T) {
+	// Point at a path that explicitly doesn't exist; handler must not
+	// error — "no CI context" is a normal state for any non-CI box.
+	dir := t.TempDir()
+	t.Setenv(ciContextPathEnv, filepath.Join(dir, "does-not-exist.json"))
+
+	trc := callCIContextResource(t)
+	if trc.MIMEType != "application/json" {
+		t.Errorf("MIMEType = %q, want application/json", trc.MIMEType)
+	}
+
+	// The stub must be parseable JSON — agents that assume MIME-type
+	// honesty will choke on a non-JSON body.
+	var stub struct {
+		SchemaVersion string `json:"schema_version"`
+		Platform      any    `json:"platform"`
+		Available     bool   `json:"available"`
+	}
+	if err := json.Unmarshal([]byte(trc.Text), &stub); err != nil {
+		t.Fatalf("absent-file stub is not valid JSON: %v\nbody: %q", err, trc.Text)
+	}
+	if stub.Available {
+		t.Errorf("absent stub should have available=false, got true")
+	}
+	if stub.Platform != nil {
+		t.Errorf("absent stub should have platform=null, got %v", stub.Platform)
+	}
+	if stub.SchemaVersion == "" {
+		t.Errorf("absent stub should have schema_version set, got empty")
+	}
+}
+
+func TestCIContext_EnvVarOverrideTakesPrecedence(t *testing.T) {
+	// Verify the env var actually steers reads — without this we could
+	// accidentally hardcode the default in some refactor and the tests
+	// above would still pass (they'd just be silently reading the real
+	// /workspace path, if any).
+	dir := t.TempDir()
+	p := filepath.Join(dir, "custom-location.json")
+	if err := os.WriteFile(p, []byte(`{"marker":"env-override-worked"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(ciContextPathEnv, p)
+
+	if got := ciContextPath(); got != p {
+		t.Errorf("ciContextPath() = %q, want %q (env override should win)", got, p)
+	}
+
+	trc := callCIContextResource(t)
+	if trc.Text != `{"marker":"env-override-worked"}` {
+		t.Errorf("Text = %q, want env-override payload", trc.Text)
+	}
+}
+
+func TestCIContext_DefaultPathWhenEnvUnset(t *testing.T) {
+	// When the env var is empty, fall back to the canonical /workspace
+	// location — that's the contract the containarium-run Action relies
+	// on for the resource to "just work" without configuration.
+	t.Setenv(ciContextPathEnv, "")
+	if got := ciContextPath(); got != defaultCIContextPath {
+		t.Errorf("ciContextPath() with empty env = %q, want %q", got, defaultCIContextPath)
+	}
+}

--- a/internal/agentbox/server.go
+++ b/internal/agentbox/server.go
@@ -15,6 +15,12 @@
 //   - process_list    — list managed processes with PID, command, liveness
 //   - process_kill    — SIGTERM (or SIGKILL with force) and reap
 //
+// Resource taxonomy (v0):
+//
+//   - containarium://ci-context — JSON metadata about the current CI run
+//     (PR, commit, failing test), populated by the containarium-run GitHub
+//     Action. Empty stub when the box isn't being used for CI.
+//
 // File-ops tools enforce a sandbox in this order:
 //   1. AGENTBOX_ROOT env var (strict floor when set).
 //   2. MCP Roots advertised by the client via roots/list (used as the
@@ -42,4 +48,12 @@ func RegisterTools(s *server.MCPServer) {
 	registerFileTools(s)
 	registerTailLogTool(s)
 	registerProcessTools(s)
+}
+
+// RegisterResources wires every agentbox MCP resource onto the given
+// server. Resources are read-only data the agent fetches via the MCP
+// resources/read RPC — distinct from tools, which are imperative calls.
+// Called once at startup by cmd/agent-box, parallel to RegisterTools.
+func RegisterResources(s *server.MCPServer) {
+	registerCIContextResource(s)
 }


### PR DESCRIPTION
## Summary

Adds a new MCP **resource** — `containarium://ci-context` — to the
in-the-box MCP server (`cmd/agent-box`). When a CI run fails, the
companion [`FootprintAI/containarium-run`](https://github.com/FootprintAI/containarium-run)
GitHub Action keeps the failed-CI box alive so an agent can SSH in and
debug. That Action writes a JSON file at
`/workspace/.containarium/ci-context.json` describing the run: PR
number, commit SHA, failing test name, run URL, etc. This change
surfaces that file as an MCP resource so the agent has full context
the moment it connects — no human paste-buffering required.

## Why a resource (not a tool)

MCP resources are the right shape for read-only data the agent fetches
on connect. Tools are for imperative actions. The agent reads
`containarium://ci-context` once at the start of a session and uses it
to drive its plan ("PR #1234 has `TestExposePort_TLSHandshake` failing;
let me read that test's source first").

## Schema (defined by the writer side, opaque pass-through here)

```json
{
  "schema_version": "1.0",
  "platform": "github",
  "repo": "FootprintAI/containarium-cloud",
  "pr_number": 1234,
  "pr_url": "https://github.com/.../pull/1234",
  "pr_title": "feat: add caddy 2.7 support",
  "commit_sha": "a7b2f93f1a...",
  "branch": "feat/caddy-2.7",
  "actor": "alice",
  "run_id": "1234567890",
  "run_url": "https://github.com/.../actions/runs/1234567890",
  "run_attempt": 1,
  "failing_test": "TestExposePort_TLSHandshake",
  "failure_log_tail": "expose_test.go:142: ...",
  "workspace_path": "/workspace"
}
```

agent-box treats this as opaque bytes — it doesn't parse or validate.
The schema is owned by the writer (`containarium-run`) and can evolve
independently.

## What's in the change

- `internal/agentbox/resources.go` — new file. Defines the resource,
  the path constant, the env-var override
  (`CONTAINARIUM_CI_CONTEXT_PATH`) for testability, and the handler.
- `internal/agentbox/resources_test.go` — covers file-present
  (byte-for-byte passthrough), file-absent (returns valid-JSON stub,
  never errors), env-var override precedence, and default-when-unset.
- `internal/agentbox/server.go` — new `RegisterResources(s)` function
  parallel to `RegisterTools(s)`; package doc updated.
- `cmd/agent-box/main.go` — calls `RegisterResources`, declares
  `WithResourceCapabilities(false, false)` (static resource set), and
  top-of-file doc lists tools + resources.
- `README.md` — adds a resources table next to the existing tools
  table under the `agent-box` section.

## Absent-file behavior

When the file doesn't exist (i.e. the box isn't a CI box at all, which
is the common case), the handler returns
`{"schema_version":"1.0","platform":null,"available":false}` rather
than an error. That way every caller can `JSON.parse(body).available`
without special-casing the missing-file error path.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/agentbox/...` passes (full suite + 4 new tests)
- [x] New tests verify: present-file passthrough, absent-file stub is
  valid JSON, env override wins, default path used when env unset
- [ ] Manual: drop a file at `/workspace/.containarium/ci-context.json`
  on a real box, connect with an MCP client, confirm
  `resources/read containarium://ci-context` returns the bytes
- [ ] Manual: with no file present, confirm same call returns the
  `{"available": false}` stub instead of erroring

## Out of scope (separate PRs)

- The writer side in `containarium-run` (different repo)
- No CLI verb — resources are an MCP-only concept by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)