### PR TITLE
feat(sentinel): preemption/recovery alerting — webhook + /metrics (#514)

### DIFF
--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -37,6 +37,7 @@ var (
 	sentinelTunnelToken            string
 	sentinelTunnelTokenPolicies    []string
 	sentinelProxyProtocol          bool
+	sentinelAlertWebhookURL        string
 )
 
 var sentinelCmd = &cobra.Command{
@@ -85,6 +86,7 @@ func init() {
 	sentinelCmd.Flags().DurationVar(&sentinelCertSyncInterval, "cert-sync-interval", 6*time.Hour, "Interval for syncing TLS certificates from backend (0 to use default 6h)")
 	sentinelCmd.Flags().DurationVar(&sentinelKeySyncInterval, "key-sync-interval", 2*time.Minute, "Interval for syncing SSH keys from backend for sshpiper (0 to use default 2m)")
 	sentinelCmd.Flags().BoolVar(&sentinelProxyProtocol, "proxy-protocol", false, "Prepend a PROXY v2 header to forwarded HTTPS streams so the backend Caddy sees the real client IP (requires Caddy with proxy_protocol listener wrapper trusting the sentinel)")
+	sentinelCmd.Flags().StringVar(&sentinelAlertWebhookURL, "alert-webhook-url", os.Getenv("CONTAINARIUM_SENTINEL_ALERT_WEBHOOK"), "Webhook POSTed on spot preempted/recovered (always-on alert path; the on-spot vmalert dies with the VM). Falls back to $CONTAINARIUM_SENTINEL_ALERT_WEBHOOK (#514)")
 }
 
 func runSentinel(cmd *cobra.Command, args []string) error {
@@ -146,6 +148,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 				KeySyncInterval:        sentinelKeySyncInterval,
 				HybridMode:             true,
 				ProxyProtocol:          sentinelProxyProtocol,
+				AlertWebhookURL:        sentinelAlertWebhookURL,
 			}
 
 			manager := sentinel.NewManager(config, gcpProvider)
@@ -234,6 +237,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 			KeySyncInterval:        sentinelKeySyncInterval,
 			TunnelMode:             true,
 			ProxyProtocol:          sentinelProxyProtocol,
+			AlertWebhookURL:        sentinelAlertWebhookURL,
 		}
 
 		manager := sentinel.NewManager(config, provider)
@@ -297,6 +301,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 		CertSyncInterval:       sentinelCertSyncInterval,
 		KeySyncInterval:        sentinelKeySyncInterval,
 		ProxyProtocol:          sentinelProxyProtocol,
+		AlertWebhookURL:        sentinelAlertWebhookURL,
 	}
 
 	manager := sentinel.NewManager(config, provider)

--- a/internal/sentinel/binaryserver.go
+++ b/internal/sentinel/binaryserver.go
@@ -168,6 +168,12 @@ func StartBinaryServer(port int, manager *Manager) (stop func(), err error) {
 		json.NewEncoder(w).Encode(status)
 	})
 
