### PR TITLE
feat(autosleep): birth idle-stop + don't sleep active sessions (#524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Birth idle-stop — `containarium create --idle-stop <dur>`** — a box can be born with its auto-sleep (idle→stop) timer, not just its delete timer. `CreateContainer` accepts an optional `idle_stop_minutes`; the daemon enables auto-sleep at create with that idle threshold (same persistence as `toggle_auto_sleep`), so a crashed/cancelled job still releases CPU/RAM (disk kept, wakes on access) — no separate `toggle_auto_sleep` call to forget. The stop half of the default-sleep→default-dead model (birth TTL #523 is the delete half). Off by default. (#524)
+
+### Fixed
+
+- **Auto-sleep no longer stops a box with an active session.** The idle signal treated a long-lived open connection (e.g. an SSH/exec debug session) as last-active at its *start*, so a session open longer than the idle threshold looked idle and the box was slept mid-debug. An open connection now counts as active-as-of-now; the box stays awake while anyone is connected and becomes sleep-eligible only after the session closes. (#524)
+
 ## [0.23.2] - 2026-06-06
 
 ### Added

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -6090,6 +6090,11 @@
           "type": "string",
           "format": "int64",
           "description": "Birth TTL (optional) — seconds from creation after which the box is\nauto-deleted. When \u003e 0, the daemon stamps ttl_expires_at = now() +\nttl_seconds at create time (same persistence as SetContainerTTL), so\nthe box is born with a death date and the ttlsweeper reaps it even if\nthe client dies right after create — no separate `ttl set` call needed\n(#523). 0 = no TTL (today's behavior). Capped at 604800 (7 days);\nlarger values return InvalidArgument, same bound as SetContainerTTL."
+        },
+        "idleStopMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Birth idle-stop (optional) — minutes of inactivity after which the box\nis auto-STOPPED (freeing CPU/RAM, keeping disk; wakes on next access).\nWhen \u003e 0, the daemon enables auto-sleep at create time with this idle\nthreshold (same persistence as ToggleAutoSleep), so the box is born\nwith the stop timer too — no separate `toggle_auto_sleep` call to\nforget (#524, the stop half of #522's default-sleep→default-dead\nmodel; ttl_seconds is the delete half). 0 = no auto-sleep (today's\nbehavior). The auto-sleep loop treats an open SSH/exec session as\nactive, so an actively-debugged box is never stopped mid-session."
         }
       },
       "title": "CreateContainerRequest is the request to create a new container"

