### PR TITLE
fix(gateway): filter orphan authorized_keys at read time (#343)

### DIFF
--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -61,6 +61,12 @@ type GatewayServer struct {
 	// A-CRIT-4).
 	sentinelAuthSecret []byte
 
+	// containerExistsFn is the orphan filter used by
+	// /authorized-keys (#343). When set, the handler drops users
+	// whose container has been deleted but whose home dir survived.
+	// Wired from dual_server using the container manager.
+	containerExistsFn func(username string) bool
+
 	// Wake handler (for serverless / wake-on-HTTP, set externally).
 	// Mounted at /wake/ and at the root catch-all when the daemon's
 	// wake feature is enabled. NOT wrapped by the JWT auth middleware
@@ -154,6 +160,14 @@ func (gs *GatewayServer) SetRecordDeliveryFn(fn func(ctx context.Context, alertN
 // the daemon and the sentinel.
 func (gs *GatewayServer) SetSentinelAuthSecret(secret []byte) {
 	gs.sentinelAuthSecret = secret
+}
+
+// SetContainerExistsFn wires the orphan filter for /authorized-keys.
+// When set, sentinel keysync responses exclude entries whose container
+// has been deleted — preventing the #343 "auth accepted, then
+// disconnected" symptom.
+func (gs *GatewayServer) SetContainerExistsFn(fn func(username string) bool) {
+	gs.containerExistsFn = fn
 }
 
 // SetBackendsHandler sets the handler for the /v1/backends endpoint.
@@ -620,7 +634,7 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 	// Fail-closed: if the secret isn't configured, all requests get
 	// 401. See findings A-CRIT-4 and A-HIGH-2.
 	httpMux.Handle("/certs", auth.SentinelHMACMiddleware(gs.sentinelAuthSecret, ServeCerts(gs.caddyCertDir)))
-	httpMux.Handle("/authorized-keys", auth.SentinelHMACMiddleware(gs.sentinelAuthSecret, ServeAuthorizedKeys()))
+	httpMux.Handle("/authorized-keys", auth.SentinelHMACMiddleware(gs.sentinelAuthSecret, ServeAuthorizedKeys("", gs.containerExistsFn)))
 	httpMux.Handle("/authorized-keys/sentinel", auth.SentinelHMACMiddleware(gs.sentinelAuthSecret, ServeSentinelKey()))
 
 	// Catch-all fallback: when wake-on-HTTP is enabled, Caddy

--- a/internal/gateway/keys_handler.go
+++ b/internal/gateway/keys_handler.go
@@ -26,19 +26,34 @@ type SentinelKeyRequest struct {
 	PublicKey string `json:"public_key"`
 }
 
-// ServeAuthorizedKeys returns an HTTP handler that walks /home/*/.ssh/authorized_keys
-// and returns all users' authorized keys as JSON. This allows the sentinel to sync
-// SSH keys for sshpiper configuration.
-func ServeAuthorizedKeys() http.HandlerFunc {
+// ServeAuthorizedKeys returns an HTTP handler that walks
+// homeRoot/*/.ssh/authorized_keys and returns each user's authorized keys
+// as JSON for the sentinel to sync into sshpiper.
+//
+// homeRoot defaults to "/home" when empty (allows tests to inject a
+// tmp dir).
+//
+// containerExistsFn is the orphan filter for #343: when non-nil, each
+// candidate username is checked against the live container registry,
+// and entries whose container is missing are dropped from the response
+// AND logged as `WARNING orphan ...`. This prevents sshpiper from
+// accepting keys for tenants whose container has been deleted (the
+// resulting "Container <name>-container not found" inside the SSH
+// session was the user-facing symptom in #343). Pass nil to disable
+// the filter (back-compat / tests).
+func ServeAuthorizedKeys(homeRoot string, containerExistsFn func(username string) bool) http.HandlerFunc {
+	if homeRoot == "" {
+		homeRoot = "/home"
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
 			return
 		}
 
-		entries, err := os.ReadDir("/home")
+		entries, err := os.ReadDir(homeRoot)
 		if err != nil {
-			log.Printf("[keys] failed to read /home: %v", err)
+			log.Printf("[keys] failed to read %s: %v", homeRoot, err)
 			http.Error(w, `{"error":"failed to read home directories"}`, http.StatusInternalServerError)
 			return
 		}
@@ -49,13 +64,21 @@ func ServeAuthorizedKeys() http.HandlerFunc {
 				continue
 			}
 			username := entry.Name()
-			akPath := filepath.Join("/home", username, ".ssh", "authorized_keys")
+			akPath := filepath.Join(homeRoot, username, ".ssh", "authorized_keys")
+			// akPath is built from os.ReadDir output (entry.Name() has
+			// no path separators) joined with a fixed suffix — caller
+			// can't inject a traversal.
+			// #nosec G304 -- safe path construction (see above)
 			data, err := os.ReadFile(akPath)
 			if err != nil {
 				continue // no authorized_keys file, skip
 			}
 			content := strings.TrimSpace(string(data))
 			if content == "" {
+				continue
+			}
+			if containerExistsFn != nil && !containerExistsFn(username) {
+				log.Printf("[keys] WARNING: orphan authorized_keys for %q — no live container; skipping (run `containarium delete %s` or `userdel -r %s` to clean up)", username, username, username)
 				continue
 			}
 			keys = append(keys, UserKeys{
@@ -65,7 +88,7 @@ func ServeAuthorizedKeys() http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(KeysResponse{Keys: keys})
+		_ = json.NewEncoder(w).Encode(KeysResponse{Keys: keys})
 	}
 }
 

--- a/internal/gateway/keys_handler_test.go
+++ b/internal/gateway/keys_handler_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestServeAuthorizedKeys_Empty(t *testing.T) {
 	// The handler reads from /home which we can't override, so test the response structure
-	handler := ServeAuthorizedKeys()
+	handler := ServeAuthorizedKeys("", nil)
 	req := httptest.NewRequest(http.MethodGet, "/authorized-keys", nil)
 	rr := httptest.NewRecorder()
 
@@ -33,8 +33,67 @@ func TestServeAuthorizedKeys_Empty(t *testing.T) {
 	t.Logf("got %d keys from /home", len(resp.Keys))
 }
 
+// TestServeAuthorizedKeys_OrphanFiltered is the regression guard for
+// #343: when a tenant container has been deleted but the host user +
+// authorized_keys file survive (userdel failure, manual provisioning,
+// etc.), the keys endpoint must NOT return the orphan — otherwise
+// sshpiper accepts the client's key and the relay later fails inside
+// the SSH session with "Container X not found".
+func TestServeAuthorizedKeys_OrphanFiltered(t *testing.T) {
+	tmpHome := t.TempDir()
+	mkUser(t, tmpHome, "alice", "ssh-ed25519 AAAA_alice alice@laptop\n")
+	mkUser(t, tmpHome, "orphan", "ssh-ed25519 AAAA_orphan orphan@old\n")
+
+	// Filter says alice's container exists, orphan's does not.
+	exists := func(username string) bool { return username == "alice" }
+
+	handler := ServeAuthorizedKeys(tmpHome, exists)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/authorized-keys", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp KeysResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Keys) != 1 {
+		t.Fatalf("expected exactly 1 entry (alice only), got %d", len(resp.Keys))
+	}
+	if resp.Keys[0].Username != "alice" {
+		t.Errorf("expected alice, got %s", resp.Keys[0].Username)
+	}
+}
+
+// TestServeAuthorizedKeys_NilFilterIncludesAll asserts the back-compat
+// path — when containerExistsFn is nil, every user in homeRoot is
+// returned (matches the pre-#343 behavior so the orphan filter is
+// strictly opt-in at the wiring layer).
+func TestServeAuthorizedKeys_NilFilterIncludesAll(t *testing.T) {
+	tmpHome := t.TempDir()
+	mkUser(t, tmpHome, "alice", "ssh-ed25519 AAAA_alice alice@laptop\n")
+	mkUser(t, tmpHome, "bob", "ssh-ed25519 AAAA_bob bob@laptop\n")
+
+	handler := ServeAuthorizedKeys(tmpHome, nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/authorized-keys", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var resp KeysResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Keys) != 2 {
+		t.Fatalf("expected 2 entries (no filter), got %d", len(resp.Keys))
+	}
+}
+
 func TestServeAuthorizedKeys_MethodNotAllowed(t *testing.T) {
-	handler := ServeAuthorizedKeys()
+	handler := ServeAuthorizedKeys("", nil)
 	req := httptest.NewRequest(http.MethodPost, "/authorized-keys", nil)
 	rr := httptest.NewRecorder()
 

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1039,6 +1039,21 @@ skipAppHosting:
 			log.Printf("WARNING: CONTAINARIUM_SENTINEL_AUTH_SECRET is unset — /certs, /authorized-keys, /authorized-keys/sentinel will return 401 until configured")
 		}
 
+		// Orphan filter for /authorized-keys (#343). When a container
+		// is deleted but its host user / home dir survives (userdel
+		// failed under lock contention, or the user was provisioned
+		// outside the normal flow), the keys endpoint used to return
+		// the stale entry — sshpiper would accept the client's key
+		// and then the relay would fail with "Container X not found"
+		// inside the SSH session. Filtering at read time drops those
+		// entries AND logs a per-orphan WARNING so operators can clean
+		// up.
+		if mgr := containerServer.GetManager(); mgr != nil {
+			gatewayServer.SetContainerExistsFn(func(username string) bool {
+				return mgr.ContainerExists(username + "-container")
+			})
+		}
+
 		// Wire security store for CSV export
 		if securityStore != nil {
 			gatewayServer.SetSecurityStore(securityStore)


### PR DESCRIPTION
## Summary
Addresses #343: `/authorized-keys` used to return entries for tenant usernames whose container had been deleted. sshpiper wrote those into its config → accepted the client's key → upstream relay failed mid-session with `Container <name>-container not found`. No signal at any layer that the entry was an orphan.

## Change

Read-time filter on `/authorized-keys`:

- `ServeAuthorizedKeys(homeRoot, containerExistsFn)` — new signature. Defaults preserve old behavior (`""` → `/home`, `nil` → no filter / all users).
- When `containerExistsFn(username)` returns false, the entry is dropped AND a `WARNING orphan ...` is logged with the exact cleanup command (`containarium delete X` / `userdel -r X`) so operators can drain orphans actively.
- `GatewayServer.SetContainerExistsFn` wires the filter; the daemon's `dual_server.go` binds it to `manager.ContainerExists(username + "-container")`.

## Why read-time over prune-on-delete

#343 lists prune-on-delete / filter-at-read / both. Prune already happens (`DeleteJumpServerAccount` → `userdel -r`), but the #335-era investigation showed that path can fail silently under lock contention or when the user was provisioned outside the normal flow — exactly the orphan scenario. Filter-at-read is the defense-in-depth that catches all such cases regardless of source.

Bonus: the filter also drops system accounts like `ubuntu`/operator accounts from sshpiper's tenant config — those were always returned today and were never valid sshpiper upstreams anyway.

## Tests

- `TestServeAuthorizedKeys_OrphanFiltered` — orphan dropped, live entry kept.
- `TestServeAuthorizedKeys_NilFilterIncludesAll` — back-compat guard.
- Existing tests updated to the new signature (`("", nil)`).

## Related

- #343 — parent issue
- #341 / #347 — companion sentinel-HMAC loud-misconfig fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)