### PR TITLE
feat(version): GetLatestRelease — "update available" check (#354 Phase A1)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -2699,6 +2699,30 @@
         ]
       }
     },
+    "/v1/releases/latest": {
+      "get": {
+        "summary": "Get latest release",
+        "description": "Returns the latest Containarium release tag from GitHub (cached) alongside this daemon's running version and whether an update is available.",
+        "operationId": "ContainerService_GetLatestRelease",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetLatestReleaseResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "System"
+        ]
+      }
+    },
     "/v1/secrets": {
       "post": {
         "summary": "Create or update a tenant secret",
@@ -5763,6 +5787,24 @@
         }
       },
       "title": "GetContainerResponse is the response from getting a container"
+    },
+    "GetLatestReleaseResponse": {
+      "type": "object",
+      "properties": {
+        "latestRelease": {
+          "type": "string",
+          "description": "Latest release tag from GitHub (e.g. \"v0.21.2\"). Empty when the lookup\nhasn't succeeded yet (e.g. rate-limited with no cached value)."
+        },
+        "currentVersion": {
+          "type": "string",
+          "description": "This daemon's running version (e.g. \"0.21.0\")."
+        },
+        "updateAvailable": {
+          "type": "boolean",
+          "description": "True when latest_release is a newer semver than current_version."
+        }
+      },
+      "description": "GetLatestReleaseResponse reports the latest published release vs the\nrunning daemon version. See #354."
     },
     "GetMetricsResponse": {
       "type": "object",

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.10
 
 require (
 	cloud.google.com/go/compute v1.64.0
+	github.com/blang/semver/v4 v4.0.0
 	github.com/cilium/ebpf v0.21.0
 	github.com/footprintai/go-certs v0.0.4
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -43,7 +44,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 // indirect
 	github.com/apex/log v1.9.0 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -551,6 +551,27 @@ func (c *Client) GetSystemInfo() (*GetSystemInfoResponse, error) {
 	return &resp, nil
 }
 
+// LatestReleaseResponse is the GET /v1/releases/latest body (#354).
+type LatestReleaseResponse struct {
+	LatestRelease   string `json:"latestRelease"`
+	CurrentVersion  string `json:"currentVersion"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+}
+
+// GetLatestRelease reports the latest published Containarium release vs the
+// daemon's running version (cached server-side). #354.
+func (c *Client) GetLatestRelease() (*LatestReleaseResponse, error) {
+	respBody, err := c.doRequest("GET", "/v1/releases/latest", nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp LatestReleaseResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
 // AddRoute creates a domain → container:port mapping in the sentinel
 // reverse proxy. Used by the expose_port tool to make a container
 // reachable on the public internet under a chosen hostname.

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -405,6 +405,27 @@ func TestClientPreMarshaledBodyNotDoubleEncoded(t *testing.T) {
 	})
 }
 
+// TestClientGetLatestRelease is the #354 wire-contract check: the daemon's
+// latest-release fields round-trip into the client (camelCase JSON).
+func TestClientGetLatestRelease(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/v1/releases/latest", r.URL.Path)
+		json.NewEncoder(w).Encode(LatestReleaseResponse{
+			LatestRelease:   "v0.21.2",
+			CurrentVersion:  "0.21.0",
+			UpdateAvailable: true,
+		})
+	}))
+	defer server.Close()
+
+	resp, err := NewClient(server.URL, "test-token").GetLatestRelease()
+	require.NoError(t, err)
+	assert.Equal(t, "v0.21.2", resp.LatestRelease)
+	assert.Equal(t, "0.21.0", resp.CurrentVersion)
+	assert.True(t, resp.UpdateAvailable)
+}
+
 // TestClientAuthenticationHeader tests JWT token is sent correctly
 func TestClientAuthenticationHeader(t *testing.T) {
 	expectedToken := "test-jwt-token-123"

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,8 +22,8 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	// 29 base + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes.
-	assert.Len(t, server.tools, 38, "Should have 38 tools registered")
+	// 30 base (+check_for_updates, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes.
+	assert.Len(t, server.tools, 39, "Should have 39 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -127,8 +127,8 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	// 29 base + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes.
-	assert.Len(t, tools, 38)
+	// 30 base (+check_for_updates, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes.
+	assert.Len(t, tools, 39)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -516,6 +516,15 @@ func (s *Server) registerTools() {
 			Handler: handleGetSystemInfo,
 		},
 		{
+			Name:        "check_for_updates",
+			Description: "Check whether a newer Containarium release is available. Returns the running daemon version, the latest GitHub release (cached), and whether an update is available.",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+			Handler: handleCheckForUpdates,
+		},
+		{
 			Name: "list_backends",
 			Description: "List the cluster's backend hosts (the local daemon plus any " +
 				"tunnel-connected peers). Returns id, type (local/tunnel), health, " +
@@ -993,6 +1002,7 @@ func toolScopeAssignments() map[string]string {
 		"debug_container":   auth.ScopeContainersRead,
 		"get_metrics":       auth.ScopeContainersRead,
 		"get_system_info":   auth.ScopeContainersRead,
+		"check_for_updates": auth.ScopeContainersRead,
 		"list_backends":     auth.ScopeContainersRead,
 		"get_backend":       auth.ScopeContainersRead,
 		// secrets
@@ -1462,6 +1472,25 @@ func handleGetSystemInfo(client *Client, args map[string]interface{}) (string, e
 		result += "\nOTel collector: not configured (app monitoring unavailable)\n"
 	}
 
+	return result, nil
+}
+
+func handleCheckForUpdates(client *Client, args map[string]interface{}) (string, error) {
+	resp, err := client.GetLatestRelease()
+	if err != nil {
+		return "", fmt.Errorf("failed to check for updates: %w", err)
+	}
+	result := fmt.Sprintf("Running version:  %s\n", resp.CurrentVersion)
+	if resp.LatestRelease == "" {
+		result += "Latest release:   unknown (GitHub lookup unavailable)\n"
+		return result, nil
+	}
+	result += fmt.Sprintf("Latest release:   %s\n", resp.LatestRelease)
+	if resp.UpdateAvailable {
+		result += fmt.Sprintf("\n⚠ Update available: %s → %s\n", resp.CurrentVersion, resp.LatestRelease)
+	} else {
+		result += "\n✓ Up to date\n"
+	}
 	return result, nil
 }
 

--- a/internal/releasecheck/releasecheck.go
+++ b/internal/releasecheck/releasecheck.go
@@ -1,0 +1,129 @@
+// Package releasecheck reports the latest Containarium release published on
+// GitHub, cached server-side so a busy fleet's status checks don't burn the
+// unauthenticated GitHub rate limit (~60/hr). Used to surface "newer version
+// available" next to each backend's running version (#354).
+package releasecheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/blang/semver/v4"
+)
+
+const (
+	// DefaultOwner / DefaultRepo identify the Containarium repo on GitHub.
+	DefaultOwner = "FootprintAI"
+	DefaultRepo  = "Containarium"
+
+	// DefaultTTL is how long a fetched tag is served before refetching.
+	DefaultTTL = time.Hour
+)
+
+// Checker fetches and caches the latest release tag. Safe for concurrent use.
+type Checker struct {
+	owner   string
+	repo    string
+	baseURL string // overridable in tests; defaults to the GitHub API
+	client  *http.Client
+	ttl     time.Duration
+	now     func() time.Time
+
+	mu       sync.Mutex
+	cached   string
+	cachedAt time.Time
+	hasCache bool
+}
+
+// New returns a Checker for the Containarium repo with sensible defaults.
+func New() *Checker {
+	return &Checker{
+		owner:   DefaultOwner,
+		repo:    DefaultRepo,
+		baseURL: "https://api.github.com",
+		client:  &http.Client{Timeout: 10 * time.Second},
+		ttl:     DefaultTTL,
+		now:     time.Now,
+	}
+}
+
+// Latest returns the latest release tag (e.g. "v0.21.2"), cached for the TTL.
+//
+// Best-effort by design: on a fetch error it serves the last good value if
+// one was ever cached (stale beats nothing for a status panel), and only
+// returns an error when there's no cache to fall back on. Callers that just
+// want drift info can ignore the error and use the (possibly empty) string.
+func (c *Checker) Latest(ctx context.Context) (string, error) {
+	c.mu.Lock()
+	if c.hasCache && c.now().Sub(c.cachedAt) < c.ttl {
+		v := c.cached
+		c.mu.Unlock()
+		return v, nil
+	}
+	c.mu.Unlock()
+
+	tag, err := c.fetch(ctx)
+	if err != nil {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.hasCache {
+			return c.cached, nil // serve stale
+		}
+		return "", err
+	}
+
+	c.mu.Lock()
+	c.cached = tag
+	c.cachedAt = c.now()
+	c.hasCache = true
+	c.mu.Unlock()
+	return tag, nil
+}
+
+// githubRelease is the subset of the GitHub releases API we read.
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+func (c *Checker) fetch(ctx context.Context) (string, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", c.baseURL, c.owner, c.repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch latest release: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", fmt.Errorf("github API status %d: %s", resp.StatusCode, string(body))
+	}
+	var rel githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return "", fmt.Errorf("decode release: %w", err)
+	}
+	if rel.TagName == "" {
+		return "", fmt.Errorf("latest release has no tag_name")
+	}
+	return rel.TagName, nil
+}
+
+// UpdateAvailable reports whether latest is a newer semver than current.
+// Tolerant of a leading "v" on either; returns false on empty or unparseable
+// input (a status panel should not claim "update available" on bad data).
+func UpdateAvailable(current, latest string) bool {
+	cv, err1 := semver.ParseTolerant(current)
+	lv, err2 := semver.ParseTolerant(latest)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return cv.LT(lv)
+}

--- a/internal/releasecheck/releasecheck_test.go
+++ b/internal/releasecheck/releasecheck_test.go
@@ -1,0 +1,122 @@
+package releasecheck
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newTestChecker wires a Checker at an httptest server with a controllable
+// clock and a 1h TTL.
+func newTestChecker(baseURL string, now func() time.Time) *Checker {
+	return &Checker{
+		owner:   "FootprintAI",
+		repo:    "Containarium",
+		baseURL: baseURL,
+		client:  &http.Client{Timeout: 2 * time.Second},
+		ttl:     time.Hour,
+		now:     now,
+	}
+}
+
+func TestChecker_FetchAndCache(t *testing.T) {
+	var hits int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		if r.URL.Path != "/repos/FootprintAI/Containarium/releases/latest" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"tag_name":"v0.21.2","name":"ignored"}`))
+	}))
+	defer srv.Close()
+
+	clock := time.Unix(1_700_000_000, 0)
+	c := newTestChecker(srv.URL, func() time.Time { return clock })
+
+	// First call fetches.
+	got, err := c.Latest(context.Background())
+	if err != nil || got != "v0.21.2" {
+		t.Fatalf("Latest() = %q, %v; want v0.21.2", got, err)
+	}
+	// Second call within TTL is served from cache (no new hit).
+	if got, _ := c.Latest(context.Background()); got != "v0.21.2" {
+		t.Fatalf("cached Latest() = %q", got)
+	}
+	if h := atomic.LoadInt64(&hits); h != 1 {
+		t.Fatalf("server hit %d times, want 1 (second call should hit cache)", h)
+	}
+
+	// Advance past the TTL → refetch.
+	clock = clock.Add(time.Hour + time.Minute)
+	if got, _ := c.Latest(context.Background()); got != "v0.21.2" {
+		t.Fatalf("post-TTL Latest() = %q", got)
+	}
+	if h := atomic.LoadInt64(&hits); h != 2 {
+		t.Fatalf("server hit %d times, want 2 (TTL expiry refetches)", h)
+	}
+}
+
+func TestChecker_ServesStaleOnError(t *testing.T) {
+	var fail atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"tag_name":"v0.21.2"}`))
+	}))
+	defer srv.Close()
+
+	clock := time.Unix(1_700_000_000, 0)
+	c := newTestChecker(srv.URL, func() time.Time { return clock })
+
+	if got, _ := c.Latest(context.Background()); got != "v0.21.2" {
+		t.Fatalf("seed Latest() = %q", got)
+	}
+	// Expire the cache, then make the server fail: should serve the stale value.
+	clock = clock.Add(2 * time.Hour)
+	fail.Store(true)
+	got, err := c.Latest(context.Background())
+	if err != nil {
+		t.Fatalf("expected stale value, got error %v", err)
+	}
+	if got != "v0.21.2" {
+		t.Errorf("stale Latest() = %q, want v0.21.2", got)
+	}
+}
+
+func TestChecker_ErrorWithNoCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden) // e.g. rate limited
+	}))
+	defer srv.Close()
+
+	c := newTestChecker(srv.URL, time.Now)
+	if _, err := c.Latest(context.Background()); err == nil {
+		t.Error("want error when the first fetch fails with no cache to fall back on")
+	}
+}
+
+func TestUpdateAvailable(t *testing.T) {
+	cases := []struct {
+		current, latest string
+		want            bool
+	}{
+		{"0.21.0", "0.21.2", true},
+		{"v0.21.0", "v0.21.2", true}, // tolerant of leading v
+		{"0.21.0", "v0.21.0", false}, // equal
+		{"0.21.3", "0.21.2", false},  // current newer
+		{"v1.0.0", "v0.21.2", false},
+		{"", "v0.21.2", false}, // bad current
+		{"0.21.0", "", false},  // bad latest
+		{"garbage", "0.21.2", false},
+	}
+	for _, tc := range cases {
+		if got := UpdateAvailable(tc.current, tc.latest); got != tc.want {
+			t.Errorf("UpdateAvailable(%q, %q) = %v, want %v", tc.current, tc.latest, got, tc.want)
+		}
+	}
+}

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/guacamole"
+	"github.com/footprintai/containarium/internal/releasecheck"
 	"github.com/footprintai/containarium/internal/secrets"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
@@ -1619,6 +1620,28 @@ func (s *ContainerServer) GetMetrics(ctx context.Context, req *pb.GetMetricsRequ
 
 	return &pb.GetMetricsResponse{
 		Metrics: protoMetrics,
+	}, nil
+}
+
+// daemonReleaseChecker caches the latest GitHub release across requests so a
+// busy fleet's status checks don't burn the unauthenticated GitHub rate
+// limit. Package-level (not per-request) for that shared cache. #354.
+var daemonReleaseChecker = releasecheck.New()
+
+// GetLatestRelease reports the latest published Containarium release vs this
+// daemon's running version. Admin-only, matching the other System endpoints.
+// Best-effort: a failed/rate-limited GitHub lookup yields an empty
+// latest_release (and update_available=false) rather than an error. #354.
+func (s *ContainerServer) GetLatestRelease(ctx context.Context, req *pb.GetLatestReleaseRequest) (*pb.GetLatestReleaseResponse, error) {
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+	current := version.GetVersion()
+	latest, _ := daemonReleaseChecker.Latest(ctx) // empty on persistent failure
+	return &pb.GetLatestReleaseResponse{
+		LatestRelease:   latest,
+		CurrentVersion:  current,
+		UpdateAvailable: releasecheck.UpdateAvailable(current, latest),
 	}, nil
 }
 

--- a/pkg/pb/containarium/v1/config.pb.go
+++ b/pkg/pb/containarium/v1/config.pb.go
@@ -1299,6 +1299,109 @@ func (x *GetSystemInfoResponse) GetPeers() []*SystemInfo {
 	return nil
 }
 
+// GetLatestReleaseRequest is the request for the latest-release check.
+type GetLatestReleaseRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetLatestReleaseRequest) Reset() {
+	*x = GetLatestReleaseRequest{}
+	mi := &file_containarium_v1_config_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetLatestReleaseRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetLatestReleaseRequest) ProtoMessage() {}
+
+func (x *GetLatestReleaseRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetLatestReleaseRequest.ProtoReflect.Descriptor instead.
+func (*GetLatestReleaseRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{13}
+}
+
+// GetLatestReleaseResponse reports the latest published release vs the
+// running daemon version. See #354.
+type GetLatestReleaseResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Latest release tag from GitHub (e.g. "v0.21.2"). Empty when the lookup
+	// hasn't succeeded yet (e.g. rate-limited with no cached value).
+	LatestRelease string `protobuf:"bytes,1,opt,name=latest_release,json=latestRelease,proto3" json:"latest_release,omitempty"`
+	// This daemon's running version (e.g. "0.21.0").
+	CurrentVersion string `protobuf:"bytes,2,opt,name=current_version,json=currentVersion,proto3" json:"current_version,omitempty"`
+	// True when latest_release is a newer semver than current_version.
+	UpdateAvailable bool `protobuf:"varint,3,opt,name=update_available,json=updateAvailable,proto3" json:"update_available,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *GetLatestReleaseResponse) Reset() {
+	*x = GetLatestReleaseResponse{}
+	mi := &file_containarium_v1_config_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetLatestReleaseResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetLatestReleaseResponse) ProtoMessage() {}
+
+func (x *GetLatestReleaseResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetLatestReleaseResponse.ProtoReflect.Descriptor instead.
+func (*GetLatestReleaseResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *GetLatestReleaseResponse) GetLatestRelease() string {
+	if x != nil {
+		return x.LatestRelease
+	}
+	return ""
+}
+
+func (x *GetLatestReleaseResponse) GetCurrentVersion() string {
+	if x != nil {
+		return x.CurrentVersion
+	}
+	return ""
+}
+
+func (x *GetLatestReleaseResponse) GetUpdateAvailable() bool {
+	if x != nil {
+		return x.UpdateAvailable
+	}
+	return false
+}
+
 // BackendInfo contains information about a backend instance
 type BackendInfo struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1316,7 +1419,7 @@ type BackendInfo struct {
 
 func (x *BackendInfo) Reset() {
 	*x = BackendInfo{}
-	mi := &file_containarium_v1_config_proto_msgTypes[13]
+	mi := &file_containarium_v1_config_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1328,7 +1431,7 @@ func (x *BackendInfo) String() string {
 func (*BackendInfo) ProtoMessage() {}
 
 func (x *BackendInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[13]
+	mi := &file_containarium_v1_config_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1341,7 +1444,7 @@ func (x *BackendInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackendInfo.ProtoReflect.Descriptor instead.
 func (*BackendInfo) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{13}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *BackendInfo) GetId() string {
@@ -1381,7 +1484,7 @@ type ListBackendsRequest struct {
 
 func (x *ListBackendsRequest) Reset() {
 	*x = ListBackendsRequest{}
-	mi := &file_containarium_v1_config_proto_msgTypes[14]
+	mi := &file_containarium_v1_config_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1393,7 +1496,7 @@ func (x *ListBackendsRequest) String() string {
 func (*ListBackendsRequest) ProtoMessage() {}
 
 func (x *ListBackendsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[14]
+	mi := &file_containarium_v1_config_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1406,7 +1509,7 @@ func (x *ListBackendsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendsRequest.ProtoReflect.Descriptor instead.
 func (*ListBackendsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{14}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{16}
 }
 
 // ListBackendsResponse is the response from listing backends
@@ -1420,7 +1523,7 @@ type ListBackendsResponse struct {
 
 func (x *ListBackendsResponse) Reset() {
 	*x = ListBackendsResponse{}
-	mi := &file_containarium_v1_config_proto_msgTypes[15]
+	mi := &file_containarium_v1_config_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1432,7 +1535,7 @@ func (x *ListBackendsResponse) String() string {
 func (*ListBackendsResponse) ProtoMessage() {}
 
 func (x *ListBackendsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[15]
+	mi := &file_containarium_v1_config_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1445,7 +1548,7 @@ func (x *ListBackendsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendsResponse.ProtoReflect.Descriptor instead.
 func (*ListBackendsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{15}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ListBackendsResponse) GetBackends() []*BackendInfo {
@@ -1547,7 +1650,12 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\x14GetSystemInfoRequest\"{\n" +
 	"\x15GetSystemInfoResponse\x12/\n" +
 	"\x04info\x18\x01 \x01(\v2\x1b.containarium.v1.SystemInfoR\x04info\x121\n" +
-	"\x05peers\x18\x02 \x03(\v2\x1b.containarium.v1.SystemInfoR\x05peers\"\x85\x01\n" +
+	"\x05peers\x18\x02 \x03(\v2\x1b.containarium.v1.SystemInfoR\x05peers\"\x19\n" +
+	"\x17GetLatestReleaseRequest\"\x95\x01\n" +
+	"\x18GetLatestReleaseResponse\x12%\n" +
+	"\x0elatest_release\x18\x01 \x01(\tR\rlatestRelease\x12'\n" +
+	"\x0fcurrent_version\x18\x02 \x01(\tR\x0ecurrentVersion\x12)\n" +
+	"\x10update_available\x18\x03 \x01(\bR\x0fupdateAvailable\"\x85\x01\n" +
 	"\vBackendInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x120\n" +
 	"\x04type\x18\x02 \x01(\x0e2\x1c.containarium.v1.BackendTypeR\x04type\x12\x18\n" +
@@ -1605,37 +1713,39 @@ func file_containarium_v1_config_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_config_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_containarium_v1_config_proto_goTypes = []any{
-	(GPUVendor)(0),                // 0: containarium.v1.GPUVendor
-	(GPUModel)(0),                 // 1: containarium.v1.GPUModel
-	(BackendType)(0),              // 2: containarium.v1.BackendType
-	(*Config)(nil),                // 3: containarium.v1.Config
-	(*IncusConfig)(nil),           // 4: containarium.v1.IncusConfig
-	(*NetworkConfig)(nil),         // 5: containarium.v1.NetworkConfig
-	(*StorageConfig)(nil),         // 6: containarium.v1.StorageConfig
-	(*SecurityConfig)(nil),        // 7: containarium.v1.SecurityConfig
-	(*GetConfigRequest)(nil),      // 8: containarium.v1.GetConfigRequest
-	(*GetConfigResponse)(nil),     // 9: containarium.v1.GetConfigResponse
-	(*UpdateConfigRequest)(nil),   // 10: containarium.v1.UpdateConfigRequest
-	(*UpdateConfigResponse)(nil),  // 11: containarium.v1.UpdateConfigResponse
-	(*SystemInfo)(nil),            // 12: containarium.v1.SystemInfo
-	(*GPUInfo)(nil),               // 13: containarium.v1.GPUInfo
-	(*GetSystemInfoRequest)(nil),  // 14: containarium.v1.GetSystemInfoRequest
-	(*GetSystemInfoResponse)(nil), // 15: containarium.v1.GetSystemInfoResponse
-	(*BackendInfo)(nil),           // 16: containarium.v1.BackendInfo
-	(*ListBackendsRequest)(nil),   // 17: containarium.v1.ListBackendsRequest
-	(*ListBackendsResponse)(nil),  // 18: containarium.v1.ListBackendsResponse
-	(*ResourceLimits)(nil),        // 19: containarium.v1.ResourceLimits
-	(OSType)(0),                   // 20: containarium.v1.OSType
+	(GPUVendor)(0),                   // 0: containarium.v1.GPUVendor
+	(GPUModel)(0),                    // 1: containarium.v1.GPUModel
+	(BackendType)(0),                 // 2: containarium.v1.BackendType
+	(*Config)(nil),                   // 3: containarium.v1.Config
+	(*IncusConfig)(nil),              // 4: containarium.v1.IncusConfig
+	(*NetworkConfig)(nil),            // 5: containarium.v1.NetworkConfig
+	(*StorageConfig)(nil),            // 6: containarium.v1.StorageConfig
+	(*SecurityConfig)(nil),           // 7: containarium.v1.SecurityConfig
+	(*GetConfigRequest)(nil),         // 8: containarium.v1.GetConfigRequest
+	(*GetConfigResponse)(nil),        // 9: containarium.v1.GetConfigResponse
+	(*UpdateConfigRequest)(nil),      // 10: containarium.v1.UpdateConfigRequest
+	(*UpdateConfigResponse)(nil),     // 11: containarium.v1.UpdateConfigResponse
+	(*SystemInfo)(nil),               // 12: containarium.v1.SystemInfo
+	(*GPUInfo)(nil),                  // 13: containarium.v1.GPUInfo
+	(*GetSystemInfoRequest)(nil),     // 14: containarium.v1.GetSystemInfoRequest
+	(*GetSystemInfoResponse)(nil),    // 15: containarium.v1.GetSystemInfoResponse
+	(*GetLatestReleaseRequest)(nil),  // 16: containarium.v1.GetLatestReleaseRequest
+	(*GetLatestReleaseResponse)(nil), // 17: containarium.v1.GetLatestReleaseResponse
+	(*BackendInfo)(nil),              // 18: containarium.v1.BackendInfo
+	(*ListBackendsRequest)(nil),      // 19: containarium.v1.ListBackendsRequest
+	(*ListBackendsResponse)(nil),     // 20: containarium.v1.ListBackendsResponse
+	(*ResourceLimits)(nil),           // 21: containarium.v1.ResourceLimits
+	(OSType)(0),                      // 22: containarium.v1.OSType
 }
 var file_containarium_v1_config_proto_depIdxs = []int32{
 	4,  // 0: containarium.v1.Config.incus:type_name -> containarium.v1.IncusConfig
-	19, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
+	21, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
 	5,  // 2: containarium.v1.Config.network:type_name -> containarium.v1.NetworkConfig
 	6,  // 3: containarium.v1.Config.storage:type_name -> containarium.v1.StorageConfig
 	7,  // 4: containarium.v1.Config.security:type_name -> containarium.v1.SecurityConfig
-	20, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
+	22, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
 	3,  // 6: containarium.v1.GetConfigResponse.config:type_name -> containarium.v1.Config
 	3,  // 7: containarium.v1.UpdateConfigRequest.config:type_name -> containarium.v1.Config
 	3,  // 8: containarium.v1.UpdateConfigResponse.config:type_name -> containarium.v1.Config
@@ -1645,7 +1755,7 @@ var file_containarium_v1_config_proto_depIdxs = []int32{
 	12, // 12: containarium.v1.GetSystemInfoResponse.info:type_name -> containarium.v1.SystemInfo
 	12, // 13: containarium.v1.GetSystemInfoResponse.peers:type_name -> containarium.v1.SystemInfo
 	2,  // 14: containarium.v1.BackendInfo.type:type_name -> containarium.v1.BackendType
-	16, // 15: containarium.v1.ListBackendsResponse.backends:type_name -> containarium.v1.BackendInfo
+	18, // 15: containarium.v1.ListBackendsResponse.backends:type_name -> containarium.v1.BackendInfo
 	16, // [16:16] is the sub-list for method output_type
 	16, // [16:16] is the sub-list for method input_type
 	16, // [16:16] is the sub-list for extension type_name
@@ -1665,7 +1775,7 @@ func file_containarium_v1_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_config_proto_rawDesc), len(file_containarium_v1_config_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   16,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xefb\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xa6e\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -82,7 +82,9 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x14Container Operations\x12\x1eList available software stacks\x1a\x86\x01Returns all configured software stacks including their parameters (name, type, default, etc.) for rendering the Create Container form.\x82\xd3\xe4\x93\x02\f\x12\n" +
 	"/v1/stacks\x12\x8b\x02\n" +
 	"\rGetSystemInfo\x12%.containarium.v1.GetSystemInfoRequest\x1a&.containarium.v1.GetSystemInfoResponse\"\xaa\x01\x92A\x8f\x01\n" +
-	"\x06System\x12\x16Get system information\x1amReturns information about the host system including Incus version, available resources, and container counts.\x82\xd3\xe4\x93\x02\x11\x12\x0f/v1/system/info\x12\xb7\x02\n" +
+	"\x06System\x12\x16Get system information\x1amReturns information about the host system including Incus version, available resources, and container counts.\x82\xd3\xe4\x93\x02\x11\x12\x0f/v1/system/info\x12\xb4\x02\n" +
+	"\x10GetLatestRelease\x12(.containarium.v1.GetLatestReleaseRequest\x1a).containarium.v1.GetLatestReleaseResponse\"\xca\x01\x92A\xab\x01\n" +
+	"\x06System\x12\x12Get latest release\x1a\x8c\x01Returns the latest Containarium release tag from GitHub (cached) alongside this daemon's running version and whether an update is available.\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/releases/latest\x12\xb7\x02\n" +
 	"\x11GetMonitoringInfo\x12).containarium.v1.GetMonitoringInfoRequest\x1a*.containarium.v1.GetMonitoringInfoResponse\"\xca\x01\x92A\xa9\x01\n" +
 	"\n" +
 	"Monitoring\x12\x1aGet monitoring information\x1a\x7fReturns monitoring configuration including Grafana and VictoriaMetrics URLs. Used by the web UI to embed the Grafana dashboard.\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/system/monitoring\x12\x87\x02\n" +
@@ -152,61 +154,63 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*InstallStackRequest)(nil),            // 20: containarium.v1.InstallStackRequest
 	(*ListStacksRequest)(nil),              // 21: containarium.v1.ListStacksRequest
 	(*GetSystemInfoRequest)(nil),           // 22: containarium.v1.GetSystemInfoRequest
-	(*GetMonitoringInfoRequest)(nil),       // 23: containarium.v1.GetMonitoringInfoRequest
-	(*CreateAlertRuleRequest)(nil),         // 24: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),          // 25: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),            // 26: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),         // 27: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),         // 28: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),         // 29: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),   // 30: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),    // 31: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),             // 32: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),   // 33: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),               // 34: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),               // 35: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),             // 36: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),            // 37: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),          // 38: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),        // 39: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),         // 40: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),           // 41: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),         // 42: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),        // 43: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),         // 44: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),          // 45: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),        // 46: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),          // 47: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerResponse)(nil), // 48: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),       // 49: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),        // 50: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),        // 51: containarium.v1.SetContainerTTLResponse
-	(*AddSSHKeyResponse)(nil),              // 52: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),           // 53: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),        // 54: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),     // 55: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),      // 56: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),             // 57: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),            // 58: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),           // 59: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),             // 60: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),          // 61: containarium.v1.GetSystemInfoResponse
-	(*GetMonitoringInfoResponse)(nil),      // 62: containarium.v1.GetMonitoringInfoResponse
-	(*CreateAlertRuleResponse)(nil),        // 63: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),         // 64: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),           // 65: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),        // 66: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),        // 67: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),        // 68: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),  // 69: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),   // 70: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),            // 71: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),  // 72: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),              // 73: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),              // 74: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),            // 75: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),           // 76: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),         // 77: containarium.v1.RefreshSecretsResponse
+	(*GetLatestReleaseRequest)(nil),        // 23: containarium.v1.GetLatestReleaseRequest
+	(*GetMonitoringInfoRequest)(nil),       // 24: containarium.v1.GetMonitoringInfoRequest
+	(*CreateAlertRuleRequest)(nil),         // 25: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),          // 26: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),            // 27: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),         // 28: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),         // 29: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),         // 30: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),   // 31: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),    // 32: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),             // 33: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),   // 34: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),               // 35: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),               // 36: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),             // 37: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),            // 38: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),          // 39: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),        // 40: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),         // 41: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),           // 42: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),         // 43: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),        // 44: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),         // 45: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),          // 46: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),        // 47: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),          // 48: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerResponse)(nil), // 49: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),       // 50: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),        // 51: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),        // 52: containarium.v1.SetContainerTTLResponse
+	(*AddSSHKeyResponse)(nil),              // 53: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),           // 54: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),        // 55: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),     // 56: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),      // 57: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),             // 58: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),            // 59: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),           // 60: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),             // 61: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),          // 62: containarium.v1.GetSystemInfoResponse
+	(*GetLatestReleaseResponse)(nil),       // 63: containarium.v1.GetLatestReleaseResponse
+	(*GetMonitoringInfoResponse)(nil),      // 64: containarium.v1.GetMonitoringInfoResponse
+	(*CreateAlertRuleResponse)(nil),        // 65: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),         // 66: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),           // 67: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),        // 68: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),        // 69: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),        // 70: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),  // 71: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),   // 72: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),            // 73: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),  // 74: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),              // 75: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),              // 76: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),            // 77: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),           // 78: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),         // 79: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -232,63 +236,65 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	20, // 20: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
 	21, // 21: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
 	22, // 22: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
-	23, // 23: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	24, // 24: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	25, // 25: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	26, // 26: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	27, // 27: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	28, // 28: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	29, // 29: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	30, // 30: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	31, // 31: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	32, // 32: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	33, // 33: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	34, // 34: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	35, // 35: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	36, // 36: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	37, // 37: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	38, // 38: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	39, // 39: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	40, // 40: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	41, // 41: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	42, // 42: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	43, // 43: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	44, // 44: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	45, // 45: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	46, // 46: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	47, // 47: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	48, // 48: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	49, // 49: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	50, // 50: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	51, // 51: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	52, // 52: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	53, // 53: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	54, // 54: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	55, // 55: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	56, // 56: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	57, // 57: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	58, // 58: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	59, // 59: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	60, // 60: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	61, // 61: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	62, // 62: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	63, // 63: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	64, // 64: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	65, // 65: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	66, // 66: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	67, // 67: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	68, // 68: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	69, // 69: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	70, // 70: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	71, // 71: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	72, // 72: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	73, // 73: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	74, // 74: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	75, // 75: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	76, // 76: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	77, // 77: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	39, // [39:78] is the sub-list for method output_type
-	0,  // [0:39] is the sub-list for method input_type
+	23, // 23: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
+	24, // 24: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	25, // 25: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	26, // 26: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	27, // 27: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	28, // 28: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	29, // 29: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	30, // 30: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	31, // 31: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	32, // 32: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	33, // 33: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	34, // 34: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	35, // 35: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	36, // 36: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	37, // 37: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	38, // 38: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	39, // 39: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	40, // 40: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	41, // 41: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	42, // 42: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	43, // 43: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	44, // 44: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	45, // 45: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	46, // 46: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	47, // 47: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	48, // 48: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	49, // 49: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	50, // 50: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	51, // 51: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	52, // 52: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	53, // 53: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	54, // 54: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	55, // 55: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	56, // 56: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	57, // 57: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	58, // 58: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	59, // 59: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	60, // 60: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	61, // 61: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	62, // 62: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	63, // 63: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	64, // 64: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	65, // 65: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	66, // 66: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	67, // 67: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	68, // 68: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	69, // 69: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	70, // 70: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	71, // 71: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	72, // 72: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	73, // 73: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	74, // 74: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	75, // 75: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	76, // 76: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	77, // 77: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	78, // 78: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	79, // 79: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	40, // [40:80] is the sub-list for method output_type
+	0,  // [0:40] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -1033,6 +1033,27 @@ func local_request_ContainerService_GetSystemInfo_0(ctx context.Context, marshal
 	return msg, metadata, err
 }
 
+func request_ContainerService_GetLatestRelease_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetLatestReleaseRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.GetLatestRelease(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_GetLatestRelease_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetLatestReleaseRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.GetLatestRelease(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_GetMonitoringInfo_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq GetMonitoringInfoRequest
@@ -2063,6 +2084,26 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_GetSystemInfo_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_GetLatestRelease_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/GetLatestRelease", runtime.WithHTTPPathPattern("/v1/releases/latest"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_GetLatestRelease_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_GetLatestRelease_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ContainerService_GetMonitoringInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2831,6 +2872,23 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_GetSystemInfo_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_GetLatestRelease_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/GetLatestRelease", runtime.WithHTTPPathPattern("/v1/releases/latest"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_GetLatestRelease_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_GetLatestRelease_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ContainerService_GetMonitoringInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3131,6 +3189,7 @@ var (
 	pattern_ContainerService_InstallStack_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "install-stack"}, ""))
 	pattern_ContainerService_ListStacks_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "stacks"}, ""))
 	pattern_ContainerService_GetSystemInfo_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "info"}, ""))
+	pattern_ContainerService_GetLatestRelease_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "releases", "latest"}, ""))
 	pattern_ContainerService_GetMonitoringInfo_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "monitoring"}, ""))
 	pattern_ContainerService_CreateAlertRule_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "alerts"}, ""))
 	pattern_ContainerService_ListAlertRules_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "alerts"}, ""))
