### PR TITLE
chore(release): bump to 0.22.10 (#483)

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.22.9"
+	Version = "0.22.10"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Cuts **v0.22.10**, shipping #483 (runner provision uses the daemon-assigned username for SSH/install, fixing #482). After merge, tag `v0.22.10` triggers the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
