### PR TITLE
docs(terraform): 0.9.x→0.21.x migration note + sentinel_auth_secret guard (#375)

### DIFF
--- a/terraform/modules/containarium/README.md
+++ b/terraform/modules/containarium/README.md
@@ -1,0 +1,77 @@
+# `containarium` Terraform module
+
+Provisions a Containarium deployment on GCP (spot daemon + optional sentinel
+HA front). Consume by `?ref=`-pinning a tag:
+
+```hcl
+module "containarium" {
+  source = "git::https://github.com/FootprintAI/Containarium//terraform/modules/containarium?ref=v0.21.0"
+  # ...
+}
+```
+
+Requires **Terraform >= 1.2** (for the `sentinel_auth_secret` precondition).
+
+---
+
+## Migration: `0.9.x` → `0.21.x`
+
+This is a **breaking variable-API change**. A consumer pinned at `0.9.1` that
+bumps `?ref=` to `v0.21.0` will fail `terraform plan` with `Unsupported
+argument` until the removed variables below are deleted from the module block.
+(Var count: 37 → 44.)
+
+### Removed variables
+
+| Removed | Why |
+|---|---|
+| `enable_glb_backend` | **GLB dropped** (`077c84b`). The GCP Global Load Balancer (~$648/mo) was replaced by **Caddy TLS termination**. |
+| `enable_health_check_firewall` | Belonged to the GLB health-check path, removed with the GLB. |
+
+**This removal is intentional.** External HTTPS now flows
+**sentinel DNAT → Caddy → Let's Encrypt (HTTP-01 ACME)** instead of through a
+Google-managed HTTPS load balancer.
+
+**How the daemon is fronted now:** the daemon's REST (`:8080`) and gRPC
+(`:50051`) ports are **no longer exposed externally** — they were removed from
+the sentinel DNAT forwarded-ports default. Reach the daemon through **Caddy on
+`:443`** (which terminates TLS and reverse-proxies). If you were fronting `:8080`
+with the GLB, that path is gone; use the Caddy/`:443` ingress.
+
+To migrate a GLB-less consumer (the common case): **just delete** the
+`enable_glb_backend` / `enable_health_check_firewall` lines — there is no
+replacement variable to set.
+
+### Added variables (`v0.21.0`)
+
+| Variable | Default | Notes |
+|---|---|---|
+| `base_domain` | set | Apex for Caddy-managed certs / routing. |
+| `enable_app_hosting` | `false` | Caddy app-hosting / public route management. |
+| `enable_proxy_protocol` | `false` | Prepend PROXY v2 so Caddy sees the real client IP. |
+| `proxy_protocol_trusted_cidrs` | defaulted | Trusted sources for the PROXY header. |
+| `allowed_management_sources` | defaulted | CIDRs allowed to reach management/SSH. |
+| `sentinel_auth_secret` | `""` | **Sentinel↔daemon HMAC secret (32+ bytes).** See below. |
+| `enable_peer_mtls` | `false` | Phase 0.5 peer mTLS. **Requires `sentinel_auth_secret`.** |
+| `kms_key_self_link` | `""` | KMS key for encryption integrations. |
+| `zfs_encryption_keyfile` | `""` | Per-host ZFS encryption keyfile path. |
+
+### Required variables
+
+**None of the new variables are Terraform-required** — all have defaults, so
+omitting them will not error `plan`. Two need a closer read:
+
+- **`sentinel_auth_secret`** defaults to `""`, which means *"fall back to
+  pre-Phase-0 behavior with the audit-known vulnerabilities."* It is **not**
+  enforced by Terraform, but you **should set it** (32+ bytes, the same value on
+  the sentinel and every daemon it talks to) whenever `enable_sentinel = true`.
+  An empty/short secret is exactly the path into the silent keysync/certsync
+  **401 lockout** tracked in [#341]: both daemons report `active`, but every
+  sync fails until the secret is configured.
+
+- **`enable_peer_mtls = true` now requires `sentinel_auth_secret`** to be 32+
+  bytes — enforced by a `precondition`, so a mismatch fails at **plan time**
+  with a clear message instead of coming up broken. (This is why the module now
+  requires Terraform >= 1.2.)
+
+[#341]: https://github.com/FootprintAI/Containarium/issues/341

--- a/terraform/modules/containarium/main.tf
+++ b/terraform/modules/containarium/main.tf
@@ -5,7 +5,9 @@
 # Network references are parameterized for both default and VPC networks.
 
 terraform {
-  required_version = ">= 1.0"
+  # >= 1.2 for the lifecycle precondition guarding sentinel_auth_secret
+  # when enable_peer_mtls is set (see sentinel.tf, issue #341).
+  required_version = ">= 1.2"
 
   required_providers {
     google = {

--- a/terraform/modules/containarium/sentinel.tf
+++ b/terraform/modules/containarium/sentinel.tf
@@ -88,6 +88,16 @@ resource "google_compute_instance" "sentinel" {
     ignore_changes = [
       metadata["ssh-keys"],
     ]
+
+    # Phase 0.5 peer mTLS rides on the sentinel↔daemon HMAC channel, so it
+    # is inert without a shared secret. Fail at plan time rather than let
+    # the deployment come up and silently 401 every keysync/certsync (the
+    # lockout described in issue #341). 32 bytes matches the daemon's
+    # auth.SentinelMinSecretLen.
+    precondition {
+      condition     = !var.enable_peer_mtls || length(var.sentinel_auth_secret) >= 32
+      error_message = "enable_peer_mtls = true requires sentinel_auth_secret to be a 32+ byte shared secret (currently ${length(var.sentinel_auth_secret)} bytes). An empty/short secret silently 401s every sentinel↔daemon sync — see issue #341."
+    }
   }
 }
 


### PR DESCRIPTION
Closes #375.

## What & why
The `containarium` module dropped `enable_glb_backend` and `enable_health_check_firewall` between `0.9.1` and `v0.21.0` (in `077c84b`, *"remove GLB and secure management domain via Caddy TLS"*) with no migration note, so a consumer bumping `?ref=` fails `plan` with `Unsupported argument`.

## Changes
1. **Module `README.md`** with a **0.9.x → 0.21.x** migration section:
   - Removed vars + why — **GLB (~$648/mo) replaced by Caddy TLS / Let's Encrypt**; the daemon's `:8080`/`:50051` are no longer externally exposed and are reached via **Caddy on `:443`** (sentinel DNAT → Caddy).
   - Added-vars table (all 9, with defaults).
   - **Required-vars clarification:** none of the new vars are Terraform-required (all defaulted), but `sentinel_auth_secret` should be set when `enable_sentinel = true` — empty is the documented pre-Phase-0 vulnerable fallback and the path into the #341 silent-401 lockout.
2. **`precondition` guard** on the sentinel instance: `enable_peer_mtls = true` now requires `sentinel_auth_secret` ≥ 32 bytes (matching the daemon's `auth.SentinelMinSecretLen`), failing at **plan time** instead of coming up broken. This enforces the requirement the `enable_peer_mtls` description already documented, and turns a #341-style silent runtime lockout into a clear error. Bumps `required_version` to `>= 1.2` for precondition support.

## Validation
`terraform fmt -check` clean; `terraform validate` passes.

## Note
The `required_version` bump (`>= 1.0` → `>= 1.2`) is itself a minor consumer-facing requirement; 1.2 shipped mid-2022, so it should be a non-issue, and it's called out in the migration note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)