### PR TITLE
feat(netbpf): denied-flow event decoder + perf consumer (Phase A piece 6b, #315)

### DIFF
--- a/cmd/ebpf-phaseA/main.go
+++ b/cmd/ebpf-phaseA/main.go
@@ -23,8 +23,6 @@
 package main
 
 import (
-	"bytes"
-	"encoding/binary"
 	"flag"
 	"fmt"
 	"log"
@@ -38,17 +36,6 @@ import (
 
 	"github.com/footprintai/containarium/internal/netbpf"
 )
-
-// denyEvent mirrors `struct deny_event` in netpolicy.bpf.c.
-type denyEvent struct {
-	Ifindex  uint32
-	TenantID uint32
-	Saddr    uint32
-	Daddr    uint32
-	Dport    uint16
-	Proto    uint8
-	Pad      uint8
-}
 
 type cidrList []string
 
@@ -153,13 +140,13 @@ func run(objPath, veth string, tenant uint32, allowIntra bool, allow cidrList, p
 				log.Printf("perf: lost %d samples", rec.LostSamples)
 				continue
 			}
-			var ev denyEvent
-			if err := binary.Read(bytes.NewReader(rec.RawSample), binary.NativeEndian, &ev); err != nil {
+			ev, err := netbpf.ParseDenyEvent(rec.RawSample)
+			if err != nil {
 				log.Printf("perf: decode: %v", err)
 				continue
 			}
 			log.Printf("WOULD-DENY src=%s dst=%s proto=%d dport=%d (tenant=%d ifindex=%d)",
-				ipv4(ev.Saddr), ipv4(ev.Daddr), ev.Proto, ev.Dport, ev.TenantID, ev.Ifindex)
+				ev.Src(), ev.Dst(), ev.Proto, ev.Dport, ev.TenantID, ev.Ifindex)
 		}
 	}()
 
@@ -181,12 +168,4 @@ func run(objPath, veth string, tenant uint32, allowIntra bool, allow cidrList, p
 			return nil
 		}
 	}
-}
-
-// ipv4 renders a network-byte-order __u32 (as carried in the BPF event) as a
-// dotted-quad string.
-func ipv4(be uint32) string {
-	var b [4]byte
-	binary.NativeEndian.PutUint32(b[:], be)
-	return netip.AddrFrom4(b).String()
 }

