### PR TITLE
feat(agents): in-box A2A server / serve mode (#609)

### DIFF
--- a/agent-runtime/README.md
+++ b/agent-runtime/README.md
@@ -27,6 +27,20 @@ takes the MCP config inline (`mcpServers`); the Codex engine writes a
 Select with `CONTAINARIUM_AGENT_ENGINE=claude|codex` (a later phase moves this
 onto the skill manifest as an `engine` field).
 
+## Two modes
+
+`CONTAINARIUM_AGENT_MODE` selects how the loop runs:
+
+- `run` (default) — one-shot: read `input.json`, run once, write `artifact.json`.
+  This is the `agent run` path (Phase 4a).
+- `serve` — start the in-box **A2A server** on `:8674` and stay up:
+  - `GET /agent-card` → the seeded agent card (peer discovery)
+  - `POST /tasks` → run one delegated task (`AgentTask` in → `AgentArtifact`
+    out), the listener the daemon's `SendAgentTask` reaches (Phase 4b).
+
+  A failed task returns `200` with `state: AGENT_TASK_STATE_FAILED` so the caller
+  still gets the artifact rather than an HTTP error.
+
 ## What it reads (the seed)
 
 `RunAgentSkill` seeds `/etc/containarium/agent/` at launch
@@ -71,13 +85,17 @@ Verified: `tsc --noEmit` passes against the installed types of both SDKs
 ## Status / remaining 4a work
 
 - ✅ The component: engine interface + Claude + Codex engines + seed/artifact +
-  runner. Typechecks against real SDK types.
+  one-shot runner (4a) + the A2A server / serve mode (4b). Typechecks against
+  real SDK types.
+- ✅ **Daemon invoke + read-back** (4a) — `RunAgentSkill` execs the runtime and
+  reads `artifact.json` into `RunAgentSkillResponse.artifact_json` (#614).
 - ⏳ **Box image assembly** — the `agent-runtime` recipe must ship Node + this
   component + `agent-box` into the box (design-note open question #5).
-- ⏳ **Daemon invoke + read-back** — `RunAgentSkill` execs the runtime over the
-  seed and reads `artifact.json` into `RunAgentSkillResponse.artifact_json`.
+- ⏳ **Serve-mode lifecycle** — a peer/crew-member box must run
+  `CONTAINARIUM_AGENT_MODE=serve` as a long-running process so `:8674` is up;
+  wired in 4c (crew choreography) alongside the daemon starting members.
 - ⏳ **Live validation** — needs the assembled image + a provider API key + a
   backend (the standing "needs a live box" seam). Not runnable in CI alone.
 
-Phase 4b adds the in-box A2A server (`:8674` `/agent-card` + `/tasks`) on top of
-this loop; 4c wires crew choreography.
+4c wires crew choreography (`RunCrew` starts members in serve mode, drives the
+hops, reports `COMPLETED`).

--- a/agent-runtime/src/a2a.ts
+++ b/agent-runtime/src/a2a.ts
@@ -1,0 +1,81 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { Engine, EngineConfig } from "./engine.js";
+import type { Seed } from "./seed.js";
+
+// A2A_PORT is the port the daemon resolves for a peer's in-box A2A server
+// (resolvePeerA2A in internal/server/agent_server.go uses :8674).
+export const A2A_PORT = 8674;
+
+// Wire shapes match the proto (containarium/v1/agent.proto) as serialized by
+// protojson, which the daemon's sendA2ATask uses: lowerCamelCase fields, enum
+// values as their proto name strings.
+interface AgentTaskWire {
+  id?: string;
+  inputJson?: string;
+  input_json?: string; // protojson accepts snake_case on input too
+}
+interface AgentArtifactWire {
+  taskId: string;
+  outputJson: string;
+  state: "AGENT_TASK_STATE_COMPLETED" | "AGENT_TASK_STATE_FAILED";
+  error: string;
+}
+
+// runTask runs one delegated A2A task through the engine and shapes the
+// artifact. Pure (engine + cfg injected) — the HTTP layer just adapts to it.
+export async function runTask(task: AgentTaskWire, engine: Engine, cfg: EngineConfig): Promise<AgentArtifactWire> {
+  const taskId = task.id ?? "";
+  const input = task.inputJson ?? task.input_json ?? "{}";
+  try {
+    const result = await engine.run(input, cfg);
+    return { taskId, outputJson: result.outputJson, state: "AGENT_TASK_STATE_COMPLETED", error: "" };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { taskId, outputJson: "", state: "AGENT_TASK_STATE_FAILED", error: msg };
+  }
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.on("data", (c) => {
+      body += c;
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+}
+
+// startA2AServer serves the Phase-1 A2A surface from inside the box:
+//   GET  /agent-card  -> the seeded agent card (discovery)
+//   POST /tasks       -> run one task, return the artifact
+// A failed task still returns 200 with state FAILED so the caller (the daemon's
+// SendAgentTask) receives the artifact rather than an HTTP error.
+export function startA2AServer(seed: Seed, engine: Engine, cfg: EngineConfig, port: number = A2A_PORT): void {
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    if (req.method === "GET" && req.url === "/agent-card") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(seed.agentCard ?? {}));
+      return;
+    }
+    if (req.method === "POST" && req.url === "/tasks") {
+      void (async () => {
+        try {
+          const body = await readBody(req);
+          const task = JSON.parse(body || "{}") as AgentTaskWire;
+          const artifact = await runTask(task, engine, cfg);
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify(artifact));
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          res.writeHead(400, { "content-type": "application/json" });
+          res.end(JSON.stringify({ taskId: "", outputJson: "", state: "AGENT_TASK_STATE_FAILED", error: msg }));
+        }
+      })();
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  server.listen(port, () => process.stdout.write(`agent-runtime: A2A server listening on :${port}\n`));
+}

--- a/agent-runtime/src/index.ts
+++ b/agent-runtime/src/index.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { startA2AServer } from "./a2a.js";
 import { writeArtifact } from "./artifact.js";
 import type { Engine, EngineConfig } from "./engine.js";
 import { ClaudeEngine } from "./engines/claude.js";
@@ -50,6 +51,11 @@ function writeCodexConfig(cfg: EngineConfig): void {
   writeFileSync(join(dir, "config.toml"), toml);
 }
 
+// mode: "run" (one-shot — read input.json, run once, write artifact.json; the
+// 4a path `agent run` uses) or "serve" (start the A2A server so peers/crews can
+// delegate tasks; the 4b path SendAgentTask reaches). Default "run".
+const mode = (process.env.CONTAINARIUM_AGENT_MODE ?? "run").toLowerCase();
+
 async function main(): Promise<void> {
   const seed = loadSeed(seedDir);
   const engine = pickEngine(engineName);
@@ -62,6 +68,12 @@ async function main(): Promise<void> {
   };
 
   if (engine.name === "codex") writeCodexConfig(cfg);
+
+  if (mode === "serve") {
+    // Long-running: serve /agent-card + /tasks until the box stops.
+    startA2AServer(seed, engine, cfg);
+    return;
+  }
 
   try {
     const res = await engine.run(seed.inputJson, cfg);


### PR DESCRIPTION
## Summary

Phase 4b — the **in-box A2A server**, added to the `agent-runtime` component. Closes #609.

This is the listener the daemon's `SendAgentTask` / `resolvePeerA2A` (`:8674`) have been POSTing to since Phase 1 — so no daemon change is needed; the box just needs to run it.

## What's here

- **`src/a2a.ts`** — `startA2AServer` serves:
  - `GET /agent-card` → the seeded agent card (peer discovery)
  - `POST /tasks` → run one delegated task (`AgentTask` in → `AgentArtifact` out)

  Wire shapes match the proto as protojson serializes it (lowerCamel fields, enum-name strings). A failed task returns **200** with `state: AGENT_TASK_STATE_FAILED` so the caller still receives the artifact rather than an HTTP error. `runTask` is a pure, engine-injected helper.
- **`src/index.ts`** — `CONTAINARIUM_AGENT_MODE` selects `run` (one-shot, the 4a default) vs `serve` (start the A2A server and stay up). Engine/config building is shared across both modes.

## Verification

`tsc --noEmit` passes against the installed SDK types.

## Remaining (4c + assembly)

A peer/crew-member box must run `CONTAINARIUM_AGENT_MODE=serve` as a long-running process so `:8674` is up — that lifecycle (the daemon starting members in serve mode + driving the hops + reporting `COMPLETED`) is **4c**, and depends on the same box-image assembly as 4a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)