### PR TITLE
chore(release): cut v0.26.2 (native Windows CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.2] - 2026-06-09
+
+Native Windows CLI client.
+
+### Added
+
+- **Windows (`windows/amd64`) CLI build + release artifact** (`containarium-windows-amd64.exe`). Windows users can now run the `containarium` CLI natively instead of only via WSL. The binary is **client-only**: the `daemon`/`sentinel`/`tunnel` subcommands and the direct-DB / host-admin commands (which depend on Linux facilities — incus/LXC, eBPF, netlink, iptables) are gated `//go:build !windows`, so the Windows binary exposes the remote-client commands (`create`/`list`/`ssh`/`info`/`connect`/…) that talk to a daemon over gRPC/HTTP. linux/macOS builds are unchanged (full binary, daemon included). (#624)
+
 ## [0.26.1] - 2026-06-09
 
 Wake-on-SSH fix. The v0.26.0 implementation never fired in the real

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.26.1"
+	Version = "0.26.2"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Version bump 0.26.1 → 0.26.2 + CHANGELOG. Tagging `v0.26.2` ships the windows/amd64 client-only CLI (#625) as a release artifact.