### PR TITLE
feat(login): per-server access model (prefer server signal, cache it, drop hostname guess)

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -280,34 +280,25 @@ func loginHTTPClient() *http.Client {
 	return &http.Client{Timeout: loginHTTPTimeout}
 }
 
-// Box-access models. A server is reached either by presenting the API token
-// (cloud — `containarium connect`) or by registering the user's SSH key
-// (self-hosted). Stored per-server in the credentials file.
-const (
-	accessModelToken  = "token"
-	accessModelSSHKey = "sshKey"
-)
-
 // resolveAccessModel decides how box access works for srv. The server's own
 // declaration wins (the cloud will return "accessModel" in the session
 // response); when it's absent or unrecognized, fall back to the host heuristic
 // — the cloud apex is token-based, everything else is SSH-key-based. This is the
 // authoritative-signal-with-bootstrap-fallback from the #637 discussion.
-func resolveAccessModel(declared, srv string) string {
-	switch declared {
-	case accessModelToken, accessModelSSHKey:
-		return declared
+func resolveAccessModel(declared, srv string) credentials.AccessModel {
+	if m := credentials.AccessModel(declared); m.Known() {
+		return m
 	}
 	if isCloudServer(srv) {
-		return accessModelToken
+		return credentials.AccessModelToken
 	}
-	return accessModelSSHKey
+	return credentials.AccessModelSSHKey
 }
 
 // accessModelFor returns the access model cached for srv in the credentials
 // file, or "" if unknown. Best-effort: any load error yields "" so callers
 // degrade gracefully rather than failing.
-func accessModelFor(srv string) string {
+func accessModelFor(srv string) credentials.AccessModel {
 	path, err := credentials.DefaultPath()
 	if err != nil {
 		return ""
@@ -601,7 +592,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 // as "no" because hitting people with a key-registration in CI
 // without an explicit opt-in is hostile. Use --with-ssh-setup to
 // force-on in CI.
-func maybeRunPostLoginSSHSetup(out io.Writer, srv, accessModel string) {
+func maybeRunPostLoginSSHSetup(out io.Writer, srv string, accessModel credentials.AccessModel) {
 	if loginNoSSHSetup {
 		return
 	}
@@ -615,7 +606,7 @@ func maybeRunPostLoginSSHSetup(out io.Writer, srv, accessModel string) {
 	//     user's own key, so the registration flow below applies.
 	// --with-ssh-setup forces the key flow even on a token server, for users who
 	// still want plain `ssh user@host`.
-	if accessModel == accessModelToken && !loginWithSSHSetup {
+	if accessModel == credentials.AccessModelToken && !loginWithSSHSetup {
 		fmt.Fprintf(out, "\nOpen a shell on a box:  containarium connect <box>\n")
 		return
 	}

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -231,6 +231,11 @@ type sessionStatusResp struct {
 	OrgID     string `json:"orgId,omitempty"`
 	// ExpiresAt is RFC3339; absent or empty means non-expiring.
 	ExpiresAt string `json:"expiresAt,omitempty"`
+	// AccessModel, when the server declares it ("token" | "sshKey"), tells the
+	// CLI how box access works so it doesn't have to guess from the hostname
+	// (#637 follow-up). Absent on servers that don't yet emit it — the CLI then
+	// falls back to the host heuristic (see resolveAccessModel).
+	AccessModel string `json:"accessModel,omitempty"`
 }
 
 // emailFromToken best-effort extracts a human identity from a JWT access
@@ -275,12 +280,53 @@ func loginHTTPClient() *http.Client {
 	return &http.Client{Timeout: loginHTTPTimeout}
 }
 
+// Box-access models. A server is reached either by presenting the API token
+// (cloud — `containarium connect`) or by registering the user's SSH key
+// (self-hosted). Stored per-server in the credentials file.
+const (
+	accessModelToken  = "token"
+	accessModelSSHKey = "sshKey"
+)
+
+// resolveAccessModel decides how box access works for srv. The server's own
+// declaration wins (the cloud will return "accessModel" in the session
+// response); when it's absent or unrecognized, fall back to the host heuristic
+// — the cloud apex is token-based, everything else is SSH-key-based. This is the
+// authoritative-signal-with-bootstrap-fallback from the #637 discussion.
+func resolveAccessModel(declared, srv string) string {
+	switch declared {
+	case accessModelToken, accessModelSSHKey:
+		return declared
+	}
+	if isCloudServer(srv) {
+		return accessModelToken
+	}
+	return accessModelSSHKey
+}
+
+// accessModelFor returns the access model cached for srv in the credentials
+// file, or "" if unknown. Best-effort: any load error yields "" so callers
+// degrade gracefully rather than failing.
+func accessModelFor(srv string) string {
+	path, err := credentials.DefaultPath()
+	if err != nil {
+		return ""
+	}
+	cf, err := credentials.Load(path)
+	if err != nil {
+		return ""
+	}
+	if c, ok := cf.Get(srv); ok {
+		return c.AccessModel
+	}
+	return ""
+}
+
 // isCloudServer reports whether srv is the managed cloud rather than a
-// self-hosted OSS daemon. The two have different box-access models — cloud
-// authenticates with the API token (`containarium connect`), self-hosted with
-// the user's SSH key — so the post-login flow branches on it. Detection keys off
-// the cloud apex host (defaultLoginServer), normalized so an explicit --server
-// pointing at the cloud is recognized too.
+// self-hosted OSS daemon — the bootstrap heuristic resolveAccessModel uses
+// before a server declares its model. Detection keys off the cloud apex host
+// (defaultLoginServer), normalized so an explicit --server pointing at the cloud
+// is recognized too.
 func isCloudServer(srv string) bool {
 	return credentials.NormalizeServer(srv) == credentials.NormalizeServer(defaultLoginServer)
 }
@@ -488,11 +534,15 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	if email == "" {
 		email = emailFromToken(status.Token)
 	}
+	// How box access works for this server — the server's declaration if it
+	// makes one, else the host heuristic. Cached so later commands don't guess.
+	accessModel := resolveAccessModel(status.AccessModel, srv)
 	creds := credentials.ServerCreds{
-		Token:     status.Token,
-		UserEmail: email,
-		OrgID:     status.OrgID,
-		IssuedAt:  time.Now().UTC(),
+		Token:       status.Token,
+		UserEmail:   email,
+		OrgID:       status.OrgID,
+		IssuedAt:    time.Now().UTC(),
+		AccessModel: accessModel,
 	}
 	if status.ExpiresAt != "" {
 		if t, err := time.Parse(time.RFC3339, status.ExpiresAt); err == nil {
@@ -535,7 +585,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	// command. Errors are surfaced but non-fatal — the login itself
 	// succeeded, and the user can re-run `containarium ssh setup`
 	// later.
-	maybeRunPostLoginSSHSetup(out, srv)
+	maybeRunPostLoginSSHSetup(out, srv, accessModel)
 	return nil
 }
 
@@ -551,21 +601,21 @@ func runLogin(cmd *cobra.Command, args []string) error {
 // as "no" because hitting people with a key-registration in CI
 // without an explicit opt-in is hostile. Use --with-ssh-setup to
 // force-on in CI.
-func maybeRunPostLoginSSHSetup(out io.Writer, srv string) {
+func maybeRunPostLoginSSHSetup(out io.Writer, srv, accessModel string) {
 	if loginNoSSHSetup {
 		return
 	}
 
 	// Two access models:
-	//   - Cloud: the API token you just minted IS the credential.
+	//   - token (cloud): the API token you just minted IS the credential.
 	//     `containarium connect <box>` turns it into a shell with a managed key
 	//     — there's no personal SSH key to register. So we skip key registration
 	//     and point at connect.
-	//   - Self-hosted (OSS): boxes are reached over plain `ssh` with the user's
-	//     own key, so the registration flow below applies.
-	// --with-ssh-setup forces the key flow even against the cloud, for users who
+	//   - sshKey (self-hosted): boxes are reached over plain `ssh` with the
+	//     user's own key, so the registration flow below applies.
+	// --with-ssh-setup forces the key flow even on a token server, for users who
 	// still want plain `ssh user@host`.
-	if isCloudServer(srv) && !loginWithSSHSetup {
+	if accessModel == accessModelToken && !loginWithSSHSetup {
 		fmt.Fprintf(out, "\nOpen a shell on a box:  containarium connect <box>\n")
 		return
 	}

--- a/internal/cmd/login_ssh_test.go
+++ b/internal/cmd/login_ssh_test.go
@@ -255,7 +255,7 @@ func TestPostLoginSSHSetup_CloudSkipsKeyRegistration(t *testing.T) {
 	loginPromptReader = strings.NewReader("y\n")
 
 	var buf bytes.Buffer
-	maybeRunPostLoginSSHSetup(&buf, defaultLoginServer, accessModelToken)
+	maybeRunPostLoginSSHSetup(&buf, defaultLoginServer, credentials.AccessModelToken)
 
 	out := buf.String()
 	if !strings.Contains(out, "containarium connect") {
@@ -276,7 +276,7 @@ func TestPostLoginSSHSetup_CloudWithFlagStillRegisters(t *testing.T) {
 	loginWithSSHSetup = true
 
 	var buf bytes.Buffer
-	maybeRunPostLoginSSHSetup(&buf, defaultLoginServer, accessModelToken)
+	maybeRunPostLoginSSHSetup(&buf, defaultLoginServer, credentials.AccessModelToken)
 
 	out := buf.String()
 	if strings.Contains(out, "containarium connect") {

--- a/internal/cmd/login_ssh_test.go
+++ b/internal/cmd/login_ssh_test.go
@@ -255,7 +255,7 @@ func TestPostLoginSSHSetup_CloudSkipsKeyRegistration(t *testing.T) {
 	loginPromptReader = strings.NewReader("y\n")
 
 	var buf bytes.Buffer
-	maybeRunPostLoginSSHSetup(&buf, defaultLoginServer)
+	maybeRunPostLoginSSHSetup(&buf, defaultLoginServer, accessModelToken)
 
 	out := buf.String()
 	if !strings.Contains(out, "containarium connect") {
@@ -276,7 +276,7 @@ func TestPostLoginSSHSetup_CloudWithFlagStillRegisters(t *testing.T) {
 	loginWithSSHSetup = true
 
 	var buf bytes.Buffer
-	maybeRunPostLoginSSHSetup(&buf, defaultLoginServer)
+	maybeRunPostLoginSSHSetup(&buf, defaultLoginServer, accessModelToken)
 
 	out := buf.String()
 	if strings.Contains(out, "containarium connect") {

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -591,15 +591,18 @@ func TestIsCloudServer(t *testing.T) {
 }
 
 func TestResolveAccessModel(t *testing.T) {
-	cases := []struct{ declared, srv, want string }{
+	cases := []struct {
+		declared, srv string
+		want          credentials.AccessModel
+	}{
 		// The server's declaration wins — even against the host heuristic.
-		{"token", "https://self-hosted.example.com", accessModelToken},
-		{"sshKey", defaultLoginServer, accessModelSSHKey},
+		{"token", "https://self-hosted.example.com", credentials.AccessModelToken},
+		{"sshKey", defaultLoginServer, credentials.AccessModelSSHKey},
 		// No / unrecognized declaration → host heuristic (cloud=token, else sshKey).
-		{"", defaultLoginServer, accessModelToken},
-		{"", "https://self-hosted.example.com", accessModelSSHKey},
-		{"bogus", defaultLoginServer, accessModelToken},
-		{"bogus", "https://self-hosted.example.com", accessModelSSHKey},
+		{"", defaultLoginServer, credentials.AccessModelToken},
+		{"", "https://self-hosted.example.com", credentials.AccessModelSSHKey},
+		{"bogus", defaultLoginServer, credentials.AccessModelToken},
+		{"bogus", "https://self-hosted.example.com", credentials.AccessModelSSHKey},
 	}
 	for _, c := range cases {
 		if got := resolveAccessModel(c.declared, c.srv); got != c.want {

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -590,6 +590,40 @@ func TestIsCloudServer(t *testing.T) {
 	}
 }
 
+func TestResolveAccessModel(t *testing.T) {
+	cases := []struct{ declared, srv, want string }{
+		// The server's declaration wins — even against the host heuristic.
+		{"token", "https://self-hosted.example.com", accessModelToken},
+		{"sshKey", defaultLoginServer, accessModelSSHKey},
+		// No / unrecognized declaration → host heuristic (cloud=token, else sshKey).
+		{"", defaultLoginServer, accessModelToken},
+		{"", "https://self-hosted.example.com", accessModelSSHKey},
+		{"bogus", defaultLoginServer, accessModelToken},
+		{"bogus", "https://self-hosted.example.com", accessModelSSHKey},
+	}
+	for _, c := range cases {
+		if got := resolveAccessModel(c.declared, c.srv); got != c.want {
+			t.Errorf("resolveAccessModel(%q, %q) = %q, want %q", c.declared, c.srv, got, c.want)
+		}
+	}
+}
+
+func TestFetchSessionStatus_DecodesAccessModel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"CLI_SESSION_STATUS_APPROVED","token":"t","accessModel":"token"}`))
+	}))
+	defer srv.Close()
+
+	st, err := fetchSessionStatus(context.Background(), srv.Client(), srv.URL+"/status")
+	if err != nil {
+		t.Fatalf("fetchSessionStatus: %v", err)
+	}
+	if st.AccessModel != "token" {
+		t.Errorf("AccessModel = %q, want \"token\"", st.AccessModel)
+	}
+}
+
 func TestShortDeviceSuffix_HexAndVaries(t *testing.T) {
 	seen := map[string]bool{}
 	for i := 0; i < 100; i++ {

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -365,7 +365,7 @@ func runSSHSetup(cmd *cobra.Command, args []string) error {
 	// FYI for token-access servers (cloud): registering an SSH key works, but
 	// it isn't needed — `containarium connect` uses the API token. We still
 	// proceed; the user ran `ssh setup` deliberately.
-	if accessModelFor(srv) == accessModelToken {
+	if accessModelFor(srv) == credentials.AccessModelToken {
 		fmt.Fprintf(out, "Note: %s uses token-based access — `containarium connect <box>` opens a shell with no SSH key.\n", srv)
 	}
 	name := sshSetupName

--- a/internal/cmd/ssh.go
+++ b/internal/cmd/ssh.go
@@ -362,6 +362,12 @@ func (c *sshHTTPClient) PropagateSSHKeys(ctx context.Context, boxes []string) (*
 func runSSHSetup(cmd *cobra.Command, args []string) error {
 	out := cmd.OutOrStdout()
 	srv := pickSSHServer(sshSetupServer)
+	// FYI for token-access servers (cloud): registering an SSH key works, but
+	// it isn't needed — `containarium connect` uses the API token. We still
+	// proceed; the user ran `ssh setup` deliberately.
+	if accessModelFor(srv) == accessModelToken {
+		fmt.Fprintf(out, "Note: %s uses token-based access — `containarium connect <box>` opens a shell with no SSH key.\n", srv)
+	}
 	name := sshSetupName
 	if name == "" {
 		name = defaultLocalKeyName()

--- a/internal/credentials/store.go
+++ b/internal/credentials/store.go
@@ -41,6 +41,13 @@ type ServerCreds struct {
 	OrgID     string     `json:"org_id"`
 	IssuedAt  time.Time  `json:"issued_at"`
 	ExpiresAt *time.Time `json:"expires_at"`
+	// AccessModel records how this server grants box access — "token"
+	// (cloud: `containarium connect` with the API token) or "sshKey"
+	// (self-hosted: register the user's SSH key). Learned at login from the
+	// server's declared model, falling back to a host heuristic, and cached
+	// here so later commands don't re-detect (#637 follow-up). Empty for
+	// credentials written before this field existed.
+	AccessModel string `json:"access_model,omitempty"`
 }
 
 // CredentialsFile is the on-disk JSON document. DefaultServer is the

--- a/internal/credentials/store.go
+++ b/internal/credentials/store.go
@@ -35,19 +35,36 @@ const DefaultRelPath = ".containarium/credentials.json"
 // ExpiresAt is a *time.Time because the locked schema explicitly
 // allows `null` (non-expiring tokens — service accounts, dev tokens).
 // Marshalling nil emits JSON `null`, matching the PRD example.
+// AccessModel is how a server grants box access. It's a closed set, so it's a
+// defined type with typed constants rather than a bare string (per the repo's
+// strong-typing convention).
+type AccessModel string
+
+const (
+	// AccessModelToken — cloud: the API token IS the credential
+	// (`containarium connect`), no per-user SSH key.
+	AccessModelToken AccessModel = "token"
+	// AccessModelSSHKey — self-hosted: register the user's SSH public key.
+	AccessModelSSHKey AccessModel = "sshKey"
+)
+
+// Known reports whether m is one of the defined access models (vs an empty or
+// unrecognized value decoded off the wire).
+func (m AccessModel) Known() bool {
+	return m == AccessModelToken || m == AccessModelSSHKey
+}
+
 type ServerCreds struct {
 	Token     string     `json:"token"`
 	UserEmail string     `json:"user_email"`
 	OrgID     string     `json:"org_id"`
 	IssuedAt  time.Time  `json:"issued_at"`
 	ExpiresAt *time.Time `json:"expires_at"`
-	// AccessModel records how this server grants box access — "token"
-	// (cloud: `containarium connect` with the API token) or "sshKey"
-	// (self-hosted: register the user's SSH key). Learned at login from the
-	// server's declared model, falling back to a host heuristic, and cached
-	// here so later commands don't re-detect (#637 follow-up). Empty for
+	// AccessModel records how this server grants box access. Learned at login
+	// from the server's declared model, falling back to a host heuristic, and
+	// cached here so later commands don't re-detect (#637 follow-up). Empty for
 	// credentials written before this field existed.
-	AccessModel string `json:"access_model,omitempty"`
+	AccessModel AccessModel `json:"access_model,omitempty"`
 }
 
 // CredentialsFile is the on-disk JSON document. DefaultServer is the


### PR DESCRIPTION
Follow-up to #637. That PR decided cloud-vs-OSS box access by matching the
server hostname against the cloud apex — correct today, but it's a **per-server**
fact inferred at the wrong layer (breaks for a second cloud host, a regional
apex, a rename, or a vanity control-plane domain). This replaces the guess with
an **authoritative, cached signal**, with the hostname match kept only as a
bootstrap fallback.

## Changes

- **`credentials.ServerCreds.AccessModel`** (`"token"` | `"sshKey"`), persisted
  per server in `credentials.json`. `omitempty` → backward-compatible with files
  written before the field.
- **CLI decodes `accessModel`** from the cloud's CLI-session response
  (`sessionStatusResp`). **`resolveAccessModel` prefers the server's declaration**
  and falls back to the host heuristic only when it's absent/unrecognized. Both
  directions are backward-compatible: an old CLI ignores the field; a new CLI
  works against a cloud that doesn't emit it yet.
- **`runLogin`** resolves the model once, **caches it** on the creds entry, and
  passes it to `maybeRunPostLoginSSHSetup`, which now branches on the *model*
  (`token` → point at `containarium connect`; `sshKey` → register a key) rather
  than re-deriving from the hostname.
- **`containarium ssh setup`** reads the cached model and nudges toward `connect`
  on token servers (still proceeds — the user invoked it deliberately). This is
  the per-server cache being consumed beyond login, kubectl-context style.

## Tests

- `TestResolveAccessModel` — declaration wins (even over the host heuristic);
  fallback by host when absent/unrecognized.
- `TestFetchSessionStatus_DecodesAccessModel` — the wire field decodes.
- #637's cloud-skip / `--with-ssh-setup` tests updated to the model-gated
  signature. Full `internal/cmd` + `internal/credentials` suites green; `go build
  ./...` clean.

## Not in this PR (cloud-side)

The cloud actually **emitting** `accessModel` in the session response is a
closed-source change — filed as a follow-up. Until it ships, the host fallback
preserves today's behavior, so this is safe to merge now and the cloud field
becomes a zero-CLI-change drop-in later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
