### PR TITLE
feat(agents): audit A2A hops under a shared trace_id (#575)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -9249,6 +9249,10 @@
         "inputJson": {
           "type": "string",
           "description": "JSON task input matching the peer's agent_card input schema."
+        },
+        "traceId": {
+          "type": "string",
+          "description": "Correlation id threaded through the audit trail for this delegation. A\ncaller (e.g. a crew, Phase 3) sets it so every hop of a run shares one id;\nwhen empty the daemon generates one. Echoed back in the response."
         }
       },
       "description": "SendAgentTaskRequest delegates a task to a running peer agent. The peer is\naddressed by its agent_card.id (or skill id). In Phase 2 the daemon will\nreject a send to a peer not in the caller's allowed_peers; in Phase 1 the\nfield set is established and the send is best-effort over A2A."
@@ -9258,6 +9262,10 @@
       "properties": {
         "artifact": {
           "$ref": "#/definitions/AgentArtifact"
+        },
+        "traceId": {
+          "type": "string",
+          "description": "The trace id this hop was audited under (generated if the request omitted\none). Lets a caller chain subsequent hops under the same id."
         }
       },
       "description": "SendAgentTaskResponse returns the peer's artifact."

--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -12,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/footprintai/containarium/internal/audit"
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/netpolicy"
 	"github.com/footprintai/containarium/pkg/core/skills"
@@ -46,7 +50,12 @@ type AgentSkillServer struct {
 	recipes   *RecipeServer        // box provisioning (reuses CreateContainer/exec/expose)
 	tokens    *auth.TokenManager   // mints the skill's scoped in-box token
 	netpolicy *NetworkPolicyServer // compiles allowed_peers into a per-box egress policy (Phase 2)
+	audit     *audit.Store         // records A2A hops under a trace id (Phase 2); set once the pool is ready
 }
+
+// SetAuditStore wires the audit store once the Postgres pool exists (it isn't
+// available at construction). A2A hop logging no-ops until then.
+func (s *AgentSkillServer) SetAuditStore(store *audit.Store) { s.audit = store }
 
 // NewAgentSkillServer wires the agent-skill service to the recipe server (for
 // box provisioning), the token manager (for minting scoped in-box tokens), and
