### PR TITLE
chore(release): bump to 0.22.1 (ships #400 Caddy-edge self-heal)

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.22.0"
+	Version = "0.22.1"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Patch release carrying the **#400** fix (already on `main`): **#405** (self-heal Caddy edge after stub-Caddyfile revert — the dead-`:443` / intermittent `tls: internal error` flap) + **#406** (clear stale Caddy DNAT on caddy-IP change). Latest release v0.22.0 predates both. After merge: tag `v0.22.1` → release build → upgrade the daemon on the boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)