--- a/internal/autosleep/idle.go
+++ b/internal/autosleep/idle.go
@@ -44,17 +44,24 @@ func NewTrafficStoreAdapter(pool *pgxpool.Pool) *TrafficStoreAdapter {
 // the Decide rules treat as "no traffic ever recorded" rather than
 // confusing with epoch 0.
 //
-// We read max(GREATEST(ended_at, started_at)) so an open connection
-// (no ended_at, only started_at) still counts. This matches the
-// collector's semantics: ended_at is stamped only when a connection
-// closes; a long-lived TCP session looks "active" because it started
-// recently even if it hasn't ended.
+// An OPEN connection (ended_at IS NULL) counts as activity AS OF NOW, not
+// as of when it started. This is the fix for #524's "a box running an active
+// session is NOT stopped": a long-lived SSH/exec debug session is a single
+// TCP connection whose conntrack row has no ended_at until it closes. The
+// previous COALESCE(ended_at, started_at) pinned its activity to started_at,
+// so a session open LONGER than the idle threshold looked idle and the box
+// was slept out from under the person debugging it. Treating any open
+// connection as now-active keeps the box awake for exactly as long as someone
+// is connected; once the session closes the collector stamps ended_at (on the
+// conntrack destroy event) and the box becomes eligible to sleep again. A
+// closed connection contributes its ended_at (always set on close), which is
+// its true last-activity instant.
 func (a *TrafficStoreAdapter) LastNetworkActivity(ctx context.Context, containerName string) (time.Time, error) {
 	if a == nil || a.pool == nil {
 		return time.Time{}, nil
 	}
 	const q = `
-		SELECT MAX(COALESCE(ended_at, started_at))
+		SELECT MAX(CASE WHEN ended_at IS NULL THEN now() ELSE ended_at END)
 		FROM traffic_connections
 		WHERE container_name = $1
 	`

--- a/internal/autosleep/idle_test.go
+++ b/internal/autosleep/idle_test.go
@@ -1,0 +1,98 @@
+package autosleep
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// fakeRow is a pgx.Row whose Scan writes a preset *time.Time into the
+// caller's **time.Time destination (the shape LastNetworkActivity scans).
+type fakeRow struct {
+	val *time.Time
+	err error
+}
+
+func (r fakeRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	if len(dest) == 1 {
+		if p, ok := dest[0].(**time.Time); ok {
+			*p = r.val
+		}
+	}
+	return nil
+}
+
+// fakePool captures the SQL it was asked to run and returns a canned row.
+type fakePool struct {
+	gotSQL string
+	row    pgx.Row
+}
+
+func (p *fakePool) QueryRow(_ context.Context, sql string, _ ...any) pgx.Row {
+	p.gotSQL = sql
+	return p.row
+}
+
+// TestLastNetworkActivity_OpenConnectionCountsAsNow pins #524's fix: the
+// activity query must treat an OPEN connection (ended_at IS NULL) as
+// active-now via now(), NOT fall back to started_at — otherwise a long SSH
+// debug session looks idle and the box is slept mid-session. This guards the
+// SQL so a refactor can't silently revert to the COALESCE(ended_at,
+// started_at) form that had the bug.
+func TestLastNetworkActivity_OpenConnectionCountsAsNow(t *testing.T) {
+	p := &fakePool{row: fakeRow{val: nil}}
+	a := &TrafficStoreAdapter{pool: p}
+	if _, err := a.LastNetworkActivity(context.Background(), "alice-container"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(p.gotSQL, "ended_at IS NULL") || !strings.Contains(p.gotSQL, "now()") {
+		t.Errorf("query must treat an open connection as now-active (CASE WHEN ended_at IS NULL THEN now()); got:\n%s", p.gotSQL)
+	}
+	if strings.Contains(p.gotSQL, "COALESCE(ended_at, started_at)") {
+		t.Errorf("query regressed to the started_at fallback that sleeps active sessions (#524); got:\n%s", p.gotSQL)
+	}
+}
+
+// TestLastNetworkActivity_ScansTime confirms a returned timestamp is passed
+// through, and a NULL aggregate (no rows / all-null) maps to the zero time
+// (the "no traffic ever" signal Decide special-cases).
+func TestLastNetworkActivity_ScansTime(t *testing.T) {
+	want := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	p := &fakePool{row: fakeRow{val: &want}}
+	a := &TrafficStoreAdapter{pool: p}
+	got, err := a.LastNetworkActivity(context.Background(), "alice-container")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Errorf("got %s, want %s", got, want)
+	}
+
+	// NULL aggregate → *time.Time nil → zero time.
+	p2 := &fakePool{row: fakeRow{val: nil}}
+	a2 := &TrafficStoreAdapter{pool: p2}
+	got2, err := a2.LastNetworkActivity(context.Background(), "x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got2.IsZero() {
+		t.Errorf("NULL aggregate should map to zero time, got %s", got2)
+	}
+}
+
+// TestLastNetworkActivity_NilAdapter is the documented nil-receiver contract:
+// a daemon without a traffic store returns zero time (no signal), so Decide
+// falls back to its since-start branch rather than panicking.
+func TestLastNetworkActivity_NilAdapter(t *testing.T) {
+	var a *TrafficStoreAdapter
+	got, err := a.LastNetworkActivity(context.Background(), "x")
+	if err != nil || !got.IsZero() {
+		t.Errorf("nil adapter: got (%v, %v), want (zero, nil)", got, err)
+	}
+}

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -153,7 +153,7 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 }
 
 // CreateContainer creates a container via gRPC
-func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64) (*incus.ContainerInfo, error) {
+func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute) // Container creation can take time (includes ultra-aggressive retry logic for google_guest_agent)
 	defer cancel()
 
