### PR TITLE
feat(agents): load external skill/crew catalogs (#620)

### DIFF
--- a/docs/AGENT-SKILLS-QUICKSTART.md
+++ b/docs/AGENT-SKILLS-QUICKSTART.md
@@ -217,13 +217,19 @@ The platform MCP server exposes the same surface as thin wrappers:
 { "crew_id": "hello-crew", "input_json": "{\"q\":\"hi\"}" }
 ```
 
-## Add your own skill (local)
+## Add your own skill
 
-Add an entry to `pkg/core/skills/skills.yaml`. The loader validates at startup:
+Built-in: add an entry to `pkg/core/skills/skills.yaml` (compiled in).
+
+External (no rebuild): drop `*.yaml` skill catalogs in `CONTAINARIUM_SKILLS_DIR`
+and crew catalogs in `CONTAINARIUM_CREWS_DIR`; the daemon merges them onto the
+built-ins at startup (skills first — crews reference them). Either way the
+loader validates:
 
 - `recipe_id`, `system_prompt`, and **at least one** `allowed_scope` are required.
 - every `allowed_scope` must be a known scope (`internal/auth/scopes.go`) — a
   typo is a load-time error, not a silently-overbroad token.
+- an id that collides with an already-loaded skill/crew is rejected.
 
 ```yaml
 skills:

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -35,9 +35,11 @@ import (
 	"github.com/footprintai/containarium/internal/wake"
 	zapscanner "github.com/footprintai/containarium/internal/zap"
 	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/crews"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/pkg/core/network"
 	corecryptosecrets "github.com/footprintai/containarium/pkg/core/secrets"
+	"github.com/footprintai/containarium/pkg/core/skills"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"google.golang.org/grpc"
@@ -325,6 +327,25 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	// task purpose; reuses the agent-skill server to provision each member box.
 	pb.RegisterCrewServiceServer(grpcServer, NewCrewServer(agentSkillServer))
 	log.Printf("Crew service enabled")
+
+	// Merge external skill/crew catalogs (#620) into the process-wide catalogs
+	// the agent/crew servers use, so out-of-tree packs register without a
+	// rebuild. Skills first (crews reference them). Best-effort: a bad external
+	// catalog logs and is skipped rather than failing daemon startup.
+	if dir := os.Getenv("CONTAINARIUM_SKILLS_DIR"); dir != "" {
+		if err := skills.GetDefault().LoadDir(dir); err != nil {
+			log.Printf("[agent-skill] external skills from %s: %v", dir, err)
+		} else {
+			log.Printf("Loaded external skills from %s", dir)
+		}
+	}
+	if dir := os.Getenv("CONTAINARIUM_CREWS_DIR"); dir != "" {
+		if err := crews.GetDefault().LoadDir(dir); err != nil {
+			log.Printf("[crew] external crews from %s: %v", dir, err)
+		} else {
+			log.Printf("Loaded external crews from %s", dir)
+		}
+	}
 
 	// Register BackupService — logical (pg_dump) database backups for the
 	// databases running inside containers, stored off-host (local dir or

--- a/pkg/core/crews/crews.go
+++ b/pkg/core/crews/crews.go
@@ -11,6 +11,9 @@ package crews
 import (
 	"embed"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -122,6 +125,61 @@ func validate(c *crewDef) error {
 	}
 	if len(c.SkillIDs) < 2 {
 		return fmt.Errorf("crew %q must reference at least two skills", c.ID)
+	}
+	return nil
+}
+
+// LoadDir merges every *.yaml crew catalog in dir on top of the embedded
+// built-ins (#620). A missing dir is not an error. Fails on a parse/validate
+// error or an id that collides with an already-loaded crew. (Topology vs the
+// members' allowed_peers is validated at RunCrew time, against the skill
+// catalog — so load external skills before external crews.)
+func (m *Manager) LoadDir(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read crews dir %q: %w", dir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", e.Name(), err)
+		}
+		if err := m.mergeBytes(data); err != nil {
+			return fmt.Errorf("%s: %w", e.Name(), err)
+		}
+	}
+	return nil
+}
+
+// mergeBytes parses + validates a catalog and appends it, rejecting an id that
+// collides with an already-loaded crew.
+func (m *Manager) mergeBytes(data []byte) error {
+	var cfg config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parse crews YAML: %w", err)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	existing := make(map[string]bool, len(m.crews))
+	for _, c := range m.crews {
+		existing[c.Id] = true
+	}
+	for i := range cfg.Crews {
+		def := &cfg.Crews[i]
+		if err := validate(def); err != nil {
+			return err
+		}
+		if existing[def.ID] {
+			return fmt.Errorf("duplicate crew id: %s", def.ID)
+		}
+		existing[def.ID] = true
+		m.crews = append(m.crews, def.ToProto())
 	}
 	return nil
 }

