### PR TITLE
fix(daemon): sync create-request ssh_keys to the jump-server authorized_keys (#470)

### DIFF
--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -445,8 +445,25 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		go func() {
 			if err := container.EnsureJumpServerAccount(req.Username); err != nil {
 				log.Printf("Warning: failed to create jump server account for %s: %v", req.Username, err)
-			} else {
-				log.Printf("Jump server account ensured for %s", req.Username)
+				return
+			}
+			log.Printf("Jump server account ensured for %s", req.Username)
+
+			// Write the create-request ssh_keys to the HOST-SIDE
+			// authorized_keys (the jump-server account's file), the same
+			// file AddSSHKey writes and ServeAuthorizedKeys serves to the
+			// sentinel keysync. EnsureJumpServerAccount only creates the
+			// account with an empty .ssh; the request keys were applied to
+			// the LXC-internal authorized_keys (via Container.SSHKeys) but
+			// NOT here — so a box created with ssh_keys was reachable on the
+			// box itself yet REJECTED at the sentinel (publickey), because
+			// sshpiper validates the client against the host-side file. Mirror
+			// the request keys here so the sentinel authorizes exactly the
+			// keys the box does. Keys are already validated above. (#470)
+			for _, key := range req.SshKeys {
+				if err := container.AddAuthorizedKey(req.Username, key); err != nil {
+					log.Printf("Warning: failed to sync create-request ssh key to jump account for %s: %v", req.Username, err)
+				}
 			}
 		}()
 	}


### PR DESCRIPTION
Fixes #470.

## Problem

A container created with `ssh_keys` in the create request is reachable **on the box itself** but **rejected at the sentinel** with `Permission denied (publickey)` — even though the exact key is present in the box's `authorized_keys`.

## Cause

At create, `req.SshKeys` are applied to the **LXC-internal** `authorized_keys` (via `Container.SSHKeys`), but `EnsureJumpServerAccount` only creates the host jump-server account with an **empty `.ssh`**. The request keys were never written to the **host-side** `/home/<user>/.ssh/authorized_keys`.

That host-side file is the one `ServeAuthorizedKeys` serves to the sentinel keysync, and the one sshpiper validates inbound clients against — the existing `AddSSHKey` doc says exactly this:

> *this writes the host-side file, not the LXC-internal one. That's the file sshpiper's keysync reads from… Adding only inside the LXC would not let anyone SSH in via the sentinel.*

Registered keys reach the host-side file via the separate `AddSSHKey` path; **request-supplied keys did not**. So the sentinel gate was missing exactly the key the client used → the `ssh -vv` "partial success" loop → deny.

## Fix

After `EnsureJumpServerAccount`, mirror `req.SshKeys` into the host-side `authorized_keys` via `container.AddAuthorizedKey` (the same helper `AddSSHKey` already uses). Now the sentinel authorizes the same key set the box does. Keys are already validated earlier in `CreateContainer`. (+19/-2)

## Impact

Unblocks any flow that authorizes a box solely via request-supplied `ssh_keys` and connects through the sentinel — `containarium runner provision`'s SSH-install step and CI box provisioning.

## Verification

- `go build` / `go vet ./internal/server/` green.
- Reproduced live: a box created with a request key had the key in its own `authorized_keys` but **not** in the sentinel's `/etc/sshpiper/users/<box>/authorized_keys`; manually adding it there made SSH succeed immediately — confirming the box, its sshd, and the upstream pipe are all fine, and the only gap is this host-side sync. This change closes that gap at the source.
- Reuses the unit-tested `AddAuthorizedKey` helper; the create-path wiring is exercised by host-level e2e (useradd + file writes require a real host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
