### PR TITLE
refactor(box): runtime-neutral BoxBackend seam + LXC adapter (#700)

### DIFF
--- a/pkg/core/box/box.go
+++ b/pkg/core/box/box.go
@@ -1,0 +1,189 @@
+// Package box defines the runtime-neutral seam between the daemon and the
+// substrate a box runs on. Today the only implementation is LXC/incus
+// (pkg/core/box/lxc), which wraps the existing container.Manager with no
+// behavior change. A Kubernetes implementation lands against this same
+// contract behind a build tag — see docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md.
+//
+// The seam sits one altitude *above* incus.Backend on purpose: incus.Backend
+// is a leaky, LXC-shaped interface (Exec, WriteFile, ResolveGPUInputToPCI,
+// raw config-key writes) that a non-incus runtime cannot implement cleanly.
+// BoxBackend is coarse-grained — lifecycle, addressing, SSH identity, and
+// metadata — and lets each runtime realize those however it must.
+package box
+
+import (
+	"context"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// BackendKind identifies the substrate a BoxBackend manages.
+type BackendKind string
+
+const (
+	// KindLXC is the LXC/incus backend (today's default).
+	KindLXC BackendKind = "lxc"
+	// KindK8s is the Kubernetes backend (behind the `k8s` build tag).
+	KindK8s BackendKind = "k8s"
+)
+
+// BoxRef names a box independent of runtime. Tenant is the routing key / SSH
+// username the daemon's SSH front routes by; Name is the substrate-level
+// object name (LXC: "<tenant>-container"; K8s: the StatefulSet pod "box-0").
+// Name may be empty on input — an implementation derives it from Tenant via
+// its own naming convention — and is always populated on values returned by
+// the backend.
+type BoxRef struct {
+	Tenant string
+	Name   string
+}
+
+// ResourceLimits is the runtime-neutral form of a box's CPU/memory/disk
+// request. Values are substrate-native strings (e.g. "2", "4GB", "20GB"); an
+// empty field means "leave unchanged" on mutation and "unset" on read.
+type ResourceLimits struct {
+	CPU    string
+	Memory string
+	Disk   string
+}
+
+// BoxSpec is the declarative input to Create. The backend makes a box matching
+// the spec exist and returns a BoxHandle. Create must be idempotent on
+// re-create (the agent-skills bring-up taught us this the hard way, #669).
+type BoxSpec struct {
+	Ref        BoxRef
+	Image      string
+	OSType     pb.OSType
+	Resources  ResourceLimits
+	GPUs       []string // empty on K8s v1 (deferred)
+	SSHKeys    []string
+	Labels     map[string]string
+	Monitoring bool
+
+	// Provisioning intent — NOT an exec script. The backend decides how to
+	// realize it: LXC runs incus exec; K8s bakes it into the image / an init
+	// container. Keeps stack-install runtime-specific, below the seam.
+	Stack       string
+	StackParams map[string]string
+
+	// AutoStart requests the box be started as part of Create.
+	AutoStart bool
+}
+
+// BoxEndpoint describes how an agent reaches a box over SSH. The server turns
+// it into Container.ssh_host and the displayed ssh command.
+type BoxEndpoint struct {
+	// SSHHost is the gateway/sentinel public host an agent connects to. Empty
+	// means "direct IP mode" (no gateway in front) — the server may stamp the
+	// daemon's configured gateway host above the seam when this is empty.
+	SSHHost string
+	// SSHPort is the gateway SSH port (22 via sshpiper); 0 means default.
+	SSHPort int
+	// SSHUser is the routing key the SSH front (sshpiper) routes by — the
+	// tenant.
+	SSHUser string
+	// DirectIP is the box's own address, used when no gateway is in front.
+	DirectIP string
+	// AccessType distinguishes SSH from RDP (Windows VMs).
+	AccessType pb.AccessType
+}
+
+// BoxHandle is returned by Create: the resolved ref, how to reach the box, and
+// its state at creation time.
+type BoxHandle struct {
+	Ref      BoxRef
+	Endpoint BoxEndpoint
+	State    pb.ContainerState
+}
+
+// BoxStatus is the runtime-neutral view of an existing box.
+type BoxStatus struct {
+	Ref       BoxRef
+	State     pb.ContainerState
+	Endpoint  BoxEndpoint
+	Resources ResourceLimits
+	// Meta is the runtime-neutral replacement for raw incus config keys —
+	// labels today, and (as wiring lands) TTL / delete-policy /
+	// monitoring-enabled. LXC maps it to user.containarium.*; K8s maps it to
+	// pod annotations/labels.
+	Meta      map[string]string
+	BackendID string
+}
+
+// BoxMetrics is the runtime-neutral form of a box's runtime metrics.
+type BoxMetrics struct {
+	CPUUsageSeconds  int64
+	MemoryUsageBytes int64
+	MemoryLimitBytes int64
+	DiskUsageBytes   int64
+	NetworkRxBytes   int64
+	NetworkTxBytes   int64
+	ProcessCount     int32
+}
+
+// BoxBackend is the runtime-neutral seam. LXC/incus and Kubernetes both
+// implement it. It is coarse-grained on purpose — no Exec/WriteFile/config-key
+// leakage. ctx is threaded for the K8s client; the LXC implementation ignores
+// it (its incus client predates ctx plumbing).
+type BoxBackend interface {
+	// Kind reports which substrate this backend manages.
+	Kind() BackendKind
+
+	// Create makes a box matching spec exist and returns its handle.
+	// Idempotent on re-create.
+	Create(ctx context.Context, spec BoxSpec) (*BoxHandle, error)
+	// Start starts a stopped box.
+	Start(ctx context.Context, ref BoxRef) error
+	// Stop stops a running box; force skips graceful shutdown.
+	Stop(ctx context.Context, ref BoxRef, force bool) error
+	// Delete removes a box; force stops it first if running.
+	Delete(ctx context.Context, ref BoxRef, force bool) error
+
+	// Get returns the current status of a box, or (nil, nil) if it does not
+	// exist.
+	Get(ctx context.Context, ref BoxRef) (*BoxStatus, error)
+	// List returns the status of every box this backend manages.
+	List(ctx context.Context) ([]BoxStatus, error)
+
+	// Resolve reports how an agent reaches the box over SSH. This is the
+	// method that makes the K8s value real (gateway host + routing user); on
+	// LXC it reports the direct IP, with the gateway host stamped above the
+	// seam.
+	Resolve(ctx context.Context, ref BoxRef) (*BoxEndpoint, error)
+
+	// SetAuthorizedKeys sets the box's authorized SSH keys to exactly the
+	// given set. Lives below the seam because the mechanism differs per
+	// runtime: LXC writes the box's authorized_keys; K8s reconciles the
+	// per-tenant Secret + PiperUpstream.
+	SetAuthorizedKeys(ctx context.Context, ref BoxRef, keys []string) error
+
+	// Resize updates the box's resource limits; empty fields are left
+	// unchanged.
+	Resize(ctx context.Context, ref BoxRef, r ResourceLimits) error
+
+	// SetMeta replaces the box's runtime-neutral metadata.
+	SetMeta(ctx context.Context, ref BoxRef, meta map[string]string) error
+	// GetMeta reads the box's runtime-neutral metadata.
+	GetMeta(ctx context.Context, ref BoxRef) (map[string]string, error)
+}
+
+// ExecCapable is an optional capability for in-box exec and file seeding.
+// LXC implements it (incus exec / file push). The K8s agent-box is pinned by
+// ForceCommand, so a K8s backend may NOT implement it — provisioning is
+// image-baked. Discover support with a type assertion.
+type ExecCapable interface {
+	Exec(ctx context.Context, ref BoxRef, cmd []string) (stdout, stderr string, err error)
+	WriteFile(ctx context.Context, ref BoxRef, path string, content []byte, mode string) error
+}
+
+// MetricsCapable is an optional capability for per-box runtime metrics.
+type MetricsCapable interface {
+	Metrics(ctx context.Context, ref BoxRef) (*BoxMetrics, error)
+}
+
+// GPUCapable is an optional capability for resolving a user-supplied GPU
+// identifier to a stable device ID. LXC implements it; K8s GPU support is
+// deferred.
+type GPUCapable interface {
+	ResolveGPU(ctx context.Context, input string) (deviceID string, err error)
+}

--- a/pkg/core/box/lxc/lxc.go
+++ b/pkg/core/box/lxc/lxc.go
@@ -1,0 +1,234 @@
+// Package lxc implements box.BoxBackend over the existing LXC/incus
+// container.Manager. It is a pure adapter: every method delegates to the
+// Manager that the daemon already uses, so behavior is unchanged. The package
+// exists to give the daemon a runtime-neutral seam (box.BoxBackend) it can
+// hold instead of a concrete *container.Manager — see
+// docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md.
+package lxc
+
+import (
+	"context"
+	"strings"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Backend adapts a *container.Manager to box.BoxBackend.
+type Backend struct {
+	mgr *container.Manager
+}
+
+// Compile-time assertions: Backend satisfies the core interface and the
+// optional capabilities LXC supports.
+var (
+	_ box.BoxBackend     = (*Backend)(nil)
+	_ box.ExecCapable    = (*Backend)(nil)
+	_ box.MetricsCapable = (*Backend)(nil)
+)
+
+// New returns an LXC backend wrapping the given Manager.
+func New(mgr *container.Manager) *Backend {
+	return &Backend{mgr: mgr}
+}
+
+// Kind reports the LXC substrate.
+func (b *Backend) Kind() box.BackendKind { return box.KindLXC }
+
+// Create makes a container matching spec exist and returns its handle.
+func (b *Backend) Create(_ context.Context, spec box.BoxSpec) (*box.BoxHandle, error) {
+	info, err := b.mgr.Create(specToCreateOptions(spec))
+	if err != nil {
+		return nil, err
+	}
+	st := infoToStatus(info)
+	return &box.BoxHandle{Ref: st.Ref, Endpoint: st.Endpoint, State: st.State}, nil
+}
+
+// Start starts a stopped container.
+func (b *Backend) Start(_ context.Context, ref box.BoxRef) error {
+	return b.mgr.Start(ref.Tenant)
+}
+
+// Stop stops a running container.
+func (b *Backend) Stop(_ context.Context, ref box.BoxRef, force bool) error {
+	return b.mgr.Stop(ref.Tenant, force)
+}
+
+// Delete removes a container, stopping it first if running.
+func (b *Backend) Delete(_ context.Context, ref box.BoxRef, force bool) error {
+	return b.mgr.Delete(ref.Tenant, force)
+}
+
+// Get returns the status of a container, or (nil, nil) if it does not exist.
+func (b *Backend) Get(_ context.Context, ref box.BoxRef) (*box.BoxStatus, error) {
+	info, err := b.mgr.Get(ref.Tenant)
+	if err != nil {
+		return nil, err
+	}
+	if info == nil {
+		return nil, nil
+	}
+	st := infoToStatus(info)
+	return &st, nil
+}
+
+// List returns the status of every container the Manager sees.
+func (b *Backend) List(_ context.Context) ([]box.BoxStatus, error) {
+	infos, err := b.mgr.List()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]box.BoxStatus, 0, len(infos))
+	for i := range infos {
+		out = append(out, infoToStatus(&infos[i]))
+	}
+	return out, nil
+}
+
+// Resolve reports how an agent reaches the container over SSH. The LXC backend
+// knows only the box's direct IP and routing user; the gateway/sentinel host
+// is stamped above the seam by the server (from the daemon's --ssh-host flag).
+func (b *Backend) Resolve(ctx context.Context, ref box.BoxRef) (*box.BoxEndpoint, error) {
+	st, err := b.Get(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	if st == nil {
+		return nil, nil
+	}
+	ep := st.Endpoint
+	return &ep, nil
+}
+
+// SetAuthorizedKeys sets the container's authorized SSH keys to exactly the
+// given set.
+func (b *Backend) SetAuthorizedKeys(_ context.Context, ref box.BoxRef, keys []string) error {
+	return b.mgr.SetAuthorizedKeys(ref.Tenant, keys)
+}
+
+// Resize updates the container's resource limits; empty fields are unchanged.
+func (b *Backend) Resize(_ context.Context, ref box.BoxRef, r box.ResourceLimits) error {
+	return b.mgr.Resize(containerName(ref), r.CPU, r.Memory, r.Disk, false)
+}
+
+// SetMeta replaces the container's labels (the runtime-neutral metadata LXC
+// supports today; TTL/delete-policy route through dedicated server methods
+// pending follow-up).
+func (b *Backend) SetMeta(_ context.Context, ref box.BoxRef, meta map[string]string) error {
+	return b.mgr.SetLabels(ref.Tenant, meta)
+}
+
+// GetMeta reads the container's labels.
+func (b *Backend) GetMeta(_ context.Context, ref box.BoxRef) (map[string]string, error) {
+	return b.mgr.GetLabels(ref.Tenant)
+}
+
+// Exec runs a command inside the container and returns its output.
+// Implements box.ExecCapable.
+func (b *Backend) Exec(_ context.Context, ref box.BoxRef, cmd []string) (string, string, error) {
+	return b.mgr.ExecWithOutput(containerName(ref), cmd)
+}
+
+// WriteFile writes a file inside the container. Implements box.ExecCapable.
+func (b *Backend) WriteFile(_ context.Context, ref box.BoxRef, path string, content []byte, mode string) error {
+	return b.mgr.WriteFile(containerName(ref), path, content, mode)
+}
+
+// Metrics returns runtime metrics for the container. Implements
+// box.MetricsCapable.
+func (b *Backend) Metrics(_ context.Context, ref box.BoxRef) (*box.BoxMetrics, error) {
+	m, err := b.mgr.GetMetrics(ref.Tenant)
+	if err != nil {
+		return nil, err
+	}
+	if m == nil {
+		return nil, nil
+	}
+	return &box.BoxMetrics{
+		CPUUsageSeconds:  m.CPUUsageSeconds,
+		MemoryUsageBytes: m.MemoryUsageBytes,
+		MemoryLimitBytes: m.MemoryLimitBytes,
+		DiskUsageBytes:   m.DiskUsageBytes,
+		NetworkRxBytes:   m.NetworkRxBytes,
+		NetworkTxBytes:   m.NetworkTxBytes,
+		ProcessCount:     m.ProcessCount,
+	}, nil
+}
+
+// --- pure mapping helpers (unit-tested directly) ---
+
+// specToCreateOptions maps the runtime-neutral spec onto the Manager's
+// CreateOptions. Fields the box seam does not yet model (StaticIP, podman,
+// git source, OTel endpoint) stay at their zero value and are added as the
+// server wiring needs them.
+func specToCreateOptions(spec box.BoxSpec) container.CreateOptions {
+	return container.CreateOptions{
+		Username:        spec.Ref.Tenant,
+		Image:           spec.Image,
+		CPU:             spec.Resources.CPU,
+		Memory:          spec.Resources.Memory,
+		Disk:            spec.Resources.Disk,
+		GPUs:            spec.GPUs,
+		SSHKeys:         spec.SSHKeys,
+		Labels:          spec.Labels,
+		OSType:          spec.OSType,
+		Monitoring:      spec.Monitoring,
+		Stack:           spec.Stack,
+		StackParameters: spec.StackParams,
+		AutoStart:       spec.AutoStart,
+	}
+}
+
+// infoToStatus maps incus.ContainerInfo onto the runtime-neutral BoxStatus.
+func infoToStatus(info *incus.ContainerInfo) box.BoxStatus {
+	tenant := tenantOf(info)
+	return box.BoxStatus{
+		Ref:   box.BoxRef{Tenant: tenant, Name: info.Name},
+		State: parseState(info.State),
+		Endpoint: box.BoxEndpoint{
+			SSHUser:    tenant,
+			DirectIP:   info.IPAddress,
+			AccessType: pb.AccessType_ACCESS_TYPE_SSH,
+		},
+		Resources: box.ResourceLimits{CPU: info.CPU, Memory: info.Memory, Disk: info.Disk},
+		Meta:      info.Labels,
+		BackendID: info.BackendID,
+	}
+}
+
+// parseState maps an incus state string to the proto enum. Mirrors the
+// daemon's toProtoContainer mapping so the seam reports identical states.
+func parseState(s string) pb.ContainerState {
+	switch s {
+	case "Running":
+		return pb.ContainerState_CONTAINER_STATE_RUNNING
+	case "Stopped":
+		return pb.ContainerState_CONTAINER_STATE_STOPPED
+	case "Frozen":
+		return pb.ContainerState_CONTAINER_STATE_FROZEN
+	default:
+		return pb.ContainerState_CONTAINER_STATE_UNSPECIFIED
+	}
+}
+
+// tenantOf recovers the routing user/tenant from container info: the daemon's
+// reported Username when present, else the name with the "-container" suffix
+// stripped (the create-time naming convention).
+func tenantOf(info *incus.ContainerInfo) string {
+	if info.Username != "" {
+		return info.Username
+	}
+	return strings.TrimSuffix(info.Name, "-container")
+}
+
+// containerName resolves the substrate-level container name for a ref: the
+// explicit Name when set, else derived from Tenant via the naming convention.
+func containerName(ref box.BoxRef) string {
+	if ref.Name != "" {
+		return ref.Name
+	}
+	return ref.Tenant + "-container"
+}

--- a/pkg/core/box/lxc/lxc_test.go
+++ b/pkg/core/box/lxc/lxc_test.go
@@ -1,0 +1,267 @@
+package lxc
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// newTestBackend wires an lxc.Backend over a Manager backed by the shared
+// incustest.MockBackend, so delegation can be exercised without a real host.
+func newTestBackend(mock *incustest.MockBackend) *Backend {
+	return New(container.NewWithBackend(mock))
+}
+
+func TestKind(t *testing.T) {
+	if got := New(nil).Kind(); got != box.KindLXC {
+		t.Fatalf("Kind() = %q, want %q", got, box.KindLXC)
+	}
+}
+
+func TestParseState(t *testing.T) {
+	cases := map[string]pb.ContainerState{
+		"Running": pb.ContainerState_CONTAINER_STATE_RUNNING,
+		"Stopped": pb.ContainerState_CONTAINER_STATE_STOPPED,
+		"Frozen":  pb.ContainerState_CONTAINER_STATE_FROZEN,
+		"":        pb.ContainerState_CONTAINER_STATE_UNSPECIFIED,
+		"weird":   pb.ContainerState_CONTAINER_STATE_UNSPECIFIED,
+	}
+	for in, want := range cases {
+		if got := parseState(in); got != want {
+			t.Errorf("parseState(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestTenantOf(t *testing.T) {
+	if got := tenantOf(&incus.ContainerInfo{Username: "alice", Name: "alice-container"}); got != "alice" {
+		t.Errorf("tenantOf with Username = %q, want alice", got)
+	}
+	// Falls back to stripping the -container suffix when Username is empty.
+	if got := tenantOf(&incus.ContainerInfo{Name: "bob-container"}); got != "bob" {
+		t.Errorf("tenantOf fallback = %q, want bob", got)
+	}
+}
+
+func TestContainerName(t *testing.T) {
+	if got := containerName(box.BoxRef{Tenant: "alice"}); got != "alice-container" {
+		t.Errorf("containerName derived = %q, want alice-container", got)
+	}
+	if got := containerName(box.BoxRef{Tenant: "alice", Name: "explicit"}); got != "explicit" {
+		t.Errorf("containerName explicit = %q, want explicit", got)
+	}
+}
+
+func TestSpecToCreateOptions(t *testing.T) {
+	spec := box.BoxSpec{
+		Ref:         box.BoxRef{Tenant: "alice"},
+		Image:       "ubuntu/24.04",
+		OSType:      pb.OSType_OS_TYPE_UBUNTU_2404,
+		Resources:   box.ResourceLimits{CPU: "2", Memory: "4GB", Disk: "20GB"},
+		GPUs:        []string{"0"},
+		SSHKeys:     []string{"ssh-ed25519 AAAA"},
+		Labels:      map[string]string{"team": "infra"},
+		Monitoring:  true,
+		Stack:       "python",
+		StackParams: map[string]string{"version": "3.12"},
+		AutoStart:   true,
+	}
+	got := specToCreateOptions(spec)
+	want := container.CreateOptions{
+		Username:        "alice",
+		Image:           "ubuntu/24.04",
+		CPU:             "2",
+		Memory:          "4GB",
+		Disk:            "20GB",
+		GPUs:            []string{"0"},
+		SSHKeys:         []string{"ssh-ed25519 AAAA"},
+		Labels:          map[string]string{"team": "infra"},
+		OSType:          pb.OSType_OS_TYPE_UBUNTU_2404,
+		Monitoring:      true,
+		Stack:           "python",
+		StackParameters: map[string]string{"version": "3.12"},
+		AutoStart:       true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("specToCreateOptions mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+func TestInfoToStatus(t *testing.T) {
+	info := &incus.ContainerInfo{
+		Name:      "alice-container",
+		Username:  "alice",
+		State:     "Running",
+		IPAddress: "10.0.0.5",
+		CPU:       "2",
+		Memory:    "4GB",
+		Disk:      "20GB",
+		Labels:    map[string]string{"team": "infra"},
+		BackendID: "node-a",
+	}
+	st := infoToStatus(info)
+	if st.Ref != (box.BoxRef{Tenant: "alice", Name: "alice-container"}) {
+		t.Errorf("Ref = %+v", st.Ref)
+	}
+	if st.State != pb.ContainerState_CONTAINER_STATE_RUNNING {
+		t.Errorf("State = %v", st.State)
+	}
+	wantEP := box.BoxEndpoint{SSHUser: "alice", DirectIP: "10.0.0.5", AccessType: pb.AccessType_ACCESS_TYPE_SSH}
+	if st.Endpoint != wantEP {
+		t.Errorf("Endpoint = %+v, want %+v", st.Endpoint, wantEP)
+	}
+	if st.Resources != (box.ResourceLimits{CPU: "2", Memory: "4GB", Disk: "20GB"}) {
+		t.Errorf("Resources = %+v", st.Resources)
+	}
+	if st.BackendID != "node-a" || !reflect.DeepEqual(st.Meta, info.Labels) {
+		t.Errorf("BackendID/Meta = %q / %+v", st.BackendID, st.Meta)
+	}
+}
+
+func TestLifecycleDelegation(t *testing.T) {
+	mock := incustest.NewMockBackend()
+	mock.Containers["alice-container"] = &incus.ContainerInfo{
+		Name:      "alice-container",
+		State:     "Stopped",
+		IPAddress: "10.0.0.5",
+	}
+	b := newTestBackend(mock)
+	ctx := context.Background()
+	ref := box.BoxRef{Tenant: "alice"}
+
+	// Get
+	st, err := b.Get(ctx, ref)
+	if err != nil || st == nil {
+		t.Fatalf("Get returned (%v, %v)", st, err)
+	}
+	if st.Ref.Tenant != "alice" || st.Endpoint.DirectIP != "10.0.0.5" {
+		t.Errorf("Get status = %+v", st)
+	}
+
+	// Get of a missing box → (nil, nil)
+	if missing, err := b.Get(ctx, box.BoxRef{Tenant: "ghost"}); err != nil || missing != nil {
+		t.Errorf("Get(missing) = (%v, %v), want (nil, nil)", missing, err)
+	}
+
+	// List
+	list, err := b.List(ctx)
+	if err != nil || len(list) != 1 {
+		t.Fatalf("List returned (%d, %v)", len(list), err)
+	}
+
+	// Start / Stop toggle the mock state.
+	if err := b.Start(ctx, ref); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if mock.Containers["alice-container"].State != "Running" {
+		t.Errorf("after Start, state = %q", mock.Containers["alice-container"].State)
+	}
+	if err := b.Stop(ctx, ref, false); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if mock.Containers["alice-container"].State != "Stopped" {
+		t.Errorf("after Stop, state = %q", mock.Containers["alice-container"].State)
+	}
+
+	// Resolve mirrors Get's endpoint.
+	ep, err := b.Resolve(ctx, ref)
+	if err != nil || ep == nil || ep.DirectIP != "10.0.0.5" || ep.SSHUser != "alice" {
+		t.Errorf("Resolve = (%+v, %v)", ep, err)
+	}
+
+	// Delete removes it.
+	if err := b.Delete(ctx, ref, true); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok := mock.Containers["alice-container"]; ok {
+		t.Errorf("after Delete, container still present")
+	}
+}
+
+func TestResizeDelegation(t *testing.T) {
+	mock := incustest.NewMockBackend()
+	mock.Containers["alice-container"] = &incus.ContainerInfo{Name: "alice-container", State: "Running"}
+	var gotDisk, gotCPU, gotMem string
+	mock.SetDeviceSizeFunc = func(_, dev, size string) error {
+		if dev == "root" {
+			gotDisk = size
+		}
+		return nil
+	}
+	mock.SetCPULimitFunc = func(_, cpu string) error { gotCPU = cpu; return nil }
+	mock.SetConfigFunc = func(_, key, val string) error {
+		if key == "limits.memory" {
+			gotMem = val
+		}
+		return nil
+	}
+	b := newTestBackend(mock)
+	if err := b.Resize(context.Background(), box.BoxRef{Tenant: "alice"}, box.ResourceLimits{CPU: "4", Memory: "8GB", Disk: "40GB"}); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+	if gotCPU != "4" || gotMem != "8GB" || gotDisk != "40GB" {
+		t.Errorf("Resize delegated cpu=%q mem=%q disk=%q", gotCPU, gotMem, gotDisk)
+	}
+}
+
+func TestMetaDelegation(t *testing.T) {
+	mock := incustest.NewMockBackend()
+	var setLabels map[string]string
+	mock.SetLabelsFunc = func(_ string, labels map[string]string) error { setLabels = labels; return nil }
+	mock.GetLabelsFunc = func(_ string) (map[string]string, error) {
+		return map[string]string{"team": "infra"}, nil
+	}
+	b := newTestBackend(mock)
+	ref := box.BoxRef{Tenant: "alice"}
+
+	if err := b.SetMeta(context.Background(), ref, map[string]string{"env": "prod"}); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	if !reflect.DeepEqual(setLabels, map[string]string{"env": "prod"}) {
+		t.Errorf("SetMeta delegated labels = %+v", setLabels)
+	}
+
+	meta, err := b.GetMeta(context.Background(), ref)
+	if err != nil || !reflect.DeepEqual(meta, map[string]string{"team": "infra"}) {
+		t.Errorf("GetMeta = (%+v, %v)", meta, err)
+	}
+}
+
+func TestMetricsDelegation(t *testing.T) {
+	mock := incustest.NewMockBackend()
+	mock.GetContainerMetricsFunc = func(name string) (*incus.ContainerMetrics, error) {
+		return &incus.ContainerMetrics{Name: name, CPUUsageSeconds: 42, MemoryUsageBytes: 1024, ProcessCount: 7}, nil
+	}
+	b := newTestBackend(mock)
+	m, err := b.Metrics(context.Background(), box.BoxRef{Tenant: "alice"})
+	if err != nil || m == nil {
+		t.Fatalf("Metrics returned (%v, %v)", m, err)
+	}
+	if m.CPUUsageSeconds != 42 || m.MemoryUsageBytes != 1024 || m.ProcessCount != 7 {
+		t.Errorf("Metrics mapping = %+v", m)
+	}
+}
+
+func TestSetAuthorizedKeysDelegation(t *testing.T) {
+	mock := incustest.NewMockBackend()
+	var wrotePath string
+	mock.WriteFileFunc = func(_, path string, _ []byte, _ string) error {
+		wrotePath = path
+		return nil
+	}
+	b := newTestBackend(mock)
+	// Empty key set exercises the delegation path (mkdir/chmod/write/chown)
+	// without depending on SSH key validation.
+	if err := b.SetAuthorizedKeys(context.Background(), box.BoxRef{Tenant: "alice"}, nil); err != nil {
+		t.Fatalf("SetAuthorizedKeys: %v", err)
+	}
+	if wrotePath != "/home/alice/.ssh/authorized_keys" {
+		t.Errorf("authorized_keys written to %q", wrotePath)
+	}
+}

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -715,6 +715,15 @@ func (m *Manager) createUser(containerName, username string, family ostype.OSFam
 	return nil
 }
 
+// SetAuthorizedKeys sets a user's authorized_keys to exactly the given set of
+// SSH public keys. It is the exported entry point for the box.BoxBackend seam
+// (pkg/core/box/lxc); it delegates to the same addSSHKeys path the create flow
+// uses, which overwrites authorized_keys via the Incus file push API. The
+// container name follows the create-time convention (<username>-container).
+func (m *Manager) SetAuthorizedKeys(username string, sshKeys []string) error {
+	return m.addSSHKeys(username+"-container", username, sshKeys)
+}
+
 // addSSHKeys adds SSH public keys to a user's authorized_keys
 // SECURITY: Uses Incus file push API to avoid shell injection vulnerabilities
 func (m *Manager) addSSHKeys(containerName, username string, sshKeys []string) error {


### PR DESCRIPTION
First implementation step of the K8s agent-box backend (design: #700, doc PR #701). **Purely additive, behavior-preserving** — introduces the seam, rewires nothing.

## What

- **`pkg/core/box`** — the runtime-neutral `BoxBackend` interface (lifecycle + `Resolve` + `SetAuthorizedKeys` + `Resize` + `Meta`), sitting one altitude *above* the leaky LXC-shaped `incus.Backend`. Plus runtime-neutral types (`BoxRef`/`BoxSpec`/`BoxHandle`/`BoxEndpoint`/`BoxStatus`/`BoxMetrics`) and optional capability interfaces (`ExecCapable`/`MetricsCapable`/`GPUCapable`).
- **`pkg/core/box/lxc`** — `Backend`, a pure adapter delegating every method to the existing `container.Manager`. State mapping mirrors the daemon's `toProtoContainer` so the seam reports identical states.
- **`container.Manager.SetAuthorizedKeys`** — thin exported wrapper over the existing `addSSHKeys` path (exposes current behavior; does not change it).

## Why this shape

- The seam is **above** `incus.Backend` because that interface is LXC-shaped (`Exec`, `WriteFile`, `ResolveGPUInputToPCI`, raw config-key writes) and a non-incus runtime can't implement it cleanly.
- SSH addressing + key-sync sit **below** the seam (`Resolve` / `SetAuthorizedKeys`) because the mechanism is runtime-specific (LXC jump-server vs K8s Secret + `PiperUpstream`).
- Interface lives in **`pkg/core/box`** (public, not `internal/`) so a later extraction to its own repo is a `git mv`, not a redesign — per the packaging strategy in the design doc.

## Not in this PR (follow-ups)

- Rewiring `ContainerServer` to hold a `BoxBackend` instead of `*Manager`.
- `BoxSpec` fields the seam doesn't yet model (StaticIP, podman, git source, OTel) — added as the server wiring needs them.
- The K8s implementation (behind `//go:build k8s`).

## Tests

`go test ./pkg/core/box/...` — pure mapper tests white-box (`parseState`, `specToCreateOptions`, `infoToStatus`, `tenantOf`, `containerName`) + lifecycle delegation through the shared `incustest.MockBackend` (Get/List/Start/Stop/Resolve/Delete/Resize/Meta/Metrics/SetAuthorizedKeys). Full `go build ./...` and `go vet` clean; existing `container` package tests still green.