### PR TITLE
fix(install-cli): use 'containarium version' subcommand, not --version

### DIFF
--- a/hacks/install-cli.sh
+++ b/hacks/install-cli.sh
@@ -71,7 +71,14 @@ if [ ! -w "$INSTALL_DIR" ]; then
 fi
 
 mv "$TMP/containarium" "${INSTALL_DIR}/containarium"
-echo "Installed: $(${INSTALL_DIR}/containarium --version 2>&1 | head -1)"
+# Print the installed version. The CLI exposes its version via the
+# `version` subcommand, NOT a top-level `--version` flag (the daemon
+# accepts both, the CLI doesn't). The previous wording here
+# (`--version`) produced "Installed: Error: unknown flag: --version"
+# which read like a fatal install error in CI logs — see
+# containarium-run#8 / #9 / #10 for the cloud CI debug chain that
+# this misleading message helped delay.
+echo "Installed: $(${INSTALL_DIR}/containarium version 2>&1 | head -1)"
 echo
 echo "Talk to a remote Containarium server with:"
 echo "  export CONTAINARIUM_HTTP=true"


### PR DESCRIPTION
## Summary

\`install-cli.sh\` ended with:

\`\`\`bash
echo "Installed: \$(\${INSTALL_DIR}/containarium --version 2>&1 | head -1)"
\`\`\`

But the CLI doesn't accept a top-level \`--version\` flag (only the daemon does — \`containarium-run#8\` documents this exact mismatch the same way). The CLI prints:

\`\`\`
Installed: Error: unknown flag: --version
\`\`\`

The 2>&1 + subshell swallows the exit code, so the install itself succeeds — but the literal text \`Installed: Error: ...\` reads like a fatal install error in CI logs. Earlier this week the cloud-CI debug chain burned real time on this red herring before tracing it back to "the install-cli print is just confused; the actual install succeeded."

## Fix

One-character change: \`--version\` → \`version\` (drop the dashes; the subcommand form works). Same successful output, no more misleading error string.

## Test plan

- [x] \`bash -n hacks/install-cli.sh\` clean
- [ ] Next CI run that uses \`install-cli.sh\` (via containarium-run action OR direct curl) prints a clean version line in its logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)