### PR TITLE
feat(version): per-backend daemon version in get_system_info + /v1/backends (#354 Phase A0)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -7782,6 +7782,10 @@
         "otelCollectorEndpoint": {
           "type": "string",
           "description": "OTLP collector endpoint (e.g., \"http://10.0.3.5:4318\") that\nmonitoring=true containers ship app telemetry to. Empty when the\ncore OTel collector isn't provisioned. Advertised here so a tenant\nor agent can discover where to point OTEL_EXPORTER_OTLP_ENDPOINT —\nin particular for docker-in-LXC apps that don't inherit the\nenv-stamped value. See #370."
+        },
+        "daemonVersion": {
+          "type": "string",
+          "description": "Containarium daemon version of this backend (e.g. \"0.21.0\"), so the\nfleet's running versions + drift are visible via get_system_info and\n/v1/backends without SSHing each host. See #354."
         }
       },
       "title": "SystemInfo contains information about the host system"

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1126,6 +1126,10 @@ type SystemInfo struct {
 	ContainersStopped int    `json:"containersStopped"`
 	ContainersTotal   int    `json:"containersTotal"`
 	Hostname          string `json:"hostname"`
+	// DaemonVersion is the Containarium daemon version on this backend
+	// (e.g. "0.21.0") — surfaced so fleet version drift is visible without
+	// SSHing each host. #354.
+	DaemonVersion string `json:"daemonVersion"`
 	// OTelCollectorEndpoint is where monitoring=true containers ship
 	// OTLP telemetry (e.g. "http://10.0.3.5:4318"). Empty when the
 	// daemon has no OTel collector. Surfaced so an agent can configure

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -332,6 +332,7 @@ func TestClientGetSystemInfo(t *testing.T) {
 				ContainersRunning:     5,
 				ContainersTotal:       10,
 				OTelCollectorEndpoint: "http://10.0.3.5:4318",
+				DaemonVersion:         "0.21.0",
 			},
 		}
 
