### PR TITLE
chore(release): bump to 0.22.3

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.22.2"
+	Version = "0.22.3"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Release bump 0.22.2 → 0.22.3.

Ships since v0.22.1:
- **#422 — CLI HTTP/2 edge flap fixed** (`#423`): the `--http` REST client now pins HTTP/1.1 and drains response bodies on every path. Fixes `containarium create` intermittently returning `tls: internal error` through a CDN-fronted HTTPS edge (confirmed HTTP/2-only).
- **#416 — L4 listener latch** (`#418`): the route reconcile no longer deactivates layer4 when the passthrough-route set empties, so `:443` ownership stops swapping under live traffic.

(0.22.2 was bump-committed via #421 but never tagged; this supersedes it.)

After merge, tag `v0.22.3` to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)