### PR TITLE
chore(security): fix all gosec G115 overflow conversions + gate it in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,17 @@ run:
 # clean baseline holds.
 linters:
   default: standard
+  enable:
+    # gosec, scoped to G115 only (integer-overflow conversions). The rest of
+    # gosec's rules aren't enforced yet — enabling them wholesale would surface
+    # a separate debt. G115 is clean as of the safecast rollout, so gate it to
+    # prevent regressions: new unchecked int conversions must go through
+    # internal/safecast (or carry a justified //nolint:gosec).
+    - gosec
   settings:
+    gosec:
+      includes:
+        - G115
     errcheck:
       # Conventionally-unchecked stdlib calls. Their errors are not actionable
       # in the contexts we use them (deferred cleanup, best-effort writes to an

--- a/cmd/ebpf-phaseA/main.go
+++ b/cmd/ebpf-phaseA/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/ebpf/perf"
 
 	"github.com/footprintai/containarium/internal/netbpf"
+	"github.com/footprintai/containarium/internal/safecast"
 )
 
 type cidrList []string
@@ -62,7 +63,7 @@ func main() {
 	if *veth == "" {
 		log.Fatal("phase A validator: --veth is required")
 	}
-	if err := run(*obj, *veth, uint32(*tenant), *allowIntra, allow, *peerIP, uint32(*peerTenant), *every); err != nil {
+	if err := run(*obj, *veth, safecast.U32FromUint(*tenant), *allowIntra, allow, *peerIP, safecast.U32FromUint(*peerTenant), *every); err != nil {
 		log.Fatalf("phase A validator: %v", err)
 	}
 }
@@ -98,7 +99,7 @@ func run(objPath, veth string, tenant uint32, allowIntra bool, allow cidrList, p
 		}
 		p = p.Masked()
 		if err := loader.AddEgress(netbpf.EgressEntry{
-			PrefixLen: 32 + uint32(p.Bits()),
+			PrefixLen: 32 + safecast.U32(p.Bits()),
 			TenantID:  tenant,
 			Addr:      p.Addr().As4(),
 		}); err != nil {

--- a/internal/cmd/scale_down.go
+++ b/internal/cmd/scale_down.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/footprintai/containarium/internal/client"
+	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/spf13/cobra"
@@ -82,7 +83,7 @@ func parseIdleMinutes(s string) (int32, error) {
 	if d < time.Minute {
 		return 0, fmt.Errorf("idle duration must be at least 1 minute, got %s", s)
 	}
-	mins := int32(d / time.Minute)
+	mins := safecast.I32(d / time.Minute)
 	if mins < 1 {
 		mins = 1
 	}

--- a/internal/collaborator/store.go
+++ b/internal/collaborator/store.go
@@ -9,6 +9,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/footprintai/containarium/internal/safecast"
 )
 
 var (
@@ -283,7 +285,7 @@ func (s *Store) Count(ctx context.Context, containerName string) (int32, error) 
 		return 0, fmt.Errorf("failed to count collaborators: %w", err)
 	}
 
-	return int32(count), nil
+	return safecast.I32(count), nil
 }
 
 // scanCollaborators is a helper to scan rows into Collaborator structs

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/pkg/core/expose"
 )
 
@@ -1519,7 +1520,7 @@ func handleToggleAutoSleep(client *Client, args map[string]interface{}) (string,
 	}
 	idle := int32(0)
 	if n, ok := getIntArg(args, "idleThresholdMinutes"); ok {
-		idle = int32(n)
+		idle = safecast.I32(n)
 	}
 
 	resp, err := client.ToggleAutoSleep(username, enabled, idle)

--- a/internal/netbpf/policymap.go
+++ b/internal/netbpf/policymap.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/footprintai/containarium/internal/netpolicy"
+	"github.com/footprintai/containarium/internal/safecast"
 )
 
 // BPF mode constants — mirror the #defines in
