### PR TITLE
feat(byoc): report disk + GPU in the host capability probe (#696)

### DIFF
--- a/internal/cloud/probe.go
+++ b/internal/cloud/probe.go
@@ -14,14 +14,15 @@ import (
 )
 
 // DefaultStatusProbe is the daemon's host-capability probe: it self-measures
-// hardware (CPU cores, total + available RAM), reports the running agent
-// version, and runs the `doctor` capability self-check (the DEGRADED signal —
-// running-as-root / caps / useradd probe). It satisfies StatusProbe so the
-// actuation client's status loop pushes it to the cloud, making the BYO fleet
-// view show real specs + headroom + health.
+// hardware (CPU cores, RAM, disk, GPU), reports the running agent version, and
+// runs the `doctor` capability self-check (the DEGRADED signal — running-as-
+// root / caps / useradd probe). It satisfies StatusProbe so the actuation
+// client's status loop pushes it to the cloud, making the BYO fleet view show
+// real specs + headroom + health.
 //
-// Disk + GPU are still left for a follow-up (0 = not reported), since they
-// need Incus/storage introspection.
+// Introspection is intentionally lightweight (runtime + /proc + statfs +
+// /dev/nvidia* + nvidia-smi) so it's cheap enough to run every report cycle —
+// distinct from the daemon's one-shot nvidia.runtime LXC GPU validation.
 type DefaultStatusProbe struct{}
 
 // Probe gathers the current capability snapshot. Best-effort: a field it can't
@@ -30,19 +31,28 @@ type DefaultStatusProbe struct{}
 // in-process; for an accurate caps/useradd result the daemon must run under
 // its hardened systemd unit (same caveat as `containarium doctor`).
 func (DefaultStatusProbe) Probe(_ context.Context) (HostStatus, error) {
-	total, avail := readMemInfoMB()
+	totalRAM, availRAM := readMemInfoMB()
+	totalDisk, availDisk := diskGB()
+	gpuCount, gpuSpec := gpuInfo()
 	raw := hostcheck.Run()
 	checks := make([]HostCheck, 0, len(raw))
 	for _, c := range raw {
 		checks = append(checks, HostCheck{Name: c.Name, OK: c.OK, Detail: c.Detail})
 	}
 	return HostStatus{
-		AgentVersion: version.GetVersion(),
-		CPUCores:     safecast.I32(runtime.NumCPU()),
-		TotalRAMMB:   total,
-		AvailRAMMB:   avail,
-		SelfCheckOK:  hostcheck.AllRequiredPass(raw),
-		Checks:       checks,
+		AgentVersion:  version.GetVersion(),
+		CPUCores:      safecast.I32(runtime.NumCPU()),
+		TotalRAMMB:    totalRAM,
+		AvailRAMMB:    availRAM,
+		TotalDiskGB:   totalDisk,
+		AvailDiskGB:   availDisk,
+		TotalGPUCount: gpuCount,
+		// No host-local in-use tracking; the cloud scheduler accounts for
+		// assigned GPUs. Report all detected GPUs as available headroom.
+		AvailGPUCount: gpuCount,
+		GPUSpec:       gpuSpec,
+		SelfCheckOK:   hostcheck.AllRequiredPass(raw),
+		Checks:        checks,
 	}, nil
 }
 

--- a/internal/cloud/probe_unix.go
+++ b/internal/cloud/probe_unix.go
@@ -1,0 +1,66 @@
+//go:build !windows
+
+package cloud
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/footprintai/containarium/internal/safecast"
+)
+
+// diskDataDir is where the daemon's Incus storage lives — the disk the host's
+// container workloads consume. statfs here reflects the capacity that
+// actually matters for scheduling. Falls back to "/" when absent.
+const diskDataDir = "/var/lib/incus"
+
+// diskGB returns (total, available) disk in GB for the daemon's data dir via
+// statfs. Best-effort: (0, 0) when neither the data dir nor "/" can be
+// stat-ed. Computed in uint64 so it's correct whether the platform's Bsize is
+// signed (Linux int64) or unsigned (darwin uint32).
+func diskGB() (total, avail int32) {
+	path := diskDataDir
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		if err := syscall.Statfs("/", &st); err != nil {
+			return 0, 0
+		}
+	}
+	bsize := safecast.U64FromI64(int64(st.Bsize))
+	const bytesPerGB = 1024 * 1024 * 1024
+	total = safecast.I32(safecast.I64FromU64(uint64(st.Blocks) * bsize / bytesPerGB))
+	avail = safecast.I32(safecast.I64FromU64(uint64(st.Bavail) * bsize / bytesPerGB))
+	return total, avail
+}
+
+// gpuInfo returns (count, spec): the number of NVIDIA GPUs (counted from
+// /dev/nvidia[0-9]* device nodes) and a lowercased model string from
+// nvidia-smi. Best-effort and cheap (no LXC spin-up): (0, "") on a host with
+// no NVIDIA GPUs or no nvidia-smi. The heavyweight nvidia.runtime validation
+// stays a separate one-shot admin check, not this per-cycle probe.
+func gpuInfo() (count int32, spec string) {
+	nodes, _ := filepath.Glob("/dev/nvidia[0-9]*")
+	if len(nodes) == 0 {
+		return 0, ""
+	}
+	count = safecast.I32(len(nodes))
+	// Model name from nvidia-smi (first GPU). Optional — a host can have the
+	// device nodes but a broken driver; we still report the count.
+	out, err := exec.Command("nvidia-smi", "--query-gpu=name", "--format=csv,noheader").Output() // #nosec G204 -- fixed args, no user input
+	if err == nil {
+		if line := strings.TrimSpace(firstLine(string(out))); line != "" {
+			spec = strings.ToLower(line)
+		}
+	}
+	return count, spec
+}
+
+// firstLine returns the first line of s (without the newline).
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/internal/cloud/probe_unix_test.go
+++ b/internal/cloud/probe_unix_test.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package cloud
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDiskGB_ReportsPositiveTotal(t *testing.T) {
+	// "/" (the fallback) always exists on a unix test host, so total disk
+	// should be a positive GB figure and available should not exceed it.
+	total, avail := diskGB()
+	if total <= 0 {
+		t.Errorf("total disk GB should be positive, got %d", total)
+	}
+	if avail < 0 || avail > total {
+		t.Errorf("available disk GB %d out of range (total %d)", avail, total)
+	}
+}
+
+func TestGPUInfo_NoGPUIsCleanZero(t *testing.T) {
+	// On a GPU-less test host gpuInfo returns (0, ""). On a GPU host it
+	// returns a positive count; either way it must not panic and the spec is
+	// non-empty only when a GPU is present.
+	count, spec := gpuInfo()
+	if count < 0 {
+		t.Errorf("gpu count should be non-negative, got %d", count)
+	}
+	if count == 0 && spec != "" {
+		t.Errorf("no GPUs but got spec %q", spec)
+	}
+}
+
+func TestProbe_PopulatesDisk(t *testing.T) {
+	st, err := DefaultStatusProbe{}.Probe(context.Background())
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if st.TotalDiskGB <= 0 {
+		t.Errorf("probe should report positive total disk, got %d", st.TotalDiskGB)
+	}
+}

