### PR TITLE
chore(security): bump Go toolchain 1.25.10 → 1.25.11 (stdlib vuln fixes)

### DIFF
--- a/.github/workflows/distros-go-ci.yml
+++ b/.github/workflows/distros-go-ci.yml
@@ -38,7 +38,7 @@ jobs:
           # Pinned to match the version the daemon's release workflow
           # uses; drift would mean release-built daemon and CI-tested
           # distro stop sharing a toolchain.
-          go-version: '1.25.10'
+          go-version: '1.25.11'
 
       - name: Verify module hygiene
         # `go mod tidy` should be a no-op on a clean PR. If it changes

--- a/.github/workflows/proxyproto-e2e.yml
+++ b/.github/workflows/proxyproto-e2e.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
 
       - name: Run sentinel + app tests
         # The skipped tests are pre-existing failures on unprivileged Linux
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
 
       - name: Cache built caddy binary
         id: cache-caddy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
 
       - name: Install buf
         # `make build-release` transitively runs `make proto`, which
@@ -163,7 +163,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
 
       - name: Install buf
         run: go install github.com/bufbuild/buf/cmd/buf@latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/footprintai/containarium
 
-go 1.25.10
+go 1.25.11
 
 require (
 	cloud.google.com/go/compute v1.64.0


### PR DESCRIPTION
Unblocks the `Vulnerability Check (govulncheck)` gate, which is currently **red on every open PR**.

## Why

`govulncheck` flags three Go **standard-library** advisories, all **fixed in go1.25.11**:

| Vuln | Package |
|---|---|
| GO-2026-5039 | `net/textproto` |
| GO-2026-5037 | `crypto/x509` |
| GO-2026-5038 | `mime` |

The repo pins **go1.25.10** (`go.mod` + `go-version: '1.25.10'` in the workflows), and the gate fails on any vuln with an available fix — so it trips regardless of a PR's diff (it was blocking a docs-only CHANGELOG PR). The `incus` advisories are `Fixed in: N/A` and do not trip the gate.

## Change

Bump `go 1.25.11` in `go.mod` and the `setup-go` pins (`release.yml`, `security.yml`, `distros-go-ci.yml`, `proxyproto-e2e.yml` ×2) from `1.25.10` → `1.25.11`. Patch-level toolchain bump; **no source changes**. `go build ./...` clean locally on go1.26.0.

After this merges, re-running the other open PRs' checks clears their `govulncheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)