### PR TITLE
fix(incus): retry exec on the transient "Failed to retrieve PID" error

### DIFF
--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -876,6 +876,44 @@ func (c *Client) GetContainer(name string) (*ContainerInfo, error) {
 	return info, nil
 }
 
+// execMaxAttempts bounds retries of an incus exec on the transient
+// PID-tracking failure (see isTransientExecErr). 4 attempts with the
+// linear backoff below is ~1s total — enough to ride out the race
+// without masking a genuinely wedged container.
+const execMaxAttempts = 4
+
+// execBackoffBase is the linear backoff unit between exec retries. A var
+// (not const) so tests can zero it; production keeps the default.
+var execBackoffBase = 150 * time.Millisecond
+
+// isTransientExecErr reports whether an incus exec error is the transient
+// "Failed to retrieve PID of executing child process". incus intermittently
+// fails to track the forked process — notably right after a container
+// launches (init/cgroup not fully settled) or under concurrent exec load —
+// so the command never actually ran. Retrying the exec absorbs it. The
+// daemon's provisioning commands (systemctl enable, apt/pip install, etc.)
+// are idempotent, so a retry is safe. A real non-zero command exit is a
+// DIFFERENT error and is deliberately NOT matched here, so we never silently
+// re-run a command that genuinely failed.
+func isTransientExecErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Failed to retrieve PID of executing child process")
+}
+
+// execWithRetry runs attempt up to execMaxAttempts times, retrying ONLY the
+// transient PID-tracking error with a linear backoff. attempt returns nil on
+// success; any other (non-transient) error returns immediately.
+func execWithRetry(what string, attempt func() error) error {
+	var err error
+	for i := 1; i <= execMaxAttempts; i++ {
+		if err = attempt(); err == nil || !isTransientExecErr(err) || i == execMaxAttempts {
+			return err
+		}
+		log.Printf("[incus] %s: transient exec error (attempt %d/%d), retrying: %v", what, i, execMaxAttempts, err)
+		time.Sleep(time.Duration(i) * execBackoffBase)
+	}
+	return err
+}
+
 // Exec executes a command inside a container
 func (c *Client) Exec(containerName string, command []string) error {
 	req := api.InstanceExecPost{
@@ -883,17 +921,16 @@ func (c *Client) Exec(containerName string, command []string) error {
 		WaitForWS:   true,
 		Interactive: false,
 	}
-
-	op, err := c.server.ExecInstance(containerName, req, nil)
-	if err != nil {
-		return fmt.Errorf("failed to execute command: %w", err)
-	}
-
-	if err := op.Wait(); err != nil {
-		return fmt.Errorf("command execution failed: %w", err)
-	}
-
-	return nil
+	return execWithRetry("exec "+containerName, func() error {
+		op, err := c.server.ExecInstance(containerName, req, nil)
+		if err != nil {
+			return fmt.Errorf("failed to execute command: %w", err)
+		}
+		if err := op.Wait(); err != nil {
+			return fmt.Errorf("command execution failed: %w", err)
+		}
+		return nil
+	})
 }
 
 // WaitForNetwork waits for the container to have a network IP
@@ -1698,32 +1735,31 @@ func (c *Client) ExecWithOutput(containerName string, command []string) (string,
 		// We capture output via the args.Stdout/Stderr instead
 	}
 
-	// Create exec args with stdio handlers to capture output
-	args := &incus.InstanceExecArgs{
-		Stdout: &stdout,
-		Stderr: &stderr,
-	}
+	err := execWithRetry("exec "+containerName, func() error {
+		// Reset the capture buffers each attempt so a retried command's
+		// output replaces (not appends to) a failed attempt's partial output.
+		stdout.Reset()
+		stderr.Reset()
+		args := &incus.InstanceExecArgs{Stdout: &stdout, Stderr: &stderr}
 
-	op, err := c.server.ExecInstance(containerName, req, args)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to execute command: %w", err)
-	}
-
-	// Wait for the operation to complete
-	err = op.Wait()
-	if err != nil {
-		return stdout.String(), stderr.String(), fmt.Errorf("command execution failed: %w", err)
-	}
-
-	// Check exit code
-	opMeta := op.Get()
-	if opMeta.Metadata != nil {
-		if returnVal, ok := opMeta.Metadata["return"].(float64); ok && returnVal != 0 {
-			return stdout.String(), stderr.String(), fmt.Errorf("command exited with code %d", int(returnVal))
+		op, err := c.server.ExecInstance(containerName, req, args)
+		if err != nil {
+			return fmt.Errorf("failed to execute command: %w", err)
 		}
-	}
-
-	return stdout.String(), stderr.String(), nil
+		if err := op.Wait(); err != nil {
+			return fmt.Errorf("command execution failed: %w", err)
+		}
+		// A non-zero exit is a genuine command failure, not the transient
+		// PID race — return it so execWithRetry does NOT retry it.
+		opMeta := op.Get()
+		if opMeta.Metadata != nil {
+			if returnVal, ok := opMeta.Metadata["return"].(float64); ok && returnVal != 0 {
+				return fmt.Errorf("command exited with code %d", int(returnVal))
+			}
+		}
+		return nil
+	})
+	return stdout.String(), stderr.String(), err
 }
 
 // CleanupDisk frees disk space inside a container by removing temp files,

