### PR TITLE
fix(netpolicy): cache veth resolution so reconcile stops hammering incus (#654)

### DIFF
--- a/internal/server/network_policy_enforcer.go
+++ b/internal/server/network_policy_enforcer.go
@@ -27,7 +27,9 @@ const containerSuffix = "-container"
 // defaultNetPolicyReconcileInterval is how often the enforcer re-converges the BPF maps
 // to the live container + policy state. The reconcile loop is the source of
 // truth (robust against dropped bus events); the bus only triggers an early
-// reconcile for latency.
+// reconcile for latency. Each cycle does one Incus ListContainers plus a cheap
+// per-container netlink lookup; the expensive per-container Incus inspect is
+// cached and only re-runs when a container starts/restarts (#654).
 const defaultNetPolicyReconcileInterval = 10 * time.Second
 
 // defaultFlowPollInterval is how often the enforcer reads the BPF per-flow
@@ -95,6 +97,13 @@ type NetworkPolicyEnforcer struct {
 
 	loader *netbpf.Loader
 
+	// vethCache maps a running container name -> its host veth name, so a steady
+	// reconcile resolves the ifindex with a cheap local netlink lookup
+	// (VethIndex) instead of an Incus inspect (GetRawInstance) every cycle (#654).
+	// Only touched from gather, which runs serially inside reconcile (the reconcile
+	// loop is single-goroutine), so it needs no lock.
+	vethCache map[string]string
+
 	mu              sync.Mutex
 	attached        map[int]string              // ifindex -> container name currently attached
 	idName          map[uint32]string           // tenant id -> name (for audit/log)
@@ -120,6 +129,7 @@ func NewNetworkPolicyEnforcer(objPath string, store NetworkPolicyStore, registry
 		domainRefresh:   defaultDomainRefreshInterval,
 		flowPoll:        defaultFlowPollInterval,
 		flowIdleTimeout: defaultFlowIdleTimeout,
+		vethCache:       make(map[string]string),
 		attached:        make(map[int]string),
 		idName:          make(map[uint32]string),
 		enforced:        make(map[uint32]bool),
@@ -538,6 +548,7 @@ func (e *NetworkPolicyEnforcer) gather(_ context.Context) ([]containerView, map[
 	}
 	views := make([]containerView, 0, len(containers))
 	idName := make(map[uint32]string)
+	running := make(map[string]bool, len(containers))
 	for _, c := range containers {
 		tenant := resolveTenant(c.Tenant, c.Name)
 		if tenant == "" {
@@ -556,19 +567,52 @@ func (e *NetworkPolicyEnforcer) gather(_ context.Context) ([]containerView, map[
 		}
 		if strings.EqualFold(c.State, "running") {
 			v.Running = true
-			cfg, _, err := e.insp.GetRawInstance(c.Name)
-			if err == nil {
-				if veth := netbpf.HostVethFromConfig(cfg); veth != "" {
-					if ifindex, err := netbpf.VethIndex(veth); err == nil {
-						v.Ifindex = ifindex
-						v.HasVeth = true
-					}
-				}
+			running[c.Name] = true
+			if ifindex, ok := e.resolveVeth(c.Name); ok {
+				v.Ifindex = ifindex
+				v.HasVeth = true
 			}
 		}
 		views = append(views, v)
 	}
+	// Evict cache entries for containers that are gone or no longer running, so the
+	// map stays bounded and a container that restarts re-inspects for its new veth.
+	for name := range e.vethCache {
+		if !running[name] {
+			delete(e.vethCache, name)
+		}
+	}
 	return views, idName, nil
+}
+
+// resolveVeth maps a running container to its host veth ifindex (#654). It caches
+// the container's veth *name* so the steady-state path is a cheap local netlink
+// lookup (VethIndex) rather than an Incus inspect (GetRawInstance) every cycle.
+// The expensive inspect runs only on a cache miss or when the cached veth has
+// disappeared from the host — which is exactly when a container has just started
+// or restarted (a restart yields a new veth, so the stale lookup fails and we
+// re-inspect, self-healing without depending on perfect bus-event delivery).
+func (e *NetworkPolicyEnforcer) resolveVeth(name string) (int, bool) {
+	if veth := e.vethCache[name]; veth != "" {
+		if ifindex, err := netbpf.VethIndex(veth); err == nil {
+			return ifindex, true
+		}
+		delete(e.vethCache, name) // veth gone (restart) — fall through to re-inspect
+	}
+	cfg, _, err := e.insp.GetRawInstance(name)
+	if err != nil {
+		return 0, false
+	}
+	veth := netbpf.HostVethFromConfig(cfg)
+	if veth == "" {
+		return 0, false
+	}
+	ifindex, err := netbpf.VethIndex(veth)
+	if err != nil {
+		return 0, false
+	}
+	e.vethCache[name] = veth
+	return ifindex, true
 }
 
 // compiledPolicies loads + compiles every stored policy, keyed by tenant.

--- a/internal/server/network_policy_enforcer_test.go
+++ b/internal/server/network_policy_enforcer_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// fakeInspector is a containerInspector that counts GetRawInstance calls so a
+// test can assert the reconcile no longer inspects every container every cycle
+// (#654).
+type fakeInspector struct {
+	containers []incus.ContainerInfo
+	veth       string
+	rawCalls   map[string]int
+}
+
+func (f *fakeInspector) ListContainers() ([]incus.ContainerInfo, error) { return f.containers, nil }
+
+func (f *fakeInspector) GetRawInstance(name string) (map[string]string, string, error) {
+	f.rawCalls[name]++
+	return map[string]string{"volatile.eth0.host_name": f.veth}, "", nil
+}
+
+// firstHostIface returns a host interface name that net.InterfaceByName can
+// resolve, so the veth-resolution path exercises the real VethIndex lookup
+// portably (the name differs across Linux/darwin, e.g. lo vs lo0).
+func firstHostIface(t *testing.T) string {
+	t.Helper()
+	ifaces, err := net.Interfaces()
+	if err != nil || len(ifaces) == 0 {
+		t.Skipf("no host interfaces available: %v", err)
+	}
+	return ifaces[0].Name
+}
+
+// TestGather_CachesVethToAvoidInspect locks down the #654 fix: a steady running
+// container is inspected (GetRawInstance) once, not on every reconcile; the cache
+// is evicted when it stops; and it re-inspects after a restart.
+func TestGather_CachesVethToAvoidInspect(t *testing.T) {
+	veth := firstHostIface(t)
+	insp := &fakeInspector{
+		containers: []incus.ContainerInfo{{Name: "web-container", State: "running", IPAddress: "10.100.0.42"}},
+		veth:       veth,
+		rawCalls:   map[string]int{},
+	}
+	e := NewNetworkPolicyEnforcer("", nil, NewMemTenantRegistry(), insp, nil, nil, false)
+	e.ctx = context.Background()
+
+	// First gather: cache miss -> exactly one inspect, veth resolved.
+	views, _, err := e.gather(context.Background())
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	if len(views) != 1 || !views[0].HasVeth {
+		t.Fatalf("gather views = %+v, want 1 view with HasVeth", views)
+	}
+	if got := insp.rawCalls["web-container"]; got != 1 {
+		t.Fatalf("GetRawInstance calls = %d, want 1 after first gather", got)
+	}
+
+	// Repeated gathers while running steady: cache hit, no further inspects.
+	for i := 0; i < 5; i++ {
+		if _, _, err := e.gather(context.Background()); err != nil {
+			t.Fatalf("gather %d: %v", i, err)
+		}
+	}
+	if got := insp.rawCalls["web-container"]; got != 1 {
+		t.Fatalf("GetRawInstance calls = %d, want 1 (cached across reconciles)", got)
+	}
+
+	// Container stops: the cache entry is evicted so it cannot go stale.
+	insp.containers[0].State = "stopped"
+	if _, _, err := e.gather(context.Background()); err != nil {
+		t.Fatalf("gather (stopped): %v", err)
+	}
+	if _, ok := e.vethCache["web-container"]; ok {
+		t.Fatalf("vethCache still holds web-container after it stopped")
+	}
+
+	// Restart: running again -> re-inspect for the (possibly new) veth.
+	insp.containers[0].State = "running"
+	if _, _, err := e.gather(context.Background()); err != nil {
+		t.Fatalf("gather (restarted): %v", err)
+	}
+	if got := insp.rawCalls["web-container"]; got != 2 {
+		t.Fatalf("GetRawInstance calls = %d, want 2 (re-inspect after restart)", got)
+	}
+}


### PR DESCRIPTION
Closes #654.

## Problem

Enabling eBPF traffic accounting / network-policy enforcement starts the `NetworkPolicyEnforcer`, whose reconcile loop runs every 10s and, each cycle, called `ListContainers()` **plus** `GetRawInstance(name)` (an Incus inspect) **for every container**. On a busy/constrained host (many containers × little incus headroom), this repeated inspect storm could wedge `incusd`: `incus list` hangs, exec control websockets fail, and anything that fans out to incus (container listing, the dependent API) times out. Observed live: ~38 containers on a 4-vCPU host wedged within ~20 min.

## Fix

Cache each running container's host veth **name**, keyed by container name (`gather` → new `resolveVeth`):

- **Steady state**: resolve the ifindex with a cheap local netlink lookup (`VethIndex` / `net.InterfaceByName`) — **no Incus inspect**.
- **Cache miss / stale veth**: fall back to one `GetRawInstance`. The cached veth disappearing from the host is exactly the start/restart signal (a restart yields a new veth, so the stale lookup fails and we re-inspect) — self-healing without relying on perfect bus-event delivery.
- **Eviction**: entries for stopped/gone containers are dropped each cycle, so the map stays bounded.

Net effect per reconcile: one `ListContainers` + N cheap netlink lookups; **zero Incus inspects in steady state** (was N inspects every cycle). Behaviour is otherwise unchanged — same views, same plan.

## Test

`TestGather_CachesVethToAvoidInspect` asserts: one inspect on first sight, zero across repeated reconciles while running steady, cache eviction on stop, and a re-inspect after restart. Uses a real host interface name discovered at runtime so it runs portably on Linux CI and the dev machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)