### PR TITLE
feat(cli): add windows/amd64 client-only build target (#624)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,12 @@ jobs:
             https://github.com/footprintai/containarium/releases/download/${{ github.ref_name }}/containarium-linux-amd64
           chmod +x /usr/local/bin/containarium
 
+          # Windows: client-only CLI (create/list/ssh/… against a remote daemon;
+          # the daemon/sentinel/tunnel subcommands are Linux/macOS only)
+          # PowerShell:
+          #   curl.exe -L -o containarium.exe `
+          #     https://github.com/footprintai/containarium/releases/download/${{ github.ref_name }}/containarium-windows-amd64.exe
+
           # platform MCP (your laptop, e.g. macOS arm64)
           curl -L -o /usr/local/bin/mcp-server \
             https://github.com/footprintai/containarium/releases/download/${{ github.ref_name }}/mcp-server-darwin-arm64
@@ -138,6 +144,7 @@ jobs:
             bin/containarium-linux-amd64
             bin/containarium-darwin-amd64
             bin/containarium-darwin-arm64
+            bin/containarium-windows-amd64.exe
             bin/mcp-server-linux-amd64
             bin/mcp-server-darwin-amd64
             bin/mcp-server-darwin-arm64

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ build-all: proto web-ui swagger-ui ## Build for all platforms (includes Swagger 
 	@GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 cmd/containarium/main.go
 	@GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 cmd/containarium/main.go
 	@GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 cmd/containarium/main.go
+	# Windows is CLIENT-ONLY: the daemon/sentinel/tunnel + direct-DB admin
+	# subcommands are //go:build !windows, so this binary exposes only the
+	# remote-client commands (create/list/ssh/…). The daemon stays linux/mac.
+	@GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe cmd/containarium/main.go
 	@echo "==> Binaries built in $(BUILD_DIR)/"
 
 build-mcp: ## Build the MCP server binary
@@ -167,13 +171,14 @@ sidecar-build-otel: ## Build the otel-sidecar Docker image locally (tag = pkg/ve
 # platform: containarium + mcp-server + agent-box, each for
 # linux/amd64, darwin/amd64, darwin/arm64. Used by the release.yml
 # workflow on v* tag pushes; safe to run locally to dry-run a release.
-build-release: build-all build-mcp-all build-agent-box-all ## Build all 9 release artifacts (3 binaries × 3 platforms) + checksums
+build-release: build-all build-mcp-all build-agent-box-all ## Build all 10 release artifacts (CLI ×4 platforms incl. windows; mcp/agent-box ×3) + checksums
 	@echo "==> Generating SHA256SUMS..."
 	@cd $(BUILD_DIR) && \
 	  shasum -a 256 \
 	    $(BINARY_NAME)-linux-amd64 \
 	    $(BINARY_NAME)-darwin-amd64 \
 	    $(BINARY_NAME)-darwin-arm64 \
+	    $(BINARY_NAME)-windows-amd64.exe \
 	    $(MCP_BINARY_NAME)-linux-amd64 \
 	    $(MCP_BINARY_NAME)-darwin-amd64 \
 	    $(MCP_BINARY_NAME)-darwin-arm64 \

--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/collaborator_add.go
+++ b/internal/cmd/collaborator_add.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/collaborator_list.go
+++ b/internal/cmd/collaborator_list.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/collaborator_remove.go
+++ b/internal/cmd/collaborator_remove.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/postgres.go
+++ b/internal/cmd/postgres.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/recover.go
+++ b/internal/cmd/recover.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/secrets_migrate.go
+++ b/internal/cmd/secrets_migrate.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/sentinel_service.go
+++ b/internal/cmd/sentinel_service.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/sync_accounts.go
+++ b/internal/cmd/sync_accounts.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (

--- a/internal/cmd/tunnel.go
+++ b/internal/cmd/tunnel.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package cmd
 
 import (


### PR DESCRIPTION
Closes #624.

## What

Adds a **Windows (`windows/amd64`) client-only** build of the `containarium` CLI so Windows users can run it natively (no WSL).

The CLI shares one binary with the daemon. Rather than make the whole daemon cross-compile, this keeps the **daemon on Linux/macOS** and ships a **client-only** binary on Windows: the server-side subcommands are gated `//go:build !windows`, so the Windows binary exposes only the remote-client commands (`create`/`list`/`ssh`/`info`/`connect`/…) — which talk to a daemon over gRPC/HTTP via `internal/client` and are fully portable.

## How

- **Gate 13 daemon-side `internal/cmd` files** `//go:build !windows`: the server subcommands (`daemon`, `sentinel`, `tunnel`) and the direct-DB / host-admin commands (`audit`, `collaborator_*`, `secrets_migrate`, `sync_accounts`, `recover`, `postgres`, `service`) — all of which pull in Linux-only facilities (incus/LXC, eBPF, netlink, iptables). The remote-client commands were already decoupled (they use `internal/client`), so nothing else needed touching.
- **Makefile** `build-all`: add `GOOS=windows GOARCH=amd64 → containarium-windows-amd64.exe`, and include it in `SHA256SUMS` (now 10 release artifacts).
- **release.yml**: upload `containarium-windows-amd64.exe` + a Windows install note.

## Why this shape (not a full daemon/client split)

`containarium daemon` is load-bearing across deployment tooling (systemd units, install scripts, etc.), so a full binary split would be a coordinated migration. This change is **zero-impact** on `containarium daemon` and on linux/macOS builds (still the full binary) — it only adds a client-only Windows target.

## Verification

`GOOS=windows|linux|darwin go build ./cmd/containarium` all succeed; the Windows binary omits the server subcommands and keeps the client ones; `gofmt` clean.

## Deferred (issue open questions)

- MCP-server (`cmd/mcp-server`) Windows build — same pattern, easy follow-up.
- `windows/arm64` — add when there's demand.