### PR TITLE
feat(k8s): agent-box container image + align box pod to it (#700)

### DIFF
--- a/.github/workflows/agent-box-image.yml
+++ b/.github/workflows/agent-box-image.yml
@@ -1,0 +1,49 @@
+name: agent-box image
+
+# Builds the Kubernetes agent-box image (images/agent-box/Dockerfile) to validate
+# both stages — the agent-box Go build and the rootless dropbear runtime. Build
+# only (no push); publishing to ghcr.io/footprintai/containarium-agent-box is
+# wired into the release flow separately.
+on:
+  pull_request:
+    paths:
+      - 'images/agent-box/**'
+      - 'cmd/agent-box/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/agent-box-image.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'images/agent-box/**'
+      - 'cmd/agent-box/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/agent-box-image.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build agent-box image
+        run: docker build -f images/agent-box/Dockerfile -t containarium-agent-box:ci .
+      - name: Smoke-check the image
+        # The binary and SSH server must be present and the entrypoint executable.
+        run: |
+          docker run --rm --entrypoint /bin/sh containarium-agent-box:ci -c '
+            set -e
+            test -x /usr/local/bin/agent-box
+            command -v dropbear
+            command -v dropbearkey
+            test -x /usr/local/bin/agent-box-entrypoint.sh
+            id -u | grep -qx 1000
+          '

--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -99,6 +99,14 @@ AllowTcpForwarding  no                          # no pivoting out of the box
 `ForceCommand` is the load-bearing line: even a misbehaving client cannot get
 a shell — it gets `agent-box` and nothing else.
 
+**Shipped image (`images/agent-box/`):** the config above is the contract; the
+actual image realizes it with **dropbear** rather than OpenSSH — dropbear runs
+cleanly rootless and takes a forced command (`-c agent-box`), so the box runs
+**non-root on `:2222`** (an unprivileged port → no added capabilities) and the
+pod satisfies the `restricted` Pod Security profile. The agent still reaches the
+gateway on `:22`; `:2222` is only the internal sshpiper→pod hop. Built per
+release as `ghcr.io/footprintai/containarium-agent-box`.
+
 ### 2. Gateway (`sshpiper` Deployment + upstream controller)
 
 `sshpiper` itself is unchanged from the sentinel deployment — it terminates
@@ -112,7 +120,8 @@ The new piece is a thin **upstream controller** replacing the sentinel's
 - Programs the sshpiper upstream map via the maintained sshpiper **Kubernetes
   plugin** CRD — the `Pipe` resource (`sshpiper.com/v1beta1`, plural `pipes`;
   earlier drafts of this note called it "PiperUpstream"): `spec.from[].username
-  = <tenant>` → `spec.to.host = box-0.boxes.<tenant>.svc:22`, with the box's
+  = <tenant>` → `spec.to.host = box-0.boxes.<tenant>.svc:2222` (the box's
+  internal SSH port), upstream user `agent`, with the box's
   authorized keys inline as `authorized_keys_data`. The daemon manages Pipes via
   the dynamic client (no sshpiper Go types imported). CRD-driven removes the
   file-write race that bit the sentinel (the `#301`/`#404` class of bug).

--- a/images/agent-box/Dockerfile
+++ b/images/agent-box/Dockerfile
@@ -1,0 +1,47 @@
+# containarium-agent-box
+#
+# The in-the-box image for the Kubernetes backend (docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md):
+# a minimal SSH server whose every session is pinned by forced command to
+# `agent-box` (the in-the-box MCP — shell/file ops over stdio). An agent reaches
+# it over SSH and can do nothing but talk to agent-box.
+#
+# Hardening posture (matches the StatefulSet securityContext the daemon sets, so
+# the pod satisfies the `restricted` Pod Security profile):
+#   - runs as a non-root user (uid 1000)
+#   - SSH listens on :2222, an UNPRIVILEGED port — so no capabilities are
+#     needed at all (the agent connects to the gateway on :22; :2222 is the
+#     internal sshpiper→pod hop).
+#   - dropbear instead of OpenSSH: it runs cleanly rootless and supports a
+#     forced command, so there's no sshd privsep/PAM/root dance.
+#
+# Published per-release as ghcr.io/footprintai/containarium-agent-box:vX.Y.Z.
+# Build context is the repo root:
+#   docker build -f images/agent-box/Dockerfile -t containarium-agent-box .
+
+# --- build agent-box -------------------------------------------------------
+# No `k8s` build tag here: agent-box is the in-box MCP and never imports
+# client-go, so this stays a small static binary.
+FROM golang:1.25.11-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/agent-box ./cmd/agent-box
+
+# --- runtime: rootless dropbear + agent-box --------------------------------
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends dropbear-bin ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 --shell /bin/bash agent \
+    && mkdir -p /home/agent/.ssh /etc/agent-box \
+    && chown -R agent:agent /home/agent /etc/agent-box
+
+COPY --from=build /out/agent-box /usr/local/bin/agent-box
+COPY --chmod=0755 images/agent-box/entrypoint.sh /usr/local/bin/agent-box-entrypoint.sh
+
+USER agent
+ENV HOME=/home/agent
+# Documentation only; the entrypoint binds this port.
+EXPOSE 2222
+ENTRYPOINT ["/usr/local/bin/agent-box-entrypoint.sh"]

--- a/images/agent-box/entrypoint.sh
+++ b/images/agent-box/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# agent-box image entrypoint: prepare authorized_keys + host key, then run
+# dropbear in the foreground with a forced command pinning every session to
+# agent-box. See images/agent-box/Dockerfile.
+set -euo pipefail
+
+# The daemon mounts the box's authorized_keys Secret at
+# /etc/agent-box/authorized_keys; dropbear reads ~/.ssh/authorized_keys, so
+# point there. The file may not exist until the Secret is mounted — dropbear
+# simply rejects every login until it appears (fail closed).
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+if [ -e /etc/agent-box/authorized_keys ]; then
+  ln -sf /etc/agent-box/authorized_keys "$HOME/.ssh/authorized_keys"
+fi
+
+# Host key in a writable per-container dir. Regenerated each start; the gateway
+# uses ignore_hostkey today (host-key pinning is a follow-up), so a fresh key
+# per restart is fine.
+KEYDIR="$HOME/.dropbear"
+mkdir -p "$KEYDIR"
+HOSTKEY="$KEYDIR/ed25519_host_key"
+[ -f "$HOSTKEY" ] || dropbearkey -t ed25519 -f "$HOSTKEY" >/dev/null 2>&1
+
+# dropbear flags:
+#   -F  foreground (PID 1)            -E  log to stderr
+#   -s  disable password auth         -j -k  no local/remote port forwarding
+#   -p 2222  unprivileged port        -r  host key file
+#   -c  forced command — every session runs agent-box, nothing else
+exec dropbear -F -E -s -j -k -p 2222 -r "$HOSTKEY" -c /usr/local/bin/agent-box

--- a/pkg/core/box/k8s/e2e_test.go
+++ b/pkg/core/box/k8s/e2e_test.go
@@ -172,7 +172,7 @@ func TestE2E_GatewayPipe(t *testing.T) {
 		t.Fatalf("get pipe: %v", err)
 	}
 	host, _, _ := unstructured.NestedString(p.Object, "spec", "to", "host")
-	if host != "box-0.boxes.tenant-gw-e2e.svc.cluster.local:22" {
+	if host != "box-0.boxes.tenant-gw-e2e.svc.cluster.local:2222" {
 		t.Errorf("pipe to.host = %q", host)
 	}
 

--- a/pkg/core/box/k8s/gateway.go
+++ b/pkg/core/box/k8s/gateway.go
@@ -61,8 +61,11 @@ func (b *Backend) pipeObject(tenant string, keys []string) *unstructured.Unstruc
 				"authorized_keys_data": base64.StdEncoding.EncodeToString(buf),
 			}},
 			"to": map[string]any{
-				"host":           b.upstreamHost(tenant),
-				"username":       tenant,
+				"host":     b.upstreamHost(tenant),
+				"username": boxSSHUser, // fixed box login user; tenant identity is enforced by from.username
+				// ignore_hostkey for now (host-key pinning is a follow-up). The
+				// upstream credential (spec.to.private_key_secret authorized on
+				// the box) is part of the end-to-end SSH data-plane follow-up.
 				"ignore_hostkey": true,
 			},
 		},

--- a/pkg/core/box/k8s/gateway_test.go
+++ b/pkg/core/box/k8s/gateway_test.go
@@ -68,12 +68,12 @@ func TestCreateProgramsPipe(t *testing.T) {
 	}
 
 	host, _, _ := unstructured.NestedString(p.Object, "spec", "to", "host")
-	if host != "box-0.boxes.tenant-alice.svc.cluster.local:22" {
+	if host != "box-0.boxes.tenant-alice.svc.cluster.local:2222" {
 		t.Errorf("to.host = %q", host)
 	}
 	user, _, _ := unstructured.NestedString(p.Object, "spec", "to", "username")
-	if user != "alice" {
-		t.Errorf("to.username = %q, want alice", user)
+	if user != "agent" {
+		t.Errorf("to.username = %q, want agent", user)
 	}
 }
 

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -128,6 +128,9 @@ func (b *Backend) namespaceFor(tenant string) string {
 func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus, error) {
 	ns := b.namespaceFor(spec.Ref.Tenant)
 	tenant := spec.Ref.Tenant
+	if spec.Image == "" {
+		spec.Image = b.cfg.BoxImage // default to the configured agent-box image
+	}
 
 	if _, err := b.clientset.CoreV1().Namespaces().Create(ctx, namespaceObject(ns, tenant), metav1.CreateOptions{}); ignoreExists(err) != nil {
 		return nil, fmt.Errorf("k8s: ensure namespace: %w", err)

--- a/pkg/core/box/k8s/k8s_test.go
+++ b/pkg/core/box/k8s/k8s_test.go
@@ -53,8 +53,21 @@ func TestCreateReconcilesObjects(t *testing.T) {
 	if _, err := cs.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{}); err != nil {
 		t.Errorf("namespace not created: %v", err)
 	}
-	if _, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{}); err != nil {
+	ss, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{})
+	if err != nil {
 		t.Errorf("statefulset not created: %v", err)
+	} else {
+		// restricted-PSA hardening the box image is built for.
+		sc := ss.Spec.Template.Spec.Containers[0].SecurityContext
+		if sc == nil || sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
+			t.Errorf("container not runAsNonRoot: %+v", sc)
+		}
+		if sc != nil && (sc.Capabilities == nil || len(sc.Capabilities.Drop) != 1 || string(sc.Capabilities.Drop[0]) != "ALL") {
+			t.Errorf("container does not drop ALL caps: %+v", sc.Capabilities)
+		}
+		if pscPort := ss.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort; pscPort != 2222 {
+			t.Errorf("container port = %d, want 2222", pscPort)
+		}
 	}
 	if _, err := cs.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{}); err != nil {
 		t.Errorf("service not created: %v", err)

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -19,7 +19,14 @@ const (
 	statefulSetName = "box"
 	serviceName     = "boxes"
 	sshPortName     = "ssh"
-	sshPort         = 22
+	// sshPort is the box's in-pod SSH port. 2222 (unprivileged) so the box
+	// runs fully non-root with no added capabilities — the agent connects to
+	// the gateway on :22; this is the internal sshpiper→pod hop.
+	sshPort = 2222
+	// boxSSHUser is the fixed login user inside the box. The gateway connects
+	// upstream as this user (Pipe spec.to.username); tenant identity is
+	// enforced at the gateway, not by per-tenant box users.
+	boxSSHUser = "agent"
 
 	managedByLabel       = "app.kubernetes.io/managed-by"
 	managedByValue       = "containarium"
@@ -30,6 +37,8 @@ const (
 )
 
 func int32p(i int32) *int32 { return &i }
+func int64p(i int64) *int64 { return &i }
+func boolp(b bool) *bool    { return &b }
 
 // boxLabels are the identity labels shared by all of a tenant box's objects;
 // the pod selector and the cross-namespace List selector both key off them.
@@ -118,14 +127,20 @@ func statefulSetObject(ns string, spec box.BoxSpec) *appsv1.StatefulSet {
 		replicas = 1
 	}
 	labels := boxLabels(spec.Ref.Tenant)
-	falsePtr := false
 
+	// restricted-PSA container hardening: non-root, no privilege escalation,
+	// all capabilities dropped, default seccomp. The box image (dropbear on
+	// :2222) is built to run under exactly this.
 	container := corev1.Container{
 		Name:  "agent-box",
 		Image: spec.Image,
 		Ports: []corev1.ContainerPort{{Name: sshPortName, ContainerPort: sshPort, Protocol: corev1.ProtocolTCP}},
 		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: &falsePtr,
+			AllowPrivilegeEscalation: boolp(false),
+			RunAsNonRoot:             boolp(true),
+			RunAsUser:                int64p(1000),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 		},
 	}
 	if res := resourceRequirements(spec.Resources); res != nil {
@@ -141,8 +156,13 @@ func statefulSetObject(ns string, spec box.BoxSpec) *appsv1.StatefulSet {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec: corev1.PodSpec{
-					AutomountServiceAccountToken: &falsePtr, // the box is a leaf, never a kube-apiserver client
-					Containers:                   []corev1.Container{container},
+					AutomountServiceAccountToken: boolp(false), // the box is a leaf, never a kube-apiserver client
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot:   boolp(true),
+						RunAsUser:      int64p(1000),
+						SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+					},
+					Containers: []corev1.Container{container},
 				},
 			},
 		},


### PR DESCRIPTION
Builds the **in-the-box image** the Kubernetes backend runs (the StatefulSet has used `registry.k8s.io/pause` as a stand-in until now), and hardens the pod spec so it actually satisfies the `restricted` Pod Security profile the README/design promise.

## The image — `images/agent-box/`
Multi-stage Dockerfile: build `agent-box`, then a minimal runtime that runs **dropbear** with a **forced command** pinning every SSH session to `agent-box`.

- **Rootless, non-root (uid 1000), on `:2222`** — an *unprivileged* port, so the container needs **zero added capabilities** (no `NET_BIND_SERVICE` dance). The agent still connects to the gateway on `:22`; `:2222` is only the internal sshpiper→pod hop.
- dropbear over OpenSSH precisely because it runs cleanly rootless and supports `-c <forced command>` — no sshd privsep/PAM/root requirements.
- `authorized_keys` from the mounted Secret at `/etc/agent-box/authorized_keys`; host key generated per start (host-key pinning is a follow-up).
- Published per release as `ghcr.io/footprintai/containarium-agent-box`.

## Pod spec aligned to the image
- `objects.go`: box port **22 → 2222**, and a real **restricted-PSA** `securityContext` (runAsNonRoot uid 1000, drop ALL caps, seccomp `RuntimeDefault`, no priv-esc) at both container and pod level.
- `gateway.go`: the Pipe's `spec.to.username` is the **fixed box user `agent`** (tenant identity is enforced at the gateway by `from.username`), `to.host` → `:2222`.
- `k8s.go`: `spec.Image` falls back to `cfg.BoxImage` when the caller doesn't pin one — so the daemon defaults boxes to the agent-box image.

## CI
`agent-box-image.yml` builds the image and **smoke-checks** it (the `agent-box` binary + `dropbear`/`dropbearkey` present, entrypoint executable, runs as uid 1000). Build-only — release-time push is separate.

## Tests
Unit tests updated for `:2222` + the fixed user, and now assert the **hardened securityContext** (runAsNonRoot, drop-ALL, port 2222). The kind e2e's Pipe assertion updated to `:2222`.

## Honest scope / follow-ups
- I have **no local Docker** (the sandbox), so the Dockerfile/entrypoint are validated by the new CI image job, not locally. dropbear *runtime flag* correctness is only fully exercised once the data-plane e2e runs it.
- **Remaining data-plane**: deploy sshpiper + wire the upstream credential (`Pipe spec.to.private_key_secret` authorized on the box) for a true end-to-end SSH-through-the-gateway e2e; host-key pinning instead of `ignore_hostkey`.

## Verification (local)
- `go test -tags k8s ./pkg/core/box/k8s/` — green (incl. new hardening assertions).
- `gofmt` clean; entrypoint `bash -n` + workflow YAML valid.