### PR TITLE
feat(netpolicy): tenant identity via label, not just name (#315 cloud extension pt.1)

### DIFF
--- a/internal/server/network_policy_enforcer.go
+++ b/internal/server/network_policy_enforcer.go
@@ -332,7 +332,7 @@ func (e *NetworkPolicyEnforcer) gather(_ context.Context) ([]containerView, map[
 	views := make([]containerView, 0, len(containers))
 	idName := make(map[uint32]string)
 	for _, c := range containers {
-		tenant := tenantOf(c.Name)
+		tenant := resolveTenant(c.Tenant, c.Name)
 		if tenant == "" {
 			continue
 		}
@@ -409,6 +409,19 @@ func (e *NetworkPolicyEnforcer) refreshDomains() {
 	cctx, cancel := context.WithTimeout(e.ctx, 10*time.Second)
 	defer cancel()
 	e.resolver.Refresh(cctx, domains)
+}
+
+// resolveTenant determines a container's owning tenant. An explicit tenant
+// label (user.containarium.tenant) wins — it decouples tenant identity from the
+// container name, which is what lets cloud-assigned containers (named
+// cld-<uuid>, not <tenant>-container) be policed too (#315 "Cloud extension").
+// Falls back to the <tenant>-container naming convention; "" if neither yields
+// a tenant (the container is then left unmanaged).
+func resolveTenant(tenantLabel, containerName string) string {
+	if t := strings.TrimSpace(tenantLabel); t != "" {
+		return t
+	}
+	return tenantOf(containerName)
 }
 
 // tenantOf extracts the tenant name from a container name, or "" if it doesn't

--- a/internal/server/network_policy_plan_test.go
+++ b/internal/server/network_policy_plan_test.go
@@ -17,6 +17,24 @@ func compiled(t *testing.T, p *pb.NetworkPolicy) netpolicy.CompiledPolicy {
 	return c
 }
 
+func TestResolveTenant(t *testing.T) {
+	cases := []struct {
+		label, name, want string
+	}{
+		{"acme", "cld-1a2b3c", "acme"},          // label wins for a cloud-named container
+		{"acme", "alice-container", "acme"},     // label wins over name
+		{"", "alice-container", "alice"},        // fall back to name convention
+		{"  ", "alice-container", "alice"},      // blank label ignored
+		{"", "cld-1a2b3c", ""},                  // cloud name, no label → unmanaged
+		{" tenant7 ", "x-container", "tenant7"}, // label trimmed
+	}
+	for _, c := range cases {
+		if got := resolveTenant(c.label, c.name); got != c.want {
+			t.Errorf("resolveTenant(%q, %q) = %q, want %q", c.label, c.name, got, c.want)
+		}
+	}
+}
+
 func TestTenantOf(t *testing.T) {
 	cases := map[string]string{
 		"alice-container": "alice",

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -208,9 +208,9 @@ type ContainerConfig struct {
 	Image                  string
 	CPU                    string
 	Memory                 string
-	Disk                   *DiskDevice    // Root disk configuration
-	NIC                    *NICDevice     // Network interface configuration
-	GPU                    *GPUDevice     // GPU device configuration for passthrough
+	Disk                   *DiskDevice      // Root disk configuration
+	NIC                    *NICDevice       // Network interface configuration
+	GPU                    *GPUDevice       // GPU device configuration for passthrough
 	InstanceType           api.InstanceType // Container (LXC) or VM (QEMU/KVM). Defaults to Container.
 	EnableNesting          bool
 	EnablePodmanPrivileged bool // Full Docker support (requires privileged container + AppArmor disabled)
@@ -232,18 +232,27 @@ const LabelPrefix = "user.containarium.label."
 // RoleKey is the Incus config key used to tag core containers by role.
 const RoleKey = "user.containarium.role"
 
+// TenantLabelKey is the Incus config key that names a container's owning tenant
+// explicitly, decoupling tenant identity from the <tenant>-container naming
+// convention. The network-policy enforcer (#315) prefers this label and falls
+// back to the name. Stamped by the cloud-actuation reconciler from the
+// assignment (multi-tenant cloud), or by an operator for a container that
+// doesn't follow the naming convention. See NETWORK-ISOLATION-DESIGN.md
+// "Cloud extension".
+const TenantLabelKey = "user.containarium.tenant"
+
 // Role is a typed string for core container roles.
 type Role string
 
 // Core container roles
 const (
-	RoleNone              Role = ""
-	RolePostgres          Role = "core-postgres"
-	RoleCaddy             Role = "core-caddy"
-	RoleVictoriaMetrics   Role = "core-victoriametrics"
-	RoleSecurity          Role = "core-security"
-	RoleGuacamole         Role = "core-guacamole"
-	RoleOTelCollector     Role = "core-otelcollector"
+	RoleNone            Role = ""
+	RolePostgres        Role = "core-postgres"
+	RoleCaddy           Role = "core-caddy"
+	RoleVictoriaMetrics Role = "core-victoriametrics"
+	RoleSecurity        Role = "core-security"
+	RoleGuacamole       Role = "core-guacamole"
+	RoleOTelCollector   Role = "core-otelcollector"
 )
 
 // IsCoreRole returns true if the role represents a core container.
@@ -263,6 +272,7 @@ type ContainerInfo struct {
 	InstanceType string // "container" or "virtual-machine"
 	Labels       map[string]string
 	Role         Role   // Core container role (e.g., RolePostgres, RoleCaddy), empty for user containers
+	Tenant       string // Explicit owning tenant (user.containarium.tenant); empty falls back to the name convention
 	CreatedAt    time.Time
 	BackendID    string // Backend this container runs on (populated by PeerPool fan-out)
 
@@ -370,13 +380,13 @@ func parseTTLExpiresAt(cfg map[string]string) time.Time {
 // ContainerMetrics holds runtime metrics for a container
 type ContainerMetrics struct {
 	Name             string
-	CPUUsageSeconds  int64   // CPU usage in seconds
-	MemoryUsageBytes int64   // Current memory usage in bytes
-	MemoryLimitBytes int64   // Memory limit in bytes
-	DiskUsageBytes   int64   // Root disk usage in bytes
-	NetworkRxBytes   int64   // Network bytes received
-	NetworkTxBytes   int64   // Network bytes transmitted
-	ProcessCount     int32   // Number of running processes
+	CPUUsageSeconds  int64 // CPU usage in seconds
+	MemoryUsageBytes int64 // Current memory usage in bytes
+	MemoryLimitBytes int64 // Memory limit in bytes
+	DiskUsageBytes   int64 // Root disk usage in bytes
+	NetworkRxBytes   int64 // Network bytes received
+	NetworkTxBytes   int64 // Network bytes transmitted
+	ProcessCount     int32 // Number of running processes
 }
 
 // ServerInfo holds information about the Incus server
@@ -635,6 +645,7 @@ func (c *Client) ListContainers() ([]ContainerInfo, error) {
 			CreatedAt:            inst.CreatedAt,
 			Labels:               extractLabelsFromConfig(inst.Config),
 			Role:                 Role(inst.Config[RoleKey]),
+			Tenant:               inst.Config[TenantLabelKey],
 			MonitoringEnabled:    inst.Config["environment.OTEL_EXPORTER_OTLP_ENDPOINT"] != "",
 			AutoSleepEnabled:     inst.Config[AutoSleepEnabledKey] == "true",
 			IdleThresholdMinutes: parseIdleThresholdMinutes(inst.Config),
@@ -763,6 +774,7 @@ func (c *Client) GetContainer(name string) (*ContainerInfo, error) {
 		CreatedAt:            inst.CreatedAt,
 		Labels:               extractLabelsFromConfig(inst.Config),
 		Role:                 Role(inst.Config[RoleKey]),
+		Tenant:               inst.Config[TenantLabelKey],
 		MonitoringEnabled:    inst.Config["environment.OTEL_EXPORTER_OTLP_ENDPOINT"] != "",
 		AutoSleepEnabled:     inst.Config[AutoSleepEnabledKey] == "true",
 		IdleThresholdMinutes: parseIdleThresholdMinutes(inst.Config),
@@ -1076,12 +1088,12 @@ type GPUInfo struct {
 
 // SystemResources holds system resource information
 type SystemResources struct {
-	TotalCPUs          int32
-	TotalMemoryBytes   int64
-	UsedMemoryBytes    int64
-	TotalDiskBytes     int64
-	UsedDiskBytes      int64
-	UptimeSeconds      int64
+	TotalCPUs        int32
+	TotalMemoryBytes int64
+	UsedMemoryBytes  int64
+	TotalDiskBytes   int64
+	UsedDiskBytes    int64
+	UptimeSeconds    int64
 	// CPU load averages (from /proc/loadavg)
 	CPULoad1Min  float64
 	CPULoad5Min  float64


### PR DESCRIPTION
First buildable slice of the **#315 "Cloud extension"** (see `NETWORK-ISOLATION-DESIGN.md`). Decouples a container's tenant identity from its name — the documented blocker for policing cloud-assigned containers.

## Why

The enforcer derived tenant **only** from the `<tenant>-container` naming convention (`tenantOf`), so a container named otherwise — notably the cloud-actuation client's proposed `cld-<uuid>` — was **skipped entirely** (no policy, no veth attach, no isolation). On a multi-tenant cloud host that means cloud containers share the bridge wide open.

## What

- **`incus.ContainerInfo.Tenant`** — populated from the `user.containarium.tenant` config key (`TenantLabelKey`) at both `ListContainers` and `GetContainer`, mirroring the existing `Role` pattern.
- **`resolveTenant(label, name)`** — prefers the explicit tenant label, falls back to the `<tenant>-container` name convention, `""` if neither. The enforcer's `gather()` uses it.

**Behavior is unchanged when no label is set** — every container today still resolves by name, so this is a safe no-op for existing deployments.

## Scope / dependencies

- **Usable now** for an OSS container that doesn't follow the naming convention: `incus config set <c> user.containarium.tenant=<t>`.
- The **cloud-actuation reconciler** will stamp the label from the assignment — that's integration point 2, **gated on the cloud-actuation client (not built) + its cross-repo proto** in `Containarium-cloud` (no access from here). Points 2–4 of the cloud extension can't start until that lands.

## Test

`go build ./...`, `go vet`, `gofmt` clean; `internal/server` tests pass, incl. new `resolveTenant` table (label wins / blank-label ignored / cloud-name-no-label → unmanaged / name fallback). Pure string+config logic feeding the already-hardware-validated attach path, so no kernel run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)