### PR TITLE
feat(caddy): DNS-01 ACME support for wildcard certs (#378)

### DIFF
--- a/internal/app/caddy_dns01_test.go
+++ b/internal/app/caddy_dns01_test.go
@@ -1,0 +1,120 @@
+package app
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestIssuersFor_NoDNS_MatchesLegacyDefault locks in that, without a DNS
+// challenge, the emitted issuers JSON is byte-identical to the pre-#378
+// default (acme + zerossl, no `challenges` field) — so existing HTTP-01
+// deployments are unaffected.
+func TestIssuersFor_NoDNS_MatchesLegacyDefault(t *testing.T) {
+	got, err := json.Marshal(issuersFor(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `[{"module":"acme"},{"module":"acme","ca":"https://acme.zerossl.com/v2/DV90"}]`
+	if string(got) != want {
+		t.Errorf("no-DNS issuers changed shape:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestIssuersFor_DNS_AttachesChallengeToBoth verifies the DNS-01 challenge
+// block lands on both the ACME and ZeroSSL issuers.
+func TestIssuersFor_DNS_AttachesChallengeToBoth(t *testing.T) {
+	dns := &CaddyACMEChallenges{DNS: &CaddyDNSChallenge{Provider: map[string]interface{}{
+		"name": "cloudflare", "api_token": "{env.CF_API_TOKEN}",
+	}}}
+	issuers := issuersFor(dns)
+	if len(issuers) != 2 {
+		t.Fatalf("want 2 issuers, got %d", len(issuers))
+	}
+	for i, iss := range issuers {
+		if iss.Challenges == nil || iss.Challenges.DNS == nil {
+			t.Fatalf("issuer %d missing DNS challenge", i)
+		}
+		if iss.Challenges.DNS.Provider["name"] != "cloudflare" {
+			t.Errorf("issuer %d provider name = %v, want cloudflare", i, iss.Challenges.DNS.Provider["name"])
+		}
+	}
+	// And it serializes into Caddy's expected nesting.
+	out, _ := json.Marshal(issuers[0])
+	if !strings.Contains(string(out), `"challenges":{"dns":{"provider":{"api_token":"{env.CF_API_TOKEN}","name":"cloudflare"}}}`) {
+		t.Errorf("unexpected DNS-01 issuer JSON: %s", out)
+	}
+}
+
+func TestDNSChallengeFromEnv(t *testing.T) {
+	t.Run("unset → nil (default HTTP-01)", func(t *testing.T) {
+		t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", "")
+		if got := DNSChallengeFromEnv(); got != nil {
+			t.Errorf("want nil when provider unset, got %+v", got)
+		}
+	})
+
+	t.Run("cloudflare default api_token", func(t *testing.T) {
+		t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", "cloudflare")
+		t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG", "")
+		got := DNSChallengeFromEnv()
+		if got == nil || got.DNS == nil {
+			t.Fatal("want a DNS challenge")
+		}
+		if got.DNS.Provider["name"] != "cloudflare" {
+			t.Errorf("name = %v", got.DNS.Provider["name"])
+		}
+		if got.DNS.Provider["api_token"] != "{env.CF_API_TOKEN}" {
+			t.Errorf("api_token = %v, want the CF_API_TOKEN env placeholder", got.DNS.Provider["api_token"])
+		}
+	})
+
+	t.Run("arbitrary provider via JSON config", func(t *testing.T) {
+		t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", "route53")
+		t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG", `{"max_retries":10}`)
+		got := DNSChallengeFromEnv()
+		if got == nil || got.DNS == nil {
+			t.Fatal("want a DNS challenge")
+		}
+		if got.DNS.Provider["name"] != "route53" {
+			t.Errorf("name = %v", got.DNS.Provider["name"])
+		}
+		// route53 reads AWS env, so no token field is injected.
+		if _, ok := got.DNS.Provider["api_token"]; ok {
+			t.Error("did not expect api_token for route53")
+		}
+		if got.DNS.Provider["max_retries"] != float64(10) {
+			t.Errorf("max_retries = %v, want extra JSON field merged in", got.DNS.Provider["max_retries"])
+		}
+	})
+
+	t.Run("explicit config overrides cloudflare default", func(t *testing.T) {
+		t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", "cloudflare")
+		t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG", `{"api_token":"{env.MY_TOKEN}"}`)
+		got := DNSChallengeFromEnv()
+		if got.DNS.Provider["api_token"] != "{env.MY_TOKEN}" {
+			t.Errorf("api_token = %v, want explicit override", got.DNS.Provider["api_token"])
+		}
+	})
+}
+
+// TestNewTLSPolicyWithDNS_Wildcard checks a wildcard subject pairs with the
+// DNS-01 issuers (the combination HTTP-01 can't do).
+func TestNewTLSPolicyWithDNS_Wildcard(t *testing.T) {
+	dns := DNSChallengeFromEnvWith(t, "cloudflare")
+	pol := NewTLSPolicyWithDNS([]string{"*.example.com"}, dns)
+	if len(pol.Subjects) != 1 || pol.Subjects[0] != "*.example.com" {
+		t.Fatalf("subjects = %v", pol.Subjects)
+	}
+	if pol.Issuers[0].Challenges == nil {
+		t.Error("wildcard policy issuer missing DNS-01 challenge")
+	}
+}
+
+// DNSChallengeFromEnvWith is a tiny test helper that sets the provider env and
+// returns the resulting challenge.
+func DNSChallengeFromEnvWith(t *testing.T, provider string) *CaddyACMEChallenges {
+	t.Helper()
+	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", provider)
+	return DNSChallengeFromEnv()
+}

--- a/internal/app/caddy_dns01_test.go
+++ b/internal/app/caddy_dns01_test.go
@@ -118,3 +118,21 @@ func DNSChallengeFromEnvWith(t *testing.T, provider string) *CaddyACMEChallenges
 	t.Setenv("CONTAINARIUM_ACME_DNS_PROVIDER", provider)
 	return DNSChallengeFromEnv()
 }
+
+// TestDNSProviderModule maps provider names to their xcaddy module so the core
+// Caddy build can compile in the right caddy-dns plugin (#378). A config the
+// daemon emits is useless if Caddy lacks the matching module.
+func TestDNSProviderModule(t *testing.T) {
+	cases := map[string]string{
+		"cloudflare":   "github.com/caddy-dns/cloudflare",
+		"route53":      "github.com/caddy-dns/route53",
+		" cloudflare ": "github.com/caddy-dns/cloudflare", // trimmed
+		"unknown":      "",
+		"":             "",
+	}
+	for in, want := range cases {
+		if got := DNSProviderModule(in); got != want {
+			t.Errorf("DNSProviderModule(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/app/caddy_types.go
+++ b/internal/app/caddy_types.go
@@ -1,5 +1,11 @@
 package app
 
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
+
 // Caddy API Types
 // These types provide type-safe representations of Caddy's JSON API structures.
 // Reference: https://caddyserver.com/docs/json/
@@ -32,9 +38,9 @@ type CaddyTrustedProxies struct {
 
 // CaddyRouteTyped represents a fully typed Caddy route configuration
 type CaddyRouteTyped struct {
-	ID     string             `json:"@id,omitempty"`
-	Match  []CaddyMatchTyped  `json:"match,omitempty"`
-	Handle []CaddyHandler     `json:"handle,omitempty"`
+	ID     string            `json:"@id,omitempty"`
+	Match  []CaddyMatchTyped `json:"match,omitempty"`
+	Handle []CaddyHandler    `json:"handle,omitempty"`
 }
 
 // CaddyMatchTyped represents typed match conditions for a route
@@ -51,16 +57,16 @@ type CaddyHandler interface {
 
 // CaddyReverseProxyHandler represents a reverse_proxy handler configuration
 type CaddyReverseProxyHandler struct {
-	Handler   string                `json:"handler"` // Always "reverse_proxy"
-	Upstreams []CaddyUpstreamTyped  `json:"upstreams"`
-	Headers   *CaddyHeadersConfig   `json:"headers,omitempty"`
-	Transport *CaddyHTTPTransport   `json:"transport,omitempty"` // For gRPC/HTTP2 support
+	Handler   string               `json:"handler"` // Always "reverse_proxy"
+	Upstreams []CaddyUpstreamTyped `json:"upstreams"`
+	Headers   *CaddyHeadersConfig  `json:"headers,omitempty"`
+	Transport *CaddyHTTPTransport  `json:"transport,omitempty"` // For gRPC/HTTP2 support
 }
 
 // CaddyHTTPTransport represents the HTTP transport configuration
 // Used to enable HTTP/2 (h2c) for gRPC proxying
 type CaddyHTTPTransport struct {
-	Protocol string   `json:"protocol"`          // Always "http" for HTTP transport
+	Protocol string   `json:"protocol"`           // Always "http" for HTTP transport
 	Versions []string `json:"versions,omitempty"` // ["h2c", "2"] for gRPC
 }
 
@@ -97,10 +103,10 @@ type CaddyHeaderOps struct {
 
 // CaddyStaticResponseHandler represents a static_response handler
 type CaddyStaticResponseHandler struct {
-	Handler    string            `json:"handler"` // Always "static_response"
-	StatusCode int               `json:"status_code,omitempty"`
+	Handler    string              `json:"handler"` // Always "static_response"
+	StatusCode int                 `json:"status_code,omitempty"`
 	Headers    map[string][]string `json:"headers,omitempty"`
-	Body       string            `json:"body,omitempty"`
+	Body       string              `json:"body,omitempty"`
 }
 
 // HandlerName implements CaddyHandler
@@ -110,20 +116,39 @@ func (h CaddyStaticResponseHandler) HandlerName() string {
 
 // CaddyTLSAutomationPolicy represents a TLS automation policy
 type CaddyTLSAutomationPolicy struct {
-	Subjects      []string          `json:"subjects,omitempty"`
-	Issuers       []CaddyTLSIssuer  `json:"issuers,omitempty"`
-	OnDemand      bool              `json:"on_demand,omitempty"`
-	MustStaple    bool              `json:"must_staple,omitempty"`
-	RenewalWindow string            `json:"renewal_window,omitempty"` // Duration string, e.g., "720h"
+	Subjects      []string         `json:"subjects,omitempty"`
+	Issuers       []CaddyTLSIssuer `json:"issuers,omitempty"`
+	OnDemand      bool             `json:"on_demand,omitempty"`
+	MustStaple    bool             `json:"must_staple,omitempty"`
+	RenewalWindow string           `json:"renewal_window,omitempty"` // Duration string, e.g., "720h"
 }
 
 // CaddyTLSIssuer represents a TLS certificate issuer configuration
 type CaddyTLSIssuer struct {
-	Module                string `json:"module"`            // "acme", "internal", "zerossl"
-	CA                    string `json:"ca,omitempty"`      // ACME CA URL
-	Email                 string `json:"email,omitempty"`   // ACME account email
-	ExternalAccountKey    string `json:"external_account,omitempty"`
-	TrustedRootsPEMFiles  []string `json:"trusted_roots_pem_files,omitempty"`
+	Module               string               `json:"module"`          // "acme", "internal", "zerossl"
+	CA                   string               `json:"ca,omitempty"`    // ACME CA URL
+	Email                string               `json:"email,omitempty"` // ACME account email
+	ExternalAccountKey   string               `json:"external_account,omitempty"`
+	TrustedRootsPEMFiles []string             `json:"trusted_roots_pem_files,omitempty"`
+	Challenges           *CaddyACMEChallenges `json:"challenges,omitempty"` // DNS-01 opt-in; nil = Caddy default (HTTP-01 + TLS-ALPN-01)
+}
+
+// CaddyACMEChallenges configures which ACME challenge types the issuer may
+// use. Only the DNS-01 path is modeled here — it's the one that can issue
+// wildcard certs and sidesteps the HTTP-01 redirect failure mode. Leaving
+// this nil keeps Caddy's default HTTP-01 + TLS-ALPN-01 behavior.
+type CaddyACMEChallenges struct {
+	DNS *CaddyDNSChallenge `json:"dns,omitempty"`
+}
+
+// CaddyDNSChallenge holds the DNS-01 provider configuration. Provider is a
+// type-erased object because each caddy-dns module has its own schema (e.g.
+// cloudflare uses {"name":"cloudflare","api_token":"..."}, route53 reads the
+// AWS environment with just {"name":"route53"}). The Caddy binary must be
+// built with the matching dns.providers.<name> module — see
+// internal/hosting/caddy.go for the xcaddy build path.
+type CaddyDNSChallenge struct {
+	Provider map[string]interface{} `json:"provider"`
 }
 
 // CaddyTLSAutomation represents the TLS automation configuration
@@ -256,13 +281,68 @@ func NewZeroSSLIssuer() CaddyTLSIssuer {
 	}
 }
 
+// issuersFor returns the standard ACME + ZeroSSL issuers, attaching the
+// DNS-01 challenge config to each when dns is non-nil (both CAs support
+// DNS-01). When dns is nil the issuers carry no `challenges` field, so the
+// emitted JSON is identical to the pre-DNS-01 default (HTTP-01 + TLS-ALPN-01).
+func issuersFor(dns *CaddyACMEChallenges) []CaddyTLSIssuer {
+	acme := NewACMEIssuer()
+	zerossl := NewZeroSSLIssuer()
+	acme.Challenges = dns
+	zerossl.Challenges = dns
+	return []CaddyTLSIssuer{acme, zerossl}
+}
+
 // NewTLSPolicy creates a TLS automation policy with default issuers
+// (HTTP-01 + TLS-ALPN-01).
 func NewTLSPolicy(subjects []string) CaddyTLSAutomationPolicy {
+	return NewTLSPolicyWithDNS(subjects, nil)
+}
+
+// NewTLSPolicyWithDNS creates a TLS automation policy whose issuers solve
+// DNS-01 via the given challenge config. Passing nil is equivalent to
+// NewTLSPolicy. DNS-01 is required for wildcard subjects (e.g.
+// "*.example.com").
+func NewTLSPolicyWithDNS(subjects []string, dns *CaddyACMEChallenges) CaddyTLSAutomationPolicy {
 	return CaddyTLSAutomationPolicy{
 		Subjects: subjects,
-		Issuers: []CaddyTLSIssuer{
-			NewACMEIssuer(),
-			NewZeroSSLIssuer(),
-		},
+		Issuers:  issuersFor(dns),
 	}
+}
+
+// DNSChallengeFromEnv builds a DNS-01 challenge config from the daemon's
+// environment, or returns nil (the default — HTTP-01 + TLS-ALPN-01) when
+// DNS-01 isn't opted into.
+//
+//   - CONTAINARIUM_ACME_DNS_PROVIDER — the caddy-dns provider name, e.g.
+//     "cloudflare". Empty/unset → DNS-01 disabled, returns nil.
+//   - CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG — optional JSON object of
+//     provider-specific fields merged into the provider block, so any
+//     caddy-dns module works without hardcoding its schema, e.g.
+//     '{"api_token":"{env.MY_TOKEN}"}'. Caddy expands {env.X} at load time,
+//     so the secret itself is never placed in this process's config or logs.
+//
+// As a convenience for the common case, "cloudflare" defaults api_token to
+// "{env.CF_API_TOKEN}" when not overridden. The Caddy binary must be built
+// with the matching dns.providers.<name> module.
+func DNSChallengeFromEnv() *CaddyACMEChallenges {
+	provider := strings.TrimSpace(os.Getenv("CONTAINARIUM_ACME_DNS_PROVIDER"))
+	if provider == "" {
+		return nil
+	}
+	prov := map[string]interface{}{"name": provider}
+	if raw := strings.TrimSpace(os.Getenv("CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG")); raw != "" {
+		var extra map[string]interface{}
+		if err := json.Unmarshal([]byte(raw), &extra); err == nil {
+			for k, v := range extra {
+				prov[k] = v
+			}
+		}
+	}
+	if provider == "cloudflare" {
+		if _, ok := prov["api_token"]; !ok {
+			prov["api_token"] = "{env.CF_API_TOKEN}"
+		}
+	}
+	return &CaddyACMEChallenges{DNS: &CaddyDNSChallenge{Provider: prov}}
 }

--- a/internal/app/caddy_types.go
+++ b/internal/app/caddy_types.go
@@ -348,10 +348,11 @@ func DNSChallengeFromEnv() *CaddyACMEChallenges {
 }
 
 // dnsProviderModules maps a caddy-dns provider name to its Go module path,
-// for the xcaddy build of the core Caddy. This is the canonical list — the
-// core Caddy build (internal/server.setupCaddy) must compile in the matching
-// dns.providers.<name> module or Caddy will reject the DNS-01 config the
-// daemon emits. Mirrors internal/hosting/caddy.go's provider list.
+// for the xcaddy build of Caddy. This is the single source of truth shared by
+// the core Caddy build (internal/server.setupCaddy) and the hosting Caddy
+// build (internal/hosting.CaddyManager.providerModule): the build must compile
+// in the matching dns.providers.<name> module or Caddy rejects the DNS-01
+// config the daemon emits.
 var dnsProviderModules = map[string]string{
 	"cloudflare":     "github.com/caddy-dns/cloudflare",
 	"route53":        "github.com/caddy-dns/route53",

--- a/internal/app/caddy_types.go
+++ b/internal/app/caddy_types.go
@@ -346,3 +346,33 @@ func DNSChallengeFromEnv() *CaddyACMEChallenges {
 	}
 	return &CaddyACMEChallenges{DNS: &CaddyDNSChallenge{Provider: prov}}
 }
+
+// dnsProviderModules maps a caddy-dns provider name to its Go module path,
+// for the xcaddy build of the core Caddy. This is the canonical list — the
+// core Caddy build (internal/server.setupCaddy) must compile in the matching
+// dns.providers.<name> module or Caddy will reject the DNS-01 config the
+// daemon emits. Mirrors internal/hosting/caddy.go's provider list.
+var dnsProviderModules = map[string]string{
+	"cloudflare":     "github.com/caddy-dns/cloudflare",
+	"route53":        "github.com/caddy-dns/route53",
+	"godaddy":        "github.com/caddy-dns/godaddy",
+	"googleclouddns": "github.com/caddy-dns/googleclouddns",
+	"digitalocean":   "github.com/caddy-dns/digitalocean",
+	"azure":          "github.com/caddy-dns/azure",
+	"vultr":          "github.com/caddy-dns/vultr",
+	"duckdns":        "github.com/caddy-dns/duckdns",
+	"namecheap":      "github.com/caddy-dns/namecheap",
+}
+
+// DNSProviderModule returns the xcaddy `--with` module path for a caddy-dns
+// provider name, or "" if unknown. Used by the core Caddy build to compile in
+// the DNS-01 provider the daemon is configured to emit (#378).
+func DNSProviderModule(provider string) string {
+	return dnsProviderModules[strings.TrimSpace(provider)]
+}
+
+// DNSProviderFromEnv returns the configured caddy-dns provider name (from
+// CONTAINARIUM_ACME_DNS_PROVIDER), or "" when DNS-01 isn't opted into.
+func DNSProviderFromEnv() string {
+	return strings.TrimSpace(os.Getenv("CONTAINARIUM_ACME_DNS_PROVIDER"))
+}

--- a/internal/app/manager.go
+++ b/internal/app/manager.go
@@ -41,7 +41,7 @@ type ManagerConfig struct {
 func NewManager(store AppStore, incusClient incus.Backend, config ManagerConfig) *Manager {
 	detector := buildpack.NewDetector()
 	builder := NewBuilder(incusClient, detector)
-	proxy := NewProxyManager(config.CaddyAdminURL, config.BaseDomain)
+	proxy := NewProxyManager(config.CaddyAdminURL, config.BaseDomain).WithDNSChallenge(DNSChallengeFromEnv())
 
 	return &Manager{
 		store:       store,

--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -20,6 +20,11 @@ type ProxyManager struct {
 	baseDomain    string
 	serverName    string // Caddy server name (default: "srv0")
 	httpClient    *http.Client
+	// dnsChallenge, when non-nil, makes provisioned policies solve ACME
+	// DNS-01 (required for wildcard certs). Nil keeps Caddy's default
+	// HTTP-01 + TLS-ALPN-01. Configured via WithDNSChallenge /
+	// DNSChallengeFromEnv. See issue #378.
+	dnsChallenge *CaddyACMEChallenges
 }
 
 // RouteProtocol represents the protocol type for a route
@@ -46,9 +51,9 @@ type Route struct {
 // caddyRouteJSON is used for JSON marshaling routes to Caddy API
 // It uses a concrete handler type for type safety while remaining JSON-compatible
 type caddyRouteJSON struct {
-	ID     string                       `json:"@id,omitempty"`
-	Match  []CaddyMatchTyped            `json:"match,omitempty"`
-	Handle []CaddyReverseProxyHandler   `json:"handle,omitempty"`
+	ID     string                     `json:"@id,omitempty"`
+	Match  []CaddyMatchTyped          `json:"match,omitempty"`
+	Handle []CaddyReverseProxyHandler `json:"handle,omitempty"`
 }
 
 // caddyRouteRaw is used for unmarshaling routes from Caddy API
@@ -69,6 +74,15 @@ func NewProxyManager(caddyAdminURL, baseDomain string) *ProxyManager {
 			Timeout: 10 * time.Second,
 		},
 	}
+}
+
+// WithDNSChallenge configures the manager to provision certificates via ACME
+// DNS-01, which is required for wildcard subjects and sidesteps the HTTP-01
+// redirect failure mode. Nil keeps the default HTTP-01 + TLS-ALPN-01 path.
+// Returns the manager for chaining. See DNSChallengeFromEnv and issue #378.
+func (p *ProxyManager) WithDNSChallenge(dns *CaddyACMEChallenges) *ProxyManager {
+	p.dnsChallenge = dns
+	return p
 }
 
 // SetServerName sets the Caddy server name (useful when Caddy uses a custom server name)
@@ -306,8 +320,9 @@ func (p *ProxyManager) ProvisionTLS(domain string) error {
 		return nil
 	}
 
-	// No existing policies, create a new one with ACME issuers
-	newPolicy := NewTLSPolicy([]string{domain})
+	// No existing policies, create a new one with ACME issuers (DNS-01 when
+	// configured, otherwise Caddy's default HTTP-01 + TLS-ALPN-01).
+	newPolicy := NewTLSPolicyWithDNS([]string{domain}, p.dnsChallenge)
 
 	policyJSON, err := json.Marshal([]CaddyTLSAutomationPolicy{newPolicy})
 	if err != nil {
@@ -332,6 +347,25 @@ func (p *ProxyManager) ProvisionTLS(domain string) error {
 	}
 
 	return nil
+}
+
+// ProvisionWildcardTLS adds a single "*.<baseDomain>" wildcard subject to
+// Caddy's TLS automation, issued via DNS-01. This is the per-cluster
+// alternative to per-subdomain on-demand issuance: one cert covers every
+// subdomain, eliminating the Let's Encrypt per-domain rate-limit exposure and
+// the HTTP-01 redirect failure mode (issue #378).
+//
+// Requires a DNS-01 challenge to be configured — HTTP-01 / TLS-ALPN-01 cannot
+// issue wildcard certificates, so this returns an error rather than silently
+// falling back to a path that can't work.
+func (p *ProxyManager) ProvisionWildcardTLS() error {
+	if p.dnsChallenge == nil {
+		return fmt.Errorf("wildcard TLS requires an ACME DNS-01 provider (set CONTAINARIUM_ACME_DNS_PROVIDER); HTTP-01 / TLS-ALPN-01 cannot issue wildcard certificates")
+	}
+	if p.baseDomain == "" {
+		return fmt.Errorf("wildcard TLS requires a base domain")
+	}
+	return p.ProvisionTLS("*." + p.baseDomain)
 }
 
 // RemoveRoute removes a route from Caddy by subdomain or full domain
@@ -584,20 +618,19 @@ func (p *ProxyManager) ensureTLSApp() error {
 
 // createTLSApp creates the base TLS app with automation policies using ACME issuers
 func (p *ProxyManager) createTLSApp() error {
-	tlsConfig := map[string]interface{}{
-		"automation": map[string]interface{}{
-			"policies": []map[string]interface{}{
-				{
-					"issuers": []map[string]interface{}{
-						{"module": "acme"},
-						{"module": "acme", "ca": "https://acme.zerossl.com/v2/DV90"},
-					},
-				},
+	// Typed config (was a map[string]interface{}). When no DNS challenge is
+	// configured the issuers carry no `challenges` field, so the emitted JSON
+	// is identical to the previous default. With DNS-01 configured, both the
+	// ACME and ZeroSSL issuers gain the provider's `challenges.dns` block.
+	tlsApp := CaddyTLSApp{
+		Automation: &CaddyTLSAutomation{
+			Policies: []CaddyTLSAutomationPolicy{
+				{Issuers: issuersFor(p.dnsChallenge)},
 			},
 		},
 	}
 
-	configJSON, err := json.Marshal(tlsConfig)
+	configJSON, err := json.Marshal(tlsApp)
 	if err != nil {
 		return fmt.Errorf("failed to marshal TLS config: %w", err)
 	}

--- a/internal/hosting/caddy.go
+++ b/internal/hosting/caddy.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/footprintai/containarium/internal/app"
 )
 
 const (
@@ -65,34 +67,25 @@ func NewCaddyManager(cfg CaddyConfig) *CaddyManager {
 	return &CaddyManager{config: cfg}
 }
 
-// providerModule returns the Go module path for the DNS provider
+// providerModule returns the Go module path for the configured DNS provider.
+// Delegates to app.DNSProviderModule — the single source of truth shared with
+// the core Caddy build (internal/server.setupCaddy) so the two can't drift.
 func (m *CaddyManager) providerModule() string {
-	modules := map[string]string{
-		"godaddy":        "github.com/caddy-dns/godaddy",
-		"cloudflare":    "github.com/caddy-dns/cloudflare",
-		"route53":       "github.com/caddy-dns/route53",
-		"googleclouddns": "github.com/caddy-dns/googleclouddns",
-		"digitalocean":  "github.com/caddy-dns/digitalocean",
-		"azure":         "github.com/caddy-dns/azure",
-		"vultr":         "github.com/caddy-dns/vultr",
-		"duckdns":       "github.com/caddy-dns/duckdns",
-		"namecheap":     "github.com/caddy-dns/namecheap",
-	}
-	return modules[m.config.Provider]
+	return app.DNSProviderModule(m.config.Provider)
 }
 
 // dnsConfigBlock returns the Caddyfile DNS configuration block for the provider
 func (m *CaddyManager) dnsConfigBlock() string {
 	configs := map[string]string{
 		"godaddy":        "dns godaddy { api_token {env.GODADDY_API_TOKEN} }",
-		"cloudflare":    "dns cloudflare {env.CF_API_TOKEN}",
-		"route53":       "dns route53",
+		"cloudflare":     "dns cloudflare {env.CF_API_TOKEN}",
+		"route53":        "dns route53",
 		"googleclouddns": "dns googleclouddns {env.GCP_PROJECT}",
-		"digitalocean":  "dns digitalocean {env.DO_AUTH_TOKEN}",
-		"azure":         "dns azure",
-		"vultr":         "dns vultr {env.VULTR_API_KEY}",
-		"duckdns":       "dns duckdns {env.DUCKDNS_API_TOKEN}",
-		"namecheap":     "dns namecheap",
+		"digitalocean":   "dns digitalocean {env.DO_AUTH_TOKEN}",
+		"azure":          "dns azure",
+		"vultr":          "dns vultr {env.VULTR_API_KEY}",
+		"duckdns":        "dns duckdns {env.DUCKDNS_API_TOKEN}",
+		"namecheap":      "dns namecheap",
 	}
 	return configs[m.config.Provider]
 }

--- a/internal/server/core_services.go
+++ b/internal/server/core_services.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/footprintai/containarium/internal/app"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/pkg/core/stacks"
 )
@@ -66,12 +67,12 @@ type CoreServicesConfig struct {
 
 // CoreServices manages the core infrastructure containers (PostgreSQL, Caddy, VictoriaMetrics+Grafana)
 type CoreServices struct {
-	incusClient        incus.Backend
-	config             CoreServicesConfig
-	postgresIP         string
-	caddyIP            string
-	victoriaMetricsIP  string
-	otelCollectorIP    string
+	incusClient       incus.Backend
+	config            CoreServicesConfig
+	postgresIP        string
+	caddyIP           string
+	victoriaMetricsIP string
+	otelCollectorIP   string
 }
 
 // NewCoreServices creates a new core services manager
@@ -442,11 +443,22 @@ func (cs *CoreServices) setupCaddy(ctx context.Context, baseDomain string) error
 		return fmt.Errorf("failed to install xcaddy: %w", err)
 	}
 
-	// Build Caddy with caddy-l4 plugin using xcaddy
-	log.Printf("Building Caddy with caddy-l4 plugin (this may take a few minutes)...")
-	if err := cs.incusClient.Exec(CoreCaddyContainer, []string{
-		"bash", "-c", "xcaddy build --with github.com/mholt/caddy-l4 --output /usr/bin/caddy",
-	}); err != nil {
+	// Build Caddy with caddy-l4 (SNI passthrough) and, when an ACME DNS-01
+	// provider is configured, the matching caddy-dns module — without it Caddy
+	// rejects the DNS-01 config the daemon emits (#378).
+	buildCmd := "xcaddy build --with github.com/mholt/caddy-l4"
+	if provider := app.DNSProviderFromEnv(); provider != "" {
+		if mod := app.DNSProviderModule(provider); mod != "" {
+			buildCmd += " --with " + mod
+			log.Printf("Building Caddy with caddy-l4 + DNS-01 provider %q (%s) (this may take a few minutes)...", provider, mod)
+		} else {
+			log.Printf("WARNING: CONTAINARIUM_ACME_DNS_PROVIDER=%q has no known caddy-dns module; building Caddy without it — DNS-01 wildcard issuance will fail until a module is added", provider)
+		}
+	} else {
+		log.Printf("Building Caddy with caddy-l4 plugin (this may take a few minutes)...")
+	}
+	buildCmd += " --output /usr/bin/caddy"
+	if err := cs.incusClient.Exec(CoreCaddyContainer, []string{"bash", "-c", buildCmd}); err != nil {
 		return fmt.Errorf("failed to build caddy with xcaddy: %w", err)
 	}
 

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -24,22 +24,22 @@ import (
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/autosleep"
 	"github.com/footprintai/containarium/internal/collaborator"
-	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/gateway"
 	"github.com/footprintai/containarium/internal/guacamole"
-	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/internal/metrics"
 	"github.com/footprintai/containarium/internal/mtls"
-	"github.com/footprintai/containarium/pkg/core/network"
 	"github.com/footprintai/containarium/internal/pentest"
-	"github.com/footprintai/containarium/internal/security"
 	secretsstore "github.com/footprintai/containarium/internal/secrets"
-	corecryptosecrets "github.com/footprintai/containarium/pkg/core/secrets"
-	zapscanner "github.com/footprintai/containarium/internal/zap"
+	"github.com/footprintai/containarium/internal/security"
 	"github.com/footprintai/containarium/internal/traffic"
 	"github.com/footprintai/containarium/internal/ttlsweeper"
 	"github.com/footprintai/containarium/internal/wake"
+	zapscanner "github.com/footprintai/containarium/internal/zap"
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/network"
+	corecryptosecrets "github.com/footprintai/containarium/pkg/core/secrets"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/footprintai/containarium/pkg/version"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -67,10 +67,10 @@ type DualServerConfig struct {
 	SwaggerDir string
 
 	// App hosting settings (optional)
-	EnableAppHosting     bool
-	PostgresConnString   string
-	BaseDomain           string
-	CaddyAdminURL        string
+	EnableAppHosting   bool
+	PostgresConnString string
+	BaseDomain         string
+	CaddyAdminURL      string
 
 	// Route sync settings
 	RouteSyncInterval time.Duration // Interval for syncing routes to Caddy (default 5s)
@@ -123,42 +123,42 @@ type DualServerConfig struct {
 
 // DualServer runs both gRPC and HTTP/REST servers
 type DualServer struct {
-	config                *DualServerConfig
-	grpcServer            *grpc.Server
-	containerServer       *ContainerServer
-	appServer             *AppServer
-	networkServer         *NetworkServer
-	trafficServer         *TrafficServer
-	trafficCollector      *traffic.Collector
-	gatewayServer         *gateway.GatewayServer
-	tokenManager          *auth.TokenManager
-	authMiddleware        *auth.AuthMiddleware
-	routeStore            *app.RouteStore
-	routeSyncJob          *app.RouteSyncJob
-	passthroughStore      network.PassthroughStore
-	passthroughSyncJob    *network.PassthroughSyncJob
-	collaboratorStore     *collaborator.Store
-	daemonConfigStore     *app.DaemonConfigStore
-	metricsCollector      *metrics.Collector
-	securityScanner       *security.Scanner
-	securityStore         *security.Store
-	securityServer        *SecurityServer
-	auditStore            *audit.Store
-	auditEventSubscriber  *audit.EventSubscriber
-	sshCollector          *audit.SSHCollector
-	revocationStore       *auth.PgRevocationStore // Phase 1.2 — kill-switch for issued JWTs
-	alertStore            *alert.Store
-	alertManager          *alert.Manager
-	alertDeliveryStore    *alert.DeliveryStore
-	pentestManager        *pentest.Manager
-	pentestStore          *pentest.Store
-	zapManager            *zapscanner.Manager
-	zapStore              *zapscanner.Store
-	peerPool              *PeerPool
-	autoSleepManager      *autosleep.Manager
-	ttlSweeperManager     *ttlsweeper.Manager // ephemeral CI box auto-delete (#299)
-	secretsReconciler     *secretsReconciler // Phase 4.3 Phase B-3
-	startTime             time.Time
+	config               *DualServerConfig
+	grpcServer           *grpc.Server
+	containerServer      *ContainerServer
+	appServer            *AppServer
+	networkServer        *NetworkServer
+	trafficServer        *TrafficServer
+	trafficCollector     *traffic.Collector
+	gatewayServer        *gateway.GatewayServer
+	tokenManager         *auth.TokenManager
+	authMiddleware       *auth.AuthMiddleware
+	routeStore           *app.RouteStore
+	routeSyncJob         *app.RouteSyncJob
+	passthroughStore     network.PassthroughStore
+	passthroughSyncJob   *network.PassthroughSyncJob
+	collaboratorStore    *collaborator.Store
+	daemonConfigStore    *app.DaemonConfigStore
+	metricsCollector     *metrics.Collector
+	securityScanner      *security.Scanner
+	securityStore        *security.Store
+	securityServer       *SecurityServer
+	auditStore           *audit.Store
+	auditEventSubscriber *audit.EventSubscriber
+	sshCollector         *audit.SSHCollector
+	revocationStore      *auth.PgRevocationStore // Phase 1.2 — kill-switch for issued JWTs
+	alertStore           *alert.Store
+	alertManager         *alert.Manager
+	alertDeliveryStore   *alert.DeliveryStore
+	pentestManager       *pentest.Manager
+	pentestStore         *pentest.Store
+	zapManager           *zapscanner.Manager
+	zapStore             *zapscanner.Store
+	peerPool             *PeerPool
+	autoSleepManager     *autosleep.Manager
+	ttlSweeperManager    *ttlsweeper.Manager // ephemeral CI box auto-delete (#299)
+	secretsReconciler    *secretsReconciler  // Phase 4.3 Phase B-3
+	startTime            time.Time
 }
 
 // NewDualServer creates a new dual server instance
@@ -545,7 +545,7 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 					var proxyManager *app.ProxyManager
 
 					if caddyAdminURL != "" {
-						proxyManager = app.NewProxyManager(caddyAdminURL, config.BaseDomain)
+						proxyManager = app.NewProxyManager(caddyAdminURL, config.BaseDomain).WithDNSChallenge(app.DNSChallengeFromEnv())
 						// Ensure Caddy has basic server config for routes
 						if err := proxyManager.EnsureServerConfig(); err != nil {
 							log.Printf("Warning: Failed to ensure Caddy server config: %v", err)
@@ -714,7 +714,7 @@ skipAppHosting:
 				log.Printf("Warning: Failed to create route store: %v", err)
 				pool.Close()
 			} else {
-				proxyManager := app.NewProxyManager(caddyAdminURL, config.BaseDomain)
+				proxyManager := app.NewProxyManager(caddyAdminURL, config.BaseDomain).WithDNSChallenge(app.DNSChallengeFromEnv())
 				if err := proxyManager.EnsureServerConfig(); err != nil {
 					log.Printf("Warning: Failed to ensure Caddy server config: %v", err)
 				}
@@ -1178,23 +1178,23 @@ skipAppHosting:
 	}
 
 	ds := &DualServer{
-		config:             config,
-		grpcServer:         grpcServer,
-		containerServer:    containerServer,
-		appServer:          appServer,
-		networkServer:      networkServer,
-		trafficServer:      trafficServer,
-		trafficCollector:   trafficCollector,
-		gatewayServer:      gatewayServer,
-		tokenManager:       tokenManager,
-		authMiddleware:     authMiddleware,
-		routeStore:         routeStore,
-		routeSyncJob:       routeSyncJob,
-		passthroughStore:   passthroughStore,
-		passthroughSyncJob: passthroughSyncJob,
-		collaboratorStore:  collabStore,
-		daemonConfigStore:  config.DaemonConfigStore,
-		metricsCollector:   metricsCollector,
+		config:               config,
+		grpcServer:           grpcServer,
+		containerServer:      containerServer,
+		appServer:            appServer,
+		networkServer:        networkServer,
+		trafficServer:        trafficServer,
+		trafficCollector:     trafficCollector,
+		gatewayServer:        gatewayServer,
+		tokenManager:         tokenManager,
+		authMiddleware:       authMiddleware,
+		routeStore:           routeStore,
+		routeSyncJob:         routeSyncJob,
+		passthroughStore:     passthroughStore,
+		passthroughSyncJob:   passthroughSyncJob,
+		collaboratorStore:    collabStore,
+		daemonConfigStore:    config.DaemonConfigStore,
+		metricsCollector:     metricsCollector,
 		securityScanner:      securityScanner,
 		securityStore:        securityStore,
 		securityServer:       securityServerInstance,


### PR DESCRIPTION
Closes #378.

## Problem
The daemon drives Caddy's TLS through the JSON admin API, and `CaddyTLSIssuer` (`internal/app/caddy_types.go`) modeled **no DNS-01 challenge** — so it could only do Caddy's default HTTP-01 / TLS-ALPN-01 with per-subdomain on-demand issuance. That:
- **can't issue wildcard certs** (only DNS-01 can),
- exposes a busy cluster to **Let's Encrypt's ~50-cert/domain/week limit** (one cert per `expose_port` subdomain), and
- hits the **HTTP-01 redirect failure mode** (issuance fails when `/.well-known/acme-challenge/*` redirects to HTTPS, RFC 8555 §8.3).

## Change — DNS-01 as an opt-in
- **`caddy_types.go`** — `CaddyTLSIssuer` gains optional `challenges.dns` (`CaddyACMEChallenges` / `CaddyDNSChallenge`). `nil` keeps the **exact** prior JSON (HTTP-01 + TLS-ALPN-01); a test locks the no-DNS output byte-for-byte.
- **`DNSChallengeFromEnv()`** — `CONTAINARIUM_ACME_DNS_PROVIDER` selects the caddy-dns provider; `CONTAINARIUM_ACME_DNS_PROVIDER_CONFIG` supplies provider-specific JSON fields so **any** provider works without hardcoding its schema; `cloudflare` defaults `api_token` to `{env.CF_API_TOKEN}`. Caddy expands `{env.X}` at load time, so **the secret never enters this process's config or logs**.
- **`ProxyManager.WithDNSChallenge`** wires it; `createTLSApp` (now typed — was a `map[string]interface{}`) and the new-policy path emit DNS-01 issuers when configured. The three construction sites read `DNSChallengeFromEnv()`.
- **`ProvisionWildcardTLS()`** provisions one `*.<base_domain>` wildcard via DNS-01 (errors if no DNS provider is set — HTTP-01 can't issue wildcards, so it won't silently fall back to a path that can't work).

## Operator requirement (documented, not code)
Caddy must be built with the matching `dns.providers.<name>` module via `xcaddy` — the same requirement `internal/hosting/caddy.go` already documents (it has the provider→module map). This PR makes the **daemon emit the correct config**; the binary capability is operator-side.

## Test plan
`internal/app` + `internal/server` suites green. New tests:
- no-DNS issuers JSON is **byte-identical** to the legacy default (zero behavior change when unconfigured),
- DNS-01 challenge attaches to both ACME + ZeroSSL issuers and serializes to Caddy's expected nesting,
- `DNSChallengeFromEnv` matrix: unset→nil, cloudflare default token, arbitrary provider via JSON config, explicit override,
- wildcard subject pairs with DNS-01 issuers.

End-to-end issuance (Caddy minting a real `*.<domain>` via Cloudflare) needs a Caddy-with-plugin + live DNS provider — operator/host validation, out of scope for the code change.

## Default behavior
**Unchanged** when DNS-01 isn't configured. Relates to the GLB→Caddy migration in #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)