### PR TITLE
feat(agents): finalize Crew + CrewService proto (#579)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -27,6 +27,9 @@
       "name": "AgentSkillService"
     },
     {
+      "name": "CrewService"
+    },
+    {
       "name": "NetworkService"
     },
     {
@@ -2232,6 +2235,134 @@
         ],
         "tags": [
           "Container Operations"
+        ]
+      }
+    },
+    "/v1/crew-runs/{id}": {
+      "get": {
+        "summary": "Get crew run",
+        "description": "Returns the state, trace id, and (when complete) the artifact of a crew execution.",
+        "operationId": "CrewService_GetCrewRun",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetCrewRunResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Agents"
+        ]
+      }
+    },
+    "/v1/crews": {
+      "get": {
+        "summary": "List crews",
+        "description": "Returns all crews (collaborating skill sets) available to run.",
+        "operationId": "CrewService_ListCrews",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ListCrewsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "Agents"
+        ]
+      }
+    },
+    "/v1/crews/{crewId}/run": {
+      "post": {
+        "summary": "Run a crew",
+        "description": "Provisions each skill's box, gates A2A traffic with network policy compiled from allowed_peers, runs the collaboration, and returns the run handle.",
+        "operationId": "CrewService_RunCrew",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/RunCrewResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "crewId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RunCrewBody"
+            }
+          }
+        ],
+        "tags": [
+          "Agents"
+        ]
+      }
+    },
+    "/v1/crews/{id}": {
+      "get": {
+        "summary": "Get crew",
+        "description": "Returns one crew's definition, including its topology and member skills.",
+        "operationId": "CrewService_GetCrew",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetCrewResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Agents"
         ]
       }
     },
@@ -6469,6 +6600,90 @@
         }
       }
     },
+    "Crew": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable crew identifier (e.g. \"research-crew\")."
+        },
+        "name": {
+          "type": "string",
+          "description": "Display name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Short description of the task purpose."
+        },
+        "topology": {
+          "$ref": "#/definitions/CrewTopology",
+          "description": "How the skills are wired."
+        },
+        "skillIds": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Skill ids that make up this crew (in pipeline order when PIPELINE;\ncoordinator first when ORCHESTRATOR)."
+        }
+      },
+      "description": "Crew is a collaborating set of skills bound to a task purpose."
+    },
+    "CrewRun": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "crewId": {
+          "type": "string"
+        },
+        "traceId": {
+          "type": "string",
+          "description": "Shared trace id threaded through every agent's audit entries for this run."
+        },
+        "state": {
+          "$ref": "#/definitions/CrewRunState"
+        },
+        "inputJson": {
+          "type": "string",
+          "description": "JSON input handed to the crew's entry skill(s)."
+        },
+        "artifactJson": {
+          "type": "string",
+          "description": "JSON artifact produced by the crew. Populated when state is COMPLETED."
+        },
+        "error": {
+          "type": "string",
+          "description": "Human-readable error when state is FAILED."
+        }
+      },
+      "description": "CrewRun is one execution of a crew. Every A2A hop and MCP call made by any\nagent in the run is audit-logged under this run's trace_id, so a run is\nitself an evidence artifact."
+    },
+    "CrewRunState": {
+      "type": "string",
+      "enum": [
+        "CREW_RUN_STATE_UNSPECIFIED",
+        "CREW_RUN_STATE_PENDING",
+        "CREW_RUN_STATE_RUNNING",
+        "CREW_RUN_STATE_COMPLETED",
+        "CREW_RUN_STATE_FAILED",
+        "CREW_RUN_STATE_CANCELLED"
+      ],
+      "default": "CREW_RUN_STATE_UNSPECIFIED",
+      "description": "CrewRunState tracks the lifecycle of a single crew execution."
+    },
+    "CrewTopology": {
+      "type": "string",
+      "enum": [
+        "CREW_TOPOLOGY_UNSPECIFIED",
+        "CREW_TOPOLOGY_PIPELINE",
+        "CREW_TOPOLOGY_ORCHESTRATOR",
+        "CREW_TOPOLOGY_FREEFORM"
+      ],
+      "default": "CREW_TOPOLOGY_UNSPECIFIED",
+      "description": "CrewTopology describes how a crew's skills are wired together.\n\n - CREW_TOPOLOGY_PIPELINE: Linear pipeline: output of skill[i] feeds skill[i+1].\n - CREW_TOPOLOGY_ORCHESTRATOR: A coordinator skill fans tasks out to worker skills and synthesizes.\n - CREW_TOPOLOGY_FREEFORM: Skills coordinate freely over A2A within the allowed_peers graph; the crew\njust bounds the set and the trace."
+    },
     "DNSRecord": {
       "type": "object",
       "properties": {
@@ -7220,6 +7435,22 @@
       },
       "title": "GetContainerResponse is the response from getting a container"
     },
+    "GetCrewResponse": {
+      "type": "object",
+      "properties": {
+        "crew": {
+          "$ref": "#/definitions/Crew"
+        }
+      }
+    },
+    "GetCrewRunResponse": {
+      "type": "object",
+      "properties": {
+        "run": {
+          "$ref": "#/definitions/CrewRun"
+        }
+      }
+    },
     "GetEnvelopeCoverageResponse": {
       "type": "object",
       "properties": {
@@ -7787,6 +8018,18 @@
         }
       },
       "title": "ListContainersResponse is the response from listing containers"
+    },
+    "ListCrewsResponse": {
+      "type": "object",
+      "properties": {
+        "crews": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/Crew"
+          }
+        }
+      }
     },
     "ListDNSRecordsResponse": {
       "type": "object",
@@ -9158,6 +9401,29 @@
         "artifactJson": {
           "type": "string",
           "description": "JSON artifact matching the skill's output schema."
+        }
+      }
+    },
+    "RunCrewBody": {
+      "type": "object",
+      "properties": {
+        "backendId": {
+          "type": "string"
+        },
+        "pool": {
+          "type": "string"
+        },
+        "inputJson": {
+          "type": "string",
+          "description": "JSON input for the crew's entry skill(s)."
+        }
+      }
+    },
+    "RunCrewResponse": {
+      "type": "object",
+      "properties": {
+        "run": {
+          "$ref": "#/definitions/CrewRun"
         }
       }
     },

--- a/pkg/pb/containarium/v1/agent.pb.go
+++ b/pkg/pb/containarium/v1/agent.pb.go
@@ -79,6 +79,122 @@ func (AgentTaskState) EnumDescriptor() ([]byte, []int) {
 	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{0}
 }
 
