### PR TITLE
fix(mcp): decode proto-JSON string-encoded int64 in list_backends

### DIFF
--- a/internal/mcp/backends_decode_test.go
+++ b/internal/mcp/backends_decode_test.go
@@ -1,0 +1,76 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestListBackends_DecodesProtoJSONStringInts is the regression test for the
+// list_backends decode bug: grpc-gateway's protojson serializes int64 as a
+// QUOTED STRING, which the prior plain-int64 fields rejected ("cannot
+// unmarshal string into int64"), failing the whole response. flexInt64 must
+// accept the string form (and the number form, for mixed-fleet safety).
+func TestListBackends_DecodesProtoJSONStringInts(t *testing.T) {
+	// Exactly the shape a proto-first daemon emits: int64s as strings.
+	wire := `{
+	  "backends": [
+	    {
+	      "id": "tunnel-fts-13700k-gpu",
+	      "type": "tunnel",
+	      "healthy": true,
+	      "uptimeSeconds": "123456",
+	      "containerCount": 7,
+	      "gpus": [{"vendor":"NVIDIA","modelName":"RTX 3090","vramBytes":"25769803776"}]
+	    }
+	  ]
+	}`
+	var resp ListBackendsResponse
+	if err := json.Unmarshal([]byte(wire), &resp); err != nil {
+		t.Fatalf("decode proto-JSON (string int64) failed: %v", err)
+	}
+	if len(resp.Backends) != 1 {
+		t.Fatalf("got %d backends, want 1", len(resp.Backends))
+	}
+	b := resp.Backends[0]
+	if b.UptimeSeconds != 123456 {
+		t.Errorf("UptimeSeconds = %d, want 123456", b.UptimeSeconds)
+	}
+	if len(b.GPUs) != 1 || b.GPUs[0].VRAMBytes != 25769803776 {
+		t.Errorf("VRAMBytes = %d, want 25769803776", b.GPUs[0].VRAMBytes)
+	}
+}
+
+// TestListBackends_DecodesNumberInts ensures the number form still works
+// (a daemon / hand-coded handler that emits bare numbers).
+func TestListBackends_DecodesNumberInts(t *testing.T) {
+	wire := `{"backends":[{"id":"local","type":"local","healthy":true,"uptimeSeconds":42,"gpus":[{"vramBytes":1024}]}]}`
+	var resp ListBackendsResponse
+	if err := json.Unmarshal([]byte(wire), &resp); err != nil {
+		t.Fatalf("decode number int64 failed: %v", err)
+	}
+	if resp.Backends[0].UptimeSeconds != 42 {
+		t.Errorf("UptimeSeconds = %d, want 42", resp.Backends[0].UptimeSeconds)
+	}
+	if resp.Backends[0].GPUs[0].VRAMBytes != 1024 {
+		t.Errorf("VRAMBytes = %d, want 1024", resp.Backends[0].GPUs[0].VRAMBytes)
+	}
+}
+
+// TestFlexInt64_EmptyAndNull tolerates omitted/null values → 0.
+func TestFlexInt64_EmptyAndNull(t *testing.T) {
+	var v struct {
+		N flexInt64 `json:"n"`
+	}
+	// null and "" exercise flexInt64.UnmarshalJSON → 0. (An absent key
+	// isn't tested: encoding/json never calls UnmarshalJSON for it, so the
+	// field keeps its prior value — standard behavior, not flexInt64's job.)
+	for _, in := range []string{`{"n":null}`, `{"n":""}`} {
+		v.N = 7
+		if err := json.Unmarshal([]byte(in), &v); err != nil {
+			t.Fatalf("decode %q: %v", in, err)
+		}
+		if v.N != 0 {
+			t.Errorf("decode %q: N = %d, want 0", in, v.N)
+		}
+	}
+}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1176,12 +1177,17 @@ type GetSystemInfoResponse struct {
 	Info SystemInfo `json:"info"`
 }
 
