### PR TITLE
chore(release): v0.23.0

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.22.10"
+	Version = "0.23.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Bumps `pkg/version/version.go` to 0.23.0 so the released binaries report the right version. Tag `v0.23.0` will be pushed after merge to trigger the release workflow (9 binaries + SHA256SUMS). Packages all merged `main` work since v0.22.10 — notably #503 (ssh_host) and #505 (#354 Phase A+B upgrade UI). 🤖 Generated with [Claude Code](https://claude.com/claude-code)