@@ -175,9 +175,10 @@ func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, 
 		BackendId:     backendID,
 		GitSource:     git.Source,
 		GitRef:        git.Ref,
-		GitCredential: git.Credential,
-		WorkspacePath: git.WorkspacePath,
-		TtlSeconds:    ttlSeconds,
+		GitCredential:   git.Credential,
+		WorkspacePath:   git.WorkspacePath,
+		TtlSeconds:      ttlSeconds,
+		IdleStopMinutes: idleStopMinutes,
 	}
 
 	resp, err := c.client.CreateContainer(ctx, req)

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -280,7 +280,7 @@ type GitSourceOpts struct {
 	WorkspacePath string // empty defaults to /workspace
 }
 
-func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64) (*incus.ContainerInfo, error) {
+func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
@@ -313,6 +313,11 @@ func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, 
 	// create's body.
 	if ttlSeconds > 0 {
 		reqBody["ttlSeconds"] = ttlSeconds
+	}
+	// Birth idle-stop (#524): same posture — only include when enabling
+	// auto-sleep, so a plain create's body is unchanged.
+	if idleStopMinutes > 0 {
+		reqBody["idleStopMinutes"] = idleStopMinutes
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/containers", reqBody)

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -39,6 +39,7 @@ var (
 	createGitCredentialFile  string
 	createWorkspacePath      string
 	createTTL                string
+	createIdleStop           string
 )
 
 var createCmd = &cobra.Command{
@@ -120,6 +121,7 @@ func init() {
 	createCmd.Flags().StringVar(&createGitCredentialFile, "git-credential-file", "", "Path to a file holding a bearer token for a private --git-source. Used daemon-side for one fetch; never written to the box's .git/config.")
 	createCmd.Flags().StringVar(&createWorkspacePath, "workspace-path", "", "Where --git-source lands inside the box. Empty defaults to /workspace.")
 	createCmd.Flags().StringVar(&createTTL, "ttl", "", "Birth TTL — auto-delete the box this long after creation (Go duration: '30m', '1h', '24h'; max 168h/7 days). The death date is stamped atomically at create, so the box is reaped even if the client dies right after — no separate 'ttl set' needed (#523). Empty = no TTL.")
+	createCmd.Flags().StringVar(&createIdleStop, "idle-stop", "", "Birth idle-stop — auto-STOP the box (free CPU/RAM, keep disk; wakes on access) after this long with no activity (Go duration: '20m', '1h'). Enables auto-sleep atomically at create, so a crashed/cancelled job still releases compute — no separate 'toggle_auto_sleep' needed (#524). An active SSH/exec session counts as activity, so a box being debugged is never stopped mid-session. Empty = no auto-sleep.")
 }
 
 // validateSSHKeyMode enforces "exactly one of --ssh-key / --no-ssh-key".
@@ -161,6 +163,24 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		ttlSeconds = int64(d.Seconds())
 	}
 
+	// Birth idle-stop (#524): parse the optional --idle-stop duration into the
+	// minute-resolution idle threshold auto-sleep uses. A positive sub-minute
+	// value rounds up to 1 minute (the smallest threshold the daemon stores).
+	var idleStopMinutes int32
+	if createIdleStop != "" {
+		d, err := time.ParseDuration(createIdleStop)
+		if err != nil {
+			return fmt.Errorf("invalid --idle-stop %q: %w (expected Go duration like '20m', '1h')", createIdleStop, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("--idle-stop must be positive, got %s", createIdleStop)
+		}
+		idleStopMinutes = int32(d.Minutes())
+		if idleStopMinutes < 1 {
+			idleStopMinutes = 1
+		}
+	}
+
 	fmt.Printf("Creating container for user: %s\n", username)
 	if verbose {
 		fmt.Printf("  CPU: %s\n", cpuLimit)
@@ -181,6 +201,9 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		}
 		if ttlSeconds > 0 {
 			fmt.Printf("  TTL: %s (auto-delete at create+TTL)\n", createTTL)
+		}
+		if idleStopMinutes > 0 {
+			fmt.Printf("  Idle-stop: %dm (auto-sleep when idle)\n", idleStopMinutes)
 		}
 		if len(parsedLabels) > 0 {
 			fmt.Printf("  Labels:\n")
@@ -345,13 +368,13 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if httpMode && serverAddr != "" {
 		// Remote mode via HTTP
-		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds)
+		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes)
 		if err != nil {
 			return fmt.Errorf("failed to create container via HTTP API: %w", err)
 		}
 	} else if serverAddr != "" {
 		// Remote mode via gRPC
-		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds)
+		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes)
 		if err != nil {
 			return fmt.Errorf("failed to create container via remote server: %w", err)
 		}
@@ -360,7 +383,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		if verbose {
 			fmt.Println("Creating container...")
 		}
-		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevice, osType, monitoring, gitOpts, ttlSeconds)
+		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevice, osType, monitoring, gitOpts, ttlSeconds, idleStopMinutes)
 		if err != nil {
 			// Cleanup jump server account on failure
 			_ = container.DeleteJumpServerAccount(username, false)
@@ -502,7 +525,7 @@ func resolveGitSourceOpts() (client.GitSourceOpts, error) {
 }
 
 // createLocal creates a container using local Incus daemon
-func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, git client.GitSourceOpts, ttlSeconds int64) (*incus.ContainerInfo, error) {
+func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32) (*incus.ContainerInfo, error) {
 	mgr, err := container.New()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
@@ -550,6 +573,19 @@ func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []
 		}
 	}
 
