### PR TITLE
feat(runner): system-wide runner cap + reconcile controller

### DIFF
--- a/internal/cmd/runner_reconcile.go
+++ b/internal/cmd/runner_reconcile.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/footprintai/containarium/internal/runner"
+	"github.com/spf13/cobra"
+)
+
+// Flags specific to `containarium runner reconcile`.
+var (
+	runnerMaxTotal         int
+	runnerReconcileDesired int
+	runnerReconcilePoll    time.Duration
+)
+
+var runnerReconcileCmd = &cobra.Command{
+	Use:   "reconcile <repo>",
+	Short: "Keep a capped pool of ephemeral runners topped up (standalone controller)",
+	Long: `Run a long-lived controller that keeps the runner fleet for <repo> at a
+target size without ever exceeding the system-wide cap.
+
+This is the "queue the rest" half of runner capacity management. Each tick
+it counts the live runner boxes (names starting with --name-prefix) and, if
+the fleet is below the target, provisions the difference — but the
+provisioning path enforces --max-total, so the fleet never grows past the
+cap. Jobs beyond the cap simply wait in GitHub's own queue until an
+ephemeral runner finishes and frees a slot, at which point the next tick
+tops the pool back up.
+
+It is STATELESS: the desired state is re-derived from reality every tick, so
+the controller can be killed and restarted at any time with no bookkeeping
+to lose. Run it under systemd / a process supervisor.
+
+Unlike folding this into the daemon, the controller authenticates as an
+ordinary client (the same --server / token path as every other CLI verb),
+so no GitHub PAT or privileged auth context has to live inside the daemon.
+
+Examples:
+  # Keep up to 20 runners warm for the repo (cap = 20), poll every 15s
+  containarium runner reconcile footprintai/containarium \
+      --github-pat ghp_xxxx --sentinel sentinel.example.com:22 \
+      --max-total 20
+
+  # Keep a small warm pool of 5 (cap stays at 20), poll every 30s
+  containarium runner reconcile footprintai/containarium \
+      --github-pat ghp_xxxx --sentinel sentinel.example.com:22 \
+      --max-total 20 --desired 5 --poll 30s`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRunnerReconcile,
+}
+
+func init() {
+	runnerCmd.AddCommand(runnerReconcileCmd)
+
+	runnerReconcileCmd.Flags().StringVar(&runnerPAT, "github-pat", os.Getenv("GH_PAT"), "GitHub PAT with `repo` scope (env: GH_PAT). REQUIRED.")
+	runnerReconcileCmd.Flags().StringVar(&runnerSentinelHost, "sentinel", os.Getenv("CONTAINARIUM_SENTINEL_HOST"), "Sentinel SSH host (env: CONTAINARIUM_SENTINEL_HOST). REQUIRED for the install step.")
+	runnerReconcileCmd.Flags().StringVar(&runnerSSHUser, "ssh-user", "", "SSH user when SSH'ing into a runner box (default: the runner name, via sshpiper)")
+	runnerReconcileCmd.Flags().StringVar(&runnerSSHKeyPath, "ssh-key", "", "Path to SSH public key used when creating new boxes (default: ~/.ssh/id_rsa.pub)")
+	runnerReconcileCmd.Flags().StringVar(&runnerNamePrefix, "name-prefix", "ci-runner", "Prefix for generated box names (also the count filter)")
+	runnerReconcileCmd.Flags().StringVar(&runnerLabels, "labels", "containarium,ephemeral", "Comma-separated runner labels")
+	runnerReconcileCmd.Flags().StringVar(&runnerNameTemplate, "runner-name-template", "{prefix}-{i}", "Template for box names; {prefix} and {i} are substituted")
+	runnerReconcileCmd.Flags().IntVar(&runnerMaxTotal, "max-total", 0, "System-wide cap on concurrent runner boxes (0 = env MAX_RUNNERS_TOTAL or built-in default)")
+	runnerReconcileCmd.Flags().IntVar(&runnerReconcileDesired, "desired", 0, "Target warm-pool size to maintain, capped by --max-total (0 = maintain at the cap)")
+	runnerReconcileCmd.Flags().DurationVar(&runnerReconcilePoll, "poll", 15*time.Second, "How often to reconcile the fleet")
+}
+
+func runRunnerReconcile(_ *cobra.Command, args []string) error {
+	repo := args[0]
+
+	// Resolve the cap once for the validation/logging banner; the
+	// per-tick provisioning re-resolves it (so a changed
+	// MAX_RUNNERS_TOTAL is picked up live) by passing MaxTotal
+	// through Options.
+	capTotal := runnerMaxTotal
+	if capTotal <= 0 {
+		capTotal = runner.MaxRunnersTotal()
+	}
+	target := runnerReconcileDesired
+	if target <= 0 || target > capTotal {
+		// Default to "maintain at the cap"; also clamp a target that
+		// was set above the cap (the cap always wins).
+		target = capTotal
+	}
+	if runnerReconcilePoll <= 0 {
+		return fmt.Errorf("--poll must be > 0")
+	}
+
+	// Validate the provision inputs up front using the same checks
+	// the one-shot provision verb uses (repo shape, PAT present).
+	if err := runner.ValidateOptions(runner.Options{Repo: repo, PAT: runnerPAT, Count: 1}); err != nil {
+		return err
+	}
+	if runnerSentinelHost == "" {
+		return fmt.Errorf("--sentinel is required (or set CONTAINARIUM_SENTINEL_HOST); the install step needs to SSH into each new box")
+	}
+
+	deps, sshKey, err := buildRunnerDeps(runnerSentinelHost, runnerSSHUser)
+	if err != nil {
+		return err
+	}
+
+	// Stop cleanly on SIGINT/SIGTERM so a supervisor restart doesn't
+	// leave a half-finished provision; in-flight Provision calls run
+	// to completion because we only check ctx between ticks.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	fmt.Printf("runner reconcile: repo=%s target=%d cap=%d poll=%s prefix=%q\n",
+		repo, target, capTotal, runnerReconcilePoll, runnerNamePrefix)
+	fmt.Println("watching fleet — Ctrl-C to stop")
+
+	// Reconcile once immediately so an operator sees action without
+	// waiting a full poll interval, then on the ticker.
+	reconcileOnce(ctx, deps, repo, sshKey, target)
+
+	t := time.NewTicker(runnerReconcilePoll)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("\nstopping reconcile loop")
+			return nil
+		case <-t.C:
+			reconcileOnce(ctx, deps, repo, sshKey, target)
+		}
+	}
+}
+
+// reconcileOnce is one maintain pass: count the live fleet and, if
+// below target, provision the difference. Provision itself enforces
+// the system-wide cap (MaxTotal), so even a stale/oversized target
+// can never push the fleet past the ceiling. Errors are logged and
+// the loop continues — a transient daemon/GitHub blip shouldn't kill
+// the controller.
+func reconcileOnce(ctx context.Context, deps runner.Deps, repo, sshKey string, target int) {
+	live, err := runner.CountLiveRunners(ctx, deps, runnerNamePrefix)
+	if err != nil {
+		fmt.Printf("  [reconcile] count live runners: %v (skipping)\n", err)
+		return
+	}
+	need := target - live
+	if need <= 0 {
+		return // fleet at/above target; ephemeral runners self-remove after jobs
+	}
+
+	res, err := runner.Provision(ctx, deps, runner.Options{
+		Repo:         repo,
+		PAT:          runnerPAT,
+		Count:        need,
+		NamePrefix:   runnerNamePrefix,
+		Labels:       runnerLabels,
+		NameTemplate: runnerNameTemplate,
+		SSHKey:       sshKey,
+		MaxTotal:     runnerMaxTotal, // 0 → runner.MaxRunnersTotal()
+	})
+	if err != nil {
+		fmt.Printf("  [reconcile] provision: %v\n", err)
+		return
+	}
+	created := 0
+	for _, r := range res.Runners {
+		switch r.State {
+		case "provisioned", "registering", "exists":
+			created++
+		}
+	}
+	fmt.Printf("  [reconcile] live=%d target=%d → provisioned %d (deferred=%d)\n",
+		live, target, created, res.Deferred)
+}

