### PR TITLE
feat(secrets): add AWS KMS envelope-encryption backend

### DIFF
--- a/docs/security/OPERATOR-SECURITY-RUNBOOK.md
+++ b/docs/security/OPERATOR-SECURITY-RUNBOOK.md
@@ -423,6 +423,7 @@ Pick a backend via `CONTAINARIUM_KMS_BACKEND`. Supported:
 | `inproc`   | In-process wrap under the master key. Dev/test mostly — protection level is unchanged from legacy, but it writes envelope-shaped rows so a future cutover to a real KMS doesn't re-touch every row. |
 | `vault`    | Vault Transit secret engine over HTTP. See setup below. |
 | `gcp`      | Google Cloud KMS via the REST API. See setup below. |
+| `aws`      | AWS KMS via the REST API (SigV4-signed). See setup below. |
 
 ### Vault Transit setup
 
@@ -643,6 +644,82 @@ version is baked into the ciphertext); Cloud KMS
 transparently decrypts under whichever version each row
 was wrapped against. To force re-wrap under the new
 primary:
+
+```bash
+containarium secrets migrate-to-envelope
+```
+
+### AWS KMS setup
+
+```bash
+# 1. Create a symmetric KMS key and a friendly alias. The
+#    key never leaves AWS; the daemon only ever calls
+#    Encrypt/Decrypt against it.
+KEY_ID=$(aws kms create-key \
+    --description "containarium secrets KEK" \
+    --query KeyMetadata.KeyId --output text)
+aws kms create-alias \
+    --alias-name alias/containarium-secrets \
+    --target-key-id "$KEY_ID"
+
+# 2. Grant the daemon's IAM principal the narrowest policy:
+#    kms:Encrypt + kms:Decrypt against THIS key only (not a
+#    wildcard resource — the blast radius matters). Attach
+#    to the IAM user / role the daemon runs as, e.g.:
+#    {
+#      "Effect": "Allow",
+#      "Action": ["kms:Encrypt", "kms:Decrypt"],
+#      "Resource": "arn:aws:kms:us-west-2:<acct>:key/<KEY_ID>"
+#    }
+
+# 3. Deliver credentials. The daemon signs requests with
+#    SigV4 from an access-key / secret pair (+ optional
+#    session token for STS temp creds). The secret is the
+#    sensitive part — keep it 0600 and out of the env where
+#    practical:
+#
+#    On EC2/EKS, an IRSA or IMDS sidecar refreshes temp creds
+#    into files the daemon reads:
+#      aws sts assume-role ... | jq -r .Credentials.SecretAccessKey \
+#        | sudo install -m 0600 /dev/stdin /etc/containarium/aws-kms.secret
+#      (and likewise the SessionToken file)
+#    Off-cloud: a static IAM user's secret in the file, no
+#    session token.
+
+# 4. Configure the daemon. Add to systemd Environment=:
+CONTAINARIUM_KMS_BACKEND=aws
+CONTAINARIUM_AWS_KMS_REGION=us-west-2
+CONTAINARIUM_AWS_KMS_KEY_ID=alias/containarium-secrets
+CONTAINARIUM_AWS_ACCESS_KEY_ID=AKIA...
+CONTAINARIUM_AWS_SECRET_ACCESS_KEY_FILE=/etc/containarium/aws-kms.secret
+# Optional: CONTAINARIUM_AWS_SESSION_TOKEN_FILE=/etc/containarium/aws-kms.session
+#           (required when the access key is an STS temp cred)
+# Optional: CONTAINARIUM_AWS_KMS_ENDPOINT (override for a
+#           VPC endpoint / air-gapped deployment).
+# Optional: CONTAINARIUM_AWS_KMS_TIMEOUT=5s
+
+# 5. Restart the daemon. Confirm the startup log shows:
+#    Secrets store ready (file-keyed AES-256-GCM, envelope: aws kms (region=... key=...))
+sudo systemctl restart containarium
+```
+
+Migration and Phase E retirement work the same as the Vault
+and GCP paths — `containarium secrets migrate-to-envelope`
+re-wraps legacy rows under the AWS KEK; `envelope-coverage`
+reports progress; `CONTAINARIUM_REQUIRE_ENVELOPE=true`
+rejects any remaining legacy rows.
+
+### Rotating the AWS KMS key
+
+```bash
+# Enable annual automatic rotation (recommended):
+aws kms enable-key-rotation --key-id alias/containarium-secrets
+```
+
+Existing wrapped DEKs reference the prior key material (the
+version is baked into the CiphertextBlob); AWS KMS
+transparently decrypts under whichever backing key each row
+was wrapped against. To force re-wrap under the new primary:
 
 ```bash
 containarium secrets migrate-to-envelope

--- a/pkg/core/secrets/kms_aws.go
+++ b/pkg/core/secrets/kms_aws.go
@@ -1,0 +1,385 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Phase 4.1 Phase-C — AWS KMS implementation of KMSClient.
+// Audit C-HIGH-6.
+//
+// AWS KMS exposes Encrypt / Decrypt JSON actions on a
+// single regional endpoint; the named key (id, ARN, or
+// alias) is the KEK. The key material never leaves AWS's
+// HSM-backed boundary — the daemon submits the plaintext
+// DEK (base64) and gets back an opaque CiphertextBlob.
+//
+// We follow the Vault / GCP pattern and talk to the JSON
+// REST API directly rather than pulling in aws-sdk-go-v2.
+// Reasons:
+//
+//   - The SDK transitive tree is large (smithy, the whole
+//     service-client codegen, the credential-provider
+//     chain, …); govulncheck has to track it all, and it
+//     dwarfs the rest of this repo's dependency surface.
+//   - Our usage is two actions — Encrypt and Decrypt.
+//   - The one thing the SDK really buys you is SigV4
+//     request signing and the credential chain. SigV4 is
+//     ~60 lines of HMAC-SHA256 (below); credentials are
+//     supplied by the operator the same way the Vault
+//     token and the GCP access token are. Daemons on EC2 /
+//     EKS can run a tiny sidecar that refreshes IMDS /
+//     IRSA credentials into the env or a file; bare-metal
+//     uses a static IAM user. Either way the daemon only
+//     needs the access-key / secret pair (+ optional
+//     session token for STS temp creds).
+//
+// Wire shape (AWS JSON 1.1, "TrentService" is KMS's
+// internal name):
+//
+//   POST https://kms.<region>.amazonaws.com/
+//     X-Amz-Target: TrentService.Encrypt
+//     Authorization: AWS4-HMAC-SHA256 Credential=... Signature=...
+//     {"KeyId": "<key>", "Plaintext": "<base64(DEK)>"}
+//   →  {"KeyId": "<arn>", "CiphertextBlob": "<base64>"}
+//
+//   POST https://kms.<region>.amazonaws.com/
+//     X-Amz-Target: TrentService.Decrypt
+//     {"KeyId": "<key>", "CiphertextBlob": "<base64>"}
+//   →  {"KeyId": "<arn>", "Plaintext": "<base64(DEK)>"}
+//
+// kek_id encodes the region + configured key id so a row
+// migrated under one account / key / region can't be
+// unwrapped by a daemon reconfigured against a different
+// one. AWS's own key rotation is transparent: the key
+// version that produced a CiphertextBlob is baked into the
+// blob, so Decrypt for old ciphertext keeps succeeding.
+
+// AWSConfig configures the AWS KMS backend.
+type AWSConfig struct {
+	// Region is the AWS region of the KMS key, e.g.
+	// "us-west-2". Used for the endpoint host and the
+	// SigV4 credential scope.
+	Region string
+
+	// KeyID identifies the KMS key used as the KEK. Accepts
+	// any form AWS accepts on Encrypt: a key id
+	// ("1234abcd-..."), a full ARN
+	// ("arn:aws:kms:us-west-2:111122223333:key/..."), an
+	// alias name ("alias/containarium-secrets"), or an
+	// alias ARN. Encrypt always uses the key's current
+	// rotation; the daemon never pins a version.
+	KeyID string
+
+	// AccessKeyID is the AWS access key id (not secret).
+	AccessKeyID string
+
+	// SecretAccessKey is the AWS secret access key. Operators
+	// refresh this out-of-band (IRSA / IMDS sidecar tee'd to
+	// a file, a static IAM user, or Vault's aws secret
+	// engine).
+	SecretAccessKey string
+
+	// SessionToken is the STS session token, set only when
+	// the credentials are temporary (assume-role / IRSA /
+	// IMDS). Empty for a static IAM user. When present it is
+	// sent as X-Amz-Security-Token and folded into the
+	// SigV4 signed headers.
+	SessionToken string
+
+	// Endpoint is the KMS API base URL. Defaults to the
+	// public regional endpoint; the field exists so tests
+	// can point at a httptest.Server and so VPC-endpoint /
+	// air-gapped deployments can override.
+	Endpoint string
+
+	// Timeout caps every KMS HTTP call. Default 5s.
+	Timeout time.Duration
+}
+
+// AWSKMS implements KMSClient against AWS KMS.
+type AWSKMS struct {
+	cfg    AWSConfig
+	client *http.Client
+	kekID  string // cached, set in NewAWSKMS
+}
+
+// awsKEKPrefix labels a kek_id as "wrap was done by AWS
+// KMS." Future readers (a daemon swapped to Vault or GCP,
+// for instance) match this prefix and refuse to even
+// attempt decryption of a non-matching row.
+const awsKEKPrefix = "aws:"
+
+// awsKMSService is the SigV4 service name for KMS. Used in
+// both the endpoint host and the credential scope.
+const awsKMSService = "kms"
+
+// awsJSONContentType is the AWS JSON 1.1 protocol content
+// type KMS expects.
+const awsJSONContentType = "application/x-amz-json-1.1"
+
+// NewAWSKMS constructs the backend. Validates config shape
+// but does NOT call AWS — the first Wrap / Unwrap surfaces a
+// bad credential / missing key / network outage as a normal
+// Wrap / Unwrap error. Lazy connection mirrors the Vault and
+// GCP backends so daemon startup can't be blocked by a
+// momentarily-unreachable endpoint.
+func NewAWSKMS(cfg AWSConfig) (*AWSKMS, error) {
+	cfg.Region = strings.TrimSpace(cfg.Region)
+	if cfg.Region == "" {
+		return nil, errors.New("aws KMS: region required")
+	}
+	cfg.KeyID = strings.TrimSpace(cfg.KeyID)
+	if cfg.KeyID == "" {
+		return nil, errors.New("aws KMS: key id required")
+	}
+	cfg.AccessKeyID = strings.TrimSpace(cfg.AccessKeyID)
+	if cfg.AccessKeyID == "" {
+		return nil, errors.New("aws KMS: access key id required")
+	}
+	if cfg.SecretAccessKey == "" {
+		return nil, errors.New("aws KMS: secret access key required")
+	}
+	cfg.Endpoint = strings.TrimRight(strings.TrimSpace(cfg.Endpoint), "/")
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = fmt.Sprintf("https://kms.%s.amazonaws.com", cfg.Region)
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 5 * time.Second
+	}
+	// kek_id is fully determined by region + configured key
+	// id. Rows wrapped under different keys / regions get
+	// distinct kek_ids; cross-deployment confusion is
+	// structurally impossible. We encode the configured key
+	// id (not the ARN echoed back by AWS) so the value is
+	// deterministic from config alone — matching how Vault
+	// and GCP encode their kek_ids.
+	kekID := fmt.Sprintf("%s%s|%s", awsKEKPrefix, cfg.Region, cfg.KeyID)
+	return &AWSKMS{
+		cfg:    cfg,
+		client: &http.Client{Timeout: cfg.Timeout},
+		kekID:  kekID,
+	}, nil
+}
+
+// Wrap encrypts the DEK against the configured KMS key.
+// AWS returns an opaque base64 CiphertextBlob we store
+// verbatim as wrapped_dek; it self-describes the key version
+// for Decrypt. kek_id reflects the region + key for
+// cross-deployment safety.
+func (a *AWSKMS) Wrap(ctx context.Context, plaintextDEK []byte) ([]byte, string, error) {
+	if len(plaintextDEK) != DEKSize {
+		return nil, "", fmt.Errorf("DEK must be %d bytes; got %d", DEKSize, len(plaintextDEK))
+	}
+	body := map[string]string{
+		"KeyId":     a.cfg.KeyID,
+		"Plaintext": base64.StdEncoding.EncodeToString(plaintextDEK),
+	}
+	var resp struct {
+		CiphertextBlob string `json:"CiphertextBlob"`
+	}
+	if err := a.do(ctx, "TrentService.Encrypt", body, &resp); err != nil {
+		return nil, "", fmt.Errorf("aws kms encrypt: %w", err)
+	}
+	if resp.CiphertextBlob == "" {
+		return nil, "", errors.New("aws kms encrypt: empty CiphertextBlob in response")
+	}
+	// Store the base64 blob verbatim; Unwrap passes it
+	// straight back to KMS as the Decrypt payload. No
+	// re-encoding round-trip in the hot path.
+	return []byte(resp.CiphertextBlob), a.kekID, nil
+}
+
+// Unwrap reverses Wrap. The kek_id must start with the
+// aws:-prefix; otherwise the row was wrapped by a different
+// backend (Vault, GCP, InProc, …) and we refuse rather than
+// spending a KMS call on a guaranteed mismatch. We also pin
+// the Decrypt to the configured KeyId so a forged blob can't
+// coax a decrypt under a key we didn't intend.
+func (a *AWSKMS) Unwrap(ctx context.Context, wrappedDEK []byte, kekID string) ([]byte, error) {
+	if !strings.HasPrefix(kekID, awsKEKPrefix) {
+		return nil, fmt.Errorf("AWSKMS: refusing to unwrap row whose kek_id=%q (no %q prefix)", kekID, awsKEKPrefix)
+	}
+	body := map[string]string{
+		"KeyId":          a.cfg.KeyID,
+		"CiphertextBlob": string(wrappedDEK),
+	}
+	var resp struct {
+		Plaintext string `json:"Plaintext"`
+	}
+	if err := a.do(ctx, "TrentService.Decrypt", body, &resp); err != nil {
+		return nil, fmt.Errorf("aws kms decrypt: %w", err)
+	}
+	dek, err := base64.StdEncoding.DecodeString(resp.Plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("aws kms decrypt: base64: %w", err)
+	}
+	if len(dek) != DEKSize {
+		return nil, fmt.Errorf("aws kms decrypt: DEK has %d bytes; want %d", len(dek), DEKSize)
+	}
+	return dek, nil
+}
+
+// do POSTs a KMS action and decodes the JSON response.
+// Centralized so SigV4 signing, error mapping, and future
+// telemetry sit in one place.
+//
+// target is the X-Amz-Target value ("TrentService.Encrypt"
+// / "TrentService.Decrypt").
+func (a *AWSKMS) do(ctx context.Context, target string, body, out any) error {
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.cfg.Endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", awsJSONContentType)
+	req.Header.Set("X-Amz-Target", target)
+	if err := a.signV4(req, jsonBody); err != nil {
+		return fmt.Errorf("sigv4: %w", err)
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		// KMS returns {"__type":"...","message":"..."} on
+		// failure (some actions capitalize "Message").
+		var errResp struct {
+			Type     string `json:"__type"`
+			Message  string `json:"message"`
+			MessageU string `json:"Message"`
+		}
+		_ = json.Unmarshal(respBody, &errResp)
+		msg := errResp.Message
+		if msg == "" {
+			msg = errResp.MessageU
+		}
+		if msg != "" {
+			return fmt.Errorf("status %d: %s: %s", resp.StatusCode, errResp.Type, msg)
+		}
+		return fmt.Errorf("status %d: %s", resp.StatusCode, string(respBody))
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+	return nil
+}
+
+// signV4 signs req in place with AWS Signature Version 4.
+// It sets X-Amz-Date (and X-Amz-Security-Token when the
+// config carries a session token) and the Authorization
+// header. body is the exact request payload — it must match
+// what was attached to req, since its SHA-256 is part of
+// the signature.
+//
+// Spec:
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
+func (a *AWSKMS) signV4(req *http.Request, body []byte) error {
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+
+	req.Header.Set("X-Amz-Date", amzDate)
+	if a.cfg.SessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", a.cfg.SessionToken)
+	}
+
+	host := req.URL.Host
+	if host == "" {
+		return errors.New("endpoint has no host")
+	}
+
+	// Headers we sign. Host + the x-amz-* headers; AWS
+	// requires host and x-amz-date at minimum. We include
+	// content-type and x-amz-target so a proxy can't strip /
+	// swap them, and x-amz-security-token when present.
+	signedValues := map[string]string{
+		"content-type": req.Header.Get("Content-Type"),
+		"host":         host,
+		"x-amz-date":   amzDate,
+		"x-amz-target": req.Header.Get("X-Amz-Target"),
+	}
+	if a.cfg.SessionToken != "" {
+		signedValues["x-amz-security-token"] = a.cfg.SessionToken
+	}
+	names := make([]string, 0, len(signedValues))
+	for n := range signedValues {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	var canonicalHeaders strings.Builder
+	for _, n := range names {
+		canonicalHeaders.WriteString(n)
+		canonicalHeaders.WriteByte(':')
+		canonicalHeaders.WriteString(strings.TrimSpace(signedValues[n]))
+		canonicalHeaders.WriteByte('\n')
+	}
+	signedHeaders := strings.Join(names, ";")
+
+	canonicalURI := req.URL.EscapedPath()
+	if canonicalURI == "" {
+		canonicalURI = "/"
+	}
+	payloadHash := sha256.Sum256(body)
+	canonicalRequest := strings.Join([]string{
+		http.MethodPost,
+		canonicalURI,
+		"", // canonical query string (none)
+		canonicalHeaders.String(),
+		signedHeaders,
+		hex.EncodeToString(payloadHash[:]),
+	}, "\n")
+
+	scope := strings.Join([]string{dateStamp, a.cfg.Region, awsKMSService, "aws4_request"}, "/")
+	crHash := sha256.Sum256([]byte(canonicalRequest))
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		scope,
+		hex.EncodeToString(crHash[:]),
+	}, "\n")
+
+	signature := hex.EncodeToString(hmacSHA256(a.signingKey(dateStamp), []byte(stringToSign)))
+	authz := fmt.Sprintf(
+		"AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		a.cfg.AccessKeyID, scope, signedHeaders, signature,
+	)
+	req.Header.Set("Authorization", authz)
+	return nil
+}
+
+// signingKey derives the SigV4 signing key for the day via
+// the standard HMAC chain: AWS4+secret → date → region →
+// service → "aws4_request".
+func (a *AWSKMS) signingKey(dateStamp string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+a.cfg.SecretAccessKey), []byte(dateStamp))
+	kRegion := hmacSHA256(kDate, []byte(a.cfg.Region))
+	kService := hmacSHA256(kRegion, []byte(awsKMSService))
+	return hmacSHA256(kService, []byte("aws4_request"))
+}
+
+// hmacSHA256 is the HMAC primitive SigV4's key-derivation
+// chain and final signature both use.
+func hmacSHA256(key, data []byte) []byte {
+	m := hmac.New(sha256.New, key)
+	m.Write(data)
+	return m.Sum(nil)
+}

--- a/pkg/core/secrets/kms_aws_test.go
+++ b/pkg/core/secrets/kms_aws_test.go
@@ -1,0 +1,450 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Phase 4.1 Phase-C — AWS KMS backend tests.
+//
+// We stand up a fake KMS server with httptest that:
+//   - INDEPENDENTLY re-derives the SigV4 signature from the
+//     incoming request (a second implementation, written
+//     inline below) and rejects a mismatch with a 403. This
+//     is the real cross-check for the hand-rolled signer:
+//     a round-trip only succeeds if production's canonical
+//     request, string-to-sign, signing-key chain, and
+//     scope all match an independent reimplementation.
+//   - symmetric-encrypts the plaintext under a process-local
+//     AES key to produce a base64 CiphertextBlob, reversing
+//     on Decrypt.
+//   - can be configured to return AWS-style errors.
+//
+// No real AWS credentials or network are needed.
+
+type fakeAWSKMS struct {
+	t                 *testing.T
+	wantAccessKey     string
+	wantSecret        string
+	encryptKey        []byte
+	statusCode        int    // override status (default 200)
+	errType           string // AWS __type on forced error
+	errMsg            string // AWS message on forced error
+	lastSignedHeaders string // recorded from the last verified request
+}
+
+func newFakeAWSKMS(t *testing.T) (*httptest.Server, *fakeAWSKMS) {
+	t.Helper()
+	fk := &fakeAWSKMS{
+		t:             t,
+		wantAccessKey: "AKIDEXAMPLE",
+		wantSecret:    "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+		encryptKey:    make([]byte, 32),
+		statusCode:    200,
+	}
+	if _, err := io.ReadFull(rand.Reader, fk.encryptKey); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(fk.handle))
+	return srv, fk
+}
+
+func (f *fakeAWSKMS) handle(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+
+	// Independent SigV4 verification. A signing bug in the
+	// production code surfaces here as a 403.
+	if err := f.verifySig(r, body); err != "" {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"__type":"InvalidSignatureException","message":"` + err + `"}`))
+		return
+	}
+
+	if f.statusCode >= 400 {
+		w.WriteHeader(f.statusCode)
+		_, _ = w.Write([]byte(`{"__type":"` + f.errType + `","message":"` + f.errMsg + `"}`))
+		return
+	}
+
+	target := r.Header.Get("X-Amz-Target")
+	switch target {
+	case "TrentService.Encrypt":
+		var req struct {
+			KeyId     string `json:"KeyId"`
+			Plaintext string `json:"Plaintext"`
+		}
+		_ = json.Unmarshal(body, &req)
+		pt, err := base64.StdEncoding.DecodeString(req.Plaintext)
+		if err != nil {
+			http.Error(w, `{"__type":"ValidationException","message":"bad plaintext b64"}`, http.StatusBadRequest)
+			return
+		}
+		ct := f.symEncrypt(pt)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"KeyId":          "arn:aws:kms:us-west-2:111122223333:key/abcd",
+			"CiphertextBlob": base64.StdEncoding.EncodeToString(ct),
+		})
+	case "TrentService.Decrypt":
+		var req struct {
+			KeyId          string `json:"KeyId"`
+			CiphertextBlob string `json:"CiphertextBlob"`
+		}
+		_ = json.Unmarshal(body, &req)
+		raw, err := base64.StdEncoding.DecodeString(req.CiphertextBlob)
+		if err != nil {
+			http.Error(w, `{"__type":"InvalidCiphertextException","message":"bad blob b64"}`, http.StatusBadRequest)
+			return
+		}
+		pt, err := f.symDecrypt(raw)
+		if err != nil {
+			http.Error(w, `{"__type":"InvalidCiphertextException","message":"bad ciphertext"}`, http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"KeyId":     "arn:aws:kms:us-west-2:111122223333:key/abcd",
+			"Plaintext": base64.StdEncoding.EncodeToString(pt),
+		})
+	default:
+		http.Error(w, `{"__type":"UnknownOperationException","message":"`+target+`"}`, http.StatusBadRequest)
+	}
+}
+
+// verifySig re-derives the SigV4 signature from the request
+// and compares it to the one in the Authorization header.
+// Returns "" on success or a message on failure. This is a
+// deliberately separate implementation from signV4 — they
+// must agree for a round-trip to pass.
+func (f *fakeAWSKMS) verifySig(r *http.Request, body []byte) string {
+	authz := r.Header.Get("Authorization")
+	const scheme = "AWS4-HMAC-SHA256 "
+	if !strings.HasPrefix(authz, scheme) {
+		return "missing AWS4-HMAC-SHA256 authorization"
+	}
+	var credential, signedHeaders, signature string
+	for _, p := range strings.Split(strings.TrimPrefix(authz, scheme), ", ") {
+		switch {
+		case strings.HasPrefix(p, "Credential="):
+			credential = strings.TrimPrefix(p, "Credential=")
+		case strings.HasPrefix(p, "SignedHeaders="):
+			signedHeaders = strings.TrimPrefix(p, "SignedHeaders=")
+		case strings.HasPrefix(p, "Signature="):
+			signature = strings.TrimPrefix(p, "Signature=")
+		}
+	}
+	f.lastSignedHeaders = signedHeaders
+
+	credParts := strings.Split(credential, "/")
+	if len(credParts) != 5 {
+		return "malformed credential scope"
+	}
+	access, dateStamp, region, service := credParts[0], credParts[1], credParts[2], credParts[3]
+	if access != f.wantAccessKey {
+		return "unknown access key id"
+	}
+	amzDate := r.Header.Get("X-Amz-Date")
+
+	var ch strings.Builder
+	for _, n := range strings.Split(signedHeaders, ";") {
+		var val string
+		if n == "host" {
+			val = r.Host
+		} else {
+			val = r.Header.Get(n)
+		}
+		ch.WriteString(n)
+		ch.WriteByte(':')
+		ch.WriteString(strings.TrimSpace(val))
+		ch.WriteByte('\n')
+	}
+	uri := r.URL.EscapedPath()
+	if uri == "" {
+		uri = "/"
+	}
+	ph := sha256.Sum256(body)
+	canonicalRequest := strings.Join([]string{
+		http.MethodPost, uri, "", ch.String(), signedHeaders, hex.EncodeToString(ph[:]),
+	}, "\n")
+	scope := strings.Join([]string{dateStamp, region, service, "aws4_request"}, "/")
+	crHash := sha256.Sum256([]byte(canonicalRequest))
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256", amzDate, scope, hex.EncodeToString(crHash[:]),
+	}, "\n")
+
+	kDate := tHMAC([]byte("AWS4"+f.wantSecret), []byte(dateStamp))
+	kRegion := tHMAC(kDate, []byte(region))
+	kService := tHMAC(kRegion, []byte(service))
+	kSigning := tHMAC(kService, []byte("aws4_request"))
+	want := hex.EncodeToString(tHMAC(kSigning, []byte(stringToSign)))
+	if want != signature {
+		return "signature mismatch"
+	}
+	return ""
+}
+
+// tHMAC is the test's own HMAC-SHA256, kept separate from
+// the production hmacSHA256 so the verifier shares no code
+// with the signer beyond the Go standard library.
+func tHMAC(key, data []byte) []byte {
+	m := hmac.New(sha256.New, key)
+	m.Write(data)
+	return m.Sum(nil)
+}
+
+func (f *fakeAWSKMS) symEncrypt(pt []byte) []byte {
+	block, _ := aes.NewCipher(f.encryptKey)
+	gcm, _ := cipher.NewGCM(block)
+	nonce := make([]byte, gcm.NonceSize())
+	_, _ = io.ReadFull(rand.Reader, nonce)
+	return append(nonce, gcm.Seal(nil, nonce, pt, nil)...)
+}
+
+func (f *fakeAWSKMS) symDecrypt(blob []byte) ([]byte, error) {
+	block, _ := aes.NewCipher(f.encryptKey)
+	gcm, _ := cipher.NewGCM(block)
+	ns := gcm.NonceSize()
+	if len(blob) < ns {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return gcm.Open(nil, blob[:ns], blob[ns:], nil)
+}
+
+const (
+	awsTestRegion = "us-west-2"
+	awsTestKeyID  = "alias/containarium-secrets"
+	awsTestAccess = "AKIDEXAMPLE"
+	awsTestSecret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+)
+
+// --- Tests ---
+
+func TestAWSKMS_WrapUnwrapRoundtrip(t *testing.T) {
+	srv, _ := newFakeAWSKMS(t)
+	defer srv.Close()
+
+	k, err := NewAWSKMS(AWSConfig{
+		Region:          awsTestRegion,
+		KeyID:           awsTestKeyID,
+		AccessKeyID:     awsTestAccess,
+		SecretAccessKey: awsTestSecret,
+		Endpoint:        srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewAWSKMS: %v", err)
+	}
+
+	dek, _ := NewDEK()
+	wrapped, kekID, err := k.Wrap(context.Background(), dek)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	if !strings.HasPrefix(kekID, "aws:") {
+		t.Fatalf("kek_id missing aws: prefix: %q", kekID)
+	}
+	if !strings.Contains(kekID, awsTestRegion) || !strings.Contains(kekID, awsTestKeyID) {
+		t.Fatalf("kek_id should encode region+key; got %q", kekID)
+	}
+	if len(wrapped) == 0 {
+		t.Fatal("wrapped DEK is empty")
+	}
+
+	out, err := k.Unwrap(context.Background(), wrapped, kekID)
+	if err != nil {
+		t.Fatalf("Unwrap: %v", err)
+	}
+	if !bytes.Equal(out, dek) {
+		t.Fatal("round-trip altered DEK")
+	}
+}
+
+func TestAWSKMS_RejectsBadCredentials(t *testing.T) {
+	srv, _ := newFakeAWSKMS(t)
+	defer srv.Close()
+
+	// Wrong secret → the server's independent signature
+	// derivation won't match → 403 InvalidSignatureException.
+	k, _ := NewAWSKMS(AWSConfig{
+		Region:          awsTestRegion,
+		KeyID:           awsTestKeyID,
+		AccessKeyID:     awsTestAccess,
+		SecretAccessKey: "the-wrong-secret",
+		Endpoint:        srv.URL,
+	})
+	dek, _ := NewDEK()
+	_, _, err := k.Wrap(context.Background(), dek)
+	if err == nil {
+		t.Fatal("Wrap with wrong secret should fail signature verification")
+	}
+	if !strings.Contains(err.Error(), "signature mismatch") {
+		t.Fatalf("error should surface the signature failure; got %v", err)
+	}
+}
+
+func TestAWSKMS_SessionTokenIsSigned(t *testing.T) {
+	srv, fk := newFakeAWSKMS(t)
+	defer srv.Close()
+
+	k, _ := NewAWSKMS(AWSConfig{
+		Region:          awsTestRegion,
+		KeyID:           awsTestKeyID,
+		AccessKeyID:     awsTestAccess,
+		SecretAccessKey: awsTestSecret,
+		SessionToken:    "session-token-abc",
+		Endpoint:        srv.URL,
+	})
+	dek, _ := NewDEK()
+	if _, _, err := k.Wrap(context.Background(), dek); err != nil {
+		t.Fatalf("Wrap with session token: %v", err)
+	}
+	// The token must be folded into the signed headers, or a
+	// proxy could strip it and break auth silently.
+	if !strings.Contains(fk.lastSignedHeaders, "x-amz-security-token") {
+		t.Fatalf("session token not in signed headers: %q", fk.lastSignedHeaders)
+	}
+}
+
+func TestAWSKMS_RejectsRowFromDifferentBackend(t *testing.T) {
+	srv, _ := newFakeAWSKMS(t)
+	defer srv.Close()
+
+	k, _ := NewAWSKMS(AWSConfig{
+		Region: awsTestRegion, KeyID: awsTestKeyID,
+		AccessKeyID: awsTestAccess, SecretAccessKey: awsTestSecret, Endpoint: srv.URL,
+	})
+	// kek_id from another backend (Vault).
+	_, err := k.Unwrap(context.Background(), []byte("blob"), "vault:https://v|transit|k")
+	if err == nil {
+		t.Fatal("AWSKMS must refuse non-aws: kek_id")
+	}
+	if !strings.Contains(err.Error(), "no \"aws:\" prefix") {
+		t.Fatalf("error should mention the missing prefix; got %v", err)
+	}
+}
+
+func TestAWSKMS_RejectsBadDEKSize(t *testing.T) {
+	srv, _ := newFakeAWSKMS(t)
+	defer srv.Close()
+	k, _ := NewAWSKMS(AWSConfig{
+		Region: awsTestRegion, KeyID: awsTestKeyID,
+		AccessKeyID: awsTestAccess, SecretAccessKey: awsTestSecret, Endpoint: srv.URL,
+	})
+	for _, badSize := range []int{0, 16, 64} {
+		if _, _, err := k.Wrap(context.Background(), make([]byte, badSize)); err == nil {
+			t.Fatalf("Wrap with DEK size %d should fail", badSize)
+		}
+	}
+}
+
+func TestAWSKMS_KEKIDEncodesKeyIdentity(t *testing.T) {
+	srv, _ := newFakeAWSKMS(t)
+	defer srv.Close()
+	a, _ := NewAWSKMS(AWSConfig{
+		Region: "us-east-1", KeyID: "alias/key-a",
+		AccessKeyID: awsTestAccess, SecretAccessKey: awsTestSecret, Endpoint: srv.URL,
+	})
+	b, _ := NewAWSKMS(AWSConfig{
+		Region: "us-west-2", KeyID: "alias/key-b",
+		AccessKeyID: awsTestAccess, SecretAccessKey: awsTestSecret, Endpoint: srv.URL,
+	})
+	dek, _ := NewDEK()
+	_, kekA, _ := a.Wrap(context.Background(), dek)
+	_, kekB, _ := b.Wrap(context.Background(), dek)
+	if kekA == kekB {
+		t.Fatal("different region/key should produce different kek_ids")
+	}
+}
+
+func TestAWSKMS_RejectsEmptyConfig(t *testing.T) {
+	cases := []AWSConfig{
+		{Region: "", KeyID: "alias/k", AccessKeyID: "a", SecretAccessKey: "s"},
+		{Region: "us-west-2", KeyID: "", AccessKeyID: "a", SecretAccessKey: "s"},
+		{Region: "us-west-2", KeyID: "alias/k", AccessKeyID: "", SecretAccessKey: "s"},
+		{Region: "us-west-2", KeyID: "alias/k", AccessKeyID: "a", SecretAccessKey: ""},
+	}
+	for _, c := range cases {
+		if _, err := NewAWSKMS(c); err == nil {
+			t.Fatalf("NewAWSKMS should reject config %+v", c)
+		}
+	}
+}
+
+func TestAWSKMS_EndpointDefaultsToRegional(t *testing.T) {
+	k, err := NewAWSKMS(AWSConfig{
+		Region:          awsTestRegion,
+		KeyID:           awsTestKeyID,
+		AccessKeyID:     awsTestAccess,
+		SecretAccessKey: awsTestSecret,
+		// no Endpoint → defaults to kms.<region>.amazonaws.com
+		Timeout: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewAWSKMS: %v", err)
+	}
+	dek, _ := NewDEK()
+	_, _, err = k.Wrap(context.Background(), dek)
+	if err == nil {
+		t.Fatal("Wrap should fail (we can't actually reach AWS KMS)")
+	}
+	if !strings.Contains(err.Error(), "kms."+awsTestRegion+".amazonaws.com") {
+		t.Logf("err = %v (does not mention default endpoint, but that's OK on some networks)", err)
+	}
+}
+
+func TestAWSKMS_TimeoutAppliesToHTTP(t *testing.T) {
+	hang := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+	}))
+	defer hang.Close()
+
+	k, _ := NewAWSKMS(AWSConfig{
+		Region: awsTestRegion, KeyID: awsTestKeyID,
+		AccessKeyID: awsTestAccess, SecretAccessKey: awsTestSecret,
+		Endpoint: hang.URL, Timeout: 100 * time.Millisecond,
+	})
+	dek, _ := NewDEK()
+	start := time.Now()
+	_, _, err := k.Wrap(context.Background(), dek)
+	if err == nil {
+		t.Fatal("Wrap should time out")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("timeout not honored; elapsed = %v", elapsed)
+	}
+}
+
+func TestAWSKMS_PassesKMSErrorThrough(t *testing.T) {
+	srv, fk := newFakeAWSKMS(t)
+	defer srv.Close()
+	fk.statusCode = 400
+	fk.errType = "AccessDeniedException"
+	fk.errMsg = "User is not authorized to perform kms:Encrypt"
+
+	k, _ := NewAWSKMS(AWSConfig{
+		Region: awsTestRegion, KeyID: awsTestKeyID,
+		AccessKeyID: awsTestAccess, SecretAccessKey: awsTestSecret, Endpoint: srv.URL,
+	})
+	dek, _ := NewDEK()
+	_, _, err := k.Wrap(context.Background(), dek)
+	if err == nil {
+		t.Fatal("Wrap should fail with 400")
+	}
+	if !strings.Contains(err.Error(), "not authorized to perform kms:Encrypt") {
+		t.Fatalf("error should surface the KMS message; got %v", err)
+	}
+}
+
+// Compile-time conformance.
+var _ KMSClient = (*AWSKMS)(nil)

