### PR TITLE
chore: cut v0.21.0

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.20.0"
+	Version = "0.21.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary
Bump `pkg/version/version.go` 0.20.0 → 0.21.0 so the built binary reports the correct version. Minor bump because there's a new feature since v0.20.0.

Once merged, tag `v0.21.0` on the merge commit — the Release workflow builds the 9 binaries + SHA256SUMS and publishes the GitHub release.

## Changes since v0.20.0
- `feat(create)`: `--git-source` — daemon fetches repo into the box at create time (#363)
- `fix(wake)`: 404 instead of futile start for container-less routes (#362)

## Test plan
- [x] `go build ./...` clean
- [ ] CI green on this PR before merge