### PR TITLE
fix(cli): pin ALPN to http/1.1 in --http REST client (complete the #422 h1 pin)

### DIFF
--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -45,9 +45,21 @@ func NewHTTPClient(baseURL string, token string) (*HTTPClient, error) {
 	// buys nothing here. Clearing TLSNextProto on a cloned default transport
 	// is the documented way to force HTTP/1.1 on net/http while keeping the
 	// default dial/timeout/proxy behaviour. See FootprintAI/Containarium#422.
+	//
+	// Clearing TLSNextProto only removes the h2 *handler* — it does NOT
+	// constrain ALPN. A fronting edge that defaults to h2 when the client
+	// advertises no ALPN protocols (e.g. Cloudflare) then still negotiates
+	// HTTP/2, the server sends h2 frames, and the h1 parser chokes on them:
+	// `malformed HTTP response "\x00\x00\x12\x04..."` (an h2 SETTINGS frame),
+	// deterministically. Pin the ALPN offer to http/1.1 so the edge serves
+	// HTTP/1.1 — matching the clean `curl --http1.1` path.
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.ForceAttemptHTTP2 = false
 	transport.TLSNextProto = map[string]func(authority string, c *tls.Conn) http.RoundTripper{}
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"http/1.1"},
+	}
 
 	return &HTTPClient{
 		baseURL: baseURL,


### PR DESCRIPTION
## Problem

#422/#423 hardened the CLI's `--http` REST client against HTTP/2 edge resets by clearing `ForceAttemptHTTP2` and `TLSNextProto`. That removes the HTTP/2 **handler**, but it does **not** constrain the TLS **ALPN** offer. With an empty `NextProtos`, the Go client still advertises HTTP/2-capable ALPN, so a TLS-terminating edge that defaults to h2 (a CDN/reverse proxy in front of the daemon) negotiates HTTP/2 anyway. The server then writes h2 frames, and since the h2 handler was stripped, the HTTP/1.1 parser fails on the very first frame:

```
net/http: HTTP/1.x transport connection broken: malformed HTTP response
"\x00\x00\x12\x04..."        # an HTTP/2 SETTINGS frame
```

Behind such an edge this is **deterministic** — every `--http` call (`create` / `list` / `delete` / `runner provision`) fails identically. A plain `curl --http1.1` against the same endpoint is clean, because curl offers only `http/1.1` in ALPN.

## Fix

Pin the ALPN offer to HTTP/1.1 so the client advertises only `http/1.1`, matching curl and completing the #422 intent:

```go
transport.TLSClientConfig = &tls.Config{
    MinVersion: tls.VersionTLS12,
    NextProtos: []string{"http/1.1"},
}
```

One file, `internal/client/http.go` (+12). `MinVersion: TLS 1.2` preserves the rest of the default posture.

## Why it matters

Clearing `TLSNextProto` alone is only sufficient against an origin that honors the client's preference; against an h2-default edge it silently regresses to the exact failure #422 set out to fix. Constraining ALPN is the part that actually forces HTTP/1.1 end-to-end.

## Test

- `go build ./...` green.
- Reproduced the `malformed HTTP response "\x00\x00\x12\x04..."` failure with the pre-fix client against an h2-default TLS edge; with this change the same request completes over HTTP/1.1 (matching `curl --http1.1`).

Relates to #422, #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
