### PR TITLE
fix(tf): version-aware, downgrade-safe daemon binary on spot VM (#385)

### DIFF
--- a/terraform/modules/containarium/README.md
+++ b/terraform/modules/containarium/README.md
@@ -75,3 +75,44 @@ omitting them will not error `plan`. Two need a closer read:
   requires Terraform >= 1.2.)
 
 [#341]: https://github.com/FootprintAI/Containarium/issues/341
+
+## Upgrading the daemon (`containarium_version`)
+
+The startup script reconciles the installed binary to `containarium_version`
+on **every boot**: it compares `containarium version` against the requested
+value (substring match) and only re-downloads + `systemctl restart
+containarium` when they differ. So bumping the version *does* upgrade the
+daemon — with two caveats that bit a prod sentinel-HA deployment ([#385]):
+
+- **A metadata-only `terraform apply` does not restart the instance.** The new
+  `startup-script` lands in instance metadata but only runs on the next boot.
+  To upgrade an existing VM either reboot it, let a preemption-recovery cycle
+  it, or force a replacement:
+
+  ```sh
+  # workhorse (spot VM); use ...sentinel[0] for the sentinel
+  terraform apply -replace='module.containarium.google_compute_instance.jump_server_spot[0]'
+  ```
+
+- **Sentinel-HA recovery can't silently downgrade anymore.** A recovered
+  workhorse pulls from the sentinel's `:8888` binary server first, but now
+  **declines** a sentinel-served binary whose version doesn't match
+  `containarium_version`, falling back to `containarium_binary_url` (the
+  authoritative source for a pinned version). Still, **upgrade the sentinel
+  first** so its `:8888` server hands out the matching version and the
+  workhorse can take the fast same-version path on recovery.
+
+  > The sentinel's own binary is still existence-aware on its boot path;
+  > applying the same version-aware reconcile to `startup-sentinel.sh` is a
+  > tracked follow-up. Until then, upgrade the sentinel via `-replace` (or the
+  > out-of-band swap below) so it serves the intended version.
+
+**Out-of-band swap** (when you can't reboot, e.g. a live upgrade): on the
+**sentinel first**, then the workhorse — `curl` the release binary to
+`/usr/local/bin/containarium.new`, `chmod +x`, verify `.new version`, atomic
+`mv` over `/usr/local/bin/containarium`, then `systemctl restart containarium`
+(workhorse) / `containarium-sentinel` (sentinel). The sentinel's admin sshd is
+on **port 2222** (22 is sshpiper), and restarting the sentinel briefly serves a
+self-signed cert on the public `:443`.
+
+[#385]: https://github.com/FootprintAI/Containarium/issues/385

--- a/terraform/modules/containarium/scripts/startup-spot.sh
+++ b/terraform/modules/containarium/scripts/startup-spot.sh
@@ -31,6 +31,107 @@ JWT_SECRET="${jwt_secret}"
 # custody story.
 ZFS_ENCRYPTION_KEYFILE="${zfs_encryption_keyfile}"
 
+# Containarium binary sources. Declared up here (not just in the full-install
+# block) so the fast path can reconcile the binary to the desired version too.
+CONTAINARIUM_VERSION="${containarium_version}"
+CONTAINARIUM_BINARY_URL="${containarium_binary_url}"
+SENTINEL_BINARY_URL="${sentinel_binary_url}"
+
+# reconcile_containarium_binary ensures /usr/local/bin/containarium is at the
+# desired version (CONTAINARIUM_VERSION), re-downloading and restarting the
+# daemon when it isn't. This replaces the old existence-aware install, which
+# made the binary write-once: a tfvar version bump never upgraded an existing
+# box (the fast path skipped all install), and a spot-recovery would pull
+# whatever the sentinel served and could silently DOWNGRADE the workhorse to an
+# older pinned version (#385).
+#
+# Behavior:
+#   - version pinned + already installed at that version  → no-op (stays fast).
+#   - version pinned + missing/mismatched                 → download + restart,
+#     accepting the sentinel only when it serves the desired version (else it
+#     could downgrade us), otherwise the explicit URL (authoritative).
+#   - version NOT pinned                                   → prior behavior:
+#     install only if absent; sentinel-first then URL.
+#
+# Strictly best-effort: every failure falls through keeping the existing binary
+# and returns 0, so it can never block the boot / the fast path's service start.
+reconcile_containarium_binary() {
+    desired="$CONTAINARIUM_VERSION"
+    current=""
+    if [ -x /usr/local/bin/containarium ]; then
+        current="$(/usr/local/bin/containarium version 2>/dev/null || true)"
+    fi
+
+    if [ -n "$desired" ]; then
+        if printf '%s' "$current" | grep -qF "$desired"; then
+            echo "==> containarium already at desired version ($desired) — skipping download"
+            return 0
+        fi
+        if [ -n "$current" ]; then
+            echo "==> containarium version mismatch (have: $current, want: $desired) — upgrading"
+        fi
+    elif [ -x /usr/local/bin/containarium ]; then
+        echo "==> containarium present, version not pinned — leaving as-is"
+        return 0
+    fi
+
+    tmp=/usr/local/bin/.containarium.new
+    rm -f "$tmp"
+    got=false
+
+    # Sentinel first (internal, fast) — but only accept it when it serves the
+    # desired version (or the version isn't pinned). This is what stops a stale
+    # sentinel from downgrading a recovered workhorse (#385).
+    if [ -n "$SENTINEL_BINARY_URL" ] && [ "$got" = "false" ]; then
+        echo "Trying sentinel: $SENTINEL_BINARY_URL"
+        for i in $(seq 1 10); do
+            if curl -fsSL --connect-timeout 5 "$SENTINEL_BINARY_URL" -o "$tmp"; then
+                chmod +x "$tmp"
+                sv="$("$tmp" version 2>/dev/null || true)"
+                if [ -z "$desired" ] || printf '%s' "$sv" | grep -qF "$desired"; then
+                    echo "✓ accepted sentinel binary ($sv)"
+                    got=true
+                else
+                    echo "  sentinel serves '$sv' but want '$desired' — declining (avoiding downgrade)"
+                    rm -f "$tmp"
+                fi
+                break
+            fi
+            echo "  sentinel not ready yet, retrying... ($i/10)"
+            sleep 10
+        done
+    fi
+
+    # Explicit URL — authoritative for a pinned version.
+    if [ -n "$CONTAINARIUM_BINARY_URL" ] && [ "$got" = "false" ]; then
+        echo "Downloading from: $CONTAINARIUM_BINARY_URL"
+        if curl -fsSL "$CONTAINARIUM_BINARY_URL" -o "$tmp"; then
+            chmod +x "$tmp"
+            got=true
+        fi
+    fi
+
+    if [ "$got" = "false" ]; then
+        rm -f "$tmp"
+        if [ -x /usr/local/bin/containarium ]; then
+            echo "⚠ could not fetch desired binary; keeping existing ($current)"
+        else
+            echo "⚠ No Containarium binary source available, daemon not installed"
+        fi
+        return 0
+    fi
+
+    # Atomic swap, then restart only if the service is already installed (it
+    # isn't on first boot — the full-install path enables+starts it later).
+    mv -f "$tmp" /usr/local/bin/containarium
+    chmod +x /usr/local/bin/containarium
+    echo "✓ containarium installed: $(/usr/local/bin/containarium version 2>/dev/null || echo '(version unavailable)')"
+    if systemctl list-unit-files containarium.service >/dev/null 2>&1; then
+        systemctl restart containarium 2>/dev/null || true
+    fi
+    return 0
+}
+
 # ==========================================================================
 # FAST PATH: If this is a restart (not first boot), skip software install.
 # The sentinel restarts the stopped VM — boot disk is preserved, everything
@@ -39,6 +140,15 @@ ZFS_ENCRYPTION_KEYFILE="${zfs_encryption_keyfile}"
 if [ -f /opt/containarium/.setup_complete ]; then
     echo "==> RESTART detected (setup_complete marker exists), using fast path"
     date > /opt/containarium/.last_restart_timestamp
+
+    # Reconcile the binary to the desired version BEFORE starting the daemon.
+    # The .setup_complete marker now gates only the heavy host setup
+    # (Incus/ZFS/packages); the binary is version-checked on every boot so an
+    # "apply (version bump) + reboot" actually upgrades, and a spot-recovery
+    # can't be left on a stale binary (#385). Best-effort — never blocks start.
+    # `|| true` also suspends `set -e` inside the function, so an internal
+    # command failure can't abort the boot before services start.
+    reconcile_containarium_binary || true
 
     # Ensure critical services are running
     systemctl start incus 2>/dev/null || true
@@ -559,43 +669,10 @@ echo "==> Creating Containarium directory structure..."
 mkdir -p /opt/containarium/{bin,config,logs}
 chmod 755 /opt/containarium
 
-# Install Containarium daemon
+# Install Containarium daemon. Version-aware + downgrade-safe via the shared
+# reconcile helper (defined near the top so the fast path uses it too) — #385.
 echo "==> Installing Containarium daemon..."
-CONTAINARIUM_VERSION="${containarium_version}"
-CONTAINARIUM_BINARY_URL="${containarium_binary_url}"
-SENTINEL_BINARY_URL="${sentinel_binary_url}"
-
-BINARY_INSTALLED=false
-
-# Try sentinel binary server first (internal network, fast)
-if [ -n "$SENTINEL_BINARY_URL" ] && [ "$BINARY_INSTALLED" = "false" ]; then
-    echo "Downloading from sentinel: $SENTINEL_BINARY_URL"
-    # Retry up to 10 times (sentinel may still be booting)
-    for i in {1..10}; do
-        if curl -fsSL --connect-timeout 5 "$SENTINEL_BINARY_URL" -o /usr/local/bin/containarium; then
-            chmod +x /usr/local/bin/containarium
-            echo "✓ Containarium downloaded from sentinel"
-            BINARY_INSTALLED=true
-            break
-        fi
-        echo "  Sentinel not ready yet, retrying... ($i/10)"
-        sleep 10
-    done
-fi
-
-# Fallback to explicit URL (e.g., GitHub releases, GCS)
-if [ -n "$CONTAINARIUM_BINARY_URL" ] && [ "$BINARY_INSTALLED" = "false" ]; then
-    echo "Downloading from: $CONTAINARIUM_BINARY_URL"
-    curl -fsSL "$CONTAINARIUM_BINARY_URL" -o /usr/local/bin/containarium
-    chmod +x /usr/local/bin/containarium
-    echo "✓ Containarium daemon downloaded"
-    BINARY_INSTALLED=true
-fi
-
-if [ "$BINARY_INSTALLED" = "false" ]; then
-    echo "⚠ No Containarium binary source available, daemon not installed"
-    echo "  You can manually install it later by copying the binary to /usr/local/bin/containarium"
-fi
+reconcile_containarium_binary || true
 
 # Verify installation
 if [ -f /usr/local/bin/containarium ]; then

--- a/terraform/modules/containarium/variables.tf
+++ b/terraform/modules/containarium/variables.tf
@@ -328,7 +328,17 @@ variable "enable_disk_snapshots" {
 # -----------------------------------------------------------------------------
 
 variable "containarium_version" {
-  description = "Containarium version to install"
+  description = <<-EOT
+    Containarium version to install. The startup script reconciles the
+    installed binary to this version on every boot (substring match against
+    `containarium version`), so bumping it upgrades the daemon — but note a
+    metadata-only `terraform apply` does NOT restart the instance, so the new
+    version takes effect on the next reboot/preemption-recovery (or force one
+    with `terraform apply -replace=<instance>`). On a sentinel-HA deployment a
+    recovered workhorse declines a sentinel-served binary whose version doesn't
+    match this value (avoids silent downgrade); upgrade the sentinel too so its
+    :8888 server hands out the matching version. See #385 and the module README.
+  EOT
   type        = string
   default     = "dev"
 }


### PR DESCRIPTION
Addresses #385 (workhorse + docs; sentinel-side reconcile is a noted follow-up).

## Problem

`containarium_version` was effectively **write-once** on the spot workhorse:

1. The fast path (`.setup_complete` marker) skipped *all* install on every reboot, so a tfvar version bump + `apply` never upgraded an existing box.
2. On sentinel-HA recovery the workhorse pulled whatever the sentinel served on `:8888` **first**, only falling back to `containarium_binary_url` if the sentinel was down — so a stale sentinel could silently **downgrade** the workhorse (observed: sentinel serving 0.19.3 while the workhorse ran 0.20.0).

## Change (`startup-spot.sh`)

Replace the existence-aware install with a shared **`reconcile_containarium_binary`** helper, defined before the fast path and called from both it and the full-install block:

- **Version-aware, not existence-aware.** Compares the installed `containarium version` to `containarium_version` (substring match); re-downloads + `systemctl restart containarium` only on a mismatch. A same-version reboot stays on the fast path; a version bump upgrades on the next boot. `.setup_complete` now gates only the heavy host setup (Incus/ZFS/packages), not the binary.
- **Downgrade-safe.** Accepts the sentinel-served binary only when its version matches the desired version; otherwise declines and falls back to the authoritative `containarium_binary_url`. A stale sentinel can no longer downgrade a recovered workhorse.
- **Strictly best-effort.** `|| true` at the call sites also suspends `set -e` inside the function, so an internal failure can never block the boot / fast-path service start. Unpinned version → prior install-if-absent behavior.

## Docs (fix #3)

- `variables.tf` `containarium_version` now documents that a **metadata-only apply doesn't restart the VM** — the upgrade lands on the next reboot/recovery or a forced `terraform apply -replace=...`.
- README gains an **"Upgrading the daemon"** section: the reboot/replace requirement, sentinel-first ordering, and the out-of-band swap runbook (sentinel admin sshd on :2222, brief self-signed cert on :443 during restart).

## Acceptance (from the issue)

- ✅ Fix #1 (version-aware install) — done for the workhorse.
- ✅ Fix #2 (sentinel can't silently override an explicit version) — done.
- ✅ Fix #3 (document + surface) — variable description + README.

## Validation

This is fleet-wide provisioning bash and untestable end-to-end from a dev box, so I validated structurally: the helper uses only brace-free bash vars (no accidental Terraform interpolation), a **full template render passes `bash -n`**, and **`terraform validate` is green**. The reconcile is best-effort by construction (worst case it's a no-op and the existing binary keeps running — same as today).

## Follow-up

`startup-sentinel.sh` is still existence-aware on its own boot path; applying the same version-aware reconcile there (so the sentinel auto-serves the requested version after apply+reboot, enabling the same-version fast path on recovery) is left as a follow-up. Until then, upgrade the sentinel via `-replace`; the workhorse's downgrade-decline already prevents the unsafe case. Leaving #385 open for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)