### PR TITLE
feat(proto): report stopped_at + delete_after_stopped on Container (#525/#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Container.stopped_at` + `Container.delete_after_stopped_seconds`** — the container read API (`GetContainer`/`ListContainers`) now reports the two-phase reaping status (#525) alongside `ttl_expires_at` and `auto_sleep_enabled`, so a reader sees the *full* lifecycle (where a box is in idle→stop→delete) without host access. Read from the Incus config the daemon stamps; `stopped_at` is omitted while the box runs. Completes the read-side of the box-lifecycle model for the fleet-hygiene view (cloud #264). (#525)
+
 ## [0.24.0] - 2026-06-07
 
 Box lifecycle: the full default-sleep → default-dead model (#522). Every box

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -5840,6 +5840,16 @@
           "type": "string",
           "description": "- direct mode  → the container's reachable IP (same value as\n    network.ip_address);\n  - sentinel-jump mode → the configured sentinel's public host,\n    e.g. \"region-a.example.com\".\n\nCombined with `username`, this is the connect target\n`username@ssh_host`. Empty means \"no explicit host — fall back to\nnetwork.ip_address\". Clients (the ssh_config generator, a future\n`connect` verb) should USE this verbatim rather than reconstructing\na host from the IP / sentinel config themselves.",
           "title": "The host:port a client should SSH to in order to reach this\ncontainer, as computed by the daemon from its own routing config —\nso a client never has to infer the SSH target from other fields:"
+        },
+        "stoppedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Two-phase reaping status (#525), read from the Incus config the daemon\nstamps. Lets a reader see where a box is in the stopped→delete lifecycle\nwithout host access (#264 fleet hygiene) — alongside ttl_expires_at (the\nabsolute death date) and auto_sleep_enabled (idle→stop).\n\nstopped_at: when the box most recently became STOPPED (cleared on start,\nso a woken box has none). The stopped→delete timer runs from here. Unset\nwhen running / never stopped."
+        },
+        "deleteAfterStoppedSeconds": {
+          "type": "string",
+          "format": "int64",
+          "description": "delete_after_stopped_seconds: the box's stopped→delete window. \u003e 0 means\nit auto-deletes once it has been stopped that long (reclaiming disk); 0 =\nnever delete on stop. Opt-in, independent of auto_sleep_enabled."
         }
       },
       "title": "Container represents a complete container instance"

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -2372,6 +2372,13 @@ func toProtoContainer(info *incus.ContainerInfo) *pb.Container {
 	if !info.TTLExpiresAt.IsZero() {
 		pc.TtlExpiresAt = timestamppb.New(info.TTLExpiresAt)
 	}
+	// Two-phase reaping status (#525): stopped_at (cleared on start, so unset
+	// while running) + the stopped→delete window. Read from the Incus config;
+	// surfaced so a reader sees the full lifecycle (#264).
+	if !info.StoppedAt.IsZero() {
+		pc.StoppedAt = timestamppb.New(info.StoppedAt)
+	}
+	pc.DeleteAfterStoppedSeconds = info.DeleteAfterStoppedSeconds
 	return pc
 }
 

--- a/internal/server/container_server_birth_ttl_test.go
+++ b/internal/server/container_server_birth_ttl_test.go
@@ -117,6 +117,36 @@ func TestStampBirthDeleteAfterStopped_PersistsWindow(t *testing.T) {
 	}
 }
 
