### PR TITLE
docs(ebpf): correct Phase A attach point to per-container veth TC_INGRESS (#315)

### DIFF
--- a/docs/security/NETWORK-ISOLATION-DESIGN.md
+++ b/docs/security/NETWORK-ISOLATION-DESIGN.md
@@ -83,9 +83,37 @@ at the application:
   isolation. Their architecture doc would be the right reference.
 
 Containarium isn't k8s and shouldn't pull Cilium. The right shape is
-**a small set of tc-bpf programs attached to `incusbr0`** that
-implement the policy from a per-tenant rule set the daemon
-maintains.
+**a small set of tc-bpf programs attached at each container's
+host-side veth in `TC_INGRESS`** that implement the policy from a
+per-tenant rule set the daemon maintains.
+
+## Phase 0 validation findings — the attach point (#315)
+
+Phase 0 ran on a real backend (Ubuntu 24.04, kernel 6.8, Incus 6.23) and
+**ruled out the obvious `incusbr0` attach point.** Two on-hardware runs:
+
+- **Bridge master (`incusbr0`), `TC_INGRESS` + `TC_EGRESS`** — on an A→B ping
+  the ingress counter incremented but **egress stayed 0**: a Linux bridge
+  forwards frames between ports without them traversing the bridge device's
+  tc-egress hook.
+- **Per-container host veth, `TC_INGRESS` + `TC_EGRESS`** — A's veth *ingress*
+  saw A's outbound; A's veth *egress* stayed 0 even though B's **5/5** replies
+  flowed (they were counted at **B's** veth ingress). So bridge-forwarded
+  *inbound* bypasses the destination veth's tc-egress too.
+
+**Conclusion:** `TC_EGRESS` on bridge / bridge-slave devices is not a reliable
+hook for inter-container traffic. The reliable, sufficient point is
+**`TC_INGRESS` on each container's host veth** — it sees that container's
+*entire* outbound, which is the **sender side of every flow**. Therefore:
+
+- **Observation** = the union of every container's veth-ingress hook (each flow
+  counted once, at its sender).
+- **Enforcement** = a container's egress policy is enforced at *its* veth
+  ingress; to block Y→X you drop at **Y's** veth ingress. All enforcement lives
+  at the sender's veth ingress — no egress hook needed.
+
+The Phase 0 / 0.5 harnesses (`experimental/ebpf-phase0/validate.sh`,
+`validate-veth.sh`) reproduce both results.
 
 ## Architecture sketch
 
@@ -108,9 +136,9 @@ maintains.
                   │   └── allow_intra_tenant     │
                   └──────────────────────────────┘
                             ▲
-                            │ tc-bpf (ingress + egress)
-                            │
-              incusbr0 ─────┴──── tenant containers
+                            │ tc-bpf (TC_INGRESS) on each
+                            │ container's host veth
+         container veths ───┴──── tenant containers (enslaved to incusbr0)
                             │
                             v
                   ┌──────────────────────────────┐
@@ -124,9 +152,17 @@ maintains.
 1. **Policy data model** — `NetworkPolicy { tenant, allow_intra_tenant: bool, egress_cidrs: [CIDR], egress_domains: [string] }`. Proto-first per the
    project convention.
 2. **BPF programs** — small tc-bpf programs (~200-400 LOC C or Rust)
-   attached to `incusbr0` in TC_INGRESS and TC_EGRESS. Lookup
-   src/dst against BPF maps; pass on allow, drop + perf_event on
-   deny.
+   attached to **each container's host-side veth in TC_INGRESS** (the
+   point where the container's outbound packets enter the host stack;
+   see the Phase 0 findings — bridge/veth TC_EGRESS doesn't observe
+   bridge-forwarded traffic, so all enforcement is at the sender's veth
+   ingress). Lookup src/dst against BPF maps; pass on allow, drop +
+   perf_event on deny.
+2a. **Veth discovery + lifecycle** — resolve each container's host veth
+   (Incus exposes it as `volatile.eth0.host_name`; fall back to mapping
+   the container's `eth0` `iflink` to a host interface) and (de)attach
+   the program as containers come and go. New attach point vs. a single
+   bridge program: one program instance per container veth.
 3. **Map-update plumbing in the daemon** — Go side uses
    `github.com/cilium/ebpf` (popular, well-maintained, no Cilium
    runtime dependency) to load programs and update maps.
@@ -144,17 +180,18 @@ maintains.
 
 | Phase | Scope | Bound |
 | --- | --- | --- |
-| **0 — discovery** | Stand up a throwaway tc-bpf program that counts cross-container packets on a test backend. Validate the assumption that the bridge is the right attach point. Not user-facing. | 1 week |
+| **0 — discovery** | ✅ **Done.** Threw a tc-bpf counter at a real backend (kernel 6.8 / Incus 6.23). Outcome: the bridge is the *wrong* attach point (TC_EGRESS on bridge/veth doesn't see forwarded traffic) — corrected to **per-container veth TC_INGRESS** (see "Phase 0 validation findings" above). | done |
 | **A — observation only** | Land the BPF programs + map-update plumbing in `log_only` mode. Every denied flow would generate an audit row but no packets are actually dropped. Operators learn what real traffic looks like. | 2 weeks |
 | **B — policy enforcement** | Flip from log-only to drop on a per-tenant `CONTAINARIUM_ENFORCE_NETWORK_POLICY=true`. Default off until ≥1 production tenant has soaked it. | 1 week |
 | **C — egress allowlist** | Domain → CIDR resolver + DNS-TTL refresh loop. Egress now constrainable to a list. | 1 week |
 | **D — cloud metadata block** | Default-deny on `169.254.169.254/32` unless the tenant opts in. | 2 days |
 | **E — CLI / MCP / runbook** | Operator surface + docs. | 1 week |
 
-Total bounded estimate: **5-6 weeks** of focused work. Phase 0 is
-the load-bearing risk — if the bridge attach point doesn't work
-cleanly with Incus's network management, the design needs revisiting
-before any of the user-facing work starts.
+Total bounded estimate: **5-6 weeks** of focused work. Phase 0 was
+the load-bearing risk and it paid off: the bridge attach point the
+design originally assumed does **not** work for inter-container
+traffic, so Phase A starts from the corrected per-container-veth
+`TC_INGRESS` model above rather than discovering that mid-build.
 
 ## Honest tradeoffs
 

--- a/experimental/ebpf-phase0/validate-veth.sh
+++ b/experimental/ebpf-phase0/validate-veth.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Phase 0.5 — per-container veth-attach validation.
+#
+# Phase 0 (validate.sh) found that tc-bpf on the BRIDGE MASTER (incusbr0) only
+# sees one direction of container↔container traffic: the bridge forwards frames
+# between ports without them traversing the master's tc-egress hook, so the
+# egress counter stayed 0. (#315)
+#
+# This re-tests the corrected attach point the Phase A design needs: attach to a
+# container's HOST-SIDE VETH instead of the bridge. On the host veth:
+#   - tc ingress = frames arriving from the container  (its OUTBOUND traffic)
+#   - tc egress  = frames the host delivers to the container (its INBOUND)
+# so a single A→B ping must bump BOTH counters on A's veth. If it does, the
+# per-veth attach point observes both directions and Phase A can build on it.
+#
+# THROWAWAY — observation only (TC_ACT_OK, no drops); cleanup trap on EXIT.
+# Run on a Linux+Incus backend as root, kernel ≥ 6.6.
+#
+# Usage: sudo ./validate-veth.sh [--keep]
+#
+set -euo pipefail
+
+KEEP=0
+CT_A="phase0-veth-a"
+CT_B="phase0-veth-b"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --keep) KEEP=1; shift ;;
+        --help|-h) sed -n '2,/^$/p' "$0" | sed 's|^# \{0,1\}||'; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+[ "$(id -u)" -eq 0 ] || { echo "must run as root (need tc, bpftool, incus)" >&2; exit 2; }
+[ "$(uname -s)" = "Linux" ] || { echo "Linux only" >&2; exit 2; }
+for cmd in clang tc bpftool incus; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "missing required command: $cmd" >&2; exit 2; }
+done
+
+VETH_A=""
+VETH_B=""
+cleanup() {
+    set +e
+    if [ "$KEEP" -eq 0 ]; then
+        echo "==> cleanup"
+        [ -n "$VETH_A" ] && tc qdisc del dev "$VETH_A" clsact 2>/dev/null
+        [ -n "$VETH_B" ] && tc qdisc del dev "$VETH_B" clsact 2>/dev/null
+        rm -f /sys/fs/bpf/phase0_pkt_counter 2>/dev/null
+        incus delete --force "$CT_A" </dev/null 2>/dev/null
+        incus delete --force "$CT_B" </dev/null 2>/dev/null
+        rm -f "$SCRIPT_DIR/counter.bpf.o"
+    else
+        echo "==> --keep set; leaving veth=$VETH_A attached + containers up"
+    fi
+}
+trap cleanup EXIT
+
+# resolve_host_veth <container> — the host-side veth name for the default nic.
+# Prefer Incus' volatile.eth0.host_name; fall back to mapping eth0's iflink to a
+# host interface (works regardless of the nic's volatile key name).
+resolve_host_veth() {
+    ct="$1"
+    veth="$(incus config get "$ct" volatile.eth0.host_name </dev/null 2>/dev/null)"
+    if [ -n "$veth" ] && ip link show "$veth" >/dev/null 2>&1; then
+        echo "$veth"; return 0
+    fi
+    iflink="$(incus exec "$ct" -- cat /sys/class/net/eth0/iflink </dev/null 2>/dev/null | tr -d '[:space:]')"
+    [ -n "$iflink" ] || return 1
+    ip -o link 2>/dev/null | awk -F': ' -v i="$iflink" '$1==i {split($2,a,"@"); print a[1]; exit}'
+}
+
+echo "==> 1/5: building BPF object"
+cd "$SCRIPT_DIR"
+MULTIARCH_INC="/usr/include/$(uname -m)-linux-gnu"
+clang -O2 -g -target bpf -I"$MULTIARCH_INC" -c counter.bpf.c -o counter.bpf.o
+echo "    OK: counter.bpf.o ($(stat -c%s counter.bpf.o) bytes)"
+
+echo "==> 2/5: spawning two throwaway containers"
+incus launch images:ubuntu/24.04 "$CT_A" --quiet </dev/null
+incus launch images:ubuntu/24.04 "$CT_B" --quiet </dev/null
+for i in $(seq 30); do
+    IP_A=$(incus list "$CT_A" -c4 --format csv </dev/null | awk '{print $1}')
+    IP_B=$(incus list "$CT_B" -c4 --format csv </dev/null | awk '{print $1}')
+    [ -n "$IP_A" ] && [ -n "$IP_B" ] && break
+    sleep 1
+done
+[ -n "${IP_A:-}" ] && [ -n "${IP_B:-}" ] || { echo "    FAIL: containers didn't get IPs" >&2; exit 1; }
+echo "    OK: $CT_A=$IP_A  $CT_B=$IP_B"
+
+echo "==> 3/5: resolving + attaching counters"
+VETH_A="$(resolve_host_veth "$CT_A")"
+VETH_B="$(resolve_host_veth "$CT_B")"
+[ -n "$VETH_A" ] && [ -n "$VETH_B" ] || { echo "    FAIL: could not resolve host veths ($CT_A=$VETH_A $CT_B=$VETH_B)" >&2; exit 1; }
+echo "    $CT_A veth=$VETH_A   $CT_B veth=$VETH_B"
+# A's veth: ingress (A-out) → index 0, egress (A-in) → index 1.
+tc qdisc add dev "$VETH_A" clsact 2>/dev/null || true
+tc filter add dev "$VETH_A" ingress bpf da obj counter.bpf.o sec classifier/ingress
+tc filter add dev "$VETH_A" egress  bpf da obj counter.bpf.o sec classifier/egress
+# B's veth: ingress (B-out, i.e. the replies to A) also → index 0. So index 0 is
+# the union of both containers' OUTBOUND; if it jumps far past A's own outbound,
+# B genuinely sent replies — letting us tell "no connectivity" from "veth-egress
+# doesn't observe inbound".
+tc qdisc add dev "$VETH_B" clsact 2>/dev/null || true
+tc filter add dev "$VETH_B" ingress bpf da obj counter.bpf.o sec classifier/ingress
+echo "    OK: A veth ingress+egress, B veth ingress"
+
+echo "==> 4/5: snapshotting counters, pinging A→B, re-reading"
+MAP_ID=$(bpftool map show | awk '/name pkt_counter/ {print $1}' | tr -d ':' | head -1)
+[ -n "$MAP_ID" ] || { echo "    FAIL: pkt_counter map not visible" >&2; exit 1; }
+read_counter() {
+    bpftool map lookup id "$MAP_ID" key hex 0$1 00 00 00 \
+        | awk '/value/ {for (i=NF; i>1; i--) printf "%s", $i; print ""}' \
+        | sed 's/[^0-9a-f]//g' | xargs -I{} printf "%d\n" "0x{}"
+}
+BEFORE_VETHIN=$(read_counter 0); BEFORE_AEG=$(read_counter 1)
+echo "    before: veth-ingress(A-out+B-out)=$BEFORE_VETHIN  A-veth-egress(A-in)=$BEFORE_AEG"
+PING_OUT="$(incus exec "$CT_A" -- ping -c 5 -W 2 "$IP_B" </dev/null 2>&1 || true)"
+RECV="$(printf '%s' "$PING_OUT" | grep -oE '[0-9]+ (packets )?received' | grep -oE '^[0-9]+' | head -1)"
+AFTER_VETHIN=$(read_counter 0); AFTER_AEG=$(read_counter 1)
+echo "    ping:   ${RECV:-0}/5 replies received"
+echo "    after:  veth-ingress(A-out+B-out)=$AFTER_VETHIN  A-veth-egress(A-in)=$AFTER_AEG"
+
+echo "==> 5/5: interpretation"
+echo "    veth-ingress delta = $((AFTER_VETHIN - BEFORE_VETHIN))   A-veth-egress delta = $((AFTER_AEG - BEFORE_AEG))"
+if [ "${RECV:-0}" -gt 0 ] && [ "$((AFTER_AEG - BEFORE_AEG))" -eq 0 ]; then
+    echo ""
+    echo "  ✗ FINDING: replies flowed (${RECV}/5) and were counted at the SENDER's veth"
+    echo "    ingress, but A's veth-EGRESS never fired — bridge-forwarded inbound bypasses"
+    echo "    the destination veth's tc-egress too. Phase A must observe/enforce at each"
+    echo "    container's veth INGRESS (captures that container's outbound = every flow's"
+    echo "    sender side); tc-egress on bridge/veth is not a reliable hook."
+    exit 1
+elif [ "${RECV:-0}" -eq 0 ]; then
+    echo ""
+    echo "  ⚠ INCONCLUSIVE: ping got 0 replies — intra-bridge connectivity issue, not a"
+    echo "    hook result. Fix connectivity (default profile / firewall) and re-run." >&2
+    exit 2
+else
+    echo ""
+    echo "  ✓ A's veth-egress DID observe inbound (delta>0) — per-veth attach sees both"
+    echo "    directions; Phase A can attach ingress+egress at the container veth."
+fi


