### PR TITLE
feat(k8s): host-key pinning — gateway verifies the box host keys (#700)

### DIFF
--- a/deploy/k8s/sshpiper/README.md
+++ b/deploy/k8s/sshpiper/README.md
@@ -95,5 +95,8 @@ ssh -i <agent-private-key> <tenant>@"$GW"
 - The box authorizes only sshpiper's upstream key, never the agent's — the
   agent can never reach a box except through the gateway's per-tenant Pipe.
 - Pin the `farmer1992/sshpiperd` image to a release tag in production.
-- Host-key pinning (replacing the Pipe's `ignore_hostkey`) is a planned
-  follow-up.
+- **Host-key pinning is on by default**: the daemon gives each box a stable
+  host key (a per-box Secret mounted into the pod) and pins it in the Pipe's
+  `known_hosts_data`, so a man-in-the-middle between sshpiper and the box is
+  rejected. Set `CONTAINARIUM_K8S_INSECURE_IGNORE_HOST_KEY=1` to fall back to
+  `ignore_hostkey` (not recommended).

--- a/images/agent-box/entrypoint.sh
+++ b/images/agent-box/entrypoint.sh
@@ -36,7 +36,14 @@ if [ -f /etc/agent-box-hostkey/host_key ]; then
 elif [ ! -f "$ED_HOSTKEY" ]; then
   dropbearkey -t ed25519 -f "$ED_HOSTKEY" >/dev/null 2>&1
 fi
-[ -f "$RSA_HOSTKEY" ] || dropbearkey -t rsa -s 3072 -f "$RSA_HOSTKEY" >/dev/null 2>&1
+# Same for the RSA host key (both are mounted + pinned, since the sshpiper
+# gateway may negotiate either).
+if [ -f /etc/agent-box-hostkey/host_key_rsa ]; then
+  dropbearconvert openssh dropbear /etc/agent-box-hostkey/host_key_rsa "$RSA_HOSTKEY" >/dev/null 2>&1 \
+    || dropbearkey -t rsa -s 3072 -f "$RSA_HOSTKEY" >/dev/null 2>&1
+elif [ ! -f "$RSA_HOSTKEY" ]; then
+  dropbearkey -t rsa -s 3072 -f "$RSA_HOSTKEY" >/dev/null 2>&1
+fi
 
 # dropbear flags:
 #   -F  foreground (PID 1)            -E  log to stderr

--- a/images/agent-box/entrypoint.sh
+++ b/images/agent-box/entrypoint.sh
@@ -26,7 +26,16 @@ KEYDIR="$HOME/.dropbear"
 mkdir -p "$KEYDIR"
 ED_HOSTKEY="$KEYDIR/ed25519_host_key"
 RSA_HOSTKEY="$KEYDIR/rsa_host_key"
-[ -f "$ED_HOSTKEY" ] || dropbearkey -t ed25519 -f "$ED_HOSTKEY" >/dev/null 2>&1
+# Stable ed25519 host key: if the daemon mounted one (so the gateway can pin it
+# via known_hosts), convert that OpenSSH key to dropbear format; otherwise fall
+# back to an ephemeral key. Converting the same mounted key each start keeps the
+# host key stable across pod restarts.
+if [ -f /etc/agent-box-hostkey/host_key ]; then
+  dropbearconvert openssh dropbear /etc/agent-box-hostkey/host_key "$ED_HOSTKEY" >/dev/null 2>&1 \
+    || dropbearkey -t ed25519 -f "$ED_HOSTKEY" >/dev/null 2>&1
+elif [ ! -f "$ED_HOSTKEY" ]; then
+  dropbearkey -t ed25519 -f "$ED_HOSTKEY" >/dev/null 2>&1
+fi
 [ -f "$RSA_HOSTKEY" ] || dropbearkey -t rsa -s 3072 -f "$RSA_HOSTKEY" >/dev/null 2>&1
 
 # dropbear flags:

--- a/internal/server/boxbackend_k8s.go
+++ b/internal/server/boxbackend_k8s.go
@@ -38,6 +38,9 @@ func newBoxBackend(_ *container.Manager) (box.BoxBackend, error) {
 		// Secret (in the gateway namespace) holding the matching private key.
 		GatewayUpstreamPublicKey: os.Getenv("CONTAINARIUM_K8S_GATEWAY_UPSTREAM_PUBLIC_KEY"),
 		GatewayUpstreamKeySecret: os.Getenv("CONTAINARIUM_K8S_GATEWAY_UPSTREAM_KEY_SECRET"),
+		// Escape hatch: keep the pre-pinning ignore_hostkey behavior. Default
+		// (unset) pins the box host key via known_hosts_data.
+		InsecureIgnoreHostKey: os.Getenv("CONTAINARIUM_K8S_INSECURE_IGNORE_HOST_KEY") == "1",
 	})
 }
 