+// TestToProtoContainer_SurfacesStoppedDeleteStatus — #525/#264: the daemon's
+// container→proto projection surfaces the two-phase reaping status
+// (stopped_at + delete_after_stopped_seconds) read from the Incus config, so a
+// reader sees the full lifecycle without host access. stopped_at is omitted
+// (nil) when the box isn't stopped; the window passes through as-is.
+func TestToProtoContainer_SurfacesStoppedDeleteStatus(t *testing.T) {
+	stoppedAt := time.Now().Add(-15 * time.Minute).UTC().Truncate(time.Second)
+	pc := toProtoContainer(&incus.ContainerInfo{
+		Name:                      "alice-container",
+		State:                     "Stopped",
+		StoppedAt:                 stoppedAt,
+		DeleteAfterStoppedSeconds: 86400,
+	})
+	if pc.GetDeleteAfterStoppedSeconds() != 86400 {
+		t.Errorf("DeleteAfterStoppedSeconds = %d, want 86400", pc.GetDeleteAfterStoppedSeconds())
+	}
+	if pc.GetStoppedAt() == nil || !pc.GetStoppedAt().AsTime().Equal(stoppedAt) {
+		t.Errorf("StoppedAt = %v, want %s", pc.GetStoppedAt(), stoppedAt)
+	}
+
+	// Running box (zero StoppedAt) → no stopped_at on the wire.
+	running := toProtoContainer(&incus.ContainerInfo{Name: "bob-container", State: "Running"})
+	if running.GetStoppedAt() != nil {
+		t.Errorf("running box should have no stopped_at, got %v", running.GetStoppedAt())
+	}
+	if running.GetDeleteAfterStoppedSeconds() != 0 {
+		t.Errorf("unset window should be 0, got %d", running.GetDeleteAfterStoppedSeconds())
+	}
+}
+
 // TestValidateTTLSeconds — the bound shared by create and set. Zero is valid
 // (no TTL / clear); negative and over-cap are rejected; the 7-day boundary is
 // inclusive. Keeps the two entry points rejecting identical input identically.

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -428,9 +428,22 @@ type Container struct {
 	// network.ip_address". Clients (the ssh_config generator, a future
 	// `connect` verb) should USE this verbatim rather than reconstructing
 	// a host from the IP / sentinel config themselves.
-	SshHost       string `protobuf:"bytes,23,opt,name=ssh_host,json=sshHost,proto3" json:"ssh_host,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	SshHost string `protobuf:"bytes,23,opt,name=ssh_host,json=sshHost,proto3" json:"ssh_host,omitempty"`
+	// Two-phase reaping status (#525), read from the Incus config the daemon
+	// stamps. Lets a reader see where a box is in the stopped→delete lifecycle
+	// without host access (#264 fleet hygiene) — alongside ttl_expires_at (the
+	// absolute death date) and auto_sleep_enabled (idle→stop).
+	//
+	// stopped_at: when the box most recently became STOPPED (cleared on start,
+	// so a woken box has none). The stopped→delete timer runs from here. Unset
+	// when running / never stopped.
+	StoppedAt *timestamppb.Timestamp `protobuf:"bytes,24,opt,name=stopped_at,json=stoppedAt,proto3" json:"stopped_at,omitempty"`
+	// delete_after_stopped_seconds: the box's stopped→delete window. > 0 means
+	// it auto-deletes once it has been stopped that long (reclaiming disk); 0 =
+	// never delete on stop. Opt-in, independent of auto_sleep_enabled.
+	DeleteAfterStoppedSeconds int64 `protobuf:"varint,25,opt,name=delete_after_stopped_seconds,json=deleteAfterStoppedSeconds,proto3" json:"delete_after_stopped_seconds,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
 }
 
 func (x *Container) Reset() {
@@ -622,6 +635,20 @@ func (x *Container) GetSshHost() string {
 		return x.SshHost
 	}
 	return ""
+}
+
+func (x *Container) GetStoppedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StoppedAt
+	}
+	return nil
+}
+
+func (x *Container) GetDeleteAfterStoppedSeconds() int64 {
+	if x != nil {
+		return x.DeleteAfterStoppedSeconds
+	}
+	return 0
 }
 
 // ContainerMetrics contains runtime metrics for a container
