### PR TITLE
feat(cloud): cloud-actuation client slice 1 — enrollment config + CLI (#354)

### DIFF
--- a/internal/cloud/config.go
+++ b/internal/cloud/config.go
@@ -1,0 +1,134 @@
+// Package cloud is the OSS daemon's cloud-actuation client (#354 /
+// docs/CLOUD-ACTUATION-CLIENT-DESIGN.md): the opt-in mode where a registered
+// host receives desired-state container assignments + per-org network policies
+// from a cloud control plane and reconciles them locally.
+//
+// This file is the local enrollment config — the host-bearer token + control
+// plane address an operator writes once via `containarium cloud login`. It is
+// deliberately dependency-free (no cloud proto, no gRPC) so it builds in the
+// default OSS binary; the actuation client itself (heartbeat / WatchAssignments)
+// lands in later slices and consumes this.
+package cloud
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultRelPath is the cloud-enrollment config location under $HOME, alongside
+// the user-JWT credentials.json. Kept separate: credentials.json is the
+// user-facing JWT (`containarium login`); this is the host-bearer the daemon
+// uses for the actuation channel (`containarium cloud login`).
+const DefaultRelPath = ".containarium/cloud.yaml"
+
+// Config is a host's cloud-actuation enrollment. Written by `containarium cloud
+// login`; read by the daemon on startup to decide whether to run the actuation
+// client.
+type Config struct {
+	// ControlPlane is the cloud-daemon's gRPC address (host:port).
+	ControlPlane string `yaml:"control_plane"`
+	// HostID is the cloud-assigned host UUID (from the sysadmin who ran CreateHost).
+	HostID string `yaml:"host_id"`
+	// Token is the opaque, single-host-scoped host bearer. Sent as the
+	// host-bearer gRPC metadata on every actuation RPC; never parsed here.
+	Token string `yaml:"token"`
+}
+
+// DefaultPath resolves $HOME/.containarium/cloud.yaml.
+func DefaultPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(home, DefaultRelPath), nil
+}
+
+// Load reads the config at path. A missing file is not an error — it returns
+// (nil, nil), meaning "not enrolled" (the daemon then runs single-tenant).
+func Load(path string) (*Config, error) {
+	b, err := os.ReadFile(path) // #nosec G304 -- path is operator-provided config location
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read cloud config: %w", err)
+	}
+	if len(b) == 0 {
+		return nil, nil
+	}
+	var c Config
+	if err := yaml.Unmarshal(b, &c); err != nil {
+		return nil, fmt.Errorf("parse cloud config %s: %w", path, err)
+	}
+	return &c, nil
+}
+
+// Validate reports whether the config has the fields the client needs.
+func (c *Config) Validate() error {
+	if c == nil {
+		return fmt.Errorf("nil cloud config")
+	}
+	var missing []string
+	if strings.TrimSpace(c.ControlPlane) == "" {
+		missing = append(missing, "control_plane")
+	}
+	if strings.TrimSpace(c.HostID) == "" {
+		missing = append(missing, "host_id")
+	}
+	if strings.TrimSpace(c.Token) == "" {
+		missing = append(missing, "token")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("cloud config missing: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// Save writes the config to path atomically at mode 0600 (it holds a bearer
+// token). Creates the parent dir at 0700.
+func Save(path string, c *Config) error {
+	if c == nil {
+		return fmt.Errorf("nil cloud config")
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create cloud config dir %s: %w", dir, err)
+	}
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("marshal cloud config: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".cloud-*.yaml.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp cloud config: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }() // no-op if the rename succeeded
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp cloud config: %w", err)
+	}
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp cloud config: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp cloud config: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename cloud config into place: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the config (logout). Missing file is not an error.
+func Delete(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove cloud config: %w", err)
+	}
+	return nil
+}

--- a/internal/cloud/config_test.go
+++ b/internal/cloud/config_test.go
@@ -1,0 +1,78 @@
+package cloud
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestConfigRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "cloud.yaml")
+	in := &Config{ControlPlane: "cloud.example:443", HostID: "11111111-1111-1111-1111-111111111111", Token: "secret-bearer"}
+	if err := Save(path, in); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	out, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if out == nil || *out != *in {
+		t.Fatalf("round-trip mismatch: got %+v want %+v", out, in)
+	}
+}
+
+func TestLoadMissingIsNotEnrolled(t *testing.T) {
+	got, err := Load(filepath.Join(t.TempDir(), "nope.yaml"))
+	if err != nil {
+		t.Fatalf("missing file must not error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("missing file should yield nil config (not enrolled), got %+v", got)
+	}
+}
+
+func TestSaveIs0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permissions")
+	}
+	path := filepath.Join(t.TempDir(), "cloud.yaml")
+	if err := Save(path, &Config{ControlPlane: "x:443", HostID: "h", Token: "t"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("cloud config must be 0600 (holds a token), got %o", perm)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	if err := (&Config{ControlPlane: "x:443", HostID: "h", Token: "t"}).Validate(); err != nil {
+		t.Errorf("complete config should validate: %v", err)
+	}
+	if err := (&Config{HostID: "h", Token: "t"}).Validate(); err == nil {
+		t.Error("missing control_plane should fail validation")
+	}
+	if err := (*Config)(nil).Validate(); err == nil {
+		t.Error("nil config should fail validation")
+	}
+}
+
+func TestDeleteIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cloud.yaml")
+	if err := Delete(path); err != nil {
+		t.Errorf("delete of missing file must be nil, got %v", err)
+	}
+	if err := Save(path, &Config{ControlPlane: "x:443", HostID: "h", Token: "t"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Delete(path); err != nil {
+		t.Errorf("delete: %v", err)
+	}
+	if got, _ := Load(path); got != nil {
+		t.Error("config should be gone after delete")
+	}
+}

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/footprintai/containarium/internal/cloud"
+)
+
+// cloudCmd is the parent for `containarium cloud <verb>` — host enrollment with
+// a cloud control plane (#354, docs/CLOUD-ACTUATION-CLIENT-DESIGN.md). This is
+// the OSS opt-in: a registered host receives desired-state container assignments
+// + per-org egress network policies from the cloud and reconciles them locally.
+//
+// Distinct from `containarium login` (which stores a user-facing JWT in
+// credentials.json): `cloud login` stores a host bearer in cloud.yaml, used by
+// the daemon's actuation client. Slice 1: enrollment config only — the daemon
+// heartbeat / WatchAssignments client lands in later slices.
+var cloudCmd = &cobra.Command{
+	Use:   "cloud",
+	Short: "Enroll this host with a cloud control plane (actuation)",
+	Long: `Manage this host's enrollment with a Containarium cloud control plane.
+
+When enrolled, the daemon runs an actuation client that receives desired-state
+container assignments and per-org network policies from the cloud and reconciles
+them against local Incus state. Enrollment is opt-in — an unenrolled daemon is
+single-tenant and makes no outbound calls.
+
+The host bearer token comes from a cloud sysadmin (who runs the cloud-side
+CreateHost); you receive the host ID + token out of band and register here.`,
+}
+
+var (
+	cloudControlPlane string
+	cloudHostID       string
+	cloudTokenFile    string
+)
+
+var cloudLoginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Register this host (writes ~/.containarium/cloud.yaml)",
+	Long: `Register this host with a cloud control plane.
+
+The token is read from --token-file (not a flag) so it never lands in shell
+history. Writes the enrollment to ~/.containarium/cloud.yaml at mode 0600.`,
+	RunE: runCloudLogin,
+}
+
+var cloudStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show this host's cloud enrollment",
+	RunE:  runCloudStatus,
+}
+
+var cloudLogoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Remove this host's enrollment (~/.containarium/cloud.yaml)",
+	Long: `Delete the local enrollment config. The daemon stops actuating on next
+restart. The cloud-side host row stays until a sysadmin tombstones it
+(cloud DeleteHost).`,
+	RunE: runCloudLogout,
+}
+
+func init() {
+	rootCmd.AddCommand(cloudCmd)
+	cloudCmd.AddCommand(cloudLoginCmd, cloudStatusCmd, cloudLogoutCmd)
+
+	cloudLoginCmd.Flags().StringVar(&cloudControlPlane, "control-plane", "", "cloud control-plane gRPC address (host:port) (required)")
+	cloudLoginCmd.Flags().StringVar(&cloudHostID, "host-id", "", "cloud-assigned host UUID from the sysadmin (required)")
+	cloudLoginCmd.Flags().StringVar(&cloudTokenFile, "token-file", "", "file containing the host bearer token (required)")
+	_ = cloudLoginCmd.MarkFlagRequired("control-plane")
+	_ = cloudLoginCmd.MarkFlagRequired("host-id")
+	_ = cloudLoginCmd.MarkFlagRequired("token-file")
+}
+
+func runCloudLogin(cmd *cobra.Command, _ []string) error {
+	tokenBytes, err := os.ReadFile(cloudTokenFile) // #nosec G304 -- operator-provided token path
+	if err != nil {
+		return fmt.Errorf("read --token-file: %w", err)
+	}
+	token := strings.TrimSpace(string(tokenBytes))
+	if token == "" {
+		return fmt.Errorf("--token-file %q is empty", cloudTokenFile)
+	}
+	cfg := &cloud.Config{
+		ControlPlane: strings.TrimSpace(cloudControlPlane),
+		HostID:       strings.TrimSpace(cloudHostID),
+		Token:        token,
+	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	path, err := cloud.DefaultPath()
+	if err != nil {
+		return err
+	}
+	if err := cloud.Save(path, cfg); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "✓ enrolled host %s with %s\n  config: %s (restart the daemon to start actuating)\n",
+		cfg.HostID, cfg.ControlPlane, path)
+	return nil
+}
+
+func runCloudStatus(cmd *cobra.Command, _ []string) error {
+	path, err := cloud.DefaultPath()
+	if err != nil {
+		return err
+	}
+	cfg, err := cloud.Load(path)
+	if err != nil {
+		return err
+	}
+	w := cmd.OutOrStdout()
+	if cfg == nil {
+		fmt.Fprintf(w, "not enrolled (no %s) — daemon runs single-tenant\n", path)
+		return nil
+	}
+	fmt.Fprintf(w, "enrolled\n  control-plane: %s\n  host-id:       %s\n  token:         %s\n  config:        %s\n",
+		cfg.ControlPlane, cfg.HostID, redactToken(cfg.Token), path)
+	return nil
+}
+
+func runCloudLogout(cmd *cobra.Command, _ []string) error {
+	path, err := cloud.DefaultPath()
+	if err != nil {
+		return err
+	}
+	if err := cloud.Delete(path); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "✓ removed cloud enrollment (%s)\n", path)
+	return nil
+}
+
+// redactToken shows only enough to recognize which token is stored, never the
+// whole bearer.
+func redactToken(t string) string {
+	if len(t) <= 8 {
+		return "********"
+	}
+	return t[:4] + "…" + t[len(t)-4:]
+}


