### PR TITLE
RFC: agent model-gateway (design) + pull-based run-queue (prototype)

### DIFF
--- a/agent-runtime/src/index.ts
+++ b/agent-runtime/src/index.ts
@@ -6,6 +6,7 @@ import { writeArtifact } from "./artifact.js";
 import type { Engine, EngineConfig } from "./engine.js";
 import { ClaudeEngine } from "./engines/claude.js";
 import { CodexEngine } from "./engines/codex.js";
+import { pollConfigFromEnv, runPollLoop } from "./poll.js";
 import { DEFAULT_SEED_DIR, loadSeed } from "./seed.js";
 
 // The in-box loop entrypoint (Phase 4a). Reads the seed the daemon planted,
@@ -52,8 +53,10 @@ function writeCodexConfig(cfg: EngineConfig): void {
 }
 
 // mode: "run" (one-shot — read input.json, run once, write artifact.json; the
-// 4a path `agent run` uses) or "serve" (start the A2A server so peers/crews can
-// delegate tasks; the 4b path SendAgentTask reaches). Default "run".
+// 4a path `agent run` uses), "serve" (start the A2A server so peers/crews can
+// delegate tasks; the 4b path SendAgentTask reaches), or "poll" (pull-queue
+// worker: lease → run → complete in a loop, outbound-only; prototype). Default
+// "run".
 const mode = (process.env.CONTAINARIUM_AGENT_MODE ?? "run").toLowerCase();
 
 async function main(): Promise<void> {
@@ -72,6 +75,14 @@ async function main(): Promise<void> {
   if (mode === "serve") {
     // Long-running: serve /agent-card + /tasks until the box stops.
     startA2AServer(seed, engine, cfg);
+    return;
+  }
+
+  if (mode === "poll") {
+    // Long-running pull-queue worker: lease → run → complete, outbound-only.
+    // The seed's system prompt is the worker's persona; the leased task's
+    // input_json is the per-run input.
+    await runPollLoop(pollConfigFromEnv(), engine, cfg);
     return;
   }
 

--- a/agent-runtime/src/poll.ts
+++ b/agent-runtime/src/poll.ts
@@ -1,0 +1,133 @@
+import { runTask } from "./a2a.js";
+import type { Engine, EngineConfig } from "./engine.js";
+
+// poll.ts — worker side of the pull-based run queue (prototype). Instead of the
+// daemon exec-ing a run into the box (push), a long-lived worker box LEASES
+// tasks from the daemon/gateway over HTTP, runs them locally through the same
+// engine, and reports the result back. All traffic is OUTBOUND from the box, so
+// it works behind NAT / a tunnel with no inbound listener.
+// See docs/AGENT-MODEL-GATEWAY-DESIGN.md (pull-queue section).
+
+// Wire shapes match protojson (lowerCamelCase) on the agent-tasks endpoints.
+interface LeaseResponseWire {
+  hasTask?: boolean;
+  taskId?: string;
+  skillId?: string;
+  inputJson?: string;
+  leaseToken?: string;
+}
+
+export interface PollConfig {
+  // Base URL of the daemon/gateway, e.g. "https://<host>:8080".
+  baseUrl: string;
+  // Bearer token authorizing the queue calls (needs agents:run). This is the
+  // worker's *runtime* credential, distinct from the skill's in-box token —
+  // see the design note's open question on who mints it.
+  token: string;
+  workerId: string;
+  // Lease only this skill's tasks; "" = any skill.
+  skillId: string;
+  // Visibility timeout requested per lease; keep > worst-case run time.
+  leaseSeconds: number;
+  // Backoff when the queue is empty.
+  idleMs: number;
+  // When true, process exactly one task then return (live-test / one-shot).
+  once: boolean;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+async function postJSON(url: string, token: string, body: unknown): Promise<Response> {
+  return fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+}
+
+async function lease(cfg: PollConfig): Promise<LeaseResponseWire> {
+  const res = await postJSON(`${cfg.baseUrl}/v1/agent-tasks/lease`, cfg.token, {
+    workerId: cfg.workerId,
+    skillId: cfg.skillId,
+    leaseSeconds: cfg.leaseSeconds,
+  });
+  if (!res.ok) throw new Error(`lease failed: HTTP ${res.status} ${await res.text()}`);
+  return (await res.json()) as LeaseResponseWire;
+}
+
+async function complete(
+  cfg: PollConfig,
+  taskId: string,
+  leaseToken: string,
+  artifactJson: string,
+  error: string,
+): Promise<boolean> {
+  const res = await postJSON(
+    `${cfg.baseUrl}/v1/agent-tasks/${encodeURIComponent(taskId)}/complete`,
+    cfg.token,
+    { taskId, leaseToken, artifactJson, error },
+  );
+  if (!res.ok) throw new Error(`complete failed: HTTP ${res.status} ${await res.text()}`);
+  const out = (await res.json()) as { accepted?: boolean };
+  return out.accepted === true;
+}
+
+// runPollLoop leases → runs → completes until aborted (or once). Errors on a
+// single iteration are logged and the loop backs off; one bad task never kills
+// the worker.
+export async function runPollLoop(
+  cfg: PollConfig,
+  engine: Engine,
+  engineCfg: EngineConfig,
+  signal?: AbortSignal,
+): Promise<void> {
+  while (!signal?.aborted) {
+    try {
+      const leased = await lease(cfg);
+      if (!leased.hasTask || !leased.taskId || !leased.leaseToken) {
+        if (cfg.once) return;
+        await sleep(cfg.idleMs);
+        continue;
+      }
+
+      // runTask (shared with the A2A path) never throws — a failed run comes
+      // back as state FAILED, which we map to the completion's error field.
+      const art = await runTask(
+        { id: leased.taskId, inputJson: leased.inputJson },
+        engine,
+        engineCfg,
+      );
+      const errMsg = art.state === "AGENT_TASK_STATE_FAILED" ? art.error : "";
+      const accepted = await complete(cfg, leased.taskId, leased.leaseToken, art.outputJson, errMsg);
+      process.stdout.write(
+        `agent-runtime poll: task ${leased.taskId} ${errMsg ? "failed" : "done"}` +
+          `${accepted ? "" : " (lease stale — result dropped)"}\n`,
+      );
+
+      if (cfg.once) return;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      process.stderr.write(`agent-runtime poll: iteration error: ${msg}\n`);
+      await sleep(cfg.idleMs);
+    }
+  }
+}
+
+// pollConfigFromEnv reads the worker's poll settings from the environment the
+// daemon stamps onto a worker box.
+export function pollConfigFromEnv(): PollConfig {
+  const baseUrl = process.env.CONTAINARIUM_QUEUE_URL ?? "";
+  const token = process.env.CONTAINARIUM_QUEUE_TOKEN ?? "";
+  if (!baseUrl || !token) {
+    throw new Error("poll mode needs CONTAINARIUM_QUEUE_URL and CONTAINARIUM_QUEUE_TOKEN");
+  }
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ""),
+    token,
+    workerId: process.env.CONTAINARIUM_WORKER_ID ?? "worker",
+    skillId: process.env.CONTAINARIUM_QUEUE_SKILL ?? "",
+    leaseSeconds: Number(process.env.CONTAINARIUM_LEASE_SECONDS ?? "300"),
+    idleMs: Number(process.env.CONTAINARIUM_POLL_IDLE_MS ?? "2000"),
+    once: process.env.CONTAINARIUM_POLL_ONCE === "1",
+  };
+}

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -293,6 +293,116 @@
         ]
       }
     },
+    "/v1/agent-tasks": {
+      "post": {
+        "summary": "Enqueue an agent task (pull queue)",
+        "description": "Places a task on the pull queue for a skill; worker boxes lease and run it.",
+        "operationId": "AgentSkillService_EnqueueAgentTask",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/EnqueueAgentTaskResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "EnqueueAgentTaskRequest places one task on the pull queue.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EnqueueAgentTaskRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Agents"
+        ]
+      }
+    },
+    "/v1/agent-tasks/lease": {
+      "post": {
+        "summary": "Lease the next agent task (pull queue)",
+        "description": "Worker boxes poll this to lease the next task; the task is hidden from other workers until completed or the lease expires.",
+        "operationId": "AgentSkillService_LeaseAgentTask",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/LeaseAgentTaskResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "LeaseAgentTaskRequest asks for the next runnable task.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LeaseAgentTaskRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Agents"
+        ]
+      }
+    },
+    "/v1/agent-tasks/{taskId}/complete": {
+      "post": {
+        "summary": "Complete a leased agent task (pull queue)",
+        "description": "Worker boxes report a leased task's artifact/error here; a stale lease is rejected.",
+        "operationId": "AgentSkillService_CompleteAgentTask",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/CompleteAgentTaskResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CompleteAgentTaskBody"
+            }
+          }
+        ],
+        "tags": [
+          "Agents"
+        ]
+      }
+    },
     "/v1/alerts": {
       "get": {
         "summary": "List alert rules",
@@ -6105,6 +6215,32 @@
       },
       "title": "Collaborator represents a user with access to a container"
     },
+    "CompleteAgentTaskBody": {
+      "type": "object",
+      "properties": {
+        "leaseToken": {
+          "type": "string"
+        },
+        "artifactJson": {
+          "type": "string",
+          "description": "The run artifact as JSON; empty when error is set."
+        },
+        "error": {
+          "type": "string",
+          "description": "Non-empty when the run failed; the task is removed (no auto-retry in the\nprototype) and the error is recorded."
+        }
+      },
+      "description": "CompleteAgentTaskRequest reports a leased task's outcome."
+    },
+    "CompleteAgentTaskResponse": {
+      "type": "object",
+      "properties": {
+        "accepted": {
+          "type": "boolean",
+          "description": "False when the lease was stale (expired + redelivered); the worker should\ndrop its result — another lease owns the task now."
+        }
+      }
+    },
     "ComposeStack": {
       "type": "object",
       "properties": {
@@ -7247,6 +7383,29 @@
         }
       }
     },
+    "EnqueueAgentTaskRequest": {
+      "type": "object",
+      "properties": {
+        "skillId": {
+          "type": "string",
+          "description": "Skill this task is for (workers may filter their lease by it)."
+        },
+        "inputJson": {
+          "type": "string",
+          "description": "Task input as JSON (the same shape RunAgentSkill takes as input_json)."
+        }
+      },
+      "description": "EnqueueAgentTaskRequest places one task on the pull queue."
+    },
+    "EnqueueAgentTaskResponse": {
+      "type": "object",
+      "properties": {
+        "taskId": {
+          "type": "string",
+          "description": "Server-assigned task id, used later to correlate the completion."
+        }
+      }
+    },
     "Event": {
       "type": "object",
       "properties": {
@@ -8019,6 +8178,47 @@
         },
         "message": {
           "type": "string"
+        }
+      }
+    },
+    "LeaseAgentTaskRequest": {
+      "type": "object",
+      "properties": {
+        "workerId": {
+          "type": "string",
+          "description": "Stable id of the polling worker (audit/debug; not a security boundary)."
+        },
+        "skillId": {
+          "type": "string",
+          "description": "Optional: lease only tasks for this skill. Empty = any skill."
+        },
+        "leaseSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "How long the lease is held before the task becomes visible again. 0 = a\nserver default. Keep it longer than the worst-case run time."
+        }
+      },
+      "description": "LeaseAgentTaskRequest asks for the next runnable task."
+    },
+    "LeaseAgentTaskResponse": {
+      "type": "object",
+      "properties": {
+        "hasTask": {
+          "type": "boolean",
+          "description": "False when the queue had nothing visible — the worker should back off."
+        },
+        "taskId": {
+          "type": "string"
+        },
+        "skillId": {
+          "type": "string"
+        },
+        "inputJson": {
+          "type": "string"
+        },
+        "leaseToken": {
+          "type": "string",
+          "description": "Opaque token proving this worker holds the current lease; must be presented\nto CompleteAgentTask. A new lease (after expiry) mints a new token, so a\nslow worker's stale completion is rejected rather than clobbering a retry."
         }
       }
     },

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -252,6 +252,47 @@
         ]
       }
     },
+    "/v1/agent-skills/{skillId}/worker": {
+      "post": {
+        "summary": "Start a pull-queue worker for a skill",
+        "description": "Provisions the skill's box, mints an agents:run queue credential, and launches the in-box runtime in poll mode to lease and run queued tasks.",
+        "operationId": "AgentSkillService_StartAgentWorker",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/StartAgentWorkerResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "skillId",
+            "description": "Skill whose box runs as the worker (its persona is the worker's; the\nworker leases only this skill's tasks).",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StartAgentWorkerBody"
+            }
+          }
+        ],
+        "tags": [
+          "Agents"
+        ]
+      }
+    },
     "/v1/agent-skills/{toPeerId}/call": {
       "post": {
         "summary": "Send a task to a peer agent (A2A)",
@@ -10139,6 +10180,37 @@
         }
       },
       "description": "StackParameter describes an input the stack accepts at install time.\nReturned by ListStacks so the web UI can render appropriate form fields."
+    },
+    "StartAgentWorkerBody": {
+      "type": "object",
+      "properties": {
+        "backendId": {
+          "type": "string",
+          "description": "Target backend (must be local in the prototype)."
+        },
+        "pool": {
+          "type": "string",
+          "description": "Target pool (unsupported in the prototype)."
+        },
+        "workerId": {
+          "type": "string",
+          "description": "Optional stable worker id for audit/debug; defaults to the box name."
+        }
+      },
+      "description": "StartAgentWorkerRequest launches a poll-mode worker for a skill."
+    },
+    "StartAgentWorkerResponse": {
+      "type": "object",
+      "properties": {
+        "container": {
+          "$ref": "#/definitions/Container",
+          "description": "The worker box."
+        },
+        "workerId": {
+          "type": "string",
+          "description": "The worker id the daemon used."
+        }
+      }
     },
     "StartAppBody": {
       "type": "object",

--- a/docs/AGENT-MODEL-GATEWAY-DESIGN.md
+++ b/docs/AGENT-MODEL-GATEWAY-DESIGN.md
@@ -243,14 +243,38 @@ is prototyped, Phase 0:
   `agents:run`).
 - **Producer CLI**: `containarium agent enqueue <skill> --input …`
   (`internal/cmd/agent_enqueue.go`), plus gRPC/HTTP client methods.
+- **Worker provisioning**: `StartAgentWorker` RPC + `containarium agent worker
+  <skill>` (`internal/server/agent_queue_server.go`, `internal/cmd/agent_worker.go`).
+  Provisions/reuses the skill's box, **mints a queue credential** — a JWT scoped
+  to `agents:run` only, *separate* from the skill's in-box token, since leasing
+  is a runtime action the skill's own scopes don't grant — and launches the
+  runtime in poll mode with that credential + the daemon URL seeded as env
+  (`buildWorkerPollCommand`). The worker resolves the daemon host from its
+  default route (the backend) at launch, so the daemon needn't know the bridge
+  address. Gated on `agents:run`; the launch is best-effort like serve mode.
 - **Worker**: `agent-runtime` `poll` mode (`agent-runtime/src/poll.ts`,
   `CONTAINARIUM_AGENT_MODE=poll`) — lease → run engine → complete, **outbound
   only** (NAT/tunnel-friendly), reusing the A2A path's `runTask`.
 
-**Open before promoting past prototype**: (a) durability — the queue is memory
-only, so a daemon restart drops in-flight tasks; (b) the worker's *queue*
-credential (needs `agents:run`) is distinct from the skill's in-box token and
-isn't minted yet — same "who issues the runtime credential" question the
-gateway token raises; (c) per-tenant fairness + dead-letter on repeated
-failure. These are deliberately deferred — the prototype proves the
-lease/redelivery semantics and the outbound-only worker shape.
+End-to-end loop:
+
+```
+containarium agent worker  hello-agent --server <host>   # start a poll-mode worker
+containarium agent enqueue hello-agent --input '{"q":…}' --server <host>   # produce
+# worker leases → runs the engine → completes; repeat per enqueue.
+```
+
+The producer→worker cycle (enqueue → lease → run → complete, incl. the
+`agents:run`-credential auth and the stale-lease guard) is covered end-to-end
+through the real RPC handlers in `agent_queue_server_test.go`.
+
+**Open before promoting past prototype**: (a) **durability** — the queue is
+memory only, so a daemon restart drops in-flight tasks; (b) **credential
+lifetime** — the worker's `agents:run` token has the 30-minute agent TTL, so a
+long-lived worker needs a refresh path (the same open question the gateway token
+raises; a durable answer is a re-mint-on-401 or a daemon-side renew); (c)
+**egress** — when the eBPF policy is enforced, a worker box must be allowed out
+to the daemon's host:port (today's allowlist is the model providers); (d)
+**per-tenant fairness + dead-letter** on repeated failure. These are
+deliberately deferred — the prototype proves the credential-scoped lease/run/
+complete loop and the outbound-only worker shape.

