### PR TITLE
feat(metrics): egress fan-out detection — crawler abuse signal

### DIFF
--- a/docs/EGRESS-FANOUT-DETECTION.md
+++ b/docs/EGRESS-FANOUT-DETECTION.md
@@ -1,0 +1,124 @@
+# Egress fan-out detection (crawler abuse) — design
+
+**Status:** Proposed
+**Last updated:** 2026-06-09
+**Related:** [`internal/traffic/collector.go`](../internal/traffic/collector.go) (the conntrack collector that already observes egress destinations), [`internal/metrics/otel.go`](../internal/metrics/otel.go) (the metric pipeline this emits through), [`docs/REQUEST-RATE-PLANE-DESIGN.md`](REQUEST-RATE-PLANE-DESIGN.md) (the inbound sibling plane), eBPF network policy (#315, the egress *enforcement* counterpart).
+
+## Context
+
+Hosting a crawler/scraper on behalf of a customer is prohibited. A crawler has
+a distinctive network signature: it makes outbound connections to a large,
+constantly-changing set of **distinct destinations**, where a normal app talks
+to a handful (its database, an upstream API, a CDN). We want a signal that
+surfaces that fan-out so abuse can be detected and acted on.
+
+Unlike the inbound request-rate plane (which had no data source and needed one
+built), the **egress data already exists**. The conntrack traffic collector
+(`internal/traffic`) records every container egress connection with its
+destination IP — it classifies a connection as `EGRESS` when the source IP is a
+container (`collector.go`), persists connections on close (7-day retention), and
+`GetConnectionSummary` already aggregates per-destination connection counts and
+a `TopDestinations` list. What's missing is a **continuously-emitted detection
+metric**: today the fan-out is only visible at query time, so nothing can alert
+on it.
+
+## The signal
+
+Per container, per collection window:
+
+- **`container_egress_distinct_destinations`** — count of unique destination IPs
+  the container connected out to. The primary crawler tell: a sustained spike
+  separates a fan-out crawler from a normal app.
+- **`container_egress_connections`** — total egress connection count (secondary;
+  high churn alongside high distinct-count strengthens the signal).
+
+Both carry the `container.id` attribute (the `cloud_container_id` label) so they
+join to a tenant exactly like the bytes plane (#550), plus `container.name` and
+`backend.id`.
+
+## Privacy posture — count the fan-out, don't index the targets
+
+The metric is a **per-container aggregate**. We deliberately do **not** emit a
+per-destination-IP series. That would:
+
+1. **Explode cardinality** — destination IPs are unbounded label values; a single
+   crawler would create thousands of series.
+2. **Be a privacy / recon liability** — it would turn "every site a customer's
+   box visits" into indexed, retained time-series.
+
+The raw destinations remain available where they already are — the conntrack
+`GetConnectionSummary` (`TopDestinations`) and the persisted store — which are
+query-time, access-controlled surfaces, not metric labels. If a confirmed abuse
+case needs the actual targets, that's the surface to use.
+
+## Architecture
+
+```
+   tenant container ──outbound──▶ conntrack (already running)
+                                    │  EGRESS conn: srcIP=container, dstIP=...
+                                    ▼
+                      internal/traffic.Collector
+                        • snapshot of active connections
+                        • EgressFanout(): per-container
+                          { distinct dst IPs, egress conn count, container_id }
+                                    │  (EgressFanoutFetcherAdapter)
+                                    ▼
+                      internal/metrics OTel collector (every tick)
+                        container.egress.distinct_destinations{container_id,...}
+                        container.egress.connections{container_id,...}
+                                    │  OTLP push
+                                    ▼
+                              VictoriaMetrics ──▶ threshold/alert
+                                    (sentinel alerting plane: webhook + /metrics)
+```
+
+### Components (this slice)
+
+- **`internal/traffic/fanout.go`** — `aggregateEgress` (pure, unit-tested):
+  folds egress connections into per-container `{DistinctDestinations,
+  EgressConnections, ContainerID}`, sorted by name. `Collector.EgressFanout()`
+  snapshots the live conntrack state, filters EGRESS, and aggregates. Returns
+  nil when conntrack is unavailable (macOS).
+- **`internal/traffic/cache.go`** — `LookupID` resolves container name →
+  `cloud_container_id` so the metric joins to a tenant.
+- **`internal/metrics/otel.go`** — the two `container.egress.*` instruments,
+  `EgressFanoutFetcher` interface + `SetEgressFetcher`, and `RecordEgressFanout`,
+  recorded each collection tick.
+- **`internal/server/egress_fanout_adapter.go`** + `dual_server.go` wiring —
+  bridges the traffic collector to the metrics collector when conntrack is
+  available.
+
+## What is buildable offline vs. needs a live box
+
+**Offline, unit-tested (shipped in this slice):** the `aggregateEgress` fold —
+distinct-destination counting, connection totals, blank-dst handling, container
+-id stamping, stable ordering.
+
+**Already live (no new source needed):** the conntrack collector runs on Linux
+daemons today and produces the egress connections this reads. The only thing
+that was missing is the metric, which this slice adds and wires end-to-end.
+
+**Needs a live box to confirm:** the emitted series in VictoriaMetrics under
+real egress, and tuning the alert threshold (what distinct-destination count,
+over what window, separates a crawler from a busy-but-legitimate app) — that's a
+deployment decision, not code.
+
+## Detection & response
+
+- **Detect:** threshold `container_egress_distinct_destinations` via the sentinel
+  alerting plane that just shipped (webhook + `/metrics`), or a cloud-side rule.
+  A static ceiling is the v1; a baseline-relative anomaly check is a follow-on.
+- **Respond:** the eBPF egress allowlist (#315, deny-by-default) is the
+  enforcement clamp once a crawler is confirmed — detection (this metric) and
+  enforcement (network policy) compose.
+
+## Caveats
+
+- **IPs, not hostnames.** conntrack sees destination IPs. Many hosts behind one
+  CDN IP undercount the fan-out; conversely, many distinct IPs is a strong
+  signal. Good enough for a detection trigger, not a precise crawl census.
+- **Linux-only.** conntrack monitoring is unavailable on macOS; the fetcher
+  returns nil and the plane stays dark (no false readings).
+- **Window aliasing.** The count is over the snapshot window; a slow crawler
+  spread across windows shows a lower instantaneous distinct-count. The
+  persisted store covers longer-horizon analysis.

--- a/internal/metrics/otel.go
+++ b/internal/metrics/otel.go
@@ -51,6 +51,26 @@ type PeerBackendHealth struct {
 	LastSeen  time.Time
 }
 
+// EgressFanoutStat is one container's egress fan-out for a collection tick —
+// the crawler-detection signal. DistinctDestinations is the number of unique
+// destination IPs the container connected out to; EgressConnections is the
+// total egress connection count. ContainerID is the cloud_container_id tenant
+// join key (empty on non-cloud boxes). Mirrors traffic.EgressStat at the
+// metrics boundary so this package needn't import internal/traffic.
+type EgressFanoutStat struct {
+	ContainerName        string
+	ContainerID          string
+	DistinctDestinations int
+	EgressConnections    int
+}
+
+// EgressFanoutFetcher reports per-container egress fan-out. Implemented by an
+// adapter over the conntrack traffic collector; nil when conntrack monitoring
+// is unavailable (e.g. macOS), in which case the plane stays dark.
+type EgressFanoutFetcher interface {
+	EgressFanout() []EgressFanoutStat
+}
+
 // PeerMetricsFetcher fetches container and system metrics from peer backends.
 type PeerMetricsFetcher interface {
 	// FetchPeerMetrics returns container metrics from all healthy peers.
@@ -109,6 +129,10 @@ type Collector struct {
 	containerProcessCount otelmetric.Int64Gauge
 	containerRequestRate  otelmetric.Float64Gauge
 
+	// Egress fan-out instruments (crawler detection, #231 follow-on).
+	containerEgressDistinctDest otelmetric.Int64Gauge
+	containerEgressConnections  otelmetric.Int64Gauge
+
 	// Aggregate instruments
 	containersRunning otelmetric.Int64Gauge
 	containersStopped otelmetric.Int64Gauge
@@ -116,9 +140,10 @@ type Collector struct {
 	// Backend health instruments
 	backendHealthy otelmetric.Int64Gauge
 
-	ctx         context.Context
-	cancel      context.CancelFunc
-	peerFetcher PeerMetricsFetcher
+	ctx           context.Context
+	cancel        context.CancelFunc
+	peerFetcher   PeerMetricsFetcher
+	egressFetcher EgressFanoutFetcher
 }
 
 // NewCollector creates a new OTel metrics collector
@@ -291,6 +316,23 @@ func (c *Collector) initInstruments() error {
 		return err
 	}
 
+	// Egress fan-out (#231 follow-on): the crawler-detection signal. A large,
+	// churning count of distinct outbound destinations is a crawler's hallmark;
+	// a normal app talks to a handful. Per-container aggregates only — the raw
+	// destination IPs stay in the conntrack store, never in metric labels (see
+	// docs/EGRESS-FANOUT-DETECTION.md).
+	c.containerEgressDistinctDest, err = meter.Int64Gauge("container.egress.distinct_destinations",
+		otelmetric.WithDescription("Distinct outbound destination IPs per container in the window (crawler-detection fan-out signal)"))
+	if err != nil {
+		return err
+	}
+
+	c.containerEgressConnections, err = meter.Int64Gauge("container.egress.connections",
+		otelmetric.WithDescription("Active egress connections per container in the window"))
+	if err != nil {
+		return err
+	}
+
 	// Aggregate metrics
 	c.containersRunning, err = meter.Int64Gauge("containarium.containers.running",
 		otelmetric.WithDescription("Number of running containers"))
@@ -452,6 +494,12 @@ func (c *Collector) collect() {
 	c.containersRunning.Record(ctx, running, localAttrs)
 	c.containersStopped.Record(ctx, stopped, localAttrs)
 
+	// Egress fan-out (crawler detection): record per-container distinct
+	// destination + egress connection counts from the conntrack collector.
+	if c.egressFetcher != nil {
+		c.RecordEgressFanout(c.egressFetcher.EgressFanout())
+	}
+
 	// Collect metrics from peer backends
 	if c.peerFetcher != nil {
 		peerMetrics := c.peerFetcher.FetchPeerMetrics("")
@@ -499,6 +547,33 @@ func (c *Collector) RecordRequestRates(samples []reqrate.Sample) {
 // SetPeerFetcher sets the peer metrics fetcher for collecting metrics from peer backends.
 func (c *Collector) SetPeerFetcher(fetcher PeerMetricsFetcher) {
 	c.peerFetcher = fetcher
+}
+
+// SetEgressFetcher sets the egress fan-out fetcher (crawler-detection signal).
+// When set, each collection tick records container.egress.* gauges from it.
+func (c *Collector) SetEgressFetcher(fetcher EgressFanoutFetcher) {
+	c.egressFetcher = fetcher
+}
+
+// RecordEgressFanout records per-container egress fan-out (distinct destinations
+// + egress connections) for one tick. Samples carry their own container.id (the
+// cloud_container_id, empty on standalone boxes) so the VM series joins to a
+// tenant like the bytes plane; backend.id is this daemon's. A spike in
+// distinct_destinations is the crawler tell — alert on it via the sentinel
+// alerting plane (see docs/EGRESS-FANOUT-DETECTION.md).
+func (c *Collector) RecordEgressFanout(stats []EgressFanoutStat) {
+	for _, s := range stats {
+		attrSet := []attribute.KeyValue{
+			attribute.String("container.name", s.ContainerName),
+			attribute.String("backend.id", c.config.LocalBackendID),
+		}
+		if s.ContainerID != "" {
+			attrSet = append(attrSet, attribute.String("container.id", s.ContainerID))
+		}
+		attrs := otelmetric.WithAttributes(attrSet...)
+		c.containerEgressDistinctDest.Record(c.ctx, int64(s.DistinctDestinations), attrs)
+		c.containerEgressConnections.Record(c.ctx, int64(s.EgressConnections), attrs)
+	}
 }
 
 // Stop shuts down the collector

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1673,6 +1673,13 @@ func (ds *DualServer) Start(ctx context.Context) error {
 				})
 			}
 		}
+		// Wire the egress fan-out fetcher (crawler-detection signal) when the
+		// conntrack traffic collector is available.
+		if ds.trafficCollector != nil && ds.trafficCollector.IsAvailable() {
+			ds.metricsCollector.SetEgressFetcher(&EgressFanoutFetcherAdapter{
+				Collector: ds.trafficCollector,
+			})
+		}
 		ds.metricsCollector.Start()
 	}
 

--- a/internal/server/egress_fanout_adapter.go
+++ b/internal/server/egress_fanout_adapter.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	metricsPackage "github.com/footprintai/containarium/internal/metrics"
+	"github.com/footprintai/containarium/internal/traffic"
+)
+
+// EgressFanoutFetcherAdapter adapts the conntrack traffic collector to the
+// metrics.EgressFanoutFetcher interface, bridging traffic.EgressStat to the
+// metrics-boundary type so neither package imports the other. Supplies the
+// egress fan-out crawler-detection signal to the OTel metrics collector.
+type EgressFanoutFetcherAdapter struct {
+	Collector *traffic.Collector
+}
+
+// EgressFanout returns per-container egress fan-out stats, or nil when conntrack
+// monitoring is unavailable.
+func (a *EgressFanoutFetcherAdapter) EgressFanout() []metricsPackage.EgressFanoutStat {
+	if a.Collector == nil {
+		return nil
+	}
+	stats := a.Collector.EgressFanout()
+	out := make([]metricsPackage.EgressFanoutStat, len(stats))
+	for i, s := range stats {
+		out[i] = metricsPackage.EgressFanoutStat{
+			ContainerName:        s.ContainerName,
+			ContainerID:          s.ContainerID,
+			DistinctDestinations: s.DistinctDestinations,
+			EgressConnections:    s.EgressConnections,
+		}
+	}
+	return out
+}

--- a/internal/traffic/cache.go
+++ b/internal/traffic/cache.go
@@ -18,6 +18,7 @@ type ContainerCache struct {
 	mu       sync.RWMutex
 	ipToName map[string]string
 	nameToIP map[string]string
+	nameToID map[string]string // container name -> cloud_container_id label ("" on non-cloud boxes)
 }
 
 // NewContainerCache creates a new container cache
@@ -33,6 +34,7 @@ func NewContainerCache(incusClient *incus.Client, networkCIDR string) *Container
 		network:     network,
 		ipToName:    make(map[string]string),
 		nameToIP:    make(map[string]string),
+		nameToID:    make(map[string]string),
 	}
 }
 
@@ -48,6 +50,15 @@ func (c *ContainerCache) LookupName(name string) string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.nameToIP[name]
+}
+
+// LookupID returns the cloud_container_id label for a container name, or "" if
+// the box is not a cloud-managed tenant (no label). Used to stamp container.id
+// on egress fan-out metrics so they join to a tenant like the bytes plane.
+func (c *ContainerCache) LookupID(name string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.nameToID[name]
 }
 
 // IsContainerIP checks if an IP belongs to the container network
