### PR TITLE
feat(ttlsweeper): two-phase reaping — stopped→delete timer (#525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Birth idle-stop — `containarium create --idle-stop <dur>`** — a box can be born with its auto-sleep (idle→stop) timer, not just its delete timer. `CreateContainer` accepts an optional `idle_stop_minutes`; the daemon enables auto-sleep at create with that idle threshold (same persistence as `toggle_auto_sleep`), so a crashed/cancelled job still releases CPU/RAM (disk kept, wakes on access) — no separate `toggle_auto_sleep` call to forget. The stop half of the default-sleep→default-dead model (birth TTL #523 is the delete half). Off by default. (#524)
+- **Two-phase reaping — `containarium create --delete-after-stopped <dur>`** — completes the lifecycle's second timer: a box left STOPPED past this window is auto-deleted (disk reclaim) after idle-stop already reclaimed CPU/RAM. The clock runs from the stop transition and RESETS when the box is woken, so a box you keep investigating is never reaped — only one left continuously stopped is. A **separate opt-in** from idle-stop/auto-sleep: a scale-to-zero box that merely sleeps is never deleted just for being stopped. `ttlsweeper.Decide` now deletes on either the absolute TTL (#523) or the stopped→delete window (#525); the daemon stamps `stopped_at` on stop and clears it on start. Off by default. (#525)
 
 ### Fixed
 

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -6095,6 +6095,11 @@
           "type": "integer",
           "format": "int32",
           "description": "Birth idle-stop (optional) — minutes of inactivity after which the box\nis auto-STOPPED (freeing CPU/RAM, keeping disk; wakes on next access).\nWhen \u003e 0, the daemon enables auto-sleep at create time with this idle\nthreshold (same persistence as ToggleAutoSleep), so the box is born\nwith the stop timer too — no separate `toggle_auto_sleep` call to\nforget (#524, the stop half of #522's default-sleep→default-dead\nmodel; ttl_seconds is the delete half). 0 = no auto-sleep (today's\nbehavior). The auto-sleep loop treats an open SSH/exec session as\nactive, so an actively-debugged box is never stopped mid-session."
+        },
+        "deleteAfterStoppedSeconds": {
+          "type": "string",
+          "format": "int64",
+          "description": "Birth stopped→delete (optional) — seconds the box may remain STOPPED\nbefore it is auto-deleted, reclaiming disk after idle_stop_minutes\nalready reclaimed CPU/RAM (#525, the second timer of #522's two-phase\nlifecycle). The clock runs from the stop transition and RESETS when the\nbox is woken (accessed), so a box someone keeps investigating is never\nreaped; only one left continuously stopped past this window is. This is\na SEPARATE opt-in from idle_stop_minutes / auto-sleep: a scale-to-zero\nbox that merely sleeps must never be deleted just for being stopped.\n0 = never delete on stop (today's behavior)."
         }
       },
       "title": "CreateContainerRequest is the request to create a new container"

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -153,7 +153,7 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 }
 
 // CreateContainer creates a container via gRPC
-func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32) (*incus.ContainerInfo, error) {
+func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute) // Container creation can take time (includes ultra-aggressive retry logic for google_guest_agent)
 	defer cancel()
 
@@ -175,10 +175,11 @@ func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, 
 		BackendId:     backendID,
 		GitSource:     git.Source,
 		GitRef:        git.Ref,
-		GitCredential:   git.Credential,
-		WorkspacePath:   git.WorkspacePath,
-		TtlSeconds:      ttlSeconds,
-		IdleStopMinutes: idleStopMinutes,
+		GitCredential:             git.Credential,
+		WorkspacePath:             git.WorkspacePath,
+		TtlSeconds:                ttlSeconds,
+		IdleStopMinutes:           idleStopMinutes,
+		DeleteAfterStoppedSeconds: deleteAfterStoppedSeconds,
 	}
 
 	resp, err := c.client.CreateContainer(ctx, req)

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -280,7 +280,7 @@ type GitSourceOpts struct {
 	WorkspacePath string // empty defaults to /workspace
 }
 
