### PR TITLE
chore(release): v0.23.1

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.23.0"
+	Version = "0.23.1"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Bumps version.go to 0.23.1 so released binaries report the right version. Tag pushed after merge → builds the release. Patch over v0.23.0: #509 (gcp KMS token-refresh). 🤖 Generated with [Claude Code](https://claude.com/claude-code)