### PR TITLE
feat(agents): ship agent-runtime bundle in releases + default model egress (#611)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,18 @@ jobs:
         # writes SHA256SUMS.txt. 9 binaries + 1 checksum file.
         run: make build-release VERSION="${GITHUB_REF_NAME#v}"
 
+      - name: Set up Node
+        # agent-runtime is a Node/TS sibling package (the in-box agent loop);
+        # `make bundle-agent-runtime` runs npm ci + tsc and tars it.
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build agent-runtime bundle
+        # Produces bin/agent-runtime-bundle.tar.gz, pulled in-box by
+        # scripts/install-agent-runtime.sh alongside agent-box-linux-amd64.
+        run: make bundle-agent-runtime
+
       - name: Create release notes
         id: release_notes
         run: |
@@ -132,6 +144,7 @@ jobs:
             bin/agent-box-linux-amd64
             bin/agent-box-darwin-amd64
             bin/agent-box-darwin-arm64
+            bin/agent-runtime-bundle.tar.gz
             bin/SHA256SUMS.txt
           draft: false
           prerelease: false

--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -278,12 +278,18 @@ func (s *AgentSkillServer) applyAllowedPeersPolicy(ctx context.Context, tenant s
 	if s.netpolicy == nil || len(skill.AllowedPeers) == 0 {
 		return
 	}
-	extraCIDRs, enforce := agentNetworkPolicyConfig()
-	policy := compileAllowedPeersPolicy(tenant, skill.AllowedPeers, s.resolvePeerIP, extraCIDRs, enforce)
-	if len(policy.EgressCidrs) == 0 {
-		// Nothing to allow (no peers running, no platform CIDRs). Skip rather
-		// than install an empty allowlist (which, under ENFORCE, denies all).
+	extraCIDRs, extraDomains, enforce := agentNetworkPolicyConfig()
+	policy := compileAllowedPeersPolicy(tenant, skill.AllowedPeers, s.resolvePeerIP, extraCIDRs, extraDomains, enforce)
+	if len(policy.EgressCidrs) == 0 && len(policy.EgressDomains) == 0 {
+		// Nothing to allow at all. Skip rather than install an empty allowlist
+		// (which, under ENFORCE, denies everything).
 		return
+	}
+	if enforce && len(policy.EgressDomains) == 0 {
+		// #611: an armed agent with no model-provider egress is stranded — it
+		// can reach its peers but not the Claude/OpenAI API. Default domains
+		// prevent this; warn loudly if an operator cleared them.
+		log.Printf("[agent-skill] WARNING: ENFORCE armed for %q with no model egress (CONTAINARIUM_AGENT_EGRESS_DOMAINS empty) — the agent loop may be unable to reach its provider API", tenant)
 	}
 	// Compile (validate + normalize) before storing — same path the
 	// SetNetworkPolicy RPC uses — so a bad operator-supplied egress CIDR is
@@ -308,14 +314,29 @@ func (s *AgentSkillServer) applyAllowedPeersPolicy(ctx context.Context, tenant s
 // Both default off/empty, so the out-of-the-box behaviour stays observe-only.
 // ENFORCE additionally requires the daemon-wide eBPF enforcer to be armed
 // (CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT + CONTAINARIUM_NETWORK_POLICY_ENFORCE).
-func agentNetworkPolicyConfig() (extraCIDRs []string, enforce bool) {
+// defaultAgentEgressDomains is the model-provider egress every agent box needs
+// so an armed (ENFORCE) policy doesn't strand the loop (#611). Both providers
+// are allowed since a box may run either engine (Claude or Codex).
+var defaultAgentEgressDomains = []string{"api.anthropic.com", "api.openai.com"}
+
+func agentNetworkPolicyConfig() (extraCIDRs, extraDomains []string, enforce bool) {
 	enforce = os.Getenv("CONTAINARIUM_AGENT_NETWORK_POLICY_ENFORCE") == "1"
 	for _, c := range strings.Split(os.Getenv("CONTAINARIUM_AGENT_EGRESS_CIDRS"), ",") {
 		if c = strings.TrimSpace(c); c != "" {
 			extraCIDRs = append(extraCIDRs, c)
 		}
 	}
-	return extraCIDRs, enforce
+	// Model-provider egress: operator override, else the provider defaults.
+	if raw, ok := os.LookupEnv("CONTAINARIUM_AGENT_EGRESS_DOMAINS"); ok {
+		for _, d := range strings.Split(raw, ",") {
+			if d = strings.TrimSpace(d); d != "" {
+				extraDomains = append(extraDomains, d)
+			}
+		}
+	} else {
+		extraDomains = append(extraDomains, defaultAgentEgressDomains...)
+	}
+	return extraCIDRs, extraDomains, enforce
 }
 
 // callerSkillID recovers the skill id of the agent making an A2A call. The
@@ -366,7 +387,7 @@ func (s *AgentSkillServer) resolvePeerIP(peerID string) (string, bool) {
 // allowed_peers: each currently-running peer's box IP becomes an egress /32.
 // Pure (resolution is injected) so it is unit-testable without a daemon. The
 // policy is LOG_ONLY — observe, never drop — until Phase 2 enforcement is armed.
-func compileAllowedPeersPolicy(tenant string, allowedPeers []string, resolve func(peerID string) (string, bool), extraCIDRs []string, enforce bool) *pb.NetworkPolicy {
+func compileAllowedPeersPolicy(tenant string, allowedPeers []string, resolve func(peerID string) (string, bool), extraCIDRs, extraDomains []string, enforce bool) *pb.NetworkPolicy {
 	var cidrs []string
 	for _, peer := range allowedPeers {
 		if ip, ok := resolve(peer); ok {
@@ -385,9 +406,12 @@ func compileAllowedPeersPolicy(tenant string, allowedPeers []string, resolve fun
 		Tenant:           tenant,
 		AllowIntraTenant: false,
 		EgressCidrs:      cidrs,
-		Mode:             mode,
-		AllowMetadata:    false,
-		Source:           "agent-skill",
+		// Model-provider egress (resolved to IPs by the enforcer's domain
+		// resolver) so the in-box loop can reach the Claude/OpenAI API (#611).
+		EgressDomains: extraDomains,
+		Mode:          mode,
+		AllowMetadata: false,
+		Source:        "agent-skill",
 	}
 }
 

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -75,6 +76,32 @@ func TestSendAgentTaskRequiresCallScope(t *testing.T) {
 	}
 }
 
+func TestAgentNetworkPolicyConfigDomains(t *testing.T) {
+	t.Run("defaults to the model providers when unset", func(t *testing.T) {
+		os.Unsetenv("CONTAINARIUM_AGENT_EGRESS_DOMAINS")
+		_, domains, _ := agentNetworkPolicyConfig()
+		if len(domains) != 2 || domains[0] != "api.anthropic.com" {
+			t.Errorf("default domains = %v, want the provider defaults", domains)
+		}
+	})
+	t.Run("operator override wins", func(t *testing.T) {
+		t.Setenv("CONTAINARIUM_AGENT_EGRESS_DOMAINS", "api.example.com, llm.internal")
+		_, domains, _ := agentNetworkPolicyConfig()
+		if len(domains) != 2 || domains[0] != "api.example.com" || domains[1] != "llm.internal" {
+			t.Errorf("override domains = %v", domains)
+		}
+	})
+}
+
+func TestCompileAllowedPeersPolicySetsDomains(t *testing.T) {
+	p := compileAllowedPeersPolicy("agent-x", []string{"peer-a"},
+		func(string) (string, bool) { return "10.0.0.5", true },
+		nil, []string{"api.anthropic.com"}, true)
+	if len(p.EgressDomains) != 1 || p.EgressDomains[0] != "api.anthropic.com" {
+		t.Errorf("egress_domains = %v, want [api.anthropic.com]", p.EgressDomains)
+	}
+}
+
 func TestParseArtifactOutput(t *testing.T) {
 	t.Run("output", func(t *testing.T) {
 		out, err := parseArtifactOutput([]byte(`{"outputJson":"{\"ok\":true}","engine":"claude","model":"claude-opus-4-8"}`))
@@ -128,7 +155,7 @@ func TestCompileAllowedPeersPolicy(t *testing.T) {
 	resolve := func(id string) (string, bool) { ip, ok := running[id]; return ip, ok }
 
 	// peer-c is not running, so it must be omitted from the allowlist.
-	p := compileAllowedPeersPolicy("agent-caller", []string{"peer-a", "peer-b", "peer-c"}, resolve, nil, false)
+	p := compileAllowedPeersPolicy("agent-caller", []string{"peer-a", "peer-b", "peer-c"}, resolve, nil, nil, false)
 
 	if p.Tenant != "agent-caller" {
 		t.Errorf("tenant = %q, want agent-caller", p.Tenant)
@@ -156,7 +183,7 @@ func TestCompileAllowedPeersPolicy(t *testing.T) {
 func TestCompileAllowedPeersPolicyNoneRunning(t *testing.T) {
 	// No peer is running -> empty allowlist (the caller skips installing it
 	// rather than denying all egress under a future ENFORCE).
-	p := compileAllowedPeersPolicy("t", []string{"x", "y"}, func(string) (string, bool) { return "", false }, nil, false)
+	p := compileAllowedPeersPolicy("t", []string{"x", "y"}, func(string) (string, bool) { return "", false }, nil, nil, false)
 	if len(p.EgressCidrs) != 0 {
 		t.Errorf("expected no egress cidrs when no peers run, got %v", p.EgressCidrs)
 	}
@@ -172,7 +199,7 @@ func TestCompileAllowedPeersPolicyEnforceAndExtraCIDRs(t *testing.T) {
 	// Armed ENFORCE + platform egress (e.g. daemon + DNS) so the agent isn't
 	// stranded by a peer-only allowlist.
 	extra := []string{"10.0.1.1/32", "10.0.1.2/32"}
-	p := compileAllowedPeersPolicy("agent-x", []string{"peer-a"}, resolve, extra, true)
+	p := compileAllowedPeersPolicy("agent-x", []string{"peer-a"}, resolve, extra, nil, true)
 
 	if p.Mode != pb.NetworkPolicyMode_NETWORK_POLICY_MODE_ENFORCE {
 		t.Errorf("mode = %v, want ENFORCE when armed", p.Mode)


### PR DESCRIPTION
## Summary

The two remaining **codeable** Phase-4 items.

### Release workflow — publish the assembly artifacts
The Release job now sets up Node 20, runs `make bundle-agent-runtime`, and ships **`agent-runtime-bundle.tar.gz`** as a release asset alongside `agent-box-linux-amd64`. So any tagged release carries both artifacts that `scripts/install-agent-runtime.sh` (the `agent-runtime` recipe's `post_start`) pulls.

### #611 — default model-provider egress (don't strand an armed agent)
- `agentNetworkPolicyConfig` now also returns `extraDomains`: operator override via `CONTAINARIUM_AGENT_EGRESS_DOMAINS`, else the provider defaults (`api.anthropic.com`, `api.openai.com` — both, since a box may run either engine).
- `compileAllowedPeersPolicy` sets `NetworkPolicy.EgressDomains` (the enforcer's domain resolver turns these into allow rules), so a peered agent under **ENFORCE** can reach the Claude/OpenAI API *and* its peers.
- `applyAllowedPeersPolicy` installs the policy when it has any egress (CIDRs **or** domains), and logs a loud **WARNING** if ENFORCE is armed with no model egress (operator cleared the domains) — the "don't strand the agent" guard, made concrete.

Closes #611.

## Verification

`go build ./...`, `internal/server` + recipes tests green — including the new tests (default vs override domains; compiled policy carries `EgressDomains`).

## Remaining (live-ops only)

Cut a release (so the artifacts exist), seed a provider API key via secrets, and run end-to-end on a backend. That's the last gate, and it needs a real box — not CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)