-func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32) (*incus.ContainerInfo, error) {
+func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
@@ -318,6 +318,10 @@ func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, 
 	// auto-sleep, so a plain create's body is unchanged.
 	if idleStopMinutes > 0 {
 		reqBody["idleStopMinutes"] = idleStopMinutes
+	}
+	// Birth stopped→delete (#525): same posture.
+	if deleteAfterStoppedSeconds > 0 {
+		reqBody["deleteAfterStoppedSeconds"] = deleteAfterStoppedSeconds
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/containers", reqBody)

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -40,6 +40,7 @@ var (
 	createWorkspacePath      string
 	createTTL                string
 	createIdleStop           string
+	createDeleteAfterStopped string
 )
 
 var createCmd = &cobra.Command{
@@ -122,6 +123,7 @@ func init() {
 	createCmd.Flags().StringVar(&createWorkspacePath, "workspace-path", "", "Where --git-source lands inside the box. Empty defaults to /workspace.")
 	createCmd.Flags().StringVar(&createTTL, "ttl", "", "Birth TTL — auto-delete the box this long after creation (Go duration: '30m', '1h', '24h'; max 168h/7 days). The death date is stamped atomically at create, so the box is reaped even if the client dies right after — no separate 'ttl set' needed (#523). Empty = no TTL.")
 	createCmd.Flags().StringVar(&createIdleStop, "idle-stop", "", "Birth idle-stop — auto-STOP the box (free CPU/RAM, keep disk; wakes on access) after this long with no activity (Go duration: '20m', '1h'). Enables auto-sleep atomically at create, so a crashed/cancelled job still releases compute — no separate 'toggle_auto_sleep' needed (#524). An active SSH/exec session counts as activity, so a box being debugged is never stopped mid-session. Empty = no auto-sleep.")
+	createCmd.Flags().StringVar(&createDeleteAfterStopped, "delete-after-stopped", "", "Birth stopped→delete — auto-DELETE the box (reclaim disk) once it has been STOPPED this long (Go duration: '6h', '24h'). The second timer of the two-phase lifecycle: pair with --idle-stop to free CPU/RAM fast, then disk after a debug window (#525). The clock resets when the box is woken, so a box you keep investigating is never reaped. Separate opt-in from --idle-stop. Empty = never delete on stop.")
 }
 
 // validateSSHKeyMode enforces "exactly one of --ssh-key / --no-ssh-key".
@@ -181,6 +183,20 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Birth stopped→delete (#525): parse the optional --delete-after-stopped
+	// into seconds (the wire/config unit).
+	var deleteAfterStoppedSeconds int64
+	if createDeleteAfterStopped != "" {
+		d, err := time.ParseDuration(createDeleteAfterStopped)
+		if err != nil {
+			return fmt.Errorf("invalid --delete-after-stopped %q: %w (expected Go duration like '6h', '24h')", createDeleteAfterStopped, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("--delete-after-stopped must be positive, got %s", createDeleteAfterStopped)
+		}
+		deleteAfterStoppedSeconds = int64(d.Seconds())
+	}
+
 	fmt.Printf("Creating container for user: %s\n", username)
 	if verbose {
 		fmt.Printf("  CPU: %s\n", cpuLimit)
@@ -204,6 +220,9 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		}
 		if idleStopMinutes > 0 {
 			fmt.Printf("  Idle-stop: %dm (auto-sleep when idle)\n", idleStopMinutes)
+		}
+		if deleteAfterStoppedSeconds > 0 {
+			fmt.Printf("  Delete-after-stopped: %s (reclaim disk once stopped)\n", createDeleteAfterStopped)
 		}
 		if len(parsedLabels) > 0 {
 			fmt.Printf("  Labels:\n")
@@ -368,13 +387,13 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if httpMode && serverAddr != "" {
 		// Remote mode via HTTP
-		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes)
+		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
 		if err != nil {
 			return fmt.Errorf("failed to create container via HTTP API: %w", err)
 		}
 	} else if serverAddr != "" {
 		// Remote mode via gRPC
-		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes)
+		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
 		if err != nil {
 			return fmt.Errorf("failed to create container via remote server: %w", err)
 		}
@@ -383,7 +402,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		if verbose {
 			fmt.Println("Creating container...")
 		}
-		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevice, osType, monitoring, gitOpts, ttlSeconds, idleStopMinutes)
+		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevice, osType, monitoring, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
 		if err != nil {
 			// Cleanup jump server account on failure
 			_ = container.DeleteJumpServerAccount(username, false)
@@ -525,7 +544,7 @@ func resolveGitSourceOpts() (client.GitSourceOpts, error) {
 }
 
 // createLocal creates a container using local Incus daemon
-func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32) (*incus.ContainerInfo, error) {
+func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
 	mgr, err := container.New()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
@@ -586,6 +605,14 @@ func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []
 		}
 	}
 
+	// Birth stopped→delete (#525), local path. Best-effort, same as the
+	// server path — persist the window; the clock starts when the box stops.
+	if deleteAfterStoppedSeconds > 0 {
+		if serr := mgr.SetConfig(info.Name, incus.DeleteAfterStoppedSecondsKey, fmt.Sprintf("%d", deleteAfterStoppedSeconds)); serr != nil {
+			fmt.Printf("warning: failed to set birth stopped→delete on %s: %v (continuing; box has no stopped→delete)\n", info.Name, serr)
+		}
+	}
+
 	return info, nil
 }
 
@@ -606,23 +633,23 @@ func parseLabels(labelSlice []string) map[string]string {
 }
 
 // createRemote creates a container using remote gRPC server
-func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32) (*incus.ContainerInfo, error) {
+func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
 	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
 		return nil, err
 	}
 	defer grpcClient.Close()
 
-	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes)
+	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
 }
 
 // createRemoteHTTP creates a container using remote HTTP API
-func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32) (*incus.ContainerInfo, error) {
+func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
 	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
 	if err != nil {
 		return nil, err
 	}
 	defer httpClient.Close()
 
-	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes)
+	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
 }

