### PR TITLE
fix(agent): make skill-box provisioning idempotent (reuse existing box)

### DIFF
--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -172,20 +172,42 @@ func (s *AgentSkillServer) provisionSkillBox(ctx context.Context, skill *pb.Agen
 		return "", nil, err
 	}
 
-	// Provision the box by reusing the recipe deploy path. Pass the daemon's
-	// version as the agent-runtime recipe's `release` param so the box's
-	// post_start pulls matching agent-box + agent-runtime artifacts (box-image
-	// assembly). Recipes that don't declare these params ignore the extras;
-	// assembly is best-effort (a dev/unpublished version just skips it).
-	dep, err := s.recipes.deploy(ctx, &pb.DeployRecipeRequest{
-		RecipeId:   recipeID,
-		Name:       name,
-		BackendId:  backendID,
-		Pool:       pool,
-		Parameters: map[string]string{"release": agentRuntimeReleaseTag()},
-	})
-	if err != nil {
-		return "", nil, err // already a gRPC status from deploy/CreateContainer
+	// Provision the box, idempotently. The normal skill flow is run → (set a
+	// secret / inspect) → run again, and a crew re-drives its members every
+	// run, so the SAME box name recurs. The deploy path's CreateContainer
+	// errors on an existing instance ("already exists"), which would make every
+	// re-run fail. So if the box is already provisioned, reuse it: skip deploy
+	// (and its one-time post_start assembly) and just re-mint the token,
+	// re-seed, and re-apply policy below. A stopped box (idle-sleep, host
+	// reboot) is started so the subsequent seed-exec / loop-exec lands.
+	var container *pb.Container
+	if info, gerr := s.recipes.containers.manager.Get(name); gerr == nil && info != nil {
+		if info.State != "Running" {
+			if err := s.recipes.containers.manager.Start(name); err != nil {
+				return "", nil, status.Errorf(codes.Internal, "failed to start existing agent box %s: %v", name, err)
+			}
+			if reread, rerr := s.recipes.containers.manager.Get(name); rerr == nil && reread != nil {
+				info = reread
+			}
+		}
+		container = toProtoContainer(info)
+	} else {
+		// First provision. Pass the daemon's version as the agent-runtime
+		// recipe's `release` param so the box's post_start pulls matching
+		// agent-box + agent-runtime artifacts (box-image assembly). Recipes that
+		// don't declare these params ignore the extras; assembly is best-effort
+		// (a dev/unpublished version just skips it).
+		dep, err := s.recipes.deploy(ctx, &pb.DeployRecipeRequest{
+			RecipeId:   recipeID,
+			Name:       name,
+			BackendId:  backendID,
+			Pool:       pool,
+			Parameters: map[string]string{"release": agentRuntimeReleaseTag()},
+		})
+		if err != nil {
+			return "", nil, err // already a gRPC status from deploy/CreateContainer
+		}
+		container = dep.Container
 	}
 
 	// Mint a JWT scoped to EXACTLY the skill's allowed_scopes (catalog
@@ -211,7 +233,7 @@ func (s *AgentSkillServer) provisionSkillBox(ctx context.Context, skill *pb.Agen
 	// Compile allowed_peers into the per-box egress policy (Phase 2).
 	s.applyAllowedPeersPolicy(ctx, name, skill)
 
-	return containerName, dep.Container, nil
+	return containerName, container, nil
 }
 
 // startServeMode launches the in-box agent-runtime in serve mode (the A2A


### PR DESCRIPTION
## Summary

Second daemon bug surfaced by the **Phase 4 agent-skills live bring-up** (#612 / #608), alongside the release-tag fix (#668).

`provisionSkillBox` always went through the recipe deploy path, whose `CreateContainer` errors **`Instance <name>-container already exists`** on a box that's already provisioned. But the normal skill flow re-uses the same deterministic box name:

- the documented bring-up flow is *run once (creates box) → set the provider key → run again*;
- a crew re-drives each member every run.

So every re-run after the first failed with `code=Internal`, making the runbook's "run again" step impossible via the RPC.

## Fix

Reuse an existing box: if `manager.Get(name)` finds it, skip `deploy` (and its one-time `post_start` assembly) and fall through to the existing scoped-token re-mint + re-seed + `allowed_peers` policy re-apply. A stopped box (idle-sleep, host reboot) is started first so the subsequent seed-exec / loop-exec lands. First provision is unchanged.

## Testing

`provisionSkillBox` depends on the concrete `*container.Manager` (no interface seam), so the reuse branch isn't cheaply mockable without an invasive refactor. Validated **live** by re-running `agent run` against an already-provisioned box on ase1-spot. Existing `internal/server` agent tests pass; `go build`/`go vet` clean.

## Bring-up status

With #668 (merged) + this, both daemon blockers for the literal `agent run` / `crew run` RPC acceptance are fixed. Reaching backends needs a daemon release carrying both, then a redeploy — tracked under #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)