### PR TITLE
feat(traffic): source network usage (src/dst IP + bytes) from eBPF per-veth program (#627)

### DIFF
--- a/docs/security/NETWORK-ISOLATION-DESIGN.md
+++ b/docs/security/NETWORK-ISOLATION-DESIGN.md
@@ -352,6 +352,50 @@ network-policy / egress-allowlist message (so egress policy rides desired-state)
 Both land in `Containarium-cloud` first; this section plus
 `CLOUD-ACTUATION-CLIENT-DESIGN.md` are the OSS-side contract they plug into.
 
+## Per-flow accounting → the traffic view (#627)
+
+The same per-veth `TC_INGRESS` program doubles as the traffic
+view's data source. The view (`TrafficService` → webui) was
+wired to the host conntrack collector, which on real backends
+comes up mostly empty: tenants run docker-compose *inside* an
+LXC, so host conntrack sees the LXC/bridge address (post-
+masquerade) rather than the per-tenant container IP the
+collector's IP→name cache is keyed on — the flow is then
+dropped — and byte counts need `nf_conntrack_acct=1`.
+
+The eBPF hook has neither problem. It already parses the flow's
+src/dst IP, and it is keyed by veth ifindex, so **attribution is
+exact** (the ifindex maps 1:1 to a container — no IP cache). The
+program keeps a `flows` map (`BPF_MAP_TYPE_LRU_HASH`, 5-tuple →
+`{packets, bytes, first_ns, last_ns}`) updated for **every**
+observed flow — allowed and would-deny alike, since this is
+usage accounting, not a policy decision. The daemon's enforcer
+polls the map (default 15s), attributes each entry via its
+`attached` ifindex→container map, and feeds the batch to the
+traffic collector, which merges them into
+`GetConnections`/`GetConnectionSummary` alongside any conntrack
+rows.
+
+Properties / limits:
+
+- **EGRESS only.** The veth ingress hook sees the container's
+  outbound (sender) side, so `bytes_sent`/`packets_sent` are
+  populated and the reply direction stays 0. A second hook
+  (veth egress) for reply-byte accounting is a follow-up.
+- **Cumulative, LRU-bounded.** Counters are monotonic per flow;
+  the map self-evicts under a short-lived-flow burst rather than
+  filling. The poll snapshots (does not drain), so the active-
+  connection view stays stable; evicted flows simply drop out on
+  the next full-replace ingest.
+- **Opt-in, backward-compatible.** Gated behind the existing
+  `CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT`. An older object built
+  before the `flows` map still loads and enforces; the daemon
+  logs that flow accounting is unavailable and leaves the poll
+  off until the operator rebuilds `netpolicy.bpf.o`.
+- **Historical persistence** (the `traffic_history` table) is
+  still conntrack-fed; persisting eBPF flows on eviction/close is
+  a follow-up.
+
 ## What this is NOT
 
 - A k8s NetworkPolicy implementation. Different threat model

--- a/experimental/ebpf-phaseA/README.md
+++ b/experimental/ebpf-phaseA/README.md
@@ -166,3 +166,32 @@ containarium network-policy set <tenant> --allow-metadata ...
 Validated on a Linux backend: under enforce with `--allow-cidr 0.0.0.0/0`, traffic
 to `8.8.8.8` passes but `169.254.169.254` is dropped (`deny … dst=169.254.169.254
 … DROPPED`); adding `--allow-metadata` lets it through.
+
+## Per-flow accounting → traffic view (#627)
+
+The program also keeps a `flows` map (`BPF_MAP_TYPE_LRU_HASH`, 5-tuple →
+`{packets, bytes, first_ns, last_ns}`) updated for **every** observed flow
+(allowed and would-deny). The daemon enforcer polls it (`Loader.Flows()`,
+default 15s), attributes each flow to a container by veth ifindex, and feeds the
+traffic collector — so the traffic view shows real src/dst IP + byte counts
+sourced straight from eBPF, independent of conntrack accounting and the IP→name
+cache (both of which come up empty in the common docker-in-LXC topology). EGRESS
+only (the veth ingress hook sees the container's outbound side); reply bytes
+stay 0.
+
+Rebuilding `netpolicy.bpf.o` with the new map is required to enable it — an
+older object still loads and enforces, the daemon just logs that flow accounting
+is off. To validate on a backend (after rebuild + `export
+CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT=...`, with a tenant container running):
+
+```sh
+incus exec <container> -- curl -s https://1.1.1.1 >/dev/null   # generate egress
+# then query the daemon's traffic API (or open the webui traffic view):
+curl -s -H "Authorization: Bearer $JWT" \
+  "$DAEMON/v1/containers/<tenant>-container/connections" | jq .
+```
+
+Expect non-empty rows carrying the container's source IP, the destination
+IP/port, and non-zero `bytes_sent` — with **no** dependency on
+`nf_conntrack_acct` or the conntrack collector matching. Counters are cumulative
+per flow; the LRU map self-evicts idle flows.

--- a/experimental/ebpf-phaseA/netpolicy.bpf.c
+++ b/experimental/ebpf-phaseA/netpolicy.bpf.c
@@ -93,6 +93,42 @@ struct {
 #define STAT_SEEN       0
 #define STAT_WOULD_DENY 1
 
+// Per-flow accounting (issue #627). Every observed flow on a managed veth gets a
+// cumulative bytes/packets tally here, keyed by its 5-tuple, so the daemon can
+// populate the traffic view (src/dst IP + byte counts) straight from eBPF —
+// independent of conntrack accounting and the IP→container cache. Attribution is
+// exact: the ifindex in the key maps 1:1 to a container. Recorded for ALLOWED and
+// would-deny flows alike (it's usage accounting, not a policy decision).
+//
+// The veth ingress hook sees the container's outbound (sender) side, so these
+// counts are the container's EGRESS; reply-direction bytes aren't visible here.
+//
+// LRU_HASH so a burst of short-lived flows self-evicts under pressure rather than
+// filling the map; the daemon reads it on a poll and ages out idle entries.
+struct flow_key {
+    __u32 ifindex;   // host veth — attribution handle (1:1 with a container)
+    __u32 saddr;     // source IPv4, network byte order
+    __u32 daddr;     // destination IPv4, network byte order
+    __u16 sport;     // host byte order
+    __u16 dport;     // host byte order
+    __u8  proto;     // IP protocol number
+    __u8  pad[3];
+};
+
+struct flow_stat {
+    __u64 packets;
+    __u64 bytes;
+    __u64 first_ns;  // bpf_ktime_get_ns at first packet (monotonic)
+    __u64 last_ns;   // bpf_ktime_get_ns at most recent packet (monotonic)
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, struct flow_key);
+    __type(value, struct flow_stat);
+    __uint(max_entries, 65536);
+} flows SEC(".maps");
+
 // Perf event ring for denied flows; the daemon's consumer turns each into an
 // audit row (action=net_deny).
 struct {
@@ -117,6 +153,38 @@ static __always_inline void bump(__u32 idx) {
     __u64 *v = bpf_map_lookup_elem(&stats, &idx);
     if (v)
         __sync_fetch_and_add(v, 1);
+}
+
+// account_flow tallies one packet against its 5-tuple in the flows map (#627).
+// First packet of a flow creates the entry; subsequent packets bump the
+// cumulative byte/packet counters and the last-seen timestamp.
+static __always_inline void account_flow(struct __sk_buff *skb, __u32 ifindex,
+                                         __u32 saddr, __u32 daddr,
+                                         __u16 sport, __u16 dport, __u8 proto) {
+    struct flow_key fk = {};
+    fk.ifindex = ifindex;
+    fk.saddr = saddr;
+    fk.daddr = daddr;
+    fk.sport = sport;
+    fk.dport = dport;
+    fk.proto = proto;
+
+    __u64 now = bpf_ktime_get_ns();
+    __u64 len = skb->len; // full L2+ length of this packet
+
+    struct flow_stat *fs = bpf_map_lookup_elem(&flows, &fk);
+    if (fs) {
+        __sync_fetch_and_add(&fs->packets, 1);
+        __sync_fetch_and_add(&fs->bytes, len);
+        fs->last_ns = now;
+        return;
+    }
+    struct flow_stat nfs = {};
+    nfs.packets = 1;
+    nfs.bytes = len;
+    nfs.first_ns = now;
+    nfs.last_ns = now;
+    bpf_map_update_elem(&flows, &fk, &nfs, BPF_ANY);
 }
 
 SEC("classifier/netpolicy")
@@ -145,6 +213,29 @@ int netpolicy_ingress(struct __sk_buff *skb) {
 
     __u32 saddr = ip->saddr;
     __u32 daddr = ip->daddr;
+
+    // Parse L4 ports once (host byte order), bounds-checked for the verifier.
+    // Used both for per-flow accounting (#627) and the deny audit event below.
+    // ICMP and other L4 protocols carry 0 ports. NOTE: assumes no IP options
+    // (ihl=5), same as the deny path historically did.
+    __u16 sport = 0, dport = 0;
+    if (ip->protocol == IPPROTO_TCP) {
+        struct tcphdr *tcp = (void *)ip + sizeof(*ip);
+        if ((void *)(tcp + 1) <= data_end) {
+            sport = bpf_ntohs(tcp->source);
+            dport = bpf_ntohs(tcp->dest);
+        }
+    } else if (ip->protocol == IPPROTO_UDP) {
+        struct udphdr *udp = (void *)ip + sizeof(*ip);
+        if ((void *)(udp + 1) <= data_end) {
+            sport = bpf_ntohs(udp->source);
+            dport = bpf_ntohs(udp->dest);
+        }
+    }
+
+    // Usage accounting for the traffic view (#627): tally EVERY flow, allowed or
+    // not. Done before the policy decision so a would-deny flow is still counted.
+    account_flow(skb, ifindex, saddr, daddr, sport, dport, ip->protocol);
 
     // Decide whether this flow is allowed under the sender's policy.
     int allowed = 0;
@@ -186,17 +277,7 @@ int netpolicy_ingress(struct __sk_buff *skb) {
     ev.saddr = saddr;
     ev.daddr = daddr;
     ev.proto = ip->protocol;
-
-    // Best-effort L4 dport for the audit row. Bounds-checked for the verifier.
-    if (ip->protocol == IPPROTO_TCP) {
-        struct tcphdr *tcp = (void *)ip + sizeof(*ip);
-        if ((void *)(tcp + 1) <= data_end)
-            ev.dport = bpf_ntohs(tcp->dest);
-    } else if (ip->protocol == IPPROTO_UDP) {
-        struct udphdr *udp = (void *)ip + sizeof(*ip);
-        if ((void *)(udp + 1) <= data_end)
-            ev.dport = bpf_ntohs(udp->dest);
-    }
+    ev.dport = dport; // parsed once above
 
     bpf_perf_event_output(skb, &events, BPF_F_CURRENT_CPU, &ev, sizeof(ev));
 

--- a/internal/netbpf/flows.go
+++ b/internal/netbpf/flows.go
@@ -1,0 +1,68 @@
+package netbpf
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net/netip"
+)
+
+// FlowRecord is one decoded per-flow accounting entry from the BPF `flows` map
+// (issue #627). It carries the flow's 5-tuple — attributed to a container by
+// Ifindex — plus the cumulative byte/packet tally observed on the container's
+// host-veth ingress hook, i.e. the container's EGRESS direction. The wire layout
+// of the key/value must stay in lockstep with `struct flow_key` / `struct
+// flow_stat` in experimental/ebpf-phaseA/netpolicy.bpf.c.
+type FlowRecord struct {
+	Ifindex uint32
+	Saddr   uint32 // source IPv4, network byte order (as carried on the wire)
+	Daddr   uint32 // destination IPv4, network byte order
+	Sport   uint16 // host byte order
+	Dport   uint16 // host byte order
+	Proto   uint8  // IP protocol number (1=ICMP, 6=TCP, 17=UDP)
+	Packets uint64
+	Bytes   uint64
+	FirstNs uint64 // bpf_ktime_get_ns at first packet (monotonic; boot-relative)
+	LastNs  uint64 // bpf_ktime_get_ns at most recent packet (monotonic)
+}
+
+// flowKeySize / flowStatSize are the wire sizes of `struct flow_key` and
+// `struct flow_stat`:
+//
+//	flow_key  = u32 ifindex + u32 saddr + u32 daddr + u16 sport + u16 dport + u8 proto + u8[3] pad
+//	flow_stat = u64 packets + u64 bytes + u64 first_ns + u64 last_ns
+const (
+	flowKeySize  = 20
+	flowStatSize = 32
+)
+
+// Src and Dst render the network-byte-order addresses as netip.Addr, matching
+// DenyEvent.Src/Dst (the wire value is a __u32 holding the 4 IPv4 bytes in
+// network order).
+func (f FlowRecord) Src() netip.Addr { return ipFromBE(f.Saddr) }
+func (f FlowRecord) Dst() netip.Addr { return ipFromBE(f.Daddr) }
+
+// decodeFlowKey fills the 5-tuple fields of rec from a raw `struct flow_key`.
+func decodeFlowKey(b []byte, rec *FlowRecord) error {
+	if len(b) < flowKeySize {
+		return fmt.Errorf("netbpf: flow key sample too short: %d < %d bytes", len(b), flowKeySize)
+	}
+	rec.Ifindex = binary.NativeEndian.Uint32(b[0:4])
+	rec.Saddr = binary.NativeEndian.Uint32(b[4:8])
+	rec.Daddr = binary.NativeEndian.Uint32(b[8:12])
+	rec.Sport = binary.NativeEndian.Uint16(b[12:14])
+	rec.Dport = binary.NativeEndian.Uint16(b[14:16])
+	rec.Proto = b[16]
+	return nil
+}
+
+// decodeFlowStat fills the counter fields of rec from a raw `struct flow_stat`.
+func decodeFlowStat(b []byte, rec *FlowRecord) error {
+	if len(b) < flowStatSize {
+		return fmt.Errorf("netbpf: flow stat sample too short: %d < %d bytes", len(b), flowStatSize)
+	}
+	rec.Packets = binary.NativeEndian.Uint64(b[0:8])
+	rec.Bytes = binary.NativeEndian.Uint64(b[8:16])
+	rec.FirstNs = binary.NativeEndian.Uint64(b[16:24])
+	rec.LastNs = binary.NativeEndian.Uint64(b[24:32])
+	return nil
+}

--- a/internal/netbpf/flows_test.go
+++ b/internal/netbpf/flows_test.go
@@ -1,0 +1,72 @@
+package netbpf
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// encodeFlowKey / encodeFlowStat mirror the C `struct flow_key` / `struct
+// flow_stat` wire layout, so the round-trip test pins the byte offsets the
+// loader's Flows() decode relies on.
+func encodeFlowKey(r FlowRecord) []byte {
+	b := make([]byte, flowKeySize)
+	binary.NativeEndian.PutUint32(b[0:4], r.Ifindex)
+	binary.NativeEndian.PutUint32(b[4:8], r.Saddr)
+	binary.NativeEndian.PutUint32(b[8:12], r.Daddr)
+	binary.NativeEndian.PutUint16(b[12:14], r.Sport)
+	binary.NativeEndian.PutUint16(b[14:16], r.Dport)
+	b[16] = r.Proto
+	return b
+}
+
+func encodeFlowStat(r FlowRecord) []byte {
+	b := make([]byte, flowStatSize)
+	binary.NativeEndian.PutUint64(b[0:8], r.Packets)
+	binary.NativeEndian.PutUint64(b[8:16], r.Bytes)
+	binary.NativeEndian.PutUint64(b[16:24], r.FirstNs)
+	binary.NativeEndian.PutUint64(b[24:32], r.LastNs)
+	return b
+}
+
+func TestDecodeFlow_RoundTrip(t *testing.T) {
+	// 10.100.0.42:51000 -> 1.1.1.1:443, TCP, addresses in network byte order.
+	want := FlowRecord{
+		Ifindex: 59,
+		Saddr:   binary.NativeEndian.Uint32([]byte{10, 100, 0, 42}),
+		Daddr:   binary.NativeEndian.Uint32([]byte{1, 1, 1, 1}),
+		Sport:   51000,
+		Dport:   443,
+		Proto:   6,
+		Packets: 12,
+		Bytes:   8456,
+		FirstNs: 1_000_000_000,
+		LastNs:  3_500_000_000,
+	}
+
+	var got FlowRecord
+	if err := decodeFlowKey(encodeFlowKey(want), &got); err != nil {
+		t.Fatalf("decodeFlowKey: %v", err)
+	}
+	if err := decodeFlowStat(encodeFlowStat(want), &got); err != nil {
+		t.Fatalf("decodeFlowStat: %v", err)
+	}
+	if got != want {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", got, want)
+	}
+	if got.Src().String() != "10.100.0.42" {
+		t.Errorf("Src() = %s, want 10.100.0.42", got.Src())
+	}
+	if got.Dst().String() != "1.1.1.1" {
+		t.Errorf("Dst() = %s, want 1.1.1.1", got.Dst())
+	}
+}
+
+func TestDecodeFlow_ShortSamples(t *testing.T) {
+	var r FlowRecord
+	if err := decodeFlowKey([]byte{1, 2, 3}, &r); err == nil {
+		t.Error("expected error for short flow key")
+	}
+	if err := decodeFlowStat([]byte{1, 2, 3}, &r); err == nil {
+		t.Error("expected error for short flow stat")
+	}
+}

--- a/internal/netbpf/loader.go
+++ b/internal/netbpf/loader.go
@@ -20,6 +20,7 @@ const (
 	mapIPTenant     = "ip_tenant"
 	mapStats        = "stats"
 	mapEvents       = "events"
+	mapFlows        = "flows"
 	statSeen        = uint32(0)
 	statWouldDeny   = uint32(1)
 	statsEntryCount = 2
@@ -161,6 +162,44 @@ func (l *Loader) Stats() (seen, wouldDeny uint64, err error) {
 // EventsMap exposes the perf-event array so the denied-flow consumer (a later
 // increment) can open a perf reader over it.
 func (l *Loader) EventsMap() *ebpf.Map { return l.coll.Maps[mapEvents] }
+
+// HasFlowAccounting reports whether the loaded object carries the per-flow
+// accounting map (#627). It is intentionally NOT required by Load — an older
+// object built before this feature still loads and enforces; the daemon just
+// skips the traffic-flow poll. The operator rebuilds netpolicy.bpf.o to enable
+// it.
+func (l *Loader) HasFlowAccounting() bool { return l.coll.Maps[mapFlows] != nil }
+
+// Flows snapshots the per-flow accounting map (#627): every observed flow on a
+// managed veth with its cumulative byte/packet tally and first/last timestamps.
+// Read-only — entries are aged out by the map's LRU eviction and the caller's
+// idle pruning, NOT drained here, so the cumulative counters stay monotonic for
+// the active-connection view. Returns an error if the object lacks the map
+// (HasFlowAccounting is false).
+func (l *Loader) Flows() ([]FlowRecord, error) {
+	m := l.coll.Maps[mapFlows]
+	if m == nil {
+		return nil, fmt.Errorf("netbpf: flows map not present (rebuild netpolicy.bpf.o?)")
+	}
+	keyBuf := make([]byte, flowKeySize)
+	valBuf := make([]byte, flowStatSize)
+	var out []FlowRecord
+	it := m.Iterate()
+	for it.Next(&keyBuf, &valBuf) {
+		var rec FlowRecord
+		if err := decodeFlowKey(keyBuf, &rec); err != nil {
+			return nil, err
+		}
+		if err := decodeFlowStat(valBuf, &rec); err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	if err := it.Err(); err != nil {
+		return nil, fmt.Errorf("netbpf: iterate flows: %w", err)
+	}
+	return out, nil
+}
 
 // Close detaches every veth link and frees the collection.
 func (l *Loader) Close() error {

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -78,7 +78,7 @@ func TestSendAgentTaskRequiresCallScope(t *testing.T) {
 
 func TestAgentNetworkPolicyConfigDomains(t *testing.T) {
 	t.Run("defaults to the model providers when unset", func(t *testing.T) {
-		os.Unsetenv("CONTAINARIUM_AGENT_EGRESS_DOMAINS")
+		_ = os.Unsetenv("CONTAINARIUM_AGENT_EGRESS_DOMAINS")
 		_, domains, _ := agentNetworkPolicyConfig()
 		if len(domains) != 2 || domains[0] != "api.anthropic.com" {
 			t.Errorf("default domains = %v, want the provider defaults", domains)

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1801,6 +1801,12 @@ func (ds *DualServer) Start(ctx context.Context) error {
 	// logged and the daemon continues without enforcement — it must never block
 	// the daemon from serving.
 	if ds.networkPolicyEnforcer != nil {
+		// #627: let the enforcer feed eBPF per-flow accounting into the traffic
+		// collector so the traffic view shows real src/dst IP + byte counts. Wired
+		// before Start (which launches the poll loop). No-op if either side is off.
+		if ds.trafficCollector != nil {
+			ds.networkPolicyEnforcer.SetFlowSink(ds.trafficCollector)
+		}
 		if err := ds.networkPolicyEnforcer.Start(ctx); err != nil {
 			log.Printf("Warning: network-policy enforcer failed to start: %v (continuing without it)", err)
 			ds.networkPolicyEnforcer = nil

--- a/internal/server/network_policy_enforcer.go
+++ b/internal/server/network_policy_enforcer.go
@@ -14,6 +14,8 @@ import (
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/netbpf"
 	"github.com/footprintai/containarium/internal/netpolicy"
+	"github.com/footprintai/containarium/internal/safecast"
+	"github.com/footprintai/containarium/internal/traffic"
 	"github.com/footprintai/containarium/pkg/core/incus"
 )
 
@@ -26,6 +28,19 @@ const containerSuffix = "-container"
 // truth (robust against dropped bus events); the bus only triggers an early
 // reconcile for latency.
 const defaultNetPolicyReconcileInterval = 10 * time.Second
+
+// defaultFlowPollInterval is how often the enforcer reads the BPF per-flow
+// accounting map (#627) and feeds it to the traffic collector. Shorter than the
+// reconcile interval isn't useful (the counters are cumulative); a few seconds
+// keeps the traffic view fresh without churning the map iterator.
+const defaultFlowPollInterval = 15 * time.Second
+
+// FlowSink receives per-flow accounting records sourced from the eBPF program
+// (#627). *traffic.Collector implements it; kept an interface so the enforcer is
+// testable without the collector.
+type FlowSink interface {
+	IngestEBPFFlows(flows []traffic.EBPFFlow)
+}
 
 // defaultDomainRefreshInterval is how often egress_domains are re-resolved to
 // IPs (Phase C). A fixed interval rather than per-record DNS TTL — TTL-aware
@@ -60,6 +75,9 @@ type NetworkPolicyEnforcer struct {
 	resolver      *DomainResolver // Phase C: egress_domains -> IPs
 	domainRefresh time.Duration
 
+	flowSink FlowSink      // #627: traffic-view flow accounting (nil = disabled)
+	flowPoll time.Duration // how often to read the BPF flows map
+
 	loader *netbpf.Loader
 
 	mu              sync.Mutex
@@ -85,12 +103,18 @@ func NewNetworkPolicyEnforcer(objPath string, store NetworkPolicyStore, registry
 		enforceEnabled:  enforceEnabled,
 		resolver:        NewDomainResolver(nil),
 		domainRefresh:   defaultDomainRefreshInterval,
+		flowPoll:        defaultFlowPollInterval,
 		attached:        make(map[int]string),
 		idName:          make(map[uint32]string),
 		enforced:        make(map[uint32]bool),
 		egressInstalled: make(map[netbpf.EgressEntry]bool),
 	}
 }
+
+// SetFlowSink wires the traffic collector so the enforcer can feed it per-flow
+// accounting read from the BPF flows map (#627). Must be called before Start.
+// Nil leaves flow accounting off.
+func (e *NetworkPolicyEnforcer) SetFlowSink(s FlowSink) { e.flowSink = s }
 
 // Start loads the BPF object, runs an initial reconcile, and launches the
 // perf-ring consumer + the periodic reconcile loop (also woken by container bus
@@ -144,6 +168,35 @@ func (e *NetworkPolicyEnforcer) Start(ctx context.Context) error {
 				log.Printf("[netpolicy] perf: %v", err)
 			})
 		}()
+	}
+
+	// Flow-accounting poll (#627): read the BPF per-flow map on a cadence and
+	// feed it to the traffic collector so the traffic view shows real src/dst IP
+	// + byte counts sourced from eBPF. Only runs when a sink is wired AND the
+	// loaded object carries the flows map (an older object still enforces; the
+	// poll just stays off until the operator rebuilds it).
+	switch {
+	case e.flowSink == nil:
+		// no sink configured — flow accounting disabled
+	case !loader.HasFlowAccounting():
+		log.Printf("[netpolicy] traffic-flow accounting unavailable: loaded BPF object lacks the 'flows' map (rebuild netpolicy.bpf.o to enable #627)")
+	default:
+		e.wg.Add(1)
+		go func() {
+			defer e.wg.Done()
+			t := time.NewTicker(e.flowPoll)
+			defer t.Stop()
+			e.pollFlows() // prime the view immediately rather than after one tick
+			for {
+				select {
+				case <-e.ctx.Done():
+					return
+				case <-t.C:
+					e.pollFlows()
+				}
+			}
+		}()
+		log.Printf("[netpolicy] traffic-flow accounting enabled (poll=%s)", e.flowPoll)
 	}
 
 	// Reconcile loop + bus trigger.
@@ -234,6 +287,81 @@ func (e *NetworkPolicyEnforcer) OnDenyEvent(ctx context.Context, ev netbpf.DenyE
 	}
 	if err := e.audit.Log(ctx, entry); err != nil {
 		log.Printf("[netpolicy] audit deny event: %v", err)
+	}
+}
+
+// pollFlows reads the BPF per-flow accounting map (#627), attributes each flow
+// to a container via the veth ifindex (exact — the map key carries it), and
+// hands the batch to the traffic collector. Flows on a veth that is no longer
+// attached are skipped (the container is gone; its flows age out of the LRU map).
+func (e *NetworkPolicyEnforcer) pollFlows() {
+	if e.loader == nil || e.flowSink == nil {
+		return
+	}
+	records, err := e.loader.Flows()
+	if err != nil {
+		log.Printf("[netpolicy] read flows: %v", err)
+		return
+	}
+	// Snapshot the ifindex -> container attribution under the lock.
+	e.mu.Lock()
+	attached := make(map[int]string, len(e.attached))
+	for idx, name := range e.attached {
+		attached[idx] = name
+	}
+	e.mu.Unlock()
+
+	e.flowSink.IngestEBPFFlows(flowsToEBPF(records, attached, time.Now()))
+}
+
+// flowsToEBPF attributes each BPF flow record to its container via the veth
+// ifindex and renders it as a traffic.EBPFFlow. Records on an unmanaged veth are
+// dropped. Pure (no loader/clock access) so it is unit-testable. Absolute
+// first/last timestamps aren't recoverable from the monotonic ktime stamps, so
+// First is derived as now-duration to preserve the flow's age.
+func flowsToEBPF(records []netbpf.FlowRecord, attached map[int]string, now time.Time) []traffic.EBPFFlow {
+	out := make([]traffic.EBPFFlow, 0, len(records))
+	for _, r := range records {
+		name := attached[int(r.Ifindex)]
+		if name == "" {
+			continue // veth not (or no longer) managed
+		}
+		// The accounting hook sees the container's egress, so the flow's source
+		// IP is the container's own IP.
+		src := r.Src().String()
+		var dur time.Duration
+		if r.LastNs >= r.FirstNs {
+			dur = time.Duration(r.LastNs - r.FirstNs) // both are bpf_ktime_get_ns (ns)
+		}
+		out = append(out, traffic.EBPFFlow{
+			ContainerName: name,
+			ContainerIP:   src,
+			Protocol:      protoName(r.Proto),
+			SrcIP:         src,
+			SrcPort:       r.Sport,
+			DstIP:         r.Dst().String(),
+			DstPort:       r.Dport,
+			Bytes:         safecast.I64FromU64(r.Bytes),
+			Packets:       safecast.I64FromU64(r.Packets),
+			First:         now.Add(-dur), // absolute first/last unknown; preserve duration
+			Last:          now,
+		})
+	}
+	return out
+}
+
+// protoName renders an IP protocol number as the lowercase string the traffic
+// collector's protoStringToEnum expects.
+func protoName(proto uint8) string {
+	switch proto {
+	case 1:
+		return "icmp"
+	case 6:
+		return "tcp"
+	case 17:
+		return "udp"
+	default:
+		return ""
 	}
 }
 

--- a/internal/server/network_policy_enforcer.go
+++ b/internal/server/network_policy_enforcer.go
@@ -331,7 +331,8 @@ func flowsToEBPF(records []netbpf.FlowRecord, attached map[int]string, now time.
 		src := r.Src().String()
 		var dur time.Duration
 		if r.LastNs >= r.FirstNs {
-			dur = time.Duration(r.LastNs - r.FirstNs) // both are bpf_ktime_get_ns (ns)
+			// both are bpf_ktime_get_ns (ns); safecast guards the u64->i64 (Duration) cast
+			dur = time.Duration(safecast.I64FromU64(r.LastNs - r.FirstNs))
 		}
 		out = append(out, traffic.EBPFFlow{
 			ContainerName: name,

--- a/internal/server/network_policy_flows_test.go
+++ b/internal/server/network_policy_flows_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/netbpf"
+)
+
+func beIPv4(a, b, c, d byte) uint32 {
+	return binary.NativeEndian.Uint32([]byte{a, b, c, d})
+}
+
+func TestFlowsToEBPF_AttributesAndMaps(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	records := []netbpf.FlowRecord{
+		{ // managed veth 59 -> web-container
+			Ifindex: 59,
+			Saddr:   beIPv4(10, 100, 0, 42),
+			Daddr:   beIPv4(1, 1, 1, 1),
+			Sport:   51000,
+			Dport:   443,
+			Proto:   6,
+			Packets: 12,
+			Bytes:   8456,
+			FirstNs: 1_000_000_000,
+			LastNs:  3_000_000_000, // 2s old
+		},
+		{ // unmanaged veth 99 -> dropped
+			Ifindex: 99,
+			Saddr:   beIPv4(10, 100, 0, 99),
+			Daddr:   beIPv4(8, 8, 8, 8),
+			Proto:   17,
+			Packets: 1,
+			Bytes:   60,
+		},
+	}
+	attached := map[int]string{59: "web-container"}
+
+	out := flowsToEBPF(records, attached, now)
+	if len(out) != 1 {
+		t.Fatalf("flowsToEBPF returned %d flows, want 1 (unmanaged veth dropped)", len(out))
+	}
+	f := out[0]
+	if f.ContainerName != "web-container" {
+		t.Errorf("ContainerName = %q, want web-container", f.ContainerName)
+	}
+	if f.SrcIP != "10.100.0.42" || f.ContainerIP != "10.100.0.42" {
+		t.Errorf("SrcIP/ContainerIP = %s/%s, want 10.100.0.42", f.SrcIP, f.ContainerIP)
+	}
+	if f.DstIP != "1.1.1.1" || f.DstPort != 443 || f.SrcPort != 51000 {
+		t.Errorf("unexpected ports/dst: src:%d dst:%s:%d", f.SrcPort, f.DstIP, f.DstPort)
+	}
+	if f.Protocol != "tcp" {
+		t.Errorf("Protocol = %q, want tcp", f.Protocol)
+	}
+	if f.Bytes != 8456 || f.Packets != 12 {
+		t.Errorf("Bytes/Packets = %d/%d, want 8456/12", f.Bytes, f.Packets)
+	}
+	if !f.Last.Equal(now) {
+		t.Errorf("Last = %v, want %v", f.Last, now)
+	}
+	if want := now.Add(-2 * time.Second); !f.First.Equal(want) {
+		t.Errorf("First = %v, want %v (now - 2s duration)", f.First, want)
+	}
+}
+
+func TestProtoName(t *testing.T) {
+	for proto, want := range map[uint8]string{1: "icmp", 6: "tcp", 17: "udp", 47: ""} {
+		if got := protoName(proto); got != want {
+			t.Errorf("protoName(%d) = %q, want %q", proto, got, want)
+		}
+	}
+}

--- a/internal/traffic/collector.go
+++ b/internal/traffic/collector.go
@@ -55,6 +55,7 @@ type Collector struct {
 
 	mu          sync.RWMutex
 	connections map[string]*pb.Connection // conntrack ID -> connection
+	ebpfFlows   map[string]*pb.Connection // eBPF flow ID -> connection (#627)
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -84,6 +85,7 @@ func NewCollector(config CollectorConfig, incusClient *incus.Client, store *Stor
 		monitor:     monitor,
 		emitter:     emitter,
 		connections: make(map[string]*pb.Connection),
+		ebpfFlows:   make(map[string]*pb.Connection),
 		ctx:         ctx,
 		cancel:      cancel,
 	}, nil
@@ -219,6 +221,67 @@ func (c *Collector) convertToProto(event *ConntrackEvent, containerName, contain
 	return conn
 }
 
+// EBPFFlow is one per-flow accounting record sourced from the eBPF per-veth
+// network-policy program (issue #627). It is the container's EGRESS as observed
+// on the host-veth ingress hook: Bytes/Packets are cumulative container→peer
+// counts. The reply direction (peer→container) is not visible on that hook, so
+// BytesReceived/PacketsReceived stay 0 — a known v1 limitation noted in the
+// network-isolation design doc.
+type EBPFFlow struct {
+	ContainerName string
+	ContainerIP   string
+	Protocol      string // "tcp" | "udp" | "icmp"
+	SrcIP         string
+	SrcPort       uint16
+	DstIP         string
+	DstPort       uint16
+	Bytes         int64
+	Packets       int64
+	First         time.Time
+	Last          time.Time
+}
+
+// IngestEBPFFlows replaces the collector's eBPF-sourced flow set with a fresh
+// snapshot (the loader hands the daemon the full active set on each poll, so a
+// full replace is correct and prunes flows the LRU map has evicted). These flows
+// are merged into GetConnections / GetConnectionSummary alongside conntrack
+// connections, giving the traffic view real src/dst IP + byte counts on backends
+// where conntrack attribution comes up empty (#627).
+func (c *Collector) IngestEBPFFlows(flows []EBPFFlow) {
+	next := make(map[string]*pb.Connection, len(flows))
+	for _, f := range flows {
+		conn := &pb.Connection{
+			Id:              ebpfFlowID(f),
+			ContainerName:   f.ContainerName,
+			ContainerIp:     f.ContainerIP,
+			Protocol:        protoStringToEnum(f.Protocol),
+			SourceIp:        f.SrcIP,
+			SourcePort:      uint32(f.SrcPort),
+			DestIp:          f.DstIP,
+			DestPort:        uint32(f.DstPort),
+			State:           pb.ConnectionState_CONNECTION_STATE_UNSPECIFIED,
+			Direction:       pb.TrafficDirection_TRAFFIC_DIRECTION_EGRESS,
+			BytesSent:       f.Bytes,
+			PacketsSent:     f.Packets,
+			BytesReceived:   0, // reply direction not visible on the veth ingress hook
+			PacketsReceived: 0,
+			FirstSeen:       timestamppb.New(f.First),
+			LastSeen:        timestamppb.New(f.Last),
+		}
+		next[conn.Id] = conn
+	}
+	c.mu.Lock()
+	c.ebpfFlows = next
+	c.mu.Unlock()
+}
+
+// ebpfFlowID is a stable identifier for an eBPF flow, derived from its 5-tuple
+// and owning container so a flow keeps the same ID across polls. The "ebpf-"
+// prefix keeps it from colliding with conntrack connection IDs.
+func ebpfFlowID(f EBPFFlow) string {
+	return fmt.Sprintf("ebpf-%s-%s-%s:%d-%s:%d", f.ContainerName, f.Protocol, f.SrcIP, f.SrcPort, f.DstIP, f.DstPort)
+}
+
 // emitTrafficEvent emits a traffic event to subscribers
 func (c *Collector) emitTrafficEvent(eventType ConntrackEventType, conn *pb.Connection) {
 	if c.emitter == nil {
@@ -347,6 +410,13 @@ func (c *Collector) GetConnections(containerName string) []*pb.Connection {
 
 	var result []*pb.Connection
 	for _, conn := range c.connections {
+		if containerName == "" || conn.ContainerName == containerName {
+			result = append(result, conn)
+		}
+	}
+	// Merge eBPF-sourced flows (#627). On backends where conntrack attribution
+	// fails (docker-in-LXC, masquerade), these may be the only connections seen.
+	for _, conn := range c.ebpfFlows {
 		if containerName == "" || conn.ContainerName == containerName {
 			result = append(result, conn)
 		}

--- a/internal/traffic/ebpf_flows_test.go
+++ b/internal/traffic/ebpf_flows_test.go
@@ -1,0 +1,106 @@
+package traffic
+
+import (
+	"testing"
+	"time"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// newTestCollector builds a Collector with no conntrack monitor or incus client,
+// suitable for exercising the eBPF flow merge path in isolation. The cache is
+// seeded non-empty so GetConnections skips its incus-backed Refresh.
+func newTestCollector() *Collector {
+	cache := NewContainerCache(nil, "10.100.0.0/24")
+	cache.nameToIP["seed-container"] = "10.100.0.1" // make Size() > 0
+	return &Collector{
+		cache:       cache,
+		connections: make(map[string]*pb.Connection),
+		ebpfFlows:   make(map[string]*pb.Connection),
+	}
+}
+
+func TestIngestEBPFFlows_SurfacesInGetConnections(t *testing.T) {
+	c := newTestCollector()
+
+	now := time.Now()
+	c.IngestEBPFFlows([]EBPFFlow{
+		{
+			ContainerName: "web-container",
+			ContainerIP:   "10.100.0.42",
+			Protocol:      "tcp",
+			SrcIP:         "10.100.0.42",
+			SrcPort:       51000,
+			DstIP:         "1.1.1.1",
+			DstPort:       443,
+			Bytes:         8456,
+			Packets:       12,
+			First:         now.Add(-2 * time.Second),
+			Last:          now,
+		},
+		{
+			ContainerName: "db-container",
+			ContainerIP:   "10.100.0.43",
+			Protocol:      "udp",
+			SrcIP:         "10.100.0.43",
+			SrcPort:       33000,
+			DstIP:         "8.8.8.8",
+			DstPort:       53,
+			Bytes:         120,
+			Packets:       2,
+			First:         now,
+			Last:          now,
+		},
+	})
+
+	// Filtered by container.
+	web := c.GetConnections("web-container")
+	if len(web) != 1 {
+		t.Fatalf("GetConnections(web-container) = %d conns, want 1", len(web))
+	}
+	got := web[0]
+	if got.SourceIp != "10.100.0.42" || got.DestIp != "1.1.1.1" || got.DestPort != 443 {
+		t.Errorf("unexpected 5-tuple: src=%s dst=%s:%d", got.SourceIp, got.DestIp, got.DestPort)
+	}
+	if got.BytesSent != 8456 || got.PacketsSent != 12 {
+		t.Errorf("byte/packet counts = %d/%d, want 8456/12", got.BytesSent, got.PacketsSent)
+	}
+	if got.Direction != pb.TrafficDirection_TRAFFIC_DIRECTION_EGRESS {
+		t.Errorf("direction = %v, want EGRESS", got.Direction)
+	}
+	if got.Protocol != pb.Protocol_PROTOCOL_TCP {
+		t.Errorf("protocol = %v, want TCP", got.Protocol)
+	}
+
+	// Unfiltered returns both eBPF flows.
+	if all := c.GetConnections(""); len(all) != 2 {
+		t.Fatalf("GetConnections(\"\") = %d conns, want 2", len(all))
+	}
+}
+
+func TestIngestEBPFFlows_ReplacesSnapshot(t *testing.T) {
+	c := newTestCollector()
+	c.IngestEBPFFlows([]EBPFFlow{{ContainerName: "web-container", SrcIP: "10.100.0.42", DstIP: "1.1.1.1", Protocol: "tcp", Bytes: 1}})
+	if n := len(c.GetConnections("")); n != 1 {
+		t.Fatalf("after first ingest = %d, want 1", n)
+	}
+	// A fresh snapshot with a different flow set fully replaces the prior one
+	// (flows the LRU map evicted must not linger).
+	c.IngestEBPFFlows([]EBPFFlow{{ContainerName: "db-container", SrcIP: "10.100.0.43", DstIP: "8.8.8.8", Protocol: "udp", Bytes: 2}})
+	got := c.GetConnections("")
+	if len(got) != 1 {
+		t.Fatalf("after replace = %d, want 1", len(got))
+	}
+	if got[0].ContainerName != "db-container" {
+		t.Errorf("stale flow lingered: got %s", got[0].ContainerName)
+	}
+}
+
+func TestIngestEBPFFlows_EmptyClears(t *testing.T) {
+	c := newTestCollector()
+	c.IngestEBPFFlows([]EBPFFlow{{ContainerName: "web-container", SrcIP: "10.100.0.42", DstIP: "1.1.1.1", Protocol: "tcp"}})
+	c.IngestEBPFFlows(nil)
+	if n := len(c.GetConnections("")); n != 0 {
+		t.Errorf("after empty ingest = %d conns, want 0", n)
+	}
+}


### PR DESCRIPTION
Fixes #627.

## Problem

The traffic view (`TrafficService` → webui) is wired but renders mostly
empty on real backends. Its only data source is the host conntrack
collector, which fails in our topology two ways:

1. **Attribution misses.** Tenants run docker-compose *inside* an LXC, so
   host conntrack sees the LXC/bridge address (post-masquerade), not the
   per-tenant container IP the collector's IP→name cache is keyed on. The
   flow is then dropped (`collector.go` `LookupIP` miss).
2. **No byte counts** without `nf_conntrack_acct=1`.

## Approach

Reuse the per-veth `TC_INGRESS` network-policy program (#315 Phase A) as
the data source. It already parses src/dst IP and is keyed by veth
ifindex, so **attribution is exact** — the ifindex maps 1:1 to a
container, no IP cache needed.

**Data plane** (`netpolicy.bpf.c`):
- New `flows` map (`BPF_MAP_TYPE_LRU_HASH`, 5-tuple →
  `{packets, bytes, first_ns, last_ns}`), updated for **every** observed
  flow — allowed and would-deny — since this is usage accounting, not a
  policy decision.
- L4 sport/dport parsed once up front; the deny event reuses the parsed
  dport.

**Control plane:**
- `netbpf.Loader.Flows()` snapshots the map read-only (LRU handles
  eviction). `HasFlowAccounting()` keeps an **older object loading +
  enforcing** with the poll simply off until the operator rebuilds the
  object — no hard break.
- `NetworkPolicyEnforcer` polls the map (default 15s), attributes each
  flow to its container via the veth ifindex, and feeds
  `traffic.Collector`.
- `Collector.IngestEBPFFlows` merges eBPF flows into `GetConnections` /
  `GetConnectionSummary` alongside conntrack rows.

Gated behind the existing `CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT`
opt-in; the conntrack path is unchanged when eBPF is off.

## Limitations (v1)

- **EGRESS only** — the veth ingress hook sees the container's outbound
  side, so `bytes_sent`/`packets_sent` populate and the reply direction
  stays 0. A second (veth egress) hook for reply bytes is a follow-up.
- **Historical persistence** (`traffic_history`) stays conntrack-fed;
  persisting eBPF flows on eviction is a follow-up.
- The traffic view has **no CLI** today (webui/REST only) — noted as a
  separate follow-up against the CLI-first convention; out of scope here.

## Tests

Go unit tests (pass locally):
- `internal/netbpf` — flow key/stat decode round-trip + short-sample
  guards (pins the C↔Go wire layout).
- `internal/server` — ifindex→container attribution mapping + `protoName`.
- `internal/traffic` — collector merge into `GetConnections`, full-replace
  snapshot semantics, empty-clear.

## ⚠️ Before merge — on-backend validation required

This changes the eBPF data plane. The object is never committed (built on
the backend), so it must be **rebuilt and hardware-validated** on a Linux
backend per `experimental/ebpf-phaseA/README.md`:

```sh
clang -O2 -g -target bpf -I/usr/include/$(uname -m)-linux-gnu \
    -c netpolicy.bpf.c -o netpolicy.bpf.o
```

Then, with the daemon pointed at it and a tenant container generating
egress, confirm `GET /v1/containers/<tenant>-container/connections`
returns non-empty rows with correct source IP, dest IP/port, and non-zero
`bytes_sent` — with no dependency on `nf_conntrack_acct`. Verifier must
accept the per-packet map update (LRU hash) on the target kernel.

Drafting until that run is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
