### PR TITLE
fix(wake): 404 instead of futile start for container-less routes

### DIFF
--- a/internal/wake/proxy.go
+++ b/internal/wake/proxy.go
@@ -158,6 +158,16 @@ func (w *WakeProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	containerName := route.ContainerName
+	// A resolved route with no container is not wake-eligible. The
+	// platform's own apex / base-domain routes carry an empty
+	// ContainerName; without this guard the starter is invoked with an
+	// empty username and StartContainer rejects it with a confusing
+	// "username is required" 503. A 404 matches the no-route case and
+	// is what an unmatched path on a container-less host should get.
+	if containerName == "" {
+		http.Error(rw, "wake: no matching route", http.StatusNotFound)
+		return
+	}
 	username := strings.TrimSuffix(containerName, "-container")
 
 	// Coalesce concurrent wakes for the same container.

--- a/internal/wake/proxy_test.go
+++ b/internal/wake/proxy_test.go
@@ -174,6 +174,38 @@ func TestWakeProxy_StarterReceivesSystemIdentity(t *testing.T) {
 	}
 }
 
+// TestWakeProxy_EmptyContainerNameRoute returns 404 (not a futile
+// wake) when the resolved route has no container. The platform's
+// apex / base-domain routes have an empty ContainerName; calling the
+// starter with the resulting empty username only yields a confusing
+// "username is required" 503, so the proxy should treat it as a
+// no-match instead.
+func TestWakeProxy_EmptyContainerNameRoute(t *testing.T) {
+	const fullDomain = "apex.example.test"
+	starter := &subjectCapturingStarter{ready: true}
+
+	proxy := NewWakeProxy(
+		starter,
+		&fakeLookup{fullDomain: fullDomain, containerName: ""},
+		&fakeRouteStore{},
+		nil,
+		nil,
+		5*time.Second,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "http://"+fullDomain+"/healthz", nil)
+	req.Host = fullDomain
+	rec := httptest.NewRecorder()
+	proxy.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%q", rec.Code, rec.Body.String())
+	}
+	if starter.gotCtx != nil {
+		t.Error("starter must not be invoked for a container-less route")
+	}
+}
+
 // TestWakeProxy_NotFound returns 404 when the Host header doesn't
 // match any route.
 func TestWakeProxy_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #357. The wake proxy is mounted as the gateway's catch-all `/` handler, so any path not matched by a specific handler resolves the incoming `Host` to a route and tries to wake its container. The platform's own apex / base-domain routes carry an **empty `ContainerName`**, so the starter was called with an empty username and `StartContainer` rejected it with a confusing `503 wake: start: username is required`.

This surfaced when probing `/healthz` on the apex — `/healthz` isn't a registered route (the real health endpoint is `/health`, which returns `200`), so it fell through to the wake catch-all and hit a container-less apex route.

**Guard:** a resolved route with an empty `ContainerName` is not wake-eligible — return `404 "no matching route"` (matching the no-route case) instead of invoking the starter. Real tenant subdomains have a container and are unaffected.

No production impact was at stake (GLB health checks already probe `/health`); this just turns a misleading `503` into a correct `404` for apex / container-less hosts.

## Test plan

- [x] `go vet ./internal/wake/` clean; full `internal/wake` suite passes
- [x] New `TestWakeProxy_EmptyContainerNameRoute`: empty-container route returns `404` and the starter is **not** invoked
- [x] Existing wake tests (incl. #357's `TestWakeProxy_StarterReceivesSystemIdentity`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)