### PR TITLE
fix(mcp): make the daemon's per-container ssh_host the source of truth for SSH

### DIFF
--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -64,7 +64,6 @@ func printUsage() {
 	log.Println("")
 	log.Println("Optional environment variables:")
 	log.Println("  CONTAINARIUM_DEBUG           - Enable debug logging (true/false)")
-	log.Println("  CONTAINARIUM_SENTINEL_HOST   - Public SSH endpoint, shown in create_container responses")
 	log.Println("")
 	log.Println("Example usage:")
 	log.Println("  export CONTAINARIUM_SERVER_URL='http://localhost:8080'")

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -16,9 +16,7 @@ import (
 	"github.com/footprintai/containarium/pkg/version"
 )
 
-// Client is a REST API client for Containarium. Carries a small amount
-// of non-HTTP deployment metadata (SentinelHost) so tool handlers that
-// need it can read it without a separate config plumbing layer.
+// Client is a REST API client for Containarium.
 type Client struct {
 	baseURL string
 
@@ -41,13 +39,6 @@ type Client struct {
 	// to the caller rather than buried in the startup log. Audit
 	// C-HIGH-1.
 	tlsConfigErr error
-
-	// SentinelHost, when set, is the public SSH endpoint for this
-	// deployment (e.g. "sentinel.example.com" or "34.42.156.100").
-	// create_container's response uses it to construct a complete
-	// ready-to-paste ssh command. Empty means the response falls
-	// back to a placeholder.
-	SentinelHost string
 }
 
 // NewClient creates a new Containarium REST API client.

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1288,6 +1288,12 @@ type Container struct {
 	PodmanEnabled bool              `json:"podmanEnabled"`
 	BackendID     string            `json:"backendId,omitempty"`
 	Pool          string            `json:"pool,omitempty"`
+	// SSHHost is the public SSH endpoint (the sentinel) clients dial to reach
+	// this container: `ssh <username>@<SSHHost>`. The daemon stamps it per
+	// container from its --ssh-host, so it is the source of truth for which
+	// sentinel a container belongs to. Empty in direct / no-sentinel
+	// deployments, where clients fall back to the container IP.
+	SSHHost string `json:"sshHost,omitempty"`
 }
 
 type NetworkInfo struct {

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -28,14 +28,6 @@ type Config struct {
 	// Whitespace around the token in the file is trimmed.
 	JWTTokenFile string
 
-	// SentinelHost is the public SSH endpoint for the deployment.
-	// When set, create_container's response includes a ready-to-paste
-	// `ssh -i <key> <user>@<sentinel-host>` command — agents don't have
-	// to figure out hostnames or modify ~/.ssh/config. Empty means
-	// the response falls back to a placeholder.
-	// Example: sentinel.example.com or 34.42.156.100
-	SentinelHost string
-
 	// Debug enables debug logging
 	Debug bool
 }
@@ -66,7 +58,6 @@ func LoadConfig() *Config {
 		ServerURL:    os.Getenv("CONTAINARIUM_SERVER_URL"),
 		JWTToken:     os.Getenv("CONTAINARIUM_JWT_TOKEN"),
 		JWTTokenFile: os.Getenv("CONTAINARIUM_JWT_TOKEN_FILE"),
-		SentinelHost: os.Getenv("CONTAINARIUM_SENTINEL_HOST"),
 		Debug:        debug,
 	}
 

--- a/internal/mcp/push.go
+++ b/internal/mcp/push.go
@@ -91,17 +91,20 @@ func handleSync(client *Client, args map[string]interface{}) (string, error) {
 	), nil
 }
 
-// pickSentinel prefers an explicit "sentinel" arg, then falls back to the
-// client's configured SentinelHost (which itself comes from
-// CONTAINARIUM_SENTINEL_HOST). Returning "" lets transfer.Options.resolve
-// fall back to the env var directly, which keeps the error message
-// uniform across both code paths.
+// pickSentinel prefers an explicit "sentinel" arg, then the target
+// container's daemon-stamped ssh_host — the sentinel it actually belongs
+// to. Returning "" (a direct / no-sentinel deployment, or a lookup miss)
+// lets transfer.Options.resolve surface the uniform "pass --sentinel" error.
 func pickSentinel(client *Client, args map[string]interface{}) string {
 	if h := getStringArg(args, "sentinel", ""); h != "" {
 		return h
 	}
-	if client != nil && client.SentinelHost != "" {
-		return client.SentinelHost
+	if client != nil {
+		if u := getStringArg(args, "username", ""); u != "" {
+			if resp, err := client.GetContainer(u); err == nil && resp.Container.SSHHost != "" {
+				return resp.Container.SSHHost
+			}
+		}
 	}
 	return ""
 }

--- a/internal/mcp/runner_tools.go
+++ b/internal/mcp/runner_tools.go
@@ -74,7 +74,7 @@ func runnerTools() []Tool {
 					},
 					"sentinel": map[string]interface{}{
 						"type":        "string",
-						"description": "Sentinel SSH host (default $CONTAINARIUM_SENTINEL_HOST). The install step SSHes into each new box through sshpiper at this address.",
+						"description": "Sentinel SSH host override. Default: each box's ssh_host (the sentinel it belongs to). The install step SSHes into each new box through sshpiper at this address.",
 					},
 					"ssh_key_path": map[string]interface{}{
 						"type":        "string",
@@ -215,12 +215,6 @@ func buildMCPRunnerDeps(client *Client, sentinel, sshKeyPath string, withSSH boo
 
 	var sshPubKey string
 	if withSSH {
-		if sentinel == "" {
-			sentinel = client.SentinelHost
-		}
-		if sentinel == "" {
-			return runner.Deps{}, "", fmt.Errorf("sentinel host is required (pass `sentinel` arg or set CONTAINARIUM_SENTINEL_HOST in the MCP env)")
-		}
 		pubPath, privPath, err := resolveMCPSSHKey(sshKeyPath)
 		if err != nil {
 			return runner.Deps{}, "", err
@@ -236,9 +230,21 @@ func buildMCPRunnerDeps(client *Client, sentinel, sshKeyPath string, withSSH boo
 		sshPubKey = string(pubBytes)
 		installer, err := runner.NewSSHInstaller(runner.SSHInstallerConfig{
 			Endpoint: runner.SSHEndpointFunc(func(_ context.Context, boxName string) (string, string, error) {
-				host, port, err := net.SplitHostPort(sentinel)
+				// Resolve this box's sentinel from its own daemon-stamped
+				// ssh_host (the sentinel it belongs to); an explicit `sentinel`
+				// arg overrides. No env var anywhere.
+				sh := sentinel
+				if sh == "" {
+					if resp, gcErr := client.GetContainer(boxName); gcErr == nil {
+						sh = resp.Container.SSHHost
+					}
+				}
+				if sh == "" {
+					return "", "", fmt.Errorf("no sentinel for box %s: daemon reported no ssh_host; pass the `sentinel` arg", boxName)
+				}
+				host, port, err := net.SplitHostPort(sh)
 				if err != nil {
-					host = sentinel
+					host = sh
 					port = "22"
 				}
 				return boxName, net.JoinHostPort(host, port), nil

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -23,7 +23,6 @@ func NewServer(config *Config) (*Server, error) {
 	if config.JWTTokenFile != "" {
 		client.SetTokenFile(config.JWTTokenFile)
 	}
-	client.SentinelHost = config.SentinelHost
 
 	server := &Server{
 		config: config,

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -635,7 +635,7 @@ func (s *Server) registerTools() {
 					},
 					"sentinel": map[string]interface{}{
 						"type":        "string",
-						"description": "Sentinel SSH host override. Default uses CONTAINARIUM_SENTINEL_HOST env.",
+						"description": "Sentinel SSH host override. Default: the container's ssh_host (the sentinel it belongs to, reported by the daemon).",
 					},
 					"key_path": map[string]interface{}{
 						"type":        "string",
@@ -688,7 +688,7 @@ func (s *Server) registerTools() {
 					},
 					"sentinel": map[string]interface{}{
 						"type":        "string",
-						"description": "Sentinel SSH host override. Default uses CONTAINARIUM_SENTINEL_HOST env.",
+						"description": "Sentinel SSH host override. Default: the container's ssh_host (the sentinel it belongs to, reported by the daemon).",
 					},
 					"key_path": map[string]interface{}{
 						"type":        "string",
@@ -1214,15 +1214,11 @@ func handleCreateContainer(client *Client, args map[string]interface{}) (string,
 			result += fmt.Sprintf("  ~/.containarium/keys/%s\n\n", resp.Container.Username)
 		}
 		result += "To SSH in:\n"
-		// Prefer the per-container sentinel the daemon stamps onto ssh_host —
-		// the daemon knows which sentinel each container belongs to, so the
-		// agent gets a reachable host straight from create_container with no
-		// env config. Fall back to the deployment-wide CONTAINARIUM_SENTINEL_HOST
-		// (client.SentinelHost), then a placeholder when neither is known.
+		// The daemon stamps ssh_host with the sentinel this container belongs
+		// to (from its --ssh-host), so the agent gets a reachable host straight
+		// from create_container — no env, no config. Empty means a direct /
+		// no-sentinel deployment, where the container IP is the way in.
 		sentinelHost := resp.Container.SSHHost
-		if sentinelHost == "" {
-			sentinelHost = client.SentinelHost
-		}
 		if sentinelHost == "" {
 			sentinelHost = "<sentinel-host>"
 		}
@@ -1234,9 +1230,10 @@ func handleCreateContainer(client *Client, args map[string]interface{}) (string,
 		result += "~/.ssh/, and sshpiper's failtoban counts each rejected offer toward\n"
 		result += "the ban quota. Workstations with several keys can get banned on a\n"
 		result += "single ssh attempt.\n\n"
-		if client.SentinelHost == "" {
-			result += "(Sentinel host not configured — set CONTAINARIUM_SENTINEL_HOST in the\n"
-			result += "MCP server's env, or call sync_ssh_config for an alias-based setup.)\n\n"
+		if resp.Container.SSHHost == "" {
+			result += "(The daemon reported no ssh_host for this container — a direct /\n"
+			result += "no-sentinel deployment. SSH to the container's IP directly, or call\n"
+			result += "sync_ssh_config for an alias-based setup.)\n\n"
 		}
 		// Include the key text regardless of save outcome — even on success
 		// it's useful for one-off copy to other machines (vendor laptop,

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1214,7 +1214,15 @@ func handleCreateContainer(client *Client, args map[string]interface{}) (string,
 			result += fmt.Sprintf("  ~/.containarium/keys/%s\n\n", resp.Container.Username)
 		}
 		result += "To SSH in:\n"
-		sentinelHost := client.SentinelHost
+		// Prefer the per-container sentinel the daemon stamps onto ssh_host —
+		// the daemon knows which sentinel each container belongs to, so the
+		// agent gets a reachable host straight from create_container with no
+		// env config. Fall back to the deployment-wide CONTAINARIUM_SENTINEL_HOST
+		// (client.SentinelHost), then a placeholder when neither is known.
+		sentinelHost := resp.Container.SSHHost
+		if sentinelHost == "" {
+			sentinelHost = client.SentinelHost
+		}
 		if sentinelHost == "" {
 			sentinelHost = "<sentinel-host>"
 		}

--- a/internal/mcp/wire_format_test.go
+++ b/internal/mcp/wire_format_test.go
@@ -122,6 +122,19 @@ func TestWireFormat_CreateContainer(t *testing.T) {
 	assert.Equal(t, int64(1771209160), resp.Container.CreatedAt)
 }
 
+// TestWireFormat_ContainerSSHHost guards a regression: the daemon stamps the
+// per-container sentinel onto ssh_host (from --ssh-host), but the MCP client's
+// Container struct lacked the field, so json.Unmarshal silently dropped the
+// reachable host and create_container fell back to the (often unset)
+// CONTAINARIUM_SENTINEL_HOST env — surfacing a "<sentinel-host>" placeholder
+// even though the daemon knew the real host all along.
+func TestWireFormat_ContainerSSHHost(t *testing.T) {
+	var c Container
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"username":"cld-30dc0e41","sshHost":"asia-east1.example.com"}`), &c))
+	assert.Equal(t, "asia-east1.example.com", c.SSHHost)
+}
+
 func TestWireFormat_ListBackends(t *testing.T) {
 	var resp ListBackendsResponse
 	require.NoError(t, json.Unmarshal(loadFixture(t, "list_backends_response.json"), &resp))


### PR DESCRIPTION
## Problem

The daemon stamps `Container.ssh_host` — the sentinel a container belongs to (from its `--ssh-host`) — onto every container in the read path (`internal/server/container_server.go`). But the MCP layer ignored it and used a static, deployment-wide `CONTAINARIUM_SENTINEL_HOST` env instead.

Two failures resulted:
1. The MCP client's `Container` struct had **no field** for `ssh_host`, so `json.Unmarshal` silently dropped it.
2. When the env was unset (the norm for multi-region / cloud deployments, where the sentinel differs per backend), `create_container` returned a `<sentinel-host>` placeholder — even though the daemon already returned the real, reachable host on the wire:

```
GET /v1/containers/<id> → { "container": { ..., "sshHost": "region-a.example.com" } }
```

So an agent couldn't learn where to SSH from the create response, despite the daemon knowing.

## Fix

**Commit 1 — surface it:**
- Add `Container.SSHHost` (`json:"sshHost,omitempty"`) so the field decodes.
- `create_container` / `get_container` now carry the daemon's per-container host.

**Commit 2 — make it the *sole* source; remove the env entirely:**
- Drop `Config.SentinelHost` / `Client.SentinelHost` and the `CONTAINARIUM_SENTINEL_HOST` read + server wiring.
- `create_container`: render the SSH host from `ssh_host` only (placeholder + direct-mode hint when the daemon reports none).
- `push` / `sync`: `pickSentinel` resolves the target container's `ssh_host` when no explicit `sentinel` arg.
- `runner provision`: the per-box install `Endpoint` resolves **each box's own** `ssh_host` (explicit `sentinel` arg still overrides), erroring clearly when the daemon reports none.
- Drop the env from the mcp-server help banner + tool-arg descriptions.

The CLI's own `--sentinel` flags (`internal/cmd`, `internal/transfer`) keep their env defaults — a separate operator-facing surface, intentionally out of scope.

## Result

Agents learn the correct per-container sentinel straight from `create_container`, with **zero env config** — the daemon is the single source of truth for which sentinel a container belongs to. This is exactly the gap that made `create_container` unusable on a multi-region cloud deployment whose sentinel isn't the env's value.

## Test

`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/mcp/...` all green; added `TestWireFormat_ContainerSSHHost` locking the decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)