### PR TITLE
feat(agents): typed client + containarium agent CLI (#561)

### DIFF
--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -24,6 +24,7 @@ type GRPCClient struct {
 	backupClient  pb.BackupServiceClient
 	volumeClient  pb.VolumeServiceClient
 	kmsClient     pb.KmsServiceClient
+	agentClient   pb.AgentSkillServiceClient
 }
 
 // NewGRPCClient creates a new gRPC client
@@ -79,6 +80,7 @@ func NewGRPCClient(serverAddr string, certsDir string, insecureConn bool) (*GRPC
 	backupClient := pb.NewBackupServiceClient(conn)
 	volumeClient := pb.NewVolumeServiceClient(conn)
 	kmsClient := pb.NewKmsServiceClient(conn)
+	agentClient := pb.NewAgentSkillServiceClient(conn)
 
 	return &GRPCClient{
 		conn:          conn,
@@ -89,6 +91,7 @@ func NewGRPCClient(serverAddr string, certsDir string, insecureConn bool) (*GRPC
 		backupClient:  backupClient,
 		volumeClient:  volumeClient,
 		kmsClient:     kmsClient,
+		agentClient:   agentClient,
 	}, nil
 }
 
@@ -583,6 +586,49 @@ func (c *GRPCClient) DeployRecipe(recipeID, name, gpu, backendID, pool string, p
 	resp, err := c.recipeClient.DeployRecipe(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy recipe: %w", err)
+	}
+	return resp, nil
+}
+
+// ListAgentSkills lists all built-in agent skills via gRPC.
+func (c *GRPCClient) ListAgentSkills() ([]*pb.AgentSkill, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := c.agentClient.ListAgentSkills(ctx, &pb.ListAgentSkillsRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list agent skills: %w", err)
+	}
+	return resp.Skills, nil
+}
+
+// GetAgentSkill fetches a single agent skill definition via gRPC.
+func (c *GRPCClient) GetAgentSkill(id string) (*pb.AgentSkill, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := c.agentClient.GetAgentSkill(ctx, &pb.GetAgentSkillRequest{Id: id})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get agent skill: %w", err)
+	}
+	return resp.Skill, nil
+}
+
+// RunAgentSkill provisions a skill's box, mints a scoped token, runs one task,
+// and returns the box via gRPC.
+func (c *GRPCClient) RunAgentSkill(skillID, backendID, pool, inputJSON string) (*pb.RunAgentSkillResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute) // box provisioning can take time
+	defer cancel()
+
+	req := &pb.RunAgentSkillRequest{
+		SkillId:   skillID,
+		BackendId: backendID,
+		Pool:      pool,
+		InputJson: inputJSON,
+	}
+	resp, err := c.agentClient.RunAgentSkill(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to run agent skill: %w", err)
 	}
 	return resp, nil
 }

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -1063,6 +1063,81 @@ func (c *HTTPClient) DeployRecipe(recipeID, name, gpu, backendID, pool string, p
 	return out, nil
 }
 
