### PR TITLE
chore(security): triage gosec — justify intentional findings + fix guarded G109

### DIFF
--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -97,7 +97,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 		// Create parent directory if needed
 		parentDir := filepath.Dir(expandedPath)
-		if err := os.MkdirAll(parentDir, 0755); err != nil {
+		if err := os.MkdirAll(parentDir, 0755); err != nil { //nolint:gosec // G301: user-chosen export dir; 0755 matches mkdir default
 			return fmt.Errorf("failed to create directory %s: %w", parentDir, err)
 		}
 

--- a/internal/gateway/events.go
+++ b/internal/gateway/events.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/footprintai/containarium/internal/events"
+	"github.com/footprintai/containarium/internal/safecast"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
@@ -125,7 +126,7 @@ func parseEventFilter(r *http.Request) *pb.SubscribeEventsRequest {
 	if intervalStr := r.URL.Query().Get("metricsInterval"); intervalStr != "" {
 		if interval, err := strconv.Atoi(intervalStr); err == nil {
 			if interval >= 1 && interval <= 60 {
-				filter.MetricsIntervalSeconds = int32(interval)
+				filter.MetricsIntervalSeconds = safecast.I32(interval)
 			}
 		}
 	}

--- a/internal/hosting/caddy.go
+++ b/internal/hosting/caddy.go
@@ -132,7 +132,7 @@ func (m *CaddyManager) InstallCaddy(ctx context.Context) error {
 	}
 
 	buildDir := "/tmp/caddy-build"
-	if err := os.MkdirAll(buildDir, 0755); err != nil {
+	if err := os.MkdirAll(buildDir, 0755); err != nil { //nolint:gosec // G301: ephemeral build dir, no secrets
 		return fmt.Errorf("create build dir: %w", err)
 	}
 
@@ -148,7 +148,7 @@ func (m *CaddyManager) InstallCaddy(ctx context.Context) error {
 	}
 
 	// Make executable
-	if err := os.Chmod(m.config.CaddyBin, 0755); err != nil {
+	if err := os.Chmod(m.config.CaddyBin, 0755); err != nil { //nolint:gosec // G302: the Caddy binary needs the executable bit (0755)
 		return fmt.Errorf("chmod caddy: %w", err)
 	}
 
@@ -208,7 +208,7 @@ const caddyfileTemplate = `# Caddy configuration for Containarium App Hosting
 func (m *CaddyManager) WriteCaddyfile() error {
 	// Ensure directory exists
 	dir := filepath.Dir(m.config.Caddyfile)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0755); err != nil { //nolint:gosec // G301: standard config dir, not secret-bearing
 		return fmt.Errorf("create caddy config dir: %w", err)
 	}
 

--- a/internal/mtls/certgen.go
+++ b/internal/mtls/certgen.go
@@ -240,7 +240,7 @@ func GenerateWithExistingCA(caPath, caKeyPath string, opts GenerateOptions) erro
 	}
 
 	// Copy CA cert to output directory (not the key for security)
-	if err := os.WriteFile(paths.CACert, caCert, 0644); err != nil {
+	if err := os.WriteFile(paths.CACert, caCert, 0644); err != nil { //nolint:gosec // G306: CA cert is public by design; only the private key is mode-restricted
 		return fmt.Errorf("failed to copy CA cert: %w", err)
 	}
 

--- a/internal/pentest/module_tls.go
+++ b/internal/pentest/module_tls.go
@@ -26,7 +26,11 @@ func (m *TLSModule) Scan(ctx context.Context, target ScanTarget) ([]Finding, err
 
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
 	conn, err := tls.DialWithDialer(dialer, "tcp", addr, &tls.Config{
-		InsecureSkipVerify: true, // We inspect the cert ourselves
+		// #nosec G402 -- this is a TLS-inspection probe: it deliberately skips
+		// verification so it can examine whatever cert the target presents
+		// (expired/self-signed/mismatched) and report on it. Not a transport
+		// trust decision.
+		InsecureSkipVerify: true, //nolint:gosec // G402: see comment above
 	})
 	if err != nil {
 		return nil, nil // TLS not available or unreachable

--- a/pkg/core/network/portforward.go
+++ b/pkg/core/network/portforward.go
@@ -142,7 +142,7 @@ func (pf *PortForwarder) enableRouteLocalnet() error {
 	// Best-effort persistence so the setting survives reboots.
 	const path = "/etc/sysctl.d/99-containarium-route-localnet.conf"
 	const body = "# containarium: required for DNAT of 127.0.0.0/8 (tunneled-primary path)\nnet.ipv4.conf.all.route_localnet = 1\n"
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil { //nolint:gosec // G306: sysctl drop-in must be world-readable for the system to load it
 		log.Printf("  Note: could not persist sysctl to %s: %v (the runtime value is set, but it'll reset on reboot)", path, err)
 	}
 	return nil


### PR DESCRIPTION
The Q2 follow-up: a **document-intent pass** over the high-signal gosec findings (no broad gosec gate — only G115 is enforced) plus the one genuinely-improvable fix.

## Justified as intentional (`//nolint:gosec` + reason)
- **G402** `pentest/module_tls.go` — `InsecureSkipVerify` *is* the feature: a TLS cert-inspection probe that examines whatever cert the target presents. Not a transport-trust decision.
- **G306** — `mtls` CA **certificate** (public by design; only the key is restricted) + the sysctl drop-in (must be world-readable for the system to load it).
- **G302/G301** — the Caddy **binary** (needs the exec bit) + ephemeral build dir + config dir + user export dir.

## Fixed in code
- **G109** `gateway/events.go` — the `strconv.Atoi → int32` was already range-guarded (1..60); routed through `safecast.I32` so it's overflow-safe by construction and gosec-clean, rather than relying on the guard gosec can't see.

## Verified
`GOOS=linux golangci-lint run` → 0 issues; `go build ./...` clean; touched-package tests pass.

These annotations pre-justify the intentional findings if gosec rules are ever broadened; the rest of gosec stays unenforced (mostly FP/risky, per the triage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)