### PR TITLE
feat(cloud): actuation client slice 4 — WatchAssignments → network-policy sync (#354)

### DIFF
--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -27,6 +27,17 @@ const hostBearerMetadataKey = "host-bearer"
 // staleness threshold is ~3 missed beats; see the cloud container-actuation PRD.
 const defaultHeartbeatInterval = 30 * time.Second
 
+// PolicySink receives each AssignmentBatch's per-org network policies so the
+// daemon can converge its NetworkPolicyStore (where the eBPF enforcer applies
+// them). The daemon implements this; keeping it an interface lets the client be
+// tested with a fake and keeps internal/cloud free of an internal/server import.
+type PolicySink interface {
+	// SyncNetworkPolicies is handed the full set of policies on the current
+	// batch (a snapshot, like assignments). Implementations converge their store
+	// to exactly this set, keyed by org.
+	SyncNetworkPolicies(ctx context.Context, policies []*cloudv1.NetworkPolicy) error
+}
+
 // Client is the host-side cloud-actuation client. Slice 3 implements the
 // heartbeat; WatchAssignments + the reconciler land in slice 4. The actuation
 // proto is vendored (proto/containarium/cloud/v1), so this builds in the default
@@ -35,6 +46,7 @@ const defaultHeartbeatInterval = 30 * time.Second
 type Client struct {
 	cfg      *Config
 	interval time.Duration
+	sink     PolicySink // optional; nil = heartbeat only (no policy reconcile)
 
 	conn *grpc.ClientConn
 	ac   cloudv1.ActuationServiceClient
@@ -47,12 +59,13 @@ type Client struct {
 	failures int // consecutive heartbeat failures, for observability
 }
 
-// New builds a client from a validated config.
-func New(cfg *Config) (*Client, error) {
+// New builds a client from a validated config. sink may be nil (heartbeat only);
+// pass a PolicySink to converge per-org network policies from WatchAssignments.
+func New(cfg *Config, sink PolicySink) (*Client, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
-	return &Client{cfg: cfg, interval: defaultHeartbeatInterval}, nil
+	return &Client{cfg: cfg, interval: defaultHeartbeatInterval, sink: sink}, nil
 }
 
 // Start dials the control plane and launches the heartbeat loop. A dial error is
@@ -69,8 +82,12 @@ func (c *Client) Start(ctx context.Context) error {
 
 	c.wg.Add(1)
 	go c.heartbeatLoop()
-	log.Printf("[cloud] actuation client started: host=%s control-plane=%s (heartbeat %s)",
-		c.cfg.HostID, c.cfg.ControlPlane, c.interval)
+	if c.sink != nil {
+		c.wg.Add(1)
+		go c.watchLoop()
+	}
+	log.Printf("[cloud] actuation client started: host=%s control-plane=%s (heartbeat %s, watch=%v)",
+		c.cfg.HostID, c.cfg.ControlPlane, c.interval, c.sink != nil)
 	return nil
 }
 
@@ -139,4 +156,72 @@ func (c *Client) heartbeatOnce(ctx context.Context) error {
 // authContext attaches the host bearer the cloud interceptor authenticates on.
 func (c *Client) authContext(ctx context.Context) context.Context {
 	return metadata.AppendToOutgoingContext(ctx, hostBearerMetadataKey, c.cfg.Token)
+}
+
+// watchBackoff is the reconnect schedule for the WatchAssignments stream:
+// exponential with a 60s cap. Jitter is omitted (single host per process; no
+// thundering herd to spread).
+var watchBackoff = []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second, 32 * time.Second, 60 * time.Second}
+
+// watchLoop opens the WatchAssignments server stream and reconciles each batch,
+// reconnecting with capped exponential backoff on any stream error. Runs until
+// the client context is cancelled.
+func (c *Client) watchLoop() {
+	defer c.wg.Done()
+	attempt := 0
+	for {
+		if c.ctx.Err() != nil {
+			return
+		}
+		err := c.watchOnce()
+		if c.ctx.Err() != nil {
+			return
+		}
+		// Stream ended (error or clean EOF) — back off, then re-open. A fresh
+		// WatchAssignments resends the full snapshot, so the reconcile is
+		// self-correcting; we never lose state by reconnecting.
+		d := watchBackoff[attempt]
+		if attempt < len(watchBackoff)-1 {
+			attempt++
+		}
+		if err != nil {
+			log.Printf("[cloud] watch stream ended (%v); reconnecting in %s", err, d)
+		}
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-time.After(d):
+		}
+	}
+}
+
+// watchOnce opens one stream and reconciles batches until it errors. On the
+// first successful batch it resets nothing — the caller's backoff index resets
+// only via a successful reconnect cycle (kept simple: any return re-enters the
+// loop). Returns the stream error (nil on a clean server close).
+func (c *Client) watchOnce() error {
+	stream, err := c.ac.WatchAssignments(c.authContext(c.ctx), &cloudv1.WatchAssignmentsRequest{})
+	if err != nil {
+		return err
+	}
+	for {
+		batch, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		c.reconcile(batch)
+	}
+}
+
+// reconcile applies one batch. Slice 4 converges per-org network policies into
+// the sink (closing the #315 cloud-extension loop: cloud-authored egress policy
+// → host enforcer). Container desired-state reconciliation (create/start/stop/
+// delete) is a separate follow-up.
+func (c *Client) reconcile(batch *cloudv1.AssignmentBatch) {
+	if c.sink == nil {
+		return
+	}
+	if err := c.sink.SyncNetworkPolicies(c.ctx, batch.GetNetworkPolicies()); err != nil {
+		log.Printf("[cloud] sync network policies: %v", err)
+	}
 }

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -34,6 +34,31 @@ func (f *fakeActuation) Heartbeat(ctx context.Context, _ *cloudv1.HeartbeatReque
 	return &cloudv1.HeartbeatResponse{}, nil
 }
 
+// WatchAssignments sends one batch (with the canned policies) then closes the
+// stream, so watchOnce reconciles once and returns cleanly.
+func (f *fakeActuation) WatchAssignments(_ *cloudv1.WatchAssignmentsRequest, stream cloudv1.ActuationService_WatchAssignmentsServer) error {
+	return stream.Send(&cloudv1.AssignmentBatch{
+		NetworkPolicies: []*cloudv1.NetworkPolicy{
+			{OrgId: "org-1", EgressCidrs: []string{"8.8.8.8/32"}, Mode: cloudv1.NetworkPolicyMode_NETWORK_POLICY_MODE_ENFORCE},
+		},
+	})
+}
+
+// recordingSink captures the policies handed to it.
+type recordingSink struct {
+	mu       sync.Mutex
+	policies []*cloudv1.NetworkPolicy
+	calls    int
+}
+
+func (s *recordingSink) SyncNetworkPolicies(_ context.Context, p []*cloudv1.NetworkPolicy) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	s.policies = p
+	return nil
+}
+
 // newTestClient wires a Client to a bufconn-backed fake server, bypassing dial.
 func newTestClient(t *testing.T, cfg *Config) (*Client, *fakeActuation) {
 	t.Helper()
@@ -54,6 +79,8 @@ func newTestClient(t *testing.T, cfg *Config) (*Client, *fakeActuation) {
 	t.Cleanup(func() { _ = conn.Close() })
 
 	c := &Client{cfg: cfg, interval: defaultHeartbeatInterval, ac: cloudv1.NewActuationServiceClient(conn)}
+	c.ctx, c.cancel = context.WithCancel(context.Background())
+	t.Cleanup(c.cancel)
 	return c, fake
 }
 
@@ -75,7 +102,35 @@ func TestHeartbeatSendsHostBearer(t *testing.T) {
 }
 
 func TestNewRejectsIncompleteConfig(t *testing.T) {
-	if _, err := New(&Config{HostID: "h", Token: "t"}); err == nil {
+	if _, err := New(&Config{HostID: "h", Token: "t"}, nil); err == nil {
 		t.Error("New must reject a config missing control_plane")
 	}
+}
+
+func TestWatchOnceSyncsNetworkPolicies(t *testing.T) {
+	cfg := &Config{ControlPlane: "bufconn", HostID: "host-1", Token: "host-1.bearer"}
+	c, _ := newTestClient(t, cfg)
+	sink := &recordingSink{}
+	c.sink = sink
+
+	// watchOnce reconciles the one batch the fake sends, then returns on EOF.
+	_ = c.watchOnce()
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if sink.calls == 0 {
+		t.Fatal("sink never received a batch")
+	}
+	if len(sink.policies) != 1 || sink.policies[0].GetOrgId() != "org-1" {
+		t.Fatalf("sink got wrong policies: %+v", sink.policies)
+	}
+	if sink.policies[0].GetMode() != cloudv1.NetworkPolicyMode_NETWORK_POLICY_MODE_ENFORCE {
+		t.Errorf("mode not propagated: %v", sink.policies[0].GetMode())
+	}
+}
+
+func TestReconcileNilSinkIsNoop(t *testing.T) {
+	c := &Client{} // no sink
+	c.ctx = context.Background()
+	c.reconcile(&cloudv1.AssignmentBatch{NetworkPolicies: []*cloudv1.NetworkPolicy{{OrgId: "x"}}}) // must not panic
 }

--- a/internal/server/cloud_policy_sink.go
+++ b/internal/server/cloud_policy_sink.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"context"
+
+	cloudv1 "github.com/footprintai/containarium/pkg/pb/containarium/cloud/v1"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// cloudPolicySink implements cloud.PolicySink: it writes per-org egress policies
+// received from the cloud-actuation channel into the NetworkPolicyServer's store
+// (keyed by org as the tenant), where the eBPF enforcer's reconcile loop applies
+// them. This is the OSS end of the #315 cloud extension — it closes the loop
+// from cloud-authored policy to on-box enforcement.
+//
+// It holds the *NetworkPolicyServer (not the store directly) so it always writes
+// to the current store, even after the startup-time Postgres swap.
+type cloudPolicySink struct {
+	np *NetworkPolicyServer
+}
+
+func newCloudPolicySink(np *NetworkPolicyServer) *cloudPolicySink {
+	return &cloudPolicySink{np: np}
+}
+
+// SyncNetworkPolicies upserts each org's policy into the store. The org_id is the
+// tenant key — cloud containers are labelled user.containarium.tenant=<org_id>
+// (container reconcile, a follow-up), so the enforcer matches them. Upsert-only:
+// a policy removed cloud-side is not deleted locally yet (distinguishing
+// cloud-authored from CLI-authored policies needs a source marker — a follow-up);
+// upsert keeps the common rollout path correct without risking clobbering a
+// self-hosted operator's CLI-authored policy.
+func (s *cloudPolicySink) SyncNetworkPolicies(ctx context.Context, policies []*cloudv1.NetworkPolicy) error {
+	store := s.np.Store()
+	if store == nil {
+		return nil
+	}
+	for _, np := range policies {
+		if np.GetOrgId() == "" {
+			continue
+		}
+		if err := store.Set(ctx, &pb.NetworkPolicy{
+			Tenant:           np.GetOrgId(),
+			AllowIntraTenant: np.GetAllowIntraTenant(),
+			EgressCidrs:      np.GetEgressCidrs(),
+			EgressDomains:    np.GetEgressDomains(),
+			AllowMetadata:    np.GetAllowMetadata(),
+			Mode:             pb.NetworkPolicyMode(int32(np.GetMode())), // same enum values (vendored from one source)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/server/cloud_policy_sink_test.go
+++ b/internal/server/cloud_policy_sink_test.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	cloudv1 "github.com/footprintai/containarium/pkg/pb/containarium/cloud/v1"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+func TestCloudPolicySink_WritesIntoStore(t *testing.T) {
+	np := NewNetworkPolicyServer(NewMemNetworkPolicyStore())
+	sink := newCloudPolicySink(np)
+
+	err := sink.SyncNetworkPolicies(context.Background(), []*cloudv1.NetworkPolicy{
+		{
+			OrgId:         "org-7",
+			EgressCidrs:   []string{"8.8.8.8/32"},
+			EgressDomains: []string{"api.github.com"},
+			AllowMetadata: false,
+			Mode:          cloudv1.NetworkPolicyMode_NETWORK_POLICY_MODE_ENFORCE,
+		},
+		{OrgId: ""}, // skipped (no org)
+	})
+	if err != nil {
+		t.Fatalf("SyncNetworkPolicies: %v", err)
+	}
+
+	got, err := np.Store().Get(context.Background(), "org-7")
+	if err != nil {
+		t.Fatalf("policy not stored under org tenant: %v", err)
+	}
+	if got.GetMode() != pb.NetworkPolicyMode_NETWORK_POLICY_MODE_ENFORCE {
+		t.Errorf("mode not mapped to ENFORCE: %v", got.GetMode())
+	}
+	if len(got.GetEgressCidrs()) != 1 || got.GetEgressCidrs()[0] != "8.8.8.8/32" {
+		t.Errorf("egress not stored: %v", got.GetEgressCidrs())
+	}
+	if got.GetAllowMetadata() {
+		t.Errorf("metadata must stay denied")
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/footprintai/containarium/internal/audit"
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/autosleep"
+	"github.com/footprintai/containarium/internal/cloud"
 	"github.com/footprintai/containarium/internal/collaborator"
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/gateway"
@@ -176,6 +177,7 @@ type DualServer struct {
 	ttlSweeperManager     *ttlsweeper.Manager    // ephemeral CI box auto-delete (#299)
 	secretsReconciler     *secretsReconciler     // Phase 4.3 Phase B-3
 	networkPolicyEnforcer *NetworkPolicyEnforcer // #315 Phase A — eBPF per-tenant net policy (off unless configured)
+	cloudClient           *cloud.Client          // #354 — cloud-actuation client (nil unless host is enrolled)
 	startTime             time.Time
 }
 
@@ -302,6 +304,32 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	npServer := NewNetworkPolicyServer(NewMemNetworkPolicyStore())
 	pb.RegisterNetworkPolicyServiceServer(grpcServer, npServer)
 	log.Printf("NetworkPolicy service enabled (in-memory store; Phase A)")
+
+	// Cloud-actuation client (#354): if this host is enrolled with a cloud
+	// control plane, run the actuation client. It heartbeats and consumes
+	// WatchAssignments, syncing each org's egress network policy into the
+	// NetworkPolicyServer's store (closing the #315 cloud-extension loop:
+	// cloud-authored policy → on-box enforcer). Unenrolled (no cloud.yaml) → the
+	// daemon is single-tenant and makes no outbound calls. The sink holds
+	// npServer so it always writes to the current store (post-Postgres-swap).
+	var cloudClient *cloud.Client
+	cloudCfgPath := os.Getenv("CONTAINARIUM_CLOUD_CONFIG")
+	if cloudCfgPath == "" {
+		if p, perr := cloud.DefaultPath(); perr == nil {
+			cloudCfgPath = p
+		}
+	}
+	if cloudCfg, cerr := cloud.Load(cloudCfgPath); cerr != nil {
+		log.Printf("Warning: failed to read cloud-actuation config %s: %v (running single-tenant)", cloudCfgPath, cerr)
+	} else if cloudCfg != nil {
+		if cc, nerr := cloud.New(cloudCfg, newCloudPolicySink(npServer)); nerr != nil {
+			log.Printf("Warning: cloud-actuation config invalid: %v (running single-tenant)", nerr)
+		} else {
+			cloudClient = cc
+			log.Printf("Cloud-actuation client configured (host=%s control-plane=%s); starts with the daemon",
+				cloudCfg.HostID, cloudCfg.ControlPlane)
+		}
+	}
 
 	// Create TrafficServer (always available, but conntrack only works on Linux)
 	var trafficServer *TrafficServer
@@ -1312,6 +1340,7 @@ skipAppHosting:
 		zapStore:              zapStore,
 		peerPool:              NewPeerPool(config.LocalBackendID, config.SentinelURL, config.Peers, config.Pool),
 		networkPolicyEnforcer: networkPolicyEnforcer,
+		cloudClient:           cloudClient,
 		startTime:             time.Now(),
 	}
 
@@ -1688,6 +1717,18 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		}
 	}
 
+	// Start the cloud-actuation client if the host is enrolled (#354). A dial
+	// failure is logged and the daemon serves on — cloud connectivity must never
+	// block local serving.
+	if ds.cloudClient != nil {
+		if err := ds.cloudClient.Start(ctx); err != nil {
+			log.Printf("Warning: cloud-actuation client failed to start: %v (continuing without it)", err)
+			ds.cloudClient = nil
+		} else {
+			log.Printf("Cloud-actuation client started")
+		}
+	}
+
 	// Ensure a management route per served base domain persists in
 	// PostgreSQL (RouteSyncJob pushes each to Caddy — host matcher + TLS
 	// subject). One route per PublicBaseDomains entry, so the daemon
@@ -1799,6 +1840,9 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		}
 		if ds.trafficCollector != nil {
 			ds.trafficCollector.Stop()
+		}
+		if ds.cloudClient != nil {
+			ds.cloudClient.Stop()
 		}
 		if ds.networkPolicyEnforcer != nil {
 			ds.networkPolicyEnforcer.Stop()


### PR DESCRIPTION
**Closes the #315 cloud-extension loop end to end**: cloud-authored per-org egress policy → on-box eBPF enforcer. Builds on slice 3 (#450).

## What

The client now consumes `WatchAssignments` and syncs each batch's per-org network policies into the daemon's `NetworkPolicyServer` store, where the hardware-validated enforcer applies them.

- **`internal/cloud`** — `PolicySink` interface; `Client.New(cfg, sink)`; `Start` launches a `WatchAssignments` consumer alongside the heartbeat. `watchLoop` reconnects with capped exponential backoff (1→60s); a fresh stream resends the full snapshot, so reconcile is self-correcting. `reconcile()` hands `batch.network_policies` to the sink.
- **`internal/server/cloud_policy_sink.go`** — `cloudPolicySink` maps each `cloudv1.NetworkPolicy` → `pb.NetworkPolicy` (org_id as tenant) and upserts via the live `NetworkPolicyServer` (lazy `Store()` so it follows the Postgres swap).
- **`dual_server.go`** — construct + Start/Stop the cloud client when the host is enrolled (`cloud.Load` via `CONTAINARIUM_CLOUD_CONFIG` or `~/.containarium/cloud.yaml`). Unenrolled → no outbound calls, single-tenant (unchanged default).
- **Tests** — `watchOnce` streams a batch to a recording sink; nil-sink no-op; the daemon sink writes a cloud policy into the store keyed by org with mode mapped. Vendored proto → default `go build`/`go test` exercise everything; `go mod tidy` no-op.

## The full chain now exists

```
cloud author (NetworkPolicyService) → store → ship (AssignmentBatch.network_policies)
  → OSS WatchAssignments consumer → cloudPolicySink → NetworkPolicyStore → eBPF enforcer (drops)
```

## Scope notes

- **Upsert-only** sync (no delete-convergence): distinguishing cloud- vs CLI-authored policies needs a source marker — follow-up.
- **Container desired-state reconcile** (create/start/stop/delete + stamp `user.containarium.tenant=<org_id>`) is the remaining cloud-actuation feature — orthogonal to the #315 egress arc, its own piece.
- **Slice 5 (on-backend smoke)** against a live control plane needs a host token from a cloud sysadmin; that's the validation step (I can't self-issue one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)