### PR DESCRIPTION
First slice of the OSS **cloud-actuation client** (`docs/CLOUD-ACTUATION-CLIENT-DESIGN.md`): the opt-in enrollment surface a host uses to register with a cloud control plane. This is the piece that, in later slices, closes the loop to the #315 enforcer — the cloud authors per-org egress policy ([cloud #262](https://github.com/FootprintAI/Containarium-cloud/pull/262)), ships it over actuation ([#259](https://github.com/FootprintAI/Containarium-cloud/pull/259)/[#260](https://github.com/FootprintAI/Containarium-cloud/pull/260)/[#261](https://github.com/FootprintAI/Containarium-cloud/pull/261)), and the host applies it.

## What

- **`internal/cloud`** — dependency-free enrollment config: `Config{ControlPlane, HostID, Token}` in `~/.containarium/cloud.yaml`. `Load` returns `nil` when absent (= "not enrolled → run single-tenant"); `Save` is atomic + `0600` (holds a bearer); plus `Validate`/`Delete`. Mirrors `internal/credentials`.
- **`internal/cmd`** — `containarium cloud login|status|logout`. `login` reads the bearer from `--token-file` (never a flag → not in shell history); `status` redacts the token; `logout` removes the config. Distinct from `containarium login` (user JWT → `credentials.json`); this is the **host bearer** → `cloud.yaml`.
- **Tests** — config round-trip / missing=not-enrolled / `0600` perms / `Validate` / idempotent `Delete`; CLI smoke-tested `login→status→logout`.

## Deliberate deviation: no cloud-proto dep yet

The design's slice 1 front-loads `go get github.com/footprintai/containarium-cloud/pkg/pb/...`. That module is **private** and this is a **public** repo — importing it unconditionally would break the community `go build`. So this slice is **dep-free** (the default OSS binary is completely unaffected), and the proto dependency lands with the heartbeat/`WatchAssignments` slice, behind a `//go:build cloud_actuation` tag (+ `GOPRIVATE` in the cloud-build CI) or via vendored protos. Calling that decision out there rather than silently adding a private dep here.

## Next slices

3. Heartbeat ticker (needs the cloud pb dep — the decision above). 4. `WatchAssignments` + reconciler: stamp `user.containarium.tenant=<org_id>`, write `network_policies` into the `NetworkPolicyStore`. 5. On-backend smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)