--- a/internal/netbpf/events.go
+++ b/internal/netbpf/events.go
@@ -1,0 +1,97 @@
+package netbpf
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net/netip"
+
+	"github.com/cilium/ebpf/perf"
+)
+
+// DenyEvent is the decoded form of a `struct deny_event` emitted by the BPF
+// program (experimental/ebpf-phaseA/netpolicy.bpf.c) for a would-deny flow. The
+// binary layout must stay in lockstep with that C struct.
+type DenyEvent struct {
+	Ifindex  uint32
+	TenantID uint32
+	Saddr    uint32 // source IPv4, network byte order (as carried on the wire)
+	Daddr    uint32 // destination IPv4, network byte order
+	Dport    uint16 // host byte order (the program already ntoh'd it)
+	Proto    uint8  // IP protocol number (1=ICMP, 6=TCP, 17=UDP)
+	_        uint8  // pad, matches the C struct
+}
+
+// denyEventSize is the wire size of struct deny_event (4+4+4+4+2+1+1).
+const denyEventSize = 20
+
+// ParseDenyEvent decodes one perf-ring sample into a DenyEvent. It tolerates a
+// sample longer than the struct (perf samples are padded) but rejects a short
+// one.
+func ParseDenyEvent(raw []byte) (DenyEvent, error) {
+	if len(raw) < denyEventSize {
+		return DenyEvent{}, fmt.Errorf("netbpf: deny event sample too short: %d < %d bytes", len(raw), denyEventSize)
+	}
+	var ev DenyEvent
+	if err := binary.Read(bytes.NewReader(raw[:denyEventSize]), binary.NativeEndian, &ev); err != nil {
+		return DenyEvent{}, fmt.Errorf("netbpf: decode deny event: %w", err)
+	}
+	return ev, nil
+}
+
+// Src and Dst render the network-byte-order addresses as netip.Addr. The wire
+// value is a __u32 holding the 4 IPv4 bytes in network order; NativeEndian.Put
+// writes them back to the same byte sequence regardless of host endianness.
+func (e DenyEvent) Src() netip.Addr { return ipFromBE(e.Saddr) }
+func (e DenyEvent) Dst() netip.Addr { return ipFromBE(e.Daddr) }
+
+func ipFromBE(v uint32) netip.Addr {
+	var b [4]byte
+	binary.NativeEndian.PutUint32(b[:], v)
+	return netip.AddrFrom4(b)
+}
+
+// DenyEventSink consumes decoded would-deny events. The daemon implements this
+// to turn each event into an audit row; keeping it an interface keeps netbpf
+// free of an internal/audit dependency.
+type DenyEventSink interface {
+	OnDenyEvent(ctx context.Context, ev DenyEvent)
+}
+
+// perfRecordReader is the subset of *perf.Reader that ConsumeDenyEvents needs,
+// so the loop can be unit-tested with a fake reader.
+type perfRecordReader interface {
+	Read() (perf.Record, error)
+}
+
+// ConsumeDenyEvents reads would-deny samples from a perf ring until the reader
+// returns an error (e.g. it is closed on shutdown) or ctx is cancelled, decoding
+// each and handing it to the sink. Lost-sample notices and malformed samples are
+// reported via the onError callback (nil to ignore) and do not stop the loop.
+func ConsumeDenyEvents(ctx context.Context, rd perfRecordReader, sink DenyEventSink, onError func(error)) {
+	report := func(err error) {
+		if onError != nil {
+			onError(err)
+		}
+	}
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		rec, err := rd.Read()
+		if err != nil {
+			return // reader closed / unrecoverable
+		}
+		if rec.LostSamples > 0 {
+			report(fmt.Errorf("netbpf: perf ring lost %d samples", rec.LostSamples))
+			continue
+		}
+		ev, err := ParseDenyEvent(rec.RawSample)
+		if err != nil {
+			report(err)
+			continue
+		}
+		sink.OnDenyEvent(ctx, ev)
+	}
+}

