### PR TITLE
feat(k8s): sshpiper gateway deploy + upstream-credential wiring (#700)

### DIFF
--- a/deploy/k8s/sshpiper/00-namespace.yaml
+++ b/deploy/k8s/sshpiper/00-namespace.yaml
@@ -1,0 +1,9 @@
+# The gateway namespace: sshpiper + its LoadBalancer Service live here, and the
+# daemon programs Pipe CRs (and references the upstream key Secret) here. Must
+# match the daemon's CONTAINARIUM_K8S_GATEWAY_NAMESPACE (default "agent-gateway").
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agent-gateway
+  labels:
+    app.kubernetes.io/part-of: containarium-agent-box

--- a/deploy/k8s/sshpiper/10-pipe-crd.yaml
+++ b/deploy/k8s/sshpiper/10-pipe-crd.yaml
@@ -1,0 +1,27 @@
+# The sshpiper "Pipe" CRD (sshpiper.com/v1beta1). The daemon programs one Pipe
+# per box; sshpiper watches them and routes incoming SSH by username.
+#
+# This ships an OPEN schema (x-kubernetes-preserve-unknown-fields) so it accepts
+# the plugin's full spec without us tracking every field. Operators who want
+# strict validation can apply sshpiper's upstream CRD instead — the
+# group/version/kind are identical, so the daemon and sshpiper work with either.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pipes.sshpiper.com
+spec:
+  group: sshpiper.com
+  scope: Namespaced
+  names:
+    plural: pipes
+    singular: pipe
+    kind: Pipe
+    listKind: PipeList
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true

--- a/deploy/k8s/sshpiper/20-rbac.yaml
+++ b/deploy/k8s/sshpiper/20-rbac.yaml
@@ -1,0 +1,40 @@
+# Least-privilege RBAC for sshpiperd's kubernetes plugin, scoped to the gateway
+# namespace (a Role, not a ClusterRole — sshpiper watches only this namespace).
+# It reads the Pipes the daemon programs and the Secrets they reference (the
+# upstream private key + any from-side key Secrets).
+#
+# NOTE: sshpiper's exec-into-pod mode additionally needs pods[get] +
+# pods/exec[create]. We route over TCP to the box Service, so those are omitted
+# (least privilege). Add them only if you enable that mode.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sshpiper
+  namespace: agent-gateway
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sshpiper
+  namespace: agent-gateway
+rules:
+  - apiGroups: ["sshpiper.com"]
+    resources: ["pipes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sshpiper
+  namespace: agent-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sshpiper
+subjects:
+  - kind: ServiceAccount
+    name: sshpiper
+    namespace: agent-gateway

--- a/deploy/k8s/sshpiper/30-deployment.yaml
+++ b/deploy/k8s/sshpiper/30-deployment.yaml
@@ -1,0 +1,46 @@
+# sshpiperd with the kubernetes plugin. It watches Pipes in its own namespace
+# and reverse-proxies SSH: client → sshpiper (authenticated by the Pipe's
+# spec.from authorized_keys_data) → box pod (authenticated by the upstream key
+# in spec.to.private_key_secret). sshpiperd listens on :2222.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sshpiper
+  namespace: agent-gateway
+  labels:
+    app.kubernetes.io/name: sshpiper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sshpiper
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sshpiper
+    spec:
+      serviceAccountName: sshpiper
+      containers:
+        - name: sshpiperd
+          # Pin to a release tag in production rather than :latest.
+          image: farmer1992/sshpiperd:latest
+          env:
+            # Activates the kubernetes plugin (watches Pipes in this namespace).
+            - name: PLUGIN
+              value: "kubernetes"
+            # Host key sshpiper presents to CLIENTS (see the runbook for how the
+            # sshpiper-server-key Secret is generated).
+            - name: SSHPIPERD_SERVER_KEY
+              value: /etc/sshpiper/server_key
+          ports:
+            - name: ssh
+              containerPort: 2222
+          volumeMounts:
+            - name: server-key
+              mountPath: /etc/sshpiper
+              readOnly: true
+      volumes:
+        - name: server-key
+          secret:
+            secretName: sshpiper-server-key
+            defaultMode: 0400

--- a/deploy/k8s/sshpiper/40-service.yaml
+++ b/deploy/k8s/sshpiper/40-service.yaml
@@ -1,0 +1,19 @@
+# Public SSH entrypoint. Agents connect here on :22; the Service forwards to
+# sshpiper's :2222. On bare-metal clusters without a LoadBalancer provider, swap
+# type to NodePort (or front it with your own LB) — see the runbook.
+apiVersion: v1
+kind: Service
+metadata:
+  name: sshpiper
+  namespace: agent-gateway
+  labels:
+    app.kubernetes.io/name: sshpiper
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: sshpiper
+  ports:
+    - name: ssh
+      port: 22
+      targetPort: 2222
+      protocol: TCP

--- a/deploy/k8s/sshpiper/README.md
+++ b/deploy/k8s/sshpiper/README.md
@@ -1,0 +1,97 @@
+# sshpiper gateway for the Kubernetes agent-box backend
+
+Deploys the SSH gateway that fronts Containarium's Kubernetes boxes. An agent
+connects once to this gateway; sshpiper routes by SSH username to the right
+per-tenant box pod. Design + topology: [`docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md`](../../../docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md).
+
+```
+agent ──ssh <tenant>@<gateway> :22──▶ sshpiper ──:2222──▶ box-0 (agent-box)
+        auth: Pipe spec.from                auth: Pipe spec.to.private_key_secret
+        (the agent's key)                   (sshpiper's upstream key, authorized on the box)
+```
+
+The Containarium daemon (k8s build) programs one `Pipe` per box automatically;
+these manifests stand up sshpiper itself. Two keypairs are involved:
+
+| Key | Presented by | Verified by | Lives in |
+| --- | --- | --- | --- |
+| **server key** | sshpiper → client | the agent's `known_hosts` | `sshpiper-server-key` Secret |
+| **upstream key** | sshpiper → box | the box's `authorized_keys` | `sshpiper-upstream-key` Secret (private) + daemon config (public) |
+
+## Prerequisites
+
+- A cluster with a NetworkPolicy-enforcing CNI (Calico/Cilium) for the box
+  default-deny policy to bite. The gateway itself works on any CNI.
+- The Containarium daemon running the `k8s` build variant.
+
+## 1. Generate the two keypairs
+
+```bash
+# Server key — sshpiper's identity to clients.
+ssh-keygen -t ed25519 -N '' -f ./sshpiper_server -C sshpiper-server
+# Upstream key — sshpiper's identity to boxes.
+ssh-keygen -t ed25519 -N '' -f ./sshpiper_upstream -C sshpiper-upstream
+```
+
+## 2. Create the Secrets (in the gateway namespace)
+
+```bash
+kubectl apply -f 00-namespace.yaml
+kubectl -n agent-gateway create secret generic sshpiper-server-key \
+  --from-file=server_key=./sshpiper_server
+kubectl -n agent-gateway create secret generic sshpiper-upstream-key \
+  --from-file=privatekey=./sshpiper_upstream
+```
+
+## 3. Point the daemon at the gateway
+
+Set these on the `containarium-k8s` daemon so it programs Pipes that route
+through sshpiper and so boxes authorize the upstream key:
+
+```bash
+CONTAINARIUM_K8S_GATEWAY_NAMESPACE=agent-gateway
+CONTAINARIUM_K8S_GATEWAY_HOST=<gateway public host>      # surfaced to clients
+CONTAINARIUM_K8S_GATEWAY_UPSTREAM_KEY_SECRET=sshpiper-upstream-key
+CONTAINARIUM_K8S_GATEWAY_UPSTREAM_PUBLIC_KEY="$(cat ./sshpiper_upstream.pub)"
+```
+
+## 4. Deploy sshpiper
+
+```bash
+kubectl apply -f 10-pipe-crd.yaml -f 20-rbac.yaml -f 30-deployment.yaml -f 40-service.yaml
+kubectl -n agent-gateway rollout status deploy/sshpiper
+```
+
+## 5. Create a box and watch the route appear
+
+```bash
+# via the daemon (CLI/MCP); then:
+kubectl -n agent-gateway get pipes
+```
+
+## 6. Acceptance — SSH through the gateway
+
+```bash
+GW=$(kubectl -n agent-gateway get svc sshpiper -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+ssh -i <agent-private-key> <tenant>@"$GW"
+# Lands directly in the box's agent-box stdio MCP (ForceCommand-pinned) —
+# no shell. Point an MCP client at this exact ssh command.
+```
+
+## Dev / kind notes
+
+- **No LoadBalancer** (kind, bare-metal): change `40-service.yaml` to
+  `type: NodePort`, or `kubectl -n agent-gateway port-forward svc/sshpiper 2222:22`
+  and `ssh -p 2222 <tenant>@127.0.0.1`.
+- **kindnet doesn't enforce NetworkPolicy** — the box default-deny policy is a
+  no-op there; use a Calico-backed kind config to exercise enforcement.
+
+## Security notes
+
+- `automountServiceAccountToken: false` on boxes; the gateway SA is least
+  privilege (read Pipes + Secrets in this namespace only — no `pods/exec`).
+- The box authorizes only sshpiper's upstream key, never the agent's — the
+  agent can never reach a box except through the gateway's per-tenant Pipe.
+- Pin the `farmer1992/sshpiperd` image to a release tag in production.
+- Host-key pinning (replacing the Pipe's `ignore_hostkey`) is a planned
+  follow-up.

--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -127,6 +127,15 @@ The new piece is a thin **upstream controller** replacing the sentinel's
   file-write race that bit the sentinel (the `#301`/`#404` class of bug).
 - Reconciles each tenant's authorized key into the per-tenant Secret.
 
+**Credential chain (two keypairs).** sshpiper terminates the client connection
+and opens a *new* one to the box, so two hops authenticate independently:
+client→sshpiper against the Pipe's `spec.from.authorized_keys_data` (the agent's
+key), and sshpiper→box against `spec.to.private_key_secret` (sshpiper's
+**upstream** key, whose public half the daemon authorizes on the box — the box
+never authorizes the agent's key in gateway mode). Deployable manifests +
+runbook live in [`deploy/k8s/sshpiper/`](../deploy/k8s/sshpiper/); the daemon is
+wired via `CONTAINARIUM_K8S_GATEWAY_UPSTREAM_{PUBLIC_KEY,KEY_SECRET}`.
+
 ### 3. Isolation (NetworkPolicy)
 
 Per tenant namespace:

--- a/images/agent-box/Dockerfile
+++ b/images/agent-box/Dockerfile
@@ -38,7 +38,10 @@ RUN apt-get update \
     && chown -R agent:agent /home/agent /etc/agent-box
 
 COPY --from=build /out/agent-box /usr/local/bin/agent-box
-COPY --chmod=0755 images/agent-box/entrypoint.sh /usr/local/bin/agent-box-entrypoint.sh
+# Plain COPY + chmod (not COPY --chmod) so the image also builds with the
+# legacy builder, not only BuildKit.
+COPY images/agent-box/entrypoint.sh /usr/local/bin/agent-box-entrypoint.sh
+RUN chmod 0755 /usr/local/bin/agent-box-entrypoint.sh
 
 USER agent
 ENV HOME=/home/agent

--- a/internal/server/boxbackend_k8s.go
+++ b/internal/server/boxbackend_k8s.go
@@ -34,6 +34,10 @@ func newBoxBackend(_ *container.Manager) (box.BoxBackend, error) {
 		TenantNamespacePrefix: k8sEnvOr("CONTAINARIUM_K8S_TENANT_NS_PREFIX", "tenant-"),
 		BoxImage:              os.Getenv("CONTAINARIUM_K8S_BOX_IMAGE"),
 		StorageClass:          os.Getenv("CONTAINARIUM_K8S_STORAGE_CLASS"),
+		// sshpiper upstream credential: the public key boxes authorize, and the
+		// Secret (in the gateway namespace) holding the matching private key.
+		GatewayUpstreamPublicKey: os.Getenv("CONTAINARIUM_K8S_GATEWAY_UPSTREAM_PUBLIC_KEY"),
+		GatewayUpstreamKeySecret: os.Getenv("CONTAINARIUM_K8S_GATEWAY_UPSTREAM_KEY_SECRET"),
 	})
 }
 

--- a/pkg/core/box/k8s/gateway.go
+++ b/pkg/core/box/k8s/gateway.go
@@ -47,6 +47,17 @@ func (b *Backend) pipeObject(tenant string, keys []string) *unstructured.Unstruc
 		buf = append(buf, []byte(k)...)
 		buf = append(buf, '\n')
 	}
