### PR TITLE
feat(ttl): birth TTL — accept a TTL atomically in CreateContainer (#523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Birth TTL — `containarium create --ttl <dur>`** — a box can be born with a death date. `CreateContainer` accepts an optional `ttl_seconds`; the daemon stamps `ttl_expires_at` atomically at create time (same persistence + 7-day cap as `ttl set`), so the `ttlsweeper` reaps the box even if the client dies the instant after create — no separate `ttl set` call to forget. Closes the leak window where an ephemeral/CI box runs forever because its TTL was never set. If the TTL can't be stamped the box is deleted rather than left to leak (default-dead). (#523)
 - **`ProxyRoute.container_name`** — `GetRoutes` now returns the container behind each route in a dedicated field instead of overloading `app_name` (the display name), so a multi-tenant control plane can key its route reconciler on the box identity. Additive; `app_name` unchanged. (#511)
 
 ## [0.23.1] - 2026-06-06

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -6085,6 +6085,11 @@
         "workspacePath": {
           "type": "string",
           "description": "workspace_path: where in the box to place the source. Empty\ndefaults to \"/workspace\"."
+        },
+        "ttlSeconds": {
+          "type": "string",
+          "format": "int64",
+          "description": "Birth TTL (optional) — seconds from creation after which the box is\nauto-deleted. When \u003e 0, the daemon stamps ttl_expires_at = now() +\nttl_seconds at create time (same persistence as SetContainerTTL), so\nthe box is born with a death date and the ttlsweeper reaps it even if\nthe client dies right after create — no separate `ttl set` call needed\n(#523). 0 = no TTL (today's behavior). Capped at 604800 (7 days);\nlarger values return InvalidArgument, same bound as SetContainerTTL."
         }
       },
       "title": "CreateContainerRequest is the request to create a new container"

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -153,7 +153,7 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 }
 
 // CreateContainer creates a container via gRPC
-func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts) (*incus.ContainerInfo, error) {
+func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute) // Container creation can take time (includes ultra-aggressive retry logic for google_guest_agent)
 	defer cancel()
 
@@ -177,6 +177,7 @@ func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, 
 		GitRef:        git.Ref,
 		GitCredential: git.Credential,
 		WorkspacePath: git.WorkspacePath,
+		TtlSeconds:    ttlSeconds,
 	}
 
 	resp, err := c.client.CreateContainer(ctx, req)

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -280,7 +280,7 @@ type GitSourceOpts struct {
 	WorkspacePath string // empty defaults to /workspace
 }
 
-func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts) (*incus.ContainerInfo, error) {
+func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
@@ -306,6 +306,13 @@ func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, 
 		reqBody["gitRef"] = git.Ref
 		reqBody["gitCredential"] = git.Credential
 		reqBody["workspacePath"] = git.WorkspacePath
+	}
+	// Birth TTL (#523): only include when set, so an unset TTL stays absent
+	// on the wire (0 = no TTL) rather than forcing a "ttlSeconds":0 the
+	// daemon would treat the same but that needlessly differs from a plain
+	// create's body.
+	if ttlSeconds > 0 {
+		reqBody["ttlSeconds"] = ttlSeconds
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/containers", reqBody)

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/footprintai/containarium/internal/client"
 	"github.com/footprintai/containarium/pkg/core/container"
@@ -37,6 +38,7 @@ var (
 	createGitRef             string
 	createGitCredentialFile  string
 	createWorkspacePath      string
+	createTTL                string
 )
 
 var createCmd = &cobra.Command{
@@ -117,6 +119,7 @@ func init() {
 	createCmd.Flags().StringVar(&createGitRef, "git-ref", "", "Exact ref to check out for --git-source: full SHA (preferred), branch, tag, or refs/pull/N/merge. Empty = the remote's default branch.")
 	createCmd.Flags().StringVar(&createGitCredentialFile, "git-credential-file", "", "Path to a file holding a bearer token for a private --git-source. Used daemon-side for one fetch; never written to the box's .git/config.")
 	createCmd.Flags().StringVar(&createWorkspacePath, "workspace-path", "", "Where --git-source lands inside the box. Empty defaults to /workspace.")
+	createCmd.Flags().StringVar(&createTTL, "ttl", "", "Birth TTL — auto-delete the box this long after creation (Go duration: '30m', '1h', '24h'; max 168h/7 days). The death date is stamped atomically at create, so the box is reaped even if the client dies right after — no separate 'ttl set' needed (#523). Empty = no TTL.")
 }
 
 // validateSSHKeyMode enforces "exactly one of --ssh-key / --no-ssh-key".
@@ -146,6 +149,18 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	// Parse labels from key=value format
 	parsedLabels := parseLabels(labels)
 
+	// Birth TTL (#523): parse the optional --ttl with the SAME parser +
+	// cap as `containarium ttl set` (parseTTL), so create and set agree on
+	// format and the 7-day bound. Empty = no TTL (today's behavior).
+	var ttlSeconds int64
+	if createTTL != "" {
+		d, err := parseTTL(createTTL)
+		if err != nil {
+			return err
+		}
+		ttlSeconds = int64(d.Seconds())
+	}
+
 	fmt.Printf("Creating container for user: %s\n", username)
 	if verbose {
 		fmt.Printf("  CPU: %s\n", cpuLimit)
@@ -163,6 +178,9 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		}
 		if gpuDevice != "" {
 			fmt.Printf("  GPU: %s\n", gpuDevice)
+		}
+		if ttlSeconds > 0 {
+			fmt.Printf("  TTL: %s (auto-delete at create+TTL)\n", createTTL)
 		}
 		if len(parsedLabels) > 0 {
 			fmt.Printf("  Labels:\n")
@@ -327,13 +345,13 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if httpMode && serverAddr != "" {
 		// Remote mode via HTTP
-		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts)
+		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds)
 		if err != nil {
 			return fmt.Errorf("failed to create container via HTTP API: %w", err)
 		}
 	} else if serverAddr != "" {
 		// Remote mode via gRPC
-		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts)
+		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds)
 		if err != nil {
 			return fmt.Errorf("failed to create container via remote server: %w", err)
 		}
@@ -342,7 +360,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		if verbose {
 			fmt.Println("Creating container...")
 		}
