### PR TITLE
fix(release): stamp the tag version into release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         # `make build-release` builds containarium + mcp-server +
         # agent-box for linux/amd64, darwin/amd64, darwin/arm64 and
         # writes SHA256SUMS.txt. 9 binaries + 1 checksum file.
-        run: make build-release
+        run: make build-release VERSION="${GITHUB_REF_NAME#v}"
 
       - name: Create release notes
         id: release_notes
@@ -178,7 +178,7 @@ jobs:
         # the binary outputs land in bin/ before the bundle script reads
         # them. (The job above only writes binaries to the release page,
         # not to a workflow artifact; we rebuild here.)
-        run: make build-release
+        run: make build-release VERSION="${GITHUB_REF_NAME#v}"
 
       - name: Download bundle dependencies
         run: |

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,8 +7,11 @@ import (
 )
 
 var (
-	// Version is the semantic version - UPDATE THIS MANUALLY for releases
-	Version = "0.23.2"
+	// Version is the semantic version. Release builds override this via
+	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
+	// so the tag is the source of truth; keep this constant in sync as the
+	// fallback for plain `make build` / `go build`.
+	Version = "0.25.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Problem

The release workflow ran `make build-release` **without** `VERSION`, so binaries took their version from the static `pkg/version/version.go` constant — which had drifted to `0.23.2`. So the **v0.24.0 and v0.25.0 release binaries both self-report `v0.23.2`** (the code is correct — confirmed by `protect`/`unprotect`/`prune` being present — only the version string is wrong). Surfaced while deploying v0.25.0 to prod.

## Fix

- **`release.yml`** — build with `make build-release VERSION="${GITHUB_REF_NAME#v}"` in both the release-page job and the bundle job, so the **tag is the source of truth** for every future release (no more manual-bump dependency).
- **`version.go`** — bump the fallback constant to `0.25.0` and document that release builds override it via ldflags.

Not re-spinning v0.25.0 (per decision — its code is correct; the next tag will be stamped right).

🤖 Generated with [Claude Code](https://claude.com/claude-code)