### PR TITLE
fix(cli): harden --http REST client against HTTP/2 edge resets — pin HTTP/1.1 + drain bodies (#422)

### DIFF
--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -32,11 +33,27 @@ func NewHTTPClient(baseURL string, token string) (*HTTPClient, error) {
 	// Remove trailing slash
 	baseURL = strings.TrimSuffix(baseURL, "/")
 
+	// Pin HTTP/1.1. Go's default client negotiates HTTP/2 via ALPN against
+	// an HTTPS server, but a long-running request (a container create can
+	// take minutes) carried on an HTTP/2 connection through a fronting TLS
+	// edge intermittently gets the connection reset with
+	// `remote error: tls: internal error` — the server still completes the
+	// work (the box is provisioned), only the response connection dies. The
+	// identical request over HTTP/1.1 (e.g. curl's default) is clean. This
+	// REST client issues one request per process, so HTTP/2 multiplexing
+	// buys nothing here. Clearing TLSNextProto on a cloned default transport
+	// is the documented way to force HTTP/1.1 on net/http while keeping the
+	// default dial/timeout/proxy behaviour. See FootprintAI/Containarium#422.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ForceAttemptHTTP2 = false
+	transport.TLSNextProto = map[string]func(authority string, c *tls.Conn) http.RoundTripper{}
+
 	return &HTTPClient{
 		baseURL: baseURL,
 		token:   token,
 		httpClient: &http.Client{
-			Timeout: 15 * time.Minute, // Match gRPC client timeout for container creation
+			Timeout:   15 * time.Minute, // Match gRPC client timeout for container creation
+			Transport: transport,
 		},
 	}, nil
 }

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -88,9 +88,27 @@ func (c *HTTPClient) doRequest(ctx context.Context, method, path string, body in
 	return c.httpClient.Do(req)
 }
 
+// drainClose fully drains then closes an HTTP response body. Draining
+// before Close matters for HTTP/2: a body closed while still unread makes
+// Go send a RST_STREAM (plus a PING) to cancel the stream, which
+// Cloudflare and similar edges treat as abusive client behaviour and
+// answer by tearing down the whole connection (GOAWAY ENHANCE_YOUR_CALM)
+// — see FootprintAI/Containarium#422 and
+// https://blog.cloudflare.com/go-and-enhance-your-calm/. This REST client
+// is pinned to HTTP/1.1 today (where the concern is moot), but draining on
+// every path keeps it correct if HTTP/2 is ever re-enabled, and it's a
+// no-op cost when the caller already read the body to EOF.
+func drainClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
 // parseResponse reads and parses the response body
 func parseResponse[T any](resp *http.Response) (*T, error) {
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -303,7 +321,7 @@ func (c *HTTPClient) ToggleAutoSleep(username string, enabled bool, idleThreshol
 	if err != nil {
 		return nil, fmt.Errorf("toggle auto-sleep: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
@@ -343,7 +361,7 @@ func (c *HTTPClient) StartContainer(username string, waitForReady bool, readyTim
 	if err != nil {
 		return nil, fmt.Errorf("start container: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
@@ -374,7 +392,7 @@ func (c *HTTPClient) StopContainer(username string, force bool) (*pb.StopContain
 	if err != nil {
 		return nil, fmt.Errorf("stop container: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
@@ -409,7 +427,7 @@ func (c *HTTPClient) ToggleMonitoring(username string, enabled bool) (string, bo
 	if err != nil {
 		return "", false, fmt.Errorf("toggle monitoring: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
@@ -444,7 +462,7 @@ func (c *HTTPClient) RefreshToken(refreshTok string) (string, string, int64, int
 	if err != nil {
 		return "", "", 0, 0, fmt.Errorf("refresh token: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return "", "", 0, 0, parseErr(b, resp.StatusCode, "refresh token")
@@ -496,7 +514,7 @@ func (c *HTTPClient) ListRevokedTokens(limit int32, includeExpired bool, jtiPref
 	if err != nil {
 		return nil, fmt.Errorf("list revoked tokens: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return nil, parseErr(b, resp.StatusCode, "list revoked tokens")
@@ -528,7 +546,7 @@ func (c *HTTPClient) RevokeToken(jti, reason, expiresAt string) (string, error) 
 	if err != nil {
 		return "", fmt.Errorf("revoke token: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return "", parseErr(b, resp.StatusCode, "revoke token")
@@ -560,7 +578,7 @@ func (c *HTTPClient) SetSecret(username, name, value, delivery string) (string, 
 	if err != nil {
 		return "", fmt.Errorf("set secret: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return "", parseErr(b, resp.StatusCode, "set secret")
@@ -581,7 +599,7 @@ func (c *HTTPClient) GetSecret(username, name string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("get secret: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return "", parseErr(b, resp.StatusCode, "get secret")
@@ -604,7 +622,7 @@ func (c *HTTPClient) ListSecrets(username string) ([]map[string]interface{}, err
 	if err != nil {
 		return nil, fmt.Errorf("list secrets: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return nil, parseErr(b, resp.StatusCode, "list secrets")
@@ -625,7 +643,7 @@ func (c *HTTPClient) DeleteSecret(username, name string) error {
 	if err != nil {
 		return fmt.Errorf("delete secret: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return parseErr(b, resp.StatusCode, "delete secret")
@@ -642,7 +660,7 @@ func (c *HTTPClient) RefreshSecrets(username string) (string, int32, error) {
 	if err != nil {
 		return "", 0, fmt.Errorf("refresh secrets: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return "", 0, parseErr(b, resp.StatusCode, "refresh secrets")
@@ -687,7 +705,7 @@ func (c *HTTPClient) ResizeContainer(username, cpu, memory, disk string) (string
 	if err != nil {
 		return "", fmt.Errorf("resize container: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
@@ -723,7 +741,7 @@ func (c *HTTPClient) DeleteContainer(username string, force bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete container: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	if resp.StatusCode >= 400 {
 		bodyBytes, _ := io.ReadAll(resp.Body)
@@ -773,7 +791,7 @@ func (c *HTTPClient) DebugContainer(username string) (*pb.DebugContainerResponse
 	if err != nil {
 		return nil, fmt.Errorf("failed to debug container: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -831,7 +849,7 @@ func (c *HTTPClient) InstallStack(username, stackID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to install stack: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	if resp.StatusCode >= 400 {
 		bodyBytes, _ := io.ReadAll(resp.Body)
@@ -856,7 +874,7 @@ func (c *HTTPClient) ListRecipes() ([]*pb.Recipe, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list recipes: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
@@ -879,7 +897,7 @@ func (c *HTTPClient) GetRecipe(id string) (*pb.Recipe, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get recipe: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
@@ -910,7 +928,7 @@ func (c *HTTPClient) DeployRecipe(recipeID, name, gpu, backendID, pool string, p
 	if err != nil {
 		return nil, fmt.Errorf("deploy recipe: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
@@ -956,7 +974,7 @@ func (c *HTTPClient) SetLabels(username string, labels map[string]string) error 
 	if err != nil {
 		return fmt.Errorf("failed to set labels: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	if resp.StatusCode >= 400 {
 		bodyBytes, _ := io.ReadAll(resp.Body)
@@ -983,7 +1001,7 @@ func (c *HTTPClient) RemoveLabel(username string, key string) error {
 	if err != nil {
 		return fmt.Errorf("failed to remove label: %w", err)
 	}
-	defer resp.Body.Close()
+	defer drainClose(resp)
 
 	if resp.StatusCode >= 400 {
 		bodyBytes, _ := io.ReadAll(resp.Body)

--- a/internal/client/http_test.go
+++ b/internal/client/http_test.go
@@ -1,9 +1,54 @@
 package client
 
 import (
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 )
+
+// trackBody records whether it was read to EOF and closed, so a test can
+// assert drainClose's drain-before-close behaviour.
+type trackBody struct {
+	r         io.Reader
+	readToEOF bool
+	closed    bool
+}
+
+func (b *trackBody) Read(p []byte) (int, error) {
+	n, err := b.r.Read(p)
+	if err == io.EOF {
+		b.readToEOF = true
+	}
+	return n, err
+}
+
+func (b *trackBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+// TestDrainClose_DrainsThenCloses guards the HTTP/2 hygiene fix
+// (FootprintAI/Containarium#422): a response body must be drained to EOF
+// before Close so Go doesn't emit a stream-cancelling RST_STREAM/PING that
+// a fronting edge (Cloudflare) treats as abusive.
+func TestDrainClose_DrainsThenCloses(t *testing.T) {
+	body := &trackBody{r: strings.NewReader("unread payload")}
+	drainClose(&http.Response{Body: body})
+	if !body.readToEOF {
+		t.Error("drainClose must read the body to EOF before closing")
+	}
+	if !body.closed {
+		t.Error("drainClose must close the body")
+	}
+}
+
+// TestDrainClose_NilSafe: drainClose must tolerate a nil response or body
+// (some methods return early before assigning resp).
+func TestDrainClose_NilSafe(t *testing.T) {
+	drainClose(nil)
+	drainClose(&http.Response{})
+}
 
 // TestNewHTTPClient_PinsHTTP1 is the regression guard for
 // FootprintAI/Containarium#422: the REST client must NOT negotiate

--- a/internal/client/http_test.go
+++ b/internal/client/http_test.go
@@ -1,0 +1,42 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestNewHTTPClient_PinsHTTP1 is the regression guard for
+// FootprintAI/Containarium#422: the REST client must NOT negotiate
+// HTTP/2. A long-running container create carried on an HTTP/2
+// connection through a fronting TLS edge intermittently resets with
+// `remote error: tls: internal error` (the box is provisioned; only the
+// response connection dies), while the same request over HTTP/1.1 is
+// clean. The fix clears TLSNextProto on a cloned default transport — the
+// documented way to force HTTP/1.1 — so this asserts the transport is
+// pinned and h2 cannot be auto-enabled.
+func TestNewHTTPClient_PinsHTTP1(t *testing.T) {
+	c, err := NewHTTPClient("https://example.test", "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	tr, ok := c.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", c.httpClient.Transport)
+	}
+	if tr.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 must be false to keep HTTP/2 off")
+	}
+	// A non-nil but empty TLSNextProto is what disables HTTP/2 auto-upgrade:
+	// net/http only installs the h2 ALPN handler when TLSNextProto is nil.
+	if tr.TLSNextProto == nil {
+		t.Fatal("TLSNextProto must be non-nil (empty) to disable HTTP/2 auto-upgrade")
+	}
+	if len(tr.TLSNextProto) != 0 {
+		t.Errorf("TLSNextProto must be empty, got %d entries", len(tr.TLSNextProto))
+	}
+	// Sanity: the cloned default transport must preserve sane dial defaults
+	// (not a zero-value transport with no timeouts).
+	if tr.DialContext == nil {
+		t.Error("expected DialContext preserved from http.DefaultTransport clone")
+	}
+}


### PR DESCRIPTION
Fixes #422.

## Problem

`containarium create` in HTTP/REST mode (`CONTAINARIUM_HTTP=true`) intermittently fails with `remote error: tls: internal error` against an HTTPS edge, while the **identical** request via `curl` is clean.

## Root cause — HTTP/2, not a certificate (confirmed)

1. **No client certificate is involved.** In `--http` mode `create` uses a stock `http.Client` (`internal/client/http.go`) — no `tls.Config`, no client cert. The mTLS path (`NewGRPCClient(... certsDir ...)`) is taken only when `httpMode` is false (`internal/cmd/create.go`). The "wrong cert" theory is dead.
2. **It's HTTP/2.** Go's `net/http` auto-upgrades to HTTP/2 via ALPN over HTTPS; curl defaults to HTTP/1.1. The handshake is solid (probe: 40/40), so this is a **post-handshake reset of the long-lived h2 connection mid-request** — the box is still provisioned, only the response connection dies. Fast requests (a 401) return before the reset window, which is why no-op probes looked clean over both protocols.

**Confirmed by A/B bracket:** `GODEBUG=http2client=0` (CLI→h1) is clean; `curl --http2` on a real create reproduces the flap.

Why HTTP/2 specifically: it's a single long-lived multiplexed connection with frame-level control (`PING`/`RST_STREAM`/`GOAWAY`) that HTTP/1.1 lacks, so a CDN edge can reset it under conditions that can't arise on h1. Cloudflare documents this exact Go interop hazard: https://blog.cloudflare.com/go-and-enhance-your-calm/

## Fix (two commits)

1. **Pin HTTP/1.1** on the REST client — clear `TLSNextProto` on a cloned `http.DefaultTransport` (documented net/http way to disable h2 while keeping default dial/timeout/proxy behaviour). This client issues one request per process, so h2 multiplexing buys nothing.
2. **Drain response bodies before close on every path.** Several methods (`DeleteContainer`, `InstallStack`, `SetLabels`, `RemoveLabel`) read the body only on the error branch, so the success path closed it unread — over h2 that emits a stream-cancelling `RST_STREAM`/`PING` the edge treats as abusive. New `drainClose()` helper (`io.Copy`→`io.Discard`, then `Close`) routes every `defer`. Belt-and-suspenders given (1), but it's the documented root-cause hygiene fix and keeps the client correct if h2 is ever re-enabled.

## Tests

- `TestNewHTTPClient_PinsHTTP1` — transport has h2 off (`ForceAttemptHTTP2=false`, `TLSNextProto` non-nil+empty) and preserves default dial settings.
- `TestDrainClose_DrainsThenCloses` / `_NilSafe` — body is read to EOF before close; nil-safe.

`go build`, `go vet`, `go test ./internal/client/` pass.

Companion: FootprintAI/containarium-run#23 moves CI's create+delete to `curl --http1.1` so CI is unblocked without waiting on a CLI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)