### PR TITLE
feat: TTL handler + sweeper wiring — completes the keep-on-failure chain

### DIFF
--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // PendingCreation tracks an async container creation
@@ -1841,7 +1842,7 @@ func toProtoContainer(info *incus.ContainerInfo) *pb.Container {
 		}
 	}
 
-	return &pb.Container{
+	pc := &pb.Container{
 		Name:     info.Name,
 		Username: username,
 		State:    state,
@@ -1866,6 +1867,14 @@ func toProtoContainer(info *incus.ContainerInfo) *pb.Container {
 		AutoSleepEnabled:     info.AutoSleepEnabled,
 		IdleThresholdMinutes: info.IdleThresholdMinutes,
 	}
+	// TTL — populated by SetContainerTTL on the writer side, read here
+	// from the Incus config map. Zero value means no TTL set (parser
+	// silently drops missing/unparseable keys; a corrupted key shouldn't
+	// 5xx the list endpoint).
+	if !info.TTLExpiresAt.IsZero() {
+		pc.TtlExpiresAt = timestamppb.New(info.TTLExpiresAt)
+	}
+	return pc
 }
 
 // GetManager returns the container manager for reuse by other components

--- a/internal/server/container_server_ttl.go
+++ b/internal/server/container_server_ttl.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// maxTTLSeconds caps the duration a caller can request. 604800 seconds
+// (7 days) mirrors the 168h ceiling enforced by `containarium ttl set`
+// in PR #297 and the proto comment on SetContainerTTLRequest. Larger
+// values return InvalidArgument so callers see a clear error rather
+// than a silently clamped value — matches the CLI's behavior on the
+// same input. Centralized here so the cap is enforced both by the CLI
+// (before the round trip, friendly UX) and by the server (defense in
+// depth, in case some other client forgets).
+const maxTTLSeconds int64 = 7 * 24 * 60 * 60
+
+// SetContainerTTL schedules or clears a container's auto-delete time.
+// duration_seconds == 0 clears any existing TTL (the container persists
+// indefinitely). duration_seconds > 0 sets ttl_expires_at to now() +
+// duration. Capped at maxTTLSeconds; larger values return
+// InvalidArgument. Persistence model: the wall-clock expiry is stamped
+// onto the Incus container config under user.containarium.ttl_expires_at
+// (RFC3339), so it survives daemon restart without a separate store.
+// Read by the ttlsweeper goroutine on every tick (PR #299) and by
+// toProtoContainer on the list/get read paths so callers see the
+// committed value.
+//
+// Mirrors the username-as-name convention of the other per-container
+// RPCs (ToggleAutoSleep, StopContainer, ...): req.Name carries the
+// username, the handler resolves <username>-container under the hood
+// via manager.Get. Consistency matters because the CLI in PR #297
+// passes the bare username and the gRPC stubs flow that value into
+// req.Name verbatim.
+func (s *ContainerServer) SetContainerTTL(ctx context.Context, req *pb.SetContainerTTLRequest) (*pb.SetContainerTTLResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeContainersWrite); err != nil {
+		return nil, err
+	}
+	if req.Name == "" {
+		return nil, status.Error(codes.InvalidArgument, "name is required")
+	}
+	if req.DurationSeconds < 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "duration_seconds must be >= 0, got %d", req.DurationSeconds)
+	}
+	if req.DurationSeconds > maxTTLSeconds {
+		return nil, status.Errorf(codes.InvalidArgument, "duration_seconds %d exceeds maximum of %d (7 days)", req.DurationSeconds, maxTTLSeconds)
+	}
+
+	// Treat req.Name as the bare username (matches the per-container
+	// RPC convention; see CLI PR #297 which sends the bare username
+	// through ttlClientSet). manager.Get appends "-container".
+	username := req.Name
+	if err := auth.AuthorizeTenant(ctx, username); err != nil {
+		return nil, err
+	}
+
+	info, err := s.manager.Get(username)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "container for user %s not found: %v", username, err)
+	}
+	if info.Role.IsCoreRole() {
+		return nil, status.Errorf(codes.InvalidArgument, "container %s is a core container; TTL is for user containers only", info.Name)
+	}
+	containerName := info.Name
+
+	resp := &pb.SetContainerTTLResponse{}
+	if req.DurationSeconds == 0 {
+		// Clear: remove the key entirely so parseTTLExpiresAt and the
+		// sweeper see "absent" rather than "empty string". UnsetConfig
+		// is idempotent — clearing an already-clear TTL is a no-op
+		// followed by a no-op response (TtlExpiresAt zero-value).
+		if err := s.manager.UnsetConfig(containerName, incus.TTLExpiresAtKey); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to clear %s: %v", incus.TTLExpiresAtKey, err)
+		}
+		log.Printf("[ttl] cleared container=%s", containerName)
+		return resp, nil
+	}
+
+	// Set: stamp now() + duration in UTC RFC3339 so the sweeper's
+	// time.Parse round-trips with the same precision. Capping is
+	// already enforced above.
+	expiresAt := time.Now().Add(time.Duration(req.DurationSeconds) * time.Second).UTC()
+	if err := s.manager.SetConfig(containerName, incus.TTLExpiresAtKey, expiresAt.Format(time.RFC3339)); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to set %s: %v", incus.TTLExpiresAtKey, err)
+	}
+	log.Printf("[ttl] set container=%s expires_at=%s (duration=%ds)", containerName, expiresAt.Format(time.RFC3339), req.DurationSeconds)
+	resp.TtlExpiresAt = timestamppb.New(expiresAt)
+	return resp, nil
+}

