### PR TITLE
fix(agent): pass v-prefixed release tag for agent-box assembly

### DIFF
--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -132,6 +132,24 @@ func (s *AgentSkillServer) RunAgentSkill(ctx context.Context, req *pb.RunAgentSk
 	return &pb.RunAgentSkillResponse{Container: container, ArtifactJson: artifact}, nil
 }
 
+// agentRuntimeReleaseTag returns the GitHub release tag the agent-runtime box
+// pulls its artifacts from. version.GetVersion() is the BARE semver ("0.26.6")
+// — the release workflow builds with VERSION=${tag#v}, so the `v` is stripped
+// at build time — but the git tag and release are `v`-prefixed ("v0.26.6"),
+// and the recipe's post_start uses this value directly in
+// raw.githubusercontent.com/<repo>/<ref>/... and releases/download/<ref>/...
+// URLs. Without the `v` those 404 and the best-effort assembly silently skips,
+// so the box comes up without the in-box loop. Re-add the prefix (idempotent —
+// a value that already carries it, or a dev/unpublished version, is left as-is
+// and just degrades to skip-assembly as before).
+func agentRuntimeReleaseTag() string {
+	v := version.GetVersion()
+	if v == "" || strings.HasPrefix(v, "v") {
+		return v
+	}
+	return "v" + v
+}
+
 // provisionSkillBox provisions a skill's box and gets it ready to run: resolve
 // the box recipe, deploy it, mint a JWT scoped to exactly the skill's
 // allowed_scopes, seed the prompt/token/input/card, and compile allowed_peers
@@ -164,7 +182,7 @@ func (s *AgentSkillServer) provisionSkillBox(ctx context.Context, skill *pb.Agen
 		Name:       name,
 		BackendId:  backendID,
 		Pool:       pool,
-		Parameters: map[string]string{"release": version.GetVersion()},
+		Parameters: map[string]string{"release": agentRuntimeReleaseTag()},
 	})
 	if err != nil {
 		return "", nil, err // already a gRPC status from deploy/CreateContainer

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -125,6 +125,20 @@ func TestParseArtifactOutput(t *testing.T) {
 	})
 }
 
+func TestAgentRuntimeReleaseTag(t *testing.T) {
+	// version.GetVersion() is the bare semver at runtime (the release workflow
+	// builds with VERSION=${tag#v}); the recipe needs the v-prefixed git tag or
+	// the artifact URLs 404 and box assembly silently skips. The helper must
+	// re-add the prefix without double-prefixing an already-tagged value.
+	got := agentRuntimeReleaseTag()
+	if !strings.HasPrefix(got, "v") {
+		t.Errorf("agentRuntimeReleaseTag() = %q, want a v-prefixed tag", got)
+	}
+	if strings.HasPrefix(got, "vv") {
+		t.Errorf("agentRuntimeReleaseTag() = %q, double-prefixed", got)
+	}
+}
+
 func TestGenTraceID(t *testing.T) {
 	a, b := genTraceID(), genTraceID()
 	if len(a) != 32 { // 16 bytes hex


### PR DESCRIPTION
## Summary

Surfaced during the **Phase 4 agent-skills live bring-up** (#612 / #608): provisioned agent boxes came up with node + seed files but **no in-box loop** (`/usr/local/bin/agent-runtime` missing, `/opt` empty), so `agent run` fell back to the empty artifact regardless of provider key.

Root cause: the `agent-runtime` recipe's `post_start` builds artifact URLs from the `release` param the daemon passes — `version.GetVersion()`. But `GetVersion()` is the **bare** semver (`0.26.6`): the release workflow builds with `VERSION=${GITHUB_REF_NAME#v}`, stripping the `v`. The git tag / GitHub release are **`v`-prefixed** (`v0.26.6`). So the recipe hit:

- `raw.githubusercontent.com/.../0.26.6/scripts/install-agent-runtime.sh` → **404** (`v0.26.6` → 200)
- `releases/download/0.26.6/agent-box-linux-amd64` → **404** (`v0.26.6` → 200)

…and the best-effort `|| echo "skipped"` swallowed it silently.

## Fix

Add `agentRuntimeReleaseTag()` which re-adds the `v` prefix (idempotent — an already-tagged value, or a dev/unpublished version, is left as-is and degrades to skip-assembly exactly as before). Recipe authors and `recipe deploy` callers already pass `v`-prefixed tags per the param docs; only the daemon's auto-pass was wrong.

## Tests

- `TestAgentRuntimeReleaseTag` — output is `v`-prefixed, never double-prefixed.
- Existing agent_server tests green; `go build ./internal/server/` clean; gofmt clean.

## Acceptance impact

This unblocks the auto-assembly half of the #612/#608 live bring-up. The live acceptance itself (agent run → real artifact, crew → COMPLETED) is being run against manually-assembled boxes on the existing v0.26.6 release in parallel; this fix makes fresh boxes self-assemble on the next release that carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)