### PR TITLE
ci: enforce gofmt via a dedicated workflow

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -1,0 +1,47 @@
+name: gofmt
+
+# Enforce gofmt across the Go tree. The repo had drifted (89 files swept
+# clean in #542); this gate keeps it clean so formatting noise never rides
+# along in unrelated diffs again. Deliberately just gofmt — not a full
+# golangci-lint run — so it enforces formatting without pulling in the
+# linter set's pre-existing vet/staticcheck debt (a separate effort).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gofmt:
+    name: gofmt check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.11'
+
+      - name: Check gofmt
+        run: |
+          set -euo pipefail
+          # gofmt -l lists files whose formatting differs from gofmt's.
+          # Empty output = clean. Use the toolchain's gofmt (matches the
+          # pinned Go above) so contributors get identical results locally.
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::These files are not gofmt-clean. Run 'gofmt -w .' and commit:"
+            echo "$unformatted"
+            exit 1
+          fi
+          echo "All Go files are gofmt-clean."


### PR DESCRIPTION
## What

Adds a `gofmt` GitHub Actions workflow that **fails a PR when any Go file isn't gofmt-clean** (`gofmt -l .` non-empty). Keeps the tree clean after the #542 sweep so formatting drift can't silently ride along in unrelated diffs again.

## Scope

Deliberately **gofmt only** — not a full `golangci-lint run`. The OSS repo has no golangci config today, and `default: standard` would surface the linter set's pre-existing vet/staticcheck debt (e.g. the `using resp before checking for errors` vet warning in a test fixture), turning a focused formatting gate into a large cleanup. This is the minimal, on-target enforcement; adding golangci-lint proper can be a separate effort.

## Verified

- Workflow YAML parses.
- The gate's command (`gofmt -l .`) is **empty on current main** (post-#542), so the new check passes — confirmed by a local dry-run on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)