### PR TITLE
deploy: refuse binary swap when sentinel HMAC secret missing + runbook (#341 §2)

### DIFF
--- a/docs/SENTINEL-AUTH-SECRET.md
+++ b/docs/SENTINEL-AUTH-SECRET.md
@@ -1,0 +1,142 @@
+# Sentinel ↔ daemon HMAC secret (`CONTAINARIUM_SENTINEL_AUTH_SECRET`)
+
+Since **v0.19.0** the sentinel-facing daemon endpoints are gated behind an
+HMAC signature keyed on a shared secret:
+
+| Endpoint | Used by |
+| --- | --- |
+| `/authorized-keys` | sentinel keysync — builds the sshpiper upstream map |
+| `/authorized-keys/sentinel` | sentinel pushes its own upstream key to the daemon |
+| `/certs` | sentinel certsync — pulls Caddy-managed TLS certs |
+
+Both ends read the secret from the environment variable
+`CONTAINARIUM_SENTINEL_AUTH_SECRET`, which must be **at least 32 bytes** and
+**identical on the sentinel and every daemon it talks to** (one secret per
+cluster, not per host).
+
+The endpoints **fail closed**: if the secret is missing or too short on either
+end, the daemon answers every request with
+`{"error":"sentinel auth not configured","code":401}`.
+
+## Why this matters — the silent-lockout failure mode
+
+A binary upgrade from a pre-HMAC version that leaves the secret unset does not
+fail at startup; it fails per request, hours later:
+
+1. Sentinel keysync hits the daemon's `/authorized-keys` → 401 every cycle.
+2. The sshpiper upstream map stops being refreshed — frozen at last-known-good.
+3. As backend addresses rotate (tunnel reconnects, loopback-alias races), the
+   frozen map develops stale upstream pointers.
+4. Tenants start getting `Permission denied (publickey)` / `Connection closed`
+   — symptoms that look like per-user SSH problems but are a sentinel-wide
+   outage.
+5. Both daemons still report `active` in `systemctl status`, so the cause is
+   several layers down (sshpiper pipe → backend listener → daemon endpoint 401).
+
+This is tracked in **issue #341** (a real incident locked tenants out for
+hours after a routine upgrade). The daemon and sentinel now log a rate-limited
+`WARNING` when the secret is missing (see [Verifying](#verifying) below), and
+`scripts/deploy-binary.sh` refuses to swap a binary onto a host whose secret
+isn't provisioned.
+
+## Generate the secret (once per cluster)
+
+```bash
+# 64 hex chars = 64 bytes, comfortably over the 32-byte minimum.
+openssl rand -hex 32
+```
+
+Keep this value somewhere durable and off-host (a secrets manager / password
+vault). It is **not** stored in Terraform state when written by the startup
+scripts, and losing it means regenerating + redistributing to the whole
+cluster.
+
+## Distribute to the sentinel and every daemon
+
+On **each** host — the sentinel, the primary daemon, and every peer daemon —
+install the *same* value:
+
+```bash
+# As root on the host. Mode 0600 so the secret never shows up in `ps`,
+# `systemctl cat`, or `systemctl show -p Environment`.
+sudo install -d -m 0700 /etc/containarium
+umask 077
+sudo tee /etc/containarium/env.secrets >/dev/null <<EOF
+CONTAINARIUM_SENTINEL_AUTH_SECRET=<the-secret-from-above>
+EOF
+sudo chmod 0600 /etc/containarium/env.secrets
+```
+
+Wire it into the systemd unit via a drop-in (the leading `-` on
+`EnvironmentFile=-` tells systemd to tolerate the file being absent, which keeps
+a not-yet-provisioned host bootable):
+
+```bash
+# Daemon hosts (primary + peers): unit name `containarium`.
+# Sentinel host: unit name `containarium-sentinel`.
+UNIT=containarium   # or containarium-sentinel on the sentinel
+sudo mkdir -p "/etc/systemd/system/${UNIT}.service.d"
+sudo tee "/etc/systemd/system/${UNIT}.service.d/secrets.conf" >/dev/null <<'EOF'
+[Service]
+EnvironmentFile=-/etc/containarium/env.secrets
+EOF
+sudo chmod 0644 "/etc/systemd/system/${UNIT}.service.d/secrets.conf"
+sudo systemctl daemon-reload
+```
+
+> On a Terraform-provisioned cluster the startup scripts already write
+> `/etc/containarium/env.secrets` and this drop-in from the `sentinel_auth_secret`
+> module variable — see `terraform/modules/containarium/scripts/startup*.sh`.
+> Set that variable to the cluster secret and you get the same result on boot.
+
+## Restart order
+
+Restart **daemons first, then the sentinel**, so that by the time the sentinel
+resumes keysync/certsync the daemons are already accepting signed requests:
+
+```bash
+# 1. Each daemon host (primary + peers)
+sudo systemctl restart containarium
+
+# 2. Sentinel host, last
+sudo systemctl restart containarium-sentinel
+```
+
+## Upgrading from < v0.19.0
+
+1. Generate the cluster secret (above) if you don't already have one.
+2. Distribute it to the sentinel and every daemon, install the drop-in,
+   `daemon-reload`.
+3. Deploy the new binary. `scripts/deploy-binary.sh` runs a preflight that
+   **aborts** if the secret is missing on the sentinel or primary, pointing
+   back here. Provision first, then re-run.
+4. Restart daemons, then the sentinel.
+5. Verify (below).
+
+## Verifying
+
+**Sentinel** exposes the state on its status endpoint — alert on
+`sentinel_auth_misconfigured` being `true`:
+
+```bash
+curl -s http://<sentinel-host>:<health-port>/status | jq '.sentinel_auth_misconfigured, .sentinel_auth_detail'
+# want: false / null
+```
+
+**Daemon** logs a rate-limited (once / 60s) line while the secret is missing
+and a sentinel request arrives:
+
+```bash
+journalctl -u containarium --since '-5min' | grep -i 'sentinel-hmac'
+# a healthy daemon logs nothing here
+```
+
+Once both are quiet and `/status` reports `false`, keysync/certsync is
+authenticating and the sshpiper map is refreshing again.
+
+## Rotating the secret
+
+Rotation is the same distribute-then-restart dance with a fresh
+`openssl rand -hex 32`. Push the new value to **every** host before restarting
+anything; during the window where hosts disagree, requests 401. Restart
+daemons first, then the sentinel, to minimize that window.

--- a/scripts/deploy-binary.sh
+++ b/scripts/deploy-binary.sh
@@ -51,6 +51,59 @@ fi
 BINARY_SIZE=$(du -h "$BINARY" | cut -f1)
 echo "==> Binary: $BINARY ($BINARY_SIZE)"
 
+# 1b. Preflight: the sentinel↔daemon HMAC secret must already be provisioned.
+#
+# v0.19.0+ gates the sentinel-facing endpoints (/authorized-keys, /certs,
+# /authorized-keys/sentinel) behind an HMAC over CONTAINARIUM_SENTINEL_AUTH_SECRET
+# (>=32 bytes), loaded from /etc/containarium/env.secrets via a systemd
+# EnvironmentFile drop-in. Swapping a v0.19.0+ binary onto a host that lacks the
+# secret silently 401s every sentinel keysync/certsync cycle — sshpiper config
+# freezes, upstream pointers go stale, and tenants get locked out for hours
+# before anyone finds the 401 (issue #341). Refuse to swap the binary until the
+# secret is in place rather than recreate that outage.
+#
+# Set ALLOW_MISSING_SENTINEL_SECRET=1 to bypass (deliberate pre-HMAC rollback,
+# or an unsecured single-node dev box). See docs/SENTINEL-AUTH-SECRET.md for how
+# to generate and distribute the secret.
+SECRET_FILE="/etc/containarium/env.secrets"
+SECRET_MIN_LEN=32
+RUNBOOK="docs/SENTINEL-AUTH-SECRET.md"
+# grep emits SECRET_OK iff env.secrets holds a CONTAINARIUM_SENTINEL_AUTH_SECRET
+# value of at least SECRET_MIN_LEN chars; SECRET_MISSING otherwise (incl. no file).
+SECRET_CHECK_CMD="sudo grep -Eq '^CONTAINARIUM_SENTINEL_AUTH_SECRET=.{${SECRET_MIN_LEN},}' '$SECRET_FILE' 2>/dev/null && echo SECRET_OK || echo SECRET_MISSING"
+
+if [[ "${ALLOW_MISSING_SENTINEL_SECRET:-0}" == "1" ]]; then
+    echo "==> ALLOW_MISSING_SENTINEL_SECRET=1 — skipping HMAC secret preflight (#341)"
+else
+    echo "==> Preflight: checking CONTAINARIUM_SENTINEL_AUTH_SECRET on sentinel + primary (#341)..."
+    missing=()
+
+    sentinel_secret=$(gcloud compute ssh "$SENTINEL_VM" --zone="$ZONE" --project="$PROJECT" \
+        --tunnel-through-iap --ssh-flag="-p 2222" --command="$SECRET_CHECK_CMD" 2>/dev/null || echo SECRET_MISSING)
+    [[ "$sentinel_secret" == *SECRET_OK* ]] || missing+=("sentinel ($SENTINEL_VM)")
+
+    primary_secret=$(gcloud compute ssh "$PRIMARY_VM" --zone="$ZONE" --project="$PROJECT" \
+        --tunnel-through-iap --command="$SECRET_CHECK_CMD" 2>/dev/null || echo SECRET_MISSING)
+    [[ "$primary_secret" == *SECRET_OK* ]] || missing+=("primary ($PRIMARY_VM)")
+
+    if (( ${#missing[@]} > 0 )); then
+        echo ""
+        echo "ERROR: CONTAINARIUM_SENTINEL_AUTH_SECRET (>=${SECRET_MIN_LEN} bytes) is not provisioned on:"
+        for h in "${missing[@]}"; do echo "         - $h"; done
+        echo ""
+        echo "  Deploying a v0.19.0+ binary here would silently 401 every sentinel"
+        echo "  keysync/certsync cycle and can SSH-lock tenants for hours (#341)."
+        echo ""
+        echo "  Provision the secret first (one per cluster, same value on every host):"
+        echo "    see $RUNBOOK"
+        echo ""
+        echo "  To bypass intentionally (pre-HMAC rollback / unsecured dev box):"
+        echo "    ALLOW_MISSING_SENTINEL_SECRET=1 $0 $*"
+        exit 1
+    fi
+    echo "  OK: secret present on sentinel and primary"
+fi
+
 # 2. Upload to sentinel
 echo "==> Uploading to sentinel..."
 gcloud compute scp "$BINARY" "$SENTINEL_VM:/tmp/containarium" \
@@ -94,3 +147,8 @@ echo ""
 echo "  NOTE: If peers have --sentinel-url configured, they will auto-update"
 echo "        from the sentinel within 5 minutes. Otherwise, run the printed"
 echo "        commands with sudo on each peer."
+echo ""
+echo "  NOTE: Peer daemons also need CONTAINARIUM_SENTINEL_AUTH_SECRET set to the"
+echo "        same cluster secret (the preflight above only gates sentinel +"
+echo "        primary). Verify each peer has it before they take sentinel"
+echo "        keysync/certsync traffic — see $RUNBOOK."


### PR DESCRIPTION
Closes the remaining **§2** half of #341. (§1 "fail loudly" — per-cycle/per-request WARNING logging — shipped in #347.)

## Problem

v0.19.0+ gates the sentinel-facing daemon endpoints (`/authorized-keys`, `/certs`, `/authorized-keys/sentinel`) behind an HMAC over `CONTAINARIUM_SENTINEL_AUTH_SECRET`. A manual binary swap via `scripts/deploy-binary.sh` onto a host that lacks the secret silently 401s every sentinel keysync/certsync cycle → the sshpiper upstream map freezes → stale pointers → tenants locked out for hours before anyone finds the 401. That's the incident #341 was filed for.

The deploy script never checked for the secret. This adds the conservative gate (refuse-if-absent) chosen for §2, plus the runbook the error points to.

## Changes

**`scripts/deploy-binary.sh`** — preflight before any binary swap:
- SSHes to the sentinel and primary and verifies `/etc/containarium/env.secrets` holds a `CONTAINARIUM_SENTINEL_AUTH_SECRET` of ≥32 chars (matching the daemon's `SentinelMinSecretLen` / `>= 32` fail-closed check).
- Aborts with a clear, host-listed error pointing at the runbook if either is missing — fails fast, before touching any binary.
- `ALLOW_MISSING_SENTINEL_SECRET=1` bypasses (deliberate pre-HMAC rollback / unsecured dev box).
- Peer note reminds operators peer daemons need the same cluster secret.

**`docs/SENTINEL-AUTH-SECRET.md`** (new runbook):
- The silent-lockout failure mode, anonymized.
- Generate (`openssl rand -hex 32`, one per cluster), distribute to sentinel + every daemon via `/etc/containarium/env.secrets` (0600 root) + systemd `EnvironmentFile=-` drop-in.
- Daemons-first-then-sentinel restart order; the `< v0.19.0` upgrade path.
- Verify via the sentinel `/status` `sentinel_auth_misconfigured` flag and the daemon's `[sentinel-hmac]` WARNING log; rotation note.

## Acceptance criteria (#341)

- [x] §1 daemon + sentinel fail-loud logging (shipped #347)
- [x] Deploy script refuses to upgrade when the env is absent (this PR)
- [x] Runbook: "upgrading from < v0.19" with generate + distribute steps (this PR)

The auto-provision option was explicitly **not** taken — a deploy script that generates/rotates a live shared secret risks recreating the exact lockout on a re-run. Refuse-if-absent keeps the script from ever touching a live secret.

## Testing

- `bash -n` clean; grep regex verified against valid(64)/exact(32)/short(10)/missing-file fixtures → `OK/OK/MISSING/MISSING`, matching the daemon's ≥32 semantics.
- Empty-array expansion is bash 3.2 (macOS) safe — the only `"${arr[@]}"` expansion is guarded behind a non-empty count check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)