### PR TITLE
feat(backends): promote /v1/backends to a proto-first ListBackends RPC (#354)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -617,6 +617,30 @@
         ]
       }
     },
+    "/v1/backends": {
+      "get": {
+        "summary": "List backends",
+        "description": "Lists every backend in the fleet (local daemon + tunnel peers) with health, version, OS, running container count, and GPU inventory. Admin-only — discloses fleet topology.",
+        "operationId": "ContainerService_ListBackends",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListBackendsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "System"
+        ]
+      }
+    },
     "/v1/containers": {
       "get": {
         "summary": "List all containers",
@@ -4559,6 +4583,77 @@
       "description": "- APP_STATE_UNSPECIFIED: Unspecified state (should not be used)\n - APP_STATE_UPLOADING: Source code is being uploaded\n - APP_STATE_BUILDING: Container image is being built (using Podman)\n - APP_STATE_RUNNING: App is running and healthy\n - APP_STATE_STOPPED: App is stopped by user\n - APP_STATE_FAILED: Build or runtime failure\n - APP_STATE_RESTARTING: App is restarting",
       "title": "AppState represents the lifecycle state of an application"
     },
+    "BackendGPU": {
+      "type": "object",
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "description": "GPU vendor string (e.g. \"GPU_VENDOR_NVIDIA\")."
+        },
+        "modelName": {
+          "type": "string",
+          "description": "Human-readable GPU model name."
+        },
+        "vramBytes": {
+          "type": "string",
+          "format": "int64",
+          "description": "Total VRAM in bytes."
+        }
+      },
+      "description": "BackendGPU describes one GPU on a backend."
+    },
+    "BackendInfo": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique backend identifier (e.g., \"gcp-spot\", \"tunnel-node-a\")."
+        },
+        "type": {
+          "type": "string",
+          "description": "Backend kind: \"local\" for this daemon, \"tunnel\" for a peer."
+        },
+        "healthy": {
+          "type": "boolean",
+          "description": "Whether the backend is currently healthy / reachable."
+        },
+        "version": {
+          "type": "string",
+          "description": "Containarium daemon version running on this backend (e.g. \"0.21.0\")."
+        },
+        "hostname": {
+          "type": "string",
+          "description": "Hostname of the backend."
+        },
+        "uptimeSeconds": {
+          "type": "string",
+          "format": "int64",
+          "description": "Seconds this backend has been up (local backend only)."
+        },
+        "lastSeenAt": {
+          "type": "string",
+          "description": "RFC3339 timestamp this backend was last seen (peers)."
+        },
+        "os": {
+          "type": "string",
+          "description": "Operating-system string of the backend."
+        },
+        "containerCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of containers currently running on this backend."
+        },
+        "gpus": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/BackendGPU"
+          },
+          "description": "GPUs present on this backend."
+        }
+      },
+      "description": "BackendInfo describes one backend in the fleet — the local daemon\nplus any tunnel-connected peers. Emitted by ListBackends (GET\n/v1/backends). The field shape is the wire contract the CLI and MCP\nclients consume; it supersedes the hand-coded /v1/backends handler\nthis RPC replaced (see #354)."
+    },
     "BuildpackOptions": {
       "type": "object",
       "properties": {
@@ -6349,6 +6444,20 @@
           "title": "Total count"
         }
       }
+    },
+    "ListBackendsResponse": {
+      "type": "object",
+      "properties": {
+        "backends": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/BackendInfo"
+          },
+          "title": "List of available backends"
+        }
+      },
+      "title": "ListBackendsResponse is the response from listing backends"
     },
     "ListClamavReportsResponse": {
       "type": "object",

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -626,15 +626,23 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 		log.Printf("Audit logs endpoint enabled at /v1/audit/logs")
 	}
 
-	// Backends endpoint — JWT-authenticated, same as /v1/containers et al.
-	// Previously left open with the comment "for web UI backend selector",
-	// but the web UI never actually called this endpoint, and an
-	// unauthenticated /v1/backends leaks fleet topology (peer IDs,
-	// hostnames, GPU inventory) to anyone who can reach the gateway.
+	// Backends endpoint. The LIST (GET /v1/backends) is now the proto-first
+	// ContainerService.ListBackends RPC — it flows through the grpc-gateway
+	// (corsHandler) like every other /v1/ route, so the wire shape is
+	// generated from BackendInfo and can't drift from the CLI / MCP / cloud
+	// consumers (#354, proto-first convention). We register the exact path
+	// explicitly so http.ServeMux does NOT 301-redirect it into the
+	// trailing-slash subtree below.
+	//
+	// The per-backend forward (GET /v1/backends/{id}/system-info) is still
+	// the hand-coded handler — it proxies to a specific peer rather than
+	// returning a generated message — mounted on the subtree only. Auth on
+	// the RPC path is the gRPC ListBackends admin check + JWT interceptor
+	// (RequireRole admin); the subtree keeps its own JWT middleware.
+	httpMux.Handle("/v1/backends", corsHandler)
 	if gs.backendsHandler != nil {
 		authed := gs.authMiddleware.HTTPMiddleware(http.HandlerFunc(gs.backendsHandler))
 		httpMux.Handle("/v1/backends/", authed)
-		httpMux.Handle("/v1/backends", authed)
 	}
 
 	// Sentinel-facing endpoints: /certs and /authorized-keys[/sentinel].

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1066,11 +1066,12 @@ type GetSystemInfoResponse struct {
 	Info SystemInfo `json:"info"`
 }
 
-// ListBackendsResponse mirrors the hand-coded /v1/backends handler. The
-// shape isn't proto-generated, so JSON tag conventions follow what the
-// handler emits (camelCase, not snake_case). int64 fields here are
-// emitted as numbers (the handler is hand-coded, not grpc-gateway), so
-// no `,string` tags needed.
+// ListBackendsResponse mirrors the /v1/backends wire shape — now the
+// proto-first ContainerService.ListBackends RPC (BackendInfo), which
+// replaced the former hand-coded handler (#354). The MCP client keeps its
+// own struct rather than importing the generated type; the field tags are
+// the grpc-gateway camelCase the gateway emits, and int64 fields arrive as
+// numbers, so no `,string` tags are needed.
 type ListBackendsResponse struct {
 	Backends []Backend `json:"backends"`
 }

