### PR TITLE
feat(agents): crew choreography → COMPLETED (#610)

### DIFF
--- a/docs/AGENT-SKILLS-QUICKSTART.md
+++ b/docs/AGENT-SKILLS-QUICKSTART.md
@@ -184,11 +184,17 @@ containarium crew status <run-id> --server <host>
 Driving a crew needs `crews:run` (plus `agents:run` + `containers:write`, since
 it provisions boxes).
 
-> **Phase 3 seam.** The actual inter-agent choreography and artifact
-> aggregation are the in-box agent loop's job (the `agent-runtime` image, not
-> yet wired), so a run lands in `RUNNING` once the boxes are up + network-gated,
-> not `COMPLETED`. Topology validation, provisioning, network gating, and the
-> shared trace are all wired and tested.
+As of Phase 4c, `RunCrew` provisions each member in **serve mode**, drives the
+topology hops over A2A under the shared `trace_id` (pipeline chains outputs;
+orchestrator/freeform deliver to the entry skill), and moves the `CrewRun`
+`RUNNING → COMPLETED` (or `FAILED` with the hop error). `crew status <run-id>`
+shows the terminal state + artifact.
+
+> **Seam.** This runs end-to-end only once the box image ships the in-box loop
+> (`agent-runtime`) + `agent-box` so members actually serve `/tasks` — until
+> then a run lands `FAILED` (no listener). Topology validation, provisioning,
+> network gating, serve-mode start, hop sequencing, and the shared trace are all
+> wired and tested.
 
 ## From an AI agent (MCP)
 

