### PR TITLE
feat(netbpf): host-veth discovery for network policy (Phase A piece 4, #315)

### DIFF
--- a/internal/netbpf/veth.go
+++ b/internal/netbpf/veth.go
@@ -1,0 +1,65 @@
+// Package netbpf holds the host-side plumbing for the per-tenant network
+// isolation feature (#315, Phase A): resolving each container's host veth (so
+// the tc-bpf TC_INGRESS program can be attached to the sender side of every
+// flow — see docs/security/NETWORK-ISOLATION-DESIGN.md, "Phase 0 validation
+// findings") and, on Linux, loading/attaching the BPF programs themselves.
+//
+// This file is the veth-discovery half and is deliberately pure Go with no
+// cilium/ebpf or netlink dependency, so it builds and unit-tests on every
+// platform. The Linux-only attach/load path lives behind build tags in a
+// later increment.
+package netbpf
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+)
+
+// HostVethFromConfig resolves a container's host-side veth interface name from
+// its Incus instance config. Incus records the host end of each NIC's veth pair
+// in a volatile key once the container has started:
+//
+//	volatile.eth0.host_name = "vethXXXXXXXX"
+//
+// Resolution order:
+//  1. volatile.eth0.host_name — the conventional primary NIC.
+//  2. the lexicographically-first volatile.<nic>.host_name otherwise, so a
+//     container whose primary NIC isn't named eth0 still resolves.
+//
+// Returns "" if the config carries no veth host_name (e.g. the container is
+// stopped, or its NIC is a non-veth type such as a physical/SR-IOV passthrough).
+// On "" the caller falls back to the Linux-only iflink lookup (mapping the
+// container's eth0 iflink to a host interface), which validate-veth.sh exercises.
+func HostVethFromConfig(config map[string]string) string {
+	if v := strings.TrimSpace(config["volatile.eth0.host_name"]); v != "" {
+		return v
+	}
+	// No eth0: scan for any volatile.<nic>.host_name and pick deterministically.
+	var keys []string
+	for k, v := range config {
+		if strings.HasPrefix(k, "volatile.") && strings.HasSuffix(k, ".host_name") && strings.TrimSpace(v) != "" {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) == 0 {
+		return ""
+	}
+	sort.Strings(keys)
+	return strings.TrimSpace(config[keys[0]])
+}
+
+// VethIndex resolves a host veth interface name to its kernel ifindex — the
+// handle link.AttachTCX needs. Thin wrapper over net.InterfaceByName so the
+// not-found path has a single, testable error shape.
+func VethIndex(name string) (int, error) {
+	if name == "" {
+		return 0, fmt.Errorf("veth name is empty")
+	}
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return 0, fmt.Errorf("resolve host veth %q: %w", name, err)
+	}
+	return iface.Index, nil
+}

--- a/internal/netbpf/veth_test.go
+++ b/internal/netbpf/veth_test.go
@@ -1,0 +1,67 @@
+package netbpf
+
+import "testing"
+
+func TestHostVethFromConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		config map[string]string
+		want   string
+	}{
+		{
+			name:   "primary eth0",
+			config: map[string]string{"volatile.eth0.host_name": "veth1a2b3c4d", "volatile.eth0.hwaddr": "00:16:3e:aa:bb:cc"},
+			want:   "veth1a2b3c4d",
+		},
+		{
+			name:   "eth0 preferred over other nics",
+			config: map[string]string{"volatile.eth1.host_name": "vethZZZZ", "volatile.eth0.host_name": "vethEEEE"},
+			want:   "vethEEEE",
+		},
+		{
+			name:   "non-eth0 nic falls back to lexicographically first",
+			config: map[string]string{"volatile.net9.host_name": "vethNINE", "volatile.net1.host_name": "vethONE"},
+			want:   "vethONE",
+		},
+		{
+			name:   "whitespace trimmed",
+			config: map[string]string{"volatile.eth0.host_name": "  vethTRIM  "},
+			want:   "vethTRIM",
+		},
+		{
+			name:   "empty value ignored",
+			config: map[string]string{"volatile.eth0.host_name": "   ", "volatile.eth1.host_name": "vethREAL"},
+			want:   "vethREAL",
+		},
+		{
+			name:   "stopped container with no host_name",
+			config: map[string]string{"volatile.eth0.hwaddr": "00:16:3e:aa:bb:cc"},
+			want:   "",
+		},
+		{
+			name:   "nil config",
+			config: nil,
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HostVethFromConfig(tt.config); got != tt.want {
+				t.Errorf("HostVethFromConfig() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVethIndex_Empty(t *testing.T) {
+	if _, err := VethIndex(""); err == nil {
+		t.Fatal("expected error for empty veth name")
+	}
+}
+
+func TestVethIndex_NotFound(t *testing.T) {
+	// A name that cannot exist as an interface.
+	if _, err := VethIndex("veth-does-not-exist-zzzz"); err == nil {
+		t.Fatal("expected error for nonexistent interface")
+	}
+}


### PR DESCRIPTION
Increment 4 of the network-isolation control plane (#315, Phase A). Builds on #430 (data model + compiler), #431 (service CRUD + store), #432 (Postgres persistence + CLI).

## What

The veth-discovery brick the tc-bpf loader needs. Per the Phase 0 findings (`docs/security/NETWORK-ISOLATION-DESIGN.md`), the reliable attach point for inter-container traffic is each container's **host-side veth in TC_INGRESS** — the sender side of every flow. Before attaching a program we must resolve that veth.

New package `internal/netbpf`:
- **`HostVethFromConfig`** — resolve a container's host veth name from its Incus volatile config. Primary `volatile.eth0.host_name`; deterministic fallback to the lexicographically-first `volatile.<nic>.host_name` for non-eth0 primary NICs. Returns `""` when the container is stopped / has no veth, signalling the caller to use the Linux-only iflink fallback that `validate-veth.sh` exercises.
- **`VethIndex`** — resolve a veth name to its kernel ifindex (the handle `link.AttachTCX` consumes), with a single testable not-found error shape.

Pure Go — no cilium/ebpf or netlink dependency — so it builds and unit-tests on every platform.

## Why a separate package, not a method on the incus client

`internal/netbpf` is `internal/`; `pkg/core/incus` is `pkg/`. Hanging the resolver off the incus client would invert the layering (`pkg/` depending on `internal/`). The daemon-side loader (next increment, in `internal/`) composes the client's existing `GetRawInstance` with `netbpf.HostVethFromConfig` at the call site.

## Test

`go build ./...`, `go vet`, `gofmt` clean; `go test ./internal/netbpf/` passes (config-resolution table + VethIndex error paths).

## Follow-up (Phase A piece 5)

The Linux-only load/attach path: the tc-bpf TC_INGRESS policy program (C) + cilium/ebpf loader that populates the policy maps from a `netpolicy.CompiledPolicy` and attaches to a resolved veth. Hardware-validated on a Linux backend per the Phase 0 pattern (the load-bearing risk — it caught two real bugs + an architectural correction in Phase 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)