--- a/internal/runner/cap.go
+++ b/internal/runner/cap.go
@@ -1,0 +1,71 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// DefaultMaxRunnersTotal is the system-wide ceiling on how many
+// runner boxes may exist at once, used when MAX_RUNNERS_TOTAL is
+// unset/invalid. 20 is comfortably above a typical CI fan-out,
+// well under the per-call MaxRunnerCount=100 sanity bound, and
+// small enough to protect the cloud bill if an autoscaler (or an
+// agent) keeps asking for more. Unlike MaxRunnerCount — which
+// bounds a SINGLE provision call — this bounds the WHOLE fleet
+// across every caller (CLI, MCP, the daemon reconciler).
+const DefaultMaxRunnersTotal = 20
+
+// MaxRunnersTotal resolves the system-wide runner ceiling. It
+// reads MAX_RUNNERS_TOTAL from the environment and falls back to
+// DefaultMaxRunnersTotal when the var is unset, unparseable, or
+// non-positive. Kept as a function (not a package var) so a value
+// change picks up without a process restart and so tests can flip
+// it with t.Setenv.
+func MaxRunnersTotal() int {
+	raw := strings.TrimSpace(os.Getenv("MAX_RUNNERS_TOTAL"))
+	if raw == "" {
+		return DefaultMaxRunnersTotal
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		// A typo'd/garbage value should fail safe to the default
+		// rather than disable the cap (n<=0) or crash.
+		return DefaultMaxRunnersTotal
+	}
+	return n
+}
+
+// CountLiveRunners reports how many runner boxes currently exist on
+// the daemon — the capacity signal the cap is enforced against. We
+// count BOXES (via deps.Boxes.List) rather than GitHub-registered
+// runners on purpose: a box counts against the cap the moment it
+// exists (that's what's billed), even before it registers with
+// GitHub and after it finishes a job but before teardown. GitHub's
+// registered view lags box lifecycle in both directions, so it's
+// the wrong primary gate.
+//
+// namePrefix defaults to "ci-runner" — the same default Provision
+// uses — and only boxes whose name starts with it are counted, so
+// non-runner containers never consume runner headroom.
+func CountLiveRunners(ctx context.Context, deps Deps, namePrefix string) (int, error) {
+	if namePrefix == "" {
+		namePrefix = "ci-runner"
+	}
+	if deps.Boxes == nil {
+		return 0, fmt.Errorf("internal error: CountLiveRunners called with nil Boxes")
+	}
+	names, err := deps.Boxes.List(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("count live runners: %w", err)
+	}
+	n := 0
+	for _, name := range names {
+		if strings.HasPrefix(name, namePrefix) {
+			n++
+		}
+	}
+	return n, nil
+}

