### PR TITLE
chore: gofmt sweep (formatting-only)

### DIFF
--- a/distros/go/containariumotel/resource.go
+++ b/distros/go/containariumotel/resource.go
@@ -15,13 +15,13 @@ const containariumDistroAttrKey = "containarium.distro"
 // buildResource composes a *resource.Resource per the precedence
 // table in TELEMETRY-DISTRO-DESIGN.md, low to high (later wins):
 //
-//	1. SDK defaults  (resource.Default merge baseline)
-//	2. Standard detectors (host, process, container)
-//	3. Containarium env attrs (container.id, backend.id,
-//	   service.namespace, service.version)
-//	4. OTEL_RESOURCE_ATTRIBUTES env (resource.WithFromEnv())
-//	5. Caller's extra_attrs
-//	6. containarium.distro stamp (defended — wins all)
+//  1. SDK defaults  (resource.Default merge baseline)
+//  2. Standard detectors (host, process, container)
+//  3. Containarium env attrs (container.id, backend.id,
+//     service.namespace, service.version)
+//  4. OTEL_RESOURCE_ATTRIBUTES env (resource.WithFromEnv())
+//  5. Caller's extra_attrs
+//  6. containarium.distro stamp (defended — wins all)
 //
 // Unlike Python's Resource.create() which silently runs the env
 // detector, Go's resource.New() only runs the detectors you ask for.