--- a/internal/netbpf/events_test.go
+++ b/internal/netbpf/events_test.go
@@ -1,0 +1,120 @@
+package netbpf
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/cilium/ebpf/perf"
+)
+
+func encodeDenyEvent(e DenyEvent) []byte {
+	b := make([]byte, denyEventSize)
+	binary.NativeEndian.PutUint32(b[0:4], e.Ifindex)
+	binary.NativeEndian.PutUint32(b[4:8], e.TenantID)
+	binary.NativeEndian.PutUint32(b[8:12], e.Saddr)
+	binary.NativeEndian.PutUint32(b[12:16], e.Daddr)
+	binary.NativeEndian.PutUint16(b[16:18], e.Dport)
+	b[18] = e.Proto
+	return b
+}
+
+func TestParseDenyEvent_RoundTrip(t *testing.T) {
+	// 10.100.0.155 -> 1.1.1.1, ICMP. Addresses in network byte order.
+	want := DenyEvent{
+		Ifindex:  59,
+		TenantID: 1,
+		Saddr:    binary.NativeEndian.Uint32([]byte{10, 100, 0, 155}),
+		Daddr:    binary.NativeEndian.Uint32([]byte{1, 1, 1, 1}),
+		Dport:    0,
+		Proto:    1,
+	}
+	got, err := ParseDenyEvent(encodeDenyEvent(want))
+	if err != nil {
+		t.Fatalf("ParseDenyEvent: %v", err)
+	}
+	if got != want {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", got, want)
+	}
+	if got.Src().String() != "10.100.0.155" {
+		t.Errorf("Src() = %s, want 10.100.0.155", got.Src())
+	}
+	if got.Dst().String() != "1.1.1.1" {
+		t.Errorf("Dst() = %s, want 1.1.1.1", got.Dst())
+	}
+}
+
+func TestParseDenyEvent_ShortSample(t *testing.T) {
+	if _, err := ParseDenyEvent([]byte{1, 2, 3}); err == nil {
+		t.Fatal("expected error for short sample")
+	}
+}
+
+func TestParseDenyEvent_PaddedSample(t *testing.T) {
+	raw := append(encodeDenyEvent(DenyEvent{TenantID: 7, Proto: 6}), 0, 0, 0, 0) // padded
+	ev, err := ParseDenyEvent(raw)
+	if err != nil {
+		t.Fatalf("ParseDenyEvent (padded): %v", err)
+	}
+	if ev.TenantID != 7 || ev.Proto != 6 {
+		t.Errorf("padded decode wrong: %+v", ev)
+	}
+}
+
+// fakeReader yields a fixed sequence of perf records then an error to stop the loop.
+type fakeReader struct {
+	recs []perf.Record
+	i    int
+}
+
+func (f *fakeReader) Read() (perf.Record, error) {
+	if f.i >= len(f.recs) {
+		return perf.Record{}, errors.New("closed")
+	}
+	r := f.recs[f.i]
+	f.i++
+	return r, nil
+}
+
+type captureSink struct{ events []DenyEvent }
+
+func (c *captureSink) OnDenyEvent(_ context.Context, ev DenyEvent) {
+	c.events = append(c.events, ev)
+}
+
+func TestConsumeDenyEvents(t *testing.T) {
+	e1 := DenyEvent{TenantID: 1, Proto: 1}
+	e2 := DenyEvent{TenantID: 2, Proto: 6}
+	rd := &fakeReader{recs: []perf.Record{
+		{RawSample: encodeDenyEvent(e1)},
+		{LostSamples: 3},          // should be reported, not delivered
+		{RawSample: []byte{0xff}}, // malformed: reported, not delivered
+		{RawSample: encodeDenyEvent(e2)},
+	}}
+	sink := &captureSink{}
+	var errCount int
+	ConsumeDenyEvents(context.Background(), rd, sink, func(error) { errCount++ })
+
+	if len(sink.events) != 2 {
+		t.Fatalf("expected 2 delivered events, got %d: %+v", len(sink.events), sink.events)
+	}
+	if sink.events[0].TenantID != 1 || sink.events[1].TenantID != 2 {
+		t.Errorf("wrong events delivered: %+v", sink.events)
+	}
+	if errCount != 2 { // one lost-samples notice + one malformed
+		t.Errorf("expected 2 error reports, got %d", errCount)
+	}
+}
+
+func TestConsumeDenyEvents_CtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// Even with records available, a cancelled ctx stops before delivering.
+	rd := &fakeReader{recs: []perf.Record{{RawSample: encodeDenyEvent(DenyEvent{TenantID: 1})}}}
+	sink := &captureSink{}
+	ConsumeDenyEvents(ctx, rd, sink, nil)
+	if len(sink.events) != 0 {
+		t.Errorf("expected no events after ctx cancel, got %d", len(sink.events))
+	}
+}


### PR DESCRIPTION
Phase A piece 6b (daemon integration) of the network-isolation feature (#315). Second of three sub-increments; builds on #434 (loader) and #436 (tenant registry).

## What

The consumer half of the network-policy data path. The BPF program emits a `struct deny_event` per would-deny flow (validated on hardware in #434); this decodes those samples off the perf ring and hands them to a sink (the daemon turns each into an audit row in piece 6c).

- **`DenyEvent` + `ParseDenyEvent`** — exported, binary layout locked to the C struct; tolerates padded perf samples, rejects short ones. `Src()`/`Dst()` render the network-byte-order addresses as `netip.Addr`.
- **`DenyEventSink`** interface — keeps `netbpf` free of an `internal/audit` dependency; the daemon implements it.
- **`ConsumeDenyEvents`** — reads the perf ring until closed / ctx-cancelled, decoding each sample to the sink. Lost-sample notices and malformed samples are reported via a callback **without stopping the loop**. The reader is taken as an interface, so the loop is unit-tested with a fake (no kernel needed).
- **`cmd/ebpf-phaseA`** — DRY'd to use the promoted `DenyEvent`/`ParseDenyEvent` instead of its inline copy.

## Test

`go build ./...`, `go vet`, `gofmt` clean. `go test ./internal/netbpf/` passes: decode round-trip / short-sample / padded-sample, and the consume loop (delivery ordering, lost-sample + malformed reporting, ctx-cancel-before-deliver).

## Follow-up (piece 6c)

The enforcer: owns the `netbpf.Loader`, reconciles stored policies + live containers into the BPF maps (using the #436 registry), attaches/detaches on container lifecycle, and runs `ConsumeDenyEvents` with an audit-writing sink. Wired into `NewDualServer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)