### PR TITLE
feat(sentinel): wake-on-SSH — start a slept box on inbound SSH (#539)

### DIFF
--- a/internal/cmd/ssh_wake_proxy.go
+++ b/internal/cmd/ssh_wake_proxy.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"context"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/footprintai/containarium/internal/sentinel/wakeproxy"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sshWakeProxyRoutes   string
+	sshWakeProxyHost     string
+	sshWakeProxyInterval time.Duration
+)
+
+// sshWakeProxyCmd runs the sentinel-side wake-on-SSH proxy (#539). It's a
+// subcommand of the containarium binary (already present on the sentinel)
+// rather than a separate binary, so deployment ships nothing extra — the
+// startup script just runs it as its own systemd service alongside
+// `containarium sentinel`.
+var sshWakeProxyCmd = &cobra.Command{
+	Use:   "ssh-wake-proxy",
+	Short: "Sentinel-side wake-on-SSH proxy (#539)",
+	Long: `Run the wake-on-SSH proxy on the sentinel.
+
+sshpiper's generated config (keysync) points each user's upstream at
+127.0.0.1:<wakePort> instead of the box directly. This process listens on
+those ports and, per inbound SSH connection, ensures the box's sshd is up
+— waking a slept box via the daemon's HMAC-signed /ssh-wake endpoint —
+then splices the TCP stream to the real box sshd. sshpiper's authorized_keys
+auth and per-user routing are untouched. It re-reads the wake-routes file
+periodically so newly-claimed users become reachable without a restart.
+
+The shared HMAC secret is read from CONTAINARIUM_SENTINEL_AUTH_SECRET (the
+same secret the sentinel uses for /authorized-keys); without it the daemon
+rejects wake calls with 401.`,
+	RunE: runSSHWakeProxy,
+}
+
+func init() {
+	rootCmd.AddCommand(sshWakeProxyCmd)
+	sshWakeProxyCmd.Flags().StringVar(&sshWakeProxyRoutes, "routes", "/etc/sshpiper/wake-routes.json", "path to the wake-routes JSON written by keysync")
+	sshWakeProxyCmd.Flags().StringVar(&sshWakeProxyHost, "host", "127.0.0.1", "host to bind the per-box wake listeners on")
+	sshWakeProxyCmd.Flags().DurationVar(&sshWakeProxyInterval, "reload-interval", 5*time.Second, "how often to re-read the routes file")
+}
+
+func runSSHWakeProxy(cmd *cobra.Command, args []string) error {
+	secret := []byte(os.Getenv("CONTAINARIUM_SENTINEL_AUTH_SECRET"))
+	if len(secret) == 0 {
+		log.Printf("[ssh-wake-proxy] WARNING: CONTAINARIUM_SENTINEL_AUTH_SECRET is unset — /ssh-wake calls will be unsigned and the daemon will reject them (401)")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	m := &wakeListenerSet{
+		proxy:     wakeproxy.New(secret),
+		host:      sshWakeProxyHost,
+		ctx:       ctx,
+		listeners: make(map[int]net.Listener),
+		routes:    make(map[int]wakeproxy.Route),
+	}
+
+	m.reload(sshWakeProxyRoutes)
+	ticker := time.NewTicker(sshWakeProxyInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("[ssh-wake-proxy] shutting down")
+			m.closeAll()
+			return nil
+		case <-ticker.C:
+			m.reload(sshWakeProxyRoutes)
+		}
+	}
+}
+
+// wakeListenerSet owns one listener per wakePort and reconciles the set
+// against the routes file on each reload.
+type wakeListenerSet struct {
+	proxy *wakeproxy.Proxy
+	host  string
+	ctx   context.Context
+
+	mu        sync.RWMutex
+	listeners map[int]net.Listener
+	routes    map[int]wakeproxy.Route
+}
+
+func (m *wakeListenerSet) reload(path string) {
+	routes, err := wakeproxy.LoadRoutes(path)
+	if err != nil {
+		log.Printf("[ssh-wake-proxy] load routes: %v (keeping current set)", err)
+		return
+	}
+	want := make(map[int]wakeproxy.Route, len(routes))
+	for _, r := range routes {
+		if r.WakePort <= 0 || r.BackendIP == "" {
+			continue
+		}
+		want[r.WakePort] = r
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for port, ln := range m.listeners {
+		if _, ok := want[port]; !ok {
+			_ = ln.Close()
+			delete(m.listeners, port)
+			delete(m.routes, port)
+		}
+	}
+	for port, r := range want {
+		m.routes[port] = r
+		if _, ok := m.listeners[port]; ok {
+			continue
+		}
+		addr := net.JoinHostPort(m.host, strconv.Itoa(port))
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			log.Printf("[ssh-wake-proxy] listen %s for %s: %v", addr, r.Username, err)
+			continue
+		}
+		m.listeners[port] = ln
+		go m.accept(port, ln)
+	}
+}
+
+// accept serves a single listener until it's closed, looking up the
+// current route for its port per connection so a reload that re-points
+// the port takes effect for the next connection.
+func (m *wakeListenerSet) accept(port int, ln net.Listener) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return // listener closed by a reload, or fatal
+		}
+		m.mu.RLock()
+		r, ok := m.routes[port]
+		m.mu.RUnlock()
+		if !ok {
+			_ = conn.Close()
+			continue
+		}
+		go m.proxy.Handle(m.ctx, conn, r)
+	}
+}
+
+func (m *wakeListenerSet) closeAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for port, ln := range m.listeners {
+		_ = ln.Close()
+		delete(m.listeners, port)
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -69,6 +69,13 @@ type GatewayServer struct {
 	// Wired from dual_server using the container manager.
 	containerExistsFn func(username string) bool
 
+	// sshWakeFn is the wake-on-SSH hook (#539). When set, POST
+	// /ssh-wake starts a slept box and blocks until its sshd (:22) is
+	// dial-ready, so the sentinel's ssh-wake-proxy can hold an inbound
+	// SSH connection during cold start. Wired from dual_server to
+	// ContainerServer.WakeForSSH; nil disables the endpoint (503).
+	sshWakeFn func(ctx context.Context, username string) (bool, string, error)
+
 	// Wake handler (for serverless / wake-on-HTTP, set externally).
 	// Mounted at /wake/ and at the root catch-all when the daemon's
 	// wake feature is enabled. NOT wrapped by the JWT auth middleware
@@ -170,6 +177,14 @@ func (gs *GatewayServer) SetSentinelAuthSecret(secret []byte) {
 // disconnected" symptom.
 func (gs *GatewayServer) SetContainerExistsFn(fn func(username string) bool) {
 	gs.containerExistsFn = fn
+}
+
+// SetSSHWakeFn wires the wake-on-SSH hook (#539) used by POST /ssh-wake.
+// fn starts a slept box and blocks until its sshd (:22) is dial-ready,
+// returning (ready, containerIP, err). Wired from dual_server to
+// ContainerServer.WakeForSSH; leaving it unset disables /ssh-wake (503).
+func (gs *GatewayServer) SetSSHWakeFn(fn func(ctx context.Context, username string) (bool, string, error)) {
+	gs.sshWakeFn = fn
 }
 
 // SetBackendsHandler sets the handler for the /v1/backends endpoint.
@@ -679,6 +694,10 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 	httpMux.Handle("/certs", auth.SentinelHMACMiddleware(gs.sentinelAuthSecret, ServeCerts(gs.caddyCertDir)))
 	httpMux.Handle("/authorized-keys", auth.SentinelHMACMiddleware(gs.sentinelAuthSecret, ServeAuthorizedKeys("", gs.containerExistsFn)))
 	httpMux.Handle("/authorized-keys/sentinel", auth.SentinelHMACMiddleware(gs.sentinelAuthSecret, ServeSentinelKey()))
+	// Wake-on-SSH (#539): the sentinel's ssh-wake-proxy POSTs here to
+	// start a slept box and wait for its sshd before splicing the held
+	// SSH connection. Same HMAC channel as the other sentinel endpoints.
+	httpMux.Handle("/ssh-wake", auth.SentinelHMACMiddleware(gs.sentinelAuthSecret, ServeSSHWake(gs.sshWakeFn)))
 
 	// Catch-all fallback: when wake-on-HTTP is enabled, Caddy
 	// forwards user traffic to this daemon while a container is

--- a/internal/gateway/ssh_wake_handler.go
+++ b/internal/gateway/ssh_wake_handler.go
@@ -1,0 +1,60 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// SSHWakeRequest is the JSON body for POST /ssh-wake. The sentinel's
+// ssh-wake-proxy sends the box's username when an inbound SSH connection
+// arrives for a box whose sshd isn't answering (i.e. it's auto-slept).
+type SSHWakeRequest struct {
+	Username string `json:"username"`
+}
+
+// SSHWakeResponse reports whether the box's sshd became dial-ready
+// within the wake budget, plus the container IP the daemon observed.
+type SSHWakeResponse struct {
+	Ready bool   `json:"ready"`
+	IP    string `json:"ip"`
+}
+
+// ServeSSHWake returns the handler for POST /ssh-wake (#539, wake-on-SSH).
+// It is the SSH analogue of wake-on-HTTP's wake handler: the sentinel
+// calls it to transparently start a slept box and block until the box's
+// sshd (port 22) accepts, so the held SSH connection can then be spliced
+// through. fn is wired to ContainerServer.WakeForSSH; a nil fn means the
+// feature is not enabled on this daemon (503). This handler is mounted
+// behind auth.SentinelHMACMiddleware — same HMAC channel as
+// /authorized-keys — so only the sentinel can trigger a wake.
+func ServeSSHWake(fn func(ctx context.Context, username string) (bool, string, error)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		if fn == nil {
+			http.Error(w, `{"error":"ssh wake not configured"}`, http.StatusServiceUnavailable)
+			return
+		}
+		var req SSHWakeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Username == "" {
+			http.Error(w, `{"error":"invalid request: username required"}`, http.StatusBadRequest)
+			return
+		}
+
+		ready, ip, err := fn(r.Context(), req.Username)
+		if err != nil {
+			log.Printf("[ssh-wake] wake %s failed: %v", req.Username, err)
+			http.Error(w, `{"error":"wake failed"}`, http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(SSHWakeResponse{Ready: ready, IP: ip}); err != nil {
+			log.Printf("[ssh-wake] encode response for %s: %v", req.Username, err)
+		}
+	}
+}

--- a/internal/gateway/ssh_wake_handler_test.go
+++ b/internal/gateway/ssh_wake_handler_test.go
@@ -1,0 +1,58 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func okWake(_ context.Context, _ string) (bool, string, error) { return true, "10.0.0.7", nil }
+
+func TestServeSSHWake_NilFn(t *testing.T) {
+	rr := httptest.NewRecorder()
+	ServeSSHWake(nil)(rr, httptest.NewRequest(http.MethodPost, "/ssh-wake", strings.NewReader(`{"username":"u"}`)))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("nil fn: code = %d, want 503", rr.Code)
+	}
+}
+
+func TestServeSSHWake_MethodNotAllowed(t *testing.T) {
+	rr := httptest.NewRecorder()
+	ServeSSHWake(okWake)(rr, httptest.NewRequest(http.MethodGet, "/ssh-wake", nil))
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET: code = %d, want 405", rr.Code)
+	}
+}
+
+func TestServeSSHWake_MissingUsername(t *testing.T) {
+	rr := httptest.NewRecorder()
+	ServeSSHWake(okWake)(rr, httptest.NewRequest(http.MethodPost, "/ssh-wake", strings.NewReader(`{}`)))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("empty username: code = %d, want 400", rr.Code)
+	}
+}
+
+func TestServeSSHWake_Happy(t *testing.T) {
+	var got string
+	fn := func(_ context.Context, u string) (bool, string, error) { got = u; return true, "10.0.0.9", nil }
+
+	rr := httptest.NewRecorder()
+	ServeSSHWake(fn)(rr, httptest.NewRequest(http.MethodPost, "/ssh-wake", strings.NewReader(`{"username":"alice"}`)))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200", rr.Code)
+	}
+	if got != "alice" {
+		t.Fatalf("fn got username %q, want alice", got)
+	}
+	var resp SSHWakeResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Ready || resp.IP != "10.0.0.9" {
+		t.Fatalf("resp = %+v, want {Ready:true IP:10.0.0.9}", resp)
+	}
+}

