### PR TITLE
fix(terraform): spot VM private-by-default in sentinel mode

### DIFF
--- a/terraform/modules/containarium/variables.tf
+++ b/terraform/modules/containarium/variables.tf
@@ -223,9 +223,9 @@ variable "enable_iap_firewall" {
 }
 
 variable "spot_vm_external_ip" {
-  description = "Give spot VM an ephemeral external IP (false = Cloud NAT only)"
+  description = "Give the spot VM an ephemeral external IP. Default false: in sentinel mode the spot must be private (inbound via the sentinel, egress via Cloud NAT) — a public IP on the backend is an unintended exposure. Set true only for a sentinel-less / debug deployment that needs the spot directly reachable. (Non-sentinel deployments ignore this — they always get the static IP.)"
   type        = bool
-  default     = true
+  default     = false
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
The module variable `spot_vm_external_ip` **defaulted to `true`**, so a sentinel-mode deployment that didn't explicitly override it gave the backend spot VM an **ephemeral public IP** — an unintended exposure. The spot should be reachable only *through* the sentinel (inbound) with **Cloud NAT** for egress; a public IP on the backend defeats that.

This bit prod: **`containarium-jump-ase1-spot` was running with a public IP (`35.236.183.79`)** purely because the consumer left the default in place. (Removed from the live instance separately; it's now private-only `10.140.0.51`.)

```hcl
# sentinel mode + default true → spot still gets an ephemeral public IP
for_each = local.use_sentinel ? (var.spot_vm_external_ip ? [1] : []) : [1]
```

## Fix
Flip the default `true → false`. The secure posture stops depending on each consumer remembering to override.

## Blast radius
- `terraform/gce/main.tf` sets it `true` **explicitly** (sentinel-less dev) — unaffected.
- `terraform/gce-demo/main.tf` sets it `false` **explicitly** — unaffected.
- External consumers (kafeido-infra) that relied on the default get the secure posture on the next module bump, or should pin `false` now.
- **Caveat** (already true for any `false` consumer): a private spot needs a **Cloud NAT** for egress — the module *assumes* one exists, it doesn't create it. asia-east1 and us-west1 prod both have it.

`terraform fmt` + `validate` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)