--- a/pkg/core/secrets/kms_factory.go
+++ b/pkg/core/secrets/kms_factory.go
@@ -30,6 +30,7 @@ const (
 	KMSBackendInProc = "inproc"
 	KMSBackendVault  = "vault"
 	KMSBackendGCP    = "gcp"
+	KMSBackendAWS    = "aws"
 )
 
 // LoadKMSClient picks a backend based on
@@ -78,8 +79,18 @@ func LoadKMSClient(masterKey []byte) (KMSClient, string, error) {
 			return nil, "", fmt.Errorf("KMS backend gcp: %w", err)
 		}
 		return k, fmt.Sprintf("gcp cloud kms (key=%s)", cfg.KeyName), nil
+	case KMSBackendAWS:
+		cfg, err := awsConfigFromEnv()
+		if err != nil {
+			return nil, "", fmt.Errorf("KMS backend aws: %w", err)
+		}
+		k, err := NewAWSKMS(cfg)
+		if err != nil {
+			return nil, "", fmt.Errorf("KMS backend aws: %w", err)
+		}
+		return k, fmt.Sprintf("aws kms (region=%s key=%s)", cfg.Region, cfg.KeyID), nil
 	default:
-		return nil, "", fmt.Errorf("KMS backend: unrecognized value %q (expected: none, inproc, vault, gcp)", backend)
+		return nil, "", fmt.Errorf("KMS backend: unrecognized value %q (expected: none, inproc, vault, gcp, aws)", backend)
 	}
 }
 