+	// Birth idle-stop (#524), local path. Mirror the daemon's best-effort
+	// stamp: enable auto-sleep with the requested threshold so the box is
+	// born with its idle→stop timer. Best-effort — auto-sleep is an
+	// optimization, not a leak contract, so a failed stamp warns and the box
+	// keeps running (unlike the TTL path, we do NOT delete the box).
+	if idleStopMinutes > 0 {
+		if serr := mgr.SetConfig(info.Name, incus.AutoSleepEnabledKey, "true"); serr != nil {
+			fmt.Printf("warning: failed to enable birth auto-sleep on %s: %v (continuing; box has no idle-stop)\n", info.Name, serr)
+		} else if serr := mgr.SetConfig(info.Name, incus.IdleThresholdMinutesKey, fmt.Sprintf("%d", idleStopMinutes)); serr != nil {
+			fmt.Printf("warning: enabled auto-sleep on %s but failed to set idle threshold: %v\n", info.Name, serr)
+		}
+	}
+
 	return info, nil
 }
 
@@ -570,23 +606,23 @@ func parseLabels(labelSlice []string) map[string]string {
 }
 
 // createRemote creates a container using remote gRPC server
-func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64) (*incus.ContainerInfo, error) {
+func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32) (*incus.ContainerInfo, error) {
 	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
 		return nil, err
 	}
 	defer grpcClient.Close()
 
-	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git, ttlSeconds)
+	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes)
 }
 
 // createRemoteHTTP creates a container using remote HTTP API
-func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64) (*incus.ContainerInfo, error) {
+func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32) (*incus.ContainerInfo, error) {
 	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
 	if err != nil {
 		return nil, err
 	}
 	defer httpClient.Close()
 
-	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git, ttlSeconds)
+	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes)
 }

