### PR TITLE
feat(agent-box): add ci-prompt MCP resource — opinionated debug playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Resources (read-only data the agent fetches via MCP `resources/read`):
 | URI | What it returns |
 |---|---|
 | `containarium://ci-context` | JSON metadata about the current CI run (PR number, commit SHA, failing test, etc.) when the box was kept alive by the FootprintAI/containarium-run GitHub Action after a failed CI run. Returns `{"available": false}` on non-CI boxes so callers never have to special-case errors. |
+| `containarium://ci-prompt` | Static markdown playbook telling agents how to debug a failing CI run inside this box (what to read first, how to iterate, what not to do). Same body on every box; pair with `ci-context` for the per-run data. |
 
 Optional sandbox: when `AGENTBOX_ROOT` is set, every file-ops path is
 resolved against that root with a boundary-aware prefix check. Default

--- a/cmd/agent-box/main.go
+++ b/cmd/agent-box/main.go
@@ -19,10 +19,14 @@
 // move_file, delete_file, tail_log, process_start, process_list,
 // process_kill. See internal/agentbox/server.go for the canonical list.
 //
-// Resources (read-only data): containarium://ci-context — JSON metadata
-// about the current CI run when the box is kept alive after a failed CI
-// run by the FootprintAI/containarium-run GitHub Action. Returns a stub
-// `{"available": false}` object when the box isn't a CI box.
+// Resources (read-only data):
+//   - containarium://ci-context — JSON metadata about the current CI run
+//     when the box is kept alive after a failed CI run by the
+//     FootprintAI/containarium-run GitHub Action. Returns a stub
+//     `{"available": false}` object when the box isn't a CI box.
+//   - containarium://ci-prompt  — static markdown playbook that tells an
+//     agent how to behave when debugging that failing CI run. Same
+//     content on every box; pair with ci-context for the per-run data.
 //
 // Distinct from cmd/mcp-server/, which is the *platform* MCP for outside-the-
 // box admin operations (create_container, list_containers, etc.). agent-box

--- a/internal/agentbox/resources.go
+++ b/internal/agentbox/resources.go
@@ -92,3 +92,96 @@ func handleCIContextRead(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.Re
 		},
 	}, nil
 }
+
+// ciPromptResourceURI is the MCP URI for the static "how to debug a
+// failing CI run" playbook. Paired with ciContextResourceURI: ci-context
+// gives the agent the *data* (which PR, which test), ci-prompt gives it
+// the *behavior* (how to investigate, what not to do).
+const ciPromptResourceURI = "containarium://ci-prompt"
+
+// ciPromptBody is the opinionated playbook returned by the ci-prompt
+// resource. Baked into the binary as a constant so the resource is
+// always available with zero filesystem dependencies — the prompt is
+// the same for every Containarium-hosted CI debug session in v0.
+//
+// Keep this prescriptive. The whole point is to give agents clear
+// behavior guidance rather than hedged suggestions.
+const ciPromptBody = `# Debugging a failing CI run in Containarium
+
+You are connected to a Containarium box that was kept alive after a CI
+test failure. Your job is to diagnose and propose a fix — not just
+describe the problem.
+
+## What to read first
+
+1. **` + "`containarium://ci-context`" + `** — JSON with the PR number, commit
+   SHA, branch, failing test name, and last ~50 lines of test output.
+   Read this before anything else; it tells you what to focus on.
+2. **` + "`/workspace/`" + `** — the repo's source code, checked out at the
+   failing commit. The path is also in ` + "`ci-context.workspace_path`" + `.
+
+## How to work
+
+- Use ` + "`shell_exec`" + ` to reproduce the failure. The test command lives in
+  the project's ` + "`.github/containarium.yml`" + ` under the ` + "`test:`" + ` key.
+- Inspect the failing test's source and recent commits on the file
+  (` + "`git log -p -- <path>`" + `). The bug is usually in code touched by this
+  PR, not in stable code.
+- Make minimal, scoped fixes. Don't refactor unrelated code, don't
+  bump dependencies, don't reformat files you aren't touching.
+- Re-run the failing test after each change. Iterate until it passes.
+
+## How to report
+
+When you have a fix:
+
+1. Show the diff (` + "`git diff`" + ` or per-file patches).
+2. Explain in one sentence what the root cause was.
+3. Note any tests you didn't run (e.g. flaky tests skipped, integration
+   tests requiring external services). The operator who reviews your
+   proposal needs to know what's still untested.
+
+## What NOT to do
+
+- **Don't push commits or open PRs from this box.** You don't have
+  repo write credentials, and even if you did, code changes should
+  go through the operator's review on their machine.
+- **Don't modify ` + "`/workspace/.containarium/`" + `.** That directory belongs
+  to the CI tooling and shouldn't be edited.
+- **Don't run destructive commands** (` + "`rm -rf`" + `, ` + "`git reset --hard`" + `,
+  etc.) without first explaining why.
+
+## When you're stuck
+
+If reproduction or diagnosis stalls, write a short summary of what
+you tried and what you observed, then stop. The operator can pick up
+the thread.
+`
+
+// registerCIPromptResource wires the ci-prompt MCP resource onto the
+// given server. Mirrors registerCIContextResource, with a static body
+// instead of a file read — the prompt is the same on every box.
+func registerCIPromptResource(s *server.MCPServer) {
+	resource := mcp.NewResource(
+		ciPromptResourceURI,
+		"CI debug playbook",
+		mcp.WithResourceDescription(
+			"An opinionated prompt for agents debugging a failing CI run "+
+				"inside this box. Read alongside containarium://ci-context.",
+		),
+		mcp.WithMIMEType("text/markdown"),
+	)
+	s.AddResource(resource, handleCIPromptRead)
+}
+
+// handleCIPromptRead returns the static playbook body. No filesystem
+// reads, no error path — the body is a compile-time constant.
+func handleCIPromptRead(_ context.Context, _ mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	return []mcp.ResourceContents{
+		mcp.TextResourceContents{
+			URI:      ciPromptResourceURI,
+			MIMEType: "text/markdown",
+			Text:     ciPromptBody,
+		},
+	}, nil
+}