--- a/internal/server/backends_handler_test.go
+++ b/internal/server/backends_handler_test.go
@@ -1,13 +1,24 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
-func TestBackendsHandler_ListBackends(t *testing.T) {
+// TestContainerServer_ListBackends exercises the proto-first ListBackends
+// RPC that replaced the hand-coded /v1/backends list handler (#354): the
+// local backend plus any tunnel peers, with health and type. The local
+// GetSystemInfo enrichment (OS / container count / GPUs) needs Incus, so a
+// nil manager here degrades to identity + health — which is exactly what
+// the method must return on a daemon that can't reach its manager.
+func TestContainerServer_ListBackends(t *testing.T) {
 	pool := NewPeerPool("local-spot", "", nil, "")
 	pool.mu.Lock()
 	pool.peers["tunnel-gpu"] = &PeerClient{
@@ -17,65 +28,33 @@ func TestBackendsHandler_ListBackends(t *testing.T) {
 	}
 	pool.mu.Unlock()
 
-	// Simulate the handler logic (same as DualServer.backendsHandler)
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		type backendInfo struct {
-			ID      string `json:"id"`
-			Type    string `json:"type"`
-			Healthy bool   `json:"healthy"`
-		}
-		var backends []backendInfo
-		backends = append(backends, backendInfo{
-			ID:      pool.LocalBackendID(),
-			Type:    "local",
-			Healthy: true,
-		})
-		for _, peer := range pool.Peers() {
-			backends = append(backends, backendInfo{
-				ID:      peer.ID,
-				Type:    "tunnel",
-				Healthy: peer.Healthy,
-			})
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{"backends": backends})
-	})
+	s := &ContainerServer{peerPool: pool, startTime: time.Now().Add(-time.Minute)}
+	ctx := auth.ContextWithTestSubject(context.Background(), "ops", auth.RoleAdmin)
 
-	req := httptest.NewRequest("GET", "/v1/backends", nil)
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-
-	if rec.Code != 200 {
-		t.Fatalf("expected 200, got %d", rec.Code)
+	resp, err := s.ListBackends(ctx, &pb.ListBackendsRequest{})
+	if err != nil {
+		t.Fatalf("ListBackends: %v", err)
 	}
-
-	var resp struct {
-		Backends []struct {
-			ID      string `json:"id"`
-			Type    string `json:"type"`
-			Healthy bool   `json:"healthy"`
-		} `json:"backends"`
-	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("failed to parse response: %v", err)
-	}
-
 	if len(resp.Backends) != 2 {
 		t.Fatalf("expected 2 backends, got %d", len(resp.Backends))
 	}
 
-	// Local backend
-	if resp.Backends[0].ID != "local-spot" {
-		t.Errorf("expected local backend ID 'local-spot', got %q", resp.Backends[0].ID)
+	// Local backend is first, healthy, with uptime derived from startTime.
+	local := resp.Backends[0]
+	if local.Id != "local-spot" || local.Type != "local" {
+		t.Errorf("local backend wrong: id=%q type=%q", local.Id, local.Type)
 	}
-	if resp.Backends[0].Type != "local" {
-		t.Errorf("expected type 'local', got %q", resp.Backends[0].Type)
+	if !local.Healthy {
+		t.Error("local backend should be healthy")
+	}
+	if local.UptimeSeconds <= 0 {
+		t.Errorf("expected positive uptime, got %d", local.UptimeSeconds)
 	}
 
-	// Tunnel backend
+	// Tunnel peer present, typed, healthy.
 	found := false
 	for _, b := range resp.Backends {
-		if b.ID == "tunnel-gpu" {
+		if b.Id == "tunnel-gpu" {
 			found = true
 			if b.Type != "tunnel" {
 				t.Errorf("expected type 'tunnel', got %q", b.Type)
@@ -87,6 +66,16 @@ func TestBackendsHandler_ListBackends(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected to find tunnel-gpu in backends list")
+	}
+}
+
+// TestContainerServer_ListBackends_RequiresAdmin proves the admin gate: a
+// non-admin token never enumerates the fleet (topology is operator-grade).
+func TestContainerServer_ListBackends_RequiresAdmin(t *testing.T) {
+	s := &ContainerServer{peerPool: NewPeerPool("local-spot", "", nil, "")}
+	ctx := auth.ContextWithTestSubject(context.Background(), "tenant", "member")
+	if _, err := s.ListBackends(ctx, &pb.ListBackendsRequest{}); err == nil {
+		t.Fatal("expected RequireRole to reject a non-admin caller")
 	}
 }
 

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -62,6 +62,11 @@ type ContainerServer struct {
 	coreServices       *CoreServices
 	daemonConfigStore  *app.DaemonConfigStore
 	peerPool           *PeerPool
+	// startTime is when this daemon process started; ListBackends reports
+	// the local backend's uptime from it. Set by DualServer wiring
+	// (SetStartTime); zero on a server that was never wired, in which case
+	// uptime is reported as 0.
+	startTime time.Time
 	// Route / Caddy cleanup deps (set by DualServer wiring, may be nil if
 	// the daemon was started without --app-hosting). Used by DeleteContainer
 	// to cascade-remove the routes / TLS-automation subjects a container
@@ -1830,6 +1835,103 @@ func (s *ContainerServer) GetSystemInfo(ctx context.Context, req *pb.GetSystemIn
 	}, nil
 }
 
+// ListBackends returns the fleet topology — the local daemon plus any
+// tunnel-connected peers — with per-backend health, version, OS, running
+// container count, and GPU inventory. This is the proto-first replacement
+// for the former hand-coded /v1/backends HTTP handler (#354): the wire
+// shape is now generated from BackendInfo, so the CLI / MCP clients and
+// the cloud control plane all share one contract that cannot drift.
+//
+// Admin-only: the response discloses fleet topology (peer IDs, hostnames,
+// GPU inventory), which is operator-grade, not tenant-grade. The cloud
+// control plane redacts it per-tenant at its own boundary.
+func (s *ContainerServer) ListBackends(ctx context.Context, _ *pb.ListBackendsRequest) (*pb.ListBackendsResponse, error) {
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+
+	// Without a peer pool this daemon has no backend identity to report
+	// (the local backend ID comes from the pool), so the fleet view is
+	// empty — same behavior as the handler this replaced.
+	if s.peerPool == nil {
+		return &pb.ListBackendsResponse{}, nil
+	}
+
+	backends := make([]*pb.BackendInfo, 0, 1+len(s.peerPool.Peers()))
+
+	// Local backend. OS / container count / GPUs come from GetSystemInfo;
+	// uptime from the wired process start time.
+	local := &pb.BackendInfo{
+		Id:      s.peerPool.LocalBackendID(),
+		Type:    "local",
+		Healthy: true,
+		Version: version.GetVersion(),
+	}
+	if !s.startTime.IsZero() {
+		local.UptimeSeconds = int64(time.Since(s.startTime).Seconds())
+	}
+	// OS / container count / GPUs come from GetSystemInfo, which needs the
+	// container manager + Incus. Guard the nil manager so a daemon (or test)
+	// without one still reports the local backend's identity + health
+	// instead of panicking.
+	if s.manager != nil {
+		if sysResp, err := s.GetSystemInfo(ctx, &pb.GetSystemInfoRequest{}); err == nil && sysResp.Info != nil {
+			local.Hostname = sysResp.Info.Hostname
+			local.Os = sysResp.Info.Os
+			local.ContainerCount = sysResp.Info.ContainersRunning
+			local.Gpus = backendGPUsFromSystemInfo(sysResp.Info)
+		}
+	}
+	backends = append(backends, local)
+
+	// Peer backends. Forward GetSystemInfo to each healthy peer using the
+	// caller's (admin) token — the same mechanism GetSystemInfo's peer
+	// fan-out uses.
+	authToken := extractAuthToken(ctx)
+	for _, peer := range s.peerPool.Peers() {
+		pi := &pb.BackendInfo{
+			Id:      peer.ID,
+			Type:    "tunnel",
+			Healthy: peer.Healthy,
+		}
+		if !peer.LastSeenAt.IsZero() {
+			pi.LastSeenAt = peer.LastSeenAt.UTC().Format(time.RFC3339)
+		}
+		if peer.Healthy {
+			if body, err := peer.ForwardGetSystemInfo(authToken); err == nil {
+				var peerResp pb.GetSystemInfoResponse
+				if protojson.Unmarshal(body, &peerResp) == nil && peerResp.Info != nil {
+					pi.Hostname = peerResp.Info.Hostname
+					pi.Os = peerResp.Info.Os
+					pi.Version = peerResp.Info.DaemonVersion
+					pi.ContainerCount = peerResp.Info.ContainersRunning
+					pi.Gpus = backendGPUsFromSystemInfo(peerResp.Info)
+				}
+			}
+		}
+		backends = append(backends, pi)
+	}
+
+	return &pb.ListBackendsResponse{Backends: backends}, nil
+}
+
+// backendGPUsFromSystemInfo projects a SystemInfo's GPU list onto the
+// BackendInfo GPU wire shape (vendor string, model name, VRAM bytes).
+func backendGPUsFromSystemInfo(info *pb.SystemInfo) []*pb.BackendGPU {
+	if len(info.Gpus) == 0 {
+		return nil
+	}
+	out := make([]*pb.BackendGPU, 0, len(info.Gpus))
+	for _, g := range info.Gpus {
+		out = append(out, &pb.BackendGPU{
+			Vendor:    g.Vendor.String(),
+			ModelName: g.ModelName,
+			VramBytes: g.VramBytes,
+		})
+	}
+	return out
+}
+
 // mapGPUVendor maps a vendor string to the proto enum.
 func mapGPUVendor(vendor string) pb.GPUVendor {
 	v := strings.ToLower(vendor)
@@ -2016,6 +2118,12 @@ func extractAuthToken(ctx context.Context) string {
 // SetPeerPool sets the peer pool for multi-backend support
 func (s *ContainerServer) SetPeerPool(pool *PeerPool) {
 	s.peerPool = pool
+}
+
+// SetStartTime wires the daemon's process start time so ListBackends can
+// report the local backend's uptime. Called once from DualServer setup.
+func (s *ContainerServer) SetStartTime(t time.Time) {
+	s.startTime = t
 }
 
 // SetOTelCollectorEndpoint wires the OTLP/HTTP URL of this daemon's

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -41,11 +40,9 @@ import (
 	"github.com/footprintai/containarium/pkg/core/network"
 	corecryptosecrets "github.com/footprintai/containarium/pkg/core/secrets"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
-	"github.com/footprintai/containarium/pkg/version"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // DualServerConfig holds configuration for the dual server
@@ -1282,8 +1279,11 @@ skipAppHosting:
 }
 
 // Start starts both gRPC and HTTP servers
-// backendsHandler returns an HTTP handler for the /v1/backends endpoint.
-// It also handles /v1/backends/{id}/system-info for per-backend system info.
+// backendsHandler serves /v1/backends/{id}/system-info — forwarding a
+// per-backend system-info request to a specific peer. The list
+// (GET /v1/backends) is no longer here: it is now the proto-first
+// ContainerService.ListBackends RPC served via the grpc-gateway (#354),
+// so this handler is mounted on the /v1/backends/ subtree only.
 //
 // Admin-only (Phase 1.4 / audit finding A-MED-4). The endpoint
 // discloses fleet topology — peer IDs, hostnames, OS versions,
@@ -1304,106 +1304,6 @@ func (ds *DualServer) backendsHandler() http.HandlerFunc {
 		if strings.Contains(path, "/system-info") {
 			backendID := strings.Split(path, "/")[0]
 			ds.handleBackendSystemInfo(w, r, backendID)
-			return
-		}
-
-		// /v1/backends — list all backends
-		if path == "" {
-			type gpuInfo struct {
-				Vendor    string `json:"vendor,omitempty"`
-				ModelName string `json:"modelName,omitempty"`
-				VRAMBytes int64  `json:"vramBytes,omitempty"`
-			}
-			type backendInfo struct {
-				ID             string    `json:"id"`
-				Type           string    `json:"type"`
-				Healthy        bool      `json:"healthy"`
-				Version        string    `json:"version,omitempty"`
-				Hostname       string    `json:"hostname,omitempty"`
-				UptimeSeconds  int64     `json:"uptimeSeconds,omitempty"`
-				LastSeenAt     string    `json:"lastSeenAt,omitempty"`
-				OS             string    `json:"os,omitempty"`
-				ContainerCount int32     `json:"containerCount"`
-				GPUs           []gpuInfo `json:"gpus,omitempty"`
-			}
-
-			var backends []backendInfo
-
-			if ds.peerPool != nil {
-				// Local backend info
-				hostname, _ := os.Hostname()
-				localInfo := backendInfo{
-					ID:            ds.peerPool.LocalBackendID(),
-					Type:          "local",
-					Healthy:       true,
-					Version:       version.GetVersion(),
-					Hostname:      hostname,
-					UptimeSeconds: int64(time.Since(ds.startTime).Seconds()),
-					LastSeenAt:    time.Now().UTC().Format(time.RFC3339),
-				}
-
-				// Get local system info for OS and container count
-				if ds.containerServer != nil {
-					sysResp, err := ds.containerServer.GetSystemInfo(context.Background(), &pb.GetSystemInfoRequest{})
-					if err == nil && sysResp.Info != nil {
-						localInfo.OS = sysResp.Info.Os
-						localInfo.ContainerCount = sysResp.Info.ContainersRunning
-						for _, g := range sysResp.Info.Gpus {
-							localInfo.GPUs = append(localInfo.GPUs, gpuInfo{
-								Vendor:    g.Vendor.String(),
-								ModelName: g.ModelName,
-								VRAMBytes: g.VramBytes,
-							})
-						}
-					}
-				}
-
-				backends = append(backends, localInfo)
-
-				// Peer backends — generate service token for peer API calls
-				serviceToken := ""
-				if ds.tokenManager != nil {
-					if t, err := ds.tokenManager.GenerateToken("_system", []string{"admin"}, 30*time.Second); err == nil {
-						serviceToken = t
-					}
-				}
-
-				for _, peer := range ds.peerPool.Peers() {
-					peerInfo := backendInfo{
-						ID:      peer.ID,
-						Type:    "tunnel",
-						Healthy: peer.Healthy,
-					}
-					if !peer.LastSeenAt.IsZero() {
-						peerInfo.LastSeenAt = peer.LastSeenAt.UTC().Format(time.RFC3339)
-					}
-					// Fetch live system info from peer using service token
-					if peer.Healthy && serviceToken != "" {
-						if body, err := peer.ForwardGetSystemInfo(serviceToken); err == nil {
-							var peerResp pb.GetSystemInfoResponse
-							if protojson.Unmarshal(body, &peerResp) == nil && peerResp.Info != nil {
-								peerInfo.Hostname = peerResp.Info.Hostname
-								peerInfo.OS = peerResp.Info.Os
-								peerInfo.Version = peerResp.Info.DaemonVersion // #354: per-backend version
-								peerInfo.ContainerCount = peerResp.Info.ContainersRunning
-								for _, g := range peerResp.Info.Gpus {
-									peerInfo.GPUs = append(peerInfo.GPUs, gpuInfo{
-										Vendor:    g.Vendor.String(),
-										ModelName: g.ModelName,
-										VRAMBytes: g.VramBytes,
-									})
-								}
-							}
-						}
-					}
-					backends = append(backends, peerInfo)
-				}
-			}
-
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"backends": backends,
-			})
 			return
 		}
 
@@ -1533,6 +1433,8 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		}
 		ds.peerPool.StartDiscovery(ctx)
 		ds.containerServer.SetPeerPool(ds.peerPool)
+		// Local-backend uptime for ListBackends (GET /v1/backends).
+		ds.containerServer.SetStartTime(ds.startTime)
 
 		// Migration runner: shells out to `incus snapshot/copy/...`.
 		// Only useful in conjunction with peerPool (you can't migrate

--- a/pkg/pb/containarium/v1/config.pb.go
+++ b/pkg/pb/containarium/v1/config.pb.go
@@ -2065,17 +2065,33 @@ func (*DeleteNetworkPolicyResponse) Descriptor() ([]byte, []int) {
 	return file_containarium_v1_config_proto_rawDescGZIP(), []int{25}
 }
 
-// BackendInfo contains information about a backend instance
+// BackendInfo describes one backend in the fleet — the local daemon
+// plus any tunnel-connected peers. Emitted by ListBackends (GET
+// /v1/backends). The field shape is the wire contract the CLI and MCP
+// clients consume; it supersedes the hand-coded /v1/backends handler
+// this RPC replaced (see #354).
 type BackendInfo struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Unique backend identifier (e.g., "gcp-spot", "tunnel-node-a-gpu")
+	// Unique backend identifier (e.g., "gcp-spot", "tunnel-node-a").
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	// Backend type
-	Type BackendType `protobuf:"varint,2,opt,name=type,proto3,enum=containarium.v1.BackendType" json:"type,omitempty"`
-	// Whether the backend is currently healthy
+	// Backend kind: "local" for this daemon, "tunnel" for a peer.
+	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	// Whether the backend is currently healthy / reachable.
 	Healthy bool `protobuf:"varint,3,opt,name=healthy,proto3" json:"healthy,omitempty"`
-	// Priority (lower = preferred, GCP=0, tunnel=10)
-	Priority      int32 `protobuf:"varint,4,opt,name=priority,proto3" json:"priority,omitempty"`
+	// Containarium daemon version running on this backend (e.g. "0.21.0").
+	Version string `protobuf:"bytes,4,opt,name=version,proto3" json:"version,omitempty"`
+	// Hostname of the backend.
+	Hostname string `protobuf:"bytes,5,opt,name=hostname,proto3" json:"hostname,omitempty"`
+	// Seconds this backend has been up (local backend only).
+	UptimeSeconds int64 `protobuf:"varint,6,opt,name=uptime_seconds,json=uptimeSeconds,proto3" json:"uptime_seconds,omitempty"`
+	// RFC3339 timestamp this backend was last seen (peers).
+	LastSeenAt string `protobuf:"bytes,7,opt,name=last_seen_at,json=lastSeenAt,proto3" json:"last_seen_at,omitempty"`
+	// Operating-system string of the backend.
+	Os string `protobuf:"bytes,8,opt,name=os,proto3" json:"os,omitempty"`
+	// Number of containers currently running on this backend.
+	ContainerCount int32 `protobuf:"varint,9,opt,name=container_count,json=containerCount,proto3" json:"container_count,omitempty"`
+	// GPUs present on this backend.
+	Gpus          []*BackendGPU `protobuf:"bytes,10,rep,name=gpus,proto3" json:"gpus,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2117,11 +2133,11 @@ func (x *BackendInfo) GetId() string {
 	return ""
 }
 
-func (x *BackendInfo) GetType() BackendType {
+func (x *BackendInfo) GetType() string {
 	if x != nil {
 		return x.Type
 	}
-	return BackendType_BACKEND_TYPE_UNSPECIFIED
+	return ""
 }
 
 func (x *BackendInfo) GetHealthy() bool {
@@ -2131,9 +2147,115 @@ func (x *BackendInfo) GetHealthy() bool {
 	return false
 }
 
-func (x *BackendInfo) GetPriority() int32 {
+func (x *BackendInfo) GetVersion() string {
 	if x != nil {
-		return x.Priority
+		return x.Version
+	}
+	return ""
+}
+
+func (x *BackendInfo) GetHostname() string {
+	if x != nil {
+		return x.Hostname
+	}
+	return ""
+}
+
+func (x *BackendInfo) GetUptimeSeconds() int64 {
+	if x != nil {
+		return x.UptimeSeconds
+	}
+	return 0
+}
+
+func (x *BackendInfo) GetLastSeenAt() string {
+	if x != nil {
+		return x.LastSeenAt
+	}
+	return ""
+}
+
+func (x *BackendInfo) GetOs() string {
+	if x != nil {
+		return x.Os
+	}
+	return ""
+}
+
+func (x *BackendInfo) GetContainerCount() int32 {
+	if x != nil {
+		return x.ContainerCount
+	}
+	return 0
+}
+
+func (x *BackendInfo) GetGpus() []*BackendGPU {
+	if x != nil {
+		return x.Gpus
+	}
+	return nil
+}
+
+// BackendGPU describes one GPU on a backend.
+type BackendGPU struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// GPU vendor string (e.g. "GPU_VENDOR_NVIDIA").
+	Vendor string `protobuf:"bytes,1,opt,name=vendor,proto3" json:"vendor,omitempty"`
+	// Human-readable GPU model name.
+	ModelName string `protobuf:"bytes,2,opt,name=model_name,json=modelName,proto3" json:"model_name,omitempty"`
+	// Total VRAM in bytes.
+	VramBytes     int64 `protobuf:"varint,3,opt,name=vram_bytes,json=vramBytes,proto3" json:"vram_bytes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BackendGPU) Reset() {
+	*x = BackendGPU{}
+	mi := &file_containarium_v1_config_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BackendGPU) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BackendGPU) ProtoMessage() {}
+
+func (x *BackendGPU) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BackendGPU.ProtoReflect.Descriptor instead.
+func (*BackendGPU) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *BackendGPU) GetVendor() string {
+	if x != nil {
+		return x.Vendor
+	}
+	return ""
+}
+
+func (x *BackendGPU) GetModelName() string {
+	if x != nil {
+		return x.ModelName
+	}
+	return ""
+}
+
+func (x *BackendGPU) GetVramBytes() int64 {
+	if x != nil {
+		return x.VramBytes
 	}
 	return 0
 }
@@ -2147,7 +2269,7 @@ type ListBackendsRequest struct {
 
 func (x *ListBackendsRequest) Reset() {
 	*x = ListBackendsRequest{}
-	mi := &file_containarium_v1_config_proto_msgTypes[27]
+	mi := &file_containarium_v1_config_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2159,7 +2281,7 @@ func (x *ListBackendsRequest) String() string {
 func (*ListBackendsRequest) ProtoMessage() {}
 
 func (x *ListBackendsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[27]
+	mi := &file_containarium_v1_config_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2172,7 +2294,7 @@ func (x *ListBackendsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendsRequest.ProtoReflect.Descriptor instead.
 func (*ListBackendsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{27}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{28}
 }
 
 // ListBackendsResponse is the response from listing backends
@@ -2186,7 +2308,7 @@ type ListBackendsResponse struct {
 
 func (x *ListBackendsResponse) Reset() {
 	*x = ListBackendsResponse{}
-	mi := &file_containarium_v1_config_proto_msgTypes[28]
+	mi := &file_containarium_v1_config_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2198,7 +2320,7 @@ func (x *ListBackendsResponse) String() string {
 func (*ListBackendsResponse) ProtoMessage() {}
 
 func (x *ListBackendsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[28]
+	mi := &file_containarium_v1_config_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2211,7 +2333,7 @@ func (x *ListBackendsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendsResponse.ProtoReflect.Descriptor instead.
 func (*ListBackendsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{28}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListBackendsResponse) GetBackends() []*BackendInfo {
@@ -2354,12 +2476,27 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\bpolicies\x18\x01 \x03(\v2\x1e.containarium.v1.NetworkPolicyR\bpolicies\"4\n" +
 	"\x1aDeleteNetworkPolicyRequest\x12\x16\n" +
 	"\x06tenant\x18\x01 \x01(\tR\x06tenant\"\x1d\n" +
-	"\x1bDeleteNetworkPolicyResponse\"\x85\x01\n" +
+	"\x1bDeleteNetworkPolicyResponse\"\xb4\x02\n" +
 	"\vBackendInfo\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x120\n" +
-	"\x04type\x18\x02 \x01(\x0e2\x1c.containarium.v1.BackendTypeR\x04type\x12\x18\n" +
-	"\ahealthy\x18\x03 \x01(\bR\ahealthy\x12\x1a\n" +
-	"\bpriority\x18\x04 \x01(\x05R\bpriority\"\x15\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\tR\x04type\x12\x18\n" +
+	"\ahealthy\x18\x03 \x01(\bR\ahealthy\x12\x18\n" +
+	"\aversion\x18\x04 \x01(\tR\aversion\x12\x1a\n" +
+	"\bhostname\x18\x05 \x01(\tR\bhostname\x12%\n" +
+	"\x0euptime_seconds\x18\x06 \x01(\x03R\ruptimeSeconds\x12 \n" +
+	"\flast_seen_at\x18\a \x01(\tR\n" +
+	"lastSeenAt\x12\x0e\n" +
+	"\x02os\x18\b \x01(\tR\x02os\x12'\n" +
+	"\x0fcontainer_count\x18\t \x01(\x05R\x0econtainerCount\x12/\n" +
+	"\x04gpus\x18\n" +
+	" \x03(\v2\x1b.containarium.v1.BackendGPUR\x04gpus\"b\n" +
+	"\n" +
+	"BackendGPU\x12\x16\n" +
+	"\x06vendor\x18\x01 \x01(\tR\x06vendor\x12\x1d\n" +
+	"\n" +
+	"model_name\x18\x02 \x01(\tR\tmodelName\x12\x1d\n" +
+	"\n" +
+	"vram_bytes\x18\x03 \x01(\x03R\tvramBytes\"\x15\n" +
 	"\x13ListBackendsRequest\"P\n" +
 	"\x14ListBackendsResponse\x128\n" +
 	"\bbackends\x18\x01 \x03(\v2\x1c.containarium.v1.BackendInfoR\bbackends*h\n" +
@@ -2416,7 +2553,7 @@ func file_containarium_v1_config_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_config_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_containarium_v1_config_proto_goTypes = []any{
 	(GPUVendor)(0),                      // 0: containarium.v1.GPUVendor
 	(GPUModel)(0),                       // 1: containarium.v1.GPUModel
@@ -2450,18 +2587,19 @@ var file_containarium_v1_config_proto_goTypes = []any{
 	(*DeleteNetworkPolicyRequest)(nil),  // 29: containarium.v1.DeleteNetworkPolicyRequest
 	(*DeleteNetworkPolicyResponse)(nil), // 30: containarium.v1.DeleteNetworkPolicyResponse
 	(*BackendInfo)(nil),                 // 31: containarium.v1.BackendInfo
-	(*ListBackendsRequest)(nil),         // 32: containarium.v1.ListBackendsRequest
-	(*ListBackendsResponse)(nil),        // 33: containarium.v1.ListBackendsResponse
-	(*ResourceLimits)(nil),              // 34: containarium.v1.ResourceLimits
-	(OSType)(0),                         // 35: containarium.v1.OSType
+	(*BackendGPU)(nil),                  // 32: containarium.v1.BackendGPU
+	(*ListBackendsRequest)(nil),         // 33: containarium.v1.ListBackendsRequest
+	(*ListBackendsResponse)(nil),        // 34: containarium.v1.ListBackendsResponse
+	(*ResourceLimits)(nil),              // 35: containarium.v1.ResourceLimits
+	(OSType)(0),                         // 36: containarium.v1.OSType
 }
 var file_containarium_v1_config_proto_depIdxs = []int32{
 	6,  // 0: containarium.v1.Config.incus:type_name -> containarium.v1.IncusConfig
-	34, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
+	35, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
 	7,  // 2: containarium.v1.Config.network:type_name -> containarium.v1.NetworkConfig
 	8,  // 3: containarium.v1.Config.storage:type_name -> containarium.v1.StorageConfig
 	9,  // 4: containarium.v1.Config.security:type_name -> containarium.v1.SecurityConfig
-	35, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
+	36, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
 	5,  // 6: containarium.v1.GetConfigResponse.config:type_name -> containarium.v1.Config
 	5,  // 7: containarium.v1.UpdateConfigRequest.config:type_name -> containarium.v1.Config
 	5,  // 8: containarium.v1.UpdateConfigResponse.config:type_name -> containarium.v1.Config
@@ -2476,7 +2614,7 @@ var file_containarium_v1_config_proto_depIdxs = []int32{
 	22, // 17: containarium.v1.SetNetworkPolicyResponse.policy:type_name -> containarium.v1.NetworkPolicy
 	22, // 18: containarium.v1.GetNetworkPolicyResponse.policy:type_name -> containarium.v1.NetworkPolicy
 	22, // 19: containarium.v1.ListNetworkPoliciesResponse.policies:type_name -> containarium.v1.NetworkPolicy
-	3,  // 20: containarium.v1.BackendInfo.type:type_name -> containarium.v1.BackendType
+	32, // 20: containarium.v1.BackendInfo.gpus:type_name -> containarium.v1.BackendGPU
 	31, // 21: containarium.v1.ListBackendsResponse.backends:type_name -> containarium.v1.BackendInfo
 	22, // [22:22] is the sub-list for method output_type
 	22, // [22:22] is the sub-list for method input_type
@@ -2497,7 +2635,7 @@ func file_containarium_v1_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_config_proto_rawDesc), len(file_containarium_v1_config_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   29,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xe2g\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xa2j\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -82,7 +82,9 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x14Container Operations\x12\x1eList available software stacks\x1a\x86\x01Returns all configured software stacks including their parameters (name, type, default, etc.) for rendering the Create Container form.\x82\xd3\xe4\x93\x02\f\x12\n" +
 	"/v1/stacks\x12\x8b\x02\n" +
 	"\rGetSystemInfo\x12%.containarium.v1.GetSystemInfoRequest\x1a&.containarium.v1.GetSystemInfoResponse\"\xaa\x01\x92A\x8f\x01\n" +
-	"\x06System\x12\x16Get system information\x1amReturns information about the host system including Incus version, available resources, and container counts.\x82\xd3\xe4\x93\x02\x11\x12\x0f/v1/system/info\x12\xb4\x02\n" +
+	"\x06System\x12\x16Get system information\x1amReturns information about the host system including Incus version, available resources, and container counts.\x82\xd3\xe4\x93\x02\x11\x12\x0f/v1/system/info\x12\xbd\x02\n" +
+	"\fListBackends\x12$.containarium.v1.ListBackendsRequest\x1a%.containarium.v1.ListBackendsResponse\"\xdf\x01\x92A\xc7\x01\n" +
+	"\x06System\x12\rList backends\x1a\xad\x01Lists every backend in the fleet (local daemon + tunnel peers) with health, version, OS, running container count, and GPU inventory. Admin-only — discloses fleet topology.\x82\xd3\xe4\x93\x02\x0e\x12\f/v1/backends\x12\xb4\x02\n" +
 	"\x10GetLatestRelease\x12(.containarium.v1.GetLatestReleaseRequest\x1a).containarium.v1.GetLatestReleaseResponse\"\xca\x01\x92A\xab\x01\n" +
 	"\x06System\x12\x12Get latest release\x1a\x8c\x01Returns the latest Containarium release tag from GitHub (cached) alongside this daemon's running version and whether an update is available.\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/releases/latest\x12\xb9\x02\n" +
 	"\vValidateGPU\x12#.containarium.v1.ValidateGPURequest\x1a$.containarium.v1.ValidateGPUResponse\"\xde\x01\x92A\xbf\x01\n" +
@@ -156,65 +158,67 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*InstallStackRequest)(nil),            // 20: containarium.v1.InstallStackRequest
 	(*ListStacksRequest)(nil),              // 21: containarium.v1.ListStacksRequest
 	(*GetSystemInfoRequest)(nil),           // 22: containarium.v1.GetSystemInfoRequest
-	(*GetLatestReleaseRequest)(nil),        // 23: containarium.v1.GetLatestReleaseRequest
-	(*ValidateGPURequest)(nil),             // 24: containarium.v1.ValidateGPURequest
-	(*GetMonitoringInfoRequest)(nil),       // 25: containarium.v1.GetMonitoringInfoRequest
-	(*CreateAlertRuleRequest)(nil),         // 26: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),          // 27: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),            // 28: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),         // 29: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),         // 30: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),         // 31: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),   // 32: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),    // 33: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),             // 34: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),   // 35: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),               // 36: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),               // 37: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),             // 38: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),            // 39: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),          // 40: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),        // 41: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),         // 42: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),           // 43: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),         // 44: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),        // 45: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),         // 46: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),          // 47: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),        // 48: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),          // 49: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerResponse)(nil), // 50: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),       // 51: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),        // 52: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),        // 53: containarium.v1.SetContainerTTLResponse
-	(*AddSSHKeyResponse)(nil),              // 54: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),           // 55: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),        // 56: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),     // 57: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),      // 58: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),             // 59: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),            // 60: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),           // 61: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),             // 62: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),          // 63: containarium.v1.GetSystemInfoResponse
-	(*GetLatestReleaseResponse)(nil),       // 64: containarium.v1.GetLatestReleaseResponse
-	(*ValidateGPUResponse)(nil),            // 65: containarium.v1.ValidateGPUResponse
-	(*GetMonitoringInfoResponse)(nil),      // 66: containarium.v1.GetMonitoringInfoResponse
-	(*CreateAlertRuleResponse)(nil),        // 67: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),         // 68: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),           // 69: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),        // 70: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),        // 71: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),        // 72: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),  // 73: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),   // 74: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),            // 75: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),  // 76: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),              // 77: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),              // 78: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),            // 79: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),           // 80: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),         // 81: containarium.v1.RefreshSecretsResponse
+	(*ListBackendsRequest)(nil),            // 23: containarium.v1.ListBackendsRequest
+	(*GetLatestReleaseRequest)(nil),        // 24: containarium.v1.GetLatestReleaseRequest
+	(*ValidateGPURequest)(nil),             // 25: containarium.v1.ValidateGPURequest
+	(*GetMonitoringInfoRequest)(nil),       // 26: containarium.v1.GetMonitoringInfoRequest
+	(*CreateAlertRuleRequest)(nil),         // 27: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),          // 28: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),            // 29: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),         // 30: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),         // 31: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),         // 32: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),   // 33: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),    // 34: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),             // 35: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),   // 36: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),               // 37: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),               // 38: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),             // 39: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),            // 40: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),          // 41: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),        // 42: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),         // 43: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),           // 44: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),         // 45: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),        // 46: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),         // 47: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),          // 48: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),        // 49: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),          // 50: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerResponse)(nil), // 51: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),       // 52: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),        // 53: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),        // 54: containarium.v1.SetContainerTTLResponse
+	(*AddSSHKeyResponse)(nil),              // 55: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),           // 56: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),        // 57: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),     // 58: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),      // 59: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),             // 60: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),            // 61: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),           // 62: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),             // 63: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),          // 64: containarium.v1.GetSystemInfoResponse
+	(*ListBackendsResponse)(nil),           // 65: containarium.v1.ListBackendsResponse
+	(*GetLatestReleaseResponse)(nil),       // 66: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),            // 67: containarium.v1.ValidateGPUResponse
+	(*GetMonitoringInfoResponse)(nil),      // 68: containarium.v1.GetMonitoringInfoResponse
+	(*CreateAlertRuleResponse)(nil),        // 69: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),         // 70: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),           // 71: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),        // 72: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),        // 73: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),        // 74: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),  // 75: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),   // 76: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),            // 77: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),  // 78: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),              // 79: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),              // 80: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),            // 81: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),           // 82: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),         // 83: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -240,67 +244,69 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	20, // 20: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
 	21, // 21: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
 	22, // 22: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
-	23, // 23: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
-	24, // 24: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
-	25, // 25: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	26, // 26: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	27, // 27: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	28, // 28: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	29, // 29: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	30, // 30: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	31, // 31: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	32, // 32: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	33, // 33: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	34, // 34: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	35, // 35: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	36, // 36: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	37, // 37: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	38, // 38: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	39, // 39: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	40, // 40: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	41, // 41: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	42, // 42: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	43, // 43: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	44, // 44: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	45, // 45: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	46, // 46: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	47, // 47: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	48, // 48: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	49, // 49: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	50, // 50: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	51, // 51: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	52, // 52: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	53, // 53: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	54, // 54: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	55, // 55: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	56, // 56: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	57, // 57: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	58, // 58: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	59, // 59: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	60, // 60: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	61, // 61: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	62, // 62: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	63, // 63: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	64, // 64: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	65, // 65: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
-	66, // 66: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	67, // 67: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	68, // 68: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	69, // 69: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	70, // 70: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	71, // 71: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	72, // 72: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	73, // 73: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	74, // 74: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	75, // 75: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	76, // 76: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	77, // 77: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	78, // 78: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	79, // 79: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	80, // 80: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	81, // 81: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	41, // [41:82] is the sub-list for method output_type
-	0,  // [0:41] is the sub-list for method input_type
+	23, // 23: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
+	24, // 24: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
+	25, // 25: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
+	26, // 26: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	27, // 27: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	28, // 28: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	29, // 29: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	30, // 30: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	31, // 31: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	32, // 32: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	33, // 33: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	34, // 34: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	35, // 35: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	36, // 36: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	37, // 37: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	38, // 38: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	39, // 39: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	40, // 40: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	41, // 41: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	42, // 42: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	43, // 43: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	44, // 44: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	45, // 45: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	46, // 46: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	47, // 47: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	48, // 48: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	49, // 49: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	50, // 50: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	51, // 51: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	52, // 52: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	53, // 53: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	54, // 54: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	55, // 55: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	56, // 56: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	57, // 57: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	58, // 58: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	59, // 59: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	60, // 60: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	61, // 61: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	62, // 62: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	63, // 63: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	64, // 64: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	65, // 65: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
+	66, // 66: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	67, // 67: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	68, // 68: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	69, // 69: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	70, // 70: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	71, // 71: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	72, // 72: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	73, // 73: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	74, // 74: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	75, // 75: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	76, // 76: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	77, // 77: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	78, // 78: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	79, // 79: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	80, // 80: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	81, // 81: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	82, // 82: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	83, // 83: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	42, // [42:84] is the sub-list for method output_type
+	0,  // [0:42] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -1033,6 +1033,27 @@ func local_request_ContainerService_GetSystemInfo_0(ctx context.Context, marshal
 	return msg, metadata, err
 }
 
+func request_ContainerService_ListBackends_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListBackendsRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListBackends(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_ListBackends_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListBackendsRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.ListBackends(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_GetLatestRelease_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq GetLatestReleaseRequest
@@ -2111,6 +2132,26 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_GetSystemInfo_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_ListBackends_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/ListBackends", runtime.WithHTTPPathPattern("/v1/backends"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_ListBackends_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_ListBackends_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ContainerService_GetLatestRelease_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2919,6 +2960,23 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_GetSystemInfo_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_ListBackends_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/ListBackends", runtime.WithHTTPPathPattern("/v1/backends"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_ListBackends_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_ListBackends_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ContainerService_GetLatestRelease_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3253,6 +3311,7 @@ var (
 	pattern_ContainerService_InstallStack_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "install-stack"}, ""))
 	pattern_ContainerService_ListStacks_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "stacks"}, ""))
 	pattern_ContainerService_GetSystemInfo_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "info"}, ""))
+	pattern_ContainerService_ListBackends_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "backends"}, ""))
 	pattern_ContainerService_GetLatestRelease_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "releases", "latest"}, ""))
 	pattern_ContainerService_ValidateGPU_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "validate-gpu"}, ""))
 	pattern_ContainerService_GetMonitoringInfo_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "monitoring"}, ""))
