### PR TITLE
chore(release): bump to 0.22.6 (ships #473 jump-server key fix)

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.22.5"
+	Version = "0.22.6"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Bumps to 0.22.6. Ships #473 (authorize all request ssh_keys host-side → boxes reachable via the sentinel with any key; real #470 fix). Tag v0.22.6 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)