### PR TITLE
fix(edge): stop deactivating layer4 on empty route set (#416)

### DIFF
--- a/internal/app/route_sync.go
+++ b/internal/app/route_sync.go
@@ -246,20 +246,26 @@ func (j *RouteSyncJob) syncHTTPRoutes(dbRoutes []*RouteRecord) error {
 // syncL4Routes synchronizes TLS passthrough routes to the Caddy L4 layer.
 // L4 is lazily activated when passthrough routes exist and deactivated when empty.
 func (j *RouteSyncJob) syncL4Routes(dbRoutes []*RouteRecord) error {
-	if len(dbRoutes) == 0 {
-		// No passthrough routes — deactivate L4 if active
-		if j.l4ProxyManager.IsL4Active() {
-			if err := j.l4ProxyManager.DeactivateL4(); err != nil {
-				log.Printf("[RouteSyncJob] Failed to deactivate L4: %v", err)
-			} else {
-				log.Printf("[RouteSyncJob] L4 deactivated (no passthrough routes)")
-			}
-		}
-		return nil
-	}
-
-	// Passthrough routes exist — ensure L4 is active
+	// L4 ownership of :443 is a one-way latch. Activating L4 moves the HTTP
+	// server off :443 onto the fallback port and hands :443 to the layer4
+	// app; deactivating reverses it. BOTH rewrite the :443 listen address,
+	// which restarts the :443 listener and drops every in-flight TLS
+	// connection on it — including the response of a concurrent container
+	// create (issue #416: edge create returns "tls: internal error" while
+	// the box itself is provisioned). The 5s reconcile previously toggled
+	// activate/deactivate on every 0<->1 transition in the passthrough-route
+	// set, so any container's route churn bounced :443 for everyone.
+	//
+	// Fix: once L4 is active, keep it active. When the route set empties we
+	// drain the SNI routes down to the catch-all (handled by the diff below)
+	// instead of deactivating. A layer4 server holding only the catch-all is
+	// behaviourally identical to the HTTP-on-:443 baseline — non-matching SNI
+	// already falls through to the HTTP fallback — but it never rewrites the
+	// listen address, so the listener is never restarted under live traffic.
 	if !j.l4ProxyManager.IsL4Active() {
+		if len(dbRoutes) == 0 {
+			return nil // never activated and nothing to route — stay lazy
+		}
 		if err := j.l4ProxyManager.ActivateL4(); err != nil {
 			return fmt.Errorf("failed to activate L4: %w", err)
 		}

--- a/internal/app/route_sync_l4_latch_test.go
+++ b/internal/app/route_sync_l4_latch_test.go
@@ -1,0 +1,125 @@
+package app
+
+import (
+	"testing"
+)
+
+// TestSyncL4Routes_LatchesActiveAcrossEmptyRouteSet is the regression test for
+// issue #416: the 5s route reconcile must NOT deactivate L4 (move :443 back to
+// the HTTP server) when the passthrough-route set drops to zero. Deactivating
+// rewrites the :443 listen address, which restarts the listener and drops
+// in-flight TLS connections — surfacing as "tls: internal error" on a
+// concurrent container create's response.
+//
+// The invariant: once L4 is active, a subsequent sync with an empty route set
+// drains the SNI routes down to the catch-all but leaves L4 owning :443.
+func TestSyncL4Routes_LatchesActiveAcrossEmptyRouteSet(t *testing.T) {
+	initial := map[string]interface{}{
+		"apps": map[string]interface{}{
+			"http": map[string]interface{}{
+				"servers": map[string]interface{}{
+					"srv0": map[string]interface{}{
+						"listen": []interface{}{":80", ":443"},
+						"routes": []interface{}{},
+					},
+				},
+			},
+		},
+	}
+	srv := newFakeCaddy(initial)
+	defer srv.Close()
+
+	m := NewL4ProxyManager(srv.URL)
+	j := &RouteSyncJob{l4ProxyManager: m}
+
+	route := &RouteRecord{
+		FullDomain: "box-a.example",
+		TargetIP:   "203.0.113.7",
+		TargetPort: 22,
+		Protocol:   string(RouteProtocolTLSPassthrough),
+		Active:     true,
+	}
+
+	// 1) First passthrough route → L4 activates, :443 moves to layer4.
+	if err := j.syncL4Routes([]*RouteRecord{route}); err != nil {
+		t.Fatalf("syncL4Routes(1 route): %v", err)
+	}
+	if !m.IsL4Active() {
+		t.Fatal("L4 should be active after the first passthrough route")
+	}
+	assertHTTPOff443(t, srv.URL)
+	if got := l4SNIs(t, m); len(got) != 1 || got[0] != "box-a.example" {
+		t.Fatalf("expected 1 SNI route [box-a.example], got %v", got)
+	}
+
+	// 2) Route set empties → the OLD code deactivated L4 here (deleting the
+	//    layer4 app and moving :443 back to srv0), bouncing the listener.
+	//    The latch must instead keep L4 active and just drain the SNI route.
+	if err := j.syncL4Routes(nil); err != nil {
+		t.Fatalf("syncL4Routes(empty): %v", err)
+	}
+	if !m.IsL4Active() {
+		t.Fatal("REGRESSION (#416): L4 was deactivated on an empty route set — " +
+			"this restarts the :443 listener and drops in-flight TLS connections")
+	}
+	assertHTTPOff443(t, srv.URL)
+	if got := l4SNIs(t, m); len(got) != 0 {
+		t.Fatalf("expected SNI routes drained to none, got %v", got)
+	}
+
+	// 3) A new route arrives again → no re-activation needed (L4 still owns
+	//    :443), the route is simply added. This is the steady-state CI path:
+	//    box churn no longer touches the listener.
+	route2 := &RouteRecord{
+		FullDomain: "box-b.example",
+		TargetIP:   "203.0.113.8",
+		TargetPort: 22,
+		Protocol:   string(RouteProtocolTLSPassthrough),
+		Active:     true,
+	}
+	if err := j.syncL4Routes([]*RouteRecord{route2}); err != nil {
+		t.Fatalf("syncL4Routes(re-add): %v", err)
+	}
+	if !m.IsL4Active() {
+		t.Fatal("L4 should remain active across route churn")
+	}
+	if got := l4SNIs(t, m); len(got) != 1 || got[0] != "box-b.example" {
+		t.Fatalf("expected 1 SNI route [box-b.example], got %v", got)
+	}
+}
+
+// assertHTTPOff443 verifies the HTTP server is NOT listening on :443 — i.e.
+// layer4 owns :443. If srv0 ever regains :443 the listener was swapped back.
+func assertHTTPOff443(t *testing.T, baseURL string) {
+	t.Helper()
+	cfg := readConfig(t, baseURL)
+	apps, _ := cfg["apps"].(map[string]interface{})
+	httpApp, _ := apps["http"].(map[string]interface{})
+	if httpApp == nil {
+		return // no HTTP app at all is fine for this assertion
+	}
+	servers, _ := httpApp["servers"].(map[string]interface{})
+	srv0, _ := servers["srv0"].(map[string]interface{})
+	if srv0 == nil {
+		return
+	}
+	listen, _ := srv0["listen"].([]interface{})
+	for _, l := range listen {
+		if l == ":443" {
+			t.Fatalf("HTTP srv0 is back on :443 — layer4 no longer owns the listener (listen=%v)", listen)
+		}
+	}
+}
+
+func l4SNIs(t *testing.T, m *L4ProxyManager) []string {
+	t.Helper()
+	routes, err := m.ListL4Routes()
+	if err != nil {
+		t.Fatalf("ListL4Routes: %v", err)
+	}
+	snis := make([]string, 0, len(routes))
+	for _, r := range routes {
+		snis = append(snis, r.SNI)
+	}
+	return snis
+}


### PR DESCRIPTION
Fixes #416.

## Problem

`containarium create` through the hosted edge intermittently returns `remote error: tls: internal error` on the create **response** (the box itself is provisioned — a retry hits "already exists"). A no-op request that programs no route never flaps; a real create that programs a `tls_passthrough` route does. That asymmetry localizes it to route programming.

## Root cause (verified in code)

`RouteSyncJob.syncL4Routes` (the 5s reconcile) toggled L4 SNI routing on every **0↔1** transition in the `tls_passthrough` route set — `ActivateL4` when the first passthrough route appears, `DeactivateL4` when the last one goes away.

Both rewrite the **`:443` listen address**:
- `ActivateL4` (`internal/app/l4_proxy.go:117`) moves the HTTP server off `:443` onto the fallback port (`moveHTTPServerOff443`) and hands `:443` to the layer4 app, then `POST /load`.
- `DeactivateL4` (`l4_proxy.go:317`) deletes the layer4 app and moves `:443` back to the HTTP server.

Rewriting the listen address **restarts the `:443` listener**, dropping every in-flight TLS connection on it. The reconcile is **global**, so any container's passthrough-route churn within a 5s window bounces `:443` for everyone — including a concurrent `create` whose HTTPS response is mid-flight. That's the `tls: internal error`.

> The 5s `GET …/layer4/servers/tls_passthrough → 400` log line is a **symptom, not the cause**: `IsL4Active` returns 200 when active / 400 when inactive, so a steady 400 just means "zero passthrough routes right now". This PR deliberately doesn't touch it.

## Fix

Make L4 ownership of `:443` a **one-way latch**. Once active, keep it active; when the route set empties, **drain the SNI routes down to the catch-all** (the existing diff loop already does this) instead of deactivating. A layer4 server holding only the catch-all is behaviourally identical to the HTTP-on-`:443` baseline — non-matching SNI already falls through to the HTTP fallback — but it never rewrites the listen address, so the listener is never restarted under live traffic.

After the first activation, container/route churn (the CI dogfood pattern) only edits the inner routes array with the `:443` listen address unchanged, which Caddy applies by reusing the existing listener — in-flight connections survive.

**Lazy activation is preserved**: a deployment that never uses TLS passthrough never activates L4 and never pays the layer4 hop.

## Test

`TestSyncL4Routes_LatchesActiveAcrossEmptyRouteSet` drives sync(1 route) → sync(empty) → sync(new route) against a fake Caddy admin and asserts:
- after the first route, L4 is active and the HTTP server is off `:443`;
- **after the route set empties, L4 is still active and the HTTP server is still off `:443`** (the regression — old code deactivated here), with the SNI routes drained to none;
- a new route re-adds without any listener re-swap.

`go test ./internal/app/` and `go vet ./internal/app/` pass.

## Possible follow-up (not in this PR)

Two refinements would harden the remaining one-time edges (first-ever activation; re-activation after a core-caddy config revert), kept out to limit blast radius:
1. Build the layer4 app (with just the catch-all) into the base/boot config so `:443` is L4-owned from the start and even the first passthrough route causes no swap.
2. Replace `putRoutes`' whole-config `POST /load` with a scoped `PUT …/layer4/servers/tls_passthrough/routes` so route edits touch only the routes array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)