### PR TITLE
fix(login): decode cloud device-flow JSON (camelCase + enum status)

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -194,20 +194,34 @@ type createSessionReq struct {
 	DeviceName string `json:"device_name"`
 }
 
+// JSON tags are lowerCamelCase: the cloud's CLISessionService is served
+// through grpc-gateway, whose protojson marshaler emits proto field names
+// in camelCase (sessionId, verificationUrl, …), NOT the snake_case proto
+// names. An earlier version used snake_case and silently decoded every
+// field to its zero value (→ "incomplete session"). Names mirror the
+// cloud CLISessionService's grpc-gateway JSON.
 type createSessionResp struct {
-	SessionID       string `json:"session_id"`
-	UserCode        string `json:"user_code"`
-	VerificationURL string `json:"verification_url"`
-	ExpiresIn       int    `json:"expires_in"`
+	SessionID       string `json:"sessionId"`
+	UserCode        string `json:"userCode"`
+	VerificationURL string `json:"verificationUrl"`
+	// Proto field expires_in_seconds → expiresInSeconds on the wire.
+	ExpiresIn int `json:"expiresInSeconds"`
 }
 
 type sessionStatusResp struct {
-	Status    string `json:"status"` // pending | approved | denied | expired
-	Token     string `json:"token,omitempty"`
-	UserEmail string `json:"user_email,omitempty"`
-	OrgID     string `json:"org_id,omitempty"`
+	// Status is a CLISessionStatus proto enum; grpc-gateway emits it as the
+	// enum NAME ("CLI_SESSION_STATUS_APPROVED"), so it is normalized to the
+	// short form (pending|approved|denied|expired) in fetchSessionStatus.
+	Status string `json:"status"`
+	Token  string `json:"token,omitempty"`
+	// UserEmail / OrgID are NOT in the cloud's GetCLISessionStatusResponse
+	// (it carries only status/token/expires_at/approved_at), so they stay
+	// empty here — identity is carried by the token itself. Retained so the
+	// credentials write + whoami display compile; tags are harmless.
+	UserEmail string `json:"userEmail,omitempty"`
+	OrgID     string `json:"orgId,omitempty"`
 	// ExpiresAt is RFC3339; absent or empty means non-expiring.
-	ExpiresAt string `json:"expires_at,omitempty"`
+	ExpiresAt string `json:"expiresAt,omitempty"`
 }
 
 // loginHTTPClient is the unauthenticated HTTP client used by the
