### PR TITLE
feat(metrics): request-rate plane — design + slice 1 (#231)

### DIFF
--- a/docs/REQUEST-RATE-PLANE-DESIGN.md
+++ b/docs/REQUEST-RATE-PLANE-DESIGN.md
@@ -1,0 +1,247 @@
+# Request-rate metric plane — design
+
+**Status:** Proposed
+**Last updated:** 2026-06-09
+**Related:** [`internal/metrics/otel.go`](../internal/metrics/otel.go) (the per-container metric collector this extends), [`internal/app/proxy.go`](../internal/app/proxy.go) (the Caddy edge that is the only request-volume source), [`docs/OTEL-COLLECTOR-DESIGN.md`](OTEL-COLLECTOR-DESIGN.md) (app-emitted OTel — the in-container alternative this complements).
+
+## Context
+
+The daemon already emits a per-container **bytes plane** — CPU, memory, disk, and
+network rx/tx as cgroup-level gauges pushed to VictoriaMetrics every 30s
+(`internal/metrics/otel.go`). When a box is a cloud-managed tenant, each
+per-container series carries a `container.id` attribute (the
+`cloud_container_id` label → VM `container_id` label), so the cloud's
+`MetricsService` can join the series to a tenant and render history panels.
+
+What's missing is the **request-rate plane**: `container_request_rate` —
+HTTP requests per second hitting a tenant's container through the edge. The
+metric name and a placeholder webui panel already exist on the cloud side
+(`internal/metrics/names.go` `MetricRequestRate = "container_request_rate"`;
+`RequestRatePanel`), and the cloud `QueryMetric` path scopes by
+`{container_id="<uuid>"}` exactly as it does for the bytes plane. **The
+contract is built; the source is not.** Nothing in the daemon emits
+`container_request_rate` today, and nothing produces the data it would be
+computed from.
+
+This doc designs the source: where per-tenant request volume is observed,
+how it's attributed to a container, and how it becomes a metric that lands in
+VictoriaMetrics with the `container.id` label the cloud already joins on.
+
+## The gap, precisely
+
+Per-tenant HTTP request volume is visible in exactly one place: the **Caddy
+edge reverse proxy** (`internal/app/proxy.go`). Every tenant container is
+fronted by a route — `Match Host=<sub>.<base-domain>` → `reverse_proxy`
+upstream `<containerIP>:<port>`. Caddy sees every request before it reaches
+the container.
+
+But Caddy is **not currently configured to emit any access record.** The
+server config it builds is `{listen: [":80", ":443"], routes: [...]}` plus
+the TLS app and (optionally) the PROXY listener wrappers — there is no `logs`
+block and no metrics module. So there is no request-volume signal anywhere in
+the system today. The request-rate plane cannot be "wired up" — its source
+has to be created first.
+
+## Goals / non-goals
+
+**Goals**
+
+- Emit `container_request_rate` (requests/sec) per tenant container, with a
+  `container.id` attribute matching the bytes plane, so the existing cloud
+  `QueryMetric` + `RequestRatePanel` render it with **zero cloud-side change**.
+- Attribution is **platform-measured at the edge**, not trusted from the
+  app — works whether or not the tenant instruments their own app.
+- **Off by default**, opt-in via env flag — same posture as `--monitoring`
+  (app OTel) and the eBPF network policy. Operators are not surprised by new
+  edge logging or its disk cost.
+- Bounded cardinality (one series per active tenant container) and bounded
+  disk (rolled access logs).
+
+**Non-goals (v1)**
+
+- Per-route / per-path request rates, latency histograms, status-code
+  breakdowns. v1 is a single rate per container. Latency and status planes are
+  a clean follow-on once the source exists.
+- Request rate for **TLS-passthrough (L4) routes** — those terminate no HTTP
+  at the edge, so there is no request to count. Documented gap; such tenants
+  show no request-rate series.
+- Replacing app-emitted OTel. A tenant that instruments its own app
+  (`OTEL-COLLECTOR-DESIGN.md`) gets richer in-app metrics; this plane is the
+  platform-guaranteed floor that exists regardless.
+
+## Candidate sources (and why the access log wins)
+
+**1. Caddy native Prometheus metrics** (`caddy_http_requests_total`). Enabled
+via the global `metrics` option, scraped from the admin endpoint. Labels are
+`server`, `handler`, `code`, `method` — **there is no per-host or per-route
+label**, so a count cannot be attributed to a specific tenant container. Usable
+only for an edge-wide aggregate, not per-tenant. Rejected for v1.
+
+**2. Caddy structured access log** (JSON). A per-server `logs` configuration
+makes Caddy write one JSON object per request, including `request.host`. Host
+→ tenant container is resolvable **in-process** from data the collector
+already holds (route store gives host→upstream IP; the container list gives
+IP→`cloud_container_id`). This is the chosen source: it is the only option
+that yields per-tenant attribution without a custom Caddy module.
+
+## Architecture
+
+```
+   client ──HTTP──▶ Caddy edge (srv0)
+                      │  reverse_proxy  Host:<sub>.<base-domain> → <containerIP>:<port>
+                      │
+                      ├──▶ tenant container          (unchanged request path)
+                      │
+                      └──▶ JSON access log line       {"request":{"host":"<sub>.<base-domain>"},"status":200,...}
+                                  │
+                                  ▼
+                       ┌────────────────────────────┐
+                       │ request-rate aggregator     │   (new, in the daemon)
+                       │  • tail JSON access log      │
+                       │  • count per request.host    │
+                       │  • host → container_id        │   (route store ∪ container labels)
+                       │  • rate = Δcount / interval   │
+                       └────────────┬─────────────────┘
+                                    ▼  every collection tick (30s)
+                       container_request_rate{container.id, container.name, backend.id}
+                                    │
+                                    ▼  OTLP push (existing collector pipeline)
+                              VictoriaMetrics ──▶ cloud QueryMetric ──▶ RequestRatePanel
+```
+
+### A. Enable structured access logging (`internal/app/proxy.go`)
+
+Add an access-log configuration to the Caddy edge, gated on an env flag
+(`CONTAINARIUM_ACCESS_LOG=1`, default off):
+
+- Define a named log in Caddy's `logging` app with a **file** writer to a
+  known path (e.g. `<caddy-log-dir>/access.log`), a **json** encoder, and
+  level `INFO` (access records only — no debug).
+- Set **roll** options (`roll_size`, `roll_keep`, `roll_keep_days`) so disk is
+  bounded regardless of traffic.
+- Reference that log from the `srv0` server's `logs` field so request records
+  flow to it.
+
+This is the one piece that touches the existing Caddy-config builder. It must
+be re-asserted by `EnsureBaseConfig` alongside the http app / TLS app / PROXY
+wrappers, because the bundled core-caddy reverts to its stub Caddyfile on any
+reload (the #400 self-heal path) — otherwise access logging silently stops
+after the first caddy restart.
+
+### B. The aggregator (new package, driven by the collector)
+
+A goroutine, started only when the flag is on:
+
+- **Tail** the JSON access log: open, seek to end, read appended lines;
+  reopen on rotation (inode/size-truncation change) so a roll doesn't stall
+  it. Only lines appended since the last tick are read — memory is bounded to
+  the current window, not the whole file.
+- Maintain a **per-host counter** for the current interval.
+- On each collector tick (the existing 30s cadence), for each host:
+  `rate = Δcount / interval_seconds`, resolve host → container, record the
+  gauge, reset the window.
+
+Parsing targets Caddy's **documented, stable** access-log schema
+(`{"level","ts","logger","msg":"handled request","request":{"host",...},"status",...}`),
+so the parser is unit-testable against captured sample lines without a live
+edge — the same way the OTLP gateway (#361) is tested against the OTLP proto
+without a live VictoriaMetrics.
+
+### C. Host → container resolution
+
+The collector already lists containers each tick with their `Labels` (incl.
+`cloud_container_id`) and IPs, and `ProxyManager.ListRoutes()` returns
+host→upstream `IP:port`. Join: `request.host` → upstream IP (route store) →
+container (match by IP) → `cloud_container_id`. Cache the map, refresh per
+tick. A host with no resolvable container (stale route, core service) is
+counted but dropped before emit.
+
+### D. The metric (`internal/metrics/otel.go`)
+
+Add one instrument mirroring the bytes-plane gauges:
+
+```go
+c.containerRequestRate, _ = meter.Float64Gauge("container.request_rate",
+    otelmetric.WithDescription("Container HTTP requests per second (edge-measured)"),
+    otelmetric.WithUnit("1/s"))
+```
+
+Recorded with the same attribute set as the per-container bytes gauges —
+`container.name`, `backend.id`, and (when present) `container.id` — so the VM
+series is `container_request_rate{container_id="<uuid>",...}`, exactly what the
+cloud `QueryMetric` already asks for. No cloud change.
+
+> Naming: the OTel instrument name `container.request_rate` → VM
+> `container_request_rate` (dots→underscores, no unit suffix) matches the
+> cloud constant already shipped in `internal/metrics/names.go`. Confirm the
+> mapping with a single live sample before declaring the plane done.
+
+### E. Cloud side — already built
+
+`MetricRequestRate`, the `QueryMetric` scoping, and `RequestRatePanel` are
+shipped. Once the OSS metric flows with the `container_id` label, the panel
+renders with no further work. The per-org cardinality cap in the OTLP gateway
+(#361) already covers this series on the cloud ingest path.
+
+## Cost & cardinality
+
+- **Series:** one per active tenant container (`container_id` + `container_name`
+  + `backend_id`). Bounded by container count, not request volume.
+- **Disk:** bounded by the roll config; the flag stays off until an operator
+  has sized it for a given edge.
+- **CPU:** one JSON-decode per request line on the tail goroutine. For
+  high-traffic edges, a sampling factor (count every Nth line × N) is the
+  obvious lever if decode cost shows up — deferred until measured.
+
+## What is buildable offline vs. what needs a live edge
+
+**Offline, unit-tested (no live dependency):**
+
+- The access-log parser (against captured Caddy JSON lines — documented schema).
+- The per-host counter + rate computation over a window.
+- The host→container resolver (given a route table + container list fixture).
+- The new `container.request_rate` instrument and its attribute set.
+
+**Requires a live edge (cannot be validated offline):**
+
+- That Caddy actually writes the configured access log at the expected path /
+  schema, survives a core-caddy stub revert, and rolls as configured.
+- The end-to-end flow: real requests → log lines → gauge → VM series →
+  `RequestRatePanel`.
+- The instrument-name → VM-label mapping (one sample confirms it).
+- Disk-usage behaviour on a high-traffic prod edge before enabling always-on.
+
+## Live validation plan
+
+1. On a lab edge, set `CONTAINARIUM_ACCESS_LOG=1`; `curl` a tenant host N
+   times; confirm N JSON lines with the expected `request.host`.
+2. Start the aggregator; confirm `container_request_rate{container_id=...}`
+   appears in VictoriaMetrics with the right tenant id and a plausible rate.
+3. Confirm the cloud `RequestRatePanel` renders the series.
+4. Restart core-caddy; confirm `EnsureBaseConfig` re-asserts the log config and
+   the series resumes.
+5. Measure access-log disk growth under representative traffic before
+   considering it for an always-on prod edge.
+
+## Rollout / risk
+
+- **Off by default.** `CONTAINARIUM_ACCESS_LOG=1` opt-in, like `--monitoring`
+  and the eBPF enforce flag. No behaviour change for existing deployments.
+- **TLS-passthrough (L4) routes** produce no HTTP access record — those tenants
+  have no request-rate series. Documented, not silently zero.
+- **gRPC routes** count each HTTP/2 request; a long-lived streaming RPC counts
+  once at stream open, not per message. Documented so the panel isn't
+  misread.
+- **High-traffic prod edge:** gate behind the flag + roll config; size disk
+  first. Sampling is the escape hatch if decode cost matters.
+
+## Implementation slices
+
+1. **Parser + aggregator + instrument** (offline, unit-tested) — the building
+   block, no behaviour change (nothing calls it until the flag is on).
+2. **Caddy access-log config in `proxy.go`** behind `CONTAINARIUM_ACCESS_LOG`,
+   re-asserted by `EnsureBaseConfig`.
+3. **Wire the aggregator into the collector** when the flag is on; record the
+   gauge each tick.
+4. **Live validation** per the plan above, then flip the cloud panel from
+   placeholder to live.

--- a/internal/metrics/otel.go
+++ b/internal/metrics/otel.go
@@ -12,6 +12,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 
 	"github.com/footprintai/containarium/distros/go/containariumotel"
+	"github.com/footprintai/containarium/internal/reqrate"
 	"github.com/footprintai/containarium/pkg/core/incus"
 )
 
@@ -106,6 +107,7 @@ type Collector struct {
 	containerNetRx        otelmetric.Int64Gauge
 	containerNetTx        otelmetric.Int64Gauge
 	containerProcessCount otelmetric.Int64Gauge
+	containerRequestRate  otelmetric.Float64Gauge
 
 	// Aggregate instruments
 	containersRunning otelmetric.Int64Gauge
@@ -272,6 +274,19 @@ func (c *Collector) initInstruments() error {
 
 	c.containerProcessCount, err = meter.Int64Gauge("container.process.count",
 		otelmetric.WithDescription("Number of running processes in container"))
+	if err != nil {
+		return err
+	}
+
+	// Request-rate plane (#231): edge-measured HTTP requests/sec per container.
+	// → VM series container_request_rate{container_id=...}, the same join key
+	// the bytes plane uses, consumed by the cloud's RequestRatePanel. Recorded
+	// only when access-log aggregation is enabled (see RecordRequestRates and
+	// docs/REQUEST-RATE-PLANE-DESIGN.md); the instrument is created
+	// unconditionally so the wiring slice has nothing to bootstrap.
+	c.containerRequestRate, err = meter.Float64Gauge("container.request_rate",
+		otelmetric.WithDescription("Container HTTP requests per second (edge-measured)"),
+		otelmetric.WithUnit("1/s"))
 	if err != nil {
 		return err
 	}
@@ -455,6 +470,29 @@ func (c *Collector) collect() {
 			c.containerNetTx.Record(ctx, pm.NetworkTxBytes, attrs)
 			c.containerProcessCount.Record(ctx, pm.ProcessCount, attrs)
 		}
+	}
+}
+
+// RecordRequestRates records edge-measured per-container request rates
+// (container.request_rate) for one collection tick. The collector calls this
+// only when access-log aggregation is enabled (CONTAINARIUM_ACCESS_LOG=1, a
+// later wiring slice — see docs/REQUEST-RATE-PLANE-DESIGN.md); until then it
+// has no callers and the plane stays dark.
+//
+// Samples carry their own container.id (the cloud_container_id, empty on
+// standalone boxes) so the VM series joins to a tenant exactly like the bytes
+// plane; backend.id is this daemon's, since the aggregator runs against the
+// local edge.
+func (c *Collector) RecordRequestRates(samples []reqrate.Sample) {
+	for _, s := range samples {
+		attrSet := []attribute.KeyValue{
+			attribute.String("container.name", s.ContainerName),
+			attribute.String("backend.id", c.config.LocalBackendID),
+		}
+		if s.ContainerID != "" {
+			attrSet = append(attrSet, attribute.String("container.id", s.ContainerID))
+		}
+		c.containerRequestRate.Record(c.ctx, s.RequestsPerSec, otelmetric.WithAttributes(attrSet...))
 	}
 }
 

--- a/internal/reqrate/aggregator.go
+++ b/internal/reqrate/aggregator.go
@@ -1,0 +1,72 @@
+package reqrate
+
+import (
+	"bufio"
+	"io"
+	"sync"
+	"time"
+)
+
+// Counter accumulates per-host request counts for the current interval. The
+// live tailer feeds it via Add from a single goroutine while the collector
+// drains it via Snapshot on each tick; the mutex makes that hand-off safe.
+type Counter struct {
+	mu     sync.Mutex
+	counts map[string]int64
+}
+
+// NewCounter returns an empty per-host counter.
+func NewCounter() *Counter {
+	return &Counter{counts: make(map[string]int64)}
+}
+
+// Add records one request against host.
+func (c *Counter) Add(host string) {
+	c.mu.Lock()
+	c.counts[host]++
+	c.mu.Unlock()
+}
+
+// Snapshot returns per-host requests-per-second over interval and resets the
+// counter for the next window. It returns nil (and still resets) when there is
+// nothing to report or interval is non-positive — the latter guards against a
+// div-by-zero from a misconfigured tick.
+func (c *Counter) Snapshot(interval time.Duration) map[string]float64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	prev := c.counts
+	c.counts = make(map[string]int64)
+	if interval <= 0 || len(prev) == 0 {
+		return nil
+	}
+	secs := interval.Seconds()
+	out := make(map[string]float64, len(prev))
+	for h, n := range prev {
+		out[h] = float64(n) / secs
+	}
+	return out
+}
+
+// Scan reads newline-delimited JSON access-log records from r, extracting each
+// record's host and adding it to counter. Lines that aren't access records (or
+// carry no host) are skipped. Returns the number of records counted.
+//
+// The live tailer (a later slice) calls Scan on the growing access-log file;
+// tests call it on an in-memory reader of captured lines. Either way the
+// parsing/counting path is identical.
+func Scan(r io.Reader, counter *Counter) (int, error) {
+	sc := bufio.NewScanner(r)
+	// Access-log lines can be long (full request/response detail); raise the
+	// scanner's max token size well above the 64 KiB default.
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	n := 0
+	for sc.Scan() {
+		host, ok := ParseHost(sc.Bytes())
+		if !ok {
+			continue
+		}
+		counter.Add(host)
+		n++
+	}
+	return n, sc.Err()
+}

--- a/internal/reqrate/aggregator_test.go
+++ b/internal/reqrate/aggregator_test.go
@@ -1,0 +1,69 @@
+package reqrate
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCounter_SnapshotComputesRateAndResets(t *testing.T) {
+	c := NewCounter()
+	for i := 0; i < 6; i++ {
+		c.Add("alice.example.com")
+	}
+	for i := 0; i < 3; i++ {
+		c.Add("bob.example.com")
+	}
+
+	got := c.Snapshot(30 * time.Second)
+	if got["alice.example.com"] != 0.2 { // 6 / 30s
+		t.Errorf("alice rate = %v, want 0.2", got["alice.example.com"])
+	}
+	if got["bob.example.com"] != 0.1 { // 3 / 30s
+		t.Errorf("bob rate = %v, want 0.1", got["bob.example.com"])
+	}
+
+	// Second snapshot of an untouched counter is empty — the window reset.
+	if got := c.Snapshot(30 * time.Second); got != nil {
+		t.Errorf("second snapshot = %v, want nil after reset", got)
+	}
+}
+
+func TestCounter_SnapshotGuards(t *testing.T) {
+	c := NewCounter()
+	c.Add("x")
+	if got := c.Snapshot(0); got != nil {
+		t.Errorf("zero interval snapshot = %v, want nil", got)
+	}
+	// The guarded snapshot still reset the window, so a real one is now empty.
+	if got := c.Snapshot(time.Second); got != nil {
+		t.Errorf("snapshot after guarded reset = %v, want nil", got)
+	}
+}
+
+func TestScan_CountsAccessRecordsSkipsJunk(t *testing.T) {
+	log := strings.Join([]string{
+		`{"msg":"handled request","request":{"host":"alice.example.com"}}`,
+		`not json at all`,
+		`{"msg":"handled request","request":{"host":"alice.example.com"}}`,
+		`{"level":"info","msg":"serving initial configuration"}`, // no host
+		`{"msg":"handled request","request":{"host":"bob.example.com:443"}}`,
+		``, // blank line
+	}, "\n")
+
+	c := NewCounter()
+	n, err := Scan(strings.NewReader(log), c)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("counted %d records, want 3", n)
+	}
+	got := c.Snapshot(time.Second)
+	if got["alice.example.com"] != 2 {
+		t.Errorf("alice count = %v, want 2", got["alice.example.com"])
+	}
+	if got["bob.example.com"] != 1 {
+		t.Errorf("bob count = %v, want 1", got["bob.example.com"])
+	}
+}

--- a/internal/reqrate/parser.go
+++ b/internal/reqrate/parser.go
@@ -1,0 +1,58 @@
+// Package reqrate computes per-container HTTP request rates from the Caddy
+// edge's structured (JSON) access log — the source for #231's request-rate
+// plane. See docs/REQUEST-RATE-PLANE-DESIGN.md.
+//
+// The package is the offline, unit-tested building block (slice 1): it parses
+// access-log lines, accumulates per-host counts over an interval, and joins
+// hosts to containers using the route table + container list the collector
+// already holds. The live tailer + collector wiring (which turn this into
+// emitted metrics) are later slices; nothing here reads a file or talks to
+// Caddy, so all of it is testable without a running edge.
+package reqrate
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+)
+
+// accessEntry is the subset of a Caddy JSON access-log record we need. Caddy
+// writes one such object per handled request when the server has a `logs`
+// configuration with the json encoder. Fields we don't use are ignored by the
+// decoder.
+type accessEntry struct {
+	Request struct {
+		Host string `json:"host"`
+	} `json:"request"`
+}
+
+// ParseHost extracts the (lower-cased, port-stripped) request host from one
+// JSON access-log line. It returns ("", false) for lines that don't decode as
+// JSON, that aren't access records (e.g. Caddy's own startup/info lines if they
+// share the file), or that carry no host — callers skip those rather than
+// counting them.
+func ParseHost(line []byte) (string, bool) {
+	var e accessEntry
+	if err := json.Unmarshal(line, &e); err != nil {
+		return "", false
+	}
+	return normalizeHost(e.Request.Host)
+}
+
+// normalizeHost lower-cases the host and strips an optional :port suffix
+// (clients may send Host with a port). Returns ok=false for an empty host.
+func normalizeHost(h string) (string, bool) {
+	if h == "" {
+		return "", false
+	}
+	// SplitHostPort only succeeds when a port is actually present; otherwise
+	// keep the host as-is (it has no port to strip).
+	if host, _, err := net.SplitHostPort(h); err == nil {
+		h = host
+	}
+	h = strings.ToLower(strings.TrimSpace(h))
+	if h == "" {
+		return "", false
+	}
+	return h, true
+}

