### PR TITLE
chore(release): bump to 0.22.8 (#478)

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.22.7"
+	Version = "0.22.8"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Cuts **v0.22.8**, shipping #478 (merged): runner provisioning grants the runner user passwordless sudo + clears stale ephemeral config before re-register.

After merge, tag `v0.22.8` triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)