### PR TITLE
feat(server): stable tenant→u32 ID registry for network policy (Phase A piece 6a, #315)

### DIFF
--- a/internal/server/tenant_registry.go
+++ b/internal/server/tenant_registry.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TenantRegistry assigns a stable, non-zero uint32 ID to each tenant name. The
+// eBPF network-policy maps (#315) key everything on this ID — a container's
+// veth_policy entry, its egress_cidr LPM entries, and the ip_tenant map all
+// carry the tenant's uint32. The ID MUST be stable across daemon restarts: the
+// BPF maps are repopulated from stored policies + live containers on boot, and
+// if a tenant's ID changed between runs its egress rules would be keyed to a
+// different ID than its containers — silently misrouting policy. So this is a
+// registry (assign once, persist, reuse), NOT a hash of the tenant name (a hash
+// collision would merge two tenants' policies — unacceptable for a security
+// control).
+//
+// ID 0 is reserved: the BPF programs treat a zero tenant_id / absent map entry
+// as "unmanaged", so assigned IDs start at 1.
+type TenantRegistry interface {
+	// ID returns the tenant's stable ID, assigning (and persisting) a new one on
+	// first use. Idempotent: repeated calls for the same tenant return the same ID.
+	ID(ctx context.Context, tenant string) (uint32, error)
+}
+
+// --- in-memory ------------------------------------------------------
+
+// MemTenantRegistry assigns IDs from a monotonic counter held in memory. IDs do
+// not survive a restart — used on --standalone daemons (no Postgres) and tests.
+// On a standalone daemon that's acceptable: the maps are rebuilt from scratch on
+// boot anyway, and a single run is internally consistent.
+type MemTenantRegistry struct {
+	mu   sync.Mutex
+	ids  map[string]uint32
+	next uint32
+}
+
+func NewMemTenantRegistry() *MemTenantRegistry {
+	return &MemTenantRegistry{ids: make(map[string]uint32), next: 1}
+}
+
+func (r *MemTenantRegistry) ID(_ context.Context, tenant string) (uint32, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if id, ok := r.ids[tenant]; ok {
+		return id, nil
+	}
+	id := r.next
+	r.ids[tenant] = id
+	r.next++
+	return id, nil
+}
+
+// --- postgres -------------------------------------------------------
+
+// PostgresTenantRegistry persists assignments in a tenant_ids table so IDs are
+// stable across restarts. Mirrors the store pattern (pool + initSchema).
+type PostgresTenantRegistry struct {
+	pool *pgxpool.Pool
+	mu   sync.Mutex        // serialize assignment so the MAX(id)+1 read-modify-write is atomic per daemon
+	c    map[string]uint32 // local cache so the hot path avoids a round-trip
+}
+
+func NewPostgresTenantRegistry(ctx context.Context, pool *pgxpool.Pool) (*PostgresTenantRegistry, error) {
+	r := &PostgresTenantRegistry{pool: pool, c: make(map[string]uint32)}
+	schema := `
+		CREATE TABLE IF NOT EXISTS tenant_ids (
+			tenant TEXT PRIMARY KEY,
+			id INTEGER NOT NULL UNIQUE,
+			created_at TIMESTAMP NOT NULL DEFAULT NOW()
+		);
+	`
+	if _, err := pool.Exec(ctx, schema); err != nil {
+		return nil, fmt.Errorf("init tenant_ids schema: %w", err)
+	}
+	return r, nil
+}
+
+func (r *PostgresTenantRegistry) ID(ctx context.Context, tenant string) (uint32, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if id, ok := r.c[tenant]; ok {
+		return id, nil
+	}
+	// Assign-or-fetch in one statement: the ON CONFLICT no-op UPDATE lets
+	// RETURNING return the existing id for an already-registered tenant, while a
+	// fresh tenant gets MAX(id)+1. The per-daemon mutex serializes the MAX read so
+	// concurrent assignments can't pick the same id; the UNIQUE(id) constraint is
+	// the backstop if two daemons ever race.
+	const q = `
+		INSERT INTO tenant_ids (tenant, id)
+		VALUES ($1, (SELECT COALESCE(MAX(id), 0) + 1 FROM tenant_ids))
+		ON CONFLICT (tenant) DO UPDATE SET tenant = EXCLUDED.tenant
+		RETURNING id
+	`
+	var id int32
+	if err := r.pool.QueryRow(ctx, q, tenant).Scan(&id); err != nil {
+		return 0, fmt.Errorf("assign tenant id for %q: %w", tenant, err)
+	}
+	uid := uint32(id) // #nosec G115 -- id is a small positive serial, never negative
+	r.c[tenant] = uid
+	return uid, nil
+}

--- a/internal/server/tenant_registry_test.go
+++ b/internal/server/tenant_registry_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestMemTenantRegistry_StableAndDistinct(t *testing.T) {
+	r := NewMemTenantRegistry()
+	ctx := context.Background()
+
+	alice1, err := r.ID(ctx, "alice")
+	if err != nil {
+		t.Fatalf("ID(alice): %v", err)
+	}
+	bob, err := r.ID(ctx, "bob")
+	if err != nil {
+		t.Fatalf("ID(bob): %v", err)
+	}
+	alice2, err := r.ID(ctx, "alice")
+	if err != nil {
+		t.Fatalf("ID(alice) again: %v", err)
+	}
+
+	if alice1 == 0 || bob == 0 {
+		t.Errorf("IDs must be non-zero (0 is reserved): alice=%d bob=%d", alice1, bob)
+	}
+	if alice1 != alice2 {
+		t.Errorf("ID must be stable for the same tenant: %d != %d", alice1, alice2)
+	}
+	if alice1 == bob {
+		t.Errorf("distinct tenants must get distinct IDs: alice=bob=%d", alice1)
+	}
+}
+
+func TestMemTenantRegistry_Concurrent(t *testing.T) {
+	r := NewMemTenantRegistry()
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	got := make(map[string]uint32)
+	for _, name := range []string{"a", "b", "c", "a", "b", "c", "a"} {
+		wg.Add(1)
+		go func(n string) {
+			defer wg.Done()
+			id, err := r.ID(ctx, n)
+			if err != nil {
+				t.Errorf("ID(%s): %v", n, err)
+				return
+			}
+			mu.Lock()
+			if prev, ok := got[n]; ok && prev != id {
+				t.Errorf("tenant %q got two IDs: %d and %d", n, prev, id)
+			}
+			got[n] = id
+			mu.Unlock()
+		}(name)
+	}
+	wg.Wait()
+
+	// Three distinct tenants → three distinct IDs.
+	seen := map[uint32]bool{}
+	for _, id := range got {
+		seen[id] = true
+	}
+	if len(seen) != 3 {
+		t.Errorf("expected 3 distinct IDs, got %d: %v", len(seen), got)
+	}
+}


### PR DESCRIPTION
Phase A piece 6a (daemon integration) of the network-isolation feature (#315). First of three sub-increments; builds on #430–#434 (control plane + hardware-validated loader).

## Why a registry, not a hash

The eBPF network-policy maps key every entry on a `uint32` tenant ID — a container's `veth_policy`, its `egress_cidr` LPM entries, and the `ip_tenant` map all carry it. Two hard requirements:

1. **Stable across restarts.** The BPF maps are rebuilt from stored policies + live containers on daemon boot. If a tenant's ID changed between runs, its egress rules would be keyed to a different ID than its containers — silently misrouting policy.
2. **Collision-free.** A hash of the tenant name could map two tenants to the same ID, merging their policies. Unacceptable for a security control.

So: assign once, persist, reuse.

## What

- **`TenantRegistry`** interface — `ID(ctx, tenant) (uint32, error)`, idempotent. IDs start at 1 (0 is reserved as "unmanaged" in the BPF programs).
- **`MemTenantRegistry`** — monotonic counter, for `--standalone` daemons + tests.
- **`PostgresTenantRegistry`** — `tenant_ids` table; assign-or-fetch in one statement (`ON CONFLICT` no-op `UPDATE` + `RETURNING` returns the existing ID for a known tenant, `MAX(id)+1` for a fresh one); per-daemon mutex serializes the read-modify-write with a `UNIQUE(id)` backstop; local cache on the hot path.

Consumed by the network-policy enforcer (piece 6c).

## Test

`go build ./...` clean; `go test ./internal/server/ -run TestMemTenantRegistry` passes (stable/distinct/non-zero + concurrent assignment).

## Follow-ups (piece 6)

- 6b — denied-flow → audit consumer (perf ring → `network_policy.deny` rows on the hash-chained audit log).
- 6c — the enforcer: owns the `netbpf.Loader`, reconciles stored policies + live containers into the BPF maps (using this registry), attaches/detaches on container lifecycle, runs the perf consumer. Wired into `NewDualServer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)