### PR TITLE
docs(agents): agent skills & crews — mechanism design + proto stub

### DIFF
--- a/docs/AGENT-SKILLS-CREWS-DESIGN.md
+++ b/docs/AGENT-SKILLS-CREWS-DESIGN.md
@@ -1,0 +1,164 @@
+# Agent Skills & Crews — Design Note
+
+> Status: **Exploration / not yet approved.** Proto stub lives at
+> `proto/containarium/v1/agent.proto` (also marked unapproved). This note
+> proposes the **generic mechanism** for running collaborating agents on top of
+> Containarium. Concrete skills and crews — compliance packs, research crews,
+> domain catalogs — are built on this mechanism and ship **outside this
+> repo**; nothing task-specific belongs here. Nothing below is wired yet.
+
+## The thesis: Containarium is the trust fabric, not "another agent framework"
+
+Anyone can stand up a CrewAI / LangGraph / AutoGen crew today. That is not a
+moat, and we should not try to win on orchestration ergonomics.
+
+What Containarium *uniquely already has* — and what almost no agent framework
+has — is the thing that matters the moment agents start talking to each other
+and touching real systems:
+
+- **Per-box isolation** — every agent runs in its own LXC sandbox, not a
+  thread in one process.
+- **eBPF network policy** — deny-by-default, egress allowlist, enforced
+  in-kernel (Phase A shipped; see `NetworkPolicyService`).
+- **Audit logging** — every action, username, IP, timestamp, to Postgres
+  (`internal/audit/`, `/v1/audit/logs`).
+- **Scope-gated MCP tools** — `containers:create` etc., JWT-claim validated
+  (`internal/auth/scopes.go`).
+- **Secrets encryption + KMS** — AES-256-GCM, audit-logged on read.
+
+So the product framing is: **agent-to-agent collaboration where every hop is
+sandboxed, network-policy-gated, and audit-logged.** That is the moat. It is
+also what makes Containarium the right substrate for the workloads where the
+*how* of agent collaboration matters as much as the result — untrusted code,
+multi-tenant fan-out, anything an auditor will later ask about. The mechanism
+here is deliberately neutral about *which* such workload; those are built on
+top, elsewhere.
+
+## What's missing today
+
+From the current surface (MCP, `RecipeService`, `EventService`, audit,
+`NetworkPolicyService`, `SecurityService`, `PentestService`), exactly three
+pieces are absent:
+
+1. **An agent as a first-class, runnable, packaged unit.** A recipe gives you
+   the box; nothing gives you the *agent* (its prompt, its allowed tools, its
+   allowed peers).
+2. **Agent-to-agent transport.** `EventService` is observe-only fan-out; MCP
+   is agent→tool, not agent→agent request/reply.
+3. **Crew / orchestration.** No workflow, choreography, or pipeline exists.
+
+This note fills those three with the smallest surface that preserves the
+trust-fabric guarantees.
+
+## Three channels, kept separate
+
+| Channel | Direction | Carries | Status |
+|---|---|---|---|
+| **MCP** | agent → platform / box | "do things": create container, run shell, read logs | exists |
+| **A2A** | agent ↔ agent | "delegate a task, get an artifact back" | **new** |
+| **EventService** | platform → agents | "container created → wake the worker" (async triggers/observation) | exists |
+
+We adopt the **A2A (Agent2Agent) protocol** for inter-agent transport rather
+than inventing a bus. It is the emerging standard (agent cards, tasks,
+artifacts), it is request/reply with streaming, and it fits proto-first
+cleanly. We **insulate it behind our own proto** (`AgentCard`, crew messages)
+so upstream A2A churn can't break the `AgentSkill`/`Crew` surface — the same
+way recipes are insulated from backend churn.
+
+## The "skill" abstraction: Recipe + Agent Manifest
+
+A **skill = a recipe (the box) + an agent manifest (the agent layer).** See
+`AgentSkill` in the proto stub. The manifest's load-bearing fields:
+
+```
+AgentSkill {
+  recipe_ref / recipe   // the box: image, resources, gpu
+  system_prompt         // who this agent is
+  allowed_scopes[]      // which MCP tools it may call  → minted into its JWT
+  agent_card            // A2A discovery: name, capabilities, in/out schema
+  allowed_peers[]       // which OTHER skills it may talk to → COMPILES TO eBPF
+}
+```
+
+**`allowed_peers` is the keystone.** It compiles directly into an eBPF
+`NetworkPolicy` egress allowlist. A skill that is only allowed to talk to one
+peer *literally cannot open a socket to anything else* — dropped in-kernel, and
+the attempt is logged. The crew topology and the network ACL are the same
+artifact.
+
+Corollary (and a hard rule per `CLAUDE.md`'s strong-typing convention):
+`allowed_scopes` and `allowed_peers` are **typed, first-class fields, never a
+prompt string**. If a skill is just "a recipe plus a system prompt blob," the
+network-gating differentiator never materializes and we've built a worse
+CrewAI. **The typing is the product.**
+
+## Crews
+
+A **crew** is a collaborating set of skills bound to a task purpose
+(`Crew` + `CrewService`). The daemon, on `RunCrew`:
+
+1. Validates the crew's topology against the union of member skills'
+   `allowed_peers` — **rejects any A2A edge that network policy would drop**
+   (no silent "the prompt says talk to X but the kernel blocks it").
+2. Provisions each skill's box.
+3. Compiles per-agent `NetworkPolicy` from `allowed_peers`.
+4. Threads **one `trace_id`** through every agent's audit entries — so a crew
+   run is itself an evidence artifact.
+
+`CLI-first` per convention: `containarium crew run <crew.yaml>`; the MCP tool
+and `CrewService` REST endpoint are thin wrappers over the same Go function.
+
+The crew *mechanism* lives here; the crew *definitions* (which skills, what
+topology, for what purpose) ship outside this repo as catalogs.
+
+## Roadmap (mechanism only)
+
+All phases below are the generic substrate that lives in this repo. Concrete
+skill/crew catalogs are built on top of it and shipped separately.
+
+| Phase | Deliverable |
+|---|---|
+| **0 — Agent-as-a-box** | `AgentSkill` proto; `containarium agent run <skill>` launches one agent in a box with scoped MCP access. Reuses agent-box + recipe + scopes. |
+| **1 — A2A transport** | Agent card served per box; `containarium agent call` request/reply. Two agents collaborate; B returns an artifact to A. |
+| **2 — Trust fabric** ← moat | `allowed_peers` → eBPF `NetworkPolicy`; every A2A hop audit-logged under a shared `trace_id`. **Demo: an agent that tries to reach a non-allowed peer is dropped in-kernel and logged.** This is the slide that separates us from CrewAI. |
+| **3 — Crew primitive** | `containarium crew run <crew.yaml>` — declarative topology, shared artifact store, single trace. |
+
+## Phase 0 — issue breakdown
+
+1. **`proto/containarium/v1/agent.proto` → real.** Finalize `AgentSkill` +
+   `AgentSkillService` (defer `Crew`/`CrewService` to Phase 3). `make proto`.
+2. **`agent-runtime` recipe.** A box image with the model client + agent-box
+   MCP preinstalled, so a skill's `recipe_ref` can point at it.
+3. **`internal/server/agent_server.go`.** Implement `RunAgentSkill`: mint a
+   JWT scoped to exactly `allowed_scopes`, provision the box (reuse
+   `RecipeService` deploy path), inject prompt + scoped token, run one task,
+   return the artifact. No peers yet.
+4. **CLI: `internal/cmd/agent.go`.** `containarium agent list|get|run` →
+   thin cobra over the generated client (CLI-first).
+5. **MCP wrapper.** `run_agent_skill` tool in `internal/mcp/tools.go`,
+   `RequiredScope: "agents:run"` — thin wrapper over the same Go function.
+6. **Scope additions.** Add `agents:run` to `internal/auth/scopes.go`.
+7. **A neutral reference skill.** A generic example (e.g. a shell/worker
+   skill) used only to prove the runtime end-to-end — kept deliberately
+   task-agnostic. Real, opinionated skills live outside this repo.
+8. **Docs.** `docs/AGENT-SKILLS-QUICKSTART.md` (mirror `MCP-QUICKSTART.md`).
+
+## Risks / open questions
+
+1. **Don't let "skill" decay into "recipe + a prompt string."** If the
+   manifest doesn't carry `allowed_scopes` / `allowed_peers` as typed,
+   compiled fields, the network-gating differentiator never ships. Gate this
+   in review.
+2. **A2A is young.** Pin a version; keep it behind our proto so the wire
+   format can be swapped without breaking `AgentSkill`/`Crew`.
+3. **Model-driving runtime placement.** Where does the agent loop actually
+   run — inside the box (agent-box reachable over stdio/SSH) or a
+   daemon-side driver? Phase 0 leans "inside the box" to reuse agent-box and
+   keep the model's blast radius inside the sandbox; revisit for crews.
+4. **Cost/quotas.** Crews fan out boxes; tie into the existing per-tenant
+   accounting + ephemeral-sandbox warm-pool work
+   (`docs/EPHEMERAL-SANDBOX-DESIGN.md`) so an agent inner loop isn't paying
+   30–90s box-create each hop.
+5. **Secret exposure to agents.** Agents should read secret *metadata/config*,
+   never plaintext, unless the skill explicitly declares the scope. Enforce
+   via scope granularity, not convention.

--- a/proto/containarium/v1/agent.proto
+++ b/proto/containarium/v1/agent.proto
@@ -1,0 +1,334 @@
+syntax = "proto3";
+
+package containarium.v1;
+
+import "google/api/annotations.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
+import "containarium/v1/container.proto";
+import "containarium/v1/recipe.proto";
+
+option go_package = "github.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1";
+
+// =============================================================================
+// DESIGN STUB — NOT YET APPROVED. See docs/AGENT-SKILLS-CREWS-DESIGN.md.
+//
+// This file sketches the proto contract for "agent skills" (a packaged,
+// runnable agent in a box) and "crews" (a collaborating set of skills bound
+// to a task purpose). It is the generic mechanism only — concrete skills and
+// crews ship outside this repo. It is the Phase 0/1 surface; field numbers and
+// shapes will change before `make proto` is run for real. Do not wire
+// servers/clients against it until the design lands.
+// =============================================================================
+
+// AgentCard is the A2A (Agent2Agent) discovery document a skill serves so peer
+// agents can find it and learn how to delegate to it. Mirrors the A2A agent
+// card; we carry it in-proto so the wire format stays insulated from upstream
+// A2A churn (see "A2A is young" in the design note).
+message AgentCard {
+  // Stable handle used by peers to address this agent (e.g. "researcher").
+  string id = 1;
+
+  // Human-readable name.
+  string name = 2;
+
+  // What this agent does — surfaced to peers and to a planner.
+  string description = 3;
+
+  // Free-form capability tags a planner can match against (e.g.
+  // "web-search", "code-review", "summarize").
+  repeated string capabilities = 4;
+
+  // JSON Schema describing the task input this agent accepts (A2A "skills").
+  string input_schema_json = 5;
+
+  // JSON Schema describing the artifact this agent returns.
+  string output_schema_json = 6;
+}
+
+// AgentSkill is a packaged, runnable agent: a Recipe (the box — image,
+// resources, GPU) plus the agent layer (who it is, what tools it may call,
+// who it may talk to). This is the unit a marketplace ships and `containarium
+// agent run` launches.
+//
+// Key invariant: allowed_scopes and allowed_peers are typed, first-class
+// fields — NOT a prompt string. They compile into JWT scope grants and eBPF
+// network policy respectively. The typing IS the security boundary.
+message AgentSkill {
+  // Stable skill identifier (e.g. "web-researcher").
+  string id = 1;
+
+  // Display name.
+  string name = 2;
+
+  // Short description.
+  string description = 3;
+
+  // The box this agent runs in. Either reference a built-in recipe by id, or
+  // inline an ad-hoc recipe definition (exactly one).
+  oneof box {
+    // Reference an existing recipe by id (e.g. "agent-runtime").
+    string recipe_id = 4;
+    // Inline recipe definition for one-off skills.
+    Recipe recipe = 5;
+  }
+
+  // System prompt / persona handed to the model inside the box.
+  string system_prompt = 6;
+
+  // Platform MCP scopes this agent is permitted to use (e.g.
+  // "containers:read", "containers:create"). Validated against the scope
+  // taxonomy in internal/auth/scopes.go; minted into the agent's JWT at
+  // launch. Least-privilege: a skill gets ONLY what it declares.
+  repeated string allowed_scopes = 7;
+
+  // A2A discovery document this skill serves.
+  AgentCard agent_card = 8;
+
+  // IDs of the OTHER skills this skill is permitted to send A2A tasks to.
+  // THE KEYSTONE: this list compiles to an eBPF NetworkPolicy egress
+  // allowlist, so an agent literally cannot open a socket to a non-allowed
+  // peer (enforced in-kernel, not in prompt). A skill that is only allowed
+  // one peer cannot reach any other. An empty list = talks to no peer
+  // (leaf agent).
+  repeated string allowed_peers = 9;
+
+  // Model identifier the runtime should drive this agent with (e.g.
+  // "claude-opus-4-8"). Empty = runtime default.
+  string model = 10;
+}
+
+// CrewTopology describes how a crew's skills are wired together.
+enum CrewTopology {
+  CREW_TOPOLOGY_UNSPECIFIED = 0;
+
+  // Skills run as a linear pipeline: output of skill[i] feeds skill[i+1].
+  CREW_TOPOLOGY_PIPELINE = 1;
+
+  // A coordinator skill fans tasks out to worker skills and synthesizes.
+  CREW_TOPOLOGY_ORCHESTRATOR = 2;
+
+  // Skills coordinate freely over A2A within the allowed_peers graph; the
+  // crew just bounds the set and the trace.
+  CREW_TOPOLOGY_FREEFORM = 3;
+}
+
+// Crew is a collaborating set of skills bound to a task purpose. The crew's
+// edges must be a subset of the union of its skills' allowed_peers graphs —
+// the daemon rejects a crew whose topology asks for an A2A edge that network
+// policy would drop.
+message Crew {
+  // Stable crew identifier (e.g. "research-crew").
+  string id = 1;
+
+  // Display name.
+  string name = 2;
+
+  // Short description of the task purpose (e.g. "Research a topic across
+  // several sources and produce a synthesized report").
+  string description = 3;
+
+  // How the skills are wired.
+  CrewTopology topology = 4;
+
+  // Skill ids that make up this crew (in pipeline order when topology is
+  // PIPELINE; coordinator first when ORCHESTRATOR).
+  repeated string skill_ids = 5;
+}
+
+// CrewRunState tracks the lifecycle of a single crew execution.
+enum CrewRunState {
+  CREW_RUN_STATE_UNSPECIFIED = 0;
+  CREW_RUN_STATE_PENDING = 1;
+  CREW_RUN_STATE_RUNNING = 2;
+  CREW_RUN_STATE_COMPLETED = 3;
+  CREW_RUN_STATE_FAILED = 4;
+  CREW_RUN_STATE_CANCELLED = 5;
+}
+
+// CrewRun is one execution of a crew. Every A2A hop and every MCP tool call
+// made by any agent in the run is audit-logged under this run's trace_id
+// (ties into internal/audit), so a run is itself an evidence artifact.
+message CrewRun {
+  // Run identifier.
+  string id = 1;
+
+  // The crew that was run.
+  string crew_id = 2;
+
+  // Shared trace id threaded through every agent's audit entries for this run.
+  string trace_id = 3;
+
+  // Current state.
+  CrewRunState state = 4;
+
+  // JSON input handed to the crew's entry skill(s).
+  string input_json = 5;
+
+  // JSON artifact produced by the crew (e.g. the final report). Populated when
+  // state is COMPLETED.
+  string artifact_json = 6;
+
+  // RFC3339 timestamps.
+  string created_at = 7;
+  string finished_at = 8;
+}
+
+// ---- AgentSkillService request/response messages ----------------------------
+
+message ListAgentSkillsRequest {}
+message ListAgentSkillsResponse {
+  repeated AgentSkill skills = 1;
+}
+
+message GetAgentSkillRequest {
+  string id = 1;
+}
+message GetAgentSkillResponse {
+  AgentSkill skill = 1;
+}
+
+// RunAgentSkillRequest launches a single skill in its box and sends it one
+// task (no peers). Useful for testing a skill in isolation.
+message RunAgentSkillRequest {
+  string skill_id = 1;
+  // Target backend/pool placement, same scheme as recipes.
+  string backend_id = 2;
+  string pool = 3;
+  // JSON task input matching the skill's agent_card input schema.
+  string input_json = 4;
+}
+message RunAgentSkillResponse {
+  // The box the agent ran in.
+  Container container = 1;
+  // JSON artifact matching the skill's output schema.
+  string artifact_json = 2;
+}
+
+// ---- CrewService request/response messages ----------------------------------
+
+message ListCrewsRequest {}
+message ListCrewsResponse {
+  repeated Crew crews = 1;
+}
+
+message GetCrewRequest {
+  string id = 1;
+}
+message GetCrewResponse {
+  Crew crew = 1;
+}
+
+message RunCrewRequest {
+  string crew_id = 1;
+  string backend_id = 2;
+  string pool = 3;
+  // JSON input for the crew's entry skill(s).
+  string input_json = 4;
+}
+message RunCrewResponse {
+  CrewRun run = 1;
+}
+
+message GetCrewRunRequest {
+  string id = 1;
+}
+message GetCrewRunResponse {
+  CrewRun run = 1;
+}
+
+// AgentSkillService manages and runs individual packaged agents.
+service AgentSkillService {
+  // ListAgentSkills returns all available skills (built-in + registered).
+  rpc ListAgentSkills(ListAgentSkillsRequest) returns (ListAgentSkillsResponse) {
+    option (google.api.http) = {
+      get: "/v1/agent-skills"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List agent skills";
+      description: "Returns all packaged agent skills that can be run individually or composed into a crew.";
+      tags: "Agents";
+    };
+  }
+
+  // GetAgentSkill returns a single skill definition by id.
+  rpc GetAgentSkill(GetAgentSkillRequest) returns (GetAgentSkillResponse) {
+    option (google.api.http) = {
+      get: "/v1/agent-skills/{id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get agent skill";
+      description: "Returns one skill's definition, including its agent card, allowed scopes, and allowed peers.";
+      tags: "Agents";
+    };
+  }
+
+  // RunAgentSkill launches a single skill in a box and runs one task against
+  // it. The agent's JWT is minted with exactly the skill's allowed_scopes.
+  rpc RunAgentSkill(RunAgentSkillRequest) returns (RunAgentSkillResponse) {
+    option (google.api.http) = {
+      post: "/v1/agent-skills/{skill_id}/run"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Run an agent skill";
+      description: "Provisions the skill's box, mints a scoped token, runs one task, and returns the artifact.";
+      tags: "Agents";
+    };
+  }
+}
+
+// CrewService runs collaborating sets of skills bound to a task purpose.
+service CrewService {
+  // ListCrews returns all available crews.
+  rpc ListCrews(ListCrewsRequest) returns (ListCrewsResponse) {
+    option (google.api.http) = {
+      get: "/v1/crews"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List crews";
+      description: "Returns all crews (collaborating skill sets) available to run.";
+      tags: "Agents";
+    };
+  }
+
+  // GetCrew returns a single crew definition by id.
+  rpc GetCrew(GetCrewRequest) returns (GetCrewResponse) {
+    option (google.api.http) = {
+      get: "/v1/crews/{id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get crew";
+      description: "Returns one crew's definition, including its topology and member skills.";
+      tags: "Agents";
+    };
+  }
+
+  // RunCrew launches a crew against an input. The daemon validates the crew's
+  // topology against the union of member skills' allowed_peers (rejecting any
+  // edge network policy would drop), provisions the boxes, compiles per-agent
+  // network policy from allowed_peers, and threads one trace_id through every
+  // hop's audit record.
+  rpc RunCrew(RunCrewRequest) returns (RunCrewResponse) {
+    option (google.api.http) = {
+      post: "/v1/crews/{crew_id}/run"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Run a crew";
+      description: "Provisions each skill's box, gates A2A traffic with eBPF network policy compiled from allowed_peers, runs the collaboration, and returns the run handle.";
+      tags: "Agents";
+    };
+  }
+
+  // GetCrewRun returns the status and artifact of a crew run.
+  rpc GetCrewRun(GetCrewRunRequest) returns (GetCrewRunResponse) {
+    option (google.api.http) = {
+      get: "/v1/crew-runs/{id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get crew run";
+      description: "Returns the state, trace id, and (when complete) the artifact of a crew execution.";
+      tags: "Agents";
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Exploration design note + a generic proto contract for running **collaborating agents** on top of Containarium.

- A **skill** = a recipe (the box) + a typed agent manifest: `system_prompt`, `allowed_scopes` (→ minted into the agent's JWT), `agent_card` (A2A discovery), and `allowed_peers` (→ compiled into an eBPF NetworkPolicy egress allowlist).
- A **crew** = a collaborating set of skills bound to a task purpose.
- The thesis: Containarium is the **trust fabric** for multi-agent systems — every agent-to-agent hop is sandboxed (per-box LXC), network-policy-gated (`allowed_peers` → eBPF, enforced in-kernel), and audit-logged under a shared trace id.

## Scope

This is the **generic mechanism only** — agent-as-a-box, A2A transport, the `allowed_peers` → network-policy compilation, and the crew primitive. No named skills, crews, or domain-specific content live here; those are built on top and shipped separately.

## Files

- `docs/AGENT-SKILLS-CREWS-DESIGN.md` — design note: thesis, three channels (MCP / A2A / EventService), skill = recipe + manifest, crews, roadmap phases 0–3, Phase-0 issue breakdown, risks.
- `proto/containarium/v1/agent.proto` — `AgentSkill` / `Crew` / `AgentSkillService` / `CrewService` contract stub.

## Status / not done on purpose

- Both files are marked **exploration / not yet approved**.
- `make proto` was **not** run — the contract is exploratory; no generated code until the design is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)