### PR TITLE
fix(ttl): wire `containarium ttl` CLI to the real SetContainerTTL RPC (#264)

### DIFF
--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -165,17 +165,17 @@ func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, 
 			Memory: memory,
 			Disk:   disk,
 		},
-		SshKeys:       sshKeys,
-		Image:         image,
-		EnablePodman:  enablePodman,
-		Stack:         stack,
-		Gpu:           gpu,
-		OsType:        osType,
-		Monitoring:    monitoring,
-		Pool:          pool,
-		BackendId:     backendID,
-		GitSource:     git.Source,
-		GitRef:        git.Ref,
+		SshKeys:                   sshKeys,
+		Image:                     image,
+		EnablePodman:              enablePodman,
+		Stack:                     stack,
+		Gpu:                       gpu,
+		OsType:                    osType,
+		Monitoring:                monitoring,
+		Pool:                      pool,
+		BackendId:                 backendID,
+		GitSource:                 git.Source,
+		GitRef:                    git.Ref,
 		GitCredential:             git.Credential,
 		WorkspacePath:             git.WorkspacePath,
 		TtlSeconds:                ttlSeconds,
@@ -247,6 +247,25 @@ func (c *GRPCClient) ToggleAutoSleep(username string, enabled bool, idleThreshol
 		return nil, fmt.Errorf("failed to toggle auto-sleep: %w", err)
 	}
 	return resp, nil
+}
+
+// SetContainerTTL schedules (durationSeconds > 0) or clears (== 0) a
+// container's auto-delete TTL. The daemon stamps
+// user.containarium.ttl_expires_at, which the ttlsweeper consumes to
+// force-delete the box when it elapses. Used by the containarium-run GitHub
+// Action's keep-on-failure path so a kept debug box self-reaps (#264 TTL-404).
+//
+// The error is returned UNWRAPPED so a daemon too old to implement the RPC
+// surfaces as gRPC codes.Unimplemented, which the `containarium ttl` CLI
+// treats as a soft no-op rather than a hard failure.
+func (c *GRPCClient) SetContainerTTL(username string, durationSeconds int64) (*pb.SetContainerTTLResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	return c.client.SetContainerTTL(ctx, &pb.SetContainerTTLRequest{
+		Name:            username,
+		DurationSeconds: durationSeconds,
+	})
 }
 
 // StartContainer starts a stopped container via gRPC. When

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -15,6 +15,8 @@ import (
 	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/footprintai/containarium/pkg/version"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -371,6 +373,47 @@ func (c *HTTPClient) ToggleAutoSleep(username string, enabled bool, idleThreshol
 	}
 
 	out := &pb.ToggleAutoSleepResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
+// SetContainerTTL schedules (durationSeconds > 0) or clears (== 0) a
+// container's auto-delete TTL via the REST shim. Used by the containarium-run
+// keep-on-failure path so a kept debug box self-reaps (#264 TTL-404).
+//
+// A 404 (a daemon too old to expose /v1/containers/{name}/ttl) is mapped to
+// gRPC codes.Unimplemented so the `containarium ttl` CLI's isUnimplemented
+// soft-path fires identically across both transports — the box won't auto-
+// delete on an old daemon, but the Action doesn't hard-fail.
+func (c *HTTPClient) SetContainerTTL(username string, durationSeconds int64) (*pb.SetContainerTTLResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/containers/%s/ttl", url.PathEscape(username))
+	body := map[string]interface{}{"duration_seconds": durationSeconds}
+	resp, err := c.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("set ttl: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, status.Errorf(codes.Unimplemented, "server does not expose SetContainerTTL (HTTP 404)")
+	}
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(bodyBytes, &errResp) == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("%s", errResp.Error)
+		}
+		return nil, fmt.Errorf("set ttl: status %d", resp.StatusCode)
+	}
+
+	out := &pb.SetContainerTTLResponse{}
 	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}

