### PR TITLE
feat(netpolicy): cloud policy-sync convergence + fix dropped allow_metadata (#354/#315)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -9028,6 +9028,10 @@
         "allowMetadata": {
           "type": "boolean",
           "description": "Allow reaching the cloud metadata service (169.254.169.254). Default false:\nthe metadata IP is denied even if egress_cidrs/egress_domains would\notherwise cover it (deny-beats-allow for this one sensitive IP, since it\nhands out cloud credentials). Set true only for a tenant that legitimately\nneeds instance metadata. #315 Phase D."
+        },
+        "source": {
+          "type": "string",
+          "description": "Source identifies who authored this policy: \"\" / \"cli\" for an operator via\n`containarium network-policy set`, \"cloud\" for one synced from a cloud\ncontrol plane (#354). The cloud-actuation reconciler converges only its own\n(\"cloud\") policies — so removing a policy cloud-side clears it on the host\nwithout clobbering an operator's CLI-authored policy. Informational on\nget/list."
         }
       },
       "description": "NetworkPolicy is a tenant's network-isolation policy, enforced at each of the\ntenant's container host-veth TC_INGRESS hooks (the sender side of every flow;\nsee the Phase 0 findings in NETWORK-ISOLATION-DESIGN.md). #315."

--- a/internal/cmd/network_policy.go
+++ b/internal/cmd/network_policy.go
@@ -102,6 +102,7 @@ type netPolicyJSON struct {
 	EgressDomains    []string `json:"egressDomains"`
 	AllowMetadata    bool     `json:"allowMetadata"`
 	Mode             string   `json:"mode"`
+	Source           string   `json:"source"`
 }
 
 type setNetworkPolicyRequest struct {
@@ -229,6 +230,9 @@ func printPolicy(w io.Writer, p netPolicyJSON) {
 	fmt.Fprintf(w, "  mode:               %s\n", shortMode(p.Mode))
 	fmt.Fprintf(w, "  allow-intra-tenant: %v\n", p.AllowIntraTenant)
 	fmt.Fprintf(w, "  allow-metadata:     %v\n", p.AllowMetadata)
+	if p.Source != "" {
+		fmt.Fprintf(w, "  source:             %s\n", p.Source)
+	}
 	if len(p.EgressCidrs) > 0 {
 		fmt.Fprintf(w, "  egress-cidrs:       %s\n", strings.Join(p.EgressCidrs, ", "))
 	}

--- a/internal/server/cloud_policy_sink.go
+++ b/internal/server/cloud_policy_sink.go
@@ -19,26 +19,32 @@ type cloudPolicySink struct {
 	np *NetworkPolicyServer
 }
 
+// cloudPolicySource marks a stored policy as cloud-authored, so convergence
+// only ever deletes the cloud's own policies — never an operator's CLI-authored
+// one (which carries an empty source). Matches pb.NetworkPolicy.Source.
+const cloudPolicySource = "cloud"
+
 func newCloudPolicySink(np *NetworkPolicyServer) *cloudPolicySink {
 	return &cloudPolicySink{np: np}
 }
 
-// SyncNetworkPolicies upserts each org's policy into the store. The org_id is the
-// tenant key — cloud containers are labelled user.containarium.tenant=<org_id>
-// (container reconcile, a follow-up), so the enforcer matches them. Upsert-only:
-// a policy removed cloud-side is not deleted locally yet (distinguishing
-// cloud-authored from CLI-authored policies needs a source marker — a follow-up);
-// upsert keeps the common rollout path correct without risking clobbering a
-// self-hosted operator's CLI-authored policy.
+// SyncNetworkPolicies converges the store to the cloud's current set: upsert
+// each org's policy (tagged source="cloud"; org_id is the tenant key, matching
+// the user.containarium.tenant label the container reconcile stamps), then
+// delete any previously cloud-authored policy no longer in the batch. Policies
+// authored locally via the CLI (empty source) are never touched — so a mixed
+// host (cloud + operator policies) stays correct.
 func (s *cloudPolicySink) SyncNetworkPolicies(ctx context.Context, policies []*cloudv1.NetworkPolicy) error {
 	store := s.np.Store()
 	if store == nil {
 		return nil
 	}
+	desired := make(map[string]bool, len(policies))
 	for _, np := range policies {
 		if np.GetOrgId() == "" {
 			continue
 		}
+		desired[np.GetOrgId()] = true
 		if err := store.Set(ctx, &pb.NetworkPolicy{
 			Tenant:           np.GetOrgId(),
 			AllowIntraTenant: np.GetAllowIntraTenant(),
@@ -46,8 +52,22 @@ func (s *cloudPolicySink) SyncNetworkPolicies(ctx context.Context, policies []*c
 			EgressDomains:    np.GetEgressDomains(),
 			AllowMetadata:    np.GetAllowMetadata(),
 			Mode:             pb.NetworkPolicyMode(int32(np.GetMode())), // same enum values (vendored from one source)
+			Source:           cloudPolicySource,
 		}); err != nil {
 			return err
+		}
+	}
+
+	// Convergence: drop cloud-authored policies the cloud no longer sends.
+	existing, err := store.List(ctx)
+	if err != nil {
+		return err
+	}
+	for _, p := range existing {
+		if p.GetSource() == cloudPolicySource && !desired[p.GetTenant()] {
+			if err := store.Delete(ctx, p.GetTenant()); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/internal/server/cloud_policy_sink_test.go
+++ b/internal/server/cloud_policy_sink_test.go
@@ -39,4 +39,39 @@ func TestCloudPolicySink_WritesIntoStore(t *testing.T) {
 	if got.GetAllowMetadata() {
 		t.Errorf("metadata must stay denied")
 	}
+	if got.GetSource() != cloudPolicySource {
+		t.Errorf("cloud-synced policy must be tagged source=cloud, got %q", got.GetSource())
+	}
+}
+
+func TestCloudPolicySink_ConvergesWithoutClobberingCLI(t *testing.T) {
+	np := NewNetworkPolicyServer(NewMemNetworkPolicyStore())
+	ctx := context.Background()
+	store := np.Store()
+
+	// An operator's CLI-authored policy (empty source) + an initial cloud policy.
+	if err := store.Set(ctx, &pb.NetworkPolicy{Tenant: "local-team", EgressCidrs: []string{"10.0.0.0/8"}}); err != nil {
+		t.Fatal(err)
+	}
+	sink := newCloudPolicySink(np)
+	if err := sink.SyncNetworkPolicies(ctx, []*cloudv1.NetworkPolicy{
+		{OrgId: "org-a"}, {OrgId: "org-b"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Next batch drops org-b → it must be deleted; org-a kept; local-team untouched.
+	if err := sink.SyncNetworkPolicies(ctx, []*cloudv1.NetworkPolicy{{OrgId: "org-a"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Get(ctx, "org-a"); err != nil {
+		t.Errorf("org-a should remain: %v", err)
+	}
+	if _, err := store.Get(ctx, "org-b"); err == nil {
+		t.Errorf("org-b should be converged away (removed cloud-side)")
+	}
+	if _, err := store.Get(ctx, "local-team"); err != nil {
+		t.Errorf("CLI-authored local-team must NOT be clobbered by cloud convergence: %v", err)
+	}
 }

--- a/internal/server/network_policy_store.go
+++ b/internal/server/network_policy_store.go
@@ -87,7 +87,9 @@ func clonePolicy(p *pb.NetworkPolicy) *pb.NetworkPolicy {
 		AllowIntraTenant: p.GetAllowIntraTenant(),
 		EgressCidrs:      append([]string(nil), p.GetEgressCidrs()...),
 		EgressDomains:    append([]string(nil), p.GetEgressDomains()...),
+		AllowMetadata:    p.GetAllowMetadata(),
 		Mode:             p.GetMode(),
+		Source:           p.GetSource(),
 	}
 }
 
@@ -108,8 +110,14 @@ func NewPostgresNetworkPolicyStore(ctx context.Context, pool *pgxpool.Pool) (*Po
 			egress_cidrs TEXT[] NOT NULL DEFAULT '{}',
 			egress_domains TEXT[] NOT NULL DEFAULT '{}',
 			mode INTEGER NOT NULL DEFAULT 0,
+			allow_metadata BOOLEAN NOT NULL DEFAULT false,
+			source TEXT NOT NULL DEFAULT '',
 			updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 		);
+		-- Non-destructive upgrades for tables created before these columns
+		-- (allow_metadata: #315 Phase D; source: #354 convergence).
+		ALTER TABLE network_policies ADD COLUMN IF NOT EXISTS allow_metadata BOOLEAN NOT NULL DEFAULT false;
+		ALTER TABLE network_policies ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT '';
 	`
 	if _, err := pool.Exec(ctx, schema); err != nil {
 		return nil, fmt.Errorf("init network_policies schema: %w", err)
@@ -119,18 +127,21 @@ func NewPostgresNetworkPolicyStore(ctx context.Context, pool *pgxpool.Pool) (*Po
 
 func (s *PostgresNetworkPolicyStore) Set(ctx context.Context, p *pb.NetworkPolicy) error {
 	const q = `
-		INSERT INTO network_policies (tenant, allow_intra_tenant, egress_cidrs, egress_domains, mode, updated_at)
-		VALUES ($1, $2, $3, $4, $5, NOW())
+		INSERT INTO network_policies (tenant, allow_intra_tenant, egress_cidrs, egress_domains, mode, allow_metadata, source, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
 		ON CONFLICT (tenant) DO UPDATE SET
 			allow_intra_tenant = EXCLUDED.allow_intra_tenant,
 			egress_cidrs = EXCLUDED.egress_cidrs,
 			egress_domains = EXCLUDED.egress_domains,
 			mode = EXCLUDED.mode,
+			allow_metadata = EXCLUDED.allow_metadata,
+			source = EXCLUDED.source,
 			updated_at = NOW()
 	`
 	_, err := s.pool.Exec(ctx, q,
 		p.GetTenant(), p.GetAllowIntraTenant(),
-		p.GetEgressCidrs(), p.GetEgressDomains(), int32(p.GetMode()))
+		p.GetEgressCidrs(), p.GetEgressDomains(), int32(p.GetMode()),
+		p.GetAllowMetadata(), p.GetSource())
 	if err != nil {
 		return fmt.Errorf("save network policy: %w", err)
 	}
@@ -138,11 +149,11 @@ func (s *PostgresNetworkPolicyStore) Set(ctx context.Context, p *pb.NetworkPolic
 }
 
 func (s *PostgresNetworkPolicyStore) Get(ctx context.Context, tenant string) (*pb.NetworkPolicy, error) {
-	const q = `SELECT tenant, allow_intra_tenant, egress_cidrs, egress_domains, mode
+	const q = `SELECT tenant, allow_intra_tenant, egress_cidrs, egress_domains, mode, allow_metadata, source
 		FROM network_policies WHERE tenant = $1`
 	p := &pb.NetworkPolicy{}
 	var mode int32
-	err := s.pool.QueryRow(ctx, q, tenant).Scan(&p.Tenant, &p.AllowIntraTenant, &p.EgressCidrs, &p.EgressDomains, &mode)
+	err := s.pool.QueryRow(ctx, q, tenant).Scan(&p.Tenant, &p.AllowIntraTenant, &p.EgressCidrs, &p.EgressDomains, &mode, &p.AllowMetadata, &p.Source)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNetworkPolicyNotFound
@@ -154,7 +165,7 @@ func (s *PostgresNetworkPolicyStore) Get(ctx context.Context, tenant string) (*p
 }
 
 func (s *PostgresNetworkPolicyStore) List(ctx context.Context) ([]*pb.NetworkPolicy, error) {
-	const q = `SELECT tenant, allow_intra_tenant, egress_cidrs, egress_domains, mode
+	const q = `SELECT tenant, allow_intra_tenant, egress_cidrs, egress_domains, mode, allow_metadata, source
 		FROM network_policies ORDER BY tenant`
 	rows, err := s.pool.Query(ctx, q)
 	if err != nil {
@@ -165,7 +176,7 @@ func (s *PostgresNetworkPolicyStore) List(ctx context.Context) ([]*pb.NetworkPol
 	for rows.Next() {
 		p := &pb.NetworkPolicy{}
 		var mode int32
-		if err := rows.Scan(&p.Tenant, &p.AllowIntraTenant, &p.EgressCidrs, &p.EgressDomains, &mode); err != nil {
+		if err := rows.Scan(&p.Tenant, &p.AllowIntraTenant, &p.EgressCidrs, &p.EgressDomains, &mode, &p.AllowMetadata, &p.Source); err != nil {
 			return nil, fmt.Errorf("scan network policy: %w", err)
 		}
 		p.Mode = pb.NetworkPolicyMode(mode)

--- a/pkg/pb/containarium/v1/config.pb.go
+++ b/pkg/pb/containarium/v1/config.pb.go
@@ -1665,6 +1665,13 @@ type NetworkPolicy struct {
 	// hands out cloud credentials). Set true only for a tenant that legitimately
 	// needs instance metadata. #315 Phase D.
 	AllowMetadata bool `protobuf:"varint,6,opt,name=allow_metadata,json=allowMetadata,proto3" json:"allow_metadata,omitempty"`
+	// Source identifies who authored this policy: "" / "cli" for an operator via
+	// `containarium network-policy set`, "cloud" for one synced from a cloud
+	// control plane (#354). The cloud-actuation reconciler converges only its own
+	// ("cloud") policies — so removing a policy cloud-side clears it on the host
+	// without clobbering an operator's CLI-authored policy. Informational on
+	// get/list.
+	Source        string `protobuf:"bytes,7,opt,name=source,proto3" json:"source,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1739,6 +1746,13 @@ func (x *NetworkPolicy) GetAllowMetadata() bool {
 		return x.AllowMetadata
 	}
 	return false
+}
+
+func (x *NetworkPolicy) GetSource() string {
+	if x != nil {
+		return x.Source
+	}
+	return ""
 }
 
 type SetNetworkPolicyRequest struct {
@@ -2469,14 +2483,15 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\x16GPU_STATUS_UNSPECIFIED\x10\x00\x12\x11\n" +
 	"\rGPU_STATUS_OK\x10\x01\x12\x1a\n" +
 	"\x16GPU_STATUS_UNAVAILABLE\x10\x02\x12\x17\n" +
-	"\x13GPU_STATUS_DEGRADED\x10\x03\"\xfe\x01\n" +
+	"\x13GPU_STATUS_DEGRADED\x10\x03\"\x96\x02\n" +
 	"\rNetworkPolicy\x12\x16\n" +
 	"\x06tenant\x18\x01 \x01(\tR\x06tenant\x12,\n" +
 	"\x12allow_intra_tenant\x18\x02 \x01(\bR\x10allowIntraTenant\x12!\n" +
 	"\fegress_cidrs\x18\x03 \x03(\tR\vegressCidrs\x12%\n" +
 	"\x0eegress_domains\x18\x04 \x03(\tR\regressDomains\x126\n" +
 	"\x04mode\x18\x05 \x01(\x0e2\".containarium.v1.NetworkPolicyModeR\x04mode\x12%\n" +
-	"\x0eallow_metadata\x18\x06 \x01(\bR\rallowMetadata\"Q\n" +
+	"\x0eallow_metadata\x18\x06 \x01(\bR\rallowMetadata\x12\x16\n" +
+	"\x06source\x18\a \x01(\tR\x06source\"Q\n" +
 	"\x17SetNetworkPolicyRequest\x126\n" +
 	"\x06policy\x18\x01 \x01(\v2\x1e.containarium.v1.NetworkPolicyR\x06policy\"R\n" +
 	"\x18SetNetworkPolicyResponse\x126\n" +

--- a/proto/containarium/v1/config.proto
+++ b/proto/containarium/v1/config.proto
@@ -368,6 +368,14 @@ message NetworkPolicy {
   // hands out cloud credentials). Set true only for a tenant that legitimately
   // needs instance metadata. #315 Phase D.
   bool allow_metadata = 6;
+
+  // Source identifies who authored this policy: "" / "cli" for an operator via
+  // `containarium network-policy set`, "cloud" for one synced from a cloud
+  // control plane (#354). The cloud-actuation reconciler converges only its own
+  // ("cloud") policies — so removing a policy cloud-side clears it on the host
+  // without clobbering an operator's CLI-authored policy. Informational on
+  // get/list.
+  string source = 7;
 }
 
 // --- NetworkPolicyService request/response messages (#315) ---


### PR DESCRIPTION
Adds **convergence** to the cloud policy sync — a policy removed on the cloud is now cleared on the host — without clobbering an operator's CLI-authored policy. Builds on the container-reconcile (#459).

## Convergence

- **proto**: `NetworkPolicy.source` (field 7) — `""`/`"cli"` for operator-authored, `"cloud"` for cloud-synced. Persisted; shown on `get`/`list`.
- **cloud sink**: tags upserts `source="cloud"`, then after upserting the batch deletes any `source="cloud"` policy whose tenant is no longer present. **CLI-authored policies (empty source) are never touched**, so a host running both stays correct. Test covers drop-an-org + keep-the-CLI-policy.
- **CLI** `network-policy get/list` surfaces `source` when set.

## Drive-by bug fix (found while wiring this)

The `NetworkPolicyStore` — **both** `MemNetworkPolicyStore.clonePolicy` and `PostgresNetworkPolicyStore` — silently **dropped `AllowMetadata`** (added in #315 Phase D / #442) on every round-trip. So a tenant's metadata opt-in was lost once stored, leaving `169.254.169.254` denied even when the operator allowed it. Fail-safe (deny), but wrong. Now persisted: `clonePolicy` copies it; Postgres gains `allow_metadata` + `source` columns (`ADD COLUMN IF NOT EXISTS` for existing tables) and `Set/Get/List` carry both.

> This is the kind of rot the codebase's own "verify known claims" rule warns about — the #442 hardware smoke passed (likely on a dirty tree with the store fix uncommitted), so the gap reached main silently. The store round-trip is now covered.

## Test

`go build ./...`, `go vet`, `gofmt`, `go mod tidy` (no-op) clean; `server` / `netpolicy` / `netbpf` / `cmd` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)