### PR TITLE
feat(metrics): label per-container metrics with cloud container_id (cloud #231)

### DIFF
--- a/internal/metrics/otel.go
+++ b/internal/metrics/otel.go
@@ -401,10 +401,24 @@ func (c *Collector) collect() {
 				continue
 			}
 
-			attrs := otelmetric.WithAttributes(
+			attrSet := []attribute.KeyValue{
 				attribute.String("container.name", ct.Name),
 				attribute.String("backend.id", c.config.LocalBackendID),
-			)
+			}
+			// Stamp the cloud container UUID as container.id when this box is a
+			// cloud-managed tenant. The cloud's MetricsService scopes tenant
+			// queries with {container_id="<uuid>"} (dots→underscores: the OTLP
+			// container.id attr becomes the container_id VM label), so without
+			// it the cloud can't join these per-container infra series
+			// (cpu/mem/disk/network) to a tenant and its history panels stay
+			// empty (#231). The value is the cloud_container_id container label
+			// — the same source container_ips.json reads (#536); see
+			// cloudContainerIDLabel in internal/server. Absent on standalone /
+			// non-cloud boxes, so it's omitted rather than emitted empty.
+			if cid := ct.Labels["cloud_container_id"]; cid != "" {
+				attrSet = append(attrSet, attribute.String("container.id", cid))
+			}
+			attrs := otelmetric.WithAttributes(attrSet...)
 
 			c.containerCPUUsage.Record(ctx, metrics.CPUUsageSeconds, attrs)
 			c.containerMemUsage.Record(ctx, metrics.MemoryUsageBytes, attrs)


### PR DESCRIPTION
## What

The OTel collector already scrapes per-container `container.cpu/memory/disk/network.*` gauges and pushes them to VictoriaMetrics — but labels them only with `container.name` + `backend.id`. The cloud control plane's `MetricsService` scopes tenant queries with `{container_id="<cloud uuid>"}`, so it could **never join these infra series to a tenant** — its CPU/mem/disk/**network history** panels stayed empty (cloud #231) even though the data was flowing.

This stamps the cloud container UUID as the OTLP `container.id` attribute (→ `container_id` VM label) when the box carries the `cloud_container_id` label — the same source `container_ips.json` uses (#536). Cloud-managed tenant boxes become joinable; standalone/non-cloud boxes omit it (no empty label). Local-backend path only (peers are GPU nodes, not where cloud tenants run).

## Impact

Functionally unblocks the **network-bytes (and cpu/mem/disk) history half of cloud #231** once this ships + the daemon is redeployed. The metric names already match the cloud's contract (`container_network_rx_bytes`/`_tx_bytes`). The **request-rate** plane (edge access log) remains a separate effort.

Corrects the record: cloud #231's "blocked on #370" was a phantom (that issue is a closed, unrelated MCP bug). The real gap was this one missing label.

`go build`, `gofmt -s`, `go vet` clean. End-to-end (label in VM, cloud query matches) verifies once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)