### PR TITLE
fix(jump-server): surface useradd output when all retries exhaust

### DIFF
--- a/pkg/core/container/jump_server.go
+++ b/pkg/core/container/jump_server.go
@@ -695,6 +695,12 @@ func retryUseraddWithLockWait(username string, verbose bool) error {
 
 	// Retry useradd with flock for serialization
 	var lastErr error
+	var lastOutput string // Captured stdout/stderr of the last useradd
+	                       // attempt — surfaced in the final error when
+	                       // all retries exhaust. Without this, callers
+	                       // see only "exit status 1", which is actively
+	                       // misleading when the real cause was e.g.
+	                       // /etc/passwd locked by another process.
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
 			fmt.Printf("       Retry attempt %d/%d...\n", attempt+1, maxRetries)
@@ -721,6 +727,7 @@ func retryUseraddWithLockWait(username string, verbose bool) error {
 
 		lastErr = err
 		errMsg := string(output)
+		lastOutput = errMsg
 
 		// Check if it's a lock-related error (retry) or something else (fail immediately)
 		if !strings.Contains(errMsg, "cannot lock") && !strings.Contains(errMsg, "try again later") {
@@ -739,8 +746,13 @@ func retryUseraddWithLockWait(username string, verbose bool) error {
 		killGoogleProcesses(verbose)
 	}
 
-	// All retries exhausted
+	// All retries exhausted — surface the last attempt's useradd output
+	// so the operator sees what actually failed (e.g. "cannot lock
+	// /etc/passwd; try again later"), not just "exit status 1".
 	fmt.Printf("       useradd failed after %d attempts!\n", maxRetries)
+	if trimmed := strings.TrimSpace(lastOutput); trimmed != "" {
+		return fmt.Errorf("failed to create user %s after %d attempts: %w\nLast useradd output: %s", username, maxRetries, lastErr, trimmed)
+	}
 	return fmt.Errorf("failed to create user %s after %d attempts: %w", username, maxRetries, lastErr)
 }
 


### PR DESCRIPTION
## Summary

Pure error-message improvement, no behavior change. The useradd retry loop captures stdout/stderr per attempt to decide whether to retry (lock error → yes, anything else → fail-fast). But when all retries exhaust, only the bare \`lastErr\` ("exit status 1") goes into the final error message — the captured output is dropped on the floor.

## How this surfaced

A cloud-CI debug session today (the now-fixed dogfood chain in containarium-run#9-#12) finally got far enough into the daemon that the daemon's own error landed in the failure-debug PR comment:

\`\`\`
Error: failed to create jump server account:
failed to create user ci-26388125553-1 after 5 attempts: exit status 1
\`\`\`

"exit status 1" is genuinely uninformative — \`useradd\` has dozens of exit-1 paths (UID exhausted, lock held, /etc/passwd unwritable, shell not in /etc/shells, …). The actual output ("cannot lock /etc/passwd; try again later" in this case) was sitting in \`errMsg\` on the last iteration and got thrown away.

## Fix

Hoist a \`lastOutput\` variable in the loop (mirror of \`lastErr\`), capture each attempt's output into it, append to the final error when retries exhaust:

\`\`\`go
if trimmed := strings.TrimSpace(lastOutput); trimmed != "" {
    return fmt.Errorf("failed to create user %s after %d attempts: %w\nLast useradd output: %s", username, maxRetries, lastErr, trimmed)
}
\`\`\`

Operator sees the same string the operational logs already emit (per the per-iteration Printf), but now WITHOUT needing journal access — it surfaces all the way up to the gRPC client (and in cloud's case, into the failure-debug PR comment).

The fail-fast path on line 731 already does this for non-lock errors; this just brings the retry-exhausted path to parity.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./pkg/core/container/\` clean
- [x] \`go test ./pkg/core/container/ -count=1\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)