--- a/internal/sentinel/keysync.go
+++ b/internal/sentinel/keysync.go
@@ -15,19 +15,36 @@ import (
 	"time"
 
 	"github.com/footprintai/containarium/internal/gateway"
+	"github.com/footprintai/containarium/internal/sentinel/wakeproxy"
 )
 
 const (
 	sshpiperConfigDir   = "/etc/sshpiper"
-	sshpiperConfigFile  = "/etc/sshpiper/config.yaml"
-	sshpiperUsersDir    = "/etc/sshpiper/users"
 	sshpiperUpstreamKey = "/etc/sshpiper/upstream_key"
+
+	// wake-on-SSH (#539): sshpiper routes each user's upstream through
+	// the local ssh-wake-proxy at 127.0.0.1:<wakePort> instead of the
+	// box directly; the proxy reads wakeRoutesFile to know where to wake
+	// + splice. Ports are assigned deterministically from the sorted
+	// user list as wakeProxyBasePort+index, so the config stays
+	// byte-stable across reruns with the same user set.
+	wakeProxyHost     = "127.0.0.1"
+	wakeProxyBasePort = 40000
+)
+
+// File paths Apply writes. Vars (not const) so tests can redirect them
+// to a temp dir; production values are the /etc/sshpiper defaults.
+var (
+	sshpiperConfigFile = "/etc/sshpiper/config.yaml"
+	sshpiperUsersDir   = "/etc/sshpiper/users"
+	wakeRoutesFile     = "/etc/sshpiper/wake-routes.json"
 )
 
 // backendKeys holds the users fetched from a single backend.
 type backendKeys struct {
 	backendID string
 	backendIP string
+	httpPort  int // daemon HTTP port — used by wake-on-SSH (#539) to reach /ssh-wake
 	users     []gateway.UserKeys
 	lastSync  time.Time
 	lastErr   error
@@ -85,6 +102,7 @@ func (ks *KeyStore) Sync(backendID, backendIP string, httpPort int) error {
 
 	ks.mu.Lock()
 	bk := ks.ensureBackendLocked(backendID, backendIP)
+	bk.httpPort = httpPort
 	bk.users = keysResp.Keys
 	bk.lastSync = time.Now()
 	bk.lastErr = nil
@@ -117,6 +135,7 @@ func (ks *KeyStore) Apply() error {
 		username       string
 		authorizedKeys string
 		backendIP      string
+		httpPort       int
 	}
 	seen := make(map[string]bool)
 	var routes []userRoute
@@ -140,6 +159,7 @@ func (ks *KeyStore) Apply() error {
 				username:       u.Username,
 				authorizedKeys: u.AuthorizedKeys,
 				backendIP:      bk.backendIP,
+				httpPort:       bk.httpPort,
 			})
 		}
 	}
