### PR TITLE
feat(byoc): OSS host→cloud enrollment + status report path (#528 companion)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -121,6 +121,40 @@
         ]
       }
     },
+    "/v1/actuation/enroll": {
+      "post": {
+        "summary": "EnrollHost redeems a single-use join token and registers the BYO host.\nSelf-authenticating via the token in the body (NOT host-bearer — the row\ndoesn't exist yet).",
+        "operationId": "ActuationService_EnrollHost",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/EnrollHostResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "EnrollHostRequest carries the single-use join token a BYO host redeems to\nregister itself with the cloud (BYO-compute report path). Unlike every other\nActuationService RPC this one is NOT host-bearer authed — the host row\ndoesn't exist yet; the cloud validates + single-use-redeems the token.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EnrollHostRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ActuationService"
+        ]
+      }
+    },
     "/v1/actuation/heartbeat": {
       "post": {
         "summary": "Heartbeat updates hosts.last_heartbeat_at for the calling host.\nA stale gap (\u003e2 × the host's expected interval) marks the host\nfor the HostSweeper, which reassigns its containers. Hosts are\nexpected to call this every N seconds with N \u003c\u003c the staleness\nthreshold.",
@@ -148,6 +182,40 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/HeartbeatRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ActuationService"
+        ]
+      }
+    },
+    "/v1/actuation/status": {
+      "post": {
+        "summary": "ReportHostStatus upserts the calling host's capability profile +\n`doctor` self-check and bumps its heartbeat. Requires a valid\n`host-bearer` header. Idempotent.",
+        "operationId": "ActuationService_ReportHostStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/ReportHostStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "ReportHostStatusRequest is a BYO host's push of its self-measured\ncapability profile + `doctor` self-check. Host-bearer authed; the host id\ncomes from the bearer, never the body.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReportHostStatusRequest"
             }
           }
         ],
@@ -7617,6 +7685,25 @@
         }
       }
     },
+    "EnrollHostRequest": {
+      "type": "object",
+      "properties": {
+        "joinToken": {
+          "type": "string",
+          "description": "The join token, format \"\u003chost_id\u003e.\u003csecret\u003e\", from the cloud's\n`pool join` / `cloud enroll` one-liner."
+        }
+      },
+      "description": "EnrollHostRequest carries the single-use join token a BYO host redeems to\nregister itself with the cloud (BYO-compute report path). Unlike every other\nActuationService RPC this one is NOT host-bearer authed — the host row\ndoesn't exist yet; the cloud validates + single-use-redeems the token."
+    },
+    "EnrollHostResponse": {
+      "type": "object",
+      "properties": {
+        "hostId": {
+          "type": "string",
+          "description": "The enrolled host's id. The host keeps using its join token as its\ndurable host-bearer for Heartbeat / ReportHostStatus."
+        }
+      }
+    },
     "Event": {
       "type": "object",
       "properties": {
@@ -8368,6 +8455,21 @@
         }
       },
       "title": "HistoricalConnection represents a persisted connection record"
+    },
+    "HostCapabilityCheck": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "ok": {
+          "type": "boolean"
+        },
+        "detail": {
+          "type": "string"
+        }
+      },
+      "description": "HostCapabilityCheck is one line of the `doctor` self-check: a named probe\nwith a pass/fail + human-readable detail. Defined locally here (same field\nnumbers as the cloud's host.proto message) so the vendored actuation proto\nstays self-contained — wire-compatible without vendoring host.proto."
     },
     "InstallPentestToolRequest": {
       "type": "object",
@@ -9863,6 +9965,65 @@
           "type": "string",
           "format": "date-time",
           "description": "Server time when the report was recorded."
+        }
+      }
+    },
+    "ReportHostStatusRequest": {
+      "type": "object",
+      "properties": {
+        "agentVersion": {
+          "type": "string"
+        },
+        "cpuCores": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "totalRamMb": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "totalDiskGb": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "totalGpuCount": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "gpuSpec": {
+          "type": "string"
+        },
+        "availRamMb": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "availDiskGb": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "availGpuCount": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "selfCheckOk": {
+          "type": "boolean"
+        },
+        "checks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/HostCapabilityCheck"
+          }
+        }
+      },
+      "description": "ReportHostStatusRequest is a BYO host's push of its self-measured\ncapability profile + `doctor` self-check. Host-bearer authed; the host id\ncomes from the bearer, never the body."
+    },
+    "ReportHostStatusResponse": {
+      "type": "object",
+      "properties": {
+        "receivedAt": {
+          "type": "string",
+          "format": "date-time"
         }
       }
     },

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -76,12 +76,48 @@ type ContainerActuator interface {
 	EnsureDeleted(ctx context.Context, localName string) error
 }
 
-// Deps are the daemon-provided collaborators. Both are optional: nil Policies
-// skips network-policy sync, nil Containers skips container reconcile. With both
-// nil the client is heartbeat-only.
+// HostCheck is one line of the host's `doctor` self-check — mirrors the
+// proto HostCapabilityCheck so callers (the daemon's probe) don't depend on
+// generated types.
+type HostCheck struct {
+	Name   string
+	OK     bool
+	Detail string
+}
+
+// HostStatus is the host's self-measured capability profile + `doctor`
+// self-check, reported to the cloud so the BYO fleet view goes live.
+type HostStatus struct {
+	AgentVersion  string
+	CPUCores      int32
+	TotalRAMMB    int32
+	TotalDiskGB   int32
+	TotalGPUCount int32
+	GPUSpec       string
+	// Spare headroom — currently-available, self-measured.
+	AvailRAMMB    int32
+	AvailDiskGB   int32
+	AvailGPUCount int32
+	SelfCheckOK   bool
+	Checks        []HostCheck
+}
+
+// StatusProbe gathers the host's current capability profile + self-check.
+// The daemon implements it (hardware introspection + `containarium doctor`);
+// the interface keeps internal/cloud free of those deps and lets the report
+// loop be tested with a fake.
+type StatusProbe interface {
+	Probe(ctx context.Context) (HostStatus, error)
+}
+
+// Deps are the daemon-provided collaborators. All optional: nil Policies
+// skips network-policy sync, nil Containers skips container reconcile, nil
+// Status skips capability reporting. With all nil the client is
+// heartbeat-only.
 type Deps struct {
 	Policies   PolicySink
 	Containers ContainerActuator
+	Status     StatusProbe
 }
 
 // Client is the host-side cloud-actuation client. Slice 3 implements the
@@ -94,6 +130,8 @@ type Client struct {
 	interval   time.Duration
 	sink       PolicySink        // optional; nil = no policy reconcile
 	containers ContainerActuator // optional; nil = no container reconcile
+
+	status StatusProbe // optional; nil = no capability reporting
 
 	conn *grpc.ClientConn
 	ac   cloudv1.ActuationServiceClient
@@ -112,7 +150,7 @@ func New(cfg *Config, deps Deps) (*Client, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
-	return &Client{cfg: cfg, interval: defaultHeartbeatInterval, sink: deps.Policies, containers: deps.Containers}, nil
+	return &Client{cfg: cfg, interval: defaultHeartbeatInterval, sink: deps.Policies, containers: deps.Containers, status: deps.Status}, nil
 }
 
 // Start dials the control plane and launches the heartbeat loop. A dial error is
@@ -134,8 +172,12 @@ func (c *Client) Start(ctx context.Context) error {
 		c.wg.Add(1)
 		go c.watchLoop()
 	}
-	log.Printf("[cloud] actuation client started: host=%s control-plane=%s (heartbeat %s, watch=%v)",
-		c.cfg.HostID, c.cfg.ControlPlane, c.interval, watch)
+	if c.status != nil {
+		c.wg.Add(1)
+		go c.statusLoop()
+	}
+	log.Printf("[cloud] actuation client started: host=%s control-plane=%s (heartbeat %s, watch=%v, status=%v)",
+		c.cfg.HostID, c.cfg.ControlPlane, c.interval, watch, c.status != nil)
 	return nil
 }
 
