### PR TITLE
fix(k8s): gateway data-plane fixes from the live sshpiper run (#700)

### DIFF
--- a/deploy/k8s/sshpiper/30-deployment.yaml
+++ b/deploy/k8s/sshpiper/30-deployment.yaml
@@ -43,4 +43,6 @@ spec:
         - name: server-key
           secret:
             secretName: sshpiper-server-key
-            defaultMode: 0400
+            # 0444 (not 0400): the sshpiperd image runs non-root, so an
+            # owner-only key it can't read crashes it ("permission denied").
+            defaultMode: 0444

--- a/deploy/k8s/sshpiper/README.md
+++ b/deploy/k8s/sshpiper/README.md
@@ -39,8 +39,10 @@ ssh-keygen -t ed25519 -N '' -f ./sshpiper_upstream -C sshpiper-upstream
 kubectl apply -f 00-namespace.yaml
 kubectl -n agent-gateway create secret generic sshpiper-server-key \
   --from-file=server_key=./sshpiper_server
+# The data key MUST be `ssh-privatekey` — sshpiper's kubernetes plugin reads
+# spec.to.private_key_secret from that key (verified live).
 kubectl -n agent-gateway create secret generic sshpiper-upstream-key \
-  --from-file=privatekey=./sshpiper_upstream
+  --from-file=ssh-privatekey=./sshpiper_upstream
 ```
 
 ## 3. Point the daemon at the gateway

--- a/images/agent-box/entrypoint.sh
+++ b/images/agent-box/entrypoint.sh
@@ -15,17 +15,23 @@ if [ -e /etc/agent-box/authorized_keys ]; then
   ln -sf /etc/agent-box/authorized_keys "$HOME/.ssh/authorized_keys"
 fi
 
-# Host key in a writable per-container dir. Regenerated each start; the gateway
-# uses ignore_hostkey today (host-key pinning is a follow-up), so a fresh key
-# per restart is fine.
+# Host keys in a writable per-container dir. Regenerated each start; the gateway
+# uses ignore_hostkey today (host-key pinning is a follow-up), so fresh keys
+# per restart are fine. BOTH an ed25519 and an RSA key are generated: the
+# sshpiper gateway (Go x/crypto/ssh) offers rsa-sha2 host-key algorithms, and a
+# dropbear with no RSA host key hits a NULL-key assertion (rsa.c) and drops the
+# connection before auth — observed live against sshpiper. Shipping an RSA host
+# key too makes the upstream handshake succeed.
 KEYDIR="$HOME/.dropbear"
 mkdir -p "$KEYDIR"
-HOSTKEY="$KEYDIR/ed25519_host_key"
-[ -f "$HOSTKEY" ] || dropbearkey -t ed25519 -f "$HOSTKEY" >/dev/null 2>&1
+ED_HOSTKEY="$KEYDIR/ed25519_host_key"
+RSA_HOSTKEY="$KEYDIR/rsa_host_key"
+[ -f "$ED_HOSTKEY" ] || dropbearkey -t ed25519 -f "$ED_HOSTKEY" >/dev/null 2>&1
+[ -f "$RSA_HOSTKEY" ] || dropbearkey -t rsa -s 3072 -f "$RSA_HOSTKEY" >/dev/null 2>&1
 
 # dropbear flags:
 #   -F  foreground (PID 1)            -E  log to stderr
 #   -s  disable password auth         -j -k  no local/remote port forwarding
-#   -p 2222  unprivileged port        -r  host key file
+#   -p 2222  unprivileged port        -r  host key file (repeatable)
 #   -c  forced command — every session runs agent-box, nothing else
-exec dropbear -F -E -s -j -k -p 2222 -r "$HOSTKEY" -c /usr/local/bin/agent-box
+exec dropbear -F -E -s -j -k -p 2222 -r "$ED_HOSTKEY" -r "$RSA_HOSTKEY" -c /usr/local/bin/agent-box


### PR DESCRIPTION
The **live sshpiper front hop** now works end-to-end. I deployed sshpiperd + a box + a Pipe in a real kind cluster (in a Containarium cloud box) and connected **client → sshpiper (as `alice`) → box → agent-box** — it returned a valid MCP `initialize`. The two-keypair auth chain works: the agent key authenticates client→sshpiper (`spec.from.authorized_keys_data`), the upstream key authenticates sshpiper→box (`spec.to.private_key_secret`).

Getting there surfaced two real bugs CI never could (no live SSH in CI):

- 🐞 **Box dropbear had only an ed25519 host key.** sshpiper (Go `x/crypto/ssh`) offers rsa-sha2 host-key algorithms; a dropbear with no RSA host key hits a NULL-key assertion (`rsa.c`) and drops the upstream connection *before auth* (`Exit before auth ... key != NULL`). **Fix:** the image entrypoint now generates an RSA host key too and passes both to dropbear.
- 🐞 **sshpiper server-key Secret mounted `defaultMode: 0400`** (owner-only) — but `farmer1992/sshpiperd` runs non-root → `permission denied` crashloop. **Fix:** `0444`.
- 📓 **Runbook:** the upstream-key Secret must use data key **`ssh-privatekey`** (what the plugin reads — confirmed in sshpiper's trace), not `privatekey`.

## Live trace highlights (after fixes)
```
downstream (username alice) is sending public key auth
mapping to box-0.boxes.tenant-alice.svc.cluster.local:2222 private key using secret sshpiper-upstream-key
found private key in secret sshpiper-upstream-key/ssh-privatekey
connecting to upstream agent@…:2222 with auth [privatekey]
→ {"jsonrpc":"2.0","id":1,"result":{…,"serverInfo":{"name":"containarium-agent-box","version":"0.30.0"}}}
```

## Scope
Docs/manifests/entrypoint only — no Go changes. The `agent-box image` workflow rebuilds + smoke-checks the image (validates the entrypoint). Box deleted after the run (billing stopped).

This is the **last data-plane gap** — the K8s agent-box backend is now proven end-to-end, gateway included. Remaining: host-key pinning (drop `ignore_hostkey`).