### PR TITLE
chore(release): bump to 0.22.7 (ships #476 provision keysync retry)

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.22.6"
+	Version = "0.22.7"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Bumps to 0.22.7. Ships #476 (runner provision retries the SSH probe across the keysync window → hands-off provisioning of fresh boxes). Tag v0.22.7 after merge to publish the containarium / mcp-server binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)