### PR TITLE
feat(create): --git-source — daemon fetches repo into the box at create time

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -5035,6 +5035,22 @@
         "pool": {
           "type": "string",
           "title": "Pool selector — when set and backend_id is empty, the daemon\npicks any healthy peer tagged with this pool"
+        },
+        "gitSource": {
+          "type": "string",
+          "description": "Git source provisioning — when git_source is set, the daemon\nfetches the repo into the box's workspace at create time (via\nincus exec, no caller→box SSH). Removes the caller's need to\npush code in over rsync/scp. See\nprd/oss/create-git-source.md (Containarium-cloud).\n\ngit_source: clone URL, e.g. \"https://github.com/org/repo\"."
+        },
+        "gitRef": {
+          "type": "string",
+          "description": "git_ref: the exact ref to check out — full SHA (preferred,\nreproducible), branch, tag, or a server ref like\n\"refs/pull/\u003cn\u003e/merge\". Empty = the remote's default branch."
+        },
+        "gitCredential": {
+          "type": "string",
+          "description": "git_credential: bearer token for private repos. Used daemon-side\nfor a single fetch (injected as an ephemeral http.extraHeader)\nand never written to the box's .git/config. Empty = public repo."
+        },
+        "workspacePath": {
+          "type": "string",
+          "description": "workspace_path: where in the box to place the source. Empty\ndefaults to \"/workspace\"."
         }
       },
       "title": "CreateContainerRequest is the request to create a new container"

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/internal/mtls"
+	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -143,7 +143,7 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 }
 
 // CreateContainer creates a container via gRPC
-func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string) (*incus.ContainerInfo, error) {
+func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute) // Container creation can take time (includes ultra-aggressive retry logic for google_guest_agent)
 	defer cancel()
 
@@ -154,15 +154,19 @@ func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, 
 			Memory: memory,
 			Disk:   disk,
 		},
-		SshKeys:      sshKeys,
-		Image:        image,
-		EnablePodman: enablePodman,
-		Stack:        stack,
-		Gpu:          gpu,
-		OsType:       osType,
-		Monitoring:   monitoring,
-		Pool:         pool,
-		BackendId:    backendID,
+		SshKeys:       sshKeys,
+		Image:         image,
+		EnablePodman:  enablePodman,
+		Stack:         stack,
+		Gpu:           gpu,
+		OsType:        osType,
+		Monitoring:    monitoring,
+		Pool:          pool,
+		BackendId:     backendID,
+		GitSource:     git.Source,
+		GitRef:        git.Ref,
+		GitCredential: git.Credential,
+		WorkspacePath: git.WorkspacePath,
 	}
 
 	resp, err := c.client.CreateContainer(ctx, req)

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -214,7 +214,18 @@ func (c *HTTPClient) ListContainers() ([]incus.ContainerInfo, error) {
 }
 
 // CreateContainer creates a container via HTTP
-func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string) (*incus.ContainerInfo, error) {
+// GitSourceOpts carries the optional create-time git provisioning
+// parameters. Zero value (Source == "") means "no git source" and the
+// daemon skips provisioning. Kept as a struct so CreateContainer's
+// already-long signature doesn't grow four more positional strings.
+type GitSourceOpts struct {
+	Source        string // clone URL; empty disables git provisioning
+	Ref           string // SHA / branch / tag / refs/pull/N/merge; empty = default branch
+	Credential    string // bearer token for private repos
+	WorkspacePath string // empty defaults to /workspace
+}
+
+func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
@@ -234,6 +245,12 @@ func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, 
 		"monitoring":   monitoring,
 		"pool":         pool,
 		"backendId":    backendID,
+	}
+	if git.Source != "" {
+		reqBody["gitSource"] = git.Source
+		reqBody["gitRef"] = git.Ref
+		reqBody["gitCredential"] = git.Credential
+		reqBody["workspacePath"] = git.WorkspacePath
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/containers", reqBody)

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -16,22 +16,26 @@ import (
 )
 
 var (
-	sshKeyPath     string
-	cpuLimit       string
-	memoryLimit    string
-	diskLimit      string
-	staticIP       string
-	containerImage string
-	enablePodman   bool
-	labels         []string
-	forceRecreate  bool
-	stackID        string
-	gpuDevice      string
-	osTypeStr      string
-	monitoring     bool
-	createPool     string
+	sshKeyPath               string
+	cpuLimit                 string
+	memoryLimit              string
+	diskLimit                string
+	staticIP                 string
+	containerImage           string
+	enablePodman             bool
+	labels                   []string
+	forceRecreate            bool
+	stackID                  string
+	gpuDevice                string
+	osTypeStr                string
+	monitoring               bool
+	createPool               string
 	createBackendID          string
 	createAutoRestartCompose string
+	createGitSource          string
+	createGitRef             string
+	createGitCredentialFile  string
+	createWorkspacePath      string
 )
 
 var createCmd = &cobra.Command{
@@ -96,6 +100,10 @@ func init() {
 			"create. Requires --server (the daemon's ComposeAutostartService "+
 			"backs the call). Best-effort — a failure to enable autostart "+
 			"surfaces a warning but does NOT fail the overall create.")
+	createCmd.Flags().StringVar(&createGitSource, "git-source", "", "Git clone URL to provision into the box's workspace at create time (e.g. https://github.com/org/repo). The daemon fetches it via incus exec — no SSH back to the box. Empty = no source provisioning.")
+	createCmd.Flags().StringVar(&createGitRef, "git-ref", "", "Exact ref to check out for --git-source: full SHA (preferred), branch, tag, or refs/pull/N/merge. Empty = the remote's default branch.")
+	createCmd.Flags().StringVar(&createGitCredentialFile, "git-credential-file", "", "Path to a file holding a bearer token for a private --git-source. Used daemon-side for one fetch; never written to the box's .git/config.")
+	createCmd.Flags().StringVar(&createWorkspacePath, "workspace-path", "", "Where --git-source lands inside the box. Empty defaults to /workspace.")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -179,7 +187,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 			_, err = httpClient.GetContainer(username)
 			containerExists = (err == nil)
 		} else if serverAddr != "" {
-			// Remote mode via gRPC 
+			// Remote mode via gRPC
 			grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 			if err != nil {
 				return fmt.Errorf("failed to connect to remote server: %w", err)
@@ -214,7 +222,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 					return fmt.Errorf("failed to delete existing container: %w", err)
 				}
 			} else if serverAddr != "" {
-				// Remote mode via gRPC 
+				// Remote mode via gRPC
 				grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 				if err != nil {
 					return fmt.Errorf("failed to connect to remote server: %w", err)
@@ -264,15 +272,22 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	// Parse OS type from flag
 	osType := ostype.OSTypeFromString(osTypeStr)
 
+	// Resolve optional git-source provisioning from flags (reads the
+	// credential file if one was given). Empty Source = no-op.
+	gitOpts, err := resolveGitSourceOpts()
+	if err != nil {
+		return err
+	}
+
 	if httpMode && serverAddr != "" {
 		// Remote mode via HTTP
-		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID)
+		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts)
 		if err != nil {
 			return fmt.Errorf("failed to create container via HTTP API: %w", err)
 		}
 	} else if serverAddr != "" {
 		// Remote mode via gRPC
-		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID)
+		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts)
 		if err != nil {
 			return fmt.Errorf("failed to create container via remote server: %w", err)
 		}
