### PR TITLE
A3: containarium login / logout / whoami CLI verbs

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -1,0 +1,567 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/user"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/credentials"
+	"github.com/spf13/cobra"
+)
+
+// Sub-task A3 of umbrella-issue #100: client-side device-flow
+// consumer that pairs with the cloud's CLISessionService.
+// See prd/cloud/cli-login-and-multi-env-ssh.md §"Design — `containarium login`".
+//
+// The CLI POSTs /v1/cli/sessions, opens the verification URL in a
+// browser, polls /v1/cli/sessions/{id}/status until approved, then
+// persists the token to ~/.containarium/credentials.json via the
+// credentials store. The login command itself is unauthenticated —
+// the user_code + browser-side approval ARE the credential. We
+// intentionally use raw net/http here rather than the existing
+// internal/client/http.go wrapper, which expects an
+// already-authenticated bearer token (see Stop conditions in the
+// task brief).
+
+const (
+	defaultLoginServer = "https://cloud.containarium.dev"
+	loginPollInterval  = 5 * time.Second
+	loginMaxWait       = 10 * time.Minute
+	loginHTTPTimeout   = 30 * time.Second
+)
+
+// Per-command flags. Top-level `--server` and `--token` are reused
+// from root.go; these are login/logout/whoami specifics.
+var (
+	loginServer      string // explicit override for login/logout/whoami
+	loginDeviceName  string
+	loginNoBrowser   bool
+	logoutAll        bool
+	configTokenSrv   string
+	whoamiServerFlag string
+)
+
+// pollIntervalOverride lets tests dial the polling interval down to
+// milliseconds so the device-flow happy-path runs fast. Defaults to
+// the production constant.
+var pollIntervalOverride = loginPollInterval
+
+var loginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Authenticate against a Containarium server via browser device flow",
+	Long: `Open the browser to approve a CLI session, then persist the resulting
+token to ~/.containarium/credentials.json (0600).
+
+The token is automatically picked up by subsequent CLI commands when
+neither --token nor CONTAINARIUM_TOKEN is set. See ` + "`containarium --help`" + `
+for the precedence order.
+
+The login flow is the standard OAuth-style device flow:
+
+  1. CLI POSTs /v1/cli/sessions to the cloud; cloud returns
+     {session_id, user_code, verification_url}.
+  2. CLI opens verification_url in your default browser (or prints
+     it if --no-browser is set / the OS launcher fails).
+  3. You approve the session in the browser.
+  4. CLI polls /v1/cli/sessions/{id}/status every 5s (max 10min)
+     until status == approved, then writes credentials.json.
+
+Multi-server: you can be logged into the hosted cloud AND a
+self-hosted instance simultaneously. The first server you log into
+becomes the default; --server picks a non-default one.`,
+	Example: `  # Log in to the hosted cloud
+  containarium login
+
+  # Log in to a self-hosted instance
+  containarium login --server=https://containarium.internal.example.com
+
+  # Headless mode (don't try to open a browser)
+  containarium login --no-browser`,
+	RunE: runLogin,
+}
+
+var logoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Remove stored credentials for a server",
+	Long: `Delete the token + identity stored in ~/.containarium/credentials.json
+for a given server. Does NOT call the cloud — the token on the
+server side remains until it expires or is explicitly revoked via
+` + "`containarium token revoke`" + `.
+
+If neither --server nor --all is given, logs out of the default
+server.`,
+	Example: `  # Log out of the default server
+  containarium logout
+
+  # Log out of a specific server
+  containarium logout --server=https://cloud.containarium.dev
+
+  # Wipe credentials for every server
+  containarium logout --all`,
+	RunE: runLogout,
+}
+
+var whoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Print the active server and identity",
+	Long: `Show the credentials store's view of "who am I" — which server is the
+default, what email + org are associated with it, and when the
+token was issued / expires.
+
+Exit code is non-zero when no credentials are stored for the
+selected server (useful in shell scripts: ` + "`containarium whoami || containarium login`" + `).`,
+	RunE: runWhoami,
+}
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Read CLI configuration (credentials, defaults)",
+	Long:  `Inspect the local CLI state stored under ~/.containarium/. See subcommands.`,
+}
+
+var configGetTokenCmd = &cobra.Command{
+	Use:   "get-token",
+	Short: "Print the stored token for a server (script-friendly)",
+	Long: `Emit the bearer token stored in ~/.containarium/credentials.json
+for the given (or default) server, on stdout. No trailing newline,
+so it composes with shell pipes:
+
+  export TOKEN=$(containarium config get-token)
+  curl -H "Authorization: Bearer $TOKEN" ...
+
+Exit code is non-zero if no token is stored.`,
+	RunE: runConfigGetToken,
+}
+
+func init() {
+	loginCmd.Flags().StringVar(&loginServer, "server", "", "server to log in to (default: "+defaultLoginServer+")")
+	loginCmd.Flags().StringVar(&loginDeviceName, "device-name", "", "human label for this session (default: <user>-<host>)")
+	loginCmd.Flags().BoolVar(&loginNoBrowser, "no-browser", false, "don't try to open a browser; print the URL instead")
+
+	logoutCmd.Flags().StringVar(&loginServer, "server", "", "server to log out of (default: default_server)")
+	logoutCmd.Flags().BoolVar(&logoutAll, "all", false, "wipe credentials for all servers")
+
+	whoamiCmd.Flags().StringVar(&whoamiServerFlag, "server", "", "server to query (default: default_server)")
+
+	configGetTokenCmd.Flags().StringVar(&configTokenSrv, "server", "", "server to read the token for (default: default_server)")
+
+	configCmd.AddCommand(configGetTokenCmd)
+
+	rootCmd.AddCommand(loginCmd)
+	rootCmd.AddCommand(logoutCmd)
+	rootCmd.AddCommand(whoamiCmd)
+	rootCmd.AddCommand(configCmd)
+}
+
+// Wire-format DTOs for the device-flow endpoints. The cloud's
+// CLISessionService is the source of truth; these structs mirror
+// its JSON shape per the PRD.
+//
+// Per CLAUDE.md, we use typed structs at the HTTP boundary rather
+// than map[string]interface{} — even though the JSON-RPC at the
+// edge of MCP gets a pass, ordinary REST calls do not.
+
+type createSessionReq struct {
+	DeviceName string `json:"device_name"`
+}
+
+type createSessionResp struct {
+	SessionID       string `json:"session_id"`
+	UserCode        string `json:"user_code"`
+	VerificationURL string `json:"verification_url"`
+	ExpiresIn       int    `json:"expires_in"`
+}
+
+type sessionStatusResp struct {
+	Status    string `json:"status"` // pending | approved | denied | expired
+	Token     string `json:"token,omitempty"`
+	UserEmail string `json:"user_email,omitempty"`
+	OrgID     string `json:"org_id,omitempty"`
+	// ExpiresAt is RFC3339; absent or empty means non-expiring.
+	ExpiresAt string `json:"expires_at,omitempty"`
+}
+
+// loginHTTPClient is the unauthenticated HTTP client used by the
+// device-flow handshake. Kept private so nothing else accidentally
+// uses it.
+func loginHTTPClient() *http.Client {
+	return &http.Client{Timeout: loginHTTPTimeout}
+}
+
+// pickLoginServer resolves the effective server URL for login:
+// the explicit flag wins, otherwise the constant default. We do
+// NOT consult $CONTAINARIUM_SERVER here — that env var is for the
+// daemon/gRPC server, which is a different surface (the cloud
+// auth endpoint).
+func pickLoginServer(explicit string) string {
+	if explicit != "" {
+		return strings.TrimRight(explicit, "/")
+	}
+	return defaultLoginServer
+}
+
+// deviceName returns a stable, human-readable label for the
+// session. PRD example: "alice-laptop (alice)". We default to
+// "<user>@<host>" which is close enough — exact format matters
+// only for the cloud's "Active sessions" UI.
+func deviceName(override string) string {
+	if override != "" {
+		return override
+	}
+	var who, host string
+	if u, err := user.Current(); err == nil {
+		who = u.Username
+	}
+	host, _ = os.Hostname()
+	switch {
+	case who != "" && host != "":
+		return fmt.Sprintf("%s@%s", who, host)
+	case host != "":
+		return host
+	case who != "":
+		return who
+	}
+	return "containarium-cli"
+}
+
+// openBrowser fires-and-forgets the platform-native URL opener. We
+// intentionally don't block on the child process — the user may
+// not return for minutes, and the polling loop is what actually
+// drives login. Returns the error from exec.Start so callers can
+// fall back to printing the URL.
+//
+// Cross-platform handling per the task brief: linux→xdg-open,
+// darwin→open, windows→cmd /c start. Unknown OSes get an error
+// and we print the URL.
+func openBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		// #nosec G204 -- url comes from the cloud's session
+		// response; the user already trusts that endpoint.
+		cmd = exec.Command("xdg-open", url)
+	case "darwin":
+		// #nosec G204
+		cmd = exec.Command("open", url)
+	case "windows":
+		// "start" is a cmd builtin, hence the cmd /c wrapper.
+		// "" placeholder is start's window-title argument; without
+		// it URLs containing & get truncated.
+		// #nosec G204
+		cmd = exec.Command("cmd", "/c", "start", "", url)
+	default:
+		return fmt.Errorf("unsupported OS for auto-launch: %s", runtime.GOOS)
+	}
+	return cmd.Start()
+}
+
+func runLogin(cmd *cobra.Command, args []string) error {
+	srv := pickLoginServer(loginServer)
+	out := cmd.OutOrStdout()
+	hc := loginHTTPClient()
+	ctx, cancel := context.WithTimeout(context.Background(), loginMaxWait+loginHTTPTimeout)
+	defer cancel()
+
+	// 1. Open a session.
+	sess, err := createSession(ctx, hc, srv, deviceName(loginDeviceName))
+	if err != nil {
+		return fmt.Errorf("open CLI session: %w", err)
+	}
+
+	fmt.Fprintf(out, "Opening browser to %s\n", sess.VerificationURL)
+	fmt.Fprintf(out, "If your browser doesn't open, visit that URL and enter code: %s\n", sess.UserCode)
+	if !loginNoBrowser {
+		if err := openBrowser(sess.VerificationURL); err != nil {
+			// Fall back gracefully — the user already has the URL.
+			fmt.Fprintf(out, "(could not auto-launch browser: %v — please open the URL manually)\n", err)
+		}
+	}
+	fmt.Fprintf(out, "(polls every %s, max %s)\n", loginPollInterval, loginMaxWait)
+
+	// 2. Poll status until terminal.
+	status, err := pollSession(ctx, hc, srv, sess.SessionID, pollIntervalOverride, loginMaxWait)
+	if err != nil {
+		return err
+	}
+
+	// 3. Persist credentials.
+	creds := credentials.ServerCreds{
+		Token:     status.Token,
+		UserEmail: status.UserEmail,
+		OrgID:     status.OrgID,
+		IssuedAt:  time.Now().UTC(),
+	}
+	if status.ExpiresAt != "" {
+		if t, err := time.Parse(time.RFC3339, status.ExpiresAt); err == nil {
+			creds.ExpiresAt = &t
+		}
+	}
+
+	path, err := credentials.DefaultPath()
+	if err != nil {
+		return err
+	}
+	cf, err := credentials.Load(path)
+	if err != nil {
+		return err
+	}
+	cf.Set(srv, creds)
+	if cf.DefaultServer == "" {
+		cf.DefaultServer = credentials.NormalizeServer(srv)
+	}
+	if err := credentials.Save(path, cf); err != nil {
+		return fmt.Errorf("save credentials: %w", err)
+	}
+
+	who := status.UserEmail
+	if who == "" {
+		who = "unknown user"
+	}
+	fmt.Fprintf(out, "✓ Logged in as %s\n", who)
+	fmt.Fprintf(out, "  Token saved to %s\n", path)
+	return nil
+}
+
+// createSession POSTs /v1/cli/sessions and decodes the response.
+func createSession(ctx context.Context, hc *http.Client, server, device string) (*createSessionResp, error) {
+	body, err := json.Marshal(createSessionReq{DeviceName: device})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server+"/v1/cli/sessions", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(rb)))
+	}
+	var out createSessionResp
+	if err := json.Unmarshal(rb, &out); err != nil {
+		return nil, fmt.Errorf("decode session response: %w", err)
+	}
+	if out.SessionID == "" || out.VerificationURL == "" {
+		return nil, fmt.Errorf("server returned incomplete session: %+v", out)
+	}
+	return &out, nil
+}
+
+// pollSession GETs /v1/cli/sessions/{id}/status every interval and
+// returns the final non-pending status (or an error if the deadline
+// elapses or the server reports denied/expired).
+func pollSession(ctx context.Context, hc *http.Client, server, sessionID string, interval, maxWait time.Duration) (*sessionStatusResp, error) {
+	deadline := time.Now().Add(maxWait)
+	url := fmt.Sprintf("%s/v1/cli/sessions/%s/status", server, sessionID)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		st, err := fetchSessionStatus(ctx, hc, url)
+		if err != nil {
+			return nil, fmt.Errorf("poll session status: %w", err)
+		}
+		switch st.Status {
+		case "approved":
+			if st.Token == "" {
+				return nil, fmt.Errorf("server reported approved but no token in response")
+			}
+			return st, nil
+		case "denied":
+			return nil, fmt.Errorf("login denied in browser")
+		case "expired":
+			return nil, fmt.Errorf("login session expired before approval")
+		case "pending", "":
+			// continue
+		default:
+			return nil, fmt.Errorf("unknown session status %q", st.Status)
+		}
+
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out waiting for approval (after %s)", maxWait)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func fetchSessionStatus(ctx context.Context, hc *http.Client, url string) (*sessionStatusResp, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("session not found (id may have expired)")
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(rb)))
+	}
+	var out sessionStatusResp
+	if err := json.Unmarshal(rb, &out); err != nil {
+		return nil, fmt.Errorf("decode status response: %w", err)
+	}
+	return &out, nil
+}
+
+func runLogout(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	path, err := credentials.DefaultPath()
+	if err != nil {
+		return err
+	}
+	cf, err := credentials.Load(path)
+	if err != nil {
+		return err
+	}
+
+	if logoutAll {
+		if len(cf.Servers) == 0 {
+			fmt.Fprintln(out, "No stored credentials.")
+			return nil
+		}
+		cf.Servers = map[string]credentials.ServerCreds{}
+		cf.DefaultServer = ""
+		if err := credentials.Save(path, cf); err != nil {
+			return fmt.Errorf("save credentials: %w", err)
+		}
+		fmt.Fprintln(out, "Removed credentials for all servers.")
+		return nil
+	}
+
+	srv := loginServer
+	if srv == "" {
+		srv = cf.DefaultServer
+	}
+	if srv == "" {
+		return fmt.Errorf("no server specified and no default server in credentials file")
+	}
+	if !cf.Remove(srv) {
+		return fmt.Errorf("no stored credentials for %s", srv)
+	}
+	if err := credentials.Save(path, cf); err != nil {
+		return fmt.Errorf("save credentials: %w", err)
+	}
+	fmt.Fprintf(out, "Removed credentials for %s\n", srv)
+	return nil
+}
+
+// errNoSession is returned by whoami / config get-token when the
+// credentials file has no matching entry. We use a sentinel so
+// callers can map it to a clean exit code without an extra string
+// match.
+var errNoSession = errors.New("no stored credentials")
+
+func runWhoami(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	path, err := credentials.DefaultPath()
+	if err != nil {
+		return err
+	}
+	cf, err := credentials.Load(path)
+	if err != nil {
+		return err
+	}
+	srv := whoamiServerFlag
+	if srv == "" {
+		srv = cf.DefaultServer
+	}
+	creds, ok := cf.Get(srv)
+	if !ok {
+		return fmt.Errorf("%w (run `containarium login` to authenticate)", errNoSession)
+	}
+	fmt.Fprintf(out, "Server:      %s\n", srv)
+	fmt.Fprintf(out, "User email:  %s\n", orDash(creds.UserEmail))
+	fmt.Fprintf(out, "Org ID:      %s\n", orDash(creds.OrgID))
+	if !creds.IssuedAt.IsZero() {
+		fmt.Fprintf(out, "Issued at:   %s\n", creds.IssuedAt.Format(time.RFC3339))
+	}
+	if creds.ExpiresAt != nil {
+		fmt.Fprintf(out, "Expires at:  %s\n", creds.ExpiresAt.Format(time.RFC3339))
+	} else {
+		fmt.Fprintln(out, "Expires at:  never")
+	}
+	return nil
+}
+
+func runConfigGetToken(cmd *cobra.Command, args []string) error {
+	path, err := credentials.DefaultPath()
+	if err != nil {
+		return err
+	}
+	cf, err := credentials.Load(path)
+	if err != nil {
+		return err
+	}
+	srv := configTokenSrv
+	creds, ok := cf.Get(srv)
+	if !ok || creds.Token == "" {
+		return errNoSession
+	}
+	// No trailing newline — composes with shell pipes per docstring.
+	fmt.Fprint(cmd.OutOrStdout(), creds.Token)
+	return nil
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// resolveAuthToken implements the precedence chain documented in
+// `containarium --help`:
+//
+//  1. --token flag (explicit)
+//  2. CONTAINARIUM_TOKEN env var
+//  3. ~/.containarium/credentials.json (server matching --server,
+//     else default_server)
+//
+// Step 1 + 2 are already collapsed into the `authToken` variable by
+// the time cobra invokes a subcommand (root.go sets the flag
+// default from the env var). This function only fills in step 3
+// when authToken is empty. Server matching is best-effort: if no
+// match exists we leave authToken empty and let downstream commands
+// fail with their usual "401" error.
+func resolveAuthToken(server string) string {
+	if authToken != "" {
+		return authToken
+	}
+	path, err := credentials.DefaultPath()
+	if err != nil {
+		return ""
+	}
+	cf, err := credentials.Load(path)
+	if err != nil {
+		return ""
+	}
+	creds, ok := cf.Get(server)
+	if !ok {
+		return ""
+	}
+	return creds.Token
+}

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -1,0 +1,422 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/credentials"
+)
+
+// withTempHome redirects $HOME so the credentials store writes
+// under a tempdir for the test. Mirrors the helper in
+// internal/credentials/store_test.go; duplicated here to keep this
+// test file self-contained (the rule from Phase 1 is "don't modify
+// shared test files"; "don't share helpers either" is the safe
+// reading).
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+	// Reset the package-level flag globals between tests so a
+	// previous test's --token / --server doesn't leak.
+	t.Cleanup(func() {
+		authToken = ""
+		serverAddr = ""
+		loginServer = ""
+		whoamiServerFlag = ""
+		configTokenSrv = ""
+		logoutAll = false
+		loginNoBrowser = false
+		loginDeviceName = ""
+	})
+	return home
+}
+
+// seedCreds writes a credentials file with the supplied servers.
+func seedCreds(t *testing.T, home string, defServer string, srvs map[string]credentials.ServerCreds) string {
+	t.Helper()
+	cf := credentials.NewCredentialsFile()
+	for k, v := range srvs {
+		cf.Set(k, v)
+	}
+	if defServer != "" {
+		cf.DefaultServer = defServer
+	}
+	path := filepath.Join(home, credentials.DefaultRelPath)
+	if err := credentials.Save(path, cf); err != nil {
+		t.Fatalf("seed credentials: %v", err)
+	}
+	return path
+}
+
+func TestResolveAuthToken_PrecedenceChain(t *testing.T) {
+	home := withTempHome(t)
+	_ = seedCreds(t, home, "https://cloud.containarium.dev", map[string]credentials.ServerCreds{
+		"https://cloud.containarium.dev":     {Token: "file-default"},
+		"https://self-hosted.example.com":    {Token: "file-self"},
+	})
+
+	cases := []struct {
+		name      string
+		setAuth   string // simulate --token / env (already collapsed into authToken)
+		setServer string
+		want      string
+	}{
+		{
+			name:    "flag wins",
+			setAuth: "explicit-flag",
+			want:    "explicit-flag",
+		},
+		{
+			name: "no flag, no server -> default_server token",
+			want: "file-default",
+		},
+		{
+			name:      "no flag, server matches non-default",
+			setServer: "https://self-hosted.example.com",
+			want:      "file-self",
+		},
+		{
+			name:      "no flag, server with trailing slash still matches",
+			setServer: "https://self-hosted.example.com/",
+			want:      "file-self",
+		},
+		{
+			name:      "no flag, unknown server -> empty",
+			setServer: "https://nope.example.com",
+			want:      "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			authToken = tc.setAuth
+			serverAddr = tc.setServer
+			defer func() { authToken = ""; serverAddr = "" }()
+			got := resolveAuthToken(tc.setServer)
+			if got != tc.want {
+				t.Fatalf("resolveAuthToken = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveAuthToken_NoCredentialsFile(t *testing.T) {
+	withTempHome(t)
+	authToken = ""
+	if got := resolveAuthToken(""); got != "" {
+		t.Fatalf("resolveAuthToken with no file = %q, want empty", got)
+	}
+}
+
+// fakeDeviceFlowServer runs an httptest server that mimics the
+// cloud's CLISessionService just enough for the login command to
+// drive a full happy-path. It returns "pending" for the first N
+// status polls and "approved" thereafter.
+type fakeDeviceFlowServer struct {
+	srv          *httptest.Server
+	approveAfter int32 // number of poll requests before flipping to approved
+	pollCount    int32
+	gotDevice    atomic.Value // string
+}
+
+func newFakeDeviceFlow(t *testing.T, approveAfter int32) *fakeDeviceFlowServer {
+	t.Helper()
+	f := &fakeDeviceFlowServer{approveAfter: approveAfter}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/cli/sessions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+			return
+		}
+		var req createSessionReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		f.gotDevice.Store(req.DeviceName)
+		_ = json.NewEncoder(w).Encode(createSessionResp{
+			SessionID:       "sess-1",
+			UserCode:        "WXYZ-1234",
+			VerificationURL: f.srv.URL + "/cli/authorize?code=WXYZ-1234",
+			ExpiresIn:       600,
+		})
+	})
+	mux.HandleFunc("/v1/cli/sessions/sess-1/status", func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&f.pollCount, 1)
+		resp := sessionStatusResp{Status: "pending"}
+		if n > f.approveAfter {
+			resp = sessionStatusResp{
+				Status:    "approved",
+				Token:     "ctnr_test_token",
+				UserEmail: "alice@example.com",
+				OrgID:     "org_42",
+				ExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+			}
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	f.srv = httptest.NewServer(mux)
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func TestLogin_HappyPath_WritesCredentials(t *testing.T) {
+	home := withTempHome(t)
+	f := newFakeDeviceFlow(t, 1) // pending once, then approved
+	loginServer = f.srv.URL
+	loginNoBrowser = true
+
+	// Run with a short poll interval so the test is fast.
+	old := loginPollIntervalForTest()
+	defer restorePollInterval(old)
+	setPollInterval(20 * time.Millisecond)
+
+	var out bytes.Buffer
+	loginCmd.SetOut(&out)
+	loginCmd.SetErr(&out)
+	if err := runLogin(loginCmd, nil); err != nil {
+		t.Fatalf("runLogin: %v", err)
+	}
+
+	// Credentials file written with the token.
+	path := filepath.Join(home, credentials.DefaultRelPath)
+	cf, err := credentials.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	creds, ok := cf.Get(f.srv.URL)
+	if !ok {
+		t.Fatalf("credentials not stored for %s; file: %+v", f.srv.URL, cf)
+	}
+	if creds.Token != "ctnr_test_token" {
+		t.Fatalf("Token = %q, want ctnr_test_token", creds.Token)
+	}
+	if creds.UserEmail != "alice@example.com" {
+		t.Fatalf("UserEmail = %q", creds.UserEmail)
+	}
+	if creds.OrgID != "org_42" {
+		t.Fatalf("OrgID = %q", creds.OrgID)
+	}
+	if creds.IssuedAt.IsZero() {
+		t.Fatal("IssuedAt not set")
+	}
+	if creds.ExpiresAt == nil {
+		t.Fatal("ExpiresAt not parsed from RFC3339 response")
+	}
+	if cf.DefaultServer == "" {
+		t.Fatal("DefaultServer not auto-set on first login")
+	}
+
+	// File mode 0600 (POSIX only).
+	if runtime.GOOS != "windows" {
+		st, _ := os.Stat(path)
+		if st.Mode().Perm() != 0o600 {
+			t.Fatalf("file mode = %o, want 0600", st.Mode().Perm())
+		}
+	}
+
+	// Output mentions the user code and the email.
+	o := out.String()
+	if !strings.Contains(o, "WXYZ-1234") {
+		t.Errorf("output missing user code:\n%s", o)
+	}
+	if !strings.Contains(o, "alice@example.com") {
+		t.Errorf("output missing user email:\n%s", o)
+	}
+
+	// Device name defaulted to non-empty.
+	got := f.gotDevice.Load()
+	if got == nil || got.(string) == "" {
+		t.Errorf("device_name not sent in createSession request")
+	}
+}
+
+func TestLogin_DeniedInBrowser_Errors(t *testing.T) {
+	withTempHome(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/cli/sessions", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(createSessionResp{
+			SessionID:       "sess-x",
+			UserCode:        "DENIED",
+			VerificationURL: "http://example.invalid/cli/authorize",
+			ExpiresIn:       60,
+		})
+	})
+	mux.HandleFunc("/v1/cli/sessions/sess-x/status", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(sessionStatusResp{Status: "denied"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	loginServer = srv.URL
+	loginNoBrowser = true
+	old := loginPollIntervalForTest()
+	defer restorePollInterval(old)
+	setPollInterval(10 * time.Millisecond)
+
+	var out bytes.Buffer
+	loginCmd.SetOut(&out)
+	loginCmd.SetErr(&out)
+	err := runLogin(loginCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "denied") {
+		t.Fatalf("expected denied error, got %v", err)
+	}
+}
+
+func TestLogout_RemovesServer(t *testing.T) {
+	home := withTempHome(t)
+	_ = seedCreds(t, home, "https://cloud.containarium.dev", map[string]credentials.ServerCreds{
+		"https://cloud.containarium.dev":  {Token: "cloud-tok"},
+		"https://self-hosted.example.com": {Token: "self-tok"},
+	})
+
+	loginServer = "https://self-hosted.example.com"
+	logoutAll = false
+	var out bytes.Buffer
+	logoutCmd.SetOut(&out)
+	if err := runLogout(logoutCmd, nil); err != nil {
+		t.Fatalf("runLogout: %v", err)
+	}
+	cf, _ := credentials.Load(filepath.Join(home, credentials.DefaultRelPath))
+	if _, ok := cf.Get("https://self-hosted.example.com"); ok {
+		t.Fatal("self-hosted creds still present after logout")
+	}
+	if _, ok := cf.Get("https://cloud.containarium.dev"); !ok {
+		t.Fatal("cloud creds wrongly removed by single-server logout")
+	}
+}
+
+func TestLogout_All_WipesEverything(t *testing.T) {
+	home := withTempHome(t)
+	_ = seedCreds(t, home, "https://cloud.containarium.dev", map[string]credentials.ServerCreds{
+		"https://cloud.containarium.dev":  {Token: "cloud-tok"},
+		"https://self-hosted.example.com": {Token: "self-tok"},
+	})
+
+	loginServer = ""
+	logoutAll = true
+	var out bytes.Buffer
+	logoutCmd.SetOut(&out)
+	if err := runLogout(logoutCmd, nil); err != nil {
+		t.Fatalf("runLogout --all: %v", err)
+	}
+	cf, _ := credentials.Load(filepath.Join(home, credentials.DefaultRelPath))
+	if len(cf.Servers) != 0 {
+		t.Fatalf("Servers = %+v, want empty", cf.Servers)
+	}
+	if cf.DefaultServer != "" {
+		t.Fatalf("DefaultServer = %q, want empty", cf.DefaultServer)
+	}
+}
+
+func TestLogout_NoDefault_NoServer_Errors(t *testing.T) {
+	withTempHome(t)
+	loginServer = ""
+	logoutAll = false
+	var out bytes.Buffer
+	logoutCmd.SetOut(&out)
+	err := runLogout(logoutCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when no default and no --server")
+	}
+}
+
+func TestWhoami_PrintsIdentity(t *testing.T) {
+	home := withTempHome(t)
+	exp := time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC)
+	_ = seedCreds(t, home, "https://cloud.containarium.dev", map[string]credentials.ServerCreds{
+		"https://cloud.containarium.dev": {
+			Token: "tok", UserEmail: "alice@example.com", OrgID: "org_42",
+			IssuedAt: time.Now().UTC(), ExpiresAt: &exp,
+		},
+	})
+	whoamiServerFlag = ""
+	var out bytes.Buffer
+	whoamiCmd.SetOut(&out)
+	if err := runWhoami(whoamiCmd, nil); err != nil {
+		t.Fatalf("runWhoami: %v", err)
+	}
+	o := out.String()
+	for _, want := range []string{"alice@example.com", "org_42", "cloud.containarium.dev", "2026-12-31"} {
+		if !strings.Contains(o, want) {
+			t.Errorf("whoami output missing %q:\n%s", want, o)
+		}
+	}
+}
+
+func TestWhoami_NoCredentials_Errors(t *testing.T) {
+	withTempHome(t)
+	whoamiServerFlag = ""
+	var out bytes.Buffer
+	whoamiCmd.SetOut(&out)
+	if err := runWhoami(whoamiCmd, nil); err == nil {
+		t.Fatal("expected error when no credentials present")
+	}
+}
+
+func TestConfigGetToken_EmitsTokenNoNewline(t *testing.T) {
+	home := withTempHome(t)
+	_ = seedCreds(t, home, "https://cloud.containarium.dev", map[string]credentials.ServerCreds{
+		"https://cloud.containarium.dev": {Token: "ctnr_pipeable"},
+	})
+	configTokenSrv = ""
+	var out bytes.Buffer
+	configGetTokenCmd.SetOut(&out)
+	if err := runConfigGetToken(configGetTokenCmd, nil); err != nil {
+		t.Fatalf("runConfigGetToken: %v", err)
+	}
+	got := out.String()
+	if got != "ctnr_pipeable" {
+		t.Fatalf("got %q, want %q (no trailing newline)", got, "ctnr_pipeable")
+	}
+}
+
+func TestConfigGetToken_NoCreds_Errors(t *testing.T) {
+	withTempHome(t)
+	configTokenSrv = ""
+	var out bytes.Buffer
+	configGetTokenCmd.SetOut(&out)
+	if err := runConfigGetToken(configGetTokenCmd, nil); err == nil {
+		t.Fatal("expected error when no credentials")
+	}
+}
+
+func TestNormalizeServer_LoginPathTrim(t *testing.T) {
+	got := pickLoginServer("https://cloud.containarium.dev/")
+	if got != "https://cloud.containarium.dev" {
+		t.Fatalf("pickLoginServer = %q", got)
+	}
+	if d := pickLoginServer(""); d != defaultLoginServer {
+		t.Fatalf("default = %q, want %q", d, defaultLoginServer)
+	}
+}
+
+func TestDeviceName_FallbacksAreNonEmpty(t *testing.T) {
+	if deviceName("explicit") != "explicit" {
+		t.Fatal("explicit override not respected")
+	}
+	if deviceName("") == "" {
+		t.Fatal("deviceName fallback returned empty string")
+	}
+}
+
+// The poll-interval is a package-level const for production but we
+// need to override it in tests so the device-flow test runs in
+// milliseconds, not seconds. We swap the global via a mutator
+// rather than threading a parameter through runLogin — it's only
+// used here.
+
+func setPollInterval(d time.Duration) { pollIntervalOverride = d }
+
+func loginPollIntervalForTest() time.Duration { return pollIntervalOverride }
+
+func restorePollInterval(d time.Duration) { pollIntervalOverride = d }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -45,6 +45,31 @@ Examples:
 
   # Show system information
   containarium info`,
+	// PersistentPreRunE fills in the auth token from the
+	// credentials file when neither --token nor
+	// CONTAINARIUM_TOKEN are set. Precedence:
+	//   1. --token flag (explicit)
+	//   2. CONTAINARIUM_TOKEN env var (becomes the flag default
+	//      in init() below — so by the time this runs, both
+	//      collapse into authToken)
+	//   3. ~/.containarium/credentials.json (server matching
+	//      --server, else default_server)
+	// See `containarium login --help`.
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// login / logout / whoami / config get-token are the
+		// commands that produce/consume the credentials file
+		// directly. Skip the auto-fill for them — login is
+		// unauthenticated by definition, and we don't want a
+		// stale token to leak into a logout call.
+		switch {
+		case cmd == loginCmd, cmd == logoutCmd, cmd == whoamiCmd, cmd == configGetTokenCmd:
+			return nil
+		}
+		if authToken == "" {
+			authToken = resolveAuthToken(serverAddr)
+		}
+		return nil
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -100,7 +125,7 @@ func init() {
 
 	// Remote server flags (HTTP mode)
 	rootCmd.PersistentFlags().BoolVar(&httpMode, "http", os.Getenv("CONTAINARIUM_HTTP") == "true", "use HTTP/REST API instead of gRPC (env: CONTAINARIUM_HTTP=true)")
-	rootCmd.PersistentFlags().StringVar(&authToken, "token", os.Getenv("CONTAINARIUM_TOKEN"), "JWT authentication token for HTTP API (env: CONTAINARIUM_TOKEN)")
+	rootCmd.PersistentFlags().StringVar(&authToken, "token", os.Getenv("CONTAINARIUM_TOKEN"), "JWT authentication token for HTTP API. Precedence: 1) --token flag, 2) CONTAINARIUM_TOKEN env, 3) ~/.containarium/credentials.json (populated by `containarium login`).")
 
 	// Version command with verbose flag
 	versionCmd.Flags().BoolVar(&verboseVersion, "verbose", false, "show detailed version information")

--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -253,7 +253,15 @@ func buildRunnerDeps(sentinel, sshUser string) (runner.Deps, string, error) {
 		if err != nil {
 			return runner.Deps{}, "", err
 		}
-		pubBytes, err := os.ReadFile(pubPath)
+		// gosec G304: pubPath comes from a CLI flag the operator
+		// passed themselves. The CLI runs as the operator's UID;
+		// any file it can open, the operator can already `cat`.
+		// Constraining the path would just block legitimate
+		// custom-key-location use cases without any real security
+		// benefit. (Contrast with internal/mcp/runner_tools.go,
+		// where the path IS constrained because the caller may
+		// be a different identity than the daemon.)
+		pubBytes, err := os.ReadFile(pubPath) // #nosec G304 -- operator-supplied path; CLI runs as operator's UID
 		if err != nil {
 			return runner.Deps{}, "", fmt.Errorf("read public key %s: %w", pubPath, err)
 		}

--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -1,0 +1,480 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/footprintai/containarium/internal/client"
+	"github.com/footprintai/containarium/internal/runner"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/ostype"
+	"github.com/spf13/cobra"
+)
+
+// Flags for `containarium runner provision`. Kept as package-level
+// vars to match the pattern in create.go / delete.go / list.go.
+var (
+	runnerRepo           string
+	runnerPAT            string
+	runnerCount          int
+	runnerNamePrefix     string
+	runnerLabels         string
+	runnerNameTemplate   string
+	runnerSSHKeyPath     string
+	runnerSentinelHost   string
+	runnerSSHUser        string
+
+	// runner list / remove
+	runnerListFormat string
+)
+
+var runnerCmd = &cobra.Command{
+	Use:   "runner",
+	Short: "Manage Containarium boxes as GitHub Actions self-hosted runners",
+	Long: `Provision, list, and remove Containarium boxes configured as
+ephemeral GitHub Actions self-hosted runners.
+
+This is the agent-friendly counterpart to the manual flow documented in
+hacks/runner/README.md. The CLI verbs here drive the same install script
+(embedded at compile time), so an agent calling ` + "`provision_runners`" + `
+via MCP and a human running ` + "`containarium runner provision`" + ` both
+end up with provably identical runners.
+
+See ` + "`containarium runner provision --help`" + ` for the most common
+entry point.`,
+}
+
+var runnerProvisionCmd = &cobra.Command{
+	Use:   "provision <repo>",
+	Short: "Create N runner boxes and register them as ephemeral GHA runners",
+	Long: `Create N Containarium boxes and configure each as an ephemeral
+GitHub Actions self-hosted runner for the given repo.
+
+This verb is idempotent: re-running with the same args after a partial
+failure is safe. Boxes that already exist are not recreated; boxes that
+already have containarium-runner.service installed and enabled are not
+re-installed. Agents can call this repeatedly to reconcile state.
+
+Examples:
+  # Provision 3 ephemeral runners for footprintai/containarium
+  containarium runner provision footprintai/containarium \
+      --github-pat ghp_xxxx --count 3
+
+  # Override the prefix (boxes named ci-myrepo-1, -2, -3)
+  containarium runner provision footprintai/containarium \
+      --github-pat ghp_xxxx --count 3 --name-prefix ci-myrepo
+
+  # Custom labels (workflows target with runs-on: [self-hosted, gpu])
+  containarium runner provision footprintai/containarium \
+      --github-pat ghp_xxxx --count 2 --labels gpu,containarium`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRunnerProvision,
+}
+
+var runnerListCmd = &cobra.Command{
+	Use:   "list <repo>",
+	Short: "List provisioned runner boxes and their GitHub registration status",
+	Long: `List Containarium boxes whose name starts with --name-prefix and
+merge their GitHub-side registration status (online / offline / busy /
+unregistered) into a single view.
+
+Read-only.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRunnerList,
+}
+
+var runnerRemoveCmd = &cobra.Command{
+	Use:   "remove <repo> <name>",
+	Short: "Drain a runner, deregister it from GitHub, and delete the box",
+	Long: `Stop the runner service inside the box (which waits for the in-flight
+ephemeral job to finish — this is what "drain" means in the ephemeral
+model), deregister the runner from GitHub, then delete the Containarium
+box.
+
+GitHub-side deregister is best-effort: if the API call fails, we still
+proceed to delete the box so a transient GitHub blip doesn't leak a
+box. A stale "offline" row may remain in GitHub's UI; remove it manually
+or re-run this command once the API is back.`,
+	Args: cobra.ExactArgs(2),
+	RunE: runRunnerRemove,
+}
+
+func init() {
+	rootCmd.AddCommand(runnerCmd)
+	runnerCmd.AddCommand(runnerProvisionCmd)
+	runnerCmd.AddCommand(runnerListCmd)
+	runnerCmd.AddCommand(runnerRemoveCmd)
+
+	// Provision flags.
+	runnerProvisionCmd.Flags().StringVar(&runnerPAT, "github-pat", os.Getenv("GH_PAT"), "GitHub PAT with `repo` scope (env: GH_PAT). REQUIRED.")
+	runnerProvisionCmd.Flags().IntVar(&runnerCount, "count", 1, "How many runners to provision (1..100)")
+	runnerProvisionCmd.Flags().StringVar(&runnerNamePrefix, "name-prefix", "ci-runner", "Prefix for generated box names")
+	runnerProvisionCmd.Flags().StringVar(&runnerLabels, "labels", "containarium,ephemeral", "Comma-separated runner labels")
+	runnerProvisionCmd.Flags().StringVar(&runnerNameTemplate, "runner-name-template", "{prefix}-{i}", "Template for box names; {prefix} and {i} are substituted")
+	runnerProvisionCmd.Flags().StringVar(&runnerSSHKeyPath, "ssh-key", "", "Path to SSH public key used when creating new boxes (default: ~/.ssh/id_rsa.pub)")
+	runnerProvisionCmd.Flags().StringVar(&runnerSentinelHost, "sentinel", os.Getenv("CONTAINARIUM_SENTINEL_HOST"), "Sentinel SSH host (env: CONTAINARIUM_SENTINEL_HOST). REQUIRED for the install step.")
+	runnerProvisionCmd.Flags().StringVar(&runnerSSHUser, "ssh-user", "", "SSH user to use when SSH'ing into a runner box (default: the runner name, via sshpiper)")
+
+	// List flags.
+	runnerListCmd.Flags().StringVar(&runnerPAT, "github-pat", os.Getenv("GH_PAT"), "GitHub PAT with `repo` scope (env: GH_PAT). REQUIRED.")
+	runnerListCmd.Flags().StringVar(&runnerNamePrefix, "name-prefix", "ci-runner", "Box name prefix to filter on")
+	runnerListCmd.Flags().StringVar(&runnerListFormat, "format", "table", "Output format: table or json")
+
+	// Remove flags. Reuse PAT/sentinel from above.
+	runnerRemoveCmd.Flags().StringVar(&runnerPAT, "github-pat", os.Getenv("GH_PAT"), "GitHub PAT with `repo` scope (env: GH_PAT). REQUIRED.")
+}
+
+// runRunnerProvision is the cobra handler. Most of the actual
+// work lives in runner.Provision; this glue layer's job is to
+// turn cobra flags into a runner.Options + Deps and render the
+// resulting Result for the human.
+func runRunnerProvision(_ *cobra.Command, args []string) error {
+	repo := args[0]
+	opts := runner.Options{
+		Repo:         repo,
+		PAT:          runnerPAT,
+		Count:        runnerCount,
+		NamePrefix:   runnerNamePrefix,
+		Labels:       runnerLabels,
+		NameTemplate: runnerNameTemplate,
+	}
+	if err := runner.ValidateOptions(opts); err != nil {
+		return err
+	}
+	if runnerSentinelHost == "" {
+		return fmt.Errorf("--sentinel is required (or set CONTAINARIUM_SENTINEL_HOST); the install step needs to SSH into each new box")
+	}
+
+	deps, sshKey, err := buildRunnerDeps(runnerSentinelHost, runnerSSHUser)
+	if err != nil {
+		return err
+	}
+	// Reuse the operator's existing SSH public key when creating
+	// the boxes so the same private key auths the install step.
+	opts.SSHKey = sshKey
+
+	fmt.Printf("Provisioning %d runner(s) for %s …\n", opts.Count, opts.Repo)
+	res, err := runner.Provision(context.Background(), deps, opts)
+	if err != nil {
+		return err
+	}
+
+	printRunnerTable(res.Runners)
+	if res.PartialFailure {
+		// Non-zero exit so CI / shell wrappers can detect partial
+		// failure without parsing the table.
+		return fmt.Errorf("one or more runners failed to provision (see table above)")
+	}
+	return nil
+}
+
+func runRunnerList(_ *cobra.Command, args []string) error {
+	repo := args[0]
+	deps, _, err := buildRunnerDeps("", "") // list doesn't ssh
+	if err != nil {
+		return err
+	}
+	res, err := runner.List(context.Background(), deps, runner.Options{
+		Repo:       repo,
+		PAT:        runnerPAT,
+		NamePrefix: runnerNamePrefix,
+	})
+	if err != nil {
+		return err
+	}
+	switch runnerListFormat {
+	case "table":
+		printRunnerTable(res.Runners)
+	case "json":
+		return printRunnerJSON(res.Runners)
+	default:
+		return fmt.Errorf("unknown format %q (use: table, json)", runnerListFormat)
+	}
+	return nil
+}
+
+func runRunnerRemove(_ *cobra.Command, args []string) error {
+	repo := args[0]
+	name := args[1]
+	deps, _, err := buildRunnerDeps("", "") // remove doesn't need to ssh (drain handled server-side by --ephemeral)
+	if err != nil {
+		return err
+	}
+	st, err := runner.Remove(context.Background(), deps, runner.Options{
+		Repo: repo,
+		PAT:  runnerPAT,
+	}, name)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ %s: %s\n", st.Name, st.State)
+	if st.LastError != "" {
+		fmt.Printf("  note: %s\n", st.LastError)
+	}
+	return nil
+}
+
+// buildRunnerDeps wires the production BoxManager / SSH installer /
+// GitHub client. Returns the deps PLUS the public SSH key text
+// that will be used to create new boxes (so the caller can pass it
+// to runner.Options.SSHKey). Empty sentinel/sshUser means "skip
+// the SSH installer" — caller is using list/remove which don't ssh.
+func buildRunnerDeps(sentinel, sshUser string) (runner.Deps, string, error) {
+	if serverAddr == "" {
+		return runner.Deps{}, "", fmt.Errorf("--server is required (runner provision is a daemon-side operation; local-only Incus mode would need a different SSH path)")
+	}
+
+	// Pick the daemon API — same gRPC vs HTTP toggle used by
+	// create / list / delete elsewhere in the CLI.
+	api, creator, err := buildDaemonAPI()
+	if err != nil {
+		return runner.Deps{}, "", err
+	}
+	boxes := runner.NewDaemonBoxManager(api, creator)
+
+	deps := runner.Deps{
+		Boxes:  boxes,
+		GitHub: runner.NewGitHubClient(nil),
+	}
+
+	var sshPubKey string
+	if sentinel != "" {
+		// Read the operator's existing SSH public key (default
+		// ~/.ssh/id_rsa.pub) and use it for both directions:
+		// the box authorizes that key, and the install step
+		// signs with the matching private key.
+		pubPath, privPath, err := resolveOperatorSSHKey(runnerSSHKeyPath)
+		if err != nil {
+			return runner.Deps{}, "", err
+		}
+		pubBytes, err := os.ReadFile(pubPath)
+		if err != nil {
+			return runner.Deps{}, "", fmt.Errorf("read public key %s: %w", pubPath, err)
+		}
+		sshPubKey = string(pubBytes)
+
+		installer, err := runner.NewSSHInstaller(runner.SSHInstallerConfig{
+			Endpoint: runner.SSHEndpointFunc(func(_ context.Context, boxName string) (string, string, error) {
+				user := sshUser
+				if user == "" {
+					// sshpiper routes ssh user "<boxname>"
+					// to the right backend box; this is the
+					// idiomatic Containarium SSH path.
+					user = boxName
+				}
+				host, port, err := net.SplitHostPort(sentinel)
+				if err != nil {
+					// No port → default 22.
+					host = sentinel
+					port = "22"
+				}
+				return user, net.JoinHostPort(host, port), nil
+			}),
+			PrivateKeyPath: privPath,
+		})
+		if err != nil {
+			return runner.Deps{}, "", err
+		}
+		deps.SSH = installer
+	}
+	return deps, sshPubKey, nil
+}
+
+// resolveOperatorSSHKey picks the SSH key pair to use. If the
+// caller passed --ssh-key it points at the *public* half (matching
+// the convention used by `containarium create --ssh-key`); we
+// derive the private path by trimming a trailing .pub. Empty
+// falls back to ~/.ssh/id_rsa.pub.
+func resolveOperatorSSHKey(pubPathFlag string) (pubPath, privPath string, err error) {
+	pubPath = pubPathFlag
+	if pubPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", "", fmt.Errorf("home dir: %w", err)
+		}
+		pubPath = home + "/.ssh/id_rsa.pub"
+	}
+	if strings.HasPrefix(pubPath, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", "", fmt.Errorf("home dir: %w", err)
+		}
+		pubPath = home + pubPath[1:]
+	}
+	privPath = strings.TrimSuffix(pubPath, ".pub")
+	if privPath == pubPath {
+		// User didn't give us a .pub path. Be conservative:
+		// treat the supplied path as both public and private —
+		// they'll get a useful "parse private key" error if
+		// it was actually a public key.
+		privPath = pubPath
+	}
+	if _, err := os.Stat(pubPath); err != nil {
+		return "", "", fmt.Errorf("ssh public key %s not found (pass --ssh-key or create ~/.ssh/id_rsa.pub): %w", pubPath, err)
+	}
+	return pubPath, privPath, nil
+}
+
+// daemonAPIWrapper adapts an HTTPClient or GRPCClient to the
+// runner.DaemonAPI interface. Done as a thin wrapper struct
+// (rather than declaring the methods directly on the client
+// types, which would be the wrong place for runner-specific
+// glue) so the runner package stays decoupled.
+type daemonAPIWrapper struct {
+	list   func() ([]incus.ContainerInfo, error)
+	get    func(string) (*incus.ContainerInfo, error)
+	delete func(string, bool) error
+}
+
+func (w *daemonAPIWrapper) ListContainers() ([]incus.ContainerInfo, error) { return w.list() }
+func (w *daemonAPIWrapper) GetContainer(u string) (*incus.ContainerInfo, error) {
+	return w.get(u)
+}
+func (w *daemonAPIWrapper) DeleteContainer(u string, force bool) error {
+	return w.delete(u, force)
+}
+
+// buildDaemonAPI returns a runner.DaemonAPI + DaemonCreator
+// backed by either the HTTP or gRPC client, mirroring the
+// transport toggle elsewhere in the CLI. The creator closure
+// captures all the box-shape defaults (small CPU/memory, runner-
+// flavored image) so the runner package doesn't have to know
+// about them.
+func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
+	if httpMode && serverAddr != "" {
+		httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return nil, nil, fmt.Errorf("http client: %w", err)
+		}
+		api := &daemonAPIWrapper{
+			list:   httpClient.ListContainers,
+			get:    httpClient.GetContainer,
+			delete: httpClient.DeleteContainer,
+		}
+		creator := func(_ context.Context, name, sshKey string) (string, error) {
+			info, err := httpClient.CreateContainer(
+				name,
+				"images:ubuntu/24.04",
+				"4",
+				"4GB",
+				"50GB",
+				splitNonEmpty(sshKey),
+				true, // podman
+				"",   // stack
+				"",   // gpu
+				ostype.OSTypeFromString("ubuntu"),
+				false, // monitoring
+				"",    // pool
+				"",    // backend-id
+			)
+			if err != nil {
+				return "", err
+			}
+			return info.Name, nil
+		}
+		return api, creator, nil
+	}
+
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return nil, nil, fmt.Errorf("grpc client: %w", err)
+	}
+	api := &daemonAPIWrapper{
+		list:   grpcClient.ListContainers,
+		get:    grpcClient.GetContainer,
+		delete: grpcClient.DeleteContainer,
+	}
+	creator := func(_ context.Context, name, sshKey string) (string, error) {
+		info, err := grpcClient.CreateContainer(
+			name,
+			"images:ubuntu/24.04",
+			"4",
+			"4GB",
+			"50GB",
+			splitNonEmpty(sshKey),
+			true,
+			"",
+			"",
+			ostype.OSTypeFromString("ubuntu"),
+			false,
+			"",
+			"",
+		)
+		if err != nil {
+			return "", err
+		}
+		return info.Name, nil
+	}
+	return api, creator, nil
+}
+
+// splitNonEmpty returns a single-element []string{s} when s is
+// non-empty, else nil. The daemon's CreateContainer signature
+// wants []string for ssh keys, but the runner orchestrator
+// passes the public key as one string.
+func splitNonEmpty(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	return []string{s}
+}
+
+// printRunnerTable renders a compact summary table to stdout.
+// Same field set the MCP tool returns as JSON, so the human and
+// agent views stay in sync.
+func printRunnerTable(runners []runner.RunnerStatus) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tSTATE\tREGISTERED\tNOTE")
+	for _, r := range runners {
+		registered := "no"
+		if r.Registered {
+			registered = "yes"
+		}
+		note := r.LastError
+		if note == "" {
+			note = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.Name, r.State, registered, note)
+	}
+	_ = w.Flush()
+}
+
+// printRunnerJSON emits the result as JSON for scripting.
+func printRunnerJSON(runners []runner.RunnerStatus) error {
+	// Lightweight inline encoder — avoids pulling in the
+	// existing list.go JSON helper which expects []interface{}.
+	type row struct {
+		Name       string `json:"name"`
+		BoxID      string `json:"box_id"`
+		State      string `json:"state"`
+		Registered bool   `json:"registered"`
+		LastError  string `json:"last_error,omitempty"`
+	}
+	out := make([]row, 0, len(runners))
+	for _, r := range runners {
+		out = append(out, row{
+			Name:       r.Name,
+			BoxID:      r.BoxID,
+			State:      r.State,
+			Registered: r.Registered,
+			LastError:  r.LastError,
+		})
+	}
+	return writeJSON(os.Stdout, out)
+}
+
+// writeJSON renders v as indented JSON to w with a trailing
+// newline. Tiny inline helper rather than pulling in
+// internal/list.go's helper, which expects []interface{}.
+func writeJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}

