### PR TITLE
chore(release): bump to 0.22.9 (#480)

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.22.8"
+	Version = "0.22.9"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Cuts **v0.22.9**, shipping #480 (RUNNER_DNS resolver pin). After merge, tag `v0.22.9` triggers the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)