### PR TITLE
chore(release): cut v0.31.0 — experimental Kubernetes backend

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.30.0"
+	Version = "0.31.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Bumps `pkg/version/version.go` 0.30.0 → 0.31.0 to match the `[0.31.0]` CHANGELOG section (#718). Companion to the release cut; the `v0.31.0` tag (source of truth for release builds) follows on merge.