### PR TITLE
docs(readme): add "vs Docker AI Sandboxes (sbx)" comparison row

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,36 @@ These give you sandboxes for AI agents, but only as hosted SaaS:
 - **Transport**: MCP-native from day one, not a custom SDK with MCP
   bolted on.
 
+### vs. Docker AI Sandboxes (`sbx`)
+
+Docker's `sbx run claude` and Containarium both call themselves
+"AI sandboxes," but they sit on opposite ends of the same spectrum:
+
+- **Locality**: `sbx` runs the sandbox on the developer's laptop
+  (microVM, host-isolation). Containarium runs the sandbox on a VM
+  you host (LXC, multi-tenant, public-internet reachable via the
+  sentinel).
+- **Persistence**: `sbx` is session-shaped (workspace mount, no
+  documented "give me a box that survives reboot and has a
+  hostname"). Containarium containers persist indefinitely, with
+  ZFS snapshots and 30-day retention.
+- **Public reach**: `containarium expose-port alice --domain
+  blog.example.com` is one verb. `sbx` is laptop-local; no
+  public-hostname story.
+- **Agent surface**: `sbx` is CLI-first (`sbx run <agent>`).
+  Containarium is MCP-native — two MCP servers (in-the-box
+  `agent-box` + platform `mcp-server`) plus the same surface via
+  CLI, SSH, REST/gRPC, and a web UI.
+- **License**: `sbx` CLI is free; team policy (Docker Admin Console)
+  is a paid subscription. Containarium is Apache 2.0 — including
+  the audit log, RBAC, KMS integrations, and everything else on
+  this page.
+
+If you're stopping an agent from `rm -rf`-ing the laptop it's
+running on, `sbx` is the lighter tool. If you're giving your agent
+(or your customer's agent) a persistent Linux box on the public
+internet, Containarium is the shape.
+
 ### vs. dev environment platforms (Codespaces, Gitpod, Coder)
 
 Those are persistent IDEs. Containarium is a persistent **box** —


### PR DESCRIPTION
## Summary

Adds a new \`### vs. Docker AI Sandboxes (sbx)\` subsection to the README's "How it's different" block, placed between the SaaS-only (e2b/Modal/Replit) and dev-env (Codespaces/Gitpod/Coder) entries.

Docker shipped \`sbx\` as their explicit AI-sandbox positioning while we were heads-down on the telemetry distro work. The two products both call themselves "AI sandboxes" but sit on opposite ends of the same spectrum — \`sbx\` is laptop-local microVM with host-isolation; Containarium is self-hosted persistent LXC with public-internet reach.

The new entry covers:

| Axis | \`sbx\` | Containarium |
|---|---|---|
| Locality | Laptop microVM | Hosted LXC |
| Persistence | Session-shaped | Survives reboot, ZFS snapshots |
| Public reach | None documented | \`expose-port --domain\` as one verb |
| Agent surface | CLI-first | MCP-native (two-server pattern), CLI, SSH, REST/gRPC, web UI |
| License | Free CLI + paid Admin Console for org policy | Apache 2.0 throughout |

Tone matches the other "vs." subsections — terse, direct, ends with the "if you want X use them, if you want Y use us" decision frame.

## Test plan

- [ ] \`gh pr diff\` shows only the new 30-line subsection plus surrounding context
- [ ] No other README sections moved or reflowed
- [ ] \`grep -c "^### vs\\." README.md\` is now 4 (was 3)
- [ ] No design / code changes

## Out of scope

- Updating other comparison docs (none exist; README "How it's different" is the canonical positioning).
- Marketing-site copy at containarium.dev (separate property).
- Specific claims about \`sbx\`'s persistence semantics — Docker's docs are thin here and we describe what's documented, not what's inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)