### PR TITLE
docs(ssh): fix off-by-one citations in broker design

### DIFF
--- a/docs/SSH-CONNECT-BROKER-DESIGN.md
+++ b/docs/SSH-CONNECT-BROKER-DESIGN.md
@@ -15,10 +15,10 @@ The CLI already authenticates against the cloud:
 
 - `containarium login` runs an OAuth-style device flow and
   stores a bearer token in `~/.containarium/credentials.json`
-  (`internal/cmd/login.go:76`).
+  (`internal/cmd/login.go:75`).
 - `containarium ssh setup` generates or finds a local SSH key,
   uploads the **public** half to the cloud, registers it under
-  a friendly name (`internal/cmd/ssh.go:85`).
+  a friendly name (`internal/cmd/ssh.go:84`).
 - `containarium ssh propagate` pushes the registered key-set to
   every box the user owns (`internal/cmd/ssh.go:152`).
 - `containarium ssh-config sync` writes a self-contained


### PR DESCRIPTION
## Summary

Two of the three cited code anchors in §"Where we are today" of \`docs/SSH-CONNECT-BROKER-DESIGN.md\` point at the blank line *after* the actual \`var ...Cmd = &cobra.Command{\` declaration:

| Cited | Actual \`var ...Cmd = ...\` |
|---|---|
| \`internal/cmd/login.go:76\` | \`internal/cmd/login.go:75\` |
| \`internal/cmd/ssh.go:85\` | \`internal/cmd/ssh.go:84\` |
| \`internal/cmd/ssh.go:152\` | unchanged (was already correct) |

Spotted while verifying citations against current main after the telemetry / recipes / jump-server commits churned line numbers in this area. All path-only references in the doc still resolve cleanly.

No design changes — pure citation hygiene.

## Test plan

- [ ] \`grep -n "var loginCmd\\|var sshSetupCmd\\|var sshPropagateCmd" internal/cmd/login.go internal/cmd/ssh.go\` confirms the new line numbers
- [ ] Sanity-check the doc renders the same in markdown viewers (\`gh pr diff\` is a 2-line change, low risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)