### PR TITLE
feat: ValidateGPU RPC + CLI + MCP — GPU passthrough check (#316)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -3599,6 +3599,41 @@
         ]
       }
     },
+    "/v1/validate-gpu": {
+      "post": {
+        "summary": "Validate GPU passthrough",
+        "description": "Launches a throwaway nvidia.runtime LXC on the backend, runs nvidia-smi inside, and returns whether the GPU is usable (status, model, driver). Admin-only.",
+        "operationId": "ContainerService_ValidateGPU",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ValidateGPUResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "ValidateGPURequest asks a backend to prove GPU passthrough works from inside\nan LXC. See #316.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ValidateGPURequest"
+            }
+          }
+        ],
+        "tags": [
+          "System"
+        ]
+      }
+    },
     "/v1/zap/alerts": {
       "get": {
         "summary": "List ZAP alerts",
@@ -5618,6 +5653,17 @@
       "default": "GPU_MODEL_UNSPECIFIED",
       "description": "- GPU_MODEL_NVIDIA_RTX_4090: NVIDIA Consumer\n - GPU_MODEL_NVIDIA_A100: NVIDIA Datacenter\n - GPU_MODEL_AMD_MI300X: AMD\n - GPU_MODEL_INTEL_MAX_1550: Intel",
       "title": "GPU model enum (common datacenter and workstation GPUs)"
+    },
+    "GPUStatus": {
+      "type": "string",
+      "enum": [
+        "GPU_STATUS_UNSPECIFIED",
+        "GPU_STATUS_OK",
+        "GPU_STATUS_UNAVAILABLE",
+        "GPU_STATUS_DEGRADED"
+      ],
+      "default": "GPU_STATUS_UNSPECIFIED",
+      "title": "- GPU_STATUS_OK: nvidia-smi saw the GPU inside the LXC\n - GPU_STATUS_UNAVAILABLE: no GPU / passthrough not visible / setup failed\n - GPU_STATUS_DEGRADED: reserved (e.g. present but reporting errors)"
     },
     "GPUVendor": {
       "type": "string",
@@ -8264,6 +8310,45 @@
           "title": "Status message"
         }
       }
