### PR TITLE
fix(network): clear stale Caddy DNAT rules on caddy-IP change (#400 follow-up)

### DIFF
--- a/pkg/core/network/portforward.go
+++ b/pkg/core/network/portforward.go
@@ -272,6 +272,9 @@ func (pf *PortForwarder) reconcileStaleRules() {
 		return
 	}
 	for _, args := range staleCaddyNATRules(string(out), pf.caddyIP) {
+		// #nosec G204 -- args are iptables rule specs read back from this host's
+		// own `iptables -t nat -S` output and re-issued verbatim as -D deletes;
+		// not external/user input.
 		if e := exec.Command("iptables", args...).Run(); e != nil {
 			log.Printf("  Warning: failed to delete stale Caddy rule (%v): %v", args, e)
 		} else {

--- a/pkg/core/network/portforward.go
+++ b/pkg/core/network/portforward.go
@@ -78,6 +78,14 @@ func (pf *PortForwarder) SetupPortForwarding() error {
 		log.Printf("  Warning: failed to set route_localnet=1: %v (tunneled-primary loopback path may not work)", err)
 	}
 
+	// Clear Caddy DNAT/MASQUERADE rules that point at a *different* IP than the
+	// current one. When core-caddy is recreated it comes back with a new
+	// container IP; the per-rule existence checks below would then ADD rules for
+	// the new IP while leaving the old ones in place. The stale rule sorts first
+	// in the chain and matches, so all :443 traffic is DNAT'd to a container
+	// that no longer exists and the TLS handshake returns nothing (#400).
+	pf.reconcileStaleRules()
+
 	// Each rule is added independently with its own existence check.
 	// An older deploy may have PREROUTING but not OUTPUT — we want to
 	// add the missing one without duplicating what's already there.
@@ -250,6 +258,105 @@ func (pf *PortForwarder) removeMasqueradeRule() {
 	cmd := exec.Command("iptables", "-t", "nat", "-D", "POSTROUTING",
 		"-d", pf.caddyIP, "-j", "MASQUERADE")
 	cmd.Run() // Ignore errors - rule might not exist
+}
+
+// reconcileStaleRules deletes Caddy port-forward DNAT/MASQUERADE rules whose
+// target IP is not pf.caddyIP. Best-effort: enumerates the nat table with
+// `iptables -t nat -S`, computes the stale deletions, and runs each. Failures
+// are logged, not fatal — the subsequent ensure*Rule calls still install the
+// current rules. See SetupPortForwarding / issue #400.
+func (pf *PortForwarder) reconcileStaleRules() {
+	out, err := exec.Command("iptables", "-t", "nat", "-S").CombinedOutput()
+	if err != nil {
+		log.Printf("  Warning: could not enumerate nat rules to clear stale Caddy targets: %v", err)
+		return
+	}
+	for _, args := range staleCaddyNATRules(string(out), pf.caddyIP) {
+		if e := exec.Command("iptables", args...).Run(); e != nil {
+			log.Printf("  Warning: failed to delete stale Caddy rule (%v): %v", args, e)
+		} else {
+			log.Printf("  Cleared stale Caddy port-forward rule pointing away from %s: %v", pf.caddyIP, args)
+		}
+	}
+}
+
+// staleCaddyNATRules scans `iptables -t nat -S` output and returns the argument
+// lists (ready to pass to `iptables`, with the leading `-A` turned into `-D`)
+// for Caddy port-forward rules that point at an IP other than currentIP:
+//
+//   - PREROUTING/OUTPUT DNAT rules whose --dport is 80 or 443 (the dport gate
+//     keeps passthrough-route DNATs, which use other ports, untouched), and
+//   - the POSTROUTING MASQUERADE rule of the form `-d <ip> -j MASQUERADE`
+//     with no -p/--dport (passthrough MASQUERADE rules carry -p/--dport, so
+//     they're left alone).
+//
+// Pure/string-only so it can be unit-tested without touching the host firewall.
+func staleCaddyNATRules(saveOutput, currentIP string) [][]string {
+	var dels [][]string
+	for _, raw := range strings.Split(saveOutput, "\n") {
+		line := strings.TrimSpace(raw)
+		if !strings.HasPrefix(line, "-A ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		chain := fields[1]
+
+		var toIP, dport, dstIP string
+		isMasq := false
+		for i, f := range fields {
+			switch f {
+			case "--to-destination":
+				if i+1 < len(fields) {
+					toIP = hostOnly(fields[i+1])
+				}
+			case "--dport":
+				if i+1 < len(fields) {
+					dport = fields[i+1]
+				}
+			case "-d":
+				if i+1 < len(fields) {
+					dstIP = stripCIDR(fields[i+1])
+				}
+			case "MASQUERADE":
+				isMasq = true
+			}
+		}
+
+		stale := false
+		switch {
+		case (chain == "PREROUTING" || chain == "OUTPUT") && toIP != "" && (dport == "80" || dport == "443"):
+			stale = toIP != currentIP
+		case chain == "POSTROUTING" && isMasq && dport == "":
+			stale = dstIP != "" && dstIP != currentIP
+		}
+		if !stale {
+			continue
+		}
+
+		// Re-issue the exact rule spec as a delete: -t nat -D <chain> <rest>.
+		del := append([]string{"-t", "nat", "-D"}, fields[1:]...)
+		dels = append(dels, del)
+	}
+	return dels
+}
+
+// stripCIDR drops a trailing /prefix from an address ("10.0.3.5/32" → "10.0.3.5").
+func stripCIDR(s string) string {
+	if i := strings.IndexByte(s, '/'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// hostOnly drops a trailing :port ("10.0.3.5:443" → "10.0.3.5").
+func hostOnly(s string) string {
+	if i := strings.LastIndexByte(s, ':'); i >= 0 {
+		return s[:i]
+	}
+	return s
 }
 
 // CheckIPTablesAvailable checks if iptables is available on the system

--- a/pkg/core/network/portforward_test.go
+++ b/pkg/core/network/portforward_test.go
@@ -1,0 +1,62 @@
+package network
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStaleCaddyNATRules(t *testing.T) {
+	// A representative `iptables -t nat -S` dump: the current Caddy IP is
+	// 10.0.3.50; 10.0.3.111 is a stale (recreated-away) Caddy IP; and there's
+	// a passthrough route (dport 50051) that must never be touched.
+	save := `-P PREROUTING ACCEPT
+-P POSTROUTING ACCEPT
+-A PREROUTING -p tcp -m tcp ! -s 10.0.3.0/24 --dport 80 -j DNAT --to-destination 10.0.3.111:80
+-A PREROUTING -p tcp -m tcp ! -s 10.0.3.0/24 --dport 443 -j DNAT --to-destination 10.0.3.111:443
+-A PREROUTING -p tcp -m tcp ! -s 10.0.3.0/24 --dport 80 -j DNAT --to-destination 10.0.3.50:80
+-A PREROUTING -p tcp -m tcp ! -s 10.0.3.0/24 --dport 443 -j DNAT --to-destination 10.0.3.50:443
+-A PREROUTING -p tcp -m tcp ! -s 10.0.3.0/24 --dport 50051 -j DNAT --to-destination 10.0.3.150:50051
+-A OUTPUT -d 127.0.0.0/8 -p tcp -m tcp --dport 443 -j DNAT --to-destination 10.0.3.111:443
+-A OUTPUT -d 127.0.0.0/8 -p tcp -m tcp --dport 443 -j DNAT --to-destination 10.0.3.50:443
+-A POSTROUTING -d 10.0.3.111/32 -j MASQUERADE
+-A POSTROUTING -d 10.0.3.50/32 -j MASQUERADE
+-A POSTROUTING -p tcp -d 10.0.3.150/32 --dport 50051 -j MASQUERADE`
+
+	got := staleCaddyNATRules(save, "10.0.3.50")
+
+	want := [][]string{
+		{"-t", "nat", "-D", "PREROUTING", "-p", "tcp", "-m", "tcp", "!", "-s", "10.0.3.0/24", "--dport", "80", "-j", "DNAT", "--to-destination", "10.0.3.111:80"},
+		{"-t", "nat", "-D", "PREROUTING", "-p", "tcp", "-m", "tcp", "!", "-s", "10.0.3.0/24", "--dport", "443", "-j", "DNAT", "--to-destination", "10.0.3.111:443"},
+		{"-t", "nat", "-D", "OUTPUT", "-d", "127.0.0.0/8", "-p", "tcp", "-m", "tcp", "--dport", "443", "-j", "DNAT", "--to-destination", "10.0.3.111:443"},
+		{"-t", "nat", "-D", "POSTROUTING", "-d", "10.0.3.111/32", "-j", "MASQUERADE"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("staleCaddyNATRules mismatch.\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestStaleCaddyNATRules_AllCurrentNoOp(t *testing.T) {
+	// Every Caddy rule already points at the current IP — nothing to delete.
+	save := `-A PREROUTING -p tcp -m tcp ! -s 10.0.3.0/24 --dport 80 -j DNAT --to-destination 10.0.3.50:80
+-A PREROUTING -p tcp -m tcp ! -s 10.0.3.0/24 --dport 443 -j DNAT --to-destination 10.0.3.50:443
+-A OUTPUT -d 127.0.0.0/8 -p tcp -m tcp --dport 443 -j DNAT --to-destination 10.0.3.50:443
+-A POSTROUTING -d 10.0.3.50/32 -j MASQUERADE
+-A PREROUTING -p tcp -m tcp ! -s 10.0.3.0/24 --dport 50051 -j DNAT --to-destination 10.0.3.150:50051`
+
+	if got := staleCaddyNATRules(save, "10.0.3.50"); len(got) != 0 {
+		t.Errorf("expected no stale rules, got %v", got)
+	}
+}
+
+func TestStaleCaddyNATRules_LeavesPassthroughAlone(t *testing.T) {
+	// A passthrough DNAT + its MASQUERADE on a non-Caddy IP must NOT be flagged,
+	// even though their target IP differs from the Caddy IP, because their dport
+	// isn't 80/443 (DNAT) and the masq carries -p/--dport.
+	save := `-A PREROUTING -p tcp -m tcp ! -s 10.0.3.0/24 --dport 8080 -j DNAT --to-destination 10.0.3.200:8080
+-A POSTROUTING -p tcp -d 10.0.3.200/32 --dport 8080 -j MASQUERADE`
+
+	if got := staleCaddyNATRules(save, "10.0.3.50"); len(got) != 0 {
+		t.Errorf("expected passthrough rules to be left alone, got %v", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #400 (#405 fixed the self-heal of Caddy's *config*; this fixes the *DNAT* facet from the issue comment).

## Problem

When `core-caddy` is recreated it comes back with a **new container IP**. `PortForwarder.SetupPortForwarding` checks for each rule individually and ADDs `:80/:443` DNAT (+ MASQUERADE) rules for the new IP — but never removes the rules pointing at the **old** IP. The stale rule sorts first in the nat chain and matches, so all `:443` traffic is DNAT'd to a container that no longer exists and the TLS handshake returns nothing. That's the recreate-recovery gap called out in the #400 comment ("the daemon should delete the prior DNAT target when the Caddy IP changes").

## Fix

`SetupPortForwarding` now reconciles before installing the current rules:
1. enumerate `iptables -t nat -S`,
2. delete any Caddy port-forward rule whose target IP ≠ the current caddyIP:
   - `PREROUTING`/`OUTPUT` DNAT with `--dport 80|443` (the dport gate leaves passthrough-route DNATs alone), and
   - the `POSTROUTING -d <ip> -j MASQUERADE` rule with no `-p`/`--dport` (passthrough MASQUERADEs carry those, so they're untouched),
3. then install the current-IP rules as before.

Because the reconcile lives inside `SetupPortForwarding`, it covers **every** caller — the startup re-detect path (`cmd/daemon.go`) and the core-services bring-up path (`dual_server.go`) — so a recreate-with-new-IP now recovers without manual iptables surgery.

The selection logic is factored into a pure `staleCaddyNATRules(saveOutput, currentIP)` so it's unit-tested without touching the host firewall.

## Tests

New `portforward_test.go`:
- mixed dump (stale 10.0.3.111 + current 10.0.3.50 + a passthrough on :50051) → only the four stale Caddy rules selected for deletion, as `-D` arg lists
- all-current → no-op
- passthrough DNAT/MASQUERADE on a non-Caddy IP → left alone

`go build ./...` clean; `go test ./pkg/core/network/` green.

## On the issue comment's other facet (re-detect/re-wire after create)

Already handled on current `main`: `EnsureCaddy` returns the admin URL on both the existing and freshly-created paths, and `dual_server.go:370-401` sets `caddyAdminURL` + port forwarding + the DNS override **before** the `ProxyManager` is constructed — see the explanatory comment at `dual_server.go:378-383`. The v0.22.0 behavior described in the comment was fixed since, so no code change is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)