--- a/internal/reqrate/parser_test.go
+++ b/internal/reqrate/parser_test.go
@@ -1,0 +1,57 @@
+package reqrate
+
+import "testing"
+
+func TestParseHost(t *testing.T) {
+	cases := []struct {
+		name     string
+		line     string
+		wantHost string
+		wantOK   bool
+	}{
+		{
+			name:     "typical caddy access record",
+			line:     `{"level":"info","ts":1718000000.1,"logger":"http.log.access.log0","msg":"handled request","request":{"remote_ip":"203.0.113.7","method":"GET","host":"alice.example.com","uri":"/"},"status":200}`,
+			wantHost: "alice.example.com",
+			wantOK:   true,
+		},
+		{
+			name:     "host carries a port",
+			line:     `{"msg":"handled request","request":{"host":"bob.example.com:443"}}`,
+			wantHost: "bob.example.com",
+			wantOK:   true,
+		},
+		{
+			name:     "uppercase host is lower-cased",
+			line:     `{"request":{"host":"Carol.Example.COM"}}`,
+			wantHost: "carol.example.com",
+			wantOK:   true,
+		},
+		{
+			name:   "not json",
+			line:   `this is not json`,
+			wantOK: false,
+		},
+		{
+			name:   "json without a request host (e.g. a startup line)",
+			line:   `{"level":"info","msg":"serving initial configuration"}`,
+			wantOK: false,
+		},
+		{
+			name:   "empty host",
+			line:   `{"request":{"host":""}}`,
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			host, ok := ParseHost([]byte(tc.line))
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && host != tc.wantHost {
+				t.Errorf("host = %q, want %q", host, tc.wantHost)
+			}
+		})
+	}
+}