--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -382,6 +382,7 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 				"",                     // backend-id
 				client.GitSourceOpts{}, // no git-source for runner boxes
 				0,                      // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
+				0,                      // idle-stop: runner boxes are long-lived; not auto-slept
 			)
 			if err != nil {
 				return "", "", err
@@ -417,6 +418,7 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 			"",
 			client.GitSourceOpts{}, // no git-source for runner boxes
 			0,                      // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
+			0,                      // idle-stop: runner boxes are long-lived; not auto-slept
 		)
 		if err != nil {
 			return "", "", err

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -186,6 +186,11 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	if err := validateTTLSeconds(req.TtlSeconds); err != nil {
 		return nil, err
 	}
+	// Birth idle-stop (#524): a negative threshold is nonsense; reject early.
+	// 0 = no auto-sleep; > 0 enables it with that idle threshold (minutes).
+	if req.IdleStopMinutes < 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "idle_stop_minutes must be >= 0, got %d", req.IdleStopMinutes)
+	}
 
 	// Pool resolution — if a pool is requested, either validate that
 	// the explicit backend_id belongs to that pool, or pick any
@@ -393,6 +398,13 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 				}
 			}
 
+			// Birth idle-stop (#524), async path. Best-effort like the sync
+			// path — auto-sleep is an optimization, not a leak contract, so a
+			// failed stamp never turns a created box into a failed creation.
+			if err == nil && info != nil && req.IdleStopMinutes > 0 {
+				s.stampBirthAutoSleep(info.Name, req.IdleStopMinutes)
+			}
+
 			s.pendingMu.Lock()
 			if pending, exists := s.pendingCreations[req.Username]; exists {
 				pending.Done = true
@@ -458,6 +470,16 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		if err := s.stampBirthTTL(info.Name, req.Username, req.TtlSeconds); err != nil {
 			return nil, err
 		}
+	}
+
+	// Birth idle-stop (#524): enable auto-sleep at create with the requested
+	// idle threshold, so the box is born with the stop timer and the
+	// autosleep loop reclaims its CPU/RAM if a job crashes/cancels without
+	// anyone calling toggle_auto_sleep. Best-effort: unlike the TTL (a leak
+	// contract), auto-sleep is an optimization — a failed stamp logs and the
+	// box keeps running (it can be toggled later), it never fails the create.
+	if req.IdleStopMinutes > 0 {
+		s.stampBirthAutoSleep(info.Name, req.IdleStopMinutes)
 	}
 
 	// Stamp tenant secrets into the LXC's env (best-effort — a

--- a/internal/server/container_server_birth_ttl_test.go
+++ b/internal/server/container_server_birth_ttl_test.go
@@ -77,6 +77,27 @@ func TestStampBirthTTL_FailureDeletesBox(t *testing.T) {
 	}
 }
 
+// TestStampBirthAutoSleep_EnablesWithThreshold — #524: a create-time idle-stop
+// enables auto-sleep at birth by writing the same two Incus keys ToggleAutoSleep
+// uses, so the box is born with its idle→stop timer (no separate toggle call).
+func TestStampBirthAutoSleep_EnablesWithThreshold(t *testing.T) {
+	s, calls, _ := newTTLTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Running"},
+	})
+	s.stampBirthAutoSleep("alice-container", 20)
+
+	if len(*calls) != 2 {
+		t.Fatalf("expected 2 SetConfig calls (enable + threshold), got %d: %+v", len(*calls), *calls)
+	}
+	enable, thresh := (*calls)[0], (*calls)[1]
+	if enable.key != incus.AutoSleepEnabledKey || enable.value != "true" {
+		t.Errorf("first call = %+v, want %s=true", enable, incus.AutoSleepEnabledKey)
+	}
+	if thresh.key != incus.IdleThresholdMinutesKey || thresh.value != "20" {
+		t.Errorf("second call = %+v, want %s=20", thresh, incus.IdleThresholdMinutesKey)
+	}
+}
+
 // TestValidateTTLSeconds — the bound shared by create and set. Zero is valid
 // (no TTL / clear); negative and over-cap are rejected; the 7-day boundary is
 // inclusive. Keeps the two entry points rejecting identical input identically.

