### PR TITLE
feat: backend capacity advertise/withdraw, capability profile, graceful drain, signed self-measurement (#680–#683)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -2597,6 +2597,39 @@
         ]
       }
     },
+    "/v1/integrity/self-measurement": {
+      "get": {
+        "summary": "Get a backend's signed integrity self-measurement",
+        "description": "Computes and signs a fresh integrity self-measurement (daemon binary digest, loaded in-kernel program object digests, policy/config-state digest) with the node's identity key. The daemon also emits this on its heartbeat. Admin-only.",
+        "operationId": "ContainerService_GetSelfMeasurement",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetSelfMeasurementResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "backendId",
+            "description": "Backend to measure. Empty = the local/primary daemon's own host; a peer id\nforwards to that peer (which measures itself).",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "System"
+        ]
+      }
+    },
     "/v1/kms/envelope-coverage": {
       "get": {
         "summary": "Count secrets by encryption mode (legacy vs envelope)",
@@ -8149,6 +8182,19 @@
         }
       }
     },
+    "GetSelfMeasurementResponse": {
+      "type": "object",
+      "properties": {
+        "measurement": {
+          "$ref": "#/definitions/SelfMeasurement"
+        },
+        "backendId": {
+          "type": "string",
+          "description": "Echoes the measured backend (\"\" = local)."
+        }
+      },
+      "description": "GetSelfMeasurementResponse returns the freshly computed signed measurement."
+    },
     "GetSystemInfoResponse": {
       "type": "object",
       "properties": {
@@ -9455,6 +9501,20 @@
       },
       "description": "ProfileBackendResponse returns the freshly recorded capability profile."
     },
+    "ProgramDigest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Stable name/path identifying the program object (e.g. the configured BPF\nobject path)."
+        },
+        "digest": {
+          "type": "string",
+          "description": "Hex-encoded digest of the program object bytes."
+        }
+      },
+      "description": "ProgramDigest is one loaded in-kernel program object's identity + digest."
+    },
     "Protocol": {
       "type": "string",
       "enum": [
@@ -10128,6 +10188,64 @@
         }
       },
       "description": "SecretMetadata is the public-safe view of a stored secret.\n`value` is never returned by `ListSecrets` — only per-name `GetSecret`."
+    },
+    "SelfMeasurement": {
+      "type": "object",
+      "properties": {
+        "hashAlgorithm": {
+          "type": "string",
+          "description": "Hash algorithm used for every component digest below (e.g. \"sha256\")."
+        },
+        "binaryDigest": {
+          "type": "string",
+          "description": "Hex-encoded digest of the running daemon binary on disk."
+        },
+        "programDigests": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ProgramDigest"
+          },
+          "description": "Hex-encoded digests of the loaded in-kernel network-policy program\nobject(s), in stable (sorted) order. Empty when no program object is\nconfigured on this backend."
+        },
+        "configDigest": {
+          "type": "string",
+          "description": "Hex-encoded digest of the canonicalized policy/config state (the\nintegrity-relevant daemon configuration + active network-policy posture)."
+        },
+        "measurementDigest": {
+          "type": "string",
+          "description": "Hex-encoded digest of the canonical measurement bytes that were signed\n(binds all components together). The signature below covers exactly these\nbytes."
+        },
+        "signature": {
+          "type": "string",
+          "description": "Signature over the canonical measurement bytes, base64-encoded."
+        },
+        "signatureAlgorithm": {
+          "type": "string",
+          "description": "Signature scheme used (e.g. \"ecdsa-p256-sha256\"). Empty when the daemon had\nno identity key available and the measurement is unsigned (signature empty)."
+        },
+        "tpmBacked": {
+          "type": "boolean",
+          "description": "Whether the signature was produced by a TPM-backed key. False = the\nsoftware identity key (sentinel-issued peer leaf) signed it."
+        },
+        "signed": {
+          "type": "boolean",
+          "description": "Whether an identity key was available to sign. False means the measurement\nis present but unsigned (no peer PKI bootstrapped yet); the control plane\ntreats an unsigned measurement as unverifiable, not as tamper."
+        },
+        "signingCertPem": {
+          "type": "string",
+          "description": "PEM of the signing certificate (the peer leaf), so the control plane can\nverify the signature against the sentinel CA chain without a side lookup.\nEmpty when unsigned."
+        },
+        "measuredAt": {
+          "type": "string",
+          "description": "RFC3339 timestamp the measurement was taken."
+        },
+        "daemonVersion": {
+          "type": "string",
+          "description": "Daemon version that produced the measurement."
+        }
+      },
+      "description": "SelfMeasurement is a backend's signed integrity attestation, emitted by the\ndaemon on its heartbeat. It hashes the daemon's own binary, the loaded\nin-kernel network-policy program object(s), and the policy/config state, then\nsigns the canonical measurement with the node's identity key (the\nsentinel-issued peer leaf key reused from the peer-PKI plumbing; TPM-backed\nwhen a TPM is present, software-signed otherwise). The control plane reads\nthis through the backend surface to detect tampering of a backend's control\nplane out of band of the backend's own reporting. The node-side half only:\nthe control plane's verification/quarantine logic lives elsewhere. See #683."
     },
     "SendAgentTaskBody": {
       "type": "object",

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -1183,6 +1183,23 @@
             }
           }
         },
+        "parameters": [
+          {
+            "name": "drain",
+            "description": "When true the backend also reclaims the guest workloads it had implicitly\noffered, draining them gracefully within a bounded window instead of\nhard-killing them. Each drained workload is stopped through the normal\nstop path so the control plane observes a stop event and can reschedule.\nWhen false (default) withdraw only flips the advertisement off and leaves\nrunning guests untouched. See #682.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "drainWindowSeconds",
+            "description": "Bounded wall-clock budget (seconds) for the graceful drain. Once exhausted\nany still-running candidate is force-stopped so the host is reliably\nreclaimed (no wedge on repeated advertise/withdraw cycles). 0 applies the\nbackend default (120s). Only honored when drain is true.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
         "tags": [
           "System"
         ]
@@ -11163,6 +11180,24 @@
         "headroom": {
           "$ref": "#/definitions/CapacityHeadroom",
           "description": "The post-withdraw headroom (advertised=false)."
+        },
+        "drained": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Container names that drained gracefully within the window. Empty unless\nthe request set drain. See #682."
+        },
+        "forceStopped": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Container names that were force-stopped because the bounded window was\nexhausted before they stopped gracefully."
+        },
+        "drainWindowExceeded": {
+          "type": "boolean",
+          "description": "True when the graceful budget was exhausted and the backend fell back to\nforce-stopping the remaining workloads."
         }
       },
       "description": "WithdrawCapacityResponse confirms the backend is no longer advertising."

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -1076,6 +1076,72 @@
         ]
       }
     },
+    "/v1/capabilities/profile": {
+      "get": {
+        "summary": "Get a backend's capability profile",
+        "description": "Returns a backend's last-recorded capability profile (hardware class, GPU probe, micro-benchmark, region) without re-running it. Admin-only.",
+        "operationId": "ContainerService_GetCapabilityProfile",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetCapabilityProfileResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "backendId",
+            "description": "Backend to read. Empty = the local/primary daemon's own host.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "System"
+        ]
+      },
+      "post": {
+        "summary": "Profile a backend's hardware capability",
+        "description": "Records a backend's capability profile (hardware class, GPU probe, bounded CPU/memory micro-benchmark, region) and reconciles measured vs self-reported class. Surfaced through ListBackends. Admin-only.",
+        "operationId": "ContainerService_ProfileBackend",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ProfileBackendResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "ProfileBackendRequest asks a backend to (re)record its capability profile:\nread system info, run the GPU passthrough probe and the bounded\nCPU/memory micro-benchmark, derive the measured class, and persist it. See\n#681.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProfileBackendRequest"
+            }
+          }
+        ],
+        "tags": [
+          "System"
+        ]
+      }
+    },
     "/v1/capacity/headroom": {
       "get": {
         "summary": "Get spare scheduling capacity",
@@ -5965,6 +6031,10 @@
         "headroom": {
           "$ref": "#/definitions/CapacityHeadroom",
           "description": "Spare scheduling capacity this backend currently advertises to the\ncontrol plane, or null when nothing is advertised (withdrawn or never\npublished). Lets the control plane direct scheduling at hosts that have\nexplicitly offered freed headroom. See #680."
+        },
+        "capabilityProfile": {
+          "$ref": "#/definitions/CapabilityProfile",
+          "description": "The backend's hardware capability profile recorded at join (hardware\nclass, a bounded CPU/memory micro-benchmark, and region), or null when no\nprofile has been recorded yet. Lets the control plane place work by\nmeasured class rather than self-reported class alone. See #681."
         }
       },
       "description": "BackendInfo describes one backend in the fleet — the local daemon\nplus any tunnel-connected peers. Emitted by ListBackends (GET\n/v1/backends). The field shape is the wire contract the CLI and MCP\nclients consume; it supersedes the hand-coded /v1/backends handler\nthis RPC replaced (see #354)."
@@ -6047,6 +6117,88 @@
         }
       },
       "title": "BuildpackOptions for auto-generating Dockerfiles/Containerfiles"
+    },
+    "CapabilityBenchmark": {
+      "type": "object",
+      "properties": {
+        "cpuOpsPerSec": {
+          "type": "string",
+          "format": "int64",
+          "description": "CPU score: integer-work iterations completed per second during the bounded\nrun (higher is faster). Single-threaded."
+        },
+        "memBytesPerSec": {
+          "type": "string",
+          "format": "int64",
+          "description": "Memory score: bytes per second moved through a bounded buffer copy/sum\nloop (higher is faster)."
+        },
+        "durationMs": {
+          "type": "string",
+          "format": "int64",
+          "description": "Wall-clock duration of the benchmark in milliseconds (bounded; the runner\ncaps each phase)."
+        }
+      },
+      "description": "CapabilityBenchmark is a lightweight, time-bounded CPU/memory micro-benchmark\nrun when the profile is recorded. The scores are relative integrity/capacity\nsignals, not absolute hardware specs — they let the control plane confirm a\nbackend's self-reported class is plausible. See #681."
+    },
+    "CapabilityProfile": {
+      "type": "object",
+      "properties": {
+        "cpuCores": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total physical CPU cores on the host (from SystemInfo.total_cpus)."
+        },
+        "cpuModel": {
+          "type": "string",
+          "description": "Best-effort CPU model/generation string (e.g. \"AMD EPYC 7B13\"), empty when\nthe host doesn't expose one."
+        },
+        "totalMemoryBytes": {
+          "type": "string",
+          "format": "int64",
+          "description": "Total RAM in bytes (from SystemInfo.total_memory_bytes)."
+        },
+        "totalDiskBytes": {
+          "type": "string",
+          "format": "int64",
+          "description": "Total disk in bytes (from SystemInfo.total_disk_bytes)."
+        },
+        "gpuModel": {
+          "type": "string",
+          "description": "GPU model name from the existing nvidia.runtime passthrough probe\n(ValidateGPU), empty on a CPU-only backend."
+        },
+        "gpuDriverVersion": {
+          "type": "string",
+          "description": "GPU driver version from the same probe, empty on a CPU-only backend."
+        },
+        "gpuAvailable": {
+          "type": "boolean",
+          "description": "Whether the GPU passthrough probe saw a usable GPU."
+        },
+        "region": {
+          "type": "string",
+          "description": "Region the backend serves (operator-set via --region; falls back to the\npool name). Empty when unset."
+        },
+        "reportedClass": {
+          "type": "string",
+          "description": "Self-reported hardware class the operator assigned the backend (e.g. the\npool name / declared tier), if any."
+        },
+        "measuredClass": {
+          "type": "string",
+          "description": "Measured hardware class derived from the profile (e.g. \"gpu\", \"cpu-large\",\n\"cpu-small\"). Coarse buckets; the control plane refines placement from the\nraw figures."
+        },
+        "classConsistent": {
+          "type": "boolean",
+          "description": "True when measured_class matches reported_class (or reported_class is\nempty, treated as consistent). False flags a drift the control plane and\noperator should reconcile."
+        },
+        "benchmark": {
+          "$ref": "#/definitions/CapabilityBenchmark",
+          "description": "The bounded micro-benchmark result. See CapabilityBenchmark."
+        },
+        "profiledAt": {
+          "type": "string",
+          "description": "RFC3339 timestamp the profile was recorded."
+        }
+      },
+      "description": "CapabilityProfile is a backend's hardware capability snapshot recorded at\njoin (and refreshable on demand): the hardware class derived from the host's\nsystem info + GPU probe, a lightweight bounded CPU/memory micro-benchmark,\nand the region. The control plane reads it through the backend surface to\nplace work by measured capability rather than by the self-reported class\nalone, and to detect a backend whose measured class drifts from what it\nreports. See #681."
     },
     "CapacityHeadroom": {
       "type": "object",
@@ -7657,6 +7809,19 @@
         }
       }
     },
+    "GetCapabilityProfileResponse": {
+      "type": "object",
+      "properties": {
+        "profile": {
+          "$ref": "#/definitions/CapabilityProfile"
+        },
+        "backendId": {
+          "type": "string",
+          "description": "Echoes the backend (\"\" = local)."
+        }
+      },
+      "description": "GetCapabilityProfileResponse returns the last-recorded profile, or null when\nnothing has been profiled yet."
+    },
     "GetCapacityHeadroomResponse": {
       "type": "object",
       "properties": {
@@ -9245,6 +9410,33 @@
         }
       },
       "description": "PgConnection carries the connection parameters pg_dump / pg_restore use\n*inside the container*. Defaults target a per-container local Postgres\nreached over loopback. db_password is never logged and is passed to the\nchild process via the PGPASSWORD environment variable, not argv."
+    },
+    "ProfileBackendRequest": {
+      "type": "object",
+      "properties": {
+        "backendId": {
+          "type": "string",
+          "description": "Backend to profile. Empty = the local/primary daemon's own host; a peer id\nforwards to that peer (which profiles itself)."
+        },
+        "skipGpu": {
+          "type": "boolean",
+          "description": "Skip the GPU passthrough probe (which creates+deletes a throwaway LXC and\ncan take ~30s). The profile then records gpu_available=false. Useful on a\nbackend known to be CPU-only."
+        }
+      },
+      "description": "ProfileBackendRequest asks a backend to (re)record its capability profile:\nread system info, run the GPU passthrough probe and the bounded\nCPU/memory micro-benchmark, derive the measured class, and persist it. See\n#681."
+    },
+    "ProfileBackendResponse": {
+      "type": "object",
+      "properties": {
+        "profile": {
+          "$ref": "#/definitions/CapabilityProfile"
+        },
+        "backendId": {
+          "type": "string",
+          "description": "Echoes the profiled backend (\"\" = local)."
+        }
+      },
+      "description": "ProfileBackendResponse returns the freshly recorded capability profile."
     },
     "Protocol": {
       "type": "string",

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -11316,6 +11316,13 @@
         "drainWindowExceeded": {
           "type": "boolean",
           "description": "True when the graceful budget was exhausted and the backend fell back to\nforce-stopping the remaining workloads."
+        },
+        "failed": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Container name → error for guests that could NOT be stopped even after the\nforce fallback. A non-empty map means the host is NOT fully reclaimed —\nthe control plane must not treat those guests' resources as freed."
         }
       },
       "description": "WithdrawCapacityResponse confirms the backend is no longer advertising."

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -1076,6 +1076,85 @@
         ]
       }
     },
+    "/v1/capacity/headroom": {
+      "get": {
+        "summary": "Get spare scheduling capacity",
+        "description": "Returns this backend's current headroom advertisement and recomputed spare figures. Admin-only.",
+        "operationId": "ContainerService_GetCapacityHeadroom",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetCapacityHeadroomResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "System"
+        ]
+      },
+      "delete": {
+        "summary": "Withdraw spare scheduling capacity",
+        "description": "Withdraws this backend's headroom advertisement. Idempotent — succeeds even when nothing is currently advertised. Admin-only.",
+        "operationId": "ContainerService_WithdrawCapacity",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/WithdrawCapacityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "System"
+        ]
+      },
+      "post": {
+        "summary": "Advertise spare scheduling capacity",
+        "description": "Publishes this backend's spare scheduling headroom (spare CPU/memory/disk + host idle fraction) to the control plane, bounded by a local policy. Surfaced through ListBackends. Admin-only.",
+        "operationId": "ContainerService_AdvertiseCapacity",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/AdvertiseCapacityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "AdvertiseCapacityRequest publishes (or republishes) this backend's spare\nscheduling headroom to the control plane, bounded by the supplied policy.\nSee #680.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AdvertiseCapacityRequest"
+            }
+          }
+        ],
+        "tags": [
+          "System"
+        ]
+      }
+    },
     "/v1/containers": {
       "get": {
         "summary": "List all containers",
@@ -5440,6 +5519,25 @@
       },
       "description": "AdoptMigratedContainerResponse confirms the destination registered\nthe container and returns its IP for the source's route swap."
     },
+    "AdvertiseCapacityRequest": {
+      "type": "object",
+      "properties": {
+        "policy": {
+          "$ref": "#/definitions/CapacityPolicy",
+          "description": "The local policy that bounds the advertisement. When omitted the backend\napplies its current/default policy (always-open window, no exclusions, no\nreservation)."
+        }
+      },
+      "description": "AdvertiseCapacityRequest publishes (or republishes) this backend's spare\nscheduling headroom to the control plane, bounded by the supplied policy.\nSee #680."
+    },
+    "AdvertiseCapacityResponse": {
+      "type": "object",
+      "properties": {
+        "headroom": {
+          "$ref": "#/definitions/CapacityHeadroom"
+        }
+      },
+      "description": "AdvertiseCapacityResponse returns the headroom the backend computed and is\nnow advertising. When the policy window is closed, advertised is true but\nthe spare figures are zero."
+    },
     "AgentArtifact": {
       "type": "object",
       "properties": {
@@ -5863,6 +5961,10 @@
             "$ref": "#/definitions/BackendGPU"
           },
           "description": "GPUs present on this backend."
+        },
+        "headroom": {
+          "$ref": "#/definitions/CapacityHeadroom",
+          "description": "Spare scheduling capacity this backend currently advertises to the\ncontrol plane, or null when nothing is advertised (withdrawn or never\npublished). Lets the control plane direct scheduling at hosts that have\nexplicitly offered freed headroom. See #680."
         }
       },
       "description": "BackendInfo describes one backend in the fleet — the local daemon\nplus any tunnel-connected peers. Emitted by ListBackends (GET\n/v1/backends). The field shape is the wire contract the CLI and MCP\nclients consume; it supersedes the hand-coded /v1/backends handler\nthis RPC replaced (see #354)."
@@ -5945,6 +6047,72 @@
         }
       },
       "title": "BuildpackOptions for auto-generating Dockerfiles/Containerfiles"
+    },
+    "CapacityHeadroom": {
+      "type": "object",
+      "properties": {
+        "advertised": {
+          "type": "boolean",
+          "description": "Whether an advertisement is currently active. False means the backend has\nwithdrawn (or never published) — the rest of the fields are then a stale\nsnapshot the control plane must ignore."
+        },
+        "spareCpus": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Spare CPU cores the backend offers for control-plane-directed scheduling."
+        },
+        "spareMemoryBytes": {
+          "type": "string",
+          "format": "int64",
+          "description": "Spare memory in bytes (derived from SystemInfo.available_memory_bytes,\nbounded by policy headroom reservation)."
+        },
+        "spareDiskBytes": {
+          "type": "string",
+          "format": "int64",
+          "description": "Spare disk in bytes (derived from SystemInfo.available_disk_bytes,\nbounded by policy headroom reservation)."
+        },
+        "idleFraction": {
+          "type": "number",
+          "format": "double",
+          "description": "Host-level idle fraction in [0,1]: the share of running user containers\ncurrently idle (a host aggregate over the per-container idle signal). A\nhigh value indicates a box that would scale down and can instead offer\nits headroom. 0 when no signal is available."
+        },
+        "advertisedAt": {
+          "type": "string",
+          "description": "RFC3339 timestamp the advertisement was last (re)published."
+        },
+        "policy": {
+          "$ref": "#/definitions/CapacityPolicy",
+          "description": "The local policy that bounds this advertisement."
+        }
+      },
+      "description": "CapacityHeadroom is a backend's explicit, policy-bounded offer of spare\nscheduling capacity to the control plane. Today a backend's capacity is\nimplicit (derived from system info); a box that would otherwise scale down\ncan instead publish its freed headroom here so the control plane can direct\nwork at it. Surfaced through BackendInfo (ListBackends). See #680."
+    },
+    "CapacityPolicy": {
+      "type": "object",
+      "properties": {
+        "windowStartHour": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Local-clock hour the advertisement window opens (0-23). When\nwindow_start_hour == window_end_hour the window is always open."
+        },
+        "windowEndHour": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Local-clock hour the advertisement window closes (0-23, exclusive). May be\nless than window_start_hour to express an overnight window (e.g. 22..6)."
+        },
+        "excludedWorkloadClasses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Workload classes that must NOT be displaced or co-scheduled — running\ncontainers carrying any of these classes are excluded from the idle/spare\ncomputation, so a host running protected work never advertises it as free.\nMatched against the container's \"user.containarium.workload_class\" label."
+        },
+        "reserveFraction": {
+          "type": "number",
+          "format": "double",
+          "description": "Fraction of host resources to hold back as a safety reservation, in\n[0,1). Spare = available * (1 - reserve_fraction). 0 means offer all\navailable headroom."
+        }
+      },
+      "description": "CapacityPolicy bounds what a backend is willing to advertise. The\nadvertisement only computes spare capacity when the current time falls\ninside the allowed window and respects the excluded workload classes.\nOperator-set per backend. See #680."
     },
     "ClamavContainerSummary": {
       "type": "object",
@@ -7488,6 +7656,15 @@
           "$ref": "#/definitions/BackupRecord"
         }
       }
+    },
+    "GetCapacityHeadroomResponse": {
+      "type": "object",
+      "properties": {
+        "headroom": {
+          "$ref": "#/definitions/CapacityHeadroom"
+        }
+      },
+      "description": "GetCapacityHeadroomResponse returns the current headroom snapshot."
     },
     "GetClamavSummaryResponse": {
       "type": "object",
@@ -10787,6 +10964,16 @@
         }
       },
       "title": "WebhookDelivery represents a single webhook delivery attempt"
+    },
+    "WithdrawCapacityResponse": {
+      "type": "object",
+      "properties": {
+        "headroom": {
+          "$ref": "#/definitions/CapacityHeadroom",
+          "description": "The post-withdraw headroom (advertised=false)."
+        }
+      },
+      "description": "WithdrawCapacityResponse confirms the backend is no longer advertising."
     },
     "ZapAlert": {
       "type": "object",

--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -97,9 +97,7 @@ func MeasuredClass(f HostFacts) string {
 
 // classConsistent reports whether the measured class is consistent with the
 // self-reported one. An empty reported class is treated as consistent (the
-// operator declared nothing to reconcile against). The comparison is
-// case-insensitive and substring-tolerant so a reported "gpu-pool" reconciles
-// against measured "gpu".
+// operator declared nothing to reconcile against). Case-insensitive.
 func classConsistent(reported, measured string) bool {
 	r := strings.ToLower(strings.TrimSpace(reported))
 	if r == "" {
@@ -109,9 +107,23 @@ func classConsistent(reported, measured string) bool {
 	if r == m {
 		return true
 	}
-	// A reported class that names the measured bucket (e.g. "gpu-spot" vs
-	// "gpu", "cpu-large-pool" vs "cpu-large") is consistent.
-	return strings.Contains(r, m) || strings.Contains(m, r)
+	// Compare on hyphen segments, NOT arbitrary substrings: the old
+	// bidirectional strings.Contains made "cpu" consistent with BOTH
+	// "cpu-small" and "cpu-large", hiding the exact size drift this reconcile
+	// exists to surface. Rule:
+	//   - the FAMILY (first segment, e.g. cpu/gpu) must match;
+	//   - if BOTH name a sub-class (size/model), the sub-classes must agree;
+	//   - a coarse class on one side (no sub-segment) is a consistent
+	//     refinement of the other ("gpu" vs "gpu-a10").
+	rSeg := strings.SplitN(r, "-", 2)
+	mSeg := strings.SplitN(m, "-", 2)
+	if rSeg[0] != mSeg[0] {
+		return false // different family → drift
+	}
+	if len(rSeg) == 2 && len(mSeg) == 2 {
+		return rSeg[1] == mSeg[1] // both specified a sub-class → must match
+	}
+	return true
 }
 
 // Compute derives the profile from a HostFacts snapshot. Pure: no I/O.

--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -1,0 +1,169 @@
+// Package capabilities turns a backend's host system info, GPU passthrough
+// probe, and a bounded CPU/memory micro-benchmark into an explicit capability
+// profile recorded at join. The control plane reads the profile through the
+// backend surface (ListBackends) to place work by measured hardware class
+// rather than by a self-reported class alone, and to detect a backend whose
+// measured class drifts from what it reports.
+//
+// The compute is pure (no proto, no Incus dependency) so it is unit-testable in
+// isolation; the server gathers the inputs and maps the result onto the wire
+// type. A small concurrent Store holds the last-recorded profile per daemon.
+// See #681.
+package capabilities
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// Hardware-class buckets. Coarse on purpose — the control plane refines
+// placement from the raw figures; these only give a stable label to reconcile
+// the self-reported class against. Generic capacity wording only.
+const (
+	ClassGPU      = "gpu"
+	ClassCPULarge = "cpu-large"
+	ClassCPUSmall = "cpu-small"
+)
+
+// cpuLargeCoreThreshold is the core count at or above which a CPU-only backend
+// is classed "cpu-large". Below it, "cpu-small".
+const cpuLargeCoreThreshold = 16
+
+// Benchmark mirrors container.BenchmarkResult but stays free of any other
+// package dependency so the profile compute is self-contained.
+type Benchmark struct {
+	CPUOpsPerSec   int64
+	MemBytesPerSec int64
+	DurationMs     int64
+}
+
+// HostFacts is the snapshot the profile compute consumes. The caller (the
+// daemon) gathers it from SystemInfo (CPU cores, RAM, disk), the GPU
+// passthrough probe (model/driver/available), the micro-benchmark, the region,
+// and the self-reported class.
+type HostFacts struct {
+	CPUCores         int32
+	CPUModel         string
+	TotalMemoryBytes int64
+	TotalDiskBytes   int64
+
+	GPUModel         string
+	GPUDriverVersion string
+	GPUAvailable     bool
+
+	Region        string
+	ReportedClass string
+
+	Benchmark Benchmark
+
+	// Now is injected so callers/tests can pin the recorded timestamp.
+	Now time.Time
+}
+
+// Profile is the computed capability profile. It mirrors pb.CapabilityProfile
+// but carries no proto dependency; the server maps it onto the wire type.
+type Profile struct {
+	CPUCores         int32
+	CPUModel         string
+	TotalMemoryBytes int64
+	TotalDiskBytes   int64
+
+	GPUModel         string
+	GPUDriverVersion string
+	GPUAvailable     bool
+
+	Region          string
+	ReportedClass   string
+	MeasuredClass   string
+	ClassConsistent bool
+
+	Benchmark  Benchmark
+	ProfiledAt time.Time
+}
+
+// MeasuredClass derives the coarse hardware-class bucket from the facts: any
+// usable GPU makes it a GPU backend; otherwise core count splits large from
+// small.
+func MeasuredClass(f HostFacts) string {
+	if f.GPUAvailable {
+		return ClassGPU
+	}
+	if f.CPUCores >= cpuLargeCoreThreshold {
+		return ClassCPULarge
+	}
+	return ClassCPUSmall
+}
+
+// classConsistent reports whether the measured class is consistent with the
+// self-reported one. An empty reported class is treated as consistent (the
+// operator declared nothing to reconcile against). The comparison is
+// case-insensitive and substring-tolerant so a reported "gpu-pool" reconciles
+// against measured "gpu".
+func classConsistent(reported, measured string) bool {
+	r := strings.ToLower(strings.TrimSpace(reported))
+	if r == "" {
+		return true
+	}
+	m := strings.ToLower(strings.TrimSpace(measured))
+	if r == m {
+		return true
+	}
+	// A reported class that names the measured bucket (e.g. "gpu-spot" vs
+	// "gpu", "cpu-large-pool" vs "cpu-large") is consistent.
+	return strings.Contains(r, m) || strings.Contains(m, r)
+}
+
+// Compute derives the profile from a HostFacts snapshot. Pure: no I/O.
+func Compute(f HostFacts) Profile {
+	measured := MeasuredClass(f)
+	return Profile{
+		CPUCores:         f.CPUCores,
+		CPUModel:         f.CPUModel,
+		TotalMemoryBytes: f.TotalMemoryBytes,
+		TotalDiskBytes:   f.TotalDiskBytes,
+		GPUModel:         f.GPUModel,
+		GPUDriverVersion: f.GPUDriverVersion,
+		GPUAvailable:     f.GPUAvailable,
+		Region:           f.Region,
+		ReportedClass:    f.ReportedClass,
+		MeasuredClass:    measured,
+		ClassConsistent:  classConsistent(f.ReportedClass, measured),
+		Benchmark:        f.Benchmark,
+		ProfiledAt:       f.Now,
+	}
+}
+
+// Store holds the per-daemon last-recorded profile. One per daemon; safe for
+// concurrent use. Empty until the first profile is recorded.
+type Store struct {
+	mu      sync.RWMutex
+	profile *Profile
+}
+
+// NewStore returns an empty store (nothing profiled yet).
+func NewStore() *Store {
+	return &Store{}
+}
+
+// Record computes and persists the profile from the given facts and returns
+// it.
+func (s *Store) Record(f HostFacts) Profile {
+	p := Compute(f)
+	s.mu.Lock()
+	cp := p
+	s.profile = &cp
+	s.mu.Unlock()
+	return p
+}
+
+// Current returns the last-recorded profile and whether one exists. The
+// returned Profile is a copy, safe to mutate.
+func (s *Store) Current() (Profile, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.profile == nil {
+		return Profile{}, false
+	}
+	return *s.profile, true
+}

--- a/internal/capabilities/capabilities_test.go
+++ b/internal/capabilities/capabilities_test.go
@@ -1,0 +1,102 @@
+package capabilities
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMeasuredClass(t *testing.T) {
+	cases := []struct {
+		name string
+		f    HostFacts
+		want string
+	}{
+		{"gpu beats core count", HostFacts{GPUAvailable: true, CPUCores: 4}, ClassGPU},
+		{"large cpu", HostFacts{CPUCores: 32}, ClassCPULarge},
+		{"exactly threshold is large", HostFacts{CPUCores: cpuLargeCoreThreshold}, ClassCPULarge},
+		{"small cpu", HostFacts{CPUCores: 4}, ClassCPUSmall},
+		{"zero cores small", HostFacts{}, ClassCPUSmall},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MeasuredClass(tc.f); got != tc.want {
+				t.Fatalf("MeasuredClass = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeClassReconciliation(t *testing.T) {
+	cases := []struct {
+		name        string
+		f           HostFacts
+		wantClass   string
+		wantConsist bool
+	}{
+		{"empty reported is consistent", HostFacts{CPUCores: 4}, ClassCPUSmall, true},
+		{"exact match", HostFacts{GPUAvailable: true, ReportedClass: "gpu"}, ClassGPU, true},
+		{"reported names bucket", HostFacts{GPUAvailable: true, ReportedClass: "gpu-spot"}, ClassGPU, true},
+		{"case insensitive", HostFacts{CPUCores: 32, ReportedClass: "CPU-Large"}, ClassCPULarge, true},
+		{"drift: reported gpu but cpu-only", HostFacts{CPUCores: 4, ReportedClass: "gpu"}, ClassCPUSmall, false},
+		{"drift: reported small but large", HostFacts{CPUCores: 64, ReportedClass: "tiny"}, ClassCPULarge, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := Compute(tc.f)
+			if p.MeasuredClass != tc.wantClass {
+				t.Fatalf("MeasuredClass = %q, want %q", p.MeasuredClass, tc.wantClass)
+			}
+			if p.ClassConsistent != tc.wantConsist {
+				t.Fatalf("ClassConsistent = %v, want %v", p.ClassConsistent, tc.wantConsist)
+			}
+		})
+	}
+}
+
+func TestComputeCarriesFields(t *testing.T) {
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	f := HostFacts{
+		CPUCores:         8,
+		CPUModel:         "Test CPU",
+		TotalMemoryBytes: 1 << 34,
+		TotalDiskBytes:   1 << 40,
+		Region:           "region-a",
+		ReportedClass:    "cpu-small",
+		Benchmark:        Benchmark{CPUOpsPerSec: 100, MemBytesPerSec: 200, DurationMs: 5},
+		Now:              now,
+	}
+	p := Compute(f)
+	if p.CPUModel != "Test CPU" || p.Region != "region-a" || p.TotalMemoryBytes != 1<<34 {
+		t.Fatalf("fields not carried: %+v", p)
+	}
+	if !p.ProfiledAt.Equal(now) {
+		t.Fatalf("ProfiledAt = %v, want %v", p.ProfiledAt, now)
+	}
+	if p.Benchmark.CPUOpsPerSec != 100 {
+		t.Fatalf("benchmark not carried: %+v", p.Benchmark)
+	}
+}
+
+func TestStoreRecordAndCurrent(t *testing.T) {
+	s := NewStore()
+	if _, ok := s.Current(); ok {
+		t.Fatalf("fresh store must report no profile")
+	}
+	p := s.Record(HostFacts{CPUCores: 4, Now: time.Now()})
+	if p.MeasuredClass != ClassCPUSmall {
+		t.Fatalf("recorded class = %q", p.MeasuredClass)
+	}
+	got, ok := s.Current()
+	if !ok {
+		t.Fatalf("Current must report a profile after Record")
+	}
+	if got.MeasuredClass != ClassCPUSmall {
+		t.Fatalf("Current class = %q", got.MeasuredClass)
+	}
+	// Current returns a copy: mutating it must not affect the store.
+	got.MeasuredClass = "mutated"
+	again, _ := s.Current()
+	if again.MeasuredClass != ClassCPUSmall {
+		t.Fatalf("store mutated through returned copy: %q", again.MeasuredClass)
+	}
+}

--- a/internal/capacity/capacity.go
+++ b/internal/capacity/capacity.go
@@ -1,0 +1,254 @@
+// Package capacity turns a backend's implicit spare resources into an
+// explicit, policy-bounded scheduling-headroom signal that the control plane
+// can read through the backend surface (ListBackends).
+//
+// Today a backend's capacity is implicit — the control plane infers it from
+// SystemInfo. A box that the auto-sleep loop would scale down can instead
+// publish its freed headroom here so the control plane can direct work at it.
+// The advertisement is bounded by a local Policy (a time window, excluded
+// workload classes, and a safety reservation), so a host running protected
+// work never offers it as free. Withdrawing is idempotent. See #680.
+package capacity
+
+import (
+	"sync"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// WorkloadClassLabel is the container label that tags a workload's class. A
+// container whose class appears in Policy.ExcludedWorkloadClasses is excluded
+// from the idle/spare computation, so protected work is never advertised as
+// freed headroom.
+const WorkloadClassLabel = "user.containarium.workload_class"
+
+// Policy bounds what a backend is willing to advertise. The zero value is a
+// valid "always open, no exclusions, offer everything available" policy.
+type Policy struct {
+	// WindowStartHour / WindowEndHour describe the local-clock hour window
+	// during which the advertisement offers non-zero spare. Equal values mean
+	// the window is always open. A start greater than the end expresses an
+	// overnight window (e.g. 22..6).
+	WindowStartHour int32
+	WindowEndHour   int32
+
+	// ExcludedWorkloadClasses are workload classes that must not be displaced
+	// or co-scheduled. Running containers carrying any of these classes are
+	// excluded from the idle/spare computation.
+	ExcludedWorkloadClasses []string
+
+	// ReserveFraction is the share of host resources to hold back as a safety
+	// reservation, in [0,1). Spare = available * (1 - ReserveFraction).
+	ReserveFraction float64
+}
+
+// WindowOpen reports whether the policy's advertisement window includes the
+// given local time. An always-open window (start == end) is always true.
+func (p Policy) WindowOpen(now time.Time) bool {
+	if p.WindowStartHour == p.WindowEndHour {
+		return true
+	}
+	h := int32(now.Hour())
+	if p.WindowStartHour < p.WindowEndHour {
+		return h >= p.WindowStartHour && h < p.WindowEndHour
+	}
+	// Overnight window wraps midnight, e.g. 22..6.
+	return h >= p.WindowStartHour || h < p.WindowEndHour
+}
+
+// excludes reports whether the policy excludes the given workload class.
+func (p Policy) excludes(class string) bool {
+	if class == "" {
+		return false
+	}
+	for _, c := range p.ExcludedWorkloadClasses {
+		if c == class {
+			return true
+		}
+	}
+	return false
+}
+
+// HostState is the snapshot the headroom computation consumes. The caller
+// (the daemon) gathers it from SystemInfo (the AvailableMemoryBytes /
+// AvailableDiskBytes already fetched in peer.go) plus the container list.
+type HostState struct {
+	// AvailableCPUs / AvailableMemoryBytes / AvailableDiskBytes mirror the
+	// host-level figures from SystemInfo. AvailableCPUs is derived from total
+	// cores minus the 1-minute load average (clamped at zero).
+	AvailableCPUs        int32
+	AvailableMemoryBytes int64
+	AvailableDiskBytes   int64
+
+	// Containers is the host's full container list. Used to derive the
+	// host-level idle fraction (a host aggregate over the per-container idle
+	// signal) and to honor workload-class exclusions.
+	Containers []incus.ContainerInfo
+
+	// Now is injected so callers/tests can pin the clock for the window check
+	// and the per-container idle threshold.
+	Now time.Time
+}
+
+// Headroom is the computed advertisement. It mirrors pb.CapacityHeadroom but
+// stays free of any proto dependency so the computation is unit-testable in
+// isolation; the server maps it onto the wire type.
+type Headroom struct {
+	Advertised       bool
+	SpareCPUs        int32
+	SpareMemoryBytes int64
+	SpareDiskBytes   int64
+	IdleFraction     float64
+	AdvertisedAt     time.Time
+	Policy           Policy
+}
+
+// Compute derives the policy-bounded headroom from a HostState. When the
+// policy window is closed the spare figures are all zero (the host advertises
+// "available, but nothing free right now"); advertised stays whatever the
+// caller passes in via the Store. Compute itself is pure: it computes the
+// figures and leaves the advertised flag to the Store.
+func Compute(p Policy, st HostState) Headroom {
+	h := Headroom{Policy: p}
+
+	idleN, userN := hostIdle(p, st)
+	if userN > 0 {
+		h.IdleFraction = float64(idleN) / float64(userN)
+	}
+
+	// Outside the window we surface zero spare — the host keeps its capacity
+	// to itself until the window reopens.
+	if !p.WindowOpen(st.Now) {
+		return h
+	}
+
+	keep := 1 - p.ReserveFraction
+	if keep < 0 {
+		keep = 0
+	}
+	if keep > 1 {
+		keep = 1
+	}
+
+	if st.AvailableCPUs > 0 {
+		h.SpareCPUs = int32(float64(st.AvailableCPUs) * keep)
+	}
+	if st.AvailableMemoryBytes > 0 {
+		h.SpareMemoryBytes = int64(float64(st.AvailableMemoryBytes) * keep)
+	}
+	if st.AvailableDiskBytes > 0 {
+		h.SpareDiskBytes = int64(float64(st.AvailableDiskBytes) * keep)
+	}
+	return h
+}
+
+// hostIdle returns (idle user containers, total considered user containers).
+// A container is "considered" when it is a running, non-core user container
+// whose workload class is not excluded by policy. A considered container
+// counts as idle when it has gone quiet longer than its idle threshold — the
+// same scale-down signal the auto-sleep loop uses, aggregated to a host level.
+func hostIdle(p Policy, st HostState) (idle, considered int) {
+	for _, c := range st.Containers {
+		if c.Role.IsCoreRole() {
+			continue
+		}
+		if c.State != "Running" {
+			continue
+		}
+		if p.excludes(c.Labels[WorkloadClassLabel]) {
+			continue
+		}
+		considered++
+
+		threshold := time.Duration(c.IdleThresholdMinutes) * time.Minute
+		if threshold <= 0 {
+			threshold = 15 * time.Minute
+		}
+		// Reuse the auto-sleep "since last start" idle proxy: a container that
+		// has been up longer than its idle threshold and shows no recent start
+		// activity is treated as idle for the host aggregate. The per-container
+		// network signal lives in the auto-sleep loop; here we only need a
+		// host-level fraction, so the start-stamp proxy is sufficient and needs
+		// no traffic store.
+		if c.LastStartedAt.IsZero() {
+			continue
+		}
+		if st.Now.Sub(c.LastStartedAt) >= threshold {
+			idle++
+		}
+	}
+	return idle, considered
+}
+
+// Store holds the per-daemon advertise/withdraw state and the active policy.
+// One per daemon. All methods are safe for concurrent use. The store does not
+// itself gather HostState — the caller passes a fresh snapshot on each call so
+// the figures are always current.
+type Store struct {
+	mu           sync.RWMutex
+	advertised   bool
+	policy       Policy
+	advertisedAt time.Time
+}
+
+// NewStore returns an empty store: nothing advertised, default policy.
+func NewStore() *Store {
+	return &Store{}
+}
+
+// Advertise publishes (or republishes) the backend's headroom under the given
+// policy and returns the freshly computed advertisement. Republishing with a
+// new policy replaces the old one and re-stamps advertisedAt.
+func (s *Store) Advertise(p Policy, st HostState) Headroom {
+	s.mu.Lock()
+	s.advertised = true
+	s.policy = p
+	s.advertisedAt = st.Now
+	s.mu.Unlock()
+
+	h := Compute(p, st)
+	h.Advertised = true
+	h.AdvertisedAt = st.Now
+	return h
+}
+
+// Withdraw removes any active advertisement. Idempotent: withdrawing when
+// nothing is advertised succeeds and returns a withdrawn snapshot. The policy
+// is retained so a subsequent bare Advertise can reuse it, but the spare
+// figures are zeroed because nothing is offered while withdrawn.
+func (s *Store) Withdraw() Headroom {
+	s.mu.Lock()
+	s.advertised = false
+	s.advertisedAt = time.Time{}
+	p := s.policy
+	s.mu.Unlock()
+
+	return Headroom{Advertised: false, Policy: p}
+}
+
+// Current returns the present advertisement state with spare figures
+// recomputed against the supplied HostState. When nothing is advertised the
+// figures are zeroed (advertised=false); the policy is still surfaced.
+func (s *Store) Current(st HostState) Headroom {
+	s.mu.RLock()
+	advertised := s.advertised
+	p := s.policy
+	at := s.advertisedAt
+	s.mu.RUnlock()
+
+	if !advertised {
+		return Headroom{Advertised: false, Policy: p}
+	}
+	h := Compute(p, st)
+	h.Advertised = true
+	h.AdvertisedAt = at
+	return h
+}
+
+// Policy returns the store's current policy (the one a bare Advertise reuses).
+func (s *Store) Policy() Policy {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.policy
+}

--- a/internal/capacity/capacity.go
+++ b/internal/capacity/capacity.go
@@ -49,12 +49,15 @@ func (p Policy) WindowOpen(now time.Time) bool {
 	if p.WindowStartHour == p.WindowEndHour {
 		return true
 	}
-	h := int32(now.Hour())
-	if p.WindowStartHour < p.WindowEndHour {
-		return h >= p.WindowStartHour && h < p.WindowEndHour
+	// Compare in int space — now.Hour() is already int (0–23), and widening
+	// the int32 bounds to int avoids a narrowing int→int32 conversion (G115).
+	h := now.Hour()
+	start, end := int(p.WindowStartHour), int(p.WindowEndHour)
+	if start < end {
+		return h >= start && h < end
 	}
 	// Overnight window wraps midnight, e.g. 22..6.
-	return h >= p.WindowStartHour || h < p.WindowEndHour
+	return h >= start || h < end
 }
 
 // excludes reports whether the policy excludes the given workload class.

--- a/internal/capacity/capacity_test.go
+++ b/internal/capacity/capacity_test.go
@@ -1,0 +1,128 @@
+package capacity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+func at(hour int) time.Time {
+	return time.Date(2026, 6, 14, hour, 0, 0, 0, time.UTC)
+}
+
+func TestPolicyWindowOpen(t *testing.T) {
+	cases := []struct {
+		name  string
+		p     Policy
+		hour  int
+		open  bool
+	}{
+		{"always open (equal)", Policy{}, 3, true},
+		{"day window in", Policy{WindowStartHour: 9, WindowEndHour: 17}, 12, true},
+		{"day window before", Policy{WindowStartHour: 9, WindowEndHour: 17}, 8, false},
+		{"day window at end exclusive", Policy{WindowStartHour: 9, WindowEndHour: 17}, 17, false},
+		{"overnight in late", Policy{WindowStartHour: 22, WindowEndHour: 6}, 23, true},
+		{"overnight in early", Policy{WindowStartHour: 22, WindowEndHour: 6}, 2, true},
+		{"overnight out midday", Policy{WindowStartHour: 22, WindowEndHour: 6}, 12, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.p.WindowOpen(at(c.hour)); got != c.open {
+				t.Fatalf("WindowOpen(%d) = %v, want %v", c.hour, got, c.open)
+			}
+		})
+	}
+}
+
+func TestComputeSpareWithReserve(t *testing.T) {
+	st := HostState{
+		AvailableCPUs:        10,
+		AvailableMemoryBytes: 1000,
+		AvailableDiskBytes:   2000,
+		Now:                  at(12),
+	}
+	h := Compute(Policy{ReserveFraction: 0.2}, st)
+	if h.SpareCPUs != 8 {
+		t.Errorf("SpareCPUs = %d, want 8", h.SpareCPUs)
+	}
+	if h.SpareMemoryBytes != 800 {
+		t.Errorf("SpareMemoryBytes = %d, want 800", h.SpareMemoryBytes)
+	}
+	if h.SpareDiskBytes != 1600 {
+		t.Errorf("SpareDiskBytes = %d, want 1600", h.SpareDiskBytes)
+	}
+}
+
+func TestComputeWindowClosedZeroesSpare(t *testing.T) {
+	st := HostState{
+		AvailableCPUs:        10,
+		AvailableMemoryBytes: 1000,
+		AvailableDiskBytes:   2000,
+		Now:                  at(3),
+	}
+	h := Compute(Policy{WindowStartHour: 9, WindowEndHour: 17}, st)
+	if h.SpareCPUs != 0 || h.SpareMemoryBytes != 0 || h.SpareDiskBytes != 0 {
+		t.Fatalf("window closed should zero spare, got %+v", h)
+	}
+}
+
+func TestHostIdleFractionAndExclusion(t *testing.T) {
+	now := at(12)
+	old := now.Add(-1 * time.Hour) // well past the 15m default threshold
+	containers := []incus.ContainerInfo{
+		// idle user container
+		{Name: "a-container", State: "Running", LastStartedAt: old, IdleThresholdMinutes: 15},
+		// active user container (recently started)
+		{Name: "b-container", State: "Running", LastStartedAt: now.Add(-1 * time.Minute), IdleThresholdMinutes: 15},
+		// excluded workload class — must not count toward considered or idle
+		{Name: "c-container", State: "Running", LastStartedAt: old, IdleThresholdMinutes: 15,
+			Labels: map[string]string{WorkloadClassLabel: "protected"}},
+		// core container — never considered
+		{Name: "postgres", State: "Running", LastStartedAt: old, Role: incus.RolePostgres},
+		// stopped — never considered
+		{Name: "d-container", State: "Stopped", LastStartedAt: old},
+	}
+	p := Policy{ExcludedWorkloadClasses: []string{"protected"}}
+	st := HostState{Now: now, Containers: containers}
+	h := Compute(p, st)
+	// considered = a + b = 2; idle = a = 1 → 0.5
+	if h.IdleFraction != 0.5 {
+		t.Fatalf("IdleFraction = %v, want 0.5", h.IdleFraction)
+	}
+}
+
+func TestStoreAdvertiseWithdrawIdempotent(t *testing.T) {
+	s := NewStore()
+	st := HostState{AvailableCPUs: 4, AvailableMemoryBytes: 100, Now: at(12)}
+
+	// Initially nothing advertised.
+	if cur := s.Current(st); cur.Advertised {
+		t.Fatal("fresh store should not be advertised")
+	}
+
+	h := s.Advertise(Policy{ReserveFraction: 0.25}, st)
+	if !h.Advertised || h.SpareCPUs != 3 {
+		t.Fatalf("advertise = %+v, want advertised w/ 3 spare cpus", h)
+	}
+	if cur := s.Current(st); !cur.Advertised || cur.SpareCPUs != 3 {
+		t.Fatalf("current after advertise = %+v", cur)
+	}
+
+	// Withdraw is idempotent.
+	w1 := s.Withdraw()
+	if w1.Advertised {
+		t.Fatal("withdraw should clear advertised")
+	}
+	w2 := s.Withdraw()
+	if w2.Advertised {
+		t.Fatal("second withdraw should remain withdrawn (idempotent)")
+	}
+	if cur := s.Current(st); cur.Advertised || cur.SpareCPUs != 0 {
+		t.Fatalf("current after withdraw = %+v, want withdrawn + zero spare", cur)
+	}
+	// Policy is retained across withdraw.
+	if s.Policy().ReserveFraction != 0.25 {
+		t.Fatalf("policy not retained: %+v", s.Policy())
+	}
+}

--- a/internal/capacity/capacity_test.go
+++ b/internal/capacity/capacity_test.go
@@ -13,10 +13,10 @@ func at(hour int) time.Time {
 
 func TestPolicyWindowOpen(t *testing.T) {
 	cases := []struct {
-		name  string
-		p     Policy
-		hour  int
-		open  bool
+		name string
+		p    Policy
+		hour int
+		open bool
 	}{
 		{"always open (equal)", Policy{}, 3, true},
 		{"day window in", Policy{WindowStartHour: 9, WindowEndHour: 17}, 12, true},

--- a/internal/capacity/drain.go
+++ b/internal/capacity/drain.go
@@ -1,0 +1,213 @@
+package capacity
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// DefaultDrainWindow is the bounded wall-clock budget a drain gets to evict the
+// guest workloads a backend had implicitly offered as headroom. Picked to be
+// generous enough for a clean per-workload graceful stop (the backend's stop
+// path issues a SIGTERM with its own 30s timeout) across a handful of guests,
+// while still being short enough that a control plane reclaiming the host is
+// not left waiting indefinitely.
+const DefaultDrainWindow = 120 * time.Second
+
+// DrainStopper is the narrow capability the drainer needs: stop one workload,
+// optionally forcing it. ContainerServer satisfies this by routing through the
+// same StopContainer plumbing a manual stop uses, so a drained workload is
+// indistinguishable on the event bus from any other stop and the control plane
+// can reschedule it. Kept as an interface so the drain logic is unit-testable
+// without the full server import graph.
+type DrainStopper interface {
+	// StopWorkload gracefully stops the workload owned by username. When force
+	// is true the stop must not block on a graceful shutdown (the bounded window
+	// has been exhausted). The implementation owns its own per-call timeout. The
+	// username is the daemon's routing key — the same one StopContainer takes —
+	// not the raw container name.
+	StopWorkload(ctx context.Context, username string, force bool) error
+}
+
+// DrainCandidate is one guest workload selected for reclaim. Core-service and
+// policy-excluded workloads are filtered out by the caller (DrainCandidates)
+// before they ever reach the drainer, so the drainer treats every candidate as
+// fair game. ContainerName is the display/audit identity; Username is the
+// daemon routing key handed to the stopper (the same key StopContainer uses).
+type DrainCandidate struct {
+	ContainerName string
+	Username      string
+}
+
+// DrainResult records what a single drain pass did. It is the audit trail the
+// withdraw handler surfaces to the control plane: which workloads drained
+// gracefully, which had to be force-stopped because the window ran out, and
+// which failed outright.
+type DrainResult struct {
+	// Drained are workloads that stopped gracefully within the window.
+	Drained []string
+	// ForceStopped are workloads still running when the window expired; they
+	// were force-stopped so the host is reliably reclaimed (no wedge).
+	ForceStopped []string
+	// Failed are workloads whose stop returned an error even after the force
+	// fallback. The container name maps to the last error string.
+	Failed map[string]string
+	// WindowExceeded is true when the graceful budget was exhausted and the
+	// drainer fell back to force-stopping the remainder.
+	WindowExceeded bool
+	// Elapsed is the wall-clock time the drain took.
+	Elapsed time.Duration
+}
+
+// Drainer performs a bounded graceful reclaim of guest workloads. It is the
+// new graceful-drain-with-window primitive the reclaim path needed: there was
+// previously only a single-shot StopContainer (with an optional hard force) and
+// the cutover stop inside MoveContainer — neither bounds a multi-workload
+// graceful drain. The Drainer wraps the existing per-workload stop path with a
+// total-window budget and a force fallback so a host that withdraws headroom is
+// reliably reclaimed without hard-killing live guests up front.
+//
+// A single in-flight drain at a time is enforced by mu. Repeated
+// advertise/withdraw cycles therefore cannot stack overlapping drains and wedge
+// the host with N concurrent stop storms — a withdraw that arrives while a
+// drain is already running is coalesced (Drain returns the in-flight guard's
+// zero result via skipped=true) rather than spawning a second pass.
+type Drainer struct {
+	stopper DrainStopper
+
+	mu       sync.Mutex
+	draining bool
+
+	// nowFn is injectable for deterministic tests of the window/deadline logic.
+	// Production uses time.Now.
+	nowFn func() time.Time
+}
+
+// NewDrainer builds a Drainer over the given stop capability.
+func NewDrainer(stopper DrainStopper) *Drainer {
+	return &Drainer{stopper: stopper, nowFn: time.Now}
+}
+
+// DrainCandidates selects the guest workloads a backend should reclaim when it
+// withdraws headroom. It mirrors hostIdle's filtering exactly — core-service
+// roles and policy-excluded workload classes are never candidates — so the set
+// drained is precisely the set the backend was implicitly offering as spare.
+// Stopped containers are skipped (nothing to drain). Pure; the caller passes a
+// HostState snapshot.
+func DrainCandidates(p Policy, st HostState) []DrainCandidate {
+	var out []DrainCandidate
+	for _, c := range st.Containers {
+		if c.Role.IsCoreRole() {
+			continue
+		}
+		if c.State != "Running" {
+			continue
+		}
+		if p.excludes(c.Labels[WorkloadClassLabel]) {
+			continue
+		}
+		// Username is the daemon's stop-routing key; fall back to the container
+		// name when the host doesn't report one (the name-convention case).
+		username := c.Username
+		if username == "" {
+			username = c.Name
+		}
+		out = append(out, DrainCandidate{ContainerName: c.Name, Username: username})
+	}
+	return out
+}
+
+// Drain reclaims the given candidates within the bounded window. It attempts a
+// graceful stop of each candidate in turn; once the window is exhausted any
+// remaining candidates (including the in-flight one's successors) are
+// force-stopped so the host is reliably reclaimed. A window <= 0 falls back to
+// DefaultDrainWindow.
+//
+// skipped is true when another drain was already in flight; in that case the
+// returned result is zero and no stops are issued (the cycle is coalesced).
+//
+// Drain never returns an error: a per-workload stop failure is recorded in
+// DrainResult.Failed and the drain proceeds to the next candidate, because a
+// stuck single guest must not block reclaiming the rest of the host.
+func (d *Drainer) Drain(ctx context.Context, candidates []DrainCandidate, window time.Duration) (DrainResult, bool) {
+	d.mu.Lock()
+	if d.draining {
+		d.mu.Unlock()
+		return DrainResult{}, true
+	}
+	d.draining = true
+	d.mu.Unlock()
+	defer func() {
+		d.mu.Lock()
+		d.draining = false
+		d.mu.Unlock()
+	}()
+
+	if window <= 0 {
+		window = DefaultDrainWindow
+	}
+	start := d.now()
+	deadline := start.Add(window)
+
+	res := DrainResult{Failed: map[string]string{}}
+
+	for _, c := range candidates {
+		// Past the window: force-stop the remainder so the host is reclaimed
+		// promptly. force=true skips the graceful shutdown wait, bounding the
+		// total time the drain can consume.
+		forced := !d.now().Before(deadline)
+		if forced {
+			res.WindowExceeded = true
+		}
+
+		if err := d.stopper.StopWorkload(ctx, c.Username, forced); err != nil {
+			// Graceful attempt failed and we still have window left: try once
+			// more with force before giving up, so a guest that ignores
+			// SIGTERM is still reclaimed rather than left running.
+			if !forced {
+				if ferr := d.stopper.StopWorkload(ctx, c.Username, true); ferr != nil {
+					res.Failed[c.ContainerName] = ferr.Error()
+					log.Printf("[drain] force-stop %s failed: %v", c.ContainerName, ferr)
+					continue
+				}
+				res.ForceStopped = append(res.ForceStopped, c.ContainerName)
+				continue
+			}
+			res.Failed[c.ContainerName] = err.Error()
+			log.Printf("[drain] force-stop %s failed: %v", c.ContainerName, err)
+			continue
+		}
+
+		if forced {
+			res.ForceStopped = append(res.ForceStopped, c.ContainerName)
+		} else {
+			res.Drained = append(res.Drained, c.ContainerName)
+		}
+
+		// Cancellation cuts the drain short — the caller's context expiring is a
+		// stronger bound than the window. Remaining candidates are left for a
+		// subsequent reconcile/withdraw to pick up.
+		if ctx.Err() != nil {
+			break
+		}
+	}
+
+	res.Elapsed = d.now().Sub(start)
+	return res, false
+}
+
+// now returns the drainer's clock (injectable for tests).
+func (d *Drainer) now() time.Time {
+	if d.nowFn != nil {
+		return d.nowFn()
+	}
+	return time.Now()
+}
+
+// assert the incus container info shape is what DrainCandidates reads, so a
+// field rename upstream is caught at compile time rather than silently
+// selecting an empty candidate set.
+var _ = func(c incus.ContainerInfo) (string, string) { return c.Name, c.State }

--- a/internal/capacity/drain.go
+++ b/internal/capacity/drain.go
@@ -109,6 +109,18 @@ func DrainCandidates(p Policy, st HostState) []DrainCandidate {
 		if p.excludes(c.Labels[WorkloadClassLabel]) {
 			continue
 		}
+		// Only the IDLE guests are part of the spare the backend implicitly
+		// offered; a busy, non-idle workload was never advertised, so a routine
+		// headroom withdraw must NOT reclaim it. This mirrors hostIdle's idle
+		// gate (capacity.go) exactly — the two must stay in sync or the set
+		// drained diverges from the set advertised.
+		threshold := time.Duration(c.IdleThresholdMinutes) * time.Minute
+		if threshold <= 0 {
+			threshold = 15 * time.Minute
+		}
+		if c.LastStartedAt.IsZero() || st.Now.Sub(c.LastStartedAt) < threshold {
+			continue
+		}
 		// Username is the daemon's stop-routing key; fall back to the container
 		// name when the host doesn't report one (the name-convention case).
 		username := c.Username

--- a/internal/capacity/drain.go
+++ b/internal/capacity/drain.go
@@ -2,12 +2,21 @@ package capacity
 
 import (
 	"context"
+	"errors"
 	"log"
 	"sync"
 	"time"
 
 	"github.com/footprintai/containarium/pkg/core/incus"
 )
+
+// forceStopBudget bounds a single force-stop attempt so even the fallback
+// can't hang the drain indefinitely on a wedged stop.
+const forceStopBudget = 15 * time.Second
+
+// errStopTimedOut marks a stop that outlived its per-attempt budget. Treated
+// like a stop failure so the drain moves on (and force-retries a graceful one).
+var errStopTimedOut = errors.New("capacity: stop exceeded its budget")
 
 // DefaultDrainWindow is the bounded wall-clock budget a drain gets to evict the
 // guest workloads a backend had implicitly offered as headroom. Picked to be
@@ -168,19 +177,29 @@ func (d *Drainer) Drain(ctx context.Context, candidates []DrainCandidate, window
 
 	for _, c := range candidates {
 		// Past the window: force-stop the remainder so the host is reclaimed
-		// promptly. force=true skips the graceful shutdown wait, bounding the
-		// total time the drain can consume.
-		forced := !d.now().Before(deadline)
+		// promptly. force=true skips the graceful shutdown wait.
+		remaining := deadline.Sub(d.now())
+		forced := remaining <= 0
 		if forced {
 			res.WindowExceeded = true
 		}
 
-		if err := d.stopper.StopWorkload(ctx, c.Username, forced); err != nil {
-			// Graceful attempt failed and we still have window left: try once
-			// more with force before giving up, so a guest that ignores
-			// SIGTERM is still reclaimed rather than left running.
+		// Bound EACH attempt: StopWorkload (StopContainer) ignores ctx and can
+		// block for the backend's graceful timeout, so without a per-stop budget
+		// one stubborn guest makes the whole drain blow past `window`. A graceful
+		// stop gets the time left in the window; a forced stop gets forceStopBudget.
+		var err error
+		if forced {
+			err = d.stopWithBudget(ctx, c.Username, true, forceStopBudget)
+		} else {
+			err = d.stopWithBudget(ctx, c.Username, false, remaining)
+		}
+		if err != nil {
+			// Graceful attempt failed/timed out with window left: try once more
+			// with force before giving up, so a guest that ignores SIGTERM (or
+			// outlasts the graceful budget) is still reclaimed.
 			if !forced {
-				if ferr := d.stopper.StopWorkload(ctx, c.Username, true); ferr != nil {
+				if ferr := d.stopWithBudget(ctx, c.Username, true, forceStopBudget); ferr != nil {
 					res.Failed[c.ContainerName] = ferr.Error()
 					log.Printf("[drain] force-stop %s failed: %v", c.ContainerName, ferr)
 					continue
@@ -209,6 +228,25 @@ func (d *Drainer) Drain(ctx context.Context, candidates []DrainCandidate, window
 
 	res.Elapsed = d.now().Sub(start)
 	return res, false
+}
+
+// stopWithBudget runs a stop but returns once `budget` elapses even if the
+// underlying StopWorkload (which may ignore ctx) is still blocking — so a guest
+// that ignores SIGTERM can't push the drain past its window. The orphaned stop
+// keeps running in the background (the goroutine sends to a buffered channel
+// and exits, so it never leaks) and the daemon reconciles it on a later pass.
+func (d *Drainer) stopWithBudget(ctx context.Context, username string, force bool, budget time.Duration) error {
+	if budget <= 0 {
+		budget = forceStopBudget
+	}
+	done := make(chan error, 1)
+	go func() { done <- d.stopper.StopWorkload(ctx, username, force) }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(budget):
+		return errStopTimedOut
+	}
 }
 
 // now returns the drainer's clock (injectable for tests).

--- a/internal/capacity/drain_test.go
+++ b/internal/capacity/drain_test.go
@@ -1,0 +1,267 @@
+package capacity
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// fakeStopper records every StopWorkload call and lets a test script per-call
+// behavior (error once, error always) so the drainer's graceful→force fallback
+// and failure recording are observable.
+type fakeStopper struct {
+	mu    sync.Mutex
+	calls []stopCall
+	// failGraceful: usernames whose non-forced stop returns an error (the
+	// drainer should then retry with force).
+	failGraceful map[string]bool
+	// failAll: usernames whose stop always errors (records into Failed).
+	failAll map[string]bool
+}
+
+type stopCall struct {
+	username string
+	force    bool
+}
+
+func (f *fakeStopper) StopWorkload(_ context.Context, username string, force bool) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, stopCall{username: username, force: force})
+	if f.failAll[username] {
+		return errors.New("boom")
+	}
+	if !force && f.failGraceful[username] {
+		return errors.New("graceful refused")
+	}
+	return nil
+}
+
+func (f *fakeStopper) callsFor(username string) []stopCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []stopCall
+	for _, c := range f.calls {
+		if c.username == username {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func cand(name, user string) DrainCandidate {
+	return DrainCandidate{ContainerName: name, Username: user}
+}
+
+func TestDrainAllGraceful(t *testing.T) {
+	fs := &fakeStopper{}
+	d := NewDrainer(fs)
+	res, skipped := d.Drain(context.Background(),
+		[]DrainCandidate{cand("a-container", "a"), cand("b-container", "b")},
+		time.Minute)
+	if skipped {
+		t.Fatal("unexpected skip on first drain")
+	}
+	if len(res.Drained) != 2 {
+		t.Fatalf("Drained = %v, want 2", res.Drained)
+	}
+	if res.WindowExceeded {
+		t.Fatal("WindowExceeded should be false when nothing forced")
+	}
+	if len(res.ForceStopped) != 0 || len(res.Failed) != 0 {
+		t.Fatalf("expected no force/fail, got force=%v fail=%v", res.ForceStopped, res.Failed)
+	}
+	// Each was stopped exactly once, gracefully (force=false).
+	for _, u := range []string{"a", "b"} {
+		c := fs.callsFor(u)
+		if len(c) != 1 || c[0].force {
+			t.Fatalf("user %s calls = %+v, want one graceful stop", u, c)
+		}
+	}
+}
+
+func TestDrainGracefulRefusedFallsBackToForce(t *testing.T) {
+	fs := &fakeStopper{failGraceful: map[string]bool{"a": true}}
+	d := NewDrainer(fs)
+	res, _ := d.Drain(context.Background(),
+		[]DrainCandidate{cand("a-container", "a")}, time.Minute)
+
+	if len(res.ForceStopped) != 1 || res.ForceStopped[0] != "a-container" {
+		t.Fatalf("ForceStopped = %v, want [a-container]", res.ForceStopped)
+	}
+	if len(res.Failed) != 0 {
+		t.Fatalf("Failed = %v, want empty", res.Failed)
+	}
+	// First graceful (errored) then a forced retry.
+	c := fs.callsFor("a")
+	if len(c) != 2 || c[0].force || !c[1].force {
+		t.Fatalf("calls = %+v, want graceful then forced", c)
+	}
+}
+
+func TestDrainRecordsFailure(t *testing.T) {
+	fs := &fakeStopper{failAll: map[string]bool{"a": true}}
+	d := NewDrainer(fs)
+	res, _ := d.Drain(context.Background(),
+		[]DrainCandidate{cand("a-container", "a"), cand("b-container", "b")}, time.Minute)
+
+	if _, ok := res.Failed["a-container"]; !ok {
+		t.Fatalf("Failed should record a-container, got %v", res.Failed)
+	}
+	// A stuck guest must not block reclaiming the rest.
+	if len(res.Drained) != 1 || res.Drained[0] != "b-container" {
+		t.Fatalf("Drained = %v, want [b-container] (b still reclaimed)", res.Drained)
+	}
+}
+
+// TestDrainWindowExceededForcesRemainder pins the clock so the deadline is
+// already in the past on the second candidate; that candidate must be
+// force-stopped and WindowExceeded set.
+func TestDrainWindowExceededForcesRemainder(t *testing.T) {
+	fs := &fakeStopper{}
+	d := NewDrainer(fs)
+
+	base := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	// now() is called: start, then once per candidate for the deadline check,
+	// then once at the end for Elapsed. Window is 10s. Advance the clock past
+	// the deadline before the second candidate's check.
+	ticks := []time.Time{
+		base,                       // start
+		base.Add(1 * time.Second),  // candidate a: within window
+		base.Add(30 * time.Second), // candidate b: past 10s window
+		base.Add(31 * time.Second), // elapsed
+	}
+	i := 0
+	d.nowFn = func() time.Time {
+		t := ticks[i]
+		if i < len(ticks)-1 {
+			i++
+		}
+		return t
+	}
+
+	res, _ := d.Drain(context.Background(),
+		[]DrainCandidate{cand("a-container", "a"), cand("b-container", "b")},
+		10*time.Second)
+
+	if !res.WindowExceeded {
+		t.Fatal("WindowExceeded should be true")
+	}
+	if len(res.Drained) != 1 || res.Drained[0] != "a-container" {
+		t.Fatalf("Drained = %v, want [a-container]", res.Drained)
+	}
+	if len(res.ForceStopped) != 1 || res.ForceStopped[0] != "b-container" {
+		t.Fatalf("ForceStopped = %v, want [b-container]", res.ForceStopped)
+	}
+	// b was force-stopped (no graceful attempt once past the window).
+	c := fs.callsFor("b")
+	if len(c) != 1 || !c[0].force {
+		t.Fatalf("b calls = %+v, want single forced stop", c)
+	}
+}
+
+// TestDrainCoalescesConcurrent verifies the in-flight guard: a second drain
+// arriving while the first holds the lock is skipped (returns skipped=true,
+// zero result, no stops) — repeated withdraw cycles can't stack stop storms.
+func TestDrainCoalescesConcurrent(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{})
+	bs := &blockingStopper{entered: entered, release: release}
+	d := NewDrainer(bs)
+
+	var firstRes DrainResult
+	var firstSkipped bool
+	done := make(chan struct{})
+	go func() {
+		firstRes, firstSkipped = d.Drain(context.Background(),
+			[]DrainCandidate{cand("a-container", "a")}, time.Minute)
+		close(done)
+	}()
+
+	<-entered // first drain is now inside StopWorkload, holding the guard
+	res2, skipped2 := d.Drain(context.Background(),
+		[]DrainCandidate{cand("b-container", "b")}, time.Minute)
+	if !skipped2 {
+		t.Fatal("second concurrent drain should be coalesced (skipped)")
+	}
+	if len(res2.Drained) != 0 || len(res2.ForceStopped) != 0 {
+		t.Fatalf("skipped drain must return zero result, got %+v", res2)
+	}
+
+	close(release)
+	<-done
+	if firstSkipped {
+		t.Fatal("first drain should not be skipped")
+	}
+	if len(firstRes.Drained) != 1 {
+		t.Fatalf("first drain Drained = %v, want 1", firstRes.Drained)
+	}
+}
+
+// blockingStopper blocks inside the first StopWorkload until released, so the
+// test can race a second Drain against the in-flight guard deterministically.
+type blockingStopper struct {
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingStopper) StopWorkload(_ context.Context, _ string, _ bool) error {
+	b.once.Do(func() {
+		close(b.entered)
+		<-b.release
+	})
+	return nil
+}
+
+func TestDrainWindowDefaults(t *testing.T) {
+	fs := &fakeStopper{}
+	d := NewDrainer(fs)
+	// window <= 0 falls back to DefaultDrainWindow; with a graceful stopper the
+	// drain completes well inside it.
+	res, _ := d.Drain(context.Background(), []DrainCandidate{cand("a-container", "a")}, 0)
+	if res.WindowExceeded {
+		t.Fatal("default window should not be exceeded for an instant stop")
+	}
+	if len(res.Drained) != 1 {
+		t.Fatalf("Drained = %v, want 1", res.Drained)
+	}
+}
+
+func TestDrainCandidatesFiltersAndMapsUsername(t *testing.T) {
+	st := HostState{
+		Now: time.Now(),
+		Containers: []incus.ContainerInfo{
+			{Name: "guest-container", Username: "guest", State: "Running"},
+			{Name: "stopped-container", Username: "stopped", State: "Stopped"},
+			{Name: "core", State: "Running", Role: incus.RolePostgres},
+			{
+				Name:   "protected-container",
+				State:  "Running",
+				Labels: map[string]string{WorkloadClassLabel: "critical"},
+			},
+			// No Username reported: candidate falls back to the name.
+			{Name: "noname-container", State: "Running"},
+		},
+	}
+	p := Policy{ExcludedWorkloadClasses: []string{"critical"}}
+	got := DrainCandidates(p, st)
+
+	if len(got) != 2 {
+		t.Fatalf("got %d candidates, want 2: %+v", len(got), got)
+	}
+	byName := map[string]DrainCandidate{}
+	for _, c := range got {
+		byName[c.ContainerName] = c
+	}
+	if c, ok := byName["guest-container"]; !ok || c.Username != "guest" {
+		t.Fatalf("guest candidate = %+v, want username guest", c)
+	}
+	if c, ok := byName["noname-container"]; !ok || c.Username != "noname-container" {
+		t.Fatalf("noname candidate = %+v, want username fallback to name", c)
+	}
+}

--- a/internal/capacity/drain_test.go
+++ b/internal/capacity/drain_test.go
@@ -233,19 +233,25 @@ func TestDrainWindowDefaults(t *testing.T) {
 }
 
 func TestDrainCandidatesFiltersAndMapsUsername(t *testing.T) {
+	now := time.Now()
+	old := now.Add(-time.Hour) // idle past the default 15m threshold
 	st := HostState{
-		Now: time.Now(),
+		Now: now,
 		Containers: []incus.ContainerInfo{
-			{Name: "guest-container", Username: "guest", State: "Running"},
-			{Name: "stopped-container", Username: "stopped", State: "Stopped"},
-			{Name: "core", State: "Running", Role: incus.RolePostgres},
+			{Name: "guest-container", Username: "guest", State: "Running", LastStartedAt: old},
+			{Name: "stopped-container", Username: "stopped", State: "Stopped", LastStartedAt: old},
+			{Name: "core", State: "Running", Role: incus.RolePostgres, LastStartedAt: old},
 			{
-				Name:   "protected-container",
-				State:  "Running",
-				Labels: map[string]string{WorkloadClassLabel: "critical"},
+				Name:          "protected-container",
+				State:         "Running",
+				Labels:        map[string]string{WorkloadClassLabel: "critical"},
+				LastStartedAt: old,
 			},
+			// Running but only just started → still busy, not part of the idle
+			// spare the backend offered → must NOT be drained.
+			{Name: "busy-container", Username: "busy", State: "Running", LastStartedAt: now},
 			// No Username reported: candidate falls back to the name.
-			{Name: "noname-container", State: "Running"},
+			{Name: "noname-container", State: "Running", LastStartedAt: old},
 		},
 	}
 	p := Policy{ExcludedWorkloadClasses: []string{"critical"}}
@@ -263,5 +269,8 @@ func TestDrainCandidatesFiltersAndMapsUsername(t *testing.T) {
 	}
 	if c, ok := byName["noname-container"]; !ok || c.Username != "noname-container" {
 		t.Fatalf("noname candidate = %+v, want username fallback to name", c)
+	}
+	if _, ok := byName["busy-container"]; ok {
+		t.Fatalf("busy (non-idle) container must not be a drain candidate")
 	}
 }

--- a/internal/cmd/backends_profile.go
+++ b/internal/cmd/backends_profile.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	profileBackendSkipGPU bool
+	profileBackendGet     bool
+	profileBackendFormat  string
+)
+
+var backendsProfileCmd = &cobra.Command{
+	Use:   "profile [backend-id]",
+	Short: "Record (or read) a backend's hardware capability profile",
+	Long: `Record a backend's hardware capability profile: hardware class (CPU cores +
+model, GPU model via the passthrough probe, RAM/disk), a bounded CPU/memory
+micro-benchmark, and region. The measured class is reconciled against the
+backend's self-reported class so drift is visible.
+
+With no backend-id it profiles the local/primary daemon's host; with a peer id
+it forwards to that peer (which profiles its own host). The profile is surfaced
+through 'containarium backends list'.
+
+  --skip-gpu  skip the GPU passthrough probe (CPU-only backends; faster)
+  --get       read the last-recorded profile without re-running the benchmark
+
+Admin-only. Recording runs a short micro-benchmark and (unless --skip-gpu) a
+throwaway GPU probe LXC, so it can take ~30s. See #681.
+
+Requires --server pointing at the daemon's HTTP address.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runBackendsProfile,
+}
+
+func init() {
+	backendsCmd.AddCommand(backendsProfileCmd)
+	backendsProfileCmd.Flags().BoolVar(&profileBackendSkipGPU, "skip-gpu", false,
+		"Skip the GPU passthrough probe (CPU-only backends). Records gpu_available=false.")
+	backendsProfileCmd.Flags().BoolVar(&profileBackendGet, "get", false,
+		"Read the last-recorded profile instead of re-recording it.")
+	backendsProfileCmd.Flags().StringVarP(&profileBackendFormat, "format", "f", "text",
+		"Output format: text, json")
+}
+
+// profileBackendReq is the typed /v1/capabilities/profile request body.
+type profileBackendReq struct {
+	BackendID string `json:"backend_id,omitempty"`
+	SkipGpu   bool   `json:"skip_gpu,omitempty"`
+}
+
+// capabilityBenchmark mirrors the proto CapabilityBenchmark wire shape.
+type capabilityBenchmark struct {
+	CpuOpsPerSec   int64 `json:"cpuOpsPerSec,omitempty"`
+	MemBytesPerSec int64 `json:"memBytesPerSec,omitempty"`
+	DurationMs     int64 `json:"durationMs,omitempty"`
+}
+
+// capabilityProfile mirrors the proto CapabilityProfile wire shape (camelCase
+// via grpc-gateway JSON).
+type capabilityProfile struct {
+	CpuCores         int32                `json:"cpuCores,omitempty"`
+	CpuModel         string               `json:"cpuModel,omitempty"`
+	TotalMemoryBytes int64                `json:"totalMemoryBytes,omitempty"`
+	TotalDiskBytes   int64                `json:"totalDiskBytes,omitempty"`
+	GpuModel         string               `json:"gpuModel,omitempty"`
+	GpuDriverVersion string               `json:"gpuDriverVersion,omitempty"`
+	GpuAvailable     bool                 `json:"gpuAvailable,omitempty"`
+	Region           string               `json:"region,omitempty"`
+	ReportedClass    string               `json:"reportedClass,omitempty"`
+	MeasuredClass    string               `json:"measuredClass,omitempty"`
+	ClassConsistent  bool                 `json:"classConsistent,omitempty"`
+	Benchmark        *capabilityBenchmark `json:"benchmark,omitempty"`
+	ProfiledAt       string               `json:"profiledAt,omitempty"`
+}
+
+// profileBackendResp mirrors both ProfileBackendResponse and
+// GetCapabilityProfileResponse (same shape).
+type profileBackendResp struct {
+	Profile   *capabilityProfile `json:"profile"`
+	BackendID string             `json:"backendId"`
+}
+
+func runBackendsProfile(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (the platform daemon's HTTP address, e.g. http://host:8080)")
+	}
+	backendID := ""
+	if len(args) == 1 {
+		backendID = args[0]
+	}
+
+	url := strings.TrimSuffix(serverAddr, "/") + "/v1/capabilities/profile"
+	var req *http.Request
+	var err error
+	if profileBackendGet {
+		if backendID != "" {
+			url += "?backend_id=" + backendID
+		}
+		req, err = http.NewRequest("GET", url, nil)
+	} else {
+		reqBody, _ := json.Marshal(profileBackendReq{BackendID: backendID, SkipGpu: profileBackendSkipGPU})
+		req, err = http.NewRequest("POST", url, bytes.NewReader(reqBody))
+	}
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+
+	// Generous timeout: recording runs a micro-benchmark and (unless skipped)
+	// creates+starts+execs+deletes a throwaway GPU probe LXC.
+	httpClient := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	if profileBackendFormat == "json" {
+		if _, err := cmd.OutOrStdout().Write(body); err != nil {
+			return fmt.Errorf("write response: %w", err)
+		}
+		fmt.Fprintln(cmd.OutOrStdout())
+		return nil
+	}
+
+	var out profileBackendResp
+	if err := json.Unmarshal(body, &out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	target := out.BackendID
+	if target == "" {
+		target = "(local)"
+	}
+	if out.Profile == nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "no capability profile recorded for %s yet (run 'containarium backends profile %s')\n", target, out.BackendID)
+		return nil
+	}
+
+	p := out.Profile
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "Capability profile for %s:\n", target)
+	fmt.Fprintf(w, "  Region:          %s\n", orDash(p.Region))
+	fmt.Fprintf(w, "  CPU:             %d cores  %s\n", p.CpuCores, orDash(p.CpuModel))
+	fmt.Fprintf(w, "  Memory:          %s\n", humanBytes(p.TotalMemoryBytes))
+	fmt.Fprintf(w, "  Disk:            %s\n", humanBytes(p.TotalDiskBytes))
+	if p.GpuAvailable {
+		fmt.Fprintf(w, "  GPU:             %s (driver %s)\n", orDash(p.GpuModel), orDash(p.GpuDriverVersion))
+	} else {
+		fmt.Fprintf(w, "  GPU:             none\n")
+	}
+	if p.Benchmark != nil {
+		fmt.Fprintf(w, "  Benchmark:       CPU %d ops/s, mem %s/s (%dms)\n",
+			p.Benchmark.CpuOpsPerSec, humanBytes(p.Benchmark.MemBytesPerSec), p.Benchmark.DurationMs)
+	}
+	fmt.Fprintf(w, "  Reported class:  %s\n", orDash(p.ReportedClass))
+	fmt.Fprintf(w, "  Measured class:  %s\n", orDash(p.MeasuredClass))
+	if p.ClassConsistent {
+		fmt.Fprintf(w, "  Class:           consistent\n")
+	} else {
+		fmt.Fprintf(w, "  Class:           DRIFT — measured %q != reported %q\n", p.MeasuredClass, p.ReportedClass)
+	}
+	if p.ProfiledAt != "" {
+		fmt.Fprintf(w, "  Profiled at:     %s\n", p.ProfiledAt)
+	}
+	return nil
+}

--- a/internal/cmd/backends_self_measurement.go
+++ b/internal/cmd/backends_self_measurement.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var selfMeasurementFormat string
+
+var backendsSelfMeasurementCmd = &cobra.Command{
+	Use:   "self-measurement [backend-id]",
+	Short: "Fetch a backend's signed integrity self-measurement",
+	Long: `Fetch a backend's signed integrity self-measurement: digests of the running
+daemon binary, the loaded in-kernel network-policy program object(s), and the
+canonical policy/config state, signed with the node's identity key (the
+sentinel-issued peer leaf; TPM-backed when a TPM is present).
+
+The daemon also emits this measurement on its heartbeat. The control plane
+verifies it to detect tampering of a backend's control plane.
+
+With no backend-id it measures the local/primary daemon's host; with a peer id
+it forwards to that peer (which measures its own host).
+
+Admin-only. See #683.
+
+Requires --server pointing at the daemon's HTTP address.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runBackendsSelfMeasurement,
+}
+
+func init() {
+	backendsCmd.AddCommand(backendsSelfMeasurementCmd)
+	backendsSelfMeasurementCmd.Flags().StringVarP(&selfMeasurementFormat, "format", "f", "text",
+		"Output format: text, json")
+}
+
+// programDigest mirrors the proto ProgramDigest wire shape.
+type programDigest struct {
+	Name   string `json:"name,omitempty"`
+	Digest string `json:"digest,omitempty"`
+}
+
+// selfMeasurement mirrors the proto SelfMeasurement wire shape (camelCase via
+// grpc-gateway JSON).
+type selfMeasurement struct {
+	HashAlgorithm      string          `json:"hashAlgorithm,omitempty"`
+	BinaryDigest       string          `json:"binaryDigest,omitempty"`
+	ProgramDigests     []programDigest `json:"programDigests,omitempty"`
+	ConfigDigest       string          `json:"configDigest,omitempty"`
+	MeasurementDigest  string          `json:"measurementDigest,omitempty"`
+	Signature          string          `json:"signature,omitempty"`
+	SignatureAlgorithm string          `json:"signatureAlgorithm,omitempty"`
+	TpmBacked          bool            `json:"tpmBacked,omitempty"`
+	Signed             bool            `json:"signed,omitempty"`
+	SigningCertPem     string          `json:"signingCertPem,omitempty"`
+	MeasuredAt         string          `json:"measuredAt,omitempty"`
+	DaemonVersion      string          `json:"daemonVersion,omitempty"`
+}
+
+// selfMeasurementResp mirrors GetSelfMeasurementResponse.
+type selfMeasurementResp struct {
+	Measurement *selfMeasurement `json:"measurement"`
+	BackendID   string           `json:"backendId"`
+}
+
+func runBackendsSelfMeasurement(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (the platform daemon's HTTP address, e.g. http://host:8080)")
+	}
+	backendID := ""
+	if len(args) == 1 {
+		backendID = args[0]
+	}
+
+	url := strings.TrimSuffix(serverAddr, "/") + "/v1/integrity/self-measurement"
+	if backendID != "" {
+		url += "?backend_id=" + backendID
+	}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+
+	httpClient := &http.Client{Timeout: 1 * time.Minute}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	if selfMeasurementFormat == "json" {
+		if _, err := cmd.OutOrStdout().Write(body); err != nil {
+			return fmt.Errorf("write response: %w", err)
+		}
+		fmt.Fprintln(cmd.OutOrStdout())
+		return nil
+	}
+
+	var out selfMeasurementResp
+	if err := json.Unmarshal(body, &out); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	target := out.BackendID
+	if target == "" {
+		target = "(local)"
+	}
+	if out.Measurement == nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "no self-measurement returned for %s\n", target)
+		return nil
+	}
+
+	m := out.Measurement
+	w := cmd.OutOrStdout()
+	fmt.Fprintf(w, "Integrity self-measurement for %s:\n", target)
+	fmt.Fprintf(w, "  Measured at:     %s\n", orDash(m.MeasuredAt))
+	fmt.Fprintf(w, "  Daemon version:  %s\n", orDash(m.DaemonVersion))
+	fmt.Fprintf(w, "  Hash algorithm:  %s\n", orDash(m.HashAlgorithm))
+	fmt.Fprintf(w, "  Binary digest:   %s\n", orDash(m.BinaryDigest))
+	if len(m.ProgramDigests) == 0 {
+		fmt.Fprintf(w, "  Program objects: none\n")
+	} else {
+		fmt.Fprintf(w, "  Program objects:\n")
+		for _, p := range m.ProgramDigests {
+			fmt.Fprintf(w, "    %s = %s\n", p.Name, p.Digest)
+		}
+	}
+	fmt.Fprintf(w, "  Config digest:   %s\n", orDash(m.ConfigDigest))
+	fmt.Fprintf(w, "  Measurement:     %s\n", orDash(m.MeasurementDigest))
+	if m.Signed {
+		tpm := "software key"
+		if m.TpmBacked {
+			tpm = "TPM-backed key"
+		}
+		fmt.Fprintf(w, "  Signature:       SIGNED (%s, %s)\n", orDash(m.SignatureAlgorithm), tpm)
+	} else {
+		fmt.Fprintf(w, "  Signature:       UNSIGNED (no node identity key bootstrapped — unverifiable, not tamper)\n")
+	}
+	return nil
+}

--- a/internal/cmd/capacity.go
+++ b/internal/cmd/capacity.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -36,15 +37,23 @@ Examples:
   # Withdraw (idempotent)
   containarium capacity withdraw --server <host:port>
 
+  # Withdraw and gracefully reclaim the offered workloads within 120s
+  containarium capacity withdraw --drain --server <host:port>
+
+  # Withdraw and drain within a 30s bounded window
+  containarium capacity withdraw --drain --drain-window 30 --server <host:port>
+
   # Read the current advertisement
   containarium capacity get --server <host:port>`,
 }
 
 var (
-	capWindow   string
-	capReserve  float64
-	capExclude  []string
-	capFormat   string
+	capWindow      string
+	capReserve     float64
+	capExclude     []string
+	capFormat      string
+	capDrain       bool
+	capDrainWindow int32
 )
 
 type capacityPolicyJSON struct {
@@ -66,6 +75,11 @@ type capacityHeadroomJSON struct {
 
 type capacityHeadroomResponse struct {
 	Headroom *capacityHeadroomJSON `json:"headroom"`
+	// Drain fields are only populated by the withdraw response when --drain was
+	// requested (#682). Empty/false otherwise.
+	Drained             []string `json:"drained,omitempty"`
+	ForceStopped        []string `json:"forceStopped,omitempty"`
+	DrainWindowExceeded bool     `json:"drainWindowExceeded,omitempty"`
 }
 
 func init() {
@@ -91,6 +105,10 @@ func init() {
 		RunE:  runCapacityWithdraw,
 	}
 	withdrawCmd.Flags().StringVarP(&capFormat, "format", "f", "table", "Output format: table, json")
+	withdrawCmd.Flags().BoolVar(&capDrain, "drain", false,
+		"Also reclaim the guest workloads this backend offered, draining them gracefully within a bounded window")
+	withdrawCmd.Flags().Int32Var(&capDrainWindow, "drain-window", 0,
+		"Bounded wall-clock budget in seconds for the graceful drain (0 = backend default, 120s). Only honored with --drain")
 	capacityCmd.AddCommand(withdrawCmd)
 
 	getCmd := &cobra.Command{
@@ -154,7 +172,21 @@ func runCapacityWithdraw(cmd *cobra.Command, args []string) error {
 	if serverAddr == "" {
 		return fmt.Errorf("--server is required (the daemon's HTTP address, e.g. http://host:8080)")
 	}
-	return capacityCall("DELETE", "/v1/capacity/headroom", nil)
+	if capDrainWindow < 0 {
+		return fmt.Errorf("--drain-window must be >= 0, got %d", capDrainWindow)
+	}
+	// The withdraw RPC maps to DELETE; its drain knobs travel as query
+	// parameters (grpc-gateway populates the request from the query string).
+	path := "/v1/capacity/headroom"
+	if capDrain {
+		q := url.Values{}
+		q.Set("drain", "true")
+		if capDrainWindow > 0 {
+			q.Set("drainWindowSeconds", fmt.Sprintf("%d", capDrainWindow))
+		}
+		path += "?" + q.Encode()
+	}
+	return capacityCall("DELETE", path, nil)
 }
 
 func runCapacityGet(cmd *cobra.Command, args []string) error {
@@ -207,6 +239,13 @@ func capacityCall(method, path string, reqBody []byte) error {
 		fmt.Println(string(out))
 	default:
 		printHeadroom(parsed.Headroom)
+		if len(parsed.Drained) > 0 || len(parsed.ForceStopped) > 0 {
+			fmt.Printf("Drained gracefully: %d %v\n", len(parsed.Drained), parsed.Drained)
+			fmt.Printf("Force-stopped:      %d %v\n", len(parsed.ForceStopped), parsed.ForceStopped)
+			if parsed.DrainWindowExceeded {
+				fmt.Println("Note: drain window exceeded; remaining workloads were force-stopped.")
+			}
+		}
 	}
 	return nil
 }

--- a/internal/cmd/capacity.go
+++ b/internal/cmd/capacity.go
@@ -77,9 +77,10 @@ type capacityHeadroomResponse struct {
 	Headroom *capacityHeadroomJSON `json:"headroom"`
 	// Drain fields are only populated by the withdraw response when --drain was
 	// requested (#682). Empty/false otherwise.
-	Drained             []string `json:"drained,omitempty"`
-	ForceStopped        []string `json:"forceStopped,omitempty"`
-	DrainWindowExceeded bool     `json:"drainWindowExceeded,omitempty"`
+	Drained             []string          `json:"drained,omitempty"`
+	ForceStopped        []string          `json:"forceStopped,omitempty"`
+	DrainWindowExceeded bool              `json:"drainWindowExceeded,omitempty"`
+	Failed              map[string]string `json:"failed,omitempty"`
 }
 
 func init() {
@@ -239,11 +240,19 @@ func capacityCall(method, path string, reqBody []byte) error {
 		fmt.Println(string(out))
 	default:
 		printHeadroom(parsed.Headroom)
-		if len(parsed.Drained) > 0 || len(parsed.ForceStopped) > 0 {
+		if len(parsed.Drained) > 0 || len(parsed.ForceStopped) > 0 || len(parsed.Failed) > 0 || parsed.DrainWindowExceeded {
 			fmt.Printf("Drained gracefully: %d %v\n", len(parsed.Drained), parsed.Drained)
 			fmt.Printf("Force-stopped:      %d %v\n", len(parsed.ForceStopped), parsed.ForceStopped)
 			if parsed.DrainWindowExceeded {
 				fmt.Println("Note: drain window exceeded; remaining workloads were force-stopped.")
+			}
+			if len(parsed.Failed) > 0 {
+				// Surface failures prominently — these guests are still running,
+				// so the host is NOT fully reclaimed.
+				fmt.Printf("FAILED to stop:     %d (host NOT fully reclaimed)\n", len(parsed.Failed))
+				for name, msg := range parsed.Failed {
+					fmt.Printf("  - %s: %s\n", name, msg)
+				}
 			}
 		}
 	}

--- a/internal/cmd/capacity.go
+++ b/internal/cmd/capacity.go
@@ -1,0 +1,241 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// capacityCmd is the parent for advertising / withdrawing this backend's spare
+// scheduling headroom to the control plane (#680). A box that would otherwise
+// scale down can instead offer its freed headroom for control-plane-directed
+// scheduling, bounded by a local policy.
+var capacityCmd = &cobra.Command{
+	Use:   "capacity",
+	Short: "Advertise or withdraw this backend's spare scheduling capacity",
+	Long: `Publish (or withdraw) this backend's spare scheduling headroom to the
+control plane. The advertisement is bounded by a local policy: an
+optional time window, excluded workload classes, and a safety
+reservation. It is surfaced through the backend list (containarium
+backends list).
+
+Examples:
+  # Advertise all available headroom (always-open window)
+  containarium capacity advertise --server <host:port>
+
+  # Advertise only 09:00-17:00, holding back 20%, excluding a class
+  containarium capacity advertise --window 9-17 --reserve 0.2 \
+      --exclude batch --server <host:port>
+
+  # Withdraw (idempotent)
+  containarium capacity withdraw --server <host:port>
+
+  # Read the current advertisement
+  containarium capacity get --server <host:port>`,
+}
+
+var (
+	capWindow   string
+	capReserve  float64
+	capExclude  []string
+	capFormat   string
+)
+
+type capacityPolicyJSON struct {
+	WindowStartHour         int32    `json:"windowStartHour,omitempty"`
+	WindowEndHour           int32    `json:"windowEndHour,omitempty"`
+	ExcludedWorkloadClasses []string `json:"excludedWorkloadClasses,omitempty"`
+	ReserveFraction         float64  `json:"reserveFraction,omitempty"`
+}
+
+type capacityHeadroomJSON struct {
+	Advertised       bool                `json:"advertised"`
+	SpareCpus        int32               `json:"spareCpus,omitempty"`
+	SpareMemoryBytes int64               `json:"spareMemoryBytes,omitempty"`
+	SpareDiskBytes   int64               `json:"spareDiskBytes,omitempty"`
+	IdleFraction     float64             `json:"idleFraction,omitempty"`
+	AdvertisedAt     string              `json:"advertisedAt,omitempty"`
+	Policy           *capacityPolicyJSON `json:"policy,omitempty"`
+}
+
+type capacityHeadroomResponse struct {
+	Headroom *capacityHeadroomJSON `json:"headroom"`
+}
+
+func init() {
+	rootCmd.AddCommand(capacityCmd)
+
+	advertiseCmd := &cobra.Command{
+		Use:   "advertise",
+		Short: "Advertise spare scheduling capacity (bounded by a local policy)",
+		RunE:  runCapacityAdvertise,
+	}
+	advertiseCmd.Flags().StringVar(&capWindow, "window", "",
+		"Local-clock advertisement window as START-END hours (e.g. 9-17, or 22-6 for overnight); empty = always open")
+	advertiseCmd.Flags().Float64Var(&capReserve, "reserve", 0,
+		"Fraction of host resources to hold back as a safety reservation [0,1)")
+	advertiseCmd.Flags().StringSliceVar(&capExclude, "exclude", nil,
+		"Workload class(es) to exclude from the idle/spare computation (repeatable)")
+	advertiseCmd.Flags().StringVarP(&capFormat, "format", "f", "table", "Output format: table, json")
+	capacityCmd.AddCommand(advertiseCmd)
+
+	withdrawCmd := &cobra.Command{
+		Use:   "withdraw",
+		Short: "Withdraw the spare-capacity advertisement (idempotent)",
+		RunE:  runCapacityWithdraw,
+	}
+	withdrawCmd.Flags().StringVarP(&capFormat, "format", "f", "table", "Output format: table, json")
+	capacityCmd.AddCommand(withdrawCmd)
+
+	getCmd := &cobra.Command{
+		Use:   "get",
+		Short: "Show the current spare-capacity advertisement",
+		RunE:  runCapacityGet,
+	}
+	getCmd.Flags().StringVarP(&capFormat, "format", "f", "table", "Output format: table, json")
+	capacityCmd.AddCommand(getCmd)
+}
+
+// parseWindow turns "9-17" / "22-6" into (start, end) hours. An empty string
+// yields (0,0) which the daemon treats as always-open.
+func parseWindow(w string) (int32, int32, error) {
+	if w == "" {
+		return 0, 0, nil
+	}
+	parts := strings.SplitN(w, "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid --window %q (want START-END, e.g. 9-17)", w)
+	}
+	var start, end int32
+	if _, err := fmt.Sscanf(parts[0], "%d", &start); err != nil {
+		return 0, 0, fmt.Errorf("invalid window start %q: %w", parts[0], err)
+	}
+	if _, err := fmt.Sscanf(parts[1], "%d", &end); err != nil {
+		return 0, 0, fmt.Errorf("invalid window end %q: %w", parts[1], err)
+	}
+	if start < 0 || start > 23 || end < 0 || end > 23 {
+		return 0, 0, fmt.Errorf("window hours must be 0-23, got %d-%d", start, end)
+	}
+	return start, end, nil
+}
+
+func runCapacityAdvertise(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (the daemon's HTTP address, e.g. http://host:8080)")
+	}
+	start, end, err := parseWindow(capWindow)
+	if err != nil {
+		return err
+	}
+	if capReserve < 0 || capReserve >= 1 {
+		return fmt.Errorf("--reserve must be in [0,1), got %v", capReserve)
+	}
+	body, err := json.Marshal(map[string]any{
+		"policy": capacityPolicyJSON{
+			WindowStartHour:         start,
+			WindowEndHour:           end,
+			ExcludedWorkloadClasses: capExclude,
+			ReserveFraction:         capReserve,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return capacityCall("POST", "/v1/capacity/headroom", body)
+}
+
+func runCapacityWithdraw(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (the daemon's HTTP address, e.g. http://host:8080)")
+	}
+	return capacityCall("DELETE", "/v1/capacity/headroom", nil)
+}
+
+func runCapacityGet(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required (the daemon's HTTP address, e.g. http://host:8080)")
+	}
+	return capacityCall("GET", "/v1/capacity/headroom", nil)
+}
+
+func capacityCall(method, path string, reqBody []byte) error {
+	url := strings.TrimSuffix(serverAddr, "/") + path
+	var rdr io.Reader
+	if reqBody != nil {
+		rdr = bytes.NewReader(reqBody)
+	}
+	req, err := http.NewRequest(method, url, rdr)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("api error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var parsed capacityHeadroomResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	switch capFormat {
+	case "json":
+		out, err := json.MarshalIndent(parsed, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(out))
+	default:
+		printHeadroom(parsed.Headroom)
+	}
+	return nil
+}
+
+func printHeadroom(h *capacityHeadroomJSON) {
+	if h == nil {
+		fmt.Println("No headroom advertised.")
+		return
+	}
+	state := "withdrawn"
+	if h.Advertised {
+		state = "advertised"
+	}
+	fmt.Printf("Capacity advertisement: %s\n", state)
+	if h.Advertised {
+		fmt.Printf("  spare cpus:   %d\n", h.SpareCpus)
+		fmt.Printf("  spare memory: %d bytes\n", h.SpareMemoryBytes)
+		fmt.Printf("  spare disk:   %d bytes\n", h.SpareDiskBytes)
+		fmt.Printf("  idle frac:    %.2f\n", h.IdleFraction)
+		if h.AdvertisedAt != "" {
+			fmt.Printf("  since:        %s\n", h.AdvertisedAt)
+		}
+	}
+	if h.Policy != nil {
+		win := "always open"
+		if h.Policy.WindowStartHour != h.Policy.WindowEndHour {
+			win = fmt.Sprintf("%02d:00-%02d:00", h.Policy.WindowStartHour, h.Policy.WindowEndHour)
+		}
+		fmt.Printf("  policy:       window=%s reserve=%.2f exclude=%v\n",
+			win, h.Policy.ReserveFraction, h.Policy.ExcludedWorkloadClasses)
+	}
+}

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -54,6 +54,7 @@ var (
 	peerAddrs          []string
 	localBackendID     string
 	pool               string
+	region             string
 	publicHostname     string
 	publicAliases      []string
 	publicBaseDomains  []string
@@ -143,6 +144,7 @@ func init() {
 	daemonCmd.Flags().StringSliceVar(&peerAddrs, "peers", nil, "Static peer daemon addresses (e.g., 10.128.0.5:18001)")
 	daemonCmd.Flags().StringVar(&localBackendID, "backend-id", "", "This daemon's backend ID (defaults to hostname)")
 	daemonCmd.Flags().StringVar(&pool, "pool", "", "Pool name to scope sentinel peer discovery (empty = unscoped, see all peers)")
+	daemonCmd.Flags().StringVar(&region, "region", "", "Region this backend serves; recorded in its capability profile (containarium backends profile). Empty falls back to the --pool name.")
 	daemonCmd.Flags().StringVar(&publicHostname, "public-hostname", "", "Public hostname this primary serves (e.g. prod.example.com); enables sentinel primary registration")
 	daemonCmd.Flags().StringSliceVar(&publicAliases, "public-aliases", nil, "Additional hostnames the primary's Caddy serves (e.g. api.example.com,voice.example.com); the sentinel SNI router treats these as aliases of --public-hostname")
 	daemonCmd.Flags().StringSliceVar(&publicBaseDomains, "public-base-domain", nil, "Suffix-match anchor advertised to the sentinel — inbound SNI of the form <anything>.<public-base-domain> routes here without each subdomain being a registered alias. Repeatable: list multiple to host workloads under different parent domains on the same backend (e.g. --public-base-domain lab.example.com --public-base-domain demo.example.org). Defaults to [--base-domain] when unset. See docs/PER-POOL-BASE-DOMAIN.md.")
@@ -487,6 +489,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		Peers:                peerAddrs,
 		LocalBackendID:       resolveBackendID(localBackendID),
 		Pool:                 pool,
+		Region:               region,
 		PublicHostname:       publicHostname,
 		PublicAliases:        publicAliases,
 		PublicBaseDomains:    resolvePublicBaseDomains(publicBaseDomains, baseDomain),

--- a/internal/integrity/integrity.go
+++ b/internal/integrity/integrity.go
@@ -237,7 +237,7 @@ func digestFile(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err

--- a/internal/integrity/integrity.go
+++ b/internal/integrity/integrity.go
@@ -1,0 +1,267 @@
+// Package integrity turns a backend's own runtime state into a signed
+// self-measurement that the control plane verifies out of band of the
+// backend's normal reporting, to detect tampering of a backend's control
+// plane.
+//
+// The measurement hashes three things:
+//   - the running daemon binary on disk,
+//   - the loaded in-kernel network-policy program object(s), and
+//   - the canonical policy/config state (the integrity-relevant daemon
+//     configuration + active network-policy posture).
+//
+// Those component digests are folded into one canonical byte string, hashed
+// once more to a measurement digest, and signed with the node's identity key.
+// The signer is supplied by the caller: the daemon reuses the sentinel-issued
+// peer leaf private key from the peer-PKI plumbing (TPM-backed when a TPM is
+// present, software-signed via the peer key otherwise). When no identity key
+// is available the measurement is still produced, just unsigned — the control
+// plane treats an unsigned measurement as unverifiable, not as tamper.
+//
+// The compute here is pure (no proto, no Incus, no filesystem assumptions
+// beyond reading the paths the caller hands it) so it is unit-testable in
+// isolation; the server gathers the inputs (binary path, program-object
+// paths, config snapshot, signer) and maps the result onto the wire type.
+// This is the node-side half only; the control plane's verification and
+// quarantine logic lives elsewhere. See #683.
+package integrity
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// HashAlgorithm is the digest algorithm name recorded in the measurement. Only
+// sha256 is produced today; the field makes the choice explicit on the wire so
+// a future change is unambiguous to the verifier.
+const HashAlgorithm = "sha256"
+
+// SignatureAlgorithmECDSAP256SHA256 is the scheme recorded when an ECDSA P-256
+// identity key (the sentinel-issued peer leaf) signs the measurement.
+const SignatureAlgorithmECDSAP256SHA256 = "ecdsa-p256-sha256"
+
+// ProgramObject identifies one in-kernel program object to digest: a stable
+// name (the configured object path) and the path to read its bytes from.
+type ProgramObject struct {
+	// Name is the stable identifier recorded in the measurement (typically the
+	// configured object path itself).
+	Name string
+	// Path is where to read the object bytes from. When empty, Name is used as
+	// the path.
+	Path string
+}
+
+// Inputs is the snapshot the measurement compute consumes. The caller (the
+// daemon) gathers it: the running binary path, the loaded program objects, a
+// canonicalizable config-state snapshot, the daemon version, and a signer.
+type Inputs struct {
+	// BinaryPath is the path to the running daemon binary on disk. Empty skips
+	// the binary digest (recorded as empty).
+	BinaryPath string
+
+	// Programs are the loaded in-kernel program object(s) to digest. Empty when
+	// no program object is configured on this backend.
+	Programs []ProgramObject
+
+	// ConfigState is the integrity-relevant policy/config snapshot. It is
+	// serialized canonically (sorted keys) before hashing so two daemons with
+	// the same posture produce the same digest regardless of map ordering. Nil
+	// is treated as an empty object.
+	ConfigState map[string]string
+
+	// DaemonVersion is recorded into the measurement.
+	DaemonVersion string
+
+	// Signer is the node identity key. When nil the measurement is produced
+	// unsigned. Today the daemon passes its sentinel-issued peer leaf key
+	// (an *ecdsa.PrivateKey via tls.Certificate.PrivateKey).
+	Signer crypto.Signer
+
+	// SigningCertPEM is the PEM of the signing certificate (the peer leaf), so
+	// the verifier can check the signature against the sentinel CA without a
+	// side lookup. Empty when unsigned or unavailable.
+	SigningCertPEM string
+
+	// TPMBacked records whether Signer is a TPM-backed key. The daemon sets this
+	// when a TPM provided the key; false means the software peer key signed.
+	TPMBacked bool
+
+	// Now is injected so callers/tests can pin the recorded timestamp.
+	Now time.Time
+}
+
+// ProgramDigest is one program object's identity + digest.
+type ProgramDigest struct {
+	Name   string
+	Digest string
+}
+
+// Measurement is the computed, possibly-signed self-measurement. It mirrors
+// pb.SelfMeasurement but carries no proto dependency; the server maps it onto
+// the wire type.
+type Measurement struct {
+	HashAlgorithm      string
+	BinaryDigest       string
+	ProgramDigests     []ProgramDigest
+	ConfigDigest       string
+	MeasurementDigest  string
+	Signature          string
+	SignatureAlgorithm string
+	TPMBacked          bool
+	Signed             bool
+	SigningCertPEM     string
+	MeasuredAt         time.Time
+	DaemonVersion      string
+}
+
+// Compute reads the inputs, builds the component digests, folds them into a
+// canonical measurement, and signs it when a signer is supplied. Read errors
+// on the binary or a program object are returned (a measurement we cannot
+// build from real bytes would be misleading); a nil/absent signer is not an
+// error — it yields an unsigned measurement.
+func Compute(in Inputs) (Measurement, error) {
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	m := Measurement{
+		HashAlgorithm: HashAlgorithm,
+		DaemonVersion: in.DaemonVersion,
+		MeasuredAt:    now.UTC(),
+	}
+
+	if in.BinaryPath != "" {
+		d, err := digestFile(in.BinaryPath)
+		if err != nil {
+			return Measurement{}, fmt.Errorf("digest daemon binary %q: %w", in.BinaryPath, err)
+		}
+		m.BinaryDigest = d
+	}
+
+	// Digest each program object, then sort by name for a stable order so the
+	// measurement (and its signature) is deterministic regardless of the
+	// caller's slice ordering.
+	for _, p := range in.Programs {
+		path := p.Path
+		if path == "" {
+			path = p.Name
+		}
+		d, err := digestFile(path)
+		if err != nil {
+			return Measurement{}, fmt.Errorf("digest program object %q: %w", p.Name, err)
+		}
+		m.ProgramDigests = append(m.ProgramDigests, ProgramDigest{Name: p.Name, Digest: d})
+	}
+	sort.Slice(m.ProgramDigests, func(i, j int) bool {
+		return m.ProgramDigests[i].Name < m.ProgramDigests[j].Name
+	})
+
+	m.ConfigDigest = digestConfigState(in.ConfigState)
+
+	// Fold the components into the canonical measurement bytes. This is exactly
+	// what gets signed and what measurement_digest covers, so the verifier
+	// reconstructs the same bytes from the component fields.
+	canonical := canonicalBytes(m)
+	sum := sha256.Sum256(canonical)
+	m.MeasurementDigest = hex.EncodeToString(sum[:])
+
+	if in.Signer == nil {
+		// Unsigned but valid measurement.
+		return m, nil
+	}
+
+	sig, alg, err := sign(in.Signer, sum[:])
+	if err != nil {
+		return Measurement{}, fmt.Errorf("sign measurement: %w", err)
+	}
+	m.Signature = base64.StdEncoding.EncodeToString(sig)
+	m.SignatureAlgorithm = alg
+	m.Signed = true
+	m.TPMBacked = in.TPMBacked
+	m.SigningCertPEM = in.SigningCertPEM
+	return m, nil
+}
+
+// canonicalBytes builds the deterministic byte string that is hashed +
+// signed. A line-oriented, field-tagged encoding keeps it human-auditable and
+// trivially reproducible by a verifier in any language, and avoids JSON map
+// ordering surprises. The measurement_digest / signature fields are excluded —
+// they are derived from these bytes.
+func canonicalBytes(m Measurement) []byte {
+	var b strings.Builder
+	b.WriteString("containarium.self-measurement.v1\n")
+	b.WriteString("hash=" + m.HashAlgorithm + "\n")
+	b.WriteString("daemon_version=" + m.DaemonVersion + "\n")
+	b.WriteString("measured_at=" + m.MeasuredAt.UTC().Format(time.RFC3339Nano) + "\n")
+	b.WriteString("binary=" + m.BinaryDigest + "\n")
+	for _, p := range m.ProgramDigests {
+		b.WriteString("program=" + p.Name + ":" + p.Digest + "\n")
+	}
+	b.WriteString("config=" + m.ConfigDigest + "\n")
+	return []byte(b.String())
+}
+
+// digestConfigState canonicalizes the config snapshot (sorted keys) and hashes
+// it. A nil/empty map hashes the empty object so the field is always present
+// and stable.
+func digestConfigState(state map[string]string) string {
+	keys := make([]string, 0, len(state))
+	for k := range state {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	h := sha256.New()
+	enc := json.NewEncoder(h)
+	for _, k := range keys {
+		// Encode each key/value pair via json so embedded separators in values
+		// can't forge a different pairing.
+		_ = enc.Encode([2]string{k, state[k]})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// digestFile streams a file through SHA-256 and returns the hex digest.
+func digestFile(path string) (string, error) {
+	f, err := os.Open(path) // #nosec G304 -- path is operator/daemon-controlled (binary + configured program object), not user input
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// sign signs the measurement digest with the node identity key. ECDSA keys
+// (the sentinel-issued peer leaf) sign the digest directly; any other
+// crypto.Signer is signed with SHA-256 as the opts hash. The returned
+// algorithm string records the scheme for the verifier.
+func sign(signer crypto.Signer, digest []byte) (sig []byte, alg string, err error) {
+	switch signer.(type) {
+	case *ecdsa.PrivateKey:
+		s, err := signer.Sign(rand.Reader, digest, crypto.SHA256)
+		if err != nil {
+			return nil, "", err
+		}
+		return s, SignatureAlgorithmECDSAP256SHA256, nil
+	default:
+		s, err := signer.Sign(rand.Reader, digest, crypto.SHA256)
+		if err != nil {
+			return nil, "", err
+		}
+		return s, "sha256", nil
+	}
+}

--- a/internal/integrity/integrity_test.go
+++ b/internal/integrity/integrity_test.go
@@ -1,0 +1,195 @@
+package integrity
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeTemp(t *testing.T, name string, data []byte) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+func TestCompute_Unsigned(t *testing.T) {
+	bin := writeTemp(t, "daemon", []byte("daemon-bytes"))
+	prog := writeTemp(t, "policy.o", []byte("ebpf-object-bytes"))
+
+	now := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	m, err := Compute(Inputs{
+		BinaryPath:    bin,
+		Programs:      []ProgramObject{{Name: "policy.o", Path: prog}},
+		ConfigState:   map[string]string{"enforce": "1", "base_domain": "example.com"},
+		DaemonVersion: "v0.28.0",
+		Now:           now,
+	})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	// No signer → unsigned but still a complete measurement.
+	if m.Signed {
+		t.Errorf("expected unsigned measurement, got Signed=true")
+	}
+	if m.Signature != "" {
+		t.Errorf("expected empty signature, got %q", m.Signature)
+	}
+
+	// Binary digest matches a direct sha256 of the file bytes.
+	wantBin := sha256.Sum256([]byte("daemon-bytes"))
+	if m.BinaryDigest != hex.EncodeToString(wantBin[:]) {
+		t.Errorf("binary digest mismatch: got %s", m.BinaryDigest)
+	}
+	if len(m.ProgramDigests) != 1 || m.ProgramDigests[0].Name != "policy.o" {
+		t.Fatalf("expected 1 program digest named policy.o, got %+v", m.ProgramDigests)
+	}
+	wantProg := sha256.Sum256([]byte("ebpf-object-bytes"))
+	if m.ProgramDigests[0].Digest != hex.EncodeToString(wantProg[:]) {
+		t.Errorf("program digest mismatch: got %s", m.ProgramDigests[0].Digest)
+	}
+	if m.MeasurementDigest == "" || m.ConfigDigest == "" {
+		t.Errorf("expected non-empty measurement/config digests")
+	}
+	if m.HashAlgorithm != HashAlgorithm {
+		t.Errorf("hash algorithm: got %s want %s", m.HashAlgorithm, HashAlgorithm)
+	}
+}
+
+func TestCompute_Deterministic(t *testing.T) {
+	bin := writeTemp(t, "daemon", []byte("x"))
+	now := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	in := Inputs{
+		BinaryPath:    bin,
+		ConfigState:   map[string]string{"a": "1", "b": "2"},
+		DaemonVersion: "v1",
+		Now:           now,
+	}
+	m1, err := Compute(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m2, err := Compute(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m1.MeasurementDigest != m2.MeasurementDigest {
+		t.Errorf("measurement digest not deterministic: %s vs %s", m1.MeasurementDigest, m2.MeasurementDigest)
+	}
+
+	// Config map ordering must not affect the config digest.
+	in.ConfigState = map[string]string{"b": "2", "a": "1"}
+	m3, err := Compute(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m3.ConfigDigest != m1.ConfigDigest {
+		t.Errorf("config digest depends on map ordering: %s vs %s", m3.ConfigDigest, m1.ConfigDigest)
+	}
+}
+
+func TestCompute_ProgramDigestsSorted(t *testing.T) {
+	bin := writeTemp(t, "daemon", []byte("x"))
+	p1 := writeTemp(t, "zeta.o", []byte("z"))
+	p2 := writeTemp(t, "alpha.o", []byte("a"))
+	m, err := Compute(Inputs{
+		BinaryPath: bin,
+		Programs: []ProgramObject{
+			{Name: "zeta.o", Path: p1},
+			{Name: "alpha.o", Path: p2},
+		},
+		Now: time.Unix(0, 0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.ProgramDigests) != 2 {
+		t.Fatalf("expected 2 program digests, got %d", len(m.ProgramDigests))
+	}
+	if m.ProgramDigests[0].Name != "alpha.o" || m.ProgramDigests[1].Name != "zeta.o" {
+		t.Errorf("program digests not sorted by name: %+v", m.ProgramDigests)
+	}
+}
+
+func TestCompute_Signed_VerifiesECDSA(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin := writeTemp(t, "daemon", []byte("signed-daemon"))
+
+	m, err := Compute(Inputs{
+		BinaryPath:    bin,
+		DaemonVersion: "v1",
+		Signer:        key,
+		Now:           time.Unix(0, 0),
+	})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if !m.Signed {
+		t.Fatalf("expected Signed=true")
+	}
+	if m.SignatureAlgorithm != SignatureAlgorithmECDSAP256SHA256 {
+		t.Errorf("signature algorithm: got %q", m.SignatureAlgorithm)
+	}
+
+	// The signature must verify over the SHA-256 of the canonical bytes, which
+	// equals the bytes the measurement_digest covers. A verifier reconstructs
+	// the canonical bytes from the component fields.
+	canonical := canonicalBytes(m)
+	sum := sha256.Sum256(canonical)
+	if hex.EncodeToString(sum[:]) != m.MeasurementDigest {
+		t.Fatalf("measurement digest does not match canonical bytes")
+	}
+	sig, err := base64.StdEncoding.DecodeString(m.Signature)
+	if err != nil {
+		t.Fatalf("decode signature: %v", err)
+	}
+	if !ecdsa.VerifyASN1(&key.PublicKey, sum[:], sig) {
+		t.Errorf("ECDSA signature did not verify")
+	}
+}
+
+func TestCompute_TamperBreaksSignature(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	bin := writeTemp(t, "daemon", []byte("orig"))
+	m, err := Compute(Inputs{BinaryPath: bin, Signer: key, Now: time.Unix(0, 0)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a verifier that recomputes the canonical bytes after the binary
+	// digest is tampered: the signature must no longer verify.
+	tampered := m
+	tampered.BinaryDigest = "deadbeef"
+	sum := sha256.Sum256(canonicalBytes(tampered))
+	sig, _ := base64.StdEncoding.DecodeString(m.Signature)
+	if ecdsa.VerifyASN1(&key.PublicKey, sum[:], sig) {
+		t.Errorf("signature verified over tampered measurement — integrity check is broken")
+	}
+}
+
+func TestCompute_MissingBinaryErrors(t *testing.T) {
+	_, err := Compute(Inputs{BinaryPath: filepath.Join(t.TempDir(), "nope")})
+	if err == nil {
+		t.Errorf("expected error for missing binary path")
+	}
+}
+
+// ensure x509 import is exercised (cert parsing not strictly needed here but
+// documents that signing_cert_pem is opaque to Compute).
+var _ = x509.ParseCertificate
+var _ = big.NewInt

--- a/internal/server/capability_handler_test.go
+++ b/internal/server/capability_handler_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// The capability-profile RPCs (#681) are admin-only: they read/record a
+// fleet-level hardware signal, not a tenant resource.
+
+func TestProfileBackend_RejectsNonAdmin(t *testing.T) {
+	srv := &ContainerServer{}
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "user")
+	if _, err := srv.ProfileBackend(ctx, &pb.ProfileBackendRequest{}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin must be denied; got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestGetCapabilityProfile_RejectsNonAdmin(t *testing.T) {
+	srv := &ContainerServer{}
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "user")
+	if _, err := srv.GetCapabilityProfile(ctx, &pb.GetCapabilityProfileRequest{}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin must be denied; got %v (%v)", status.Code(err), err)
+	}
+}
+
+// GetCapabilityProfile before any ProfileBackend returns a null profile (not an
+// error) so the control plane can tell "unprofiled" from "profiled".
+func TestGetCapabilityProfile_NullBeforeProfiling(t *testing.T) {
+	srv := &ContainerServer{}
+	ctx := auth.ContextWithSystemIdentity(context.Background())
+	resp, err := srv.GetCapabilityProfile(ctx, &pb.GetCapabilityProfileRequest{})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if resp.Profile != nil {
+		t.Fatalf("expected null profile before profiling; got %+v", resp.Profile)
+	}
+}
+
+// Profile (skip GPU, nil manager) → Get records and reads back. The nil manager
+// + missing Incus daemon yields zero hardware figures, but the benchmark runs
+// and the profile is persisted and class-reconciled. reportedClass is set so we
+// can assert the reconciliation path.
+func TestProfileBackendRecordsAndPersists(t *testing.T) {
+	srv := &ContainerServer{}
+	srv.SetCapabilityIdentity("region-a", "")
+	ctx := auth.ContextWithSystemIdentity(context.Background())
+
+	rec, err := srv.ProfileBackend(ctx, &pb.ProfileBackendRequest{SkipGpu: true})
+	if err != nil {
+		t.Fatalf("profile: %v", err)
+	}
+	if rec.Profile == nil {
+		t.Fatalf("profile response must carry a profile")
+	}
+	if rec.Profile.Region != "region-a" {
+		t.Fatalf("region = %q, want region-a", rec.Profile.Region)
+	}
+	// Empty reported class is treated as consistent.
+	if !rec.Profile.ClassConsistent {
+		t.Fatalf("empty reported class must reconcile as consistent; got %+v", rec.Profile)
+	}
+	if rec.Profile.Benchmark == nil || rec.Profile.Benchmark.CpuOpsPerSec <= 0 {
+		t.Fatalf("benchmark must run and report positive CPU score; got %+v", rec.Profile.Benchmark)
+	}
+	if rec.Profile.ProfiledAt == "" {
+		t.Fatalf("profiledAt must be stamped")
+	}
+
+	got, err := srv.GetCapabilityProfile(ctx, &pb.GetCapabilityProfileRequest{})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Profile == nil || got.Profile.Region != "region-a" {
+		t.Fatalf("get after profile must return the persisted profile; got %+v", got.Profile)
+	}
+}

--- a/internal/server/capacity_handler_test.go
+++ b/internal/server/capacity_handler_test.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// The capacity RPCs (#680) are admin-only: they read/mutate a fleet-level
+// scheduling signal, not a tenant resource.
+
+func TestAdvertiseCapacity_RejectsNonAdmin(t *testing.T) {
+	srv := &ContainerServer{}
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "user")
+	if _, err := srv.AdvertiseCapacity(ctx, &pb.AdvertiseCapacityRequest{}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin must be denied; got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestWithdrawCapacity_RejectsNonAdmin(t *testing.T) {
+	srv := &ContainerServer{}
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "user")
+	if _, err := srv.WithdrawCapacity(ctx, &pb.WithdrawCapacityRequest{}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin must be denied; got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestGetCapacityHeadroom_RejectsNonAdmin(t *testing.T) {
+	srv := &ContainerServer{}
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "user")
+	if _, err := srv.GetCapacityHeadroom(ctx, &pb.GetCapacityHeadroomRequest{}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin must be denied; got %v (%v)", status.Code(err), err)
+	}
+}
+
+// Advertise → Get → Withdraw (twice) exercises the lifecycle and the
+// idempotence of withdraw. The nil manager makes hostStateSnapshot return a
+// zero-resource snapshot, so the spare figures are zero but the advertise /
+// withdraw state transitions are still observable.
+func TestCapacityLifecycleIdempotentWithdraw(t *testing.T) {
+	srv := &ContainerServer{}
+	ctx := auth.ContextWithSystemIdentity(context.Background())
+
+	adv, err := srv.AdvertiseCapacity(ctx, &pb.AdvertiseCapacityRequest{
+		Policy: &pb.CapacityPolicy{ReserveFraction: 0.1},
+	})
+	if err != nil {
+		t.Fatalf("advertise: %v", err)
+	}
+	if adv.Headroom == nil || !adv.Headroom.Advertised {
+		t.Fatalf("advertise should set advertised=true; got %+v", adv.Headroom)
+	}
+
+	got, err := srv.GetCapacityHeadroom(ctx, &pb.GetCapacityHeadroomRequest{})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Headroom == nil || !got.Headroom.Advertised {
+		t.Fatalf("get after advertise should be advertised; got %+v", got.Headroom)
+	}
+
+	w1, err := srv.WithdrawCapacity(ctx, &pb.WithdrawCapacityRequest{})
+	if err != nil {
+		t.Fatalf("withdraw: %v", err)
+	}
+	if w1.Headroom == nil || w1.Headroom.Advertised {
+		t.Fatalf("withdraw should clear advertised; got %+v", w1.Headroom)
+	}
+
+	// Idempotent: a second withdraw succeeds and stays withdrawn.
+	w2, err := srv.WithdrawCapacity(ctx, &pb.WithdrawCapacityRequest{})
+	if err != nil {
+		t.Fatalf("second withdraw: %v", err)
+	}
+	if w2.Headroom == nil || w2.Headroom.Advertised {
+		t.Fatalf("second withdraw must remain withdrawn; got %+v", w2.Headroom)
+	}
+}

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -75,6 +75,12 @@ type ContainerServer struct {
 	// server (tests) answers GetCapabilityProfile with "not profiled yet".
 	capabilityStore     *capabilities.Store
 	capabilityStoreOnce sync.Once
+	// drainer performs the bounded graceful reclaim of guest workloads when a
+	// backend withdraws headroom (#682). Lazily initialized; a single in-flight
+	// drain at a time guards against repeated advertise/withdraw cycles wedging
+	// the host.
+	drainer     *capacity.Drainer
+	drainerOnce sync.Once
 	// region is the region this backend serves, wired from --region (falling
 	// back to the pool name). Recorded into the capability profile. Empty when
 	// unset.
@@ -2240,6 +2246,32 @@ func (s *ContainerServer) capStore() *capacity.Store {
 	return s.capacityStore
 }
 
+// drainHandle returns the lazily-initialized per-daemon drainer. A single
+// drainer instance is reused across withdraw calls so its in-flight guard
+// coalesces overlapping drains — repeated advertise/withdraw cycles can't stack
+// concurrent stop storms and wedge the host (#682). The drainer routes each
+// stop back through StopWorkload, which reuses StopContainer's plumbing.
+func (s *ContainerServer) drainHandle() *capacity.Drainer {
+	s.drainerOnce.Do(func() {
+		if s.drainer == nil {
+			s.drainer = capacity.NewDrainer(s)
+		}
+	})
+	return s.drainer
+}
+
+// StopWorkload stops the workload owned by username, satisfying
+// capacity.DrainStopper. It routes through StopContainer so a drained workload
+// emits the same stop event a manual stop does and the control plane can
+// reschedule it — there is no drain-only side door. The daemon context is
+// promoted to the system identity (the drain is daemon-internal, triggered by a
+// headroom withdraw, not by an end-user request).
+func (s *ContainerServer) StopWorkload(ctx context.Context, username string, force bool) error {
+	ctx = auth.ContextWithSystemIdentity(ctx)
+	_, err := s.StopContainer(ctx, &pb.StopContainerRequest{Username: username, Force: force})
+	return err
+}
+
 // hostStateSnapshot gathers the current host-level resource + container
 // snapshot the headroom computation consumes. It reuses the same Incus
 // system-resources call GetSystemInfo uses and the manager's container list,
@@ -2323,13 +2355,53 @@ func (s *ContainerServer) AdvertiseCapacity(ctx context.Context, req *pb.Adverti
 
 // WithdrawCapacity withdraws any active headroom advertisement. Idempotent:
 // withdrawing when nothing is advertised succeeds as a no-op. Admin-only.
-// See #680.
-func (s *ContainerServer) WithdrawCapacity(ctx context.Context, _ *pb.WithdrawCapacityRequest) (*pb.WithdrawCapacityResponse, error) {
+//
+// When req.Drain is set the backend also reclaims the guest workloads it had
+// implicitly offered: it snapshots the host, selects the same candidate set the
+// headroom computation considered free, and drains them gracefully within a
+// bounded window (req.DrainWindowSeconds, default 120s) instead of hard-killing
+// them. Each drained workload is stopped through the normal StopContainer path
+// so the control plane observes a stop event and can reschedule it. Any
+// candidate still running when the window expires is force-stopped so the host
+// is reliably reclaimed — no wedge on repeated advertise/withdraw cycles, since
+// the drainer coalesces an overlapping drain rather than stacking a second one.
+// See #680, #682.
+func (s *ContainerServer) WithdrawCapacity(ctx context.Context, req *pb.WithdrawCapacityRequest) (*pb.WithdrawCapacityResponse, error) {
 	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
 		return nil, err
 	}
+
+	// Flip the advertisement off first so no new work is directed here while we
+	// drain. Withdraw is idempotent, so the order is safe even if the drain
+	// fails partway.
 	h := s.capStore().Withdraw()
-	return &pb.WithdrawCapacityResponse{Headroom: headroomToProto(h)}, nil
+	resp := &pb.WithdrawCapacityResponse{Headroom: headroomToProto(h)}
+
+	if !req.GetDrain() {
+		return resp, nil
+	}
+
+	st := s.hostStateSnapshot()
+	candidates := capacity.DrainCandidates(s.capStore().Policy(), st)
+	if len(candidates) == 0 {
+		return resp, nil
+	}
+
+	window := time.Duration(req.GetDrainWindowSeconds()) * time.Second
+	result, skipped := s.drainHandle().Drain(ctx, candidates, window)
+	if skipped {
+		// A drain was already in flight (e.g. a rapid second withdraw). The
+		// advertisement is already off; the running drain reclaims the host.
+		log.Printf("[drain] withdraw coalesced: a drain is already in flight")
+		return resp, nil
+	}
+
+	resp.Drained = result.Drained
+	resp.ForceStopped = result.ForceStopped
+	resp.DrainWindowExceeded = result.WindowExceeded
+	log.Printf("[drain] withdraw drained=%d force_stopped=%d failed=%d window_exceeded=%t elapsed=%s",
+		len(result.Drained), len(result.ForceStopped), len(result.Failed), result.WindowExceeded, result.Elapsed)
+	return resp, nil
 }
 
 // GetCapacityHeadroom returns this backend's current advertisement with spare

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/footprintai/containarium/internal/alert"
 	"github.com/footprintai/containarium/internal/app"
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/capabilities"
 	"github.com/footprintai/containarium/internal/capacity"
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/guacamole"
@@ -69,6 +70,19 @@ type ContainerServer struct {
 	// (tests) still answers GetCapacityHeadroom with "not advertised".
 	capacityStore     *capacity.Store
 	capacityStoreOnce sync.Once
+	// capabilityStore holds this backend's last-recorded hardware capability
+	// profile (#681). Lazily initialized like capacityStore so an unwired
+	// server (tests) answers GetCapabilityProfile with "not profiled yet".
+	capabilityStore     *capabilities.Store
+	capabilityStoreOnce sync.Once
+	// region is the region this backend serves, wired from --region (falling
+	// back to the pool name). Recorded into the capability profile. Empty when
+	// unset.
+	region string
+	// reportedClass is the self-reported hardware class the operator assigned
+	// this backend (defaults to the pool name). Reconciled against the measured
+	// class in the capability profile. Empty when unset.
+	reportedClass string
 	// startTime is when this daemon process started; ListBackends reports
 	// the local backend's uptime from it. Set by DualServer wiring
 	// (SetStartTime); zero on a server that was never wired, in which case
@@ -2176,6 +2190,12 @@ func (s *ContainerServer) ListBackends(ctx context.Context, _ *pb.ListBackendsRe
 	if h := s.capStore().Current(s.hostStateSnapshot()); h.Advertised {
 		local.Headroom = headroomToProto(h)
 	}
+	// Surface the local backend's last-recorded capability profile (#681).
+	// Null until ProfileBackend has run, so the control plane can tell
+	// "unprofiled" from "profiled CPU-only".
+	if p, ok := s.capabStore().Current(); ok {
+		local.CapabilityProfile = profileToProto(p)
+	}
 	backends = append(backends, local)
 
 	// Peer backends. Forward GetSystemInfo to each healthy peer using the
@@ -2320,6 +2340,172 @@ func (s *ContainerServer) GetCapacityHeadroom(ctx context.Context, _ *pb.GetCapa
 	}
 	h := s.capStore().Current(s.hostStateSnapshot())
 	return &pb.GetCapacityHeadroomResponse{Headroom: headroomToProto(h)}, nil
+}
+
+// capabStore returns the lazily-initialized per-daemon capability-profile
+// store. Safe to call from any RPC; the first caller wins.
+func (s *ContainerServer) capabStore() *capabilities.Store {
+	s.capabilityStoreOnce.Do(func() {
+		if s.capabilityStore == nil {
+			s.capabilityStore = capabilities.NewStore()
+		}
+	})
+	return s.capabilityStore
+}
+
+// gatherHostFacts collects the inputs the capability profile is computed from:
+// host system resources (CPU cores + model, RAM, disk) via the same Incus call
+// GetSystemInfo uses, the GPU passthrough probe (unless skipped), the bounded
+// CPU/memory micro-benchmark, and the operator-set region / reported class.
+// Best-effort on the resource read: a missing Incus client yields zero hardware
+// figures rather than an error, so a profile is always recordable.
+func (s *ContainerServer) gatherHostFacts(skipGPU bool) capabilities.HostFacts {
+	f := capabilities.HostFacts{
+		Now:           time.Now(),
+		Region:        s.region,
+		ReportedClass: s.reportedClass,
+	}
+
+	if client, err := incus.New(); err == nil {
+		if res, err := client.GetSystemResources(); err == nil && res != nil {
+			f.CPUCores = res.TotalCPUs
+			f.CPUModel = res.CPUModel
+			f.TotalMemoryBytes = res.TotalMemoryBytes
+			f.TotalDiskBytes = res.TotalDiskBytes
+		}
+	}
+
+	// GPU model/driver from the existing nvidia.runtime passthrough probe —
+	// the same ValidateGPU the validate-gpu command runs. Skipped on request
+	// (CPU-only backends) or when no container manager is wired.
+	if !skipGPU && s.manager != nil {
+		res := s.manager.ValidateGPU("")
+		if res.Status == container.GPUStatusOK {
+			f.GPUAvailable = true
+			f.GPUModel = res.Model
+			f.GPUDriverVersion = res.DriverVersion
+		}
+	}
+
+	// Bounded CPU/memory micro-benchmark.
+	b := container.RunBenchmark()
+	f.Benchmark = capabilities.Benchmark{
+		CPUOpsPerSec:   b.CPUOpsPerSec,
+		MemBytesPerSec: b.MemBytesPerSec,
+		DurationMs:     b.DurationMs,
+	}
+	return f
+}
+
+// profileToProto maps the internal capability profile onto the wire type.
+func profileToProto(p capabilities.Profile) *pb.CapabilityProfile {
+	out := &pb.CapabilityProfile{
+		CpuCores:         p.CPUCores,
+		CpuModel:         p.CPUModel,
+		TotalMemoryBytes: p.TotalMemoryBytes,
+		TotalDiskBytes:   p.TotalDiskBytes,
+		GpuModel:         p.GPUModel,
+		GpuDriverVersion: p.GPUDriverVersion,
+		GpuAvailable:     p.GPUAvailable,
+		Region:           p.Region,
+		ReportedClass:    p.ReportedClass,
+		MeasuredClass:    p.MeasuredClass,
+		ClassConsistent:  p.ClassConsistent,
+		Benchmark: &pb.CapabilityBenchmark{
+			CpuOpsPerSec:   p.Benchmark.CPUOpsPerSec,
+			MemBytesPerSec: p.Benchmark.MemBytesPerSec,
+			DurationMs:     p.Benchmark.DurationMs,
+		},
+	}
+	if !p.ProfiledAt.IsZero() {
+		out.ProfiledAt = p.ProfiledAt.UTC().Format(time.RFC3339)
+	}
+	return out
+}
+
+// ProfileBackend records a backend's hardware capability profile: read system
+// info, run the GPU passthrough probe + bounded micro-benchmark, derive the
+// measured class, reconcile it against the self-reported class, and persist it.
+// Admin-only. An empty (or local) backend_id profiles this daemon; a peer
+// backend_id forwards to that peer, which profiles itself. See #681.
+func (s *ContainerServer) ProfileBackend(ctx context.Context, req *pb.ProfileBackendRequest) (*pb.ProfileBackendResponse, error) {
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+
+	// Remote backend → forward to the owning peer (it profiles its own host).
+	if req.BackendId != "" && req.BackendId != s.localBackendID() {
+		if s.peerPool == nil {
+			return nil, status.Errorf(codes.Unavailable, "backend %q: no peer pool configured on this daemon", req.BackendId)
+		}
+		peer := s.peerPool.Get(req.BackendId)
+		if peer == nil {
+			return nil, status.Errorf(codes.NotFound, "backend %q not found (see 'containarium backends list')", req.BackendId)
+		}
+		body, err := protojson.Marshal(req)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "marshal profile request: %v", err)
+		}
+		respBody, st, err := peer.ForwardRequest("POST", "/v1/capabilities/profile", extractAuthToken(ctx), body)
+		if err != nil {
+			return nil, status.Errorf(codes.Unavailable, "forward profile to %s: %v", req.BackendId, err)
+		}
+		if st >= 400 {
+			return nil, status.Errorf(codes.Internal, "peer %s returned status %d for profile", req.BackendId, st)
+		}
+		var resp pb.ProfileBackendResponse
+		if err := protojson.Unmarshal(respBody, &resp); err != nil {
+			return nil, status.Errorf(codes.Internal, "parse peer %s profile response: %v", req.BackendId, err)
+		}
+		resp.BackendId = req.BackendId
+		return &resp, nil
+	}
+
+	// Local backend.
+	p := s.capabStore().Record(s.gatherHostFacts(req.SkipGpu))
+	return &pb.ProfileBackendResponse{
+		Profile:   profileToProto(p),
+		BackendId: req.BackendId,
+	}, nil
+}
+
+// GetCapabilityProfile returns a backend's last-recorded capability profile
+// without re-running the benchmark/probe. Admin-only. A peer backend_id
+// forwards to that peer. Returns a null profile when nothing has been recorded
+// yet. See #681.
+func (s *ContainerServer) GetCapabilityProfile(ctx context.Context, req *pb.GetCapabilityProfileRequest) (*pb.GetCapabilityProfileResponse, error) {
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+
+	if req.BackendId != "" && req.BackendId != s.localBackendID() {
+		if s.peerPool == nil {
+			return nil, status.Errorf(codes.Unavailable, "backend %q: no peer pool configured on this daemon", req.BackendId)
+		}
+		peer := s.peerPool.Get(req.BackendId)
+		if peer == nil {
+			return nil, status.Errorf(codes.NotFound, "backend %q not found (see 'containarium backends list')", req.BackendId)
+		}
+		respBody, st, err := peer.ForwardRequest("GET", "/v1/capabilities/profile", extractAuthToken(ctx), nil)
+		if err != nil {
+			return nil, status.Errorf(codes.Unavailable, "forward get-profile to %s: %v", req.BackendId, err)
+		}
+		if st >= 400 {
+			return nil, status.Errorf(codes.Internal, "peer %s returned status %d for get-profile", req.BackendId, st)
+		}
+		var resp pb.GetCapabilityProfileResponse
+		if err := protojson.Unmarshal(respBody, &resp); err != nil {
+			return nil, status.Errorf(codes.Internal, "parse peer %s get-profile response: %v", req.BackendId, err)
+		}
+		resp.BackendId = req.BackendId
+		return &resp, nil
+	}
+
+	resp := &pb.GetCapabilityProfileResponse{BackendId: req.BackendId}
+	if p, ok := s.capabStore().Current(); ok {
+		resp.Profile = profileToProto(p)
+	}
+	return resp, nil
 }
 
 // backendGPUsFromSystemInfo projects a SystemInfo's GPU list onto the
@@ -2545,6 +2731,16 @@ func (s *ContainerServer) SetPeerPool(pool *PeerPool) {
 // report the local backend's uptime. Called once from DualServer setup.
 func (s *ContainerServer) SetStartTime(t time.Time) {
 	s.startTime = t
+}
+
+// SetCapabilityIdentity wires the region this backend serves and its
+// self-reported hardware class into the capability profile (#681). Both are
+// operator-set: region from --region (falling back to the pool name) and the
+// reported class from the pool name. Called once from DualServer setup; either
+// may be empty.
+func (s *ContainerServer) SetCapabilityIdentity(region, reportedClass string) {
+	s.region = region
+	s.reportedClass = reportedClass
 }
 
 // SetSSHHost wires the public SSH host clients dial to reach this daemon's

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -18,6 +19,7 @@ import (
 	"github.com/footprintai/containarium/internal/capacity"
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/guacamole"
+	"github.com/footprintai/containarium/internal/integrity"
 	"github.com/footprintai/containarium/internal/releasecheck"
 	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/internal/secrets"
@@ -85,6 +87,12 @@ type ContainerServer struct {
 	// back to the pool name). Recorded into the capability profile. Empty when
 	// unset.
 	region string
+	// integrityConfigState is the integrity-relevant policy/config posture this
+	// backend folds into its signed self-measurement (#683): base domain,
+	// network-policy enforcement posture, and any other config the control plane
+	// verifies hasn't been tampered with. Wired once via SetIntegrityConfig;
+	// nil/empty on an unwired server still yields a (config-empty) measurement.
+	integrityConfigState map[string]string
 	// reportedClass is the self-reported hardware class the operator assigned
 	// this backend (defaults to the pool name). Reconciled against the measured
 	// class in the capability profile. Empty when unset.
@@ -2578,6 +2586,124 @@ func (s *ContainerServer) GetCapabilityProfile(ctx context.Context, req *pb.GetC
 		resp.Profile = profileToProto(p)
 	}
 	return resp, nil
+}
+
+// GetSelfMeasurement computes and signs a fresh integrity self-measurement for
+// a backend: digests of the running daemon binary, the loaded in-kernel
+// network-policy program object(s), and the canonical policy/config state,
+// signed with the node's identity key (the sentinel-issued peer leaf reused
+// from the peer-PKI plumbing). The daemon also emits the same measurement on
+// its heartbeat. A peer backend_id forwards to that peer (which measures
+// itself). Admin-only. The control plane verifies the measurement to detect
+// tampering; the verification half lives elsewhere. See #683.
+func (s *ContainerServer) GetSelfMeasurement(ctx context.Context, req *pb.GetSelfMeasurementRequest) (*pb.GetSelfMeasurementResponse, error) {
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+
+	// Remote backend → forward to the owning peer (it measures its own host).
+	if req.BackendId != "" && req.BackendId != s.localBackendID() {
+		if s.peerPool == nil {
+			return nil, status.Errorf(codes.Unavailable, "backend %q: no peer pool configured on this daemon", req.BackendId)
+		}
+		peer := s.peerPool.Get(req.BackendId)
+		if peer == nil {
+			return nil, status.Errorf(codes.NotFound, "backend %q not found (see 'containarium backends list')", req.BackendId)
+		}
+		respBody, st, err := peer.ForwardRequest("GET", "/v1/integrity/self-measurement", extractAuthToken(ctx), nil)
+		if err != nil {
+			return nil, status.Errorf(codes.Unavailable, "forward self-measurement to %s: %v", req.BackendId, err)
+		}
+		if st >= 400 {
+			return nil, status.Errorf(codes.Internal, "peer %s returned status %d for self-measurement", req.BackendId, st)
+		}
+		var resp pb.GetSelfMeasurementResponse
+		if err := protojson.Unmarshal(respBody, &resp); err != nil {
+			return nil, status.Errorf(codes.Internal, "parse peer %s self-measurement response: %v", req.BackendId, err)
+		}
+		resp.BackendId = req.BackendId
+		return &resp, nil
+	}
+
+	// Local backend.
+	m, err := s.computeSelfMeasurement()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "compute self-measurement: %v", err)
+	}
+	return &pb.GetSelfMeasurementResponse{
+		Measurement: measurementToProto(m),
+		BackendId:   req.BackendId,
+	}, nil
+}
+
+// computeSelfMeasurement gathers this backend's integrity inputs (running
+// binary path, loaded in-kernel network-policy program object(s), policy/config
+// state, node identity signer) and computes the signed measurement. The signer
+// is the sentinel-issued peer leaf from the peer pool; when no PKI has been
+// bootstrapped the measurement is produced unsigned.
+func (s *ContainerServer) computeSelfMeasurement() (integrity.Measurement, error) {
+	in := integrity.Inputs{
+		ConfigState:   s.integrityConfigState,
+		DaemonVersion: version.Version,
+		Now:           time.Now(),
+	}
+
+	// Running daemon binary on disk. Best-effort: a path we can't resolve
+	// leaves the binary digest empty rather than failing the measurement.
+	if exe, err := os.Executable(); err == nil {
+		in.BinaryPath = exe
+	}
+
+	// Loaded in-kernel network-policy program object(s). The daemon arms the
+	// per-veth enforcer only when CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT points
+	// at an object on disk; that object's bytes are exactly what we attest.
+	if bpfObj := strings.TrimSpace(os.Getenv("CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT")); bpfObj != "" {
+		in.Programs = append(in.Programs, integrity.ProgramObject{Name: bpfObj, Path: bpfObj})
+	}
+
+	// Node identity signer: the sentinel-issued peer leaf key.
+	if s.peerPool != nil {
+		signer, certPEM := s.peerPool.IdentitySigner()
+		in.Signer = signer
+		in.SigningCertPEM = certPEM
+		// TPM-backed signing is a future hook; the software peer key signs today.
+		in.TPMBacked = false
+	}
+
+	return integrity.Compute(in)
+}
+
+// SetIntegrityConfig wires the integrity-relevant policy/config posture this
+// backend folds into its signed self-measurement (#683): base domain and the
+// network-policy enforcement posture. Called once from DualServer setup with
+// the resolved config; either field may be empty. The map is canonicalized
+// (sorted keys) before hashing, so caller ordering is irrelevant.
+func (s *ContainerServer) SetIntegrityConfig(state map[string]string) {
+	s.integrityConfigState = state
+}
+
+// measurementToProto maps the internal integrity measurement onto the wire type.
+func measurementToProto(m integrity.Measurement) *pb.SelfMeasurement {
+	out := &pb.SelfMeasurement{
+		HashAlgorithm:      m.HashAlgorithm,
+		BinaryDigest:       m.BinaryDigest,
+		ConfigDigest:       m.ConfigDigest,
+		MeasurementDigest:  m.MeasurementDigest,
+		Signature:          m.Signature,
+		SignatureAlgorithm: m.SignatureAlgorithm,
+		TpmBacked:          m.TPMBacked,
+		Signed:             m.Signed,
+		SigningCertPem:     m.SigningCertPEM,
+		MeasuredAt:         m.MeasuredAt.UTC().Format(time.RFC3339),
+		DaemonVersion:      m.DaemonVersion,
+	}
+	for _, p := range m.ProgramDigests {
+		out.ProgramDigests = append(out.ProgramDigests, &pb.ProgramDigest{
+			Name:   p.Name,
+			Digest: p.Digest,
+		})
+	}
+	return out
 }
 
 // backendGPUsFromSystemInfo projects a SystemInfo's GPU list onto the

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -83,6 +83,10 @@ type ContainerServer struct {
 	// the host.
 	drainer     *capacity.Drainer
 	drainerOnce sync.Once
+	// profileMu serializes ProfileBackend: each profile spins a throwaway
+	// GPU-probe LXC + a benchmark on the host, so concurrent/repeated calls
+	// must coalesce rather than stack a probe storm that can wedge the runtime.
+	profileMu sync.Mutex
 	// region is the region this backend serves, wired from --region (falling
 	// back to the pool name). Recorded into the capability profile. Empty when
 	// unset.
@@ -2313,10 +2317,18 @@ func (s *ContainerServer) hostStateSnapshot() capacity.HostState {
 	st.AvailableMemoryBytes = res.TotalMemoryBytes - res.UsedMemoryBytes
 	st.AvailableDiskBytes = res.TotalDiskBytes - res.UsedDiskBytes
 	// Available CPU cores ≈ total cores minus the 1-minute load average,
-	// clamped at zero. A coarse but honest host-level idle-CPU proxy.
+	// clamped to [0, TotalCPUs]. This is a COARSE, burstable hint only: load
+	// average counts runnable+uninterruptible tasks (I/O wait can inflate it
+	// without the CPU being busy), so it neither equals idle cores nor is the
+	// binding constraint — RAM and disk are the hard limits on how many guests
+	// a host can take. The upper clamp guards against a bogus/negative load
+	// reading reporting more spare cores than exist.
 	avail := float64(res.TotalCPUs) - res.CPULoad1Min
 	if avail < 0 {
 		avail = 0
+	}
+	if avail > float64(res.TotalCPUs) {
+		avail = float64(res.TotalCPUs)
 	}
 	st.AvailableCPUs = int32(avail)
 	return st
@@ -2443,6 +2455,12 @@ func (s *ContainerServer) WithdrawCapacity(ctx context.Context, req *pb.Withdraw
 	resp.Drained = result.Drained
 	resp.ForceStopped = result.ForceStopped
 	resp.DrainWindowExceeded = result.WindowExceeded
+	// Surface guests that couldn't be stopped even after force — a non-empty
+	// map means the host is NOT fully reclaimed, so the control plane must not
+	// treat their resources as freed.
+	if len(result.Failed) > 0 {
+		resp.Failed = result.Failed
+	}
 	log.Printf("[drain] withdraw drained=%d force_stopped=%d failed=%d window_exceeded=%t elapsed=%s",
 		len(result.Drained), len(result.ForceStopped), len(result.Failed), result.WindowExceeded, result.Elapsed)
 	return resp, nil
@@ -2577,7 +2595,13 @@ func (s *ContainerServer) ProfileBackend(ctx context.Context, req *pb.ProfileBac
 		return &resp, nil
 	}
 
-	// Local backend.
+	// Local backend. Serialize against concurrent profiles: gatherHostFacts
+	// spins a throwaway GPU-probe LXC + runs a benchmark, so a second caller
+	// (retry, multi-replica control plane) must not stack a second probe.
+	if !s.profileMu.TryLock() {
+		return nil, status.Error(codes.Aborted, "a backend profile is already in progress; retry shortly")
+	}
+	defer s.profileMu.Unlock()
 	p := s.capabStore().Record(s.gatherHostFacts(req.SkipGpu))
 	return &pb.ProfileBackendResponse{
 		Profile:   profileToProto(p),

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -2254,6 +2254,14 @@ func (s *ContainerServer) capStore() *capacity.Store {
 	return s.capacityStore
 }
 
+// maxDrainWindow caps a caller-supplied drain window so an absurd value can't
+// pin the host (and the drainer's in-flight guard) for an unreasonable time.
+// drainCtxGrace is extra headroom past the window for the final force-stop.
+const (
+	maxDrainWindow = 10 * time.Minute
+	drainCtxGrace  = 30 * time.Second
+)
+
 // drainHandle returns the lazily-initialized per-daemon drainer. A single
 // drainer instance is reused across withdraw calls so its in-flight guard
 // coalesces overlapping drains — repeated advertise/withdraw cycles can't stack
@@ -2356,6 +2364,19 @@ func (s *ContainerServer) AdvertiseCapacity(ctx context.Context, req *pb.Adverti
 	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
 		return nil, err
 	}
+	// Validate the policy server-side — the CLI checks these, but a direct
+	// gRPC/REST caller must not be trusted. A negative reserve_fraction would
+	// otherwise clamp to a ZERO reservation (advertising 100% of the host as
+	// spare — the opposite of intent); an out-of-range window hour would make
+	// the window silently never open.
+	if pol := req.GetPolicy(); pol != nil {
+		if rf := pol.GetReserveFraction(); rf < 0 || rf >= 1 {
+			return nil, status.Errorf(codes.InvalidArgument, "reserve_fraction must be in [0,1), got %v", rf)
+		}
+		if hs, he := pol.GetWindowStartHour(), pol.GetWindowEndHour(); hs < 0 || hs > 23 || he < 0 || he > 23 {
+			return nil, status.Errorf(codes.InvalidArgument, "window hours must be in [0,23], got start=%d end=%d", hs, he)
+		}
+	}
 	p := policyFromProto(req.GetPolicy())
 	h := s.capStore().Advertise(p, s.hostStateSnapshot())
 	return &pb.AdvertiseCapacityResponse{Headroom: headroomToProto(h)}, nil
@@ -2396,7 +2417,22 @@ func (s *ContainerServer) WithdrawCapacity(ctx context.Context, req *pb.Withdraw
 	}
 
 	window := time.Duration(req.GetDrainWindowSeconds()) * time.Second
-	result, skipped := s.drainHandle().Drain(ctx, candidates, window)
+	if window > maxDrainWindow {
+		window = maxDrainWindow // clamp an absurd request so the drain can't pin the host for ages
+	}
+	// Detach the drain from the request context and bound it by the window: a
+	// graceful drain can take the full window (default 120s), far longer than a
+	// typical CLI / grpc-gateway HTTP timeout — we must NOT abandon a
+	// half-finished reclaim just because the caller disconnected. (Same posture
+	// as the upgrade path's context.WithoutCancel.) The +grace covers the final
+	// force-stop after the window elapses.
+	effectiveWindow := window
+	if effectiveWindow <= 0 {
+		effectiveWindow = capacity.DefaultDrainWindow
+	}
+	drainCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), effectiveWindow+drainCtxGrace)
+	defer cancel()
+	result, skipped := s.drainHandle().Drain(drainCtx, candidates, window)
 	if skipped {
 		// A drain was already in flight (e.g. a rapid second withdraw). The
 		// advertisement is already off; the running drain reclaims the host.
@@ -2694,8 +2730,12 @@ func measurementToProto(m integrity.Measurement) *pb.SelfMeasurement {
 		TpmBacked:          m.TPMBacked,
 		Signed:             m.Signed,
 		SigningCertPem:     m.SigningCertPEM,
-		MeasuredAt:         m.MeasuredAt.UTC().Format(time.RFC3339),
-		DaemonVersion:      m.DaemonVersion,
+		// RFC3339Nano (not RFC3339): the signed canonical form uses nanosecond
+		// precision, so the wire MUST carry the same precision or a verifier
+		// reconstructing the canonical bytes computes a different digest and
+		// the signature never verifies.
+		MeasuredAt:    m.MeasuredAt.UTC().Format(time.RFC3339Nano),
+		DaemonVersion: m.DaemonVersion,
 	}
 	for _, p := range m.ProgramDigests {
 		out.ProgramDigests = append(out.ProgramDigests, &pb.ProgramDigest{

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/footprintai/containarium/internal/alert"
 	"github.com/footprintai/containarium/internal/app"
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/capacity"
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/guacamole"
 	"github.com/footprintai/containarium/internal/releasecheck"
@@ -63,6 +64,11 @@ type ContainerServer struct {
 	coreServices       *CoreServices
 	daemonConfigStore  *app.DaemonConfigStore
 	peerPool           *PeerPool
+	// capacityStore holds this backend's spare-capacity advertise/withdraw
+	// state + local policy (#680). Lazily initialized so an unwired server
+	// (tests) still answers GetCapacityHeadroom with "not advertised".
+	capacityStore     *capacity.Store
+	capacityStoreOnce sync.Once
 	// startTime is when this daemon process started; ListBackends reports
 	// the local backend's uptime from it. Set by DualServer wiring
 	// (SetStartTime); zero on a server that was never wired, in which case
@@ -2163,6 +2169,13 @@ func (s *ContainerServer) ListBackends(ctx context.Context, _ *pb.ListBackendsRe
 			local.Gpus = backendGPUsFromSystemInfo(sysResp.Info)
 		}
 	}
+	// Surface the local backend's spare-capacity advertisement (#680). Only
+	// attach when something is actively advertised — an unadvertised backend
+	// leaves headroom null so the control plane can tell "not offering" from
+	// "offering zero".
+	if h := s.capStore().Current(s.hostStateSnapshot()); h.Advertised {
+		local.Headroom = headroomToProto(h)
+	}
 	backends = append(backends, local)
 
 	// Peer backends. Forward GetSystemInfo to each healthy peer using the
@@ -2194,6 +2207,119 @@ func (s *ContainerServer) ListBackends(ctx context.Context, _ *pb.ListBackendsRe
 	}
 
 	return &pb.ListBackendsResponse{Backends: backends}, nil
+}
+
+// capStore returns the lazily-initialized per-daemon capacity store. Safe to
+// call from any RPC; the first caller wins.
+func (s *ContainerServer) capStore() *capacity.Store {
+	s.capacityStoreOnce.Do(func() {
+		if s.capacityStore == nil {
+			s.capacityStore = capacity.NewStore()
+		}
+	})
+	return s.capacityStore
+}
+
+// hostStateSnapshot gathers the current host-level resource + container
+// snapshot the headroom computation consumes. It reuses the same Incus
+// system-resources call GetSystemInfo uses and the manager's container list,
+// so the figures match what ListBackends already reports. Best-effort: a
+// missing manager or Incus call yields a zero-resource snapshot rather than an
+// error, so advertise/withdraw still work on an unwired server.
+func (s *ContainerServer) hostStateSnapshot() capacity.HostState {
+	st := capacity.HostState{Now: time.Now()}
+	if s.manager == nil {
+		return st
+	}
+	if containers, err := s.manager.List(); err == nil {
+		st.Containers = containers
+	}
+	client, err := incus.New()
+	if err != nil {
+		return st
+	}
+	res, err := client.GetSystemResources()
+	if err != nil || res == nil {
+		return st
+	}
+	st.AvailableMemoryBytes = res.TotalMemoryBytes - res.UsedMemoryBytes
+	st.AvailableDiskBytes = res.TotalDiskBytes - res.UsedDiskBytes
+	// Available CPU cores ≈ total cores minus the 1-minute load average,
+	// clamped at zero. A coarse but honest host-level idle-CPU proxy.
+	avail := float64(res.TotalCPUs) - res.CPULoad1Min
+	if avail < 0 {
+		avail = 0
+	}
+	st.AvailableCPUs = int32(avail)
+	return st
+}
+
+// policyFromProto maps the wire CapacityPolicy onto the internal policy. A nil
+// proto policy yields the zero (always-open, no-exclusion) policy.
+func policyFromProto(p *pb.CapacityPolicy) capacity.Policy {
+	if p == nil {
+		return capacity.Policy{}
+	}
+	return capacity.Policy{
+		WindowStartHour:         p.GetWindowStartHour(),
+		WindowEndHour:           p.GetWindowEndHour(),
+		ExcludedWorkloadClasses: p.GetExcludedWorkloadClasses(),
+		ReserveFraction:         p.GetReserveFraction(),
+	}
+}
+
+// headroomToProto maps the internal headroom onto the wire type.
+func headroomToProto(h capacity.Headroom) *pb.CapacityHeadroom {
+	out := &pb.CapacityHeadroom{
+		Advertised:       h.Advertised,
+		SpareCpus:        h.SpareCPUs,
+		SpareMemoryBytes: h.SpareMemoryBytes,
+		SpareDiskBytes:   h.SpareDiskBytes,
+		IdleFraction:     h.IdleFraction,
+		Policy: &pb.CapacityPolicy{
+			WindowStartHour:         h.Policy.WindowStartHour,
+			WindowEndHour:           h.Policy.WindowEndHour,
+			ExcludedWorkloadClasses: h.Policy.ExcludedWorkloadClasses,
+			ReserveFraction:         h.Policy.ReserveFraction,
+		},
+	}
+	if !h.AdvertisedAt.IsZero() {
+		out.AdvertisedAt = h.AdvertisedAt.UTC().Format(time.RFC3339)
+	}
+	return out
+}
+
+// AdvertiseCapacity publishes this backend's spare scheduling headroom to the
+// control plane, bounded by the supplied local policy. The advertisement is
+// surfaced through ListBackends. Admin-only. See #680.
+func (s *ContainerServer) AdvertiseCapacity(ctx context.Context, req *pb.AdvertiseCapacityRequest) (*pb.AdvertiseCapacityResponse, error) {
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+	p := policyFromProto(req.GetPolicy())
+	h := s.capStore().Advertise(p, s.hostStateSnapshot())
+	return &pb.AdvertiseCapacityResponse{Headroom: headroomToProto(h)}, nil
+}
+
+// WithdrawCapacity withdraws any active headroom advertisement. Idempotent:
+// withdrawing when nothing is advertised succeeds as a no-op. Admin-only.
+// See #680.
+func (s *ContainerServer) WithdrawCapacity(ctx context.Context, _ *pb.WithdrawCapacityRequest) (*pb.WithdrawCapacityResponse, error) {
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+	h := s.capStore().Withdraw()
+	return &pb.WithdrawCapacityResponse{Headroom: headroomToProto(h)}, nil
+}
+
+// GetCapacityHeadroom returns this backend's current advertisement with spare
+// figures recomputed against the live host snapshot. Admin-only. See #680.
+func (s *ContainerServer) GetCapacityHeadroom(ctx context.Context, _ *pb.GetCapacityHeadroomRequest) (*pb.GetCapacityHeadroomResponse, error) {
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+	h := s.capStore().Current(s.hostStateSnapshot())
+	return &pb.GetCapacityHeadroomResponse{Headroom: headroomToProto(h)}, nil
 }
 
 // backendGPUsFromSystemInfo projects a SystemInfo's GPU list onto the

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -101,6 +101,7 @@ type DualServerConfig struct {
 	Peers          []string // Static peer addresses (e.g., ["10.128.0.5:18001"])
 	LocalBackendID string   // This daemon's backend ID (defaults to hostname)
 	Pool           string   // Pool name to filter sentinel peer discovery (empty = no filter)
+	Region         string   // Region this backend serves; recorded in the capability profile (#681). Falls back to Pool when empty.
 
 	// Sentinel primary registration (multi-pool routing). Empty PublicHostname
 	// disables registration; the daemon still works as a single-pool primary.
@@ -1619,6 +1620,15 @@ func (ds *DualServer) Start(ctx context.Context) error {
 	// it unconditionally; empty --ssh-host leaves ssh_host empty.
 	if ds.containerServer != nil {
 		ds.containerServer.SetSSHHost(ds.config.SSHHost)
+		// Capability-profile identity (#681): region from --region, falling
+		// back to the pool name; self-reported class from the pool name. Both
+		// may be empty. Wired unconditionally — profiling works on a
+		// single-backend daemon with no peer pool.
+		region := ds.config.Region
+		if region == "" {
+			region = ds.config.Pool
+		}
+		ds.containerServer.SetCapabilityIdentity(region, ds.config.Pool)
 	}
 
 	// Start peer discovery for multi-backend support

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1543,6 +1543,53 @@ func (ds *DualServer) runRevocationCleanup(ctx context.Context) {
 	}
 }
 
+// startIntegrityHeartbeat launches the integrity self-measurement heartbeat
+// (#683). On a fixed cadence the daemon computes + signs a measurement of its
+// own binary, loaded in-kernel program object(s), and policy/config state, and
+// emits the signed digest to the log. The control plane reads the same
+// measurement on demand (GET /v1/integrity/self-measurement) and verifies it
+// to detect tampering of a backend's control plane; that verification half is
+// out of scope here — this is the node-side emission only.
+//
+// The measurement is the same one GetSelfMeasurement returns; the heartbeat
+// exists so a measurement is produced even when no operator/control plane is
+// polling, giving a continuous integrity trail in the daemon log.
+func (ds *DualServer) startIntegrityHeartbeat(ctx context.Context) {
+	if ds.containerServer == nil {
+		return
+	}
+	const interval = 5 * time.Minute
+
+	emit := func() {
+		m, err := ds.containerServer.computeSelfMeasurement()
+		if err != nil {
+			log.Printf("[integrity] self-measurement failed: %v", err)
+			return
+		}
+		signed := "UNSIGNED (no peer identity key)"
+		if m.Signed {
+			signed = fmt.Sprintf("signed %s tpm=%v", m.SignatureAlgorithm, m.TPMBacked)
+		}
+		log.Printf("[integrity] self-measurement digest=%s programs=%d %s",
+			m.MeasurementDigest, len(m.ProgramDigests), signed)
+	}
+
+	go func() {
+		// One initial emission once the daemon is up, then on the cadence.
+		emit()
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				emit()
+			}
+		}
+	}()
+}
+
 // handleBackendSystemInfo returns system info for a specific backend.
 // For the local backend, it returns the local system info.
 // For peer backends, it forwards the request to the peer.
@@ -1629,6 +1676,24 @@ func (ds *DualServer) Start(ctx context.Context) error {
 			region = ds.config.Pool
 		}
 		ds.containerServer.SetCapabilityIdentity(region, ds.config.Pool)
+
+		// Integrity self-measurement posture (#683): the policy/config state the
+		// daemon folds into its signed self-measurement so the control plane can
+		// detect tampering of a backend's control plane. Generic, integrity-
+		// relevant config only — base domain + network-policy enforcement posture.
+		netPolicyEnforce := "0"
+		switch strings.ToLower(strings.TrimSpace(os.Getenv("CONTAINARIUM_NETWORK_POLICY_ENFORCE"))) {
+		case "1", "true", "yes", "on":
+			netPolicyEnforce = "1"
+		}
+		netPolicyObj := strings.TrimSpace(os.Getenv("CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT"))
+		ds.containerServer.SetIntegrityConfig(map[string]string{
+			"base_domain":            ds.config.BaseDomain,
+			"pool":                   ds.config.Pool,
+			"backend_id":             ds.config.LocalBackendID,
+			"network_policy_object":  netPolicyObj,
+			"network_policy_enforce": netPolicyEnforce,
+		})
 	}
 
 	// Start peer discovery for multi-backend support
@@ -1646,6 +1711,15 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		}
 		ds.peerPool.StartDiscovery(ctx)
 		ds.containerServer.SetPeerPool(ds.peerPool)
+
+		// Integrity self-measurement heartbeat (#683): on a fixed cadence the
+		// daemon computes + signs a measurement of its own binary, loaded
+		// in-kernel program object(s), and policy/config state, and emits it
+		// (logs the signed digest now; the control plane reads the same
+		// measurement on demand via GET /v1/integrity/self-measurement and
+		// verifies it to detect tampering — the verification half is out of
+		// scope here). SetPeerPool above wired the signer.
+		ds.startIntegrityHeartbeat(ctx)
 		// Local-backend uptime for ListBackends (GET /v1/backends).
 		ds.containerServer.SetStartTime(ds.startTime)
 

--- a/internal/server/peer.go
+++ b/internal/server/peer.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -420,6 +421,18 @@ func (p *PeerPool) discover() {
 // LocalBackendID returns this daemon's backend ID.
 func (p *PeerPool) LocalBackendID() string {
 	return p.localBackendID
+}
+
+// IdentitySigner returns the daemon's node identity key (the
+// sentinel-issued peer leaf) as a crypto.Signer plus the leaf cert
+// PEM, for signing the integrity self-measurement (#683). Returns
+// (nil, "") when no peer PKI has been bootstrapped — the measurement
+// is then produced unsigned.
+func (p *PeerPool) IdentitySigner() (crypto.Signer, string) {
+	p.mu.RLock()
+	pki := p.pki
+	p.mu.RUnlock()
+	return pki.IdentitySigner()
 }
 
 // LocalPool returns the pool tag this daemon's PeerPool was configured

--- a/internal/server/peer_pki.go
+++ b/internal/server/peer_pki.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"log"
@@ -64,6 +66,28 @@ func (p *peerPKI) ClientCertificate() tls.Certificate {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.tlsCert
+}
+
+// IdentitySigner returns the daemon's leaf private key as a
+// crypto.Signer (the sentinel-issued ECDSA peer leaf) plus the PEM
+// of the leaf cert, for callers that need to sign with the node's
+// identity key — e.g. the integrity self-measurement (#683). Returns
+// (nil, "") when no PKI is configured or the leaf key doesn't
+// implement crypto.Signer.
+func (p *peerPKI) IdentitySigner() (crypto.Signer, string) {
+	if p == nil {
+		return nil, ""
+	}
+	p.mu.RLock()
+	cert := p.tlsCert
+	p.mu.RUnlock()
+
+	signer, ok := cert.PrivateKey.(crypto.Signer)
+	if !ok || len(cert.Certificate) == 0 {
+		return nil, ""
+	}
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
+	return signer, string(leafPEM)
 }
 
 // CACertPEM returns the PEM bytes of the trusted CA, for callers

--- a/internal/server/self_measurement_handler_test.go
+++ b/internal/server/self_measurement_handler_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// GetSelfMeasurement (#683) is admin-only: the signed integrity attestation is
+// a control-plane verification signal, not a tenant resource.
+func TestGetSelfMeasurement_RejectsNonAdmin(t *testing.T) {
+	srv := &ContainerServer{}
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "user")
+	if _, err := srv.GetSelfMeasurement(ctx, &pb.GetSelfMeasurementRequest{}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin must be denied; got %v (%v)", status.Code(err), err)
+	}
+}
+
+// With no peer pool bootstrapped there is no node identity key, so the local
+// measurement is produced but unsigned — present and unverifiable, not an
+// error and not flagged as tamper.
+func TestGetSelfMeasurement_LocalUnsignedWhenNoPKI(t *testing.T) {
+	srv := &ContainerServer{}
+	srv.SetIntegrityConfig(map[string]string{
+		"base_domain":            "example.com",
+		"network_policy_enforce": "0",
+	})
+	ctx := auth.ContextWithSystemIdentity(context.Background())
+
+	resp, err := srv.GetSelfMeasurement(ctx, &pb.GetSelfMeasurementRequest{})
+	if err != nil {
+		t.Fatalf("GetSelfMeasurement: %v", err)
+	}
+	m := resp.Measurement
+	if m == nil {
+		t.Fatalf("expected a measurement")
+	}
+	if m.Signed {
+		t.Errorf("expected unsigned measurement without a peer identity key")
+	}
+	if m.Signature != "" {
+		t.Errorf("unsigned measurement must have empty signature, got %q", m.Signature)
+	}
+	if m.HashAlgorithm == "" || m.MeasurementDigest == "" || m.ConfigDigest == "" {
+		t.Errorf("measurement should carry hash/measurement/config digests even when unsigned: %+v", m)
+	}
+	// The running test binary exists on disk, so the binary digest is populated.
+	if m.BinaryDigest == "" {
+		t.Errorf("expected a non-empty binary digest for the running daemon binary")
+	}
+}

--- a/pkg/core/container/benchmark.go
+++ b/pkg/core/container/benchmark.go
@@ -57,7 +57,8 @@ func RunBenchmark() BenchmarkResult {
 // integer arithmetic so the score tracks raw single-thread CPU throughput and
 // is comparable across runs on the same host.
 func benchCPU(budget time.Duration) int64 {
-	deadline := time.Now().Add(budget)
+	start := time.Now()
+	deadline := start.Add(budget)
 	// Check the clock only every checkEvery iterations — time.Now() per
 	// iteration would dominate the measurement.
 	const checkEvery = 1 << 16
@@ -78,7 +79,11 @@ func benchCPU(budget time.Duration) int64 {
 	if acc == 0 {
 		iters++
 	}
-	elapsed := budget.Seconds()
+	// Divide by the ACTUAL elapsed time, not the nominal budget: the loop
+	// overruns the deadline by up to one checkEvery batch, and on a slow/noisy
+	// host that overrun is significant — using budget.Seconds() would overstate
+	// throughput exactly where accuracy matters for class-drift detection.
+	elapsed := time.Since(start).Seconds()
 	if elapsed <= 0 {
 		return 0
 	}
@@ -97,7 +102,8 @@ func benchMem(budget time.Duration, bufBytes int) int64 {
 	for i := range src {
 		src[i] = byte(i)
 	}
-	deadline := time.Now().Add(budget)
+	start := time.Now()
+	deadline := start.Add(budget)
 	var moved int64
 	var sum uint64
 	for {
@@ -114,7 +120,9 @@ func benchMem(budget time.Duration, bufBytes int) int64 {
 	if sum == 0 {
 		moved++
 	}
-	elapsed := budget.Seconds()
+	// Actual elapsed, not the nominal budget — the final pass overruns the
+	// deadline (a whole buffer of work), which budget.Seconds() would ignore.
+	elapsed := time.Since(start).Seconds()
 	if elapsed <= 0 {
 		return 0
 	}

--- a/pkg/core/container/benchmark.go
+++ b/pkg/core/container/benchmark.go
@@ -1,0 +1,122 @@
+package container
+
+import (
+	"time"
+)
+
+// Micro-benchmark tuning. Package vars (not consts) so tests can shrink the
+// time budget to keep the suite fast while still exercising the loops.
+var (
+	// benchmarkCPUBudget / benchmarkMemBudget bound each phase's wall clock.
+	// The whole benchmark is therefore bounded by their sum; both are short so
+	// recording a profile at join stays cheap.
+	benchmarkCPUBudget = 150 * time.Millisecond
+	benchmarkMemBudget = 150 * time.Millisecond
+
+	// benchmarkMemBufBytes is the size of the buffer the memory phase streams
+	// through. Small enough to fit comfortably in cache-and-RAM on any host,
+	// large enough that the copy/sum loop is memory- rather than loop-bound.
+	benchmarkMemBufBytes = 4 << 20 // 4 MiB
+)
+
+// BenchmarkResult is the outcome of the bounded CPU/memory micro-benchmark.
+// The scores are relative capacity/integrity signals (higher is faster), not
+// absolute hardware specs — they let a profile confirm a backend's
+// self-reported class is plausible. See #681.
+type BenchmarkResult struct {
+	// CPUOpsPerSec is integer-work iterations completed per second during the
+	// bounded single-threaded CPU phase.
+	CPUOpsPerSec int64
+
+	// MemBytesPerSec is bytes per second moved through the bounded buffer
+	// copy/sum loop.
+	MemBytesPerSec int64
+
+	// DurationMs is the total wall-clock time both phases took.
+	DurationMs int64
+}
+
+// RunBenchmark runs a lightweight, time-bounded CPU and memory micro-benchmark
+// and returns relative scores. It is pure Go (no external process, no GPU) so
+// it runs on any backend, is safe to call at join time, and is bounded by the
+// package time budgets above. It never blocks longer than benchmarkCPUBudget +
+// benchmarkMemBudget plus a little loop slack.
+func RunBenchmark() BenchmarkResult {
+	start := time.Now()
+	cpuOps := benchCPU(benchmarkCPUBudget)
+	memBps := benchMem(benchmarkMemBudget, benchmarkMemBufBytes)
+	return BenchmarkResult{
+		CPUOpsPerSec:   cpuOps,
+		MemBytesPerSec: memBps,
+		DurationMs:     time.Since(start).Milliseconds(),
+	}
+}
+
+// benchCPU runs a tight integer-work loop until the budget elapses and returns
+// iterations completed per second. The loop body is deliberately simple
+// integer arithmetic so the score tracks raw single-thread CPU throughput and
+// is comparable across runs on the same host.
+func benchCPU(budget time.Duration) int64 {
+	deadline := time.Now().Add(budget)
+	// Check the clock only every checkEvery iterations — time.Now() per
+	// iteration would dominate the measurement.
+	const checkEvery = 1 << 16
+	var iters int64
+	var acc uint64 = 1
+	for {
+		for i := 0; i < checkEvery; i++ {
+			// A cheap, non-trivial mix the compiler can't fold away.
+			acc = acc*6364136223846793005 + 1442695040888963407
+			acc ^= acc >> 33
+			iters++
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+	}
+	// Keep acc live so the loop isn't optimized out.
+	if acc == 0 {
+		iters++
+	}
+	elapsed := budget.Seconds()
+	if elapsed <= 0 {
+		return 0
+	}
+	return int64(float64(iters) / elapsed)
+}
+
+// benchMem streams a buffer through a copy+sum loop until the budget elapses
+// and returns bytes per second moved. Each pass reads and writes the whole
+// buffer, so the score tracks memory bandwidth rather than loop overhead.
+func benchMem(budget time.Duration, bufBytes int) int64 {
+	if bufBytes <= 0 {
+		return 0
+	}
+	src := make([]byte, bufBytes)
+	dst := make([]byte, bufBytes)
+	for i := range src {
+		src[i] = byte(i)
+	}
+	deadline := time.Now().Add(budget)
+	var moved int64
+	var sum uint64
+	for {
+		copy(dst, src)
+		for _, b := range dst {
+			sum += uint64(b)
+		}
+		// One pass reads src + writes dst + reads dst.
+		moved += int64(bufBytes) * 3
+		if time.Now().After(deadline) {
+			break
+		}
+	}
+	if sum == 0 {
+		moved++
+	}
+	elapsed := budget.Seconds()
+	if elapsed <= 0 {
+		return 0
+	}
+	return int64(float64(moved) / elapsed)
+}

--- a/pkg/core/container/benchmark_test.go
+++ b/pkg/core/container/benchmark_test.go
@@ -1,0 +1,43 @@
+package container
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRunBenchmarkBounded shrinks the per-phase time budget so the test stays
+// fast, and asserts the benchmark produces positive scores within the bound.
+func TestRunBenchmarkBounded(t *testing.T) {
+	origCPU, origMem, origBuf := benchmarkCPUBudget, benchmarkMemBudget, benchmarkMemBufBytes
+	benchmarkCPUBudget = 20 * time.Millisecond
+	benchmarkMemBudget = 20 * time.Millisecond
+	benchmarkMemBufBytes = 1 << 20
+	defer func() {
+		benchmarkCPUBudget, benchmarkMemBudget, benchmarkMemBufBytes = origCPU, origMem, origBuf
+	}()
+
+	start := time.Now()
+	r := RunBenchmark()
+	elapsed := time.Since(start)
+
+	if r.CPUOpsPerSec <= 0 {
+		t.Errorf("CPUOpsPerSec must be positive, got %d", r.CPUOpsPerSec)
+	}
+	if r.MemBytesPerSec <= 0 {
+		t.Errorf("MemBytesPerSec must be positive, got %d", r.MemBytesPerSec)
+	}
+	if r.DurationMs < 0 {
+		t.Errorf("DurationMs must be non-negative, got %d", r.DurationMs)
+	}
+	// Bounded: total wall clock should be well under a second with the shrunk
+	// budgets (allow generous slack for slow CI).
+	if elapsed > 2*time.Second {
+		t.Errorf("benchmark ran too long: %v", elapsed)
+	}
+}
+
+func TestBenchMemZeroBuffer(t *testing.T) {
+	if got := benchMem(10*time.Millisecond, 0); got != 0 {
+		t.Fatalf("benchMem with zero buffer = %d, want 0", got)
+	}
+}

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -1212,6 +1212,7 @@ type GPUInfo struct {
 // SystemResources holds system resource information
 type SystemResources struct {
 	TotalCPUs        int32
+	CPUModel         string // e.g. "AMD EPYC 7B13" (first socket's name), empty when unavailable
 	TotalMemoryBytes int64
 	UsedMemoryBytes  int64
 	TotalDiskBytes   int64
@@ -1237,8 +1238,11 @@ func (c *Client) GetSystemResources() (*SystemResources, error) {
 		UsedMemoryBytes:  safecast.I64FromU64(resources.Memory.Used),
 	}
 
-	// Count total CPU cores
+	// Count total CPU cores and capture the CPU model from the first socket.
 	for _, socket := range resources.CPU.Sockets {
+		if res.CPUModel == "" && socket.Name != "" {
+			res.CPUModel = socket.Name
+		}
 		for _, core := range socket.Cores {
 			res.TotalCPUs += safecast.I32(len(core.Threads))
 		}

--- a/pkg/pb/containarium/v1/config.pb.go
+++ b/pkg/pb/containarium/v1/config.pb.go
@@ -3701,9 +3701,21 @@ func (x *AdvertiseCapacityResponse) GetHeadroom() *CapacityHeadroom {
 // WithdrawCapacityRequest withdraws any active advertisement. Idempotent —
 // withdrawing when nothing is advertised succeeds and is a no-op.
 type WithdrawCapacityRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// When true the backend also reclaims the guest workloads it had implicitly
+	// offered, draining them gracefully within a bounded window instead of
+	// hard-killing them. Each drained workload is stopped through the normal
+	// stop path so the control plane observes a stop event and can reschedule.
+	// When false (default) withdraw only flips the advertisement off and leaves
+	// running guests untouched. See #682.
+	Drain bool `protobuf:"varint,1,opt,name=drain,proto3" json:"drain,omitempty"`
+	// Bounded wall-clock budget (seconds) for the graceful drain. Once exhausted
+	// any still-running candidate is force-stopped so the host is reliably
+	// reclaimed (no wedge on repeated advertise/withdraw cycles). 0 applies the
+	// backend default (120s). Only honored when drain is true.
+	DrainWindowSeconds int32 `protobuf:"varint,2,opt,name=drain_window_seconds,json=drainWindowSeconds,proto3" json:"drain_window_seconds,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *WithdrawCapacityRequest) Reset() {
@@ -3736,13 +3748,36 @@ func (*WithdrawCapacityRequest) Descriptor() ([]byte, []int) {
 	return file_containarium_v1_config_proto_rawDescGZIP(), []int{49}
 }
 
+func (x *WithdrawCapacityRequest) GetDrain() bool {
+	if x != nil {
+		return x.Drain
+	}
+	return false
+}
+
+func (x *WithdrawCapacityRequest) GetDrainWindowSeconds() int32 {
+	if x != nil {
+		return x.DrainWindowSeconds
+	}
+	return 0
+}
+
 // WithdrawCapacityResponse confirms the backend is no longer advertising.
 type WithdrawCapacityResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The post-withdraw headroom (advertised=false).
-	Headroom      *CapacityHeadroom `protobuf:"bytes,1,opt,name=headroom,proto3" json:"headroom,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Headroom *CapacityHeadroom `protobuf:"bytes,1,opt,name=headroom,proto3" json:"headroom,omitempty"`
+	// Container names that drained gracefully within the window. Empty unless
+	// the request set drain. See #682.
+	Drained []string `protobuf:"bytes,2,rep,name=drained,proto3" json:"drained,omitempty"`
+	// Container names that were force-stopped because the bounded window was
+	// exhausted before they stopped gracefully.
+	ForceStopped []string `protobuf:"bytes,3,rep,name=force_stopped,json=forceStopped,proto3" json:"force_stopped,omitempty"`
+	// True when the graceful budget was exhausted and the backend fell back to
+	// force-stopping the remaining workloads.
+	DrainWindowExceeded bool `protobuf:"varint,4,opt,name=drain_window_exceeded,json=drainWindowExceeded,proto3" json:"drain_window_exceeded,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *WithdrawCapacityResponse) Reset() {
@@ -3780,6 +3815,27 @@ func (x *WithdrawCapacityResponse) GetHeadroom() *CapacityHeadroom {
 		return x.Headroom
 	}
 	return nil
+}
+
+func (x *WithdrawCapacityResponse) GetDrained() []string {
+	if x != nil {
+		return x.Drained
+	}
+	return nil
+}
+
+func (x *WithdrawCapacityResponse) GetForceStopped() []string {
+	if x != nil {
+		return x.ForceStopped
+	}
+	return nil
+}
+
+func (x *WithdrawCapacityResponse) GetDrainWindowExceeded() bool {
+	if x != nil {
+		return x.DrainWindowExceeded
+	}
+	return false
 }
 
 // GetCapacityHeadroomRequest reads the backend's current advertisement and the
@@ -4334,10 +4390,15 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\x18AdvertiseCapacityRequest\x127\n" +
 	"\x06policy\x18\x01 \x01(\v2\x1f.containarium.v1.CapacityPolicyR\x06policy\"Z\n" +
 	"\x19AdvertiseCapacityResponse\x12=\n" +
-	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\"\x19\n" +
-	"\x17WithdrawCapacityRequest\"Y\n" +
+	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\"a\n" +
+	"\x17WithdrawCapacityRequest\x12\x14\n" +
+	"\x05drain\x18\x01 \x01(\bR\x05drain\x120\n" +
+	"\x14drain_window_seconds\x18\x02 \x01(\x05R\x12drainWindowSeconds\"\xcc\x01\n" +
 	"\x18WithdrawCapacityResponse\x12=\n" +
-	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\"\x1c\n" +
+	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\x12\x18\n" +
+	"\adrained\x18\x02 \x03(\tR\adrained\x12#\n" +
+	"\rforce_stopped\x18\x03 \x03(\tR\fforceStopped\x122\n" +
+	"\x15drain_window_exceeded\x18\x04 \x01(\bR\x13drainWindowExceeded\"\x1c\n" +
 	"\x1aGetCapacityHeadroomRequest\"\\\n" +
 	"\x1bGetCapacityHeadroomResponse\x12=\n" +
 	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\"Q\n" +

--- a/pkg/pb/containarium/v1/config.pb.go
+++ b/pkg/pb/containarium/v1/config.pb.go
@@ -3776,8 +3776,12 @@ type WithdrawCapacityResponse struct {
 	// True when the graceful budget was exhausted and the backend fell back to
 	// force-stopping the remaining workloads.
 	DrainWindowExceeded bool `protobuf:"varint,4,opt,name=drain_window_exceeded,json=drainWindowExceeded,proto3" json:"drain_window_exceeded,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Container name → error for guests that could NOT be stopped even after the
+	// force fallback. A non-empty map means the host is NOT fully reclaimed —
+	// the control plane must not treat those guests' resources as freed.
+	Failed        map[string]string `protobuf:"bytes,5,rep,name=failed,proto3" json:"failed,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *WithdrawCapacityResponse) Reset() {
@@ -3836,6 +3840,13 @@ func (x *WithdrawCapacityResponse) GetDrainWindowExceeded() bool {
 		return x.DrainWindowExceeded
 	}
 	return false
+}
+
+func (x *WithdrawCapacityResponse) GetFailed() map[string]string {
+	if x != nil {
+		return x.Failed
+	}
+	return nil
 }
 
 // GetCapacityHeadroomRequest reads the backend's current advertisement and the
@@ -4715,12 +4726,16 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\"a\n" +
 	"\x17WithdrawCapacityRequest\x12\x14\n" +
 	"\x05drain\x18\x01 \x01(\bR\x05drain\x120\n" +
-	"\x14drain_window_seconds\x18\x02 \x01(\x05R\x12drainWindowSeconds\"\xcc\x01\n" +
+	"\x14drain_window_seconds\x18\x02 \x01(\x05R\x12drainWindowSeconds\"\xd6\x02\n" +
 	"\x18WithdrawCapacityResponse\x12=\n" +
 	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\x12\x18\n" +
 	"\adrained\x18\x02 \x03(\tR\adrained\x12#\n" +
 	"\rforce_stopped\x18\x03 \x03(\tR\fforceStopped\x122\n" +
-	"\x15drain_window_exceeded\x18\x04 \x01(\bR\x13drainWindowExceeded\"\x1c\n" +
+	"\x15drain_window_exceeded\x18\x04 \x01(\bR\x13drainWindowExceeded\x12M\n" +
+	"\x06failed\x18\x05 \x03(\v25.containarium.v1.WithdrawCapacityResponse.FailedEntryR\x06failed\x1a9\n" +
+	"\vFailedEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x1c\n" +
 	"\x1aGetCapacityHeadroomRequest\"\\\n" +
 	"\x1bGetCapacityHeadroomResponse\x12=\n" +
 	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\"Q\n" +
@@ -4818,7 +4833,7 @@ func file_containarium_v1_config_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_config_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 61)
+var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 62)
 var file_containarium_v1_config_proto_goTypes = []any{
 	(GPUVendor)(0),                               // 0: containarium.v1.GPUVendor
 	(GPUModel)(0),                                // 1: containarium.v1.GPUModel
@@ -4886,16 +4901,17 @@ var file_containarium_v1_config_proto_goTypes = []any{
 	(*ProgramDigest)(nil),                        // 63: containarium.v1.ProgramDigest
 	(*GetSelfMeasurementRequest)(nil),            // 64: containarium.v1.GetSelfMeasurementRequest
 	(*GetSelfMeasurementResponse)(nil),           // 65: containarium.v1.GetSelfMeasurementResponse
-	(*ResourceLimits)(nil),                       // 66: containarium.v1.ResourceLimits
-	(OSType)(0),                                  // 67: containarium.v1.OSType
+	nil,                                          // 66: containarium.v1.WithdrawCapacityResponse.FailedEntry
+	(*ResourceLimits)(nil),                       // 67: containarium.v1.ResourceLimits
+	(OSType)(0),                                  // 68: containarium.v1.OSType
 }
 var file_containarium_v1_config_proto_depIdxs = []int32{
 	6,  // 0: containarium.v1.Config.incus:type_name -> containarium.v1.IncusConfig
-	66, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
+	67, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
 	7,  // 2: containarium.v1.Config.network:type_name -> containarium.v1.NetworkConfig
 	8,  // 3: containarium.v1.Config.storage:type_name -> containarium.v1.StorageConfig
 	9,  // 4: containarium.v1.Config.security:type_name -> containarium.v1.SecurityConfig
-	67, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
+	68, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
 	5,  // 6: containarium.v1.GetConfigResponse.config:type_name -> containarium.v1.Config
 	5,  // 7: containarium.v1.UpdateConfigRequest.config:type_name -> containarium.v1.Config
 	5,  // 8: containarium.v1.UpdateConfigResponse.config:type_name -> containarium.v1.Config
@@ -4924,16 +4940,17 @@ var file_containarium_v1_config_proto_depIdxs = []int32{
 	48, // 31: containarium.v1.AdvertiseCapacityRequest.policy:type_name -> containarium.v1.CapacityPolicy
 	47, // 32: containarium.v1.AdvertiseCapacityResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
 	47, // 33: containarium.v1.WithdrawCapacityResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
-	47, // 34: containarium.v1.GetCapacityHeadroomResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
-	45, // 35: containarium.v1.ProfileBackendResponse.profile:type_name -> containarium.v1.CapabilityProfile
-	45, // 36: containarium.v1.GetCapabilityProfileResponse.profile:type_name -> containarium.v1.CapabilityProfile
-	63, // 37: containarium.v1.SelfMeasurement.program_digests:type_name -> containarium.v1.ProgramDigest
-	62, // 38: containarium.v1.GetSelfMeasurementResponse.measurement:type_name -> containarium.v1.SelfMeasurement
-	39, // [39:39] is the sub-list for method output_type
-	39, // [39:39] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	39, // [39:39] is the sub-list for extension extendee
-	0,  // [0:39] is the sub-list for field type_name
+	66, // 34: containarium.v1.WithdrawCapacityResponse.failed:type_name -> containarium.v1.WithdrawCapacityResponse.FailedEntry
+	47, // 35: containarium.v1.GetCapacityHeadroomResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
+	45, // 36: containarium.v1.ProfileBackendResponse.profile:type_name -> containarium.v1.CapabilityProfile
+	45, // 37: containarium.v1.GetCapabilityProfileResponse.profile:type_name -> containarium.v1.CapabilityProfile
+	63, // 38: containarium.v1.SelfMeasurement.program_digests:type_name -> containarium.v1.ProgramDigest
+	62, // 39: containarium.v1.GetSelfMeasurementResponse.measurement:type_name -> containarium.v1.SelfMeasurement
+	40, // [40:40] is the sub-list for method output_type
+	40, // [40:40] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_config_proto_init() }
@@ -4948,7 +4965,7 @@ func file_containarium_v1_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_config_proto_rawDesc), len(file_containarium_v1_config_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   61,
+			NumMessages:   62,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/config.pb.go
+++ b/pkg/pb/containarium/v1/config.pb.go
@@ -2898,9 +2898,14 @@ type BackendInfo struct {
 	// control plane, or null when nothing is advertised (withdrawn or never
 	// published). Lets the control plane direct scheduling at hosts that have
 	// explicitly offered freed headroom. See #680.
-	Headroom      *CapacityHeadroom `protobuf:"bytes,11,opt,name=headroom,proto3" json:"headroom,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Headroom *CapacityHeadroom `protobuf:"bytes,11,opt,name=headroom,proto3" json:"headroom,omitempty"`
+	// The backend's hardware capability profile recorded at join (hardware
+	// class, a bounded CPU/memory micro-benchmark, and region), or null when no
+	// profile has been recorded yet. Lets the control plane place work by
+	// measured class rather than self-reported class alone. See #681.
+	CapabilityProfile *CapabilityProfile `protobuf:"bytes,12,opt,name=capability_profile,json=capabilityProfile,proto3" json:"capability_profile,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *BackendInfo) Reset() {
@@ -3010,6 +3015,251 @@ func (x *BackendInfo) GetHeadroom() *CapacityHeadroom {
 	return nil
 }
 
+func (x *BackendInfo) GetCapabilityProfile() *CapabilityProfile {
+	if x != nil {
+		return x.CapabilityProfile
+	}
+	return nil
+}
+
+// CapabilityProfile is a backend's hardware capability snapshot recorded at
+// join (and refreshable on demand): the hardware class derived from the host's
+// system info + GPU probe, a lightweight bounded CPU/memory micro-benchmark,
+// and the region. The control plane reads it through the backend surface to
+// place work by measured capability rather than by the self-reported class
+// alone, and to detect a backend whose measured class drifts from what it
+// reports. See #681.
+type CapabilityProfile struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Total physical CPU cores on the host (from SystemInfo.total_cpus).
+	CpuCores int32 `protobuf:"varint,1,opt,name=cpu_cores,json=cpuCores,proto3" json:"cpu_cores,omitempty"`
+	// Best-effort CPU model/generation string (e.g. "AMD EPYC 7B13"), empty when
+	// the host doesn't expose one.
+	CpuModel string `protobuf:"bytes,2,opt,name=cpu_model,json=cpuModel,proto3" json:"cpu_model,omitempty"`
+	// Total RAM in bytes (from SystemInfo.total_memory_bytes).
+	TotalMemoryBytes int64 `protobuf:"varint,3,opt,name=total_memory_bytes,json=totalMemoryBytes,proto3" json:"total_memory_bytes,omitempty"`
+	// Total disk in bytes (from SystemInfo.total_disk_bytes).
+	TotalDiskBytes int64 `protobuf:"varint,4,opt,name=total_disk_bytes,json=totalDiskBytes,proto3" json:"total_disk_bytes,omitempty"`
+	// GPU model name from the existing nvidia.runtime passthrough probe
+	// (ValidateGPU), empty on a CPU-only backend.
+	GpuModel string `protobuf:"bytes,5,opt,name=gpu_model,json=gpuModel,proto3" json:"gpu_model,omitempty"`
+	// GPU driver version from the same probe, empty on a CPU-only backend.
+	GpuDriverVersion string `protobuf:"bytes,6,opt,name=gpu_driver_version,json=gpuDriverVersion,proto3" json:"gpu_driver_version,omitempty"`
+	// Whether the GPU passthrough probe saw a usable GPU.
+	GpuAvailable bool `protobuf:"varint,7,opt,name=gpu_available,json=gpuAvailable,proto3" json:"gpu_available,omitempty"`
+	// Region the backend serves (operator-set via --region; falls back to the
+	// pool name). Empty when unset.
+	Region string `protobuf:"bytes,8,opt,name=region,proto3" json:"region,omitempty"`
+	// Self-reported hardware class the operator assigned the backend (e.g. the
+	// pool name / declared tier), if any.
+	ReportedClass string `protobuf:"bytes,9,opt,name=reported_class,json=reportedClass,proto3" json:"reported_class,omitempty"`
+	// Measured hardware class derived from the profile (e.g. "gpu", "cpu-large",
+	// "cpu-small"). Coarse buckets; the control plane refines placement from the
+	// raw figures.
+	MeasuredClass string `protobuf:"bytes,10,opt,name=measured_class,json=measuredClass,proto3" json:"measured_class,omitempty"`
+	// True when measured_class matches reported_class (or reported_class is
+	// empty, treated as consistent). False flags a drift the control plane and
+	// operator should reconcile.
+	ClassConsistent bool `protobuf:"varint,11,opt,name=class_consistent,json=classConsistent,proto3" json:"class_consistent,omitempty"`
+	// The bounded micro-benchmark result. See CapabilityBenchmark.
+	Benchmark *CapabilityBenchmark `protobuf:"bytes,12,opt,name=benchmark,proto3" json:"benchmark,omitempty"`
+	// RFC3339 timestamp the profile was recorded.
+	ProfiledAt    string `protobuf:"bytes,13,opt,name=profiled_at,json=profiledAt,proto3" json:"profiled_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CapabilityProfile) Reset() {
+	*x = CapabilityProfile{}
+	mi := &file_containarium_v1_config_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CapabilityProfile) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CapabilityProfile) ProtoMessage() {}
+
+func (x *CapabilityProfile) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CapabilityProfile.ProtoReflect.Descriptor instead.
+func (*CapabilityProfile) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *CapabilityProfile) GetCpuCores() int32 {
+	if x != nil {
+		return x.CpuCores
+	}
+	return 0
+}
+
+func (x *CapabilityProfile) GetCpuModel() string {
+	if x != nil {
+		return x.CpuModel
+	}
+	return ""
+}
+
+func (x *CapabilityProfile) GetTotalMemoryBytes() int64 {
+	if x != nil {
+		return x.TotalMemoryBytes
+	}
+	return 0
+}
+
+func (x *CapabilityProfile) GetTotalDiskBytes() int64 {
+	if x != nil {
+		return x.TotalDiskBytes
+	}
+	return 0
+}
+
+func (x *CapabilityProfile) GetGpuModel() string {
+	if x != nil {
+		return x.GpuModel
+	}
+	return ""
+}
+
+func (x *CapabilityProfile) GetGpuDriverVersion() string {
+	if x != nil {
+		return x.GpuDriverVersion
+	}
+	return ""
+}
+
+func (x *CapabilityProfile) GetGpuAvailable() bool {
+	if x != nil {
+		return x.GpuAvailable
+	}
+	return false
+}
+
+func (x *CapabilityProfile) GetRegion() string {
+	if x != nil {
+		return x.Region
+	}
+	return ""
+}
+
+func (x *CapabilityProfile) GetReportedClass() string {
+	if x != nil {
+		return x.ReportedClass
+	}
+	return ""
+}
+
+func (x *CapabilityProfile) GetMeasuredClass() string {
+	if x != nil {
+		return x.MeasuredClass
+	}
+	return ""
+}
+
+func (x *CapabilityProfile) GetClassConsistent() bool {
+	if x != nil {
+		return x.ClassConsistent
+	}
+	return false
+}
+
+func (x *CapabilityProfile) GetBenchmark() *CapabilityBenchmark {
+	if x != nil {
+		return x.Benchmark
+	}
+	return nil
+}
+
+func (x *CapabilityProfile) GetProfiledAt() string {
+	if x != nil {
+		return x.ProfiledAt
+	}
+	return ""
+}
+
+// CapabilityBenchmark is a lightweight, time-bounded CPU/memory micro-benchmark
+// run when the profile is recorded. The scores are relative integrity/capacity
+// signals, not absolute hardware specs — they let the control plane confirm a
+// backend's self-reported class is plausible. See #681.
+type CapabilityBenchmark struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// CPU score: integer-work iterations completed per second during the bounded
+	// run (higher is faster). Single-threaded.
+	CpuOpsPerSec int64 `protobuf:"varint,1,opt,name=cpu_ops_per_sec,json=cpuOpsPerSec,proto3" json:"cpu_ops_per_sec,omitempty"`
+	// Memory score: bytes per second moved through a bounded buffer copy/sum
+	// loop (higher is faster).
+	MemBytesPerSec int64 `protobuf:"varint,2,opt,name=mem_bytes_per_sec,json=memBytesPerSec,proto3" json:"mem_bytes_per_sec,omitempty"`
+	// Wall-clock duration of the benchmark in milliseconds (bounded; the runner
+	// caps each phase).
+	DurationMs    int64 `protobuf:"varint,3,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CapabilityBenchmark) Reset() {
+	*x = CapabilityBenchmark{}
+	mi := &file_containarium_v1_config_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CapabilityBenchmark) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CapabilityBenchmark) ProtoMessage() {}
+
+func (x *CapabilityBenchmark) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CapabilityBenchmark.ProtoReflect.Descriptor instead.
+func (*CapabilityBenchmark) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *CapabilityBenchmark) GetCpuOpsPerSec() int64 {
+	if x != nil {
+		return x.CpuOpsPerSec
+	}
+	return 0
+}
+
+func (x *CapabilityBenchmark) GetMemBytesPerSec() int64 {
+	if x != nil {
+		return x.MemBytesPerSec
+	}
+	return 0
+}
+
+func (x *CapabilityBenchmark) GetDurationMs() int64 {
+	if x != nil {
+		return x.DurationMs
+	}
+	return 0
+}
+
 // CapacityHeadroom is a backend's explicit, policy-bounded offer of spare
 // scheduling capacity to the control plane. Today a backend's capacity is
 // implicit (derived from system info); a box that would otherwise scale down
@@ -3044,7 +3294,7 @@ type CapacityHeadroom struct {
 
 func (x *CapacityHeadroom) Reset() {
 	*x = CapacityHeadroom{}
-	mi := &file_containarium_v1_config_proto_msgTypes[40]
+	mi := &file_containarium_v1_config_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3056,7 +3306,7 @@ func (x *CapacityHeadroom) String() string {
 func (*CapacityHeadroom) ProtoMessage() {}
 
 func (x *CapacityHeadroom) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[40]
+	mi := &file_containarium_v1_config_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3069,7 +3319,7 @@ func (x *CapacityHeadroom) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapacityHeadroom.ProtoReflect.Descriptor instead.
 func (*CapacityHeadroom) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{40}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *CapacityHeadroom) GetAdvertised() bool {
@@ -3148,7 +3398,7 @@ type CapacityPolicy struct {
 
 func (x *CapacityPolicy) Reset() {
 	*x = CapacityPolicy{}
-	mi := &file_containarium_v1_config_proto_msgTypes[41]
+	mi := &file_containarium_v1_config_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3160,7 +3410,7 @@ func (x *CapacityPolicy) String() string {
 func (*CapacityPolicy) ProtoMessage() {}
 
 func (x *CapacityPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[41]
+	mi := &file_containarium_v1_config_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3173,7 +3423,7 @@ func (x *CapacityPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapacityPolicy.ProtoReflect.Descriptor instead.
 func (*CapacityPolicy) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{41}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *CapacityPolicy) GetWindowStartHour() int32 {
@@ -3219,7 +3469,7 @@ type BackendGPU struct {
 
 func (x *BackendGPU) Reset() {
 	*x = BackendGPU{}
-	mi := &file_containarium_v1_config_proto_msgTypes[42]
+	mi := &file_containarium_v1_config_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3231,7 +3481,7 @@ func (x *BackendGPU) String() string {
 func (*BackendGPU) ProtoMessage() {}
 
 func (x *BackendGPU) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[42]
+	mi := &file_containarium_v1_config_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3244,7 +3494,7 @@ func (x *BackendGPU) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackendGPU.ProtoReflect.Descriptor instead.
 func (*BackendGPU) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{42}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *BackendGPU) GetVendor() string {
@@ -3277,7 +3527,7 @@ type ListBackendsRequest struct {
 
 func (x *ListBackendsRequest) Reset() {
 	*x = ListBackendsRequest{}
-	mi := &file_containarium_v1_config_proto_msgTypes[43]
+	mi := &file_containarium_v1_config_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3289,7 +3539,7 @@ func (x *ListBackendsRequest) String() string {
 func (*ListBackendsRequest) ProtoMessage() {}
 
 func (x *ListBackendsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[43]
+	mi := &file_containarium_v1_config_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3302,7 +3552,7 @@ func (x *ListBackendsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendsRequest.ProtoReflect.Descriptor instead.
 func (*ListBackendsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{43}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{45}
 }
 
 // ListBackendsResponse is the response from listing backends
@@ -3316,7 +3566,7 @@ type ListBackendsResponse struct {
 
 func (x *ListBackendsResponse) Reset() {
 	*x = ListBackendsResponse{}
-	mi := &file_containarium_v1_config_proto_msgTypes[44]
+	mi := &file_containarium_v1_config_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3328,7 +3578,7 @@ func (x *ListBackendsResponse) String() string {
 func (*ListBackendsResponse) ProtoMessage() {}
 
 func (x *ListBackendsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[44]
+	mi := &file_containarium_v1_config_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3341,7 +3591,7 @@ func (x *ListBackendsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendsResponse.ProtoReflect.Descriptor instead.
 func (*ListBackendsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{44}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ListBackendsResponse) GetBackends() []*BackendInfo {
@@ -3366,7 +3616,7 @@ type AdvertiseCapacityRequest struct {
 
 func (x *AdvertiseCapacityRequest) Reset() {
 	*x = AdvertiseCapacityRequest{}
-	mi := &file_containarium_v1_config_proto_msgTypes[45]
+	mi := &file_containarium_v1_config_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3378,7 +3628,7 @@ func (x *AdvertiseCapacityRequest) String() string {
 func (*AdvertiseCapacityRequest) ProtoMessage() {}
 
 func (x *AdvertiseCapacityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[45]
+	mi := &file_containarium_v1_config_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3391,7 +3641,7 @@ func (x *AdvertiseCapacityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdvertiseCapacityRequest.ProtoReflect.Descriptor instead.
 func (*AdvertiseCapacityRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{45}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *AdvertiseCapacityRequest) GetPolicy() *CapacityPolicy {
@@ -3413,7 +3663,7 @@ type AdvertiseCapacityResponse struct {
 
 func (x *AdvertiseCapacityResponse) Reset() {
 	*x = AdvertiseCapacityResponse{}
-	mi := &file_containarium_v1_config_proto_msgTypes[46]
+	mi := &file_containarium_v1_config_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3425,7 +3675,7 @@ func (x *AdvertiseCapacityResponse) String() string {
 func (*AdvertiseCapacityResponse) ProtoMessage() {}
 
 func (x *AdvertiseCapacityResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[46]
+	mi := &file_containarium_v1_config_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3438,7 +3688,7 @@ func (x *AdvertiseCapacityResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdvertiseCapacityResponse.ProtoReflect.Descriptor instead.
 func (*AdvertiseCapacityResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{46}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *AdvertiseCapacityResponse) GetHeadroom() *CapacityHeadroom {
@@ -3458,7 +3708,7 @@ type WithdrawCapacityRequest struct {
 
 func (x *WithdrawCapacityRequest) Reset() {
 	*x = WithdrawCapacityRequest{}
-	mi := &file_containarium_v1_config_proto_msgTypes[47]
+	mi := &file_containarium_v1_config_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3470,7 +3720,7 @@ func (x *WithdrawCapacityRequest) String() string {
 func (*WithdrawCapacityRequest) ProtoMessage() {}
 
 func (x *WithdrawCapacityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[47]
+	mi := &file_containarium_v1_config_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3483,7 +3733,7 @@ func (x *WithdrawCapacityRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WithdrawCapacityRequest.ProtoReflect.Descriptor instead.
 func (*WithdrawCapacityRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{47}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{49}
 }
 
 // WithdrawCapacityResponse confirms the backend is no longer advertising.
@@ -3497,7 +3747,7 @@ type WithdrawCapacityResponse struct {
 
 func (x *WithdrawCapacityResponse) Reset() {
 	*x = WithdrawCapacityResponse{}
-	mi := &file_containarium_v1_config_proto_msgTypes[48]
+	mi := &file_containarium_v1_config_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3509,7 +3759,7 @@ func (x *WithdrawCapacityResponse) String() string {
 func (*WithdrawCapacityResponse) ProtoMessage() {}
 
 func (x *WithdrawCapacityResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[48]
+	mi := &file_containarium_v1_config_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3522,7 +3772,7 @@ func (x *WithdrawCapacityResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WithdrawCapacityResponse.ProtoReflect.Descriptor instead.
 func (*WithdrawCapacityResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{48}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *WithdrawCapacityResponse) GetHeadroom() *CapacityHeadroom {
@@ -3542,7 +3792,7 @@ type GetCapacityHeadroomRequest struct {
 
 func (x *GetCapacityHeadroomRequest) Reset() {
 	*x = GetCapacityHeadroomRequest{}
-	mi := &file_containarium_v1_config_proto_msgTypes[49]
+	mi := &file_containarium_v1_config_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3554,7 +3804,7 @@ func (x *GetCapacityHeadroomRequest) String() string {
 func (*GetCapacityHeadroomRequest) ProtoMessage() {}
 
 func (x *GetCapacityHeadroomRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[49]
+	mi := &file_containarium_v1_config_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3567,7 +3817,7 @@ func (x *GetCapacityHeadroomRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCapacityHeadroomRequest.ProtoReflect.Descriptor instead.
 func (*GetCapacityHeadroomRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{49}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{51}
 }
 
 // GetCapacityHeadroomResponse returns the current headroom snapshot.
@@ -3580,7 +3830,7 @@ type GetCapacityHeadroomResponse struct {
 
 func (x *GetCapacityHeadroomResponse) Reset() {
 	*x = GetCapacityHeadroomResponse{}
-	mi := &file_containarium_v1_config_proto_msgTypes[50]
+	mi := &file_containarium_v1_config_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3592,7 +3842,7 @@ func (x *GetCapacityHeadroomResponse) String() string {
 func (*GetCapacityHeadroomResponse) ProtoMessage() {}
 
 func (x *GetCapacityHeadroomResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[50]
+	mi := &file_containarium_v1_config_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3605,7 +3855,7 @@ func (x *GetCapacityHeadroomResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCapacityHeadroomResponse.ProtoReflect.Descriptor instead.
 func (*GetCapacityHeadroomResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{50}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *GetCapacityHeadroomResponse) GetHeadroom() *CapacityHeadroom {
@@ -3613,6 +3863,223 @@ func (x *GetCapacityHeadroomResponse) GetHeadroom() *CapacityHeadroom {
 		return x.Headroom
 	}
 	return nil
+}
+
+// ProfileBackendRequest asks a backend to (re)record its capability profile:
+// read system info, run the GPU passthrough probe and the bounded
+// CPU/memory micro-benchmark, derive the measured class, and persist it. See
+// #681.
+type ProfileBackendRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Backend to profile. Empty = the local/primary daemon's own host; a peer id
+	// forwards to that peer (which profiles itself).
+	BackendId string `protobuf:"bytes,1,opt,name=backend_id,json=backendId,proto3" json:"backend_id,omitempty"`
+	// Skip the GPU passthrough probe (which creates+deletes a throwaway LXC and
+	// can take ~30s). The profile then records gpu_available=false. Useful on a
+	// backend known to be CPU-only.
+	SkipGpu       bool `protobuf:"varint,2,opt,name=skip_gpu,json=skipGpu,proto3" json:"skip_gpu,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProfileBackendRequest) Reset() {
+	*x = ProfileBackendRequest{}
+	mi := &file_containarium_v1_config_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProfileBackendRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProfileBackendRequest) ProtoMessage() {}
+
+func (x *ProfileBackendRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProfileBackendRequest.ProtoReflect.Descriptor instead.
+func (*ProfileBackendRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *ProfileBackendRequest) GetBackendId() string {
+	if x != nil {
+		return x.BackendId
+	}
+	return ""
+}
+
+func (x *ProfileBackendRequest) GetSkipGpu() bool {
+	if x != nil {
+		return x.SkipGpu
+	}
+	return false
+}
+
+// ProfileBackendResponse returns the freshly recorded capability profile.
+type ProfileBackendResponse struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Profile *CapabilityProfile     `protobuf:"bytes,1,opt,name=profile,proto3" json:"profile,omitempty"`
+	// Echoes the profiled backend ("" = local).
+	BackendId     string `protobuf:"bytes,2,opt,name=backend_id,json=backendId,proto3" json:"backend_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProfileBackendResponse) Reset() {
+	*x = ProfileBackendResponse{}
+	mi := &file_containarium_v1_config_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProfileBackendResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProfileBackendResponse) ProtoMessage() {}
+
+func (x *ProfileBackendResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProfileBackendResponse.ProtoReflect.Descriptor instead.
+func (*ProfileBackendResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *ProfileBackendResponse) GetProfile() *CapabilityProfile {
+	if x != nil {
+		return x.Profile
+	}
+	return nil
+}
+
+func (x *ProfileBackendResponse) GetBackendId() string {
+	if x != nil {
+		return x.BackendId
+	}
+	return ""
+}
+
+// GetCapabilityProfileRequest reads a backend's last-recorded capability
+// profile without re-running the benchmark/probe. See #681.
+type GetCapabilityProfileRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Backend to read. Empty = the local/primary daemon's own host.
+	BackendId     string `protobuf:"bytes,1,opt,name=backend_id,json=backendId,proto3" json:"backend_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetCapabilityProfileRequest) Reset() {
+	*x = GetCapabilityProfileRequest{}
+	mi := &file_containarium_v1_config_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetCapabilityProfileRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetCapabilityProfileRequest) ProtoMessage() {}
+
+func (x *GetCapabilityProfileRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetCapabilityProfileRequest.ProtoReflect.Descriptor instead.
+func (*GetCapabilityProfileRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *GetCapabilityProfileRequest) GetBackendId() string {
+	if x != nil {
+		return x.BackendId
+	}
+	return ""
+}
+
+// GetCapabilityProfileResponse returns the last-recorded profile, or null when
+// nothing has been profiled yet.
+type GetCapabilityProfileResponse struct {
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Profile *CapabilityProfile     `protobuf:"bytes,1,opt,name=profile,proto3" json:"profile,omitempty"`
+	// Echoes the backend ("" = local).
+	BackendId     string `protobuf:"bytes,2,opt,name=backend_id,json=backendId,proto3" json:"backend_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetCapabilityProfileResponse) Reset() {
+	*x = GetCapabilityProfileResponse{}
+	mi := &file_containarium_v1_config_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetCapabilityProfileResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetCapabilityProfileResponse) ProtoMessage() {}
+
+func (x *GetCapabilityProfileResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetCapabilityProfileResponse.ProtoReflect.Descriptor instead.
+func (*GetCapabilityProfileResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *GetCapabilityProfileResponse) GetProfile() *CapabilityProfile {
+	if x != nil {
+		return x.Profile
+	}
+	return nil
+}
+
+func (x *GetCapabilityProfileResponse) GetBackendId() string {
+	if x != nil {
+		return x.BackendId
+	}
+	return ""
 }
 
 var File_containarium_v1_config_proto protoreflect.FileDescriptor
@@ -3801,7 +4268,7 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"signatures\"9\n" +
 	"#DeleteNetworkPolicySignatureRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"&\n" +
-	"$DeleteNetworkPolicySignatureResponse\"\xf3\x02\n" +
+	"$DeleteNetworkPolicySignatureResponse\"\xc6\x03\n" +
 	"\vBackendInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x18\n" +
@@ -3815,7 +4282,29 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\x0fcontainer_count\x18\t \x01(\x05R\x0econtainerCount\x12/\n" +
 	"\x04gpus\x18\n" +
 	" \x03(\v2\x1b.containarium.v1.BackendGPUR\x04gpus\x12=\n" +
-	"\bheadroom\x18\v \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\"\xac\x02\n" +
+	"\bheadroom\x18\v \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\x12Q\n" +
+	"\x12capability_profile\x18\f \x01(\v2\".containarium.v1.CapabilityProfileR\x11capabilityProfile\"\x8b\x04\n" +
+	"\x11CapabilityProfile\x12\x1b\n" +
+	"\tcpu_cores\x18\x01 \x01(\x05R\bcpuCores\x12\x1b\n" +
+	"\tcpu_model\x18\x02 \x01(\tR\bcpuModel\x12,\n" +
+	"\x12total_memory_bytes\x18\x03 \x01(\x03R\x10totalMemoryBytes\x12(\n" +
+	"\x10total_disk_bytes\x18\x04 \x01(\x03R\x0etotalDiskBytes\x12\x1b\n" +
+	"\tgpu_model\x18\x05 \x01(\tR\bgpuModel\x12,\n" +
+	"\x12gpu_driver_version\x18\x06 \x01(\tR\x10gpuDriverVersion\x12#\n" +
+	"\rgpu_available\x18\a \x01(\bR\fgpuAvailable\x12\x16\n" +
+	"\x06region\x18\b \x01(\tR\x06region\x12%\n" +
+	"\x0ereported_class\x18\t \x01(\tR\rreportedClass\x12%\n" +
+	"\x0emeasured_class\x18\n" +
+	" \x01(\tR\rmeasuredClass\x12)\n" +
+	"\x10class_consistent\x18\v \x01(\bR\x0fclassConsistent\x12B\n" +
+	"\tbenchmark\x18\f \x01(\v2$.containarium.v1.CapabilityBenchmarkR\tbenchmark\x12\x1f\n" +
+	"\vprofiled_at\x18\r \x01(\tR\n" +
+	"profiledAt\"\x88\x01\n" +
+	"\x13CapabilityBenchmark\x12%\n" +
+	"\x0fcpu_ops_per_sec\x18\x01 \x01(\x03R\fcpuOpsPerSec\x12)\n" +
+	"\x11mem_bytes_per_sec\x18\x02 \x01(\x03R\x0ememBytesPerSec\x12\x1f\n" +
+	"\vduration_ms\x18\x03 \x01(\x03R\n" +
+	"durationMs\"\xac\x02\n" +
 	"\x10CapacityHeadroom\x12\x1e\n" +
 	"\n" +
 	"advertised\x18\x01 \x01(\bR\n" +
@@ -3851,7 +4340,22 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\"\x1c\n" +
 	"\x1aGetCapacityHeadroomRequest\"\\\n" +
 	"\x1bGetCapacityHeadroomResponse\x12=\n" +
-	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom*h\n" +
+	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\"Q\n" +
+	"\x15ProfileBackendRequest\x12\x1d\n" +
+	"\n" +
+	"backend_id\x18\x01 \x01(\tR\tbackendId\x12\x19\n" +
+	"\bskip_gpu\x18\x02 \x01(\bR\askipGpu\"u\n" +
+	"\x16ProfileBackendResponse\x12<\n" +
+	"\aprofile\x18\x01 \x01(\v2\".containarium.v1.CapabilityProfileR\aprofile\x12\x1d\n" +
+	"\n" +
+	"backend_id\x18\x02 \x01(\tR\tbackendId\"<\n" +
+	"\x1bGetCapabilityProfileRequest\x12\x1d\n" +
+	"\n" +
+	"backend_id\x18\x01 \x01(\tR\tbackendId\"{\n" +
+	"\x1cGetCapabilityProfileResponse\x12<\n" +
+	"\aprofile\x18\x01 \x01(\v2\".containarium.v1.CapabilityProfileR\aprofile\x12\x1d\n" +
+	"\n" +
+	"backend_id\x18\x02 \x01(\tR\tbackendId*h\n" +
 	"\tGPUVendor\x12\x1a\n" +
 	"\x16GPU_VENDOR_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11GPU_VENDOR_NVIDIA\x10\x01\x12\x12\n" +
@@ -3905,7 +4409,7 @@ func file_containarium_v1_config_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_config_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
+var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 57)
 var file_containarium_v1_config_proto_goTypes = []any{
 	(GPUVendor)(0),                               // 0: containarium.v1.GPUVendor
 	(GPUModel)(0),                                // 1: containarium.v1.GPUModel
@@ -3952,27 +4456,33 @@ var file_containarium_v1_config_proto_goTypes = []any{
 	(*DeleteNetworkPolicySignatureRequest)(nil),  // 42: containarium.v1.DeleteNetworkPolicySignatureRequest
 	(*DeleteNetworkPolicySignatureResponse)(nil), // 43: containarium.v1.DeleteNetworkPolicySignatureResponse
 	(*BackendInfo)(nil),                          // 44: containarium.v1.BackendInfo
-	(*CapacityHeadroom)(nil),                     // 45: containarium.v1.CapacityHeadroom
-	(*CapacityPolicy)(nil),                       // 46: containarium.v1.CapacityPolicy
-	(*BackendGPU)(nil),                           // 47: containarium.v1.BackendGPU
-	(*ListBackendsRequest)(nil),                  // 48: containarium.v1.ListBackendsRequest
-	(*ListBackendsResponse)(nil),                 // 49: containarium.v1.ListBackendsResponse
-	(*AdvertiseCapacityRequest)(nil),             // 50: containarium.v1.AdvertiseCapacityRequest
-	(*AdvertiseCapacityResponse)(nil),            // 51: containarium.v1.AdvertiseCapacityResponse
-	(*WithdrawCapacityRequest)(nil),              // 52: containarium.v1.WithdrawCapacityRequest
-	(*WithdrawCapacityResponse)(nil),             // 53: containarium.v1.WithdrawCapacityResponse
-	(*GetCapacityHeadroomRequest)(nil),           // 54: containarium.v1.GetCapacityHeadroomRequest
-	(*GetCapacityHeadroomResponse)(nil),          // 55: containarium.v1.GetCapacityHeadroomResponse
-	(*ResourceLimits)(nil),                       // 56: containarium.v1.ResourceLimits
-	(OSType)(0),                                  // 57: containarium.v1.OSType
+	(*CapabilityProfile)(nil),                    // 45: containarium.v1.CapabilityProfile
+	(*CapabilityBenchmark)(nil),                  // 46: containarium.v1.CapabilityBenchmark
+	(*CapacityHeadroom)(nil),                     // 47: containarium.v1.CapacityHeadroom
+	(*CapacityPolicy)(nil),                       // 48: containarium.v1.CapacityPolicy
+	(*BackendGPU)(nil),                           // 49: containarium.v1.BackendGPU
+	(*ListBackendsRequest)(nil),                  // 50: containarium.v1.ListBackendsRequest
+	(*ListBackendsResponse)(nil),                 // 51: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityRequest)(nil),             // 52: containarium.v1.AdvertiseCapacityRequest
+	(*AdvertiseCapacityResponse)(nil),            // 53: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityRequest)(nil),              // 54: containarium.v1.WithdrawCapacityRequest
+	(*WithdrawCapacityResponse)(nil),             // 55: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomRequest)(nil),           // 56: containarium.v1.GetCapacityHeadroomRequest
+	(*GetCapacityHeadroomResponse)(nil),          // 57: containarium.v1.GetCapacityHeadroomResponse
+	(*ProfileBackendRequest)(nil),                // 58: containarium.v1.ProfileBackendRequest
+	(*ProfileBackendResponse)(nil),               // 59: containarium.v1.ProfileBackendResponse
+	(*GetCapabilityProfileRequest)(nil),          // 60: containarium.v1.GetCapabilityProfileRequest
+	(*GetCapabilityProfileResponse)(nil),         // 61: containarium.v1.GetCapabilityProfileResponse
+	(*ResourceLimits)(nil),                       // 62: containarium.v1.ResourceLimits
+	(OSType)(0),                                  // 63: containarium.v1.OSType
 }
 var file_containarium_v1_config_proto_depIdxs = []int32{
 	6,  // 0: containarium.v1.Config.incus:type_name -> containarium.v1.IncusConfig
-	56, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
+	62, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
 	7,  // 2: containarium.v1.Config.network:type_name -> containarium.v1.NetworkConfig
 	8,  // 3: containarium.v1.Config.storage:type_name -> containarium.v1.StorageConfig
 	9,  // 4: containarium.v1.Config.security:type_name -> containarium.v1.SecurityConfig
-	57, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
+	63, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
 	5,  // 6: containarium.v1.GetConfigResponse.config:type_name -> containarium.v1.Config
 	5,  // 7: containarium.v1.UpdateConfigRequest.config:type_name -> containarium.v1.Config
 	5,  // 8: containarium.v1.UpdateConfigResponse.config:type_name -> containarium.v1.Config
@@ -3992,19 +4502,23 @@ var file_containarium_v1_config_proto_depIdxs = []int32{
 	37, // 22: containarium.v1.SetNetworkPolicySignatureRequest.signature:type_name -> containarium.v1.NetworkPolicySignature
 	37, // 23: containarium.v1.SetNetworkPolicySignatureResponse.signature:type_name -> containarium.v1.NetworkPolicySignature
 	37, // 24: containarium.v1.ListNetworkPolicySignaturesResponse.signatures:type_name -> containarium.v1.NetworkPolicySignature
-	47, // 25: containarium.v1.BackendInfo.gpus:type_name -> containarium.v1.BackendGPU
-	45, // 26: containarium.v1.BackendInfo.headroom:type_name -> containarium.v1.CapacityHeadroom
-	46, // 27: containarium.v1.CapacityHeadroom.policy:type_name -> containarium.v1.CapacityPolicy
-	44, // 28: containarium.v1.ListBackendsResponse.backends:type_name -> containarium.v1.BackendInfo
-	46, // 29: containarium.v1.AdvertiseCapacityRequest.policy:type_name -> containarium.v1.CapacityPolicy
-	45, // 30: containarium.v1.AdvertiseCapacityResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
-	45, // 31: containarium.v1.WithdrawCapacityResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
-	45, // 32: containarium.v1.GetCapacityHeadroomResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
-	33, // [33:33] is the sub-list for method output_type
-	33, // [33:33] is the sub-list for method input_type
-	33, // [33:33] is the sub-list for extension type_name
-	33, // [33:33] is the sub-list for extension extendee
-	0,  // [0:33] is the sub-list for field type_name
+	49, // 25: containarium.v1.BackendInfo.gpus:type_name -> containarium.v1.BackendGPU
+	47, // 26: containarium.v1.BackendInfo.headroom:type_name -> containarium.v1.CapacityHeadroom
+	45, // 27: containarium.v1.BackendInfo.capability_profile:type_name -> containarium.v1.CapabilityProfile
+	46, // 28: containarium.v1.CapabilityProfile.benchmark:type_name -> containarium.v1.CapabilityBenchmark
+	48, // 29: containarium.v1.CapacityHeadroom.policy:type_name -> containarium.v1.CapacityPolicy
+	44, // 30: containarium.v1.ListBackendsResponse.backends:type_name -> containarium.v1.BackendInfo
+	48, // 31: containarium.v1.AdvertiseCapacityRequest.policy:type_name -> containarium.v1.CapacityPolicy
+	47, // 32: containarium.v1.AdvertiseCapacityResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
+	47, // 33: containarium.v1.WithdrawCapacityResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
+	47, // 34: containarium.v1.GetCapacityHeadroomResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
+	45, // 35: containarium.v1.ProfileBackendResponse.profile:type_name -> containarium.v1.CapabilityProfile
+	45, // 36: containarium.v1.GetCapabilityProfileResponse.profile:type_name -> containarium.v1.CapabilityProfile
+	37, // [37:37] is the sub-list for method output_type
+	37, // [37:37] is the sub-list for method input_type
+	37, // [37:37] is the sub-list for extension type_name
+	37, // [37:37] is the sub-list for extension extendee
+	0,  // [0:37] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_config_proto_init() }
@@ -4019,7 +4533,7 @@ func file_containarium_v1_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_config_proto_rawDesc), len(file_containarium_v1_config_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   51,
+			NumMessages:   57,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/config.pb.go
+++ b/pkg/pb/containarium/v1/config.pb.go
@@ -4138,6 +4138,328 @@ func (x *GetCapabilityProfileResponse) GetBackendId() string {
 	return ""
 }
 
+// SelfMeasurement is a backend's signed integrity attestation, emitted by the
+// daemon on its heartbeat. It hashes the daemon's own binary, the loaded
+// in-kernel network-policy program object(s), and the policy/config state, then
+// signs the canonical measurement with the node's identity key (the
+// sentinel-issued peer leaf key reused from the peer-PKI plumbing; TPM-backed
+// when a TPM is present, software-signed otherwise). The control plane reads
+// this through the backend surface to detect tampering of a backend's control
+// plane out of band of the backend's own reporting. The node-side half only:
+// the control plane's verification/quarantine logic lives elsewhere. See #683.
+type SelfMeasurement struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Hash algorithm used for every component digest below (e.g. "sha256").
+	HashAlgorithm string `protobuf:"bytes,1,opt,name=hash_algorithm,json=hashAlgorithm,proto3" json:"hash_algorithm,omitempty"`
+	// Hex-encoded digest of the running daemon binary on disk.
+	BinaryDigest string `protobuf:"bytes,2,opt,name=binary_digest,json=binaryDigest,proto3" json:"binary_digest,omitempty"`
+	// Hex-encoded digests of the loaded in-kernel network-policy program
+	// object(s), in stable (sorted) order. Empty when no program object is
+	// configured on this backend.
+	ProgramDigests []*ProgramDigest `protobuf:"bytes,3,rep,name=program_digests,json=programDigests,proto3" json:"program_digests,omitempty"`
+	// Hex-encoded digest of the canonicalized policy/config state (the
+	// integrity-relevant daemon configuration + active network-policy posture).
+	ConfigDigest string `protobuf:"bytes,4,opt,name=config_digest,json=configDigest,proto3" json:"config_digest,omitempty"`
+	// Hex-encoded digest of the canonical measurement bytes that were signed
+	// (binds all components together). The signature below covers exactly these
+	// bytes.
+	MeasurementDigest string `protobuf:"bytes,5,opt,name=measurement_digest,json=measurementDigest,proto3" json:"measurement_digest,omitempty"`
+	// Signature over the canonical measurement bytes, base64-encoded.
+	Signature string `protobuf:"bytes,6,opt,name=signature,proto3" json:"signature,omitempty"`
+	// Signature scheme used (e.g. "ecdsa-p256-sha256"). Empty when the daemon had
+	// no identity key available and the measurement is unsigned (signature empty).
+	SignatureAlgorithm string `protobuf:"bytes,7,opt,name=signature_algorithm,json=signatureAlgorithm,proto3" json:"signature_algorithm,omitempty"`
+	// Whether the signature was produced by a TPM-backed key. False = the
+	// software identity key (sentinel-issued peer leaf) signed it.
+	TpmBacked bool `protobuf:"varint,8,opt,name=tpm_backed,json=tpmBacked,proto3" json:"tpm_backed,omitempty"`
+	// Whether an identity key was available to sign. False means the measurement
+	// is present but unsigned (no peer PKI bootstrapped yet); the control plane
+	// treats an unsigned measurement as unverifiable, not as tamper.
+	Signed bool `protobuf:"varint,9,opt,name=signed,proto3" json:"signed,omitempty"`
+	// PEM of the signing certificate (the peer leaf), so the control plane can
+	// verify the signature against the sentinel CA chain without a side lookup.
+	// Empty when unsigned.
+	SigningCertPem string `protobuf:"bytes,10,opt,name=signing_cert_pem,json=signingCertPem,proto3" json:"signing_cert_pem,omitempty"`
+	// RFC3339 timestamp the measurement was taken.
+	MeasuredAt string `protobuf:"bytes,11,opt,name=measured_at,json=measuredAt,proto3" json:"measured_at,omitempty"`
+	// Daemon version that produced the measurement.
+	DaemonVersion string `protobuf:"bytes,12,opt,name=daemon_version,json=daemonVersion,proto3" json:"daemon_version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SelfMeasurement) Reset() {
+	*x = SelfMeasurement{}
+	mi := &file_containarium_v1_config_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SelfMeasurement) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SelfMeasurement) ProtoMessage() {}
+
+func (x *SelfMeasurement) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SelfMeasurement.ProtoReflect.Descriptor instead.
+func (*SelfMeasurement) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{57}
+}
+
+func (x *SelfMeasurement) GetHashAlgorithm() string {
+	if x != nil {
+		return x.HashAlgorithm
+	}
+	return ""
+}
+
+func (x *SelfMeasurement) GetBinaryDigest() string {
+	if x != nil {
+		return x.BinaryDigest
+	}
+	return ""
+}
+
+func (x *SelfMeasurement) GetProgramDigests() []*ProgramDigest {
+	if x != nil {
+		return x.ProgramDigests
+	}
+	return nil
+}
+
+func (x *SelfMeasurement) GetConfigDigest() string {
+	if x != nil {
+		return x.ConfigDigest
+	}
+	return ""
+}
+
+func (x *SelfMeasurement) GetMeasurementDigest() string {
+	if x != nil {
+		return x.MeasurementDigest
+	}
+	return ""
+}
+
+func (x *SelfMeasurement) GetSignature() string {
+	if x != nil {
+		return x.Signature
+	}
+	return ""
+}
+
+func (x *SelfMeasurement) GetSignatureAlgorithm() string {
+	if x != nil {
+		return x.SignatureAlgorithm
+	}
+	return ""
+}
+
+func (x *SelfMeasurement) GetTpmBacked() bool {
+	if x != nil {
+		return x.TpmBacked
+	}
+	return false
+}
+
+func (x *SelfMeasurement) GetSigned() bool {
+	if x != nil {
+		return x.Signed
+	}
+	return false
+}
+
+func (x *SelfMeasurement) GetSigningCertPem() string {
+	if x != nil {
+		return x.SigningCertPem
+	}
+	return ""
+}
+
+func (x *SelfMeasurement) GetMeasuredAt() string {
+	if x != nil {
+		return x.MeasuredAt
+	}
+	return ""
+}
+
+func (x *SelfMeasurement) GetDaemonVersion() string {
+	if x != nil {
+		return x.DaemonVersion
+	}
+	return ""
+}
+
+// ProgramDigest is one loaded in-kernel program object's identity + digest.
+type ProgramDigest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Stable name/path identifying the program object (e.g. the configured BPF
+	// object path).
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Hex-encoded digest of the program object bytes.
+	Digest        string `protobuf:"bytes,2,opt,name=digest,proto3" json:"digest,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ProgramDigest) Reset() {
+	*x = ProgramDigest{}
+	mi := &file_containarium_v1_config_proto_msgTypes[58]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ProgramDigest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ProgramDigest) ProtoMessage() {}
+
+func (x *ProgramDigest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[58]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ProgramDigest.ProtoReflect.Descriptor instead.
+func (*ProgramDigest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{58}
+}
+
+func (x *ProgramDigest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ProgramDigest) GetDigest() string {
+	if x != nil {
+		return x.Digest
+	}
+	return ""
+}
+
+// GetSelfMeasurementRequest asks a backend to compute and sign a fresh self
+// measurement. See #683.
+type GetSelfMeasurementRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Backend to measure. Empty = the local/primary daemon's own host; a peer id
+	// forwards to that peer (which measures itself).
+	BackendId     string `protobuf:"bytes,1,opt,name=backend_id,json=backendId,proto3" json:"backend_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSelfMeasurementRequest) Reset() {
+	*x = GetSelfMeasurementRequest{}
+	mi := &file_containarium_v1_config_proto_msgTypes[59]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSelfMeasurementRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSelfMeasurementRequest) ProtoMessage() {}
+
+func (x *GetSelfMeasurementRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[59]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSelfMeasurementRequest.ProtoReflect.Descriptor instead.
+func (*GetSelfMeasurementRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{59}
+}
+
+func (x *GetSelfMeasurementRequest) GetBackendId() string {
+	if x != nil {
+		return x.BackendId
+	}
+	return ""
+}
+
+// GetSelfMeasurementResponse returns the freshly computed signed measurement.
+type GetSelfMeasurementResponse struct {
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	Measurement *SelfMeasurement       `protobuf:"bytes,1,opt,name=measurement,proto3" json:"measurement,omitempty"`
+	// Echoes the measured backend ("" = local).
+	BackendId     string `protobuf:"bytes,2,opt,name=backend_id,json=backendId,proto3" json:"backend_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSelfMeasurementResponse) Reset() {
+	*x = GetSelfMeasurementResponse{}
+	mi := &file_containarium_v1_config_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSelfMeasurementResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSelfMeasurementResponse) ProtoMessage() {}
+
+func (x *GetSelfMeasurementResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSelfMeasurementResponse.ProtoReflect.Descriptor instead.
+func (*GetSelfMeasurementResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *GetSelfMeasurementResponse) GetMeasurement() *SelfMeasurement {
+	if x != nil {
+		return x.Measurement
+	}
+	return nil
+}
+
+func (x *GetSelfMeasurementResponse) GetBackendId() string {
+	if x != nil {
+		return x.BackendId
+	}
+	return ""
+}
+
 var File_containarium_v1_config_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_config_proto_rawDesc = "" +
@@ -4416,6 +4738,32 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\x1cGetCapabilityProfileResponse\x12<\n" +
 	"\aprofile\x18\x01 \x01(\v2\".containarium.v1.CapabilityProfileR\aprofile\x12\x1d\n" +
 	"\n" +
+	"backend_id\x18\x02 \x01(\tR\tbackendId\"\xf2\x03\n" +
+	"\x0fSelfMeasurement\x12%\n" +
+	"\x0ehash_algorithm\x18\x01 \x01(\tR\rhashAlgorithm\x12#\n" +
+	"\rbinary_digest\x18\x02 \x01(\tR\fbinaryDigest\x12G\n" +
+	"\x0fprogram_digests\x18\x03 \x03(\v2\x1e.containarium.v1.ProgramDigestR\x0eprogramDigests\x12#\n" +
+	"\rconfig_digest\x18\x04 \x01(\tR\fconfigDigest\x12-\n" +
+	"\x12measurement_digest\x18\x05 \x01(\tR\x11measurementDigest\x12\x1c\n" +
+	"\tsignature\x18\x06 \x01(\tR\tsignature\x12/\n" +
+	"\x13signature_algorithm\x18\a \x01(\tR\x12signatureAlgorithm\x12\x1d\n" +
+	"\n" +
+	"tpm_backed\x18\b \x01(\bR\ttpmBacked\x12\x16\n" +
+	"\x06signed\x18\t \x01(\bR\x06signed\x12(\n" +
+	"\x10signing_cert_pem\x18\n" +
+	" \x01(\tR\x0esigningCertPem\x12\x1f\n" +
+	"\vmeasured_at\x18\v \x01(\tR\n" +
+	"measuredAt\x12%\n" +
+	"\x0edaemon_version\x18\f \x01(\tR\rdaemonVersion\";\n" +
+	"\rProgramDigest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
+	"\x06digest\x18\x02 \x01(\tR\x06digest\":\n" +
+	"\x19GetSelfMeasurementRequest\x12\x1d\n" +
+	"\n" +
+	"backend_id\x18\x01 \x01(\tR\tbackendId\"\x7f\n" +
+	"\x1aGetSelfMeasurementResponse\x12B\n" +
+	"\vmeasurement\x18\x01 \x01(\v2 .containarium.v1.SelfMeasurementR\vmeasurement\x12\x1d\n" +
+	"\n" +
 	"backend_id\x18\x02 \x01(\tR\tbackendId*h\n" +
 	"\tGPUVendor\x12\x1a\n" +
 	"\x16GPU_VENDOR_UNSPECIFIED\x10\x00\x12\x15\n" +
@@ -4470,7 +4818,7 @@ func file_containarium_v1_config_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_config_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 57)
+var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 61)
 var file_containarium_v1_config_proto_goTypes = []any{
 	(GPUVendor)(0),                               // 0: containarium.v1.GPUVendor
 	(GPUModel)(0),                                // 1: containarium.v1.GPUModel
@@ -4534,16 +4882,20 @@ var file_containarium_v1_config_proto_goTypes = []any{
 	(*ProfileBackendResponse)(nil),               // 59: containarium.v1.ProfileBackendResponse
 	(*GetCapabilityProfileRequest)(nil),          // 60: containarium.v1.GetCapabilityProfileRequest
 	(*GetCapabilityProfileResponse)(nil),         // 61: containarium.v1.GetCapabilityProfileResponse
-	(*ResourceLimits)(nil),                       // 62: containarium.v1.ResourceLimits
-	(OSType)(0),                                  // 63: containarium.v1.OSType
+	(*SelfMeasurement)(nil),                      // 62: containarium.v1.SelfMeasurement
+	(*ProgramDigest)(nil),                        // 63: containarium.v1.ProgramDigest
+	(*GetSelfMeasurementRequest)(nil),            // 64: containarium.v1.GetSelfMeasurementRequest
+	(*GetSelfMeasurementResponse)(nil),           // 65: containarium.v1.GetSelfMeasurementResponse
+	(*ResourceLimits)(nil),                       // 66: containarium.v1.ResourceLimits
+	(OSType)(0),                                  // 67: containarium.v1.OSType
 }
 var file_containarium_v1_config_proto_depIdxs = []int32{
 	6,  // 0: containarium.v1.Config.incus:type_name -> containarium.v1.IncusConfig
-	62, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
+	66, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
 	7,  // 2: containarium.v1.Config.network:type_name -> containarium.v1.NetworkConfig
 	8,  // 3: containarium.v1.Config.storage:type_name -> containarium.v1.StorageConfig
 	9,  // 4: containarium.v1.Config.security:type_name -> containarium.v1.SecurityConfig
-	63, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
+	67, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
 	5,  // 6: containarium.v1.GetConfigResponse.config:type_name -> containarium.v1.Config
 	5,  // 7: containarium.v1.UpdateConfigRequest.config:type_name -> containarium.v1.Config
 	5,  // 8: containarium.v1.UpdateConfigResponse.config:type_name -> containarium.v1.Config
@@ -4575,11 +4927,13 @@ var file_containarium_v1_config_proto_depIdxs = []int32{
 	47, // 34: containarium.v1.GetCapacityHeadroomResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
 	45, // 35: containarium.v1.ProfileBackendResponse.profile:type_name -> containarium.v1.CapabilityProfile
 	45, // 36: containarium.v1.GetCapabilityProfileResponse.profile:type_name -> containarium.v1.CapabilityProfile
-	37, // [37:37] is the sub-list for method output_type
-	37, // [37:37] is the sub-list for method input_type
-	37, // [37:37] is the sub-list for extension type_name
-	37, // [37:37] is the sub-list for extension extendee
-	0,  // [0:37] is the sub-list for field type_name
+	63, // 37: containarium.v1.SelfMeasurement.program_digests:type_name -> containarium.v1.ProgramDigest
+	62, // 38: containarium.v1.GetSelfMeasurementResponse.measurement:type_name -> containarium.v1.SelfMeasurement
+	39, // [39:39] is the sub-list for method output_type
+	39, // [39:39] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	39, // [39:39] is the sub-list for extension extendee
+	0,  // [0:39] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_config_proto_init() }
@@ -4594,7 +4948,7 @@ func file_containarium_v1_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_config_proto_rawDesc), len(file_containarium_v1_config_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   57,
+			NumMessages:   61,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/config.pb.go
+++ b/pkg/pb/containarium/v1/config.pb.go
@@ -2893,7 +2893,12 @@ type BackendInfo struct {
 	// Number of containers currently running on this backend.
 	ContainerCount int32 `protobuf:"varint,9,opt,name=container_count,json=containerCount,proto3" json:"container_count,omitempty"`
 	// GPUs present on this backend.
-	Gpus          []*BackendGPU `protobuf:"bytes,10,rep,name=gpus,proto3" json:"gpus,omitempty"`
+	Gpus []*BackendGPU `protobuf:"bytes,10,rep,name=gpus,proto3" json:"gpus,omitempty"`
+	// Spare scheduling capacity this backend currently advertises to the
+	// control plane, or null when nothing is advertised (withdrawn or never
+	// published). Lets the control plane direct scheduling at hosts that have
+	// explicitly offered freed headroom. See #680.
+	Headroom      *CapacityHeadroom `protobuf:"bytes,11,opt,name=headroom,proto3" json:"headroom,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2998,6 +3003,207 @@ func (x *BackendInfo) GetGpus() []*BackendGPU {
 	return nil
 }
 
+func (x *BackendInfo) GetHeadroom() *CapacityHeadroom {
+	if x != nil {
+		return x.Headroom
+	}
+	return nil
+}
+
+// CapacityHeadroom is a backend's explicit, policy-bounded offer of spare
+// scheduling capacity to the control plane. Today a backend's capacity is
+// implicit (derived from system info); a box that would otherwise scale down
+// can instead publish its freed headroom here so the control plane can direct
+// work at it. Surfaced through BackendInfo (ListBackends). See #680.
+type CapacityHeadroom struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Whether an advertisement is currently active. False means the backend has
+	// withdrawn (or never published) — the rest of the fields are then a stale
+	// snapshot the control plane must ignore.
+	Advertised bool `protobuf:"varint,1,opt,name=advertised,proto3" json:"advertised,omitempty"`
+	// Spare CPU cores the backend offers for control-plane-directed scheduling.
+	SpareCpus int32 `protobuf:"varint,2,opt,name=spare_cpus,json=spareCpus,proto3" json:"spare_cpus,omitempty"`
+	// Spare memory in bytes (derived from SystemInfo.available_memory_bytes,
+	// bounded by policy headroom reservation).
+	SpareMemoryBytes int64 `protobuf:"varint,3,opt,name=spare_memory_bytes,json=spareMemoryBytes,proto3" json:"spare_memory_bytes,omitempty"`
+	// Spare disk in bytes (derived from SystemInfo.available_disk_bytes,
+	// bounded by policy headroom reservation).
+	SpareDiskBytes int64 `protobuf:"varint,4,opt,name=spare_disk_bytes,json=spareDiskBytes,proto3" json:"spare_disk_bytes,omitempty"`
+	// Host-level idle fraction in [0,1]: the share of running user containers
+	// currently idle (a host aggregate over the per-container idle signal). A
+	// high value indicates a box that would scale down and can instead offer
+	// its headroom. 0 when no signal is available.
+	IdleFraction float64 `protobuf:"fixed64,5,opt,name=idle_fraction,json=idleFraction,proto3" json:"idle_fraction,omitempty"`
+	// RFC3339 timestamp the advertisement was last (re)published.
+	AdvertisedAt string `protobuf:"bytes,6,opt,name=advertised_at,json=advertisedAt,proto3" json:"advertised_at,omitempty"`
+	// The local policy that bounds this advertisement.
+	Policy        *CapacityPolicy `protobuf:"bytes,7,opt,name=policy,proto3" json:"policy,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CapacityHeadroom) Reset() {
+	*x = CapacityHeadroom{}
+	mi := &file_containarium_v1_config_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CapacityHeadroom) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CapacityHeadroom) ProtoMessage() {}
+
+func (x *CapacityHeadroom) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CapacityHeadroom.ProtoReflect.Descriptor instead.
+func (*CapacityHeadroom) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *CapacityHeadroom) GetAdvertised() bool {
+	if x != nil {
+		return x.Advertised
+	}
+	return false
+}
+
+func (x *CapacityHeadroom) GetSpareCpus() int32 {
+	if x != nil {
+		return x.SpareCpus
+	}
+	return 0
+}
+
+func (x *CapacityHeadroom) GetSpareMemoryBytes() int64 {
+	if x != nil {
+		return x.SpareMemoryBytes
+	}
+	return 0
+}
+
+func (x *CapacityHeadroom) GetSpareDiskBytes() int64 {
+	if x != nil {
+		return x.SpareDiskBytes
+	}
+	return 0
+}
+
+func (x *CapacityHeadroom) GetIdleFraction() float64 {
+	if x != nil {
+		return x.IdleFraction
+	}
+	return 0
+}
+
+func (x *CapacityHeadroom) GetAdvertisedAt() string {
+	if x != nil {
+		return x.AdvertisedAt
+	}
+	return ""
+}
+
+func (x *CapacityHeadroom) GetPolicy() *CapacityPolicy {
+	if x != nil {
+		return x.Policy
+	}
+	return nil
+}
+
+// CapacityPolicy bounds what a backend is willing to advertise. The
+// advertisement only computes spare capacity when the current time falls
+// inside the allowed window and respects the excluded workload classes.
+// Operator-set per backend. See #680.
+type CapacityPolicy struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Local-clock hour the advertisement window opens (0-23). When
+	// window_start_hour == window_end_hour the window is always open.
+	WindowStartHour int32 `protobuf:"varint,1,opt,name=window_start_hour,json=windowStartHour,proto3" json:"window_start_hour,omitempty"`
+	// Local-clock hour the advertisement window closes (0-23, exclusive). May be
+	// less than window_start_hour to express an overnight window (e.g. 22..6).
+	WindowEndHour int32 `protobuf:"varint,2,opt,name=window_end_hour,json=windowEndHour,proto3" json:"window_end_hour,omitempty"`
+	// Workload classes that must NOT be displaced or co-scheduled — running
+	// containers carrying any of these classes are excluded from the idle/spare
+	// computation, so a host running protected work never advertises it as free.
+	// Matched against the container's "user.containarium.workload_class" label.
+	ExcludedWorkloadClasses []string `protobuf:"bytes,3,rep,name=excluded_workload_classes,json=excludedWorkloadClasses,proto3" json:"excluded_workload_classes,omitempty"`
+	// Fraction of host resources to hold back as a safety reservation, in
+	// [0,1). Spare = available * (1 - reserve_fraction). 0 means offer all
+	// available headroom.
+	ReserveFraction float64 `protobuf:"fixed64,4,opt,name=reserve_fraction,json=reserveFraction,proto3" json:"reserve_fraction,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *CapacityPolicy) Reset() {
+	*x = CapacityPolicy{}
+	mi := &file_containarium_v1_config_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CapacityPolicy) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CapacityPolicy) ProtoMessage() {}
+
+func (x *CapacityPolicy) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CapacityPolicy.ProtoReflect.Descriptor instead.
+func (*CapacityPolicy) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *CapacityPolicy) GetWindowStartHour() int32 {
+	if x != nil {
+		return x.WindowStartHour
+	}
+	return 0
+}
+
+func (x *CapacityPolicy) GetWindowEndHour() int32 {
+	if x != nil {
+		return x.WindowEndHour
+	}
+	return 0
+}
+
+func (x *CapacityPolicy) GetExcludedWorkloadClasses() []string {
+	if x != nil {
+		return x.ExcludedWorkloadClasses
+	}
+	return nil
+}
+
+func (x *CapacityPolicy) GetReserveFraction() float64 {
+	if x != nil {
+		return x.ReserveFraction
+	}
+	return 0
+}
+
 // BackendGPU describes one GPU on a backend.
 type BackendGPU struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -3013,7 +3219,7 @@ type BackendGPU struct {
 
 func (x *BackendGPU) Reset() {
 	*x = BackendGPU{}
-	mi := &file_containarium_v1_config_proto_msgTypes[40]
+	mi := &file_containarium_v1_config_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3025,7 +3231,7 @@ func (x *BackendGPU) String() string {
 func (*BackendGPU) ProtoMessage() {}
 
 func (x *BackendGPU) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[40]
+	mi := &file_containarium_v1_config_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3038,7 +3244,7 @@ func (x *BackendGPU) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackendGPU.ProtoReflect.Descriptor instead.
 func (*BackendGPU) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{40}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *BackendGPU) GetVendor() string {
@@ -3071,7 +3277,7 @@ type ListBackendsRequest struct {
 
 func (x *ListBackendsRequest) Reset() {
 	*x = ListBackendsRequest{}
-	mi := &file_containarium_v1_config_proto_msgTypes[41]
+	mi := &file_containarium_v1_config_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3083,7 +3289,7 @@ func (x *ListBackendsRequest) String() string {
 func (*ListBackendsRequest) ProtoMessage() {}
 
 func (x *ListBackendsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[41]
+	mi := &file_containarium_v1_config_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3096,7 +3302,7 @@ func (x *ListBackendsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendsRequest.ProtoReflect.Descriptor instead.
 func (*ListBackendsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{41}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{43}
 }
 
 // ListBackendsResponse is the response from listing backends
@@ -3110,7 +3316,7 @@ type ListBackendsResponse struct {
 
 func (x *ListBackendsResponse) Reset() {
 	*x = ListBackendsResponse{}
-	mi := &file_containarium_v1_config_proto_msgTypes[42]
+	mi := &file_containarium_v1_config_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3122,7 +3328,7 @@ func (x *ListBackendsResponse) String() string {
 func (*ListBackendsResponse) ProtoMessage() {}
 
 func (x *ListBackendsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_config_proto_msgTypes[42]
+	mi := &file_containarium_v1_config_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3135,12 +3341,276 @@ func (x *ListBackendsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListBackendsResponse.ProtoReflect.Descriptor instead.
 func (*ListBackendsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_config_proto_rawDescGZIP(), []int{42}
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ListBackendsResponse) GetBackends() []*BackendInfo {
 	if x != nil {
 		return x.Backends
+	}
+	return nil
+}
+
+// AdvertiseCapacityRequest publishes (or republishes) this backend's spare
+// scheduling headroom to the control plane, bounded by the supplied policy.
+// See #680.
+type AdvertiseCapacityRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The local policy that bounds the advertisement. When omitted the backend
+	// applies its current/default policy (always-open window, no exclusions, no
+	// reservation).
+	Policy        *CapacityPolicy `protobuf:"bytes,1,opt,name=policy,proto3" json:"policy,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AdvertiseCapacityRequest) Reset() {
+	*x = AdvertiseCapacityRequest{}
+	mi := &file_containarium_v1_config_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdvertiseCapacityRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdvertiseCapacityRequest) ProtoMessage() {}
+
+func (x *AdvertiseCapacityRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdvertiseCapacityRequest.ProtoReflect.Descriptor instead.
+func (*AdvertiseCapacityRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *AdvertiseCapacityRequest) GetPolicy() *CapacityPolicy {
+	if x != nil {
+		return x.Policy
+	}
+	return nil
+}
+
+// AdvertiseCapacityResponse returns the headroom the backend computed and is
+// now advertising. When the policy window is closed, advertised is true but
+// the spare figures are zero.
+type AdvertiseCapacityResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Headroom      *CapacityHeadroom      `protobuf:"bytes,1,opt,name=headroom,proto3" json:"headroom,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AdvertiseCapacityResponse) Reset() {
+	*x = AdvertiseCapacityResponse{}
+	mi := &file_containarium_v1_config_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdvertiseCapacityResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdvertiseCapacityResponse) ProtoMessage() {}
+
+func (x *AdvertiseCapacityResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdvertiseCapacityResponse.ProtoReflect.Descriptor instead.
+func (*AdvertiseCapacityResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *AdvertiseCapacityResponse) GetHeadroom() *CapacityHeadroom {
+	if x != nil {
+		return x.Headroom
+	}
+	return nil
+}
+
+// WithdrawCapacityRequest withdraws any active advertisement. Idempotent —
+// withdrawing when nothing is advertised succeeds and is a no-op.
+type WithdrawCapacityRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WithdrawCapacityRequest) Reset() {
+	*x = WithdrawCapacityRequest{}
+	mi := &file_containarium_v1_config_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WithdrawCapacityRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WithdrawCapacityRequest) ProtoMessage() {}
+
+func (x *WithdrawCapacityRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WithdrawCapacityRequest.ProtoReflect.Descriptor instead.
+func (*WithdrawCapacityRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{47}
+}
+
+// WithdrawCapacityResponse confirms the backend is no longer advertising.
+type WithdrawCapacityResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The post-withdraw headroom (advertised=false).
+	Headroom      *CapacityHeadroom `protobuf:"bytes,1,opt,name=headroom,proto3" json:"headroom,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WithdrawCapacityResponse) Reset() {
+	*x = WithdrawCapacityResponse{}
+	mi := &file_containarium_v1_config_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WithdrawCapacityResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WithdrawCapacityResponse) ProtoMessage() {}
+
+func (x *WithdrawCapacityResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WithdrawCapacityResponse.ProtoReflect.Descriptor instead.
+func (*WithdrawCapacityResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{48}
+}
+
+func (x *WithdrawCapacityResponse) GetHeadroom() *CapacityHeadroom {
+	if x != nil {
+		return x.Headroom
+	}
+	return nil
+}
+
+// GetCapacityHeadroomRequest reads the backend's current advertisement and the
+// freshly recomputed spare figures, without changing advertise/withdraw state.
+type GetCapacityHeadroomRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetCapacityHeadroomRequest) Reset() {
+	*x = GetCapacityHeadroomRequest{}
+	mi := &file_containarium_v1_config_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetCapacityHeadroomRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetCapacityHeadroomRequest) ProtoMessage() {}
+
+func (x *GetCapacityHeadroomRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetCapacityHeadroomRequest.ProtoReflect.Descriptor instead.
+func (*GetCapacityHeadroomRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{49}
+}
+
+// GetCapacityHeadroomResponse returns the current headroom snapshot.
+type GetCapacityHeadroomResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Headroom      *CapacityHeadroom      `protobuf:"bytes,1,opt,name=headroom,proto3" json:"headroom,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetCapacityHeadroomResponse) Reset() {
+	*x = GetCapacityHeadroomResponse{}
+	mi := &file_containarium_v1_config_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetCapacityHeadroomResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetCapacityHeadroomResponse) ProtoMessage() {}
+
+func (x *GetCapacityHeadroomResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_config_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetCapacityHeadroomResponse.ProtoReflect.Descriptor instead.
+func (*GetCapacityHeadroomResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_config_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *GetCapacityHeadroomResponse) GetHeadroom() *CapacityHeadroom {
+	if x != nil {
+		return x.Headroom
 	}
 	return nil
 }
@@ -3331,7 +3801,7 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"signatures\"9\n" +
 	"#DeleteNetworkPolicySignatureRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"&\n" +
-	"$DeleteNetworkPolicySignatureResponse\"\xb4\x02\n" +
+	"$DeleteNetworkPolicySignatureResponse\"\xf3\x02\n" +
 	"\vBackendInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12\x18\n" +
@@ -3344,7 +3814,24 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\x02os\x18\b \x01(\tR\x02os\x12'\n" +
 	"\x0fcontainer_count\x18\t \x01(\x05R\x0econtainerCount\x12/\n" +
 	"\x04gpus\x18\n" +
-	" \x03(\v2\x1b.containarium.v1.BackendGPUR\x04gpus\"b\n" +
+	" \x03(\v2\x1b.containarium.v1.BackendGPUR\x04gpus\x12=\n" +
+	"\bheadroom\x18\v \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\"\xac\x02\n" +
+	"\x10CapacityHeadroom\x12\x1e\n" +
+	"\n" +
+	"advertised\x18\x01 \x01(\bR\n" +
+	"advertised\x12\x1d\n" +
+	"\n" +
+	"spare_cpus\x18\x02 \x01(\x05R\tspareCpus\x12,\n" +
+	"\x12spare_memory_bytes\x18\x03 \x01(\x03R\x10spareMemoryBytes\x12(\n" +
+	"\x10spare_disk_bytes\x18\x04 \x01(\x03R\x0espareDiskBytes\x12#\n" +
+	"\ridle_fraction\x18\x05 \x01(\x01R\fidleFraction\x12#\n" +
+	"\radvertised_at\x18\x06 \x01(\tR\fadvertisedAt\x127\n" +
+	"\x06policy\x18\a \x01(\v2\x1f.containarium.v1.CapacityPolicyR\x06policy\"\xcb\x01\n" +
+	"\x0eCapacityPolicy\x12*\n" +
+	"\x11window_start_hour\x18\x01 \x01(\x05R\x0fwindowStartHour\x12&\n" +
+	"\x0fwindow_end_hour\x18\x02 \x01(\x05R\rwindowEndHour\x12:\n" +
+	"\x19excluded_workload_classes\x18\x03 \x03(\tR\x17excludedWorkloadClasses\x12)\n" +
+	"\x10reserve_fraction\x18\x04 \x01(\x01R\x0freserveFraction\"b\n" +
 	"\n" +
 	"BackendGPU\x12\x16\n" +
 	"\x06vendor\x18\x01 \x01(\tR\x06vendor\x12\x1d\n" +
@@ -3354,7 +3841,17 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"vram_bytes\x18\x03 \x01(\x03R\tvramBytes\"\x15\n" +
 	"\x13ListBackendsRequest\"P\n" +
 	"\x14ListBackendsResponse\x128\n" +
-	"\bbackends\x18\x01 \x03(\v2\x1c.containarium.v1.BackendInfoR\bbackends*h\n" +
+	"\bbackends\x18\x01 \x03(\v2\x1c.containarium.v1.BackendInfoR\bbackends\"S\n" +
+	"\x18AdvertiseCapacityRequest\x127\n" +
+	"\x06policy\x18\x01 \x01(\v2\x1f.containarium.v1.CapacityPolicyR\x06policy\"Z\n" +
+	"\x19AdvertiseCapacityResponse\x12=\n" +
+	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\"\x19\n" +
+	"\x17WithdrawCapacityRequest\"Y\n" +
+	"\x18WithdrawCapacityResponse\x12=\n" +
+	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom\"\x1c\n" +
+	"\x1aGetCapacityHeadroomRequest\"\\\n" +
+	"\x1bGetCapacityHeadroomResponse\x12=\n" +
+	"\bheadroom\x18\x01 \x01(\v2!.containarium.v1.CapacityHeadroomR\bheadroom*h\n" +
 	"\tGPUVendor\x12\x1a\n" +
 	"\x16GPU_VENDOR_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11GPU_VENDOR_NVIDIA\x10\x01\x12\x12\n" +
@@ -3408,7 +3905,7 @@ func file_containarium_v1_config_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_config_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
+var file_containarium_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
 var file_containarium_v1_config_proto_goTypes = []any{
 	(GPUVendor)(0),                               // 0: containarium.v1.GPUVendor
 	(GPUModel)(0),                                // 1: containarium.v1.GPUModel
@@ -3455,19 +3952,27 @@ var file_containarium_v1_config_proto_goTypes = []any{
 	(*DeleteNetworkPolicySignatureRequest)(nil),  // 42: containarium.v1.DeleteNetworkPolicySignatureRequest
 	(*DeleteNetworkPolicySignatureResponse)(nil), // 43: containarium.v1.DeleteNetworkPolicySignatureResponse
 	(*BackendInfo)(nil),                          // 44: containarium.v1.BackendInfo
-	(*BackendGPU)(nil),                           // 45: containarium.v1.BackendGPU
-	(*ListBackendsRequest)(nil),                  // 46: containarium.v1.ListBackendsRequest
-	(*ListBackendsResponse)(nil),                 // 47: containarium.v1.ListBackendsResponse
-	(*ResourceLimits)(nil),                       // 48: containarium.v1.ResourceLimits
-	(OSType)(0),                                  // 49: containarium.v1.OSType
+	(*CapacityHeadroom)(nil),                     // 45: containarium.v1.CapacityHeadroom
+	(*CapacityPolicy)(nil),                       // 46: containarium.v1.CapacityPolicy
+	(*BackendGPU)(nil),                           // 47: containarium.v1.BackendGPU
+	(*ListBackendsRequest)(nil),                  // 48: containarium.v1.ListBackendsRequest
+	(*ListBackendsResponse)(nil),                 // 49: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityRequest)(nil),             // 50: containarium.v1.AdvertiseCapacityRequest
+	(*AdvertiseCapacityResponse)(nil),            // 51: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityRequest)(nil),              // 52: containarium.v1.WithdrawCapacityRequest
+	(*WithdrawCapacityResponse)(nil),             // 53: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomRequest)(nil),           // 54: containarium.v1.GetCapacityHeadroomRequest
+	(*GetCapacityHeadroomResponse)(nil),          // 55: containarium.v1.GetCapacityHeadroomResponse
+	(*ResourceLimits)(nil),                       // 56: containarium.v1.ResourceLimits
+	(OSType)(0),                                  // 57: containarium.v1.OSType
 }
 var file_containarium_v1_config_proto_depIdxs = []int32{
 	6,  // 0: containarium.v1.Config.incus:type_name -> containarium.v1.IncusConfig
-	48, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
+	56, // 1: containarium.v1.Config.default_resources:type_name -> containarium.v1.ResourceLimits
 	7,  // 2: containarium.v1.Config.network:type_name -> containarium.v1.NetworkConfig
 	8,  // 3: containarium.v1.Config.storage:type_name -> containarium.v1.StorageConfig
 	9,  // 4: containarium.v1.Config.security:type_name -> containarium.v1.SecurityConfig
-	49, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
+	57, // 5: containarium.v1.Config.default_os_type:type_name -> containarium.v1.OSType
 	5,  // 6: containarium.v1.GetConfigResponse.config:type_name -> containarium.v1.Config
 	5,  // 7: containarium.v1.UpdateConfigRequest.config:type_name -> containarium.v1.Config
 	5,  // 8: containarium.v1.UpdateConfigResponse.config:type_name -> containarium.v1.Config
@@ -3487,13 +3992,19 @@ var file_containarium_v1_config_proto_depIdxs = []int32{
 	37, // 22: containarium.v1.SetNetworkPolicySignatureRequest.signature:type_name -> containarium.v1.NetworkPolicySignature
 	37, // 23: containarium.v1.SetNetworkPolicySignatureResponse.signature:type_name -> containarium.v1.NetworkPolicySignature
 	37, // 24: containarium.v1.ListNetworkPolicySignaturesResponse.signatures:type_name -> containarium.v1.NetworkPolicySignature
-	45, // 25: containarium.v1.BackendInfo.gpus:type_name -> containarium.v1.BackendGPU
-	44, // 26: containarium.v1.ListBackendsResponse.backends:type_name -> containarium.v1.BackendInfo
-	27, // [27:27] is the sub-list for method output_type
-	27, // [27:27] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	47, // 25: containarium.v1.BackendInfo.gpus:type_name -> containarium.v1.BackendGPU
+	45, // 26: containarium.v1.BackendInfo.headroom:type_name -> containarium.v1.CapacityHeadroom
+	46, // 27: containarium.v1.CapacityHeadroom.policy:type_name -> containarium.v1.CapacityPolicy
+	44, // 28: containarium.v1.ListBackendsResponse.backends:type_name -> containarium.v1.BackendInfo
+	46, // 29: containarium.v1.AdvertiseCapacityRequest.policy:type_name -> containarium.v1.CapacityPolicy
+	45, // 30: containarium.v1.AdvertiseCapacityResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
+	45, // 31: containarium.v1.WithdrawCapacityResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
+	45, // 32: containarium.v1.GetCapacityHeadroomResponse.headroom:type_name -> containarium.v1.CapacityHeadroom
+	33, // [33:33] is the sub-list for method output_type
+	33, // [33:33] is the sub-list for method input_type
+	33, // [33:33] is the sub-list for extension type_name
+	33, // [33:33] is the sub-list for extension extendee
+	0,  // [0:33] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_config_proto_init() }
@@ -3508,7 +4019,7 @@ func file_containarium_v1_config_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_config_proto_rawDesc), len(file_containarium_v1_config_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   43,
+			NumMessages:   51,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\x8cu\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xe5|\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -86,7 +86,13 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\rGetSystemInfo\x12%.containarium.v1.GetSystemInfoRequest\x1a&.containarium.v1.GetSystemInfoResponse\"\xaa\x01\x92A\x8f\x01\n" +
 	"\x06System\x12\x16Get system information\x1amReturns information about the host system including Incus version, available resources, and container counts.\x82\xd3\xe4\x93\x02\x11\x12\x0f/v1/system/info\x12\xbd\x02\n" +
 	"\fListBackends\x12$.containarium.v1.ListBackendsRequest\x1a%.containarium.v1.ListBackendsResponse\"\xdf\x01\x92A\xc7\x01\n" +
-	"\x06System\x12\rList backends\x1a\xad\x01Lists every backend in the fleet (local daemon + tunnel peers) with health, version, OS, running container count, and GPU inventory. Admin-only — discloses fleet topology.\x82\xd3\xe4\x93\x02\x0e\x12\f/v1/backends\x12\xb4\x02\n" +
+	"\x06System\x12\rList backends\x1a\xad\x01Lists every backend in the fleet (local daemon + tunnel peers) with health, version, OS, running container count, and GPU inventory. Admin-only — discloses fleet topology.\x82\xd3\xe4\x93\x02\x0e\x12\f/v1/backends\x12\xfc\x02\n" +
+	"\x11AdvertiseCapacity\x12).containarium.v1.AdvertiseCapacityRequest\x1a*.containarium.v1.AdvertiseCapacityResponse\"\x8f\x02\x92A\xeb\x01\n" +
+	"\x06System\x12#Advertise spare scheduling capacity\x1a\xbb\x01Publishes this backend's spare scheduling headroom (spare CPU/memory/disk + host idle fraction) to the control plane, bounded by a local policy. Surfaced through ListBackends. Admin-only.\x82\xd3\xe4\x93\x02\x1a:\x01*\"\x15/v1/capacity/headroom\x12\xb8\x02\n" +
+	"\x10WithdrawCapacity\x12(.containarium.v1.WithdrawCapacityRequest\x1a).containarium.v1.WithdrawCapacityResponse\"\xce\x01\x92A\xad\x01\n" +
+	"\x06System\x12\"Withdraw spare scheduling capacity\x1a\x7fWithdraws this backend's headroom advertisement. Idempotent — succeeds even when nothing is currently advertised. Admin-only.\x82\xd3\xe4\x93\x02\x17*\x15/v1/capacity/headroom\x12\x9c\x02\n" +
+	"\x13GetCapacityHeadroom\x12+.containarium.v1.GetCapacityHeadroomRequest\x1a,.containarium.v1.GetCapacityHeadroomResponse\"\xa9\x01\x92A\x88\x01\n" +
+	"\x06System\x12\x1dGet spare scheduling capacity\x1a_Returns this backend's current headroom advertisement and recomputed spare figures. Admin-only.\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/capacity/headroom\x12\xb4\x02\n" +
 	"\x10GetLatestRelease\x12(.containarium.v1.GetLatestReleaseRequest\x1a).containarium.v1.GetLatestReleaseResponse\"\xca\x01\x92A\xab\x01\n" +
 	"\x06System\x12\x12Get latest release\x1a\x8c\x01Returns the latest Containarium release tag from GitHub (cached) alongside this daemon's running version and whether an update is available.\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/releases/latest\x12\xb9\x02\n" +
 	"\vValidateGPU\x12#.containarium.v1.ValidateGPURequest\x1a$.containarium.v1.ValidateGPUResponse\"\xde\x01\x92A\xbf\x01\n" +
@@ -166,71 +172,77 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*ListStacksRequest)(nil),                // 22: containarium.v1.ListStacksRequest
 	(*GetSystemInfoRequest)(nil),             // 23: containarium.v1.GetSystemInfoRequest
 	(*ListBackendsRequest)(nil),              // 24: containarium.v1.ListBackendsRequest
-	(*GetLatestReleaseRequest)(nil),          // 25: containarium.v1.GetLatestReleaseRequest
-	(*ValidateGPURequest)(nil),               // 26: containarium.v1.ValidateGPURequest
-	(*TriggerUpgradeRequest)(nil),            // 27: containarium.v1.TriggerUpgradeRequest
-	(*GetUpgradeStatusRequest)(nil),          // 28: containarium.v1.GetUpgradeStatusRequest
-	(*GetMonitoringInfoRequest)(nil),         // 29: containarium.v1.GetMonitoringInfoRequest
-	(*CreateAlertRuleRequest)(nil),           // 30: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),            // 31: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),              // 32: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),           // 33: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),           // 34: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),           // 35: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),     // 36: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),      // 37: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),               // 38: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),     // 39: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),                 // 40: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),                 // 41: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),               // 42: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),              // 43: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),            // 44: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),          // 45: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),           // 46: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),             // 47: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),           // 48: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),          // 49: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),           // 50: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),            // 51: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),          // 52: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),            // 53: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerResponse)(nil),   // 54: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),         // 55: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),          // 56: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),          // 57: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyResponse)(nil), // 58: containarium.v1.SetContainerDeletePolicyResponse
-	(*AddSSHKeyResponse)(nil),                // 59: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),             // 60: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),          // 61: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),       // 62: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),        // 63: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),               // 64: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),              // 65: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),             // 66: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),               // 67: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),            // 68: containarium.v1.GetSystemInfoResponse
-	(*ListBackendsResponse)(nil),             // 69: containarium.v1.ListBackendsResponse
-	(*GetLatestReleaseResponse)(nil),         // 70: containarium.v1.GetLatestReleaseResponse
-	(*ValidateGPUResponse)(nil),              // 71: containarium.v1.ValidateGPUResponse
-	(*TriggerUpgradeResponse)(nil),           // 72: containarium.v1.TriggerUpgradeResponse
-	(*GetUpgradeStatusResponse)(nil),         // 73: containarium.v1.GetUpgradeStatusResponse
-	(*GetMonitoringInfoResponse)(nil),        // 74: containarium.v1.GetMonitoringInfoResponse
-	(*CreateAlertRuleResponse)(nil),          // 75: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),           // 76: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),             // 77: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),          // 78: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),          // 79: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),          // 80: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),    // 81: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),     // 82: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),              // 83: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),    // 84: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),                // 85: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),                // 86: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),              // 87: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),             // 88: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),           // 89: containarium.v1.RefreshSecretsResponse
+	(*AdvertiseCapacityRequest)(nil),         // 25: containarium.v1.AdvertiseCapacityRequest
+	(*WithdrawCapacityRequest)(nil),          // 26: containarium.v1.WithdrawCapacityRequest
+	(*GetCapacityHeadroomRequest)(nil),       // 27: containarium.v1.GetCapacityHeadroomRequest
+	(*GetLatestReleaseRequest)(nil),          // 28: containarium.v1.GetLatestReleaseRequest
+	(*ValidateGPURequest)(nil),               // 29: containarium.v1.ValidateGPURequest
+	(*TriggerUpgradeRequest)(nil),            // 30: containarium.v1.TriggerUpgradeRequest
+	(*GetUpgradeStatusRequest)(nil),          // 31: containarium.v1.GetUpgradeStatusRequest
+	(*GetMonitoringInfoRequest)(nil),         // 32: containarium.v1.GetMonitoringInfoRequest
+	(*CreateAlertRuleRequest)(nil),           // 33: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),            // 34: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),              // 35: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),           // 36: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),           // 37: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),           // 38: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),     // 39: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),      // 40: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),               // 41: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),     // 42: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),                 // 43: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),                 // 44: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),               // 45: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),              // 46: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),            // 47: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),          // 48: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),           // 49: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),             // 50: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),           // 51: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),          // 52: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),           // 53: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),            // 54: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),          // 55: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),            // 56: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerResponse)(nil),   // 57: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),         // 58: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),          // 59: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),          // 60: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyResponse)(nil), // 61: containarium.v1.SetContainerDeletePolicyResponse
+	(*AddSSHKeyResponse)(nil),                // 62: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),             // 63: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),          // 64: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),       // 65: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),        // 66: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),               // 67: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),              // 68: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),             // 69: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),               // 70: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),            // 71: containarium.v1.GetSystemInfoResponse
+	(*ListBackendsResponse)(nil),             // 72: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityResponse)(nil),        // 73: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityResponse)(nil),         // 74: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomResponse)(nil),      // 75: containarium.v1.GetCapacityHeadroomResponse
+	(*GetLatestReleaseResponse)(nil),         // 76: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),              // 77: containarium.v1.ValidateGPUResponse
+	(*TriggerUpgradeResponse)(nil),           // 78: containarium.v1.TriggerUpgradeResponse
+	(*GetUpgradeStatusResponse)(nil),         // 79: containarium.v1.GetUpgradeStatusResponse
+	(*GetMonitoringInfoResponse)(nil),        // 80: containarium.v1.GetMonitoringInfoResponse
+	(*CreateAlertRuleResponse)(nil),          // 81: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),           // 82: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),             // 83: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),          // 84: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),          // 85: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),          // 86: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),    // 87: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),     // 88: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),              // 89: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),    // 90: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),                // 91: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),                // 92: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),              // 93: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),             // 94: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),           // 95: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -258,73 +270,79 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	22, // 22: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
 	23, // 23: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
 	24, // 24: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
-	25, // 25: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
-	26, // 26: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
-	27, // 27: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
-	28, // 28: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
-	29, // 29: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	30, // 30: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	31, // 31: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	32, // 32: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	33, // 33: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	34, // 34: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	35, // 35: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	36, // 36: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	37, // 37: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	38, // 38: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	39, // 39: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	40, // 40: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	41, // 41: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	42, // 42: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	43, // 43: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	44, // 44: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	45, // 45: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	46, // 46: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	47, // 47: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	48, // 48: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	49, // 49: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	50, // 50: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	51, // 51: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	52, // 52: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	53, // 53: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	54, // 54: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	55, // 55: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	56, // 56: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	57, // 57: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	58, // 58: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
-	59, // 59: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	60, // 60: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	61, // 61: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	62, // 62: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	63, // 63: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	64, // 64: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	65, // 65: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	66, // 66: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	67, // 67: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	68, // 68: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	69, // 69: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
-	70, // 70: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	71, // 71: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
-	72, // 72: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
-	73, // 73: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
-	74, // 74: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	75, // 75: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	76, // 76: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	77, // 77: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	78, // 78: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	79, // 79: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	80, // 80: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	81, // 81: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	82, // 82: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	83, // 83: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	84, // 84: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	85, // 85: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	86, // 86: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	87, // 87: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	88, // 88: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	89, // 89: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	45, // [45:90] is the sub-list for method output_type
-	0,  // [0:45] is the sub-list for method input_type
+	25, // 25: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
+	26, // 26: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
+	27, // 27: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
+	28, // 28: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
+	29, // 29: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
+	30, // 30: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
+	31, // 31: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
+	32, // 32: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	33, // 33: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	34, // 34: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	35, // 35: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	36, // 36: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	37, // 37: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	38, // 38: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	39, // 39: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	40, // 40: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	41, // 41: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	42, // 42: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	43, // 43: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	44, // 44: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	45, // 45: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	46, // 46: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	47, // 47: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	48, // 48: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	49, // 49: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	50, // 50: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	51, // 51: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	52, // 52: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	53, // 53: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	54, // 54: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	55, // 55: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	56, // 56: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	57, // 57: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	58, // 58: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	59, // 59: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	60, // 60: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	61, // 61: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
+	62, // 62: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	63, // 63: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	64, // 64: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	65, // 65: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	66, // 66: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	67, // 67: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	68, // 68: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	69, // 69: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	70, // 70: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	71, // 71: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	72, // 72: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
+	73, // 73: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
+	74, // 74: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
+	75, // 75: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
+	76, // 76: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	77, // 77: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	78, // 78: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
+	79, // 79: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
+	80, // 80: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	81, // 81: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	82, // 82: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	83, // 83: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	84, // 84: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	85, // 85: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	86, // 86: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	87, // 87: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	88, // 88: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	89, // 89: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	90, // 90: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	91, // 91: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	92, // 92: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	93, // 93: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	94, // 94: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	95, // 95: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	48, // [48:96] is the sub-list for method output_type
+	0,  // [0:48] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2Ȃ\x01\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\x8b\x86\x01\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -96,7 +96,9 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x0eProfileBackend\x12&.containarium.v1.ProfileBackendRequest\x1a'.containarium.v1.ProfileBackendResponse\"\xa4\x02\x92A\xfd\x01\n" +
 	"\x06System\x12'Profile a backend's hardware capability\x1a\xc9\x01Records a backend's capability profile (hardware class, GPU probe, bounded CPU/memory micro-benchmark, region) and reconciles measured vs self-reported class. Surfaced through ListBackends. Admin-only.\x82\xd3\xe4\x93\x02\x1d:\x01*\"\x18/v1/capabilities/profile\x12\xd5\x02\n" +
 	"\x14GetCapabilityProfile\x12,.containarium.v1.GetCapabilityProfileRequest\x1a-.containarium.v1.GetCapabilityProfileResponse\"\xdf\x01\x92A\xbb\x01\n" +
-	"\x06System\x12\"Get a backend's capability profile\x1a\x8c\x01Returns a backend's last-recorded capability profile (hardware class, GPU probe, micro-benchmark, region) without re-running it. Admin-only.\x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/capabilities/profile\x12\xb4\x02\n" +
+	"\x06System\x12\"Get a backend's capability profile\x1a\x8c\x01Returns a backend's last-recorded capability profile (hardware class, GPU probe, micro-benchmark, region) without re-running it. Admin-only.\x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/capabilities/profile\x12\xc0\x03\n" +
+	"\x12GetSelfMeasurement\x12*.containarium.v1.GetSelfMeasurementRequest\x1a+.containarium.v1.GetSelfMeasurementResponse\"\xd0\x02\x92A\xa6\x02\n" +
+	"\x06System\x121Get a backend's signed integrity self-measurement\x1a\xe8\x01Computes and signs a fresh integrity self-measurement (daemon binary digest, loaded in-kernel program object digests, policy/config-state digest) with the node's identity key. The daemon also emits this on its heartbeat. Admin-only.\x82\xd3\xe4\x93\x02 \x12\x1e/v1/integrity/self-measurement\x12\xb4\x02\n" +
 	"\x10GetLatestRelease\x12(.containarium.v1.GetLatestReleaseRequest\x1a).containarium.v1.GetLatestReleaseResponse\"\xca\x01\x92A\xab\x01\n" +
 	"\x06System\x12\x12Get latest release\x1a\x8c\x01Returns the latest Containarium release tag from GitHub (cached) alongside this daemon's running version and whether an update is available.\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/releases/latest\x12\xb9\x02\n" +
 	"\vValidateGPU\x12#.containarium.v1.ValidateGPURequest\x1a$.containarium.v1.ValidateGPUResponse\"\xde\x01\x92A\xbf\x01\n" +
@@ -181,183 +183,187 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*GetCapacityHeadroomRequest)(nil),       // 27: containarium.v1.GetCapacityHeadroomRequest
 	(*ProfileBackendRequest)(nil),            // 28: containarium.v1.ProfileBackendRequest
 	(*GetCapabilityProfileRequest)(nil),      // 29: containarium.v1.GetCapabilityProfileRequest
-	(*GetLatestReleaseRequest)(nil),          // 30: containarium.v1.GetLatestReleaseRequest
-	(*ValidateGPURequest)(nil),               // 31: containarium.v1.ValidateGPURequest
-	(*TriggerUpgradeRequest)(nil),            // 32: containarium.v1.TriggerUpgradeRequest
-	(*GetUpgradeStatusRequest)(nil),          // 33: containarium.v1.GetUpgradeStatusRequest
-	(*GetMonitoringInfoRequest)(nil),         // 34: containarium.v1.GetMonitoringInfoRequest
-	(*CreateAlertRuleRequest)(nil),           // 35: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),            // 36: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),              // 37: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),           // 38: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),           // 39: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),           // 40: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),     // 41: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),      // 42: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),               // 43: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),     // 44: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),                 // 45: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),                 // 46: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),               // 47: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),              // 48: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),            // 49: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),          // 50: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),           // 51: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),             // 52: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),           // 53: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),          // 54: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),           // 55: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),            // 56: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),          // 57: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),            // 58: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerResponse)(nil),   // 59: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),         // 60: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),          // 61: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),          // 62: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyResponse)(nil), // 63: containarium.v1.SetContainerDeletePolicyResponse
-	(*AddSSHKeyResponse)(nil),                // 64: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),             // 65: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),          // 66: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),       // 67: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),        // 68: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),               // 69: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),              // 70: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),             // 71: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),               // 72: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),            // 73: containarium.v1.GetSystemInfoResponse
-	(*ListBackendsResponse)(nil),             // 74: containarium.v1.ListBackendsResponse
-	(*AdvertiseCapacityResponse)(nil),        // 75: containarium.v1.AdvertiseCapacityResponse
-	(*WithdrawCapacityResponse)(nil),         // 76: containarium.v1.WithdrawCapacityResponse
-	(*GetCapacityHeadroomResponse)(nil),      // 77: containarium.v1.GetCapacityHeadroomResponse
-	(*ProfileBackendResponse)(nil),           // 78: containarium.v1.ProfileBackendResponse
-	(*GetCapabilityProfileResponse)(nil),     // 79: containarium.v1.GetCapabilityProfileResponse
-	(*GetLatestReleaseResponse)(nil),         // 80: containarium.v1.GetLatestReleaseResponse
-	(*ValidateGPUResponse)(nil),              // 81: containarium.v1.ValidateGPUResponse
-	(*TriggerUpgradeResponse)(nil),           // 82: containarium.v1.TriggerUpgradeResponse
-	(*GetUpgradeStatusResponse)(nil),         // 83: containarium.v1.GetUpgradeStatusResponse
-	(*GetMonitoringInfoResponse)(nil),        // 84: containarium.v1.GetMonitoringInfoResponse
-	(*CreateAlertRuleResponse)(nil),          // 85: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),           // 86: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),             // 87: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),          // 88: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),          // 89: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),          // 90: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),    // 91: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),     // 92: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),              // 93: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),    // 94: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),                // 95: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),                // 96: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),              // 97: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),             // 98: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),           // 99: containarium.v1.RefreshSecretsResponse
+	(*GetSelfMeasurementRequest)(nil),        // 30: containarium.v1.GetSelfMeasurementRequest
+	(*GetLatestReleaseRequest)(nil),          // 31: containarium.v1.GetLatestReleaseRequest
+	(*ValidateGPURequest)(nil),               // 32: containarium.v1.ValidateGPURequest
+	(*TriggerUpgradeRequest)(nil),            // 33: containarium.v1.TriggerUpgradeRequest
+	(*GetUpgradeStatusRequest)(nil),          // 34: containarium.v1.GetUpgradeStatusRequest
+	(*GetMonitoringInfoRequest)(nil),         // 35: containarium.v1.GetMonitoringInfoRequest
+	(*CreateAlertRuleRequest)(nil),           // 36: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),            // 37: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),              // 38: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),           // 39: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),           // 40: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),           // 41: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),     // 42: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),      // 43: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),               // 44: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),     // 45: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),                 // 46: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),                 // 47: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),               // 48: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),              // 49: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),            // 50: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),          // 51: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),           // 52: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),             // 53: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),           // 54: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),          // 55: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),           // 56: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),            // 57: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),          // 58: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),            // 59: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerResponse)(nil),   // 60: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),         // 61: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),          // 62: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),          // 63: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyResponse)(nil), // 64: containarium.v1.SetContainerDeletePolicyResponse
+	(*AddSSHKeyResponse)(nil),                // 65: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),             // 66: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),          // 67: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),       // 68: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),        // 69: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),               // 70: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),              // 71: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),             // 72: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),               // 73: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),            // 74: containarium.v1.GetSystemInfoResponse
+	(*ListBackendsResponse)(nil),             // 75: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityResponse)(nil),        // 76: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityResponse)(nil),         // 77: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomResponse)(nil),      // 78: containarium.v1.GetCapacityHeadroomResponse
+	(*ProfileBackendResponse)(nil),           // 79: containarium.v1.ProfileBackendResponse
+	(*GetCapabilityProfileResponse)(nil),     // 80: containarium.v1.GetCapabilityProfileResponse
+	(*GetSelfMeasurementResponse)(nil),       // 81: containarium.v1.GetSelfMeasurementResponse
+	(*GetLatestReleaseResponse)(nil),         // 82: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),              // 83: containarium.v1.ValidateGPUResponse
+	(*TriggerUpgradeResponse)(nil),           // 84: containarium.v1.TriggerUpgradeResponse
+	(*GetUpgradeStatusResponse)(nil),         // 85: containarium.v1.GetUpgradeStatusResponse
+	(*GetMonitoringInfoResponse)(nil),        // 86: containarium.v1.GetMonitoringInfoResponse
+	(*CreateAlertRuleResponse)(nil),          // 87: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),           // 88: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),             // 89: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),          // 90: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),          // 91: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),          // 92: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),    // 93: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),     // 94: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),              // 95: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),    // 96: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),                // 97: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),                // 98: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),              // 99: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),             // 100: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),           // 101: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
-	0,  // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
-	1,  // 1: containarium.v1.ContainerService.ListContainers:input_type -> containarium.v1.ListContainersRequest
-	2,  // 2: containarium.v1.ContainerService.GetContainer:input_type -> containarium.v1.GetContainerRequest
-	3,  // 3: containarium.v1.ContainerService.DebugContainer:input_type -> containarium.v1.DebugContainerRequest
-	4,  // 4: containarium.v1.ContainerService.DeleteContainer:input_type -> containarium.v1.DeleteContainerRequest
-	5,  // 5: containarium.v1.ContainerService.StartContainer:input_type -> containarium.v1.StartContainerRequest
-	6,  // 6: containarium.v1.ContainerService.StopContainer:input_type -> containarium.v1.StopContainerRequest
-	7,  // 7: containarium.v1.ContainerService.ResizeContainer:input_type -> containarium.v1.ResizeContainerRequest
-	8,  // 8: containarium.v1.ContainerService.MoveContainer:input_type -> containarium.v1.MoveContainerRequest
-	9,  // 9: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
-	10, // 10: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
-	11, // 11: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
-	12, // 12: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
-	13, // 13: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
-	14, // 14: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
-	15, // 15: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
-	16, // 16: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
-	17, // 17: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
-	18, // 18: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
-	19, // 19: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
-	20, // 20: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
-	21, // 21: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
-	22, // 22: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
-	23, // 23: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
-	24, // 24: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
-	25, // 25: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
-	26, // 26: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
-	27, // 27: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
-	28, // 28: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
-	29, // 29: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
-	30, // 30: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
-	31, // 31: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
-	32, // 32: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
-	33, // 33: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
-	34, // 34: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	35, // 35: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	36, // 36: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	37, // 37: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	38, // 38: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	39, // 39: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	40, // 40: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	41, // 41: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	42, // 42: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	43, // 43: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	44, // 44: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	45, // 45: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	46, // 46: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	47, // 47: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	48, // 48: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	49, // 49: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	50, // 50: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	51, // 51: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	52, // 52: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	53, // 53: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	54, // 54: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	55, // 55: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	56, // 56: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	57, // 57: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	58, // 58: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	59, // 59: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	60, // 60: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	61, // 61: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	62, // 62: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	63, // 63: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
-	64, // 64: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	65, // 65: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	66, // 66: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	67, // 67: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	68, // 68: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	69, // 69: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	70, // 70: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	71, // 71: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	72, // 72: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	73, // 73: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	74, // 74: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
-	75, // 75: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
-	76, // 76: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
-	77, // 77: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
-	78, // 78: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
-	79, // 79: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
-	80, // 80: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	81, // 81: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
-	82, // 82: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
-	83, // 83: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
-	84, // 84: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	85, // 85: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	86, // 86: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	87, // 87: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	88, // 88: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	89, // 89: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	90, // 90: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	91, // 91: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	92, // 92: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	93, // 93: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	94, // 94: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	95, // 95: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	96, // 96: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	97, // 97: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	98, // 98: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	99, // 99: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	50, // [50:100] is the sub-list for method output_type
-	0,  // [0:50] is the sub-list for method input_type
-	0,  // [0:0] is the sub-list for extension type_name
-	0,  // [0:0] is the sub-list for extension extendee
-	0,  // [0:0] is the sub-list for field type_name
+	0,   // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
+	1,   // 1: containarium.v1.ContainerService.ListContainers:input_type -> containarium.v1.ListContainersRequest
+	2,   // 2: containarium.v1.ContainerService.GetContainer:input_type -> containarium.v1.GetContainerRequest
+	3,   // 3: containarium.v1.ContainerService.DebugContainer:input_type -> containarium.v1.DebugContainerRequest
+	4,   // 4: containarium.v1.ContainerService.DeleteContainer:input_type -> containarium.v1.DeleteContainerRequest
+	5,   // 5: containarium.v1.ContainerService.StartContainer:input_type -> containarium.v1.StartContainerRequest
+	6,   // 6: containarium.v1.ContainerService.StopContainer:input_type -> containarium.v1.StopContainerRequest
+	7,   // 7: containarium.v1.ContainerService.ResizeContainer:input_type -> containarium.v1.ResizeContainerRequest
+	8,   // 8: containarium.v1.ContainerService.MoveContainer:input_type -> containarium.v1.MoveContainerRequest
+	9,   // 9: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
+	10,  // 10: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
+	11,  // 11: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
+	12,  // 12: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
+	13,  // 13: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
+	14,  // 14: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
+	15,  // 15: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
+	16,  // 16: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
+	17,  // 17: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
+	18,  // 18: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
+	19,  // 19: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
+	20,  // 20: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
+	21,  // 21: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
+	22,  // 22: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
+	23,  // 23: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
+	24,  // 24: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
+	25,  // 25: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
+	26,  // 26: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
+	27,  // 27: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
+	28,  // 28: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
+	29,  // 29: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
+	30,  // 30: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
+	31,  // 31: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
+	32,  // 32: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
+	33,  // 33: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
+	34,  // 34: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
+	35,  // 35: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	36,  // 36: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	37,  // 37: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	38,  // 38: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	39,  // 39: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	40,  // 40: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	41,  // 41: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	42,  // 42: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	43,  // 43: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	44,  // 44: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	45,  // 45: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	46,  // 46: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	47,  // 47: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	48,  // 48: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	49,  // 49: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	50,  // 50: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	51,  // 51: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	52,  // 52: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	53,  // 53: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	54,  // 54: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	55,  // 55: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	56,  // 56: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	57,  // 57: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	58,  // 58: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	59,  // 59: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	60,  // 60: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	61,  // 61: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	62,  // 62: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	63,  // 63: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	64,  // 64: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
+	65,  // 65: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	66,  // 66: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	67,  // 67: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	68,  // 68: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	69,  // 69: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	70,  // 70: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	71,  // 71: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	72,  // 72: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	73,  // 73: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	74,  // 74: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	75,  // 75: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
+	76,  // 76: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
+	77,  // 77: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
+	78,  // 78: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
+	79,  // 79: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
+	80,  // 80: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
+	81,  // 81: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
+	82,  // 82: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	83,  // 83: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	84,  // 84: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
+	85,  // 85: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
+	86,  // 86: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	87,  // 87: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	88,  // 88: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	89,  // 89: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	90,  // 90: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	91,  // 91: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	92,  // 92: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	93,  // 93: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	94,  // 94: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	95,  // 95: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	96,  // 96: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	97,  // 97: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	98,  // 98: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	99,  // 99: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	100, // 100: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	101, // 101: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	51,  // [51:102] is the sub-list for method output_type
+	0,   // [0:51] is the sub-list for method input_type
+	0,   // [0:0] is the sub-list for extension type_name
+	0,   // [0:0] is the sub-list for extension extendee
+	0,   // [0:0] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_service_proto_init() }

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xe5|\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2Ȃ\x01\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -92,7 +92,11 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x10WithdrawCapacity\x12(.containarium.v1.WithdrawCapacityRequest\x1a).containarium.v1.WithdrawCapacityResponse\"\xce\x01\x92A\xad\x01\n" +
 	"\x06System\x12\"Withdraw spare scheduling capacity\x1a\x7fWithdraws this backend's headroom advertisement. Idempotent — succeeds even when nothing is currently advertised. Admin-only.\x82\xd3\xe4\x93\x02\x17*\x15/v1/capacity/headroom\x12\x9c\x02\n" +
 	"\x13GetCapacityHeadroom\x12+.containarium.v1.GetCapacityHeadroomRequest\x1a,.containarium.v1.GetCapacityHeadroomResponse\"\xa9\x01\x92A\x88\x01\n" +
-	"\x06System\x12\x1dGet spare scheduling capacity\x1a_Returns this backend's current headroom advertisement and recomputed spare figures. Admin-only.\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/capacity/headroom\x12\xb4\x02\n" +
+	"\x06System\x12\x1dGet spare scheduling capacity\x1a_Returns this backend's current headroom advertisement and recomputed spare figures. Admin-only.\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/capacity/headroom\x12\x88\x03\n" +
+	"\x0eProfileBackend\x12&.containarium.v1.ProfileBackendRequest\x1a'.containarium.v1.ProfileBackendResponse\"\xa4\x02\x92A\xfd\x01\n" +
+	"\x06System\x12'Profile a backend's hardware capability\x1a\xc9\x01Records a backend's capability profile (hardware class, GPU probe, bounded CPU/memory micro-benchmark, region) and reconciles measured vs self-reported class. Surfaced through ListBackends. Admin-only.\x82\xd3\xe4\x93\x02\x1d:\x01*\"\x18/v1/capabilities/profile\x12\xd5\x02\n" +
+	"\x14GetCapabilityProfile\x12,.containarium.v1.GetCapabilityProfileRequest\x1a-.containarium.v1.GetCapabilityProfileResponse\"\xdf\x01\x92A\xbb\x01\n" +
+	"\x06System\x12\"Get a backend's capability profile\x1a\x8c\x01Returns a backend's last-recorded capability profile (hardware class, GPU probe, micro-benchmark, region) without re-running it. Admin-only.\x82\xd3\xe4\x93\x02\x1a\x12\x18/v1/capabilities/profile\x12\xb4\x02\n" +
 	"\x10GetLatestRelease\x12(.containarium.v1.GetLatestReleaseRequest\x1a).containarium.v1.GetLatestReleaseResponse\"\xca\x01\x92A\xab\x01\n" +
 	"\x06System\x12\x12Get latest release\x1a\x8c\x01Returns the latest Containarium release tag from GitHub (cached) alongside this daemon's running version and whether an update is available.\x82\xd3\xe4\x93\x02\x15\x12\x13/v1/releases/latest\x12\xb9\x02\n" +
 	"\vValidateGPU\x12#.containarium.v1.ValidateGPURequest\x1a$.containarium.v1.ValidateGPUResponse\"\xde\x01\x92A\xbf\x01\n" +
@@ -175,74 +179,78 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*AdvertiseCapacityRequest)(nil),         // 25: containarium.v1.AdvertiseCapacityRequest
 	(*WithdrawCapacityRequest)(nil),          // 26: containarium.v1.WithdrawCapacityRequest
 	(*GetCapacityHeadroomRequest)(nil),       // 27: containarium.v1.GetCapacityHeadroomRequest
-	(*GetLatestReleaseRequest)(nil),          // 28: containarium.v1.GetLatestReleaseRequest
-	(*ValidateGPURequest)(nil),               // 29: containarium.v1.ValidateGPURequest
-	(*TriggerUpgradeRequest)(nil),            // 30: containarium.v1.TriggerUpgradeRequest
-	(*GetUpgradeStatusRequest)(nil),          // 31: containarium.v1.GetUpgradeStatusRequest
-	(*GetMonitoringInfoRequest)(nil),         // 32: containarium.v1.GetMonitoringInfoRequest
-	(*CreateAlertRuleRequest)(nil),           // 33: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),            // 34: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),              // 35: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),           // 36: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),           // 37: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),           // 38: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),     // 39: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),      // 40: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),               // 41: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),     // 42: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),                 // 43: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),                 // 44: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),               // 45: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),              // 46: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),            // 47: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),          // 48: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),           // 49: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),             // 50: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),           // 51: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),          // 52: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),           // 53: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),            // 54: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),          // 55: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),            // 56: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerResponse)(nil),   // 57: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),         // 58: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),          // 59: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),          // 60: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyResponse)(nil), // 61: containarium.v1.SetContainerDeletePolicyResponse
-	(*AddSSHKeyResponse)(nil),                // 62: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),             // 63: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),          // 64: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),       // 65: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),        // 66: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),               // 67: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),              // 68: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),             // 69: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),               // 70: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),            // 71: containarium.v1.GetSystemInfoResponse
-	(*ListBackendsResponse)(nil),             // 72: containarium.v1.ListBackendsResponse
-	(*AdvertiseCapacityResponse)(nil),        // 73: containarium.v1.AdvertiseCapacityResponse
-	(*WithdrawCapacityResponse)(nil),         // 74: containarium.v1.WithdrawCapacityResponse
-	(*GetCapacityHeadroomResponse)(nil),      // 75: containarium.v1.GetCapacityHeadroomResponse
-	(*GetLatestReleaseResponse)(nil),         // 76: containarium.v1.GetLatestReleaseResponse
-	(*ValidateGPUResponse)(nil),              // 77: containarium.v1.ValidateGPUResponse
-	(*TriggerUpgradeResponse)(nil),           // 78: containarium.v1.TriggerUpgradeResponse
-	(*GetUpgradeStatusResponse)(nil),         // 79: containarium.v1.GetUpgradeStatusResponse
-	(*GetMonitoringInfoResponse)(nil),        // 80: containarium.v1.GetMonitoringInfoResponse
-	(*CreateAlertRuleResponse)(nil),          // 81: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),           // 82: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),             // 83: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),          // 84: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),          // 85: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),          // 86: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),    // 87: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),     // 88: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),              // 89: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),    // 90: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),                // 91: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),                // 92: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),              // 93: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),             // 94: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),           // 95: containarium.v1.RefreshSecretsResponse
+	(*ProfileBackendRequest)(nil),            // 28: containarium.v1.ProfileBackendRequest
+	(*GetCapabilityProfileRequest)(nil),      // 29: containarium.v1.GetCapabilityProfileRequest
+	(*GetLatestReleaseRequest)(nil),          // 30: containarium.v1.GetLatestReleaseRequest
+	(*ValidateGPURequest)(nil),               // 31: containarium.v1.ValidateGPURequest
+	(*TriggerUpgradeRequest)(nil),            // 32: containarium.v1.TriggerUpgradeRequest
+	(*GetUpgradeStatusRequest)(nil),          // 33: containarium.v1.GetUpgradeStatusRequest
+	(*GetMonitoringInfoRequest)(nil),         // 34: containarium.v1.GetMonitoringInfoRequest
+	(*CreateAlertRuleRequest)(nil),           // 35: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),            // 36: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),              // 37: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),           // 38: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),           // 39: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),           // 40: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),     // 41: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),      // 42: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),               // 43: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),     // 44: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),                 // 45: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),                 // 46: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),               // 47: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),              // 48: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),            // 49: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),          // 50: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),           // 51: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),             // 52: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),           // 53: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),          // 54: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),           // 55: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),            // 56: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),          // 57: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),            // 58: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerResponse)(nil),   // 59: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),         // 60: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),          // 61: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),          // 62: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyResponse)(nil), // 63: containarium.v1.SetContainerDeletePolicyResponse
+	(*AddSSHKeyResponse)(nil),                // 64: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),             // 65: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),          // 66: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),       // 67: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),        // 68: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),               // 69: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),              // 70: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),             // 71: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),               // 72: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),            // 73: containarium.v1.GetSystemInfoResponse
+	(*ListBackendsResponse)(nil),             // 74: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityResponse)(nil),        // 75: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityResponse)(nil),         // 76: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomResponse)(nil),      // 77: containarium.v1.GetCapacityHeadroomResponse
+	(*ProfileBackendResponse)(nil),           // 78: containarium.v1.ProfileBackendResponse
+	(*GetCapabilityProfileResponse)(nil),     // 79: containarium.v1.GetCapabilityProfileResponse
+	(*GetLatestReleaseResponse)(nil),         // 80: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),              // 81: containarium.v1.ValidateGPUResponse
+	(*TriggerUpgradeResponse)(nil),           // 82: containarium.v1.TriggerUpgradeResponse
+	(*GetUpgradeStatusResponse)(nil),         // 83: containarium.v1.GetUpgradeStatusResponse
+	(*GetMonitoringInfoResponse)(nil),        // 84: containarium.v1.GetMonitoringInfoResponse
+	(*CreateAlertRuleResponse)(nil),          // 85: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),           // 86: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),             // 87: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),          // 88: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),          // 89: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),          // 90: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),    // 91: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),     // 92: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),              // 93: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),    // 94: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),                // 95: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),                // 96: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),              // 97: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),             // 98: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),           // 99: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -273,76 +281,80 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	25, // 25: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
 	26, // 26: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
 	27, // 27: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
-	28, // 28: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
-	29, // 29: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
-	30, // 30: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
-	31, // 31: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
-	32, // 32: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	33, // 33: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	34, // 34: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	35, // 35: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	36, // 36: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	37, // 37: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	38, // 38: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	39, // 39: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	40, // 40: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	41, // 41: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	42, // 42: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	43, // 43: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	44, // 44: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	45, // 45: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	46, // 46: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	47, // 47: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	48, // 48: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	49, // 49: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	50, // 50: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	51, // 51: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	52, // 52: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	53, // 53: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	54, // 54: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	55, // 55: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	56, // 56: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	57, // 57: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	58, // 58: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	59, // 59: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	60, // 60: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	61, // 61: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
-	62, // 62: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	63, // 63: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	64, // 64: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	65, // 65: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	66, // 66: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	67, // 67: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	68, // 68: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	69, // 69: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	70, // 70: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	71, // 71: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	72, // 72: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
-	73, // 73: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
-	74, // 74: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
-	75, // 75: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
-	76, // 76: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	77, // 77: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
-	78, // 78: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
-	79, // 79: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
-	80, // 80: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	81, // 81: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	82, // 82: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	83, // 83: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	84, // 84: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	85, // 85: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	86, // 86: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	87, // 87: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	88, // 88: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	89, // 89: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	90, // 90: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	91, // 91: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	92, // 92: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	93, // 93: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	94, // 94: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	95, // 95: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	48, // [48:96] is the sub-list for method output_type
-	0,  // [0:48] is the sub-list for method input_type
+	28, // 28: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
+	29, // 29: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
+	30, // 30: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
+	31, // 31: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
+	32, // 32: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
+	33, // 33: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
+	34, // 34: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	35, // 35: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	36, // 36: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	37, // 37: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	38, // 38: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	39, // 39: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	40, // 40: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	41, // 41: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	42, // 42: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	43, // 43: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	44, // 44: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	45, // 45: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	46, // 46: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	47, // 47: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	48, // 48: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	49, // 49: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	50, // 50: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	51, // 51: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	52, // 52: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	53, // 53: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	54, // 54: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	55, // 55: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	56, // 56: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	57, // 57: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	58, // 58: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	59, // 59: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	60, // 60: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	61, // 61: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	62, // 62: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	63, // 63: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
+	64, // 64: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	65, // 65: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	66, // 66: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	67, // 67: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	68, // 68: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	69, // 69: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	70, // 70: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	71, // 71: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	72, // 72: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	73, // 73: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	74, // 74: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
+	75, // 75: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
+	76, // 76: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
+	77, // 77: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
+	78, // 78: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
+	79, // 79: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
+	80, // 80: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	81, // 81: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	82, // 82: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
+	83, // 83: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
+	84, // 84: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	85, // 85: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	86, // 86: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	87, // 87: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	88, // 88: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	89, // 89: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	90, // 90: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	91, // 91: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	92, // 92: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	93, // 93: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	94, // 94: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	95, // 95: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	96, // 96: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	97, // 97: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	98, // 98: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	99, // 99: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	50, // [50:100] is the sub-list for method output_type
+	0,  // [0:50] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -1244,6 +1244,41 @@ func local_request_ContainerService_GetCapabilityProfile_0(ctx context.Context, 
 	return msg, metadata, err
 }
 
+var filter_ContainerService_GetSelfMeasurement_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_ContainerService_GetSelfMeasurement_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetSelfMeasurementRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ContainerService_GetSelfMeasurement_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.GetSelfMeasurement(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_GetSelfMeasurement_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetSelfMeasurementRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ContainerService_GetSelfMeasurement_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetSelfMeasurement(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_GetLatestRelease_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq GetLatestReleaseRequest
@@ -2528,6 +2563,26 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_GetCapabilityProfile_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_GetSelfMeasurement_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/GetSelfMeasurement", runtime.WithHTTPPathPattern("/v1/integrity/self-measurement"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_GetSelfMeasurement_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_GetSelfMeasurement_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ContainerService_GetLatestRelease_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3495,6 +3550,23 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_GetCapabilityProfile_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_GetSelfMeasurement_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/GetSelfMeasurement", runtime.WithHTTPPathPattern("/v1/integrity/self-measurement"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_GetSelfMeasurement_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_GetSelfMeasurement_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ContainerService_GetLatestRelease_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3870,6 +3942,7 @@ var (
 	pattern_ContainerService_GetCapacityHeadroom_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
 	pattern_ContainerService_ProfileBackend_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capabilities", "profile"}, ""))
 	pattern_ContainerService_GetCapabilityProfile_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capabilities", "profile"}, ""))
+	pattern_ContainerService_GetSelfMeasurement_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "integrity", "self-measurement"}, ""))
 	pattern_ContainerService_GetLatestRelease_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "releases", "latest"}, ""))
 	pattern_ContainerService_ValidateGPU_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "validate-gpu"}, ""))
 	pattern_ContainerService_TriggerUpgrade_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "backends", "upgrade"}, ""))
@@ -3924,6 +3997,7 @@ var (
 	forward_ContainerService_GetCapacityHeadroom_0      = runtime.ForwardResponseMessage
 	forward_ContainerService_ProfileBackend_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_GetCapabilityProfile_0     = runtime.ForwardResponseMessage
+	forward_ContainerService_GetSelfMeasurement_0       = runtime.ForwardResponseMessage
 	forward_ContainerService_GetLatestRelease_0         = runtime.ForwardResponseMessage
 	forward_ContainerService_ValidateGPU_0              = runtime.ForwardResponseMessage
 	forward_ContainerService_TriggerUpgrade_0           = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -1099,6 +1099,75 @@ func local_request_ContainerService_ListBackends_0(ctx context.Context, marshale
 	return msg, metadata, err
 }
 
+func request_ContainerService_AdvertiseCapacity_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AdvertiseCapacityRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.AdvertiseCapacity(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_AdvertiseCapacity_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq AdvertiseCapacityRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.AdvertiseCapacity(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ContainerService_WithdrawCapacity_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq WithdrawCapacityRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.WithdrawCapacity(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_WithdrawCapacity_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq WithdrawCapacityRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.WithdrawCapacity(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ContainerService_GetCapacityHeadroom_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetCapacityHeadroomRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.GetCapacityHeadroom(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_GetCapacityHeadroom_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetCapacityHeadroomRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.GetCapacityHeadroom(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_GetLatestRelease_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq GetLatestReleaseRequest
@@ -2283,6 +2352,66 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_ListBackends_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_AdvertiseCapacity_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/AdvertiseCapacity", runtime.WithHTTPPathPattern("/v1/capacity/headroom"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_AdvertiseCapacity_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_AdvertiseCapacity_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_ContainerService_WithdrawCapacity_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/WithdrawCapacity", runtime.WithHTTPPathPattern("/v1/capacity/headroom"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_WithdrawCapacity_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_WithdrawCapacity_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_GetCapacityHeadroom_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/GetCapacityHeadroom", runtime.WithHTTPPathPattern("/v1/capacity/headroom"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_GetCapacityHeadroom_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_GetCapacityHeadroom_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ContainerService_GetLatestRelease_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3165,6 +3294,57 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_ListBackends_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_AdvertiseCapacity_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/AdvertiseCapacity", runtime.WithHTTPPathPattern("/v1/capacity/headroom"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_AdvertiseCapacity_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_AdvertiseCapacity_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_ContainerService_WithdrawCapacity_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/WithdrawCapacity", runtime.WithHTTPPathPattern("/v1/capacity/headroom"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_WithdrawCapacity_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_WithdrawCapacity_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_GetCapacityHeadroom_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/GetCapacityHeadroom", runtime.WithHTTPPathPattern("/v1/capacity/headroom"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_GetCapacityHeadroom_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_GetCapacityHeadroom_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ContainerService_GetLatestRelease_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3535,6 +3715,9 @@ var (
 	pattern_ContainerService_ListStacks_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "stacks"}, ""))
 	pattern_ContainerService_GetSystemInfo_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "info"}, ""))
 	pattern_ContainerService_ListBackends_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "backends"}, ""))
+	pattern_ContainerService_AdvertiseCapacity_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
+	pattern_ContainerService_WithdrawCapacity_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
+	pattern_ContainerService_GetCapacityHeadroom_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
 	pattern_ContainerService_GetLatestRelease_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "releases", "latest"}, ""))
 	pattern_ContainerService_ValidateGPU_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "validate-gpu"}, ""))
 	pattern_ContainerService_TriggerUpgrade_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "backends", "upgrade"}, ""))
@@ -3584,6 +3767,9 @@ var (
 	forward_ContainerService_ListStacks_0               = runtime.ForwardResponseMessage
 	forward_ContainerService_GetSystemInfo_0            = runtime.ForwardResponseMessage
 	forward_ContainerService_ListBackends_0             = runtime.ForwardResponseMessage
+	forward_ContainerService_AdvertiseCapacity_0        = runtime.ForwardResponseMessage
+	forward_ContainerService_WithdrawCapacity_0         = runtime.ForwardResponseMessage
+	forward_ContainerService_GetCapacityHeadroom_0      = runtime.ForwardResponseMessage
 	forward_ContainerService_GetLatestRelease_0         = runtime.ForwardResponseMessage
 	forward_ContainerService_ValidateGPU_0              = runtime.ForwardResponseMessage
 	forward_ContainerService_TriggerUpgrade_0           = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -1168,6 +1168,68 @@ func local_request_ContainerService_GetCapacityHeadroom_0(ctx context.Context, m
 	return msg, metadata, err
 }
 
+func request_ContainerService_ProfileBackend_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ProfileBackendRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ProfileBackend(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_ProfileBackend_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ProfileBackendRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ProfileBackend(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+var filter_ContainerService_GetCapabilityProfile_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_ContainerService_GetCapabilityProfile_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetCapabilityProfileRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ContainerService_GetCapabilityProfile_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.GetCapabilityProfile(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_GetCapabilityProfile_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetCapabilityProfileRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ContainerService_GetCapabilityProfile_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.GetCapabilityProfile(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_GetLatestRelease_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq GetLatestReleaseRequest
@@ -2412,6 +2474,46 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_GetCapacityHeadroom_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_ProfileBackend_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/ProfileBackend", runtime.WithHTTPPathPattern("/v1/capabilities/profile"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_ProfileBackend_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_ProfileBackend_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_GetCapabilityProfile_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/GetCapabilityProfile", runtime.WithHTTPPathPattern("/v1/capabilities/profile"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_GetCapabilityProfile_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_GetCapabilityProfile_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ContainerService_GetLatestRelease_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3345,6 +3447,40 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_GetCapacityHeadroom_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_ProfileBackend_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/ProfileBackend", runtime.WithHTTPPathPattern("/v1/capabilities/profile"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_ProfileBackend_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_ProfileBackend_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_GetCapabilityProfile_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/GetCapabilityProfile", runtime.WithHTTPPathPattern("/v1/capabilities/profile"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_GetCapabilityProfile_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_GetCapabilityProfile_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ContainerService_GetLatestRelease_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3718,6 +3854,8 @@ var (
 	pattern_ContainerService_AdvertiseCapacity_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
 	pattern_ContainerService_WithdrawCapacity_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
 	pattern_ContainerService_GetCapacityHeadroom_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
+	pattern_ContainerService_ProfileBackend_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capabilities", "profile"}, ""))
+	pattern_ContainerService_GetCapabilityProfile_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capabilities", "profile"}, ""))
 	pattern_ContainerService_GetLatestRelease_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "releases", "latest"}, ""))
 	pattern_ContainerService_ValidateGPU_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "validate-gpu"}, ""))
 	pattern_ContainerService_TriggerUpgrade_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "backends", "upgrade"}, ""))
@@ -3770,6 +3908,8 @@ var (
 	forward_ContainerService_AdvertiseCapacity_0        = runtime.ForwardResponseMessage
 	forward_ContainerService_WithdrawCapacity_0         = runtime.ForwardResponseMessage
 	forward_ContainerService_GetCapacityHeadroom_0      = runtime.ForwardResponseMessage
+	forward_ContainerService_ProfileBackend_0           = runtime.ForwardResponseMessage
+	forward_ContainerService_GetCapabilityProfile_0     = runtime.ForwardResponseMessage
 	forward_ContainerService_GetLatestRelease_0         = runtime.ForwardResponseMessage
 	forward_ContainerService_ValidateGPU_0              = runtime.ForwardResponseMessage
 	forward_ContainerService_TriggerUpgrade_0           = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -1126,6 +1126,8 @@ func local_request_ContainerService_AdvertiseCapacity_0(ctx context.Context, mar
 	return msg, metadata, err
 }
 
+var filter_ContainerService_WithdrawCapacity_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
 func request_ContainerService_WithdrawCapacity_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq WithdrawCapacityRequest
@@ -1133,6 +1135,12 @@ func request_ContainerService_WithdrawCapacity_0(ctx context.Context, marshaler 
 	)
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ContainerService_WithdrawCapacity_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	msg, err := client.WithdrawCapacity(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
@@ -1143,6 +1151,12 @@ func local_request_ContainerService_WithdrawCapacity_0(ctx context.Context, mars
 		protoReq WithdrawCapacityRequest
 		metadata runtime.ServerMetadata
 	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ContainerService_WithdrawCapacity_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
 	msg, err := server.WithdrawCapacity(ctx, &protoReq)
 	return msg, metadata, err
 }

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -47,6 +47,8 @@ const (
 	ContainerService_AdvertiseCapacity_FullMethodName        = "/containarium.v1.ContainerService/AdvertiseCapacity"
 	ContainerService_WithdrawCapacity_FullMethodName         = "/containarium.v1.ContainerService/WithdrawCapacity"
 	ContainerService_GetCapacityHeadroom_FullMethodName      = "/containarium.v1.ContainerService/GetCapacityHeadroom"
+	ContainerService_ProfileBackend_FullMethodName           = "/containarium.v1.ContainerService/ProfileBackend"
+	ContainerService_GetCapabilityProfile_FullMethodName     = "/containarium.v1.ContainerService/GetCapabilityProfile"
 	ContainerService_GetLatestRelease_FullMethodName         = "/containarium.v1.ContainerService/GetLatestRelease"
 	ContainerService_ValidateGPU_FullMethodName              = "/containarium.v1.ContainerService/ValidateGPU"
 	ContainerService_TriggerUpgrade_FullMethodName           = "/containarium.v1.ContainerService/TriggerUpgrade"
@@ -192,6 +194,16 @@ type ContainerServiceClient interface {
 	// freshly recomputed spare figures without changing advertise/withdraw
 	// state. Admin-only. See #680.
 	GetCapacityHeadroom(ctx context.Context, in *GetCapacityHeadroomRequest, opts ...grpc.CallOption) (*GetCapacityHeadroomResponse, error)
+	// ProfileBackend records a backend's hardware capability profile: it reads
+	// system info, runs the GPU passthrough probe and a bounded CPU/memory
+	// micro-benchmark, derives the measured hardware class, reconciles it
+	// against the self-reported class, and persists the profile. The profile is
+	// surfaced through ListBackends. Admin-only; runs a short-lived benchmark and
+	// (unless skipped) a throwaway GPU probe LXC. See #681.
+	ProfileBackend(ctx context.Context, in *ProfileBackendRequest, opts ...grpc.CallOption) (*ProfileBackendResponse, error)
+	// GetCapabilityProfile reads a backend's last-recorded capability profile
+	// without re-running the benchmark/probe. Admin-only. See #681.
+	GetCapabilityProfile(ctx context.Context, in *GetCapabilityProfileRequest, opts ...grpc.CallOption) (*GetCapabilityProfileResponse, error)
 	// GetLatestRelease reports the latest Containarium release on GitHub vs the
 	// running version, so operators see "update available" without SSHing in.
 	// The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
@@ -544,6 +556,26 @@ func (c *containerServiceClient) GetCapacityHeadroom(ctx context.Context, in *Ge
 	return out, nil
 }
 
+func (c *containerServiceClient) ProfileBackend(ctx context.Context, in *ProfileBackendRequest, opts ...grpc.CallOption) (*ProfileBackendResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ProfileBackendResponse)
+	err := c.cc.Invoke(ctx, ContainerService_ProfileBackend_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) GetCapabilityProfile(ctx context.Context, in *GetCapabilityProfileRequest, opts ...grpc.CallOption) (*GetCapabilityProfileResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetCapabilityProfileResponse)
+	err := c.cc.Invoke(ctx, ContainerService_GetCapabilityProfile_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *containerServiceClient) GetLatestRelease(ctx context.Context, in *GetLatestReleaseRequest, opts ...grpc.CallOption) (*GetLatestReleaseResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetLatestReleaseResponse)
@@ -867,6 +899,16 @@ type ContainerServiceServer interface {
 	// freshly recomputed spare figures without changing advertise/withdraw
 	// state. Admin-only. See #680.
 	GetCapacityHeadroom(context.Context, *GetCapacityHeadroomRequest) (*GetCapacityHeadroomResponse, error)
+	// ProfileBackend records a backend's hardware capability profile: it reads
+	// system info, runs the GPU passthrough probe and a bounded CPU/memory
+	// micro-benchmark, derives the measured hardware class, reconciles it
+	// against the self-reported class, and persists the profile. The profile is
+	// surfaced through ListBackends. Admin-only; runs a short-lived benchmark and
+	// (unless skipped) a throwaway GPU probe LXC. See #681.
+	ProfileBackend(context.Context, *ProfileBackendRequest) (*ProfileBackendResponse, error)
+	// GetCapabilityProfile reads a backend's last-recorded capability profile
+	// without re-running the benchmark/probe. Admin-only. See #681.
+	GetCapabilityProfile(context.Context, *GetCapabilityProfileRequest) (*GetCapabilityProfileResponse, error)
 	// GetLatestRelease reports the latest Containarium release on GitHub vs the
 	// running version, so operators see "update available" without SSHing in.
 	// The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
@@ -1022,6 +1064,12 @@ func (UnimplementedContainerServiceServer) WithdrawCapacity(context.Context, *Wi
 }
 func (UnimplementedContainerServiceServer) GetCapacityHeadroom(context.Context, *GetCapacityHeadroomRequest) (*GetCapacityHeadroomResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetCapacityHeadroom not implemented")
+}
+func (UnimplementedContainerServiceServer) ProfileBackend(context.Context, *ProfileBackendRequest) (*ProfileBackendResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ProfileBackend not implemented")
+}
+func (UnimplementedContainerServiceServer) GetCapabilityProfile(context.Context, *GetCapabilityProfileRequest) (*GetCapabilityProfileResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetCapabilityProfile not implemented")
 }
 func (UnimplementedContainerServiceServer) GetLatestRelease(context.Context, *GetLatestReleaseRequest) (*GetLatestReleaseResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetLatestRelease not implemented")
@@ -1608,6 +1656,42 @@ func _ContainerService_GetCapacityHeadroom_Handler(srv interface{}, ctx context.
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ContainerService_ProfileBackend_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ProfileBackendRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).ProfileBackend(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_ProfileBackend_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).ProfileBackend(ctx, req.(*ProfileBackendRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_GetCapabilityProfile_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetCapabilityProfileRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).GetCapabilityProfile(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_GetCapabilityProfile_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).GetCapabilityProfile(ctx, req.(*GetCapabilityProfileRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ContainerService_GetLatestRelease_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetLatestReleaseRequest)
 	if err := dec(in); err != nil {
@@ -2086,6 +2170,14 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetCapacityHeadroom",
 			Handler:    _ContainerService_GetCapacityHeadroom_Handler,
+		},
+		{
+			MethodName: "ProfileBackend",
+			Handler:    _ContainerService_ProfileBackend_Handler,
+		},
+		{
+			MethodName: "GetCapabilityProfile",
+			Handler:    _ContainerService_GetCapabilityProfile_Handler,
 		},
 		{
 			MethodName: "GetLatestRelease",

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -49,6 +49,7 @@ const (
 	ContainerService_GetCapacityHeadroom_FullMethodName      = "/containarium.v1.ContainerService/GetCapacityHeadroom"
 	ContainerService_ProfileBackend_FullMethodName           = "/containarium.v1.ContainerService/ProfileBackend"
 	ContainerService_GetCapabilityProfile_FullMethodName     = "/containarium.v1.ContainerService/GetCapabilityProfile"
+	ContainerService_GetSelfMeasurement_FullMethodName       = "/containarium.v1.ContainerService/GetSelfMeasurement"
 	ContainerService_GetLatestRelease_FullMethodName         = "/containarium.v1.ContainerService/GetLatestRelease"
 	ContainerService_ValidateGPU_FullMethodName              = "/containarium.v1.ContainerService/ValidateGPU"
 	ContainerService_TriggerUpgrade_FullMethodName           = "/containarium.v1.ContainerService/TriggerUpgrade"
@@ -204,6 +205,14 @@ type ContainerServiceClient interface {
 	// GetCapabilityProfile reads a backend's last-recorded capability profile
 	// without re-running the benchmark/probe. Admin-only. See #681.
 	GetCapabilityProfile(ctx context.Context, in *GetCapabilityProfileRequest, opts ...grpc.CallOption) (*GetCapabilityProfileResponse, error)
+	// GetSelfMeasurement computes and signs a fresh integrity self-measurement
+	// for a backend: digests of the running daemon binary, the loaded in-kernel
+	// network-policy program object(s), and the canonical policy/config state,
+	// signed with the node's identity key (the sentinel-issued peer leaf reused
+	// from the peer-PKI plumbing; TPM-backed when present). The daemon also emits
+	// this on its heartbeat; this RPC exposes the same measurement on demand. The
+	// control plane verifies it to detect tampering. Admin-only. See #683.
+	GetSelfMeasurement(ctx context.Context, in *GetSelfMeasurementRequest, opts ...grpc.CallOption) (*GetSelfMeasurementResponse, error)
 	// GetLatestRelease reports the latest Containarium release on GitHub vs the
 	// running version, so operators see "update available" without SSHing in.
 	// The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
@@ -576,6 +585,16 @@ func (c *containerServiceClient) GetCapabilityProfile(ctx context.Context, in *G
 	return out, nil
 }
 
+func (c *containerServiceClient) GetSelfMeasurement(ctx context.Context, in *GetSelfMeasurementRequest, opts ...grpc.CallOption) (*GetSelfMeasurementResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetSelfMeasurementResponse)
+	err := c.cc.Invoke(ctx, ContainerService_GetSelfMeasurement_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *containerServiceClient) GetLatestRelease(ctx context.Context, in *GetLatestReleaseRequest, opts ...grpc.CallOption) (*GetLatestReleaseResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetLatestReleaseResponse)
@@ -909,6 +928,14 @@ type ContainerServiceServer interface {
 	// GetCapabilityProfile reads a backend's last-recorded capability profile
 	// without re-running the benchmark/probe. Admin-only. See #681.
 	GetCapabilityProfile(context.Context, *GetCapabilityProfileRequest) (*GetCapabilityProfileResponse, error)
+	// GetSelfMeasurement computes and signs a fresh integrity self-measurement
+	// for a backend: digests of the running daemon binary, the loaded in-kernel
+	// network-policy program object(s), and the canonical policy/config state,
+	// signed with the node's identity key (the sentinel-issued peer leaf reused
+	// from the peer-PKI plumbing; TPM-backed when present). The daemon also emits
+	// this on its heartbeat; this RPC exposes the same measurement on demand. The
+	// control plane verifies it to detect tampering. Admin-only. See #683.
+	GetSelfMeasurement(context.Context, *GetSelfMeasurementRequest) (*GetSelfMeasurementResponse, error)
 	// GetLatestRelease reports the latest Containarium release on GitHub vs the
 	// running version, so operators see "update available" without SSHing in.
 	// The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
@@ -1070,6 +1097,9 @@ func (UnimplementedContainerServiceServer) ProfileBackend(context.Context, *Prof
 }
 func (UnimplementedContainerServiceServer) GetCapabilityProfile(context.Context, *GetCapabilityProfileRequest) (*GetCapabilityProfileResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetCapabilityProfile not implemented")
+}
+func (UnimplementedContainerServiceServer) GetSelfMeasurement(context.Context, *GetSelfMeasurementRequest) (*GetSelfMeasurementResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSelfMeasurement not implemented")
 }
 func (UnimplementedContainerServiceServer) GetLatestRelease(context.Context, *GetLatestReleaseRequest) (*GetLatestReleaseResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetLatestRelease not implemented")
@@ -1692,6 +1722,24 @@ func _ContainerService_GetCapabilityProfile_Handler(srv interface{}, ctx context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ContainerService_GetSelfMeasurement_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSelfMeasurementRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).GetSelfMeasurement(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_GetSelfMeasurement_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).GetSelfMeasurement(ctx, req.(*GetSelfMeasurementRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ContainerService_GetLatestRelease_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetLatestReleaseRequest)
 	if err := dec(in); err != nil {
@@ -2178,6 +2226,10 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetCapabilityProfile",
 			Handler:    _ContainerService_GetCapabilityProfile_Handler,
+		},
+		{
+			MethodName: "GetSelfMeasurement",
+			Handler:    _ContainerService_GetSelfMeasurement_Handler,
 		},
 		{
 			MethodName: "GetLatestRelease",

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -44,6 +44,9 @@ const (
 	ContainerService_ListStacks_FullMethodName               = "/containarium.v1.ContainerService/ListStacks"
 	ContainerService_GetSystemInfo_FullMethodName            = "/containarium.v1.ContainerService/GetSystemInfo"
 	ContainerService_ListBackends_FullMethodName             = "/containarium.v1.ContainerService/ListBackends"
+	ContainerService_AdvertiseCapacity_FullMethodName        = "/containarium.v1.ContainerService/AdvertiseCapacity"
+	ContainerService_WithdrawCapacity_FullMethodName         = "/containarium.v1.ContainerService/WithdrawCapacity"
+	ContainerService_GetCapacityHeadroom_FullMethodName      = "/containarium.v1.ContainerService/GetCapacityHeadroom"
 	ContainerService_GetLatestRelease_FullMethodName         = "/containarium.v1.ContainerService/GetLatestRelease"
 	ContainerService_ValidateGPU_FullMethodName              = "/containarium.v1.ContainerService/ValidateGPU"
 	ContainerService_TriggerUpgrade_FullMethodName           = "/containarium.v1.ContainerService/TriggerUpgrade"
@@ -175,6 +178,20 @@ type ContainerServiceClient interface {
 	// /v1/backends HTTP handler with the proto-first, gateway-generated
 	// contract (proto-first convention; #354).
 	ListBackends(ctx context.Context, in *ListBackendsRequest, opts ...grpc.CallOption) (*ListBackendsResponse, error)
+	// AdvertiseCapacity publishes this backend's spare scheduling headroom to
+	// the control plane, bounded by a local policy (time window, excluded
+	// workload classes, safety reservation). A box that would scale down can
+	// instead offer its freed headroom for control-plane-directed scheduling.
+	// The advertisement is surfaced through ListBackends. Admin-only. See #680.
+	AdvertiseCapacity(ctx context.Context, in *AdvertiseCapacityRequest, opts ...grpc.CallOption) (*AdvertiseCapacityResponse, error)
+	// WithdrawCapacity withdraws any active headroom advertisement. Idempotent:
+	// withdrawing when nothing is advertised succeeds as a no-op. Admin-only.
+	// See #680.
+	WithdrawCapacity(ctx context.Context, in *WithdrawCapacityRequest, opts ...grpc.CallOption) (*WithdrawCapacityResponse, error)
+	// GetCapacityHeadroom reads this backend's current advertisement and the
+	// freshly recomputed spare figures without changing advertise/withdraw
+	// state. Admin-only. See #680.
+	GetCapacityHeadroom(ctx context.Context, in *GetCapacityHeadroomRequest, opts ...grpc.CallOption) (*GetCapacityHeadroomResponse, error)
 	// GetLatestRelease reports the latest Containarium release on GitHub vs the
 	// running version, so operators see "update available" without SSHing in.
 	// The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
@@ -497,6 +514,36 @@ func (c *containerServiceClient) ListBackends(ctx context.Context, in *ListBacke
 	return out, nil
 }
 
+func (c *containerServiceClient) AdvertiseCapacity(ctx context.Context, in *AdvertiseCapacityRequest, opts ...grpc.CallOption) (*AdvertiseCapacityResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(AdvertiseCapacityResponse)
+	err := c.cc.Invoke(ctx, ContainerService_AdvertiseCapacity_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) WithdrawCapacity(ctx context.Context, in *WithdrawCapacityRequest, opts ...grpc.CallOption) (*WithdrawCapacityResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(WithdrawCapacityResponse)
+	err := c.cc.Invoke(ctx, ContainerService_WithdrawCapacity_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) GetCapacityHeadroom(ctx context.Context, in *GetCapacityHeadroomRequest, opts ...grpc.CallOption) (*GetCapacityHeadroomResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetCapacityHeadroomResponse)
+	err := c.cc.Invoke(ctx, ContainerService_GetCapacityHeadroom_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *containerServiceClient) GetLatestRelease(ctx context.Context, in *GetLatestReleaseRequest, opts ...grpc.CallOption) (*GetLatestReleaseResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetLatestReleaseResponse)
@@ -806,6 +853,20 @@ type ContainerServiceServer interface {
 	// /v1/backends HTTP handler with the proto-first, gateway-generated
 	// contract (proto-first convention; #354).
 	ListBackends(context.Context, *ListBackendsRequest) (*ListBackendsResponse, error)
+	// AdvertiseCapacity publishes this backend's spare scheduling headroom to
+	// the control plane, bounded by a local policy (time window, excluded
+	// workload classes, safety reservation). A box that would scale down can
+	// instead offer its freed headroom for control-plane-directed scheduling.
+	// The advertisement is surfaced through ListBackends. Admin-only. See #680.
+	AdvertiseCapacity(context.Context, *AdvertiseCapacityRequest) (*AdvertiseCapacityResponse, error)
+	// WithdrawCapacity withdraws any active headroom advertisement. Idempotent:
+	// withdrawing when nothing is advertised succeeds as a no-op. Admin-only.
+	// See #680.
+	WithdrawCapacity(context.Context, *WithdrawCapacityRequest) (*WithdrawCapacityResponse, error)
+	// GetCapacityHeadroom reads this backend's current advertisement and the
+	// freshly recomputed spare figures without changing advertise/withdraw
+	// state. Admin-only. See #680.
+	GetCapacityHeadroom(context.Context, *GetCapacityHeadroomRequest) (*GetCapacityHeadroomResponse, error)
 	// GetLatestRelease reports the latest Containarium release on GitHub vs the
 	// running version, so operators see "update available" without SSHing in.
 	// The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.
@@ -952,6 +1013,15 @@ func (UnimplementedContainerServiceServer) GetSystemInfo(context.Context, *GetSy
 }
 func (UnimplementedContainerServiceServer) ListBackends(context.Context, *ListBackendsRequest) (*ListBackendsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListBackends not implemented")
+}
+func (UnimplementedContainerServiceServer) AdvertiseCapacity(context.Context, *AdvertiseCapacityRequest) (*AdvertiseCapacityResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method AdvertiseCapacity not implemented")
+}
+func (UnimplementedContainerServiceServer) WithdrawCapacity(context.Context, *WithdrawCapacityRequest) (*WithdrawCapacityResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method WithdrawCapacity not implemented")
+}
+func (UnimplementedContainerServiceServer) GetCapacityHeadroom(context.Context, *GetCapacityHeadroomRequest) (*GetCapacityHeadroomResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetCapacityHeadroom not implemented")
 }
 func (UnimplementedContainerServiceServer) GetLatestRelease(context.Context, *GetLatestReleaseRequest) (*GetLatestReleaseResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetLatestRelease not implemented")
@@ -1484,6 +1554,60 @@ func _ContainerService_ListBackends_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ContainerService_AdvertiseCapacity_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AdvertiseCapacityRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).AdvertiseCapacity(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_AdvertiseCapacity_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).AdvertiseCapacity(ctx, req.(*AdvertiseCapacityRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_WithdrawCapacity_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(WithdrawCapacityRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).WithdrawCapacity(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_WithdrawCapacity_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).WithdrawCapacity(ctx, req.(*WithdrawCapacityRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_GetCapacityHeadroom_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetCapacityHeadroomRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).GetCapacityHeadroom(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_GetCapacityHeadroom_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).GetCapacityHeadroom(ctx, req.(*GetCapacityHeadroomRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ContainerService_GetLatestRelease_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetLatestReleaseRequest)
 	if err := dec(in); err != nil {
@@ -1950,6 +2074,18 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListBackends",
 			Handler:    _ContainerService_ListBackends_Handler,
+		},
+		{
+			MethodName: "AdvertiseCapacity",
+			Handler:    _ContainerService_AdvertiseCapacity_Handler,
+		},
+		{
+			MethodName: "WithdrawCapacity",
+			Handler:    _ContainerService_WithdrawCapacity_Handler,
+		},
+		{
+			MethodName: "GetCapacityHeadroom",
+			Handler:    _ContainerService_GetCapacityHeadroom_Handler,
 		},
 		{
 			MethodName: "GetLatestRelease",

--- a/proto/containarium/v1/config.proto
+++ b/proto/containarium/v1/config.proto
@@ -593,6 +593,72 @@ message BackendInfo {
 
   // GPUs present on this backend.
   repeated BackendGPU gpus = 10;
+
+  // Spare scheduling capacity this backend currently advertises to the
+  // control plane, or null when nothing is advertised (withdrawn or never
+  // published). Lets the control plane direct scheduling at hosts that have
+  // explicitly offered freed headroom. See #680.
+  CapacityHeadroom headroom = 11;
+}
+
+// CapacityHeadroom is a backend's explicit, policy-bounded offer of spare
+// scheduling capacity to the control plane. Today a backend's capacity is
+// implicit (derived from system info); a box that would otherwise scale down
+// can instead publish its freed headroom here so the control plane can direct
+// work at it. Surfaced through BackendInfo (ListBackends). See #680.
+message CapacityHeadroom {
+  // Whether an advertisement is currently active. False means the backend has
+  // withdrawn (or never published) — the rest of the fields are then a stale
+  // snapshot the control plane must ignore.
+  bool advertised = 1;
+
+  // Spare CPU cores the backend offers for control-plane-directed scheduling.
+  int32 spare_cpus = 2;
+
+  // Spare memory in bytes (derived from SystemInfo.available_memory_bytes,
+  // bounded by policy headroom reservation).
+  int64 spare_memory_bytes = 3;
+
+  // Spare disk in bytes (derived from SystemInfo.available_disk_bytes,
+  // bounded by policy headroom reservation).
+  int64 spare_disk_bytes = 4;
+
+  // Host-level idle fraction in [0,1]: the share of running user containers
+  // currently idle (a host aggregate over the per-container idle signal). A
+  // high value indicates a box that would scale down and can instead offer
+  // its headroom. 0 when no signal is available.
+  double idle_fraction = 5;
+
+  // RFC3339 timestamp the advertisement was last (re)published.
+  string advertised_at = 6;
+
+  // The local policy that bounds this advertisement.
+  CapacityPolicy policy = 7;
+}
+
+// CapacityPolicy bounds what a backend is willing to advertise. The
+// advertisement only computes spare capacity when the current time falls
+// inside the allowed window and respects the excluded workload classes.
+// Operator-set per backend. See #680.
+message CapacityPolicy {
+  // Local-clock hour the advertisement window opens (0-23). When
+  // window_start_hour == window_end_hour the window is always open.
+  int32 window_start_hour = 1;
+
+  // Local-clock hour the advertisement window closes (0-23, exclusive). May be
+  // less than window_start_hour to express an overnight window (e.g. 22..6).
+  int32 window_end_hour = 2;
+
+  // Workload classes that must NOT be displaced or co-scheduled — running
+  // containers carrying any of these classes are excluded from the idle/spare
+  // computation, so a host running protected work never advertises it as free.
+  // Matched against the container's "user.containarium.workload_class" label.
+  repeated string excluded_workload_classes = 3;
+
+  // Fraction of host resources to hold back as a safety reservation, in
+  // [0,1). Spare = available * (1 - reserve_fraction). 0 means offer all
+  // available headroom.
+  double reserve_fraction = 4;
 }
 
 // BackendGPU describes one GPU on a backend.
@@ -614,4 +680,40 @@ message ListBackendsRequest {}
 message ListBackendsResponse {
   // List of available backends
   repeated BackendInfo backends = 1;
+}
+
+// AdvertiseCapacityRequest publishes (or republishes) this backend's spare
+// scheduling headroom to the control plane, bounded by the supplied policy.
+// See #680.
+message AdvertiseCapacityRequest {
+  // The local policy that bounds the advertisement. When omitted the backend
+  // applies its current/default policy (always-open window, no exclusions, no
+  // reservation).
+  CapacityPolicy policy = 1;
+}
+
+// AdvertiseCapacityResponse returns the headroom the backend computed and is
+// now advertising. When the policy window is closed, advertised is true but
+// the spare figures are zero.
+message AdvertiseCapacityResponse {
+  CapacityHeadroom headroom = 1;
+}
+
+// WithdrawCapacityRequest withdraws any active advertisement. Idempotent —
+// withdrawing when nothing is advertised succeeds and is a no-op.
+message WithdrawCapacityRequest {}
+
+// WithdrawCapacityResponse confirms the backend is no longer advertising.
+message WithdrawCapacityResponse {
+  // The post-withdraw headroom (advertised=false).
+  CapacityHeadroom headroom = 1;
+}
+
+// GetCapacityHeadroomRequest reads the backend's current advertisement and the
+// freshly recomputed spare figures, without changing advertise/withdraw state.
+message GetCapacityHeadroomRequest {}
+
+// GetCapacityHeadroomResponse returns the current headroom snapshot.
+message GetCapacityHeadroomResponse {
+  CapacityHeadroom headroom = 1;
 }

--- a/proto/containarium/v1/config.proto
+++ b/proto/containarium/v1/config.proto
@@ -599,6 +599,86 @@ message BackendInfo {
   // published). Lets the control plane direct scheduling at hosts that have
   // explicitly offered freed headroom. See #680.
   CapacityHeadroom headroom = 11;
+
+  // The backend's hardware capability profile recorded at join (hardware
+  // class, a bounded CPU/memory micro-benchmark, and region), or null when no
+  // profile has been recorded yet. Lets the control plane place work by
+  // measured class rather than self-reported class alone. See #681.
+  CapabilityProfile capability_profile = 12;
+}
+
+// CapabilityProfile is a backend's hardware capability snapshot recorded at
+// join (and refreshable on demand): the hardware class derived from the host's
+// system info + GPU probe, a lightweight bounded CPU/memory micro-benchmark,
+// and the region. The control plane reads it through the backend surface to
+// place work by measured capability rather than by the self-reported class
+// alone, and to detect a backend whose measured class drifts from what it
+// reports. See #681.
+message CapabilityProfile {
+  // Total physical CPU cores on the host (from SystemInfo.total_cpus).
+  int32 cpu_cores = 1;
+
+  // Best-effort CPU model/generation string (e.g. "AMD EPYC 7B13"), empty when
+  // the host doesn't expose one.
+  string cpu_model = 2;
+
+  // Total RAM in bytes (from SystemInfo.total_memory_bytes).
+  int64 total_memory_bytes = 3;
+
+  // Total disk in bytes (from SystemInfo.total_disk_bytes).
+  int64 total_disk_bytes = 4;
+
+  // GPU model name from the existing nvidia.runtime passthrough probe
+  // (ValidateGPU), empty on a CPU-only backend.
+  string gpu_model = 5;
+
+  // GPU driver version from the same probe, empty on a CPU-only backend.
+  string gpu_driver_version = 6;
+
+  // Whether the GPU passthrough probe saw a usable GPU.
+  bool gpu_available = 7;
+
+  // Region the backend serves (operator-set via --region; falls back to the
+  // pool name). Empty when unset.
+  string region = 8;
+
+  // Self-reported hardware class the operator assigned the backend (e.g. the
+  // pool name / declared tier), if any.
+  string reported_class = 9;
+
+  // Measured hardware class derived from the profile (e.g. "gpu", "cpu-large",
+  // "cpu-small"). Coarse buckets; the control plane refines placement from the
+  // raw figures.
+  string measured_class = 10;
+
+  // True when measured_class matches reported_class (or reported_class is
+  // empty, treated as consistent). False flags a drift the control plane and
+  // operator should reconcile.
+  bool class_consistent = 11;
+
+  // The bounded micro-benchmark result. See CapabilityBenchmark.
+  CapabilityBenchmark benchmark = 12;
+
+  // RFC3339 timestamp the profile was recorded.
+  string profiled_at = 13;
+}
+
+// CapabilityBenchmark is a lightweight, time-bounded CPU/memory micro-benchmark
+// run when the profile is recorded. The scores are relative integrity/capacity
+// signals, not absolute hardware specs — they let the control plane confirm a
+// backend's self-reported class is plausible. See #681.
+message CapabilityBenchmark {
+  // CPU score: integer-work iterations completed per second during the bounded
+  // run (higher is faster). Single-threaded.
+  int64 cpu_ops_per_sec = 1;
+
+  // Memory score: bytes per second moved through a bounded buffer copy/sum
+  // loop (higher is faster).
+  int64 mem_bytes_per_sec = 2;
+
+  // Wall-clock duration of the benchmark in milliseconds (bounded; the runner
+  // caps each phase).
+  int64 duration_ms = 3;
 }
 
 // CapacityHeadroom is a backend's explicit, policy-bounded offer of spare
@@ -716,4 +796,43 @@ message GetCapacityHeadroomRequest {}
 // GetCapacityHeadroomResponse returns the current headroom snapshot.
 message GetCapacityHeadroomResponse {
   CapacityHeadroom headroom = 1;
+}
+
+// ProfileBackendRequest asks a backend to (re)record its capability profile:
+// read system info, run the GPU passthrough probe and the bounded
+// CPU/memory micro-benchmark, derive the measured class, and persist it. See
+// #681.
+message ProfileBackendRequest {
+  // Backend to profile. Empty = the local/primary daemon's own host; a peer id
+  // forwards to that peer (which profiles itself).
+  string backend_id = 1;
+
+  // Skip the GPU passthrough probe (which creates+deletes a throwaway LXC and
+  // can take ~30s). The profile then records gpu_available=false. Useful on a
+  // backend known to be CPU-only.
+  bool skip_gpu = 2;
+}
+
+// ProfileBackendResponse returns the freshly recorded capability profile.
+message ProfileBackendResponse {
+  CapabilityProfile profile = 1;
+
+  // Echoes the profiled backend ("" = local).
+  string backend_id = 2;
+}
+
+// GetCapabilityProfileRequest reads a backend's last-recorded capability
+// profile without re-running the benchmark/probe. See #681.
+message GetCapabilityProfileRequest {
+  // Backend to read. Empty = the local/primary daemon's own host.
+  string backend_id = 1;
+}
+
+// GetCapabilityProfileResponse returns the last-recorded profile, or null when
+// nothing has been profiled yet.
+message GetCapabilityProfileResponse {
+  CapabilityProfile profile = 1;
+
+  // Echoes the backend ("" = local).
+  string backend_id = 2;
 }

--- a/proto/containarium/v1/config.proto
+++ b/proto/containarium/v1/config.proto
@@ -813,6 +813,11 @@ message WithdrawCapacityResponse {
   // True when the graceful budget was exhausted and the backend fell back to
   // force-stopping the remaining workloads.
   bool drain_window_exceeded = 4;
+
+  // Container name → error for guests that could NOT be stopped even after the
+  // force fallback. A non-empty map means the host is NOT fully reclaimed —
+  // the control plane must not treat those guests' resources as freed.
+  map<string, string> failed = 5;
 }
 
 // GetCapacityHeadroomRequest reads the backend's current advertisement and the

--- a/proto/containarium/v1/config.proto
+++ b/proto/containarium/v1/config.proto
@@ -862,3 +862,87 @@ message GetCapabilityProfileResponse {
   // Echoes the backend ("" = local).
   string backend_id = 2;
 }
+
+// SelfMeasurement is a backend's signed integrity attestation, emitted by the
+// daemon on its heartbeat. It hashes the daemon's own binary, the loaded
+// in-kernel network-policy program object(s), and the policy/config state, then
+// signs the canonical measurement with the node's identity key (the
+// sentinel-issued peer leaf key reused from the peer-PKI plumbing; TPM-backed
+// when a TPM is present, software-signed otherwise). The control plane reads
+// this through the backend surface to detect tampering of a backend's control
+// plane out of band of the backend's own reporting. The node-side half only:
+// the control plane's verification/quarantine logic lives elsewhere. See #683.
+message SelfMeasurement {
+  // Hash algorithm used for every component digest below (e.g. "sha256").
+  string hash_algorithm = 1;
+
+  // Hex-encoded digest of the running daemon binary on disk.
+  string binary_digest = 2;
+
+  // Hex-encoded digests of the loaded in-kernel network-policy program
+  // object(s), in stable (sorted) order. Empty when no program object is
+  // configured on this backend.
+  repeated ProgramDigest program_digests = 3;
+
+  // Hex-encoded digest of the canonicalized policy/config state (the
+  // integrity-relevant daemon configuration + active network-policy posture).
+  string config_digest = 4;
+
+  // Hex-encoded digest of the canonical measurement bytes that were signed
+  // (binds all components together). The signature below covers exactly these
+  // bytes.
+  string measurement_digest = 5;
+
+  // Signature over the canonical measurement bytes, base64-encoded.
+  string signature = 6;
+
+  // Signature scheme used (e.g. "ecdsa-p256-sha256"). Empty when the daemon had
+  // no identity key available and the measurement is unsigned (signature empty).
+  string signature_algorithm = 7;
+
+  // Whether the signature was produced by a TPM-backed key. False = the
+  // software identity key (sentinel-issued peer leaf) signed it.
+  bool tpm_backed = 8;
+
+  // Whether an identity key was available to sign. False means the measurement
+  // is present but unsigned (no peer PKI bootstrapped yet); the control plane
+  // treats an unsigned measurement as unverifiable, not as tamper.
+  bool signed = 9;
+
+  // PEM of the signing certificate (the peer leaf), so the control plane can
+  // verify the signature against the sentinel CA chain without a side lookup.
+  // Empty when unsigned.
+  string signing_cert_pem = 10;
+
+  // RFC3339 timestamp the measurement was taken.
+  string measured_at = 11;
+
+  // Daemon version that produced the measurement.
+  string daemon_version = 12;
+}
+
+// ProgramDigest is one loaded in-kernel program object's identity + digest.
+message ProgramDigest {
+  // Stable name/path identifying the program object (e.g. the configured BPF
+  // object path).
+  string name = 1;
+
+  // Hex-encoded digest of the program object bytes.
+  string digest = 2;
+}
+
+// GetSelfMeasurementRequest asks a backend to compute and sign a fresh self
+// measurement. See #683.
+message GetSelfMeasurementRequest {
+  // Backend to measure. Empty = the local/primary daemon's own host; a peer id
+  // forwards to that peer (which measures itself).
+  string backend_id = 1;
+}
+
+// GetSelfMeasurementResponse returns the freshly computed signed measurement.
+message GetSelfMeasurementResponse {
+  SelfMeasurement measurement = 1;
+
+  // Echoes the measured backend ("" = local).
+  string backend_id = 2;
+}

--- a/proto/containarium/v1/config.proto
+++ b/proto/containarium/v1/config.proto
@@ -781,12 +781,38 @@ message AdvertiseCapacityResponse {
 
 // WithdrawCapacityRequest withdraws any active advertisement. Idempotent —
 // withdrawing when nothing is advertised succeeds and is a no-op.
-message WithdrawCapacityRequest {}
+message WithdrawCapacityRequest {
+  // When true the backend also reclaims the guest workloads it had implicitly
+  // offered, draining them gracefully within a bounded window instead of
+  // hard-killing them. Each drained workload is stopped through the normal
+  // stop path so the control plane observes a stop event and can reschedule.
+  // When false (default) withdraw only flips the advertisement off and leaves
+  // running guests untouched. See #682.
+  bool drain = 1;
+
+  // Bounded wall-clock budget (seconds) for the graceful drain. Once exhausted
+  // any still-running candidate is force-stopped so the host is reliably
+  // reclaimed (no wedge on repeated advertise/withdraw cycles). 0 applies the
+  // backend default (120s). Only honored when drain is true.
+  int32 drain_window_seconds = 2;
+}
 
 // WithdrawCapacityResponse confirms the backend is no longer advertising.
 message WithdrawCapacityResponse {
   // The post-withdraw headroom (advertised=false).
   CapacityHeadroom headroom = 1;
+
+  // Container names that drained gracefully within the window. Empty unless
+  // the request set drain. See #682.
+  repeated string drained = 2;
+
+  // Container names that were force-stopped because the bounded window was
+  // exhausted before they stopped gracefully.
+  repeated string force_stopped = 3;
+
+  // True when the graceful budget was exhausted and the backend fell back to
+  // force-stopping the remaining workloads.
+  bool drain_window_exceeded = 4;
 }
 
 // GetCapacityHeadroomRequest reads the backend's current advertisement and the

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -467,6 +467,37 @@ service ContainerService {
     };
   }
 
+  // ProfileBackend records a backend's hardware capability profile: it reads
+  // system info, runs the GPU passthrough probe and a bounded CPU/memory
+  // micro-benchmark, derives the measured hardware class, reconciles it
+  // against the self-reported class, and persists the profile. The profile is
+  // surfaced through ListBackends. Admin-only; runs a short-lived benchmark and
+  // (unless skipped) a throwaway GPU probe LXC. See #681.
+  rpc ProfileBackend(ProfileBackendRequest) returns (ProfileBackendResponse) {
+    option (google.api.http) = {
+      post: "/v1/capabilities/profile"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Profile a backend's hardware capability";
+      description: "Records a backend's capability profile (hardware class, GPU probe, bounded CPU/memory micro-benchmark, region) and reconciles measured vs self-reported class. Surfaced through ListBackends. Admin-only.";
+      tags: "System";
+    };
+  }
+
+  // GetCapabilityProfile reads a backend's last-recorded capability profile
+  // without re-running the benchmark/probe. Admin-only. See #681.
+  rpc GetCapabilityProfile(GetCapabilityProfileRequest) returns (GetCapabilityProfileResponse) {
+    option (google.api.http) = {
+      get: "/v1/capabilities/profile"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get a backend's capability profile";
+      description: "Returns a backend's last-recorded capability profile (hardware class, GPU probe, micro-benchmark, region) without re-running it. Admin-only.";
+      tags: "System";
+    };
+  }
+
   // GetLatestRelease reports the latest Containarium release on GitHub vs the
   // running version, so operators see "update available" without SSHing in.
   // The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -498,6 +498,24 @@ service ContainerService {
     };
   }
 
+  // GetSelfMeasurement computes and signs a fresh integrity self-measurement
+  // for a backend: digests of the running daemon binary, the loaded in-kernel
+  // network-policy program object(s), and the canonical policy/config state,
+  // signed with the node's identity key (the sentinel-issued peer leaf reused
+  // from the peer-PKI plumbing; TPM-backed when present). The daemon also emits
+  // this on its heartbeat; this RPC exposes the same measurement on demand. The
+  // control plane verifies it to detect tampering. Admin-only. See #683.
+  rpc GetSelfMeasurement(GetSelfMeasurementRequest) returns (GetSelfMeasurementResponse) {
+    option (google.api.http) = {
+      get: "/v1/integrity/self-measurement"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get a backend's signed integrity self-measurement";
+      description: "Computes and signs a fresh integrity self-measurement (daemon binary digest, loaded in-kernel program object digests, policy/config-state digest) with the node's identity key. The daemon also emits this on its heartbeat. Admin-only.";
+      tags: "System";
+    };
+  }
+
   // GetLatestRelease reports the latest Containarium release on GitHub vs the
   // running version, so operators see "update available" without SSHing in.
   // The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -422,6 +422,51 @@ service ContainerService {
     };
   }
 
+  // AdvertiseCapacity publishes this backend's spare scheduling headroom to
+  // the control plane, bounded by a local policy (time window, excluded
+  // workload classes, safety reservation). A box that would scale down can
+  // instead offer its freed headroom for control-plane-directed scheduling.
+  // The advertisement is surfaced through ListBackends. Admin-only. See #680.
+  rpc AdvertiseCapacity(AdvertiseCapacityRequest) returns (AdvertiseCapacityResponse) {
+    option (google.api.http) = {
+      post: "/v1/capacity/headroom"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Advertise spare scheduling capacity";
+      description: "Publishes this backend's spare scheduling headroom (spare CPU/memory/disk + host idle fraction) to the control plane, bounded by a local policy. Surfaced through ListBackends. Admin-only.";
+      tags: "System";
+    };
+  }
+
+  // WithdrawCapacity withdraws any active headroom advertisement. Idempotent:
+  // withdrawing when nothing is advertised succeeds as a no-op. Admin-only.
+  // See #680.
+  rpc WithdrawCapacity(WithdrawCapacityRequest) returns (WithdrawCapacityResponse) {
+    option (google.api.http) = {
+      delete: "/v1/capacity/headroom"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Withdraw spare scheduling capacity";
+      description: "Withdraws this backend's headroom advertisement. Idempotent — succeeds even when nothing is currently advertised. Admin-only.";
+      tags: "System";
+    };
+  }
+
+  // GetCapacityHeadroom reads this backend's current advertisement and the
+  // freshly recomputed spare figures without changing advertise/withdraw
+  // state. Admin-only. See #680.
+  rpc GetCapacityHeadroom(GetCapacityHeadroomRequest) returns (GetCapacityHeadroomResponse) {
+    option (google.api.http) = {
+      get: "/v1/capacity/headroom"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get spare scheduling capacity";
+      description: "Returns this backend's current headroom advertisement and recomputed spare figures. Admin-only.";
+      tags: "System";
+    };
+  }
+
   // GetLatestRelease reports the latest Containarium release on GitHub vs the
   // running version, so operators see "update available" without SSHing in.
   // The GitHub lookup is cached server-side (1h) to spare the rate limit. #354.

--- a/test/fixtures/tier2-l4-lifecycle/main.go
+++ b/test/fixtures/tier2-l4-lifecycle/main.go
@@ -70,7 +70,10 @@ func main() {
 	}
 
 	log.Println("step 6: print full L4 server config")
-	resp, _ := http.Get(*adminURL + "/config/apps/layer4/servers/tls_passthrough")
+	resp, err := http.Get(*adminURL + "/config/apps/layer4/servers/tls_passthrough")
+	if err != nil {
+		log.Fatalf("get layer4 config: %v", err)
+	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	var pretty map[string]interface{}


### PR DESCRIPTION
## Summary

First-pass implementation of four generic multi-backend capacity/integrity primitives (workflow-generated; **review-required first draft**):

- **#680** — advertise/withdraw a backend's spare scheduling headroom to the control plane (`internal/capacity`), driven by a host-level idle signal; reuses the `SystemInfo` available-memory/disk already reported.
- **#681** — backend capability profile + lightweight CPU/RAM micro-benchmark recorded at join (`internal/capabilities`, `pkg/core/container/benchmark.go`); generalizes `ValidateGPU`.
- **#682** — bounded graceful drain when advertised headroom is withdrawn (`internal/capacity/drain.go`), reusing `StopContainer` + `move_container`.
- **#683** — daemon emits a signed self-measurement (daemon binary + eBPF + policy hashes) on a heartbeat for control-plane integrity verification (`internal/integrity`); reuses the peer identity/cert plumbing.

## Verification

`go build ./...` clean; `go vet ./...` clean (one pre-existing fixture diagnostic fixed); the new packages `internal/{capacity,capabilities,integrity}` + `pkg/core/container` pass `go test -count=1`. The only red in `go test ./...` is the pre-existing `test/integration` live-daemon suite (dials `:50051`, connection refused in CI) — environmental, untouched by this branch.

## Known follow-ups (flagged by the implementing agents)

- Aggregate peer headroom + capability profiles in the `ListBackends` fan-out (currently local-backend only).
- Auto-record the capability profile at actual peer-join time (hook discovery), not only on explicit profile.
- Live-validate the drain path on a real backend (advertise → run guest → withdraw `--drain` → confirm graceful stop + force-stop on window expiry).
- Gate `test/integration` behind a build tag / live-daemon precondition so unit runs are unambiguously green (pre-existing).
- TPM-backed signing is currently a hook (software-signed); wire a TPM signer when support lands.

Refs #680 #681 #682 #683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
