### PR TITLE
A5+A6+A7: containarium ssh setup/list/remove/propagate + login --with-ssh-setup

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -49,7 +50,22 @@ var (
 	logoutAll        bool
 	configTokenSrv   string
 	whoamiServerFlag string
+
+	// Sub-task A7 (umbrella-issue #100): post-login SSH-key
+	// auto-registration. Default behaviour is "prompt the user with
+	// Y default"; --with-ssh-setup forces the prompt-and-go path
+	// non-interactively (assume yes), and --no-ssh-setup skips it
+	// entirely. The two flags are mutually exclusive — cobra
+	// enforces.
+	loginWithSSHSetup bool
+	loginNoSSHSetup   bool
 )
+
+// loginPromptReader is the io.Reader the prompt loop drains for the
+// y/N answer. Tests swap it for a strings.Reader; production reads
+// from stdin. Kept package-private so nothing else accidentally
+// drives the login prompt.
+var loginPromptReader io.Reader = os.Stdin
 
 // pollIntervalOverride lets tests dial the polling interval down to
 // milliseconds so the device-flow happy-path runs fast. Defaults to
@@ -147,6 +163,9 @@ func init() {
 	loginCmd.Flags().StringVar(&loginServer, "server", "", "server to log in to (default: "+defaultLoginServer+")")
 	loginCmd.Flags().StringVar(&loginDeviceName, "device-name", "", "human label for this session (default: <user>-<host>)")
 	loginCmd.Flags().BoolVar(&loginNoBrowser, "no-browser", false, "don't try to open a browser; print the URL instead")
+	loginCmd.Flags().BoolVar(&loginWithSSHSetup, "with-ssh-setup", false, "after login, register this machine's SSH public key non-interactively (skips the y/N prompt)")
+	loginCmd.Flags().BoolVar(&loginNoSSHSetup, "no-ssh-setup", false, "after login, skip the SSH-key registration prompt entirely")
+	loginCmd.MarkFlagsMutuallyExclusive("with-ssh-setup", "no-ssh-setup")
 
 	logoutCmd.Flags().StringVar(&loginServer, "server", "", "server to log out of (default: default_server)")
 	logoutCmd.Flags().BoolVar(&logoutAll, "all", false, "wipe credentials for all servers")
@@ -329,8 +348,130 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Fprintf(out, "✓ Logged in as %s\n", who)
 	fmt.Fprintf(out, "  Token saved to %s\n", path)
+
+	// Sub-task A7: optionally register this machine's SSH key for
+	// access to boxes created under this account. Done as a tail of
+	// login so a fresh user gets a working `ssh <box>` after a single
+	// command. Errors are surfaced but non-fatal — the login itself
+	// succeeded, and the user can re-run `containarium ssh setup`
+	// later.
+	maybeRunPostLoginSSHSetup(out, srv)
 	return nil
 }