@@ -44,7 +45,7 @@ const tenantPrefixBits = 32
 // caller-assigned tenant ID. Tenant ID assignment (registry vs. hash) is a
 // daemon concern resolved at the call site, so this layer takes it explicitly.
 func CompileConfig(tenantID uint32, c netpolicy.CompiledPolicy) PolicyConfig {
-	mode := uint8(c.Mode) // pb enum values match the C #defines (LOG_ONLY=1, ENFORCE=2)
+	mode := safecast.U8(c.Mode) // pb enum values match the C #defines (LOG_ONLY=1, ENFORCE=2)
 	if mode != ModeLogOnly && mode != ModeEnforce {
 		mode = ModeLogOnly // CompiledPolicy already resolves UNSPECIFIED→LOG_ONLY; belt-and-suspenders
 	}
@@ -73,7 +74,7 @@ func CompileEgress(tenantID uint32, c netpolicy.CompiledPolicy) ([]EgressEntry, 
 			return nil, fmt.Errorf("netbpf: egress CIDR %s is not IPv4 (Phase A is IPv4-only)", p)
 		}
 		entry := EgressEntry{
-			PrefixLen: tenantPrefixBits + uint32(p.Bits()),
+			PrefixLen: tenantPrefixBits + safecast.U32(p.Bits()),
 			TenantID:  tenantID,
 			Addr:      p.Addr().As4(), // masked network address, network byte order
 		}

--- a/internal/safecast/safecast.go
+++ b/internal/safecast/safecast.go
@@ -1,0 +1,84 @@
+// Package safecast provides overflow-safe integer conversions.
+//
+// Each converter SATURATES (clamps) at the destination type's bounds instead
+// of silently wrapping, so a value that doesn't fit yields the nearest
+// representable value rather than a corrupted one. This addresses gosec G115
+// (integer overflow conversion) at the call sites in a single, tested place
+// rather than scattering bounds checks or suppressions across the tree.
+//
+// Use these wherever a wider/signed-mismatched value flows into a narrower or
+// differently-signed type — counts/lengths into proto int32 fields, byte sizes
+// from an unsigned source into int64, ports between int32 and uint32, etc. The
+// inputs in this codebase are almost always already in range; the clamp is a
+// safety net that turns a theoretical wrap into a benign saturation.
+package safecast
+
+import "math"
+
+// I32 converts a signed integer to int32, clamping to [MinInt32, MaxInt32].
+func I32[T ~int | ~int64](v T) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v)
+}
+
+// I64FromU64 converts uint64 to int64, clamping at MaxInt64.
+func I64FromU64(v uint64) int64 {
+	if v > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(v)
+}
+
+// U32 converts a signed integer to uint32, clamping to [0, MaxUint32].
+func U32[T ~int | ~int32 | ~int64](v T) uint32 {
+	if v < 0 {
+		return 0
+	}
+	if uint64(v) > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v)
+}
+
+// I16 converts a signed integer to int16, clamping to [MinInt16, MaxInt16].
+func I16[T ~int | ~int32 | ~int64](v T) int16 {
+	if v > math.MaxInt16 {
+		return math.MaxInt16
+	}
+	if v < math.MinInt16 {
+		return math.MinInt16
+	}
+	return int16(v)
+}
+
+// I32FromU32 converts uint32 to int32, clamping at MaxInt32.
+func I32FromU32(v uint32) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(v)
+}
+
+// U32FromUint converts an unsigned integer to uint32, clamping at MaxUint32.
+func U32FromUint[T ~uint | ~uint64](v T) uint32 {
+	if v > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v)
+}
+
+// U8 converts a signed integer to uint8, clamping to [0, 255].
+func U8[T ~int | ~int32 | ~int64](v T) uint8 {
+	if v < 0 {
+		return 0
+	}
+	if v > math.MaxUint8 {
+		return math.MaxUint8
+	}
+	return uint8(v)
+}