@@ -176,11 +196,16 @@ func (ks *KeyStore) Apply() error {
 		}
 	}
 
-	// Generate sshpiper YAML config with per-user backend routing
+	// Generate sshpiper YAML config. Each user's upstream is routed
+	// through the local ssh-wake-proxy at 127.0.0.1:<wakePort> instead
+	// of the box directly, so an SSH connection to a slept box wakes it
+	// first (#539, wake-on-SSH). The proxy reads wakeRoutesFile to learn
+	// the real box address + how to reach the daemon's /ssh-wake.
 	var buf bytes.Buffer
 	buf.WriteString("version: \"1.0\"\npipes:\n")
 
-	for _, r := range routes {
+	wakeRoutes := make([]wakeproxy.Route, 0, len(routes))
+	for i, r := range routes {
 		// Tunnel backends use loopback aliases (127.0.0.x where x >= 10) with
 		// SSH on port 20022 to avoid conflicting with sshpiper's *:22 listener.
 		// Direct backends (e.g., 10.x.x.x) use the standard port 22.
@@ -188,23 +213,42 @@ func (ks *KeyStore) Apply() error {
 		if isTunnelLoopback(r.backendIP) {
 			sshPort = 20022
 		}
+		// Deterministic per-user wake port (sorted user order → stable
+		// config across reruns with the same user set).
+		wakePort := wakeProxyBasePort + i
+
 		akPath := filepath.Join(sshpiperUsersDir, r.username, "authorized_keys")
 		fmt.Fprintf(&buf, "  - from:\n")
 		fmt.Fprintf(&buf, "      - username: %q\n", r.username)
 		fmt.Fprintf(&buf, "        authorized_keys:\n")
 		fmt.Fprintf(&buf, "          - %s\n", akPath)
 		fmt.Fprintf(&buf, "    to:\n")
-		fmt.Fprintf(&buf, "      host: %s:%d\n", r.backendIP, sshPort)
+		fmt.Fprintf(&buf, "      host: %s:%d\n", wakeProxyHost, wakePort)
 		fmt.Fprintf(&buf, "      username: %q\n", r.username)
 		fmt.Fprintf(&buf, "      ignore_hostkey: true\n")
 		fmt.Fprintf(&buf, "      private_key: %s\n", sshpiperUpstreamKey)
+
+		wakeRoutes = append(wakeRoutes, wakeproxy.Route{
+			Username:        r.username,
+			WakePort:        wakePort,
+			BackendIP:       r.backendIP,
+			SSHPort:         sshPort,
+			BackendHTTPPort: r.httpPort,
+		})
 	}
 
 	newContent := buf.Bytes()
+	wakeRoutesContent, err := json.MarshalIndent(wakeproxy.RouteFile{Routes: wakeRoutes}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal wake routes: %w", err)
+	}
 
-	// Compare with existing config
+	// The sshpiper config is the change trigger; the wake-routes file
+	// derives from the same data, so we also reconcile it when it drifts
+	// (e.g. missing on the first run after upgrade).
 	oldContent, _ := os.ReadFile(sshpiperConfigFile)
-	if bytes.Equal(oldContent, newContent) {
+	oldWake, _ := os.ReadFile(wakeRoutesFile)
+	if bytes.Equal(oldContent, newContent) && bytes.Equal(oldWake, wakeRoutesContent) {
 		ks.mu.Lock()
 		ks.configChanged = false
 		ks.mu.Unlock()
@@ -213,6 +257,9 @@ func (ks *KeyStore) Apply() error {
 
 	if err := os.WriteFile(sshpiperConfigFile, newContent, 0600); err != nil {
 		return fmt.Errorf("failed to write sshpiper config: %w", err)
+	}
+	if err := os.WriteFile(wakeRoutesFile, wakeRoutesContent, 0600); err != nil {
+		return fmt.Errorf("failed to write wake routes: %w", err)
 	}
 
 	ks.mu.Lock()

--- a/internal/sentinel/keysync_wake_test.go
+++ b/internal/sentinel/keysync_wake_test.go
@@ -1,0 +1,71 @@
+package sentinel
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/gateway"
+	"github.com/footprintai/containarium/internal/sentinel/wakeproxy"
+)
+
+// TestApply_RoutesThroughWakeProxy verifies wake-on-SSH wiring (#539):
+// the generated sshpiper config sends each user's upstream to the local
+// wake-proxy port, and the wake-routes file records the real box address
+// + the daemon HTTP port so the proxy can wake and splice.
+func TestApply_RoutesThroughWakeProxy(t *testing.T) {
+	dir := t.TempDir()
+	oldCfg, oldUsers, oldWake := sshpiperConfigFile, sshpiperUsersDir, wakeRoutesFile
+	sshpiperConfigFile = dir + "/config.yaml"
+	sshpiperUsersDir = dir + "/users"
+	wakeRoutesFile = dir + "/wake-routes.json"
+	defer func() {
+		sshpiperConfigFile, sshpiperUsersDir, wakeRoutesFile = oldCfg, oldUsers, oldWake
+	}()
+
+	ks := NewKeyStore()
+	ks.mu.Lock()
+	bk := ks.ensureBackendLocked("b1", "10.0.0.5")
+	bk.httpPort = 8080
+	bk.users = []gateway.UserKeys{{Username: "alice", AuthorizedKeys: "ssh-ed25519 AAAAkey alice"}}
+	ks.mu.Unlock()
+
+	if err := ks.Apply(); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	cfg, err := os.ReadFile(sshpiperConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(cfg), "host: 127.0.0.1:40000") {
+		t.Errorf("sshpiper config should route through the wake proxy port, got:\n%s", cfg)
+	}
+	// It must NOT dial the box directly anymore.
+	if strings.Contains(string(cfg), "host: 10.0.0.5:22") {
+		t.Errorf("sshpiper config still dials the box directly:\n%s", cfg)
+	}
+
+	routes, err := wakeproxy.LoadRoutes(wakeRoutesFile)
+	if err != nil {
+		t.Fatalf("LoadRoutes: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("want 1 route, got %d", len(routes))
+	}
+	r := routes[0]
+	if r.Username != "alice" || r.WakePort != 40000 || r.BackendIP != "10.0.0.5" || r.SSHPort != 22 || r.BackendHTTPPort != 8080 {
+		t.Errorf("wake route = %+v", r)
+	}
+
+	// Re-running with the same state is a no-op (byte-stable config).
+	if err := ks.Apply(); err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	ks.mu.RLock()
+	changed := ks.configChanged
+	ks.mu.RUnlock()
+	if changed {
+		t.Error("second Apply with unchanged state should not mark config changed")
+	}
+}

--- a/internal/sentinel/wakeproxy/wakeproxy.go
+++ b/internal/sentinel/wakeproxy/wakeproxy.go
@@ -1,0 +1,207 @@
+// Package wakeproxy implements the sentinel-side ssh-wake-proxy (#539,
+// wake-on-SSH). sshpiper's generated config points each user's upstream
+// at 127.0.0.1:<wakePort> instead of the box directly; this proxy
+// listens there and, on each inbound connection, ensures the box's sshd
+// is up — waking a slept box via the daemon's HMAC /ssh-wake endpoint —
+// then splices the TCP stream to the real box sshd. It is the SSH
+// analogue of the wake-on-HTTP proxy (internal/wake): sshpiper keeps
+// doing authorized_keys auth and per-user routing untouched.
+package wakeproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+// logf emits a tagged log line. Kept tiny so the proxy stays dependency-light.
+func logf(format string, args ...interface{}) {
+	log.Printf("[ssh-wake-proxy] "+format, args...)
+}
+
+// Route describes how to reach (and wake) one box. sshpiper dials
+// 127.0.0.1:WakePort; the proxy wakes BackendIP via the daemon at
+// BackendHTTPPort then splices to BackendIP:SSHPort.
+type Route struct {
+	Username        string `json:"username"`
+	WakePort        int    `json:"wake_port"`
+	BackendIP       string `json:"backend_ip"`
+	SSHPort         int    `json:"ssh_port"`
+	BackendHTTPPort int    `json:"backend_http_port"`
+}
+
+// RouteFile is the on-disk format keysync writes (wake-routes.json).
+type RouteFile struct {
+	Routes []Route `json:"routes"`
+}
+
+// LoadRoutes reads and parses the wake-routes file. A missing file is
+// not an error — it yields an empty set (the sentinel may start before
+// keysync has written any users).
+func LoadRoutes(path string) ([]Route, error) {
+	b, err := os.ReadFile(path) // #nosec G304 -- operator-controlled config path
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var rf RouteFile
+	if err := json.Unmarshal(b, &rf); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return rf.Routes, nil
+}
+
+// Proxy wakes-then-splices SSH connections for a single Route. The
+// network seams (probe dial, upstream dial, wake HTTP client) are
+// overridable for tests; production uses the defaults.
+type Proxy struct {
+	secret []byte
+
+	// WakeTimeout bounds how long we wait for the box's sshd to accept
+	// after the daemon reports the box ready (mirror wake-on-HTTP's 30s).
+	WakeTimeout time.Duration
+	// ProbeTimeout is the per-dial timeout for the "is sshd up?" check.
+	ProbeTimeout time.Duration
+
+	// HTTPClient calls the daemon's /ssh-wake. Defaults to a client whose
+	// timeout covers the daemon's own wake budget plus slack.
+	HTTPClient *http.Client
+	// Dial opens the upstream SSH connection; defaults to net.DialTimeout.
+	Dial func(network, addr string, timeout time.Duration) (net.Conn, error)
+}
+
+// New builds a Proxy with production defaults. secret is the shared
+// CONTAINARIUM_SENTINEL_AUTH_SECRET used to sign /ssh-wake calls; an
+// empty secret means calls go unsigned and the daemon will 401 (the
+// fail-closed posture matches the other sentinel endpoints).
+func New(secret []byte) *Proxy {
+	p := &Proxy{
+		secret:       secret,
+		WakeTimeout:  30 * time.Second,
+		ProbeTimeout: 500 * time.Millisecond,
+	}
+	p.HTTPClient = &http.Client{Timeout: p.WakeTimeout + 5*time.Second}
+	p.Dial = net.DialTimeout
+	return p
+}
+
+// Handle services one accepted client connection for route r: ensure the
+// box's sshd is reachable (waking it if needed), then splice. It always
+// closes client before returning.
+func (p *Proxy) Handle(ctx context.Context, client net.Conn, r Route) {
+	defer func() { _ = client.Close() }()
+
+	upstream := net.JoinHostPort(r.BackendIP, strconv.Itoa(r.SSHPort))
+
+	// Fast path: a running box answers immediately, so we add only a
+	// single dial probe before splicing.
+	if !p.portOpen(upstream) {
+		if err := p.wake(ctx, r); err != nil {
+			logf("wake %s: %v", r.Username, err)
+			return
+		}
+		// The daemon probes the box's own IP:22; re-confirm the address
+		// the sentinel actually splices to is accepting before we dial.
+		if !p.waitOpen(ctx, upstream) {
+			logf("wake %s: upstream %s not ready after wake", r.Username, upstream)
+			return
+		}
+	}
+
+	dst, err := p.Dial("tcp", upstream, p.ProbeTimeout+5*time.Second)
+	if err != nil {
+		logf("dial upstream %s for %s: %v", upstream, r.Username, err)
+		return
+	}
+	defer func() { _ = dst.Close() }()
+
+	splice(client, dst)
+}
+
+// wake POSTs the daemon's HMAC-signed /ssh-wake and returns nil once the
+// daemon reports the box ready.
+func (p *Proxy) wake(ctx context.Context, r Route) error {
+	url := fmt.Sprintf("http://%s:%d/ssh-wake", r.BackendIP, r.BackendHTTPPort)
+	body, _ := json.Marshal(map[string]string{"username": r.Username})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if len(p.secret) > 0 {
+		auth.SignSentinelRequest(req, p.secret)
+	}
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	var wr struct {
+		Ready bool `json:"ready"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&wr); err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+	if !wr.Ready {
+		return fmt.Errorf("box did not become ready")
+	}
+	return nil
+}
+
+// portOpen reports whether addr accepts a TCP connection right now.
+func (p *Proxy) portOpen(addr string) bool {
+	conn, err := p.Dial("tcp", addr, p.ProbeTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// waitOpen polls addr until it accepts or WakeTimeout elapses / ctx ends.
+func (p *Proxy) waitOpen(ctx context.Context, addr string) bool {
+	deadline := time.Now().Add(p.WakeTimeout)
+	for time.Now().Before(deadline) {
+		if p.portOpen(addr) {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+	return false
+}
+
+// splice copies bytes bidirectionally until either side closes.
+func splice(a, b net.Conn) {
+	done := make(chan struct{}, 2)
+	cp := func(dst, src net.Conn) {
+		_, _ = io.Copy(dst, src)
+		// Unblock the peer copy by half-closing where possible.
+		if c, ok := dst.(interface{ CloseWrite() error }); ok {
+			_ = c.CloseWrite()
+		}
+		done <- struct{}{}
+	}
+	go cp(a, b)
+	go cp(b, a)
+	<-done
+	<-done
+}

--- a/internal/sentinel/wakeproxy/wakeproxy_test.go
+++ b/internal/sentinel/wakeproxy/wakeproxy_test.go
@@ -1,0 +1,192 @@
+package wakeproxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+// echoServer accepts one connection on ln and echoes bytes back until EOF.
+func echoServer(t *testing.T, ln net.Listener) {
+	t.Helper()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				_, _ = io.Copy(c, c)
+			}(c)
+		}
+	}()
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("freePort: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+func hostPort(t *testing.T, rawURL string) (string, int) {
+	t.Helper()
+	u := strings.TrimPrefix(rawURL, "http://")
+	host, portStr, err := net.SplitHostPort(u)
+	if err != nil {
+		t.Fatalf("split %s: %v", rawURL, err)
+	}
+	port, _ := strconv.Atoi(portStr)
+	return host, port
+}
+
+// roundTrip writes a probe string through the proxy and asserts the echo.
+func roundTrip(t *testing.T, p *Proxy, r Route) {
+	t.Helper()
+	clientSide, proxySide := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		p.Handle(context.Background(), proxySide, r)
+		close(done)
+	}()
+
+	msg := []byte("wake-on-ssh-hello")
+	go func() { _, _ = clientSide.Write(msg) }()
+	buf := make([]byte, len(msg))
+	_ = clientSide.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, err := io.ReadFull(clientSide, buf); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if string(buf) != string(msg) {
+		t.Fatalf("echo = %q, want %q", buf, msg)
+	}
+	_ = clientSide.Close()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Handle did not return after client close")
+	}
+}
+
+func TestProxy_FastPath_NoWakeWhenUp(t *testing.T) {
+	backend, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = backend.Close() }()
+	echoServer(t, backend)
+	backendPort := backend.Addr().(*net.TCPAddr).Port
+
+	// A daemon that fails the test if it's ever called — the box is up,
+	// so the proxy must take the fast path and never wake.
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("daemon /ssh-wake called for an already-running box")
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	}))
+	defer daemon.Close()
+	_, dPort := hostPort(t, daemon.URL)
+
+	p := New(nil)
+	roundTrip(t, p, Route{Username: "u", BackendIP: "127.0.0.1", SSHPort: backendPort, BackendHTTPPort: dPort})
+}
+
+func TestProxy_WakesSleptBoxThenSplices(t *testing.T) {
+	// Reserve the backend port but DON'T listen — the box is "slept".
+	backendPort := freePort(t)
+	secret := []byte("0123456789abcdef0123456789abcdef")
+
+	var signed bool
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Containarium-Sentinel-Sig") != "" {
+			signed = true
+		}
+		// "Start" the box: bring up the echo backend on its known port.
+		ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(backendPort)))
+		if err != nil {
+			http.Error(w, "start failed", http.StatusInternalServerError)
+			return
+		}
+		echoServer(t, ln)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]bool{"ready": true})
+	}))
+	defer daemon.Close()
+	_, dPort := hostPort(t, daemon.URL)
+
+	p := New(secret)
+	p.WakeTimeout = 3 * time.Second
+	roundTrip(t, p, Route{Username: "u", BackendIP: "127.0.0.1", SSHPort: backendPort, BackendHTTPPort: dPort})
+
+	if !signed {
+		t.Error("wake request was not HMAC-signed")
+	}
+}
+
+func TestProxy_WakeNotReady_ClosesClient(t *testing.T) {
+	backendPort := freePort(t) // never comes up
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]bool{"ready": false})
+	}))
+	defer daemon.Close()
+	_, dPort := hostPort(t, daemon.URL)
+
+	p := New(nil)
+	clientSide, proxySide := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		p.Handle(context.Background(), proxySide, Route{Username: "u", BackendIP: "127.0.0.1", SSHPort: backendPort, BackendHTTPPort: dPort})
+		close(done)
+	}()
+
+	// Client read should hit EOF (proxy closed the conn after a failed wake).
+	_ = clientSide.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 1)
+	if _, err := clientSide.Read(buf); err == nil {
+		t.Fatal("expected client conn to be closed after failed wake")
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Handle did not return after failed wake")
+	}
+}
+
+func TestLoadRoutes(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/wake-routes.json"
+
+	// Missing file → empty, no error.
+	if got, err := LoadRoutes(path); err != nil || len(got) != 0 {
+		t.Fatalf("missing file: got %v, %v", got, err)
+	}
+
+	rf := RouteFile{Routes: []Route{{Username: "alice", WakePort: 40000, BackendIP: "10.0.0.5", SSHPort: 22, BackendHTTPPort: 8080}}}
+	b, _ := json.Marshal(rf)
+	if err := os.WriteFile(path, b, 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadRoutes(path)
+	if err != nil || len(got) != 1 || got[0].Username != "alice" || got[0].WakePort != 40000 {
+		t.Fatalf("LoadRoutes = %#v, %v", got, err)
+	}
+}
+
+// ensure the auth import is exercised (signing path) so a refactor that
+// drops it is caught by the build, not just at runtime.
+var _ = auth.SignSentinelRequest

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -1015,12 +1015,21 @@ func (s *ContainerServer) waitForContainerReady(ctx context.Context, username, c
 	if err != nil || len(routes) == 0 {
 		return false
 	}
-	port := routes[0].TargetPort
-	if port <= 0 {
+	return waitForPortReady(ctx, containerIP, routes[0].TargetPort, total)
+}
+
+// waitForPortReady polls a TCP dial against ip:port until it accepts or
+// the deadline elapses. Returns true when the probe timed out (the port
+// never became dial-ready); false as soon as a dial succeeds. An empty
+// ip or non-positive port short-circuits to "ready" (false) — the probe
+// is opportunistic. Shared by the HTTP readiness probe
+// (waitForContainerReady, primary route port) and the SSH wake path
+// (WakeForSSH, sshd :22).
+func waitForPortReady(ctx context.Context, ip string, port int, total time.Duration) bool {
+	if ip == "" || port <= 0 {
 		return false
 	}
-
-	addr := net.JoinHostPort(containerIP, strconv.Itoa(port))
+	addr := net.JoinHostPort(ip, strconv.Itoa(port))
 	deadline := time.Now().Add(total)
 	for time.Now().Before(deadline) {
 		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
@@ -1035,6 +1044,46 @@ func (s *ContainerServer) waitForContainerReady(ctx context.Context, username, c
 		}
 	}
 	return true
+}
+
+// SSHDPort is the port the in-container sshd listens on. Fixed at 22 —
+// the wake readiness probe targets the box's own sshd, not the
+// sentinel-side loopback alias (which keysync maps separately).
+const SSHDPort = 22
+
+// WakeForSSH starts a (possibly slept) container and waits for its sshd
+// (port 22) to become dial-ready, so the sentinel's ssh-wake-proxy can
+// hold an inbound SSH connection during a cold start and then splice it
+// through — parity with wake-on-HTTP (internal/wake). Returns:
+//   - ready=true  when the box is up and :22 accepts within the budget;
+//   - ready=false when the readiness probe times out (NOT a hard error —
+//     the caller can still attempt the dial / surface a clean failure);
+//   - err only on a hard failure of the start itself.
+//
+// Runs under the system identity (like the HTTP wake path,
+// internal/wake/proxy.go) because the sentinel calls this out-of-band
+// over the HMAC channel, with no tenant scope on the context. Idle-clock
+// reset and the anti-thrash window are handled by StartContainer itself
+// (it stamps LastStartedAt; autosleep skips sleep for 2× the idle window
+// after a start) plus the conntrack traffic collector, so there is no
+// SSH-specific autosleep bookkeeping here.
+func (s *ContainerServer) WakeForSSH(ctx context.Context, username string, total time.Duration) (bool, string, error) {
+	if username == "" {
+		return false, "", fmt.Errorf("username is required")
+	}
+	if total <= 0 {
+		total = 30 * time.Second
+	}
+	ctx = auth.ContextWithSystemIdentity(ctx)
+	if _, err := s.StartContainer(ctx, &pb.StartContainerRequest{Username: username}); err != nil {
+		return false, "", fmt.Errorf("start %s: %w", username, err)
+	}
+	info, err := s.manager.Get(username)
+	if err != nil || info == nil {
+		return false, "", fmt.Errorf("post-start get %s: %w", username, err)
+	}
+	timedOut := waitForPortReady(ctx, info.IPAddress, SSHDPort, total)
+	return !timedOut, info.IPAddress, nil
 }
 
 // StopContainer stops a running container

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1228,6 +1228,13 @@ skipAppHosting:
 			})
 		}
 
+		// Wake-on-SSH hook (#539): the sentinel's ssh-wake-proxy POSTs
+		// /ssh-wake to start a slept box and block until its sshd (:22)
+		// is dial-ready, parity with wake-on-HTTP. 0 = default 30s budget.
+		gatewayServer.SetSSHWakeFn(func(ctx context.Context, username string) (bool, string, error) {
+			return containerServer.WakeForSSH(ctx, username, 0)
+		})
+
 		// Wire security store for CSV export
 		if securityStore != nil {
 			gatewayServer.SetSecurityStore(securityStore)

--- a/internal/server/wait_for_port_ready_test.go
+++ b/internal/server/wait_for_port_ready_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestWaitForPortReady(t *testing.T) {
+	ctx := context.Background()
+
+	// A listening port → becomes ready immediately (returns false = not timed out).
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	addr := ln.Addr().(*net.TCPAddr)
+	if waitForPortReady(ctx, "127.0.0.1", addr.Port, time.Second) {
+		t.Error("listening port: expected ready (false), got timed-out (true)")
+	}
+
+	// A closed port → times out (returns true).
+	closedLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	closedPort := closedLn.Addr().(*net.TCPAddr).Port
+	_ = closedLn.Close()
+	if !waitForPortReady(ctx, "127.0.0.1", closedPort, 300*time.Millisecond) {
+		t.Error("closed port: expected timed-out (true), got ready (false)")
+	}
+
+	// Empty IP / non-positive port short-circuit to "ready" (false).
+	if waitForPortReady(ctx, "", 22, time.Second) {
+		t.Error("empty ip: expected short-circuit ready (false)")
+	}
+	if waitForPortReady(ctx, "127.0.0.1", 0, time.Second) {
+		t.Error("zero port: expected short-circuit ready (false)")
+	}
+}

--- a/terraform/modules/containarium/scripts/startup-sentinel.sh
+++ b/terraform/modules/containarium/scripts/startup-sentinel.sh
@@ -290,6 +290,34 @@ EOF
     systemctl restart containarium-sentinel.service
     echo "✓ wrote secrets.conf systemd drop-in"
 
+    # Wake-on-SSH proxy (#539). keysync now points each sshpiper upstream
+    # at 127.0.0.1:<wakePort>; this service listens there and, per inbound
+    # SSH connection, wakes a slept box (via the daemon's HMAC-signed
+    # /ssh-wake) before splicing to the real sshd — parity with
+    # wake-on-HTTP. Same binary as the sentinel; reads the shared HMAC
+    # secret from env.secrets. StartLimitIntervalSec=0 + Restart=always
+    # because wake-routes.json isn't written until the first keysync; the
+    # proxy tolerates the missing file and serves an empty set until then.
+    cat > /etc/systemd/system/ssh-wake-proxy.service <<'EOF'
+[Unit]
+Description=Containarium wake-on-SSH proxy
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+EnvironmentFile=-/etc/containarium/env.secrets
+ExecStart=/usr/local/bin/containarium ssh-wake-proxy
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload
+    systemctl enable ssh-wake-proxy
+    systemctl restart ssh-wake-proxy
+    echo "✓ ssh-wake-proxy service installed and started"
+
     # Optional override.conf for --proxy-protocol on the sentinel.
     #
     # `sentinel service install` generates a fixed ExecStart without


### PR DESCRIPTION
Closes #539.

## What
Auto-sleep stops idle boxes and wake-on-HTTP transparently restarts them on an inbound request. SSH had no equivalent — `ssh` to a slept box just failed and the user had to wake it out-of-band. This adds the same **transparent wake-on-new-connection for SSH**.

## Approach
SSH reaches a box through **sshpiper** (external binary) on the sentinel, which has no per-connection pre-dial hook. So the interception is a **thin sentinel-side proxy**, not an sshpiper plugin — sshpiper's `authorized_keys` auth and per-user routing stay untouched.

```
ssh → sshpiperd :22 (auth/routing unchanged)
    → to.host = 127.0.0.1:<wakePort>           (keysync)
    → ssh-wake-proxy: probe box:22 (fast path for running boxes),
        else POST <daemon>/ssh-wake (HMAC) → StartContainer + poll :22 ≤30s
      → splice TCP to the real box sshd
```

## Changes
- **daemon** (`internal/server`): `ContainerServer.WakeForSSH` starts the box under the system identity (like the HTTP wake path) and polls sshd `:22` until ready; the dial loop is factored out of `waitForContainerReady` as `waitForPortReady`. Exposed as `POST /ssh-wake` behind the existing `SentinelHMAC` middleware (same channel as `/authorized-keys`).
- **sentinel** (`internal/sentinel/wakeproxy` + `containarium ssh-wake-proxy`): a subcommand of the existing binary, run as its own systemd unit — no new artifact to ship. Per connection: fast-path probe, else HMAC-signed wake, wait, splice. Routes hot-reload from `wake-routes.json`.
- **keysync**: `to.host` now points at `127.0.0.1:<wakePort>` (deterministic per-user port), plus a `wake-routes.json` mapping each box's real address + the daemon HTTP port.
- **terraform**: a `ssh-wake-proxy` systemd unit on the sentinel.

**Idle reset + anti-thrash come for free:** `StartContainer` stamps `LastStartedAt` (autosleep skips 2× the idle window after a start) and SSH traffic registers via the conntrack collector — no SSH-specific autosleep bookkeeping.

## Tests
`wakeproxy` (fast-path / wake-then-splice with HMAC assertion / wake-timeout / route load), `/ssh-wake` handler (method, nil-fn 503, missing username, happy), `waitForPortReady`, and `keysync` (routes-through-wake-proxy + byte-stable no-op rerun). `gofmt -s` + `go vet` clean; touched-package tests pass.

## Follow-ups (out of scope)
- Per-connection wake currently adds a thin always-on TCP hop for running boxes; a future optimization could route only slept boxes through the proxy.
- Connection-time budget: the handshake is held during cold start (bounded ~30s); documented for clients with short SSH connect timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)