### PR TITLE
fix(sentinel): periodic recovery retry with backoff for a down backend (#514)

### DIFF
--- a/docs/security/KMS-BROKER-DESIGN.md
+++ b/docs/security/KMS-BROKER-DESIGN.md
@@ -1,11 +1,31 @@
 # In-Container KMS Broker (design note)
 
-This is a design note for letting **tenant workloads inside a
-container** perform envelope encrypt/decrypt against the
-platform's KMS — *without* ever handing those workloads the
-KEK or the cloud KMS credentials. Documentation lands ahead of
-implementation; treat the code references here as the
-intended shape, not a description of what exists today.
+This is a design note for letting **workloads** — tenant
+containers AND the cloud control plane itself — use the
+platform's KMS through a host-mounted socket, *without* ever
+handing those workloads the KEK or the cloud KMS credentials.
+The broker offers two families of operation:
+
+- **Envelope crypto** (`wrap` / `unwrap`) — a workload encrypts
+  its *own* data under a platform-managed key.
+- **Secret custody** (`get_secret` / `sign`) — the broker holds
+  the secret/private key and exposes only the *result*: the
+  decrypted value, or a signature whose key never leaves KMS.
+
+Documentation lands ahead of implementation; treat the code
+references here as the intended shape, not a description of
+what exists today.
+
+> **Status (2026-06).** Only the **envelope floor is shipped** —
+> `secrets.KMSClient` (`wrap`/`unwrap`) with `inproc`/`vault`/`gcp`/`aws`
+> backends, plus the cloud's shared-KEK secret envelope
+> (FootprintAI/Containarium-cloud#509, v0.23.1). The **broker socket
+> itself is NOT built** in either repo: there is no host-mounted
+> `get_secret`/`sign` endpoint yet. The cloud control plane's interim
+> is App-key-via-env + self-sign-via-ADC (Containarium-cloud #302/#303)
+> until the broker's `sign` lands. The companion cloud PRD is
+> `prd/cloud/kms-secret-broker.md` (Containarium-cloud #311); this doc
+> is the OSS-daemon half of that contract.
 
 It builds directly on two things already in the tree:
 
@@ -238,38 +258,101 @@ forge another tenant's context.
 ## Wire protocol
 
 Newline-delimited JSON over the unix socket — small,
-language-agnostic, trivially testable with a fake socket:
+language-agnostic, trivially testable with a fake socket. Four
+operations across the two families:
 
 ```
+# --- Envelope crypto (the workload encrypts its own data) ---
 → {"op":"wrap","dek_b64":"..."}
 ← {"wrapped_b64":"...","kek_id":"aws:us-west-2|alias/..."}
 
 → {"op":"unwrap","wrapped_b64":"...","kek_id":"aws:..."}
 ← {"dek_b64":"..."}
 
+# --- Secret custody (the broker holds the secret/key) ---
+# get_secret: decrypt a stored secret under the CALLER's KEK and
+# return the value. name is the caller's own secret namespace; the
+# broker NEVER lets one identity read another's (authz below).
+→ {"op":"get_secret","name":"OPENAI_API_KEY"}
+← {"value_b64":"..."}
+
+# sign: KMS-sign payload with the caller's key. The private key
+# NEVER leaves KMS — only the signature comes back. Powers e.g.
+# the cloud daemon's GitHub-App JWT without a PEM in the workload.
+→ {"op":"sign","payload_b64":"...","alg":"RS256"}
+← {"signature_b64":"...","kek_id":"gcp:projects/.../cryptoKeys/..."}
+
 ← {"error":"..."}   // on failure, non-empty error field
 ```
 
-The broker is a thin adapter over the existing `KMSClient`:
+> **`get_secret` here ≠ the existing REST/MCP `get_secret`.** The
+> platform already has a `get_secret` (`internal/mcp/tools.go`,
+> REST `/v1/secrets/...`) — an *authenticated, audit-logged API*
+> that returns a tenant's stored secret to an admin/agent token.
+> The broker `get_secret` is a *different mechanism*: an unprivileged
+> in-workload call over the host-mounted socket, authenticated by
+> **possession of the socket** (no token), scoped to the caller's
+> own namespace, decrypting under the caller's KEK. Keep the two
+> distinct in code and docs — same verb, different trust model.
+
+The broker is a thin adapter over the existing `KMSClient` plus
+the secrets store:
 
 ```go
 // internal/server/kms_broker.go (sketch)
 type kmsBroker struct {
     kms       secrets.KMSClient        // the Vault/GCP/AWS backend, unchanged
-    tenantFor func(container string) string
+    secrets   *secrets.Store           // for get_secret (per-identity namespace)
+    tenantFor func(socket string) string // identity = socket provenance
 }
 
-func (b *kmsBroker) handle(container string, req kmsReq) kmsResp {
-    aad := []byte(b.tenantFor(container)) // server-derived; binds ownership
+func (b *kmsBroker) handle(id string, req brokerReq) brokerResp {
+    aad := []byte(id) // server-derived; binds ownership + scopes the namespace
     switch req.Op {
     case "wrap":
         wrapped, kekID, err := b.kms.Wrap(ctx, dek, aad)
     case "unwrap":
         dek, err := b.kms.Unwrap(ctx, req.Wrapped, req.KEKID, aad)
-        // wrong tenant → context mismatch → KMS refuses
+        // wrong identity → context mismatch → KMS refuses
+    case "get_secret":
+        // ONLY id's own namespace — a cross-identity name is "not found",
+        // never another identity's value (no existence leak).
+        value, err := b.secrets.GetForIdentity(ctx, id, req.Name)
+    case "sign":
+        // KMS sign under id's key; the private key never leaves KMS.
+        sig, kekID, err := b.kms.Sign(ctx, id, req.Payload, req.Alg)
     }
 }
 ```
+
+`sign` needs a `KMSClient.Sign` the envelope backends don't have
+yet (Vault Transit `sign`, GCP KMS asymmetric-sign, AWS KMS
+`Sign`) — a backend-capability addition, gated behind the
+`sign`-capable backends so a wrap/unwrap-only deployment degrades
+to "sign unsupported" rather than failing closed elsewhere.
+
+## Consumers: tenant workloads AND the cloud control plane
+
+The broker has **one consumer model**, used uniformly:
+
+- **Tenant workloads** — a container's app calls `wrap`/`unwrap`
+  to encrypt its own data, or `get_secret` to read a secret the
+  platform delivered, over the socket mounted into its LXC.
+- **The cloud control plane** — the cloud daemon mounts the same
+  broker socket **like any tenant** and is just another identity:
+  `get_secret` for its own config, `sign` for the GitHub-App JWT.
+  No GCP service account, no creds, no plaintext env-file or
+  mounted PEM in the cloud daemon. The host-mounted socket
+  **dissolves the bootstrap-credential problem** — the daemon
+  authenticates by *possessing the mount*, not by holding a
+  secret it had to get from somewhere first.
+
+The same isolation invariant covers both: an identity (tenant or
+the cloud daemon) can reference only its own namespace, and under
+per-tenant KEKs the wrong key cannot unwrap another's secret even
+if authz were somehow bypassed. So **the cloud daemon cannot read
+a tenant's secrets, and vice versa** — the broker holds no
+"superuser" view. (Cloud PRD: Containarium-cloud #311.)
 
 ## CLI surface (CLI-first)
 
@@ -354,9 +437,16 @@ at rest.
 
 - **No KMS creds in containers.** The only thing delivered is a
   socket path. Compromise of a tenant container yields the
-  ability to wrap/unwrap *that tenant's* DEKs through the broker
-  — bounded by daemon-side authz — and nothing about the KEK or
-  the cloud account.
+  ability to wrap/unwrap *that tenant's* DEKs (and `get_secret`
+  *that tenant's* secrets / `sign` with *that tenant's* key)
+  through the broker — bounded by daemon-side authz — and nothing
+  about the KEK or the cloud account.
+- **`sign` keeps the private key in KMS.** A compromised workload
+  with `sign` access can produce signatures *while it holds the
+  socket*, but never exfiltrates the key — revoking the mount (or
+  the per-identity key) stops it, and there is no PEM on disk to
+  steal. This is the whole reason the cloud daemon's App JWT moves
+  to `sign`.
 - **Quota / abuse.** The broker is a natural rate-limit and
   audit point; per-container request accounting lives here, not
   reachable by bypassing it (there is no direct KMS path).
@@ -383,6 +473,20 @@ at rest.
    add the socket volume mount.
 4. **Thin Python client** — published only once 1–3 exist and a
    concrete tenant asks. Keep it demand-driven.
+5. **`get_secret` over the socket** — broker reads the caller's
+   own namespace from the secrets store and decrypts under its
+   KEK; per-identity scoping (a cross-identity name is "not
+   found"). Lets a workload read platform-delivered secrets
+   without the env-file/`env_file:` delivery at all.
+6. **`KMSClient.Sign` + `sign` op** — add `Sign` to the
+   sign-capable backends (Vault Transit, GCP/AWS asymmetric),
+   gated so wrap/unwrap-only deployments report "sign
+   unsupported." Unblocks the cloud daemon's App-JWT move off the
+   #302/#303 interim.
+7. **Cloud control plane as a consumer** — the cloud daemon mounts
+   the broker socket and uses `get_secret`/`sign` for its own
+   config + App JWT (Containarium-cloud #300/#307). Removes the
+   last bootstrap creds from the daemon.
 
 ## Open questions
 

--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -16,25 +16,27 @@ import (
 )
 
 var (
-	sentinelProvider           string
-	sentinelSpotVM             string
-	sentinelZone               string
-	sentinelProject            string
-	sentinelBackendAddr        string
-	sentinelHealthPort         int
-	sentinelCheckInterval      time.Duration
-	sentinelHTTPPort           int
-	sentinelHTTPSPort          int
-	sentinelForwardedPorts     string
-	sentinelHealthyThreshold   int
-	sentinelUnhealthyThreshold int
-	sentinelBinaryPort         int
-	sentinelRecoveryTimeout    time.Duration
-	sentinelCertSyncInterval   time.Duration
-	sentinelKeySyncInterval    time.Duration
-	sentinelTunnelToken         string
-	sentinelTunnelTokenPolicies []string
-	sentinelProxyProtocol       bool
+	sentinelProvider               string
+	sentinelSpotVM                 string
+	sentinelZone                   string
+	sentinelProject                string
+	sentinelBackendAddr            string
+	sentinelHealthPort             int
+	sentinelCheckInterval          time.Duration
+	sentinelHTTPPort               int
+	sentinelHTTPSPort              int
+	sentinelForwardedPorts         string
+	sentinelHealthyThreshold       int
+	sentinelUnhealthyThreshold     int
+	sentinelBinaryPort             int
+	sentinelRecoveryTimeout        time.Duration
+	sentinelRecoveryBackoffInitial time.Duration
+	sentinelRecoveryBackoffMax     time.Duration
+	sentinelCertSyncInterval       time.Duration
+	sentinelKeySyncInterval        time.Duration
+	sentinelTunnelToken            string
+	sentinelTunnelTokenPolicies    []string
+	sentinelProxyProtocol          bool
 )
 
 var sentinelCmd = &cobra.Command{
@@ -78,6 +80,8 @@ func init() {
 	sentinelCmd.Flags().IntVar(&sentinelUnhealthyThreshold, "unhealthy-threshold", 2, "Consecutive unhealthy checks before switching to maintenance")
 	sentinelCmd.Flags().IntVar(&sentinelBinaryPort, "binary-port", 8888, "Port to serve containarium binary for spot VM downloads (0 to disable)")
 	sentinelCmd.Flags().DurationVar(&sentinelRecoveryTimeout, "recovery-timeout", 10*time.Minute, "Warn if recovery takes longer than this (0 to disable)")
+	sentinelCmd.Flags().DurationVar(&sentinelRecoveryBackoffInitial, "recovery-backoff-initial", 30*time.Second, "Initial interval between StartInstance retries while a backend is down (#514)")
+	sentinelCmd.Flags().DurationVar(&sentinelRecoveryBackoffMax, "recovery-backoff-max", 5*time.Minute, "Max interval between StartInstance retries (exponential backoff cap)")
 	sentinelCmd.Flags().DurationVar(&sentinelCertSyncInterval, "cert-sync-interval", 6*time.Hour, "Interval for syncing TLS certificates from backend (0 to use default 6h)")
 	sentinelCmd.Flags().DurationVar(&sentinelKeySyncInterval, "key-sync-interval", 2*time.Minute, "Interval for syncing SSH keys from backend for sshpiper (0 to use default 2m)")
 	sentinelCmd.Flags().BoolVar(&sentinelProxyProtocol, "proxy-protocol", false, "Prepend a PROXY v2 header to forwarded HTTPS streams so the backend Caddy sees the real client IP (requires Caddy with proxy_protocol listener wrapper trusting the sentinel)")
@@ -127,19 +131,21 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 			log.Printf("[sentinel] hybrid mode: GCP + tunnel (ConnMux on port %d)", sentinelHTTPSPort)
 
 			config := sentinel.Config{
-				HealthPort:         sentinelHealthPort,
-				CheckInterval:      sentinelCheckInterval,
-				HTTPPort:           sentinelHTTPPort,
-				HTTPSPort:          sentinelHTTPSPort,
-				ForwardedPorts:     ports,
-				HealthyThreshold:   sentinelHealthyThreshold,
-				UnhealthyThreshold: sentinelUnhealthyThreshold,
-				BinaryPort:         sentinelBinaryPort,
-				RecoveryTimeout:    sentinelRecoveryTimeout,
-				CertSyncInterval:   sentinelCertSyncInterval,
-				KeySyncInterval:    sentinelKeySyncInterval,
-				HybridMode:         true,
-				ProxyProtocol:      sentinelProxyProtocol,
+				HealthPort:             sentinelHealthPort,
+				CheckInterval:          sentinelCheckInterval,
+				HTTPPort:               sentinelHTTPPort,
+				HTTPSPort:              sentinelHTTPSPort,
+				ForwardedPorts:         ports,
+				HealthyThreshold:       sentinelHealthyThreshold,
+				UnhealthyThreshold:     sentinelUnhealthyThreshold,
+				BinaryPort:             sentinelBinaryPort,
+				RecoveryTimeout:        sentinelRecoveryTimeout,
+				RecoveryBackoffInitial: sentinelRecoveryBackoffInitial,
+				RecoveryBackoffMax:     sentinelRecoveryBackoffMax,
+				CertSyncInterval:       sentinelCertSyncInterval,
+				KeySyncInterval:        sentinelKeySyncInterval,
+				HybridMode:             true,
+				ProxyProtocol:          sentinelProxyProtocol,
 			}
 
 			manager := sentinel.NewManager(config, gcpProvider)
@@ -213,19 +219,21 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 		provider = sentinel.NewTunnelProvider(registry, "")
 
 		config := sentinel.Config{
-			HealthPort:         sentinelHealthPort,
-			CheckInterval:      sentinelCheckInterval,
-			HTTPPort:           sentinelHTTPPort,
-			HTTPSPort:          sentinelHTTPSPort,
-			ForwardedPorts:     ports,
-			HealthyThreshold:   sentinelHealthyThreshold,
-			UnhealthyThreshold: sentinelUnhealthyThreshold,
-			BinaryPort:         sentinelBinaryPort,
-			RecoveryTimeout:    sentinelRecoveryTimeout,
-			CertSyncInterval:   sentinelCertSyncInterval,
-			KeySyncInterval:    sentinelKeySyncInterval,
-			TunnelMode:         true,
-			ProxyProtocol:      sentinelProxyProtocol,
+			HealthPort:             sentinelHealthPort,
+			CheckInterval:          sentinelCheckInterval,
+			HTTPPort:               sentinelHTTPPort,
+			HTTPSPort:              sentinelHTTPSPort,
+			ForwardedPorts:         ports,
+			HealthyThreshold:       sentinelHealthyThreshold,
+			UnhealthyThreshold:     sentinelUnhealthyThreshold,
+			BinaryPort:             sentinelBinaryPort,
+			RecoveryTimeout:        sentinelRecoveryTimeout,
+			RecoveryBackoffInitial: sentinelRecoveryBackoffInitial,
+			RecoveryBackoffMax:     sentinelRecoveryBackoffMax,
+			CertSyncInterval:       sentinelCertSyncInterval,
+			KeySyncInterval:        sentinelKeySyncInterval,
+			TunnelMode:             true,
+			ProxyProtocol:          sentinelProxyProtocol,
 		}
 
 		manager := sentinel.NewManager(config, provider)
@@ -275,18 +283,20 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 	}
 
 	config := sentinel.Config{
-		HealthPort:         sentinelHealthPort,
-		CheckInterval:      sentinelCheckInterval,
-		HTTPPort:           sentinelHTTPPort,
-		HTTPSPort:          sentinelHTTPSPort,
-		ForwardedPorts:     ports,
-		HealthyThreshold:   sentinelHealthyThreshold,
-		UnhealthyThreshold: sentinelUnhealthyThreshold,
-		BinaryPort:         sentinelBinaryPort,
-		RecoveryTimeout:    sentinelRecoveryTimeout,
-		CertSyncInterval:   sentinelCertSyncInterval,
-		KeySyncInterval:    sentinelKeySyncInterval,
-		ProxyProtocol:      sentinelProxyProtocol,
+		HealthPort:             sentinelHealthPort,
+		CheckInterval:          sentinelCheckInterval,
+		HTTPPort:               sentinelHTTPPort,
+		HTTPSPort:              sentinelHTTPSPort,
+		ForwardedPorts:         ports,
+		HealthyThreshold:       sentinelHealthyThreshold,
+		UnhealthyThreshold:     sentinelUnhealthyThreshold,
+		BinaryPort:             sentinelBinaryPort,
+		RecoveryTimeout:        sentinelRecoveryTimeout,
+		RecoveryBackoffInitial: sentinelRecoveryBackoffInitial,
+		RecoveryBackoffMax:     sentinelRecoveryBackoffMax,
+		CertSyncInterval:       sentinelCertSyncInterval,
+		KeySyncInterval:        sentinelKeySyncInterval,
+		ProxyProtocol:          sentinelProxyProtocol,
 	}
 
 	manager := sentinel.NewManager(config, provider)

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -39,11 +39,22 @@ type Config struct {
 	UnhealthyThreshold int
 	BinaryPort         int           // port to serve containarium binary for spot VM downloads (0 = disabled)
 	RecoveryTimeout    time.Duration // warn if recovery takes longer than this (0 = no warning)
-	CertSyncInterval   time.Duration // interval for syncing TLS certs from backend (0 = default 6h)
-	KeySyncInterval    time.Duration // interval for syncing SSH keys from backend (0 = default 2m)
-	TunnelMode         bool          // if true, the Manager waits for tunnel connections instead of resolving IP at startup
-	HybridMode         bool          // if true, GCP + tunnel backends coexist
-	ProxyProtocol      bool          // if true, prepend a PROXY v2 header to forwarded HTTPS streams so the downstream Caddy sees the real client IP
+	// RecoveryBackoffInitial / RecoveryBackoffMax bound the periodic
+	// re-attempt of StartInstance while the backend is stuck down (e.g.
+	// spot capacity unavailable). Without this the sentinel attempts a
+	// start once at the proxy→maintenance transition and then waits
+	// passively (#514). With it, recovery is retried on an exponential
+	// schedule (Initial, doubling up to Max) so a preempted spot
+	// self-heals when capacity returns, without hammering the cloud API.
+	// Zero values fall back to defaults (30s / 5m). Initial<=0 with a
+	// provider still recovers using the defaults.
+	RecoveryBackoffInitial time.Duration
+	RecoveryBackoffMax     time.Duration
+	CertSyncInterval       time.Duration // interval for syncing TLS certs from backend (0 = default 6h)
+	KeySyncInterval        time.Duration // interval for syncing SSH keys from backend (0 = default 2m)
+	TunnelMode             bool          // if true, the Manager waits for tunnel connections instead of resolving IP at startup
+	HybridMode             bool          // if true, GCP + tunnel backends coexist
+	ProxyProtocol          bool          // if true, prepend a PROXY v2 header to forwarded HTTPS streams so the downstream Caddy sees the real client IP
 }
 
 // Manager is the core sentinel orchestrator.
@@ -88,6 +99,15 @@ type Manager struct {
 	outageStart    time.Time // when the current outage began
 	lastPreemption time.Time // when the last preemption event was detected
 	preemptCount   int       // total preemption events observed
+
+	// Backoff schedule for periodic recovery retries while stuck in
+	// maintenance (#514). nextRecoveryAttempt gates re-attempts;
+	// recoveryBackoff is the current interval, doubled on each failed
+	// StartInstance up to RecoveryBackoffMax and reset when the backend
+	// recovers. Accessed only from the single Run() event-loop goroutine
+	// (healthCheckAll / handleEvent / diagnoseAndRecover), so no lock.
+	recoveryBackoff     time.Duration
+	nextRecoveryAttempt time.Time
 
 	// hmacSecret is the shared HMAC secret used to sign
 	// /sentinel/peers responses (and reused for keysync/certsync
@@ -216,6 +236,18 @@ func (m *Manager) IssuePeerCert(peerID string) (certPEM, keyPEM []byte, err erro
 // response. Tests can override with SetHMACSecret without touching
 // the environment.
 func NewManager(config Config, provider CloudProvider) *Manager {
+	// Recovery-backoff defaults (#514). 30s initial keeps a transient
+	// blip recovering quickly; doubling to a 5m cap stops a sustained
+	// capacity outage from hammering the cloud API every tick.
+	if config.RecoveryBackoffInitial <= 0 {
+		config.RecoveryBackoffInitial = 30 * time.Second
+	}
+	if config.RecoveryBackoffMax <= 0 {
+		config.RecoveryBackoffMax = 5 * time.Minute
+	}
+	if config.RecoveryBackoffMax < config.RecoveryBackoffInitial {
+		config.RecoveryBackoffMax = config.RecoveryBackoffInitial
+	}
 	m := &Manager{
 		config:    config,
 		provider:  provider,
@@ -498,6 +530,12 @@ func (m *Manager) Run(ctx context.Context) error {
 
 		case <-ticker.C:
 			m.healthCheckAll(ctx)
+			// Periodic recovery while stuck in maintenance: re-attempt
+			// StartInstance on the backoff schedule so a preempted spot
+			// self-heals when capacity returns (#514). No-op outside
+			// maintenance or before the backoff window elapses.
+			m.maybeRetryRecovery(ctx)
+			m.checkRecoveryTimeout()
 		}
 	}
 }
@@ -592,15 +630,21 @@ func (m *Manager) healthCheckAll(ctx context.Context) {
 			if err := m.switchToProxy(best); err != nil {
 				log.Printf("[sentinel] failed to switch to proxy: %v", err)
 			}
+			// Recovered — clear the outage + backoff schedule so the next
+			// outage starts fresh (#514).
+			m.outageStart = time.Time{}
+			m.resetRecovery()
 		}
 	}
 	if !anyHealthy && m.currentState() == StateProxy {
 		log.Printf("[sentinel] all backends unhealthy, switching to maintenance")
 		m.outageStart = time.Now()
+		m.resetRecovery() // fresh backoff for this outage
 		if err := m.switchToMaintenance(); err != nil {
 			log.Printf("[sentinel] failed to switch to maintenance: %v", err)
 		}
-		// Try to recover GCP backend
+		// First recovery attempt immediately; maybeRetryRecovery then
+		// re-attempts on the backoff schedule while we stay in maintenance.
 		for _, b := range backends {
 			if b.Type == BackendGCP && b.Provider != nil {
 				m.diagnoseAndRecover(ctx, b)
@@ -983,15 +1027,32 @@ func (m *Manager) checkRecoveryTimeout() {
 	}
 }
 
-func (m *Manager) diagnoseAndRecover(ctx context.Context, b *Backend) {
+// recoveryOutcome reports what diagnoseAndRecover did, so the periodic
+// retry driver (maybeRetryRecovery) can manage the backoff schedule.
+type recoveryOutcome int
+
+const (
+	recoveryNoop        recoveryOutcome = iota // nothing to start (running/provisioning) or no provider
+	recoveryStartOK                            // StartInstance command accepted
+	recoveryStartFailed                        // StartInstance errored (e.g. no spot capacity)
+)
+
+// diagnoseAndRecover inspects the backend's cloud status and, if it's
+// stopped/terminated, attempts to start it. It then advances the backoff
+// schedule based on the outcome (#514) so subsequent maybeRetryRecovery
+// ticks re-attempt on an exponential cadence rather than once-and-wait.
+func (m *Manager) diagnoseAndRecover(ctx context.Context, b *Backend) recoveryOutcome {
 	if b.Provider == nil {
-		return
+		return recoveryNoop
 	}
 
 	status, err := b.Provider.GetInstanceStatus(ctx)
 	if err != nil {
 		log.Printf("[sentinel] failed to get status for %s: %v", b.ID, err)
-		return
+		// Treat an unreadable status like a failed attempt: keep trying,
+		// but backed off, rather than hammering the status API.
+		m.advanceRecoveryBackoff()
+		return recoveryStartFailed
 	}
 
 	log.Printf("[sentinel] backend %s status: %s", b.ID, status)
@@ -1000,15 +1061,83 @@ func (m *Manager) diagnoseAndRecover(ctx context.Context, b *Backend) {
 	case StatusStopped, StatusTerminated:
 		log.Printf("[sentinel] attempting to start %s...", b.ID)
 		if err := b.Provider.StartInstance(ctx); err != nil {
-			log.Printf("[sentinel] failed to start %s: %v", b.ID, err)
-		} else {
-			log.Printf("[sentinel] start command sent for %s", b.ID)
+			log.Printf("[sentinel] failed to start %s: %v (will retry, backing off)", b.ID, err)
+			m.advanceRecoveryBackoff()
+			return recoveryStartFailed
 		}
+		log.Printf("[sentinel] start command sent for %s", b.ID)
+		// Start accepted — re-probe soon (initial interval) so we catch
+		// it either coming healthy or, if capacity is then lost again,
+		// retrying without a long stall.
+		m.scheduleRecovery(m.config.RecoveryBackoffInitial)
+		return recoveryStartOK
 	case StatusProvisioning:
 		log.Printf("[sentinel] %s is provisioning...", b.ID)
+		m.scheduleRecovery(m.config.RecoveryBackoffInitial)
+		return recoveryNoop
 	case StatusRunning:
+		// Cloud says running but TCP health failed — starting won't help;
+		// the health check will flip it healthy when the daemon answers.
 		log.Printf("[sentinel] %s reports running but health check failed", b.ID)
+		m.scheduleRecovery(m.config.RecoveryBackoffInitial)
+		return recoveryNoop
 	}
+	return recoveryNoop
+}
+
+// scheduleRecovery sets the current backoff and the next-attempt time.
+func (m *Manager) scheduleRecovery(d time.Duration) {
+	if d <= 0 {
+		d = m.config.RecoveryBackoffInitial
+	}
+	m.recoveryBackoff = d
+	m.nextRecoveryAttempt = time.Now().Add(d)
+}
+
+// advanceRecoveryBackoff doubles the backoff (capped at Max) and schedules
+// the next attempt. Called on a failed start / unreadable status.
+func (m *Manager) advanceRecoveryBackoff() {
+	next := m.recoveryBackoff * 2
+	if m.recoveryBackoff == 0 {
+		next = m.config.RecoveryBackoffInitial
+	}
+	if next > m.config.RecoveryBackoffMax {
+		next = m.config.RecoveryBackoffMax
+	}
+	m.scheduleRecovery(next)
+}
+
+// resetRecovery clears the backoff schedule — called when the backend
+// recovers (switch back to proxy), so the next outage starts fresh.
+func (m *Manager) resetRecovery() {
+	m.recoveryBackoff = 0
+	m.nextRecoveryAttempt = time.Time{}
+}
+
+// maybeRetryRecovery re-attempts recovery while the sentinel is stuck in
+// maintenance with a provider-backed (GCP) backend, gated by the backoff
+// schedule. This is the periodic counterpart to the one-shot recovery at
+// the proxy→maintenance transition: it lets a preempted spot self-heal
+// when capacity returns, without a start attempt every health-check tick
+// (#514). Called from the Run() loop's tick, single-goroutine.
+func (m *Manager) maybeRetryRecovery(ctx context.Context) {
+	if m.currentState() != StateMaintenance {
+		return
+	}
+	if !m.nextRecoveryAttempt.IsZero() && time.Now().Before(m.nextRecoveryAttempt) {
+		return // backoff window not elapsed yet
+	}
+	var target *Backend
+	for _, b := range m.backends.All() {
+		if b.Type == BackendGCP && b.Provider != nil && !b.Healthy {
+			target = b
+			break
+		}
+	}
+	if target == nil {
+		return // nothing provider-backed to recover (e.g. pure tunnel mode)
+	}
+	m.diagnoseAndRecover(ctx, target)
 }
 
 func (m *Manager) cleanup() {

--- a/internal/sentinel/recovery_backoff_test.go
+++ b/internal/sentinel/recovery_backoff_test.go
@@ -1,0 +1,156 @@
+package sentinel
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeRecoveryProvider is a CloudProvider whose status and StartInstance
+// behavior the test drives, counting StartInstance calls. Used to exercise
+// the #514 periodic-recovery + backoff logic without a real cloud.
+type fakeRecoveryProvider struct {
+	status     InstanceStatus
+	startErr   error // returned by StartInstance (nil = accepted)
+	startCalls int
+}
+
+func (f *fakeRecoveryProvider) GetInstanceStatus(context.Context) (InstanceStatus, error) {
+	return f.status, nil
+}
+func (f *fakeRecoveryProvider) GetInstanceIP(context.Context) (string, error) { return "10.0.0.1", nil }
+func (f *fakeRecoveryProvider) StartInstance(context.Context) error {
+	f.startCalls++
+	return f.startErr
+}
+
+// newMaintenanceManager builds a Manager pinned in maintenance with a
+// single provider-backed GCP backend, ready to exercise recovery.
+func newMaintenanceManager(t *testing.T, p *fakeRecoveryProvider, cfg Config) (*Manager, *Backend) {
+	t.Helper()
+	m := NewManager(cfg, p)
+	m.state.Store(StateMaintenance)
+	b := &Backend{ID: "gcp", Type: BackendGCP, IP: "10.0.0.1", Provider: p, Healthy: false}
+	m.backends.Add(b)
+	return m, b
+}
+
+func TestRecovery_DefaultsApplied(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	if m.config.RecoveryBackoffInitial != 30*time.Second {
+		t.Errorf("initial default = %v, want 30s", m.config.RecoveryBackoffInitial)
+	}
+	if m.config.RecoveryBackoffMax != 5*time.Minute {
+		t.Errorf("max default = %v, want 5m", m.config.RecoveryBackoffMax)
+	}
+	// Max < Initial is clamped up to Initial.
+	m2 := NewManager(Config{RecoveryBackoffInitial: time.Minute, RecoveryBackoffMax: time.Second}, &fakeRecoveryProvider{})
+	if m2.config.RecoveryBackoffMax < m2.config.RecoveryBackoffInitial {
+		t.Errorf("max (%v) should be clamped >= initial (%v)", m2.config.RecoveryBackoffMax, m2.config.RecoveryBackoffInitial)
+	}
+}
+
+func TestRecovery_FailedStartGrowsBackoffAndRetries(t *testing.T) {
+	p := &fakeRecoveryProvider{status: StatusTerminated, startErr: errors.New("no spot capacity")}
+	cfg := Config{RecoveryBackoffInitial: 30 * time.Second, RecoveryBackoffMax: 5 * time.Minute}
+	m, _ := newMaintenanceManager(t, p, cfg)
+	ctx := context.Background()
+
+	// First attempt (the transition-time call).
+	m.diagnoseAndRecover(ctx, m.backends.Get("gcp"))
+	if p.startCalls != 1 {
+		t.Fatalf("after first attempt, startCalls = %d, want 1", p.startCalls)
+	}
+	if m.recoveryBackoff != 30*time.Second {
+		t.Fatalf("backoff after first failure = %v, want 30s", m.recoveryBackoff)
+	}
+
+	// Before the window elapses, maybeRetryRecovery must NOT re-attempt.
+	m.maybeRetryRecovery(ctx)
+	if p.startCalls != 1 {
+		t.Fatalf("re-attempt before backoff window: startCalls = %d, want still 1", p.startCalls)
+	}
+
+	// Force the window open → it re-attempts and doubles the backoff.
+	m.nextRecoveryAttempt = time.Now().Add(-time.Second)
+	m.maybeRetryRecovery(ctx)
+	if p.startCalls != 2 {
+		t.Fatalf("after window elapsed, startCalls = %d, want 2", p.startCalls)
+	}
+	if m.recoveryBackoff != 60*time.Second {
+		t.Fatalf("backoff after second failure = %v, want 60s (doubled)", m.recoveryBackoff)
+	}
+}
+
+func TestRecovery_BackoffCapsAtMax(t *testing.T) {
+	p := &fakeRecoveryProvider{status: StatusTerminated, startErr: errors.New("no capacity")}
+	cfg := Config{RecoveryBackoffInitial: time.Minute, RecoveryBackoffMax: 3 * time.Minute}
+	m, _ := newMaintenanceManager(t, p, cfg)
+	ctx := context.Background()
+
+	// Drive many failures; backoff must never exceed Max (1→2→3→3→3...).
+	m.diagnoseAndRecover(ctx, m.backends.Get("gcp")) // 1m
+	for i := 0; i < 6; i++ {
+		m.nextRecoveryAttempt = time.Now().Add(-time.Second)
+		m.maybeRetryRecovery(ctx)
+		if m.recoveryBackoff > cfg.RecoveryBackoffMax {
+			t.Fatalf("backoff %v exceeded max %v", m.recoveryBackoff, cfg.RecoveryBackoffMax)
+		}
+	}
+	if m.recoveryBackoff != cfg.RecoveryBackoffMax {
+		t.Fatalf("backoff settled at %v, want the cap %v", m.recoveryBackoff, cfg.RecoveryBackoffMax)
+	}
+}
+
+func TestRecovery_NoOpOutsideMaintenance(t *testing.T) {
+	p := &fakeRecoveryProvider{status: StatusTerminated, startErr: errors.New("x")}
+	m, _ := newMaintenanceManager(t, p, Config{})
+	m.state.Store(StateProxy) // not in maintenance
+	m.maybeRetryRecovery(context.Background())
+	if p.startCalls != 0 {
+		t.Fatalf("maybeRetryRecovery should be a no-op outside maintenance; startCalls = %d", p.startCalls)
+	}
+}
+
+func TestRecovery_SuccessfulStartSchedulesInitial(t *testing.T) {
+	p := &fakeRecoveryProvider{status: StatusTerminated, startErr: nil} // start accepted
+	cfg := Config{RecoveryBackoffInitial: 30 * time.Second, RecoveryBackoffMax: 5 * time.Minute}
+	m, _ := newMaintenanceManager(t, p, cfg)
+
+	m.diagnoseAndRecover(context.Background(), m.backends.Get("gcp"))
+	if p.startCalls != 1 {
+		t.Fatalf("startCalls = %d, want 1", p.startCalls)
+	}
+	// A successful start re-probes at the initial interval (not grown).
+	if m.recoveryBackoff != cfg.RecoveryBackoffInitial {
+		t.Fatalf("backoff after successful start = %v, want initial %v", m.recoveryBackoff, cfg.RecoveryBackoffInitial)
+	}
+	if m.nextRecoveryAttempt.IsZero() {
+		t.Fatal("a next attempt should be scheduled after a successful start")
+	}
+}
+
+func TestRecovery_ResetClearsSchedule(t *testing.T) {
+	p := &fakeRecoveryProvider{status: StatusTerminated, startErr: errors.New("x")}
+	m, _ := newMaintenanceManager(t, p, Config{})
+	m.diagnoseAndRecover(context.Background(), m.backends.Get("gcp"))
+	if m.nextRecoveryAttempt.IsZero() || m.recoveryBackoff == 0 {
+		t.Fatal("precondition: a schedule should exist after a failed attempt")
+	}
+	m.resetRecovery()
+	if !m.nextRecoveryAttempt.IsZero() || m.recoveryBackoff != 0 {
+		t.Fatalf("resetRecovery should clear the schedule; got backoff=%v next=%v", m.recoveryBackoff, m.nextRecoveryAttempt)
+	}
+}
+
+func TestRecovery_RunningStatusDoesNotStart(t *testing.T) {
+	// Cloud says running but TCP health failed — starting won't help and
+	// must not be attempted.
+	p := &fakeRecoveryProvider{status: StatusRunning}
+	m, _ := newMaintenanceManager(t, p, Config{})
+	m.diagnoseAndRecover(context.Background(), m.backends.Get("gcp"))
+	if p.startCalls != 0 {
+		t.Fatalf("StartInstance must not be called for a running backend; startCalls = %d", p.startCalls)
+	}
+}


### PR DESCRIPTION
Closes #514 (options 1 + 2; partially 4).

## Problem (#514)
When the spot backend went down, the sentinel attempted `StartInstance` **~once** — at the proxy→maintenance transition or on a discrete GCP preemption event. If that start failed (e.g. **spot capacity unavailable**), it just logged and **waited passively**: the 15s health checks kept TCP-probing but never re-triggered a start. So a capacity-out spot **did not self-heal** — it required a manual spot→STANDARD switch (exactly what prod had to do). Separately, `checkRecoveryTimeout` (the 10-min warning) was **dead code, never called**.

## Fix — periodic recovery with exponential backoff
- **`diagnoseAndRecover`** now returns an outcome and drives a backoff schedule: a failed `StartInstance` (or unreadable status) **doubles** the interval up to a cap; a successful start / provisioning / running re-probes at the **initial** interval.
- **`maybeRetryRecovery`** runs each health-check tick while stuck in maintenance with a provider-backed (GCP) backend, re-attempting **only once the backoff window elapses** — so a preempted spot self-heals when capacity returns, **without hammering the cloud API** every tick.
- The schedule **resets on recovery** (switch back to proxy), so the next outage starts fresh.
- **`checkRecoveryTimeout` is now actually called** on the tick → the 10-min recovery warning fires (was dead code).

## New knobs
`--recovery-backoff-initial` (default **30s**), `--recovery-backoff-max` (default **5m**). Wired through all three sentinel `Config` builders; defaults applied in `NewManager` (with a max≥initial clamp).

## Concurrency
The recovery fields are touched only from the single `Run()` event-loop goroutine (`healthCheckAll` / `handleEvent` / `diagnoseAndRecover`), so no extra locking.

## Tests
`internal/sentinel/recovery_backoff_test.go` (7 cases, via a fake provider): defaults + clamp; failed start grows backoff, respects the window, then retries; cap at max; no-op outside maintenance; successful start schedules initial; reset clears the schedule; a "running" backend is never started. `go build ./... && go test ./internal/sentinel/...` green.

## Deliberately out of scope
**Spot→STANDARD fallback** (issue option 3) — a cost/policy decision, left for a follow-up. This PR makes the existing spot-recovery path actually converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)