### PR TITLE
fix(sentinel): drain registry on shutdown to clean up loopback aliases (#337 follow-up)

### DIFF
--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -153,6 +153,12 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 			defer connMux.Close()
 
 			registry := sentinel.NewTunnelRegistry()
+			// Issue #337 §"Related observations" — drain the registry
+			// on shutdown so per-spot loopback aliases (127.0.0.x)
+			// get removed. Without this, restarting the sentinel
+			// inherits stale aliases that block fresh allocations
+			// and force a manual `ip addr del`.
+			defer registry.UnregisterAll()
 			tunnelPolicy, polErr := sentinel.PolicyFromCLI(tunnelToken, sentinelTunnelTokenPolicies)
 			if polErr != nil {
 				return polErr
@@ -200,6 +206,10 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("--tunnel-token, --tunnel-token-policy, or CONTAINARIUM_TUNNEL_TOKEN is required for tunnel provider")
 		}
 		registry := sentinel.NewTunnelRegistry()
+		// Issue #337 §"Related observations" — drain on shutdown so
+		// per-spot 127.0.0.x aliases get removed (else the next start
+		// inherits them and has to ip-addr-del them by hand).
+		defer registry.UnregisterAll()
 		provider = sentinel.NewTunnelProvider(registry, "")
 
 		config := sentinel.Config{

--- a/internal/sentinel/tunnel_registry.go
+++ b/internal/sentinel/tunnel_registry.go
@@ -112,6 +112,27 @@ func (r *TunnelRegistry) Register(hs *TunnelHandshake, session *yamux.Session) (
 	return localIP, nil
 }
 
+// UnregisterAll iterates every registered spot and unregisters it.
+// Used on sentinel shutdown so the loopback aliases (127.0.0.x)
+// don't persist into the next start. Without this, restarting the
+// sentinel can leave the previous run's aliases blocking fresh
+// allocations — operators had to `ip addr del` them by hand
+// (#337 §"Related observations").
+//
+// Safe to call concurrently with Register; takes the registry lock.
+// Each Unregister closes the yamux session and removes the alias.
+func (r *TunnelRegistry) UnregisterAll() {
+	r.mu.Lock()
+	ids := make([]string, 0, len(r.spots))
+	for id := range r.spots {
+		ids = append(ids, id)
+	}
+	r.mu.Unlock()
+	for _, id := range ids {
+		r.Unregister(id)
+	}
+}
+
 // Unregister removes a spot from the registry and cleans up its loopback alias.
 func (r *TunnelRegistry) Unregister(spotID string) {
 	r.mu.Lock()


### PR DESCRIPTION
## Summary
Companion to the just-merged #344 (which fixed the main #337 bug). Addresses #337's "Related observations" footnote: the sentinel doesn't clean up per-spot 127.0.0.x loopback aliases on shutdown — they persist across restarts and block fresh allocations, forcing operators to `ip addr del` by hand.

- New `TunnelRegistry.UnregisterAll()` — snapshots spot IDs under the lock, releases, iterates Unregister (which already closes the yamux session AND runs `ip addr del`). No deadlock; Unregister re-takes the lock per spot.
- `defer registry.UnregisterAll()` wired at both registry-creation sites in `cmd/sentinel.go` (`provider=gcp` hybrid + `provider=tunnel`). Runs on graceful exit AND ctx-cancel from SIGINT/SIGTERM.

## Sibling issue filed
#345 — sentinel `[keysync]`/`[certsync]` 401s against v0.19.0 spots from the v0.18+ endpoint-auth tightening (#233). Same "Related observations" section; needs a design call on the sentinel↔spot trust model. Filed separately so it doesn't block this PR.

## No PR test
`Unregister` calls `spot.Session.Close()` which panics on nil; a clean unit test needs real yamux setup — more weight than the 10-line function warrants. Mechanical change; existing single-spot Unregister already exercises `removeLoopbackAlias`.

**Validation plan**: start a sentinel, register one spot, SIGTERM, verify `ip addr show dev lo` doesn't show the 127.0.0.x alias afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)