--- a/internal/cloud/probe_windows.go
+++ b/internal/cloud/probe_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package cloud
+
+// diskGB / gpuInfo are no-op stubs on Windows: the daemon doesn't run there,
+// but internal/cloud is in the cross-platform base binary's import graph, so
+// these must compile. They report zeros (the cloud treats zero as "not
+// reported").
+func diskGB() (total, avail int32) { return 0, 0 }
+
+func gpuInfo() (count int32, spec string) { return 0, "" }


### PR DESCRIPTION
Closes #696 — fills in the last two capability fields the cloud already persists + surfaces (`host_capabilities.total_disk_gb` / `total_gpu_count` / `gpu_spec` / `avail_*`) but the OSS probe left at `0`.

## What's here
`DefaultStatusProbe` now also self-measures, lightweight + cheap enough to run every report cycle (no LXC spin-up — distinct from the one-shot `nvidia.runtime` GPU validation):
- **Disk**: `statfs` on the Incus data dir (`/var/lib/incus`, fallback `/`) → total + available GB. `uint64→int32` via `safecast` (gosec-clean).
- **GPU**: count `/dev/nvidia[0-9]*` device nodes + the model string from `nvidia-smi` (lowercased). `AvailGPUCount` = detected count (the cloud scheduler accounts for assigned GPUs; the host probe has no in-use view).

Platform-split so `internal/cloud` still compiles for the cross-platform base binary: `probe_unix.go` (`statfs` + `/dev/nvidia`, `//go:build !windows`) + `probe_windows.go` (zeros stub). `probe.go` wires the fields.

## Tests
`!windows`: `diskGB` reports a positive total, `gpuInfo` is clean-zero on a GPU-less host, `Probe` populates disk. Native + Windows binary + Linux cross builds verified; gofmt + gosec clean.

## Result
With this, an enrolled host reports its **full** capability profile — CPU / RAM / disk / GPU + headroom + `doctor` self-check — so the BYO fleet view (#519) and host detail (#521) show complete, live specs. This is the last item in the BYO-compute arc (umbrella #515 + report path #528).

🤖 Generated with [Claude Code](https://claude.com/claude-code)