--- a/internal/client/http_test.go
+++ b/internal/client/http_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/footprintai/containarium/pkg/version"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // trackBody records whether it was read to EOF and closed, so a test can
@@ -118,5 +121,60 @@ func TestDoRequest_AdvertisesClientVersion(t *testing.T) {
 	}
 	if gotVer != version.GetVersion() {
 		t.Errorf("%s = %q; want %q", version.ClientVersionHeader, gotVer, version.GetVersion())
+	}
+}
+
+// TestHTTPSetContainerTTL_Success: the client POSTs duration_seconds to
+// /v1/containers/{name}/ttl and parses the returned ttl_expires_at. This is
+// the keep-on-failure path that #264's TTL-404 left broken (the CLI was a
+// client-side stub that never called the endpoint).
+func TestHTTPSetContainerTTL_Success(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		// grpc-gateway emits camelCase JSON; protojson accepts it.
+		_, _ = w.Write([]byte(`{"ttlExpiresAt":"2030-01-01T00:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	resp, err := c.SetContainerTTL("alice", 3600)
+	if err != nil {
+		t.Fatalf("SetContainerTTL: %v", err)
+	}
+	if gotPath != "/v1/containers/alice/ttl" {
+		t.Errorf("path = %q; want /v1/containers/alice/ttl", gotPath)
+	}
+	// JSON numbers decode as float64.
+	if gotBody["duration_seconds"] != float64(3600) {
+		t.Errorf("duration_seconds = %v; want 3600", gotBody["duration_seconds"])
+	}
+	if resp.GetTtlExpiresAt() == nil {
+		t.Errorf("response ttl_expires_at not parsed")
+	}
+}
+
+// TestHTTPSetContainerTTL_404IsUnimplemented: a daemon too old to expose the
+// endpoint returns 404, which the client maps to codes.Unimplemented so the
+// CLI's soft-degrade path fires (Action doesn't hard-fail).
+func TestHTTPSetContainerTTL_404IsUnimplemented(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	_, err = c.SetContainerTTL("alice", 3600)
+	if status.Code(err) != codes.Unimplemented {
+		t.Errorf("404 mapped to %v; want Unimplemented", status.Code(err))
 	}
 }

--- a/internal/cmd/ttl.go
+++ b/internal/cmd/ttl.go
@@ -4,36 +4,29 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/footprintai/containarium/internal/client"
+	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-// TODO(ttl-server-side): The TTL verbs below are CLI-only for now. The
-// server-side enforcement (so a box actually auto-deletes when its TTL
-// expires) still needs to land. Specifically:
+// The TTL verbs below are wired end-to-end:
 //
-//   1. Add a `SetContainerTTL` (and `GetContainerTTL`) RPC to
-//      proto/containarium/v1/container.proto, with a `google.api.http`
-//      annotation so grpc-gateway exposes a REST shim (PUT/GET
-//      /v1/containers/{username}/ttl), and regenerate via `make proto`.
-//   2. Persist `expires_at` (and `ttl_set_at`) on the container row in
-//      the daemon's container metadata store.
-//   3. Add a sweeper goroutine in the daemon's main loop that wakes on
-//      a short tick (e.g. every 30s) and force-deletes any container
-//      whose `expires_at` is in the past.
-//   4. Wire `internal/client/{grpc,http}.go` so SetContainerTTL /
-//      GetContainerTTL hit the new endpoint; then swap the
-//      synthetic-Unimplemented stub in ttlClientStub below for the
-//      real client call.
+//   - set/unset call the SetContainerTTL RPC (POST /v1/containers/{name}/ttl;
+//     duration 0 clears), which stamps user.containarium.ttl_expires_at on the
+//     Incus container — the exact key the daemon's ttlsweeper consumes to
+//     force-delete the box when it elapses (see internal/ttlsweeper +
+//     internal/server/container_server_ttl.go).
+//   - get reads ttl_expires_at off the container via GetContainer (no separate
+//     GetContainerTTL RPC; the field is part of the container view).
 //
-// Until that lands, this verb is wired up so that callers (notably
-// the containarium-run GitHub Action's "keep on failure" feature)
-// can call `containarium ttl set <box> 1h` and get a clean,
-// non-fatal "server does not support TTL yet" message rather than a
-// confusing error. The Action can then proceed; the box just won't
-// auto-delete and will need manual cleanup. Once the server-side
-// lands, the same CLI call will Just Work — no Action change needed.
+// This closes the #264 leak where the containarium-run "keep on failure" path
+// called `containarium ttl set` but the call was a client-side stub (and over
+// REST returned 404), so the kept debug box never got a TTL and never reaped.
+// A daemon too old to implement SetContainerTTL still degrades gracefully:
+// codes.Unimplemented (gRPC) / HTTP 404 mapped to Unimplemented (REST) → the
+// CLI prints a friendly no-op rather than failing the Action.
 
 // maxTTL caps the duration a caller can request. 168h (7 days) is the
 // upper bound: long enough to cover a long weekend debug session on a
@@ -231,27 +224,70 @@ func isUnimplemented(err error) bool {
 	return false
 }
 
-// ttlClientSet / ttlClientGet / ttlClientUnset are the call sites that
-// will become thin wrappers over `internal/client/{grpc,http}.go`
-// methods once the server-side RPCs ship. Until then they synthesize
-// an Unimplemented status so the handler's friendly-warning path
-// exercises end-to-end.
+// ttlClientSet / ttlClientGet / ttlClientUnset are thin wrappers over the
+// transport client (grpc or http per the global httpMode flag), mirroring
+// how scale_down.go's toggleAutoSleepViaServer dispatches.
 //
-// When the real client methods land, replace the body of each with
-// the equivalent of:
-//
-//   if httpMode { return httpClient.SetContainerTTL(username, d) }
-//   return grpcClient.SetContainerTTL(username, d)
-//
-// and the rest of the file stays as-is.
-func ttlClientSet(username string, d time.Duration) error {
-	return status.Errorf(codes.Unimplemented, "SetContainerTTL not implemented by this server")
-}
+// set/unset call the SetContainerTTL RPC (unset = duration 0 = clear). get
+// reads ttl_expires_at off the container via GetContainer — there is no
+// separate GetContainerTTL RPC; the field is part of the container view. A
+// daemon too old to implement SetContainerTTL surfaces codes.Unimplemented
+// (gRPC) or HTTP 404 mapped to Unimplemented (REST), which runTTLSet/Unset
+// degrade to a friendly no-op via isUnimplemented.
 
-func ttlClientGet(username string) (time.Time, bool, error) {
-	return time.Time{}, false, status.Errorf(codes.Unimplemented, "GetContainerTTL not implemented by this server")
+func ttlClientSet(username string, d time.Duration) error {
+	return setContainerTTLViaServer(username, int64(d.Seconds()))
 }
 
 func ttlClientUnset(username string) error {
-	return status.Errorf(codes.Unimplemented, "ClearContainerTTL not implemented by this server")
+	return setContainerTTLViaServer(username, 0)
+}
+
+func setContainerTTLViaServer(username string, durationSeconds int64) error {
+	if httpMode {
+		hc, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return err
+		}
+		defer hc.Close()
+		_, err = hc.SetContainerTTL(username, durationSeconds)
+		return err
+	}
+	gc, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return err
+	}
+	defer gc.Close()
+	_, err = gc.SetContainerTTL(username, durationSeconds)
+	return err
+}
+
+// ttlClientGet reads the container's current TTL via GetContainer. A zero
+// expiry means "no TTL set" (ok == false). GetContainer is a long-standing
+// RPC, so no Unimplemented degradation is needed here.
+func ttlClientGet(username string) (time.Time, bool, error) {
+	var info *incus.ContainerInfo
+	var err error
+	if httpMode {
+		hc, e := client.NewHTTPClient(serverAddr, authToken)
+		if e != nil {
+			return time.Time{}, false, e
+		}
+		defer hc.Close()
+		info, err = hc.GetContainer(username)
+	} else {
+		gc, e := client.NewGRPCClient(serverAddr, certsDir, insecure)
+		if e != nil {
+			return time.Time{}, false, e
+		}
+		defer gc.Close()
+		info, err = gc.GetContainer(username)
+	}
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	if info == nil || info.TTLExpiresAt.IsZero() {
+		return time.Time{}, false, nil
+	}
+	return info.TTLExpiresAt, true, nil
 }


### PR DESCRIPTION
## The TTL-404 leak behind #264

`containarium-run`'s *keep on failure* path runs `containarium ttl set <box> 1h` so a kept CI debug box self-reaps. But the CLI's `ttlClientSet/Get/Unset` were **client-side stubs** that synthesized `Unimplemented` and never called the server — over REST the missing call read as **HTTP 404**. So the box never got a `ttl_expires_at`, the `ttlsweeper` never saw it, and it leaked until deleted by hand (the pileup of `cld-…` debug boxes in #264).

The server side already exists — the `SetContainerTTL` RPC (`POST /v1/containers/{name}/ttl`, `duration_seconds=0` clears), the handler in `container_server_ttl.go`, and the `ttlsweeper` consumer. The stale TODO atop `ttl.go` (claiming none of it had landed) had simply **rotted**. This wires the last mile.

## Changes
- **client:** add `SetContainerTTL` to `GRPCClient` + `HTTPClient` (mirrors `ToggleAutoSleep`). The HTTP client maps a **404 → `codes.Unimplemented`** so the CLI's existing soft-degrade path fires identically on both transports: a daemon too old to expose the endpoint no-ops with a friendly message instead of hard-failing the Action.
- **`ttl.go`:** `set`/`unset` now call `SetContainerTTL` (unset = duration 0); `get` reads `ttl_expires_at` off `GetContainer` (no separate `GetContainerTTL` RPC needed — the field is already on the container view). Replaced the rotted TODO with an accurate description.

## Why no proto change
`SetContainerTTL` + its REST annotation + the server impl already shipped; `ttl_expires_at` is already exposed on the `Container` message. This was purely missing CLI client wiring.

## Tests
HTTP `SetContainerTTL` posts `duration_seconds` and parses the response; a 404 maps to `Unimplemented`. `go build ./...` + cmd/client/server suites green.

Fixes the TTL-404 root cause flagged in #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)