### PR TITLE
feat(server): incus-free startup for the k8s build variant (#700)

### DIFF
--- a/internal/server/boxbackend_k8s.go
+++ b/internal/server/boxbackend_k8s.go
@@ -3,12 +3,14 @@
 package server
 
 import (
+	"log"
 	"os"
 	"strconv"
 
 	"github.com/footprintai/containarium/pkg/core/box"
 	boxk8s "github.com/footprintai/containarium/pkg/core/box/k8s"
 	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
 )
 
 // newBoxBackend selects the box runtime for the `containarium-k8s` build
@@ -33,6 +35,21 @@ func newBoxBackend(_ *container.Manager) (box.BoxBackend, error) {
 		BoxImage:              os.Getenv("CONTAINARIUM_K8S_BOX_IMAGE"),
 		StorageClass:          os.Getenv("CONTAINARIUM_K8S_STORAGE_CLASS"),
 	})
+}
+
+// newManager constructs the daemon's container.Manager for the k8s variant.
+// A K8s node usually has no incus, so a failed connection is NOT fatal here:
+// the box-lifecycle surface is served by the Kubernetes backend, and the
+// residual incus-only Manager methods fall back to an UnavailableBackend that
+// returns clear errors instead of crashing. A host that happens to run both
+// (hybrid) still gets the real incus client.
+func newManager() (*container.Manager, error) {
+	mgr, err := container.New()
+	if err != nil {
+		log.Printf("[k8s] incus not reachable (%v); box lifecycle uses the Kubernetes backend — legacy incus-only RPCs will return errors", err)
+		return container.NewWithBackend(incus.NewUnavailableBackend()), nil
+	}
+	return mgr, nil
 }
 
 // k8sEnvOr returns the env var value or a default when unset. Defined here (in

