### PR TITLE
fix(jump-server): gate google-guest-agent / pwd-lock dance on GCP-only hosts (closes #351)

### DIFF
--- a/pkg/core/container/host_class.go
+++ b/pkg/core/container/host_class.go
@@ -1,0 +1,80 @@
+package container
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// Host-class detection for environment-specific code paths in
+// jump_server.go and friends.
+//
+// Background: the useradd preconditions (`systemctl stop google-guest-
+// agent`, force-removing `/etc/.pwd.lock`) were written for GCP VMs,
+// where `google-guest-agent` races with local `useradd` over the
+// passwd lock. On any non-GCP host (a VirtualBox lab spot, an on-prem
+// box, AWS, Azure, …) those steps are at best no-ops with misleading
+// "Access denied" stderr, and at worst actively harmful (force-removing
+// a lock file held by something else). Issue #351.
+//
+// Hosts don't change class at runtime, so we cache the answer behind
+// sync.Once. The detector is a package var so tests can swap in a
+// deterministic stub without shelling out to `systemd-detect-virt`.
+
+var (
+	hostClassOnce   sync.Once
+	hostClassResult hostClass
+
+	// hostClassDetector returns the detected hostClass. Real impl
+	// runs `systemd-detect-virt`; tests can replace.
+	hostClassDetector func() hostClass = detectHostClassViaSystemd
+)
+
+// hostClass identifies the platform a host runs on, for the small
+// number of places (useradd preconditions) that need to behave
+// differently per-platform. Keep this enum tight — we don't want a
+// proliferation of platform-specific branches.
+type hostClass int
+
+const (
+	hostClassUnknown hostClass = iota
+	hostClassGCP
+)
+
+// getHostClass returns the detected host class, computing it on the
+// first call and caching for the lifetime of the process.
+func getHostClass() hostClass {
+	hostClassOnce.Do(func() {
+		hostClassResult = hostClassDetector()
+	})
+	return hostClassResult
+}
+
+// isGCPHost reports whether this daemon is running on a GCP VM.
+// Use it to gate code that talks to GCP-specific services
+// (google-guest-agent, OS Login, the metadata server's user feed).
+func isGCPHost() bool {
+	return getHostClass() == hostClassGCP
+}
+
+// detectHostClassViaSystemd asks systemd-detect-virt what we're on.
+// On GCP that returns "gcp"; KVM/AWS/Azure return their own strings;
+// VirtualBox returns "oracle"; bare metal returns "none". Anything
+// other than "gcp" is treated as "not GCP" — we can extend the enum
+// if other platforms grow their own special-cased code paths.
+//
+// systemd-detect-virt is in systemd-tools / systemd-container / the
+// base systemd package on every host we currently support. If it's
+// missing (very old / minimal containers), we treat that as unknown
+// rather than crashing — the gated code paths fall back to
+// generic behavior, which is the safe default.
+func detectHostClassViaSystemd() hostClass {
+	out, err := exec.Command("systemd-detect-virt").Output()
+	if err != nil {
+		return hostClassUnknown
+	}
+	if strings.TrimSpace(string(out)) == "gcp" {
+		return hostClassGCP
+	}
+	return hostClassUnknown
+}

--- a/pkg/core/container/host_class_test.go
+++ b/pkg/core/container/host_class_test.go
@@ -1,0 +1,76 @@
+package container
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestHostClassDetection covers the gating contract for the
+// jump-server's GCP-specific code paths (issue #351). The actual
+// useradd/systemctl calls in retryUseraddWithLockWait need root and
+// a real host, so we test what we CAN cheaply test: that isGCPHost
+// returns the detector's verdict and that the detector is replaceable
+// for callers that want deterministic behavior in tests.
+func TestHostClassDetection(t *testing.T) {
+	t.Run("isGCPHost returns true when detector reports GCP", func(t *testing.T) {
+		withStubDetector(t, func() hostClass { return hostClassGCP })
+		if !isGCPHost() {
+			t.Errorf("isGCPHost() = false, want true (detector returned hostClassGCP)")
+		}
+	})
+
+	t.Run("isGCPHost returns false when detector reports unknown", func(t *testing.T) {
+		withStubDetector(t, func() hostClass { return hostClassUnknown })
+		if isGCPHost() {
+			t.Errorf("isGCPHost() = true, want false (detector returned hostClassUnknown)")
+		}
+	})
+
+	t.Run("detector is invoked exactly once per process", func(t *testing.T) {
+		calls := 0
+		withStubDetector(t, func() hostClass {
+			calls++
+			return hostClassGCP
+		})
+
+		// Hammer it from a few goroutines too — sync.Once should
+		// still let exactly one detector call through.
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_ = isGCPHost()
+			}()
+		}
+		wg.Wait()
+		_ = isGCPHost()
+
+		if calls != 1 {
+			t.Errorf("detector called %d times, want 1 (sync.Once should cache)", calls)
+		}
+	})
+}
+
+// withStubDetector swaps the package-level hostClassDetector for the
+// duration of a sub-test and clears the sync.Once / cached result so
+// the next isGCPHost() call re-invokes the stub. On cleanup the
+// detector is restored to its real implementation and the Once is
+// reset again — any subsequent caller in the same process will
+// re-detect against the real host. Note: sync.Once contains a
+// noCopy field so it isn't safe to value-copy; we reset to a fresh
+// zero-value instead of saving/restoring the previous Once.
+func withStubDetector(t *testing.T, stub func() hostClass) {
+	t.Helper()
+	prevDetector := hostClassDetector
+
+	hostClassDetector = stub
+	hostClassOnce = sync.Once{}
+	hostClassResult = hostClassUnknown
+
+	t.Cleanup(func() {
+		hostClassDetector = prevDetector
+		hostClassOnce = sync.Once{}
+		hostClassResult = hostClassUnknown
+	})
+}