@@ -315,25 +324,77 @@ func (s *AgentSkillServer) SendAgentTask(ctx context.Context, req *pb.SendAgentT
 	// defense-in-depth + fail-fast UX — the hard boundary for raw box-originated
 	// traffic is the eBPF egress policy compiled from allowed_peers.
 	caller := s.callerSkillID(ctx, req.FromSkillId)
+
+	// Correlation id for the whole delegation: honor a caller-threaded id
+	// (a crew, Phase 3), else generate one. Every audit record for this hop
+	// shares it.
+	trace := req.TraceId
+	if trace == "" {
+		trace = genTraceID()
+	}
+
 	if !s.peerAllowed(caller, req.ToPeerId) {
+		s.auditHop(ctx, trace, caller, req.ToPeerId, "denied", "not in allowed_peers")
 		return nil, status.Errorf(codes.PermissionDenied,
 			"skill %q is not permitted to call peer %q (not in its allowed_peers)", caller, req.ToPeerId)
 	}
 
 	baseURL, _, err := s.resolvePeerA2A(req.ToPeerId)
 	if err != nil {
+		s.auditHop(ctx, trace, caller, req.ToPeerId, "unreachable", err.Error())
 		return nil, err
 	}
 
 	task := &pb.AgentTask{
-		Id:        "task-" + req.FromSkillId + "-" + req.ToPeerId,
+		Id:        "task-" + caller + "-" + req.ToPeerId,
 		InputJson: req.InputJson,
 	}
 	art, err := sendA2ATask(ctx, baseURL, task)
 	if err != nil {
+		s.auditHop(ctx, trace, caller, req.ToPeerId, "failed", err.Error())
 		return nil, status.Errorf(codes.Unavailable, "deliver task to peer %q: %v", req.ToPeerId, err)
 	}
-	return &pb.SendAgentTaskResponse{Artifact: art}, nil
+	s.auditHop(ctx, trace, caller, req.ToPeerId, "delivered", "")
+	return &pb.SendAgentTaskResponse{Artifact: art, TraceId: trace}, nil
+}
+
+// genTraceID returns a random 128-bit hex correlation id for an A2A run.
+func genTraceID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// rand failure is effectively impossible; fall back to a time nonce so
+		// the trace is still non-empty rather than colliding on "".
+		return fmt.Sprintf("t%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// auditHop records one A2A delegation under the shared trace id. Best-effort:
+// audit must never fail the call. No-op until the audit store is wired.
+func (s *AgentSkillServer) auditHop(ctx context.Context, trace, from, to, outcome, detail string) {
+	if s.audit == nil {
+		return
+	}
+	username := from
+	if username == "" {
+		username = "_unknown"
+	}
+	payload, _ := json.Marshal(map[string]string{
+		"trace_id": trace,
+		"from":     from,
+		"to":       to,
+		"outcome":  outcome,
+		"detail":   detail,
+	})
+	if err := s.audit.Log(ctx, &audit.AuditEntry{
+		Username:     username,
+		Action:       "agent.a2a_call",
+		ResourceType: "agent_skill",
+		ResourceID:   to,
+		Detail:       string(payload),
+	}); err != nil {
+		log.Printf("[agent-skill] audit A2A hop %s->%s: %v", from, to, err)
+	}
 }
 
 // resolvePeerA2A finds a running peer's in-box A2A base URL and its agent card.

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -32,6 +33,22 @@ func TestBuildAgentSeedScriptDefaultsInput(t *testing.T) {
 	if !strings.Contains(script, "'{}'") {
 		t.Errorf("empty input should default to {}, got:\n%s", script)
 	}
+}
+
+func TestGenTraceID(t *testing.T) {
+	a, b := genTraceID(), genTraceID()
+	if len(a) != 32 { // 16 bytes hex
+		t.Errorf("trace id len = %d, want 32", len(a))
+	}
+	if a == "" || a == b {
+		t.Errorf("trace ids should be non-empty and unique: %q %q", a, b)
+	}
+}
+
+func TestAuditHopNilStoreNoPanic(t *testing.T) {
+	// With no audit store wired, auditHop must be a safe no-op.
+	s := &AgentSkillServer{}
+	s.auditHop(context.Background(), "trace", "from", "to", "delivered", "")
 }
 
 func TestBuildAgentSeedScriptEscapesSingleQuotes(t *testing.T) {

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -317,7 +317,8 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	// manager for minting the skill's scoped in-box token, and the network
 	// policy server to compile allowed_peers into a per-box egress policy at
 	// launch (Phase 2).
-	pb.RegisterAgentSkillServiceServer(grpcServer, NewAgentSkillServer(recipeServer, tokenManager, npServer))
+	agentSkillServer := NewAgentSkillServer(recipeServer, tokenManager, npServer)
+	pb.RegisterAgentSkillServiceServer(grpcServer, agentSkillServer)
 	log.Printf("Agent-skill service enabled")
 
 	// Register BackupService — logical (pg_dump) database backups for the
@@ -1246,6 +1247,8 @@ skipAppHosting:
 		// Wire audit store for HTTP audit middleware
 		if auditStore != nil {
 			gatewayServer.SetAuditStore(auditStore)
+			// Agent-skill service logs A2A hops under a trace id (Phase 2 / #575).
+			agentSkillServer.SetAuditStore(auditStore)
 		}
 
 		// Wire Grafana reverse proxy if VictoriaMetrics is configured

--- a/pkg/pb/containarium/v1/agent.pb.go
+++ b/pkg/pb/containarium/v1/agent.pb.go
@@ -782,7 +782,11 @@ type SendAgentTaskRequest struct {
 	// The target peer to deliver the task to.
 	ToPeerId string `protobuf:"bytes,2,opt,name=to_peer_id,json=toPeerId,proto3" json:"to_peer_id,omitempty"`
 	// JSON task input matching the peer's agent_card input schema.
-	InputJson     string `protobuf:"bytes,3,opt,name=input_json,json=inputJson,proto3" json:"input_json,omitempty"`
+	InputJson string `protobuf:"bytes,3,opt,name=input_json,json=inputJson,proto3" json:"input_json,omitempty"`
+	// Correlation id threaded through the audit trail for this delegation. A
+	// caller (e.g. a crew, Phase 3) sets it so every hop of a run shares one id;
+	// when empty the daemon generates one. Echoed back in the response.
+	TraceId       string `protobuf:"bytes,4,opt,name=trace_id,json=traceId,proto3" json:"trace_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -838,10 +842,20 @@ func (x *SendAgentTaskRequest) GetInputJson() string {
 	return ""
 }
 
+func (x *SendAgentTaskRequest) GetTraceId() string {
+	if x != nil {
+		return x.TraceId
+	}
+	return ""
+}
+
 // SendAgentTaskResponse returns the peer's artifact.
 type SendAgentTaskResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Artifact      *AgentArtifact         `protobuf:"bytes,1,opt,name=artifact,proto3" json:"artifact,omitempty"`
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Artifact *AgentArtifact         `protobuf:"bytes,1,opt,name=artifact,proto3" json:"artifact,omitempty"`
+	// The trace id this hop was audited under (generated if the request omitted
+	// one). Lets a caller chain subsequent hops under the same id.
+	TraceId       string `protobuf:"bytes,2,opt,name=trace_id,json=traceId,proto3" json:"trace_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -881,6 +895,13 @@ func (x *SendAgentTaskResponse) GetArtifact() *AgentArtifact {
 		return x.Artifact
 	}
 	return nil
+}
+
+func (x *SendAgentTaskResponse) GetTraceId() string {
+	if x != nil {
+		return x.TraceId
+	}
+	return ""
 }
 
 var File_containarium_v1_agent_proto protoreflect.FileDescriptor
@@ -936,15 +957,17 @@ const file_containarium_v1_agent_proto_rawDesc = "" +
 	"\voutput_json\x18\x02 \x01(\tR\n" +
 	"outputJson\x125\n" +
 	"\x05state\x18\x03 \x01(\x0e2\x1f.containarium.v1.AgentTaskStateR\x05state\x12\x14\n" +
-	"\x05error\x18\x04 \x01(\tR\x05error\"w\n" +
+	"\x05error\x18\x04 \x01(\tR\x05error\"\x92\x01\n" +
 	"\x14SendAgentTaskRequest\x12\"\n" +
 	"\rfrom_skill_id\x18\x01 \x01(\tR\vfromSkillId\x12\x1c\n" +
 	"\n" +
 	"to_peer_id\x18\x02 \x01(\tR\btoPeerId\x12\x1d\n" +
 	"\n" +
-	"input_json\x18\x03 \x01(\tR\tinputJson\"S\n" +
+	"input_json\x18\x03 \x01(\tR\tinputJson\x12\x19\n" +
+	"\btrace_id\x18\x04 \x01(\tR\atraceId\"n\n" +
 	"\x15SendAgentTaskResponse\x12:\n" +
-	"\bartifact\x18\x01 \x01(\v2\x1e.containarium.v1.AgentArtifactR\bartifact*\xad\x01\n" +
+	"\bartifact\x18\x01 \x01(\v2\x1e.containarium.v1.AgentArtifactR\bartifact\x12\x19\n" +
+	"\btrace_id\x18\x02 \x01(\tR\atraceId*\xad\x01\n" +
 	"\x0eAgentTaskState\x12 \n" +
 	"\x1cAGENT_TASK_STATE_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aAGENT_TASK_STATE_SUBMITTED\x10\x01\x12\x1c\n" +

--- a/proto/containarium/v1/agent.proto
+++ b/proto/containarium/v1/agent.proto
@@ -177,11 +177,19 @@ message SendAgentTaskRequest {
   string to_peer_id = 2;
   // JSON task input matching the peer's agent_card input schema.
   string input_json = 3;
+
+  // Correlation id threaded through the audit trail for this delegation. A
+  // caller (e.g. a crew, Phase 3) sets it so every hop of a run shares one id;
+  // when empty the daemon generates one. Echoed back in the response.
+  string trace_id = 4;
 }
 
 // SendAgentTaskResponse returns the peer's artifact.
 message SendAgentTaskResponse {
   AgentArtifact artifact = 1;
+  // The trace id this hop was audited under (generated if the request omitted
+  // one). Lets a caller chain subsequent hops under the same id.
+  string trace_id = 2;
 }
 
 // AgentSkillService manages and runs individual packaged agents.


### PR DESCRIPTION
## Summary

Phase 2 / #575 — every A2A delegation is recorded in the audit log under a correlation id. Builds on #574. Closes #575.

## What's here

- **proto**: `SendAgentTaskRequest.trace_id` (caller-threaded — a crew sets it in Phase 3 so a whole run shares one id) + `SendAgentTaskResponse.trace_id` (the id used; generated if the request omitted one). `make proto` regenerated.
- **`SendAgentTask`**: resolves the trace (honor request, else `genTraceID` = 128-bit hex) and **`auditHop` on every outcome** — `denied` (allowed_peers), `unreachable` (peer down), `failed` (delivery), `delivered`. Action `agent.a2a_call`, resource_type `agent_skill`, detail JSON `{trace_id, from, to, outcome, detail}`. Best-effort: audit never fails the call; no-ops until the store is wired.
- **Wiring**: `AgentSkillServer.SetAuditStore`, called from `dual_server` alongside the gateway audit store once the Postgres pool exists.

## Note on "every A2A hop + MCP call"

Platform/MCP calls the agent makes are **already** audited by the gateway audit middleware. This PR adds the **agent-to-agent** dimension plus the **shared trace_id** that a crew (Phase 3) threads through an entire run, so the two correlate.

## Verification

`go build ./...`, `gofmt`, `internal/server` tests green (genTraceID len/uniqueness, auditHop nil-store no-op).

Follow-ups: #576 (negative-path test), #577 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)