--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -118,42 +118,60 @@ func (s *AgentSkillServer) RunAgentSkill(ctx context.Context, req *pb.RunAgentSk
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
 
+	containerName, container, err := s.provisionSkillBox(ctx, skill, req.BackendId, req.Pool, req.InputJson)
+	if err != nil {
+		return nil, err
+	}
+
+	// Run the in-box agent loop (Phase 4a) and read its artifact back.
+	// Best-effort: until the box image ships agent-runtime + agent-box this
+	// degrades to an empty artifact (prior behavior), so a base-image box never
+	// fails the run.
+	artifact := s.runInBoxAgent(containerName)
+	return &pb.RunAgentSkillResponse{Container: container, ArtifactJson: artifact}, nil
+}
+
+// provisionSkillBox provisions a skill's box and gets it ready to run: resolve
+// the box recipe, deploy it, mint a JWT scoped to exactly the skill's
+// allowed_scopes, seed the prompt/token/input/card, and compile allowed_peers
+// into the per-box egress policy. It does NOT run the loop — RunAgentSkill runs
+// it one-shot, RunCrew starts it in serve mode. Returns the container name +
+// the provisioned Container.
+func (s *AgentSkillServer) provisionSkillBox(ctx context.Context, skill *pb.AgentSkill, backendID, pool, inputJSON string) (string, *pb.Container, error) {
 	// Phase 0 supports only the recipe_id box form (catalog skills). Inline
 	// recipes are an API-only construct deferred to a later phase.
 	recipeID := skill.GetRecipeId()
 	if recipeID == "" {
-		return nil, status.Error(codes.Unimplemented,
+		return "", nil, status.Error(codes.Unimplemented,
 			"inline-recipe skills are not supported yet; use a skill that references a recipe_id")
 	}
 
-	// Deterministic box identity for the run (see limitations above).
+	// Deterministic box identity (concurrent same-skill runs collide — a later
+	// per-run-box / warm-pool concern, see docs/EPHEMERAL-SANDBOX-DESIGN.md).
 	name := "agent-" + skill.Id
 	if err := auth.AuthorizeTenant(ctx, name); err != nil {
-		return nil, err
+		return "", nil, err
 	}
 
-	// 1. Provision the box by reusing the recipe deploy path.
+	// Provision the box by reusing the recipe deploy path.
 	dep, err := s.recipes.deploy(ctx, &pb.DeployRecipeRequest{
 		RecipeId:  recipeID,
 		Name:      name,
-		BackendId: req.BackendId,
-		Pool:      req.Pool,
+		BackendId: backendID,
+		Pool:      pool,
 	})
 	if err != nil {
-		return nil, err // already a gRPC status from deploy/CreateContainer
+		return "", nil, err // already a gRPC status from deploy/CreateContainer
 	}
 
-	// 2. Mint a JWT scoped to EXACTLY the skill's allowed_scopes. The catalog
-	//    guarantees len(allowed_scopes) >= 1, so this is a bounded token, not
-	//    the "no restriction" nil-claim case.
+	// Mint a JWT scoped to EXACTLY the skill's allowed_scopes (catalog
+	// guarantees >= 1, so this is bounded, not the nil-claim "no restriction").
 	token, err := s.tokens.GenerateToken(name, []string{}, agentTokenTTL, skill.AllowedScopes...)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to mint scoped agent token: %v", err)
+		return "", nil, status.Errorf(codes.Internal, "failed to mint scoped agent token: %v", err)
 	}
 
-	// 3. Seed the prompt/token/input/card into the box. The agent card is
-	//    seeded so the box's A2A server (Phase 1, agent-runtime image's job)
-	//    can serve it for peer discovery.
+	// Seed the prompt/token/input/card into the box.
 	cardJSON := ""
 	if skill.AgentCard != nil {
 		if b, err := protojson.Marshal(skill.AgentCard); err == nil {
@@ -162,22 +180,31 @@ func (s *AgentSkillServer) RunAgentSkill(ctx context.Context, req *pb.RunAgentSk
 	}
 	containerName := name + "-container"
 	if err := s.recipes.containers.manager.Exec(containerName,
-		[]string{"bash", "-c", buildAgentSeedScript(skill.SystemPrompt, token, req.InputJson, cardJSON)}); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to seed agent box %s: %v", containerName, err)
+		[]string{"bash", "-c", buildAgentSeedScript(skill.SystemPrompt, token, inputJSON, cardJSON)}); err != nil {
+		return "", nil, status.Errorf(codes.Internal, "failed to seed agent box %s: %v", containerName, err)
 	}
 
-	// 4. Compile the skill's allowed_peers into a per-box egress network policy
-	//    (Phase 2). Best-effort + LOG_ONLY: a failure here must not fail the
-	//    run, and observe-only never drops traffic. Enforcement (drop) requires
-	//    the env-gated eBPF enforcer AND flipping to ENFORCE — see #574.
+	// Compile allowed_peers into the per-box egress policy (Phase 2).
 	s.applyAllowedPeersPolicy(ctx, name, skill)
 
-	// 5. Run the in-box agent loop (Phase 4a) and read its artifact back.
-	//    Best-effort: until the box image ships agent-runtime + agent-box this
-	//    degrades to an empty artifact (prior behavior), so a base-image box
-	//    never fails the run.
-	artifact := s.runInBoxAgent(containerName)
-	return &pb.RunAgentSkillResponse{Container: dep.Container, ArtifactJson: artifact}, nil
+	return containerName, dep.Container, nil
+}
+
+// startServeMode launches the in-box agent-runtime in serve mode (the A2A
+// server on :8674) as a background process, so peers/crews can delegate tasks
+// to this box. Best-effort: until the box image ships agent-runtime this is a
+// no-op failure (logged), like runInBoxAgent. Used by RunCrew for members.
+func (s *AgentSkillServer) startServeMode(containerName string) {
+	if s.recipes == nil || s.recipes.containers == nil || s.recipes.containers.manager == nil {
+		return
+	}
+	cmd := "CONTAINARIUM_AGENT_MODE=serve AGENT_SEED_DIR=" + agentSeedDir +
+		" setsid agent-runtime >/var/log/agent-runtime.log 2>&1 &"
+	if _, stderr, err := s.recipes.containers.manager.ExecWithOutput(containerName,
+		[]string{"bash", "-lc", cmd}); err != nil {
+		log.Printf("[agent-skill] could not start serve mode on %s (image may not ship runtime): %v; stderr=%s",
+			containerName, err, strings.TrimSpace(stderr))
+	}
 }
 
 // runInBoxAgent executes the in-box agent-runtime over the seeded task and

--- a/internal/server/crew_server.go
+++ b/internal/server/crew_server.go
@@ -94,25 +94,89 @@ func (s *CrewServer) RunCrew(ctx context.Context, req *pb.RunCrewRequest) (*pb.R
 		InputJson: req.InputJson,
 	}
 
-	// Provision each member box (reuses RunAgentSkill: scoped token + per-box
-	// allowed_peers network policy). The in-box loop drives the actual
-	// collaboration; the run stays RUNNING until that lands (Phase 3 seam).
+	// Provision each member box (scoped token + per-box allowed_peers policy)
+	// and start it in serve mode so it serves /tasks for the hops below. Members
+	// are seeded with no task input — the crew delivers per-hop input over A2A.
 	for _, sid := range crew.SkillIds {
-		_, err := s.agents.RunAgentSkill(ctx, &pb.RunAgentSkillRequest{
-			SkillId:   sid,
-			BackendId: req.BackendId,
-			Pool:      req.Pool,
-		})
+		skill, _ := s.skillByID(sid) // existence already checked by validateCrewTopology
+		containerName, _, err := s.agents.provisionSkillBox(ctx, skill, req.BackendId, req.Pool, "")
 		if err != nil {
 			run.State = pb.CrewRunState_CREW_RUN_STATE_FAILED
 			run.Error = fmt.Sprintf("provision skill %q: %v", sid, err)
 			s.runs.put(run)
 			return nil, status.Errorf(codes.Internal, "crew %q: %s", crew.Id, run.Error)
 		}
+		s.agents.startServeMode(containerName)
+	}
+
+	// Drive the topology hops over A2A under the shared trace_id, and record the
+	// terminal state. driveCrew failures (e.g. a member's A2A server not up yet)
+	// land the run in FAILED rather than erroring the RPC — the caller gets the
+	// run handle to inspect via GetCrewRun.
+	out, err := driveCrew(ctx, crew, trace, req.InputJson, s.agents.SendAgentTask)
+	if err != nil {
+		run.State = pb.CrewRunState_CREW_RUN_STATE_FAILED
+		run.Error = err.Error()
+	} else {
+		run.State = pb.CrewRunState_CREW_RUN_STATE_COMPLETED
+		run.ArtifactJson = out
 	}
 
 	s.runs.put(run)
 	return &pb.RunCrewResponse{Run: run}, nil
+}
+
+// taskSender delivers one A2A task — AgentSkillServer.SendAgentTask in
+// production, a fake in tests. Lets driveCrew be unit-tested without boxes.
+type taskSender func(ctx context.Context, req *pb.SendAgentTaskRequest) (*pb.SendAgentTaskResponse, error)
+
+// driveCrew runs the crew's topology to a final artifact, threading the run's
+// trace_id through every hop:
+//   - PIPELINE: deliver the crew input to skill[0], chain each output into the
+//     next skill (from = the previous skill, so allowed_peers gates the hop).
+//   - ORCHESTRATOR / FREEFORM: deliver the input to the entry skill and return
+//     its artifact — the agent self-delegates to the rest within its
+//     allowed_peers.
+func driveCrew(ctx context.Context, crew *pb.Crew, trace, input string, send taskSender) (string, error) {
+	ids := crew.SkillIds
+	if len(ids) == 0 {
+		return "", fmt.Errorf("crew %q has no skills", crew.Id)
+	}
+
+	deliver := func(from, to, in string) (string, error) {
+		resp, err := send(ctx, &pb.SendAgentTaskRequest{
+			FromSkillId: from,
+			ToPeerId:    to,
+			InputJson:   in,
+			TraceId:     trace,
+		})
+		if err != nil {
+			return "", fmt.Errorf("hop %q->%q: %w", from, to, err)
+		}
+		if resp.Artifact == nil {
+			return "", fmt.Errorf("hop %q->%q returned no artifact", from, to)
+		}
+		if resp.Artifact.State == pb.AgentTaskState_AGENT_TASK_STATE_FAILED {
+			return "", fmt.Errorf("hop %q->%q failed: %s", from, to, resp.Artifact.Error)
+		}
+		return resp.Artifact.OutputJson, nil
+	}
+
+	if crew.Topology == pb.CrewTopology_CREW_TOPOLOGY_PIPELINE {
+		cur := input
+		from := "" // first hop originates from the crew/operator, not a skill
+		for _, sid := range ids {
+			out, err := deliver(from, sid, cur)
+			if err != nil {
+				return "", err
+			}
+			cur, from = out, sid
+		}
+		return cur, nil
+	}
+
+	// ORCHESTRATOR / FREEFORM: the entry skill owns the rest.
+	return deliver("", ids[0], input)
 }
 
 // GetCrewRun returns the status and artifact of a crew run.

