### PR TITLE
fix(sentinel-hmac): per-cycle WARNING when secret unconfigured (#341 §1)

### DIFF
--- a/internal/auth/sentinel_hmac.go
+++ b/internal/auth/sentinel_hmac.go
@@ -5,8 +5,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
+	"sync/atomic"
 	"time"
 )
 
@@ -120,10 +122,16 @@ func VerifySentinelRequest(req *http.Request, secret []byte, now time.Time) erro
 // requests with 401 — fail-closed by default, no silent
 // passthrough. Operators must configure
 // CONTAINARIUM_SENTINEL_AUTH_SECRET to enable the wrapped endpoints.
+//
+// When unconfigured AND requests are actually arriving, a WARNING
+// is logged at most once per sentinelMisconfigLogInterval so the
+// daemon's journal shows the misconfiguration in real time during
+// an incident — the startup line alone is easy to miss (#341).
 func SentinelHMACMiddleware(secret []byte, next http.Handler) http.Handler {
 	configured := len(secret) >= SentinelMinSecretLen
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !configured {
+			logDaemonSentinelMisconfigOncePerInterval(r)
 			http.Error(w, `{"error":"sentinel auth not configured","code":401}`, http.StatusUnauthorized)
 			return
 		}
@@ -133,6 +141,24 @@ func SentinelHMACMiddleware(secret []byte, next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+const sentinelMisconfigLogInterval = 60 * time.Second
+
+// lastDaemonMisconfigLogNs tracks the most recent per-request
+// WARNING so the daemon doesn't spam the log every keysync cycle.
+var lastDaemonMisconfigLogNs atomic.Int64
+
+func logDaemonSentinelMisconfigOncePerInterval(r *http.Request) {
+	now := time.Now().UnixNano()
+	last := lastDaemonMisconfigLogNs.Load()
+	if last != 0 && now-last < int64(sentinelMisconfigLogInterval) {
+		return
+	}
+	if !lastDaemonMisconfigLogNs.CompareAndSwap(last, now) {
+		return
+	}
+	log.Printf("[sentinel-hmac] WARNING: sentinel-auth secret unconfigured but request received for %s %s — set CONTAINARIUM_SENTINEL_AUTH_SECRET on the daemon host; until then every sentinel keysync/certsync cycle is failing", r.Method, r.URL.Path)
 }
 
 func computeSentinelSignature(secret []byte, method, path, ts string) string {

--- a/internal/auth/sentinel_hmac_test.go
+++ b/internal/auth/sentinel_hmac_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"bytes"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -101,6 +103,63 @@ func TestMiddleware_FailsClosedWithoutSecret(t *testing.T) {
 	}
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("want 401, got %d", rec.Code)
+	}
+}
+
+// TestMiddleware_UnconfiguredLogsLoudly is the regression guard for
+// #341 §1: when the secret is missing and a request actually hits,
+// the daemon must emit a WARNING (not just at startup) so the
+// operator sees the misconfig in real-time log output during an
+// incident.
+func TestMiddleware_UnconfiguredLogsLoudly(t *testing.T) {
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	// Reset rate-limit so this test stands on its own.
+	lastDaemonMisconfigLogNs.Store(0)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	srv := SentinelHMACMiddleware(nil, next)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/authorized-keys", nil)
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", rec.Code)
+	}
+	if !strings.Contains(buf.String(), "sentinel-auth secret unconfigured") {
+		t.Fatalf("missing-secret middleware must log misconfig; got %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "/authorized-keys") {
+		t.Fatalf("log line should mention the request path; got %q", buf.String())
+	}
+}
+
+// TestMiddleware_UnconfiguredLogRateLimit guards against log-flood:
+// keysync hits every interval (often <1s), so without rate-limiting
+// the daemon would dump 100+ identical WARNING lines per minute.
+// The middleware logs at most once per minute — second invocation
+// in the same window must be silent.
+func TestMiddleware_UnconfiguredLogRateLimit(t *testing.T) {
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	lastDaemonMisconfigLogNs.Store(0)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	srv := SentinelHMACMiddleware(nil, next)
+
+	for i := 0; i < 5; i++ {
+		srv.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/certs", nil))
+	}
+
+	if got := strings.Count(buf.String(), "sentinel-auth secret unconfigured"); got != 1 {
+		t.Fatalf("want exactly 1 misconfig WARNING under rate-limit; got %d", got)
 	}
 }
 

--- a/internal/sentinel/sentinel_auth.go
+++ b/internal/sentinel/sentinel_auth.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/footprintai/containarium/internal/auth"
 )