@@ -163,6 +174,69 @@ func gcpConfigFromEnv() (GCPConfig, error) {
 		d, err := time.ParseDuration(t)
 		if err != nil {
 			return cfg, fmt.Errorf("CONTAINARIUM_GCP_KMS_TIMEOUT: %w", err)
+		}
+		cfg.Timeout = d
+	}
+	return cfg, nil
+}
+
+// awsConfigFromEnv reads the AWS KMS config from env.
+// Required: CONTAINARIUM_AWS_KMS_REGION,
+// CONTAINARIUM_AWS_KMS_KEY_ID, CONTAINARIUM_AWS_ACCESS_KEY_ID,
+// and one of CONTAINARIUM_AWS_SECRET_ACCESS_KEY / _FILE.
+// Optional: CONTAINARIUM_AWS_SESSION_TOKEN / _FILE (STS temp
+// creds), CONTAINARIUM_AWS_KMS_ENDPOINT (VPC-endpoint /
+// air-gapped deployments override this),
+// CONTAINARIUM_AWS_KMS_TIMEOUT (default 5s).
+func awsConfigFromEnv() (AWSConfig, error) {
+	cfg := AWSConfig{
+		Region:      strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_KMS_REGION")),
+		KeyID:       strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_KMS_KEY_ID")),
+		AccessKeyID: strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_ACCESS_KEY_ID")),
+		Endpoint:    strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_KMS_ENDPOINT")),
+	}
+	if cfg.Region == "" {
+		return cfg, fmt.Errorf("CONTAINARIUM_AWS_KMS_REGION is required")
+	}
+	if cfg.KeyID == "" {
+		return cfg, fmt.Errorf("CONTAINARIUM_AWS_KMS_KEY_ID is required (key id, ARN, or alias/<name>)")
+	}
+	if cfg.AccessKeyID == "" {
+		return cfg, fmt.Errorf("CONTAINARIUM_AWS_ACCESS_KEY_ID is required")
+	}
+
+	// Secret access key: env wins over file. File is the
+	// recommended long-lived path — an IRSA / IMDS sidecar
+	// refreshes the credential and writes it atomically.
+	if sk := os.Getenv("CONTAINARIUM_AWS_SECRET_ACCESS_KEY"); sk != "" {
+		cfg.SecretAccessKey = sk
+	} else if path := strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_SECRET_ACCESS_KEY_FILE")); path != "" {
+		sk, err := readBearerLikeFile(path)
+		if err != nil {
+			return cfg, fmt.Errorf("read CONTAINARIUM_AWS_SECRET_ACCESS_KEY_FILE: %w", err)
+		}
+		cfg.SecretAccessKey = sk
+	}
+	if cfg.SecretAccessKey == "" {
+		return cfg, fmt.Errorf("set either CONTAINARIUM_AWS_SECRET_ACCESS_KEY or CONTAINARIUM_AWS_SECRET_ACCESS_KEY_FILE")
+	}
+
+	// Session token: optional (only for STS temp creds).
+	// Same env-wins-over-file contract.
+	if st := os.Getenv("CONTAINARIUM_AWS_SESSION_TOKEN"); st != "" {
+		cfg.SessionToken = st
+	} else if path := strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_SESSION_TOKEN_FILE")); path != "" {
+		st, err := readBearerLikeFile(path)
+		if err != nil {
+			return cfg, fmt.Errorf("read CONTAINARIUM_AWS_SESSION_TOKEN_FILE: %w", err)
+		}
+		cfg.SessionToken = st
+	}
+
+	if t := strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_KMS_TIMEOUT")); t != "" {
+		d, err := time.ParseDuration(t)
+		if err != nil {
+			return cfg, fmt.Errorf("CONTAINARIUM_AWS_KMS_TIMEOUT: %w", err)
 		}
 		cfg.Timeout = d
 	}

