### PR TITLE
feat(auth): read-only scopes audit:read, network-policy:read, tokens:read (#621)

### DIFF
--- a/internal/auth/authz.go
+++ b/internal/auth/authz.go
@@ -147,6 +147,25 @@ func RequireRole(ctx context.Context, role string) error {
 	return nil
 }
 
+// RequireRoleOrScope passes if the caller holds the role OR explicitly holds
+// the scope. It's for read paths an admin reaches by role and a
+// least-privilege token reaches by an explicit read scope (#621). Uses
+// HasExplicitScope, not HasScope — an absent scopes claim must NOT unlock an
+// otherwise admin-only read.
+func RequireRoleOrScope(ctx context.Context, role, scope string) error {
+	_, roles, ok := SubjectFromGRPCContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "no authenticated subject in request context")
+	}
+	if HasRole(roles, role) {
+		return nil
+	}
+	if scopes, _ := ScopesFromGRPCContext(ctx); HasExplicitScope(scopes, scope) {
+		return nil
+	}
+	return status.Errorf(codes.PermissionDenied, "requires role %q or scope %q", role, scope)
+}
+
 // RequireScope returns nil if the authenticated subject's JWT
 // carries the required scope (or no scopes claim at all, which
 // is the Phase 1.7 backwards-compat "unrestricted" path).