--- a/internal/reqrate/resolver.go
+++ b/internal/reqrate/resolver.go
@@ -1,0 +1,101 @@
+package reqrate
+
+import (
+	"sort"
+	"strings"
+)
+
+// Container identifies a tenant container for request-rate attribution. The
+// collector builds these from its existing container list — Name + primary IP
+// the edge dials, plus the cloud_container_id label (empty on non-cloud boxes).
+type Container struct {
+	Name        string // incus container name
+	IP          string // primary IPv4 the edge reverse-proxies to
+	ContainerID string // cloud_container_id label; "" on standalone boxes
+}
+
+// Route maps an edge hostname to the upstream IP it proxies to — the subset of
+// ProxyManager.ListRoutes the resolver needs.
+type Route struct {
+	Host       string
+	UpstreamIP string
+}
+
+// Resolver maps a request host to the container serving it, by joining routes
+// (host→upstream IP) with the container list (IP→container). Built once per
+// collection tick from data the collector already has; cheap and immutable
+// after construction.
+type Resolver struct {
+	byHost map[string]Container
+}
+
+// NewResolver joins routes and containers into a host→container map. A route
+// whose upstream IP matches no container is dropped (the container may have
+// gone away); a container with no IP can't be reverse-proxied so it's skipped.
+func NewResolver(routes []Route, containers []Container) *Resolver {
+	byIP := make(map[string]Container, len(containers))
+	for _, c := range containers {
+		if c.IP != "" {
+			byIP[c.IP] = c
+		}
+	}
+	byHost := make(map[string]Container, len(routes))
+	for _, r := range routes {
+		if c, ok := byIP[r.UpstreamIP]; ok {
+			byHost[strings.ToLower(r.Host)] = c
+		}
+	}
+	return &Resolver{byHost: byHost}
+}
+
+// Resolve returns the container serving host, or ok=false when the host maps to
+// no known container — a stale route, a core service, or an L4/passthrough host
+// that produced no reverse-proxy route (those have no request-rate series).
+func (r *Resolver) Resolve(host string) (Container, bool) {
+	c, ok := r.byHost[strings.ToLower(host)]
+	return c, ok
+}
+
+// Sample is one container's request rate for a tick, ready to record as the
+// container.request_rate gauge.
+type Sample struct {
+	ContainerName  string
+	ContainerID    string
+	RequestsPerSec float64
+}
+
+// Build joins a host→rate snapshot with a resolver into per-container samples.
+// Several hostnames can front the same container (e.g. the default subdomain
+// plus a custom-domain alias), so their rates are summed. Hosts that resolve to
+// no container are dropped and tallied in dropped (surfaced by the caller for
+// observability). Output is sorted by container name for stable emit ordering.
+func Build(rates map[string]float64, res *Resolver) (samples []Sample, dropped int) {
+	byKey := make(map[string]*Sample)
+	for host, rate := range rates {
+		c, ok := res.Resolve(host)
+		if !ok {
+			dropped++
+			continue
+		}
+		// Key on the cloud container id when present, else the container name,
+		// so two hostnames for the same container coalesce.
+		key := c.ContainerID
+		if key == "" {
+			key = "name:" + c.Name
+		}
+		s := byKey[key]
+		if s == nil {
+			s = &Sample{ContainerName: c.Name, ContainerID: c.ContainerID}
+			byKey[key] = s
+		}
+		s.RequestsPerSec += rate
+	}
+	samples = make([]Sample, 0, len(byKey))
+	for _, s := range byKey {
+		samples = append(samples, *s)
+	}
+	sort.Slice(samples, func(i, j int) bool {
+		return samples[i].ContainerName < samples[j].ContainerName
+	})
+	return samples, dropped
+}

