### PR TITLE
fix(login): ride out transient poll errors + guide on device-name collision (#455, #456)

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -72,6 +72,11 @@ var loginPromptReader io.Reader = os.Stdin
 // the production constant.
 var pollIntervalOverride = loginPollInterval
 
+// maxWaitOverride lets tests shrink the overall approval window so the
+// timeout path (and its #456 collision guidance) is exercisable in
+// milliseconds. Defaults to the production constant.
+var maxWaitOverride = loginMaxWait
+
 var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Authenticate against a Containarium server via browser device flow",
@@ -302,7 +307,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	srv := pickLoginServer(loginServer)
 	out := cmd.OutOrStdout()
 	hc := loginHTTPClient()
-	ctx, cancel := context.WithTimeout(context.Background(), loginMaxWait+loginHTTPTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), maxWaitOverride+loginHTTPTimeout)
 	defer cancel()
 
 	// 1. Open a session.
@@ -322,8 +327,23 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(out, "(polls every %s, max %s)\n", loginPollInterval, loginMaxWait)
 
 	// 2. Poll status until terminal.
-	status, err := pollSession(ctx, hc, srv, sess.SessionID, pollIntervalOverride, loginMaxWait)
+	status, err := pollSession(ctx, out, hc, srv, sess.SessionID, pollIntervalOverride, maxWaitOverride)
 	if err != nil {
+		// A timeout most often means the browser approval never landed.
+		// The single most common reason it silently fails: the token
+		// the approval mints is named after --device-name, and a token
+		// with that name already exists in the org, so the server
+		// refuses the approve and the session just sits pending until it
+		// expires (#456). The CLI can't see that approve-side error
+		// (it's unauthenticated and only polls status), so spell out the
+		// remedy instead of leaving the user staring at a bare timeout.
+		if errors.Is(err, errPollTimeout) {
+			dev := deviceName(loginDeviceName)
+			base := strings.TrimRight(srv, "/")
+			fmt.Fprintf(out, "\nApproval didn't complete in time.\n")
+			fmt.Fprintf(out, "If you've signed in as %q before, that device name may already be in use —\n", dev)
+			fmt.Fprintf(out, "revoke the old token at %s/settings/api-tokens, or rerun with a different --device-name.\n", base)
+		}
 		return err
 	}
 
@@ -524,19 +544,57 @@ func createSession(ctx context.Context, hc *http.Client, server, device string) 
 }
 
 // pollSession GETs /v1/cli/sessions/{id}/status every interval and
