### PR TITLE
feat(cloud): expose cloud-assigned container routes at the host edge (#354)

### DIFF
--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -53,6 +53,16 @@ type ContainerSpec struct {
 	// SecretEnv are name→value pairs the actuator injects as container
 	// environment (from Assignment.secret_env).
 	SecretEnv map[string]string
+	// Routes are the hostname→port exposures for this container (from
+	// Assignment.routes); the actuator registers them at the host edge.
+	Routes []RouteSpec
+}
+
+// RouteSpec is one hostname→container-port exposure (from cloudv1.PortRoute).
+type RouteSpec struct {
+	Domain     string
+	TargetPort int32
+	Protocol   string
 }
 
 // ContainerActuator drives local Incus state toward an assignment's
@@ -274,16 +284,14 @@ func (c *Client) reconcileAssignment(a *cloudv1.Assignment) {
 	name := localContainerName(a.GetContainerId())
 	switch a.GetDesiredState() {
 	case "running":
-		// Routes ride the assignment (Assignment.routes); applying them to the
-		// host edge (Caddy) needs the daemon's route machinery — a follow-up.
-		// Log so the gap is visible rather than silent.
-		if len(a.GetRoutes()) > 0 {
-			log.Printf("[cloud] %s: %d route(s) received; edge route application is not yet wired", name, len(a.GetRoutes()))
+		routes := make([]RouteSpec, 0, len(a.GetRoutes()))
+		for _, r := range a.GetRoutes() {
+			routes = append(routes, RouteSpec{Domain: r.GetDomain(), TargetPort: r.GetTargetPort(), Protocol: r.GetProtocol()})
 		}
 		if err := c.containers.EnsureRunning(c.ctx, ContainerSpec{
 			LocalName: name, OrgID: a.GetOrgId(), Image: a.GetImage(),
 			RAMMB: a.GetRamMb(), DiskGB: a.GetDiskGb(), GPUCount: a.GetGpuCount(),
-			SecretEnv: a.GetSecretEnv(),
+			SecretEnv: a.GetSecretEnv(), Routes: routes,
 		}); err != nil {
 			log.Printf("[cloud] ensure running %s: %v", name, err)
 			return // leave the cloud's observed state stale; next snapshot retries

--- a/internal/server/cloud_container_actuator.go
+++ b/internal/server/cloud_container_actuator.go
@@ -3,8 +3,10 @@ package server
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
+	"github.com/footprintai/containarium/internal/app"
 	"github.com/footprintai/containarium/internal/cloud"
 	"github.com/footprintai/containarium/pkg/core/incus"
 )
@@ -15,27 +17,29 @@ import (
 // the container to its org's egress policy (cloud names are cld-<uuid>, not
 // <tenant>-container, so the label — not the name — carries the tenant).
 //
-// Scope: create / start / stop / delete to converge to desired_state. It does
-// NOT manage routes, secrets, or the richer create options the user-facing
+// Scope: create / start / stop / delete to converge to desired_state, plus
+// exposing the container's routes at the host edge (routeStore → Caddy) and
+// injecting secret_env. Not the richer create options the user-facing
 // ContainerService offers — cloud-assigned boxes are minimal v1 workloads.
 type cloudContainerActuator struct {
-	incus *incus.Client
+	incus  *incus.Client
+	routes *app.RouteStore // nil when the host has no route store (no Postgres/Caddy) → routes skipped
 }
 
-// newCloudContainerActuator builds an actuator with its own Incus client.
-// Returns an error (→ caller runs policy-sync-only) if Incus is unavailable,
-// e.g. on a non-Linux dev box.
-func newCloudContainerActuator() (*cloudContainerActuator, error) {
+// newCloudContainerActuator builds an actuator with its own Incus client and the
+// daemon's route store (may be nil — then route exposure is skipped). Returns an
+// error (→ caller runs policy-sync-only) if Incus is unavailable, e.g. non-Linux.
+func newCloudContainerActuator(routes *app.RouteStore) (*cloudContainerActuator, error) {
 	c, err := incus.New()
 	if err != nil {
 		return nil, fmt.Errorf("incus client: %w", err)
 	}
-	return &cloudContainerActuator{incus: c}, nil
+	return &cloudContainerActuator{incus: c, routes: routes}, nil
 }
 
-// EnsureRunning creates the container (stamping the tenant label) if absent, then
-// ensures it is started. Idempotent.
-func (a *cloudContainerActuator) EnsureRunning(_ context.Context, spec cloud.ContainerSpec) error {
+// EnsureRunning creates the container (stamping the tenant label) if absent,
+// ensures it is started, and converges its edge routes. Idempotent.
+func (a *cloudContainerActuator) EnsureRunning(ctx context.Context, spec cloud.ContainerSpec) error {
 	info, err := a.incus.GetContainer(spec.LocalName)
 	if err != nil {
 		// Treat any lookup failure as "not present" and try to create — a real
@@ -44,11 +48,13 @@ func (a *cloudContainerActuator) EnsureRunning(_ context.Context, spec cloud.Con
 			return cerr
 		}
 	} else if isRunning(info.State) {
-		return nil // already converged
+		a.applyRoutes(ctx, spec) // already running — still converge routes
+		return nil
 	}
 	if err := a.incus.StartContainer(spec.LocalName); err != nil {
 		return fmt.Errorf("start %s: %w", spec.LocalName, err)
 	}
+	a.applyRoutes(ctx, spec)
 	return nil
 }
 
@@ -67,8 +73,9 @@ func (a *cloudContainerActuator) EnsureStopped(_ context.Context, localName stri
 	return nil
 }
 
-// EnsureDeleted deletes the container if it exists. Idempotent.
-func (a *cloudContainerActuator) EnsureDeleted(_ context.Context, localName string) error {
+// EnsureDeleted removes the container's edge routes, then deletes it. Idempotent.
+func (a *cloudContainerActuator) EnsureDeleted(ctx context.Context, localName string) error {
+	a.removeRoutes(ctx, localName)
 	if _, err := a.incus.GetContainer(localName); err != nil {
 		return nil // already gone
 	}
@@ -122,3 +129,90 @@ func buildContainerConfig(spec cloud.ContainerSpec) incus.ContainerConfig {
 
 // isRunning matches Incus's running state case-insensitively.
 func isRunning(state string) bool { return strings.EqualFold(state, "running") }
+
+// applyRoutes converges the container's edge routes to spec.Routes: upsert each
+// (pointing at the container's current IP) and delete any cloud route for this
+// container the cloud no longer sends. Best-effort — route errors are logged,
+// never fail the reconcile (the loop retries). No-op when there's no route store.
+//
+// The container IP is read fresh: right after first start it may be empty (DHCP
+// lag), in which case routes are skipped this pass and applied on the next
+// reconcile once the lease lands.
+func (a *cloudContainerActuator) applyRoutes(ctx context.Context, spec cloud.ContainerSpec) {
+	if a.routes == nil || len(spec.Routes) == 0 {
+		// Still converge-away stale routes even if the desired set is now empty.
+		if a.routes != nil {
+			a.pruneRoutes(ctx, spec.LocalName, nil)
+		}
+		return
+	}
+	info, err := a.incus.GetContainer(spec.LocalName)
+	if err != nil || info.IPAddress == "" {
+		log.Printf("[cloud] %s: IP not ready, deferring route exposure to next reconcile", spec.LocalName)
+		return
+	}
+	desired := make(map[string]bool, len(spec.Routes))
+	for _, r := range spec.Routes {
+		if r.Domain == "" {
+			continue
+		}
+		desired[r.Domain] = true
+		rec := routeRecordFor(spec.LocalName, info.IPAddress, r)
+		if err := a.routes.Save(ctx, rec); err != nil {
+			log.Printf("[cloud] expose route %s → %s:%d: %v", r.Domain, info.IPAddress, r.TargetPort, err)
+		}
+	}
+	a.pruneRoutes(ctx, spec.LocalName, desired)
+}
+
+// pruneRoutes deletes this container's cloud-created routes whose domain isn't in
+// `keep`. Only touches routes created_by="cloud" so it won't remove an operator's
+// manually-exposed route on the same container.
+func (a *cloudContainerActuator) pruneRoutes(ctx context.Context, localName string, keep map[string]bool) {
+	existing, err := a.routes.ListByContainer(ctx, localName)
+	if err != nil {
+		return
+	}
+	for _, r := range existing {
+		if r.CreatedBy == cloudRouteCreatedBy && !keep[r.FullDomain] {
+			if err := a.routes.Delete(ctx, r.FullDomain); err != nil {
+				log.Printf("[cloud] prune route %s: %v", r.FullDomain, err)
+			}
+		}
+	}
+}
+
+// removeRoutes deletes all of this container's cloud-created routes (on delete).
+func (a *cloudContainerActuator) removeRoutes(ctx context.Context, localName string) {
+	if a.routes != nil {
+		a.pruneRoutes(ctx, localName, nil)
+	}
+}
+
+// cloudRouteCreatedBy tags routes the cloud actuator owns, so convergence/cleanup
+// never touches operator-authored routes on the same container.
+const cloudRouteCreatedBy = "cloud-actuation"
+
+// routeRecordFor maps a cloud route + the container's IP to a daemon RouteRecord.
+// Protocol: the daemon edge speaks http/grpc; grpc passes through, everything
+// else (http/https/"") becomes http. Pure → unit-testable.
+func routeRecordFor(localName, ip string, r cloud.RouteSpec) *app.RouteRecord {
+	proto := "http"
+	if strings.EqualFold(r.Protocol, "grpc") {
+		proto = "grpc"
+	}
+	sub := r.Domain
+	if i := strings.IndexByte(sub, '.'); i > 0 {
+		sub = sub[:i]
+	}
+	return &app.RouteRecord{
+		Subdomain:     sub,
+		FullDomain:    r.Domain,
+		TargetIP:      ip,
+		TargetPort:    int(r.TargetPort),
+		Protocol:      proto,
+		ContainerName: localName,
+		Active:        true,
+		CreatedBy:     cloudRouteCreatedBy,
+	}
+}

--- a/internal/server/cloud_container_actuator_test.go
+++ b/internal/server/cloud_container_actuator_test.go
@@ -29,6 +29,31 @@ func TestBuildContainerConfig(t *testing.T) {
 	}
 }
 
+func TestRouteRecordFor(t *testing.T) {
+	rec := routeRecordFor("cld-abc", "10.100.0.42", cloud.RouteSpec{
+		Domain: "web.acme.example.com", TargetPort: 8080, Protocol: "http",
+	})
+	if rec.FullDomain != "web.acme.example.com" || rec.Subdomain != "web" {
+		t.Errorf("domain/subdomain wrong: full=%q sub=%q", rec.FullDomain, rec.Subdomain)
+	}
+	if rec.TargetIP != "10.100.0.42" || rec.TargetPort != 8080 {
+		t.Errorf("target wrong: %s:%d", rec.TargetIP, rec.TargetPort)
+	}
+	if rec.Protocol != "http" || rec.ContainerName != "cld-abc" {
+		t.Errorf("proto/container wrong: %q %q", rec.Protocol, rec.ContainerName)
+	}
+	if rec.CreatedBy != cloudRouteCreatedBy || !rec.Active {
+		t.Errorf("must be tagged cloud-created + active: by=%q active=%v", rec.CreatedBy, rec.Active)
+	}
+	// grpc passes through; anything else → http.
+	if g := routeRecordFor("c", "1.2.3.4", cloud.RouteSpec{Domain: "g.x", TargetPort: 9, Protocol: "grpc"}); g.Protocol != "grpc" {
+		t.Errorf("grpc protocol should pass through, got %q", g.Protocol)
+	}
+	if h := routeRecordFor("c", "1.2.3.4", cloud.RouteSpec{Domain: "h.x", TargetPort: 9, Protocol: "https"}); h.Protocol != "http" {
+		t.Errorf("https should map to http edge, got %q", h.Protocol)
+	}
+}
+
 func TestBuildContainerConfig_MinimalOmitsDevices(t *testing.T) {
 	cfg := buildContainerConfig(cloud.ContainerSpec{LocalName: "cld-x", Image: "alpine"})
 	if cfg.Memory != "" {

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -312,37 +312,10 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	pb.RegisterNetworkPolicyServiceServer(grpcServer, npServer)
 	log.Printf("NetworkPolicy service enabled (in-memory store; Phase A)")
 
-	// Cloud-actuation client (#354): if this host is enrolled with a cloud
-	// control plane, run the actuation client. It heartbeats and consumes
-	// WatchAssignments, syncing each org's egress network policy into the
-	// NetworkPolicyServer's store (closing the #315 cloud-extension loop:
-	// cloud-authored policy → on-box enforcer). Unenrolled (no cloud.yaml) → the
-	// daemon is single-tenant and makes no outbound calls. The sink holds
-	// npServer so it always writes to the current store (post-Postgres-swap).
+	// Cloud-actuation client (#354) is constructed later, once routeStore is
+	// finalized — the container actuator needs it to expose cloud routes at the
+	// host edge. Declared here so it's in scope for the DualServer assembly.
 	var cloudClient *cloud.Client
-	cloudCfgPath := os.Getenv("CONTAINARIUM_CLOUD_CONFIG")
-	if cloudCfgPath == "" {
-		if p, perr := cloud.DefaultPath(); perr == nil {
-			cloudCfgPath = p
-		}
-	}
-	if cloudCfg, cerr := cloud.Load(cloudCfgPath); cerr != nil {
-		log.Printf("Warning: failed to read cloud-actuation config %s: %v (running single-tenant)", cloudCfgPath, cerr)
-	} else if cloudCfg != nil {
-		cloudDeps := cloud.Deps{Policies: newCloudPolicySink(npServer)}
-		if cloudActuator, actErr := newCloudContainerActuator(); actErr != nil {
-			log.Printf("Warning: cloud container actuator unavailable (%v); policy sync only", actErr)
-		} else {
-			cloudDeps.Containers = cloudActuator // only set when non-nil (avoid nil-iface trap)
-		}
-		if cc, nerr := cloud.New(cloudCfg, cloudDeps); nerr != nil {
-			log.Printf("Warning: cloud-actuation config invalid: %v (running single-tenant)", nerr)
-		} else {
-			cloudClient = cc
-			log.Printf("Cloud-actuation client configured (host=%s control-plane=%s); starts with the daemon",
-				cloudCfg.HostID, cloudCfg.ControlPlane)
-		}
-	}
 
 	// Create TrafficServer (always available, but conntrack only works on Linux)
 	var trafficServer *TrafficServer
@@ -835,6 +808,37 @@ skipAppHosting:
 					log.Printf("Network service updated with route store (standalone)")
 				}
 			}
+		}
+	}
+
+	// Cloud-actuation client (#354): if this host is enrolled with a cloud
+	// control plane, run the actuation client — heartbeat + WatchAssignments,
+	// syncing each org's egress policy into the NetworkPolicyServer store
+	// (closing the #315 loop), reconciling assigned containers, and exposing their
+	// routes at the host edge via routeStore. Unenrolled (no cloud.yaml) → the
+	// daemon is single-tenant and makes no outbound calls. Built here (not at
+	// npServer setup) so the actuator has the finalized routeStore.
+	cloudCfgPath := os.Getenv("CONTAINARIUM_CLOUD_CONFIG")
+	if cloudCfgPath == "" {
+		if p, perr := cloud.DefaultPath(); perr == nil {
+			cloudCfgPath = p
+		}
+	}
+	if cloudCfg, cerr := cloud.Load(cloudCfgPath); cerr != nil {
+		log.Printf("Warning: failed to read cloud-actuation config %s: %v (running single-tenant)", cloudCfgPath, cerr)
+	} else if cloudCfg != nil {
+		cloudDeps := cloud.Deps{Policies: newCloudPolicySink(npServer)}
+		if cloudActuator, actErr := newCloudContainerActuator(routeStore); actErr != nil {
+			log.Printf("Warning: cloud container actuator unavailable (%v); policy sync only", actErr)
+		} else {
+			cloudDeps.Containers = cloudActuator // only set when non-nil (avoid nil-iface trap)
+		}
+		if cc, nerr := cloud.New(cloudCfg, cloudDeps); nerr != nil {
+			log.Printf("Warning: cloud-actuation config invalid: %v (running single-tenant)", nerr)
+		} else {
+			cloudClient = cc
+			log.Printf("Cloud-actuation client configured (host=%s control-plane=%s); starts with the daemon",
+				cloudCfg.HostID, cloudCfg.ControlPlane)
 		}
 	}
 


### PR DESCRIPTION
Wires `Assignment.routes` through to the daemon's edge — the actuator registers each cloud route in the `RouteStore` (→ Caddy), so a cloud-assigned container is reachable at its hostname. Completes the routes field populated cloud-side in [Containarium-cloud#273](https://github.com/FootprintAI/Containarium-cloud/pull/273).

## What

- **`internal/cloud`** — `ContainerSpec.Routes` + `RouteSpec`; `reconcileAssignment` maps `Assignment.routes` → spec (replacing the earlier "received, not applied" log).
- **`cloud_container_actuator`** — holds the daemon `RouteStore` (nil → routes skipped, e.g. no Postgres/Caddy). `EnsureRunning` exposes each route (`RouteRecord` → container IP:port, tagged `created_by=cloud-actuation`) and **converges** (prunes cloud routes the cloud no longer sends); `EnsureDeleted` removes them. **IP-not-ready (DHCP lag) → deferred** to the next reconcile. Only `cloud-actuation`-created routes are pruned, so an operator's manual route on the same container is untouched. `routeRecordFor` is pure + unit-tested (domain/subdomain/proto mapping; grpc passthrough, else http).
- **`dual_server`** — the cloud client is now built *after* `routeStore` is finalized so the actuator has it.

## Notes

- Built in a **clean worktree** off `origin/main` (keeps the main checkout's unrelated WIP untouched). Full `go build ./...`, `go vet`, `gofmt`, `go mod tidy` (no-op) clean; cloud+server suites pass.
- Actuator's live Incus/route calls are validated via the smoke runbook (Linux + a registered host).

This closes the route half of the routes/secrets extension. `secret_env` (applied as container env, #465) + routes now both flow cloud→host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)