### PR TITLE
fix(jump-server): fail-fast on useradd Permission denied (closes containarium-run#15)

### DIFF
--- a/pkg/core/container/jump_server.go
+++ b/pkg/core/container/jump_server.go
@@ -729,6 +729,22 @@ func retryUseraddWithLockWait(username string, verbose bool) error {
 		errMsg := string(output)
 		lastOutput = errMsg
 
+		// Permission-denied is a permanent error — fail-fast with a
+		// pointed message. useradd emits BOTH "Permission denied" and
+		// "cannot lock /etc/passwd; try again later" when run as a
+		// non-root user: the privileged read+lock fails first, then
+		// useradd's generic fallback prints the lock line. Without
+		// this guard the lock-error retry branch below catches both
+		// lines and we burn 5 retries on a condition that won't fix
+		// itself — observed in cloud CI (containarium-run issue #15)
+		// where the cloud-daemon process didn't have the capability
+		// to add a system user.
+		if strings.Contains(errMsg, "Permission denied") {
+			fmt.Printf("       useradd failed with Permission denied — daemon process lacks the privilege to add a system user.\n")
+			fmt.Printf("       Output: %s\n", errMsg)
+			return fmt.Errorf("failed to create user %s: %w\nuseradd requires root (or CAP_CHOWN+CAP_DAC_OVERRIDE on /etc/passwd). Check the daemon's deploy unit (systemd User= directive) or container privileges. Output: %s", username, err, errMsg)
+		}
+
 		// Check if it's a lock-related error (retry) or something else (fail immediately)
 		if !strings.Contains(errMsg, "cannot lock") && !strings.Contains(errMsg, "try again later") {
 			// Not a lock error - fail immediately


### PR DESCRIPTION
## Fixes [containarium-run#15](https://github.com/FootprintAI/containarium-run/issues/15)

### Root cause

\`useradd\` emits BOTH \`Permission denied.\` AND \`useradd: cannot lock /etc/passwd; try again later.\` when run by a non-root user — the privileged read+lock fails first, then useradd's generic fallback prints the lock line. The existing retry branch only inspects the \`cannot lock\` string, so it catches both lines and retries 5× on a condition that won't fix itself.

Issue #15's log shows exactly this:

\`\`\`
useradd failed with lock error, will retry...
Output: useradd: Permission denied.
useradd: cannot lock /etc/passwd; try again later.
        ... (5 retries)
useradd failed after 5 attempts!
\`\`\`

### Daemon-side fix (this PR)

Check for \`Permission denied\` **before** the lock-retry branch. Fail-fast with a pointed error that names the actual remediation (daemon's systemd User= directive or container privileges), not the man-page lock-contention boilerplate. The error now reads:

\`\`\`
failed to create user X: exit status 1
useradd requires root (or CAP_CHOWN+CAP_DAC_OVERRIDE on /etc/passwd). Check
the daemon's deploy unit (systemd User= directive) or container privileges.
Output: useradd: Permission denied. useradd: cannot lock /etc/passwd; ...
\`\`\`

Pure error-handling improvement; behavior change is only at the permission-denied branch (used to retry 5×, now returns immediately). Lock-contention path unchanged. Builds on OSS#320 (which surfaced the captured output in the first place) so callers see the actionable message in the failure-debug PR comment without journal access.

### Operator-side fix (out of scope for this PR)

Make the daemon process actually privileged. The error log shows \`Failed to stop google-guest-agent.service: Access denied\` alongside the useradd failure — confirms the daemon's not running as root anywhere it ought to be. Likely fixes:

1. **systemd unit** has \`User=\` non-root → change to \`User=root\` (the install path uses systemd-system, not systemd-user).
2. **Container deploy** drops capabilities → ensure \`CAP_CHOWN\` + \`CAP_DAC_OVERRIDE\` are present, or run the container privileged.
3. **Sudoers** for the daemon user includes \`NOPASSWD\` useradd — needs the daemon to be patched to call \`sudo useradd\` instead of bare \`useradd\` (separate PR; bigger scope).

(1) is the simplest in most deploys.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./pkg/core/container/\` clean
- [x] \`go test ./pkg/core/container/ -count=1\` passes
- [ ] After deploy + operator fix from above: next cloud CI run gets past create-box

🤖 Generated with [Claude Code](https://claude.com/claude-code)