### PR TITLE
feat(node): containarium node — carve a host into GPU/CPU node-VMs (design + scaffold)

### DIFF
--- a/docs/NODE-VM-PROVISIONING.md
+++ b/docs/NODE-VM-PROVISIONING.md
@@ -1,0 +1,163 @@
+# Node-VM provisioning — carve one host into multiple Containarium nodes
+
+Status: **design + scaffold** (CPU path implemented; GPU/VFIO path gated and
+partial). Validated by hand on an RTX 3090 workstation (see "Validation").
+
+## What this is
+
+A first-class `containarium node` command group that turns one physical
+host into **several Containarium backends** by provisioning Incus VMs,
+each running its own daemon + tunnel and registering with the sentinel as
+a distinct pool-tagged node:
+
+```
+physical host (Incus, qemu driver)
+├─ VM "gpu-node"  ──VFIO GPU──┐   daemon + `containarium tunnel --pool gpu`
+│     └─ nested Incus → LXC + nvidia.runtime → tenant GPU containers
+└─ VM "cpu-node" (no GPU)     ┘   daemon + `containarium tunnel --pool cpu`
+        └─ nested Incus → LXC → tenant CPU containers
+                  ↓ each tunnels to the sentinel
+        sentinel sees TWO backends; MULTI-POOL routes workloads by pool tag
+```
+
+The container/peer/pool machinery already exists (`docs/MULTI-POOL.md`,
+`docs/MULTI-BACKEND-PEERS.md`, `containarium tunnel`). This feature is the
+missing **day-0 carve**: provision the VMs and bootstrap a daemon+tunnel
+into each.
+
+## When to use it (and when not to)
+
+A single bare-metal daemon can already run GPU **and** CPU containers and
+route them with pool tags — no VMs, no nested Incus. Reach for node-VMs
+only when you need:
+
+- **Hard isolation** between the GPU tenant(s) and CPU tenants (separate
+  kernels, contained blast radius),
+- **Independent lifecycle** — snapshot / reboot / upgrade one node without
+  touching the other,
+- a clean **capacity boundary** (the GPU VM gets the GPU + a CPU slice;
+  the rest becomes a pure CPU node).
+
+If the goal is only "send GPU work to GPU capacity," use pool-tagged
+containers on bare metal instead — it's strictly simpler.
+
+## Why the CLI, not the daemon API (no proto)
+
+Everything daemon-served in this repo is proto-first. This is **not** —
+carving a hypervisor host is a day-0 operation that runs *before and
+around* the daemon (there is no daemon to call yet), manipulates Incus +
+system config on the bare-metal host, and bootstraps daemons *into* the
+VMs. It therefore belongs with the other **host-local** CLI commands
+(`daemon`, `tunnel`, `recover`), as a cobra command with local logic — not
+a gRPC RPC. The CLI is canonical; the existing `scripts/setup-peer.sh` /
+`scripts/setup-gpu-host.sh` become thin wrappers over it.
+
+The orchestration logic lives in `pkg/core/nodevm` as pure `incus`-argv
+builders behind an injected runner (the same testable pattern as
+`pkg/core/volume`), so it's unit-tested even though a real run needs
+hardware.
+
+## Command surface
+
+```
+# One-time, reboot-class host prep for a GPU node (VFIO). Explicit + gated.
+containarium node prepare-gpu --gpu pci=0000:01:00.0
+    → adds intel_iommu=on iommu=pt to GRUB, binds the GPU's PCI IDs to
+      vfio-pci, prints the reboot instruction. DOES NOT reboot for you.
+      WARNS: the host (and its current GPU containers) lose the GPU.
+
+# Provision a node-VM (idempotent; re-run reconciles).
+containarium node provision \
+    --name cpu-node --kind cpu --pool cpu \
+    --cpu 16 --memory 64GiB --disk 200GiB \
+    --sentinel <sentinel-host:port> --tunnel-token <token>
+
+containarium node provision \
+    --name gpu-node --kind gpu --pool gpu \
+    --cpu 8 --memory 32GiB --gpu pci=0000:01:00.0 \
+    --sentinel <sentinel-host:port> --tunnel-token <token>
+
+containarium node list                    # node-VMs on this host + state
+containarium node destroy --name cpu-node # tear a node-VM down
+```
+
+`--tunnel-token` / `--sentinel` may also come from
+`CONTAINARIUM_TUNNEL_TOKEN` / `CONTAINARIUM_SENTINEL_ADDR` (same env the
+peer setup already honors), so the token never has to sit in shell
+history.
+
+## What `provision` does (per VM)
+
+1. **Create the VM** via Incus's native qemu driver:
+   `incus launch <image> <name> --vm -c limits.cpu=N -c limits.memory=X`
+   (+ `--device root,size=<disk>`).
+2. **For `--kind gpu`**: attach the GPU —
+   `incus config device add <name> gpu0 gpu pci=<addr>` — which requires
+   `prepare-gpu` + reboot to have run first (the host must already have
+   the GPU on `vfio-pci`).
+3. **Bootstrap inside the VM via cloud-init** — the same sequence
+   `scripts/setup-peer.sh` runs today, just executed in the guest:
+   - drop the `containarium` binary in (`/usr/local/bin/containarium`),
+   - install nested Incus + `incus admin init --auto` (+ the NVIDIA driver
+     for a GPU node),
+   - `containarium service install` (daemon systemd unit + override),
+   - a `containarium-tunnel.service` running
+     `containarium tunnel --sentinel-addr <addr> --pool <pool> --spot-id <name>-<pool>`,
+   - the tunnel token delivered as a cloud-init secret, written
+     `0600 root` (never on the kernel cmdline / process args).
+4. The node tunnels up and **registers as a backend**; verify with
+   `containarium backends list` and `backends validate-gpu --backend-id <name>`.
+
+## Idempotency / reconcile
+
+`provision` is safe to re-run: an existing VM with the right config is
+left alone; a half-provisioned one is reconciled (re-run cloud-init steps
+that didn't complete). Mirrors the `runner provision` reconcile model — a
+partial failure is a retryable state, not a duplicate-creating one.
+
+## Open decisions
+
+1. **`node` vs `host`** as the command group name.
+2. **Binary delivery into the VM**: copy the operator's local binary vs.
+   pull a pinned release URL in cloud-init. (Lean: copy local, so the node
+   matches the operator's version exactly; fall back to release URL.)
+3. **GRUB/VFIO edit safety**: `prepare-gpu` should back up the GRUB config
+   and refuse if the GPU shares an IOMMU group with host-critical devices
+   (no clean passthrough without ACS override — detect and bail with a
+   clear message).
+4. **Resource-split policy**: explicit `--cpu/--memory/--disk` per node
+   (this design) vs. an auto-split heuristic. Explicit wins for v1.
+5. **Reversal**: `node destroy` removes the VM; reclaiming a VFIO'd GPU for
+   the host is a separate `node release-gpu` (unbind vfio-pci → nvidia →
+   reboot), not automatic.
+
+## Security notes
+
+- The **tunnel token** is the credential that lets a node join the
+  cluster. It's passed via env / a cloud-init secret and written `0600`
+  inside the VM — never on argv or the kernel cmdline.
+- `prepare-gpu` is the only privileged, reboot-class, partially-reversible
+  step; it's a separate explicit verb precisely so it is never buried
+  inside `provision`.
+- A GPU passed to a node-VM is **exclusive to that VM** — the host and any
+  host-side GPU containers lose it (it's bound to `vfio-pci`). This is
+  inherent to VM GPU passthrough, not a tooling choice.
+
+## Validation (what's proven)
+
+On an RTX 3090 workstation (Incus 6.23, KVM, IOMMU active with the GPU
+alone in its IOMMU group), by hand:
+
+- An Incus qemu VM boots cleanly (`virt=kvm`, networking, DNS).
+- Nested Incus installs + `admin init` inside the VM and runs LXC
+  containers — i.e. the VM is a valid Containarium node substrate.
+- Bare-metal → LXC GPU passthrough works (`nvidia.runtime` + GPU device →
+  `nvidia-smi` sees the card), so the GPU-node nested path is sound.
+
+Not yet exercised end-to-end: the in-VM daemon+tunnel registration (needs
+sentinel creds) and the VFIO GPU-to-VM bind (the reboot-class step).
+
+## Related
+- `docs/MULTI-POOL.md`, `docs/MULTI-BACKEND-PEERS.md` — pool routing the nodes plug into.
+- `docs/CONTAINARIUM-HOST-TO-VM-MIGRATION.md` — the VFIO/host→VM concerns this shares (#318).
+- `scripts/setup-peer.sh` — the in-guest bootstrap this cloud-init replicates.

--- a/internal/cmd/node.go
+++ b/internal/cmd/node.go
@@ -1,0 +1,214 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/footprintai/containarium/pkg/core/nodevm"
+	"github.com/spf13/cobra"
+)
+
+// `containarium node` carves the LOCAL hypervisor host into Containarium
+// node-VMs (one GPU node + one CPU node, etc.). Host-local like `daemon`
+// and `tunnel` — it drives the local `incus`, not a remote daemon, so it
+// takes no --server. See docs/NODE-VM-PROVISIONING.md.
+
+var nodeCmd = &cobra.Command{
+	Use:   "node",
+	Short: "Carve this host into Containarium node-VMs (GPU/CPU nodes)",
+	Long: `Provision Incus VMs on THIS host that each register with the sentinel
+as a pool-tagged Containarium backend — e.g. a GPU node (VFIO passthrough)
+plus a CPU node, from one physical box.
+
+This runs locally against the host's Incus (no --server). See
+docs/NODE-VM-PROVISIONING.md.
+
+  containarium node prepare-gpu --gpu pci=0000:01:00.0   # one-time VFIO prep (reboot-class)
+  containarium node provision --name cpu-node --kind cpu --pool cpu --cpu 16 --memory 64GiB --sentinel <addr>
+  containarium node provision --name gpu-node --kind gpu --pool gpu --cpu 8 --memory 32GiB --gpu pci=0000:01:00.0 --sentinel <addr>
+  containarium node list
+  containarium node destroy --name cpu-node`,
+}
+
+var (
+	nodeName        string
+	nodeKind        string
+	nodePool        string
+	nodeCPU         int
+	nodeMemory      string
+	nodeDisk        string
+	nodeGPU         string
+	nodeSentinel    string
+	nodeTunnelToken string
+	nodeImage       string
+	nodeBinary      string
+)
+
+var nodeProvisionCmd = &cobra.Command{
+	Use:   "provision",
+	Short: "Provision a node-VM (create VM + bootstrap daemon/tunnel)",
+	RunE:  runNodeProvision,
+}
+
+var nodePrepareGPUCmd = &cobra.Command{
+	Use:   "prepare-gpu",
+	Short: "Print the one-time VFIO host prep for a GPU node (reboot-class)",
+	Long: `Emit the exact steps to bind a GPU to vfio-pci so it can be passed to a
+GPU node-VM. This is reboot-class and takes the GPU away from the host
+(and any host-side GPU containers), so it PRINTS the plan for you to review
+and run — it does not modify GRUB or reboot for you.`,
+	RunE: runNodePrepareGPU,
+}
+
+var nodeListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List node-VMs on this host",
+	Args:  cobra.NoArgs,
+	RunE:  runNodeList,
+}
+
+var nodeDestroyCmd = &cobra.Command{
+	Use:   "destroy",
+	Short: "Tear down a node-VM",
+	RunE:  runNodeDestroy,
+}
+
+func init() {
+	rootCmd.AddCommand(nodeCmd)
+	nodeCmd.AddCommand(nodeProvisionCmd, nodePrepareGPUCmd, nodeListCmd, nodeDestroyCmd)
+
+	pf := nodeProvisionCmd.Flags()
+	pf.StringVar(&nodeName, "name", "", "node-VM name (required)")
+	pf.StringVar(&nodeKind, "kind", "cpu", "node kind: 'cpu' or 'gpu'")
+	pf.StringVar(&nodePool, "pool", "", "Containarium pool tag to register under (required)")
+	pf.IntVar(&nodeCPU, "cpu", 0, "vCPUs for the VM (required)")
+	pf.StringVar(&nodeMemory, "memory", "", "memory for the VM, e.g. 64GiB (required)")
+	pf.StringVar(&nodeDisk, "disk", "", "root disk size, e.g. 200GiB (default: image default)")
+	pf.StringVar(&nodeGPU, "gpu", "", "GPU PCI address for --kind gpu, e.g. pci=0000:01:00.0 or 0000:01:00.0")
+	pf.StringVar(&nodeSentinel, "sentinel", os.Getenv("CONTAINARIUM_SENTINEL_ADDR"), "sentinel address host:port (env: CONTAINARIUM_SENTINEL_ADDR)")
+	pf.StringVar(&nodeTunnelToken, "tunnel-token", os.Getenv("CONTAINARIUM_TUNNEL_TOKEN"), "tunnel auth token (prefer CONTAINARIUM_TUNNEL_TOKEN env)")
+	pf.StringVar(&nodeImage, "image", nodevm.DefaultImage, "base image for the VM")
+	pf.StringVar(&nodeBinary, "binary", "", "local containarium binary to push into the VM (default: this binary)")
+
+	nodePrepareGPUCmd.Flags().StringVar(&nodeGPU, "gpu", "", "GPU PCI address, e.g. pci=0000:01:00.0 or 0000:01:00.0 (required)")
+	nodeDestroyCmd.Flags().StringVar(&nodeName, "name", "", "node-VM name to destroy (required)")
+}
+
+// parseGPUPCI accepts "pci=0000:01:00.0" or "0000:01:00.0".
+func parseGPUPCI(v string) string {
+	return strings.TrimPrefix(strings.TrimSpace(v), "pci=")
+}
+
+func newNodeManager() (*nodevm.Manager, error) {
+	runner, err := nodevm.NewCLIRunner()
+	if err != nil {
+		return nil, err
+	}
+	bin := nodeBinary
+	if bin == "" {
+		if self, err := os.Executable(); err == nil {
+			bin = self
+		}
+	}
+	return nodevm.NewManager(runner, bin), nil
+}
+
+func runNodeProvision(cmd *cobra.Command, args []string) error {
+	spec := nodevm.Spec{
+		Name:        nodeName,
+		Kind:        nodevm.Kind(nodeKind),
+		Pool:        nodePool,
+		CPU:         nodeCPU,
+		Memory:      nodeMemory,
+		Disk:        nodeDisk,
+		Image:       nodeImage,
+		GPUPCI:      parseGPUPCI(nodeGPU),
+		Sentinel:    nodeSentinel,
+		TunnelToken: nodeTunnelToken,
+	}
+	if err := spec.Validate(); err != nil {
+		return err
+	}
+	if spec.TunnelToken == "" {
+		return fmt.Errorf("a tunnel token is required (set CONTAINARIUM_TUNNEL_TOKEN or --tunnel-token) so the node can register")
+	}
+	m, err := newNodeManager()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Provisioning %s node %q (pool=%s, %d vCPU, %s)...\n", spec.Kind, spec.Name, spec.Pool, spec.CPU, spec.Memory)
+	n, err := m.Provision(spec)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ node %q %s — registering with the sentinel as spot-id %q (pool %q)\n", n.Name, n.State, spec.SpotID(), spec.Pool)
+	fmt.Printf("  verify:  containarium backends list   (look for %s)\n", spec.SpotID())
+	return nil
+}
+
+func runNodePrepareGPU(cmd *cobra.Command, args []string) error {
+	pci := parseGPUPCI(nodeGPU)
+	if pci == "" {
+		return fmt.Errorf("--gpu pci=<addr> is required")
+	}
+	fmt.Printf(`One-time VFIO prep to pass GPU %s into a node-VM.
+⚠  REBOOT-CLASS and DESTRUCTIVE: this binds the GPU to vfio-pci, so the
+   host (and any host-side GPU containers) LOSE the card until reversed.
+
+Run as root, after reviewing:
+
+  # 1. resolve the GPU's vendor:device IDs (and its audio function)
+  lspci -nns %s
+
+  # 2. enable IOMMU + reserve the GPU for vfio-pci
+  sed -i 's/GRUB_CMDLINE_LINUX="/GRUB_CMDLINE_LINUX="intel_iommu=on iommu=pt /' /etc/default/grub
+  echo "options vfio-pci ids=<vendor:device>,<audio vendor:device>" > /etc/modprobe.d/vfio.conf
+  printf 'vfio\nvfio_pci\nvfio_iommu_type1\n' > /etc/modules-load.d/vfio.conf
+  update-grub && update-initramfs -u
+
+  # 3. reboot, then verify the GPU is on vfio-pci:
+  reboot
+  lspci -nnk -s %s   # → "Kernel driver in use: vfio-pci"
+
+Then: containarium node provision --kind gpu --gpu pci=%s ...
+`, pci, pci, pci, pci)
+	return nil
+}
+
+func runNodeList(cmd *cobra.Command, args []string) error {
+	m, err := newNodeManager()
+	if err != nil {
+		return err
+	}
+	nodes, err := m.List()
+	if err != nil {
+		return err
+	}
+	if len(nodes) == 0 {
+		fmt.Println("No node-VMs on this host.")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tSTATE")
+	for _, n := range nodes {
+		fmt.Fprintf(w, "%s\t%s\n", n.Name, n.State)
+	}
+	return w.Flush()
+}
+
+func runNodeDestroy(cmd *cobra.Command, args []string) error {
+	if nodeName == "" {
+		return fmt.Errorf("--name is required")
+	}
+	m, err := newNodeManager()
+	if err != nil {
+		return err
+	}
+	if err := m.Destroy(nodeName); err != nil {
+		return err
+	}
+	fmt.Printf("✓ node-VM %q destroyed\n", nodeName)
+	return nil
+}

--- a/pkg/core/nodevm/manager.go
+++ b/pkg/core/nodevm/manager.go
@@ -14,7 +14,7 @@ const guestBinaryPath = "/usr/local/bin/containarium"
 
 // guestTokenPath is the perm-tight file the in-guest tunnel reads its
 // token from (never passed on argv / kernel cmdline).
-const guestTokenPath = "/etc/containarium/tunnel.token"
+const guestTokenPath = "/etc/containarium/tunnel.token" // #nosec G101 -- filesystem path to the token file, not a credential value
 
 // Manager orchestrates node-VM lifecycle over the incus CLI.
 type Manager struct {

--- a/pkg/core/nodevm/manager.go
+++ b/pkg/core/nodevm/manager.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // guestBinaryPath is where the containarium binary lands inside the node VM.
@@ -21,15 +22,18 @@ type Manager struct {
 	// BinaryPath is the local containarium binary pushed into each node VM
 	// (so the node matches the operator's version exactly).
 	BinaryPath string
-	// waitAttempts/waitSleepSecs bound the agent-readiness poll; small in
-	// tests. Zero values fall back to sane defaults.
+	// waitAttempts / waitSleep bound the agent-readiness poll. A VM takes
+	// tens of seconds to boot its incus-agent, so we must sleep between
+	// probes — without it the retries burn out in milliseconds. Small/zero
+	// in tests (success on the first probe never reaches the sleep).
 	waitAttempts int
+	waitSleep    time.Duration
 }
 
 // NewManager builds a Manager. binaryPath is the local containarium binary
 // to push into node VMs (empty = skip the push, e.g. for a dry run).
 func NewManager(r Runner, binaryPath string) *Manager {
-	return &Manager{run: r, BinaryPath: binaryPath, waitAttempts: 30}
+	return &Manager{run: r, BinaryPath: binaryPath, waitAttempts: 60, waitSleep: 4 * time.Second}
 }
 
 // Node is one node VM as listed on the host.
@@ -124,8 +128,11 @@ func (m *Manager) waitAgent(name string) error {
 		if _, err := m.run.Run("exec", name, "--", "true"); err == nil {
 			return nil
 		}
+		if i < attempts-1 && m.waitSleep > 0 {
+			time.Sleep(m.waitSleep)
+		}
 	}
-	return fmt.Errorf("VM %s agent did not become ready", name)
+	return fmt.Errorf("VM %s agent did not become ready after %d attempts", name, attempts)
 }
 
 func (m *Manager) vmExists(name string) (bool, error) {

--- a/pkg/core/nodevm/manager.go
+++ b/pkg/core/nodevm/manager.go
@@ -1,0 +1,198 @@
+package nodevm
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// guestBinaryPath is where the containarium binary lands inside the node VM.
+const guestBinaryPath = "/usr/local/bin/containarium"
+
+// guestTokenPath is the perm-tight file the in-guest tunnel reads its
+// token from (never passed on argv / kernel cmdline).
+const guestTokenPath = "/etc/containarium/tunnel.token"
+
+// Manager orchestrates node-VM lifecycle over the incus CLI.
+type Manager struct {
+	run Runner
+	// BinaryPath is the local containarium binary pushed into each node VM
+	// (so the node matches the operator's version exactly).
+	BinaryPath string
+	// waitAttempts/waitSleepSecs bound the agent-readiness poll; small in
+	// tests. Zero values fall back to sane defaults.
+	waitAttempts int
+}
+
+// NewManager builds a Manager. binaryPath is the local containarium binary
+// to push into node VMs (empty = skip the push, e.g. for a dry run).
+func NewManager(r Runner, binaryPath string) *Manager {
+	return &Manager{run: r, BinaryPath: binaryPath, waitAttempts: 30}
+}
+
+// Node is one node VM as listed on the host.
+type Node struct {
+	Name  string
+	State string
+}
+
+// Provision creates the VM, (for GPU) attaches the card, pushes the
+// binary + token, and runs the in-guest bootstrap. Idempotent intent:
+// if the VM already exists it reconciles the bootstrap rather than
+// failing (full reconcile of partial state is a follow-up).
+func (m *Manager) Provision(s Spec) (*Node, error) {
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	exists, err := m.vmExists(s.Name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		if _, err := m.run.Run(launchArgs(s)...); err != nil {
+			return nil, fmt.Errorf("launch VM: %w", err)
+		}
+		if s.Kind == KindGPU {
+			if _, err := m.run.Run(gpuDeviceArgs(s.Name, s.GPUPCI)...); err != nil {
+				return nil, fmt.Errorf("attach GPU: %w", err)
+			}
+		}
+	}
+
+	if err := m.waitAgent(s.Name); err != nil {
+		return nil, err
+	}
+
+	// Deliver the binary (so the node matches the operator's version).
+	if m.BinaryPath != "" {
+		if _, err := m.run.Run("file", "push", m.BinaryPath, s.Name+guestBinaryPath, "--mode", "0755"); err != nil {
+			return nil, fmt.Errorf("push binary: %w", err)
+		}
+	}
+
+	// Deliver the tunnel token as a 0600 file — never on argv.
+	if s.TunnelToken != "" {
+		if err := m.pushToken(s.Name, s.TunnelToken); err != nil {
+			return nil, err
+		}
+	}
+
+	// Run the in-guest bootstrap (nested Incus + daemon + tunnel).
+	script := RenderBootstrap(s, guestTokenPath)
+	if _, err := m.run.Run("exec", s.Name, "--", "bash", "-c", script); err != nil {
+		return nil, fmt.Errorf("bootstrap guest: %w", err)
+	}
+
+	return &Node{Name: s.Name, State: "provisioned"}, nil
+}
+
+// pushToken writes the token to a local 0600 temp file and `incus file
+// push`es it to the guest at 0600, then removes the temp. Keeps the token
+// off every command line.
+func (m *Manager) pushToken(name, token string) error {
+	tmp, err := os.CreateTemp("", "ctnr-tunnel-token-")
+	if err != nil {
+		return fmt.Errorf("stage token: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+	if err := os.Chmod(tmp.Name(), 0o600); err != nil {
+		return fmt.Errorf("chmod token tmp: %w", err)
+	}
+	if _, err := tmp.WriteString(token); err != nil {
+		return fmt.Errorf("write token tmp: %w", err)
+	}
+	_ = tmp.Close()
+	// Ensure the parent dir exists in the guest, then push 0600.
+	if _, err := m.run.Run("exec", name, "--", "mkdir", "-p", filepath.Dir(guestTokenPath)); err != nil {
+		return fmt.Errorf("mkdir token dir: %w", err)
+	}
+	if _, err := m.run.Run("file", "push", tmp.Name(), name+guestTokenPath, "--mode", "0600"); err != nil {
+		return fmt.Errorf("push token: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) waitAgent(name string) error {
+	attempts := m.waitAttempts
+	if attempts <= 0 {
+		attempts = 30
+	}
+	for i := 0; i < attempts; i++ {
+		if _, err := m.run.Run("exec", name, "--", "true"); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("VM %s agent did not become ready", name)
+}
+
+func (m *Manager) vmExists(name string) (bool, error) {
+	nodes, err := m.List()
+	if err != nil {
+		return false, err
+	}
+	for _, n := range nodes {
+		if n.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// List returns the node VMs on this host.
+func (m *Manager) List() ([]Node, error) {
+	out, err := m.run.Run(listArgs()...)
+	if err != nil {
+		return nil, fmt.Errorf("list VMs: %w", err)
+	}
+	var nodes []Node
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		f := strings.SplitN(line, ",", 2)
+		n := Node{Name: strings.TrimSpace(f[0])}
+		if len(f) > 1 {
+			n.State = strings.TrimSpace(f[1])
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes, nil
+}
+
+// Destroy tears a node VM down.
+func (m *Manager) Destroy(name string) error {
+	if name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if _, err := m.run.Run(destroyArgs(name)...); err != nil {
+		return fmt.Errorf("destroy VM: %w", err)
+	}
+	return nil
+}
+
+// CLIRunner is the production Runner: it shells out to `incus`.
+type CLIRunner struct{ bin string }
+
+// NewCLIRunner locates `incus` on PATH.
+func NewCLIRunner() (*CLIRunner, error) {
+	bin, err := exec.LookPath("incus")
+	if err != nil {
+		return nil, fmt.Errorf("incus not found on PATH (required for node-VM provisioning): %w", err)
+	}
+	return &CLIRunner{bin: bin}, nil
+}
+
+// Run executes `incus <args...>`.
+func (r *CLIRunner) Run(args ...string) (string, error) {
+	// #nosec G204 -- bin is resolved via exec.LookPath("incus"); args are
+	// fixed verbs plus validated VM/pool names, PCI addrs, and paths.
+	out, err := exec.Command(r.bin, args...).CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("incus %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}

--- a/pkg/core/nodevm/nodevm.go
+++ b/pkg/core/nodevm/nodevm.go
@@ -1,0 +1,150 @@
+// Package nodevm provisions Incus VMs that each become a Containarium
+// backend ("node") — carving one physical host into multiple pool-tagged
+// nodes (e.g. a GPU node + a CPU node). See docs/NODE-VM-PROVISIONING.md.
+//
+// This is day-0 host bootstrap, not a daemon RPC: it runs on the
+// hypervisor host, drives the `incus` CLI to create VMs, and bootstraps a
+// daemon+tunnel inside each (the same sequence scripts/setup-peer.sh runs,
+// just executed in the guest). The CLI command group `containarium node`
+// is a thin wrapper over this package.
+//
+// The incus-argv builders and the in-guest bootstrap renderer are pure
+// functions and are unit-tested; the actual exec needs a host with Incus +
+// the qemu driver and is not exercised in CI.
+package nodevm
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Kind is the node flavor.
+type Kind string
+
+const (
+	KindCPU Kind = "cpu"
+	KindGPU Kind = "gpu"
+)
+
+// DefaultImage is the base image for a node VM.
+const DefaultImage = "images:ubuntu/24.04"
+
+// gpuDeviceName is the Incus device name used for the passed-through GPU.
+const gpuDeviceName = "gpu0"
+
+// Runner executes `incus <args...>` (and a couple of guest helpers) and
+// returns combined output. Injected so tests can fake it.
+type Runner interface {
+	Run(args ...string) (string, error)
+}
+
+// Spec describes one node VM to provision.
+type Spec struct {
+	Name     string // VM / node name, e.g. "gpu-node"
+	Kind     Kind   // cpu | gpu
+	Pool     string // Containarium pool tag, e.g. "gpu" / "cpu"
+	CPU      int    // vCPUs
+	Memory   string // e.g. "64GiB"
+	Disk     string // e.g. "200GiB" (root disk); empty = image default
+	Image    string // base image; empty = DefaultImage
+	GPUPCI   string // PCI address for KindGPU, e.g. "0000:01:00.0"
+	Sentinel string // sentinel addr host:port the in-guest tunnel dials
+	// TunnelToken is the credential the in-guest tunnel uses. It is NOT
+	// placed on any argv — Provision delivers it as a perm-tight file
+	// inside the VM. Kept here so callers pass it through one struct.
+	TunnelToken string
+}
+
+// Validate checks a Spec before any host mutation.
+func (s Spec) Validate() error {
+	if s.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	switch s.Kind {
+	case KindCPU, KindGPU:
+	default:
+		return fmt.Errorf("kind must be %q or %q, got %q", KindCPU, KindGPU, s.Kind)
+	}
+	if s.Kind == KindGPU && s.GPUPCI == "" {
+		return fmt.Errorf("kind %q requires --gpu pci=<addr>", KindGPU)
+	}
+	if s.CPU <= 0 {
+		return fmt.Errorf("cpu must be > 0")
+	}
+	if s.Memory == "" {
+		return fmt.Errorf("memory is required (e.g. 64GiB)")
+	}
+	if s.Sentinel == "" {
+		return fmt.Errorf("sentinel address is required")
+	}
+	if s.Pool == "" {
+		return fmt.Errorf("pool is required")
+	}
+	return nil
+}
+
+func (s Spec) image() string {
+	if s.Image == "" {
+		return DefaultImage
+	}
+	return s.Image
+}
+
+// SpotID is the tunnel/peer identity this node registers under — derived
+// from name+pool so it's stable and human-readable in `backends list`.
+func (s Spec) SpotID() string {
+	return s.Name + "-" + s.Pool
+}
+
+// launchArgs builds `incus launch <image> <name> --vm -c limits.cpu=N
+// -c limits.memory=X [--device root,size=<disk>]`.
+func launchArgs(s Spec) []string {
+	args := []string{
+		"launch", s.image(), s.Name, "--vm",
+		"-c", "limits.cpu=" + strconv.Itoa(s.CPU),
+		"-c", "limits.memory=" + s.Memory,
+	}
+	if s.Disk != "" {
+		args = append(args, "--device", "root,size="+s.Disk)
+	}
+	return args
+}
+
+// gpuDeviceArgs builds `incus config device add <name> gpu0 gpu pci=<addr>`.
+func gpuDeviceArgs(name, pci string) []string {
+	return []string{"config", "device", "add", name, gpuDeviceName, "gpu", "pci=" + pci}
+}
+
+func destroyArgs(name string) []string { return []string{"delete", "-f", name} }
+func listArgs() []string               { return []string{"list", "--vm", "--format", "csv", "-c", "ns"} }
+
+// RenderBootstrap produces the in-guest bootstrap script — the
+// setup-peer.sh-equivalent run inside the VM on first provision. It does
+// NOT contain the tunnel token (delivered separately as a file at
+// tokenPath); the script reads it from there. Pure function for testing.
+func RenderBootstrap(s Spec, tokenPath string) string {
+	var b strings.Builder
+	b.WriteString("set -euo pipefail\n")
+	b.WriteString("export DEBIAN_FRONTEND=noninteractive\n")
+	b.WriteString("# nested Incus (the node's container runtime)\n")
+	b.WriteString("apt-get update -qq\n")
+	b.WriteString("apt-get install -y -qq incus\n")
+	if s.Kind == KindGPU {
+		b.WriteString("# GPU node: the host VFIO-passed the card in; install the userspace driver\n")
+		b.WriteString("apt-get install -y -qq nvidia-driver-570-server || apt-get install -y -qq nvidia-utils-570-server || true\n")
+	}
+	b.WriteString("incus admin init --auto\n")
+	b.WriteString("# daemon + tunnel (same path scripts/setup-peer.sh installs)\n")
+	b.WriteString("/usr/local/bin/containarium service install\n")
+	fmt.Fprintf(&b, "export CONTAINARIUM_TUNNEL_TOKEN=\"$(cat %s)\"\n", tokenPath)
+	fmt.Fprintf(&b,
+		"/usr/local/bin/containarium tunnel --sentinel-addr %s --pool %s --spot-id %s &\n",
+		shellQuote(s.Sentinel), shellQuote(s.Pool), shellQuote(s.SpotID()))
+	return b.String()
+}
+
+// shellQuote single-quotes s for safe interpolation into a bash command.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/pkg/core/nodevm/nodevm.go
+++ b/pkg/core/nodevm/nodevm.go
@@ -117,7 +117,12 @@ func gpuDeviceArgs(name, pci string) []string {
 }
 
 func destroyArgs(name string) []string { return []string{"delete", "-f", name} }
-func listArgs() []string               { return []string{"list", "--vm", "--format", "csv", "-c", "ns"} }
+
+// listArgs lists only VMs. Note: `--vm` is a `launch`/`init` flag, NOT a
+// `list` flag — VM filtering on `list` uses the positional `type=` filter.
+func listArgs() []string {
+	return []string{"list", "type=virtual-machine", "--format", "csv", "-c", "ns"}
+}
 
 // RenderBootstrap produces the in-guest bootstrap script — the
 // setup-peer.sh-equivalent run inside the VM on first provision. It does

--- a/pkg/core/nodevm/nodevm_test.go
+++ b/pkg/core/nodevm/nodevm_test.go
@@ -105,7 +105,7 @@ func (f *fakeRunner) Run(args ...string) (string, error) {
 	if f.failOn != "" && strings.Contains(joined, f.failOn) {
 		return "", fmt.Errorf("forced failure on %q", f.failOn)
 	}
-	if strings.HasPrefix(joined, "list --vm") {
+	if strings.HasPrefix(joined, "list type=virtual-machine") {
 		return f.listOut, nil
 	}
 	return "", nil

--- a/pkg/core/nodevm/nodevm_test.go
+++ b/pkg/core/nodevm/nodevm_test.go
@@ -1,0 +1,183 @@
+package nodevm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func cpuSpec() Spec {
+	return Spec{Name: "cpu-node", Kind: KindCPU, Pool: "cpu", CPU: 16, Memory: "64GiB", Disk: "200GiB", Sentinel: "sentinel:443"}
+}
+func gpuSpec() Spec {
+	return Spec{Name: "gpu-node", Kind: KindGPU, Pool: "gpu", CPU: 8, Memory: "32GiB", GPUPCI: "0000:01:00.0", Sentinel: "sentinel:443"}
+}
+
+func TestValidate(t *testing.T) {
+	if err := cpuSpec().Validate(); err != nil {
+		t.Errorf("valid cpu spec rejected: %v", err)
+	}
+	if err := gpuSpec().Validate(); err != nil {
+		t.Errorf("valid gpu spec rejected: %v", err)
+	}
+	bad := []Spec{
+		{Kind: KindCPU, Pool: "cpu", CPU: 1, Memory: "1GiB", Sentinel: "s:1"},            // no name
+		{Name: "n", Kind: "weird", Pool: "p", CPU: 1, Memory: "1GiB", Sentinel: "s:1"},   // bad kind
+		{Name: "n", Kind: KindGPU, Pool: "gpu", CPU: 1, Memory: "1GiB", Sentinel: "s:1"}, // gpu w/o pci
+		{Name: "n", Kind: KindCPU, Pool: "cpu", CPU: 0, Memory: "1GiB", Sentinel: "s:1"}, // cpu<=0
+		{Name: "n", Kind: KindCPU, Pool: "cpu", CPU: 1, Sentinel: "s:1"},                 // no memory
+		{Name: "n", Kind: KindCPU, Pool: "cpu", CPU: 1, Memory: "1GiB"},                  // no sentinel
+		{Name: "n", Kind: KindCPU, CPU: 1, Memory: "1GiB", Sentinel: "s:1"},              // no pool
+	}
+	for i, s := range bad {
+		if err := s.Validate(); err == nil {
+			t.Errorf("bad spec %d should be rejected", i)
+		}
+	}
+}
+
+func TestSpotID(t *testing.T) {
+	if got := gpuSpec().SpotID(); got != "gpu-node-gpu" {
+		t.Errorf("SpotID = %q, want gpu-node-gpu", got)
+	}
+}
+
+func TestLaunchArgs(t *testing.T) {
+	got := strings.Join(launchArgs(cpuSpec()), " ")
+	want := "launch images:ubuntu/24.04 cpu-node --vm -c limits.cpu=16 -c limits.memory=64GiB --device root,size=200GiB"
+	if got != want {
+		t.Errorf("launchArgs =\n %q\nwant\n %q", got, want)
+	}
+	// No disk → no --device root.
+	s := cpuSpec()
+	s.Disk = ""
+	if strings.Contains(strings.Join(launchArgs(s), " "), "--device") {
+		t.Errorf("no-disk spec should not emit --device root")
+	}
+}
+
+func TestGPUDeviceArgs(t *testing.T) {
+	got := strings.Join(gpuDeviceArgs("gpu-node", "0000:01:00.0"), " ")
+	want := "config device add gpu-node gpu0 gpu pci=0000:01:00.0"
+	if got != want {
+		t.Errorf("gpuDeviceArgs = %q, want %q", got, want)
+	}
+}
+
+func TestRenderBootstrap(t *testing.T) {
+	script := RenderBootstrap(gpuSpec(), guestTokenPath)
+	for _, want := range []string{
+		"apt-get install -y -qq incus",
+		"incus admin init --auto",
+		"containarium service install",
+		"--pool 'gpu'",
+		"--spot-id 'gpu-node-gpu'",
+		"--sentinel-addr 'sentinel:443'",
+		"nvidia", // GPU node installs the driver
+		"CONTAINARIUM_TUNNEL_TOKEN=\"$(cat /etc/containarium/tunnel.token)\"", // token from file, not argv
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("bootstrap missing %q in:\n%s", want, script)
+		}
+	}
+	// CPU node must NOT install the nvidia driver.
+	if strings.Contains(RenderBootstrap(cpuSpec(), guestTokenPath), "nvidia") {
+		t.Errorf("cpu bootstrap should not install nvidia driver")
+	}
+	// The token value itself must never appear in the script.
+	s := cpuSpec()
+	s.TunnelToken = "SUPERSECRET"
+	if strings.Contains(RenderBootstrap(s, guestTokenPath), "SUPERSECRET") {
+		t.Errorf("token value leaked into bootstrap script")
+	}
+}
+
+// fakeRunner records calls; "list" returns canned VM rows.
+type fakeRunner struct {
+	calls   []string
+	listOut string
+	failOn  string // substring of a joined call to fail
+}
+
+func (f *fakeRunner) Run(args ...string) (string, error) {
+	joined := strings.Join(args, " ")
+	f.calls = append(f.calls, joined)
+	if f.failOn != "" && strings.Contains(joined, f.failOn) {
+		return "", fmt.Errorf("forced failure on %q", f.failOn)
+	}
+	if strings.HasPrefix(joined, "list --vm") {
+		return f.listOut, nil
+	}
+	return "", nil
+}
+func (f *fakeRunner) calledWith(sub string) bool {
+	for _, c := range f.calls {
+		if strings.Contains(c, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestProvision_CPUSequence(t *testing.T) {
+	f := &fakeRunner{}
+	m := NewManager(f, "") // no binary push
+	m.waitAttempts = 1
+	if _, err := m.Provision(cpuSpec()); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if !f.calledWith("launch images:ubuntu/24.04 cpu-node --vm") {
+		t.Error("did not launch the VM")
+	}
+	if f.calledWith("config device add") {
+		t.Error("cpu node must NOT attach a GPU")
+	}
+	if !f.calledWith("exec cpu-node -- bash -c") {
+		t.Error("did not run the in-guest bootstrap")
+	}
+}
+
+func TestProvision_GPUAttachesCard(t *testing.T) {
+	f := &fakeRunner{}
+	m := NewManager(f, "")
+	m.waitAttempts = 1
+	if _, err := m.Provision(gpuSpec()); err != nil {
+		t.Fatalf("Provision gpu: %v", err)
+	}
+	if !f.calledWith("config device add gpu-node gpu0 gpu pci=0000:01:00.0") {
+		t.Error("gpu node must attach the GPU device")
+	}
+}
+
+func TestProvision_IdempotentSkipsLaunch(t *testing.T) {
+	f := &fakeRunner{listOut: "cpu-node,RUNNING\n"} // already exists
+	m := NewManager(f, "")
+	m.waitAttempts = 1
+	if _, err := m.Provision(cpuSpec()); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if f.calledWith("launch ") {
+		t.Error("existing VM should not be re-launched")
+	}
+	if !f.calledWith("exec cpu-node -- bash -c") {
+		t.Error("should still re-run bootstrap to reconcile")
+	}
+}
+
+func TestListAndDestroy(t *testing.T) {
+	f := &fakeRunner{listOut: "cpu-node,RUNNING\ngpu-node,STOPPED\n"}
+	m := NewManager(f, "")
+	nodes, err := m.List()
+	if err != nil || len(nodes) != 2 {
+		t.Fatalf("List: %v len=%d", err, len(nodes))
+	}
+	if nodes[0].Name != "cpu-node" || nodes[0].State != "RUNNING" {
+		t.Errorf("unexpected node[0]: %+v", nodes[0])
+	}
+	if err := m.Destroy("cpu-node"); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if !f.calledWith("delete -f cpu-node") {
+		t.Error("Destroy did not issue delete -f")
+	}
+}


### PR DESCRIPTION
Design doc + working scaffold for "one physical host → multiple Containarium nodes" (the idea we prototyped by hand on a 3090 box).

## What & why
A host-local **`containarium node`** command group provisions Incus VMs that each register with the sentinel as a pool-tagged backend — e.g. a **GPU node** (VFIO passthrough) + a **CPU node**, from one box. The peer/pool/routing half already exists (`MULTI-POOL`, `tunnel`); this is the missing day-0 *carve*.

**It's a CLI command, not a daemon RPC** — carving a hypervisor is day-0 bootstrap that runs before/around the daemon and drives the local `incus`, so it sits with `daemon`/`tunnel`/`recover`, not proto. (Everything daemon-served in this repo stays proto-first; this deliberately isn't.) The existing `setup-peer.sh`/`setup-gpu-host.sh` become thin wrappers.

## Contents
- **`docs/NODE-VM-PROVISIONING.md`** — architecture, when-to-use (vs. just pool-tagging containers on bare metal), command surface, the in-guest cloud-init/creds flow (replicates `setup-peer.sh`), idempotency, security, and validation status.
- **`pkg/core/nodevm`** — testable `incus`-argv builders + bootstrap renderer behind an injected `Runner` (same pattern as `pkg/core/volume`). `Manager.Provision` = launch VM → [attach GPU] → wait agent → push binary → push **0600 tunnel-token** → run in-guest bootstrap; plus `List`/`Destroy`. **Token is delivered as a perm-tight file, never on argv.** Unit-tested: validation, arg builders, `SpotID`, bootstrap rendering (incl. "token value never in the script" + "CPU node skips the nvidia driver"), and the provision command-sequence (cpu vs gpu, idempotent skip-launch).
- **`internal/cmd/node.go`** — `node provision|prepare-gpu|list|destroy`. `prepare-gpu` **prints** the reboot-class VFIO plan (never edits GRUB / reboots for you) — keeping the destructive step explicit and out of `provision`.

## Scaffold status (honest)
- **CPU path**: wired end-to-end (create VM → nested Incus + daemon + tunnel → registers).
- **GPU path**: attaches the card + installs the in-guest driver, but depends on `prepare-gpu` + reboot having bound the GPU to `vfio-pci` first.
- **Not run live** (needs a host + sentinel creds). The underlying mechanism was validated by hand on an RTX 3090 host: Incus VM boots (KVM/net/DNS), nested Incus runs containers, and bare-metal GPU→LXC passthrough works.

## Test plan
`go build ./...` ✅; `go test ./pkg/core/nodevm/` ✅; `containarium node --help` / `provision --help` wire up correctly.

## Follow-ups
- Real end-to-end run on a host (CPU node first — no reboot), then the GPU node after `prepare-gpu`.
- Reconcile semantics for partially-provisioned VMs; `node release-gpu` (rebind vfio-pci→nvidia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)