+
+// maybeRunPostLoginSSHSetup implements the A7 contract:
+//
+//   --no-ssh-setup        skip silently
+//   --with-ssh-setup      run setup non-interactively (assume yes)
+//   neither (default)     prompt "Register this machine's SSH key
+//                         as 'X' for SSH access to your boxes? [Y/n]"
+//                         — empty answer = yes, anything else parsed
+//
+// In non-TTY environments (CI, pipes) we treat an empty/EOF answer
+// as "no" because hitting people with a key-registration in CI
+// without an explicit opt-in is hostile. Use --with-ssh-setup to
+// force-on in CI.
+func maybeRunPostLoginSSHSetup(out io.Writer, srv string) {
+	if loginNoSSHSetup {
+		return
+	}
+
+	name := defaultLocalKeyName()
+	if loginDeviceName != "" {
+		// Re-use the login --device-name when the user gave one;
+		// otherwise the SSH-keys table on the cloud has a different
+		// label than the "Active sessions" table, which is confusing.
+		name = loginDeviceName
+	}
+
+	// Prompt-or-skip decision.
+	yes := loginWithSSHSetup
+	if !yes {
+		isTTY := isStdinTTY()
+		prompt := fmt.Sprintf("\nRegister this machine's SSH key as %q for SSH access to your boxes? [Y/n] ", name)
+		fmt.Fprint(out, prompt)
+		ans, ok := readYesNo(loginPromptReader)
+		switch {
+		case !ok && isTTY:
+			fmt.Fprintln(out, "(no answer; skipping. Run `containarium ssh setup` later.)")
+			return
+		case !ok:
+			// Non-TTY + no answer = silent no.
+			return
+		case ans:
+			yes = true
+		default:
+			fmt.Fprintln(out, "(skipped. Run `containarium ssh setup` later.)")
+			return
+		}
+	}
+
+	if !yes {
+		return
+	}
+
+	// Drive the same code path `containarium ssh setup` uses, with
+	// the post-login defaults wired in. Errors surface as warnings
+	// because the login itself already succeeded — we don't want to
+	// roll that back.
+	oldName, oldServer := sshSetupName, sshSetupServer
+	sshSetupName = name
+	sshSetupServer = srv
+	defer func() {
+		sshSetupName = oldName
+		sshSetupServer = oldServer
+	}()
+
+	// Build a tiny cobra context so the handler's cmd.OutOrStdout()
+	// flows to the same writer login is using.
+	tmp := &cobra.Command{}
+	tmp.SetOut(out)
+	if err := runSSHSetup(tmp, nil); err != nil {
+		fmt.Fprintf(out, "⚠ SSH key setup skipped: %v\n", err)
+		fmt.Fprintln(out, "  You can re-run it later with `containarium ssh setup`.")
+	}
+}
+
+// readYesNo reads a single line from r and returns (yes, true) for
+// y/Y/yes/empty (because the prompt's default is Y), (no, true) for
+// n/N/no, and (_, false) for EOF.
+func readYesNo(r io.Reader) (bool, bool) {
+	if r == nil {
+		return false, false
+	}
+	br := bufio.NewReader(r)
+	line, err := br.ReadString('\n')
+	if err != nil && line == "" {
+		return false, false
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "", "y", "yes":
+		return true, true
+	case "n", "no":
+		return false, true
+	default:
+		// Unrecognised answer = treat as "no" but ok=true so the
+		// caller knows we got *some* input.
+		return false, true
+	}
+}
+
+// isStdinTTY is a best-effort "are we attached to a terminal?"
+// check. We don't pull in golang.org/x/term to keep the dependency
+// footprint tight — Stat() on stdin and checking the file mode is
+// good enough for the "should I treat empty-prompt as silent skip?"
+// decision below.
+func isStdinTTY() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// defaultLocalKeyName is defined in ssh.go (same package); this
+// comment is just a pointer for the next reader so they don't grep
+// for a missing helper.
 
 // createSession POSTs /v1/cli/sessions and decodes the response.
 func createSession(ctx context.Context, hc *http.Client, server, device string) (*createSessionResp, error) {

--- a/internal/cmd/login_ssh_test.go
+++ b/internal/cmd/login_ssh_test.go
@@ -1,0 +1,245 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/credentials"
+	"github.com/footprintai/containarium/internal/sshkey"
+)
+
+// Tests for sub-task A7 (umbrella-issue #100): the
+// `containarium login --with-ssh-setup / --no-ssh-setup` integration
+// landed in login.go's runLogin tail-call to maybeRunPostLoginSSHSetup.
+//
+// These tests intentionally live in a NEW file (per the brief's
+// "lesson from Phase 1: don't modify shared test files"). They share
+// the cmd-package globals with ssh_test.go and login_test.go but
+// redeclare nothing — withSSHHome (defined in ssh_test.go) is reused
+// because its cleanup already resets the ssh-setup-related flag
+// globals.
+
+// withSSHLoginHome stacks ssh_test.go's withSSHHome with extra
+// cleanup for the A7-only flag globals (loginWithSSHSetup,
+// loginNoSSHSetup, loginPromptReader).
+func withSSHLoginHome(t *testing.T) string {
+	t.Helper()
+	home := withSSHHome(t)
+	t.Cleanup(func() {
+		loginWithSSHSetup = false
+		loginNoSSHSetup = false
+		loginPromptReader = nil
+		loginServer = ""
+		loginNoBrowser = false
+		loginDeviceName = ""
+	})
+	return home
+}
+
+// fakeLoginAndSSHKeysServer wires the device-flow endpoints from
+// login.go AND the SSH-keys endpoints from ssh.go on a single
+// httptest.Server, because the post-login auto-setup path expects to
+// hit the same host the login ran against.
+type fakeLoginAndSSHKeysServer struct {
+	srv           *httptest.Server
+	addedKeys     []addSSHKeyReq
+	approveAfter  int32
+	pollCount     int32
+	sawAddSSHKey  atomic.Bool
+	receivedToken string
+}
+
+func newFakeLoginAndSSHKeysServer(t *testing.T, approveAfter int32) *fakeLoginAndSSHKeysServer {
+	t.Helper()
+	mux := http.NewServeMux()
+	f := &fakeLoginAndSSHKeysServer{approveAfter: approveAfter}
+
+	mux.HandleFunc("/v1/cli/sessions", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(createSessionResp{
+			SessionID:       "sess-A7",
+			UserCode:        "WXYZ-7777",
+			VerificationURL: "http://example.invalid/cli/authorize",
+			ExpiresIn:       600,
+		})
+	})
+	mux.HandleFunc("/v1/cli/sessions/sess-A7/status", func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&f.pollCount, 1)
+		resp := sessionStatusResp{Status: "pending"}
+		if n > f.approveAfter {
+			resp = sessionStatusResp{
+				Status:    "approved",
+				Token:     "tok-A7",
+				UserEmail: "alice@example.com",
+				OrgID:     "org_42",
+				ExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+			}
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	// SSH-key Add endpoint. Records the bearer token so the test can
+	// assert the login → ssh-setup handoff used the freshly-issued
+	// credential.
+	mux.HandleFunc("/v1/user/ssh-keys", func(w http.ResponseWriter, r *http.Request) {
+		f.receivedToken = strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		f.sawAddSSHKey.Store(true)
+		var req addSSHKeyReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		f.addedKeys = append(f.addedKeys, req)
+		fp, _ := sshkey.Fingerprint(req.PublicKey)
+		_ = json.NewEncoder(w).Encode(addSSHKeyResp{
+			Key: sshkey.SSHKey{
+				Name:        req.Name,
+				PublicKey:   req.PublicKey,
+				Fingerprint: fp,
+				CreatedAt:   time.Now().UTC(),
+			},
+		})
+	})
+
+	f.srv = httptest.NewServer(mux)
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+// runLoginWithSSHFlagsHelper performs the common test-setup boilerplate
+// for the A7 cases: short poll interval, no browser, scripted stdin.
+func runLoginWithSSHFlagsHelper(t *testing.T, f *fakeLoginAndSSHKeysServer, promptInput string) (*bytes.Buffer, error) {
+	t.Helper()
+	loginServer = f.srv.URL
+	loginNoBrowser = true
+	loginPromptReader = strings.NewReader(promptInput)
+
+	old := loginPollIntervalForTest()
+	t.Cleanup(func() { restorePollInterval(old) })
+	setPollInterval(10 * time.Millisecond)
+
+	var out bytes.Buffer
+	loginCmd.SetOut(&out)
+	loginCmd.SetErr(&out)
+	err := runLogin(loginCmd, nil)
+	return &out, err
+}
+
+func TestLogin_NoSSHSetup_SkipsRegistration(t *testing.T) {
+	withSSHLoginHome(t)
+	f := newFakeLoginAndSSHKeysServer(t, 0)
+
+	loginNoSSHSetup = true
+	out, err := runLoginWithSSHFlagsHelper(t, f, "")
+	if err != nil {
+		t.Fatalf("runLogin: %v", err)
+	}
+
+	if f.sawAddSSHKey.Load() {
+		t.Errorf("--no-ssh-setup should have skipped AddSSHKey, but it was called")
+	}
+	// Login itself succeeded — credentials file written.
+	path, _ := credentials.DefaultPath()
+	cf, _ := credentials.Load(path)
+	if _, ok := cf.Get(f.srv.URL); !ok {
+		t.Errorf("login credentials missing after --no-ssh-setup login")
+	}
+	o := out.String()
+	if !strings.Contains(o, "Logged in as alice@example.com") {
+		t.Errorf("login success line missing:\n%s", o)
+	}
+	if strings.Contains(o, "Register this machine's SSH key") {
+		t.Errorf("--no-ssh-setup leaked the prompt:\n%s", o)
+	}
+}
+
+func TestLogin_WithSSHSetup_AutoRegisters(t *testing.T) {
+	withSSHLoginHome(t)
+	f := newFakeLoginAndSSHKeysServer(t, 0)
+
+	loginWithSSHSetup = true
+	loginDeviceName = "alice-laptop"
+	out, err := runLoginWithSSHFlagsHelper(t, f, "")
+	if err != nil {
+		t.Fatalf("runLogin: %v", err)
+	}
+
+	if !f.sawAddSSHKey.Load() {
+		t.Fatalf("--with-ssh-setup should have triggered AddSSHKey; output:\n%s", out.String())
+	}
+	if f.receivedToken != "tok-A7" {
+		t.Errorf("AddSSHKey called with token %q, want tok-A7", f.receivedToken)
+	}
+	if len(f.addedKeys) != 1 {
+		t.Fatalf("added = %+v, want 1 entry", f.addedKeys)
+	}
+	if f.addedKeys[0].Name != "alice-laptop" {
+		t.Errorf("registered key name = %q, want alice-laptop (from --device-name)", f.addedKeys[0].Name)
+	}
+}
+
+func TestLogin_PromptYDefault_RegistersOnEmptyInput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("interactive prompt behaviour is POSIX-only in this test")
+	}
+	withSSHLoginHome(t)
+	f := newFakeLoginAndSSHKeysServer(t, 0)
+
+	// Empty line = accept Y default.
+	out, err := runLoginWithSSHFlagsHelper(t, f, "\n")
+	if err != nil {
+		t.Fatalf("runLogin: %v", err)
+	}
+	if !f.sawAddSSHKey.Load() {
+		t.Fatalf("empty answer (Y default) should trigger AddSSHKey; output:\n%s", out.String())
+	}
+}
+
+func TestLogin_PromptN_SkipsRegistration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("interactive prompt behaviour is POSIX-only in this test")
+	}
+	withSSHLoginHome(t)
+	f := newFakeLoginAndSSHKeysServer(t, 0)
+
+	out, err := runLoginWithSSHFlagsHelper(t, f, "n\n")
+	if err != nil {
+		t.Fatalf("runLogin: %v", err)
+	}
+	if f.sawAddSSHKey.Load() {
+		t.Errorf("answer 'n' should NOT trigger AddSSHKey; output:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "skipped") {
+		t.Errorf("expected skip notice in output:\n%s", out.String())
+	}
+}
+
+func TestReadYesNo_Defaults(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		yes  bool
+		ok   bool
+	}{
+		{"empty line treated as yes", "\n", true, true},
+		{"y", "y\n", true, true},
+		{"Y", "Y\n", true, true},
+		{"yes", "yes\n", true, true},
+		{"n", "n\n", false, true},
+		{"N", "N\n", false, true},
+		{"no", "no\n", false, true},
+		{"unknown text parsed as no", "maybe\n", false, true},
+		{"EOF (no newline) is unknown", "", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			yes, ok := readYesNo(strings.NewReader(tc.in))
+			if yes != tc.yes || ok != tc.ok {
+				t.Errorf("readYesNo(%q) = (%v, %v), want (%v, %v)", tc.in, yes, ok, tc.yes, tc.ok)
+			}
+		})
+	}
+}

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -1,0 +1,622 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/user"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/footprintai/containarium/internal/credentials"
+	"github.com/footprintai/containarium/internal/sshkey"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Sub-tasks A5 + A6 of umbrella-issue #100: per-machine SSH key
+// registration with the cloud's UserService.
+//
+// See prd/cloud/cli-login-and-multi-env-ssh.md §"Design —
+// Multi-environment SSH" for the contract:
+//
+//   containarium ssh setup [--name=<friendly>] [--key=<path>]
+//       reads/generates local key, POSTs UserService.AddSSHKey
+//   containarium ssh list
+//       GETs UserService.ListSSHKeys, prints a table
+//   containarium ssh remove <name>
+//       DELETEs UserService.RemoveSSHKey by name
+//   containarium ssh propagate
+//       POSTs UserService.PropagateSSHKeysToBoxes (cloud-side RPC
+//       not yet implemented; the CLI handles Unimplemented
+//       gracefully, matching the pattern from PR #297 / `containarium
+//       ttl`).
+//
+// Strong typing per CLAUDE.md: the on-wire shape is sshkey.SSHKey,
+// not map[string]any. The HTTP shim around UserService is small enough
+// that we inline it here rather than refactor internal/client/http.go
+// — those wrappers expect already-authenticated gRPC plumbing pointed
+// at the daemon, whereas the SSH-keys endpoints live on the cloud
+// (the same surface login.go talks to).
+
+// Per-command flags.
+var (
+	sshSetupName        string
+	sshSetupKeyPath     string
+	sshSetupGenerate    bool
+	sshSetupForce       bool
+	sshSetupServer      string
+	sshListServer       string
+	sshRemoveServer     string
+	sshPropagateServer  string
+	sshPropagateBoxes   []string
+)
+
+var sshCmd = &cobra.Command{
+	Use:   "ssh",
+	Short: "Manage per-machine SSH keys registered with your account",
+	Long: `Register, list, and remove the SSH public key(s) the cloud knows about
+for your user. Once a key is registered with ` + "`containarium ssh setup`" + `,
+it gets installed in the authorized_keys file of every box you create
+(or, with ` + "`containarium ssh propagate`" + `, every box you already own).
+
+The key registration lives on the cloud's UserService, NOT on a single
+daemon — so it follows you across self-hosted instances. This is the
+"one laptop, many boxes" half of the multi-environment SSH design.
+
+Typical first-run, post-login flow:
+
+  containarium login                  # populates ~/.containarium/credentials.json
+  containarium ssh setup              # uploads ~/.ssh/id_ed25519.pub (or generates one)
+  containarium create alice ...       # the key is auto-installed in alice's authorized_keys
+  ssh alice                           # works
+
+To register the same machine's key without re-running setup on every
+fresh box, run ` + "`containarium ssh propagate`" + ` once.`,
+}
+
+var sshSetupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Register this machine's SSH public key with the cloud",
+	Long: `Locate (or generate) the local SSH keypair, then upload the public
+half to the cloud via UserService.AddSSHKey. The private key stays
+on your laptop.
+
+Behavior:
+
+  - With no flags, looks for ~/.ssh/id_ed25519.pub (then id_rsa.pub).
+    If neither exists, generates a fresh ed25519 key at
+    ~/.ssh/containarium_ed25519{,.pub} and uploads the public half.
+
+  - --key=<path> uses an explicit public-key file (overrides the
+    search).
+
+  - --name=<label> sets the friendly name shown by ` + "`containarium ssh list`" + `.
+    Defaults to "<user>@<host>".
+
+  - --generate forces generation of a new keypair even if one
+    already exists in ~/.ssh.
+
+  - --force allows --generate to overwrite an existing
+    containarium-prefixed key.
+
+Requires ` + "`containarium login`" + ` first (the upload is
+authenticated with the credentials-file token).`,
+	Example: `  # Default: find ~/.ssh/id_ed25519.pub and register as alice@laptop
+  containarium ssh setup
+
+  # Custom label
+  containarium ssh setup --name=alice-mbp
+
+  # Explicit key file
+  containarium ssh setup --key=~/.ssh/work_ed25519.pub
+
+  # Generate a fresh containarium-only key
+  containarium ssh setup --generate`,
+	RunE: runSSHSetup,
+}
+
+var sshListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List SSH keys registered with your account",
+	Long: `Print the keys the cloud knows about for your user, one per row,
+showing the friendly name, the SHA256 fingerprint, and when each
+key was registered.
+
+Pipes-friendly: passes through stdout as a tab-aligned table; the
+key column is the fingerprint, not the full public-key blob.`,
+	RunE: runSSHList,
+}
+
+var sshRemoveCmd = &cobra.Command{
+	Use:   "remove <name>",
+	Short: "Remove a registered SSH key by friendly name",
+	Long: `Delete the SSH key with the given name from the cloud's record.
+Future boxes you create will not include this key in their
+authorized_keys (existing boxes are NOT touched — use
+` + "`containarium ssh propagate`" + ` to push the updated key set).
+
+The <name> argument is matched against the friendly label you set
+with ` + "`containarium ssh setup --name=`" + `. List the available
+names with ` + "`containarium ssh list`" + `.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSSHRemove,
+}
+
+var sshPropagateCmd = &cobra.Command{
+	Use:   "propagate",
+	Short: "Push your registered SSH keys to every existing box you own",
+	Long: `Walk every container you own and update its authorized_keys to
+match the keys currently registered with ` + "`containarium ssh list`" + `.
+
+Useful after:
+
+  - Adding a new laptop with ` + "`containarium ssh setup`" + ` —
+    propagate so the new key gets installed retroactively.
+
+  - Removing a lost laptop's key with ` + "`containarium ssh remove`" + ` —
+    propagate so the removal takes effect on existing boxes.
+
+This invokes UserService.PropagateSSHKeysToBoxes on the cloud, which
+fans out to every daemon hosting one of your boxes. The cloud-side
+RPC is not yet implemented (see the "what's NOT in this PR" section
+of the PR description); the CLI handles the resulting Unimplemented
+gracefully (prints a clear warning, exits 0) so callers can wire
+this into their workflow today.`,
+	Example: `  # Push to every owned box
+  containarium ssh propagate
+
+  # Limit to a specific subset of boxes
+  containarium ssh propagate --box=alice --box=bob`,
+	RunE: runSSHPropagate,
+}
+
+func init() {
+	sshSetupCmd.Flags().StringVar(&sshSetupName, "name", "", "friendly label for this key (default: <user>@<host>)")
+	sshSetupCmd.Flags().StringVar(&sshSetupKeyPath, "key", "", "path to public key file (default: auto-detect ~/.ssh/id_ed25519.pub or generate)")
+	sshSetupCmd.Flags().BoolVar(&sshSetupGenerate, "generate", false, "always generate a fresh ed25519 keypair (default: re-use ~/.ssh/id_ed25519.pub if present)")
+	sshSetupCmd.Flags().BoolVar(&sshSetupForce, "force", false, "with --generate, allow overwriting an existing containarium_ed25519 key")
+	sshSetupCmd.Flags().StringVar(&sshSetupServer, "server", "", "server URL for the upload (default: default_server from credentials file, then "+defaultLoginServer+")")
+
+	sshListCmd.Flags().StringVar(&sshListServer, "server", "", "server URL to query (default: default_server)")
+	sshRemoveCmd.Flags().StringVar(&sshRemoveServer, "server", "", "server URL to target (default: default_server)")
+	sshPropagateCmd.Flags().StringVar(&sshPropagateServer, "server", "", "server URL to target (default: default_server)")
+	sshPropagateCmd.Flags().StringSliceVar(&sshPropagateBoxes, "box", nil, "restrict propagation to these box names (repeatable); default: all owned boxes")
+
+	sshCmd.AddCommand(sshSetupCmd)
+	sshCmd.AddCommand(sshListCmd)
+	sshCmd.AddCommand(sshRemoveCmd)
+	sshCmd.AddCommand(sshPropagateCmd)
+	rootCmd.AddCommand(sshCmd)
+}
+
+// pickSSHServer collapses the precedence chain for the SSH-key
+// endpoints. Mirrors pickLoginServer's intent but adds a
+// credentials-file fallback because we usually want the same server
+// the user is logged into:
+//
+//   1. explicit --server flag
+//   2. credentials-file default_server
+//   3. defaultLoginServer constant
+func pickSSHServer(explicit string) string {
+	if explicit != "" {
+		return strings.TrimRight(explicit, "/")
+	}
+	if path, err := credentials.DefaultPath(); err == nil {
+		if cf, err := credentials.Load(path); err == nil && cf.DefaultServer != "" {
+			return strings.TrimRight(cf.DefaultServer, "/")
+		}
+	}
+	return defaultLoginServer
+}
+
+// sshHTTPClient is a small wrapper that talks to the cloud's
+// UserService REST endpoints with the bearer token from the
+// credentials store. Kept package-local rather than reaching into
+// internal/client/http.go because that wrapper is daemon-shaped
+// (gRPC-gateway over an mTLS-fronted daemon) — wrong surface for the
+// cloud's user-keys endpoints.
+type sshHTTPClient struct {
+	hc     *http.Client
+	server string
+	token  string
+}
+
+func newSSHHTTPClient(server string) (*sshHTTPClient, error) {
+	tok := resolveAuthToken(server)
+	if tok == "" {
+		return nil, fmt.Errorf("no auth token for %s (run `containarium login`)", server)
+	}
+	return &sshHTTPClient{
+		hc:     &http.Client{Timeout: 30 * time.Second},
+		server: server,
+		token:  tok,
+	}, nil
+}
+
+// doJSON sends method+path with optional body, decodes the response
+// into out (if non-nil), and converts 501 Not Implemented into a gRPC
+// Unimplemented status so the call-site can lean on isUnimplemented()
+// (defined in ttl.go).
+func (c *sshHTTPClient) doJSON(ctx context.Context, method, path string, body, out any) error {
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.server+path, rdr)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == http.StatusNotImplemented {
+		return status.Errorf(codes.Unimplemented, "%s %s: server returned 501 Not Implemented", method, path)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		// grpc-gateway emits 404 for routes the cloud hasn't wired
+		// yet. Treat that as Unimplemented too so the propagate path
+		// can fall through gracefully — matching ttl.go's posture.
+		return status.Errorf(codes.Unimplemented, "%s %s: route not found (server may not support this RPC yet)", method, path)
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(rb)))
+	}
+
+	if out != nil && len(rb) > 0 {
+		if err := json.Unmarshal(rb, out); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+// Wire-format DTOs for the UserService SSH-key endpoints. Each
+// mirrors the .proto on the cloud side; we redeclare here so the OSS
+// CLI compiles without depending on a cloud-private pb package.
+//
+// Per CLAUDE.md: typed structs, not map[string]any.
+
+type addSSHKeyReq struct {
+	Name      string `json:"name"`
+	PublicKey string `json:"public_key"`
+}
+
+type addSSHKeyResp struct {
+	Key sshkey.SSHKey `json:"key"`
+}
+
+type listSSHKeysResp struct {
+	Keys []sshkey.SSHKey `json:"keys"`
+}
+
+type propagateReq struct {
+	Boxes []string `json:"boxes,omitempty"` // empty = all owned
+}
+
+type propagateResp struct {
+	UpdatedBoxes []string `json:"updated_boxes"`
+	SkippedBoxes []string `json:"skipped_boxes"`
+}
+
+// AddSSHKey uploads pubkey under the given name. Returns the
+// canonicalised SSHKey (with fingerprint + created_at) the server
+// stored.
+func (c *sshHTTPClient) AddSSHKey(ctx context.Context, name, pub string) (*sshkey.SSHKey, error) {
+	var out addSSHKeyResp
+	if err := c.doJSON(ctx, http.MethodPost, "/v1/user/ssh-keys", addSSHKeyReq{Name: name, PublicKey: pub}, &out); err != nil {
+		return nil, err
+	}
+	return &out.Key, nil
+}
+
+func (c *sshHTTPClient) ListSSHKeys(ctx context.Context) ([]sshkey.SSHKey, error) {
+	var out listSSHKeysResp
+	if err := c.doJSON(ctx, http.MethodGet, "/v1/user/ssh-keys", nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Keys, nil
+}
+
+func (c *sshHTTPClient) RemoveSSHKey(ctx context.Context, name string) error {
+	// Name is path-segment safe (we validate at runSSHRemove) so we
+	// can inline it without url-escaping. Switch to url.PathEscape if
+	// we ever loosen the validator.
+	return c.doJSON(ctx, http.MethodDelete, "/v1/user/ssh-keys/"+name, nil, nil)
+}
+
+func (c *sshHTTPClient) PropagateSSHKeys(ctx context.Context, boxes []string) (*propagateResp, error) {
+	var out propagateResp
+	if err := c.doJSON(ctx, http.MethodPost, "/v1/user/ssh-keys:propagate", propagateReq{Boxes: boxes}, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ---- command handlers --------------------------------------------------
+
+func runSSHSetup(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	srv := pickSSHServer(sshSetupServer)
+	name := sshSetupName
+	if name == "" {
+		name = defaultLocalKeyName()
+	}
+	if err := validateKeyName(name); err != nil {
+		return err
+	}
+
+	pub, source, generated, err := obtainLocalPublicKey()
+	if err != nil {
+		return err
+	}
+	fp, err := sshkey.Fingerprint(pub)
+	if err != nil {
+		return fmt.Errorf("fingerprint key: %w", err)
+	}
+
+	if generated {
+		fmt.Fprintf(out, "Generated new ed25519 keypair at %s\n", source)
+	} else {
+		fmt.Fprintf(out, "Using existing key at %s\n", source)
+	}
+	fmt.Fprintf(out, "  Fingerprint: %s\n", fp)
+	fmt.Fprintf(out, "  Registering as %q with %s\n", name, srv)
+
+	client, err := newSSHHTTPClient(srv)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	stored, err := client.AddSSHKey(ctx, name, pub)
+	if isUnimplemented(err) {
+		fmt.Fprintf(out, "\n⚠ SSH-key registration not yet supported by %s (UserService.AddSSHKey returned Unimplemented).\n", srv)
+		fmt.Fprintf(out, "  Your key is on disk at %s — once the cloud-side endpoint ships, re-run `containarium ssh setup`.\n", source)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("register key: %w", err)
+	}
+
+	fmt.Fprintf(out, "✓ Registered key %q (fingerprint %s)\n", stored.Name, stored.Fingerprint)
+	return nil
+}
+
+func runSSHList(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	srv := pickSSHServer(sshListServer)
+	client, err := newSSHHTTPClient(srv)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	keys, err := client.ListSSHKeys(ctx)
+	if isUnimplemented(err) {
+		fmt.Fprintf(out, "⚠ Listing SSH keys not yet supported by %s (UserService.ListSSHKeys returned Unimplemented).\n", srv)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("list keys: %w", err)
+	}
+	if len(keys) == 0 {
+		fmt.Fprintln(out, "No SSH keys registered. Run `containarium ssh setup` to add one.")
+		return nil
+	}
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tFINGERPRINT\tCREATED")
+	for _, k := range keys {
+		created := "-"
+		if !k.CreatedAt.IsZero() {
+			created = k.CreatedAt.UTC().Format(time.RFC3339)
+		}
+		fp := k.Fingerprint
+		if fp == "" && k.PublicKey != "" {
+			// Compute it locally if the server didn't include it
+			// — common against early/partial implementations.
+			if f, err := sshkey.Fingerprint(k.PublicKey); err == nil {
+				fp = f
+			}
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", k.Name, fp, created)
+	}
+	return tw.Flush()
+}
+
+func runSSHRemove(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	name := args[0]
+	if err := validateKeyName(name); err != nil {
+		return err
+	}
+	srv := pickSSHServer(sshRemoveServer)
+	client, err := newSSHHTTPClient(srv)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err = client.RemoveSSHKey(ctx, name)
+	if isUnimplemented(err) {
+		fmt.Fprintf(out, "⚠ SSH-key removal not yet supported by %s (UserService.RemoveSSHKey returned Unimplemented).\n", srv)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("remove key %q: %w", name, err)
+	}
+	fmt.Fprintf(out, "✓ Removed SSH key %q from %s\n", name, srv)
+	fmt.Fprintln(out, "  (Existing boxes still have this key in authorized_keys — run `containarium ssh propagate` to push the removal.)")
+	return nil
+}
+
+func runSSHPropagate(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	srv := pickSSHServer(sshPropagateServer)
+	for _, b := range sshPropagateBoxes {
+		if err := validateBoxName(b); err != nil {
+			return err
+		}
+	}
+	client, err := newSSHHTTPClient(srv)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	if len(sshPropagateBoxes) == 0 {
+		fmt.Fprintf(out, "Propagating keys to every owned box on %s ...\n", srv)
+	} else {
+		fmt.Fprintf(out, "Propagating keys to %d box(es) on %s ...\n", len(sshPropagateBoxes), srv)
+	}
+
+	res, err := client.PropagateSSHKeys(ctx, sshPropagateBoxes)
+	if isUnimplemented(err) {
+		fmt.Fprintf(out, "⚠ Key propagation not yet supported by %s.\n", srv)
+		fmt.Fprintln(out, "  UserService.PropagateSSHKeysToBoxes is a planned cloud-side RPC that")
+		fmt.Fprintln(out, "  hasn't shipped yet. New boxes still get the latest keys at create time;")
+		fmt.Fprintln(out, "  this command will Just Work once the cloud-side endpoint lands —")
+		fmt.Fprintln(out, "  re-run it then. See the PR that introduced `containarium ssh propagate`")
+		fmt.Fprintln(out, "  for the deferred follow-up.")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("propagate: %w", err)
+	}
+	fmt.Fprintf(out, "✓ Updated %d box(es)", len(res.UpdatedBoxes))
+	if len(res.SkippedBoxes) > 0 {
+		fmt.Fprintf(out, ", skipped %d", len(res.SkippedBoxes))
+	}
+	fmt.Fprintln(out)
+	for _, b := range res.UpdatedBoxes {
+		fmt.Fprintf(out, "  + %s\n", b)
+	}
+	for _, b := range res.SkippedBoxes {
+		fmt.Fprintf(out, "  - %s (skipped)\n", b)
+	}
+	return nil
+}
+
+// ---- helpers -----------------------------------------------------------
+
+// obtainLocalPublicKey runs the flag-precedence chain documented on
+// `ssh setup`: explicit --key wins; --generate forces creation; else
+// LocateOrGenerate. Returns (pubkeyContents, sourcePath, wasGenerated, err).
+func obtainLocalPublicKey() (string, string, bool, error) {
+	switch {
+	case sshSetupKeyPath != "":
+		pub, err := sshkey.ReadPublicKey(sshSetupKeyPath)
+		if err != nil {
+			return "", "", false, err
+		}
+		return pub, sshSetupKeyPath, false, nil
+
+	case sshSetupGenerate:
+		path, pub, err := sshkey.Generate(sshkey.LocateOpts{}, sshSetupForce)
+		if err != nil {
+			return "", "", false, fmt.Errorf("generate keypair: %w", err)
+		}
+		return pub, path, true, nil
+
+	default:
+		path, pub, generated, err := sshkey.LocateOrGenerate(sshkey.LocateOpts{})
+		if err != nil {
+			return "", "", false, fmt.Errorf("locate or generate keypair: %w", err)
+		}
+		return pub, path, generated, nil
+	}
+}
+
+// defaultLocalKeyName mirrors login.go's deviceName fallback so the
+// "Active sessions" UI and the "SSH keys" UI on the cloud read with
+// matching labels.
+func defaultLocalKeyName() string {
+	var who, host string
+	if u, err := user.Current(); err == nil {
+		who = u.Username
+	}
+	host, _ = os.Hostname()
+	return sshkey.DefaultKeyName(who, host)
+}
+
+// validateKeyName guards the friendly-name field against obviously
+// hostile input. The cloud-side will re-validate, but rejecting at
+// the CLI gives a clearer message — and validating before we put the
+// name into a URL path (for `ssh remove`) means we don't need
+// url.PathEscape.
+//
+// Rules (intentionally narrow):
+//   - non-empty after trim
+//   - 1..64 chars
+//   - alphanumerics, dash, underscore, dot, @
+//
+// Loosen the regex when a real user files a feature request — until
+// then this is the safe baseline.
+func validateKeyName(name string) error {
+	n := strings.TrimSpace(name)
+	if n == "" {
+		return fmt.Errorf("name is empty")
+	}
+	if len(n) > 64 {
+		return fmt.Errorf("name %q exceeds 64 characters", n)
+	}
+	for _, r := range n {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '-', r == '_', r == '.', r == '@':
+			continue
+		default:
+			return fmt.Errorf("name %q contains disallowed character %q (allowed: alphanumerics, '-', '_', '.', '@')", n, r)
+		}
+	}
+	return nil
+}
+
+// validateBoxName is the same shape as validateKeyName but tighter
+// (no '@' or '.') because box names go into Linux usernames upstream.
+// Keep in sync with internal/server/create_bounds.go if it changes
+// there.
+func validateBoxName(name string) error {
+	n := strings.TrimSpace(name)
+	if n == "" {
+		return fmt.Errorf("box name is empty")
+	}
+	if len(n) > 32 {
+		return fmt.Errorf("box name %q exceeds 32 characters", n)
+	}
+	for _, r := range n {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= '0' && r <= '9',
+			r == '-', r == '_':
+			continue
+		default:
+			return fmt.Errorf("box name %q contains disallowed character %q (allowed: lowercase, digits, '-', '_')", n, r)
+		}
+	}
+	return nil
+}

--- a/internal/cmd/ssh_test.go
+++ b/internal/cmd/ssh_test.go
@@ -1,0 +1,551 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/credentials"
+	"github.com/footprintai/containarium/internal/sshkey"
+)
+
+// withSSHHome mirrors withTempHome from login_test.go but also
+// resets the ssh-command-scope flag globals between runs so
+// previous tests' --name / --key don't leak.
+func withSSHHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+	t.Cleanup(func() {
+		authToken = ""
+		serverAddr = ""
+		sshSetupName = ""
+		sshSetupKeyPath = ""
+		sshSetupGenerate = false
+		sshSetupForce = false
+		sshSetupServer = ""
+		sshListServer = ""
+		sshRemoveServer = ""
+		sshPropagateServer = ""
+		sshPropagateBoxes = nil
+	})
+	return home
+}
+
+func seedTokenFor(t *testing.T, home, server, token string) {
+	t.Helper()
+	cf := credentials.NewCredentialsFile()
+	cf.Set(server, credentials.ServerCreds{
+		Token:    token,
+		IssuedAt: time.Now().UTC(),
+	})
+	path := filepath.Join(home, credentials.DefaultRelPath)
+	if err := credentials.Save(path, cf); err != nil {
+		t.Fatalf("seedTokenFor: %v", err)
+	}
+}
+
+// fakeSSHKeysServer impersonates the cloud's UserService SSH-keys
+// REST surface. We register only the routes the test needs and let
+// the rest 404 (which the client turns into Unimplemented).
+type fakeSSHKeysServer struct {
+	srv     *httptest.Server
+	mux     *http.ServeMux
+	keys    []sshkey.SSHKey
+	added   []addSSHKeyReq
+	gotAuth string
+}
+
+func newFakeSSHKeysServer(t *testing.T) *fakeSSHKeysServer {
+	t.Helper()
+	f := &fakeSSHKeysServer{mux: http.NewServeMux()}
+	f.srv = httptest.NewServer(f.mux)
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *fakeSSHKeysServer) wireAdd() {
+	f.mux.HandleFunc("/v1/user/ssh-keys", func(w http.ResponseWriter, r *http.Request) {
+		f.gotAuth = r.Header.Get("Authorization")
+		switch r.Method {
+		case http.MethodPost:
+			var req addSSHKeyReq
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			f.added = append(f.added, req)
+			fp, _ := sshkey.Fingerprint(req.PublicKey)
+			k := sshkey.SSHKey{
+				Name:        req.Name,
+				PublicKey:   req.PublicKey,
+				Fingerprint: fp,
+				CreatedAt:   time.Now().UTC(),
+			}
+			f.keys = append(f.keys, k)
+			_ = json.NewEncoder(w).Encode(addSSHKeyResp{Key: k})
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(listSSHKeysResp{Keys: f.keys})
+		default:
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func (f *fakeSSHKeysServer) wireRemove() {
+	// Subtree handler — strip the prefix in the handler.
+	f.mux.HandleFunc("/v1/user/ssh-keys/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+			return
+		}
+		name := strings.TrimPrefix(r.URL.Path, "/v1/user/ssh-keys/")
+		out := f.keys[:0]
+		for _, k := range f.keys {
+			if k.Name != name {
+				out = append(out, k)
+			}
+		}
+		f.keys = out
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// --- validators ---------------------------------------------------------
+
+func TestValidateKeyName(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"plain", "alice", false},
+		{"with at", "alice@laptop", false},
+		{"with dash and underscore", "alice-mbp_2024", false},
+		{"with dot", "alice.work", false},
+		{"empty", "", true},
+		{"whitespace only", "   ", true},
+		{"too long", strings.Repeat("a", 65), true},
+		{"path-traversal attempt", "../etc/passwd", true},
+		{"slash", "alice/bob", true},
+		{"space", "alice laptop", true},
+		{"quote", `alice"laptop`, true},
+		{"semicolon", "alice;rm", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateKeyName(tc.in)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateKeyName(%q) = nil, want error", tc.in)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateKeyName(%q) = %v, want nil", tc.in, err)
+			}
+		})
+	}
+}
+
+func TestValidateBoxName(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"plain", "alice", false},
+		{"with dash", "ci-bob-pr123", false},
+		{"empty", "", true},
+		{"uppercase", "Alice", true},
+		{"at sign", "alice@laptop", true},
+		{"dot", "alice.laptop", true},
+		{"too long", strings.Repeat("a", 33), true},
+		{"slash", "alice/bob", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateBoxName(tc.in)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateBoxName(%q) = nil, want error", tc.in)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateBoxName(%q) = %v, want nil", tc.in, err)
+			}
+		})
+	}
+}
+
+// --- pickSSHServer -----------------------------------------------------
+
+func TestPickSSHServer_ExplicitWins(t *testing.T) {
+	home := withSSHHome(t)
+	seedTokenFor(t, home, "https://cloud.containarium.dev", "t")
+	got := pickSSHServer("https://explicit.example.com/")
+	if got != "https://explicit.example.com" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestPickSSHServer_DefaultsToCredentials(t *testing.T) {
+	home := withSSHHome(t)
+	seedTokenFor(t, home, "https://self-hosted.example.com", "t")
+	got := pickSSHServer("")
+	if got != "https://self-hosted.example.com" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestPickSSHServer_FallsBackToConstant(t *testing.T) {
+	withSSHHome(t)
+	got := pickSSHServer("")
+	if got != defaultLoginServer {
+		t.Fatalf("got %q, want %q", got, defaultLoginServer)
+	}
+}
+
+// --- newSSHHTTPClient ---------------------------------------------------
+
+func TestNewSSHHTTPClient_RequiresToken(t *testing.T) {
+	withSSHHome(t)
+	_, err := newSSHHTTPClient("https://no-token.example.com")
+	if err == nil || !strings.Contains(err.Error(), "no auth token") {
+		t.Fatalf("err = %v, want no-auth-token error", err)
+	}
+}
+
+func TestNewSSHHTTPClient_LoadsTokenFromCreds(t *testing.T) {
+	home := withSSHHome(t)
+	seedTokenFor(t, home, "https://cloud.example.com", "tok-xyz")
+	c, err := newSSHHTTPClient("https://cloud.example.com")
+	if err != nil {
+		t.Fatalf("newSSHHTTPClient: %v", err)
+	}
+	if c.token != "tok-xyz" {
+		t.Errorf("token = %q", c.token)
+	}
+}
+
+// --- runSSHSetup --------------------------------------------------------
+
+func TestSSHSetup_HappyPath_GeneratesAndUploads(t *testing.T) {
+	home := withSSHHome(t)
+	f := newFakeSSHKeysServer(t)
+	f.wireAdd()
+	seedTokenFor(t, home, f.srv.URL, "tok")
+
+	sshSetupServer = f.srv.URL
+	sshSetupName = "alice-laptop"
+
+	var out bytes.Buffer
+	sshSetupCmd.SetOut(&out)
+	sshSetupCmd.SetErr(&out)
+	if err := runSSHSetup(sshSetupCmd, nil); err != nil {
+		t.Fatalf("runSSHSetup: %v", err)
+	}
+
+	if len(f.added) != 1 {
+		t.Fatalf("added = %+v, want 1 entry", f.added)
+	}
+	if f.added[0].Name != "alice-laptop" {
+		t.Errorf("Name = %q", f.added[0].Name)
+	}
+	if !strings.HasPrefix(f.added[0].PublicKey, "ssh-ed25519 ") {
+		t.Errorf("PublicKey = %q, want ssh-ed25519 prefix", f.added[0].PublicKey)
+	}
+	if !strings.HasPrefix(f.gotAuth, "Bearer tok") {
+		t.Errorf("Authorization header = %q", f.gotAuth)
+	}
+
+	o := out.String()
+	if !strings.Contains(o, "Generated new ed25519 keypair") {
+		t.Errorf("output missing generation notice:\n%s", o)
+	}
+	if !strings.Contains(o, "Registered key") {
+		t.Errorf("output missing success line:\n%s", o)
+	}
+
+	// Key file actually landed in $HOME/.ssh.
+	if _, err := os.Stat(filepath.Join(home, ".ssh", "containarium_ed25519.pub")); err != nil {
+		t.Errorf("public key not on disk: %v", err)
+	}
+}
+
+func TestSSHSetup_UsesExplicitKeyFlag(t *testing.T) {
+	home := withSSHHome(t)
+
+	// Generate a key into a sidecar dir, then point --key at it.
+	stage := t.TempDir()
+	_, pub, err := sshkey.Generate(sshkey.LocateOpts{HomeDir: stage}, false)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	keyPath := filepath.Join(stage, ".ssh", "containarium_ed25519.pub")
+
+	f := newFakeSSHKeysServer(t)
+	f.wireAdd()
+	seedTokenFor(t, home, f.srv.URL, "tok")
+
+	sshSetupServer = f.srv.URL
+	sshSetupKeyPath = keyPath
+
+	var out bytes.Buffer
+	sshSetupCmd.SetOut(&out)
+	if err := runSSHSetup(sshSetupCmd, nil); err != nil {
+		t.Fatalf("runSSHSetup: %v", err)
+	}
+	if len(f.added) != 1 {
+		t.Fatalf("added = %+v", f.added)
+	}
+	if strings.TrimSpace(f.added[0].PublicKey) != pub {
+		t.Errorf("uploaded pubkey doesn't match --key file")
+	}
+
+	// We did NOT generate anything in $HOME/.ssh.
+	if _, err := os.Stat(filepath.Join(home, ".ssh", "containarium_ed25519.pub")); err == nil {
+		t.Error("setup unexpectedly generated a key in HOME when --key was given")
+	}
+}
+
+func TestSSHSetup_BadNameRejected(t *testing.T) {
+	home := withSSHHome(t)
+	f := newFakeSSHKeysServer(t)
+	f.wireAdd()
+	seedTokenFor(t, home, f.srv.URL, "tok")
+
+	sshSetupServer = f.srv.URL
+	sshSetupName = "alice; rm -rf /"
+
+	var out bytes.Buffer
+	sshSetupCmd.SetOut(&out)
+	err := runSSHSetup(sshSetupCmd, nil)
+	if err == nil {
+		t.Fatal("expected error on disallowed name")
+	}
+	if len(f.added) != 0 {
+		t.Errorf("bad name reached server: %+v", f.added)
+	}
+}
+
+func TestSSHSetup_NoToken_Errors(t *testing.T) {
+	withSSHHome(t)
+	f := newFakeSSHKeysServer(t)
+	f.wireAdd()
+	// Note: no seedTokenFor — credentials file is empty.
+
+	sshSetupServer = f.srv.URL
+	sshSetupName = "alice"
+
+	var out bytes.Buffer
+	sshSetupCmd.SetOut(&out)
+	err := runSSHSetup(sshSetupCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "no auth token") {
+		t.Fatalf("err = %v, want no-auth-token", err)
+	}
+}
+
+func TestSSHSetup_GracefulOnUnimplementedServer(t *testing.T) {
+	home := withSSHHome(t)
+	// Empty mux → every route 404s → client maps to Unimplemented.
+	f := newFakeSSHKeysServer(t)
+	seedTokenFor(t, home, f.srv.URL, "tok")
+
+	sshSetupServer = f.srv.URL
+	sshSetupName = "alice"
+
+	var out bytes.Buffer
+	sshSetupCmd.SetOut(&out)
+	if err := runSSHSetup(sshSetupCmd, nil); err != nil {
+		t.Fatalf("runSSHSetup should swallow Unimplemented, got: %v", err)
+	}
+	o := out.String()
+	if !strings.Contains(o, "not yet supported") {
+		t.Errorf("expected friendly warning in output:\n%s", o)
+	}
+}
+
+// --- runSSHList ---------------------------------------------------------
+
+func TestSSHList_EmptyPrintsHint(t *testing.T) {
+	home := withSSHHome(t)
+	f := newFakeSSHKeysServer(t)
+	f.wireAdd()
+	seedTokenFor(t, home, f.srv.URL, "tok")
+
+	sshListServer = f.srv.URL
+	var out bytes.Buffer
+	sshListCmd.SetOut(&out)
+	if err := runSSHList(sshListCmd, nil); err != nil {
+		t.Fatalf("runSSHList: %v", err)
+	}
+	if !strings.Contains(out.String(), "No SSH keys registered") {
+		t.Errorf("expected empty-hint output, got %q", out.String())
+	}
+}
+
+func TestSSHList_PrintsTable(t *testing.T) {
+	home := withSSHHome(t)
+	f := newFakeSSHKeysServer(t)
+	f.wireAdd()
+	seedTokenFor(t, home, f.srv.URL, "tok")
+
+	// Seed two keys by hitting setup twice with different names.
+	for _, n := range []string{"alice-laptop", "alice-mbp"} {
+		sshSetupServer = f.srv.URL
+		sshSetupName = n
+		sshSetupGenerate = true
+		sshSetupForce = true
+		var sink bytes.Buffer
+		sshSetupCmd.SetOut(&sink)
+		if err := runSSHSetup(sshSetupCmd, nil); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	sshSetupName = ""
+	sshSetupGenerate = false
+	sshSetupForce = false
+
+	sshListServer = f.srv.URL
+	var out bytes.Buffer
+	sshListCmd.SetOut(&out)
+	if err := runSSHList(sshListCmd, nil); err != nil {
+		t.Fatalf("runSSHList: %v", err)
+	}
+	o := out.String()
+	for _, want := range []string{"NAME", "FINGERPRINT", "alice-laptop", "alice-mbp", "SHA256:"} {
+		if !strings.Contains(o, want) {
+			t.Errorf("output missing %q:\n%s", want, o)
+		}
+	}
+}
+
+func TestSSHList_GracefulOnUnimplemented(t *testing.T) {
+	home := withSSHHome(t)
+	f := newFakeSSHKeysServer(t)
+	seedTokenFor(t, home, f.srv.URL, "tok")
+
+	sshListServer = f.srv.URL
+	var out bytes.Buffer
+	sshListCmd.SetOut(&out)
+	if err := runSSHList(sshListCmd, nil); err != nil {
+		t.Fatalf("runSSHList: %v", err)
+	}
+	if !strings.Contains(out.String(), "not yet supported") {
+		t.Errorf("expected warning output, got %q", out.String())
+	}
+}
+
+// --- runSSHRemove -------------------------------------------------------
+
+func TestSSHRemove_HappyPath(t *testing.T) {
+	home := withSSHHome(t)
+	f := newFakeSSHKeysServer(t)
+	f.wireAdd()
+	f.wireRemove()
+	seedTokenFor(t, home, f.srv.URL, "tok")
+
+	sshSetupServer = f.srv.URL
+	sshSetupName = "alice-laptop"
+	var sink bytes.Buffer
+	sshSetupCmd.SetOut(&sink)
+	if err := runSSHSetup(sshSetupCmd, nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	sshSetupName = ""
+
+	sshRemoveServer = f.srv.URL
+	var out bytes.Buffer
+	sshRemoveCmd.SetOut(&out)
+	if err := runSSHRemove(sshRemoveCmd, []string{"alice-laptop"}); err != nil {
+		t.Fatalf("runSSHRemove: %v", err)
+	}
+	if len(f.keys) != 0 {
+		t.Errorf("keys = %+v, want empty after remove", f.keys)
+	}
+	if !strings.Contains(out.String(), "Removed SSH key") {
+		t.Errorf("output: %q", out.String())
+	}
+}
+
+func TestSSHRemove_BadNameRejected(t *testing.T) {
+	home := withSSHHome(t)
+	f := newFakeSSHKeysServer(t)
+	seedTokenFor(t, home, f.srv.URL, "tok")
+	sshRemoveServer = f.srv.URL
+
+	err := runSSHRemove(sshRemoveCmd, []string{"../etc/shadow"})
+	if err == nil {
+		t.Fatal("expected error on disallowed name")
+	}
+}
+
+// --- runSSHPropagate ----------------------------------------------------
+
+func TestSSHPropagate_GracefulOnUnimplemented(t *testing.T) {
+	home := withSSHHome(t)
+	f := newFakeSSHKeysServer(t)
+	seedTokenFor(t, home, f.srv.URL, "tok")
+
+	sshPropagateServer = f.srv.URL
+	var out bytes.Buffer
+	sshPropagateCmd.SetOut(&out)
+	if err := runSSHPropagate(sshPropagateCmd, nil); err != nil {
+		t.Fatalf("runSSHPropagate should swallow Unimplemented, got: %v", err)
+	}
+	o := out.String()
+	if !strings.Contains(o, "not yet supported") {
+		t.Errorf("expected friendly warning, got %q", o)
+	}
+}
+
+func TestSSHPropagate_HappyPath(t *testing.T) {
+	home := withSSHHome(t)
+	f := newFakeSSHKeysServer(t)
+	f.mux.HandleFunc("/v1/user/ssh-keys:propagate", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+			return
+		}
+		var req propagateReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		boxes := req.Boxes
+		if len(boxes) == 0 {
+			boxes = []string{"alice", "bob"}
+		}
+		_ = json.NewEncoder(w).Encode(propagateResp{UpdatedBoxes: boxes})
+	})
+	seedTokenFor(t, home, f.srv.URL, "tok")
+
+	sshPropagateServer = f.srv.URL
+	sshPropagateBoxes = []string{"alice", "ci-box-1"}
+	var out bytes.Buffer
+	sshPropagateCmd.SetOut(&out)
+	if err := runSSHPropagate(sshPropagateCmd, nil); err != nil {
+		t.Fatalf("runSSHPropagate: %v", err)
+	}
+	o := out.String()
+	for _, want := range []string{"Updated 2 box(es)", "+ alice", "+ ci-box-1"} {
+		if !strings.Contains(o, want) {
+			t.Errorf("output missing %q:\n%s", want, o)
+		}
+	}
+}
+
+func TestSSHPropagate_RejectsBadBoxName(t *testing.T) {
+	home := withSSHHome(t)
+	f := newFakeSSHKeysServer(t)
+	seedTokenFor(t, home, f.srv.URL, "tok")
+
+	sshPropagateServer = f.srv.URL
+	sshPropagateBoxes = []string{"alice", "alice@laptop"}
+	var out bytes.Buffer
+	sshPropagateCmd.SetOut(&out)
+	err := runSSHPropagate(sshPropagateCmd, nil)
+	if err == nil {
+		t.Fatal("expected error on disallowed box name")
+	}
+}

--- a/internal/sshkey/local.go
+++ b/internal/sshkey/local.go
@@ -1,0 +1,291 @@
+// Package sshkey detects, generates, and fingerprints local SSH
+// keypairs for the `containarium ssh setup` flow (sub-task A5 of
+// umbrella-issue #100). See prd/cloud/cli-login-and-multi-env-ssh.md
+// §"Design — Multi-environment SSH".
+//
+// Why a dedicated package: the CLI flow needs three slightly-different
+// things from "the user's local SSH key" — locate an existing one,
+// generate a new one on first login, and compute the SHA256 fingerprint
+// so the cloud-side ListSSHKeys table is human-meaningful. Concentrating
+// all three in one place gives `internal/cmd/ssh.go` and the
+// `--with-ssh-setup` path in login.go a single, testable surface.
+//
+// Strong typing per CLAUDE.md: the public shape is the SSHKey struct
+// (which mirrors the cloud's UserService SSHKey message field-for-field),
+// not a (string, string, string) triple.
+package sshkey
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// SSHKey is the wire-shape of a user-registered SSH key as returned by
+// the cloud's UserService.ListSSHKeys / AddSSHKey. Kept here (rather
+// than in pkg/pb) so the CLI compiles cleanly even before the
+// cloud-side proto/pb regen lands; the field tags match the JSON the
+// REST shim will emit.
+type SSHKey struct {
+	Name        string    `json:"name"`
+	PublicKey   string    `json:"public_key"`
+	Fingerprint string    `json:"fingerprint"`
+	CreatedAt   time.Time `json:"created_at,omitempty"`
+}
+
+// DefaultPrivateKeyPath is the file we look at first when "find the
+// local key" is asked. It's the canonical OpenSSH default; nearly
+// every developer machine has ed25519 here or at id_rsa.
+const (
+	DefaultPrivateKeyPath    = "id_ed25519"
+	DefaultPublicKeyPath     = "id_ed25519.pub"
+	FallbackPrivateKeyPath   = "id_rsa"
+	FallbackPublicKeyPath    = "id_rsa.pub"
+	containariumKeyName      = "containarium_ed25519"
+	containariumPubKeySuffix = ".pub"
+)
+
+// LocateOpts controls Locate's search order. Zero value is "look in
+// ~/.ssh for ed25519 then rsa". Tests inject HomeDir to redirect at a
+// tempdir.
+type LocateOpts struct {
+	HomeDir string // override $HOME (mostly for tests); empty = os.UserHomeDir
+}
+
+// Locate scans ~/.ssh for an existing SSH keypair and returns the
+// path to the *public* key file plus its parsed contents. The
+// private key is not loaded — we never need to send it anywhere, and
+// reading it would gratuitously require an unlock prompt on
+// passphrase-protected keys.
+//
+// Search order: id_ed25519.pub, then id_rsa.pub. Returns os.ErrNotExist
+// if neither exists (callers can choose to fall through to Generate).
+func Locate(opts LocateOpts) (pubPath string, pub string, err error) {
+	dir, err := sshDir(opts.HomeDir)
+	if err != nil {
+		return "", "", err
+	}
+	for _, name := range []string{DefaultPublicKeyPath, FallbackPublicKeyPath} {
+		p := filepath.Join(dir, name)
+		// #nosec G304 -- path is under the user's own ~/.ssh; not
+		// attacker-controlled.
+		b, err := os.ReadFile(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", "", fmt.Errorf("read %s: %w", p, err)
+		}
+		s := strings.TrimSpace(string(b))
+		if s == "" {
+			continue
+		}
+		if err := validatePublicKey(s); err != nil {
+			return "", "", fmt.Errorf("public key %s is malformed: %w", p, err)
+		}
+		return p, s, nil
+	}
+	return "", "", os.ErrNotExist
+}
+
+// Generate creates a fresh ed25519 keypair, writes it to
+// ~/.ssh/containarium_ed25519{,.pub} with the standard 0600/0644
+// perms, and returns the public-key path + contents.
+//
+// We deliberately use a containarium-prefixed filename rather than
+// clobbering id_ed25519: a user might already have a personal key
+// there that's registered with GitHub/GitLab, and silently replacing
+// it would be hostile. The cost is one extra file in ~/.ssh; the
+// benefit is "containarium ssh setup is idempotent and never
+// destructive."
+//
+// Returns os.ErrExist if the target paths already exist — callers
+// should call Locate first, or pass force=true to overwrite (the
+// containarium-prefixed variant only, not the personal keys).
+func Generate(opts LocateOpts, force bool) (pubPath string, pub string, err error) {
+	dir, err := sshDir(opts.HomeDir)
+	if err != nil {
+		return "", "", err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", "", fmt.Errorf("create %s: %w", dir, err)
+	}
+
+	privPath := filepath.Join(dir, containariumKeyName)
+	pubPath = privPath + containariumPubKeySuffix
+
+	if !force {
+		if _, err := os.Stat(privPath); err == nil {
+			return "", "", fmt.Errorf("%s already exists: %w", privPath, os.ErrExist)
+		}
+		if _, err := os.Stat(pubPath); err == nil {
+			return "", "", fmt.Errorf("%s already exists: %w", pubPath, os.ErrExist)
+		}
+	}
+
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", "", fmt.Errorf("generate ed25519: %w", err)
+	}
+
+	// Marshal private key in OpenSSH PEM format.
+	pemBlock, err := ssh.MarshalPrivateKey(privKey, "containarium-cli")
+	if err != nil {
+		return "", "", fmt.Errorf("marshal private key: %w", err)
+	}
+	privBytes := pem.EncodeToMemory(pemBlock)
+
+	sshPub, err := ssh.NewPublicKey(pubKey)
+	if err != nil {
+		return "", "", fmt.Errorf("wrap public key: %w", err)
+	}
+	pubBytes := ssh.MarshalAuthorizedKey(sshPub)
+
+	// Write private FIRST (0600). If we crash between, the .pub
+	// without its counterpart is harmless; the reverse is not (a
+	// .pub-less private key may look orphan to ssh-agent).
+	if err := writeFileMode(privPath, privBytes, 0o600); err != nil {
+		return "", "", fmt.Errorf("write %s: %w", privPath, err)
+	}
+	if err := writeFileMode(pubPath, pubBytes, 0o644); err != nil {
+		return "", "", fmt.Errorf("write %s: %w", pubPath, err)
+	}
+	return pubPath, strings.TrimSpace(string(pubBytes)), nil
+}
+
+// LocateOrGenerate convenience-wraps the common "use existing if
+// present, else generate" path used by `containarium ssh setup` and
+// the login --with-ssh-setup branch.
+//
+// `generated` reports whether the key on disk was freshly created
+// (true) versus already there (false), so the caller can tell the
+// user "found existing key at X" vs "generated new key at X".
+func LocateOrGenerate(opts LocateOpts) (pubPath string, pub string, generated bool, err error) {
+	pubPath, pub, err = Locate(opts)
+	if err == nil {
+		return pubPath, pub, false, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", "", false, err
+	}
+	pubPath, pub, err = Generate(opts, false)
+	if err != nil {
+		return "", "", false, err
+	}
+	return pubPath, pub, true, nil
+}
+
+// Fingerprint returns the SHA256 fingerprint of an OpenSSH-format
+// public key, in the same "SHA256:base64..." form that `ssh-keygen
+// -lf` prints. Padding is stripped to match ssh-keygen's output.
+func Fingerprint(authorizedKey string) (string, error) {
+	pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(strings.TrimSpace(authorizedKey)))
+	if err != nil {
+		return "", fmt.Errorf("parse public key: %w", err)
+	}
+	sum := sha256.Sum256(pk.Marshal())
+	enc := base64.StdEncoding.EncodeToString(sum[:])
+	enc = strings.TrimRight(enc, "=")
+	return "SHA256:" + enc, nil
+}
+
+// ReadPublicKey reads a public-key file from disk, validates it, and
+// returns the trimmed contents. Convenience for `--key=<path>` on the
+// CLI.
+func ReadPublicKey(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	// #nosec G304 -- path comes from a --key flag the user supplied
+	// explicitly; not attacker-controlled.
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	s := strings.TrimSpace(string(b))
+	if err := validatePublicKey(s); err != nil {
+		return "", fmt.Errorf("public key %s is malformed: %w", path, err)
+	}
+	return s, nil
+}
+
+// DefaultKeyName synthesizes a human-friendly label for the
+// "Register this machine's key as 'X'" prompt. PRD example:
+// "alice-laptop". We use "<user>@<host>" matching login.go's
+// deviceName fallback — close enough that the cloud-side "Active
+// sessions" and "SSH keys" tables read consistently.
+func DefaultKeyName(user, host string) string {
+	user = strings.TrimSpace(user)
+	host = strings.TrimSpace(host)
+	switch {
+	case user != "" && host != "":
+		return fmt.Sprintf("%s@%s", user, host)
+	case host != "":
+		return host
+	case user != "":
+		return user
+	}
+	return "containarium-cli"
+}
+
+// validatePublicKey is a thin wrapper that rejects obvious malformed
+// public-key strings before we ship them to the cloud. The cloud will
+// re-validate, but rejecting at the CLI gives a much clearer error
+// message ("not a valid SSH public key: …") than the cloud's generic
+// HTTP 400.
+func validatePublicKey(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return fmt.Errorf("key is empty")
+	}
+	if strings.ContainsAny(s, "\r\n") {
+		return fmt.Errorf("key contains embedded newline")
+	}
+	_, _, _, _, err := ssh.ParseAuthorizedKey([]byte(s))
+	if err != nil {
+		return fmt.Errorf("ssh.ParseAuthorizedKey: %w", err)
+	}
+	return nil
+}
+
+func sshDir(home string) (string, error) {
+	if home == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		home = h
+	}
+	return filepath.Join(home, ".ssh"), nil
+}
+
+// writeFileMode is a small wrapper that combines O_CREATE|O_EXCL|O_WRONLY
+// with the supplied mode. We don't use os.WriteFile because it doesn't
+// guarantee O_EXCL — and Generate's whole contract is "don't clobber".
+// Force-mode callers stat-then-write through the same path; the EXCL
+// flag protects against a race between the stat and the write.
+func writeFileMode(path string, data []byte, mode os.FileMode) error {
+	// #nosec G304 -- path computed from ~/.ssh; not attacker-controlled.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Chmod(mode); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}

--- a/internal/sshkey/local_test.go
+++ b/internal/sshkey/local_test.go
@@ -1,0 +1,268 @@
+package sshkey
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// withTempHome returns a tempdir that callers should pass as
+// LocateOpts.HomeDir. We do not Setenv HOME here because the only
+// production caller paths through the LocateOpts.HomeDir override —
+// keeping the test hermetic.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	return t.TempDir()
+}
+
+// seedPubKey drops a placeholder public key file at ~/.ssh/<name>
+// under home. The contents are a freshly-generated ed25519 key, so
+// ssh.ParseAuthorizedKey accepts them; we reuse Generate to keep the
+// helper short.
+func seedPubKey(t *testing.T, home, name string) string {
+	t.Helper()
+	// Use Generate against a fresh tempdir to get a syntactically-valid
+	// key, then copy the .pub into the target home.
+	stage := t.TempDir()
+	_, pub, err := Generate(LocateOpts{HomeDir: stage}, false)
+	if err != nil {
+		t.Fatalf("seed: Generate: %v", err)
+	}
+	dir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("seed: mkdir: %v", err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(pub+"\n"), 0o644); err != nil {
+		t.Fatalf("seed: write: %v", err)
+	}
+	return p
+}
+
+func TestGenerate_WritesBothKeysWithCorrectModes(t *testing.T) {
+	home := withTempHome(t)
+	pubPath, pub, err := Generate(LocateOpts{HomeDir: home}, false)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if !strings.HasSuffix(pubPath, "/containarium_ed25519.pub") {
+		t.Errorf("pubPath = %q, want suffix containarium_ed25519.pub", pubPath)
+	}
+	if !strings.HasPrefix(pub, "ssh-ed25519 ") {
+		t.Errorf("pub = %q, want ssh-ed25519 prefix", pub)
+	}
+
+	priv := strings.TrimSuffix(pubPath, ".pub")
+	if _, err := os.Stat(priv); err != nil {
+		t.Fatalf("private key not written: %v", err)
+	}
+
+	// POSIX perm checks only — Windows has no notion of 0600.
+	if runtime.GOOS == "windows" {
+		return
+	}
+	if st, _ := os.Stat(priv); st.Mode().Perm() != 0o600 {
+		t.Errorf("private mode = %o, want 0600", st.Mode().Perm())
+	}
+	if st, _ := os.Stat(pubPath); st.Mode().Perm() != 0o644 {
+		t.Errorf("public mode = %o, want 0644", st.Mode().Perm())
+	}
+}
+
+func TestGenerate_RefusesClobberWithoutForce(t *testing.T) {
+	home := withTempHome(t)
+	if _, _, err := Generate(LocateOpts{HomeDir: home}, false); err != nil {
+		t.Fatalf("Generate first: %v", err)
+	}
+	_, _, err := Generate(LocateOpts{HomeDir: home}, false)
+	if err == nil {
+		t.Fatal("expected error on second Generate without force")
+	}
+	if !errors.Is(err, os.ErrExist) {
+		t.Errorf("err = %v, want ErrExist", err)
+	}
+}
+
+func TestGenerate_ForceOverwrites(t *testing.T) {
+	home := withTempHome(t)
+	_, pub1, err := Generate(LocateOpts{HomeDir: home}, false)
+	if err != nil {
+		t.Fatalf("Generate 1: %v", err)
+	}
+	_, pub2, err := Generate(LocateOpts{HomeDir: home}, true)
+	if err != nil {
+		t.Fatalf("Generate 2 (force): %v", err)
+	}
+	if pub1 == pub2 {
+		t.Fatal("force regenerate produced identical key — should be a fresh keypair")
+	}
+}
+
+func TestLocate_PicksEd25519First(t *testing.T) {
+	home := withTempHome(t)
+	rsaPath := seedPubKey(t, home, FallbackPublicKeyPath)
+	edPath := seedPubKey(t, home, DefaultPublicKeyPath)
+
+	pubPath, pub, err := Locate(LocateOpts{HomeDir: home})
+	if err != nil {
+		t.Fatalf("Locate: %v", err)
+	}
+	if pubPath != edPath {
+		t.Errorf("Locate picked %q, want ed25519 path %q", pubPath, edPath)
+	}
+	if pub == "" {
+		t.Error("Locate returned empty key contents")
+	}
+	_ = rsaPath
+}
+
+func TestLocate_FallsBackToRSA(t *testing.T) {
+	home := withTempHome(t)
+	rsaPath := seedPubKey(t, home, FallbackPublicKeyPath)
+
+	pubPath, _, err := Locate(LocateOpts{HomeDir: home})
+	if err != nil {
+		t.Fatalf("Locate: %v", err)
+	}
+	if pubPath != rsaPath {
+		t.Errorf("Locate picked %q, want %q", pubPath, rsaPath)
+	}
+}
+
+func TestLocate_NoKeys_ReturnsErrNotExist(t *testing.T) {
+	home := withTempHome(t)
+	_, _, err := Locate(LocateOpts{HomeDir: home})
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("err = %v, want ErrNotExist", err)
+	}
+}
+
+func TestLocateOrGenerate_GeneratesOnEmpty(t *testing.T) {
+	home := withTempHome(t)
+	pubPath, pub, generated, err := LocateOrGenerate(LocateOpts{HomeDir: home})
+	if err != nil {
+		t.Fatalf("LocateOrGenerate: %v", err)
+	}
+	if !generated {
+		t.Error("expected generated=true on empty home")
+	}
+	if !strings.HasSuffix(pubPath, "/containarium_ed25519.pub") {
+		t.Errorf("pubPath = %q", pubPath)
+	}
+	if !strings.HasPrefix(pub, "ssh-ed25519 ") {
+		t.Errorf("pub = %q", pub)
+	}
+}
+
+func TestLocateOrGenerate_FindsExisting(t *testing.T) {
+	home := withTempHome(t)
+	seedPubKey(t, home, DefaultPublicKeyPath)
+
+	_, _, generated, err := LocateOrGenerate(LocateOpts{HomeDir: home})
+	if err != nil {
+		t.Fatalf("LocateOrGenerate: %v", err)
+	}
+	if generated {
+		t.Error("expected generated=false when ed25519 exists")
+	}
+}
+
+func TestFingerprint_MatchesSSHKeygenForm(t *testing.T) {
+	home := withTempHome(t)
+	_, pub, err := Generate(LocateOpts{HomeDir: home}, false)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	fp, err := Fingerprint(pub)
+	if err != nil {
+		t.Fatalf("Fingerprint: %v", err)
+	}
+	if !strings.HasPrefix(fp, "SHA256:") {
+		t.Errorf("fingerprint = %q, want SHA256: prefix", fp)
+	}
+	if strings.HasSuffix(fp, "=") {
+		t.Errorf("fingerprint %q still has base64 padding", fp)
+	}
+	// Deterministic: same input → same output.
+	fp2, err := Fingerprint(pub)
+	if err != nil {
+		t.Fatalf("Fingerprint 2: %v", err)
+	}
+	if fp != fp2 {
+		t.Errorf("Fingerprint not deterministic: %q vs %q", fp, fp2)
+	}
+}
+
+func TestFingerprint_RejectsGarbage(t *testing.T) {
+	if _, err := Fingerprint("not a key"); err == nil {
+		t.Fatal("expected error on garbage input")
+	}
+}
+
+func TestReadPublicKey_ReadsAndValidates(t *testing.T) {
+	home := withTempHome(t)
+	path := seedPubKey(t, home, DefaultPublicKeyPath)
+
+	got, err := ReadPublicKey(path)
+	if err != nil {
+		t.Fatalf("ReadPublicKey: %v", err)
+	}
+	if !strings.HasPrefix(got, "ssh-ed25519 ") {
+		t.Errorf("got = %q", got)
+	}
+}
+
+func TestReadPublicKey_RejectsMalformed(t *testing.T) {
+	home := withTempHome(t)
+	dir := filepath.Join(home, ".ssh")
+	_ = os.MkdirAll(dir, 0o700)
+	bad := filepath.Join(dir, "bad.pub")
+	if err := os.WriteFile(bad, []byte("garbage data"), 0o644); err != nil {
+		t.Fatalf("write bad: %v", err)
+	}
+	if _, err := ReadPublicKey(bad); err == nil {
+		t.Fatal("expected error on malformed key")
+	}
+}
+
+func TestReadPublicKey_EmptyPathErrors(t *testing.T) {
+	if _, err := ReadPublicKey(""); err == nil {
+		t.Fatal("expected error on empty path")
+	}
+}
+
+func TestDefaultKeyName(t *testing.T) {
+	cases := []struct {
+		user, host, want string
+	}{
+		{"alice", "laptop", "alice@laptop"},
+		{"", "laptop", "laptop"},
+		{"alice", "", "alice"},
+		{"", "", "containarium-cli"},
+		{"  ", "  ", "containarium-cli"},
+	}
+	for _, tc := range cases {
+		if got := DefaultKeyName(tc.user, tc.host); got != tc.want {
+			t.Errorf("DefaultKeyName(%q,%q) = %q, want %q", tc.user, tc.host, got, tc.want)
+		}
+	}
+}
+
+func TestLocate_RejectsEmbeddedNewlineKey(t *testing.T) {
+	home := withTempHome(t)
+	// Drop a malformed key with an embedded newline.
+	dir := filepath.Join(home, ".ssh")
+	_ = os.MkdirAll(dir, 0o700)
+	path := filepath.Join(dir, DefaultPublicKeyPath)
+	if err := os.WriteFile(path, []byte("ssh-ed25519 AAA\ninjected"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, _, err := Locate(LocateOpts{HomeDir: home})
+	if err == nil {
+		t.Fatal("expected error on key with embedded newline")
+	}
+}


### PR DESCRIPTION
Phase-3 rollout of umbrella-issue [FootprintAI/Containarium-cloud#100](https://github.com/FootprintAI/Containarium-cloud/issues/100), sub-tasks **A5+A6+A7**. See `prd/cloud/cli-login-and-multi-env-ssh.md` §"Design — Multi-environment SSH".

## Summary

- **A5 (`containarium ssh setup/list/remove`)** — Per-machine SSH key registration. `setup` finds (or generates) ~/.ssh/id_ed25519, uploads the public half via `UserService.AddSSHKey` using the bearer token populated by A3's `containarium login`. `list` prints a NAME/FINGERPRINT/CREATED table. `remove` deletes by friendly name.
- **A6 (`containarium ssh propagate`)** — CLI verb that POSTs `UserService.PropagateSSHKeysToBoxes` with an optional `--box=<name>` filter. Cloud-side RPC deferred; CLI handles 404/Unimplemented gracefully (warning + exit 0), matching the pattern PR #297 established for `containarium ttl`.
- **A7 (`containarium login --with-ssh-setup`)** — After successful login, prompt `"Register this machine's SSH key as 'X'? [Y/n]"` and on Y (or empty answer) invoke the same path as `ssh setup`. Defaults: prompt-with-Y on TTY, silent-skip on non-TTY (CI). `--with-ssh-setup` forces on, `--no-ssh-setup` forces off (mutually exclusive).

New `internal/sshkey` package isolates "find or generate the local key + compute SHA256 fingerprint" so login.go and ssh.go share one tested surface. The `SSHKey` wire-shape mirrors the cloud's `UserService` message field-for-field (Name, PublicKey, Fingerprint, CreatedAt) per CLAUDE.md's strong-typing rule.

## Files

| Path | Change |
|---|---|
| `internal/sshkey/local.go` | new — Locate / Generate / LocateOrGenerate / Fingerprint / ReadPublicKey / DefaultKeyName |
| `internal/sshkey/local_test.go` | new — table-driven unit tests |
| `internal/cmd/ssh.go` | new — cobra group + 4 subcommands; thin REST client over UserService SSH-keys endpoints |
| `internal/cmd/ssh_test.go` | new — httptest fake of UserService SSH-keys REST + validators |
| `internal/cmd/login_ssh_test.go` | new — A7 integration via a combined login+ssh-keys fake |
| `internal/cmd/login.go` | additive — `--with-ssh-setup` / `--no-ssh-setup` flags + maybeRunPostLoginSSHSetup tail call |

Pure-additive: no shared test files were modified (per the "lesson from Phase 1" rule in the brief).

## What's NOT in this PR

- **Cloud-side `UserService.PropagateSSHKeysToBoxes` RPC.** The CLI verb ships with a friendly Unimplemented-tolerant client; the matching server-side endpoint will land in a separate cross-repo PR on `FootprintAI/Containarium-cloud`. Until then, `containarium ssh propagate` prints a clear warning and exits 0. **Judgment call:** deferred the cloud-side commit to keep this PR focused on the OSS-CLI surface and avoid blocking on cross-repo coordination, mirroring the precedent set by PR #297 for `containarium ttl`.
- **Container-creation integration** that auto-installs the registered keys in new boxes' `authorized_keys`. Independent follow-up in the cloud's create-container path.
- **MCP wrapper** for `ssh setup/list/remove/propagate`. Per CLAUDE.md (CLI-first; MCP wraps later), the MCP tool is a follow-up.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/cmd/... ./internal/sshkey/...` clean
- [x] `go test ./internal/cmd/... ./internal/sshkey/...` green
- [x] `containarium ssh --help` renders the 4 subcommands
- [x] `containarium login --help` shows `--with-ssh-setup` / `--no-ssh-setup` as mutually exclusive
- [ ] Manual end-to-end against a staging cloud once the matching `UserService` endpoints are wired
- [ ] Manual smoke of `containarium login --with-ssh-setup` against the staging cloud

Closes three items of FootprintAI/Containarium-cloud#100

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>