### PR TITLE
docs(agents): A2A / agent call in quickstart (#571)

### DIFF
--- a/docs/AGENT-SKILLS-QUICKSTART.md
+++ b/docs/AGENT-SKILLS-QUICKSTART.md
@@ -2,11 +2,13 @@
 
 Run a packaged agent in its own Containarium box in a couple of minutes.
 
-> **Phase 0 (agent-as-a-box).** This is the generic mechanism only. The
-> in-box agent loop is the box image's job and is not wired yet, so a run
-> provisions and seeds the box but returns an empty artifact. See
-> `docs/AGENT-SKILLS-CREWS-DESIGN.md` for the full design and the later
-> phases (A2A transport, the `allowed_peers` → eBPF trust fabric, crews).
+> **Phases 0–1.** This is the generic mechanism only. The **in-box agent
+> loop and the in-box A2A server are the box image's job and are not wired
+> yet**, so a `run` seeds the box but returns an empty artifact, and a `call`
+> to a real box reaches no listener. The daemon-side surface (run, discovery,
+> agent-to-agent send) is wired and tested. See
+> `docs/AGENT-SKILLS-CREWS-DESIGN.md` for the full design and the later phases
+> (the `allowed_peers` → eBPF trust fabric in Phase 2, crews in Phase 3).
 
 ## What is a skill?
 
@@ -70,9 +72,49 @@ The operator/agent token that drives the AgentSkillService needs:
 | --- | --- |
 | `agent list` / `agent get` (via `--server`) | `agents:read` |
 | `agent run` | `agents:run` (+ `containers:write`, since a run provisions a box) |
+| `agent call` | `agents:call` |
 
 These gate the *caller*. They are separate from the skill's **own** in-box
 token, which carries only the skill's declared `allowed_scopes`.
+
+## Talk to a peer (A2A) — Phase 1
+
+Once two skills are running, one can delegate a task to the other over the
+**agent-to-agent (A2A)** transport and get an artifact back:
+
+```bash
+containarium agent run hello-agent --server <host>          # the peer
+containarium agent run my-agent   --server <host>           # the caller
+
+containarium agent call hello-agent \
+  --from my-agent \
+  --input '{"q":"hi"}' \
+  --server <host>
+
+# Delegating task to peer "hello-agent"...
+#
+# ✓ task task-my-agent-hello-agent — AGENT_TASK_STATE_COMPLETED
+#
+# Artifact:
+# {"ok":true}
+```
+
+How it works: the daemon resolves the peer's box, finds its in-box A2A server
+at `http://<box-ip>:8674/tasks`, POSTs an `AgentTask`, and returns the
+`AgentArtifact`. The peer's agent card (seeded at `run` into
+`/etc/containarium/agent/agent-card.json`) is what the in-box server serves for
+discovery.
+
+Driving the call needs the `agents:call` scope.
+
+> **Phase 1 seam.** The in-box A2A *server* (which receives `/tasks`) is the
+> `agent-runtime` image's job. Until it ships, `agent call` to a real box
+> returns `Unavailable`. The daemon-side transport + discovery + resolution are
+> wired and unit-tested against a stub peer.
+
+> **Phase 2 preview.** `allowed_peers` becomes enforced: the daemon rejects a
+> `call` to a peer not in the caller's `allowed_peers`, and eBPF network policy
+> drops the hop in-kernel. In Phase 1 the send is best-effort.
 
 ## From an AI agent (MCP)
 
@@ -80,10 +122,14 @@ The platform MCP server exposes the same surface as thin wrappers:
 
 - `list_agent_skills` — scope `agents:read`
 - `run_agent_skill` — scope `agents:run`
+- `call_agent` — scope `agents:call`
 
 ```jsonc
 // run_agent_skill arguments
 { "skill_id": "hello-agent", "input_json": "{\"q\":\"hi\"}" }
+
+// call_agent arguments
+{ "to_peer_id": "hello-agent", "from_skill_id": "my-agent", "input_json": "{\"q\":\"hi\"}" }
 ```
 
 ## Add your own skill (local)
@@ -111,15 +157,17 @@ skills:
       capabilities: [example]
 ```
 
-## Phase 0 limitations (by design)
+## Limitations (by design, Phases 0–1)
 
-- **No in-box loop yet** — the box is provisioned and seeded; producing the
-  artifact is the `agent-runtime` image's job (a later phase). `run` returns an
-  empty artifact.
+- **No in-box loop / A2A server yet** — the box is provisioned and seeded; the
+  in-box agent loop and the A2A `/tasks` server are the `agent-runtime` image's
+  job (a later phase). `run` returns an empty artifact; `call` to a real box
+  returns `Unavailable`.
 - **Box name is derived from the skill id** (`agent-<skill-id>`), so two
   concurrent runs of the same skill collide. Per-run boxes / a warm pool are a
   later concern (see `docs/EPHEMERAL-SANDBOX-DESIGN.md`).
-- **`allowed_peers` is inert** until Phase 2 wires it to eBPF network policy.
+- **`allowed_peers` is inert** until Phase 2 wires it to eBPF network policy
+  (the send is best-effort and ungated in Phase 1).
 
 ## See also
 


### PR DESCRIPTION
## Summary

Phase 1 / #571 — document the agent-to-agent flow in `AGENT-SKILLS-QUICKSTART.md`. Completes the Phase 1 issue set (#567–571).

## Covers

- New **"Talk to a peer (A2A)"** section: run two skills, `agent call` one from the other, how the daemon resolves the peer's in-box A2A server (`:8674/tasks`), the `agents:call` scope, and the two-phase seam (in-box A2A server = image's job; `allowed_peers` enforced in Phase 2).
- `call_agent` added to the MCP tool list + example.
- `agents:call` row added to the scopes table.
- Status note + limitations refreshed to cover Phases 0–1.

Docs only — no code dependency, branched from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)