### PR TITLE
feat(mcp): credentials.json fallback for token (A4)

### DIFF
--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -19,11 +19,11 @@ func main() {
 
 	if config.ServerURL == "" {
 		printUsage()
-		log.Fatal("CONTAINARIUM_SERVER_URL environment variable is required")
+		log.Fatal("no server URL found: set CONTAINARIUM_SERVER_URL, or run `containarium login` (writes ~/.containarium/credentials.json with a default_server)")
 	}
 	if config.JWTToken == "" && config.JWTTokenFile == "" {
 		printUsage()
-		log.Fatal("either CONTAINARIUM_JWT_TOKEN or CONTAINARIUM_JWT_TOKEN_FILE environment variable is required")
+		log.Fatal("no token found: set CONTAINARIUM_JWT_TOKEN or CONTAINARIUM_JWT_TOKEN_FILE, or run `containarium login` (writes ~/.containarium/credentials.json)")
 	}
 
 	// Create MCP server with protobuf-defined contracts
@@ -49,12 +49,18 @@ func printUsage() {
 	log.Println("")
 	log.Println("=== Containarium MCP Server Configuration ===")
 	log.Println("")
-	log.Println("Required environment variables:")
-	log.Println("  CONTAINARIUM_SERVER_URL      - URL of the Containarium REST API (e.g., http://localhost:8080)")
-	log.Println("  CONTAINARIUM_JWT_TOKEN       - JWT token for authentication  (use one or the other)")
+	log.Println("Required configuration:")
+	log.Println("  CONTAINARIUM_SERVER_URL      - URL of the Containarium REST API (e.g., http://localhost:8080).")
+	log.Println("                                 Optional when ~/.containarium/credentials.json has a")
+	log.Println("                                 default_server (written by `containarium login`).")
+	log.Println("")
+	log.Println("Token resolution (highest precedence first):")
+	log.Println("  CONTAINARIUM_JWT_TOKEN       - JWT token (static, captured at MCP start)")
 	log.Println("  CONTAINARIUM_JWT_TOKEN_FILE  - Path to a file with the JWT — re-read on every request,")
 	log.Println("                                 so rotating the token is `mv newtoken oldpath`. Prefer this")
 	log.Println("                                 for long-running MCP processes that need to survive rotation.")
+	log.Println("  ~/.containarium/credentials.json — fallback when neither env var is set.")
+	log.Println("                                 Written by `containarium login`; looked up by server URL.")
 	log.Println("")
 	log.Println("Optional environment variables:")
 	log.Println("  CONTAINARIUM_DEBUG           - Enable debug logging (true/false)")

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -1,8 +1,11 @@
 package mcp
 
 import (
+	"log"
 	"os"
 	"strconv"
+
+	"github.com/footprintai/containarium/internal/credentials"
 )
 
 // Config holds configuration for the MCP server
@@ -37,18 +40,72 @@ type Config struct {
 	Debug bool
 }
 
-// LoadConfig loads configuration from environment variables
+// LoadConfig loads configuration from environment variables, with a
+// final fallback to ~/.containarium/credentials.json (the file
+// `containarium login` writes — see internal/credentials). The
+// precedence is, highest first:
+//
+//  1. CONTAINARIUM_JWT_TOKEN (static, in-process)
+//  2. CONTAINARIUM_JWT_TOKEN_FILE (re-read per request — rotation-safe)
+//  3. credentials.json lookup for ServerURL (or DefaultServer when
+//     ServerURL is empty). Static for the life of the process —
+//     prefer (2) when you need long-running token rotation.
+//
+// Fallback (3) is best-effort: any error reading credentials.json is
+// logged + ignored, leaving JWTToken empty so the existing
+// "missing token" message in cmd/mcp-server fires with full guidance.
+// Logging lands on stderr (the MCP protocol owns stdout), so it
+// never corrupts the JSON-RPC stream.
 func LoadConfig() *Config {
 	debug := false
 	if debugStr := os.Getenv("CONTAINARIUM_DEBUG"); debugStr != "" {
 		debug, _ = strconv.ParseBool(debugStr)
 	}
 
-	return &Config{
+	cfg := &Config{
 		ServerURL:    os.Getenv("CONTAINARIUM_SERVER_URL"),
 		JWTToken:     os.Getenv("CONTAINARIUM_JWT_TOKEN"),
 		JWTTokenFile: os.Getenv("CONTAINARIUM_JWT_TOKEN_FILE"),
 		SentinelHost: os.Getenv("CONTAINARIUM_SENTINEL_HOST"),
 		Debug:        debug,
+	}
+
+	if cfg.JWTToken == "" && cfg.JWTTokenFile == "" {
+		applyCredentialsFileFallback(cfg)
+	}
+
+	return cfg
+}
+
+// applyCredentialsFileFallback populates cfg.JWTToken (and ServerURL,
+// when unset) from the user's ~/.containarium/credentials.json. A
+// missing file or missing entry is silent — the existing env-var
+// error message in cmd/mcp-server then surfaces with full guidance.
+func applyCredentialsFileFallback(cfg *Config) {
+	path, err := credentials.DefaultPath()
+	if err != nil {
+		// Home directory unresolvable — exotic env (no $HOME); leave
+		// the env-var error to be the user's only signal.
+		return
+	}
+	cf, err := credentials.Load(path)
+	if err != nil {
+		// Malformed / unreadable credentials file — log so the
+		// operator sees it, but don't fail-stop; an explicit
+		// env-var override may still be incoming via main.go's
+		// startup check.
+		log.Printf("[mcp-config] credentials.json at %s unreadable, ignoring: %v", path, err)
+		return
+	}
+	creds, ok := cf.Get(cfg.ServerURL) // empty ServerURL → falls back to DefaultServer
+	if !ok {
+		return
+	}
+	cfg.JWTToken = creds.Token
+	if cfg.ServerURL == "" {
+		// User didn't pin a server; credentials.json's DefaultServer
+		// answered the lookup, so adopt it as ServerURL too. Required
+		// in the file's schema (Save enforces it's a key in Servers).
+		cfg.ServerURL = cf.DefaultServer
 	}
 }

--- a/internal/mcp/credentials_fallback_test.go
+++ b/internal/mcp/credentials_fallback_test.go
@@ -1,0 +1,128 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/credentials"
+)
+
+// writeCredsFile is a helper that drops a credentials.json under
+// $HOME (which the test t.Setenvs to a temp dir, so DefaultPath()
+// resolves there) with the given default server + entries.
+func writeCredsFile(t *testing.T, home string, defaultServer string, servers map[string]credentials.ServerCreds) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	cf := credentials.NewCredentialsFile()
+	for srv, creds := range servers {
+		cf.Set(srv, creds)
+	}
+	if defaultServer != "" {
+		cf.DefaultServer = credentials.NormalizeServer(defaultServer)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".containarium"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := credentials.Save(filepath.Join(home, credentials.DefaultRelPath), cf); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+}
+
+func TestLoadConfig_CredentialsFallback_PopulatesToken(t *testing.T) {
+	t.Setenv("CONTAINARIUM_JWT_TOKEN", "")
+	t.Setenv("CONTAINARIUM_JWT_TOKEN_FILE", "")
+	t.Setenv("CONTAINARIUM_SERVER_URL", "https://cloud.example.com")
+	home := t.TempDir()
+	writeCredsFile(t, home, "https://cloud.example.com", map[string]credentials.ServerCreds{
+		"https://cloud.example.com": {Token: "ctnr_abc.secret"},
+	})
+
+	c := LoadConfig()
+	if c.JWTToken != "ctnr_abc.secret" {
+		t.Errorf("JWTToken = %q, want %q (fallback should have populated it)", c.JWTToken, "ctnr_abc.secret")
+	}
+	if c.ServerURL != "https://cloud.example.com" {
+		t.Errorf("ServerURL changed unexpectedly: %q", c.ServerURL)
+	}
+}
+
+func TestLoadConfig_CredentialsFallback_UsesDefaultServerWhenURLEmpty(t *testing.T) {
+	t.Setenv("CONTAINARIUM_JWT_TOKEN", "")
+	t.Setenv("CONTAINARIUM_JWT_TOKEN_FILE", "")
+	t.Setenv("CONTAINARIUM_SERVER_URL", "")
+	home := t.TempDir()
+	writeCredsFile(t, home, "https://default.example.com", map[string]credentials.ServerCreds{
+		"https://default.example.com": {Token: "default-tok"},
+		"https://other.example.com":   {Token: "other-tok"},
+	})
+
+	c := LoadConfig()
+	if c.JWTToken != "default-tok" {
+		t.Errorf("JWTToken = %q, want default-server token %q", c.JWTToken, "default-tok")
+	}
+	if c.ServerURL != "https://default.example.com" {
+		t.Errorf("ServerURL = %q, want default_server propagated to %q", c.ServerURL, "https://default.example.com")
+	}
+}
+
+func TestLoadConfig_CredentialsFallback_SkippedWhenEnvTokenSet(t *testing.T) {
+	t.Setenv("CONTAINARIUM_JWT_TOKEN", "env-tok")
+	t.Setenv("CONTAINARIUM_JWT_TOKEN_FILE", "")
+	t.Setenv("CONTAINARIUM_SERVER_URL", "https://cloud.example.com")
+	home := t.TempDir()
+	writeCredsFile(t, home, "https://cloud.example.com", map[string]credentials.ServerCreds{
+		"https://cloud.example.com": {Token: "creds-file-tok"},
+	})
+
+	c := LoadConfig()
+	if c.JWTToken != "env-tok" {
+		t.Errorf("JWTToken = %q, want env-tok (env should take precedence over credentials.json)", c.JWTToken)
+	}
+}
+
+func TestLoadConfig_CredentialsFallback_SkippedWhenEnvTokenFileSet(t *testing.T) {
+	t.Setenv("CONTAINARIUM_JWT_TOKEN", "")
+	t.Setenv("CONTAINARIUM_JWT_TOKEN_FILE", "/some/file")
+	t.Setenv("CONTAINARIUM_SERVER_URL", "https://cloud.example.com")
+	home := t.TempDir()
+	writeCredsFile(t, home, "https://cloud.example.com", map[string]credentials.ServerCreds{
+		"https://cloud.example.com": {Token: "creds-file-tok"},
+	})
+
+	c := LoadConfig()
+	if c.JWTToken != "" {
+		t.Errorf("JWTToken = %q, want empty (JWTTokenFile path overrides credentials.json fallback)", c.JWTToken)
+	}
+	if c.JWTTokenFile != "/some/file" {
+		t.Errorf("JWTTokenFile = %q, want /some/file", c.JWTTokenFile)
+	}
+}
+
+func TestLoadConfig_CredentialsFallback_MissingFileIsSilent(t *testing.T) {
+	t.Setenv("CONTAINARIUM_JWT_TOKEN", "")
+	t.Setenv("CONTAINARIUM_JWT_TOKEN_FILE", "")
+	t.Setenv("CONTAINARIUM_SERVER_URL", "https://cloud.example.com")
+	// HOME points to a fresh tmpdir with no credentials.json.
+	t.Setenv("HOME", t.TempDir())
+
+	c := LoadConfig()
+	if c.JWTToken != "" {
+		t.Errorf("JWTToken = %q, want empty (no credentials file present)", c.JWTToken)
+	}
+}
+
+func TestLoadConfig_CredentialsFallback_MissingServerEntryIsSilent(t *testing.T) {
+	t.Setenv("CONTAINARIUM_JWT_TOKEN", "")
+	t.Setenv("CONTAINARIUM_JWT_TOKEN_FILE", "")
+	t.Setenv("CONTAINARIUM_SERVER_URL", "https://missing.example.com")
+	home := t.TempDir()
+	writeCredsFile(t, home, "https://cloud.example.com", map[string]credentials.ServerCreds{
+		"https://cloud.example.com": {Token: "wrong-server-tok"},
+	})
+
+	c := LoadConfig()
+	if c.JWTToken != "" {
+		t.Errorf("JWTToken = %q, want empty (no entry for the requested ServerURL)", c.JWTToken)
+	}
+}


### PR DESCRIPTION
## Summary

Closes one item of FootprintAI/Containarium-cloud#100 (workstream A4 — the last unblocked Phase-3 follow-up that I could ship without operator action).

When neither \`CONTAINARIUM_JWT_TOKEN\` nor \`CONTAINARIUM_JWT_TOKEN_FILE\` is set, the MCP server falls back to \`~/.containarium/credentials.json\` — the file \`containarium login\` writes after the device-flow approval lands (A3, shipped in #305).

This closes Workstream A's "no env-var rituals to attach an agent to Containarium" story:

\`\`\`
containarium login                    # writes credentials.json
Claude / Cursor / etc. → mcp-server   # no env vars set
mcp-server                            # reads credentials.json
                                      # uses default server + its token
\`\`\`

## Precedence

Highest first:
1. \`CONTAINARIUM_JWT_TOKEN\` — static, in-process
2. \`CONTAINARIUM_JWT_TOKEN_FILE\` — re-read per request (rotation-safe)
3. \`~/.containarium/credentials.json\` — lookup by \`ServerURL\`, or by \`DefaultServer\` when \`ServerURL\` is unset (in which case \`ServerURL\` is adopted from credentials.json too — fully zero-env startup)

## Behavior

- Fallback is **best-effort**: missing file or missing entry → silent (the existing "no token found" startup error fires with updated guidance pointing at \`containarium login\`).
- **Unreadable / malformed file** → logged to stderr (not stdout — MCP owns stdout for JSON-RPC), then ignored.
- **Env vars always win** over credentials.json — no behavior change for existing operators.
- \`ServerURL\` adoption only happens when **unset** — explicit \`CONTAINARIUM_SERVER_URL\` is never overridden.

## Test plan

- [x] \`go test ./internal/mcp/ -run 'TestLoadConfig_CredentialsFallback' -v\` — 6/6 pass
- [x] \`go test ./internal/mcp/ -count=1\` — full mcp suite green
- [x] \`go vet ./internal/mcp/ ./cmd/mcp-server/\` — clean
- Test file is NEW (\`credentials_fallback_test.go\`) — kept the diff out of the contended \`token_file_test.go\`.

## Files

- \`internal/mcp/config.go\` — wired the fallback in \`LoadConfig\`; \`applyCredentialsFileFallback\` helper handles the lookup
- \`cmd/mcp-server/main.go\` — startup error messages + \`printUsage\` updated to mention \`containarium login\`
- \`internal/mcp/credentials_fallback_test.go\` — new, 6 subtests

🤖 Generated with [Claude Code](https://claude.com/claude-code)