--- a/pkg/core/secrets/kms_factory_test.go
+++ b/pkg/core/secrets/kms_factory_test.go
@@ -25,6 +25,15 @@ func clearKMSEnv(t *testing.T) {
 		"CONTAINARIUM_GCP_KMS_TOKEN_FILE",
 		"CONTAINARIUM_GCP_KMS_ENDPOINT",
 		"CONTAINARIUM_GCP_KMS_TIMEOUT",
+		"CONTAINARIUM_AWS_KMS_REGION",
+		"CONTAINARIUM_AWS_KMS_KEY_ID",
+		"CONTAINARIUM_AWS_ACCESS_KEY_ID",
+		"CONTAINARIUM_AWS_SECRET_ACCESS_KEY",
+		"CONTAINARIUM_AWS_SECRET_ACCESS_KEY_FILE",
+		"CONTAINARIUM_AWS_SESSION_TOKEN",
+		"CONTAINARIUM_AWS_SESSION_TOKEN_FILE",
+		"CONTAINARIUM_AWS_KMS_ENDPOINT",
+		"CONTAINARIUM_AWS_KMS_TIMEOUT",
 	} {
 		t.Setenv(k, "")
 	}
@@ -261,6 +270,135 @@ func TestLoadKMSClient_GCPTimeoutParse(t *testing.T) {
 		t.Fatalf("valid duration should parse; got %v", err)
 	}
 	t.Setenv("CONTAINARIUM_GCP_KMS_TIMEOUT", "garbage")
