### PR TITLE
fix(netpolicy): guard gosec G115 int64->uint64 casts in the idle-flow reaper

### DIFF
--- a/internal/safecast/safecast.go
+++ b/internal/safecast/safecast.go
@@ -72,6 +72,17 @@ func U32FromUint[T ~uint | ~uint64](v T) uint32 {
 	return uint32(v)
 }
 
+// U64FromI64 converts a signed integer to uint64, clamping negatives to 0. No
+// upper clamp is needed — every int64 fits in uint64. Generic over the signed
+// widths so it covers both time.Duration nanoseconds and unix.Timespec fields
+// (whose Sec/Nsec are int64 on 64-bit, int32 on 32-bit platforms).
+func U64FromI64[T ~int | ~int32 | ~int64](v T) uint64 {
+	if v < 0 {
+		return 0
+	}
+	return uint64(v)
+}
+
 // U8 converts a signed integer to uint8, clamping to [0, 255].
 func U8[T ~int | ~int32 | ~int64](v T) uint8 {
 	if v < 0 {

--- a/internal/safecast/safecast_test.go
+++ b/internal/safecast/safecast_test.go
@@ -45,6 +45,24 @@ func TestI64FromU64(t *testing.T) {
 	}
 }
 
+func TestU64FromI64(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want uint64
+	}{
+		{0, 0},
+		{42, 42},
+		{-1, 0},            // clamp negative
+		{math.MinInt64, 0}, // clamp negative
+		{math.MaxInt64, math.MaxInt64},
+	}
+	for _, c := range cases {
+		if got := U64FromI64(c.in); got != c.want {
+			t.Errorf("U64FromI64(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
 func TestU32(t *testing.T) {
 	cases := []struct {
 		in   int64

--- a/internal/server/network_policy_enforcer.go
+++ b/internal/server/network_policy_enforcer.go
@@ -371,7 +371,7 @@ func (e *NetworkPolicyEnforcer) pollFlows() {
 // unit-testable. A zero/garbage nowNs (clock read failed) yields no idle flows —
 // the sweep simply no-ops that poll rather than reaping live flows.
 func splitIdleFlows(records []netbpf.FlowRecord, nowNs uint64, idleFor time.Duration) (active, idle []netbpf.FlowRecord) {
-	cutoff := uint64(idleFor.Nanoseconds())
+	cutoff := safecast.U64FromI64(idleFor.Nanoseconds())
 	for _, r := range records {
 		if nowNs > r.LastNs && nowNs-r.LastNs > cutoff {
 			idle = append(idle, r)
@@ -391,7 +391,7 @@ func monotonicNowNs() uint64 {
 	if err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts); err != nil {
 		return 0
 	}
-	return uint64(ts.Sec)*1_000_000_000 + uint64(ts.Nsec)
+	return safecast.U64FromI64(ts.Sec)*1_000_000_000 + safecast.U64FromI64(ts.Nsec)
 }
 
 // flowsToEBPF attributes each BPF flow record to its container via the veth


### PR DESCRIPTION
Follow-up hygiene from #655 — `main` is red on the (non-required) `golangci-lint` check.

## Problem

`gosec` rule **G115** (integer overflow conversion) flags two int64→uint64 casts in the #632 idle-flow reaper (shipped in v0.26.5, predates #655):

- `splitIdleFlows` — `uint64(idleFor.Nanoseconds())`
- `monotonicNowNs` — `uint64(ts.Sec)` / `uint64(ts.Nsec)`

Both are safe in context (a `Duration` cutoff and `CLOCK_MONOTONIC` readings are non-negative), but the raw casts trip G115 and keep the lint job failing.

## Fix

Route both through a new `safecast.U64FromI64` helper — the same single-tested-place pattern the `safecast` package exists for (per its package doc). It clamps negatives to 0; no upper clamp is needed since every int64 fits in uint64. It's generic over signed widths so it also covers 32-bit platforms where `unix.Timespec` fields are int32.

## Verification

- `gosec -include=G115 ./internal/server/...` → **0 issues** on `network_policy_enforcer.go` (was 2).
- `go test ./internal/safecast/ ./internal/server/` green; new `TestU64FromI64` covers 0 / positive / negative / `MinInt64` / `MaxInt64`.
- darwin + linux (CI target) builds both clean.

No behavior change — the clamp is a safety net over values already in range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)