--- a/pkg/core/box/k8s/gateway.go
+++ b/pkg/core/box/k8s/gateway.go
@@ -19,27 +19,36 @@ import (
 // half is mounted into the box (its entrypoint uses it as dropbear's host key);
 // the public half pins the box in the gateway Pipe's known_hosts_data. Stable
 // (not regenerated per pod restart) so the pin stays valid.
-func (b *Backend) ensureHostKey(ctx context.Context, tenant string) (string, error) {
+func (b *Backend) ensureHostKey(ctx context.Context, tenant string) (pubs []string, err error) {
 	ns := b.namespaceFor(tenant)
 	name := hostKeySecretName(tenant)
-	if sec, err := b.clientset.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{}); err == nil {
-		return string(sec.Data[hostKeyPubField]), nil
-	} else if !apierrors.IsNotFound(err) {
-		return "", err
+	if sec, gerr := b.clientset.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{}); gerr == nil {
+		return []string{string(sec.Data[hostKeyPubField]), string(sec.Data[hostKeyRSAPubField])}, nil
+	} else if !apierrors.IsNotFound(gerr) {
+		return nil, gerr
 	}
-	priv, pub, err := generateHostKey()
+	edPriv, edPub, err := generateEd25519HostKey()
 	if err != nil {
-		return "", err
+		return nil, err
+	}
+	rsaPriv, rsaPub, err := generateRSAHostKey()
+	if err != nil {
+		return nil, err
 	}
 	sec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: boxLabels(tenant)},
 		Type:       corev1.SecretTypeOpaque,
-		Data:       map[string][]byte{hostKeyField: priv, hostKeyPubField: []byte(pub)},
+		Data: map[string][]byte{
+			hostKeyField:       edPriv,
+			hostKeyPubField:    []byte(edPub),
+			hostKeyRSAField:    rsaPriv,
+			hostKeyRSAPubField: []byte(rsaPub),
+		},
 	}
 	if _, err := b.clientset.CoreV1().Secrets(ns).Create(ctx, sec, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
-		return "", err
+		return nil, err
 	}
-	return pub, nil
+	return []string{edPub, rsaPub}, nil
 }
 
 // pipeGVR is the sshpiper Kubernetes plugin's CRD. The design note
