### PR TITLE
chore(release): cut v0.26.3 — eBPF-sourced network usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.3] - 2026-06-10
+
+eBPF-sourced network usage.
+
+### Added
+
+- **Per-container network usage (src/dst IP + bytes) from eBPF.** Network traffic is now sourced from a per-veth eBPF program, giving accurate per-container ingress/egress byte accounting with source/destination IPs. (#628)
+- **Release binaries embed the compiled BPF object.** The eBPF object is embedded at build time, so release binaries ship it directly — no clang/BPF toolchain required on the backend host to run the traffic collector. (#629)
+
 ## [0.26.2] - 2026-06-09
 
 Native Windows CLI client.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.26.2"
+	Version = "0.26.3"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Version bump to **v0.26.3** + CHANGELOG.

Since v0.26.2:
- **#628** — per-container network usage (src/dst IP + bytes) from a per-veth eBPF program
- **#629** — embed the compiled BPF object so release binaries ship it (no backend clang)

After merge: tag `v0.26.3` → release.yml builds + publishes the binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)