@@ -4053,7 +4080,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\vmac_address\x18\x02 \x01(\tR\n" +
 	"macAddress\x12\x1c\n" +
 	"\tinterface\x18\x03 \x01(\tR\tinterface\x12\x16\n" +
-	"\x06bridge\x18\x04 \x01(\tR\x06bridge\"\xe3\a\n" +
+	"\x06bridge\x18\x04 \x01(\tR\x06bridge\"\xdf\b\n" +
 	"\tContainer\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x125\n" +
@@ -4084,7 +4111,10 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x12auto_sleep_enabled\x18\x14 \x01(\bR\x10autoSleepEnabled\x124\n" +
 	"\x16idle_threshold_minutes\x18\x15 \x01(\x05R\x14idleThresholdMinutes\x12@\n" +
 	"\x0ettl_expires_at\x18\x16 \x01(\v2\x1a.google.protobuf.TimestampR\fttlExpiresAt\x12\x19\n" +
-	"\bssh_host\x18\x17 \x01(\tR\asshHost\x1a9\n" +
+	"\bssh_host\x18\x17 \x01(\tR\asshHost\x129\n" +
+	"\n" +
+	"stopped_at\x18\x18 \x01(\v2\x1a.google.protobuf.TimestampR\tstoppedAt\x12?\n" +
+	"\x1cdelete_after_stopped_seconds\x18\x19 \x01(\x03R\x19deleteAfterStoppedSeconds\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xcf\x02\n" +
@@ -4436,33 +4466,34 @@ var file_containarium_v1_container_proto_depIdxs = []int32{
 	0,  // 4: containarium.v1.Container.os_type:type_name -> containarium.v1.OSType
 	1,  // 5: containarium.v1.Container.access_type:type_name -> containarium.v1.AccessType
 	60, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
-	3,  // 7: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
-	57, // 8: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
-	0,  // 9: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
-	58, // 10: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
-	5,  // 11: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
-	2,  // 12: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
-	59, // 13: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
-	5,  // 14: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
-	5,  // 15: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
-	6,  // 16: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
-	5,  // 17: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
-	5,  // 18: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
-	60, // 19: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
-	6,  // 20: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
-	5,  // 21: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
-	35, // 22: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
-	35, // 23: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
-	5,  // 24: containarium.v1.CleanupDiskResponse.container:type_name -> containarium.v1.Container
-	5,  // 25: containarium.v1.InstallStackResponse.container:type_name -> containarium.v1.Container
-	46, // 26: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
-	47, // 27: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
-	61, // 28: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
-	29, // [29:29] is the sub-list for method output_type
-	29, // [29:29] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	28, // [28:29] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	60, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
+	3,  // 8: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
+	57, // 9: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
+	0,  // 10: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
+	58, // 11: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
+	5,  // 12: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
+	2,  // 13: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
+	59, // 14: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
+	5,  // 15: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
+	5,  // 16: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
+	6,  // 17: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
+	5,  // 18: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
+	5,  // 19: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
+	60, // 20: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	6,  // 21: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
+	5,  // 22: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
+	35, // 23: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
+	35, // 24: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
+	5,  // 25: containarium.v1.CleanupDiskResponse.container:type_name -> containarium.v1.Container
+	5,  // 26: containarium.v1.InstallStackResponse.container:type_name -> containarium.v1.Container
+	46, // 27: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
+	47, // 28: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
+	61, // 29: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
+	30, // [30:30] is the sub-list for method output_type
+	30, // [30:30] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	29, // [29:30] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_container_proto_init() }

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -195,6 +195,21 @@ message Container {
   // `connect` verb) should USE this verbatim rather than reconstructing
   // a host from the IP / sentinel config themselves.
   string ssh_host = 23;
+
+  // Two-phase reaping status (#525), read from the Incus config the daemon
+  // stamps. Lets a reader see where a box is in the stopped→delete lifecycle
+  // without host access (#264 fleet hygiene) — alongside ttl_expires_at (the
+  // absolute death date) and auto_sleep_enabled (idle→stop).
+  //
+  // stopped_at: when the box most recently became STOPPED (cleared on start,
+  // so a woken box has none). The stopped→delete timer runs from here. Unset
+  // when running / never stopped.
+  google.protobuf.Timestamp stopped_at = 24;
+
+  // delete_after_stopped_seconds: the box's stopped→delete window. > 0 means
+  // it auto-deletes once it has been stopped that long (reclaiming disk); 0 =
+  // never delete on stop. Opt-in, independent of auto_sleep_enabled.
+  int64 delete_after_stopped_seconds = 25;
 }
 
 // ContainerMetrics contains runtime metrics for a container


### PR DESCRIPTION
Completes the **read-side** of the box-lifecycle model. The `Container` read API already reported `ttl_expires_at` (absolute death date) and `auto_sleep_enabled` (idle→stop), but not the **two-phase reaping** status (#525).

## Change

- Adds `stopped_at` (`google.protobuf.Timestamp`, field 24) and `delete_after_stopped_seconds` (`int64`, field 25) to the `Container` message.
- `toProtoContainer` populates them from the Incus config the daemon stamps (`incus.ContainerInfo` already carries them since #525). `stopped_at` is omitted while the box runs (it's cleared on start).

Now `GetContainer` / `ListContainers` report the **full** lifecycle — where a box sits in idle→stop→delete — without host access.

## Why

It's the foundation the cloud **fleet-hygiene** view (#264) consumes: cloud #325 just surfaced `ttl_expires_at` / `auto_sleep_enabled` through the cloud read path but had to skip `stopped_at` / `delete_after_stopped` precisely because they weren't on this response message (only on `CreateContainerRequest`). With this, a future cloud bump can show the complete picture.

## Tests

`toProtoContainer` surfaces both fields (and omits `stopped_at` for a running box; the window passes through as-is). Full unit suite green (`go test -short ./...`); diff scanned clean.

## Note

Reaches the cloud on the next OSS release + cloud dep bump (same path as v0.24.0). Not cutting a release in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)