+// CrewTopology describes how a crew's skills are wired together.
+type CrewTopology int32
+
+const (
+	CrewTopology_CREW_TOPOLOGY_UNSPECIFIED CrewTopology = 0
+	// Linear pipeline: output of skill[i] feeds skill[i+1].
+	CrewTopology_CREW_TOPOLOGY_PIPELINE CrewTopology = 1
+	// A coordinator skill fans tasks out to worker skills and synthesizes.
+	CrewTopology_CREW_TOPOLOGY_ORCHESTRATOR CrewTopology = 2
+	// Skills coordinate freely over A2A within the allowed_peers graph; the crew
+	// just bounds the set and the trace.
+	CrewTopology_CREW_TOPOLOGY_FREEFORM CrewTopology = 3
+)
+
+// Enum value maps for CrewTopology.
+var (
+	CrewTopology_name = map[int32]string{
+		0: "CREW_TOPOLOGY_UNSPECIFIED",
+		1: "CREW_TOPOLOGY_PIPELINE",
+		2: "CREW_TOPOLOGY_ORCHESTRATOR",
+		3: "CREW_TOPOLOGY_FREEFORM",
+	}
+	CrewTopology_value = map[string]int32{
+		"CREW_TOPOLOGY_UNSPECIFIED":  0,
+		"CREW_TOPOLOGY_PIPELINE":     1,
+		"CREW_TOPOLOGY_ORCHESTRATOR": 2,
+		"CREW_TOPOLOGY_FREEFORM":     3,
+	}
+)
+
+func (x CrewTopology) Enum() *CrewTopology {
+	p := new(CrewTopology)
+	*p = x
+	return p
+}
+
+func (x CrewTopology) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CrewTopology) Descriptor() protoreflect.EnumDescriptor {
+	return file_containarium_v1_agent_proto_enumTypes[1].Descriptor()
+}
+
+func (CrewTopology) Type() protoreflect.EnumType {
+	return &file_containarium_v1_agent_proto_enumTypes[1]
+}
+
+func (x CrewTopology) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CrewTopology.Descriptor instead.
+func (CrewTopology) EnumDescriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{1}
+}
+
+// CrewRunState tracks the lifecycle of a single crew execution.
+type CrewRunState int32
+
+const (
+	CrewRunState_CREW_RUN_STATE_UNSPECIFIED CrewRunState = 0
+	CrewRunState_CREW_RUN_STATE_PENDING     CrewRunState = 1
+	CrewRunState_CREW_RUN_STATE_RUNNING     CrewRunState = 2
+	CrewRunState_CREW_RUN_STATE_COMPLETED   CrewRunState = 3
+	CrewRunState_CREW_RUN_STATE_FAILED      CrewRunState = 4
+	CrewRunState_CREW_RUN_STATE_CANCELLED   CrewRunState = 5
+)
+
+// Enum value maps for CrewRunState.
+var (
+	CrewRunState_name = map[int32]string{
+		0: "CREW_RUN_STATE_UNSPECIFIED",
+		1: "CREW_RUN_STATE_PENDING",
+		2: "CREW_RUN_STATE_RUNNING",
+		3: "CREW_RUN_STATE_COMPLETED",
+		4: "CREW_RUN_STATE_FAILED",
+		5: "CREW_RUN_STATE_CANCELLED",
+	}
+	CrewRunState_value = map[string]int32{
+		"CREW_RUN_STATE_UNSPECIFIED": 0,
+		"CREW_RUN_STATE_PENDING":     1,
+		"CREW_RUN_STATE_RUNNING":     2,
+		"CREW_RUN_STATE_COMPLETED":   3,
+		"CREW_RUN_STATE_FAILED":      4,
+		"CREW_RUN_STATE_CANCELLED":   5,
+	}
+)
+
+func (x CrewRunState) Enum() *CrewRunState {
+	p := new(CrewRunState)
+	*p = x
+	return p
+}
+
+func (x CrewRunState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CrewRunState) Descriptor() protoreflect.EnumDescriptor {
+	return file_containarium_v1_agent_proto_enumTypes[2].Descriptor()
+}
+
+func (CrewRunState) Type() protoreflect.EnumType {
+	return &file_containarium_v1_agent_proto_enumTypes[2]
+}
+
+func (x CrewRunState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CrewRunState.Descriptor instead.
+func (CrewRunState) EnumDescriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{2}
+}
+
 // AgentCard is the discovery document a skill serves so peer agents can find
 // it and learn how to delegate to it (A2A, Phase 1). It is carried in-proto so
 // the wire format stays insulated from upstream A2A churn.
@@ -904,6 +1020,557 @@ func (x *SendAgentTaskResponse) GetTraceId() string {
 	return ""
 }
 