--- a/internal/reqrate/resolver_test.go
+++ b/internal/reqrate/resolver_test.go
@@ -1,0 +1,106 @@
+package reqrate
+
+import "testing"
+
+func sampleByName(samples []Sample, name string) (Sample, bool) {
+	for _, s := range samples {
+		if s.ContainerName == name {
+			return s, true
+		}
+	}
+	return Sample{}, false
+}
+
+func TestResolver_JoinsHostToContainer(t *testing.T) {
+	res := NewResolver(
+		[]Route{
+			{Host: "alice.example.com", UpstreamIP: "10.0.0.2"},
+			{Host: "bob.example.com", UpstreamIP: "10.0.0.3"},
+			{Host: "stale.example.com", UpstreamIP: "10.0.0.9"}, // no such container
+		},
+		[]Container{
+			{Name: "alice", IP: "10.0.0.2", ContainerID: "uuid-a"},
+			{Name: "bob", IP: "10.0.0.3", ContainerID: "uuid-b"},
+			{Name: "noip", IP: ""}, // unroutable, skipped
+		},
+	)
+
+	if c, ok := res.Resolve("alice.example.com"); !ok || c.ContainerID != "uuid-a" {
+		t.Errorf("alice → %+v, ok=%v; want uuid-a", c, ok)
+	}
+	if c, ok := res.Resolve("ALICE.example.com"); !ok || c.ContainerID != "uuid-a" {
+		t.Errorf("case-insensitive resolve failed: %+v ok=%v", c, ok)
+	}
+	if _, ok := res.Resolve("stale.example.com"); ok {
+		t.Errorf("stale host resolved, want miss")
+	}
+	if _, ok := res.Resolve("unknown.example.com"); ok {
+		t.Errorf("unknown host resolved, want miss")
+	}
+}
+
+func TestBuild_SumsAliasesAndCountsDropped(t *testing.T) {
+	res := NewResolver(
+		[]Route{
+			{Host: "alice.example.com", UpstreamIP: "10.0.0.2"},
+			{Host: "alice-custom.com", UpstreamIP: "10.0.0.2"}, // alias → same container
+			{Host: "bob.example.com", UpstreamIP: "10.0.0.3"},
+		},
+		[]Container{
+			{Name: "alice", IP: "10.0.0.2", ContainerID: "uuid-a"},
+			{Name: "bob", IP: "10.0.0.3", ContainerID: "uuid-b"},
+		},
+	)
+
+	rates := map[string]float64{
+		"alice.example.com": 0.2,
+		"alice-custom.com":  0.3, // coalesces into alice → 0.5
+		"bob.example.com":   0.1,
+		"ghost.example.com": 9.9, // unresolved → dropped
+	}
+
+	samples, dropped := Build(rates, res)
+	if dropped != 1 {
+		t.Errorf("dropped = %d, want 1", dropped)
+	}
+	if len(samples) != 2 {
+		t.Fatalf("len(samples) = %d, want 2 (%+v)", len(samples), samples)
+	}
+	// Sorted by name: alice before bob.
+	if samples[0].ContainerName != "alice" || samples[1].ContainerName != "bob" {
+		t.Errorf("samples not sorted by name: %+v", samples)
+	}
+	a, _ := sampleByName(samples, "alice")
+	if a.RequestsPerSec != 0.5 || a.ContainerID != "uuid-a" {
+		t.Errorf("alice sample = %+v, want rate 0.5 id uuid-a", a)
+	}
+	b, _ := sampleByName(samples, "bob")
+	if b.RequestsPerSec != 0.1 {
+		t.Errorf("bob rate = %v, want 0.1", b.RequestsPerSec)
+	}
+}
+
+func TestBuild_KeysByNameWhenNoContainerID(t *testing.T) {
+	// Standalone box: containers have no cloud_container_id. Build must still
+	// coalesce aliases by name and produce a sample (recorded under name only).
+	res := NewResolver(
+		[]Route{
+			{Host: "h1.example.com", UpstreamIP: "10.0.0.5"},
+			{Host: "h2.example.com", UpstreamIP: "10.0.0.5"},
+		},
+		[]Container{{Name: "solo", IP: "10.0.0.5"}},
+	)
+	samples, dropped := Build(map[string]float64{
+		"h1.example.com": 1,
+		"h2.example.com": 2,
+	}, res)
+	if dropped != 0 {
+		t.Errorf("dropped = %d, want 0", dropped)
+	}
+	if len(samples) != 1 || samples[0].ContainerName != "solo" || samples[0].RequestsPerSec != 3 {
+		t.Fatalf("samples = %+v, want one solo @ 3", samples)
+	}
+	if samples[0].ContainerID != "" {
+		t.Errorf("ContainerID = %q, want empty on standalone box", samples[0].ContainerID)
+	}
+}


