### PR TITLE
feat(edge): provision *.<base-domain> wildcard TLS via DNS-01 (#389 slice)

### DIFF
--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -90,6 +90,14 @@ func (p *ProxyManager) WithDNSChallenge(dns *CaddyACMEChallenges) *ProxyManager 
 	return p
 }
 
+// HasDNSChallenge reports whether the manager is configured to solve ACME
+// DNS-01 — i.e. whether a wildcard certificate can be issued (HTTP-01 /
+// TLS-ALPN-01 cannot). Callers use this to decide whether to provision a
+// `*.<base-domain>` wildcard for per-region/subdomain endpoints. See #389.
+func (p *ProxyManager) HasDNSChallenge() bool {
+	return p.dnsChallenge != nil
+}
+
 // SetServerName sets the Caddy server name (useful when Caddy uses a custom server name)
 func (p *ProxyManager) SetServerName(name string) {
 	p.serverName = name

--- a/internal/app/proxy_wildcard_test.go
+++ b/internal/app/proxy_wildcard_test.go
@@ -1,0 +1,101 @@
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func dnsChallengeForTest() *CaddyACMEChallenges {
+	return &CaddyACMEChallenges{DNS: &CaddyDNSChallenge{Provider: map[string]interface{}{"name": "cloudflare"}}}
+}
+
+func TestHasDNSChallenge(t *testing.T) {
+	pm := NewProxyManager("http://127.0.0.1:2019", "example.com")
+	if pm.HasDNSChallenge() {
+		t.Error("expected HasDNSChallenge=false before WithDNSChallenge")
+	}
+	pm.WithDNSChallenge(dnsChallengeForTest())
+	if !pm.HasDNSChallenge() {
+		t.Error("expected HasDNSChallenge=true after WithDNSChallenge")
+	}
+	pm.WithDNSChallenge(nil)
+	if pm.HasDNSChallenge() {
+		t.Error("expected HasDNSChallenge=false after WithDNSChallenge(nil)")
+	}
+}
+
+func TestProvisionWildcardTLS_RequiresDNS01(t *testing.T) {
+	// No DNS-01 → error, and no HTTP call is made (fails before any request).
+	pm := NewProxyManager("http://127.0.0.1:1", "example.com") // unroutable; must not be dialed
+	err := pm.ProvisionWildcardTLS()
+	if err == nil || !strings.Contains(err.Error(), "DNS-01") {
+		t.Fatalf("expected a DNS-01-required error, got %v", err)
+	}
+}
+
+func TestProvisionWildcardTLS_RequiresBaseDomain(t *testing.T) {
+	pm := NewProxyManager("http://127.0.0.1:1", "").WithDNSChallenge(dnsChallengeForTest())
+	err := pm.ProvisionWildcardTLS()
+	if err == nil || !strings.Contains(err.Error(), "base domain") {
+		t.Fatalf("expected a base-domain-required error, got %v", err)
+	}
+}
+
+func TestProvisionWildcardTLS_AddsWildcardSubjectViaDNS01(t *testing.T) {
+	var postedPolicies []CaddyTLSAutomationPolicy
+	posted := false
+
+	mux := http.NewServeMux()
+	// ensureTLSApp probes the tls app — return a present (non-null) app so it
+	// doesn't try to create one.
+	mux.HandleFunc("/config/apps/tls", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"automation":{"policies":[]}}`)
+	})
+	// ProvisionTLS reads then writes the automation policies.
+	mux.HandleFunc("/config/apps/tls/automation/policies", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = io.WriteString(w, `[]`) // no existing policies → POST a new one
+		case http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &postedPolicies); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			posted = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	pm := NewProxyManager(srv.URL, "example.com").WithDNSChallenge(dnsChallengeForTest())
+	if err := pm.ProvisionWildcardTLS(); err != nil {
+		t.Fatalf("ProvisionWildcardTLS: %v", err)
+	}
+
+	if !posted || len(postedPolicies) != 1 {
+		t.Fatalf("expected one policy POSTed, got posted=%v policies=%d", posted, len(postedPolicies))
+	}
+	// The subject must be the wildcard for the base domain.
+	subjects := postedPolicies[0].Subjects
+	if len(subjects) != 1 || subjects[0] != "*.example.com" {
+		t.Errorf("expected subjects [*.example.com], got %v", subjects)
+	}
+	// And the issuers must carry the DNS-01 challenge (not plain HTTP-01).
+	foundDNS := false
+	for _, iss := range postedPolicies[0].Issuers {
+		if iss.Challenges != nil && iss.Challenges.DNS != nil {
+			foundDNS = true
+		}
+	}
+	if !foundDNS {
+		t.Error("expected the wildcard policy's issuers to carry a DNS-01 challenge")
+	}
+}

--- a/internal/app/route_sync.go
+++ b/internal/app/route_sync.go
@@ -149,6 +149,14 @@ func (j *RouteSyncJob) sync(ctx context.Context) error {
 		log.Printf("[RouteSyncJob] Base Caddy config reconcile failed: %v", err)
 	} else if rebuilt {
 		log.Printf("[RouteSyncJob] Caddy reverted to stub config — rebuilt base edge config; routes/TLS/L4 will be repopulated this sync (#400)")
+		// Per-route TLS subjects come back via the diff below, but the
+		// `*.<base-domain>` wildcard isn't tied to a route — re-provision it
+		// here so a Caddy reload doesn't silently drop wildcard coverage (#389).
+		if j.proxyManager.HasDNSChallenge() {
+			if err := j.proxyManager.ProvisionWildcardTLS(); err != nil {
+				log.Printf("[RouteSyncJob] re-provision wildcard TLS after rebuild failed: %v", err)
+			}
+		}
 	}
 
 	// Get routes from PostgreSQL (source of truth)

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -578,6 +578,21 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 							}
 						}
 
+						// With DNS-01 configured, provision a single `*.<base-domain>`
+						// wildcard so every per-region / subdomain endpoint
+						// (region-a.<base>, …) gets a cert from one issuance — no
+						// per-hostname HTTP-01, which sidesteps both the HTTP-01
+						// redirect failure and Let's Encrypt per-domain rate limits
+						// as regions scale (#389). Best-effort; per-route ProvisionTLS
+						// still covers individual hostnames if this is skipped.
+						if proxyManager.HasDNSChallenge() {
+							if err := proxyManager.ProvisionWildcardTLS(); err != nil {
+								log.Printf("Warning: failed to provision wildcard TLS (*.%s): %v", config.BaseDomain, err)
+							} else {
+								log.Printf("Caddy TLS: provisioned wildcard *.%s via DNS-01", config.BaseDomain)
+							}
+						}
+
 						// Create L4ProxyManager for TLS passthrough (SNI-based) routing
 						l4ProxyManager := app.NewL4ProxyManager(caddyAdminURL)
 						if config.ProxyProtocol {


### PR DESCRIPTION
Advances #389 (the wildcard slice). The issue's v0.22.0 framing had partly rotted: **multi-hostname serving** (`--public-base-domain`, #213) and the **DNS-01 issuer + caddy-dns build** (#378) already landed. The genuine remaining gap was that `ProxyManager.ProvisionWildcardTLS()` existed (`proxy.go`) but was **never called** — so no `*.<base-domain>` wildcard subject was ever added.

## Change

- **Wire `ProvisionWildcardTLS()` at edge init** (`dual_server.go`): when DNS-01 is configured (`HasDNSChallenge()`), provision a single `*.<base-domain>` wildcard so every per-region/subdomain endpoint (`region-a.<base>`, …) gets a cert from one DNS-01 issuance — no per-hostname HTTP-01 (sidesteps the `.well-known` redirect failure and Let's Encrypt per-domain rate limits as regions scale). Best-effort + logged.
- **Self-heal** (`route_sync.go`): re-provision the wildcard after the #400 stub-revert rebuild — it isn't tied to a route, so it'd otherwise be silently dropped on a Caddy reload.
- **`HasDNSChallenge()`** accessor so callers gate on DNS-01 without poking internals.

Per-route `ProvisionTLS` still covers individual hostnames when DNS-01 isn't configured — no behavior change there.

## Tests

`internal/app/proxy_wildcard_test.go`: `HasDNSChallenge` toggle; `ProvisionWildcardTLS` error guards (no DNS-01 / no base domain — and asserts no HTTP is dialed); and the happy path against a fake Caddy asserting exactly one `*.example.com` policy is POSTed **with DNS-01 issuers** (not plain HTTP-01). `go build ./...`, `go test ./internal/app/` green.

## Still open on #389

The HTTP-01 `/.well-known/acme-challenge/*` redirect carve-out (for deployments that *don't* configure DNS-01) is the remaining piece — leaving #389 open for it. Cert issuance end-to-end still needs a real Cloudflare token + public DNS to fully verify; this PR is the daemon-side config wiring, which is what's unit-testable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)