+// ListAgentSkills lists all built-in agent skills via HTTP.
+func (c *HTTPClient) ListAgentSkills() ([]*pb.AgentSkill, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := c.doRequest(ctx, http.MethodGet, "/v1/agent-skills", nil)
+	if err != nil {
+		return nil, fmt.Errorf("list agent skills: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "list agent skills")
+	}
+	out := &pb.ListAgentSkillsResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out.Skills, nil
+}
+
+// GetAgentSkill fetches a single agent skill definition via HTTP.
+func (c *HTTPClient) GetAgentSkill(id string) (*pb.AgentSkill, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/agent-skills/%s", url.PathEscape(id))
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get agent skill: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "get agent skill")
+	}
+	out := &pb.GetAgentSkillResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out.Skill, nil
+}
+
+// RunAgentSkill provisions a skill's box, mints a scoped token, runs one task,
+// and returns the box via HTTP.
+func (c *HTTPClient) RunAgentSkill(skillID, backendID, pool, inputJSON string) (*pb.RunAgentSkillResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute) // box provisioning can take time
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/agent-skills/%s/run", url.PathEscape(skillID))
+	body := map[string]interface{}{
+		"skill_id":   skillID,
+		"backend_id": backendID,
+		"pool":       pool,
+		"input_json": inputJSON,
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("run agent skill: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "run agent skill")
+	}
+	out := &pb.RunAgentSkillResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
 // CreateBackup dumps a tenant's database and stores it off-host via HTTP.
 func (c *HTTPClient) CreateBackup(req *pb.CreateBackupRequest) (*pb.CreateBackupResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/footprintai/containarium/internal/client"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/spf13/cobra"
+)
+
+var agentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "Run packaged agent skills (Phase 0: agent-as-a-box)",
+	Long: `An agent skill is a packaged, runnable agent: a box (a recipe) plus a
+typed manifest (system prompt, allowed scopes, allowed peers). 'agent run'
+provisions the skill's box, mints a token scoped to exactly the skill's
+allowed_scopes, and seeds the prompt/token/input into the box.
+
+  containarium agent list
+  containarium agent get hello-agent
+  containarium agent run hello-agent --input '{"q":"hi"}' --server <host>`,
+}
+
+func init() {
+	rootCmd.AddCommand(agentCmd)
+}
+
+// agentAPI is the subset of the typed client used by agent commands. Both the
+// gRPC and HTTP clients satisfy it, so commands dispatch on --http without
+// duplicating method calls.
+type agentAPI interface {
+	ListAgentSkills() ([]*pb.AgentSkill, error)
+	GetAgentSkill(id string) (*pb.AgentSkill, error)
+	RunAgentSkill(skillID, backendID, pool, inputJSON string) (*pb.RunAgentSkillResponse, error)
+	Close() error
+}
+
+// newAgentClient returns an agent-capable client for the configured server.
+func newAgentClient() (agentAPI, error) {
+	if serverAddr == "" {
+		return nil, fmt.Errorf("--server is required")
+	}
+	if httpMode {
+		return client.NewHTTPClient(serverAddr, authToken)
+	}
+	return client.NewGRPCClient(serverAddr, certsDir, insecure)
+}

--- a/internal/cmd/agent_get.go
+++ b/internal/cmd/agent_get.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/footprintai/containarium/pkg/core/skills"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/spf13/cobra"
+)
+
+var agentGetCmd = &cobra.Command{
+	Use:   "get <skill-id>",
+	Short: "Show an agent skill's definition",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAgentGet,
+}
+
+func init() {
+	agentCmd.AddCommand(agentGetCmd)
+}
+
+func runAgentGet(cmd *cobra.Command, args []string) error {
+	id := args[0]
+
+	var s *pb.AgentSkill
+	var err error
+	if serverAddr == "" {
+		s, err = skills.GetDefault().Get(id)
+	} else {
+		var c agentAPI
+		c, err = newAgentClient()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = c.Close() }()
+		s, err = c.GetAgentSkill(id)
+	}
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("ID:            %s\n", s.Id)
+	fmt.Printf("Name:          %s\n", s.Name)
+	fmt.Printf("Description:   %s\n", s.Description)
+	fmt.Printf("Box (recipe):  %s\n", s.GetRecipeId())
+	fmt.Printf("Model:         %s\n", s.Model)
+	fmt.Printf("Allowed scopes: %s\n", strings.Join(s.AllowedScopes, ", "))
+	peers := "(none — leaf agent)"
+	if len(s.AllowedPeers) > 0 {
+		peers = strings.Join(s.AllowedPeers, ", ")
+	}
+	fmt.Printf("Allowed peers: %s\n", peers)
+	if s.AgentCard != nil {
+		fmt.Printf("Capabilities:  %s\n", strings.Join(s.AgentCard.Capabilities, ", "))
+	}
+	fmt.Printf("\nSystem prompt:\n%s\n", s.SystemPrompt)
+	return nil
+}

