### PR TITLE
fix(sentinel): enable tunnel-server when only --tunnel-token-policy is set (closes #337)

### DIFF
--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -108,12 +108,19 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 		defer gcpProvider.Close()
 		provider = gcpProvider
 
-		// Hybrid mode: GCP + tunnel if --tunnel-token is also provided
+		// Hybrid mode: GCP + tunnel if --tunnel-token OR
+		// --tunnel-token-policy is provided. Issue #337 — previously
+		// gated on --tunnel-token alone, which contradicted the
+		// --help text labeling --tunnel-token as "legacy; use
+		// --tunnel-token-policy for pool-restricted tokens." Operators
+		// following the documented rotation pattern (stage NEW via
+		// policy, drop legacy) silently lost the tunnel-server when
+		// they finished step 2.
 		tunnelToken := sentinelTunnelToken
 		if tunnelToken == "" {
 			tunnelToken = os.Getenv("CONTAINARIUM_TUNNEL_TOKEN")
 		}
-		if tunnelToken != "" {
+		if tunnelToken != "" || len(sentinelTunnelTokenPolicies) > 0 {
 			// Hybrid mode: GCP + tunnel on the same port 443 via ConnMux.
 			// The ConnMux peeks the first byte to route tunnel ({) vs HTTPS (0x16).
 			// HTTPS is proxied as raw TCP to the spot VM (Caddy handles TLS via SNI).
@@ -185,8 +192,12 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 		if tunnelToken == "" {
 			tunnelToken = os.Getenv("CONTAINARIUM_TUNNEL_TOKEN")
 		}
-		if tunnelToken == "" {
-			return fmt.Errorf("--tunnel-token or CONTAINARIUM_TUNNEL_TOKEN is required for tunnel provider")
+		// Issue #337 — accept --tunnel-token-policy as a sufficient
+		// enablement signal too. The --help text frames --tunnel-token
+		// as "legacy; use --tunnel-token-policy for pool-restricted
+		// tokens", so requiring both is a contradiction.
+		if tunnelToken == "" && len(sentinelTunnelTokenPolicies) == 0 {
+			return fmt.Errorf("--tunnel-token, --tunnel-token-policy, or CONTAINARIUM_TUNNEL_TOKEN is required for tunnel provider")
 		}
 		registry := sentinel.NewTunnelRegistry()
 		provider = sentinel.NewTunnelProvider(registry, "")


### PR DESCRIPTION
## Summary
Closes #337. Operator-reported silent-fail: with `--provider=gcp` (the default) and ONLY `--tunnel-token-policy` flags (no `--tunnel-token`), the hybrid-mode tunnel-server didn't start. The sentinel still listened, but no `[tunnel-server] spot ... authenticated` events fired.

## Root cause
Two gates keyed on `--tunnel-token` alone:
1. `provider=gcp` hybrid path: `if tunnelToken != ""` only entered hybrid mode when the legacy token was set. Policy-only silently skipped.
2. `provider=tunnel` path: hard-failed with "--tunnel-token … is required."

Both contradicted the `--help` text framing `--tunnel-token` as "legacy; use --tunnel-token-policy."

## Fix
Both gates now accept `--tunnel-token` OR `--tunnel-token-policy` (or `CONTAINARIUM_TUNNEL_TOKEN` env). `PolicyFromCLI("", []string{...})` already handles the policy-only case correctly — verified by existing `TestPolicyFromCLI`.

## Out of scope (mentioned in issue, deserve own issues)
- Loopback `127.0.0.x` aliases not cleaned on sentinel shutdown
- `[keysync]` / `[certsync]` 401s against v0.19.0 spots after the v0.18+ endpoint-auth tightening (#233)

## Validation
Rerun the #337 repro: drop `--tunnel-token` from the ExecStart, leave `--tunnel-token-policy` in place, restart. Expect `[tunnel-server] spot ... authenticated` within seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)