### PR TITLE
feat(metrics): carry cloud_container_id into the OTLP attribution map (Slice 2)

### DIFF
--- a/internal/server/container_ip_map_test.go
+++ b/internal/server/container_ip_map_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// TestBuildContainerIPMap covers the source-IP → identity projection that
+// feeds container_ips.json (#231/#264 metrics ingest). Each entry must carry
+// the cloud_container_id (the cloud's metrics join key) when present; core
+// containers and IP-less boxes are excluded.
+func TestBuildContainerIPMap(t *testing.T) {
+	infos := []incus.ContainerInfo{
+		{
+			Name:      "alice-container",
+			IPAddress: "10.0.0.5",
+			Labels:    map[string]string{cloudContainerIDLabel: "cld-uuid-1"},
+		},
+		{
+			// CLI/standalone box: has an IP but no cloud label.
+			Name:      "bob-container",
+			IPAddress: "10.0.0.6",
+		},
+		{
+			// Core container — never attributed.
+			Name:      "containarium-core-caddy",
+			IPAddress: "10.0.0.2",
+			Role:      incus.RoleCaddy,
+		},
+		{
+			// Not placed yet — no IP to key on.
+			Name:   "carol-container",
+			Labels: map[string]string{cloudContainerIDLabel: "cld-uuid-2"},
+		},
+	}
+
+	got := buildContainerIPMap(infos)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries (core + IP-less skipped), got %d: %+v", len(got), got)
+	}
+	if e := got["10.0.0.5"]; e.Name != "alice-container" || e.CloudContainerID != "cld-uuid-1" {
+		t.Errorf("alice entry = %+v; want name=alice-container cloud=cld-uuid-1", e)
+	}
+	if e := got["10.0.0.6"]; e.Name != "bob-container" || e.CloudContainerID != "" {
+		t.Errorf("bob entry = %+v; want name=bob-container cloud=\"\" (no label)", e)
+	}
+	if _, ok := got["10.0.0.2"]; ok {
+		t.Error("core container must be excluded")
+	}
+}

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -2468,16 +2468,33 @@ func (s *ContainerServer) refreshContainerIPMap() {
 		log.Printf("Warning: failed to list containers for IP map refresh: %v", err)
 		return
 	}
-	ipMap := make(map[string]string, len(infos))
+	if err := s.coreServices.WriteContainerIPMap(buildContainerIPMap(infos)); err != nil {
+		log.Printf("Warning: failed to push container IP map to collector: %v", err)
+	}
+}
+
+// cloudContainerIDLabel is the container label the cloud control plane stamps
+// with its container UUID (ossprimary.LabelCloudContainerID on the cloud side).
+// The OSS daemon is generic about labels; we read this one by its literal key
+// to carry the cloud's join identity into container_ips.json.
+const cloudContainerIDLabel = "cloud_container_id"
+
+// buildContainerIPMap projects the live container list into the source-IP →
+// identity map the OTel collector attributes telemetry by. Pure (no IO) so the
+// projection is unit-tested directly. Core containers and IP-less boxes (not
+// placed yet) are skipped — neither emits app telemetry to attribute.
+func buildContainerIPMap(infos []incus.ContainerInfo) map[string]ContainerIPEntry {
+	ipMap := make(map[string]ContainerIPEntry, len(infos))
 	for _, c := range infos {
 		if c.Role.IsCoreRole() || c.IPAddress == "" {
 			continue
 		}
-		ipMap[c.IPAddress] = c.Name
+		ipMap[c.IPAddress] = ContainerIPEntry{
+			Name:             c.Name,
+			CloudContainerID: c.Labels[cloudContainerIDLabel],
+		}
 	}
-	if err := s.coreServices.WriteContainerIPMap(ipMap); err != nil {
-		log.Printf("Warning: failed to push container IP map to collector: %v", err)
-	}
+	return ipMap
 }
 
 // localBackendID returns this daemon's backend ID for stamping into