+	to := map[string]any{
+		"host":     b.upstreamHost(tenant),
+		"username": boxSSHUser, // fixed box login user; tenant identity is enforced by from.username
+		// ignore_hostkey for now (host-key pinning is a follow-up).
+		"ignore_hostkey": true,
+	}
+	// The upstream credential: sshpiper authenticates to the box with this key
+	// (its public half is authorized on the box). Set only when configured.
+	if b.cfg.GatewayUpstreamKeySecret != "" {
+		to["private_key_secret"] = map[string]any{"name": b.cfg.GatewayUpstreamKeySecret}
+	}
 	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "sshpiper.com/v1beta1",
 		"kind":       "Pipe",
@@ -60,14 +71,7 @@ func (b *Backend) pipeObject(tenant string, keys []string) *unstructured.Unstruc
 				"username":             tenant,
 				"authorized_keys_data": base64.StdEncoding.EncodeToString(buf),
 			}},
-			"to": map[string]any{
-				"host":     b.upstreamHost(tenant),
-				"username": boxSSHUser, // fixed box login user; tenant identity is enforced by from.username
-				// ignore_hostkey for now (host-key pinning is a follow-up). The
-				// upstream credential (spec.to.private_key_secret authorized on
-				// the box) is part of the end-to-end SSH data-plane follow-up.
-				"ignore_hostkey": true,
-			},
+			"to": to,
 		},
 	}}
 }

