### PR TITLE
docs(readme): mark the Kubernetes backend shipped in the roadmap (#700)

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,11 @@ Demoed Containarium somewhere? Open a PR and add it here.
 
 ## Roadmap
 
+- **Shipped (2026-06)**: experimental **[Kubernetes backend](#kubernetes-backend-experimental)**
+  — run a box as a pod in a cluster you operate, reached over SSH like an LXC
+  box, with the sshpiper gateway, default-deny NetworkPolicy, and host-key
+  pinning. End-to-end validated on `kind`; behind the `k8s` build tag. See
+  [docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md](docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md).
 - **Q2 2026 (in flight)**: `agent-box` MCP, `ssh-config` CLI,
   `expose-port` CLI, demo recording.
 - **Q3 2026**: `agent-box` tier-2 (MCP Roots, background process


### PR DESCRIPTION
Adds a **Shipped (2026-06)** roadmap entry for the experimental Kubernetes backend — pod-as-box over SSH, sshpiper gateway, default-deny NetworkPolicy, host-key pinning; validated end-to-end on kind; behind the `k8s` build tag. Links the *What's in the box* section and the design doc. Docs-only.