### PR TITLE
test(agents): negative-path A2A enforcement + caller-subject fix (#576)

### DIFF
--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -236,7 +236,11 @@ func agentNetworkPolicyConfig() (extraCIDRs []string, enforce bool) {
 // authenticated token subject wins (an agent box's JWT subject is
 // agent-<skill-id>); otherwise it falls back to the caller-asserted value.
 func (s *AgentSkillServer) callerSkillID(ctx context.Context, asserted string) string {
-	if subj, ok := auth.UsernameFromContext(ctx); ok && strings.HasPrefix(subj, agentBoxPrefix) {
+	// Use the same gRPC-metadata subject the rest of the server authenticates
+	// on (RequireScope / AuthorizeTenant). The authenticated subject is the
+	// real boundary; the caller-asserted from_skill_id is only a fallback for
+	// non-agent callers (admin/operator), who aren't gated here anyway.
+	if subj, _, ok := auth.SubjectFromGRPCContext(ctx); ok && strings.HasPrefix(subj, agentBoxPrefix) {
 		return strings.TrimPrefix(subj, agentBoxPrefix)
 	}
 	return asserted

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/pkg/core/skills"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
@@ -32,6 +36,42 @@ func TestBuildAgentSeedScriptDefaultsInput(t *testing.T) {
 	script := buildAgentSeedScript("p", "t", "", "")
 	if !strings.Contains(script, "'{}'") {
 		t.Errorf("empty input should default to {}, got:\n%s", script)
+	}
+}
+
+// TestSendAgentTaskRejectsDisallowedPeer is the moat as a test: an agent whose
+// allowed_peers does not include the target is rejected at the API boundary,
+// BEFORE any A2A send is attempted. The caller identity is taken from the
+// authenticated token subject (agent-<skill-id>), not the caller-asserted
+// field, so an agent box can't spoof a different caller to bypass the gate.
+func TestSendAgentTaskRejectsDisallowedPeer(t *testing.T) {
+	// hello-agent ships with allowed_peers: [] (a leaf), so every peer is denied.
+	s := &AgentSkillServer{catalog: skills.GetDefault()}
+
+	// Authenticate as the agent box itself; agents:call scope present.
+	ctx := auth.ContextWithTestSubjectScopes(
+		context.Background(), "agent-hello-agent", nil, []string{auth.ScopeAgentsCall})
+
+	// from_skill_id deliberately lies ("admin-ish") — the authenticated subject
+	// must win, so the call is still denied.
+	_, err := s.SendAgentTask(ctx, &pb.SendAgentTaskRequest{
+		FromSkillId: "some-privileged-skill",
+		ToPeerId:    "other-peer",
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied for a peer not in allowed_peers, got %v", err)
+	}
+}
+
+// TestSendAgentTaskRequiresCallScope confirms the agents:call gate.
+func TestSendAgentTaskRequiresCallScope(t *testing.T) {
+	s := &AgentSkillServer{catalog: skills.GetDefault()}
+	// Authenticated, but without agents:call.
+	ctx := auth.ContextWithTestSubjectScopes(
+		context.Background(), "agent-hello-agent", nil, []string{auth.ScopeAgentsRead})
+	_, err := s.SendAgentTask(ctx, &pb.SendAgentTaskRequest{ToPeerId: "x"})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied without agents:call, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 2 / #576 — the moat as a test, plus a real bug it caught. Builds on #574/#575. Closes #576.

## Tests

- **`TestSendAgentTaskRejectsDisallowedPeer`**: an agent box (`hello-agent`, `allowed_peers: []`) authenticated as its own token subject is rejected with `PermissionDenied` **before any A2A send** — and a lying `from_skill_id` can't bypass it (the authenticated subject wins).
- **`TestSendAgentTaskRequiresCallScope`**: the `agents:call` gate.

## Bug caught + fixed

Writing the test surfaced a real defect in #574: `callerSkillID` read the subject via `auth.UsernameFromContext` — a context-value path the **gRPC auth interceptor does not populate** — so in real gRPC it silently fell back to the caller-asserted `from_skill_id`, defeating the boundary. Switched to `auth.SubjectFromGRPCContext` (the same metadata-based accessor `RequireScope`/`AuthorizeTenant` use). Now the authenticated agent-box subject is the real identity for the `allowed_peers` gate.

## Scope

This covers the **API-boundary** negative path. The **in-kernel eBPF drop** for raw box-originated traffic still needs a Linux backend + the armed enforcer to verify end-to-end (the hardware-validation seam, same as eBPF Phase A).

## Verification

`go build ./...`, `gofmt`, full `internal/server` tests green.

Follow-up: #577 (docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)