### PR TITLE
fix(wake): stamp _system identity on wake-on-HTTP start call

### DIFF
--- a/internal/wake/proxy.go
+++ b/internal/wake/proxy.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/footprintai/containarium/internal/app"
+	"github.com/footprintai/containarium/internal/auth"
 )
 
 // WakeStarter starts a container and blocks until its primary route
@@ -172,7 +173,15 @@ func (w *WakeProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if leader {
 		// Leader: run the actual wake on a derived context so
 		// followers' cancellations don't abort the whole group.
-		ctx, cancel := context.WithTimeout(context.Background(), w.waitTimeout)
+		//
+		// Wake is a daemon-internal action: the inbound request that
+		// triggered it may be unauthenticated (a public route, a health
+		// probe), but StartContainer is authz-gated (RequireScope +
+		// AuthorizeTenant). Stamp the _system identity so the wake call
+		// passes those gates — the same pattern the autosleep ticker
+		// and peer forwarders use. Without it, every wake fails with
+		// "no authenticated subject in request context".
+		ctx, cancel := context.WithTimeout(auth.ContextWithSystemIdentity(context.Background()), w.waitTimeout)
 		ready, ip, port, werr := w.starter.WakeForRequest(ctx, username)
 		cancel()
 		if werr != nil {

--- a/internal/wake/proxy_test.go
+++ b/internal/wake/proxy_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/footprintai/containarium/internal/app"
+	"github.com/footprintai/containarium/internal/auth"
 )
 
 // fakeStarter satisfies WakeStarter for tests.
@@ -101,6 +102,75 @@ func TestWakeProxy_HappyPath(t *testing.T) {
 	}
 	if got := rec.Body.String(); got != "hello from container" {
 		t.Errorf("body: got %q, want %q", got, "hello from container")
+	}
+}
+
+// subjectCapturingStarter records the context it was invoked with so
+// the test can assert what identity the wake proxy stamps before
+// calling into the authz-gated StartContainer.
+type subjectCapturingStarter struct {
+	ready  bool
+	ip     string
+	port   int
+	gotCtx context.Context
+}
+
+func (s *subjectCapturingStarter) WakeForRequest(ctx context.Context, username string) (bool, string, int, error) {
+	s.gotCtx = ctx
+	return s.ready, s.ip, s.port, nil
+}
+
+// TestWakeProxy_StarterReceivesSystemIdentity is a regression test for
+// the wake-on-HTTP auth bug. The proxy used to invoke the starter with
+// a bare context.Background(), so StartContainer's RequireScope /
+// AuthorizeTenant gate rejected every wake with "no authenticated
+// subject in request context" — wake-on-HTTP could never succeed.
+// Wake is a daemon-internal action, so the proxy must stamp the
+// _system identity. If someone reverts to context.Background(), the
+// subject lookup below fails and this test catches it.
+func TestWakeProxy_StarterReceivesSystemIdentity(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	host, portStr, err := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split host/port: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("port parse: %v", err)
+	}
+
+	const fullDomain = "alice-web.example.test"
+	starter := &subjectCapturingStarter{ready: true, ip: host, port: port}
+
+	proxy := NewWakeProxy(
+		starter,
+		&fakeLookup{fullDomain: fullDomain, containerName: "alice-container", targetIP: host, targetPort: port},
+		&fakeRouteStore{},
+		nil,
+		nil,
+		5*time.Second,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "http://"+fullDomain+"/", nil)
+	req.Host = fullDomain
+	proxy.ServeHTTP(httptest.NewRecorder(), req)
+
+	if starter.gotCtx == nil {
+		t.Fatal("starter was never invoked")
+	}
+	username, roles, ok := auth.SubjectFromGRPCContext(starter.gotCtx)
+	if !ok {
+		t.Fatal("wake context carries no authenticated subject — StartContainer's authz gate would reject this wake")
+	}
+	if username != auth.SystemSubject {
+		t.Errorf("subject: got %q, want %q", username, auth.SystemSubject)
+	}
+	if !auth.HasRole(roles, auth.RoleAdmin) {
+		t.Errorf("roles: got %v, want to include %q", roles, auth.RoleAdmin)
 	}
 }
 


### PR DESCRIPTION
## Summary

Wake-on-HTTP could never start a sleeping container. The wake leader invoked the starter with a bare `context.Background()`, so the downstream `StartContainer` authz gates (`RequireScope` + `AuthorizeTenant`) rejected every wake with `Unauthenticated: no authenticated subject in request context`. Any request routed to a scaled-down container returned `503 wake: start: ...` instead of waking it.

Wake is a daemon-internal action triggered by an inbound request that may itself be unauthenticated (a public route, a health probe). The fix stamps the `_system` identity (admin role, no scope restriction) onto the wake context before calling the starter — the same `auth.ContextWithSystemIdentity` pattern already used by the autosleep ticker and peer forwarders.

- `internal/wake/proxy.go`: wrap the wake context with `auth.ContextWithSystemIdentity(context.Background())`.
- `internal/wake/proxy_test.go`: add `TestWakeProxy_StarterReceivesSystemIdentity`, asserting the starter receives a context whose subject is `_system` with the admin role.

The bug was introduced when wake-on-HTTP (scale-down Phase 3) landed — the `ContextWithSystemIdentity` wiring was simply missed for this code path.

## Test plan

- [x] `go vet ./internal/wake/...` — clean
- [x] `go test ./internal/wake/...` — all pass
- [x] Confirmed the regression test catches the bug: reverting to `context.Background()` fails the new test at the subject assertion; the fix makes it pass
- [ ] Verify on a backend: a request to a scaled-down container's route wakes it (returns the upstream response) rather than `503 wake: start: ... no authenticated subject`

🤖 Generated with [Claude Code](https://claude.com/claude-code)