### PR TITLE
feat(cli): `containarium backends versions` cluster version overview (#354)

### DIFF
--- a/internal/cmd/backends_versions.go
+++ b/internal/cmd/backends_versions.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/releasecheck"
+	"github.com/spf13/cobra"
+)
+
+var backendsVersionsFormat string
+
+var backendsVersionsCmd = &cobra.Command{
+	Use:   "versions",
+	Short: "Show the daemon version of every backend vs the latest release",
+	Long: `Show a cluster-wide version overview: the daemon version running on the
+local daemon and each tunnel peer, the latest published GitHub release, and a
+per-backend status (current / behind) so drift is visible at a glance.
+
+Composes the existing /v1/backends (per-backend version) and /v1/releases/latest
+(cached GitHub lookup) endpoints — both HTTP-only and admin-authenticated, so
+this command requires --server pointing at the daemon's HTTP address. See #354.`,
+	Aliases: []string{"version", "ver"},
+	RunE:    runBackendsVersions,
+}
+
+func init() {
+	backendsCmd.AddCommand(backendsVersionsCmd)
+	backendsVersionsCmd.Flags().StringVarP(&backendsVersionsFormat, "format", "f", "table",
+		"Output format: table, json")
+}
+
+// latestReleaseResponse mirrors the /v1/releases/latest (GetLatestRelease)
+// response shape (camelCase from grpc-gateway). Kept local so a server-side
+// schema change surfaces as a decode failure here, not a silent field-drop.
+type latestReleaseResponse struct {
+	LatestRelease   string `json:"latestRelease"`
+	CurrentVersion  string `json:"currentVersion"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+}
+
+// backendVersionRow is the rendered per-backend version line.
+type backendVersionRow struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Healthy bool   `json:"healthy"`
+	Version string `json:"version"`
+	Status  string `json:"status"` // current | behind | dev | unknown
+}
+
+type backendsVersionsOutput struct {
+	LatestRelease string              `json:"latestRelease"`
+	Backends      []backendVersionRow `json:"backends"`
+}
+
+// backendVersionStatus classifies a backend's version against the latest
+// published release. "behind" when the latest is a newer semver; "current"
+// when equal or ahead; "dev" for an unversioned dev build; "unknown" when
+// either side is missing or unparseable.
+func backendVersionStatus(current, latest string) string {
+	if current == "" {
+		return "unknown"
+	}
+	if current == "dev" {
+		return "dev"
+	}
+	if latest == "" {
+		return "unknown"
+	}
+	if releasecheck.UpdateAvailable(current, latest) {
+		return "behind"
+	}
+	return "current"
+}
+
+func runBackendsVersions(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (the platform daemon's HTTP address, e.g. http://host:8080)")
+	}
+	base := strings.TrimSuffix(serverAddr, "/")
+
+	var backendsResp backendsListResponse
+	if err := getJSON(base+"/v1/backends", &backendsResp); err != nil {
+		return fmt.Errorf("fetch backends: %w", err)
+	}
+
+	// Latest-release lookup is best-effort: a rate-limited / offline daemon
+	// still gives us the version table, just without the "behind" column.
+	var latest latestReleaseResponse
+	if err := getJSON(base+"/v1/releases/latest", &latest); err != nil {
+		fmt.Printf("Warning: could not fetch latest release (%v); status column will read 'unknown'\n", err)
+	}
+
+	rows := make([]backendVersionRow, 0, len(backendsResp.Backends))
+	for _, b := range backendsResp.Backends {
+		rows = append(rows, backendVersionRow{
+			ID:      b.ID,
+			Type:    b.Type,
+			Healthy: b.Healthy,
+			Version: b.Version,
+			Status:  backendVersionStatus(b.Version, latest.LatestRelease),
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].ID < rows[j].ID })
+
+	if backendsVersionsFormat == "json" {
+		out := backendsVersionsOutput{LatestRelease: latest.LatestRelease, Backends: rows}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+
+	w := cmd.OutOrStdout()
+	if latest.LatestRelease != "" {
+		fmt.Fprintf(w, "Latest release: %s\n\n", latest.LatestRelease)
+	} else {
+		fmt.Fprintf(w, "Latest release: (unavailable)\n\n")
+	}
+	fmt.Fprintf(w, "%-28s %-8s %-12s %s\n", "BACKEND", "TYPE", "VERSION", "STATUS")
+	for _, r := range rows {
+		ver := r.Version
+		if ver == "" {
+			ver = "?"
+		}
+		status := r.Status
+		switch status {
+		case "behind":
+			status = "⚠ behind"
+		case "current":
+			status = "✓ current"
+		}
+		fmt.Fprintf(w, "%-28s %-8s %-12s %s\n", r.ID, r.Type, ver, status)
+	}
+	return nil
+}
+
+// getJSON does an admin-authenticated GET and decodes the JSON body.
+func getJSON(url string, out interface{}) error {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/internal/cmd/backends_versions_test.go
+++ b/internal/cmd/backends_versions_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import "testing"
+
+func TestBackendVersionStatus(t *testing.T) {
+	cases := []struct {
+		name    string
+		current string
+		latest  string
+		want    string
+	}{
+		{"behind", "0.21.0", "v0.21.2", "behind"},
+		{"behind across minor", "v0.20.0", "v0.21.0", "behind"},
+		{"current equal", "v0.21.2", "v0.21.2", "current"},
+		{"current equal sans-v", "0.21.2", "v0.21.2", "current"},
+		{"ahead counts as current", "v0.22.0", "v0.21.2", "current"},
+		{"dev build", "dev", "v0.21.2", "dev"},
+		{"missing current", "", "v0.21.2", "unknown"},
+		{"missing latest", "v0.21.0", "", "unknown"},
+		{"unparseable current is not behind", "garbage", "v0.21.2", "current"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := backendVersionStatus(tc.current, tc.latest); got != tc.want {
+				t.Errorf("backendVersionStatus(%q, %q) = %q, want %q", tc.current, tc.latest, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Advances #354 (Phase A — version visibility), at the CLI-first surface CLAUDE.md mandates. Leaves the issue open for the webui panel and Phase B/C upgrade machinery.

## Why

#354's #1 motivation: *"operators can't see at a glance what version each backend is running, whether they're drifted, or whether a newer release exists."* The backend primitives already merged — `/v1/backends` carries each backend's daemon version, and `/v1/releases/latest` (`GetLatestRelease`) does the cached GitHub lookup. The missing piece for operators-not-at-the-webui is a single command that composes them.

## Change

`containarium backends versions [--format table|json]`:
- fetches `/v1/backends` (local daemon + every tunnel peer, with versions) and `/v1/releases/latest`,
- renders a table with a per-backend **status**: `current` / `behind` / `dev` / `unknown`, computed via the existing `releasecheck.UpdateAvailable` semver logic,
- latest-release lookup is **best-effort** — a rate-limited/offline daemon still prints the table (status reads `unknown`),
- mirrors `backends list`'s direct-HTTP-to-`/v1/backends` pattern (both endpoints are HTTP-only + admin-authed; needs `--server`).

Example:

```
Latest release: v0.21.2

BACKEND                      TYPE     VERSION      STATUS
containarium-jump-usw1       local    v0.21.2      ✓ current
tunnel-node-a-gpu            tunnel   v0.20.0      ⚠ behind
```

## Scope / acceptance

This is the **CLI-first** counterpart of Phase A's "version display" (the issue's webui table) — proto-first wasn't needed since the data already exists in two endpoints (the issue explicitly says "don't rebuild these"). No proto changes, no `autoupdate.go` changes — purely additive.

Still open on #354: the webui panel (needs the Next.js toolchain) and Phase B/C (the `TriggerUpgrade` RPC, rollback, sentinel GitHub-fetch — real restart risk). Leaving the issue open.

## Tests

`backendVersionStatus` unit-tested across behind / equal / ahead / dev / missing / unparseable. `go build ./internal/cmd/` clean; `go test ./internal/cmd/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)