### PR TITLE
fix(login): conform auto-generated device name to the cloud charset (#634)

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -268,11 +268,56 @@ func pickLoginServer(explicit string) string {
 // "just work". The cost is one extra (revocable) token per login,
 // prunable in the cloud's API-tokens UI — a far better failure mode than
 // a silent 10-minute strand.
+//
+// The default is also conformed to the cloud's device_name charset
+// (#634): "<user>@<host>" carries '@', which is outside the allowed set
+// [-_.() a-zA-Z0-9], so an unsanitized default 400s on every login. An
+// explicit override is NOT sanitized — the user owns that string.
 func deviceName(override string) string {
 	if override != "" {
 		return override
 	}
-	return defaultDeviceBase() + "-" + shortDeviceSuffix()
+	return defaultDeviceName(defaultDeviceBase(), shortDeviceSuffix())
+}
+
+// allowedDeviceNameLen is the cloud's device_name cap (1-64 chars).
+const allowedDeviceNameLen = 64
+
+// defaultDeviceName joins the base + random suffix and conforms the result
+// to the cloud's device_name validation: 1-64 chars of [-_.() a-zA-Z0-9]
+// (#634). Disallowed runes in the base are mapped to '-'; the base is then
+// clamped so "<base>-<suffix>" fits the cap, keeping the suffix intact (it's
+// what guarantees the per-login uniqueness from #456).
+func defaultDeviceName(base, suffix string) string {
+	clean := sanitizeDeviceLabel(base)
+	if max := allowedDeviceNameLen - len(suffix) - 1; max < 1 {
+		clean = "" // suffix alone already fills the budget
+	} else if len(clean) > max {
+		clean = clean[:max] // safe: sanitizeDeviceLabel emits ASCII only
+	}
+	clean = strings.Trim(clean, "- ")
+	if clean == "" {
+		return suffix
+	}
+	return clean + "-" + suffix
+}
+
+// sanitizeDeviceLabel maps a label to the cloud's allowed device_name
+// charset [-_.() a-zA-Z0-9], replacing any other rune (e.g. '@' in
+// <user>@<host>, or '\' in a Windows DOMAIN\user) with '-'. Output is
+// ASCII-only, so byte-slicing it for the length clamp is safe.
+func sanitizeDeviceLabel(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '-', r == '_', r == '.', r == '(', r == ')', r == ' ':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
 }
 
 // defaultDeviceBase builds the stable "<user>@<host>" portion of the

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -480,9 +481,9 @@ func TestDeviceName_DefaultIsAutoDisambiguated(t *testing.T) {
 		t.Fatalf("explicit override mutated: %q", got)
 	}
 
-	// The default name starts with the stable "<user>@<host>" base and
-	// appends "-<suffix>".
-	base := defaultDeviceBase()
+	// The default name starts with the sanitized "<user>@<host>" base
+	// (charset-conformed for the cloud, #634) and appends "-<suffix>".
+	base := sanitizeDeviceLabel(defaultDeviceBase())
 	a := deviceName("")
 	if !strings.HasPrefix(a, base+"-") {
 		t.Fatalf("default %q should start with base %q + '-'", a, base)
@@ -499,6 +500,49 @@ func TestDeviceName_DefaultIsAutoDisambiguated(t *testing.T) {
 		if len(suffix) != 6 {
 			t.Errorf("suffix %q (from %q) is not 6 chars", suffix, n)
 		}
+	}
+}
+
+// cloudDeviceNameRe mirrors the cloud's device_name validation
+// (#634): 1-64 chars of [-_.() a-zA-Z0-9].
+var cloudDeviceNameRe = regexp.MustCompile(`^[-_.() a-zA-Z0-9]{1,64}$`)
+
+// TestDeviceName_DefaultMatchesCloudCharset guards #634: the auto-generated
+// default must satisfy the cloud's device_name validation with no user
+// action — the old "<user>@<host>" default carried '@' and 400'd every login.
+func TestDeviceName_DefaultMatchesCloudCharset(t *testing.T) {
+	got := deviceName("")
+	if !cloudDeviceNameRe.MatchString(got) {
+		t.Errorf("default device name %q does not match cloud charset %s", got, cloudDeviceNameRe)
+	}
+	if strings.Contains(got, "@") {
+		t.Errorf("default device name %q still contains '@'", got)
+	}
+}
+
+func TestDefaultDeviceName_SanitizesAndClamps(t *testing.T) {
+	// '@' (user@host) and '\' (Windows DOMAIN\user) map to '-'.
+	if got := defaultDeviceName("alice@laptop.local", "abc123"); got != "alice-laptop.local-abc123" {
+		t.Errorf("sanitize @ : got %q", got)
+	}
+	if got := defaultDeviceName(`CORP\bob`, "abc123"); got != "CORP-bob-abc123" {
+		t.Errorf("sanitize backslash: got %q", got)
+	}
+	// Over-long base is clamped so "<base>-<suffix>" fits 64 chars, suffix kept.
+	long := defaultDeviceName(strings.Repeat("x", 200), "abc123")
+	if len(long) > allowedDeviceNameLen {
+		t.Errorf("clamped name %q exceeds %d chars (len %d)", long, allowedDeviceNameLen, len(long))
+	}
+	if !strings.HasSuffix(long, "-abc123") {
+		t.Errorf("clamp dropped the suffix: %q", long)
+	}
+	if !cloudDeviceNameRe.MatchString(long) {
+		t.Errorf("clamped name %q violates cloud charset", long)
+	}
+	// An all-disallowed base trims to empty → fall back to the bare suffix
+	// (still a valid, non-empty device name).
+	if got := defaultDeviceName("@@@", "abc123"); got != "abc123" {
+		t.Errorf("all-disallowed base: got %q, want bare suffix", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #634.

## Problem

`containarium login --server=https://<cloud-host>` (and the no-flag default,
which already targets the hosted cloud) failed for every user who didn't pass
`--device-name`:

```
Error: open CLI session: status 400:
{"code":3,"message":"device_name must be 1-64 chars of [-_.() a-zA-Z0-9]"}
```

The CLI auto-generates the device name as `<user>@<host>-<rand>`
(`defaultDeviceBase()` → `fmt.Sprintf("%s@%s", who, host)`), but **`@` is not in
the cloud's allowed set** `[-_.() a-zA-Z0-9]`. So the default 400'd on every
login and the only workaround was passing `--device-name` with a `@`-free value
— which made it look like a device name was *required*. (Windows `DOMAIN\user`
hits the same wall via `\`.)

## Fix

Conform the **auto-generated default** to the cloud's charset:

- `sanitizeDeviceLabel` maps any rune outside `[-_.() a-zA-Z0-9]` to `-`
  (so `alice@laptop` → `alice-laptop`, `CORP\bob` → `CORP-bob`).
- `defaultDeviceName` clamps `<base>-<suffix>` to 64 chars, **keeping the
  random suffix** that provides the per-login uniqueness from #456, and falls
  back to the bare suffix if the base sanitizes to empty.
- An explicit `--device-name` is **unchanged** — still passed verbatim; the
  user owns that string (an invalid one still gets the clear 400).

## Tests

- `TestDeviceName_DefaultMatchesCloudCharset` — default matches
  `^[-_.() a-zA-Z0-9]{1,64}$` and contains no `@`.
- `TestDefaultDeviceName_SanitizesAndClamps` — `@`/`\` sanitization, over-long
  clamp (suffix preserved, ≤64), all-disallowed base → bare suffix.
- Updated `TestDeviceName_DefaultIsAutoDisambiguated` to expect the sanitized base.

## Note

The default server is already `https://cloud.containarium.dev`
(`login.go` `defaultLoginServer`), so `containarium login` with no `--server`
targets the hosted cloud — no change needed there. Users hitting the old
behaviour were likely on a stale binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