-		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevice, osType, monitoring, gitOpts)
+		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevice, osType, monitoring, gitOpts, ttlSeconds)
 		if err != nil {
 			// Cleanup jump server account on failure
 			_ = container.DeleteJumpServerAccount(username, false)
@@ -484,7 +502,7 @@ func resolveGitSourceOpts() (client.GitSourceOpts, error) {
 }
 
 // createLocal creates a container using local Incus daemon
-func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, git client.GitSourceOpts) (*incus.ContainerInfo, error) {
+func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, git client.GitSourceOpts, ttlSeconds int64) (*incus.ContainerInfo, error) {
 	mgr, err := container.New()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
@@ -513,7 +531,26 @@ func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []
 		WorkspacePath:          git.WorkspacePath,
 	}
 
-	return mgr.Create(opts)
+	info, err := mgr.Create(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Birth TTL (#523), local path. The daemon's CreateContainer stamps this
+	// server-side; in local Incus mode we stamp the same key+format directly
+	// so the box is born with its death date (reaped by whichever daemon
+	// manages this host's ttlsweeper). On failure delete the box rather than
+	// leave an ephemeral box that would leak — default-dead (#522), matching
+	// the server path.
+	if ttlSeconds > 0 {
+		expiresAt := time.Now().Add(time.Duration(ttlSeconds) * time.Second).UTC()
+		if serr := mgr.SetConfig(info.Name, incus.TTLExpiresAtKey, expiresAt.Format(time.RFC3339)); serr != nil {
+			_ = deleteLocal(username, true)
+			return nil, fmt.Errorf("failed to set birth TTL on %s (box deleted to avoid a leak): %w", info.Name, serr)
+		}
+	}
+
+	return info, nil
 }
 
 // parseLabels parses labels from key=value format
@@ -533,23 +570,23 @@ func parseLabels(labelSlice []string) map[string]string {
 }
 
 // createRemote creates a container using remote gRPC server
-func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts) (*incus.ContainerInfo, error) {
+func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64) (*incus.ContainerInfo, error) {
 	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
 		return nil, err
 	}
 	defer grpcClient.Close()
 
-	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git)
+	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git, ttlSeconds)
 }
 
 // createRemoteHTTP creates a container using remote HTTP API
-func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts) (*incus.ContainerInfo, error) {
+func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64) (*incus.ContainerInfo, error) {
 	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
 	if err != nil {
 		return nil, err
 	}
 	defer httpClient.Close()
 
-	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git)
+	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git, ttlSeconds)
 }

--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -381,6 +381,7 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 				"",                     // pool
 				"",                     // backend-id
 				client.GitSourceOpts{}, // no git-source for runner boxes
+				0,                      // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
 			)
 			if err != nil {
 				return "", "", err
@@ -415,6 +416,7 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 			"",
 			"",
 			client.GitSourceOpts{}, // no git-source for runner boxes
+			0,                      // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
 		)
 		if err != nil {
 			return "", "", err

--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -37,6 +37,7 @@ var (
 	sentinelTunnelToken            string
 	sentinelTunnelTokenPolicies    []string
 	sentinelProxyProtocol          bool
+	sentinelAlertWebhookURL        string
 )
 
 var sentinelCmd = &cobra.Command{
@@ -85,6 +86,7 @@ func init() {
 	sentinelCmd.Flags().DurationVar(&sentinelCertSyncInterval, "cert-sync-interval", 6*time.Hour, "Interval for syncing TLS certificates from backend (0 to use default 6h)")
 	sentinelCmd.Flags().DurationVar(&sentinelKeySyncInterval, "key-sync-interval", 2*time.Minute, "Interval for syncing SSH keys from backend for sshpiper (0 to use default 2m)")
 	sentinelCmd.Flags().BoolVar(&sentinelProxyProtocol, "proxy-protocol", false, "Prepend a PROXY v2 header to forwarded HTTPS streams so the backend Caddy sees the real client IP (requires Caddy with proxy_protocol listener wrapper trusting the sentinel)")
+	sentinelCmd.Flags().StringVar(&sentinelAlertWebhookURL, "alert-webhook-url", os.Getenv("CONTAINARIUM_SENTINEL_ALERT_WEBHOOK"), "Webhook POSTed on spot preempted/recovered (always-on alert path; the on-spot vmalert dies with the VM). Falls back to $CONTAINARIUM_SENTINEL_ALERT_WEBHOOK (#514)")
 }
 
 func runSentinel(cmd *cobra.Command, args []string) error {
@@ -146,6 +148,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 				KeySyncInterval:        sentinelKeySyncInterval,
 				HybridMode:             true,
 				ProxyProtocol:          sentinelProxyProtocol,
+				AlertWebhookURL:        sentinelAlertWebhookURL,
 			}
 
 			manager := sentinel.NewManager(config, gcpProvider)
@@ -234,6 +237,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 			KeySyncInterval:        sentinelKeySyncInterval,
 			TunnelMode:             true,
 			ProxyProtocol:          sentinelProxyProtocol,
+			AlertWebhookURL:        sentinelAlertWebhookURL,
 		}
 
 		manager := sentinel.NewManager(config, provider)
@@ -297,6 +301,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 		CertSyncInterval:       sentinelCertSyncInterval,
 		KeySyncInterval:        sentinelKeySyncInterval,
 		ProxyProtocol:          sentinelProxyProtocol,
+		AlertWebhookURL:        sentinelAlertWebhookURL,
 	}
 
 	manager := sentinel.NewManager(config, provider)

--- a/internal/runner/boxes.go
+++ b/internal/runner/boxes.go
@@ -48,12 +48,12 @@ type daemonBoxManager struct {
 	create DaemonCreator
 }
 