--- a/internal/runner/cap_test.go
+++ b/internal/runner/cap_test.go
@@ -1,0 +1,215 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// -----------------------------------------------------------------
+// MaxRunnersTotal env parsing
+// -----------------------------------------------------------------
+
+func TestMaxRunnersTotal(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		set  bool
+		want int
+	}{
+		{"unset -> default", "", false, DefaultMaxRunnersTotal},
+		{"empty -> default", "", true, DefaultMaxRunnersTotal},
+		{"valid", "7", true, 7},
+		{"whitespace", "  12 ", true, 12},
+		{"garbage -> default", "abc", true, DefaultMaxRunnersTotal},
+		{"zero -> default", "0", true, DefaultMaxRunnersTotal},
+		{"negative -> default", "-5", true, DefaultMaxRunnersTotal},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("MAX_RUNNERS_TOTAL", tc.env)
+			} else {
+				// Ensure no ambient value leaks in.
+				t.Setenv("MAX_RUNNERS_TOTAL", "")
+			}
+			if got := MaxRunnersTotal(); got != tc.want {
+				t.Errorf("MaxRunnersTotal() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------
+// CountLiveRunners
+// -----------------------------------------------------------------
+
+func TestCountLiveRunners(t *testing.T) {
+	boxes := &fakeBoxes{
+		listOut: []string{"ci-runner-1", "ci-runner-2", "alice", "bob", "ci-runner-x"},
+	}
+	n, err := CountLiveRunners(context.Background(), Deps{Boxes: boxes}, "ci-runner")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("expected 3 ci-runner* boxes, got %d", n)
+	}
+
+	// Empty prefix falls back to the default "ci-runner".
+	n, err = CountLiveRunners(context.Background(), Deps{Boxes: boxes}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("default-prefix count expected 3, got %d", n)
+	}
+}
+
+// -----------------------------------------------------------------
+// Provision cap enforcement
+// -----------------------------------------------------------------
+
+// helper: build deps whose box listing reports `existing` live
+// runner boxes (names that do NOT collide with the ones Provision
+// will generate, so the requested runners are all net-new).
+func capDeps(liveNames []string) (Deps, *fakeBoxes) {
+	boxes := &fakeBoxes{existing: map[string]bool{}, listOut: liveNames}
+	return Deps{
+		Boxes:  boxes,
+		SSH:    &fakeInstaller{alreadyInstalled: map[string]bool{}},
+		GitHub: &fakeGitHub{registerOnAttempt: map[string]int{}},
+		Clock:  newFakeClock(),
+	}, boxes
+}
+
+func filledNames(prefix string, n int) []string {
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		// Names distinct from the generated "ci-runner-<i>" set so
+		// requested runners are net-new (use a letter suffix).
+		out = append(out, fmt.Sprintf("%s-x%d", prefix, i))
+	}
+	return out
+}
+
+func TestProvisionRespectsCap_ClampsToHeadroom(t *testing.T) {
+	// 18 live runner boxes, cap 20 → headroom 2. Request 5 → 2
+	// created, 3 deferred/queued.
+	deps, boxes := capDeps(filledNames("ci-runner", 18))
+	opts := Options{
+		Repo:                "owner/repo",
+		PAT:                 "ghp_x",
+		Count:               5,
+		MaxTotal:            20,
+		RegistrationTimeout: 1 * time.Second,
+	}
+	res, err := Provision(context.Background(), deps, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Deferred != 3 {
+		t.Errorf("expected Deferred=3, got %d", res.Deferred)
+	}
+	if res.PartialFailure {
+		t.Errorf("deferral is backpressure, must not set PartialFailure")
+	}
+	if len(boxes.created) != 2 {
+		t.Errorf("expected exactly 2 boxes created (headroom), got %d (%v)", len(boxes.created), boxes.created)
+	}
+	queued := 0
+	for _, r := range res.Runners {
+		if r.State == "queued" {
+			queued++
+		}
+	}
+	if queued != 3 {
+		t.Errorf("expected 3 queued rows, got %d", queued)
+	}
+}
+
+func TestProvisionAtCap_DefersAllNotError(t *testing.T) {
+	// Already at the ceiling → zero creates, all requested deferred,
+	// no Go error, no PartialFailure.
+	deps, boxes := capDeps(filledNames("ci-runner", 20))
+	opts := Options{
+		Repo:                "owner/repo",
+		PAT:                 "ghp_x",
+		Count:               3,
+		MaxTotal:            20,
+		RegistrationTimeout: 1 * time.Second,
+	}
+	res, err := Provision(context.Background(), deps, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(boxes.created) != 0 {
+		t.Errorf("expected zero creates at cap, got %d", len(boxes.created))
+	}
+	if res.Deferred != 3 {
+		t.Errorf("expected Deferred=3, got %d", res.Deferred)
+	}
+	if res.PartialFailure {
+		t.Errorf("at-cap is not a failure")
+	}
+	for _, r := range res.Runners {
+		if r.State != "queued" {
+			t.Errorf("expected all rows queued, got %s for %s", r.State, r.Name)
+		}
+	}
+}
+
+func TestProvisionCapIgnoresNonPrefixBoxes(t *testing.T) {
+	// 19 non-runner boxes + 1 runner box, cap 20. Only the single
+	// ci-runner* box counts → headroom 19. Request 3 → all created.
+	live := append([]string{"ci-runner-x0"}, filledNamesPlain("tenant", 19)...)
+	deps, boxes := capDeps(live)
+	opts := Options{
+		Repo:                "owner/repo",
+		PAT:                 "ghp_x",
+		Count:               3,
+		MaxTotal:            20,
+		RegistrationTimeout: 1 * time.Second,
+	}
+	res, err := Provision(context.Background(), deps, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Deferred != 0 {
+		t.Errorf("non-runner boxes must not consume headroom; Deferred=%d", res.Deferred)
+	}
+	if len(boxes.created) != 3 {
+		t.Errorf("expected 3 creates, got %d", len(boxes.created))
+	}
+}
+
+func filledNamesPlain(prefix string, n int) []string {
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, fmt.Sprintf("%s-%d", prefix, i))
+	}
+	return out
+}
+
+func TestProvisionCapDefaultsFromEnv(t *testing.T) {
+	// With MaxTotal unset on Options, applyDefaults pulls the env.
+	t.Setenv("MAX_RUNNERS_TOTAL", "1")
+	deps, boxes := capDeps(nil)
+	opts := Options{
+		Repo:                "owner/repo",
+		PAT:                 "ghp_x",
+		Count:               3, // env cap of 1 → only 1 created
+		RegistrationTimeout: 1 * time.Second,
+	}
+	res, err := Provision(context.Background(), deps, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(boxes.created) != 1 {
+		t.Errorf("expected 1 create under env cap of 1, got %d", len(boxes.created))
+	}
+	if res.Deferred != 2 {
+		t.Errorf("expected Deferred=2, got %d", res.Deferred)
+	}
+}

--- a/internal/runner/provision.go
+++ b/internal/runner/provision.go
@@ -130,6 +130,17 @@ type Options struct {
 	BoxCreateTimeout    time.Duration
 	InstallTimeout      time.Duration
 	RegistrationTimeout time.Duration
+
+	// MaxTotal is the system-wide ceiling on how many runner boxes
+	// (names matching NamePrefix) may exist at once, across every
+	// caller. Provision counts the live fleet and creates at most
+	// (MaxTotal - live) net-new boxes; the remainder of a request is
+	// DEFERRED (returned as "queued" rows, see Result.Deferred) rather
+	// than failed — the jobs wait in GitHub's queue until an ephemeral
+	// runner frees a slot. Zero falls back to MaxRunnersTotal() (env
+	// MAX_RUNNERS_TOTAL or DefaultMaxRunnersTotal). Distinct from
+	// MaxRunnerCount, which bounds a single call's Count.
+	MaxTotal int
 }
 
 // RunnerStatus is the per-runner outcome shape returned by
@@ -174,6 +185,15 @@ type RunnerStatus struct {
 type Result struct {
 	Runners        []RunnerStatus
 	PartialFailure bool
+
+	// Deferred is how many of the requested runners were NOT created
+	// because doing so would exceed Options.MaxTotal. These appear in
+	// Runners with State "queued". Deferral is backpressure, not
+	// failure: it never sets PartialFailure and Provision returns a
+	// nil error. The deferred jobs wait in GitHub's own queue until an
+	// ephemeral runner finishes and a `runner reconcile` tick (or the
+	// next provision call) tops the pool back up.
+	Deferred int
 }
 
 // BoxManager abstracts the create/exists/delete operations on
@@ -321,6 +341,9 @@ func applyDefaults(opts Options) Options {
 	if opts.RegistrationTimeout == 0 {
 		opts.RegistrationTimeout = DefaultRegistrationTimeout
 	}
+	if opts.MaxTotal <= 0 {
+		opts.MaxTotal = MaxRunnersTotal()
+	}
 	return opts
 }
 
@@ -371,8 +394,29 @@ func Provision(ctx context.Context, deps Deps, opts Options) (*Result, error) {
 		Runners: make([]RunnerStatus, 0, opts.Count),
 	}
 
+	// Enforce the system-wide cap. Count the live runner fleet (boxes
+	// matching NamePrefix — the same signal the cap is billed against)
+	// and create at most (MaxTotal - live) net-new boxes this call.
+	// Anything beyond headroom is DEFERRED, not failed: it comes back
+	// as a "queued" row so the caller (notably `runner reconcile`)
+	// knows the job is waiting on GitHub's queue, not broken.
+	live, err := CountLiveRunners(ctx, deps, opts.NamePrefix)
+	if err != nil {
+		return nil, err
+	}
+	headroom := opts.MaxTotal - live
+	if headroom < 0 {
+		headroom = 0
+	}
+
 	for i := 1; i <= opts.Count; i++ {
 		name := RenderName(opts.NameTemplate, opts.NamePrefix, i)
+		if i > headroom {
+			// Past the cap — queue rather than create.
+			res.Runners = append(res.Runners, RunnerStatus{Name: name, State: "queued"})
+			res.Deferred++
+			continue
+		}
 		status := provisionOne(ctx, deps, opts, name)
 		if status.State == "failed" {
 			res.PartialFailure = true

--- a/internal/runner/provision_test.go
+++ b/internal/runner/provision_test.go
@@ -661,6 +661,9 @@ func TestEmbeddedInstallScriptNonEmpty(t *testing.T) {
 // -----------------------------------------------------------------
 
 func TestApplyDefaults(t *testing.T) {
+	// Force the cap to its built-in default regardless of the ambient
+	// environment so MaxTotal is deterministic.
+	t.Setenv("MAX_RUNNERS_TOTAL", "")
 	got := applyDefaults(Options{Repo: "owner/repo", PAT: "x", Count: 1})
 	want := Options{
 		Repo:                "owner/repo",
@@ -672,6 +675,7 @@ func TestApplyDefaults(t *testing.T) {
 		BoxCreateTimeout:    DefaultBoxCreateTimeout,
 		InstallTimeout:      DefaultInstallTimeout,
 		RegistrationTimeout: DefaultRegistrationTimeout,
+		MaxTotal:            DefaultMaxRunnersTotal,
 	}
 	if got != want {
 		t.Errorf("applyDefaults mismatch:\n  got:  %+v\n  want: %+v", got, want)


### PR DESCRIPTION
## Summary

Enforce a fleet-wide ceiling on ephemeral GitHub Actions runner boxes so a CI fan-out (or an agent) can't push past the cloud-bill ceiling. The cap is billed against live **boxes** matching the name prefix — not GitHub's lagging registered view, which trails box lifecycle in both directions.

- **`Options.MaxTotal`** — per-call ceiling; when `0`, defaults to `MaxRunnersTotal()` = env `MAX_RUNNERS_TOTAL` or `DefaultMaxRunnersTotal` (20). Distinct from `MaxRunnerCount`, which bounds a single call's `Count`.
- **`Provision`** counts the live fleet (`CountLiveRunners` by prefix), creates at most `MaxTotal - live` net-new boxes, and **defers** the remainder as `"queued"` rows. Deferral is backpressure, not failure: `Result.Deferred` carries the count, it never sets `PartialFailure`, and no Go error is returned — the jobs wait in GitHub's own queue until an ephemeral runner frees a slot.
- **`containarium runner reconcile <repo>`** — a stateless, supervisor-run controller that re-derives desired state each tick and tops the pool back up to target without exceeding the cap. Authenticates as an ordinary client (no PAT / privileged context inside the daemon).

`cap.go` (`MaxRunnersTotal`/`CountLiveRunners`) and `cap_test.go` lock the behavior down; `provision.go` wires the clamp into the existing orchestration loop.

## Test plan
- `go build ./...` ✅
- `go test ./internal/runner/` ✅ — incl. the 4 cap tests (clamp-to-headroom, defer-all-at-cap, ignore-non-prefix-boxes, env-default) and the updated `TestApplyDefaults`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)