### PR TITLE
fix(daemon): self-heal Caddy edge after stub-Caddyfile revert (#400)

### DIFF
--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -25,6 +25,11 @@ type ProxyManager struct {
 	// HTTP-01 + TLS-ALPN-01. Configured via WithDNSChallenge /
 	// DNSChallengeFromEnv. See issue #378.
 	dnsChallenge *CaddyACMEChallenges
+	// proxyProtocolTrusted records the CIDRs passed to the last successful
+	// EnableProxyProtocol, so the self-healing reconcile (EnsureBaseConfig)
+	// can re-install the PROXY listener wrappers after the bundled Caddy
+	// reverts to its stub Caddyfile. Empty = PROXY protocol not enabled. #400.
+	proxyProtocolTrusted []string
 }
 
 // RouteProtocol represents the protocol type for a route
@@ -801,7 +806,83 @@ func (p *ProxyManager) EnableProxyProtocol(trustedCIDRs []string) error {
 	if err := p.loadConfig(config); err != nil {
 		return fmt.Errorf("load config with proxy_protocol: %w", err)
 	}
+	// Remember the trusted set so EnsureBaseConfig can re-apply the wrappers
+	// after a stub-Caddyfile revert (#400).
+	p.proxyProtocolTrusted = append(p.proxyProtocolTrusted[:0], trustedCIDRs...)
 	return nil
+}
+
+// EnsureBaseConfig re-asserts the base Caddy edge config — the http app, the
+// `srv0` server, the tls app, and (when configured) the PROXY listener
+// wrappers — rebuilding them when the bundled Caddy has reverted to its stub
+// Caddyfile (`{ admin :2019 }`).
+//
+// The bundled `*-core-caddy` boots from that stub and is configured entirely
+// over the admin API; any caddy reload/restart/crash drops the running config
+// back to the stub, which wipes the http app. The periodic route sync then
+// loops on `400 invalid traversal path` and :443 goes permanently dark with no
+// self-heal (issue #400). Calling this at the top of every sync makes the edge
+// reconcile itself: once the base is rebuilt, the normal route/L4 diff
+// repopulates HTTP routes (with TLS subjects, via AddRoute→ProvisionTLS) and
+// re-activates layer4.
+//
+// It is cheap when the config is intact (a single GET) and only issues writes
+// on a detected revert. Returns whether it rebuilt.
+func (p *ProxyManager) EnsureBaseConfig() (bool, error) {
+	intact, err := p.baseConfigIntact()
+	if err != nil {
+		return false, err
+	}
+	if intact {
+		return false, nil
+	}
+	if err := p.EnsureServerConfig(); err != nil {
+		return false, fmt.Errorf("rebuild base server config: %w", err)
+	}
+	if len(p.proxyProtocolTrusted) > 0 {
+		if err := p.EnableProxyProtocol(p.proxyProtocolTrusted); err != nil {
+			return true, fmt.Errorf("re-apply PROXY protocol after rebuild: %w", err)
+		}
+	}
+	return true, nil
+}
+
+// baseConfigIntact reports whether the Caddy http server `srv0` is present and
+// (when PROXY protocol is configured) still carries its listener wrappers. A
+// false return means Caddy has reverted to the stub Caddyfile and the base
+// config must be rebuilt. See EnsureBaseConfig (#400).
+func (p *ProxyManager) baseConfigIntact() (bool, error) {
+	url := fmt.Sprintf("%s/config/apps/http/servers/%s", p.caddyAdminURL, p.serverName)
+	resp, err := p.httpClient.Get(url)
+	if err != nil {
+		return false, fmt.Errorf("probe http server config: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusBadRequest {
+		return false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return false, fmt.Errorf("probe http server config: status %d: %s", resp.StatusCode, string(body))
+	}
+	body, _ := io.ReadAll(resp.Body)
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" || trimmed == "null" {
+		return false, nil
+	}
+	// When PROXY protocol is enabled the server must keep its listener wrappers;
+	// a rebuilt-but-bare server (no wrappers) means the wrappers were wiped too.
+	if len(p.proxyProtocolTrusted) > 0 {
+		var srv map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(trimmed), &srv); err != nil {
+			// Malformed — treat as reverted so we rebuild from a known-good base.
+			return false, nil
+		}
+		if _, ok := srv["listener_wrappers"]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // toAnySlice converts a []string into []interface{} for embedding into raw

--- a/internal/app/proxy_selfheal_test.go
+++ b/internal/app/proxy_selfheal_test.go
@@ -1,0 +1,220 @@
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// rwFakeCaddy is a fuller stand-in for the Caddy admin API than newFakeCaddy:
+// it also honours PUT on a /config/<path> (creating intermediate maps), which
+// is what EnsureServerConfig / createHTTPApp / createTLSApp use to rebuild the
+// base config. GET walks the tree; POST /load replaces it; PUT sets a subtree.
+type rwFakeCaddy struct {
+	config map[string]interface{}
+	loads  int
+	puts   int
+}
+
+func newRWFakeCaddy(initial map[string]interface{}) (*httptest.Server, *rwFakeCaddy) {
+	if initial == nil {
+		initial = map[string]interface{}{}
+	}
+	fc := &rwFakeCaddy{config: initial}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/config/", func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/config/")
+		path = strings.TrimSuffix(path, "/")
+
+		if r.Method == http.MethodPut {
+			body, _ := io.ReadAll(r.Body)
+			var val interface{}
+			if err := json.Unmarshal(body, &val); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			segs := strings.Split(path, "/")
+			node := fc.config
+			for _, p := range segs[:len(segs)-1] {
+				next, ok := node[p].(map[string]interface{})
+				if !ok {
+					next = map[string]interface{}{}
+					node[p] = next
+				}
+				node = next
+			}
+			node[segs[len(segs)-1]] = val
+			fc.puts++
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// GET
+		if path == "" {
+			_ = json.NewEncoder(w).Encode(fc.config)
+			return
+		}
+		var node interface{} = fc.config
+		for _, p := range strings.Split(path, "/") {
+			m, ok := node.(map[string]interface{})
+			if !ok {
+				http.Error(w, "null", http.StatusNotFound)
+				return
+			}
+			node = m[p]
+		}
+		_ = json.NewEncoder(w).Encode(node)
+	})
+	mux.HandleFunc("/load", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var newCfg map[string]interface{}
+		if err := json.Unmarshal(body, &newCfg); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		fc.config = newCfg
+		fc.loads++
+		w.WriteHeader(http.StatusOK)
+	})
+	return httptest.NewServer(mux), fc
+}
+
+// intactConfig is a config tree with the http app + srv0 already present.
+func intactConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"apps": map[string]interface{}{
+			"http": map[string]interface{}{
+				"servers": map[string]interface{}{
+					DefaultCaddyServerName: map[string]interface{}{
+						"listen": []interface{}{":80", ":443"},
+						"routes": []interface{}{},
+					},
+				},
+			},
+			"tls": map[string]interface{}{"automation": map[string]interface{}{}},
+		},
+	}
+}
+
+// stubConfig mirrors the bundled Caddy's stub Caddyfile state: admin only, no
+// apps at all.
+func stubConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"admin": map[string]interface{}{"listen": ":2019"},
+	}
+}
+
+func TestEnsureBaseConfig_IntactIsNoOp(t *testing.T) {
+	srv, fc := newRWFakeCaddy(intactConfig())
+	defer srv.Close()
+	pm := NewProxyManager(srv.URL, "containarium.dev")
+
+	rebuilt, err := pm.EnsureBaseConfig()
+	if err != nil {
+		t.Fatalf("EnsureBaseConfig: %v", err)
+	}
+	if rebuilt {
+		t.Error("expected rebuilt=false when config is intact")
+	}
+	if fc.loads != 0 || fc.puts != 0 {
+		t.Errorf("expected no writes when intact, got loads=%d puts=%d", fc.loads, fc.puts)
+	}
+}
+
+func TestEnsureBaseConfig_RebuildsFromStub(t *testing.T) {
+	srv, fc := newRWFakeCaddy(stubConfig())
+	defer srv.Close()
+	pm := NewProxyManager(srv.URL, "containarium.dev")
+
+	rebuilt, err := pm.EnsureBaseConfig()
+	if err != nil {
+		t.Fatalf("EnsureBaseConfig: %v", err)
+	}
+	if !rebuilt {
+		t.Fatal("expected rebuilt=true when config reverted to stub")
+	}
+	if fc.puts == 0 {
+		t.Error("expected the rebuild to PUT the http app, but no PUTs happened")
+	}
+
+	// The srv0 server must now exist again.
+	srvNode := getMapField(getMapField(getMapField(getMapField(fc.config, "apps"), "http"), "servers"), DefaultCaddyServerName)
+	if srvNode == nil {
+		t.Fatal("expected apps.http.servers.srv0 to be present after rebuild")
+	}
+
+	// A second call is now a no-op (idempotent).
+	rebuilt, err = pm.EnsureBaseConfig()
+	if err != nil {
+		t.Fatalf("EnsureBaseConfig (2nd): %v", err)
+	}
+	if rebuilt {
+		t.Error("expected rebuilt=false on the second call (already healed)")
+	}
+}
+
+func TestEnsureBaseConfig_ReappliesProxyProtocol(t *testing.T) {
+	srv, fc := newRWFakeCaddy(intactConfig())
+	defer srv.Close()
+	pm := NewProxyManager(srv.URL, "containarium.dev")
+
+	// Enable PROXY protocol against the intact config — this records the
+	// trusted set on the manager and installs listener_wrappers on srv0.
+	if err := pm.EnableProxyProtocol([]string{"127.0.0.0/8"}); err != nil {
+		t.Fatalf("EnableProxyProtocol: %v", err)
+	}
+	srv0 := getMapField(getMapField(getMapField(getMapField(fc.config, "apps"), "http"), "servers"), DefaultCaddyServerName)
+	if _, ok := srv0["listener_wrappers"]; !ok {
+		t.Fatal("precondition: listener_wrappers should be set after EnableProxyProtocol")
+	}
+
+	// Simulate a Caddy reload reverting to the stub.
+	fc.config = stubConfig()
+
+	rebuilt, err := pm.EnsureBaseConfig()
+	if err != nil {
+		t.Fatalf("EnsureBaseConfig: %v", err)
+	}
+	if !rebuilt {
+		t.Fatal("expected rebuilt=true after stub revert")
+	}
+
+	// srv0 must be back AND carry the PROXY listener wrappers again.
+	srv0 = getMapField(getMapField(getMapField(getMapField(fc.config, "apps"), "http"), "servers"), DefaultCaddyServerName)
+	if srv0 == nil {
+		t.Fatal("expected srv0 to be rebuilt")
+	}
+	if _, ok := srv0["listener_wrappers"]; !ok {
+		t.Error("expected listener_wrappers to be re-applied after rebuild")
+	}
+}
+
+func TestBaseConfigIntact_MissingWrappersWhenProxyEnabled(t *testing.T) {
+	// srv0 exists but has no listener_wrappers; with PROXY protocol expected,
+	// that's a partial revert and must be treated as not-intact.
+	srv, _ := newRWFakeCaddy(intactConfig())
+	defer srv.Close()
+	pm := NewProxyManager(srv.URL, "containarium.dev")
+	pm.proxyProtocolTrusted = []string{"127.0.0.0/8"}
+
+	intact, err := pm.baseConfigIntact()
+	if err != nil {
+		t.Fatalf("baseConfigIntact: %v", err)
+	}
+	if intact {
+		t.Error("expected intact=false when listener_wrappers missing and PROXY enabled")
+	}
+
+	// Without PROXY protocol configured, the bare server is fine.
+	pm.proxyProtocolTrusted = nil
+	intact, err = pm.baseConfigIntact()
+	if err != nil {
+		t.Fatalf("baseConfigIntact (no proxy): %v", err)
+	}
+	if !intact {
+		t.Error("expected intact=true for a present server when PROXY not configured")
+	}
+}

