### PR TITLE
docs(changelog): roll [Unreleased] into [0.31.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-06-17
+
+An experimental **Kubernetes backend**: run an agent box as a pod in a cluster
+you already operate, reached over SSH exactly like an LXC box — same `agent-box`
+stdio MCP contract, no kube-apiserver token in the agent's hands. Gated behind
+the `k8s` build tag, so the default daemon is unchanged.
+
 ### Added
 
 - **Experimental Kubernetes backend (`//go:build k8s`).** Run an agent box as a


### PR DESCRIPTION
Rolls the `[Unreleased]` CHANGELOG section into **`[0.31.0]` - 2026-06-17** for the experimental Kubernetes backend (the only unreleased change since v0.30.0). Minor bump — feature is behind the `k8s` build tag, default daemon unchanged. No tag pushed; the release workflow handles publishing.