### PR TITLE
fix(runner): retry install-state SSH probe across the keysync window (#475)

### DIFF
--- a/internal/runner/provision.go
+++ b/internal/runner/provision.go
@@ -29,6 +29,55 @@ const DefaultBoxCreateTimeout = 5 * time.Minute
 // over a slow link. 10 min is "generous-but-bounded".
 const DefaultInstallTimeout = 10 * time.Minute
 
+// DefaultSSHReadyTimeout bounds how long provision waits for a freshly-
+// created box to become reachable via the sentinel before the first
+// install-state probe. A new box isn't SSH-able the instant it reaches
+// RUNNING: its sshd has to come up AND the sentinel keysync has to
+// propagate the box's host-side authorized_keys into sshpiper's per-box
+// gate — a periodic poll that can take a couple of minutes. Until then
+// the probe is rejected publickey / dial-refused, which is transient, not
+// a real failure. Comfortably over the observed keysync interval. (#475)
+const DefaultSSHReadyTimeout = 5 * time.Minute
+
+// sshProbeInitialBackoff is the first inter-probe wait in
+// waitForSSHInstalled; it doubles up to sshProbeMaxBackoff. A package var
+// so tests can shrink it to keep the retry loop instant.
+var sshProbeInitialBackoff = 3 * time.Second
+
+const sshProbeMaxBackoff = 15 * time.Second
+
+// waitForSSHInstalled retries the install-state probe until the box is
+// reachable via the sentinel (sshd up + keysync done) or readyTimeout /
+// ctx expires. A freshly-created box's first probes fail publickey/dial;
+// those are transient here, so we back off and retry rather than failing
+// the whole provision on the first miss. Returns IsInstalled's result once
+// SSH succeeds. (#475)
+func waitForSSHInstalled(ctx context.Context, ssh RunnerInstaller, name string, readyTimeout time.Duration) (bool, error) {
+	deadline := time.Now().Add(readyTimeout)
+	backoff := sshProbeInitialBackoff
+	var lastErr error
+	for {
+		installed, err := ssh.IsInstalled(ctx, name)
+		if err == nil {
+			return installed, nil
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			return false, fmt.Errorf("box not reachable via sentinel within %s (sshd/keysync not ready): %w", readyTimeout, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return false, fmt.Errorf("box not reachable via sentinel: %w", lastErr)
+		case <-time.After(backoff):
+		}
+		if backoff < sshProbeMaxBackoff {
+			if backoff *= 2; backoff > sshProbeMaxBackoff {
+				backoff = sshProbeMaxBackoff
+			}
+		}
+	}
+}
+
 // DefaultRegistrationTimeout caps the post-install poll waiting
 // for the runner to appear in GitHub's runners list. systemd
 // usually starts the service within a couple of seconds; we give
@@ -78,9 +127,9 @@ type Options struct {
 
 	// BoxCreateTimeout / InstallTimeout / RegistrationTimeout are
 	// per-step deadlines. Zero falls back to the Default* values.
-	BoxCreateTimeout       time.Duration
-	InstallTimeout         time.Duration
-	RegistrationTimeout    time.Duration
+	BoxCreateTimeout    time.Duration
+	InstallTimeout      time.Duration
+	RegistrationTimeout time.Duration
 }
 
 // RunnerStatus is the per-runner outcome shape returned by
@@ -123,8 +172,8 @@ type RunnerStatus struct {
 // have to inspect the error to find the partial state, which is
 // the same dynamic-typing footgun CLAUDE.md warns about.
 type Result struct {
-	Runners         []RunnerStatus
-	PartialFailure  bool
+	Runners        []RunnerStatus
+	PartialFailure bool
 }
 
 // BoxManager abstracts the create/exists/delete operations on
@@ -213,10 +262,10 @@ func (realClock) Sleep(d time.Duration) { time.Sleep(d) }
 // tests can build a fully-wired dependency graph in one place
 // and the function signature stays narrow.
 type Deps struct {
-	Boxes   BoxManager
-	SSH     RunnerInstaller
-	GitHub  GitHubAPI
-	Clock   Clock
+	Boxes  BoxManager
+	SSH    RunnerInstaller
+	GitHub GitHubAPI
+	Clock  Clock
 }
 
 // repoPattern matches GitHub's "owner/repo" shape. Owner and repo
@@ -367,7 +416,11 @@ func provisionOne(ctx context.Context, deps Deps, opts Options, name string) Run
 	installCtx, cancelInstall := context.WithTimeout(ctx, opts.InstallTimeout)
 	defer cancelInstall()
 
-	installed, err := deps.SSH.IsInstalled(installCtx, name)
+	// Retry the first probe across the sshd-startup + sentinel-keysync
+	// window — a fresh box is briefly unreachable (publickey/dial) before
+	// its key is live in sshpiper. Bounded by installCtx (InstallTimeout)
+	// and DefaultSSHReadyTimeout. (#475)
+	installed, err := waitForSSHInstalled(installCtx, deps.SSH, name, DefaultSSHReadyTimeout)
 	if err != nil {
 		st.State = "failed"
 		st.LastError = fmt.Sprintf("check install state: %v", err)

--- a/internal/runner/ssh_retry_test.go
+++ b/internal/runner/ssh_retry_test.go
@@ -1,0 +1,74 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// flakyInstaller fails IsInstalled with a publickey-style handshake error
+// for the first failN calls, then succeeds — modeling a freshly-created
+// box that isn't reachable via the sentinel until the keysync propagates
+// its authorized_keys into sshpiper. Install is a no-op (unused here).
+type flakyInstaller struct {
+	mu        sync.Mutex
+	calls     int
+	failN     int
+	installed bool
+}
+
+func (f *flakyInstaller) IsInstalled(_ context.Context, _ string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.calls <= f.failN {
+		return false, fmt.Errorf("ssh handshake: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain")
+	}
+	return f.installed, nil
+}
+
+func (f *flakyInstaller) Install(context.Context, string, []byte, map[string]string) error {
+	return nil
+}
+
+// TestWaitForSSHInstalled_RetriesThroughKeysync is the #475 regression:
+// the install-state probe must retry across the sshd-startup + sentinel-
+// keysync window (transient publickey/dial failures on a fresh box) rather
+// than failing the whole provision on the first miss.
+func TestWaitForSSHInstalled_RetriesThroughKeysync(t *testing.T) {
+	orig := sshProbeInitialBackoff
+	sshProbeInitialBackoff = time.Millisecond
+	t.Cleanup(func() { sshProbeInitialBackoff = orig })
+
+	f := &flakyInstaller{failN: 3, installed: true}
+	installed, err := waitForSSHInstalled(context.Background(), f, "box", 5*time.Second)
+	if err != nil {
+		t.Fatalf("waitForSSHInstalled returned error after %d probes, want success once SSH comes up: %v", f.calls, err)
+	}
+	if !installed {
+		t.Errorf("installed = false, want true (IsInstalled result must pass through once SSH succeeds)")
+	}
+	if f.calls < 4 {
+		t.Errorf("probe called %d times, want >=4 (3 transient failures + 1 success)", f.calls)
+	}
+}
+
+// TestWaitForSSHInstalled_FailsAfterTimeout: a box that never becomes
+// reachable still fails — bounded, with an actionable error.
+func TestWaitForSSHInstalled_FailsAfterTimeout(t *testing.T) {
+	orig := sshProbeInitialBackoff
+	sshProbeInitialBackoff = time.Millisecond
+	t.Cleanup(func() { sshProbeInitialBackoff = orig })
+
+	f := &flakyInstaller{failN: 1 << 30} // never succeeds
+	_, err := waitForSSHInstalled(context.Background(), f, "box", 40*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error after readyTimeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "not reachable") {
+		t.Errorf("error = %q, want it to mention the box was not reachable", err)
+	}
+}


### PR DESCRIPTION
Fixes #475.

## Problem

`containarium runner provision` reliably fails at the SSH-install step on a **freshly-created** box — even when the box's keys are correct — with:

```
ci-runner-N  failed  check install state: ssh probe: ssh handshake …:
             ssh: unable to authenticate, attempted methods [none publickey]
```

A new box isn't reachable via the sentinel the instant it reaches RUNNING: its sshd has to come up **and** the sentinel keysync has to propagate the box's host-side `authorized_keys` into sshpiper's per-box gate (a periodic poll, ~minutes). `provision` did a **single** `IsInstalled` probe and marked the whole runner `failed` on that first miss. The box becomes reachable ~2 min later — verified directly.

## Fix

Wrap the first probe in `waitForSSHInstalled`, which retries `IsInstalled` with exponential backoff (3s→15s) until the box answers or `DefaultSSHReadyTimeout` (5 min, comfortably over the keysync interval) / `installCtx` expires. The `IsInstalled` result passes through unchanged once SSH succeeds; a box that genuinely never comes up still fails — bounded, with an actionable error. Net +63/-10 in `provision.go`.

## Tests

- `TestWaitForSSHInstalled_RetriesThroughKeysync` — probe fails N times (publickey handshake error) then succeeds → returns success after ≥N+1 attempts. Fails against the pre-fix single-probe behavior.
- `TestWaitForSSHInstalled_FailsAfterTimeout` — never reachable → bounded error mentioning the box wasn't reachable.

`sshProbeInitialBackoff` is a package var the tests shrink to keep the retry loop instant. Full `internal/runner` suite green.

## Context

Surfaced while validating #470 (the host-side key authorization fix, shipped in v0.22.6). With #470 fixed the keys are correct on the box; this keysync race was the only remaining reason `runner provision` reported failure on a fresh box. This is a **client-side** change — it ships in the next `containarium` / `mcp-server` build; no daemon redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