--- a/internal/app/route_sync.go
+++ b/internal/app/route_sync.go
@@ -25,10 +25,10 @@ type RouteSyncJob struct {
 	wakeTracker    WakeTracker     // optional; when set, sleeping containers route to daemon's wake handler
 	interval       time.Duration
 
-	mu       sync.Mutex
-	running  bool
-	stopCh   chan struct{}
-	doneCh   chan struct{}
+	mu      sync.Mutex
+	running bool
+	stopCh  chan struct{}
+	doneCh  chan struct{}
 }
 
 // NewRouteSyncJob creates a new route sync job
@@ -138,6 +138,19 @@ func (j *RouteSyncJob) run(ctx context.Context) {
 
 // sync performs the actual synchronization from PostgreSQL to Caddy
 func (j *RouteSyncJob) sync(ctx context.Context) error {
+	// Self-heal the base Caddy config first. The bundled Caddy boots from a stub
+	// Caddyfile and is configured entirely over the admin API; any caddy
+	// reload/restart/crash reverts the running config to that stub, wiping the
+	// http app. Without this, the route diff below would loop on
+	// "400 invalid traversal path" and :443 would stay dark (issue #400).
+	// Rebuilding the base lets the diff repopulate HTTP routes (+ TLS subjects)
+	// and re-activate layer4 on this same tick. Cheap (one GET) when intact.
+	if rebuilt, err := j.proxyManager.EnsureBaseConfig(); err != nil {
+		log.Printf("[RouteSyncJob] Base Caddy config reconcile failed: %v", err)
+	} else if rebuilt {
+		log.Printf("[RouteSyncJob] Caddy reverted to stub config — rebuilt base edge config; routes/TLS/L4 will be repopulated this sync (#400)")
+	}
+
 	// Get routes from PostgreSQL (source of truth)
 	dbRoutes, err := j.routeStore.List(ctx, true) // activeOnly = true
 	if err != nil {


### PR DESCRIPTION
Addresses the core of #400 (the titular bug: 400-loop → permanent dead `:443`, restart only partially recovers).

## Problem

The bundled Caddy (`*-core-caddy`) boots from a stub Caddyfile (`{ admin :2019 }`) and is configured **entirely over the admin API**. Any caddy reload/restart/crash reverts the running config to that stub, wiping the `http` app. The periodic route sync then loops on `400 "invalid traversal path"` against the missing config tree, and the public `:443` edge goes **permanently dark** — silently, because the ACME cert is still on disk. A daemon restart only *partially* recovered: infra init re-added the host to TLS automation subjects, but **not** the `layer4` `:443` servers or the HTTP `reverse_proxy` route.

## Fix — make the edge reconcile itself

- **`ProxyManager.EnsureBaseConfig()`** detects the stub revert — `srv0` missing, or (when PROXY protocol is configured) its `listener_wrappers` missing — and rebuilds the base `http` app + server + `tls` app via the existing idempotent `EnsureServerConfig()`, then re-applies the PROXY listener wrappers.
- **`RouteSyncJob.sync()`** calls it first on every tick. Once the base is back, the **existing** route/L4 diff repopulates HTTP routes (with TLS subjects, since `AddRoute → ProvisionTLS`) and re-activates `layer4` (`ActivateL4`, which now finds the http app present) — all on the same tick.
- Cheap when intact (a single GET); issues writes only on a detected revert.
- `EnableProxyProtocol` now records its trusted CIDRs so the rebuild can re-install the wrappers.

**Net:** the edge heals on the next ~5s sync after *any* Caddy reload (no restart needed), and a daemon restart now *fully* recovers.

## Tests

New `proxy_selfheal_test.go` with a read/write fake Caddy admin API (GET tree / PUT subtree / POST `/load`):
- intact config → no-op, zero writes
- revert-to-stub → rebuild, `srv0` present afterward, idempotent on the second call
- PROXY wrappers re-applied after a revert
- partial revert (server present, wrappers gone, PROXY enabled) detected as not-intact

`go build ./...` clean; `go test ./internal/app/` green.

## Deliberately out of scope (follow-ups from the issue comment)

Both are separate subsystems that only matter in the narrower "core-caddy recreated with a **new IP**" recovery path, and aren't unit-testable from here:
1. **Stale DNAT** — when core-caddy is recreated with a new IP, the old `:80/:443` DNAT rule isn't removed; the stale rule matches first. Needs `pkg/core/network/portforward.go` to reconcile the nat rules to exactly the current IP.
2. **Re-detect after create** — if the daemon (re)starts while core-caddy is absent, it creates the container but doesn't re-wire the admin client, so Caddy features stay off until another restart. Needs a re-detect after provisioning in `internal/cmd/daemon.go` / `core_services.go`.

I can pick these up in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)