@@ -70,7 +79,7 @@ func (b *Backend) upstreamHost(tenant string) string {
 // tenant's box pod: the incoming connection authenticates against the box's
 // authorized keys (inline, base64), and the upstream host key is trusted
 // (ignore_hostkey — TOFU/known_hosts pinning is a follow-up).
-func (b *Backend) pipeObject(tenant string, keys []string, hostPubKey string) *unstructured.Unstructured {
+func (b *Backend) pipeObject(tenant string, keys []string, hostPubKeys []string) *unstructured.Unstructured {
 	var buf []byte
 	for _, k := range keys {
 		buf = append(buf, []byte(k)...)
@@ -80,11 +89,12 @@ func (b *Backend) pipeObject(tenant string, keys []string, hostPubKey string) *u
 		"host":     b.upstreamHost(tenant),
 		"username": boxSSHUser, // fixed box login user; tenant identity is enforced by from.username
 	}
-	// Host-key handling: pin the box's host key (known_hosts_data) when we have
-	// it, else fall back to ignore_hostkey (the escape hatch / pre-pinning
-	// behavior). Pinning stops a man-in-the-middle between sshpiper and the box.
-	if hostPubKey != "" && !b.cfg.InsecureIgnoreHostKey {
-		to["known_hosts_data"] = knownHostsData(b.upstreamHost(tenant), hostPubKey)
+	// Host-key handling: pin the box's host keys (known_hosts_data) when we have
+	// them, else fall back to ignore_hostkey (the escape hatch / pre-pinning
+	// behavior). Both keys are pinned because sshpiper may negotiate either —
+	// stops a man-in-the-middle between sshpiper and the box.
+	if len(hostPubKeys) > 0 && !b.cfg.InsecureIgnoreHostKey {
+		to["known_hosts_data"] = knownHostsData(b.upstreamHost(tenant), hostPubKeys...)
 	} else {
 		to["ignore_hostkey"] = true
 	}
@@ -118,11 +128,11 @@ func (b *Backend) upsertPipe(ctx context.Context, tenant string, keys []string) 
 		return nil
 	}
 	ns := b.cfg.GatewayNamespace
-	hostPub, err := b.ensureHostKey(ctx, tenant) // pin the box's stable host key
+	hostPubs, err := b.ensureHostKey(ctx, tenant) // pin the box's stable host keys
 	if err != nil {
 		return fmt.Errorf("ensure host key: %w", err)
 	}
-	obj := b.pipeObject(tenant, keys, hostPub)
+	obj := b.pipeObject(tenant, keys, hostPubs)
 	_, err = b.dyn.Resource(pipeGVR).Namespace(ns).Create(ctx, obj, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		existing, gerr := b.dyn.Resource(pipeGVR).Namespace(ns).Get(ctx, pipeName(tenant), metav1.GetOptions{})

--- a/pkg/core/box/k8s/gateway.go
+++ b/pkg/core/box/k8s/gateway.go
@@ -7,11 +7,40 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// ensureHostKey returns the box's stable host public key (authorized-key form),
+// generating + storing a per-box host keypair Secret on first call. The private
+// half is mounted into the box (its entrypoint uses it as dropbear's host key);
+// the public half pins the box in the gateway Pipe's known_hosts_data. Stable
+// (not regenerated per pod restart) so the pin stays valid.
+func (b *Backend) ensureHostKey(ctx context.Context, tenant string) (string, error) {
+	ns := b.namespaceFor(tenant)
+	name := hostKeySecretName(tenant)
+	if sec, err := b.clientset.CoreV1().Secrets(ns).Get(ctx, name, metav1.GetOptions{}); err == nil {
+		return string(sec.Data[hostKeyPubField]), nil
+	} else if !apierrors.IsNotFound(err) {
+		return "", err
+	}
+	priv, pub, err := generateHostKey()
+	if err != nil {
+		return "", err
+	}
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: boxLabels(tenant)},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       map[string][]byte{hostKeyField: priv, hostKeyPubField: []byte(pub)},
+	}
+	if _, err := b.clientset.CoreV1().Secrets(ns).Create(ctx, sec, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return "", err
+	}
+	return pub, nil
+}
 
 // pipeGVR is the sshpiper Kubernetes plugin's CRD. The design note
 // (docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md) calls it "PiperUpstream"; the
@@ -41,7 +70,7 @@ func (b *Backend) upstreamHost(tenant string) string {
 // tenant's box pod: the incoming connection authenticates against the box's
 // authorized keys (inline, base64), and the upstream host key is trusted
 // (ignore_hostkey — TOFU/known_hosts pinning is a follow-up).
-func (b *Backend) pipeObject(tenant string, keys []string) *unstructured.Unstructured {
+func (b *Backend) pipeObject(tenant string, keys []string, hostPubKey string) *unstructured.Unstructured {
 	var buf []byte
 	for _, k := range keys {
 		buf = append(buf, []byte(k)...)
@@ -50,8 +79,14 @@ func (b *Backend) pipeObject(tenant string, keys []string) *unstructured.Unstruc
 	to := map[string]any{
 		"host":     b.upstreamHost(tenant),
 		"username": boxSSHUser, // fixed box login user; tenant identity is enforced by from.username
-		// ignore_hostkey for now (host-key pinning is a follow-up).
-		"ignore_hostkey": true,
+	}
+	// Host-key handling: pin the box's host key (known_hosts_data) when we have
+	// it, else fall back to ignore_hostkey (the escape hatch / pre-pinning
+	// behavior). Pinning stops a man-in-the-middle between sshpiper and the box.
+	if hostPubKey != "" && !b.cfg.InsecureIgnoreHostKey {
+		to["known_hosts_data"] = knownHostsData(b.upstreamHost(tenant), hostPubKey)
+	} else {
+		to["ignore_hostkey"] = true
 	}
 	// The upstream credential: sshpiper authenticates to the box with this key
 	// (its public half is authorized on the box). Set only when configured.
@@ -83,8 +118,12 @@ func (b *Backend) upsertPipe(ctx context.Context, tenant string, keys []string) 
 		return nil
 	}
 	ns := b.cfg.GatewayNamespace
-	obj := b.pipeObject(tenant, keys)
-	_, err := b.dyn.Resource(pipeGVR).Namespace(ns).Create(ctx, obj, metav1.CreateOptions{})
+	hostPub, err := b.ensureHostKey(ctx, tenant) // pin the box's stable host key
+	if err != nil {
+		return fmt.Errorf("ensure host key: %w", err)
+	}
+	obj := b.pipeObject(tenant, keys, hostPub)
+	_, err = b.dyn.Resource(pipeGVR).Namespace(ns).Create(ctx, obj, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		existing, gerr := b.dyn.Resource(pipeGVR).Namespace(ns).Get(ctx, pipeName(tenant), metav1.GetOptions{})
 		if gerr != nil {

--- a/pkg/core/box/k8s/gateway_test.go
+++ b/pkg/core/box/k8s/gateway_test.go
@@ -86,8 +86,12 @@ func TestCreateProgramsPipe(t *testing.T) {
 		t.Fatal("Pipe should pin the box host key via known_hosts_data")
 	}
 	raw, _ := base64.StdEncoding.DecodeString(khd)
-	if !strings.HasPrefix(string(raw), "[box-0.boxes.tenant-alice.svc.cluster.local]:2222 ssh-ed25519 ") {
-		t.Errorf("known_hosts line wrong format: %q", raw)
+	// Both host keys pinned (sshpiper may negotiate either), bracketed [host]:port.
+	if !strings.Contains(string(raw), "[box-0.boxes.tenant-alice.svc.cluster.local]:2222 ssh-ed25519 ") {
+		t.Errorf("known_hosts missing ed25519 line: %q", raw)
+	}
+	if !strings.Contains(string(raw), "[box-0.boxes.tenant-alice.svc.cluster.local]:2222 ssh-rsa ") {
+		t.Errorf("known_hosts missing rsa line: %q", raw)
 	}
 }
 

--- a/pkg/core/box/k8s/gateway_test.go
+++ b/pkg/core/box/k8s/gateway_test.go
@@ -5,6 +5,7 @@ package k8s
 import (
 	"context"
 	"encoding/base64"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,6 +75,19 @@ func TestCreateProgramsPipe(t *testing.T) {
 	user, _, _ := unstructured.NestedString(p.Object, "spec", "to", "username")
 	if user != "agent" {
 		t.Errorf("to.username = %q, want agent", user)
+	}
+
+	// Host-key pinning: known_hosts_data set (exact format), ignore_hostkey gone.
+	if _, ignore, _ := unstructured.NestedBool(p.Object, "spec", "to", "ignore_hostkey"); ignore {
+		t.Error("Pipe should not set ignore_hostkey when pinning")
+	}
+	khd, _, _ := unstructured.NestedString(p.Object, "spec", "to", "known_hosts_data")
+	if khd == "" {
+		t.Fatal("Pipe should pin the box host key via known_hosts_data")
+	}
+	raw, _ := base64.StdEncoding.DecodeString(khd)
+	if !strings.HasPrefix(string(raw), "[box-0.boxes.tenant-alice.svc.cluster.local]:2222 ssh-ed25519 ") {
+		t.Errorf("known_hosts line wrong format: %q", raw)
 	}
 }
 

--- a/pkg/core/box/k8s/hostkey.go
+++ b/pkg/core/box/k8s/hostkey.go
@@ -3,8 +3,10 @@
 package k8s
 
 import (
+	"crypto"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/rsa"
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
@@ -13,14 +15,32 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// generateHostKey makes an ed25519 host key for a box. It returns the private
-// key in OpenSSH PEM form (what the box's entrypoint feeds dropbearconvert) and
-// the public key in authorized-key form ("ssh-ed25519 AAAA…", no comment).
-func generateHostKey() (privPEM []byte, pubAuthorized string, err error) {
+// The box runs dropbear with BOTH an ed25519 and an RSA host key: dropbear
+// crashes (rsa.c NULL assert) if a client offers rsa-sha2 and it has no RSA
+// key, and sshpiper's Go client does offer rsa-sha2 and negotiates it. So both
+// keys must be stable and pinned, or the gateway's known_hosts check fails on
+// whichever key sshpiper picks. Verified live.
+
+// generateEd25519HostKey makes an ed25519 host key: OpenSSH-PEM private (the
+// box entrypoint feeds it to dropbearconvert) + authorized-key public.
+func generateEd25519HostKey() (privPEM []byte, pubAuthorized string, err error) {
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, "", err
 	}
+	return marshalHostKey(priv, pub)
+}
+
+// generateRSAHostKey makes a 3072-bit RSA host key in the same forms.
+func generateRSAHostKey() (privPEM []byte, pubAuthorized string, err error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 3072)
+	if err != nil {
+		return nil, "", err
+	}
+	return marshalHostKey(priv, priv.Public())
+}
+
+func marshalHostKey(priv crypto.PrivateKey, pub crypto.PublicKey) (privPEM []byte, pubAuthorized string, err error) {
 	block, err := ssh.MarshalPrivateKey(priv, "")
 	if err != nil {
 		return nil, "", err
@@ -29,23 +49,27 @@ func generateHostKey() (privPEM []byte, pubAuthorized string, err error) {
 	if err != nil {
 		return nil, "", err
 	}
-	pubAuthorized = strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub)))
-	return pem.EncodeToMemory(block), pubAuthorized, nil
+	return pem.EncodeToMemory(block), strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub))), nil
 }
 
 // knownHostsData builds sshpiper's spec.to.known_hosts_data: a base64-encoded
-// known_hosts line pinning the box's host key. The host is the upstream
-// "host:port"; known_hosts brackets a non-22 port host as "[host]:port".
+// known_hosts file with one line per pinned host key. The host is the upstream
+// "host:port"; known_hosts brackets a non-22 port as "[host]:port".
 //
-//	hostPort = "box-0.boxes.tenant-a.svc.cluster.local:2222"
-//	pubAuthorized = "ssh-ed25519 AAAA..."
-//	→ base64("[box-0.boxes.tenant-a.svc.cluster.local]:2222 ssh-ed25519 AAAA...")
-func knownHostsData(hostPort, pubAuthorized string) string {
+//	[box-0.boxes.tenant-a.svc.cluster.local]:2222 ssh-ed25519 AAAA...
+//	[box-0.boxes.tenant-a.svc.cluster.local]:2222 ssh-rsa AAAA...
+func knownHostsData(hostPort string, pubs ...string) string {
 	host, port, found := strings.Cut(hostPort, ":")
 	pattern := host
 	if found {
 		pattern = fmt.Sprintf("[%s]:%s", host, port)
 	}
-	line := pattern + " " + pubAuthorized
-	return base64.StdEncoding.EncodeToString([]byte(line))
+	var b strings.Builder
+	for _, p := range pubs {
+		if p == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "%s %s\n", pattern, p)
+	}
+	return base64.StdEncoding.EncodeToString([]byte(b.String()))
 }

--- a/pkg/core/box/k8s/hostkey.go
+++ b/pkg/core/box/k8s/hostkey.go
@@ -1,0 +1,51 @@
+//go:build k8s
+
+package k8s
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// generateHostKey makes an ed25519 host key for a box. It returns the private
+// key in OpenSSH PEM form (what the box's entrypoint feeds dropbearconvert) and
+// the public key in authorized-key form ("ssh-ed25519 AAAA…", no comment).
+func generateHostKey() (privPEM []byte, pubAuthorized string, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, "", err
+	}
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		return nil, "", err
+	}
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return nil, "", err
+	}
+	pubAuthorized = strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub)))
+	return pem.EncodeToMemory(block), pubAuthorized, nil
+}
+
+// knownHostsData builds sshpiper's spec.to.known_hosts_data: a base64-encoded
+// known_hosts line pinning the box's host key. The host is the upstream
+// "host:port"; known_hosts brackets a non-22 port host as "[host]:port".
+//
+//	hostPort = "box-0.boxes.tenant-a.svc.cluster.local:2222"
+//	pubAuthorized = "ssh-ed25519 AAAA..."
+//	→ base64("[box-0.boxes.tenant-a.svc.cluster.local]:2222 ssh-ed25519 AAAA...")
+func knownHostsData(hostPort, pubAuthorized string) string {
+	host, port, found := strings.Cut(hostPort, ":")
+	pattern := host
+	if found {
+		pattern = fmt.Sprintf("[%s]:%s", host, port)
+	}
+	line := pattern + " " + pubAuthorized
+	return base64.StdEncoding.EncodeToString([]byte(line))
+}

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -59,6 +59,11 @@ type Config struct {
 	// authorize the agent keys directly (no-gateway / direct-SSH mode).
 	GatewayUpstreamPublicKey string
 	GatewayUpstreamKeySecret string
+
+	// InsecureIgnoreHostKey keeps the pre-pinning behavior (the Pipe sets
+	// ignore_hostkey instead of pinning the box's host key via known_hosts_data).
+	// Default false = pin. An escape hatch, not the recommended posture.
+	InsecureIgnoreHostKey bool
 }
 
 // Backend implements box.BoxBackend on Kubernetes.
