### PR TITLE
feat(cli): K2 — clarify post-login banner with rotation hint (cloud#147)

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -347,7 +347,13 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		who = "unknown user"
 	}
 	fmt.Fprintf(out, "✓ Logged in as %s\n", who)
-	fmt.Fprintf(out, "  Token saved to %s\n", path)
+	fmt.Fprintf(out, "✓ API token saved to %s\n", path)
+	// K2 of cloud#147 — surface the rotation path so the operator
+	// knows where to find the token they just got handed. The cloud
+	// minted this token during the cli-session approve flow; it's
+	// org-scoped and long-lived (no expiry) until explicit revoke.
+	fmt.Fprintf(out, "  → View / rotate at %s/settings/api-tokens\n",
+		strings.TrimRight(srv, "/"))
 
 	// Sub-task A7: optionally register this machine's SSH key for
 	// access to boxes created under this account. Done as a tail of


### PR DESCRIPTION
## Summary
K2 of cloud's Free-vs-Paid-Tier-Gates umbrella (cloud#147). The device-flow login was already writing an API token (cli-session approve mints one via APITokenService); this PR just sharpens the printed banner so a brand-new user knows where to find / rotate the token.

**Before:**
```
✓ Logged in as alice@example.com
  Token saved to /home/alice/.containarium/credentials.json
```

**After:**
```
✓ Logged in as alice@example.com
✓ API token saved to /home/alice/.containarium/credentials.json
  → View / rotate at https://cloud.containarium.dev/settings/api-tokens
```

## Why the rotation hint
Cloud's K1 (PR #154) auto-mints a `default` token without an explicit "save this" UI moment. The CLI banner is the only place that tells a brand-new user where the token lives + how to rotate.

## No new logic
The credentials.json write itself was already in place from A3 — this is purely UX polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)