### PR TITLE
chore(release): bump to 0.22.4

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.22.3"
+	Version = "0.22.4"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Release bump 0.22.3 → 0.22.4. Ships #425 (incus exec retry on the transient `Failed to retrieve PID` error). Tag `v0.22.4` after merge to build the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)