--- a/pkg/core/container/jump_server.go
+++ b/pkg/core/container/jump_server.go
@@ -782,6 +782,10 @@ func retryUseraddWithLockWait(username string, verbose bool) error {
 		// flock -w 30 ensures we wait up to 30 seconds to acquire the lock
 		fmt.Printf("       Creating user %s (with flock)...\n", username)
 		shell := getUserShell()
+		// #nosec G204 -- `username` is validated by isValidUsername at the
+		// CreateJumpServerAccount entry point (alphanumeric, dash, underscore
+		// only). `shell` is a fixed-path constant from getUserShell(). No
+		// untrusted input reaches the subprocess invocation.
 		cmd := exec.Command("flock", "-w", "30", "/var/lock/containarium-useradd.lock",
 			"useradd", username,
 			"-s", shell, // nologin (ProxyJump) or containarium-shell (exec into container)

--- a/pkg/core/container/jump_server.go
+++ b/pkg/core/container/jump_server.go
@@ -418,8 +418,18 @@ func ensureProxyOnlyShell(username string, verbose bool) error {
 	return nil
 }
 
-// waitForLocksAndRun stops google-guest-agent, executes the function, then restarts it
+// waitForLocksAndRun stops google-guest-agent, executes the function, then restarts it.
+// On non-GCP hosts the stop/start sequence is meaningless (google-guest-agent
+// doesn't exist) and produces misleading errors, so we just run fn directly.
+// Issue #351.
 func waitForLocksAndRun(fn func() error, verbose bool) error {
+	if !isGCPHost() {
+		if verbose {
+			fmt.Printf("       Skipping google-guest-agent dance: host is not a GCP VM\n")
+		}
+		return fn()
+	}
+
 	if verbose {
 		fmt.Printf("       Temporarily stopping google-guest-agent...\n")
 	}
@@ -650,69 +660,82 @@ func retryUseraddWithLockWait(username string, verbose bool) error {
 
 	const maxRetries = 10 // Bumped from 5 (cloud #163). Combined with the new exponential backoff below, total ceiling is ~6min vs the old 10s — gives stale passwd locks enough room to clear or be force-removed.
 
-	fmt.Printf("       Temporarily stopping google-guest-agent to avoid race condition...\n")
-
-	// Stop google-guest-agent
-	cmd := exec.Command("systemctl", "stop", "google-guest-agent")
-	if output, err := cmd.CombinedOutput(); err != nil {
-		fmt.Printf("       Warning: Failed to stop google-guest-agent: %v\n%s\n", err, output)
-		fmt.Printf("       Proceeding anyway...\n")
-	} else {
-		fmt.Printf("       ✓ google-guest-agent stopped\n")
-	}
-
-	// Kill any remaining google processes that might be holding locks
-	killGoogleProcesses(verbose)
-
-	// Ensure we restart it when done
-	defer func() {
-		fmt.Printf("       Restarting google-guest-agent...\n")
-		cmd := exec.Command("systemctl", "start", "google-guest-agent")
-		if output, err := cmd.CombinedOutput(); err != nil {
-			fmt.Printf("       Warning: Failed to restart google-guest-agent: %v\n%s\n", err, output)
-		} else {
-			fmt.Printf("       ✓ google-guest-agent restarted\n")
-		}
-	}()
-
-	// Wait for the agent to fully stop and release locks
-	fmt.Printf("       Waiting for agent to stop and release locks...\n")
-	time.Sleep(2 * time.Second)
-
-	// Check if agent actually stopped
-	checkCmd := exec.Command("systemctl", "is-active", "google-guest-agent")
-	if statusOutput, _ := checkCmd.CombinedOutput(); len(statusOutput) > 0 {
-		fmt.Printf("       Agent status after stop: %s\n", strings.TrimSpace(string(statusOutput)))
-	}
-
-	// Wait for lock files to clear (up to 10 seconds)
+	// Pre-useradd dance: stop google-guest-agent, wait for the
+	// passwd lock to clear, force-remove if stuck. This is GCP-VM
+	// specific — google-guest-agent races with local useradd over
+	// /etc/.pwd.lock via OS Login. On a non-GCP backend (VirtualBox
+	// lab spot, on-prem, AWS/Azure, …) the service doesn't exist
+	// and the lockfile is held by something else legitimately;
+	// running this dance just produces misleading "Access denied"
+	// stderr and force-removes a lock we shouldn't touch. Issue
+	// #351 — gate it on host-class detection.
 	lockFiles := []string{"/etc/passwd.lock", "/etc/shadow.lock", "/etc/.pwd.lock", "/etc/group.lock"}
-	locksClear := false
-	for attempt := 0; attempt < 10; attempt++ {
-		allClear := true
-		for _, lockFile := range lockFiles {
-			if _, err := os.Stat(lockFile); err == nil {
-				allClear = false
-				if attempt == 0 {
-					fmt.Printf("       Waiting for lock file to clear: %s\n", lockFile)
+	if isGCPHost() {
+		fmt.Printf("       Temporarily stopping google-guest-agent to avoid race condition...\n")
+
+		// Stop google-guest-agent
+		cmd := exec.Command("systemctl", "stop", "google-guest-agent")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			fmt.Printf("       Warning: Failed to stop google-guest-agent: %v\n%s\n", err, output)
+			fmt.Printf("       Proceeding anyway...\n")
+		} else {
+			fmt.Printf("       ✓ google-guest-agent stopped\n")
+		}
+
+		// Kill any remaining google processes that might be holding locks
+		killGoogleProcesses(verbose)
+
+		// Ensure we restart it when done
+		defer func() {
+			fmt.Printf("       Restarting google-guest-agent...\n")
+			cmd := exec.Command("systemctl", "start", "google-guest-agent")
+			if output, err := cmd.CombinedOutput(); err != nil {
+				fmt.Printf("       Warning: Failed to restart google-guest-agent: %v\n%s\n", err, output)
+			} else {
+				fmt.Printf("       ✓ google-guest-agent restarted\n")
+			}
+		}()
+
+		// Wait for the agent to fully stop and release locks
+		fmt.Printf("       Waiting for agent to stop and release locks...\n")
+		time.Sleep(2 * time.Second)
+
+		// Check if agent actually stopped
+		checkCmd := exec.Command("systemctl", "is-active", "google-guest-agent")
+		if statusOutput, _ := checkCmd.CombinedOutput(); len(statusOutput) > 0 {
+			fmt.Printf("       Agent status after stop: %s\n", strings.TrimSpace(string(statusOutput)))
+		}
+
+		// Wait for lock files to clear (up to 10 seconds)
+		locksClear := false
+		for attempt := 0; attempt < 10; attempt++ {
+			allClear := true
+			for _, lockFile := range lockFiles {
+				if _, err := os.Stat(lockFile); err == nil {
+					allClear = false
+					if attempt == 0 {
+						fmt.Printf("       Waiting for lock file to clear: %s\n", lockFile)
+					}
+					break
 				}
+			}
+			if allClear {
+				locksClear = true
 				break
 			}
+			time.Sleep(1 * time.Second)
 		}
-		if allClear {
-			locksClear = true
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
 
-	if !locksClear {
-		fmt.Printf("       Warning: Lock files still present after waiting, forcing removal...\n")
-		// Since we stopped google-guest-agent, any remaining lock files are stale
-		// Forcibly remove them regardless of age
-		forceRemoveLockFiles(lockFiles, verbose)
-	} else {
-		fmt.Printf("       ✓ All lock files cleared\n")
+		if !locksClear {
+			fmt.Printf("       Warning: Lock files still present after waiting, forcing removal...\n")
+			// Since we stopped google-guest-agent, any remaining lock files are stale
+			// Forcibly remove them regardless of age
+			forceRemoveLockFiles(lockFiles, verbose)
+		} else {
+			fmt.Printf("       ✓ All lock files cleared\n")
+		}
+	} else if verbose {
+		fmt.Printf("       Skipping google-guest-agent / pwd-lock dance: host is not a GCP VM\n")
 	}
 
 	// Retry useradd with flock for serialization
@@ -759,7 +782,7 @@ func retryUseraddWithLockWait(username string, verbose bool) error {
 		// flock -w 30 ensures we wait up to 30 seconds to acquire the lock
 		fmt.Printf("       Creating user %s (with flock)...\n", username)
 		shell := getUserShell()
-		cmd = exec.Command("flock", "-w", "30", "/var/lock/containarium-useradd.lock",
+		cmd := exec.Command("flock", "-w", "30", "/var/lock/containarium-useradd.lock",
 			"useradd", username,
 			"-s", shell, // nologin (ProxyJump) or containarium-shell (exec into container)
 			"-m",                      // Create home directory


### PR DESCRIPTION
## Summary

Closes #351 — the jump-server's useradd precondition sequence (`systemctl stop google-guest-agent`, force-remove \`/etc/.pwd.lock\`, useradd, restart agent) was hardcoded for GCP VMs. On non-GCP backends it runs anyway, producing misleading "Access denied" stderr and force-removing a lockfile that's held legitimately by something else. End-to-end this blocks every \`containarium create\` that lands on a lab / on-prem / non-GCP backend.

## Approach

Host class is a process-level property — detect once, gate forever.

- **\`pkg/core/container/host_class.go\`** (new): \`isGCPHost()\` backed by \`systemd-detect-virt\`, cached behind \`sync.Once\`. The detector is a package-level var so tests can stub.
- **\`pkg/core/container/jump_server.go\`**:
  - \`retryUseraddWithLockWait\`: the entire stop/start google-guest-agent + clear-pwd-lock block is now wrapped in \`if isGCPHost()\`. Non-GCP hosts skip straight to the generic \`flock + useradd\` retry loop.
  - \`waitForLocksAndRun\`: same gate.
- **\`pkg/core/container/host_class_test.go\`** (new): asserts the gating contract — stubbed detector flows through \`isGCPHost\`, and \`sync.Once\` caches across goroutines.

The fail-fast on \`Permission denied\` (#322) and serialize/backoff/lock-cleanup (#335) keep working untouched — they layer on top of the gate. The diff is concentrated; no behavior change for GCP-VM deploys.

## Repro
[FootprintAI/Argus#26485542817](https://github.com/FootprintAI/Argus/actions/runs/26485542817) — Argus CI workflow targets the \`containarium-lab\` runner, which lands on a VirtualBox-backed lab spot. Daemon is root with full caps, but useradd kept failing because the precondition layer wedged the host. Re-running with v0.19.2 still fails for the same reason. After this PR the lab pool can host CI boxes cleanly.

## Tests

\`\`\`
=== RUN   TestHostClassDetection
=== RUN   TestHostClassDetection/isGCPHost_returns_true_when_detector_reports_GCP
=== RUN   TestHostClassDetection/isGCPHost_returns_false_when_detector_reports_unknown
=== RUN   TestHostClassDetection/detector_is_invoked_exactly_once_per_process
--- PASS: TestHostClassDetection (0.00s)
\`\`\`

\`go test ./pkg/core/container/\` passes; \`go vet ./pkg/core/container/\` clean.

The actual useradd path needs root + a real host to exercise meaningfully, so the unit test covers the gate's contract; the end-to-end validation will be the lab-spot CI succeeding once this lands and v0.19.3 deploys.

## Notes

- Stretch option I considered: define an enum of host classes (GCP / AWS / Azure / bare metal / …) so other code paths could grow per-platform branches. Kept it as \`hostClassGCP | hostClassUnknown\` for now — we don't need the others yet, and \`bool\` is a one-way door if we do.
- \`systemd-detect-virt\` is in the base systemd package on every host we currently support. Falling back to \`hostClassUnknown\` when it's missing means non-GCP behavior, which is the safe default.

## Test plan

- [ ] CI green
- [ ] After merge: cut v0.19.3, redeploy to fleet, re-run [FootprintAI/Argus#26485542817](https://github.com/FootprintAI/Argus/actions/runs/26485542817) — box-create on the lab spot succeeds
- [ ] Existing GCP-VM deploys keep behaving identically (the gated block is byte-equivalent on GCP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)