### PR TITLE
fix(runner): provision SSHes as the daemon-assigned username, not the requested name

### DIFF
--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -114,6 +114,7 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 	for _, container := range resp.Containers {
 		info := incus.ContainerInfo{
 			Name:                 container.Name,
+			Username:             container.Username,
 			State:                container.State.String(),
 			MonitoringEnabled:    container.MonitoringEnabled,
 			AutoSleepEnabled:     container.AutoSleepEnabled,
@@ -177,8 +178,9 @@ func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, 
 	// Convert protobuf Container to incus.ContainerInfo
 	container := resp.Container
 	info := &incus.ContainerInfo{
-		Name:  container.Name,
-		State: container.State.String(),
+		Name:     container.Name,
+		Username: container.Username,
+		State:    container.State.String(),
 	}
 
 	if container.Network != nil {
@@ -394,6 +396,7 @@ func (c *GRPCClient) GetContainer(username string) (*incus.ContainerInfo, error)
 	container := resp.Container
 	info := &incus.ContainerInfo{
 		Name:                 container.Name,
+		Username:             container.Username,
 		State:                container.State.String(),
 		MonitoringEnabled:    container.MonitoringEnabled,
 		AutoSleepEnabled:     container.AutoSleepEnabled,

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -215,6 +215,7 @@ type systemInfo struct {
 func containerToIncusInfo(c *containerResponse) incus.ContainerInfo {
 	info := incus.ContainerInfo{
 		Name:                 c.Name,
+		Username:             c.Username,
 		State:                c.State,
 		Labels:               c.Labels,
 		MonitoringEnabled:    c.MonitoringEnabled,

--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -365,7 +365,7 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 			get:    httpClient.GetContainer,
 			delete: httpClient.DeleteContainer,
 		}
-		creator := func(_ context.Context, name, sshKey string) (string, error) {
+		creator := func(_ context.Context, name, sshKey string) (string, string, error) {
 			info, err := httpClient.CreateContainer(
 				name,
 				"images:ubuntu/24.04",
@@ -383,9 +383,9 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 				client.GitSourceOpts{}, // no git-source for runner boxes
 			)
 			if err != nil {
-				return "", err
+				return "", "", err
 			}
-			return info.Name, nil
+			return info.Name, info.Username, nil
 		}
 		return api, creator, nil
 	}
@@ -399,7 +399,7 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 		get:    grpcClient.GetContainer,
 		delete: grpcClient.DeleteContainer,
 	}
-	creator := func(_ context.Context, name, sshKey string) (string, error) {
+	creator := func(_ context.Context, name, sshKey string) (string, string, error) {
 		info, err := grpcClient.CreateContainer(
 			name,
 			"images:ubuntu/24.04",
@@ -417,9 +417,9 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 			client.GitSourceOpts{}, // no git-source for runner boxes
 		)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
-		return info.Name, nil
+		return info.Name, info.Username, nil
 	}
 	return api, creator, nil
 }

--- a/internal/mcp/runner_tools.go
+++ b/internal/mcp/runner_tools.go
@@ -186,7 +186,7 @@ func (a *mcpDaemonAPI) DeleteContainer(username string, force bool) error {
 // internal/runner with the same orchestrator.
 func buildMCPRunnerDeps(client *Client, sentinel, sshKeyPath string, withSSH bool) (runner.Deps, string, error) {
 	api := &mcpDaemonAPI{c: client}
-	creator := func(_ context.Context, name, sshPubKey string) (string, error) {
+	creator := func(_ context.Context, name, sshPubKey string) (string, string, error) {
 		req := CreateContainerRequest{
 			Username: name,
 			Resources: &ResourceLimits{
@@ -200,9 +200,11 @@ func buildMCPRunnerDeps(client *Client, sentinel, sshKeyPath string, withSSH boo
 		}
 		resp, err := client.CreateContainer(req)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
-		return resp.Container.Name, nil
+		// Return the daemon-assigned username (≠ requested name when a
+		// control plane mints one) so the install step SSHes as it. (#482)
+		return resp.Container.Name, resp.Container.Username, nil
 	}
 	boxes := runner.NewDaemonBoxManager(api, creator)
 

--- a/internal/runner/boxes.go
+++ b/internal/runner/boxes.go
@@ -23,10 +23,16 @@ type DaemonAPI interface {
 // DaemonCreator narrows down "the bit of the daemon client that
 // makes a new container." Real implementations have richer
 // signatures; we just need name + ssh key + a return of the box
-// ID. Done as a function shape so callers can curry their full
-// create call (with all the labels/cpu/etc baked in) into
-// something this package can drive.
-type DaemonCreator func(ctx context.Context, name, sshKey string) (boxID string, err error)
+// ID and the daemon-assigned SSH username. Done as a function shape
+// so callers can curry their full create call (with all the
+// labels/cpu/etc baked in) into something this package can drive.
+//
+// username is the login the daemon actually assigned to the box (which
+// may differ from the requested name — a control plane can mint a
+// generated username at create); it is what the daemon's SSH front
+// routes by, so the install step must SSH as it, not as name. Empty when
+// the daemon doesn't report one (then callers fall back to name).
+type DaemonCreator func(ctx context.Context, name, sshKey string) (boxID, username string, err error)
 
 // NewDaemonBoxManager wraps a (DaemonAPI, DaemonCreator) pair as
 // a BoxManager. The split lets callers reuse their existing
@@ -63,7 +69,7 @@ func (m *daemonBoxManager) Exists(_ context.Context, name string) (bool, error) 
 	return true, nil
 }
 
-func (m *daemonBoxManager) Create(ctx context.Context, name, sshKey string) (string, error) {
+func (m *daemonBoxManager) Create(ctx context.Context, name, sshKey string) (boxID, username string, err error) {
 	return m.create(ctx, name, sshKey)
 }
 

--- a/internal/runner/provision.go
+++ b/internal/runner/provision.go
@@ -146,6 +146,14 @@ type RunnerStatus struct {
 	// got a name.
 	BoxID string
 
+	// SSHUser is the login the daemon assigned to the box (which can
+	// differ from Name when a control plane mints a generated username).
+	// It's the handle the box is actually reachable/addressable by — the
+	// SSH/install steps use it, and callers need it to clean up a box
+	// whose requested name doesn't resolve. Falls back to Name when the
+	// daemon doesn't report a distinct username.
+	SSHUser string
+
 	// State is one of: "provisioned" (full success — box up,
 	// service installed, runner registered), "registering"
 	// (install succeeded, GitHub poll timed out — usually
@@ -189,8 +197,12 @@ type BoxManager interface {
 
 	// Create provisions a new box with the given name. The
 	// implementation supplies whatever sensible defaults the
-	// caller doesn't override (CPU/mem/disk, image, etc.).
-	Create(ctx context.Context, name, sshKey string) (boxID string, err error)
+	// caller doesn't override (CPU/mem/disk, image, etc.). It
+	// returns the box ID and the daemon-assigned SSH username,
+	// which may differ from name (a control plane can mint a
+	// generated username) and is what subsequent SSH/install steps
+	// must use. username is empty when the daemon doesn't report one.
+	Create(ctx context.Context, name, sshKey string) (boxID, username string, err error)
 
 	// Delete tears down the box. force is the same semantics as
 	// `containarium delete --force`.
@@ -390,6 +402,16 @@ func Provision(ctx context.Context, deps Deps, opts Options) (*Result, error) {
 func provisionOne(ctx context.Context, deps Deps, opts Options, name string) RunnerStatus {
 	st := RunnerStatus{Name: name}
 
+	// sshUser is the login the install step SSHes as. It defaults to the
+	// requested name (correct for OSS daemons, which use the name as the
+	// container username) but is overridden below by the daemon-assigned
+	// username from the create response when they differ: a control plane
+	// mints a generated username and its SSH front routes by THAT, not the
+	// requested name — so SSHing as name would always fail with
+	// [none publickey] and orphan the box. (#482)
+	sshUser := name
+	st.SSHUser = name
+
 	// Step 1+2: idempotent box create.
 	createCtx, cancelCreate := context.WithTimeout(ctx, opts.BoxCreateTimeout)
 	defer cancelCreate()
@@ -403,13 +425,17 @@ func provisionOne(ctx context.Context, deps Deps, opts Options, name string) Run
 	if exists {
 		st.BoxID = name // best-effort, the daemon's canonical ID may differ but matches in practice
 	} else {
-		boxID, err := deps.Boxes.Create(createCtx, name, opts.SSHKey)
+		boxID, username, err := deps.Boxes.Create(createCtx, name, opts.SSHKey)
 		if err != nil {
 			st.State = "failed"
 			st.LastError = fmt.Sprintf("create box: %v", err)
 			return st
 		}
 		st.BoxID = boxID
+		if username != "" {
+			sshUser = username
+			st.SSHUser = username
+		}
 	}
 
 	// Step 3+4: idempotent runner install.
@@ -420,7 +446,7 @@ func provisionOne(ctx context.Context, deps Deps, opts Options, name string) Run
 	// window — a fresh box is briefly unreachable (publickey/dial) before
 	// its key is live in sshpiper. Bounded by installCtx (InstallTimeout)
 	// and DefaultSSHReadyTimeout. (#475)
-	installed, err := waitForSSHInstalled(installCtx, deps.SSH, name, DefaultSSHReadyTimeout)
+	installed, err := waitForSSHInstalled(installCtx, deps.SSH, sshUser, DefaultSSHReadyTimeout)
 	if err != nil {
 		st.State = "failed"
 		st.LastError = fmt.Sprintf("check install state: %v", err)
@@ -439,7 +465,7 @@ func provisionOne(ctx context.Context, deps Deps, opts Options, name string) Run
 			"RUNNER_NAME":   name,
 			"RUNNER_LABELS": opts.Labels,
 		}
-		if err := deps.SSH.Install(installCtx, name, InstallScript, env); err != nil {
+		if err := deps.SSH.Install(installCtx, sshUser, InstallScript, env); err != nil {
 			st.State = "failed"
 			st.LastError = fmt.Sprintf("install runner: %v", err)
 			return st

--- a/internal/runner/provision_test.go
+++ b/internal/runner/provision_test.go
@@ -13,12 +13,16 @@ import (
 // fakeBoxes implements BoxManager. Tracks calls so tests can
 // assert on what the orchestrator did.
 type fakeBoxes struct {
-	mu       sync.Mutex
-	existing map[string]bool // box name -> already present
-	created  []string
-	deleted  []string
-	listOut  []string
+	mu         sync.Mutex
+	existing   map[string]bool // box name -> already present
+	created    []string
+	deleted    []string
+	listOut    []string
 	failCreate map[string]error
+	// assignUsername maps a requested name → the username the daemon
+	// "assigns" at create (≠ name), to exercise the control-plane case
+	// where SSH must target the assigned username, not the request. (#482)
+	assignUsername map[string]string
 }
 
 func (f *fakeBoxes) Exists(_ context.Context, name string) (bool, error) {
@@ -27,15 +31,22 @@ func (f *fakeBoxes) Exists(_ context.Context, name string) (bool, error) {
 	return f.existing[name], nil
 }
 
-func (f *fakeBoxes) Create(_ context.Context, name, _ string) (string, error) {
+func (f *fakeBoxes) Create(_ context.Context, name, _ string) (string, string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if err, ok := f.failCreate[name]; ok {
-		return "", err
+		return "", "", err
 	}
 	f.created = append(f.created, name)
 	f.existing[name] = true
-	return name, nil
+	// Default: the daemon uses the requested name as the username (OSS
+	// daemon behaviour). A test can override via assignUsername to model a
+	// control plane that mints a generated username at create. (#482)
+	username := name
+	if u, ok := f.assignUsername[name]; ok {
+		username = u
+	}
+	return name, username, nil
 }
 
 func (f *fakeBoxes) Delete(_ context.Context, name string, _ bool) error {
@@ -54,11 +65,11 @@ func (f *fakeBoxes) List(_ context.Context) ([]string, error) {
 // got an install call and lets tests pre-seed "already installed"
 // status to exercise the idempotent path.
 type fakeInstaller struct {
-	mu             sync.Mutex
+	mu               sync.Mutex
 	alreadyInstalled map[string]bool
-	installed      []string
-	failInstall    map[string]error
-	gotEnv         map[string]map[string]string
+	installed        []string
+	failInstall      map[string]error
+	gotEnv           map[string]map[string]string
 }
 
 func (f *fakeInstaller) IsInstalled(_ context.Context, name string) (bool, error) {
@@ -132,8 +143,8 @@ func (f *fakeGitHub) RemoveRunner(_ context.Context, _, _ string, id int64) erro
 // fakeClock advances on each Sleep so tests don't actually pause
 // and the registration loop hits its deadline deterministically.
 type fakeClock struct {
-	now      time.Time
-	sleeps   []time.Duration
+	now    time.Time
+	sleeps []time.Duration
 }
 
 func newFakeClock() *fakeClock {
@@ -293,6 +304,70 @@ func TestProvisionHappyPath(t *testing.T) {
 	}
 	if installer.gotEnv["ci-runner-2"]["RUNNER_NAME"] != "ci-runner-2" {
 		t.Errorf("RUNNER_NAME mismatch: %+v", installer.gotEnv["ci-runner-2"])
+	}
+}
+
+// TestProvision_UsesAssignedUsernameForSSH_482 verifies that when the
+// daemon assigns a container username different from the requested name
+// (a control plane minting a generated username at create), the SSH
+// install step targets the ASSIGNED username — not the requested name.
+// SSHing as the requested name fails [none publickey] and orphans the
+// box. RUNNER_NAME and the GitHub-registration poll keep the requested
+// name. (#482)
+func TestProvision_UsesAssignedUsernameForSSH_482(t *testing.T) {
+	const requested = "ci-runner-1"
+	const assigned = "assigned-7f3a2b" // daemon-minted username, ≠ requested
+	boxes := &fakeBoxes{
+		existing:       map[string]bool{},
+		assignUsername: map[string]string{requested: assigned},
+	}
+	installer := &fakeInstaller{alreadyInstalled: map[string]bool{}}
+	// Registration polls by the requested name (the GitHub runner name).
+	gh := &fakeGitHub{registerOnAttempt: map[string]int{requested: 1}}
+	clock := newFakeClock()
+
+	res, err := Provision(context.Background(), Deps{
+		Boxes: boxes, SSH: installer, GitHub: gh, Clock: clock,
+	}, Options{
+		Repo:       "footprintai/containarium",
+		PAT:        "ghp_test",
+		Count:      1,
+		NamePrefix: "ci-runner",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Runners) != 1 {
+		t.Fatalf("expected 1 runner, got %d", len(res.Runners))
+	}
+	r := res.Runners[0]
+	if r.State != "provisioned" {
+		t.Fatalf("expected provisioned, got %s (err=%s)", r.State, r.LastError)
+	}
+
+	// The whole bug: the install must run against the ASSIGNED username,
+	// never the requested name.
+	if len(installer.installed) != 1 || installer.installed[0] != assigned {
+		t.Fatalf("install target = %v, want SSH as assigned username %q (not requested %q)",
+			installer.installed, assigned, requested)
+	}
+	if _, leaked := installer.gotEnv[requested]; leaked {
+		t.Errorf("install was attempted against the requested name %q — must never SSH as it", requested)
+	}
+
+	// Identity surfaced for cleanup: SSHUser is the assigned username; the
+	// runner is still named after the request.
+	if r.SSHUser != assigned {
+		t.Errorf("RunnerStatus.SSHUser = %q, want %q", r.SSHUser, assigned)
+	}
+	if r.Name != requested {
+		t.Errorf("RunnerStatus.Name = %q, want %q", r.Name, requested)
+	}
+
+	// RUNNER_NAME (the GitHub runner name) keeps the requested name even
+	// though SSH targeted the assigned username.
+	if got := installer.gotEnv[assigned]["RUNNER_NAME"]; got != requested {
+		t.Errorf("RUNNER_NAME env = %q, want %q", got, requested)
 	}
 }
 
@@ -597,7 +672,7 @@ func TestRemove_DeregistersAndDeletes(t *testing.T) {
 func TestRemove_GitHubFailureDoesNotBlockBoxDelete(t *testing.T) {
 	boxes := &fakeBoxes{existing: map[string]bool{"ci-runner-1": true}}
 	gh := &fakeGitHub{
-		listed:  []string{"ci-runner-1"},
+		listed:    []string{"ci-runner-1"},
 		removeErr: errors.New("github 500"),
 	}
 

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -262,7 +262,13 @@ func (r Role) IsCoreRole() bool {
 
 // ContainerInfo holds information about a container
 type ContainerInfo struct {
-	Name         string
+	Name string
+	// Username is the SSH login the daemon assigned to this container. It
+	// may differ from the requested name (e.g. a control plane that mints a
+	// generated username at create time), and it's what the daemon's SSH
+	// front routes by — so callers doing SSH/install must use this, not the
+	// requested name. Empty when the daemon doesn't report it.
+	Username     string
 	State        string
 	IPAddress    string
 	CPU          string


### PR DESCRIPTION
Fixes #482.

## Problem
`runner provision` (and the MCP `provision_runners` wrapper) assumed the box's SSH username equals the **requested** name. When the daemon assigns a different username at create — a control plane can mint a generated one (the response already carries it, #250) — the install-over-SSH step connects as the wrong user → `[none publickey]` → runner never installs → box orphaned (addressable only by the requested name).

## Fix
- **Surface the assigned login**: add `ContainerInfo.Username`; populate it in the HTTP + gRPC clients (the wire/proto already carries `username` — it was dropped in the struct mapping).
- **Thread it through**: `DaemonCreator` / `BoxManager.Create` now return `(boxID, username)`; updated the two `cmd` creators and the MCP creator.
- **Use it**: `provisionOne` SSHes (probe + install) as the assigned username, falling back to the requested name when the daemon reports none — so OSS daemons (where `name == username`) are unchanged. `RUNNER_NAME` and the GitHub-registration poll keep the requested name.
- **Surface for cleanup**: `RunnerStatus.SSHUser` carries the real login so callers can address/delete a box whose requested name doesn't resolve.

## Test
`TestProvision_UsesAssignedUsernameForSSH_482` — when the daemon assigns a distinct username, the install targets it (never the requested name) and `RUNNER_NAME` stays the request. All existing runner/client/mcp/cmd tests green; `go build ./...` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