### PR DESCRIPTION
Follow-on to the Phase 0 hardware validation (#315). Phase 0.5 settles the attach-point question the whole network-isolation design hinges on — and the answer is **not** what the design assumed.

## What was run (real backend: kernel 6.8, Incus 6.23)

| Attach point | A→B ping result |
|---|---|
| `incusbr0` master, TC_INGRESS + TC_EGRESS (Phase 0) | ingress counted, **egress 0** |
| per-container **veth**, TC_INGRESS + TC_EGRESS (Phase 0.5) | A-veth ingress counted A's outbound; **A-veth egress 0** despite **5/5 replies received** (replies were counted at *B's* veth ingress) |

So bridge-forwarded **inbound** bypasses the destination veth's tc-egress too — `TC_EGRESS` on bridge/bridge-slave devices is simply not a usable hook for inter-container traffic.

## The corrected model

**`TC_INGRESS` on each container's host veth.** It captures that container's *entire* outbound = the **sender side of every flow**:
- **Observation** = union of every container's veth-ingress hook (each flow counted once, at its sender).
- **Enforcement** = a container's egress policy enforced at *its* veth ingress; to block Y→X, drop at **Y's** veth ingress. No egress hook needed.

## Changes

- `docs/security/NETWORK-ISOLATION-DESIGN.md`: the design assumed `incusbr0` TC_INGRESS+TC_EGRESS — revised the "right shape", the architecture sketch, the BPF-programs piece, a new **veth-discovery/lifecycle** piece (`volatile.eth0.host_name` + `iflink` fallback), a **"Phase 0 validation findings"** section, and the phase table (Phase 0 → ✅ done).
- `experimental/ebpf-phase0/validate-veth.sh`: the harness that produces the result (attaches at the veth, cross-checks the sender's veth ingress + ping reply count to distinguish "no connectivity" from "egress hook blind"). Observation-only, cleanup trap, `</dev/null`-hardened incus calls.

## Verification

Run on the GPU backend: `5/5 replies received`, veth-ingress Δ=15 (both A's requests and B's replies), **A-veth-egress Δ=0**. Host left clean (no qdiscs/containers), tenants unaffected. This unblocks Phase A on a correct foundation instead of discovering the dead-end mid-build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)