--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -383,6 +383,7 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 				client.GitSourceOpts{}, // no git-source for runner boxes
 				0,                      // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
 				0,                      // idle-stop: runner boxes are long-lived; not auto-slept
+				0,                      // delete-after-stopped: not applicable to runner boxes
 			)
 			if err != nil {
 				return "", "", err
@@ -419,6 +420,7 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 			client.GitSourceOpts{}, // no git-source for runner boxes
 			0,                      // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
 			0,                      // idle-stop: runner boxes are long-lived; not auto-slept
+			0,                      // delete-after-stopped: not applicable to runner boxes
 		)
 		if err != nil {
 			return "", "", err

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -191,6 +191,11 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	if req.IdleStopMinutes < 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "idle_stop_minutes must be >= 0, got %d", req.IdleStopMinutes)
 	}
+	// Birth stopped→delete (#525): same — reject a negative window early.
+	// 0 = never delete on stop; > 0 reaps a box left stopped that long.
+	if req.DeleteAfterStoppedSeconds < 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "delete_after_stopped_seconds must be >= 0, got %d", req.DeleteAfterStoppedSeconds)
+	}
 
 	// Pool resolution — if a pool is requested, either validate that
 	// the explicit backend_id belongs to that pool, or pick any
@@ -404,6 +409,10 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 			if err == nil && info != nil && req.IdleStopMinutes > 0 {
 				s.stampBirthAutoSleep(info.Name, req.IdleStopMinutes)
 			}
+			// Birth stopped→delete (#525), async path. Best-effort like above.
+			if err == nil && info != nil && req.DeleteAfterStoppedSeconds > 0 {
+				s.stampBirthDeleteAfterStopped(info.Name, req.DeleteAfterStoppedSeconds)
+			}
 
 			s.pendingMu.Lock()
 			if pending, exists := s.pendingCreations[req.Username]; exists {
@@ -480,6 +489,15 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	// box keeps running (it can be toggled later), it never fails the create.
 	if req.IdleStopMinutes > 0 {
 		s.stampBirthAutoSleep(info.Name, req.IdleStopMinutes)
+	}
+
+	// Birth stopped→delete (#525): record the window so the ttlsweeper reaps
+	// the box once it's been stopped that long. Best-effort like the other
+	// lifecycle stamps. The clock only starts when the box actually stops
+	// (StopContainer stamps stopped_at), so just persisting the window here
+	// is enough.
+	if req.DeleteAfterStoppedSeconds > 0 {
+		s.stampBirthDeleteAfterStopped(info.Name, req.DeleteAfterStoppedSeconds)
 	}
 
 	// Stamp tenant secrets into the LXC's env (best-effort — a
@@ -915,6 +933,15 @@ func (s *ContainerServer) StartContainer(ctx context.Context, req *pb.StartConta
 		log.Printf("[autosleep] failed to stamp %s on %s: %v (continuing)", incus.LastStartedAtKey, req.Username, err)
 	}
 
+	// Two-phase reaping (#525): the box is running again, so clear stopped_at.
+	// This resets the stopped→delete timer — a box someone keeps waking to
+	// investigate never gets reaped; only a box left continuously stopped past
+	// its window does. Best-effort + idempotent (UnsetConfig of an absent key
+	// is a no-op).
+	if err := s.manager.UnsetConfig(req.Username+"-container", incus.StoppedAtKey); err != nil {
+		log.Printf("[ttl] failed to clear %s on %s: %v (continuing)", incus.StoppedAtKey, req.Username, err)
+	}
+
 	// Re-stamp tenant secrets from the current DB state. Picks up
 	// any rotations that happened while the container was stopped;
 	// existing processes won't see the change (POSIX inherit-at-fork),
@@ -1042,6 +1069,16 @@ func (s *ContainerServer) StopContainer(ctx context.Context, req *pb.StopContain
 	info, err := s.manager.Get(req.Username)
 	if err != nil {
 		return nil, fmt.Errorf("container stopped but failed to get info: %w", err)
+	}
+
+	// Two-phase reaping (#525): record when the box became stopped so the
+	// ttlsweeper's stopped→delete timer runs from here. Best-effort — a failed
+	// stamp just means the stopped→delete clock doesn't start until a later
+	// stop restamps it; it never fails the stop. Only matters for boxes that
+	// opted into delete_after_stopped, but stamping unconditionally keeps the
+	// timestamp honest for any box and costs one config write.
+	if serr := s.manager.SetConfig(info.Name, incus.StoppedAtKey, time.Now().UTC().Format(time.RFC3339)); serr != nil {
+		log.Printf("[ttl] failed to stamp %s on %s: %v (stopped→delete timer not started)", incus.StoppedAtKey, info.Name, serr)
 	}
 
 	s.emitter.EmitContainerStopped(toProtoContainer(info))

--- a/internal/server/container_server_birth_ttl_test.go
+++ b/internal/server/container_server_birth_ttl_test.go
@@ -98,6 +98,25 @@ func TestStampBirthAutoSleep_EnablesWithThreshold(t *testing.T) {
 	}
 }
 
+// TestStampBirthDeleteAfterStopped_PersistsWindow — #525: a create-time
+// stopped→delete window is persisted under the Incus key the two-phase reaper
+// reads, so the box is born with its disk-reclaim timer (the clock starts only
+// when it actually stops).
+func TestStampBirthDeleteAfterStopped_PersistsWindow(t *testing.T) {
+	s, calls, _ := newTTLTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Running"},
+	})
+	s.stampBirthDeleteAfterStopped("alice-container", 21600) // 6h
+
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 SetConfig call, got %d: %+v", len(*calls), *calls)
+	}
+	c := (*calls)[0]
+	if c.key != incus.DeleteAfterStoppedSecondsKey || c.value != "21600" {
+		t.Errorf("call = %+v, want %s=21600", c, incus.DeleteAfterStoppedSecondsKey)
+	}
+}
+
 // TestValidateTTLSeconds — the bound shared by create and set. Zero is valid
 // (no TTL / clear); negative and over-cap are rejected; the 7-day boundary is
 // inclusive. Keeps the two entry points rejecting identical input identically.