--- a/pkg/core/box/k8s/gateway_test.go
+++ b/pkg/core/box/k8s/gateway_test.go
@@ -112,6 +112,51 @@ func TestDeleteRemovesPipe(t *testing.T) {
 	}
 }
 
+func TestGatewayUpstreamCredential(t *testing.T) {
+	scheme := runtime.NewScheme()
+	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{pipeGVR: "PipeList"})
+	cs := fake.NewSimpleClientset()
+	b := NewWithClients(cs, dyn, Config{
+		GatewayNamespace:         "sshpiper",
+		GatewayHost:              "gw.example.com",
+		GatewayUpstreamPublicKey: "ssh-ed25519 GATEWAYPUB gateway",
+		GatewayUpstreamKeySecret: "sshpiper-upstream-key",
+	})
+	ctx := context.Background()
+	if _, err := b.Create(ctx, box.BoxSpec{
+		Ref:       box.BoxRef{Tenant: "alice"},
+		Image:     "x",
+		SSHKeys:   []string{"ssh-ed25519 AGENTPUB agent"},
+		AutoStart: true,
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// The box authorizes the GATEWAY's key (so sshpiper can log in), NOT the
+	// agent's key.
+	sec, err := cs.CoreV1().Secrets("tenant-alice").Get(ctx, secretName("alice"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get box secret: %v", err)
+	}
+	if got := string(sec.Data[authorizedKeysKey]); got != "ssh-ed25519 GATEWAYPUB gateway\n" {
+		t.Errorf("box authorized_keys = %q, want the gateway key", got)
+	}
+
+	// The Pipe authenticates the client with the agent's key (from) and
+	// references the upstream private key (to.private_key_secret).
+	p := getPipe(t, dyn, "alice")
+	from, _, _ := unstructured.NestedSlice(p.Object, "spec", "from")
+	wantAgent := base64.StdEncoding.EncodeToString([]byte("ssh-ed25519 AGENTPUB agent\n"))
+	if f0 := from[0].(map[string]any); f0["authorized_keys_data"] != wantAgent {
+		t.Errorf("from.authorized_keys_data = %v, want agent key", f0["authorized_keys_data"])
+	}
+	keyName, _, _ := unstructured.NestedString(p.Object, "spec", "to", "private_key_secret", "name")
+	if keyName != "sshpiper-upstream-key" {
+		t.Errorf("to.private_key_secret.name = %q, want sshpiper-upstream-key", keyName)
+	}
+}
+
 func TestGatewayDisabledSkipsPipe(t *testing.T) {
 	// No dynamic client (NewWithClientset) → gateway off → Create still succeeds
 	// and programs no Pipe.

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -47,6 +47,18 @@ type Config struct {
 
 	// StorageClass is reserved for the box PVC (not wired in this slice).
 	StorageClass string
+
+	// Gateway upstream credential (sshpiper → box hop). sshpiper terminates the
+	// client connection and opens a NEW connection to the box as user `agent`,
+	// authenticating with its own key. So:
+	//   - GatewayUpstreamPublicKey is authorized ON each box (sshpiper logs in).
+	//   - GatewayUpstreamKeySecret is the Secret in GatewayNamespace holding the
+	//     matching private key, referenced by each Pipe's spec.to.private_key_secret.
+	// The agent's own keys (spec.SSHKeys) authenticate client→gateway via the
+	// Pipe's spec.from.authorized_keys_data. When these are unset, boxes
+	// authorize the agent keys directly (no-gateway / direct-SSH mode).
+	GatewayUpstreamPublicKey string
+	GatewayUpstreamKeySecret string
 }
 
 // Backend implements box.BoxBackend on Kubernetes.
@@ -135,7 +147,7 @@ func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus,
 	if _, err := b.clientset.CoreV1().Namespaces().Create(ctx, namespaceObject(ns, tenant), metav1.CreateOptions{}); ignoreExists(err) != nil {
 		return nil, fmt.Errorf("k8s: ensure namespace: %w", err)
 	}
-	if _, err := b.clientset.CoreV1().Secrets(ns).Create(ctx, secretObject(ns, tenant, spec.SSHKeys), metav1.CreateOptions{}); ignoreExists(err) != nil {
+	if _, err := b.clientset.CoreV1().Secrets(ns).Create(ctx, secretObject(ns, tenant, b.boxAuthorizedKeys(spec.SSHKeys)), metav1.CreateOptions{}); ignoreExists(err) != nil {
 		return nil, fmt.Errorf("k8s: ensure secret: %w", err)
 	}
 	if _, err := b.clientset.CoreV1().Services(ns).Create(ctx, serviceObject(ns, tenant), metav1.CreateOptions{}); ignoreExists(err) != nil {
@@ -242,20 +254,37 @@ func (b *Backend) Resolve(ctx context.Context, ref box.BoxRef) (*box.BoxEndpoint
 	}, nil
 }
 
-// SetAuthorizedKeys upserts the box's authorized_keys Secret.
+// SetAuthorizedKeys rotates the keys that authenticate the agent.
+//
+// In the gateway path (sshpiper authenticates to the box with its own upstream
+// key) the box's authorized_keys stays the gateway key — the agent's keys live
+// in the Pipe's spec.from, so we only re-program the Pipe. In the direct path
+// the agent's keys authorize the box itself, so we update the box Secret too.
 func (b *Backend) SetAuthorizedKeys(ctx context.Context, ref box.BoxRef, keys []string) error {
 	ns := b.namespaceFor(ref.Tenant)
-	sec := secretObject(ns, ref.Tenant, keys)
-	_, err := b.clientset.CoreV1().Secrets(ns).Update(ctx, sec, metav1.UpdateOptions{})
-	if apierrors.IsNotFound(err) {
-		_, err = b.clientset.CoreV1().Secrets(ns).Create(ctx, sec, metav1.CreateOptions{})
+	if !(b.gatewayEnabled() && b.cfg.GatewayUpstreamPublicKey != "") {
+		sec := secretObject(ns, ref.Tenant, keys)
+		_, err := b.clientset.CoreV1().Secrets(ns).Update(ctx, sec, metav1.UpdateOptions{})
+		if apierrors.IsNotFound(err) {
+			_, err = b.clientset.CoreV1().Secrets(ns).Create(ctx, sec, metav1.CreateOptions{})
+		}
+		if err != nil {
+			return err
+		}
 	}
-	if err != nil {
-		return err
-	}
-	// Re-program the gateway Pipe so the rotated keys take effect at the front
-	// (no-op when the gateway isn't configured).
+	// Re-program the gateway Pipe so the rotated client keys take effect at the
+	// front (no-op when the gateway isn't configured).
 	return b.upsertPipe(ctx, ref.Tenant, keys)
+}
+
+// boxAuthorizedKeys returns the keys the box itself should authorize: the
+// gateway's upstream key when routing through sshpiper, else the agent's keys
+// (direct access).
+func (b *Backend) boxAuthorizedKeys(agentKeys []string) []string {
+	if b.gatewayEnabled() && b.cfg.GatewayUpstreamPublicKey != "" {
+		return []string{b.cfg.GatewayUpstreamPublicKey}
+	}
+	return agentKeys
 }
 
 // Resize patches the box container's resource limits. Unparseable (incus-native)

--- a/pkg/core/box/k8s/k8s_test.go
+++ b/pkg/core/box/k8s/k8s_test.go
@@ -68,6 +68,16 @@ func TestCreateReconcilesObjects(t *testing.T) {
 		if pscPort := ss.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort; pscPort != 2222 {
 			t.Errorf("container port = %d, want 2222", pscPort)
 		}
+		// The authorized_keys Secret must be mounted where the image reads it,
+		// or the box has no keys and rejects every login (found in live test).
+		vm := ss.Spec.Template.Spec.Containers[0].VolumeMounts
+		if len(vm) != 1 || vm[0].MountPath != "/etc/agent-box" {
+			t.Errorf("authorized_keys not mounted at /etc/agent-box: %+v", vm)
+		}
+		vols := ss.Spec.Template.Spec.Volumes
+		if len(vols) != 1 || vols[0].Secret == nil || vols[0].Secret.SecretName != secretName("alice") {
+			t.Errorf("box volume not sourced from the authorized_keys Secret: %+v", vols)
+		}
 	}
 	if _, err := cs.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{}); err != nil {
 		t.Errorf("service not created: %v", err)

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -34,6 +34,10 @@ const (
 	metaAnnotationPrefix = "containarium.dev/meta."
 
 	authorizedKeysKey = "authorized_keys"
+	// authorizedKeysMount is where the box image (dropbear entrypoint) reads
+	// authorized_keys; the box's Secret is mounted here.
+	authorizedKeysMount  = "/etc/agent-box"
+	authorizedKeysVolume = "authorized-keys"
 )
 
 func int32p(i int32) *int32 { return &i }
@@ -142,6 +146,13 @@ func statefulSetObject(ns string, spec box.BoxSpec) *appsv1.StatefulSet {
 			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 		},
+		// Mount the box's authorized_keys Secret where the image reads it.
+		// Without this the box has no keys and rejects every login.
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      authorizedKeysVolume,
+			MountPath: authorizedKeysMount,
+			ReadOnly:  true,
+		}},
 	}
 	if res := resourceRequirements(spec.Resources); res != nil {
 		container.Resources = *res
@@ -163,6 +174,12 @@ func statefulSetObject(ns string, spec box.BoxSpec) *appsv1.StatefulSet {
 						SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 					},
 					Containers: []corev1.Container{container},
+					Volumes: []corev1.Volume{{
+						Name: authorizedKeysVolume,
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{SecretName: secretName(spec.Ref.Tenant)},
+						},
+					}},
 				},
 			},
 		},