--- a/internal/agentbox/resources_test.go
+++ b/internal/agentbox/resources_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 )
 
 // callCIContextResource invokes the resource handler and returns the
@@ -114,4 +116,105 @@ func TestCIContext_DefaultPathWhenEnvUnset(t *testing.T) {
 	if got := ciContextPath(); got != defaultCIContextPath {
 		t.Errorf("ciContextPath() with empty env = %q, want %q", got, defaultCIContextPath)
 	}
+}
+
+// callCIPromptResource is the ci-prompt counterpart to
+// callCIContextResource — invokes the handler and returns the single
+// text body it produced.
+func callCIPromptResource(t *testing.T) mcp.TextResourceContents {
+	t.Helper()
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = ciPromptResourceURI
+	out, err := handleCIPromptRead(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleCIPromptRead: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 resource content, got %d", len(out))
+	}
+	trc, ok := out[0].(mcp.TextResourceContents)
+	if !ok {
+		t.Fatalf("expected TextResourceContents, got %T", out[0])
+	}
+	return trc
+}
+
+func TestCIPrompt_HandlerReturnsMarkdownPlaybook(t *testing.T) {
+	trc := callCIPromptResource(t)
+
+	if trc.URI != ciPromptResourceURI {
+		t.Errorf("URI = %q, want %q", trc.URI, ciPromptResourceURI)
+	}
+	if trc.MIMEType != "text/markdown" {
+		t.Errorf("MIMEType = %q, want text/markdown", trc.MIMEType)
+	}
+	if trc.Text == "" {
+		t.Fatal("Text is empty; prompt body must be non-empty")
+	}
+
+	// Lock in the headings that agents will actually look for. If a
+	// future edit drops these, the prompt has either been gutted or
+	// renamed and the test wants to know.
+	wantSubstrings := []string{
+		"# Debugging a failing CI run in Containarium",
+		"## What to read first",
+		"## How to work",
+		"## How to report",
+		"## What NOT to do",
+		"containarium://ci-context",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(trc.Text, want) {
+			t.Errorf("prompt body missing expected substring %q", want)
+		}
+	}
+}
+
+func TestCIPrompt_RegisteredOnServer(t *testing.T) {
+	// Smoke test: a freshly-created server with RegisterResources called
+	// must end up advertising the ci-prompt URI. Catches the kind of
+	// regression where someone adds the handler but forgets to wire it
+	// into RegisterResources.
+	s := server.NewMCPServer("test", "0.0.0",
+		server.WithResourceCapabilities(false, false),
+	)
+	RegisterResources(s)
+
+	req := mcp.ListResourcesRequest{}
+	resp := s.HandleMessage(context.Background(), mustMarshalListResources(t, req))
+	body := jsonString(t, resp)
+	if !strings.Contains(body, ciPromptResourceURI) {
+		t.Errorf("ListResources response missing %q\nbody: %s", ciPromptResourceURI, body)
+	}
+	if !strings.Contains(body, ciContextResourceURI) {
+		t.Errorf("ListResources response missing %q (regression in ci-context registration?)\nbody: %s",
+			ciContextResourceURI, body)
+	}
+}
+
+// mustMarshalListResources builds a minimal JSON-RPC envelope for the
+// resources/list method so we can drive the MCP server in-process.
+func mustMarshalListResources(t *testing.T, _ mcp.ListResourcesRequest) []byte {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "resources/list",
+		"params":  map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("marshal list-resources envelope: %v", err)
+	}
+	return b
+}
+
+// jsonString renders any value as compact JSON for substring assertions
+// on the ListResources response shape.
+func jsonString(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	return string(b)
 }

