### PR TITLE
feat(cli): ttl set/get verbs for box auto-delete scheduling

### DIFF
--- a/internal/cmd/ttl.go
+++ b/internal/cmd/ttl.go
@@ -1,0 +1,257 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TODO(ttl-server-side): The TTL verbs below are CLI-only for now. The
+// server-side enforcement (so a box actually auto-deletes when its TTL
+// expires) still needs to land. Specifically:
+//
+//   1. Add a `SetContainerTTL` (and `GetContainerTTL`) RPC to
+//      proto/containarium/v1/container.proto, with a `google.api.http`
+//      annotation so grpc-gateway exposes a REST shim (PUT/GET
+//      /v1/containers/{username}/ttl), and regenerate via `make proto`.
+//   2. Persist `expires_at` (and `ttl_set_at`) on the container row in
+//      the daemon's container metadata store.
+//   3. Add a sweeper goroutine in the daemon's main loop that wakes on
+//      a short tick (e.g. every 30s) and force-deletes any container
+//      whose `expires_at` is in the past.
+//   4. Wire `internal/client/{grpc,http}.go` so SetContainerTTL /
+//      GetContainerTTL hit the new endpoint; then swap the
+//      synthetic-Unimplemented stub in ttlClientStub below for the
+//      real client call.
+//
+// Until that lands, this verb is wired up so that callers (notably
+// the containarium-run GitHub Action's "keep on failure" feature)
+// can call `containarium ttl set <box> 1h` and get a clean,
+// non-fatal "server does not support TTL yet" message rather than a
+// confusing error. The Action can then proceed; the box just won't
+// auto-delete and will need manual cleanup. Once the server-side
+// lands, the same CLI call will Just Work — no Action change needed.
+
+// maxTTL caps the duration a caller can request. 168h (7 days) is the
+// upper bound: long enough to cover a long weekend debug session on a
+// failed CI run, short enough that a forgotten box won't bleed cloud
+// budget for a month. Reject anything longer with InvalidArgument so
+// callers see a clear error rather than a silently clamped value.
+const maxTTL = 168 * time.Hour
+
+var ttlCmd = &cobra.Command{
+	Use:   "ttl",
+	Short: "Manage container time-to-live (auto-delete) settings",
+	Long: `Manage the TTL (time-to-live) on a container. When a TTL is set,
+the container is scheduled for automatic deletion after the given
+duration. Useful for ephemeral/CI boxes that should not leak when a
+test run fails and the box is kept open for debugging.
+
+Examples:
+  # Keep this box alive for 1 hour, then auto-delete
+  containarium ttl set alice 1h
+
+  # Update an existing TTL to 30 minutes from now
+  containarium ttl set alice 30m
+
+  # Inspect the current TTL
+  containarium ttl get alice
+
+  # Clear the TTL (box will never auto-delete)
+  containarium ttl unset alice
+
+Maximum allowed TTL is 168h (7 days).`,
+}
+
+var ttlSetCmd = &cobra.Command{
+	Use:   "set <username> <duration>",
+	Short: "Set or update the TTL on a container",
+	Long: `Set the TTL on a container. The container will be auto-deleted
+after the given duration. Duration uses Go's time.ParseDuration
+format ("30m", "1h", "24h", etc.). Maximum allowed: 168h (7 days).
+
+If a TTL is already set, this overrides it (the timer restarts
+from now). To clear an existing TTL, use 'containarium ttl unset'.
+
+Examples:
+  containarium ttl set alice 1h
+  containarium ttl set ci-bob-pr123 30m
+  containarium ttl set debug-box 24h`,
+	Args: cobra.ExactArgs(2),
+	RunE: runTTLSet,
+}
+
+var ttlGetCmd = &cobra.Command{
+	Use:   "get <username>",
+	Short: "Show the current TTL on a container",
+	Long: `Print the TTL setting and the remaining time before
+auto-delete. Prints "no TTL set" if the container has no TTL.
+
+Examples:
+  containarium ttl get alice`,
+	Args: cobra.ExactArgs(1),
+	RunE: runTTLGet,
+}
+
+var ttlUnsetCmd = &cobra.Command{
+	Use:   "unset <username>",
+	Short: "Clear the TTL on a container (it will never auto-delete)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runTTLUnset,
+}
+
+func init() {
+	rootCmd.AddCommand(ttlCmd)
+	ttlCmd.AddCommand(ttlSetCmd)
+	ttlCmd.AddCommand(ttlGetCmd)
+	ttlCmd.AddCommand(ttlUnsetCmd)
+}
+
+// parseTTL parses and validates a Go-format duration string against
+// the maxTTL cap. Returns InvalidArgument-flavoured errors so callers
+// can distinguish "your input was wrong" from "the server choked".
+func parseTTL(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, fmt.Errorf("ttl duration is required")
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w (expected Go duration format like '30m', '1h', '24h')", s, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("ttl duration must be positive, got %s", s)
+	}
+	if d > maxTTL {
+		return 0, fmt.Errorf("ttl duration %s exceeds maximum of %s (7 days); use a smaller value or delete the container manually", s, maxTTL)
+	}
+	return d, nil
+}
+
+func runTTLSet(cmd *cobra.Command, args []string) error {
+	username := args[0]
+	durStr := args[1]
+
+	d, err := parseTTL(durStr)
+	if err != nil {
+		return err
+	}
+
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (ttl scheduling is a server-side feature)")
+	}
+
+	expiresAt := time.Now().Add(d).UTC()
+	if verbose {
+		fmt.Printf("Setting TTL on %s: %s (expires at %s)\n", username, d, expiresAt.Format(time.RFC3339))
+	}
+
+	err = ttlClientSet(username, d)
+	if isUnimplemented(err) {
+		fmt.Printf("⚠ TTL not yet supported by this server (containarium daemon does not implement SetContainerTTL); the box will not auto-delete.\n")
+		fmt.Printf("  Requested: ttl=%s, would have expired at %s.\n", d, expiresAt.Format(time.RFC3339))
+		fmt.Printf("  See the TODO at the top of internal/cmd/ttl.go for the server-side gap.\n")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to set TTL: %w", err)
+	}
+
+	fmt.Printf("✓ TTL set on %s: expires in %s (at %s)\n", username, d, expiresAt.Format(time.RFC3339))
+	return nil
+}
+
+func runTTLGet(cmd *cobra.Command, args []string) error {
+	username := args[0]
+
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (ttl scheduling is a server-side feature)")
+	}
+
+	expiresAt, ok, err := ttlClientGet(username)
+	if isUnimplemented(err) {
+		fmt.Printf("⚠ TTL not yet supported by this server (containarium daemon does not implement GetContainerTTL).\n")
+		fmt.Printf("  See the TODO at the top of internal/cmd/ttl.go for the server-side gap.\n")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get TTL: %w", err)
+	}
+
+	if !ok {
+		fmt.Printf("no TTL set on %s\n", username)
+		return nil
+	}
+
+	remaining := time.Until(expiresAt).Round(time.Second)
+	if remaining <= 0 {
+		fmt.Printf("TTL on %s has expired (was due at %s); awaiting sweeper.\n", username, expiresAt.UTC().Format(time.RFC3339))
+		return nil
+	}
+	fmt.Printf("expires in %s (at %s)\n", remaining, expiresAt.UTC().Format(time.RFC3339))
+	return nil
+}
+
+func runTTLUnset(cmd *cobra.Command, args []string) error {
+	username := args[0]
+
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (ttl scheduling is a server-side feature)")
+	}
+
+	err := ttlClientUnset(username)
+	if isUnimplemented(err) {
+		fmt.Printf("⚠ TTL not yet supported by this server (containarium daemon does not implement ClearContainerTTL); nothing to clear.\n")
+		fmt.Printf("  See the TODO at the top of internal/cmd/ttl.go for the server-side gap.\n")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to clear TTL: %w", err)
+	}
+
+	fmt.Printf("✓ TTL cleared on %s\n", username)
+	return nil
+}
+
+// isUnimplemented returns true if err carries the gRPC Unimplemented
+// status code. We treat that as a soft failure (print a warning,
+// exit 0) rather than a hard error, so callers like the
+// containarium-run Action can wire `containarium ttl set` into their
+// failure path today without breaking when running against an older
+// daemon.
+func isUnimplemented(err error) bool {
+	if err == nil {
+		return false
+	}
+	if s, ok := status.FromError(err); ok && s.Code() == codes.Unimplemented {
+		return true
+	}
+	return false
+}
+
+// ttlClientSet / ttlClientGet / ttlClientUnset are the call sites that
+// will become thin wrappers over `internal/client/{grpc,http}.go`
+// methods once the server-side RPCs ship. Until then they synthesize
+// an Unimplemented status so the handler's friendly-warning path
+// exercises end-to-end.
+//
+// When the real client methods land, replace the body of each with
+// the equivalent of:
+//
+//   if httpMode { return httpClient.SetContainerTTL(username, d) }
+//   return grpcClient.SetContainerTTL(username, d)
+//
+// and the rest of the file stays as-is.
+func ttlClientSet(username string, d time.Duration) error {
+	return status.Errorf(codes.Unimplemented, "SetContainerTTL not implemented by this server")
+}
+
+func ttlClientGet(username string) (time.Time, bool, error) {
+	return time.Time{}, false, status.Errorf(codes.Unimplemented, "GetContainerTTL not implemented by this server")
+}
+
+func ttlClientUnset(username string) error {
+	return status.Errorf(codes.Unimplemented, "ClearContainerTTL not implemented by this server")
+}

