### PR TITLE
fix(daemon): translate fractional CPU to limits.cpu.allowance (#401)

### DIFF
--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -924,7 +924,7 @@ func (m *Manager) Resize(containerName, cpu, memory, disk string, verbose bool) 
 		if verbose {
 			fmt.Printf("  Setting CPU limit: %s\n", cpu)
 		}
-		if err := m.incus.SetConfig(containerName, "limits.cpu", cpu); err != nil {
+		if err := m.incus.SetCPULimit(containerName, cpu); err != nil {
 			if strings.Contains(err.Error(), "disk quota exceeded") || strings.Contains(err.Error(), "no space left") {
 				return fmt.Errorf("container disk is full. Include a larger disk size in the resize request, or clean up disk space first")
 			}

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -48,6 +48,7 @@ type Backend interface {
 
 	// Config & devices
 	SetConfig(containerName, key, value string) error
+	SetCPULimit(containerName, cpu string) error
 	UnsetConfig(containerName, key string) error
 	SetDeviceSize(containerName, deviceName, size string) error
 	UpdateContainerConfig(name, key, value string) error
@@ -474,9 +475,20 @@ func (c *Client) CreateContainer(config ContainerConfig) error {
 	// Set container configuration
 	req.Config = make(map[string]string)
 
-	// Resource limits
+	// Resource limits. CPU may be a whole-core count, a CPU set, or a
+	// fractional request (millicpu / decimal) — translate to the correct
+	// Incus key (limits.cpu vs limits.cpu.allowance). See issue #401.
 	if config.CPU != "" {
-		req.Config["limits.cpu"] = config.CPU
+		cl, err := parseCPULimit(config.CPU)
+		if err != nil {
+			return err
+		}
+		if cl.Count != "" {
+			req.Config["limits.cpu"] = cl.Count
+		}
+		if cl.Allowance != "" {
+			req.Config["limits.cpu.allowance"] = cl.Allowance
+		}
 	}
 	if config.Memory != "" {
 		req.Config["limits.memory"] = config.Memory
@@ -631,7 +643,7 @@ func (c *Client) ListContainers() ([]ContainerInfo, error) {
 		}
 
 		// Get CPU and memory limits from config
-		if cpu, ok := inst.Config["limits.cpu"]; ok {
+		if cpu := formatCPULimitFromConfig(inst.Config); cpu != "" {
 			info.CPU = cpu
 		}
 		if mem, ok := inst.Config["limits.memory"]; ok {
@@ -759,7 +771,7 @@ func (c *Client) GetContainer(name string) (*ContainerInfo, error) {
 	}
 
 	// Get resource limits
-	if cpu, ok := inst.Config["limits.cpu"]; ok {
+	if cpu := formatCPULimitFromConfig(inst.Config); cpu != "" {
 		info.CPU = cpu
 	}
 	if mem, ok := inst.Config["limits.memory"]; ok {
@@ -1192,6 +1204,41 @@ func (c *Client) GetContainerImageFingerprint(containerName string) (string, err
 		return "", fmt.Errorf("get instance for fingerprint: %w", err)
 	}
 	return inst.Config["volatile.base_image"], nil
+}
+
+// SetCPULimit updates a container's CPU limit, translating the request into
+// the correct Incus key — limits.cpu for whole-core counts and CPU sets, or
+// limits.cpu.allowance for fractional requests (millicpu / decimal). It clears
+// the other key first so a fractional→whole-core resize (or vice versa) never
+// leaves a stale, conflicting limit behind. See issue #401.
+func (c *Client) SetCPULimit(containerName, cpu string) error {
+	cl, err := parseCPULimit(cpu)
+	if err != nil {
+		return err
+	}
+
+	inst, etag, err := c.server.GetInstance(containerName)
+	if err != nil {
+		return fmt.Errorf("failed to get container: %w", err)
+	}
+
+	delete(inst.Config, "limits.cpu")
+	delete(inst.Config, "limits.cpu.allowance")
+	if cl.Count != "" {
+		inst.Config["limits.cpu"] = cl.Count
+	}
+	if cl.Allowance != "" {
+		inst.Config["limits.cpu.allowance"] = cl.Allowance
+	}
+
+	op, err := c.server.UpdateInstance(containerName, inst.Writable(), etag)
+	if err != nil {
+		return fmt.Errorf("failed to update container config: %w", err)
+	}
+	if err := op.Wait(); err != nil {
+		return fmt.Errorf("failed to wait for config update: %w", err)
+	}
+	return nil
 }
 
 func (c *Client) SetConfig(containerName, key, value string) error {

--- a/pkg/core/incus/cpu_limits.go
+++ b/pkg/core/incus/cpu_limits.go
@@ -1,0 +1,105 @@
+package incus
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// cpuLimit holds the Incus instance-config representation of a CPU request.
+// At most one of Count or Allowance is non-empty:
+//
+//   - Count     → set as `limits.cpu` (whole-core count "2" or CPU set "0-3").
+//   - Allowance → set as `limits.cpu.allowance` (fractional share expressed as
+//     a percentage, e.g. "25%").
+//
+// Incus's `limits.cpu` key only accepts an integer core count or a set/range;
+// fractional CPU must go through `limits.cpu.allowance`. Passing millicpu
+// notation ("250m") straight to `limits.cpu` is rejected by Incus with
+// "Invalid CPU limit syntax". See issue #401.
+type cpuLimit struct {
+	Count     string
+	Allowance string
+}
+
+// parseCPULimit translates a Containarium CPU request string into the Incus
+// config key it maps to.
+//
+// Accepted inputs:
+//   - whole-core count:    "1", "4"           → limits.cpu
+//   - CPU set / pinning:   "0-3", "0,2-4"     → limits.cpu (passed through)
+//   - Kubernetes millicpu: "250m" (0.25 core) → limits.cpu.allowance "25%"
+//   - decimal cores:       "0.25", "1.5"      → limits.cpu.allowance "25%" / "150%"
+//
+// Millicpu / decimals that resolve to a whole number of cores ("1000m",
+// "2.0") map back to limits.cpu as an integer count. An empty request returns
+// a zero cpuLimit (no keys to set).
+func parseCPULimit(cpu string) (cpuLimit, error) {
+	cpu = strings.TrimSpace(cpu)
+	if cpu == "" {
+		return cpuLimit{}, nil
+	}
+
+	// CPU set / pinning notation ("0-3", "0,2-4") — pass through to limits.cpu.
+	// A leading "-" is a negative sign, not a range separator, so only treat an
+	// interior "-" as set notation; negatives fall through to be rejected below.
+	if strings.Contains(cpu, ",") || (strings.Contains(cpu, "-") && cpu[0] != '-') {
+		return cpuLimit{Count: cpu}, nil
+	}
+
+	// Resolve the request to a fractional number of cores.
+	var cores float64
+	if strings.HasSuffix(cpu, "m") {
+		// Kubernetes millicpu: "250m" == 0.25 core.
+		milli, err := strconv.Atoi(strings.TrimSuffix(cpu, "m"))
+		if err != nil || milli < 0 {
+			return cpuLimit{}, fmt.Errorf("invalid millicpu CPU request %q", cpu)
+		}
+		cores = float64(milli) / 1000
+	} else {
+		f, err := strconv.ParseFloat(cpu, 64)
+		if err != nil || f < 0 {
+			return cpuLimit{}, fmt.Errorf("invalid CPU request %q", cpu)
+		}
+		cores = f
+	}
+
+	if cores == 0 {
+		return cpuLimit{}, fmt.Errorf("CPU request %q resolves to zero cores", cpu)
+	}
+
+	// Whole-core requests map to an integer limits.cpu count.
+	if cores == float64(int64(cores)) {
+		return cpuLimit{Count: strconv.FormatInt(int64(cores), 10)}, nil
+	}
+
+	// Fractional requests become a percentage allowance. 0.25 core → "25%".
+	pct := cores * 100
+	return cpuLimit{Allowance: strconv.FormatFloat(pct, 'f', -1, 64) + "%"}, nil
+}
+
+// formatCPULimitFromConfig renders the CPU request stored in an Incus instance
+// config back into the Containarium representation, for display in container
+// info. A whole-core count or set is returned verbatim from `limits.cpu`; a
+// fractional `limits.cpu.allowance` percentage is converted back to Kubernetes
+// millicpu ("25%" → "250m"). A non-percentage (time-slice) allowance has no
+// millicpu equivalent and is returned as-is. Returns "" when neither key is
+// set.
+func formatCPULimitFromConfig(config map[string]string) string {
+	if v, ok := config["limits.cpu"]; ok && v != "" {
+		return v
+	}
+	allowance, ok := config["limits.cpu.allowance"]
+	if !ok || allowance == "" {
+		return ""
+	}
+	if !strings.HasSuffix(allowance, "%") {
+		return allowance
+	}
+	pct, err := strconv.ParseFloat(strings.TrimSuffix(allowance, "%"), 64)
+	if err != nil {
+		return allowance
+	}
+	milli := int64(pct * 10) // 25% → 250m
+	return strconv.FormatInt(milli, 10) + "m"
+}

--- a/pkg/core/incus/cpu_limits_test.go
+++ b/pkg/core/incus/cpu_limits_test.go
@@ -1,0 +1,110 @@
+package incus
+
+import "testing"
+
+func TestParseCPULimit(t *testing.T) {
+	tests := []struct {
+		name          string
+		cpu           string
+		wantCount     string
+		wantAllowance string
+		wantErr       bool
+	}{
+		{name: "empty", cpu: "", wantCount: "", wantAllowance: ""},
+		{name: "whole core", cpu: "1", wantCount: "1"},
+		{name: "multiple cores", cpu: "4", wantCount: "4"},
+		{name: "cpu range", cpu: "0-3", wantCount: "0-3"},
+		{name: "cpu set", cpu: "0,2-4", wantCount: "0,2-4"},
+		{name: "millicpu quarter core", cpu: "250m", wantAllowance: "25%"},
+		{name: "millicpu half core", cpu: "500m", wantAllowance: "50%"},
+		{name: "millicpu whole core", cpu: "1000m", wantCount: "1"},
+		{name: "millicpu one and a half", cpu: "1500m", wantAllowance: "150%"},
+		{name: "decimal quarter core", cpu: "0.25", wantAllowance: "25%"},
+		{name: "decimal whole core", cpu: "2.0", wantCount: "2"},
+		{name: "decimal one and a half", cpu: "1.5", wantAllowance: "150%"},
+		{name: "whitespace trimmed", cpu: "  250m  ", wantAllowance: "25%"},
+		{name: "invalid millicpu", cpu: "abcm", wantErr: true},
+		{name: "invalid decimal", cpu: "xyz", wantErr: true},
+		{name: "negative", cpu: "-1.5", wantErr: true},
+		{name: "zero", cpu: "0", wantErr: true},
+		{name: "zero millicpu", cpu: "0m", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCPULimit(tt.cpu)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseCPULimit(%q) = %+v, want error", tt.cpu, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseCPULimit(%q) unexpected error: %v", tt.cpu, err)
+			}
+			if got.Count != tt.wantCount {
+				t.Errorf("parseCPULimit(%q).Count = %q, want %q", tt.cpu, got.Count, tt.wantCount)
+			}
+			if got.Allowance != tt.wantAllowance {
+				t.Errorf("parseCPULimit(%q).Allowance = %q, want %q", tt.cpu, got.Allowance, tt.wantAllowance)
+			}
+		})
+	}
+}
+
+func TestParseCPULimitNegativeMillicpu(t *testing.T) {
+	if _, err := parseCPULimit("-250m"); err == nil {
+		t.Fatal("parseCPULimit(\"-250m\") = nil error, want error")
+	}
+}
+
+func TestFormatCPULimitFromConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		config map[string]string
+		want   string
+	}{
+		{name: "no limits", config: map[string]string{}, want: ""},
+		{name: "whole core", config: map[string]string{"limits.cpu": "4"}, want: "4"},
+		{name: "cpu set", config: map[string]string{"limits.cpu": "0-3"}, want: "0-3"},
+		{name: "allowance percentage", config: map[string]string{"limits.cpu.allowance": "25%"}, want: "250m"},
+		{name: "allowance half", config: map[string]string{"limits.cpu.allowance": "50%"}, want: "500m"},
+		{name: "allowance over one core", config: map[string]string{"limits.cpu.allowance": "150%"}, want: "1500m"},
+		{name: "time slice allowance passthrough", config: map[string]string{"limits.cpu.allowance": "25ms/100ms"}, want: "25ms/100ms"},
+		{
+			name:   "limits.cpu wins over allowance",
+			config: map[string]string{"limits.cpu": "2", "limits.cpu.allowance": "50%"},
+			want:   "2",
+		},
+		{name: "empty limits.cpu falls through to allowance", config: map[string]string{"limits.cpu": "", "limits.cpu.allowance": "25%"}, want: "250m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatCPULimitFromConfig(tt.config); got != tt.want {
+				t.Errorf("formatCPULimitFromConfig(%v) = %q, want %q", tt.config, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCPULimitRoundTrip confirms a fractional request survives the
+// translate-then-read-back cycle as the same millicpu value.
+func TestCPULimitRoundTrip(t *testing.T) {
+	for _, in := range []string{"250m", "500m", "1500m"} {
+		cl, err := parseCPULimit(in)
+		if err != nil {
+			t.Fatalf("parseCPULimit(%q): %v", in, err)
+		}
+		config := map[string]string{}
+		if cl.Count != "" {
+			config["limits.cpu"] = cl.Count
+		}
+		if cl.Allowance != "" {
+			config["limits.cpu.allowance"] = cl.Allowance
+		}
+		if got := formatCPULimitFromConfig(config); got != in {
+			t.Errorf("round-trip of %q = %q, want %q", in, got, in)
+		}
+	}
+}

--- a/pkg/core/incus/incustest/mock.go
+++ b/pkg/core/incus/incustest/mock.go
@@ -35,6 +35,7 @@ type MockBackend struct {
 	WriteFileFunc            func(containerName, path string, content []byte, mode string) error
 	ReadFileFunc             func(containerName, path string) ([]byte, error)
 	SetConfigFunc            func(containerName, key, value string) error
+	SetCPULimitFunc          func(containerName, cpu string) error
 	UnsetConfigFunc          func(containerName, key string) error
 	SetDeviceSizeFunc        func(containerName, deviceName, size string) error
 	ResolveGPUInputToPCIFunc func(input string) (string, error)
@@ -168,6 +169,13 @@ func (m *MockBackend) ReadFile(containerName, path string) ([]byte, error) {
 func (m *MockBackend) SetConfig(containerName, key, value string) error {
 	if m.SetConfigFunc != nil {
 		return m.SetConfigFunc(containerName, key, value)
+	}
+	return nil
+}
+
+func (m *MockBackend) SetCPULimit(containerName, cpu string) error {
+	if m.SetCPULimitFunc != nil {
+		return m.SetCPULimitFunc(containerName, cpu)
 	}
 	return nil
 }

--- a/test/integration/storage_test.go
+++ b/test/integration/storage_test.go
@@ -91,17 +91,18 @@ func testCreateContainerWithQuota(t *testing.T, ctx context.Context, grpcClient 
 	container, err := grpcClient.CreateContainer(
 		username,
 		"images:ubuntu/24.04",
-		"2",                            // 2 CPUs
-		"2GB",                          // 2GB RAM
-		fmt.Sprintf("%dGB", quotaGB),   // 10GB disk
-		[]string{},                     // No SSH keys for test
-		false,                          // No Podman
-		"",                             // No stack
-		"",                             // No GPU
-		0,                              // Default OS type
-		false,                          // No monitoring
-		"",                             // No pool
-		"",                             // No backend ID
+		"2",                          // 2 CPUs
+		"2GB",                        // 2GB RAM
+		fmt.Sprintf("%dGB", quotaGB), // 10GB disk
+		[]string{},                   // No SSH keys for test
+		false,                        // No Podman
+		"",                           // No stack
+		"",                           // No GPU
+		0,                            // Default OS type
+		false,                        // No monitoring
+		"",                           // No pool
+		"",                           // No backend ID
+		client.GitSourceOpts{},       // No git provisioning
 	)
 	require.NoError(t, err, "Failed to create container")
 	require.NotNil(t, container)
@@ -147,8 +148,9 @@ func testQuotaEnforcement(t *testing.T, ctx context.Context, grpcClient *client.
 		"",
 		0, // Default OS type
 		false,
-		"", // No pool
-		"", // No backend ID
+		"",                     // No pool
+		"",                     // No backend ID
+		client.GitSourceOpts{}, // No git provisioning
 	)
 	require.NoError(t, err)
 	require.NotNil(t, container)
@@ -185,11 +187,11 @@ func testMultiContainerIsolation(t *testing.T, ctx context.Context, grpcClient *
 	t.Log("Creating multiple containers to test quota isolation...")
 
 	// Create two containers with different quotas
-	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "")
+	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{})
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(user1, true)
 
-	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", "", 0, false, "", "")
+	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{})
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(user2, true)
 
@@ -215,7 +217,7 @@ func testCompression(t *testing.T, ctx context.Context, grpcClient *client.GRPCC
 
 	t.Log("Creating container to test compression...")
 
-	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "")
+	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{})
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(username, true)
 
@@ -238,7 +240,7 @@ func testPrepareRebootData(t *testing.T, ctx context.Context, grpcClient *client
 	t.Logf("Creating container for persistence test: %s", username)
 
 	// Create container
-	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", "", 0, false, "", "")
+	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{})
 	require.NoError(t, err)
 	require.NotNil(t, container)
 
@@ -251,11 +253,11 @@ func testPrepareRebootData(t *testing.T, ctx context.Context, grpcClient *client
 
 	// Save test state for post-reboot verification
 	state := RebootTestState{
-		Username:     username,
+		Username:      username,
 		ContainerName: info.Name,
-		TestData:     testData,
-		TestDataHash: testDataHash,
-		CreatedAt:    time.Now(),
+		TestData:      testData,
+		TestDataHash:  testDataHash,
+		CreatedAt:     time.Now(),
 	}
 
 	err = saveRebootTestState(stateFile, &state)


### PR DESCRIPTION
Fixes #401.

## Problem

`POST /v1/containers` with a **fractional** CPU request failed async
provisioning with `Invalid CPU limit syntax`. The `resources.cpu` string
(e.g. Kubernetes millicpu `"250m"`, or a decimal `"0.25"`) was passed
straight through to incus's `limits.cpu`, which only accepts an integer
core count (`"2"`) or a set (`"0-3"`). Only whole-core requests reached
`RUNNING`.

## Fix

Incus expresses fractional CPU through `limits.cpu.allowance` (a
percentage), reserving `limits.cpu` for whole-core counts/sets. This PR
adds the translation:

- **`parseCPULimit`** maps a request to the right incus key:
  - `"1"`, `"4"` → `limits.cpu`
  - `"0-3"`, `"0,2-4"` → `limits.cpu` (set/pinning, passed through)
  - `"250m"` / `"0.25"` → `limits.cpu.allowance = "25%"`
  - `"1500m"` / `"1.5"` → `limits.cpu.allowance = "150%"`
  - millicpu/decimals that resolve to whole cores (`"1000m"`, `"2.0"`) → `limits.cpu`
- **`CreateContainer`** uses it instead of the raw pass-through.
- **Resize** goes through a new `SetCPULimit`, which clears the sibling
  key so a fractional↔whole-core resize never leaves a stale conflicting
  limit behind.
- **Read-back** (`GetContainer`/`ListContainers`) converts a percentage
  allowance back to millicpu for display (`"25%"` → `"250m"`) via
  `formatCPULimitFromConfig`.

## Tests

`pkg/core/incus/cpu_limits_test.go` covers parse (whole/set/millicpu/
decimal/whitespace/invalid/negative/zero), read-back formatting, and a
millicpu round-trip. `go build ./...` clean; `go test ./pkg/core/...`
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)