### PR TITLE
fix(login): show real identity after login + treat SSH-key 409 as success

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -232,6 +233,41 @@ type sessionStatusResp struct {
 	ExpiresAt string `json:"expiresAt,omitempty"`
 }
 
+// emailFromToken best-effort extracts a human identity from a JWT access
+// token WITHOUT verifying its signature — display only. The cloud's
+// CLI-session-status response doesn't carry the user email (identity lives in
+// the token itself, see sessionStatusResp), so we read it from the token's
+// claims to label the login ("Logged in as …") and persist it for `whoami`.
+// Returns "" for anything that isn't a decodable JWT, so the caller falls back
+// gracefully (previously every login showed "unknown user", #634 follow-up).
+func emailFromToken(tok string) string {
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		return "" // not a JWT (e.g. an opaque token) — nothing to decode
+	}
+	// JWT segments are unpadded base64url; tolerate accidental padding too.
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(parts[1], "="))
+	if err != nil {
+		return ""
+	}
+	var claims struct {
+		Email             string `json:"email"`
+		PreferredUsername string `json:"preferred_username"`
+		Sub               string `json:"sub"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	switch {
+	case claims.Email != "":
+		return claims.Email
+	case claims.PreferredUsername != "":
+		return claims.PreferredUsername
+	default:
+		return claims.Sub
+	}
+}
+
 // loginHTTPClient is the unauthenticated HTTP client used by the
 // device-flow handshake. Kept private so nothing else accidentally
 // uses it.
@@ -434,10 +470,17 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// 3. Persist credentials.
+	// 3. Persist credentials. The status response doesn't carry the user
+	//    email (identity lives in the token), so recover it from the token's
+	//    JWT claims for the banner + `whoami`; falls back to "" if the token
+	//    isn't a decodable JWT.
+	email := status.UserEmail
+	if email == "" {
+		email = emailFromToken(status.Token)
+	}
 	creds := credentials.ServerCreds{
 		Token:     status.Token,
-		UserEmail: status.UserEmail,
+		UserEmail: email,
 		OrgID:     status.OrgID,
 		IssuedAt:  time.Now().UTC(),
 	}
@@ -463,7 +506,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("save credentials: %w", err)
 	}
 
-	who := status.UserEmail
+	who := email
 	if who == "" {
 		who = "unknown user"
 	}

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -543,6 +544,29 @@ func TestDefaultDeviceName_SanitizesAndClamps(t *testing.T) {
 	// (still a valid, non-empty device name).
 	if got := defaultDeviceName("@@@", "abc123"); got != "abc123" {
 		t.Errorf("all-disallowed base: got %q, want bare suffix", got)
+	}
+}
+
+// TestEmailFromToken covers the identity-from-JWT recovery used for the
+// "Logged in as …" banner (the cloud session-status response omits the email).
+func TestEmailFromToken(t *testing.T) {
+	mk := func(claims string) string {
+		return "hdr." + base64.RawURLEncoding.EncodeToString([]byte(claims)) + ".sig"
+	}
+	cases := []struct{ name, tok, want string }{
+		{"email claim wins", mk(`{"email":"alice@example.com","sub":"u1"}`), "alice@example.com"},
+		{"preferred_username fallback", mk(`{"preferred_username":"alice","sub":"u1"}`), "alice"},
+		{"sub fallback", mk(`{"sub":"user-123"}`), "user-123"},
+		{"empty claims", mk(`{}`), ""},
+		{"opaque non-jwt token", "opaque-api-token", ""},
+		{"too few segments", "a.b", ""},
+		{"bad base64 payload", "hdr.!!!notb64!!!.sig", ""},
+		{"non-json payload", "hdr." + base64.RawURLEncoding.EncodeToString([]byte("not json")) + ".sig", ""},
+	}
+	for _, c := range cases {
+		if got := emailFromToken(c.tok); got != c.want {
+			t.Errorf("%s: emailFromToken() = %q, want %q", c.name, got, c.want)
+		}
 	}
 }
 

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -277,6 +277,12 @@ func (c *sshHTTPClient) doJSON(ctx context.Context, method, path string, body, o
 		// can fall through gracefully — matching ttl.go's posture.
 		return status.Errorf(codes.Unimplemented, "%s %s: route not found (server may not support this RPC yet)", method, path)
 	}
+	if resp.StatusCode == http.StatusConflict {
+		// 409 = the resource already exists (e.g. this SSH key is already
+		// registered). Surface it as a typed AlreadyExists so callers can
+		// treat re-registration as idempotent success rather than a failure.
+		return status.Errorf(codes.AlreadyExists, "%s %s: %s", method, path, strings.TrimSpace(string(rb)))
+	}
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(rb)))
 	}
@@ -392,6 +398,13 @@ func runSSHSetup(cmd *cobra.Command, args []string) error {
 	if isUnimplemented(err) {
 		fmt.Fprintf(out, "\n⚠ SSH-key registration not yet supported by %s (UserService.AddSSHKey returned Unimplemented).\n", srv)
 		fmt.Fprintf(out, "  Your key is on disk at %s — once the cloud-side endpoint ships, re-run `containarium ssh setup`.\n", source)
+		return nil
+	}
+	if isAlreadyExists(err) {
+		// Re-registering the same key is a no-op, not a failure. This is the
+		// common case on a repeat `containarium login` from the same machine —
+		// report success so the post-login banner doesn't look like an error.
+		fmt.Fprintf(out, "✓ SSH key %q already registered with %s — nothing to do\n", name, srv)
 		return nil
 	}
 	if err != nil {

--- a/internal/cmd/ttl.go
+++ b/internal/cmd/ttl.go
@@ -224,6 +224,18 @@ func isUnimplemented(err error) bool {
 	return false
 }
 
+// isAlreadyExists reports whether err is a gRPC AlreadyExists (a 409 from the
+// REST surface, see sshHTTPClient.doJSON). Callers use it to treat a duplicate
+// create — e.g. re-registering an SSH key already on file — as idempotent
+// success rather than a hard failure.
+func isAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	s, ok := status.FromError(err)
+	return ok && s.Code() == codes.AlreadyExists
+}
+
 // ttlClientSet / ttlClientGet / ttlClientUnset are thin wrappers over the
 // transport client (grpc or http per the global httpMode flag), mirroring
 // how scale_down.go's toggleAutoSleepViaServer dispatches.

--- a/internal/cmd/ttl_test.go
+++ b/internal/cmd/ttl_test.go
@@ -175,3 +175,23 @@ func TestIsUnimplemented(t *testing.T) {
 		})
 	}
 }
+
+func TestIsAlreadyExists(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is not AlreadyExists", nil, false},
+		{"plain error is not AlreadyExists", errors.New("boom"), false},
+		{"gRPC AlreadyExists is detected", status.Errorf(codes.AlreadyExists, "dup"), true},
+		{"gRPC Unimplemented is not AlreadyExists", status.Errorf(codes.Unimplemented, "nope"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAlreadyExists(tt.err); got != tt.want {
+				t.Errorf("isAlreadyExists(%v) = %v; want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-on polish to the login flow (after #635 made `containarium login` work
with no flags). Two warts from a real login session:

```
✓ Logged in as unknown user
...
⚠ SSH key setup skipped: register key: POST /v1/user/ssh-keys: status 409:
  {"code":6,"message":"ssh key already registered"}
```

## 1. "Logged in as unknown user"

The cloud's CLI-session-status response doesn't carry the user email — identity
lives in the token (see the `sessionStatusResp` comment). So `status.UserEmail`
was always empty and the banner (plus `whoami`, which reads the persisted
`creds.UserEmail`) showed "unknown user" / a dash.

**Fix:** recover the email from the access token's JWT claims
(`email` → `preferred_username` → `sub`), **display-only — no signature
verification** (it's our own freshly-minted token). Populates the banner and the
persisted credential. Safe fallback: returns `""` for anything that isn't a
decodable 3-segment JWT, so opaque tokens just keep the prior "unknown user"
behaviour rather than erroring.

## 2. SSH key 409 treated as failure

Re-registering the same key on a repeat login from the same machine is
idempotent, but the 409 was surfaced as `⚠ SSH key setup skipped: … status
409`, which reads like something broke.

**Fix:** `sshHTTPClient.doJSON` now maps `409` to a typed gRPC `AlreadyExists`
(mirroring the existing 501/404 → `Unimplemented` handling); `runSSHSetup`
treats it via a new `isAlreadyExists` helper and prints
`✓ SSH key "<name>" already registered with <server> — nothing to do`,
returning nil. The post-login banner no longer looks like an error.

## Tests

- `TestEmailFromToken` — email/username/sub precedence, empty claims, opaque
  (non-JWT) token, too-few-segments, bad base64, non-JSON payload all → safe
  result.
- `TestIsAlreadyExists` — nil / plain error / `AlreadyExists` / other gRPC code.
- Existing device-name + login-flow + SSH tests unchanged and green.

Net effect: `containarium login` from a returning machine now ends with
`✓ Logged in as you@example.com` and `✓ SSH key already registered — nothing to
do`, no scary warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
