### PR TITLE
feat(gpu): multi-GPU passthrough per container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-GPU passthrough per container.** A container can now be created with more than one GPU attached. `containarium create` takes a repeatable/comma-separated `--gpu` flag (`--gpu 0 --gpu 1` or `--gpu 0,1`), each entry an index or PCI address; every device is resolved to a stable PCI address at create time (same kernel-upgrade-safe pinning as the single-GPU path) and attached as a distinct Incus device (`gpu`, `gpu1`, `gpu2`, …). A GPU requested twice (same resolved PCI) is rejected. The proto contract gains `repeated string gpus` on `CreateContainerRequest`/`ResourceLimits` and `repeated string gpu_devices` on `Container`; the singular `gpu`/`gpu_device` fields stay for back-compat (`gpus` supersedes `gpu` when set, a lone `gpu` is promoted to a one-element list). The single-GPU device name stays `gpu`, so existing single-GPU containers are byte-identical. Surfaced through the gRPC + HTTP clients, and the platform MCP `create_container` tool gains a `gpus` array argument. Read-back (`list`/`get`) reports all attached GPUs (`gpu_devices`), sorted for stable output.
+
 ## [0.27.0] - 2026-06-13
 
 eBPF virtual patching (Tier 1) + the agent-skills Phase 4 box-assembly fixes

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -6350,7 +6350,7 @@
         },
         "gpuDevice": {
           "type": "string",
-          "title": "GPU device info (e.g., GPU ID or PCI address if attached)"
+          "description": "GPU device info (e.g., GPU ID or PCI address if attached). For a\nmulti-GPU container this is the first device; see `gpu_devices` for all."
         },
         "backendId": {
           "type": "string",
@@ -6408,6 +6408,13 @@
         "deletePolicy": {
           "$ref": "#/definitions/DeletePolicy",
           "description": "Whether this box is protected from the daemon's automated/bulk deletion\npaths (#284). DELETE_POLICY_PROTECTED means the ttlsweeper auto-reap and\n`containarium prune` skip it; a deliberate single-box delete still removes\nit. Read from the user.containarium.delete_policy Incus config key; set via\nSetContainerDeletePolicy. Absent/unprotected = DELETE_POLICY_UNSPECIFIED."
+        },
+        "gpuDevices": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "All GPU devices attached to this container (device index or PCI address\nper entry). For a single-GPU container this has one entry mirroring\n`gpu_device`; empty when no GPU is attached."
         }
       },
       "title": "Container represents a complete container instance"
@@ -6613,6 +6620,7 @@
         },
         "gpu": {
           "type": "string",
+          "description": "Deprecated: single-GPU field. Prefer `gpus`. When `gpus` is non-empty it\ntakes precedence; when `gpus` is empty a non-empty `gpu` is treated as a\nsingle-element list.",
           "title": "GPU device ID for passthrough (e.g., \"0\" for first GPU, PCI address, or empty for none)"
         },
         "backendId": {
@@ -6668,6 +6676,13 @@
           "type": "string",
           "format": "int64",
           "description": "Birth stopped→delete (optional) — seconds the box may remain STOPPED\nbefore it is auto-deleted, reclaiming disk after idle_stop_minutes\nalready reclaimed CPU/RAM (#525, the second timer of #522's two-phase\nlifecycle). The clock runs from the stop transition and RESETS when the\nbox is woken (accessed), so a box someone keeps investigating is never\nreaped; only one left continuously stopped past this window is. This is\na SEPARATE opt-in from idle_stop_minutes / auto-sleep: a scale-to-zero\nbox that merely sleeps must never be deleted just for being stopped.\n0 = never delete on stop (today's behavior)."
+        },
+        "gpus": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "GPU device IDs for passthrough — one entry per GPU to attach (device\nindex like \"0\"/\"1\" or PCI address like \"0000:0b:00.0\"). Supersedes the\nsingular `gpu` field: when non-empty `gpu` is ignored; when empty a\nnon-empty `gpu` is treated as a single-element list. Each device is\nresolved to a stable PCI address at create time."
         }
       },
       "title": "CreateContainerRequest is the request to create a new container"
@@ -9454,7 +9469,15 @@
         },
         "gpu": {
           "type": "string",
+          "description": "Deprecated: single-GPU field. Prefer `gpus` for one-or-many. When `gpus`\nis non-empty it takes precedence and this field is ignored; when `gpus`\nis empty a non-empty `gpu` is treated as a single-element list.",
           "title": "GPU device ID for passthrough (e.g., \"0\" for first GPU, PCI address, or empty for none)"
+        },
+        "gpus": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "GPU device IDs for passthrough — one entry per GPU to attach (each is a\ndevice index like \"0\"/\"1\" or a PCI address like \"0000:0b:00.0\"). Empty\nmeans no GPU. Supersedes the singular `gpu` field."
         }
       },
       "title": "ResourceLimits defines resource constraints for a container"

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -160,7 +160,7 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 }
 
 // CreateContainer creates a container via gRPC
-func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
+func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute) // Container creation can take time (includes ultra-aggressive retry logic for google_guest_agent)
 	defer cancel()
 
@@ -175,7 +175,7 @@ func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, 
 		Image:                     image,
 		EnablePodman:              enablePodman,
 		Stack:                     stack,
-		Gpu:                       gpu,
+		Gpus:                      gpus,
 		OsType:                    osType,
 		Monitoring:                monitoring,
 		Pool:                      pool,
@@ -210,6 +210,9 @@ func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, 
 		info.CPU = container.Resources.Cpu
 		info.Memory = container.Resources.Memory
 	}
+
+	info.GPU = container.GpuDevice
+	info.GPUs = container.GpuDevices
 
 	if container.CreatedAt > 0 {
 		info.CreatedAt = time.Unix(container.CreatedAt, 0)
@@ -466,6 +469,9 @@ func (c *GRPCClient) GetContainer(username string) (*incus.ContainerInfo, error)
 		info.CPU = container.Resources.Cpu
 		info.Memory = container.Resources.Memory
 	}
