### PR TITLE
feat(cloud): container reconcile — actuate cloud assignments, stamp tenant label (#354)

### DIFF
--- a/docs/CLOUD-ACTUATION-SMOKE.md
+++ b/docs/CLOUD-ACTUATION-SMOKE.md
@@ -91,13 +91,23 @@ until daemon restart.)
 ## Step 6 — observe enforcement
 
 The enforcer matches a container to its tenant by the
-`user.containarium.tenant` label. The cloud **container reconcile** that stamps
-this label on cloud-assigned containers is a separate follow-up, so for the smoke
-**label a test container manually** to exercise the loop:
+`user.containarium.tenant` label. The cloud **container reconcile** stamps this
+label automatically: a container the cloud assigns to this host (desired_state
+`running`) is created locally as `cld-<short-uuid>` with
+`user.containarium.tenant=<org-id>` set, then started. So the clean path is to
+create a container for the org **in the cloud dashboard** and watch it appear:
+
+```sh
+incus list                                   # a cld-<short-uuid> instance appears, owned by <org-id>
+incus config get cld-<short-uuid> user.containarium.tenant   # == <org-id>
+```
+
+To exercise just the policy/enforcer path **without** a cloud assignment, you can
+still hand-label a local container (what the reconcile does for you):
 
 ```sh
 incus launch images:ubuntu/24.04 smoke-box
-incus config set smoke-box user.containarium.tenant <org-id>   # what the reconcile will do automatically later
+incus config set smoke-box user.containarium.tenant <org-id>
 ```
 
 Within one enforcer reconcile (≤ a few seconds) the policy applies. From inside