### PR DESCRIPTION
Stands up the **SSH gateway data-plane** and wires the daemon to authenticate the sshpiper→box hop — so an agent reaches a box **end-to-end through sshpiper**, not just to the box directly. Builds on #712.

## Credential model — two keypairs, two independent hops
sshpiper terminates the client connection and opens a *new* one to the box, so each hop authenticates on its own:

```
client → sshpiper : Pipe spec.from.authorized_keys_data   (the agent's key)
sshpiper → box    : Pipe spec.to.private_key_secret        (sshpiper's upstream key)
```

In **gateway mode the box authorizes ONLY the upstream key** (whose public half the daemon installs in the box's authorized_keys) — the agent can never reach a box except through its per-tenant Pipe. In direct mode (no gateway) the box authorizes the agent's keys, as before.

## Reconciler (`pkg/core/box/k8s`)
- `Config` gains `GatewayUpstreamPublicKey` (authorized on boxes) + `GatewayUpstreamKeySecret` (the Pipe's `spec.to.private_key_secret`).
- `Create` authorizes the gateway key on the box; the Pipe carries `to.private_key_secret`. `SetAuthorizedKeys` rotates the **client** keys at the Pipe (gateway path) vs the box Secret (direct path).
- Daemon reads `CONTAINARIUM_K8S_GATEWAY_UPSTREAM_{PUBLIC_KEY,KEY_SECRET}`.
- **Unit test** (fake clients): box authorizes the gateway key (not the agent's); Pipe carries `from`=agent-key + `to.private_key_secret`.

## Deploy — `deploy/k8s/sshpiper/`
Reviewable manifests: namespace, Pipe CRD (open schema), **least-privilege RBAC** (read pipes + secrets in the gateway ns, *no* `pods/exec`), `sshpiperd` Deployment (`PLUGIN=kubernetes`, server key from a Secret), LoadBalancer Service `:22→:2222`, and a **runbook** (generate both keypairs, create Secrets, configure the daemon, deploy, and the SSH-through-gateway acceptance test). RBAC/image/flags verified against upstream sshpiper docs.

## Honest scope
- **Live end-to-end SSH is a real-cluster acceptance step**, documented in the runbook — I have no Docker/kind in the dev sandbox, so the live handshake (deploy sshpiper + SSH through it) isn't auto-tested here. What *is* validated: the reconciler credential wiring (unit tests, green) and all manifests parse.
- **Host-key pinning** (dropping the Pipe's `ignore_hostkey`) remains a follow-up.

## Verification (local)
- `go test -tags k8s ./pkg/core/box/k8s/` — green (incl. new upstream-credential test).
- All `deploy/k8s/sshpiper/*.yaml` parse; `gofmt` clean.
- Full `-tags k8s` build + the existing kind e2e validated by CI (the daemon dep tree re-download + the disk-limited sandbox mean I lean on CI's `build + unit (-tags k8s)` job for the full compile, as on prior PRs).