### PR TITLE
fix(secrets): gcp KMS backend re-reads its token file (refresh-aware)

### DIFF
--- a/pkg/core/secrets/kms_factory.go
+++ b/pkg/core/secrets/kms_factory.go
@@ -153,21 +153,22 @@ func gcpConfigFromEnv() (GCPConfig, error) {
 		return cfg, fmt.Errorf("CONTAINARIUM_GCP_KMS_KEY_NAME is required (e.g. projects/<p>/locations/<l>/keyRings/<r>/cryptoKeys/<k>)")
 	}
 
-	// Token: env wins over file. File is the recommended
-	// long-lived path — a sidecar refreshes
-	// `gcloud auth print-access-token` or hits the GCE
-	// metadata server and writes the result atomically.
-	if tok := strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_TOKEN")); tok != "" {
-		cfg.Token = tok
-	} else if path := strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_TOKEN_FILE")); path != "" {
-		tok, err := readBearerLikeFile(path)
-		if err != nil {
+	// Token source: a static token (CONTAINARIUM_GCP_KMS_TOKEN) or — recommended
+	// for long-running daemons — a file (CONTAINARIUM_GCP_KMS_TOKEN_FILE) an
+	// out-of-band sidecar refreshes (gcloud auth print-access-token / the GCE
+	// metadata server, written atomically). The backend re-reads the file before
+	// each call, so a refresh takes effect without a daemon restart. #300.
+	cfg.Token = strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_TOKEN"))
+	cfg.TokenFile = strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_TOKEN_FILE"))
+	if cfg.Token == "" && cfg.TokenFile == "" {
+		return cfg, fmt.Errorf("set either CONTAINARIUM_GCP_KMS_TOKEN or CONTAINARIUM_GCP_KMS_TOKEN_FILE")
+	}
+	if cfg.TokenFile != "" {
+		// Fail fast on an unreadable / insecurely-permissioned token file at
+		// startup; the backend then re-reads it per call to honor refreshes.
+		if _, err := readBearerLikeFile(cfg.TokenFile); err != nil {
 			return cfg, fmt.Errorf("read CONTAINARIUM_GCP_KMS_TOKEN_FILE: %w", err)
 		}
-		cfg.Token = tok
-	}
-	if cfg.Token == "" {
-		return cfg, fmt.Errorf("set either CONTAINARIUM_GCP_KMS_TOKEN or CONTAINARIUM_GCP_KMS_TOKEN_FILE")
 	}
 
 	if t := strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_TIMEOUT")); t != "" {

--- a/pkg/core/secrets/kms_gcp.go
+++ b/pkg/core/secrets/kms_gcp.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -75,6 +76,12 @@ type GCPConfig struct {
 	// Agent with the gcp secret engine).
 	Token string
 
+	// TokenFile, when set, is a path the backend RE-READS before each Cloud
+	// KMS call (cached briefly) so an out-of-band refresh sidecar's rotations
+	// are honored without restarting the daemon. Takes precedence over Token.
+	// Without it, Token is frozen at startup and expires within the hour. #300.
+	TokenFile string
+
 	// Endpoint is the Cloud KMS API base URL. Defaults to
 	// the public production endpoint; the field exists so
 	// tests can point at a httptest.Server and so
@@ -90,6 +97,11 @@ type GCPKMS struct {
 	cfg    GCPConfig
 	client *http.Client
 	kekID  string // cached, set in NewGCPKMS
+
+	// tokMu guards the brief token cache used when cfg.TokenFile is set.
+	tokMu     sync.Mutex
+	cachedTok string
+	cachedAt  time.Time
 }
 
 // gcpKEKPrefix labels a kek_id as "wrap was done by GCP
@@ -124,8 +136,8 @@ func NewGCPKMS(cfg GCPConfig) (*GCPKMS, error) {
 		!strings.Contains(cfg.KeyName, "/cryptoKeys/") {
 		return nil, fmt.Errorf("gcp KMS: key name %q is not a CryptoKey resource path (want projects/.../cryptoKeys/...)", cfg.KeyName)
 	}
-	if cfg.Token == "" {
-		return nil, errors.New("gcp KMS: access token required")
+	if cfg.Token == "" && cfg.TokenFile == "" {
+		return nil, errors.New("gcp KMS: access token or token file required")
 	}
 	cfg.Endpoint = strings.TrimRight(strings.TrimSpace(cfg.Endpoint), "/")
 	if cfg.Endpoint == "" {
@@ -202,6 +214,38 @@ func (g *GCPKMS) Unwrap(ctx context.Context, wrappedDEK []byte, kekID string) ([
 	return dek, nil
 }
 
+// gcpTokenCacheTTL bounds how long a token read from TokenFile is reused before
+// re-reading — short enough to pick up a sidecar refresh promptly, long enough
+// to avoid a file read on every Cloud KMS call.
+const gcpTokenCacheTTL = 30 * time.Second
+
+// token returns the current bearer token. With TokenFile set it re-reads the
+// file (cached for gcpTokenCacheTTL) so a refresh sidecar's rotations are
+// honored without a daemon restart; otherwise it returns the static Token.
+// On a transient read error it serves the last-good token rather than failing.
+func (g *GCPKMS) token() (string, error) {
+	if g.cfg.TokenFile == "" {
+		return g.cfg.Token, nil
+	}
+	g.tokMu.Lock()
+	defer g.tokMu.Unlock()
+	if g.cachedTok != "" && time.Since(g.cachedAt) < gcpTokenCacheTTL {
+		return g.cachedTok, nil
+	}
+	// readBearerLikeFile enforces 0600-ish perms + trims + rejects empty —
+	// the same defense-in-depth the Vault/AWS token-file paths use.
+	tok, err := readBearerLikeFile(g.cfg.TokenFile)
+	if err != nil {
+		if g.cachedTok != "" {
+			return g.cachedTok, nil // serve last-good through a transient read error
+		}
+		return "", err
+	}
+	g.cachedTok = tok
+	g.cachedAt = time.Now()
+	return tok, nil
+}
+
 // do POSTs to the encrypt/decrypt endpoint and decodes
 // the JSON response. Centralized so error mapping and
 // future telemetry sit in one place.
@@ -218,7 +262,11 @@ func (g *GCPKMS) do(ctx context.Context, op string, body, out any) error {
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+g.cfg.Token)
+	tok, err := g.token()
+	if err != nil {
+		return fmt.Errorf("gcp kms token: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := g.client.Do(req)
 	if err != nil {

--- a/pkg/core/secrets/kms_gcp_tokenfile_test.go
+++ b/pkg/core/secrets/kms_gcp_tokenfile_test.go
@@ -1,0 +1,60 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The gcp KMS backend must re-read its token file so a refresh sidecar's
+// rotations take effect without a daemon restart (the prior bug froze the
+// token at startup → 401 after ~1h). #300.
+func TestGCPKMS_TokenFileReReadAndRefresh(t *testing.T) {
+	dir := t.TempDir()
+	tf := filepath.Join(dir, "token")
+	if err := os.WriteFile(tf, []byte("tok1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := NewGCPKMS(GCPConfig{
+		KeyName:   "projects/p/locations/l/keyRings/r/cryptoKeys/k",
+		TokenFile: tf,
+	})
+	if err != nil {
+		t.Fatalf("NewGCPKMS: %v", err)
+	}
+
+	if got, err := g.token(); err != nil || got != "tok1" {
+		t.Fatalf("token() = %q, %v; want tok1", got, err)
+	}
+
+	// Rotate the file; within the TTL the cached value is still served.
+	if err := os.WriteFile(tf, []byte("tok2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := g.token(); got != "tok1" {
+		t.Fatalf("token() = %q within TTL; want cached tok1", got)
+	}
+
+	// Expire the cache → the next read picks up the rotation (no restart).
+	g.tokMu.Lock()
+	g.cachedAt = time.Now().Add(-time.Hour)
+	g.tokMu.Unlock()
+	if got, err := g.token(); err != nil || got != "tok2" {
+		t.Fatalf("token() after expiry = %q, %v; want tok2", got, err)
+	}
+}
+
+func TestGCPKMS_StaticTokenStillWorks(t *testing.T) {
+	g, err := NewGCPKMS(GCPConfig{
+		KeyName: "projects/p/locations/l/keyRings/r/cryptoKeys/k",
+		Token:   "static-tok",
+	})
+	if err != nil {
+		t.Fatalf("NewGCPKMS: %v", err)
+	}
+	if got, _ := g.token(); got != "static-tok" {
+		t.Fatalf("token() = %q; want static-tok", got)
+	}
+}


### PR DESCRIPTION
## Problem
The `gcp` envelope backend read `CONTAINARIUM_GCP_KMS_TOKEN_FILE` **once at startup** into a static `cfg.Token` and reused it for every Cloud KMS call (`kms_gcp.go` `do()` → `Bearer cfg.Token`). A GCP access token lives ~1h, so with `CONTAINARIUM_KMS_BACKEND=gcp` the daemon worked for ~an hour, then **every secret encrypt/decrypt 401'd — for all tenants**. The code's own "refresh sidecar" comment couldn't be honored because the daemon never re-read the file.

## Fix
- `GCPConfig.TokenFile`: the backend **re-reads** the token before each Cloud KMS call (cached ~30s) via the existing `readBearerLikeFile` (0600 perm-check + trim + reject-empty), serving the last-good token through a transient read error. Static `Token` still supported (tests/short-lived).
- `gcpConfigFromEnv` passes the **path** through (and validates perms/readability at startup) instead of freezing the value at boot.

## Tests
`go build`, `go vet`, `gofmt` clean; full `pkg/core/secrets` suite green. Added `kms_gcp_tokenfile_test.go`: a rotated token is picked up after the cache TTL; the static-token path still works. The pre-existing insecure-perms rejection still passes.

## Why
Unblocks a long-running daemon using `CONTAINARIUM_KMS_BACKEND=gcp` with a metadata-server token-refresh sidecar — the deployment shape needed by Containarium-cloud#300 (dogfood control-plane secrets under a GCP KMS envelope KEK). 🤖 Generated with [Claude Code](https://claude.com/claude-code)