--- a/pkg/core/crews/crews_test.go
+++ b/pkg/core/crews/crews_test.go
@@ -1,10 +1,39 @@
 package crews
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
+
+func TestLoadDirMergesCrews(t *testing.T) {
+	m := New()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ext.yaml"), []byte(`
+crews:
+  - id: ext-crew
+    topology: freeform
+    skill_ids: [a, b]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.LoadDir(dir); err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	c, err := m.Get("ext-crew")
+	if err != nil {
+		t.Fatalf("external crew not merged: %v", err)
+	}
+	if c.Topology != pb.CrewTopology_CREW_TOPOLOGY_FREEFORM {
+		t.Errorf("topology = %v", c.Topology)
+	}
+	// missing dir is a no-op
+	if err := m.LoadDir(filepath.Join(dir, "nope")); err != nil {
+		t.Errorf("missing dir should be a no-op, got %v", err)
+	}
+}
 
 func TestEmbeddedCatalogLoads(t *testing.T) {
 	m := GetDefault()

--- a/pkg/core/skills/skills.go
+++ b/pkg/core/skills/skills.go
@@ -12,6 +12,9 @@ package skills
 import (
 	"embed"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/footprintai/containarium/internal/auth"
@@ -162,6 +165,61 @@ func validate(s *skillDef) error {
 		if !auth.IsKnownScope(sc) {
 			return fmt.Errorf("skill %q declares unknown scope %q", s.ID, sc)
 		}
+	}
+	return nil
+}
+
+// LoadDir merges every *.yaml skill catalog in dir on top of what's already
+// loaded (the embedded built-ins), so out-of-tree catalogs can register skills
+// without recompiling (#620). A missing dir is not an error (no external
+// catalog configured). Fails on a parse/validate error or an id that collides
+// with an already-loaded skill.
+func (m *Manager) LoadDir(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read skills dir %q: %w", dir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", e.Name(), err)
+		}
+		if err := m.mergeBytes(data); err != nil {
+			return fmt.Errorf("%s: %w", e.Name(), err)
+		}
+	}
+	return nil
+}
+
+// mergeBytes parses + validates a catalog and appends it, rejecting an id that
+// collides with an already-loaded skill.
+func (m *Manager) mergeBytes(data []byte) error {
+	var cfg config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parse skills YAML: %w", err)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	existing := make(map[string]bool, len(m.skills))
+	for _, s := range m.skills {
+		existing[s.Id] = true
+	}
+	for i := range cfg.Skills {
+		def := &cfg.Skills[i]
+		if err := validate(def); err != nil {
+			return err
+		}
+		if existing[def.ID] {
+			return fmt.Errorf("duplicate skill id: %s", def.ID)
+		}
+		existing[def.ID] = true
+		m.skills = append(m.skills, def.ToProto())
 	}
 	return nil
 }

--- a/pkg/core/skills/skills_test.go
+++ b/pkg/core/skills/skills_test.go
@@ -1,6 +1,10 @@
 package skills
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestEmbeddedCatalogLoads(t *testing.T) {
 	m := GetDefault()
@@ -71,6 +75,55 @@ skills:
 				t.Errorf("expected load error for %q, got nil", name)
 			}
 		})
+	}
+}
+
+func TestLoadDirMerges(t *testing.T) {
+	const base = `
+skills:
+  - id: a
+    recipe_id: agent-runtime
+    system_prompt: hi
+    allowed_scopes: [containers:read]
+`
+	m := New()
+	if err := m.LoadFromBytes([]byte(base)); err != nil {
+		t.Fatalf("base load: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ext.yaml"), []byte(`
+skills:
+  - id: ext-skill
+    recipe_id: agent-runtime
+    system_prompt: external
+    allowed_scopes: [security:read]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.LoadDir(dir); err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if _, err := m.Get("a"); err != nil {
+		t.Error("base skill lost after merge")
+	}
+	if _, err := m.Get("ext-skill"); err != nil {
+		t.Error("external skill not merged")
+	}
+}
+
+func TestLoadDirRejectsCollisionAndAllowsMissing(t *testing.T) {
+	m := New()
+	_ = m.LoadFromBytes([]byte("skills:\n  - id: dup\n    recipe_id: agent-runtime\n    system_prompt: x\n    allowed_scopes: [containers:read]\n"))
+
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "dup.yaml"), []byte("skills:\n  - id: dup\n    recipe_id: agent-runtime\n    system_prompt: y\n    allowed_scopes: [containers:read]\n"), 0o600)
+	if err := m.LoadDir(dir); err == nil {
+		t.Error("expected collision error for duplicate id")
+	}
+
+	if err := m.LoadDir(filepath.Join(dir, "does-not-exist")); err != nil {
+		t.Errorf("missing dir should be a no-op, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

The agent-skills mechanism loaded skills/crews only from **embedded** YAML, so out-of-tree catalogs (curated packs, operator-authored skills) couldn't run without recompiling. This adds **merge-on-top external loading** — the gating capability for any out-of-tree catalog. Closes #620.

## What's here

- **`skills.Manager.LoadDir(dir)`** + **`crews.Manager.LoadDir(dir)`**: parse every `*.yaml`, validate with the existing rules, merge onto the embedded built-ins, reject id collisions; a missing dir is a no-op.
- **`dual_server`** merges `CONTAINARIUM_SKILLS_DIR` then `CONTAINARIUM_CREWS_DIR` (skills first — crews reference them) into the process-wide catalogs the agent/crew servers use. **Best-effort:** a bad external catalog logs + is skipped, never fails daemon startup.
- Quickstart documents the external-catalog path.

## Scope

Loading only. **Signing/provenance** for external catalogs is the trust layer on top — a separate follow-up (the marketplace half).

## Verification

`go build ./...` + `pkg/core/skills`, `pkg/core/crews`, `internal/server` tests green — incl. new `LoadDir` tests (merge, id-collision rejection, missing-dir no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)