### PR TITLE
fix(network-policy): coerce nil egress arrays so Set doesn't write NULL

### DIFF
--- a/internal/server/network_policy_store.go
+++ b/internal/server/network_policy_store.go
@@ -138,14 +138,29 @@ func (s *PostgresNetworkPolicyStore) Set(ctx context.Context, p *pb.NetworkPolic
 			source = EXCLUDED.source,
 			updated_at = NOW()
 	`
+	// egress_cidrs / egress_domains are `TEXT[] NOT NULL DEFAULT '{}'`, but the
+	// DEFAULT only applies when the column is OMITTED — here we pass them
+	// explicitly, and pgx encodes a nil []string as SQL NULL, which violates the
+	// NOT NULL constraint (SQLSTATE 23502). A policy that allows no domains (or no
+	// CIDRs) arrives with a nil slice, so coerce nil -> empty so the array lands
+	// as '{}' rather than NULL.
 	_, err := s.pool.Exec(ctx, q,
 		p.GetTenant(), p.GetAllowIntraTenant(),
-		p.GetEgressCidrs(), p.GetEgressDomains(), int32(p.GetMode()),
+		nonNilStrings(p.GetEgressCidrs()), nonNilStrings(p.GetEgressDomains()), int32(p.GetMode()),
 		p.GetAllowMetadata(), p.GetSource())
 	if err != nil {
 		return fmt.Errorf("save network policy: %w", err)
 	}
 	return nil
+}
+
+// nonNilStrings returns s, or an empty (non-nil) slice when s is nil, so a
+// NOT NULL Postgres array column stores '{}' instead of NULL.
+func nonNilStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }
 
 func (s *PostgresNetworkPolicyStore) Get(ctx context.Context, tenant string) (*pb.NetworkPolicy, error) {

--- a/internal/server/network_policy_store_test.go
+++ b/internal/server/network_policy_store_test.go
@@ -1,0 +1,26 @@
+package server
+
+import "testing"
+
+// TestNonNilStrings guards the fix for the egress_cidrs/egress_domains NOT NULL
+// violation: a policy with no domains (or no CIDRs) arrives as a nil slice, and
+// pgx would encode that as SQL NULL against a `TEXT[] NOT NULL` column. nonNilStrings
+// coerces nil -> empty so the array stores '{}' instead.
+func TestNonNilStrings(t *testing.T) {
+	if got := nonNilStrings(nil); got == nil {
+		t.Fatal("nil input must become a non-nil empty slice (else pgx writes NULL)")
+	} else if len(got) != 0 {
+		t.Fatalf("nil input should yield empty slice, got %v", got)
+	}
+
+	in := []string{"0.0.0.0/0", "10.0.0.0/8"}
+	got := nonNilStrings(in)
+	if len(got) != 2 || got[0] != in[0] || got[1] != in[1] {
+		t.Fatalf("non-nil input must pass through unchanged, got %v", got)
+	}
+
+	// Empty-but-non-nil passes through as-is (already safe).
+	if got := nonNilStrings([]string{}); got == nil || len(got) != 0 {
+		t.Fatalf("empty non-nil slice should stay empty non-nil, got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #652.

`PostgresNetworkPolicyStore.Set` passed nil `[]string` egress arrays straight to the INSERT; pgx encodes nil as SQL NULL, violating the `egress_cidrs / egress_domains TEXT[] NOT NULL` columns (the `DEFAULT '{}'` only applies when a column is omitted, not on an explicit NULL). So creating a domains-less policy (e.g. `--mode log_only --egress-cidr 0.0.0.0/0`) 500'd with SQLSTATE 23502.

Coerce nil → empty slice via `nonNilStrings` so the array stores `'{}'`. Unit test added; builds + `go test ./internal/server` green.

Found while enabling eBPF traffic accounting on prod (worked around there with a throwaway `--egress-domain "*"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)