### PR TITLE
feat(netpolicy): log would-deny flows + smoke-test harness (Phase A, #315)

### DIFF
--- a/cmd/netpolicy-smoke/main.go
+++ b/cmd/netpolicy-smoke/main.go
@@ -1,0 +1,85 @@
+// Command netpolicy-smoke is a throwaway end-to-end smoke test for the eBPF
+// network-policy *enforcer* (#315 Phase A piece 6c). Where cmd/ebpf-phaseA
+// exercises the bare loader, this drives the real server.NetworkPolicyEnforcer:
+// it constructs the enforcer with an in-memory policy store + tenant registry +
+// a real Incus client, seeds a policy for a test tenant, then Start()s it so the
+// enforcer's own reconcile loop discovers the live container, resolves its veth,
+// populates the BPF maps, attaches the program, and runs the perf consumer.
+//
+// Run it on a backend, create a `<tenant>-container`, generate traffic, and
+// watch the enforcer log "would-deny" lines for flows outside the seeded
+// allow-list (and stay silent for flows inside it). Observation-only — nothing
+// is dropped.
+//
+// THROWAWAY. Not built into releases. Run with --help.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/footprintai/containarium/internal/events"
+	"github.com/footprintai/containarium/internal/server"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+type cidrList []string
+
+func (c *cidrList) String() string { return "" }
+func (c *cidrList) Set(v string) error {
+	*c = append(*c, v)
+	return nil
+}
+
+func main() {
+	var (
+		obj        = flag.String("obj", "netpolicy.bpf.o", "Path to the compiled netpolicy.bpf.o")
+		tenant     = flag.String("tenant", "smoketest", "Tenant to seed a policy for (container must be <tenant>-container)")
+		allowIntra = flag.Bool("allow-intra", false, "Allow same-tenant intra-backend traffic")
+	)
+	var allow cidrList
+	flag.Var(&allow, "allow-cidr", "Allowed egress CIDR (repeatable)")
+	flag.Parse()
+
+	incusClient, err := incus.New()
+	if err != nil {
+		log.Fatalf("incus client: %v", err)
+	}
+
+	// Seed an in-memory policy for the test tenant.
+	store := server.NewMemNetworkPolicyStore()
+	if err := store.Set(context.Background(), &pb.NetworkPolicy{
+		Tenant:           *tenant,
+		AllowIntraTenant: *allowIntra,
+		EgressCidrs:      []string(allow),
+		Mode:             pb.NetworkPolicyMode_NETWORK_POLICY_MODE_LOG_ONLY,
+	}); err != nil {
+		log.Fatalf("seed policy: %v", err)
+	}
+	log.Printf("seeded log_only policy: tenant=%q allow_intra=%v egress=%v", *tenant, *allowIntra, []string(allow))
+
+	// Real enforcer: Mem store + Mem registry + real Incus + no audit store
+	// (would-deny flows surface as log lines via OnDenyEvent) + the global bus.
+	enforcer := server.NewNetworkPolicyEnforcer(*obj, store, server.NewMemTenantRegistry(), incusClient, nil, events.GetBus())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := enforcer.Start(ctx); err != nil {
+		log.Fatalf("enforcer start: %v", err)
+	}
+	log.Printf("enforcer running; create %s-container, generate traffic, watch for would-deny lines. ^C to stop.", *tenant)
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	<-sig
+	log.Printf("stopping enforcer (detaching)...")
+	cancel()
+	enforcer.Stop()
+	time.Sleep(200 * time.Millisecond)
+}

--- a/internal/server/network_policy_enforcer.go
+++ b/internal/server/network_policy_enforcer.go
@@ -159,12 +159,17 @@ func (e *NetworkPolicyEnforcer) Stop() {
 // audit log. Action network_policy.deny; the tenant name is resolved from the
 // id->name map built during reconcile.
 func (e *NetworkPolicyEnforcer) OnDenyEvent(ctx context.Context, ev netbpf.DenyEvent) {
-	if e.audit == nil {
-		return
-	}
 	e.mu.Lock()
 	tenant := e.idName[ev.TenantID]
 	e.mu.Unlock()
+	// Always log the would-deny flow — in log_only mode this line IS the
+	// operator-visible signal that a flow would be blocked. The audit row below
+	// is the durable record (when an audit store is configured).
+	log.Printf("[netpolicy] would-deny: tenant=%q src=%s dst=%s proto=%d dport=%d (log_only)",
+		tenant, ev.Src(), ev.Dst(), ev.Proto, ev.Dport)
+	if e.audit == nil {
+		return
+	}
 	detail := `{"src":"` + ev.Src().String() + `","dst":"` + ev.Dst().String() +
 		`","proto":` + itoa(int(ev.Proto)) + `,"dport":` + itoa(int(ev.Dport)) + `}`
 	entry := &audit.AuditEntry{


### PR DESCRIPTION
Follow-up to the Phase A enforcer (#438), driven by an end-to-end smoke test on a Linux backend (kernel 6.8).

## Validated live

Ran the real `NetworkPolicyEnforcer` against live containers via the new harness, with a seeded `log_only` policy (`egress 8.8.8.8/32`) for a `smoketest` tenant:

```
[netpolicy] enforcer started (obj=…, interval=10s, observation-only)
# ping 8.8.8.8 (allowed) then 1.1.1.1 (not listed), from smoketest-container:
[netpolicy] would-deny: tenant="smoketest" src=10.100.0.64 dst=1.1.1.1 proto=1 dport=0 (log_only)   ×3
# zero would-deny for dst=8.8.8.8
[netpolicy] stopping enforcer (detaching)...
```

Confirmed the **full piece-6c orchestration**: `Start → gather` (real Incus `ListContainers` + `GetRawInstance` + veth resolve) `→ planReconcile` (seeded policy) `→ apply` (`SetVethPolicy`/`AddEgress`/`SetIPTenant`/`AttachVeth`) `→ perf consumer → OnDenyEvent`. The egress allow-list matched (`8.8.8.8` → no deny); the tenant name resolved from the id→name map; the reconcile loop discovered every live container and attached to each veth; all detached cleanly on `Stop()`. Observation-only — nothing dropped, no container's networking affected.

## Changes

- **`OnDenyEvent` logs every would-deny flow** (tenant/src/dst/proto/dport) before the audit write. In `log_only` mode this line *is* the operator's signal that a flow would be blocked; previously a deny was only observable via an audit row — and invisible entirely when no audit store was configured.
- **`cmd/netpolicy-smoke`** — throwaway harness that drives the real enforcer with in-memory store + registry + a real Incus client (no Postgres, no production daemon), making the enabled path reproducible on a backend. Mirrors `cmd/ebpf-phase0` / `ebpf-phaseA`; not built into releases.

## Test

`go build ./...`, `go vet`, `gofmt` clean; existing `internal/server` + `internal/netbpf` tests pass.

With this, **Phase A is validated end-to-end** — both the bare loader (#434) and the full daemon enforcer path. Phase B (flip `--mode enforce` to drop; `TC_ACT_SHOT` already wired, inert) is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)