### PR TITLE
feat(traffic): arbitrate conntrack vs eBPF per container to avoid double-count (#643)

### DIFF
--- a/docs/security/NETWORK-ISOLATION-DESIGN.md
+++ b/docs/security/NETWORK-ISOLATION-DESIGN.md
@@ -400,10 +400,16 @@ Properties / limits:
   between polls (LRU-evicted or aged out = effectively closed),
   its final counters are written to `traffic_history` via the
   same `SaveConnection` path conntrack uses, so the historical
-  view + aggregates light up on eBPF-only backends. Caveat: on a
-  backend where conntrack attribution also works, the same
-  logical flow may be persisted once per source (distinct IDs) —
-  cross-source 5-tuple dedup is a follow-up.
+  view + aggregates light up on eBPF-only backends.
+- **Source arbitration (#643).** conntrack and eBPF both feed the
+  view, so to avoid double-counting the collector tracks which
+  containers conntrack has attributed (`conntrackSeen`). Where
+  conntrack works for a container it owns that container's
+  traffic — the eBPF copies are suppressed from both the live
+  view and history persistence. Where it doesn't (docker-in-LXC),
+  conntrack never attributes the container, so eBPF is the sole
+  source and is used. Container-granularity, so there's no
+  per-flow timing race.
 
 ## What this is NOT
 

--- a/internal/traffic/collector.go
+++ b/internal/traffic/collector.go
@@ -56,6 +56,16 @@ type Collector struct {
 	mu          sync.RWMutex
 	connections map[string]*pb.Connection // conntrack ID -> connection
 	ebpfFlows   map[string]*pb.Connection // eBPF flow ID -> connection (#627)
+	// conntrackSeen is the set of container names the conntrack collector has
+	// successfully attributed at least one flow for. It's the source-arbitration
+	// signal for #643: where conntrack works for a container, it owns that
+	// container's traffic (live view + history), so the eBPF flow data is
+	// suppressed to avoid double-counting; where it doesn't (docker-in-LXC,
+	// masquerade — conntrack never attributes the container), eBPF is the only
+	// source and is used. Container-granularity, so there's no per-flow timing
+	// race. Sticky: once true it stays true (attribution is by container IP,
+	// all-or-nothing per container).
+	conntrackSeen map[string]bool
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -78,16 +88,17 @@ func NewCollector(config CollectorConfig, incusClient *incus.Client, store *Stor
 	}
 
 	return &Collector{
-		config:      config,
-		incusClient: incusClient,
-		store:       store,
-		cache:       cache,
-		monitor:     monitor,
-		emitter:     emitter,
-		connections: make(map[string]*pb.Connection),
-		ebpfFlows:   make(map[string]*pb.Connection),
-		ctx:         ctx,
-		cancel:      cancel,
+		config:        config,
+		incusClient:   incusClient,
+		store:         store,
+		cache:         cache,
+		monitor:       monitor,
+		emitter:       emitter,
+		connections:   make(map[string]*pb.Connection),
+		ebpfFlows:     make(map[string]*pb.Connection),
+		conntrackSeen: make(map[string]bool),
+		ctx:           ctx,
+		cancel:        cancel,
 	}, nil
 }
 
@@ -167,6 +178,7 @@ func (c *Collector) processConntrackEvent(event *ConntrackEvent) {
 
 	// Update local cache
 	c.mu.Lock()
+	c.conntrackSeen[containerName] = true // conntrack owns this container's history (#643)
 	if event.Type == ConntrackEventDestroy {
 		delete(c.connections, event.ID)
 	} else {
@@ -268,11 +280,11 @@ func (c *Collector) IngestEBPFFlows(flows []EBPFFlow) {
 	// collector never attributed the flow (docker-in-LXC).
 	//
 	// SaveConnection is ON CONFLICT DO NOTHING keyed by the (stable) flow ID, so
-	// a re-evicted flow that briefly reappeared won't duplicate. Caveat: on a
-	// backend where conntrack attribution DOES work, the same logical flow may be
-	// persisted once by each source (distinct IDs) — true cross-source 5-tuple
-	// dedup is a follow-up; the eBPF path is the value-add where conntrack comes
-	// up empty.
+	// a re-evicted flow that briefly reappeared won't duplicate. Cross-source
+	// dedup (#643) is applied inside persistClosedFlows: a flow whose container
+	// conntrack already attributes is skipped, so the same logical flow doesn't
+	// land in history once per source. The eBPF path is the sole writer only
+	// where conntrack came up empty (docker-in-LXC).
 	c.persistClosedFlows(closedFlows(prev, next))
 }
 
@@ -294,12 +306,19 @@ func (c *Collector) PersistEBPFFlows(flows []EBPFFlow) {
 }
 
 // persistClosedFlows writes each closed eBPF flow to history off the hot path.
-// No-op when the store isn't configured (history disabled).
+// No-op when the store isn't configured (history disabled). Cross-source dedup
+// (#643): a flow whose container conntrack already attributes is skipped here —
+// otherwise the same logical flow lands in history once per source. Applying it
+// at this shared chokepoint covers both the closedFlows (eviction) path and the
+// idle reaper (#632), so neither double-counts against conntrack.
 func (c *Collector) persistClosedFlows(conns []*pb.Connection) {
 	if c.store == nil {
 		return
 	}
 	for _, conn := range conns {
+		if c.conntrackOwns(conn.ContainerName) {
+			continue
+		}
 		conn := conn
 		go func() {
 			if err := c.store.SaveConnection(c.ctx, conn); err != nil {
@@ -330,6 +349,16 @@ func ebpfFlowToConn(f EBPFFlow) *pb.Connection {
 		FirstSeen:       timestamppb.New(f.First),
 		LastSeen:        timestamppb.New(f.Last),
 	}
+}
+
+// conntrackOwns reports whether the conntrack collector has attributed traffic
+// for container — in which case it owns that container's history and the eBPF
+// path defers to it (#643). Takes its own read lock; do NOT call while already
+// holding c.mu.
+func (c *Collector) conntrackOwns(container string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.conntrackSeen[container]
 }
 
 // closedFlows returns the connections present in prev but not in next — flows
@@ -439,6 +468,7 @@ func (c *Collector) takeSnapshot() {
 		}
 
 		matched++
+		c.conntrackSeen[containerName] = true // conntrack owns this container's history (#643)
 		conn := c.convertToProto(event, containerName, containerIP, direction)
 		c.connections[event.ID] = conn
 	}
@@ -487,7 +517,13 @@ func (c *Collector) GetConnections(containerName string) []*pb.Connection {
 	}
 	// Merge eBPF-sourced flows (#627). On backends where conntrack attribution
 	// fails (docker-in-LXC, masquerade), these may be the only connections seen.
+	// Where conntrack DID attribute the container, it already lists these flows,
+	// so skip the eBPF copies to avoid double-display (#643). Read under the held
+	// RLock.
 	for _, conn := range c.ebpfFlows {
+		if c.conntrackSeen[conn.ContainerName] {
+			continue
+		}
 		if containerName == "" || conn.ContainerName == containerName {
 			result = append(result, conn)
 		}

--- a/internal/traffic/ebpf_flows_test.go
+++ b/internal/traffic/ebpf_flows_test.go
@@ -14,9 +14,10 @@ func newTestCollector() *Collector {
 	cache := NewContainerCache(nil, "10.100.0.0/24")
 	cache.nameToIP["seed-container"] = "10.100.0.1" // make Size() > 0
 	return &Collector{
-		cache:       cache,
-		connections: make(map[string]*pb.Connection),
-		ebpfFlows:   make(map[string]*pb.Connection),
+		cache:         cache,
+		connections:   make(map[string]*pb.Connection),
+		ebpfFlows:     make(map[string]*pb.Connection),
+		conntrackSeen: make(map[string]bool),
 	}
 }
 
@@ -146,5 +147,43 @@ func TestClosedFlows_FirstPollEmpty(t *testing.T) {
 	next := map[string]*pb.Connection{"ebpf-a": {Id: "ebpf-a"}}
 	if c := closedFlows(map[string]*pb.Connection{}, next); len(c) != 0 {
 		t.Errorf("first poll should close nothing, got %d", len(c))
+	}
+}
+
+// TestEBPFFlows_SuppressedWhenConntrackOwns guards #643: once conntrack has
+// attributed a container, the eBPF copies of that container's flows are NOT
+// shown in the live view (conntrack already lists them) — but a container
+// conntrack never attributed (docker-in-LXC) still surfaces via eBPF.
+func TestEBPFFlows_SuppressedWhenConntrackOwns(t *testing.T) {
+	c := newTestCollector()
+	// conntrack attributed "web-container" but never "lxc-container".
+	c.conntrackSeen["web-container"] = true
+
+	c.IngestEBPFFlows([]EBPFFlow{
+		{ContainerName: "web-container", SrcIP: "10.100.0.42", DstIP: "1.1.1.1", Protocol: "tcp", Bytes: 1},
+		{ContainerName: "lxc-container", SrcIP: "10.100.0.50", DstIP: "8.8.8.8", Protocol: "udp", Bytes: 2},
+	})
+
+	all := c.GetConnections("")
+	if len(all) != 1 {
+		t.Fatalf("GetConnections = %d, want 1 (web suppressed, lxc shown)", len(all))
+	}
+	if all[0].ContainerName != "lxc-container" {
+		t.Errorf("surfaced %q, want lxc-container (conntrack-owned web suppressed)", all[0].ContainerName)
+	}
+	// Explicit filter for a conntrack-owned container yields nothing from eBPF.
+	if n := len(c.GetConnections("web-container")); n != 0 {
+		t.Errorf("GetConnections(web-container) = %d, want 0 (conntrack owns it)", n)
+	}
+}
+
+func TestConntrackOwns(t *testing.T) {
+	c := newTestCollector()
+	if c.conntrackOwns("x") {
+		t.Error("unseen container should not be owned")
+	}
+	c.conntrackSeen["x"] = true
+	if !c.conntrackOwns("x") {
+		t.Error("seen container should be owned")
 	}
 }


### PR DESCRIPTION
Closes #643. **Stacked on #642 (#632)** → base branch `feat/traffic-history-persist`; review/merge that first (its diff shows here until it lands).

## Problem

conntrack and eBPF both feed the traffic view. #632 had the eBPF path persist
closed flows to `traffic_history`, but on a backend where conntrack attribution
**also** works, the same logical flow was recorded **once per source** (distinct
IDs) — inflating `QueryTrafficHistory` and especially `GetTrafficAggregates` byte
sums. The live view (#627) had the same double-**display**.

## Approach chosen

Of the options in #643, I picked **source arbitration at container granularity**
over a schema/SQL change, because it's **topology-independent** (no guessing
about masquerade) and **fully unit-testable without a database**:

> Where conntrack has attributed a container, it owns that container's traffic —
> suppress the eBPF copies. Where it hasn't (docker-in-LXC: conntrack never
> attributes the container), eBPF is the sole source and is used.

- Collector tracks `conntrackSeen` — container names conntrack attributed, marked
  in `processConntrackEvent` + `takeSnapshot` under the existing lock.
- `GetConnections` skips eBPF flows for conntrack-owned containers (live view).
- `IngestEBPFFlows` skips persisting closed flows for conntrack-owned containers
  (history), via `conntrackOwns()`.

**No race:** it's container-granularity, not per-flow timing. Attribution is by
container IP (all-or-nothing per container) and the flag is sticky once set — so
there's no dependency on the relative ordering of conntrack-destroy vs
eBPF-eviction that a per-flow rule would have.

Why not the schema/query-time options: a unique index keyed on 5-tuple+time
can't match because the two sources stamp different `started_at`; query-time
collapse breaks pagination; and any SQL-layer change can't be unit-tested in
this environment. The container rule is correct, simple, and testable.

## Tests

A conntrack-owned container's eBPF flows are suppressed from the live view while
an unattributed (docker-in-LXC) container still surfaces; `conntrackOwns` lookup.
Race-clean (`go test -race`); full `traffic` suite green; `go build ./...` clean.

## Note

Like #641/#642 this is most meaningfully exercised on a Linux backend (the eBPF
side is what produces the duplicate), but the arbitration logic itself is pure Go
and unit-tested here. Not marking draft — the logic stands on its own — but it
**must merge after #642**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