@@ -281,7 +296,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		if verbose {
 			fmt.Println("Creating container...")
 		}
-		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevice, osType, monitoring)
+		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevice, osType, monitoring, gitOpts)
 		if err != nil {
 			// Cleanup jump server account on failure
 			_ = container.DeleteJumpServerAccount(username, false)
@@ -392,8 +407,30 @@ func enableAutoRestartCompose(username, dir string) error {
 	return nil
 }
 
+// resolveGitSourceOpts builds the git-source options from the create
+// flags, reading the credential file if one was supplied. Returns the
+// zero value (Source == "") when --git-source wasn't set.
+func resolveGitSourceOpts() (client.GitSourceOpts, error) {
+	if createGitSource == "" {
+		return client.GitSourceOpts{}, nil
+	}
+	opts := client.GitSourceOpts{
+		Source:        createGitSource,
+		Ref:           createGitRef,
+		WorkspacePath: createWorkspacePath,
+	}
+	if createGitCredentialFile != "" {
+		data, err := os.ReadFile(createGitCredentialFile)
+		if err != nil {
+			return client.GitSourceOpts{}, fmt.Errorf("failed to read --git-credential-file: %w", err)
+		}
+		opts.Credential = strings.TrimSpace(string(data))
+	}
+	return opts, nil
+}
+
 // createLocal creates a container using local Incus daemon
-func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool) (*incus.ContainerInfo, error) {
+func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, git client.GitSourceOpts) (*incus.ContainerInfo, error) {
 	mgr, err := container.New()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
@@ -416,6 +453,10 @@ func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []
 		Stack:                  stack,
 		OSType:                 osType,
 		Monitoring:             monitoring,
+		GitSource:              git.Source,
+		GitRef:                 git.Ref,
+		GitCredential:          git.Credential,
+		WorkspacePath:          git.WorkspacePath,
 	}
 
 	return mgr.Create(opts)
@@ -438,23 +479,23 @@ func parseLabels(labelSlice []string) map[string]string {
 }
 
 // createRemote creates a container using remote gRPC server
-func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string) (*incus.ContainerInfo, error) {
+func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts) (*incus.ContainerInfo, error) {
 	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
 		return nil, err
 	}
 	defer grpcClient.Close()
 
-	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID)
+	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git)
 }
 
 // createRemoteHTTP creates a container using remote HTTP API