--- a/internal/cmd/ttl_test.go
+++ b/internal/cmd/ttl_test.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestParseTTL(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      time.Duration
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "valid 30 minutes",
+			input:   "30m",
+			want:    30 * time.Minute,
+			wantErr: false,
+		},
+		{
+			name:    "valid 1 hour",
+			input:   "1h",
+			want:    time.Hour,
+			wantErr: false,
+		},
+		{
+			name:    "valid 24 hours",
+			input:   "24h",
+			want:    24 * time.Hour,
+			wantErr: false,
+		},
+		{
+			name:    "valid at exactly the cap",
+			input:   "168h",
+			want:    168 * time.Hour,
+			wantErr: false,
+		},
+		{
+			name:    "valid mixed units",
+			input:   "1h30m",
+			want:    time.Hour + 30*time.Minute,
+			wantErr: false,
+		},
+		{
+			name:    "valid seconds",
+			input:   "45s",
+			want:    45 * time.Second,
+			wantErr: false,
+		},
+		{
+			name:      "empty string is rejected",
+			input:     "",
+			wantErr:   true,
+			errSubstr: "required",
+		},
+		{
+			name:      "garbage string is rejected",
+			input:     "not-a-duration",
+			wantErr:   true,
+			errSubstr: "invalid duration",
+		},
+		{
+			name:      "bare number is rejected (no units)",
+			input:     "30",
+			wantErr:   true,
+			errSubstr: "invalid duration",
+		},
+		{
+			name:      "zero duration is rejected",
+			input:     "0s",
+			wantErr:   true,
+			errSubstr: "must be positive",
+		},
+		{
+			name:      "negative duration is rejected",
+			input:     "-1h",
+			wantErr:   true,
+			errSubstr: "must be positive",
+		},
+		{
+			name:      "just over the cap is rejected",
+			input:     "169h",
+			wantErr:   true,
+			errSubstr: "exceeds maximum",
+		},
+		{
+			name:      "way over the cap (30 days) is rejected",
+			input:     "720h",
+			wantErr:   true,
+			errSubstr: "exceeds maximum",
+		},
+		{
+			name:      "cap-plus-one-second is rejected",
+			input:     "168h1s",
+			wantErr:   true,
+			errSubstr: "exceeds maximum",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTTL(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseTTL(%q) = %v, nil; want error containing %q", tt.input, got, tt.errSubstr)
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("parseTTL(%q) error = %q; want substring %q", tt.input, err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTTL(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseTTL(%q) = %v; want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTTL_MaxCapMatchesDocumentation(t *testing.T) {
+	// Guards against accidental edits to the cap constant. The help
+	// text and PR description promise 168h (7 days); if someone bumps
+	// the constant they should bump this test (and the docs) too.
+	if maxTTL != 168*time.Hour {
+		t.Errorf("maxTTL = %v; want 168h — docs and help text reference 7 days", maxTTL)
+	}
+}
+
+func TestIsUnimplemented(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil is not unimplemented",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "plain error is not unimplemented",
+			err:  errors.New("boom"),
+			want: false,
+		},
+		{
+			name: "gRPC Unimplemented is detected",
+			err:  status.Errorf(codes.Unimplemented, "nope"),
+			want: true,
+		},
+		{
+			name: "gRPC NotFound is not Unimplemented",
+			err:  status.Errorf(codes.NotFound, "missing"),
+			want: false,
+		},
+		{
+			name: "gRPC InvalidArgument is not Unimplemented",
+			err:  status.Errorf(codes.InvalidArgument, "bad"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUnimplemented(tt.err); got != tt.want {
+				t.Errorf("isUnimplemented(%v) = %v; want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

The [containarium-run](https://github.com/FootprintAI/containarium-run) GitHub Action has a "keep on failure" feature: when CI tests fail, it keeps the box alive for an hour so a human or agent can SSH in and debug, then auto-deletes. Today there is no CLI way to schedule that auto-delete — without this verb, failure-mode boxes leak indefinitely until someone notices and runs `containarium delete` by hand.

This PR adds the CLI surface that the Action will call. Specifically:

```bash
containarium ttl set <box> 1h        # auto-delete in 1 hour
containarium ttl get <box>           # "expires in 47m23s (at 2026-05-23T22:30:00Z)"
containarium ttl unset <box>         # clear TTL, box will never auto-delete
```

The Action's flow then becomes:

```bash
# in the failure path
containarium ttl set "$BOX_NAME" 1h
```

## Scope — CLI only, server-side TTL enforcement is a follow-up

This is **only the CLI surface**. The server-side enforcement — persisting `expires_at` on the container row plus a sweeper goroutine that force-deletes when expiry passes — is intentionally not in this PR (it touches the proto, the daemon, the container metadata store, and needs its own tests). It is tracked with a clear TODO at the top of `internal/cmd/ttl.go` calling out exactly what needs to land:

1. New `SetContainerTTL` / `GetContainerTTL` RPCs in `proto/containarium/v1/container.proto` with `google.api.http` annotations (so grpc-gateway exposes REST automatically per CLAUDE.md proto-first convention).
2. Persist `expires_at` on the container row.
3. Sweeper goroutine in the daemon main loop, force-deleting expired boxes on a short tick.
4. Wire the real RPC into `internal/client/{grpc,http}.go` and swap the synthetic-Unimplemented stub for the real call.

Until that lands, the CLI verb's `ttlClientSet` / `ttlClientGet` / `ttlClientUnset` synthesize a `codes.Unimplemented` gRPC status, and the handler converts that into a clean stderr warning and exits 0 — see next section.

## "Graceful Unimplemented" behaviour

When the server (the current daemon) doesn't yet implement the TTL endpoints, the verb does **not** return a non-zero exit code. Instead it prints something like:

```
⚠ TTL not yet supported by this server (containarium daemon does not implement SetContainerTTL); the box will not auto-delete.
  Requested: ttl=1h0m0s, would have expired at 2026-05-23T15:30:00Z.
  See the TODO at the top of internal/cmd/ttl.go for the server-side gap.
```

…and exits with code 0. This is deliberate so the containarium-run Action can wire `containarium ttl set` into its failure path **today**, against the current daemon, without that step breaking the Action's overall run. The box just won't auto-delete in the interim — same situation as today, but with a clear log line announcing it.

Once the server-side ships, the exact same CLI call starts actually scheduling the auto-delete — no Action change needed.

## Validation

- `168h` (7 days) hard cap on accepted durations, returned as a clear `InvalidArgument`-flavoured error. Rationale: long enough to cover a long-weekend debug session on a Friday-night CI failure; short enough that a forgotten box can't bleed cloud budget for a month.
- Empty / negative / zero / unparseable durations are rejected at parse time, before any network call.
- The `set` / `get` / `unset` handlers all require `--server` (this is a server-side feature and there is no local-Incus fallback that would meaningfully implement it).

## Conventions

- CLI-first per CLAUDE.md: the verb is a cobra subcommand under `internal/cmd/ttl.go`; no MCP wrapper added yet (will follow once the server side lands, per CLAUDE.md ordering).
- Uses the existing `--server` / `--token` / `--http` persistent flags; no new global flags.
- Style matches `internal/cmd/scale_down.go` (which is the closest existing pattern — also takes a Go duration string and toggles a server-side flag).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/...` passes (new table-driven test covers parse, the 168h cap, the cap-plus-1s edge case, negative durations, empty strings, and gRPC `Unimplemented` detection)
- [x] `containarium ttl --help` shows the three subcommands with examples
- [x] `containarium ttl set foo 200h` exits non-zero with "exceeds maximum of 168h"
- [x] `containarium ttl set foo 1h --server=http://example.com --http` exits 0 with the friendly Unimplemented warning (validated against the synthetic stub)
- [ ] (follow-up) Once `SetContainerTTL` ships on the daemon: end-to-end test that `ttl set` actually causes a box to be deleted on time
- [ ] (follow-up) containarium-run integration: wire `containarium ttl set "\$BOX" 1h` into the keep-on-failure path and verify the box gets a graceful no-op against current daemon and (later) real auto-delete against the patched daemon

## Out of scope (explicit)

- Server-side enforcement (proto RPC + sweeper + persistence) — separate PR, tracked in TODO at top of `internal/cmd/ttl.go`.
- MCP tool wrapper — will follow once the server side lands, per CLAUDE.md "CLI-first, MCP wraps it" ordering.
- Any changes to `containarium-cloud` or `containarium-run` — those repos will start calling this verb in a separate change after this lands.