### PR TITLE
test(mcp) + docs: K3 + K4 + K5 — MCP API-token verify + 60-second doc (cloud#147)

### DIFF
--- a/docs/MCP-60-SECONDS.md
+++ b/docs/MCP-60-SECONDS.md
@@ -1,0 +1,92 @@
+# 60 Seconds: Create + Expose a Container from MCP
+
+The fastest path from `containarium login` to an HTTPS URL serving a
+container. Targets the Containarium Cloud surface; works for self-hosted
+deployments if you swap the URL.
+
+K5 of the Free-vs-Paid-Tier-Gates work (cloud#147). Companion to the
+broader [MCP-QUICKSTART.md](MCP-QUICKSTART.md) — that one walks the full
+Claude Desktop setup; this one is the agent-friendly path once the MCP
+server is already wired.
+
+---
+
+## What you need
+
+- `containarium` CLI installed (see `hacks/install-cli.sh`).
+- A Containarium Cloud account. Sign up at the cloud's login page — a
+  personal-sandbox org + a `default` API token are auto-provisioned for
+  you. If you've already signed up via the dashboard, you're set.
+- An MCP-capable client (Claude Desktop, Cursor, etc.) wired to the
+  cloud's MCP server endpoint.
+
+## Step 1 — Log in (10s)
+
+```bash
+containarium login
+```
+
+Opens a browser tab for one-click approval. On success you'll see:
+
+```
+✓ Logged in as you@example.com
+✓ API token saved to /home/you/.containarium/credentials.json
+  → View / rotate at https://<your-host>/settings/api-tokens
+```
+
+The saved token is the same one MCP clients use — they read
+`credentials.json` directly via the
+[MCP credentials fallback](../internal/mcp/credentials_fallback_test.go).
+
+## Step 2 — Tell your agent (5s)
+
+In your MCP client (e.g. Claude Desktop), ask:
+
+> Create a container named `demo`, run `python3 -m http.server 8080` in
+> it, and expose port 8080 publicly.
+
+## Step 3 — Watch the agent run two tools (~45s)
+
+Under the hood your agent calls:
+
+1. **`create_container`** — provisions an LXC container under your org.
+2. *(agent SSHes in and starts the HTTP server — uses the MCP `ssh`
+   bridge or a separate shell session.)*
+3. **`expose_port`** — claims a subdomain and wires it through the
+   cloud's HTTPS proxy.
+
+A successful `expose_port` response includes the public URL, e.g.
+`https://demo-<hash>.<your-host>`. Open it in a browser — your container
+is serving traffic.
+
+## Tier-specific URL shape
+
+- **Free** (`is_personal=true` org): URL is `<name>-<8-char-hash>.<host>`.
+  The hash is deterministic per (name, org_id) — re-claiming after a
+  delete produces the same URL (no cert churn, bookmarks survive).
+- **Pro / Enterprise**: clean `<name>.<host>`. Subject to the per-tier
+  subdomain quota (Pro = 25 soft-capped; Enterprise unlimited).
+
+If you're on Free and want a clean URL, upgrade in the dashboard. The
+existing kept-alive URLs stay live during the upgrade.
+
+## What happens if the agent's request fails
+
+- **`401 unauthorized`**: token isn't in `credentials.json`. Re-run
+  `containarium login`.
+- **`403 / failed_precondition: personal-tier-org-no-invite`**: not
+  related to container ops — that's the team-invite gate. Container +
+  expose work on every tier.
+- **Container created but expose_port fails with `quota_exceeded`**:
+  you're at the subdomain limit. Delete an unused subdomain via the
+  dashboard or upgrade.
+
+## Related docs
+
+- [MCP-QUICKSTART.md](MCP-QUICKSTART.md) — full Claude Desktop +
+  Containarium-host setup (where this 60-second flow assumes you've
+  already landed).
+- [MCP-INTEGRATION.md](MCP-INTEGRATION.md) — protocol-level notes for
+  building your own MCP-capable client.
+- `prd/cloud/free-vs-paid-tier-gates.md` (cloud repo, private) — the
+  PRD this 60-second flow is the user-facing surface of.

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -347,7 +347,13 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		who = "unknown user"
 	}
 	fmt.Fprintf(out, "✓ Logged in as %s\n", who)
-	fmt.Fprintf(out, "  Token saved to %s\n", path)
+	fmt.Fprintf(out, "✓ API token saved to %s\n", path)
+	// K2 of cloud#147 — surface the rotation path so the operator
+	// knows where to find the token they just got handed. The cloud
+	// minted this token during the cli-session approve flow; it's
+	// org-scoped and long-lived (no expiry) until explicit revoke.
+	fmt.Fprintf(out, "  → View / rotate at %s/settings/api-tokens\n",
+		strings.TrimRight(srv, "/"))
 
 	// Sub-task A7: optionally register this machine's SSH key for
 	// access to boxes created under this account. Done as a tail of

--- a/internal/mcp/k3_k4_api_token_test.go
+++ b/internal/mcp/k3_k4_api_token_test.go
@@ -1,0 +1,81 @@
+package mcp
+
+// Per-workstream test file for K3 + K4 of cloud#147 — assert the MCP
+// `create_container` + `expose_port` tools dispatch correctly when
+// the operator-supplied bearer is an API token (ctnr_<id>.<secret>
+// shape) rather than a JWT.
+//
+// The cloud's JWTServerInterceptorWithAPITokens accepts both
+// schemes — this test confirms the OSS MCP server forwards the
+// bearer verbatim (no JWT-specific massaging) so an API-token
+// caller doesn't get stuck at the cloud edge.
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMCPClient_K3_CreateContainerAcceptsAPIToken — the create
+// flow is the K3 acceptance path: handler → client.CreateContainer
+// → POST /v1/containers with the API token in the Bearer header.
+func TestMCPClient_K3_CreateContainerAcceptsAPIToken(t *testing.T) {
+	const apiToken = "ctnr_abc123def456.deadbeefcafebabe1234567890abcdef"
+
+	var sawHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"username":"alice","status":"created"}`)
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, apiToken)
+	resp, err := c.CreateContainer(CreateContainerRequest{
+		Username: "alice",
+		Image:    "ubuntu:22.04",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, "Bearer "+apiToken, sawHeader,
+		"MCP must forward the API token verbatim as a Bearer header")
+}
+
+// TestMCPClient_K4_ExposePortAcceptsAPIToken — same shape for
+// the expose_port flow. The MCP server's expose_port tool wraps
+// route creation; the client forwards the bearer.
+func TestMCPClient_K4_ExposePortAcceptsAPIToken(t *testing.T) {
+	const apiToken = "ctnr_xyz789.fedcba0987654321"
+
+	var sawHeader, sawPath, sawMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawHeader = r.Header.Get("Authorization")
+		sawPath = r.URL.Path
+		sawMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"route":{"domain":"alice-myapp.example.dev"},"message":"ok"}`)
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, apiToken)
+	resp, err := c.AddRoute(AddRouteRequest{
+		Domain:        "alice-myapp.example.dev",
+		TargetIP:      "10.0.0.1",
+		TargetPort:    8080,
+		ContainerName: "alice",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, "Bearer "+apiToken, sawHeader,
+		"MCP expose_port must forward the API token verbatim")
+	assert.True(t, strings.Contains(sawPath, "/routes"),
+		"expose_port should target the routes endpoint (got %q)", sawPath)
+	assert.Equal(t, http.MethodPost, sawMethod, "expose_port creates a route → POST")
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,9 +22,8 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	// 29 base tools + 3 runner-provision tools (provision_runners,
-	// list_runners, remove_runner) added in the runner-MCP-tool PR.
-	assert.Len(t, server.tools, 32, "Should have 32 tools registered")
+	// 29 base + 3 runner-provision + 4 compose-autostart (#325).
+	assert.Len(t, server.tools, 36, "Should have 36 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -128,9 +127,8 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	// 29 base tools + 3 runner-provision tools (provision_runners,
-	// list_runners, remove_runner) added in the runner-MCP-tool PR.
-	assert.Len(t, tools, 32)
+	// 29 base + 3 runner-provision + 4 compose-autostart (#325).
+	assert.Len(t, tools, 36)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -975,6 +975,14 @@ func toolScopeAssignments() map[string]string {
 		"provision_runners": auth.ScopeContainersWrite,
 		"remove_runner":     auth.ScopeContainersWrite,
 		"list_runners":      auth.ScopeContainersRead,
+		// Compose-autostart (platform MCP tools added in #325).
+		// Discovery is read-only; enable/disable + status mutate or
+		// inspect the LXC's systemd-user units. Reuses containers:*
+		// scopes since the operations are box-local lifecycle.
+		"compose_discover": auth.ScopeContainersRead,
+		"compose_status":   auth.ScopeContainersRead,
+		"compose_enable":   auth.ScopeContainersWrite,
+		"compose_disable":  auth.ScopeContainersWrite,
 	}
 }
 


### PR DESCRIPTION
## Summary
Closes K3 + K4 + K5 of cloud's #147 umbrella (the K-track minus K1 which is cloud-side).

- **K3 + K4 verify** — new test file asserting the OSS MCP client forwards a `ctnr_*` API-token Bearer verbatim for both `create_container` and `expose_port` (AddRoute) flows. The cloud's JWTServerInterceptorWithAPITokens already accepts both schemes; this test pins the "no JWT-specific massaging" contract on the OSS side.
- **K5 onboarding doc** — `docs/MCP-60-SECONDS.md`. Tight quickstart focused on the PRD's "signup → first MCP-driven container in 60s" target. Includes tier-specific URL shape callout (Free hash-suffixed vs Pro clean) and three "what if it fails" failure modes.

## Drive-by fixes (was red on `main`)
- `toolScopeAssignments()` was missing the four compose_* tools added in #325. `TestEveryToolHasScope` had been failing since then. Added the assignments.
- `TestServerCreation` + `TestHandleToolsList` asserted Len(tools)==32 but compose tools brought the count to 36. Updated.

All MCP tests now green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)