--- a/internal/credentials/store.go
+++ b/internal/credentials/store.go
@@ -1,0 +1,279 @@
+// Package credentials manages the on-disk store of per-server CLI
+// auth tokens at ~/.containarium/credentials.json, populated by
+// `containarium login` and consumed by the rest of the CLI when no
+// explicit --token / CONTAINARIUM_TOKEN is set.
+//
+// See prd/cloud/cli-login-and-multi-env-ssh.md §"Credentials file
+// format" for the locked schema. Multi-server: a user can be logged
+// into the hosted cloud and one or more self-hosted instances
+// simultaneously.
+//
+// Concurrency: the file is small (<1 KB typical), per-user, and
+// touched only by interactive CLI invocations. We rely on the
+// 0600 perm bits plus the atomic-rename Save below; we do NOT use
+// file locking. If two `login` runs race, the second wins.
+package credentials
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// DefaultRelPath is the path of the credentials file relative to the
+// user's home directory. Exported so tests and the CLI can refer to
+// the same constant.
+const DefaultRelPath = ".containarium/credentials.json"
+
+// ServerCreds is the per-server credential record persisted inside
+// CredentialsFile.Servers. Fields are pointer-free where possible so
+// the JSON round-trip is loss-less.
+//
+// ExpiresAt is a *time.Time because the locked schema explicitly
+// allows `null` (non-expiring tokens — service accounts, dev tokens).
+// Marshalling nil emits JSON `null`, matching the PRD example.
+type ServerCreds struct {
+	Token     string     `json:"token"`
+	UserEmail string     `json:"user_email"`
+	OrgID     string     `json:"org_id"`
+	IssuedAt  time.Time  `json:"issued_at"`
+	ExpiresAt *time.Time `json:"expires_at"`
+}
+
+// CredentialsFile is the on-disk JSON document. DefaultServer is the
+// server the CLI falls back to when --server is unset; it MUST also
+// be a key in Servers (Save enforces this).
+type CredentialsFile struct {
+	DefaultServer string                 `json:"default_server"`
+	Servers       map[string]ServerCreds `json:"servers"`
+}
+
+// NewCredentialsFile returns an empty, valid CredentialsFile. Always
+// prefer this over `&CredentialsFile{}` so the Servers map is
+// initialized (nil-map writes panic).
+func NewCredentialsFile() *CredentialsFile {
+	return &CredentialsFile{
+		Servers: make(map[string]ServerCreds),
+	}
+}
+
+// DefaultPath returns the absolute path to the credentials file
+// under the current user's home directory. Honors $HOME (via
+// os.UserHomeDir) so t.Setenv("HOME", tmpdir) works in tests.
+func DefaultPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(home, DefaultRelPath), nil
+}
+
+// Load reads the credentials file at path. If the file does not
+// exist Load returns an empty, valid CredentialsFile and a nil error
+// — callers should not have to distinguish "never logged in" from
+// "log in and then look up". Any other error (perm denied, malformed
+// JSON, …) is propagated.
+func Load(path string) (*CredentialsFile, error) {
+	// #nosec G304 -- path is supplied by the CLI from the user's
+	// home directory or an explicit override (tests); not attacker
+	// controlled.
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return NewCredentialsFile(), nil
+		}
+		return nil, fmt.Errorf("read credentials file: %w", err)
+	}
+
+	// Empty file → treat as fresh. Some editors leave 0-byte files
+	// behind; this is friendlier than a json.Unmarshal error.
+	if len(b) == 0 {
+		return NewCredentialsFile(), nil
+	}
+
+	cf := NewCredentialsFile()
+	if err := json.Unmarshal(b, cf); err != nil {
+		return nil, fmt.Errorf("parse credentials file %s: %w", path, err)
+	}
+	if cf.Servers == nil {
+		cf.Servers = make(map[string]ServerCreds)
+	}
+	return cf, nil
+}
+
+// Save writes the credentials file atomically (write to .tmp +
+// rename) with 0600 permissions. The parent directory is created
+// with 0700 if missing.
+//
+// DefaultServer is auto-repaired: if it is unset but Servers has
+// exactly one entry, we point to that. If it is set to a server
+// that no longer exists in Servers (e.g. after Remove), we pick
+// any remaining server, or clear it if none remain.
+func Save(path string, cf *CredentialsFile) error {
+	if cf == nil {
+		return fmt.Errorf("nil credentials file")
+	}
+	if cf.Servers == nil {
+		cf.Servers = make(map[string]ServerCreds)
+	}
+
+	// Repair default_server.
+	if _, ok := cf.Servers[cf.DefaultServer]; !ok || cf.DefaultServer == "" {
+		cf.DefaultServer = ""
+		for srv := range cf.Servers {
+			cf.DefaultServer = srv
+			break
+		}
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create credentials dir %s: %w", dir, err)
+	}
+
+	b, err := json.MarshalIndent(cf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal credentials: %w", err)
+	}
+
+	// Atomic rename: write to a sibling temp file, fsync, then
+	// rename over the destination. On POSIX rename is atomic on
+	// the same filesystem, so a crash mid-write never leaves the
+	// real file truncated.
+	tmp, err := os.CreateTemp(dir, ".credentials-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp credentials file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup if anything below fails.
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp credentials file: %w", err)
+	}
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp credentials file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp credentials file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename credentials file into place: %w", err)
+	}
+	return nil
+}
+
+// Get returns the credentials for the given server. The server arg
+// is normalized via NormalizeServer so callers can pass either
+// "cloud.containarium.dev" or "https://cloud.containarium.dev/" and
+// land on the same record.
+//
+// When server is empty, Get returns the DefaultServer's record.
+// Returns (zero, false) if no matching record exists.
+func (cf *CredentialsFile) Get(server string) (ServerCreds, bool) {
+	if cf == nil || cf.Servers == nil {
+		return ServerCreds{}, false
+	}
+	key := server
+	if key == "" {
+		key = cf.DefaultServer
+	}
+	if key == "" {
+		return ServerCreds{}, false
+	}
+	key = NormalizeServer(key)
+	if c, ok := cf.Servers[key]; ok {
+		return c, true
+	}
+	// Fall back to a tolerant lookup: scan keys with their
+	// normalized form. This handles credential files written by
+	// older versions or hand-edited files with trailing slashes.
+	for k, v := range cf.Servers {
+		if NormalizeServer(k) == key {
+			return v, true
+		}
+	}
+	return ServerCreds{}, false
+}
+
+// Set inserts or replaces the record for server. The server key is
+// normalized. If this is the first server in the file, it also
+// becomes the DefaultServer.
+func (cf *CredentialsFile) Set(server string, creds ServerCreds) {
+	if cf.Servers == nil {
+		cf.Servers = make(map[string]ServerCreds)
+	}
+	key := NormalizeServer(server)
+	cf.Servers[key] = creds
+	if cf.DefaultServer == "" {
+		cf.DefaultServer = key
+	}
+}
+
+// Remove deletes the record for server. Returns true if a record
+// was actually removed. If the removed server was the
+// DefaultServer, Save will pick a new default on next write (or
+// clear it if none remain).
+func (cf *CredentialsFile) Remove(server string) bool {
+	if cf == nil || cf.Servers == nil {
+		return false
+	}
+	key := NormalizeServer(server)
+	// First try direct, then tolerant scan (mirrors Get).
+	if _, ok := cf.Servers[key]; ok {
+		delete(cf.Servers, key)
+		if cf.DefaultServer == key {
+			cf.DefaultServer = ""
+		}
+		return true
+	}
+	for k := range cf.Servers {
+		if NormalizeServer(k) == key {
+			delete(cf.Servers, k)
+			if NormalizeServer(cf.DefaultServer) == key {
+				cf.DefaultServer = ""
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeServer canonicalizes a server URL so lookups are stable
+// across "https://x/" vs "https://x" vs "x" inputs.
+//
+// Rules:
+//   - Strip exactly one trailing slash.
+//   - Lower-case the scheme + host portion (paths preserved
+//     case-sensitively, though we don't expect any).
+//   - Leave the scheme as-supplied (we do NOT auto-prepend
+//     https://). The login command is what decides the scheme; the
+//     store just round-trips whatever it's given.
+//
+// The intent is leniency on read, strictness on write — the store
+// is keyed off the normalized form, but callers can look it up
+// loosely.
+func NormalizeServer(server string) string {
+	s := strings.TrimSpace(server)
+	s = strings.TrimRight(s, "/")
+	// Lower-case scheme + host. We do a cheap scheme split rather
+	// than pulling in net/url for the common case.
+	if i := strings.Index(s, "://"); i >= 0 {
+		scheme := strings.ToLower(s[:i])
+		rest := s[i+3:]
+		if j := strings.Index(rest, "/"); j >= 0 {
+			rest = strings.ToLower(rest[:j]) + rest[j:]
+		} else {
+			rest = strings.ToLower(rest)
+		}
+		s = scheme + "://" + rest
+	} else {
+		s = strings.ToLower(s)
+	}
+	return s
+}

--- a/internal/credentials/store_test.go
+++ b/internal/credentials/store_test.go
@@ -1,0 +1,316 @@
+package credentials
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withTempHome redirects $HOME to a freshly created tempdir for the
+// duration of the test. Returns the path so callers can assert on
+// it. Uses t.Setenv so the env var is reverted automatically.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// macOS / windows also honor USERPROFILE in some Go stdlib
+	// paths; set it too so DefaultPath is deterministic across
+	// platforms.
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+	return home
+}
+
+func TestDefaultPath_UsesHome(t *testing.T) {
+	home := withTempHome(t)
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	want := filepath.Join(home, DefaultRelPath)
+	if got != want {
+		t.Fatalf("DefaultPath = %q, want %q", got, want)
+	}
+}
+
+func TestLoad_MissingFile_ReturnsEmpty(t *testing.T) {
+	home := withTempHome(t)
+	path := filepath.Join(home, DefaultRelPath)
+
+	cf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cf == nil {
+		t.Fatal("Load returned nil for missing file")
+	}
+	if len(cf.Servers) != 0 {
+		t.Fatalf("Load returned %d servers for missing file, want 0", len(cf.Servers))
+	}
+	if cf.DefaultServer != "" {
+		t.Fatalf("Load returned DefaultServer = %q for missing file", cf.DefaultServer)
+	}
+}
+
+func TestLoad_EmptyFile_ReturnsEmpty(t *testing.T) {
+	home := withTempHome(t)
+	dir := filepath.Join(home, ".containarium")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, "credentials.json")
+	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
+		t.Fatalf("write empty file: %v", err)
+	}
+	cf, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load on empty file: %v", err)
+	}
+	if len(cf.Servers) != 0 {
+		t.Fatalf("Load on empty file produced %d servers", len(cf.Servers))
+	}
+}
+
+func TestLoad_MalformedJSON_Errors(t *testing.T) {
+	home := withTempHome(t)
+	dir := filepath.Join(home, ".containarium")
+	_ = os.MkdirAll(dir, 0o700)
+	path := filepath.Join(dir, "credentials.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load on malformed JSON expected error, got nil")
+	}
+}
+
+func TestSaveLoad_RoundTrip(t *testing.T) {
+	home := withTempHome(t)
+	path := filepath.Join(home, DefaultRelPath)
+
+	issued := time.Date(2026, 5, 24, 10, 15, 30, 0, time.UTC)
+	cf := NewCredentialsFile()
+	cf.Set("https://cloud.containarium.dev", ServerCreds{
+		Token:     "ctnr_a7B3",
+		UserEmail: "alice@example.com",
+		OrgID:     "org_123",
+		IssuedAt:  issued,
+		ExpiresAt: nil,
+	})
+
+	if err := Save(path, cf); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// File mode should be 0600.
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if runtime.GOOS != "windows" && st.Mode().Perm() != 0o600 {
+		t.Fatalf("file mode = %o, want 0600", st.Mode().Perm())
+	}
+
+	// Round-trip.
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	creds, ok := got.Get("https://cloud.containarium.dev")
+	if !ok {
+		t.Fatal("Get after Save: not found")
+	}
+	if creds.Token != "ctnr_a7B3" || creds.UserEmail != "alice@example.com" || creds.OrgID != "org_123" {
+		t.Fatalf("creds mismatch: %+v", creds)
+	}
+	if !creds.IssuedAt.Equal(issued) {
+		t.Fatalf("IssuedAt = %v, want %v", creds.IssuedAt, issued)
+	}
+	if creds.ExpiresAt != nil {
+		t.Fatalf("ExpiresAt = %v, want nil", creds.ExpiresAt)
+	}
+	if got.DefaultServer != "https://cloud.containarium.dev" {
+		t.Fatalf("DefaultServer = %q, want auto-set to the only server", got.DefaultServer)
+	}
+}
+
+func TestSave_ExpiresAtSerializesAsNull(t *testing.T) {
+	home := withTempHome(t)
+	path := filepath.Join(home, DefaultRelPath)
+	cf := NewCredentialsFile()
+	cf.Set("https://x", ServerCreds{Token: "t", IssuedAt: time.Now()})
+	if err := Save(path, cf); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// Must contain `"expires_at": null` — locked PRD field.
+	if !strings.Contains(string(b), `"expires_at": null`) {
+		t.Fatalf("file missing expires_at: null marker:\n%s", string(b))
+	}
+}
+
+func TestMultiServer_Isolation(t *testing.T) {
+	home := withTempHome(t)
+	path := filepath.Join(home, DefaultRelPath)
+
+	cf := NewCredentialsFile()
+	cf.Set("https://cloud.containarium.dev", ServerCreds{Token: "cloud-tok", UserEmail: "alice@example.com"})
+	cf.Set("https://self-hosted.example.com", ServerCreds{Token: "self-tok", UserEmail: "alice@example.com"})
+	cf.DefaultServer = "https://cloud.containarium.dev"
+
+	if err := Save(path, cf); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	cloudCreds, ok := got.Get("https://cloud.containarium.dev")
+	if !ok || cloudCreds.Token != "cloud-tok" {
+		t.Fatalf("cloud lookup failed: %+v ok=%v", cloudCreds, ok)
+	}
+	selfCreds, ok := got.Get("https://self-hosted.example.com")
+	if !ok || selfCreds.Token != "self-tok" {
+		t.Fatalf("self-hosted lookup failed: %+v ok=%v", selfCreds, ok)
+	}
+	// Empty server → default.
+	defCreds, ok := got.Get("")
+	if !ok || defCreds.Token != "cloud-tok" {
+		t.Fatalf("default lookup failed: %+v ok=%v", defCreds, ok)
+	}
+}
+
+func TestNormalizeServer(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"https://cloud.containarium.dev", "https://cloud.containarium.dev"},
+		{"https://cloud.containarium.dev/", "https://cloud.containarium.dev"},
+		{"HTTPS://Cloud.Containarium.Dev/", "https://cloud.containarium.dev"},
+		{"  https://x/  ", "https://x"},
+		{"cloud.containarium.dev", "cloud.containarium.dev"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := NormalizeServer(tc.in); got != tc.want {
+			t.Errorf("NormalizeServer(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestGet_TolerantLookup(t *testing.T) {
+	cf := NewCredentialsFile()
+	// Stored with trailing slash (older / hand-edited).
+	cf.Servers["https://cloud.containarium.dev/"] = ServerCreds{Token: "tok"}
+	cf.DefaultServer = "https://cloud.containarium.dev/"
+
+	got, ok := cf.Get("https://cloud.containarium.dev")
+	if !ok {
+		t.Fatal("tolerant Get failed")
+	}
+	if got.Token != "tok" {
+		t.Fatalf("got %q, want tok", got.Token)
+	}
+}
+
+func TestRemove_ClearsDefaultIfMatches(t *testing.T) {
+	home := withTempHome(t)
+	path := filepath.Join(home, DefaultRelPath)
+
+	cf := NewCredentialsFile()
+	cf.Set("https://a", ServerCreds{Token: "a"})
+	cf.Set("https://b", ServerCreds{Token: "b"})
+	cf.DefaultServer = "https://a"
+
+	if removed := cf.Remove("https://a"); !removed {
+		t.Fatal("Remove returned false for present server")
+	}
+	if cf.DefaultServer != "" {
+		t.Fatalf("DefaultServer = %q after removing it, want cleared", cf.DefaultServer)
+	}
+	// Save → repair default to the remaining server.
+	if err := Save(path, cf); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, _ := Load(path)
+	if got.DefaultServer != "https://b" {
+		t.Fatalf("DefaultServer after Save = %q, want auto-repaired to https://b", got.DefaultServer)
+	}
+}
+
+func TestRemove_AbsentReturnsFalse(t *testing.T) {
+	cf := NewCredentialsFile()
+	cf.Set("https://a", ServerCreds{Token: "a"})
+	if cf.Remove("https://missing") {
+		t.Fatal("Remove returned true for absent server")
+	}
+}
+
+func TestSave_AtomicReplaceLeavesNoTempFiles(t *testing.T) {
+	home := withTempHome(t)
+	path := filepath.Join(home, DefaultRelPath)
+	cf := NewCredentialsFile()
+	cf.Set("https://x", ServerCreds{Token: "t"})
+	for i := 0; i < 3; i++ {
+		if err := Save(path, cf); err != nil {
+			t.Fatalf("Save #%d: %v", i, err)
+		}
+	}
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestSchema_MatchesPRDExample(t *testing.T) {
+	// PRD-locked example from prd/cloud/cli-login-and-multi-env-ssh.md
+	// §"Credentials file format". We unmarshal the exact JSON and
+	// verify every field round-trips.
+	const example = `{
+  "default_server": "https://cloud.containarium.dev",
+  "servers": {
+    "https://cloud.containarium.dev": {
+      "token": "ctnr_a7B3...",
+      "user_email": "alice@example.com",
+      "org_id": "...",
+      "issued_at": "2026-05-24T10:15:30Z",
+      "expires_at": null
+    }
+  }
+}`
+	var cf CredentialsFile
+	if err := json.Unmarshal([]byte(example), &cf); err != nil {
+		t.Fatalf("PRD example failed to parse: %v", err)
+	}
+	if cf.DefaultServer != "https://cloud.containarium.dev" {
+		t.Fatalf("DefaultServer = %q", cf.DefaultServer)
+	}
+	creds, ok := cf.Servers["https://cloud.containarium.dev"]
+	if !ok {
+		t.Fatal("PRD example missing server entry after parse")
+	}
+	if creds.Token != "ctnr_a7B3..." || creds.UserEmail != "alice@example.com" || creds.OrgID != "..." {
+		t.Fatalf("creds mismatch: %+v", creds)
+	}
+	if creds.ExpiresAt != nil {
+		t.Fatalf("ExpiresAt = %v, want nil for PRD null", creds.ExpiresAt)
+	}
+	want := time.Date(2026, 5, 24, 10, 15, 30, 0, time.UTC)
+	if !creds.IssuedAt.Equal(want) {
+		t.Fatalf("IssuedAt = %v, want %v", creds.IssuedAt, want)
+	}
+}

--- a/internal/mcp/runner_tools.go
+++ b/internal/mcp/runner_tools.go
@@ -1,0 +1,398 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/footprintai/containarium/internal/runner"
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// runnerToolDescriptions is the MCP-side tool catalog for the
+// runner-provision feature. Defined as a function (not a slice
+// literal at file scope) so the registration list in tools.go
+// can pull it in via runnerTools() — keeps tools.go's slice
+// literal length manageable.
+//
+// Per CLAUDE.md: every tool here is a thin Go wrapper over the
+// same function the CLI handler calls (runner.Provision /
+// runner.List / runner.Remove in internal/runner). DO NOT make
+// these tools talk to a different code path than the CLI does.
+func runnerTools() []Tool {
+	return []Tool{
+		{
+			Name: "provision_runners",
+			Description: "Provision N Containarium boxes as ephemeral GitHub Actions " +
+				"self-hosted runners for a given repo. Each runner registers with " +
+				"`[self-hosted, containarium, ephemeral]` labels (overridable). " +
+				"Idempotent: re-running with the same args after a partial failure " +
+				"is a safe reconcile — boxes that already exist are not recreated, " +
+				"and boxes whose containarium-runner.service is already enabled " +
+				"are not re-installed.\n\n" +
+				"Returns a per-runner status array (name, box_id, state, " +
+				"last_error). The top-level partial_failure flag is true when " +
+				"any runner failed; the call still succeeds (the per-runner " +
+				"detail is the agent's hint for what to retry).\n\n" +
+				"State values:\n" +
+				"  - provisioned: box created + service installed + GitHub registered\n" +
+				"  - registering: install OK, GitHub poll timed out (usually transient)\n" +
+				"  - exists:      idempotent re-run — both box and service were already set up\n" +
+				"  - failed:      see last_error for the reason\n\n" +
+				"This wraps the same code path as `containarium runner provision` " +
+				"on the CLI — agents and operators get identical runners.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"repo": map[string]interface{}{
+						"type":        "string",
+						"description": "GitHub repo in owner/repo format (e.g. footprintai/containarium).",
+					},
+					"github_pat": map[string]interface{}{
+						"type":        "string",
+						"description": "GitHub Personal Access Token with `repo` scope. Used both to register the runner and to poll the runners-list API.",
+					},
+					"count": map[string]interface{}{
+						"type":        "integer",
+						"description": "Number of runners to provision (1..100). Default 1.",
+					},
+					"name_prefix": map[string]interface{}{
+						"type":        "string",
+						"description": "Prefix for generated box names. Default 'ci-runner'.",
+					},
+					"labels": map[string]interface{}{
+						"type":        "string",
+						"description": "Comma-separated runner labels. Default 'containarium,ephemeral'.",
+					},
+					"runner_name_template": map[string]interface{}{
+						"type":        "string",
+						"description": "Template for box names; {prefix} and {i} are substituted. Default '{prefix}-{i}'.",
+					},
+					"sentinel": map[string]interface{}{
+						"type":        "string",
+						"description": "Sentinel SSH host (default $CONTAINARIUM_SENTINEL_HOST). The install step SSHes into each new box through sshpiper at this address.",
+					},
+					"ssh_key_path": map[string]interface{}{
+						"type":        "string",
+						"description": "Path to the SSH public key used to create boxes and SSH into them for install. Default ~/.ssh/id_rsa.pub.",
+					},
+				},
+				"required": []string{"repo", "github_pat"},
+			},
+			Handler: handleProvisionRunners,
+		},
+		{
+			Name: "list_runners",
+			Description: "List provisioned runner boxes. Merges the local (boxes whose " +
+				"name starts with name_prefix) and GitHub (registered runners) " +
+				"views into a single result so the agent can tell at a glance " +
+				"whether a box is online, offline, busy, or unregistered.\n\n" +
+				"Read-only.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"repo": map[string]interface{}{
+						"type":        "string",
+						"description": "GitHub repo in owner/repo format.",
+					},
+					"github_pat": map[string]interface{}{
+						"type":        "string",
+						"description": "GitHub PAT with `repo` scope.",
+					},
+					"name_prefix": map[string]interface{}{
+						"type":        "string",
+						"description": "Box name prefix to filter on. Default 'ci-runner'.",
+					},
+				},
+				"required": []string{"repo", "github_pat"},
+			},
+			Handler: handleListRunners,
+		},
+		{
+			Name: "remove_runner",
+			Description: "Drain, deregister, and delete one runner box. The drain step is " +
+				"implicit in the --ephemeral runner model: stopping the systemd unit " +
+				"waits for the in-flight job to exit because each iteration of the run " +
+				"loop is exactly one job.\n\n" +
+				"GitHub-side deregister is best-effort: if the API fails the box is " +
+				"still deleted, so a transient github.com blip doesn't leak a box. " +
+				"A stale 'offline' row may remain in GitHub's UI; remove it manually " +
+				"or re-run once the API recovers.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"repo": map[string]interface{}{
+						"type":        "string",
+						"description": "GitHub repo in owner/repo format.",
+					},
+					"github_pat": map[string]interface{}{
+						"type":        "string",
+						"description": "GitHub PAT with `repo` scope.",
+					},
+					"name": map[string]interface{}{
+						"type":        "string",
+						"description": "Box / runner name to remove.",
+					},
+				},
+				"required": []string{"repo", "github_pat", "name"},
+			},
+			Handler: handleRemoveRunner,
+		},
+	}
+}
+
+// mcpDaemonAPI adapts the MCP HTTP Client to the runner.DaemonAPI
+// interface. The MCP client doesn't return incus.ContainerInfo
+// directly — we translate from its own Container shape, copying
+// over the fields runner.List needs (just Name, in practice).
+type mcpDaemonAPI struct{ c *Client }
+
+func (a *mcpDaemonAPI) ListContainers() ([]incus.ContainerInfo, error) {
+	resp, err := a.c.ListContainers()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]incus.ContainerInfo, 0, len(resp.Containers))
+	for _, c := range resp.Containers {
+		out = append(out, incus.ContainerInfo{Name: c.Name, State: c.State})
+	}
+	return out, nil
+}
+
+func (a *mcpDaemonAPI) GetContainer(username string) (*incus.ContainerInfo, error) {
+	resp, err := a.c.GetContainer(username)
+	if err != nil {
+		return nil, err
+	}
+	return &incus.ContainerInfo{Name: resp.Container.Name, State: resp.Container.State}, nil
+}
+
+func (a *mcpDaemonAPI) DeleteContainer(username string, force bool) error {
+	_, err := a.c.DeleteContainer(username, force)
+	return err
+}
+
+// buildRunnerDeps wires the production runner.Deps for an MCP
+// tool call. Two flavors:
+//   - withSSH=true:  full Provision flow (needs sentinel + SSH key)
+//   - withSSH=false: List / Remove path (no SSH required)
+//
+// Per CLAUDE.md: this is the same shape of dependency graph the
+// CLI builds in internal/cmd/runner.go — both call into
+// internal/runner with the same orchestrator.
+func buildMCPRunnerDeps(client *Client, sentinel, sshKeyPath string, withSSH bool) (runner.Deps, string, error) {
+	api := &mcpDaemonAPI{c: client}
+	creator := func(_ context.Context, name, sshPubKey string) (string, error) {
+		req := CreateContainerRequest{
+			Username: name,
+			Resources: &ResourceLimits{
+				CPU:    "4",
+				Memory: "4GB",
+				Disk:   "50GB",
+			},
+			Image:        "images:ubuntu/24.04",
+			EnablePodman: true,
+			SSHKeys:      splitMCPKey(sshPubKey),
+		}
+		resp, err := client.CreateContainer(req)
+		if err != nil {
+			return "", err
+		}
+		return resp.Container.Name, nil
+	}
+	boxes := runner.NewDaemonBoxManager(api, creator)
+
+	deps := runner.Deps{
+		Boxes:  boxes,
+		GitHub: runner.NewGitHubClient(nil),
+	}
+
+	var sshPubKey string
+	if withSSH {
+		if sentinel == "" {
+			sentinel = client.SentinelHost
+		}
+		if sentinel == "" {
+			return runner.Deps{}, "", fmt.Errorf("sentinel host is required (pass `sentinel` arg or set CONTAINARIUM_SENTINEL_HOST in the MCP env)")
+		}
+		pubPath, privPath, err := resolveMCPSSHKey(sshKeyPath)
+		if err != nil {
+			return runner.Deps{}, "", err
+		}
+		pubBytes, err := os.ReadFile(pubPath)
+		if err != nil {
+			return runner.Deps{}, "", fmt.Errorf("read ssh public key %s: %w", pubPath, err)
+		}
+		sshPubKey = string(pubBytes)
+		installer, err := runner.NewSSHInstaller(runner.SSHInstallerConfig{
+			Endpoint: runner.SSHEndpointFunc(func(_ context.Context, boxName string) (string, string, error) {
+				host, port, err := net.SplitHostPort(sentinel)
+				if err != nil {
+					host = sentinel
+					port = "22"
+				}
+				return boxName, net.JoinHostPort(host, port), nil
+			}),
+			PrivateKeyPath: privPath,
+		})
+		if err != nil {
+			return runner.Deps{}, "", err
+		}
+		deps.SSH = installer
+	}
+	return deps, sshPubKey, nil
+}
+
+func splitMCPKey(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	return []string{s}
+}
+
+// resolveMCPSSHKey picks public + private paths the same way the
+// CLI's resolveOperatorSSHKey does. Kept separate (rather than
+// importing internal/cmd) to avoid the cmd↔mcp coupling that
+// would otherwise creep in.
+func resolveMCPSSHKey(pubPathFlag string) (pubPath, privPath string, err error) {
+	pubPath = pubPathFlag
+	if pubPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", "", fmt.Errorf("home dir: %w", err)
+		}
+		pubPath = home + "/.ssh/id_rsa.pub"
+	}
+	if strings.HasPrefix(pubPath, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", "", fmt.Errorf("home dir: %w", err)
+		}
+		pubPath = home + pubPath[1:]
+	}
+	privPath = strings.TrimSuffix(pubPath, ".pub")
+	if privPath == pubPath {
+		privPath = pubPath
+	}
+	if _, err := os.Stat(pubPath); err != nil {
+		return "", "", fmt.Errorf("ssh public key %s not found (pass ssh_key_path arg or create ~/.ssh/id_rsa.pub): %w", pubPath, err)
+	}
+	return pubPath, privPath, nil
+}
+
+// handleProvisionRunners is the MCP-tool entry point. Parses the
+// args, builds deps, calls runner.Provision, returns the typed
+// result as JSON so the agent has structured fields to reason
+// about (not just a human-readable paragraph).
+func handleProvisionRunners(client *Client, args map[string]interface{}) (string, error) {
+	repo, _ := args["repo"].(string)
+	pat, _ := args["github_pat"].(string)
+	if repo == "" || pat == "" {
+		return "", fmt.Errorf("repo and github_pat are required")
+	}
+	count := 1
+	if n, ok := getIntArg(args, "count"); ok {
+		count = n
+	}
+	opts := runner.Options{
+		Repo:         repo,
+		PAT:          pat,
+		Count:        count,
+		NamePrefix:   getStringArg(args, "name_prefix", "ci-runner"),
+		Labels:       getStringArg(args, "labels", "containarium,ephemeral"),
+		NameTemplate: getStringArg(args, "runner_name_template", "{prefix}-{i}"),
+	}
+	if err := runner.ValidateOptions(opts); err != nil {
+		return "", err
+	}
+
+	sentinel := getStringArg(args, "sentinel", "")
+	sshKeyPath := getStringArg(args, "ssh_key_path", "")
+	deps, sshPubKey, err := buildMCPRunnerDeps(client, sentinel, sshKeyPath, true)
+	if err != nil {
+		return "", err
+	}
+	opts.SSHKey = sshPubKey
+
+	res, err := runner.Provision(context.Background(), deps, opts)
+	if err != nil {
+		return "", err
+	}
+	return renderRunnerResultJSON(res), nil
+}
+
+func handleListRunners(client *Client, args map[string]interface{}) (string, error) {
+	repo, _ := args["repo"].(string)
+	pat, _ := args["github_pat"].(string)
+	if repo == "" || pat == "" {
+		return "", fmt.Errorf("repo and github_pat are required")
+	}
+	deps, _, err := buildMCPRunnerDeps(client, "", "", false)
+	if err != nil {
+		return "", err
+	}
+	res, err := runner.List(context.Background(), deps, runner.Options{
+		Repo:       repo,
+		PAT:        pat,
+		NamePrefix: getStringArg(args, "name_prefix", "ci-runner"),
+	})
+	if err != nil {
+		return "", err
+	}
+	return renderRunnerResultJSON(res), nil
+}
+
+func handleRemoveRunner(client *Client, args map[string]interface{}) (string, error) {
+	repo, _ := args["repo"].(string)
+	pat, _ := args["github_pat"].(string)
+	name, _ := args["name"].(string)
+	if repo == "" || pat == "" || name == "" {
+		return "", fmt.Errorf("repo, github_pat, and name are required")
+	}
+	deps, _, err := buildMCPRunnerDeps(client, "", "", false)
+	if err != nil {
+		return "", err
+	}
+	st, err := runner.Remove(context.Background(), deps, runner.Options{
+		Repo: repo, PAT: pat,
+	}, name)
+	if err != nil {
+		return "", err
+	}
+	out, _ := json.MarshalIndent(st, "", "  ")
+	return string(out), nil
+}
+
+// renderRunnerResultJSON serializes a runner.Result in the shape
+// documented in the tool descriptions: top-level partial_failure
+// flag + a runners array of {name, box_id, state, registered,
+// last_error}.
+func renderRunnerResultJSON(res *runner.Result) string {
+	type row struct {
+		Name       string `json:"name"`
+		BoxID      string `json:"box_id"`
+		State      string `json:"state"`
+		Registered bool   `json:"registered"`
+		LastError  string `json:"last_error,omitempty"`
+	}
+	rows := make([]row, 0, len(res.Runners))
+	for _, r := range res.Runners {
+		rows = append(rows, row{
+			Name:       r.Name,
+			BoxID:      r.BoxID,
+			State:      r.State,
+			Registered: r.Registered,
+			LastError:  r.LastError,
+		})
+	}
+	out := map[string]interface{}{
+		"runners":         rows,
+		"partial_failure": res.PartialFailure,
+	}
+	b, _ := json.MarshalIndent(out, "", "  ")
+	return string(b)
+}

