### PR TITLE
Promote integration/docs-cleanup: SSH citations + distro CI triggers + Docker sbx comparison

### DIFF
--- a/.github/workflows/distros-go-ci.yml
+++ b/.github/workflows/distros-go-ci.yml
@@ -1,16 +1,22 @@
 name: CI — Go distro
 
 # Symmetric with distros-py-ci.yml: run the Go distro's test suite on
-# PRs that touch it and on every push to main. The Go distro ships
-# inside the main go.mod (D13), so this workflow is narrower than the
-# top-level Go build — just the distro's own packages.
+# PRs that touch it and on every push to main OR an integration/**
+# branch. Per the team's PR-target rule we stage changes on integration
+# branches before promoting to main — validating the integration HEAD
+# before promotion catches regressions at the same point the old
+# "push to main" trigger did. The Go distro ships inside the main
+# go.mod (D13), so this workflow is narrower than the top-level Go
+# build — just the distro's own packages.
 on:
   pull_request:
     paths:
       - 'distros/go/**'
       - '.github/workflows/distros-go-ci.yml'
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'integration/**'
     paths:
       - 'distros/go/**'
       - '.github/workflows/distros-go-ci.yml'

--- a/.github/workflows/distros-py-ci.yml
+++ b/.github/workflows/distros-py-ci.yml
@@ -1,15 +1,20 @@
 name: CI — Python distro
 
 # Run the distro test suite on PRs that touch it, and on every push to
-# main. Keeps the release workflow honest: when the v* tag fires, the
-# code on main has already passed CI.
+# main OR an integration/** branch. Per the team's PR-target rule we
+# stage changes on integration branches before promoting to main —
+# validating the integration HEAD before promotion catches regressions
+# at the same point the old "push to main" trigger did. The pull_request
+# trigger has no `branches:` filter so it fires on PRs against any base.
 on:
   pull_request:
     paths:
       - 'distros/py/**'
       - '.github/workflows/distros-py-ci.yml'
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'integration/**'
     paths:
       - 'distros/py/**'
       - '.github/workflows/distros-py-ci.yml'

--- a/README.md
+++ b/README.md
@@ -261,6 +261,36 @@ These give you sandboxes for AI agents, but only as hosted SaaS:
 - **Transport**: MCP-native from day one, not a custom SDK with MCP
   bolted on.
 
+### vs. Docker AI Sandboxes (`sbx`)
+
+Docker's `sbx run claude` and Containarium both call themselves
+"AI sandboxes," but they sit on opposite ends of the same spectrum:
+
+- **Locality**: `sbx` runs the sandbox on the developer's laptop
+  (microVM, host-isolation). Containarium runs the sandbox on a VM
+  you host (LXC, multi-tenant, public-internet reachable via the
+  sentinel).
+- **Persistence**: `sbx` is session-shaped (workspace mount, no
+  documented "give me a box that survives reboot and has a
+  hostname"). Containarium containers persist indefinitely, with
+  ZFS snapshots and 30-day retention.
+- **Public reach**: `containarium expose-port alice --domain
+  blog.example.com` is one verb. `sbx` is laptop-local; no
+  public-hostname story.
+- **Agent surface**: `sbx` is CLI-first (`sbx run <agent>`).
+  Containarium is MCP-native — two MCP servers (in-the-box
+  `agent-box` + platform `mcp-server`) plus the same surface via
+  CLI, SSH, REST/gRPC, and a web UI.
+- **License**: `sbx` CLI is free; team policy (Docker Admin Console)
+  is a paid subscription. Containarium is Apache 2.0 — including
+  the audit log, RBAC, KMS integrations, and everything else on
+  this page.
+
+If you're stopping an agent from `rm -rf`-ing the laptop it's
+running on, `sbx` is the lighter tool. If you're giving your agent
+(or your customer's agent) a persistent Linux box on the public
+internet, Containarium is the shape.
+
 ### vs. dev environment platforms (Codespaces, Gitpod, Coder)
 
 Those are persistent IDEs. Containarium is a persistent **box** —

--- a/docs/SSH-CONNECT-BROKER-DESIGN.md
+++ b/docs/SSH-CONNECT-BROKER-DESIGN.md
@@ -15,10 +15,10 @@ The CLI already authenticates against the cloud:
 
 - `containarium login` runs an OAuth-style device flow and
   stores a bearer token in `~/.containarium/credentials.json`
-  (`internal/cmd/login.go:76`).
+  (`internal/cmd/login.go:75`).
 - `containarium ssh setup` generates or finds a local SSH key,
   uploads the **public** half to the cloud, registers it under
-  a friendly name (`internal/cmd/ssh.go:85`).
+  a friendly name (`internal/cmd/ssh.go:84`).
 - `containarium ssh propagate` pushes the registered key-set to
   every box the user owns (`internal/cmd/ssh.go:152`).
 - `containarium ssh-config sync` writes a self-contained


### PR DESCRIPTION
## Summary

Promotion PR for the \`integration/docs-cleanup\` integration branch. Three child PRs were squash-merged into it; this is the single landing PR into \`main\`.

| Child PR | Title | Files |
|---|---|---|
| #360 | docs(ssh): fix off-by-one citations in broker design | \`docs/SSH-CONNECT-BROKER-DESIGN.md\` |
| #361 | ci(distros): broaden push trigger to integration/** branches | \`.github/workflows/distros-py-ci.yml\`, \`.github/workflows/distros-go-ci.yml\` |
| #364 | docs(readme): add "vs Docker AI Sandboxes (sbx)" comparison row | \`README.md\` |

Zero file overlap with the four commits that landed on main in parallel (\`fc23473\` v0.20.0 cut, \`08c6027\`/\`b3c5bb3\` wake proxy 404 fix, \`0fbb07f\` \`--git-source\` feature) — clean merge expected.

## Test plan

- [ ] \`gh pr diff 365\` shows exactly the three child PRs' content, no extras
- [ ] Security workflows (gosec, govulncheck, trivy) fire (this is the first PR against main from the integration branch — confirms the workflow trigger model)
- [ ] After merge: push a no-op change under \`distros/py/\` to an integration branch and confirm \`distros-py-ci.yml\` fires per the new trigger config
- [ ] After merge: verify \`README.md\` rendering at containarium.dev / GitHub renders the new "vs sbx" section correctly

## Out of scope

- Broadening security.yml / proxyproto-e2e.yml to integration branches (separate call, noted in #361's "Out of scope")
- Documenting the integration-branch workflow in CONTRIBUTING.md (CONTRIBUTING.md doesn't exist yet — separate effort if we want one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)