### PR TITLE
feat(agents): daemon runs in-box loop + reads artifact back (#608)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help proto build clean clean-ui clean-all install test lint fmt run-local web-ui swagger-ui build-mcp build-mcp-linux install-mcp build-agent-box build-agent-box-linux build-agent-box-all install-agent-box build-release sidecar-build-otel bundle-download-deps build-bundle build-bundle-all
+.PHONY: help proto build clean clean-ui clean-all install test lint fmt run-local web-ui swagger-ui build-mcp build-mcp-linux install-mcp build-agent-box build-agent-box-linux build-agent-box-all install-agent-box build-agent-runtime build-release sidecar-build-otel bundle-download-deps build-bundle build-bundle-all
 
 # Variables
 BINARY_NAME=containarium
@@ -118,6 +118,11 @@ build-agent-box: ## Build the in-the-box agent-box MCP binary
 	@mkdir -p $(BUILD_DIR)
 	@go build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(AGENTBOX_BINARY_NAME) cmd/agent-box/main.go
 	@echo "==> agent-box built: $(BUILD_DIR)/$(AGENTBOX_BINARY_NAME)"
+
+build-agent-runtime: ## Build the in-box agent-runtime loop (Node/TS sibling package; its own lane, not a Go binary)
+	@echo "==> Building agent-runtime (npm ci + tsc)..."
+	@cd agent-runtime && npm ci && npm run build
+	@echo "==> agent-runtime built: agent-runtime/dist/"
 
 build-agent-box-linux: ## Build agent-box for Linux (the typical install target — agent-box runs INSIDE LXC containers)
 	@echo "==> Building agent-box for Linux..."

--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -172,8 +172,61 @@ func (s *AgentSkillServer) RunAgentSkill(ctx context.Context, req *pb.RunAgentSk
 	//    the env-gated eBPF enforcer AND flipping to ENFORCE — see #574.
 	s.applyAllowedPeersPolicy(ctx, name, skill)
 
-	// artifact_json intentionally empty in Phase 0 (in-box loop seam).
-	return &pb.RunAgentSkillResponse{Container: dep.Container, ArtifactJson: ""}, nil
+	// 5. Run the in-box agent loop (Phase 4a) and read its artifact back.
+	//    Best-effort: until the box image ships agent-runtime + agent-box this
+	//    degrades to an empty artifact (prior behavior), so a base-image box
+	//    never fails the run.
+	artifact := s.runInBoxAgent(containerName)
+	return &pb.RunAgentSkillResponse{Container: dep.Container, ArtifactJson: artifact}, nil
+}
+
+// runInBoxAgent executes the in-box agent-runtime over the seeded task and
+// reads its artifact back. The agent-runtime + agent-box live in the
+// agent-runtime box image (Phase 4a image assembly); the model/engine/provider
+// key come from the box env (secrets-injected). Best-effort: any failure
+// (runtime absent, exec error, bad artifact) logs and returns "" rather than
+// failing RunAgentSkill — the box is still provisioned + gated + traced.
+func (s *AgentSkillServer) runInBoxAgent(containerName string) string {
+	if s.recipes == nil || s.recipes.containers == nil || s.recipes.containers.manager == nil {
+		return ""
+	}
+	mgr := s.recipes.containers.manager
+
+	if _, stderr, err := mgr.ExecWithOutput(containerName,
+		[]string{"bash", "-lc", "AGENT_SEED_DIR=" + agentSeedDir + " agent-runtime"}); err != nil {
+		log.Printf("[agent-skill] in-box runtime did not run on %s (image may not ship it yet): %v; stderr=%s",
+			containerName, err, strings.TrimSpace(stderr))
+		return ""
+	}
+
+	raw, err := mgr.ReadFile(containerName, agentSeedDir+"/artifact.json")
+	if err != nil {
+		log.Printf("[agent-skill] could not read artifact from %s: %v", containerName, err)
+		return ""
+	}
+	out, err := parseArtifactOutput(raw)
+	if err != nil {
+		log.Printf("[agent-skill] in-box agent on %s reported an error: %v", containerName, err)
+		return ""
+	}
+	return out
+}
+
+// parseArtifactOutput extracts the agent's output JSON from artifact.json
+// (written by agent-runtime). A non-empty `error` field is surfaced as an
+// error so RunAgentSkill can log it and fall back to an empty artifact.
+func parseArtifactOutput(raw []byte) (string, error) {
+	var a struct {
+		OutputJSON string `json:"outputJson"`
+		Error      string `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return "", fmt.Errorf("decode artifact.json: %w", err)
+	}
+	if a.Error != "" {
+		return "", fmt.Errorf("%s", a.Error)
+	}
+	return a.OutputJSON, nil
 }
 
 // applyAllowedPeersPolicy compiles a skill's allowed_peers into a per-box

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -75,6 +75,29 @@ func TestSendAgentTaskRequiresCallScope(t *testing.T) {
 	}
 }
 
+func TestParseArtifactOutput(t *testing.T) {
+	t.Run("output", func(t *testing.T) {
+		out, err := parseArtifactOutput([]byte(`{"outputJson":"{\"ok\":true}","engine":"claude","model":"claude-opus-4-8"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != `{"ok":true}` {
+			t.Errorf("output = %q", out)
+		}
+	})
+	t.Run("error field surfaces", func(t *testing.T) {
+		_, err := parseArtifactOutput([]byte(`{"outputJson":"","error":"model egress blocked"}`))
+		if err == nil || !strings.Contains(err.Error(), "egress") {
+			t.Errorf("expected the artifact error to surface, got %v", err)
+		}
+	})
+	t.Run("malformed", func(t *testing.T) {
+		if _, err := parseArtifactOutput([]byte("not json")); err == nil {
+			t.Error("expected decode error for malformed artifact")
+		}
+	})
+}
+
 func TestGenTraceID(t *testing.T) {
 	a, b := genTraceID(), genTraceID()
 	if len(a) != 32 { // 16 bytes hex

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -66,14 +66,21 @@ recipes:
       - 'podman run -d --name llamacpp --restart=always --device nvidia.com/gpu=all -p 8080:8080 -v llamacpp-models:/models ghcr.io/ggml-org/llama.cpp:server-cuda -hf "$CONTAINARIUM_PARAM_HF_REPO" --host 0.0.0.0 --port 8080'
 
   # agent-runtime is the box an AgentSkill runs in (AgentSkillService). It is a
-  # plain Ubuntu LXC with the agent-box MCP available; the skill's system
-  # prompt, scoped token, and task input are seeded under /etc/containarium/agent
-  # by RunAgentSkill, and the in-box agent loop (the agent-runtime image's job)
-  # consumes them. No GPU and no exposed ports by default — a skill that needs
-  # either declares its own box. post_start just ensures the seed directory.
+  # plain Ubuntu LXC; the skill's system prompt, scoped token, and task input
+  # are seeded under /etc/containarium/agent by RunAgentSkill, and the in-box
+  # agent loop (agent-runtime/, the Node sibling package) consumes them and
+  # writes artifact.json back. No GPU and no exposed ports by default — a skill
+  # that needs either declares its own box.
+  #
+  # post_start installs the Node runtime the loop needs and ensures the seed
+  # dir. The agent-runtime loop component + the agent-box binary themselves are
+  # installed as part of image assembly (design-note open question #5): publish
+  # them as a release artifact and add the install step here, or bake a
+  # prebuilt agent-runtime image. The daemon execs `agent-runtime` (PATH) over
+  # the seed and reads artifact.json (best-effort until that lands).
   - id: agent-runtime
     name: Agent Runtime
-    description: Base box for running an AgentSkill — Ubuntu LXC with the agent-box MCP; the in-box agent loop reads its prompt/token/input from /etc/containarium/agent.
+    description: Base box for running an AgentSkill — Ubuntu LXC with Node + the in-box agent loop; reads its prompt/token/input from /etc/containarium/agent and writes artifact.json.
     image: images:ubuntu/24.04
     requires_gpu: false
     resources:
@@ -82,3 +89,5 @@ recipes:
       disk: 20GB
     post_start:
       - mkdir -p /etc/containarium/agent
+      - 'curl -fsSL https://deb.nodesource.com/setup_20.x | bash -'
+      - DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs


### PR DESCRIPTION
## Summary

Phase 4a, the **daemon + assembly** side (the `agent-runtime` Node component landed in #613). Builds on it to close the empty-artifact seam at the daemon contract. Continues #608.

## What's here

- **`RunAgentSkill` runs the loop + reads the artifact back.** After seeding + policy, it execs the in-box `agent-runtime` over the seed (`ExecWithOutput`) and reads `/etc/containarium/agent/artifact.json` (`ReadFile`), parsing it into `RunAgentSkillResponse.artifact_json`. **Best-effort:** if the box image doesn't ship the runtime yet (or it errors), it logs and returns an empty artifact — a base-image box never fails the run. `parseArtifactOutput` surfaces a non-empty `error` field as an error.
- **`make build-agent-runtime`** — the Node sibling package's own build lane (`npm ci` + `tsc`), kept separate from the Go release, per the "sibling package with its own lane" decision.
- **`agent-runtime` recipe** — `post_start` installs Node 20 + ensures the seed dir (box-image assembly). The loop component + `agent-box` binary install is the remaining assembly step (design-note open Q#5), documented inline.

## Verification

`go build ./...`, recipes loader test (validates the updated recipe), and `internal/server` tests green — including `parseArtifactOutput` (output / error-field / malformed).

## Remaining for 4a end-to-end

Ship `agent-runtime` + `agent-box` into the box image (release artifact or prebuilt image), then a live run with a provider key on a backend — the standing "needs a live box" seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)