### PR TITLE
chore: cut v0.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3] - 2026-05-27
+
+Patch release fixing CI box creation on non-GCP backends.
+
+### Fixed
+
+- **jump-server: gate google-guest-agent / pwd-lock dance on GCP-only hosts** ([#351](https://github.com/FootprintAI/Containarium/issues/351) / [#352](https://github.com/FootprintAI/Containarium/pull/352)). The useradd precondition sequence — `systemctl stop google-guest-agent`, wait for `/etc/.pwd.lock` to clear, force-remove if stuck — was hardcoded for GCP VMs (where `google-guest-agent` races with local `useradd` via OS Login). On any non-GCP backend (VirtualBox lab spot, on-prem, AWS, Azure, …) the service doesn't exist; running the dance produced misleading "Access denied" stderr and force-removed lockfiles held legitimately by other processes, blocking every `containarium create` that landed on that backend.
+
+  Fix: new `isGCPHost()` (backed by `systemd-detect-virt`, cached behind `sync.Once`) gates both `retryUseraddWithLockWait` and `waitForLocksAndRun`. Non-GCP hosts skip straight to the generic `flock + useradd` retry loop; GCP-VM deploys are byte-equivalent to v0.19.2. v0.19.2's "lacks privilege" final-error stops being misleading on non-GCP hosts — if useradd still fails after this, it's a real permission problem.
+
 ## [0.19.2] - 2026-05-27
 
 Patch release covering the sentinel-side incident-response footguns shaken out during today's investigation: a silent tunnel-server enablement bug, three loopback / authorized-keys observability gaps that turned routine reconnects into hours-long operator drilling sessions, and the sentinel↔daemon HMAC misconfig that 401s every keysync without warning.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.19.2"
+	Version = "0.19.3"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary

Patch release on top of v0.19.2 containing just #352 — gates the GCP-VM-specific google-guest-agent / pwd-lock dance behind a host-class check so non-GCP backends can host CI boxes (closes #351).

Drop-in replacement for v0.19.2. GCP-VM deploys are byte-equivalent — the gated code path runs identically when `systemd-detect-virt` returns `gcp`.

## Test plan

- [ ] CI green
- [ ] After merge: tag v0.19.3; release workflow uploads all 10 assets; `./containarium-linux-amd64 version` reports `Containarium v0.19.3`
- [ ] Deploy to fleet; re-run [FootprintAI/Argus#26485542817](https://github.com/FootprintAI/Argus/actions/runs/26485542817) — lab-spot box-create succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)