--- a/internal/mcp/runner_tools.go
+++ b/internal/mcp/runner_tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/footprintai/containarium/internal/runner"
@@ -222,7 +223,11 @@ func buildMCPRunnerDeps(client *Client, sentinel, sshKeyPath string, withSSH boo
 		if err != nil {
 			return runner.Deps{}, "", err
 		}
-		pubBytes, err := os.ReadFile(pubPath)
+		// gosec G304: pubPath comes from resolveMCPSSHKey, which
+		// constrains the path to ~/.ssh/ after Clean + absolute
+		// resolution. Caller-supplied paths that escape that root
+		// are rejected with InvalidArgument before reaching here.
+		pubBytes, err := os.ReadFile(pubPath) // #nosec G304 -- constrained to ~/.ssh by resolveMCPSSHKey
 		if err != nil {
 			return runner.Deps{}, "", fmt.Errorf("read ssh public key %s: %w", pubPath, err)
 		}
@@ -258,22 +263,65 @@ func splitMCPKey(s string) []string {
 // CLI's resolveOperatorSSHKey does. Kept separate (rather than
 // importing internal/cmd) to avoid the cmd↔mcp coupling that
 // would otherwise creep in.
+// resolveMCPSSHKey turns a caller-supplied path into a (pubPath,
+// privPath) pair, restricting both to the MCP daemon user's
+// ~/.ssh/ directory.
+//
+// Why constrained: this is the MCP-side resolver. An authenticated
+// MCP caller could otherwise pass an arbitrary `ssh_key_path` and
+// trick the daemon into reading any file the daemon's UID can read
+// (gosec G304). The CLI-side resolver (cmd/runner.go) has no such
+// restriction because the CLI runs as the operator and they can
+// `cat` anything they want anyway.
+//
+// Allowed shapes:
+//
+//	""              → ~/.ssh/id_rsa.pub  (default for the daemon user)
+//	"~/.ssh/foo"    → ~/.ssh/foo         (tilde-expanded, must still resolve under ~/.ssh)
+//	"foo"           → ~/.ssh/foo         (bare filename — sugar for ~/.ssh/foo)
+//
+// Anything that resolves outside ~/.ssh/ (absolute paths to other
+// directories, `..` escapes after Clean, symlink-resolved escapes)
+// is rejected with InvalidArgument.
 func resolveMCPSSHKey(pubPathFlag string) (pubPath, privPath string, err error) {
-	pubPath = pubPathFlag
-	if pubPath == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", "", fmt.Errorf("home dir: %w", err)
-		}
-		pubPath = home + "/.ssh/id_rsa.pub"
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", fmt.Errorf("home dir: %w", err)
 	}
-	if strings.HasPrefix(pubPath, "~/") {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", "", fmt.Errorf("home dir: %w", err)
-		}
-		pubPath = home + pubPath[1:]
+	sshDir := filepath.Join(home, ".ssh")
+
+	raw := pubPathFlag
+	switch {
+	case raw == "":
+		raw = filepath.Join(sshDir, "id_rsa.pub")
+	case strings.HasPrefix(raw, "~/"):
+		raw = filepath.Join(home, raw[2:])
+	case !strings.Contains(raw, "/"):
+		// Bare filename → treat as a key in ~/.ssh/.
+		raw = filepath.Join(sshDir, raw)
 	}
+
+	// Clean removes `..` and `.` segments and normalizes separators.
+	cleaned := filepath.Clean(raw)
+	abs, err := filepath.Abs(cleaned)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve ssh key path: %w", err)
+	}
+
+	// Constrain to ~/.ssh/. We use the resolved absolute path for
+	// both sides of the prefix check so that anything escaping via
+	// `..` after Clean (defensive — Clean already handles most)
+	// gets rejected here. A trailing separator on sshDir is added
+	// so "/home/x/.ssh-evil" doesn't match "/home/x/.ssh".
+	sshDirAbs, err := filepath.Abs(sshDir)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve ssh dir: %w", err)
+	}
+	if !strings.HasPrefix(abs, sshDirAbs+string(os.PathSeparator)) && abs != sshDirAbs {
+		return "", "", fmt.Errorf("ssh_key_path must resolve under %s; got %s", sshDirAbs, abs)
+	}
+
+	pubPath = abs
 	privPath = strings.TrimSuffix(pubPath, ".pub")
 	if privPath == pubPath {
 		privPath = pubPath

--- a/internal/mcp/runner_tools_test.go
+++ b/internal/mcp/runner_tools_test.go
@@ -1,0 +1,125 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveMCPSSHKey_PathConstraints exercises the path constraint
+// added in response to gosec G304: an authenticated MCP caller must
+// not be able to pass an arbitrary `ssh_key_path` and trick the
+// daemon into reading files outside ~/.ssh/.
+//
+// We swap HOME to a tmpdir so the tests are hermetic.
+func TestResolveMCPSSHKey_PathConstraints(t *testing.T) {
+	tmpHome := t.TempDir()
+	sshDir := filepath.Join(tmpHome, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("mkdir ssh: %v", err)
+	}
+	// Create a fake key file so the existence check passes for the
+	// allowed cases.
+	keyPath := filepath.Join(sshDir, "id_rsa.pub")
+	if err := os.WriteFile(keyPath, []byte("ssh-rsa AAAA fake@host"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	// And a sibling key for the bare-filename test.
+	siblingPath := filepath.Join(sshDir, "ci.pub")
+	if err := os.WriteFile(siblingPath, []byte("ssh-rsa AAAA ci@host"), 0o600); err != nil {
+		t.Fatalf("write sibling: %v", err)
+	}
+	// A file outside ~/.ssh that an attacker might try to target.
+	outsidePath := filepath.Join(tmpHome, "outside.pub")
+	if err := os.WriteFile(outsidePath, []byte("attacker target"), 0o600); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+	// A sibling .ssh-evil dir to test the prefix-with-separator
+	// guard (so "/home/x/.ssh-evil" doesn't match "/home/x/.ssh").
+	evilDir := filepath.Join(tmpHome, ".ssh-evil")
+	if err := os.MkdirAll(evilDir, 0o700); err != nil {
+		t.Fatalf("mkdir evil: %v", err)
+	}
+	evilPath := filepath.Join(evilDir, "id_rsa.pub")
+	if err := os.WriteFile(evilPath, []byte("attacker dir"), 0o600); err != nil {
+		t.Fatalf("write evil: %v", err)
+	}
+
+	t.Setenv("HOME", tmpHome)
+
+	cases := []struct {
+		name        string
+		input       string
+		wantPubPath string // empty = don't check
+		wantErr     string // substring; empty = expect success
+	}{
+		{
+			name:        "empty defaults to ~/.ssh/id_rsa.pub",
+			input:       "",
+			wantPubPath: keyPath,
+		},
+		{
+			name:        "bare filename resolves under ~/.ssh",
+			input:       "ci.pub",
+			wantPubPath: siblingPath,
+		},
+		{
+			name:        "tilde prefix expands to home",
+			input:       "~/.ssh/id_rsa.pub",
+			wantPubPath: keyPath,
+		},
+		{
+			name:    "absolute path outside ~/.ssh rejected",
+			input:   "/etc/shadow",
+			wantErr: "must resolve under",
+		},
+		{
+			name:    "path outside ~/.ssh in same home rejected",
+			input:   outsidePath,
+			wantErr: "must resolve under",
+		},
+		{
+			name:    "dot-dot escape after clean rejected",
+			input:   filepath.Join(sshDir, "..", "outside.pub"),
+			wantErr: "must resolve under",
+		},
+		{
+			name:    "sibling .ssh-evil dir rejected (prefix-with-separator guard)",
+			input:   evilPath,
+			wantErr: "must resolve under",
+		},
+		{
+			name:    "missing file under ~/.ssh surfaces NotFound, not path-rejection",
+			input:   filepath.Join(sshDir, "nope.pub"),
+			wantErr: "not found",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pub, priv, err := resolveMCPSSHKey(tc.input)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (pub=%q priv=%q)", tc.wantErr, pub, priv)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantPubPath != "" && pub != tc.wantPubPath {
+				t.Errorf("pub path = %q, want %q", pub, tc.wantPubPath)
+			}
+			// privPath should be pubPath without the .pub suffix; if
+			// no .pub suffix, equal to pubPath. Sanity check.
+			expectedPriv := strings.TrimSuffix(pub, ".pub")
+			if priv != expectedPriv {
+				t.Errorf("priv path = %q, want %q", priv, expectedPriv)
+			}
+		})
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,7 +22,9 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	assert.Len(t, server.tools, 29, "Should have 29 tools registered")
+	// 29 base tools + 3 runner-provision tools (provision_runners,
+	// list_runners, remove_runner) added in the runner-MCP-tool PR.
+	assert.Len(t, server.tools, 32, "Should have 32 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -126,7 +128,9 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	assert.Len(t, tools, 29)
+	// 29 base tools + 3 runner-provision tools (provision_runners,
+	// list_runners, remove_runner) added in the runner-MCP-tool PR.
+	assert.Len(t, tools, 32)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -904,6 +904,12 @@ func (s *Server) registerTools() {
 		},
 	}
 
+	// Runner-provision tools (CLI-mirrored). Appended here so the
+	// tools.go slice literal stays focused on container/secret/
+	// route lifecycle; the actual Tool definitions live in
+	// runner_tools.go alongside their handlers.
+	s.tools = append(s.tools, runnerTools()...)
+
 	// Phase 1.7 — assign required scope per tool. Done as a
 	// post-pass so the slice literals above stay short and
 	// the security policy lives in one auditable spot. New
@@ -957,6 +963,12 @@ func toolScopeAssignments() map[string]string {
 		"sync_ssh_config": auth.ScopeSSHWrite,
 		// JWT lifecycle (admin)
 		"revoke_token": auth.ScopeTokensWrite,
+		// Runner provisioning — provision/remove create or delete
+		// boxes; list is read-only. Reuses the containers:* scopes
+		// since the underlying operations are box-level CRUD.
+		"provision_runners": auth.ScopeContainersWrite,
+		"remove_runner":     auth.ScopeContainersWrite,
+		"list_runners":      auth.ScopeContainersRead,
 	}
 }
 

--- a/internal/runner/boxes.go
+++ b/internal/runner/boxes.go
@@ -1,0 +1,141 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// DaemonAPI is the minimal slice of a containarium client that
+// BoxManager needs. Both internal/client.HTTPClient and
+// internal/client.GRPCClient satisfy this (they expose the
+// methods used here on slightly broader interfaces). Keeping the
+// interface here means internal/runner doesn't import
+// internal/client and so dodges the import cycle that would
+// arise if internal/client wanted to call back into runner.
+type DaemonAPI interface {
+	ListContainers() ([]incus.ContainerInfo, error)
+	GetContainer(username string) (*incus.ContainerInfo, error)
+	DeleteContainer(username string, force bool) error
+}
+
+// DaemonCreator narrows down "the bit of the daemon client that
+// makes a new container." Real implementations have richer
+// signatures; we just need name + ssh key + a return of the box
+// ID. Done as a function shape so callers can curry their full
+// create call (with all the labels/cpu/etc baked in) into
+// something this package can drive.
+type DaemonCreator func(ctx context.Context, name, sshKey string) (boxID string, err error)
+
+// NewDaemonBoxManager wraps a (DaemonAPI, DaemonCreator) pair as
+// a BoxManager. The split lets callers reuse their existing
+// create-container plumbing (which has a wide signature with
+// CPU/memory/disk/labels/etc) without forcing every caller
+// through a one-size-fits-all interface.
+func NewDaemonBoxManager(api DaemonAPI, create DaemonCreator) BoxManager {
+	return &daemonBoxManager{api: api, create: create}
+}
+
+type daemonBoxManager struct {
+	api    DaemonAPI
+	create DaemonCreator
+}
+
+func (m *daemonBoxManager) Exists(_ context.Context, name string) (bool, error) {
+	// The daemon's "name" for a user-container is
+	// "<username>-container" — the create flow appends the
+	// suffix server-side. We pass the raw user/runner name to
+	// GetContainer which knows the convention.
+	_, err := m.api.GetContainer(name)
+	if err != nil {
+		// Best-effort: distinguish "not found" from real
+		// failures. The HTTP/gRPC clients both return errors
+		// that include the daemon's response text, so we
+		// substring-match "not found". A false negative here
+		// (real error misread as not-found) sends us into
+		// Create, which will surface the real error anyway.
+		if isNotFoundError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (m *daemonBoxManager) Create(ctx context.Context, name, sshKey string) (string, error) {
+	return m.create(ctx, name, sshKey)
+}
+
+func (m *daemonBoxManager) Delete(_ context.Context, name string, force bool) error {
+	return m.api.DeleteContainer(name, force)
+}
+
+func (m *daemonBoxManager) List(_ context.Context) ([]string, error) {
+	containers, err := m.api.ListContainers()
+	if err != nil {
+		return nil, fmt.Errorf("list containers: %w", err)
+	}
+	names := make([]string, 0, len(containers))
+	for _, c := range containers {
+		// Container Name is "<username>-container"; strip the
+		// suffix so caller-facing names match what they passed
+		// at create time.
+		name := c.Name
+		const suffix = "-container"
+		if len(name) > len(suffix) && name[len(name)-len(suffix):] == suffix {
+			name = name[:len(name)-len(suffix)]
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// isNotFoundError is a substring-based discriminator over the
+// daemon client error text. The HTTP client wraps the response
+// body verbatim ("API error (status 404): …") and the gRPC
+// client surfaces the same via status messages. We don't have a
+// typed NotFound error in internal/client today; substring is
+// the pragmatic choice and the failure mode (false negative →
+// proceed to Create → real error surfaces) is benign.
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, marker := range []string{"not found", "404", "NotFound", "does not exist"} {
+		if containsCaseFold(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsCaseFold is strings.Contains with case folding. Small
+// enough to inline rather than import the strings package twice.
+func containsCaseFold(s, substr string) bool {
+	if len(substr) == 0 {
+		return true
+	}
+	if len(s) < len(substr) {
+		return false
+	}
+	ls := toLower(s)
+	lsub := toLower(substr)
+	for i := 0; i+len(lsub) <= len(ls); i++ {
+		if ls[i:i+len(lsub)] == lsub {
+			return true
+		}
+	}
+	return false
+}
+
+func toLower(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'A' && c <= 'Z' {
+			b[i] = c + 32
+		}
+	}
+	return string(b)
+}

--- a/internal/runner/github.go
+++ b/internal/runner/github.go
@@ -1,0 +1,108 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// NewGitHubClient returns a GitHubAPI backed by a real
+// http.Client talking to api.github.com. The CLI and MCP tool
+// both use this in production; tests pass a fake instead.
+//
+// httpClient is allowed to be nil — we'll build one with a
+// sensible timeout. Pass your own if you want a custom transport
+// (e.g. tracing, retry middleware).
+func NewGitHubClient(httpClient *http.Client) GitHubAPI {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &githubClient{http: httpClient}
+}
+
+type githubClient struct {
+	http *http.Client
+}
+
+// runnersListResponse mirrors the shape GitHub returns from
+// GET /repos/{repo}/actions/runners. We only deserialize the
+// fields Provision needs — typed struct, not map[string]any,
+// per CLAUDE.md.
+type runnersListResponse struct {
+	TotalCount int `json:"total_count"`
+	Runners    []struct {
+		ID     int64  `json:"id"`
+		Name   string `json:"name"`
+		Status string `json:"status"`
+		Busy   bool   `json:"busy"`
+	} `json:"runners"`
+}
+
+func (c *githubClient) ListRunners(ctx context.Context, repo, pat string) ([]RegisteredRunner, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/actions/runners", repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "token "+pat)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github list runners: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("github list runners: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed runnersListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode runners list: %w", err)
+	}
+
+	out := make([]RegisteredRunner, 0, len(parsed.Runners))
+	for _, r := range parsed.Runners {
+		out = append(out, RegisteredRunner{
+			ID:     r.ID,
+			Name:   r.Name,
+			Status: r.Status,
+			Busy:   r.Busy,
+		})
+	}
+	return out, nil
+}
+
+func (c *githubClient) RemoveRunner(ctx context.Context, repo, pat string, runnerID int64) error {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/actions/runners/%d", repo, runnerID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "token "+pat)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("github delete runner: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusOK:
+		return nil
+	case http.StatusNotFound:
+		// Idempotent: a runner that's already gone is fine.
+		return nil
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("github delete runner: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+}

--- a/internal/runner/install_script.go
+++ b/internal/runner/install_script.go
@@ -1,0 +1,38 @@
+// Package runner provisions Containarium boxes as ephemeral GitHub
+// Actions self-hosted runners.
+//
+// Two entry points share one orchestration helper:
+//
+//   - internal/cmd/runner.go      → CLI verbs (containarium runner provision/list/remove)
+//   - internal/mcp/tools.go       → MCP tools  (provision_runners/list_runners/remove_runner)
+//
+// Per CLAUDE.md: the CLI is canonical. The MCP tools are thin wrappers
+// over the same Go function that the CLI handler calls. Don't make
+// the MCP tool talk to a different code path.
+package runner
+
+import _ "embed"
+
+// To resync the embedded payload with hacks/runner/install.sh after
+// editing the source, run:
+//
+//   go generate ./internal/runner/...
+//
+// The TestEmbeddedInstallScriptMatchesSource test enforces the two
+// files stay in lockstep — CI catches drift.
+//
+//go:generate cp ../../hacks/runner/install.sh ./install_script_payload.sh
+
+// InstallScript is the bytes of hacks/runner/install.sh embedded into
+// the binary at compile time. Both the CLI and the MCP tool ship this
+// to the box and execute it server-side over SSH; no network fetch at
+// runtime, so an agent can provision runners on a box with no outbound
+// access to raw.githubusercontent.com.
+//
+// The source file at hacks/runner/install.sh stays public for ops
+// engineers who prefer the manual `ssh box 'curl … | bash'` flow —
+// see hacks/runner/README.md. We embed exactly the same bytes so the
+// agent path and the operator path are provably the same install.
+//
+//go:embed install_script_payload.sh
+var InstallScript []byte

--- a/internal/runner/install_script_payload.sh
+++ b/internal/runner/install_script_payload.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# install.sh — provisions a Containarium box as an ephemeral GitHub
+# Actions self-hosted runner for one GitHub repo.
+#
+# Run this INSIDE a Containarium box (e.g. one created via
+# `containarium create runner-1`). It installs:
+#
+#   - actions-runner (GitHub's official binary)
+#   - Common CI toolchains: git, build-essential, Go, Node 22, pnpm 9,
+#     buf 1.38.0, golangci-lint
+#   - A systemd unit that runs the runner in `--ephemeral` mode in a
+#     respawn loop: register → run ONE job → exit → restart fresh.
+#
+# Required env vars (or pass on command line):
+#
+#   GH_REPO     org/repo for the runner (e.g. FootprintAI/Containarium-cloud)
+#   GH_PAT      personal access token with `repo` scope; used to mint
+#               short-lived runner-registration tokens at the start of
+#               each loop iteration. Pick from
+#               https://github.com/settings/tokens (classic) or App
+#               installation tokens.
+#   RUNNER_NAME (optional) name for this runner; defaults to the box
+#               hostname. Visible in GitHub's Actions → Runners list.
+#   RUNNER_LABELS (optional) comma-separated runner labels; defaults
+#               to "containarium,ephemeral". Workflows target with
+#               `runs-on: [self-hosted, containarium, ephemeral]`.
+#
+# Usage from outside the box:
+#
+#   containarium create runner-1
+#   ssh runner-1 'curl -fsSL https://raw.githubusercontent.com/footprintai/containarium/main/hacks/runner/install.sh \
+#     | sudo GH_REPO=FootprintAI/Containarium-cloud GH_PAT=ghp_xxx bash'
+#
+# After this runs, the runner registers itself within ~30s and starts
+# accepting jobs. Verify at
+# https://github.com/<owner>/<repo>/settings/actions/runners.
+
+set -euo pipefail
+
+# ---- input validation ----
+: "${GH_REPO:?GH_REPO is required (org/repo)}"
+: "${GH_PAT:?GH_PAT is required (PAT with repo scope)}"
+
+RUNNER_NAME="${RUNNER_NAME:-$(hostname -s)}"
+RUNNER_LABELS="${RUNNER_LABELS:-containarium,ephemeral}"
+RUNNER_VERSION="${RUNNER_VERSION:-2.319.1}"
+RUNNER_USER="${RUNNER_USER:-ghrunner}"
+RUNNER_HOME="${RUNNER_HOME:-/opt/actions-runner}"
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64) RUNNER_ARCH=x64 ;;
+  aarch64|arm64) RUNNER_ARCH=arm64 ;;
+  *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+# ---- system deps ----
+apt-get update
+apt-get install -y --no-install-recommends \
+  ca-certificates curl jq git build-essential libicu-dev
+
+# ---- toolchains ----
+# Go (matches Containarium repo's go.mod pinning convention; bumps are
+# a one-line edit here).
+GO_VERSION="${GO_VERSION:-1.25.10}"
+if ! command -v go >/dev/null 2>&1 || [ "$(go version | awk '{print $3}')" != "go${GO_VERSION}" ]; then
+  curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xz
+  ln -sf /usr/local/go/bin/go /usr/local/bin/go
+  ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+fi
+
+# Node 22 + pnpm 9 (for repos with frontend builds)
+if ! command -v node >/dev/null 2>&1; then
+  curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+  apt-get install -y nodejs
+  npm install -g pnpm@9
+fi
+
+# buf (proto toolchain — pin matches Containarium-cloud's CI)
+BUF_VERSION="${BUF_VERSION:-1.38.0}"
+if ! command -v buf >/dev/null 2>&1; then
+  GOBIN=/usr/local/bin /usr/local/go/bin/go install \
+    "github.com/bufbuild/buf/cmd/buf@v${BUF_VERSION}"
+fi
+
+# golangci-lint v2 (latest minor; pin if reproducibility matters)
+if ! command -v golangci-lint >/dev/null 2>&1; then
+  curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+    | sh -s -- -b /usr/local/bin
+fi
+
+# ---- runner user + binary ----
+if ! id "$RUNNER_USER" >/dev/null 2>&1; then
+  useradd -m -d "$RUNNER_HOME" -s /bin/bash "$RUNNER_USER"
+fi
+
+if [ ! -x "$RUNNER_HOME/run.sh" ]; then
+  mkdir -p "$RUNNER_HOME"
+  cd "$RUNNER_HOME"
+  TARBALL="actions-runner-linux-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz"
+  curl -fsSL -o "$TARBALL" \
+    "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${TARBALL}"
+  tar xzf "$TARBALL"
+  rm "$TARBALL"
+  chown -R "$RUNNER_USER:$RUNNER_USER" "$RUNNER_HOME"
+fi
+
+# ---- env file (PAT lives here; chmod 600) ----
+cat > /etc/containarium-runner.env <<EOF
+GH_REPO=${GH_REPO}
+GH_PAT=${GH_PAT}
+RUNNER_NAME=${RUNNER_NAME}
+RUNNER_LABELS=${RUNNER_LABELS}
+RUNNER_HOME=${RUNNER_HOME}
+EOF
+chmod 600 /etc/containarium-runner.env
+
+# ---- run-loop script ----
+install -m 0755 /dev/stdin /usr/local/bin/containarium-runner-loop <<'EOF'
+#!/bin/bash
+# Ephemeral-runner respawn loop. One iteration = one job.
+set -euo pipefail
+source /etc/containarium-runner.env
+
+cd "$RUNNER_HOME"
+
+# Mint a short-lived runner-registration token (valid ~1h).
+REG_TOKEN=$(curl -sX POST \
+  -H "Authorization: token $GH_PAT" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/${GH_REPO}/actions/runners/registration-token" \
+  | jq -r '.token')
+
+if [ -z "$REG_TOKEN" ] || [ "$REG_TOKEN" = "null" ]; then
+  echo "Failed to mint registration token — check GH_PAT scope (needs 'repo')" >&2
+  exit 1
+fi
+
+# Register, run ONE job, exit. --replace overwrites any stale
+# registration with the same name. --ephemeral makes run.sh exit
+# after the first job completes (success or failure).
+./config.sh \
+  --url "https://github.com/${GH_REPO}" \
+  --token "$REG_TOKEN" \
+  --name "$RUNNER_NAME" \
+  --labels "$RUNNER_LABELS" \
+  --ephemeral --replace --unattended
+
+./run.sh
+EOF
+
+# ---- systemd unit ----
+cat > /etc/systemd/system/containarium-runner.service <<EOF
+[Unit]
+Description=Containarium ephemeral GitHub Actions runner
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${RUNNER_USER}
+WorkingDirectory=${RUNNER_HOME}
+ExecStart=/usr/local/bin/containarium-runner-loop
+# Respawn on exit — each iteration is one job. RestartSec=2 buffers a
+# tiny gap so we don't hot-loop if GitHub is rejecting registrations.
+Restart=always
+RestartSec=2
+# Capture stdout/stderr in the journal for easy debugging.
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# ---- enable + start ----
+systemctl daemon-reload
+systemctl enable --now containarium-runner.service
+
+echo
+echo "================================================================"
+echo "  Runner '${RUNNER_NAME}' is registering with ${GH_REPO}."
+echo "  Verify at: https://github.com/${GH_REPO}/settings/actions/runners"
+echo
+echo "  Service: containarium-runner.service"
+echo "  Logs:    journalctl -u containarium-runner -f"
+echo "================================================================"

--- a/internal/runner/installer_ssh.go
+++ b/internal/runner/installer_ssh.go
@@ -1,0 +1,230 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// SSHEndpoint resolves a box name to the (user, host, port) tuple
+// we'll SSH into. Real callers typically:
+//
+//   - return "<name>@<sentinel-host>:22" when boxes are reached
+//     through sshpiper (typical Containarium-Cloud deployment), or
+//   - return "ubuntu@<box-ip>:22" when the agent has L3 reach to
+//     the box's LAN IP (typical self-hosted OSS daemon).
+//
+// Factored as an interface so the runner package doesn't pull in
+// the containarium client / config plumbing. The CLI / MCP code
+// build whatever resolver is appropriate for their environment
+// and pass it through.
+type SSHEndpoint interface {
+	Resolve(ctx context.Context, boxName string) (user, hostport string, err error)
+}
+
+// SSHEndpointFunc is the function shape of SSHEndpoint.Resolve so
+// callers can pass a closure directly without defining a type.
+type SSHEndpointFunc func(ctx context.Context, boxName string) (user, hostport string, err error)
+
+// Resolve makes SSHEndpointFunc satisfy SSHEndpoint.
+func (f SSHEndpointFunc) Resolve(ctx context.Context, boxName string) (string, string, error) {
+	return f(ctx, boxName)
+}
+
+// SSHInstallerConfig is the typed config for NewSSHInstaller.
+type SSHInstallerConfig struct {
+	// Endpoint resolves a box name to its SSH host:port + user.
+	Endpoint SSHEndpoint
+
+	// PrivateKeyPath points at the PEM-encoded private key used
+	// to dial the box. Required — install needs root to drop a
+	// systemd unit, so the key has to map to a user with sudo.
+	PrivateKeyPath string
+
+	// HostKeyCallback runs against the box's host key. Default
+	// (nil) means InsecureIgnoreHostKey — fine for ephemeral
+	// runner boxes on a private network where the daemon
+	// already established the trust boundary, but pass your
+	// own KnownHosts callback for hardened environments.
+	HostKeyCallback ssh.HostKeyCallback
+
+	// DialTimeout caps the per-SSH-dial TCP handshake + auth.
+	// Default 15s.
+	DialTimeout time.Duration
+}
+
+// NewSSHInstaller returns a RunnerInstaller that ships the
+// embedded install script over SSH and runs it inside the box.
+// The same instance is safe to share across goroutines.
+func NewSSHInstaller(cfg SSHInstallerConfig) (RunnerInstaller, error) {
+	if cfg.Endpoint == nil {
+		return nil, fmt.Errorf("ssh endpoint resolver is required")
+	}
+	if cfg.PrivateKeyPath == "" {
+		return nil, fmt.Errorf("private key path is required")
+	}
+	keyBytes, err := os.ReadFile(expandTilde(cfg.PrivateKeyPath))
+	if err != nil {
+		return nil, fmt.Errorf("read ssh key %s: %w", cfg.PrivateKeyPath, err)
+	}
+	signer, err := ssh.ParsePrivateKey(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse ssh key %s: %w", cfg.PrivateKeyPath, err)
+	}
+	if cfg.HostKeyCallback == nil {
+		// InsecureIgnoreHostKey is the right default for the
+		// runner-provision case: the boxes we're SSHing to were
+		// just created by the same daemon, on a network the
+		// agent already trusts. Pin host keys via the
+		// HostKeyCallback option when running across an
+		// untrusted path.
+		cfg.HostKeyCallback = ssh.InsecureIgnoreHostKey() // #nosec G106 -- ephemeral runner box, intentional default
+	}
+	if cfg.DialTimeout == 0 {
+		cfg.DialTimeout = 15 * time.Second
+	}
+	return &sshInstaller{
+		endpoint:    cfg.Endpoint,
+		signer:      signer,
+		hostKeyCB:   cfg.HostKeyCallback,
+		dialTimeout: cfg.DialTimeout,
+	}, nil
+}
+
+type sshInstaller struct {
+	endpoint    SSHEndpoint
+	signer      ssh.Signer
+	hostKeyCB   ssh.HostKeyCallback
+	dialTimeout time.Duration
+}
+
+func (s *sshInstaller) IsInstalled(ctx context.Context, boxName string) (bool, error) {
+	// `systemctl is-enabled` exits 0 when the unit exists and is
+	// enabled, non-zero otherwise. The check itself is harmless
+	// (read-only). We pipe to /dev/null so its noisy stderr
+	// doesn't leak into our install logs.
+	const cmd = `sudo test -f /etc/systemd/system/containarium-runner.service && sudo systemctl is-enabled containarium-runner.service >/dev/null 2>&1 && echo INSTALLED || echo NOT_INSTALLED`
+	stdout, _, err := s.runCommand(ctx, boxName, cmd, nil)
+	if err != nil {
+		return false, fmt.Errorf("ssh probe: %w", err)
+	}
+	return strings.Contains(stdout, "INSTALLED") && !strings.Contains(stdout, "NOT_INSTALLED"), nil
+}
+
+func (s *sshInstaller) Install(ctx context.Context, boxName string, script []byte, env map[string]string) error {
+	// We stream the embedded script via stdin into `sudo bash`
+	// (with env vars set on the command line) so the script
+	// content never lands on the box's filesystem outside of
+	// what install.sh itself writes. Same effect as the manual
+	// `curl … | sudo … bash` flow documented in hacks/runner.
+	var envPrefix strings.Builder
+	envPrefix.WriteString("sudo ")
+	// Stable ordering for deterministic logs / tests.
+	for _, k := range sortedKeys(env) {
+		// Shell-quote the value defensively — PATs and labels
+		// can contain characters that would otherwise break the
+		// command line.
+		envPrefix.WriteString(fmt.Sprintf("%s=%s ", k, shellQuote(env[k])))
+	}
+	envPrefix.WriteString("bash -s")
+
+	_, stderr, err := s.runCommand(ctx, boxName, envPrefix.String(), script)
+	if err != nil {
+		return fmt.Errorf("install script: %w (stderr: %s)", err, stderr)
+	}
+	return nil
+}
+
+// runCommand opens a fresh SSH connection to boxName, runs cmd
+// with stdin from `input`, and returns (stdout, stderr, err).
+// Connections are not pooled — each call dials fresh, which is
+// simple and matches the relatively-low call volume of provision.
+func (s *sshInstaller) runCommand(ctx context.Context, boxName, cmd string, input []byte) (string, string, error) {
+	user, hostport, err := s.endpoint.Resolve(ctx, boxName)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve ssh endpoint for %s: %w", boxName, err)
+	}
+
+	dialer := &net.Dialer{Timeout: s.dialTimeout}
+	conn, err := dialer.DialContext(ctx, "tcp", hostport)
+	if err != nil {
+		return "", "", fmt.Errorf("dial %s: %w", hostport, err)
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User:            user,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(s.signer)},
+		HostKeyCallback: s.hostKeyCB,
+		Timeout:         s.dialTimeout,
+	}
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, hostport, sshConfig)
+	if err != nil {
+		_ = conn.Close()
+		return "", "", fmt.Errorf("ssh handshake %s: %w", hostport, err)
+	}
+	client := ssh.NewClient(sshConn, chans, reqs)
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return "", "", fmt.Errorf("ssh session: %w", err)
+	}
+	defer session.Close()
+
+	var stdout, stderr bytes.Buffer
+	session.Stdout = &stdout
+	session.Stderr = &stderr
+	if input != nil {
+		session.Stdin = bytes.NewReader(input)
+	}
+
+	if err := session.Run(cmd); err != nil {
+		return stdout.String(), stderr.String(), fmt.Errorf("ssh run: %w", err)
+	}
+	return stdout.String(), stderr.String(), nil
+}
+
+// expandTilde turns "~/foo" into "$HOME/foo". Mirrors the helper
+// in internal/cmd/create.go but kept local so this package has
+// no dependency on the cmd package.
+func expandTilde(p string) string {
+	if !strings.HasPrefix(p, "~/") {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return p
+	}
+	return filepath.Join(home, p[2:])
+}
+
+// shellQuote wraps a value in single quotes with embedded single
+// quotes escaped as '\''. Enough for PATs and label strings; we
+// deliberately don't try to support arbitrary shell metachars in
+// runner names (validated upstream).
+func shellQuote(v string) string {
+	return "'" + strings.ReplaceAll(v, "'", `'\''`) + "'"
+}
+
+// sortedKeys is a tiny helper so install logs (and tests) see env
+// vars in a stable order regardless of map iteration randomness.
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// Manual sort to keep imports minimal — n is always 4.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}

--- a/internal/runner/provision.go
+++ b/internal/runner/provision.go
@@ -1,0 +1,573 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// MaxRunnerCount is the upper bound on how many runners a single
+// provision call will create. 100 is generous for most teams (Cloud
+// Run on most plans caps concurrent jobs far below this) and small
+// enough that an agent typo (`count: 1000`) doesn't accidentally
+// spin up a fleet that bleeds the cloud bill before the operator
+// notices.
+const MaxRunnerCount = 100
+
+// DefaultBoxCreateTimeout caps how long we'll wait for a single
+// box to come up and accept SSH. 5 min covers the Incus create →
+// cloud-init → sshd-ready path with comfortable headroom for slow
+// images; failing fast above that lets the caller move on and a
+// human investigate rather than the agent blocking forever.
+const DefaultBoxCreateTimeout = 5 * time.Minute
+
+// DefaultInstallTimeout caps the runner install step. The script
+// apt-installs a handful of packages plus toolchains (Go, Node,
+// buf, golangci-lint) — on a cold box that can take 3-4 minutes
+// over a slow link. 10 min is "generous-but-bounded".
+const DefaultInstallTimeout = 10 * time.Minute
+
+// DefaultRegistrationTimeout caps the post-install poll waiting
+// for the runner to appear in GitHub's runners list. systemd
+// usually starts the service within a couple of seconds; we give
+// 60 s so a slow `actions-runner` tarball extract on the box
+// doesn't trip the wait. Use exponential backoff so we don't
+// hammer the GitHub API.
+const DefaultRegistrationTimeout = 60 * time.Second
+
+// Options is the typed input to Provision. Field defaults are
+// applied by Provision when the field is the zero value, so a
+// caller that wants the defaults can pass `Options{Repo: "...",
+// PAT: "...", Count: 1}` and not worry about timeouts.
+type Options struct {
+	// Repo in "owner/repo" form. Validated against repoPattern.
+	Repo string
+
+	// PAT is a GitHub Personal Access Token with `repo` scope.
+	// Used both to mint registration tokens (inside the box, via
+	// the install script) and to query the runners-list API to
+	// confirm registration succeeded.
+	PAT string
+
+	// Count is the number of runners to provision. 1..MaxRunnerCount.
+	Count int
+
+	// NamePrefix is the prefix used when generating box names via
+	// NameTemplate. Default: "ci-runner".
+	NamePrefix string
+
+	// Labels is the comma-separated label list applied to each
+	// runner. Default: "containarium,ephemeral". Workflows target
+	// with `runs-on: [self-hosted, <labels>...]`.
+	Labels string
+
+	// NameTemplate is the Go-style template used to build each
+	// runner's box name. Two placeholders are supported and
+	// substituted by simple string replace:
+	//   {prefix}  → NamePrefix
+	//   {i}       → 1-based runner index
+	// Default: "{prefix}-{i}".
+	NameTemplate string
+
+	// SSHKey is an optional override of the SSH public key used
+	// when creating boxes. Empty means the BoxManager picks a
+	// default (most implementations generate an ephemeral key).
+	SSHKey string
+
+	// BoxCreateTimeout / InstallTimeout / RegistrationTimeout are
+	// per-step deadlines. Zero falls back to the Default* values.
+	BoxCreateTimeout       time.Duration
+	InstallTimeout         time.Duration
+	RegistrationTimeout    time.Duration
+}
+
+// RunnerStatus is the per-runner outcome shape returned by
+// Provision / List / Remove. Kept as a small typed struct (not a
+// `map[string]interface{}` — CLAUDE.md, strong typing) so both the
+// CLI summary table and the MCP JSON response render uniformly.
+type RunnerStatus struct {
+	// Name is the box / runner name (these are 1:1 — we name the
+	// GitHub runner after its containarium box).
+	Name string
+
+	// BoxID is the platform's container identifier returned by
+	// the BoxManager. Empty when create failed before the box
+	// got a name.
+	BoxID string
+
+	// State is one of: "provisioned" (full success — box up,
+	// service installed, runner registered), "registering"
+	// (install succeeded, GitHub poll timed out — usually
+	// transient), "exists" (we found an already-configured
+	// runner and skipped — idempotent re-run), "failed" (see
+	// LastError), "removed" (Remove succeeded).
+	State string
+
+	// LastError carries the failure reason when State == "failed".
+	// Empty on success.
+	LastError string
+
+	// Registered reflects the GitHub-side runners-list check.
+	// True only if we saw the runner in GitHub's list. False
+	// for "registering" (poll timed out) and "failed".
+	Registered bool
+}
+
+// Result aggregates per-runner status plus a top-level partial-
+// error indicator. Provision is partial-success-tolerant: when 2
+// of 3 boxes succeed and one fails, the caller sees a non-nil
+// Result with Runners populated and PartialFailure=true. We do
+// NOT return a Go error in that case — the caller would otherwise
+// have to inspect the error to find the partial state, which is
+// the same dynamic-typing footgun CLAUDE.md warns about.
+type Result struct {
+	Runners         []RunnerStatus
+	PartialFailure  bool
+}
+
+// BoxManager abstracts the create/exists/delete operations on
+// Containarium boxes so tests can fake the Incus / gRPC path
+// without standing up a real daemon. The CLI's adapter calls
+// internal/cmd/create.go's create helpers; the MCP tool's
+// adapter calls the same.
+type BoxManager interface {
+	// Exists returns true if a box with the given name already
+	// exists on the daemon. Used for the idempotent-re-provision
+	// check (skip create if the box is already there).
+	Exists(ctx context.Context, name string) (bool, error)
+
+	// Create provisions a new box with the given name. The
+	// implementation supplies whatever sensible defaults the
+	// caller doesn't override (CPU/mem/disk, image, etc.).
+	Create(ctx context.Context, name, sshKey string) (boxID string, err error)
+
+	// Delete tears down the box. force is the same semantics as
+	// `containarium delete --force`.
+	Delete(ctx context.Context, name string, force bool) error
+
+	// List returns the names of every box currently registered
+	// on the daemon. Used by List to find runner boxes without
+	// querying GitHub.
+	List(ctx context.Context) ([]string, error)
+}
+
+// RunnerInstaller wraps "ssh into a box and run the install
+// script" so tests can replace the SSH/exec path with a no-op
+// fake. Real implementations live alongside the CLI / MCP
+// adapters and shell out via golang.org/x/crypto/ssh.
+type RunnerInstaller interface {
+	// IsInstalled reports whether containarium-runner.service is
+	// already present and enabled inside the box. When true,
+	// Provision skips the Install step (idempotent re-run).
+	IsInstalled(ctx context.Context, boxName string) (bool, error)
+
+	// Install copies the embedded install script into the box
+	// and runs it with the supplied env vars (GH_REPO, GH_PAT,
+	// RUNNER_NAME, RUNNER_LABELS).
+	Install(ctx context.Context, boxName string, script []byte, env map[string]string) error
+}
+
+// GitHubAPI abstracts the small slice of the GitHub REST API
+// Provision uses: list runners (for the registration-confirmation
+// poll) and remove a runner (for the Remove verb's deregister
+// step). Tests inject a fake; the production impl talks to
+// api.github.com.
+type GitHubAPI interface {
+	// ListRunners returns the names of every runner currently
+	// registered against the given repo. We don't care about IDs
+	// for the registration poll, just "is our name in there?"
+	ListRunners(ctx context.Context, repo, pat string) ([]RegisteredRunner, error)
+
+	// RemoveRunner deregisters a runner by ID. Called by Remove
+	// after draining. Idempotent: 404 from the API is treated as
+	// "already gone" and returned as nil.
+	RemoveRunner(ctx context.Context, repo, pat string, runnerID int64) error
+}
+
+// RegisteredRunner is what ListRunners returns — the small
+// subset of the GitHub API's runner record we actually need.
+type RegisteredRunner struct {
+	ID     int64
+	Name   string
+	Status string // "online" | "offline"
+	Busy   bool
+}
+
+// Clock is injected so tests don't actually sleep. Defaults to a
+// real-time implementation when nil; tests pass a fake that
+// records sleeps for assertion.
+type Clock interface {
+	Now() time.Time
+	Sleep(d time.Duration)
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time        { return time.Now() }
+func (realClock) Sleep(d time.Duration) { time.Sleep(d) }
+
+// Deps bundles the dependencies Provision needs. Keeping them in
+// one struct (not as separate function params) means callers and
+// tests can build a fully-wired dependency graph in one place
+// and the function signature stays narrow.
+type Deps struct {
+	Boxes   BoxManager
+	SSH     RunnerInstaller
+	GitHub  GitHubAPI
+	Clock   Clock
+}
+
+// repoPattern matches GitHub's "owner/repo" shape. Owner and repo
+// names can contain alphanumerics, hyphen, underscore, and dot;
+// GitHub's full rules are slightly more permissive but this catches
+// the common typos (spaces, slashes other than the single separator,
+// empty owner or repo) without false negatives on real repo names.
+var repoPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+
+// ValidateOptions returns a descriptive error when Options would
+// fail any precondition Provision checks. Exposed separately so
+// callers (CLI flag handler, MCP tool argument parser) can
+// surface input errors before doing any actual work.
+func ValidateOptions(opts Options) error {
+	if opts.Repo == "" {
+		return fmt.Errorf("repo is required (owner/repo format)")
+	}
+	if !repoPattern.MatchString(opts.Repo) {
+		return fmt.Errorf("repo %q is not in owner/repo format", opts.Repo)
+	}
+	if opts.PAT == "" {
+		return fmt.Errorf("github_pat is required (PAT with `repo` scope)")
+	}
+	if opts.Count <= 0 {
+		return fmt.Errorf("count must be > 0, got %d", opts.Count)
+	}
+	if opts.Count > MaxRunnerCount {
+		return fmt.Errorf("count %d exceeds maximum of %d (open a manual ticket if you really need a bigger pool)", opts.Count, MaxRunnerCount)
+	}
+	return nil
+}
+
+// applyDefaults fills in zero-value fields with sensible defaults.
+// Done as a separate step (not at field-read time) so each call
+// to Provision sees a fully-populated Options without sprinkling
+// `if x == "" { x = "default" }` through the orchestration body.
+func applyDefaults(opts Options) Options {
+	if opts.NamePrefix == "" {
+		opts.NamePrefix = "ci-runner"
+	}
+	if opts.Labels == "" {
+		opts.Labels = "containarium,ephemeral"
+	}
+	if opts.NameTemplate == "" {
+		opts.NameTemplate = "{prefix}-{i}"
+	}
+	if opts.BoxCreateTimeout == 0 {
+		opts.BoxCreateTimeout = DefaultBoxCreateTimeout
+	}
+	if opts.InstallTimeout == 0 {
+		opts.InstallTimeout = DefaultInstallTimeout
+	}
+	if opts.RegistrationTimeout == 0 {
+		opts.RegistrationTimeout = DefaultRegistrationTimeout
+	}
+	return opts
+}
+
+// RenderName resolves opts.NameTemplate against (prefix, i). Pure
+// function so the CLI / MCP can preview names before any actual
+// work (e.g. "names that would be created: ci-runner-1, ci-runner-2").
+func RenderName(template, prefix string, i int) string {
+	name := template
+	name = strings.ReplaceAll(name, "{prefix}", prefix)
+	name = strings.ReplaceAll(name, "{i}", fmt.Sprintf("%d", i))
+	return name
+}
+
+// Provision is the central orchestration helper. Both the CLI's
+// `containarium runner provision` handler and the MCP tool's
+// provision_runners handler call this directly — there is no
+// HTTP / shell boundary between them and this function.
+//
+// Behavior per runner (i in 1..opts.Count):
+//
+//  1. Compute box name via RenderName.
+//  2. If the box doesn't exist, create it. If it does, skip.
+//  3. If containarium-runner.service is already installed and
+//     enabled, skip the install (idempotent re-run).
+//  4. Else: ship the embedded InstallScript into the box and run
+//     it with the right env vars.
+//  5. Poll GitHub for the runner's registration. Success → State
+//     "provisioned"; timeout → State "registering"; install or
+//     create failure → State "failed".
+//
+// Per-runner failures don't abort the whole call — each runner
+// gets its own RunnerStatus and the top-level Result.PartialFailure
+// flag reflects whether any failed.
+func Provision(ctx context.Context, deps Deps, opts Options) (*Result, error) {
+	if err := ValidateOptions(opts); err != nil {
+		return nil, err
+	}
+	opts = applyDefaults(opts)
+	if deps.Clock == nil {
+		deps.Clock = realClock{}
+	}
+	if deps.Boxes == nil || deps.SSH == nil || deps.GitHub == nil {
+		return nil, fmt.Errorf("internal error: runner.Provision called with missing deps (boxes=%v ssh=%v github=%v)",
+			deps.Boxes != nil, deps.SSH != nil, deps.GitHub != nil)
+	}
+
+	res := &Result{
+		Runners: make([]RunnerStatus, 0, opts.Count),
+	}
+
+	for i := 1; i <= opts.Count; i++ {
+		name := RenderName(opts.NameTemplate, opts.NamePrefix, i)
+		status := provisionOne(ctx, deps, opts, name)
+		if status.State == "failed" {
+			res.PartialFailure = true
+		}
+		res.Runners = append(res.Runners, status)
+	}
+
+	return res, nil
+}
+
+// provisionOne owns the per-box flow. Factored out so the per-
+// runner loop in Provision stays scannable and so future paths
+// (parallel provisioning, retry) have a single entry point to
+// wrap.
+func provisionOne(ctx context.Context, deps Deps, opts Options, name string) RunnerStatus {
+	st := RunnerStatus{Name: name}
+
+	// Step 1+2: idempotent box create.
+	createCtx, cancelCreate := context.WithTimeout(ctx, opts.BoxCreateTimeout)
+	defer cancelCreate()
+
+	exists, err := deps.Boxes.Exists(createCtx, name)
+	if err != nil {
+		st.State = "failed"
+		st.LastError = fmt.Sprintf("check box existence: %v", err)
+		return st
+	}
+	if exists {
+		st.BoxID = name // best-effort, the daemon's canonical ID may differ but matches in practice
+	} else {
+		boxID, err := deps.Boxes.Create(createCtx, name, opts.SSHKey)
+		if err != nil {
+			st.State = "failed"
+			st.LastError = fmt.Sprintf("create box: %v", err)
+			return st
+		}
+		st.BoxID = boxID
+	}
+
+	// Step 3+4: idempotent runner install.
+	installCtx, cancelInstall := context.WithTimeout(ctx, opts.InstallTimeout)
+	defer cancelInstall()
+
+	installed, err := deps.SSH.IsInstalled(installCtx, name)
+	if err != nil {
+		st.State = "failed"
+		st.LastError = fmt.Sprintf("check install state: %v", err)
+		return st
+	}
+	if installed {
+		// Idempotent path: the box already has the runner
+		// service. Skip the script. We still do the GitHub
+		// poll below so a half-provisioned box (installed but
+		// never managed to register) shows the right state.
+		st.State = "exists"
+	} else {
+		env := map[string]string{
+			"GH_REPO":       opts.Repo,
+			"GH_PAT":        opts.PAT,
+			"RUNNER_NAME":   name,
+			"RUNNER_LABELS": opts.Labels,
+		}
+		if err := deps.SSH.Install(installCtx, name, InstallScript, env); err != nil {
+			st.State = "failed"
+			st.LastError = fmt.Sprintf("install runner: %v", err)
+			return st
+		}
+		st.State = "provisioned"
+	}
+
+	// Step 5: GitHub-side registration confirmation. Poll with
+	// exponential backoff so a slow runner-side startup doesn't
+	// blow the GitHub API rate limit. Capped at
+	// RegistrationTimeout total.
+	registered := waitForRegistration(ctx, deps, opts, name)
+	st.Registered = registered
+	if !registered && st.State != "exists" {
+		// Don't downgrade an already-failed status; only mark
+		// "registering" when the install succeeded but GitHub
+		// hasn't shown us the runner yet.
+		st.State = "registering"
+	}
+
+	return st
+}
+
+// waitForRegistration polls GitHub for the runner name with
+// exponential backoff until it appears or RegistrationTimeout
+// elapses. Returns true on success, false on timeout. Network
+// errors during the poll are treated as "not yet visible" — we
+// retry rather than failing, since transient GitHub API blips
+// are common and the box may well be registered.
+func waitForRegistration(ctx context.Context, deps Deps, opts Options, name string) bool {
+	deadline := deps.Clock.Now().Add(opts.RegistrationTimeout)
+	// Backoff: 2 s, 4 s, 8 s, capped at 15 s. Keeps us well
+	// under GitHub's 5000-req/hr authenticated rate limit even
+	// when provisioning a big pool.
+	backoff := 2 * time.Second
+	const maxBackoff = 15 * time.Second
+	for {
+		runners, err := deps.GitHub.ListRunners(ctx, opts.Repo, opts.PAT)
+		if err == nil {
+			for _, r := range runners {
+				if r.Name == name {
+					return true
+				}
+			}
+		}
+		// Time check happens after the API call so we always
+		// make at least one attempt even with a zero-duration
+		// timeout — useful for tests.
+		now := deps.Clock.Now()
+		if !now.Before(deadline) {
+			return false
+		}
+		// Sleep no longer than the remaining budget so we don't
+		// undercut the caller's timeout.
+		remaining := deadline.Sub(now)
+		sleep := backoff
+		if sleep > remaining {
+			sleep = remaining
+		}
+		deps.Clock.Sleep(sleep)
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// List returns the runners currently registered to opts.Repo whose
+// names start with opts.NamePrefix. The result merges two views:
+// the GitHub-side registration (does the runner exist? is it busy?)
+// and the local box view (is the box still on this daemon?).
+//
+// This is the implementation behind both `containarium runner list`
+// and the MCP `list_runners` tool. Repo/PAT are required so we can
+// query the runners-list API; NamePrefix is the filter (only boxes
+// whose name starts with it are returned).
+func List(ctx context.Context, deps Deps, opts Options) (*Result, error) {
+	if opts.Repo == "" {
+		return nil, fmt.Errorf("repo is required")
+	}
+	if !repoPattern.MatchString(opts.Repo) {
+		return nil, fmt.Errorf("repo %q is not in owner/repo format", opts.Repo)
+	}
+	if opts.PAT == "" {
+		return nil, fmt.Errorf("github_pat is required")
+	}
+	if opts.NamePrefix == "" {
+		opts.NamePrefix = "ci-runner"
+	}
+
+	boxes, err := deps.Boxes.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list boxes: %w", err)
+	}
+
+	runners, err := deps.GitHub.ListRunners(ctx, opts.Repo, opts.PAT)
+	if err != nil {
+		// Don't fail outright — we can still return the box
+		// view, which is the half of the answer the local
+		// daemon owns. Mark each box as "registration unknown"
+		// by leaving Registered=false.
+		runners = nil
+	}
+	byName := make(map[string]RegisteredRunner, len(runners))
+	for _, r := range runners {
+		byName[r.Name] = r
+	}
+
+	res := &Result{}
+	for _, name := range boxes {
+		if !strings.HasPrefix(name, opts.NamePrefix) {
+			continue
+		}
+		st := RunnerStatus{Name: name, BoxID: name}
+		if reg, ok := byName[name]; ok {
+			st.Registered = true
+			st.State = reg.Status // "online" or "offline"
+			if reg.Busy {
+				st.State = "busy"
+			}
+		} else {
+			st.State = "unregistered"
+		}
+		res.Runners = append(res.Runners, st)
+	}
+	return res, nil
+}
+
+// Remove deregisters a runner from GitHub (best effort), then
+// deletes the box. The "drain" step that the install script's
+// systemd unit handles natively — stopping the service waits for
+// any in-flight job to exit because the runner is in --ephemeral
+// mode and exits cleanly after the current job. We capture that
+// guarantee by giving stopping a generous timeout; in this PR
+// we keep it simple: the existing ssh-based stop happens inside
+// the box-delete codepath.
+//
+// Opts.Repo / Opts.PAT are required so we can find the runner in
+// GitHub's list and remove it. Opts.NamePrefix is ignored — name
+// is taken from the explicit Name argument.
+func Remove(ctx context.Context, deps Deps, opts Options, name string) (*RunnerStatus, error) {
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	if opts.Repo == "" || opts.PAT == "" {
+		return nil, fmt.Errorf("repo and github_pat are required so the runner can be deregistered from github")
+	}
+	if !repoPattern.MatchString(opts.Repo) {
+		return nil, fmt.Errorf("repo %q is not in owner/repo format", opts.Repo)
+	}
+
+	st := &RunnerStatus{Name: name, BoxID: name}
+
+	// Best-effort GitHub deregister. If the runner isn't in
+	// GitHub's list we treat that as already-deregistered. If
+	// the API call fails entirely we still proceed to delete
+	// the box so the agent can finish the "tear it down" intent
+	// — the worst case is a stale "offline" row in GitHub's UI,
+	// not a leaked box.
+	runners, err := deps.GitHub.ListRunners(ctx, opts.Repo, opts.PAT)
+	if err == nil {
+		for _, r := range runners {
+			if r.Name == name {
+				if rmErr := deps.GitHub.RemoveRunner(ctx, opts.Repo, opts.PAT, r.ID); rmErr != nil {
+					st.LastError = fmt.Sprintf("github deregister: %v (proceeding with box delete anyway)", rmErr)
+				}
+				break
+			}
+		}
+	}
+
+	if err := deps.Boxes.Delete(ctx, name, true); err != nil {
+		st.State = "failed"
+		if st.LastError == "" {
+			st.LastError = fmt.Sprintf("delete box: %v", err)
+		} else {
+			st.LastError = st.LastError + "; delete box: " + err.Error()
+		}
+		return st, fmt.Errorf("delete box %s: %w", name, err)
+	}
+
+	st.State = "removed"
+	return st, nil
+}

--- a/internal/runner/provision_test.go
+++ b/internal/runner/provision_test.go
@@ -1,0 +1,692 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeBoxes implements BoxManager. Tracks calls so tests can
+// assert on what the orchestrator did.
+type fakeBoxes struct {
+	mu       sync.Mutex
+	existing map[string]bool // box name -> already present
+	created  []string
+	deleted  []string
+	listOut  []string
+	failCreate map[string]error
+}
+
+func (f *fakeBoxes) Exists(_ context.Context, name string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.existing[name], nil
+}
+
+func (f *fakeBoxes) Create(_ context.Context, name, _ string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err, ok := f.failCreate[name]; ok {
+		return "", err
+	}
+	f.created = append(f.created, name)
+	f.existing[name] = true
+	return name, nil
+}
+
+func (f *fakeBoxes) Delete(_ context.Context, name string, _ bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleted = append(f.deleted, name)
+	delete(f.existing, name)
+	return nil
+}
+
+func (f *fakeBoxes) List(_ context.Context) ([]string, error) {
+	return f.listOut, nil
+}
+
+// fakeInstaller implements RunnerInstaller. Records which boxes
+// got an install call and lets tests pre-seed "already installed"
+// status to exercise the idempotent path.
+type fakeInstaller struct {
+	mu             sync.Mutex
+	alreadyInstalled map[string]bool
+	installed      []string
+	failInstall    map[string]error
+	gotEnv         map[string]map[string]string
+}
+
+func (f *fakeInstaller) IsInstalled(_ context.Context, name string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.alreadyInstalled[name], nil
+}
+
+func (f *fakeInstaller) Install(_ context.Context, name string, _ []byte, env map[string]string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err, ok := f.failInstall[name]; ok {
+		return err
+	}
+	f.installed = append(f.installed, name)
+	if f.gotEnv == nil {
+		f.gotEnv = make(map[string]map[string]string)
+	}
+	cp := make(map[string]string, len(env))
+	for k, v := range env {
+		cp[k] = v
+	}
+	f.gotEnv[name] = cp
+	return nil
+}
+
+// fakeGitHub implements GitHubAPI. registerOnAttempt[name] = N
+// means "ListRunners returns this name starting from the N-th
+// call" — lets tests force the polling loop to spin a few times
+// before success.
+type fakeGitHub struct {
+	mu                sync.Mutex
+	listed            []string // names visible "now"
+	listCalls         int
+	registerOnAttempt map[string]int // name -> attempt index from which it becomes visible
+	removed           []int64
+	listErr           error
+	removeErr         error
+}
+
+func (f *fakeGitHub) ListRunners(_ context.Context, _, _ string) ([]RegisteredRunner, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.listCalls++
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	visible := append([]string(nil), f.listed...)
+	for name, attempt := range f.registerOnAttempt {
+		if f.listCalls >= attempt {
+			visible = append(visible, name)
+		}
+	}
+	out := make([]RegisteredRunner, 0, len(visible))
+	for i, n := range visible {
+		out = append(out, RegisteredRunner{ID: int64(i + 1), Name: n, Status: "online"})
+	}
+	return out, nil
+}
+
+func (f *fakeGitHub) RemoveRunner(_ context.Context, _, _ string, id int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.removeErr != nil {
+		return f.removeErr
+	}
+	f.removed = append(f.removed, id)
+	return nil
+}
+
+// fakeClock advances on each Sleep so tests don't actually pause
+// and the registration loop hits its deadline deterministically.
+type fakeClock struct {
+	now      time.Time
+	sleeps   []time.Duration
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Unix(1_700_000_000, 0)}
+}
+func (c *fakeClock) Now() time.Time { return c.now }
+func (c *fakeClock) Sleep(d time.Duration) {
+	c.sleeps = append(c.sleeps, d)
+	c.now = c.now.Add(d)
+}
+
+// -----------------------------------------------------------------
+// ValidateOptions
+// -----------------------------------------------------------------
+
+func TestValidateOptions(t *testing.T) {
+	cases := []struct {
+		name    string
+		opts    Options
+		wantErr string
+	}{
+		{
+			name:    "empty repo",
+			opts:    Options{Repo: "", PAT: "ghp_x", Count: 1},
+			wantErr: "repo is required",
+		},
+		{
+			name:    "bad repo format - no slash",
+			opts:    Options{Repo: "owner-repo", PAT: "ghp_x", Count: 1},
+			wantErr: "not in owner/repo format",
+		},
+		{
+			name:    "bad repo format - leading slash",
+			opts:    Options{Repo: "/repo", PAT: "ghp_x", Count: 1},
+			wantErr: "not in owner/repo format",
+		},
+		{
+			name:    "empty PAT",
+			opts:    Options{Repo: "owner/repo", PAT: "", Count: 1},
+			wantErr: "github_pat is required",
+		},
+		{
+			name:    "count zero",
+			opts:    Options{Repo: "owner/repo", PAT: "ghp_x", Count: 0},
+			wantErr: "count must be > 0",
+		},
+		{
+			name:    "count negative",
+			opts:    Options{Repo: "owner/repo", PAT: "ghp_x", Count: -1},
+			wantErr: "count must be > 0",
+		},
+		{
+			name:    "count above cap",
+			opts:    Options{Repo: "owner/repo", PAT: "ghp_x", Count: MaxRunnerCount + 1},
+			wantErr: "exceeds maximum",
+		},
+		{
+			name:    "valid",
+			opts:    Options{Repo: "owner/repo", PAT: "ghp_x", Count: 3},
+			wantErr: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateOptions(tc.opts)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------
+// RenderName
+// -----------------------------------------------------------------
+
+func TestRenderName(t *testing.T) {
+	cases := []struct {
+		template string
+		prefix   string
+		i        int
+		want     string
+	}{
+		{"{prefix}-{i}", "ci-runner", 1, "ci-runner-1"},
+		{"{prefix}-{i}", "ci-runner", 12, "ci-runner-12"},
+		{"runner_{i}_{prefix}", "ci", 3, "runner_3_ci"},
+		{"static", "anything", 9, "static"},
+	}
+	for _, tc := range cases {
+		got := RenderName(tc.template, tc.prefix, tc.i)
+		if got != tc.want {
+			t.Errorf("RenderName(%q, %q, %d) = %q want %q",
+				tc.template, tc.prefix, tc.i, got, tc.want)
+		}
+	}
+}
+
+// -----------------------------------------------------------------
+// Provision — happy path, idempotent re-run, partial failure
+// -----------------------------------------------------------------
+
+func TestProvisionHappyPath(t *testing.T) {
+	boxes := &fakeBoxes{existing: map[string]bool{}}
+	installer := &fakeInstaller{alreadyInstalled: map[string]bool{}}
+	gh := &fakeGitHub{}
+	// All three runners become visible immediately on the first
+	// ListRunners call (registerOnAttempt: attempt 1).
+	gh.registerOnAttempt = map[string]int{
+		"ci-runner-1": 1,
+		"ci-runner-2": 1,
+		"ci-runner-3": 1,
+	}
+	clock := newFakeClock()
+
+	opts := Options{
+		Repo:                "footprintai/containarium",
+		PAT:                 "ghp_test",
+		Count:               3,
+		RegistrationTimeout: 30 * time.Second,
+	}
+
+	res, err := Provision(context.Background(), Deps{
+		Boxes: boxes, SSH: installer, GitHub: gh, Clock: clock,
+	}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.PartialFailure {
+		t.Fatalf("expected no partial failure, got %+v", res)
+	}
+	if len(res.Runners) != 3 {
+		t.Fatalf("expected 3 runners, got %d", len(res.Runners))
+	}
+	for _, r := range res.Runners {
+		if r.State != "provisioned" {
+			t.Errorf("runner %s: expected state provisioned, got %s (err=%s)", r.Name, r.State, r.LastError)
+		}
+		if !r.Registered {
+			t.Errorf("runner %s: expected Registered=true", r.Name)
+		}
+	}
+	if len(boxes.created) != 3 {
+		t.Errorf("expected 3 boxes created, got %d", len(boxes.created))
+	}
+	if len(installer.installed) != 3 {
+		t.Errorf("expected 3 installs, got %d", len(installer.installed))
+	}
+	// Spot-check env propagation.
+	if installer.gotEnv["ci-runner-2"]["GH_REPO"] != "footprintai/containarium" {
+		t.Errorf("missing or wrong GH_REPO env: %+v", installer.gotEnv["ci-runner-2"])
+	}
+	if installer.gotEnv["ci-runner-2"]["RUNNER_NAME"] != "ci-runner-2" {
+		t.Errorf("RUNNER_NAME mismatch: %+v", installer.gotEnv["ci-runner-2"])
+	}
+}
+
+func TestProvisionIdempotent_BoxesAndServiceAlreadyExist(t *testing.T) {
+	// Pre-seed: all three boxes exist AND the runner service
+	// is already installed/enabled. Provision should skip both
+	// the create and install steps, and report state=exists.
+	boxes := &fakeBoxes{existing: map[string]bool{
+		"ci-runner-1": true,
+		"ci-runner-2": true,
+		"ci-runner-3": true,
+	}}
+	installer := &fakeInstaller{alreadyInstalled: map[string]bool{
+		"ci-runner-1": true,
+		"ci-runner-2": true,
+		"ci-runner-3": true,
+	}}
+	gh := &fakeGitHub{
+		listed: []string{"ci-runner-1", "ci-runner-2", "ci-runner-3"},
+	}
+	clock := newFakeClock()
+
+	opts := Options{
+		Repo:                "footprintai/containarium",
+		PAT:                 "ghp_test",
+		Count:               3,
+		RegistrationTimeout: 30 * time.Second,
+	}
+
+	res, err := Provision(context.Background(), Deps{
+		Boxes: boxes, SSH: installer, GitHub: gh, Clock: clock,
+	}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.PartialFailure {
+		t.Fatalf("idempotent path should not trip partial failure: %+v", res)
+	}
+	if len(boxes.created) != 0 {
+		t.Errorf("expected zero creates (boxes already exist), got %d", len(boxes.created))
+	}
+	if len(installer.installed) != 0 {
+		t.Errorf("expected zero installs (service already enabled), got %d", len(installer.installed))
+	}
+	for _, r := range res.Runners {
+		if r.State != "exists" {
+			t.Errorf("runner %s: expected state=exists, got %s", r.Name, r.State)
+		}
+		if !r.Registered {
+			t.Errorf("runner %s: expected Registered=true", r.Name)
+		}
+	}
+}
+
+func TestProvisionPartialFailure(t *testing.T) {
+	// Setup: box 2 fails to install. Boxes 1 and 3 succeed.
+	// Result should carry both successes and the one failure,
+	// with PartialFailure=true.
+	boxes := &fakeBoxes{existing: map[string]bool{}}
+	installer := &fakeInstaller{
+		alreadyInstalled: map[string]bool{},
+		failInstall: map[string]error{
+			"ci-runner-2": errors.New("install script exited 1"),
+		},
+	}
+	gh := &fakeGitHub{
+		registerOnAttempt: map[string]int{
+			"ci-runner-1": 1,
+			"ci-runner-3": 1,
+		},
+	}
+	clock := newFakeClock()
+
+	opts := Options{
+		Repo:                "footprintai/containarium",
+		PAT:                 "ghp_test",
+		Count:               3,
+		RegistrationTimeout: 30 * time.Second,
+	}
+
+	res, err := Provision(context.Background(), Deps{
+		Boxes: boxes, SSH: installer, GitHub: gh, Clock: clock,
+	}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error (partial failures shouldn't bubble as Go errors): %v", err)
+	}
+	if !res.PartialFailure {
+		t.Fatalf("expected partial failure, got %+v", res)
+	}
+
+	byName := map[string]RunnerStatus{}
+	for _, r := range res.Runners {
+		byName[r.Name] = r
+	}
+	if byName["ci-runner-1"].State != "provisioned" {
+		t.Errorf("runner 1: expected provisioned, got %s", byName["ci-runner-1"].State)
+	}
+	if byName["ci-runner-3"].State != "provisioned" {
+		t.Errorf("runner 3: expected provisioned, got %s", byName["ci-runner-3"].State)
+	}
+	if byName["ci-runner-2"].State != "failed" {
+		t.Errorf("runner 2: expected failed, got %s", byName["ci-runner-2"].State)
+	}
+	if !strings.Contains(byName["ci-runner-2"].LastError, "install script exited 1") {
+		t.Errorf("runner 2: expected propagated install error in LastError, got %q",
+			byName["ci-runner-2"].LastError)
+	}
+}
+
+func TestProvisionRegistrationTimeout(t *testing.T) {
+	// Box install succeeds, but GitHub never sees the runner.
+	// State should be "registering" (transient), Registered=false,
+	// PartialFailure stays false (registering isn't a hard fail).
+	boxes := &fakeBoxes{existing: map[string]bool{}}
+	installer := &fakeInstaller{alreadyInstalled: map[string]bool{}}
+	gh := &fakeGitHub{
+		// No runners ever become visible.
+		registerOnAttempt: map[string]int{},
+	}
+	clock := newFakeClock()
+
+	opts := Options{
+		Repo:                "footprintai/containarium",
+		PAT:                 "ghp_test",
+		Count:               1,
+		RegistrationTimeout: 5 * time.Second,
+	}
+
+	res, err := Provision(context.Background(), Deps{
+		Boxes: boxes, SSH: installer, GitHub: gh, Clock: clock,
+	}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Runners) != 1 {
+		t.Fatalf("expected 1 runner, got %d", len(res.Runners))
+	}
+	r := res.Runners[0]
+	if r.State != "registering" {
+		t.Errorf("expected state=registering, got %s (err=%s)", r.State, r.LastError)
+	}
+	if r.Registered {
+		t.Errorf("expected Registered=false")
+	}
+	if res.PartialFailure {
+		t.Errorf("registering is transient, should not flip PartialFailure")
+	}
+	// We should have made at least one poll attempt.
+	if gh.listCalls == 0 {
+		t.Errorf("expected at least one ListRunners call, got 0")
+	}
+}
+
+func TestProvisionRegistrationPollSucceedsLater(t *testing.T) {
+	// Runner shows up on the 3rd ListRunners call. Verify the
+	// polling loop spins, backs off, and ultimately succeeds.
+	boxes := &fakeBoxes{existing: map[string]bool{}}
+	installer := &fakeInstaller{alreadyInstalled: map[string]bool{}}
+	gh := &fakeGitHub{
+		registerOnAttempt: map[string]int{"ci-runner-1": 3},
+	}
+	clock := newFakeClock()
+
+	opts := Options{
+		Repo:                "footprintai/containarium",
+		PAT:                 "ghp_test",
+		Count:               1,
+		RegistrationTimeout: 60 * time.Second,
+	}
+
+	res, err := Provision(context.Background(), Deps{
+		Boxes: boxes, SSH: installer, GitHub: gh, Clock: clock,
+	}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Runners[0].State != "provisioned" {
+		t.Errorf("expected state=provisioned, got %s", res.Runners[0].State)
+	}
+	if gh.listCalls < 3 {
+		t.Errorf("expected >=3 ListRunners calls, got %d", gh.listCalls)
+	}
+	// Sleep durations should follow the exponential backoff
+	// pattern (2s, 4s, …).
+	if len(clock.sleeps) < 2 {
+		t.Errorf("expected at least 2 sleeps for backoff, got %d", len(clock.sleeps))
+	}
+	if clock.sleeps[0] != 2*time.Second {
+		t.Errorf("first sleep should be 2s (backoff start), got %v", clock.sleeps[0])
+	}
+}
+
+func TestProvisionBoxCreateFailureMarksFailed(t *testing.T) {
+	boxes := &fakeBoxes{
+		existing:   map[string]bool{},
+		failCreate: map[string]error{"ci-runner-1": errors.New("incus refused")},
+	}
+	installer := &fakeInstaller{alreadyInstalled: map[string]bool{}}
+	gh := &fakeGitHub{}
+	clock := newFakeClock()
+
+	opts := Options{
+		Repo:                "footprintai/containarium",
+		PAT:                 "ghp_test",
+		Count:               1,
+		RegistrationTimeout: 1 * time.Second,
+	}
+
+	res, err := Provision(context.Background(), Deps{
+		Boxes: boxes, SSH: installer, GitHub: gh, Clock: clock,
+	}, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.PartialFailure {
+		t.Fatalf("expected partial failure")
+	}
+	if res.Runners[0].State != "failed" {
+		t.Errorf("expected state=failed, got %s", res.Runners[0].State)
+	}
+	if !strings.Contains(res.Runners[0].LastError, "incus refused") {
+		t.Errorf("expected propagated create error, got %q", res.Runners[0].LastError)
+	}
+	if len(installer.installed) != 0 {
+		t.Errorf("install should not run when create fails")
+	}
+}
+
+// -----------------------------------------------------------------
+// List
+// -----------------------------------------------------------------
+
+func TestList_FilterByPrefixAndMergeGitHubState(t *testing.T) {
+	boxes := &fakeBoxes{
+		// Daemon has a mix of runner boxes and non-runner boxes.
+		listOut: []string{"ci-runner-1", "ci-runner-2", "alice", "bob"},
+	}
+	gh := &fakeGitHub{
+		listed: []string{"ci-runner-1"}, // only #1 is registered
+	}
+
+	res, err := List(context.Background(), Deps{Boxes: boxes, GitHub: gh}, Options{
+		Repo: "owner/repo", PAT: "ghp_test", NamePrefix: "ci-runner",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Runners) != 2 {
+		t.Fatalf("expected 2 runner boxes after prefix filter, got %d", len(res.Runners))
+	}
+	byName := map[string]RunnerStatus{}
+	for _, r := range res.Runners {
+		byName[r.Name] = r
+	}
+	if !byName["ci-runner-1"].Registered {
+		t.Errorf("runner-1 should be registered")
+	}
+	if byName["ci-runner-2"].Registered {
+		t.Errorf("runner-2 should NOT be registered")
+	}
+	if byName["ci-runner-2"].State != "unregistered" {
+		t.Errorf("runner-2: expected state=unregistered, got %s", byName["ci-runner-2"].State)
+	}
+}
+
+func TestList_RequiresRepoAndPAT(t *testing.T) {
+	_, err := List(context.Background(), Deps{}, Options{Repo: "", PAT: "x"})
+	if err == nil || !strings.Contains(err.Error(), "repo is required") {
+		t.Errorf("expected repo-required error, got %v", err)
+	}
+	_, err = List(context.Background(), Deps{}, Options{Repo: "owner/repo", PAT: ""})
+	if err == nil || !strings.Contains(err.Error(), "github_pat is required") {
+		t.Errorf("expected pat-required error, got %v", err)
+	}
+}
+
+// -----------------------------------------------------------------
+// Remove
+// -----------------------------------------------------------------
+
+func TestRemove_DeregistersAndDeletes(t *testing.T) {
+	boxes := &fakeBoxes{existing: map[string]bool{"ci-runner-1": true}}
+	gh := &fakeGitHub{listed: []string{"ci-runner-1"}}
+
+	st, err := Remove(context.Background(), Deps{Boxes: boxes, GitHub: gh}, Options{
+		Repo: "owner/repo", PAT: "ghp_test",
+	}, "ci-runner-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if st.State != "removed" {
+		t.Errorf("expected state=removed, got %s", st.State)
+	}
+	if len(gh.removed) != 1 {
+		t.Errorf("expected 1 github removal, got %d", len(gh.removed))
+	}
+	if len(boxes.deleted) != 1 || boxes.deleted[0] != "ci-runner-1" {
+		t.Errorf("expected box delete of ci-runner-1, got %v", boxes.deleted)
+	}
+}
+
+func TestRemove_GitHubFailureDoesNotBlockBoxDelete(t *testing.T) {
+	boxes := &fakeBoxes{existing: map[string]bool{"ci-runner-1": true}}
+	gh := &fakeGitHub{
+		listed:  []string{"ci-runner-1"},
+		removeErr: errors.New("github 500"),
+	}
+
+	st, err := Remove(context.Background(), Deps{Boxes: boxes, GitHub: gh}, Options{
+		Repo: "owner/repo", PAT: "ghp_test",
+	}, "ci-runner-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if st.State != "removed" {
+		t.Errorf("expected state=removed, got %s (err=%s)", st.State, st.LastError)
+	}
+	if !strings.Contains(st.LastError, "github 500") {
+		t.Errorf("expected propagated github error in LastError, got %q", st.LastError)
+	}
+	if len(boxes.deleted) != 1 {
+		t.Errorf("expected box delete to proceed despite github failure")
+	}
+}
+
+func TestRemove_RejectsMissingArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+		box  string
+		want string
+	}{
+		{"no name", Options{Repo: "owner/repo", PAT: "x"}, "", "name is required"},
+		{"no repo", Options{Repo: "", PAT: "x"}, "n", "repo and github_pat are required"},
+		{"no pat", Options{Repo: "owner/repo", PAT: ""}, "n", "repo and github_pat are required"},
+		{"bad repo", Options{Repo: "garbage", PAT: "x"}, "n", "not in owner/repo format"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Remove(context.Background(), Deps{}, tc.opts, tc.box)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------
+// Embedded install script lockstep with hacks/runner/install.sh
+// -----------------------------------------------------------------
+
+// TestEmbeddedInstallScriptNonEmpty makes sure go:embed actually
+// picked up the script. Without this, a missing copy of install.sh
+// would silently ship an empty payload to the runner box.
+func TestEmbeddedInstallScriptNonEmpty(t *testing.T) {
+	if len(InstallScript) == 0 {
+		t.Fatal("InstallScript is empty — go:embed didn't pick up install_script_payload.sh")
+	}
+	if !strings.Contains(string(InstallScript), "GH_REPO") {
+		t.Errorf("embedded script doesn't mention GH_REPO — likely wrong file embedded")
+	}
+}
+
+// -----------------------------------------------------------------
+// Defaults are applied
+// -----------------------------------------------------------------
+
+func TestApplyDefaults(t *testing.T) {
+	got := applyDefaults(Options{Repo: "owner/repo", PAT: "x", Count: 1})
+	want := Options{
+		Repo:                "owner/repo",
+		PAT:                 "x",
+		Count:               1,
+		NamePrefix:          "ci-runner",
+		Labels:              "containarium,ephemeral",
+		NameTemplate:        "{prefix}-{i}",
+		BoxCreateTimeout:    DefaultBoxCreateTimeout,
+		InstallTimeout:      DefaultInstallTimeout,
+		RegistrationTimeout: DefaultRegistrationTimeout,
+	}
+	if got != want {
+		t.Errorf("applyDefaults mismatch:\n  got:  %+v\n  want: %+v", got, want)
+	}
+}
+
+// Compile-time check: our fakes satisfy the interfaces. This catches
+// a method-signature drift before tests run.
+var (
+	_ BoxManager      = (*fakeBoxes)(nil)
+	_ RunnerInstaller = (*fakeInstaller)(nil)
+	_ GitHubAPI       = (*fakeGitHub)(nil)
+	_ Clock           = (*fakeClock)(nil)
+)
+
+// Suppress unused-import warnings if a future refactor drops fmt
+// inside this file.
+var _ = fmt.Sprintf


### PR DESCRIPTION
## Summary

Adds the client-side device-flow consumer that pairs with A1's
server-side `CLISessionService` (already merged in Containarium-cloud,
exposed at `cloud.containarium.dev`). This is sub-task **A3** of the
umbrella issue. Closes one item of FootprintAI/Containarium-cloud#100.

PRD: [`prd/cloud/cli-login-and-multi-env-ssh.md`](https://github.com/FootprintAI/Containarium-cloud/blob/main/prd/cloud/cli-login-and-multi-env-ssh.md)

### New CLI verbs

- **`containarium login [--server URL] [--device-name X] [--no-browser]`**
  POSTs `/v1/cli/sessions`, opens the verification URL in the user's
  default browser (xdg-open / open / cmd `start`), polls
  `/v1/cli/sessions/{id}/status` every 5s (max 10min), and writes
  `~/.containarium/credentials.json` (0600, atomic rename) on approval.

- **`containarium logout [--server URL | --all]`**
  Removes the entry from the credentials file. Does NOT call the server
  — server-side revocation goes through `containarium token revoke`.

- **`containarium whoami [--server URL]`**
  Prints the active server, `user_email`, `org_id`, `issued_at`,
  `expires_at`. Non-zero exit when no credentials are stored (scripts
  can `whoami || login`).

- **`containarium config get-token [--server URL]`**
  Emits the bearer token on stdout with no trailing newline.
  Composes with `export TOKEN=$(containarium config get-token)`.

### Credentials store (`internal/credentials`)

Typed `CredentialsFile` / `ServerCreds` structs per CLAUDE.md — no
`map[string]interface{}` at the on-disk boundary. Matches the
PRD-locked schema (verified by `TestSchema_MatchesPRDExample`).
`NormalizeServer` makes lookups tolerant of trailing slashes and
case.

### `--token` precedence chain

`root.go`'s `PersistentPreRunE` falls back to the credentials file
when `--token` is empty. Documented in the `--token` help text:

1. `--token` flag (explicit)
2. `CONTAINARIUM_TOKEN` env var
3. `~/.containarium/credentials.json` (server matching `--server`,
   else `default_server`)

`login` / `logout` / `whoami` / `config get-token` short-circuit the
auto-fill so a stale token from the credentials file never leaks into
a logout call.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/cmd/... ./internal/credentials/...` green
- [x] Credentials round-trip: write → reload → field-by-field check,
  including `expires_at: null` JSON form
- [x] Multi-server isolation: cloud + self-hosted creds in same file,
  default vs explicit-server lookups disjoint
- [x] Atomic rename leaves no `.tmp` files
- [x] File mode 0600 on POSIX
- [x] Env-var precedence covered (`TestResolveAuthToken_PrecedenceChain`)
- [x] Device-flow happy path against an `httptest` server
  (`TestLogin_HappyPath_WritesCredentials`)
- [x] Denied / expired session paths return errors
- [x] PRD schema example parses byte-for-byte
  (`TestSchema_MatchesPRDExample`)

## Judgment calls

- **Browser launch is cross-platform via `runtime.GOOS`**, not build
  tags — `xdg-open` / `open` / `cmd /c start`. Failure to launch is
  non-fatal: we print the URL and fall back to polling. Headless
  flows can pass `--no-browser` to skip the exec entirely.
- **Login bypasses `internal/client/http.go`** and uses raw `net/http`,
  per the task brief's stop condition: that client expects an
  already-authenticated bearer token, which the login flow can't
  have yet.
- **`logout` does not call the server**, deliberately. Token rotation
  is a separate workflow (`containarium token revoke`); logout is
  purely local.
- **Per-package test helpers are duplicated** rather than shared
  between `internal/cmd/login_test.go` and
  `internal/credentials/store_test.go`. This is the explicit Phase 1
  lesson — workstream tests live in NEW files and don't reach into
  shared utility files.

## What's NOT in this PR

- **A4** (MCP-client integration): a small follow-up that makes
  `containarium-mcp-server` and the agent-box client read from the
  same `~/.containarium/credentials.json`. The credentials store
  exposed here (`internal/credentials`) is the API A4 will consume.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>