--- a/internal/server/container_server_ttl_test.go
+++ b/internal/server/container_server_ttl_test.go
@@ -1,0 +1,260 @@
+package server
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ttlMockCall is a single observed Set/UnsetConfig invocation. We
+// capture both flavours into the same channel so the assertions can
+// read "what calls did the handler make, in order" without juggling
+// two slices.
+type ttlMockCall struct {
+	kind  string // "set" or "unset"
+	name  string
+	key   string
+	value string
+}
+
+// newTTLTestServer wires a ContainerServer over a *MockBackend seeded
+// with the given containers, and returns the captured-call slice the
+// caller can inspect after a handler invocation. Mirrors the shape of
+// newAutoSleepTestServer from toggle_auto_sleep_test.go so the two
+// container-handler test files stay readable side-by-side.
+func newTTLTestServer(t *testing.T, seed map[string]*incus.ContainerInfo) (*ContainerServer, *[]ttlMockCall, *incustest.MockBackend) {
+	t.Helper()
+	mock := incustest.NewMockBackend()
+	for name, info := range seed {
+		mock.Containers[name] = info
+	}
+	var mu sync.Mutex
+	calls := make([]ttlMockCall, 0, 4)
+	mock.SetConfigFunc = func(name, key, value string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, ttlMockCall{kind: "set", name: name, key: key, value: value})
+		// Persist into the mock so subsequent Get reflects the change.
+		if c, ok := mock.Containers[name]; ok && key == incus.TTLExpiresAtKey {
+			if t2, err := time.Parse(time.RFC3339, value); err == nil {
+				c.TTLExpiresAt = t2
+			}
+		}
+		return nil
+	}
+	mock.UnsetConfigFunc = func(name, key string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, ttlMockCall{kind: "unset", name: name, key: key})
+		if c, ok := mock.Containers[name]; ok && key == incus.TTLExpiresAtKey {
+			c.TTLExpiresAt = time.Time{}
+		}
+		return nil
+	}
+	mgr := container.NewWithBackend(mock)
+	return &ContainerServer{manager: mgr}, &calls, mock
+}
+
+// TestSetContainerTTL_ValidDurationStampsExpiry — happy path: a 1h TTL
+// yields one SetConfig call with an RFC3339 value ~1h in the future,
+// and the response echoes the same instant.
+func TestSetContainerTTL_ValidDurationStampsExpiry(t *testing.T) {
+	s, calls, _ := newTTLTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Running"},
+	})
+	before := time.Now().UTC()
+	resp, err := s.SetContainerTTL(testCtx(), &pb.SetContainerTTLRequest{
+		Name:            "alice",
+		DurationSeconds: 3600,
+	})
+	after := time.Now().UTC()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil || resp.TtlExpiresAt == nil {
+		t.Fatalf("response missing TtlExpiresAt: %+v", resp)
+	}
+	got := resp.TtlExpiresAt.AsTime()
+	lo := before.Add(1 * time.Hour).Add(-time.Second)
+	hi := after.Add(1 * time.Hour).Add(time.Second)
+	if got.Before(lo) || got.After(hi) {
+		t.Errorf("response expiry %s outside [%s, %s]", got, lo, hi)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 SetConfig call, got %d: %+v", len(*calls), *calls)
+	}
+	c := (*calls)[0]
+	if c.kind != "set" || c.name != "alice-container" || c.key != incus.TTLExpiresAtKey {
+		t.Errorf("call = %+v, want set alice-container/%s", c, incus.TTLExpiresAtKey)
+	}
+	stamped, err := time.Parse(time.RFC3339, c.value)
+	if err != nil {
+		t.Fatalf("stamped value %q not RFC3339: %v", c.value, err)
+	}
+	// The stamped value must match the response (modulo nanosecond
+	// truncation — RFC3339 has 1s resolution, the response carries
+	// the original Time).
+	if !stamped.Equal(got.Truncate(time.Second)) {
+		t.Errorf("stamped %s != response %s (truncated)", stamped, got.Truncate(time.Second))
+	}
+}
+
+// TestSetContainerTTL_DurationExceedsMax — the cap rejects 8 days.
+func TestSetContainerTTL_DurationExceedsMax(t *testing.T) {
+	s, calls, _ := newTTLTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Running"},
+	})
+	_, err := s.SetContainerTTL(testCtx(), &pb.SetContainerTTLRequest{
+		Name:            "alice",
+		DurationSeconds: 8 * 24 * 60 * 60, // 8 days
+	})
+	if err == nil {
+		t.Fatal("expected error for duration > 7 days")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("error = %v, want InvalidArgument status", err)
+	}
+	if len(*calls) != 0 {
+		t.Errorf("rejected request must not call Set/UnsetConfig, got %d calls: %+v", len(*calls), *calls)
+	}
+}
+
+// TestSetContainerTTL_NegativeDuration — negative values are rejected
+// (vs. silently clamped to 0 = clear) so a typo doesn't accidentally
+// nuke the existing TTL.
+func TestSetContainerTTL_NegativeDuration(t *testing.T) {
+	s, calls, _ := newTTLTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Running"},
+	})
+	_, err := s.SetContainerTTL(testCtx(), &pb.SetContainerTTLRequest{
+		Name:            "alice",
+		DurationSeconds: -1,
+	})
+	if err == nil {
+		t.Fatal("expected error for negative duration")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("error = %v, want InvalidArgument status", err)
+	}
+	if len(*calls) != 0 {
+		t.Errorf("rejected request must not call Set/UnsetConfig, got %d calls: %+v", len(*calls), *calls)
+	}
+}
+
+// TestSetContainerTTL_ZeroClearsKey — duration_seconds == 0 takes the
+// unset path: one UnsetConfig call, response TtlExpiresAt unset.
+func TestSetContainerTTL_ZeroClearsKey(t *testing.T) {
+	existing := time.Now().Add(30 * time.Minute).UTC().Truncate(time.Second)
+	s, calls, _ := newTTLTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {
+			Name:         "alice-container",
+			State:        "Running",
+			TTLExpiresAt: existing,
+		},
+	})
+	resp, err := s.SetContainerTTL(testCtx(), &pb.SetContainerTTLRequest{
+		Name:            "alice",
+		DurationSeconds: 0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.TtlExpiresAt != nil {
+		t.Errorf("clear response should have nil TtlExpiresAt, got %v", resp.TtlExpiresAt)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 UnsetConfig call, got %d: %+v", len(*calls), *calls)
+	}
+	c := (*calls)[0]
+	if c.kind != "unset" || c.name != "alice-container" || c.key != incus.TTLExpiresAtKey {
+		t.Errorf("call = %+v, want unset alice-container/%s", c, incus.TTLExpiresAtKey)
+	}
+}
+
+// TestSetContainerTTL_UnknownContainer — NotFound, not Internal.
+func TestSetContainerTTL_UnknownContainer(t *testing.T) {
+	mock := incustest.NewMockBackend()
+	mock.GetContainerFunc = func(name string) (*incus.ContainerInfo, error) {
+		return nil, errors.New("container not found: " + name)
+	}
+	s := &ContainerServer{manager: container.NewWithBackend(mock)}
+	_, err := s.SetContainerTTL(testCtx(), &pb.SetContainerTTLRequest{
+		Name:            "ghost",
+		DurationSeconds: 3600,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing container")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.NotFound {
+		t.Errorf("error = %v, want NotFound status", err)
+	}
+}
+
+// TestSetContainerTTL_MissingName — universal precondition check.
+func TestSetContainerTTL_MissingName(t *testing.T) {
+	s := &ContainerServer{}
+	_, err := s.SetContainerTTL(testCtx(), &pb.SetContainerTTLRequest{DurationSeconds: 3600})
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("error = %v, want InvalidArgument status", err)
+	}
+}
+
+// TestSetContainerTTL_CoreContainerRejected — core containers must
+// never carry a TTL (the autosleep handler enforces the same rule;
+// keep the symmetry so an operator can't pin a 1h TTL on
+// caddy-container by accident).
+func TestSetContainerTTL_CoreContainerRejected(t *testing.T) {
+	s, calls, _ := newTTLTestServer(t, map[string]*incus.ContainerInfo{
+		"caddy-container": {
+			Name:  "caddy-container",
+			State: "Running",
+			Role:  incus.RoleCaddy,
+		},
+	})
+	_, err := s.SetContainerTTL(testCtx(), &pb.SetContainerTTLRequest{
+		Name:            "caddy",
+		DurationSeconds: 3600,
+	})
+	if err == nil {
+		t.Fatal("expected error for core container")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("error = %v, want InvalidArgument status", err)
+	}
+	if len(*calls) != 0 {
+		t.Errorf("core rejection must not call Set/UnsetConfig, got %d calls: %+v", len(*calls), *calls)
+	}
+}
+
+// TestSetContainerTTL_BoundaryMaxAccepted — exactly 7 days is OK; one
+// second over is rejected (covered above). Locks the inclusive
+// boundary so it doesn't drift on a future refactor.
+func TestSetContainerTTL_BoundaryMaxAccepted(t *testing.T) {
+	s, _, _ := newTTLTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Running"},
+	})
+	resp, err := s.SetContainerTTL(testCtx(), &pb.SetContainerTTLRequest{
+		Name:            "alice",
+		DurationSeconds: 7 * 24 * 60 * 60,
+	})
+	if err != nil {
+		t.Fatalf("7d should be accepted, got error: %v", err)
+	}
+	if resp == nil || resp.TtlExpiresAt == nil {
+		t.Errorf("7d accept should return TtlExpiresAt, got %+v", resp)
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -38,6 +38,7 @@ import (
 	corecryptosecrets "github.com/footprintai/containarium/pkg/core/secrets"
 	zapscanner "github.com/footprintai/containarium/internal/zap"
 	"github.com/footprintai/containarium/internal/traffic"
+	"github.com/footprintai/containarium/internal/ttlsweeper"
 	"github.com/footprintai/containarium/internal/wake"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/footprintai/containarium/pkg/version"
@@ -155,6 +156,7 @@ type DualServer struct {
 	zapStore              *zapscanner.Store
 	peerPool              *PeerPool
 	autoSleepManager      *autosleep.Manager
+	ttlSweeperManager     *ttlsweeper.Manager // ephemeral CI box auto-delete (#299)
 	secretsReconciler     *secretsReconciler // Phase 4.3 Phase B-3
 	startTime             time.Time
 }
@@ -1497,6 +1499,27 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		ds.autoSleepManager.Start(ctx)
 	}
 
+	// Start TTL sweeper (#299 scaffold + this PR's wiring). Reads
+	// user.containarium.ttl_expires_at off each container's Incus
+	// config every 60s; when the wall clock crosses the stamped
+	// expiry (minus a 30s clock-skew grace), routes the deletion
+	// through DeleteContainer so the audit + event + Caddy-cascade
+	// hooks all fire. Always-on by daemon policy; per-container
+	// opt-in (the TTL key must be set explicitly via SetContainerTTL).
+	// Naturally cooperates with autosleep — if both ticks decide on
+	// the same container in the same second, deletion is final and
+	// the autosleep stop becomes a no-op against a missing container.
+	if incusClient, err := incus.New(); err != nil {
+		log.Printf("[ttlsweeper] incus client unavailable: %v (sweeper disabled)", err)
+	} else {
+		ds.ttlSweeperManager = ttlsweeper.NewManager(
+			&ttlsweeperIncusAdapter{ic: incusClient},
+			&ttlsweeperDeleter{cs: ds.containerServer},
+			ttlsweeper.Options{},
+		)
+		ds.ttlSweeperManager.Start(ctx)
+	}
+
 	// Phase 4.3 Phase B-3 — file-mode secret reconciler.
 	// Periodically re-stamps tmpfs secrets on running
 	// containers so a bare `incus restart` not routed
@@ -1706,6 +1729,9 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		}
 		if ds.autoSleepManager != nil {
 			ds.autoSleepManager.Stop()
+		}
+		if ds.ttlSweeperManager != nil {
+			ds.ttlSweeperManager.Stop()
 		}
 		if ds.secretsReconciler != nil {
 			ds.secretsReconciler.Stop()

--- a/internal/server/ttlsweeper_adapter.go
+++ b/internal/server/ttlsweeper_adapter.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/ttlsweeper"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// ttlsweeperIncusAdapter bridges *incus.Client → ttlsweeper.IncusClient.
+//
+// The ttlsweeper package was deliberately decoupled from
+// pkg/core/incus and pkg/pb to keep its decision logic pure-Go and
+// trivially testable; the wiring lives here on the daemon side, where
+// the binding to the real Incus client costs ~15 lines and keeps the
+// dependency arrow pointing the right way (daemon → sweeper, never
+// sweeper → daemon).
+//
+// The adapter strips ListContainers down to just (Name, TTLExpiresAt)
+// — the only fields Decide actually consumes — and skips core
+// containers entirely. Core containers must never carry a TTL; this
+// is defense in depth in case a writer somewhere stamps the key by
+// mistake. Decide would still skip them (because no one should be
+// setting the key in the first place), but excluding here means a
+// stray key never even reaches the decision function.
+type ttlsweeperIncusAdapter struct {
+	ic *incus.Client
+}
+
+// ListContainers returns one ContainerView per non-core container
+// the Incus client knows about. Containers whose TTL key parses as
+// the zero time (missing/empty/malformed) carry a nil TTLExpiresAt
+// so Decide's "skip" branch is naturally exercised.
+func (a *ttlsweeperIncusAdapter) ListContainers() ([]ttlsweeper.ContainerView, error) {
+	raw, err := a.ic.ListContainers()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ttlsweeper.ContainerView, 0, len(raw))
+	for i := range raw {
+		c := raw[i]
+		if c.Role.IsCoreRole() {
+			continue
+		}
+		v := ttlsweeper.ContainerView{Name: c.Name}
+		if !c.TTLExpiresAt.IsZero() {
+			t := c.TTLExpiresAt
+			v.TTLExpiresAt = &t
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// ttlsweeperDeleter routes the sweeper's "delete this container"
+// requests through the existing DeleteContainer RPC plumbing so audit
+// logging, event emission, route/Caddy cascade cleanup, the IP-map
+// refresh, and the Guacamole-deregister step all fire — same code
+// path a human invocation of `containarium delete` would take.
+//
+// Bypassing the handler and calling incus.Client.DeleteContainer
+// directly would technically delete the LXC but leave Caddy routes
+// pointing at a dead upstream IP (502s on the public hostname),
+// orphan TLS-cert ACME renewals, and skip every event subscriber that
+// downstream observers rely on. So we go through the handler.
+//
+// reason is propagated as a structured log line — the sweeper already
+// logs a [ttlsweeper] line on success; the duplicate log here is
+// intentional, it bridges the sweeper's log namespace and the
+// handler's existing log namespace so an operator grepping either
+// surface sees the event.
+type ttlsweeperDeleter struct {
+	cs *ContainerServer
+}
+
+func (d *ttlsweeperDeleter) DeleteContainer(ctx context.Context, name, reason string) error {
+	// Promote to the daemon-internal identity so the handler's authz
+	// checks pass (mirrors what StopForAutoSleep does for the
+	// autosleep ticker).
+	ctx = auth.ContextWithSystemIdentity(ctx)
+
+	// The container key is "<username>-container" in this codebase
+	// (see ToggleAutoSleep, StopContainer, etc.). Strip the suffix
+	// to recover the username the handler expects in
+	// DeleteContainerRequest.
+	username := name
+	const suffix = "-container"
+	if len(name) > len(suffix) && name[len(name)-len(suffix):] == suffix {
+		username = name[:len(name)-len(suffix)]
+	} else {
+		// Defensive: anything that doesn't fit the "-container"
+		// convention isn't a user box the sweeper should delete.
+		// Don't bypass that check by guessing a username.
+		return fmt.Errorf("ttlsweeper: refusing to delete %q (not in <username>-container form)", name)
+	}
+
+	log.Printf("[ttl] auto-deleting container=%s reason=%q", name, reason)
+	_, err := d.cs.DeleteContainer(ctx, &pb.DeleteContainerRequest{
+		Username: username,
+		// Force=true: TTL expiry is a "delete now" event, not a
+		// "ask the container nicely" event. The CI box may well be
+		// in a broken state (that's often why it was kept); a
+		// graceful stop request could hang and leave the box
+		// straddling the TTL deadline.
+		Force: true,
+	})
+	return err
+}

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -679,6 +679,15 @@ func (m *Manager) SetConfig(containerName, key, value string) error {
 	return m.incus.SetConfig(containerName, key, value)
 }
 
+// UnsetConfig removes an arbitrary Incus config key from a container.
+// Used by SetContainerTTL's clear path (duration_seconds == 0) so the
+// "no TTL" state is represented by key absence — symmetric with
+// UnsetEnv for the OTel keys. Idempotent: missing keys are not an
+// error on the backend.
+func (m *Manager) UnsetConfig(containerName, key string) error {
+	return m.incus.UnsetConfig(containerName, key)
+}
+
 // GetContainerImageFingerprint returns the Incus-computed
 // fingerprint of the image the container was created from
 // (Phase 3.1 Phase-C). Thin delegate so the server-layer

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -48,6 +48,7 @@ type Backend interface {
 
 	// Config & devices
 	SetConfig(containerName, key, value string) error
+	UnsetConfig(containerName, key string) error
 	SetDeviceSize(containerName, deviceName, size string) error
 	UpdateContainerConfig(name, key, value string) error
 	GetRawInstance(name string) (map[string]string, string, error)
@@ -283,6 +284,15 @@ type ContainerInfo struct {
 	// StartContainer. Zero value when the key is missing or unparseable.
 	// Consumed by the Phase 2 auto-sleep ticker for its anti-thrash window.
 	LastStartedAt time.Time
+
+	// TTLExpiresAt mirrors user.containarium.ttl_expires_at — the wall-clock
+	// time at which the daemon's ttlsweeper goroutine should force-delete
+	// the container. Zero value when the key is missing or unparseable
+	// (treated by the sweeper and proto-conversion as "no TTL set").
+	// Persistence model is the Incus container config (survives daemon
+	// restart, no extra store needed); see internal/ttlsweeper for the
+	// sweep side and server.SetContainerTTL for the writer side.
+	TTLExpiresAt time.Time
 }
 
 // AutoSleepEnabledKey is the Incus config key storing the per-container
@@ -298,6 +308,13 @@ const IdleThresholdMinutesKey = "user.containarium.idle_threshold_minutes"
 // reads it to enforce its anti-thrash window (don't sleep a container
 // within 2× the idle threshold of its last start).
 const LastStartedAtKey = "user.containarium.last_started_at"
+
+// TTLExpiresAtKey is the Incus config key storing the RFC3339 timestamp at
+// which the container should be auto-deleted. Written by SetContainerTTL
+// (PR following #299) and read by the ttlsweeper goroutine on every tick.
+// Persisted on the Incus config (not a separate store) so it survives
+// daemon restart with no extra plumbing.
+const TTLExpiresAtKey = "user.containarium.ttl_expires_at"
 
 // DefaultIdleThresholdMinutes is the fallback used when the threshold
 // config key is missing or unparseable.
@@ -322,6 +339,23 @@ func parseIdleThresholdMinutes(cfg map[string]string) int32 {
 // that as "unknown" rather than a real moment in epoch history.
 func parseLastStartedAt(cfg map[string]string) time.Time {
 	raw, ok := cfg[LastStartedAtKey]
+	if !ok || raw == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// parseTTLExpiresAt reads the TTL-expiry timestamp from an Incus config
+// map. Missing or unparseable values yield the zero time — the read-path
+// (toProtoContainer) and the sweeper both treat the zero value as "no
+// TTL set" so a corrupt key never 5xx's the list endpoint or trips
+// false-positive deletions.
+func parseTTLExpiresAt(cfg map[string]string) time.Time {
+	raw, ok := cfg[TTLExpiresAtKey]
 	if !ok || raw == "" {
 		return time.Time{}
 	}
@@ -593,6 +627,7 @@ func (c *Client) ListContainers() ([]ContainerInfo, error) {
 			AutoSleepEnabled:     inst.Config[AutoSleepEnabledKey] == "true",
 			IdleThresholdMinutes: parseIdleThresholdMinutes(inst.Config),
 			LastStartedAt:        parseLastStartedAt(inst.Config),
+			TTLExpiresAt:         parseTTLExpiresAt(inst.Config),
 		}
 
 		// Get CPU and memory limits from config
@@ -720,6 +755,7 @@ func (c *Client) GetContainer(name string) (*ContainerInfo, error) {
 		AutoSleepEnabled:     inst.Config[AutoSleepEnabledKey] == "true",
 		IdleThresholdMinutes: parseIdleThresholdMinutes(inst.Config),
 		LastStartedAt:        parseLastStartedAt(inst.Config),
+		TTLExpiresAt:         parseTTLExpiresAt(inst.Config),
 	}
 
 	// Get resource limits
@@ -1180,6 +1216,32 @@ func (c *Client) SetConfig(containerName, key, value string) error {
 		return fmt.Errorf("failed to wait for config update: %w", err)
 	}
 
+	return nil
+}
+
+// UnsetConfig removes an arbitrary config key from a container's Incus
+// config (deletes the key rather than setting it to empty). Mirrors
+// UnsetEnv but for non-environment keys — used by SetContainerTTL's
+// clear path so "no TTL" is represented by key absence rather than a
+// stored empty string, which keeps parseTTLExpiresAt and the sweeper
+// from having to special-case empty values. Idempotent — a missing
+// key is not an error.
+func (c *Client) UnsetConfig(containerName, key string) error {
+	inst, etag, err := c.server.GetInstance(containerName)
+	if err != nil {
+		return fmt.Errorf("failed to get container: %w", err)
+	}
+	if _, present := inst.Config[key]; !present {
+		return nil
+	}
+	delete(inst.Config, key)
+	op, err := c.server.UpdateInstance(containerName, inst.Writable(), etag)
+	if err != nil {
+		return fmt.Errorf("failed to update container config: %w", err)
+	}
+	if err := op.Wait(); err != nil {
+		return fmt.Errorf("failed to wait for config update: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/core/incus/incustest/mock.go
+++ b/pkg/core/incus/incustest/mock.go
@@ -35,6 +35,7 @@ type MockBackend struct {
 	WriteFileFunc            func(containerName, path string, content []byte, mode string) error
 	ReadFileFunc             func(containerName, path string) ([]byte, error)
 	SetConfigFunc            func(containerName, key, value string) error
+	UnsetConfigFunc          func(containerName, key string) error
 	SetDeviceSizeFunc        func(containerName, deviceName, size string) error
 	ResolveGPUInputToPCIFunc func(input string) (string, error)
 	CleanupDiskFunc          func(containerName string) (string, int64, error)
@@ -167,6 +168,13 @@ func (m *MockBackend) ReadFile(containerName, path string) ([]byte, error) {
 func (m *MockBackend) SetConfig(containerName, key, value string) error {
 	if m.SetConfigFunc != nil {
 		return m.SetConfigFunc(containerName, key, value)
+	}
+	return nil
+}
+
+func (m *MockBackend) UnsetConfig(containerName, key string) error {
+	if m.UnsetConfigFunc != nil {
+		return m.UnsetConfigFunc(containerName, key)
 	}
 	return nil
 }

--- a/pkg/core/incus/ttl_helpers_test.go
+++ b/pkg/core/incus/ttl_helpers_test.go
@@ -1,0 +1,68 @@
+package incus
+
+import (
+	"testing"
+	"time"
+)
+
+// TestTTLExpiresAtKeyStable locks the user-* config key name. The
+// ttlsweeper goroutine reads this key on every tick and the CLI's
+// `containarium ttl get` calls into the same field via the proto
+// read path, so renaming would silently break both consumers — pin
+// the value here so the rename is caught in CI.
+func TestTTLExpiresAtKeyStable(t *testing.T) {
+	if TTLExpiresAtKey != "user.containarium.ttl_expires_at" {
+		t.Errorf("TTLExpiresAtKey = %q, must remain stable across releases", TTLExpiresAtKey)
+	}
+}
+
+// TestParseTTLExpiresAt mirrors TestParseLastStartedAt — missing,
+// empty, or malformed values resolve to the zero time so a corrupt
+// key (e.g. someone edited the Incus config by hand) never 5xx's the
+// list endpoint and never tricks the sweeper into a false-positive
+// deletion. The helper is intentionally permissive: never panics on
+// garbage, never logs, never returns a non-zero time it can't justify
+// from the input.
+func TestParseTTLExpiresAt(t *testing.T) {
+	ref := time.Date(2026, 5, 23, 18, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		cfg  map[string]string
+		want time.Time
+	}{
+		{
+			name: "missing key returns zero",
+			cfg:  map[string]string{},
+			want: time.Time{},
+		},
+		{
+			name: "empty string returns zero",
+			cfg:  map[string]string{TTLExpiresAtKey: ""},
+			want: time.Time{},
+		},
+		{
+			name: "valid RFC3339 round-trips",
+			cfg:  map[string]string{TTLExpiresAtKey: ref.Format(time.RFC3339)},
+			want: ref,
+		},
+		{
+			name: "malformed garbage returns zero",
+			cfg:  map[string]string{TTLExpiresAtKey: "not-a-timestamp"},
+			want: time.Time{},
+		},
+		{
+			name: "unsupported format (RFC1123) returns zero",
+			cfg:  map[string]string{TTLExpiresAtKey: ref.Format(time.RFC1123)},
+			want: time.Time{},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseTTLExpiresAt(tc.cfg)
+			if !got.Equal(tc.want) {
+				t.Errorf("parseTTLExpiresAt(%v) = %v, want %v", tc.cfg, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes the loop on the TTL feature. Three predecessor PRs landed pieces that didn't talk to each other:

- **#297** — `containarium ttl set/get/unset` CLI, gracefully degraded to "server doesn't support TTL yet"
- **#299** — proto contract (`SetContainerTTL`, `Container.ttl_expires_at`) + pure `internal/ttlsweeper` decision package, with the wiring intentionally deferred

This PR is the wiring:

```
CLI (#297) → SetContainerTTL handler (here)
          → user.containarium.ttl_expires_at on the Incus config
          → ttlsweeper.Manager tick (#299)
          → DeleteContainer (existing handler, with audit + Caddy
            cascade + event bus)
```

After this lands, `containarium-run`'s keep-on-failure flag actually auto-cleans the debug box when its TTL expires, instead of leaning on humans to remember to `containarium delete` it.

## Persistence model — Incus config map

The wall-clock expiry is stamped onto the container's Incus config under the new key `user.containarium.ttl_expires_at` (RFC3339), mirroring how autosleep already persists `user.containarium.auto_sleep_enabled` etc.

Why:

- Survives daemon restart — lives in Incus, not in daemon memory.
- No new persistence layer (no SQLite, no JSON file).
- Read path is free — `incus.ContainerInfo` gains a `TTLExpiresAt time.Time` field populated in `ListContainers`/`GetContainer`, and `toProtoContainer` reads it through to `pb.Container.ttl_expires_at`.
- Unset clears the key entirely (vs. setting it to an empty string), so "no TTL" is represented by absence. `parseTTLExpiresAt` is permissive on garbage — a corrupt key never 5xx's the list endpoint or trips a false-positive delete.

## Interaction with autosleep — none, by design

If both tickers decide on the same container in the same second, deletion is final and the autosleep stop becomes a no-op against a missing container. No coordination layer; the natural ordering of "list, decide, act" handles it.

## Wiring locations

- **Handler:** `internal/server/container_server_ttl.go` (new file). Sibling to `container_server.go` rather than appended to keep the diff readable.
- **Read-path:** `internal/server/container_server.go` — `toProtoContainer` now sets `TtlExpiresAt` when `info.TTLExpiresAt` is non-zero.
- **Incus helpers:** added `UnsetConfig` to `pkg/core/incus.Backend`, `*incus.Client`, `incustest.MockBackend`, and `pkg/core/container.Manager`. Symmetric with the existing `UnsetEnv` (used by ToggleMonitoring's disable path).
- **Sweeper wiring:** `internal/server/dual_server.go` constructs and starts a `ttlsweeper.Manager` right after the autosleep manager; Stop wired into the shutdown path next to autosleep. Adapter in `internal/server/ttlsweeper_adapter.go` bridges `*incus.Client` → `ttlsweeper.IncusClient` and the sweeper's `Deleter` seam → the existing `DeleteContainer` handler (force=true, system identity).

The `internal/ttlsweeper/` package itself was not touched (frozen per #299).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/server/... ./pkg/core/incus/... ./pkg/core/container/... ./internal/ttlsweeper/... ./internal/autosleep/...` all green
- [x] Handler test covers: valid duration stamps RFC3339 expiry; duration > 7 days → InvalidArgument; negative duration → InvalidArgument; duration = 0 clears the key (UnsetConfig); unknown container → NotFound; missing name → InvalidArgument; core-container rejection; 7d boundary accepted
- [x] `parseTTLExpiresAt` permissive-on-garbage contract locked; key name pinned by `TestTTLExpiresAtKeyStable`
- [x] Pre-existing test failures (`internal/sentinel`, `test/integration/Storage*`) confirmed identical on `main` — unrelated to this PR

## Out of scope

- The MCP wrapper for `SetContainerTTL` — per CLAUDE.md, MCP wraps the CLI which already exists, so the natural next step is a thin tool definition rather than something on this PR.
- Cross-ticker coordination between autosleep + ttlsweeper (see "Interaction with autosleep" above).
- Any refactor of existing container handler code beyond what was needed to populate the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)