@@ -87,11 +98,15 @@ func (c *ContainerCache) Refresh() error {
 	// Clear and rebuild
 	c.ipToName = make(map[string]string)
 	c.nameToIP = make(map[string]string)
+	c.nameToID = make(map[string]string)
 
 	for _, container := range containers {
 		if container.IPAddress != "" {
 			c.ipToName[container.IPAddress] = container.Name
 			c.nameToIP[container.Name] = container.IPAddress
+		}
+		if id := container.Labels["cloud_container_id"]; id != "" {
+			c.nameToID[container.Name] = id
 		}
 	}
 

--- a/internal/traffic/fanout.go
+++ b/internal/traffic/fanout.go
@@ -1,0 +1,95 @@
+package traffic
+
+import (
+	"sort"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// EgressStat is one container's egress fan-out for a snapshot window — the
+// crawler-detection signal (docs/EGRESS-FANOUT-DETECTION.md). DistinctDestinations
+// is the number of unique destination IPs the container connected out to in the
+// window; a crawler's hallmark is a large, churning fan-out where a normal app
+// talks to a handful of destinations. EgressConnections is the total egress
+// connection count. ContainerID is the cloud_container_id label (empty on
+// non-cloud boxes), the tenant join key shared with the bytes plane.
+//
+// Deliberately a per-container *aggregate*: we count the fan-out, we do not turn
+// each destination IP into its own series. Per-destination series would be
+// unbounded cardinality and would index every site a customer's box visits —
+// the raw destinations stay in the conntrack summary / store (query-time,
+// access-controlled), never in metric labels.
+type EgressStat struct {
+	ContainerName        string
+	ContainerID          string
+	DistinctDestinations int
+	EgressConnections    int
+}
+
+// egressConn is the minimal connection shape the fan-out aggregation needs.
+type egressConn struct {
+	containerName string
+	destIP        string
+}
+
+// aggregateEgress folds a set of egress connections into per-container fan-out
+// stats. idForName resolves a container name to its cloud_container_id ("" when
+// unknown). Output is sorted by container name for stable emit ordering. Pure
+// and side-effect free — the unit-tested core of the egress-fanout metric.
+func aggregateEgress(conns []egressConn, idForName func(string) string) []EgressStat {
+	type acc struct {
+		dests map[string]struct{}
+		count int
+	}
+	byName := make(map[string]*acc)
+	for _, c := range conns {
+		a := byName[c.containerName]
+		if a == nil {
+			a = &acc{dests: make(map[string]struct{})}
+			byName[c.containerName] = a
+		}
+		a.count++
+		if c.destIP != "" {
+			a.dests[c.destIP] = struct{}{}
+		}
+	}
+
+	out := make([]EgressStat, 0, len(byName))
+	for name, a := range byName {
+		id := ""
+		if idForName != nil {
+			id = idForName(name)
+		}
+		out = append(out, EgressStat{
+			ContainerName:        name,
+			ContainerID:          id,
+			DistinctDestinations: len(a.dests),
+			EgressConnections:    a.count,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ContainerName < out[j].ContainerName })
+	return out
+}
+
+// EgressFanout returns per-container egress fan-out stats from the current
+// connection snapshot — the crawler-detection signal. It refreshes the snapshot
+// first (when conntrack is available) so the counts reflect live state, then
+// aggregates only EGRESS-direction connections. Returns nil when conntrack
+// monitoring is unavailable (e.g. macOS).
+func (c *Collector) EgressFanout() []EgressStat {
+	if c.monitor == nil {
+		return nil
+	}
+	c.takeSnapshot()
+
+	c.mu.RLock()
+	conns := make([]egressConn, 0, len(c.connections))
+	for _, conn := range c.connections {
+		if conn.Direction == pb.TrafficDirection_TRAFFIC_DIRECTION_EGRESS {
+			conns = append(conns, egressConn{containerName: conn.ContainerName, destIP: conn.DestIp})
+		}
+	}
+	c.mu.RUnlock()
+
+	return aggregateEgress(conns, c.cache.LookupID)
+}

--- a/internal/traffic/fanout_test.go
+++ b/internal/traffic/fanout_test.go
@@ -1,0 +1,85 @@
+package traffic
+
+import "testing"
+
+func statByName(stats []EgressStat, name string) (EgressStat, bool) {
+	for _, s := range stats {
+		if s.ContainerName == name {
+			return s, true
+		}
+	}
+	return EgressStat{}, false
+}
+
+func TestAggregateEgress_DistinctDestinationsAndCount(t *testing.T) {
+	ids := map[string]string{"crawler": "uuid-c", "normal": "uuid-n"}
+	idForName := func(n string) string { return ids[n] }
+
+	conns := []egressConn{
+		// "crawler": 5 connections to 4 distinct destinations (one repeat).
+		{"crawler", "1.1.1.1"},
+		{"crawler", "2.2.2.2"},
+		{"crawler", "3.3.3.3"},
+		{"crawler", "4.4.4.4"},
+		{"crawler", "1.1.1.1"}, // repeat dst — still one distinct
+		// "normal": 3 connections to 1 distinct destination (an upstream API).
+		{"normal", "10.0.0.9"},
+		{"normal", "10.0.0.9"},
+		{"normal", "10.0.0.9"},
+	}
+
+	stats := aggregateEgress(conns, idForName)
+	if len(stats) != 2 {
+		t.Fatalf("len(stats) = %d, want 2 (%+v)", len(stats), stats)
+	}
+	// Sorted by name: crawler before normal.
+	if stats[0].ContainerName != "crawler" || stats[1].ContainerName != "normal" {
+		t.Errorf("not sorted by name: %+v", stats)
+	}
+
+	c, _ := statByName(stats, "crawler")
+	if c.DistinctDestinations != 4 {
+		t.Errorf("crawler distinct destinations = %d, want 4", c.DistinctDestinations)
+	}
+	if c.EgressConnections != 5 {
+		t.Errorf("crawler egress connections = %d, want 5", c.EgressConnections)
+	}
+	if c.ContainerID != "uuid-c" {
+		t.Errorf("crawler container id = %q, want uuid-c", c.ContainerID)
+	}
+
+	n, _ := statByName(stats, "normal")
+	if n.DistinctDestinations != 1 {
+		t.Errorf("normal distinct destinations = %d, want 1 (fan-out signal separates it from the crawler)", n.DistinctDestinations)
+	}
+	if n.EgressConnections != 3 {
+		t.Errorf("normal egress connections = %d, want 3", n.EgressConnections)
+	}
+}
+
+func TestAggregateEgress_EmptyAndNilID(t *testing.T) {
+	if got := aggregateEgress(nil, nil); got == nil || len(got) != 0 {
+		t.Errorf("aggregateEgress(nil,nil) = %+v, want empty non-nil slice", got)
+	}
+	// nil idForName must not panic and leaves ContainerID empty (standalone box).
+	stats := aggregateEgress([]egressConn{{"solo", "8.8.8.8"}}, nil)
+	if len(stats) != 1 || stats[0].ContainerID != "" || stats[0].DistinctDestinations != 1 {
+		t.Fatalf("stats = %+v, want one solo @ 1 distinct, empty id", stats)
+	}
+}
+
+func TestAggregateEgress_BlankDestIPNotCountedAsDistinct(t *testing.T) {
+	// A connection with no resolved dst IP still counts toward connection total
+	// but must not inflate the distinct-destination fan-out signal.
+	stats := aggregateEgress([]egressConn{
+		{"x", ""},
+		{"x", "9.9.9.9"},
+	}, nil)
+	s, _ := statByName(stats, "x")
+	if s.EgressConnections != 2 {
+		t.Errorf("connections = %d, want 2", s.EgressConnections)
+	}
+	if s.DistinctDestinations != 1 {
+		t.Errorf("distinct destinations = %d, want 1 (blank dst ignored)", s.DistinctDestinations)
+	}
+}


### PR DESCRIPTION
## What

A per-container metric that surfaces the **crawler signature** — a large, churning set of distinct outbound destinations — so hosting a customer crawler (prohibited) can be detected and acted on.

> **Stacked on #551** (base = `docs/request-rate-plane-231`). The `otel.go` egress instruments sit alongside the request-rate ones; retarget to `main` once #551 merges.

## Why this is small

Unlike the inbound request-rate plane (which had no data source), the **egress data already exists**: the conntrack traffic collector (`internal/traffic`) records every container `EGRESS` connection with its destination IP and already aggregates per-destination counts (`GetConnectionSummary` → `TopDestinations`). What was missing is a **continuously-emitted detection metric** — the fan-out was query-time only, so nothing could alert on it.

## The signal (per container, per window)

- **`container_egress_distinct_destinations`** — unique outbound destination IPs (the primary crawler tell; a normal app talks to a handful).
- **`container_egress_connections`** — total egress connection count.

Both carry `container.id` (the `cloud_container_id` join key, like the bytes plane #550) + `container.name` + `backend.id`.

## Privacy posture — count the fan-out, don't index the targets

Deliberately a **per-container aggregate**. **No per-destination-IP series**, because that would (1) explode cardinality (unbounded dst IPs) and (2) turn "every site a customer's box visits" into indexed, retained time-series — a privacy/recon liability. Raw destinations stay in the conntrack summary + store (query-time, access-controlled), never in metric labels.

## Changes

- `internal/traffic/fanout.go` — `aggregateEgress` (pure, unit-tested) + `Collector.EgressFanout()` (snapshots live conntrack, EGRESS-only, nil on macOS).
- `internal/traffic/cache.go` — `LookupID` (container name → `cloud_container_id`).
- `internal/metrics/otel.go` — two instruments, `EgressFanoutFetcher` + `SetEgressFetcher`, `RecordEgressFanout`, wired into the `collect()` tick.
- `internal/server/egress_fanout_adapter.go` + `dual_server.go` — bridge + wiring, active when conntrack is available.
- `docs/EGRESS-FANOUT-DETECTION.md` — signal, privacy posture, detect (sentinel alerting plane) + respond (eBPF egress allowlist #315).

## Tests

`go test ./internal/traffic/...` green — distinct-destination counting (with repeats), connection totals, blank-dst not counted as distinct, container-id stamping, nil-id (standalone box), stable ordering. Full `go build ./...` + `go vet` clean.

## Detect & respond

- **Detect:** threshold `container_egress_distinct_destinations` via the sentinel alerting plane (`d8e312f` — webhook + `/metrics`), or a cloud-side rule. Threshold tuning is a deployment decision.
- **Respond:** the eBPF egress allowlist (#315, deny-by-default) is the enforcement clamp — detection + enforcement compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)