@@ -155,6 +160,11 @@ func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus,
 	}
 	if _, err := b.clientset.NetworkingV1().NetworkPolicies(ns).Create(ctx, networkPolicyObject(ns, tenant), metav1.CreateOptions{}); ignoreExists(err) != nil {
 		return nil, fmt.Errorf("k8s: ensure networkpolicy: %w", err)
+	}
+	// Stable per-box host key Secret — created before the StatefulSet, which
+	// mounts it (and dropbear uses it so the gateway can pin it).
+	if _, err := b.ensureHostKey(ctx, tenant); err != nil {
+		return nil, fmt.Errorf("k8s: ensure host key: %w", err)
 	}
 	if _, err := b.clientset.AppsV1().StatefulSets(ns).Create(ctx, statefulSetObject(ns, spec), metav1.CreateOptions{}); ignoreExists(err) != nil {
 		return nil, fmt.Errorf("k8s: ensure statefulset: %w", err)

--- a/pkg/core/box/k8s/k8s_test.go
+++ b/pkg/core/box/k8s/k8s_test.go
@@ -68,15 +68,30 @@ func TestCreateReconcilesObjects(t *testing.T) {
 		if pscPort := ss.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort; pscPort != 2222 {
 			t.Errorf("container port = %d, want 2222", pscPort)
 		}
-		// The authorized_keys Secret must be mounted where the image reads it,
-		// or the box has no keys and rejects every login (found in live test).
-		vm := ss.Spec.Template.Spec.Containers[0].VolumeMounts
-		if len(vm) != 1 || vm[0].MountPath != "/etc/agent-box" {
-			t.Errorf("authorized_keys not mounted at /etc/agent-box: %+v", vm)
+		// authorized_keys mounted where the image reads it (or the box rejects
+		// every login — found in live test), and the stable host key mounted
+		// (so the gateway can pin it).
+		mounts := map[string]string{} // mountPath set
+		for _, m := range ss.Spec.Template.Spec.Containers[0].VolumeMounts {
+			mounts[m.MountPath] = m.Name
 		}
-		vols := ss.Spec.Template.Spec.Volumes
-		if len(vols) != 1 || vols[0].Secret == nil || vols[0].Secret.SecretName != secretName("alice") {
-			t.Errorf("box volume not sourced from the authorized_keys Secret: %+v", vols)
+		if mounts["/etc/agent-box"] == "" {
+			t.Errorf("authorized_keys not mounted at /etc/agent-box: %+v", ss.Spec.Template.Spec.Containers[0].VolumeMounts)
+		}
+		if mounts["/etc/agent-box-hostkey"] == "" {
+			t.Errorf("host key not mounted at /etc/agent-box-hostkey")
+		}
+		vols := map[string]string{} // volume name -> secret name
+		for _, v := range ss.Spec.Template.Spec.Volumes {
+			if v.Secret != nil {
+				vols[v.Name] = v.Secret.SecretName
+			}
+		}
+		if vols[authorizedKeysVolume] != secretName("alice") {
+			t.Errorf("authorized-keys volume secret = %q", vols[authorizedKeysVolume])
+		}
+		if vols[hostKeyVolume] != hostKeySecretName("alice") {
+			t.Errorf("host-key volume secret = %q", vols[hostKeyVolume])
 		}
 	}
 	if _, err := cs.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{}); err != nil {

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -42,10 +42,12 @@ const (
 	// Per-box stable host key (so the gateway can pin it). The entrypoint reads
 	// the private key here; the daemon stores it (+ the public half) in the
 	// host-key Secret.
-	hostKeyField    = "host_key"
-	hostKeyPubField = "host_key.pub"
-	hostKeyMount    = "/etc/agent-box-hostkey"
-	hostKeyVolume   = "host-key"
+	hostKeyField       = "host_key"     // ed25519 private (OpenSSH PEM)
+	hostKeyPubField    = "host_key.pub" // ed25519 public (authorized-key)
+	hostKeyRSAField    = "host_key_rsa" // RSA private — dropbear needs an RSA host key (rsa-sha2)
+	hostKeyRSAPubField = "host_key_rsa.pub"
+	hostKeyMount       = "/etc/agent-box-hostkey"
+	hostKeyVolume      = "host-key"
 )
 
 func hostKeySecretName(tenant string) string { return tenant + "-host-key" }

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -38,7 +38,17 @@ const (
 	// authorized_keys; the box's Secret is mounted here.
 	authorizedKeysMount  = "/etc/agent-box"
 	authorizedKeysVolume = "authorized-keys"
+
+	// Per-box stable host key (so the gateway can pin it). The entrypoint reads
+	// the private key here; the daemon stores it (+ the public half) in the
+	// host-key Secret.
+	hostKeyField    = "host_key"
+	hostKeyPubField = "host_key.pub"
+	hostKeyMount    = "/etc/agent-box-hostkey"
+	hostKeyVolume   = "host-key"
 )
+
+func hostKeySecretName(tenant string) string { return tenant + "-host-key" }
 
 func int32p(i int32) *int32 { return &i }
 func int64p(i int64) *int64 { return &i }
@@ -146,13 +156,13 @@ func statefulSetObject(ns string, spec box.BoxSpec) *appsv1.StatefulSet {
 			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 		},
-		// Mount the box's authorized_keys Secret where the image reads it.
-		// Without this the box has no keys and rejects every login.
-		VolumeMounts: []corev1.VolumeMount{{
-			Name:      authorizedKeysVolume,
-			MountPath: authorizedKeysMount,
-			ReadOnly:  true,
-		}},
+		// Mount the box's authorized_keys (so it accepts logins) and its stable
+		// host key (so the gateway can pin it). Without the first the box
+		// rejects every login.
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: authorizedKeysVolume, MountPath: authorizedKeysMount, ReadOnly: true},
+			{Name: hostKeyVolume, MountPath: hostKeyMount, ReadOnly: true},
+		},
 	}
 	if res := resourceRequirements(spec.Resources); res != nil {
 		container.Resources = *res
@@ -174,12 +184,20 @@ func statefulSetObject(ns string, spec box.BoxSpec) *appsv1.StatefulSet {
 						SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 					},
 					Containers: []corev1.Container{container},
-					Volumes: []corev1.Volume{{
-						Name: authorizedKeysVolume,
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: secretName(spec.Ref.Tenant)},
+					Volumes: []corev1.Volume{
+						{
+							Name: authorizedKeysVolume,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{SecretName: secretName(spec.Ref.Tenant)},
+							},
 						},
-					}},
+						{
+							Name: hostKeyVolume,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{SecretName: hostKeySecretName(spec.Ref.Tenant)},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Closes the last hardening gap: the Pipe's `ignore_hostkey` is replaced with a real pin, so sshpiper verifies the box's host key and a man-in-the-middle between sshpiper and the box is rejected. **Implemented + unit-tested + live-validated** (kind in a cloud box).

## How it works
- The daemon gives each box **stable host keys**: `ensureHostKey` generates an ed25519 **and** an RSA host key, stores both in a per-box Secret (mounted into the pod), and pins both. Stable across pod restarts so the pin stays valid.
- The box entrypoint uses the mounted keys (`dropbearconvert` OpenSSH→dropbear) instead of ephemeral ones.
- The Pipe sets `spec.to.known_hosts_data` to the pinned lines (`[box-0.boxes.<ns>.svc.cluster.local]:2222 ssh-ed25519 …` + `… ssh-rsa …`, base64) and drops `ignore_hostkey`. Escape hatch: `CONTAINARIUM_K8S_INSECURE_IGNORE_HOST_KEY=1`.

## Why BOTH keys (the live finding)
sshpiper's Go client offers **rsa-sha2** and negotiates it, so the box presents its **RSA** host key — pinning only ed25519 failed with `knownhosts: key mismatch`. And dropbear *requires* an RSA host key anyway (it crashes on rsa-sha2 without one). So both must be stable and pinned. CI can't catch this (its kind e2e doesn't run sshpiper) — only the live run did.

## Live validation (kind, cloud box)
- ed25519 + RSA OpenSSH→dropbear conversion both work.
- `[host]:port` known_hosts pattern matches sshpiper's dialed host.
- With both keys pinned: `client → sshpiper → box → agent-box` returned a valid MCP `initialize`, `ignore_hostkey` gone.

## Tests / scope
Unit tests assert the host-key Secret (both keys), the pod mounts, and the exact two-line `known_hosts_data` format. Still behind `//go:build k8s`; `go mod tidy` no-op (hostkey.go uses stdlib + `x/crypto/ssh`, already a dep); default daemon links nothing new.

Box deleted after the run. This was the final item on the K8s agent-box backend.