--- a/internal/server/container_server_ttl.go
+++ b/internal/server/container_server_ttl.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/footprintai/containarium/internal/auth"
@@ -128,6 +129,27 @@ func (s *ContainerServer) stampBirthTTL(containerName, username string, ttlSecon
 	}
 	log.Printf("[ttl] birth TTL set container=%s expires_at=%s (duration=%ds)", containerName, expiresAt.Format(time.RFC3339), ttlSeconds)
 	return nil
+}
+
+// stampBirthAutoSleep enables auto-sleep on a just-created box (#524) with the
+// given idle threshold (minutes), via the same Incus config keys ToggleAutoSleep
+// writes — so the box is born with its idle→stop timer and the autosleep loop
+// reclaims its CPU/RAM if a job crashes/cancels without anyone calling
+// toggle_auto_sleep (the stop half of #522's default-sleep model; birth TTL is
+// the delete half). Best-effort: auto-sleep is an optimization, not a leak
+// contract, so a failed stamp logs and the box keeps running (it can be toggled
+// later) rather than failing the create. idleMinutes must be > 0 (the zero case
+// is "no auto-sleep" and never reaches here).
+func (s *ContainerServer) stampBirthAutoSleep(containerName string, idleMinutes int32) {
+	if err := s.manager.SetConfig(containerName, incus.AutoSleepEnabledKey, "true"); err != nil {
+		log.Printf("[autosleep] failed to enable birth auto-sleep on %s: %v (continuing; box has no idle-stop)", containerName, err)
+		return
+	}
+	if err := s.manager.SetConfig(containerName, incus.IdleThresholdMinutesKey, strconv.Itoa(int(idleMinutes))); err != nil {
+		log.Printf("[autosleep] enabled auto-sleep on %s but failed to set idle threshold: %v (autosleep loop falls back to its %dm default)", containerName, err, incus.DefaultIdleThresholdMinutes)
+		return
+	}
+	log.Printf("[autosleep] birth auto-sleep enabled container=%s idle_threshold=%dm", containerName, idleMinutes)
 }
 
 // stampTTL writes now()+duration as a UTC RFC3339 wall-clock expiry onto the

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -810,9 +810,19 @@ type CreateContainerRequest struct {
 	// the client dies right after create — no separate `ttl set` call needed
 	// (#523). 0 = no TTL (today's behavior). Capped at 604800 (7 days);
 	// larger values return InvalidArgument, same bound as SetContainerTTL.
-	TtlSeconds    int64 `protobuf:"varint,20,opt,name=ttl_seconds,json=ttlSeconds,proto3" json:"ttl_seconds,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	TtlSeconds int64 `protobuf:"varint,20,opt,name=ttl_seconds,json=ttlSeconds,proto3" json:"ttl_seconds,omitempty"`
+	// Birth idle-stop (optional) — minutes of inactivity after which the box
+	// is auto-STOPPED (freeing CPU/RAM, keeping disk; wakes on next access).
+	// When > 0, the daemon enables auto-sleep at create time with this idle
+	// threshold (same persistence as ToggleAutoSleep), so the box is born
+	// with the stop timer too — no separate `toggle_auto_sleep` call to
+	// forget (#524, the stop half of #522's default-sleep→default-dead
+	// model; ttl_seconds is the delete half). 0 = no auto-sleep (today's
+	// behavior). The auto-sleep loop treats an open SSH/exec session as
+	// active, so an actively-debugged box is never stopped mid-session.
+	IdleStopMinutes int32 `protobuf:"varint,21,opt,name=idle_stop_minutes,json=idleStopMinutes,proto3" json:"idle_stop_minutes,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *CreateContainerRequest) Reset() {
@@ -981,6 +991,13 @@ func (x *CreateContainerRequest) GetWorkspacePath() string {
 func (x *CreateContainerRequest) GetTtlSeconds() int64 {
 	if x != nil {
 		return x.TtlSeconds
+	}
+	return 0
+}
+
+func (x *CreateContainerRequest) GetIdleStopMinutes() int32 {
+	if x != nil {
+		return x.IdleStopMinutes
 	}
 	return 0
 }
@@ -4062,7 +4079,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x10disk_usage_bytes\x18\x05 \x01(\x03R\x0ediskUsageBytes\x12(\n" +
 	"\x10network_rx_bytes\x18\x06 \x01(\x03R\x0enetworkRxBytes\x12(\n" +
 	"\x10network_tx_bytes\x18\a \x01(\x03R\x0enetworkTxBytes\x12#\n" +
-	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\x85\a\n" +
+	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\xb1\a\n" +
 	"\x16CreateContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12=\n" +
 	"\tresources\x18\x02 \x01(\v2\x1f.containarium.v1.ResourceLimitsR\tresources\x12\x19\n" +
@@ -4089,7 +4106,8 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x0egit_credential\x18\x12 \x01(\tR\rgitCredential\x12%\n" +
 	"\x0eworkspace_path\x18\x13 \x01(\tR\rworkspacePath\x12\x1f\n" +
 	"\vttl_seconds\x18\x14 \x01(\x03R\n" +
-	"ttlSeconds\x1a9\n" +
+	"ttlSeconds\x12*\n" +
+	"\x11idle_stop_minutes\x18\x15 \x01(\x05R\x0fidleStopMinutes\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aB\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -320,6 +320,17 @@ message CreateContainerRequest {
   // (#523). 0 = no TTL (today's behavior). Capped at 604800 (7 days);
   // larger values return InvalidArgument, same bound as SetContainerTTL.
   int64 ttl_seconds = 20;
+
+  // Birth idle-stop (optional) — minutes of inactivity after which the box
+  // is auto-STOPPED (freeing CPU/RAM, keeping disk; wakes on next access).
+  // When > 0, the daemon enables auto-sleep at create time with this idle
+  // threshold (same persistence as ToggleAutoSleep), so the box is born
+  // with the stop timer too — no separate `toggle_auto_sleep` call to
+  // forget (#524, the stop half of #522's default-sleep→default-dead
+  // model; ttl_seconds is the delete half). 0 = no auto-sleep (today's
+  // behavior). The auto-sleep loop treats an open SSH/exec session as
+  // active, so an actively-debugged box is never stopped mid-session.
+  int32 idle_stop_minutes = 21;
 }
 
 // CreateContainerResponse is the response from creating a container

--- a/test/integration/storage_test.go
+++ b/test/integration/storage_test.go
@@ -104,6 +104,7 @@ func testCreateContainerWithQuota(t *testing.T, ctx context.Context, grpcClient 
 		"",                           // No backend ID
 		client.GitSourceOpts{},       // No git provisioning
 		0,                            // No birth TTL
+		0,                            // No idle-stop
 	)
 	require.NoError(t, err, "Failed to create container")
 	require.NotNil(t, container)
@@ -153,6 +154,7 @@ func testQuotaEnforcement(t *testing.T, ctx context.Context, grpcClient *client.
 		"",                     // No backend ID
 		client.GitSourceOpts{}, // No git provisioning
 		0,                      // No birth TTL
+		0,                      // No idle-stop
 	)
 	require.NoError(t, err)
 	require.NotNil(t, container)
@@ -189,11 +191,11 @@ func testMultiContainerIsolation(t *testing.T, ctx context.Context, grpcClient *
 	t.Log("Creating multiple containers to test quota isolation...")
 
 	// Create two containers with different quotas
-	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0)
+	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0)
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(user1, true)
 
-	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0)
+	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0)
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(user2, true)
 
@@ -219,7 +221,7 @@ func testCompression(t *testing.T, ctx context.Context, grpcClient *client.GRPCC
 
 	t.Log("Creating container to test compression...")
 
-	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0)
+	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0)
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(username, true)
 
