### PR TITLE
fix(mcp): make container connection path discoverable to agents (#658)

### DIFF
--- a/docs/MCP-INTEGRATION.md
+++ b/docs/MCP-INTEGRATION.md
@@ -109,7 +109,7 @@ Create a new LXC container with specified resources.
 - `disk`: Disk limit (e.g., "50GB", "100GB", default: "50GB")
 - `ssh_keys`: Array of SSH public keys (optional)
 - `image`: Container image (default: "images:ubuntu/24.04")
-- `enable_docker`: Enable Docker support (default: true)
+- `enable_podman`: Enable Podman support (default: true)
 
 **Example prompts:**
 - "Create a container for alice"
@@ -169,6 +169,75 @@ Stop a running container.
 - "Shut down bob's container gracefully"
 - "Force stop charlie's container"
 
+### Connecting & Running Code on a Box
+
+> **You do not need to know a hostname or set `CONTAINARIUM_SENTINEL_HOST`.**
+> The daemon stamps every container's reachable SSH target into its
+> `ssh_host` field (the sentinel the container belongs to, or empty for a
+> direct deployment). `create_container` reports it, `get_container` returns
+> it, and the tools below resolve it for you automatically. An agent never
+> has to discover the host or fall back to the env var — that variable is
+> only a last-resort override.
+
+After `create_container`, the canonical flow to get code running on the box is:
+
+```
+create_container  →  read ssh_host (or just use the tools below)
+       │
+       ├─ connect (exec mode)  — run a command inside the box
+       ├─ push                 — ship committed git history into the box
+       └─ sync                 — mirror the working directory into the box
+```
+
+#### `connect`
+Connect to a box, or run a single command inside it. The agent-native half
+of `containarium connect` — it resolves the SSH target from the box's
+`ssh_host`, authorizes a managed key, and either hands back a ready
+`ssh user@host` invocation (config mode) or runs one command and returns its
+stdout / stderr / exit code (exec mode). No PTY, so interactive sessions stay
+CLI-only.
+
+**Parameters:**
+- `box` (required): Container/username to connect to
+- `exec`: A command to run inside the box (omit for config mode — returns the ready `ssh` invocation)
+- `user`, `host`: Optional overrides (default: the box's username / `ssh_host`)
+- `session`: Optional tmux session name for state that persists across calls
+
+**Example prompts:**
+- "Run `uname -a` inside alice's box"
+- "Show me the SSH command to reach bob's container"
+
+#### `push`
+Ship committed git history from the local repo into the box via `git bundle`
+(atomic per commit; refuses a dirty tree unless `include_wip` is set).
+
+**Parameters:**
+- `username` (required): Target container
+- `branch`, `include_wip`, `deploy_cmd`, `local_path`, `remote_path`: Optional
+- `sentinel`: SSH host override — **default: the box's `ssh_host`**, resolved automatically
+
+**Example prompts:**
+- "Push my current branch into alice's box and run `make test`"
+
+#### `sync`
+Mirror the local working directory (including uncommitted + untracked files)
+into the box. Delta-only on subsequent calls.
+
+**Parameters:**
+- `username` (required): Target container
+- `delete`, `exclude`, `local_path`, `remote_path`: Optional
+- `sentinel`: SSH host override — **default: the box's `ssh_host`**, resolved automatically
+
+**Example prompts:**
+- "Sync my working directory into bob's box, then run the tests"
+
+> **If a tool reports it "could not resolve the SSH target":** call
+> `get_container` and read its `ssh_host` — that is the host to reach. Pass it
+> as the `sentinel` argument, or use `connect`. An empty `ssh_host` means a
+> direct / no-sentinel deployment, where you reach the container at its IP
+> (or set up an alias with `sync_ssh_config`). Setting
+> `CONTAINARIUM_SENTINEL_HOST` is **not** required.
+
 ### Monitoring
 
 #### `get_metrics`
@@ -210,6 +279,19 @@ tell me which one is using the most memory.
 ```
 
 Claude will call `get_metrics` and analyze the results.
+
+### Run Code on a New Box
+
+```
+Create a container for atc-crawler, push my current branch into it,
+and run scripts/run_tests.sh inside the box.
+```
+
+Claude calls `create_container` (which reports the box's `ssh_host`), then
+`push` and `connect` — both resolve the SSH target from `ssh_host`
+automatically. No hostname, env var, or manual SSH config is needed. This is
+the path to reach for whenever you want to *build or run* code on a box you
+just created, rather than only manage its lifecycle.
 
 ### Container Lifecycle
 

--- a/internal/mcp/push.go
+++ b/internal/mcp/push.go
@@ -1,10 +1,29 @@
 package mcp
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/footprintai/containarium/internal/transfer"
 )
+
+// sentinelHint turns transfer's bare "sentinel unresolved" failure into
+// agent-native guidance. push/sync already auto-resolve the SSH target
+// from the container's ssh_host, so when we still couldn't find one the
+// agent should reach for get_container (to read ssh_host) or pass the
+// `sentinel` arg explicitly — NOT go hunting for CONTAINARIUM_SENTINEL_HOST.
+func sentinelHint(verb string, username string, err error) error {
+	if errors.Is(err, transfer.ErrSentinelUnresolved) {
+		return fmt.Errorf("%s failed: could not resolve the SSH target for %q. "+
+			"Call get_container(%q) and read its ssh_host — that is the host to "+
+			"reach. Pass it as the `sentinel` arg here, or use the `connect` tool "+
+			"(exec mode) which resolves it for you. An empty ssh_host means a "+
+			"direct / no-sentinel deployment (reach the container at its IP). "+
+			"You do not need to set CONTAINARIUM_SENTINEL_HOST. (%w)",
+			verb, username, username, err)
+	}
+	return fmt.Errorf("%s failed: %w", verb, err)
+}
 
 // handlePush is the agent-native version of `containarium push <user>`.
 // Same Go function (transfer.Push) backs both surfaces; this just adapts
@@ -30,7 +49,7 @@ func handlePush(client *Client, args map[string]interface{}) (string, error) {
 		RemoteName: getStringArg(args, "remote_name", ""),
 	})
 	if err != nil {
-		return "", fmt.Errorf("push failed: %w", err)
+		return "", sentinelHint("push", username, err)
 	}
 
 	var out string
@@ -79,7 +98,7 @@ func handleSync(client *Client, args map[string]interface{}) (string, error) {
 		Excludes: excludes,
 	})
 	if err != nil {
-		return "", fmt.Errorf("sync failed: %w", err)
+		return "", sentinelHint("sync", username, err)
 	}
 
 	if res.Added == 0 && res.Modified == 0 && res.Deleted == 0 {

--- a/internal/mcp/push_test.go
+++ b/internal/mcp/push_test.go
@@ -1,0 +1,46 @@
+package mcp
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/transfer"
+)
+
+// TestSentinelHint_RewritesUnresolvedError verifies that an unresolved-sentinel
+// failure from transfer is turned into agent-native guidance: point at
+// get_container / the connect tool, and explicitly say the env var is NOT
+// required. This is the fix for agents that chased CONTAINARIUM_SENTINEL_HOST
+// and gave up (issue #658).
+func TestSentinelHint_RewritesUnresolvedError(t *testing.T) {
+	err := sentinelHint("push", "alice", fmt.Errorf("%w: boom", transfer.ErrSentinelUnresolved))
+	msg := err.Error()
+
+	for _, want := range []string{"get_container", "ssh_host", "connect", "alice"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("guidance missing %q; got: %s", want, msg)
+		}
+	}
+	if !strings.Contains(msg, "do not need to set CONTAINARIUM_SENTINEL_HOST") {
+		t.Errorf("guidance should steer away from the env var; got: %s", msg)
+	}
+	// The typed cause must remain unwrappable for callers up the stack.
+	if !errors.Is(err, transfer.ErrSentinelUnresolved) {
+		t.Errorf("wrapped error must stay matchable with errors.Is")
+	}
+}
+
+// TestSentinelHint_PassesThroughOtherErrors verifies non-sentinel failures
+// are not rewritten with sentinel guidance (which would be misleading).
+func TestSentinelHint_PassesThroughOtherErrors(t *testing.T) {
+	err := sentinelHint("sync", "bob", fmt.Errorf("ssh key not readable"))
+	msg := err.Error()
+	if strings.Contains(msg, "ssh_host") || strings.Contains(msg, "get_container") {
+		t.Errorf("non-sentinel error should not get sentinel guidance; got: %s", msg)
+	}
+	if !strings.Contains(msg, "sync failed") || !strings.Contains(msg, "ssh key not readable") {
+		t.Errorf("non-sentinel error should be wrapped plainly; got: %s", msg)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1338,6 +1338,31 @@ func handleCreateContainer(client *Client, args map[string]interface{}) (string,
 	}
 	result += fmt.Sprintf("\n%s", resp.Message)
 
+	// Always tell the caller how to reach the box and which tool to use —
+	// independent of whether we generated a key. The daemon stamps ssh_host
+	// with the reachable SSH target (the sentinel this container belongs to,
+	// or empty for a direct deployment), so the caller never has to discover
+	// a host or set CONTAINARIUM_SENTINEL_HOST. Without this, agents that pass
+	// their own ssh_keys got no connection guidance at all and tended to go
+	// hunting for the env var and give up (see issue #658).
+	result += "\n\n--- CONNECTING ---\n"
+	if resp.Container.SSHHost != "" {
+		result += fmt.Sprintf("SSH target: %s@%s  (resolved from ssh_host — no env/config needed)\n",
+			resp.Container.Username, resp.Container.SSHHost)
+	} else {
+		result += "SSH target: direct / no-sentinel deployment — the daemon reported no\n"
+		result += "ssh_host. Reach the container at its IP"
+		if resp.Container.Network != nil && resp.Container.Network.IPAddress != "" {
+			result += fmt.Sprintf(" (%s)", resp.Container.Network.IPAddress)
+		}
+		result += ", or call sync_ssh_config for an alias.\n"
+	}
+	result += "\nTo run code on this box, prefer the MCP tools — they resolve the SSH\n"
+	result += "target from ssh_host automatically (you do NOT need to know a hostname\n"
+	result += "or set CONTAINARIUM_SENTINEL_HOST):\n"
+	result += "  - connect (exec mode): run a command inside the box.\n"
+	result += "  - push / sync: transfer code into the box.\n"
+
 	if ephemeralPrivKey != nil {
 		// Write the key to the local filesystem ourselves rather than
 		// asking the agent to do it. The agent could forget the save step

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -543,8 +543,8 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 			}
 		}()
 	} else {
-		// Linux container: return SSH command and ensure jump server account
-		resp.SshCommand = fmt.Sprintf("ssh %s@%s", req.Username, info.IPAddress)
+		// Linux container: return SSH command and ensure jump server account.
+		resp.SshCommand = sshCommandFor(req.Username, protoContainer.SshHost, info.IPAddress)
 		go func() {
 			if err := container.EnsureJumpServerAccount(req.Username); err != nil {
 				log.Printf("Warning: failed to create jump server account for %s: %v", req.Username, err)
@@ -2427,6 +2427,20 @@ func (s *ContainerServer) SetStartTime(t time.Time) {
 // fall back to the container IP. Called once from DualServer setup.
 func (s *ContainerServer) SetSSHHost(host string) {
 	s.sshHost = host
+}
+
+// sshCommandFor builds the ssh_command returned by CreateContainer from the
+// reachable target — the daemon-stamped ssh_host (the sentinel this container
+// belongs to) when set, falling back to the container IP only for direct /
+// no-sentinel deployments. Using the private IP unconditionally produced an
+// ssh_command that callers off the backend LAN (notably MCP agents) couldn't
+// reach — they'd see `ssh user@10.x.x.x` and give up. See #658.
+func sshCommandFor(username, sshHost, ip string) string {
+	target := ip
+	if sshHost != "" {
+		target = sshHost
+	}
+	return fmt.Sprintf("ssh %s@%s", username, target)
 }
 
 // SetAutoUpdater wires the daemon's auto-updater so TriggerUpgrade can run an

--- a/internal/server/container_server_ssh_host_test.go
+++ b/internal/server/container_server_ssh_host_test.go
@@ -56,6 +56,29 @@ func TestGetContainer_EmptySSHHostDirectMode(t *testing.T) {
 	}
 }
 
+// TestSSHCommandFor — CreateContainer's ssh_command must name the reachable
+// target: the sentinel ssh_host when set (so off-LAN callers like MCP agents
+// can actually connect), and only the container IP for direct deployments.
+// Regression guard for #658, where the command always used the private IP.
+func TestSSHCommandFor(t *testing.T) {
+	cases := []struct {
+		name    string
+		sshHost string
+		ip      string
+		want    string
+	}{
+		{"sentinel mode uses ssh_host", "region-a.example.com", "10.0.0.5", "ssh alice@region-a.example.com"},
+		{"direct mode falls back to ip", "", "10.0.0.5", "ssh alice@10.0.0.5"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := sshCommandFor("alice", c.sshHost, c.ip); got != c.want {
+				t.Fatalf("sshCommandFor = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
 // TestSetSSHHost — the DualServer wiring setter stores the value the read
 // path stamps.
 func TestSetSSHHost(t *testing.T) {

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -18,11 +18,20 @@
 package transfer
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+// ErrSentinelUnresolved is returned by resolve when no SSH endpoint could
+// be determined — neither an explicit SentinelHost, the container's
+// daemon-stamped ssh_host (tried by callers before reaching here), nor
+// $CONTAINARIUM_SENTINEL_HOST. Callers (notably the MCP push/sync
+// handlers) check this with errors.Is to attach surface-specific guidance
+// instead of leaving the agent to chase the env var.
+var ErrSentinelUnresolved = errors.New("sentinel host not set")
 
 // Options carries the inputs both Push and Sync need.
 type Options struct {
@@ -61,7 +70,11 @@ func (o *Options) resolve() error {
 	if o.SentinelHost == "" {
 		o.SentinelHost = os.Getenv("CONTAINARIUM_SENTINEL_HOST")
 		if o.SentinelHost == "" {
-			return fmt.Errorf("sentinel host not set: pass --sentinel or set CONTAINARIUM_SENTINEL_HOST")
+			return fmt.Errorf("%w: the daemon reports the reachable SSH target in the "+
+				"container's ssh_host (see `containarium get %s` / the get_container tool) — "+
+				"pass it as --sentinel <host>, or set CONTAINARIUM_SENTINEL_HOST. "+
+				"An empty ssh_host means a direct / no-sentinel deployment; reach the "+
+				"container at its IP instead", ErrSentinelUnresolved, o.Username)
 		}
 	}
 	if o.KeyPath == "" {

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +9,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestResolve_UnresolvedSentinelIsTyped locks in that a missing sentinel
+// (no field, no $CONTAINARIUM_SENTINEL_HOST) surfaces as ErrSentinelUnresolved
+// so callers can errors.Is it and attach surface-specific guidance, and that
+// the message points at the container's ssh_host rather than only the env var.
+func TestResolve_UnresolvedSentinelIsTyped(t *testing.T) {
+	t.Setenv("CONTAINARIUM_SENTINEL_HOST", "")
+	opt := &Options{
+		Username:  "alice",
+		KeyPath:   writeKey(t),
+		LocalPath: t.TempDir(),
+	}
+	err := opt.resolve()
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSentinelUnresolved), "must be matchable with errors.Is")
+	assert.Contains(t, err.Error(), "ssh_host", "message should point the caller at ssh_host")
+}
 
 // keyFile is a minimal test helper: writes a file at path so the
 // readability check in Options.resolve() passes.


### PR DESCRIPTION
Closes #658 — MCP agents that created a container kept chasing `CONTAINARIUM_SENTINEL_HOST`, found the private container IP unreachable, and gave up, even though the platform already hands them everything they need.

## Root cause

The capability existed; it just wasn't discoverable:
- the daemon already stamps the reachable SSH target in `Container.ssh_host`;
- the `connect` (exec), `push`, and `sync` tools already resolve it automatically — the env var is only a last-resort fallback.

The agent took a dead end because nothing in the response or the error pointed it at that path — and the one structured field that could have (`ssh_command`) carried the unreachable private IP.

## Changes

**1. `create_container` always surfaces connection guidance** (`internal/mcp/tools.go`)

A new `--- CONNECTING ---` block now renders on every create — the resolved `user@ssh_host` target (or a direct/no-sentinel note with the container IP) and which tool to use (`connect` for exec, `push`/`sync` for code transfer). Previously this guidance was inside the `ephemeralPrivKey != nil` branch, so callers that supplied their own `ssh_keys` got nothing.

**2. The unresolved-sentinel error is self-correcting** (`internal/transfer/transfer.go`, `internal/mcp/push.go`)

- `transfer` now returns a typed `ErrSentinelUnresolved` whose message points at the container's `ssh_host` (`containarium get <user>` / `get_container`) rather than only the env var. Shared by CLI and MCP.
- The MCP `push`/`sync` handlers wrap it via `sentinelHint(...)` into agent-native guidance — read `ssh_host` from `get_container`, or use `connect` — and state explicitly that `CONTAINARIUM_SENTINEL_HOST` is **not** required. Non-sentinel errors pass through unchanged.

**3. `CreateContainerResponse.ssh_command` now names a reachable target** (`internal/server/container_server.go`)

The daemon built `ssh_command` from the private `info.IPAddress` unconditionally, so the structured field handed off-LAN callers an `ssh user@10.x.x.x` they couldn't reach. It now uses the stamped `ssh_host` when set, falling back to the IP only for direct deployments. Extracted as `sshCommandFor` and unit-tested both modes.

**4. Documented the canonical agent flow** (`docs/MCP-INTEGRATION.md`)

New "Connecting & Running Code on a Box" tool section (`connect` / `push` / `sync`, all auto-resolving the SSH target from `ssh_host`) plus a worked `create → push → connect` example. Makes explicit that `CONTAINARIUM_SENTINEL_HOST` is a fallback, not a prerequisite, and what an empty `ssh_host` means. Also corrects a stale `create_container` param (`enable_docker` → `enable_podman`).

## Tests

- `transfer_test.go`: unresolved sentinel surfaces as `ErrSentinelUnresolved` (matchable with `errors.Is`) and the message mentions `ssh_host`.
- `push_test.go` (new): the MCP hint rewrite for sentinel errors, and pass-through for non-sentinel errors.
- `container_server_ssh_host_test.go`: `ssh_command` uses `ssh_host` in sentinel mode and falls back to the IP in direct mode.

`go build`, `go vet`, `gofmt`, and `go test ./internal/server/... ./internal/mcp/... ./internal/transfer/...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