--- a/internal/server/crew_server_test.go
+++ b/internal/server/crew_server_test.go
@@ -1,10 +1,95 @@
 package server
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
+
+func completed(out string) *pb.SendAgentTaskResponse {
+	return &pb.SendAgentTaskResponse{Artifact: &pb.AgentArtifact{
+		OutputJson: out, State: pb.AgentTaskState_AGENT_TASK_STATE_COMPLETED,
+	}}
+}
+
+func TestDriveCrew(t *testing.T) {
+	const trace = "trace-xyz"
+
+	t.Run("pipeline chains outputs, threads from + trace", func(t *testing.T) {
+		var calls []*pb.SendAgentTaskRequest
+		send := func(_ context.Context, req *pb.SendAgentTaskRequest) (*pb.SendAgentTaskResponse, error) {
+			calls = append(calls, req)
+			return completed("out-of-" + req.ToPeerId), nil
+		}
+		crew := &pb.Crew{Id: "c", Topology: pb.CrewTopology_CREW_TOPOLOGY_PIPELINE, SkillIds: []string{"relay", "hello"}}
+
+		out, err := driveCrew(context.Background(), crew, trace, "seed-input", send)
+		if err != nil {
+			t.Fatalf("driveCrew: %v", err)
+		}
+		if out != "out-of-hello" {
+			t.Errorf("final output = %q, want out-of-hello", out)
+		}
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 hops, got %d", len(calls))
+		}
+		if calls[0].FromSkillId != "" || calls[0].ToPeerId != "relay" || calls[0].InputJson != "seed-input" {
+			t.Errorf("hop1 = %+v", calls[0])
+		}
+		if calls[1].FromSkillId != "relay" || calls[1].ToPeerId != "hello" || calls[1].InputJson != "out-of-relay" {
+			t.Errorf("hop2 = %+v (want from=relay to=hello input=out-of-relay)", calls[1])
+		}
+		for i, c := range calls {
+			if c.TraceId != trace {
+				t.Errorf("hop %d trace = %q, want %q", i, c.TraceId, trace)
+			}
+		}
+	})
+
+	t.Run("failed hop surfaces the peer error", func(t *testing.T) {
+		send := func(_ context.Context, _ *pb.SendAgentTaskRequest) (*pb.SendAgentTaskResponse, error) {
+			return &pb.SendAgentTaskResponse{Artifact: &pb.AgentArtifact{
+				State: pb.AgentTaskState_AGENT_TASK_STATE_FAILED, Error: "boom",
+			}}, nil
+		}
+		crew := &pb.Crew{Id: "c", Topology: pb.CrewTopology_CREW_TOPOLOGY_PIPELINE, SkillIds: []string{"a", "b"}}
+		if _, err := driveCrew(context.Background(), crew, trace, "x", send); err == nil || !strings.Contains(err.Error(), "boom") {
+			t.Errorf("expected the peer failure to surface, got %v", err)
+		}
+	})
+
+	t.Run("transport error propagates", func(t *testing.T) {
+		send := func(_ context.Context, _ *pb.SendAgentTaskRequest) (*pb.SendAgentTaskResponse, error) {
+			return nil, errors.New("unavailable")
+		}
+		crew := &pb.Crew{Id: "c", Topology: pb.CrewTopology_CREW_TOPOLOGY_PIPELINE, SkillIds: []string{"a", "b"}}
+		if _, err := driveCrew(context.Background(), crew, trace, "x", send); err == nil {
+			t.Error("expected transport error to propagate")
+		}
+	})
+
+	t.Run("orchestrator delivers to the entry skill only", func(t *testing.T) {
+		var calls []*pb.SendAgentTaskRequest
+		send := func(_ context.Context, req *pb.SendAgentTaskRequest) (*pb.SendAgentTaskResponse, error) {
+			calls = append(calls, req)
+			return completed("coordinated"), nil
+		}
+		crew := &pb.Crew{Id: "c", Topology: pb.CrewTopology_CREW_TOPOLOGY_ORCHESTRATOR, SkillIds: []string{"coord", "w1", "w2"}}
+		out, err := driveCrew(context.Background(), crew, trace, "x", send)
+		if err != nil {
+			t.Fatalf("driveCrew: %v", err)
+		}
+		if out != "coordinated" {
+			t.Errorf("output = %q", out)
+		}
+		if len(calls) != 1 || calls[0].ToPeerId != "coord" {
+			t.Errorf("expected one delivery to coord, got %d calls (%+v)", len(calls), calls)
+		}
+	})
+}
 
 // skillSet builds a lookup over a fixed set of skills for topology tests.
 func skillSet(skills ...*pb.AgentSkill) func(string) (*pb.AgentSkill, bool) {


### PR DESCRIPTION
## Summary

Phase 4c — `RunCrew` now drives the topology to a **terminal state**, threading the run's `trace_id` through every hop. Closes #610.

## What's here

- **Refactor**: extract `provisionSkillBox` from `RunAgentSkill` (resolve recipe → deploy → mint scoped token → seed → apply `allowed_peers` policy; *no* in-box run). `RunAgentSkill` = `provisionSkillBox` + `runInBoxAgent` (behavior unchanged). New `startServeMode` background-execs `CONTAINARIUM_AGENT_MODE=serve agent-runtime` (best-effort).
- **`RunCrew`**: provisions each member via `provisionSkillBox` + `startServeMode` (members seeded with no input — the crew delivers per-hop input over A2A), then `driveCrew` runs the hops and records the terminal state. A `driveCrew` failure lands the run **`FAILED`** (inspect via `GetCrewRun`) rather than erroring the RPC.
- **`driveCrew`** (pure, `taskSender` injected, unit-tested):
  - **PIPELINE** chains each output into the next skill — `from` = the previous skill, so `allowed_peers` gates each hop (consistent with the topology validation).
  - **ORCHESTRATOR / FREEFORM** deliver to the entry skill, which self-delegates within its `allowed_peers`.
- Quickstart updated: `RUNNING → COMPLETED`.

## Verification

`go build ./...` + `internal/server` tests green — including `driveCrew` (pipeline chaining + `from`/`trace` threading, failed hop, transport error, orchestrator single-delivery).

## Notes / remaining

- `crews:run` caller also needs `agents:run` + `agents:call` + `containers:write` (the internal `RunAgentSkill`/`SendAgentTask` paths re-gate on the same ctx).
- End-to-end needs the box image to ship the in-box loop so members actually serve `/tasks` (the standing assembly + live seam). Until then a crew run lands `FAILED` (no listener) — by design, gracefully.

This completes the pure-code slices of Phase 4 (4a #613/#614, 4b #615, 4c here). What's left for a live demo is box-image assembly (#5) + `api.anthropic.com` egress (#611) + a backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)