### PR TITLE
feat(cli): containarium prune — bulk-delete by filter for fleet cleanup (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`containarium prune`** — bulk-delete containers matching a filter, for fleet cleanup (reaping piles of leaked/finished ephemeral boxes one command instead of one-by-one). Filters combine with AND: `--state running|stopped`, `--name-contains`, `--older-than <dur>`, `--label key=value` (repeatable). Safeguards: at least one filter required (no accidental delete-all), core platform containers are never eligible, the matching set is listed before anything happens, and deletion needs confirmation (`--yes` to skip, `--dry-run` to preview). Composes the existing list + delete surface, so it works against the OSS daemon and Containarium Cloud alike. (cloud #264)
 - **`Container.stopped_at` + `Container.delete_after_stopped_seconds`** — the container read API (`GetContainer`/`ListContainers`) now reports the two-phase reaping status (#525) alongside `ttl_expires_at` and `auto_sleep_enabled`, so a reader sees the *full* lifecycle (where a box is in idle→stop→delete) without host access. Read from the Incus config the daemon stamps; `stopped_at` is omitted while the box runs. Completes the read-side of the box-lifecycle model for the fleet-hygiene view (cloud #264). (#525)
+
+### Fixed
+
+- **gRPC `ListContainers` now returns labels** — the gRPC client dropped the `labels` map when converting the response, so label-based filtering (e.g. `containarium prune --label`) saw no labels over gRPC. HTTP already carried them.
 
 ## [0.24.0] - 2026-06-07
 

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -125,6 +125,7 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 			Name:                 container.Name,
 			Username:             container.Username,
 			State:                container.State.String(),
+			Labels:               container.Labels,
 			MonitoringEnabled:    container.MonitoringEnabled,
 			AutoSleepEnabled:     container.AutoSleepEnabled,
 			IdleThresholdMinutes: container.IdleThresholdMinutes,

--- a/internal/cmd/prune.go
+++ b/internal/cmd/prune.go
@@ -1,0 +1,221 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	pruneState        string
+	pruneNameContains string
+	pruneOlderThan    string
+	pruneLabels       []string
+	pruneDryRun       bool
+	pruneYes          bool
+	pruneForce        bool
+)
+
+var pruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Bulk-delete containers matching a filter (fleet cleanup)",
+	Long: `Delete every container matching a filter in one command, instead of
+deleting them one by one.
+
+Built for fleet hygiene: reaping a pile of leaked/finished ephemeral boxes
+(e.g. CI debug boxes that outlived their run). It LISTs containers, narrows by
+the filters you pass, shows exactly which boxes match, and — after you confirm —
+deletes each. Core platform containers are never eligible.
+
+At least one filter is required (refusing to prune everything by accident).
+Filters combine with AND. By default you're prompted to confirm; use --yes to
+skip the prompt (e.g. in scripts) or --dry-run to only preview.
+
+Examples:
+  # Preview which stopped boxes would be deleted (no deletion)
+  containarium prune --state stopped --dry-run
+
+  # Delete all stopped boxes created over an hour ago, after confirming
+  containarium prune --state stopped --older-than 1h
+
+  # Reap all CI boxes by label, no prompt (scripted)
+  containarium prune --label managed_by=ci --yes
+
+  # Delete boxes whose name contains "pr-" older than a day
+  containarium prune --name-contains pr- --older-than 24h --yes`,
+	Args: cobra.NoArgs,
+	RunE: runPrune,
+}
+
+func init() {
+	rootCmd.AddCommand(pruneCmd)
+	pruneCmd.Flags().StringVar(&pruneState, "state", "", "Only containers in this state: running | stopped")
+	pruneCmd.Flags().StringVar(&pruneNameContains, "name-contains", "", "Only containers whose name/username contains this substring")
+	pruneCmd.Flags().StringVar(&pruneOlderThan, "older-than", "", "Only containers created longer ago than this (Go duration: '1h', '24h', '7d' is not valid — use '168h')")
+	pruneCmd.Flags().StringSliceVar(&pruneLabels, "label", nil, "Only containers with this label (key=value); repeatable, all must match")
+	pruneCmd.Flags().BoolVar(&pruneDryRun, "dry-run", false, "Show what would be deleted and exit without deleting")
+	pruneCmd.Flags().BoolVarP(&pruneYes, "yes", "y", false, "Skip the confirmation prompt (delete immediately)")
+	pruneCmd.Flags().BoolVar(&pruneForce, "force", false, "Force-stop running containers before deleting (passed to each delete)")
+}
+
+func runPrune(_ *cobra.Command, _ []string) error {
+	// Require at least one narrowing filter. Without this guard a bare
+	// `prune` would match (and offer to delete) every container — exactly the
+	// foot-gun bulk delete must not have.
+	if pruneState == "" && pruneNameContains == "" && pruneOlderThan == "" && len(pruneLabels) == 0 {
+		return fmt.Errorf("refusing to prune without a filter: pass at least one of --state, --name-contains, --older-than, --label (they combine with AND to narrow the set)")
+	}
+
+	switch pruneState {
+	case "", "running", "stopped":
+	default:
+		return fmt.Errorf("--state must be 'running' or 'stopped', got %q", pruneState)
+	}
+
+	var olderThan time.Duration
+	if pruneOlderThan != "" {
+		d, err := time.ParseDuration(pruneOlderThan)
+		if err != nil {
+			return fmt.Errorf("invalid --older-than %q: %w (expected Go duration like '1h', '24h', '168h')", pruneOlderThan, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("--older-than must be positive, got %s", pruneOlderThan)
+		}
+		olderThan = d
+	}
+
+	labelFilter := parseLabels(pruneLabels)
+
+	containers, err := pruneList()
+	if err != nil {
+		return fmt.Errorf("failed to list containers: %w", err)
+	}
+
+	now := time.Now()
+	matches := filterForPrune(containers, pruneState, pruneNameContains, olderThan, labelFilter, now)
+
+	if len(matches) == 0 {
+		fmt.Println("No containers match the filter — nothing to prune.")
+		return nil
+	}
+
+	fmt.Printf("%d container(s) match:\n", len(matches))
+	for _, c := range matches {
+		fmt.Printf("  - %-24s state=%-8s %s\n", pruneDeleteKey(c), c.State, ageString(now, c.CreatedAt))
+	}
+
+	if pruneDryRun {
+		fmt.Printf("\ndry-run: would delete %d container(s). Re-run without --dry-run to delete.\n", len(matches))
+		return nil
+	}
+
+	if !pruneYes {
+		fmt.Printf("\nDelete these %d container(s)? [y/N]: ", len(matches))
+		reader := bufio.NewReader(os.Stdin)
+		resp, _ := reader.ReadString('\n')
+		if r := strings.TrimSpace(strings.ToLower(resp)); r != "y" && r != "yes" {
+			fmt.Println("Cancelled — nothing deleted.")
+			return nil
+		}
+	}
+
+	var deleted, failed int
+	for _, c := range matches {
+		key := pruneDeleteKey(c)
+		if err := pruneDelete(key, pruneForce); err != nil {
+			fmt.Printf("  ✗ %s: %v\n", key, err)
+			failed++
+			continue
+		}
+		fmt.Printf("  ✓ %s deleted\n", key)
+		deleted++
+	}
+	fmt.Printf("\nPruned %d/%d container(s).\n", deleted, len(matches))
+	if failed > 0 {
+		return fmt.Errorf("%d container(s) failed to delete", failed)
+	}
+	return nil
+}
+
+// filterForPrune is the pure selection logic: which containers match the
+// filters. Core containers are NEVER matched (infrastructure safety). Filters
+// combine with AND. olderThan == 0 / state == "" / nameContains == "" /
+// empty labels each mean "don't filter on that". A box with no CreatedAt is
+// excluded by an olderThan filter (can't prove it's old enough). Pure — no IO,
+// `now` injected — so it's unit-tested directly.
+func filterForPrune(containers []incus.ContainerInfo, state, nameContains string, olderThan time.Duration, labels map[string]string, now time.Time) []incus.ContainerInfo {
+	var matches []incus.ContainerInfo
+	for _, c := range containers {
+		if c.Role.IsCoreRole() {
+			continue
+		}
+		if state == "running" && !strings.EqualFold(c.State, "Running") {
+			continue
+		}
+		if state == "stopped" && !strings.EqualFold(c.State, "Stopped") {
+			continue
+		}
+		if nameContains != "" &&
+			!strings.Contains(c.Name, nameContains) &&
+			!strings.Contains(c.Username, nameContains) {
+			continue
+		}
+		if olderThan > 0 {
+			if c.CreatedAt.IsZero() || now.Sub(c.CreatedAt) < olderThan {
+				continue
+			}
+		}
+		if len(labels) > 0 && !incus.MatchLabels(c.Labels, labels) {
+			continue
+		}
+		matches = append(matches, c)
+	}
+	return matches
+}
+
+// pruneDeleteKey is the identifier delete is addressed by: the container's
+// Username (the cloud-assigned cld-<id> on a cloud backend, or the bare
+// username on an OSS daemon) — NOT the friendly name. Falls back to the
+// name with the "-container" suffix stripped when Username is empty.
+func pruneDeleteKey(c incus.ContainerInfo) string {
+	if c.Username != "" {
+		return c.Username
+	}
+	return strings.TrimSuffix(c.Name, "-container")
+}
+
+// ageString renders how long ago the box was created, for the preview list.
+func ageString(now, created time.Time) string {
+	if created.IsZero() {
+		return "age=unknown"
+	}
+	return fmt.Sprintf("age=%s", now.Sub(created).Round(time.Minute))
+}
+
+// pruneList / pruneDelete reuse the exact gRPC / HTTP / local dispatch the
+// list and delete commands use, so prune is purely a filter+loop over the
+// existing per-container surface — no new server endpoint.
+func pruneList() ([]incus.ContainerInfo, error) {
+	if httpMode && serverAddr != "" {
+		return listRemoteHTTP()
+	}
+	if serverAddr != "" {
+		return listRemote()
+	}
+	return listLocal()
+}
+
+func pruneDelete(username string, force bool) error {
+	if httpMode && serverAddr != "" {
+		return deleteRemoteHTTP(username, force)
+	}
+	if serverAddr != "" {
+		return deleteRemote(username, force)
+	}
+	return deleteLocal(username, force)
+}

--- a/internal/cmd/prune_test.go
+++ b/internal/cmd/prune_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+func names(cs []incus.ContainerInfo) []string {
+	out := make([]string, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, c.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestFilterForPrune covers the selection logic that decides which containers
+// a `prune` would delete — the safety-critical part of bulk delete.
+func TestFilterForPrune(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	fleet := []incus.ContainerInfo{
+		{Name: "core-pg", Role: incus.RolePostgres, State: "Running", CreatedAt: now.Add(-72 * time.Hour)},
+		{Name: "run-old", State: "Running", CreatedAt: now.Add(-2 * time.Hour), Labels: map[string]string{"managed_by": "ci"}},
+		{Name: "run-new", State: "Running", CreatedAt: now.Add(-10 * time.Minute)},
+		{Name: "stop-old", State: "Stopped", CreatedAt: now.Add(-3 * time.Hour)},
+		{Name: "stop-new", State: "Stopped", CreatedAt: now.Add(-5 * time.Minute)},
+		{Name: "pr-42-box", State: "Running", CreatedAt: now.Add(-26 * time.Hour)},
+		{Name: "no-age", State: "Stopped"}, // CreatedAt zero
+	}
+
+	cases := []struct {
+		name         string
+		state        string
+		nameContains string
+		olderThan    time.Duration
+		labels       map[string]string
+		want         []string
+	}{
+		{
+			name:  "core is never matched (state=running)",
+			state: "running",
+			want:  []string{"pr-42-box", "run-new", "run-old"}, // core-pg excluded
+		},
+		{
+			name:  "stopped only",
+			state: "stopped",
+			want:  []string{"no-age", "stop-new", "stop-old"},
+		},
+		{
+			name:      "stopped + older-than 1h",
+			state:     "stopped",
+			olderThan: time.Hour,
+			want:      []string{"stop-old"}, // stop-new too young; no-age has no CreatedAt → excluded
+		},
+		{
+			// Every non-core box created >1h ago; no-age (zero CreatedAt) is
+			// excluded because we can't prove its age.
+			name:      "older-than 1h, no other filter",
+			olderThan: time.Hour,
+			want:      []string{"pr-42-box", "run-old", "stop-old"},
+		},
+		{
+			name:         "name-contains",
+			nameContains: "pr-",
+			want:         []string{"pr-42-box"},
+		},
+		{
+			name:   "label filter",
+			labels: map[string]string{"managed_by": "ci"},
+			want:   []string{"run-old"},
+		},
+		{
+			name: "no filters matches all non-core",
+			want: []string{"no-age", "pr-42-box", "run-new", "run-old", "stop-new", "stop-old"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := names(filterForPrune(fleet, tc.state, tc.nameContains, tc.olderThan, tc.labels, now))
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
+			if len(got) != len(want) {
+				t.Fatalf("got %v, want %v", got, want)
+			}
+			for i := range got {
+				if got[i] != want[i] {
+					t.Fatalf("got %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestPruneDeleteKey: delete is addressed by Username (the cld-<id> on cloud /
+// bare user on OSS), falling back to the name minus "-container".
+func TestPruneDeleteKey(t *testing.T) {
+	if got := pruneDeleteKey(incus.ContainerInfo{Name: "alice-container", Username: "cld-abc123"}); got != "cld-abc123" {
+		t.Errorf("got %q, want cld-abc123 (Username preferred)", got)
+	}
+	if got := pruneDeleteKey(incus.ContainerInfo{Name: "alice-container"}); got != "alice" {
+		t.Errorf("got %q, want alice (name fallback)", got)
+	}
+}


### PR DESCRIPTION
The unblocked, backend half of cloud #264 (fleet management): **bulk delete**. Reaping leaked/finished ephemeral boxes was one-by-one — the operator pain that motivated #264. `containarium prune` does it in one command.

## What it does

`list → filter → show matches → confirm → delete each`. Filters combine with **AND**:
- `--state running|stopped`
- `--name-contains <substr>`
- `--older-than <dur>` (by created-at; Go duration)
- `--label key=value` (repeatable)

```bash
containarium prune --state stopped --older-than 1h --dry-run   # preview
containarium prune --label managed_by=ci --yes                 # scripted reap
```

## Safeguards (the #264-B asks)

- **At least one filter required** — a bare `prune` is refused, so you can't delete every box by accident.
- **Core platform containers are never eligible** (`Role.IsCoreRole`) — deleting Postgres/Caddy would break the host.
- **The matching set is listed** before anything happens (name, state, age).
- **Confirmation required** — interactive `[y/N]`; `--yes` to skip (scripts), `--dry-run` to only preview.

## Design

CLI-first per CLAUDE.md, and purely **composes the existing `list` + `delete` surface** — no new server endpoint — reusing the same gRPC/HTTP/local dispatch, so it works against the OSS daemon **and** Containarium Cloud. Deletes by the canonical `Username` (`cld-<id>` on cloud / bare user on OSS), falling back to the name minus `-container`.

Also **fixes** gRPC `ListContainers` dropping the `labels` map (HTTP already carried it), so `--label` works over gRPC too.

## Tests

`filterForPrune` table — core excluded, state/name/age/label filters, a box with no created-at excluded under `--older-than`, no-filter matches all non-core; `pruneDeleteKey` (Username preferred, name fallback). Full unit suite green (`go test -short ./...`); diff scanned clean.

## Follow-ups (noted, not here)

- A `--stopped-for <dur>` filter (on `stopped_at`) once #531's read fields are released + mapped through the clients.
- The dashboard bulk-ops UI (#264 frontend) can call this same logic / endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)