### PR TITLE
refactor(byoc): report doctor self-check in the cloud status probe (#528 follow-up)

### DIFF
--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -358,7 +358,10 @@ func TestDefaultStatusProbe_ReportsVersionAndCPU(t *testing.T) {
 	if st.CPUCores <= 0 {
 		t.Errorf("cpu cores should be positive, got %d", st.CPUCores)
 	}
-	if !st.SelfCheckOK {
-		t.Error("default probe reports self_check_ok=true until doctor integration lands")
+	// SelfCheckOK / Checks are environment-dependent (root + useradd needed to
+	// pass), so we don't assert their values — only that the self-check ran and
+	// populated the breakdown on this (non-windows) platform.
+	if len(st.Checks) == 0 {
+		t.Error("doctor self-check should populate at least one check on non-windows")
 	}
 }

--- a/internal/cloud/probe.go
+++ b/internal/cloud/probe.go
@@ -8,35 +8,41 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/footprintai/containarium/internal/hostcheck"
 	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/pkg/version"
 )
 
 // DefaultStatusProbe is the daemon's host-capability probe: it self-measures
-// hardware (CPU cores, total + available RAM) and reports the running agent
-// version. It satisfies StatusProbe so the actuation client's status loop can
-// push it to the cloud, making the BYO fleet view show real specs + headroom.
+// hardware (CPU cores, total + available RAM), reports the running agent
+// version, and runs the `doctor` capability self-check (the DEGRADED signal —
+// running-as-root / caps / useradd probe). It satisfies StatusProbe so the
+// actuation client's status loop pushes it to the cloud, making the BYO fleet
+// view show real specs + headroom + health.
 //
-// NOTE: the `doctor` capability self-check (the DEGRADED signal — running-as-
-// root / caps / useradd probe) is NOT yet reported here. Those checks live in
-// internal/cmd/doctor.go and can't be imported from the daemon layer without a
-// shared-package extraction; that's a fast follow-up. Until then the probe
-// reports SelfCheckOK=true with no checks, so a reporting host shows CONNECTED
-// with its hardware. Disk + GPU are likewise left for a follow-up (0 = not
-// reported), since they need Incus/storage introspection.
+// Disk + GPU are still left for a follow-up (0 = not reported), since they
+// need Incus/storage introspection.
 type DefaultStatusProbe struct{}
 
 // Probe gathers the current capability snapshot. Best-effort: a field it can't
 // measure on this platform is reported as zero rather than failing the whole
-// report (the cloud treats zero as "not reported").
+// report (the cloud treats zero as "not reported"). The self-check is run
+// in-process; for an accurate caps/useradd result the daemon must run under
+// its hardened systemd unit (same caveat as `containarium doctor`).
 func (DefaultStatusProbe) Probe(_ context.Context) (HostStatus, error) {
 	total, avail := readMemInfoMB()
+	raw := hostcheck.Run()
+	checks := make([]HostCheck, 0, len(raw))
+	for _, c := range raw {
+		checks = append(checks, HostCheck{Name: c.Name, OK: c.OK, Detail: c.Detail})
+	}
 	return HostStatus{
 		AgentVersion: version.GetVersion(),
 		CPUCores:     safecast.I32(runtime.NumCPU()),
 		TotalRAMMB:   total,
 		AvailRAMMB:   avail,
-		SelfCheckOK:  true, // doctor self-check reporting is a follow-up
+		SelfCheckOK:  hostcheck.AllRequiredPass(raw),
+		Checks:       checks,
 	}, nil
 }
 

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -5,12 +5,10 @@ package cmd
 import (
 	"fmt"
 	"log"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/footprintai/containarium/internal/hostcheck"
 )
 
 // doctor — the host capability self-check from the daemon deploy contract
@@ -21,38 +19,12 @@ import (
 // FIRST container create, hours later. The definitive check is a live
 // useradd/userdel probe.
 //
+// The check logic lives in internal/hostcheck so the daemon's cloud status
+// probe can run the same checks (#528); this file is the CLI shell.
+//
 // Run it under the SAME constraints as the daemon (i.e. via the systemd
 // unit, or as the daemon) for an accurate result — a plain root shell has
 // full caps and will pass even if the daemon unit is mis-configured.
-
-// requiredCaps are the effective capabilities the daemon needs to manage
-// per-tenant Linux users (useradd, chown ~, etc.). Bit numbers per
-// <linux/capability.h>.
-var requiredCaps = []struct {
-	name string
-	bit  uint
-}{
-	{"CAP_CHOWN", 0},
-	{"CAP_DAC_OVERRIDE", 1},
-	{"CAP_FOWNER", 3},
-	{"CAP_SETGID", 6},
-	{"CAP_SETUID", 7},
-}
-
-// daemonWritablePaths must be writable for the daemon (the unit's
-// ReadWritePaths) plus /var/log — useradd touches /var/log/lastlog, the
-// "second, independent trap" the deploy contract calls out.
-var daemonWritablePaths = []string{
-	"/var/lib/incus", "/etc/containarium", "/etc", "/home",
-	"/var/lock", "/run/lock", "/opt/containarium", "/var/log",
-}
-
-type doctorCheck struct {
-	name     string
-	ok       bool
-	required bool
-	detail   string
-}
 
 var doctorCmd = &cobra.Command{
 	Use:   "doctor",
@@ -72,133 +44,9 @@ func init() {
 	rootCmd.AddCommand(doctorCmd)
 }
 
-// hostDoctorChecks runs every host capability check and returns the results.
-// Pure of CLI concerns so `pool join` (and, later, daemon startup) can run
-// the same checks.
-func hostDoctorChecks() []doctorCheck {
-	var checks []doctorCheck
-
-	// 1. Running as (effective) root.
-	euid := os.Geteuid()
-	checks = append(checks, doctorCheck{
-		name: "running as root", ok: euid == 0, required: true,
-		detail: fmt.Sprintf("euid=%d (need 0)", euid),
-	})
-
-	// 2. Effective capabilities. Diagnostic — the useradd probe (4) is the
-	// definitive test; a host can lack the readable mask yet still work, or
-	// have it yet be broken by other sandboxing.
-	checks = append(checks, capCheck())
-
-	// 3. Writable paths.
-	for _, p := range daemonWritablePaths {
-		checks = append(checks, writableCheck(p))
-	}
-
-	// 4. The definitive capability-trap test: create + delete a throwaway user.
-	checks = append(checks, useraddProbe())
-
-	// 5. incus present (the unit Requires=incus.service).
-	_, err := exec.LookPath("incus")
-	checks = append(checks, doctorCheck{
-		name: "incus binary present", ok: err == nil, required: true,
-		detail: "incus not found on PATH",
-	})
-
-	return checks
-}
-
-// capCheck reads CapEff from /proc/self/status and verifies the required caps.
-func capCheck() doctorCheck {
-	c := doctorCheck{name: "effective capabilities", required: true}
-	data, err := os.ReadFile("/proc/self/status")
-	if err != nil {
-		c.detail = fmt.Sprintf("cannot read /proc/self/status: %v", err)
-		return c
-	}
-	var capEff uint64
-	found := false
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.HasPrefix(line, "CapEff:") {
-			hexStr := strings.TrimSpace(strings.TrimPrefix(line, "CapEff:"))
-			v, perr := strconv.ParseUint(hexStr, 16, 64)
-			if perr != nil {
-				c.detail = fmt.Sprintf("parse CapEff %q: %v", hexStr, perr)
-				return c
-			}
-			capEff = v
-			found = true
-			break
-		}
-	}
-	if !found {
-		c.detail = "CapEff not found in /proc/self/status"
-		return c
-	}
-	if missing := missingCaps(capEff); len(missing) > 0 {
-		c.detail = "missing: " + strings.Join(missing, ", ")
-		return c
-	}
-	c.ok = true
-	return c
-}
-
-// missingCaps returns the required capabilities NOT set in the effective
-// capability mask. Pure — unit-tested.
-func missingCaps(capEff uint64) []string {
-	var missing []string
-	for _, rc := range requiredCaps {
-		if capEff&(1<<rc.bit) == 0 {
-			missing = append(missing, rc.name)
-		}
-	}
-	return missing
-}
-
-// writableCheck confirms dir exists and is writable by creating+removing a
-// temp file (tests writability under the CURRENT caps/sandbox, not just mode).
-func writableCheck(dir string) doctorCheck {
-	c := doctorCheck{name: "writable: " + dir, required: true}
-	info, err := os.Stat(dir)
-	if err != nil {
-		c.detail = fmt.Sprintf("missing: %v", err)
-		return c
-	}
-	if !info.IsDir() {
-		c.detail = "not a directory"
-		return c
-	}
-	f, err := os.CreateTemp(dir, ".containarium-doctor-*")
-	if err != nil {
-		c.detail = fmt.Sprintf("not writable: %v", err)
-		return c
-	}
-	name := f.Name()
-	_ = f.Close()
-	_ = os.Remove(name)
-	c.ok = true
-	return c
-}
-
-// useraddProbe creates then deletes a throwaway user — the definitive
-// capability-trap test (the daemon does this per tenant).
-func useraddProbe() doctorCheck {
-	c := doctorCheck{name: "useradd/userdel probe", required: true}
-	if _, err := exec.LookPath("useradd"); err != nil {
-		c.detail = "useradd not found on PATH"
-		return c
-	}
-	probe := fmt.Sprintf("__ctn_preflight_%d", os.Getpid())
-	// -M: no home dir (keeps the probe minimal). Always attempt cleanup.
-	out, err := exec.Command("useradd", "-M", "-s", "/usr/sbin/nologin", probe).CombinedOutput() // #nosec G204 -- fixed args + a pid-derived probe name, not user input
-	defer func() { _ = exec.Command("userdel", probe).Run() }()                                  // #nosec G204 -- same
-	if err != nil {
-		c.detail = fmt.Sprintf("useradd failed (the capability trap): %v: %s", err, strings.TrimSpace(string(out)))
-		return c
-	}
-	c.ok = true
-	return c
-}
+// hostDoctorChecks runs every host capability check. Thin alias over
+// hostcheck.Run so existing callers (`pool join`) stay unchanged.
+func hostDoctorChecks() []hostcheck.Check { return hostcheck.Run() }
 
 func runDoctor(cmd *cobra.Command, args []string) error {
 	checks := hostDoctorChecks()
@@ -216,9 +64,9 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 // keeps running so an operator can fix the unit and recover without a restart
 // loop. Returns the number of failed required checks.
 func logStartupSelfCheck() int {
-	var bad []doctorCheck
+	var bad []hostcheck.Check
 	for _, c := range hostDoctorChecks() {
-		if !c.ok && c.required {
+		if !c.OK && c.Required {
 			bad = append(bad, c)
 		}
 	}
@@ -230,7 +78,7 @@ func logStartupSelfCheck() int {
 	log.Printf("break until fixed (this is the 'capability trap': a unit that looks fine")
 	log.Printf("but whose caps/ReadWritePaths silently break useradd):")
 	for _, c := range bad {
-		log.Printf("  ✗ %s — %s", c.name, c.detail)
+		log.Printf("  ✗ %s — %s", c.Name, c.Detail)
 	}
 	log.Printf("See prd daemon-deploy-contract; run 'containarium doctor'. Continuing (non-fatal).")
 	log.Printf("========================================================================")
@@ -239,21 +87,21 @@ func logStartupSelfCheck() int {
 
 // printDoctor renders the checks and returns the count of failed REQUIRED
 // checks. Shared by `doctor` and `pool join`.
-func printDoctor(checks []doctorCheck) int {
+func printDoctor(checks []hostcheck.Check) int {
 	failed := 0
 	for _, c := range checks {
 		mark := "✓"
-		if !c.ok {
-			if c.required {
+		if !c.OK {
+			if c.Required {
 				mark = "✗"
 				failed++
 			} else {
 				mark = "!"
 			}
 		}
-		line := fmt.Sprintf("  %s %s", mark, c.name)
-		if !c.ok && c.detail != "" {
-			line += " — " + c.detail
+		line := fmt.Sprintf("  %s %s", mark, c.Name)
+		if !c.OK && c.Detail != "" {
+			line += " — " + c.Detail
 		}
 		fmt.Println(line)
 	}

--- a/internal/cmd/doctor_test.go
+++ b/internal/cmd/doctor_test.go
@@ -2,35 +2,18 @@
 
 package cmd
 
-import "testing"
+import (
+	"testing"
 
-func TestMissingCaps(t *testing.T) {
-	// All required cap bits set (CHOWN=0, DAC_OVERRIDE=1, FOWNER=3, SETGID=6,
-	// SETUID=7) → nothing missing.
-	full := uint64(1<<0 | 1<<1 | 1<<3 | 1<<6 | 1<<7)
-	if got := missingCaps(full); len(got) != 0 {
-		t.Errorf("full caps: missing=%v, want none", got)
-	}
-
-	// No caps → all required missing.
-	if got := missingCaps(0); len(got) != len(requiredCaps) {
-		t.Errorf("zero caps: missing=%v, want all %d", got, len(requiredCaps))
-	}
-
-	// Drop only CAP_SETUID (bit 7) → exactly that one is missing.
-	noSetuid := full &^ (1 << 7)
-	got := missingCaps(noSetuid)
-	if len(got) != 1 || got[0] != "CAP_SETUID" {
-		t.Errorf("no-setuid: missing=%v, want [CAP_SETUID]", got)
-	}
-}
+	"github.com/footprintai/containarium/internal/hostcheck"
+)
 
 func TestPrintDoctor_CountsRequiredFailures(t *testing.T) {
-	checks := []doctorCheck{
-		{name: "ok-required", ok: true, required: true},
-		{name: "fail-required", ok: false, required: true, detail: "x"}, // counts
-		{name: "warn-optional", ok: false, required: false},             // not counted
-		{name: "fail-required-2", ok: false, required: true},            // counts
+	checks := []hostcheck.Check{
+		{Name: "ok-required", OK: true, Required: true},
+		{Name: "fail-required", OK: false, Required: true, Detail: "x"}, // counts
+		{Name: "warn-optional", OK: false, Required: false},             // not counted
+		{Name: "fail-required-2", OK: false, Required: true},            // counts
 	}
 	if got := printDoctor(checks); got != 2 {
 		t.Fatalf("printDoctor required-failure count = %d, want 2", got)

--- a/internal/hostcheck/check.go
+++ b/internal/hostcheck/check.go
@@ -1,0 +1,31 @@
+// Package hostcheck is the host capability self-check from the daemon deploy
+// contract (prd/oss/daemon-deploy-contract.md) — the checks behind the
+// "capability trap": running uid/caps, writability of the daemon's paths, and
+// a live useradd/userdel probe.
+//
+// Extracted from internal/cmd so BOTH the `containarium doctor` / `pool join`
+// CLIs AND the daemon's cloud-actuation status probe (internal/cloud) can run
+// the same checks without an import cycle. The check logic is //go:build
+// !windows (it pokes Linux caps + useradd); a windows stub keeps the package
+// importable from the cross-platform internal/cloud.
+package hostcheck
+
+// Check is one capability-self-check result. Required=true means a failure
+// blocks the host from running the daemon's per-tenant user management.
+type Check struct {
+	Name     string
+	OK       bool
+	Required bool
+	Detail   string
+}
+
+// AllRequiredPass reports whether every required check in cs passed. Used by
+// the status probe to derive the cloud-facing self_check_ok flag.
+func AllRequiredPass(cs []Check) bool {
+	for _, c := range cs {
+		if c.Required && !c.OK {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/hostcheck/run.go
+++ b/internal/hostcheck/run.go
@@ -1,0 +1,161 @@
+//go:build !windows
+
+package hostcheck
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// RequiredCaps are the effective capabilities the daemon needs to manage
+// per-tenant Linux users (useradd, chown ~, etc.). Bit numbers per
+// <linux/capability.h>.
+var RequiredCaps = []struct {
+	Name string
+	Bit  uint
+}{
+	{"CAP_CHOWN", 0},
+	{"CAP_DAC_OVERRIDE", 1},
+	{"CAP_FOWNER", 3},
+	{"CAP_SETGID", 6},
+	{"CAP_SETUID", 7},
+}
+
+// DaemonWritablePaths must be writable for the daemon (the unit's
+// ReadWritePaths) plus /var/log — useradd touches /var/log/lastlog, the
+// "second, independent trap" the deploy contract calls out.
+var DaemonWritablePaths = []string{
+	"/var/lib/incus", "/etc/containarium", "/etc", "/home",
+	"/var/lock", "/run/lock", "/opt/containarium", "/var/log",
+}
+
+// Run executes every host capability check and returns the results. Pure of
+// CLI concerns so the `doctor` / `pool join` CLIs, the daemon startup
+// self-check, and the cloud status probe all share one implementation.
+func Run() []Check {
+	var checks []Check
+
+	// 1. Running as (effective) root.
+	euid := os.Geteuid()
+	checks = append(checks, Check{
+		Name: "running as root", OK: euid == 0, Required: true,
+		Detail: fmt.Sprintf("euid=%d (need 0)", euid),
+	})
+
+	// 2. Effective capabilities. Diagnostic — the useradd probe (4) is the
+	// definitive test; a host can lack the readable mask yet still work, or
+	// have it yet be broken by other sandboxing.
+	checks = append(checks, capCheck())
+
+	// 3. Writable paths.
+	for _, p := range DaemonWritablePaths {
+		checks = append(checks, writableCheck(p))
+	}
+
+	// 4. The definitive capability-trap test: create + delete a throwaway user.
+	checks = append(checks, useraddProbe())
+
+	// 5. incus present (the unit Requires=incus.service).
+	_, err := exec.LookPath("incus")
+	checks = append(checks, Check{
+		Name: "incus binary present", OK: err == nil, Required: true,
+		Detail: "incus not found on PATH",
+	})
+
+	return checks
+}
+
+// capCheck reads CapEff from /proc/self/status and verifies the required caps.
+func capCheck() Check {
+	c := Check{Name: "effective capabilities", Required: true}
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		c.Detail = fmt.Sprintf("cannot read /proc/self/status: %v", err)
+		return c
+	}
+	var capEff uint64
+	found := false
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "CapEff:") {
+			hexStr := strings.TrimSpace(strings.TrimPrefix(line, "CapEff:"))
+			v, perr := strconv.ParseUint(hexStr, 16, 64)
+			if perr != nil {
+				c.Detail = fmt.Sprintf("parse CapEff %q: %v", hexStr, perr)
+				return c
+			}
+			capEff = v
+			found = true
+			break
+		}
+	}
+	if !found {
+		c.Detail = "CapEff not found in /proc/self/status"
+		return c
+	}
+	if missing := MissingCaps(capEff); len(missing) > 0 {
+		c.Detail = "missing: " + strings.Join(missing, ", ")
+		return c
+	}
+	c.OK = true
+	return c
+}
+
+// MissingCaps returns the required capabilities NOT set in the effective
+// capability mask. Pure — unit-tested.
+func MissingCaps(capEff uint64) []string {
+	var missing []string
+	for _, rc := range RequiredCaps {
+		if capEff&(1<<rc.Bit) == 0 {
+			missing = append(missing, rc.Name)
+		}
+	}
+	return missing
+}
+
+// writableCheck confirms dir exists and is writable by creating+removing a
+// temp file (tests writability under the CURRENT caps/sandbox, not just mode).
+func writableCheck(dir string) Check {
+	c := Check{Name: "writable: " + dir, Required: true}
+	info, err := os.Stat(dir)
+	if err != nil {
+		c.Detail = fmt.Sprintf("missing: %v", err)
+		return c
+	}
+	if !info.IsDir() {
+		c.Detail = "not a directory"
+		return c
+	}
+	f, err := os.CreateTemp(dir, ".containarium-doctor-*")
+	if err != nil {
+		c.Detail = fmt.Sprintf("not writable: %v", err)
+		return c
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+	c.OK = true
+	return c
+}
+
+// useraddProbe creates then deletes a throwaway user — the definitive
+// capability-trap test (the daemon does this per tenant).
+func useraddProbe() Check {
+	c := Check{Name: "useradd/userdel probe", Required: true}
+	if _, err := exec.LookPath("useradd"); err != nil {
+		c.Detail = "useradd not found on PATH"
+		return c
+	}
+	probe := fmt.Sprintf("__ctn_preflight_%d", os.Getpid())
+	// -M: no home dir (keeps the probe minimal). Always attempt cleanup.
+	out, err := exec.Command("useradd", "-M", "-s", "/usr/sbin/nologin", probe).CombinedOutput() // #nosec G204 -- fixed args + a pid-derived probe name, not user input
+	defer func() { _ = exec.Command("userdel", probe).Run() }()                                  // #nosec G204 -- same
+	if err != nil {
+		c.Detail = fmt.Sprintf("useradd failed (the capability trap): %v: %s", err, strings.TrimSpace(string(out)))
+		return c
+	}
+	c.OK = true
+	return c
+}

--- a/internal/hostcheck/run_test.go
+++ b/internal/hostcheck/run_test.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package hostcheck
+
+import "testing"
+
+func TestMissingCaps(t *testing.T) {
+	// All required cap bits set (CHOWN=0, DAC_OVERRIDE=1, FOWNER=3, SETGID=6,
+	// SETUID=7) → nothing missing.
+	full := uint64(1<<0 | 1<<1 | 1<<3 | 1<<6 | 1<<7)
+	if got := MissingCaps(full); len(got) != 0 {
+		t.Errorf("full caps: missing=%v, want none", got)
+	}
+
+	// No caps → all required missing.
+	if got := MissingCaps(0); len(got) != len(RequiredCaps) {
+		t.Errorf("zero caps: missing=%v, want all %d", got, len(RequiredCaps))
+	}
+
+	// Drop only CAP_SETUID (bit 7) → exactly that one is missing.
+	noSetuid := full &^ (1 << 7)
+	got := MissingCaps(noSetuid)
+	if len(got) != 1 || got[0] != "CAP_SETUID" {
+		t.Errorf("no-setuid: missing=%v, want [CAP_SETUID]", got)
+	}
+}
+
+func TestAllRequiredPass(t *testing.T) {
+	pass := []Check{{Name: "a", OK: true, Required: true}, {Name: "b", OK: false, Required: false}}
+	if !AllRequiredPass(pass) {
+		t.Error("optional failure should not flip AllRequiredPass")
+	}
+	fail := []Check{{Name: "a", OK: false, Required: true}}
+	if AllRequiredPass(fail) {
+		t.Error("required failure should flip AllRequiredPass")
+	}
+}

--- a/internal/hostcheck/run_windows.go
+++ b/internal/hostcheck/run_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package hostcheck
+
+// Run is a no-op stub on Windows: the capability checks (Linux caps, useradd,
+// daemon paths) don't apply, and the daemon doesn't run on Windows. The base
+// `containarium` Windows binary still imports this package transitively
+// (internal/cloud → hostcheck), so it must compile — it just reports no checks.
+func Run() []Check { return nil }


### PR DESCRIPTION
Follow-up to the BYO-compute report path (#528 / #694): make the daemon's cloud status probe report the **`doctor` self-check** so the fleet view's live **DEGRADED** signal works.

## The problem
`#694` shipped capability reporting, but the self-check (the "capability trap" checks) lives in `internal/cmd/doctor.go`, which the daemon layer (`internal/cloud`) can't import (cycle). So `DefaultStatusProbe` reported `SelfCheckOK=true` always — a host that hit the capability trap still showed CONNECTED, never DEGRADED.

## The fix
Extract the pure check logic into a shared **`internal/hostcheck`** package both sides import:
- **`internal/hostcheck`**: `Check` type + `Run()` + `AllRequiredPass()` (moved verbatim from `doctor.go`). `//go:build !windows` for the real checks (Linux caps + useradd) + a **windows stub** (`Run → nil`), since `internal/cloud` is in the cross-platform base binary's import graph.
- **`internal/cmd/doctor.go`**: now a thin CLI shell over `hostcheck` (`doctorCmd`, `printDoctor`, `logStartupSelfCheck`, a `hostDoctorChecks` alias). `pool join` is unchanged.
- **`internal/cloud` `DefaultStatusProbe`**: runs `hostcheck.Run()` and reports the per-check breakdown + `self_check_ok` (= all required pass). A host whose unit hits the trap now reports `✗ useradd` and shows **DEGRADED** in the #519 fleet view + #521 host detail.

## Tests
`hostcheck` (`MissingCaps`, `AllRequiredPass`); `cmd` (`printDoctor`); the cloud probe test now asserts the self-check breakdown is populated (its pass/fail is environment-dependent — root + useradd — so not asserted). Native + Windows binary builds verified; gofmt/gosec clean.

## Remaining (smaller) follow-up
Disk + GPU in the capability profile (needs Incus/storage introspection) — still reported as 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)