### PR TITLE
fix(app-hosting): pin core-caddy to a stable IP across recreates (#240)

### DIFF
--- a/internal/server/core_services.go
+++ b/internal/server/core_services.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"log"
+	"net"
 	"os/exec"
 	"strings"
 	"time"
@@ -50,6 +52,56 @@ const (
 	// Default Alertmanager port
 	DefaultAlertmanagerPort = 9093
 )
+
+// coreBridgeName is the incus managed bridge the core + tenant containers
+// attach to. Matches the value hard-coded at the GetNetworkSubnet call sites.
+const coreBridgeName = "incusbr0"
+
+// coreStaticIPHostOffsets pins each core container to a stable host number high
+// in the bridge subnet (well clear of the low addresses incus' DHCP hands out
+// first). incus reserves a NIC's ipv4.address and excludes it from the DHCP
+// pool, so these never collide with a tenant lease.
+//
+// Why (#240): core-caddy's IP is hard-coded into the split-horizon dnsmasq
+// record (and historically a host DNAT rule) with NO reconciler. Its DHCP lease
+// changes on recreate, stranding those references — internal clients then
+// resolve every platform hostname under the base domain to a dead IP. A
+// deterministic IP that survives a daemon-driven recreate keeps those
+// references self-consistent. Only caddy is pinned today (it's the one those
+// references point at); the map is keyed by container name so others can opt in.
+var coreStaticIPHostOffsets = map[string]uint32{
+	CoreCaddyContainer: 241,
+}
+
+// coreStaticIP returns the deterministic static IP for a core container within
+// networkCIDR (gateway or network form, e.g. "10.100.0.1/24" — ParseCIDR masks
+// either to the network base). Returns ("", nil) when the container has no
+// assigned offset (caller falls back to DHCP); an error only when the CIDR is
+// unparseable, not IPv4, or too small to hold the offset.
+func coreStaticIP(networkCIDR, containerName string) (string, error) {
+	offset, ok := coreStaticIPHostOffsets[containerName]
+	if !ok {
+		return "", nil
+	}
+	_, ipnet, err := net.ParseCIDR(networkCIDR)
+	if err != nil {
+		return "", fmt.Errorf("parse network cidr %q: %w", networkCIDR, err)
+	}
+	base := ipnet.IP.To4()
+	if base == nil {
+		return "", fmt.Errorf("network %q is not IPv4", networkCIDR)
+	}
+	ones, bits := ipnet.Mask.Size()
+	hostCount := uint32(1) << uint(bits-ones)
+	// Reject the network (.0) and broadcast (last) addresses and anything past
+	// the subnet — a misconfigured tiny subnet shouldn't yield a bogus IP.
+	if offset == 0 || offset >= hostCount-1 {
+		return "", fmt.Errorf("host offset %d out of range for %q", offset, networkCIDR)
+	}
+	out := make(net.IP, net.IPv4len)
+	binary.BigEndian.PutUint32(out, binary.BigEndian.Uint32(base)+offset)
+	return out.String(), nil
+}
 
 // CoreServicesConfig holds configuration for core services
 type CoreServicesConfig struct {
@@ -379,6 +431,16 @@ func (cs *CoreServices) EnsureCaddy(ctx context.Context, baseDomain string) (str
 			Pool: "default",
 			Size: "5GB",
 		},
+	}
+
+	// Pin a stable IP so a recreate reuses it — keeps the split-horizon dnsmasq
+	// record / host DNAT that reference caddy's IP valid across recreates (#240).
+	// Best-effort: a compute failure logs and falls back to DHCP (today's behaviour).
+	if staticIP, err := coreStaticIP(cs.config.NetworkCIDR, CoreCaddyContainer); err != nil {
+		log.Printf("Warning: could not compute stable IP for %s (%v); using DHCP", CoreCaddyContainer, err)
+	} else if staticIP != "" {
+		config.NIC = &incus.NICDevice{Name: "eth0", Network: coreBridgeName, IPv4Address: staticIP}
+		log.Printf("Assigning stable IP %s to %s (survives recreate; #240)", staticIP, CoreCaddyContainer)
 	}
 
 	if err := cs.incusClient.CreateContainer(config); err != nil {

--- a/internal/server/core_services_test.go
+++ b/internal/server/core_services_test.go
@@ -1,0 +1,90 @@
+package server
+
+import "testing"
+
+// TestCoreStaticIP covers the deterministic stable-IP assignment for core
+// containers (#240): caddy gets a fixed high host in the bridge subnet so a
+// recreate reuses the same IP, keeping the dnsmasq/DNAT references valid.
+func TestCoreStaticIP(t *testing.T) {
+	tests := []struct {
+		name      string
+		cidr      string
+		container string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "caddy in /24 gateway form",
+			cidr:      "10.100.0.1/24",
+			container: CoreCaddyContainer,
+			want:      "10.100.0.241",
+		},
+		{
+			name:      "caddy in /24 network form",
+			cidr:      "10.20.0.0/24",
+			container: CoreCaddyContainer,
+			want:      "10.20.0.241",
+		},
+		{
+			name:      "caddy in /16 masks to network base + offset",
+			cidr:      "10.100.5.1/16",
+			container: CoreCaddyContainer,
+			want:      "10.100.0.241",
+		},
+		{
+			name:      "container without an assigned offset falls back to DHCP",
+			cidr:      "10.100.0.1/24",
+			container: CorePostgresContainer,
+			want:      "", // no offset → empty, no error
+		},
+		{
+			name:      "unparseable cidr errors",
+			cidr:      "not-a-cidr",
+			container: CoreCaddyContainer,
+			wantErr:   true,
+		},
+		{
+			name:      "subnet too small for the offset errors",
+			cidr:      "10.0.0.0/28", // 16 hosts; offset 241 is out of range
+			container: CoreCaddyContainer,
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := coreStaticIP(tc.cidr, tc.container)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (ip=%q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("coreStaticIP(%q,%q) = %q, want %q", tc.cidr, tc.container, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCoreStaticIP_Deterministic: the whole point is stability across recreates
+// — same inputs must always yield the same IP.
+func TestCoreStaticIP_Deterministic(t *testing.T) {
+	const cidr = "10.20.0.1/24"
+	first, err := coreStaticIP(cidr, CoreCaddyContainer)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		again, err := coreStaticIP(cidr, CoreCaddyContainer)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if again != first {
+			t.Fatalf("non-deterministic: got %q then %q", first, again)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

core-caddy (the `--app-hosting` edge container) has a **dynamic DHCP lease**, but its IP is hard-coded into the split-horizon dnsmasq record (`raw.dnsmasq address=/<base-domain>/<caddyIP>`) and historically a host DNAT rule, with **no reconciler**. Every recreate gives core-caddy a new lease and strands those references — internal clients then resolve every platform hostname under the base domain to a dead IP. That's what broke a fresh CI runner box's reachability, and the `:443=000` stale-DNAT symptom.

This is one recurring class of bug (stale reference to a dynamic IP), not three coincidences — see the table in #240.

## Fix

Fix 1 from the issue, which it calls *"the real fix"*: assign core-caddy a **deterministic static IP** at creation, high in the bridge subnet (`.241`), where incus reserves it and excludes it from the DHCP pool. A daemon-driven recreate now reuses the same IP, so the dnsmasq/DNAT references the bootstrap writes stay self-consistent — there's no staleness left to reconcile.

- `coreStaticIP(networkCIDR, container)` — pure, deterministic host-offset computation (parses gateway- or network-form CIDR, masks to base, adds the offset). Keyed by container name so other `core-*` containers can opt in later. Out-of-range / non-IPv4 / unparseable CIDR → error; an unassigned container → `("", nil)` so it falls back to DHCP.
- `EnsureCaddy` create path sets `NIC.IPv4Address` from it — best-effort: a compute failure logs and falls back to DHCP (today's behaviour).

The static IP also stabilises the DNAT target (the `:443=000` manifestation), since the port-forwarder is built from the same caddy IP.

## Scope

- Existing deployments get the stable IP on the **next** caddy recreate (matches the issue's "daemon assigning stable IPs at bootstrap").
- Fix 4 (carving the control-plane host out of the app-hosting apex) is a cloud deployment/naming decision, out of scope here.

## Tests

`coreStaticIP` across /24 (gateway + network form) and /16, unassigned-container fallback, bad CIDR, too-small subnet, and determinism across repeated calls. `go build ./...` + `go test ./internal/server/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)