### PR TITLE
feat(scripts): standalone GPU-passthrough validation gate (#316)

### DIFF
--- a/docs/CONTAINARIUM-HOST-TO-VM-MIGRATION.md
+++ b/docs/CONTAINARIUM-HOST-TO-VM-MIGRATION.md
@@ -172,6 +172,20 @@ sudo virt-install --name containarium-vm \
 
 **Gate:** VM is up, has a LAN IP, Tailscale-reachable, `nvidia-smi` sees the GPU, Incus is initialized.
 
+> Verify GPU passthrough end-to-end — that the GPU is usable from inside an
+> **LXC**, not just from the VM shell — with the standalone gate script (no
+> daemon needed). It launches a throwaway `nvidia.runtime=true` LXC, runs
+> `nvidia-smi` inside, parses the model + driver, and tears it down:
+>
+> ```sh
+> sudo ./scripts/validate-gpu-passthrough.sh            # or --pci 0000:01:00.0, --json
+> # → ✓ GPU PASSTHROUGH OK: NVIDIA GeForce RTX 4090 (driver 570.x)
+> ```
+>
+> A non-zero exit here is the **D6 rollback trigger** — abort the migration
+> rather than continue with a broken GPU. Re-run it after any VFIO bind or
+> driver upgrade too. (#316)
+
 ### Phase 4 — LXC migration (host → VM)
 
 For each container, in this order (platform first, then CPU-only user containers, GPU container last):

--- a/scripts/validate-gpu-passthrough.sh
+++ b/scripts/validate-gpu-passthrough.sh
@@ -69,7 +69,7 @@ cleanup() {
     code=$?
     if [ "$LAUNCHED" = true ]; then
         if [ "$STATUS" = "ok" ] || [ "$KEEP_ON_FAIL" != true ]; then
-            incus delete --force "$CT" >/dev/null 2>&1 || true
+            incus delete --force "$CT" >/dev/null 2>&1 </dev/null || true
         else
             echo "  (kept $CT for debugging — 'incus delete --force $CT' to remove)" >&2
         fi
@@ -85,37 +85,42 @@ trap cleanup EXIT
 fail() { REASON="$1"; exit 1; }
 
 # --- preflight --------------------------------------------------------------
+# Every `incus` call below redirects stdin from /dev/null. `incus exec` (and,
+# observed, `incus launch`) inherit this process's stdin and forward/consume it;
+# if the script itself was piped in (`bash -s < script` / `curl ... | bash`),
+# that drains the bytes the shell still needs and the run breaks. </dev/null
+# makes the script behave identically whether run as a file or piped.
 command -v incus >/dev/null 2>&1 || fail "incus not found on host"
-incus info >/dev/null 2>&1 || fail "cannot talk to incus (run as root / in the incus group?)"
+incus info >/dev/null 2>&1 </dev/null || fail "cannot talk to incus (run as root / in the incus group?)"
 
 # --- launch throwaway LXC with NVIDIA passthrough ---------------------------
 # nvidia.runtime=true makes Incus inject the host's NVIDIA driver + nvidia-smi.
-if ! incus launch "$IMAGE" "$CT" -c nvidia.runtime=true >/dev/null 2>&1; then
+if ! incus launch "$IMAGE" "$CT" -c nvidia.runtime=true >/dev/null 2>&1 </dev/null; then
     fail "incus launch failed (image $IMAGE, nvidia.runtime=true)"
 fi
 LAUNCHED=true
 
 # Attach the GPU device — a specific PCI address if given, else all GPUs.
 if [ -n "$PCI" ]; then
-    incus config device add "$CT" gpu gpu "pci=$PCI" >/dev/null 2>&1 \
+    incus config device add "$CT" gpu gpu "pci=$PCI" >/dev/null 2>&1 </dev/null \
         || fail "could not attach GPU device pci=$PCI"
 else
-    incus config device add "$CT" gpu gpu >/dev/null 2>&1 \
+    incus config device add "$CT" gpu gpu >/dev/null 2>&1 </dev/null \
         || fail "could not attach GPU device"
 fi
 
 # Give the container a moment to finish booting before exec.
 for _ in $(seq 1 15); do
-    if incus exec "$CT" -- true >/dev/null 2>&1; then break; fi
+    if incus exec "$CT" -- true >/dev/null 2>&1 </dev/null; then break; fi
     sleep 1
 done
 
 # --- run nvidia-smi inside --------------------------------------------------
-if ! incus exec "$CT" -- sh -c 'command -v nvidia-smi >/dev/null 2>&1'; then
+if ! incus exec "$CT" -- sh -c 'command -v nvidia-smi >/dev/null 2>&1' </dev/null; then
     fail "nvidia-smi not present in the container (nvidia.runtime injection failed — check host driver + libnvidia-container)"
 fi
 
-OUT="$(incus exec "$CT" -- nvidia-smi --query-gpu=name,driver_version --format=csv,noheader 2>/dev/null | head -1 || true)"
+OUT="$(incus exec "$CT" -- nvidia-smi --query-gpu=name,driver_version --format=csv,noheader 2>/dev/null </dev/null | head -1 || true)"
 if [ -z "$OUT" ]; then
     fail "nvidia-smi ran but returned no GPU (passthrough not visible inside the LXC)"
 fi

--- a/scripts/validate-gpu-passthrough.sh
+++ b/scripts/validate-gpu-passthrough.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# validate-gpu-passthrough.sh — does GPU passthrough actually work from inside
+# an Incus LXC on this host?
+#
+# Standalone (no Containarium daemon needed). The migration gate for
+# docs/CONTAINARIUM-HOST-TO-VM-MIGRATION.md (#316): run it before committing to
+# a host→VM move, and after any VFIO bind or NVIDIA driver upgrade.
+#
+# What it does:
+#   1. launches a throwaway LXC (nvidia.runtime=true + a gpu device, the
+#      standard Incus NVIDIA recipe — libnvidia-container injects the host
+#      driver libs + nvidia-smi into the container; no in-container install)
+#   2. runs `nvidia-smi` inside and parses the GPU model + driver version
+#   3. tears the LXC down (always, via trap)
+#   4. prints `✓ GPU PASSTHROUGH OK: <model> (driver <ver>)` or
+#      `✗ GPU PASSTHROUGH FAILED: <reason>` and exits 0 / 1 accordingly.
+#
+# Usage:
+#   sudo ./scripts/validate-gpu-passthrough.sh [--pci <addr>] [--image <img>]
+#                                              [--json] [--keep-on-fail]
+#
+#   --pci <addr>     Pass a specific GPU by PCI address (e.g. 0000:01:00.0).
+#                    Default: pass all GPUs (Incus `gpu` device with no filter).
+#   --image <img>    Base image. Default images:ubuntu/24.04.
+#   --json           Emit a single JSON object instead of human text.
+#   --keep-on-fail   Don't delete the throwaway LXC if validation fails
+#                    (for debugging). It's always deleted on success.
+#
+set -euo pipefail
+
+PCI=""
+IMAGE="images:ubuntu/24.04"
+JSON=false
+KEEP_ON_FAIL=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --pci) PCI="$2"; shift 2 ;;
+        --image) IMAGE="$2"; shift 2 ;;
+        --json) JSON=true; shift ;;
+        --keep-on-fail) KEEP_ON_FAIL=true; shift ;;
+        -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# A fixed-but-unique-enough name without Date/RANDOM dependencies in odd shells.
+CT="gpuval-$$"
+STATUS="failed"
+MODEL=""
+DRIVER=""
+REASON=""
+LAUNCHED=false
+
+emit() {
+    if [ "$JSON" = true ]; then
+        # Hand-rolled JSON (no jq dependency on a minimal host).
+        printf '{"gpu_status":"%s","gpu_model":"%s","driver_version":"%s","reason":"%s"}\n' \
+            "$STATUS" "$MODEL" "$DRIVER" "$REASON"
+    elif [ "$STATUS" = "ok" ]; then
+        echo "✓ GPU PASSTHROUGH OK: $MODEL (driver $DRIVER)"
+    else
+        echo "✗ GPU PASSTHROUGH FAILED: $REASON"
+    fi
+}
+
+cleanup() {
+    code=$?
+    if [ "$LAUNCHED" = true ]; then
+        if [ "$STATUS" = "ok" ] || [ "$KEEP_ON_FAIL" != true ]; then
+            incus delete --force "$CT" >/dev/null 2>&1 || true
+        else
+            echo "  (kept $CT for debugging — 'incus delete --force $CT' to remove)" >&2
+        fi
+    fi
+    emit
+    # Preserve an explicit failure exit set before normal completion.
+    if [ "$STATUS" = "ok" ]; then exit 0; fi
+    [ "$code" -ne 0 ] && exit "$code"
+    exit 1
+}
+trap cleanup EXIT
+
+fail() { REASON="$1"; exit 1; }
+
+# --- preflight --------------------------------------------------------------
+command -v incus >/dev/null 2>&1 || fail "incus not found on host"
+incus info >/dev/null 2>&1 || fail "cannot talk to incus (run as root / in the incus group?)"
+
+# --- launch throwaway LXC with NVIDIA passthrough ---------------------------
+# nvidia.runtime=true makes Incus inject the host's NVIDIA driver + nvidia-smi.
+if ! incus launch "$IMAGE" "$CT" -c nvidia.runtime=true >/dev/null 2>&1; then
+    fail "incus launch failed (image $IMAGE, nvidia.runtime=true)"
+fi
+LAUNCHED=true
+
+# Attach the GPU device — a specific PCI address if given, else all GPUs.
+if [ -n "$PCI" ]; then
+    incus config device add "$CT" gpu gpu "pci=$PCI" >/dev/null 2>&1 \
+        || fail "could not attach GPU device pci=$PCI"
+else
+    incus config device add "$CT" gpu gpu >/dev/null 2>&1 \
+        || fail "could not attach GPU device"
+fi
+
+# Give the container a moment to finish booting before exec.
+for _ in $(seq 1 15); do
+    if incus exec "$CT" -- true >/dev/null 2>&1; then break; fi
+    sleep 1
+done
+
+# --- run nvidia-smi inside --------------------------------------------------
+if ! incus exec "$CT" -- sh -c 'command -v nvidia-smi >/dev/null 2>&1'; then
+    fail "nvidia-smi not present in the container (nvidia.runtime injection failed — check host driver + libnvidia-container)"
+fi
+
+OUT="$(incus exec "$CT" -- nvidia-smi --query-gpu=name,driver_version --format=csv,noheader 2>/dev/null | head -1 || true)"
+if [ -z "$OUT" ]; then
+    fail "nvidia-smi ran but returned no GPU (passthrough not visible inside the LXC)"
+fi
+
+# OUT looks like: "NVIDIA GeForce RTX 4090, 570.86.15"
+MODEL="$(printf '%s' "$OUT" | cut -d, -f1 | sed 's/^ *//;s/ *$//')"
+DRIVER="$(printf '%s' "$OUT" | cut -d, -f2 | sed 's/^ *//;s/ *$//')"
+[ -n "$MODEL" ] || fail "could not parse GPU model from nvidia-smi output: $OUT"
+
+STATUS="ok"
+# cleanup() runs on EXIT: tears down the LXC, emits the result, exits 0.


