### PR TITLE
feat(server): build-tag box-backend selection (lxc default / k8s variant) (#700)

### DIFF
--- a/internal/server/boxbackend_k8s.go
+++ b/internal/server/boxbackend_k8s.go
@@ -1,0 +1,45 @@
+//go:build k8s
+
+package server
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+	boxk8s "github.com/footprintai/containarium/pkg/core/box/k8s"
+	"github.com/footprintai/containarium/pkg/core/container"
+)
+
+// newBoxBackend selects the box runtime for the `containarium-k8s` build
+// variant: the Kubernetes backend, configured from CONTAINARIUM_K8S_* env.
+//
+// mgr is intentionally unused — the K8s backend talks to the kube-apiserver,
+// not incus. The server still constructs and holds a Manager for the
+// non-lifecycle surface (Exec, config keys, security scan, app hosting) during
+// the transition, so a K8s-only host today still needs incus reachable at
+// startup; making that construction incus-free is a follow-up.
+func newBoxBackend(_ *container.Manager) (box.BoxBackend, error) {
+	port, _ := strconv.Atoi(os.Getenv("CONTAINARIUM_K8S_GATEWAY_SSH_PORT"))
+	if port == 0 {
+		port = 22
+	}
+	return boxk8s.New(boxk8s.Config{
+		Kubeconfig:            os.Getenv("CONTAINARIUM_K8S_KUBECONFIG"),
+		GatewayNamespace:      k8sEnvOr("CONTAINARIUM_K8S_GATEWAY_NAMESPACE", "agent-gateway"),
+		GatewayHost:           os.Getenv("CONTAINARIUM_K8S_GATEWAY_HOST"),
+		GatewaySSHPort:        port,
+		TenantNamespacePrefix: k8sEnvOr("CONTAINARIUM_K8S_TENANT_NS_PREFIX", "tenant-"),
+		BoxImage:              os.Getenv("CONTAINARIUM_K8S_BOX_IMAGE"),
+		StorageClass:          os.Getenv("CONTAINARIUM_K8S_STORAGE_CLASS"),
+	})
+}
+
+// k8sEnvOr returns the env var value or a default when unset. Defined here (in
+// the k8s-tagged file) so it never collides with the default build.
+func k8sEnvOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/internal/server/boxbackend_lxc.go
+++ b/internal/server/boxbackend_lxc.go
@@ -1,0 +1,17 @@
+//go:build !k8s
+
+package server
+
+import (
+	"github.com/footprintai/containarium/pkg/core/box"
+	boxlxc "github.com/footprintai/containarium/pkg/core/box/lxc"
+	"github.com/footprintai/containarium/pkg/core/container"
+)
+
+// newBoxBackend selects the box runtime for this build. The default build
+// (no `k8s` tag) uses the LXC/incus backend wrapping the daemon's Manager —
+// today's behavior. The `k8s` build variant provides a different
+// implementation of this same function (boxbackend_k8s.go).
+func newBoxBackend(mgr *container.Manager) (box.BoxBackend, error) {
+	return boxlxc.New(mgr), nil
+}

--- a/internal/server/boxbackend_select_test.go
+++ b/internal/server/boxbackend_select_test.go
@@ -1,0 +1,28 @@
+//go:build !k8s
+
+package server
+
+import (
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+)
+
+// TestNewBoxBackend_SelectsLXC — the default build selects the LXC backend.
+// The k8s build variant's selection is exercised by the k8s package's own
+// skeleton test (go test -tags k8s ./pkg/core/box/k8s/).
+func TestNewBoxBackend_SelectsLXC(t *testing.T) {
+	mgr := container.NewWithBackend(incustest.NewMockBackend())
+	bb, err := newBoxBackend(mgr)
+	if err != nil {
+		t.Fatalf("newBoxBackend: %v", err)
+	}
+	if bb == nil {
+		t.Fatal("newBoxBackend returned nil backend")
+	}
+	if bb.Kind() != box.KindLXC {
+		t.Errorf("Kind() = %q, want %q", bb.Kind(), box.KindLXC)
+	}
+}

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -200,9 +200,13 @@ func NewContainerServer() (*ContainerServer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create container manager: %w", err)
 	}
+	bb, err := newBoxBackend(mgr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to select box backend: %w", err)
+	}
 	return &ContainerServer{
 		manager:          mgr,
-		boxBackend:       boxlxc.New(mgr),
+		boxBackend:       bb,
 		emitter:          events.NewEmitter(events.GetBus()),
 		pendingCreations: make(map[string]*PendingCreation),
 	}, nil


### PR DESCRIPTION
Stacked on #706. Makes the daemon **select** its box backend at compile time, so the `containarium-k8s` build variant runs on the K8s backend while the default binary stays on LXC.

> Stack: #704 → #705 → #706 → this.

## What changed

`NewContainerServer` now calls a build-tagged `newBoxBackend(mgr)` seam instead of hard-coding `boxlxc.New`:

- **`boxbackend_lxc.go`** (`//go:build !k8s`) — default: LXC backend over the Manager (today's behavior).
- **`boxbackend_k8s.go`** (`//go:build k8s`) — the `containarium-k8s` variant: the K8s backend, configured from `CONTAINARIUM_K8S_*` env (kubeconfig, gateway namespace/host/port, tenant-namespace prefix, box image, storage class).
- **`boxbackend_select_test.go`** (`//go:build !k8s`) — asserts the default build selects `KindLXC`. The k8s side is covered by the k8s package's own skeleton test.

The two selector files are mutually exclusive, so exactly one `newBoxBackend` exists per build.

## Transitional caveat (called out, not a regression)

The K8s variant still constructs a `Manager` — the server holds it for the non-lifecycle surface (Exec, config keys, security scan, app hosting) that hasn't moved behind the seam yet. So a K8s-only host today still needs incus reachable at `container.New()` startup. Making that construction incus-free is the natural next follow-up once more of the surface migrates.

## Verified

- `go build ./...` — clean (default, LXC selector)
- `go build -tags k8s ./...` — clean (**full repo incl. daemon main** compiles with the K8s selector + backend)
- `go vet ./...` and `go vet -tags k8s ./internal/server/ ./pkg/core/box/...` — clean
- `go test ./internal/server/` — green; selection test passes

## Follow-ups

client-go wiring + real reconciliation in the k8s backend; incus-free `container.New()` for K8s-only hosts; the build/release target for the `containarium-k8s` binary; Helm chart + `kind` quickstart (#703).