--- a/pkg/core/incus/exec_retry_test.go
+++ b/pkg/core/incus/exec_retry_test.go
@@ -1,0 +1,96 @@
+package incus
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// noBackoff zeroes execBackoffBase for the duration of a test so the
+// retry loop doesn't actually sleep.
+func noBackoff(t *testing.T) {
+	t.Helper()
+	old := execBackoffBase
+	execBackoffBase = 0
+	t.Cleanup(func() { execBackoffBase = old })
+}
+
+// transientErr mimics the incus exec PID-tracking failure as it surfaces
+// from the wrapper (wrapped in "command execution failed: …").
+var transientErr = fmt.Errorf("command execution failed: %w",
+	errors.New("Failed to retrieve PID of executing child process"))
+
+func TestIsTransientExecErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"transient PID race", transientErr, true},
+		{"wrapped transient", fmt.Errorf("exec foo: %w", transientErr), true},
+		{"real non-zero exit", errors.New("command exited with code 1"), false},
+		{"other failure", errors.New("instance not found"), false},
+	}
+	for _, c := range cases {
+		if got := isTransientExecErr(c.err); got != c.want {
+			t.Errorf("%s: isTransientExecErr = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestExecWithRetry_RetriesTransientThenSucceeds: the transient PID error
+// is retried and a later success is returned cleanly.
+func TestExecWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
+	noBackoff(t)
+	calls := 0
+	err := execWithRetry("test", func() error {
+		calls++
+		if calls < 3 {
+			return transientErr
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil after transient retries", err)
+	}
+	if calls != 3 {
+		t.Errorf("attempts = %d, want 3 (2 transient + 1 success)", calls)
+	}
+}
+
+// TestExecWithRetry_DoesNotRetryRealError: a genuine command failure
+// (non-transient) must NOT be retried — retrying could double-run a
+// non-idempotent side effect.
+func TestExecWithRetry_DoesNotRetryRealError(t *testing.T) {
+	noBackoff(t)
+	calls := 0
+	realErr := errors.New("command exited with code 1")
+	err := execWithRetry("test", func() error {
+		calls++
+		return realErr
+	})
+	if !errors.Is(err, realErr) {
+		t.Fatalf("err = %v, want the real error", err)
+	}
+	if calls != 1 {
+		t.Errorf("attempts = %d, want 1 (no retry on a real failure)", calls)
+	}
+}
+
+// TestExecWithRetry_ExhaustsAndReturnsLast: a persistently transient error
+// is retried up to the cap, then the last error is returned.
+func TestExecWithRetry_ExhaustsAndReturnsLast(t *testing.T) {
+	noBackoff(t)
+	calls := 0
+	err := execWithRetry("test", func() error {
+		calls++
+		return transientErr
+	})
+	if !isTransientExecErr(err) {
+		t.Fatalf("err = %v, want the transient error after exhaustion", err)
+	}
+	if calls != execMaxAttempts {
+		t.Errorf("attempts = %d, want execMaxAttempts (%d)", calls, execMaxAttempts)
+	}
+}


### PR DESCRIPTION
## Problem

`incus exec` intermittently returns `Failed to retrieve PID of executing child process` — it can't track the forked process, notably right after a container launches (init/cgroup not settled) or under concurrent exec load. The command never runs, so the daemon's post-launch provisioning (`install packages` / `enable ssh`) fails and the box is delete-cascaded:

```
Async container creation failed for cld-…: failed to install packages:
  failed to enable ssh: command execution failed:
    Failed to retrieve PID of executing child process
```

`Exec` and `ExecWithOutput` had **no retry** — a single transient miss kills the create. It's intermittent (some boxes reach RUNNING, some die), and under a burst of concurrent creates it compounds (each create's provisioning thrashes the daemon).

## Change

Route both exec wrappers through a small `execWithRetry` helper that retries **only** this transient error (up to `execMaxAttempts` = 4, linear backoff). The provisioning commands are idempotent, so a retry is safe.

- A genuine **non-zero command exit** is a distinct error and is **not** retried — we never silently re-run a command that really failed.
- `ExecWithOutput` resets its capture buffers each attempt so a retried command's output replaces (not appends to) the failed attempt's partial output.

## Tests

`isTransientExecErr` classification + the retry loop (retry-then-succeed, no-retry-on-real-error, exhaust-and-return-last) via a function seam — no incus server mock needed. `go test ./pkg/core/incus/` + `go vet` pass.

> Context: this is the daemon-side reliability fix for the box-create flakiness seen on a busy dogfood host. The cloud control plane separately gained a driver-create queue (FootprintAI/Containarium-cloud#248) so a *burst* degrades into a short wait; this fix makes each individual provision reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)