--- a/internal/agentbox/server.go
+++ b/internal/agentbox/server.go
@@ -20,6 +20,9 @@
 //   - containarium://ci-context — JSON metadata about the current CI run
 //     (PR, commit, failing test), populated by the containarium-run GitHub
 //     Action. Empty stub when the box isn't being used for CI.
+//   - containarium://ci-prompt  — static markdown playbook telling agents
+//     how to debug a failing CI run inside this box. Paired with
+//     ci-context: ci-context is the data, ci-prompt is the behavior.
 //
 // File-ops tools enforce a sandbox in this order:
 //   1. AGENTBOX_ROOT env var (strict floor when set).
@@ -56,4 +59,5 @@ func RegisterTools(s *server.MCPServer) {
 // Called once at startup by cmd/agent-box, parallel to RegisterTools.
 func RegisterResources(s *server.MCPServer) {
 	registerCIContextResource(s)
+	registerCIPromptResource(s)
 }


### PR DESCRIPTION
## Summary

- Adds a second MCP resource to agent-box: `containarium://ci-prompt`,
  a static markdown playbook telling agents how to behave when
  debugging a failing CI run inside a Containarium box.
- Pairs with `containarium://ci-context` (added in #296):
  - `ci-context` = the **data** (which PR, which commit, which test
    failed, last ~50 lines of output) — dynamic, populated by the
    `containarium-run` GitHub Action.
  - `ci-prompt` = the **behavior** (what to read first, how to
    iterate, what NOT to do) — static, baked into the binary.
- Without this pairing, every agent that connects to a debug box
  guesses at the workflow, and some guess badly (push commits from
  inside the box, nuke `/workspace/.containarium/`, refactor unrelated
  code). v0 locks down the expectations in one opinionated playbook
  shared across every Containarium-hosted CI debug session.

## Implementation notes

- The body is embedded as a Go raw-string constant in
  `internal/agentbox/resources.go` next to the ci-context plumbing.
  Chose a constant over `//go:embed` so the whole resource is
  self-contained in one file — trivial to grep and review.
- Handler has no error path: bytes-in-bytes-out, no filesystem
  dependency, same response on every box.
- Wired into `RegisterResources` alongside the existing
  ci-context registration; `cmd/agent-box/main.go` and the README
  resource table now enumerate both URIs.
- Per-org / per-repo customization is explicitly out of scope for v0.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/agentbox/...` passes (new tests:
  `TestCIPrompt_HandlerReturnsMarkdownPlaybook`,
  `TestCIPrompt_RegisteredOnServer`)
- [x] New tests verify URI, MIME type (`text/markdown`), non-empty
  body, presence of key headings, and that
  `RegisterResources` actually advertises the new URI through the
  MCP `resources/list` RPC (catches the regression where someone
  adds the handler but forgets the registration call).
- [ ] Manual smoke test on a real debug box once next CI run fails:
  connect via agent-box MCP, fetch both resources, confirm an
  agent can act on the playbook end-to-end.