--- a/internal/server/boxbackend_lxc.go
+++ b/internal/server/boxbackend_lxc.go
@@ -15,3 +15,10 @@ import (
 func newBoxBackend(mgr *container.Manager) (box.BoxBackend, error) {
 	return boxlxc.New(mgr), nil
 }
+
+// newManager constructs the daemon's container.Manager. The default build
+// requires a reachable incus — a failure here is fatal, as it always has been.
+// The `k8s` build variant overrides this to tolerate a host without incus.
+func newManager() (*container.Manager, error) {
+	return container.New()
+}

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -196,7 +196,7 @@ type upgradeJob struct {
 
 // NewContainerServer creates a new container server
 func NewContainerServer() (*ContainerServer, error) {
-	mgr, err := container.New()
+	mgr, err := newManager()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create container manager: %w", err)
 	}

--- a/pkg/core/incus/unavailable.go
+++ b/pkg/core/incus/unavailable.go
@@ -1,0 +1,72 @@
+package incus
+
+import (
+	"errors"
+	"time"
+
+	"github.com/lxc/incus/v6/shared/api"
+)
+
+// ErrUnavailable is returned by every UnavailableBackend method. It marks a
+// host where incus is not reachable — e.g. the Kubernetes build variant
+// running on a node with no incus daemon. Box lifecycle on such a host is
+// served by a different box backend (pkg/core/box); any residual incus-only
+// operation fails cleanly with this error instead of panicking on a nil
+// client.
+var ErrUnavailable = errors.New("incus backend not available on this host")
+
+// UnavailableBackend implements Backend with every method returning
+// ErrUnavailable. It lets the daemon construct a container.Manager on a host
+// without incus so the process can still start; the box-lifecycle surface is
+// served by another backend, and the legacy incus-only Manager methods return
+// a clear error rather than crash.
+type UnavailableBackend struct{}
+
+// NewUnavailableBackend returns an UnavailableBackend.
+func NewUnavailableBackend() *UnavailableBackend { return &UnavailableBackend{} }
+
+// Compile-time assertion.
+var _ Backend = (*UnavailableBackend)(nil)
+
+func (*UnavailableBackend) CreateContainer(ContainerConfig) error       { return ErrUnavailable }
+func (*UnavailableBackend) StartContainer(string) error                 { return ErrUnavailable }
+func (*UnavailableBackend) StopContainer(string, bool) error            { return ErrUnavailable }
+func (*UnavailableBackend) DeleteContainer(string) error                { return ErrUnavailable }
+func (*UnavailableBackend) GetContainer(string) (*ContainerInfo, error) { return nil, ErrUnavailable }
+func (*UnavailableBackend) ListContainers() ([]ContainerInfo, error)    { return nil, ErrUnavailable }
+func (*UnavailableBackend) WaitForNetwork(string, time.Duration) (string, error) {
+	return "", ErrUnavailable
+}
+func (*UnavailableBackend) Exec(string, []string) error { return ErrUnavailable }
+func (*UnavailableBackend) ExecWithOutput(string, []string) (string, string, error) {
+	return "", "", ErrUnavailable
+}
+func (*UnavailableBackend) WriteFile(string, string, []byte, string) error { return ErrUnavailable }
+func (*UnavailableBackend) ReadFile(string, string) ([]byte, error)        { return nil, ErrUnavailable }
+func (*UnavailableBackend) SetConfig(string, string, string) error         { return ErrUnavailable }
+func (*UnavailableBackend) SetCPULimit(string, string) error               { return ErrUnavailable }
+func (*UnavailableBackend) UnsetConfig(string, string) error               { return ErrUnavailable }
+func (*UnavailableBackend) SetDeviceSize(string, string, string) error     { return ErrUnavailable }
+func (*UnavailableBackend) UpdateContainerConfig(string, string, string) error {
+	return ErrUnavailable
+}
+func (*UnavailableBackend) GetRawInstance(string) (map[string]string, string, error) {
+	return nil, "", ErrUnavailable
+}
+func (*UnavailableBackend) ResolveGPUInputToPCI(string) (string, error) { return "", ErrUnavailable }
+func (*UnavailableBackend) CleanupDisk(string) (string, int64, error) {
+	return "", 0, ErrUnavailable
+}
+func (*UnavailableBackend) AddLabel(string, string, string) error { return ErrUnavailable }
+func (*UnavailableBackend) RemoveLabel(string, string) error      { return ErrUnavailable }
+func (*UnavailableBackend) GetLabels(string) (map[string]string, error) {
+	return nil, ErrUnavailable
+}
+func (*UnavailableBackend) SetLabels(string, map[string]string) error { return ErrUnavailable }
+func (*UnavailableBackend) GetServerInfo() (*api.Server, error)       { return nil, ErrUnavailable }
+func (*UnavailableBackend) GetContainerMetrics(string) (*ContainerMetrics, error) {
+	return nil, ErrUnavailable
+}
+func (*UnavailableBackend) GetContainerImageFingerprint(string) (string, error) {
+	return "", ErrUnavailable
+}

--- a/pkg/core/incus/unavailable_test.go
+++ b/pkg/core/incus/unavailable_test.go
@@ -1,0 +1,30 @@
+package incus
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestUnavailableBackend_ReturnsErrUnavailable — a representative sample of the
+// Backend surface returns ErrUnavailable rather than panicking, so a daemon on
+// a host without incus can still construct a Manager and start.
+func TestUnavailableBackend_ReturnsErrUnavailable(t *testing.T) {
+	b := NewUnavailableBackend()
+
+	if err := b.StartContainer("x"); !errors.Is(err, ErrUnavailable) {
+		t.Errorf("StartContainer err = %v, want ErrUnavailable", err)
+	}
+	if _, err := b.GetContainer("x"); !errors.Is(err, ErrUnavailable) {
+		t.Errorf("GetContainer err = %v, want ErrUnavailable", err)
+	}
+	if _, err := b.ListContainers(); !errors.Is(err, ErrUnavailable) {
+		t.Errorf("ListContainers err = %v, want ErrUnavailable", err)
+	}
+	if _, err := b.WaitForNetwork("x", time.Second); !errors.Is(err, ErrUnavailable) {
+		t.Errorf("WaitForNetwork err = %v, want ErrUnavailable", err)
+	}
+	if _, _, err := b.ExecWithOutput("x", []string{"true"}); !errors.Is(err, ErrUnavailable) {
+		t.Errorf("ExecWithOutput err = %v, want ErrUnavailable", err)
+	}
+}


### PR DESCRIPTION
Stacked on #707. Lets the `containarium-k8s` binary **boot on a node with no incus** — the last thing standing between the build-tag stack and an actually-startable K8s variant.

> Stack: #704 → #705 → #706 → #707 → this.

## What changed

Manager construction moves behind the same build-tagged seam as backend selection (`newManager()`):

- **`newManager()`** in `boxbackend_lxc.go` (default): `container.New()` — incus required, failure fatal, exactly as before.
- **`newManager()`** in `boxbackend_k8s.go`: tolerates a missing incus — on connect failure it logs and falls back to a `Manager` over `incus.UnavailableBackend`. The process starts; box lifecycle runs through the Kubernetes backend. A **hybrid** host that does run incus still gets the real client.
- **`incus.UnavailableBackend`**: implements `incus.Backend` with every method returning `incus.ErrUnavailable`, so the residual incus-only `Manager` calls (Exec, config keys, …) return a clear error instead of panicking on a nil client.
- `NewContainerServer` calls `newManager()` instead of `container.New()` directly.

## Why a stub backend (not nil)

The server still holds a `Manager` for the non-lifecycle surface that hasn't migrated behind the seam. A nil `Manager` would panic on any of those calls; `UnavailableBackend` turns them into clean `ErrUnavailable` errors — the difference between "feature not available on this runtime" and a crash.

## Net effect

`go build -tags k8s ./...` already compiled; now the resulting binary also **starts** without incus and serves box lifecycle via the (skeleton) K8s backend. The default binary is unchanged — `newManager()` there is just `container.New()`.

## Verified

- `go build ./...` and `go build -tags k8s ./...` — clean
- `go vet ./...` and `go vet -tags k8s ./internal/server/` — clean
- `go test ./pkg/core/incus/ ./internal/server/` — green (incl. new `UnavailableBackend` test)

## Follow-ups

client-go wiring + real reconciliation in the k8s backend (the first heavy-dep PR); migrating more of the non-lifecycle surface off `Manager` so `UnavailableBackend` is hit less; Helm chart + `kind` quickstart (#703).