### PR TITLE
feat(alerting): vmalert rules for egress fan-out (crawler detection)

### DIFF
--- a/docs/EGRESS-FANOUT-DETECTION.md
+++ b/docs/EGRESS-FANOUT-DETECTION.md
@@ -68,8 +68,8 @@ case needs the actual targets, that's the surface to use.
                         container.egress.connections{container_id,...}
                                     │  OTLP push
                                     ▼
-                              VictoriaMetrics ──▶ threshold/alert
-                                    (sentinel alerting plane: webhook + /metrics)
+                              VictoriaMetrics ──▶ vmalert (abuse_alerts) ──▶ Alertmanager
+                                    (ContainerEgressFanoutHigh / *Critical)
 ```
 
 ### Components (this slice)
@@ -105,9 +105,20 @@ deployment decision, not code.
 
 ## Detection & response
 
-- **Detect:** threshold `container_egress_distinct_destinations` via the sentinel
-  alerting plane that just shipped (webhook + `/metrics`), or a cloud-side rule.
-  A static ceiling is the v1; a baseline-relative anomaly check is a follow-on.
+- **Detect:** vmalert rules on `container_egress_distinct_destinations` in the
+  monitoring stack's default ruleset (`internal/server/alert_rules.go`,
+  `abuse_alerts` group) — `ContainerEgressFanoutHigh` (> 100 distinct
+  destinations for 10m, warning) and `ContainerEgressFanoutCritical` (> 500 for
+  5m, critical), both excluding `containarium-core-*`. These are **conservative
+  static ceilings** for v1; a baseline-relative anomaly check (per-container
+  rolling norm) is the natural follow-on. They route through the same
+  vmalert → Alertmanager path as the existing system/container/pentest alerts.
+
+  > Not the sentinel alerting plane (`sentinel_preempted_total` etc.): that
+  > exists specifically because the on-spot monitoring dies *with* the spot, so
+  > it owns only the preemption signal. The egress metric lives in
+  > VictoriaMetrics on the running backend, so vmalert is the correct vehicle.
+
 - **Respond:** the eBPF egress allowlist (#315, deny-by-default) is the
   enforcement clamp once a crawler is confirmed — detection (this metric) and
   enforcement (network policy) compose.

--- a/internal/server/alert_rules.go
+++ b/internal/server/alert_rules.go
@@ -151,4 +151,27 @@ const DefaultAlertRules = `groups:
         annotations:
           summary: "Sustained high CPU during pentest"
           description: "System CPU load has been above 90% for 10 minutes, possibly due to an active pentest scan or attack."
+
+  - name: abuse_alerts
+    interval: 30s
+    rules:
+      - alert: ContainerEgressFanoutHigh
+        expr: container_egress_distinct_destinations{container_name!~"containarium-core-.*"} > 100
+        for: 10m
+        labels:
+          severity: warning
+          source: default
+        annotations:
+          summary: "Container egress fan-out is high (possible crawler)"
+          description: "Container {{ $labels.container_name }} is connecting out to {{ $value }} distinct destinations — well above a normal app's handful (DB, an API, a CDN). Sustained high fan-out is the network signature of a crawler/scraper, which is prohibited. This is a conservative default threshold; tune per deployment. See docs/EGRESS-FANOUT-DETECTION.md."
+
+      - alert: ContainerEgressFanoutCritical
+        expr: container_egress_distinct_destinations{container_name!~"containarium-core-.*"} > 500
+        for: 5m
+        labels:
+          severity: critical
+          source: default
+        annotations:
+          summary: "Container egress fan-out is very high (likely crawler)"
+          description: "Container {{ $labels.container_name }} is connecting out to {{ $value }} distinct destinations. This is a strong crawler/scraper signature (prohibited). Investigate, and consider clamping egress via the network policy (deny-by-default allowlist, #315). See docs/EGRESS-FANOUT-DETECTION.md."
 `


### PR DESCRIPTION
## What

The alert layer for the egress fan-out crawler signal (#553). Adds an `abuse_alerts` group to the monitoring stack's `DefaultAlertRules` (vmalert), so `container_egress_distinct_destinations` actually fires:

- **`ContainerEgressFanoutHigh`** — > 100 distinct destinations for 10m (warning)
- **`ContainerEgressFanoutCritical`** — > 500 distinct destinations for 5m (critical)

Both exclude `containarium-core-*` and route through the existing **vmalert → Alertmanager** path, alongside the system/container/pentest rules.

## Threshold rationale

A normal app talks to a handful of destinations (its DB, an upstream API, a CDN); a crawler fans out to hundreds. These are **conservative static ceilings** for v1 — deliberately high to avoid false positives — and are meant to be tuned per deployment. A baseline-relative anomaly check (per-container rolling norm) is the natural follow-on.

## Doc correction

Fixes `docs/EGRESS-FANOUT-DETECTION.md`: detection is **vmalert**, not the sentinel alerting plane. The sentinel plane (`sentinel_preempted_total` etc.) exists specifically because the on-spot monitoring dies *with* the spot, so it owns only the preemption signal. The egress metric lives in VictoriaMetrics on the running backend, so vmalert is the correct vehicle.

## Verification

`DefaultAlertRules` is parsed by `parseDefaultAlertRules` (→ `ListDefaultAlertRules` RPC) and written to the VM container's vmalert rules dir. Verified the new YAML parses and both rules are picked up by that exact parser; `go build ./internal/server/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)