### PR TITLE
fix(ebpf-phase0): clang bpf build needs the multiarch include path (#315)

### DIFF
--- a/experimental/ebpf-phase0/counter.bpf.c
+++ b/experimental/ebpf-phase0/counter.bpf.c
@@ -9,8 +9,10 @@
 // If those three hold, Phase A productionalizes; if any fails, the
 // design needs to be revised before the user-facing work starts.
 //
-// Build:
-//   clang -O2 -g -target bpf -c counter.bpf.c -o counter.bpf.o
+// Build (the multiarch -I lets clang's bpf target find <asm/types.h>,
+// which linux/bpf.h pulls in; without it the build fails on stock Ubuntu):
+//   clang -O2 -g -target bpf -I/usr/include/$(uname -m)-linux-gnu \
+//       -c counter.bpf.c -o counter.bpf.o
 //
 // Requires kernel ≥ 5.4 with BPF + CLS_BPF enabled (Ubuntu 24.04 is
 // fine out of the box).

--- a/experimental/ebpf-phase0/validate.sh
+++ b/experimental/ebpf-phase0/validate.sh
@@ -75,7 +75,12 @@ trap cleanup EXIT
 
 echo "==> 1/5: building BPF object"
 cd "$SCRIPT_DIR"
-clang -O2 -g -target bpf -c counter.bpf.c -o counter.bpf.o
+# linux/bpf.h pulls in <asm/types.h>, which on Debian/Ubuntu lives under the
+# multiarch dir (/usr/include/x86_64-linux-gnu/asm/) — clang's `-target bpf`
+# default search path doesn't include it, so add it explicitly. Without this
+# the build fails on a stock Ubuntu 24.04 with "asm/types.h file not found".
+MULTIARCH_INC="/usr/include/$(uname -m)-linux-gnu"
+clang -O2 -g -target bpf -I"$MULTIARCH_INC" -c counter.bpf.c -o counter.bpf.o
 echo "    OK: counter.bpf.o ($(stat -c%s counter.bpf.o) bytes)"
 
 echo "==> 2/5: attaching to $BRIDGE"


### PR DESCRIPTION
Surfaced by the **first real on-backend run** of eBPF Phase 0 (the whole point of #315).

## Problem

On a stock Ubuntu 24.04 backend (kernel 6.8, Incus 6.23 — the documented target), `validate.sh` fails at step 1/5:

```
/usr/include/linux/types.h:5:10: fatal error: 'asm/types.h' file not found
```

`linux/bpf.h` pulls in `<asm/types.h>`, which on Debian/Ubuntu lives under the multiarch dir `/usr/include/<arch>-linux-gnu/asm/`. clang's `-target bpf` default search path doesn't include it, so the BPF object never builds — the harness couldn't run at all on the documented target.

## Fix

Add `-I/usr/include/$(uname -m)-linux-gnu` to the `clang -target bpf` invocation in `validate.sh` (works for `x86_64` and `aarch64`), and update the build command in the `counter.bpf.c` header comment to match. After the fix the object builds (10704 bytes) and the harness proceeds.

## Verified

On a real Linux+Incus backend (kernel 6.8.0-110, Incus 6.23, clang 18.1.3): build → tc-bpf attach to the bridge → throwaway containers → cleanup all run. Bridge left clean, tenant containers unaffected.

> Note: the validation run itself produced a **separate Phase 0 result** — the bridge master's tc-**egress** hook does not observe inter-container *forwarded* traffic (ingress counter incremented, egress stayed 0), so the "attach to the bridge sees both directions" assumption needs revising before Phase A (attach at the per-container veth instead). That's a design finding tracked on #315, not part of this build fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)