### PR TITLE
feat(policy): protect boxes from auto-reap + bulk prune (#284)

### DIFF
--- a/internal/cmd/prune.go
+++ b/internal/cmd/prune.go
@@ -143,7 +143,8 @@ func runPrune(_ *cobra.Command, _ []string) error {
 }
 
 // filterForPrune is the pure selection logic: which containers match the
-// filters. Core containers are NEVER matched (infrastructure safety). Filters
+// filters. Core containers and protected boxes (#284) are NEVER matched
+// (infrastructure + runner safety, regardless of the other filters). Filters
 // combine with AND. olderThan == 0 / state == "" / nameContains == "" /
 // empty labels each mean "don't filter on that". A box with no CreatedAt is
 // excluded by an olderThan filter (can't prove it's old enough). Pure — no IO,
@@ -152,6 +153,12 @@ func filterForPrune(containers []incus.ContainerInfo, state, nameContains string
 	var matches []incus.ContainerInfo
 	for _, c := range containers {
 		if c.Role.IsCoreRole() {
+			continue
+		}
+		// Protected boxes (#284, e.g. persistent runners) are never bulk-deleted
+		// — a "clean up leaked boxes" sweep must not take out a runner. Removing
+		// one takes a deliberate single-box `containarium delete`.
+		if c.DeletePolicy == incus.DeletePolicyProtected {
 			continue
 		}
 		if state == "running" && !strings.EqualFold(c.State, "Running") {

--- a/internal/cmd/prune_test.go
+++ b/internal/cmd/prune_test.go
@@ -105,3 +105,20 @@ func TestPruneDeleteKey(t *testing.T) {
 		t.Errorf("got %q, want alice (name fallback)", got)
 	}
 }
+
+// TestFilterForPrune_SkipsProtected: a protected box (#284) is never selected
+// for prune, even when it matches every other filter — the guard that would
+// have prevented a "clean up leaked boxes" sweep from deleting a runner.
+func TestFilterForPrune_SkipsProtected(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	fleet := []incus.ContainerInfo{
+		{Name: "ci-runner-1", State: "Running", CreatedAt: now.Add(-26 * time.Hour), DeletePolicy: incus.DeletePolicyProtected},
+		{Name: "leaked-box", State: "Running", CreatedAt: now.Add(-26 * time.Hour)},
+	}
+	// Broad filter (all running, >1h old) that matches BOTH boxes on every
+	// axis; only the unprotected one should come back.
+	got := names(filterForPrune(fleet, "running", "", time.Hour, nil, now))
+	if len(got) != 1 || got[0] != "leaked-box" {
+		t.Fatalf("filterForPrune = %v; want only [leaked-box] (protected runner must be skipped)", got)
+	}
+}

--- a/internal/server/ttlsweeper_adapter.go
+++ b/internal/server/ttlsweeper_adapter.go
@@ -65,6 +65,8 @@ func (a *ttlsweeperIncusAdapter) ListContainers() ([]ttlsweeper.ContainerView, e
 			d := time.Duration(c.DeleteAfterStoppedSeconds) * time.Second
 			v.DeleteAfterStopped = &d
 		}
+		// Protected boxes (#284) are never auto-reaped, regardless of any timer.
+		v.Protected = c.DeletePolicy == incus.DeletePolicyProtected
 		out = append(out, v)
 	}
 	return out, nil

--- a/internal/ttlsweeper/sweeper.go
+++ b/internal/ttlsweeper/sweeper.go
@@ -36,6 +36,13 @@ type ContainerView struct {
 	// scale-to-zero box that merely sleeps is never reaped for being
 	// stopped). Set + Stopped + StoppedAt+window elapsed → delete.
 	DeleteAfterStopped *time.Duration
+
+	// Protected marks a box that must never be auto-reaped (#284, delete-policy
+	// = protected — e.g. a persistent runner). When true, Decide skips the box
+	// regardless of any TTL or stopped→delete window. Defense in depth: a
+	// protected box should never carry a TTL, but if one is stamped by mistake
+	// the box still survives the sweeper.
+	Protected bool
 }
 
 // graceMargin is subtracted from the comparison clock before checking
@@ -66,11 +73,17 @@ const graceMargin = 30 * time.Second
 //
 // Unset/missing fields skip the corresponding rule, so a box with neither a
 // TTL nor a stopped→delete window is never reaped. A name matching both rules
-// is returned once (the two rules share the append-and-continue).
+// is returned once (the two rules share the append-and-continue). A box marked
+// Protected (#284) is skipped entirely, regardless of either timer.
 func Decide(containers []ContainerView, now time.Time) []string {
 	cutoff := now.Add(-graceMargin)
 	var expired []string
 	for _, c := range containers {
+		// Protected boxes (#284) are never auto-reaped — skip before any timer
+		// check so a stray TTL on a protected box can't delete it.
+		if c.Protected {
+			continue
+		}
 		// Absolute TTL.
 		if c.TTLExpiresAt != nil && !c.TTLExpiresAt.After(cutoff) {
 			expired = append(expired, c.Name)

--- a/internal/ttlsweeper/sweeper_test.go
+++ b/internal/ttlsweeper/sweeper_test.go
@@ -251,3 +251,25 @@ func TestDecide_PureFunction(t *testing.T) {
 		t.Errorf("Decide mutated its input slice")
 	}
 }
+
+// TestDecide_ProtectedSkipped: a protected box (#284) is never reaped, even
+// with a long-expired TTL or an elapsed stopped→delete window. Protection
+// wins over both timers.
+func TestDecide_ProtectedSkipped(t *testing.T) {
+	now := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	window := 10 * time.Minute
+	stopped := now.Add(-time.Hour)
+
+	got := Decide([]ContainerView{
+		// Protected with a long-expired absolute TTL → must survive.
+		{Name: "runner-protected", TTLExpiresAt: ptr(now.Add(-time.Hour)), Protected: true},
+		// Protected, stopped past its delete window → must survive.
+		{Name: "runner-protected-stopped", Protected: true, Stopped: true, StoppedAt: &stopped, DeleteAfterStopped: &window},
+		// Control: same expired TTL but unprotected → reaped.
+		{Name: "ephemeral-expired", TTLExpiresAt: ptr(now.Add(-time.Hour))},
+	}, now)
+
+	if len(got) != 1 || got[0] != "ephemeral-expired" {
+		t.Fatalf("Decide = %v; want only [ephemeral-expired] (protected boxes must survive)", got)
+	}
+}

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -322,6 +322,12 @@ type ContainerInfo struct {
 	// stopped→delete window (#525). 0 = never delete on stop. Independent of
 	// auto-sleep so a scale-to-zero box that merely sleeps is never reaped.
 	DeleteAfterStoppedSeconds int64
+
+	// DeletePolicy mirrors user.containarium.delete_policy (#284). When set to
+	// DeletePolicyProtected, every automated/bulk deletion path (ttlsweeper
+	// auto-reap, `containarium prune`) skips the box — only a deliberate
+	// single-box delete can remove it. Empty = unprotected (today's default).
+	DeletePolicy string
 }
 
 // AutoSleepEnabledKey is the Incus config key storing the per-container
@@ -362,6 +368,20 @@ const StoppedAtKey = "user.containarium.stopped_at"
 // explicitly asked for stopped→delete gets reaped. Absent/0 = never delete on
 // stop (today's behavior).
 const DeleteAfterStoppedSecondsKey = "user.containarium.delete_after_stopped_seconds"
+
+// DeletePolicyKey is the Incus config key carrying a box's delete policy
+// (#284). A box set to DeletePolicyProtected is skipped by every automated /
+// bulk deletion path — the ttlsweeper's auto-reap and `containarium prune` —
+// so a "clean up leaked boxes" sweep can never take out a persistent runner.
+// Absent/empty = unprotected (today's default: eligible for prune + reap).
+const DeletePolicyKey = "user.containarium.delete_policy"
+
+// DeletePolicyProtected marks a box that must never be auto-reaped or
+// bulk-deleted (e.g. a persistent GitHub Actions runner). Deleting it takes a
+// deliberate single-box delete, not a sweep. The value is a stable string
+// contract: operators can set it directly (`incus config set <box>
+// user.containarium.delete_policy protected`) and every deletion path honors it.
+const DeletePolicyProtected = "protected"
 
 // DefaultIdleThresholdMinutes is the fallback used when the threshold
 // config key is missing or unparseable.
@@ -705,20 +725,21 @@ func (c *Client) ListContainers() ([]ContainerInfo, error) {
 		}
 
 		info := ContainerInfo{
-			Name:                 inst.Name,
-			State:                inst.Status,
-			InstanceType:         inst.Type,
-			CreatedAt:            inst.CreatedAt,
-			Labels:               extractLabelsFromConfig(inst.Config),
-			Role:                 Role(inst.Config[RoleKey]),
-			Tenant:               inst.Config[TenantLabelKey],
-			MonitoringEnabled:    inst.Config["environment.OTEL_EXPORTER_OTLP_ENDPOINT"] != "",
-			AutoSleepEnabled:     inst.Config[AutoSleepEnabledKey] == "true",
+			Name:                      inst.Name,
+			State:                     inst.Status,
+			InstanceType:              inst.Type,
+			CreatedAt:                 inst.CreatedAt,
+			Labels:                    extractLabelsFromConfig(inst.Config),
+			Role:                      Role(inst.Config[RoleKey]),
+			Tenant:                    inst.Config[TenantLabelKey],
+			MonitoringEnabled:         inst.Config["environment.OTEL_EXPORTER_OTLP_ENDPOINT"] != "",
+			AutoSleepEnabled:          inst.Config[AutoSleepEnabledKey] == "true",
 			IdleThresholdMinutes:      parseIdleThresholdMinutes(inst.Config),
 			LastStartedAt:             parseLastStartedAt(inst.Config),
 			TTLExpiresAt:              parseTTLExpiresAt(inst.Config),
 			StoppedAt:                 parseStoppedAt(inst.Config),
 			DeleteAfterStoppedSeconds: parseDeleteAfterStoppedSeconds(inst.Config),
+			DeletePolicy:              inst.Config[DeletePolicyKey],
 		}
 
 		// Get CPU and memory limits from config
@@ -848,6 +869,7 @@ func (c *Client) GetContainer(name string) (*ContainerInfo, error) {
 		IdleThresholdMinutes: parseIdleThresholdMinutes(inst.Config),
 		LastStartedAt:        parseLastStartedAt(inst.Config),
 		TTLExpiresAt:         parseTTLExpiresAt(inst.Config),
+		DeletePolicy:         inst.Config[DeletePolicyKey],
 	}
 
 	// Get resource limits


### PR DESCRIPTION
The **"protect what matters"** half of the container delete policy (#284).

## Why
A manual "clean up leaked boxes" sweep once force-deleted a *persistent, registered GitHub Actions runner* — because leaked per-job boxes and runners were indistinguishable and nothing protected the runner. This makes protection a first-class, **enforced** contract.

## What
A box carrying `user.containarium.delete_policy=protected` is now skipped by every automated / bulk deletion path:
- **ttlsweeper auto-reap** — `Decide` skips `Protected` before any timer check, so a stray TTL on a protected box can't delete it.
- **`containarium prune`** — `filterForPrune` excludes protected boxes regardless of the other filters (same safety tier as core containers).

Only a deliberate single-box `containarium delete` can remove a protected box. The marker is a stable string contract (`incus.DeletePolicyKey` / `DeletePolicyProtected`): operators can set it today via `incus config set <box> user.containarium.delete_policy protected`, and both paths honor it immediately. Surfaced on `incus.ContainerInfo.DeletePolicy` (list + get).

## Context — the rest of #284 is already done
- **Reap half** (auto-delete what's expired): the ttlsweeper already runs with delete perms, and #534 made `containarium ttl set` actually stamp the TTL — so expired boxes now reap.
- **Distinguishability**: #321 surfaced the display name, so runners vs. ephemeral boxes are already tellable apart in the API.

This PR adds the missing **enforcement** so a sweep can't nuke a runner.

## Tests
`Decide` skips a protected box with an expired TTL / elapsed stopped→delete window; `filterForPrune` skips a protected box that matches every other filter. `go build ./...` + ttlsweeper/cmd/server/incus suites green.

## Follow-ups (not here)
- Birth-time stamping of `protected` on `runner provision` (needs a config-set RPC).
- Surfacing `delete_policy` through the proto `Container` + cloud list/get + a confirm-to-delete gate on the delete RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)