+    },
+    "ValidateGPURequest": {
+      "type": "object",
+      "properties": {
+        "backendId": {
+          "type": "string",
+          "description": "Backend to validate. Empty = the local/primary daemon's own host."
+        },
+        "pci": {
+          "type": "string",
+          "description": "Specific GPU PCI address (e.g. \"0000:01:00.0\"). Empty = pass through all\nGPUs. Prefer PCI over a DRM index — it's stable across kernel upgrades."
+        }
+      },
+      "description": "ValidateGPURequest asks a backend to prove GPU passthrough works from inside\nan LXC. See #316."
+    },
+    "ValidateGPUResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/GPUStatus"
+        },
+        "gpuModel": {
+          "type": "string",
+          "title": "e.g. \"NVIDIA GeForce RTX 3090\""
+        },
+        "driverVersion": {
+          "type": "string",
+          "title": "e.g. \"570.211.01\""
+        },
+        "detail": {
+          "type": "string",
+          "title": "populated when status != OK"
+        },
+        "backendId": {
+          "type": "string",
+          "title": "echoes the validated backend (\"\" = local)"
+        }
+      },
+      "description": "ValidateGPUResponse reports whether the GPU is usable from inside an LXC on\nthe backend: the daemon launches a throwaway nvidia.runtime LXC, runs\nnvidia-smi inside, tears it down, and returns the parsed model + driver."
     },
     "WebhookDelivery": {
       "type": "object",

--- a/internal/cmd/backends_validate_gpu.go
+++ b/internal/cmd/backends_validate_gpu.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	validateGPUPci    string
+	validateGPUFormat string
+)
+
+var backendsValidateGPUCmd = &cobra.Command{
+	Use:   "validate-gpu [backend-id]",
+	Short: "Check that GPU passthrough works inside an LXC on a backend",
+	Long: `Launch a throwaway nvidia.runtime LXC on the backend, run nvidia-smi inside,
+tear it down, and report whether the GPU is usable (status + model + driver).
+
+Pre-flight before provisioning a GPU container, and a re-check after any VFIO
+bind or driver upgrade. With no backend-id it validates the local/primary
+daemon's host; with a peer id it forwards to that peer (which validates its own
+GPU). Admin-only; the daemon creates and deletes a short-lived container, so
+this can take ~30s (longer if the base image isn't cached). See #316.
+
+Requires --server pointing at the daemon's HTTP address.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runBackendsValidateGPU,
+}
+
+func init() {
+	backendsCmd.AddCommand(backendsValidateGPUCmd)
+	backendsValidateGPUCmd.Flags().StringVar(&validateGPUPci, "pci", "",
+		"Validate a specific GPU by PCI address (e.g. 0000:01:00.0). Empty = all GPUs.")
+	backendsValidateGPUCmd.Flags().StringVarP(&validateGPUFormat, "format", "f", "text",
+		"Output format: text, json")
+}
+
+// validateGPUReq is the typed /v1/validate-gpu request body. snake_case tags
+// match the daemon's grpc-gateway field names.
+type validateGPUReq struct {
+	BackendID string `json:"backend_id,omitempty"`
+	Pci       string `json:"pci,omitempty"`
+}
+
+// validateGPUResp mirrors the /v1/validate-gpu (ValidateGPU) response. The
+// status enum serializes as its proto name via grpc-gateway, e.g.
+// "GPU_STATUS_OK".
+type validateGPUResp struct {
+	Status        string `json:"status"`
+	GpuModel      string `json:"gpuModel"`
+	DriverVersion string `json:"driverVersion"`
+	Detail        string `json:"detail"`
+	BackendID     string `json:"backendId"`
+}
+
+func runBackendsValidateGPU(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (the platform daemon's HTTP address, e.g. http://host:8080)")
+	}
+	backendID := ""
+	if len(args) == 1 {
+		backendID = args[0]
+	}
+
+	reqBody, _ := json.Marshal(validateGPUReq{BackendID: backendID, Pci: validateGPUPci})
+	url := strings.TrimSuffix(serverAddr, "/") + "/v1/validate-gpu"
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(reqBody))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+
+	// Generous timeout: the daemon creates+starts+execs+deletes a container,
+	// and may pull the base image on first run.
+	httpClient := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var out validateGPUResp
+	if err := json.Unmarshal(body, &out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	if validateGPUFormat == "json" {
+		cmd.OutOrStdout().Write(body)
+		fmt.Fprintln(cmd.OutOrStdout())
+		return gpuExitErr(out.Status)
+	}
+
+	target := out.BackendID
+	if target == "" {
+		target = "(local)"
+	}
+	switch out.Status {
+	case "GPU_STATUS_OK":
+		fmt.Fprintf(cmd.OutOrStdout(), "✓ GPU PASSTHROUGH OK on %s: %s (driver %s)\n", target, out.GpuModel, out.DriverVersion)
+	default:
+		fmt.Fprintf(cmd.OutOrStdout(), "✗ GPU PASSTHROUGH %s on %s: %s\n", strings.TrimPrefix(out.Status, "GPU_STATUS_"), target, out.Detail)
+	}
+	return gpuExitErr(out.Status)
+}
+
+// gpuExitErr makes a non-OK validation a non-zero CLI exit (useful as a gate in
+// scripts / CI) without printing a duplicate error — the line above already
+// explained it.
+func gpuExitErr(status string) error {
+	if status == "GPU_STATUS_OK" {
+		return nil
+	}
+	// SilenceUsage/SilenceErrors-friendly: return a sentinel the root cmd
+	// renders quietly. Cobra prints "Error: ..."; keep it terse.
+	return fmt.Errorf("GPU validation did not pass (%s)", strings.TrimPrefix(status, "GPU_STATUS_"))
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -572,6 +572,42 @@ func (c *Client) GetLatestRelease() (*LatestReleaseResponse, error) {
 	return &resp, nil
 }
 
+// ValidateGPURequest is the typed /v1/validate-gpu request body. snake_case
+// tags match the daemon's grpc-gateway field names. #316.
+type ValidateGPURequest struct {
+	BackendID string `json:"backend_id,omitempty"`
+	Pci       string `json:"pci,omitempty"`
+}
+
+// ValidateGPUResult mirrors the /v1/validate-gpu (ValidateGPU) response. Status
+// is the proto enum name, e.g. "GPU_STATUS_OK". #316.
+type ValidateGPUResult struct {
+	Status        string `json:"status"`
+	GpuModel      string `json:"gpuModel"`
+	DriverVersion string `json:"driverVersion"`
+	Detail        string `json:"detail"`
+	BackendID     string `json:"backendId"`
+}
+
+// ValidateGPU asks the daemon to prove GPU passthrough works inside an LXC on a
+// backend (empty backendID = local; a peer id forwards to that peer). The
+// daemon creates and deletes a short-lived nvidia.runtime container, so this
+// can take ~30s. #316.
+func (c *Client) ValidateGPU(backendID, pci string) (*ValidateGPUResult, error) {
+	respBody, err := c.doRequest("POST", "/v1/validate-gpu", ValidateGPURequest{
+		BackendID: backendID,
+		Pci:       pci,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var resp ValidateGPUResult
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
 // AddRoute creates a domain → container:port mapping in the sentinel
 // reverse proxy. Used by the expose_port tool to make a container
 // reachable on the public internet under a chosen hostname.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -23,7 +23,7 @@ func TestServerCreation(t *testing.T) {
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
 	// 30 base (+check_for_updates, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes.
-	assert.Len(t, server.tools, 39, "Should have 39 tools registered")
+	assert.Len(t, server.tools, 40, "Should have 40 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -128,7 +128,7 @@ func TestHandleToolsList(t *testing.T) {
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
 	// 30 base (+check_for_updates, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes.
-	assert.Len(t, tools, 39)
+	assert.Len(t, tools, 40)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -557,6 +557,29 @@ func (s *Server) registerTools() {
 			Handler: handleGetBackend,
 		},
 		{
+			Name: "backend_validate_gpu",
+			Description: "Check that GPU passthrough works inside an LXC on a backend. The " +
+				"daemon launches a throwaway nvidia.runtime LXC, runs nvidia-smi inside, " +
+				"tears it down, and returns status + GPU model + driver version. Use before " +
+				"provisioning a GPU container, or after a VFIO/driver change. Omit backend_id " +
+				"for the local/primary host; pass a peer id (from list_backends) to validate " +
+				"that peer's GPU. Admin-only; creates and deletes a short-lived container (~30s).",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"backend_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Backend to validate (from list_backends). Empty = local/primary host.",
+					},
+					"pci": map[string]interface{}{
+						"type":        "string",
+						"description": "Validate a specific GPU by PCI address (e.g. '0000:01:00.0'). Empty = all GPUs.",
+					},
+				},
+			},
+			Handler: handleBackendValidateGPU,
+		},
+		{
 			Name: "push",
 			Description: "Push committed git history into a container via real `git push` over " +
 				"SSH (laptop -> sentinel -> sshpiper -> container). On first call, sets up a " +
@@ -1005,6 +1028,9 @@ func toolScopeAssignments() map[string]string {
 		"check_for_updates": auth.ScopeContainersRead,
 		"list_backends":     auth.ScopeContainersRead,
 		"get_backend":       auth.ScopeContainersRead,
+		// validate-gpu creates+deletes a throwaway container (a write op);
+		// the daemon additionally enforces admin role.
+		"backend_validate_gpu": auth.ScopeContainersWrite,
 		// secrets
 		"set_secret":      auth.ScopeSecretsWrite,
 		"delete_secret":   auth.ScopeSecretsWrite,
@@ -1473,6 +1499,26 @@ func handleGetSystemInfo(client *Client, args map[string]interface{}) (string, e
 	}
 
 	return result, nil
+}
+
+func handleBackendValidateGPU(client *Client, args map[string]interface{}) (string, error) {
+	backendID, _ := args["backend_id"].(string)
+	pci, _ := args["pci"].(string)
+
+	resp, err := client.ValidateGPU(backendID, pci)
+	if err != nil {
+		return "", fmt.Errorf("validate GPU: %w", err)
+	}
+
+	target := resp.BackendID
+	if target == "" {
+		target = "(local)"
+	}
+	if resp.Status == "GPU_STATUS_OK" {
+		return fmt.Sprintf("✓ GPU passthrough OK on %s: %s (driver %s)", target, resp.GpuModel, resp.DriverVersion), nil
+	}
+	status := strings.TrimPrefix(resp.Status, "GPU_STATUS_")
+	return fmt.Sprintf("✗ GPU passthrough %s on %s: %s", status, target, resp.Detail), nil
 }
 
 func handleCheckForUpdates(client *Client, args map[string]interface{}) (string, error) {

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -1645,6 +1645,68 @@ func (s *ContainerServer) GetLatestRelease(ctx context.Context, req *pb.GetLates
 	}, nil
 }
 
+// ValidateGPU launches a throwaway nvidia.runtime LXC on the target backend,
+// runs nvidia-smi inside, tears it down, and reports whether the GPU is usable.
+// Admin-only. An empty (or local) backend_id runs the check on this daemon's
+// own host; a peer backend_id forwards to that peer's daemon, which runs the
+// same check locally on its host. See #316.
+func (s *ContainerServer) ValidateGPU(ctx context.Context, req *pb.ValidateGPURequest) (*pb.ValidateGPUResponse, error) {
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+
+	// Remote backend → forward to the owning peer (it validates its own GPU).
+	if req.BackendId != "" && req.BackendId != s.localBackendID() {
+		if s.peerPool == nil {
+			return nil, status.Errorf(codes.Unavailable, "backend %q: no peer pool configured on this daemon", req.BackendId)
+		}
+		peer := s.peerPool.Get(req.BackendId)
+		if peer == nil {
+			return nil, status.Errorf(codes.NotFound, "backend %q not found (see 'containarium backends list')", req.BackendId)
+		}
+		body, err := protojson.Marshal(req)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "marshal validate-gpu request: %v", err)
+		}
+		respBody, st, err := peer.ForwardRequest("POST", "/v1/validate-gpu", extractAuthToken(ctx), body)
+		if err != nil {
+			return nil, status.Errorf(codes.Unavailable, "forward validate-gpu to %s: %v", req.BackendId, err)
+		}
+		if st >= 400 {
+			return nil, status.Errorf(codes.Internal, "peer %s returned status %d for validate-gpu", req.BackendId, st)
+		}
+		var resp pb.ValidateGPUResponse
+		if err := protojson.Unmarshal(respBody, &resp); err != nil {
+			return nil, status.Errorf(codes.Internal, "parse peer %s validate-gpu response: %v", req.BackendId, err)
+		}
+		resp.BackendId = req.BackendId
+		return &resp, nil
+	}
+
+	// Local backend.
+	res := s.manager.ValidateGPU(req.Pci)
+	return &pb.ValidateGPUResponse{
+		Status:        gpuValidationStatusToProto(res.Status),
+		GpuModel:      res.Model,
+		DriverVersion: res.DriverVersion,
+		Detail:        res.Detail,
+		BackendId:     req.BackendId,
+	}, nil
+}
+
+// gpuValidationStatusToProto maps the manager's GPU validation status string to
+// the proto enum.
+func gpuValidationStatusToProto(s string) pb.ValidateGPUResponse_GPUStatus {
+	switch s {
+	case container.GPUStatusOK:
+		return pb.ValidateGPUResponse_GPU_STATUS_OK
+	case container.GPUStatusUnavailable:
+		return pb.ValidateGPUResponse_GPU_STATUS_UNAVAILABLE
+	default:
+		return pb.ValidateGPUResponse_GPU_STATUS_UNSPECIFIED
+	}
+}
+
 // GetSystemInfo gets information about the Incus host
 func (s *ContainerServer) GetSystemInfo(ctx context.Context, req *pb.GetSystemInfoRequest) (*pb.GetSystemInfoResponse, error) {
 	// Admin-only: exposes fleet-internal details (hostname, OS,

--- a/pkg/core/container/validate_gpu.go
+++ b/pkg/core/container/validate_gpu.go
@@ -1,0 +1,114 @@
+package container
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// gpuValidationImage is the throwaway base image. Minimal Ubuntu; nvidia.runtime
+// injects the host driver + nvidia-smi, so nothing needs installing inside.
+const gpuValidationImage = "images:ubuntu/24.04"
+
+// Readiness loop tuning. Package vars (not consts) so tests can shrink them.
+var (
+	gpuValidationReadyTries = 15
+	gpuValidationReadyDelay = 1 * time.Second
+)
+
+// GPU validation status values (mirror the proto GPUStatus enum).
+const (
+	GPUStatusOK          = "ok"
+	GPUStatusUnavailable = "unavailable"
+)
+
+// GPUValidationResult is the outcome of a passthrough check.
+type GPUValidationResult struct {
+	Status        string // GPUStatusOK | GPUStatusUnavailable
+	Model         string // e.g. "NVIDIA GeForce RTX 3090"
+	DriverVersion string // e.g. "570.211.01"
+	Detail        string // populated when Status != ok
+}
+
+// ValidateGPU launches a throwaway nvidia.runtime LXC, attaches the GPU (a
+// specific PCI address if given, else all GPUs), runs nvidia-smi inside, and
+// tears the container down. Returns the parsed model + driver on success; the
+// throwaway is always deleted (best-effort) once it exists, even on failure.
+//
+// This is the daemon-side counterpart of scripts/validate-gpu-passthrough.sh
+// (hardware-verified on an RTX 3090 host): the create→nvidia.runtime→start→
+// nvidia-smi sequence was confirmed live before this landed. Never returns an
+// error — a failed check is reported as Status=unavailable with a Detail, so a
+// CPU-only or mis-bound backend reads cleanly rather than erroring.
+func (m *Manager) ValidateGPU(pci string) GPUValidationResult {
+	ct := fmt.Sprintf("gpuval-%d", time.Now().UnixNano())
+
+	cfg := incus.ContainerConfig{Name: ct, Image: gpuValidationImage}
+	if pci != "" {
+		cfg.GPU = &incus.GPUDevice{PCI: pci}
+	} else {
+		cfg.GPU = &incus.GPUDevice{} // empty = pass through all GPUs
+	}
+
+	if err := m.incus.CreateContainer(cfg); err != nil {
+		return GPUValidationResult{Status: GPUStatusUnavailable, Detail: fmt.Sprintf("create throwaway LXC: %v", err)}
+	}
+	// From here the container exists — always tear it down.
+	defer func() { _ = m.incus.DeleteContainer(ct) }()
+
+	// nvidia.runtime makes Incus inject the host NVIDIA driver + nvidia-smi at
+	// start (set on the stopped instance, before start).
+	if err := m.incus.SetConfig(ct, "nvidia.runtime", "true"); err != nil {
+		return GPUValidationResult{Status: GPUStatusUnavailable, Detail: fmt.Sprintf("set nvidia.runtime: %v", err)}
+	}
+	if err := m.incus.StartContainer(ct); err != nil {
+		return GPUValidationResult{Status: GPUStatusUnavailable, Detail: fmt.Sprintf("start throwaway LXC: %v", err)}
+	}
+
+	// Wait for the container to be exec-ready, then query the GPU.
+	var out string
+	var lastErr error
+	for i := 0; i < gpuValidationReadyTries; i++ {
+		o, _, err := m.incus.ExecWithOutput(ct, []string{
+			"nvidia-smi", "--query-gpu=name,driver_version", "--format=csv,noheader",
+		})
+		if err == nil && strings.TrimSpace(o) != "" {
+			out = o
+			break
+		}
+		lastErr = err
+		time.Sleep(gpuValidationReadyDelay)
+	}
+
+	if strings.TrimSpace(out) == "" {
+		detail := "nvidia-smi returned no GPU (passthrough not visible inside the LXC)"
+		if lastErr != nil {
+			detail = fmt.Sprintf("nvidia-smi did not run: %v", lastErr)
+		}
+		return GPUValidationResult{Status: GPUStatusUnavailable, Detail: detail}
+	}
+
+	model, driver := parseNvidiaSmiCSV(out)
+	if model == "" {
+		return GPUValidationResult{Status: GPUStatusUnavailable, Detail: "could not parse nvidia-smi output: " + strings.TrimSpace(out)}
+	}
+	return GPUValidationResult{Status: GPUStatusOK, Model: model, DriverVersion: driver}
+}
+
+// parseNvidiaSmiCSV parses the first line of
+// `nvidia-smi --query-gpu=name,driver_version --format=csv,noheader`,
+// e.g. "NVIDIA GeForce RTX 3090, 570.211.01".
+func parseNvidiaSmiCSV(out string) (model, driver string) {
+	line := strings.TrimSpace(strings.SplitN(out, "\n", 2)[0])
+	if line == "" {
+		return "", ""
+	}
+	parts := strings.SplitN(line, ",", 2)
+	model = strings.TrimSpace(parts[0])
+	if len(parts) > 1 {
+		driver = strings.TrimSpace(parts[1])
+	}
+	return model, driver
+}

--- a/pkg/core/container/validate_gpu_test.go
+++ b/pkg/core/container/validate_gpu_test.go
@@ -1,0 +1,133 @@
+package container
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+)
+
+func init() {
+	// Keep the readiness loop instant in tests.
+	gpuValidationReadyTries = 1
+	gpuValidationReadyDelay = 0
+}
+
+func TestParseNvidiaSmiCSV(t *testing.T) {
+	cases := []struct{ in, model, driver string }{
+		{"NVIDIA GeForce RTX 3090, 570.211.01", "NVIDIA GeForce RTX 3090", "570.211.01"},
+		{"NVIDIA GeForce RTX 3090, 570.211.01\nNVIDIA A100, 535.0", "NVIDIA GeForce RTX 3090", "570.211.01"},
+		{"  NVIDIA L4 ,  550.x  ", "NVIDIA L4", "550.x"},
+		{"", "", ""},
+		{"weird-no-comma", "weird-no-comma", ""},
+	}
+	for _, c := range cases {
+		m, d := parseNvidiaSmiCSV(c.in)
+		if m != c.model || d != c.driver {
+			t.Errorf("parseNvidiaSmiCSV(%q) = (%q, %q), want (%q, %q)", c.in, m, d, c.model, c.driver)
+		}
+	}
+}
+
+func TestValidateGPU_OK(t *testing.T) {
+	var created incus.ContainerConfig
+	var nvruntime string
+	started, deleted := false, false
+	mock := &incustest.MockBackend{
+		CreateContainerFunc: func(cfg incus.ContainerConfig) error { created = cfg; return nil },
+		SetConfigFunc: func(_, k, v string) error {
+			if k == "nvidia.runtime" {
+				nvruntime = v
+			}
+			return nil
+		},
+		StartContainerFunc:  func(string) error { started = true; return nil },
+		DeleteContainerFunc: func(string) error { deleted = true; return nil },
+		ExecWithOutputFunc: func(_ string, _ []string) (string, string, error) {
+			return "NVIDIA GeForce RTX 3090, 570.211.01\n", "", nil
+		},
+	}
+	m := NewWithBackend(mock)
+
+	got := m.ValidateGPU("0000:01:00.0")
+
+	if got.Status != GPUStatusOK {
+		t.Fatalf("status = %q (detail %q), want ok", got.Status, got.Detail)
+	}
+	if got.Model != "NVIDIA GeForce RTX 3090" || got.DriverVersion != "570.211.01" {
+		t.Errorf("model/driver = %q / %q", got.Model, got.DriverVersion)
+	}
+	if created.GPU == nil || created.GPU.PCI != "0000:01:00.0" {
+		t.Errorf("expected throwaway created with GPU pci=0000:01:00.0, got %+v", created.GPU)
+	}
+	if nvruntime != "true" {
+		t.Errorf("expected nvidia.runtime=true set, got %q", nvruntime)
+	}
+	if !started {
+		t.Error("expected the throwaway to be started")
+	}
+	if !deleted {
+		t.Error("expected the throwaway to be deleted (teardown)")
+	}
+}
+
+func TestValidateGPU_AllGPUsWhenNoPCI(t *testing.T) {
+	var created incus.ContainerConfig
+	mock := &incustest.MockBackend{
+		CreateContainerFunc: func(cfg incus.ContainerConfig) error { created = cfg; return nil },
+		ExecWithOutputFunc: func(_ string, _ []string) (string, string, error) {
+			return "NVIDIA L4, 550.0\n", "", nil
+		},
+	}
+	got := NewWithBackend(mock).ValidateGPU("")
+	if got.Status != GPUStatusOK {
+		t.Fatalf("status = %q, want ok", got.Status)
+	}
+	if created.GPU == nil || created.GPU.PCI != "" {
+		t.Errorf("expected GPU device with empty PCI (all GPUs), got %+v", created.GPU)
+	}
+}
+
+func TestValidateGPU_NoGPU_TearsDown(t *testing.T) {
+	deleted := false
+	mock := &incustest.MockBackend{
+		DeleteContainerFunc: func(string) error { deleted = true; return nil },
+		ExecWithOutputFunc: func(_ string, _ []string) (string, string, error) {
+			return "", "", errors.New("nvidia-smi: command not found")
+		},
+	}
+	got := NewWithBackend(mock).ValidateGPU("")
+	if got.Status != GPUStatusUnavailable {
+		t.Fatalf("status = %q, want unavailable", got.Status)
+	}
+	if got.Detail == "" {
+		t.Error("expected a Detail explaining the failure")
+	}
+	if !deleted {
+		t.Error("expected teardown even when validation fails")
+	}
+}
+
+func TestValidateGPU_CreateFails_NoTeardown(t *testing.T) {
+	deleteCalled := false
+	mock := &incustest.MockBackend{
+		CreateContainerFunc: func(incus.ContainerConfig) error { return errors.New("no GPU device on host") },
+		DeleteContainerFunc: func(string) error { deleteCalled = true; return nil },
+	}
+	got := NewWithBackend(mock).ValidateGPU("")
+	if got.Status != GPUStatusUnavailable {
+		t.Fatalf("status = %q, want unavailable", got.Status)
+	}
+	if deleteCalled {
+		t.Error("must not attempt teardown when the throwaway was never created")
+	}
+}
+
+// Guard: the readiness knobs are tiny in tests so failures don't sleep.
+func TestValidateGPU_ReadyKnobsSmallInTests(t *testing.T) {
+	if gpuValidationReadyDelay != 0 || gpuValidationReadyTries != 1 {
+		t.Fatalf("test init() should have shrunk readiness knobs; got tries=%d delay=%v",
+			gpuValidationReadyTries, gpuValidationReadyDelay)
+	}
+}

--- a/pkg/pb/containarium/v1/config.pb.go
+++ b/pkg/pb/containarium/v1/config.pb.go
@@ -244,6 +244,58 @@ func (BackendType) EnumDescriptor() ([]byte, []int) {
 	return file_containarium_v1_config_proto_rawDescGZIP(), []int{2}
 }
 
+type ValidateGPUResponse_GPUStatus int32
+
+const (
+	ValidateGPUResponse_GPU_STATUS_UNSPECIFIED ValidateGPUResponse_GPUStatus = 0
+	ValidateGPUResponse_GPU_STATUS_OK          ValidateGPUResponse_GPUStatus = 1 // nvidia-smi saw the GPU inside the LXC
+	ValidateGPUResponse_GPU_STATUS_UNAVAILABLE ValidateGPUResponse_GPUStatus = 2 // no GPU / passthrough not visible / setup failed
+	ValidateGPUResponse_GPU_STATUS_DEGRADED    ValidateGPUResponse_GPUStatus = 3 // reserved (e.g. present but reporting errors)
+)
+
+// Enum value maps for ValidateGPUResponse_GPUStatus.
+var (
+	ValidateGPUResponse_GPUStatus_name = map[int32]string{
+		0: "GPU_STATUS_UNSPECIFIED",
+		1: "GPU_STATUS_OK",
+		2: "GPU_STATUS_UNAVAILABLE",
+		3: "GPU_STATUS_DEGRADED",
+	}
+	ValidateGPUResponse_GPUStatus_value = map[string]int32{
+		"GPU_STATUS_UNSPECIFIED": 0,
+		"GPU_STATUS_OK":          1,
+		"GPU_STATUS_UNAVAILABLE": 2,
+		"GPU_STATUS_DEGRADED":    3,
+	}
+)
+
+func (x ValidateGPUResponse_GPUStatus) Enum() *ValidateGPUResponse_GPUStatus {
+	p := new(ValidateGPUResponse_GPUStatus)
+	*p = x
+	return p
+}
+
+func (x ValidateGPUResponse_GPUStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ValidateGPUResponse_GPUStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_containarium_v1_config_proto_enumTypes[3].Descriptor()
+}
+
+func (ValidateGPUResponse_GPUStatus) Type() protoreflect.EnumType {
+	return &file_containarium_v1_config_proto_enumTypes[3]
+}
+
+func (x ValidateGPUResponse_GPUStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ValidateGPUResponse_GPUStatus.Descriptor instead.
+func (ValidateGPUResponse_GPUStatus) EnumDescriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{16, 0}
+}
+
 // Config represents the system-wide configuration for Containarium
 type Config struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1402,6 +1454,142 @@ func (x *GetLatestReleaseResponse) GetUpdateAvailable() bool {
 	return false
 }
 
+// ValidateGPURequest asks a backend to prove GPU passthrough works from inside
+// an LXC. See #316.
+type ValidateGPURequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Backend to validate. Empty = the local/primary daemon's own host.
+	BackendId string `protobuf:"bytes,1,opt,name=backend_id,json=backendId,proto3" json:"backend_id,omitempty"`
+	// Specific GPU PCI address (e.g. "0000:01:00.0"). Empty = pass through all
+	// GPUs. Prefer PCI over a DRM index — it's stable across kernel upgrades.
+	Pci           string `protobuf:"bytes,2,opt,name=pci,proto3" json:"pci,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ValidateGPURequest) Reset() {
+	*x = ValidateGPURequest{}
+	mi := &file_containarium_v1_config_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ValidateGPURequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ValidateGPURequest) ProtoMessage() {}
+
+func (x *ValidateGPURequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ValidateGPURequest.ProtoReflect.Descriptor instead.
+func (*ValidateGPURequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ValidateGPURequest) GetBackendId() string {
+	if x != nil {
+		return x.BackendId
+	}
+	return ""
+}
+
+func (x *ValidateGPURequest) GetPci() string {
+	if x != nil {
+		return x.Pci
+	}
+	return ""
+}
+
+// ValidateGPUResponse reports whether the GPU is usable from inside an LXC on
+// the backend: the daemon launches a throwaway nvidia.runtime LXC, runs
+// nvidia-smi inside, tears it down, and returns the parsed model + driver.
+type ValidateGPUResponse struct {
+	state         protoimpl.MessageState        `protogen:"open.v1"`
+	Status        ValidateGPUResponse_GPUStatus `protobuf:"varint,1,opt,name=status,proto3,enum=containarium.v1.ValidateGPUResponse_GPUStatus" json:"status,omitempty"`
+	GpuModel      string                        `protobuf:"bytes,2,opt,name=gpu_model,json=gpuModel,proto3" json:"gpu_model,omitempty"`                // e.g. "NVIDIA GeForce RTX 3090"
+	DriverVersion string                        `protobuf:"bytes,3,opt,name=driver_version,json=driverVersion,proto3" json:"driver_version,omitempty"` // e.g. "570.211.01"
+	Detail        string                        `protobuf:"bytes,4,opt,name=detail,proto3" json:"detail,omitempty"`                                    // populated when status != OK
+	BackendId     string                        `protobuf:"bytes,5,opt,name=backend_id,json=backendId,proto3" json:"backend_id,omitempty"`             // echoes the validated backend ("" = local)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ValidateGPUResponse) Reset() {
+	*x = ValidateGPUResponse{}
+	mi := &file_containarium_v1_config_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ValidateGPUResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ValidateGPUResponse) ProtoMessage() {}
+
+func (x *ValidateGPUResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ValidateGPUResponse.ProtoReflect.Descriptor instead.
+func (*ValidateGPUResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *ValidateGPUResponse) GetStatus() ValidateGPUResponse_GPUStatus {
+	if x != nil {
+		return x.Status
+	}
+	return ValidateGPUResponse_GPU_STATUS_UNSPECIFIED
+}
+
+func (x *ValidateGPUResponse) GetGpuModel() string {
+	if x != nil {
+		return x.GpuModel
+	}
+	return ""
+}
+
+func (x *ValidateGPUResponse) GetDriverVersion() string {
+	if x != nil {
+		return x.DriverVersion
+	}
+	return ""
+}
+
+func (x *ValidateGPUResponse) GetDetail() string {
+	if x != nil {
+		return x.Detail
+	}
+	return ""
+}
+
+func (x *ValidateGPUResponse) GetBackendId() string {
+	if x != nil {
+		return x.BackendId
+	}
+	return ""
+}
+
 // BackendInfo contains information about a backend instance
 type BackendInfo struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1419,7 +1607,7 @@ type BackendInfo struct {
 
 func (x *BackendInfo) Reset() {
 	*x = BackendInfo{}
-	mi := &file_containarium_v1_config_proto_msgTypes[15]
+	mi := &file_containarium_v1_config_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1431,7 +1619,7 @@ func (x *BackendInfo) String() string {
 func (*BackendInfo) ProtoMessage() {}
 
 func (x *BackendInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[15]
+	mi := &file_containarium_v1_config_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1444,7 +1632,7 @@ func (x *BackendInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackendInfo.ProtoReflect.Descriptor instead.
 func (*BackendInfo) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{15}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *BackendInfo) GetId() string {
@@ -1484,7 +1672,7 @@ type ListBackendsRequest struct {
 
 func (x *ListBackendsRequest) Reset() {
 	*x = ListBackendsRequest{}
-	mi := &file_containarium_v1_config_proto_msgTypes[16]
+	mi := &file_containarium_v1_config_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1496,7 +1684,7 @@ func (x *ListBackendsRequest) String() string {
 func (*ListBackendsRequest) ProtoMessage() {}
 
 func (x *ListBackendsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[16]
+	mi := &file_containarium_v1_config_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1509,7 +1697,7 @@ func (x *ListBackendsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendsRequest.ProtoReflect.Descriptor instead.
 func (*ListBackendsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{16}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{18}
 }
 
 // ListBackendsResponse is the response from listing backends
@@ -1523,7 +1711,7 @@ type ListBackendsResponse struct {
 
 func (x *ListBackendsResponse) Reset() {
 	*x = ListBackendsResponse{}
-	mi := &file_containarium_v1_config_proto_msgTypes[17]
+	mi := &file_containarium_v1_config_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1535,7 +1723,7 @@ func (x *ListBackendsResponse) String() string {
 func (*ListBackendsResponse) ProtoMessage() {}
 
 func (x *ListBackendsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[17]
+	mi := &file_containarium_v1_config_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1548,7 +1736,7 @@ func (x *ListBackendsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendsResponse.ProtoReflect.Descriptor instead.
 func (*ListBackendsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{17}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ListBackendsResponse) GetBackends() []*BackendInfo {
@@ -1655,7 +1843,23 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\x18GetLatestReleaseResponse\x12%\n" +
 	"\x0elatest_release\x18\x01 \x01(\tR\rlatestRelease\x12'\n" +
 	"\x0fcurrent_version\x18\x02 \x01(\tR\x0ecurrentVersion\x12)\n" +
-	"\x10update_available\x18\x03 \x01(\bR\x0fupdateAvailable\"\x85\x01\n" +
+	"\x10update_available\x18\x03 \x01(\bR\x0fupdateAvailable\"E\n" +
+	"\x12ValidateGPURequest\x12\x1d\n" +
+	"\n" +
+	"backend_id\x18\x01 \x01(\tR\tbackendId\x12\x10\n" +
+	"\x03pci\x18\x02 \x01(\tR\x03pci\"\xc9\x02\n" +
+	"\x13ValidateGPUResponse\x12F\n" +
+	"\x06status\x18\x01 \x01(\x0e2..containarium.v1.ValidateGPUResponse.GPUStatusR\x06status\x12\x1b\n" +
+	"\tgpu_model\x18\x02 \x01(\tR\bgpuModel\x12%\n" +
+	"\x0edriver_version\x18\x03 \x01(\tR\rdriverVersion\x12\x16\n" +
+	"\x06detail\x18\x04 \x01(\tR\x06detail\x12\x1d\n" +
+	"\n" +
+	"backend_id\x18\x05 \x01(\tR\tbackendId\"o\n" +
+	"\tGPUStatus\x12\x1a\n" +
+	"\x16GPU_STATUS_UNSPECIFIED\x10\x00\x12\x11\n" +
+	"\rGPU_STATUS_OK\x10\x01\x12\x1a\n" +
+	"\x16GPU_STATUS_UNAVAILABLE\x10\x02\x12\x17\n" +
+	"\x13GPU_STATUS_DEGRADED\x10\x03\"\x85\x01\n" +
 	"\vBackendInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x120\n" +
 	"\x04type\x18\x02 \x01(\x0e2\x1c.containarium.v1.BackendTypeR\x04type\x12\x18\n" +
@@ -1712,55 +1916,59 @@ func file_containarium_v1_config_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_config_proto_rawDescData
 }
 
-var file_containarium_v1_config_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_containarium_v1_config_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_containarium_v1_config_proto_goTypes = []any{
-	(GPUVendor)(0),                   // 0: containarium.v1.GPUVendor
-	(GPUModel)(0),                    // 1: containarium.v1.GPUModel
-	(BackendType)(0),                 // 2: containarium.v1.BackendType
-	(*Config)(nil),                   // 3: containarium.v1.Config
-	(*IncusConfig)(nil),              // 4: containarium.v1.IncusConfig
-	(*NetworkConfig)(nil),            // 5: containarium.v1.NetworkConfig
-	(*StorageConfig)(nil),            // 6: containarium.v1.StorageConfig
-	(*SecurityConfig)(nil),           // 7: containarium.v1.SecurityConfig
-	(*GetConfigRequest)(nil),         // 8: containarium.v1.GetConfigRequest
-	(*GetConfigResponse)(nil),        // 9: containarium.v1.GetConfigResponse
-	(*UpdateConfigRequest)(nil),      // 10: containarium.v1.UpdateConfigRequest
-	(*UpdateConfigResponse)(nil),     // 11: containarium.v1.UpdateConfigResponse
-	(*SystemInfo)(nil),               // 12: containarium.v1.SystemInfo
-	(*GPUInfo)(nil),                  // 13: containarium.v1.GPUInfo
-	(*GetSystemInfoRequest)(nil),     // 14: containarium.v1.GetSystemInfoRequest
-	(*GetSystemInfoResponse)(nil),    // 15: containarium.v1.GetSystemInfoResponse
-	(*GetLatestReleaseRequest)(nil),  // 16: containarium.v1.GetLatestReleaseRequest
-	(*GetLatestReleaseResponse)(nil), // 17: containarium.v1.GetLatestReleaseResponse
-	(*BackendInfo)(nil),              // 18: containarium.v1.BackendInfo
-	(*ListBackendsRequest)(nil),      // 19: containarium.v1.ListBackendsRequest
-	(*ListBackendsResponse)(nil),     // 20: containarium.v1.ListBackendsResponse
-	(*ResourceLimits)(nil),           // 21: containarium.v1.ResourceLimits
-	(OSType)(0),                      // 22: containarium.v1.OSType
+	(GPUVendor)(0),                     // 0: containarium.v1.GPUVendor
+	(GPUModel)(0),                      // 1: containarium.v1.GPUModel
+	(BackendType)(0),                   // 2: containarium.v1.BackendType
+	(ValidateGPUResponse_GPUStatus)(0), // 3: containarium.v1.ValidateGPUResponse.GPUStatus
+	(*Config)(nil),                     // 4: containarium.v1.Config
+	(*IncusConfig)(nil),                // 5: containarium.v1.IncusConfig
+	(*NetworkConfig)(nil),              // 6: containarium.v1.NetworkConfig
+	(*StorageConfig)(nil),              // 7: containarium.v1.StorageConfig
+	(*SecurityConfig)(nil),             // 8: containarium.v1.SecurityConfig
+	(*GetConfigRequest)(nil),           // 9: containarium.v1.GetConfigRequest
+	(*GetConfigResponse)(nil),          // 10: containarium.v1.GetConfigResponse
+	(*UpdateConfigRequest)(nil),        // 11: containarium.v1.UpdateConfigRequest
+	(*UpdateConfigResponse)(nil),       // 12: containarium.v1.UpdateConfigResponse
+	(*SystemInfo)(nil),                 // 13: containarium.v1.SystemInfo
+	(*GPUInfo)(nil),                    // 14: containarium.v1.GPUInfo
+	(*GetSystemInfoRequest)(nil),       // 15: containarium.v1.GetSystemInfoRequest
+	(*GetSystemInfoResponse)(nil),      // 16: containarium.v1.GetSystemInfoResponse
+	(*GetLatestReleaseRequest)(nil),    // 17: containarium.v1.GetLatestReleaseRequest
+	(*GetLatestReleaseResponse)(nil),   // 18: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPURequest)(nil),         // 19: containarium.v1.ValidateGPURequest
+	(*ValidateGPUResponse)(nil),        // 20: containarium.v1.ValidateGPUResponse
+	(*BackendInfo)(nil),                // 21: containarium.v1.BackendInfo
+	(*ListBackendsRequest)(nil),        // 22: containarium.v1.ListBackendsRequest
+	(*ListBackendsResponse)(nil),       // 23: containarium.v1.ListBackendsResponse
+	(*ResourceLimits)(nil),             // 24: containarium.v1.ResourceLimits
+	(OSType)(0),                        // 25: containarium.v1.OSType
 }
 var file_containarium_v1_config_proto_depIdxs = []int32{
-	4,  // 0: containarium.v1.Config.incus:type_name -> containarium.v1.IncusConfig
-	21, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
-	5,  // 2: containarium.v1.Config.network:type_name -> containarium.v1.NetworkConfig
-	6,  // 3: containarium.v1.Config.storage:type_name -> containarium.v1.StorageConfig
-	7,  // 4: containarium.v1.Config.security:type_name -> containarium.v1.SecurityConfig
-	22, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
-	3,  // 6: containarium.v1.GetConfigResponse.config:type_name -> containarium.v1.Config
-	3,  // 7: containarium.v1.UpdateConfigRequest.config:type_name -> containarium.v1.Config
-	3,  // 8: containarium.v1.UpdateConfigResponse.config:type_name -> containarium.v1.Config
-	13, // 9: containarium.v1.SystemInfo.gpus:type_name -> containarium.v1.GPUInfo
+	5,  // 0: containarium.v1.Config.incus:type_name -> containarium.v1.IncusConfig
+	24, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
+	6,  // 2: containarium.v1.Config.network:type_name -> containarium.v1.NetworkConfig
+	7,  // 3: containarium.v1.Config.storage:type_name -> containarium.v1.StorageConfig
+	8,  // 4: containarium.v1.Config.security:type_name -> containarium.v1.SecurityConfig
+	25, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
+	4,  // 6: containarium.v1.GetConfigResponse.config:type_name -> containarium.v1.Config
+	4,  // 7: containarium.v1.UpdateConfigRequest.config:type_name -> containarium.v1.Config
+	4,  // 8: containarium.v1.UpdateConfigResponse.config:type_name -> containarium.v1.Config
+	14, // 9: containarium.v1.SystemInfo.gpus:type_name -> containarium.v1.GPUInfo
 	0,  // 10: containarium.v1.GPUInfo.vendor:type_name -> containarium.v1.GPUVendor
 	1,  // 11: containarium.v1.GPUInfo.model:type_name -> containarium.v1.GPUModel
-	12, // 12: containarium.v1.GetSystemInfoResponse.info:type_name -> containarium.v1.SystemInfo
-	12, // 13: containarium.v1.GetSystemInfoResponse.peers:type_name -> containarium.v1.SystemInfo
-	2,  // 14: containarium.v1.BackendInfo.type:type_name -> containarium.v1.BackendType
-	18, // 15: containarium.v1.ListBackendsResponse.backends:type_name -> containarium.v1.BackendInfo
-	16, // [16:16] is the sub-list for method output_type
-	16, // [16:16] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	13, // 12: containarium.v1.GetSystemInfoResponse.info:type_name -> containarium.v1.SystemInfo
+	13, // 13: containarium.v1.GetSystemInfoResponse.peers:type_name -> containarium.v1.SystemInfo
+	3,  // 14: containarium.v1.ValidateGPUResponse.status:type_name -> containarium.v1.ValidateGPUResponse.GPUStatus
+	2,  // 15: containarium.v1.BackendInfo.type:type_name -> containarium.v1.BackendType
+	21, // 16: containarium.v1.ListBackendsResponse.backends:type_name -> containarium.v1.BackendInfo
+	17, // [17:17] is the sub-list for method output_type
+	17, // [17:17] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_config_proto_init() }
@@ -1774,8 +1982,8 @@ func file_containarium_v1_config_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_config_proto_rawDesc), len(file_containarium_v1_config_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   18,
+			NumEnums:      4,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xa6e\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xe2g\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -84,7 +84,9 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\rGetSystemInfo\x12%.containarium.v1.GetSystemInfoRequest\x1a&.containarium.v1.GetSystemInfoResponse\"\xaa\x01\x92A\x8f\x01\n" +
 	"\x06System\x12\x16Get system information\x1amReturns information about the host system including Incus version, available resources, and container counts.\x82\xd3\xe4\x93\x02\x11\x12\x0f/v1/system/info\x12\xb4\x02\n" +
 	"\x10GetLatestRelease\x12(.containarium.v1.GetLatestReleaseRequest\x1a).containarium.v1.GetLatestReleaseResponse\"\xca\x01\x92A\xab\x01\n" +
-	"\x06System\x12\x12Get latest release\x1a\x8c\x01Returns the latest Containarium release tag from GitHub (cached) alongside this daemon's running version and whether an update is available.\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/releases/latest\x12\xb7\x02\n" +
+	"\x06System\x12\x12Get latest release\x1a\x8c\x01Returns the latest Containarium release tag from GitHub (cached) alongside this daemon's running version and whether an update is available.\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/releases/latest\x12\xb9\x02\n" +
+	"\vValidateGPU\x12#.containarium.v1.ValidateGPURequest\x1a$.containarium.v1.ValidateGPUResponse\"\xde\x01\x92A\xbf\x01\n" +
+	"\x06System\x12\x18Validate GPU passthrough\x1a\x9a\x01Launches a throwaway nvidia.runtime LXC on the backend, runs nvidia-smi inside, and returns whether the GPU is usable (status, model, driver). Admin-only.\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/v1/validate-gpu\x12\xb7\x02\n" +
 	"\x11GetMonitoringInfo\x12).containarium.v1.GetMonitoringInfoRequest\x1a*.containarium.v1.GetMonitoringInfoResponse\"\xca\x01\x92A\xa9\x01\n" +
 	"\n" +
 	"Monitoring\x12\x1aGet monitoring information\x1a\x7fReturns monitoring configuration including Grafana and VictoriaMetrics URLs. Used by the web UI to embed the Grafana dashboard.\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/system/monitoring\x12\x87\x02\n" +
@@ -155,62 +157,64 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*ListStacksRequest)(nil),              // 21: containarium.v1.ListStacksRequest
 	(*GetSystemInfoRequest)(nil),           // 22: containarium.v1.GetSystemInfoRequest
 	(*GetLatestReleaseRequest)(nil),        // 23: containarium.v1.GetLatestReleaseRequest
-	(*GetMonitoringInfoRequest)(nil),       // 24: containarium.v1.GetMonitoringInfoRequest
-	(*CreateAlertRuleRequest)(nil),         // 25: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),          // 26: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),            // 27: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),         // 28: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),         // 29: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),         // 30: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),   // 31: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),    // 32: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),             // 33: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),   // 34: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),               // 35: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),               // 36: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),             // 37: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),            // 38: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),          // 39: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),        // 40: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),         // 41: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),           // 42: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),         // 43: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),        // 44: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),         // 45: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),          // 46: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),        // 47: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),          // 48: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerResponse)(nil), // 49: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),       // 50: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),        // 51: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),        // 52: containarium.v1.SetContainerTTLResponse
-	(*AddSSHKeyResponse)(nil),              // 53: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),           // 54: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),        // 55: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),     // 56: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),      // 57: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),             // 58: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),            // 59: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),           // 60: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),             // 61: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),          // 62: containarium.v1.GetSystemInfoResponse
-	(*GetLatestReleaseResponse)(nil),       // 63: containarium.v1.GetLatestReleaseResponse
-	(*GetMonitoringInfoResponse)(nil),      // 64: containarium.v1.GetMonitoringInfoResponse
-	(*CreateAlertRuleResponse)(nil),        // 65: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),         // 66: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),           // 67: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),        // 68: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),        // 69: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),        // 70: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),  // 71: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),   // 72: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),            // 73: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),  // 74: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),              // 75: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),              // 76: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),            // 77: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),           // 78: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),         // 79: containarium.v1.RefreshSecretsResponse
+	(*ValidateGPURequest)(nil),             // 24: containarium.v1.ValidateGPURequest
+	(*GetMonitoringInfoRequest)(nil),       // 25: containarium.v1.GetMonitoringInfoRequest
+	(*CreateAlertRuleRequest)(nil),         // 26: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),          // 27: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),            // 28: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),         // 29: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),         // 30: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),         // 31: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),   // 32: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),    // 33: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),             // 34: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),   // 35: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),               // 36: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),               // 37: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),             // 38: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),            // 39: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),          // 40: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),        // 41: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),         // 42: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),           // 43: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),         // 44: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),        // 45: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),         // 46: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),          // 47: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),        // 48: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),          // 49: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerResponse)(nil), // 50: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),       // 51: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),        // 52: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),        // 53: containarium.v1.SetContainerTTLResponse
+	(*AddSSHKeyResponse)(nil),              // 54: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),           // 55: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),        // 56: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),     // 57: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),      // 58: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),             // 59: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),            // 60: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),           // 61: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),             // 62: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),          // 63: containarium.v1.GetSystemInfoResponse
+	(*GetLatestReleaseResponse)(nil),       // 64: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),            // 65: containarium.v1.ValidateGPUResponse
+	(*GetMonitoringInfoResponse)(nil),      // 66: containarium.v1.GetMonitoringInfoResponse
+	(*CreateAlertRuleResponse)(nil),        // 67: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),         // 68: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),           // 69: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),        // 70: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),        // 71: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),        // 72: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),  // 73: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),   // 74: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),            // 75: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),  // 76: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),              // 77: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),              // 78: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),            // 79: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),           // 80: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),         // 81: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -237,64 +241,66 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	21, // 21: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
 	22, // 22: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
 	23, // 23: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
-	24, // 24: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	25, // 25: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	26, // 26: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	27, // 27: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	28, // 28: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	29, // 29: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	30, // 30: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	31, // 31: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	32, // 32: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	33, // 33: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	34, // 34: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	35, // 35: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	36, // 36: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	37, // 37: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	38, // 38: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	39, // 39: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	40, // 40: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	41, // 41: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	42, // 42: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	43, // 43: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	44, // 44: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	45, // 45: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	46, // 46: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	47, // 47: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	48, // 48: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	49, // 49: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	50, // 50: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	51, // 51: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	52, // 52: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	53, // 53: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	54, // 54: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	55, // 55: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	56, // 56: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	57, // 57: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	58, // 58: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	59, // 59: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	60, // 60: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	61, // 61: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	62, // 62: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	63, // 63: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	64, // 64: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	65, // 65: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	66, // 66: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	67, // 67: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	68, // 68: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	69, // 69: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	70, // 70: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	71, // 71: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	72, // 72: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	73, // 73: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	74, // 74: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	75, // 75: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	76, // 76: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	77, // 77: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	78, // 78: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	79, // 79: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	40, // [40:80] is the sub-list for method output_type
-	0,  // [0:40] is the sub-list for method input_type
+	24, // 24: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
+	25, // 25: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	26, // 26: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	27, // 27: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	28, // 28: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	29, // 29: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	30, // 30: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	31, // 31: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	32, // 32: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	33, // 33: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	34, // 34: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	35, // 35: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	36, // 36: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	37, // 37: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	38, // 38: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	39, // 39: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	40, // 40: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	41, // 41: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	42, // 42: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	43, // 43: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	44, // 44: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	45, // 45: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	46, // 46: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	47, // 47: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	48, // 48: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	49, // 49: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	50, // 50: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	51, // 51: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	52, // 52: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	53, // 53: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	54, // 54: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	55, // 55: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	56, // 56: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	57, // 57: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	58, // 58: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	59, // 59: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	60, // 60: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	61, // 61: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	62, // 62: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	63, // 63: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	64, // 64: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	65, // 65: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	66, // 66: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	67, // 67: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	68, // 68: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	69, // 69: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	70, // 70: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	71, // 71: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	72, // 72: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	73, // 73: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	74, // 74: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	75, // 75: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	76, // 76: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	77, // 77: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	78, // 78: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	79, // 79: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	80, // 80: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	81, // 81: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	41, // [41:82] is the sub-list for method output_type
+	0,  // [0:41] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -1054,6 +1054,33 @@ func local_request_ContainerService_GetLatestRelease_0(ctx context.Context, mars
 	return msg, metadata, err
 }
 
+func request_ContainerService_ValidateGPU_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ValidateGPURequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ValidateGPU(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_ValidateGPU_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ValidateGPURequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ValidateGPU(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_GetMonitoringInfo_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq GetMonitoringInfoRequest
@@ -2104,6 +2131,26 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_GetLatestRelease_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_ValidateGPU_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/ValidateGPU", runtime.WithHTTPPathPattern("/v1/validate-gpu"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_ValidateGPU_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_ValidateGPU_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ContainerService_GetMonitoringInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2889,6 +2936,23 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_GetLatestRelease_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_ValidateGPU_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/ValidateGPU", runtime.WithHTTPPathPattern("/v1/validate-gpu"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_ValidateGPU_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_ValidateGPU_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ContainerService_GetMonitoringInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3190,6 +3254,7 @@ var (
 	pattern_ContainerService_ListStacks_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "stacks"}, ""))
 	pattern_ContainerService_GetSystemInfo_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "info"}, ""))
 	pattern_ContainerService_GetLatestRelease_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "releases", "latest"}, ""))
+	pattern_ContainerService_ValidateGPU_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "validate-gpu"}, ""))
 	pattern_ContainerService_GetMonitoringInfo_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "monitoring"}, ""))
 	pattern_ContainerService_CreateAlertRule_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "alerts"}, ""))
 	pattern_ContainerService_ListAlertRules_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "alerts"}, ""))
