### PR TITLE
feat(traffic): capture reply-direction bytes via a 2nd veth-egress eBPF hook (#631)

### DIFF
--- a/docs/security/NETWORK-ISOLATION-DESIGN.md
+++ b/docs/security/NETWORK-ISOLATION-DESIGN.md
@@ -378,10 +378,14 @@ rows.
 
 Properties / limits:
 
-- **EGRESS only.** The veth ingress hook sees the container's
-  outbound (sender) side, so `bytes_sent`/`packets_sent` are
-  populated and the reply direction stays 0. A second hook
-  (veth egress) for reply-byte accounting is a follow-up.
+- **Both directions (#631).** The veth ingress hook tallies the
+  container's egress (`bytes_sent`/`packets_sent`); a second
+  program on the veth's TC_EGRESS hook tallies the reply
+  direction into `rx_bytes`/`rx_packets` of the same flow entry
+  (it rebuilds the request-oriented key by swapping the reply's
+  tuple), surfaced as `bytes_received`/`packets_received`. An
+  object built before #631 omits the egress program — received
+  counters then stay 0.
 - **Cumulative, LRU-bounded.** Counters are monotonic per flow;
   the map self-evicts under a short-lived-flow burst rather than
   filling. The poll snapshots (does not drain), so the active-

--- a/experimental/ebpf-phaseA/README.md
+++ b/experimental/ebpf-phaseA/README.md
@@ -204,9 +204,10 @@ The program also keeps a `flows` map (`BPF_MAP_TYPE_LRU_HASH`, 5-tuple →
 default 15s), attributes each flow to a container by veth ifindex, and feeds the
 traffic collector — so the traffic view shows real src/dst IP + byte counts
 sourced straight from eBPF, independent of conntrack accounting and the IP→name
-cache (both of which come up empty in the common docker-in-LXC topology). EGRESS
-only (the veth ingress hook sees the container's outbound side); reply bytes
-stay 0.
+cache (both of which come up empty in the common docker-in-LXC topology). Both
+directions are captured (#631): the ingress hook tallies the container's egress
+(bytes_sent), and a second program on the veth TC_EGRESS hook tallies the reply
+direction (bytes_received) onto the same flow entry.
 
 Rebuilding `netpolicy.bpf.o` with the new map is required to enable it — an
 older object still loads and enforces, the daemon just logs that flow accounting

--- a/experimental/ebpf-phaseA/netpolicy.bpf.c
+++ b/experimental/ebpf-phaseA/netpolicy.bpf.c
@@ -100,8 +100,12 @@ struct {
 // exact: the ifindex in the key maps 1:1 to a container. Recorded for ALLOWED and
 // would-deny flows alike (it's usage accounting, not a policy decision).
 //
-// The veth ingress hook sees the container's outbound (sender) side, so these
-// counts are the container's EGRESS; reply-direction bytes aren't visible here.
+// The veth ingress hook sees the container's outbound (sender) side, so the
+// packets/bytes counts are the container's EGRESS. The reply direction
+// (peer→container) is captured by a second program on the veth's TC_EGRESS hook
+// (#631), tallied into rx_packets/rx_bytes on the SAME flow entry (the egress
+// program rebuilds the request-oriented key by swapping the reply's tuple), so a
+// flow carries both directions.
 //
 // LRU_HASH so a burst of short-lived flows self-evicts under pressure rather than
 // filling the map; the daemon reads it on a poll and ages out idle entries.
@@ -115,11 +119,17 @@ struct flow_key {
     __u8  pad[3];
 };
 
+// flow_stat: tx_* (packets/bytes) are the container's egress, observed on the
+// veth ingress hook; rx_* are the reply direction, observed on the veth egress
+// hook (#631). rx fields are APPENDED so an older 32-byte value (pre-#631) still
+// decodes — the Go reader treats missing rx as 0.
 struct flow_stat {
-    __u64 packets;
+    __u64 packets;     // tx: container → peer
     __u64 bytes;
-    __u64 first_ns;  // bpf_ktime_get_ns at first packet (monotonic)
-    __u64 last_ns;   // bpf_ktime_get_ns at most recent packet (monotonic)
+    __u64 first_ns;    // bpf_ktime_get_ns at first packet (monotonic)
+    __u64 last_ns;     // bpf_ktime_get_ns at most recent packet (monotonic)
+    __u64 rx_packets;  // reply: peer → container (#631)
+    __u64 rx_bytes;
 };
 
 struct {
@@ -182,6 +192,41 @@ static __always_inline void account_flow(struct __sk_buff *skb, __u32 ifindex,
     struct flow_stat nfs = {};
     nfs.packets = 1;
     nfs.bytes = len;
+    nfs.first_ns = now;
+    nfs.last_ns = now;
+    bpf_map_update_elem(&flows, &fk, &nfs, BPF_ANY);
+}
+
+// account_reply tallies one reply packet (peer → container, seen on the veth
+// TC_EGRESS hook) into the rx_* counters of its flow (#631). The caller passes
+// the key already rebuilt in REQUEST orientation (src=container, dst=peer), so
+// the reply lands on the same entry the ingress hook created for the request.
+// If the request entry doesn't exist yet (reply observed first), create it with
+// only the rx counters set.
+static __always_inline void account_reply(struct __sk_buff *skb, __u32 ifindex,
+                                          __u32 saddr, __u32 daddr,
+                                          __u16 sport, __u16 dport, __u8 proto) {
+    struct flow_key fk = {};
+    fk.ifindex = ifindex;
+    fk.saddr = saddr;
+    fk.daddr = daddr;
+    fk.sport = sport;
+    fk.dport = dport;
+    fk.proto = proto;
+
+    __u64 now = bpf_ktime_get_ns();
+    __u64 len = skb->len;
+
+    struct flow_stat *fs = bpf_map_lookup_elem(&flows, &fk);
+    if (fs) {
+        __sync_fetch_and_add(&fs->rx_packets, 1);
+        __sync_fetch_and_add(&fs->rx_bytes, len);
+        fs->last_ns = now;
+        return;
+    }
+    struct flow_stat nfs = {};
+    nfs.rx_packets = 1;
+    nfs.rx_bytes = len;
     nfs.first_ns = now;
     nfs.last_ns = now;
     bpf_map_update_elem(&flows, &fk, &nfs, BPF_ANY);
@@ -283,6 +328,61 @@ int netpolicy_ingress(struct __sk_buff *skb) {
 
     if (cfg->mode == MODE_ENFORCE)
         return TC_ACT_SHOT; // Phase B path; Phase A never sets ENFORCE here.
+    return TC_ACT_OK;
+}
+
+// netpolicy_egress runs on the container veth's TC_EGRESS hook — packets the
+// host transmits TOWARD the container, i.e. the container's RECEIVE direction
+// (#631). It does accounting ONLY (no policy: enforcement happens on the
+// sender's egress, which the ingress hook above already sees); it always passes.
+//
+// The reply packet's tuple is the mirror of the request: src=peer, dst=container.
+// To land the rx bytes on the same flow entry the request created, rebuild the
+// request-oriented key by swapping — saddr=ip->daddr (container), daddr=ip->saddr
+// (peer), sport=reply dport, dport=reply sport.
+SEC("classifier/netpolicy_egress")
+int netpolicy_egress(struct __sk_buff *skb) {
+    void *data = (void *)(long)skb->data;
+    void *data_end = (void *)(long)skb->data_end;
+
+    struct ethhdr *eth = data;
+    if ((void *)(eth + 1) > data_end)
+        return TC_ACT_OK;
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
+        return TC_ACT_OK;
+
+    struct iphdr *ip = (void *)(eth + 1);
+    if ((void *)(ip + 1) > data_end)
+        return TC_ACT_OK;
+
+    // On the egress hook the veth is the transmit interface: skb->ifindex
+    // (ingress_ifindex is 0 here). Only account managed veths.
+    __u32 ifindex = skb->ifindex;
+    if (!bpf_map_lookup_elem(&veth_policy, &ifindex))
+        return TC_ACT_OK;
+
+    __u16 sport = 0, dport = 0;
+    if (ip->protocol == IPPROTO_TCP) {
+        struct tcphdr *tcp = (void *)ip + sizeof(*ip);
+        if ((void *)(tcp + 1) <= data_end) {
+            sport = bpf_ntohs(tcp->source);
+            dport = bpf_ntohs(tcp->dest);
+        }
+    } else if (ip->protocol == IPPROTO_UDP) {
+        struct udphdr *udp = (void *)ip + sizeof(*ip);
+        if ((void *)(udp + 1) <= data_end) {
+            sport = bpf_ntohs(udp->source);
+            dport = bpf_ntohs(udp->dest);
+        }
+    }
+
+    // Swap to request orientation: container is the reply's destination.
+    account_reply(skb, ifindex,
+                  ip->daddr,  // saddr (request) = reply dst = container
+                  ip->saddr,  // daddr (request) = reply src = peer
+                  dport,      // sport (request) = reply dport = container port
+                  sport,      // dport (request) = reply sport = peer port
+                  ip->protocol);
     return TC_ACT_OK;
 }
 

--- a/internal/netbpf/flows.go
+++ b/internal/netbpf/flows.go
@@ -8,31 +8,36 @@ import (
 
 // FlowRecord is one decoded per-flow accounting entry from the BPF `flows` map
 // (issue #627). It carries the flow's 5-tuple — attributed to a container by
-// Ifindex — plus the cumulative byte/packet tally observed on the container's
-// host-veth ingress hook, i.e. the container's EGRESS direction. The wire layout
-// of the key/value must stay in lockstep with `struct flow_key` / `struct
-// flow_stat` in experimental/ebpf-phaseA/netpolicy.bpf.c.
+// Ifindex — plus the cumulative tally: Packets/Bytes are the container's EGRESS
+// (veth ingress hook), RxPackets/RxBytes the reply direction (veth egress hook,
+// #631). The wire layout of the key/value must stay in lockstep with `struct
+// flow_key` / `struct flow_stat` in experimental/ebpf-phaseA/netpolicy.bpf.c.
 type FlowRecord struct {
-	Ifindex uint32
-	Saddr   uint32 // source IPv4, network byte order (as carried on the wire)
-	Daddr   uint32 // destination IPv4, network byte order
-	Sport   uint16 // host byte order
-	Dport   uint16 // host byte order
-	Proto   uint8  // IP protocol number (1=ICMP, 6=TCP, 17=UDP)
-	Packets uint64
-	Bytes   uint64
-	FirstNs uint64 // bpf_ktime_get_ns at first packet (monotonic; boot-relative)
-	LastNs  uint64 // bpf_ktime_get_ns at most recent packet (monotonic)
+	Ifindex   uint32
+	Saddr     uint32 // source IPv4, network byte order (as carried on the wire)
+	Daddr     uint32 // destination IPv4, network byte order
+	Sport     uint16 // host byte order
+	Dport     uint16 // host byte order
+	Proto     uint8  // IP protocol number (1=ICMP, 6=TCP, 17=UDP)
+	Packets   uint64 // tx: container → peer (egress)
+	Bytes     uint64
+	FirstNs   uint64 // bpf_ktime_get_ns at first packet (monotonic; boot-relative)
+	LastNs    uint64 // bpf_ktime_get_ns at most recent packet (monotonic)
+	RxPackets uint64 // reply: peer → container (#631); 0 if the object predates it
+	RxBytes   uint64
 }
 
-// flowKeySize / flowStatSize are the wire sizes of `struct flow_key` and
-// `struct flow_stat`:
+// flowKeySize is the wire size of `struct flow_key`. flowStatSizeV1 is the
+// original tx-only `struct flow_stat` (4×u64); flowStatSize is the current
+// layout with the appended rx counters (#631). Decode accepts either — a value
+// from an older object (no rx fields) leaves RxPackets/RxBytes at 0.
 //
 //	flow_key  = u32 ifindex + u32 saddr + u32 daddr + u16 sport + u16 dport + u8 proto + u8[3] pad
-//	flow_stat = u64 packets + u64 bytes + u64 first_ns + u64 last_ns
+//	flow_stat = u64 packets + u64 bytes + u64 first_ns + u64 last_ns [+ u64 rx_packets + u64 rx_bytes]
 const (
-	flowKeySize  = 20
-	flowStatSize = 32
+	flowKeySize    = 20
+	flowStatSizeV1 = 32
+	flowStatSize   = 48
 )
 
 // Src and Dst render the network-byte-order addresses as netip.Addr, matching
@@ -56,13 +61,19 @@ func decodeFlowKey(b []byte, rec *FlowRecord) error {
 }
 
 // decodeFlowStat fills the counter fields of rec from a raw `struct flow_stat`.
+// Accepts both the v1 (tx-only, 32-byte) and current (48-byte, with rx) layouts
+// (#631): a v1 value leaves RxPackets/RxBytes at 0.
 func decodeFlowStat(b []byte, rec *FlowRecord) error {
-	if len(b) < flowStatSize {
-		return fmt.Errorf("netbpf: flow stat sample too short: %d < %d bytes", len(b), flowStatSize)
+	if len(b) < flowStatSizeV1 {
+		return fmt.Errorf("netbpf: flow stat sample too short: %d < %d bytes", len(b), flowStatSizeV1)
 	}
 	rec.Packets = binary.NativeEndian.Uint64(b[0:8])
 	rec.Bytes = binary.NativeEndian.Uint64(b[8:16])
 	rec.FirstNs = binary.NativeEndian.Uint64(b[16:24])
 	rec.LastNs = binary.NativeEndian.Uint64(b[24:32])
+	if len(b) >= flowStatSize {
+		rec.RxPackets = binary.NativeEndian.Uint64(b[32:40])
+		rec.RxBytes = binary.NativeEndian.Uint64(b[40:48])
+	}
 	return nil
 }

--- a/internal/netbpf/flows_test.go
+++ b/internal/netbpf/flows_test.go
@@ -25,22 +25,26 @@ func encodeFlowStat(r FlowRecord) []byte {
 	binary.NativeEndian.PutUint64(b[8:16], r.Bytes)
 	binary.NativeEndian.PutUint64(b[16:24], r.FirstNs)
 	binary.NativeEndian.PutUint64(b[24:32], r.LastNs)
+	binary.NativeEndian.PutUint64(b[32:40], r.RxPackets)
+	binary.NativeEndian.PutUint64(b[40:48], r.RxBytes)
 	return b
 }
 
 func TestDecodeFlow_RoundTrip(t *testing.T) {
 	// 10.100.0.42:51000 -> 1.1.1.1:443, TCP, addresses in network byte order.
 	want := FlowRecord{
-		Ifindex: 59,
-		Saddr:   binary.NativeEndian.Uint32([]byte{10, 100, 0, 42}),
-		Daddr:   binary.NativeEndian.Uint32([]byte{1, 1, 1, 1}),
-		Sport:   51000,
-		Dport:   443,
-		Proto:   6,
-		Packets: 12,
-		Bytes:   8456,
-		FirstNs: 1_000_000_000,
-		LastNs:  3_500_000_000,
+		Ifindex:   59,
+		Saddr:     binary.NativeEndian.Uint32([]byte{10, 100, 0, 42}),
+		Daddr:     binary.NativeEndian.Uint32([]byte{1, 1, 1, 1}),
+		Sport:     51000,
+		Dport:     443,
+		Proto:     6,
+		Packets:   12,
+		Bytes:     8456,
+		FirstNs:   1_000_000_000,
+		LastNs:    3_500_000_000,
+		RxPackets: 9,
+		RxBytes:   12_004,
 	}
 
 	var got FlowRecord
@@ -58,6 +62,24 @@ func TestDecodeFlow_RoundTrip(t *testing.T) {
 	}
 	if got.Dst().String() != "1.1.1.1" {
 		t.Errorf("Dst() = %s, want 1.1.1.1", got.Dst())
+	}
+}
+
+// TestDecodeFlowStat_V1NoRx guards backward compat (#631): a 32-byte value from
+// an object built before the rx counters decodes fine, leaving Rx* at 0.
+func TestDecodeFlowStat_V1NoRx(t *testing.T) {
+	v1 := make([]byte, flowStatSizeV1)
+	binary.NativeEndian.PutUint64(v1[0:8], 7)     // packets
+	binary.NativeEndian.PutUint64(v1[8:16], 4096) // bytes
+	var got FlowRecord
+	if err := decodeFlowStat(v1, &got); err != nil {
+		t.Fatalf("decodeFlowStat(v1): %v", err)
+	}
+	if got.Packets != 7 || got.Bytes != 4096 {
+		t.Errorf("tx fields = %d/%d, want 7/4096", got.Packets, got.Bytes)
+	}
+	if got.RxPackets != 0 || got.RxBytes != 0 {
+		t.Errorf("rx fields should default 0 for a v1 value, got %d/%d", got.RxPackets, got.RxBytes)
 	}
 }
 

--- a/internal/netbpf/loader.go
+++ b/internal/netbpf/loader.go
@@ -16,16 +16,17 @@ import (
 // Map / program / section names — must match SEC(".maps") names and the
 // program section in experimental/ebpf-phaseA/netpolicy.bpf.c.
 const (
-	progNetpolicy   = "netpolicy_ingress"
-	mapVethPolicy   = "veth_policy"
-	mapEgressCIDR   = "egress_cidr"
-	mapIPTenant     = "ip_tenant"
-	mapStats        = "stats"
-	mapEvents       = "events"
-	mapFlows        = "flows"
-	statSeen        = uint32(0)
-	statWouldDeny   = uint32(1)
-	statsEntryCount = 2
+	progNetpolicy       = "netpolicy_ingress"
+	progNetpolicyEgress = "netpolicy_egress"
+	mapVethPolicy       = "veth_policy"
+	mapEgressCIDR       = "egress_cidr"
+	mapIPTenant         = "ip_tenant"
+	mapStats            = "stats"
+	mapEvents           = "events"
+	mapFlows            = "flows"
+	statSeen            = uint32(0)
+	statWouldDeny       = uint32(1)
+	statsEntryCount     = 2
 )
 
 // Loader owns a loaded netpolicy BPF collection and the per-veth TCX links it
@@ -36,8 +37,9 @@ const (
 // Linux-only at runtime: cilium/ebpf compiles on every platform (so the daemon
 // builds on a dev mac), but Load/Attach return errors on non-Linux kernels.
 type Loader struct {
-	coll  *ebpf.Collection
-	links map[int]link.Link // ifindex -> TCX link
+	coll        *ebpf.Collection
+	links       map[int]link.Link // ifindex -> TCX ingress link
+	egressLinks map[int]link.Link // ifindex -> TCX egress link (#631 reply accounting)
 }
 
 // Resolve loads the netpolicy BPF object from the operator-supplied source. The
@@ -111,8 +113,19 @@ func newLoaderFromSpec(spec *ebpf.CollectionSpec) (*Loader, error) {
 		coll.Close()
 		return nil, fmt.Errorf("netbpf: BPF object missing program %q", progNetpolicy)
 	}
-	return &Loader{coll: coll, links: make(map[int]link.Link)}, nil
+	// progNetpolicyEgress is OPTIONAL: an object built before #631 lacks it, and
+	// the loader still works (reply-byte accounting just stays off). AttachVethEgress
+	// no-ops when it's absent.
+	return &Loader{
+		coll:        coll,
+		links:       make(map[int]link.Link),
+		egressLinks: make(map[int]link.Link),
+	}, nil
 }
+
+// hasEgressProgram reports whether the loaded object carries the reply-accounting
+// egress program (#631).
+func (l *Loader) hasEgressProgram() bool { return l.coll.Programs[progNetpolicyEgress] != nil }
 
 // AttachVeth attaches the policy program to a container's host veth in
 // TC_INGRESS via TCX (kernel ≥ 6.6). Idempotent per ifindex.
@@ -132,14 +145,45 @@ func (l *Loader) AttachVeth(ifindex int) error {
 	return nil
 }
 
-// DetachVeth removes the program from a veth (e.g. on container stop/delete).
-func (l *Loader) DetachVeth(ifindex int) error {
-	lnk, ok := l.links[ifindex]
-	if !ok {
+// AttachVethEgress attaches the reply-accounting program to a container's host
+// veth in TC_EGRESS via TCX (#631), so the container's receive-direction bytes
+// are tallied. Idempotent per ifindex. No-ops when the loaded object predates
+// #631 (no egress program) — reply bytes then stay 0 rather than failing.
+func (l *Loader) AttachVethEgress(ifindex int) error {
+	if !l.hasEgressProgram() {
 		return nil
 	}
-	delete(l.links, ifindex)
-	return lnk.Close()
+	if _, ok := l.egressLinks[ifindex]; ok {
+		return nil
+	}
+	lnk, err := link.AttachTCX(link.TCXOptions{
+		Interface: ifindex,
+		Program:   l.coll.Programs[progNetpolicyEgress],
+		Attach:    ebpf.AttachTCXEgress,
+	})
+	if err != nil {
+		return fmt.Errorf("netbpf: attach TCX egress on ifindex %d: %w", ifindex, err)
+	}
+	l.egressLinks[ifindex] = lnk
+	return nil
+}
+
+// DetachVeth removes both programs from a veth (e.g. on container stop/delete).
+func (l *Loader) DetachVeth(ifindex int) error {
+	var errs []error
+	if lnk, ok := l.links[ifindex]; ok {
+		delete(l.links, ifindex)
+		if err := lnk.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if lnk, ok := l.egressLinks[ifindex]; ok {
+		delete(l.egressLinks, ifindex)
+		if err := lnk.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // SetVethPolicy writes the per-veth policy config into the veth_policy map,
@@ -224,8 +268,11 @@ func (l *Loader) Flows() ([]FlowRecord, error) {
 	if m == nil {
 		return nil, fmt.Errorf("netbpf: flows map not present (rebuild netpolicy.bpf.o?)")
 	}
+	// Size the value buffer to the map's actual ValueSize so Lookup matches the
+	// kernel map whether the object is the v1 (32-byte) or current (48-byte, with
+	// rx) flow_stat (#631). decodeFlowStat tolerates either length.
 	keyBuf := make([]byte, flowKeySize)
-	valBuf := make([]byte, flowStatSize)
+	valBuf := make([]byte, m.ValueSize())
 	var out []FlowRecord
 	it := m.Iterate()
 	for it.Next(&keyBuf, &valBuf) {
@@ -244,7 +291,7 @@ func (l *Loader) Flows() ([]FlowRecord, error) {
 	return out, nil
 }
 
-// Close detaches every veth link and frees the collection.
+// Close detaches every veth link (ingress + egress) and frees the collection.
 func (l *Loader) Close() error {
 	var errs []error
 	for idx, lnk := range l.links {
@@ -252,7 +299,13 @@ func (l *Loader) Close() error {
 			errs = append(errs, fmt.Errorf("close link ifindex %d: %w", idx, err))
 		}
 	}
+	for idx, lnk := range l.egressLinks {
+		if err := lnk.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close egress link ifindex %d: %w", idx, err))
+		}
+	}
 	l.links = nil
+	l.egressLinks = nil
 	if l.coll != nil {
 		l.coll.Close()
 		l.coll = nil

--- a/internal/server/network_policy_enforcer.go
+++ b/internal/server/network_policy_enforcer.go
@@ -347,7 +347,9 @@ func flowsToEBPF(records []netbpf.FlowRecord, attached map[int]string, now time.
 			DstPort:       r.Dport,
 			Bytes:         safecast.I64FromU64(r.Bytes),
 			Packets:       safecast.I64FromU64(r.Packets),
-			First:         now.Add(-dur), // absolute first/last unknown; preserve duration
+			RxBytes:       safecast.I64FromU64(r.RxBytes),   // reply direction (#631)
+			RxPackets:     safecast.I64FromU64(r.RxPackets), // 0 if object predates #631
+			First:         now.Add(-dur),                    // absolute first/last unknown; preserve duration
 			Last:          now,
 		})
 	}
@@ -426,6 +428,12 @@ func (e *NetworkPolicyEnforcer) reconcile(ctx context.Context) error {
 		if err := e.loader.AttachVeth(ifindex); err != nil {
 			log.Printf("[netpolicy] attach ifindex %d: %v", ifindex, err)
 			continue
+		}
+		// Reply-direction accounting (#631): attach the egress program too. No-ops
+		// on an object that predates it. Non-fatal — ingress accounting + policy
+		// still work without it.
+		if err := e.loader.AttachVethEgress(ifindex); err != nil {
+			log.Printf("[netpolicy] attach egress ifindex %d: %v", ifindex, err)
 		}
 		e.attached[ifindex] = plan.ifName[ifindex]
 		present[ifindex] = true

--- a/internal/server/network_policy_flows_test.go
+++ b/internal/server/network_policy_flows_test.go
@@ -16,16 +16,18 @@ func TestFlowsToEBPF_AttributesAndMaps(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	records := []netbpf.FlowRecord{
 		{ // managed veth 59 -> web-container
-			Ifindex: 59,
-			Saddr:   beIPv4(10, 100, 0, 42),
-			Daddr:   beIPv4(1, 1, 1, 1),
-			Sport:   51000,
-			Dport:   443,
-			Proto:   6,
-			Packets: 12,
-			Bytes:   8456,
-			FirstNs: 1_000_000_000,
-			LastNs:  3_000_000_000, // 2s old
+			Ifindex:   59,
+			Saddr:     beIPv4(10, 100, 0, 42),
+			Daddr:     beIPv4(1, 1, 1, 1),
+			Sport:     51000,
+			Dport:     443,
+			Proto:     6,
+			Packets:   12,
+			Bytes:     8456,
+			RxPackets: 9,
+			RxBytes:   12_004,
+			FirstNs:   1_000_000_000,
+			LastNs:    3_000_000_000, // 2s old
 		},
 		{ // unmanaged veth 99 -> dropped
 			Ifindex: 99,
@@ -57,6 +59,9 @@ func TestFlowsToEBPF_AttributesAndMaps(t *testing.T) {
 	}
 	if f.Bytes != 8456 || f.Packets != 12 {
 		t.Errorf("Bytes/Packets = %d/%d, want 8456/12", f.Bytes, f.Packets)
+	}
+	if f.RxBytes != 12_004 || f.RxPackets != 9 {
+		t.Errorf("RxBytes/RxPackets = %d/%d, want 12004/9 (#631 reply direction)", f.RxBytes, f.RxPackets)
 	}
 	if !f.Last.Equal(now) {
 		t.Errorf("Last = %v, want %v", f.Last, now)

--- a/internal/traffic/collector.go
+++ b/internal/traffic/collector.go
@@ -222,11 +222,10 @@ func (c *Collector) convertToProto(event *ConntrackEvent, containerName, contain
 }
 
 // EBPFFlow is one per-flow accounting record sourced from the eBPF per-veth
-// network-policy program (issue #627). It is the container's EGRESS as observed
-// on the host-veth ingress hook: Bytes/Packets are cumulative container→peer
-// counts. The reply direction (peer→container) is not visible on that hook, so
-// BytesReceived/PacketsReceived stay 0 — a known v1 limitation noted in the
-// network-isolation design doc.
+// network-policy program (issue #627). Bytes/Packets are the container's EGRESS
+// (container→peer) seen on the host-veth ingress hook; RxBytes/RxPackets are the
+// reply direction (peer→container) seen on the veth egress hook (#631). RxBytes/
+// RxPackets are 0 when the loaded BPF object predates #631 (no egress program).
 type EBPFFlow struct {
 	ContainerName string
 	ContainerIP   string
@@ -235,8 +234,10 @@ type EBPFFlow struct {
 	SrcPort       uint16
 	DstIP         string
 	DstPort       uint16
-	Bytes         int64
+	Bytes         int64 // sent: container → peer (veth ingress hook)
 	Packets       int64
+	RxBytes       int64 // received: peer → container (veth egress hook, #631); 0 if unavailable
+	RxPackets     int64
 	First         time.Time
 	Last          time.Time
 }
@@ -263,8 +264,8 @@ func (c *Collector) IngestEBPFFlows(flows []EBPFFlow) {
 			Direction:       pb.TrafficDirection_TRAFFIC_DIRECTION_EGRESS,
 			BytesSent:       f.Bytes,
 			PacketsSent:     f.Packets,
-			BytesReceived:   0, // reply direction not visible on the veth ingress hook
-			PacketsReceived: 0,
+			BytesReceived:   f.RxBytes,   // reply direction via the veth egress hook (#631)
+			PacketsReceived: f.RxPackets, // 0 when the BPF object predates #631
 			FirstSeen:       timestamppb.New(f.First),
 			LastSeen:        timestamppb.New(f.Last),
 		}

--- a/internal/traffic/ebpf_flows_test.go
+++ b/internal/traffic/ebpf_flows_test.go
@@ -35,6 +35,8 @@ func TestIngestEBPFFlows_SurfacesInGetConnections(t *testing.T) {
 			DstPort:       443,
 			Bytes:         8456,
 			Packets:       12,
+			RxBytes:       12_004,
+			RxPackets:     9,
 			First:         now.Add(-2 * time.Second),
 			Last:          now,
 		},
@@ -64,6 +66,9 @@ func TestIngestEBPFFlows_SurfacesInGetConnections(t *testing.T) {
 	}
 	if got.BytesSent != 8456 || got.PacketsSent != 12 {
 		t.Errorf("byte/packet counts = %d/%d, want 8456/12", got.BytesSent, got.PacketsSent)
+	}
+	if got.BytesReceived != 12_004 || got.PacketsReceived != 9 {
+		t.Errorf("rx byte/packet = %d/%d, want 12004/9 (#631)", got.BytesReceived, got.PacketsReceived)
 	}
 	if got.Direction != pb.TrafficDirection_TRAFFIC_DIRECTION_EGRESS {
 		t.Errorf("direction = %v, want EGRESS", got.Direction)


### PR DESCRIPTION
Closes #631. **Draft** — needs on-backend eBPF validation before merge (see bottom).

## Problem

The #627 flow accounting only observed the container's **egress** (the veth
ingress hook = sender side), so `bytes_received`/`packets_received` were always
0 in the traffic view.

## Fix — a second hook for the reply direction

Add a BPF program on the veth's **TC_EGRESS** hook (packets the host transmits
*toward* the container = the container's receive side) that tallies reply bytes
into the **same flow entry** the request created.

**Data plane (`netpolicy.bpf.c`):**
- `flow_stat` gains `rx_packets`/`rx_bytes`, **appended** so an older 32-byte
  value still decodes (rx → 0).
- `netpolicy_egress`: accounting only — no policy (enforcement stays on the
  sender's egress, already seen by the ingress hook), always `TC_ACT_OK`. It
  rebuilds the **request-oriented** key by swapping the reply's tuple
  (`saddr = reply.daddr = container`, ports swapped), so rx lands on the request
  flow's entry.

**Control plane:**
- `FlowRecord` gains `RxPackets`/`RxBytes`; `decodeFlowStat` accepts **both** the
  v1 (32-byte) and current (48-byte) layouts; `Loader.Flows()` sizes its read
  buffer to the map's `ValueSize()` so it reads either object.
- `Loader`: `progNetpolicyEgress` is **optional** (older object lacks it → no-op);
  `AttachVethEgress` adds a second TCX link per veth; `DetachVeth`/`Close` close both.
- Enforcer attaches the egress program in `reconcile` and maps `Rx*` into
  `EBPFFlow`; collector fills `BytesReceived`/`PacketsReceived`.

**Backward-compatible throughout:** an object built before #631 loads and runs
exactly as today — received counters just stay 0.

## Tests

rx round-trip + **v1-no-rx** decode tolerance (`flows_test`), `flowsToEBPF` rx
mapping (`network_policy_flows_test`), collector surfaces `BytesReceived`
(`ebpf_flows_test`). Full `netbpf` / `traffic` / `server` suites green; `go build
./...` clean.

## ⚠️ Why draft

The BPF object isn't committed (built in CI / on a backend). The new egress
program needs, on a Linux backend:
1. **verifier acceptance** of `netpolicy_egress` + the wider `flow_stat`;
2. a live **request/response** flow showing `bytes_received > 0` attributed to
   the right container;
3. no regression to ingress accounting / policy enforcement.

Same gate as #628/#629. Marking draft until that runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
