### PR TITLE
chore(release): cut v0.26.6 — network-policy reconcile + egress fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.6] - 2026-06-12
+
+Network-policy reconcile + egress fixes (hardening for eBPF traffic accounting).
+
+### Fixed
+
+- **Network-policy reconcile no longer hammers Incus.** The enforcer's reconcile loop did an `incus` inspect (`GetRawInstance`) for **every** container **every 10s** to resolve its veth — which could wedge `incusd` on busy or resource-constrained hosts (observed taking down container listing on a host running ~38 containers). Reconcile now caches the container→veth mapping and resolves the ifindex with a cheap local netlink lookup, re-inspecting only when a container starts/restarts (#654, #655).
+- **Creating a network policy with no egress domains no longer 500s.** `egress_cidrs`/`egress_domains` are `TEXT[] NOT NULL`; a nil slice was encoded as SQL `NULL` and violated the constraint, so a domains-less policy (e.g. `--mode log_only --egress-cidr 0.0.0.0/0`) failed with SQLSTATE 23502. Nil arrays are now coerced to `'{}'` (#653).
+- **Idle-flow reaper:** guarded the `int64`→`uint64` casts (gosec G115) in the #632 reaper path (#656).
+
 ## [0.26.5] - 2026-06-12
 
 eBPF traffic history + signed external catalogs.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.26.5"
+	Version = "0.26.6"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Cuts **v0.26.6** with the netpolicy fixes merged since v0.26.5:
- **#654/#655** enforcer reconcile veth-cache (no more per-container incus inspect every 10s → can't wedge incusd on busy hosts)
- **#653** egress_domains nil→NULL fix (domains-less policy no longer 500s)
- **#656** G115 cast guard in the idle-flow reaper

Hardens eBPF traffic accounting so it's safe to (re-)enable on constrained hosts. Merge → tag `v0.26.6` → deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)