### PR TITLE
docs(readme): add "In the wild" section with first live-demo entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,20 @@ and your data on your infra.
 
 ---
 
+## In the wild
+
+Where Containarium has been demonstrated live:
+
+- **2026-06-04 — AI Agent Night, Taipei.** When the grand-prize
+  giveaway (a custom vibe-keyboard) hit a snag — the event had no way
+  to run the lucky draw — we fired up Containarium and vibe-coded a
+  lucky-draw picker on the spot to save the giveaway. Still live:
+  [lucky-draw.demo.containarium.dev](https://lucky-draw.demo.containarium.dev/).
+
+Demoed Containarium somewhere? Open a PR and add it here.
+
+---
+
 ## Status
 
 - **Production-deployed** on GCP (multi-region) and bare-metal GPU


### PR DESCRIPTION
## What

Adds an **In the wild** section to the README, right after "Use cases", recording where Containarium has been demonstrated live.

First entry: **AI Agent Night, Taipei (2026-06-04)** — when the grand-prize giveaway hit a snag (no way to run the lucky draw), we fired up Containarium and vibe-coded a lucky-draw picker on the spot. Live app linked.

The section ends with an invitation for PRs adding future demos.

## Notes

- Docs-only change; no code touched.
- Anonymized per the repo's OSS-visibility convention (no internal hostnames/tenant names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)