### PR TITLE
feat(agents): arm allowed_peers enforcement (#574)

### DIFF
--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -12,9 +13,16 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/netpolicy"
 	"github.com/footprintai/containarium/pkg/core/skills"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
+
+// agentBoxPrefix is the box/tenant name prefix RunAgentSkill assigns to a
+// skill's box (agent-<skill-id>). The minted in-box JWT carries this as its
+// subject, so a call originating from an agent box authenticates as
+// agent-<skill-id> — which is how SendAgentTask recovers the real caller.
+const agentBoxPrefix = "agent-"
 
 // agentTokenTTL bounds the lifetime of the JWT minted for a skill's in-box
 // agent loop. Short by design: a skill run is a bounded task, not a session.
@@ -175,15 +183,74 @@ func (s *AgentSkillServer) applyAllowedPeersPolicy(ctx context.Context, tenant s
 	if s.netpolicy == nil || len(skill.AllowedPeers) == 0 {
 		return
 	}
-	policy := compileAllowedPeersPolicy(tenant, skill.AllowedPeers, s.resolvePeerIP)
+	extraCIDRs, enforce := agentNetworkPolicyConfig()
+	policy := compileAllowedPeersPolicy(tenant, skill.AllowedPeers, s.resolvePeerIP, extraCIDRs, enforce)
 	if len(policy.EgressCidrs) == 0 {
-		// No peers are running yet, so nothing to allow. Skip rather than
-		// install an empty allowlist (which, under ENFORCE, would deny all).
+		// Nothing to allow (no peers running, no platform CIDRs). Skip rather
+		// than install an empty allowlist (which, under ENFORCE, denies all).
 		return
 	}
-	if err := s.netpolicy.Store().Set(ctx, policy); err != nil {
+	// Compile (validate + normalize) before storing — same path the
+	// SetNetworkPolicy RPC uses — so a bad operator-supplied egress CIDR is
+	// caught here instead of silently dropped by the enforcer's reconcile.
+	compiled, err := netpolicy.Compile(policy)
+	if err != nil {
+		log.Printf("[agent-skill] invalid network policy for %q: %v", tenant, err)
+		return
+	}
+	if err := s.netpolicy.Store().Set(ctx, compiled.ToProto()); err != nil {
 		log.Printf("[agent-skill] could not set network policy for %q: %v", tenant, err)
 	}
+}
+
+// agentNetworkPolicyConfig reads the operator opt-ins for arming enforcement:
+//   - CONTAINARIUM_AGENT_NETWORK_POLICY_ENFORCE=1 → compile the policy in
+//     ENFORCE mode (drop), instead of the default LOG_ONLY (observe).
+//   - CONTAINARIUM_AGENT_EGRESS_CIDRS=cidr,cidr → platform egress the agent
+//     legitimately needs (daemon API, DNS resolver) added to every agent box's
+//     allowlist, so ENFORCE doesn't strand the agent.
+//
+// Both default off/empty, so the out-of-the-box behaviour stays observe-only.
+// ENFORCE additionally requires the daemon-wide eBPF enforcer to be armed
+// (CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT + CONTAINARIUM_NETWORK_POLICY_ENFORCE).
+func agentNetworkPolicyConfig() (extraCIDRs []string, enforce bool) {
+	enforce = os.Getenv("CONTAINARIUM_AGENT_NETWORK_POLICY_ENFORCE") == "1"
+	for _, c := range strings.Split(os.Getenv("CONTAINARIUM_AGENT_EGRESS_CIDRS"), ",") {
+		if c = strings.TrimSpace(c); c != "" {
+			extraCIDRs = append(extraCIDRs, c)
+		}
+	}
+	return extraCIDRs, enforce
+}
+
+// callerSkillID recovers the skill id of the agent making an A2A call. The
+// authenticated token subject wins (an agent box's JWT subject is
+// agent-<skill-id>); otherwise it falls back to the caller-asserted value.
+func (s *AgentSkillServer) callerSkillID(ctx context.Context, asserted string) string {
+	if subj, ok := auth.UsernameFromContext(ctx); ok && strings.HasPrefix(subj, agentBoxPrefix) {
+		return strings.TrimPrefix(subj, agentBoxPrefix)
+	}
+	return asserted
+}
+
+// peerAllowed reports whether the calling skill may send to toPeer per its
+// declared allowed_peers. An unknown/empty caller (admin or operator direct
+// call, not an agent box) is allowed — for box-originated traffic the eBPF
+// egress policy is the hard boundary; this is the API-boundary courtesy check.
+func (s *AgentSkillServer) peerAllowed(fromSkillID, toPeerID string) bool {
+	if fromSkillID == "" {
+		return true
+	}
+	skill, err := s.catalog.Get(fromSkillID)
+	if err != nil {
+		return true // unknown caller skill — not ours to gate here
+	}
+	for _, p := range skill.AllowedPeers {
+		if p == toPeerID {
+			return true
+		}
+	}
+	return false
 }
 
 // resolvePeerIP returns a running peer box's IPv4 address, if any. Used to turn
@@ -200,18 +267,26 @@ func (s *AgentSkillServer) resolvePeerIP(peerID string) (string, bool) {
 // allowed_peers: each currently-running peer's box IP becomes an egress /32.
 // Pure (resolution is injected) so it is unit-testable without a daemon. The
 // policy is LOG_ONLY — observe, never drop — until Phase 2 enforcement is armed.
-func compileAllowedPeersPolicy(tenant string, allowedPeers []string, resolve func(peerID string) (string, bool)) *pb.NetworkPolicy {
+func compileAllowedPeersPolicy(tenant string, allowedPeers []string, resolve func(peerID string) (string, bool), extraCIDRs []string, enforce bool) *pb.NetworkPolicy {
 	var cidrs []string
 	for _, peer := range allowedPeers {
 		if ip, ok := resolve(peer); ok {
 			cidrs = append(cidrs, ip+"/32")
 		}
 	}
+	// Platform egress the agent legitimately needs (daemon API, DNS) so an
+	// armed ENFORCE policy doesn't strand the agent.
+	cidrs = append(cidrs, extraCIDRs...)
+
+	mode := pb.NetworkPolicyMode_NETWORK_POLICY_MODE_LOG_ONLY
+	if enforce {
+		mode = pb.NetworkPolicyMode_NETWORK_POLICY_MODE_ENFORCE
+	}
 	return &pb.NetworkPolicy{
 		Tenant:           tenant,
 		AllowIntraTenant: false,
 		EgressCidrs:      cidrs,
-		Mode:             pb.NetworkPolicyMode_NETWORK_POLICY_MODE_LOG_ONLY,
+		Mode:             mode,
 		AllowMetadata:    false,
 		Source:           "agent-skill",
 	}
@@ -234,8 +309,16 @@ func (s *AgentSkillServer) SendAgentTask(ctx context.Context, req *pb.SendAgentT
 		return nil, status.Error(codes.InvalidArgument, "to_peer_id is required")
 	}
 
-	// TODO(Phase 2 / #578): reject when req.ToPeerId is not in the from-skill's
-	// allowed_peers, and rely on eBPF network policy to drop the hop in-kernel.
+	// Enforce allowed_peers at the API boundary (Phase 2). The real caller is
+	// the authenticated token subject when it's an agent box (agent-<skill-id>);
+	// fall back to the caller-asserted from_skill_id otherwise. This is
+	// defense-in-depth + fail-fast UX — the hard boundary for raw box-originated
+	// traffic is the eBPF egress policy compiled from allowed_peers.
+	caller := s.callerSkillID(ctx, req.FromSkillId)
+	if !s.peerAllowed(caller, req.ToPeerId) {
+		return nil, status.Errorf(codes.PermissionDenied,
+			"skill %q is not permitted to call peer %q (not in its allowed_peers)", caller, req.ToPeerId)
+	}
 
 	baseURL, _, err := s.resolvePeerA2A(req.ToPeerId)
 	if err != nil {

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/footprintai/containarium/pkg/core/skills"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
@@ -47,7 +48,7 @@ func TestCompileAllowedPeersPolicy(t *testing.T) {
 	resolve := func(id string) (string, bool) { ip, ok := running[id]; return ip, ok }
 
 	// peer-c is not running, so it must be omitted from the allowlist.
-	p := compileAllowedPeersPolicy("agent-caller", []string{"peer-a", "peer-b", "peer-c"}, resolve)
+	p := compileAllowedPeersPolicy("agent-caller", []string{"peer-a", "peer-b", "peer-c"}, resolve, nil, false)
 
 	if p.Tenant != "agent-caller" {
 		t.Errorf("tenant = %q, want agent-caller", p.Tenant)
@@ -75,8 +76,52 @@ func TestCompileAllowedPeersPolicy(t *testing.T) {
 func TestCompileAllowedPeersPolicyNoneRunning(t *testing.T) {
 	// No peer is running -> empty allowlist (the caller skips installing it
 	// rather than denying all egress under a future ENFORCE).
-	p := compileAllowedPeersPolicy("t", []string{"x", "y"}, func(string) (string, bool) { return "", false })
+	p := compileAllowedPeersPolicy("t", []string{"x", "y"}, func(string) (string, bool) { return "", false }, nil, false)
 	if len(p.EgressCidrs) != 0 {
 		t.Errorf("expected no egress cidrs when no peers run, got %v", p.EgressCidrs)
+	}
+}
+
+func TestCompileAllowedPeersPolicyEnforceAndExtraCIDRs(t *testing.T) {
+	resolve := func(id string) (string, bool) {
+		if id == "peer-a" {
+			return "10.0.0.5", true
+		}
+		return "", false
+	}
+	// Armed ENFORCE + platform egress (e.g. daemon + DNS) so the agent isn't
+	// stranded by a peer-only allowlist.
+	extra := []string{"10.0.1.1/32", "10.0.1.2/32"}
+	p := compileAllowedPeersPolicy("agent-x", []string{"peer-a"}, resolve, extra, true)
+
+	if p.Mode != pb.NetworkPolicyMode_NETWORK_POLICY_MODE_ENFORCE {
+		t.Errorf("mode = %v, want ENFORCE when armed", p.Mode)
+	}
+	want := []string{"10.0.0.5/32", "10.0.1.1/32", "10.0.1.2/32"}
+	if len(p.EgressCidrs) != len(want) {
+		t.Fatalf("egress_cidrs = %v, want %v", p.EgressCidrs, want)
+	}
+	for i := range want {
+		if p.EgressCidrs[i] != want[i] {
+			t.Errorf("egress_cidrs[%d] = %q, want %q", i, p.EgressCidrs[i], want[i])
+		}
+	}
+}
+
+func TestPeerAllowed(t *testing.T) {
+	s := &AgentSkillServer{catalog: skills.GetDefault()}
+
+	// hello-agent ships with allowed_peers: [] (leaf) — so any peer is denied.
+	if s.peerAllowed("hello-agent", "some-peer") {
+		t.Error("hello-agent has no allowed_peers; call should be denied")
+	}
+	// Empty caller (admin/operator direct call) is allowed — eBPF is the
+	// boundary for box-originated traffic.
+	if !s.peerAllowed("", "some-peer") {
+		t.Error("empty caller should be allowed (not gated at this layer)")
+	}
+	// Unknown caller skill is allowed (not ours to gate here).
+	if !s.peerAllowed("does-not-exist", "some-peer") {
+		t.Error("unknown caller skill should not be gated here")
 	}
 }


### PR DESCRIPTION
## Summary

Phase 2 / #574 — arm `allowed_peers` enforcement, in two layers. Builds on #573 (policy compilation). Closes #574.

## 1. API boundary (pure Go, tested)

`SendAgentTask` now **rejects** a call to a peer not in the calling skill's `allowed_peers` with `PermissionDenied`. The real caller is recovered from the **authenticated token subject** (an agent box's JWT subject is `agent-<skill-id>`), falling back to caller-asserted `from_skill_id`. An unknown/empty caller (admin/operator direct call) isn't gated here — for raw box-originated traffic the eBPF egress policy is the hard boundary; this is the fail-fast courtesy layer.

## 2. In-kernel drop (arming)

`applyAllowedPeersPolicy` can now compile the per-box policy in **ENFORCE** mode and add platform-egress CIDRs, via opt-in env:
- `CONTAINARIUM_AGENT_NETWORK_POLICY_ENFORCE=1` → ENFORCE (default `LOG_ONLY`)
- `CONTAINARIUM_AGENT_EGRESS_CIDRS=cidr,cidr` → daemon API + DNS, so an armed allowlist doesn't strand the agent

The policy is now `Compile()`-validated before `Set`. The actual packet **drop** is the existing **hardware-validated eBPF enforcer**, which still requires `CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT` + `_ENFORCE`.

## Safety

Defaults unchanged: **observe-only, nothing dropped**, until an operator arms *both* the agent ENFORCE opt-in *and* the daemon-wide eBPF enforcer.

## Verification

`go build ./...`, `gofmt`, `internal/server` tests green (compile enforce+extra-CIDRs, `peerAllowed` leaf/empty/unknown).

Follow-ups: #575 (audit A2A hops under `trace_id`), #576 (negative-path test), #577 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)