### PR DESCRIPTION
Advances #316. Scoped to the issue's first proposal — the standalone pre-migration gate script — which is the migration-blocking piece and is self-contained. Leaves #316 open for the daemon `validate-gpu` RPC/CLI/MCP + `/v1/backends` field.

## Why

The host→VM migration's critical gate (`docs/CONTAINARIUM-HOST-TO-VM-MIGRATION.md`, decision **D6**) is: *does GPU passthrough actually work from inside an LXC?* If `nvidia-smi` fails there, the migration must abort. There was no primitive to check this — operators eyeballed it.

## Change

`scripts/validate-gpu-passthrough.sh` — standalone (no Containarium daemon):
- launches a throwaway `nvidia.runtime=true` LXC and attaches a `gpu` device (all GPUs, or a specific `--pci <addr>`) — the standard Incus NVIDIA recipe (libnvidia-container injects the host driver + `nvidia-smi`, no in-container install),
- runs `nvidia-smi --query-gpu=name,driver_version` inside and parses the model + driver,
- **always tears the LXC down** via an EXIT trap (`--keep-on-fail` retains it for debugging; always deleted on success),
- prints `✓ GPU PASSTHROUGH OK: <model> (driver <ver>)` or `✗ GPU PASSTHROUGH FAILED: <reason>` and exits `0`/`1`, with a `--json` mode for agents/CI.

Wired into the migration runbook's Phase-2 gate as the D6 rollback trigger, and noted as re-runnable after any VFIO bind / driver upgrade.

## Validation

`bash -n` clean and made executable. **It can't be exercised in CI** — it needs a real NVIDIA GPU + Incus host — so I followed the existing `scripts/setup-gpu-host.sh` conventions (same `nvidia-smi --query-gpu` parse, incus device commands) and kept it defensive: every external step is guarded (`|| fail "<reason>"` / `if ! ...`), and teardown runs unconditionally via the trap.

## Follow-up (keeps #316 open)

The product primitive — `containarium backend validate-gpu <id>` (daemon-side throwaway-LXC orchestration over the existing manager create/exec/delete), its MCP wrapper, and the `gpu_status` field on `/v1/backends` — needs a real GPU backend to verify and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)