### PR TITLE
chore: cut v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-05-31
+
+Minor release: managed DNS-01 wildcard TLS, multi-domain Caddy apex management, fleet version visibility, and multi-key collaborators.
+
+### Added
+
+- **DNS-01 ACME for wildcard certs** — the core Caddy build now bundles the `caddy-dns` module, so the daemon issues/renews wildcard certificates via DNS-01 instead of per-host HTTP-01, with a single source of truth for the DNS-provider→module map. (#378)
+- **Daemon Caddy-manages the apex of every `PublicBaseDomain`** — multi-base-domain support: each configured apex is served and auto-TLS'd. (#213)
+- **Per-backend daemon version** in `get_system_info` and `/v1/backends`, so fleet version drift is visible without SSHing each host. (#354, Phase A0)
+- **`GetLatestRelease` "update available" check** — the daemon can report whether a newer release exists. (#354, Phase A1)
+- **`AddCollaborator` accepts multiple SSH keys** in a single call. (#369)
+- **Sentinel HMAC-misconfig surfaced in `/status`** — a machine-readable `sentinel_auth_misconfigured` flag so monitoring can alert directly on the missing/short `CONTAINARIUM_SENTINEL_AUTH_SECRET` 401 loop. (#341, #373)
+- **sshpiper-reload repro harness** (`hacks/repro/`) for validating hot-reload behavior (#301), with a single-VM Multipass bring-up. (#374)
+
+### Fixed
+
+- **App-side OpenTelemetry monitoring unblocked end-to-end** — the `--monitoring=true` ingest path now reaches the central collector. (#370, #371)
+
+### Changed
+
+- **Terraform module**: 0.9.x→0.21.x migration note plus a `sentinel_auth_secret` guard, so upgrades don't silently hit the HMAC 401 loop. (#375)
+
+## [0.21.0] - 2026-05-29
+
+Minor release: `--git-source` create plus a wake-on-HTTP fix.
+
+### Added
+
+- **`containarium create --git-source`** — the daemon fetches a git repo into the box at create time. (#363)
+
+### Fixed
+
+- **Wake-on-HTTP** returns 404 instead of a futile container start for routes with no backing container. (#362)
+
 ## [0.20.0] - 2026-05-29
 
 Minor release: app-side OpenTelemetry distros for Python and Go, plus a wake-on-HTTP fix.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.21.0"
+	Version = "0.22.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Bumps `pkg/version/version.go` `0.21.0` → `0.22.0`, mirroring the `chore: cut v0.21.0` (#366) pattern.

Cuts a minor release over the 26 commits on `main` since v0.21.0 — notably:
- DNS-01 ACME wildcard certs + Caddy `caddy-dns` module (#378)
- daemon Caddy-manages the apex of every `PublicBaseDomain` (#213)
- per-backend daemon version in `get_system_info` + `/v1/backends`, plus `GetLatestRelease` "update available" check (#354)
- `AddCollaborator` accepts multiple SSH keys (#369)
- OTEL app-monitoring end-to-end fix (#370/#371)
- sentinel HMAC-misconfig surfaced in `/status` for alerting (#341/#373)
- terraform 0.9.x→0.21.x migration note + `sentinel_auth_secret` guard (#375)

**Next step (after merge):** push the `v0.22.0` tag at the merge commit → `release.yml` builds the binaries + GitHub release (and `distros-py-release.yml` fires). That tag push is the irreversible/public step and is intentionally NOT part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)