### PR TITLE
feat(agents): MCP call_agent tool (#570)

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -348,6 +348,37 @@ func (c *Client) RunAgentSkill(req RunAgentSkillRequest) (*RunAgentSkillResponse
 	return &resp, nil
 }
 
+// CallAgentRequest is the body for an A2A task delegation. Snake_case tags
+// match the proto field names, which grpc-gateway accepts on input.
+type CallAgentRequest struct {
+	FromSkillID string `json:"from_skill_id,omitempty"`
+	ToPeerID    string `json:"to_peer_id"`
+	InputJSON   string `json:"input_json,omitempty"`
+}
+
+// CallAgentResponse is the result of an A2A task delegation.
+type CallAgentResponse struct {
+	Artifact *struct {
+		TaskID     string `json:"taskId"`
+		OutputJSON string `json:"outputJson"`
+		State      string `json:"state"`
+		Error      string `json:"error"`
+	} `json:"artifact"`
+}
+
+// CallAgent delegates a task to a running peer agent over A2A.
+func (c *Client) CallAgent(req CallAgentRequest) (*CallAgentResponse, error) {
+	respBody, err := c.doRequest("POST", "/v1/agent-skills/"+req.ToPeerID+"/call", req)
+	if err != nil {
+		return nil, err
+	}
+	var resp CallAgentResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
 // --- database backups (BackupService) ---
 
 // PgConnectionBody carries pg_dump/pg_restore connection params. Snake_case

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,8 +22,8 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562).
-	assert.Len(t, server.tools, 51, "Should have 51 tools registered")
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570).
+	assert.Len(t, server.tools, 52, "Should have 52 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -127,8 +127,8 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562).
-	assert.Len(t, tools, 51)
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570).
+	assert.Len(t, tools, 52)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1066,6 +1066,33 @@ func (s *Server) registerTools() {
 			Handler: handleRunAgentSkill,
 		},
 		{
+			Name: "call_agent",
+			Description: "Delegate a task to a running peer agent over the " +
+				"agent-to-agent (A2A) transport and return its artifact. The peer " +
+				"must already be running (run_agent_skill). In Phase 1 the peer's " +
+				"in-box A2A server receives the task; until that ships a call " +
+				"returns an error. Discover peer IDs with list_agent_skills.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"to_peer_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Peer skill/agent id to deliver the task to (see list_agent_skills).",
+					},
+					"from_skill_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Calling skill id, for attribution and the future allowed_peers check.",
+					},
+					"input_json": map[string]interface{}{
+						"type":        "string",
+						"description": "Task input as a JSON string (defaults to {}).",
+					},
+				},
+				"required": []string{"to_peer_id"},
+			},
+			Handler: handleCallAgent,
+		},
+		{
 			Name: "revoke_token",
 			Description: "Admin: revoke a JWT by its jti. The token is rejected " +
 				"on the next request that names it. Pairs with the daemon's " +
@@ -1173,6 +1200,7 @@ func toolScopeAssignments() map[string]string {
 
 		"list_agent_skills": auth.ScopeAgentsRead,
 		"run_agent_skill":   auth.ScopeAgentsRun,
+		"call_agent":        auth.ScopeAgentsCall,
 		// database backups
 		"create_backup":  auth.ScopeBackupsWrite,
 		"restore_backup": auth.ScopeBackupsWrite,
@@ -1953,6 +1981,28 @@ func handleRunAgentSkill(client *Client, args map[string]interface{}) (string, e
 		out += fmt.Sprintf("Artifact:  %s\n", resp.ArtifactJSON)
 	} else {
 		out += "(no artifact — the in-box agent loop is a Phase 0 seam)\n"
+	}
+	return out, nil
+}
+
+func handleCallAgent(client *Client, args map[string]interface{}) (string, error) {
+	resp, err := client.CallAgent(CallAgentRequest{
+		ToPeerID:    getStringArg(args, "to_peer_id", ""),
+		FromSkillID: getStringArg(args, "from_skill_id", ""),
+		InputJSON:   getStringArg(args, "input_json", ""),
+	})
+	if err != nil {
+		return "", err
+	}
+	if resp.Artifact == nil {
+		return "Peer returned no artifact.", nil
+	}
+	out := fmt.Sprintf("✅ task %s — %s\n", resp.Artifact.TaskID, resp.Artifact.State)
+	if resp.Artifact.Error != "" {
+		out += fmt.Sprintf("error:    %s\n", resp.Artifact.Error)
+	}
+	if resp.Artifact.OutputJSON != "" {
+		out += fmt.Sprintf("artifact: %s\n", resp.Artifact.OutputJSON)
 	}
 	return out, nil
 }


### PR DESCRIPTION
## Summary

Phase 1 / #570 — expose A2A task delegation through the platform MCP server, a thin wrapper over `POST /v1/agent-skills/{to_peer_id}/call`. Closes #570.

(Re-opened against `main`: the original PR #596 was auto-closed when its stacked base branch was deleted on #594's merge. Branch rebased to contain only the `call_agent` commit on top of `main`.)

## What's here

- `internal/mcp/client.go`: `CallAgentRequest` / `CallAgentResponse` + `CallAgent`.
- `internal/mcp/tools.go`: `call_agent` tool (`RequiredScope: agents:call`) + handler, wired in `toolScopeAssignments`.
- Tool count 51 → 52 (`server_test.go`).

## Verification

`go build ./...` + `internal/mcp` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)