### PR TITLE
feat(box): scaffold k8s BoxBackend skeleton behind //go:build k8s (#700)

### DIFF
--- a/pkg/core/box/k8s/doc.go
+++ b/pkg/core/box/k8s/doc.go
@@ -1,0 +1,17 @@
+// Package k8s implements box.BoxBackend on Kubernetes: a per-tenant pod an
+// agent reaches over SSH, serving the same agent-box stdio MCP surface as the
+// LXC backend. See docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md.
+//
+// The implementation lives behind the `k8s` build tag (k8s.go) so the heavy
+// k8s.io/client-go dependency never enters the default daemon build — only a
+// `containarium-k8s` build variant compiles it. This file carries no build
+// constraint so the package always has a buildable file (otherwise
+// `go build ./...` would fail with "build constraints exclude all Go files");
+// it intentionally contains nothing but the package declaration and this doc.
+//
+// Status: skeleton. The Backend type satisfies box.BoxBackend at compile time
+// (under -tags k8s) but every method returns ErrNotImplemented. The client-go
+// wiring + the StatefulSet/Service/NetworkPolicy/PiperUpstream reconciliation
+// land in follow-ups; this scaffold fixes the package shape and the build-tag
+// seam first.
+package k8s

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -1,0 +1,134 @@
+//go:build k8s
+
+package k8s
+
+import (
+	"context"
+	"errors"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+)
+
+// ErrNotImplemented is returned by every Backend method until the real
+// reconciliation lands. It lets the skeleton satisfy box.BoxBackend (and
+// compile under -tags k8s) without pulling in client-go yet.
+var ErrNotImplemented = errors.New("k8s box backend: not implemented (skeleton)")
+
+// Config is the K8s backend's wiring. It is supplied at daemon start when the
+// `k8s` build variant selects this backend. Field values map onto the design
+// note's topology (docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md).
+type Config struct {
+	// Kubeconfig is the path to a kubeconfig file. Empty means in-cluster
+	// config (the daemon runs as a pod with a mounted ServiceAccount).
+	Kubeconfig string
+
+	// GatewayNamespace is where the in-cluster sshpiper Deployment + its
+	// LoadBalancer Service live (the `agent-gateway` namespace).
+	GatewayNamespace string
+
+	// GatewayHost / GatewaySSHPort is the public SSH endpoint agents connect
+	// to — the sshpiper LB. Surfaced in BoxEndpoint.SSHHost/SSHPort so the
+	// server can build the connect target without inferring it.
+	GatewayHost    string
+	GatewaySSHPort int
+
+	// TenantNamespacePrefix prefixes the per-tenant namespace
+	// (e.g. "tenant-" → "tenant-<tenant>"); namespace-per-tenant +
+	// default-deny NetworkPolicy is the v1 isolation model.
+	TenantNamespacePrefix string
+
+	// BoxImage is the agent-box image (sshd + agent-box, ForceCommand-pinned)
+	// the per-tenant StatefulSet runs.
+	BoxImage string
+
+	// StorageClass is the StorageClass for the box's PVC (empty = cluster
+	// default).
+	StorageClass string
+}
+
+// Backend implements box.BoxBackend on Kubernetes.
+//
+// Capability note: this backend deliberately does NOT implement
+// box.ExecCapable — the K8s agent-box is pinned by sshd ForceCommand and its
+// provisioning is image-baked, so there is no in-box exec/file-push seam (the
+// LXC backend's incus-exec path has no K8s analog). box.MetricsCapable and
+// box.GPUCapable are likewise deferred. Callers discover all of this by type
+// assertion, exactly as the seam intends.
+type Backend struct {
+	cfg Config
+	// clientset kubernetes.Interface — wired when client-go lands (follow-up).
+}
+
+// Compile-time assertion: the skeleton satisfies the core interface.
+var _ box.BoxBackend = (*Backend)(nil)
+
+// New constructs a K8s backend from cfg. The real implementation builds a
+// client-go clientset (in-cluster or from cfg.Kubeconfig) and verifies the
+// gateway namespace + PiperUpstream CRD are present; the skeleton just holds
+// the config.
+func New(cfg Config) (*Backend, error) {
+	return &Backend{cfg: cfg}, nil
+}
+
+// Kind reports the Kubernetes substrate.
+func (b *Backend) Kind() box.BackendKind { return box.KindK8s }
+
+// Create will template the per-tenant namespace + StatefulSet (box-0) +
+// headless Service + default-deny NetworkPolicy + per-tenant key Secret, and
+// program the sshpiper PiperUpstream so the gateway routes username→pod.
+func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus, error) {
+	return nil, ErrNotImplemented
+}
+
+// Start will scale the tenant's StatefulSet to 1 replica.
+func (b *Backend) Start(ctx context.Context, ref box.BoxRef) error {
+	return ErrNotImplemented
+}
+
+// Stop will scale the tenant's StatefulSet to 0 replicas.
+func (b *Backend) Stop(ctx context.Context, ref box.BoxRef, force bool) error {
+	return ErrNotImplemented
+}
+
+// Delete will remove the StatefulSet/Service/Secret/NetworkPolicy and the
+// PiperUpstream entry (and the tenant namespace when the backend owns it).
+func (b *Backend) Delete(ctx context.Context, ref box.BoxRef, force bool) error {
+	return ErrNotImplemented
+}
+
+// Get will read the StatefulSet pod + its annotations into a BoxStatus.
+func (b *Backend) Get(ctx context.Context, ref box.BoxRef) (*box.BoxStatus, error) {
+	return nil, ErrNotImplemented
+}
+
+// List will enumerate every per-tenant StatefulSet this backend manages.
+func (b *Backend) List(ctx context.Context) ([]box.BoxStatus, error) {
+	return nil, ErrNotImplemented
+}
+
+// Resolve will report the gateway SSH endpoint (cfg.GatewayHost:GatewaySSHPort,
+// SSHUser = tenant) that sshpiper routes to the tenant's pod.
+func (b *Backend) Resolve(ctx context.Context, ref box.BoxRef) (*box.BoxEndpoint, error) {
+	return nil, ErrNotImplemented
+}
+
+// SetAuthorizedKeys will reconcile the tenant's authorized key into the
+// per-tenant Secret (and ensure the matching PiperUpstream entry).
+func (b *Backend) SetAuthorizedKeys(ctx context.Context, ref box.BoxRef, keys []string) error {
+	return ErrNotImplemented
+}
+
+// Resize will patch the StatefulSet pod template's resource requests/limits.
+func (b *Backend) Resize(ctx context.Context, ref box.BoxRef, r box.ResourceLimits) error {
+	return ErrNotImplemented
+}
+
+// SetMeta will write the runtime-neutral metadata as pod annotations/labels.
+func (b *Backend) SetMeta(ctx context.Context, ref box.BoxRef, meta map[string]string) error {
+	return ErrNotImplemented
+}
+
+// GetMeta will read the pod's annotations/labels back into the metadata map.
+func (b *Backend) GetMeta(ctx context.Context, ref box.BoxRef) (map[string]string, error) {
+	return nil, ErrNotImplemented
+}

