### PR TITLE
feat(skills/crews): optional signed-catalog provenance check on LoadDir (#648)

### DIFF
--- a/docs/AGENT-SKILLS-QUICKSTART.md
+++ b/docs/AGENT-SKILLS-QUICKSTART.md
@@ -248,6 +248,36 @@ skills:
       capabilities: [example]
 ```
 
+### Require signed external catalogs (optional, #648)
+
+Loading a directory you authored yourself needs no signature — that's the
+default and is unchanged. Once a catalog is **distributed** from outside your
+own tree (a packaged catalog you didn't write), you can require a provenance
+check so the daemon loads only catalogs whose signature it can verify against a
+trusted key. Verification is **offline** (no network), so it works air-gapped.
+
+Turn it on with two env vars:
+
+```sh
+export CONTAINARIUM_CATALOG_REQUIRE_SIGNED=1
+export CONTAINARIUM_CATALOG_TRUSTED_PUBKEYS=/etc/containarium/catalog-trusted.keys
+```
+
+`catalog-trusted.keys` holds one **base64 ed25519 public key per line** (blank
+lines and `#` comments ignored — list several keys to support rotation). Each
+catalog file then needs a detached signature sitting next to it: `foo.yaml` →
+`foo.yaml.sig`, where the `.sig` is the **base64 ed25519 signature over the
+exact bytes** of `foo.yaml`.
+
+When the mode is on, a file with a **missing or bad** signature fails the
+load with a clear error — it is not silently skipped. When it's off, catalogs
+load unsigned exactly as before.
+
+Generating keys and signatures is left to the operator/distributor (key custody
+and *who* signs are out of scope). For example, with Go's `crypto/ed25519` or
+any ed25519 tool: sign the raw file bytes and base64-encode the 64-byte
+signature into `<file>.yaml.sig`.
+
 ## Limitations (by design)
 
 - **No in-box loop / A2A server yet** — the box is provisioned, seeded, and

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/footprintai/containarium/internal/ttlsweeper"
 	"github.com/footprintai/containarium/internal/wake"
 	zapscanner "github.com/footprintai/containarium/internal/zap"
+	"github.com/footprintai/containarium/pkg/core/catalogsig"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/crews"
 	"github.com/footprintai/containarium/pkg/core/incus"
@@ -332,18 +333,30 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	// the agent/crew servers use, so out-of-tree packs register without a
 	// rebuild. Skills first (crews reference them). Best-effort: a bad external
 	// catalog logs and is skipped rather than failing daemon startup.
-	if dir := os.Getenv("CONTAINARIUM_SKILLS_DIR"); dir != "" {
-		if err := skills.GetDefault().LoadDir(dir); err != nil {
-			log.Printf("[agent-skill] external skills from %s: %v", dir, err)
-		} else {
-			log.Printf("Loaded external skills from %s", dir)
+	//
+	// Optional provenance check (#648): when require-signed mode is on, each
+	// external catalog file must carry a valid detached signature under a
+	// trusted key. catalogVerifier is nil when the mode is off (load unsigned,
+	// as before). A misconfigured require-signed mode (e.g. no trusted key)
+	// fails closed — we skip loading external catalogs rather than fall back to
+	// unsigned.
+	catalogVerifier, verr := catalogsig.FromEnv()
+	if verr != nil {
+		log.Printf("[catalog] require-signed mode misconfigured, skipping external catalogs: %v", verr)
+	} else {
+		if dir := os.Getenv("CONTAINARIUM_SKILLS_DIR"); dir != "" {
+			if err := skills.GetDefault().LoadDirVerified(dir, catalogVerifier); err != nil {
+				log.Printf("[agent-skill] external skills from %s: %v", dir, err)
+			} else {
+				log.Printf("Loaded external skills from %s", dir)
+			}
 		}
-	}
-	if dir := os.Getenv("CONTAINARIUM_CREWS_DIR"); dir != "" {
-		if err := crews.GetDefault().LoadDir(dir); err != nil {
-			log.Printf("[crew] external crews from %s: %v", dir, err)
-		} else {
-			log.Printf("Loaded external crews from %s", dir)
+		if dir := os.Getenv("CONTAINARIUM_CREWS_DIR"); dir != "" {
+			if err := crews.GetDefault().LoadDirVerified(dir, catalogVerifier); err != nil {
+				log.Printf("[crew] external crews from %s: %v", dir, err)
+			} else {
+				log.Printf("Loaded external crews from %s", dir)
+			}
 		}
 	}
 

--- a/pkg/core/catalogsig/catalogsig.go
+++ b/pkg/core/catalogsig/catalogsig.go
@@ -1,0 +1,157 @@
+// Package catalogsig provides an optional, offline provenance check for
+// external skill/crew catalogs loaded from disk (#648). It verifies a detached
+// ed25519 signature of each catalog file against a set of operator-configured
+// trusted public keys before the file is parsed and merged.
+//
+// The check is opt-in. When require-signed mode is off (the default), callers
+// load catalogs unsigned exactly as before — this is correct for the
+// self-authored / BYOA path where the operator points the env var at a
+// directory they wrote themselves. The check only matters once a catalog is
+// distributed from outside the operator's own tree, where "did this manifest
+// come from a source I trust, intact" is a real question.
+//
+// Verification performs no network I/O: the trusted keys are configured
+// locally, so it works for air-gapped installs.
+package catalogsig
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Environment variables that configure the provenance check.
+const (
+	// EnvRequireSigned, when truthy ("1"/"true"/"yes"), turns on require-signed
+	// mode: every external catalog file must carry a valid detached signature.
+	EnvRequireSigned = "CONTAINARIUM_CATALOG_REQUIRE_SIGNED"
+	// EnvTrustedKeys names a file holding the trusted public keys: one
+	// base64-encoded ed25519 public key per line, with blank lines and
+	// '#'-prefixed comments ignored. At least one key is required when
+	// require-signed mode is on.
+	EnvTrustedKeys = "CONTAINARIUM_CATALOG_TRUSTED_PUBKEYS"
+)
+
+// SigSuffix is appended to a catalog file's name to find its detached
+// signature: foo.yaml -> foo.yaml.sig. The .sig file holds the base64-encoded
+// raw ed25519 signature (64 bytes) over the exact bytes of the catalog file.
+const SigSuffix = ".sig"
+
+// Verifier checks detached ed25519 signatures against a set of trusted public
+// keys. The zero value is not usable; build one with FromEnv or LoadVerifier.
+type Verifier struct {
+	keys []ed25519.PublicKey
+}
+
+// NewVerifier builds a Verifier over the given trusted ed25519 public keys.
+// It is the programmatic counterpart to LoadVerifier (which reads keys from a
+// file); a caller embedding its own trusted keys can use this directly.
+func NewVerifier(keys ...ed25519.PublicKey) *Verifier {
+	return &Verifier{keys: keys}
+}
+
+// FromEnv builds a Verifier from operator configuration.
+//
+// It returns (nil, nil) when require-signed mode is off — the caller then loads
+// catalogs unsigned, exactly as before. When the mode is on, it requires
+// EnvTrustedKeys to name a file with at least one valid key, otherwise it
+// returns an error so the caller fails closed rather than loading unsigned.
+func FromEnv() (*Verifier, error) {
+	if !truthy(os.Getenv(EnvRequireSigned)) {
+		return nil, nil
+	}
+	path := os.Getenv(EnvTrustedKeys)
+	if path == "" {
+		return nil, fmt.Errorf("%s is on but %s names no trusted public-key file", EnvRequireSigned, EnvTrustedKeys)
+	}
+	return LoadVerifier(path)
+}
+
+// LoadVerifier reads trusted ed25519 public keys from path (one base64 key per
+// line; blanks and '#' comments ignored) and returns a Verifier over them.
+func LoadVerifier(path string) (*Verifier, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read trusted catalog keys %q: %w", path, err)
+	}
+	var keys []ed25519.PublicKey
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	for line := 1; sc.Scan(); line++ {
+		raw := strings.TrimSpace(sc.Text())
+		if raw == "" || strings.HasPrefix(raw, "#") {
+			continue
+		}
+		key, err := DecodePublicKey(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s line %d: %w", path, line, err)
+		}
+		keys = append(keys, key)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("read trusted catalog keys %q: %w", path, err)
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("trusted catalog keys file %q has no usable keys", path)
+	}
+	return &Verifier{keys: keys}, nil
+}
+
+// Verify reports whether sig is a valid ed25519 signature of data under any of
+// the trusted keys. It returns nil on success and a descriptive error otherwise.
+func (v *Verifier) Verify(data, sig []byte) error {
+	if v == nil {
+		return fmt.Errorf("no verifier configured")
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("signature is %d bytes, want %d", len(sig), ed25519.SignatureSize)
+	}
+	for _, k := range v.keys {
+		if ed25519.Verify(k, data, sig) {
+			return nil
+		}
+	}
+	return fmt.Errorf("no trusted key verifies this signature")
+}
+
+// ReadDetachedSig reads and base64-decodes the detached signature sitting next
+// to a catalog file (catalogPath + SigSuffix). A missing or malformed signature
+// is a hard error — the load must not silently skip it.
+func ReadDetachedSig(catalogPath string) ([]byte, error) {
+	sigPath := catalogPath + SigSuffix
+	raw, err := os.ReadFile(sigPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("missing detached signature %q (require-signed mode is on)", sigPath)
+		}
+		return nil, fmt.Errorf("read signature %q: %w", sigPath, err)
+	}
+	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(raw)))
+	if err != nil {
+		return nil, fmt.Errorf("decode signature %q: %w", sigPath, err)
+	}
+	return sig, nil
+}
+
+// DecodePublicKey decodes a base64-encoded ed25519 public key.
+func DecodePublicKey(b64 string) (ed25519.PublicKey, error) {
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64))
+	if err != nil {
+		return nil, fmt.Errorf("decode public key: %w", err)
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("public key is %d bytes, want %d", len(raw), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(raw), nil
+}
+
+func truthy(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}

--- a/pkg/core/catalogsig/catalogsig_test.go
+++ b/pkg/core/catalogsig/catalogsig_test.go
@@ -1,0 +1,182 @@
+package catalogsig
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func genKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+// writeKeyFile writes a trusted-keys file with the given public keys, base64 one
+// per line, plus a comment and a blank line to exercise the parser.
+func writeKeyFile(t *testing.T, dir string, pubs ...ed25519.PublicKey) string {
+	t.Helper()
+	path := filepath.Join(dir, "trusted.keys")
+	body := "# trusted catalog keys\n\n"
+	for _, p := range pubs {
+		body += base64.StdEncoding.EncodeToString(p) + "\n"
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+	return path
+}
+
+func TestVerifyAcceptsGoodSignature(t *testing.T) {
+	pub, priv := genKey(t)
+	v := &Verifier{keys: []ed25519.PublicKey{pub}}
+	data := []byte("skills:\n  - id: x\n")
+	if err := v.Verify(data, ed25519.Sign(priv, data)); err != nil {
+		t.Fatalf("Verify good sig: %v", err)
+	}
+}
+
+func TestVerifyRejectsTamperedDataAndWrongKey(t *testing.T) {
+	pub, priv := genKey(t)
+	_, otherPriv := genKey(t)
+	v := &Verifier{keys: []ed25519.PublicKey{pub}}
+	data := []byte("skills:\n  - id: x\n")
+
+	// Tampered payload, valid-shape signature over the original.
+	if err := v.Verify([]byte("skills:\n  - id: evil\n"), ed25519.Sign(priv, data)); err == nil {
+		t.Fatal("expected tampered data to fail verification")
+	}
+	// Right data, signed by an untrusted key.
+	if err := v.Verify(data, ed25519.Sign(otherPriv, data)); err == nil {
+		t.Fatal("expected untrusted-key signature to fail verification")
+	}
+	// Wrong-size signature.
+	if err := v.Verify(data, []byte("short")); err == nil {
+		t.Fatal("expected wrong-size signature to fail verification")
+	}
+}
+
+func TestVerifyMultipleTrustedKeysAllowsRotation(t *testing.T) {
+	oldPub, _ := genKey(t)
+	newPub, newPriv := genKey(t)
+	v := &Verifier{keys: []ed25519.PublicKey{oldPub, newPub}}
+	data := []byte("crews:\n  - id: c\n")
+	if err := v.Verify(data, ed25519.Sign(newPriv, data)); err != nil {
+		t.Fatalf("rotation: signature under one trusted key should verify: %v", err)
+	}
+}
+
+func TestLoadVerifierRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	pub, priv := genKey(t)
+	keyPath := writeKeyFile(t, dir, pub)
+
+	v, err := LoadVerifier(keyPath)
+	if err != nil {
+		t.Fatalf("LoadVerifier: %v", err)
+	}
+	data := []byte("hello")
+	if err := v.Verify(data, ed25519.Sign(priv, data)); err != nil {
+		t.Fatalf("Verify after LoadVerifier: %v", err)
+	}
+}
+
+func TestLoadVerifierRejectsBadKeyFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// No usable keys.
+	empty := filepath.Join(dir, "empty.keys")
+	if err := os.WriteFile(empty, []byte("# only comments\n\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadVerifier(empty); err == nil {
+		t.Fatal("expected error for key file with no usable keys")
+	}
+
+	// Malformed key.
+	bad := filepath.Join(dir, "bad.keys")
+	if err := os.WriteFile(bad, []byte("not-base64-!!\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadVerifier(bad); err == nil {
+		t.Fatal("expected error for malformed key")
+	}
+
+	// Missing file.
+	if _, err := LoadVerifier(filepath.Join(dir, "nope.keys")); err == nil {
+		t.Fatal("expected error for missing key file")
+	}
+}
+
+func TestFromEnv(t *testing.T) {
+	dir := t.TempDir()
+	pub, _ := genKey(t)
+	keyPath := writeKeyFile(t, dir, pub)
+
+	// Off by default -> nil verifier, no error.
+	t.Setenv(EnvRequireSigned, "")
+	t.Setenv(EnvTrustedKeys, "")
+	v, err := FromEnv()
+	if err != nil || v != nil {
+		t.Fatalf("FromEnv off: want (nil,nil), got (%v,%v)", v, err)
+	}
+
+	// On but no key file -> fail closed.
+	t.Setenv(EnvRequireSigned, "1")
+	t.Setenv(EnvTrustedKeys, "")
+	if _, err := FromEnv(); err == nil {
+		t.Fatal("FromEnv on without trusted keys should error (fail closed)")
+	}
+
+	// On with a key file -> usable verifier.
+	t.Setenv(EnvTrustedKeys, keyPath)
+	v, err = FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv on: %v", err)
+	}
+	if v == nil {
+		t.Fatal("FromEnv on: expected a verifier")
+	}
+}
+
+func TestReadDetachedSig(t *testing.T) {
+	dir := t.TempDir()
+	_, priv := genKey(t)
+	catalog := filepath.Join(dir, "skills.yaml")
+	data := []byte("skills: []\n")
+	if err := os.WriteFile(catalog, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Missing sig is a hard error.
+	if _, err := ReadDetachedSig(catalog); err == nil {
+		t.Fatal("expected error for missing detached signature")
+	}
+
+	// Present, well-formed sig decodes to the raw signature bytes.
+	sig := ed25519.Sign(priv, data)
+	if err := os.WriteFile(catalog+SigSuffix, []byte(base64.StdEncoding.EncodeToString(sig)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadDetachedSig(catalog)
+	if err != nil {
+		t.Fatalf("ReadDetachedSig: %v", err)
+	}
+	if string(got) != string(sig) {
+		t.Fatal("decoded signature does not match")
+	}
+
+	// Malformed base64 is a hard error.
+	if err := os.WriteFile(catalog+SigSuffix, []byte("not base64 !!"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadDetachedSig(catalog); err == nil {
+		t.Fatal("expected error for malformed signature encoding")
+	}
+}

--- a/pkg/core/crews/crews.go
+++ b/pkg/core/crews/crews.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/footprintai/containarium/pkg/core/catalogsig"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"gopkg.in/yaml.v3"
 )
@@ -133,8 +134,18 @@ func validate(c *crewDef) error {
 // built-ins (#620). A missing dir is not an error. Fails on a parse/validate
 // error or an id that collides with an already-loaded crew. (Topology vs the
 // members' allowed_peers is validated at RunCrew time, against the skill
-// catalog — so load external skills before external crews.)
+// catalog — so load external skills before external crews.) Catalogs are
+// loaded unsigned; use LoadDirVerified to require a provenance check.
 func (m *Manager) LoadDir(dir string) error {
+	return m.LoadDirVerified(dir, nil)
+}
+
+// LoadDirVerified is LoadDir with an optional provenance check (#648). When v
+// is non-nil (require-signed mode on), each *.yaml file must carry a valid
+// detached ed25519 signature (foo.yaml.sig) under a trusted key, verified
+// before parse/merge; a missing or bad signature fails that file's load rather
+// than silently skipping it. When v is nil, behavior is identical to LoadDir.
+func (m *Manager) LoadDirVerified(dir string, v *catalogsig.Verifier) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -146,9 +157,19 @@ func (m *Manager) LoadDir(dir string) error {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("read %s: %w", e.Name(), err)
+		}
+		if v != nil {
+			sig, err := catalogsig.ReadDetachedSig(path)
+			if err != nil {
+				return fmt.Errorf("%s: %w", e.Name(), err)
+			}
+			if err := v.Verify(data, sig); err != nil {
+				return fmt.Errorf("%s: signature verification failed: %w", e.Name(), err)
+			}
 		}
 		if err := m.mergeBytes(data); err != nil {
 			return fmt.Errorf("%s: %w", e.Name(), err)

--- a/pkg/core/skills/skills.go
+++ b/pkg/core/skills/skills.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/catalogsig"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"gopkg.in/yaml.v3"
 )
@@ -173,8 +174,18 @@ func validate(s *skillDef) error {
 // loaded (the embedded built-ins), so out-of-tree catalogs can register skills
 // without recompiling (#620). A missing dir is not an error (no external
 // catalog configured). Fails on a parse/validate error or an id that collides
-// with an already-loaded skill.
+// with an already-loaded skill. Catalogs are loaded unsigned; use
+// LoadDirVerified to require a provenance check.
 func (m *Manager) LoadDir(dir string) error {
+	return m.LoadDirVerified(dir, nil)
+}
+
+// LoadDirVerified is LoadDir with an optional provenance check (#648). When v
+// is non-nil (require-signed mode on), each *.yaml file must carry a valid
+// detached ed25519 signature (foo.yaml.sig) under a trusted key, verified
+// before parse/merge; a missing or bad signature fails that file's load rather
+// than silently skipping it. When v is nil, behavior is identical to LoadDir.
+func (m *Manager) LoadDirVerified(dir string, v *catalogsig.Verifier) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -186,9 +197,19 @@ func (m *Manager) LoadDir(dir string) error {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("read %s: %w", e.Name(), err)
+		}
+		if v != nil {
+			sig, err := catalogsig.ReadDetachedSig(path)
+			if err != nil {
+				return fmt.Errorf("%s: %w", e.Name(), err)
+			}
+			if err := v.Verify(data, sig); err != nil {
+				return fmt.Errorf("%s: signature verification failed: %w", e.Name(), err)
+			}
 		}
 		if err := m.mergeBytes(data); err != nil {
 			return fmt.Errorf("%s: %w", e.Name(), err)

--- a/pkg/core/skills/skills_test.go
+++ b/pkg/core/skills/skills_test.go
@@ -1,10 +1,96 @@
 package skills
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/catalogsig"
 )
+
+const extSkillYAML = `
+skills:
+  - id: ext-skill
+    recipe_id: agent-runtime
+    system_prompt: external
+    allowed_scopes: [security:read]
+`
+
+// TestLoadDirVerified covers the optional provenance check (#648): a good
+// signature loads, a missing or tampered one fails closed, and a nil verifier
+// is the unchanged unsigned path.
+func TestLoadDirVerified(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := catalogsig.NewVerifier(pub)
+
+	writeCatalog := func(dir string, signWith ed25519.PrivateKey) {
+		path := filepath.Join(dir, "ext.yaml")
+		if err := os.WriteFile(path, []byte(extSkillYAML), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if signWith != nil {
+			sig := ed25519.Sign(signWith, []byte(extSkillYAML))
+			if err := os.WriteFile(path+catalogsig.SigSuffix, []byte(base64.StdEncoding.EncodeToString(sig)), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	t.Run("good signature loads", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCatalog(dir, priv)
+		m := New()
+		if err := m.LoadDirVerified(dir, v); err != nil {
+			t.Fatalf("LoadDirVerified good sig: %v", err)
+		}
+		if _, err := m.Get("ext-skill"); err != nil {
+			t.Error("signed external skill not merged")
+		}
+	})
+
+	t.Run("missing signature fails", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCatalog(dir, nil) // no .sig
+		m := New()
+		if err := m.LoadDirVerified(dir, v); err == nil {
+			t.Fatal("expected unsigned file to fail in require-signed mode")
+		}
+		if _, err := m.Get("ext-skill"); err == nil {
+			t.Error("unsigned skill must not be merged")
+		}
+	})
+
+	t.Run("tampered payload fails", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCatalog(dir, priv)
+		// Mutate the catalog after signing.
+		if err := os.WriteFile(filepath.Join(dir, "ext.yaml"), []byte(extSkillYAML+"\n# tampered\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		m := New()
+		if err := m.LoadDirVerified(dir, v); err == nil {
+			t.Fatal("expected tampered file to fail verification")
+		}
+	})
+
+	t.Run("nil verifier loads unsigned", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCatalog(dir, nil)
+		m := New()
+		if err := m.LoadDirVerified(dir, nil); err != nil {
+			t.Fatalf("nil verifier should load unsigned: %v", err)
+		}
+		if _, err := m.Get("ext-skill"); err != nil {
+			t.Error("nil-verifier path should merge unsigned skill")
+		}
+	})
+}
 
 func TestEmbeddedCatalogLoads(t *testing.T) {
 	m := GetDefault()


### PR DESCRIPTION
Closes #648.

## Summary

External skill/crew catalogs loaded from `CONTAINARIUM_SKILLS_DIR` /
`CONTAINARIUM_CREWS_DIR` (#620) were merged **unsigned** — `LoadDir` validated
the manifest *shape* but never its **provenance**. That's correct for the
self-authored BYOA path, but insufficient once a catalog is distributed from
outside the operator's own tree.

This adds an **opt-in, offline-verifiable** detached-signature check. Off by
default: when off, behavior is exactly today's unsigned dir load.

## What changed

- **New `pkg/core/catalogsig`** — an ed25519 `Verifier` built from
  operator-configured trusted public keys (a local key file, base64
  one-per-line, multiple keys for rotation), plus detached-signature reading
  (`foo.yaml` → `foo.yaml.sig`, base64 of the raw 64-byte signature).
  Verification does **no network I/O**, so it works air-gapped.
- **`skills.Manager` / `crews.Manager`** gain `LoadDirVerified(dir, *Verifier)`;
  `LoadDir` is now `LoadDirVerified(dir, nil)` — unsigned behavior unchanged, so
  existing callers/tests are untouched.
- **`dual_server`** wires `catalogsig.FromEnv()`, gated on
  `CONTAINARIUM_CATALOG_REQUIRE_SIGNED` + `CONTAINARIUM_CATALOG_TRUSTED_PUBKEYS`.
  A missing/bad signature **fails that file's load** with a clear error (no
  silent skip); a misconfigured require-signed mode **fails closed** (skip
  external catalogs rather than load unsigned).

## Design notes

- **Opt-in:** off by default; the local/self-authored path stays the default and
  unchanged.
- **Offline:** trusted keys are configured locally; no network round-trip.
- **Fail-closed:** a missing/bad signature or a misconfigured mode never
  degrades to loading unsigned.
- **Out of scope (per the issue):** key custody, rotation policy, and *who*
  signs are left to the operator/distributor. OSS provides only the
  verify-before-merge hook and the trusted-key configuration point.

## Tests / verification

- `pkg/core/catalogsig`: good / tampered / wrong-key / wrong-size signatures,
  key-file parsing (comments, blanks, malformed, empty, missing), `FromEnv`
  on/off/misconfigured, detached-sig read (missing/present/malformed).
- `pkg/core/skills`: `LoadDirVerified` good / missing-sig / tampered / nil-verifier paths.
- `go build ./...` ✅, `go vet` ✅, `gofmt -l` clean, package test suites green.

Docs: "Require signed external catalogs" section added to
`docs/AGENT-SKILLS-QUICKSTART.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)