### PR TITLE
feat(agents): AgentSkillService daemon core (#560, #559, #563, #564)

### DIFF
--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -83,7 +83,47 @@ const (
 	// agent token CAN do; admin-on-paper agent tokens
 	// without `tokens:write` can't revoke either.
 	ScopeTokensWrite = "tokens:write"
+
+	// agent skills (AgentSkillService). `agents:read` lists/inspects the
+	// skill catalog; `agents:run` provisions a skill's box and runs a task.
+	// A skill's OWN token is minted with only the scopes the skill declares
+	// (allowed_scopes) — these two gate the operator/agent that drives the
+	// AgentSkillService, not the skill's in-box token.
+	ScopeAgentsRead = "agents:read"
+	ScopeAgentsRun  = "agents:run"
 )
+
+// AllScopes is the catalog of every known scope. It backs IsKnownScope so
+// callers (e.g. the skill catalog) can reject a manifest that declares a
+// scope that does not exist — turning a typo into a load-time error instead
+// of a silently-overbroad token.
+var AllScopes = []string{
+	ScopeContainersRead, ScopeContainersWrite,
+	ScopeSecretsRead, ScopeSecretsWrite,
+	ScopeKMSAdmin,
+	ScopeBackupsRead, ScopeBackupsWrite,
+	ScopeVolumesRead, ScopeVolumesWrite,
+	ScopeRoutesRead, ScopeRoutesWrite,
+	ScopeSecurityRead, ScopeSecurityWrite,
+	ScopeAlertsRead, ScopeAlertsWrite,
+	ScopeTrafficRead,
+	ScopeCodeWrite, ScopeSSHWrite,
+	ScopeTokensWrite,
+	ScopeAgentsRead, ScopeAgentsRun,
+}
+
+// IsKnownScope reports whether s is a defined scope (the wildcard counts).
+func IsKnownScope(s string) bool {
+	if s == ScopeWildcard {
+		return true
+	}
+	for _, k := range AllScopes {
+		if k == s {
+			return true
+		}
+	}
+	return false
+}
 
 // HasScope returns true when the granted-scopes set covers
 // the required scope. Semantics:

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -388,6 +388,11 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to register recipe service gateway: %w", err)
 	}
 