@@ -3298,6 +3357,7 @@ var (
 	forward_ContainerService_InstallStack_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_ListStacks_0             = runtime.ForwardResponseMessage
 	forward_ContainerService_GetSystemInfo_0          = runtime.ForwardResponseMessage
+	forward_ContainerService_ListBackends_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_GetLatestRelease_0       = runtime.ForwardResponseMessage
 	forward_ContainerService_ValidateGPU_0            = runtime.ForwardResponseMessage
 	forward_ContainerService_GetMonitoringInfo_0      = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -42,6 +42,7 @@ const (
 	ContainerService_InstallStack_FullMethodName           = "/containarium.v1.ContainerService/InstallStack"
 	ContainerService_ListStacks_FullMethodName             = "/containarium.v1.ContainerService/ListStacks"
 	ContainerService_GetSystemInfo_FullMethodName          = "/containarium.v1.ContainerService/GetSystemInfo"
+	ContainerService_ListBackends_FullMethodName           = "/containarium.v1.ContainerService/ListBackends"
 	ContainerService_GetLatestRelease_FullMethodName       = "/containarium.v1.ContainerService/GetLatestRelease"
 	ContainerService_ValidateGPU_FullMethodName            = "/containarium.v1.ContainerService/ValidateGPU"
 	ContainerService_GetMonitoringInfo_FullMethodName      = "/containarium.v1.ContainerService/GetMonitoringInfo"
@@ -155,6 +156,14 @@ type ContainerServiceClient interface {
 	ListStacks(ctx context.Context, in *ListStacksRequest, opts ...grpc.CallOption) (*ListStacksResponse, error)
 	// GetSystemInfo gets information about the Incus host
 	GetSystemInfo(ctx context.Context, in *GetSystemInfoRequest, opts ...grpc.CallOption) (*GetSystemInfoResponse, error)
+	// ListBackends returns the cluster topology — the local daemon plus any
+	// tunnel-connected peers — with per-backend health, version, OS, running
+	// container count, and GPU inventory. Admin-only: the response discloses
+	// fleet topology (peer IDs, hostnames, GPU inventory), which is operator-
+	// grade, not tenant-grade. This replaces the former hand-coded
+	// /v1/backends HTTP handler with the proto-first, gateway-generated
+	// contract (proto-first convention; #354).
+	ListBackends(ctx context.Context, in *ListBackendsRequest, opts ...grpc.CallOption) (*ListBackendsResponse, error)
 	// GetLatestRelease reports the latest Containarium release on GitHub vs the
 	// running version, so operators see "update available" without SSHing in.
 	// The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
@@ -446,6 +455,16 @@ func (c *containerServiceClient) GetSystemInfo(ctx context.Context, in *GetSyste
 	return out, nil
 }
 
+func (c *containerServiceClient) ListBackends(ctx context.Context, in *ListBackendsRequest, opts ...grpc.CallOption) (*ListBackendsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListBackendsResponse)
+	err := c.cc.Invoke(ctx, ContainerService_ListBackends_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *containerServiceClient) GetLatestRelease(ctx context.Context, in *GetLatestReleaseRequest, opts ...grpc.CallOption) (*GetLatestReleaseResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetLatestReleaseResponse)
@@ -719,6 +738,14 @@ type ContainerServiceServer interface {
 	ListStacks(context.Context, *ListStacksRequest) (*ListStacksResponse, error)
 	// GetSystemInfo gets information about the Incus host
 	GetSystemInfo(context.Context, *GetSystemInfoRequest) (*GetSystemInfoResponse, error)
+	// ListBackends returns the cluster topology — the local daemon plus any
+	// tunnel-connected peers — with per-backend health, version, OS, running
+	// container count, and GPU inventory. Admin-only: the response discloses
+	// fleet topology (peer IDs, hostnames, GPU inventory), which is operator-
+	// grade, not tenant-grade. This replaces the former hand-coded
+	// /v1/backends HTTP handler with the proto-first, gateway-generated
+	// contract (proto-first convention; #354).
+	ListBackends(context.Context, *ListBackendsRequest) (*ListBackendsResponse, error)
 	// GetLatestRelease reports the latest Containarium release on GitHub vs the
 	// running version, so operators see "update available" without SSHing in.
 	// The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
@@ -848,6 +875,9 @@ func (UnimplementedContainerServiceServer) ListStacks(context.Context, *ListStac
 }
 func (UnimplementedContainerServiceServer) GetSystemInfo(context.Context, *GetSystemInfoRequest) (*GetSystemInfoResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetSystemInfo not implemented")
+}
+func (UnimplementedContainerServiceServer) ListBackends(context.Context, *ListBackendsRequest) (*ListBackendsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListBackends not implemented")
 }
 func (UnimplementedContainerServiceServer) GetLatestRelease(context.Context, *GetLatestReleaseRequest) (*GetLatestReleaseResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetLatestRelease not implemented")
@@ -1338,6 +1368,24 @@ func _ContainerService_GetSystemInfo_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ContainerService_ListBackends_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListBackendsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).ListBackends(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_ListBackends_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).ListBackends(ctx, req.(*ListBackendsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ContainerService_GetLatestRelease_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetLatestReleaseRequest)
 	if err := dec(in); err != nil {
@@ -1760,6 +1808,10 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetSystemInfo",
 			Handler:    _ContainerService_GetSystemInfo_Handler,
+		},
+		{
+			MethodName: "ListBackends",
+			Handler:    _ContainerService_ListBackends_Handler,
 		},
 		{
 			MethodName: "GetLatestRelease",

--- a/proto/containarium/v1/config.proto
+++ b/proto/containarium/v1/config.proto
@@ -397,19 +397,53 @@ enum BackendType {
   BACKEND_TYPE_TUNNEL = 2;
 }
 
-// BackendInfo contains information about a backend instance
+// BackendInfo describes one backend in the fleet — the local daemon
+// plus any tunnel-connected peers. Emitted by ListBackends (GET
+// /v1/backends). The field shape is the wire contract the CLI and MCP
+// clients consume; it supersedes the hand-coded /v1/backends handler
+// this RPC replaced (see #354).
 message BackendInfo {
-  // Unique backend identifier (e.g., "gcp-spot", "tunnel-node-a-gpu")
+  // Unique backend identifier (e.g., "gcp-spot", "tunnel-node-a").
   string id = 1;
 
-  // Backend type
-  BackendType type = 2;
+  // Backend kind: "local" for this daemon, "tunnel" for a peer.
+  string type = 2;
 
-  // Whether the backend is currently healthy
+  // Whether the backend is currently healthy / reachable.
   bool healthy = 3;
 
-  // Priority (lower = preferred, GCP=0, tunnel=10)
-  int32 priority = 4;
+  // Containarium daemon version running on this backend (e.g. "0.21.0").
+  string version = 4;
+
+  // Hostname of the backend.
+  string hostname = 5;
+
+  // Seconds this backend has been up (local backend only).
+  int64 uptime_seconds = 6;
+
+  // RFC3339 timestamp this backend was last seen (peers).
+  string last_seen_at = 7;
+
+  // Operating-system string of the backend.
+  string os = 8;
+
+  // Number of containers currently running on this backend.
+  int32 container_count = 9;
+
+  // GPUs present on this backend.
+  repeated BackendGPU gpus = 10;
+}
+
+// BackendGPU describes one GPU on a backend.
+message BackendGPU {
+  // GPU vendor string (e.g. "GPU_VENDOR_NVIDIA").
+  string vendor = 1;
+
+  // Human-readable GPU model name.
+  string model_name = 2;
+
+  // Total VRAM in bytes.
+  int64 vram_bytes = 3;
 }
 
 // ListBackendsRequest is the request to list available backends

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -385,6 +385,24 @@ service ContainerService {
     };
   }
 
+  // ListBackends returns the cluster topology — the local daemon plus any
+  // tunnel-connected peers — with per-backend health, version, OS, running
+  // container count, and GPU inventory. Admin-only: the response discloses
+  // fleet topology (peer IDs, hostnames, GPU inventory), which is operator-
+  // grade, not tenant-grade. This replaces the former hand-coded
+  // /v1/backends HTTP handler with the proto-first, gateway-generated
+  // contract (proto-first convention; #354).
+  rpc ListBackends(ListBackendsRequest) returns (ListBackendsResponse) {
+    option (google.api.http) = {
+      get: "/v1/backends"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List backends";
+      description: "Lists every backend in the fleet (local daemon + tunnel peers) with health, version, OS, running container count, and GPU inventory. Admin-only — discloses fleet topology.";
+      tags: "System";
+    };
+  }
+
   // GetLatestRelease reports the latest Containarium release on GitHub vs the
   // running version, so operators see "update available" without SSHing in.
   // The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.


### PR DESCRIPTION
`GET /v1/backends` was served by a **hand-coded `net/http` handler**
(`DualServer.backendsHandler`) — the proto-first anti-pattern this repo's
`CLAUDE.md` calls out. Worse, its emitted JSON had already **drifted** from
the unwired `BackendInfo` proto (the handler returned `version`, `hostname`,
`uptimeSeconds`, `os`, `containerCount`, `gpus[]`; the proto message had
only `id/type/healthy/priority`). The MCP client even carried a comment
admitting it mirrors the hand-coded shape, not a generated one.

This promotes the endpoint to a real, generated contract.

## Changes

- **`service.proto`**: add `rpc ListBackends` to `ContainerService` with
  `option (google.api.http) = { get: "/v1/backends" }` + the openapiv2
  annotation. Admin-only (the response discloses fleet topology).
- **`config.proto`**: reshape the (previously unwired) `BackendInfo` to the
  served wire shape — `id, type, healthy, version, hostname, uptime_seconds,
  last_seen_at, os, container_count, gpus[]` — and add `BackendGPU`. Nothing
  referenced the old message, so no consumer breaks; the generated camelCase
  JSON matches what the CLI/MCP already deserialize (locked by the existing
  wire-format test).
- **`container_server.go`**: implement `ListBackends` — the local daemon
  plus tunnel peers, reusing `peerPool` + `GetSystemInfo` (peer fan-out uses
  the caller's admin token, same as `GetSystemInfo`); add `SetStartTime` for
  the local backend's uptime.
- **`dual_server.go` / `gateway.go`**: drop the hand-coded list branch
  (keeping `/v1/backends/{id}/system-info`, which forwards to a specific
  peer); route the exact `GET /v1/backends` through the grpc-gateway, with
  the subtree staying hand-coded. `http.ServeMux` won't 301-redirect the
  bare path into the subtree because the exact path is registered.
- Regenerated stubs; rewrote `backends_handler_test.go` to exercise the real
  RPC + its admin gate; refreshed the MCP client doc comment.

## Verification

`buf generate`, `go build ./...`, `go vet`, and `go test` on
`internal/server`, `internal/gateway`, `internal/mcp` all pass. The MCP
`TestWireFormat_ListBackends` confirms the generated wire shape matches the
prior hand-coded bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)