--- a/internal/server/core_otel_collector.go
+++ b/internal/server/core_otel_collector.go
@@ -251,14 +251,14 @@ func (cs *CoreServices) applyOTelCollectorConfig(vmIP string, dropLabels []strin
 // recognized, or when the bearer load itself fails.
 //
 // Cutover sequence for operators:
-//   1. Run the new daemon (bearer auto-created; header
-//      stamped on new monitoring containers).
-//   2. Re-toggle monitoring on existing containers so they
-//      pick up the header (or restart, which re-stamps).
-//   3. Set CONTAINARIUM_OTEL_REQUIRE_AUTH=true and restart
-//      the daemon. Now the collector enforces; any
-//      container without the header drops silently (and
-//      that's the signal to find the laggard).
+//  1. Run the new daemon (bearer auto-created; header
+//     stamped on new monitoring containers).
+//  2. Re-toggle monitoring on existing containers so they
+//     pick up the header (or restart, which re-stamps).
+//  3. Set CONTAINARIUM_OTEL_REQUIRE_AUTH=true and restart
+//     the daemon. Now the collector enforces; any
+//     container without the header drops silently (and
+//     that's the signal to find the laggard).
 func collectorBearerForConfig() string {
 	raw := strings.TrimSpace(os.Getenv("CONTAINARIUM_OTEL_REQUIRE_AUTH"))
 	on := false
@@ -281,14 +281,30 @@ func collectorBearerForConfig() string {
 	return bearer
 }
 
-// WriteContainerIPMap pushes the current source-IP → container-name
-// map into the collector LXC at containerIPsFile. The collector reads
-// this file (or v2: reloads-on-mtime) for source-IP-based identity
-// attribution.
+// ContainerIPEntry is the identity attributed to a source IP in
+// container_ips.json. It carries BOTH the local incus name (for in-cluster
+// Grafana, which keys on container_name) and the cloud_container_id (the
+// cloud control plane's join key — what cloud-daemon's MetricsService queries
+// by; see the cloud's metrics.VictoriaMetrics, which selects
+// {container_id="<cloud uuid>"}). CloudContainerID is empty for standalone /
+// CLI-created boxes that carry no cloud label.
+//
+// The source.ip → container.id join that consumes this (the OTel collector's
+// "v2" attribution step) is still pending — but capturing the cloud id at the
+// source here means that join, however it lands, can stamp the
+// cloud-queryable label rather than only the local name.
+type ContainerIPEntry struct {
+	Name             string `json:"name"`
+	CloudContainerID string `json:"cloud_container_id,omitempty"`
+}
+
+// WriteContainerIPMap pushes the current source-IP → {name, cloud_container_id}
+// map into the collector LXC at containerIPsFile. The collector reads this
+// file (v2: reloads-on-mtime) for source-IP-based identity attribution.
 //
 // Errors are returned (not logged-and-swallowed) so the caller can
 // decide whether to retry; in practice callsites log + continue.
-func (cs *CoreServices) WriteContainerIPMap(ipMap map[string]string) error {
+func (cs *CoreServices) WriteContainerIPMap(ipMap map[string]ContainerIPEntry) error {
 	if cs.otelCollectorIP == "" {
 		// Collector not provisioned yet — silently skip. The
 		// post-ensure code will re-push the map after EnsureOTelCollector.
@@ -438,7 +454,9 @@ processors:`, bind, authBlock, bind, authBlock)
   # Anti-spoofing: stamp source.ip from the OTLP client.address so a
   # misbehaving container cannot fake provenance. v1 surfaces the raw
   # IP; v2 will join it with /var/lib/containarium/container_ips.json
-  # to materialize a container.id label.
+  # (source.ip → {name, cloud_container_id}) to materialize a
+  # container.id label = the cloud_container_id, which the cloud
+  # control plane's MetricsService queries by.
   attributes/identity:
     actions:
       - key: source.ip


### PR DESCRIPTION
The OSS half of live-metrics **Slice 2**: prep the ingest so the eventual `source.ip → container.id` join can stamp the label the cloud queries by.

## Why
The cloud's metrics backend (FootprintAI/Containarium-cloud#341) selects `{container_id="<cloud uuid>"}`, but `container_ips.json` mapped `source.ip → the incus name`, throwing away the cloud id entirely. So even once the collector's v2 attribution join lands, it could only ever produce the local name — never the cloud-queryable identity.

## Change
Enriches the attribution map to `source.ip → {name, cloud_container_id}`:
- `ContainerIPEntry{Name, CloudContainerID}` is the new file value. `name` still serves in-cluster Grafana (keys on `container_name`); `cloud_container_id` is the cloud control plane's join key. Empty for standalone/CLI boxes.
- `buildContainerIPMap` (extracted, pure, unit-tested) reads the cloud's `cloud_container_id` label off each container; core + IP-less boxes skipped.
- `WriteContainerIPMap` now takes `map[string]ContainerIPEntry`; the collector-config comment documents the join target = `cloud_container_id`.

## Scope (honest)
This captures the right identity **at the source**. The actual `source.ip → container.id` join in the collector (the v2 attribution step) and the OTLP-sidecar reachability fixes still need a **live OTLP pipeline** to build and validate — they can't be exercised offline. With this + the cloud backend (#341), the only remaining work is that collector join, and it now has the correct identity to stamp.

## Test
`buildContainerIPMap` carries `cloud_container_id` when present, omits it for unlabeled boxes, excludes core + not-yet-placed containers. `go build ./...` + server suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)