@@ -3234,6 +3299,7 @@ var (
 	forward_ContainerService_ListStacks_0             = runtime.ForwardResponseMessage
 	forward_ContainerService_GetSystemInfo_0          = runtime.ForwardResponseMessage
 	forward_ContainerService_GetLatestRelease_0       = runtime.ForwardResponseMessage
+	forward_ContainerService_ValidateGPU_0            = runtime.ForwardResponseMessage
 	forward_ContainerService_GetMonitoringInfo_0      = runtime.ForwardResponseMessage
 	forward_ContainerService_CreateAlertRule_0        = runtime.ForwardResponseMessage
 	forward_ContainerService_ListAlertRules_0         = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -43,6 +43,7 @@ const (
 	ContainerService_ListStacks_FullMethodName             = "/containarium.v1.ContainerService/ListStacks"
 	ContainerService_GetSystemInfo_FullMethodName          = "/containarium.v1.ContainerService/GetSystemInfo"
 	ContainerService_GetLatestRelease_FullMethodName       = "/containarium.v1.ContainerService/GetLatestRelease"
+	ContainerService_ValidateGPU_FullMethodName            = "/containarium.v1.ContainerService/ValidateGPU"
 	ContainerService_GetMonitoringInfo_FullMethodName      = "/containarium.v1.ContainerService/GetMonitoringInfo"
 	ContainerService_CreateAlertRule_FullMethodName        = "/containarium.v1.ContainerService/CreateAlertRule"
 	ContainerService_ListAlertRules_FullMethodName         = "/containarium.v1.ContainerService/ListAlertRules"
@@ -158,6 +159,11 @@ type ContainerServiceClient interface {
 	// running version, so operators see "update available" without SSHing in.
 	// The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
 	GetLatestRelease(ctx context.Context, in *GetLatestReleaseRequest, opts ...grpc.CallOption) (*GetLatestReleaseResponse, error)
+	// ValidateGPU proves GPU passthrough works from inside an LXC on a backend:
+	// the daemon launches a throwaway nvidia.runtime LXC, runs nvidia-smi inside,
+	// tears it down, and returns the parsed model + driver. Admin-only; the check
+	// creates and deletes a short-lived container. See #316.
+	ValidateGPU(ctx context.Context, in *ValidateGPURequest, opts ...grpc.CallOption) (*ValidateGPUResponse, error)
 	// GetMonitoringInfo gets monitoring configuration (Grafana/VictoriaMetrics URLs)
 	GetMonitoringInfo(ctx context.Context, in *GetMonitoringInfoRequest, opts ...grpc.CallOption) (*GetMonitoringInfoResponse, error)
 	// CreateAlertRule creates a new custom alert rule
@@ -450,6 +456,16 @@ func (c *containerServiceClient) GetLatestRelease(ctx context.Context, in *GetLa
 	return out, nil
 }
 
+func (c *containerServiceClient) ValidateGPU(ctx context.Context, in *ValidateGPURequest, opts ...grpc.CallOption) (*ValidateGPUResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ValidateGPUResponse)
+	err := c.cc.Invoke(ctx, ContainerService_ValidateGPU_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *containerServiceClient) GetMonitoringInfo(ctx context.Context, in *GetMonitoringInfoRequest, opts ...grpc.CallOption) (*GetMonitoringInfoResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetMonitoringInfoResponse)
@@ -707,6 +723,11 @@ type ContainerServiceServer interface {
 	// running version, so operators see "update available" without SSHing in.
 	// The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
 	GetLatestRelease(context.Context, *GetLatestReleaseRequest) (*GetLatestReleaseResponse, error)
+	// ValidateGPU proves GPU passthrough works from inside an LXC on a backend:
+	// the daemon launches a throwaway nvidia.runtime LXC, runs nvidia-smi inside,
+	// tears it down, and returns the parsed model + driver. Admin-only; the check
+	// creates and deletes a short-lived container. See #316.
+	ValidateGPU(context.Context, *ValidateGPURequest) (*ValidateGPUResponse, error)
 	// GetMonitoringInfo gets monitoring configuration (Grafana/VictoriaMetrics URLs)
 	GetMonitoringInfo(context.Context, *GetMonitoringInfoRequest) (*GetMonitoringInfoResponse, error)
 	// CreateAlertRule creates a new custom alert rule
@@ -830,6 +851,9 @@ func (UnimplementedContainerServiceServer) GetSystemInfo(context.Context, *GetSy
 }
 func (UnimplementedContainerServiceServer) GetLatestRelease(context.Context, *GetLatestReleaseRequest) (*GetLatestReleaseResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetLatestRelease not implemented")
+}
+func (UnimplementedContainerServiceServer) ValidateGPU(context.Context, *ValidateGPURequest) (*ValidateGPUResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ValidateGPU not implemented")
 }
 func (UnimplementedContainerServiceServer) GetMonitoringInfo(context.Context, *GetMonitoringInfoRequest) (*GetMonitoringInfoResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetMonitoringInfo not implemented")
@@ -1332,6 +1356,24 @@ func _ContainerService_GetLatestRelease_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ContainerService_ValidateGPU_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ValidateGPURequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).ValidateGPU(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_ValidateGPU_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).ValidateGPU(ctx, req.(*ValidateGPURequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ContainerService_GetMonitoringInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetMonitoringInfoRequest)
 	if err := dec(in); err != nil {
@@ -1722,6 +1764,10 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetLatestRelease",
 			Handler:    _ContainerService_GetLatestRelease_Handler,
+		},
+		{
+			MethodName: "ValidateGPU",
+			Handler:    _ContainerService_ValidateGPU_Handler,
 		},
 		{
 			MethodName: "GetMonitoringInfo",

--- a/proto/containarium/v1/config.proto
+++ b/proto/containarium/v1/config.proto
@@ -303,6 +303,35 @@ message GetLatestReleaseResponse {
   bool update_available = 3;
 }
 
+// ValidateGPURequest asks a backend to prove GPU passthrough works from inside
+// an LXC. See #316.
+message ValidateGPURequest {
+  // Backend to validate. Empty = the local/primary daemon's own host.
+  string backend_id = 1;
+
+  // Specific GPU PCI address (e.g. "0000:01:00.0"). Empty = pass through all
+  // GPUs. Prefer PCI over a DRM index — it's stable across kernel upgrades.
+  string pci = 2;
+}
+
+// ValidateGPUResponse reports whether the GPU is usable from inside an LXC on
+// the backend: the daemon launches a throwaway nvidia.runtime LXC, runs
+// nvidia-smi inside, tears it down, and returns the parsed model + driver.
+message ValidateGPUResponse {
+  enum GPUStatus {
+    GPU_STATUS_UNSPECIFIED = 0;
+    GPU_STATUS_OK = 1;          // nvidia-smi saw the GPU inside the LXC
+    GPU_STATUS_UNAVAILABLE = 2; // no GPU / passthrough not visible / setup failed
+    GPU_STATUS_DEGRADED = 3;    // reserved (e.g. present but reporting errors)
+  }
+
+  GPUStatus status = 1;
+  string gpu_model = 2;      // e.g. "NVIDIA GeForce RTX 3090"
+  string driver_version = 3; // e.g. "570.211.01"
+  string detail = 4;         // populated when status != OK
+  string backend_id = 5;     // echoes the validated backend ("" = local)
+}
+
 // BackendType represents the type of backend instance
 enum BackendType {
   BACKEND_TYPE_UNSPECIFIED = 0;

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -399,6 +399,22 @@ service ContainerService {
     };
   }
 
+  // ValidateGPU proves GPU passthrough works from inside an LXC on a backend:
+  // the daemon launches a throwaway nvidia.runtime LXC, runs nvidia-smi inside,
+  // tears it down, and returns the parsed model + driver. Admin-only; the check
+  // creates and deletes a short-lived container. See #316.
+  rpc ValidateGPU(ValidateGPURequest) returns (ValidateGPUResponse) {
+    option (google.api.http) = {
+      post: "/v1/validate-gpu"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Validate GPU passthrough";
+      description: "Launches a throwaway nvidia.runtime LXC on the backend, runs nvidia-smi inside, and returns whether the GPU is usable (status, model, driver). Admin-only.";
+      tags: "System";
+    };
+  }
+
   // GetMonitoringInfo gets monitoring configuration (Grafana/VictoriaMetrics URLs)
   rpc GetMonitoringInfo(GetMonitoringInfoRequest) returns (GetMonitoringInfoResponse) {
     option (google.api.http) = {


### PR DESCRIPTION
Closes #316 — the daemon-side `validate-gpu` primitive (the standalone gate script landed in #413). Proto-first per CLAUDE.md: contract → server → CLI → MCP.

## What

Prove a backend's GPU is usable **from inside an LXC** — as a pre-flight before a GPU container, or a re-check after a VFIO/driver change — exposed to operators (CLI), agents (MCP), and the webui (REST).

- **proto** — `ValidateGPU(ValidateGPURequest{backend_id, pci}) → ValidateGPUResponse{GPUStatus enum, gpu_model, driver_version, detail, backend_id}`, `POST /v1/validate-gpu`. Regenerated `pkg/pb` + gateway + swagger.
- **orchestration** (`Manager.ValidateGPU`) — launches a throwaway `nvidia.runtime` LXC (a specific `--pci` GPU or all), runs `nvidia-smi`, parses model+driver, and **always tears the container down** (even on failure). Never returns an error — a failed check is `Status=unavailable` + `detail`, so a CPU-only/mis-bound backend reads cleanly. Uses only existing `Backend` methods → fully mockable.
- **server** — admin-only; empty/local `backend_id` runs locally, a **peer id forwards** via `PeerClient.ForwardRequest` so the peer validates its *own* GPU (the real multi-backend use case — validating the GPU nodes).
- **CLI** (CLI-first) — `containarium backends validate-gpu [backend-id] [--pci <addr>] [--format text|json]`; a non-OK result is a non-zero exit (gate-friendly in CI/scripts).
- **MCP** (wraps it) — `backend_validate_gpu` tool + typed client method.

## Strong typing (addressing review)

Request bodies are typed structs (`ValidateGPURequest` / `validateGPUReq`) with snake_case tags, not raw maps. The only `map[string]interface{}` left is the MCP **tool-args** boundary (InputSchema + handler args), which CLAUDE.md exempts.

## Verification

- **Hardware-verified on an RTX 3090 host** (`fts-13700k`, Incus 6.23, driver 570.211.01): the exact `create → nvidia.runtime → start → nvidia-smi` sequence the orchestration performs returns `NVIDIA GeForce RTX 3090, 570.211.01` and leaves no throwaway container behind. (The standalone gate script #413 was live-tested there too.)
- **Unit tests** for the orchestration via a command-capturing mock backend: ok path (asserts GPU device + `nvidia.runtime=true` + start + teardown), all-GPUs-when-no-PCI, no-GPU→unavailable+teardown, create-fail→no-teardown, and the nvidia-smi CSV parser.
- `go build ./...`, `go vet`, and `go test ./pkg/core/container/ ./internal/cmd/ ./internal/mcp/` all green (bumped the MCP tool-count assertion 39→40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)