-func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string) (*incus.ContainerInfo, error) {
+func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts) (*incus.ContainerInfo, error) {
 	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
 	if err != nil {
 		return nil, err
 	}
 	defer httpClient.Close()
 
-	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID)
+	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git)
 }

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -420,6 +420,8 @@ func resolveGitSourceOpts() (client.GitSourceOpts, error) {
 		WorkspacePath: createWorkspacePath,
 	}
 	if createGitCredentialFile != "" {
+		// #nosec G304 -- operator-supplied path; reading it is the documented
+		// purpose of --git-credential-file (same trust as reading an SSH key file).
 		data, err := os.ReadFile(createGitCredentialFile)
 		if err != nil {
 			return client.GitSourceOpts{}, fmt.Errorf("failed to read --git-credential-file: %w", err)

--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -20,15 +20,15 @@ import (
 // Flags for `containarium runner provision`. Kept as package-level
 // vars to match the pattern in create.go / delete.go / list.go.
 var (
-	runnerRepo           string
-	runnerPAT            string
-	runnerCount          int
-	runnerNamePrefix     string
-	runnerLabels         string
-	runnerNameTemplate   string
-	runnerSSHKeyPath     string
-	runnerSentinelHost   string
-	runnerSSHUser        string
+	runnerRepo         string
+	runnerPAT          string
+	runnerCount        int
+	runnerNamePrefix   string
+	runnerLabels       string
+	runnerNameTemplate string
+	runnerSSHKeyPath   string
+	runnerSentinelHost string
+	runnerSSHUser      string
 
 	// runner list / remove
 	runnerListFormat string
@@ -377,9 +377,10 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 				"",   // stack
 				"",   // gpu
 				ostype.OSTypeFromString("ubuntu"),
-				false, // monitoring
-				"",    // pool
-				"",    // backend-id
+				false,                  // monitoring
+				"",                     // pool
+				"",                     // backend-id
+				client.GitSourceOpts{}, // no git-source for runner boxes
 			)
 			if err != nil {
 				return "", err
@@ -413,6 +414,7 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 			false,
 			"",
 			"",
+			client.GitSourceOpts{}, // no git-source for runner boxes
 		)
 		if err != nil {
 			return "", err

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -1663,7 +1663,7 @@ func (s *ContainerServer) GetSystemInfo(ctx context.Context, req *pb.GetSystemIn
 		KernelVersion:        serverInfo.Environment.KernelVersion,
 		ContainersRunning:    running,
 		ContainersStopped:    stopped,
-		ContainersTotal:      int32(len(containers)),
+		ContainersTotal:      int32(len(containers)), // #nosec G115 -- container count cannot overflow int32
 		Hostname:             serverInfo.Environment.ServerName,
 		NetworkCidr:          networkCIDR,
 		TotalCpus:            sysResources.TotalCPUs,

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -14,10 +14,10 @@ import (
 	"github.com/footprintai/containarium/internal/alert"
 	"github.com/footprintai/containarium/internal/app"
 	"github.com/footprintai/containarium/internal/auth"
-	"github.com/footprintai/containarium/internal/secrets"
-	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/guacamole"
+	"github.com/footprintai/containarium/internal/secrets"
+	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/pkg/core/ostype"
 	"github.com/footprintai/containarium/pkg/core/stacks"
@@ -47,43 +47,43 @@ type ContainerServer struct {
 	pendingCreations    map[string]*PendingCreation
 	pendingMu           sync.RWMutex
 	// Monitoring URLs (set by DualServer after setup)
-	victoriaMetricsURL  string
-	grafanaURL          string
+	victoriaMetricsURL string
+	grafanaURL         string
 	// Alerting (set by DualServer after setup)
-	alertStore           *alert.Store
-	alertManager         *alert.Manager
-	alertDeliveryStore   *alert.DeliveryStore
-	alertWebhookURL      string
-	alertWebhookSecret   string
-	hostRelayURL         string // e.g. "http://10.100.0.1:8080/internal/alert-relay"
-	alertRelayConfigFn   func(webhookURL, secret string) // callback to update gateway relay config
-	coreServices         *CoreServices
-	daemonConfigStore    *app.DaemonConfigStore
-	peerPool             *PeerPool
+	alertStore         *alert.Store
+	alertManager       *alert.Manager
+	alertDeliveryStore *alert.DeliveryStore
+	alertWebhookURL    string
+	alertWebhookSecret string
+	hostRelayURL       string                          // e.g. "http://10.100.0.1:8080/internal/alert-relay"
+	alertRelayConfigFn func(webhookURL, secret string) // callback to update gateway relay config
+	coreServices       *CoreServices
+	daemonConfigStore  *app.DaemonConfigStore
+	peerPool           *PeerPool
 	// Route / Caddy cleanup deps (set by DualServer wiring, may be nil if
 	// the daemon was started without --app-hosting). Used by DeleteContainer
 	// to cascade-remove the routes / TLS-automation subjects a container
 	// owned, so deleting an LXC actually deletes the public hostname too.
-	routeStore           routeLister
-	proxyManager         *app.ProxyManager
+	routeStore   routeLister
+	proxyManager *app.ProxyManager
 
 	// moveRunner shells out to `incus snapshot/copy/stop/start` for the
 	// MoveContainer migration flow. Nil on daemons that don't support
 	// migration (MoveContainer returns "not configured" then).
-	moveRunner           incus.MigrationRunner
+	moveRunner incus.MigrationRunner
 
 	// secretsStore is the tenant-secrets backend. Nil on daemons
 	// that don't have Postgres wired up (--standalone); the
 	// SecretsService RPCs return Unavailable in that case.
 	// CreateContainer / StartContainer call LoadAllForUser to
 	// stamp environment.<NAME>=<value> at LXC start time.
-	secretsStore         *secrets.Store
+	secretsStore *secrets.Store
 
 	// wakeRouter applies the Caddy route swap when a container is
 	// auto-slept (SwapToWake) and woken back up (SwapToDirect).
 	// Nil on daemons without app hosting or with auto-sleep disabled;
 	// the StopForAutoSleep / StartContainer hooks are nil-safe.
-	wakeRouter           WakeRouter
+	wakeRouter WakeRouter
 
 	// otelCollectorEndpoint is the OTLP/HTTP URL of this daemon's
 	// core OTel collector LXC (e.g. "http://10.0.3.142:4318").
@@ -94,9 +94,9 @@ type ContainerServer struct {
 	// warning and skip the env-var injection.
 	otelCollectorEndpoint string
 	// Guacamole integration for Windows VM RDP access
-	guacamoleClient      *guacamole.Client
-	guacamoleUser        string // Guacamole admin username
-	guacamolePass        string // Guacamole admin password
+	guacamoleClient *guacamole.Client
+	guacamoleUser   string // Guacamole admin username
+	guacamolePass   string // Guacamole admin password
 }
 
 // NewContainerServer creates a new container server
@@ -225,9 +225,15 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		// collector tag emissions with the originating VM for
 		// cross-VM Grafana queries. Both are no-ops when
 		// req.Monitoring is false.
-		Monitoring:             req.Monitoring,
-		OTelCollectorEndpoint:  s.otelCollectorEndpoint,
-		BackendID:              s.localBackendID(),
+		Monitoring:            req.Monitoring,
+		OTelCollectorEndpoint: s.otelCollectorEndpoint,
+		BackendID:             s.localBackendID(),
+		// Git source provisioning (optional) — the daemon fetches the
+		// repo into the box at create time, no caller→box SSH.
+		GitSource:     req.GitSource,
+		GitRef:        req.GitRef,
+		GitCredential: req.GitCredential,
+		WorkspacePath: req.WorkspacePath,
 	}
 	// Phase 2.5 follow-up — load the OTel bearer for
 	// monitoring=true containers. Best-effort: an error
@@ -695,17 +701,17 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 // the demo cluster on 2026-05-14.
 //
 // Order is deliberate:
-//   1. Route store first — kills the source of truth so RouteSyncJob
-//      will reap the Caddy srv0 route on its next tick (5s). Deleting
-//      directly from Caddy without this step lets the sync job
-//      resurrect the route within seconds, producing the 502-after-
-//      delete trap.
-//   2. TLS subject removal — stops Caddy's ACME renewal loop for the
-//      dead hostname. Harmless to keep (no upstream to challenge) but
-//      wastes rate-limit budget over time.
-//   3. Host user (jump-server account) — removes the Linux user, home,
-//      and the containarium-shell wrapper. sshpiper auto-reaps the
-//      user from its own config on the next keysync (2 min).
+//  1. Route store first — kills the source of truth so RouteSyncJob
+//     will reap the Caddy srv0 route on its next tick (5s). Deleting
+//     directly from Caddy without this step lets the sync job
+//     resurrect the route within seconds, producing the 502-after-
+//     delete trap.
+//  2. TLS subject removal — stops Caddy's ACME renewal loop for the
+//     dead hostname. Harmless to keep (no upstream to challenge) but
+//     wastes rate-limit budget over time.
+//  3. Host user (jump-server account) — removes the Linux user, home,
+//     and the containarium-shell wrapper. sshpiper auto-reaps the
+//     user from its own config on the next keysync (2 min).
 //
 // On-disk Caddy cert at /data/caddy/certificates/... is intentionally
 // left in place — it's harmless after step 2 (no renewal attempts) and
@@ -1652,22 +1658,22 @@ func (s *ContainerServer) GetSystemInfo(ctx context.Context, req *pb.GetSystemIn
 
 	// Build response
 	info := &pb.SystemInfo{
-		IncusVersion:          serverInfo.Environment.ServerVersion,
-		Os:                    serverInfo.Environment.OSName,
-		KernelVersion:         serverInfo.Environment.KernelVersion,
-		ContainersRunning:     running,
-		ContainersStopped:     stopped,
-		ContainersTotal:       int32(len(containers)),
-		Hostname:              serverInfo.Environment.ServerName,
-		NetworkCidr:           networkCIDR,
-		TotalCpus:             sysResources.TotalCPUs,
-		TotalMemoryBytes:      sysResources.TotalMemoryBytes,
-		AvailableMemoryBytes:  sysResources.TotalMemoryBytes - sysResources.UsedMemoryBytes,
-		TotalDiskBytes:        sysResources.TotalDiskBytes,
-		AvailableDiskBytes:    sysResources.TotalDiskBytes - sysResources.UsedDiskBytes,
-		CpuLoad_1Min:          sysResources.CPULoad1Min,
-		CpuLoad_5Min:          sysResources.CPULoad5Min,
-		CpuLoad_15Min:         sysResources.CPULoad15Min,
+		IncusVersion:         serverInfo.Environment.ServerVersion,
+		Os:                   serverInfo.Environment.OSName,
+		KernelVersion:        serverInfo.Environment.KernelVersion,
+		ContainersRunning:    running,
+		ContainersStopped:    stopped,
+		ContainersTotal:      int32(len(containers)),
+		Hostname:             serverInfo.Environment.ServerName,
+		NetworkCidr:          networkCIDR,
+		TotalCpus:            sysResources.TotalCPUs,
+		TotalMemoryBytes:     sysResources.TotalMemoryBytes,
+		AvailableMemoryBytes: sysResources.TotalMemoryBytes - sysResources.UsedMemoryBytes,
+		TotalDiskBytes:       sysResources.TotalDiskBytes,
+		AvailableDiskBytes:   sysResources.TotalDiskBytes - sysResources.UsedDiskBytes,
+		CpuLoad_1Min:         sysResources.CPULoad1Min,
+		CpuLoad_5Min:         sysResources.CPULoad5Min,
+		CpuLoad_15Min:        sysResources.CPULoad15Min,
 	}
 
 	// Populate GPU info
@@ -1856,8 +1862,8 @@ func toProtoContainer(info *incus.ContainerInfo) *pb.Container {
 		},
 		Labels:               info.Labels,
 		CreatedAt:            info.CreatedAt.Unix(),
-		PodmanEnabled:        true,  // TODO: Get from container config
-		Stack:                "",    // TODO: Get from container labels
+		PodmanEnabled:        true, // TODO: Get from container config
+		Stack:                "",   // TODO: Get from container labels
 		GpuDevice:            info.GPU,
 		BackendId:            info.BackendID,
 		OsType:               osTypeEnum,
@@ -2054,10 +2060,10 @@ func (s *ContainerServer) AddCollaborator(ctx context.Context, req *pb.AddCollab
 			peer := s.peerPool.FindContainerPeer(req.OwnerUsername, authToken)
 			if peer != nil {
 				body, _ := json.Marshal(map[string]interface{}{
-					"collaborator_username":    req.CollaboratorUsername,
-					"ssh_public_key":           req.SshPublicKey,
-					"grant_sudo":               req.GrantSudo,
-					"grant_container_runtime":  req.GrantContainerRuntime,
+					"collaborator_username":   req.CollaboratorUsername,
+					"ssh_public_key":          req.SshPublicKey,
+					"grant_sudo":              req.GrantSudo,
+					"grant_container_runtime": req.GrantContainerRuntime,
 				})
 				respBody, statusCode, fwdErr := peer.ForwardRequest("POST", fmt.Sprintf("/v1/containers/%s/collaborators", req.OwnerUsername), authToken, body)
 				if fwdErr != nil {

--- a/pkg/core/container/git_source.go
+++ b/pkg/core/container/git_source.go
@@ -1,0 +1,94 @@
+package container
+
+import (
+	"fmt"
+	"strings"
+)
+
+// defaultWorkspacePath is where git source lands in the box when the
+// caller doesn't specify one. Matches the convention the CI flow
+// (containarium-run) and the agent-box already assume.
+const defaultWorkspacePath = "/workspace"
+
+// gitWorkspacePath returns the workspace path, defaulting to
+// /workspace when the caller left it empty.
+func gitWorkspacePath(p string) string {
+	if strings.TrimSpace(p) == "" {
+		return defaultWorkspacePath
+	}
+	return p
+}
+
+// shellSingleQuote wraps s in single quotes for safe interpolation
+// into a /bin/sh -c script, escaping any embedded single quotes.
+// Used so a caller-supplied repo URL / ref / workspace path can't
+// break out of string context in the fetch script.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// buildGitFetchScript returns the /bin/sh script the daemon runs
+// inside the box to populate the workspace from a git remote.
+//
+// Design notes:
+//   - The box base image may lack git; the script installs it via
+//     whatever package manager is present before fetching.
+//   - A shallow fetch of the exact ref keeps it fast + reproducible.
+//     Empty ref fetches the remote's default branch (FETCH_HEAD).
+//   - A private-repo credential is injected as an ephemeral
+//     `http.extraHeader` on the single fetch invocation — it is
+//     never written to the repo's .git/config, so it doesn't persist
+//     in the box after provisioning. (Matches how actions/checkout
+//     scopes its token, minus the on-disk config write.)
+//   - All caller-supplied values are single-quoted to prevent shell
+//     injection.
+func buildGitFetchScript(repoURL, ref, credential, workspacePath string) string {
+	ws := gitWorkspacePath(workspacePath)
+
+	var fetch strings.Builder
+	fetch.WriteString("git ")
+	if credential != "" {
+		// The header value carries the token; quote it as one arg.
+		hdr := "AUTHORIZATION: bearer " + credential
+		fetch.WriteString("-c http.extraHeader=" + shellSingleQuote(hdr) + " ")
+	}
+	fetch.WriteString("fetch --depth 1 -q " + shellSingleQuote(repoURL))
+	if ref != "" {
+		fetch.WriteString(" " + shellSingleQuote(ref))
+	}
+
+	// `set -e` so any step failing aborts with a non-zero exit the
+	// daemon surfaces. git install is best-effort across apt/dnf/yum.
+	return strings.Join([]string{
+		"set -e",
+		`if ! command -v git >/dev/null 2>&1; then`,
+		`  (apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git) \`,
+		`    || (dnf install -y -q git) || (yum install -y -q git) \`,
+		`    || { echo "git unavailable and auto-install failed" >&2; exit 1; }`,
+		`fi`,
+		"mkdir -p " + shellSingleQuote(ws),
+		"cd " + shellSingleQuote(ws),
+		"git init -q",
+		fetch.String(),
+		"git checkout -q FETCH_HEAD",
+	}, "\n")
+}
+
+// provisionGitSource fetches opts.GitSource into the box's workspace
+// by running buildGitFetchScript via incus exec. No caller→box SSH is
+// involved — the daemon reaches the box it just created directly.
+func (m *Manager) provisionGitSource(containerName string, opts CreateOptions) error {
+	script := buildGitFetchScript(opts.GitSource, opts.GitRef, opts.GitCredential, opts.WorkspacePath)
+	stdout, stderr, err := m.incus.ExecWithOutput(containerName, []string{"/bin/sh", "-c", script})
+	if err != nil {
+		// Surface the box-side stderr (credential-free: the token only
+		// ever appears in the script's http.extraHeader arg, not in
+		// git's diagnostic output) so the failure is actionable.
+		msg := strings.TrimSpace(stderr)
+		if msg == "" {
+			msg = strings.TrimSpace(stdout)
+		}
+		return fmt.Errorf("git fetch in box failed: %w: %s", err, msg)
+	}
+	return nil
+}

--- a/pkg/core/container/git_source_test.go
+++ b/pkg/core/container/git_source_test.go
@@ -1,0 +1,70 @@
+package container
+
+import "strings"
+
+import "testing"
+
+func TestGitWorkspacePath(t *testing.T) {
+	if got := gitWorkspacePath(""); got != "/workspace" {
+		t.Errorf("empty → %q, want /workspace", got)
+	}
+	if got := gitWorkspacePath("  "); got != "/workspace" {
+		t.Errorf("blank → %q, want /workspace", got)
+	}
+	if got := gitWorkspacePath("/srv/app"); got != "/srv/app" {
+		t.Errorf("explicit → %q, want /srv/app", got)
+	}
+}
+
+func TestBuildGitFetchScript_PublicRepoWithRef(t *testing.T) {
+	s := buildGitFetchScript("https://github.com/org/repo", "abc123", "", "")
+
+	wantContains := []string{
+		"git init -q",
+		"fetch --depth 1 -q 'https://github.com/org/repo' 'abc123'",
+		"git checkout -q FETCH_HEAD",
+		"mkdir -p '/workspace'",
+	}
+	for _, w := range wantContains {
+		if !strings.Contains(s, w) {
+			t.Errorf("script missing %q\n---\n%s", w, s)
+		}
+	}
+	if strings.Contains(s, "http.extraHeader") {
+		t.Errorf("public repo must not inject an auth header:\n%s", s)
+	}
+}
+
+func TestBuildGitFetchScript_PrivateRepoInjectsEphemeralHeader(t *testing.T) {
+	token := "ghs_SECRETTOKEN"
+	s := buildGitFetchScript("https://github.com/org/repo", "deadbeef", token, "/ws")
+
+	// Token must be present only as an ephemeral http.extraHeader on
+	// the fetch — never written to .git/config (no `git config` line
+	// carrying it), so it doesn't persist in the box.
+	if !strings.Contains(s, "-c http.extraHeader='AUTHORIZATION: bearer "+token+"'") {
+		t.Errorf("expected ephemeral extraHeader with token, got:\n%s", s)
+	}
+	if strings.Contains(s, "git config") {
+		t.Errorf("token/header must not be written via `git config` (would persist):\n%s", s)
+	}
+	if !strings.Contains(s, "mkdir -p '/ws'") {
+		t.Errorf("custom workspace not honored:\n%s", s)
+	}
+}
+
+func TestBuildGitFetchScript_EmptyRefFetchesDefault(t *testing.T) {
+	s := buildGitFetchScript("https://github.com/org/repo", "", "", "")
+	// No trailing ref arg after the URL when ref is empty.
+	if !strings.Contains(s, "fetch --depth 1 -q 'https://github.com/org/repo'\n") {
+		t.Errorf("empty ref should fetch default branch (no ref arg):\n%s", s)
+	}
+}
+
+func TestBuildGitFetchScript_ShellInjectionIsQuoted(t *testing.T) {
+	// A malicious ref must not break out of the command.
+	s := buildGitFetchScript("https://github.com/org/repo", "x'; rm -rf /; '", "", "")
+	if strings.Contains(s, "; rm -rf /; ") && !strings.Contains(s, `'\''`) {
+		t.Errorf("ref not shell-escaped — injection risk:\n%s", s)
+	}
+}

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -37,11 +37,11 @@ type CreateOptions struct {
 	EnablePodmanPrivileged bool // Full Docker support (privileged + AppArmor disabled)
 	AutoStart              bool
 	Verbose                bool
-	Stack                  string    // Software stack to install (e.g., "nodejs", "python")
+	Stack                  string            // Software stack to install (e.g., "nodejs", "python")
 	StackParameters        map[string]string // Stack parameters — passed to install scripts as CONTAINARIUM_STACK_<name> env vars
-	OSType                 pb.OSType // Operating system type for the container
-	OnProvisioning         func()    // Called when container is running but still provisioning (installing packages/stack)
-	RDPPassword            string    // Generated RDP password for Windows VMs (output, set by Create)
+	OSType                 pb.OSType         // Operating system type for the container
+	OnProvisioning         func()            // Called when container is running but still provisioning (installing packages/stack)
+	RDPPassword            string            // Generated RDP password for Windows VMs (output, set by Create)
 
 	// Monitoring toggles application-emitted OpenTelemetry. When
 	// true, the container is created with OTEL_EXPORTER_OTLP_ENDPOINT
@@ -70,6 +70,15 @@ type CreateOptions struct {
 	// LoadOrCreateOTelBearer in internal/server. Phase 2.5
 	// follow-up (audit C-HIGH-5).
 	OTelBearer string
+
+	// Git source provisioning. When GitSource is set, Create fetches
+	// the repo into WorkspacePath inside the box (via incus exec, no
+	// caller→box SSH) right after the container is up + packaged.
+	// See prd/oss/create-git-source.md (Containarium-cloud).
+	GitSource     string // clone URL, e.g. "https://github.com/org/repo"
+	GitRef        string // SHA / branch / tag / "refs/pull/N/merge"; empty = default branch
+	GitCredential string // bearer token for private repos; daemon-side only, never persisted in the box
+	WorkspacePath string // where to place source; empty defaults to "/workspace"
 }
 
 // New creates a new container manager backed by a real Incus client.
@@ -302,6 +311,20 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 	} else {
 		if opts.Verbose {
 			fmt.Println("       No SSH keys to add, skipping...")
+		}
+	}
+
+	// Step 8: Provision git source into the workspace (optional).
+	// The daemon fetches the repo via incus exec — no caller→box SSH.
+	// A failed fetch fails the create: a box without its source is
+	// useless, and a half-populated workspace is worse than none.
+	if opts.GitSource != "" {
+		if opts.Verbose {
+			fmt.Printf("  [8/8] Fetching git source %s into %s...\n", opts.GitSource, gitWorkspacePath(opts.WorkspacePath))
+		}
+		if err := m.provisionGitSource(containerName, opts); err != nil {
+			_ = m.cleanup(containerName)
+			return nil, fmt.Errorf("failed to provision git source: %w", err)
 		}
 	}
 
@@ -782,7 +805,7 @@ func (m *Manager) GetServerInfo() (*incus.ServerInfo, error) {
 
 	// Convert to our own type for easier use
 	info := &incus.ServerInfo{
-		Version:    server.Environment.ServerVersion,
+		Version:       server.Environment.ServerVersion,
 		KernelVersion: server.Environment.KernelVersion,
 	}
 

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -761,7 +761,26 @@ type CreateContainerRequest struct {
 	// the peer's daemon). When both pool and backend_id are set, the
 	// chosen backend_id must belong to this pool or the request is
 	// rejected. Empty means "untagged backends only" (legacy behavior).
-	Pool          string `protobuf:"bytes,15,opt,name=pool,proto3" json:"pool,omitempty"`
+	Pool string `protobuf:"bytes,15,opt,name=pool,proto3" json:"pool,omitempty"`
+	// Git source provisioning — when git_source is set, the daemon
+	// fetches the repo into the box's workspace at create time (via
+	// incus exec, no caller→box SSH). Removes the caller's need to
+	// push code in over rsync/scp. See
+	// prd/oss/create-git-source.md (Containarium-cloud).
+	//
+	// git_source: clone URL, e.g. "https://github.com/org/repo".
+	GitSource string `protobuf:"bytes,16,opt,name=git_source,json=gitSource,proto3" json:"git_source,omitempty"`
+	// git_ref: the exact ref to check out — full SHA (preferred,
+	// reproducible), branch, tag, or a server ref like
+	// "refs/pull/<n>/merge". Empty = the remote's default branch.
+	GitRef string `protobuf:"bytes,17,opt,name=git_ref,json=gitRef,proto3" json:"git_ref,omitempty"`
+	// git_credential: bearer token for private repos. Used daemon-side
+	// for a single fetch (injected as an ephemeral http.extraHeader)
+	// and never written to the box's .git/config. Empty = public repo.
+	GitCredential string `protobuf:"bytes,18,opt,name=git_credential,json=gitCredential,proto3" json:"git_credential,omitempty"`
+	// workspace_path: where in the box to place the source. Empty
+	// defaults to "/workspace".
+	WorkspacePath string `protobuf:"bytes,19,opt,name=workspace_path,json=workspacePath,proto3" json:"workspace_path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -897,6 +916,34 @@ func (x *CreateContainerRequest) GetMonitoring() bool {
 func (x *CreateContainerRequest) GetPool() string {
 	if x != nil {
 		return x.Pool
+	}
+	return ""
+}
+
+func (x *CreateContainerRequest) GetGitSource() string {
+	if x != nil {
+		return x.GitSource
+	}
+	return ""
+}
+
+func (x *CreateContainerRequest) GetGitRef() string {
+	if x != nil {
+		return x.GitRef
+	}
+	return ""
+}
+
+func (x *CreateContainerRequest) GetGitCredential() string {
+	if x != nil {
+		return x.GitCredential
+	}
+	return ""
+}
+
+func (x *CreateContainerRequest) GetWorkspacePath() string {
+	if x != nil {
+		return x.WorkspacePath
 	}
 	return ""
 }
@@ -3964,7 +4011,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x10disk_usage_bytes\x18\x05 \x01(\x03R\x0ediskUsageBytes\x12(\n" +
 	"\x10network_rx_bytes\x18\x06 \x01(\x03R\x0enetworkRxBytes\x12(\n" +
 	"\x10network_tx_bytes\x18\a \x01(\x03R\x0enetworkTxBytes\x12#\n" +
-	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\xde\x05\n" +
+	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\xe4\x06\n" +
 	"\x16CreateContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12=\n" +
 	"\tresources\x18\x02 \x01(\v2\x1f.containarium.v1.ResourceLimitsR\tresources\x12\x19\n" +
@@ -3984,7 +4031,12 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\n" +
 	"monitoring\x18\x0e \x01(\bR\n" +
 	"monitoring\x12\x12\n" +
-	"\x04pool\x18\x0f \x01(\tR\x04pool\x1a9\n" +
+	"\x04pool\x18\x0f \x01(\tR\x04pool\x12\x1d\n" +
+	"\n" +
+	"git_source\x18\x10 \x01(\tR\tgitSource\x12\x17\n" +
+	"\agit_ref\x18\x11 \x01(\tR\x06gitRef\x12%\n" +
+	"\x0egit_credential\x18\x12 \x01(\tR\rgitCredential\x12%\n" +
+	"\x0eworkspace_path\x18\x13 \x01(\tR\rworkspacePath\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aB\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -272,6 +272,29 @@ message CreateContainerRequest {
   // chosen backend_id must belong to this pool or the request is
   // rejected. Empty means "untagged backends only" (legacy behavior).
   string pool = 15;
+
+  // Git source provisioning — when git_source is set, the daemon
+  // fetches the repo into the box's workspace at create time (via
+  // incus exec, no caller→box SSH). Removes the caller's need to
+  // push code in over rsync/scp. See
+  // prd/oss/create-git-source.md (Containarium-cloud).
+  //
+  // git_source: clone URL, e.g. "https://github.com/org/repo".
+  string git_source = 16;
+
+  // git_ref: the exact ref to check out — full SHA (preferred,
+  // reproducible), branch, tag, or a server ref like
+  // "refs/pull/<n>/merge". Empty = the remote's default branch.
+  string git_ref = 17;
+
+  // git_credential: bearer token for private repos. Used daemon-side
+  // for a single fetch (injected as an ephemeral http.extraHeader)
+  // and never written to the box's .git/config. Empty = public repo.
+  string git_credential = 18;
+
+  // workspace_path: where in the box to place the source. Empty
+  // defaults to "/workspace".
+  string workspace_path = 19;
 }
 
 // CreateContainerResponse is the response from creating a container


### PR DESCRIPTION
## Summary

Implements `prd/oss/create-git-source.md` (Containarium-cloud #170). The daemon provisions a box's `/workspace` from a git remote **during create, via `incus exec`, with no caller→box SSH**.

This removes the source-delivery failure class the 2026-05-29 CI debug session bottomed out on: rsync missing on the runner, and `ssh "$BOX"` not resolving for a box created on a remote daemon. Every caller-side push/pull needs caller→box SSH; the daemon is already adjacent to the box, so it does the fetch.

## Changes

- **proto**: `git_source` / `git_ref` / `git_credential` / `workspace_path` on `CreateContainerRequest` (fields 16–19), regenerated (Go + swagger).
- **pkg/core/container**: `CreateOptions` gains the four fields; `Manager.Create` runs `buildGitFetchScript` via `incus.ExecWithOutput` as Step 8 (after the box is up + packaged + SSH keys added). git auto-installed in-box if absent; shallow fetch of the exact ref; empty ref → remote default branch. Private-repo credential injected as an **ephemeral `http.extraHeader`** on the single fetch — **never** written to `.git/config`. All caller values shell-quoted.
- **server**: `CreateContainer` maps the request fields → `CreateOptions`, so any client (CLI / containarium-run / direct API) gets it.
- **CLI**: `--git-source` / `--git-ref` / `--git-credential-file` / `--workspace-path` on `containarium create`, threaded through local + remote (gRPC/HTTP) via a `GitSourceOpts` struct (avoids growing the 13-arg client signature into 17 positionals).
- **tests**: `buildGitFetchScript` unit tests — public/private/empty-ref/shell-injection-quoting, plus the assertion that the token never lands in `.git/config`.

Both the local-Incus and remote-daemon create paths funnel through `Manager.Create`, so one implementation covers both. A failed fetch fails the create (a box without its source is useless).

## Test plan

- [x] `go build ./...`, `go vet`, `go test ./pkg/core/container/ ./internal/cmd/` — green locally
- [ ] CI green
- [ ] e2e: `containarium create $BOX --git-source <repo>@<sha>` on a remote daemon populates `/workspace` with no caller→box SSH (the case that fails today at `ssh $BOX`)
- [ ] private-repo e2e: token appears in no log and no `.git/config`
- [ ] follow-up (containarium-run#18): drop the action's rsync push step in favor of `--git-source`

🤖 Generated with [Claude Code](https://claude.com/claude-code)