--- a/internal/cmd/agent_list.go
+++ b/internal/cmd/agent_list.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/footprintai/containarium/pkg/core/skills"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/spf13/cobra"
+)
+
+var agentListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List available agent skills",
+	Long: `List built-in agent skills. Reads the embedded catalog when no --server
+is given, or the daemon's catalog when --server is set.`,
+	Args: cobra.NoArgs,
+	RunE: runAgentList,
+}
+
+func init() {
+	agentCmd.AddCommand(agentListCmd)
+}
+
+func runAgentList(cmd *cobra.Command, args []string) error {
+	var list []*pb.AgentSkill
+	if serverAddr == "" {
+		// Offline: the catalog is compiled into the CLI binary too.
+		list = skills.GetDefault().List()
+	} else {
+		c, err := newAgentClient()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = c.Close() }()
+		list, err = c.ListAgentSkills()
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(list) == 0 {
+		fmt.Println("No agent skills available.")
+		return nil
+	}
+	fmt.Printf("%-16s %-16s %-24s %s\n", "ID", "BOX", "SCOPES", "DESCRIPTION")
+	fmt.Println(strings.Repeat("-", 90))
+	for _, s := range list {
+		fmt.Printf("%-16s %-16s %-24s %s\n",
+			s.Id, s.GetRecipeId(), strings.Join(s.AllowedScopes, ","), s.Description)
+	}
+	return nil
+}

--- a/internal/cmd/agent_run.go
+++ b/internal/cmd/agent_run.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	agentRunBackendID string
+	agentRunPool      string
+	agentRunInput     string
+)
+
+var agentRunCmd = &cobra.Command{
+	Use:   "run <skill-id>",
+	Short: "Run an agent skill in a box",
+	Long: `Provision the skill's box, mint a token scoped to exactly the skill's
+allowed_scopes, seed the system prompt + token + task input into the box, and
+return the box.
+
+Phase 0: the in-box agent loop (the agent-runtime image's job) consumes the
+seed; the returned artifact is empty until that lands.
+
+Examples:
+  containarium agent run hello-agent --input '{"q":"hi"}' --server <host>`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAgentRun,
+}
+
+func init() {
+	agentCmd.AddCommand(agentRunCmd)
+	agentRunCmd.Flags().StringVar(&agentRunBackendID, "backend-id", "",
+		"Target backend ID (must be the local backend in v1)")
+	agentRunCmd.Flags().StringVar(&agentRunPool, "pool", "",
+		"Target pool (not supported in v1)")
+	agentRunCmd.Flags().StringVar(&agentRunInput, "input", "",
+		"Task input as a JSON string (defaults to {})")
+}
+
+func runAgentRun(cmd *cobra.Command, args []string) error {
+	skillID := args[0]
+
+	c, err := newAgentClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	fmt.Printf("Running agent skill %q...\n", skillID)
+	resp, err := c.RunAgentSkill(skillID, agentRunBackendID, agentRunPool, agentRunInput)
+	if err != nil {
+		return err
+	}
+
+	if resp.Container != nil {
+		fmt.Printf("\n✓ box ready: %s (%s)\n", resp.Container.Name, resp.Container.State)
+	}
+	if resp.ArtifactJson != "" {
+		fmt.Printf("\nArtifact:\n%s\n", resp.ArtifactJson)
+	} else {
+		fmt.Println("\n(no artifact — the in-box agent loop is a Phase 0 seam; see docs/AGENT-SKILLS-QUICKSTART.md)")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Phase 0 / #561 — wire `AgentSkillService` into the typed client (both transports) and add the `containarium agent` command. Builds on the merged daemon core (#588).

Closes #561. Follow-ups: #562 (MCP tool), #565 (docs).

## What's here

- **Client** (`internal/client/grpc.go`, `http.go`): `ListAgentSkills` / `GetAgentSkill` / `RunAgentSkill` on both the gRPC and HTTP clients, mirroring the recipe methods. `RunAgentSkill` uses a 30m timeout (box provisioning).
- **CLI** (`internal/cmd/agent*.go`): `agent` parent + `agentAPI` interface + `newAgentClient` (dispatches on `--http`), CLI-first per convention.
  - `agent list` / `agent get` read the **embedded catalog offline** (no `--server`) or the daemon's catalog with `--server`.
  - `agent run` provisions the box, mints the scoped token, seeds it, prints the box; notes the empty-artifact Phase-0 seam.

## Verification

`go build ./...` + `gofmt` clean. Ran offline:

```
$ containarium agent list
ID               BOX              SCOPES            DESCRIPTION
hello-agent      agent-runtime    containers:read   Neutral reference skill...

$ containarium agent get hello-agent
ID:            hello-agent
Box (recipe):  agent-runtime
Allowed scopes: containers:read
Allowed peers: (none — leaf agent)
...
```

(`agent run` needs a live daemon, so it's exercised by build + the pattern it shares with `recipe deploy`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)