### PR TITLE
feat(version): release-drift visibility — endpoints + CLI check (#354 Phase A)

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"time"
 
+	"github.com/footprintai/containarium/internal/releases"
 	"github.com/footprintai/containarium/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -11,6 +14,7 @@ import (
 var (
 	cfgFile        string
 	verbose        bool
+	versionCheck   bool
 	serverAddr     string
 	certsDir       string
 	insecure       bool
@@ -85,7 +89,6 @@ func SetVersionInfo(ver, build string) {
 	// See Makefile for usage
 }
 
-
 // initConfig reads in config file and ENV variables if set
 func initConfig() {
 	// TODO: implement config file reading with viper
@@ -106,7 +109,30 @@ Use --verbose flag for detailed build information including Git commit, build ti
 		} else {
 			fmt.Println(version.String())
 		}
+		if versionCheck {
+			runVersionCheck(cmd)
+		}
 	},
+}
+
+// runVersionCheck queries GitHub for the latest published release and
+// reports whether this binary is behind it (#354). Server-less — it asks
+// GitHub directly, so it works without a daemon configured.
+func runVersionCheck(cmd *cobra.Command) {
+	ctx, cancel := context.WithTimeout(cmd.Context(), 12*time.Second)
+	defer cancel()
+	rel, _, err := releases.NewClient().Latest(ctx)
+	if err != nil {
+		fmt.Printf("\nCould not check for updates: %v\n", err)
+		return
+	}
+	cur := version.GetVersion()
+	fmt.Printf("\ncurrent: %s\nlatest:  %s\n", cur, rel.TagName)
+	if releases.IsBehind(cur, rel.TagName) {
+		fmt.Printf("⚠ a newer release is available: %s\n", rel.HTMLURL)
+	} else {
+		fmt.Println("✓ up to date")
+	}
 }
 
 func init() {
@@ -129,5 +155,6 @@ func init() {
 
 	// Version command with verbose flag
 	versionCmd.Flags().BoolVar(&verboseVersion, "verbose", false, "show detailed version information")
+	versionCmd.Flags().BoolVar(&versionCheck, "check", false, "check GitHub for a newer release and report drift")
 	rootCmd.AddCommand(versionCmd)
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -20,6 +20,7 @@ import (
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/mtls"
+	"github.com/footprintai/containarium/internal/releases"
 	"github.com/footprintai/containarium/internal/security"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
@@ -32,20 +33,20 @@ import (
 
 // GatewayServer implements the HTTP/REST gateway for the gRPC service
 type GatewayServer struct {
-	grpcAddress        string
-	httpPort           int
-	authMiddleware     *auth.AuthMiddleware
-	swaggerDir         string
-	certsDir           string // Optional: for mTLS connection to gRPC server
-	caddyCertDir       string // Optional: Caddy certificate directory for /certs endpoint
-	grafanaBackendURL      string // Optional: internal Grafana URL for reverse proxy (e.g., "http://10.0.3.229:3000")
-	alertmanagerBackendURL string // Optional: internal Alertmanager URL for reverse proxy (e.g., "http://10.0.3.229:9093")
-	securityStore      *security.Store // Optional: for CSV export endpoint
-	auditStore         *audit.Store    // Optional: for HTTP audit middleware
-	terminalHandler     *TerminalHandler
-	labelHandler        *LabelHandler
-	eventHandler        *EventHandler
-	coreServicesHandler *CoreServicesHandler
+	grpcAddress            string
+	httpPort               int
+	authMiddleware         *auth.AuthMiddleware
+	swaggerDir             string
+	certsDir               string          // Optional: for mTLS connection to gRPC server
+	caddyCertDir           string          // Optional: Caddy certificate directory for /certs endpoint
+	grafanaBackendURL      string          // Optional: internal Grafana URL for reverse proxy (e.g., "http://10.0.3.229:3000")
+	alertmanagerBackendURL string          // Optional: internal Alertmanager URL for reverse proxy (e.g., "http://10.0.3.229:9093")
+	securityStore          *security.Store // Optional: for CSV export endpoint
+	auditStore             *audit.Store    // Optional: for HTTP audit middleware
+	terminalHandler        *TerminalHandler
+	labelHandler           *LabelHandler
+	eventHandler           *EventHandler
+	coreServicesHandler    *CoreServicesHandler
 
 	// Guacamole reverse proxy (browser-based RDP for Windows VMs)
 	guacamoleBackendURL string
@@ -107,12 +108,12 @@ func NewGatewayServer(grpcAddress string, httpPort int, authMiddleware *auth.Aut
 	eventHandler := NewEventHandler(events.GetBus())
 
 	return &GatewayServer{
-		grpcAddress:     grpcAddress,
-		httpPort:        httpPort,
-		authMiddleware:  authMiddleware,
-		swaggerDir:      swaggerDir,
-		certsDir:        certsDir,
-		caddyCertDir:    caddyCertDir,
+		grpcAddress:         grpcAddress,
+		httpPort:            httpPort,
+		authMiddleware:      authMiddleware,
+		swaggerDir:          swaggerDir,
+		certsDir:            certsDir,
+		caddyCertDir:        caddyCertDir,
 		terminalHandler:     terminalHandler,
 		labelHandler:        labelHandler,
 		eventHandler:        eventHandler,
@@ -630,6 +631,11 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 		registerAuditEndpoint(httpMux, gs.auditStore, gs.authMiddleware)
 		log.Printf("Audit logs endpoint enabled at /v1/audit/logs")
 	}
+
+	// Version-visibility endpoint (#354): this daemon's version + the latest
+	// published GitHub release (cached 1h) so the webui / CLI can show drift.
+	registerVersionEndpoints(httpMux, releases.NewClient(), gs.authMiddleware)
+	log.Printf("Version endpoint enabled at /v1/releases/latest")
 
 	// Backends endpoint. The LIST (GET /v1/backends) is now the proto-first
 	// ContainerService.ListBackends RPC — it flows through the grpc-gateway

--- a/internal/gateway/version_handler.go
+++ b/internal/gateway/version_handler.go
@@ -1,0 +1,80 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/releases"
+	"github.com/footprintai/containarium/pkg/version"
+)
+
+// registerVersionEndpoints wires the version-visibility endpoints (#354):
+//
+//   - GET /v1/releases/latest — this daemon's running version alongside the
+//     latest published GitHub release and a "behind" flag, so the webui /
+//     `containarium version --check` can show drift in one call. The GitHub
+//     lookup is cached (rc) so page loads don't burn the unauthenticated
+//     rate limit.
+//
+// Per-backend versions come from the existing /v1/backends; the sentinel's
+// version comes from its own /sentinel/version (internal/sentinel).
+//
+// Bearer-auth gated like the other /v1 introspection endpoints — the webui
+// already sends the session token.
+func registerVersionEndpoints(mux *http.ServeMux, rc *releases.Client, authMW *auth.AuthMiddleware) {
+	mux.HandleFunc("/v1/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		if !requireBearer(w, r, authMW) {
+			return
+		}
+		rel, cached, err := rc.Latest(r.Context())
+		if err != nil {
+			http.Error(w, `{"error":"failed to fetch latest release","code":502}`, http.StatusBadGateway)
+			return
+		}
+		cur := version.GetVersion()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(latestReleaseResponse{
+			Current:     cur,
+			Latest:      rel.TagName,
+			Name:        rel.Name,
+			HTMLURL:     rel.HTMLURL,
+			PublishedAt: rel.PublishedAt.UTC().Format(time.RFC3339),
+			Behind:      releases.IsBehind(cur, rel.TagName),
+			CheckedAt:   time.Now().UTC().Format(time.RFC3339),
+			Cached:      cached,
+		})
+	})
+}
+
+// latestReleaseResponse is the JSON for GET /v1/releases/latest. camelCase
+// to match the webui's other endpoints (audit, etc.).
+type latestReleaseResponse struct {
+	Current     string `json:"current"`     // this daemon's running version
+	Latest      string `json:"latest"`      // latest published GitHub tag
+	Name        string `json:"name"`        // release title
+	HTMLURL     string `json:"htmlUrl"`     // release page
+	PublishedAt string `json:"publishedAt"` // RFC3339
+	Behind      bool   `json:"behind"`      // current < latest
+	CheckedAt   string `json:"checkedAt"`   // when the daemon answered
+	Cached      bool   `json:"cached"`      // served from the daemon's 1h cache
+}
+
+// requireBearer enforces a valid Bearer token, writing a 401 and returning
+// false when absent/invalid. Mirrors the audit / security-export endpoints
+// (Authorization header only — never a ?token= query param, which leaks
+// into proxy logs).
+func requireBearer(w http.ResponseWriter, r *http.Request, authMW *auth.AuthMiddleware) bool {
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		http.Error(w, `{"error":"unauthorized: Bearer token required in Authorization header","code":401}`, http.StatusUnauthorized)
+		return false
+	}
+	if _, err := authMW.ValidateToken(strings.TrimPrefix(authHeader, "Bearer ")); err != nil {
+		http.Error(w, `{"error":"unauthorized: invalid token","code":401}`, http.StatusUnauthorized)
+		return false
+	}
+	return true
+}

--- a/internal/gateway/version_handler_test.go
+++ b/internal/gateway/version_handler_test.go
@@ -1,0 +1,97 @@
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/releases"
+	"github.com/footprintai/containarium/pkg/version"
+)
+
+// fakeGitHubLatest serves a minimal GitHub "latest release" response.
+func fakeGitHubLatest(t *testing.T, tag string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"tag_name":%q,"name":"Release %s","html_url":"https://github.com/x/releases/%s","published_at":"2026-06-01T00:00:00Z"}`, tag, tag, tag)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newVersionMux(t *testing.T, tag string) (*http.ServeMux, string) {
+	t.Helper()
+	tm, err := auth.NewTokenManager("test-secret-key-for-version-handler-test", "test-issuer")
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	tok, err := tm.GenerateToken("alice", []string{"admin"}, 0)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	gh := fakeGitHubLatest(t, tag)
+	rc := releases.NewClient(releases.WithURL(gh.URL))
+	mux := http.NewServeMux()
+	registerVersionEndpoints(mux, rc, auth.NewAuthMiddleware(tm))
+	return mux, tok
+}
+
+func TestVersionEndpoint_RequiresAuth(t *testing.T) {
+	mux, _ := newVersionMux(t, "v99.0.0")
+	req := httptest.NewRequest(http.MethodGet, "/v1/releases/latest", nil) // no Bearer
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no-auth status = %d, want 401", rec.Code)
+	}
+}
+
+func TestVersionEndpoint_ReportsBehind(t *testing.T) {
+	// Latest is far ahead of whatever this build's version is, so behind=true.
+	mux, tok := newVersionMux(t, "v99.0.0")
+	req := httptest.NewRequest(http.MethodGet, "/v1/releases/latest", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	var resp latestReleaseResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Current != version.GetVersion() {
+		t.Errorf("current = %q, want %q", resp.Current, version.GetVersion())
+	}
+	if resp.Latest != "v99.0.0" {
+		t.Errorf("latest = %q, want v99.0.0", resp.Latest)
+	}
+	if !resp.Behind {
+		t.Errorf("behind = false, want true (current %s < v99.0.0)", resp.Current)
+	}
+	if resp.CheckedAt == "" {
+		t.Error("checkedAt should be populated")
+	}
+}
+
+func TestVersionEndpoint_UpToDate(t *testing.T) {
+	// Latest equals this build's version → behind=false.
+	mux, tok := newVersionMux(t, version.GetVersion())
+	req := httptest.NewRequest(http.MethodGet, "/v1/releases/latest", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	var resp latestReleaseResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Behind {
+		t.Errorf("behind = true, want false when current == latest (%s)", resp.Current)
+	}
+}

--- a/internal/releases/releases.go
+++ b/internal/releases/releases.go
@@ -1,0 +1,164 @@
+// Package releases fetches the project's latest published GitHub release
+// and caches it, so operators can see "a newer version is available"
+// without every page load burning GitHub's unauthenticated rate limit
+// (60 req/h/IP). It backs the /v1/releases/latest endpoint and the
+// `containarium version --check` CLI. See issue #354.
+package releases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultLatestURL is GitHub's "latest published release" API for this repo.
+const DefaultLatestURL = "https://api.github.com/repos/FootprintAI/Containarium/releases/latest"
+
+// DefaultTTL is how long a fetched release is served from cache before the
+// next upstream call. One hour keeps us far under the rate limit while
+// still surfacing a new release the same operating session.
+const DefaultTTL = time.Hour
+
+// Release is the subset of GitHub's release record we surface.
+type Release struct {
+	TagName     string    `json:"tag_name"`
+	Name        string    `json:"name"`
+	HTMLURL     string    `json:"html_url"`
+	PublishedAt time.Time `json:"published_at"`
+}
+
+// Client fetches and caches the latest release. Safe for concurrent use.
+type Client struct {
+	url string
+	ttl time.Duration
+	hc  *http.Client
+	now func() time.Time
+
+	mu        sync.Mutex
+	cached    *Release
+	fetchedAt time.Time
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithURL overrides the upstream URL (tests point it at an httptest server).
+func WithURL(u string) Option { return func(c *Client) { c.url = u } }
+
+// WithTTL overrides the cache TTL.
+func WithTTL(d time.Duration) Option { return func(c *Client) { c.ttl = d } }
+
+// WithHTTPClient overrides the HTTP client.
+func WithHTTPClient(hc *http.Client) Option { return func(c *Client) { c.hc = hc } }
+
+// WithClock overrides the time source (tests advance it to expire the cache).
+func WithClock(now func() time.Time) Option { return func(c *Client) { c.now = now } }
+
+// NewClient builds a Client with sensible defaults.
+func NewClient(opts ...Option) *Client {
+	c := &Client{
+		url: DefaultLatestURL,
+		ttl: DefaultTTL,
+		hc:  &http.Client{Timeout: 10 * time.Second},
+		now: time.Now,
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// Latest returns the latest release. The second return value is true when
+// the result was served from cache. On an upstream error a still-cached
+// (stale) value is served if one exists — staleness beats a hard failure
+// for a "newer version available" hint — and the error is returned only
+// when there is nothing cached to fall back to.
+func (c *Client) Latest(ctx context.Context) (*Release, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.cached != nil && c.now().Sub(c.fetchedAt) < c.ttl {
+		return c.cached, true, nil
+	}
+
+	rel, err := c.fetch(ctx)
+	if err != nil {
+		if c.cached != nil {
+			return c.cached, true, nil // serve stale rather than fail
+		}
+		return nil, false, err
+	}
+	c.cached = rel
+	c.fetchedAt = c.now()
+	return rel, false, nil
+}
+
+func (c *Client) fetch(ctx context.Context) (*Release, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch latest release: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github releases API returned %d", resp.StatusCode)
+	}
+	var rel Release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("decode release: %w", err)
+	}
+	if rel.TagName == "" {
+		return nil, fmt.Errorf("release has empty tag_name")
+	}
+	return &rel, nil
+}
+
+// Compare returns -1, 0, or +1 as semantic version a is less than, equal
+// to, or greater than b. A leading "v" and any pre-release/build suffix
+// (after '-' or '+') are ignored — sufficient for this project's vX.Y.Z
+// release tags. A non-numeric or missing component sorts as 0.
+func Compare(a, b string) int {
+	pa, pb := splitVersion(a), splitVersion(b)
+	for i := 0; i < 3; i++ {
+		if pa[i] != pb[i] {
+			if pa[i] < pb[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+// IsBehind reports whether current is an older release than latest.
+func IsBehind(current, latest string) bool {
+	return Compare(current, latest) < 0
+}
+
+// splitVersion turns "v0.22.10" / "0.22.10-rc1" into [0,22,10].
+func splitVersion(s string) [3]int {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+	// Drop pre-release / build metadata.
+	if i := strings.IndexAny(s, "-+"); i >= 0 {
+		s = s[:i]
+	}
+	var out [3]int
+	for i, part := range strings.SplitN(s, ".", 3) {
+		if i > 2 {
+			break
+		}
+		n, _ := strconv.Atoi(strings.TrimSpace(part))
+		out[i] = n
+	}
+	return out
+}

--- a/internal/releases/releases_test.go
+++ b/internal/releases/releases_test.go
@@ -1,0 +1,133 @@
+package releases
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func fakeGitHub(t *testing.T, tag string, hits *int32) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"tag_name":%q,"name":"Release %s","html_url":"https://github.com/x/releases/%s","published_at":"2026-06-01T00:00:00Z"}`, tag, tag, tag)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestLatest_CachesWithinTTL(t *testing.T) {
+	var hits int32
+	srv := fakeGitHub(t, "v0.23.0", &hits)
+	c := NewClient(WithURL(srv.URL), WithTTL(time.Hour))
+
+	rel, cached, err := c.Latest(context.Background())
+	if err != nil {
+		t.Fatalf("first Latest: %v", err)
+	}
+	if cached {
+		t.Error("first call should not be from cache")
+	}
+	if rel.TagName != "v0.23.0" {
+		t.Errorf("tag = %q", rel.TagName)
+	}
+
+	// Second call within TTL → cache hit, no extra upstream request.
+	_, cached2, err := c.Latest(context.Background())
+	if err != nil || !cached2 {
+		t.Fatalf("second Latest: cached=%v err=%v", cached2, err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("expected 1 upstream hit, got %d", got)
+	}
+}
+
+func TestLatest_RefetchesAfterTTL(t *testing.T) {
+	var hits int32
+	srv := fakeGitHub(t, "v0.23.0", &hits)
+	now := time.Unix(1_000_000, 0)
+	c := NewClient(WithURL(srv.URL), WithTTL(time.Hour), WithClock(func() time.Time { return now }))
+
+	if _, _, err := c.Latest(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(2 * time.Hour) // advance past TTL
+	if _, cached, err := c.Latest(context.Background()); err != nil || cached {
+		t.Fatalf("post-TTL call should refetch: cached=%v err=%v", cached, err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Errorf("expected 2 upstream hits, got %d", got)
+	}
+}
+
+func TestLatest_ServesStaleOnError(t *testing.T) {
+	var hits int32
+	flaky := int32(0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		if atomic.AddInt32(&flaky, 1) == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"tag_name":"v0.23.0"}`)
+			return
+		}
+		http.Error(w, "rate limited", http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+
+	now := time.Unix(1_000_000, 0)
+	c := NewClient(WithURL(srv.URL), WithTTL(time.Minute), WithClock(func() time.Time { return now }))
+
+	if _, _, err := c.Latest(context.Background()); err != nil {
+		t.Fatalf("seed fetch: %v", err)
+	}
+	now = now.Add(2 * time.Minute) // expire cache; next fetch errors
+	rel, cached, err := c.Latest(context.Background())
+	if err != nil {
+		t.Fatalf("should serve stale on error, got err %v", err)
+	}
+	if !cached || rel.TagName != "v0.23.0" {
+		t.Errorf("expected stale cached v0.23.0, got cached=%v rel=%+v", cached, rel)
+	}
+}
+
+func TestLatest_ErrorWhenNoCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	c := NewClient(WithURL(srv.URL))
+	if _, _, err := c.Latest(context.Background()); err == nil {
+		t.Fatal("expected error with no cache to fall back to")
+	}
+}
+
+func TestCompareAndIsBehind(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"0.22.10", "0.22.10", 0},
+		{"v0.22.10", "0.22.10", 0}, // leading v ignored
+		{"0.22.9", "0.22.10", -1},  // numeric, not lexical (9 < 10)
+		{"0.23.0", "0.22.10", 1},
+		{"1.0.0", "0.99.99", 1},
+		{"0.22.10-rc1", "0.22.10", 0}, // pre-release suffix ignored
+		{"0.22", "0.22.0", 0},         // missing patch == 0
+	}
+	for _, tc := range cases {
+		if got := Compare(tc.a, tc.b); got != tc.want {
+			t.Errorf("Compare(%q,%q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+	if !IsBehind("0.22.9", "0.22.10") {
+		t.Error("0.22.9 should be behind 0.22.10")
+	}
+	if IsBehind("0.23.0", "0.22.10") {
+		t.Error("0.23.0 should not be behind 0.22.10")
+	}
+}

--- a/internal/sentinel/binaryserver.go
+++ b/internal/sentinel/binaryserver.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/version"
 )
 
 const defaultBinaryPath = "/usr/local/bin/containarium"
@@ -75,6 +76,17 @@ func StartBinaryServer(port int, manager *Manager) (stop func(), err error) {
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("ok"))
+	})
+
+	// Version endpoint (#354) — lets the webui's Versions panel show the
+	// sentinel's running version alongside each backend's (from the
+	// daemon's /v1/backends) and the latest GitHub release (from the
+	// daemon's /v1/releases/latest). Unauthenticated: it reveals only the
+	// build version, the same as the binary the sentinel already serves at
+	// /containarium for peers to pull.
+	mux.HandleFunc("/sentinel/version", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(version.Get())
 	})
 
 	// Peers endpoint — for daemon multi-backend discovery


### PR DESCRIPTION
Implements the backend of #354 Phase A (version display).

## Problem
Operators couldn't see at a glance what version each component runs, whether they're drifted, or whether a newer release exists — the gap that turned #341 into a 4-daemon-on-a-stale-version incident.

## What's here (verifiable backend slice)
- **`internal/releases`** — cached GitHub latest-release client (1h TTL; serves stale on upstream error so a rate-limit blip doesn't break the check) + numeric semver `Compare`/`IsBehind`. **Fully unit-tested** (cache hit, TTL refetch, stale-on-error, error-when-no-cache, version compare incl. `0.22.9 < 0.22.10` and `v`/pre-release handling).
- **`GET /v1/releases/latest`** (daemon gateway) — returns the daemon's running version + the latest published release + a `behind` flag in one call. Bearer-auth gated like the other `/v1` introspection endpoints; the GitHub lookup is cached so page loads don't burn the unauthenticated rate limit. **Handler-tested** (401 without auth; behind; up-to-date).
- **`GET /sentinel/version`** (sentinel control plane) — the sentinel's build version for the panel's Sentinel row. Per-backend versions already come from `/v1/backends`.
- **`containarium version --check`** — server-less GitHub lookup that prints current/latest and flags drift.

## What's NOT here (scoped out, deliberately)
- **The webui Versions panel itself.** The webui ships as a **built Next.js static export** (`internal/gateway/webui/_next/*`); changing it needs the UI source repo + JS toolchain, which isn't in this Go repo and couldn't be verified here. These endpoints are exactly the data that panel renders — it's a thin follow-up.
- **Phases B/C** (sentinel GitHub-fetch + one-click per-backend upgrade) — the issue scopes them separately.

## Test plan
`go build ./...` ✅; `go test ./internal/releases/ ./internal/gateway/ ./internal/cmd/` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)