### PR TITLE
chore(release): bump to 0.22.5 (ships #471 sshpiper key-sync fix)

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.22.4"
+	Version = "0.22.5"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Bumps `pkg/version/version.go` 0.22.4 → 0.22.5. Ships #471 (sync create-request ssh_keys to the jump-server authorized_keys → boxes created with request keys are reachable through the sentinel; fixes #470). Tag `v0.22.5` after merge to build + publish the daemon binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)