--- a/internal/safecast/safecast_test.go
+++ b/internal/safecast/safecast_test.go
@@ -1,0 +1,123 @@
+package safecast
+
+import (
+	"math"
+	"testing"
+)
+
+func TestI32(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want int32
+	}{
+		{0, 0},
+		{42, 42},
+		{-42, -42},
+		{math.MaxInt32, math.MaxInt32},
+		{math.MinInt32, math.MinInt32},
+		{math.MaxInt32 + 1, math.MaxInt32}, // saturate high
+		{math.MinInt32 - 1, math.MinInt32}, // saturate low
+		{math.MaxInt64, math.MaxInt32},
+		{math.MinInt64, math.MinInt32},
+	}
+	for _, c := range cases {
+		if got := I32(c.in); got != c.want {
+			t.Errorf("I32(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestI64FromU64(t *testing.T) {
+	cases := []struct {
+		in   uint64
+		want int64
+	}{
+		{0, 0},
+		{42, 42},
+		{math.MaxInt64, math.MaxInt64},
+		{math.MaxInt64 + 1, math.MaxInt64}, // saturate
+		{math.MaxUint64, math.MaxInt64},
+	}
+	for _, c := range cases {
+		if got := I64FromU64(c.in); got != c.want {
+			t.Errorf("I64FromU64(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestU32(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want uint32
+	}{
+		{0, 0},
+		{42, 42},
+		{-1, 0}, // negative clamps to 0
+		{math.MinInt64, 0},
+		{math.MaxUint32, math.MaxUint32},
+		{math.MaxUint32 + 1, math.MaxUint32}, // saturate
+		{math.MaxInt64, math.MaxUint32},
+	}
+	for _, c := range cases {
+		if got := U32(c.in); got != c.want {
+			t.Errorf("U32(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestU32FromUint(t *testing.T) {
+	if got := U32FromUint(uint(42)); got != 42 {
+		t.Errorf("U32FromUint(42) = %d, want 42", got)
+	}
+	if got := U32FromUint(uint64(math.MaxUint32) + 1); got != math.MaxUint32 {
+		t.Errorf("U32FromUint(MaxUint32+1) = %d, want MaxUint32", got)
+	}
+}
+
+func TestI16(t *testing.T) {
+	cases := []struct {
+		in   int32
+		want int16
+	}{
+		{0, 0},
+		{42, 42},
+		{-42, -42},
+		{math.MaxInt16, math.MaxInt16},
+		{math.MinInt16, math.MinInt16},
+		{math.MaxInt16 + 1, math.MaxInt16},
+		{math.MinInt16 - 1, math.MinInt16},
+	}
+	for _, c := range cases {
+		if got := I16(c.in); got != c.want {
+			t.Errorf("I16(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestI32FromU32(t *testing.T) {
+	if got := I32FromU32(42); got != 42 {
+		t.Errorf("I32FromU32(42) = %d, want 42", got)
+	}
+	if got := I32FromU32(math.MaxUint32); got != math.MaxInt32 {
+		t.Errorf("I32FromU32(MaxUint32) = %d, want MaxInt32", got)
+	}
+}
+
+func TestU8(t *testing.T) {
+	cases := []struct {
+		in   int32
+		want uint8
+	}{
+		{0, 0},
+		{200, 200},
+		{255, 255},
+		{-1, 0},    // negative clamps to 0
+		{256, 255}, // saturate
+		{1000, 255},
+	}
+	for _, c := range cases {
+		if got := U8(c.in); got != c.want {
+			t.Errorf("U8(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/sentinel/tunnel_integration_test.go
+++ b/internal/sentinel/tunnel_integration_test.go
@@ -145,7 +145,7 @@ func TestTunnelIntegration(t *testing.T) {
 		defer func() { _ = stream.Close() }()
 
 		// Send port header
-		portBytes := []byte{byte(spotDaemonPort >> 8), byte(spotDaemonPort & 0xff)}
+		portBytes := []byte{byte((spotDaemonPort >> 8) & 0xff), byte(spotDaemonPort & 0xff)}
 		_, err = stream.Write(portBytes)
 		require.NoError(t, err)
 
@@ -174,7 +174,7 @@ func TestTunnelIntegration(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { _ = stream.Close() }()
 
-		portBytes := []byte{byte(spotDaemonPort >> 8), byte(spotDaemonPort & 0xff)}
+		portBytes := []byte{byte((spotDaemonPort >> 8) & 0xff), byte(spotDaemonPort & 0xff)}
 		_, err = stream.Write(portBytes)
 		require.NoError(t, err)
 

--- a/internal/sentinel/tunnel_registry.go
+++ b/internal/sentinel/tunnel_registry.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/hashicorp/yamux"
 )
 
@@ -176,7 +177,7 @@ func (r *TunnelRegistry) DialTunnel(spotID string, port int) (net.Conn, error) {
 	}
 	// Wire protocol: 2-byte big-endian port number, then bidirectional copy.
 	// Same handshake the existing proxyConnection() uses on the loopback path.
-	portBytes := []byte{byte(port >> 8), byte(port & 0xff)}
+	portBytes := []byte{byte((port >> 8) & 0xff), byte(port & 0xff)}
 	if _, err := stream.Write(portBytes); err != nil {
 		_ = stream.Close()
 		return nil, fmt.Errorf("write port header to spot %q: %w", spotID, err)
@@ -247,7 +248,7 @@ func (r *TunnelRegistry) allocateOctet(spotID string) (byte, error) {
 		// wrapping if we run off the top.
 		candidate := preferred + i
 		if candidate < 2 || candidate > 254 {
-			candidate = byte(2 + (int(preferred)+int(i)-2)%253)
+			candidate = safecast.U8(2 + (int(preferred)+int(i)-2)%253)
 		}
 		if _, used := r.usedIPs[candidate]; !used {
 			r.usedIPs[candidate] = spotID

--- a/internal/sentinel/tunnel_server.go
+++ b/internal/sentinel/tunnel_server.go
@@ -272,7 +272,7 @@ func (ts *TunnelServer) proxyConnection(localConn net.Conn, port int, session *y
 	defer func() { _ = stream.Close() }()
 
 	// Send the target port as a 2-byte big-endian header
-	portBytes := []byte{byte(port >> 8), byte(port & 0xff)}
+	portBytes := []byte{byte((port >> 8) & 0xff), byte(port & 0xff)}
 	if _, err := stream.Write(portBytes); err != nil {
 		log.Printf("[tunnel-server] failed to write port header to spot %s: %v", spotID, err)
 		return

--- a/internal/server/alert_server.go
+++ b/internal/server/alert_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/footprintai/containarium/internal/alert"
 	"github.com/footprintai/containarium/internal/app"
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/safecast"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -279,7 +280,7 @@ func (s *ContainerServer) GetAlertingInfo(ctx context.Context, req *pb.GetAlerti
 	// Count rules
 	rules, err := s.alertStore.List(ctx)
 	if err == nil {
-		resp.CustomRules = int32(len(rules))
+		resp.CustomRules = safecast.I32(len(rules))
 	}
 	// Default rules count is static (9 rules in default.yml)
 	resp.TotalRules = 9 + resp.CustomRules
@@ -581,7 +582,7 @@ func (s *ContainerServer) TestWebhook(ctx context.Context, req *pb.TestWebhookRe
 
 	return &pb.TestWebhookResponse{
 		Success:    success,
-		StatusCode: int32(resp.StatusCode),
+		StatusCode: safecast.I32(resp.StatusCode),
 		Message:    msg,
 	}, nil
 }
@@ -637,16 +638,16 @@ func (s *ContainerServer) ListWebhookDeliveries(ctx context.Context, req *pb.Lis
 			Source:       d.Source,
 			WebhookUrl:   d.WebhookURL,
 			Success:      d.Success,
-			HttpStatus:   int32(d.HTTPStatus),
+			HttpStatus:   safecast.I32(d.HTTPStatus),
 			ErrorMessage: d.ErrorMessage,
-			PayloadSize:  int32(d.PayloadSize),
-			DurationMs:   int32(d.DurationMs),
+			PayloadSize:  safecast.I32(d.PayloadSize),
+			DurationMs:   safecast.I32(d.DurationMs),
 		}
 	}
 
 	return &pb.ListWebhookDeliveriesResponse{
 		Deliveries: pbDeliveries,
-		TotalCount: int32(total),
+		TotalCount: safecast.I32(total),
 	}, nil
 }
 

--- a/internal/server/app_server.go
+++ b/internal/server/app_server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/footprintai/containarium/internal/app"
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/events"
+	"github.com/footprintai/containarium/internal/safecast"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
@@ -101,7 +102,7 @@ func (s *AppServer) ListApps(ctx context.Context, req *pb.ListAppsRequest) (*pb.
 
 	count, err := s.store.Count(ctx, req.Username, req.StateFilter)
 	if err != nil {
-		count = int32(len(apps))
+		count = safecast.I32(len(apps))
 	}
 
 	return &pb.ListAppsResponse{

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/guacamole"
 	"github.com/footprintai/containarium/internal/releasecheck"
+	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/internal/secrets"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
@@ -676,7 +677,7 @@ func (s *ContainerServer) ListContainers(ctx context.Context, req *pb.ListContai
 
 	return &pb.ListContainersResponse{
 		Containers: protoContainers,
-		TotalCount: int32(len(protoContainers)),
+		TotalCount: safecast.I32(len(protoContainers)),
 	}, nil
 }
 
@@ -2776,7 +2777,7 @@ func (s *ContainerServer) ListCollaborators(ctx context.Context, req *pb.ListCol
 
 	return &pb.ListCollaboratorsResponse{
 		Collaborators: protoCollaborators,
-		TotalCount:    int32(len(protoCollaborators)),
+		TotalCount:    safecast.I32(len(protoCollaborators)),
 	}, nil
 }
 

--- a/internal/server/network_server.go
+++ b/internal/server/network_server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/footprintai/containarium/internal/app"
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/events"
+	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/pkg/core/network"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -131,7 +132,7 @@ func (s *NetworkServer) GetRoutes(ctx context.Context, req *pb.GetRoutesRequest)
 
 		return &pb.GetRoutesResponse{
 			Routes:     pbRoutes,
-			TotalCount: int32(len(pbRoutes)),
+			TotalCount: safecast.I32(len(pbRoutes)),
 		}, nil
 	}
 
@@ -201,7 +202,7 @@ func (s *NetworkServer) GetRoutes(ctx context.Context, req *pb.GetRoutesRequest)
 
 	return &pb.GetRoutesResponse{
 		Routes:     pbRoutes,
-		TotalCount: int32(len(pbRoutes)),
+		TotalCount: safecast.I32(len(pbRoutes)),
 	}, nil
 }
 
@@ -500,9 +501,9 @@ func (s *NetworkServer) ListPassthroughRoutes(ctx context.Context, req *pb.ListP
 			}
 
 			pbRoutes = append(pbRoutes, &pb.PassthroughRoute{
-				ExternalPort:  int32(rec.ExternalPort),
+				ExternalPort:  safecast.I32(rec.ExternalPort),
 				TargetIp:      rec.TargetIP,
-				TargetPort:    int32(rec.TargetPort),
+				TargetPort:    safecast.I32(rec.TargetPort),
 				Protocol:      protocol,
 				Active:        rec.Active,
 				ContainerName: containerName,
@@ -512,7 +513,7 @@ func (s *NetworkServer) ListPassthroughRoutes(ctx context.Context, req *pb.ListP
 
 		return &pb.ListPassthroughRoutesResponse{
 			Routes:     pbRoutes,
-			TotalCount: int32(len(pbRoutes)),
+			TotalCount: safecast.I32(len(pbRoutes)),
 		}, nil
 	}
 
@@ -535,9 +536,9 @@ func (s *NetworkServer) ListPassthroughRoutes(ctx context.Context, req *pb.ListP
 		}
 
 		pbRoutes = append(pbRoutes, &pb.PassthroughRoute{
-			ExternalPort:  int32(route.ExternalPort),
+			ExternalPort:  safecast.I32(route.ExternalPort),
 			TargetIp:      route.TargetIP,
-			TargetPort:    int32(route.TargetPort),
+			TargetPort:    safecast.I32(route.TargetPort),
 			Protocol:      protocol,
 			Active:        route.Active,
 			ContainerName: containerName,
@@ -547,7 +548,7 @@ func (s *NetworkServer) ListPassthroughRoutes(ctx context.Context, req *pb.ListP
 
 	return &pb.ListPassthroughRoutesResponse{
 		Routes:     pbRoutes,
-		TotalCount: int32(len(pbRoutes)),
+		TotalCount: safecast.I32(len(pbRoutes)),
 	}, nil
 }
 
@@ -779,7 +780,7 @@ func (s *NetworkServer) ListDNSRecords(ctx context.Context, req *pb.ListDNSRecor
 	return &pb.ListDNSRecordsResponse{
 		Records:    records,
 		BaseDomain: s.baseDomain,
-		TotalCount: int32(len(records)),
+		TotalCount: safecast.I32(len(records)),
 	}, nil
 }
 

--- a/internal/server/pentest_server.go
+++ b/internal/server/pentest_server.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/pentest"
+	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
@@ -81,10 +82,10 @@ func (s *PentestServer) ListPentestScanRuns(ctx context.Context, req *pb.ListPen
 		pbRun := scanRunToProto(&run)
 		if run.Status == "running" {
 			if count, err := s.store.CountFinishedJobs(ctx, run.ID); err == nil {
-				pbRun.CompletedCount = int32(count)
+				pbRun.CompletedCount = safecast.I32(count)
 			}
 		} else {
-			pbRun.CompletedCount = int32(run.TargetsCount)
+			pbRun.CompletedCount = safecast.I32(run.TargetsCount)
 		}
 		pbRuns = append(pbRuns, pbRun)
 	}
@@ -423,12 +424,12 @@ func scanRunToProto(run *pentest.ScanRun) *pb.PentestScanRun {
 		Trigger:       run.Trigger,
 		Status:        run.Status,
 		Modules:       run.Modules,
-		TargetsCount:  int32(run.TargetsCount),
-		CriticalCount: int32(run.CriticalCount),
-		HighCount:     int32(run.HighCount),
-		MediumCount:   int32(run.MediumCount),
-		LowCount:      int32(run.LowCount),
-		InfoCount:     int32(run.InfoCount),
+		TargetsCount:  safecast.I32(run.TargetsCount),
+		CriticalCount: safecast.I32(run.CriticalCount),
+		HighCount:     safecast.I32(run.HighCount),
+		MediumCount:   safecast.I32(run.MediumCount),
+		LowCount:      safecast.I32(run.LowCount),
+		InfoCount:     safecast.I32(run.InfoCount),
 		ErrorMessage:  run.ErrorMessage,
 		StartedAt:     run.StartedAt.Format(time.RFC3339),
 		ContainerName: run.ContainerName,

--- a/internal/server/secrets_server.go
+++ b/internal/server/secrets_server.go
@@ -7,6 +7,7 @@ import (
 	"log"
 
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/internal/secrets"
 	"github.com/footprintai/containarium/pkg/core/container"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -169,7 +170,7 @@ func (s *ContainerServer) RefreshSecrets(ctx context.Context, req *pb.RefreshSec
 	log.Printf("[secrets] refresh %s: stamped=%d", req.Username, stamped)
 	return &pb.RefreshSecretsResponse{
 		Message: fmt.Sprintf("re-stamped %d secret(s) on %s-container; new execs will see updated values", stamped, req.Username),
-		Stamped: int32(stamped),
+		Stamped: safecast.I32(stamped),
 	}, nil
 }
 

--- a/internal/server/toggle_auto_sleep_test.go
+++ b/internal/server/toggle_auto_sleep_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/pkg/core/incus/incustest"
@@ -45,7 +46,7 @@ func newAutoSleepTestServer(t *testing.T, seed map[string]*incus.ContainerInfo) 
 			}
 			if key == incus.IdleThresholdMinutesKey {
 				if n, err := strconv.Atoi(value); err == nil {
-					c.IdleThresholdMinutes = int32(n)
+					c.IdleThresholdMinutes = safecast.I32(n)
 				}
 			}
 		}

--- a/internal/server/traffic_server.go
+++ b/internal/server/traffic_server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/events"
+	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/internal/traffic"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
@@ -82,7 +83,7 @@ func (s *TrafficServer) GetConnections(ctx context.Context, req *pb.GetConnectio
 
 	return &pb.GetConnectionsResponse{
 		Connections: filtered,
-		TotalCount:  int32(totalCount),
+		TotalCount:  safecast.I32(totalCount),
 	}, nil
 }
 

--- a/internal/server/zap_server.go
+++ b/internal/server/zap_server.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/safecast"
 	zapscanner "github.com/footprintai/containarium/internal/zap"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
@@ -75,10 +76,10 @@ func (s *ZapServer) ListZapScanRuns(ctx context.Context, req *pb.ListZapScanRuns
 		pbRun := zapScanRunToProto(&run)
 		if run.Status == "running" {
 			if count, err := s.store.CountFinishedJobs(ctx, run.ID); err == nil {
-				pbRun.CompletedCount = int32(count)
+				pbRun.CompletedCount = safecast.I32(count)
 			}
 		} else {
-			pbRun.CompletedCount = int32(run.TargetsCount)
+			pbRun.CompletedCount = safecast.I32(run.TargetsCount)
 		}
 		pbRuns = append(pbRuns, pbRun)
 	}
@@ -271,11 +272,11 @@ func zapScanRunToProto(run *zapscanner.ScanRun) *pb.ZapScanRun {
 		Id:            run.ID,
 		Trigger:       run.Trigger,
 		Status:        run.Status,
-		TargetsCount:  int32(run.TargetsCount),
-		HighCount:     int32(run.HighCount),
-		MediumCount:   int32(run.MediumCount),
-		LowCount:      int32(run.LowCount),
-		InfoCount:     int32(run.InfoCount),
+		TargetsCount:  safecast.I32(run.TargetsCount),
+		HighCount:     safecast.I32(run.HighCount),
+		MediumCount:   safecast.I32(run.MediumCount),
+		LowCount:      safecast.I32(run.LowCount),
+		InfoCount:     safecast.I32(run.InfoCount),
 		ErrorMessage:  run.ErrorMessage,
 		StartedAt:     run.StartedAt.Format(time.RFC3339),
 		ContainerName: run.ContainerName,

--- a/internal/traffic/collector.go
+++ b/internal/traffic/collector.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/footprintai/containarium/internal/events"
+	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/pkg/core/network"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -359,7 +360,7 @@ func (c *Collector) GetConnectionSummary(containerName string) *pb.ConnectionSum
 
 	summary := &pb.ConnectionSummary{
 		ContainerName:     containerName,
-		ActiveConnections: int32(len(connections)),
+		ActiveConnections: safecast.I32(len(connections)),
 	}
 
 	destCounts := make(map[string]int)
@@ -384,7 +385,7 @@ func (c *Collector) GetConnectionSummary(containerName string) *pb.ConnectionSum
 	for ip, count := range destCounts {
 		summary.TopDestinations = append(summary.TopDestinations, &pb.DestinationStats{
 			DestIp:          ip,
-			ConnectionCount: int32(count),
+			ConnectionCount: safecast.I32(count),
 			BytesTotal:      destBytes[ip],
 		})
 	}

--- a/internal/traffic/conntrack_linux.go
+++ b/internal/traffic/conntrack_linux.go
@@ -10,6 +10,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/footprintai/containarium/internal/safecast"
+
 	"github.com/ti-mo/conntrack"
 	"github.com/ti-mo/netfilter"
 )
@@ -119,12 +121,12 @@ func (m *LinuxConntrackMonitor) processEvent(ev conntrack.Event) {
 
 	// Get byte/packet counters if available
 	if flow.CountersOrig.Bytes > 0 {
-		event.BytesOrig = int64(flow.CountersOrig.Bytes)
-		event.PacketsOrig = int64(flow.CountersOrig.Packets)
+		event.BytesOrig = safecast.I64FromU64(flow.CountersOrig.Bytes)
+		event.PacketsOrig = safecast.I64FromU64(flow.CountersOrig.Packets)
 	}
 	if flow.CountersReply.Bytes > 0 {
-		event.BytesReply = int64(flow.CountersReply.Bytes)
-		event.PacketsReply = int64(flow.CountersReply.Packets)
+		event.BytesReply = safecast.I64FromU64(flow.CountersReply.Bytes)
+		event.PacketsReply = safecast.I64FromU64(flow.CountersReply.Packets)
 	}
 
 	// Get TCP state
@@ -134,7 +136,7 @@ func (m *LinuxConntrackMonitor) processEvent(ev conntrack.Event) {
 
 	// Get timeout
 	if flow.Timeout > 0 {
-		event.Timeout = int32(flow.Timeout)
+		event.Timeout = safecast.I32FromU32(flow.Timeout)
 	}
 
 	// Send event (non-blocking)
@@ -186,11 +188,11 @@ func (m *LinuxConntrackMonitor) Snapshot() ([]*ConntrackEvent, error) {
 			SrcPort:      flow.TupleOrig.Proto.SourcePort,
 			DstIP:        flow.TupleOrig.IP.DestinationAddress.String(),
 			DstPort:      flow.TupleOrig.Proto.DestinationPort,
-			BytesOrig:    int64(flow.CountersOrig.Bytes),
-			BytesReply:   int64(flow.CountersReply.Bytes),
-			PacketsOrig:  int64(flow.CountersOrig.Packets),
-			PacketsReply: int64(flow.CountersReply.Packets),
-			Timeout:      int32(flow.Timeout),
+			BytesOrig:    safecast.I64FromU64(flow.CountersOrig.Bytes),
+			BytesReply:   safecast.I64FromU64(flow.CountersReply.Bytes),
+			PacketsOrig:  safecast.I64FromU64(flow.CountersOrig.Packets),
+			PacketsReply: safecast.I64FromU64(flow.CountersReply.Packets),
+			Timeout:      safecast.I32FromU32(flow.Timeout),
 			Timestamp:    time.Now(),
 		}
 

--- a/internal/traffic/store.go
+++ b/internal/traffic/store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/footprintai/containarium/internal/safecast"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
@@ -140,12 +141,12 @@ func (s *Store) SaveConnection(ctx context.Context, conn *pb.Connection) error {
 
 	_, err := s.pool.Exec(ctx, query,
 		conn.ContainerName,
-		int16(conn.Protocol),
+		safecast.I16(conn.Protocol),
 		conn.SourceIp,
 		conn.SourcePort,
 		conn.DestIp,
 		conn.DestPort,
-		int16(conn.Direction),
+		safecast.I16(conn.Direction),
 		conn.BytesSent,
 		conn.BytesReceived,
 		conn.PacketsSent,
@@ -270,10 +271,10 @@ func (s *Store) QueryConnections(ctx context.Context, params QueryParams) ([]*pb
 		}
 
 		if sourcePort != nil {
-			conn.SourcePort = uint32(*sourcePort)
+			conn.SourcePort = safecast.U32(*sourcePort)
 		}
 		if destPort != nil {
-			conn.DestPort = uint32(*destPort)
+			conn.DestPort = safecast.U32(*destPort)
 		}
 		if endedAt != nil {
 			conn.EndedAt = timestamppb.New(*endedAt)
@@ -374,7 +375,7 @@ func (s *Store) GetAggregates(ctx context.Context, params AggregateParams) ([]*p
 			agg.DestIp = *destIP
 		}
 		if destPort != nil {
-			agg.DestPort = uint32(*destPort)
+			agg.DestPort = safecast.U32(*destPort)
 		}
 
 		aggregates = append(aggregates, agg)
@@ -497,7 +498,7 @@ func (s *Store) SaveAggregate(ctx context.Context, agg *pb.TrafficAggregate, con
 		destIP = &agg.DestIp
 	}
 	if agg.DestPort > 0 {
-		port := int32(agg.DestPort)
+		port := safecast.I32FromU32(agg.DestPort)
 		destPort = &port
 	}
 

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/footprintai/containarium/internal/safecast"
 	incus "github.com/lxc/incus/v6/client"
 	"github.com/lxc/incus/v6/shared/api"
 )
@@ -428,7 +429,7 @@ func parseIdleThresholdMinutes(cfg map[string]string) int32 {
 	if err != nil || n < 1 {
 		return DefaultIdleThresholdMinutes
 	}
-	return int32(n)
+	return safecast.I32(n)
 }
 
 // parseLastStartedAt reads the last-started timestamp from an Incus config
@@ -1200,14 +1201,14 @@ func (c *Client) GetSystemResources() (*SystemResources, error) {
 	}
 
 	res := &SystemResources{
-		TotalMemoryBytes: int64(resources.Memory.Total),
-		UsedMemoryBytes:  int64(resources.Memory.Used),
+		TotalMemoryBytes: safecast.I64FromU64(resources.Memory.Total),
+		UsedMemoryBytes:  safecast.I64FromU64(resources.Memory.Used),
 	}
 
 	// Count total CPU cores
 	for _, socket := range resources.CPU.Sockets {
 		for _, core := range socket.Cores {
-			res.TotalCPUs += int32(len(core.Threads))
+			res.TotalCPUs += safecast.I32(len(core.Threads))
 		}
 	}
 
@@ -1217,8 +1218,8 @@ func (c *Client) GetSystemResources() (*SystemResources, error) {
 		for _, pool := range pools {
 			poolResources, err := c.server.GetStoragePoolResources(pool.Name)
 			if err == nil {
-				res.TotalDiskBytes += int64(poolResources.Space.Total)
-				res.UsedDiskBytes += int64(poolResources.Space.Used)
+				res.TotalDiskBytes += safecast.I64FromU64(poolResources.Space.Total)
+				res.UsedDiskBytes += safecast.I64FromU64(poolResources.Space.Used)
 			}
 		}
 	}
@@ -1512,7 +1513,7 @@ func (c *Client) GetContainerMetrics(name string) (*ContainerMetrics, error) {
 
 	metrics := &ContainerMetrics{
 		Name:         name,
-		ProcessCount: int32(state.Processes),
+		ProcessCount: safecast.I32(state.Processes),
 	}
 
 	// CPU usage (in nanoseconds, convert to seconds)


### PR DESCRIPTION
## What

Eliminates all **74** gosec `G115` (integer-overflow conversion) findings and gates the rule in CI so they can't come back. Follow-up to the golangci-lint standup (#545).

## How

New **`internal/safecast`** package: small, tested helpers (`I32`, `I64FromU64`, `U32`, `U32FromUint`, `I16`, `I32FromU32`, `U8`) that convert between integer widths/signedness by **saturating** at the destination bounds instead of silently wrapping. Generic over `~`-underlying types so proto enums work.

Every flagged conversion is replaced with the matching helper — counts/lengths into proto `int32` fields, byte sizes from unsigned sources (`uint64→int64`), ports (`int32↔uint32`), eBPF prefix lengths, conntrack counters. Bit-extraction framing bytes (`byte(port >> 8)`) are masked (`& 0xff`) rather than clamped, since those are provably in range by construction.

Inputs are virtually always already in range; the clamp is a safety net that turns a theoretical wrap into a benign saturation rather than a corrupted value.

## Gate

`.golangci.yml` enables golangci's `gosec` linter **scoped to G115 only** (`settings.gosec.includes: [G115]`). Baseline is clean, so new unchecked integer conversions now fail the lint job and must go through `safecast` (or carry a justified `//nolint:gosec`). The rest of gosec's rules stay unenforced — wholesale gosec is a separate, larger debt.

## Verified (CI target, GOOS=linux)

- `golangci-lint run` (standard set + gosec/G115) → **0 issues**
- `go build ./...` → clean
- `go test ./...` → green (only the pre-existing infra-dependent `test/integration` suite fails — needs a live daemon on `:50051`)
- `internal/safecast` has table tests covering in-range, boundary, and saturation cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)