+	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
+		t.Fatal("malformed duration should error")
+	}
+}
+
+// --- AWS KMS factory cases ---
+
+func setAWSBaseEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "aws")
+	t.Setenv("CONTAINARIUM_AWS_KMS_REGION", "us-west-2")
+	t.Setenv("CONTAINARIUM_AWS_KMS_KEY_ID", "alias/containarium-secrets")
+	t.Setenv("CONTAINARIUM_AWS_ACCESS_KEY_ID", "AKIDEXAMPLE")
+}
+
+func TestLoadKMSClient_AWSFromEnvSucceeds(t *testing.T) {
+	clearKMSEnv(t)
+	setAWSBaseEnv(t)
+	t.Setenv("CONTAINARIUM_AWS_SECRET_ACCESS_KEY", "secret-key-xyz")
+	c, desc, err := LoadKMSClient(mkMaster(t))
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if _, ok := c.(*AWSKMS); !ok {
+		t.Fatalf("expected *AWSKMS; got %T", c)
+	}
+	if desc == "" || desc[:3] != "aws" {
+		t.Fatalf("description should announce aws backend; got %q", desc)
+	}
+}
+
+func TestLoadKMSClient_AWSRequiresRegion(t *testing.T) {
+	clearKMSEnv(t)
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "aws")
+	t.Setenv("CONTAINARIUM_AWS_KMS_KEY_ID", "alias/k")
+	t.Setenv("CONTAINARIUM_AWS_ACCESS_KEY_ID", "AKIDEXAMPLE")
+	t.Setenv("CONTAINARIUM_AWS_SECRET_ACCESS_KEY", "secret-key-xyz")
+	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
+		t.Fatal("missing AWS_KMS_REGION should error")
+	}
+}
+
+func TestLoadKMSClient_AWSRequiresKeyID(t *testing.T) {
+	clearKMSEnv(t)
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "aws")
+	t.Setenv("CONTAINARIUM_AWS_KMS_REGION", "us-west-2")
+	t.Setenv("CONTAINARIUM_AWS_ACCESS_KEY_ID", "AKIDEXAMPLE")
+	t.Setenv("CONTAINARIUM_AWS_SECRET_ACCESS_KEY", "secret-key-xyz")
+	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
+		t.Fatal("missing AWS_KMS_KEY_ID should error")
+	}
+}
+
+func TestLoadKMSClient_AWSRequiresAccessKey(t *testing.T) {
+	clearKMSEnv(t)
+	t.Setenv("CONTAINARIUM_KMS_BACKEND", "aws")
+	t.Setenv("CONTAINARIUM_AWS_KMS_REGION", "us-west-2")
+	t.Setenv("CONTAINARIUM_AWS_KMS_KEY_ID", "alias/k")
+	t.Setenv("CONTAINARIUM_AWS_SECRET_ACCESS_KEY", "secret-key-xyz")
+	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
+		t.Fatal("missing AWS_ACCESS_KEY_ID should error")
+	}
+}
+
+func TestLoadKMSClient_AWSRequiresSecret(t *testing.T) {
+	clearKMSEnv(t)
+	setAWSBaseEnv(t)
+	// No secret env or file.
+	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
+		t.Fatal("missing AWS secret (env or file) should error")
+	}
+}
+
+func TestLoadKMSClient_AWSSecretFromFile(t *testing.T) {
+	clearKMSEnv(t)
+	setAWSBaseEnv(t)
+	dir := t.TempDir()
+	p := filepath.Join(dir, "aws.secret")
+	if err := os.WriteFile(p, []byte("secret-key-xyz\n"), 0o600); err != nil {
+		t.Fatalf("write secret file: %v", err)
+	}
+	t.Setenv("CONTAINARIUM_AWS_SECRET_ACCESS_KEY_FILE", p)
+	c, _, err := LoadKMSClient(mkMaster(t))
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if _, ok := c.(*AWSKMS); !ok {
+		t.Fatalf("expected *AWSKMS from secret-file path; got %T", c)
+	}
+}
+
+func TestLoadKMSClient_AWSSecretFileWithBadPerms(t *testing.T) {
+	clearKMSEnv(t)
+	setAWSBaseEnv(t)
+	dir := t.TempDir()
+	p := filepath.Join(dir, "aws.secret")
+	if err := os.WriteFile(p, []byte("secret-key-xyz\n"), 0o644); err != nil {
+		t.Fatalf("write secret file: %v", err)
+	}
+	t.Setenv("CONTAINARIUM_AWS_SECRET_ACCESS_KEY_FILE", p)
+	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
+		t.Fatal("0644 secret file should be rejected (defense-in-depth, same as Vault/GCP)")
+	}
+}
+
+func TestLoadKMSClient_AWSSessionTokenFromFile(t *testing.T) {
+	clearKMSEnv(t)
+	setAWSBaseEnv(t)
+	t.Setenv("CONTAINARIUM_AWS_SECRET_ACCESS_KEY", "secret-key-xyz")
+	dir := t.TempDir()
+	p := filepath.Join(dir, "aws.session")
+	if err := os.WriteFile(p, []byte("session-token-abc\n"), 0o600); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+	t.Setenv("CONTAINARIUM_AWS_SESSION_TOKEN_FILE", p)
+	if _, _, err := LoadKMSClient(mkMaster(t)); err != nil {
+		t.Fatalf("session token from file should be accepted; got %v", err)
+	}
+}
+
+func TestLoadKMSClient_AWSTimeoutParse(t *testing.T) {
+	clearKMSEnv(t)
+	setAWSBaseEnv(t)
+	t.Setenv("CONTAINARIUM_AWS_SECRET_ACCESS_KEY", "secret-key-xyz")
+	t.Setenv("CONTAINARIUM_AWS_KMS_TIMEOUT", "10s")
+	if _, _, err := LoadKMSClient(mkMaster(t)); err != nil {
+		t.Fatalf("valid duration should parse; got %v", err)
+	}
+	t.Setenv("CONTAINARIUM_AWS_KMS_TIMEOUT", "garbage")
 	if _, _, err := LoadKMSClient(mkMaster(t)); err == nil {
 		t.Fatal("malformed duration should error")
 	}


### PR DESCRIPTION
## What

Adds an **AWS KMS** implementation of the `KMSClient` envelope-encryption interface, alongside the existing **Vault Transit** and **GCP Cloud KMS** backends. Selected with `CONTAINARIUM_KMS_BACKEND=aws`.

This completes the "pick your KMS, no vendor lock-in" story: `none` / `inproc` / `vault` / `gcp` / `aws`.

## Why this shape

Consistent with the Vault and GCP backends, it talks to the KMS JSON API directly rather than pulling in `aws-sdk-go-v2` — keeps the govulncheck dependency tree small (the SDK's transitive tree dwarfs the rest of the repo). The one thing the SDK really buys you, **SigV4 request signing**, is hand-rolled here (~60 lines of HMAC-SHA256). Credentials are operator-supplied the same way the Vault token and GCP access token are (env var or perm-checked `*_FILE`), plus optional STS **session-token** support for IRSA / IMDS temp creds.

## Changes

- `pkg/core/secrets/kms_aws.go` — `AWSKMS{Wrap,Unwrap}` + the SigV4 signer. `kek_id` is prefixed `aws:<region>|<keyid>` so a row wrapped under one region/key can't be silently unwrapped by a daemon pointed elsewhere (matches Vault/GCP).
- `pkg/core/secrets/kms_factory.go` — `aws` case + `awsConfigFromEnv()` (`CONTAINARIUM_AWS_KMS_REGION`, `_KEY_ID`, `_ACCESS_KEY_ID`, `_SECRET_ACCESS_KEY[_FILE]`, optional `_SESSION_TOKEN[_FILE]`, `_ENDPOINT`, `_TIMEOUT`). Secret/session files are 0600-perm-checked like the others.
- `pkg/core/secrets/kms_aws_test.go` — fake KMS server that **independently re-derives the SigV4 signature** and 403s on mismatch. A round-trip only passes if the production signer is byte-for-byte correct — the real cross-check for hand-rolled SigV4. Plus session-token, kek_id, error-passthrough, timeout, and bad-config cases.
- `pkg/core/secrets/kms_factory_test.go` — AWS env-loading factory cases (required fields, secret-from-file, bad perms, timeout parse).
- `docs/security/OPERATOR-SECURITY-RUNBOOK.md` — AWS KMS setup + key-rotation section; backend table updated.

## Wiring

No daemon changes needed — `LoadKMSClient` is the single dispatch point, exactly as the interface intends. Switching a deployment to AWS is a config change, not a code change.

## Tests

`go test ./pkg/core/secrets/` — all green (19 new AWS cases). `go vet` clean. Migration / `envelope-coverage` / `CONTAINARIUM_REQUIRE_ENVELOPE` all work identically to the Vault and GCP paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)