--- a/internal/auth/require_role_or_scope_test.go
+++ b/internal/auth/require_role_or_scope_test.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// #621 — RequireRoleOrScope passes if the caller holds the role OR
+// explicitly holds the scope. It gates read paths an admin reaches by
+// role and a least-privilege token reaches by an explicit read scope.
+// Unlike RequireScope, a nil/absent scopes claim must NOT unlock the read
+// (that's HasExplicitScope, not HasScope).
+
+func TestRequireRoleOrScope_NoSubject(t *testing.T) {
+	err := RequireRoleOrScope(context.Background(), RoleAdmin, ScopeTokensRead)
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("want Unauthenticated, got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestRequireRoleOrScope_AdminByRole(t *testing.T) {
+	// Admin role, an unrelated scope — the role alone passes.
+	ctx := ContextWithTestSubjectScopes(context.Background(),
+		"ops", []string{RoleAdmin}, []string{ScopeContainersRead})
+	if err := RequireRoleOrScope(ctx, RoleAdmin, ScopeTokensRead); err != nil {
+		t.Fatalf("admin by role should pass: %v", err)
+	}
+}
+
+func TestRequireRoleOrScope_NonAdminWithScope(t *testing.T) {
+	ctx := ContextWithTestSubjectScopes(context.Background(),
+		"collector", []string{"user"}, []string{ScopeTokensRead})
+	if err := RequireRoleOrScope(ctx, RoleAdmin, ScopeTokensRead); err != nil {
+		t.Fatalf("non-admin with explicit scope should pass: %v", err)
+	}
+}
+
+func TestRequireRoleOrScope_NonAdminMissingScope(t *testing.T) {
+	ctx := ContextWithTestSubjectScopes(context.Background(),
+		"alice", []string{"user"}, []string{ScopeContainersRead})
+	err := RequireRoleOrScope(ctx, RoleAdmin, ScopeTokensRead)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("want PermissionDenied, got %v (%v)", status.Code(err), err)
+	}
+}
+
+// The key difference from RequireScope: an absent scopes claim is NOT a
+// pass. A subject with no scopes claim and not holding the role is denied —
+// a missing claim must not silently unlock an otherwise admin-only read.
+func TestRequireRoleOrScope_AbsentScopesClaimIsDenied(t *testing.T) {
+	ctx := ContextWithTestSubjectScopes(context.Background(),
+		"alice", []string{"user"}, nil)
+	err := RequireRoleOrScope(ctx, RoleAdmin, ScopeTokensRead)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("absent scopes claim must be denied; got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestRequireRoleOrScope_WildcardScopePasses(t *testing.T) {
+	ctx := ContextWithTestSubjectScopes(context.Background(),
+		"svc", []string{"user"}, []string{ScopeWildcard})
+	if err := RequireRoleOrScope(ctx, RoleAdmin, ScopeTokensRead); err != nil {
+		t.Fatalf("wildcard scope should pass: %v", err)
+	}
+}

--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -100,6 +100,12 @@ const (
 	// crews:run provisions a crew's member boxes and runs the collaboration.
 	ScopeCrewsRead = "crews:read"
 	ScopeCrewsRun  = "crews:run"
+
+	// read-only scopes for surfaces that were admin-only, so a least-privilege
+	// (e.g. compliance/evidence) token can read one without full admin (#621).
+	ScopeAuditRead         = "audit:read"          // audit-log query
+	ScopeNetworkPolicyRead = "network-policy:read" // NetworkPolicyService Get/List
+	ScopeTokensRead        = "tokens:read"         // token listing
 )
 
 // AllScopes is the catalog of every known scope. It backs IsKnownScope so
@@ -120,6 +126,20 @@ var AllScopes = []string{
 	ScopeTokensWrite,
 	ScopeAgentsRead, ScopeAgentsRun, ScopeAgentsCall,
 	ScopeCrewsRead, ScopeCrewsRun,
+	ScopeAuditRead, ScopeNetworkPolicyRead, ScopeTokensRead,
+}
+
+// HasExplicitScope reports whether want is explicitly in granted (or the
+// wildcard is). Unlike HasScope, a nil/absent scopes claim does NOT match —
+// use this when *granting* access by scope (a missing claim must not silently
+// unlock an otherwise admin-only read).
+func HasExplicitScope(granted []string, want string) bool {
+	for _, s := range granted {
+		if s = strings.TrimSpace(s); s == want || s == ScopeWildcard {
+			return true
+		}
+	}
+	return false
 }
 
 // IsKnownScope reports whether s is a defined scope (the wildcard counts).

--- a/internal/gateway/audit_handler.go
+++ b/internal/gateway/audit_handler.go
@@ -28,8 +28,17 @@ func registerAuditEndpoint(mux *http.ServeMux, store *audit.Store, authMW *auth.
 			return
 		}
 		token := strings.TrimPrefix(authHeader, "Bearer ")
-		if _, err := authMW.ValidateToken(token); err != nil {
+		claims, err := authMW.ValidateToken(token)
+		if err != nil {
 			http.Error(w, `{"error": "unauthorized: invalid token", "code": 401}`, http.StatusUnauthorized)
+			return
+		}
+		// #621: the audit log is sensitive (who-did-what across tenants). Gate
+		// reads on admin role OR an explicit audit:read scope. NOTE: this is a
+		// tightening — the endpoint previously accepted any valid token. A
+		// non-admin consumer must now carry audit:read.
+		if !auth.HasRole(claims.Roles, auth.RoleAdmin) && !auth.HasExplicitScope(claims.Scopes, auth.ScopeAuditRead) {
+			http.Error(w, `{"error": "forbidden: requires admin role or audit:read scope", "code": 403}`, http.StatusForbidden)
 			return
 		}
 

--- a/internal/gateway/audit_handler_test.go
+++ b/internal/gateway/audit_handler_test.go
@@ -102,6 +102,38 @@ func TestAuditEndpoint_RejectsInvalidToken(t *testing.T) {
 	}
 }
 
+// #621 — the audit log is sensitive (who-did-what across tenants), so a
+// valid-but-non-admin token without an explicit audit:read scope is now
+// forbidden (was: any valid token could read). The auth/scope check runs
+// before the store, so this exercises the gate with a nil store. The
+// allowed paths (admin role, or audit:read scope) reach handleAuditQuery
+// and need a live store — covered in the audit store integration test.
+func TestAuditEndpoint_RejectsValidNonAdminWithoutScope(t *testing.T) {
+	tm, err := auth.NewTokenManager(auditTestSecret, "containarium")
+	if err != nil {
+		t.Fatalf("NewTokenManager: %v", err)
+	}
+	// Valid token, non-admin role, an unrelated scope — no audit:read.
+	tok, err := tm.GenerateToken("alice", []string{"user"}, time.Hour, auth.ScopeContainersRead)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	mux := http.NewServeMux()
+	registerAuditEndpoint(mux, nil, auth.NewAuthMiddleware(tm))
+
+	req := httptest.NewRequest("GET", "/v1/audit/logs", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("non-admin without audit:read must be forbidden; got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "audit:read") {
+		t.Fatalf("error should name the required scope: %s", rec.Body.String())
+	}
+}
+
 // Note: a positive test that a valid token actually serves an
 // audit-log response requires a live Postgres connection (the
 // audit store). That coverage lives in

--- a/internal/server/network_policy_server.go
+++ b/internal/server/network_policy_server.go
@@ -57,7 +57,7 @@ func (s *NetworkPolicyServer) SetNetworkPolicy(ctx context.Context, req *pb.SetN
 }
 
 func (s *NetworkPolicyServer) GetNetworkPolicy(ctx context.Context, req *pb.GetNetworkPolicyRequest) (*pb.GetNetworkPolicyResponse, error) {
-	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+	if err := auth.RequireRoleOrScope(ctx, auth.RoleAdmin, auth.ScopeNetworkPolicyRead); err != nil {
 		return nil, err
 	}
 	if req.GetTenant() == "" {
@@ -74,7 +74,7 @@ func (s *NetworkPolicyServer) GetNetworkPolicy(ctx context.Context, req *pb.GetN
 }
 
 func (s *NetworkPolicyServer) ListNetworkPolicies(ctx context.Context, _ *pb.ListNetworkPoliciesRequest) (*pb.ListNetworkPoliciesResponse, error) {
-	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+	if err := auth.RequireRoleOrScope(ctx, auth.RoleAdmin, auth.ScopeNetworkPolicyRead); err != nil {
 		return nil, err
 	}
 	policies, err := s.store.List(ctx)

--- a/internal/server/tokens_server.go
+++ b/internal/server/tokens_server.go
@@ -203,19 +203,21 @@ func safeID(c *auth.Claims) string {
 	return c.ID
 }
 
-// ListRevokedTokens enumerates active revocations. Admin-
-// only + tokens:write scope (same surface as RevokeToken —
-// anyone who can revoke can confirm what was revoked).
+// ListRevokedTokens enumerates active revocations. It's a read
+// path, gated by admin role OR an explicit tokens:read scope
+// (#621) — a least-privilege compliance/evidence token can list
+// revocations without holding the write surface. Previously this
+// required admin AND tokens:write; the write-scope gate on a read
+// RPC was the bug.
 //
 // Default behavior is to return only non-expired
 // revocations. include_expired=true returns the full
 // forensic set (an operator chasing a leak after the fact
 // might want everything).
 func (s *TokensServer) ListRevokedTokens(ctx context.Context, req *pb.ListRevokedTokensRequest) (*pb.ListRevokedTokensResponse, error) {
-	if err := auth.RequireScope(ctx, auth.ScopeTokensWrite); err != nil {
-		return nil, err
-	}
-	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+	// Read path: admins (by role) or a least-privilege token with tokens:read
+	// (#621). Previously required admin AND tokens:write.
+	if err := auth.RequireRoleOrScope(ctx, auth.RoleAdmin, auth.ScopeTokensRead); err != nil {
 		return nil, err
 	}
 	if s.store == nil {

--- a/internal/server/tokens_server_test.go
+++ b/internal/server/tokens_server_test.go
@@ -326,27 +326,37 @@ func TestListRevokedTokens_RejectsNonAdmin(t *testing.T) {
 	}
 }
 
-func TestListRevokedTokens_RejectsAdminMissingScope(t *testing.T) {
-	srv := newTestTokensServer(t, newFakeRevocationStore())
-	ctx := auth.ContextWithTestSubjectScopes(context.Background(),
-		"ops", []string{auth.RoleAdmin}, []string{auth.ScopeContainersRead},
-	)
-	_, err := srv.ListRevokedTokens(ctx, &pb.ListRevokedTokensRequest{})
-	if status.Code(err) != codes.PermissionDenied {
-		t.Fatalf("admin without tokens:write: got %v want PermissionDenied", err)
-	}
-}
-
-func TestListRevokedTokens_AdminWithScopeSucceeds(t *testing.T) {
+// #621: ListRevokedTokens is a read path. An admin reaches it by role —
+// no scope needed. (Previously it required admin AND tokens:write; the
+// write-scope gate on a read RPC was relaxed to admin-OR-tokens:read.)
+func TestListRevokedTokens_AdminByRoleSucceeds(t *testing.T) {
 	store := newFakeRevocationStore()
 	_ = store.Revoke(context.Background(), "abc123", time.Now().Add(time.Hour), "test")
 	srv := newTestTokensServer(t, store)
 	ctx := auth.ContextWithTestSubjectScopes(context.Background(),
-		"ops", []string{auth.RoleAdmin}, []string{auth.ScopeTokensWrite},
+		"ops", []string{auth.RoleAdmin}, []string{auth.ScopeContainersRead},
 	)
 	resp, err := srv.ListRevokedTokens(ctx, &pb.ListRevokedTokensRequest{})
 	if err != nil {
-		t.Fatalf("ListRevokedTokens: %v", err)
+		t.Fatalf("admin by role (no tokens scope): %v", err)
+	}
+	if len(resp.Revocations) != 1 {
+		t.Fatalf("len(revocations) = %d, want 1", len(resp.Revocations))
+	}
+}
+
+// #621: a non-admin least-privilege token reaches the read path with an
+// explicit tokens:read scope (e.g. a compliance/evidence collector).
+func TestListRevokedTokens_NonAdminWithReadScopeSucceeds(t *testing.T) {
+	store := newFakeRevocationStore()
+	_ = store.Revoke(context.Background(), "abc123", time.Now().Add(time.Hour), "test")
+	srv := newTestTokensServer(t, store)
+	ctx := auth.ContextWithTestSubjectScopes(context.Background(),
+		"collector", []string{"user"}, []string{auth.ScopeTokensRead},
+	)
+	resp, err := srv.ListRevokedTokens(ctx, &pb.ListRevokedTokensRequest{})
+	if err != nil {
+		t.Fatalf("non-admin with tokens:read: %v", err)
 	}
 	if len(resp.Revocations) != 1 {
 		t.Fatalf("len(revocations) = %d, want 1", len(resp.Revocations))


### PR DESCRIPTION
## What

Adds three read-only JWT scopes so a least-privilege agent (the agent-skills `allowed_scopes` model) can read sensitive surfaces without being handed admin:

- `audit:read` — `/v1/audit/logs` query
- `network-policy:read` — `NetworkPolicyService` Get / List
- `tokens:read` — `TokensService` ListRevokedTokens

Admin keeps working everywhere (role / wildcard). Mirrors the existing `*:read` split (`security:read`, `traffic:read`).

## How

- `scopes.go`: three new scope consts + `AllScopes` entries; new `HasExplicitScope` helper (like `HasScope` but a **nil/absent** scopes claim does NOT match — when *granting* by scope, a missing claim must not silently unlock an admin-only read).
- `authz.go`: new `RequireRoleOrScope(role, scope)` — passes on role OR explicit scope.
- `network_policy_server.go`: Get/List now `RequireRoleOrScope(admin, network-policy:read)`. Set/Delete stay admin-only.
- `tokens_server.go`: `ListRevokedTokens` now `RequireRoleOrScope(admin, tokens:read)`.
- `audit_handler.go`: gate on admin-role OR `audit:read`.

## ⚠️ Two behavior changes (flagged)

1. **`ListRevokedTokens`** previously required admin **AND** `tokens:write` — a write-scope gate on a read RPC. Now admin-by-role alone reads it, or a least-privilege token with `tokens:read`.
2. **`/v1/audit/logs`** previously accepted **any** valid token. This PR is a **tightening**: a non-admin consumer must now carry `audit:read`. Surfaced while wiring the read scopes — the audit log is who-did-what across tenants and should never have been open to every token.

## Tests

- `internal/auth/require_role_or_scope_test.go` — role pass, scope pass, absent-claim denied, wildcard pass, no-subject.
- `tokens_server_test.go` — admin-by-role succeeds, non-admin-with-`tokens:read` succeeds (replaces the old admin-AND-`tokens:write` assertion).
- `audit_handler_test.go` — valid non-admin without `audit:read` → 403.

`go build ./...`, `go test ./internal/{auth,server,gateway}/...`, `go vet` all clean.

Closes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)