### PR TITLE
chore(release): bump to 0.22.2 (ships #416 edge create-flap fix)

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.22.1"
+	Version = "0.22.2"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Patch release packaging **#418** (the #416 fix, already on `main`): stop deactivating layer4 on an empty passthrough-route set, so core-caddy keeps owning `:443` instead of swapping the listener via whole-config `POST /load` on 0↔1 passthrough-route transitions — which was dropping the in-flight TLS response of concurrent edge `CreateContainer` calls (the CI flap). Also includes #417, #419/#420. After merge: tag `v0.22.2` → release → redeploy both asia VMs → re-test the edge create loop / CI #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)