### PR TITLE
feat(client): advertise client version on CLI + MCP daemon requests

### DIFF
--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/footprintai/containarium/pkg/version"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -84,6 +85,12 @@ func (c *HTTPClient) doRequest(ctx context.Context, method, path string, body in
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
+	// Advertise the client version so the daemon can log it and, if it
+	// chooses, gate on a minimum-supported client. Both the conventional
+	// User-Agent and the explicit header are set; a server reads whichever
+	// it prefers.
+	req.Header.Set("User-Agent", version.UserAgent())
+	req.Header.Set(version.ClientVersionHeader, version.GetVersion())
 
 	return c.httpClient.Do(req)
 }

--- a/internal/client/http_test.go
+++ b/internal/client/http_test.go
@@ -1,10 +1,14 @@
 package client
 
 import (
+	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/footprintai/containarium/pkg/version"
 )
 
 // trackBody records whether it was read to EOF and closed, so a test can
@@ -83,5 +87,36 @@ func TestNewHTTPClient_PinsHTTP1(t *testing.T) {
 	// (not a zero-value transport with no timeouts).
 	if tr.DialContext == nil {
 		t.Error("expected DialContext preserved from http.DefaultTransport clone")
+	}
+}
+
+// TestDoRequest_AdvertisesClientVersion guards that every CLI→daemon request
+// carries the client version — a conventional User-Agent ("containarium/<ver>")
+// plus the explicit X-Containarium-Client-Version header — so a server can log
+// or gate on it.
+func TestDoRequest_AdvertisesClientVersion(t *testing.T) {
+	var gotUA, gotVer string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		gotVer = r.Header.Get(version.ClientVersionHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	resp, err := c.doRequest(context.Background(), http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("doRequest: %v", err)
+	}
+	drainClose(resp)
+
+	if !strings.HasPrefix(gotUA, "containarium/") {
+		t.Errorf("User-Agent = %q; want containarium/<version> prefix", gotUA)
+	}
+	if gotVer != version.GetVersion() {
+		t.Errorf("%s = %q; want %q", version.ClientVersionHeader, gotVer, version.GetVersion())
 	}
 }

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/footprintai/containarium/pkg/version"
 )
 
 // Client is a REST API client for Containarium. Carries a small amount
@@ -161,6 +163,12 @@ func (c *Client) doRequest(method, path string, body interface{}) ([]byte, error
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
+	// Advertise the client version so the daemon can log it and, if it
+	// chooses, gate on a minimum-supported client. Both the conventional
+	// User-Agent and the explicit header are set; a server reads whichever
+	// it prefers.
+	req.Header.Set("User-Agent", version.UserAgent())
+	req.Header.Set(version.ClientVersionHeader, version.GetVersion())
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/footprintai/containarium/pkg/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,6 +61,12 @@ func TestClientDoRequest(t *testing.T) {
 
 				// Verify content type
 				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+				// Verify the client advertises its version: a conventional
+				// User-Agent ("containarium/<ver>") plus the explicit header.
+				assert.True(t, strings.HasPrefix(r.Header.Get("User-Agent"), "containarium/"),
+					"User-Agent must be containarium/<version>, got %q", r.Header.Get("User-Agent"))
+				assert.Equal(t, version.GetVersion(), r.Header.Get(version.ClientVersionHeader))
 
 				w.WriteHeader(tt.serverStatus)
 				w.Write([]byte(tt.serverResponse))

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -37,6 +37,23 @@ func GetVersion() string {
 	return Version
 }
 
+// ClientVersionHeader is the HTTP header the CLI / MCP client sets to
+// advertise its own version to the daemon, e.g.
+//
+//	X-Containarium-Client-Version: 0.22.4
+//
+// It lets a server log the client version and, if it chooses, refuse or
+// warn on clients too old to speak its contract. Sent alongside a
+// conventional User-Agent (see UserAgent) so a server can read whichever
+// it prefers.
+const ClientVersionHeader = "X-Containarium-Client-Version"
+
+// UserAgent is the product/version token the CLI and MCP client send as
+// their HTTP User-Agent when talking to the daemon, e.g. "containarium/0.22.4".
+func UserAgent() string {
+	return "containarium/" + Version
+}
+
 // GetBuildTime returns the build time
 func GetBuildTime() string {
 	return BuildTime


### PR DESCRIPTION
## What

The CLI and MCP-server HTTP clients now advertise their version on every
request to the daemon:

    User-Agent: containarium/<version>
    X-Containarium-Client-Version: <version>

## Why

Today neither client identifies its version to the daemon (only
`Authorization` + `Content-Type` are sent). With the version on the wire a
daemon can log/telemeter which client versions are in use, and optionally
refuse or warn on a client too old to speak its contract instead of letting a
shape mismatch surface as a confusing deep error.

## How

- `pkg/version` gains `UserAgent()` and the `ClientVersionHeader` constant, so
  the format lives in one place and the two clients can't drift.
- Both clients funnel every request through a single `doRequest`, so this is
  one edit point each with full coverage.
- Tests assert both headers are present on outbound requests.

No server-side behavior changes; purely additive on the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