--- a/pkg/core/box/k8s/k8s_test.go
+++ b/pkg/core/box/k8s/k8s_test.go
@@ -1,0 +1,46 @@
+//go:build k8s
+
+package k8s
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+)
+
+// TestSkeletonShape locks the build-tag seam: the K8s backend constructs,
+// reports its kind, and every lifecycle method returns ErrNotImplemented until
+// the real reconciliation lands. Run with: go test -tags k8s ./pkg/core/box/k8s/
+func TestSkeletonShape(t *testing.T) {
+	b, err := New(Config{GatewayHost: "gw.example.com", GatewaySSHPort: 22})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if b.Kind() != box.KindK8s {
+		t.Fatalf("Kind() = %q, want %q", b.Kind(), box.KindK8s)
+	}
+
+	ctx := context.Background()
+	ref := box.BoxRef{Tenant: "alice"}
+
+	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref}); !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("Create err = %v, want ErrNotImplemented", err)
+	}
+	if _, err := b.Get(ctx, ref); !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("Get err = %v, want ErrNotImplemented", err)
+	}
+	if err := b.Start(ctx, ref); !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("Start err = %v, want ErrNotImplemented", err)
+	}
+	if err := b.SetAuthorizedKeys(ctx, ref, nil); !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("SetAuthorizedKeys err = %v, want ErrNotImplemented", err)
+	}
+
+	// The skeleton must NOT advertise ExecCapable — K8s provisioning is
+	// image-baked (ForceCommand), so there's no in-box exec seam.
+	if _, ok := interface{}(b).(box.ExecCapable); ok {
+		t.Error("k8s Backend should not implement box.ExecCapable")
+	}
+}


### PR DESCRIPTION
Stacked on #705. Scaffolds the **Kubernetes** implementation of `box.BoxBackend`, isolated behind the `k8s` build tag per the packaging strategy in the design doc.

> Stack: #704 (seam) → #705 (server rewire) → this. Targets `boxbackend-rewire-server` because it implements the finalized interface (`Create → *BoxStatus`, rich `BoxStatus`).

## What's here

- **`pkg/core/box/k8s/k8s.go`** (`//go:build k8s`): `Backend` satisfies `box.BoxBackend` (compile-time `var _` assertion). Every method returns `ErrNotImplemented` — this fixes the *shape* and the build-tag seam; the client-go wiring + StatefulSet/Service/NetworkPolicy/PiperUpstream reconciliation are follow-ups. `Config` carries the design-note wiring (kubeconfig, gateway namespace/host/port, per-tenant namespace prefix, box image, storage class), and each method's doc says what it *will* do.
- **`pkg/core/box/k8s/doc.go`** (untagged): package doc, and — importantly — keeps a buildable file in the package so `go build ./...` doesn't fail with *"build constraints exclude all Go files"*.
- **`k8s_test.go`** (`//go:build k8s`): locks the shape (kind, `ErrNotImplemented`, and the deliberate *absence* of `ExecCapable`).

## Why no client-go yet

The whole point of the build tag is to keep `k8s.io/client-go`'s heavy dependency tree out of the default daemon's `go.mod`/build. This skeleton adds **zero new dependencies** — it imports only `pkg/core/box` and stdlib. client-go lands with the first real reconciliation in a follow-up, at which point only the `containarium-k8s` build variant compiles it.

## Capability surface (by design)

The K8s backend **does not** implement `box.ExecCapable` — its agent-box is `ForceCommand`-pinned and provisioning is image-baked, so there's no in-box exec/file-push seam (the LXC incus-exec path has no K8s analog). `MetricsCapable`/`GPUCapable` are deferred. The test asserts the `ExecCapable` absence, demonstrating the optional-capability discovery pattern.

## Verified

- `go build ./...` — clean (tagged file excluded; `doc.go` keeps the package valid)
- `go build -tags k8s ./pkg/core/box/k8s/` — clean
- `go test -tags k8s ./pkg/core/box/k8s/` — pass
- `go vet ./...` and `go vet -tags k8s ./pkg/core/box/k8s/` — clean

## Not in this PR (follow-ups)

client-go wiring + real reconciliation; daemon-side backend selection under the build tag; the Helm chart / `kind` quickstart (#703).