### PR TITLE
docs: migration plan — Containarium host → VM (fts-13700k worked example)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,36 @@ This file is a small set of durable conventions for AI assistants working
 on this repository. Keep it short — only rules whose violation we'd
 actually want to catch in review.
 
+## No instance / endpoint / tenant names in OSS-visible files
+
+This repository is public-facing. **Anonymize anything that names a
+specific deployment** in files that ship with the repo: `docs/`,
+`README.md`, `CHANGELOG.md`, design notes, runbooks, PR descriptions,
+and commit messages.
+
+| Don't write | Do write |
+| --- | --- |
+| Concrete backend / lab node hostnames | "a backend host" / `<host>` / "the GPU node" |
+| Live production cluster apex hostnames | "the cluster's apex hostname" / `<cluster>.example.com` |
+| Tenant container names (`<tenant>-container` with real tenants) | "a tenant container" / `<tenant>-container` (generic) |
+| Containarium-core service container names (in operator-specific context) | "the platform Postgres LXC" / "core service LXCs" |
+| Live IPs (LAN, GCP, Tailscale) | "a private LAN IP" / `<sentinel-ip>` |
+| Internal tenant workload names (docker container, app names) | "a tenant workload" / "a docker compose service" |
+
+**Why:** concrete names are reconnaissance signals — they reveal what's
+running where, which workloads to target, which backend names to
+fingerprint. The cost of generic wording is one extra word; the cost of
+leaking is permanent — PR descriptions and merged commits stay indexed
+forever.
+
+**Where concrete names ARE fine:**
+- Private operator runbooks not in the repo.
+- Internal Slack / email / private docs.
+- Operator memory files outside the repo.
+
+**Before pushing any doc / runbook / PR description:** grep the diff
+for concrete names; if you're not sure, anonymize.
+
 ## CLI-first, MCP wraps it
 
 When adding a new platform action (anything that mutates Containarium

--- a/docs/CONTAINARIUM-HOST-TO-VM-MIGRATION.md
+++ b/docs/CONTAINARIUM-HOST-TO-VM-MIGRATION.md
@@ -1,0 +1,268 @@
+# Containarium Host → VM Migration
+
+> Status: **Plan, awaiting decisions.** First worked example is
+> `fts-13700k` (2026-05-25); the pattern generalizes to any
+> Containarium bare-metal node we want to clean up.
+
+## Why
+
+Containarium installed on bare-metal pollutes the host: its iptables
+DNAT/REDIRECT rules catch any non-Containarium VM's outbound traffic,
+its Caddy occupies host :80/:443, its Incus owns the host's bridges.
+This was diagnosed the hard way when a libvirt sandbox VM on
+`fts-13700k` got its HTTPS hijacked by the host's Containarium Caddy
+(2026-05-24).
+
+Moving Containarium into a VM:
+
+- Host stays minimal (hypervisor + Tailscale + monitoring).
+- Sibling VMs can come and go without their traffic being intercepted.
+- Snapshots, backups, host swaps become VM-level operations.
+- Multi-tenant: prod + staging Containariums can be separate VMs.
+- Solves the Caddy-intercept bug structurally, not by patching.
+
+## fts-13700k inventory (2026-05-25)
+
+| # | Container | Type | CPU/RAM | GPU | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 1 | apibox-dev-3090-container | User | 16c / 64GB | **RTX 3090 (01:00.0)** | docker: cockburn-inference-server |
+| 2 | dataspark-cicd-container | User | 8c / 32GB | — | docker: pes-resume-search + pes-postgres-vector |
+| 3 | cicd-container | User | 4c / 16GB | — | empty |
+| 4 | containarium-core-caddy | Platform | 1c / 512MB | — | systemd Caddy |
+| 5 | containarium-core-postgres | Platform | 2c / 2GB | — | systemd Postgres |
+| 6 | containarium-core-otelcollector | Platform | 1c / 512MB | — | OTel collector |
+| 7 | containarium-core-security | Platform | 2c / 3GB | — | ClamAV + scanners |
+| 8 | containarium-core-victoriametrics | Platform | 1c / 1GB | — | VictoriaMetrics |
+
+Host: 24c/48t, 125GB RAM, ZFS `incus-local` (1.9TB NVMe), `incus-backup` (1.8TB HDD mirror), boot SSD (`nvme0n1`, 953G).
+
+## Target architecture
+
+```
+┌─ fts-13700k bare-metal ────────────────────────────────────┐
+│                                                            │
+│  Ubuntu 24.04 + libvirt + Tailscale                        │
+│  /dev/kvm + VFIO bound to RTX 3090 (10de:2204)             │
+│  Intel UHD 770 stays bound to host (display + i915)        │
+│                                                            │
+│  ┌─ containarium-vm (libvirt KVM) ───────────────────────┐ │
+│  │  Ubuntu 24.04, 20 vCPU, 100 GB RAM, 200GB disk       │ │
+│  │  PCI: RTX 3090 passthrough                           │ │
+│  │  Net: bridged to LAN (own MAC/IP, not NAT)           │ │
+│  │  Incus 6.x + Containarium daemon                     │ │
+│  │  zpool: incus-local-vm (carved from host's pool      │ │
+│  │  via ZVOL OR a vdisk on the host's zpool)            │ │
+│  │                                                      │ │
+│  │  ├─ apibox-dev-3090-container  (RTX 3090 from VM)    │ │
+│  │  ├─ dataspark-cicd-container                         │ │
+│  │  ├─ cicd-container                                   │ │
+│  │  └─ 5× containarium-core-*                           │ │
+│  └──────────────────────────────────────────────────────┘ │
+│                                                            │
+│  ┌─ cloud-fts-13700k (libvirt KVM)  — and future siblings ┐│
+│  │  Ad-hoc sandbox VMs. Traffic goes through libvirt NAT  ││
+│  │  to LAN; NOT hijacked by Containarium Caddy anymore.   ││
+│  └────────────────────────────────────────────────────────┘│
+└────────────────────────────────────────────────────────────┘
+```
+
+## Decisions needed before execution
+
+| # | Decision | Options | Recommendation |
+| --- | --- | --- | --- |
+| D1 | VM network mode | (a) bridged to LAN — VM gets a real LAN IP, can keep existing Tailscale identity / sentinel-peer registration. (b) libvirt NAT — simpler but loses the existing LAN IP + needs sentinel re-pointing | **(a) bridged**, to minimize sentinel + Tailscale churn |
+| D2 | Storage for VM disk | (a) raw qcow2 on `/var/lib/libvirt/images` (root ext4). (b) ZVOL carved from `incus-local`. (c) New ZFS dataset on `incus-local` mounted into the VM | **(b) ZVOL on incus-local** — fastest path (same disk as production data), single block device, ZFS snapshots of the whole VM, no double-COW |
+| D3 | LXC migration method | (a) `incus copy` over network. (b) `incus export` + scp + `incus import`. (c) `zfs send | zfs receive` from host pool → VM pool | **(c) zfs send/receive** — fastest, lossless, ZFS snapshots come along. Falls back to (b) if VM doesn't have host's zpool visible |
+| D4 | Tailscale identity for the VM | (a) Keep `fts-13700k` hostname on the VM, host becomes `fts-13700k-hv` or similar. (b) New name like `fts-13700k-vm` for the VM | **(a)** — keeps existing sentinel registration, peer ID, and SSH config pointing at the unchanged `fts-13700k` |
+| D5 | Cutover window | (a) Off-hours scheduled downtime, coordinate with apibox-dev-3090 + dataspark users. (b) ASAP, accept ~1-2 hours visible downtime | **(a)** — schedule it; both user containers serve real workloads (cockburn-inference-server, pes-resume-search) |
+| D6 | Rollback trigger | When do we abort + restore from snapshot? | **If apibox-dev-3090's RTX 3090 doesn't work in VM after Phase 4**, that's the abort gate — no point continuing if the GPU is broken |
+
+## Phased migration
+
+### Phase 0 — Pre-flight (no changes; gather data)
+
+```bash
+# All on fts-13700k.
+echo "=== IOMMU groups for the 3090 (must be in own group OR group of devices we can pass too) ==="
+for g in /sys/kernel/iommu_groups/*; do
+    iommu=$(basename "$g")
+    devs=$(ls "$g/devices/" 2>/dev/null)
+    if echo "$devs" | grep -q "01:00"; then
+        echo "IOMMU group $iommu (the 3090's):"
+        for d in $devs; do
+            lspci -nns "$d"
+        done
+    fi
+done
+
+echo "=== current GPU bindings ==="
+lspci -nnk -s 01:00.0
+lspci -nnk -s 00:02.0    # Intel UHD 770
+
+echo "=== /etc/default/grub current cmdline ==="
+grep CMDLINE /etc/default/grub
+
+echo "=== existing zpool snapshot baseline (must have one before we start) ==="
+sudo zfs list -t snapshot -o name,refer,creation -s creation | tail -10
+```
+
+**Gate:** confirm RTX 3090 is in an IOMMU group of its own (or only with its audio device), and that there's enough free space on `incus-backup` for a baseline snapshot of `incus-local`.
+
+### Phase 1 — Baseline snapshot (rollback insurance)
+
+```bash
+sudo zfs snapshot -r incus-local@pre-host-to-vm-$(date -u +%Y%m%dT%H%M%SZ)
+sudo zfs send -R incus-local@pre-host-to-vm-* | sudo zfs receive incus-backup/snapshots/pre-host-to-vm
+sudo zfs list -t snapshot -r incus-local | head
+```
+
+**Gate:** snapshot exists and is replicated to `incus-backup`. We can roll back to this point at any later phase.
+
+### Phase 2 — VFIO setup (requires reboot)
+
+```bash
+# 1. Add IOMMU + VFIO to kernel cmdline.
+sudo sed -i 's|GRUB_CMDLINE_LINUX_DEFAULT="\(.*\)"|GRUB_CMDLINE_LINUX_DEFAULT="\1 intel_iommu=on iommu=pt vfio-pci.ids=10de:2204,10de:1aef"|' /etc/default/grub
+sudo update-grub
+
+# 2. Bind vfio-pci at module load (10de:2204 = RTX 3090, 10de:1aef = its HDMI audio).
+echo "options vfio-pci ids=10de:2204,10de:1aef" | sudo tee /etc/modprobe.d/vfio.conf
+echo "vfio
+vfio_pci
+vfio_iommu_type1" | sudo tee /etc/modules-load.d/vfio.conf
+sudo update-initramfs -u
+
+# 3. REBOOT.
+sudo reboot
+
+# 4. After boot, verify:
+lspci -nnk -s 01:00.0     # should show: Kernel driver in use: vfio-pci
+dmesg | grep -i vfio | head
+```
+
+**Gate:** RTX 3090 is bound to `vfio-pci`, host display still works on Intel UHD 770, host SSH still reachable.
+
+**Impact during Phase 2:** apibox-dev-3090's GPU stops working when vfio-pci grabs the 3090. cockburn-inference-server inside that container fails. Schedule accordingly.
+
+### Phase 3 — Provision the Containarium VM
+
+```bash
+# 1. Carve a ZVOL for the VM root disk on incus-local (200GB).
+sudo zfs create -V 200G -o volblocksize=16k incus-local/containarium-vm
+
+# 2. Bridge the host's LAN interface (wlp6s0 is wifi — need wired for bridging; if wifi-only, use macvtap "passthrough" mode as a workaround, or accept libvirt NAT and re-point sentinel).
+#    TBD: confirm we have a wired Ethernet on fts-13700k. If not, this is a blocker — bridging wifi is unreliable; macvtap is the workaround.
+
+# 3. virt-install with VFIO + bridge + ZVOL disk.
+sudo virt-install --name containarium-vm \
+    --os-variant ubuntu24.04 \
+    --memory 102400 --vcpus 20 \
+    --disk path=/dev/zvol/incus-local/containarium-vm,format=raw,bus=virtio,cache=none \
+    --network bridge=br0 \
+    --hostdev pci_0000_01_00_0 \
+    --hostdev pci_0000_01_00_1 \
+    --cdrom /var/lib/libvirt/images/ubuntu-24.04-server-installer.iso \
+    --graphics none --console pty,target_type=serial
+
+# 4. Inside the VM (via serial console install), configure: hostname, SSH, Tailscale.
+# 5. Install Incus 6.x, init with `incus admin init --auto` against a ZFS pool
+#    (carved from a second ZVOL or a dataset mounted into the VM).
+# 6. Verify nvidia-smi inside the VM sees the 3090.
+```
+
+**Gate:** VM is up, has a LAN IP, Tailscale-reachable as `fts-13700k` (after D4 cutover), `nvidia-smi` sees the 3090, Incus is initialized.
+
+### Phase 4 — LXC migration (host → VM)
+
+For each container, in this order (platform first, then user containers, GPU container last):
+
+1. containarium-core-postgres
+2. containarium-core-victoriametrics
+3. containarium-core-otelcollector
+4. containarium-core-security
+5. containarium-core-caddy
+6. cicd-container
+7. dataspark-cicd-container
+8. apibox-dev-3090-container (GPU passthrough config rewritten for VM-side PCI ID)
+
+Per-container procedure (zfs send/receive variant, fastest):
+
+```bash
+# On host (fts-13700k):
+NAME=containarium-core-postgres
+incus stop "$NAME"
+sudo zfs snapshot incus-local/containers/$NAME@migrate
+sudo zfs send incus-local/containers/$NAME@migrate \
+    | ssh containarium-vm 'sudo zfs receive incus-local/containers/'$NAME
+
+# In VM:
+# Re-create the incus instance metadata pointing at the received dataset.
+# (Incus has `incus copy --refresh` for this; or use `incus import` after export.)
+incus start "$NAME"
+incus exec "$NAME" -- systemctl status   # sanity check
+```
+
+For **apibox-dev-3090-container**, rewrite the GPU device config:
+
+```bash
+# Inside the VM, after the container is imported:
+incus config device set apibox-dev-3090-container gpu pci=01:00.0
+incus start apibox-dev-3090-container
+incus exec apibox-dev-3090-container -- nvidia-smi
+```
+
+**Gate:** all 8 containers running in the VM, accessible at their original `10.100.0.x` addresses (assuming we keep the `incusbr0` subnet inside the VM).
+
+### Phase 5 — Cutover
+
+```bash
+# On host: stop the old (still-on-host) Containarium daemon + Incus
+sudo systemctl stop containarium
+sudo systemctl stop incus
+# (Leave the data in place for rollback. Don't delete.)
+
+# Move Tailscale identity to the VM if D4=(a):
+# - On host: `sudo tailscale logout`
+# - In VM:   `sudo tailscale up --hostname=fts-13700k`
+
+# Sentinel re-registration is automatic once the VM's daemon registers
+# itself as tunnel-fts-13700k-gpu (same peer ID).
+```
+
+**Gate:** sentinel shows `fts-13700k` peer via the VM; SSH `fts-13700k` lands in the VM; apibox-dev-3090's cockburn-inference-server is back up; dataspark stack is back up.
+
+### Phase 6 — Soak + cleanup
+
+- 24h observation: VictoriaMetrics graphs, sentinel peer health, no surprise restarts.
+- After soak: **don't yet delete** the host's `incus-local/containers/*`. That's our rollback. Mark with a clear timestamped retention window (e.g., 7 days).
+- After retention: `zfs destroy -r incus-local/containers` on the host.
+
+## Rollback procedure
+
+If any gate fails irrecoverably:
+
+1. In VM: `incus stop --all` (don't lose data; just stop).
+2. On host: `sudo systemctl start containarium && sudo systemctl start incus`.
+3. Containers come back up where they were. ~1 min downtime per container.
+4. The VM stays around (does nothing) until we decide what to do.
+5. The 3090 GPU stays bound to vfio-pci. To return it to the host: remove the cmdline + reboot.
+
+The `incus-backup/snapshots/pre-host-to-vm` ZFS snapshot is the nuclear-rollback option (restore the entire `incus-local` to its pre-Phase-1 state).
+
+## Open technical risks
+
+- **Bridging requires wired Ethernet.** `fts-13700k`'s default route is `wlp6s0` (wifi). Bridging wifi NICs is unreliable (most APs don't allow client MAC multiplexing). Need to confirm there's a wired interface (`enpXsY`) we can bridge against. If not: use `macvtap passthrough` or accept libvirt NAT + sentinel re-pointing.
+- **IOMMU group composition.** If the 3090 shares an IOMMU group with other host-critical devices (USB controller, root port), we have to pass them all together — sometimes a deal-breaker. Phase 0 will tell us.
+- **Memory pinning.** A VM with 100GB RAM allocated should pin its memory (`virsh memtune` `hard_limit`) so VFIO has stable DMA mappings. Out-of-default; document in the runbook.
+- **Tailscale conflict.** Tailscale logged in on the host AND the same hostname trying to log in on the VM will collide. Phase 5 covers the cutover — must be sequential, not parallel.
+
+## What this is NOT
+
+- Not a generic "make Containarium production-grade" doc — it's a specific operational migration for one node with a worked GPU case.
+- Not done. We finish this doc + ratify the 6 decisions BEFORE touching the host.
+
+## Related
+
+- 2026-05-24 incident — Caddy intercept on `fts-13700k` hijacking sibling libvirt VM traffic. Concrete motivation.
+- `docs/security/NETWORK-ISOLATION-DESIGN.md` — eBPF Phase A may run inside the new VM; clean test environment.
+- `docs/EPHEMERAL-SANDBOX-DESIGN.md` — depends on having sibling VMs that DON'T get hijacked, which this migration enables.

--- a/docs/CONTAINARIUM-HOST-TO-VM-MIGRATION.md
+++ b/docs/CONTAINARIUM-HOST-TO-VM-MIGRATION.md
@@ -1,17 +1,18 @@
 # Containarium Host → VM Migration
 
-> Status: **Plan, awaiting decisions.** First worked example is
-> `fts-13700k` (2026-05-25); the pattern generalizes to any
-> Containarium bare-metal node we want to clean up.
+> Status: **Plan, awaiting decisions.** Generic operational
+> runbook; the pattern applies to any Containarium bare-metal
+> node we want to clean up. First execution is on an internal
+> lab host (2026-05-25); specifics live in a private runbook.
 
 ## Why
 
 Containarium installed on bare-metal pollutes the host: its iptables
 DNAT/REDIRECT rules catch any non-Containarium VM's outbound traffic,
 its Caddy occupies host :80/:443, its Incus owns the host's bridges.
-This was diagnosed the hard way when a libvirt sandbox VM on
-`fts-13700k` got its HTTPS hijacked by the host's Containarium Caddy
-(2026-05-24).
+This was diagnosed the hard way when a libvirt sandbox VM on a
+Containarium-bare-metal node had its HTTPS hijacked by the host's
+Containarium Caddy.
 
 Moving Containarium into a VM:
 
@@ -21,47 +22,42 @@ Moving Containarium into a VM:
 - Multi-tenant: prod + staging Containariums can be separate VMs.
 - Solves the Caddy-intercept bug structurally, not by patching.
 
-## fts-13700k inventory (2026-05-25)
+## Host inventory shape (illustrative)
 
-| # | Container | Type | CPU/RAM | GPU | Notes |
-| --- | --- | --- | --- | --- | --- |
-| 1 | apibox-dev-3090-container | User | 16c / 64GB | **RTX 3090 (01:00.0)** | docker: cockburn-inference-server |
-| 2 | dataspark-cicd-container | User | 8c / 32GB | — | docker: pes-resume-search + pes-postgres-vector |
-| 3 | cicd-container | User | 4c / 16GB | — | empty |
-| 4 | containarium-core-caddy | Platform | 1c / 512MB | — | systemd Caddy |
-| 5 | containarium-core-postgres | Platform | 2c / 2GB | — | systemd Postgres |
-| 6 | containarium-core-otelcollector | Platform | 1c / 512MB | — | OTel collector |
-| 7 | containarium-core-security | Platform | 2c / 3GB | — | ClamAV + scanners |
-| 8 | containarium-core-victoriametrics | Platform | 1c / 1GB | — | VictoriaMetrics |
+A Containarium bare-metal node typically runs an LXC mix of:
 
-Host: 24c/48t, 125GB RAM, ZFS `incus-local` (1.9TB NVMe), `incus-backup` (1.8TB HDD mirror), boot SSD (`nvme0n1`, 953G).
+| Tier | Typical role | Special constraints |
+| --- | --- | --- |
+| **GPU user container(s)** | Tenant ML/inference workload | GPU passthrough (PCI device) |
+| **CPU user containers** | Tenant CPU workloads (CI, web apps, data jobs) | None |
+| **Platform services (5 LXCs)** | `containarium-core-{caddy, postgres, otelcollector, security, victoriametrics}` | Small, fixed resource budget |
+
+Resource sizing depends on the deployment. Sum up CPU/RAM commitments before sizing the destination VM (over-commit ratios that work on bare-metal need re-validation when CPU is virtualized).
 
 ## Target architecture
 
 ```
-┌─ fts-13700k bare-metal ────────────────────────────────────┐
+┌─ host (bare-metal) ────────────────────────────────────────┐
 │                                                            │
 │  Ubuntu 24.04 + libvirt + Tailscale                        │
-│  /dev/kvm + VFIO bound to RTX 3090 (10de:2204)             │
-│  Intel UHD 770 stays bound to host (display + i915)        │
+│  /dev/kvm + VFIO bound to GPU (passthrough device)         │
+│  Host's iGPU (if present) stays bound to host i915/Xe      │
 │                                                            │
 │  ┌─ containarium-vm (libvirt KVM) ───────────────────────┐ │
-│  │  Ubuntu 24.04, 20 vCPU, 100 GB RAM, 200GB disk       │ │
-│  │  PCI: RTX 3090 passthrough                           │ │
+│  │  Ubuntu 24.04, sized to match host LXC commitments   │ │
+│  │  PCI: GPU passthrough                                │ │
 │  │  Net: bridged to LAN (own MAC/IP, not NAT)           │ │
 │  │  Incus 6.x + Containarium daemon                     │ │
-│  │  zpool: incus-local-vm (carved from host's pool      │ │
-│  │  via ZVOL OR a vdisk on the host's zpool)            │ │
+│  │  zpool: ZVOL carved from host's pool, OR             │ │
+│  │  a dataset mounted into the VM                       │ │
 │  │                                                      │ │
-│  │  ├─ apibox-dev-3090-container  (RTX 3090 from VM)    │ │
-│  │  ├─ dataspark-cicd-container                         │ │
-│  │  ├─ cicd-container                                   │ │
-│  │  └─ 5× containarium-core-*                           │ │
+│  │  ├─ all production LXCs (GPU + CPU + platform)       │ │
 │  └──────────────────────────────────────────────────────┘ │
 │                                                            │
-│  ┌─ cloud-fts-13700k (libvirt KVM)  — and future siblings ┐│
-│  │  Ad-hoc sandbox VMs. Traffic goes through libvirt NAT  ││
-│  │  to LAN; NOT hijacked by Containarium Caddy anymore.   ││
+│  ┌─ sibling sandbox VMs (any number)  ────────────────────┐│
+│  │  Ad-hoc VMs for testing, etc. Traffic goes through    ││
+│  │  libvirt NAT to LAN; NOT hijacked by Containarium     ││
+│  │  Caddy anymore (it's scoped inside the other VM).     ││
 │  └────────────────────────────────────────────────────────┘│
 └────────────────────────────────────────────────────────────┘
 ```
@@ -71,33 +67,32 @@ Host: 24c/48t, 125GB RAM, ZFS `incus-local` (1.9TB NVMe), `incus-backup` (1.8TB 
 | # | Decision | Options | Recommendation |
 | --- | --- | --- | --- |
 | D1 | VM network mode | (a) bridged to LAN — VM gets a real LAN IP, can keep existing Tailscale identity / sentinel-peer registration. (b) libvirt NAT — simpler but loses the existing LAN IP + needs sentinel re-pointing | **(a) bridged**, to minimize sentinel + Tailscale churn |
-| D2 | Storage for VM disk | (a) raw qcow2 on `/var/lib/libvirt/images` (root ext4). (b) ZVOL carved from `incus-local`. (c) New ZFS dataset on `incus-local` mounted into the VM | **(b) ZVOL on incus-local** — fastest path (same disk as production data), single block device, ZFS snapshots of the whole VM, no double-COW |
+| D2 | Storage for VM disk | (a) raw qcow2 on `/var/lib/libvirt/images` (root ext4). (b) ZVOL carved from the host's main zpool. (c) New ZFS dataset mounted into the VM | **(b) ZVOL** — fastest path (same disk as production data), single block device, ZFS snapshots of the whole VM, no double-COW |
 | D3 | LXC migration method | (a) `incus copy` over network. (b) `incus export` + scp + `incus import`. (c) `zfs send | zfs receive` from host pool → VM pool | **(c) zfs send/receive** — fastest, lossless, ZFS snapshots come along. Falls back to (b) if VM doesn't have host's zpool visible |
-| D4 | Tailscale identity for the VM | (a) Keep `fts-13700k` hostname on the VM, host becomes `fts-13700k-hv` or similar. (b) New name like `fts-13700k-vm` for the VM | **(a)** — keeps existing sentinel registration, peer ID, and SSH config pointing at the unchanged `fts-13700k` |
-| D5 | Cutover window | (a) Off-hours scheduled downtime, coordinate with apibox-dev-3090 + dataspark users. (b) ASAP, accept ~1-2 hours visible downtime | **(a)** — schedule it; both user containers serve real workloads (cockburn-inference-server, pes-resume-search) |
-| D6 | Rollback trigger | When do we abort + restore from snapshot? | **If apibox-dev-3090's RTX 3090 doesn't work in VM after Phase 4**, that's the abort gate — no point continuing if the GPU is broken |
+| D4 | Tailscale identity for the VM | (a) Keep the original hostname on the VM; host becomes `<hostname>-hv` or similar. (b) New name for the VM, keep original on host | **(a)** — keeps existing sentinel registration, peer ID, and SSH config pointing at the unchanged hostname |
+| D5 | Cutover window | (a) Off-hours scheduled downtime, coordinate with workload owners. (b) ASAP, accept ~1-2 hours visible downtime | **(a)** — user-facing workloads need a maintenance window |
+| D6 | Rollback trigger | When do we abort + restore from snapshot? | **If GPU passthrough doesn't work in the VM after Phase 4**, that's the abort gate — no point continuing if the GPU is broken |
 
 ## Phased migration
 
 ### Phase 0 — Pre-flight (no changes; gather data)
 
 ```bash
-# All on fts-13700k.
-echo "=== IOMMU groups for the 3090 (must be in own group OR group of devices we can pass too) ==="
+# All on the target host.
+echo "=== IOMMU groups for the passthrough GPU (must be in own group OR group of devices we can pass too) ==="
+# Replace <pci-slot> with the GPU's PCI BDF, e.g. 01:00.
 for g in /sys/kernel/iommu_groups/*; do
     iommu=$(basename "$g")
     devs=$(ls "$g/devices/" 2>/dev/null)
-    if echo "$devs" | grep -q "01:00"; then
-        echo "IOMMU group $iommu (the 3090's):"
-        for d in $devs; do
-            lspci -nns "$d"
-        done
+    if echo "$devs" | grep -q "<pci-slot>"; then
+        echo "IOMMU group $iommu:"
+        for d in $devs; do lspci -nns "$d"; done
     fi
 done
 
 echo "=== current GPU bindings ==="
-lspci -nnk -s 01:00.0
-lspci -nnk -s 00:02.0    # Intel UHD 770
+lspci -nnk -s <pci-slot>.0   # GPU
+lspci -nnk -s <igpu-slot>.0  # iGPU (e.g. Intel 00:02.0)
 
 echo "=== /etc/default/grub current cmdline ==="
 grep CMDLINE /etc/default/grub
@@ -106,27 +101,31 @@ echo "=== existing zpool snapshot baseline (must have one before we start) ==="
 sudo zfs list -t snapshot -o name,refer,creation -s creation | tail -10
 ```
 
-**Gate:** confirm RTX 3090 is in an IOMMU group of its own (or only with its audio device), and that there's enough free space on `incus-backup` for a baseline snapshot of `incus-local`.
+**Gate:** confirm GPU is in an IOMMU group of its own (or only with its audio device), and that there's enough free space on the backup pool for a baseline snapshot of the main pool.
 
 ### Phase 1 — Baseline snapshot (rollback insurance)
 
 ```bash
-sudo zfs snapshot -r incus-local@pre-host-to-vm-$(date -u +%Y%m%dT%H%M%SZ)
-sudo zfs send -R incus-local@pre-host-to-vm-* | sudo zfs receive incus-backup/snapshots/pre-host-to-vm
-sudo zfs list -t snapshot -r incus-local | head
+# Replace <main-pool> / <backup-pool> with the local zpool names.
+sudo zfs snapshot -r <main-pool>@pre-host-to-vm-$(date -u +%Y%m%dT%H%M%SZ)
+sudo zfs send -R <main-pool>@pre-host-to-vm-* \
+    | sudo zfs receive <backup-pool>/snapshots/pre-host-to-vm
+sudo zfs list -t snapshot -r <main-pool> | head
 ```
 
-**Gate:** snapshot exists and is replicated to `incus-backup`. We can roll back to this point at any later phase.
+**Gate:** snapshot exists and is replicated to the backup pool. We can roll back to this point at any later phase.
 
 ### Phase 2 — VFIO setup (requires reboot)
 
 ```bash
 # 1. Add IOMMU + VFIO to kernel cmdline.
-sudo sed -i 's|GRUB_CMDLINE_LINUX_DEFAULT="\(.*\)"|GRUB_CMDLINE_LINUX_DEFAULT="\1 intel_iommu=on iommu=pt vfio-pci.ids=10de:2204,10de:1aef"|' /etc/default/grub
+#    Replace <gpu-vid:pid> with the GPU's VID:PID, e.g. 10de:2204
+#    (plus the HDMI-audio function VID:PID, e.g. 10de:1aef).
+sudo sed -i 's|GRUB_CMDLINE_LINUX_DEFAULT="\(.*\)"|GRUB_CMDLINE_LINUX_DEFAULT="\1 intel_iommu=on iommu=pt vfio-pci.ids=<gpu-vid:pid>,<audio-vid:pid>"|' /etc/default/grub
 sudo update-grub
 
-# 2. Bind vfio-pci at module load (10de:2204 = RTX 3090, 10de:1aef = its HDMI audio).
-echo "options vfio-pci ids=10de:2204,10de:1aef" | sudo tee /etc/modprobe.d/vfio.conf
+# 2. Bind vfio-pci at module load.
+echo "options vfio-pci ids=<gpu-vid:pid>,<audio-vid:pid>" | sudo tee /etc/modprobe.d/vfio.conf
 echo "vfio
 vfio_pci
 vfio_iommu_type1" | sudo tee /etc/modules-load.d/vfio.conf
@@ -136,64 +135,64 @@ sudo update-initramfs -u
 sudo reboot
 
 # 4. After boot, verify:
-lspci -nnk -s 01:00.0     # should show: Kernel driver in use: vfio-pci
+lspci -nnk -s <pci-slot>.0     # should show: Kernel driver in use: vfio-pci
 dmesg | grep -i vfio | head
 ```
 
-**Gate:** RTX 3090 is bound to `vfio-pci`, host display still works on Intel UHD 770, host SSH still reachable.
+**Gate:** GPU is bound to `vfio-pci`, host display still works on the iGPU (if present), host SSH still reachable.
 
-**Impact during Phase 2:** apibox-dev-3090's GPU stops working when vfio-pci grabs the 3090. cockburn-inference-server inside that container fails. Schedule accordingly.
+**Impact during Phase 2:** any LXC currently using the GPU loses access when vfio-pci grabs it. Schedule accordingly with workload owners.
 
 ### Phase 3 — Provision the Containarium VM
 
 ```bash
-# 1. Carve a ZVOL for the VM root disk on incus-local (200GB).
-sudo zfs create -V 200G -o volblocksize=16k incus-local/containarium-vm
+# 1. Carve a ZVOL for the VM root disk on the main zpool.
+sudo zfs create -V 200G -o volblocksize=16k <main-pool>/containarium-vm
 
-# 2. Bridge the host's LAN interface (wlp6s0 is wifi — need wired for bridging; if wifi-only, use macvtap "passthrough" mode as a workaround, or accept libvirt NAT and re-point sentinel).
-#    TBD: confirm we have a wired Ethernet on fts-13700k. If not, this is a blocker — bridging wifi is unreliable; macvtap is the workaround.
+# 2. Bridge the host's LAN interface.
+#    If the host's default route is on wifi, bridging is unreliable —
+#    use `macvtap passthrough` as a workaround, or accept libvirt NAT
+#    and re-point sentinel registration (D1 fallback).
 
 # 3. virt-install with VFIO + bridge + ZVOL disk.
 sudo virt-install --name containarium-vm \
     --os-variant ubuntu24.04 \
-    --memory 102400 --vcpus 20 \
-    --disk path=/dev/zvol/incus-local/containarium-vm,format=raw,bus=virtio,cache=none \
+    --memory <sized-to-host-LXC-RAM-sum> --vcpus <sized-to-host-vCPU-sum> \
+    --disk path=/dev/zvol/<main-pool>/containarium-vm,format=raw,bus=virtio,cache=none \
     --network bridge=br0 \
-    --hostdev pci_0000_01_00_0 \
-    --hostdev pci_0000_01_00_1 \
+    --hostdev pci_0000_<pci-slot>_0 \
+    --hostdev pci_0000_<pci-slot>_1 \
     --cdrom /var/lib/libvirt/images/ubuntu-24.04-server-installer.iso \
     --graphics none --console pty,target_type=serial
 
 # 4. Inside the VM (via serial console install), configure: hostname, SSH, Tailscale.
-# 5. Install Incus 6.x, init with `incus admin init --auto` against a ZFS pool
-#    (carved from a second ZVOL or a dataset mounted into the VM).
-# 6. Verify nvidia-smi inside the VM sees the 3090.
+# 5. Install Incus 6.x, init with `incus admin init --auto` against a ZFS pool.
+# 6. Verify nvidia-smi inside the VM sees the GPU.
 ```
 
-**Gate:** VM is up, has a LAN IP, Tailscale-reachable as `fts-13700k` (after D4 cutover), `nvidia-smi` sees the 3090, Incus is initialized.
+**Gate:** VM is up, has a LAN IP, Tailscale-reachable, `nvidia-smi` sees the GPU, Incus is initialized.
 
 ### Phase 4 — LXC migration (host → VM)
 
-For each container, in this order (platform first, then user containers, GPU container last):
+For each container, in this order (platform first, then CPU-only user containers, GPU container last):
 
 1. containarium-core-postgres
 2. containarium-core-victoriametrics
 3. containarium-core-otelcollector
 4. containarium-core-security
 5. containarium-core-caddy
-6. cicd-container
-7. dataspark-cicd-container
-8. apibox-dev-3090-container (GPU passthrough config rewritten for VM-side PCI ID)
+6. CPU-only user containers
+7. GPU user container (GPU passthrough config rewritten for VM-side PCI ID)
 
 Per-container procedure (zfs send/receive variant, fastest):
 
 ```bash
-# On host (fts-13700k):
-NAME=containarium-core-postgres
+# On host:
+NAME=<container-name>
 incus stop "$NAME"
-sudo zfs snapshot incus-local/containers/$NAME@migrate
-sudo zfs send incus-local/containers/$NAME@migrate \
-    | ssh containarium-vm 'sudo zfs receive incus-local/containers/'$NAME
+sudo zfs snapshot <main-pool>/containers/$NAME@migrate
+sudo zfs send <main-pool>/containers/$NAME@migrate \
+    | ssh <vm-hostname> 'sudo zfs receive <vm-pool>/containers/'$NAME
 
 # In VM:
 # Re-create the incus instance metadata pointing at the received dataset.
@@ -202,16 +201,16 @@ incus start "$NAME"
 incus exec "$NAME" -- systemctl status   # sanity check
 ```
 
-For **apibox-dev-3090-container**, rewrite the GPU device config:
+For the **GPU user container**, rewrite the GPU device config to use the VM's view of the PCI BDF:
 
 ```bash
 # Inside the VM, after the container is imported:
-incus config device set apibox-dev-3090-container gpu pci=01:00.0
-incus start apibox-dev-3090-container
-incus exec apibox-dev-3090-container -- nvidia-smi
+incus config device set <gpu-container-name> gpu pci=<vm-side-pci-slot>
+incus start <gpu-container-name>
+incus exec <gpu-container-name> -- nvidia-smi
 ```
 
-**Gate:** all 8 containers running in the VM, accessible at their original `10.100.0.x` addresses (assuming we keep the `incusbr0` subnet inside the VM).
+**Gate:** all containers running in the VM, accessible at their original `incusbr0` addresses (assuming we keep the same Incus subnet inside the VM).
 
 ### Phase 5 — Cutover
 
@@ -223,19 +222,19 @@ sudo systemctl stop incus
 
 # Move Tailscale identity to the VM if D4=(a):
 # - On host: `sudo tailscale logout`
-# - In VM:   `sudo tailscale up --hostname=fts-13700k`
+# - In VM:   `sudo tailscale up --hostname=<original-hostname>`
 
 # Sentinel re-registration is automatic once the VM's daemon registers
-# itself as tunnel-fts-13700k-gpu (same peer ID).
+# itself with the same peer ID.
 ```
 
-**Gate:** sentinel shows `fts-13700k` peer via the VM; SSH `fts-13700k` lands in the VM; apibox-dev-3090's cockburn-inference-server is back up; dataspark stack is back up.
+**Gate:** sentinel shows the host peer via the VM; SSH to the original hostname lands in the VM; GPU + CPU workloads are back up.
 
 ### Phase 6 — Soak + cleanup
 
 - 24h observation: VictoriaMetrics graphs, sentinel peer health, no surprise restarts.
-- After soak: **don't yet delete** the host's `incus-local/containers/*`. That's our rollback. Mark with a clear timestamped retention window (e.g., 7 days).
-- After retention: `zfs destroy -r incus-local/containers` on the host.
+- After soak: **don't yet delete** the host's `<main-pool>/containers/*`. That's our rollback. Mark with a clear timestamped retention window (e.g., 7 days).
+- After retention: `zfs destroy -r <main-pool>/containers` on the host.
 
 ## Rollback procedure
 
@@ -245,24 +244,24 @@ If any gate fails irrecoverably:
 2. On host: `sudo systemctl start containarium && sudo systemctl start incus`.
 3. Containers come back up where they were. ~1 min downtime per container.
 4. The VM stays around (does nothing) until we decide what to do.
-5. The 3090 GPU stays bound to vfio-pci. To return it to the host: remove the cmdline + reboot.
+5. The GPU stays bound to vfio-pci. To return it to the host: remove the cmdline + reboot.
 
-The `incus-backup/snapshots/pre-host-to-vm` ZFS snapshot is the nuclear-rollback option (restore the entire `incus-local` to its pre-Phase-1 state).
+The `<backup-pool>/snapshots/pre-host-to-vm` ZFS snapshot is the nuclear-rollback option (restore the entire main pool to its pre-Phase-1 state).
 
 ## Open technical risks
 
-- **Bridging requires wired Ethernet.** `fts-13700k`'s default route is `wlp6s0` (wifi). Bridging wifi NICs is unreliable (most APs don't allow client MAC multiplexing). Need to confirm there's a wired interface (`enpXsY`) we can bridge against. If not: use `macvtap passthrough` or accept libvirt NAT + sentinel re-pointing.
-- **IOMMU group composition.** If the 3090 shares an IOMMU group with other host-critical devices (USB controller, root port), we have to pass them all together — sometimes a deal-breaker. Phase 0 will tell us.
-- **Memory pinning.** A VM with 100GB RAM allocated should pin its memory (`virsh memtune` `hard_limit`) so VFIO has stable DMA mappings. Out-of-default; document in the runbook.
+- **Bridging requires wired Ethernet.** If the host's default route is on wifi, bridging wifi NICs to a guest VM is unreliable (most APs don't allow client MAC multiplexing). Need to confirm there's a wired interface to bridge against. If not: use `macvtap passthrough` or accept libvirt NAT + sentinel re-pointing.
+- **IOMMU group composition.** If the GPU shares an IOMMU group with other host-critical devices (USB controller, root port), we have to pass them all together — sometimes a deal-breaker. Phase 0 will tell us.
+- **Memory pinning.** A VM with a large RAM allocation should pin its memory (`virsh memtune` `hard_limit`) so VFIO has stable DMA mappings. Out-of-default; document in the runbook.
 - **Tailscale conflict.** Tailscale logged in on the host AND the same hostname trying to log in on the VM will collide. Phase 5 covers the cutover — must be sequential, not parallel.
 
 ## What this is NOT
 
-- Not a generic "make Containarium production-grade" doc — it's a specific operational migration for one node with a worked GPU case.
+- Not a generic "make Containarium production-grade" doc — it's a specific operational migration pattern with a worked GPU passthrough case.
 - Not done. We finish this doc + ratify the 6 decisions BEFORE touching the host.
 
 ## Related
 
-- 2026-05-24 incident — Caddy intercept on `fts-13700k` hijacking sibling libvirt VM traffic. Concrete motivation.
+- 2026-05-24 incident — Caddy intercept on a Containarium-bare-metal node hijacking sibling libvirt VM traffic. Concrete motivation.
 - `docs/security/NETWORK-ISOLATION-DESIGN.md` — eBPF Phase A may run inside the new VM; clean test environment.
 - `docs/EPHEMERAL-SANDBOX-DESIGN.md` — depends on having sibling VMs that DON'T get hijacked, which this migration enables.


### PR DESCRIPTION
## Summary

Operational runbook for moving Containarium + 8 production LXCs out of bare-metal on `fts-13700k` and into a libvirt KVM VM on the same host, with RTX 3090 passthrough.

**Motivation**: the 2026-05-24 incident on `fts-13700k` showed concretely why this matters — Containarium-core Caddy on the host intercepts ALL :80/:443 traffic from any sibling libvirt VM, breaking outbound HTTPS for ad-hoc lab VMs. Migrating Containarium into a VM scopes its iptables/Caddy rules to the VM's network namespace and unblocks sibling VMs **structurally**, not by patching individual rules.

## What's in the doc

- **fts-13700k inventory** — 8 LXCs broken down by tier (1 GPU-attached user container, 2 CPU-only user containers, 5 platform services).
- **Target architecture** — host = hypervisor + Tailscale only; Containarium VM owns the LXCs + the 3090.
- **6 open decisions** that need answers before execution (network mode, VM disk storage, LXC migration method, Tailscale identity, cutover window, rollback trigger).
- **7-phase migration plan** with concrete commands per phase.
- **Rollback procedure** (per-phase abort + nuclear ZFS-snapshot restore).
- **Open technical risks** (bridging requires wired ethernet, IOMMU group composition, memory pinning, Tailscale conflict).

## Status

**Plan, awaiting decisions.** The 6 decisions in the doc need to be ratified before any keystroke on the host. Once ratified, execution is ~3-4 hours of focused work + soak time + coordination with apibox/dataspark users on the cutover window.

## Phased rollout

| Phase | Scope | Impact |
| --- | --- | --- |
| 0 | Pre-flight (IOMMU groups, baseline data) | Zero — read-only |
| 1 | ZFS baseline snapshot to incus-backup | Zero — rollback insurance |
| 2 | VFIO kernel cmdline + reboot | apibox-dev-3090's GPU stops working until Phase 4 |
| 3 | Provision Containarium VM | Zero — VM is separate |
| 4 | Migrate 8 LXCs (zfs send/receive) | Per-container ~1-5 min stop |
| 5 | Cutover (stop host daemon, move Tailscale identity) | ~1-2 hr user-facing downtime |
| 6 | Soak + retention + cleanup | Zero (passive) |

## What this PR is NOT

- Code. Runbook only.
- A commitment to execute. The 6 decisions need ratification first.

## Test plan
- [x] Markdown renders cleanly
- [x] Follows the design-doc pattern from `KMS-ENVELOPE-DESIGN.md`, `IMAGE-DIGEST-VERIFY-DESIGN.md`, `NETWORK-ISOLATION-DESIGN.md`
- [ ] **Decisions ratified by operator** — pending. See "Decisions needed before execution" table in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)