--- a/internal/server/container_server_ttl.go
+++ b/internal/server/container_server_ttl.go
@@ -152,6 +152,22 @@ func (s *ContainerServer) stampBirthAutoSleep(containerName string, idleMinutes 
 	log.Printf("[autosleep] birth auto-sleep enabled container=%s idle_threshold=%dm", containerName, idleMinutes)
 }
 
+// stampBirthDeleteAfterStopped persists the per-box stopped→delete window
+// (#525) at create, so the ttlsweeper reaps the box once it's been STOPPED
+// that long (the disk-reclaim half of #522's two-phase lifecycle; idle→stop
+// is the CPU/RAM half). Best-effort: a failed stamp logs and the box keeps
+// today's behavior (never reaped on stop). The clock only starts when the box
+// actually stops (StopContainer stamps stopped_at), so persisting the window
+// here is all create needs to do. seconds must be > 0 (0 = no stopped→delete,
+// never reaches here).
+func (s *ContainerServer) stampBirthDeleteAfterStopped(containerName string, seconds int64) {
+	if err := s.manager.SetConfig(containerName, incus.DeleteAfterStoppedSecondsKey, strconv.FormatInt(seconds, 10)); err != nil {
+		log.Printf("[ttl] failed to set birth %s on %s: %v (continuing; box has no stopped→delete)", incus.DeleteAfterStoppedSecondsKey, containerName, err)
+		return
+	}
+	log.Printf("[ttl] birth stopped→delete set container=%s delete_after_stopped=%ds", containerName, seconds)
+}
+
 // stampTTL writes now()+duration as a UTC RFC3339 wall-clock expiry onto the
 // container's Incus config under user.containarium.ttl_expires_at — the exact
 // key + format the ttlsweeper reads, so create and set agree byte-for-byte.

--- a/internal/server/ttlsweeper_adapter.go
+++ b/internal/server/ttlsweeper_adapter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
+	"time"
 
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/ttlsweeper"
@@ -50,6 +52,18 @@ func (a *ttlsweeperIncusAdapter) ListContainers() ([]ttlsweeper.ContainerView, e
 		if !c.TTLExpiresAt.IsZero() {
 			t := c.TTLExpiresAt
 			v.TTLExpiresAt = &t
+		}
+		// Stopped→delete inputs (#525). Only a genuinely STOPPED box with a
+		// recorded stop time and an opted-in window is eligible; everything
+		// else leaves these nil/false and Decide skips the stopped rule.
+		v.Stopped = strings.EqualFold(c.State, "Stopped")
+		if !c.StoppedAt.IsZero() {
+			s := c.StoppedAt
+			v.StoppedAt = &s
+		}
+		if c.DeleteAfterStoppedSeconds > 0 {
+			d := time.Duration(c.DeleteAfterStoppedSeconds) * time.Second
+			v.DeleteAfterStopped = &d
 		}
 		out = append(out, v)
 	}

--- a/internal/ttlsweeper/sweeper.go
+++ b/internal/ttlsweeper/sweeper.go
@@ -20,6 +20,22 @@ type ContainerView struct {
 	// "unset" from "set to the zero time" — important because Decide
 	// must treat unset as "skip" rather than "delete immediately".
 	TTLExpiresAt *time.Time
+
+	// Stopped is true when the container is in the STOPPED state. Only a
+	// stopped box is eligible for the stopped→delete timer (#525); a running
+	// box is reaped only by the absolute TTLExpiresAt above.
+	Stopped bool
+
+	// StoppedAt is when the box most recently became STOPPED (cleared on
+	// start, so a woken box resets the clock). nil = not known to be stopped.
+	// The stopped→delete timer runs from here.
+	StoppedAt *time.Time
+
+	// DeleteAfterStopped is the per-box stopped→delete window (#525). nil =
+	// the box never opted into stopped→delete (the safe default — a
+	// scale-to-zero box that merely sleeps is never reaped for being
+	// stopped). Set + Stopped + StoppedAt+window elapsed → delete.
+	DeleteAfterStopped *time.Duration
 }
 
 // graceMargin is subtracted from the comparison clock before checking