@@ -3174,6 +3233,7 @@ var (
 	forward_ContainerService_InstallStack_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_ListStacks_0             = runtime.ForwardResponseMessage
 	forward_ContainerService_GetSystemInfo_0          = runtime.ForwardResponseMessage
+	forward_ContainerService_GetLatestRelease_0       = runtime.ForwardResponseMessage
 	forward_ContainerService_GetMonitoringInfo_0      = runtime.ForwardResponseMessage
 	forward_ContainerService_CreateAlertRule_0        = runtime.ForwardResponseMessage
 	forward_ContainerService_ListAlertRules_0         = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -42,6 +42,7 @@ const (
 	ContainerService_InstallStack_FullMethodName           = "/containarium.v1.ContainerService/InstallStack"
 	ContainerService_ListStacks_FullMethodName             = "/containarium.v1.ContainerService/ListStacks"
 	ContainerService_GetSystemInfo_FullMethodName          = "/containarium.v1.ContainerService/GetSystemInfo"
+	ContainerService_GetLatestRelease_FullMethodName       = "/containarium.v1.ContainerService/GetLatestRelease"
 	ContainerService_GetMonitoringInfo_FullMethodName      = "/containarium.v1.ContainerService/GetMonitoringInfo"
 	ContainerService_CreateAlertRule_FullMethodName        = "/containarium.v1.ContainerService/CreateAlertRule"
 	ContainerService_ListAlertRules_FullMethodName         = "/containarium.v1.ContainerService/ListAlertRules"
@@ -153,6 +154,10 @@ type ContainerServiceClient interface {
 	ListStacks(ctx context.Context, in *ListStacksRequest, opts ...grpc.CallOption) (*ListStacksResponse, error)
 	// GetSystemInfo gets information about the Incus host
 	GetSystemInfo(ctx context.Context, in *GetSystemInfoRequest, opts ...grpc.CallOption) (*GetSystemInfoResponse, error)
+	// GetLatestRelease reports the latest Containarium release on GitHub vs the
+	// running version, so operators see "update available" without SSHing in.
+	// The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
+	GetLatestRelease(ctx context.Context, in *GetLatestReleaseRequest, opts ...grpc.CallOption) (*GetLatestReleaseResponse, error)
 	// GetMonitoringInfo gets monitoring configuration (Grafana/VictoriaMetrics URLs)
 	GetMonitoringInfo(ctx context.Context, in *GetMonitoringInfoRequest, opts ...grpc.CallOption) (*GetMonitoringInfoResponse, error)
 	// CreateAlertRule creates a new custom alert rule
@@ -435,6 +440,16 @@ func (c *containerServiceClient) GetSystemInfo(ctx context.Context, in *GetSyste
 	return out, nil
 }
 
+func (c *containerServiceClient) GetLatestRelease(ctx context.Context, in *GetLatestReleaseRequest, opts ...grpc.CallOption) (*GetLatestReleaseResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetLatestReleaseResponse)
+	err := c.cc.Invoke(ctx, ContainerService_GetLatestRelease_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *containerServiceClient) GetMonitoringInfo(ctx context.Context, in *GetMonitoringInfoRequest, opts ...grpc.CallOption) (*GetMonitoringInfoResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetMonitoringInfoResponse)
@@ -688,6 +703,10 @@ type ContainerServiceServer interface {
 	ListStacks(context.Context, *ListStacksRequest) (*ListStacksResponse, error)
 	// GetSystemInfo gets information about the Incus host
 	GetSystemInfo(context.Context, *GetSystemInfoRequest) (*GetSystemInfoResponse, error)
+	// GetLatestRelease reports the latest Containarium release on GitHub vs the
+	// running version, so operators see "update available" without SSHing in.
+	// The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
+	GetLatestRelease(context.Context, *GetLatestReleaseRequest) (*GetLatestReleaseResponse, error)
 	// GetMonitoringInfo gets monitoring configuration (Grafana/VictoriaMetrics URLs)
 	GetMonitoringInfo(context.Context, *GetMonitoringInfoRequest) (*GetMonitoringInfoResponse, error)
 	// CreateAlertRule creates a new custom alert rule
@@ -808,6 +827,9 @@ func (UnimplementedContainerServiceServer) ListStacks(context.Context, *ListStac
 }
 func (UnimplementedContainerServiceServer) GetSystemInfo(context.Context, *GetSystemInfoRequest) (*GetSystemInfoResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetSystemInfo not implemented")
+}
+func (UnimplementedContainerServiceServer) GetLatestRelease(context.Context, *GetLatestReleaseRequest) (*GetLatestReleaseResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetLatestRelease not implemented")
 }
 func (UnimplementedContainerServiceServer) GetMonitoringInfo(context.Context, *GetMonitoringInfoRequest) (*GetMonitoringInfoResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetMonitoringInfo not implemented")
@@ -1292,6 +1314,24 @@ func _ContainerService_GetSystemInfo_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ContainerService_GetLatestRelease_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetLatestReleaseRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).GetLatestRelease(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_GetLatestRelease_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).GetLatestRelease(ctx, req.(*GetLatestReleaseRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ContainerService_GetMonitoringInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetMonitoringInfoRequest)
 	if err := dec(in); err != nil {
@@ -1678,6 +1718,10 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetSystemInfo",
 			Handler:    _ContainerService_GetSystemInfo_Handler,
+		},
+		{
+			MethodName: "GetLatestRelease",
+			Handler:    _ContainerService_GetLatestRelease_Handler,
 		},
 		{
 			MethodName: "GetMonitoringInfo",

--- a/proto/containarium/v1/config.proto
+++ b/proto/containarium/v1/config.proto
@@ -286,6 +286,23 @@ message GetSystemInfoResponse {
   repeated SystemInfo peers = 2;
 }
 
+// GetLatestReleaseRequest is the request for the latest-release check.
+message GetLatestReleaseRequest {}
+
+// GetLatestReleaseResponse reports the latest published release vs the
+// running daemon version. See #354.
+message GetLatestReleaseResponse {
+  // Latest release tag from GitHub (e.g. "v0.21.2"). Empty when the lookup
+  // hasn't succeeded yet (e.g. rate-limited with no cached value).
+  string latest_release = 1;
+
+  // This daemon's running version (e.g. "0.21.0").
+  string current_version = 2;
+
+  // True when latest_release is a newer semver than current_version.
+  bool update_available = 3;
+}
+
 // BackendType represents the type of backend instance
 enum BackendType {
   BACKEND_TYPE_UNSPECIFIED = 0;

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -385,6 +385,20 @@ service ContainerService {
     };
   }
 
+  // GetLatestRelease reports the latest Containarium release on GitHub vs the
+  // running version, so operators see "update available" without SSHing in.
+  // The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
+  rpc GetLatestRelease(GetLatestReleaseRequest) returns (GetLatestReleaseResponse) {
+    option (google.api.http) = {
+      get: "/v1/releases/latest"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get latest release";
+      description: "Returns the latest Containarium release tag from GitHub (cached) alongside this daemon's running version and whether an update is available.";
+      tags: "System";
+    };
+  }
+
   // GetMonitoringInfo gets monitoring configuration (Grafana/VictoriaMetrics URLs)
   rpc GetMonitoringInfo(GetMonitoringInfoRequest) returns (GetMonitoringInfoResponse) {
     option (google.api.http) = {


### PR DESCRIPTION
Phase A1 of #354, building on Phase A0 (#381, merged — per-backend version visibility). This adds the **"is a newer version available?"** half: a cached GitHub-release lookup so an operator sees drift without watching the releases page — the exact #341 failure (4 daemons on v0.19.0 while v0.19.2 was out).

## Change
- **`internal/releasecheck`** — the testable core: a cached (1h TTL) `releases/latest` fetcher with **injectable HTTP client + clock**. Best-effort by design: serves the last good value on a fetch error (stale beats nothing for a status panel), returns empty only when it never cached. `UpdateAvailable` does a **real semver compare** (`blang/semver`, tolerant of a leading `v`), so "current newer than latest" or garbage input never falsely claims an update.
- **proto:** `GetLatestRelease` RPC → `GET /v1/releases/latest`, returning `{latest_release, current_version, update_available}`.
- **daemon handler** (admin-only, matching the other `System` endpoints) backed by a **package-level checker** so the 1h cache is shared across requests (not per-call) — this is what spares GitHub's ~60/hr unauthenticated limit.
- **MCP:** `client.GetLatestRelease()` + a `check_for_updates` tool (current / latest / ✓ up-to-date or ⚠ update available).

## Test plan
`internal/releasecheck` fully unit-tested with **no network**:
- fetch + cache (second call within TTL doesn't hit the server),
- TTL expiry refetches,
- serves stale on error,
- errors only when there's no cache to fall back on,
- `UpdateAvailable` matrix (newer / equal / older / v-prefix / empty / garbage).

Plus a client wire round-trip test; the MCP tool-count tests are bumped (38 → 39). `internal/releasecheck` + `internal/mcp` + `internal/server` suites green.

## Scope
This is the last fully-testable, **no-host** slice of #354. Still out (and needing a live backend / the Next.js toolchain): Phase B/C upgrade execution + rollback, and the webui Versions table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)