@@ -20,28 +22,39 @@ import (
 // certsync) replace bare client.Get / client.Post with
 // client.Do(newSignedRequest(...)).
 //
-// The secret is read lazily on first request and cached for the
-// lifetime of the process. A missing or short secret is logged once
-// — the request is still issued (unsigned, will get 401 from the
-// daemon) so the operator sees clear keysync errors in the log
-// rather than silent breakage at a different layer.
+// The secret is loaded once and cached. A missing or short secret
+// triggers a per-call WARNING (rate-limited to once per
+// sentinelMisconfigLogInterval) so an operator tailing the journal
+// during an SSH-down incident sees the misconfiguration in real
+// time, not just in a startup line that may have scrolled away
+// (#341).
+
+const sentinelMisconfigLogInterval = 60 * time.Second
 
 var (
 	sentinelSecretOnce sync.Once
 	sentinelSecret     []byte
+	sentinelSecretOK   bool
+
+	// lastMisconfigLogNs is the unix-nanos of the last per-call
+	// WARNING. atomic.Int64 so concurrent keysync + certsync calls
+	// don't double-log every minute.
+	lastMisconfigLogNs atomic.Int64
 )
 
 func loadSentinelSecret() []byte {
 	sentinelSecretOnce.Do(func() {
 		raw := os.Getenv("CONTAINARIUM_SENTINEL_AUTH_SECRET")
-		if raw == "" {
+		switch {
+		case raw == "":
 			log.Printf("[sentinel-auth] WARNING: CONTAINARIUM_SENTINEL_AUTH_SECRET is unset; daemon sentinel endpoints will reject every request")
-			return
-		}
-		if len(raw) < auth.SentinelMinSecretLen {
+		case len(raw) < auth.SentinelMinSecretLen:
 			log.Printf("[sentinel-auth] WARNING: CONTAINARIUM_SENTINEL_AUTH_SECRET is %d bytes, want >=%d", len(raw), auth.SentinelMinSecretLen)
+			sentinelSecret = []byte(raw)
+		default:
+			sentinelSecret = []byte(raw)
+			sentinelSecretOK = true
 		}
-		sentinelSecret = []byte(raw)
 	})
 	return sentinelSecret
 }
@@ -49,6 +62,11 @@ func loadSentinelSecret() []byte {
 // newSignedRequest constructs an HTTP request signed with the
 // sentinel shared secret. `body` may be nil. Returns the same error
 // surface as http.NewRequest so callers can wrap with context.
+//
+// If the shared secret is missing or short, the request is built
+// anyway (it will 401 at the daemon) and a per-call WARNING is
+// emitted at most once per sentinelMisconfigLogInterval so the
+// operator sees the misconfig in current logs, not just at startup.
 func newSignedRequest(method, url string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
@@ -56,6 +74,20 @@ func newSignedRequest(method, url string, body io.Reader) (*http.Request, error)
 	}
 	if secret := loadSentinelSecret(); len(secret) >= auth.SentinelMinSecretLen {
 		auth.SignSentinelRequest(req, secret)
+	} else {
+		logSentinelMisconfigOncePerInterval()
 	}
 	return req, nil
+}
+
+func logSentinelMisconfigOncePerInterval() {
+	now := time.Now().UnixNano()
+	last := lastMisconfigLogNs.Load()
+	if last != 0 && now-last < int64(sentinelMisconfigLogInterval) {
+		return
+	}
+	if !lastMisconfigLogNs.CompareAndSwap(last, now) {
+		return
+	}
+	log.Printf("[sentinel-auth] WARNING: CONTAINARIUM_SENTINEL_AUTH_SECRET unconfigured; outbound sentinel→daemon requests will 401 (every keysync/certsync cycle is failing — fix the env var on this host)")
 }


### PR DESCRIPTION
## Summary
Addresses #341 §"Fail loudly on misconfiguration": when `CONTAINARIUM_SENTINEL_AUTH_SECRET` is missing, the daemon today returns 401 on every protected request without saying anything in its own log, and the sentinel just emits unsigned requests forever. Both sides log one WARNING at startup which scrolls out of journals within hours — by the time an operator opens an SSH-down incident, the only visible symptom is "keys are stale" with no obvious cause.

## Change

Both sides now emit a **rate-limited per-cycle WARNING** (once per 60s) when the secret is missing AND traffic is actually flowing:

- **Sentinel** (`internal/sentinel/sentinel_auth.go`): `newSignedRequest` logs every time it builds an outbound request with no signing material.
- **Daemon** (`internal/auth/sentinel_hmac.go`): `SentinelHMACMiddleware` logs every time it rejects an inbound request because the daemon-side secret is unconfigured. Includes method + path.

The 60s rate-limit prevents keysync flooding the log (it polls every few seconds) while still keeping a fresh signal in the journal at any incident moment.

## Why per-cycle log rather than "refuse to start"

#341 lists three options for fail-loud. Per-cycle log is the most operationally useful AND least disruptive: existing v0.18→v0.19 upgrades on hosts without the env don't brick on restart, but they CAN'T be silent anymore.

Deploy-script-level pre-check (acceptance criteria #3) belongs in deploy automation, not in the binary. Out of scope for this PR.

## Tests

Two new tests in `sentinel_hmac_test.go` (using `log.SetOutput(&buf)` + `t.Cleanup` to capture log output cleanly):

- `TestMiddleware_UnconfiguredLogsLoudly` — first unconfigured request emits the WARNING with method + path.
- `TestMiddleware_UnconfiguredLogRateLimit` — 5 rapid-fire requests emit exactly 1 log line.

## Related

- #341 — parent issue, §1
- #345 — companion sentinel keysync 401 trust-model issue
- v0.19.0 / #233 — original endpoint-auth tightening

🤖 Generated with [Claude Code](https://claude.com/claude-code)