@@ -134,12 +144,12 @@ containarium cloud logout            # removes ~/.containarium/cloud.yaml
 # cloud sysadmin: tombstone the host (DeleteHost)
 ```
 
-## Known gaps exercised-around here
+## Known gaps
 
-- **Container reconcile** (create/start/stop/delete + auto-stamp the tenant
-  label) isn't built yet — hence the manual `incus config set …tenant` in Step 6.
-  Once it lands, cloud-assigned `cld-<uuid>` containers carry the label and Step 6
-  needs no manual labelling.
 - **Policy sync is upsert-only** — a policy *removed* on the cloud is not yet
   cleared on the host (distinguishing cloud- from CLI-authored policies needs a
   source marker). Re-authoring with an empty allow-list is the current workaround.
+- **Container reconcile is minimal** — create/start/stop/delete + the tenant
+  label, but not the richer create options the user-facing ContainerService
+  offers (routes, secrets, GPU/disk devices beyond memory). Cloud-assigned boxes
+  are v1 minimal workloads.

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -38,15 +39,48 @@ type PolicySink interface {
 	SyncNetworkPolicies(ctx context.Context, policies []*cloudv1.NetworkPolicy) error
 }
 
+// ContainerSpec is the host-local shape of one cloud assignment the actuator
+// acts on. LocalName is the Incus instance name (cld-<short-uuid>); OrgID is
+// stamped as the container's user.containarium.tenant label so the network-policy
+// enforcer identifies it.
+type ContainerSpec struct {
+	LocalName string
+	OrgID     string
+	Image     string
+	RAMMB     int32
+	DiskGB    int32
+	GPUCount  int32
+}
+
+// ContainerActuator drives local Incus state toward an assignment's
+// desired_state. The daemon implements it (create/start/stop/delete + stamp the
+// tenant label); the interface keeps internal/cloud free of an Incus dependency
+// and lets the reconcile decision be unit-tested with a fake. Each method is
+// idempotent — the reconciler may call it for an already-converged container.
+type ContainerActuator interface {
+	EnsureRunning(ctx context.Context, spec ContainerSpec) error
+	EnsureStopped(ctx context.Context, localName string) error
+	EnsureDeleted(ctx context.Context, localName string) error
+}
+
+// Deps are the daemon-provided collaborators. Both are optional: nil Policies
+// skips network-policy sync, nil Containers skips container reconcile. With both
+// nil the client is heartbeat-only.
+type Deps struct {
+	Policies   PolicySink
+	Containers ContainerActuator
+}
+
 // Client is the host-side cloud-actuation client. Slice 3 implements the
 // heartbeat; WatchAssignments + the reconciler land in slice 4. The actuation
 // proto is vendored (proto/containarium/cloud/v1), so this builds in the default
 // OSS binary with no private dependency; it is inert unless the host is enrolled
 // (~/.containarium/cloud.yaml present).
 type Client struct {
-	cfg      *Config
-	interval time.Duration
-	sink     PolicySink // optional; nil = heartbeat only (no policy reconcile)
+	cfg        *Config
+	interval   time.Duration
+	sink       PolicySink        // optional; nil = no policy reconcile
+	containers ContainerActuator // optional; nil = no container reconcile
 
 	conn *grpc.ClientConn
 	ac   cloudv1.ActuationServiceClient
@@ -59,13 +93,13 @@ type Client struct {
 	failures int // consecutive heartbeat failures, for observability
 }
 
-// New builds a client from a validated config. sink may be nil (heartbeat only);
-// pass a PolicySink to converge per-org network policies from WatchAssignments.
-func New(cfg *Config, sink PolicySink) (*Client, error) {
+// New builds a client from a validated config. deps are optional collaborators
+// (see Deps) — both nil makes the client heartbeat-only.
+func New(cfg *Config, deps Deps) (*Client, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
-	return &Client{cfg: cfg, interval: defaultHeartbeatInterval, sink: sink}, nil
+	return &Client{cfg: cfg, interval: defaultHeartbeatInterval, sink: deps.Policies, containers: deps.Containers}, nil
 }
 
 // Start dials the control plane and launches the heartbeat loop. A dial error is
@@ -82,12 +116,13 @@ func (c *Client) Start(ctx context.Context) error {
 
 	c.wg.Add(1)
 	go c.heartbeatLoop()
-	if c.sink != nil {
+	watch := c.sink != nil || c.containers != nil
+	if watch {
 		c.wg.Add(1)
 		go c.watchLoop()
 	}
 	log.Printf("[cloud] actuation client started: host=%s control-plane=%s (heartbeat %s, watch=%v)",
-		c.cfg.HostID, c.cfg.ControlPlane, c.interval, c.sink != nil)
+		c.cfg.HostID, c.cfg.ControlPlane, c.interval, watch)
 	return nil
 }
 
@@ -213,15 +248,76 @@ func (c *Client) watchOnce() error {
 	}
 }
 
-// reconcile applies one batch. Slice 4 converges per-org network policies into
-// the sink (closing the #315 cloud-extension loop: cloud-authored egress policy
-// → host enforcer). Container desired-state reconciliation (create/start/stop/
-// delete) is a separate follow-up.
+// reconcile applies one batch: (1) converge per-org network policies into the
+// sink (the #315 cloud-extension loop), then (2) reconcile each assignment's
+// container toward its desired_state.
 func (c *Client) reconcile(batch *cloudv1.AssignmentBatch) {
-	if c.sink == nil {
-		return
+	if c.sink != nil {
+		if err := c.sink.SyncNetworkPolicies(c.ctx, batch.GetNetworkPolicies()); err != nil {
+			log.Printf("[cloud] sync network policies: %v", err)
+		}
 	}
-	if err := c.sink.SyncNetworkPolicies(c.ctx, batch.GetNetworkPolicies()); err != nil {
-		log.Printf("[cloud] sync network policies: %v", err)
+	if c.containers != nil {
+		for _, a := range batch.GetAssignments() {
+			c.reconcileAssignment(a)
+		}
 	}
+}
+
+// reconcileAssignment drives one container toward its desired_state and reports
+// the observed state back. The reconcile is idempotent (the actuator no-ops a
+// converged container), so re-sent snapshots are safe.
+func (c *Client) reconcileAssignment(a *cloudv1.Assignment) {
+	name := localContainerName(a.GetContainerId())
+	switch a.GetDesiredState() {
+	case "running":
+		if err := c.containers.EnsureRunning(c.ctx, ContainerSpec{
+			LocalName: name, OrgID: a.GetOrgId(), Image: a.GetImage(),
+			RAMMB: a.GetRamMb(), DiskGB: a.GetDiskGb(), GPUCount: a.GetGpuCount(),
+		}); err != nil {
+			log.Printf("[cloud] ensure running %s: %v", name, err)
+			return // leave the cloud's observed state stale; next snapshot retries
+		}
+		c.report(a.GetContainerId(), "active")
+	case "stopped":
+		if err := c.containers.EnsureStopped(c.ctx, name); err != nil {
+			log.Printf("[cloud] ensure stopped %s: %v", name, err)
+			return
+		}
+		c.report(a.GetContainerId(), "stopped")
+	case "deleted":
+		if err := c.containers.EnsureDeleted(c.ctx, name); err != nil {
+			log.Printf("[cloud] ensure deleted %s: %v", name, err)
+		}
+		// No state report — the cloud releases the assignment once the host
+		// stops reporting it (there is no "deleted" observed-state value).
+	default:
+		// Unknown / empty desired_state — leave it alone (informational only).
+	}
+}
+
+// report sends observed container state back to the cloud (best-effort).
+func (c *Client) report(containerID, state string) {
+	ctx, cancel := context.WithTimeout(c.authContext(c.ctx), 10*time.Second)
+	defer cancel()
+	if _, err := c.ac.ReportContainerState(ctx, &cloudv1.ReportContainerStateRequest{
+		ContainerId: containerID, State: state,
+	}); err != nil {
+		log.Printf("[cloud] report state %s=%s: %v", containerID, state, err)
+	}
+}
+
+// localContainerName maps a cloud container UUID to the host-local Incus name.
+// The cld- prefix keeps cloud-assigned containers from colliding with
+// operator-managed <tenant>-container names. Best-effort short form; the cloud
+// container_id is the durable key carried in ReportContainerState.
+func localContainerName(containerID string) string {
+	short := strings.ReplaceAll(containerID, "-", "")
+	if len(short) > 12 {
+		short = short[:12]
+	}
+	if short == "" {
+		short = "unknown"
+	}
+	return "cld-" + short
 }

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -17,9 +17,11 @@ import (
 // fakeActuation records the host-bearer metadata it saw on Heartbeat.
 type fakeActuation struct {
 	cloudv1.UnimplementedActuationServiceServer
-	mu     sync.Mutex
-	bearer string
-	beats  int
+	mu            sync.Mutex
+	bearer        string
+	beats         int
+	reportedID    string
+	reportedState string
 }
 
 func (f *fakeActuation) Heartbeat(ctx context.Context, _ *cloudv1.HeartbeatRequest) (*cloudv1.HeartbeatResponse, error) {
@@ -42,6 +44,42 @@ func (f *fakeActuation) WatchAssignments(_ *cloudv1.WatchAssignmentsRequest, str
 			{OrgId: "org-1", EgressCidrs: []string{"8.8.8.8/32"}, Mode: cloudv1.NetworkPolicyMode_NETWORK_POLICY_MODE_ENFORCE},
 		},
 	})
+}
+
+// ReportContainerState records what the client reported.
+func (f *fakeActuation) ReportContainerState(ctx context.Context, req *cloudv1.ReportContainerStateRequest) (*cloudv1.ReportContainerStateResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reportedID = req.GetContainerId()
+	f.reportedState = req.GetState()
+	return &cloudv1.ReportContainerStateResponse{}, nil
+}
+
+// fakeActuator records the container actions the reconciler drove.
+type fakeActuator struct {
+	mu      sync.Mutex
+	running []ContainerSpec
+	stopped []string
+	deleted []string
+}
+
+func (a *fakeActuator) EnsureRunning(_ context.Context, s ContainerSpec) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.running = append(a.running, s)
+	return nil
+}
+func (a *fakeActuator) EnsureStopped(_ context.Context, name string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stopped = append(a.stopped, name)
+	return nil
+}
+func (a *fakeActuator) EnsureDeleted(_ context.Context, name string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.deleted = append(a.deleted, name)
+	return nil
 }
 
 // recordingSink captures the policies handed to it.
@@ -102,7 +140,7 @@ func TestHeartbeatSendsHostBearer(t *testing.T) {
 }
 
 func TestNewRejectsIncompleteConfig(t *testing.T) {
-	if _, err := New(&Config{HostID: "h", Token: "t"}, nil); err == nil {
+	if _, err := New(&Config{HostID: "h", Token: "t"}, Deps{}); err == nil {
 		t.Error("New must reject a config missing control_plane")
 	}
 }
@@ -129,8 +167,76 @@ func TestWatchOnceSyncsNetworkPolicies(t *testing.T) {
 	}
 }
 
-func TestReconcileNilSinkIsNoop(t *testing.T) {
-	c := &Client{} // no sink
+func TestReconcileNilDepsIsNoop(t *testing.T) {
+	c := &Client{} // no sink, no actuator
 	c.ctx = context.Background()
-	c.reconcile(&cloudv1.AssignmentBatch{NetworkPolicies: []*cloudv1.NetworkPolicy{{OrgId: "x"}}}) // must not panic
+	c.reconcile(&cloudv1.AssignmentBatch{
+		NetworkPolicies: []*cloudv1.NetworkPolicy{{OrgId: "x"}},
+		Assignments:     []*cloudv1.Assignment{{ContainerId: "c", DesiredState: "running"}},
+	}) // must not panic
+}
+
+func TestReconcileAssignment_RunningCreatesAndReports(t *testing.T) {
+	cfg := &Config{ControlPlane: "bufconn", HostID: "h", Token: "h.b"}
+	c, fake := newTestClient(t, cfg)
+	act := &fakeActuator{}
+	c.containers = act
+
+	c.reconcileAssignment(&cloudv1.Assignment{
+		ContainerId:  "11111111-2222-3333-4444-555555555555",
+		OrgId:        "org-9",
+		DesiredState: "running",
+		Image:        "ubuntu:24.04",
+		RamMb:        512,
+	})
+
+	act.mu.Lock()
+	defer act.mu.Unlock()
+	if len(act.running) != 1 {
+		t.Fatalf("expected 1 EnsureRunning, got %d", len(act.running))
+	}
+	got := act.running[0]
+	if got.OrgID != "org-9" || got.Image != "ubuntu:24.04" || got.RAMMB != 512 {
+		t.Errorf("spec not propagated: %+v", got)
+	}
+	if got.LocalName != "cld-111111112222" {
+		t.Errorf("local name = %q, want cld-111111112222", got.LocalName)
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.reportedState != "active" || fake.reportedID != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("report = (%q,%q), want (container-id, active)", fake.reportedID, fake.reportedState)
+	}
+}
+
+func TestReconcileAssignment_DesiredStates(t *testing.T) {
+	cfg := &Config{ControlPlane: "bufconn", HostID: "h", Token: "h.b"}
+	c, _ := newTestClient(t, cfg)
+	act := &fakeActuator{}
+	c.containers = act
+
+	c.reconcileAssignment(&cloudv1.Assignment{ContainerId: "aaaa", DesiredState: "stopped"})
+	c.reconcileAssignment(&cloudv1.Assignment{ContainerId: "bbbb", DesiredState: "deleted"})
+
+	act.mu.Lock()
+	defer act.mu.Unlock()
+	if len(act.stopped) != 1 || act.stopped[0] != "cld-aaaa" {
+		t.Errorf("stopped = %v, want [cld-aaaa]", act.stopped)
+	}
+	if len(act.deleted) != 1 || act.deleted[0] != "cld-bbbb" {
+		t.Errorf("deleted = %v, want [cld-bbbb]", act.deleted)
+	}
+}
+
+func TestLocalContainerName(t *testing.T) {
+	cases := map[string]string{
+		"11111111-2222-3333-4444-555555555555": "cld-111111112222",
+		"short":                                "cld-short",
+		"":                                     "cld-unknown",
+	}
+	for in, want := range cases {
+		if got := localContainerName(in); got != want {
+			t.Errorf("localContainerName(%q) = %q, want %q", in, got, want)
+		}
+	}
 }

--- a/internal/server/cloud_container_actuator.go
+++ b/internal/server/cloud_container_actuator.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/footprintai/containarium/internal/cloud"
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// cloudContainerActuator implements cloud.ContainerActuator by driving the local
+// Incus instance state for cloud-assigned containers (#354). Create stamps
+// user.containarium.tenant=<org_id> so the #315 network-policy enforcer can match
+// the container to its org's egress policy (cloud names are cld-<uuid>, not
+// <tenant>-container, so the label — not the name — carries the tenant).
+//
+// Scope: create / start / stop / delete to converge to desired_state. It does
+// NOT manage routes, secrets, or the richer create options the user-facing
+// ContainerService offers — cloud-assigned boxes are minimal v1 workloads.
+type cloudContainerActuator struct {
+	incus *incus.Client
+}
+
+// newCloudContainerActuator builds an actuator with its own Incus client.
+// Returns an error (→ caller runs policy-sync-only) if Incus is unavailable,
+// e.g. on a non-Linux dev box.
+func newCloudContainerActuator() (*cloudContainerActuator, error) {
+	c, err := incus.New()
+	if err != nil {
+		return nil, fmt.Errorf("incus client: %w", err)
+	}
+	return &cloudContainerActuator{incus: c}, nil
+}
+
+// EnsureRunning creates the container (stamping the tenant label) if absent, then
+// ensures it is started. Idempotent.
+func (a *cloudContainerActuator) EnsureRunning(_ context.Context, spec cloud.ContainerSpec) error {
+	info, err := a.incus.GetContainer(spec.LocalName)
+	if err != nil {
+		// Treat any lookup failure as "not present" and try to create — a real
+		// create error surfaces below; a benign not-found proceeds to create.
+		if cerr := a.create(spec); cerr != nil {
+			return cerr
+		}
+	} else if isRunning(info.State) {
+		return nil // already converged
+	}
+	if err := a.incus.StartContainer(spec.LocalName); err != nil {
+		return fmt.Errorf("start %s: %w", spec.LocalName, err)
+	}
+	return nil
+}
+
+// EnsureStopped stops the container if it exists and is running. Idempotent.
+func (a *cloudContainerActuator) EnsureStopped(_ context.Context, localName string) error {
+	info, err := a.incus.GetContainer(localName)
+	if err != nil {
+		return nil // absent → nothing to stop
+	}
+	if !isRunning(info.State) {
+		return nil
+	}
+	if err := a.incus.StopContainer(localName, false); err != nil {
+		return fmt.Errorf("stop %s: %w", localName, err)
+	}
+	return nil
+}
+
+// EnsureDeleted deletes the container if it exists. Idempotent.
+func (a *cloudContainerActuator) EnsureDeleted(_ context.Context, localName string) error {
+	if _, err := a.incus.GetContainer(localName); err != nil {
+		return nil // already gone
+	}
+	if err := a.incus.DeleteContainer(localName); err != nil {
+		return fmt.Errorf("delete %s: %w", localName, err)
+	}
+	return nil
+}
+
+// create makes the instance (stopped) and stamps the tenant label before start.
+func (a *cloudContainerActuator) create(spec cloud.ContainerSpec) error {
+	cfg := incus.ContainerConfig{
+		Name:  spec.LocalName,
+		Image: spec.Image,
+	}
+	if spec.RAMMB > 0 {
+		cfg.Memory = fmt.Sprintf("%dMB", spec.RAMMB)
+	}
+	if err := a.incus.CreateContainer(cfg); err != nil {
+		return fmt.Errorf("create %s: %w", spec.LocalName, err)
+	}
+	// Stamp the owning org as the tenant label so the network-policy enforcer
+	// identifies this cloud container (it isn't named <tenant>-container).
+	if spec.OrgID != "" {
+		if err := a.incus.SetConfig(spec.LocalName, incus.TenantLabelKey, spec.OrgID); err != nil {
+			return fmt.Errorf("stamp tenant label on %s: %w", spec.LocalName, err)
+		}
+	}
+	return nil
+}
+
+// isRunning matches Incus's running state case-insensitively.
+func isRunning(state string) bool { return strings.EqualFold(state, "running") }

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -322,7 +322,13 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	if cloudCfg, cerr := cloud.Load(cloudCfgPath); cerr != nil {
 		log.Printf("Warning: failed to read cloud-actuation config %s: %v (running single-tenant)", cloudCfgPath, cerr)
 	} else if cloudCfg != nil {
-		if cc, nerr := cloud.New(cloudCfg, newCloudPolicySink(npServer)); nerr != nil {
+		cloudDeps := cloud.Deps{Policies: newCloudPolicySink(npServer)}
+		if cloudActuator, actErr := newCloudContainerActuator(); actErr != nil {
+			log.Printf("Warning: cloud container actuator unavailable (%v); policy sync only", actErr)
+		} else {
+			cloudDeps.Containers = cloudActuator // only set when non-nil (avoid nil-iface trap)
+		}
+		if cc, nerr := cloud.New(cloudCfg, cloudDeps); nerr != nil {
 			log.Printf("Warning: cloud-actuation config invalid: %v (running single-tenant)", nerr)
 		} else {
 			cloudClient = cc


### PR DESCRIPTION
The container-actuation slice. The `WatchAssignments` reconciler now drives local Incus state toward each assignment's `desired_state` and reports observed state back. Builds on slice 4 (#451).

## Why it matters for #315

It stamps `user.containarium.tenant=<org_id>` on create — so a cloud-assigned container (named `cld-<uuid>`, not `<tenant>-container`) is matched by the network-policy enforcer. **This makes the cloud egress loop work for real cloud containers** (previously the smoke runbook needed a manual `incus config set …tenant`).

## What

- **`internal/cloud`** — `ContainerActuator` interface + `ContainerSpec` + `Deps{Policies, Containers}`. `reconcileAssignment` maps `desired_state` running/stopped/deleted → `EnsureRunning`/`Stopped`/`Deleted` (idempotent), and reports `active`/`stopped` via `ReportContainerState` (delete reports nothing — the assignment is released). `localContainerName = cld-<short-uuid>`. `New(cfg, Deps)` replaces `New(cfg, sink)`.
- **`internal/server/cloud_container_actuator.go`** — Incus-driven actuator: create (with `SetConfig` tenant label) / start / stop / delete, all idempotent. Own Incus client; if Incus is unavailable (non-Linux dev) the daemon falls back to policy-sync-only (nil-interface-safe wiring).
- **`docs/CLOUD-ACTUATION-SMOKE.md`** — updated: cloud-assigned containers now auto-carry the label.
- **Tests** — reconcile decision per `desired_state`, spec propagation, `localName`, `ReportContainerState` fired with the right state. The actuator's Incus calls are Linux-bound (validated via the smoke runbook).

`go build ./...`, `go test ./...` (cloud+server), `go vet`, `gofmt`, `go mod tidy` (no-op) all clean.

## Scope

Minimal create options (memory + image + tenant label) — not the user-facing ContainerService's routes/secrets/GPU/disk. Cloud-assigned boxes are v1 minimal workloads; richer options are a follow-up. Policy sync stays upsert-only (noted).

## #354 status

Slices 1/3/4/5 + container reconcile now landed. The cloud→host loop — author policy, assign a container, host creates+labels it, enforcer applies the org's egress policy — is complete in code. The remaining live validation is the slice-5 smoke (needs a sysadmin-issued host token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)