### PR TITLE
feat(proto): add ssh_host to Container — daemon-owned SSH reachability

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -5202,6 +5202,11 @@
           "type": "string",
           "format": "date-time",
           "description": "Wall-clock time at which the daemon's TTL sweeper will delete\nthis container. Unset = no TTL, container persists indefinitely.\nSet via SetContainerTTL. Consumed by internal/ttlsweeper which\nruns once a minute and force-deletes any container whose\nttl_expires_at has elapsed (with a small clock-skew grace\nmargin). Used by the containarium-run GitHub Action's\n\"keep on failure\" path to schedule auto-deletion of debug boxes."
+        },
+        "sshHost": {
+          "type": "string",
+          "description": "- direct mode  → the container's reachable IP (same value as\n    network.ip_address);\n  - sentinel-jump mode → the configured sentinel's public host,\n    e.g. \"region-a.example.com\".\n\nCombined with `username`, this is the connect target\n`username@ssh_host`. Empty means \"no explicit host — fall back to\nnetwork.ip_address\". Clients (the ssh_config generator, a future\n`connect` verb) should USE this verbatim rather than reconstructing\na host from the IP / sentinel config themselves.",
+          "title": "The host:port a client should SSH to in order to reach this\ncontainer, as computed by the daemon from its own routing config —\nso a client never has to infer the SSH target from other fields:"
         }
       },
       "title": "Container represents a complete container instance"

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -48,6 +48,7 @@ var (
 	alertWebhookURL    string
 	alertWebhookSecret string
 	sentinelURL        string
+	sshHost            string
 	peerAddrs          []string
 	localBackendID     string
 	pool               string
@@ -136,6 +137,7 @@ func init() {
 
 	// Multi-backend peer settings
 	daemonCmd.Flags().StringVar(&sentinelURL, "sentinel-url", "", "Sentinel URL for auto-discovering tunnel peers (e.g., http://10.128.0.5:8081)")
+	daemonCmd.Flags().StringVar(&sshHost, "ssh-host", "", "Public SSH host clients dial to reach containers (the sentinel's SSH endpoint, e.g. region-a.example.com). Surfaced on each Container.ssh_host so clients build the target username@ssh_host. Empty = direct mode: ssh_host is left empty and clients use the container IP.")
 	daemonCmd.Flags().StringSliceVar(&peerAddrs, "peers", nil, "Static peer daemon addresses (e.g., 10.128.0.5:18001)")
 	daemonCmd.Flags().StringVar(&localBackendID, "backend-id", "", "This daemon's backend ID (defaults to hostname)")
 	daemonCmd.Flags().StringVar(&pool, "pool", "", "Pool name to scope sentinel peer discovery (empty = unscoped, see all peers)")
@@ -479,6 +481,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		AlertWebhookURL:      alertWebhookURL,
 		AlertWebhookSecret:   alertWebhookSecret,
 		SentinelURL:          sentinelURL,
+		SSHHost:              sshHost,
 		Peers:                peerAddrs,
 		LocalBackendID:       resolveBackendID(localBackendID),
 		Pool:                 pool,

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -104,6 +104,15 @@ type ContainerServer struct {
 	guacamoleClient *guacamole.Client
 	guacamoleUser   string // Guacamole admin username
 	guacamolePass   string // Guacamole admin password
+
+	// sshHost is the public host clients dial to SSH into containers this
+	// daemon fronts — the sentinel's SSH endpoint (e.g. "region-a.example.com"),
+	// set by DualServer wiring from --ssh-host. Stamped onto Container.ssh_host
+	// in the read path (alongside Pool) so a client builds its connect target
+	// `username@ssh_host` without inferring the host from the IP / config.
+	// Empty (direct mode / no sentinel) leaves ssh_host empty and clients fall
+	// back to network.ip_address.
+	sshHost string
 }
 
 // NewContainerServer creates a new container server
@@ -407,6 +416,7 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	// Convert to protobuf
 	protoContainer := toProtoContainer(info)
 	protoContainer.Pool = s.resolvePool(protoContainer.BackendId)
+	protoContainer.SshHost = s.sshHost
 
 	// Emit container created event
 	s.emitter.EmitContainerCreated(protoContainer)
@@ -529,6 +539,7 @@ func (s *ContainerServer) ListContainers(ctx context.Context, req *pb.ListContai
 	for i := range filtered {
 		pc := toProtoContainer(&filtered[i])
 		pc.Pool = s.resolvePool(pc.BackendId)
+		pc.SshHost = s.sshHost
 		protoContainers = append(protoContainers, pc)
 	}
 
@@ -539,6 +550,7 @@ func (s *ContainerServer) ListContainers(ctx context.Context, req *pb.ListContai
 		for i := range peerContainers {
 			pc := toProtoContainer(&peerContainers[i])
 			pc.Pool = s.resolvePool(pc.BackendId)
+			pc.SshHost = s.sshHost
 			protoContainers = append(protoContainers, pc)
 		}
 	}
@@ -605,6 +617,7 @@ func (s *ContainerServer) GetContainer(ctx context.Context, req *pb.GetContainer
 				if pc.Name == containerName {
 					proto := toProtoContainer(&pc)
 					proto.Pool = s.resolvePool(proto.BackendId)
+					proto.SshHost = s.sshHost
 					return &pb.GetContainerResponse{
 						Container: proto,
 					}, nil
@@ -630,6 +643,7 @@ func (s *ContainerServer) GetContainer(ctx context.Context, req *pb.GetContainer
 
 	protoInfo := toProtoContainer(info)
 	protoInfo.Pool = s.resolvePool(protoInfo.BackendId)
+	protoInfo.SshHost = s.sshHost
 	return &pb.GetContainerResponse{
 		Container: protoInfo,
 		// TODO: Add metrics
@@ -2124,6 +2138,14 @@ func (s *ContainerServer) SetPeerPool(pool *PeerPool) {
 // report the local backend's uptime. Called once from DualServer setup.
 func (s *ContainerServer) SetStartTime(t time.Time) {
 	s.startTime = t
+}
+
+// SetSSHHost wires the public SSH host clients dial to reach this daemon's
+// containers (the sentinel's SSH endpoint, from --ssh-host). Stamped onto
+// Container.ssh_host in the read path. Empty leaves ssh_host empty so clients
+// fall back to the container IP. Called once from DualServer setup.
+func (s *ContainerServer) SetSSHHost(host string) {
+	s.sshHost = host
 }
 
 // SetOTelCollectorEndpoint wires the OTLP/HTTP URL of this daemon's

--- a/internal/server/container_server_ssh_host_test.go
+++ b/internal/server/container_server_ssh_host_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// newSSHHostTestServer wires a ContainerServer over a MockBackend seeded
+// with one running container, with the daemon's --ssh-host value set to
+// sshHost. Mirrors newTTLTestServer's shape.
+func newSSHHostTestServer(t *testing.T, sshHost string) *ContainerServer {
+	t.Helper()
+	mock := incustest.NewMockBackend()
+	mock.Containers["alice-container"] = &incus.ContainerInfo{
+		Name:      "alice-container",
+		State:     "Running",
+		IPAddress: "10.0.0.5",
+	}
+	return &ContainerServer{manager: container.NewWithBackend(mock), sshHost: sshHost}
+}
+
+// TestGetContainer_StampsSSHHost — sentinel-jump mode: a configured
+// --ssh-host is surfaced verbatim on Container.ssh_host so a client can
+// build the connect target username@ssh_host without inferring the host.
+func TestGetContainer_StampsSSHHost(t *testing.T) {
+	s := newSSHHostTestServer(t, "region-a.example.com")
+	resp, err := s.GetContainer(testCtx(), &pb.GetContainerRequest{Username: "alice"})
+	if err != nil {
+		t.Fatalf("GetContainer: %v", err)
+	}
+	if got := resp.GetContainer().GetSshHost(); got != "region-a.example.com" {
+		t.Fatalf("ssh_host = %q, want %q", got, "region-a.example.com")
+	}
+}
+
+// TestGetContainer_EmptySSHHostDirectMode — direct mode: with no
+// --ssh-host configured, ssh_host is left empty so clients fall back to
+// network.ip_address. This keeps the wire byte-for-byte identical to
+// pre-field behavior for direct/local deployments.
+func TestGetContainer_EmptySSHHostDirectMode(t *testing.T) {
+	s := newSSHHostTestServer(t, "")
+	resp, err := s.GetContainer(testCtx(), &pb.GetContainerRequest{Username: "alice"})
+	if err != nil {
+		t.Fatalf("GetContainer: %v", err)
+	}
+	if got := resp.GetContainer().GetSshHost(); got != "" {
+		t.Fatalf("ssh_host = %q, want empty (direct mode)", got)
+	}
+	// The fallback source the client uses must still be present.
+	if got := resp.GetContainer().GetNetwork().GetIpAddress(); got != "10.0.0.5" {
+		t.Fatalf("ip_address = %q, want 10.0.0.5 (direct-mode fallback)", got)
+	}
+}
+
+// TestSetSSHHost — the DualServer wiring setter stores the value the read
+// path stamps.
+func TestSetSSHHost(t *testing.T) {
+	s := &ContainerServer{}
+	s.SetSSHHost("sentinel.example.com")
+	if s.sshHost != "sentinel.example.com" {
+		t.Fatalf("sshHost = %q, want %q", s.sshHost, "sentinel.example.com")
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -107,6 +107,13 @@ type DualServerConfig struct {
 	PublicBaseDomains []string // suffix-match anchors advertised to the sentinel; <anything>.<one-of-these> routes here. List multiple to host workloads under different parent domains on the same backend (see docs/PER-POOL-BASE-DOMAIN.md)
 	PublicPort        int      // TLS port the sentinel forwards to (typically 443)
 
+	// SSHHost is the public host clients dial to SSH into this daemon's
+	// containers — the sentinel's SSH endpoint (e.g. region-a.example.com),
+	// from --ssh-host. Surfaced on each Container.ssh_host so clients build
+	// the connect target username@ssh_host without inferring it. Empty =
+	// direct mode: ssh_host is left empty and clients use the container IP.
+	SSHHost string
+
 	// Alerting settings
 	AlertWebhookURL    string // Webhook URL for alert notifications (optional)
 	AlertWebhookSecret string // HMAC-SHA256 signing secret for webhook payloads (optional)
@@ -1488,6 +1495,13 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		Port:              ds.config.PublicPort,
 		BackendID:         ds.config.LocalBackendID,
 	})
+
+	// Surface the SSH host on every Container.ssh_host. Independent of peer
+	// discovery (a single-backend daemon still fronts a sentinel), so wire
+	// it unconditionally; empty --ssh-host leaves ssh_host empty.
+	if ds.containerServer != nil {
+		ds.containerServer.SetSSHHost(ds.config.SSHHost)
+	}
 
 	// Start peer discovery for multi-backend support
 	if ds.peerPool != nil {

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -413,7 +413,22 @@ type Container struct {
 	// ttl_expires_at has elapsed (with a small clock-skew grace
 	// margin). Used by the containarium-run GitHub Action's
 	// "keep on failure" path to schedule auto-deletion of debug boxes.
-	TtlExpiresAt  *timestamppb.Timestamp `protobuf:"bytes,22,opt,name=ttl_expires_at,json=ttlExpiresAt,proto3" json:"ttl_expires_at,omitempty"`
+	TtlExpiresAt *timestamppb.Timestamp `protobuf:"bytes,22,opt,name=ttl_expires_at,json=ttlExpiresAt,proto3" json:"ttl_expires_at,omitempty"`
+	// The host:port a client should SSH to in order to reach this
+	// container, as computed by the daemon from its own routing config —
+	// so a client never has to infer the SSH target from other fields:
+	//
+	//   - direct mode  → the container's reachable IP (same value as
+	//     network.ip_address);
+	//   - sentinel-jump mode → the configured sentinel's public host,
+	//     e.g. "region-a.example.com".
+	//
+	// Combined with `username`, this is the connect target
+	// `username@ssh_host`. Empty means "no explicit host — fall back to
+	// network.ip_address". Clients (the ssh_config generator, a future
+	// `connect` verb) should USE this verbatim rather than reconstructing
+	// a host from the IP / sentinel config themselves.
+	SshHost       string `protobuf:"bytes,23,opt,name=ssh_host,json=sshHost,proto3" json:"ssh_host,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -600,6 +615,13 @@ func (x *Container) GetTtlExpiresAt() *timestamppb.Timestamp {
 		return x.TtlExpiresAt
 	}
 	return nil
+}
+
+func (x *Container) GetSshHost() string {
+	if x != nil {
+		return x.SshHost
+	}
+	return ""
 }
 
 // ContainerMetrics contains runtime metrics for a container
@@ -3982,7 +4004,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\vmac_address\x18\x02 \x01(\tR\n" +
 	"macAddress\x12\x1c\n" +
 	"\tinterface\x18\x03 \x01(\tR\tinterface\x12\x16\n" +
-	"\x06bridge\x18\x04 \x01(\tR\x06bridge\"\xc8\a\n" +
+	"\x06bridge\x18\x04 \x01(\tR\x06bridge\"\xe3\a\n" +
 	"\tContainer\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x125\n" +
@@ -4012,7 +4034,8 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x04pool\x18\x13 \x01(\tR\x04pool\x12,\n" +
 	"\x12auto_sleep_enabled\x18\x14 \x01(\bR\x10autoSleepEnabled\x124\n" +
 	"\x16idle_threshold_minutes\x18\x15 \x01(\x05R\x14idleThresholdMinutes\x12@\n" +
-	"\x0ettl_expires_at\x18\x16 \x01(\v2\x1a.google.protobuf.TimestampR\fttlExpiresAt\x1a9\n" +
+	"\x0ettl_expires_at\x18\x16 \x01(\v2\x1a.google.protobuf.TimestampR\fttlExpiresAt\x12\x19\n" +
+	"\bssh_host\x18\x17 \x01(\tR\asshHost\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xcf\x02\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -179,6 +179,22 @@ message Container {
   // margin). Used by the containarium-run GitHub Action's
   // "keep on failure" path to schedule auto-deletion of debug boxes.
   google.protobuf.Timestamp ttl_expires_at = 22;
+
+  // The host:port a client should SSH to in order to reach this
+  // container, as computed by the daemon from its own routing config —
+  // so a client never has to infer the SSH target from other fields:
+  //
+  //   - direct mode  → the container's reachable IP (same value as
+  //     network.ip_address);
+  //   - sentinel-jump mode → the configured sentinel's public host,
+  //     e.g. "region-a.example.com".
+  //
+  // Combined with `username`, this is the connect target
+  // `username@ssh_host`. Empty means "no explicit host — fall back to
+  // network.ip_address". Clients (the ssh_config generator, a future
+  // `connect` verb) should USE this verbatim rather than reconstructing
+  // a host from the IP / sentinel config themselves.
+  string ssh_host = 23;
 }
 
 // ContainerMetrics contains runtime metrics for a container


### PR DESCRIPTION
Closes #452.

## Summary

Adds `string ssh_host = 23` to the `Container` message: the host:port a client dials to reach a container, **computed by the daemon from its own routing config** — so clients (the ssh_config generator, a future `connect` verb) never infer the SSH target themselves.

Combined with `username`, it's the connect target `username@ssh_host`. Empty means "no explicit host — fall back to `network.ip_address`", so direct/local deployments are byte-for-byte unchanged.

## Why

Today a client reconstructs the SSH target: read `network.ip_address` for the direct case, or already know the configured sentinel jump. That duplicates routing knowledge the daemon already has and drifts across clients. A daemon-owned field makes reachability a single source of truth.

## Changes

- **proto**: `ssh_host` field (+ regenerated `container.pb.go`, swagger).
- **`--ssh-host` daemon flag** → `DualServerConfig.SSHHost` → `ContainerServer.SetSSHHost`, wired **unconditionally** before peer discovery so a single-backend daemon surfaces it too.
- **stamped at the five read-path sites that already stamp `Pool`** (Create / List local+peer / Get local+peer). The other `toProtoContainer` callers are event/lifecycle responses that carry neither `Pool` nor `ssh_host` — consistent with existing behavior.

## Population semantics

| Mode | `ssh_host` |
|------|-----------|
| direct / no `--ssh-host` | empty → client falls back to `network.ip_address` |
| sentinel-jump (`--ssh-host` set) | the configured sentinel host, verbatim |

Generic reachability info — the field carries no default; whatever an operator configures is their value.

## Tests

`internal/server/container_server_ssh_host_test.go` — read-path stamps `ssh_host` in sentinel-jump mode; leaves it empty (with IP fallback present) in direct mode; setter stores the value. `go build` + `go vet` + `go test ./internal/server/` all green.

## Follow-on

#453 (`containarium connect <container>`) consumes this field, preferring `ssh_host` and falling back to the IP when empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)