-// ListBackendsResponse mirrors the /v1/backends wire shape — now the
-// proto-first ContainerService.ListBackends RPC (BackendInfo), which
-// replaced the former hand-coded handler (#354). The MCP client keeps its
-// own struct rather than importing the generated type; the field tags are
-// the grpc-gateway camelCase the gateway emits, and int64 fields arrive as
-// numbers, so no `,string` tags are needed.
+// ListBackendsResponse mirrors the /v1/backends wire shape — the proto-first
+// ContainerService.ListBackends RPC (BackendInfo), which replaced the former
+// hand-coded handler (#354). The MCP client keeps its own struct rather than
+// importing the generated type.
+//
+// 64-bit int fields use flexInt64: grpc-gateway's protojson serializes int64
+// as a QUOTED STRING ("12345"), not a number. The original plain-int64 fields
+// here therefore failed to decode every response from a proto-first daemon
+// ("cannot unmarshal string into int64"), silently breaking list_backends.
+// flexInt64 accepts both the string and number forms, so it works across
+// mixed daemon versions.
 type ListBackendsResponse struct {
 	Backends []Backend `json:"backends"`
 }
@@ -1192,7 +1198,7 @@ type Backend struct {
 	Healthy        bool         `json:"healthy"`
 	Version        string       `json:"version,omitempty"`
 	Hostname       string       `json:"hostname,omitempty"`
-	UptimeSeconds  int64        `json:"uptimeSeconds,omitempty"`
+	UptimeSeconds  flexInt64    `json:"uptimeSeconds,omitempty"`
 	LastSeenAt     string       `json:"lastSeenAt,omitempty"`
 	OS             string       `json:"os,omitempty"`
 	ContainerCount int32        `json:"containerCount"`
@@ -1200,9 +1206,28 @@ type Backend struct {
 }
 
 type BackendGPU struct {
-	Vendor    string `json:"vendor,omitempty"`
-	ModelName string `json:"modelName,omitempty"`
-	VRAMBytes int64  `json:"vramBytes,omitempty"`
+	Vendor    string    `json:"vendor,omitempty"`
+	ModelName string    `json:"modelName,omitempty"`
+	VRAMBytes flexInt64 `json:"vramBytes,omitempty"`
+}
+
+// flexInt64 decodes an int64 that may arrive as a JSON number OR, as
+// grpc-gateway's protojson encodes 64-bit ints, a quoted string. encoding/json
+// would reject the string form into a plain int64; this accepts both.
+type flexInt64 int64
+
+func (n *flexInt64) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), `"`)
+	if s == "" || s == "null" {
+		*n = 0
+		return nil
+	}
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return fmt.Errorf("flexInt64: cannot parse %q as int64: %w", s, err)
+	}
+	*n = flexInt64(v)
+	return nil
 }
 
 // AddRouteRequest mirrors network.proto's AddRouteRequest. JSON field

--- a/internal/mcp/testdata/list_backends_response.json
+++ b/internal/mcp/testdata/list_backends_response.json
@@ -6,7 +6,7 @@
       "healthy": true,
       "version": "0.16.4",
       "hostname": "demo-backend-local",
-      "uptimeSeconds": 345600,
+      "uptimeSeconds": "345600",
       "lastSeenAt": "2026-05-10T19:00:00Z",
       "os": "Ubuntu 24.04.1 LTS",
       "containerCount": 16
