### PR TITLE
feat(cloud): wire disk + GPU into the container actuator's create (#354)

### DIFF
--- a/docs/CLOUD-ACTUATION-SMOKE.md
+++ b/docs/CLOUD-ACTUATION-SMOKE.md
@@ -149,7 +149,7 @@ containarium cloud logout            # removes ~/.containarium/cloud.yaml
 - **Policy sync is upsert-only** — a policy *removed* on the cloud is not yet
   cleared on the host (distinguishing cloud- from CLI-authored policies needs a
   source marker). Re-authoring with an empty allow-list is the current workaround.
-- **Container reconcile is minimal** — create/start/stop/delete + the tenant
-  label, but not the richer create options the user-facing ContainerService
-  offers (routes, secrets, GPU/disk devices beyond memory). Cloud-assigned boxes
-  are v1 minimal workloads.
+- **Container reconcile** wires the resource options the actuation contract
+  carries — memory, root-disk size, and GPU passthrough — plus the tenant label.
+  It does not set routes, secrets, or CPU limits (not in the `Assignment`
+  contract); those remain a follow-up if cloud workloads need them.

--- a/internal/server/cloud_container_actuator.go
+++ b/internal/server/cloud_container_actuator.go
@@ -80,14 +80,7 @@ func (a *cloudContainerActuator) EnsureDeleted(_ context.Context, localName stri
 
 // create makes the instance (stopped) and stamps the tenant label before start.
 func (a *cloudContainerActuator) create(spec cloud.ContainerSpec) error {
-	cfg := incus.ContainerConfig{
-		Name:  spec.LocalName,
-		Image: spec.Image,
-	}
-	if spec.RAMMB > 0 {
-		cfg.Memory = fmt.Sprintf("%dMB", spec.RAMMB)
-	}
-	if err := a.incus.CreateContainer(cfg); err != nil {
+	if err := a.incus.CreateContainer(buildContainerConfig(spec)); err != nil {
 		return fmt.Errorf("create %s: %w", spec.LocalName, err)
 	}
 	// Stamp the owning org as the tenant label so the network-policy enforcer
@@ -98,6 +91,27 @@ func (a *cloudContainerActuator) create(spec cloud.ContainerSpec) error {
 		}
 	}
 	return nil
+}
+
+// buildContainerConfig maps a cloud ContainerSpec to the Incus create config.
+// It wires the resource options the actuation contract carries: memory (RAMMB),
+// root-disk size (DiskGB), and GPU passthrough (GPUCount > 0 → pass through all
+// GPUs, the cloud-v1 "this is a GPU box" semantics — per-GPU pinning needs host
+// GPU inventory the assignment doesn't carry). CPU isn't in the assignment;
+// routes/secrets aren't in the actuation contract, so they're not set here.
+// Pure (no Incus calls) so the mapping is unit-testable.
+func buildContainerConfig(spec cloud.ContainerSpec) incus.ContainerConfig {
+	cfg := incus.ContainerConfig{Name: spec.LocalName, Image: spec.Image}
+	if spec.RAMMB > 0 {
+		cfg.Memory = fmt.Sprintf("%dMB", spec.RAMMB)
+	}
+	if spec.DiskGB > 0 {
+		cfg.Disk = &incus.DiskDevice{Path: "/", Pool: "default", Size: fmt.Sprintf("%dGB", spec.DiskGB)}
+	}
+	if spec.GPUCount > 0 {
+		cfg.GPU = &incus.GPUDevice{} // empty = pass through all GPUs
+	}
+	return cfg
 }
 
 // isRunning matches Incus's running state case-insensitively.

--- a/internal/server/cloud_container_actuator_test.go
+++ b/internal/server/cloud_container_actuator_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/footprintai/containarium/internal/cloud"
+)
+
+func TestBuildContainerConfig(t *testing.T) {
+	cfg := buildContainerConfig(cloud.ContainerSpec{
+		LocalName: "cld-abc", Image: "ubuntu:24.04",
+		RAMMB: 2048, DiskGB: 40, GPUCount: 1,
+	})
+	if cfg.Name != "cld-abc" || cfg.Image != "ubuntu:24.04" {
+		t.Errorf("name/image wrong: %+v", cfg)
+	}
+	if cfg.Memory != "2048MB" {
+		t.Errorf("memory = %q, want 2048MB", cfg.Memory)
+	}
+	if cfg.Disk == nil || cfg.Disk.Size != "40GB" || cfg.Disk.Path != "/" || cfg.Disk.Pool != "default" {
+		t.Errorf("disk wrong: %+v", cfg.Disk)
+	}
+	if cfg.GPU == nil {
+		t.Error("GPUCount>0 should request GPU passthrough")
+	}
+}
+
+func TestBuildContainerConfig_MinimalOmitsDevices(t *testing.T) {
+	cfg := buildContainerConfig(cloud.ContainerSpec{LocalName: "cld-x", Image: "alpine"})
+	if cfg.Memory != "" {
+		t.Errorf("no RAM → memory unset, got %q", cfg.Memory)
+	}
+	if cfg.Disk != nil {
+		t.Errorf("no disk → Disk nil, got %+v", cfg.Disk)
+	}
+	if cfg.GPU != nil {
+		t.Errorf("no GPU → GPU nil, got %+v", cfg.GPU)
+	}
+}


### PR DESCRIPTION
The container reconcile now applies the resource options the actuation `Assignment` carries — not just memory. Builds on #459/#460.

## What

- **Root disk** — `DiskGB > 0` → `DiskDevice{Path:/, Pool:default, Size:<N>GB}` (mirrors `pkg/core/container/manager`).
- **GPU** — `GPUCount > 0` → pass through all GPUs (empty `GPUDevice`, the cloud-v1 "this is a GPU box" semantics; per-GPU pinning needs host GPU inventory the assignment doesn't carry).
- **Memory** unchanged (`RAMMB`).

Factored the spec→config mapping into a pure **`buildContainerConfig`** so it's unit-tested (full spec sets memory/disk/gpu; minimal spec omits the devices) without a real Incus.

## Not set (and why)

CPU isn't in the `Assignment` proto; routes/secrets aren't in the actuation contract at all. Noted in the smoke runbook's gap list — a follow-up if cloud workloads need them.

`go build`/`vet`/`gofmt` clean; server suite passes. Actuator's actual Incus calls remain Linux-bound (validated via the smoke runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)