--- a/internal/agentbox/agentbox_test.go
+++ b/internal/agentbox/agentbox_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 	"syscall"
+	"testing"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -362,7 +362,8 @@ func TestDeleteFile_NotFound(t *testing.T) {
 func TestSandboxRoot_RejectsOutsidePath(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv(sandboxRootEnv, dir)
-	resetSandboxOnceForTest(); t.Cleanup(resetSandboxOnceForTest)
+	resetSandboxOnceForTest()
+	t.Cleanup(resetSandboxOnceForTest)
 
 	outside := filepath.Join(t.TempDir(), "evil") // different temp tree
 	_ = os.WriteFile(outside, []byte("x"), 0o644)
@@ -376,7 +377,8 @@ func TestSandboxRoot_RejectsOutsidePath(t *testing.T) {
 func TestSandboxRoot_AcceptsInsidePath(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv(sandboxRootEnv, dir)
-	resetSandboxOnceForTest(); t.Cleanup(resetSandboxOnceForTest)
+	resetSandboxOnceForTest()
+	t.Cleanup(resetSandboxOnceForTest)
 
 	inside := filepath.Join(dir, "ok.txt")
 	_ = os.WriteFile(inside, []byte("hi"), 0o644)
@@ -394,7 +396,8 @@ func TestSandboxRoot_RejectsLookalikePrefix(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv(sandboxRootEnv, root)
-	resetSandboxOnceForTest(); t.Cleanup(resetSandboxOnceForTest)
+	resetSandboxOnceForTest()
+	t.Cleanup(resetSandboxOnceForTest)
 
 	evil := root + "-evil"
 	if err := os.Mkdir(evil, 0o755); err != nil {
@@ -513,7 +516,8 @@ func TestTailLog_NotFound(t *testing.T) {
 func TestTailLog_RespectsSandboxRoot(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv(sandboxRootEnv, dir)
-	resetSandboxOnceForTest(); t.Cleanup(resetSandboxOnceForTest)
+	resetSandboxOnceForTest()
+	t.Cleanup(resetSandboxOnceForTest)
 
 	outside := filepath.Join(t.TempDir(), "log")
 	_ = os.WriteFile(outside, []byte("x"), 0o644)
@@ -534,8 +538,8 @@ func TestRootURIsToPaths_ParsesFileURIs(t *testing.T) {
 		{URI: "file:///home/alice/project"},
 		{URI: "file://localhost/srv/box"},
 		{URI: "https://example.com/oops"}, // non-file scheme: dropped
-		{URI: "not-a-uri-at-all"},          // unparseable: dropped
-		{URI: "file://"},                   // empty path: dropped
+		{URI: "not-a-uri-at-all"},         // unparseable: dropped
+		{URI: "file://"},                  // empty path: dropped
 	}
 	got := rootURIsToPaths(roots)
 	if len(got) != 2 {

--- a/internal/agentbox/compose_test.go
+++ b/internal/agentbox/compose_test.go
@@ -144,14 +144,14 @@ func TestStackSlug_UsesTwoTailComponentsToReduceCollisions(t *testing.T) {
 
 func TestSanitizeSlug_RejectsSystemdUnsafeChars(t *testing.T) {
 	cases := map[string]string{
-		"plain":             "plain",
-		"With Spaces":       "with-spaces",
-		"under_score":       "under-score",
-		"weird@chars!":      "weird-chars",
-		"---trim---":        "trim",
-		"":                  "default",
-		"日本":               "default", // non-ASCII collapses to empty → fallback
-		"v1.2.3":            "v1.2.3",  // dots preserved
+		"plain":        "plain",
+		"With Spaces":  "with-spaces",
+		"under_score":  "under-score",
+		"weird@chars!": "weird-chars",
+		"---trim---":   "trim",
+		"":             "default",
+		"日本":           "default", // non-ASCII collapses to empty → fallback
+		"v1.2.3":       "v1.2.3",  // dots preserved
 	}
 	for in, want := range cases {
 		got := sanitizeSlug(in)
@@ -219,8 +219,8 @@ func TestArgInt_AcceptsFloat64AndInt(t *testing.T) {
 
 func TestArgStringSlice_FiltersNonStringAndEmpty(t *testing.T) {
 	args := map[string]any{
-		"good": []any{"a", "b", "c"},
-		"mixed": []any{"a", 42, "", "b"},
+		"good":        []any{"a", "b", "c"},
+		"mixed":       []any{"a", 42, "", "b"},
 		"missing-key": nil,
 	}
 	if got := argStringSlice(args, "good"); len(got) != 3 || got[2] != "c" {
@@ -239,10 +239,10 @@ func TestArgStringSlice_FiltersNonStringAndEmpty(t *testing.T) {
 func TestExpandUser(t *testing.T) {
 	home := homeDir()
 	cases := map[string]string{
-		"~/foo":  filepath.Join(home, "foo"),
-		"~":      home,
-		"/abs":   "/abs",
-		"rel":    "rel",
+		"~/foo":        filepath.Join(home, "foo"),
+		"~":            home,
+		"/abs":         "/abs",
+		"rel":          "rel",
 		"~unsupported": "~unsupported", // ~user form not supported; passes through
 	}
 	for in, want := range cases {

--- a/internal/agentbox/process.go
+++ b/internal/agentbox/process.go
@@ -98,7 +98,7 @@ func handleProcessStart(_ context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	}
 	if _, exists := processRegistry[name]; exists {
 		return mcp.NewToolResultError(fmt.Sprintf(
-			"process_start: a process named %q is already running; kill it first or pick a different name", name)),
+				"process_start: a process named %q is already running; kill it first or pick a different name", name)),
 			nil
 	}
 

--- a/internal/agentbox/server.go
+++ b/internal/agentbox/server.go
@@ -25,11 +25,11 @@
 //     ci-context: ci-context is the data, ci-prompt is the behavior.
 //
 // File-ops tools enforce a sandbox in this order:
-//   1. AGENTBOX_ROOT env var (strict floor when set).
-//   2. MCP Roots advertised by the client via roots/list (used as the
-//      sandbox when AGENTBOX_ROOT is unset). Falls back gracefully if
-//      the client doesn't support the capability.
-//   3. Unconstrained (only when both are absent).
+//  1. AGENTBOX_ROOT env var (strict floor when set).
+//  2. MCP Roots advertised by the client via roots/list (used as the
+//     sandbox when AGENTBOX_ROOT is unset). Falls back gracefully if
+//     the client doesn't support the capability.
+//  3. Unconstrained (only when both are absent).
 //
 // More tools (provision_postgres, deploy_app, snapshot, etc.) land in
 // subsequent commits.

--- a/internal/app/buildpack/detector_test.go
+++ b/internal/app/buildpack/detector_test.go
@@ -243,9 +243,9 @@ func TestNodeJSDetector_DetectStartCommand(t *testing.T) {
 	detector := &NodeJSDetector{}
 
 	tests := []struct {
-		name     string
-		files    []string
-		wantCmd  string
+		name    string
+		files   []string
+		wantCmd string
 	}{
 		{
 			name:    "server.js present",

--- a/internal/app/store_test.go
+++ b/internal/app/store_test.go
@@ -19,17 +19,17 @@ import (
 func createTestApp(username, name string) *v1.App {
 	now := timestamppb.Now()
 	return &v1.App{
-		Id:            uuid.New().String(),
-		Name:          name,
-		Username:      username,
-		ContainerName: username + "-container",
-		Subdomain:     name,
-		FullDomain:    name + ".containarium.dev",
-		Port:          3000,
-		State:         v1.AppState_APP_STATE_RUNNING,
-		ContainerImage:   username + "/" + name + ":latest",
-		CreatedAt:     now,
-		UpdatedAt:     now,
+		Id:             uuid.New().String(),
+		Name:           name,
+		Username:       username,
+		ContainerName:  username + "-container",
+		Subdomain:      name,
+		FullDomain:     name + ".containarium.dev",
+		Port:           3000,
+		State:          v1.AppState_APP_STATE_RUNNING,
+		ContainerImage: username + "/" + name + ":latest",
+		CreatedAt:      now,
+		UpdatedAt:      now,
 	}
 }
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -33,10 +33,10 @@ func TestHTTPMiddleware_AuthGate(t *testing.T) {
 	wrapped := mw.HTTPMiddleware(stub)
 
 	cases := []struct {
-		name      string
-		setup     func(r *http.Request)
-		wantCode  int
-		wantStub  bool // did the wrapped handler run?
+		name     string
+		setup    func(r *http.Request)
+		wantCode int
+		wantStub bool // did the wrapped handler run?
 	}{
 		{
 			name:     "no auth header → 401",

--- a/internal/auth/revocation_test.go
+++ b/internal/auth/revocation_test.go
@@ -17,10 +17,10 @@ import (
 // memRevocationStore is a simple in-memory store that
 // satisfies RevocationStore for tests.
 type memRevocationStore struct {
-	mu        sync.Mutex
-	rows      map[string]time.Time // jti → expiresAt
-	failNext  bool                 // simulate a DB error
-	revoked   []string             // for assertions
+	mu       sync.Mutex
+	rows     map[string]time.Time // jti → expiresAt
+	failNext bool                 // simulate a DB error
+	revoked  []string             // for assertions
 }
 
 func newMemRevStore() *memRevocationStore {

--- a/internal/auth/scopes_test.go
+++ b/internal/auth/scopes_test.go
@@ -66,13 +66,13 @@ func TestHasScope_TrimsWhitespace(t *testing.T) {
 
 func TestParseScopes(t *testing.T) {
 	cases := map[string][]string{
-		"":                              nil,
-		"   ":                           nil,
-		",,,":                           nil,
-		"containers:read":               {"containers:read"},
-		"containers:read,secrets:read":  {"containers:read", "secrets:read"},
+		"":                                   nil,
+		"   ":                                nil,
+		",,,":                                nil,
+		"containers:read":                    {"containers:read"},
+		"containers:read,secrets:read":       {"containers:read", "secrets:read"},
 		" containers:read , secrets:read,, ": {"containers:read", "secrets:read"},
-		"*":                             {"*"},
+		"*":                                  {"*"},
 	}
 	for in, want := range cases {
 		t.Run(in, func(t *testing.T) {

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -35,29 +35,29 @@ func TestGenerateToken_EnforcesMaxExpiry(t *testing.T) {
 	tm, _ := NewTokenManager("test-secret-must-be-at-least-32-bytes-long-ok", "test-issuer")
 
 	tests := []struct {
-		name           string
+		name            string
 		requestedExpiry time.Duration
-		expectClamped  bool
+		expectClamped   bool
 	}{
 		{
-			name:           "zero expiry should be clamped to max",
+			name:            "zero expiry should be clamped to max",
 			requestedExpiry: 0,
-			expectClamped:  true,
+			expectClamped:   true,
 		},
 		{
-			name:           "negative expiry should be clamped to max",
+			name:            "negative expiry should be clamped to max",
 			requestedExpiry: -1 * time.Hour,
-			expectClamped:  true,
+			expectClamped:   true,
 		},
 		{
-			name:           "expiry exceeding max should be clamped",
+			name:            "expiry exceeding max should be clamped",
 			requestedExpiry: 365 * 24 * time.Hour, // 1 year
-			expectClamped:  true,
+			expectClamped:   true,
 		},
 		{
-			name:           "valid expiry within max should be allowed",
+			name:            "valid expiry within max should be allowed",
 			requestedExpiry: 24 * time.Hour,
-			expectClamped:  false,
+			expectClamped:   false,
 		},
 	}
 

--- a/internal/autosleep/manager_test.go
+++ b/internal/autosleep/manager_test.go
@@ -235,9 +235,9 @@ func TestManager_MultipleContainersSomeSleepSomeDont(t *testing.T) {
 		},
 	}
 	traffic := &fakeTraffic{per: map[string]time.Time{
-		"alice-container":   now.Add(-90 * time.Minute), // idle
-		"bob-container":     now.Add(-1 * time.Minute),  // active
-		"carol-container":   now.Add(-90 * time.Minute), // would-sleep, but not opted in
+		"alice-container": now.Add(-90 * time.Minute), // idle
+		"bob-container":   now.Add(-1 * time.Minute),  // active
+		"carol-container": now.Add(-90 * time.Minute), // would-sleep, but not opted in
 	}}
 	stopper := &fakeStopper{}
 	audit := &fakeAudit{}

--- a/internal/cmd/audit_test.go
+++ b/internal/cmd/audit_test.go
@@ -13,12 +13,12 @@ import (
 
 func TestSanitizeDetailForCLI_NormalizesWhitespace(t *testing.T) {
 	cases := map[string]string{
-		"plain text":         "plain text",
-		"line\nbreak":        "line break",
-		"carriage\rreturn":   "carriage return",
-		"with\ttabs":         "with tabs",
-		"mix\n\tof\rwhite":   "mix  of white",
-		"":                   "",
+		"plain text":       "plain text",
+		"line\nbreak":      "line break",
+		"carriage\rreturn": "carriage return",
+		"with\ttabs":       "with tabs",
+		"mix\n\tof\rwhite": "mix  of white",
+		"":                 "",
 	}
 	for in, want := range cases {
 		if got := sanitizeDetailForCLI(in); got != want {

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -19,11 +19,11 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/footprintai/containarium/internal/app"
+	"github.com/footprintai/containarium/internal/mtls"
+	"github.com/footprintai/containarium/internal/server"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
-	"github.com/footprintai/containarium/internal/mtls"
 	"github.com/footprintai/containarium/pkg/core/network"
-	"github.com/footprintai/containarium/internal/server"
 	"github.com/spf13/cobra"
 )
 
@@ -52,10 +52,10 @@ var (
 	peerAddrs          []string
 	localBackendID     string
 	pool               string
-	publicHostname    string
-	publicAliases     []string
-	publicBaseDomains []string
-	publicPort        int
+	publicHostname     string
+	publicAliases      []string
+	publicBaseDomains  []string
+	publicPort         int
 
 	proxyProtocol        bool
 	proxyProtocolTrusted []string

--- a/internal/cmd/delete.go
+++ b/internal/cmd/delete.go
@@ -51,10 +51,10 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	// Delete container - use remote or local mode
 	var err error
 	if httpMode && serverAddr != "" {
-		// Remote mode via HTTP 
+		// Remote mode via HTTP
 		err = deleteRemoteHTTP(username, forceDelete)
 	} else if serverAddr != "" {
-		// Remote mode via gRPC 
+		// Remote mode via gRPC
 		err = deleteRemote(username, forceDelete)
 	} else {
 		// Local mode via Incus
@@ -97,7 +97,7 @@ func deleteLocal(username string, force bool) error {
 	return mgr.Delete(username, force)
 }
 
-// deleteRemote deletes a container using remote gRPC server 
+// deleteRemote deletes a container using remote gRPC server
 func deleteRemote(username string, force bool) error {
 	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
@@ -108,7 +108,7 @@ func deleteRemote(username string, force bool) error {
 	return grpcClient.DeleteContainer(username, force)
 }
 
-// deleteRemoteHTTP deletes a container using remote HTTP API 
+// deleteRemoteHTTP deletes a container using remote HTTP API
 func deleteRemoteHTTP(username string, force bool) error {
 	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
 	if err != nil {

--- a/internal/cmd/hosting_setup.go
+++ b/internal/cmd/hosting_setup.go
@@ -16,17 +16,17 @@ import (
 
 var (
 	// Setup flags
-	setupDomain     string
-	setupEmail      string
-	setupProvider   string
-	setupAPIKey     string
-	setupAPISecret  string
-	setupServerIP   string
-	skipDNS         bool
-	skipCaddy       bool
-	skipSaveConfig  bool
-	configFile      string
-	noWildcard      bool
+	setupDomain    string
+	setupEmail     string
+	setupProvider  string
+	setupAPIKey    string
+	setupAPISecret string
+	setupServerIP  string
+	skipDNS        bool
+	skipCaddy      bool
+	skipSaveConfig bool
+	configFile     string
+	noWildcard     bool
 )
 
 var hostingSetupCmd = &cobra.Command{

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -62,7 +62,7 @@ func showSystemInfo() error {
 	var err error
 
 	if httpMode && serverAddr != "" {
-		// Remote mode via HTTP 
+		// Remote mode via HTTP
 		var httpClient *client.HTTPClient
 		httpClient, err = client.NewHTTPClient(serverAddr, authToken)
 		if err != nil {
@@ -80,7 +80,7 @@ func showSystemInfo() error {
 			return fmt.Errorf("failed to list containers: %w", err)
 		}
 	} else if serverAddr != "" {
-		// Remote mode via gRPC 
+		// Remote mode via gRPC
 		var grpcClient *client.GRPCClient
 		grpcClient, err = client.NewGRPCClient(serverAddr, certsDir, insecure)
 		if err != nil {
@@ -167,7 +167,7 @@ func showContainerInfo(username string) error {
 	var err error
 
 	if httpMode && serverAddr != "" {
-		// Remote mode via HTTP 
+		// Remote mode via HTTP
 		var httpClient *client.HTTPClient
 		httpClient, err = client.NewHTTPClient(serverAddr, authToken)
 		if err != nil {
@@ -180,7 +180,7 @@ func showContainerInfo(username string) error {
 			return fmt.Errorf("container not found: %w", err)
 		}
 	} else if serverAddr != "" {
-		// Remote mode via gRPC 
+		// Remote mode via gRPC
 		var grpcClient *client.GRPCClient
 		grpcClient, err = client.NewGRPCClient(serverAddr, certsDir, insecure)
 		if err != nil {

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -13,12 +13,12 @@ import (
 )
 
 var (
-	outputFormat  string
-	filterState   string
-	filterUser    string
-	filterLabels  []string
-	showLabels    bool
-	groupByLabel  string
+	outputFormat string
+	filterState  string
+	filterUser   string
+	filterLabels []string
+	showLabels   bool
+	groupByLabel string
 )
 
 var listCmd = &cobra.Command{
@@ -71,13 +71,13 @@ func runList(cmd *cobra.Command, args []string) error {
 
 	// Check if using remote server
 	if httpMode && serverAddr != "" {
-		// Use HTTP client for remote server 
+		// Use HTTP client for remote server
 		containers, err = listRemoteHTTP()
 		if err != nil {
 			return fmt.Errorf("failed to list containers from HTTP API: %w", err)
 		}
 	} else if serverAddr != "" {
-		// Use gRPC client for remote server 
+		// Use gRPC client for remote server
 		containers, err = listRemote()
 		if err != nil {
 			return fmt.Errorf("failed to list containers from remote server: %w", err)
@@ -425,7 +425,7 @@ func listLocal() ([]incus.ContainerInfo, error) {
 	return mgr.List()
 }
 
-// listRemote lists containers from remote gRPC server 
+// listRemote lists containers from remote gRPC server
 func listRemote() ([]incus.ContainerInfo, error) {
 	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
@@ -436,7 +436,7 @@ func listRemote() ([]incus.ContainerInfo, error) {
 	return grpcClient.ListContainers()
 }
 
-// listRemoteHTTP lists containers from remote HTTP API 
+// listRemoteHTTP lists containers from remote HTTP API
 func listRemoteHTTP() ([]incus.ContainerInfo, error) {
 	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
 	if err != nil {

--- a/internal/cmd/passthrough_add.go
+++ b/internal/cmd/passthrough_add.go
@@ -8,10 +8,10 @@ import (
 )
 
 var (
-	passthroughAddPort       int
-	passthroughAddTargetIP   string
-	passthroughAddTargetPort int
-	passthroughAddProtocol   string
+	passthroughAddPort        int
+	passthroughAddTargetIP    string
+	passthroughAddTargetPort  int
+	passthroughAddProtocol    string
 	passthroughAddNetworkCIDR string
 )
 

--- a/internal/cmd/portforward_remove.go
+++ b/internal/cmd/portforward_remove.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	portforwardRemoveCaddyIP   string
+	portforwardRemoveCaddyIP    string
 	portforwardRemoveAutoDetect bool
 )
 

--- a/internal/cmd/portforward_setup.go
+++ b/internal/cmd/portforward_setup.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	portforwardCaddyIP   string
+	portforwardCaddyIP    string
 	portforwardAutoDetect bool
 )
 

--- a/internal/cmd/recover.go
+++ b/internal/cmd/recover.go
@@ -46,15 +46,15 @@ type DaemonConfig struct {
 const DefaultRecoveryConfigPath = "/mnt/incus-data/containarium-recovery.yaml"
 
 var (
-	recoverConfigFile   string
-	recoverNetworkCIDR  string
-	recoverNetworkName  string
-	recoverStoragePool  string
+	recoverConfigFile    string
+	recoverNetworkCIDR   string
+	recoverNetworkName   string
+	recoverStoragePool   string
 	recoverStorageDriver string
-	recoverZFSSource    string
-	recoverDryRun       bool
-	recoverSkipAccounts bool
-	recoverStartAll     bool
+	recoverZFSSource     string
+	recoverDryRun        bool
+	recoverSkipAccounts  bool
+	recoverStartAll      bool
 )
 
 var recoverCmd = &cobra.Command{

--- a/internal/cmd/secrets_migrate.go
+++ b/internal/cmd/secrets_migrate.go
@@ -200,4 +200,3 @@ func openSecretsStoreWithKMS(ctx context.Context, masterKeyPath string) (*intern
 	}
 	return store, func() { pool.Close() }, nil
 }
-

--- a/internal/cmd/sidecar.go
+++ b/internal/cmd/sidecar.go
@@ -97,13 +97,13 @@ func runSidecarOtelCompose(cmd *cobra.Command, args []string) error {
 	serviceName := username + "-otel"
 
 	fmt.Print(renderOTelComposeSnippet(otelComposeInputs{
-		ImageTag:            imageTag,
-		ServiceName:         serviceName,
-		Username:            username,
-		ContainerEnvName:    containerID,
-		BackendEnvValue:     backendID,
-		TenantEnvValue:      tenantID,
-		CollectorEnvValue:   endpoint,
+		ImageTag:          imageTag,
+		ServiceName:       serviceName,
+		Username:          username,
+		ContainerEnvName:  containerID,
+		BackendEnvValue:   backendID,
+		TenantEnvValue:    tenantID,
+		CollectorEnvValue: endpoint,
 	}))
 	return nil
 }

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -47,15 +47,15 @@ import (
 
 // Per-command flags.
 var (
-	sshSetupName        string
-	sshSetupKeyPath     string
-	sshSetupGenerate    bool
-	sshSetupForce       bool
-	sshSetupServer      string
-	sshListServer       string
-	sshRemoveServer     string
-	sshPropagateServer  string
-	sshPropagateBoxes   []string
+	sshSetupName       string
+	sshSetupKeyPath    string
+	sshSetupGenerate   bool
+	sshSetupForce      bool
+	sshSetupServer     string
+	sshListServer      string
+	sshRemoveServer    string
+	sshPropagateServer string
+	sshPropagateBoxes  []string
 )
 
 var sshCmd = &cobra.Command{
@@ -201,9 +201,9 @@ func init() {
 // credentials-file fallback because we usually want the same server
 // the user is logged into:
 //
-//   1. explicit --server flag
-//   2. credentials-file default_server
-//   3. defaultLoginServer constant
+//  1. explicit --server flag
+//  2. credentials-file default_server
+//  3. defaultLoginServer constant
 func pickSSHServer(explicit string) string {
 	if explicit != "" {
 		return strings.TrimRight(explicit, "/")

--- a/internal/cmd/ssh_config.go
+++ b/internal/cmd/ssh_config.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/internal/sshconfig"
+	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/token_inspect.go
+++ b/internal/cmd/token_inspect.go
@@ -75,19 +75,19 @@ func init() {
 // struct shape but is the local CLI-facing JSON shape —
 // stable independent of the auth package's internals.
 type inspectedClaims struct {
-	Username   string    `json:"username,omitempty"`
-	Roles      []string  `json:"roles,omitempty"`
-	Scopes     []string  `json:"scopes,omitempty"`
-	TokenType  string    `json:"tt,omitempty"`
-	Issuer     string    `json:"iss,omitempty"`
-	Audience   []string  `json:"aud,omitempty"`
-	JTI        string    `json:"jti,omitempty"`
-	IssuedAt   time.Time `json:"iat,omitempty"`
-	NotBefore  time.Time `json:"nbf,omitempty"`
-	Expiry     time.Time `json:"exp,omitempty"`
-	Subject    string    `json:"sub,omitempty"`
-	SignatureOK bool     `json:"signature_ok"`
-	Validated   bool     `json:"validated"`
+	Username    string    `json:"username,omitempty"`
+	Roles       []string  `json:"roles,omitempty"`
+	Scopes      []string  `json:"scopes,omitempty"`
+	TokenType   string    `json:"tt,omitempty"`
+	Issuer      string    `json:"iss,omitempty"`
+	Audience    []string  `json:"aud,omitempty"`
+	JTI         string    `json:"jti,omitempty"`
+	IssuedAt    time.Time `json:"iat,omitempty"`
+	NotBefore   time.Time `json:"nbf,omitempty"`
+	Expiry      time.Time `json:"exp,omitempty"`
+	Subject     string    `json:"sub,omitempty"`
+	SignatureOK bool      `json:"signature_ok"`
+	Validated   bool      `json:"validated"`
 }
 
 func runTokenInspect(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/tunnel.go
+++ b/internal/cmd/tunnel.go
@@ -13,11 +13,11 @@ import (
 )
 
 var (
-	tunnelSentinelAddr   string
-	tunnelToken          string
-	tunnelSpotID         string
-	tunnelPorts          string
-	tunnelPool           string
+	tunnelSentinelAddr      string
+	tunnelToken             string
+	tunnelSpotID            string
+	tunnelPorts             string
+	tunnelPool              string
 	tunnelPublicHostname    string
 	tunnelPublicAliases     []string
 	tunnelPublicBaseDomains []string

--- a/internal/gateway/labels_test.go
+++ b/internal/gateway/labels_test.go
@@ -11,12 +11,12 @@ import (
 
 func TestLabelRequestParsing(t *testing.T) {
 	tests := []struct {
-		name           string
-		path           string
-		wantUsername   string
-		wantLabelKey   string
-		wantValid      bool
-		handlerType    string // "set", "remove", "get"
+		name         string
+		path         string
+		wantUsername string
+		wantLabelKey string
+		wantValid    bool
+		handlerType  string // "set", "remove", "get"
 	}{
 		{
 			name:         "valid set labels path",

--- a/internal/gateway/security_test.go
+++ b/internal/gateway/security_test.go
@@ -93,10 +93,10 @@ func TestTerminalHandler_WebSocketOriginValidation(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		origin         string
-		envOrigins     string
-		expectAllowed  bool
+		name          string
+		origin        string
+		envOrigins    string
+		expectAllowed bool
 	}{
 		{
 			name:          "no origin header should be rejected",

--- a/internal/guacamole/client.go
+++ b/internal/guacamole/client.go
@@ -28,8 +28,8 @@ func New(baseURL string) *Client {
 
 // authResponse is the response from POST /api/tokens.
 type authResponse struct {
-	AuthToken string `json:"authToken"`
-	Username  string `json:"username"`
+	AuthToken  string `json:"authToken"`
+	Username   string `json:"username"`
 	DataSource string `json:"dataSource"`
 }
 
@@ -93,17 +93,17 @@ func (c *Client) CreateConnection(authToken string, config ConnectionConfig) (st
 		Name:             config.Name,
 		Protocol:         "rdp",
 		Parameters: map[string]string{
-			"hostname":       config.Hostname,
-			"port":           config.Port,
-			"username":       config.Username,
-			"password":       config.Password,
-			"security":       "nla",
-			"ignore-cert":    "true",
-			"resize-method":  "display-update",
+			"hostname":         config.Hostname,
+			"port":             config.Port,
+			"username":         config.Username,
+			"password":         config.Password,
+			"security":         "nla",
+			"ignore-cert":      "true",
+			"resize-method":    "display-update",
 			"enable-wallpaper": "true",
 		},
 		Attributes: map[string]string{
-			"max-connections":         "2",
+			"max-connections":          "2",
 			"max-connections-per-user": "2",
 		},
 	}

--- a/internal/hosting/setup.go
+++ b/internal/hosting/setup.go
@@ -73,14 +73,14 @@ func NewSetup(cfg SetupConfig, logger func(format string, args ...interface{})) 
 	// Determine provider environment variable name
 	envVars := map[string]string{
 		"godaddy":        "GODADDY_API_TOKEN",
-		"cloudflare":    "CF_API_TOKEN",
-		"route53":       "AWS_ACCESS_KEY_ID",
+		"cloudflare":     "CF_API_TOKEN",
+		"route53":        "AWS_ACCESS_KEY_ID",
 		"googleclouddns": "GCP_PROJECT",
-		"digitalocean":  "DO_AUTH_TOKEN",
-		"azure":         "AZURE_CLIENT_ID",
-		"vultr":         "VULTR_API_KEY",
-		"duckdns":       "DUCKDNS_API_TOKEN",
-		"namecheap":     "NAMECHEAP_API_KEY",
+		"digitalocean":   "DO_AUTH_TOKEN",
+		"azure":          "AZURE_CLIENT_ID",
+		"vultr":          "VULTR_API_KEY",
+		"duckdns":        "DUCKDNS_API_TOKEN",
+		"namecheap":      "NAMECHEAP_API_KEY",
 	}
 
 	// Format credential based on provider

--- a/internal/mcp/auto_sleep_tool_test.go
+++ b/internal/mcp/auto_sleep_tool_test.go
@@ -40,9 +40,9 @@ func TestHandleToggleAutoSleep_RequiresUsername(t *testing.T) {
 func TestHandleToggleAutoSleep_RequiresEnabledBool(t *testing.T) {
 	client := NewClient("http://127.0.0.1:1", "tok")
 	cases := []map[string]interface{}{
-		{"username": "alice"},                     // missing
-		{"username": "alice", "enabled": "true"},  // string, not bool
-		{"username": "alice", "enabled": 1},       // int, not bool
+		{"username": "alice"},                    // missing
+		{"username": "alice", "enabled": "true"}, // string, not bool
+		{"username": "alice", "enabled": 1},      // int, not bool
 	}
 	for _, args := range cases {
 		_, err := handleToggleAutoSleep(client, args)

--- a/internal/mcp/client_tls.go
+++ b/internal/mcp/client_tls.go
@@ -31,20 +31,20 @@ import (
 //     hostnames and wrong for self-signed certs.
 
 const (
-	mcpAllowInsecureEnv  = "CONTAINARIUM_MCP_ALLOW_INSECURE"
-	mcpTrustedCAFileEnv  = "CONTAINARIUM_MCP_TRUSTED_CA_FILE"
+	mcpAllowInsecureEnv = "CONTAINARIUM_MCP_ALLOW_INSECURE"
+	mcpTrustedCAFileEnv = "CONTAINARIUM_MCP_TRUSTED_CA_FILE"
 )
 
 // buildMCPTLSConfig constructs a *tls.Config for the MCP client's
 // http.Transport based on the env knobs above. Returns:
 //   - nil, nil      — caller can use the http.Transport zero
-//                      value (system roots, default TLS). Happens
-//                      for an https:// URL with no CA pin and
-//                      no insecure-allow toggle.
+//     value (system roots, default TLS). Happens
+//     for an https:// URL with no CA pin and
+//     no insecure-allow toggle.
 //   - cfg, nil      — pinned CA (cfg.RootCAs populated).
 //   - nil, error    — scheme is http:// and ALLOW_INSECURE isn't
-//                      set, OR the CA file is unreadable / not
-//                      PEM.
+//     set, OR the CA file is unreadable / not
+//     PEM.
 func buildMCPTLSConfig(baseURL string) (*tls.Config, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {

--- a/internal/mcp/security.go
+++ b/internal/mcp/security.go
@@ -30,8 +30,8 @@ type SecurityFinding struct {
 	Title         string `json:"title"`
 	Description   string `json:"description,omitempty"`
 	ContainerName string `json:"containerName,omitempty"`
-	Target        string `json:"target,omitempty"`        // pentest/ZAP-side target (URL, IP:port)
-	FixAvailable  bool   `json:"fixAvailable"`            // true ↔ security_remediate can act
+	Target        string `json:"target,omitempty"` // pentest/ZAP-side target (URL, IP:port)
+	FixAvailable  bool   `json:"fixAvailable"`     // true ↔ security_remediate can act
 }
 
 // SecurityScanResponse is what security_scan returns to the agent.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -378,9 +378,9 @@ func TestJSONRPCCompliance(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
-		name     string
-		request  *MCPRequest
-		checkFn  func(*testing.T, *MCPResponse)
+		name    string
+		request *MCPRequest
+		checkFn func(*testing.T, *MCPResponse)
 	}{
 		{
 			name: "response has jsonrpc field",

--- a/internal/mcp/sync_ssh_config.go
+++ b/internal/mcp/sync_ssh_config.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/internal/sshconfig"
+	"github.com/footprintai/containarium/pkg/core/incus"
 )
 
 // handleSyncSSHConfig is the agent-native version of `containarium

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -468,11 +468,11 @@ func TestGetBackend_RejectsMissingID(t *testing.T) {
 // agents tend to produce (float64 from encoding/json) plus native ints.
 func TestGetIntArg(t *testing.T) {
 	cases := []struct {
-		name    string
-		args    map[string]interface{}
-		key     string
-		want    int
-		wantOK  bool
+		name   string
+		args   map[string]interface{}
+		key    string
+		want   int
+		wantOK bool
 	}{
 		{"float64 from JSON", map[string]interface{}{"p": float64(8080)}, "p", 8080, true},
 		{"native int", map[string]interface{}{"p": 8080}, "p", 8080, true},

--- a/internal/metrics/otel.go
+++ b/internal/metrics/otel.go
@@ -18,14 +18,14 @@ import (
 // CollectorConfig holds configuration for the OTel metrics collector
 // PeerMetrics represents metrics from a peer backend container.
 type PeerMetrics struct {
-	ContainerName     string
-	BackendID         string
-	CPUUsageSeconds   int64
-	MemoryUsageBytes  int64
-	DiskUsageBytes    int64
-	NetworkRxBytes    int64
-	NetworkTxBytes    int64
-	ProcessCount      int64
+	ContainerName    string
+	BackendID        string
+	CPUUsageSeconds  int64
+	MemoryUsageBytes int64
+	DiskUsageBytes   int64
+	NetworkRxBytes   int64
+	NetworkTxBytes   int64
+	ProcessCount     int64
 }
 
 // PeerSystemMetrics represents system-level metrics from a peer backend.
@@ -90,14 +90,14 @@ type Collector struct {
 	shutdownFn  containariumotel.ShutdownFunc
 
 	// System metric instruments
-	systemCPUCount    otelmetric.Int64Gauge
-	systemMemTotal    otelmetric.Int64Gauge
-	systemMemUsed     otelmetric.Int64Gauge
-	systemDiskTotal   otelmetric.Int64Gauge
-	systemDiskUsed    otelmetric.Int64Gauge
-	systemCPULoad1m   otelmetric.Float64Gauge
-	systemCPULoad5m   otelmetric.Float64Gauge
-	systemCPULoad15m  otelmetric.Float64Gauge
+	systemCPUCount   otelmetric.Int64Gauge
+	systemMemTotal   otelmetric.Int64Gauge
+	systemMemUsed    otelmetric.Int64Gauge
+	systemDiskTotal  otelmetric.Int64Gauge
+	systemDiskUsed   otelmetric.Int64Gauge
+	systemCPULoad1m  otelmetric.Float64Gauge
+	systemCPULoad5m  otelmetric.Float64Gauge
+	systemCPULoad15m otelmetric.Float64Gauge
 
 	// Container metric instruments
 	containerCPUUsage     otelmetric.Int64Gauge
@@ -114,9 +114,9 @@ type Collector struct {
 	// Backend health instruments
 	backendHealthy otelmetric.Int64Gauge
 
-	ctx          context.Context
-	cancel       context.CancelFunc
-	peerFetcher  PeerMetricsFetcher
+	ctx         context.Context
+	cancel      context.CancelFunc
+	peerFetcher PeerMetricsFetcher
 }
 
 // NewCollector creates a new OTel metrics collector

--- a/internal/pentest/store.go
+++ b/internal/pentest/store.go
@@ -609,21 +609,21 @@ func (s *Store) GetOpenFindingCounts(ctx context.Context) (bySeverity map[string
 
 // PentestScanJob represents a queued pentest scan job for a single target
 type PentestScanJob struct {
-	ID            int64
-	ScanRunID     string
-	TargetDomain  string
-	TargetIP      string
-	TargetPort    int
+	ID             int64
+	ScanRunID      string
+	TargetDomain   string
+	TargetIP       string
+	TargetPort     int
 	TargetProtocol string
-	ContainerName string
-	TargetType    string
-	Status        string // pending | running | completed | failed
-	RetryCount    int
-	MaxRetries    int
-	ErrorMessage  string
-	CreatedAt     time.Time
-	StartedAt     *time.Time
-	CompletedAt   *time.Time
+	ContainerName  string
+	TargetType     string
+	Status         string // pending | running | completed | failed
+	RetryCount     int
+	MaxRetries     int
+	ErrorMessage   string
+	CreatedAt      time.Time
+	StartedAt      *time.Time
+	CompletedAt    *time.Time
 }
 
 // targetLabel returns a human-readable label for logging

--- a/internal/runner/installer_ssh.go
+++ b/internal/runner/installer_ssh.go
@@ -206,7 +206,7 @@ func expandTilde(p string) string {
 }
 
 // shellQuote wraps a value in single quotes with embedded single
-// quotes escaped as '\''. Enough for PATs and label strings; we
+// quotes escaped as '\”. Enough for PATs and label strings; we
 // deliberately don't try to support arbitrary shell metachars in
 // runner names (validated upstream).
 func shellQuote(v string) string {

--- a/internal/secrets/migrate.go
+++ b/internal/secrets/migrate.go
@@ -56,13 +56,13 @@ type MigrateOptions struct {
 
 // MigrateResult summarizes what the migration did.
 type MigrateResult struct {
-	Scanned      int       // rows we looked at
-	Migrated     int       // rows successfully rewritten to envelope
-	AlreadyDone  int       // rows already in envelope form (skipped)
-	Failed       int       // rows that errored mid-migration
-	StartedAt    time.Time
-	CompletedAt  time.Time
-	Errors       []MigrationError
+	Scanned     int // rows we looked at
+	Migrated    int // rows successfully rewritten to envelope
+	AlreadyDone int // rows already in envelope form (skipped)
+	Failed      int // rows that errored mid-migration
+	StartedAt   time.Time
+	CompletedAt time.Time
+	Errors      []MigrationError
 }
 
 // MigrationError names a row that failed and why.

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -12,12 +12,12 @@ import (
 // convention as internal/app/store_test.go: t.Skip in CI, runnable
 // locally with:
 //
-//   docker run -d -p 5432:5432 \
-//     -e POSTGRES_PASSWORD=test \
-//     -e POSTGRES_DB=containarium \
-//     postgres:16-alpine
+//	docker run -d -p 5432:5432 \
+//	  -e POSTGRES_PASSWORD=test \
+//	  -e POSTGRES_DB=containarium \
+//	  postgres:16-alpine
 //
-//   go test -run TestSecretsStore ./internal/secrets/ -v
+//	go test -run TestSecretsStore ./internal/secrets/ -v
 //
 // The crypto layer is fully unit-tested in pkg/core/secrets;
 // this test exercises the SQL roundtrip + AAD binding through

--- a/internal/security/store_test.go
+++ b/internal/security/store_test.go
@@ -4,11 +4,11 @@ import "testing"
 
 func TestParseClamScanOutput(t *testing.T) {
 	tests := []struct {
-		name           string
-		output         string
-		wantStatus     string
-		wantCount      int
-		wantFindings   string
+		name         string
+		output       string
+		wantStatus   string
+		wantCount    int
+		wantFindings string
 	}{
 		{
 			name:       "clean output",
@@ -23,17 +23,17 @@ func TestParseClamScanOutput(t *testing.T) {
 			wantCount:  0,
 		},
 		{
-			name:       "infected output",
-			output:     "/mnt/scan/home/user/eicar.com: Eicar-Signature FOUND\n/mnt/scan/tmp/malware.exe: Win.Trojan.Agent FOUND\n",
-			wantStatus: "infected",
-			wantCount:  2,
+			name:         "infected output",
+			output:       "/mnt/scan/home/user/eicar.com: Eicar-Signature FOUND\n/mnt/scan/tmp/malware.exe: Win.Trojan.Agent FOUND\n",
+			wantStatus:   "infected",
+			wantCount:    2,
 			wantFindings: "/mnt/scan/home/user/eicar.com: Eicar-Signature FOUND\n/mnt/scan/tmp/malware.exe: Win.Trojan.Agent FOUND",
 		},
 		{
-			name:       "mixed output with one finding",
-			output:     "/mnt/scan/usr/bin/ls: OK\n/mnt/scan/home/user/eicar.com: Eicar-Signature FOUND\n/mnt/scan/usr/bin/cat: OK\n",
-			wantStatus: "infected",
-			wantCount:  1,
+			name:         "mixed output with one finding",
+			output:       "/mnt/scan/usr/bin/ls: OK\n/mnt/scan/home/user/eicar.com: Eicar-Signature FOUND\n/mnt/scan/usr/bin/cat: OK\n",
+			wantStatus:   "infected",
+			wantCount:    1,
 			wantFindings: "/mnt/scan/home/user/eicar.com: Eicar-Signature FOUND",
 		},
 	}

--- a/internal/sentinel/certsync.go
+++ b/internal/sentinel/certsync.go
@@ -21,9 +21,9 @@ type CertStore struct {
 	certs    map[string]tls.Certificate // domain → parsed cert
 	fallback tls.Certificate            // self-signed fallback
 
-	lastSync     time.Time
-	lastSyncErr  error
-	syncedCount  int
+	lastSync    time.Time
+	lastSyncErr error
+	syncedCount int
 }
 
 // NewCertStore creates a CertStore with a self-signed fallback certificate.

--- a/internal/sentinel/handshake_buffering_test.go
+++ b/internal/sentinel/handshake_buffering_test.go
@@ -23,9 +23,9 @@ import (
 func TestHandshakeDecoderOverReads(t *testing.T) {
 	jsonResponse := `{"ok":true,"assigned_ip":"127.0.0.7"}` + "\n"
 	yamuxSYN := []byte{
-		0x00,             // version 0
-		0x00,             // type SYN
-		0x00, 0x01,       // flags = SYN
+		0x00,       // version 0
+		0x00,       // type SYN
+		0x00, 0x01, // flags = SYN
 		0x00, 0x00, 0x00, 0x01, // stream ID 1
 		0x00, 0x00, 0x00, 0x00, // length 0
 	}

--- a/internal/sentinel/keysync_port_test.go
+++ b/internal/sentinel/keysync_port_test.go
@@ -16,8 +16,8 @@ func TestIsTunnelLoopback(t *testing.T) {
 		{"127.0.0.10", true},
 		{"127.0.0.11", true},
 		{"127.0.0.99", true},
-		{"127.0.0.1", false},  // localhost, not a tunnel alias
-		{"127.0.0.2", true},   // loopback alias
+		{"127.0.0.1", false},   // localhost, not a tunnel alias
+		{"127.0.0.2", true},    // loopback alias
 		{"10.130.0.15", false}, // VPC internal IP
 		{"192.168.1.1", false},
 		{"", false},

--- a/internal/sentinel/sni_test.go
+++ b/internal/sentinel/sni_test.go
@@ -20,8 +20,8 @@ import (
 func TestExtractSNI_RealClientHello(t *testing.T) {
 	cases := []string{
 		"prod.example.com",
-		"a.b",            // minimal
-		"x.example.com",  // typical
+		"a.b",           // minimal
+		"x.example.com", // typical
 	}
 	for _, sni := range cases {
 		t.Run(sni, func(t *testing.T) {

--- a/internal/sentinel/token_policy_test.go
+++ b/internal/sentinel/token_policy_test.go
@@ -78,9 +78,9 @@ func TestPolicyFromCLI(t *testing.T) {
 	t.Run("legacy + specs combined", func(t *testing.T) {
 		p, err := PolicyFromCLI("legacy", []string{"lab-only=lab"})
 		require.NoError(t, err)
-		assert.NoError(t, p.Validate("legacy", "prod"))   // wildcard
-		assert.NoError(t, p.Validate("lab-only", "lab"))  // restricted
-		assert.Error(t, p.Validate("lab-only", "prod"))   // restricted rejects
+		assert.NoError(t, p.Validate("legacy", "prod"))  // wildcard
+		assert.NoError(t, p.Validate("lab-only", "lab")) // restricted
+		assert.Error(t, p.Validate("lab-only", "prod"))  // restricted rejects
 	})
 
 	t.Run("malformed spec", func(t *testing.T) {

--- a/internal/sentinel/tunnel_client.go
+++ b/internal/sentinel/tunnel_client.go
@@ -18,7 +18,7 @@ type TunnelClient struct {
 	Token        string
 	SpotID       string
 	Ports        []int
-	Pool         Pool   // optional pool tag sent in handshake
+	Pool         Pool // optional pool tag sent in handshake
 
 	// When PublicHostname is set, the sentinel auto-registers this tunnel
 	// as the primary for its pool. Saves the daemon from needing direct

--- a/internal/server/app_server_scope_test.go
+++ b/internal/server/app_server_scope_test.go
@@ -50,10 +50,19 @@ func TestAppServer_LifecycleHandlers_RejectMissingScope(t *testing.T) {
 	srv := &AppServer{}
 	ctx := tenantWithScopes("alice", auth.ScopeContainersRead) // read-only
 	cases := map[string]func() error{
-		"StopApp":    func() error { _, e := srv.StopApp(ctx, &pb.StopAppRequest{Username: "alice", AppName: "x"}); return e },
-		"StartApp":   func() error { _, e := srv.StartApp(ctx, &pb.StartAppRequest{Username: "alice", AppName: "x"}); return e },
-		"RestartApp": func() error { _, e := srv.RestartApp(ctx, &pb.RestartAppRequest{Username: "alice", AppName: "x"}); return e },
-		"DeleteApp":  func() error { _, e := srv.DeleteApp(ctx, &pb.DeleteAppRequest{Username: "alice", AppName: "x"}); return e },
+		"StopApp": func() error { _, e := srv.StopApp(ctx, &pb.StopAppRequest{Username: "alice", AppName: "x"}); return e },
+		"StartApp": func() error {
+			_, e := srv.StartApp(ctx, &pb.StartAppRequest{Username: "alice", AppName: "x"})
+			return e
+		},
+		"RestartApp": func() error {
+			_, e := srv.RestartApp(ctx, &pb.RestartAppRequest{Username: "alice", AppName: "x"})
+			return e
+		},
+		"DeleteApp": func() error {
+			_, e := srv.DeleteApp(ctx, &pb.DeleteAppRequest{Username: "alice", AppName: "x"})
+			return e
+		},
 	}
 	for name, call := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -69,7 +78,7 @@ func TestAppServer_Pre17TokensStillWork(t *testing.T) {
 	// backwards compat asserted end-to-end through the
 	// AppServer surface.
 	srv := &AppServer{}
-	defer func() { _ = recover() }() // body may nil-deref past the gate
+	defer func() { _ = recover() }()                         // body may nil-deref past the gate
 	ctx := auth.ContextWithTestSubject(nil, "alice", "user") //nolint:staticcheck // intentional nil parent
 	_, _ = srv.GetApp(ctx, &pb.GetAppRequest{Username: "alice", AppName: "x"})
 }

--- a/internal/server/compose_autostart_server.go
+++ b/internal/server/compose_autostart_server.go
@@ -17,13 +17,13 @@ import (
 // already live as MCP tools + a CLI dispatch inside agent-box.
 //
 // Each handler:
-//   1. validates the request
-//   2. SSH-execs `agent-box compose <verb> [flags]` into the tenant's
-//      LXC via the IncusExecer seam
-//   3. parses the uniform JSON envelope agent-box prints to stdout
-//      ({"ok":bool,"result":...} or {"ok":false,"error":"..."})
-//   4. maps the envelope onto the typed proto response or a gRPC
-//      status error
+//  1. validates the request
+//  2. SSH-execs `agent-box compose <verb> [flags]` into the tenant's
+//     LXC via the IncusExecer seam
+//  3. parses the uniform JSON envelope agent-box prints to stdout
+//     ({"ok":bool,"result":...} or {"ok":false,"error":"..."})
+//  4. maps the envelope onto the typed proto response or a gRPC
+//     status error
 //
 // The IncusExecer interface is the testability seam — production code
 // wires `pkg/core/incus.Client` (which implements ExecWithOutput);

--- a/internal/server/core_otel_collector_test.go
+++ b/internal/server/core_otel_collector_test.go
@@ -102,11 +102,11 @@ func TestBuildOTelCollectorConfig_NoDropLabelsSkipsTransform(t *testing.T) {
 
 func TestRegexEscape_EscapesMetacharacters(t *testing.T) {
 	cases := map[string]string{
-		"plain":      "plain",
-		"a.b":        `a\.b`,
-		"a+b":        `a\+b`,
-		"^anchor$":   `\^anchor\$`,
-		"x[y]":       `x\[y\]`,
+		"plain":       "plain",
+		"a.b":         `a\.b`,
+		"a+b":         `a\+b`,
+		"^anchor$":    `\^anchor\$`,
+		"x[y]":        `x\[y\]`,
 		"backslash\\": `backslash\\`,
 	}
 	for in, want := range cases {

--- a/internal/server/image_allowlist_test.go
+++ b/internal/server/image_allowlist_test.go
@@ -24,15 +24,15 @@ func resetImageAllowlist(t *testing.T) {
 
 func TestImageRegistryPrefix(t *testing.T) {
 	cases := map[string]string{
-		"ubuntu:22.04":                       "ubuntu",
-		"images:ubuntu/22.04/cloud":          "images",
-		"incus:noble":                        "incus",
-		"https://images.example.com/x.img":   "https://images.example.com",
-		"http://internal/foo":                "http://internal",
-		"ubuntu":                             "ubuntu",   // bare name → default remote
-		"22.04":                              "ubuntu",
-		"images/ubuntu/22.04":                "",         // path without remote → no prefix → rejected
-		"":                                   "",
+		"ubuntu:22.04":                     "ubuntu",
+		"images:ubuntu/22.04/cloud":        "images",
+		"incus:noble":                      "incus",
+		"https://images.example.com/x.img": "https://images.example.com",
+		"http://internal/foo":              "http://internal",
+		"ubuntu":                           "ubuntu", // bare name → default remote
+		"22.04":                            "ubuntu",
+		"images/ubuntu/22.04":              "", // path without remote → no prefix → rejected
+		"":                                 "",
 	}
 	for in, want := range cases {
 		t.Run(in, func(t *testing.T) {

--- a/internal/server/image_digest_test.go
+++ b/internal/server/image_digest_test.go
@@ -23,9 +23,9 @@ func TestExtractImageDigest(t *testing.T) {
 		want   string
 		wantOK bool
 	}{
-		"ubuntu:22.04@sha256:abc": {"sha256:abc", true},
-		"ubuntu:22.04":            {"", false},
-		"":                        {"", false},
+		"ubuntu:22.04@sha256:abc":             {"sha256:abc", true},
+		"ubuntu:22.04":                        {"", false},
+		"":                                    {"", false},
 		"images:ubuntu/22.04@sha256:deadbeef": {"sha256:deadbeef", true},
 		// Multi-@ is unusual but the last `@` wins (matches
 		// OCI reference semantics for digest pinning).

--- a/internal/server/move_container.go
+++ b/internal/server/move_container.go
@@ -51,20 +51,20 @@ func migrationDefaults(req *pb.MoveContainerRequest) migrationParams {
 // for the high-level contract; the implementation here is the three-
 // phase orchestration:
 //
-//   Phase 1 — initial full copy (source running)
-//     snapshot sync0 → incus copy <c>/sync0 <remote>:<c> --instance-only
+//	Phase 1 — initial full copy (source running)
+//	  snapshot sync0 → incus copy <c>/sync0 <remote>:<c> --instance-only
 //
-//   Phase 2 — iterative deltas (still running)
-//     for i in 1..max_iterations:
-//         snapshot sync<i> → incus copy --refresh
-//         if elapsed < delta_threshold_seconds: break
+//	Phase 2 — iterative deltas (still running)
+//	  for i in 1..max_iterations:
+//	      snapshot sync<i> → incus copy --refresh
+//	      if elapsed < delta_threshold_seconds: break
 //
-//   Phase 3 — cutover (source down for the final delta)
-//     stop source
-//     snapshot final → incus copy --refresh
-//     adopt-on-target (registers host user, returns new container IP)
-//     update route store: target_ip swap
-//     cascade-cleanup on source (delete LXC, host user, etc.)
+//	Phase 3 — cutover (source down for the final delta)
+//	  stop source
+//	  snapshot final → incus copy --refresh
+//	  adopt-on-target (registers host user, returns new container IP)
+//	  update route store: target_ip swap
+//	  cascade-cleanup on source (delete LXC, host user, etc.)
 //
 // Failure handling:
 //   - any failure before cutover: source container is still running and

--- a/internal/server/move_container_test.go
+++ b/internal/server/move_container_test.go
@@ -16,15 +16,15 @@ import (
 // behavior — those integration concerns live in a separate harness
 // that needs two real VMs.
 type fakeRunner struct {
-	mu             sync.Mutex
-	calls          []string
-	failSnapshot   error
-	failCopyInit   error
+	mu              sync.Mutex
+	calls           []string
+	failSnapshot    error
+	failCopyInit    error
 	failCopyRefresh map[int]error // keyed by call count: first call is 0
-	copyRefreshN   int
-	failStop       error
-	failStart      error
-	hasRemote      bool
+	copyRefreshN    int
+	failStop        error
+	failStart       error
+	hasRemote       bool
 }
 
 func (f *fakeRunner) log(s string) {

--- a/internal/server/network_server.go
+++ b/internal/server/network_server.go
@@ -22,11 +22,11 @@ type NetworkServer struct {
 	proxyManager       *app.ProxyManager
 	passthroughManager *network.PassthroughManager
 	appStore           app.AppStore
-	routeStore         *app.RouteStore            // Source of truth for routes (PostgreSQL)
-	passthroughStore   network.PassthroughStore   // Source of truth for passthrough routes (PostgreSQL)
-	containerNetwork   string                      // e.g., "10.100.0.0/24"
-	proxyIP            string                      // e.g., "10.100.0.1"
-	baseDomain         string                      // e.g., "example.com"
+	routeStore         *app.RouteStore          // Source of truth for routes (PostgreSQL)
+	passthroughStore   network.PassthroughStore // Source of truth for passthrough routes (PostgreSQL)
+	containerNetwork   string                   // e.g., "10.100.0.0/24"
+	proxyIP            string                   // e.g., "10.100.0.1"
+	baseDomain         string                   // e.g., "example.com"
 	emitter            *events.Emitter
 }
 
@@ -191,7 +191,7 @@ func (s *NetworkServer) GetRoutes(ctx context.Context, req *pb.GetRoutesRequest)
 			FullDomain:    route.FullDomain,
 			ContainerIp:   route.UpstreamIP,
 			Port:          int32(route.UpstreamPort), // #nosec G115 -- TCP port, always in [0,65535]
-			Active:        true, // If it's in the list, it's active
+			Active:        true,                      // If it's in the list, it's active
 			Protocol:      routeProtocolToProto(route.Protocol),
 			AppName:       containerName, // legacy: container name doubled as app name for display
 			ContainerName: containerName,

--- a/internal/server/otel_bearer.go
+++ b/internal/server/otel_bearer.go
@@ -63,13 +63,13 @@ var (
 // LoadOrCreateOTelBearer returns the deployment's OTel
 // bearer secret. Search order:
 //
-//   1. `CONTAINARIUM_OTEL_BEARER` env var (raw value)
-//   2. `CONTAINARIUM_OTEL_BEARER_FILE` env var → mode-
-//      checked file with the secret
-//   3. `/etc/containarium/otel.bearer` default path. If
-//      the file exists, perm-checked and read; if not,
-//      generated (mode 0600 owner-only) and persisted so
-//      every subsequent call returns the same value.
+//  1. `CONTAINARIUM_OTEL_BEARER` env var (raw value)
+//  2. `CONTAINARIUM_OTEL_BEARER_FILE` env var → mode-
+//     checked file with the secret
+//  3. `/etc/containarium/otel.bearer` default path. If
+//     the file exists, perm-checked and read; if not,
+//     generated (mode 0600 owner-only) and persisted so
+//     every subsequent call returns the same value.
 //
 // Returns ("", nil) when no source is available AND the
 // daemon can't create the default file (read-only fs,

--- a/internal/server/peer.go
+++ b/internal/server/peer.go
@@ -665,8 +665,8 @@ func (pc *PeerClient) ForwardCreateContainer(authToken string, pbReq *pb.CreateC
 
 	return &pb.CreateContainerResponse{
 		Container: &pb.Container{
-			Name:     data.Container.Name,
-			Username: data.Container.Username,
+			Name:      data.Container.Name,
+			Username:  data.Container.Username,
 			BackendId: pc.ID,
 			Network: &pb.NetworkInfo{
 				IpAddress: data.Container.Network.IPAddress,
@@ -968,13 +968,13 @@ func (a *PeerMetricsFetcherAdapter) FetchPeerMetrics(authToken string) []peerMet
 		// Parse the JSON response — values may be strings or numbers from gRPC-gateway
 		var resp struct {
 			Metrics []struct {
-				Name             string          `json:"name"`
-				CpuUsageSeconds  json.Number     `json:"cpuUsageSeconds"`
-				MemoryUsageBytes json.Number     `json:"memoryUsageBytes"`
-				DiskUsageBytes   json.Number     `json:"diskUsageBytes"`
-				NetworkRxBytes   json.Number     `json:"networkRxBytes"`
-				NetworkTxBytes   json.Number     `json:"networkTxBytes"`
-				ProcessCount     json.Number     `json:"processCount"`
+				Name             string      `json:"name"`
+				CpuUsageSeconds  json.Number `json:"cpuUsageSeconds"`
+				MemoryUsageBytes json.Number `json:"memoryUsageBytes"`
+				DiskUsageBytes   json.Number `json:"diskUsageBytes"`
+				NetworkRxBytes   json.Number `json:"networkRxBytes"`
+				NetworkTxBytes   json.Number `json:"networkTxBytes"`
+				ProcessCount     json.Number `json:"processCount"`
 			} `json:"metrics"`
 		}
 		if err := json.Unmarshal(body, &resp); err != nil {

--- a/internal/server/peer_integration_test.go
+++ b/internal/server/peer_integration_test.go
@@ -32,9 +32,9 @@ type fakeContainer struct {
 }
 
 type fakeSystemInfo struct {
-	Hostname  string  `json:"hostname"`
-	TotalCPUs int     `json:"totalCpus"`
-	TotalMem  int64   `json:"totalMemoryBytes"`
+	Hostname  string    `json:"hostname"`
+	TotalCPUs int       `json:"totalCpus"`
+	TotalMem  int64     `json:"totalMemoryBytes"`
 	GPUs      []fakeGPU `json:"gpus"`
 }
 
@@ -94,12 +94,12 @@ func (fb *fakeBackend) handler() http.Handler {
 			}
 			json.NewDecoder(r.Body).Decode(&req)
 			c := fakeContainer{
-				Name:     req.Username + "-container",
-				Username: req.Username,
-				State:    "CONTAINER_STATE_RUNNING",
+				Name:      req.Username + "-container",
+				Username:  req.Username,
+				State:     "CONTAINER_STATE_RUNNING",
 				Resources: map[string]string{"cpu": "4", "memory": "8GB", "disk": "50GB"},
-				Network:  map[string]string{"ipAddress": "10.0.3.200"},
-				GPU:      req.GPU,
+				Network:   map[string]string{"ipAddress": "10.0.3.200"},
+				GPU:       req.GPU,
 			}
 			fb.mu.Lock()
 			fb.containers = append(fb.containers, c)

--- a/internal/server/pool_placement_test.go
+++ b/internal/server/pool_placement_test.go
@@ -103,11 +103,11 @@ func TestContainerServer_ResolvePool(t *testing.T) {
 		backendID string
 		want      string
 	}{
-		{"", "prod"},                          // empty resolves to local pool
-		{"local-prod", "prod"},                // explicit local ID resolves to local pool
-		{"tunnel-demo-1", "demo"},             // known peer
-		{"tunnel-lab-1", "lab"},               // known peer
-		{"never-registered", ""},              // unknown peer → empty
+		{"", "prod"},              // empty resolves to local pool
+		{"local-prod", "prod"},    // explicit local ID resolves to local pool
+		{"tunnel-demo-1", "demo"}, // known peer
+		{"tunnel-lab-1", "lab"},   // known peer
+		{"never-registered", ""},  // unknown peer → empty
 	}
 	for _, tc := range cases {
 		if got := s.resolvePool(tc.backendID); got != tc.want {

--- a/internal/server/postgres_creds.go
+++ b/internal/server/postgres_creds.go
@@ -41,10 +41,10 @@ const (
 
 // ResolvePostgresURL returns the full DSN to use. Search
 // order:
-//   1. CONTAINARIUM_POSTGRES_URL_FILE (perm-checked file
-//      with a single-line DSN)
-//   2. CONTAINARIUM_POSTGRES_URL (env var)
-//   3. empty string (caller falls back to auto-detect)
+//  1. CONTAINARIUM_POSTGRES_URL_FILE (perm-checked file
+//     with a single-line DSN)
+//  2. CONTAINARIUM_POSTGRES_URL (env var)
+//  3. empty string (caller falls back to auto-detect)
 //
 // An unset / empty result is normal — the daemon's
 // auto-detect path then assembles a DSN from the
@@ -69,10 +69,10 @@ func ResolvePostgresURL() (dsn string, source string, err error) {
 
 // ResolvePostgresPassword returns the password to embed in
 // an auto-assembled DSN. Search order:
-//   1. CONTAINARIUM_POSTGRES_PASSWORD_FILE
-//   2. CONTAINARIUM_POSTGRES_PASSWORD
-//   3. DefaultPostgresPassword (with a WARNING log — the
-//      compiled-in default is dev-only).
+//  1. CONTAINARIUM_POSTGRES_PASSWORD_FILE
+//  2. CONTAINARIUM_POSTGRES_PASSWORD
+//  3. DefaultPostgresPassword (with a WARNING log — the
+//     compiled-in default is dev-only).
 //
 // Returns (password, source) so the caller can log the
 // active source without leaking the password itself.

--- a/internal/server/privileged_policy.go
+++ b/internal/server/privileged_policy.go
@@ -85,18 +85,18 @@ func loadPrivilegedPolicy() PrivilegedPolicy {
 // `enable_podman=true` request should result in a privileged
 // container. Returns:
 //
-//   (true,  nil)       — set EnablePodmanPrivileged=true
-//   (false, nil)       — set EnablePodmanPrivileged=false (Podman
-//                        runs unprivileged; some workloads break,
-//                        but the daemon doesn't return an error)
-//   (false, err)       — reject the CreateContainer call entirely
-//                        with status.Error
+//	(true,  nil)       — set EnablePodmanPrivileged=true
+//	(false, nil)       — set EnablePodmanPrivileged=false (Podman
+//	                     runs unprivileged; some workloads break,
+//	                     but the daemon doesn't return an error)
+//	(false, err)       — reject the CreateContainer call entirely
+//	                     with status.Error
 //
 // The choice between "silently downgrade" and "reject" depends on
 // policy:
 //   - PrivilegedPolicyAll       → (true, nil)
 //   - PrivilegedPolicyAdminOnly → (true, nil) for admin; (false,
-//                                  PermissionDenied) for non-admin
+//     PermissionDenied) for non-admin
 //   - PrivilegedPolicyDisabled  → (false, nil) — downgrade
 func authorizePrivilegedPodman(ctx context.Context) (bool, error) {
 	switch loadPrivilegedPolicy() {

--- a/internal/server/proxy_protocol_trusted_test.go
+++ b/internal/server/proxy_protocol_trusted_test.go
@@ -54,9 +54,9 @@ func TestValidateProxyProtocolTrusted_RejectsMixedWildcard(t *testing.T) {
 func TestValidateProxyProtocolTrusted_RejectsMalformedCIDR(t *testing.T) {
 	cases := []string{
 		"not-a-cidr",
-		"10.0.0.5",       // missing /mask
-		"10.0.0.5/99",    // bad mask
-		"10.0.0.5\\32",   // wrong slash
+		"10.0.0.5",     // missing /mask
+		"10.0.0.5/99",  // bad mask
+		"10.0.0.5\\32", // wrong slash
 	}
 	for _, c := range cases {
 		t.Run(c, func(t *testing.T) {

--- a/internal/server/recipe_server.go
+++ b/internal/server/recipe_server.go
@@ -198,7 +198,7 @@ func buildPostStartScript(recipe *pb.Recipe, params map[string]string) string {
 }
 
 // shellSingleQuote wraps s in single quotes, escaping embedded single quotes
-// the standard POSIX way ('\'' closes, escapes, reopens).
+// the standard POSIX way ('\” closes, escapes, reopens).
 func shellSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/server/secrets_reconciler.go
+++ b/internal/server/secrets_reconciler.go
@@ -56,13 +56,13 @@ const defaultReconcileInterval = 60 * time.Second
 // DualServer alongside the autosleep manager — same
 // shape, same lifetime.
 type secretsReconciler struct {
-	store     *secrets.Store
-	incus     *incus.Client
-	stamp     func(ctx context.Context, username string) (int, error)
-	interval  time.Duration
-	stopCh    chan struct{}
-	done      chan struct{}
-	stopOnce  sync.Once
+	store    *secrets.Store
+	incus    *incus.Client
+	stamp    func(ctx context.Context, username string) (int, error)
+	interval time.Duration
+	stopCh   chan struct{}
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 func newSecretsReconciler(store *secrets.Store, ic *incus.Client, stamp func(ctx context.Context, username string) (int, error), interval time.Duration) *secretsReconciler {

--- a/internal/server/stop_for_autosleep_test.go
+++ b/internal/server/stop_for_autosleep_test.go
@@ -133,8 +133,8 @@ func TestStopForAutoSleep_DoesNotInvokeAuditDirectly(t *testing.T) {
 // when their tracked method is called, so the test can assert the
 // SwapToWake → StopContainer happens-before relationship.
 type recordingWakeRouter struct {
-	seq        *atomic.Int64
-	swapSeqAt  int64
+	seq       *atomic.Int64
+	swapSeqAt int64
 }
 
 func (r *recordingWakeRouter) SwapToWake(_ context.Context, _ string, _ []*app.RouteRecord) error {
@@ -150,8 +150,8 @@ type recordingRouteStore struct{}
 func (recordingRouteStore) ListByContainer(_ context.Context, _ string) ([]*app.RouteRecord, error) {
 	return []*app.RouteRecord{{FullDomain: "alice.example.test", TargetIP: "10.0.0.5", TargetPort: 8080}}, nil
 }
-func (recordingRouteStore) Delete(context.Context, string) error            { return nil }
-func (recordingRouteStore) Save(context.Context, *app.RouteRecord) error    { return nil }
+func (recordingRouteStore) Delete(context.Context, string) error         { return nil }
+func (recordingRouteStore) Save(context.Context, *app.RouteRecord) error { return nil }
 
 // TestStopForAutoSleep_SwapsBeforeStop pins the #224 fix: the Caddy
 // route swap MUST happen before the container is stopped, otherwise
@@ -174,10 +174,10 @@ func TestStopForAutoSleep_SwapsBeforeStop(t *testing.T) {
 
 	wakeRouter := &recordingWakeRouter{seq: &seq}
 	s := &ContainerServer{
-		manager:     container.NewWithBackend(mock),
-		emitter:     events.NewEmitter(events.NewBus()),
-		wakeRouter:  wakeRouter,
-		routeStore:  recordingRouteStore{},
+		manager:    container.NewWithBackend(mock),
+		emitter:    events.NewEmitter(events.NewBus()),
+		wakeRouter: wakeRouter,
+		routeStore: recordingRouteStore{},
 	}
 
 	if err := s.StopForAutoSleep(testCtx(), "alice", "idle 90m", 90); err != nil {

--- a/internal/server/wait_for_ready_test.go
+++ b/internal/server/wait_for_ready_test.go
@@ -187,4 +187,3 @@ func TestWaitForContainerReady_ListByContainerErrors(t *testing.T) {
 		t.Errorf("error path should return immediately, took %v", elapsed)
 	}
 }
-

--- a/internal/server/wake_starter.go
+++ b/internal/server/wake_starter.go
@@ -19,8 +19,8 @@ import (
 // ContainerServer surface — it just sees the narrow interface
 // `wake.WakeStarter`.
 type WakeStarter struct {
-	cs             *ContainerServer
-	readyTimeoutS  int32 // seconds; mirrored into the request
+	cs            *ContainerServer
+	readyTimeoutS int32 // seconds; mirrored into the request
 }
 
 // NewWakeStarter constructs the adapter. readyTimeoutSeconds is the

--- a/internal/traffic/collector.go
+++ b/internal/traffic/collector.go
@@ -187,18 +187,18 @@ func (c *Collector) processConntrackEvent(event *ConntrackEvent) {
 // convertToProto converts a ConntrackEvent to a pb.Connection
 func (c *Collector) convertToProto(event *ConntrackEvent, containerName, containerIP string, direction pb.TrafficDirection) *pb.Connection {
 	conn := &pb.Connection{
-		Id:            event.ID,
-		ContainerName: containerName,
-		ContainerIp:   containerIP,
-		Protocol:      protoStringToEnum(event.Protocol),
-		SourceIp:      event.SrcIP,
-		SourcePort:    uint32(event.SrcPort),
-		DestIp:        event.DstIP,
-		DestPort:      uint32(event.DstPort),
-		State:         stateStringToEnum(event.State),
-		Direction:     direction,
-		FirstSeen:     timestamppb.New(event.Timestamp),
-		LastSeen:      timestamppb.New(event.Timestamp),
+		Id:             event.ID,
+		ContainerName:  containerName,
+		ContainerIp:    containerIP,
+		Protocol:       protoStringToEnum(event.Protocol),
+		SourceIp:       event.SrcIP,
+		SourcePort:     uint32(event.SrcPort),
+		DestIp:         event.DstIP,
+		DestPort:       uint32(event.DstPort),
+		State:          stateStringToEnum(event.State),
+		Direction:      direction,
+		FirstSeen:      timestamppb.New(event.Timestamp),
+		LastSeen:       timestamppb.New(event.Timestamp),
 		TimeoutSeconds: event.Timeout,
 	}
 

--- a/internal/transfer/manifest_test.go
+++ b/internal/transfer/manifest_test.go
@@ -77,8 +77,8 @@ func TestParseRemoteManifest_Roundtrip(t *testing.T) {
 	in := strings.NewReader(strings.Join([]string{
 		"a1b2 644 hello.txt",
 		"c3d4 755 bin/run.sh",
-		"",                          // blank line — skip
-		"malformed-line-no-spaces",  // skip
+		"",                         // blank line — skip
+		"malformed-line-no-spaces", // skip
 		"e5f6 600 with spaces/in/path.txt",
 	}, "\n"))
 

--- a/internal/transfer/push.go
+++ b/internal/transfer/push.go
@@ -45,7 +45,7 @@ type PushResult struct {
 	PreviousHead  string // sha that was at remote tip before this push; "" on first push
 	RemoteURL     string // ssh-style URL we pushed to, for the caller's records
 	WIPCommitMade bool
-	SetupRan      bool // true if we provisioned/refreshed the bare repo + hook this call
+	SetupRan      bool   // true if we provisioned/refreshed the bare repo + hook this call
 	DeployCmd     string // echoed back so callers can audit
 }
 

--- a/internal/wake/proxy.go
+++ b/internal/wake/proxy.go
@@ -52,7 +52,7 @@ type AuditLogger interface {
 type WakeProxy struct {
 	starter     WakeStarter
 	routeLookup RouteLookup
-	router      *Router // for fire-and-forget SwapToDirect after success
+	router      *Router    // for fire-and-forget SwapToDirect after success
 	routeStore  RouteStore // for fetching routes to pass to SwapToDirect
 	audit       AuditLogger
 	waitTimeout time.Duration

--- a/internal/wake/proxy_edge_test.go
+++ b/internal/wake/proxy_edge_test.go
@@ -22,12 +22,12 @@ import (
 // invocation atomically. The configured response is returned for every
 // call.
 type countingStarter struct {
-	calls    atomic.Int64
-	delay    time.Duration
-	ready    bool
-	ip       string
-	port     int
-	err      error
+	calls atomic.Int64
+	delay time.Duration
+	ready bool
+	ip    string
+	port  int
+	err   error
 }
 
 func (c *countingStarter) WakeForRequest(ctx context.Context, username string) (bool, string, int, error) {

--- a/internal/wake/router_test.go
+++ b/internal/wake/router_test.go
@@ -13,11 +13,11 @@ import (
 // in order and optionally returns a pre-canned error from updateErr (or
 // grpcUpdateErr) on each invocation.
 type fakeProxyManager struct {
-	mu             sync.Mutex
-	updateCalls    []proxyCall
-	grpcCalls      []proxyCall
-	updateErr      error // returned by UpdateRoute
-	grpcUpdateErr  error // returned by UpdateGRPCRoute
+	mu            sync.Mutex
+	updateCalls   []proxyCall
+	grpcCalls     []proxyCall
+	updateErr     error // returned by UpdateRoute
+	grpcUpdateErr error // returned by UpdateGRPCRoute
 }
 
 type proxyCall struct {

--- a/internal/wake/trusted_proxies_test.go
+++ b/internal/wake/trusted_proxies_test.go
@@ -138,11 +138,11 @@ func TestIsTrustedSource_AllowlistMatches(t *testing.T) {
 		netip.MustParsePrefix("192.168.1.5/32"),
 	}
 	cases := map[string]bool{
-		"10.0.0.5:1234":      true,
-		"10.255.255.255:80":  true,
-		"192.168.1.5:1234":   true,
-		"192.168.1.6:1234":   false,
-		"203.0.113.5:1234":   false,
+		"10.0.0.5:1234":     true,
+		"10.255.255.255:80": true,
+		"192.168.1.5:1234":  true,
+		"192.168.1.6:1234":  false,
+		"203.0.113.5:1234":  false,
 	}
 	for rem, want := range cases {
 		t.Run(rem, func(t *testing.T) {

--- a/pkg/core/container/authorized_keys_test.go
+++ b/pkg/core/container/authorized_keys_test.go
@@ -25,6 +25,7 @@ func withTestHomeRoot(t *testing.T, homeRoot string, userExistsFn func(string) b
 
 const validTestKey1 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBZkMdKTk8EXlTr5tlsIfAvlCi2iCl0YB/YDua3uMyDX test1"
 const validTestKey2 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDtmr5hyCwDmlxelT+dTGxmh8SpOObOWJIhoRa61oY2Q test2"
+
 // TestJumpServerAuthorizesAllRequestKeys_470 is the #470 regression.
 //
 // The manager seeds the HOST jump-server authorized_keys with SSHKeys[0]

--- a/pkg/core/container/jump_server.go
+++ b/pkg/core/container/jump_server.go
@@ -741,11 +741,11 @@ func retryUseraddWithLockWait(username string, verbose bool) error {
 	// Retry useradd with flock for serialization
 	var lastErr error
 	var lastOutput string // Captured stdout/stderr of the last useradd
-	                       // attempt — surfaced in the final error when
-	                       // all retries exhaust. Without this, callers
-	                       // see only "exit status 1", which is actively
-	                       // misleading when the real cause was e.g.
-	                       // /etc/passwd locked by another process.
+	// attempt — surfaced in the final error when
+	// all retries exhaust. Without this, callers
+	// see only "exit status 1", which is actively
+	// misleading when the real cause was e.g.
+	// /etc/passwd locked by another process.
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
 			// Cloud #163 — exponential backoff with jitter so concurrent
@@ -789,9 +789,9 @@ func retryUseraddWithLockWait(username string, verbose bool) error {
 		cmd := exec.Command("flock", "-w", "30", "/var/lock/containarium-useradd.lock",
 			"useradd", username,
 			"-s", shell, // nologin (ProxyJump) or containarium-shell (exec into container)
-			"-m",                      // Create home directory
-			"-K", "SUB_UID_COUNT=0",   // Don't allocate subordinate UIDs
-			"-K", "SUB_GID_COUNT=0",   // Don't allocate subordinate GIDs
+			"-m",                    // Create home directory
+			"-K", "SUB_UID_COUNT=0", // Don't allocate subordinate UIDs
+			"-K", "SUB_GID_COUNT=0", // Don't allocate subordinate GIDs
 			"-c", fmt.Sprintf("Containarium user - %s", username))
 
 		output, err := cmd.CombinedOutput()

--- a/pkg/core/container/jump_server_test.go
+++ b/pkg/core/container/jump_server_test.go
@@ -127,10 +127,10 @@ func TestUserExists(t *testing.T) {
 
 func TestParseSSHKeyFromAuthorizedKeys(t *testing.T) {
 	tests := []struct {
-		name           string
-		content        string
-		wantKey        string
-		wantErr        bool
+		name    string
+		content string
+		wantKey string
+		wantErr bool
 	}{
 		{
 			name:    "single RSA key",

--- a/pkg/core/container/security_test.go
+++ b/pkg/core/container/security_test.go
@@ -173,11 +173,11 @@ func TestUsernameValidationSecurityBoundary(t *testing.T) {
 		'$',  // dollar sign
 		'(',  // parenthesis
 		')',
-		'{',  // braces
+		'{', // braces
 		'}',
-		'[',  // brackets
+		'[', // brackets
 		']',
-		'<',  // redirects
+		'<', // redirects
 		'>',
 		'|',  // pipe
 		'&',  // ampersand

--- a/pkg/core/expose/expose.go
+++ b/pkg/core/expose/expose.go
@@ -90,8 +90,8 @@ func Run(ctx context.Context, c APIClient, opts Options) (*RouteResult, error) {
 		return nil, fmt.Errorf("container %q has no IP address yet (state: %s)", opts.Username, state)
 	}
 	res, err := c.CreateRoute(ctx, AddRouteParams{
-		Domain:        opts.Domain,
-		TargetIP:      ip,
+		Domain:   opts.Domain,
+		TargetIP: ip,
 		// #nosec G115 -- Options.Validate above bounds ContainerPort to
 		// 1..65535, well within int32 range.
 		TargetPort:    int32(opts.ContainerPort),

--- a/pkg/core/incus/incustest/mock.go
+++ b/pkg/core/incus/incustest/mock.go
@@ -23,31 +23,31 @@ type MockBackend struct {
 
 	// Override hooks. If non-nil, the method delegates to the function and
 	// the default behavior is skipped.
-	CreateContainerFunc      func(config incus.ContainerConfig) error
-	StartContainerFunc       func(name string) error
-	StopContainerFunc        func(name string, force bool) error
-	DeleteContainerFunc      func(name string) error
-	GetContainerFunc         func(name string) (*incus.ContainerInfo, error)
-	ListContainersFunc       func() ([]incus.ContainerInfo, error)
-	WaitForNetworkFunc       func(containerName string, timeout time.Duration) (string, error)
-	ExecFunc                 func(containerName string, command []string) error
-	ExecWithOutputFunc       func(containerName string, command []string) (string, string, error)
-	WriteFileFunc            func(containerName, path string, content []byte, mode string) error
-	ReadFileFunc             func(containerName, path string) ([]byte, error)
-	SetConfigFunc            func(containerName, key, value string) error
-	SetCPULimitFunc          func(containerName, cpu string) error
-	UnsetConfigFunc          func(containerName, key string) error
-	SetDeviceSizeFunc        func(containerName, deviceName, size string) error
-	ResolveGPUInputToPCIFunc func(input string) (string, error)
-	CleanupDiskFunc          func(containerName string) (string, int64, error)
+	CreateContainerFunc       func(config incus.ContainerConfig) error
+	StartContainerFunc        func(name string) error
+	StopContainerFunc         func(name string, force bool) error
+	DeleteContainerFunc       func(name string) error
+	GetContainerFunc          func(name string) (*incus.ContainerInfo, error)
+	ListContainersFunc        func() ([]incus.ContainerInfo, error)
+	WaitForNetworkFunc        func(containerName string, timeout time.Duration) (string, error)
+	ExecFunc                  func(containerName string, command []string) error
+	ExecWithOutputFunc        func(containerName string, command []string) (string, string, error)
+	WriteFileFunc             func(containerName, path string, content []byte, mode string) error
+	ReadFileFunc              func(containerName, path string) ([]byte, error)
+	SetConfigFunc             func(containerName, key, value string) error
+	SetCPULimitFunc           func(containerName, cpu string) error
+	UnsetConfigFunc           func(containerName, key string) error
+	SetDeviceSizeFunc         func(containerName, deviceName, size string) error
+	ResolveGPUInputToPCIFunc  func(input string) (string, error)
+	CleanupDiskFunc           func(containerName string) (string, int64, error)
 	UpdateContainerConfigFunc func(name, key, value string) error
-	GetRawInstanceFunc       func(name string) (map[string]string, string, error)
-	AddLabelFunc             func(containerName, key, value string) error
-	RemoveLabelFunc          func(containerName, key string) error
-	GetLabelsFunc            func(containerName string) (map[string]string, error)
-	SetLabelsFunc            func(containerName string, labels map[string]string) error
-	GetServerInfoFunc        func() (*api.Server, error)
-	GetContainerMetricsFunc  func(name string) (*incus.ContainerMetrics, error)
+	GetRawInstanceFunc        func(name string) (map[string]string, string, error)
+	AddLabelFunc              func(containerName, key, value string) error
+	RemoveLabelFunc           func(containerName, key string) error
+	GetLabelsFunc             func(containerName string) (map[string]string, error)
+	SetLabelsFunc             func(containerName string, labels map[string]string) error
+	GetServerInfoFunc         func() (*api.Server, error)
+	GetContainerMetricsFunc   func(name string) (*incus.ContainerMetrics, error)
 
 	// Phase 3.1 Phase-C — post-pull fingerprint check.
 	GetContainerImageFingerprintFunc func(name string) (string, error)

--- a/pkg/core/incus/labels_test.go
+++ b/pkg/core/incus/labels_test.go
@@ -26,7 +26,7 @@ func TestExtractLabelsFromConfig(t *testing.T) {
 		{
 			name: "config with single label",
 			config: map[string]string{
-				"limits.cpu":            "4",
+				"limits.cpu":                   "4",
 				"user.containarium.label.team": "backend",
 			},
 			wantLabels: map[string]string{
@@ -36,11 +36,11 @@ func TestExtractLabelsFromConfig(t *testing.T) {
 		{
 			name: "config with multiple labels",
 			config: map[string]string{
-				"limits.cpu":                "4",
-				"user.containarium.label.team":     "backend",
-				"user.containarium.label.project":  "api",
-				"user.containarium.label.env":      "production",
-				"user.containarium.label.owner":    "alice",
+				"limits.cpu":                      "4",
+				"user.containarium.label.team":    "backend",
+				"user.containarium.label.project": "api",
+				"user.containarium.label.env":     "production",
+				"user.containarium.label.owner":   "alice",
 			},
 			wantLabels: map[string]string{
 				"team":    "backend",
@@ -73,7 +73,7 @@ func TestExtractLabelsFromConfig(t *testing.T) {
 			name: "similar prefix but not a label",
 			config: map[string]string{
 				"containarium.labels":          "not a label",
-				"user.containarium.label.real":      "label",
+				"user.containarium.label.real": "label",
 				"containarium.labelconfig":     "also not a label",
 			},
 			wantLabels: map[string]string{
@@ -205,9 +205,9 @@ func TestLabelPrefix(t *testing.T) {
 // Benchmark tests
 func BenchmarkExtractLabelsFromConfig(b *testing.B) {
 	config := map[string]string{
-		"limits.cpu":               "4",
-		"limits.memory":            "8GB",
-		"security.nesting":         "true",
+		"limits.cpu":                      "4",
+		"limits.memory":                   "8GB",
+		"security.nesting":                "true",
 		"user.containarium.label.team":    "backend",
 		"user.containarium.label.project": "api",
 		"user.containarium.label.env":     "production",

--- a/pkg/core/incus/streams.go
+++ b/pkg/core/incus/streams.go
@@ -98,8 +98,8 @@ type StreamsResolver struct {
 }
 
 type cachedIndex struct {
-	idx        imagesIndex
-	fetchedAt  time.Time
+	idx       imagesIndex
+	fetchedAt time.Time
 }
 
 // defaultCacheTTL is the cache horizon when callers don't
@@ -142,8 +142,8 @@ func NewStreamsResolverWithCacheTTL(timeout, cacheTTL time.Duration) *StreamsRes
 // version → item.sha256) chain. Unknown fields are
 // ignored by encoding/json.
 type imagesIndex struct {
-	Format   string                    `json:"format"`
-	Products map[string]productEntry   `json:"products"`
+	Format   string                  `json:"format"`
+	Products map[string]productEntry `json:"products"`
 }
 
 type productEntry struct {

--- a/pkg/core/incus/streams_test.go
+++ b/pkg/core/incus/streams_test.go
@@ -310,7 +310,7 @@ func TestDigestMatchesSet_RejectsMalformed(t *testing.T) {
 		"sha256:",
 		"short",
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaXX", // too long
-		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagh",  // non-hex
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagh",   // non-hex
 		"md5:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	} {
 		if DigestMatchesSet(bad, pub) {

--- a/pkg/core/network/passthrough_sync.go
+++ b/pkg/core/network/passthrough_sync.go
@@ -10,8 +10,8 @@ import (
 
 // PassthroughSyncJob synchronizes passthrough routes from PostgreSQL (source of truth) to iptables (runtime)
 type PassthroughSyncJob struct {
-	store   PassthroughStore
-	manager *PassthroughManager
+	store    PassthroughStore
+	manager  *PassthroughManager
 	interval time.Duration
 
 	mu      sync.Mutex

--- a/pkg/core/secrets/crypto.go
+++ b/pkg/core/secrets/crypto.go
@@ -53,10 +53,10 @@ var nameRE = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
 
 // Errors callers can match on.
 var (
-	ErrInvalidName     = errors.New("secrets: name must match ^[A-Z_][A-Z0-9_]*$ and be at most 128 chars")
-	ErrValueTooLarge   = errors.New("secrets: value exceeds 64 KiB limit")
-	ErrKeyWrongSize    = errors.New("secrets: master key must be exactly 32 bytes")
-	ErrAuthentication  = errors.New("secrets: ciphertext authentication failed (tampered or wrong key?)")
+	ErrInvalidName    = errors.New("secrets: name must match ^[A-Z_][A-Z0-9_]*$ and be at most 128 chars")
+	ErrValueTooLarge  = errors.New("secrets: value exceeds 64 KiB limit")
+	ErrKeyWrongSize   = errors.New("secrets: master key must be exactly 32 bytes")
+	ErrAuthentication = errors.New("secrets: ciphertext authentication failed (tampered or wrong key?)")
 )
 
 // ValidateName returns nil if the name matches the env-var-compatible

--- a/pkg/core/secrets/crypto_test.go
+++ b/pkg/core/secrets/crypto_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestValidateName(t *testing.T) {
 	cases := []struct {
-		name     string
-		wantErr  bool
-		descr    string
+		name    string
+		wantErr bool
+		descr   string
 	}{
 		{"OPENAI_API_KEY", false, "canonical env-var name"},
 		{"DB_URL", false, "short uppercase"},


### PR DESCRIPTION
Brings the OSS tree gofmt-clean — mirrors the cloud sweep. 89 files had drifted: column alignment, multi-statement-per-line splits (`a(); b()` → two lines), import-block spacing, and Go 1.19 canonical doc-comment list markers.

**Formatting-only, no behavior change** — gofmt preserves semantics by construction. `go build ./...` clean. (The two failing items locally — a `go vet` warning in `test/fixtures/tier2-l4-lifecycle/main.go` and `TestStorageQuotaEnforcement` needing a live daemon on :50051 — both reproduce on clean main and are untouched by this sweep.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)