### PR TITLE
feat(k8s): wire sshpiper gateway routing via the Pipe CRD (#700)

### DIFF
--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -110,9 +110,12 @@ The new piece is a thin **upstream controller** replacing the sentinel's
 
 - Watches tenant objects (CRD or labeled namespaces) + their box pods.
 - Programs the sshpiper upstream map via the maintained sshpiper **Kubernetes
-  plugin** (`PiperUpstream` CRD): `username=<tenant>` →
-  `box-0.boxes.<tenant>.svc:22`. CRD-driven removes the file-write race that
-  bit the sentinel (the `#301`/`#404` class of bug) entirely.
+  plugin** CRD — the `Pipe` resource (`sshpiper.com/v1beta1`, plural `pipes`;
+  earlier drafts of this note called it "PiperUpstream"): `spec.from[].username
+  = <tenant>` → `spec.to.host = box-0.boxes.<tenant>.svc:22`, with the box's
+  authorized keys inline as `authorized_keys_data`. The daemon manages Pipes via
+  the dynamic client (no sshpiper Go types imported). CRD-driven removes the
+  file-write race that bit the sentinel (the `#301`/`#404` class of bug).
 - Reconciles each tenant's authorized key into the per-tenant Secret.
 
 ### 3. Isolation (NetworkPolicy)
@@ -131,7 +134,7 @@ Per tenant namespace:
 | --- | --- |
 | `agent-box` over stdio, SSH-wrapped | identical — same binary, same `ForceCommand` |
 | sshpiper on sentinel :22 | sshpiper Deployment + LB Service :22 |
-| sentinel key-sync → YAML | controller → `PiperUpstream` CRD + Secret |
+| sentinel key-sync → YAML | controller → `Pipe` CRD + Secret |
 | LXC box per tenant | StatefulSet `box-0` per tenant namespace |
 | eBPF deny-by-default + egress allowlist | default-deny NetworkPolicy + egress allowlist |
 | sshd 2222 (mgmt) vs sshpiper 22 | mgmt via `kubectl`/RBAC; sshpiper owns 22 |
@@ -146,7 +149,7 @@ containarium box create --runtime=k8s --tenant=<t>
 ```
 
 templates the namespace + StatefulSet + headless Service + NetworkPolicy +
-`PiperUpstream` CRD + per-tenant key Secret. The platform MCP tool wraps the
+`Pipe` CRD + per-tenant key Secret. The platform MCP tool wraps the
 **same Go function** the CLI handler calls. The backend is selected behind a
 runtime interface; LXC stays the default.
 
@@ -163,7 +166,7 @@ fork. Two facts about the current code shape where it goes:
 2. SSH addressing + key-sync currently live **above** the incus backend, in
    the `Manager`/`jump_server` layer (host user + `authorized_keys` consumed by
    the sentinel keysync). But those are **runtime-specific**: LXC uses a host
-   jump-server account; K8s uses a per-tenant Secret + `PiperUpstream`. So
+   jump-server account; K8s uses a per-tenant Secret + `Pipe`. So
    addressing and key-sync must move **below** the seam.
 
 So the seam sits one altitude **above** `incus.Backend` (a coarse,
@@ -199,7 +202,7 @@ type BoxBackend interface {
 
     // SSH identity. Below the seam because the mechanism differs per runtime:
     // LXC writes the host jump-server authorized_keys; K8s reconciles the
-    // per-tenant Secret + PiperUpstream.
+    // per-tenant Secret + Pipe.
     SetAuthorizedKeys(ctx context.Context, ref BoxRef, keys []string) error
 
     // Mutation. Meta is the runtime-neutral replacement for raw incus config
@@ -489,7 +492,7 @@ clusters cleanly. That is a feature: the RBAC ask is small and auditable.
 | Verb scope | Resources | Boundary |
 | --- | --- | --- |
 | create/get/delete | StatefulSet, Service, Secret, NetworkPolicy | **label-selected tenant namespaces only** |
-| CRUD | `PiperUpstream` | gateway namespace only |
+| CRUD | `Pipe` | gateway namespace only |
 | create | Namespace | only if the controller owns tenant-namespace lifecycle |
 
 Shipped as a **Helm chart / operator bundle** the customer reviews and installs.
@@ -501,7 +504,7 @@ Containarium then drives the cluster through the controller's ServiceAccount.
 | --- | --- | --- |
 | **L4/TCP ingress** (LoadBalancer / NodePort / Gateway API `TCPRoute`) | SSH is TCP; K8s Ingress is HTTP-only | NodePort + external LB; `kubectl port-forward` for dev |
 | **NetworkPolicy-enforcing CNI** (Calico, Cilium, …) | default-deny isolation is a **no-op** under a CNI that ignores it | degrade to namespace-only isolation — **must flag loudly** |
-| **CRD install rights** (cluster-admin, once) for `PiperUpstream` | the sshpiper Kubernetes plugin is CRD-driven | `yaml` plugin — re-inherits the sentinel file-write race |
+| **CRD install rights** (cluster-admin, once) for `Pipe` | the sshpiper Kubernetes plugin is CRD-driven | `yaml` plugin — re-inherits the sentinel file-write race |
 | **Namespace-create rights** for the controller | namespace-per-tenant | pin to one shared namespace + label/pod-selector separation (weaker) |
 
 ### Degraded modes (named, not silent)

--- a/pkg/core/box/k8s/e2e_test.go
+++ b/pkg/core/box/k8s/e2e_test.go
@@ -8,6 +8,15 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/footprintai/containarium/pkg/core/box"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
@@ -101,4 +110,129 @@ func waitForState(t *testing.T, b *Backend, ref box.BoxRef, want pb.ContainerSta
 	}
 	t.Fatalf("box did not reach %v within %s (last: %+v)", want, timeout, last)
 	return nil
+}
+
+var crdGVR = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
+
+// TestE2E_GatewayPipe installs the sshpiper Pipe CRD into the kind cluster
+// (just the CRD, not sshpiper itself), then asserts the reconciler programs and
+// removes the Pipe against the real apiserver — validating the GVR + spec shape
+// end to end. A full data-plane e2e (deploy sshpiper, SSH through the gateway)
+// needs the real agent-box image and is a follow-up.
+func TestE2E_GatewayPipe(t *testing.T) {
+	if os.Getenv("CONTAINARIUM_K8S_E2E") == "" {
+		t.Skip("set CONTAINARIUM_K8S_E2E=1 (and KUBECONFIG) to run the kind e2e")
+	}
+	kubeconfig := os.Getenv("KUBECONFIG")
+	restCfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("rest config: %v", err)
+	}
+	dyn, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		t.Fatalf("dynamic client: %v", err)
+	}
+	cs, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		t.Fatalf("clientset: %v", err)
+	}
+	ctx := context.Background()
+
+	installPipeCRD(t, dyn)
+
+	const gwNS = "sshpiper"
+	if _, err := cs.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: gwNS}}, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create gateway namespace: %v", err)
+	}
+
+	b, err := New(Config{
+		Kubeconfig:       kubeconfig,
+		BoxImage:         "registry.k8s.io/pause:3.9",
+		GatewayNamespace: gwNS,
+		GatewayHost:      "gateway.example.com",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ref := box.BoxRef{Tenant: "gw-e2e"}
+	t.Cleanup(func() { _ = b.Delete(context.Background(), ref, true) })
+
+	if _, err := b.Create(ctx, box.BoxSpec{
+		Ref:       ref,
+		Image:     "registry.k8s.io/pause:3.9",
+		SSHKeys:   []string{"ssh-ed25519 AAAAExampleKey test@gw-e2e"},
+		AutoStart: true,
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// The reconciler should have created a Pipe in the gateway namespace.
+	p, err := dyn.Resource(pipeGVR).Namespace(gwNS).Get(ctx, pipeName("gw-e2e"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pipe: %v", err)
+	}
+	host, _, _ := unstructured.NestedString(p.Object, "spec", "to", "host")
+	if host != "box-0.boxes.tenant-gw-e2e.svc.cluster.local:22" {
+		t.Errorf("pipe to.host = %q", host)
+	}
+
+	// Delete removes the Pipe (it lives in the gateway ns, outside the cascade).
+	if err := b.Delete(ctx, ref, true); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := dyn.Resource(pipeGVR).Namespace(gwNS).Get(ctx, pipeName("gw-e2e"), metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("pipe still present after Delete (err=%v)", err)
+	}
+}
+
+// installPipeCRD applies a minimal sshpiper Pipe CRD (open schema via
+// x-kubernetes-preserve-unknown-fields) and waits for it to be Established.
+func installPipeCRD(t *testing.T, dyn dynamic.Interface) {
+	t.Helper()
+	ctx := context.Background()
+	crd := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apiextensions.k8s.io/v1",
+		"kind":       "CustomResourceDefinition",
+		"metadata":   map[string]any{"name": "pipes.sshpiper.com"},
+		"spec": map[string]any{
+			"group": "sshpiper.com",
+			"scope": "Namespaced",
+			"names": map[string]any{
+				"plural":   "pipes",
+				"singular": "pipe",
+				"kind":     "Pipe",
+				"listKind": "PipeList",
+			},
+			"versions": []any{map[string]any{
+				"name":    "v1beta1",
+				"served":  true,
+				"storage": true,
+				"schema": map[string]any{
+					"openAPIV3Schema": map[string]any{
+						"type":                                 "object",
+						"x-kubernetes-preserve-unknown-fields": true,
+					},
+				},
+			}},
+		},
+	}}
+	if _, err := dyn.Resource(crdGVR).Create(ctx, crd, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("install Pipe CRD: %v", err)
+	}
+
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := dyn.Resource(crdGVR).Get(ctx, "pipes.sshpiper.com", metav1.GetOptions{})
+		if err == nil {
+			conds, _, _ := unstructured.NestedSlice(got.Object, "status", "conditions")
+			for _, c := range conds {
+				cm, ok := c.(map[string]any)
+				if ok && cm["type"] == "Established" && cm["status"] == "True" {
+					return
+				}
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatal("Pipe CRD not Established within 60s")
 }

--- a/pkg/core/box/k8s/gateway.go
+++ b/pkg/core/box/k8s/gateway.go
@@ -1,0 +1,113 @@
+//go:build k8s
+
+package k8s
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// pipeGVR is the sshpiper Kubernetes plugin's CRD. The design note
+// (docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md) calls it "PiperUpstream"; the
+// maintained plugin's actual resource is `pipes` in group sshpiper.com/v1beta1
+// (kind Pipe). sshpiper watches a namespace for these and routes incoming SSH
+// by username — so programming a Pipe is how the gateway learns to forward a
+// tenant's connection to its box pod.
+var pipeGVR = schema.GroupVersionResource{Group: "sshpiper.com", Version: "v1beta1", Resource: "pipes"}
+
+func pipeName(tenant string) string { return "box-" + tenant }
+
+// gatewayEnabled reports whether SSH-gateway routing should be programmed: a
+// dynamic client plus a configured gateway namespace where Pipes live. When
+// off (no GatewayNamespace), boxes are still reconciled but not routed — useful
+// for clusters without sshpiper, and for the core lifecycle e2e.
+func (b *Backend) gatewayEnabled() bool {
+	return b.dyn != nil && b.cfg.GatewayNamespace != ""
+}
+
+// upstreamHost is the in-cluster DNS the gateway forwards the tenant's SSH to:
+// the headless Service's stable per-pod name (box-0.boxes.<ns>.svc).
+func (b *Backend) upstreamHost(tenant string) string {
+	return fmt.Sprintf("%s-0.%s.%s.svc.cluster.local:%d", statefulSetName, serviceName, b.namespaceFor(tenant), sshPort)
+}
+
+// pipeObject builds the sshpiper Pipe that routes username=<tenant> to the
+// tenant's box pod: the incoming connection authenticates against the box's
+// authorized keys (inline, base64), and the upstream host key is trusted
+// (ignore_hostkey — TOFU/known_hosts pinning is a follow-up).
+func (b *Backend) pipeObject(tenant string, keys []string) *unstructured.Unstructured {
+	var buf []byte
+	for _, k := range keys {
+		buf = append(buf, []byte(k)...)
+		buf = append(buf, '\n')
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "sshpiper.com/v1beta1",
+		"kind":       "Pipe",
+		"metadata": map[string]any{
+			"name":      pipeName(tenant),
+			"namespace": b.cfg.GatewayNamespace,
+			"labels":    toAnyMap(boxLabels(tenant)),
+		},
+		"spec": map[string]any{
+			"from": []any{map[string]any{
+				"username":             tenant,
+				"authorized_keys_data": base64.StdEncoding.EncodeToString(buf),
+			}},
+			"to": map[string]any{
+				"host":           b.upstreamHost(tenant),
+				"username":       tenant,
+				"ignore_hostkey": true,
+			},
+		},
+	}}
+}
+
+// upsertPipe creates or updates the tenant's Pipe in the gateway namespace.
+// No-op when the gateway isn't configured.
+func (b *Backend) upsertPipe(ctx context.Context, tenant string, keys []string) error {
+	if !b.gatewayEnabled() {
+		return nil
+	}
+	ns := b.cfg.GatewayNamespace
+	obj := b.pipeObject(tenant, keys)
+	_, err := b.dyn.Resource(pipeGVR).Namespace(ns).Create(ctx, obj, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		existing, gerr := b.dyn.Resource(pipeGVR).Namespace(ns).Get(ctx, pipeName(tenant), metav1.GetOptions{})
+		if gerr != nil {
+			return gerr
+		}
+		existing.Object["spec"] = obj.Object["spec"]
+		_, err = b.dyn.Resource(pipeGVR).Namespace(ns).Update(ctx, existing, metav1.UpdateOptions{})
+	}
+	return err
+}
+
+// deletePipe removes the tenant's Pipe. No-op when the gateway isn't configured
+// or the Pipe is already gone. (The Pipe lives in the gateway namespace, so the
+// per-tenant namespace delete does not cascade to it — it must be deleted
+// explicitly.)
+func (b *Backend) deletePipe(ctx context.Context, tenant string) error {
+	if !b.gatewayEnabled() {
+		return nil
+	}
+	err := b.dyn.Resource(pipeGVR).Namespace(b.cfg.GatewayNamespace).Delete(ctx, pipeName(tenant), metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func toAnyMap(m map[string]string) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/core/box/k8s/gateway_test.go
+++ b/pkg/core/box/k8s/gateway_test.go
@@ -1,0 +1,125 @@
+//go:build k8s
+
+package k8s
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+)
+
+// gatewayBackend wires a Backend with both a fake typed clientset and a fake
+// dynamic client that knows the Pipe GVR, with the gateway namespace set so
+// Pipe reconciliation is active.
+func gatewayBackend() (*Backend, *dynfake.FakeDynamicClient) {
+	scheme := runtime.NewScheme()
+	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{pipeGVR: "PipeList"})
+	b := NewWithClients(fake.NewSimpleClientset(), dyn, Config{
+		GatewayNamespace: "sshpiper",
+		GatewayHost:      "gw.example.com",
+	})
+	return b, dyn
+}
+
+func getPipe(t *testing.T, dyn *dynfake.FakeDynamicClient, tenant string) *unstructured.Unstructured {
+	t.Helper()
+	p, err := dyn.Resource(pipeGVR).Namespace("sshpiper").Get(context.Background(), pipeName(tenant), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pipe %s: %v", pipeName(tenant), err)
+	}
+	return p
+}
+
+func TestCreateProgramsPipe(t *testing.T) {
+	b, dyn := gatewayBackend()
+	ctx := context.Background()
+	if _, err := b.Create(ctx, box.BoxSpec{
+		Ref:       box.BoxRef{Tenant: "alice"},
+		Image:     "x",
+		SSHKeys:   []string{"ssh-ed25519 AAAA"},
+		AutoStart: true,
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	p := getPipe(t, dyn, "alice")
+
+	from, _, _ := unstructured.NestedSlice(p.Object, "spec", "from")
+	if len(from) != 1 {
+		t.Fatalf("spec.from len = %d, want 1", len(from))
+	}
+	f0 := from[0].(map[string]any)
+	if f0["username"] != "alice" {
+		t.Errorf("from.username = %v, want alice", f0["username"])
+	}
+	wantKeys := base64.StdEncoding.EncodeToString([]byte("ssh-ed25519 AAAA\n"))
+	if f0["authorized_keys_data"] != wantKeys {
+		t.Errorf("authorized_keys_data = %v, want %v", f0["authorized_keys_data"], wantKeys)
+	}
+
+	host, _, _ := unstructured.NestedString(p.Object, "spec", "to", "host")
+	if host != "box-0.boxes.tenant-alice.svc.cluster.local:22" {
+		t.Errorf("to.host = %q", host)
+	}
+	user, _, _ := unstructured.NestedString(p.Object, "spec", "to", "username")
+	if user != "alice" {
+		t.Errorf("to.username = %q, want alice", user)
+	}
+}
+
+func TestSetAuthorizedKeysUpdatesPipe(t *testing.T) {
+	b, dyn := gatewayBackend()
+	ctx := context.Background()
+	ref := box.BoxRef{Tenant: "bob"}
+	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref, Image: "x", SSHKeys: []string{"old"}, AutoStart: true}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := b.SetAuthorizedKeys(ctx, ref, []string{"rotated-key"}); err != nil {
+		t.Fatalf("SetAuthorizedKeys: %v", err)
+	}
+	p := getPipe(t, dyn, "bob")
+	from, _, _ := unstructured.NestedSlice(p.Object, "spec", "from")
+	f0 := from[0].(map[string]any)
+	want := base64.StdEncoding.EncodeToString([]byte("rotated-key\n"))
+	if f0["authorized_keys_data"] != want {
+		t.Errorf("rotated authorized_keys_data = %v, want %v", f0["authorized_keys_data"], want)
+	}
+}
+
+func TestDeleteRemovesPipe(t *testing.T) {
+	b, dyn := gatewayBackend()
+	ctx := context.Background()
+	ref := box.BoxRef{Tenant: "carol"}
+	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref, Image: "x", AutoStart: true}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	getPipe(t, dyn, "carol") // present
+	if err := b.Delete(ctx, ref, true); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := dyn.Resource(pipeGVR).Namespace("sshpiper").Get(ctx, pipeName("carol"), metav1.GetOptions{}); err == nil {
+		t.Error("pipe still present after Delete")
+	}
+}
+
+func TestGatewayDisabledSkipsPipe(t *testing.T) {
+	// No dynamic client (NewWithClientset) → gateway off → Create still succeeds
+	// and programs no Pipe.
+	b := NewWithClientset(fake.NewSimpleClientset(), Config{GatewayNamespace: "sshpiper"})
+	if b.gatewayEnabled() {
+		t.Fatal("gateway should be disabled without a dynamic client")
+	}
+	if _, err := b.Create(context.Background(), box.BoxSpec{Ref: box.BoxRef{Tenant: "dave"}, Image: "x", AutoStart: true}); err != nil {
+		t.Fatalf("Create with gateway off: %v", err)
+	}
+}

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -13,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -57,12 +58,14 @@ type Config struct {
 type Backend struct {
 	cfg       Config
 	clientset kubernetes.Interface
+	dyn       dynamic.Interface // for the sshpiper Pipe CRD; nil disables gateway routing
 }
 
 var _ box.BoxBackend = (*Backend)(nil)
 
-// New constructs a K8s backend: it builds a client-go clientset (in-cluster,
-// an explicit kubeconfig, or the ambient rules) and applies config defaults.
+// New constructs a K8s backend: it builds a client-go clientset + dynamic
+// client (in-cluster, an explicit kubeconfig, or the ambient rules) and applies
+// config defaults.
 func New(cfg Config) (*Backend, error) {
 	restCfg, err := buildRestConfig(cfg.Kubeconfig)
 	if err != nil {
@@ -72,19 +75,33 @@ func New(cfg Config) (*Backend, error) {
 	if err != nil {
 		return nil, fmt.Errorf("k8s: build clientset: %w", err)
 	}
-	return NewWithClientset(cs, cfg), nil
+	dyn, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("k8s: build dynamic client: %w", err)
+	}
+	return newBackend(cs, dyn, cfg), nil
 }
 
-// NewWithClientset builds a Backend over an injected clientset (a kind cluster
-// for e2e, or a fake for unit tests). Skips rest-config discovery.
+// NewWithClientset builds a Backend over an injected clientset, with gateway
+// (Pipe) routing disabled (no dynamic client). Used by lifecycle unit tests.
 func NewWithClientset(cs kubernetes.Interface, cfg Config) *Backend {
+	return newBackend(cs, nil, cfg)
+}
+
+// NewWithClients builds a Backend over injected clientset + dynamic client
+// (fakes for unit tests, a kind cluster for e2e), exercising gateway routing.
+func NewWithClients(cs kubernetes.Interface, dyn dynamic.Interface, cfg Config) *Backend {
+	return newBackend(cs, dyn, cfg)
+}
+
+func newBackend(cs kubernetes.Interface, dyn dynamic.Interface, cfg Config) *Backend {
 	if cfg.TenantNamespacePrefix == "" {
 		cfg.TenantNamespacePrefix = "tenant-"
 	}
 	if cfg.GatewaySSHPort == 0 {
 		cfg.GatewaySSHPort = 22
 	}
-	return &Backend{cfg: cfg, clientset: cs}
+	return &Backend{cfg: cfg, clientset: cs, dyn: dyn}
 }
 
 func buildRestConfig(kubeconfig string) (*rest.Config, error) {
@@ -126,6 +143,11 @@ func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus,
 	}
 	if _, err := b.clientset.AppsV1().StatefulSets(ns).Create(ctx, statefulSetObject(ns, spec), metav1.CreateOptions{}); ignoreExists(err) != nil {
 		return nil, fmt.Errorf("k8s: ensure statefulset: %w", err)
+	}
+	// Program the SSH gateway so username=<tenant> routes to this box (no-op
+	// when the gateway isn't configured).
+	if err := b.upsertPipe(ctx, tenant, spec.SSHKeys); err != nil {
+		return nil, fmt.Errorf("k8s: ensure gateway pipe: %w", err)
 	}
 	return b.Get(ctx, spec.Ref)
 }
@@ -178,8 +200,13 @@ func (b *Backend) List(ctx context.Context) ([]box.BoxStatus, error) {
 	return out, nil
 }
 
-// Delete removes the per-tenant namespace, cascading every box object.
+// Delete removes the per-tenant namespace (cascading every box object) and the
+// tenant's gateway Pipe, which lives in the gateway namespace and so is not
+// covered by the namespace cascade.
 func (b *Backend) Delete(ctx context.Context, ref box.BoxRef, force bool) error {
+	if err := b.deletePipe(ctx, ref.Tenant); err != nil {
+		return fmt.Errorf("k8s: delete gateway pipe: %w", err)
+	}
 	err := b.clientset.CoreV1().Namespaces().Delete(ctx, b.namespaceFor(ref.Tenant), metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil
@@ -220,7 +247,12 @@ func (b *Backend) SetAuthorizedKeys(ctx context.Context, ref box.BoxRef, keys []
 	if apierrors.IsNotFound(err) {
 		_, err = b.clientset.CoreV1().Secrets(ns).Create(ctx, sec, metav1.CreateOptions{})
 	}
-	return err
+	if err != nil {
+		return err
+	}
+	// Re-program the gateway Pipe so the rotated keys take effect at the front
+	// (no-op when the gateway isn't configured).
+	return b.upsertPipe(ctx, ref.Tenant, keys)
 }
 
 // Resize patches the box container's resource limits. Unparseable (incus-native)


### PR DESCRIPTION
Wires the **SSH gateway** into the K8s backend: an agent connecting as `username=<tenant>` is now routed to that tenant's box pod, via the maintained **sshpiper Kubernetes plugin CRD**. The design note called this "PiperUpstream"; the real resource is **`Pipe`** (`sshpiper.com/v1beta1`), which I confirmed and now manage via the **dynamic client** — no sshpiper Go types imported, no new heavy deps.

Builds on #709 (the reconciler). Still entirely behind `//go:build k8s`.

## What it does
- **`gateway.go`** — upsert/delete a `Pipe` in the gateway namespace:
  - `spec.from[].username = <tenant>` + inline base64 `authorized_keys_data` (the box's keys)
  - `spec.to.host = box-0.boxes.<tenant-ns>.svc.cluster.local:22`, `ignore_hostkey: true` (host-key pinning is a follow-up)
- Wired into the lifecycle: **Create** programs the Pipe, **SetAuthorizedKeys** re-programs it with rotated keys, **Delete** removes it (the Pipe lives in the gateway namespace, *outside* the per-tenant namespace cascade, so it's deleted explicitly).
- **Opt-in**: gateway routing is active only when `GatewayNamespace` is set and a dynamic client exists. Without it, boxes reconcile unrouted — so clusters without sshpiper still work, and the core-lifecycle e2e stays gateway-free.
- `New` builds a dynamic client; `NewWithClients` injects fakes/kind for tests.

## Tests
- **`gateway_test.go`** — fake dynamic client: Create programs the Pipe (asserts `from.username`, `authorized_keys_data`, `to.host`/`username`), SetAuthorizedKeys updates it, Delete removes it, gateway-off is a clean no-op.
- **e2e** — installs the `Pipe` CRD (open schema via `x-kubernetes-preserve-unknown-fields`) into kind, waits for Established, then asserts the reconciler creates/removes the Pipe against a **real apiserver** (validates the GVR + spec shape end to end). Gated on `CONTAINARIUM_K8S_E2E`.

## Isolation preserved
client-go stays behind the build tag — default daemon links **zero** client-go packages.

## Follow-ups (noted, not in scope)
- Full **data-plane** e2e: deploy sshpiper + the real agent-box image, SSH through the gateway end to end.
- **NetworkPolicy enforcement** assertion (needs a Calico-backed kind config; kindnet doesn't enforce).
- Host-key pinning instead of `ignore_hostkey`.

## Verification (local, disk-constrained sandbox)
- `go test -tags k8s ./pkg/core/box/k8s/` — green (lifecycle + gateway unit tests; e2e compiles + skips).
- `go vet -tags k8s ./pkg/core/box/k8s/` — clean; `gofmt` clean.
- Full-repo `go build`/`go mod tidy` no-op were validated during dev but the final rerun hit a corrupted local build cache (disk limit) — **CI's `build-unit` + `kind-e2e` jobs are the authoritative full build + real-cluster validation** (same as #709).