### PR TITLE
fix(sentinel): stable per-backend loopback octets across reconnect (#342)

### DIFF
--- a/internal/sentinel/tunnel_registry.go
+++ b/internal/sentinel/tunnel_registry.go
@@ -2,6 +2,7 @@ package sentinel
 
 import (
 	"fmt"
+	"hash/fnv"
 	"log"
 	"net"
 	"os/exec"
@@ -39,7 +40,6 @@ type TunnelSpot struct {
 type TunnelRegistry struct {
 	mu      sync.RWMutex
 	spots   map[string]*TunnelSpot
-	nextIP  byte // next octet for 127.0.0.X (starts at 2)
 	usedIPs map[byte]string // octet -> spotID
 }
 
@@ -47,7 +47,6 @@ type TunnelRegistry struct {
 func NewTunnelRegistry() *TunnelRegistry {
 	return &TunnelRegistry{
 		spots:   make(map[string]*TunnelSpot),
-		nextIP:  2,
 		usedIPs: make(map[byte]string),
 	}
 }
@@ -227,23 +226,45 @@ func (r *TunnelRegistry) Spots() []*TunnelSpot {
 	return result
 }
 
+// allocateOctet picks the 127.0.0.X octet for spotID. The slot is
+// derived deterministically from a hash of spotID so a backend that
+// disconnects and reconnects (e.g., after a network blip, sshpiper
+// reload, or sentinel restart) lands on the same loopback alias
+// across the lifetime of the registry — keysync's sshpiper config
+// stays valid through churn, and "ss -tlnp" output matches the
+// config without operator confusion (#342).
+//
+// When the preferred slot is occupied by a *different* spotID, we
+// linear-probe forward to the next free slot. This keeps the
+// existing capacity (127.0.0.2..127.0.0.254 = 253 slots) and only
+// drifts under genuine contention. Two backends with the same hash
+// land in adjacent slots; the first one keeps the preferred slot,
+// the second pays one extra probe.
 func (r *TunnelRegistry) allocateOctet(spotID string) (byte, error) {
-	// Try from nextIP up to 254
+	preferred := preferredOctet(spotID)
 	for i := byte(0); i < 253; i++ {
-		candidate := r.nextIP + i
-		if candidate > 254 {
-			candidate = candidate - 253 + 2 // wrap around
+		// step through the 2..254 range starting from `preferred`,
+		// wrapping if we run off the top.
+		candidate := preferred + i
+		if candidate < 2 || candidate > 254 {
+			candidate = byte(2 + (int(preferred)+int(i)-2)%253)
 		}
 		if _, used := r.usedIPs[candidate]; !used {
 			r.usedIPs[candidate] = spotID
-			r.nextIP = candidate + 1
-			if r.nextIP > 254 {
-				r.nextIP = 2
-			}
 			return candidate, nil
 		}
 	}
 	return 0, fmt.Errorf("no available loopback addresses (all 127.0.0.2-254 in use)")
+}
+
+// preferredOctet maps a spotID to a deterministic octet in [2, 254].
+// FNV-1a is a non-cryptographic hash — collision resistance is
+// irrelevant here because we linear-probe on collision. We just want
+// a uniform spread so independent spotIDs don't pile up at slot 2.
+func preferredOctet(spotID string) byte {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(spotID))
+	return byte(2 + (h.Sum32() % 253))
 }
 
 // addLoopbackAlias adds an IP alias to the loopback interface.

--- a/internal/sentinel/tunnel_registry_alloc_test.go
+++ b/internal/sentinel/tunnel_registry_alloc_test.go
@@ -1,0 +1,112 @@
+package sentinel
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestPreferredOctet_Deterministic asserts the hash → slot mapping is
+// stable across calls. The whole point of #342 is that a spot that
+// disconnects and reconnects lands on the same loopback alias; that
+// requires preferredOctet(id) to be a pure function of id.
+func TestPreferredOctet_Deterministic(t *testing.T) {
+	ids := []string{"spot-1", "spot-2", "tunnel-vm-alpha", "x"}
+	for _, id := range ids {
+		first := preferredOctet(id)
+		for i := 0; i < 100; i++ {
+			if got := preferredOctet(id); got != first {
+				t.Fatalf("preferredOctet(%q) is non-deterministic: first=%d, again=%d", id, first, got)
+			}
+		}
+		if first < 2 || first > 254 {
+			t.Fatalf("preferredOctet(%q)=%d, want in [2, 254]", id, first)
+		}
+	}
+}
+
+// TestAllocateOctet_StableAcrossReconnect simulates the #342 scenario:
+// a backend registers, fully unregisters (clearing usedIPs), and then
+// reconnects. The new allocation must land on the same octet.
+func TestAllocateOctet_StableAcrossReconnect(t *testing.T) {
+	r := NewTunnelRegistry()
+	first, err := r.allocateOctet("spot-A")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate full unregister: drop the usedIPs entry.
+	delete(r.usedIPs, first)
+
+	second, err := r.allocateOctet("spot-A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second != first {
+		t.Fatalf("reconnect drift: first allocation = %d, post-disconnect reconnect = %d (want stable)", first, second)
+	}
+}
+
+// TestAllocateOctet_NoDriftAcrossSequentialDisconnects guards against
+// the original allocator bug — `nextIP` advanced monotonically, so
+// 100 disconnect/reconnect cycles produced 100 different IPs even
+// though only one was ever in use. With hashed allocation the slot
+// should never change.
+func TestAllocateOctet_NoDriftAcrossSequentialDisconnects(t *testing.T) {
+	r := NewTunnelRegistry()
+	const id = "spot-stable"
+
+	first, err := r.allocateOctet(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 50; i++ {
+		delete(r.usedIPs, first)
+		got, err := r.allocateOctet(id)
+		if err != nil {
+			t.Fatalf("cycle %d: %v", i, err)
+		}
+		if got != first {
+			t.Fatalf("cycle %d: drift from %d to %d", i, first, got)
+		}
+	}
+}
+
+// TestAllocateOctet_CollisionLinearProbes confirms the fallback path:
+// when two distinct spotIDs hash to the same preferred slot, the
+// second one falls forward to the next free octet. We can't easily
+// force a hash collision against an arbitrary id, so we instead
+// pre-occupy a spot's preferred slot and confirm it lands elsewhere.
+func TestAllocateOctet_CollisionLinearProbes(t *testing.T) {
+	r := NewTunnelRegistry()
+	const id = "spot-collide"
+	pref := preferredOctet(id)
+
+	// Occupy the preferred slot with someone else.
+	r.usedIPs[pref] = "squatter"
+
+	got, err := r.allocateOctet(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == pref {
+		t.Fatalf("expected fallback away from occupied preferred slot %d, got %d", pref, got)
+	}
+	if got < 2 || got > 254 {
+		t.Fatalf("allocation out of range: %d", got)
+	}
+}
+
+// TestAllocateOctet_FullExhausted asserts the error path — once
+// every slot is claimed, allocateOctet returns an error rather than
+// looping forever or returning a bogus octet.
+func TestAllocateOctet_FullExhausted(t *testing.T) {
+	r := NewTunnelRegistry()
+	for o := 2; o <= 254; o++ {
+		r.usedIPs[byte(o)] = fmt.Sprintf("filler-%d", o)
+	}
+	_, err := r.allocateOctet("late-arrival")
+	if err == nil {
+		t.Fatal("expected error when all slots are occupied")
+	}
+}


### PR DESCRIPTION
## Summary
Addresses #342: the prior `allocateOctet` advanced an internal `nextIP` cursor monotonically and never rewound it on Unregister. A single backend that bounced (sshpiper restart, sentinel restart, tunnel disconnect) landed on a *different* `127.0.0.X` each time even though only one alias was ever in use. Operators chasing an SSH-down incident saw mismatched addresses in `ss -tlnp` vs the sshpiper config and wasted time chasing the wrong layer.

Closes the third of three "Related observations" sub-bugs the user filed today (alongside #341 → #347 and #343 → #348).

## Change

`allocateOctet(spotID)` now derives a deterministic preferred slot from `fnv32a(spotID) mod 253 + 2`, linear-probes forward on collision, and the `nextIP` cursor is gone.

Properties:

- A backend that bounces re-registers at the **same octet**. sshpiper config doesn't churn; next keysync is a no-op.
- Independent backends are spread uniformly across 127.0.0.2..254.
- Distinct backends with a hash collision linear-probe forward — capacity unchanged at 253 slots.
- Original "all slots used" error preserved.

## Why FNV-1a

Non-security path; just want uniform spread. Collision resistance is irrelevant because linear probe handles it. FNV-1a is in the stdlib (`hash/fnv`), one-line setup.

## Tests (in a new file — `tunnel_registry_alloc_test.go`)

The pure `allocateOctet` is now testable without `ip addr` shell-outs:

- `TestPreferredOctet_Deterministic`
- `TestAllocateOctet_StableAcrossReconnect` — the regression guard
- `TestAllocateOctet_NoDriftAcrossSequentialDisconnects` — 50 cycles, no drift
- `TestAllocateOctet_CollisionLinearProbes`
- `TestAllocateOctet_FullExhausted`

## Related

- #342 — parent issue
- #346 — loopback-cleanup-on-shutdown sibling (already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)