### PR TITLE
feat(login): cloud uses the API token for box access, not an SSH key

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -275,6 +275,16 @@ func loginHTTPClient() *http.Client {
 	return &http.Client{Timeout: loginHTTPTimeout}
 }
 
+// isCloudServer reports whether srv is the managed cloud rather than a
+// self-hosted OSS daemon. The two have different box-access models — cloud
+// authenticates with the API token (`containarium connect`), self-hosted with
+// the user's SSH key — so the post-login flow branches on it. Detection keys off
+// the cloud apex host (defaultLoginServer), normalized so an explicit --server
+// pointing at the cloud is recognized too.
+func isCloudServer(srv string) bool {
+	return credentials.NormalizeServer(srv) == credentials.NormalizeServer(defaultLoginServer)
+}
+
 // pickLoginServer resolves the effective server URL for login:
 // the explicit flag wins, otherwise the constant default. We do
 // NOT consult $CONTAINARIUM_SERVER here — that env var is for the
@@ -543,6 +553,20 @@ func runLogin(cmd *cobra.Command, args []string) error {
 // force-on in CI.
 func maybeRunPostLoginSSHSetup(out io.Writer, srv string) {
 	if loginNoSSHSetup {
+		return
+	}
+
+	// Two access models:
+	//   - Cloud: the API token you just minted IS the credential.
+	//     `containarium connect <box>` turns it into a shell with a managed key
+	//     — there's no personal SSH key to register. So we skip key registration
+	//     and point at connect.
+	//   - Self-hosted (OSS): boxes are reached over plain `ssh` with the user's
+	//     own key, so the registration flow below applies.
+	// --with-ssh-setup forces the key flow even against the cloud, for users who
+	// still want plain `ssh user@host`.
+	if isCloudServer(srv) && !loginWithSSHSetup {
+		fmt.Fprintf(out, "\nOpen a shell on a box:  containarium connect <box>\n")
 		return
 	}
 

--- a/internal/cmd/login_ssh_test.go
+++ b/internal/cmd/login_ssh_test.go
@@ -243,3 +243,46 @@ func TestReadYesNo_Defaults(t *testing.T) {
 		})
 	}
 }
+
+// TestPostLoginSSHSetup_CloudSkipsKeyRegistration: against the cloud, box
+// access is token-based (`containarium connect`), so login must NOT prompt to
+// register a personal SSH key — it points at connect instead. Guards the
+// two-path model (cloud=API key, OSS=SSH key).
+func TestPostLoginSSHSetup_CloudSkipsKeyRegistration(t *testing.T) {
+	withSSHLoginHome(t)
+	loginWithSSHSetup = false
+	// A reader that WOULD answer "yes" — proves we never reach the prompt.
+	loginPromptReader = strings.NewReader("y\n")
+
+	var buf bytes.Buffer
+	maybeRunPostLoginSSHSetup(&buf, defaultLoginServer)
+
+	out := buf.String()
+	if !strings.Contains(out, "containarium connect") {
+		t.Errorf("cloud login should point at `containarium connect`; got:\n%s", out)
+	}
+	if strings.Contains(out, "Register this machine's SSH key") {
+		t.Errorf("cloud login must not prompt for SSH-key registration; got:\n%s", out)
+	}
+}
+
+// TestPostLoginSSHSetup_CloudWithFlagStillRegisters: --with-ssh-setup is the
+// escape hatch — a cloud user who wants plain `ssh` can still force key
+// registration. We assert we get PAST the connect-skip into the key flow
+// (it then fails to reach a real server, which is fine for this check).
+func TestPostLoginSSHSetup_CloudWithFlagStillRegisters(t *testing.T) {
+	withSSHLoginHome(t)
+	withSSHHome(t) // isolate ~/.ssh so a key can be located/generated
+	loginWithSSHSetup = true
+
+	var buf bytes.Buffer
+	maybeRunPostLoginSSHSetup(&buf, defaultLoginServer)
+
+	out := buf.String()
+	if strings.Contains(out, "containarium connect") {
+		t.Errorf("--with-ssh-setup should bypass the cloud connect-skip; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Registering as") && !strings.Contains(out, "Generated") && !strings.Contains(out, "Using existing key") {
+		t.Errorf("expected the key-registration flow to run; got:\n%s", out)
+	}
+}

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -570,6 +570,26 @@ func TestEmailFromToken(t *testing.T) {
 	}
 }
 
+func TestIsCloudServer(t *testing.T) {
+	cases := []struct {
+		srv  string
+		want bool
+	}{
+		{defaultLoginServer, true},
+		{"https://cloud.containarium.dev", true},
+		{"https://cloud.containarium.dev/", true}, // trailing slash normalized
+		{"https://CLOUD.containarium.DEV", true},  // host case-insensitive
+		{"https://self-hosted.example.com", false},
+		{"http://127.0.0.1:8080", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isCloudServer(c.srv); got != c.want {
+			t.Errorf("isCloudServer(%q) = %v, want %v", c.srv, got, c.want)
+		}
+	}
+}
+
 func TestShortDeviceSuffix_HexAndVaries(t *testing.T) {
 	seen := map[string]bool{}
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
Makes the two box-access models explicit, and stops the cloud login flow from
asking users to register an SSH key.

## The two paths

| Path | Credential | Box access |
|---|---|---|
| **Cloud** | the API token from `containarium login` | `containarium connect <box>` — already turns the token into a shell with a *managed* key; the user never touches an SSH key |
| **Self-hosted (OSS)** | the user's own SSH key | plain `ssh user@host` after `ssh setup` registers the pubkey |

The post-login *"Register this machine's SSH key as …? [Y/n]"* prompt belongs to
the **OSS** path. Surfacing it during **cloud** login was the source of the
confusing prompt (and the duplicate-key `409`): on the cloud the token *is* the
credential, so there's nothing to register.

## Change

`maybeRunPostLoginSSHSetup` now branches on `isCloudServer(srv)`:

- **Cloud** → skip key registration, print `Open a shell on a box: containarium connect <box>`.
- **Self-hosted** → unchanged SSH-key registration flow.
- `--with-ssh-setup` is the escape hatch: a cloud user who still wants plain
  `ssh user@host` can force the key flow.

`isCloudServer` matches the normalized server host against the cloud apex
(`defaultLoginServer`), so both the no-flag default and an explicit
`--server=https://cloud.containarium.dev` are recognized.

## Tests

- `TestIsCloudServer` — default / explicit / trailing-slash / case / self-hosted / empty.
- `TestPostLoginSSHSetup_CloudSkipsKeyRegistration` — cloud login points at
  `connect` and never prompts (even with a "yes" reader queued).
- `TestPostLoginSSHSetup_CloudWithFlagStillRegisters` — `--with-ssh-setup`
  bypasses the skip.
- Existing A7 tests run against httptest (non-cloud) servers → still exercise
  the SSH-key path unchanged. Full `internal/cmd` package green.

## Net effect

A cloud `containarium login` now ends:

```
✓ Logged in as you@example.com
  Open a shell on a box:  containarium connect <box>
```

No SSH-key prompt, no 409. Self-hosted is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
