### PR TITLE
feat(collaborator): AddCollaborator accepts multiple SSH keys (#369)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -3992,7 +3992,7 @@
         },
         "sshPublicKey": {
           "type": "string",
-          "title": "SSH public key for the collaborator"
+          "description": "SSH public key for the collaborator.\nDeprecated: prefer ssh_public_keys. Kept for back-compat — when\nssh_public_keys is empty this single key is used."
         },
         "grantSudo": {
           "type": "boolean",
@@ -4001,6 +4001,13 @@
         "grantContainerRuntime": {
           "type": "boolean",
           "title": "Add to docker/podman group for container runtime access"
+        },
+        "sshPublicKeys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "SSH public keys for the collaborator — all are authorized, so a\ncollaborator with several machines can connect from any of them.\nTakes precedence over ssh_public_key when non-empty. See #369."
         }
       },
       "title": "AddCollaboratorRequest is the request to add a collaborator to a container"

--- a/internal/cmd/collaborator_add.go
+++ b/internal/cmd/collaborator_add.go
@@ -20,9 +20,9 @@ var validSSHKeyPrefixes = []string{
 }
 
 var (
-	collaboratorSSHKeyFile    string
-	collaboratorGrantSudo     bool
-	collaboratorGrantRuntime  bool
+	collaboratorSSHKeyFiles  []string
+	collaboratorGrantSudo    bool
+	collaboratorGrantRuntime bool
 )
 
 var collaboratorAddCmd = &cobra.Command{
@@ -45,14 +45,17 @@ Examples:
   containarium collaborator add alice bob --ssh-key ~/.ssh/bob.pub
 
   # Add carol as a collaborator using a different SSH key
-  containarium collaborator add alice carol --ssh-key /path/to/carol.pub`,
+  containarium collaborator add alice carol --ssh-key /path/to/carol.pub
+
+  # Authorize several of bob's keys (one per machine)
+  containarium collaborator add alice bob --ssh-key ~/.ssh/bob-laptop.pub --ssh-key ~/.ssh/bob-desktop.pub`,
 	Args: cobra.ExactArgs(2),
 	RunE: runCollaboratorAdd,
 }
 
 func init() {
 	collaboratorCmd.AddCommand(collaboratorAddCmd)
-	collaboratorAddCmd.Flags().StringVar(&collaboratorSSHKeyFile, "ssh-key", "", "path to collaborator's SSH public key file (required)")
+	collaboratorAddCmd.Flags().StringArrayVar(&collaboratorSSHKeyFiles, "ssh-key", nil, "path to collaborator's SSH public key file (required; repeat to authorize multiple keys)")
 	collaboratorAddCmd.MarkFlagRequired("ssh-key")
 	collaboratorAddCmd.Flags().BoolVar(&collaboratorGrantSudo, "sudo", false, "grant full sudo access (not just su - owner)")
 	collaboratorAddCmd.Flags().BoolVar(&collaboratorGrantRuntime, "container-runtime", false, "add collaborator to docker/podman groups")
@@ -62,34 +65,36 @@ func runCollaboratorAdd(cmd *cobra.Command, args []string) error {
 	ownerUsername := args[0]
 	collaboratorUsername := args[1]
 
-	// Read SSH public key from file
-	sshKeyBytes, err := os.ReadFile(collaboratorSSHKeyFile)
-	if err != nil {
-		return fmt.Errorf("failed to read SSH key file: %w", err)
-	}
-	sshPublicKey := strings.TrimSpace(string(sshKeyBytes))
-
-	if sshPublicKey == "" {
-		return fmt.Errorf("SSH key file is empty")
-	}
-
-	// Validate SSH key format (supports standard and FIDO keys)
-	validKey := false
-	for _, prefix := range validSSHKeyPrefixes {
-		if strings.HasPrefix(sshPublicKey, prefix) {
-			validKey = true
-			break
+	// Read + validate each SSH public key file. All are authorized so
+	// the collaborator can connect from any of their machines (#369).
+	var sshPublicKeys []string
+	for _, keyFile := range collaboratorSSHKeyFiles {
+		sshKeyBytes, err := os.ReadFile(keyFile)
+		if err != nil {
+			return fmt.Errorf("failed to read SSH key file %q: %w", keyFile, err)
 		}
-	}
-	if !validKey {
-		return fmt.Errorf("invalid SSH public key format")
+		sshPublicKey := strings.TrimSpace(string(sshKeyBytes))
+		if sshPublicKey == "" {
+			return fmt.Errorf("SSH key file %q is empty", keyFile)
+		}
+		validKey := false
+		for _, prefix := range validSSHKeyPrefixes {
+			if strings.HasPrefix(sshPublicKey, prefix) {
+				validKey = true
+				break
+			}
+		}
+		if !validKey {
+			return fmt.Errorf("invalid SSH public key format in %q", keyFile)
+		}
+		sshPublicKeys = append(sshPublicKeys, sshPublicKey)
 	}
 
 	// Local mode only for now (requires PostgreSQL)
-	return addCollaboratorLocal(ownerUsername, collaboratorUsername, sshPublicKey)
+	return addCollaboratorLocal(ownerUsername, collaboratorUsername, sshPublicKeys)
 }
 
-func addCollaboratorLocal(ownerUsername, collaboratorUsername, sshPublicKey string) error {
+func addCollaboratorLocal(ownerUsername, collaboratorUsername string, sshPublicKeys []string) error {
 	// Create container manager
 	containerMgr, err := container.New()
 	if err != nil {
@@ -113,7 +118,7 @@ func addCollaboratorLocal(ownerUsername, collaboratorUsername, sshPublicKey stri
 	collaboratorMgr := container.NewCollaboratorManager(containerMgr, collaboratorStore)
 
 	// Add collaborator
-	collab, err := collaboratorMgr.AddCollaborator(ownerUsername, collaboratorUsername, sshPublicKey, collaboratorGrantSudo, collaboratorGrantRuntime)
+	collab, err := collaboratorMgr.AddCollaborator(ownerUsername, collaboratorUsername, sshPublicKeys, collaboratorGrantSudo, collaboratorGrantRuntime)
 	if err != nil {
 		return fmt.Errorf("failed to add collaborator: %w", err)
 	}

--- a/internal/server/collaborator_keys_test.go
+++ b/internal/server/collaborator_keys_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// TestCollaboratorKeysFromRequest covers the #369 back-compat resolution:
+// repeated ssh_public_keys is preferred; the legacy single ssh_public_key
+// is the fallback; neither set yields nil (the handler then rejects it).
+func TestCollaboratorKeysFromRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *pb.AddCollaboratorRequest
+		want []string
+	}{
+		{
+			name: "repeated preferred",
+			req:  &pb.AddCollaboratorRequest{SshPublicKeys: []string{"ssh-ed25519 AAA a", "ssh-ed25519 BBB b"}},
+			want: []string{"ssh-ed25519 AAA a", "ssh-ed25519 BBB b"},
+		},
+		{
+			name: "legacy single fallback",
+			req:  &pb.AddCollaboratorRequest{SshPublicKey: "ssh-ed25519 AAA a"},
+			want: []string{"ssh-ed25519 AAA a"},
+		},
+		{
+			name: "repeated wins over legacy when both set",
+			req:  &pb.AddCollaboratorRequest{SshPublicKey: "ssh-ed25519 LEGACY x", SshPublicKeys: []string{"ssh-ed25519 AAA a"}},
+			want: []string{"ssh-ed25519 AAA a"},
+		},
+		{
+			name: "neither set yields nil",
+			req:  &pb.AddCollaboratorRequest{},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collaboratorKeysFromRequest(tt.req)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d (%v)", len(got), len(tt.want), got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("key[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -2059,6 +2059,20 @@ func (s *ContainerServer) SetCollaboratorManager(cm *container.CollaboratorManag
 }
 
 // AddCollaborator adds a collaborator to a container
+// collaboratorKeysFromRequest resolves the collaborator's SSH keys from
+// the request, preferring the repeated ssh_public_keys and falling back
+// to the legacy single ssh_public_key for back-compat. Returns nil when
+// neither is set. #369.
+func collaboratorKeysFromRequest(req *pb.AddCollaboratorRequest) []string {
+	if len(req.GetSshPublicKeys()) > 0 {
+		return req.GetSshPublicKeys()
+	}
+	if req.GetSshPublicKey() != "" {
+		return []string{req.GetSshPublicKey()}
+	}
+	return nil
+}
+
 func (s *ContainerServer) AddCollaborator(ctx context.Context, req *pb.AddCollaboratorRequest) (*pb.AddCollaboratorResponse, error) {
 	if req.OwnerUsername == "" {
 		return nil, fmt.Errorf("owner_username is required")
@@ -2066,8 +2080,11 @@ func (s *ContainerServer) AddCollaborator(ctx context.Context, req *pb.AddCollab
 	if req.CollaboratorUsername == "" {
 		return nil, fmt.Errorf("collaborator_username is required")
 	}
-	if req.SshPublicKey == "" {
-		return nil, fmt.Errorf("ssh_public_key is required")
+	// Accept either the repeated ssh_public_keys (preferred) or the
+	// legacy single ssh_public_key. #369.
+	sshKeys := collaboratorKeysFromRequest(req)
+	if len(sshKeys) == 0 {
+		return nil, fmt.Errorf("at least one of ssh_public_keys or ssh_public_key is required")
 	}
 	if err := auth.AuthorizeTenant(ctx, req.OwnerUsername); err != nil {
 		return nil, err
@@ -2080,8 +2097,11 @@ func (s *ContainerServer) AddCollaborator(ctx context.Context, req *pb.AddCollab
 			peer := s.peerPool.FindContainerPeer(req.OwnerUsername, authToken)
 			if peer != nil {
 				body, _ := json.Marshal(map[string]interface{}{
-					"collaborator_username":   req.CollaboratorUsername,
-					"ssh_public_key":          req.SshPublicKey,
+					"collaborator_username": req.CollaboratorUsername,
+					// ssh_public_key kept for older peers; ssh_public_keys
+					// carries the full set for #369-aware peers.
+					"ssh_public_key":          sshKeys[0],
+					"ssh_public_keys":         sshKeys,
 					"grant_sudo":              req.GrantSudo,
 					"grant_container_runtime": req.GrantContainerRuntime,
 				})
@@ -2112,7 +2132,7 @@ func (s *ContainerServer) AddCollaborator(ctx context.Context, req *pb.AddCollab
 		return nil, fmt.Errorf("collaborator management not enabled")
 	}
 
-	collab, err := s.collaboratorManager.AddCollaborator(req.OwnerUsername, req.CollaboratorUsername, req.SshPublicKey, req.GrantSudo, req.GrantContainerRuntime)
+	collab, err := s.collaboratorManager.AddCollaborator(req.OwnerUsername, req.CollaboratorUsername, sshKeys, req.GrantSudo, req.GrantContainerRuntime)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add collaborator: %w", err)
 	}

--- a/pkg/core/container/collaborator.go
+++ b/pkg/core/container/collaborator.go
@@ -3,6 +3,7 @@ package container
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/footprintai/containarium/internal/collaborator"
@@ -31,7 +32,7 @@ func NewCollaboratorManager(manager *Manager, store *collaborator.Store) *Collab
 // 3. Session logging for audit trail
 // 4. Jump server account for SSH ProxyJump access
 // 5. Persistence record in PostgreSQL
-func (cm *CollaboratorManager) AddCollaborator(ownerUsername, collaboratorUsername, sshPublicKey string, grantSudo, grantContainerRuntime bool) (*collaborator.Collaborator, error) {
+func (cm *CollaboratorManager) AddCollaborator(ownerUsername, collaboratorUsername string, sshPublicKeys []string, grantSudo, grantContainerRuntime bool) (*collaborator.Collaborator, error) {
 	// Validate inputs
 	if ownerUsername == "" {
 		return nil, fmt.Errorf("owner username cannot be empty")
@@ -39,8 +40,17 @@ func (cm *CollaboratorManager) AddCollaborator(ownerUsername, collaboratorUserna
 	if collaboratorUsername == "" {
 		return nil, fmt.Errorf("collaborator username cannot be empty")
 	}
-	if sshPublicKey == "" {
-		return nil, fmt.Errorf("SSH public key cannot be empty")
+	// Normalize keys: drop blanks/whitespace, require at least one. All
+	// the collaborator's keys are authorized so they can connect from
+	// any of their machines (#369).
+	keys := make([]string, 0, len(sshPublicKeys))
+	for _, k := range sshPublicKeys {
+		if k = strings.TrimSpace(k); k != "" {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("at least one SSH public key is required")
 	}
 
 	// Validate owner username (same rules — prevents sudoers injection)
@@ -71,15 +81,25 @@ func (cm *CollaboratorManager) AddCollaborator(ownerUsername, collaboratorUserna
 	}
 
 	// Step 1: Create collaborator user in the container
-	if err := cm.createCollaboratorUser(containerName, ownerUsername, accountName, sshPublicKey, grantSudo, grantContainerRuntime); err != nil {
+	if err := cm.createCollaboratorUser(containerName, ownerUsername, accountName, keys, grantSudo, grantContainerRuntime); err != nil {
 		return nil, fmt.Errorf("failed to create collaborator user in container: %w", err)
 	}
 
-	// Step 2: Create jump server account for SSH ProxyJump access
-	if err := CreateJumpServerAccount(accountName, sshPublicKey, true); err != nil {
+	// Step 2: Create jump server account for SSH ProxyJump access.
+	// Seed it with the first key, then authorize the rest so the
+	// collaborator can ProxyJump from any of their machines (#369).
+	if err := CreateJumpServerAccount(accountName, keys[0], true); err != nil {
 		// Rollback: remove user from container
 		_ = cm.removeCollaboratorUser(containerName, accountName)
 		return nil, fmt.Errorf("failed to create jump server account: %w", err)
+	}
+	for _, k := range keys[1:] {
+		if err := updateUserSSHKey(accountName, k, true); err != nil {
+			// Rollback: container user + jump account.
+			_ = cm.removeCollaboratorUser(containerName, accountName)
+			_ = DeleteJumpServerAccount(accountName, true)
+			return nil, fmt.Errorf("failed to authorize additional SSH key on jump server: %w", err)
+		}
 	}
 
 	// Step 3: Store collaborator in database
@@ -88,7 +108,7 @@ func (cm *CollaboratorManager) AddCollaborator(ownerUsername, collaboratorUserna
 		OwnerUsername:        ownerUsername,
 		CollaboratorUsername: collaboratorUsername,
 		AccountName:          accountName,
-		SSHPublicKey:         sshPublicKey,
+		SSHPublicKey:         strings.Join(keys, "\n"),
 		CreatedAt:            time.Now(),
 		CreatedBy:            ownerUsername,
 		HasSudo:              grantSudo,
@@ -106,7 +126,7 @@ func (cm *CollaboratorManager) AddCollaborator(ownerUsername, collaboratorUserna
 }
 
 // createCollaboratorUser creates a collaborator user inside the container
-func (cm *CollaboratorManager) createCollaboratorUser(containerName, ownerUsername, accountName, sshPublicKey string, grantSudo, grantContainerRuntime bool) error {
+func (cm *CollaboratorManager) createCollaboratorUser(containerName, ownerUsername, accountName string, sshPublicKeys []string, grantSudo, grantContainerRuntime bool) error {
 	// Detect OS family from container labels or by probing
 	info, err := cm.manager.incus.GetContainer(containerName)
 	family := ostype.Debian
@@ -155,8 +175,8 @@ func (cm *CollaboratorManager) createCollaboratorUser(containerName, ownerUserna
 		_ = cm.manager.incus.Exec(containerName, []string{"usermod", "-aG", "podman", accountName})
 	}
 
-	// Setup SSH keys
-	if err := cm.manager.addSSHKeys(containerName, accountName, []string{sshPublicKey}); err != nil {
+	// Setup SSH keys — all of the collaborator's keys (#369).
+	if err := cm.manager.addSSHKeys(containerName, accountName, sshPublicKeys); err != nil {
 		return fmt.Errorf("failed to add SSH keys: %w", err)
 	}
 
@@ -361,4 +381,3 @@ func (cm *CollaboratorManager) SyncCollaboratorAccounts(verbose, force bool) (re
 func (cm *CollaboratorManager) GetStore() *collaborator.Store {
 	return cm.store
 }
-

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -2714,14 +2714,20 @@ type AddCollaboratorRequest struct {
 	OwnerUsername string `protobuf:"bytes,1,opt,name=owner_username,json=ownerUsername,proto3" json:"owner_username,omitempty"`
 	// Collaborator's username to add (e.g., "bob")
 	CollaboratorUsername string `protobuf:"bytes,2,opt,name=collaborator_username,json=collaboratorUsername,proto3" json:"collaborator_username,omitempty"`
-	// SSH public key for the collaborator
+	// SSH public key for the collaborator.
+	// Deprecated: prefer ssh_public_keys. Kept for back-compat — when
+	// ssh_public_keys is empty this single key is used.
 	SshPublicKey string `protobuf:"bytes,3,opt,name=ssh_public_key,json=sshPublicKey,proto3" json:"ssh_public_key,omitempty"`
 	// Grant full sudo access (not just su - owner)
 	GrantSudo bool `protobuf:"varint,4,opt,name=grant_sudo,json=grantSudo,proto3" json:"grant_sudo,omitempty"`
 	// Add to docker/podman group for container runtime access
 	GrantContainerRuntime bool `protobuf:"varint,5,opt,name=grant_container_runtime,json=grantContainerRuntime,proto3" json:"grant_container_runtime,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// SSH public keys for the collaborator — all are authorized, so a
+	// collaborator with several machines can connect from any of them.
+	// Takes precedence over ssh_public_key when non-empty. See #369.
+	SshPublicKeys []string `protobuf:"bytes,6,rep,name=ssh_public_keys,json=sshPublicKeys,proto3" json:"ssh_public_keys,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *AddCollaboratorRequest) Reset() {
@@ -2787,6 +2793,13 @@ func (x *AddCollaboratorRequest) GetGrantContainerRuntime() bool {
 		return x.GrantContainerRuntime
 	}
 	return false
+}
+
+func (x *AddCollaboratorRequest) GetSshPublicKeys() []string {
+	if x != nil {
+		return x.SshPublicKeys
+	}
+	return nil
 }
 
 // AddCollaboratorResponse is the response from adding a collaborator
@@ -4159,14 +4172,15 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"created_by\x18\b \x01(\tR\tcreatedBy\x12\x19\n" +
 	"\bhas_sudo\x18\t \x01(\bR\ahasSudo\x122\n" +
 	"\x15has_container_runtime\x18\n" +
-	" \x01(\bR\x13hasContainerRuntime\"\xf1\x01\n" +
+	" \x01(\bR\x13hasContainerRuntime\"\x99\x02\n" +
 	"\x16AddCollaboratorRequest\x12%\n" +
 	"\x0eowner_username\x18\x01 \x01(\tR\rownerUsername\x123\n" +
 	"\x15collaborator_username\x18\x02 \x01(\tR\x14collaboratorUsername\x12$\n" +
 	"\x0essh_public_key\x18\x03 \x01(\tR\fsshPublicKey\x12\x1d\n" +
 	"\n" +
 	"grant_sudo\x18\x04 \x01(\bR\tgrantSudo\x126\n" +
-	"\x17grant_container_runtime\x18\x05 \x01(\bR\x15grantContainerRuntime\"\x97\x01\n" +
+	"\x17grant_container_runtime\x18\x05 \x01(\bR\x15grantContainerRuntime\x12&\n" +
+	"\x0fssh_public_keys\x18\x06 \x03(\tR\rsshPublicKeys\"\x97\x01\n" +
 	"\x17AddCollaboratorResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12A\n" +
 	"\fcollaborator\x18\x02 \x01(\v2\x1d.containarium.v1.CollaboratorR\fcollaborator\x12\x1f\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -656,7 +656,9 @@ message AddCollaboratorRequest {
   // Collaborator's username to add (e.g., "bob")
   string collaborator_username = 2;
 
-  // SSH public key for the collaborator
+  // SSH public key for the collaborator.
+  // Deprecated: prefer ssh_public_keys. Kept for back-compat — when
+  // ssh_public_keys is empty this single key is used.
   string ssh_public_key = 3;
 
   // Grant full sudo access (not just su - owner)
@@ -664,6 +666,11 @@ message AddCollaboratorRequest {
 
   // Add to docker/podman group for container runtime access
   bool grant_container_runtime = 5;
+
+  // SSH public keys for the collaborator — all are authorized, so a
+  // collaborator with several machines can connect from any of them.
+  // Takes precedence over ssh_public_key when non-empty. See #369.
+  repeated string ssh_public_keys = 6;
 }
 
 // AddCollaboratorResponse is the response from adding a collaborator


### PR DESCRIPTION
Closes #369.

## Problem
`AddCollaborator` took a **single** `ssh_public_key`, so a collaborator's account was authorized for exactly one key — a user with several machines could only reach the box from one. The layer beneath (`Manager.addSSHKeys`) already took a slice; only the RPC message and the `AddCollaborator` / `createCollaboratorUser` entrypoints were single-key.

## Change
- **proto:** `AddCollaboratorRequest` gains `repeated string ssh_public_keys` (field 6). The legacy `ssh_public_key` is kept and used as a fallback when the repeated field is empty. Stubs regenerated via `make proto`.
- **`CollaboratorManager.AddCollaborator` / `createCollaboratorUser`** now take `[]string`:
  - **Container account** — passed straight to `addSSHKeys`, which writes + validates all keys.
  - **Jump-server account** — seeded with the first key via `CreateJumpServerAccount`, remaining keys appended via the in-package `updateUserSSHKey`, so ProxyJump works from any machine. (Avoids changing `CreateJumpServerAccount`'s signature, which has 6 callers.)
  - **DB record** — stores all keys newline-joined (authorized_keys format), so collaborator *restore* replays every key.
- **gRPC handler** resolves keys via `collaboratorKeysFromRequest` (repeated preferred → single fallback → error if neither) and forwards **both** fields to peers for back-compat with older daemons.
- **CLI** — `--ssh-key` is now repeatable (`StringArray`); pass it once per key, keeping CLI parity with the RPC.

## Back-compat
Old clients sending `ssh_public_key` keep working (fallback). Old peers receiving a forwarded request still get `ssh_public_key` (set to the first key) alongside the new `ssh_public_keys`.

## Test plan
`TestCollaboratorKeysFromRequest` covers the resolution matrix (prefer repeated / fall back to single / repeated-wins-when-both / nil when neither). `go build ./...` + `internal/server`, `pkg/core/container`, `internal/cmd` suites green. Full end-to-end add still requires Incus + Postgres (unchanged by this PR).

## Cloud side
Unblocks `Containarium-cloud`'s collaborator-governance flow (PR #177), which currently passes only the first key as a documented interim and is structured to switch to all-keys in one line once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)