-func (m *daemonBoxManager) Exists(_ context.Context, name string) (bool, error) {
+func (m *daemonBoxManager) Exists(_ context.Context, name string) (bool, string, error) {
 	// The daemon's "name" for a user-container is
 	// "<username>-container" — the create flow appends the
 	// suffix server-side. We pass the raw user/runner name to
 	// GetContainer which knows the convention.
-	_, err := m.api.GetContainer(name)
+	info, err := m.api.GetContainer(name)
 	if err != nil {
 		// Best-effort: distinguish "not found" from real
 		// failures. The HTTP/gRPC clients both return errors
@@ -62,11 +62,14 @@ func (m *daemonBoxManager) Exists(_ context.Context, name string) (bool, error) 
 		// (real error misread as not-found) sends us into
 		// Create, which will surface the real error anyway.
 		if isNotFoundError(err) {
-			return false, nil
+			return false, "", nil
 		}
-		return false, err
+		return false, "", err
 	}
-	return true, nil
+	// Return the daemon-assigned username so idempotent re-runs can
+	// SSH as the same cld-<uuid> the box originally got, not the
+	// friendly requested name. (#482)
+	return true, info.Username, nil
 }
 
 func (m *daemonBoxManager) Create(ctx context.Context, name, sshKey string) (boxID, username string, err error) {

--- a/internal/runner/provision.go
+++ b/internal/runner/provision.go
@@ -210,10 +210,12 @@ type Result struct {
 // internal/cmd/create.go's create helpers; the MCP tool's
 // adapter calls the same.
 type BoxManager interface {
-	// Exists returns true if a box with the given name already
-	// exists on the daemon. Used for the idempotent-re-provision
-	// check (skip create if the box is already there).
-	Exists(ctx context.Context, name string) (bool, error)
+	// Exists returns (found, assignedUsername, error). assignedUsername is
+	// the SSH username the daemon assigned to the box (may differ from name
+	// when a control plane mints a generated username like cld-<uuid>).
+	// Empty when found is false. The install step must SSH as assignedUsername,
+	// not name. (#482)
+	Exists(ctx context.Context, name string) (bool, string, error)
 
 	// Create provisions a new box with the given name. The
 	// implementation supplies whatever sensible defaults the
@@ -460,7 +462,7 @@ func provisionOne(ctx context.Context, deps Deps, opts Options, name string) Run
 	createCtx, cancelCreate := context.WithTimeout(ctx, opts.BoxCreateTimeout)
 	defer cancelCreate()
 
-	exists, err := deps.Boxes.Exists(createCtx, name)
+	exists, existingUsername, err := deps.Boxes.Exists(createCtx, name)
 	if err != nil {
 		st.State = "failed"
 		st.LastError = fmt.Sprintf("check box existence: %v", err)
@@ -468,6 +470,13 @@ func provisionOne(ctx context.Context, deps Deps, opts Options, name string) Run
 	}
 	if exists {
 		st.BoxID = name // best-effort, the daemon's canonical ID may differ but matches in practice
+		// Use the daemon-assigned username if the control plane reports one;
+		// an idempotent re-run on an orphaned box must SSH as the same
+		// cld-<uuid> the box was originally given, not the requested name.
+		if existingUsername != "" {
+			sshUser = existingUsername
+			st.SSHUser = existingUsername
+		}
 	} else {
 		boxID, username, err := deps.Boxes.Create(createCtx, name, opts.SSHKey)
 		if err != nil {

--- a/internal/runner/provision_test.go
+++ b/internal/runner/provision_test.go
@@ -25,10 +25,19 @@ type fakeBoxes struct {
 	assignUsername map[string]string
 }
 
-func (f *fakeBoxes) Exists(_ context.Context, name string) (bool, error) {
+func (f *fakeBoxes) Exists(_ context.Context, name string) (bool, string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.existing[name], nil
+	if !f.existing[name] {
+		return false, "", nil
+	}
+	// Return the assigned username (models the control-plane cld-<uuid>
+	// case). Falls back to name when no override is set (OSS daemon). (#482)
+	username := name
+	if u, ok := f.assignUsername[name]; ok {
+		username = u
+	}
+	return true, username, nil
 }
 
 func (f *fakeBoxes) Create(_ context.Context, name, _ string) (string, string, error) {
@@ -368,6 +377,53 @@ func TestProvision_UsesAssignedUsernameForSSH_482(t *testing.T) {
 	// though SSH targeted the assigned username.
 	if got := installer.gotEnv[assigned]["RUNNER_NAME"]; got != requested {
 		t.Errorf("RUNNER_NAME env = %q, want %q", got, requested)
+	}
+}
+
+// TestProvision_IdempotentRerun_UsesAssignedUsername_482 verifies that when
+// a box ALREADY EXISTS (orphaned from a previous failed provision) AND the
+// daemon assigned it a different username at create (cld-<uuid>), the
+// idempotent re-run SSHes as the assigned username from Exists — not the
+// requested name. The requested-name → cld-uuid mapping is only available
+// via Exists; if Exists didn't return it, we'd SSH as the wrong user and
+// the re-run would fail with [none publickey] indefinitely. (#482)
+func TestProvision_IdempotentRerun_UsesAssignedUsername_482(t *testing.T) {
+	const requested = "ci-runner-1"
+	const assigned = "cld-a7d6560a" // daemon-minted username from the first (failed) create
+	boxes := &fakeBoxes{
+		// Box already exists (was created by a previous provision attempt
+		// that died before the install step).
+		existing:       map[string]bool{requested: true},
+		assignUsername: map[string]string{requested: assigned},
+	}
+	installer := &fakeInstaller{alreadyInstalled: map[string]bool{}}
+	gh := &fakeGitHub{registerOnAttempt: map[string]int{requested: 1}}
+	clock := newFakeClock()
+
+	res, err := Provision(context.Background(), Deps{
+		Boxes: boxes, SSH: installer, GitHub: gh, Clock: clock,
+	}, Options{
+		Repo:       "footprintai/containarium",
+		PAT:        "ghp_test",
+		Count:      1,
+		NamePrefix: "ci-runner",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := res.Runners[0]
+	if r.State != "provisioned" {
+		t.Fatalf("expected provisioned, got %s (err=%s)", r.State, r.LastError)
+	}
+
+	// The key assertion: the install must target the assigned username from
+	// Exists, not the requested name (which sshpiper has no route for).
+	if len(installer.installed) != 1 || installer.installed[0] != assigned {
+		t.Fatalf("install target = %v, want SSH as assigned username %q (not requested %q)",
+			installer.installed, assigned, requested)
+	}
+	if r.SSHUser != assigned {
+		t.Errorf("RunnerStatus.SSHUser = %q, want %q", r.SSHUser, assigned)
 	}
 }
 

--- a/internal/sentinel/binaryserver.go
+++ b/internal/sentinel/binaryserver.go
@@ -168,6 +168,12 @@ func StartBinaryServer(port int, manager *Manager) (stop func(), err error) {
 		json.NewEncoder(w).Encode(status)
 	})
 
+	// Prometheus metrics for the spot preemption/recovery signal (#514
+	// follow-up). Served from the always-on sentinel so an EXTERNAL
+	// scraper can alert on the net — the on-spot VictoriaMetrics dies with
+	// the spot it would be reporting on.
+	mux.HandleFunc("/metrics", manager.MetricsHandler())
+
 	srv := &http.Server{
 		Addr:         fmt.Sprintf(":%d", port),
 		Handler:      mux,

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -55,6 +55,14 @@ type Config struct {
 	TunnelMode             bool          // if true, the Manager waits for tunnel connections instead of resolving IP at startup
 	HybridMode             bool          // if true, GCP + tunnel backends coexist
 	ProxyProtocol          bool          // if true, prepend a PROXY v2 header to forwarded HTTPS streams so the downstream Caddy sees the real client IP
+	// AlertWebhookURL, when set, receives a JSON POST when the spot is
+	// preempted ("preempted") and when it comes back ("recovered"). The
+	// on-spot vmalert/VictoriaMetrics stack dies WITH the spot, so the
+	// always-on sentinel is the only thing that can alert on the spot's
+	// own outage — it does so by an outbound webhook, not the on-spot
+	// alert chain (#514 follow-up). Empty disables the webhook; the
+	// /metrics endpoint (counters) is always served regardless.
+	AlertWebhookURL string
 }
 
 // Manager is the core sentinel orchestrator.
@@ -98,7 +106,8 @@ type Manager struct {
 	// Recovery tracking
 	outageStart    time.Time // when the current outage began
 	lastPreemption time.Time // when the last preemption event was detected
-	preemptCount   int       // total preemption events observed
+	preemptCount   int       // total preemption events observed ("down" counter)
+	recoveredCount int       // total returns-to-proxy after an outage ("up" counter); alert on preemptCount-recoveredCount > 0
 
 	// Backoff schedule for periodic recovery retries while stuck in
 	// maintenance (#514). nextRecoveryAttempt gates re-attempts;
@@ -630,8 +639,15 @@ func (m *Manager) healthCheckAll(ctx context.Context) {
 			if err := m.switchToProxy(best); err != nil {
 				log.Printf("[sentinel] failed to switch to proxy: %v", err)
 			}
-			// Recovered — clear the outage + backoff schedule so the next
-			// outage starts fresh (#514).
+			// Recovered — the "instance is back" event. Bump the up-counter
+			// and notify, then clear the outage + backoff schedule so the
+			// next outage starts fresh (#514).
+			outage := time.Duration(0)
+			if !m.outageStart.IsZero() {
+				outage = time.Since(m.outageStart)
+			}
+			m.recoveredCount++
+			m.fireAlert("recovered", best.ID, outage)
 			m.outageStart = time.Time{}
 			m.resetRecovery()
 		}
@@ -972,6 +988,9 @@ func (m *Manager) handleEvent(ctx context.Context, event VMEvent) {
 		m.lastPreemption = event.Timestamp
 		log.Printf("[sentinel] EVENT: PREEMPTION detected at %s (total: %d) — %s",
 			event.Timestamp.Format(time.RFC3339), m.preemptCount, event.Detail)
+		// The "down" event. Notify immediately — the on-spot vmalert is
+		// dying with the VM, so this outbound webhook is the alert path.
+		m.fireAlert("preempted", "gcp", 0)
 
 		if gcpBackend != nil {
 			gcpBackend.Healthy = false
@@ -1239,6 +1258,7 @@ func (m *Manager) OnTunnelDisconnect(spot *TunnelSpot) {
 
 func (m *Manager) CurrentState() State       { return m.currentState() }
 func (m *Manager) PreemptCount() int         { return m.preemptCount }
+func (m *Manager) RecoveredCount() int       { return m.recoveredCount }
 func (m *Manager) LastPreemption() time.Time { return m.lastPreemption }
 
 // SpotIP returns the primary backend IP (backward compat).

--- a/internal/sentinel/observability.go
+++ b/internal/sentinel/observability.go
@@ -1,0 +1,133 @@
+package sentinel
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+// Spot-preemption observability (#514 follow-up).
+//
+// The monitoring stack (VictoriaMetrics + vmalert + Alertmanager) runs in a
+// container ON the backend spot VM, so it dies WITH the spot — it cannot
+// alert on the spot's own preemption. The always-on sentinel is the only
+// component that survives the outage, so it owns this signal, exposed two
+// ways:
+//
+//   - An outbound webhook fired the instant the spot is preempted ("down")
+//     and the instant it returns to proxy ("recovered"/"up"). Self-contained;
+//     depends on nothing on the spot.
+//   - A Prometheus /metrics endpoint with two monotonic counters
+//     (sentinel_preempted_total / sentinel_recovered_total) plus point-in-time
+//     gauges, for an EXTERNAL scraper to alert on the net
+//     (preempted_total - recovered_total > 0 == "currently down").
+//
+// Both run from the sentinel's single event-loop goroutine (fireAlert is
+// called from handleEvent / healthCheckAll); the HTTP /metrics read takes a
+// consistent snapshot via the exported getters.
+
+// alertPayload is the JSON body POSTed to AlertWebhookURL.
+type alertPayload struct {
+	Event          string `json:"event"` // "preempted" | "recovered"
+	Backend        string `json:"backend"`
+	PreemptedTotal int    `json:"preempted_total"`
+	RecoveredTotal int    `json:"recovered_total"`
+	// Outstanding is preempted_total - recovered_total: > 0 means the spot
+	// is currently down (an unrecovered preemption). This is the "net" to
+	// alert on; included so a dumb webhook consumer can branch without state.
+	Outstanding   int    `json:"outstanding"`
+	OutageSeconds int64  `json:"outage_seconds,omitempty"` // set on "recovered"
+	Timestamp     string `json:"timestamp"`
+}
+
+// fireAlert POSTs an alert to the configured webhook, best-effort and
+// asynchronous so it never blocks (or fails) the event loop. A nil/empty
+// AlertWebhookURL is a no-op. The counters are read on the calling
+// goroutine (consistent snapshot) and captured into the payload before the
+// POST is dispatched.
+func (m *Manager) fireAlert(event, backend string, outage time.Duration) {
+	if m.config.AlertWebhookURL == "" {
+		return
+	}
+	payload := alertPayload{
+		Event:          event,
+		Backend:        backend,
+		PreemptedTotal: m.preemptCount,
+		RecoveredTotal: m.recoveredCount,
+		Outstanding:    m.preemptCount - m.recoveredCount,
+		Timestamp:      time.Now().UTC().Format(time.RFC3339),
+	}
+	if outage > 0 {
+		payload.OutageSeconds = int64(outage.Seconds())
+	}
+	url := m.config.AlertWebhookURL
+	go func() {
+		body, err := json.Marshal(payload)
+		if err != nil {
+			log.Printf("[sentinel] alert webhook: marshal: %v", err)
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			log.Printf("[sentinel] alert webhook: build request: %v", err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			log.Printf("[sentinel] alert webhook POST %s failed: %v", event, err)
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode >= 400 {
+			log.Printf("[sentinel] alert webhook POST %s returned %d", event, resp.StatusCode)
+			return
+		}
+		log.Printf("[sentinel] alert webhook %s delivered (outstanding=%d)", event, payload.Outstanding)
+	}()
+}
+
+// MetricsHandler serves Prometheus text-format metrics for the spot
+// preemption/recovery signal. Mounted at /metrics on the sentinel's
+// always-on HTTP server, so an EXTERNAL Prometheus / Grafana Cloud can
+// scrape it (the on-spot VictoriaMetrics can't — it's on the box that goes
+// down). Alert on `sentinel_preempted_total - sentinel_recovered_total > 0`.
+func (m *Manager) MetricsHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		state := 0 // 0 = maintenance/down, 1 = proxy/up
+		if m.CurrentState() == StateProxy {
+			state = 1
+		}
+		outageSecs := int64(0)
+		if od := m.OutageDuration(); od > 0 {
+			outageSecs = int64(od.Seconds())
+		}
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		fmt.Fprint(w, m.renderMetrics(state, outageSecs))
+	}
+}
+
+// renderMetrics builds the Prometheus exposition text. Split out (pure) so
+// it's unit-testable without an HTTP round trip.
+func (m *Manager) renderMetrics(state int, outageSecs int64) string {
+	var b bytes.Buffer
+	fmt.Fprint(&b, "# HELP sentinel_preempted_total Total spot-VM preemption events observed.\n")
+	fmt.Fprint(&b, "# TYPE sentinel_preempted_total counter\n")
+	fmt.Fprintf(&b, "sentinel_preempted_total %d\n", m.PreemptCount())
+	fmt.Fprint(&b, "# HELP sentinel_recovered_total Total returns to proxy after an outage.\n")
+	fmt.Fprint(&b, "# TYPE sentinel_recovered_total counter\n")
+	fmt.Fprintf(&b, "sentinel_recovered_total %d\n", m.RecoveredCount())
+	fmt.Fprint(&b, "# HELP sentinel_state Backend serving state: 1 proxy (up), 0 maintenance (down).\n")
+	fmt.Fprint(&b, "# TYPE sentinel_state gauge\n")
+	fmt.Fprintf(&b, "sentinel_state %d\n", state)
+	fmt.Fprint(&b, "# HELP sentinel_outage_seconds Duration of the current outage; 0 when serving.\n")
+	fmt.Fprint(&b, "# TYPE sentinel_outage_seconds gauge\n")
+	fmt.Fprintf(&b, "sentinel_outage_seconds %d\n", outageSecs)
+	return b.String()
+}

--- a/internal/sentinel/observability_test.go
+++ b/internal/sentinel/observability_test.go
@@ -1,0 +1,105 @@
+package sentinel
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRenderMetrics_Format(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	m.preemptCount = 3
+	m.recoveredCount = 2
+	out := m.renderMetrics(0 /*down*/, 42)
+
+	for _, want := range []string{
+		"# TYPE sentinel_preempted_total counter",
+		"sentinel_preempted_total 3",
+		"sentinel_recovered_total 2",
+		"sentinel_state 0",
+		"sentinel_outage_seconds 42",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("metrics output missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+	// The net (3 preempted - 2 recovered = 1 outstanding) is what an
+	// external alert evaluates; the raw counters must both be present.
+}
+
+func TestMetricsHandler_ServesText(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	m.state.Store(StateProxy)
+	m.preemptCount = 1
+	rec := httptest.NewRecorder()
+	m.MetricsHandler()(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("content-type = %q, want text/plain…", ct)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "sentinel_state 1") { // proxy = up
+		t.Errorf("expected sentinel_state 1 (proxy); got:\n%s", body)
+	}
+}
+
+func TestFireAlert_NoWebhookIsNoop(t *testing.T) {
+	// No AlertWebhookURL → fireAlert must not panic or block.
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	m.fireAlert("preempted", "gcp", 0) // should simply return
+}
+
+func TestFireAlert_PostsPayload(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		got  alertPayload
+		seen bool
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		_ = json.Unmarshal(b, &got)
+		seen = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := NewManager(Config{AlertWebhookURL: srv.URL}, &fakeRecoveryProvider{})
+	m.preemptCount = 5
+	m.recoveredCount = 2
+	m.fireAlert("preempted", "gcp", 0)
+
+	// fireAlert dispatches the POST asynchronously; wait briefly.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		done := seen
+		mu.Unlock()
+		if done || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !seen {
+		t.Fatal("webhook was never called")
+	}
+	if got.Event != "preempted" || got.Backend != "gcp" {
+		t.Errorf("payload event/backend = %q/%q", got.Event, got.Backend)
+	}
+	if got.PreemptedTotal != 5 || got.RecoveredTotal != 2 || got.Outstanding != 3 {
+		t.Errorf("payload counters = preempted:%d recovered:%d outstanding:%d, want 5/2/3",
+			got.PreemptedTotal, got.RecoveredTotal, got.Outstanding)
+	}
+}

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -180,6 +180,12 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	if err := validateCreateContainerBounds(req); err != nil {
 		return nil, err
 	}
+	// Birth TTL (#523): reject an out-of-range TTL before we provision
+	// anything — fail fast rather than create a box and then reject its
+	// death date. Same bound (7 days) as SetContainerTTL; 0 = no TTL.
+	if err := validateTTLSeconds(req.TtlSeconds); err != nil {
+		return nil, err
+	}
 
 	// Pool resolution — if a pool is requested, either validate that
 	// the explicit backend_id belongs to that pool, or pick any
@@ -374,6 +380,19 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 				}
 			}
 
+			// Birth TTL (#523), async path. The CREATING response already
+			// returned, so a failure can't reach the caller via the response
+			// body — it surfaces through the pending state (Done=true,
+			// Error=<ttl>) the same way the digest-mismatch path above does.
+			// stampBirthTTL deletes the box on failure so an ephemeral box
+			// never leaks just because the async stamp lost a race.
+			if err == nil && info != nil && req.TtlSeconds > 0 {
+				if terr := s.stampBirthTTL(info.Name, req.Username, req.TtlSeconds); terr != nil {
+					err = terr
+					info = nil
+				}
+			}
+
 			s.pendingMu.Lock()
 			if pending, exists := s.pendingCreations[req.Username]; exists {
 				pending.Done = true
@@ -428,6 +447,17 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 			log.Printf("[image-digest] failed to delete container %q after post-pull mismatch: %v", info.Name, delErr)
 		}
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
+	}
+
+	// Birth TTL (#523): stamp the death date now that the box exists, before
+	// any best-effort setup, so the ttlsweeper reaps it even if the client
+	// dies the instant create returns. stampBirthTTL deletes the box and
+	// errors if it can't honor the requested TTL — an ephemeral box that
+	// would leak is worse than no box.
+	if req.TtlSeconds > 0 {
+		if err := s.stampBirthTTL(info.Name, req.Username, req.TtlSeconds); err != nil {
+			return nil, err
+		}
 	}
 
 	// Stamp tenant secrets into the LXC's env (best-effort — a

--- a/internal/server/container_server_birth_ttl_test.go
+++ b/internal/server/container_server_birth_ttl_test.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Birth TTL (#523): a box should be born with a death date so it can't leak
+// when the separate `ttl set` call never runs. These tests cover the
+// create→persist path (stampBirthTTL) and the validation it shares with
+// SetContainerTTL (validateTTLSeconds), mirroring container_server_ttl_test.go.
+
+// TestStampBirthTTL_StampsExpiry — the success path writes one SetConfig with
+// an RFC3339 value ~duration in the future, using the SAME key the sweeper
+// reads, and does NOT delete the box.
+func TestStampBirthTTL_StampsExpiry(t *testing.T) {
+	s, calls, mock := newTTLTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Running"},
+	})
+	deleted := false
+	mock.DeleteContainerFunc = func(string) error { deleted = true; return nil }
+
+	before := time.Now().UTC()
+	if err := s.stampBirthTTL("alice-container", "alice", 1800); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after := time.Now().UTC()
+
+	if deleted {
+		t.Error("success path must NOT delete the box")
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 SetConfig call, got %d: %+v", len(*calls), *calls)
+	}
+	c := (*calls)[0]
+	if c.kind != "set" || c.name != "alice-container" || c.key != incus.TTLExpiresAtKey {
+		t.Errorf("call = %+v, want set alice-container/%s", c, incus.TTLExpiresAtKey)
+	}
+	stamped, err := time.Parse(time.RFC3339, c.value)
+	if err != nil {
+		t.Fatalf("stamped value %q not RFC3339: %v", c.value, err)
+	}
+	lo := before.Add(30 * time.Minute).Add(-2 * time.Second)
+	hi := after.Add(30 * time.Minute).Add(2 * time.Second)
+	if stamped.Before(lo) || stamped.After(hi) {
+		t.Errorf("stamped expiry %s outside [%s, %s]", stamped, lo, hi)
+	}
+}
+
+// TestStampBirthTTL_FailureDeletesBox — if the TTL can't be stamped, the box
+// is deleted and an Internal error is returned: a box that asked to be
+// ephemeral but would leak forever is worse than no box (default-dead, #522).
+func TestStampBirthTTL_FailureDeletesBox(t *testing.T) {
+	s, _, mock := newTTLTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Running"},
+	})
+	mock.SetConfigFunc = func(string, string, string) error {
+		return errors.New("incus config write failed")
+	}
+	deletedName := ""
+	mock.DeleteContainerFunc = func(name string) error { deletedName = name; return nil }
+
+	err := s.stampBirthTTL("alice-container", "alice", 1800)
+	if err == nil {
+		t.Fatal("expected an error when the TTL stamp fails")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.Internal {
+		t.Errorf("error = %v, want Internal status", err)
+	}
+	if deletedName != "alice-container" {
+		t.Errorf("box not deleted on stamp failure: deletedName=%q want alice-container", deletedName)
+	}
+}
+
+// TestValidateTTLSeconds — the bound shared by create and set. Zero is valid
+// (no TTL / clear); negative and over-cap are rejected; the 7-day boundary is
+// inclusive. Keeps the two entry points rejecting identical input identically.
+func TestValidateTTLSeconds(t *testing.T) {
+	cases := []struct {
+		name    string
+		seconds int64
+		wantErr bool
+	}{
+		{"zero is valid (no TTL)", 0, false},
+		{"one hour", 3600, false},
+		{"exactly 7 days (inclusive)", maxTTLSeconds, false},
+		{"negative rejected", -1, true},
+		{"over 7 days rejected", maxTTLSeconds + 1, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTTLSeconds(tc.seconds)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("validateTTLSeconds(%d) = nil, want error", tc.seconds)
+				}
+				if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+					t.Errorf("error = %v, want InvalidArgument status", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("validateTTLSeconds(%d) = %v, want nil", tc.seconds, err)
+			}
+		})
+	}
+}

--- a/internal/server/container_server_ttl.go
+++ b/internal/server/container_server_ttl.go
@@ -47,11 +47,8 @@ func (s *ContainerServer) SetContainerTTL(ctx context.Context, req *pb.SetContai
 	if req.Name == "" {
 		return nil, status.Error(codes.InvalidArgument, "name is required")
 	}
-	if req.DurationSeconds < 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "duration_seconds must be >= 0, got %d", req.DurationSeconds)
-	}
-	if req.DurationSeconds > maxTTLSeconds {
-		return nil, status.Errorf(codes.InvalidArgument, "duration_seconds %d exceeds maximum of %d (7 days)", req.DurationSeconds, maxTTLSeconds)
+	if err := validateTTLSeconds(req.DurationSeconds); err != nil {
+		return nil, err
 	}
 
 	// Treat req.Name as the bare username (matches the per-container
@@ -87,11 +84,62 @@ func (s *ContainerServer) SetContainerTTL(ctx context.Context, req *pb.SetContai
 	// Set: stamp now() + duration in UTC RFC3339 so the sweeper's
 	// time.Parse round-trips with the same precision. Capping is
 	// already enforced above.
-	expiresAt := time.Now().Add(time.Duration(req.DurationSeconds) * time.Second).UTC()
-	if err := s.manager.SetConfig(containerName, incus.TTLExpiresAtKey, expiresAt.Format(time.RFC3339)); err != nil {
+	expiresAt, err := s.stampTTL(containerName, req.DurationSeconds)
+	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to set %s: %v", incus.TTLExpiresAtKey, err)
 	}
 	log.Printf("[ttl] set container=%s expires_at=%s (duration=%ds)", containerName, expiresAt.Format(time.RFC3339), req.DurationSeconds)
 	resp.TtlExpiresAt = timestamppb.New(expiresAt)
 	return resp, nil
+}
+
+// validateTTLSeconds checks a requested TTL duration against the bounds
+// shared by SetContainerTTL and the birth-TTL path in CreateContainer (#523).
+// Zero is always valid — it means "no TTL" on create and "clear the TTL" on
+// set, so callers handle the zero case themselves. Negative and over-cap
+// (> maxTTLSeconds, 7 days) return InvalidArgument so the two entry points
+// reject identical input identically.
+func validateTTLSeconds(seconds int64) error {
+	if seconds < 0 {
+		return status.Errorf(codes.InvalidArgument, "ttl seconds must be >= 0, got %d", seconds)
+	}
+	if seconds > maxTTLSeconds {
+		return status.Errorf(codes.InvalidArgument, "ttl seconds %d exceeds maximum of %d (7 days)", seconds, maxTTLSeconds)
+	}
+	return nil
+}
+
+// stampBirthTTL applies a create-time TTL (#523) to a just-created box so it
+// is born with a death date the ttlsweeper honors — closing the leak window
+// where a box exists with no TTL because the separate `ttl set` call never
+// ran. On failure it DELETES the box and returns an error rather than hand
+// back a box that was asked to be ephemeral but would otherwise leak forever:
+// default-dead, not default-alive (#522). ttlSeconds must be > 0 (the zero
+// case is "no TTL" and never reaches here). containerName is the incus name
+// (info.Name) for the config write + logs; username is what manager.Delete
+// keys on.
+func (s *ContainerServer) stampBirthTTL(containerName, username string, ttlSeconds int64) error {
+	expiresAt, err := s.stampTTL(containerName, ttlSeconds)
+	if err != nil {
+		if delErr := s.manager.Delete(username, true); delErr != nil {
+			log.Printf("[ttl] birth TTL stamp failed AND cleanup-delete failed for %s: stamp=%v delete=%v", containerName, err, delErr)
+		}
+		return status.Errorf(codes.Internal, "failed to set birth TTL on %s (box deleted to avoid a leak): %v", containerName, err)
+	}
+	log.Printf("[ttl] birth TTL set container=%s expires_at=%s (duration=%ds)", containerName, expiresAt.Format(time.RFC3339), ttlSeconds)
+	return nil
+}
+
+// stampTTL writes now()+duration as a UTC RFC3339 wall-clock expiry onto the
+// container's Incus config under user.containarium.ttl_expires_at — the exact
+// key + format the ttlsweeper reads, so create and set agree byte-for-byte.
+// durationSeconds MUST be > 0 (validated via validateTTLSeconds); the zero
+// case is the caller's responsibility (clear on set, skip on create). Shared
+// by SetContainerTTL and CreateContainer's birth-TTL path (#523).
+func (s *ContainerServer) stampTTL(containerName string, durationSeconds int64) (time.Time, error) {
+	expiresAt := time.Now().Add(time.Duration(durationSeconds) * time.Second).UTC()
+	if err := s.manager.SetConfig(containerName, incus.TTLExpiresAtKey, expiresAt.Format(time.RFC3339)); err != nil {
+		return time.Time{}, err
+	}
+	return expiresAt, nil
 }

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -803,6 +803,14 @@ type CreateContainerRequest struct {
 	// workspace_path: where in the box to place the source. Empty
 	// defaults to "/workspace".
 	WorkspacePath string `protobuf:"bytes,19,opt,name=workspace_path,json=workspacePath,proto3" json:"workspace_path,omitempty"`
+	// Birth TTL (optional) — seconds from creation after which the box is
+	// auto-deleted. When > 0, the daemon stamps ttl_expires_at = now() +
+	// ttl_seconds at create time (same persistence as SetContainerTTL), so
+	// the box is born with a death date and the ttlsweeper reaps it even if
+	// the client dies right after create — no separate `ttl set` call needed
+	// (#523). 0 = no TTL (today's behavior). Capped at 604800 (7 days);
+	// larger values return InvalidArgument, same bound as SetContainerTTL.
+	TtlSeconds    int64 `protobuf:"varint,20,opt,name=ttl_seconds,json=ttlSeconds,proto3" json:"ttl_seconds,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -968,6 +976,13 @@ func (x *CreateContainerRequest) GetWorkspacePath() string {
 		return x.WorkspacePath
 	}
 	return ""
+}
+
+func (x *CreateContainerRequest) GetTtlSeconds() int64 {
+	if x != nil {
+		return x.TtlSeconds
+	}
+	return 0
 }
 
 // CreateContainerResponse is the response from creating a container
@@ -4047,7 +4062,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x10disk_usage_bytes\x18\x05 \x01(\x03R\x0ediskUsageBytes\x12(\n" +
 	"\x10network_rx_bytes\x18\x06 \x01(\x03R\x0enetworkRxBytes\x12(\n" +
 	"\x10network_tx_bytes\x18\a \x01(\x03R\x0enetworkTxBytes\x12#\n" +
-	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\xe4\x06\n" +
+	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\x85\a\n" +
 	"\x16CreateContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12=\n" +
 	"\tresources\x18\x02 \x01(\v2\x1f.containarium.v1.ResourceLimitsR\tresources\x12\x19\n" +
@@ -4072,7 +4087,9 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"git_source\x18\x10 \x01(\tR\tgitSource\x12\x17\n" +
 	"\agit_ref\x18\x11 \x01(\tR\x06gitRef\x12%\n" +
 	"\x0egit_credential\x18\x12 \x01(\tR\rgitCredential\x12%\n" +
-	"\x0eworkspace_path\x18\x13 \x01(\tR\rworkspacePath\x1a9\n" +
+	"\x0eworkspace_path\x18\x13 \x01(\tR\rworkspacePath\x12\x1f\n" +
+	"\vttl_seconds\x18\x14 \x01(\x03R\n" +
+	"ttlSeconds\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aB\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -311,6 +311,15 @@ message CreateContainerRequest {
   // workspace_path: where in the box to place the source. Empty
   // defaults to "/workspace".
   string workspace_path = 19;
+
+  // Birth TTL (optional) — seconds from creation after which the box is
+  // auto-deleted. When > 0, the daemon stamps ttl_expires_at = now() +
+  // ttl_seconds at create time (same persistence as SetContainerTTL), so
+  // the box is born with a death date and the ttlsweeper reaps it even if
+  // the client dies right after create — no separate `ttl set` call needed
+  // (#523). 0 = no TTL (today's behavior). Capped at 604800 (7 days);
+  // larger values return InvalidArgument, same bound as SetContainerTTL.
+  int64 ttl_seconds = 20;
 }
 
 // CreateContainerResponse is the response from creating a container

--- a/test/integration/storage_test.go
+++ b/test/integration/storage_test.go
@@ -103,6 +103,7 @@ func testCreateContainerWithQuota(t *testing.T, ctx context.Context, grpcClient 
 		"",                           // No pool
 		"",                           // No backend ID
 		client.GitSourceOpts{},       // No git provisioning
+		0,                            // No birth TTL
 	)
 	require.NoError(t, err, "Failed to create container")
 	require.NotNil(t, container)
@@ -151,6 +152,7 @@ func testQuotaEnforcement(t *testing.T, ctx context.Context, grpcClient *client.
 		"",                     // No pool
 		"",                     // No backend ID
 		client.GitSourceOpts{}, // No git provisioning
+		0,                      // No birth TTL
 	)
 	require.NoError(t, err)
 	require.NotNil(t, container)
@@ -187,11 +189,11 @@ func testMultiContainerIsolation(t *testing.T, ctx context.Context, grpcClient *
 	t.Log("Creating multiple containers to test quota isolation...")
 
 	// Create two containers with different quotas
-	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{})
+	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0)
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(user1, true)
 
-	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{})
+	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0)
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(user2, true)
 
@@ -217,7 +219,7 @@ func testCompression(t *testing.T, ctx context.Context, grpcClient *client.GRPCC
 
 	t.Log("Creating container to test compression...")
 
-	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{})
+	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0)
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(username, true)
 
@@ -240,7 +242,7 @@ func testPrepareRebootData(t *testing.T, ctx context.Context, grpcClient *client
 	t.Logf("Creating container for persistence test: %s", username)
 
 	// Create container
-	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{})
+	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0)
 	require.NoError(t, err)
 	require.NotNil(t, container)
 


### PR DESCRIPTION
Part of #522 (box lifecycle: stop ephemeral/CI boxes from leaking).

## Problem

A TTL could only be set **after** a box existed, via `SetContainerTTL` (`containarium ttl set`, #297). The window between create and that call — and any failure of it (cancelled job, dead runner, transient error) — left a box with **no TTL → it runs forever**. The `ttlsweeper` only reaps boxes that *have* a TTL, so it can't help these. At CI churn the pool slowly fills with orphaned running boxes holding CPU/RAM.

## Change — born with a death date

- **proto:** add `int64 ttl_seconds = 20` to `CreateContainerRequest` (regenerated; swagger updated).
- **daemon:** `CreateContainer` validates the TTL **up front** (fail fast, same 7-day cap as `SetContainerTTL`) and stamps `ttl_expires_at` after the box exists, via the **same persistence path** `SetContainerTTL` uses (Incus `user.containarium.ttl_expires_at`, UTC RFC3339) — so the `ttlsweeper` picks it up immediately, no second call. Wired into **both** the sync and async create paths.
- **CLI:** `containarium create --ttl <dur>` (Go duration; reuses `parseTTL` so create and set agree on format + cap). Plumbed through the gRPC + HTTP typed clients; local Incus mode stamps the same key directly.

## Default-dead, not default-alive

If the TTL can't be stamped, the box is **deleted** and the create fails (`stampBirthTTL`) rather than hand back a box that asked to be ephemeral but would leak forever — the exact failure #522 exists to prevent.

## Refactor

Extracted `validateTTLSeconds` + `stampTTL`, shared by `SetContainerTTL` and the birth-TTL path, so the bound and the persistence format can't drift between the two entry points.

## Acceptance (from #523)

- `containarium create --ttl 30m <box>` → the box has `ttl_expires_at ≈ now+30m` the instant it's RUNNING (no follow-up `ttl set`). ✅ (stamped via the same key `ttl get`/inspect read)
- Kill the client right after create → the box is still reaped by `ttlsweeper` at expiry. ✅ (persisted on the box, independent of the client)
- Unit coverage on the create→persist path mirrors the `SetContainerTTL` handler. ✅

## Tests

`container_server_birth_ttl_test.go`: `stampBirthTTL` stamps the expiry (RFC3339, correct key, no delete) / deletes-on-failure returns Internal; `validateTTLSeconds` bound table (zero ok, negative + over-cap rejected, 7-day boundary inclusive). Existing `SetContainerTTL` suite unchanged and green; full unit suite green (`go test -short ./...`).

## Related

Siblings in the #522 epic (separate PRs): #524 (idle→stop), #525 (two-phase reaping), #526 (runner create-with-ttl). Cloud-side lifecycle PRD: FootprintAI/Containarium-cloud#316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)