+// Crew is a collaborating set of skills bound to a task purpose.
+type Crew struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Stable crew identifier (e.g. "research-crew").
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Display name.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// Short description of the task purpose.
+	Description string `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	// How the skills are wired.
+	Topology CrewTopology `protobuf:"varint,4,opt,name=topology,proto3,enum=containarium.v1.CrewTopology" json:"topology,omitempty"`
+	// Skill ids that make up this crew (in pipeline order when PIPELINE;
+	// coordinator first when ORCHESTRATOR).
+	SkillIds      []string `protobuf:"bytes,5,rep,name=skill_ids,json=skillIds,proto3" json:"skill_ids,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Crew) Reset() {
+	*x = Crew{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Crew) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Crew) ProtoMessage() {}
+
+func (x *Crew) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Crew.ProtoReflect.Descriptor instead.
+func (*Crew) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *Crew) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *Crew) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Crew) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *Crew) GetTopology() CrewTopology {
+	if x != nil {
+		return x.Topology
+	}
+	return CrewTopology_CREW_TOPOLOGY_UNSPECIFIED
+}
+
+func (x *Crew) GetSkillIds() []string {
+	if x != nil {
+		return x.SkillIds
+	}
+	return nil
+}
+
+// CrewRun is one execution of a crew. Every A2A hop and MCP call made by any
+// agent in the run is audit-logged under this run's trace_id, so a run is
+// itself an evidence artifact.
+type CrewRun struct {
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Id     string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	CrewId string                 `protobuf:"bytes,2,opt,name=crew_id,json=crewId,proto3" json:"crew_id,omitempty"`
+	// Shared trace id threaded through every agent's audit entries for this run.
+	TraceId string       `protobuf:"bytes,3,opt,name=trace_id,json=traceId,proto3" json:"trace_id,omitempty"`
+	State   CrewRunState `protobuf:"varint,4,opt,name=state,proto3,enum=containarium.v1.CrewRunState" json:"state,omitempty"`
+	// JSON input handed to the crew's entry skill(s).
+	InputJson string `protobuf:"bytes,5,opt,name=input_json,json=inputJson,proto3" json:"input_json,omitempty"`
+	// JSON artifact produced by the crew. Populated when state is COMPLETED.
+	ArtifactJson string `protobuf:"bytes,6,opt,name=artifact_json,json=artifactJson,proto3" json:"artifact_json,omitempty"`
+	// Human-readable error when state is FAILED.
+	Error         string `protobuf:"bytes,7,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CrewRun) Reset() {
+	*x = CrewRun{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CrewRun) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CrewRun) ProtoMessage() {}
+
+func (x *CrewRun) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CrewRun.ProtoReflect.Descriptor instead.
+func (*CrewRun) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *CrewRun) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *CrewRun) GetCrewId() string {
+	if x != nil {
+		return x.CrewId
+	}
+	return ""
+}
+
+func (x *CrewRun) GetTraceId() string {
+	if x != nil {
+		return x.TraceId
+	}
+	return ""
+}
+
+func (x *CrewRun) GetState() CrewRunState {
+	if x != nil {
+		return x.State
+	}
+	return CrewRunState_CREW_RUN_STATE_UNSPECIFIED
+}
+
+func (x *CrewRun) GetInputJson() string {
+	if x != nil {
+		return x.InputJson
+	}
+	return ""
+}
+
+func (x *CrewRun) GetArtifactJson() string {
+	if x != nil {
+		return x.ArtifactJson
+	}
+	return ""
+}
+
+func (x *CrewRun) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+type ListCrewsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListCrewsRequest) Reset() {
+	*x = ListCrewsRequest{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListCrewsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListCrewsRequest) ProtoMessage() {}
+
+func (x *ListCrewsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListCrewsRequest.ProtoReflect.Descriptor instead.
+func (*ListCrewsRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{14}
+}
+
+type ListCrewsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Crews         []*Crew                `protobuf:"bytes,1,rep,name=crews,proto3" json:"crews,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListCrewsResponse) Reset() {
+	*x = ListCrewsResponse{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListCrewsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListCrewsResponse) ProtoMessage() {}
+
+func (x *ListCrewsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListCrewsResponse.ProtoReflect.Descriptor instead.
+func (*ListCrewsResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ListCrewsResponse) GetCrews() []*Crew {
+	if x != nil {
+		return x.Crews
+	}
+	return nil
+}
+
+type GetCrewRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetCrewRequest) Reset() {
+	*x = GetCrewRequest{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetCrewRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetCrewRequest) ProtoMessage() {}
+
+func (x *GetCrewRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetCrewRequest.ProtoReflect.Descriptor instead.
+func (*GetCrewRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *GetCrewRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type GetCrewResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Crew          *Crew                  `protobuf:"bytes,1,opt,name=crew,proto3" json:"crew,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetCrewResponse) Reset() {
+	*x = GetCrewResponse{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetCrewResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetCrewResponse) ProtoMessage() {}
+
+func (x *GetCrewResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetCrewResponse.ProtoReflect.Descriptor instead.
+func (*GetCrewResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *GetCrewResponse) GetCrew() *Crew {
+	if x != nil {
+		return x.Crew
+	}
+	return nil
+}
+
+type RunCrewRequest struct {
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	CrewId    string                 `protobuf:"bytes,1,opt,name=crew_id,json=crewId,proto3" json:"crew_id,omitempty"`
+	BackendId string                 `protobuf:"bytes,2,opt,name=backend_id,json=backendId,proto3" json:"backend_id,omitempty"`
+	Pool      string                 `protobuf:"bytes,3,opt,name=pool,proto3" json:"pool,omitempty"`
+	// JSON input for the crew's entry skill(s).
+	InputJson     string `protobuf:"bytes,4,opt,name=input_json,json=inputJson,proto3" json:"input_json,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunCrewRequest) Reset() {
+	*x = RunCrewRequest{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunCrewRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunCrewRequest) ProtoMessage() {}
+
+func (x *RunCrewRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunCrewRequest.ProtoReflect.Descriptor instead.
+func (*RunCrewRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *RunCrewRequest) GetCrewId() string {
+	if x != nil {
+		return x.CrewId
+	}
+	return ""
+}
+
+func (x *RunCrewRequest) GetBackendId() string {
+	if x != nil {
+		return x.BackendId
+	}
+	return ""
+}
+
+func (x *RunCrewRequest) GetPool() string {
+	if x != nil {
+		return x.Pool
+	}
+	return ""
+}
+
+func (x *RunCrewRequest) GetInputJson() string {
+	if x != nil {
+		return x.InputJson
+	}
+	return ""
+}
+
+type RunCrewResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Run           *CrewRun               `protobuf:"bytes,1,opt,name=run,proto3" json:"run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunCrewResponse) Reset() {
+	*x = RunCrewResponse{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunCrewResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunCrewResponse) ProtoMessage() {}
+
+func (x *RunCrewResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunCrewResponse.ProtoReflect.Descriptor instead.
+func (*RunCrewResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *RunCrewResponse) GetRun() *CrewRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
+type GetCrewRunRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetCrewRunRequest) Reset() {
+	*x = GetCrewRunRequest{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetCrewRunRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetCrewRunRequest) ProtoMessage() {}
+
+func (x *GetCrewRunRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetCrewRunRequest.ProtoReflect.Descriptor instead.
+func (*GetCrewRunRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *GetCrewRunRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type GetCrewRunResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Run           *CrewRun               `protobuf:"bytes,1,opt,name=run,proto3" json:"run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetCrewRunResponse) Reset() {
+	*x = GetCrewRunResponse{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetCrewRunResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetCrewRunResponse) ProtoMessage() {}
+
+func (x *GetCrewRunResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetCrewRunResponse.ProtoReflect.Descriptor instead.
+func (*GetCrewRunResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *GetCrewRunResponse) GetRun() *CrewRun {
+	if x != nil {
+		return x.Run
+	}
+	return nil
+}
+
 var File_containarium_v1_agent_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_agent_proto_rawDesc = "" +
@@ -967,13 +1634,60 @@ const file_containarium_v1_agent_proto_rawDesc = "" +
 	"\btrace_id\x18\x04 \x01(\tR\atraceId\"n\n" +
 	"\x15SendAgentTaskResponse\x12:\n" +
 	"\bartifact\x18\x01 \x01(\v2\x1e.containarium.v1.AgentArtifactR\bartifact\x12\x19\n" +
-	"\btrace_id\x18\x02 \x01(\tR\atraceId*\xad\x01\n" +
+	"\btrace_id\x18\x02 \x01(\tR\atraceId\"\xa4\x01\n" +
+	"\x04Crew\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
+	"\vdescription\x18\x03 \x01(\tR\vdescription\x129\n" +
+	"\btopology\x18\x04 \x01(\x0e2\x1d.containarium.v1.CrewTopologyR\btopology\x12\x1b\n" +
+	"\tskill_ids\x18\x05 \x03(\tR\bskillIds\"\xdc\x01\n" +
+	"\aCrewRun\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x17\n" +
+	"\acrew_id\x18\x02 \x01(\tR\x06crewId\x12\x19\n" +
+	"\btrace_id\x18\x03 \x01(\tR\atraceId\x123\n" +
+	"\x05state\x18\x04 \x01(\x0e2\x1d.containarium.v1.CrewRunStateR\x05state\x12\x1d\n" +
+	"\n" +
+	"input_json\x18\x05 \x01(\tR\tinputJson\x12#\n" +
+	"\rartifact_json\x18\x06 \x01(\tR\fartifactJson\x12\x14\n" +
+	"\x05error\x18\a \x01(\tR\x05error\"\x12\n" +
+	"\x10ListCrewsRequest\"@\n" +
+	"\x11ListCrewsResponse\x12+\n" +
+	"\x05crews\x18\x01 \x03(\v2\x15.containarium.v1.CrewR\x05crews\" \n" +
+	"\x0eGetCrewRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"<\n" +
+	"\x0fGetCrewResponse\x12)\n" +
+	"\x04crew\x18\x01 \x01(\v2\x15.containarium.v1.CrewR\x04crew\"{\n" +
+	"\x0eRunCrewRequest\x12\x17\n" +
+	"\acrew_id\x18\x01 \x01(\tR\x06crewId\x12\x1d\n" +
+	"\n" +
+	"backend_id\x18\x02 \x01(\tR\tbackendId\x12\x12\n" +
+	"\x04pool\x18\x03 \x01(\tR\x04pool\x12\x1d\n" +
+	"\n" +
+	"input_json\x18\x04 \x01(\tR\tinputJson\"=\n" +
+	"\x0fRunCrewResponse\x12*\n" +
+	"\x03run\x18\x01 \x01(\v2\x18.containarium.v1.CrewRunR\x03run\"#\n" +
+	"\x11GetCrewRunRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"@\n" +
+	"\x12GetCrewRunResponse\x12*\n" +
+	"\x03run\x18\x01 \x01(\v2\x18.containarium.v1.CrewRunR\x03run*\xad\x01\n" +
 	"\x0eAgentTaskState\x12 \n" +
 	"\x1cAGENT_TASK_STATE_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aAGENT_TASK_STATE_SUBMITTED\x10\x01\x12\x1c\n" +
 	"\x18AGENT_TASK_STATE_WORKING\x10\x02\x12\x1e\n" +
 	"\x1aAGENT_TASK_STATE_COMPLETED\x10\x03\x12\x1b\n" +
-	"\x17AGENT_TASK_STATE_FAILED\x10\x042\xbd\b\n" +
+	"\x17AGENT_TASK_STATE_FAILED\x10\x04*\x85\x01\n" +
+	"\fCrewTopology\x12\x1d\n" +
+	"\x19CREW_TOPOLOGY_UNSPECIFIED\x10\x00\x12\x1a\n" +
+	"\x16CREW_TOPOLOGY_PIPELINE\x10\x01\x12\x1e\n" +
+	"\x1aCREW_TOPOLOGY_ORCHESTRATOR\x10\x02\x12\x1a\n" +
+	"\x16CREW_TOPOLOGY_FREEFORM\x10\x03*\xbd\x01\n" +
+	"\fCrewRunState\x12\x1e\n" +
+	"\x1aCREW_RUN_STATE_UNSPECIFIED\x10\x00\x12\x1a\n" +
+	"\x16CREW_RUN_STATE_PENDING\x10\x01\x12\x1a\n" +
+	"\x16CREW_RUN_STATE_RUNNING\x10\x02\x12\x1c\n" +
+	"\x18CREW_RUN_STATE_COMPLETED\x10\x03\x12\x19\n" +
+	"\x15CREW_RUN_STATE_FAILED\x10\x04\x12\x1c\n" +
+	"\x18CREW_RUN_STATE_CANCELLED\x10\x052\xbd\b\n" +
 	"\x11AgentSkillService\x12\xf6\x01\n" +
 	"\x0fListAgentSkills\x12'.containarium.v1.ListAgentSkillsRequest\x1a(.containarium.v1.ListAgentSkillsResponse\"\x8f\x01\x92At\n" +
 	"\x06Agents\x12\x11List agent skills\x1aWReturns all packaged agent skills that can be run individually or composed into a crew.\x82\xd3\xe4\x93\x02\x12\x12\x10/v1/agent-skills\x12\xf8\x01\n" +
@@ -982,7 +1696,19 @@ const file_containarium_v1_agent_proto_rawDesc = "" +
 	"\rRunAgentSkill\x12%.containarium.v1.RunAgentSkillRequest\x1a&.containarium.v1.RunAgentSkillResponse\"\xa5\x01\x92Ax\n" +
 	"\x06Agents\x12\x12Run an agent skill\x1aZProvisions the skill's box, mints a scoped token, runs one task, and returns the artifact.\x82\xd3\xe4\x93\x02$:\x01*\"\x1f/v1/agent-skills/{skill_id}/run\x12\xaa\x02\n" +
 	"\rSendAgentTask\x12%.containarium.v1.SendAgentTaskRequest\x1a&.containarium.v1.SendAgentTaskResponse\"\xc9\x01\x92A\x98\x01\n" +
-	"\x06Agents\x12!Send a task to a peer agent (A2A)\x1akDelegates a task to a running peer agent over the agent-to-agent transport and returns the peer's artifact.\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/agent-skills/{to_peer_id}/callBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
+	"\x06Agents\x12!Send a task to a peer agent (A2A)\x1akDelegates a task to a running peer agent over the agent-to-agent transport and returns the peer's artifact.\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/agent-skills/{to_peer_id}/call2\x96\a\n" +
+	"\vCrewService\x12\xbc\x01\n" +
+	"\tListCrews\x12!.containarium.v1.ListCrewsRequest\x1a\".containarium.v1.ListCrewsResponse\"h\x92AT\n" +
+	"\x06Agents\x12\n" +
+	"List crews\x1a>Returns all crews (collaborating skill sets) available to run.\x82\xd3\xe4\x93\x02\v\x12\t/v1/crews\x12\xc3\x01\n" +
+	"\aGetCrew\x12\x1f.containarium.v1.GetCrewRequest\x1a .containarium.v1.GetCrewResponse\"u\x92A\\\n" +
+	"\x06Agents\x12\bGet crew\x1aHReturns one crew's definition, including its topology and member skills.\x82\xd3\xe4\x93\x02\x10\x12\x0e/v1/crews/{id}\x12\x9f\x02\n" +
+	"\aRunCrew\x12\x1f.containarium.v1.RunCrewRequest\x1a .containarium.v1.RunCrewResponse\"\xd0\x01\x92A\xaa\x01\n" +
+	"\x06Agents\x12\n" +
+	"Run a crew\x1a\x93\x01Provisions each skill's box, gates A2A traffic with network policy compiled from allowed_peers, runs the collaboration, and returns the run handle.\x82\xd3\xe4\x93\x02\x1c:\x01*\"\x17/v1/crews/{crew_id}/run\x12\xdf\x01\n" +
+	"\n" +
+	"GetCrewRun\x12\".containarium.v1.GetCrewRunRequest\x1a#.containarium.v1.GetCrewRunResponse\"\x87\x01\x92Aj\n" +
+	"\x06Agents\x12\fGet crew run\x1aRReturns the state, trace id, and (when complete) the artifact of a crew execution.\x82\xd3\xe4\x93\x02\x14\x12\x12/v1/crew-runs/{id}BKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
 
 var (
 	file_containarium_v1_agent_proto_rawDescOnce sync.Once
@@ -996,46 +1722,72 @@ func file_containarium_v1_agent_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_agent_proto_rawDescData
 }
 
-var file_containarium_v1_agent_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_containarium_v1_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_containarium_v1_agent_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_containarium_v1_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_containarium_v1_agent_proto_goTypes = []any{
 	(AgentTaskState)(0),             // 0: containarium.v1.AgentTaskState
-	(*AgentCard)(nil),               // 1: containarium.v1.AgentCard
-	(*AgentSkill)(nil),              // 2: containarium.v1.AgentSkill
-	(*ListAgentSkillsRequest)(nil),  // 3: containarium.v1.ListAgentSkillsRequest
-	(*ListAgentSkillsResponse)(nil), // 4: containarium.v1.ListAgentSkillsResponse
-	(*GetAgentSkillRequest)(nil),    // 5: containarium.v1.GetAgentSkillRequest
-	(*GetAgentSkillResponse)(nil),   // 6: containarium.v1.GetAgentSkillResponse
-	(*RunAgentSkillRequest)(nil),    // 7: containarium.v1.RunAgentSkillRequest
-	(*RunAgentSkillResponse)(nil),   // 8: containarium.v1.RunAgentSkillResponse
-	(*AgentTask)(nil),               // 9: containarium.v1.AgentTask
-	(*AgentArtifact)(nil),           // 10: containarium.v1.AgentArtifact
-	(*SendAgentTaskRequest)(nil),    // 11: containarium.v1.SendAgentTaskRequest
-	(*SendAgentTaskResponse)(nil),   // 12: containarium.v1.SendAgentTaskResponse
-	(*Recipe)(nil),                  // 13: containarium.v1.Recipe
-	(*Container)(nil),               // 14: containarium.v1.Container
+	(CrewTopology)(0),               // 1: containarium.v1.CrewTopology
+	(CrewRunState)(0),               // 2: containarium.v1.CrewRunState
+	(*AgentCard)(nil),               // 3: containarium.v1.AgentCard
+	(*AgentSkill)(nil),              // 4: containarium.v1.AgentSkill
+	(*ListAgentSkillsRequest)(nil),  // 5: containarium.v1.ListAgentSkillsRequest
+	(*ListAgentSkillsResponse)(nil), // 6: containarium.v1.ListAgentSkillsResponse
+	(*GetAgentSkillRequest)(nil),    // 7: containarium.v1.GetAgentSkillRequest
+	(*GetAgentSkillResponse)(nil),   // 8: containarium.v1.GetAgentSkillResponse
+	(*RunAgentSkillRequest)(nil),    // 9: containarium.v1.RunAgentSkillRequest
+	(*RunAgentSkillResponse)(nil),   // 10: containarium.v1.RunAgentSkillResponse
+	(*AgentTask)(nil),               // 11: containarium.v1.AgentTask
+	(*AgentArtifact)(nil),           // 12: containarium.v1.AgentArtifact
+	(*SendAgentTaskRequest)(nil),    // 13: containarium.v1.SendAgentTaskRequest
+	(*SendAgentTaskResponse)(nil),   // 14: containarium.v1.SendAgentTaskResponse
+	(*Crew)(nil),                    // 15: containarium.v1.Crew
+	(*CrewRun)(nil),                 // 16: containarium.v1.CrewRun
+	(*ListCrewsRequest)(nil),        // 17: containarium.v1.ListCrewsRequest
+	(*ListCrewsResponse)(nil),       // 18: containarium.v1.ListCrewsResponse
+	(*GetCrewRequest)(nil),          // 19: containarium.v1.GetCrewRequest
+	(*GetCrewResponse)(nil),         // 20: containarium.v1.GetCrewResponse
+	(*RunCrewRequest)(nil),          // 21: containarium.v1.RunCrewRequest
+	(*RunCrewResponse)(nil),         // 22: containarium.v1.RunCrewResponse
+	(*GetCrewRunRequest)(nil),       // 23: containarium.v1.GetCrewRunRequest
+	(*GetCrewRunResponse)(nil),      // 24: containarium.v1.GetCrewRunResponse
+	(*Recipe)(nil),                  // 25: containarium.v1.Recipe
+	(*Container)(nil),               // 26: containarium.v1.Container
 }
 var file_containarium_v1_agent_proto_depIdxs = []int32{
-	13, // 0: containarium.v1.AgentSkill.recipe:type_name -> containarium.v1.Recipe
-	1,  // 1: containarium.v1.AgentSkill.agent_card:type_name -> containarium.v1.AgentCard
-	2,  // 2: containarium.v1.ListAgentSkillsResponse.skills:type_name -> containarium.v1.AgentSkill
-	2,  // 3: containarium.v1.GetAgentSkillResponse.skill:type_name -> containarium.v1.AgentSkill
-	14, // 4: containarium.v1.RunAgentSkillResponse.container:type_name -> containarium.v1.Container
+	25, // 0: containarium.v1.AgentSkill.recipe:type_name -> containarium.v1.Recipe
+	3,  // 1: containarium.v1.AgentSkill.agent_card:type_name -> containarium.v1.AgentCard
+	4,  // 2: containarium.v1.ListAgentSkillsResponse.skills:type_name -> containarium.v1.AgentSkill
+	4,  // 3: containarium.v1.GetAgentSkillResponse.skill:type_name -> containarium.v1.AgentSkill
+	26, // 4: containarium.v1.RunAgentSkillResponse.container:type_name -> containarium.v1.Container
 	0,  // 5: containarium.v1.AgentArtifact.state:type_name -> containarium.v1.AgentTaskState
-	10, // 6: containarium.v1.SendAgentTaskResponse.artifact:type_name -> containarium.v1.AgentArtifact
-	3,  // 7: containarium.v1.AgentSkillService.ListAgentSkills:input_type -> containarium.v1.ListAgentSkillsRequest
-	5,  // 8: containarium.v1.AgentSkillService.GetAgentSkill:input_type -> containarium.v1.GetAgentSkillRequest
-	7,  // 9: containarium.v1.AgentSkillService.RunAgentSkill:input_type -> containarium.v1.RunAgentSkillRequest
-	11, // 10: containarium.v1.AgentSkillService.SendAgentTask:input_type -> containarium.v1.SendAgentTaskRequest
-	4,  // 11: containarium.v1.AgentSkillService.ListAgentSkills:output_type -> containarium.v1.ListAgentSkillsResponse
-	6,  // 12: containarium.v1.AgentSkillService.GetAgentSkill:output_type -> containarium.v1.GetAgentSkillResponse
-	8,  // 13: containarium.v1.AgentSkillService.RunAgentSkill:output_type -> containarium.v1.RunAgentSkillResponse
-	12, // 14: containarium.v1.AgentSkillService.SendAgentTask:output_type -> containarium.v1.SendAgentTaskResponse
-	11, // [11:15] is the sub-list for method output_type
-	7,  // [7:11] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	12, // 6: containarium.v1.SendAgentTaskResponse.artifact:type_name -> containarium.v1.AgentArtifact
+	1,  // 7: containarium.v1.Crew.topology:type_name -> containarium.v1.CrewTopology
+	2,  // 8: containarium.v1.CrewRun.state:type_name -> containarium.v1.CrewRunState
+	15, // 9: containarium.v1.ListCrewsResponse.crews:type_name -> containarium.v1.Crew
+	15, // 10: containarium.v1.GetCrewResponse.crew:type_name -> containarium.v1.Crew
+	16, // 11: containarium.v1.RunCrewResponse.run:type_name -> containarium.v1.CrewRun
+	16, // 12: containarium.v1.GetCrewRunResponse.run:type_name -> containarium.v1.CrewRun
+	5,  // 13: containarium.v1.AgentSkillService.ListAgentSkills:input_type -> containarium.v1.ListAgentSkillsRequest
+	7,  // 14: containarium.v1.AgentSkillService.GetAgentSkill:input_type -> containarium.v1.GetAgentSkillRequest
+	9,  // 15: containarium.v1.AgentSkillService.RunAgentSkill:input_type -> containarium.v1.RunAgentSkillRequest
+	13, // 16: containarium.v1.AgentSkillService.SendAgentTask:input_type -> containarium.v1.SendAgentTaskRequest
+	17, // 17: containarium.v1.CrewService.ListCrews:input_type -> containarium.v1.ListCrewsRequest
+	19, // 18: containarium.v1.CrewService.GetCrew:input_type -> containarium.v1.GetCrewRequest
+	21, // 19: containarium.v1.CrewService.RunCrew:input_type -> containarium.v1.RunCrewRequest
+	23, // 20: containarium.v1.CrewService.GetCrewRun:input_type -> containarium.v1.GetCrewRunRequest
+	6,  // 21: containarium.v1.AgentSkillService.ListAgentSkills:output_type -> containarium.v1.ListAgentSkillsResponse
+	8,  // 22: containarium.v1.AgentSkillService.GetAgentSkill:output_type -> containarium.v1.GetAgentSkillResponse
+	10, // 23: containarium.v1.AgentSkillService.RunAgentSkill:output_type -> containarium.v1.RunAgentSkillResponse
+	14, // 24: containarium.v1.AgentSkillService.SendAgentTask:output_type -> containarium.v1.SendAgentTaskResponse
+	18, // 25: containarium.v1.CrewService.ListCrews:output_type -> containarium.v1.ListCrewsResponse
+	20, // 26: containarium.v1.CrewService.GetCrew:output_type -> containarium.v1.GetCrewResponse
+	22, // 27: containarium.v1.CrewService.RunCrew:output_type -> containarium.v1.RunCrewResponse
+	24, // 28: containarium.v1.CrewService.GetCrewRun:output_type -> containarium.v1.GetCrewRunResponse
+	21, // [21:29] is the sub-list for method output_type
+	13, // [13:21] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_agent_proto_init() }
@@ -1054,10 +1806,10 @@ func file_containarium_v1_agent_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_agent_proto_rawDesc), len(file_containarium_v1_agent_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   12,
+			NumEnums:      3,
+			NumMessages:   22,
 			NumExtensions: 0,
-			NumServices:   1,
+			NumServices:   2,
 		},
 		GoTypes:           file_containarium_v1_agent_proto_goTypes,
 		DependencyIndexes: file_containarium_v1_agent_proto_depIdxs,

--- a/pkg/pb/containarium/v1/agent.pb.gw.go
+++ b/pkg/pb/containarium/v1/agent.pb.gw.go
@@ -185,6 +185,150 @@ func local_request_AgentSkillService_SendAgentTask_0(ctx context.Context, marsha
 	return msg, metadata, err
 }
 
+func request_CrewService_ListCrews_0(ctx context.Context, marshaler runtime.Marshaler, client CrewServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListCrewsRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListCrews(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_CrewService_ListCrews_0(ctx context.Context, marshaler runtime.Marshaler, server CrewServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListCrewsRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.ListCrews(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_CrewService_GetCrew_0(ctx context.Context, marshaler runtime.Marshaler, client CrewServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetCrewRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := client.GetCrew(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_CrewService_GetCrew_0(ctx context.Context, marshaler runtime.Marshaler, server CrewServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetCrewRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := server.GetCrew(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_CrewService_RunCrew_0(ctx context.Context, marshaler runtime.Marshaler, client CrewServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RunCrewRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["crew_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "crew_id")
+	}
+	protoReq.CrewId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "crew_id", err)
+	}
+	msg, err := client.RunCrew(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_CrewService_RunCrew_0(ctx context.Context, marshaler runtime.Marshaler, server CrewServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RunCrewRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["crew_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "crew_id")
+	}
+	protoReq.CrewId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "crew_id", err)
+	}
+	msg, err := server.RunCrew(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_CrewService_GetCrewRun_0(ctx context.Context, marshaler runtime.Marshaler, client CrewServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetCrewRunRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := client.GetCrewRun(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_CrewService_GetCrewRun_0(ctx context.Context, marshaler runtime.Marshaler, server CrewServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetCrewRunRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := server.GetCrewRun(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterAgentSkillServiceHandlerServer registers the http handlers for service AgentSkillService to "mux".
 // UnaryRPC     :call AgentSkillServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -270,6 +414,96 @@ func RegisterAgentSkillServiceHandlerServer(ctx context.Context, mux *runtime.Se
 			return
 		}
 		forward_AgentSkillService_SendAgentTask_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+
+	return nil
+}
+
+// RegisterCrewServiceHandlerServer registers the http handlers for service CrewService to "mux".
+// UnaryRPC     :call CrewServiceServer directly.
+// StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterCrewServiceHandlerFromEndpoint instead.
+// GRPC interceptors will not work for this type of registration. To use interceptors, you must use the "runtime.WithMiddlewares" option in the "runtime.NewServeMux" call.
+func RegisterCrewServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux, server CrewServiceServer) error {
+	mux.Handle(http.MethodGet, pattern_CrewService_ListCrews_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.CrewService/ListCrews", runtime.WithHTTPPathPattern("/v1/crews"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_CrewService_ListCrews_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrewService_ListCrews_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_CrewService_GetCrew_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.CrewService/GetCrew", runtime.WithHTTPPathPattern("/v1/crews/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_CrewService_GetCrew_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrewService_GetCrew_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_CrewService_RunCrew_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.CrewService/RunCrew", runtime.WithHTTPPathPattern("/v1/crews/{crew_id}/run"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_CrewService_RunCrew_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrewService_RunCrew_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_CrewService_GetCrewRun_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.CrewService/GetCrewRun", runtime.WithHTTPPathPattern("/v1/crew-runs/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_CrewService_GetCrewRun_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrewService_GetCrewRun_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -394,4 +628,125 @@ var (
 	forward_AgentSkillService_GetAgentSkill_0   = runtime.ForwardResponseMessage
 	forward_AgentSkillService_RunAgentSkill_0   = runtime.ForwardResponseMessage
 	forward_AgentSkillService_SendAgentTask_0   = runtime.ForwardResponseMessage
+)
+
+// RegisterCrewServiceHandlerFromEndpoint is same as RegisterCrewServiceHandler but
+// automatically dials to "endpoint" and closes the connection when "ctx" gets done.
+func RegisterCrewServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
+	conn, err := grpc.NewClient(endpoint, opts...)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			if cerr := conn.Close(); cerr != nil {
+				grpclog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+			}
+			return
+		}
+		go func() {
+			<-ctx.Done()
+			if cerr := conn.Close(); cerr != nil {
+				grpclog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+			}
+		}()
+	}()
+	return RegisterCrewServiceHandler(ctx, mux, conn)
+}
+
+// RegisterCrewServiceHandler registers the http handlers for service CrewService to "mux".
+// The handlers forward requests to the grpc endpoint over "conn".
+func RegisterCrewServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
+	return RegisterCrewServiceHandlerClient(ctx, mux, NewCrewServiceClient(conn))
+}
+
+// RegisterCrewServiceHandlerClient registers the http handlers for service CrewService
+// to "mux". The handlers forward requests to the grpc endpoint over the given implementation of "CrewServiceClient".
+// Note: the gRPC framework executes interceptors within the gRPC handler. If the passed in "CrewServiceClient"
+// doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
+// "CrewServiceClient" to call the correct interceptors. This client ignores the HTTP middlewares.
+func RegisterCrewServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux, client CrewServiceClient) error {
+	mux.Handle(http.MethodGet, pattern_CrewService_ListCrews_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.CrewService/ListCrews", runtime.WithHTTPPathPattern("/v1/crews"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_CrewService_ListCrews_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrewService_ListCrews_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_CrewService_GetCrew_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.CrewService/GetCrew", runtime.WithHTTPPathPattern("/v1/crews/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_CrewService_GetCrew_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrewService_GetCrew_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_CrewService_RunCrew_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.CrewService/RunCrew", runtime.WithHTTPPathPattern("/v1/crews/{crew_id}/run"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_CrewService_RunCrew_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrewService_RunCrew_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_CrewService_GetCrewRun_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.CrewService/GetCrewRun", runtime.WithHTTPPathPattern("/v1/crew-runs/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_CrewService_GetCrewRun_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_CrewService_GetCrewRun_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	return nil
+}
+
+var (
+	pattern_CrewService_ListCrews_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "crews"}, ""))
+	pattern_CrewService_GetCrew_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "crews", "id"}, ""))
+	pattern_CrewService_RunCrew_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "crews", "crew_id", "run"}, ""))
+	pattern_CrewService_GetCrewRun_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "crew-runs", "id"}, ""))
+)
+
+var (
+	forward_CrewService_ListCrews_0  = runtime.ForwardResponseMessage
+	forward_CrewService_GetCrew_0    = runtime.ForwardResponseMessage
+	forward_CrewService_RunCrew_0    = runtime.ForwardResponseMessage
+	forward_CrewService_GetCrewRun_0 = runtime.ForwardResponseMessage
 )

--- a/pkg/pb/containarium/v1/agent_grpc.pb.go
+++ b/pkg/pb/containarium/v1/agent_grpc.pb.go
@@ -251,3 +251,237 @@ var AgentSkillService_ServiceDesc = grpc.ServiceDesc{
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "containarium/v1/agent.proto",
 }
+
+const (
+	CrewService_ListCrews_FullMethodName  = "/containarium.v1.CrewService/ListCrews"
+	CrewService_GetCrew_FullMethodName    = "/containarium.v1.CrewService/GetCrew"
+	CrewService_RunCrew_FullMethodName    = "/containarium.v1.CrewService/RunCrew"
+	CrewService_GetCrewRun_FullMethodName = "/containarium.v1.CrewService/GetCrewRun"
+)
+
+// CrewServiceClient is the client API for CrewService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
+//
+// CrewService runs collaborating sets of skills bound to a task purpose.
+type CrewServiceClient interface {
+	// ListCrews returns all available crews.
+	ListCrews(ctx context.Context, in *ListCrewsRequest, opts ...grpc.CallOption) (*ListCrewsResponse, error)
+	// GetCrew returns a single crew definition by id.
+	GetCrew(ctx context.Context, in *GetCrewRequest, opts ...grpc.CallOption) (*GetCrewResponse, error)
+	// RunCrew launches a crew against an input: validates the topology against the
+	// union of member skills' allowed_peers, provisions each skill's box, compiles
+	// per-agent network policy, threads one trace_id through every hop, and
+	// returns the run handle.
+	RunCrew(ctx context.Context, in *RunCrewRequest, opts ...grpc.CallOption) (*RunCrewResponse, error)
+	// GetCrewRun returns the status and artifact of a crew run.
+	GetCrewRun(ctx context.Context, in *GetCrewRunRequest, opts ...grpc.CallOption) (*GetCrewRunResponse, error)
+}
+
+type crewServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewCrewServiceClient(cc grpc.ClientConnInterface) CrewServiceClient {
+	return &crewServiceClient{cc}
+}
+
+func (c *crewServiceClient) ListCrews(ctx context.Context, in *ListCrewsRequest, opts ...grpc.CallOption) (*ListCrewsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListCrewsResponse)
+	err := c.cc.Invoke(ctx, CrewService_ListCrews_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *crewServiceClient) GetCrew(ctx context.Context, in *GetCrewRequest, opts ...grpc.CallOption) (*GetCrewResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetCrewResponse)
+	err := c.cc.Invoke(ctx, CrewService_GetCrew_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *crewServiceClient) RunCrew(ctx context.Context, in *RunCrewRequest, opts ...grpc.CallOption) (*RunCrewResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RunCrewResponse)
+	err := c.cc.Invoke(ctx, CrewService_RunCrew_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *crewServiceClient) GetCrewRun(ctx context.Context, in *GetCrewRunRequest, opts ...grpc.CallOption) (*GetCrewRunResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetCrewRunResponse)
+	err := c.cc.Invoke(ctx, CrewService_GetCrewRun_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// CrewServiceServer is the server API for CrewService service.
+// All implementations must embed UnimplementedCrewServiceServer
+// for forward compatibility.
+//
+// CrewService runs collaborating sets of skills bound to a task purpose.
+type CrewServiceServer interface {
+	// ListCrews returns all available crews.
+	ListCrews(context.Context, *ListCrewsRequest) (*ListCrewsResponse, error)
+	// GetCrew returns a single crew definition by id.
+	GetCrew(context.Context, *GetCrewRequest) (*GetCrewResponse, error)
+	// RunCrew launches a crew against an input: validates the topology against the
+	// union of member skills' allowed_peers, provisions each skill's box, compiles
+	// per-agent network policy, threads one trace_id through every hop, and
+	// returns the run handle.
+	RunCrew(context.Context, *RunCrewRequest) (*RunCrewResponse, error)
+	// GetCrewRun returns the status and artifact of a crew run.
+	GetCrewRun(context.Context, *GetCrewRunRequest) (*GetCrewRunResponse, error)
+	mustEmbedUnimplementedCrewServiceServer()
+}
+
+// UnimplementedCrewServiceServer must be embedded to have
+// forward compatible implementations.
+//
+// NOTE: this should be embedded by value instead of pointer to avoid a nil
+// pointer dereference when methods are called.
+type UnimplementedCrewServiceServer struct{}
+
+func (UnimplementedCrewServiceServer) ListCrews(context.Context, *ListCrewsRequest) (*ListCrewsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListCrews not implemented")
+}
+func (UnimplementedCrewServiceServer) GetCrew(context.Context, *GetCrewRequest) (*GetCrewResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetCrew not implemented")
+}
+func (UnimplementedCrewServiceServer) RunCrew(context.Context, *RunCrewRequest) (*RunCrewResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RunCrew not implemented")
+}
+func (UnimplementedCrewServiceServer) GetCrewRun(context.Context, *GetCrewRunRequest) (*GetCrewRunResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetCrewRun not implemented")
+}
+func (UnimplementedCrewServiceServer) mustEmbedUnimplementedCrewServiceServer() {}
+func (UnimplementedCrewServiceServer) testEmbeddedByValue()                     {}
+
+// UnsafeCrewServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to CrewServiceServer will
+// result in compilation errors.
+type UnsafeCrewServiceServer interface {
+	mustEmbedUnimplementedCrewServiceServer()
+}
+
+func RegisterCrewServiceServer(s grpc.ServiceRegistrar, srv CrewServiceServer) {
+	// If the following call panics, it indicates UnimplementedCrewServiceServer was
+	// embedded by pointer and is nil.  This will cause panics if an
+	// unimplemented method is ever invoked, so we test this at initialization
+	// time to prevent it from happening at runtime later due to I/O.
+	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
+		t.testEmbeddedByValue()
+	}
+	s.RegisterService(&CrewService_ServiceDesc, srv)
+}
+
+func _CrewService_ListCrews_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListCrewsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CrewServiceServer).ListCrews(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CrewService_ListCrews_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CrewServiceServer).ListCrews(ctx, req.(*ListCrewsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CrewService_GetCrew_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetCrewRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CrewServiceServer).GetCrew(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CrewService_GetCrew_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CrewServiceServer).GetCrew(ctx, req.(*GetCrewRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CrewService_RunCrew_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RunCrewRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CrewServiceServer).RunCrew(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CrewService_RunCrew_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CrewServiceServer).RunCrew(ctx, req.(*RunCrewRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _CrewService_GetCrewRun_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetCrewRunRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CrewServiceServer).GetCrewRun(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: CrewService_GetCrewRun_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CrewServiceServer).GetCrewRun(ctx, req.(*GetCrewRunRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// CrewService_ServiceDesc is the grpc.ServiceDesc for CrewService service.
+// It's only intended for direct use with grpc.RegisterService,
+// and not to be introspected or modified (even as a copy)
+var CrewService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "containarium.v1.CrewService",
+	HandlerType: (*CrewServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "ListCrews",
+			Handler:    _CrewService_ListCrews_Handler,
+		},
+		{
+			MethodName: "GetCrew",
+			Handler:    _CrewService_GetCrew_Handler,
+		},
+		{
+			MethodName: "RunCrew",
+			Handler:    _CrewService_RunCrew_Handler,
+		},
+		{
+			MethodName: "GetCrewRun",
+			Handler:    _CrewService_GetCrewRun_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "containarium/v1/agent.proto",
+}

--- a/proto/containarium/v1/agent.proto
+++ b/proto/containarium/v1/agent.proto
@@ -247,3 +247,150 @@ service AgentSkillService {
     };
   }
 }
+
+// =============================================================================
+// Crews — Phase 3. A crew is a collaborating set of skills bound to a task
+// purpose. The crew mechanism lives here; concrete crew definitions ship
+// outside this repo. The daemon rejects a crew whose topology asks for an A2A
+// edge that the members' allowed_peers (and thus Phase 2 network policy) would
+// drop — the topology and the trust fabric stay consistent.
+// =============================================================================
+
+// CrewTopology describes how a crew's skills are wired together.
+enum CrewTopology {
+  CREW_TOPOLOGY_UNSPECIFIED = 0;
+  // Linear pipeline: output of skill[i] feeds skill[i+1].
+  CREW_TOPOLOGY_PIPELINE = 1;
+  // A coordinator skill fans tasks out to worker skills and synthesizes.
+  CREW_TOPOLOGY_ORCHESTRATOR = 2;
+  // Skills coordinate freely over A2A within the allowed_peers graph; the crew
+  // just bounds the set and the trace.
+  CREW_TOPOLOGY_FREEFORM = 3;
+}
+
+// Crew is a collaborating set of skills bound to a task purpose.
+message Crew {
+  // Stable crew identifier (e.g. "research-crew").
+  string id = 1;
+  // Display name.
+  string name = 2;
+  // Short description of the task purpose.
+  string description = 3;
+  // How the skills are wired.
+  CrewTopology topology = 4;
+  // Skill ids that make up this crew (in pipeline order when PIPELINE;
+  // coordinator first when ORCHESTRATOR).
+  repeated string skill_ids = 5;
+}
+
+// CrewRunState tracks the lifecycle of a single crew execution.
+enum CrewRunState {
+  CREW_RUN_STATE_UNSPECIFIED = 0;
+  CREW_RUN_STATE_PENDING = 1;
+  CREW_RUN_STATE_RUNNING = 2;
+  CREW_RUN_STATE_COMPLETED = 3;
+  CREW_RUN_STATE_FAILED = 4;
+  CREW_RUN_STATE_CANCELLED = 5;
+}
+
+// CrewRun is one execution of a crew. Every A2A hop and MCP call made by any
+// agent in the run is audit-logged under this run's trace_id, so a run is
+// itself an evidence artifact.
+message CrewRun {
+  string id = 1;
+  string crew_id = 2;
+  // Shared trace id threaded through every agent's audit entries for this run.
+  string trace_id = 3;
+  CrewRunState state = 4;
+  // JSON input handed to the crew's entry skill(s).
+  string input_json = 5;
+  // JSON artifact produced by the crew. Populated when state is COMPLETED.
+  string artifact_json = 6;
+  // Human-readable error when state is FAILED.
+  string error = 7;
+}
+
+message ListCrewsRequest {}
+message ListCrewsResponse {
+  repeated Crew crews = 1;
+}
+
+message GetCrewRequest {
+  string id = 1;
+}
+message GetCrewResponse {
+  Crew crew = 1;
+}
+
+message RunCrewRequest {
+  string crew_id = 1;
+  string backend_id = 2;
+  string pool = 3;
+  // JSON input for the crew's entry skill(s).
+  string input_json = 4;
+}
+message RunCrewResponse {
+  CrewRun run = 1;
+}
+
+message GetCrewRunRequest {
+  string id = 1;
+}
+message GetCrewRunResponse {
+  CrewRun run = 1;
+}
+
+// CrewService runs collaborating sets of skills bound to a task purpose.
+service CrewService {
+  // ListCrews returns all available crews.
+  rpc ListCrews(ListCrewsRequest) returns (ListCrewsResponse) {
+    option (google.api.http) = {
+      get: "/v1/crews"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List crews";
+      description: "Returns all crews (collaborating skill sets) available to run.";
+      tags: "Agents";
+    };
+  }
+
+  // GetCrew returns a single crew definition by id.
+  rpc GetCrew(GetCrewRequest) returns (GetCrewResponse) {
+    option (google.api.http) = {
+      get: "/v1/crews/{id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get crew";
+      description: "Returns one crew's definition, including its topology and member skills.";
+      tags: "Agents";
+    };
+  }
+
+  // RunCrew launches a crew against an input: validates the topology against the
+  // union of member skills' allowed_peers, provisions each skill's box, compiles
+  // per-agent network policy, threads one trace_id through every hop, and
+  // returns the run handle.
+  rpc RunCrew(RunCrewRequest) returns (RunCrewResponse) {
+    option (google.api.http) = {
+      post: "/v1/crews/{crew_id}/run"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Run a crew";
+      description: "Provisions each skill's box, gates A2A traffic with network policy compiled from allowed_peers, runs the collaboration, and returns the run handle.";
+      tags: "Agents";
+    };
+  }
+
+  // GetCrewRun returns the status and artifact of a crew run.
+  rpc GetCrewRun(GetCrewRunRequest) returns (GetCrewRunResponse) {
+    option (google.api.http) = {
+      get: "/v1/crew-runs/{id}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get crew run";
+      description: "Returns the state, trace id, and (when complete) the artifact of a crew execution.";
+      tags: "Agents";
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Phase 3 (crews), step 1 — re-add the `Crew` contract that was deferred back in #558. First issue of epic #586. Closes #579.

## What's here

- `CrewTopology` (pipeline / orchestrator / freeform) + `CrewRunState` enums
- `Crew`, `CrewRun` (with a shared `trace_id` — ties into the Phase 2 A2A audit)
- `CrewService`: `ListCrews` / `GetCrew` / `RunCrew` / `GetCrewRun` over `/v1/crews` + `/v1/crew-runs`

## Scope

**Contract only.** The YAML catalog + `RunCrew` orchestration (validate the topology against the **union of members' `allowed_peers`**, provision boxes, compile per-agent network policy, thread one `trace_id`) land in #580–582. The new RPCs fall back to the generated `Unimplemented` stub, so the build stays green.

## Verification

`make proto` regenerated `agent.pb*.go` + swagger; `go build ./...` green.

Follow-ups: #580 (crew YAML + loader), #581 (RunCrew), #582 (artifact store), #583 (CLI), #584 (MCP), #585 (reference crew + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)