### PR TITLE
chore(release): v0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.2] - 2026-06-06
+
 ### Added
 
 - **`ProxyRoute.container_name`** — `GetRoutes` now returns the container behind each route in a dedicated field instead of overloading `app_name` (the display name), so a multi-tenant control plane can key its route reconciler on the box identity. Additive; `app_name` unchanged. (#511)
+
+### Fixed
+
+- **Sentinel periodic recovery retry** — a backend that goes down is retried with backoff instead of being given up on after the first failed recovery attempt. (#515)
+- **Spot VMs are private-by-default in sentinel mode** — `spot_vm_external_ip=false` so a spot backend no longer gets a public IP it doesn't need; the sentinel fronts it. (#518)
 
 ## [0.23.1] - 2026-06-06
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.23.1"
+	Version = "0.23.2"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Patch release. Packages all `main` work since v0.23.1.

### Added
- **`ProxyRoute.container_name`** in `GetRoutes` — route listings carry the backing container in a dedicated field (additive; `app_name` unchanged). (#511)

### Fixed
- **Sentinel periodic recovery retry** with backoff for a down backend. (#515)
- **Spot VMs private-by-default** in sentinel mode (`spot_vm_external_ip=false`). (#518)

Bumps `pkg/version/version.go` → `0.23.2` and promotes the CHANGELOG `[Unreleased]` section. Tag `v0.23.2` after merge triggers `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)