-// returns the final non-pending status (or an error if the deadline
-// elapses or the server reports denied/expired).
-func pollSession(ctx context.Context, hc *http.Client, server, sessionID string, interval, maxWait time.Duration) (*sessionStatusResp, error) {
+// returns the final non-pending status. It rides out transient errors
+// (network blips, 5xx, 408/429) until the maxWait deadline rather than
+// aborting on the first one — a momentary DNS or connectivity hiccup
+// must not kill a multi-minute login while the user is mid-approval in
+// the browser (#455). Terminal conditions stop immediately: a gone
+// session (404), a non-retryable HTTP error, denied/expired status, or
+// a cancelled context. Progress notices for transient retries go to
+// out (nil-safe).
+func pollSession(ctx context.Context, out io.Writer, hc *http.Client, server, sessionID string, interval, maxWait time.Duration) (*sessionStatusResp, error) {
 	deadline := time.Now().Add(maxWait)
 	url := fmt.Sprintf("%s/v1/cli/sessions/%s/status", server, sessionID)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
+	var consecutiveTransient int
 	for {
 		st, err := fetchSessionStatus(ctx, hc, url)
 		if err != nil {
-			return nil, fmt.Errorf("poll session status: %w", err)
+			// Terminal: the session is gone — stop, consistent with the
+			// "expired" status branch below.
+			if errors.Is(err, errSessionGone) {
+				return nil, fmt.Errorf("login session expired before approval")
+			}
+			// Terminal: a non-retryable HTTP error (bad request, auth,
+			// etc.). Retrying won't change the answer.
+			var he httpStatusError
+			if errors.As(err, &he) && !he.retryable() {
+				return nil, fmt.Errorf("poll session status: %w", err)
+			}
+			// Transient: network error, 5xx, or 408/429. Keep polling
+			// until the deadline, but bail if they pile up consecutively
+			// (server down for good) so we fail faster than maxWait.
+			consecutiveTransient++
+			if consecutiveTransient >= maxConsecutivePollFailures {
+				return nil, fmt.Errorf("poll session status: %d consecutive failures, last: %w", consecutiveTransient, err)
+			}
+			if time.Now().After(deadline) {
+				return nil, fmt.Errorf("%w (after %s); last error: %v", errPollTimeout, maxWait, err)
+			}
+			if out != nil {
+				fmt.Fprintf(out, "  (transient error polling status, retrying: %v)\n", err)
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-ticker.C:
+			}
+			continue
 		}
+		consecutiveTransient = 0
+
 		switch st.Status {
 		case "approved":
 			if st.Token == "" {
@@ -554,7 +612,7 @@ func pollSession(ctx context.Context, hc *http.Client, server, sessionID string,
 		}
 
 		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("timed out waiting for approval (after %s)", maxWait)
+			return nil, fmt.Errorf("%w (after %s)", errPollTimeout, maxWait)
 		}
 		select {
 		case <-ctx.Done():
@@ -576,10 +634,14 @@ func fetchSessionStatus(ctx context.Context, hc *http.Client, url string) (*sess
 	defer resp.Body.Close()
 	rb, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("session not found (id may have expired)")
+		// Terminal: the session row is gone (expired / swept / unknown
+		// id). Re-polling can't bring it back.
+		return nil, errSessionGone
 	}
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(rb)))
+		// Carry the code so pollSession can decide retry-vs-give-up by
+		// class (5xx / 408 / 429 are transient; other 4xx aren't).
+		return nil, httpStatusError{code: resp.StatusCode, body: strings.TrimSpace(string(rb))}
 	}
 	var out sessionStatusResp
 	if err := json.Unmarshal(rb, &out); err != nil {
@@ -588,6 +650,50 @@ func fetchSessionStatus(ctx context.Context, hc *http.Client, url string) (*sess
 	out.Status = normalizeSessionStatus(out.Status)
 	return &out, nil
 }
+
+// errSessionGone is the terminal "this session no longer exists" signal
+// — a 404 from the status endpoint (expired, swept, or unknown id).
+// pollSession stops on it rather than retrying.
+var errSessionGone = errors.New("session not found (id may have expired)")
+
+// errPollTimeout marks the "ran out the maxWait window without an
+// approval" case so runLogin can attach actionable guidance (the most
+// common real cause is a device-name collision — see #456) without
+// string-matching the error text.
+var errPollTimeout = errors.New("timed out waiting for approval")
+
+// httpStatusError carries a non-2xx status from the status endpoint so
+// pollSession can classify it. A bare fmt.Errorf would force the loop
+// to string-match the code, which is exactly the brittleness #455 is
+// about.
+type httpStatusError struct {
+	code int
+	body string
+}
+
+func (e httpStatusError) Error() string {
+	if e.body != "" {
+		return fmt.Sprintf("status %d: %s", e.code, e.body)
+	}
+	return fmt.Sprintf("status %d", e.code)
+}
+
+// retryable reports whether re-polling could plausibly succeed: a
+// transient server fault (5xx) or a back-pressure signal (408, 429).
+// Any other 4xx is a client/contract problem that won't self-heal.
+func (e httpStatusError) retryable() bool {
+	return e.code >= 500 ||
+		e.code == http.StatusRequestTimeout ||
+		e.code == http.StatusTooManyRequests
+}
+
+// maxConsecutivePollFailures bounds how many back-to-back transient
+// poll failures we ride out before giving up. The maxWait deadline is
+// the real ceiling; this just fails faster when the server is
+// unreachable for good instead of silently retrying the whole window.
+// ~10 failures at the 5s default poll interval ≈ under a minute of
+// solid errors before we bail.
+const maxConsecutivePollFailures = 10
 
 // normalizeSessionStatus folds the cloud's CLISessionStatus proto-enum wire
 // form ("CLI_SESSION_STATUS_APPROVED") down to the short lowercase token the

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -480,3 +481,137 @@ func setPollInterval(d time.Duration) { pollIntervalOverride = d }
 func loginPollIntervalForTest() time.Duration { return pollIntervalOverride }
 
 func restorePollInterval(d time.Duration) { pollIntervalOverride = d }
+
+// --- #455: pollSession transient-error resilience ---
+
+// statusServer stands up a programmable /status endpoint. handler is
+// invoked with the 1-based poll count so a test can vary the reply by
+// attempt (e.g. "fail 3 times, then approve"). Returns the server and a
+// pointer to the live poll counter.
+func statusServer(t *testing.T, sessionID string, handler func(n int32, w http.ResponseWriter)) (*httptest.Server, *int32) {
+	t.Helper()
+	var n int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/cli/sessions/"+sessionID+"/status", func(w http.ResponseWriter, r *http.Request) {
+		handler(atomic.AddInt32(&n, 1), w)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &n
+}
+
+// TestPollSession_RidesTransientErrors is the core #455 regression: a
+// 5xx on the first polls must NOT abort the login. Pre-fix, pollSession
+// returned on poll #1; now it rides through and succeeds once the
+// server recovers.
+func TestPollSession_RidesTransientErrors(t *testing.T) {
+	srv, _ := statusServer(t, "sess-1", func(n int32, w http.ResponseWriter) {
+		if n <= 3 {
+			http.Error(w, "upstream hiccup", http.StatusBadGateway)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(sessionStatusResp{Status: "approved", Token: "ctnr_ok"})
+	})
+	var out bytes.Buffer
+	st, err := pollSession(context.Background(), &out, srv.Client(), srv.URL, "sess-1", time.Millisecond, 5*time.Second)
+	if err != nil {
+		t.Fatalf("pollSession should ride out transient 5xx then approve, got err: %v", err)
+	}
+	if st.Token != "ctnr_ok" {
+		t.Fatalf("Token = %q, want ctnr_ok", st.Token)
+	}
+	if !strings.Contains(out.String(), "retrying") {
+		t.Errorf("expected a transient-retry notice in output, got:\n%s", out.String())
+	}
+}
+
+// TestPollSession_GivesUpAfterConsecutiveFailures: a server that's down
+// for good must fail fast at the consecutive cap, not silently retry
+// the entire maxWait window.
+func TestPollSession_GivesUpAfterConsecutiveFailures(t *testing.T) {
+	srv, n := statusServer(t, "sess-1", func(_ int32, w http.ResponseWriter) {
+		http.Error(w, "down", http.StatusServiceUnavailable)
+	})
+	_, err := pollSession(context.Background(), nil, srv.Client(), srv.URL, "sess-1", time.Millisecond, 30*time.Second)
+	if err == nil || !strings.Contains(err.Error(), "consecutive failures") {
+		t.Fatalf("want consecutive-failures error, got %v", err)
+	}
+	if got := atomic.LoadInt32(n); got != int32(maxConsecutivePollFailures) {
+		t.Errorf("polled %d times, want exactly %d (the cap)", got, maxConsecutivePollFailures)
+	}
+}
+
+// TestPollSession_SessionGoneIsTerminal: a 404 is terminal — stop at
+// once (surfaced as the expired message), never retry.
+func TestPollSession_SessionGoneIsTerminal(t *testing.T) {
+	srv, n := statusServer(t, "sess-1", func(_ int32, w http.ResponseWriter) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	_, err := pollSession(context.Background(), nil, srv.Client(), srv.URL, "sess-1", time.Millisecond, 5*time.Second)
+	if err == nil || !strings.Contains(err.Error(), "expired before approval") {
+		t.Fatalf("want terminal expired error, got %v", err)
+	}
+	if got := atomic.LoadInt32(n); got != 1 {
+		t.Errorf("polled %d times on a 404, want exactly 1 (no retry)", got)
+	}
+}
+
+// TestPollSession_TimeoutWrapsSentinel: a forever-pending session over
+// a tiny window returns errPollTimeout, so runLogin can distinguish a
+// timeout (→ #456 guidance) from other failures.
+func TestPollSession_TimeoutWrapsSentinel(t *testing.T) {
+	srv, _ := statusServer(t, "sess-1", func(_ int32, w http.ResponseWriter) {
+		_ = json.NewEncoder(w).Encode(sessionStatusResp{Status: "pending"})
+	})
+	_, err := pollSession(context.Background(), nil, srv.Client(), srv.URL, "sess-1", 5*time.Millisecond, 25*time.Millisecond)
+	if !errors.Is(err, errPollTimeout) {
+		t.Fatalf("want errPollTimeout, got %v", err)
+	}
+}
+
+// --- #456: actionable guidance on the timeout path ---
+
+// TestLogin_Timeout_PrintsCollisionGuidance: when approval never lands
+// (the device-name-collision symptom), runLogin must point the user at
+// the remedy — revoke the old token or pick a different --device-name —
+// instead of leaving a bare timeout.
+func TestLogin_Timeout_PrintsCollisionGuidance(t *testing.T) {
+	withTempHome(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/cli/sessions", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(createSessionResp{
+			SessionID:       "sess-1",
+			UserCode:        "WXYZ-1234",
+			VerificationURL: "http://example.invalid/cli/authorize?code=WXYZ-1234",
+			ExpiresIn:       600,
+		})
+	})
+	mux.HandleFunc("/v1/cli/sessions/sess-1/status", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(sessionStatusResp{Status: "pending"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	loginServer = srv.URL
+	loginNoBrowser = true
+	loginDeviceName = "cloud-mcp"
+
+	oldPoll, oldWait := pollIntervalOverride, maxWaitOverride
+	defer func() { pollIntervalOverride = oldPoll; maxWaitOverride = oldWait; loginDeviceName = "" }()
+	pollIntervalOverride = 5 * time.Millisecond
+	maxWaitOverride = 25 * time.Millisecond
+
+	var out bytes.Buffer
+	loginCmd.SetOut(&out)
+	loginCmd.SetErr(&out)
+	err := runLogin(loginCmd, nil)
+	if !errors.Is(err, errPollTimeout) {
+		t.Fatalf("want errPollTimeout from runLogin, got %v", err)
+	}
+	o := out.String()
+	for _, want := range []string{"already be in use", "cloud-mcp", "--device-name", "/settings/api-tokens"} {
+		if !strings.Contains(o, want) {
+			t.Errorf("timeout guidance missing %q:\n%s", want, o)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #455 and #456 — two robustness gaps in the `containarium login` device flow, both surfaced by a real login session that stranded on a transient blip and then on a name collision.

## #455 — transient poll errors no longer kill login

`pollSession` returned on the **first** error from `fetchSessionStatus` of any kind. A single transient DNS hiccup or brief `5xx` aborted the entire 10-minute login while the user was mid-approval:

```
(polls every 5s, max 10m0s)
Error: poll session status: Get ".../status": dial tcp: lookup <host>: no such host
```

Now errors are classified:

| Class | Examples | Behavior |
|---|---|---|
| **Terminal** | 404 (session gone), other 4xx (bad request/auth), `denied`/`expired`, cancelled ctx | stop immediately |
| **Transient** | network errors, `5xx`, `408`, `429` | keep polling to the deadline, with a per-retry notice |

A consecutive-failure cap (`maxConsecutivePollFailures = 10`) fails fast when the server is down for good rather than silently retrying the whole window. `fetchSessionStatus` now returns a typed `httpStatusError` + an `errSessionGone` sentinel, so the loop classifies by **code class**, not by string-matching the error text.

## #456 — actionable guidance on the timeout path

The approve step mints a token named after `--device-name`. If a token with that name already exists in the org, the server refuses the approve and the session just sits `pending` until it expires. The CLI is unauthenticated and only polls status, so it **can't see** that approve-side error — it previously just timed out with no explanation.

`pollSession` now wraps timeouts in an `errPollTimeout` sentinel, and `runLogin` prints the remedy on timeout:

```
Approval didn't complete in time.
If you've signed in as "cloud-mcp" before, that device name may already be in use —
revoke the old token at <server>/settings/api-tokens, or rerun with a different --device-name.
```

This is the honest CLI-side fix. The deeper options in #456 — auto-disambiguating the default name (rejected here: it accretes throwaway tokens against the free-tier cap) and server-side reuse/rotate or an explicit "approve failed" signal the CLI could surface — need server cooperation and are left to that issue.

## Tests

`internal/cmd/login_test.go`: transient-then-approve, give-up-after-cap, 404-is-terminal, timeout-wraps-sentinel, and runLogin-prints-collision-guidance. Adds a `maxWaitOverride` test hook mirroring the existing `pollIntervalOverride`. Full `internal/cmd` package + `go vet` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)