+	// Register AgentSkillService gateway handler
+	if err := pb.RegisterAgentSkillServiceHandlerFromEndpoint(ctx, mux, gs.grpcAddress, opts); err != nil {
+		return fmt.Errorf("failed to register agent-skill service gateway: %w", err)
+	}
+
 	// Register BackupService gateway handler
 	if err := pb.RegisterBackupServiceHandlerFromEndpoint(ctx, mux, gs.grpcAddress, opts); err != nil {
 		return fmt.Errorf("failed to register backup service gateway: %w", err)

--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -1,0 +1,158 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/skills"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// agentTokenTTL bounds the lifetime of the JWT minted for a skill's in-box
+// agent loop. Short by design: a skill run is a bounded task, not a session.
+const agentTokenTTL = 30 * time.Minute
+
+// agentSeedDir is where RunAgentSkill writes the skill's system prompt, scoped
+// token, and task input inside the box. The in-box agent loop (the
+// agent-runtime image's job — Phase 0 integration seam) reads from here.
+const agentSeedDir = "/etc/containarium/agent"
+
+// AgentSkillServer implements the gRPC AgentSkillService (Phase 0:
+// agent-as-a-box). It is pure orchestration: RunAgentSkill resolves a skill
+// from the catalog, provisions its box by reusing RecipeServer.deploy, mints a
+// JWT scoped to exactly the skill's allowed_scopes, and seeds the box. The
+// in-box agent loop that consumes the seed and produces an artifact is the
+// agent-runtime image's responsibility and is intentionally out of scope for
+// Phase 0 (artifact_json is returned empty until that lands).
+type AgentSkillServer struct {
+	pb.UnimplementedAgentSkillServiceServer
+	catalog *skills.Manager
+	recipes *RecipeServer      // box provisioning (reuses CreateContainer/exec/expose)
+	tokens  *auth.TokenManager // mints the skill's scoped in-box token
+}
+
+// NewAgentSkillServer wires the agent-skill service to the recipe server (for
+// box provisioning) and the token manager (for minting scoped in-box tokens).
+func NewAgentSkillServer(recipes *RecipeServer, tokens *auth.TokenManager) *AgentSkillServer {
+	return &AgentSkillServer{
+		catalog: skills.GetDefault(),
+		recipes: recipes,
+		tokens:  tokens,
+	}
+}
+
+// ListAgentSkills returns all built-in skills.
+func (s *AgentSkillServer) ListAgentSkills(ctx context.Context, _ *pb.ListAgentSkillsRequest) (*pb.ListAgentSkillsResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeAgentsRead); err != nil {
+		return nil, err
+	}
+	return &pb.ListAgentSkillsResponse{Skills: s.catalog.List()}, nil
+}
+
+// GetAgentSkill returns a single skill by ID.
+func (s *AgentSkillServer) GetAgentSkill(ctx context.Context, req *pb.GetAgentSkillRequest) (*pb.GetAgentSkillResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeAgentsRead); err != nil {
+		return nil, err
+	}
+	if req.Id == "" {
+		return nil, status.Error(codes.InvalidArgument, "id is required")
+	}
+	skill, err := s.catalog.Get(req.Id)
+	if err != nil {
+		return nil, status.Error(codes.NotFound, err.Error())
+	}
+	return &pb.GetAgentSkillResponse{Skill: skill}, nil
+}
+
+// RunAgentSkill provisions a skill's box, mints a token scoped to exactly the
+// skill's allowed_scopes, seeds the prompt/token/input into the box, and
+// returns the box. Gated on agents:run; the inner provisioning still enforces
+// containers:write + tenant authz via CreateContainer.
+//
+// Phase 0 limitations (documented seams):
+//   - The in-box agent loop is the agent-runtime image's job; artifact_json is
+//     returned empty until it lands.
+//   - The box name is derived deterministically from the skill id, so two
+//     concurrent runs of the same skill collide. Per-run boxes / a warm pool
+//     are a later concern (see docs/EPHEMERAL-SANDBOX-DESIGN.md).
+//   - allowed_peers is inert until Phase 2 (eBPF enforcement).
+func (s *AgentSkillServer) RunAgentSkill(ctx context.Context, req *pb.RunAgentSkillRequest) (*pb.RunAgentSkillResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeAgentsRun); err != nil {
+		return nil, err
+	}
+	if req.SkillId == "" {
+		return nil, status.Error(codes.InvalidArgument, "skill_id is required")
+	}
+
+	skill, err := s.catalog.Get(req.SkillId)
+	if err != nil {
+		return nil, status.Error(codes.NotFound, err.Error())
+	}
+
+	// Phase 0 supports only the recipe_id box form (catalog skills). Inline
+	// recipes are an API-only construct deferred to a later phase.
+	recipeID := skill.GetRecipeId()
+	if recipeID == "" {
+		return nil, status.Error(codes.Unimplemented,
+			"inline-recipe skills are not supported yet; use a skill that references a recipe_id")
+	}
+
+	// Deterministic box identity for the run (see limitations above).
+	name := "agent-" + skill.Id
+	if err := auth.AuthorizeTenant(ctx, name); err != nil {
+		return nil, err
+	}
+
+	// 1. Provision the box by reusing the recipe deploy path.
+	dep, err := s.recipes.deploy(ctx, &pb.DeployRecipeRequest{
+		RecipeId:  recipeID,
+		Name:      name,
+		BackendId: req.BackendId,
+		Pool:      req.Pool,
+	})
+	if err != nil {
+		return nil, err // already a gRPC status from deploy/CreateContainer
+	}
+
+	// 2. Mint a JWT scoped to EXACTLY the skill's allowed_scopes. The catalog
+	//    guarantees len(allowed_scopes) >= 1, so this is a bounded token, not
+	//    the "no restriction" nil-claim case.
+	token, err := s.tokens.GenerateToken(name, []string{}, agentTokenTTL, skill.AllowedScopes...)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to mint scoped agent token: %v", err)
+	}
+
+	// 3. Seed the prompt/token/input into the box for the in-box agent loop.
+	containerName := name + "-container"
+	if err := s.recipes.containers.manager.Exec(containerName,
+		[]string{"bash", "-c", buildAgentSeedScript(skill.SystemPrompt, token, req.InputJson)}); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to seed agent box %s: %v", containerName, err)
+	}
+
+	// artifact_json intentionally empty in Phase 0 (in-box loop seam).
+	return &pb.RunAgentSkillResponse{Container: dep.Container, ArtifactJson: ""}, nil
+}
+
+// buildAgentSeedScript writes the skill's system prompt, scoped token, and task
+// input under agentSeedDir with restrictive permissions. Values are single-quote
+// escaped (shellSingleQuote, from recipe_server.go) to prevent shell injection.
+func buildAgentSeedScript(systemPrompt, token, inputJSON string) string {
+	if inputJSON == "" {
+		inputJSON = "{}"
+	}
+	var b strings.Builder
+	b.WriteString("set -euo pipefail\n")
+	b.WriteString("umask 077\n")
+	fmt.Fprintf(&b, "mkdir -p %s\n", agentSeedDir)
+	fmt.Fprintf(&b, "printf '%%s' %s > %s/system_prompt.txt\n", shellSingleQuote(systemPrompt), agentSeedDir)
+	fmt.Fprintf(&b, "printf '%%s' %s > %s/token\n", shellSingleQuote(token), agentSeedDir)
+	fmt.Fprintf(&b, "printf '%%s' %s > %s/input.json\n", shellSingleQuote(inputJSON), agentSeedDir)
+	fmt.Fprintf(&b, "chmod 600 %s/token\n", agentSeedDir)
+	return b.String()
+}

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildAgentSeedScript(t *testing.T) {
+	script := buildAgentSeedScript("be helpful", "tok-123", `{"q":"hi"}`)
+
+	for _, want := range []string{
+		"set -euo pipefail",
+		"umask 077",
+		"mkdir -p " + agentSeedDir,
+		agentSeedDir + "/system_prompt.txt",
+		agentSeedDir + "/token",
+		agentSeedDir + "/input.json",
+		"chmod 600 " + agentSeedDir + "/token",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("seed script missing %q\n---\n%s", want, script)
+		}
+	}
+}
+
+func TestBuildAgentSeedScriptDefaultsInput(t *testing.T) {
+	script := buildAgentSeedScript("p", "t", "")
+	if !strings.Contains(script, "'{}'") {
+		t.Errorf("empty input should default to {}, got:\n%s", script)
+	}
+}
+
+func TestBuildAgentSeedScriptEscapesSingleQuotes(t *testing.T) {
+	// A system prompt containing a single quote must be escaped so it can't
+	// break out of the shell-quoted printf argument.
+	script := buildAgentSeedScript("don't panic", "t", "{}")
+	if strings.Contains(script, "don't") && !strings.Contains(script, `don'\''t`) {
+		t.Errorf("single quote not escaped in seed script:\n%s", script)
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -297,8 +297,15 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	// Register RecipeService — one-command deployment of declarative
 	// GPU/app recipes. Pure orchestration over the container + network
 	// servers; networkServer may be nil (expose then degrades to a warning).
-	pb.RegisterRecipeServiceServer(grpcServer, NewRecipeServer(containerServer, networkServer))
+	recipeServer := NewRecipeServer(containerServer, networkServer)
+	pb.RegisterRecipeServiceServer(grpcServer, recipeServer)
 	log.Printf("Recipe service enabled")
+
+	// Register AgentSkillService — Phase 0 agent-as-a-box. Reuses the recipe
+	// server for box provisioning and the token manager for minting the
+	// skill's scoped in-box token.
+	pb.RegisterAgentSkillServiceServer(grpcServer, NewAgentSkillServer(recipeServer, tokenManager))
+	log.Printf("Agent-skill service enabled")
 
 	// Register BackupService — logical (pg_dump) database backups for the
 	// databases running inside containers, stored off-host (local dir or

--- a/internal/server/recipe_server.go
+++ b/internal/server/recipe_server.go
@@ -84,7 +84,13 @@ func (s *RecipeServer) DeployRecipe(ctx context.Context, req *pb.DeployRecipeReq
 	if err := auth.AuthorizeTenant(ctx, req.Name); err != nil {
 		return nil, err
 	}
+	return s.deploy(ctx, req)
+}
 
+// deploy is the provisioning body shared by DeployRecipe and the
+// AgentSkillService. Callers must perform their own authorization first;
+// the inner CreateContainer still enforces containers:write + tenant authz.
+func (s *RecipeServer) deploy(ctx context.Context, req *pb.DeployRecipeRequest) (*pb.DeployRecipeResponse, error) {
 	recipe, err := s.catalog.Get(req.RecipeId)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, err.Error())

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -64,3 +64,21 @@ recipes:
     post_start:
       - podman volume create llamacpp-models
       - 'podman run -d --name llamacpp --restart=always --device nvidia.com/gpu=all -p 8080:8080 -v llamacpp-models:/models ghcr.io/ggml-org/llama.cpp:server-cuda -hf "$CONTAINARIUM_PARAM_HF_REPO" --host 0.0.0.0 --port 8080'
+
+  # agent-runtime is the box an AgentSkill runs in (AgentSkillService). It is a
+  # plain Ubuntu LXC with the agent-box MCP available; the skill's system
+  # prompt, scoped token, and task input are seeded under /etc/containarium/agent
+  # by RunAgentSkill, and the in-box agent loop (the agent-runtime image's job)
+  # consumes them. No GPU and no exposed ports by default — a skill that needs
+  # either declares its own box. post_start just ensures the seed directory.
+  - id: agent-runtime
+    name: Agent Runtime
+    description: Base box for running an AgentSkill — Ubuntu LXC with the agent-box MCP; the in-box agent loop reads its prompt/token/input from /etc/containarium/agent.
+    image: images:ubuntu/24.04
+    requires_gpu: false
+    resources:
+      cpu: "2"
+      memory: 4GB
+      disk: 20GB
+    post_start:
+      - mkdir -p /etc/containarium/agent

--- a/pkg/core/skills/skills.go
+++ b/pkg/core/skills/skills.go
@@ -1,0 +1,188 @@
+// Package skills provides the built-in catalog of agent skills. A skill is a
+// packaged, runnable agent: a box (a recipe id) plus a typed manifest
+// (system prompt, allowed scopes, agent card, allowed peers). It mirrors
+// pkg/core/recipes: the catalog ships as embedded YAML and is exposed to the
+// rest of the system as strongly-typed pb.AgentSkill values.
+//
+// This catalog is the generic mechanism only — the reference skill is
+// deliberately task-agnostic. Opinionated/domain skills (compliance, etc.)
+// ship outside this repo.
+package skills
+
+import (
+	"embed"
+	"fmt"
+	"sync"
+
+	"github.com/footprintai/containarium/internal/auth"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed *.yaml
+var embeddedFS embed.FS
+
+// cardDef mirrors pb.AgentCard for YAML decoding.
+type cardDef struct {
+	ID               string   `yaml:"id"`
+	Name             string   `yaml:"name"`
+	Description      string   `yaml:"description,omitempty"`
+	Capabilities     []string `yaml:"capabilities,omitempty"`
+	InputSchemaJSON  string   `yaml:"input_schema_json,omitempty"`
+	OutputSchemaJSON string   `yaml:"output_schema_json,omitempty"`
+}
+
+// skillDef is the YAML shape of a skill. It converts to pb.AgentSkill via
+// ToProto so the wire/API contract stays the single source of truth. Only the
+// recipe_id box form is expressible in YAML; inline recipes are an API-only
+// (one-off) construct.
+type skillDef struct {
+	ID            string   `yaml:"id"`
+	Name          string   `yaml:"name"`
+	Description   string   `yaml:"description,omitempty"`
+	RecipeID      string   `yaml:"recipe_id"`
+	SystemPrompt  string   `yaml:"system_prompt"`
+	AllowedScopes []string `yaml:"allowed_scopes"`
+	AgentCard     *cardDef `yaml:"agent_card,omitempty"`
+	AllowedPeers  []string `yaml:"allowed_peers,omitempty"`
+	Model         string   `yaml:"model,omitempty"`
+}
+
+// ToProto converts a skillDef to its pb.AgentSkill representation.
+func (s *skillDef) ToProto() *pb.AgentSkill {
+	out := &pb.AgentSkill{
+		Id:            s.ID,
+		Name:          s.Name,
+		Description:   s.Description,
+		Box:           &pb.AgentSkill_RecipeId{RecipeId: s.RecipeID},
+		SystemPrompt:  s.SystemPrompt,
+		AllowedScopes: s.AllowedScopes,
+		AllowedPeers:  s.AllowedPeers,
+		Model:         s.Model,
+	}
+	if s.AgentCard != nil {
+		out.AgentCard = &pb.AgentCard{
+			Id:               s.AgentCard.ID,
+			Name:             s.AgentCard.Name,
+			Description:      s.AgentCard.Description,
+			Capabilities:     s.AgentCard.Capabilities,
+			InputSchemaJson:  s.AgentCard.InputSchemaJSON,
+			OutputSchemaJson: s.AgentCard.OutputSchemaJSON,
+		}
+	}
+	return out
+}
+
+type config struct {
+	Skills []skillDef `yaml:"skills"`
+}
+
+// Manager holds the loaded skill catalog.
+type Manager struct {
+	skills []*pb.AgentSkill
+	mu     sync.RWMutex
+}
+
+var (
+	defaultManager *Manager
+	once           sync.Once
+)
+
+// New creates an empty skill manager.
+func New() *Manager { return &Manager{} }
+
+// GetDefault returns the process-wide manager backed by the embedded catalog.
+func GetDefault() *Manager {
+	once.Do(func() {
+		defaultManager = New()
+		if err := defaultManager.LoadEmbedded(); err != nil {
+			// Embedded data is compiled in; a failure here is a programmer
+			// error, so leaving the catalog empty is the safe degradation.
+			defaultManager.skills = nil
+		}
+	})
+	return defaultManager
+}
+
+// LoadEmbedded loads the built-in skills.yaml bundled into the binary.
+func (m *Manager) LoadEmbedded() error {
+	data, err := embeddedFS.ReadFile("skills.yaml")
+	if err != nil {
+		return fmt.Errorf("read embedded skills: %w", err)
+	}
+	return m.LoadFromBytes(data)
+}
+
+// LoadFromBytes parses and validates a YAML skill catalog.
+func (m *Manager) LoadFromBytes(data []byte) error {
+	var cfg config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parse skills YAML: %w", err)
+	}
+
+	loaded := make([]*pb.AgentSkill, 0, len(cfg.Skills))
+	seen := map[string]bool{}
+	for i := range cfg.Skills {
+		def := &cfg.Skills[i]
+		if err := validate(def); err != nil {
+			return err
+		}
+		if seen[def.ID] {
+			return fmt.Errorf("duplicate skill id: %s", def.ID)
+		}
+		seen[def.ID] = true
+		loaded = append(loaded, def.ToProto())
+	}
+
+	m.mu.Lock()
+	m.skills = loaded
+	m.mu.Unlock()
+	return nil
+}
+
+func validate(s *skillDef) error {
+	if s.ID == "" {
+		return fmt.Errorf("skill is missing required field: id")
+	}
+	if s.RecipeID == "" {
+		return fmt.Errorf("skill %q is missing required field: recipe_id", s.ID)
+	}
+	if s.SystemPrompt == "" {
+		return fmt.Errorf("skill %q is missing required field: system_prompt", s.ID)
+	}
+	// Least-privilege is enforced at the manifest level: a skill MUST declare
+	// at least one scope. An empty set would mint a token with no `scopes`
+	// claim, which HasScope treats as "no restriction" (backwards compat) —
+	// the opposite of what a leaf skill wants. Declaring scopes makes the
+	// in-box token explicitly bounded.
+	if len(s.AllowedScopes) == 0 {
+		return fmt.Errorf("skill %q must declare at least one allowed_scope", s.ID)
+	}
+	for _, sc := range s.AllowedScopes {
+		if !auth.IsKnownScope(sc) {
+			return fmt.Errorf("skill %q declares unknown scope %q", s.ID, sc)
+		}
+	}
+	return nil
+}
+
+// List returns all loaded skills.
+func (m *Manager) List() []*pb.AgentSkill {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*pb.AgentSkill, len(m.skills))
+	copy(out, m.skills)
+	return out
+}
+
+// Get returns a skill by ID, or an error if it does not exist.
+func (m *Manager) Get(id string) (*pb.AgentSkill, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, s := range m.skills {
+		if s.Id == id {
+			return s, nil
+		}
+	}
+	return nil, fmt.Errorf("skill not found: %s", id)
+}

--- a/pkg/core/skills/skills.yaml
+++ b/pkg/core/skills/skills.yaml
@@ -1,0 +1,36 @@
+# Containarium Agent-Skill Catalog
+#
+# A skill is a packaged, runnable agent: a box (recipe_id) plus a typed
+# manifest. RunAgentSkill provisions the box, mints a JWT scoped to exactly
+# allowed_scopes, seeds the system prompt + token + task input under
+# /etc/containarium/agent, and the in-box agent loop takes it from there.
+#
+# This catalog is the GENERIC MECHANISM only. The single entry below is a
+# deliberately task-agnostic reference skill that proves the runtime
+# end-to-end. Opinionated/domain skills (compliance packs, research crews,
+# etc.) are built on this mechanism and ship OUTSIDE this repo.
+#
+# Invariants enforced at load (see skills.go validate):
+#   - recipe_id, system_prompt, and >=1 allowed_scope are required.
+#   - every allowed_scope must be a known scope (internal/auth/scopes.go).
+
+skills:
+  - id: hello-agent
+    name: Hello Agent
+    description: Neutral reference skill. Echoes/answers a task to prove the agent runtime end-to-end; not intended for real work.
+    recipe_id: agent-runtime
+    system_prompt: >-
+      You are a minimal reference agent. Read the task input, do the smallest
+      useful thing it asks, and return a concise JSON artifact. You are a
+      demonstration of the runtime, not a production assistant.
+    allowed_scopes:
+      - containers:read
+    allowed_peers: []
+    model: claude-opus-4-8
+    agent_card:
+      id: hello-agent
+      name: Hello Agent
+      description: A neutral reference agent used to validate the skill runtime.
+      capabilities:
+        - echo
+        - summarize

--- a/pkg/core/skills/skills_test.go
+++ b/pkg/core/skills/skills_test.go
@@ -1,0 +1,104 @@
+package skills
+
+import "testing"
+
+func TestEmbeddedCatalogLoads(t *testing.T) {
+	m := GetDefault()
+	all := m.List()
+	if len(all) == 0 {
+		t.Fatal("embedded skills catalog is empty")
+	}
+
+	// The neutral reference skill must be present and well-formed.
+	hello, err := m.Get("hello-agent")
+	if err != nil {
+		t.Fatalf("hello-agent reference skill missing: %v", err)
+	}
+	if hello.GetRecipeId() != "agent-runtime" {
+		t.Errorf("hello-agent box = %q, want recipe_id agent-runtime", hello.GetRecipeId())
+	}
+	if hello.SystemPrompt == "" {
+		t.Error("hello-agent has empty system_prompt")
+	}
+	if len(hello.AllowedScopes) == 0 {
+		t.Error("hello-agent declares no allowed_scopes")
+	}
+}
+
+func TestValidateRejectsBadManifests(t *testing.T) {
+	cases := map[string]string{
+		"missing recipe_id": `
+skills:
+  - id: x
+    system_prompt: hi
+    allowed_scopes: [containers:read]
+`,
+		"missing system_prompt": `
+skills:
+  - id: x
+    recipe_id: agent-runtime
+    allowed_scopes: [containers:read]
+`,
+		"no scopes": `
+skills:
+  - id: x
+    recipe_id: agent-runtime
+    system_prompt: hi
+    allowed_scopes: []
+`,
+		"unknown scope": `
+skills:
+  - id: x
+    recipe_id: agent-runtime
+    system_prompt: hi
+    allowed_scopes: [containers:teleport]
+`,
+		"duplicate id": `
+skills:
+  - id: x
+    recipe_id: agent-runtime
+    system_prompt: hi
+    allowed_scopes: [containers:read]
+  - id: x
+    recipe_id: agent-runtime
+    system_prompt: hi
+    allowed_scopes: [containers:read]
+`,
+	}
+	for name, yaml := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := New().LoadFromBytes([]byte(yaml)); err == nil {
+				t.Errorf("expected load error for %q, got nil", name)
+			}
+		})
+	}
+}
+
+func TestValidateAcceptsGoodManifest(t *testing.T) {
+	const good = `
+skills:
+  - id: ok
+    name: OK
+    recipe_id: agent-runtime
+    system_prompt: do the thing
+    allowed_scopes: [containers:read, routes:read]
+    allowed_peers: []
+    agent_card:
+      id: ok
+      capabilities: [echo]
+`
+	m := New()
+	if err := m.LoadFromBytes([]byte(good)); err != nil {
+		t.Fatalf("unexpected load error: %v", err)
+	}
+	s, err := m.Get("ok")
+	if err != nil {
+		t.Fatalf("get ok: %v", err)
+	}
+	if got := len(s.AllowedScopes); got != 2 {
+		t.Errorf("allowed_scopes len = %d, want 2", got)
+	}
+	if s.AgentCard == nil || s.AgentCard.Id != "ok" {
+		t.Error("agent_card not decoded")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 0 (agent-as-a-box), **server side** — the `AgentSkillService` gRPC + REST surface and everything it needs to run a single skill in a box. Builds on the merged proto (#558).

Closes #559, #560, #563, #564. Follow-ups: #561 (client + CLI), #562 (MCP tool), #565 (docs).

## What's here

- **Scopes (#563):** `agents:read` / `agents:run` added to `internal/auth/scopes.go`, plus `AllScopes` + `IsKnownScope` so the skill catalog rejects an unknown scope at load time (turns a manifest typo into a load error, not a silently-overbroad token).
- **`agent-runtime` recipe (#559):** a plain Ubuntu LXC box for running a skill; seed dir created in `post_start`. No GPU / no exposed ports by default.
- **Skill catalog (#564):** new `pkg/core/skills` mirroring `pkg/core/recipes` — embedded YAML → typed `pb.AgentSkill`, with load-time validation enforcing `recipe_id` + `system_prompt` + **≥1 known** `allowed_scope`. Ships **one neutral, task-agnostic** reference skill (`hello-agent`). Opinionated/domain skills ship outside this repo.
- **`AgentSkillServer` (#560):** `ListAgentSkills` / `GetAgentSkill` (catalog reads) and `RunAgentSkill`, which reuses `RecipeServer.deploy` to provision the box, mints a JWT scoped to **exactly** the skill's `allowed_scopes`, and seeds the system prompt + token + input under `/etc/containarium/agent`. Registered on the gRPC server and the REST gateway. `DeployRecipe` is split into an auth gate + a shared `deploy()` body so both services reuse the provisioning path.

## Documented Phase-0 seams

- The **in-box agent loop** (the `agent-runtime` image's job) is out of scope, so `artifact_json` is returned empty for now.
- Box name is derived from the skill id → concurrent same-skill runs collide (per-run boxes / warm pool is a later concern, see `docs/EPHEMERAL-SANDBOX-DESIGN.md`).
- `allowed_peers` is inert until **Phase 2** (eBPF enforcement, epic #578).

## Verification

- `go build ./...` green, `go vet` clean, `gofmt` clean.
- New tests: skills catalog load/validation (good + bad manifests + the reference skill) and the seed-script builder (paths, perms, default input, shell-quote escaping). `pkg/core/recipes` tests still pass (they validate the new `agent-runtime` recipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)