### PR TITLE
feat(agents): MCP list_agent_skills + run_agent_skill tools (#562)

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -286,6 +286,68 @@ func (c *Client) DeployRecipe(req DeployRecipeRequest) (*DeployRecipeResponse, e
 	return &resp, nil
 }
 
+// --- agent skills (AgentSkillService) ---
+
+// SkillSummary is one entry of the /v1/agent-skills response. JSON tags are
+// the grpc-gateway camelCase output names.
+type SkillSummary struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	Description   string   `json:"description"`
+	RecipeID      string   `json:"recipeId"`
+	AllowedScopes []string `json:"allowedScopes"`
+}
+
+// ListAgentSkillsResponse is the /v1/agent-skills response.
+type ListAgentSkillsResponse struct {
+	Skills []SkillSummary `json:"skills"`
+}
+
+// ListAgentSkills returns the daemon's built-in agent-skill catalog.
+func (c *Client) ListAgentSkills() (*ListAgentSkillsResponse, error) {
+	respBody, err := c.doRequest("GET", "/v1/agent-skills", nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp ListAgentSkillsResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
+// RunAgentSkillRequest is the body for an agent-skill run. Snake_case tags
+// match the proto field names, which grpc-gateway accepts on input.
+type RunAgentSkillRequest struct {
+	SkillID   string `json:"skill_id"`
+	BackendID string `json:"backend_id,omitempty"`
+	Pool      string `json:"pool,omitempty"`
+	InputJSON string `json:"input_json,omitempty"`
+}
+
+// RunAgentSkillResponse is the result of an agent-skill run.
+type RunAgentSkillResponse struct {
+	ArtifactJSON string `json:"artifactJson"`
+	Container    *struct {
+		Name  string `json:"name"`
+		State string `json:"state"`
+	} `json:"container"`
+}
+
+// RunAgentSkill provisions a skill's box, mints a scoped token, seeds the task,
+// and returns the box.
+func (c *Client) RunAgentSkill(req RunAgentSkillRequest) (*RunAgentSkillResponse, error) {
+	respBody, err := c.doRequest("POST", "/v1/agent-skills/"+req.SkillID+"/run", req)
+	if err != nil {
+		return nil, err
+	}
+	var resp RunAgentSkillResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
 // --- database backups (BackupService) ---
 
 // PgConnectionBody carries pg_dump/pg_restore connection params. Snake_case

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,8 +22,8 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453).
-	assert.Len(t, server.tools, 49, "Should have 49 tools registered")
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562).
+	assert.Len(t, server.tools, 51, "Should have 51 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -127,8 +127,8 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453).
-	assert.Len(t, tools, 49)
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562).
+	assert.Len(t, tools, 51)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1030,6 +1030,42 @@ func (s *Server) registerTools() {
 			Handler: handleDeployRecipe,
 		},
 		{
+			Name: "list_agent_skills",
+			Description: "List the platform's built-in agent skills. A skill is a " +
+				"packaged, runnable agent: a box (a recipe) plus a typed manifest " +
+				"(system prompt, allowed scopes, allowed peers). Use this to " +
+				"discover skill IDs before calling run_agent_skill.",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+			Handler: handleListAgentSkills,
+		},
+		{
+			Name: "run_agent_skill",
+			Description: "Run an agent skill in a box. Provisions the skill's box, " +
+				"mints a token scoped to exactly the skill's allowed_scopes, and " +
+				"seeds the system prompt + token + task input into the box. In " +
+				"Phase 0 the in-box agent loop is the box image's job, so the " +
+				"returned artifact is empty. Discover skill IDs with " +
+				"list_agent_skills.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"skill_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Skill to run, e.g. 'hello-agent' (see list_agent_skills).",
+					},
+					"input_json": map[string]interface{}{
+						"type":        "string",
+						"description": "Task input as a JSON string (defaults to {}).",
+					},
+				},
+				"required": []string{"skill_id"},
+			},
+			Handler: handleRunAgentSkill,
+		},
+		{
 			Name: "revoke_token",
 			Description: "Admin: revoke a JWT by its jti. The token is rejected " +
 				"on the next request that names it. Pairs with the daemon's " +
@@ -1134,6 +1170,9 @@ func toolScopeAssignments() map[string]string {
 		// recipes — declarative GPU/app deploys
 		"list_recipes":  auth.ScopeContainersRead,
 		"deploy_recipe": auth.ScopeContainersWrite,
+
+		"list_agent_skills": auth.ScopeAgentsRead,
+		"run_agent_skill":   auth.ScopeAgentsRun,
 		// database backups
 		"create_backup":  auth.ScopeBackupsWrite,
 		"restore_backup": auth.ScopeBackupsWrite,
@@ -1877,6 +1916,43 @@ func handleDeployRecipe(client *Client, args map[string]interface{}) (string, er
 	}
 	if resp.Container != nil {
 		out += fmt.Sprintf("Container: %s (%s)\n", resp.Container.Name, resp.Container.State)
+	}
+	return out, nil
+}
+
+func handleListAgentSkills(client *Client, _ map[string]interface{}) (string, error) {
+	resp, err := client.ListAgentSkills()
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Skills) == 0 {
+		return "No agent skills available.", nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%-16s %-16s %-24s %s\n", "ID", "BOX", "SCOPES", "DESCRIPTION")
+	for _, s := range resp.Skills {
+		fmt.Fprintf(&b, "%-16s %-16s %-24s %s\n",
+			s.ID, s.RecipeID, strings.Join(s.AllowedScopes, ","), s.Description)
+	}
+	return b.String(), nil
+}
+
+func handleRunAgentSkill(client *Client, args map[string]interface{}) (string, error) {
+	resp, err := client.RunAgentSkill(RunAgentSkillRequest{
+		SkillID:   getStringArg(args, "skill_id", ""),
+		InputJSON: getStringArg(args, "input_json", ""),
+	})
+	if err != nil {
+		return "", err
+	}
+	var out string
+	if resp.Container != nil {
+		out = fmt.Sprintf("✅ box ready: %s (%s)\n", resp.Container.Name, resp.Container.State)
+	}
+	if resp.ArtifactJSON != "" {
+		out += fmt.Sprintf("Artifact:  %s\n", resp.ArtifactJSON)
+	} else {
+		out += "(no artifact — the in-box agent loop is a Phase 0 seam)\n"
 	}
 	return out, nil
 }


### PR DESCRIPTION
## Summary

Phase 0 / #562 — expose `AgentSkillService` through the platform MCP server (`cmd/mcp-server`), as thin wrappers over the same daemon endpoints the CLI uses (MCP-wraps-CLI convention). Builds on the merged daemon core (#588).

Closes #562. Follow-up: #565 (docs).

## What's here

- **MCP client** (`internal/mcp/client.go`): `ListAgentSkills` (GET `/v1/agent-skills`) + `RunAgentSkill` (POST `/v1/agent-skills/{id}/run`) with local JSON types.
- **Tools** (`internal/mcp/tools.go`):
  - `list_agent_skills` — `RequiredScope: agents:read`
  - `run_agent_skill` — `RequiredScope: agents:run`
  - handlers + `toolScopeAssignments` wiring. `run_agent_skill` surfaces the Phase-0 empty-artifact seam in its output.
- Registered-tool count bumped 49 → 51 (`server_test.go`).

## Verification

`go build ./...`, `go vet`, and `internal/mcp` tests all green (incl. the tool-count + tools/list assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)