### PR TITLE
feat(hacks): runner kit — Containarium as a GHA ephemeral runner pool

### DIFF
--- a/hacks/README.md
+++ b/hacks/README.md
@@ -75,6 +75,26 @@ invocation.
 
 ---
 
+### 🤖 `runner/` - Containarium as a GitHub Actions runner pool
+
+Provisions a Containarium box as an **ephemeral** GitHub Actions self-hosted
+runner — one job per registration, fresh state every time. Eliminates
+GHA-hosted-runner minutes for your CI; avoids the classic
+"one long-lived runner gets stuck and the queue stalls" failure mode.
+
+```bash
+containarium create runner-1
+ssh runner-1 'curl -fsSL https://raw.githubusercontent.com/footprintai/containarium/main/hacks/runner/install.sh \
+  | sudo GH_REPO=<owner>/<repo> GH_PAT=ghp_xxx bash'
+```
+
+Workflows then target `runs-on: [self-hosted, containarium, ephemeral]`.
+
+See [`runner/README.md`](runner/README.md) for the full guide, ops
+playbook, cost comparison, and security notes.
+
+---
+
 ### 🗑️ `uninstall.sh` - Complete Removal
 
 Removes Containarium completely (keeps Incus by default).

--- a/hacks/runner/README.md
+++ b/hacks/runner/README.md
@@ -1,0 +1,200 @@
+# `hacks/runner/` — Containarium as a GitHub Actions runner pool
+
+Set up **ephemeral GitHub Actions self-hosted runners** that live inside
+Containarium boxes. Eliminates GitHub-hosted-runner minutes for your CI,
+and crucially avoids the classic self-hosted-runner failure mode
+(one long-lived runner host, stuck processes, queue stalls forever)
+by making every job run on a runner that's never run anything before.
+
+This is what [Containarium](https://containarium.dev) uses for its own
+CI — read [the design notes](#design-notes) for the why.
+
+## What you get
+
+- One `containarium-runner.service` per box, registered to one GitHub
+  repo, labeled `[self-hosted, containarium, ephemeral]`.
+- Each iteration: mint a registration token via GitHub API → register
+  the runner in `--ephemeral` mode → run **one** job → deregister →
+  systemd respawns the loop with a fresh registration.
+- Spin N boxes for N concurrent jobs. Scale by `containarium create`
+  + re-running this install script.
+- Toolchains baked in by `install.sh`: Go 1.25, Node 22 + pnpm 9,
+  buf 1.38.0, golangci-lint v2. Edit the script's version vars for
+  other pinnings.
+
+## Prerequisites
+
+- A Containarium daemon you can `containarium create` against (OSS or
+  the Cloud product, doesn't matter).
+- A GitHub repo you control + a Personal Access Token with `repo`
+  scope (classic PAT) for that repo. See
+  [GitHub's docs](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners#using-the-rest-api)
+  for what scopes the registration-token endpoint needs.
+- One Containarium box per concurrent CI job you want to run. Start
+  with 3 if you have no idea; bump as needed.
+
+## Setup (one-time per box)
+
+```bash
+# 1. Create the box (from your laptop, talking to a Containarium daemon).
+containarium create runner-1
+
+# 2. Wait for SSH, then install the runner inside it. Replace the
+#    env vars with your repo + PAT.
+ssh runner-1 'curl -fsSL \
+  https://raw.githubusercontent.com/footprintai/containarium/main/hacks/runner/install.sh \
+  | sudo GH_REPO=<owner>/<repo> GH_PAT=ghp_xxxxxxxxxxxx bash'
+
+# 3. (Optional) Repeat for runner-2, runner-3 for parallelism.
+for i in 2 3; do
+  containarium create runner-$i
+  ssh runner-$i 'curl -fsSL .../install.sh | sudo GH_REPO=... GH_PAT=... bash'
+done
+```
+
+After step 2 finishes, verify the runner appears at
+`https://github.com/<owner>/<repo>/settings/actions/runners` within
+~30 seconds. It'll show idle, with labels `containarium, ephemeral`,
+ready to pick up jobs.
+
+## Targeting the runners from a workflow
+
+In your repo's `.github/workflows/*.yml`:
+
+```yaml
+jobs:
+  test:
+    runs-on: [self-hosted, containarium, ephemeral]
+    steps:
+      - uses: actions/checkout@v4
+      - run: go test ./...   # runs natively in the Containarium box
+```
+
+No need for the [`containarium-run`](https://github.com/FootprintAI/containarium-run)
+Action — the runner IS already on Containarium. The Action is for
+the *other* model (thin-shim on GHA-hosted runners that spawn boxes
+on demand).
+
+## Operations
+
+**Tail one runner's logs:**
+```bash
+ssh runner-1 'journalctl -u containarium-runner -f'
+```
+
+**Restart a runner:**
+```bash
+ssh runner-1 'sudo systemctl restart containarium-runner'
+```
+
+**Replace the PAT (rotation):**
+```bash
+ssh runner-1 'sudo sed -i "s/^GH_PAT=.*/GH_PAT=ghp_newvalue/" /etc/containarium-runner.env'
+ssh runner-1 'sudo systemctl restart containarium-runner'
+```
+
+**Drain + tear down a runner box:**
+```bash
+ssh runner-1 'sudo systemctl stop containarium-runner'   # waits for current job
+containarium delete runner-1 --yes
+```
+
+**Add capacity:**
+```bash
+containarium create runner-4
+ssh runner-4 'curl -fsSL .../install.sh | sudo GH_REPO=... GH_PAT=... bash'
+```
+
+That's it. There's no central controller — each box is independent.
+If one box hangs (network drop, kernel panic), only that one runner
+slot is lost; the others keep picking up jobs.
+
+## Design notes
+
+### Why `--ephemeral`?
+
+Long-lived self-hosted runners are the classic CI hell. A bad job
+leaks processes, fills `/tmp`, corrupts a global state — and every
+subsequent job inherits the mess. Eventually the runner hangs and the
+queue stalls.
+
+`--ephemeral` flips that: the runner config and process exist for
+exactly one job, then exit. systemd respawns the loop with a fresh
+registration. Each job's container state is provably clean.
+
+### Why a long-lived box for each runner slot?
+
+Could each *job* spawn its own box (controller-managed, ARC-style)?
+Yes, and that's the right answer at scale — but it requires a real
+controller (watch the GitHub webhook, allocate a box, register, drain,
+delete). For most teams, **N long-lived boxes running ephemeral
+runners** gives 90% of the benefit with 10% of the engineering.
+
+If/when you outgrow this — e.g., you want sub-second runner availability
+or per-job resource sizing — graduate to a controller. Until then,
+this is fine.
+
+### Why does the install script have toolchains baked in?
+
+Per-job apt installs are the dominant CI cost when nothing is cached.
+Baking Go + Node + buf + golangci-lint into the box at provision time
+means `go test` starts in <1s after the runner picks up a job, not
+after a 60s apt cycle. Adjust the toolchain list in `install.sh` for
+your project's stack.
+
+### What about secrets and isolation?
+
+This setup gives every job in your repo access to whatever's in the
+runner box (the PAT in `/etc/containarium-runner.env`, anything else
+you've installed). That's the standard self-hosted-runner tradeoff.
+**Do not** use these runners for jobs from forks of public repos —
+GitHub's
+[security guidance](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)
+covers this. For public OSS where untrusted contributors can open PRs,
+stick to GitHub-hosted runners (or use the `containarium-run` Action's
+thin-shim model where each job is in a fresh Containarium box created
+on-demand and torn down).
+
+## Troubleshooting
+
+### Runner doesn't appear in GitHub's UI
+
+Check the logs: `ssh runner-1 'journalctl -u containarium-runner -n 100'`.
+Most common: PAT lacks `repo` scope, or the repo path in `GH_REPO`
+is wrong (must be `owner/repo` not a URL).
+
+### Runner appears but immediately deregisters
+
+`--ephemeral` means it deregisters after one job. If you're not seeing
+it stay around between jobs, that's normal — the loop spawns a new
+registration each iteration.
+
+### Jobs queue but no runner picks them up
+
+- Confirm the workflow's `runs-on:` matches the labels on your runners
+  (`[self-hosted, containarium, ephemeral]` by default).
+- Confirm the runner box has network access to `github.com`.
+- Check `journalctl -u containarium-runner -f` while pushing a commit
+  to trigger CI — you should see the registration succeed and the
+  runner pick up the job.
+
+### Toolchain version drift
+
+Edit `install.sh`'s `GO_VERSION`, `BUF_VERSION`, etc., then re-run on
+each box:
+```bash
+ssh runner-1 'curl -fsSL .../install.sh | sudo GH_REPO=... GH_PAT=... bash'
+```
+The script is idempotent — it only reinstalls toolchains whose
+version changed.
+
+## Cost comparison (rough)
+
+For a repo doing ~100 PRs/month, each triggering ~5 min of CI:
+
+| | GHA-hosted (default) | containarium-run Action (thin-shim) | This (ephemeral on Containarium) |
+|---|---|---|---|
+| GHA-hosted minutes/month | ~500 min | ~50 min | 0 min |
+| Containarium box-hours/month | 0 | ~8 hr | ~8 hr (across 3 idle-most-of-the-time runner boxes) |
+| Setup complexity | None | Add Action + 2 secrets | This README (~30 min one-time) |
+| Best for | Hobby / open-source contributions | Want failure-debug UX, don't want to manage runners | Want zero GHA minutes; have a Containarium fleet |

--- a/hacks/runner/install.sh
+++ b/hacks/runner/install.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# install.sh — provisions a Containarium box as an ephemeral GitHub
+# Actions self-hosted runner for one GitHub repo.
+#
+# Run this INSIDE a Containarium box (e.g. one created via
+# `containarium create runner-1`). It installs:
+#
+#   - actions-runner (GitHub's official binary)
+#   - Common CI toolchains: git, build-essential, Go, Node 22, pnpm 9,
+#     buf 1.38.0, golangci-lint
+#   - A systemd unit that runs the runner in `--ephemeral` mode in a
+#     respawn loop: register → run ONE job → exit → restart fresh.
+#
+# Required env vars (or pass on command line):
+#
+#   GH_REPO     org/repo for the runner (e.g. FootprintAI/Containarium-cloud)
+#   GH_PAT      personal access token with `repo` scope; used to mint
+#               short-lived runner-registration tokens at the start of
+#               each loop iteration. Pick from
+#               https://github.com/settings/tokens (classic) or App
+#               installation tokens.
+#   RUNNER_NAME (optional) name for this runner; defaults to the box
+#               hostname. Visible in GitHub's Actions → Runners list.
+#   RUNNER_LABELS (optional) comma-separated runner labels; defaults
+#               to "containarium,ephemeral". Workflows target with
+#               `runs-on: [self-hosted, containarium, ephemeral]`.
+#
+# Usage from outside the box:
+#
+#   containarium create runner-1
+#   ssh runner-1 'curl -fsSL https://raw.githubusercontent.com/footprintai/containarium/main/hacks/runner/install.sh \
+#     | sudo GH_REPO=FootprintAI/Containarium-cloud GH_PAT=ghp_xxx bash'
+#
+# After this runs, the runner registers itself within ~30s and starts
+# accepting jobs. Verify at
+# https://github.com/<owner>/<repo>/settings/actions/runners.
+
+set -euo pipefail
+
+# ---- input validation ----
+: "${GH_REPO:?GH_REPO is required (org/repo)}"
+: "${GH_PAT:?GH_PAT is required (PAT with repo scope)}"
+
+RUNNER_NAME="${RUNNER_NAME:-$(hostname -s)}"
+RUNNER_LABELS="${RUNNER_LABELS:-containarium,ephemeral}"
+RUNNER_VERSION="${RUNNER_VERSION:-2.319.1}"
+RUNNER_USER="${RUNNER_USER:-ghrunner}"
+RUNNER_HOME="${RUNNER_HOME:-/opt/actions-runner}"
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64) RUNNER_ARCH=x64 ;;
+  aarch64|arm64) RUNNER_ARCH=arm64 ;;
+  *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+# ---- system deps ----
+apt-get update
+apt-get install -y --no-install-recommends \
+  ca-certificates curl jq git build-essential libicu-dev
+
+# ---- toolchains ----
+# Go (matches Containarium repo's go.mod pinning convention; bumps are
+# a one-line edit here).
+GO_VERSION="${GO_VERSION:-1.25.10}"
+if ! command -v go >/dev/null 2>&1 || [ "$(go version | awk '{print $3}')" != "go${GO_VERSION}" ]; then
+  curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xz
+  ln -sf /usr/local/go/bin/go /usr/local/bin/go
+  ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+fi
+
+# Node 22 + pnpm 9 (for repos with frontend builds)
+if ! command -v node >/dev/null 2>&1; then
+  curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+  apt-get install -y nodejs
+  npm install -g pnpm@9
+fi
+
+# buf (proto toolchain — pin matches Containarium-cloud's CI)
+BUF_VERSION="${BUF_VERSION:-1.38.0}"
+if ! command -v buf >/dev/null 2>&1; then
+  GOBIN=/usr/local/bin /usr/local/go/bin/go install \
+    "github.com/bufbuild/buf/cmd/buf@v${BUF_VERSION}"
+fi
+
+# golangci-lint v2 (latest minor; pin if reproducibility matters)
+if ! command -v golangci-lint >/dev/null 2>&1; then
+  curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+    | sh -s -- -b /usr/local/bin
+fi
+
+# ---- runner user + binary ----
+if ! id "$RUNNER_USER" >/dev/null 2>&1; then
+  useradd -m -d "$RUNNER_HOME" -s /bin/bash "$RUNNER_USER"
+fi
+
+if [ ! -x "$RUNNER_HOME/run.sh" ]; then
+  mkdir -p "$RUNNER_HOME"
+  cd "$RUNNER_HOME"
+  TARBALL="actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz"
+  curl -fsSL -o "$TARBALL" \
+    "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${TARBALL}"
+  tar xzf "$TARBALL"
+  rm "$TARBALL"
+  chown -R "$RUNNER_USER:$RUNNER_USER" "$RUNNER_HOME"
+fi
+
+# ---- env file (PAT lives here; chmod 600) ----
+cat > /etc/containarium-runner.env <<EOF
+GH_REPO=${GH_REPO}
+GH_PAT=${GH_PAT}
+RUNNER_NAME=${RUNNER_NAME}
+RUNNER_LABELS=${RUNNER_LABELS}
+RUNNER_HOME=${RUNNER_HOME}
+EOF
+chmod 600 /etc/containarium-runner.env
+
+# ---- run-loop script ----
+install -m 0755 /dev/stdin /usr/local/bin/containarium-runner-loop <<'EOF'
+#!/bin/bash
+# Ephemeral-runner respawn loop. One iteration = one job.
+set -euo pipefail
+source /etc/containarium-runner.env
+
+cd "$RUNNER_HOME"
+
+# Mint a short-lived runner-registration token (valid ~1h).
+REG_TOKEN=$(curl -sX POST \
+  -H "Authorization: token $GH_PAT" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/${GH_REPO}/actions/runners/registration-token" \
+  | jq -r '.token')
+
+if [ -z "$REG_TOKEN" ] || [ "$REG_TOKEN" = "null" ]; then
+  echo "Failed to mint registration token — check GH_PAT scope (needs 'repo')" >&2
+  exit 1
+fi
+
+# Register, run ONE job, exit. --replace overwrites any stale
+# registration with the same name. --ephemeral makes run.sh exit
+# after the first job completes (success or failure).
+./config.sh \
+  --url "https://github.com/${GH_REPO}" \
+  --token "$REG_TOKEN" \
+  --name "$RUNNER_NAME" \
+  --labels "$RUNNER_LABELS" \
+  --ephemeral --replace --unattended
+
+./run.sh
+EOF
+
+# ---- systemd unit ----
+cat > /etc/systemd/system/containarium-runner.service <<EOF
+[Unit]
+Description=Containarium ephemeral GitHub Actions runner
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${RUNNER_USER}
+WorkingDirectory=${RUNNER_HOME}
+ExecStart=/usr/local/bin/containarium-runner-loop
+# Respawn on exit — each iteration is one job. RestartSec=2 buffers a
+# tiny gap so we don't hot-loop if GitHub is rejecting registrations.
+Restart=always
+RestartSec=2
+# Capture stdout/stderr in the journal for easy debugging.
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# ---- enable + start ----
+systemctl daemon-reload
+systemctl enable --now containarium-runner.service
+
+echo
+echo "================================================================"
+echo "  Runner '${RUNNER_NAME}' is registering with ${GH_REPO}."
+echo "  Verify at: https://github.com/${GH_REPO}/settings/actions/runners"
+echo
+echo "  Service: containarium-runner.service"
+echo "  Logs:    journalctl -u containarium-runner -f"
+echo "================================================================"


### PR DESCRIPTION
## Summary

Adds \`hacks/runner/\` — a self-serve kit for provisioning a Containarium box as an **ephemeral GitHub Actions self-hosted runner**. Each iteration: register → run **one** job → exit → systemd respawns with a fresh registration. Eliminates the classic self-hosted-runner failure mode (one long-lived runner gets wedged, queue stalls indefinitely) and removes GHA-hosted-runner minutes entirely.

This is what Containarium uses for its own dogfood CI; shipping the same kit publicly serves the enterprise TA — teams that need CI on infra they control.

## What's in the kit

| File | What |
|---|---|
| \`hacks/runner/install.sh\` | One-shot script run inside a Containarium box. Installs actions-runner v2.319.1, common toolchains (Go 1.25, Node 22, pnpm 9, buf 1.38.0, golangci-lint v2), \`/etc/containarium-runner.env\` env file, ephemeral-respawn script, systemd unit. Takes \`GH_REPO\` + \`GH_PAT\` via env. |
| \`hacks/runner/README.md\` | Full DIY guide — setup, ops playbook, troubleshooting, design notes (why \`--ephemeral\`, why long-lived boxes for runner slots, security tradeoffs), cost comparison vs GHA-hosted and the \`containarium-run\` thin-shim. |
| \`hacks/README.md\` | Index entry pointing at the new dir. |

## How a workflow consumes it

```yaml
jobs:
  test:
    runs-on: [self-hosted, containarium, ephemeral]
    steps:
      - uses: actions/checkout@v4
      - run: go test ./...
```

No \`containarium-run\` Action needed — the runner IS already on Containarium.

## Design notes (full version in the README)

- **\`--ephemeral\` mode**: every job runs on a runner that's never run anything before. Provably clean state.
- **systemd respawn loop**: \`Restart=always\`, \`RestartSec=2\`. If one iteration fails to register, the next tries again 2s later.
- **PAT in \`/etc/containarium-runner.env\` (chmod 600)**: v0 is PAT-based; App-installation tokens are a v0.1 follow-up.
- **No central controller**: each box is independent. If one box hangs, only that runner slot is lost; the others keep accepting jobs.
- **Toolchains baked at install time**: avoids the per-job apt-install tax that the \`containarium-run\` thin-shim model still pays.

## Tier-mapping (for the enterprise TA framing)

| Tier | Setup | Code path |
|---|---|---|
| 0 (evaluator) | \`containarium-run\` Action + cloud | Code → GHA-hosted → cloud → Containarium |
| **1 (mid-market — this PR)** | \`hacks/runner/\` + self-hosted Containarium | Code → GHA-hosted (orchestration only) → customer's runner pool |
| 2 (enterprise) | Tier 1 + audit log + SSO + residency docs | Nothing crosses to FootprintAI |
| 3 (air-gapped) | Tier 2 + offline install bundle + GHES | Fully contained in customer VPC |

This PR is the Tier 1 building block.

## Out of scope (follow-ups)

- Central controller spawning boxes per-job (ARC-style)
- Per-job resource sizing
- App-installation tokens vs PATs
- Offline install bundle (Tier 3 prereq)
- Per-tier audit-log + SSO documentation (Tier 2 prereq)

## Test plan

- [x] \`bash -n hacks/runner/install.sh\` syntax-clean
- [ ] Manual smoke: \`containarium create runner-1\` + \`ssh runner-1 'curl ...install.sh | sudo GH_REPO=... GH_PAT=... bash'\` + verify runner appears at \`/settings/actions/runners\` + push a commit + watch a job run
- [ ] Follow-up PR on \`Containarium-cloud\` to switch \`.github/workflows/ci.yml\` from \`containarium-run\` Action back to native \`runs-on: [self-hosted, containarium, ephemeral]\` (closes the dogfood loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)