### PR TITLE
feat(cli): target-aware host-level commands (refuse on hosted control plane)

### DIFF
--- a/internal/cmd/backends_upgrade.go
+++ b/internal/cmd/backends_upgrade.go
@@ -58,6 +58,11 @@ type triggerUpgradeResp struct {
 }
 
 func runBackendsUpgrade(cmd *cobra.Command, args []string) error {
+	// Control-plane upgrades are operator-owned; not a tenant op on the
+	// hosted control plane (#456).
+	if isCloudTarget(serverAddr, authToken) {
+		return errUnsupportedOnCloud("backends upgrade", "the platform operator owns control-plane upgrades")
+	}
 	if serverAddr == "" {
 		return fmt.Errorf("--server is required (the platform daemon's HTTP address, e.g. http://host:8080)")
 	}

--- a/internal/cmd/backends_versions.go
+++ b/internal/cmd/backends_versions.go
@@ -79,6 +79,11 @@ func backendVersionStatus(current, latest string) string {
 }
 
 func runBackendsVersions(cmd *cobra.Command, args []string) error {
+	// Backend version / release checks are operator-owned on the hosted
+	// control plane (the platform keeps it current) — refuse client-side (#456).
+	if isCloudTarget(serverAddr, authToken) {
+		return errUnsupportedOnCloud("backends versions", "the platform keeps the control plane current")
+	}
 	if serverAddr == "" {
 		return fmt.Errorf("--server is required (the platform daemon's HTTP address, e.g. http://host:8080)")
 	}

--- a/internal/cmd/cloud_target.go
+++ b/internal/cmd/cloud_target.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/footprintai/containarium/internal/credentials"
+)
+
+// isCloudTarget reports whether the effective (server, token) points at the
+// hosted control plane, where host-level operations — system info, per-box
+// debug, control-plane upgrade / release checks — are not available per
+// tenant. Host-level CLI commands call this to refuse CLIENT-SIDE with a clear
+// message instead of round-tripping to an opaque 404.
+//
+// Two signals, mirroring the MCP backend classifier (#456):
+//   - the token's shape — a `ctnr_` API key is a one-way cloud signal; and
+//   - the cached AccessModel for the server (AccessModelToken == cloud), which
+//     catches a cloud login whose token isn't prefix-identifiable.
+func isCloudTarget(server, token string) bool {
+	if credentials.IsCloudToken(token) {
+		return true
+	}
+	return accessModelFor(server) == credentials.AccessModelToken
+}
+
+// errUnsupportedOnCloud is the clear, actionable error a host-level command
+// returns when pointed at the hosted control plane. `alt` names what to use
+// instead (may be empty).
+func errUnsupportedOnCloud(op, alt string) error {
+	msg := fmt.Sprintf("%s is a host-level operation and is not available on the hosted control plane", op)
+	if alt != "" {
+		msg += "; " + alt
+	}
+	return errors.New(msg)
+}

--- a/internal/cmd/cloud_target_test.go
+++ b/internal/cmd/cloud_target_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/credentials"
+)
+
+func TestIsCloudTarget(t *testing.T) {
+	// A `ctnr_` token is a one-way cloud signal, independent of any creds file.
+	if !isCloudTarget("https://anything", "ctnr_abc.def") {
+		t.Fatal("ctnr_ token must classify as cloud")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	_ = seedCreds(t, home, "", map[string]credentials.ServerCreds{
+		"https://cloud.example":  {Token: "eyJcloud", AccessModel: credentials.AccessModelToken},
+		"https://daemon.example": {Token: "eyJdaemon", AccessModel: credentials.AccessModelSSHKey},
+	})
+
+	// A cloud login whose token isn't prefix-identifiable → cloud via AccessModel.
+	if !isCloudTarget("https://cloud.example", "eyJcloud") {
+		t.Error("server with AccessModelToken must classify as cloud")
+	}
+	// Self-hosted AccessModel + a JWT → not cloud.
+	if isCloudTarget("https://daemon.example", "eyJdaemon") {
+		t.Error("server with AccessModelSSHKey must NOT classify as cloud")
+	}
+	// Unknown server + a JWT → not cloud.
+	if isCloudTarget("https://unknown.example", "eyJrandom") {
+		t.Error("unknown server + JWT must NOT classify as cloud")
+	}
+}
+
+func TestErrUnsupportedOnCloud(t *testing.T) {
+	err := errUnsupportedOnCloud("system info", "use `containarium backends`")
+	if err == nil || !strings.Contains(err.Error(), "not available on the hosted control plane") {
+		t.Fatalf("err = %v, want the host-level marker", err)
+	}
+	if !strings.Contains(err.Error(), "use `containarium backends`") {
+		t.Errorf("err = %q, want the alternative suggestion appended", err)
+	}
+}

--- a/internal/cmd/debug.go
+++ b/internal/cmd/debug.go
@@ -41,6 +41,11 @@ func init() {
 
 func runDebug(cmd *cobra.Command, args []string) error {
 	username := args[0]
+	// debug reads a box's host-level diagnostics (sshd journal, shell); the
+	// hosted control plane has no per-tenant equivalent (#456).
+	if isCloudTarget(serverAddr, authToken) {
+		return errUnsupportedOnCloud("debug", "use `containarium connect "+username+"` to inspect the box")
+	}
 
 	report, err := fetchDebugReport(username)
 	if err != nil {

--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -53,6 +53,11 @@ func runInfo(cmd *cobra.Command, args []string) error {
 }
 
 func showSystemInfo() error {
+	// System info is a host-level view; the hosted control plane has no
+	// per-tenant equivalent. Refuse client-side (#456) rather than 404.
+	if isCloudTarget(serverAddr, authToken) {
+		return errUnsupportedOnCloud("system info", "use `containarium backends` for the fleet view")
+	}
 	fmt.Println("=== Containarium System Information ===")
 	fmt.Println()
 

--- a/internal/credentials/cloud_token_test.go
+++ b/internal/credentials/cloud_token_test.go
@@ -1,0 +1,22 @@
+package credentials
+
+import "testing"
+
+func TestIsCloudToken(t *testing.T) {
+	cases := []struct {
+		tok  string
+		want bool
+	}{
+		{"ctnr_abc.def", true},
+		{"  ctnr_abc  ", true}, // surrounding whitespace trimmed
+		{"eyJhbGciOiJIUzI1NiJ9.x.y", false}, // a JWT
+		{"", false},
+		{"ctnr", false},   // prefix must include the underscore
+		{"xctnr_", false}, // prefix must be at the start
+	}
+	for _, c := range cases {
+		if got := IsCloudToken(c.tok); got != c.want {
+			t.Errorf("IsCloudToken(%q) = %v, want %v", c.tok, got, c.want)
+		}
+	}
+}

--- a/internal/credentials/cloud_token_test.go
+++ b/internal/credentials/cloud_token_test.go
@@ -8,7 +8,7 @@ func TestIsCloudToken(t *testing.T) {
 		want bool
 	}{
 		{"ctnr_abc.def", true},
-		{"  ctnr_abc  ", true}, // surrounding whitespace trimmed
+		{"  ctnr_abc  ", true},              // surrounding whitespace trimmed
 		{"eyJhbGciOiJIUzI1NiJ9.x.y", false}, // a JWT
 		{"", false},
 		{"ctnr", false},   // prefix must include the underscore

--- a/internal/credentials/store.go
+++ b/internal/credentials/store.go
@@ -54,6 +54,24 @@ func (m AccessModel) Known() bool {
 	return m == AccessModelToken || m == AccessModelSSHKey
 }
 
+// APITokenPrefix is the prefix the hosted control plane mints its API tokens
+// with. It is a ONE-WAY target signal: only the control plane issues it, so a
+// credential carrying it unambiguously targets the cloud. A bare JWT (`eyJ…`)
+// is ambiguous — a self-hosted daemon and the cloud both accept JWTs — so it
+// is NOT a cloud signal on its own (fall back to the stored AccessModel).
+//
+// Single source of truth for both the MCP backend classifier and the CLI's
+// target-aware command guards.
+const APITokenPrefix = "ctnr_"
+
+// IsCloudToken reports whether a credential is a hosted-control-plane API key,
+// purely from its shape (the APITokenPrefix). One-way: true ⇒ cloud; false ⇒
+// unknown (could be a daemon JWT or a cloud JWT), so callers that have the
+// server URL should also consult the cached AccessModel.
+func IsCloudToken(token string) bool {
+	return strings.HasPrefix(strings.TrimSpace(token), APITokenPrefix)
+}
+
 type ServerCreds struct {
 	Token     string     `json:"token"`
 	UserEmail string     `json:"user_email"`

--- a/internal/mcp/backend.go
+++ b/internal/mcp/backend.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
+
+	"github.com/footprintai/containarium/internal/credentials"
 )
 
 // API is the contract the MCP tool handlers consume. It has two
@@ -100,18 +101,6 @@ var (
 	_ API = cloudClient{}
 )
 
-// apiTokenPrefix is the prefix the hosted control plane mints API tokens with
-// (the cloud's auth.APITokenPrefix). It is a ONE-WAY signal: only the cloud
-// issues it, so a credential carrying it unambiguously targets the cloud. A
-// bare JWT (`eyJ…`) is ambiguous — a daemon and the cloud both accept JWTs —
-// so it falls through to the daemon backend.
-const apiTokenPrefix = "ctnr_"
-
-// isCloudToken reports whether a credential is a hosted-control-plane API key.
-func isCloudToken(token string) bool {
-	return strings.HasPrefix(strings.TrimSpace(token), apiTokenPrefix)
-}
-
 // cloudClient is the hosted-control-plane backend. It embeds *Client for the
 // shared surface (create / list / expose / … map identically through the
 // cloud's OSS-compatible REST shim) and overrides ONLY the host-level
@@ -160,7 +149,7 @@ func newBackend(cfg *Config) API {
 		base.SetTokenFile(cfg.JWTTokenFile)
 	}
 	tok, _ := base.readToken()
-	if isCloudToken(tok) {
+	if credentials.IsCloudToken(tok) {
 		return cloudClient{base}
 	}
 	return base


### PR DESCRIPTION
## What

Folds the CLI under the same **target classification** as the MCP backend (#676 / design #456). A host-level command pointed at the hosted control plane now refuses **client-side** with a clear *"… is not available on the hosted control plane"* message, instead of round-tripping to the opaque `code:5` 404 that started #675.

## Changes

- **`credentials`** — add `APITokenPrefix` (`ctnr_`) + `IsCloudToken(token)` as the **single source of truth** for the classifier. The MCP backend (`internal/mcp/backend.go`) now calls it and drops its local copy, so the prefix can't drift between the two consumers.
- **`internal/cmd`** — add `isCloudTarget(server, token)`:
  - `ctnr_` token prefix (one-way: only the control plane issues it), **or**
  - the cached `credentials.AccessModel == token` for the server (catches a cloud login whose token isn't prefix-identifiable).
  - plus a shared `errUnsupportedOnCloud(op, alt)` helper.
- **Guard the four host-level commands** — `info` (system info), `debug`, `backends upgrade`, `backends versions`. Each refuses only when the target is cloud.

## Scope notes

- **Local / self-hosted-daemon targets are unaffected** — only a cloud target refuses. `info <container>` (box-level) still works on cloud (it's not host-level).
- Satisfies **precondition 2** of the cloud-side shadow-handler retire (Containarium-cloud#457): with both the MCP (#676) and now the CLI target-aware, the server no longer needs to politely 501 for these paths.

## Tests

- `credentials.IsCloudToken` — prefix matching incl. whitespace/edge cases.
- `cmd.isCloudTarget` — prefix branch + AccessModel branch (token / sshKey / unknown) via a temp HOME + seeded creds file; `errUnsupportedOnCloud` message shape.

`go build ./...`, `go vet`, and the `credentials` + `mcp` + `cmd` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