@@ -242,7 +244,7 @@ func testPrepareRebootData(t *testing.T, ctx context.Context, grpcClient *client
 	t.Logf("Creating container for persistence test: %s", username)
 
 	// Create container
-	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0)
+	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0)
 	require.NoError(t, err)
 	require.NotNil(t, container)
 


### PR DESCRIPTION
Part of #522 (box lifecycle: default-sleep, then default-dead).

## Finding first: idle→stop already exists

The idle→**stop** capability #524 describes is already implemented in `internal/autosleep` — opt-in (`auto_sleep_enabled` + `idle_threshold_minutes`), stop-keeps-disk, wake-on-access, anti-thrash, wired into the daemon's tickers. So adding a second stop action to `ttlsweeper` (the issue's literal framing) would **duplicate** it. This PR instead makes the existing component usable for the default-sleep model and fixes the bug that made it unsafe for debug boxes.

## 1. Birth idle-stop (create-time enablement)

Auto-sleep had the same gap birth-TTL (#523) closed for the delete timer: it needed a separate post-create call (`toggle_auto_sleep`) that doesn't run if the job crashes/cancels. Now `CreateContainer` accepts an optional `idle_stop_minutes`; the daemon enables auto-sleep **at create** with that threshold (`stampBirthAutoSleep`, the same Incus keys `ToggleAutoSleep` writes). So a box is **born with its stop timer** — a crashed/cancelled job still releases CPU/RAM (disk kept, wakes on access) with nobody calling toggle.

This is the **stop half** of #522's default-sleep→default-dead model; birth TTL (#523) is the delete half.

- proto: `int32 idle_stop_minutes = 21` on `CreateContainerRequest` (regenerated; swagger updated)
- CLI: `containarium create --idle-stop <dur>`; plumbed through the gRPC + HTTP clients; local Incus mode stamps the same keys
- Best-effort (auto-sleep is an optimization, not a leak contract): a failed stamp logs and the box keeps running. **Off by default.**

## 2. Active-session fix (the real bug)

This is #524's unmet acceptance criterion — *"a box running an active session is NOT stopped."* The autosleep idle signal used `COALESCE(ended_at, started_at)`, so a long-lived **open** connection (an SSH/exec debug session) was counted as last-active at its **start**. A session open *longer than the idle threshold* looked idle → the box was **slept mid-debug** — the exact opposite of the intent (and directly harmful to the #522/#526 failure-keep debug box).

Fix: an open connection (`ended_at IS NULL`) now counts as **active-as-of-now**. The box stays awake while anyone is connected and becomes sleep-eligible only after the session closes — safe because the traffic collector stamps `ended_at` on the conntrack destroy event, so dead connections can't keep a box awake forever.

## Acceptance (from #524)

- A box with idle-stop and no active session is STOPPED within ~threshold; disk intact; wakes on access. ✅ (existing autosleep, now enablable at birth)
- A box running an active session/job is NOT stopped. ✅ (the open-connection fix)
- Off by default → no behavior change. ✅

## Tests

- `TestStampBirthAutoSleep_EnablesWithThreshold` — create-time stamp writes enable + threshold keys.
- `idle_test.go` — pins the open-connection-as-now SQL (regression guard against the `started_at` form), the time/zero mapping, and the nil-receiver contract.
- proto regenerated; full unit suite green (`go test -short ./...`).

## Not done (separate issue)

`#525` (two-phase reaping: distinct idle→stop and stopped→delete timers) — this PR keeps the failure path's bounded delete-TTL; layering a *post-stop* delete timer on auto-slept boxes is #525's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)