### PR TITLE
feat(agents): compile allowed_peers into a per-box network policy at launch (#573)

### DIFF
--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -33,18 +34,22 @@ const agentSeedDir = "/etc/containarium/agent"
 // Phase 0 (artifact_json is returned empty until that lands).
 type AgentSkillServer struct {
 	pb.UnimplementedAgentSkillServiceServer
-	catalog *skills.Manager
-	recipes *RecipeServer      // box provisioning (reuses CreateContainer/exec/expose)
-	tokens  *auth.TokenManager // mints the skill's scoped in-box token
+	catalog   *skills.Manager
+	recipes   *RecipeServer        // box provisioning (reuses CreateContainer/exec/expose)
+	tokens    *auth.TokenManager   // mints the skill's scoped in-box token
+	netpolicy *NetworkPolicyServer // compiles allowed_peers into a per-box egress policy (Phase 2)
 }
 
 // NewAgentSkillServer wires the agent-skill service to the recipe server (for
-// box provisioning) and the token manager (for minting scoped in-box tokens).
-func NewAgentSkillServer(recipes *RecipeServer, tokens *auth.TokenManager) *AgentSkillServer {
+// box provisioning), the token manager (for minting scoped in-box tokens), and
+// the network policy server (to compile allowed_peers into a per-box egress
+// policy at launch). netpolicy may be nil — policy compilation then no-ops.
+func NewAgentSkillServer(recipes *RecipeServer, tokens *auth.TokenManager, netpolicy *NetworkPolicyServer) *AgentSkillServer {
 	return &AgentSkillServer{
-		catalog: skills.GetDefault(),
-		recipes: recipes,
-		tokens:  tokens,
+		catalog:   skills.GetDefault(),
+		recipes:   recipes,
+		tokens:    tokens,
+		netpolicy: netpolicy,
 	}
 }
 
@@ -144,8 +149,72 @@ func (s *AgentSkillServer) RunAgentSkill(ctx context.Context, req *pb.RunAgentSk
 		return nil, status.Errorf(codes.Internal, "failed to seed agent box %s: %v", containerName, err)
 	}
 
+	// 4. Compile the skill's allowed_peers into a per-box egress network policy
+	//    (Phase 2). Best-effort + LOG_ONLY: a failure here must not fail the
+	//    run, and observe-only never drops traffic. Enforcement (drop) requires
+	//    the env-gated eBPF enforcer AND flipping to ENFORCE — see #574.
+	s.applyAllowedPeersPolicy(ctx, name, skill)
+
 	// artifact_json intentionally empty in Phase 0 (in-box loop seam).
 	return &pb.RunAgentSkillResponse{Container: dep.Container, ArtifactJson: ""}, nil
+}
+
+// applyAllowedPeersPolicy compiles a skill's allowed_peers into a per-box
+// egress NetworkPolicy and stores it (LOG_ONLY). The box's tenant is its name
+// (the agent-<skill-id> / <tenant>-container convention the enforcer resolves).
+// Best-effort: logs and returns on any error so a policy hiccup never blocks a
+// run. No-op when no policy server is wired or the skill declares no peers.
+//
+// Phase 2 seam: the policy is observe-only here. Dropping non-allowed egress
+// in-kernel needs the env-gated eBPF enforcer (CONTAINARIUM_NETWORK_POLICY_*)
+// on a Linux backend and a flip to ENFORCE. Also, before ENFORCE is safe the
+// allowlist must be broadened to the platform egress the agent legitimately
+// needs (daemon API, DNS) — a peer-only allowlist would otherwise strand the
+// agent. Tracked in #574.
+func (s *AgentSkillServer) applyAllowedPeersPolicy(ctx context.Context, tenant string, skill *pb.AgentSkill) {
+	if s.netpolicy == nil || len(skill.AllowedPeers) == 0 {
+		return
+	}
+	policy := compileAllowedPeersPolicy(tenant, skill.AllowedPeers, s.resolvePeerIP)
+	if len(policy.EgressCidrs) == 0 {
+		// No peers are running yet, so nothing to allow. Skip rather than
+		// install an empty allowlist (which, under ENFORCE, would deny all).
+		return
+	}
+	if err := s.netpolicy.Store().Set(ctx, policy); err != nil {
+		log.Printf("[agent-skill] could not set network policy for %q: %v", tenant, err)
+	}
+}
+
+// resolvePeerIP returns a running peer box's IPv4 address, if any. Used to turn
+// an allowed_peer skill id into an egress /32 at launch.
+func (s *AgentSkillServer) resolvePeerIP(peerID string) (string, bool) {
+	info, err := s.recipes.containers.manager.Get("agent-" + peerID)
+	if err != nil || info == nil || info.IPAddress == "" {
+		return "", false
+	}
+	return info.IPAddress, true
+}
+
+// compileAllowedPeersPolicy builds a per-box egress NetworkPolicy from a skill's
+// allowed_peers: each currently-running peer's box IP becomes an egress /32.
+// Pure (resolution is injected) so it is unit-testable without a daemon. The
+// policy is LOG_ONLY — observe, never drop — until Phase 2 enforcement is armed.
+func compileAllowedPeersPolicy(tenant string, allowedPeers []string, resolve func(peerID string) (string, bool)) *pb.NetworkPolicy {
+	var cidrs []string
+	for _, peer := range allowedPeers {
+		if ip, ok := resolve(peer); ok {
+			cidrs = append(cidrs, ip+"/32")
+		}
+	}
+	return &pb.NetworkPolicy{
+		Tenant:           tenant,
+		AllowIntraTenant: false,
+		EgressCidrs:      cidrs,
+		Mode:             pb.NetworkPolicyMode_NETWORK_POLICY_MODE_LOG_ONLY,
+		AllowMetadata:    false,
+		Source:           "agent-skill",
+	}
 }
 
 // SendAgentTask delegates a task to a running peer agent over A2A and returns

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"strings"
 	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
 func TestBuildAgentSeedScript(t *testing.T) {
@@ -37,5 +39,44 @@ func TestBuildAgentSeedScriptEscapesSingleQuotes(t *testing.T) {
 	script := buildAgentSeedScript("don't panic", "t", "{}", "{}")
 	if strings.Contains(script, "don't") && !strings.Contains(script, `don'\''t`) {
 		t.Errorf("single quote not escaped in seed script:\n%s", script)
+	}
+}
+
+func TestCompileAllowedPeersPolicy(t *testing.T) {
+	running := map[string]string{"peer-a": "10.0.0.5", "peer-b": "10.0.0.6"}
+	resolve := func(id string) (string, bool) { ip, ok := running[id]; return ip, ok }
+
+	// peer-c is not running, so it must be omitted from the allowlist.
+	p := compileAllowedPeersPolicy("agent-caller", []string{"peer-a", "peer-b", "peer-c"}, resolve)
+
+	if p.Tenant != "agent-caller" {
+		t.Errorf("tenant = %q, want agent-caller", p.Tenant)
+	}
+	if p.Mode != pb.NetworkPolicyMode_NETWORK_POLICY_MODE_LOG_ONLY {
+		t.Errorf("mode = %v, want LOG_ONLY (observe-only until enforcement is armed)", p.Mode)
+	}
+	if p.AllowMetadata {
+		t.Error("allow_metadata must be false for an agent box")
+	}
+	if p.AllowIntraTenant {
+		t.Error("allow_intra_tenant must be false (deny-by-default)")
+	}
+	want := []string{"10.0.0.5/32", "10.0.0.6/32"}
+	if len(p.EgressCidrs) != len(want) {
+		t.Fatalf("egress_cidrs = %v, want %v", p.EgressCidrs, want)
+	}
+	for i := range want {
+		if p.EgressCidrs[i] != want[i] {
+			t.Errorf("egress_cidrs[%d] = %q, want %q", i, p.EgressCidrs[i], want[i])
+		}
+	}
+}
+
+func TestCompileAllowedPeersPolicyNoneRunning(t *testing.T) {
+	// No peer is running -> empty allowlist (the caller skips installing it
+	// rather than denying all egress under a future ENFORCE).
+	p := compileAllowedPeersPolicy("t", []string{"x", "y"}, func(string) (string, bool) { return "", false })
+	if len(p.EgressCidrs) != 0 {
+		t.Errorf("expected no egress cidrs when no peers run, got %v", p.EgressCidrs)
 	}
 }

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -301,10 +301,23 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	pb.RegisterRecipeServiceServer(grpcServer, recipeServer)
 	log.Printf("Recipe service enabled")
 
-	// Register AgentSkillService — Phase 0 agent-as-a-box. Reuses the recipe
-	// server for box provisioning and the token manager for minting the
-	// skill's scoped in-box token.
-	pb.RegisterAgentSkillServiceServer(grpcServer, NewAgentSkillServer(recipeServer, tokenManager))
+	// NetworkPolicyService — Phase A control-plane CRUD for per-tenant network
+	// isolation policies (#315). Registered here with an in-memory store;
+	// persistence (swap to PostgresNetworkPolicyStore once the pool exists) and
+	// the per-veth TC_INGRESS BPF loader that consumes these policies are
+	// follow-up increments. Admin-gated in the handler. Created before the
+	// agent-skill service so it can compile a skill's allowed_peers into a
+	// per-box network policy at launch (Phase 2 / #573).
+	npServer := NewNetworkPolicyServer(NewMemNetworkPolicyStore())
+	pb.RegisterNetworkPolicyServiceServer(grpcServer, npServer)
+	log.Printf("NetworkPolicy service enabled (in-memory store; Phase A)")
+
+	// Register AgentSkillService — agent-as-a-box (Phase 0) + A2A transport
+	// (Phase 1). Reuses the recipe server for box provisioning, the token
+	// manager for minting the skill's scoped in-box token, and the network
+	// policy server to compile allowed_peers into a per-box egress policy at
+	// launch (Phase 2).
+	pb.RegisterAgentSkillServiceServer(grpcServer, NewAgentSkillServer(recipeServer, tokenManager, npServer))
 	log.Printf("Agent-skill service enabled")
 
 	// Register BackupService — logical (pg_dump) database backups for the
@@ -325,16 +338,6 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	// coverage, and trigger legacy→envelope migration. Backed by
 	// the same secrets Store; backend *config* stays in env/systemd.
 	pb.RegisterKmsServiceServer(grpcServer, NewKmsServer(containerServer))
-
-	// NetworkPolicyService — Phase A control-plane CRUD for per-tenant network
-	// isolation policies (#315). Registered here (before the Postgres pool is
-	// set up below) with an in-memory store; persistence (swap to
-	// PostgresNetworkPolicyStore once the pool exists) and the per-veth
-	// TC_INGRESS BPF loader that consumes these policies are follow-up
-	// increments. Admin-gated in the handler.
-	npServer := NewNetworkPolicyServer(NewMemNetworkPolicyStore())
-	pb.RegisterNetworkPolicyServiceServer(grpcServer, npServer)
-	log.Printf("NetworkPolicy service enabled (in-memory store; Phase A)")
 
 	// Cloud-actuation client (#354) is constructed later, once routeStore is
 	// finalized — the container actuator needs it to expose cloud routes at the


### PR DESCRIPTION
## Summary

Phase 2 (the trust fabric / the moat), step 1 — `RunAgentSkill` now compiles a skill's `allowed_peers` into a per-box egress `NetworkPolicy`. First issue of epic #578. Closes #573.

## What's here

- **`compileAllowedPeersPolicy`** (pure, unit-tested): each currently-running peer's box IP → an egress `/32`; `Tenant` = the box name (`agent-<skill-id>`, the `<tenant>-container` convention the eBPF enforcer already resolves); deny-by-default (`allow_intra_tenant=false`, `allow_metadata=false`); `Source="agent-skill"`.
- **Mode `LOG_ONLY`** — observe, never drop. Wired **best-effort**: a policy error never fails the run, and an empty allowlist (no peers running yet) is *skipped* rather than installed (which under ENFORCE would deny all).
- `AgentSkillServer` now takes the `NetworkPolicyServer` (reordered in `dual_server.go` so it's constructed first) and reads the live store via `.Store()` (so it picks up the Postgres store after the swap).

## Seam → #574

Dropping non-allowed egress **in-kernel** needs the env-gated eBPF enforcer (`CONTAINARIUM_NETWORK_POLICY_*`) on a Linux backend + a flip to `ENFORCE` — and the allowlist must first be broadened to the platform egress the agent legitimately needs (daemon API, DNS) so ENFORCE doesn't strand it. The daemon-side `allowed_peers` *reject* in `SendAgentTask` (the API-boundary half of enforcement) also lands in #574. This PR is the safe, observe-only foundation.

## Verification

`go build ./...`, `go vet`, `gofmt`, and `internal/server` tests all green (incl. two new `compileAllowedPeersPolicy` tests). Reuses the existing, hardware-validated eBPF Phase A subsystem — no changes to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)