--- a/docs/AGENT-MODEL-GATEWAY-DESIGN.md
+++ b/docs/AGENT-MODEL-GATEWAY-DESIGN.md
@@ -1,0 +1,256 @@
+# Agent Model Gateway — Design Note
+
+> Status: **Exploration / not yet approved.** This proposes a daemon-side
+> *model gateway* that every agent box calls instead of reaching the model
+> provider directly. Nothing here is built yet. Builds on the in-box loop
+> (`docs/AGENT-RUNTIME-INBOX-LOOP-DESIGN.md`) and the agent-skills mechanism
+> (`docs/AGENT-SKILLS-CREWS-DESIGN.md`).
+
+## What this closes
+
+Today every agent box talks to the model provider **directly**: the in-box
+`claude` engine uses the Claude Agent SDK against `api.anthropic.com`, authed
+with an `ANTHROPIC_API_KEY` that the daemon stamps onto the LXC as an
+environment variable from the tenant secrets store
+(`internal/server/secrets_server.go`; egress allow-listed in
+`agent_server.go`'s `defaultAgentEgressDomains`). The `codex` engine does the
+same against OpenAI.
+
+That works, but it bakes in four problems that compound as the agent fleet
+grows:
+
+1. **Key sprawl.** A live, long-lived provider API key sits **inside every
+   agent box** as an env var. Any agent (or a prompt-injected one) can read
+   `$ANTHROPIC_API_KEY` and exfiltrate it. Rotation means re-stamping every
+   box. The blast radius of one compromised box is "the whole key."
+2. **No per-tenant model metering.** Token spend is invisible to the platform
+   — it lands on whatever provider account the key belongs to, with no
+   attribution to the tenant/skill/run that caused it. The metering/billing
+   plane meters box-uptime, not model tokens; model spend has **no writer**
+   (cf. the egress-meter gap).
+3. **No shared cache or pooling.** N boxes each open their own provider
+   connection with their own prompt prefix; identical system prompts and tool
+   schemas are re-sent and re-billed per box. Prompt caching is per-box, so the
+   cache-hit rate across a fleet of same-skill agents is near zero.
+4. **Wide egress.** Every agent box must be allowed out to the provider
+   API directly, so the egress allow-list can't be tightened to "the platform
+   and nothing else."
+
+The **model gateway** is a single daemon-side egress point that holds the
+provider key, brokers every box's model calls, and becomes the natural place
+to cache, meter, tier, and rate-limit. It is **not** a way to avoid metered
+billing — it is metered API, consolidated and attributed. (Using a personal
+subscription login across a box fleet is out: it violates the provider's
+per-seat subscription terms and that path is being closed off anyway. The
+gateway is the ToS-clean way to get the cost/operational wins people reach for
+when they ask about the subscription trick.)
+
+## Goals / non-goals
+
+**Goals**
+
+- The provider API key lives in **exactly one place** (the gateway), never in
+  an agent box.
+- Every model call is **attributed** to `(tenant, skill, run)` and metered in
+  tokens.
+- **Shared prompt caching** across boxes that share a system prompt / tool
+  schema.
+- **Model tiering** enforced centrally (cap a skill to Haiku; let another use
+  Opus) without trusting the box.
+- Agent-box egress shrinks to **the gateway only** — no direct provider egress.
+- **Drop-in**: the in-box engines keep using the Agent SDK / Codex SDK
+  unchanged; only their *base URL* and *credential* change (see below).
+
+**Non-goals**
+
+- Not a general LLM router/marketplace. Two providers (Anthropic, OpenAI),
+  matching today's two engines.
+- Not a caching proxy for arbitrary HTTP. Model endpoints only.
+- Not a subscription-auth bridge (explicitly excluded — see above).
+- Not changing the in-box loop's tool surface (agent-box MCP) or the seed
+  contract (`/etc/containarium/agent/`).
+
+## Architecture
+
+```
+        ┌──────────────── agent box (per skill/run) ─────────────────┐
+        │                                                            │
+        │  agent-runtime                                             │
+        │    engine (claude | codex)                                 │
+        │      Agent SDK / Codex SDK                                 │
+        │      ANTHROPIC_BASE_URL = https://<gateway>/v1/model/...   │
+        │      ANTHROPIC_AUTH_TOKEN = <short-lived gateway token>    │
+        │            │  (model HTTP, bearer = gateway token)         │
+        └────────────┼───────────────────────────────────────────────┘
+                     │  egress allow-list: gateway ONLY
+                     ▼
+        ┌──────────────── daemon: model gateway ─────────────────────┐
+        │  1. authenticate gateway token  → (tenant, skill, run)     │
+        │  2. enforce model tier / policy (allowed models, caps)     │
+        │  3. inject provider key (held here, never in the box)      │
+        │  4. set/forward prompt-cache breakpoints                   │
+        │  5. proxy to api.anthropic.com / api.openai.com            │
+        │  6. on response: meter tokens → usage rollups (per tenant) │
+        └────────────┬───────────────────────────────────────────────┘
+                     │  one key, one egress, shared cache
+                     ▼
+              api.anthropic.com / api.openai.com
+```
+
+### How a box reaches the gateway (the one real change)
+
+The in-box engines are **unchanged Go/TS code**. The Anthropic SDK (and Claude
+Code, which the Agent SDK is built on) honor two environment variables:
+
+- `ANTHROPIC_BASE_URL` — the API base the SDK dials.
+- `ANTHROPIC_AUTH_TOKEN` — a bearer token sent as `Authorization: Bearer …`
+  (used **instead** of a raw `x-api-key` when the base URL is a gateway/proxy).
+
+> ⚠️ Verify against the pinned `@anthropic-ai/claude-agent-sdk` version before
+> building — this is the design's linchpin. The pattern is the standard one
+> used for LiteLLM / Bedrock-style proxies; if a future SDK changes the env
+> contract, the fallback is a thin client option (`baseURL`, `authToken`) wired
+> in `agent-runtime/src/engines/claude.ts`. Codex SDK has the analogous
+> `OPENAI_BASE_URL` / `OPENAI_API_KEY`.
+
+So the daemon's box-seeding changes from *"stamp `ANTHROPIC_API_KEY` = the real
+provider key"* to:
+
+```
+ANTHROPIC_BASE_URL  = https://<gateway-host>/v1/model/anthropic
+ANTHROPIC_AUTH_TOKEN = <gateway token: scoped to this tenant/skill/run, short-lived>
+```
+
+The **real provider key is never in the box.** The box holds only a gateway
+token that (a) is bounded to one tenant/skill, (b) expires, and (c) is useless
+anywhere but the gateway. A compromised box leaks a throwaway, not the key.
+
+### Gateway token
+
+Reuse the existing scoped-JWT machinery that already mints the box's platform
+token (`agent_server.go` `provisionSkillBox`). Add a model-scope claim, e.g.
+`model:invoke` plus `tenant`, `skill_id`, `run_id`, and an allowed-model set.
+The gateway validates it with the same secret/PKI the rest of the daemon uses
+— no new trust root. Short TTL (a run's lifetime); a long-running A2A/serve box
+refreshes via the platform token it already holds.
+
+## Gateway responsibilities
+
+| # | Concern | Behavior |
+| --- | --- | --- |
+| 1 | **Key custody** | The single provider key is read from the daemon's secret store at startup and held in memory; never written to a box. Rotation = restart the gateway, no box churn. |
+| 2 | **Auth → identity** | Validate the gateway token; resolve `(tenant, skill, run, allowed_models)`. Reject unknown/expired tokens with `401`. |
+| 3 | **Policy / tiering** | If the requested `model` isn't in the token's allowed set, either reject or down-route to the tier ceiling (config). This is where "this skill may only use Haiku" is *enforced*, not merely requested. |
+| 4 | **Prompt caching** | Ensure cache breakpoints are set on the stable prefix (system prompt + tool schema) so same-skill boxes share cache hits. Pass through provider cache headers/usage. |
+| 5 | **Metering** | On each response, read provider `usage` (input/output/cache-read/cache-write tokens) and write a per-tenant rollup keyed by `(tenant, skill, model)`. This is the model-token *writer* the metering plane lacks today. |
+| 6 | **Egress consolidation** | The gateway is the only host allowed out to provider APIs. Agent boxes' egress allow-list drops `api.anthropic.com` / `api.openai.com` and gains only the gateway. |
+| 7 | **Rate limiting** | Central per-tenant token-bucket so one tenant's runaway agent can't exhaust the shared account's provider rate limit and starve others. |
+
+## CLI-first surface (proto → gateway is plumbing)
+
+Per repo convention, anything an operator/agent can trigger lands as a
+`containarium <verb>` first; the gateway data-plane itself (the proxied model
+HTTP) is infrastructure plumbing, like `/healthz` — **not** a product RPC, so
+it lives in the gateway layer, not the proto contract.
+
+What *does* go through proto (operator/agent-visible):
+
+- `containarium agent usage [--tenant X] [--skill Y] [--since …]` → reads the
+  per-tenant model-token rollups the gateway writes. New `GetAgentModelUsage`
+  RPC on the agent service.
+- Model-tier policy is part of the **AgentSkill manifest** (a new
+  `allowed_models` / `model_tier` field on the skill proto), so the ceiling is
+  declared with the skill and compiled into the gateway token at provision
+  time — same pattern as `allowed_scopes` → JWT and `allowed_peers` → eBPF.
+
+No new "mint model token" verb is needed: it's minted inside `provisionSkillBox`
+exactly where the platform JWT already is.
+
+## Security model
+
+- **Key isolation.** Provider key: gateway only. Box: a scoped, expiring
+  gateway token. This is the headline win — it removes the standing
+  exfiltration target from every box.
+- **Least privilege.** The gateway token's allowed-model set and tenant binding
+  mean a compromised box can at most spend *its own* tenant's tokens on *its
+  allowed* models, all metered and attributable — versus today, where reading
+  one env var yields a fleet-wide provider key.
+- **Egress.** With direct provider egress removed from agent boxes, the eBPF
+  egress policy for an agent box becomes "platform + gateway," tightening the
+  default-deny posture (#315 enforcement still applies).
+- **Audit.** Every proxied call is an attributable event `(tenant, skill, run,
+  model, tokens)` — a far better audit surface than "some box called Anthropic."
+
+## Metering / billing fit
+
+The gateway is the missing **writer** for model-token usage. It emits per-tenant
+rollups in the same shape the uptime sampler uses, so model spend can be rated
+alongside box-uptime (a `PerModelTokenCents`-style rate, Cloud-side) without a
+new pipeline. OSS ships the *mechanism* (the gateway + the token-usage rollup);
+Cloud owns the *rating* (named tiers, per-model cents) — consistent with the
+"generic mechanism in OSS, named packs in Cloud" split.
+
+## Phasing
+
+- **Phase 0 — transparent proxy.** Gateway proxies Anthropic only; holds the
+  key; validates the gateway token; boxes seeded with `ANTHROPIC_BASE_URL` +
+  gateway token instead of the raw key. No metering yet. Acceptance: an agent
+  run completes with a non-empty artifact and **no provider key in the box**.
+- **Phase 1 — metering.** Parse `usage`, write per-tenant rollups, add
+  `containarium agent usage`.
+- **Phase 2 — tiering + rate limits.** `allowed_models` on the skill manifest;
+  enforce ceiling + per-tenant token bucket at the gateway.
+- **Phase 3 — caching + OpenAI.** Shared prompt-cache breakpoint management;
+  add the `codex`/OpenAI path (`OPENAI_BASE_URL`).
+- **Phase 4 — egress tighten.** Drop provider domains from
+  `defaultAgentEgressDomains`; agent boxes egress to the gateway only.
+
+## Open questions
+
+1. **Where does the gateway run?** A core-service LXC (like the platform
+   Postgres / Caddy core services), or in-daemon as an HTTP handler? Leaning
+   in-daemon for Phase 0 (no new core box), carve out later if it needs
+   independent scaling.
+2. **Streaming + tool-use passthrough.** The Agent SDK streams SSE and does
+   multi-turn tool-use. The gateway must be a faithful streaming proxy, not a
+   buffering one, or it breaks the agent loop's latency. Needs a passthrough
+   that preserves SSE framing and only *observes* usage on the terminal event.
+3. **Multi-backend topology.** Agent boxes run on tunnel-connected backends.
+   Does each backend run a local gateway (key on each backend — back to sprawl,
+   but bounded to backends not boxes), or do boxes reach a single central
+   gateway over the tunnel (one key, but a cross-tunnel hop on every model
+   call)? This is the real architectural fork — see the pull-queue note, which
+   shares the same "central vs per-backend" tension.
+4. **SDK base-URL contract.** Confirm the pinned Agent SDK honors
+   `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` headless; otherwise wire the
+   client options directly in the engine (still a ~3-line change).
+
+## Appendix — pull-queue prototype (built)
+
+The pull-based run model (raised as the inverse of today's push-exec trigger)
+is prototyped, Phase 0:
+
+- **Contract**: `EnqueueAgentTask` / `LeaseAgentTask` / `CompleteAgentTask` on
+  `AgentSkillService` (`proto/containarium/v1/agent.proto`) — producer enqueues,
+  workers lease (SQS-style visibility timeout + redelivery), workers complete
+  with a lease-token check that rejects a stale (expired-then-redelivered)
+  completion.
+- **Queue core**: `internal/server/agent_task_queue.go` — an in-memory,
+  lock-guarded FIFO lease queue with an injectable clock; unit-tested for
+  lease-hiding, expiry redelivery, stale-token rejection, FIFO, skill filtering,
+  and concurrent-lease uniqueness (`agent_task_queue_test.go`, race-clean).
+- **RPC handlers**: `internal/server/agent_queue_server.go` (gated on
+  `agents:run`).
+- **Producer CLI**: `containarium agent enqueue <skill> --input …`
+  (`internal/cmd/agent_enqueue.go`), plus gRPC/HTTP client methods.
+- **Worker**: `agent-runtime` `poll` mode (`agent-runtime/src/poll.ts`,
+  `CONTAINARIUM_AGENT_MODE=poll`) — lease → run engine → complete, **outbound
+  only** (NAT/tunnel-friendly), reusing the A2A path's `runTask`.
+
+**Open before promoting past prototype**: (a) durability — the queue is memory
+only, so a daemon restart drops in-flight tasks; (b) the worker's *queue*
+credential (needs `agents:run`) is distinct from the skill's in-box token and
+isn't minted yet — same "who issues the runtime credential" question the
+gateway token raises; (c) per-tenant fairness + dead-letter on repeated
+failure. These are deliberately deferred — the prototype proves the
+lease/redelivery semantics and the outbound-only worker shape.

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -642,6 +642,21 @@ func (c *GRPCClient) RunAgentSkill(skillID, backendID, pool, inputJSON string) (
 	return resp, nil
 }
 
+// EnqueueAgentTask places a task on the pull queue for a skill (prototype).
+func (c *GRPCClient) EnqueueAgentTask(skillID, inputJSON string) (*pb.EnqueueAgentTaskResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := c.agentClient.EnqueueAgentTask(ctx, &pb.EnqueueAgentTaskRequest{
+		SkillId:   skillID,
+		InputJson: inputJSON,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to enqueue agent task: %w", err)
+	}
+	return resp, nil
+}
+
 // SendAgentTask delegates a task to a running peer agent over A2A via gRPC.
 func (c *GRPCClient) SendAgentTask(fromSkillID, toPeerID, inputJSON string) (*pb.AgentArtifact, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -657,6 +657,23 @@ func (c *GRPCClient) EnqueueAgentTask(skillID, inputJSON string) (*pb.EnqueueAge
 	return resp, nil
 }
 
+// StartAgentWorker launches a poll-mode worker box for a skill (prototype).
+func (c *GRPCClient) StartAgentWorker(skillID, backendID, pool, workerID string) (*pb.StartAgentWorkerResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute) // box provisioning can take time
+	defer cancel()
+
+	resp, err := c.agentClient.StartAgentWorker(ctx, &pb.StartAgentWorkerRequest{
+		SkillId:   skillID,
+		BackendId: backendID,
+		Pool:      pool,
+		WorkerId:  workerID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to start agent worker: %w", err)
+	}
+	return resp, nil
+}
+
 // SendAgentTask delegates a task to a running peer agent over A2A via gRPC.
 func (c *GRPCClient) SendAgentTask(fromSkillID, toPeerID, inputJSON string) (*pb.AgentArtifact, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -1140,6 +1140,32 @@ func (c *HTTPClient) RunAgentSkill(skillID, backendID, pool, inputJSON string) (
 	return out, nil
 }
 
+// EnqueueAgentTask places a task on the pull queue for a skill (prototype).
+func (c *HTTPClient) EnqueueAgentTask(skillID, inputJSON string) (*pb.EnqueueAgentTaskResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	body := map[string]interface{}{
+		"skill_id":   skillID,
+		"input_json": inputJSON,
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/agent-tasks", body)
+	if err != nil {
+		return nil, fmt.Errorf("enqueue agent task: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "enqueue agent task")
+	}
+	out := &pb.EnqueueAgentTaskResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
 // SendAgentTask delegates a task to a running peer agent over A2A via HTTP.
 func (c *HTTPClient) SendAgentTask(fromSkillID, toPeerID, inputJSON string) (*pb.AgentArtifact, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -1166,6 +1166,35 @@ func (c *HTTPClient) EnqueueAgentTask(skillID, inputJSON string) (*pb.EnqueueAge
 	return out, nil
 }
 
+// StartAgentWorker launches a poll-mode worker box for a skill (prototype).
+func (c *HTTPClient) StartAgentWorker(skillID, backendID, pool, workerID string) (*pb.StartAgentWorkerResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute) // box provisioning can take time
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/agent-skills/%s/worker", url.PathEscape(skillID))
+	body := map[string]interface{}{
+		"skill_id":   skillID,
+		"backend_id": backendID,
+		"pool":       pool,
+		"worker_id":  workerID,
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("start agent worker: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "start agent worker")
+	}
+	out := &pb.StartAgentWorkerResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
 // SendAgentTask delegates a task to a running peer agent over A2A via HTTP.
 func (c *HTTPClient) SendAgentTask(fromSkillID, toPeerID, inputJSON string) (*pb.AgentArtifact, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -33,6 +33,7 @@ type agentAPI interface {
 	GetAgentSkill(id string) (*pb.AgentSkill, error)
 	RunAgentSkill(skillID, backendID, pool, inputJSON string) (*pb.RunAgentSkillResponse, error)
 	EnqueueAgentTask(skillID, inputJSON string) (*pb.EnqueueAgentTaskResponse, error)
+	StartAgentWorker(skillID, backendID, pool, workerID string) (*pb.StartAgentWorkerResponse, error)
 	SendAgentTask(fromSkillID, toPeerID, inputJSON string) (*pb.AgentArtifact, error)
 	Close() error
 }

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -32,6 +32,7 @@ type agentAPI interface {
 	ListAgentSkills() ([]*pb.AgentSkill, error)
 	GetAgentSkill(id string) (*pb.AgentSkill, error)
 	RunAgentSkill(skillID, backendID, pool, inputJSON string) (*pb.RunAgentSkillResponse, error)
+	EnqueueAgentTask(skillID, inputJSON string) (*pb.EnqueueAgentTaskResponse, error)
 	SendAgentTask(fromSkillID, toPeerID, inputJSON string) (*pb.AgentArtifact, error)
 	Close() error
 }

--- a/internal/cmd/agent_enqueue.go
+++ b/internal/cmd/agent_enqueue.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// agent_enqueue.go — producer side of the pull-based run queue (prototype).
+// Where `agent run` provisions a box and runs synchronously (push), `agent
+// enqueue` drops a task on the queue for a long-lived worker box to lease and
+// run (pull). See docs/AGENT-MODEL-GATEWAY-DESIGN.md (pull-queue section).
+
+var agentEnqueueInput string
+
+var agentEnqueueCmd = &cobra.Command{
+	Use:   "enqueue <skill-id>",
+	Short: "Enqueue a task on the pull-based agent run queue (prototype)",
+	Long: `Place a task on the queue for a skill. Worker boxes running in poll mode
+lease the task, run it locally, and report the result back — no inbound exec to
+the box is needed (NAT/tunnel-friendly).
+
+Examples:
+  containarium agent enqueue hello-agent --input '{"q":"hi"}' --server <host>`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAgentEnqueue,
+}
+
+func init() {
+	agentCmd.AddCommand(agentEnqueueCmd)
+	agentEnqueueCmd.Flags().StringVar(&agentEnqueueInput, "input", "",
+		"Task input as a JSON string (defaults to {})")
+}
+
+func runAgentEnqueue(cmd *cobra.Command, args []string) error {
+	skillID := args[0]
+
+	c, err := newAgentClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.EnqueueAgentTask(skillID, agentEnqueueInput)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("✓ enqueued task %s for skill %q\n", resp.TaskId, skillID)
+	return nil
+}

--- a/internal/cmd/agent_worker.go
+++ b/internal/cmd/agent_worker.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// agent_worker.go — start the consumer side of the pull-based run queue
+// (prototype). The daemon provisions the skill's box, mints a queue credential
+// scoped to agents:run, and launches the in-box runtime in poll mode; the
+// worker then leases and runs tasks enqueued with `agent enqueue`.
+// See docs/AGENT-MODEL-GATEWAY-DESIGN.md (pull-queue section).
+
+var (
+	agentWorkerBackendID string
+	agentWorkerPool      string
+	agentWorkerID        string
+)
+
+var agentWorkerCmd = &cobra.Command{
+	Use:   "worker <skill-id>",
+	Short: "Start a pull-queue worker box for a skill (prototype)",
+	Long: `Provision the skill's box, mint a queue credential (scoped to agents:run,
+separate from the skill's in-box token), and launch the in-box runtime in poll
+mode. The worker leases tasks for the skill, runs them locally, and reports the
+results back — all outbound from the box.
+
+Pair with the producer: enqueue work with 'containarium agent enqueue'.
+
+Examples:
+  containarium agent worker hello-agent --server <host>
+  containarium agent enqueue hello-agent --input '{"q":"hi"}' --server <host>`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAgentWorker,
+}
+
+func init() {
+	agentCmd.AddCommand(agentWorkerCmd)
+	agentWorkerCmd.Flags().StringVar(&agentWorkerBackendID, "backend-id", "",
+		"Target backend ID (must be the local backend in the prototype)")
+	agentWorkerCmd.Flags().StringVar(&agentWorkerPool, "pool", "",
+		"Target pool (not supported in the prototype)")
+	agentWorkerCmd.Flags().StringVar(&agentWorkerID, "worker-id", "",
+		"Stable worker id for audit/debug (defaults to the box name)")
+}
+
+func runAgentWorker(cmd *cobra.Command, args []string) error {
+	skillID := args[0]
+
+	c, err := newAgentClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	fmt.Printf("Starting pull-queue worker for skill %q...\n", skillID)
+	resp, err := c.StartAgentWorker(skillID, agentWorkerBackendID, agentWorkerPool, agentWorkerID)
+	if err != nil {
+		return err
+	}
+
+	if resp.Container != nil {
+		fmt.Printf("\n✓ worker box ready: %s (%s)\n", resp.Container.Name, resp.Container.State)
+	}
+	fmt.Printf("  worker id: %s\n", resp.WorkerId)
+	fmt.Println("  polling for tasks — enqueue with: containarium agent enqueue " + skillID + " --input '{...}'")
+	return nil
+}

--- a/internal/server/agent_queue_server.go
+++ b/internal/server/agent_queue_server.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// agent_queue_server.go — the gRPC surface of the pull-based run queue
+// (prototype). Thin handlers over agentTaskQueue; the queue type holds the
+// semantics and the tests. All three gate on agents:run — producing, leasing,
+// and completing queued work are all "operate the agent runtime" actions.
+// See docs/AGENT-MODEL-GATEWAY-DESIGN.md (pull-queue section).
+
+// EnqueueAgentTask places a task on the queue for a skill. Validates the skill
+// exists so a typo doesn't sit in the queue forever, never leasable.
+func (s *AgentSkillServer) EnqueueAgentTask(ctx context.Context, req *pb.EnqueueAgentTaskRequest) (*pb.EnqueueAgentTaskResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeAgentsRun); err != nil {
+		return nil, err
+	}
+	if req.SkillId == "" {
+		return nil, status.Error(codes.InvalidArgument, "skill_id is required")
+	}
+	if _, err := s.catalog.Get(req.SkillId); err != nil {
+		return nil, status.Error(codes.NotFound, err.Error())
+	}
+	id := s.queue.enqueue(req.SkillId, req.InputJson)
+	return &pb.EnqueueAgentTaskResponse{TaskId: id}, nil
+}
+
+// LeaseAgentTask hands the polling worker the next visible task (optionally
+// filtered to one skill). has_task=false means "nothing right now" — a normal,
+// non-error poll result the worker backs off on.
+func (s *AgentSkillServer) LeaseAgentTask(ctx context.Context, req *pb.LeaseAgentTaskRequest) (*pb.LeaseAgentTaskResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeAgentsRun); err != nil {
+		return nil, err
+	}
+	leased, ok := s.queue.lease(req.SkillId, time.Duration(req.LeaseSeconds)*time.Second)
+	if !ok {
+		return &pb.LeaseAgentTaskResponse{HasTask: false}, nil
+	}
+	return &pb.LeaseAgentTaskResponse{
+		HasTask:    true,
+		TaskId:     leased.ID,
+		SkillId:    leased.SkillID,
+		InputJson:  leased.InputJSON,
+		LeaseToken: leased.LeaseToken,
+	}, nil
+}
+
+// CompleteAgentTask records a leased task's outcome and removes it. A stale
+// lease (the task already expired and was redelivered) returns accepted=false
+// rather than an error — the worker simply drops its now-orphaned result.
+func (s *AgentSkillServer) CompleteAgentTask(ctx context.Context, req *pb.CompleteAgentTaskRequest) (*pb.CompleteAgentTaskResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeAgentsRun); err != nil {
+		return nil, err
+	}
+	if req.TaskId == "" || req.LeaseToken == "" {
+		return nil, status.Error(codes.InvalidArgument, "task_id and lease_token are required")
+	}
+	ok := s.queue.complete(req.TaskId, req.LeaseToken, req.ArtifactJson, req.Error)
+	return &pb.CompleteAgentTaskResponse{Accepted: ok}, nil
+}

--- a/internal/server/agent_queue_server.go
+++ b/internal/server/agent_queue_server.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -10,6 +13,12 @@ import (
 	"github.com/footprintai/containarium/internal/auth"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
+
+// agentWorkerDaemonPort is the daemon's REST (grpc-gateway) port, where a
+// worker box reaches the agent-tasks endpoints. The worker resolves the host
+// (its default gateway) at launch and dials this port. Configurable later;
+// hard-coded to the daemon's well-known HTTP port for the prototype.
+const agentWorkerDaemonPort = 8080
 
 // agent_queue_server.go — the gRPC surface of the pull-based run queue
 // (prototype). Thin handlers over agentTaskQueue; the queue type holds the
@@ -65,4 +74,92 @@ func (s *AgentSkillServer) CompleteAgentTask(ctx context.Context, req *pb.Comple
 	}
 	ok := s.queue.complete(req.TaskId, req.LeaseToken, req.ArtifactJson, req.Error)
 	return &pb.CompleteAgentTaskResponse{Accepted: ok}, nil
+}
+
+// StartAgentWorker provisions (or reuses) the skill's box and launches the
+// in-box runtime in poll mode — the consumer side of the pull model. It mints a
+// SEPARATE queue credential: a JWT scoped to agents:run (NOT the skill's
+// allowed_scopes), because leasing/completing is a runtime action the skill's
+// own scopes don't grant. The credential is seeded as env so the box can reach
+// the daemon's agent-tasks endpoints; the worker resolves the daemon host from
+// its default route at launch (see buildWorkerPollCommand).
+//
+// Best-effort launch, like serve mode: a box whose image doesn't ship
+// agent-runtime yet still provisions + gets its credential; only the poll loop
+// no-ops (logged). The token's 30m TTL means a long-lived worker needs refresh
+// — deferred, the same open question as the gateway token (see the design note).
+func (s *AgentSkillServer) StartAgentWorker(ctx context.Context, req *pb.StartAgentWorkerRequest) (*pb.StartAgentWorkerResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeAgentsRun); err != nil {
+		return nil, err
+	}
+	if req.SkillId == "" {
+		return nil, status.Error(codes.InvalidArgument, "skill_id is required")
+	}
+	skill, err := s.catalog.Get(req.SkillId)
+	if err != nil {
+		return nil, status.Error(codes.NotFound, err.Error())
+	}
+
+	// Provision/reuse the box (seeds the skill's persona + its own scoped token,
+	// applies egress policy) — same path the push run uses, with no task input
+	// since the worker pulls its inputs from the queue.
+	containerName, container, err := s.provisionSkillBox(ctx, skill, req.BackendId, req.Pool, "")
+	if err != nil {
+		return nil, err
+	}
+
+	workerID := req.WorkerId
+	if workerID == "" {
+		workerID = strings.TrimSuffix(containerName, "-container")
+	}
+
+	// Mint the queue credential: agents:run only, so a compromised worker can
+	// lease/complete but nothing else.
+	queueToken, err := s.tokens.GenerateToken(workerID, []string{}, agentTokenTTL, auth.ScopeAgentsRun)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to mint worker queue credential: %v", err)
+	}
+
+	s.startPollMode(containerName, queueToken, workerID, skill.Id)
+
+	return &pb.StartAgentWorkerResponse{Container: container, WorkerId: workerID}, nil
+}
+
+// startPollMode launches agent-runtime in poll mode as a background worker in
+// the box. Best-effort (mirrors startServeMode): a failure (no runtime in the
+// image) logs and the box is still provisioned + credentialed.
+func (s *AgentSkillServer) startPollMode(containerName, queueToken, workerID, skillID string) {
+	if s.recipes == nil || s.recipes.containers == nil || s.recipes.containers.manager == nil {
+		return
+	}
+	cmd := buildWorkerPollCommand(queueToken, workerID, skillID)
+	if _, stderr, err := s.recipes.containers.manager.ExecWithOutput(containerName,
+		[]string{"bash", "-lc", cmd}); err != nil {
+		log.Printf("[agent-worker] could not start poll mode on %s (image may not ship runtime): %v; stderr=%s",
+			containerName, err, strings.TrimSpace(stderr))
+	}
+}
+
+// buildWorkerPollCommand returns the bash command that launches agent-runtime
+// in poll mode, detached, logging to a file. The daemon URL is resolved at
+// runtime from the box's default gateway (the backend host) so the daemon never
+// has to know the bridge address; the agents:run token authorizes the lease/
+// complete calls. Token, worker id, and skill filter are single-quoted; the URL
+// is intentionally unquoted so $GW expands.
+func buildWorkerPollCommand(queueToken, workerID, skillID string) string {
+	return fmt.Sprintf(
+		`GW=$(ip route 2>/dev/null | awk '/default/{print $3; exit}'); `+
+			`CONTAINARIUM_AGENT_MODE=poll `+
+			`CONTAINARIUM_QUEUE_URL=http://${GW}:%d `+
+			`CONTAINARIUM_QUEUE_TOKEN=%s `+
+			`CONTAINARIUM_WORKER_ID=%s `+
+			`CONTAINARIUM_QUEUE_SKILL=%s `+
+			`AGENT_SEED_DIR=%s `+
+			`setsid agent-runtime >/var/log/agent-runtime-poll.log 2>&1 &`,
+		agentWorkerDaemonPort,
+		shellSingleQuote(queueToken),
+		shellSingleQuote(workerID),
+		shellSingleQuote(skillID),
+		agentSeedDir,
+	)
 }

--- a/internal/server/agent_queue_server_test.go
+++ b/internal/server/agent_queue_server_test.go
@@ -1,0 +1,152 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/skills"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// runScopedCtx returns a context carrying an agents:run credential, the scope a
+// worker's minted queue token grants.
+func runScopedCtx() context.Context {
+	return auth.ContextWithTestSubjectScopes(
+		context.Background(), "agent-hello-agent", nil, []string{auth.ScopeAgentsRun})
+}
+
+func newQueueServer() *AgentSkillServer {
+	return &AgentSkillServer{catalog: skills.GetDefault(), queue: newAgentTaskQueue()}
+}
+
+// TestQueueRPC_EndToEndLoop drives the full producer→worker loop through the
+// real RPC handlers with a real agents:run credential context — the same path
+// a poll-mode worker exercises, minus the HTTP transport. This is the
+// end-to-end proof that the minted credential authorizes the lease/complete
+// cycle and the queue threads a task from enqueue to completion.
+func TestQueueRPC_EndToEndLoop(t *testing.T) {
+	s := newQueueServer()
+	ctx := runScopedCtx()
+
+	// Producer enqueues.
+	enq, err := s.EnqueueAgentTask(ctx, &pb.EnqueueAgentTaskRequest{
+		SkillId:   "hello-agent",
+		InputJson: `{"q":"hi"}`,
+	})
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if enq.TaskId == "" {
+		t.Fatal("enqueue returned empty task id")
+	}
+
+	// Worker leases.
+	lease, err := s.LeaseAgentTask(ctx, &pb.LeaseAgentTaskRequest{
+		WorkerId: "worker-1", SkillId: "hello-agent", LeaseSeconds: 60,
+	})
+	if err != nil {
+		t.Fatalf("lease: %v", err)
+	}
+	if !lease.HasTask || lease.TaskId != enq.TaskId || lease.InputJson != `{"q":"hi"}` || lease.LeaseToken == "" {
+		t.Fatalf("lease returned wrong task: %+v", lease)
+	}
+
+	// Worker completes.
+	done, err := s.CompleteAgentTask(ctx, &pb.CompleteAgentTaskRequest{
+		TaskId: lease.TaskId, LeaseToken: lease.LeaseToken, ArtifactJson: `{"ok":true}`,
+	})
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if !done.Accepted {
+		t.Fatal("complete should be accepted with the current lease token")
+	}
+
+	// Queue is now empty.
+	empty, err := s.LeaseAgentTask(ctx, &pb.LeaseAgentTaskRequest{WorkerId: "worker-1"})
+	if err != nil {
+		t.Fatalf("lease (empty): %v", err)
+	}
+	if empty.HasTask {
+		t.Fatal("queue should be empty after completion")
+	}
+}
+
+// TestQueueRPC_StaleCompleteRejected proves the cross-RPC stale-lease guard: a
+// worker whose lease expired and was redelivered cannot clobber the retry.
+func TestQueueRPC_StaleCompleteRejected(t *testing.T) {
+	s := newQueueServer()
+	ctx := runScopedCtx()
+	base := time.Unix(1_700_000_000, 0).UTC()
+	clock := base
+	s.queue.now = func() time.Time { return clock }
+
+	_, _ = s.EnqueueAgentTask(ctx, &pb.EnqueueAgentTaskRequest{SkillId: "hello-agent"})
+	first, _ := s.LeaseAgentTask(ctx, &pb.LeaseAgentTaskRequest{LeaseSeconds: 1})
+
+	// Force redelivery by expiring the lease, then re-lease (new token).
+	clock = base.Add(2 * time.Second)
+	second, _ := s.LeaseAgentTask(ctx, &pb.LeaseAgentTaskRequest{LeaseSeconds: 60})
+	if second.LeaseToken == first.LeaseToken {
+		t.Fatal("redelivery should mint a new token")
+	}
+
+	stale, _ := s.CompleteAgentTask(ctx, &pb.CompleteAgentTaskRequest{
+		TaskId: first.TaskId, LeaseToken: first.LeaseToken, ArtifactJson: "late",
+	})
+	if stale.Accepted {
+		t.Error("stale-token completion must be rejected at the RPC layer")
+	}
+}
+
+// TestQueueRPC_RequireRunScope confirms every queue op (and the worker launcher)
+// gates on agents:run — a token without it is denied.
+func TestQueueRPC_RequireRunScope(t *testing.T) {
+	s := newQueueServer()
+	noScope := auth.ContextWithTestSubjectScopes(
+		context.Background(), "nobody", nil, []string{auth.ScopeAgentsRead})
+
+	if _, err := s.EnqueueAgentTask(noScope, &pb.EnqueueAgentTaskRequest{SkillId: "hello-agent"}); status.Code(err) != codes.PermissionDenied {
+		t.Errorf("enqueue without agents:run: got %v, want PermissionDenied", err)
+	}
+	if _, err := s.LeaseAgentTask(noScope, &pb.LeaseAgentTaskRequest{}); status.Code(err) != codes.PermissionDenied {
+		t.Errorf("lease without agents:run: got %v, want PermissionDenied", err)
+	}
+	if _, err := s.CompleteAgentTask(noScope, &pb.CompleteAgentTaskRequest{TaskId: "t", LeaseToken: "x"}); status.Code(err) != codes.PermissionDenied {
+		t.Errorf("complete without agents:run: got %v, want PermissionDenied", err)
+	}
+	if _, err := s.StartAgentWorker(noScope, &pb.StartAgentWorkerRequest{SkillId: "hello-agent"}); status.Code(err) != codes.PermissionDenied {
+		t.Errorf("start-worker without agents:run: got %v, want PermissionDenied", err)
+	}
+}
+
+func TestBuildWorkerPollCommand(t *testing.T) {
+	cmd := buildWorkerPollCommand("tok.tok.tok", "worker-7", "hello-agent")
+
+	for _, want := range []string{
+		"CONTAINARIUM_AGENT_MODE=poll",
+		"ip route", // resolves the daemon host from the default gateway
+		"CONTAINARIUM_QUEUE_URL=http://${GW}:8080",
+		"CONTAINARIUM_QUEUE_TOKEN='tok.tok.tok'",
+		"CONTAINARIUM_WORKER_ID='worker-7'",
+		"CONTAINARIUM_QUEUE_SKILL='hello-agent'",
+		"AGENT_SEED_DIR=" + agentSeedDir,
+		"setsid agent-runtime",
+		"&", // detached
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("poll command missing %q\n---\n%s", want, cmd)
+		}
+	}
+
+	// The URL must stay UNQUOTED so $GW expands; the token must be quoted.
+	if strings.Contains(cmd, `'http://${GW}`) {
+		t.Error("queue URL must not be single-quoted (breaks $GW expansion)")
+	}
+}

--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -52,6 +52,7 @@ type AgentSkillServer struct {
 	tokens    *auth.TokenManager   // mints the skill's scoped in-box token
 	netpolicy *NetworkPolicyServer // compiles allowed_peers into a per-box egress policy (Phase 2)
 	audit     *audit.Store         // records A2A hops under a trace id (Phase 2); set once the pool is ready
+	queue     *agentTaskQueue      // pull-based run queue (prototype) — Enqueue/Lease/Complete
 }
 
 // SetAuditStore wires the audit store once the Postgres pool exists (it isn't
@@ -68,6 +69,7 @@ func NewAgentSkillServer(recipes *RecipeServer, tokens *auth.TokenManager, netpo
 		recipes:   recipes,
 		tokens:    tokens,
 		netpolicy: netpolicy,
+		queue:     newAgentTaskQueue(),
 	}
 }
 

--- a/internal/server/agent_task_queue.go
+++ b/internal/server/agent_task_queue.go
@@ -1,0 +1,150 @@
+package server
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// agent_task_queue.go — in-memory lease queue backing the pull-based agent run
+// model (prototype). It is deliberately a small, self-contained, lock-guarded
+// type so its semantics can be unit-tested without a daemon, a box, or a DB:
+//
+//   - enqueue appends a task (FIFO).
+//   - lease hands out the oldest *visible* task and hides it for a lease
+//     window (SQS-style visibility timeout), minting a fresh lease token.
+//   - a task whose lease window elapsed becomes visible again on the next
+//     lease scan (redelivery — crash recovery for a worker that died mid-run).
+//   - complete removes a task iff the caller presents the *current* lease
+//     token; a token from an expired-then-redelivered lease is rejected, so a
+//     slow worker can't clobber the retry that overtook it.
+//
+// Durability (survive daemon restart), per-tenant fairness, and dead-letter
+// handling are follow-ups; Phase 0 is memory-only. See the pull-queue section
+// of docs/AGENT-MODEL-GATEWAY-DESIGN.md.
+
+// defaultLeaseDuration is used when a lease request passes 0. Chosen longer
+// than a typical agent run so a healthy worker finishes well inside its lease.
+const defaultLeaseDuration = 5 * time.Minute
+
+// queuedTask is one task and its lease state. Visible (leasable) means
+// leaseToken == "" (never leased) or now >= leaseDeadline (lease expired).
+type queuedTask struct {
+	id        string
+	skillID   string
+	inputJSON string
+
+	leaseToken    string    // current lease holder's token; "" when never leased
+	leaseDeadline time.Time // when the current lease expires
+}
+
+// taskResult is a completed task's recorded outcome (kept for inspection/audit
+// in the prototype; a real impl would emit an event / write a rollup).
+type taskResult struct {
+	skillID      string
+	artifactJSON string
+	errMsg       string
+	completedAt  time.Time
+}
+
+// agentTaskQueue is a FIFO lease queue. All operations are safe for concurrent
+// callers (many worker boxes polling at once).
+type agentTaskQueue struct {
+	mu      sync.Mutex
+	tasks   []*queuedTask         // pending + leased, in enqueue order
+	results map[string]taskResult // completed, by task id
+	seq     uint64                // monotonic; backs task ids and lease tokens
+	now     func() time.Time      // injectable clock (tests override)
+}
+
+func newAgentTaskQueue() *agentTaskQueue {
+	return &agentTaskQueue{
+		results: make(map[string]taskResult),
+		now:     time.Now,
+	}
+}
+
+// enqueue adds a task and returns its server-assigned id.
+func (q *agentTaskQueue) enqueue(skillID, inputJSON string) string {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.seq++
+	id := fmt.Sprintf("task-%d", q.seq)
+	q.tasks = append(q.tasks, &queuedTask{id: id, skillID: skillID, inputJSON: inputJSON})
+	return id
+}
+
+// lease returns the oldest visible task matching skillFilter (empty = any),
+// hiding it for d (or the default when d <= 0) and minting a new lease token.
+// ok is false when nothing is currently visible.
+func (q *agentTaskQueue) lease(skillFilter string, d time.Duration) (leasedTask, bool) {
+	if d <= 0 {
+		d = defaultLeaseDuration
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	now := q.now()
+	for _, t := range q.tasks {
+		if skillFilter != "" && t.skillID != skillFilter {
+			continue
+		}
+		visible := t.leaseToken == "" || now.After(t.leaseDeadline) || now.Equal(t.leaseDeadline)
+		if !visible {
+			continue
+		}
+		q.seq++
+		t.leaseToken = fmt.Sprintf("lease-%d", q.seq)
+		t.leaseDeadline = now.Add(d)
+		return leasedTask{
+			ID: t.id, SkillID: t.skillID, InputJSON: t.inputJSON, LeaseToken: t.leaseToken,
+		}, true
+	}
+	return leasedTask{}, false
+}
+
+// complete records a leased task's outcome and removes it. Returns false (and
+// changes nothing) when the task is gone or the token is stale — meaning the
+// lease expired and the task was redelivered under a new token.
+func (q *agentTaskQueue) complete(taskID, leaseToken, artifactJSON, errMsg string) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for i, t := range q.tasks {
+		if t.id != taskID {
+			continue
+		}
+		if t.leaseToken == "" || t.leaseToken != leaseToken {
+			return false // not leased, or a different (newer) lease owns it now
+		}
+		q.tasks = append(q.tasks[:i], q.tasks[i+1:]...)
+		q.results[taskID] = taskResult{
+			skillID: t.skillID, artifactJSON: artifactJSON, errMsg: errMsg, completedAt: q.now(),
+		}
+		return true
+	}
+	return false
+}
+
+// depth reports how many tasks remain (pending or leased-not-yet-completed).
+func (q *agentTaskQueue) depth() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.tasks)
+}
+
+// result returns a completed task's recorded outcome. Prototype inspection
+// hook; a durable impl would surface this via a GetAgentTask RPC.
+func (q *agentTaskQueue) result(taskID string) (taskResult, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	r, ok := q.results[taskID]
+	return r, ok
+}
+
+// leasedTask is the data a lease hands back (a copy — callers never touch the
+// queue's internal state).
+type leasedTask struct {
+	ID         string
+	SkillID    string
+	InputJSON  string
+	LeaseToken string
+}

--- a/internal/server/agent_task_queue_test.go
+++ b/internal/server/agent_task_queue_test.go
@@ -1,0 +1,184 @@
+package server
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestQueue returns a queue with a controllable clock starting at a fixed
+// instant, plus a function to advance it.
+func newTestQueue() (*agentTaskQueue, func(time.Duration)) {
+	var mu sync.Mutex
+	now := time.Unix(1_700_000_000, 0).UTC()
+	q := newAgentTaskQueue()
+	q.now = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return now
+	}
+	advance := func(d time.Duration) {
+		mu.Lock()
+		defer mu.Unlock()
+		now = now.Add(d)
+	}
+	return q, advance
+}
+
+func TestQueue_EnqueueLeaseComplete(t *testing.T) {
+	q, _ := newTestQueue()
+	id := q.enqueue("web-researcher", `{"q":"hi"}`)
+	if id == "" {
+		t.Fatal("enqueue returned empty id")
+	}
+	if q.depth() != 1 {
+		t.Fatalf("depth = %d, want 1", q.depth())
+	}
+
+	leased, ok := q.lease("", 0)
+	if !ok {
+		t.Fatal("expected a task to lease")
+	}
+	if leased.ID != id || leased.SkillID != "web-researcher" || leased.InputJSON != `{"q":"hi"}` {
+		t.Fatalf("leased wrong task: %+v", leased)
+	}
+	if leased.LeaseToken == "" {
+		t.Error("lease token should be non-empty")
+	}
+
+	if ok := q.complete(leased.ID, leased.LeaseToken, `{"answer":42}`, ""); !ok {
+		t.Fatal("complete with valid token should succeed")
+	}
+	if q.depth() != 0 {
+		t.Fatalf("depth after complete = %d, want 0", q.depth())
+	}
+
+	// The outcome is recorded and inspectable.
+	r, ok := q.result(id)
+	if !ok {
+		t.Fatal("completed task should have a recorded result")
+	}
+	if r.artifactJSON != `{"answer":42}` || r.errMsg != "" || r.skillID != "web-researcher" {
+		t.Errorf("recorded result wrong: %+v", r)
+	}
+}
+
+func TestQueue_LeaseHidesFromOtherWorkers(t *testing.T) {
+	q, _ := newTestQueue()
+	q.enqueue("s", "a")
+
+	if _, ok := q.lease("", time.Minute); !ok {
+		t.Fatal("first lease should succeed")
+	}
+	// A second worker polling immediately sees nothing — the task is leased.
+	if _, ok := q.lease("", time.Minute); ok {
+		t.Fatal("second lease should find nothing (task is held)")
+	}
+}
+
+func TestQueue_RedeliversAfterLeaseExpiry(t *testing.T) {
+	q, advance := newTestQueue()
+	q.enqueue("s", "a")
+
+	first, ok := q.lease("", 30*time.Second)
+	if !ok {
+		t.Fatal("first lease should succeed")
+	}
+	// Still inside the lease window: invisible.
+	advance(20 * time.Second)
+	if _, ok := q.lease("", 30*time.Second); ok {
+		t.Fatal("task should still be hidden inside the lease window")
+	}
+	// Past expiry: redelivered with a NEW token.
+	advance(15 * time.Second)
+	second, ok := q.lease("", 30*time.Second)
+	if !ok {
+		t.Fatal("task should be redelivered after lease expiry")
+	}
+	if second.LeaseToken == first.LeaseToken {
+		t.Error("redelivery must mint a fresh lease token")
+	}
+
+	// The slow original worker now completes with its STALE token — rejected,
+	// because the redelivered lease owns the task.
+	if ok := q.complete(first.ID, first.LeaseToken, "late", ""); ok {
+		t.Error("stale-token completion must be rejected")
+	}
+	// The current lease holder completes successfully.
+	if ok := q.complete(second.ID, second.LeaseToken, "ok", ""); !ok {
+		t.Error("current-token completion must succeed")
+	}
+}
+
+func TestQueue_SkillFilter(t *testing.T) {
+	q, _ := newTestQueue()
+	q.enqueue("alpha", "1")
+	q.enqueue("beta", "2")
+
+	// A worker scoped to "beta" skips the alpha task at the head.
+	leased, ok := q.lease("beta", time.Minute)
+	if !ok || leased.SkillID != "beta" {
+		t.Fatalf("filtered lease should return the beta task, got ok=%v %+v", ok, leased)
+	}
+	// "alpha" is still leasable.
+	a, ok := q.lease("alpha", time.Minute)
+	if !ok || a.SkillID != "alpha" {
+		t.Fatalf("alpha task should be leasable, got ok=%v %+v", ok, a)
+	}
+}
+
+func TestQueue_FIFOAndEmpty(t *testing.T) {
+	q, _ := newTestQueue()
+	if _, ok := q.lease("", 0); ok {
+		t.Fatal("empty queue should lease nothing")
+	}
+	id1 := q.enqueue("s", "1")
+	id2 := q.enqueue("s", "2")
+	l1, _ := q.lease("", time.Minute)
+	l2, _ := q.lease("", time.Minute)
+	if l1.ID != id1 || l2.ID != id2 {
+		t.Errorf("FIFO violated: got %s then %s, want %s then %s", l1.ID, l2.ID, id1, id2)
+	}
+}
+
+func TestQueue_DoubleCompleteRejected(t *testing.T) {
+	q, _ := newTestQueue()
+	q.enqueue("s", "a")
+	l, _ := q.lease("", time.Minute)
+	if ok := q.complete(l.ID, l.LeaseToken, "first", ""); !ok {
+		t.Fatal("first complete should succeed")
+	}
+	// Re-completing a gone task is a no-op, not a panic.
+	if ok := q.complete(l.ID, l.LeaseToken, "second", ""); ok {
+		t.Error("completing an already-removed task must return false")
+	}
+}
+
+func TestQueue_ConcurrentLeasesAreUnique(t *testing.T) {
+	q := newAgentTaskQueue() // real clock is fine; we only test mutual exclusion
+	const n = 50
+	for i := 0; i < n; i++ {
+		q.enqueue("s", "x")
+	}
+	var mu sync.Mutex
+	seen := map[string]bool{}
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if l, ok := q.lease("", time.Minute); ok {
+				mu.Lock()
+				if seen[l.ID] {
+					t.Errorf("task %s leased twice concurrently", l.ID)
+				}
+				seen[l.ID] = true
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if len(seen) != n {
+		t.Errorf("leased %d distinct tasks, want %d", len(seen), n)
+	}
+}

--- a/pkg/pb/containarium/v1/agent.pb.go
+++ b/pkg/pb/containarium/v1/agent.pb.go
@@ -1020,6 +1020,369 @@ func (x *SendAgentTaskResponse) GetTraceId() string {
 	return ""
 }
 
+// EnqueueAgentTaskRequest places one task on the pull queue.
+type EnqueueAgentTaskRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Skill this task is for (workers may filter their lease by it).
+	SkillId string `protobuf:"bytes,1,opt,name=skill_id,json=skillId,proto3" json:"skill_id,omitempty"`
+	// Task input as JSON (the same shape RunAgentSkill takes as input_json).
+	InputJson     string `protobuf:"bytes,2,opt,name=input_json,json=inputJson,proto3" json:"input_json,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnqueueAgentTaskRequest) Reset() {
+	*x = EnqueueAgentTaskRequest{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnqueueAgentTaskRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnqueueAgentTaskRequest) ProtoMessage() {}
+
+func (x *EnqueueAgentTaskRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnqueueAgentTaskRequest.ProtoReflect.Descriptor instead.
+func (*EnqueueAgentTaskRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *EnqueueAgentTaskRequest) GetSkillId() string {
+	if x != nil {
+		return x.SkillId
+	}
+	return ""
+}
+
+func (x *EnqueueAgentTaskRequest) GetInputJson() string {
+	if x != nil {
+		return x.InputJson
+	}
+	return ""
+}
+
+type EnqueueAgentTaskResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Server-assigned task id, used later to correlate the completion.
+	TaskId        string `protobuf:"bytes,1,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnqueueAgentTaskResponse) Reset() {
+	*x = EnqueueAgentTaskResponse{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnqueueAgentTaskResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnqueueAgentTaskResponse) ProtoMessage() {}
+
+func (x *EnqueueAgentTaskResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnqueueAgentTaskResponse.ProtoReflect.Descriptor instead.
+func (*EnqueueAgentTaskResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *EnqueueAgentTaskResponse) GetTaskId() string {
+	if x != nil {
+		return x.TaskId
+	}
+	return ""
+}
+
+// LeaseAgentTaskRequest asks for the next runnable task.
+type LeaseAgentTaskRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Stable id of the polling worker (audit/debug; not a security boundary).
+	WorkerId string `protobuf:"bytes,1,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty"`
+	// Optional: lease only tasks for this skill. Empty = any skill.
+	SkillId string `protobuf:"bytes,2,opt,name=skill_id,json=skillId,proto3" json:"skill_id,omitempty"`
+	// How long the lease is held before the task becomes visible again. 0 = a
+	// server default. Keep it longer than the worst-case run time.
+	LeaseSeconds  int32 `protobuf:"varint,3,opt,name=lease_seconds,json=leaseSeconds,proto3" json:"lease_seconds,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LeaseAgentTaskRequest) Reset() {
+	*x = LeaseAgentTaskRequest{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LeaseAgentTaskRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LeaseAgentTaskRequest) ProtoMessage() {}
+
+func (x *LeaseAgentTaskRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LeaseAgentTaskRequest.ProtoReflect.Descriptor instead.
+func (*LeaseAgentTaskRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *LeaseAgentTaskRequest) GetWorkerId() string {
+	if x != nil {
+		return x.WorkerId
+	}
+	return ""
+}
+
+func (x *LeaseAgentTaskRequest) GetSkillId() string {
+	if x != nil {
+		return x.SkillId
+	}
+	return ""
+}
+
+func (x *LeaseAgentTaskRequest) GetLeaseSeconds() int32 {
+	if x != nil {
+		return x.LeaseSeconds
+	}
+	return 0
+}
+
+type LeaseAgentTaskResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// False when the queue had nothing visible — the worker should back off.
+	HasTask   bool   `protobuf:"varint,1,opt,name=has_task,json=hasTask,proto3" json:"has_task,omitempty"`
+	TaskId    string `protobuf:"bytes,2,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	SkillId   string `protobuf:"bytes,3,opt,name=skill_id,json=skillId,proto3" json:"skill_id,omitempty"`
+	InputJson string `protobuf:"bytes,4,opt,name=input_json,json=inputJson,proto3" json:"input_json,omitempty"`
+	// Opaque token proving this worker holds the current lease; must be presented
+	// to CompleteAgentTask. A new lease (after expiry) mints a new token, so a
+	// slow worker's stale completion is rejected rather than clobbering a retry.
+	LeaseToken    string `protobuf:"bytes,5,opt,name=lease_token,json=leaseToken,proto3" json:"lease_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LeaseAgentTaskResponse) Reset() {
+	*x = LeaseAgentTaskResponse{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LeaseAgentTaskResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LeaseAgentTaskResponse) ProtoMessage() {}
+
+func (x *LeaseAgentTaskResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LeaseAgentTaskResponse.ProtoReflect.Descriptor instead.
+func (*LeaseAgentTaskResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *LeaseAgentTaskResponse) GetHasTask() bool {
+	if x != nil {
+		return x.HasTask
+	}
+	return false
+}
+
+func (x *LeaseAgentTaskResponse) GetTaskId() string {
+	if x != nil {
+		return x.TaskId
+	}
+	return ""
+}
+
+func (x *LeaseAgentTaskResponse) GetSkillId() string {
+	if x != nil {
+		return x.SkillId
+	}
+	return ""
+}
+
+func (x *LeaseAgentTaskResponse) GetInputJson() string {
+	if x != nil {
+		return x.InputJson
+	}
+	return ""
+}
+
+func (x *LeaseAgentTaskResponse) GetLeaseToken() string {
+	if x != nil {
+		return x.LeaseToken
+	}
+	return ""
+}
+
+// CompleteAgentTaskRequest reports a leased task's outcome.
+type CompleteAgentTaskRequest struct {
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	TaskId     string                 `protobuf:"bytes,1,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	LeaseToken string                 `protobuf:"bytes,2,opt,name=lease_token,json=leaseToken,proto3" json:"lease_token,omitempty"`
+	// The run artifact as JSON; empty when error is set.
+	ArtifactJson string `protobuf:"bytes,3,opt,name=artifact_json,json=artifactJson,proto3" json:"artifact_json,omitempty"`
+	// Non-empty when the run failed; the task is removed (no auto-retry in the
+	// prototype) and the error is recorded.
+	Error         string `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CompleteAgentTaskRequest) Reset() {
+	*x = CompleteAgentTaskRequest{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CompleteAgentTaskRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CompleteAgentTaskRequest) ProtoMessage() {}
+
+func (x *CompleteAgentTaskRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CompleteAgentTaskRequest.ProtoReflect.Descriptor instead.
+func (*CompleteAgentTaskRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *CompleteAgentTaskRequest) GetTaskId() string {
+	if x != nil {
+		return x.TaskId
+	}
+	return ""
+}
+
+func (x *CompleteAgentTaskRequest) GetLeaseToken() string {
+	if x != nil {
+		return x.LeaseToken
+	}
+	return ""
+}
+
+func (x *CompleteAgentTaskRequest) GetArtifactJson() string {
+	if x != nil {
+		return x.ArtifactJson
+	}
+	return ""
+}
+
+func (x *CompleteAgentTaskRequest) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+type CompleteAgentTaskResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// False when the lease was stale (expired + redelivered); the worker should
+	// drop its result — another lease owns the task now.
+	Accepted      bool `protobuf:"varint,1,opt,name=accepted,proto3" json:"accepted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CompleteAgentTaskResponse) Reset() {
+	*x = CompleteAgentTaskResponse{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CompleteAgentTaskResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CompleteAgentTaskResponse) ProtoMessage() {}
+
+func (x *CompleteAgentTaskResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CompleteAgentTaskResponse.ProtoReflect.Descriptor instead.
+func (*CompleteAgentTaskResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *CompleteAgentTaskResponse) GetAccepted() bool {
+	if x != nil {
+		return x.Accepted
+	}
+	return false
+}
+
 // Crew is a collaborating set of skills bound to a task purpose.
 type Crew struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1040,7 +1403,7 @@ type Crew struct {
 
 func (x *Crew) Reset() {
 	*x = Crew{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[12]
+	mi := &file_containarium_v1_agent_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1052,7 +1415,7 @@ func (x *Crew) String() string {
 func (*Crew) ProtoMessage() {}
 
 func (x *Crew) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[12]
+	mi := &file_containarium_v1_agent_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1065,7 +1428,7 @@ func (x *Crew) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Crew.ProtoReflect.Descriptor instead.
 func (*Crew) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{12}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *Crew) GetId() string {
@@ -1125,7 +1488,7 @@ type CrewRun struct {
 
 func (x *CrewRun) Reset() {
 	*x = CrewRun{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[13]
+	mi := &file_containarium_v1_agent_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1137,7 +1500,7 @@ func (x *CrewRun) String() string {
 func (*CrewRun) ProtoMessage() {}
 
 func (x *CrewRun) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[13]
+	mi := &file_containarium_v1_agent_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1150,7 +1513,7 @@ func (x *CrewRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CrewRun.ProtoReflect.Descriptor instead.
 func (*CrewRun) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{13}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *CrewRun) GetId() string {
@@ -1210,7 +1573,7 @@ type ListCrewsRequest struct {
 
 func (x *ListCrewsRequest) Reset() {
 	*x = ListCrewsRequest{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[14]
+	mi := &file_containarium_v1_agent_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1222,7 +1585,7 @@ func (x *ListCrewsRequest) String() string {
 func (*ListCrewsRequest) ProtoMessage() {}
 
 func (x *ListCrewsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[14]
+	mi := &file_containarium_v1_agent_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1235,7 +1598,7 @@ func (x *ListCrewsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCrewsRequest.ProtoReflect.Descriptor instead.
 func (*ListCrewsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{14}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{20}
 }
 
 type ListCrewsResponse struct {
@@ -1247,7 +1610,7 @@ type ListCrewsResponse struct {
 
 func (x *ListCrewsResponse) Reset() {
 	*x = ListCrewsResponse{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[15]
+	mi := &file_containarium_v1_agent_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1259,7 +1622,7 @@ func (x *ListCrewsResponse) String() string {
 func (*ListCrewsResponse) ProtoMessage() {}
 
 func (x *ListCrewsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[15]
+	mi := &file_containarium_v1_agent_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1272,7 +1635,7 @@ func (x *ListCrewsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCrewsResponse.ProtoReflect.Descriptor instead.
 func (*ListCrewsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{15}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ListCrewsResponse) GetCrews() []*Crew {
@@ -1291,7 +1654,7 @@ type GetCrewRequest struct {
 
 func (x *GetCrewRequest) Reset() {
 	*x = GetCrewRequest{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[16]
+	mi := &file_containarium_v1_agent_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1303,7 +1666,7 @@ func (x *GetCrewRequest) String() string {
 func (*GetCrewRequest) ProtoMessage() {}
 
 func (x *GetCrewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[16]
+	mi := &file_containarium_v1_agent_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1316,7 +1679,7 @@ func (x *GetCrewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCrewRequest.ProtoReflect.Descriptor instead.
 func (*GetCrewRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{16}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetCrewRequest) GetId() string {
@@ -1335,7 +1698,7 @@ type GetCrewResponse struct {
 
 func (x *GetCrewResponse) Reset() {
 	*x = GetCrewResponse{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[17]
+	mi := &file_containarium_v1_agent_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1347,7 +1710,7 @@ func (x *GetCrewResponse) String() string {
 func (*GetCrewResponse) ProtoMessage() {}
 
 func (x *GetCrewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[17]
+	mi := &file_containarium_v1_agent_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1360,7 +1723,7 @@ func (x *GetCrewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCrewResponse.ProtoReflect.Descriptor instead.
 func (*GetCrewResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{17}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *GetCrewResponse) GetCrew() *Crew {
@@ -1383,7 +1746,7 @@ type RunCrewRequest struct {
 
 func (x *RunCrewRequest) Reset() {
 	*x = RunCrewRequest{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[18]
+	mi := &file_containarium_v1_agent_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1395,7 +1758,7 @@ func (x *RunCrewRequest) String() string {
 func (*RunCrewRequest) ProtoMessage() {}
 
 func (x *RunCrewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[18]
+	mi := &file_containarium_v1_agent_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1408,7 +1771,7 @@ func (x *RunCrewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunCrewRequest.ProtoReflect.Descriptor instead.
 func (*RunCrewRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{18}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *RunCrewRequest) GetCrewId() string {
@@ -1448,7 +1811,7 @@ type RunCrewResponse struct {
 
 func (x *RunCrewResponse) Reset() {
 	*x = RunCrewResponse{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[19]
+	mi := &file_containarium_v1_agent_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1460,7 +1823,7 @@ func (x *RunCrewResponse) String() string {
 func (*RunCrewResponse) ProtoMessage() {}
 
 func (x *RunCrewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[19]
+	mi := &file_containarium_v1_agent_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1473,7 +1836,7 @@ func (x *RunCrewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunCrewResponse.ProtoReflect.Descriptor instead.
 func (*RunCrewResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{19}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *RunCrewResponse) GetRun() *CrewRun {
@@ -1492,7 +1855,7 @@ type GetCrewRunRequest struct {
 
 func (x *GetCrewRunRequest) Reset() {
 	*x = GetCrewRunRequest{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[20]
+	mi := &file_containarium_v1_agent_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1504,7 +1867,7 @@ func (x *GetCrewRunRequest) String() string {
 func (*GetCrewRunRequest) ProtoMessage() {}
 
 func (x *GetCrewRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[20]
+	mi := &file_containarium_v1_agent_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1517,7 +1880,7 @@ func (x *GetCrewRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCrewRunRequest.ProtoReflect.Descriptor instead.
 func (*GetCrewRunRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{20}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetCrewRunRequest) GetId() string {
@@ -1536,7 +1899,7 @@ type GetCrewRunResponse struct {
 
 func (x *GetCrewRunResponse) Reset() {
 	*x = GetCrewRunResponse{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[21]
+	mi := &file_containarium_v1_agent_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1548,7 +1911,7 @@ func (x *GetCrewRunResponse) String() string {
 func (*GetCrewRunResponse) ProtoMessage() {}
 
 func (x *GetCrewRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[21]
+	mi := &file_containarium_v1_agent_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1561,7 +1924,7 @@ func (x *GetCrewRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCrewRunResponse.ProtoReflect.Descriptor instead.
 func (*GetCrewRunResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{21}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetCrewRunResponse) GetRun() *CrewRun {
@@ -1634,7 +1997,33 @@ const file_containarium_v1_agent_proto_rawDesc = "" +
 	"\btrace_id\x18\x04 \x01(\tR\atraceId\"n\n" +
 	"\x15SendAgentTaskResponse\x12:\n" +
 	"\bartifact\x18\x01 \x01(\v2\x1e.containarium.v1.AgentArtifactR\bartifact\x12\x19\n" +
-	"\btrace_id\x18\x02 \x01(\tR\atraceId\"\xa4\x01\n" +
+	"\btrace_id\x18\x02 \x01(\tR\atraceId\"S\n" +
+	"\x17EnqueueAgentTaskRequest\x12\x19\n" +
+	"\bskill_id\x18\x01 \x01(\tR\askillId\x12\x1d\n" +
+	"\n" +
+	"input_json\x18\x02 \x01(\tR\tinputJson\"3\n" +
+	"\x18EnqueueAgentTaskResponse\x12\x17\n" +
+	"\atask_id\x18\x01 \x01(\tR\x06taskId\"t\n" +
+	"\x15LeaseAgentTaskRequest\x12\x1b\n" +
+	"\tworker_id\x18\x01 \x01(\tR\bworkerId\x12\x19\n" +
+	"\bskill_id\x18\x02 \x01(\tR\askillId\x12#\n" +
+	"\rlease_seconds\x18\x03 \x01(\x05R\fleaseSeconds\"\xa7\x01\n" +
+	"\x16LeaseAgentTaskResponse\x12\x19\n" +
+	"\bhas_task\x18\x01 \x01(\bR\ahasTask\x12\x17\n" +
+	"\atask_id\x18\x02 \x01(\tR\x06taskId\x12\x19\n" +
+	"\bskill_id\x18\x03 \x01(\tR\askillId\x12\x1d\n" +
+	"\n" +
+	"input_json\x18\x04 \x01(\tR\tinputJson\x12\x1f\n" +
+	"\vlease_token\x18\x05 \x01(\tR\n" +
+	"leaseToken\"\x8f\x01\n" +
+	"\x18CompleteAgentTaskRequest\x12\x17\n" +
+	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12\x1f\n" +
+	"\vlease_token\x18\x02 \x01(\tR\n" +
+	"leaseToken\x12#\n" +
+	"\rartifact_json\x18\x03 \x01(\tR\fartifactJson\x12\x14\n" +
+	"\x05error\x18\x04 \x01(\tR\x05error\"7\n" +
+	"\x19CompleteAgentTaskResponse\x12\x1a\n" +
+	"\baccepted\x18\x01 \x01(\bR\baccepted\"\xa4\x01\n" +
 	"\x04Crew\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
@@ -1687,7 +2076,7 @@ const file_containarium_v1_agent_proto_rawDesc = "" +
 	"\x16CREW_RUN_STATE_RUNNING\x10\x02\x12\x1c\n" +
 	"\x18CREW_RUN_STATE_COMPLETED\x10\x03\x12\x19\n" +
 	"\x15CREW_RUN_STATE_FAILED\x10\x04\x12\x1c\n" +
-	"\x18CREW_RUN_STATE_CANCELLED\x10\x052\xbd\b\n" +
+	"\x18CREW_RUN_STATE_CANCELLED\x10\x052\xa0\x0f\n" +
 	"\x11AgentSkillService\x12\xf6\x01\n" +
 	"\x0fListAgentSkills\x12'.containarium.v1.ListAgentSkillsRequest\x1a(.containarium.v1.ListAgentSkillsResponse\"\x8f\x01\x92At\n" +
 	"\x06Agents\x12\x11List agent skills\x1aWReturns all packaged agent skills that can be run individually or composed into a crew.\x82\xd3\xe4\x93\x02\x12\x12\x10/v1/agent-skills\x12\xf8\x01\n" +
@@ -1696,7 +2085,13 @@ const file_containarium_v1_agent_proto_rawDesc = "" +
 	"\rRunAgentSkill\x12%.containarium.v1.RunAgentSkillRequest\x1a&.containarium.v1.RunAgentSkillResponse\"\xa5\x01\x92Ax\n" +
 	"\x06Agents\x12\x12Run an agent skill\x1aZProvisions the skill's box, mints a scoped token, runs one task, and returns the artifact.\x82\xd3\xe4\x93\x02$:\x01*\"\x1f/v1/agent-skills/{skill_id}/run\x12\xaa\x02\n" +
 	"\rSendAgentTask\x12%.containarium.v1.SendAgentTaskRequest\x1a&.containarium.v1.SendAgentTaskResponse\"\xc9\x01\x92A\x98\x01\n" +
-	"\x06Agents\x12!Send a task to a peer agent (A2A)\x1akDelegates a task to a running peer agent over the agent-to-agent transport and returns the peer's artifact.\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/agent-skills/{to_peer_id}/call2\x96\a\n" +
+	"\x06Agents\x12!Send a task to a peer agent (A2A)\x1akDelegates a task to a running peer agent over the agent-to-agent transport and returns the peer's artifact.\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/agent-skills/{to_peer_id}/call\x12\x80\x02\n" +
+	"\x10EnqueueAgentTask\x12(.containarium.v1.EnqueueAgentTaskRequest\x1a).containarium.v1.EnqueueAgentTaskResponse\"\x96\x01\x92Ay\n" +
+	"\x06Agents\x12\"Enqueue an agent task (pull queue)\x1aKPlaces a task on the pull queue for a skill; worker boxes lease and run it.\x82\xd3\xe4\x93\x02\x14:\x01*\"\x0f/v1/agent-tasks\x12\xb4\x02\n" +
+	"\x0eLeaseAgentTask\x12&.containarium.v1.LeaseAgentTaskRequest\x1a'.containarium.v1.LeaseAgentTaskResponse\"\xd0\x01\x92A\xac\x01\n" +
+	"\x06Agents\x12&Lease the next agent task (pull queue)\x1azWorker boxes poll this to lease the next task; the task is hidden from other workers until completed or the lease expires.\x82\xd3\xe4\x93\x02\x1a:\x01*\"\x15/v1/agent-tasks/lease\x12\xa6\x02\n" +
+	"\x11CompleteAgentTask\x12).containarium.v1.CompleteAgentTaskRequest\x1a*.containarium.v1.CompleteAgentTaskResponse\"\xb9\x01\x92A\x88\x01\n" +
+	"\x06Agents\x12)Complete a leased agent task (pull queue)\x1aSWorker boxes report a leased task's artifact/error here; a stale lease is rejected.\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/agent-tasks/{task_id}/complete2\x96\a\n" +
 	"\vCrewService\x12\xbc\x01\n" +
 	"\tListCrews\x12!.containarium.v1.ListCrewsRequest\x1a\".containarium.v1.ListCrewsResponse\"h\x92AT\n" +
 	"\x06Agents\x12\n" +
@@ -1723,68 +2118,80 @@ func file_containarium_v1_agent_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_agent_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_containarium_v1_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_containarium_v1_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
 var file_containarium_v1_agent_proto_goTypes = []any{
-	(AgentTaskState)(0),             // 0: containarium.v1.AgentTaskState
-	(CrewTopology)(0),               // 1: containarium.v1.CrewTopology
-	(CrewRunState)(0),               // 2: containarium.v1.CrewRunState
-	(*AgentCard)(nil),               // 3: containarium.v1.AgentCard
-	(*AgentSkill)(nil),              // 4: containarium.v1.AgentSkill
-	(*ListAgentSkillsRequest)(nil),  // 5: containarium.v1.ListAgentSkillsRequest
-	(*ListAgentSkillsResponse)(nil), // 6: containarium.v1.ListAgentSkillsResponse
-	(*GetAgentSkillRequest)(nil),    // 7: containarium.v1.GetAgentSkillRequest
-	(*GetAgentSkillResponse)(nil),   // 8: containarium.v1.GetAgentSkillResponse
-	(*RunAgentSkillRequest)(nil),    // 9: containarium.v1.RunAgentSkillRequest
-	(*RunAgentSkillResponse)(nil),   // 10: containarium.v1.RunAgentSkillResponse
-	(*AgentTask)(nil),               // 11: containarium.v1.AgentTask
-	(*AgentArtifact)(nil),           // 12: containarium.v1.AgentArtifact
-	(*SendAgentTaskRequest)(nil),    // 13: containarium.v1.SendAgentTaskRequest
-	(*SendAgentTaskResponse)(nil),   // 14: containarium.v1.SendAgentTaskResponse
-	(*Crew)(nil),                    // 15: containarium.v1.Crew
-	(*CrewRun)(nil),                 // 16: containarium.v1.CrewRun
-	(*ListCrewsRequest)(nil),        // 17: containarium.v1.ListCrewsRequest
-	(*ListCrewsResponse)(nil),       // 18: containarium.v1.ListCrewsResponse
-	(*GetCrewRequest)(nil),          // 19: containarium.v1.GetCrewRequest
-	(*GetCrewResponse)(nil),         // 20: containarium.v1.GetCrewResponse
-	(*RunCrewRequest)(nil),          // 21: containarium.v1.RunCrewRequest
-	(*RunCrewResponse)(nil),         // 22: containarium.v1.RunCrewResponse
-	(*GetCrewRunRequest)(nil),       // 23: containarium.v1.GetCrewRunRequest
-	(*GetCrewRunResponse)(nil),      // 24: containarium.v1.GetCrewRunResponse
-	(*Recipe)(nil),                  // 25: containarium.v1.Recipe
-	(*Container)(nil),               // 26: containarium.v1.Container
+	(AgentTaskState)(0),               // 0: containarium.v1.AgentTaskState
+	(CrewTopology)(0),                 // 1: containarium.v1.CrewTopology
+	(CrewRunState)(0),                 // 2: containarium.v1.CrewRunState
+	(*AgentCard)(nil),                 // 3: containarium.v1.AgentCard
+	(*AgentSkill)(nil),                // 4: containarium.v1.AgentSkill
+	(*ListAgentSkillsRequest)(nil),    // 5: containarium.v1.ListAgentSkillsRequest
+	(*ListAgentSkillsResponse)(nil),   // 6: containarium.v1.ListAgentSkillsResponse
+	(*GetAgentSkillRequest)(nil),      // 7: containarium.v1.GetAgentSkillRequest
+	(*GetAgentSkillResponse)(nil),     // 8: containarium.v1.GetAgentSkillResponse
+	(*RunAgentSkillRequest)(nil),      // 9: containarium.v1.RunAgentSkillRequest
+	(*RunAgentSkillResponse)(nil),     // 10: containarium.v1.RunAgentSkillResponse
+	(*AgentTask)(nil),                 // 11: containarium.v1.AgentTask
+	(*AgentArtifact)(nil),             // 12: containarium.v1.AgentArtifact
+	(*SendAgentTaskRequest)(nil),      // 13: containarium.v1.SendAgentTaskRequest
+	(*SendAgentTaskResponse)(nil),     // 14: containarium.v1.SendAgentTaskResponse
+	(*EnqueueAgentTaskRequest)(nil),   // 15: containarium.v1.EnqueueAgentTaskRequest
+	(*EnqueueAgentTaskResponse)(nil),  // 16: containarium.v1.EnqueueAgentTaskResponse
+	(*LeaseAgentTaskRequest)(nil),     // 17: containarium.v1.LeaseAgentTaskRequest
+	(*LeaseAgentTaskResponse)(nil),    // 18: containarium.v1.LeaseAgentTaskResponse
+	(*CompleteAgentTaskRequest)(nil),  // 19: containarium.v1.CompleteAgentTaskRequest
+	(*CompleteAgentTaskResponse)(nil), // 20: containarium.v1.CompleteAgentTaskResponse
+	(*Crew)(nil),                      // 21: containarium.v1.Crew
+	(*CrewRun)(nil),                   // 22: containarium.v1.CrewRun
+	(*ListCrewsRequest)(nil),          // 23: containarium.v1.ListCrewsRequest
+	(*ListCrewsResponse)(nil),         // 24: containarium.v1.ListCrewsResponse
+	(*GetCrewRequest)(nil),            // 25: containarium.v1.GetCrewRequest
+	(*GetCrewResponse)(nil),           // 26: containarium.v1.GetCrewResponse
+	(*RunCrewRequest)(nil),            // 27: containarium.v1.RunCrewRequest
+	(*RunCrewResponse)(nil),           // 28: containarium.v1.RunCrewResponse
+	(*GetCrewRunRequest)(nil),         // 29: containarium.v1.GetCrewRunRequest
+	(*GetCrewRunResponse)(nil),        // 30: containarium.v1.GetCrewRunResponse
+	(*Recipe)(nil),                    // 31: containarium.v1.Recipe
+	(*Container)(nil),                 // 32: containarium.v1.Container
 }
 var file_containarium_v1_agent_proto_depIdxs = []int32{
-	25, // 0: containarium.v1.AgentSkill.recipe:type_name -> containarium.v1.Recipe
+	31, // 0: containarium.v1.AgentSkill.recipe:type_name -> containarium.v1.Recipe
 	3,  // 1: containarium.v1.AgentSkill.agent_card:type_name -> containarium.v1.AgentCard
 	4,  // 2: containarium.v1.ListAgentSkillsResponse.skills:type_name -> containarium.v1.AgentSkill
 	4,  // 3: containarium.v1.GetAgentSkillResponse.skill:type_name -> containarium.v1.AgentSkill
-	26, // 4: containarium.v1.RunAgentSkillResponse.container:type_name -> containarium.v1.Container
+	32, // 4: containarium.v1.RunAgentSkillResponse.container:type_name -> containarium.v1.Container
 	0,  // 5: containarium.v1.AgentArtifact.state:type_name -> containarium.v1.AgentTaskState
 	12, // 6: containarium.v1.SendAgentTaskResponse.artifact:type_name -> containarium.v1.AgentArtifact
 	1,  // 7: containarium.v1.Crew.topology:type_name -> containarium.v1.CrewTopology
 	2,  // 8: containarium.v1.CrewRun.state:type_name -> containarium.v1.CrewRunState
-	15, // 9: containarium.v1.ListCrewsResponse.crews:type_name -> containarium.v1.Crew
-	15, // 10: containarium.v1.GetCrewResponse.crew:type_name -> containarium.v1.Crew
-	16, // 11: containarium.v1.RunCrewResponse.run:type_name -> containarium.v1.CrewRun
-	16, // 12: containarium.v1.GetCrewRunResponse.run:type_name -> containarium.v1.CrewRun
+	21, // 9: containarium.v1.ListCrewsResponse.crews:type_name -> containarium.v1.Crew
+	21, // 10: containarium.v1.GetCrewResponse.crew:type_name -> containarium.v1.Crew
+	22, // 11: containarium.v1.RunCrewResponse.run:type_name -> containarium.v1.CrewRun
+	22, // 12: containarium.v1.GetCrewRunResponse.run:type_name -> containarium.v1.CrewRun
 	5,  // 13: containarium.v1.AgentSkillService.ListAgentSkills:input_type -> containarium.v1.ListAgentSkillsRequest
 	7,  // 14: containarium.v1.AgentSkillService.GetAgentSkill:input_type -> containarium.v1.GetAgentSkillRequest
 	9,  // 15: containarium.v1.AgentSkillService.RunAgentSkill:input_type -> containarium.v1.RunAgentSkillRequest
 	13, // 16: containarium.v1.AgentSkillService.SendAgentTask:input_type -> containarium.v1.SendAgentTaskRequest
-	17, // 17: containarium.v1.CrewService.ListCrews:input_type -> containarium.v1.ListCrewsRequest
-	19, // 18: containarium.v1.CrewService.GetCrew:input_type -> containarium.v1.GetCrewRequest
-	21, // 19: containarium.v1.CrewService.RunCrew:input_type -> containarium.v1.RunCrewRequest
-	23, // 20: containarium.v1.CrewService.GetCrewRun:input_type -> containarium.v1.GetCrewRunRequest
-	6,  // 21: containarium.v1.AgentSkillService.ListAgentSkills:output_type -> containarium.v1.ListAgentSkillsResponse
-	8,  // 22: containarium.v1.AgentSkillService.GetAgentSkill:output_type -> containarium.v1.GetAgentSkillResponse
-	10, // 23: containarium.v1.AgentSkillService.RunAgentSkill:output_type -> containarium.v1.RunAgentSkillResponse
-	14, // 24: containarium.v1.AgentSkillService.SendAgentTask:output_type -> containarium.v1.SendAgentTaskResponse
-	18, // 25: containarium.v1.CrewService.ListCrews:output_type -> containarium.v1.ListCrewsResponse
-	20, // 26: containarium.v1.CrewService.GetCrew:output_type -> containarium.v1.GetCrewResponse
-	22, // 27: containarium.v1.CrewService.RunCrew:output_type -> containarium.v1.RunCrewResponse
-	24, // 28: containarium.v1.CrewService.GetCrewRun:output_type -> containarium.v1.GetCrewRunResponse
-	21, // [21:29] is the sub-list for method output_type
-	13, // [13:21] is the sub-list for method input_type
+	15, // 17: containarium.v1.AgentSkillService.EnqueueAgentTask:input_type -> containarium.v1.EnqueueAgentTaskRequest
+	17, // 18: containarium.v1.AgentSkillService.LeaseAgentTask:input_type -> containarium.v1.LeaseAgentTaskRequest
+	19, // 19: containarium.v1.AgentSkillService.CompleteAgentTask:input_type -> containarium.v1.CompleteAgentTaskRequest
+	23, // 20: containarium.v1.CrewService.ListCrews:input_type -> containarium.v1.ListCrewsRequest
+	25, // 21: containarium.v1.CrewService.GetCrew:input_type -> containarium.v1.GetCrewRequest
+	27, // 22: containarium.v1.CrewService.RunCrew:input_type -> containarium.v1.RunCrewRequest
+	29, // 23: containarium.v1.CrewService.GetCrewRun:input_type -> containarium.v1.GetCrewRunRequest
+	6,  // 24: containarium.v1.AgentSkillService.ListAgentSkills:output_type -> containarium.v1.ListAgentSkillsResponse
+	8,  // 25: containarium.v1.AgentSkillService.GetAgentSkill:output_type -> containarium.v1.GetAgentSkillResponse
+	10, // 26: containarium.v1.AgentSkillService.RunAgentSkill:output_type -> containarium.v1.RunAgentSkillResponse
+	14, // 27: containarium.v1.AgentSkillService.SendAgentTask:output_type -> containarium.v1.SendAgentTaskResponse
+	16, // 28: containarium.v1.AgentSkillService.EnqueueAgentTask:output_type -> containarium.v1.EnqueueAgentTaskResponse
+	18, // 29: containarium.v1.AgentSkillService.LeaseAgentTask:output_type -> containarium.v1.LeaseAgentTaskResponse
+	20, // 30: containarium.v1.AgentSkillService.CompleteAgentTask:output_type -> containarium.v1.CompleteAgentTaskResponse
+	24, // 31: containarium.v1.CrewService.ListCrews:output_type -> containarium.v1.ListCrewsResponse
+	26, // 32: containarium.v1.CrewService.GetCrew:output_type -> containarium.v1.GetCrewResponse
+	28, // 33: containarium.v1.CrewService.RunCrew:output_type -> containarium.v1.RunCrewResponse
+	30, // 34: containarium.v1.CrewService.GetCrewRun:output_type -> containarium.v1.GetCrewRunResponse
+	24, // [24:35] is the sub-list for method output_type
+	13, // [13:24] is the sub-list for method input_type
 	13, // [13:13] is the sub-list for extension type_name
 	13, // [13:13] is the sub-list for extension extendee
 	0,  // [0:13] is the sub-list for field type_name
@@ -1807,7 +2214,7 @@ func file_containarium_v1_agent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_agent_proto_rawDesc), len(file_containarium_v1_agent_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   22,
+			NumMessages:   28,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/pb/containarium/v1/agent.pb.go
+++ b/pkg/pb/containarium/v1/agent.pb.go
@@ -1383,6 +1383,134 @@ func (x *CompleteAgentTaskResponse) GetAccepted() bool {
 	return false
 }
 
+// StartAgentWorkerRequest launches a poll-mode worker for a skill.
+type StartAgentWorkerRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Skill whose box runs as the worker (its persona is the worker's; the
+	// worker leases only this skill's tasks).
+	SkillId string `protobuf:"bytes,1,opt,name=skill_id,json=skillId,proto3" json:"skill_id,omitempty"`
+	// Target backend (must be local in the prototype).
+	BackendId string `protobuf:"bytes,2,opt,name=backend_id,json=backendId,proto3" json:"backend_id,omitempty"`
+	// Target pool (unsupported in the prototype).
+	Pool string `protobuf:"bytes,3,opt,name=pool,proto3" json:"pool,omitempty"`
+	// Optional stable worker id for audit/debug; defaults to the box name.
+	WorkerId      string `protobuf:"bytes,4,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StartAgentWorkerRequest) Reset() {
+	*x = StartAgentWorkerRequest{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StartAgentWorkerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StartAgentWorkerRequest) ProtoMessage() {}
+
+func (x *StartAgentWorkerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StartAgentWorkerRequest.ProtoReflect.Descriptor instead.
+func (*StartAgentWorkerRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *StartAgentWorkerRequest) GetSkillId() string {
+	if x != nil {
+		return x.SkillId
+	}
+	return ""
+}
+
+func (x *StartAgentWorkerRequest) GetBackendId() string {
+	if x != nil {
+		return x.BackendId
+	}
+	return ""
+}
+
+func (x *StartAgentWorkerRequest) GetPool() string {
+	if x != nil {
+		return x.Pool
+	}
+	return ""
+}
+
+func (x *StartAgentWorkerRequest) GetWorkerId() string {
+	if x != nil {
+		return x.WorkerId
+	}
+	return ""
+}
+
+type StartAgentWorkerResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The worker box.
+	Container *Container `protobuf:"bytes,1,opt,name=container,proto3" json:"container,omitempty"`
+	// The worker id the daemon used.
+	WorkerId      string `protobuf:"bytes,2,opt,name=worker_id,json=workerId,proto3" json:"worker_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StartAgentWorkerResponse) Reset() {
+	*x = StartAgentWorkerResponse{}
+	mi := &file_containarium_v1_agent_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StartAgentWorkerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StartAgentWorkerResponse) ProtoMessage() {}
+
+func (x *StartAgentWorkerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_agent_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StartAgentWorkerResponse.ProtoReflect.Descriptor instead.
+func (*StartAgentWorkerResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *StartAgentWorkerResponse) GetContainer() *Container {
+	if x != nil {
+		return x.Container
+	}
+	return nil
+}
+
+func (x *StartAgentWorkerResponse) GetWorkerId() string {
+	if x != nil {
+		return x.WorkerId
+	}
+	return ""
+}
+
 // Crew is a collaborating set of skills bound to a task purpose.
 type Crew struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1403,7 +1531,7 @@ type Crew struct {
 
 func (x *Crew) Reset() {
 	*x = Crew{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[18]
+	mi := &file_containarium_v1_agent_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1415,7 +1543,7 @@ func (x *Crew) String() string {
 func (*Crew) ProtoMessage() {}
 
 func (x *Crew) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[18]
+	mi := &file_containarium_v1_agent_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1428,7 +1556,7 @@ func (x *Crew) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Crew.ProtoReflect.Descriptor instead.
 func (*Crew) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{18}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *Crew) GetId() string {
@@ -1488,7 +1616,7 @@ type CrewRun struct {
 
 func (x *CrewRun) Reset() {
 	*x = CrewRun{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[19]
+	mi := &file_containarium_v1_agent_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1500,7 +1628,7 @@ func (x *CrewRun) String() string {
 func (*CrewRun) ProtoMessage() {}
 
 func (x *CrewRun) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[19]
+	mi := &file_containarium_v1_agent_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1513,7 +1641,7 @@ func (x *CrewRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CrewRun.ProtoReflect.Descriptor instead.
 func (*CrewRun) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{19}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *CrewRun) GetId() string {
@@ -1573,7 +1701,7 @@ type ListCrewsRequest struct {
 
 func (x *ListCrewsRequest) Reset() {
 	*x = ListCrewsRequest{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[20]
+	mi := &file_containarium_v1_agent_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1585,7 +1713,7 @@ func (x *ListCrewsRequest) String() string {
 func (*ListCrewsRequest) ProtoMessage() {}
 
 func (x *ListCrewsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[20]
+	mi := &file_containarium_v1_agent_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1598,7 +1726,7 @@ func (x *ListCrewsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCrewsRequest.ProtoReflect.Descriptor instead.
 func (*ListCrewsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{20}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{22}
 }
 
 type ListCrewsResponse struct {
@@ -1610,7 +1738,7 @@ type ListCrewsResponse struct {
 
 func (x *ListCrewsResponse) Reset() {
 	*x = ListCrewsResponse{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[21]
+	mi := &file_containarium_v1_agent_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1622,7 +1750,7 @@ func (x *ListCrewsResponse) String() string {
 func (*ListCrewsResponse) ProtoMessage() {}
 
 func (x *ListCrewsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[21]
+	mi := &file_containarium_v1_agent_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1635,7 +1763,7 @@ func (x *ListCrewsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCrewsResponse.ProtoReflect.Descriptor instead.
 func (*ListCrewsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{21}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ListCrewsResponse) GetCrews() []*Crew {
@@ -1654,7 +1782,7 @@ type GetCrewRequest struct {
 
 func (x *GetCrewRequest) Reset() {
 	*x = GetCrewRequest{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[22]
+	mi := &file_containarium_v1_agent_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1666,7 +1794,7 @@ func (x *GetCrewRequest) String() string {
 func (*GetCrewRequest) ProtoMessage() {}
 
 func (x *GetCrewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[22]
+	mi := &file_containarium_v1_agent_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1679,7 +1807,7 @@ func (x *GetCrewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCrewRequest.ProtoReflect.Descriptor instead.
 func (*GetCrewRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{22}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetCrewRequest) GetId() string {
@@ -1698,7 +1826,7 @@ type GetCrewResponse struct {
 
 func (x *GetCrewResponse) Reset() {
 	*x = GetCrewResponse{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[23]
+	mi := &file_containarium_v1_agent_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1710,7 +1838,7 @@ func (x *GetCrewResponse) String() string {
 func (*GetCrewResponse) ProtoMessage() {}
 
 func (x *GetCrewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[23]
+	mi := &file_containarium_v1_agent_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1723,7 +1851,7 @@ func (x *GetCrewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCrewResponse.ProtoReflect.Descriptor instead.
 func (*GetCrewResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{23}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetCrewResponse) GetCrew() *Crew {
@@ -1746,7 +1874,7 @@ type RunCrewRequest struct {
 
 func (x *RunCrewRequest) Reset() {
 	*x = RunCrewRequest{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[24]
+	mi := &file_containarium_v1_agent_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1758,7 +1886,7 @@ func (x *RunCrewRequest) String() string {
 func (*RunCrewRequest) ProtoMessage() {}
 
 func (x *RunCrewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[24]
+	mi := &file_containarium_v1_agent_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1771,7 +1899,7 @@ func (x *RunCrewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunCrewRequest.ProtoReflect.Descriptor instead.
 func (*RunCrewRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{24}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *RunCrewRequest) GetCrewId() string {
@@ -1811,7 +1939,7 @@ type RunCrewResponse struct {
 
 func (x *RunCrewResponse) Reset() {
 	*x = RunCrewResponse{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[25]
+	mi := &file_containarium_v1_agent_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1823,7 +1951,7 @@ func (x *RunCrewResponse) String() string {
 func (*RunCrewResponse) ProtoMessage() {}
 
 func (x *RunCrewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[25]
+	mi := &file_containarium_v1_agent_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1836,7 +1964,7 @@ func (x *RunCrewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunCrewResponse.ProtoReflect.Descriptor instead.
 func (*RunCrewResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{25}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *RunCrewResponse) GetRun() *CrewRun {
@@ -1855,7 +1983,7 @@ type GetCrewRunRequest struct {
 
 func (x *GetCrewRunRequest) Reset() {
 	*x = GetCrewRunRequest{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[26]
+	mi := &file_containarium_v1_agent_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1867,7 +1995,7 @@ func (x *GetCrewRunRequest) String() string {
 func (*GetCrewRunRequest) ProtoMessage() {}
 
 func (x *GetCrewRunRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[26]
+	mi := &file_containarium_v1_agent_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1880,7 +2008,7 @@ func (x *GetCrewRunRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCrewRunRequest.ProtoReflect.Descriptor instead.
 func (*GetCrewRunRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{26}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GetCrewRunRequest) GetId() string {
@@ -1899,7 +2027,7 @@ type GetCrewRunResponse struct {
 
 func (x *GetCrewRunResponse) Reset() {
 	*x = GetCrewRunResponse{}
-	mi := &file_containarium_v1_agent_proto_msgTypes[27]
+	mi := &file_containarium_v1_agent_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1911,7 +2039,7 @@ func (x *GetCrewRunResponse) String() string {
 func (*GetCrewRunResponse) ProtoMessage() {}
 
 func (x *GetCrewRunResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_agent_proto_msgTypes[27]
+	mi := &file_containarium_v1_agent_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1924,7 +2052,7 @@ func (x *GetCrewRunResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCrewRunResponse.ProtoReflect.Descriptor instead.
 func (*GetCrewRunResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{27}
+	return file_containarium_v1_agent_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *GetCrewRunResponse) GetRun() *CrewRun {
@@ -2023,7 +2151,16 @@ const file_containarium_v1_agent_proto_rawDesc = "" +
 	"\rartifact_json\x18\x03 \x01(\tR\fartifactJson\x12\x14\n" +
 	"\x05error\x18\x04 \x01(\tR\x05error\"7\n" +
 	"\x19CompleteAgentTaskResponse\x12\x1a\n" +
-	"\baccepted\x18\x01 \x01(\bR\baccepted\"\xa4\x01\n" +
+	"\baccepted\x18\x01 \x01(\bR\baccepted\"\x84\x01\n" +
+	"\x17StartAgentWorkerRequest\x12\x19\n" +
+	"\bskill_id\x18\x01 \x01(\tR\askillId\x12\x1d\n" +
+	"\n" +
+	"backend_id\x18\x02 \x01(\tR\tbackendId\x12\x12\n" +
+	"\x04pool\x18\x03 \x01(\tR\x04pool\x12\x1b\n" +
+	"\tworker_id\x18\x04 \x01(\tR\bworkerId\"q\n" +
+	"\x18StartAgentWorkerResponse\x128\n" +
+	"\tcontainer\x18\x01 \x01(\v2\x1a.containarium.v1.ContainerR\tcontainer\x12\x1b\n" +
+	"\tworker_id\x18\x02 \x01(\tR\bworkerId\"\xa4\x01\n" +
 	"\x04Crew\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
@@ -2076,7 +2213,7 @@ const file_containarium_v1_agent_proto_rawDesc = "" +
 	"\x16CREW_RUN_STATE_RUNNING\x10\x02\x12\x1c\n" +
 	"\x18CREW_RUN_STATE_COMPLETED\x10\x03\x12\x19\n" +
 	"\x15CREW_RUN_STATE_FAILED\x10\x04\x12\x1c\n" +
-	"\x18CREW_RUN_STATE_CANCELLED\x10\x052\xa0\x0f\n" +
+	"\x18CREW_RUN_STATE_CANCELLED\x10\x052\xfd\x11\n" +
 	"\x11AgentSkillService\x12\xf6\x01\n" +
 	"\x0fListAgentSkills\x12'.containarium.v1.ListAgentSkillsRequest\x1a(.containarium.v1.ListAgentSkillsResponse\"\x8f\x01\x92At\n" +
 	"\x06Agents\x12\x11List agent skills\x1aWReturns all packaged agent skills that can be run individually or composed into a crew.\x82\xd3\xe4\x93\x02\x12\x12\x10/v1/agent-skills\x12\xf8\x01\n" +
@@ -2091,7 +2228,9 @@ const file_containarium_v1_agent_proto_rawDesc = "" +
 	"\x0eLeaseAgentTask\x12&.containarium.v1.LeaseAgentTaskRequest\x1a'.containarium.v1.LeaseAgentTaskResponse\"\xd0\x01\x92A\xac\x01\n" +
 	"\x06Agents\x12&Lease the next agent task (pull queue)\x1azWorker boxes poll this to lease the next task; the task is hidden from other workers until completed or the lease expires.\x82\xd3\xe4\x93\x02\x1a:\x01*\"\x15/v1/agent-tasks/lease\x12\xa6\x02\n" +
 	"\x11CompleteAgentTask\x12).containarium.v1.CompleteAgentTaskRequest\x1a*.containarium.v1.CompleteAgentTaskResponse\"\xb9\x01\x92A\x88\x01\n" +
-	"\x06Agents\x12)Complete a leased agent task (pull queue)\x1aSWorker boxes report a leased task's artifact/error here; a stale lease is rejected.\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/agent-tasks/{task_id}/complete2\x96\a\n" +
+	"\x06Agents\x12)Complete a leased agent task (pull queue)\x1aSWorker boxes report a leased task's artifact/error here; a stale lease is rejected.\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/agent-tasks/{task_id}/complete\x12\xda\x02\n" +
+	"\x10StartAgentWorker\x12(.containarium.v1.StartAgentWorkerRequest\x1a).containarium.v1.StartAgentWorkerResponse\"\xf0\x01\x92A\xbf\x01\n" +
+	"\x06Agents\x12%Start a pull-queue worker for a skill\x1a\x8d\x01Provisions the skill's box, mints an agents:run queue credential, and launches the in-box runtime in poll mode to lease and run queued tasks.\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/agent-skills/{skill_id}/worker2\x96\a\n" +
 	"\vCrewService\x12\xbc\x01\n" +
 	"\tListCrews\x12!.containarium.v1.ListCrewsRequest\x1a\".containarium.v1.ListCrewsResponse\"h\x92AT\n" +
 	"\x06Agents\x12\n" +
@@ -2118,7 +2257,7 @@ func file_containarium_v1_agent_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_agent_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_containarium_v1_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_containarium_v1_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_containarium_v1_agent_proto_goTypes = []any{
 	(AgentTaskState)(0),               // 0: containarium.v1.AgentTaskState
 	(CrewTopology)(0),                 // 1: containarium.v1.CrewTopology
@@ -2141,60 +2280,65 @@ var file_containarium_v1_agent_proto_goTypes = []any{
 	(*LeaseAgentTaskResponse)(nil),    // 18: containarium.v1.LeaseAgentTaskResponse
 	(*CompleteAgentTaskRequest)(nil),  // 19: containarium.v1.CompleteAgentTaskRequest
 	(*CompleteAgentTaskResponse)(nil), // 20: containarium.v1.CompleteAgentTaskResponse
-	(*Crew)(nil),                      // 21: containarium.v1.Crew
-	(*CrewRun)(nil),                   // 22: containarium.v1.CrewRun
-	(*ListCrewsRequest)(nil),          // 23: containarium.v1.ListCrewsRequest
-	(*ListCrewsResponse)(nil),         // 24: containarium.v1.ListCrewsResponse
-	(*GetCrewRequest)(nil),            // 25: containarium.v1.GetCrewRequest
-	(*GetCrewResponse)(nil),           // 26: containarium.v1.GetCrewResponse
-	(*RunCrewRequest)(nil),            // 27: containarium.v1.RunCrewRequest
-	(*RunCrewResponse)(nil),           // 28: containarium.v1.RunCrewResponse
-	(*GetCrewRunRequest)(nil),         // 29: containarium.v1.GetCrewRunRequest
-	(*GetCrewRunResponse)(nil),        // 30: containarium.v1.GetCrewRunResponse
-	(*Recipe)(nil),                    // 31: containarium.v1.Recipe
-	(*Container)(nil),                 // 32: containarium.v1.Container
+	(*StartAgentWorkerRequest)(nil),   // 21: containarium.v1.StartAgentWorkerRequest
+	(*StartAgentWorkerResponse)(nil),  // 22: containarium.v1.StartAgentWorkerResponse
+	(*Crew)(nil),                      // 23: containarium.v1.Crew
+	(*CrewRun)(nil),                   // 24: containarium.v1.CrewRun
+	(*ListCrewsRequest)(nil),          // 25: containarium.v1.ListCrewsRequest
+	(*ListCrewsResponse)(nil),         // 26: containarium.v1.ListCrewsResponse
+	(*GetCrewRequest)(nil),            // 27: containarium.v1.GetCrewRequest
+	(*GetCrewResponse)(nil),           // 28: containarium.v1.GetCrewResponse
+	(*RunCrewRequest)(nil),            // 29: containarium.v1.RunCrewRequest
+	(*RunCrewResponse)(nil),           // 30: containarium.v1.RunCrewResponse
+	(*GetCrewRunRequest)(nil),         // 31: containarium.v1.GetCrewRunRequest
+	(*GetCrewRunResponse)(nil),        // 32: containarium.v1.GetCrewRunResponse
+	(*Recipe)(nil),                    // 33: containarium.v1.Recipe
+	(*Container)(nil),                 // 34: containarium.v1.Container
 }
 var file_containarium_v1_agent_proto_depIdxs = []int32{
-	31, // 0: containarium.v1.AgentSkill.recipe:type_name -> containarium.v1.Recipe
+	33, // 0: containarium.v1.AgentSkill.recipe:type_name -> containarium.v1.Recipe
 	3,  // 1: containarium.v1.AgentSkill.agent_card:type_name -> containarium.v1.AgentCard
 	4,  // 2: containarium.v1.ListAgentSkillsResponse.skills:type_name -> containarium.v1.AgentSkill
 	4,  // 3: containarium.v1.GetAgentSkillResponse.skill:type_name -> containarium.v1.AgentSkill
-	32, // 4: containarium.v1.RunAgentSkillResponse.container:type_name -> containarium.v1.Container
+	34, // 4: containarium.v1.RunAgentSkillResponse.container:type_name -> containarium.v1.Container
 	0,  // 5: containarium.v1.AgentArtifact.state:type_name -> containarium.v1.AgentTaskState
 	12, // 6: containarium.v1.SendAgentTaskResponse.artifact:type_name -> containarium.v1.AgentArtifact
-	1,  // 7: containarium.v1.Crew.topology:type_name -> containarium.v1.CrewTopology
-	2,  // 8: containarium.v1.CrewRun.state:type_name -> containarium.v1.CrewRunState
-	21, // 9: containarium.v1.ListCrewsResponse.crews:type_name -> containarium.v1.Crew
-	21, // 10: containarium.v1.GetCrewResponse.crew:type_name -> containarium.v1.Crew
-	22, // 11: containarium.v1.RunCrewResponse.run:type_name -> containarium.v1.CrewRun
-	22, // 12: containarium.v1.GetCrewRunResponse.run:type_name -> containarium.v1.CrewRun
-	5,  // 13: containarium.v1.AgentSkillService.ListAgentSkills:input_type -> containarium.v1.ListAgentSkillsRequest
-	7,  // 14: containarium.v1.AgentSkillService.GetAgentSkill:input_type -> containarium.v1.GetAgentSkillRequest
-	9,  // 15: containarium.v1.AgentSkillService.RunAgentSkill:input_type -> containarium.v1.RunAgentSkillRequest
-	13, // 16: containarium.v1.AgentSkillService.SendAgentTask:input_type -> containarium.v1.SendAgentTaskRequest
-	15, // 17: containarium.v1.AgentSkillService.EnqueueAgentTask:input_type -> containarium.v1.EnqueueAgentTaskRequest
-	17, // 18: containarium.v1.AgentSkillService.LeaseAgentTask:input_type -> containarium.v1.LeaseAgentTaskRequest
-	19, // 19: containarium.v1.AgentSkillService.CompleteAgentTask:input_type -> containarium.v1.CompleteAgentTaskRequest
-	23, // 20: containarium.v1.CrewService.ListCrews:input_type -> containarium.v1.ListCrewsRequest
-	25, // 21: containarium.v1.CrewService.GetCrew:input_type -> containarium.v1.GetCrewRequest
-	27, // 22: containarium.v1.CrewService.RunCrew:input_type -> containarium.v1.RunCrewRequest
-	29, // 23: containarium.v1.CrewService.GetCrewRun:input_type -> containarium.v1.GetCrewRunRequest
-	6,  // 24: containarium.v1.AgentSkillService.ListAgentSkills:output_type -> containarium.v1.ListAgentSkillsResponse
-	8,  // 25: containarium.v1.AgentSkillService.GetAgentSkill:output_type -> containarium.v1.GetAgentSkillResponse
-	10, // 26: containarium.v1.AgentSkillService.RunAgentSkill:output_type -> containarium.v1.RunAgentSkillResponse
-	14, // 27: containarium.v1.AgentSkillService.SendAgentTask:output_type -> containarium.v1.SendAgentTaskResponse
-	16, // 28: containarium.v1.AgentSkillService.EnqueueAgentTask:output_type -> containarium.v1.EnqueueAgentTaskResponse
-	18, // 29: containarium.v1.AgentSkillService.LeaseAgentTask:output_type -> containarium.v1.LeaseAgentTaskResponse
-	20, // 30: containarium.v1.AgentSkillService.CompleteAgentTask:output_type -> containarium.v1.CompleteAgentTaskResponse
-	24, // 31: containarium.v1.CrewService.ListCrews:output_type -> containarium.v1.ListCrewsResponse
-	26, // 32: containarium.v1.CrewService.GetCrew:output_type -> containarium.v1.GetCrewResponse
-	28, // 33: containarium.v1.CrewService.RunCrew:output_type -> containarium.v1.RunCrewResponse
-	30, // 34: containarium.v1.CrewService.GetCrewRun:output_type -> containarium.v1.GetCrewRunResponse
-	24, // [24:35] is the sub-list for method output_type
-	13, // [13:24] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	34, // 7: containarium.v1.StartAgentWorkerResponse.container:type_name -> containarium.v1.Container
+	1,  // 8: containarium.v1.Crew.topology:type_name -> containarium.v1.CrewTopology
+	2,  // 9: containarium.v1.CrewRun.state:type_name -> containarium.v1.CrewRunState
+	23, // 10: containarium.v1.ListCrewsResponse.crews:type_name -> containarium.v1.Crew
+	23, // 11: containarium.v1.GetCrewResponse.crew:type_name -> containarium.v1.Crew
+	24, // 12: containarium.v1.RunCrewResponse.run:type_name -> containarium.v1.CrewRun
+	24, // 13: containarium.v1.GetCrewRunResponse.run:type_name -> containarium.v1.CrewRun
+	5,  // 14: containarium.v1.AgentSkillService.ListAgentSkills:input_type -> containarium.v1.ListAgentSkillsRequest
+	7,  // 15: containarium.v1.AgentSkillService.GetAgentSkill:input_type -> containarium.v1.GetAgentSkillRequest
+	9,  // 16: containarium.v1.AgentSkillService.RunAgentSkill:input_type -> containarium.v1.RunAgentSkillRequest
+	13, // 17: containarium.v1.AgentSkillService.SendAgentTask:input_type -> containarium.v1.SendAgentTaskRequest
+	15, // 18: containarium.v1.AgentSkillService.EnqueueAgentTask:input_type -> containarium.v1.EnqueueAgentTaskRequest
+	17, // 19: containarium.v1.AgentSkillService.LeaseAgentTask:input_type -> containarium.v1.LeaseAgentTaskRequest
+	19, // 20: containarium.v1.AgentSkillService.CompleteAgentTask:input_type -> containarium.v1.CompleteAgentTaskRequest
+	21, // 21: containarium.v1.AgentSkillService.StartAgentWorker:input_type -> containarium.v1.StartAgentWorkerRequest
+	25, // 22: containarium.v1.CrewService.ListCrews:input_type -> containarium.v1.ListCrewsRequest
+	27, // 23: containarium.v1.CrewService.GetCrew:input_type -> containarium.v1.GetCrewRequest
+	29, // 24: containarium.v1.CrewService.RunCrew:input_type -> containarium.v1.RunCrewRequest
+	31, // 25: containarium.v1.CrewService.GetCrewRun:input_type -> containarium.v1.GetCrewRunRequest
+	6,  // 26: containarium.v1.AgentSkillService.ListAgentSkills:output_type -> containarium.v1.ListAgentSkillsResponse
+	8,  // 27: containarium.v1.AgentSkillService.GetAgentSkill:output_type -> containarium.v1.GetAgentSkillResponse
+	10, // 28: containarium.v1.AgentSkillService.RunAgentSkill:output_type -> containarium.v1.RunAgentSkillResponse
+	14, // 29: containarium.v1.AgentSkillService.SendAgentTask:output_type -> containarium.v1.SendAgentTaskResponse
+	16, // 30: containarium.v1.AgentSkillService.EnqueueAgentTask:output_type -> containarium.v1.EnqueueAgentTaskResponse
+	18, // 31: containarium.v1.AgentSkillService.LeaseAgentTask:output_type -> containarium.v1.LeaseAgentTaskResponse
+	20, // 32: containarium.v1.AgentSkillService.CompleteAgentTask:output_type -> containarium.v1.CompleteAgentTaskResponse
+	22, // 33: containarium.v1.AgentSkillService.StartAgentWorker:output_type -> containarium.v1.StartAgentWorkerResponse
+	26, // 34: containarium.v1.CrewService.ListCrews:output_type -> containarium.v1.ListCrewsResponse
+	28, // 35: containarium.v1.CrewService.GetCrew:output_type -> containarium.v1.GetCrewResponse
+	30, // 36: containarium.v1.CrewService.RunCrew:output_type -> containarium.v1.RunCrewResponse
+	32, // 37: containarium.v1.CrewService.GetCrewRun:output_type -> containarium.v1.GetCrewRunResponse
+	26, // [26:38] is the sub-list for method output_type
+	14, // [14:26] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_agent_proto_init() }
@@ -2214,7 +2358,7 @@ func file_containarium_v1_agent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_agent_proto_rawDesc), len(file_containarium_v1_agent_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   28,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/pb/containarium/v1/agent.pb.gw.go
+++ b/pkg/pb/containarium/v1/agent.pb.gw.go
@@ -185,6 +185,105 @@ func local_request_AgentSkillService_SendAgentTask_0(ctx context.Context, marsha
 	return msg, metadata, err
 }
 
+func request_AgentSkillService_EnqueueAgentTask_0(ctx context.Context, marshaler runtime.Marshaler, client AgentSkillServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq EnqueueAgentTaskRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.EnqueueAgentTask(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_AgentSkillService_EnqueueAgentTask_0(ctx context.Context, marshaler runtime.Marshaler, server AgentSkillServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq EnqueueAgentTaskRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.EnqueueAgentTask(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_AgentSkillService_LeaseAgentTask_0(ctx context.Context, marshaler runtime.Marshaler, client AgentSkillServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq LeaseAgentTaskRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.LeaseAgentTask(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_AgentSkillService_LeaseAgentTask_0(ctx context.Context, marshaler runtime.Marshaler, server AgentSkillServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq LeaseAgentTaskRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.LeaseAgentTask(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_AgentSkillService_CompleteAgentTask_0(ctx context.Context, marshaler runtime.Marshaler, client AgentSkillServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CompleteAgentTaskRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["task_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "task_id")
+	}
+	protoReq.TaskId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "task_id", err)
+	}
+	msg, err := client.CompleteAgentTask(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_AgentSkillService_CompleteAgentTask_0(ctx context.Context, marshaler runtime.Marshaler, server AgentSkillServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CompleteAgentTaskRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["task_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "task_id")
+	}
+	protoReq.TaskId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "task_id", err)
+	}
+	msg, err := server.CompleteAgentTask(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_CrewService_ListCrews_0(ctx context.Context, marshaler runtime.Marshaler, client CrewServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq ListCrewsRequest
@@ -415,6 +514,66 @@ func RegisterAgentSkillServiceHandlerServer(ctx context.Context, mux *runtime.Se
 		}
 		forward_AgentSkillService_SendAgentTask_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_AgentSkillService_EnqueueAgentTask_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.AgentSkillService/EnqueueAgentTask", runtime.WithHTTPPathPattern("/v1/agent-tasks"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AgentSkillService_EnqueueAgentTask_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_AgentSkillService_EnqueueAgentTask_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_AgentSkillService_LeaseAgentTask_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.AgentSkillService/LeaseAgentTask", runtime.WithHTTPPathPattern("/v1/agent-tasks/lease"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AgentSkillService_LeaseAgentTask_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_AgentSkillService_LeaseAgentTask_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_AgentSkillService_CompleteAgentTask_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.AgentSkillService/CompleteAgentTask", runtime.WithHTTPPathPattern("/v1/agent-tasks/{task_id}/complete"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AgentSkillService_CompleteAgentTask_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_AgentSkillService_CompleteAgentTask_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	return nil
 }
@@ -613,21 +772,78 @@ func RegisterAgentSkillServiceHandlerClient(ctx context.Context, mux *runtime.Se
 		}
 		forward_AgentSkillService_SendAgentTask_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_AgentSkillService_EnqueueAgentTask_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.AgentSkillService/EnqueueAgentTask", runtime.WithHTTPPathPattern("/v1/agent-tasks"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AgentSkillService_EnqueueAgentTask_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_AgentSkillService_EnqueueAgentTask_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_AgentSkillService_LeaseAgentTask_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.AgentSkillService/LeaseAgentTask", runtime.WithHTTPPathPattern("/v1/agent-tasks/lease"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AgentSkillService_LeaseAgentTask_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_AgentSkillService_LeaseAgentTask_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_AgentSkillService_CompleteAgentTask_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.AgentSkillService/CompleteAgentTask", runtime.WithHTTPPathPattern("/v1/agent-tasks/{task_id}/complete"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AgentSkillService_CompleteAgentTask_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_AgentSkillService_CompleteAgentTask_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
 var (
-	pattern_AgentSkillService_ListAgentSkills_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "agent-skills"}, ""))
-	pattern_AgentSkillService_GetAgentSkill_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "agent-skills", "id"}, ""))
-	pattern_AgentSkillService_RunAgentSkill_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "agent-skills", "skill_id", "run"}, ""))
-	pattern_AgentSkillService_SendAgentTask_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "agent-skills", "to_peer_id", "call"}, ""))
+	pattern_AgentSkillService_ListAgentSkills_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "agent-skills"}, ""))
+	pattern_AgentSkillService_GetAgentSkill_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "agent-skills", "id"}, ""))
+	pattern_AgentSkillService_RunAgentSkill_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "agent-skills", "skill_id", "run"}, ""))
+	pattern_AgentSkillService_SendAgentTask_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "agent-skills", "to_peer_id", "call"}, ""))
+	pattern_AgentSkillService_EnqueueAgentTask_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "agent-tasks"}, ""))
+	pattern_AgentSkillService_LeaseAgentTask_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "agent-tasks", "lease"}, ""))
+	pattern_AgentSkillService_CompleteAgentTask_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "agent-tasks", "task_id", "complete"}, ""))
 )
 
 var (
-	forward_AgentSkillService_ListAgentSkills_0 = runtime.ForwardResponseMessage
-	forward_AgentSkillService_GetAgentSkill_0   = runtime.ForwardResponseMessage
-	forward_AgentSkillService_RunAgentSkill_0   = runtime.ForwardResponseMessage
-	forward_AgentSkillService_SendAgentTask_0   = runtime.ForwardResponseMessage
+	forward_AgentSkillService_ListAgentSkills_0   = runtime.ForwardResponseMessage
+	forward_AgentSkillService_GetAgentSkill_0     = runtime.ForwardResponseMessage
+	forward_AgentSkillService_RunAgentSkill_0     = runtime.ForwardResponseMessage
+	forward_AgentSkillService_SendAgentTask_0     = runtime.ForwardResponseMessage
+	forward_AgentSkillService_EnqueueAgentTask_0  = runtime.ForwardResponseMessage
+	forward_AgentSkillService_LeaseAgentTask_0    = runtime.ForwardResponseMessage
+	forward_AgentSkillService_CompleteAgentTask_0 = runtime.ForwardResponseMessage
 )
 
 // RegisterCrewServiceHandlerFromEndpoint is same as RegisterCrewServiceHandler but

--- a/pkg/pb/containarium/v1/agent.pb.gw.go
+++ b/pkg/pb/containarium/v1/agent.pb.gw.go
@@ -284,6 +284,51 @@ func local_request_AgentSkillService_CompleteAgentTask_0(ctx context.Context, ma
 	return msg, metadata, err
 }
 
+func request_AgentSkillService_StartAgentWorker_0(ctx context.Context, marshaler runtime.Marshaler, client AgentSkillServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq StartAgentWorkerRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["skill_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "skill_id")
+	}
+	protoReq.SkillId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "skill_id", err)
+	}
+	msg, err := client.StartAgentWorker(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_AgentSkillService_StartAgentWorker_0(ctx context.Context, marshaler runtime.Marshaler, server AgentSkillServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq StartAgentWorkerRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["skill_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "skill_id")
+	}
+	protoReq.SkillId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "skill_id", err)
+	}
+	msg, err := server.StartAgentWorker(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_CrewService_ListCrews_0(ctx context.Context, marshaler runtime.Marshaler, client CrewServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq ListCrewsRequest
@@ -574,6 +619,26 @@ func RegisterAgentSkillServiceHandlerServer(ctx context.Context, mux *runtime.Se
 		}
 		forward_AgentSkillService_CompleteAgentTask_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_AgentSkillService_StartAgentWorker_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.AgentSkillService/StartAgentWorker", runtime.WithHTTPPathPattern("/v1/agent-skills/{skill_id}/worker"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_AgentSkillService_StartAgentWorker_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_AgentSkillService_StartAgentWorker_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	return nil
 }
@@ -823,6 +888,23 @@ func RegisterAgentSkillServiceHandlerClient(ctx context.Context, mux *runtime.Se
 		}
 		forward_AgentSkillService_CompleteAgentTask_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_AgentSkillService_StartAgentWorker_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.AgentSkillService/StartAgentWorker", runtime.WithHTTPPathPattern("/v1/agent-skills/{skill_id}/worker"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_AgentSkillService_StartAgentWorker_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_AgentSkillService_StartAgentWorker_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -834,6 +916,7 @@ var (
 	pattern_AgentSkillService_EnqueueAgentTask_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "agent-tasks"}, ""))
 	pattern_AgentSkillService_LeaseAgentTask_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "agent-tasks", "lease"}, ""))
 	pattern_AgentSkillService_CompleteAgentTask_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "agent-tasks", "task_id", "complete"}, ""))
+	pattern_AgentSkillService_StartAgentWorker_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "agent-skills", "skill_id", "worker"}, ""))
 )
 
 var (
@@ -844,6 +927,7 @@ var (
 	forward_AgentSkillService_EnqueueAgentTask_0  = runtime.ForwardResponseMessage
 	forward_AgentSkillService_LeaseAgentTask_0    = runtime.ForwardResponseMessage
 	forward_AgentSkillService_CompleteAgentTask_0 = runtime.ForwardResponseMessage
+	forward_AgentSkillService_StartAgentWorker_0  = runtime.ForwardResponseMessage
 )
 
 // RegisterCrewServiceHandlerFromEndpoint is same as RegisterCrewServiceHandler but

--- a/pkg/pb/containarium/v1/agent_grpc.pb.go
+++ b/pkg/pb/containarium/v1/agent_grpc.pb.go
@@ -26,6 +26,7 @@ const (
 	AgentSkillService_EnqueueAgentTask_FullMethodName  = "/containarium.v1.AgentSkillService/EnqueueAgentTask"
 	AgentSkillService_LeaseAgentTask_FullMethodName    = "/containarium.v1.AgentSkillService/LeaseAgentTask"
 	AgentSkillService_CompleteAgentTask_FullMethodName = "/containarium.v1.AgentSkillService/CompleteAgentTask"
+	AgentSkillService_StartAgentWorker_FullMethodName  = "/containarium.v1.AgentSkillService/StartAgentWorker"
 )
 
 // AgentSkillServiceClient is the client API for AgentSkillService service.
@@ -56,6 +57,14 @@ type AgentSkillServiceClient interface {
 	// removes it from the queue. Rejected (accepted=false) if the lease token is
 	// stale — i.e. the lease already expired and the task was redelivered.
 	CompleteAgentTask(ctx context.Context, in *CompleteAgentTaskRequest, opts ...grpc.CallOption) (*CompleteAgentTaskResponse, error)
+	// StartAgentWorker provisions (or reuses) a skill's box and launches the
+	// in-box runtime in poll mode: a long-lived worker that leases tasks for the
+	// skill, runs them, and reports back — the consumer side of the pull model.
+	// The daemon mints a SEPARATE queue credential (a JWT scoped to agents:run,
+	// distinct from the skill's in-box token) and seeds it so the box can reach
+	// the queue endpoints; the worker resolves the daemon URL from its default
+	// route (the backend host) at launch.
+	StartAgentWorker(ctx context.Context, in *StartAgentWorkerRequest, opts ...grpc.CallOption) (*StartAgentWorkerResponse, error)
 }
 
 type agentSkillServiceClient struct {
@@ -136,6 +145,16 @@ func (c *agentSkillServiceClient) CompleteAgentTask(ctx context.Context, in *Com
 	return out, nil
 }
 
+func (c *agentSkillServiceClient) StartAgentWorker(ctx context.Context, in *StartAgentWorkerRequest, opts ...grpc.CallOption) (*StartAgentWorkerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(StartAgentWorkerResponse)
+	err := c.cc.Invoke(ctx, AgentSkillService_StartAgentWorker_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AgentSkillServiceServer is the server API for AgentSkillService service.
 // All implementations must embed UnimplementedAgentSkillServiceServer
 // for forward compatibility.
@@ -164,6 +183,14 @@ type AgentSkillServiceServer interface {
 	// removes it from the queue. Rejected (accepted=false) if the lease token is
 	// stale — i.e. the lease already expired and the task was redelivered.
 	CompleteAgentTask(context.Context, *CompleteAgentTaskRequest) (*CompleteAgentTaskResponse, error)
+	// StartAgentWorker provisions (or reuses) a skill's box and launches the
+	// in-box runtime in poll mode: a long-lived worker that leases tasks for the
+	// skill, runs them, and reports back — the consumer side of the pull model.
+	// The daemon mints a SEPARATE queue credential (a JWT scoped to agents:run,
+	// distinct from the skill's in-box token) and seeds it so the box can reach
+	// the queue endpoints; the worker resolves the daemon URL from its default
+	// route (the backend host) at launch.
+	StartAgentWorker(context.Context, *StartAgentWorkerRequest) (*StartAgentWorkerResponse, error)
 	mustEmbedUnimplementedAgentSkillServiceServer()
 }
 
@@ -194,6 +221,9 @@ func (UnimplementedAgentSkillServiceServer) LeaseAgentTask(context.Context, *Lea
 }
 func (UnimplementedAgentSkillServiceServer) CompleteAgentTask(context.Context, *CompleteAgentTaskRequest) (*CompleteAgentTaskResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CompleteAgentTask not implemented")
+}
+func (UnimplementedAgentSkillServiceServer) StartAgentWorker(context.Context, *StartAgentWorkerRequest) (*StartAgentWorkerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method StartAgentWorker not implemented")
 }
 func (UnimplementedAgentSkillServiceServer) mustEmbedUnimplementedAgentSkillServiceServer() {}
 func (UnimplementedAgentSkillServiceServer) testEmbeddedByValue()                           {}
@@ -342,6 +372,24 @@ func _AgentSkillService_CompleteAgentTask_Handler(srv interface{}, ctx context.C
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AgentSkillService_StartAgentWorker_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StartAgentWorkerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentSkillServiceServer).StartAgentWorker(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AgentSkillService_StartAgentWorker_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentSkillServiceServer).StartAgentWorker(ctx, req.(*StartAgentWorkerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // AgentSkillService_ServiceDesc is the grpc.ServiceDesc for AgentSkillService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -376,6 +424,10 @@ var AgentSkillService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CompleteAgentTask",
 			Handler:    _AgentSkillService_CompleteAgentTask_Handler,
+		},
+		{
+			MethodName: "StartAgentWorker",
+			Handler:    _AgentSkillService_StartAgentWorker_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/pb/containarium/v1/agent_grpc.pb.go
+++ b/pkg/pb/containarium/v1/agent_grpc.pb.go
@@ -19,10 +19,13 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	AgentSkillService_ListAgentSkills_FullMethodName = "/containarium.v1.AgentSkillService/ListAgentSkills"
-	AgentSkillService_GetAgentSkill_FullMethodName   = "/containarium.v1.AgentSkillService/GetAgentSkill"
-	AgentSkillService_RunAgentSkill_FullMethodName   = "/containarium.v1.AgentSkillService/RunAgentSkill"
-	AgentSkillService_SendAgentTask_FullMethodName   = "/containarium.v1.AgentSkillService/SendAgentTask"
+	AgentSkillService_ListAgentSkills_FullMethodName   = "/containarium.v1.AgentSkillService/ListAgentSkills"
+	AgentSkillService_GetAgentSkill_FullMethodName     = "/containarium.v1.AgentSkillService/GetAgentSkill"
+	AgentSkillService_RunAgentSkill_FullMethodName     = "/containarium.v1.AgentSkillService/RunAgentSkill"
+	AgentSkillService_SendAgentTask_FullMethodName     = "/containarium.v1.AgentSkillService/SendAgentTask"
+	AgentSkillService_EnqueueAgentTask_FullMethodName  = "/containarium.v1.AgentSkillService/EnqueueAgentTask"
+	AgentSkillService_LeaseAgentTask_FullMethodName    = "/containarium.v1.AgentSkillService/LeaseAgentTask"
+	AgentSkillService_CompleteAgentTask_FullMethodName = "/containarium.v1.AgentSkillService/CompleteAgentTask"
 )
 
 // AgentSkillServiceClient is the client API for AgentSkillService service.
@@ -42,6 +45,17 @@ type AgentSkillServiceClient interface {
 	// the peer's artifact. Phase 1 establishes the transport; Phase 2 adds the
 	// allowed_peers / network-policy enforcement around it. (Server impl: #569.)
 	SendAgentTask(ctx context.Context, in *SendAgentTaskRequest, opts ...grpc.CallOption) (*SendAgentTaskResponse, error)
+	// EnqueueAgentTask places a task on the queue for the given skill and returns
+	// its id. Producer side of the pull model.
+	EnqueueAgentTask(ctx context.Context, in *EnqueueAgentTaskRequest, opts ...grpc.CallOption) (*EnqueueAgentTaskResponse, error)
+	// LeaseAgentTask hands the caller the next visible task (optionally filtered
+	// to one skill), making it invisible for lease_seconds. Returns has_task=false
+	// when the queue is empty. Worker poll side of the pull model.
+	LeaseAgentTask(ctx context.Context, in *LeaseAgentTaskRequest, opts ...grpc.CallOption) (*LeaseAgentTaskResponse, error)
+	// CompleteAgentTask reports a leased task's result (artifact or error) and
+	// removes it from the queue. Rejected (accepted=false) if the lease token is
+	// stale — i.e. the lease already expired and the task was redelivered.
+	CompleteAgentTask(ctx context.Context, in *CompleteAgentTaskRequest, opts ...grpc.CallOption) (*CompleteAgentTaskResponse, error)
 }
 
 type agentSkillServiceClient struct {
@@ -92,6 +106,36 @@ func (c *agentSkillServiceClient) SendAgentTask(ctx context.Context, in *SendAge
 	return out, nil
 }
 
+func (c *agentSkillServiceClient) EnqueueAgentTask(ctx context.Context, in *EnqueueAgentTaskRequest, opts ...grpc.CallOption) (*EnqueueAgentTaskResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(EnqueueAgentTaskResponse)
+	err := c.cc.Invoke(ctx, AgentSkillService_EnqueueAgentTask_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *agentSkillServiceClient) LeaseAgentTask(ctx context.Context, in *LeaseAgentTaskRequest, opts ...grpc.CallOption) (*LeaseAgentTaskResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(LeaseAgentTaskResponse)
+	err := c.cc.Invoke(ctx, AgentSkillService_LeaseAgentTask_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *agentSkillServiceClient) CompleteAgentTask(ctx context.Context, in *CompleteAgentTaskRequest, opts ...grpc.CallOption) (*CompleteAgentTaskResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CompleteAgentTaskResponse)
+	err := c.cc.Invoke(ctx, AgentSkillService_CompleteAgentTask_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AgentSkillServiceServer is the server API for AgentSkillService service.
 // All implementations must embed UnimplementedAgentSkillServiceServer
 // for forward compatibility.
@@ -109,6 +153,17 @@ type AgentSkillServiceServer interface {
 	// the peer's artifact. Phase 1 establishes the transport; Phase 2 adds the
 	// allowed_peers / network-policy enforcement around it. (Server impl: #569.)
 	SendAgentTask(context.Context, *SendAgentTaskRequest) (*SendAgentTaskResponse, error)
+	// EnqueueAgentTask places a task on the queue for the given skill and returns
+	// its id. Producer side of the pull model.
+	EnqueueAgentTask(context.Context, *EnqueueAgentTaskRequest) (*EnqueueAgentTaskResponse, error)
+	// LeaseAgentTask hands the caller the next visible task (optionally filtered
+	// to one skill), making it invisible for lease_seconds. Returns has_task=false
+	// when the queue is empty. Worker poll side of the pull model.
+	LeaseAgentTask(context.Context, *LeaseAgentTaskRequest) (*LeaseAgentTaskResponse, error)
+	// CompleteAgentTask reports a leased task's result (artifact or error) and
+	// removes it from the queue. Rejected (accepted=false) if the lease token is
+	// stale — i.e. the lease already expired and the task was redelivered.
+	CompleteAgentTask(context.Context, *CompleteAgentTaskRequest) (*CompleteAgentTaskResponse, error)
 	mustEmbedUnimplementedAgentSkillServiceServer()
 }
 
@@ -130,6 +185,15 @@ func (UnimplementedAgentSkillServiceServer) RunAgentSkill(context.Context, *RunA
 }
 func (UnimplementedAgentSkillServiceServer) SendAgentTask(context.Context, *SendAgentTaskRequest) (*SendAgentTaskResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SendAgentTask not implemented")
+}
+func (UnimplementedAgentSkillServiceServer) EnqueueAgentTask(context.Context, *EnqueueAgentTaskRequest) (*EnqueueAgentTaskResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method EnqueueAgentTask not implemented")
+}
+func (UnimplementedAgentSkillServiceServer) LeaseAgentTask(context.Context, *LeaseAgentTaskRequest) (*LeaseAgentTaskResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method LeaseAgentTask not implemented")
+}
+func (UnimplementedAgentSkillServiceServer) CompleteAgentTask(context.Context, *CompleteAgentTaskRequest) (*CompleteAgentTaskResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CompleteAgentTask not implemented")
 }
 func (UnimplementedAgentSkillServiceServer) mustEmbedUnimplementedAgentSkillServiceServer() {}
 func (UnimplementedAgentSkillServiceServer) testEmbeddedByValue()                           {}
@@ -224,6 +288,60 @@ func _AgentSkillService_SendAgentTask_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AgentSkillService_EnqueueAgentTask_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EnqueueAgentTaskRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentSkillServiceServer).EnqueueAgentTask(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AgentSkillService_EnqueueAgentTask_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentSkillServiceServer).EnqueueAgentTask(ctx, req.(*EnqueueAgentTaskRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AgentSkillService_LeaseAgentTask_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(LeaseAgentTaskRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentSkillServiceServer).LeaseAgentTask(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AgentSkillService_LeaseAgentTask_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentSkillServiceServer).LeaseAgentTask(ctx, req.(*LeaseAgentTaskRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AgentSkillService_CompleteAgentTask_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CompleteAgentTaskRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentSkillServiceServer).CompleteAgentTask(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AgentSkillService_CompleteAgentTask_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentSkillServiceServer).CompleteAgentTask(ctx, req.(*CompleteAgentTaskRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // AgentSkillService_ServiceDesc is the grpc.ServiceDesc for AgentSkillService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -246,6 +364,18 @@ var AgentSkillService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SendAgentTask",
 			Handler:    _AgentSkillService_SendAgentTask_Handler,
+		},
+		{
+			MethodName: "EnqueueAgentTask",
+			Handler:    _AgentSkillService_EnqueueAgentTask_Handler,
+		},
+		{
+			MethodName: "LeaseAgentTask",
+			Handler:    _AgentSkillService_LeaseAgentTask_Handler,
+		},
+		{
+			MethodName: "CompleteAgentTask",
+			Handler:    _AgentSkillService_CompleteAgentTask_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/containarium/v1/agent.proto
+++ b/proto/containarium/v1/agent.proto
@@ -246,6 +246,115 @@ service AgentSkillService {
       tags: "Agents";
     };
   }
+
+  // ===========================================================================
+  // Pull-based run queue (prototype). The push path (RunAgentSkill) provisions
+  // a box and execs the run synchronously. The pull path inverts it: a producer
+  // ENQUEUES a task; long-lived worker boxes LEASE tasks (outbound-only, so no
+  // inbound exec is needed — NAT/tunnel-friendly), run them locally, and report
+  // back with COMPLETE. Lease = an SQS-style visibility timeout: a leased task
+  // is invisible to other workers until completed or the lease expires (then it
+  // is redelivered), giving at-most-one active worker per task with crash
+  // recovery. Phase 0 is an in-memory queue; durability is a follow-up.
+  // See the pull-queue section of docs/AGENT-MODEL-GATEWAY-DESIGN.md.
+  // ===========================================================================
+
+  // EnqueueAgentTask places a task on the queue for the given skill and returns
+  // its id. Producer side of the pull model.
+  rpc EnqueueAgentTask(EnqueueAgentTaskRequest) returns (EnqueueAgentTaskResponse) {
+    option (google.api.http) = {
+      post: "/v1/agent-tasks"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Enqueue an agent task (pull queue)";
+      description: "Places a task on the pull queue for a skill; worker boxes lease and run it.";
+      tags: "Agents";
+    };
+  }
+
+  // LeaseAgentTask hands the caller the next visible task (optionally filtered
+  // to one skill), making it invisible for lease_seconds. Returns has_task=false
+  // when the queue is empty. Worker poll side of the pull model.
+  rpc LeaseAgentTask(LeaseAgentTaskRequest) returns (LeaseAgentTaskResponse) {
+    option (google.api.http) = {
+      post: "/v1/agent-tasks/lease"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Lease the next agent task (pull queue)";
+      description: "Worker boxes poll this to lease the next task; the task is hidden from other workers until completed or the lease expires.";
+      tags: "Agents";
+    };
+  }
+
+  // CompleteAgentTask reports a leased task's result (artifact or error) and
+  // removes it from the queue. Rejected (accepted=false) if the lease token is
+  // stale — i.e. the lease already expired and the task was redelivered.
+  rpc CompleteAgentTask(CompleteAgentTaskRequest) returns (CompleteAgentTaskResponse) {
+    option (google.api.http) = {
+      post: "/v1/agent-tasks/{task_id}/complete"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Complete a leased agent task (pull queue)";
+      description: "Worker boxes report a leased task's artifact/error here; a stale lease is rejected.";
+      tags: "Agents";
+    };
+  }
+}
+
+// EnqueueAgentTaskRequest places one task on the pull queue.
+message EnqueueAgentTaskRequest {
+  // Skill this task is for (workers may filter their lease by it).
+  string skill_id = 1;
+  // Task input as JSON (the same shape RunAgentSkill takes as input_json).
+  string input_json = 2;
+}
+
+message EnqueueAgentTaskResponse {
+  // Server-assigned task id, used later to correlate the completion.
+  string task_id = 1;
+}
+
+// LeaseAgentTaskRequest asks for the next runnable task.
+message LeaseAgentTaskRequest {
+  // Stable id of the polling worker (audit/debug; not a security boundary).
+  string worker_id = 1;
+  // Optional: lease only tasks for this skill. Empty = any skill.
+  string skill_id = 2;
+  // How long the lease is held before the task becomes visible again. 0 = a
+  // server default. Keep it longer than the worst-case run time.
+  int32 lease_seconds = 3;
+}
+
+message LeaseAgentTaskResponse {
+  // False when the queue had nothing visible — the worker should back off.
+  bool has_task = 1;
+  string task_id = 2;
+  string skill_id = 3;
+  string input_json = 4;
+  // Opaque token proving this worker holds the current lease; must be presented
+  // to CompleteAgentTask. A new lease (after expiry) mints a new token, so a
+  // slow worker's stale completion is rejected rather than clobbering a retry.
+  string lease_token = 5;
+}
+
+// CompleteAgentTaskRequest reports a leased task's outcome.
+message CompleteAgentTaskRequest {
+  string task_id = 1;
+  string lease_token = 2;
+  // The run artifact as JSON; empty when error is set.
+  string artifact_json = 3;
+  // Non-empty when the run failed; the task is removed (no auto-retry in the
+  // prototype) and the error is recorded.
+  string error = 4;
+}
+
+message CompleteAgentTaskResponse {
+  // False when the lease was stale (expired + redelivered); the worker should
+  // drop its result — another lease owns the task now.
+  bool accepted = 1;
 }
 
 // =============================================================================

--- a/proto/containarium/v1/agent.proto
+++ b/proto/containarium/v1/agent.proto
@@ -302,6 +302,25 @@ service AgentSkillService {
       tags: "Agents";
     };
   }
+
+  // StartAgentWorker provisions (or reuses) a skill's box and launches the
+  // in-box runtime in poll mode: a long-lived worker that leases tasks for the
+  // skill, runs them, and reports back — the consumer side of the pull model.
+  // The daemon mints a SEPARATE queue credential (a JWT scoped to agents:run,
+  // distinct from the skill's in-box token) and seeds it so the box can reach
+  // the queue endpoints; the worker resolves the daemon URL from its default
+  // route (the backend host) at launch.
+  rpc StartAgentWorker(StartAgentWorkerRequest) returns (StartAgentWorkerResponse) {
+    option (google.api.http) = {
+      post: "/v1/agent-skills/{skill_id}/worker"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Start a pull-queue worker for a skill";
+      description: "Provisions the skill's box, mints an agents:run queue credential, and launches the in-box runtime in poll mode to lease and run queued tasks.";
+      tags: "Agents";
+    };
+  }
 }
 
 // EnqueueAgentTaskRequest places one task on the pull queue.
@@ -355,6 +374,26 @@ message CompleteAgentTaskResponse {
   // False when the lease was stale (expired + redelivered); the worker should
   // drop its result — another lease owns the task now.
   bool accepted = 1;
+}
+
+// StartAgentWorkerRequest launches a poll-mode worker for a skill.
+message StartAgentWorkerRequest {
+  // Skill whose box runs as the worker (its persona is the worker's; the
+  // worker leases only this skill's tasks).
+  string skill_id = 1;
+  // Target backend (must be local in the prototype).
+  string backend_id = 2;
+  // Target pool (unsupported in the prototype).
+  string pool = 3;
+  // Optional stable worker id for audit/debug; defaults to the box name.
+  string worker_id = 4;
+}
+
+message StartAgentWorkerResponse {
+  // The worker box.
+  Container container = 1;
+  // The worker id the daemon used.
+  string worker_id = 2;
 }
 
 // =============================================================================


### PR DESCRIPTION
> **Draft / RFC.** The design note is explicitly *exploration, not yet approved*; the queue is a Phase-0 prototype. Opened for review, not merge.

Follows from a design discussion on whether to run the `claude` CLI per box to "avoid API calling." Conclusion: the only thing that avoids metered billing is subscription auth, which is against per-seat terms for a container fleet and is being closed off — so the ToS-clean wins (cost, key custody, metering) come from **centralizing**, not subscriptions. This PR captures that as a design + prototypes the orthogonal "pull instead of push" idea, **including worker-credential minting so poll mode runs end-to-end.**

## 1. Model-gateway design note — `docs/AGENT-MODEL-GATEWAY-DESIGN.md`

A daemon-side gateway that holds the **one** provider API key and brokers every box's model calls: key never in a box, **per-tenant token metering** (the writer the metering plane lacks), central model-tiering, shared prompt cache, rate-limit. Boxes point the **existing** Agent SDK at it via `ANTHROPIC_BASE_URL` + a short-lived scoped token — an **env change, not a code change**. Phased 0–4. Explicitly **not** a subscription-auth bridge.

## 2. Pull-based run-queue prototype (push → pull, outbound-only)

A producer **enqueues**; long-lived worker boxes **lease** tasks, run locally, **complete**.

- **proto**: `EnqueueAgentTask` / `LeaseAgentTask` / `CompleteAgentTask` on `AgentSkillService`. SQS-style visibility-timeout lease → at-most-one active worker per task, redelivery on expiry, stale-token completion rejected.
- **queue core** (`internal/server/agent_task_queue.go`): in-memory, lock-guarded FIFO, injectable clock. **Unit-tested, race-clean**.
- **producer**: `containarium agent enqueue` + clients.
- **worker runtime**: `agent-runtime` `poll` mode (`poll.ts`, `CONTAINARIUM_AGENT_MODE=poll`) — lease → run → complete, reusing the A2A `runTask`.

## 3. Worker-credential minting — poll mode end-to-end

- **proto**: `StartAgentWorker` RPC.
- **server**: provisions/reuses the skill box, then **mints a queue credential** — a JWT scoped to `agents:run` *only*, separate from the skill's in-box token (leasing is a runtime action the skill's scopes don't grant) — and launches poll mode with the credential + daemon URL seeded as env. `buildWorkerPollCommand` resolves the daemon host from the box's **default route** at launch, so the daemon needn't know the bridge address.
- **CLI**: `containarium agent worker <skill>` + clients.
- **end-to-end test**: the full producer→worker loop (enqueue → lease → run → complete) driven through the **real RPC handlers with a real `agents:run` credential context** — proves credential-scoped auth + queue threading, the cross-RPC stale-lease guard, and the `agents:run` gate on every op.

```
containarium agent worker  hello-agent --server <host>     # start a poll-mode worker
containarium agent enqueue hello-agent --input '{"q":…}' --server <host>   # produce
```

## Deferred (documented, intentional)
Credential lifetime (30m TTL → long-lived worker needs refresh, same question the gateway token raises); worker-box egress allowance to the daemon host:port when eBPF enforce is on; queue durability across restart; per-tenant fairness + dead-letter. **One remaining acceptance step**: a live box→daemon transport check (gateway resolution + reachability) — not run here.

## Testing
`go build ./...` clean; queue + RPC tests pass under `-race`; `agent worker` / `agent enqueue` CLI render; proto/swagger regenerated; `poll.ts` typechecks (SDK-free subgraph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)