### PR TITLE
feat(netbpf): embed the compiled BPF object so release binaries ship it (no backend clang)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,24 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
+      - name: Compile eBPF network-policy object (#627)
+        # Builds internal/netbpf/netpolicy.bpf.o so the next `make` invocation
+        # auto-enables -tags embed_bpf and bakes the object into the
+        # containarium binary (operators enable it with
+        # CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT=embedded — no on-backend clang).
+        # The runner is little-endian amd64; -target bpfel makes one object that
+        # serves every little-endian backend (amd64/arm64). UAPI-only program, so
+        # portable across kernel versions; the verifier still runs at load time.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libbpf-dev linux-libc-dev
+          make build-bpf
+
       - name: Build all release artifacts
         # `make build-release` builds containarium + mcp-server +
         # agent-box for linux/amd64, darwin/amd64, darwin/arm64 and
-        # writes SHA256SUMS.txt. 9 binaries + 1 checksum file.
+        # writes SHA256SUMS.txt. 9 binaries + 1 checksum file. The eBPF
+        # object built above makes this invocation embed it (-tags embed_bpf).
         run: make build-release VERSION="${GITHUB_REF_NAME#v}"
 
       - name: Set up Node
@@ -192,6 +206,14 @@ jobs:
         # Needed by scripts/bundle/download-deps.sh to resolve transitive
         # .deb dependencies. Runner is ubuntu-latest so apt is present.
         run: sudo apt-get update && sudo apt-get install -y apt-rdepends
+
+      - name: Compile eBPF network-policy object (#627)
+        # Same as the build-and-release job: build the object first so the
+        # bundle's containarium binary embeds it (-tags embed_bpf, auto-enabled
+        # by the Makefile when internal/netbpf/netpolicy.bpf.o is present).
+        run: |
+          sudo apt-get install -y clang llvm libbpf-dev linux-libc-dev
+          make build-bpf
 
       - name: Build per-platform binaries
         # build-bundle depends on build-release; calling explicitly so

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ coverage.html
 Thumbs.db
 ehthumbs.db
 Desktop.ini
+
+# Compiled eBPF object — built by `make build-bpf` for embedding, never committed (#627)
+internal/netbpf/*.bpf.o

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help proto build clean clean-ui clean-all install test lint fmt run-local web-ui swagger-ui build-mcp build-mcp-linux install-mcp build-agent-box build-agent-box-linux build-agent-box-all install-agent-box build-agent-runtime bundle-agent-runtime build-release sidecar-build-otel bundle-download-deps build-bundle build-bundle-all
+.PHONY: help proto build build-bpf clean clean-ui clean-all install test lint fmt run-local web-ui swagger-ui build-mcp build-mcp-linux install-mcp build-agent-box build-agent-box-linux build-agent-box-all install-agent-box build-agent-runtime bundle-agent-runtime build-release sidecar-build-otel bundle-download-deps build-bundle build-bundle-all
 
 # Variables
 BINARY_NAME=containarium
@@ -24,6 +24,20 @@ ifdef VERSION
 endif
 
 GOFLAGS=-v
+
+# eBPF network-policy object (#627 follow-up). `make build-bpf` compiles it into
+# BPF_OBJ; it is gitignored — built in CI / on a backend, never committed. When
+# the object is present, GO_TAGS auto-enables the `embed_bpf` build tag so the
+# containarium binary bakes it in (internal/netbpf/embed_bpf.go). A normal dev
+# build (no object, no clang) leaves GO_TAGS empty and uses the stub. Because
+# $(wildcard) is evaluated at parse time, CI runs `make build-bpf` as a separate
+# invocation before `make build-release`.
+BPF_SRC := experimental/ebpf-phaseA/netpolicy.bpf.c
+BPF_OBJ := internal/netbpf/netpolicy.bpf.o
+GO_TAGS :=
+ifneq ($(wildcard $(BPF_OBJ)),)
+	GO_TAGS := -tags embed_bpf
+endif
 
 # Default target
 help: ## Show this help message
@@ -62,34 +76,41 @@ proto-breaking: ## Check for breaking changes in protobuf definitions
 	@echo "==> Checking for breaking changes..."
 	@buf breaking --against '.git#branch=main'
 
+build-bpf: ## Compile the eBPF network-policy object for embedding (Linux; needs clang + kernel UAPI headers)
+	@echo "==> Compiling eBPF object $(BPF_OBJ)..."
+	@clang -O2 -g -target bpfel \
+		-I/usr/include/$(shell uname -m)-linux-gnu \
+		-c $(BPF_SRC) -o $(BPF_OBJ)
+	@echo "==> eBPF object built: $(BPF_OBJ) ($$(wc -c < $(BPF_OBJ)) bytes). Re-run make to pick up -tags embed_bpf."
+
 build: proto web-ui swagger-ui ## Build the containarium binary (includes Swagger UI)
 	@echo "==> Building containarium..."
 	@mkdir -p $(BUILD_DIR)
-	@go build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) cmd/containarium/main.go
+	@go build $(GOFLAGS) $(GO_TAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) cmd/containarium/main.go
 	@echo "==> Binary built: $(BUILD_DIR)/$(BINARY_NAME)"
 
 build-fast: proto ## Build the containarium binary (skip Swagger UI download, uses CDN)
 	@echo "==> Building containarium (fast mode - CDN fallback)..."
 	@mkdir -p $(BUILD_DIR)
-	@go build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) cmd/containarium/main.go
+	@go build $(GOFLAGS) $(GO_TAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) cmd/containarium/main.go
 	@echo "==> Binary built: $(BUILD_DIR)/$(BINARY_NAME)"
 
 build-linux: proto web-ui swagger-ui ## Build for Linux (for deployment to GCE, includes Swagger UI)
 	@echo "==> Building containarium for Linux..."
 	@mkdir -p $(BUILD_DIR)
-	@GOOS=linux GOARCH=amd64 go build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 cmd/containarium/main.go
+	@GOOS=linux GOARCH=amd64 go build $(GOFLAGS) $(GO_TAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 cmd/containarium/main.go
 	@echo "==> Binary built: $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64"
 
 build-all: proto web-ui swagger-ui ## Build for all platforms (includes Swagger UI)
 	@echo "==> Building for all platforms..."
 	@mkdir -p $(BUILD_DIR)
-	@GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 cmd/containarium/main.go
-	@GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 cmd/containarium/main.go
-	@GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 cmd/containarium/main.go
+	@GOOS=linux GOARCH=amd64 go build $(GO_TAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 cmd/containarium/main.go
+	@GOOS=darwin GOARCH=amd64 go build $(GO_TAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 cmd/containarium/main.go
+	@GOOS=darwin GOARCH=arm64 go build $(GO_TAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 cmd/containarium/main.go
 	# Windows is CLIENT-ONLY: the daemon/sentinel/tunnel + direct-DB admin
 	# subcommands are //go:build !windows, so this binary exposes only the
 	# remote-client commands (create/list/ssh/…). The daemon stays linux/mac.
-	@GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe cmd/containarium/main.go
+	@GOOS=windows GOARCH=amd64 go build $(GO_TAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe cmd/containarium/main.go
 	@echo "==> Binaries built in $(BUILD_DIR)/"
 
 build-mcp: ## Build the MCP server binary

--- a/docs/security/OPERATOR-SECURITY-RUNBOOK.md
+++ b/docs/security/OPERATOR-SECURITY-RUNBOOK.md
@@ -1009,6 +1009,10 @@ out can never silently cut a tenant off.
 
 # 1. Enable the enforcer — OBSERVE only. Resolves policies, attaches the BPF
 #    program, audits would-deny flows. Drops NOTHING.
+#    Value is either the keyword `embedded` (use the object compiled into the
+#    release binary — no clang on the backend) or a path to a custom object:
+CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT=embedded
+#    …or…
 CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT=/etc/containarium/netpolicy.bpf.o
 
 # 2. Arm enforcement — only now does `--mode enforce` actually drop. Without
@@ -1016,13 +1020,25 @@ CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT=/etc/containarium/netpolicy.bpf.o
 CONTAINARIUM_NETWORK_POLICY_ENFORCE=1
 ```
 
-Build the object once per backend (kernel ≥ 6.6 for TCX) from
-`experimental/ebpf-phaseA/netpolicy.bpf.c`:
+#### Where the BPF object comes from
+
+`=embedded` is the normal path: official release binaries (≥ the release that
+ships #629) bake the object in, so there is **nothing to build on the backend**.
+If the daemon logs that no embedded object is present, the binary was built
+without it — set a **path** instead, or use an official release.
+
+A **path** value loads the object from that file. Build one only if you're
+iterating on the program or running a binary without the embedded object
+(kernel ≥ 6.6 for TCX), from `experimental/ebpf-phaseA/netpolicy.bpf.c`:
 
 ```bash
-clang -O2 -g -target bpf -I/usr/include/$(uname -m)-linux-gnu \
+clang -O2 -g -target bpfel -I/usr/include/$(uname -m)-linux-gnu \
     -c netpolicy.bpf.c -o /etc/containarium/netpolicy.bpf.o
 ```
+
+Either way the kernel verifier runs at load time, so a fresh kernel still
+validates the program on first start. The keyword forms `1`/`true`/`yes`/`on`
+are accepted as synonyms for `embedded`.
 
 ### Authoring a policy
 

--- a/experimental/ebpf-phaseA/README.md
+++ b/experimental/ebpf-phaseA/README.md
@@ -32,15 +32,21 @@ Success criteria, run on a real backend:
    `--peer-ip`, same-tenant peer traffic is allowed (no deny event); without it,
    it is would-denied.
 
-## Build the BPF object (on the backend)
+## Build the BPF object
 
 ```sh
-clang -O2 -g -target bpf -I/usr/include/$(uname -m)-linux-gnu \
+clang -O2 -g -target bpfel -I/usr/include/$(uname -m)-linux-gnu \
     -c netpolicy.bpf.c -o netpolicy.bpf.o
 ```
 
 (The multiarch `-I` lets clang's bpf target find `<asm/types.h>`, same as
-Phase 0.)
+Phase 0. `-target bpfel` emits a little-endian object — one object serves every
+little-endian backend, amd64 and arm64.)
+
+For the daemon, `make build-bpf` runs exactly this and stages the object at
+`internal/netbpf/netpolicy.bpf.o` for embedding; the release pipeline does it
+automatically (see "Enabling the enforcer" below). The standalone command here
+is for the validator kit / iterating by path.
 
 ## Run
 
@@ -93,19 +99,42 @@ This validates the load-bearing eBPF path. The daemon-side integration (enforcer
 
 ## Enabling the enforcer in the daemon
 
-The daemon wires all of this up but keeps it **OFF by default**. To turn it on,
-build the object on the backend (above) and point the daemon at it:
+The daemon wires all of this up but keeps it **OFF by default**. The
+`CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT` env var both enables it and selects
+where the object comes from:
 
 ```sh
+# Option 1 — use the object compiled into the release binary (no backend clang).
+export CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT=embedded
+
+# Option 2 — point at a custom / locally-built object by path.
 export CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT=/path/to/netpolicy.bpf.o
+
 # restart the daemon
 ```
 
-When set, the daemon loads the program, reconciles every tenant's stored policy
-(`containarium network-policy set ...`) and live containers into the BPF maps on
-a periodic loop (and on container events), attaches to each container's veth, and
-writes a `network_policy.deny_logged` audit row per would-deny flow. Unset → the
-daemon behaves exactly as before.
+**`embedded`** loads the object baked into the binary at build time. The release
+pipeline runs `make build-bpf` (clang) and builds with `-tags embed_bpf`, so
+official binaries carry it — operators no longer need a compiler on the backend.
+A binary built without the object (a plain `make build`) reports the embedded
+object is absent and the enforcer stays off; use a **path** instead, or build
+your own with:
+
+```sh
+make build-bpf        # compiles internal/netbpf/netpolicy.bpf.o (needs clang)
+make build            # re-run: the Makefile auto-adds -tags embed_bpf
+```
+
+A **path** value is loaded from that file as before — useful for iterating on the
+program without a full rebuild. Either way, the verifier still runs at load time
+on the target kernel.
+
+When enabled, the daemon loads the program, reconciles every tenant's stored
+policy (`containarium network-policy set ...`) and live containers into the BPF
+maps on a periodic loop (and on container events), attaches to each container's
+veth, writes a `network_policy.deny_logged` audit row per would-deny flow, and
+(with the `flows` map) feeds the traffic view (#627). Unset → the daemon behaves
+exactly as before.
 
 ## Phase B — enforcement (dropping)
 

--- a/internal/netbpf/embed_bpf.go
+++ b/internal/netbpf/embed_bpf.go
@@ -1,0 +1,19 @@
+//go:build embed_bpf
+
+package netbpf
+
+import _ "embed"
+
+// bpfObject is the compiled netpolicy BPF object, baked into the binary at build
+// time. It is populated only when building with `-tags embed_bpf`, which the
+// release pipeline enables after `make build-bpf` has compiled the object into
+// internal/netbpf/netpolicy.bpf.o (the file is gitignored — built, never
+// committed). A normal `go build` (no tag) compiles embed_stub.go instead, so
+// developers don't need a BPF toolchain.
+//
+//go:embed netpolicy.bpf.o
+var bpfObject []byte
+
+// EmbeddedObject returns the BPF object compiled into this binary, or nil if
+// this build did not embed one.
+func EmbeddedObject() []byte { return bpfObject }

--- a/internal/netbpf/embed_stub.go
+++ b/internal/netbpf/embed_stub.go
@@ -1,0 +1,9 @@
+//go:build !embed_bpf
+
+package netbpf
+
+// EmbeddedObject returns nil in builds that did not embed a BPF object. The
+// release pipeline builds with `-tags embed_bpf` (after `make build-bpf`) to get
+// the real object via embed_bpf.go; every other build uses this stub so no BPF
+// toolchain or compiled object is required to `go build`.
+func EmbeddedObject() []byte { return nil }

--- a/internal/netbpf/embed_test.go
+++ b/internal/netbpf/embed_test.go
@@ -1,0 +1,42 @@
+package netbpf
+
+import (
+	"strings"
+	"testing"
+)
+
+// In the default (untagged) test build, embed_stub.go is compiled, so no object
+// is baked in.
+func TestEmbeddedObject_NilWithoutTag(t *testing.T) {
+	if obj := EmbeddedObject(); obj != nil {
+		t.Errorf("EmbeddedObject() = %d bytes, want nil in an untagged build", len(obj))
+	}
+}
+
+// Resolve("embedded") must fail clearly (not panic / not attempt a load) when the
+// binary has no embedded object — guiding the operator to a path or a tagged
+// build. This is checked before any kernel/rlimit interaction, so it is safe on
+// every platform.
+func TestResolve_EmbeddedAbsentErrors(t *testing.T) {
+	for _, mode := range []string{"embedded", "1", "TRUE", " on "} {
+		_, err := Resolve(mode)
+		if err == nil {
+			t.Fatalf("Resolve(%q) = nil error, want a no-embedded-object error", mode)
+		}
+		if !strings.Contains(err.Error(), "no embedded BPF object") {
+			t.Errorf("Resolve(%q) error = %q, want it to mention the missing embedded object", mode, err)
+		}
+	}
+}
+
+// A non-keyword value is treated as a filesystem path; a missing file surfaces a
+// stat error naming the path rather than the embedded-object error.
+func TestResolve_PathValueIsLoadedAsFile(t *testing.T) {
+	_, err := Resolve("/no/such/netpolicy.bpf.o")
+	if err == nil {
+		t.Fatal("Resolve(path) = nil error, want a stat error for a missing file")
+	}
+	if strings.Contains(err.Error(), "no embedded BPF object") {
+		t.Errorf("Resolve(path) took the embedded branch: %v", err)
+	}
+}

--- a/internal/netbpf/loader.go
+++ b/internal/netbpf/loader.go
@@ -1,10 +1,12 @@
 package netbpf
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -38,21 +40,62 @@ type Loader struct {
 	links map[int]link.Link // ifindex -> TCX link
 }
 
-// Load reads the compiled BPF object at objPath, loads the collection, and
-// verifies the expected program + maps are present. Build the object with:
+// Resolve loads the netpolicy BPF object from the operator-supplied source. The
+// value comes from CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT and is interpreted as:
 //
-//	clang -O2 -g -target bpf -I/usr/include/$(uname -m)-linux-gnu \
+//   - "embedded" / "1" / "true" / "yes" / "on" → the object compiled into this
+//     binary at build time (release binaries bundle it; see `make build-bpf`).
+//   - anything else → a filesystem path to a netpolicy.bpf.o.
+//
+// This lets release builds enable the feature with a single env flag while a
+// custom/locally-built object can still be pointed at by path.
+func Resolve(value string) (*Loader, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "embedded", "1", "true", "yes", "on":
+		obj := EmbeddedObject()
+		if len(obj) == 0 {
+			return nil, fmt.Errorf("netbpf: no embedded BPF object in this build " +
+				"(release binaries bundle it; for a custom build run `make build-bpf` then " +
+				"build with -tags embed_bpf, or set CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT to a netpolicy.bpf.o path)")
+		}
+		return LoadFromBytes(obj)
+	default:
+		return Load(value)
+	}
+}
+
+// Load reads the compiled BPF object at objPath and loads the collection. Build
+// the object with:
+//
+//	clang -O2 -g -target bpfel -I/usr/include/$(uname -m)-linux-gnu \
 //	    -c experimental/ebpf-phaseA/netpolicy.bpf.c -o netpolicy.bpf.o
 func Load(objPath string) (*Loader, error) {
-	if err := rlimit.RemoveMemlock(); err != nil {
-		return nil, fmt.Errorf("netbpf: RemoveMemlock: %w", err)
-	}
 	if _, err := os.Stat(objPath); err != nil {
 		return nil, fmt.Errorf("netbpf: BPF object %q: %w", objPath, err)
 	}
 	spec, err := ebpf.LoadCollectionSpec(objPath)
 	if err != nil {
 		return nil, fmt.Errorf("netbpf: load spec: %w", err)
+	}
+	return newLoaderFromSpec(spec)
+}
+
+// LoadFromBytes loads the collection from an in-memory BPF object — used for the
+// object embedded into the binary (Resolve "embedded"). Same verification as
+// Load.
+func LoadFromBytes(obj []byte) (*Loader, error) {
+	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(obj))
+	if err != nil {
+		return nil, fmt.Errorf("netbpf: load spec from embedded object: %w", err)
+	}
+	return newLoaderFromSpec(spec)
+}
+
+// newLoaderFromSpec instantiates the collection from a parsed spec and verifies
+// the expected program + maps are present. Shared by Load and LoadFromBytes.
+func newLoaderFromSpec(spec *ebpf.CollectionSpec) (*Loader, error) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("netbpf: RemoveMemlock: %w", err)
 	}
 	coll, err := ebpf.NewCollection(spec)
 	if err != nil {

--- a/internal/server/network_policy_enforcer.go
+++ b/internal/server/network_policy_enforcer.go
@@ -63,7 +63,7 @@ type containerInspector interface {
 // Phase A is observation-only: the program never drops, it emits would-deny
 // events that this enforcer's perf consumer turns into audit rows.
 type NetworkPolicyEnforcer struct {
-	objPath        string
+	objPath        string // BPF object source: a path, or a keyword ("embedded"/"1") → netbpf.Resolve
 	store          NetworkPolicyStore
 	registry       TenantRegistry
 	insp           containerInspector
@@ -121,7 +121,10 @@ func (e *NetworkPolicyEnforcer) SetFlowSink(s FlowSink) { e.flowSink = s }
 // events). Returns an error if the object fails to load (e.g. not on Linux);
 // the caller logs and continues without enforcement.
 func (e *NetworkPolicyEnforcer) Start(ctx context.Context) error {
-	loader, err := netbpf.Load(e.objPath)
+	// objPath is the env value: a filesystem path, or a keyword ("embedded"/"1")
+	// selecting the object compiled into the binary (#627 follow-up). Resolve
+	// picks the right loader.
+	loader, err := netbpf.Resolve(e.objPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Stacked on #628** (base branch `feat/ebpf-traffic-flows`) — review/merge that first; this builds on its `netpolicy.bpf.c` + loader.

## What

Ship the compiled BPF object *inside* the release binary so the network-policy
enforcer (and the #627 traffic-flow accounting) can be enabled with a single env
flag — no clang on the backend.

This started from "should we pick a `.o` per running OS?" The answer is **no**,
and the PR encodes why:

- eBPF is **Linux-only** already (the loader errors on other kernels) — there's
  no macOS/Windows object to choose.
- The program is **UAPI-only** (stable struct offsets), so **one little-endian
  object** (`-target bpfel`) serves every little-endian backend (amd64/arm64)
  across kernel versions. No CO-RE needed, no per-arch matrix.

So we embed **one** object. The verifier still runs at load time on the target
kernel — embedding removes the *compiler* dependency, not the kernel check.

## How

- **`netbpf.Resolve(value)`** — `embedded`/`1`/`true`/`yes`/`on` loads the
  baked-in object (`LoadFromBytes` → `LoadCollectionSpecFromReader`); any other
  value is a filesystem path (`Load`, unchanged). `Load`/`LoadFromBytes` now
  share `newLoaderFromSpec`.
- **`embed_bpf.go`** (`//go:build embed_bpf`, `//go:embed netpolicy.bpf.o`) +
  **`embed_stub.go`** (default, returns nil) — a plain `go build` needs no BPF
  toolchain or object.
- **Makefile** — `make build-bpf` compiles the object into
  `internal/netbpf/netpolicy.bpf.o` (gitignored — built, never committed).
  `GO_TAGS` auto-adds `-tags embed_bpf` when that object is present, so a
  separate `make build-bpf` before `make build*` flips embedding on. Default dev
  builds are untouched.
- **`release.yml`** — both release jobs `apt-get install clang llvm libbpf-dev
  linux-libc-dev` and run `make build-bpf` before `make build-release`, so
  shipped `containarium` binaries embed the object.
- **Enforcer** uses `Resolve`; `objPath` now means "path **or** keyword".

## Operator UX

```sh
export CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT=embedded   # use the baked-in object
# or
export CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT=/path/to/netpolicy.bpf.o  # custom build
```

Security posture **unchanged**: still OFF by default (env unset), enforce still
needs the second opt-in (`CONTAINARIUM_NETWORK_POLICY_ENFORCE=1`). Embedding only
removes the manual build step.

## Tests / verification

- `EmbeddedObject()` is nil without the tag; `Resolve("embedded")` returns a
  clear "no embedded BPF object" error and `Resolve("/path")` takes the file
  branch (unit tests, platform-independent).
- Verified locally: with the object present the Makefile auto-adds `-tags
  embed_bpf` and the tagged build compiles; without it the tagged build fails
  cleanly (`pattern netpolicy.bpf.o: no matching files found`); the built object
  is gitignored.
- `go build ./...`, `go vet`, gofmt clean; existing netbpf/traffic/server tests
  pass.

## Not validated here

The real object still needs the **on-backend verifier/functional run from #628**
— this PR only changes *where the object comes from*, not the program. Once #628
is validated, a tagged release will carry the embedded object end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
