### PR TITLE
feat(traffic): persist eBPF flows to traffic_history on close (#632)

### DIFF
--- a/docs/security/NETWORK-ISOLATION-DESIGN.md
+++ b/docs/security/NETWORK-ISOLATION-DESIGN.md
@@ -396,9 +396,14 @@ Properties / limits:
   before the `flows` map still loads and enforces; the daemon
   logs that flow accounting is unavailable and leaves the poll
   off until the operator rebuilds `netpolicy.bpf.o`.
-- **Historical persistence** (the `traffic_history` table) is
-  still conntrack-fed; persisting eBPF flows on eviction/close is
-  a follow-up.
+- **Historical persistence (#632).** When a flow disappears
+  between polls (LRU-evicted or aged out = effectively closed),
+  its final counters are written to `traffic_history` via the
+  same `SaveConnection` path conntrack uses, so the historical
+  view + aggregates light up on eBPF-only backends. Caveat: on a
+  backend where conntrack attribution also works, the same
+  logical flow may be persisted once per source (distinct IDs) —
+  cross-source 5-tuple dedup is a follow-up.
 
 ## What this is NOT
 

--- a/experimental/ebpf-phaseA/README.md
+++ b/experimental/ebpf-phaseA/README.md
@@ -225,3 +225,7 @@ Expect non-empty rows carrying the container's source IP, the destination
 IP/port, and non-zero `bytes_sent` — with **no** dependency on
 `nf_conntrack_acct` or the conntrack collector matching. Counters are cumulative
 per flow; the LRU map self-evicts idle flows.
+
+The full on-backend acceptance procedure (verifier acceptance of the egress
+program, `bytes_received` check, history persistence, no-regression, rollback)
+is in [`VALIDATION-traffic-flows.md`](VALIDATION-traffic-flows.md).

--- a/experimental/ebpf-phaseA/VALIDATION-traffic-flows.md
+++ b/experimental/ebpf-phaseA/VALIDATION-traffic-flows.md
@@ -103,13 +103,18 @@ container, with the correct dest IP/port.
 
 ## Phase 3 — history persistence (#632)
 
-A flow is persisted when it disappears from the BPF LRU map (closed / idle /
-evicted) between polls. Generate a flow, let it finish, then wait past a couple
-of poll intervals:
+A flow is persisted by the **idle reaper**: each poll the enforcer marks any
+flow whose last packet is older than the idle timeout (`flowIdleTimeout`,
+default **2 min**) as closed, writes its final counters to history, and deletes
+it from the BPF map. (The BPF program never deletes on FIN/RST and the
+65536-entry LRU map only evicts under pressure, so without the reaper a quiesced
+flow on a lightly-loaded backend never reaches history — the gap the first
+validation pass found.) Generate a flow, let it finish, then wait past the idle
+timeout **plus** one poll:
 
 ```sh
 incus exec <container> -- sh -c 'curl -s https://1.1.1.1 -o /dev/null'
-sleep 60   # let the flow go idle and the poll observe it disappear
+sleep 150  # > flowIdleTimeout (2m) + one poll, so the reaper persists + forgets it
 ```
 
 Query history:

--- a/experimental/ebpf-phaseA/VALIDATION-traffic-flows.md
+++ b/experimental/ebpf-phaseA/VALIDATION-traffic-flows.md
@@ -1,0 +1,158 @@
+# Backend validation runbook — bidirectional flow accounting + history
+
+On-backend acceptance for the two eBPF traffic-flow changes that ship together
+on this branch:
+
+- **#631** — reply-direction bytes via a 2nd program on the veth `TC_EGRESS`
+  hook (`bytes_received` populated, not just `bytes_sent`).
+- **#632** — persist closed eBPF flows to `traffic_history` so the historical
+  view + aggregates light up on backends where conntrack attribution fails.
+
+Both are gated on this runbook because the compiled BPF object is never
+committed (built on the backend / in CI), so the kernel verifier only exercises
+the new `netpolicy_egress` program and the wider `flow_stat` at first load.
+
+> Anonymise before pasting results anywhere public: use `<backend>`, `<tenant>`,
+> `$DAEMON`, `$JWT` — never real hostnames / IPs / tenant names.
+
+## Prerequisites
+
+- A Linux backend, **kernel ≥ 6.6** (TCX attach), Incus, `clang`/`llvm` +
+  kernel UAPI headers (`libbpf-dev linux-libc-dev`).
+- The daemon built from **this branch** (`feat/traffic-history-persist`, which
+  includes #631). `make build-linux`.
+- **Postgres reachable by the daemon** (`--postgres` / the usual connstring) —
+  #632 writes history there; without it the live view still works but history
+  won't persist.
+- A throwaway tenant container you can generate traffic from.
+
+## Phase 0 — build the object and start the daemon
+
+```sh
+# On the backend, from experimental/ebpf-phaseA:
+clang -O2 -g -target bpfel -I/usr/include/$(uname -m)-linux-gnu \
+    -c netpolicy.bpf.c -o /etc/containarium/netpolicy.bpf.o
+
+# Sanity: the object must carry BOTH programs + the flows map.
+llvm-objdump -h /etc/containarium/netpolicy.bpf.o | grep -E 'netpolicy(_egress)?|flows' || true
+# Expect sections for classifier/netpolicy AND classifier/netpolicy_egress.
+```
+
+Point the daemon at it and (re)start. Enforcement is NOT needed for accounting,
+so leave `CONTAINARIUM_NETWORK_POLICY_ENFORCE` unset:
+
+```sh
+export CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT=/etc/containarium/netpolicy.bpf.o
+# restart the daemon (systemd unit / however this backend runs it)
+```
+
+Give the container a policy so the enforcer attaches to its veth (any
+log_only policy is enough to make it a managed veth):
+
+```sh
+containarium network-policy set <tenant> --mode log_only --egress-cidr 0.0.0.0/0
+```
+
+## Phase 1 — verifier acceptance (#631)
+
+The new egress program + 48-byte `flow_stat` must load without a verifier
+rejection, and both hooks must attach.
+
+```sh
+journalctl -u containarium --since "2 min ago" | grep -iE '\[netpolicy\]'
+```
+
+**Pass criteria:**
+- `enforcer started` and `traffic-flow accounting enabled (poll=…)` appear.
+- **No** verifier / load error (`load collection`, `attach TCX egress …`).
+- Both programs are attached to the container's host veth:
+  ```sh
+  VETH=$(incus config get <container> volatile.eth0.host_name)
+  tc filter show dev "$VETH" ingress      # netpolicy
+  tc filter show dev "$VETH" egress       # netpolicy_egress  ← the #631 add
+  # (or: bpftool net show dev "$VETH")
+  ```
+
+If the egress program is missing from the object, the daemon logs that
+reply-byte accounting is unavailable and continues — that means the object
+wasn't rebuilt from this branch.
+
+## Phase 2 — reply bytes are non-zero (#631)
+
+Generate a request/response flow with a real response payload (HTTPS download
+gives an obvious receive side):
+
+```sh
+incus exec <container> -- sh -c 'curl -s https://1.1.1.1 -o /dev/null'
+# or a sized download: curl -s https://<host>/100mb.bin -o /dev/null
+```
+
+Read the live view (wait one poll interval, ~15s):
+
+```sh
+curl -s -H "Authorization: Bearer $JWT" \
+  "$DAEMON/v1/containers/<tenant>-container/connections" | jq '.connections[]
+  | {destIp, destPort, bytesSent, bytesReceived}'
+# or, if the traffic CLI is present on this build:
+containarium traffic connections <tenant>-container
+```
+
+**Pass criteria:** the flow shows **both** `bytesSent > 0` **and**
+`bytesReceived > 0` (pre-#631 this was always 0), attributed to the right
+container, with the correct dest IP/port.
+
+## Phase 3 — history persistence (#632)
+
+A flow is persisted when it disappears from the BPF LRU map (closed / idle /
+evicted) between polls. Generate a flow, let it finish, then wait past a couple
+of poll intervals:
+
+```sh
+incus exec <container> -- sh -c 'curl -s https://1.1.1.1 -o /dev/null'
+sleep 60   # let the flow go idle and the poll observe it disappear
+```
+
+Query history:
+
+```sh
+curl -s -H "Authorization: Bearer $JWT" \
+  "$DAEMON/v1/containers/<tenant>-container/traffic/history" | jq '.connections[]
+  | {sourceIp, destIp, destPort, bytesSent, bytesReceived, endedAt}'
+# or: containarium traffic history <tenant>-container
+```
+
+**Pass criteria:** the closed flow appears in history with the correct
+5-tuple + byte counts. (Requires Postgres configured.)
+
+**The docker-in-LXC payoff** (optional but the point of #632): run a
+docker-compose workload *inside* the LXC and confirm history populates for it —
+this is the case where the conntrack collector attributed nothing and history
+was previously empty.
+
+## Phase 4 — no regression
+
+Confirm the existing Phase A behaviour is intact:
+
+- `seen` counter still increments as the container sends traffic (the
+  ingress-hook accounting / policy path is unchanged).
+- A would-deny flow still logs (`[netpolicy] deny …`) and, if you separately arm
+  `CONTAINARIUM_NETWORK_POLICY_ENFORCE=1` with a `--mode enforce` policy, still
+  drops — the egress program is accounting-only and must not affect enforcement.
+- A neighbour container with no policy is unaffected.
+
+## Rollback
+
+Unset `CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT` and restart — the daemon reverts
+to the conntrack-only collector exactly as before. No persisted data is removed.
+
+## Recording the result
+
+Post the outcome (pass/fail per phase, with the relevant `journalctl` / `jq`
+output, **anonymised**) on **PR #642**, and note Phase 1–2 on **PR #641**. On a
+clean pass:
+
+1. Mark **#641** ready → merge to `main`.
+2. **#642** retargets to `main` → mark ready → merge.
+3. **#644** (cross-source dedup, #643) retargets to `main` → merge.
+
+Do not reorder — each depends on the one below it.

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.52.0
+	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
 	google.golang.org/api v0.283.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa
@@ -98,7 +99,6 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/internal/netbpf/flows_test.go
+++ b/internal/netbpf/flows_test.go
@@ -5,20 +5,10 @@ import (
 	"testing"
 )
 
-// encodeFlowKey / encodeFlowStat mirror the C `struct flow_key` / `struct
-// flow_stat` wire layout, so the round-trip test pins the byte offsets the
-// loader's Flows() decode relies on.
-func encodeFlowKey(r FlowRecord) []byte {
-	b := make([]byte, flowKeySize)
-	binary.NativeEndian.PutUint32(b[0:4], r.Ifindex)
-	binary.NativeEndian.PutUint32(b[4:8], r.Saddr)
-	binary.NativeEndian.PutUint32(b[8:12], r.Daddr)
-	binary.NativeEndian.PutUint16(b[12:14], r.Sport)
-	binary.NativeEndian.PutUint16(b[14:16], r.Dport)
-	b[16] = r.Proto
-	return b
-}
-
+// encodeFlowStat mirrors the C `struct flow_stat` wire layout, so the round-trip
+// test pins the byte offsets the loader's Flows() decode relies on. (The key
+// side uses the production encodeFlowKey from loader.go, added for DeleteFlow —
+// this test doubles as its round-trip coverage.)
 func encodeFlowStat(r FlowRecord) []byte {
 	b := make([]byte, flowStatSize)
 	binary.NativeEndian.PutUint64(b[0:8], r.Packets)

--- a/internal/netbpf/loader.go
+++ b/internal/netbpf/loader.go
@@ -291,6 +291,41 @@ func (l *Loader) Flows() ([]FlowRecord, error) {
 	return out, nil
 }
 
+// DeleteFlow removes one entry from the flows map, identified by rec's 5-tuple
+// key. The idle reaper (#632) calls this to "persist + forget" a quiesced flow
+// after writing its final counters to history, so a flow that simply went quiet
+// doesn't linger in the LRU map until eviction (which, on a far-from-full map,
+// effectively never happens). A key that's already gone is not an error.
+func (l *Loader) DeleteFlow(rec FlowRecord) error {
+	m := l.coll.Maps[mapFlows]
+	if m == nil {
+		return fmt.Errorf("netbpf: flows map not present (rebuild netpolicy.bpf.o?)")
+	}
+	if err := m.Delete(encodeFlowKey(rec)); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return nil
+		}
+		return fmt.Errorf("netbpf: delete flow: %w", err)
+	}
+	return nil
+}
+
+// encodeFlowKey renders rec's 5-tuple as the 20-byte `struct flow_key` wire
+// layout — the exact inverse of decodeFlowKey (native-endian fields + 3 zero pad
+// bytes, matching the kernel's zero-initialised key). Used to address a specific
+// flow for deletion.
+func encodeFlowKey(rec FlowRecord) []byte {
+	b := make([]byte, flowKeySize)
+	binary.NativeEndian.PutUint32(b[0:4], rec.Ifindex)
+	binary.NativeEndian.PutUint32(b[4:8], rec.Saddr)
+	binary.NativeEndian.PutUint32(b[8:12], rec.Daddr)
+	binary.NativeEndian.PutUint16(b[12:14], rec.Sport)
+	binary.NativeEndian.PutUint16(b[14:16], rec.Dport)
+	b[16] = rec.Proto
+	// b[17:20] padding stays zero
+	return b
+}
+
 // Close detaches every veth link (ingress + egress) and frees the collection.
 func (l *Loader) Close() error {
 	var errs []error

--- a/internal/server/network_policy_enforcer.go
+++ b/internal/server/network_policy_enforcer.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf/perf"
+	"golang.org/x/sys/unix"
 
 	"github.com/footprintai/containarium/internal/audit"
 	"github.com/footprintai/containarium/internal/events"
@@ -35,11 +36,24 @@ const defaultNetPolicyReconcileInterval = 10 * time.Second
 // keeps the traffic view fresh without churning the map iterator.
 const defaultFlowPollInterval = 15 * time.Second
 
+// defaultFlowIdleTimeout is how long a flow may go without a packet before the
+// poll loop treats it as closed: persists its final counters to history (#632)
+// and deletes it from the BPF map. The BPF program never deletes a flow on
+// FIN/RST, and the 65536-entry LRU map only evicts under pressure — so without
+// this sweep a quiesced flow on a lightly-loaded backend never reaches history
+// (the gap on-backend validation surfaced). Two minutes is long enough that a
+// briefly-idle but still-live connection isn't split, short enough that an ended
+// flow lands in history promptly.
+const defaultFlowIdleTimeout = 2 * time.Minute
+
 // FlowSink receives per-flow accounting records sourced from the eBPF program
 // (#627). *traffic.Collector implements it; kept an interface so the enforcer is
 // testable without the collector.
 type FlowSink interface {
 	IngestEBPFFlows(flows []traffic.EBPFFlow)
+	// PersistEBPFFlows writes a batch of closed/idle flows straight to history,
+	// independent of IngestEBPFFlows' disappearance diff — the idle reaper (#632).
+	PersistEBPFFlows(flows []traffic.EBPFFlow)
 }
 
 // defaultDomainRefreshInterval is how often egress_domains are re-resolved to
@@ -75,8 +89,9 @@ type NetworkPolicyEnforcer struct {
 	resolver      *DomainResolver // Phase C: egress_domains -> IPs
 	domainRefresh time.Duration
 
-	flowSink FlowSink      // #627: traffic-view flow accounting (nil = disabled)
-	flowPoll time.Duration // how often to read the BPF flows map
+	flowSink        FlowSink      // #627: traffic-view flow accounting (nil = disabled)
+	flowPoll        time.Duration // how often to read the BPF flows map
+	flowIdleTimeout time.Duration // #632: idle age past which a flow is reaped to history
 
 	loader *netbpf.Loader
 
@@ -104,6 +119,7 @@ func NewNetworkPolicyEnforcer(objPath string, store NetworkPolicyStore, registry
 		resolver:        NewDomainResolver(nil),
 		domainRefresh:   defaultDomainRefreshInterval,
 		flowPoll:        defaultFlowPollInterval,
+		flowIdleTimeout: defaultFlowIdleTimeout,
 		attached:        make(map[int]string),
 		idName:          make(map[uint32]string),
 		enforced:        make(map[uint32]bool),
@@ -314,7 +330,58 @@ func (e *NetworkPolicyEnforcer) pollFlows() {
 	}
 	e.mu.Unlock()
 
-	e.flowSink.IngestEBPFFlows(flowsToEBPF(records, attached, time.Now()))
+	now := time.Now()
+	active, idle := splitIdleFlows(records, monotonicNowNs(), e.flowIdleTimeout)
+
+	// Live view = currently-active flows only (an idle flow being reaped this
+	// poll shouldn't show as a live connection).
+	e.flowSink.IngestEBPFFlows(flowsToEBPF(active, attached, now))
+
+	// Idle reaper (#632): a flow whose last packet is older than the idle
+	// timeout has effectively closed. Persist its final counters to history,
+	// then delete it from the BPF map so it doesn't linger until the LRU map
+	// fills — the gap on-backend validation found, where a quiesced flow on a
+	// far-from-full 65536-entry map never disappeared, so closedFlows never
+	// fired and history stayed empty.
+	if len(idle) > 0 {
+		e.flowSink.PersistEBPFFlows(flowsToEBPF(idle, attached, now))
+		for _, r := range idle {
+			if err := e.loader.DeleteFlow(r); err != nil {
+				log.Printf("[netpolicy] reap idle flow: %v", err)
+			}
+		}
+	}
+}
+
+// splitIdleFlows partitions BPF flow records into still-active and idle by the
+// monotonic last-packet stamp. A flow whose last packet is older than idleFor
+// (relative to nowNs — the current CLOCK_MONOTONIC reading, the same clock
+// bpf_ktime_get_ns stamps records with) is treated as closed and returned in
+// idle for persist+forget (#632). Pure: no clock or loader access, so it is
+// unit-testable. A zero/garbage nowNs (clock read failed) yields no idle flows —
+// the sweep simply no-ops that poll rather than reaping live flows.
+func splitIdleFlows(records []netbpf.FlowRecord, nowNs uint64, idleFor time.Duration) (active, idle []netbpf.FlowRecord) {
+	cutoff := uint64(idleFor.Nanoseconds())
+	for _, r := range records {
+		if nowNs > r.LastNs && nowNs-r.LastNs > cutoff {
+			idle = append(idle, r)
+		} else {
+			active = append(active, r)
+		}
+	}
+	return active, idle
+}
+
+// monotonicNowNs returns CLOCK_MONOTONIC in nanoseconds — the same clock
+// bpf_ktime_get_ns() stamps flow records with, so the two are directly
+// comparable for idle detection. Returns 0 if the clock read fails (the caller
+// then reaps nothing that poll).
+func monotonicNowNs() uint64 {
+	var ts unix.Timespec
+	if err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts); err != nil {
+		return 0
+	}
+	return uint64(ts.Sec)*1_000_000_000 + uint64(ts.Nsec)
 }
 
 // flowsToEBPF attributes each BPF flow record to its container via the veth

--- a/internal/server/network_policy_flows_test.go
+++ b/internal/server/network_policy_flows_test.go
@@ -78,3 +78,32 @@ func TestProtoName(t *testing.T) {
 		}
 	}
 }
+
+// TestSplitIdleFlows covers the #632 idle reaper's partition: a flow whose last
+// packet is older than the timeout is reaped, a recent one stays active, and a
+// failed clock read (nowNs == 0) reaps nothing rather than sweeping live flows.
+func TestSplitIdleFlows(t *testing.T) {
+	const nowNs = uint64(100_000_000_000) // 100s on the monotonic clock
+	idleTimeout := 2 * time.Second
+	records := []netbpf.FlowRecord{
+		{Sport: 1, LastNs: nowNs - uint64(5*time.Second)}, // idle: 5s > 2s
+		{Sport: 2, LastNs: nowNs - uint64(1*time.Second)}, // active: 1s < 2s
+		{Sport: 3, LastNs: nowNs},                         // active: just now
+		{Sport: 4, LastNs: nowNs + uint64(time.Second)},   // future stamp (skew) -> active
+	}
+
+	active, idle := splitIdleFlows(records, nowNs, idleTimeout)
+
+	if len(idle) != 1 || idle[0].Sport != 1 {
+		t.Fatalf("idle = %+v, want exactly the sport=1 flow", idle)
+	}
+	if len(active) != 3 {
+		t.Fatalf("active = %d flows, want 3", len(active))
+	}
+
+	// Clock read failed (nowNs == 0): nothing is idle.
+	active0, idle0 := splitIdleFlows(records, 0, idleTimeout)
+	if len(idle0) != 0 || len(active0) != len(records) {
+		t.Fatalf("with nowNs=0 want no reaping; got active=%d idle=%d", len(active0), len(idle0))
+	}
+}

--- a/internal/traffic/collector.go
+++ b/internal/traffic/collector.go
@@ -272,8 +272,47 @@ func (c *Collector) IngestEBPFFlows(flows []EBPFFlow) {
 		next[conn.Id] = conn
 	}
 	c.mu.Lock()
+	prev := c.ebpfFlows
 	c.ebpfFlows = next
 	c.mu.Unlock()
+
+	// Persist flows that disappeared since the last poll to traffic_history
+	// (#632). The enforcer hands us the full active set each poll, so a flow in
+	// the previous set but not this one has been evicted from the BPF LRU map or
+	// aged out — effectively closed. Persisting its final cumulative counters is
+	// what lights up QueryTrafficHistory / GetTrafficAggregates on backends where
+	// the conntrack collector never attributed the flow (docker-in-LXC).
+	//
+	// SaveConnection is ON CONFLICT DO NOTHING keyed by the (stable) flow ID, so
+	// a re-evicted flow that briefly reappeared won't duplicate. Caveat: on a
+	// backend where conntrack attribution DOES work, the same logical flow may be
+	// persisted once by each source (distinct IDs) — true cross-source 5-tuple
+	// dedup is a follow-up; the eBPF path is the value-add where conntrack comes
+	// up empty.
+	if c.store != nil {
+		for _, conn := range closedFlows(prev, next) {
+			conn := conn
+			go func() {
+				if err := c.store.SaveConnection(c.ctx, conn); err != nil {
+					log.Printf("Warning: failed to persist closed eBPF flow: %v", err)
+				}
+			}()
+		}
+	}
+}
+
+// closedFlows returns the connections present in prev but not in next — flows
+// that the BPF map no longer reports (LRU-evicted or aged out), i.e. effectively
+// closed and ready to persist to history (#632). Pure, so it's unit-testable
+// without a database.
+func closedFlows(prev, next map[string]*pb.Connection) []*pb.Connection {
+	var out []*pb.Connection
+	for id, conn := range prev {
+		if _, stillActive := next[id]; !stillActive {
+			out = append(out, conn)
+		}
+	}
+	return out
 }
 
 // ebpfFlowID is a stable identifier for an eBPF flow, derived from its 5-tuple

--- a/internal/traffic/collector.go
+++ b/internal/traffic/collector.go
@@ -251,24 +251,7 @@ type EBPFFlow struct {
 func (c *Collector) IngestEBPFFlows(flows []EBPFFlow) {
 	next := make(map[string]*pb.Connection, len(flows))
 	for _, f := range flows {
-		conn := &pb.Connection{
-			Id:              ebpfFlowID(f),
-			ContainerName:   f.ContainerName,
-			ContainerIp:     f.ContainerIP,
-			Protocol:        protoStringToEnum(f.Protocol),
-			SourceIp:        f.SrcIP,
-			SourcePort:      uint32(f.SrcPort),
-			DestIp:          f.DstIP,
-			DestPort:        uint32(f.DstPort),
-			State:           pb.ConnectionState_CONNECTION_STATE_UNSPECIFIED,
-			Direction:       pb.TrafficDirection_TRAFFIC_DIRECTION_EGRESS,
-			BytesSent:       f.Bytes,
-			PacketsSent:     f.Packets,
-			BytesReceived:   f.RxBytes,   // reply direction via the veth egress hook (#631)
-			PacketsReceived: f.RxPackets, // 0 when the BPF object predates #631
-			FirstSeen:       timestamppb.New(f.First),
-			LastSeen:        timestamppb.New(f.Last),
-		}
+		conn := ebpfFlowToConn(f)
 		next[conn.Id] = conn
 	}
 	c.mu.Lock()
@@ -277,11 +260,12 @@ func (c *Collector) IngestEBPFFlows(flows []EBPFFlow) {
 	c.mu.Unlock()
 
 	// Persist flows that disappeared since the last poll to traffic_history
-	// (#632). The enforcer hands us the full active set each poll, so a flow in
-	// the previous set but not this one has been evicted from the BPF LRU map or
-	// aged out — effectively closed. Persisting its final cumulative counters is
-	// what lights up QueryTrafficHistory / GetTrafficAggregates on backends where
-	// the conntrack collector never attributed the flow (docker-in-LXC).
+	// (#632). The enforcer hands us the active set each poll, so a flow in the
+	// previous set but not this one has been evicted from the BPF LRU map, had
+	// its container removed, or was reaped by the idle sweep — effectively
+	// closed. Persisting its final cumulative counters is what lights up
+	// QueryTrafficHistory / GetTrafficAggregates on backends where the conntrack
+	// collector never attributed the flow (docker-in-LXC).
 	//
 	// SaveConnection is ON CONFLICT DO NOTHING keyed by the (stable) flow ID, so
 	// a re-evicted flow that briefly reappeared won't duplicate. Caveat: on a
@@ -289,15 +273,62 @@ func (c *Collector) IngestEBPFFlows(flows []EBPFFlow) {
 	// persisted once by each source (distinct IDs) — true cross-source 5-tuple
 	// dedup is a follow-up; the eBPF path is the value-add where conntrack comes
 	// up empty.
-	if c.store != nil {
-		for _, conn := range closedFlows(prev, next) {
-			conn := conn
-			go func() {
-				if err := c.store.SaveConnection(c.ctx, conn); err != nil {
-					log.Printf("Warning: failed to persist closed eBPF flow: %v", err)
-				}
-			}()
-		}
+	c.persistClosedFlows(closedFlows(prev, next))
+}
+
+// PersistEBPFFlows writes a batch of eBPF flows to traffic_history immediately,
+// independent of the prev/next disappearance diff IngestEBPFFlows uses. The idle
+// reaper (#632) calls this for flows it has determined are quiesced (last packet
+// older than the idle timeout) and is about to delete from the BPF map. Without
+// it, a flow that simply goes quiet never reaches history until the 65536-entry
+// LRU map fills enough to evict it — the gap on-backend validation found, where
+// a far-from-full map meant closedFlows never fired. SaveConnection is ON
+// CONFLICT DO NOTHING by flow ID, so a flow also caught by closedFlows on a later
+// poll isn't double-counted.
+func (c *Collector) PersistEBPFFlows(flows []EBPFFlow) {
+	conns := make([]*pb.Connection, 0, len(flows))
+	for _, f := range flows {
+		conns = append(conns, ebpfFlowToConn(f))
+	}
+	c.persistClosedFlows(conns)
+}
+
+// persistClosedFlows writes each closed eBPF flow to history off the hot path.
+// No-op when the store isn't configured (history disabled).
+func (c *Collector) persistClosedFlows(conns []*pb.Connection) {
+	if c.store == nil {
+		return
+	}
+	for _, conn := range conns {
+		conn := conn
+		go func() {
+			if err := c.store.SaveConnection(c.ctx, conn); err != nil {
+				log.Printf("Warning: failed to persist closed eBPF flow: %v", err)
+			}
+		}()
+	}
+}
+
+// ebpfFlowToConn renders an EBPFFlow as the pb.Connection both the live view and
+// history persistence use, so they can never drift.
+func ebpfFlowToConn(f EBPFFlow) *pb.Connection {
+	return &pb.Connection{
+		Id:              ebpfFlowID(f),
+		ContainerName:   f.ContainerName,
+		ContainerIp:     f.ContainerIP,
+		Protocol:        protoStringToEnum(f.Protocol),
+		SourceIp:        f.SrcIP,
+		SourcePort:      uint32(f.SrcPort),
+		DestIp:          f.DstIP,
+		DestPort:        uint32(f.DstPort),
+		State:           pb.ConnectionState_CONNECTION_STATE_UNSPECIFIED,
+		Direction:       pb.TrafficDirection_TRAFFIC_DIRECTION_EGRESS,
+		BytesSent:       f.Bytes,
+		PacketsSent:     f.Packets,
+		BytesReceived:   f.RxBytes,   // reply direction via the veth egress hook (#631)
+		PacketsReceived: f.RxPackets, // 0 when the BPF object predates #631
+		FirstSeen:       timestamppb.New(f.First),
+		LastSeen:        timestamppb.New(f.Last),
 	}
 }
 

--- a/internal/traffic/ebpf_flows_test.go
+++ b/internal/traffic/ebpf_flows_test.go
@@ -109,3 +109,42 @@ func TestIngestEBPFFlows_EmptyClears(t *testing.T) {
 		t.Errorf("after empty ingest = %d conns, want 0", n)
 	}
 }
+
+// TestClosedFlows_DetectsDisappeared guards the #632 persistence trigger: a flow
+// in the previous poll but absent from the next is "closed" and must be returned
+// for persistence; flows still active are not.
+func TestClosedFlows_DetectsDisappeared(t *testing.T) {
+	mk := func(id string) *pb.Connection { return &pb.Connection{Id: id} }
+	prev := map[string]*pb.Connection{
+		"ebpf-a": mk("ebpf-a"), // stays
+		"ebpf-b": mk("ebpf-b"), // disappears → closed
+		"ebpf-c": mk("ebpf-c"), // disappears → closed
+	}
+	next := map[string]*pb.Connection{
+		"ebpf-a": mk("ebpf-a"),
+		"ebpf-d": mk("ebpf-d"), // new
+	}
+
+	closed := closedFlows(prev, next)
+	if len(closed) != 2 {
+		t.Fatalf("closedFlows returned %d, want 2", len(closed))
+	}
+	got := map[string]bool{}
+	for _, c := range closed {
+		got[c.Id] = true
+	}
+	if !got["ebpf-b"] || !got["ebpf-c"] {
+		t.Errorf("closed = %v, want ebpf-b + ebpf-c", got)
+	}
+	if got["ebpf-a"] {
+		t.Error("still-active flow ebpf-a must not be reported closed")
+	}
+}
+
+// TestClosedFlows_FirstPollEmpty: nothing closes on the first ingest (no prior).
+func TestClosedFlows_FirstPollEmpty(t *testing.T) {
+	next := map[string]*pb.Connection{"ebpf-a": {Id: "ebpf-a"}}
+	if c := closedFlows(map[string]*pb.Connection{}, next); len(c) != 0 {
+		t.Errorf("first poll should close nothing, got %d", len(c))
+	}
+}


### PR DESCRIPTION
Closes #632. **Stacked on #641 (#631)** — review/merge that first; its diff is included here until it lands. **Draft** — needs on-backend eBPF validation.

## Problem

#627 made the **live** traffic view eBPF-sourced, but **history**
(`traffic_history`, read by `QueryTrafficHistory` / `GetTrafficAggregates`) stayed
conntrack-only. The eBPF path has no "connection closed" event — flows just age
out of the BPF LRU map — so nothing was ever recorded. On docker-in-LXC backends
(where conntrack attribution fails, the case #627 targets) history stayed empty
even though the live view worked.

## Fix

The enforcer's poll hands the collector the **full active set** each time
(full-replace), so a flow present in the previous set but absent from the next
has been evicted/aged-out = **effectively closed**. `IngestEBPFFlows` now
persists those via the same `Store.SaveConnection` path conntrack uses on close.

- `closedFlows(prev, next)` — pure set-difference helper (unit-testable without a
  DB); `IngestEBPFFlows` persists each closed flow async, guarded on
  `c.store != nil`.
- `SaveConnection` is `ON CONFLICT DO NOTHING` keyed by the stable flow ID, so a
  briefly-reappearing flow won't duplicate.

## Caveat (documented)

On a backend where conntrack attribution **also** works, the same logical flow
may be persisted once per source (distinct IDs). True cross-source 5-tuple dedup
is a follow-up; the eBPF path is the value-add precisely where conntrack comes up
empty. Also: flows still active at daemon shutdown aren't flushed (no final
poll) — acceptable for v1.

## Tests

`closedFlows` detects disappeared vs still-active and no-ops on the first poll.
Full `traffic` suite green; `go build ./...` clean.

## ⚠️ Draft

Meaningfully exercised only against eBPF on a Linux backend (a flow must be
generated, observed, then evicted, and the row confirmed in
`QueryTrafficHistory`). Same backend gate as #628/#641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