+	// Prometheus metrics for the spot preemption/recovery signal (#514
+	// follow-up). Served from the always-on sentinel so an EXTERNAL
+	// scraper can alert on the net — the on-spot VictoriaMetrics dies with
+	// the spot it would be reporting on.
+	mux.HandleFunc("/metrics", manager.MetricsHandler())
+
 	srv := &http.Server{
 		Addr:         fmt.Sprintf(":%d", port),
 		Handler:      mux,

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -55,6 +55,14 @@ type Config struct {
 	TunnelMode             bool          // if true, the Manager waits for tunnel connections instead of resolving IP at startup
 	HybridMode             bool          // if true, GCP + tunnel backends coexist
 	ProxyProtocol          bool          // if true, prepend a PROXY v2 header to forwarded HTTPS streams so the downstream Caddy sees the real client IP
+	// AlertWebhookURL, when set, receives a JSON POST when the spot is
+	// preempted ("preempted") and when it comes back ("recovered"). The
+	// on-spot vmalert/VictoriaMetrics stack dies WITH the spot, so the
+	// always-on sentinel is the only thing that can alert on the spot's
+	// own outage — it does so by an outbound webhook, not the on-spot
+	// alert chain (#514 follow-up). Empty disables the webhook; the
+	// /metrics endpoint (counters) is always served regardless.
+	AlertWebhookURL string
 }
 
 // Manager is the core sentinel orchestrator.
@@ -98,7 +106,8 @@ type Manager struct {
 	// Recovery tracking
 	outageStart    time.Time // when the current outage began
 	lastPreemption time.Time // when the last preemption event was detected
-	preemptCount   int       // total preemption events observed
+	preemptCount   int       // total preemption events observed ("down" counter)
+	recoveredCount int       // total returns-to-proxy after an outage ("up" counter); alert on preemptCount-recoveredCount > 0
 
 	// Backoff schedule for periodic recovery retries while stuck in
 	// maintenance (#514). nextRecoveryAttempt gates re-attempts;
@@ -630,8 +639,15 @@ func (m *Manager) healthCheckAll(ctx context.Context) {
 			if err := m.switchToProxy(best); err != nil {
 				log.Printf("[sentinel] failed to switch to proxy: %v", err)
 			}
-			// Recovered — clear the outage + backoff schedule so the next
-			// outage starts fresh (#514).
+			// Recovered — the "instance is back" event. Bump the up-counter
+			// and notify, then clear the outage + backoff schedule so the
+			// next outage starts fresh (#514).
+			outage := time.Duration(0)
+			if !m.outageStart.IsZero() {
+				outage = time.Since(m.outageStart)
+			}
+			m.recoveredCount++
+			m.fireAlert("recovered", best.ID, outage)
 			m.outageStart = time.Time{}
 			m.resetRecovery()
 		}
@@ -972,6 +988,9 @@ func (m *Manager) handleEvent(ctx context.Context, event VMEvent) {
 		m.lastPreemption = event.Timestamp
 		log.Printf("[sentinel] EVENT: PREEMPTION detected at %s (total: %d) — %s",
 			event.Timestamp.Format(time.RFC3339), m.preemptCount, event.Detail)
+		// The "down" event. Notify immediately — the on-spot vmalert is
+		// dying with the VM, so this outbound webhook is the alert path.
+		m.fireAlert("preempted", "gcp", 0)
 
 		if gcpBackend != nil {
 			gcpBackend.Healthy = false
@@ -1239,6 +1258,7 @@ func (m *Manager) OnTunnelDisconnect(spot *TunnelSpot) {
 
 func (m *Manager) CurrentState() State       { return m.currentState() }
 func (m *Manager) PreemptCount() int         { return m.preemptCount }
+func (m *Manager) RecoveredCount() int       { return m.recoveredCount }
 func (m *Manager) LastPreemption() time.Time { return m.lastPreemption }
 
 // SpotIP returns the primary backend IP (backward compat).

--- a/internal/sentinel/observability.go
+++ b/internal/sentinel/observability.go
@@ -1,0 +1,133 @@
+package sentinel
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+// Spot-preemption observability (#514 follow-up).
+//
+// The monitoring stack (VictoriaMetrics + vmalert + Alertmanager) runs in a
+// container ON the backend spot VM, so it dies WITH the spot — it cannot
+// alert on the spot's own preemption. The always-on sentinel is the only
+// component that survives the outage, so it owns this signal, exposed two
+// ways:
+//
+//   - An outbound webhook fired the instant the spot is preempted ("down")
+//     and the instant it returns to proxy ("recovered"/"up"). Self-contained;
+//     depends on nothing on the spot.
+//   - A Prometheus /metrics endpoint with two monotonic counters
+//     (sentinel_preempted_total / sentinel_recovered_total) plus point-in-time
+//     gauges, for an EXTERNAL scraper to alert on the net
+//     (preempted_total - recovered_total > 0 == "currently down").
+//
+// Both run from the sentinel's single event-loop goroutine (fireAlert is
+// called from handleEvent / healthCheckAll); the HTTP /metrics read takes a
+// consistent snapshot via the exported getters.
+
+// alertPayload is the JSON body POSTed to AlertWebhookURL.
+type alertPayload struct {
+	Event          string `json:"event"` // "preempted" | "recovered"
+	Backend        string `json:"backend"`
+	PreemptedTotal int    `json:"preempted_total"`
+	RecoveredTotal int    `json:"recovered_total"`
+	// Outstanding is preempted_total - recovered_total: > 0 means the spot
+	// is currently down (an unrecovered preemption). This is the "net" to
+	// alert on; included so a dumb webhook consumer can branch without state.
+	Outstanding   int    `json:"outstanding"`
+	OutageSeconds int64  `json:"outage_seconds,omitempty"` // set on "recovered"
+	Timestamp     string `json:"timestamp"`
+}
+
+// fireAlert POSTs an alert to the configured webhook, best-effort and
+// asynchronous so it never blocks (or fails) the event loop. A nil/empty
+// AlertWebhookURL is a no-op. The counters are read on the calling
+// goroutine (consistent snapshot) and captured into the payload before the
+// POST is dispatched.
+func (m *Manager) fireAlert(event, backend string, outage time.Duration) {
+	if m.config.AlertWebhookURL == "" {
+		return
+	}
+	payload := alertPayload{
+		Event:          event,
+		Backend:        backend,
+		PreemptedTotal: m.preemptCount,
+		RecoveredTotal: m.recoveredCount,
+		Outstanding:    m.preemptCount - m.recoveredCount,
+		Timestamp:      time.Now().UTC().Format(time.RFC3339),
+	}
+	if outage > 0 {
+		payload.OutageSeconds = int64(outage.Seconds())
+	}
+	url := m.config.AlertWebhookURL
+	go func() {
+		body, err := json.Marshal(payload)
+		if err != nil {
+			log.Printf("[sentinel] alert webhook: marshal: %v", err)
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			log.Printf("[sentinel] alert webhook: build request: %v", err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			log.Printf("[sentinel] alert webhook POST %s failed: %v", event, err)
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode >= 400 {
+			log.Printf("[sentinel] alert webhook POST %s returned %d", event, resp.StatusCode)
+			return
+		}
+		log.Printf("[sentinel] alert webhook %s delivered (outstanding=%d)", event, payload.Outstanding)
+	}()
+}
+
+// MetricsHandler serves Prometheus text-format metrics for the spot
+// preemption/recovery signal. Mounted at /metrics on the sentinel's
+// always-on HTTP server, so an EXTERNAL Prometheus / Grafana Cloud can
+// scrape it (the on-spot VictoriaMetrics can't — it's on the box that goes
+// down). Alert on `sentinel_preempted_total - sentinel_recovered_total > 0`.
+func (m *Manager) MetricsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		state := 0 // 0 = maintenance/down, 1 = proxy/up
+		if m.CurrentState() == StateProxy {
+			state = 1
+		}
+		outageSecs := int64(0)
+		if od := m.OutageDuration(); od > 0 {
+			outageSecs = int64(od.Seconds())
+		}
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		fmt.Fprint(w, m.renderMetrics(state, outageSecs))
+	}
+}
+
+// renderMetrics builds the Prometheus exposition text. Split out (pure) so
+// it's unit-testable without an HTTP round trip.
+func (m *Manager) renderMetrics(state int, outageSecs int64) string {
+	var b bytes.Buffer
+	fmt.Fprint(&b, "# HELP sentinel_preempted_total Total spot-VM preemption events observed.\n")
+	fmt.Fprint(&b, "# TYPE sentinel_preempted_total counter\n")
+	fmt.Fprintf(&b, "sentinel_preempted_total %d\n", m.PreemptCount())
+	fmt.Fprint(&b, "# HELP sentinel_recovered_total Total returns to proxy after an outage.\n")
+	fmt.Fprint(&b, "# TYPE sentinel_recovered_total counter\n")
+	fmt.Fprintf(&b, "sentinel_recovered_total %d\n", m.RecoveredCount())
+	fmt.Fprint(&b, "# HELP sentinel_state Backend serving state: 1 proxy (up), 0 maintenance (down).\n")
+	fmt.Fprint(&b, "# TYPE sentinel_state gauge\n")
+	fmt.Fprintf(&b, "sentinel_state %d\n", state)
+	fmt.Fprint(&b, "# HELP sentinel_outage_seconds Duration of the current outage; 0 when serving.\n")
+	fmt.Fprint(&b, "# TYPE sentinel_outage_seconds gauge\n")
+	fmt.Fprintf(&b, "sentinel_outage_seconds %d\n", outageSecs)
+	return b.String()
+}

--- a/internal/sentinel/observability_test.go
+++ b/internal/sentinel/observability_test.go
@@ -1,0 +1,105 @@
+package sentinel
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRenderMetrics_Format(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	m.preemptCount = 3
+	m.recoveredCount = 2
+	out := m.renderMetrics(0 /*down*/, 42)
+
+	for _, want := range []string{
+		"# TYPE sentinel_preempted_total counter",
+		"sentinel_preempted_total 3",
+		"sentinel_recovered_total 2",
+		"sentinel_state 0",
+		"sentinel_outage_seconds 42",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("metrics output missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+	// The net (3 preempted - 2 recovered = 1 outstanding) is what an
+	// external alert evaluates; the raw counters must both be present.
+}
+
+func TestMetricsHandler_ServesText(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	m.state.Store(StateProxy)
+	m.preemptCount = 1
+	rec := httptest.NewRecorder()
+	m.MetricsHandler()(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("content-type = %q, want text/plain…", ct)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "sentinel_state 1") { // proxy = up
+		t.Errorf("expected sentinel_state 1 (proxy); got:\n%s", body)
+	}
+}
+
+func TestFireAlert_NoWebhookIsNoop(t *testing.T) {
+	// No AlertWebhookURL → fireAlert must not panic or block.
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	m.fireAlert("preempted", "gcp", 0) // should simply return
+}
+
+func TestFireAlert_PostsPayload(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		got  alertPayload
+		seen bool
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		_ = json.Unmarshal(b, &got)
+		seen = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := NewManager(Config{AlertWebhookURL: srv.URL}, &fakeRecoveryProvider{})
+	m.preemptCount = 5
+	m.recoveredCount = 2
+	m.fireAlert("preempted", "gcp", 0)
+
+	// fireAlert dispatches the POST asynchronously; wait briefly.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		done := seen
+		mu.Unlock()
+		if done || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !seen {
+		t.Fatal("webhook was never called")
+	}
+	if got.Event != "preempted" || got.Backend != "gcp" {
+		t.Errorf("payload event/backend = %q/%q", got.Event, got.Backend)
+	}
+	if got.PreemptedTotal != 5 || got.RecoveredTotal != 2 || got.Outstanding != 3 {
+		t.Errorf("payload counters = preempted:%d recovered:%d outstanding:%d, want 5/2/3",
+			got.PreemptedTotal, got.RecoveredTotal, got.Outstanding)
+	}
+}


### PR DESCRIPTION
Implements the spot-preemption alert design from #514. **Stacked on #515** (it hooks the same proxy↔maintenance transitions); base retargets to `main` once #515 merges — review #515 first.

## The key architectural fact this is built around
The monitoring stack (VictoriaMetrics + vmalert + Alertmanager) runs in a container **ON the backend spot VM** (`core_services.go`), so it **dies with the spot** — it can't alert on the spot's own preemption. The always-on sentinel is the only survivor, so it owns this signal, emitted **outbound** (not via the on-spot alert chain).

## Design (your "net of two counters")
A `down` counter (`preempted_total`, existing) and an `up` counter (`recovered_total`, new — increments on the maintenance→proxy transition). Alert on the **net**: `preempted_total - recovered_total > 0` == "spot is currently down, unrecovered."

Exposed both ways (you chose "both"):

- **Webhook** (`--alert-webhook-url` / `$CONTAINARIUM_SENTINEL_ALERT_WEBHOOK`) — POSTed the instant the spot is **preempted** and the instant it's **recovered**. Best-effort + async (never blocks/fails the event loop). Payload carries `preempted_total` / `recovered_total` / `outstanding` (the net) / `outage_seconds`, so a dumb consumer branches without state. Works today, no external infra.
- **`/metrics`** (Prometheus text, on the sentinel's always-on HTTP server) — `sentinel_preempted_total`, `sentinel_recovered_total` (counters), `sentinel_state` (1 up / 0 down), `sentinel_outage_seconds` (gauges). For an **external** Grafana Cloud / off-box Prometheus to scrape + alert on the net. Future-proof.

## Concurrency
Counters/state touched only on the single `Run()` event-loop goroutine; only the webhook POST is dispatched to a goroutine (with a captured snapshot + 10s timeout).

## Tests
`observability_test.go`: metrics text format, `/metrics` handler (proxy→`sentinel_state 1`), no-webhook no-op, and a webhook round-trip asserting the net (preempted 5 − recovered 2 = **3 outstanding**). `go build ./...` + sentinel/cmd tests + `-race` green.

## Notes / not in scope
- The "15s advance notice" idea from the discussion is **not** here: the sentinel detects preemption *reactively* (operations poll, `gcp.go:174`), not ahead-of-time. True advance notice needs the spot daemon to poll its own `instance/preempted` metadata and signal the sentinel before shutdown — a separate enhancement.
- The webhook is unsigned (unlike the daemon's HMAC alert webhook); fine for a notification-only path, can add HMAC if it feeds an authenticated receiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)