### PR TITLE
chore: cut v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-05-27
+
+Headline: **agent-box reaches the CI surface** — the platform now provisions GitHub-Actions ephemeral runners, owns the compose-autostart contract end-to-end, and ships the MCP / CLI surface (`login`, `whoami`, `ssh setup`, `runner provision`, compose-autostart tools) that lets an agent or a script drive a Containarium host without hand-rolling SSH glue. Plus the trailing useradd-on-jumpserver fixes that closed [`cloud#163`](https://github.com/FootprintAI/Containarium-cloud/issues/163).
+
+### Added — CI runner pool
+
+- **Runner kit** ([#302](https://github.com/FootprintAI/Containarium/pull/302), [#304](https://github.com/FootprintAI/Containarium/pull/304)) — Containarium as a GHA ephemeral runner pool; `containarium runner provision` CLI + MCP tool spins one up agent-driven.
+- **Pattern B docs** ([#303](https://github.com/FootprintAI/Containarium/pull/303)) — runner orchestrates nested per-job, with the trade-offs vs. flat pools written down.
+
+### Added — compose-autostart end-to-end
+
+- **Phase B** — agent-box MCP tools ([#310](https://github.com/FootprintAI/Containarium/pull/310))
+- **Phase C** — daemon proto + RPC + CLI ([#317](https://github.com/FootprintAI/Containarium/pull/317), [#323](https://github.com/FootprintAI/Containarium/pull/323), [#324](https://github.com/FootprintAI/Containarium/pull/324))
+- **Phase D** — `containarium create --auto-restart-compose=<dir>` ([#326](https://github.com/FootprintAI/Containarium/pull/326))
+- **Platform compose-autostart MCP tools** ([#325](https://github.com/FootprintAI/Containarium/pull/325))
+- **Design note** ([#309](https://github.com/FootprintAI/Containarium/pull/309)) — captures why this lands platform-level rather than per-image.
+
+### Added — CLI / MCP surface
+
+- **`containarium login` / `logout` / `whoami`** ([#305](https://github.com/FootprintAI/Containarium/pull/305)) — A3 of the agent-onboarding plan; replaces ad-hoc `~/.containarium/credentials.json` editing.
+- **`containarium ssh setup` / `list` / `remove` / `propagate`** + **`login --with-ssh-setup`** ([#307](https://github.com/FootprintAI/Containarium/pull/307)) — A5/A6/A7; one-shot SSH key onboarding from any client.
+- **MCP credentials.json fallback for token** ([#311](https://github.com/FootprintAI/Containarium/pull/311)) — A4; MCP tools pick up the credentials file when no env token is set.
+- **TTL CLI verbs** — `containarium ttl set / get / unset` ([#297](https://github.com/FootprintAI/Containarium/pull/297)) for box auto-delete scheduling.
+- **TTL sweeper + handler** ([#299](https://github.com/FootprintAI/Containarium/pull/299), [#300](https://github.com/FootprintAI/Containarium/pull/300)) — proto RPC + decision logic + keep-on-failure chain.
+- **Agent-box CI MCP resources** ([#298](https://github.com/FootprintAI/Containarium/pull/298), [#296](https://github.com/FootprintAI/Containarium/pull/296)) — `ci-context` + `ci-prompt` resources with an opinionated debug playbook.
+- **Post-login banner rotation hint** ([#333](https://github.com/FootprintAI/Containarium/pull/333)) — K2; banner now nudges users toward token rotation.
+- **Env-var defaults + CLI-only install script** ([#295](https://github.com/FootprintAI/Containarium/pull/295)) — unblocks the GHA Action path.
+
+### Added — Air-gapped install + ebpf
+
+- **Air-gapped install bundle** ([#308](https://github.com/FootprintAI/Containarium/pull/308), E3b) — `offline-install.sh`, release-pipeline matrix, GHES support.
+- **ebpf Phase 0** ([#292](https://github.com/FootprintAI/Containarium/pull/292)) — bridge-attach validator (shell + Go paths).
+
+### Fixed — Jump-server useradd reliability
+
+The fail-fast + serialization fixes that took the useradd path from "retries-until-misleading-lock-error" to "errors clearly, immediately":
+
+- **Surface useradd output when all retries exhaust** ([#320](https://github.com/FootprintAI/Containarium/pull/320)) — `lastOutput` captured so the final error includes the real stderr.
+- **Fail-fast on `Permission denied`** ([#322](https://github.com/FootprintAI/Containarium/pull/322), closes [containarium-run#15](https://github.com/FootprintAI/containarium-run/issues/15)) — distinguishes "non-root can't write /etc/passwd" from "transient lock," fails immediately on the former.
+- **Serialize useradd + exponential backoff + mid-loop lock cleanup** ([#335](https://github.com/FootprintAI/Containarium/pull/335), closes [cloud#163](https://github.com/FootprintAI/Containarium-cloud/issues/163)) — concurrent useradds no longer thrash; stale locks get cleaned up between attempts.
+
+### Fixed — Other
+
+- **`containarium version` subcommand on install** ([#321](https://github.com/FootprintAI/Containarium/pull/321)) — installer now uses the actual subcommand rather than `--version` which isn't a flag.
+
+### Tests / Docs
+
+- **MCP K3 + K4 + K5 + 60-second doc** ([#334](https://github.com/FootprintAI/Containarium/pull/334)) — API-token verify tests + new operator quickstart.
+- **VM-migration plan + OSS-disclosure rule** ([#313](https://github.com/FootprintAI/Containarium/pull/313)) — host→VM migration plan written down; CLAUDE.md gains a rule on what may leak into OSS commits.
+
+### Chores
+
+- **Scrub leaked deploy tokens + apply OSS-anonymization rule** ([#314](https://github.com/FootprintAI/Containarium/pull/314)) — closes a token leak from an earlier commit; the rule from #313 in force from here on.
+- **Dependencies**: bumps for `google.golang.org/api`, `grpc-gateway/v2`, `mcp-go`, `pgx/v5`, `cloud.google.com/go/compute`, and `docker/setup-buildx-action` ([#319](https://github.com/FootprintAI/Containarium/pull/319), [#327](https://github.com/FootprintAI/Containarium/pull/327), [#328](https://github.com/FootprintAI/Containarium/pull/328), [#329](https://github.com/FootprintAI/Containarium/pull/329), [#330](https://github.com/FootprintAI/Containarium/pull/330), [#332](https://github.com/FootprintAI/Containarium/pull/332)).
+
 ## [0.18.0] - 2026-05-22
 
 Ships the **zero-trust security audit remediation** — 46 PRs across 5 phases closing all 41 numbered findings from the internal audit ([`docs/security/ZERO-TRUST-AUDIT.md`](docs/security/ZERO-TRUST-AUDIT.md)). The headline shifts: every API surface is now authenticated by scope, every secret is decryptable through a pluggable KMS, every audit log row is in a tamper-evident hash chain, and every container-image pull is verified against the registry's published digest. Operators get a full runbook at [`docs/security/OPERATOR-SECURITY-RUNBOOK.md`](docs/security/OPERATOR-SECURITY-RUNBOOK.md).

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/ti-mo/conntrack v0.6.0
 	github.com/ti-mo/netfilter v0.5.3
 	go.opentelemetry.io/otel v1.43.0
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.42.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
@@ -93,7 +93,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 h1:Oyrsyzu
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0/go.mod h1:C2NGBr+kAB4bk3xtMXfZ94gqFDtg/GkI7e9zqGh5Beg=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
-go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.42.0 h1:H7O6RlGOMTizyl3R08Kn5pdM06bnH8oscSj7o11tmLA=
-go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.42.0/go.mod h1:mBFWu/WOVDkWWsR7Tx7h6EpQB8wsv7P0Yrh0Pb7othc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 h1:w1K+pCJoPpQifuVpsKamUdn9U0zM3xUziVOqsGksUrY=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0/go.mod h1:HBy4BjzgVE8139ieRI75oXm3EcDN+6GhD88JT1Kjvxg=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
 go.opentelemetry.io/otel/sdk v1.43.0 h1:pi5mE86i5rTeLXqoF/hhiBtUNcrAGHLKQdhg4h4V9Dg=
@@ -248,8 +248,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
-go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
-go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
+go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
+go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.18.0"
+	Version = "0.19.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary

- Bumps \`pkg/version/version.go\` to \`0.19.0\`
- Adds \`## [0.19.0]\` section to \`CHANGELOG.md\` covering 45 commits since v0.18.0

## What's in v0.19.0

**Headline**: agent-box reaches the CI surface — runner pool, compose-autostart end-to-end (Phases B–D), and the CLI/MCP surface (\`login\`, \`whoami\`, \`ssh setup\`, \`runner provision\`, compose-autostart tools).

**Plus** the trailing useradd-on-jumpserver fixes that closed cloud#163 (#320, #322, #335).

Full breakdown in the CHANGELOG diff.

## Release flow

After merge:
1. Tag v0.19.0 on the merged main HEAD
2. Push tag → release workflow builds & uploads binaries
3. Deploy v0.19.0 to prod host (replaces v0.18.1)
4. Retire \`release-0.18\` branch (no further cherry-picks)

## Test plan

- [ ] CI green on this branch
- [ ] After merge: tag pushes successfully; release workflow uploads all 10 assets
- [ ] \`./containarium-linux-amd64 version\` reports \`Containarium v0.19.0\`
- [ ] Prod host: post-deploy \`systemctl is-active containarium\` = active; daemon serves /v1/

🤖 Generated with [Claude Code](https://claude.com/claude-code)