@@ -32,31 +48,42 @@ type ContainerView struct {
 // the same value shows up in tests and operator-facing docs.
 const graceMargin = 30 * time.Second
 
-// Decide returns the names of containers whose TTL has elapsed
+// Decide returns the names of containers that should be deleted now
 // (accounting for graceMargin). Pure function — no IO, no clock, no
 // locks. Safe to call from a goroutine; safe to call repeatedly with
 // the same inputs (idempotent, deterministic).
 //
-// Rules:
-//   - TTLExpiresAt == nil → skip (no TTL set).
-//   - TTLExpiresAt.After(now - graceMargin) → skip (not yet expired).
-//   - Otherwise → include in the returned slice.
+// A container is deleted if EITHER timer has elapsed:
 //
-// The "at or before" comparison (`.After()` returning false on equal)
-// means a TTL exactly at now-graceMargin is treated as expired, which
-// matches an operator's intuition for "TTL of 0 means delete on the
-// next sweep".
+//   - Absolute TTL (#523): TTLExpiresAt set and at/before now-graceMargin.
+//     Fires regardless of running/stopped — the box's hard death date.
+//   - Stopped→delete (#525): the box is Stopped, has a StoppedAt, opted into
+//     a DeleteAfterStopped window, and StoppedAt+window is at/before
+//     now-graceMargin. This is the disk-reclaim half of the two-phase
+//     lifecycle: idle→stop (#524, autosleep) frees CPU/RAM, then a box left
+//     stopped past its window is deleted to free disk. Waking the box clears
+//     StoppedAt (→ nil here), which resets this timer.
+//
+// Unset/missing fields skip the corresponding rule, so a box with neither a
+// TTL nor a stopped→delete window is never reaped. A name matching both rules
+// is returned once (the two rules share the append-and-continue).
 func Decide(containers []ContainerView, now time.Time) []string {
 	cutoff := now.Add(-graceMargin)
 	var expired []string
 	for _, c := range containers {
-		if c.TTLExpiresAt == nil {
+		// Absolute TTL.
+		if c.TTLExpiresAt != nil && !c.TTLExpiresAt.After(cutoff) {
+			expired = append(expired, c.Name)
 			continue
 		}
-		if c.TTLExpiresAt.After(cutoff) {
-			continue
+		// Stopped→delete: only for a stopped box that opted in.
+		if c.Stopped && c.StoppedAt != nil && c.DeleteAfterStopped != nil {
+			deadline := c.StoppedAt.Add(*c.DeleteAfterStopped)
+			if !deadline.After(cutoff) {
+				expired = append(expired, c.Name)
+				continue
+			}
 		}
-		expired = append(expired, c.Name)
 	}
 	return expired
 }

--- a/internal/ttlsweeper/sweeper_test.go
+++ b/internal/ttlsweeper/sweeper_test.go
@@ -139,6 +139,92 @@ func TestDecide(t *testing.T) {
 	}
 }
 
+// dur is the *time.Duration analogue of ptr — keeps the stopped→delete
+// table literals readable.
+func dur(d time.Duration) *time.Duration { return &d }
+
+// TestDecide_StoppedDelete covers the #525 stopped→delete timer: a box left
+// STOPPED past its opted-in window is deleted (disk reclaim), but only if it's
+// stopped, has a stop timestamp, and opted in. Idle→stop lives in autosleep,
+// so a RUNNING idle box is never returned here.
+func TestDecide_StoppedDelete(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	window := time.Hour
+
+	tests := []struct {
+		name       string
+		containers []ContainerView
+		want       []string
+	}{
+		{
+			name: "running box is never stopped→deleted (idle→stop is autosleep's job)",
+			containers: []ContainerView{
+				// Stopped=false even though it has a window + an old StoppedAt.
+				{Name: "running", Stopped: false, StoppedAt: ptr(now.Add(-24 * time.Hour)), DeleteAfterStopped: dur(window)},
+			},
+			want: nil,
+		},
+		{
+			name: "stopped but young (within window) is kept",
+			containers: []ContainerView{
+				{Name: "young", Stopped: true, StoppedAt: ptr(now.Add(-30 * time.Minute)), DeleteAfterStopped: dur(window)},
+			},
+			want: nil,
+		},
+		{
+			name: "stopped past the window is deleted",
+			containers: []ContainerView{
+				{Name: "old", Stopped: true, StoppedAt: ptr(now.Add(-2 * time.Hour)), DeleteAfterStopped: dur(window)},
+			},
+			want: []string{"old"},
+		},
+		{
+			name: "stopped but never opted in (nil window) is kept — scale-to-zero safety",
+			containers: []ContainerView{
+				{Name: "sleeper", Stopped: true, StoppedAt: ptr(now.Add(-24 * time.Hour)), DeleteAfterStopped: nil},
+			},
+			want: nil,
+		},
+		{
+			name: "woken box has no StoppedAt (cleared on start) → timer reset, kept",
+			containers: []ContainerView{
+				{Name: "woken", Stopped: false, StoppedAt: nil, DeleteAfterStopped: dur(window)},
+			},
+			want: nil,
+		},
+		{
+			name: "stopped exactly at cutoff (StoppedAt+window == now-grace) is deleted",
+			containers: []ContainerView{
+				{Name: "edge", Stopped: true, StoppedAt: ptr(now.Add(-window - graceMargin)), DeleteAfterStopped: dur(window)},
+			},
+			want: []string{"edge"},
+		},
+		{
+			name: "absolute TTL still fires independently of stopped→delete",
+			containers: []ContainerView{
+				// Running, no stopped→delete, but an expired absolute TTL.
+				{Name: "ttl-expired", TTLExpiresAt: ptr(now.Add(-time.Hour))},
+				// Stopped past window AND would also be TTL'd — returned once.
+				{Name: "both", TTLExpiresAt: ptr(now.Add(-time.Hour)), Stopped: true, StoppedAt: ptr(now.Add(-2 * time.Hour)), DeleteAfterStopped: dur(window)},
+			},
+			want: []string{"ttl-expired", "both"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Decide(tc.containers, now)
+			gotSorted := append([]string(nil), got...)
+			wantSorted := append([]string(nil), tc.want...)
+			sort.Strings(gotSorted)
+			sort.Strings(wantSorted)
+			if !reflect.DeepEqual(gotSorted, wantSorted) {
+				t.Errorf("Decide returned %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestDecide_PureFunction locks in the "no side effects, no input
 // mutation" contract. Decide is called from a tick loop that holds
 // no locks on the input slice — silently rewriting an element would

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -310,6 +310,18 @@ type ContainerInfo struct {
 	// restart, no extra store needed); see internal/ttlsweeper for the
 	// sweep side and server.SetContainerTTL for the writer side.
 	TTLExpiresAt time.Time
+
+	// StoppedAt mirrors user.containarium.stopped_at — when the box most
+	// recently became STOPPED (cleared on start). Zero when running or
+	// unknown. The two-phase reaper measures the stopped→delete window from
+	// here (#525).
+	StoppedAt time.Time
+
+	// DeleteAfterStoppedSeconds mirrors
+	// user.containarium.delete_after_stopped_seconds — the per-box
+	// stopped→delete window (#525). 0 = never delete on stop. Independent of
+	// auto-sleep so a scale-to-zero box that merely sleeps is never reaped.
+	DeleteAfterStoppedSeconds int64
 }
 
 // AutoSleepEnabledKey is the Incus config key storing the per-container
@@ -333,9 +345,57 @@ const LastStartedAtKey = "user.containarium.last_started_at"
 // daemon restart with no extra plumbing.
 const TTLExpiresAtKey = "user.containarium.ttl_expires_at"
 
+// StoppedAtKey is the Incus config key storing the RFC3339 timestamp at
+// which the container most recently transitioned to STOPPED. Written by
+// StopContainer and cleared by StartContainer, so it measures how long a
+// box has been continuously stopped — the clock the two-phase reaper's
+// stopped→delete timer runs against (#525). Waking the box (start) clears
+// it, which resets that timer.
+const StoppedAtKey = "user.containarium.stopped_at"
+
+// DeleteAfterStoppedSecondsKey is the Incus config key storing the
+// per-container stopped→delete window in seconds (#525). When set (> 0) and
+// the box has been STOPPED for longer than this, the ttlsweeper deletes it —
+// reclaiming disk after the idle→stop step (#524) already reclaimed CPU/RAM.
+// This is a SEPARATE opt-in from auto_sleep_enabled: a scale-to-zero box that
+// merely sleeps must never be deleted just for being stopped; only a box that
+// explicitly asked for stopped→delete gets reaped. Absent/0 = never delete on
+// stop (today's behavior).
+const DeleteAfterStoppedSecondsKey = "user.containarium.delete_after_stopped_seconds"
+
 // DefaultIdleThresholdMinutes is the fallback used when the threshold
 // config key is missing or unparseable.
 const DefaultIdleThresholdMinutes = 15
+
+// parseStoppedAt reads the stopped-at timestamp from an Incus config map.
+// Missing/unparseable → zero time ("not known to be stopped"), so a corrupt
+// key never trips a false-positive delete.
+func parseStoppedAt(cfg map[string]string) time.Time {
+	raw, ok := cfg[StoppedAtKey]
+	if !ok || raw == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// parseDeleteAfterStoppedSeconds reads the stopped→delete window. Missing,
+// unparseable, or <= 0 → 0, which the reaper treats as "no stopped→delete"
+// (the safe default — never reap a stopped box unless it opted in).
+func parseDeleteAfterStoppedSeconds(cfg map[string]string) int64 {
+	raw, ok := cfg[DeleteAfterStoppedSecondsKey]
+	if !ok || raw == "" {
+		return 0
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
 
 // parseIdleThresholdMinutes reads the threshold key from an Incus
 // config map, falling back to the default for empty/garbage values.
@@ -654,9 +714,11 @@ func (c *Client) ListContainers() ([]ContainerInfo, error) {
 			Tenant:               inst.Config[TenantLabelKey],
 			MonitoringEnabled:    inst.Config["environment.OTEL_EXPORTER_OTLP_ENDPOINT"] != "",
 			AutoSleepEnabled:     inst.Config[AutoSleepEnabledKey] == "true",
-			IdleThresholdMinutes: parseIdleThresholdMinutes(inst.Config),
-			LastStartedAt:        parseLastStartedAt(inst.Config),
-			TTLExpiresAt:         parseTTLExpiresAt(inst.Config),
+			IdleThresholdMinutes:      parseIdleThresholdMinutes(inst.Config),
+			LastStartedAt:             parseLastStartedAt(inst.Config),
+			TTLExpiresAt:              parseTTLExpiresAt(inst.Config),
+			StoppedAt:                 parseStoppedAt(inst.Config),
+			DeleteAfterStoppedSeconds: parseDeleteAfterStoppedSeconds(inst.Config),
 		}
 
 		// Get CPU and memory limits from config

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -821,8 +821,18 @@ type CreateContainerRequest struct {
 	// behavior). The auto-sleep loop treats an open SSH/exec session as
 	// active, so an actively-debugged box is never stopped mid-session.
 	IdleStopMinutes int32 `protobuf:"varint,21,opt,name=idle_stop_minutes,json=idleStopMinutes,proto3" json:"idle_stop_minutes,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Birth stopped→delete (optional) — seconds the box may remain STOPPED
+	// before it is auto-deleted, reclaiming disk after idle_stop_minutes
+	// already reclaimed CPU/RAM (#525, the second timer of #522's two-phase
+	// lifecycle). The clock runs from the stop transition and RESETS when the
+	// box is woken (accessed), so a box someone keeps investigating is never
+	// reaped; only one left continuously stopped past this window is. This is
+	// a SEPARATE opt-in from idle_stop_minutes / auto-sleep: a scale-to-zero
+	// box that merely sleeps must never be deleted just for being stopped.
+	// 0 = never delete on stop (today's behavior).
+	DeleteAfterStoppedSeconds int64 `protobuf:"varint,22,opt,name=delete_after_stopped_seconds,json=deleteAfterStoppedSeconds,proto3" json:"delete_after_stopped_seconds,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
 }
 
 func (x *CreateContainerRequest) Reset() {
@@ -998,6 +1008,13 @@ func (x *CreateContainerRequest) GetTtlSeconds() int64 {
 func (x *CreateContainerRequest) GetIdleStopMinutes() int32 {
 	if x != nil {
 		return x.IdleStopMinutes
+	}
+	return 0
+}
+
+func (x *CreateContainerRequest) GetDeleteAfterStoppedSeconds() int64 {
+	if x != nil {
+		return x.DeleteAfterStoppedSeconds
 	}
 	return 0
 }
@@ -4079,7 +4096,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x10disk_usage_bytes\x18\x05 \x01(\x03R\x0ediskUsageBytes\x12(\n" +
 	"\x10network_rx_bytes\x18\x06 \x01(\x03R\x0enetworkRxBytes\x12(\n" +
 	"\x10network_tx_bytes\x18\a \x01(\x03R\x0enetworkTxBytes\x12#\n" +
-	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\xb1\a\n" +
+	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\xf2\a\n" +
 	"\x16CreateContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12=\n" +
 	"\tresources\x18\x02 \x01(\v2\x1f.containarium.v1.ResourceLimitsR\tresources\x12\x19\n" +
@@ -4107,7 +4124,8 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x0eworkspace_path\x18\x13 \x01(\tR\rworkspacePath\x12\x1f\n" +
 	"\vttl_seconds\x18\x14 \x01(\x03R\n" +
 	"ttlSeconds\x12*\n" +
-	"\x11idle_stop_minutes\x18\x15 \x01(\x05R\x0fidleStopMinutes\x1a9\n" +
+	"\x11idle_stop_minutes\x18\x15 \x01(\x05R\x0fidleStopMinutes\x12?\n" +
+	"\x1cdelete_after_stopped_seconds\x18\x16 \x01(\x03R\x19deleteAfterStoppedSeconds\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aB\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -331,6 +331,17 @@ message CreateContainerRequest {
   // behavior). The auto-sleep loop treats an open SSH/exec session as
   // active, so an actively-debugged box is never stopped mid-session.
   int32 idle_stop_minutes = 21;
+
+  // Birth stopped→delete (optional) — seconds the box may remain STOPPED
+  // before it is auto-deleted, reclaiming disk after idle_stop_minutes
+  // already reclaimed CPU/RAM (#525, the second timer of #522's two-phase
+  // lifecycle). The clock runs from the stop transition and RESETS when the
+  // box is woken (accessed), so a box someone keeps investigating is never
+  // reaped; only one left continuously stopped past this window is. This is
+  // a SEPARATE opt-in from idle_stop_minutes / auto-sleep: a scale-to-zero
+  // box that merely sleeps must never be deleted just for being stopped.
+  // 0 = never delete on stop (today's behavior).
+  int64 delete_after_stopped_seconds = 22;
 }
 
 // CreateContainerResponse is the response from creating a container

--- a/test/integration/storage_test.go
+++ b/test/integration/storage_test.go
@@ -105,6 +105,7 @@ func testCreateContainerWithQuota(t *testing.T, ctx context.Context, grpcClient 
 		client.GitSourceOpts{},       // No git provisioning
 		0,                            // No birth TTL
 		0,                            // No idle-stop
+		0,                            // No stopped→delete
 	)
 	require.NoError(t, err, "Failed to create container")
 	require.NotNil(t, container)
@@ -155,6 +156,7 @@ func testQuotaEnforcement(t *testing.T, ctx context.Context, grpcClient *client.
 		client.GitSourceOpts{}, // No git provisioning
 		0,                      // No birth TTL
 		0,                      // No idle-stop
+		0,                      // No stopped→delete
 	)
 	require.NoError(t, err)
 	require.NotNil(t, container)
@@ -191,11 +193,11 @@ func testMultiContainerIsolation(t *testing.T, ctx context.Context, grpcClient *
 	t.Log("Creating multiple containers to test quota isolation...")
 
 	// Create two containers with different quotas
-	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0)
+	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(user1, true)
 
-	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0)
+	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(user2, true)
 
@@ -221,7 +223,7 @@ func testCompression(t *testing.T, ctx context.Context, grpcClient *client.GRPCC
 
 	t.Log("Creating container to test compression...")
 
-	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0)
+	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
 	require.NoError(t, err)
 	defer grpcClient.DeleteContainer(username, true)
 
@@ -244,7 +246,7 @@ func testPrepareRebootData(t *testing.T, ctx context.Context, grpcClient *client
 	t.Logf("Creating container for persistence test: %s", username)
 
 	// Create container
-	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0)
+	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
 	require.NoError(t, err)
 	require.NotNil(t, container)
 


### PR DESCRIPTION
Completes #522 (default-sleep → default-dead).

## The two timers

| Phase | Reclaims | Component |
|---|---|---|
| idle → **stop** | CPU/RAM (keep disk) | autosleep (#524) |
| stopped → **delete** | disk | **this PR (#525)** |

A single absolute TTL (#523) can't express *"stop quickly but keep the disk to investigate, then delete only if left untouched."* #525 adds a second, independent timer measured from the **STOP transition** that **resets on wake** — so a box someone keeps coming back to never dies; only one left continuously stopped past its window does.

## Change

- **`ttlsweeper.Decide`** now returns a box for deletion on **either** the absolute `ttl_expires_at` (#523) **or** a stopped→delete window: `Stopped && stopped_at + delete_after_stopped` elapsed (same 30s grace margin). `ContainerView` gains `Stopped`, `StoppedAt`, `DeleteAfterStopped`; the daemon adapter populates them from Incus config.
- **Stop/start stamping:** `StopContainer` stamps `user.containarium.stopped_at = now`; `StartContainer` clears it (the wake-reset). Both best-effort.
- **Born with the timer:** `CreateContainer` accepts `delete_after_stopped_seconds`, stamped at create; CLI `containarium create --delete-after-stopped <dur>`; plumbed through the gRPC + HTTP clients; local Incus mode stamps the key.

## Safety: a SEPARATE opt-in (this is the important bit)

`delete_after_stopped` is **independent of `idle_stop_minutes` / `auto_sleep_enabled`**. This is deliberate and load-bearing: a **scale-to-zero web-service box that merely sleeps overnight must never be deleted just for being stopped** — that would be silent data loss. Only a box that *explicitly* set `delete_after_stopped` is ever reaped on stop. Off by default.

## Acceptance (from #525)

- A box: idle → stops (short timer, autosleep) → still present + wakeable → deleted at the long timer, zero manual action. ✅
- A box woken before `delete_after` resets the timer (stopped_at cleared on start). ✅
- `Decide` unit tests cover running-idle, stopped-young, stopped-expired, and woken-reset. ✅ (+ no-opt-in scale-to-zero safety, edge-at-cutoff, absolute-TTL-still-fires)

## Tests

`Decide` stopped→delete table; `stampBirthDeleteAfterStopped` persists the key; new incus keys + parsers. proto regenerated. Full unit suite green (`go test -short ./...`); diff scanned clean.

## Epic status

This closes the last sub-issue of #522. Together: #523 (birth TTL) + #524 (birth idle-stop + active-session fix) + #525 (two-phase reaping) + containarium-run #37 (lease/heartbeat) give the full default-sleep→default-dead lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)