### PR TITLE
feat(sentinel): surface HMAC misconfig in /status for alerting (#341)

### DIFF
--- a/internal/sentinel/binaryserver.go
+++ b/internal/sentinel/binaryserver.go
@@ -31,6 +31,13 @@ type StatusJSON struct {
 	CertSyncCount  int    `json:"cert_sync_count"`
 	CertLastSync   string `json:"cert_last_sync,omitempty"`
 	CertSyncError  string `json:"cert_sync_error,omitempty"`
+	// SentinelAuthMisconfigured is true when CONTAINARIUM_SENTINEL_AUTH_SECRET
+	// is unset or shorter than the minimum, which silently 401s every
+	// keysync/certsync against the daemons. Surfaced here (in addition
+	// to the startup + per-cycle log lines) so monitoring can alert on
+	// it without scraping logs — alert on this being true. #341.
+	SentinelAuthMisconfigured bool   `json:"sentinel_auth_misconfigured"`
+	SentinelAuthDetail        string `json:"sentinel_auth_detail,omitempty"`
 }
 
 // StartBinaryServer starts an HTTP server that serves the containarium binary
@@ -137,6 +144,12 @@ func StartBinaryServer(port int, manager *Manager) (stop func(), err error) {
 		}
 		if err := manager.certStore.LastSyncErr(); err != nil {
 			status.CertSyncError = err.Error()
+		}
+		if !manager.HMACSecretConfigured() {
+			status.SentinelAuthMisconfigured = true
+			status.SentinelAuthDetail = fmt.Sprintf(
+				"CONTAINARIUM_SENTINEL_AUTH_SECRET unset or < %d bytes; keysync/certsync to daemons is failing with 401",
+				auth.SentinelMinSecretLen)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/sentinel/hmac_configured_test.go
+++ b/internal/sentinel/hmac_configured_test.go
@@ -1,0 +1,37 @@
+package sentinel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+// TestHMACSecretConfigured guards the #341 misconfig signal: the
+// sentinel must report its keysync/certsync auth as misconfigured when
+// CONTAINARIUM_SENTINEL_AUTH_SECRET is unset or shorter than the
+// minimum, so /status can flag it for alerting.
+func TestHMACSecretConfigured(t *testing.T) {
+	tests := []struct {
+		name   string
+		secret []byte
+		want   bool
+	}{
+		{"unset", nil, false},
+		{"empty", []byte(""), false},
+		{"too short", []byte("short"), false},
+		{"one under min", []byte(strings.Repeat("x", auth.SentinelMinSecretLen-1)), false},
+		{"exactly min", []byte(strings.Repeat("x", auth.SentinelMinSecretLen)), true},
+		{"comfortably long", []byte(strings.Repeat("x", auth.SentinelMinSecretLen+16)), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Manager{}
+			m.SetHMACSecret(tt.secret)
+			if got := m.HMACSecretConfigured(); got != tt.want {
+				t.Errorf("HMACSecretConfigured() = %v, want %v (len=%d, min=%d)",
+					got, tt.want, len(tt.secret), auth.SentinelMinSecretLen)
+			}
+		})
+	}
+}

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -75,7 +75,7 @@ type Manager struct {
 	keyStore        *KeyStore
 
 	// Tunnel/hybrid mode: ConnMux-based HTTPS handling
-	httpsDispatch  *dispatchListener // from ConnMux, dispatches to proxy or maintenance
+	httpsDispatch *dispatchListener // from ConnMux, dispatches to proxy or maintenance
 
 	// Simple-proxy mode (no ConnMux): userspace TCP forwarder used when
 	// --proxy-protocol is set, so connections to :80/:443 traverse a Go
@@ -107,10 +107,10 @@ type Manager struct {
 	// audit-critical leak (Bearer JWTs in cleartext on peer-to-peer
 	// calls) is only fully closed once the CA is in place and every
 	// daemon is talking to the HTTPS endpoint.
-	pki              *pki.Provisioner
-	sentinelCertPEM  []byte
-	sentinelKeyPEM   []byte
-	pkiMu            sync.RWMutex
+	pki             *pki.Provisioner
+	sentinelCertPEM []byte
+	sentinelKeyPEM  []byte
+	pkiMu           sync.RWMutex
 }
 
 // SetHMACSecret wires the sentinel↔daemon shared HMAC secret. Used
@@ -121,6 +121,14 @@ type Manager struct {
 // depending on its own configuration. See finding C-CRIT-2.
 func (m *Manager) SetHMACSecret(secret []byte) {
 	m.hmacSecret = secret
+}
+
+// HMACSecretConfigured reports whether the sentinel↔daemon HMAC secret
+// is present and long enough. False means every keysync/certsync to the
+// daemons is silently 401ing; the /status endpoint surfaces this so
+// monitoring can alert without scraping logs. See #341.
+func (m *Manager) HMACSecretConfigured() bool {
+	return len(m.hmacSecret) >= auth.SentinelMinSecretLen
 }
 
 // SetCertProvisioner installs the peer-CA the sentinel will use for
@@ -1020,7 +1028,7 @@ func (m *Manager) OnTunnelConnect(spot *TunnelSpot) {
 		IP:           spot.LocalIP,
 		ExternalPort: spot.ExternalPort,
 		Provider:     NewTunnelProvider(nil, spot.ID), // tunnel provider can't restart VMs
-		Priority:     10, // lower priority than GCP for HTTP
+		Priority:     10,                              // lower priority than GCP for HTTP
 		Pool:         spot.Pool,
 	}
 	m.backends.Add(b)
@@ -1098,8 +1106,8 @@ func (m *Manager) OnTunnelDisconnect(spot *TunnelSpot) {
 
 // --- Exported state getters ---
 
-func (m *Manager) CurrentState() State  { return m.currentState() }
-func (m *Manager) PreemptCount() int    { return m.preemptCount }
+func (m *Manager) CurrentState() State       { return m.currentState() }
+func (m *Manager) PreemptCount() int         { return m.preemptCount }
 func (m *Manager) LastPreemption() time.Time { return m.lastPreemption }
 
 // SpotIP returns the primary backend IP (backward compat).


### PR DESCRIPTION
Addresses the **alertable-signal** part of #341 part 1.

## Context
When `CONTAINARIUM_SENTINEL_AUTH_SECRET` is unset or shorter than the minimum, every sentinel→daemon keysync/certsync silently 401s, and operators only discover it hours later by drilling through several layers (sshpiper → backend probe → daemon endpoint test).

Most of #341 part 1's "log loudly" ask is **already implemented**: the daemon (`dual_server.go`) and sentinel (`sentinel_auth.go`, `manager.go`) log at startup, and the daemon's HMAC middleware logs per-request. But logs aren't always wired to alerting.

## Change
Surface the misconfig as a machine-readable field on the sentinel's **always-available `/status`** endpoint:
- `Manager.HMACSecretConfigured()` — true iff the secret is ≥ `SentinelMinSecretLen`.
- `/status` now returns `sentinel_auth_misconfigured` (bool) + `sentinel_auth_detail` (human string when true).

Monitoring can alert on `sentinel_auth_misconfigured == true` instead of scraping logs — the "emit a metric / alertable signal" option from the issue.

## Why /status and not failing /health
The secret only gates daemon **sync** (keysync/certsync), not the sentinel's SSH proxying. Failing `/health` with a 503 could pull the sentinel from load-balancer rotation — or restart-loop it under a liveness probe — for a non-fatal misconfig. `/status` exposes the signal without that blast radius.

## Test plan
`TestHMACSecretConfigured` covers unset / empty / too-short / one-under-min / exactly-min / comfortably-long. `go build ./...` + full `internal/sentinel` suite green.

## Intentionally NOT included
- **Hard refuse-to-start** — riskier; would break deployments that legitimately run without sentinel-auth, and is a behavior change with fleet-wide blast radius. Left as a deliberate operator decision.
- **Part 2 (deploy-pipeline secret distribution)** — infra/automation, out of scope for a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)