### PR DESCRIPTION
## What

The **request-rate plane** for #231: the design spec plus its first offline-buildable, unit-tested building block. **No behaviour change** — nothing calls the new code until a later wiring slice.

## Why now

The cloud side of the request-rate plane is **already shipped** — `container_request_rate` (names.go), the `{container_id}`-scoped `QueryMetric`, and `RequestRatePanel`. The OSS source is **not**, and can't simply be "wired up": the Caddy edge is the only place per-tenant HTTP request volume is visible, and it currently emits **no access record at all** (server config is `listen` + `routes` + TLS; no `logs` block, no metrics module). The source has to be created first.

## Contents

**1. Design — `docs/REQUEST-RATE-PLANE-DESIGN.md`**
- **Source:** Caddy structured (JSON) access log behind an opt-in `CONTAINARIUM_ACCESS_LOG=1` flag (off by default, like `--monitoring` / eBPF enforce). Native Caddy Prometheus metrics rejected — no per-host label, so no per-tenant attribution.
- Separates what's **buildable offline** (parser, aggregator, resolver, instrument) from what **needs a live edge** (Caddy actually writing/rolling the log, end-to-end flow, disk sizing). Same honesty line as #307/#253.

**2. Slice 1 — `internal/reqrate` + the instrument** (this is the "buildable offline" set)
- `ParseHost` — host out of a Caddy JSON access line; skips non-access/host-less lines.
- `Counter` + `Scan` — per-host counts over an interval; `Snapshot` → requests/sec + window reset. `Scan` is the parse→count bridge the live tailer will call.
- `Resolver` + `Build` — join `request.host` → container via route table (host→upstream IP) ∪ container list (IP→`cloud_container_id`); sums hostname aliases, tallies unresolved hosts.
- `internal/metrics/otel.go`: `container.request_rate` gauge (→ VM `container_request_rate{container_id=...}`, the bytes-plane join key the cloud panel already queries) + `RecordRequestRates(samples)`. **Called by nothing yet.**

## Tests

`go test ./internal/reqrate/...` green — parser (port strip, lower-case, junk lines), counter (rate math + reset + guards), scan (skips non-JSON/host-less), resolver (join, case-insensitive, miss), Build (alias coalescing, dropped count, name-keyed standalone).

## Remaining slices (follow-ups)

2. Caddy access-log config in `proxy.go` behind the flag, re-asserted by `EnsureBaseConfig`.
3. Live tailer → `Counter`, and wire `RecordRequestRates` into the collector tick.
4. Live validation, then flip the cloud panel placeholder → live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)