@@ -349,6 +350,8 @@ func TestClientGetSystemInfo(t *testing.T) {
 	// #370: the collector endpoint must round-trip so an agent can
 	// discover where to point docker-in-LXC apps.
 	assert.Equal(t, "http://10.0.3.5:4318", resp.Info.OTelCollectorEndpoint)
+	// #354: the daemon version must round-trip so fleet drift is visible.
+	assert.Equal(t, "0.21.0", resp.Info.DaemonVersion)
 }
 
 // TestClientPreMarshaledBodyNotDoubleEncoded is the regression test

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1445,6 +1445,9 @@ func handleGetSystemInfo(client *Client, args map[string]interface{}) (string, e
 	result += fmt.Sprintf("OS: %s\n", resp.Info.OS)
 	result += fmt.Sprintf("Kernel: %s\n", resp.Info.KernelVersion)
 	result += fmt.Sprintf("Incus Version: %s\n", resp.Info.IncusVersion)
+	if resp.Info.DaemonVersion != "" {
+		result += fmt.Sprintf("Daemon Version: %s\n", resp.Info.DaemonVersion)
+	}
 	result += fmt.Sprintf("\nContainers:\n")
 	result += fmt.Sprintf("  Running: %d\n", resp.Info.ContainersRunning)
 	result += fmt.Sprintf("  Stopped: %d\n", resp.Info.ContainersStopped)

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/footprintai/containarium/pkg/core/ostype"
 	"github.com/footprintai/containarium/pkg/core/stacks"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/footprintai/containarium/pkg/version"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -1694,6 +1695,9 @@ func (s *ContainerServer) GetSystemInfo(ctx context.Context, req *pb.GetSystemIn
 		// inherit the env-stamped value) at the collector. Empty when
 		// the daemon has no OTel collector. See #370.
 		OtelCollectorEndpoint: s.otelCollectorEndpoint,
+		// This backend's daemon version, so the fleet's running versions +
+		// drift are visible via get_system_info / /v1/backends. See #354.
+		DaemonVersion: version.GetVersion(),
 	}
 
 	// Populate GPU info

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1341,6 +1341,7 @@ func (ds *DualServer) backendsHandler() http.HandlerFunc {
 							if protojson.Unmarshal(body, &peerResp) == nil && peerResp.Info != nil {
 								peerInfo.Hostname = peerResp.Info.Hostname
 								peerInfo.OS = peerResp.Info.Os
+								peerInfo.Version = peerResp.Info.DaemonVersion // #354: per-backend version
 								peerInfo.ContainerCount = peerResp.Info.ContainersRunning
 								for _, g := range peerResp.Info.Gpus {
 									peerInfo.GPUs = append(peerInfo.GPUs, gpuInfo{

--- a/pkg/pb/containarium/v1/config.pb.go
+++ b/pkg/pb/containarium/v1/config.pb.go
@@ -922,8 +922,12 @@ type SystemInfo struct {
 	// in particular for docker-in-LXC apps that don't inherit the
 	// env-stamped value. See #370.
 	OtelCollectorEndpoint string `protobuf:"bytes,20,opt,name=otel_collector_endpoint,json=otelCollectorEndpoint,proto3" json:"otel_collector_endpoint,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// Containarium daemon version of this backend (e.g. "0.21.0"), so the
+	// fleet's running versions + drift are visible via get_system_info and
+	// /v1/backends without SSHing each host. See #354.
+	DaemonVersion string `protobuf:"bytes,21,opt,name=daemon_version,json=daemonVersion,proto3" json:"daemon_version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SystemInfo) Reset() {
@@ -1092,6 +1096,13 @@ func (x *SystemInfo) GetBackendId() string {
 func (x *SystemInfo) GetOtelCollectorEndpoint() string {
 	if x != nil {
 		return x.OtelCollectorEndpoint
+	}
+	return ""
+}
+
+func (x *SystemInfo) GetDaemonVersion() string {
+	if x != nil {
+		return x.DaemonVersion
 	}
 	return ""
 }
@@ -1495,7 +1506,7 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"updateMask\"a\n" +
 	"\x14UpdateConfigResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12/\n" +
-	"\x06config\x18\x02 \x01(\v2\x17.containarium.v1.ConfigR\x06config\"\xa9\x06\n" +
+	"\x06config\x18\x02 \x01(\v2\x17.containarium.v1.ConfigR\x06config\"\xd0\x06\n" +
 	"\n" +
 	"SystemInfo\x12#\n" +
 	"\rincus_version\x18\x01 \x01(\tR\fincusVersion\x12\x0e\n" +
@@ -1520,7 +1531,8 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\x04gpus\x18\x12 \x03(\v2\x18.containarium.v1.GPUInfoR\x04gpus\x12\x1d\n" +
 	"\n" +
 	"backend_id\x18\x13 \x01(\tR\tbackendId\x126\n" +
-	"\x17otel_collector_endpoint\x18\x14 \x01(\tR\x15otelCollectorEndpoint\"\x97\x02\n" +
+	"\x17otel_collector_endpoint\x18\x14 \x01(\tR\x15otelCollectorEndpoint\x12%\n" +
+	"\x0edaemon_version\x18\x15 \x01(\tR\rdaemonVersion\"\x97\x02\n" +
 	"\aGPUInfo\x122\n" +
 	"\x06vendor\x18\x01 \x01(\x0e2\x1a.containarium.v1.GPUVendorR\x06vendor\x12/\n" +
 	"\x05model\x18\x02 \x01(\x0e2\x19.containarium.v1.GPUModelR\x05model\x12\x1d\n" +

--- a/proto/containarium/v1/config.proto
+++ b/proto/containarium/v1/config.proto
@@ -198,6 +198,11 @@ message SystemInfo {
   // in particular for docker-in-LXC apps that don't inherit the
   // env-stamped value. See #370.
   string otel_collector_endpoint = 20;
+
+  // Containarium daemon version of this backend (e.g. "0.21.0"), so the
+  // fleet's running versions + drift are visible via get_system_info and
+  // /v1/backends without SSHing each host. See #354.
+  string daemon_version = 21;
 }
 
 // GPU vendor enum


### PR DESCRIPTION
Phase A0 of #354 — the pure-Go, no-host, foundational slice: **make the fleet's running daemon versions (and drift) visible** without SSHing each host.

This is the exact gap the #341 incident hit: four daemons silently on v0.19.0 while v0.19.2 was out, with no way to see it at a glance.

## The gap
- `SystemInfo` carried infra versions (incus/kernel) but **not** the Containarium daemon binary version.
- `/v1/backends` populated `Version` for the **local** backend only — **peer** backends showed blank (the issue's claim that `/v1/backends` returns per-backend version was only half-true).

## Change
- **proto:** `SystemInfo.daemon_version` (field 21; 20 is the merged `otel_collector_endpoint`).
- **`GetSystemInfo`** populates it from `version.GetVersion()`.
- **`backendsHandler`** reads `peerResp.Info.DaemonVersion` into each peer's `Version` — the peer loop **already** forwards `GetSystemInfo`, so there's **no extra round-trip**.
- **MCP/CLI need no change to display it** — `list_backends`/`get_backend` + `containarium backends list` already render `Version`; they just had nothing for peers before. The `get_system_info` tool now also prints "Daemon Version" (and since it already aggregates peers' `SystemInfo`, it shows the whole fleet's versions).

## Test
`TestClientGetSystemInfo` asserts the `daemonVersion` wire round-trip. `internal/server` + `internal/mcp` suites green.

## Deliberately NOT in this slice
- **GitHub "latest release available" column** (Phase A1) — needs an HTTP-cached GitHub Releases lookup; additive, separate PR.
- **webui Versions page** — needs the embedded Next.js build toolchain.
- **Phase B/C** (trigger upgrade, rollback automation, GitHub fetch on the sentinel) — touch `systemctl`/binary swap, need a live backend to validate.

Scoped per the investigation on #354 to the buildable, host-independent foundation that everything else builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)