@@ -151,13 +193,88 @@ func (c *Client) Stop() {
 }
 
 func (c *Client) dial() (*grpc.ClientConn, error) {
+	return dialControlPlane(c.cfg.ControlPlane, c.cfg.Insecure)
+}
+
+// dialControlPlane builds a gRPC client connection to the control plane.
+// Shared by the running Client and the one-shot Enroll helper.
+func dialControlPlane(addr string, insecureTLS bool) (*grpc.ClientConn, error) {
 	var creds credentials.TransportCredentials
-	if c.cfg.Insecure {
+	if insecureTLS {
 		creds = insecure.NewCredentials()
 	} else {
 		creds = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
 	}
-	return grpc.NewClient(c.cfg.ControlPlane, grpc.WithTransportCredentials(creds))
+	return grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
+}
+
+// Enroll redeems a single-use join token against the control plane and returns
+// the registered host id. One-shot (no running client / host bearer yet — the
+// token authenticates itself in the body). Used by `containarium cloud enroll`
+// for the BYO self-service flow; after this, the same token is the host's
+// durable bearer (the cloud reuses the token secret as the host bearer).
+func Enroll(ctx context.Context, controlPlane, joinToken string, insecureTLS bool) (string, error) {
+	conn, err := dialControlPlane(controlPlane, insecureTLS)
+	if err != nil {
+		return "", fmt.Errorf("cloud: dial control plane %s: %w", controlPlane, err)
+	}
+	defer func() { _ = conn.Close() }()
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	resp, err := cloudv1.NewActuationServiceClient(conn).EnrollHost(ctx, &cloudv1.EnrollHostRequest{
+		JoinToken: joinToken,
+	})
+	if err != nil {
+		return "", fmt.Errorf("cloud: enroll: %w", err)
+	}
+	return resp.GetHostId(), nil
+}
+
+// statusLoop reports the host's capability profile + self-check on the same
+// cadence as the heartbeat. Best-effort: a failed probe or RPC is logged and
+// retried next tick — capability staleness must never crash the daemon.
+func (c *Client) statusLoop() {
+	defer c.wg.Done()
+	t := time.NewTicker(c.interval)
+	defer t.Stop()
+	c.reportStatusOnce() // immediate first report so the fleet row goes live fast
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-t.C:
+			c.reportStatusOnce()
+		}
+	}
+}
+
+func (c *Client) reportStatusOnce() {
+	st, err := c.status.Probe(c.ctx)
+	if err != nil {
+		log.Printf("[cloud] status probe failed: %v", err)
+		return
+	}
+	checks := make([]*cloudv1.HostCapabilityCheck, 0, len(st.Checks))
+	for _, ck := range st.Checks {
+		checks = append(checks, &cloudv1.HostCapabilityCheck{Name: ck.Name, Ok: ck.OK, Detail: ck.Detail})
+	}
+	ctx, cancel := context.WithTimeout(c.authContext(c.ctx), 10*time.Second)
+	defer cancel()
+	if _, err := c.ac.ReportHostStatus(ctx, &cloudv1.ReportHostStatusRequest{
+		AgentVersion:  st.AgentVersion,
+		CpuCores:      st.CPUCores,
+		TotalRamMb:    st.TotalRAMMB,
+		TotalDiskGb:   st.TotalDiskGB,
+		TotalGpuCount: st.TotalGPUCount,
+		GpuSpec:       st.GPUSpec,
+		AvailRamMb:    st.AvailRAMMB,
+		AvailDiskGb:   st.AvailDiskGB,
+		AvailGpuCount: st.AvailGPUCount,
+		SelfCheckOk:   st.SelfCheckOK,
+		Checks:        checks,
+	}); err != nil {
+		log.Printf("[cloud] report host status: %v", err)
+	}
 }
 
 func (c *Client) heartbeatLoop() {

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -22,6 +22,48 @@ type fakeActuation struct {
 	beats         int
 	reportedID    string
 	reportedState string
+	enrollToken   string
+	enrollHostID  string
+	statusBearer  string
+	statusReq     *cloudv1.ReportHostStatusRequest
+	statusReports int
+}
+
+// EnrollHost echoes back the host id embedded in the join token (first
+// dotted segment) so the client's Enroll returns it.
+func (f *fakeActuation) EnrollHost(_ context.Context, req *cloudv1.EnrollHostRequest) (*cloudv1.EnrollHostResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.enrollToken = req.GetJoinToken()
+	id := req.GetJoinToken()
+	if i := indexByte(id, '.'); i >= 0 {
+		id = id[:i]
+	}
+	f.enrollHostID = id
+	return &cloudv1.EnrollHostResponse{HostId: id}, nil
+}
+
+// ReportHostStatus records the capability report + the bearer it arrived with.
+func (f *fakeActuation) ReportHostStatus(ctx context.Context, req *cloudv1.ReportHostStatusRequest) (*cloudv1.ReportHostStatusResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statusReports++
+	f.statusReq = req
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if v := md.Get(hostBearerMetadataKey); len(v) > 0 {
+			f.statusBearer = v[0]
+		}
+	}
+	return &cloudv1.ReportHostStatusResponse{}, nil
+}
+
+func indexByte(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
 }
 
 func (f *fakeActuation) Heartbeat(ctx context.Context, _ *cloudv1.HeartbeatRequest) (*cloudv1.HeartbeatResponse, error) {
@@ -238,5 +280,85 @@ func TestLocalContainerName(t *testing.T) {
 		if got := localContainerName(in); got != want {
 			t.Errorf("localContainerName(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+// fakeProbe is a canned StatusProbe for the report-loop test.
+type fakeProbe struct{ st HostStatus }
+
+func (p fakeProbe) Probe(context.Context) (HostStatus, error) { return p.st, nil }
+
+func TestReportStatusOnce_SendsCapabilityWithBearer(t *testing.T) {
+	c, fake := newTestClient(t, &Config{
+		ControlPlane: "bufnet", HostID: "h1", Token: "h1.secret", Insecure: true,
+	})
+	c.status = fakeProbe{st: HostStatus{
+		AgentVersion: "v0.29.0", CPUCores: 8, TotalRAMMB: 32768, AvailRAMMB: 30000,
+		SelfCheckOK: false,
+		Checks:      []HostCheck{{Name: "useradd", OK: false, Detail: "blocked"}},
+	}}
+
+	c.reportStatusOnce()
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.statusReports != 1 {
+		t.Fatalf("want 1 status report, got %d", fake.statusReports)
+	}
+	if fake.statusBearer != "h1.secret" {
+		t.Errorf("status report missing host bearer: got %q", fake.statusBearer)
+	}
+	req := fake.statusReq
+	if req.GetAgentVersion() != "v0.29.0" || req.GetCpuCores() != 8 || req.GetTotalRamMb() != 32768 {
+		t.Errorf("capability fields not mapped: %+v", req)
+	}
+	if req.GetSelfCheckOk() {
+		t.Error("self_check_ok should be false")
+	}
+	if len(req.GetChecks()) != 1 || req.GetChecks()[0].GetName() != "useradd" || req.GetChecks()[0].GetOk() {
+		t.Errorf("self-check breakdown not mapped: %+v", req.GetChecks())
+	}
+}
+
+func TestEnroll_RedeemsTokenAndReturnsHostID(t *testing.T) {
+	// Enroll dials its own connection, so use a real loopback TCP server
+	// (bufconn isn't reachable by grpc.NewClient(addr)).
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	fake := &fakeActuation{}
+	cloudv1.RegisterActuationServiceServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	hostID, err := Enroll(context.Background(), lis.Addr().String(), "host-uuid.secret", true)
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if hostID != "host-uuid" {
+		t.Errorf("want host id host-uuid, got %q", hostID)
+	}
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.enrollToken != "host-uuid.secret" {
+		t.Errorf("server saw token %q", fake.enrollToken)
+	}
+}
+
+func TestDefaultStatusProbe_ReportsVersionAndCPU(t *testing.T) {
+	st, err := DefaultStatusProbe{}.Probe(context.Background())
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if st.AgentVersion == "" {
+		t.Error("agent version should be set")
+	}
+	if st.CPUCores <= 0 {
+		t.Errorf("cpu cores should be positive, got %d", st.CPUCores)
+	}
+	if !st.SelfCheckOK {
+		t.Error("default probe reports self_check_ok=true until doctor integration lands")
 	}
 }

--- a/internal/cloud/probe.go
+++ b/internal/cloud/probe.go
@@ -1,0 +1,77 @@
+package cloud
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/footprintai/containarium/internal/safecast"
+	"github.com/footprintai/containarium/pkg/version"
+)
+
+// DefaultStatusProbe is the daemon's host-capability probe: it self-measures
+// hardware (CPU cores, total + available RAM) and reports the running agent
+// version. It satisfies StatusProbe so the actuation client's status loop can
+// push it to the cloud, making the BYO fleet view show real specs + headroom.
+//
+// NOTE: the `doctor` capability self-check (the DEGRADED signal — running-as-
+// root / caps / useradd probe) is NOT yet reported here. Those checks live in
+// internal/cmd/doctor.go and can't be imported from the daemon layer without a
+// shared-package extraction; that's a fast follow-up. Until then the probe
+// reports SelfCheckOK=true with no checks, so a reporting host shows CONNECTED
+// with its hardware. Disk + GPU are likewise left for a follow-up (0 = not
+// reported), since they need Incus/storage introspection.
+type DefaultStatusProbe struct{}
+
+// Probe gathers the current capability snapshot. Best-effort: a field it can't
+// measure on this platform is reported as zero rather than failing the whole
+// report (the cloud treats zero as "not reported").
+func (DefaultStatusProbe) Probe(_ context.Context) (HostStatus, error) {
+	total, avail := readMemInfoMB()
+	return HostStatus{
+		AgentVersion: version.GetVersion(),
+		CPUCores:     safecast.I32(runtime.NumCPU()),
+		TotalRAMMB:   total,
+		AvailRAMMB:   avail,
+		SelfCheckOK:  true, // doctor self-check reporting is a follow-up
+	}, nil
+}
+
+// readMemInfoMB reads MemTotal + MemAvailable from /proc/meminfo (Linux) and
+// returns them in MB. Returns (0, 0) on any non-Linux / unreadable host — the
+// report still goes out, just without RAM numbers.
+func readMemInfoMB() (total, avail int32) {
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return 0, 0
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case strings.HasPrefix(line, "MemTotal:"):
+			total = kbFieldToMB(line)
+		case strings.HasPrefix(line, "MemAvailable:"):
+			avail = kbFieldToMB(line)
+		}
+	}
+	return total, avail
+}
+
+// kbFieldToMB parses a "/proc/meminfo" line like "MemTotal:  32791234 kB" and
+// returns the value in MB (0 on parse failure).
+func kbFieldToMB(line string) int32 {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return 0
+	}
+	kb, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return safecast.I32(int(kb / 1024))
+}

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -49,6 +49,27 @@ history. Writes the enrollment to ~/.containarium/cloud.yaml at mode 0600.`,
 	RunE: runCloudLogin,
 }
 
+var (
+	cloudEnrollControlPlane string
+	cloudEnrollTokenFile    string
+	cloudEnrollInsecure     bool
+)
+
+var cloudEnrollCmd = &cobra.Command{
+	Use:   "enroll",
+	Short: "Self-register this host with a single-use join token (BYO compute)",
+	Long: `Redeem a single-use join token to register this host with a cloud control
+plane, then write ~/.containarium/cloud.yaml.
+
+Unlike 'cloud login' (which takes a sysadmin-issued host-id + token out of
+band), 'cloud enroll' is the self-service BYO flow: the token from the cloud's
+"Add compute" one-liner is redeemed against the control plane (EnrollHost),
+which returns the host id and registers the host. The same token becomes this
+host's durable bearer. The token is read from --token-file so it never lands
+in shell history.`,
+	RunE: runCloudEnroll,
+}
+
 var cloudStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show this host's cloud enrollment",
@@ -66,7 +87,7 @@ restart. The cloud-side host row stays until a sysadmin tombstones it
 
 func init() {
 	rootCmd.AddCommand(cloudCmd)
-	cloudCmd.AddCommand(cloudLoginCmd, cloudStatusCmd, cloudLogoutCmd)
+	cloudCmd.AddCommand(cloudLoginCmd, cloudEnrollCmd, cloudStatusCmd, cloudLogoutCmd)
 
 	cloudLoginCmd.Flags().StringVar(&cloudControlPlane, "control-plane", "", "cloud control-plane gRPC address (host:port) (required)")
 	cloudLoginCmd.Flags().StringVar(&cloudHostID, "host-id", "", "cloud-assigned host UUID from the sysadmin (required)")
@@ -74,6 +95,12 @@ func init() {
 	_ = cloudLoginCmd.MarkFlagRequired("control-plane")
 	_ = cloudLoginCmd.MarkFlagRequired("host-id")
 	_ = cloudLoginCmd.MarkFlagRequired("token-file")
+
+	cloudEnrollCmd.Flags().StringVar(&cloudEnrollControlPlane, "control-plane", "", "cloud control-plane gRPC address (host:port) (required)")
+	cloudEnrollCmd.Flags().StringVar(&cloudEnrollTokenFile, "token-file", "", "file containing the single-use join token (required)")
+	cloudEnrollCmd.Flags().BoolVar(&cloudEnrollInsecure, "insecure", false, "dial the control plane without TLS (local dev only)")
+	_ = cloudEnrollCmd.MarkFlagRequired("control-plane")
+	_ = cloudEnrollCmd.MarkFlagRequired("token-file")
 }
 
 func runCloudLogin(cmd *cobra.Command, _ []string) error {
@@ -102,6 +129,45 @@ func runCloudLogin(cmd *cobra.Command, _ []string) error {
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "✓ enrolled host %s with %s\n  config: %s (restart the daemon to start actuating)\n",
 		cfg.HostID, cfg.ControlPlane, path)
+	return nil
+}
+
+func runCloudEnroll(cmd *cobra.Command, _ []string) error {
+	tokenBytes, err := os.ReadFile(cloudEnrollTokenFile) // #nosec G304 -- operator-provided token path
+	if err != nil {
+		return fmt.Errorf("read --token-file: %w", err)
+	}
+	token := strings.TrimSpace(string(tokenBytes))
+	if token == "" {
+		return fmt.Errorf("--token-file %q is empty", cloudEnrollTokenFile)
+	}
+	controlPlane := strings.TrimSpace(cloudEnrollControlPlane)
+
+	// Redeem the join token against the control plane. On success the cloud
+	// has created the host row and returns its id; the same token is now this
+	// host's durable bearer (the cloud reuses the token secret).
+	hostID, err := cloud.Enroll(cmd.Context(), controlPlane, token, cloudEnrollInsecure)
+	if err != nil {
+		return err
+	}
+	cfg := &cloud.Config{
+		ControlPlane: controlPlane,
+		HostID:       hostID,
+		Token:        token,
+		Insecure:     cloudEnrollInsecure,
+	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	path, err := cloud.DefaultPath()
+	if err != nil {
+		return err
+	}
+	if err := cloud.Save(path, cfg); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "✓ enrolled host %s with %s\n  config: %s (restart the daemon to start actuating + reporting)\n",
+		hostID, controlPlane, path)
 	return nil
 }
 

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -902,7 +902,12 @@ skipAppHosting:
 	if cloudCfg, cerr := cloud.Load(cloudCfgPath); cerr != nil {
 		log.Printf("Warning: failed to read cloud-actuation config %s: %v (running single-tenant)", cloudCfgPath, cerr)
 	} else if cloudCfg != nil {
-		cloudDeps := cloud.Deps{Policies: newCloudPolicySink(npServer)}
+		cloudDeps := cloud.Deps{
+			Policies: newCloudPolicySink(npServer),
+			// Report this host's capability profile (hardware + headroom +
+			// version) so the BYO fleet view goes live (#528).
+			Status: cloud.DefaultStatusProbe{},
+		}
 		if cloudActuator, actErr := newCloudContainerActuator(routeStore); actErr != nil {
 			log.Printf("Warning: cloud container actuator unavailable (%v); policy sync only", actErr)
 		} else {

--- a/pkg/pb/containarium/cloud/v1/actuation_service.pb.go
+++ b/pkg/pb/containarium/cloud/v1/actuation_service.pb.go
@@ -763,6 +763,337 @@ func (x *AssignmentBatch) GetNetworkPolicies() []*NetworkPolicy {
 	return nil
 }
 
+// EnrollHostRequest carries the single-use join token a BYO host redeems to
+// register itself with the cloud (BYO-compute report path). Unlike every other
+// ActuationService RPC this one is NOT host-bearer authed — the host row
+// doesn't exist yet; the cloud validates + single-use-redeems the token.
+type EnrollHostRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The join token, format "<host_id>.<secret>", from the cloud's
+	// `pool join` / `cloud enroll` one-liner.
+	JoinToken     string `protobuf:"bytes,1,opt,name=join_token,json=joinToken,proto3" json:"join_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnrollHostRequest) Reset() {
+	*x = EnrollHostRequest{}
+	mi := &file_containarium_cloud_v1_actuation_service_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnrollHostRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnrollHostRequest) ProtoMessage() {}
+
+func (x *EnrollHostRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_cloud_v1_actuation_service_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnrollHostRequest.ProtoReflect.Descriptor instead.
+func (*EnrollHostRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_cloud_v1_actuation_service_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *EnrollHostRequest) GetJoinToken() string {
+	if x != nil {
+		return x.JoinToken
+	}
+	return ""
+}
+
+type EnrollHostResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The enrolled host's id. The host keeps using its join token as its
+	// durable host-bearer for Heartbeat / ReportHostStatus.
+	HostId        string `protobuf:"bytes,1,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnrollHostResponse) Reset() {
+	*x = EnrollHostResponse{}
+	mi := &file_containarium_cloud_v1_actuation_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnrollHostResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnrollHostResponse) ProtoMessage() {}
+
+func (x *EnrollHostResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_cloud_v1_actuation_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnrollHostResponse.ProtoReflect.Descriptor instead.
+func (*EnrollHostResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_cloud_v1_actuation_service_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *EnrollHostResponse) GetHostId() string {
+	if x != nil {
+		return x.HostId
+	}
+	return ""
+}
+
+// HostCapabilityCheck is one line of the `doctor` self-check: a named probe
+// with a pass/fail + human-readable detail. Defined locally here (same field
+// numbers as the cloud's host.proto message) so the vendored actuation proto
+// stays self-contained — wire-compatible without vendoring host.proto.
+type HostCapabilityCheck struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Ok            bool                   `protobuf:"varint,2,opt,name=ok,proto3" json:"ok,omitempty"`
+	Detail        string                 `protobuf:"bytes,3,opt,name=detail,proto3" json:"detail,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HostCapabilityCheck) Reset() {
+	*x = HostCapabilityCheck{}
+	mi := &file_containarium_cloud_v1_actuation_service_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HostCapabilityCheck) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HostCapabilityCheck) ProtoMessage() {}
+
+func (x *HostCapabilityCheck) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_cloud_v1_actuation_service_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HostCapabilityCheck.ProtoReflect.Descriptor instead.
+func (*HostCapabilityCheck) Descriptor() ([]byte, []int) {
+	return file_containarium_cloud_v1_actuation_service_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *HostCapabilityCheck) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *HostCapabilityCheck) GetOk() bool {
+	if x != nil {
+		return x.Ok
+	}
+	return false
+}
+
+func (x *HostCapabilityCheck) GetDetail() string {
+	if x != nil {
+		return x.Detail
+	}
+	return ""
+}
+
+// ReportHostStatusRequest is a BYO host's push of its self-measured
+// capability profile + `doctor` self-check. Host-bearer authed; the host id
+// comes from the bearer, never the body.
+type ReportHostStatusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AgentVersion  string                 `protobuf:"bytes,1,opt,name=agent_version,json=agentVersion,proto3" json:"agent_version,omitempty"`
+	CpuCores      int32                  `protobuf:"varint,2,opt,name=cpu_cores,json=cpuCores,proto3" json:"cpu_cores,omitempty"`
+	TotalRamMb    int32                  `protobuf:"varint,3,opt,name=total_ram_mb,json=totalRamMb,proto3" json:"total_ram_mb,omitempty"`
+	TotalDiskGb   int32                  `protobuf:"varint,4,opt,name=total_disk_gb,json=totalDiskGb,proto3" json:"total_disk_gb,omitempty"`
+	TotalGpuCount int32                  `protobuf:"varint,5,opt,name=total_gpu_count,json=totalGpuCount,proto3" json:"total_gpu_count,omitempty"`
+	GpuSpec       string                 `protobuf:"bytes,6,opt,name=gpu_spec,json=gpuSpec,proto3" json:"gpu_spec,omitempty"`
+	AvailRamMb    int32                  `protobuf:"varint,7,opt,name=avail_ram_mb,json=availRamMb,proto3" json:"avail_ram_mb,omitempty"`
+	AvailDiskGb   int32                  `protobuf:"varint,8,opt,name=avail_disk_gb,json=availDiskGb,proto3" json:"avail_disk_gb,omitempty"`
+	AvailGpuCount int32                  `protobuf:"varint,9,opt,name=avail_gpu_count,json=availGpuCount,proto3" json:"avail_gpu_count,omitempty"`
+	SelfCheckOk   bool                   `protobuf:"varint,10,opt,name=self_check_ok,json=selfCheckOk,proto3" json:"self_check_ok,omitempty"`
+	Checks        []*HostCapabilityCheck `protobuf:"bytes,11,rep,name=checks,proto3" json:"checks,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReportHostStatusRequest) Reset() {
+	*x = ReportHostStatusRequest{}
+	mi := &file_containarium_cloud_v1_actuation_service_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReportHostStatusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReportHostStatusRequest) ProtoMessage() {}
+
+func (x *ReportHostStatusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_cloud_v1_actuation_service_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReportHostStatusRequest.ProtoReflect.Descriptor instead.
+func (*ReportHostStatusRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_cloud_v1_actuation_service_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ReportHostStatusRequest) GetAgentVersion() string {
+	if x != nil {
+		return x.AgentVersion
+	}
+	return ""
+}
+
+func (x *ReportHostStatusRequest) GetCpuCores() int32 {
+	if x != nil {
+		return x.CpuCores
+	}
+	return 0
+}
+
+func (x *ReportHostStatusRequest) GetTotalRamMb() int32 {
+	if x != nil {
+		return x.TotalRamMb
+	}
+	return 0
+}
+
+func (x *ReportHostStatusRequest) GetTotalDiskGb() int32 {
+	if x != nil {
+		return x.TotalDiskGb
+	}
+	return 0
+}
+
+func (x *ReportHostStatusRequest) GetTotalGpuCount() int32 {
+	if x != nil {
+		return x.TotalGpuCount
+	}
+	return 0
+}
+
+func (x *ReportHostStatusRequest) GetGpuSpec() string {
+	if x != nil {
+		return x.GpuSpec
+	}
+	return ""
+}
+
+func (x *ReportHostStatusRequest) GetAvailRamMb() int32 {
+	if x != nil {
+		return x.AvailRamMb
+	}
+	return 0
+}
+
+func (x *ReportHostStatusRequest) GetAvailDiskGb() int32 {
+	if x != nil {
+		return x.AvailDiskGb
+	}
+	return 0
+}
+
+func (x *ReportHostStatusRequest) GetAvailGpuCount() int32 {
+	if x != nil {
+		return x.AvailGpuCount
+	}
+	return 0
+}
+
+func (x *ReportHostStatusRequest) GetSelfCheckOk() bool {
+	if x != nil {
+		return x.SelfCheckOk
+	}
+	return false
+}
+
+func (x *ReportHostStatusRequest) GetChecks() []*HostCapabilityCheck {
+	if x != nil {
+		return x.Checks
+	}
+	return nil
+}
+
+type ReportHostStatusResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ReceivedAt    *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=received_at,json=receivedAt,proto3" json:"received_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReportHostStatusResponse) Reset() {
+	*x = ReportHostStatusResponse{}
+	mi := &file_containarium_cloud_v1_actuation_service_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReportHostStatusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReportHostStatusResponse) ProtoMessage() {}
+
+func (x *ReportHostStatusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_cloud_v1_actuation_service_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReportHostStatusResponse.ProtoReflect.Descriptor instead.
+func (*ReportHostStatusResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_cloud_v1_actuation_service_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *ReportHostStatusResponse) GetReceivedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ReceivedAt
+	}
+	return nil
+}
+
 var File_containarium_cloud_v1_actuation_service_proto protoreflect.FileDescriptor
 
 const file_containarium_cloud_v1_actuation_service_proto_rawDesc = "" +
@@ -817,12 +1148,42 @@ const file_containarium_cloud_v1_actuation_service_proto_rawDesc = "" +
 	"\x0fAssignmentBatch\x12C\n" +
 	"\vassignments\x18\x01 \x03(\v2!.containarium.cloud.v1.AssignmentR\vassignments\x12=\n" +
 	"\fgenerated_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vgeneratedAt\x12O\n" +
-	"\x10network_policies\x18\x03 \x03(\v2$.containarium.cloud.v1.NetworkPolicyR\x0fnetworkPolicies*{\n" +
+	"\x10network_policies\x18\x03 \x03(\v2$.containarium.cloud.v1.NetworkPolicyR\x0fnetworkPolicies\"2\n" +
+	"\x11EnrollHostRequest\x12\x1d\n" +
+	"\n" +
+	"join_token\x18\x01 \x01(\tR\tjoinToken\"-\n" +
+	"\x12EnrollHostResponse\x12\x17\n" +
+	"\ahost_id\x18\x01 \x01(\tR\x06hostId\"Q\n" +
+	"\x13HostCapabilityCheck\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
+	"\x02ok\x18\x02 \x01(\bR\x02ok\x12\x16\n" +
+	"\x06detail\x18\x03 \x01(\tR\x06detail\"\xba\x03\n" +
+	"\x17ReportHostStatusRequest\x12#\n" +
+	"\ragent_version\x18\x01 \x01(\tR\fagentVersion\x12\x1b\n" +
+	"\tcpu_cores\x18\x02 \x01(\x05R\bcpuCores\x12 \n" +
+	"\ftotal_ram_mb\x18\x03 \x01(\x05R\n" +
+	"totalRamMb\x12\"\n" +
+	"\rtotal_disk_gb\x18\x04 \x01(\x05R\vtotalDiskGb\x12&\n" +
+	"\x0ftotal_gpu_count\x18\x05 \x01(\x05R\rtotalGpuCount\x12\x19\n" +
+	"\bgpu_spec\x18\x06 \x01(\tR\agpuSpec\x12 \n" +
+	"\favail_ram_mb\x18\a \x01(\x05R\n" +
+	"availRamMb\x12\"\n" +
+	"\ravail_disk_gb\x18\b \x01(\x05R\vavailDiskGb\x12&\n" +
+	"\x0favail_gpu_count\x18\t \x01(\x05R\ravailGpuCount\x12\"\n" +
+	"\rself_check_ok\x18\n" +
+	" \x01(\bR\vselfCheckOk\x12B\n" +
+	"\x06checks\x18\v \x03(\v2*.containarium.cloud.v1.HostCapabilityCheckR\x06checks\"W\n" +
+	"\x18ReportHostStatusResponse\x12;\n" +
+	"\vreceived_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"receivedAt*{\n" +
 	"\x11NetworkPolicyMode\x12#\n" +
 	"\x1fNETWORK_POLICY_MODE_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cNETWORK_POLICY_MODE_LOG_ONLY\x10\x01\x12\x1f\n" +
-	"\x1bNETWORK_POLICY_MODE_ENFORCE\x10\x022\xc1\x03\n" +
+	"\x1bNETWORK_POLICY_MODE_ENFORCE\x10\x022\xdd\x05\n" +
 	"\x10ActuationService\x12\x82\x01\n" +
+	"\n" +
+	"EnrollHost\x12(.containarium.cloud.v1.EnrollHostRequest\x1a).containarium.cloud.v1.EnrollHostResponse\"\x1f\x82\xd3\xe4\x93\x02\x19:\x01*\"\x14/v1/actuation/enroll\x12\x94\x01\n" +
+	"\x10ReportHostStatus\x12..containarium.cloud.v1.ReportHostStatusRequest\x1a/.containarium.cloud.v1.ReportHostStatusResponse\"\x1f\x82\xd3\xe4\x93\x02\x19:\x01*\"\x14/v1/actuation/status\x12\x82\x01\n" +
 	"\tHeartbeat\x12'.containarium.cloud.v1.HeartbeatRequest\x1a(.containarium.cloud.v1.HeartbeatResponse\"\"\x82\xd3\xe4\x93\x02\x1c:\x01*\"\x17/v1/actuation/heartbeat\x12\xb9\x01\n" +
 	"\x14ReportContainerState\x122.containarium.cloud.v1.ReportContainerStateRequest\x1a3.containarium.cloud.v1.ReportContainerStateResponse\"8\x82\xd3\xe4\x93\x022:\x01*\"-/v1/actuation/containers/{container_id}/state\x12l\n" +
 	"\x10WatchAssignments\x12..containarium.cloud.v1.WatchAssignmentsRequest\x1a&.containarium.cloud.v1.AssignmentBatch0\x01BJZHgithub.com/footprintai/containarium/pkg/pb/containarium/cloud/v1;cloudv1b\x06proto3"
@@ -840,7 +1201,7 @@ func file_containarium_cloud_v1_actuation_service_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_cloud_v1_actuation_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_containarium_cloud_v1_actuation_service_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_containarium_cloud_v1_actuation_service_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_containarium_cloud_v1_actuation_service_proto_goTypes = []any{
 	(NetworkPolicyMode)(0),               // 0: containarium.cloud.v1.NetworkPolicyMode
 	(*HeartbeatRequest)(nil),             // 1: containarium.cloud.v1.HeartbeatRequest
@@ -852,31 +1213,42 @@ var file_containarium_cloud_v1_actuation_service_proto_goTypes = []any{
 	(*PortRoute)(nil),                    // 7: containarium.cloud.v1.PortRoute
 	(*NetworkPolicy)(nil),                // 8: containarium.cloud.v1.NetworkPolicy
 	(*AssignmentBatch)(nil),              // 9: containarium.cloud.v1.AssignmentBatch
-	nil,                                  // 10: containarium.cloud.v1.Assignment.SecretEnvEntry
-	(*timestamppb.Timestamp)(nil),        // 11: google.protobuf.Timestamp
+	(*EnrollHostRequest)(nil),            // 10: containarium.cloud.v1.EnrollHostRequest
+	(*EnrollHostResponse)(nil),           // 11: containarium.cloud.v1.EnrollHostResponse
+	(*HostCapabilityCheck)(nil),          // 12: containarium.cloud.v1.HostCapabilityCheck
+	(*ReportHostStatusRequest)(nil),      // 13: containarium.cloud.v1.ReportHostStatusRequest
+	(*ReportHostStatusResponse)(nil),     // 14: containarium.cloud.v1.ReportHostStatusResponse
+	nil,                                  // 15: containarium.cloud.v1.Assignment.SecretEnvEntry
+	(*timestamppb.Timestamp)(nil),        // 16: google.protobuf.Timestamp
 }
 var file_containarium_cloud_v1_actuation_service_proto_depIdxs = []int32{
-	11, // 0: containarium.cloud.v1.HeartbeatResponse.received_at:type_name -> google.protobuf.Timestamp
-	11, // 1: containarium.cloud.v1.ReportContainerStateRequest.observed_at:type_name -> google.protobuf.Timestamp
-	11, // 2: containarium.cloud.v1.ReportContainerStateResponse.received_at:type_name -> google.protobuf.Timestamp
+	16, // 0: containarium.cloud.v1.HeartbeatResponse.received_at:type_name -> google.protobuf.Timestamp
+	16, // 1: containarium.cloud.v1.ReportContainerStateRequest.observed_at:type_name -> google.protobuf.Timestamp
+	16, // 2: containarium.cloud.v1.ReportContainerStateResponse.received_at:type_name -> google.protobuf.Timestamp
 	7,  // 3: containarium.cloud.v1.Assignment.routes:type_name -> containarium.cloud.v1.PortRoute
-	10, // 4: containarium.cloud.v1.Assignment.secret_env:type_name -> containarium.cloud.v1.Assignment.SecretEnvEntry
-	11, // 5: containarium.cloud.v1.Assignment.updated_at:type_name -> google.protobuf.Timestamp
+	15, // 4: containarium.cloud.v1.Assignment.secret_env:type_name -> containarium.cloud.v1.Assignment.SecretEnvEntry
+	16, // 5: containarium.cloud.v1.Assignment.updated_at:type_name -> google.protobuf.Timestamp
 	0,  // 6: containarium.cloud.v1.NetworkPolicy.mode:type_name -> containarium.cloud.v1.NetworkPolicyMode
 	6,  // 7: containarium.cloud.v1.AssignmentBatch.assignments:type_name -> containarium.cloud.v1.Assignment
-	11, // 8: containarium.cloud.v1.AssignmentBatch.generated_at:type_name -> google.protobuf.Timestamp
+	16, // 8: containarium.cloud.v1.AssignmentBatch.generated_at:type_name -> google.protobuf.Timestamp
 	8,  // 9: containarium.cloud.v1.AssignmentBatch.network_policies:type_name -> containarium.cloud.v1.NetworkPolicy
-	1,  // 10: containarium.cloud.v1.ActuationService.Heartbeat:input_type -> containarium.cloud.v1.HeartbeatRequest
-	3,  // 11: containarium.cloud.v1.ActuationService.ReportContainerState:input_type -> containarium.cloud.v1.ReportContainerStateRequest
-	5,  // 12: containarium.cloud.v1.ActuationService.WatchAssignments:input_type -> containarium.cloud.v1.WatchAssignmentsRequest
-	2,  // 13: containarium.cloud.v1.ActuationService.Heartbeat:output_type -> containarium.cloud.v1.HeartbeatResponse
-	4,  // 14: containarium.cloud.v1.ActuationService.ReportContainerState:output_type -> containarium.cloud.v1.ReportContainerStateResponse
-	9,  // 15: containarium.cloud.v1.ActuationService.WatchAssignments:output_type -> containarium.cloud.v1.AssignmentBatch
-	13, // [13:16] is the sub-list for method output_type
-	10, // [10:13] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	12, // 10: containarium.cloud.v1.ReportHostStatusRequest.checks:type_name -> containarium.cloud.v1.HostCapabilityCheck
+	16, // 11: containarium.cloud.v1.ReportHostStatusResponse.received_at:type_name -> google.protobuf.Timestamp
+	10, // 12: containarium.cloud.v1.ActuationService.EnrollHost:input_type -> containarium.cloud.v1.EnrollHostRequest
+	13, // 13: containarium.cloud.v1.ActuationService.ReportHostStatus:input_type -> containarium.cloud.v1.ReportHostStatusRequest
+	1,  // 14: containarium.cloud.v1.ActuationService.Heartbeat:input_type -> containarium.cloud.v1.HeartbeatRequest
+	3,  // 15: containarium.cloud.v1.ActuationService.ReportContainerState:input_type -> containarium.cloud.v1.ReportContainerStateRequest
+	5,  // 16: containarium.cloud.v1.ActuationService.WatchAssignments:input_type -> containarium.cloud.v1.WatchAssignmentsRequest
+	11, // 17: containarium.cloud.v1.ActuationService.EnrollHost:output_type -> containarium.cloud.v1.EnrollHostResponse
+	14, // 18: containarium.cloud.v1.ActuationService.ReportHostStatus:output_type -> containarium.cloud.v1.ReportHostStatusResponse
+	2,  // 19: containarium.cloud.v1.ActuationService.Heartbeat:output_type -> containarium.cloud.v1.HeartbeatResponse
+	4,  // 20: containarium.cloud.v1.ActuationService.ReportContainerState:output_type -> containarium.cloud.v1.ReportContainerStateResponse
+	9,  // 21: containarium.cloud.v1.ActuationService.WatchAssignments:output_type -> containarium.cloud.v1.AssignmentBatch
+	17, // [17:22] is the sub-list for method output_type
+	12, // [12:17] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_containarium_cloud_v1_actuation_service_proto_init() }
@@ -890,7 +1262,7 @@ func file_containarium_cloud_v1_actuation_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_cloud_v1_actuation_service_proto_rawDesc), len(file_containarium_cloud_v1_actuation_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   10,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/pb/containarium/cloud/v1/actuation_service.pb.gw.go
+++ b/pkg/pb/containarium/cloud/v1/actuation_service.pb.gw.go
@@ -35,6 +35,60 @@ var (
 	_ = metadata.Join
 )
 
+func request_ActuationService_EnrollHost_0(ctx context.Context, marshaler runtime.Marshaler, client ActuationServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq EnrollHostRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.EnrollHost(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ActuationService_EnrollHost_0(ctx context.Context, marshaler runtime.Marshaler, server ActuationServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq EnrollHostRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.EnrollHost(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ActuationService_ReportHostStatus_0(ctx context.Context, marshaler runtime.Marshaler, client ActuationServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ReportHostStatusRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ReportHostStatus(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ActuationService_ReportHostStatus_0(ctx context.Context, marshaler runtime.Marshaler, server ActuationServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ReportHostStatusRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ReportHostStatus(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ActuationService_Heartbeat_0(ctx context.Context, marshaler runtime.Marshaler, client ActuationServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq HeartbeatRequest
@@ -136,6 +190,46 @@ func request_ActuationService_WatchAssignments_0(ctx context.Context, marshaler 
 // Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterActuationServiceHandlerFromEndpoint instead.
 // GRPC interceptors will not work for this type of registration. To use interceptors, you must use the "runtime.WithMiddlewares" option in the "runtime.NewServeMux" call.
 func RegisterActuationServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux, server ActuationServiceServer) error {
+	mux.Handle(http.MethodPost, pattern_ActuationService_EnrollHost_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.cloud.v1.ActuationService/EnrollHost", runtime.WithHTTPPathPattern("/v1/actuation/enroll"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ActuationService_EnrollHost_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ActuationService_EnrollHost_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ActuationService_ReportHostStatus_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.cloud.v1.ActuationService/ReportHostStatus", runtime.WithHTTPPathPattern("/v1/actuation/status"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ActuationService_ReportHostStatus_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ActuationService_ReportHostStatus_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ActuationService_Heartbeat_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -223,6 +317,40 @@ func RegisterActuationServiceHandler(ctx context.Context, mux *runtime.ServeMux,
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "ActuationServiceClient" to call the correct interceptors. This client ignores the HTTP middlewares.
 func RegisterActuationServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux, client ActuationServiceClient) error {
+	mux.Handle(http.MethodPost, pattern_ActuationService_EnrollHost_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.cloud.v1.ActuationService/EnrollHost", runtime.WithHTTPPathPattern("/v1/actuation/enroll"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ActuationService_EnrollHost_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ActuationService_EnrollHost_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_ActuationService_ReportHostStatus_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.cloud.v1.ActuationService/ReportHostStatus", runtime.WithHTTPPathPattern("/v1/actuation/status"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ActuationService_ReportHostStatus_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ActuationService_ReportHostStatus_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ActuationService_Heartbeat_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -278,12 +406,16 @@ func RegisterActuationServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 }
 
 var (
+	pattern_ActuationService_EnrollHost_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "actuation", "enroll"}, ""))
+	pattern_ActuationService_ReportHostStatus_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "actuation", "status"}, ""))
 	pattern_ActuationService_Heartbeat_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "actuation", "heartbeat"}, ""))
 	pattern_ActuationService_ReportContainerState_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"v1", "actuation", "containers", "container_id", "state"}, ""))
 	pattern_ActuationService_WatchAssignments_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"containarium.cloud.v1.ActuationService", "WatchAssignments"}, ""))
 )
 
 var (
+	forward_ActuationService_EnrollHost_0           = runtime.ForwardResponseMessage
+	forward_ActuationService_ReportHostStatus_0     = runtime.ForwardResponseMessage
 	forward_ActuationService_Heartbeat_0            = runtime.ForwardResponseMessage
 	forward_ActuationService_ReportContainerState_0 = runtime.ForwardResponseMessage
 	forward_ActuationService_WatchAssignments_0     = runtime.ForwardResponseStream

--- a/pkg/pb/containarium/cloud/v1/actuation_service_grpc.pb.go
+++ b/pkg/pb/containarium/cloud/v1/actuation_service_grpc.pb.go
@@ -48,6 +48,8 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
+	ActuationService_EnrollHost_FullMethodName           = "/containarium.cloud.v1.ActuationService/EnrollHost"
+	ActuationService_ReportHostStatus_FullMethodName     = "/containarium.cloud.v1.ActuationService/ReportHostStatus"
 	ActuationService_Heartbeat_FullMethodName            = "/containarium.cloud.v1.ActuationService/Heartbeat"
 	ActuationService_ReportContainerState_FullMethodName = "/containarium.cloud.v1.ActuationService/ReportContainerState"
 	ActuationService_WatchAssignments_FullMethodName     = "/containarium.cloud.v1.ActuationService/WatchAssignments"
@@ -57,6 +59,14 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ActuationServiceClient interface {
+	// EnrollHost redeems a single-use join token and registers the BYO host.
+	// Self-authenticating via the token in the body (NOT host-bearer — the row
+	// doesn't exist yet).
+	EnrollHost(ctx context.Context, in *EnrollHostRequest, opts ...grpc.CallOption) (*EnrollHostResponse, error)
+	// ReportHostStatus upserts the calling host's capability profile +
+	// `doctor` self-check and bumps its heartbeat. Requires a valid
+	// `host-bearer` header. Idempotent.
+	ReportHostStatus(ctx context.Context, in *ReportHostStatusRequest, opts ...grpc.CallOption) (*ReportHostStatusResponse, error)
 	// Heartbeat updates hosts.last_heartbeat_at for the calling host.
 	// A stale gap (>2 × the host's expected interval) marks the host
 	// for the HostSweeper, which reassigns its containers. Hosts are
@@ -107,6 +117,26 @@ func NewActuationServiceClient(cc grpc.ClientConnInterface) ActuationServiceClie
 	return &actuationServiceClient{cc}
 }
 
+func (c *actuationServiceClient) EnrollHost(ctx context.Context, in *EnrollHostRequest, opts ...grpc.CallOption) (*EnrollHostResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(EnrollHostResponse)
+	err := c.cc.Invoke(ctx, ActuationService_EnrollHost_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *actuationServiceClient) ReportHostStatus(ctx context.Context, in *ReportHostStatusRequest, opts ...grpc.CallOption) (*ReportHostStatusResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReportHostStatusResponse)
+	err := c.cc.Invoke(ctx, ActuationService_ReportHostStatus_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *actuationServiceClient) Heartbeat(ctx context.Context, in *HeartbeatRequest, opts ...grpc.CallOption) (*HeartbeatResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(HeartbeatResponse)
@@ -150,6 +180,14 @@ type ActuationService_WatchAssignmentsClient = grpc.ServerStreamingClient[Assign
 // All implementations must embed UnimplementedActuationServiceServer
 // for forward compatibility.
 type ActuationServiceServer interface {
+	// EnrollHost redeems a single-use join token and registers the BYO host.
+	// Self-authenticating via the token in the body (NOT host-bearer — the row
+	// doesn't exist yet).
+	EnrollHost(context.Context, *EnrollHostRequest) (*EnrollHostResponse, error)
+	// ReportHostStatus upserts the calling host's capability profile +
+	// `doctor` self-check and bumps its heartbeat. Requires a valid
+	// `host-bearer` header. Idempotent.
+	ReportHostStatus(context.Context, *ReportHostStatusRequest) (*ReportHostStatusResponse, error)
 	// Heartbeat updates hosts.last_heartbeat_at for the calling host.
 	// A stale gap (>2 × the host's expected interval) marks the host
 	// for the HostSweeper, which reassigns its containers. Hosts are
@@ -200,6 +238,12 @@ type ActuationServiceServer interface {
 // pointer dereference when methods are called.
 type UnimplementedActuationServiceServer struct{}
 
+func (UnimplementedActuationServiceServer) EnrollHost(context.Context, *EnrollHostRequest) (*EnrollHostResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method EnrollHost not implemented")
+}
+func (UnimplementedActuationServiceServer) ReportHostStatus(context.Context, *ReportHostStatusRequest) (*ReportHostStatusResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ReportHostStatus not implemented")
+}
 func (UnimplementedActuationServiceServer) Heartbeat(context.Context, *HeartbeatRequest) (*HeartbeatResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Heartbeat not implemented")
 }
@@ -228,6 +272,42 @@ func RegisterActuationServiceServer(s grpc.ServiceRegistrar, srv ActuationServic
 		t.testEmbeddedByValue()
 	}
 	s.RegisterService(&ActuationService_ServiceDesc, srv)
+}
+
+func _ActuationService_EnrollHost_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EnrollHostRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ActuationServiceServer).EnrollHost(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ActuationService_EnrollHost_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ActuationServiceServer).EnrollHost(ctx, req.(*EnrollHostRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ActuationService_ReportHostStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReportHostStatusRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ActuationServiceServer).ReportHostStatus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ActuationService_ReportHostStatus_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ActuationServiceServer).ReportHostStatus(ctx, req.(*ReportHostStatusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _ActuationService_Heartbeat_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -284,6 +364,14 @@ var ActuationService_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "containarium.cloud.v1.ActuationService",
 	HandlerType: (*ActuationServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "EnrollHost",
+			Handler:    _ActuationService_EnrollHost_Handler,
+		},
+		{
+			MethodName: "ReportHostStatus",
+			Handler:    _ActuationService_ReportHostStatus_Handler,
+		},
 		{
 			MethodName: "Heartbeat",
 			Handler:    _ActuationService_Heartbeat_Handler,

--- a/proto/containarium/cloud/v1/actuation_service.proto
+++ b/proto/containarium/cloud/v1/actuation_service.proto
@@ -202,7 +202,74 @@ message AssignmentBatch {
   repeated NetworkPolicy network_policies = 3;
 }
 
+// EnrollHostRequest carries the single-use join token a BYO host redeems to
+// register itself with the cloud (BYO-compute report path). Unlike every other
+// ActuationService RPC this one is NOT host-bearer authed — the host row
+// doesn't exist yet; the cloud validates + single-use-redeems the token.
+message EnrollHostRequest {
+  // The join token, format "<host_id>.<secret>", from the cloud's
+  // `pool join` / `cloud enroll` one-liner.
+  string join_token = 1;
+}
+
+message EnrollHostResponse {
+  // The enrolled host's id. The host keeps using its join token as its
+  // durable host-bearer for Heartbeat / ReportHostStatus.
+  string host_id = 1;
+}
+
+// HostCapabilityCheck is one line of the `doctor` self-check: a named probe
+// with a pass/fail + human-readable detail. Defined locally here (same field
+// numbers as the cloud's host.proto message) so the vendored actuation proto
+// stays self-contained — wire-compatible without vendoring host.proto.
+message HostCapabilityCheck {
+  string name = 1;
+  bool ok = 2;
+  string detail = 3;
+}
+
+// ReportHostStatusRequest is a BYO host's push of its self-measured
+// capability profile + `doctor` self-check. Host-bearer authed; the host id
+// comes from the bearer, never the body.
+message ReportHostStatusRequest {
+  string agent_version = 1;
+  int32 cpu_cores = 2;
+  int32 total_ram_mb = 3;
+  int32 total_disk_gb = 4;
+  int32 total_gpu_count = 5;
+  string gpu_spec = 6;
+  int32 avail_ram_mb = 7;
+  int32 avail_disk_gb = 8;
+  int32 avail_gpu_count = 9;
+  bool self_check_ok = 10;
+  repeated HostCapabilityCheck checks = 11;
+}
+
+message ReportHostStatusResponse {
+  google.protobuf.Timestamp received_at = 1;
+}
+
 service ActuationService {
+  // EnrollHost redeems a single-use join token and registers the BYO host.
+  // Self-authenticating via the token in the body (NOT host-bearer — the row
+  // doesn't exist yet).
+  rpc EnrollHost(EnrollHostRequest) returns (EnrollHostResponse) {
+    option (google.api.http) = {
+      post: "/v1/actuation/enroll"
+      body: "*"
+    };
+  }
+
+  // ReportHostStatus upserts the calling host's capability profile +
+  // `doctor` self-check and bumps its heartbeat. Requires a valid
+  // `host-bearer` header. Idempotent.
+  rpc ReportHostStatus(ReportHostStatusRequest) returns (ReportHostStatusResponse) {
+    option (google.api.http) = {
+      post: "/v1/actuation/status"
+      body: "*"
+    };
+  }
+
   // Heartbeat updates hosts.last_heartbeat_at for the calling host.
   // A stale gap (>2 × the host's expected interval) marks the host
   // for the HostSweeper, which reassigns its containers. Hosts are


### PR DESCRIPTION
The OSS half of the BYO-compute report path — what makes an enrolled host show up **live** in the cloud fleet view. Pairs with the cloud RPCs (`EnrollHost` / `ReportHostStatus`) shipped in FootprintAI/Containarium-cloud#529.

## What's here
- **proto (vendored)**: `ActuationService.EnrollHost` + `ReportHostStatus` + a local `HostCapabilityCheck` (same field numbers as the cloud's `host.proto` message → wire-compatible without vendoring `host.proto`). `make proto` regenerated the client stubs.
- **`internal/cloud` client**:
  - `Enroll(ctx, controlPlane, joinToken, insecure)` — one-shot redeem of a single-use join token (token self-authenticates in the body; no host bearer yet). Returns the host id.
  - `statusLoop` / `reportStatusOnce` — periodic `ReportHostStatus` on the heartbeat cadence, host-bearer authed, driven by a `StatusProbe`.
  - `StatusProbe` interface + `HostStatus`/`HostCheck` types (decouples the probe from generated types + heavy deps).
  - `DefaultStatusProbe` — self-measures agent version + CPU cores + total/available RAM (`/proc/meminfo`).
- **`containarium cloud enroll --control-plane <addr> --token-file <jt>`** — the BYO self-service CLI (distinct from `cloud login`'s sysadmin host-id+token flow).
- **daemon**: wires `DefaultStatusProbe` into the cloud-actuation client deps, so an enrolled daemon reports capability automatically on startup.

## Tests
`Enroll` over a real loopback gRPC server, `reportStatusOnce` field mapping + host-bearer propagation, `DefaultStatusProbe` version/CPU. Build + tests + gofmt + gosec clean.

## Deferred (fast follow-ups, noted in code)
- **`doctor` self-check in the report** (the live DEGRADED signal) — needs extracting `internal/cmd/doctor.go`'s checks into a shared package the daemon layer can import (it currently can't import `internal/cmd`). Until then `DefaultStatusProbe` reports `SelfCheckOK=true` so a host shows CONNECTED with real hardware.
- **Disk + GPU** in the profile — need Incus/storage introspection.

## End-to-end
With this + cloud #529, the #520 wizard's pending→connected poll and the #519 fleet view light up against a live host: `containarium cloud enroll …` → host row created → periodic status report → fleet shows CONNECTED with CPU/RAM/headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)