### PR TITLE
feat(telemetry-py): export traces + OTLP gRPC transport selection (#386)

### DIFF
--- a/distros/py/pyproject.toml
+++ b/distros/py/pyproject.toml
@@ -54,6 +54,11 @@ asyncpg = ["opentelemetry-instrumentation-asyncpg>=0.48b0"]
 psycopg = ["opentelemetry-instrumentation-psycopg>=0.48b0"]
 redis = ["opentelemetry-instrumentation-redis>=0.48b0"]
 logging = ["opentelemetry-instrumentation-logging>=0.48b0"]
+# `grpc` adds the OTLP gRPC exporter, for collectors that listen on OTLP
+# gRPC :4317 instead of HTTP :4318. Selected at runtime via
+# OTEL_EXPORTER_OTLP_PROTOCOL=grpc (#386). The HTTP exporter is a core
+# dependency, so the default transport needs no extra.
+grpc = ["opentelemetry-exporter-otlp-proto-grpc>=1.27.0"]
 # `all` is the convenience bundle — recommended default for greenfield
 # apps. Tenants with image-size sensitivity pin individual extras.
 all = [
@@ -74,6 +79,8 @@ dev = [
     # Used by integration tests for the instrumentor auto-discovery path.
     "flask>=2.0",
     "opentelemetry-instrumentation-flask>=0.48b0",
+    # So the test suite can exercise the OTLP gRPC exporter path (#386).
+    "opentelemetry-exporter-otlp-proto-grpc>=1.27.0",
 ]
 
 # `containarium-instrument` is always installed (D8) — it's a console

--- a/distros/py/src/containarium_telemetry/_init.py
+++ b/distros/py/src/containarium_telemetry/_init.py
@@ -3,9 +3,16 @@
 Contract (per docs/TELEMETRY-DISTRO-DESIGN.md):
 - Always fail-open. Missing endpoint → WARN + no-op handle (D10).
 - Idempotent. Repeat calls log at DEBUG and return the existing handle.
-- The OTLPMetricExporter reads OTEL_EXPORTER_OTLP_{ENDPOINT,HEADERS,
+- The OTLP exporters read OTEL_EXPORTER_OTLP_{ENDPOINT,HEADERS,
   PROTOCOL} from env directly, so we do not pass them as constructor
   args — that would shadow user overrides we're meant to honor.
+
+Transport selection (#386): OTEL_EXPORTER_OTLP_PROTOCOL picks the
+exporter. `grpc` uses the gRPC exporters (OTLP :4317); anything else
+(default `http/protobuf`) uses the HTTP exporters (OTLP :4318). The
+gRPC exporter package is an optional `grpc` extra and is imported
+lazily, so HTTP-only installs are unaffected and a missing gRPC
+package fails open rather than crashing the app at import time.
 """
 from __future__ import annotations
 
@@ -14,12 +21,10 @@ import os
 from typing import Dict, Optional
 
 from opentelemetry import metrics, trace
-from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
-    OTLPMetricExporter,
-)
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-from opentelemetry.trace import NoOpTracerProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from ._config import DistroConfig
 from ._distro import AUTO_INSTRUMENT_ENV_KEY
@@ -33,22 +38,40 @@ _shutdown_handle: Optional["Shutdown"] = None
 
 
 class Shutdown:
-    """Idempotent shutdown handle returned by init()."""
+    """Idempotent shutdown handle returned by init().
 
-    def __init__(self, provider: Optional[MeterProvider]):
+    Holds whatever providers init() actually installed — the meter
+    provider, and (when traces are exported) the tracer provider — and
+    shuts both down. Either may be None (e.g. the fail-open no-op handle,
+    or when the app already had its own tracer provider that we left
+    untouched).
+    """
+
+    def __init__(
+        self,
+        provider: Optional[MeterProvider],
+        tracer_provider: Optional[TracerProvider] = None,
+    ):
         self._provider = provider
+        self._tracer_provider = tracer_provider
         self._done = False
 
     def shutdown(self, timeout_s: float = 5.0) -> None:
         if self._done:
             return
         self._done = True
-        if self._provider is None:
-            return
-        try:
-            self._provider.shutdown(timeout_millis=int(timeout_s * 1000))
-        except Exception as e:  # noqa: BLE001 — never raise from shutdown
-            logger.warning("containarium_telemetry shutdown failed: %s", e)
+        if self._provider is not None:
+            try:
+                self._provider.shutdown(timeout_millis=int(timeout_s * 1000))
+            except Exception as e:  # noqa: BLE001 — never raise from shutdown
+                logger.warning("containarium_telemetry meter shutdown failed: %s", e)
+        if self._tracer_provider is not None:
+            try:
+                # TracerProvider.shutdown() flushes the BatchSpanProcessor
+                # and stops its worker thread. It takes no timeout arg.
+                self._tracer_provider.shutdown()
+            except Exception as e:  # noqa: BLE001 — never raise from shutdown
+                logger.warning("containarium_telemetry tracer shutdown failed: %s", e)
 
     def __call__(self, timeout_s: float = 5.0) -> None:
         # Lets callers use the handle directly as `handle()` instead of
@@ -102,26 +125,37 @@ def init(
         _initialized = True
         return _shutdown_handle
 
+    protocol = _otlp_protocol(config)
+
     try:
         resource = build_resource(config, extra_attrs=extra_attrs)
-        exporter = OTLPMetricExporter()
+
+        # Metrics pipeline.
         reader = PeriodicExportingMetricReader(
-            exporter,
+            _make_metric_exporter(protocol),
             export_interval_millis=metric_export_interval_ms,
             export_timeout_millis=metric_export_timeout_ms,
         )
         provider = MeterProvider(resource=resource, metric_readers=[reader])
         metrics.set_meter_provider(provider)
+
+        # Traces pipeline (#386). Only install our TracerProvider when no
+        # real one is set yet (OTel's default is a ProxyTracerProvider) —
+        # don't clobber an app that wired its own. We attach the
+        # BatchSpanProcessor only when we're the ones setting it, so we
+        # never leak an exporter/worker thread onto an unused provider.
+        tracer_provider: Optional[TracerProvider] = None
+        if type(trace.get_tracer_provider()).__name__ == "ProxyTracerProvider":
+            tracer_provider = TracerProvider(resource=resource)
+            tracer_provider.add_span_processor(
+                BatchSpanProcessor(_make_span_exporter(protocol))
+            )
+            trace.set_tracer_provider(tracer_provider)
     except Exception as e:  # noqa: BLE001 — fail-open per contract
         logger.warning("containarium_telemetry init failed: %s", e)
         _shutdown_handle = Shutdown(None)
         _initialized = True
         return _shutdown_handle
-
-    # No-op tracer provider so apps that call trace.get_tracer(...)
-    # don't crash — v1 collector accepts metrics only (D4). The v2
-    # traces pipeline will replace this with a real provider.
-    _set_noop_tracer_provider_if_unset()
 
     # Skip instrumentation registration when invoked from the
     # auto-instrument runtime (containarium-instrument /
@@ -130,23 +164,54 @@ def init(
     if os.environ.get(AUTO_INSTRUMENT_ENV_KEY) != "1":
         register_instrumentations(instrumentations)
 
-    _shutdown_handle = Shutdown(provider)
+    _shutdown_handle = Shutdown(provider, tracer_provider)
     _initialized = True
     return _shutdown_handle
 
 
-def _set_noop_tracer_provider_if_unset() -> None:
-    """Install NoOpTracerProvider only if no real one is configured.
+def _otlp_protocol(config: DistroConfig) -> str:
+    """Normalize OTEL_EXPORTER_OTLP_PROTOCOL.
 
-    OTel's default `ProxyTracerProvider` already returns no-op spans
-    when nothing has been set, so this is mostly belt-and-braces — but
-    it makes the v1→v2 transition cleaner (one call to flip).
+    Per the OTel spec the value is one of `grpc`, `http/protobuf`, or
+    `http/json`; the default (matching the SDK and the distro's prior
+    behavior) is `http/protobuf`. Only `grpc` selects the gRPC exporter;
+    everything else maps to HTTP.
     """
-    current = trace.get_tracer_provider()
-    # Only stamp if nothing real has been installed yet. Don't clobber
-    # an app that already wired its own tracer.
-    if type(current).__name__ == "ProxyTracerProvider":
-        trace.set_tracer_provider(NoOpTracerProvider())
+    return (config.protocol or "http/protobuf").strip().lower()
+
+
+def _make_metric_exporter(protocol: str):
+    """Build the OTLP metric exporter for the selected transport.
+
+    gRPC is imported lazily so the optional `grpc` extra isn't required
+    for the default HTTP path.
+    """
+    if protocol == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+            OTLPMetricExporter,
+        )
+
+        return OTLPMetricExporter()
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+        OTLPMetricExporter,
+    )
+
+    return OTLPMetricExporter()
+
+
+def _make_span_exporter(protocol: str):
+    """Build the OTLP span exporter for the selected transport."""
+    if protocol == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+
+        return OTLPSpanExporter()
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+        OTLPSpanExporter,
+    )
+
+    return OTLPSpanExporter()
 
 
 def _reset_for_tests() -> None:

--- a/distros/py/tests/test_init_traces.py
+++ b/distros/py/tests/test_init_traces.py
@@ -1,0 +1,88 @@
+"""Tests for the traces pipeline + OTLP transport selection (#386)."""
+import os
+from unittest import mock
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+
+from containarium_telemetry import init
+from containarium_telemetry._config import DistroConfig
+from containarium_telemetry._init import (
+    _make_metric_exporter,
+    _make_span_exporter,
+    _otlp_protocol,
+    _reset_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _cfg(protocol):
+    return DistroConfig(
+        endpoint="http://127.0.0.1:4318",
+        service_name=None,
+        resource_attributes=None,
+        headers=None,
+        protocol=protocol,
+        container_id=None,
+        backend_id=None,
+        tenant_id=None,
+        service_version=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, "http/protobuf"),   # default — unchanged behavior
+        ("grpc", "grpc"),
+        ("GRPC", "grpc"),          # case-insensitive
+        ("  grpc  ", "grpc"),      # trimmed
+        ("http/protobuf", "http/protobuf"),
+    ],
+)
+def test_otlp_protocol_normalization(raw, expected):
+    assert _otlp_protocol(_cfg(raw)) == expected
+
+
+def test_metric_exporter_transport_selection():
+    assert "proto.http" in type(_make_metric_exporter("http/protobuf")).__module__
+    assert "proto.grpc" in type(_make_metric_exporter("grpc")).__module__
+
+
+def test_span_exporter_transport_selection():
+    assert "proto.http" in type(_make_span_exporter("http/protobuf")).__module__
+    assert "proto.grpc" in type(_make_span_exporter("grpc")).__module__
+
+
+def test_init_installs_real_tracer_provider():
+    # Before #386 init() installed a NoOpTracerProvider and silently
+    # dropped spans; now it installs a real SDK TracerProvider so spans
+    # created via trace.get_tracer(...) are actually exported.
+    env = {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:4318"}
+    with mock.patch.dict(os.environ, env, clear=True):
+        handle = init(instrumentations="off")
+    assert isinstance(trace.get_tracer_provider(), SDKTracerProvider)
+    handle.shutdown(timeout_s=1.0)
+
+
+def test_init_grpc_protocol_constructs_both_exporters(caplog):
+    # With grpc selected and the gRPC exporter installed (dev extra),
+    # init() builds both the metric and span pipelines without falling
+    # open — no "init failed" warning, and a meter provider is wired.
+    env = {
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:4317",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        with caplog.at_level("WARNING", logger="containarium_telemetry"):
+            handle = init(instrumentations="off")
+    assert not any("init failed" in r.message for r in caplog.records)
+    assert handle._provider is not None  # meter provider wired
+    handle.shutdown(timeout_s=1.0)


### PR DESCRIPTION
Fixes #386.

## Problem

`containarium-telemetry` was **metrics-only and HTTP-only**:
- `init()` installed a `NoOpTracerProvider`, so spans created via `trace.get_tracer(...)` were silently dropped.
- the metric exporter was always the `http/protobuf` one, with no way to reach a collector on OTLP **gRPC :4317**.

## Change

- **Traces** — install a real SDK `TracerProvider` + `BatchSpanProcessor` with an OTLP span exporter, so app spans are actually exported. Installed only when no real provider is set yet (OTel default is a `ProxyTracerProvider`) so we don't clobber an app that wired its own; the `Shutdown` handle now flushes **both** the meter and tracer providers.
- **Transport** — `OTEL_EXPORTER_OTLP_PROTOCOL` selects the exporter for both signals: `grpc` → the gRPC exporters (:4317), anything else → HTTP (:4318, the **unchanged default**). The gRPC exporters are imported **lazily** inside `_make_metric_exporter` / `_make_span_exporter`, so HTTP-only installs don't need the package and a missing gRPC package **fails open** (per the distro's contract) instead of crashing at import.
- **Packaging** — new `grpc` extra pulls in `opentelemetry-exporter-otlp-proto-grpc`; added to `dev` so the test suite can exercise the gRPC path.

## Acceptance criteria

- ✅ `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` → `init()` exports both traces and metrics over gRPC.
- ✅ Default (`http/protobuf`) behavior unchanged.
- ✅ `grpc` extra pulls in `opentelemetry-exporter-otlp-proto-grpc`.
- ✅ Spans via `trace.get_tracer(...)` are exported (no more `NoOpTracerProvider`).

## Tests

New `tests/test_init_traces.py`: protocol normalization (default/case/trim), per-signal exporter transport selection (http vs grpc by module path), real `TracerProvider` installed (not NoOp), and grpc-init builds both pipelines without failing open. **Full suite: 47 passed** (38 existing + 9 new) in a fresh venv with `.[dev]`.

## Note on versioning

The distro `version` tracks the daemon and is bumped in a separate release chore (cf. `chore(distros): bump to 0.21.0 to track containarium daemon`), and there's some published-vs-repo drift (repo at 0.21.0, issue references a published 0.22.0). I left `version` untouched here to avoid a wrong choice — bump as part of the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)