@@ -571,7 +585,18 @@ func fetchSessionStatus(ctx context.Context, hc *http.Client, url string) (*sess
 	if err := json.Unmarshal(rb, &out); err != nil {
 		return nil, fmt.Errorf("decode status response: %w", err)
 	}
+	out.Status = normalizeSessionStatus(out.Status)
 	return &out, nil
+}
+
+// normalizeSessionStatus folds the cloud's CLISessionStatus proto-enum wire
+// form ("CLI_SESSION_STATUS_APPROVED") down to the short lowercase token the
+// poll loop switches on ("approved"). Tolerant of the short form too, so it
+// is a no-op if the wire ever emits the shorter shape. Empty stays empty
+// (treated as "pending" by the caller).
+func normalizeSessionStatus(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	return strings.TrimPrefix(s, "cli_session_status_")
 }
 
 func runLogout(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -167,6 +168,65 @@ func newFakeDeviceFlow(t *testing.T, approveAfter int32) *fakeDeviceFlowServer {
 	f.srv = httptest.NewServer(mux)
 	t.Cleanup(f.srv.Close)
 	return f
+}
+
+// TestCreateSession_DecodesCloudCamelCaseWire pins the POST /v1/cli/sessions
+// WIRE contract with HAND-WRITTEN lowerCamelCase JSON (captured from the live
+// cloud's grpc-gateway output) — NOT marshaled from createSessionResp. The
+// fakeDeviceFlowServer round-trips the struct, so it can't catch a tag drift;
+// this can. An earlier snake_case version of the struct decoded this body to
+// all-zero and login failed with "incomplete session".
+func TestCreateSession_DecodesCloudCamelCaseWire(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"sessionId":"sess-1","userCode":"WXYZ-1234",` +
+			`"verificationUrl":"https://cloud.example/cli/authorize?code=WXYZ-1234",` +
+			`"expiresInSeconds":600,"pollingIntervalSeconds":5,"expiresAt":"2026-06-03T08:43:25Z"}`))
+	}))
+	defer srv.Close()
+
+	got, err := createSession(context.Background(), srv.Client(), srv.URL, "cloud-mcp")
+	if err != nil {
+		t.Fatalf("createSession: %v", err)
+	}
+	if got.SessionID != "sess-1" || got.UserCode != "WXYZ-1234" {
+		t.Errorf("sessionId/userCode not decoded: %+v", got)
+	}
+	if got.VerificationURL == "" {
+		t.Error("verificationUrl not decoded (would trip the incomplete-session guard)")
+	}
+	if got.ExpiresIn != 600 {
+		t.Errorf("expiresInSeconds = %d, want 600", got.ExpiresIn)
+	}
+}
+
+// TestFetchSessionStatus_NormalizesProtoEnum pins two wire facts: (1) the
+// cloud emits CLISessionStatus as the proto-enum NAME
+// ("CLI_SESSION_STATUS_APPROVED"), which the handler folds to the short token
+// the poll loop switches on; (2) the status response carries NO email/org —
+// the cloud's GetCLISessionStatusResponse has only status/token/expires_at/
+// approved_at, so identity rides the token, not these fields.
+func TestFetchSessionStatus_NormalizesProtoEnum(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"CLI_SESSION_STATUS_APPROVED","token":"ctnr_test",` +
+			`"expiresAt":"2026-06-03T08:53:30Z"}`))
+	}))
+	defer srv.Close()
+
+	st, err := fetchSessionStatus(context.Background(), srv.Client(), srv.URL+"/status")
+	if err != nil {
+		t.Fatalf("fetchSessionStatus: %v", err)
+	}
+	if st.Status != "approved" {
+		t.Errorf("Status = %q, want normalized %q", st.Status, "approved")
+	}
+	if st.Token != "ctnr_test" {
+		t.Errorf("Token = %q, want ctnr_test", st.Token)
+	}
+	if st.UserEmail != "" || st.OrgID != "" {
+		t.Errorf("email/org must be empty (cloud status response omits them): email=%q org=%q", st.UserEmail, st.OrgID)
+	}
 }
 
 func TestLogin_HappyPath_WritesCredentials(t *testing.T) {


### PR DESCRIPTION
## What

Fixes `containarium login` failing against the hosted cloud with
`server returned incomplete session`, by decoding the device-flow responses
the way the server actually serializes them.

## Root cause

The device-flow response DTOs used snake_case JSON tags, but the cloud's
CLISessionService is served through grpc-gateway, whose protojson marshaler
emits proto fields in **lowerCamelCase** (`sessionId`, `verificationUrl`, …).
Every field decoded to its zero value, so the session looked empty. A second
latent bug: the status field is a proto enum emitted as its **name**
(`CLI_SESSION_STATUS_*`), which the poll loop didn't recognize.

## Changes

- `createSessionResp`: camelCase tags — `sessionId` / `userCode` /
  `verificationUrl` / `expiresInSeconds`.
- `sessionStatusResp`: normalize the `CLI_SESSION_STATUS_*` enum to the short
  form the poll loop switches on; `expiresAt`. `user_email`/`org_id` aren't in
  the status response, so they stay empty — documented; identity rides the
  token.
- Regression tests with **literal-JSON fixtures** that pin the real wire
  independently of the struct tags. The existing fake server round-trips the
  struct, so it could never catch a tag drift; these would have.

## Verification

Tested end-to-end against the live device-flow create endpoint; the existing
login test suite stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
