### PR TITLE
feat(daemon): Caddy-manage the apex of every PublicBaseDomain (#213)

### DIFF
--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -121,6 +121,26 @@ type DualServerConfig struct {
 	ProxyProtocolTrusted []string
 }
 
+// managementRouteDomains returns the domains the daemon serves its own
+// management UI/API apex on. These are the PublicBaseDomains — the same
+// list advertised to the sentinel for suffix routing — so what Caddy
+// serves and what the sentinel routes here stay identical by construction
+// (#213). Falls back to the single BaseDomain when PublicBaseDomains is
+// unset (e.g. configs built without resolvePublicBaseDomains), keeping
+// single-domain deployments unchanged.
+func managementRouteDomains(cfg *DualServerConfig) []string {
+	if cfg == nil {
+		return nil
+	}
+	if len(cfg.PublicBaseDomains) > 0 {
+		return cfg.PublicBaseDomains
+	}
+	if cfg.BaseDomain != "" {
+		return []string{cfg.BaseDomain}
+	}
+	return nil
+}
+
 // DualServer runs both gRPC and HTTP/REST servers
 type DualServer struct {
 	config               *DualServerConfig
@@ -1667,22 +1687,29 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		log.Printf("Passthrough sync job started")
 	}
 
-	// Ensure management route persists in PostgreSQL (RouteSyncJob will push to Caddy)
-	if ds.routeStore != nil && ds.config.BaseDomain != "" && ds.config.HostIP != "" {
-		mgmtRoute := &app.RouteRecord{
-			Subdomain:   ds.config.BaseDomain,
-			FullDomain:  ds.config.BaseDomain,
-			TargetIP:    ds.config.HostIP,
-			TargetPort:  ds.config.HTTPPort,
-			Protocol:    "http",
-			Description: "Containarium management UI",
-			Active:      true,
-			CreatedBy:   string(app.RouteCreatorSystem),
-		}
-		if err := ds.routeStore.Save(ctx, mgmtRoute); err != nil {
-			log.Printf("Warning: Failed to ensure management route: %v", err)
-		} else {
-			log.Printf("Management route ensured: %s -> %s:%d", ds.config.BaseDomain, ds.config.HostIP, ds.config.HTTPPort)
+	// Ensure a management route per served base domain persists in
+	// PostgreSQL (RouteSyncJob pushes each to Caddy — host matcher + TLS
+	// subject). One route per PublicBaseDomains entry, so the daemon
+	// Caddies+serves the apex of every parent domain the sentinel routes
+	// here (#213). Single-domain deployments resolve to [BaseDomain],
+	// unchanged.
+	if ds.routeStore != nil && ds.config.HostIP != "" {
+		for _, domain := range managementRouteDomains(ds.config) {
+			mgmtRoute := &app.RouteRecord{
+				Subdomain:   domain,
+				FullDomain:  domain,
+				TargetIP:    ds.config.HostIP,
+				TargetPort:  ds.config.HTTPPort,
+				Protocol:    "http",
+				Description: "Containarium management UI",
+				Active:      true,
+				CreatedBy:   string(app.RouteCreatorSystem),
+			}
+			if err := ds.routeStore.Save(ctx, mgmtRoute); err != nil {
+				log.Printf("Warning: Failed to ensure management route for %s: %v", domain, err)
+			} else {
+				log.Printf("Management route ensured: %s -> %s:%d", domain, ds.config.HostIP, ds.config.HTTPPort)
+			}
 		}
 	}
 

--- a/internal/server/management_route_domains_test.go
+++ b/internal/server/management_route_domains_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"testing"
+)
+
+// TestManagementRouteDomains covers #213: the daemon ensures one management
+// route per PublicBaseDomains entry (so every parent domain's apex is Caddied
+// + served), falling back to BaseDomain for single-domain deployments.
+func TestManagementRouteDomains(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *DualServerConfig
+		want []string
+	}{
+		{
+			name: "single base domain (unchanged behavior)",
+			cfg:  &DualServerConfig{BaseDomain: "example.org"},
+			want: []string{"example.org"},
+		},
+		{
+			name: "multiple public base domains take precedence",
+			cfg: &DualServerConfig{
+				BaseDomain:        "example.org",
+				PublicBaseDomains: []string{"lab.example.com", "demo.example.org"},
+			},
+			want: []string{"lab.example.com", "demo.example.org"},
+		},
+		{
+			name: "public base domains without a base domain",
+			cfg:  &DualServerConfig{PublicBaseDomains: []string{"a.com"}},
+			want: []string{"a.com"},
+		},
+		{
+			name: "nothing configured → no routes",
+			cfg:  &DualServerConfig{},
+			want: nil,
+		},
+		{
+			name: "nil config → no routes",
+			cfg:  nil,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := managementRouteDomains(tt.cfg)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("domain[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #213.

## TL;DR — neither Option A nor B; reuse what already exists
The issue proposed making `--base-domain` repeatable (A) or adding `--caddy-aliases` (B). Investigation showed a cleaner third path: the daemon **already** has a repeatable `--public-base-domain` (`PublicBaseDomains`, defaults to `[--base-domain]`) that's already advertised to the sentinel for suffix routing. The only gap was that the daemon's local Caddy/route auto-management used the single `BaseDomain`.

## Change
The daemon's **management route** (apex hostname → reverse-proxy host matcher + Caddy TLS subject, `dual_server.go`) was created for `BaseDomain` only. Now it's created **once per `PublicBaseDomains` entry**.

- **No new flag**, no overloading `--base-domain`.
- Keeps "what Caddy serves" identical to "what the sentinel routes here" **by construction** (both are `PublicBaseDomains`) — no drift.
- **Single-domain deployments are unchanged**: `PublicBaseDomains` resolves to `[BaseDomain]`, so exactly one management route as today.
- Eliminates the manual two-step glue documented in `docs/PER-POOL-BASE-DOMAIN.md` "Example D".

`RouteSyncJob` already pushes each stored route to Caddy (host matcher + ACME TLS subject), so nothing downstream needed changing.

## Test plan
- **Unit (here):** `managementRouteDomains()` is a pure helper — covered across single / multi / public-without-base / empty / nil. `internal/server` suite green.
- **Integration (needs a live host):** with two values, both apexes serve a 200 from the daemon REST API over HTTPS — same Caddy/ACME host-validation boundary as the rest of the TLS work.
- **Regression:** single-value deployments resolve to one route, asserted by the helper test.

Related: the DNS-01 wildcard work in #379 (this is the per-apex, exact-host counterpart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)