### PR TITLE
feat(agents): box-image assembly for agent-runtime (#612)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help proto build clean clean-ui clean-all install test lint fmt run-local web-ui swagger-ui build-mcp build-mcp-linux install-mcp build-agent-box build-agent-box-linux build-agent-box-all install-agent-box build-agent-runtime build-release sidecar-build-otel bundle-download-deps build-bundle build-bundle-all
+.PHONY: help proto build clean clean-ui clean-all install test lint fmt run-local web-ui swagger-ui build-mcp build-mcp-linux install-mcp build-agent-box build-agent-box-linux build-agent-box-all install-agent-box build-agent-runtime bundle-agent-runtime build-release sidecar-build-otel bundle-download-deps build-bundle build-bundle-all
 
 # Variables
 BINARY_NAME=containarium
@@ -123,6 +123,12 @@ build-agent-runtime: ## Build the in-box agent-runtime loop (Node/TS sibling pac
 	@echo "==> Building agent-runtime (npm ci + tsc)..."
 	@cd agent-runtime && npm ci && npm run build
 	@echo "==> agent-runtime built: agent-runtime/dist/"
+
+bundle-agent-runtime: build-agent-runtime ## Package agent-runtime as a release tarball (dist + manifests; `npm ci --omit=dev` runs in-box)
+	@echo "==> Packaging agent-runtime bundle..."
+	@mkdir -p $(BUILD_DIR)
+	@tar -czf $(BUILD_DIR)/agent-runtime-bundle.tar.gz -C agent-runtime dist package.json package-lock.json
+	@echo "==> agent-runtime bundle: $(BUILD_DIR)/agent-runtime-bundle.tar.gz (publish alongside agent-box-linux-amd64; scripts/install-agent-runtime.sh consumes both)"
 
 build-agent-box-linux: ## Build agent-box for Linux (the typical install target — agent-box runs INSIDE LXC containers)
 	@echo "==> Building agent-box for Linux..."

--- a/agent-runtime/README.md
+++ b/agent-runtime/README.md
@@ -89,11 +89,13 @@ Verified: `tsc --noEmit` passes against the installed types of both SDKs
   real SDK types.
 - ✅ **Daemon invoke + read-back** (4a) — `RunAgentSkill` execs the runtime and
   reads `artifact.json` into `RunAgentSkillResponse.artifact_json` (#614).
-- ⏳ **Box image assembly** — the `agent-runtime` recipe must ship Node + this
-  component + `agent-box` into the box (design-note open question #5).
-- ⏳ **Serve-mode lifecycle** — a peer/crew-member box must run
-  `CONTAINARIUM_AGENT_MODE=serve` as a long-running process so `:8674` is up;
-  wired in 4c (crew choreography) alongside the daemon starting members.
+- ✅ **Box image assembly** — `make bundle-agent-runtime` packages this
+  component; `scripts/install-agent-runtime.sh` (run by the `agent-runtime`
+  recipe's `post_start`) pulls agent-box + the bundle from the daemon's release
+  and installs `agent-box` + `agent-runtime` onto PATH. Best-effort: a
+  dev/unpublished release just skips it.
+- ✅ **Serve-mode lifecycle** — `RunCrew` starts each member in serve mode
+  (`startServeMode`); `agent run` uses run mode. Wired in 4c.
 - ⏳ **Live validation** — needs the assembled image + a provider API key + a
   backend (the standing "needs a live box" seam). Not runnable in CI alone.
 

--- a/docs/AGENT-RUNTIME-INBOX-LOOP-DESIGN.md
+++ b/docs/AGENT-RUNTIME-INBOX-LOOP-DESIGN.md
@@ -183,9 +183,14 @@ Each phase is independently demoable, mirroring how Phases 0–3 were built.
    `effort` field.)
 4. **API-key scoping.** One org key per deployment vs per-tenant keys (cost
    attribution, blast-radius). Ties into the secrets model.
-5. **Runtime image distribution.** The `agent-runtime` recipe currently points
-   at a base Ubuntu LXC; 4a needs the image to actually contain the loop binary
-   + agent-box MCP + the model client. Build + ship that image how?
+5. **Runtime image distribution.** ✅ Resolved via the release-artifact path:
+   `make bundle-agent-runtime` packages the loop component, and the
+   `agent-runtime` recipe's `post_start` runs `scripts/install-agent-runtime.sh`
+   to pull agent-box + the bundle from the daemon's release (the daemon passes
+   its version as the recipe's `release` param) and install both onto PATH.
+   Best-effort — a dev/unpublished release skips assembly and the box runs
+   without the loop. (A prebuilt OCI/LXC image remains a future optimization to
+   avoid per-box npm install.)
 
 ## See also
 

--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/footprintai/containarium/internal/netpolicy"
 	"github.com/footprintai/containarium/pkg/core/skills"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/footprintai/containarium/pkg/version"
 )
 
 // agentBoxPrefix is the box/tenant name prefix RunAgentSkill assigns to a
@@ -153,12 +154,17 @@ func (s *AgentSkillServer) provisionSkillBox(ctx context.Context, skill *pb.Agen
 		return "", nil, err
 	}
 
-	// Provision the box by reusing the recipe deploy path.
+	// Provision the box by reusing the recipe deploy path. Pass the daemon's
+	// version as the agent-runtime recipe's `release` param so the box's
+	// post_start pulls matching agent-box + agent-runtime artifacts (box-image
+	// assembly). Recipes that don't declare these params ignore the extras;
+	// assembly is best-effort (a dev/unpublished version just skips it).
 	dep, err := s.recipes.deploy(ctx, &pb.DeployRecipeRequest{
-		RecipeId:  recipeID,
-		Name:      name,
-		BackendId: backendID,
-		Pool:      pool,
+		RecipeId:   recipeID,
+		Name:       name,
+		BackendId:  backendID,
+		Pool:       pool,
+		Parameters: map[string]string{"release": version.GetVersion()},
 	})
 	if err != nil {
 		return "", nil, err // already a gRPC status from deploy/CreateContainer

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -72,22 +72,44 @@ recipes:
   # writes artifact.json back. No GPU and no exposed ports by default — a skill
   # that needs either declares its own box.
   #
-  # post_start installs the Node runtime the loop needs and ensures the seed
-  # dir. The agent-runtime loop component + the agent-box binary themselves are
-  # installed as part of image assembly (design-note open question #5): publish
-  # them as a release artifact and add the install step here, or bake a
-  # prebuilt agent-runtime image. The daemon execs `agent-runtime` (PATH) over
-  # the seed and reads artifact.json (best-effort until that lands).
+  # post_start assembles the box (design-note open question #5, addressed via
+  # the release-artifact path): install Node 20, then run
+  # scripts/install-agent-runtime.sh, which pulls the agent-box binary +
+  # agent-runtime bundle from the named release and installs `agent-box` +
+  # `agent-runtime` onto PATH. The daemon then execs `agent-runtime` (run mode)
+  # or starts serve mode; both resolve via the PATH launcher.
+  #
+  # `release` selects the release tag the artifacts are pulled from (built by
+  # `make build-agent-box-all` + `make bundle-agent-runtime`, published to the
+  # GitHub release). `repo` overrides the source repo (forks/mirrors).
   - id: agent-runtime
     name: Agent Runtime
-    description: Base box for running an AgentSkill — Ubuntu LXC with Node + the in-box agent loop; reads its prompt/token/input from /etc/containarium/agent and writes artifact.json.
+    description: Box for running an AgentSkill — Ubuntu LXC with Node + agent-box + the in-box agent loop; reads prompt/token/input from /etc/containarium/agent and writes artifact.json.
     image: images:ubuntu/24.04
     requires_gpu: false
     resources:
       cpu: "2"
       memory: 4GB
       disk: 20GB
+    parameters:
+      # release is optional: the daemon passes its own version when it
+      # provisions a skill's box (so artifacts match the daemon); a human
+      # `recipe deploy` may pass it too. When empty (or the release lacks the
+      # artifacts), assembly is skipped and the box runs without the in-box loop
+      # (the daemon's exec then degrades to an empty artifact — best-effort).
+      - name: release
+        label: Release tag
+        description: Containarium release tag to pull agent-box + the agent-runtime bundle from (e.g. v0.27.0). Empty skips assembly.
+        type: string
+      - name: repo
+        label: Source repo
+        description: GitHub owner/repo the release artifacts live in.
+        type: string
+        default: FootprintAI/Containarium
     post_start:
       - mkdir -p /etc/containarium/agent
       - 'curl -fsSL https://deb.nodesource.com/setup_20.x | bash -'
       - DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
+      # Best-effort assembly: never fail provisioning if the release lacks the
+      # artifacts (|| echo keeps the line green under `set -e`).
+      - 'if [ -n "$CONTAINARIUM_PARAM_RELEASE" ]; then curl -fsSL "https://raw.githubusercontent.com/$CONTAINARIUM_PARAM_REPO/$CONTAINARIUM_PARAM_RELEASE/scripts/install-agent-runtime.sh" | REPO="$CONTAINARIUM_PARAM_REPO" RELEASE="$CONTAINARIUM_PARAM_RELEASE" bash || echo "agent-runtime assembly skipped/failed for release=$CONTAINARIUM_PARAM_RELEASE; box runs without the in-box loop"; fi'

--- a/scripts/install-agent-runtime.sh
+++ b/scripts/install-agent-runtime.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# install-agent-runtime.sh — assemble the agent-runtime box (Phase 4a/4b/4c).
+#
+# Runs INSIDE an agent-runtime LXC. Installs the two pieces the in-box loop
+# needs so the daemon's `agent-runtime` exec (run mode) and serve mode work:
+#   1. agent-box  (Go binary, the in-box MCP tool surface)
+#   2. agent-runtime (the Node loop component) + a PATH launcher
+# Node itself is installed by the recipe's post_start (Node 20).
+#
+# Artifacts are pulled from a GitHub release:
+#   <base>/agent-box-linux-amd64
+#   <base>/agent-runtime-bundle.tar.gz
+# where <base> = https://github.com/<REPO>/releases/download/<RELEASE>.
+# Built by `make build-agent-box-all` + `make bundle-agent-runtime`.
+#
+# Env:
+#   REPO     default FootprintAI/Containarium
+#   RELEASE  required — the release tag to pull (e.g. v0.27.0)
+#   ARTIFACT_BASE_URL  optional — overrides the computed release base URL
+set -euo pipefail
+
+REPO="${REPO:-FootprintAI/Containarium}"
+RELEASE="${RELEASE:-}"
+if [[ -z "${ARTIFACT_BASE_URL:-}" ]]; then
+  if [[ -z "$RELEASE" ]]; then
+    echo "install-agent-runtime: set RELEASE (the release tag) or ARTIFACT_BASE_URL" >&2
+    exit 2
+  fi
+  ARTIFACT_BASE_URL="https://github.com/${REPO}/releases/download/${RELEASE}"
+fi
+
+PREFIX="${PREFIX:-/usr/local/bin}"
+APP_DIR="${APP_DIR:-/opt/agent-runtime}"
+
+echo "==> installing agent-box from ${ARTIFACT_BASE_URL}"
+curl -fsSL "${ARTIFACT_BASE_URL}/agent-box-linux-amd64" -o "${PREFIX}/agent-box" </dev/null
+chmod +x "${PREFIX}/agent-box"
+
+echo "==> installing agent-runtime component into ${APP_DIR}"
+mkdir -p "${APP_DIR}"
+curl -fsSL "${ARTIFACT_BASE_URL}/agent-runtime-bundle.tar.gz" -o /tmp/agent-runtime-bundle.tar.gz </dev/null
+tar -xzf /tmp/agent-runtime-bundle.tar.gz -C "${APP_DIR}"
+# The bundle ships dist/ + package manifests; install runtime deps (the agent
+# harness SDKs) in-box. --omit=dev: we only need the runtime deps, not tsc.
+( cd "${APP_DIR}" && npm ci --omit=dev )
+
+# PATH launcher so the daemon's `agent-runtime` exec resolves (run + serve mode).
+cat > "${PREFIX}/agent-runtime" <<LAUNCH
+#!/usr/bin/env bash
+exec node ${APP_DIR}/dist/index.js "\$@"
+LAUNCH
+chmod +x "${PREFIX}/agent-runtime"
+
+echo "==> agent-runtime box assembled: $(command -v agent-box), $(command -v agent-runtime)"


### PR DESCRIPTION
## Summary

Phase 4 **box-image assembly** — the design-note's open question #5, the gate between the (now-built) loop and a live `agent run` / `crew run`. Uses the **release-artifact** path, fitting the repo's existing release lane.

## What's here

- **`make bundle-agent-runtime`** — packages the Node loop component into `bin/agent-runtime-bundle.tar.gz` (`dist/` + manifests). *Verified: builds + tars (18K).*
- **`scripts/install-agent-runtime.sh`** — runs in-box: pulls `agent-box-linux-amd64` + `agent-runtime-bundle.tar.gz` from a GitHub release, `npm ci --omit=dev`, installs `agent-box` + an `agent-runtime` PATH launcher (so the daemon's run-mode exec **and** serve mode both resolve).
- **`agent-runtime` recipe** — `post_start` installs Node 20 then runs the installer, **best-effort** (`|| echo` keeps it green under `set -e`, so a dev/unpublished release just skips assembly and the box runs without the loop). New optional params: `release` (tag to pull) + `repo`.
- **`provisionSkillBox`** passes the daemon's `version` as the `release` param, so a skill's box pulls artifacts matching the daemon. Recipes that don't declare the param ignore the extra — provisioning still works on a dev daemon.

## Verification

`go build ./...`, recipes loader + `internal/server` tests green; `make bundle-agent-runtime` produces the tarball.

## What's left for a live run

A published release that actually carries `agent-box-linux-amd64` + `agent-runtime-bundle.tar.gz` (add `bundle-agent-runtime` to the release workflow), a provider API key seeded via secrets, a backend, and `api.anthropic.com` in the agent egress allowlist before ENFORCE (#611). Those need a live box, not CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)