@@ -20,7 +20,7 @@
       "os": "Ubuntu 24.04.1 LTS",
       "containerCount": 4,
       "gpus": [
-        {"vendor": "NVIDIA", "modelName": "GeForce RTX 3090", "vramBytes": 25769803776}
+        {"vendor": "NVIDIA", "modelName": "GeForce RTX 3090", "vramBytes": "25769803776"}
       ]
     },
     {
@@ -32,7 +32,7 @@
       "os": "Ubuntu 24.04.1 LTS",
       "containerCount": 0,
       "gpus": [
-        {"vendor": "NVIDIA", "modelName": "GeForce RTX 4090", "vramBytes": 25769803776}
+        {"vendor": "NVIDIA", "modelName": "GeForce RTX 4090", "vramBytes": "25769803776"}
       ]
     }
   ]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1647,7 +1647,7 @@ func writeBackendDetail(b *strings.Builder, bk *Backend) {
 	}
 	fmt.Fprintf(b, "   Containers: %d running\n", bk.ContainerCount)
 	if bk.UptimeSeconds > 0 {
-		fmt.Fprintf(b, "   Uptime:     %s\n", formatUptime(bk.UptimeSeconds))
+		fmt.Fprintf(b, "   Uptime:     %s\n", formatUptime(int64(bk.UptimeSeconds)))
 	}
 	if bk.LastSeenAt != "" && bk.Type != "local" {
 		fmt.Fprintf(b, "   Last seen:  %s\n", bk.LastSeenAt)
@@ -1657,7 +1657,7 @@ func writeBackendDetail(b *strings.Builder, bk *Backend) {
 		for _, g := range bk.GPUs {
 			vram := ""
 			if g.VRAMBytes > 0 {
-				vram = fmt.Sprintf(" — %s VRAM", humanBytes(g.VRAMBytes))
+				vram = fmt.Sprintf(" — %s VRAM", humanBytes(int64(g.VRAMBytes)))
 			}
 			fmt.Fprintf(b, "     - %s %s%s\n", g.Vendor, g.ModelName, vram)
 		}

--- a/internal/mcp/wire_format_test.go
+++ b/internal/mcp/wire_format_test.go
@@ -134,20 +134,21 @@ func TestWireFormat_ListBackends(t *testing.T) {
 	assert.True(t, local.Healthy)
 	assert.Equal(t, "0.16.4", local.Version)
 	assert.Equal(t, int32(16), local.ContainerCount)
-	// uptimeSeconds is int64 but emitted as a JSON NUMBER here (not a
-	// string) — the /v1/backends handler is hand-coded, not
-	// grpc-gateway, so it doesn't string-encode int64. Confirm decode.
-	assert.Equal(t, int64(345600), local.UptimeSeconds)
+	// uptimeSeconds is int64, which the proto-first /v1/backends RPC
+	// (grpc-gateway protojson, #354) string-encodes ("345600"). flexInt64
+	// decodes that string form; EqualValues compares the numeric value
+	// regardless of the flexInt64 vs int64 type.
+	assert.EqualValues(t, 345600, local.UptimeSeconds)
 
-	// Second backend is a tunnel peer with a GPU. VRAMBytes is also
-	// int64-as-number, not int64-as-string.
+	// Second backend is a tunnel peer with a GPU. VRAMBytes is likewise an
+	// int64 string-encoded by protojson.
 	gpuPeer := resp.Backends[1]
 	assert.Equal(t, "tunnel", gpuPeer.Type)
 	assert.True(t, gpuPeer.Healthy)
 	require.Len(t, gpuPeer.GPUs, 1)
 	assert.Equal(t, "NVIDIA", gpuPeer.GPUs[0].Vendor)
 	assert.Equal(t, "GeForce RTX 3090", gpuPeer.GPUs[0].ModelName)
-	assert.Equal(t, int64(25769803776), gpuPeer.GPUs[0].VRAMBytes) // 24 GiB
+	assert.EqualValues(t, 25769803776, gpuPeer.GPUs[0].VRAMBytes) // 24 GiB
 
 	// Third backend is unhealthy — health flag must round-trip false
 	// (no "omitempty" gotcha eating the field).


### PR DESCRIPTION
## Bug

`list_backends` (platform MCP) errors against every current daemon:
```
MCP error -32603: failed to list backends: failed to unmarshal response:
json: cannot unmarshal string into Go struct field Backend.backends.uptimeSeconds of type int64
```
When `/v1/backends` became the **proto-first** `ListBackends` RPC (#354), grpc-gateway's protojson began serializing int64 as a **quoted string** (`"345600"`), but the MCP client's `Backend` struct still declared `UptimeSeconds`/`VRAMBytes` as plain `int64`. encoding/json rejects a string into int64, so the **entire** response fails to decode — `list_backends` returns an error instead of the topology, which blocks every backend-reasoning op (e.g. "which peer has a GPU to validate?").

Found while probing for a GPU backend (`fts-13700k`) to drive `backend_validate_gpu` — the call never got past decode.

## Fix
- `flexInt64`: an int64 that unmarshals from a JSON number **or** a quoted string (robust across mixed daemon versions).
- Apply to `Backend.UptimeSeconds` and `BackendGPU.VRAMBytes`; cast to int64 at the two format sites.
- Update the testdata fixture to the **real** proto-first wire (string-encoded int64) and correct the stale comment that asserted the handler "emits numbers" — that wrong assumption is exactly what broke.

## Tests
- `TestListBackends_DecodesProtoJSONStringInts` — the regression (string form).
- `TestListBackends_DecodesNumberInts` — number form still works (mixed fleet).
- `TestFlexInt64_EmptyAndNull`, and the existing `TestWireFormat_ListBackends` updated.
- `go build ./...` ✅; full `internal/mcp` suite ✅.

> Note: the **running** mcp-server process must be rebuilt/restarted to pick this up (MCP binaries are long-lived). The daemon side is unaffected — this is purely the client decoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)