+
+	info.GPU = container.GpuDevice
+	info.GPUs = container.GpuDevices
 
 	if container.CreatedAt > 0 {
 		info.CreatedAt = time.Unix(container.CreatedAt, 0)

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -168,6 +168,7 @@ type containerResponse struct {
 	Image                string            `json:"image"`
 	PodmanEnabled        bool              `json:"dockerEnabled"`
 	GpuDevice            string            `json:"gpuDevice"`
+	GpuDevices           []string          `json:"gpuDevices"`
 	MonitoringEnabled    bool              `json:"monitoringEnabled"`
 	AutoSleepEnabled     bool              `json:"autoSleepEnabled"`
 	IdleThresholdMinutes int32             `json:"idleThresholdMinutes"`
@@ -235,6 +236,7 @@ func containerToIncusInfo(c *containerResponse) incus.ContainerInfo {
 	}
 
 	info.GPU = c.GpuDevice
+	info.GPUs = c.GpuDevices
 
 	// Parse createdAt timestamp (RFC3339 format from protobuf JSON)
 	if c.CreatedAt != "" {
@@ -282,7 +284,7 @@ type GitSourceOpts struct {
 	WorkspacePath string // empty defaults to /workspace
 }
 
-func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
+func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
@@ -297,7 +299,7 @@ func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, 
 		"image":        image,
 		"enablePodman": enablePodman,
 		"stack":        stack,
-		"gpu":          gpu,
+		"gpus":         gpus,
 		"osType":       osType,
 		"monitoring":   monitoring,
 		"pool":         pool,

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -28,7 +28,7 @@ var (
 	labels                   []string
 	forceRecreate            bool
 	stackID                  string
-	gpuDevice                string
+	gpuDevices               []string
 	osTypeStr                string
 	monitoring               bool
 	createPool               string
@@ -102,7 +102,7 @@ func init() {
 	createCmd.Flags().StringVar(&containerImage, "image", "images:ubuntu/24.04", "Container image to use")
 	createCmd.Flags().BoolVar(&enablePodman, "podman", true, "Enable Podman support (nesting)")
 	createCmd.Flags().StringVar(&stackID, "stack", "", "Software stack to install (nodejs, python, golang, rust, datascience, devops, database, fullstack)")
-	createCmd.Flags().StringVar(&gpuDevice, "gpu", "", "GPU device ID for passthrough (e.g., '0' for first GPU, PCI address)")
+	createCmd.Flags().StringSliceVar(&gpuDevices, "gpu", nil, "GPU device(s) for passthrough — index ('0') or PCI address. Repeat or comma-separate for multiple GPUs (e.g., --gpu 0 --gpu 1 or --gpu 0,1)")
 	createCmd.Flags().StringSliceVar(&labels, "labels", []string{}, "Labels in key=value format (can be specified multiple times)")
 	createCmd.Flags().BoolVar(&forceRecreate, "force", false, "Delete and recreate if container already exists")
 	createCmd.Flags().StringVar(&osTypeStr, "os-type", "", "Container OS type: ubuntu, rocky9, rhel9 (overrides --image)")
@@ -212,8 +212,8 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		if stackID != "" {
 			fmt.Printf("  Stack: %s\n", stackID)
 		}
-		if gpuDevice != "" {
-			fmt.Printf("  GPU: %s\n", gpuDevice)
+		if len(gpuDevices) > 0 {
+			fmt.Printf("  GPU: %s\n", strings.Join(gpuDevices, ", "))
 		}
 		if ttlSeconds > 0 {
 			fmt.Printf("  TTL: %s (auto-delete at create+TTL)\n", createTTL)
@@ -387,13 +387,13 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if httpMode && serverAddr != "" {
 		// Remote mode via HTTP
-		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
+		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
 		if err != nil {
 			return fmt.Errorf("failed to create container via HTTP API: %w", err)
 		}
 	} else if serverAddr != "" {
 		// Remote mode via gRPC
-		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevice, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
+		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
 		if err != nil {
 			return fmt.Errorf("failed to create container via remote server: %w", err)
 		}
@@ -402,7 +402,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		if verbose {
 			fmt.Println("Creating container...")
 		}
-		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevice, osType, monitoring, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
+		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevices, osType, monitoring, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
 		if err != nil {
 			// Cleanup jump server account on failure
 			_ = container.DeleteJumpServerAccount(username, false)
@@ -544,7 +544,7 @@ func resolveGitSourceOpts() (client.GitSourceOpts, error) {
 }
 
 // createLocal creates a container using local Incus daemon
-func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
+func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
 	mgr, err := container.New()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
@@ -556,7 +556,7 @@ func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []
 		CPU:                    cpu,
 		Memory:                 memory,
 		Disk:                   disk,
-		GPU:                    gpu,
+		GPUs:                   gpus,
 		StaticIP:               staticIP,
 		SSHKeys:                sshKeys,
 		Labels:                 labelMap,
@@ -633,23 +633,23 @@ func parseLabels(labelSlice []string) map[string]string {
 }
 
 // createRemote creates a container using remote gRPC server
-func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
+func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
 	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = grpcClient.Close() }()
 
-	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
+	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
 }
 
 // createRemoteHTTP creates a container using remote HTTP API
-func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack, gpu string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
+func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
 	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = httpClient.Close() }()
 
-	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpu, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
+	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
 }

--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -374,7 +374,7 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 				splitNonEmpty(sshKey),
 				true, // podman
 				"",   // stack
-				"",   // gpu
+				nil,  // gpus
 				ostype.OSTypeFromString("ubuntu"),
 				false,                  // monitoring
 				"",                     // pool
@@ -410,8 +410,8 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 			"50GB",
 			splitNonEmpty(sshKey),
 			true,
-			"",
-			"",
+			"",  // stack
+			nil, // gpus
 			ostype.OSTypeFromString("ubuntu"),
 			false,
 			"",

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1356,7 +1356,14 @@ type CreateContainerRequest struct {
 	Labels       map[string]string `json:"labels,omitempty"`
 	Image        string            `json:"image,omitempty"`
 	EnablePodman bool              `json:"enablePodman,omitempty"`
-	GPU          string            `json:"gpu,omitempty"`
+
+	// GPU is the legacy single-GPU field. Prefer GPUs. When GPUs is set it
+	// supersedes this on the daemon side.
+	GPU string `json:"gpu,omitempty"`
+
+	// GPUs lists the GPU devices to attach (index "0"/"1" or PCI address per
+	// entry) for multi-GPU passthrough. Empty = no GPU.
+	GPUs []string `json:"gpus,omitempty"`
 
 	// Monitoring opts the container into application-emitted
 	// OpenTelemetry. When true, the daemon stamps the LXC with

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -180,7 +180,12 @@ func (s *Server) registerTools() {
 					},
 					"gpu": map[string]interface{}{
 						"type":        "string",
-						"description": "GPU device ID for passthrough (e.g., '0' for first GPU, PCI address, or empty for none)",
+						"description": "Deprecated single-GPU field; prefer 'gpus'. GPU device ID for passthrough (e.g., '0' for first GPU, PCI address, or empty for none)",
+					},
+					"gpus": map[string]interface{}{
+						"type":        "array",
+						"items":       map[string]interface{}{"type": "string"},
+						"description": "GPU devices for passthrough — one entry per GPU (index like '0'/'1' or PCI address). Use for multi-GPU boxes. Supersedes 'gpu' when set.",
 					},
 					"os_type": map[string]interface{}{
 						"type":        "string",
@@ -1290,6 +1295,7 @@ func handleCreateContainer(client *Client, args map[string]interface{}) (string,
 		Image:        getStringArg(args, "image", "images:ubuntu/24.04"),
 		EnablePodman: getBoolArg(args, "enable_podman", true),
 		GPU:          getStringArg(args, "gpu", ""),
+		GPUs:         getStringSliceArg(args, "gpus"),
 		Monitoring:   getBoolArg(args, "monitoring", false),
 		Pool:         getStringArg(args, "pool", ""),
 		BackendID:    getStringArg(args, "backend_id", ""),
@@ -2154,6 +2160,26 @@ func getStringArg(args map[string]interface{}, key, defaultValue string) string 
 		return val
 	}
 	return defaultValue
+}
+
+// getStringSliceArg reads a JSON array argument into a []string, dropping
+// non-string and empty entries. Returns nil when the key is absent or not an
+// array — JSON-RPC decodes arrays as []interface{}.
+func getStringSliceArg(args map[string]interface{}, key string) []string {
+	raw, ok := args[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func getBoolArg(args map[string]interface{}, key string, defaultValue bool) bool {

--- a/internal/server/cloud_container_actuator.go
+++ b/internal/server/cloud_container_actuator.go
@@ -116,7 +116,10 @@ func buildContainerConfig(spec cloud.ContainerSpec) incus.ContainerConfig {
 		cfg.Disk = &incus.DiskDevice{Path: "/", Pool: "default", Size: fmt.Sprintf("%dGB", spec.DiskGB)}
 	}
 	if spec.GPUCount > 0 {
-		cfg.GPU = &incus.GPUDevice{} // empty = pass through all GPUs
+		// A single empty GPU device means "pass through all GPUs" (no PCI
+		// pin) — the cloud-v1 "this is a GPU box" semantics. Per-GPU pinning
+		// would need host GPU inventory the assignment doesn't carry.
+		cfg.GPUs = []incus.GPUDevice{{}}
 	}
 	if len(spec.SecretEnv) > 0 {
 		cfg.Env = make(map[string]string, len(spec.SecretEnv))

--- a/internal/server/cloud_container_actuator_test.go
+++ b/internal/server/cloud_container_actuator_test.go
@@ -24,8 +24,8 @@ func TestBuildContainerConfig(t *testing.T) {
 	if cfg.Disk == nil || cfg.Disk.Size != "40GB" || cfg.Disk.Path != "/" || cfg.Disk.Pool != "default" {
 		t.Errorf("disk wrong: %+v", cfg.Disk)
 	}
-	if cfg.GPU == nil {
-		t.Error("GPUCount>0 should request GPU passthrough")
+	if len(cfg.GPUs) != 1 {
+		t.Errorf("GPUCount>0 should request one GPU passthrough device, got %+v", cfg.GPUs)
 	}
 }
 
@@ -62,7 +62,7 @@ func TestBuildContainerConfig_MinimalOmitsDevices(t *testing.T) {
 	if cfg.Disk != nil {
 		t.Errorf("no disk → Disk nil, got %+v", cfg.Disk)
 	}
-	if cfg.GPU != nil {
-		t.Errorf("no GPU → GPU nil, got %+v", cfg.GPU)
+	if len(cfg.GPUs) != 0 {
+		t.Errorf("no GPU → GPUs empty, got %+v", cfg.GPUs)
 	}
 }

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -161,6 +161,19 @@ func NewContainerServer() (*ContainerServer, error) {
 	}, nil
 }
 
+// mergeGPURequests reconciles the repeated `gpus` field with the legacy
+// singular `gpu`. `gpus` wins when set; otherwise a non-empty `gpu` is
+// promoted to a single-element list. Returns nil when neither is set.
+func mergeGPURequests(gpus []string, gpu string) []string {
+	if len(gpus) > 0 {
+		return gpus
+	}
+	if gpu != "" {
+		return []string{gpu}
+	}
+	return nil
+}
+
 // CreateContainer creates a new container
 func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*pb.CreateContainerResponse, error) {
 	if err := auth.RequireScope(ctx, auth.ScopeContainersWrite); err != nil {
@@ -320,10 +333,9 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		opts.Disk = req.Resources.Disk
 	}
 
-	// Set GPU passthrough
-	if req.Gpu != "" {
-		opts.GPU = req.Gpu
-	}
+	// Set GPU passthrough. `gpus` (repeated) supersedes the legacy singular
+	// `gpu`; a non-empty `gpu` with empty `gpus` is treated as one GPU.
+	opts.GPUs = mergeGPURequests(req.Gpus, req.Gpu)
 
 	// Set static IP if specified
 	if req.StaticIp != "" {
@@ -2358,6 +2370,7 @@ func toProtoContainer(info *incus.ContainerInfo) *pb.Container {
 		PodmanEnabled:        true, // TODO: Get from container config
 		Stack:                "",   // TODO: Get from container labels
 		GpuDevice:            info.GPU,
+		GpuDevices:           info.GPUs,
 		BackendId:            info.BackendID,
 		OsType:               osTypeEnum,
 		AccessType:           accessType,

--- a/internal/server/gpu_merge_test.go
+++ b/internal/server/gpu_merge_test.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeGPURequests(t *testing.T) {
+	cases := []struct {
+		name string
+		gpus []string
+		gpu  string
+		want []string
+	}{
+		{"neither set", nil, "", nil},
+		{"singular promoted to list", nil, "0", []string{"0"}},
+		{"repeated wins", []string{"0", "1"}, "", []string{"0", "1"}},
+		{"repeated supersedes singular", []string{"0", "1"}, "2", []string{"0", "1"}},
+		{"empty singular ignored", nil, "", nil},
+		{"single-element repeated", []string{"0000:01:00.0"}, "", []string{"0000:01:00.0"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := mergeGPURequests(c.gpus, c.gpu)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("mergeGPURequests(%v, %q) = %v, want %v", c.gpus, c.gpu, got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/core/container/gpu_resolve_devices_test.go
+++ b/pkg/core/container/gpu_resolve_devices_test.go
@@ -1,0 +1,82 @@
+package container
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+)
+
+// fakePCIResolver maps index inputs to canned PCI addresses; PCI-shaped inputs
+// pass through unchanged, mirroring the real ResolveGPUInputToPCI contract.
+func fakePCIResolver(byIndex map[string]string) func(string) (string, error) {
+	return func(in string) (string, error) {
+		if strings.Contains(in, ":") {
+			return in, nil
+		}
+		if pci, ok := byIndex[in]; ok {
+			return pci, nil
+		}
+		return "", fmt.Errorf("GPU input %q: index out of range", in)
+	}
+}
+
+func TestResolveGPUDevices_MultiplePinnedByPCI(t *testing.T) {
+	mock := &incustest.MockBackend{
+		ResolveGPUInputToPCIFunc: fakePCIResolver(map[string]string{
+			"0": "0000:01:00.0",
+			"1": "0000:0b:00.0",
+		}),
+	}
+	got, err := resolveGPUDevices(mock, []string{"0", "1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []incus.GPUDevice{{PCI: "0000:01:00.0"}, {PCI: "0000:0b:00.0"}}
+	if len(got) != len(want) {
+		t.Fatalf("got %d devices, want %d (%+v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].PCI != want[i].PCI {
+			t.Errorf("device[%d].PCI = %q, want %q", i, got[i].PCI, want[i].PCI)
+		}
+	}
+}
+
+func TestResolveGPUDevices_RejectsDuplicateGPU(t *testing.T) {
+	// Two different inputs ("0" and a PCI string) that resolve to the SAME
+	// physical GPU must be rejected — you can't attach one GPU twice.
+	mock := &incustest.MockBackend{
+		ResolveGPUInputToPCIFunc: fakePCIResolver(map[string]string{
+			"0": "0000:01:00.0",
+		}),
+	}
+	_, err := resolveGPUDevices(mock, []string{"0", "0000:01:00.0"})
+	if err == nil {
+		t.Fatal("expected duplicate-GPU error, got nil")
+	}
+	if !strings.Contains(err.Error(), "more than once") {
+		t.Errorf("error = %q, want it to mention the GPU was requested more than once", err)
+	}
+}
+
+func TestResolveGPUDevices_PropagatesResolveError(t *testing.T) {
+	mock := &incustest.MockBackend{
+		ResolveGPUInputToPCIFunc: fakePCIResolver(map[string]string{"0": "0000:01:00.0"}),
+	}
+	if _, err := resolveGPUDevices(mock, []string{"0", "9"}); err == nil {
+		t.Fatal("expected error for out-of-range index, got nil")
+	}
+}
+
+func TestResolveGPUDevices_Empty(t *testing.T) {
+	got, err := resolveGPUDevices(&incustest.MockBackend{}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no devices, got %+v", got)
+	}
+}

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -28,9 +28,9 @@ type CreateOptions struct {
 	Image                  string
 	CPU                    string
 	Memory                 string
-	Disk                   string // Disk size (e.g., "20GB")
-	GPU                    string // GPU device ID for passthrough (e.g., "0", PCI address, or empty for none)
-	StaticIP               string // Static IP address (e.g., "10.100.0.100") - empty for DHCP
+	Disk                   string   // Disk size (e.g., "20GB")
+	GPUs                   []string // GPU device IDs for passthrough — one per attached GPU ("0"/"1" or PCI address); empty = none
+	StaticIP               string   // Static IP address (e.g., "10.100.0.100") - empty for DHCP
 	SSHKeys                []string
 	Labels                 map[string]string // Kubernetes-style labels
 	EnablePodman           bool
@@ -95,6 +95,28 @@ func New() (*Manager, error) {
 // implementation. Used by tests to inject a mock; production code uses New.
 func NewWithBackend(backend incus.Backend) *Manager {
 	return &Manager{incus: backend}
+}
+
+// resolveGPUDevices turns user-supplied GPU inputs ("0"/"1" or PCI address)
+// into Incus GPU device configs pinned by stable PCI address. Each input is
+// resolved via the backend; a GPU requested more than once (same resolved
+// PCI) is rejected — attaching one physical GPU twice is always a mistake.
+// See the create-time comment in Create for why we pin by PCI not DRM id.
+func resolveGPUDevices(b incus.Backend, inputs []string) ([]incus.GPUDevice, error) {
+	devices := make([]incus.GPUDevice, 0, len(inputs))
+	seen := make(map[string]bool, len(inputs))
+	for _, in := range inputs {
+		pci, err := b.ResolveGPUInputToPCI(in)
+		if err != nil {
+			return nil, err
+		}
+		if seen[pci] {
+			return nil, fmt.Errorf("GPU %q (PCI %s) requested more than once", in, pci)
+		}
+		seen[pci] = true
+		devices = append(devices, incus.GPUDevice{PCI: pci})
+	}
+	return devices, nil
 }
 
 // Create creates a new container with full setup
@@ -166,21 +188,20 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 
 	// Configure GPU passthrough.
 	//
-	// Resolve the user-supplied input ("0", "1", or a PCI address) to
-	// a stable PCI address. Passing the input through as Incus' "id"
-	// field is brittle: that field maps to the DRM card minor index,
-	// which can shift across kernel upgrades. We hit this in production
-	// when the 6.8.0-110 → 6.8.0-111 upgrade renumbered a backend host's
-	// RTX 4090 from card0 to card1, breaking every container with
-	// id="0". PCI addresses are stable, so we always pin by PCI.
-	if opts.GPU != "" {
-		pci, err := m.incus.ResolveGPUInputToPCI(opts.GPU)
+	// Resolve each user-supplied input ("0", "1", or a PCI address) to a
+	// stable PCI address. Passing the input through as Incus' "id" field is
+	// brittle: that field maps to the DRM card minor index, which can shift
+	// across kernel upgrades. We hit this in production when the 6.8.0-110 →
+	// 6.8.0-111 upgrade renumbered a backend host's RTX 4090 from card0 to
+	// card1, breaking every container with id="0". PCI addresses are stable,
+	// so we always pin by PCI. Duplicate GPUs (same resolved PCI) are
+	// rejected — attaching one physical GPU twice is always a mistake.
+	if len(opts.GPUs) > 0 {
+		gpus, err := resolveGPUDevices(m.incus, opts.GPUs)
 		if err != nil {
 			return nil, fmt.Errorf("GPU passthrough setup failed: %w", err)
 		}
-		config.GPU = &incus.GPUDevice{
-			PCI: pci,
-		}
+		config.GPUs = gpus
 	}
 
 	if err := m.incus.CreateContainer(config); err != nil {

--- a/pkg/core/container/validate_gpu.go
+++ b/pkg/core/container/validate_gpu.go
@@ -47,9 +47,9 @@ func (m *Manager) ValidateGPU(pci string) GPUValidationResult {
 
 	cfg := incus.ContainerConfig{Name: ct, Image: gpuValidationImage}
 	if pci != "" {
-		cfg.GPU = &incus.GPUDevice{PCI: pci}
+		cfg.GPUs = []incus.GPUDevice{{PCI: pci}}
 	} else {
-		cfg.GPU = &incus.GPUDevice{} // empty = pass through all GPUs
+		cfg.GPUs = []incus.GPUDevice{{}} // empty device = pass through all GPUs
 	}
 
 	if err := m.incus.CreateContainer(cfg); err != nil {

--- a/pkg/core/container/validate_gpu_test.go
+++ b/pkg/core/container/validate_gpu_test.go
@@ -58,8 +58,8 @@ func TestValidateGPU_OK(t *testing.T) {
 	if got.Model != "NVIDIA GeForce RTX 3090" || got.DriverVersion != "570.211.01" {
 		t.Errorf("model/driver = %q / %q", got.Model, got.DriverVersion)
 	}
-	if created.GPU == nil || created.GPU.PCI != "0000:01:00.0" {
-		t.Errorf("expected throwaway created with GPU pci=0000:01:00.0, got %+v", created.GPU)
+	if len(created.GPUs) != 1 || created.GPUs[0].PCI != "0000:01:00.0" {
+		t.Errorf("expected throwaway created with one GPU pci=0000:01:00.0, got %+v", created.GPUs)
 	}
 	if nvruntime != "true" {
 		t.Errorf("expected nvidia.runtime=true set, got %q", nvruntime)
@@ -84,8 +84,8 @@ func TestValidateGPU_AllGPUsWhenNoPCI(t *testing.T) {
 	if got.Status != GPUStatusOK {
 		t.Fatalf("status = %q, want ok", got.Status)
 	}
-	if created.GPU == nil || created.GPU.PCI != "" {
-		t.Errorf("expected GPU device with empty PCI (all GPUs), got %+v", created.GPU)
+	if len(created.GPUs) != 1 || created.GPUs[0].PCI != "" {
+		t.Errorf("expected one GPU device with empty PCI (all GPUs), got %+v", created.GPUs)
 	}
 }
 

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -129,6 +130,42 @@ type GPUDevice struct {
 	PCI string
 }
 
+// gpuDeviceName returns the Incus device name for the i-th attached GPU.
+// The first GPU keeps the legacy "gpu" name so single-GPU containers are
+// byte-identical to the pre-multi-GPU config; subsequent GPUs are "gpu1",
+// "gpu2", ... Device names must be unique within a container.
+func gpuDeviceName(i int) string {
+	if i == 0 {
+		return "gpu"
+	}
+	return fmt.Sprintf("gpu%d", i)
+}
+
+// gpuDeviceIdentity extracts a human-readable identity for a GPU device
+// from its Incus device config map — the PCI address if pinned (preferred,
+// stable), else the DRM id, else a generic "GPU" marker.
+func gpuDeviceIdentity(device map[string]string) string {
+	if pci, ok := device["pci"]; ok && pci != "" {
+		return pci
+	}
+	if id, ok := device["id"]; ok && id != "" {
+		return id
+	}
+	return "GPU" // Generic GPU indicator (pass-through-all, no pin)
+}
+
+// finalizeGPUInfo sorts the collected GPU identities for stable output and
+// derives the single-value GPU field (first entry) for display/back-compat.
+// Incus returns devices as an unordered map, so sorting is what makes the
+// read-back deterministic.
+func finalizeGPUInfo(info *ContainerInfo) {
+	if len(info.GPUs) == 0 {
+		return
+	}
+	sort.Strings(info.GPUs)
+	info.GPU = info.GPUs[0]
+}
+
 // ToMap converts GPUDevice to the map format required by Incus API
 func (g GPUDevice) ToMap() map[string]string {
 	m := map[string]string{
@@ -211,7 +248,7 @@ type ContainerConfig struct {
 	Memory                 string
 	Disk                   *DiskDevice      // Root disk configuration
 	NIC                    *NICDevice       // Network interface configuration
-	GPU                    *GPUDevice       // GPU device configuration for passthrough
+	GPUs                   []GPUDevice      // GPU devices for passthrough (one per attached GPU; empty = none)
 	InstanceType           api.InstanceType // Container (LXC) or VM (QEMU/KVM). Defaults to Container.
 	EnableNesting          bool
 	EnablePodmanPrivileged bool // Full Docker support (requires privileged container + AppArmor disabled)
@@ -275,8 +312,9 @@ type ContainerInfo struct {
 	CPU          string
 	Memory       string
 	Disk         string
-	GPU          string // GPU device info (e.g., "nvidia.com/gpu" or GPU ID)
-	InstanceType string // "container" or "virtual-machine"
+	GPU          string   // First GPU device info, for display/back-compat (e.g., PCI address or GPU ID); empty if none
+	GPUs         []string // All attached GPU devices (PCI address or ID per entry), sorted for stable output
+	InstanceType string   // "container" or "virtual-machine"
 	Labels       map[string]string
 	Role         Role   // Core container role (e.g., RolePostgres, RoleCaddy), empty for user containers
 	Tenant       string // Explicit owning tenant (user.containarium.tenant); empty falls back to the name convention
@@ -636,10 +674,14 @@ func (c *Client) CreateContainer(config ContainerConfig) error {
 		}
 	}
 
-	// GPU device passthrough
-	if config.GPU != nil {
-		req.Devices["gpu"] = config.GPU.ToMap()
-		fmt.Printf("[DEBUG] CreateContainer - GPU: id=%s, pci=%s\n", config.GPU.ID, config.GPU.PCI)
+	// GPU device passthrough. Each attached GPU is a distinct Incus device:
+	// the first keeps the legacy name "gpu" (byte-identical to the old
+	// single-GPU config), the rest are "gpu1", "gpu2", ... — Incus device
+	// names must be unique within a container.
+	for i, g := range config.GPUs {
+		name := gpuDeviceName(i)
+		req.Devices[name] = g.ToMap()
+		fmt.Printf("[DEBUG] CreateContainer - GPU[%s]: id=%s, pci=%s\n", name, g.ID, g.PCI)
 	}
 
 	// Create the container
@@ -765,18 +807,13 @@ func (c *Client) ListContainers() ([]ContainerInfo, error) {
 				}
 			}
 
-			// Check for GPU devices
+			// Check for GPU devices — a container may have several
+			// (gpu, gpu1, gpu2, ...); collect every one.
 			if deviceType == "gpu" {
-				// GPU device found - could be physical GPU passthrough or mdev
-				if id, ok := device["id"]; ok {
-					info.GPU = id
-				} else if pci, ok := device["pci"]; ok {
-					info.GPU = pci
-				} else {
-					info.GPU = "GPU" // Generic GPU indicator
-				}
+				info.GPUs = append(info.GPUs, gpuDeviceIdentity(device))
 			}
 		}
+		finalizeGPUInfo(&info)
 
 		// If no disk size found, check expanded devices (includes profile devices)
 		if info.Disk == "" {
@@ -896,18 +933,13 @@ func (c *Client) GetContainer(name string) (*ContainerInfo, error) {
 			}
 		}
 
-		// Check for GPU devices
+		// Check for GPU devices — a container may have several
+		// (gpu, gpu1, gpu2, ...); collect every one.
 		if deviceType == "gpu" {
-			// GPU device found - could be physical GPU passthrough or mdev
-			if id, ok := device["id"]; ok {
-				info.GPU = id
-			} else if pci, ok := device["pci"]; ok {
-				info.GPU = pci
-			} else {
-				info.GPU = "GPU" // Generic GPU indicator
-			}
+			info.GPUs = append(info.GPUs, gpuDeviceIdentity(device))
 		}
 	}
+	finalizeGPUInfo(info)
 
 	// If no disk size found, check expanded devices (includes profile devices)
 	if info.Disk == "" {

--- a/pkg/core/incus/gpu_device_test.go
+++ b/pkg/core/incus/gpu_device_test.go
@@ -1,0 +1,67 @@
+package incus
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGPUDeviceName(t *testing.T) {
+	// First GPU keeps the legacy "gpu" name (byte-identical to the
+	// pre-multi-GPU config); subsequent GPUs get numbered names.
+	cases := map[int]string{0: "gpu", 1: "gpu1", 2: "gpu2", 7: "gpu7"}
+	for i, want := range cases {
+		if got := gpuDeviceName(i); got != want {
+			t.Errorf("gpuDeviceName(%d) = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestGPUDeviceIdentity(t *testing.T) {
+	cases := []struct {
+		name   string
+		device map[string]string
+		want   string
+	}{
+		{"pci preferred over id", map[string]string{"type": "gpu", "pci": "0000:0b:00.0", "id": "0"}, "0000:0b:00.0"},
+		{"pci only", map[string]string{"type": "gpu", "pci": "0000:01:00.0"}, "0000:01:00.0"},
+		{"id only", map[string]string{"type": "gpu", "id": "1"}, "1"},
+		{"empty pci falls back to id", map[string]string{"type": "gpu", "pci": "", "id": "2"}, "2"},
+		{"pass-through-all (no pin)", map[string]string{"type": "gpu"}, "GPU"},
+		{"empty values", map[string]string{"type": "gpu", "pci": "", "id": ""}, "GPU"},
+	}
+	for _, c := range cases {
+		if got := gpuDeviceIdentity(c.device); got != c.want {
+			t.Errorf("%s: gpuDeviceIdentity(%v) = %q, want %q", c.name, c.device, got, c.want)
+		}
+	}
+}
+
+func TestFinalizeGPUInfo(t *testing.T) {
+	t.Run("sorts and sets first", func(t *testing.T) {
+		info := &ContainerInfo{GPUs: []string{"0000:0b:00.0", "0000:01:00.0", "0000:05:00.0"}}
+		finalizeGPUInfo(info)
+		want := []string{"0000:01:00.0", "0000:05:00.0", "0000:0b:00.0"}
+		if !reflect.DeepEqual(info.GPUs, want) {
+			t.Errorf("GPUs = %v, want sorted %v", info.GPUs, want)
+		}
+		if info.GPU != "0000:01:00.0" {
+			t.Errorf("GPU (first) = %q, want %q", info.GPU, want[0])
+		}
+	})
+
+	t.Run("no GPUs leaves fields zero", func(t *testing.T) {
+		info := &ContainerInfo{}
+		finalizeGPUInfo(info)
+		if info.GPU != "" || len(info.GPUs) != 0 {
+			t.Errorf("expected empty GPU fields, got GPU=%q GPUs=%v", info.GPU, info.GPUs)
+		}
+	})
+
+	t.Run("single GPU mirrors into GPU", func(t *testing.T) {
+		info := &ContainerInfo{GPUs: []string{"0000:0b:00.0"}}
+		finalizeGPUInfo(info)
+		if info.GPU != "0000:0b:00.0" {
+			t.Errorf("GPU = %q, want the single device", info.GPU)
+		}
+	})
+}

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -269,7 +269,15 @@ type ResourceLimits struct {
 	// Disk/storage limit (e.g., "50GB", "100GB")
 	Disk string `protobuf:"bytes,3,opt,name=disk,proto3" json:"disk,omitempty"`
 	// GPU device ID for passthrough (e.g., "0" for first GPU, PCI address, or empty for none)
-	Gpu           string `protobuf:"bytes,4,opt,name=gpu,proto3" json:"gpu,omitempty"`
+	//
+	// Deprecated: single-GPU field. Prefer `gpus` for one-or-many. When `gpus`
+	// is non-empty it takes precedence and this field is ignored; when `gpus`
+	// is empty a non-empty `gpu` is treated as a single-element list.
+	Gpu string `protobuf:"bytes,4,opt,name=gpu,proto3" json:"gpu,omitempty"`
+	// GPU device IDs for passthrough — one entry per GPU to attach (each is a
+	// device index like "0"/"1" or a PCI address like "0000:0b:00.0"). Empty
+	// means no GPU. Supersedes the singular `gpu` field.
+	Gpus          []string `protobuf:"bytes,5,rep,name=gpus,proto3" json:"gpus,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -330,6 +338,13 @@ func (x *ResourceLimits) GetGpu() string {
 		return x.Gpu
 	}
 	return ""
+}
+
+func (x *ResourceLimits) GetGpus() []string {
+	if x != nil {
+		return x.Gpus
+	}
+	return nil
 }
 
 // NetworkInfo contains network configuration for a container
@@ -432,7 +447,8 @@ type Container struct {
 	PodmanEnabled bool `protobuf:"varint,11,opt,name=podman_enabled,json=podmanEnabled,proto3" json:"podman_enabled,omitempty"`
 	// Software stack installed in the container (e.g., "nodejs", "python")
 	Stack string `protobuf:"bytes,12,opt,name=stack,proto3" json:"stack,omitempty"`
-	// GPU device info (e.g., GPU ID or PCI address if attached)
+	// GPU device info (e.g., GPU ID or PCI address if attached). For a
+	// multi-GPU container this is the first device; see `gpu_devices` for all.
 	GpuDevice string `protobuf:"bytes,13,opt,name=gpu_device,json=gpuDevice,proto3" json:"gpu_device,omitempty"`
 	// Backend ID this container runs on (e.g., "gcp-spot", "tunnel-node-a-gpu")
 	BackendId string `protobuf:"bytes,14,opt,name=backend_id,json=backendId,proto3" json:"backend_id,omitempty"`
@@ -504,7 +520,11 @@ type Container struct {
 	// `containarium prune` skip it; a deliberate single-box delete still removes
 	// it. Read from the user.containarium.delete_policy Incus config key; set via
 	// SetContainerDeletePolicy. Absent/unprotected = DELETE_POLICY_UNSPECIFIED.
-	DeletePolicy  DeletePolicy `protobuf:"varint,26,opt,name=delete_policy,json=deletePolicy,proto3,enum=containarium.v1.DeletePolicy" json:"delete_policy,omitempty"`
+	DeletePolicy DeletePolicy `protobuf:"varint,26,opt,name=delete_policy,json=deletePolicy,proto3,enum=containarium.v1.DeletePolicy" json:"delete_policy,omitempty"`
+	// All GPU devices attached to this container (device index or PCI address
+	// per entry). For a single-GPU container this has one entry mirroring
+	// `gpu_device`; empty when no GPU is attached.
+	GpuDevices    []string `protobuf:"bytes,27,rep,name=gpu_devices,json=gpuDevices,proto3" json:"gpu_devices,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -721,6 +741,13 @@ func (x *Container) GetDeletePolicy() DeletePolicy {
 	return DeletePolicy_DELETE_POLICY_UNSPECIFIED
 }
 
+func (x *Container) GetGpuDevices() []string {
+	if x != nil {
+		return x.GpuDevices
+	}
+	return nil
+}
+
 // ContainerMetrics contains runtime metrics for a container
 type ContainerMetrics struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -856,6 +883,10 @@ type CreateContainerRequest struct {
 	// See available stacks in configs/stacks.yaml
 	Stack string `protobuf:"bytes,9,opt,name=stack,proto3" json:"stack,omitempty"`
 	// GPU device ID for passthrough (e.g., "0" for first GPU, PCI address, or empty for none)
+	//
+	// Deprecated: single-GPU field. Prefer `gpus`. When `gpus` is non-empty it
+	// takes precedence; when `gpus` is empty a non-empty `gpu` is treated as a
+	// single-element list.
 	Gpu string `protobuf:"bytes,10,opt,name=gpu,proto3" json:"gpu,omitempty"`
 	// Target backend ID for creation (empty = primary backend)
 	BackendId string `protobuf:"bytes,11,opt,name=backend_id,json=backendId,proto3" json:"backend_id,omitempty"`
@@ -928,8 +959,14 @@ type CreateContainerRequest struct {
 	// box that merely sleeps must never be deleted just for being stopped.
 	// 0 = never delete on stop (today's behavior).
 	DeleteAfterStoppedSeconds int64 `protobuf:"varint,22,opt,name=delete_after_stopped_seconds,json=deleteAfterStoppedSeconds,proto3" json:"delete_after_stopped_seconds,omitempty"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	// GPU device IDs for passthrough — one entry per GPU to attach (device
+	// index like "0"/"1" or PCI address like "0000:0b:00.0"). Supersedes the
+	// singular `gpu` field: when non-empty `gpu` is ignored; when empty a
+	// non-empty `gpu` is treated as a single-element list. Each device is
+	// resolved to a stable PCI address at create time.
+	Gpus          []string `protobuf:"bytes,23,rep,name=gpus,proto3" json:"gpus,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateContainerRequest) Reset() {
@@ -1114,6 +1151,13 @@ func (x *CreateContainerRequest) GetDeleteAfterStoppedSeconds() int64 {
 		return x.DeleteAfterStoppedSeconds
 	}
 	return 0
+}
+
+func (x *CreateContainerRequest) GetGpus() []string {
+	if x != nil {
+		return x.Gpus
+	}
+	return nil
 }
 
 // CreateContainerResponse is the response from creating a container
@@ -4243,19 +4287,20 @@ var File_containarium_v1_container_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_container_proto_rawDesc = "" +
 	"\n" +
-	"\x1fcontainarium/v1/container.proto\x12\x0fcontainarium.v1\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"`\n" +
+	"\x1fcontainarium/v1/container.proto\x12\x0fcontainarium.v1\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"t\n" +
 	"\x0eResourceLimits\x12\x10\n" +
 	"\x03cpu\x18\x01 \x01(\tR\x03cpu\x12\x16\n" +
 	"\x06memory\x18\x02 \x01(\tR\x06memory\x12\x12\n" +
 	"\x04disk\x18\x03 \x01(\tR\x04disk\x12\x10\n" +
-	"\x03gpu\x18\x04 \x01(\tR\x03gpu\"\x83\x01\n" +
+	"\x03gpu\x18\x04 \x01(\tR\x03gpu\x12\x12\n" +
+	"\x04gpus\x18\x05 \x03(\tR\x04gpus\"\x83\x01\n" +
 	"\vNetworkInfo\x12\x1d\n" +
 	"\n" +
 	"ip_address\x18\x01 \x01(\tR\tipAddress\x12\x1f\n" +
 	"\vmac_address\x18\x02 \x01(\tR\n" +
 	"macAddress\x12\x1c\n" +
 	"\tinterface\x18\x03 \x01(\tR\tinterface\x12\x16\n" +
-	"\x06bridge\x18\x04 \x01(\tR\x06bridge\"\xa3\t\n" +
+	"\x06bridge\x18\x04 \x01(\tR\x06bridge\"\xc4\t\n" +
 	"\tContainer\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x125\n" +
@@ -4290,7 +4335,9 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\n" +
 	"stopped_at\x18\x18 \x01(\v2\x1a.google.protobuf.TimestampR\tstoppedAt\x12?\n" +
 	"\x1cdelete_after_stopped_seconds\x18\x19 \x01(\x03R\x19deleteAfterStoppedSeconds\x12B\n" +
-	"\rdelete_policy\x18\x1a \x01(\x0e2\x1d.containarium.v1.DeletePolicyR\fdeletePolicy\x1a9\n" +
+	"\rdelete_policy\x18\x1a \x01(\x0e2\x1d.containarium.v1.DeletePolicyR\fdeletePolicy\x12\x1f\n" +
+	"\vgpu_devices\x18\x1b \x03(\tR\n" +
+	"gpuDevices\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xcf\x02\n" +
@@ -4302,7 +4349,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x10disk_usage_bytes\x18\x05 \x01(\x03R\x0ediskUsageBytes\x12(\n" +
 	"\x10network_rx_bytes\x18\x06 \x01(\x03R\x0enetworkRxBytes\x12(\n" +
 	"\x10network_tx_bytes\x18\a \x01(\x03R\x0enetworkTxBytes\x12#\n" +
-	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\xf2\a\n" +
+	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\x86\b\n" +
 	"\x16CreateContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12=\n" +
 	"\tresources\x18\x02 \x01(\v2\x1f.containarium.v1.ResourceLimitsR\tresources\x12\x19\n" +
@@ -4331,7 +4378,8 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\vttl_seconds\x18\x14 \x01(\x03R\n" +
 	"ttlSeconds\x12*\n" +
 	"\x11idle_stop_minutes\x18\x15 \x01(\x05R\x0fidleStopMinutes\x12?\n" +
-	"\x1cdelete_after_stopped_seconds\x18\x16 \x01(\x03R\x19deleteAfterStoppedSeconds\x1a9\n" +
+	"\x1cdelete_after_stopped_seconds\x18\x16 \x01(\x03R\x19deleteAfterStoppedSeconds\x12\x12\n" +
+	"\x04gpus\x18\x17 \x03(\tR\x04gpus\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aB\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -92,7 +92,16 @@ message ResourceLimits {
   string disk = 3;
 
   // GPU device ID for passthrough (e.g., "0" for first GPU, PCI address, or empty for none)
+  //
+  // Deprecated: single-GPU field. Prefer `gpus` for one-or-many. When `gpus`
+  // is non-empty it takes precedence and this field is ignored; when `gpus`
+  // is empty a non-empty `gpu` is treated as a single-element list.
   string gpu = 4;
+
+  // GPU device IDs for passthrough — one entry per GPU to attach (each is a
+  // device index like "0"/"1" or a PCI address like "0000:0b:00.0"). Empty
+  // means no GPU. Supersedes the singular `gpu` field.
+  repeated string gpus = 5;
 }
 
 // NetworkInfo contains network configuration for a container
@@ -148,7 +157,8 @@ message Container {
   // Software stack installed in the container (e.g., "nodejs", "python")
   string stack = 12;
 
-  // GPU device info (e.g., GPU ID or PCI address if attached)
+  // GPU device info (e.g., GPU ID or PCI address if attached). For a
+  // multi-GPU container this is the first device; see `gpu_devices` for all.
   string gpu_device = 13;
 
   // Backend ID this container runs on (e.g., "gcp-spot", "tunnel-node-a-gpu")
@@ -234,6 +244,11 @@ message Container {
   // it. Read from the user.containarium.delete_policy Incus config key; set via
   // SetContainerDeletePolicy. Absent/unprotected = DELETE_POLICY_UNSPECIFIED.
   DeletePolicy delete_policy = 26;
+
+  // All GPU devices attached to this container (device index or PCI address
+  // per entry). For a single-GPU container this has one entry mirroring
+  // `gpu_device`; empty when no GPU is attached.
+  repeated string gpu_devices = 27;
 }
 
 // ContainerMetrics contains runtime metrics for a container
@@ -297,6 +312,10 @@ message CreateContainerRequest {
   string stack = 9;
 
   // GPU device ID for passthrough (e.g., "0" for first GPU, PCI address, or empty for none)
+  //
+  // Deprecated: single-GPU field. Prefer `gpus`. When `gpus` is non-empty it
+  // takes precedence; when `gpus` is empty a non-empty `gpu` is treated as a
+  // single-element list.
   string gpu = 10;
 
   // Target backend ID for creation (empty = primary backend)
@@ -381,6 +400,13 @@ message CreateContainerRequest {
   // box that merely sleeps must never be deleted just for being stopped.
   // 0 = never delete on stop (today's behavior).
   int64 delete_after_stopped_seconds = 22;
+
+  // GPU device IDs for passthrough — one entry per GPU to attach (device
+  // index like "0"/"1" or PCI address like "0000:0b:00.0"). Supersedes the
+  // singular `gpu` field: when non-empty `gpu` is ignored; when empty a
+  // non-empty `gpu` is treated as a single-element list. Each device is
+  // resolved to a stable PCI address at create time.
+  repeated string gpus = 23;
 }
 
 // CreateContainerResponse is the response from creating a container

--- a/test/integration/storage_test.go
+++ b/test/integration/storage_test.go
@@ -97,7 +97,7 @@ func testCreateContainerWithQuota(t *testing.T, ctx context.Context, grpcClient 
 		[]string{},                   // No SSH keys for test
 		false,                        // No Podman
 		"",                           // No stack
-		"",                           // No GPU
+		nil,                          // No GPU
 		0,                            // Default OS type
 		false,                        // No monitoring
 		"",                           // No pool
@@ -148,7 +148,7 @@ func testQuotaEnforcement(t *testing.T, ctx context.Context, grpcClient *client.
 		[]string{},
 		false,
 		"",
-		"",
+		nil,
 		0, // Default OS type
 		false,
 		"",                     // No pool
@@ -193,11 +193,11 @@ func testMultiContainerIsolation(t *testing.T, ctx context.Context, grpcClient *
 	t.Log("Creating multiple containers to test quota isolation...")
 
 	// Create two containers with different quotas
-	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
+	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
 	require.NoError(t, err)
 	defer func() { _ = grpcClient.DeleteContainer(user1, true) }()
 
-	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
+	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
 	require.NoError(t, err)
 	defer func() { _ = grpcClient.DeleteContainer(user2, true) }()
 
@@ -223,7 +223,7 @@ func testCompression(t *testing.T, ctx context.Context, grpcClient *client.GRPCC
 
 	t.Log("Creating container to test compression...")
 
-	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
+	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
 	require.NoError(t, err)
 	defer func() { _ = grpcClient.DeleteContainer(username, true) }()
 
@@ -246,7 +246,7 @@ func testPrepareRebootData(t *testing.T, ctx context.Context, grpcClient *client
 	t.Logf("Creating container for persistence test: %s", username)
 
 	// Create container
-	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", "", 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
+	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
 	require.NoError(t, err)
 	require.NotNil(t, container)
 


### PR DESCRIPTION
## What

A container can now be created with **more than one GPU** attached, closing the single-GPU limit of the existing passthrough path. GPU passthrough itself was already shipped and hardware-verified; this adds N-GPU-per-box.

## Contract (proto-first)

- `CreateContainerRequest.gpus` + `ResourceLimits.gpus` — `repeated string`
- `Container.gpu_devices` — `repeated string` on read-back
- Singular `gpu` / `gpu_device` kept for **back-compat**: `gpus` supersedes `gpu` when set; a lone `gpu` is promoted to a one-element list (`mergeGPURequests`). Wire-compatible — no breaking change.

## Engine

- `incus.ContainerConfig.GPUs []GPUDevice`; `CreateContainer` attaches each as a distinct device — the first keeps the legacy name `gpu` (so existing single-GPU containers are **byte-identical**), the rest are `gpu1`, `gpu2`, … (`gpuDeviceName`).
- `resolveGPUDevices` resolves every input to a **stable PCI address** (same kernel-upgrade-safe pinning as the single-GPU path) and **rejects the same GPU requested twice**.
- Read-back collects all `gpu` devices (`gpuDeviceIdentity`) and **sorts** them for deterministic output (`finalizeGPUInfo`); the singular `GPU` mirrors the first.

## Surfaces

- **CLI**: `--gpu` is now repeatable / comma-separated — `--gpu 0 --gpu 1` or `--gpu 0,1`; plain `--gpu 0` still works.
- **Clients**: gRPC + HTTP thread `gpus []string` and read back `gpu_devices`.
- **MCP**: platform `create_container` gains a `gpus` array argument.

## Out of scope (unchanged)

Recipe deploys still take a single `gpu` — recipes already expose all box-visible GPUs via Podman `--device nvidia.com/gpu=all`, so multi-GPU there is moot.

## Testing

- **Unit**: device naming, identity/sort, duplicate-GPU rejection, multi-resolve, and the request-merge helper.
- **Live**: validated on a two-GPU lab host (mixed integrated + discrete GPU) via the local-incus path against a throwaway container — index→PCI resolution, the two-device attach (both `card`/`renderD` nodes visible inside), and the sorted read-back all confirmed. The production daemon on the host was not touched; the throwaway was torn down.

Build clean, swagger regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)