### PR TITLE
ci(distros): broaden push trigger to integration/** branches

### DIFF
--- a/.github/workflows/distros-go-ci.yml
+++ b/.github/workflows/distros-go-ci.yml
@@ -1,16 +1,22 @@
 name: CI — Go distro
 
 # Symmetric with distros-py-ci.yml: run the Go distro's test suite on
-# PRs that touch it and on every push to main. The Go distro ships
-# inside the main go.mod (D13), so this workflow is narrower than the
-# top-level Go build — just the distro's own packages.
+# PRs that touch it and on every push to main OR an integration/**
+# branch. Per the team's PR-target rule we stage changes on integration
+# branches before promoting to main — validating the integration HEAD
+# before promotion catches regressions at the same point the old
+# "push to main" trigger did. The Go distro ships inside the main
+# go.mod (D13), so this workflow is narrower than the top-level Go
+# build — just the distro's own packages.
 on:
   pull_request:
     paths:
       - 'distros/go/**'
       - '.github/workflows/distros-go-ci.yml'
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'integration/**'
     paths:
       - 'distros/go/**'
       - '.github/workflows/distros-go-ci.yml'

--- a/.github/workflows/distros-py-ci.yml
+++ b/.github/workflows/distros-py-ci.yml
@@ -1,15 +1,20 @@
 name: CI — Python distro
 
 # Run the distro test suite on PRs that touch it, and on every push to
-# main. Keeps the release workflow honest: when the v* tag fires, the
-# code on main has already passed CI.
+# main OR an integration/** branch. Per the team's PR-target rule we
+# stage changes on integration branches before promoting to main —
+# validating the integration HEAD before promotion catches regressions
+# at the same point the old "push to main" trigger did. The pull_request
+# trigger has no `branches:` filter so it fires on PRs against any base.
 on:
   pull_request:
     paths:
       - 'distros/py/**'
       - '.github/workflows/distros-py-ci.yml'
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'integration/**'
     paths:
       - 'distros/py/**'
       - '.github/workflows/distros-py-ci.yml'


### PR DESCRIPTION
## Summary

Fixes the gap we hit on PR #360 (the SSH broker doc citation cleanup): the Python and Go distro CI workflows currently only fire their **push** trigger on \`main\`, but per the team's PR-target rule we stage changes on \`integration/**\` branches first and promote to main as a separate step.

This PR adds \`integration/**\` alongside \`main\` in the push branch list for both workflows. The push trigger now covers the post-merge state of integration branches — same regression-catching point the old "push to main" trigger gave us, just at the integration HEAD instead of main HEAD.

The pull_request trigger already fires on PRs against any base (no \`branches:\` filter), so topic-branch PRs into \`integration/**\` keep getting CI at PR time. That side is unaffected.

## Why this exists

PR #360 is a 2-line doc citation fix, base=\`integration/docs-cleanup\`. It triggered **zero** workflows: every workflow on the repo has \`pull_request: branches: [main]\` (security, proxyproto) or path filters that the doc-only change didn't match (distro CI). Without this PR, every future topic-PR against an integration branch in the distros area has the same blind-spot at integration-branch HEAD.

## Test plan

- [ ] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/distros-py-ci.yml'))\"\` parses cleanly
- [ ] same for distros-go-ci.yml
- [ ] After this lands on integration/docs-cleanup → main, push a no-op change under distros/py/ to an integration branch and confirm the workflow fires
- [ ] No path-filter or matrix changes — Python 3.9-3.12 matrix and Go test job are unchanged

## Out of scope

- Broader fix for security.yml / proxyproto-e2e.yml — both have \`pull_request: branches: [main]\` which means PRs against integration branches get no security signal either. Separate call about whether the heavier scans should run on every integration-branch PR or stay main-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)