### PR TITLE
feat(byoc): cloud enroll mints + sends the host driver token (#554 PR 3, OSS side)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -7691,6 +7691,14 @@
         "joinToken": {
           "type": "string",
           "description": "The join token, format \"\u003chost_id\u003e.\u003csecret\u003e\", from the cloud's\n`pool join` / `cloud enroll` one-liner."
+        },
+        "driverToken": {
+          "type": "string",
+          "description": "driver_token is an admin JWT this host minted with its OWN daemon\njwt.secret (`containarium token generate --roles admin --secret-file\n/etc/containarium/jwt.secret`). The cloud stores it sealed and replays\nit to drive this host's daemon through the sentinel peer-proxy (BYOC\nOption β, cloud #554). Optional: empty leaves the host enrolled but\nnot cloud-drivable. The host stays sovereign — it signs with its own\nsecret and rotates by re-enrolling."
+        },
+        "ossBackendId": {
+          "type": "string",
+          "description": "oss_backend_id is the id this host's tunnel registered under at the\nsentinel (its `pool join` spot-id) — what the sentinel `/peer/\u003cid\u003e/`\nproxy keys on. The cloud records it to map a container's backend id\nback to this host. Empty if not (yet) a peer-proxy-routed BYOC backend."
         }
       },
       "description": "EnrollHostRequest carries the single-use join token a BYO host redeems to\nregister itself with the cloud (BYO-compute report path). Unlike every other\nActuationService RPC this one is NOT host-bearer authed — the host row\ndoesn't exist yet; the cloud validates + single-use-redeems the token."

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -208,12 +208,28 @@ func dialControlPlane(addr string, insecureTLS bool) (*grpc.ClientConn, error) {
 	return grpc.NewClient(addr, grpc.WithTransportCredentials(creds))
 }
 
+// EnrollOptions carries the optional BYOC driver-routing fields of EnrollHost
+// (cloud #554). Both empty = a plain enroll (host registered + heartbeating but
+// not cloud-drivable).
+type EnrollOptions struct {
+	// DriverToken is an admin JWT this host minted with its own jwt.secret;
+	// the cloud seals + replays it to drive this host through the sentinel
+	// peer-proxy.
+	DriverToken string
+	// OSSBackendID is this host's tunnel/`pool join` spot-id — what the
+	// sentinel `/peer/<id>/` proxy keys on.
+	OSSBackendID string
+}
+
 // Enroll redeems a single-use join token against the control plane and returns
 // the registered host id. One-shot (no running client / host bearer yet — the
 // token authenticates itself in the body). Used by `containarium cloud enroll`
 // for the BYO self-service flow; after this, the same token is the host's
 // durable bearer (the cloud reuses the token secret as the host bearer).
-func Enroll(ctx context.Context, controlPlane, joinToken string, insecureTLS bool) (string, error) {
+//
+// opts optionally carries the BYOC driver token + backend id (cloud #554) so a
+// tunnel-joined host becomes cloud-drivable in the same round-trip.
+func Enroll(ctx context.Context, controlPlane, joinToken string, insecureTLS bool, opts EnrollOptions) (string, error) {
 	conn, err := dialControlPlane(controlPlane, insecureTLS)
 	if err != nil {
 		return "", fmt.Errorf("cloud: dial control plane %s: %w", controlPlane, err)
@@ -222,7 +238,9 @@ func Enroll(ctx context.Context, controlPlane, joinToken string, insecureTLS boo
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	resp, err := cloudv1.NewActuationServiceClient(conn).EnrollHost(ctx, &cloudv1.EnrollHostRequest{
-		JoinToken: joinToken,
+		JoinToken:    joinToken,
+		DriverToken:  opts.DriverToken,
+		OssBackendId: opts.OSSBackendID,
 	})
 	if err != nil {
 		return "", fmt.Errorf("cloud: enroll: %w", err)

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -22,8 +22,10 @@ type fakeActuation struct {
 	beats         int
 	reportedID    string
 	reportedState string
-	enrollToken   string
-	enrollHostID  string
+	enrollToken     string
+	enrollHostID    string
+	enrollDriverTok string
+	enrollBackendID string
 	statusBearer  string
 	statusReq     *cloudv1.ReportHostStatusRequest
 	statusReports int
@@ -35,6 +37,8 @@ func (f *fakeActuation) EnrollHost(_ context.Context, req *cloudv1.EnrollHostReq
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.enrollToken = req.GetJoinToken()
+	f.enrollDriverTok = req.GetDriverToken()
+	f.enrollBackendID = req.GetOssBackendId()
 	id := req.GetJoinToken()
 	if i := indexByte(id, '.'); i >= 0 {
 		id = id[:i]
@@ -333,7 +337,8 @@ func TestEnroll_RedeemsTokenAndReturnsHostID(t *testing.T) {
 	go func() { _ = srv.Serve(lis) }()
 	t.Cleanup(srv.Stop)
 
-	hostID, err := Enroll(context.Background(), lis.Addr().String(), "host-uuid.secret", true)
+	hostID, err := Enroll(context.Background(), lis.Addr().String(), "host-uuid.secret", true,
+		EnrollOptions{DriverToken: "admin.jwt.tok", OSSBackendID: "tunnel-gpu-1"})
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
@@ -344,6 +349,12 @@ func TestEnroll_RedeemsTokenAndReturnsHostID(t *testing.T) {
 	defer fake.mu.Unlock()
 	if fake.enrollToken != "host-uuid.secret" {
 		t.Errorf("server saw token %q", fake.enrollToken)
+	}
+	if fake.enrollDriverTok != "admin.jwt.tok" {
+		t.Errorf("server saw driver token %q", fake.enrollDriverTok)
+	}
+	if fake.enrollBackendID != "tunnel-gpu-1" {
+		t.Errorf("server saw backend id %q", fake.enrollBackendID)
 	}
 }
 

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -17,18 +17,18 @@ import (
 // fakeActuation records the host-bearer metadata it saw on Heartbeat.
 type fakeActuation struct {
 	cloudv1.UnimplementedActuationServiceServer
-	mu            sync.Mutex
-	bearer        string
-	beats         int
-	reportedID    string
-	reportedState string
+	mu              sync.Mutex
+	bearer          string
+	beats           int
+	reportedID      string
+	reportedState   string
 	enrollToken     string
 	enrollHostID    string
 	enrollDriverTok string
 	enrollBackendID string
-	statusBearer  string
-	statusReq     *cloudv1.ReportHostStatusRequest
-	statusReports int
+	statusBearer    string
+	statusReq       *cloudv1.ReportHostStatusRequest
+	statusReports   int
 }
 
 // EnrollHost echoes back the host id embedded in the join token (first

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -15,7 +15,7 @@ import (
 // defaultDaemonJWTSecretFile is where the daemon's JWT signing secret lives on
 // a standard host install — the same secret `cloud enroll` mints the BYOC
 // driver token against so the host's own daemon will accept it.
-const defaultDaemonJWTSecretFile = "/etc/containarium/jwt.secret"
+const defaultDaemonJWTSecretFile = "/etc/containarium/jwt.secret" // #nosec G101 -- a file PATH, not a credential
 
 // cloudCmd is the parent for `containarium cloud <verb>` — host enrollment with
 // a cloud control plane (#354, docs/CLOUD-ACTUATION-CLIENT-DESIGN.md). This is

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -4,11 +4,18 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/cloud"
 )
+
+// defaultDaemonJWTSecretFile is where the daemon's JWT signing secret lives on
+// a standard host install — the same secret `cloud enroll` mints the BYOC
+// driver token against so the host's own daemon will accept it.
+const defaultDaemonJWTSecretFile = "/etc/containarium/jwt.secret"
 
 // cloudCmd is the parent for `containarium cloud <verb>` — host enrollment with
 // a cloud control plane (#354, docs/CLOUD-ACTUATION-CLIENT-DESIGN.md). This is
@@ -50,9 +57,13 @@ history. Writes the enrollment to ~/.containarium/cloud.yaml at mode 0600.`,
 }
 
 var (
-	cloudEnrollControlPlane string
-	cloudEnrollTokenFile    string
-	cloudEnrollInsecure     bool
+	cloudEnrollControlPlane  string
+	cloudEnrollTokenFile     string
+	cloudEnrollInsecure      bool
+	cloudEnrollJWTSecretFile string
+	cloudEnrollBackendID     string
+	cloudEnrollNoDriverToken bool
+	cloudEnrollDriverTTL     time.Duration
 )
 
 var cloudEnrollCmd = &cobra.Command{
@@ -99,6 +110,10 @@ func init() {
 	cloudEnrollCmd.Flags().StringVar(&cloudEnrollControlPlane, "control-plane", "", "cloud control-plane gRPC address (host:port) (required)")
 	cloudEnrollCmd.Flags().StringVar(&cloudEnrollTokenFile, "token-file", "", "file containing the single-use join token (required)")
 	cloudEnrollCmd.Flags().BoolVar(&cloudEnrollInsecure, "insecure", false, "dial the control plane without TLS (local dev only)")
+	cloudEnrollCmd.Flags().StringVar(&cloudEnrollJWTSecretFile, "jwt-secret-file", defaultDaemonJWTSecretFile, "path to this daemon's JWT secret; used to mint the BYOC driver token the cloud replays to drive this host")
+	cloudEnrollCmd.Flags().StringVar(&cloudEnrollBackendID, "oss-backend-id", "", "this host's tunnel/`pool join` spot-id (what the sentinel peer-proxy keys on); enables the cloud to route container ops to this host")
+	cloudEnrollCmd.Flags().BoolVar(&cloudEnrollNoDriverToken, "no-driver-token", false, "enroll without minting a driver token (host registers + heartbeats but the cloud cannot place workloads on it)")
+	cloudEnrollCmd.Flags().DurationVar(&cloudEnrollDriverTTL, "driver-token-ttl", 30*24*time.Hour, "driver token lifetime (capped at the daemon max, 30d); re-run `cloud enroll` before it expires to rotate")
 	_ = cloudEnrollCmd.MarkFlagRequired("control-plane")
 	_ = cloudEnrollCmd.MarkFlagRequired("token-file")
 }
@@ -143,10 +158,33 @@ func runCloudEnroll(cmd *cobra.Command, _ []string) error {
 	}
 	controlPlane := strings.TrimSpace(cloudEnrollControlPlane)
 
+	// Mint the BYOC driver token (cloud #554) — an admin JWT signed with THIS
+	// host's own jwt.secret, which the cloud seals and replays to drive this
+	// host's daemon through the sentinel peer-proxy. Best-effort: if the secret
+	// isn't readable (e.g. not running as root, or a non-BYOC host), we warn and
+	// enroll without it — the host still registers + heartbeats, it just isn't
+	// cloud-drivable. --no-driver-token skips minting entirely.
+	opts := cloud.EnrollOptions{OSSBackendID: strings.TrimSpace(cloudEnrollBackendID)}
+	if !cloudEnrollNoDriverToken {
+		driverTok, mintErr := mintDriverToken(cloudEnrollJWTSecretFile, cloudEnrollDriverTTL)
+		switch {
+		case mintErr != nil:
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"⚠ no driver token minted (%v)\n  host will enroll but the cloud can't place workloads on it; fix the jwt secret and re-run, or pass --no-driver-token to silence this\n",
+				mintErr)
+		case opts.OSSBackendID == "":
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"⚠ minted a driver token but --oss-backend-id is empty\n  the cloud can't route to this host until it knows the backend id; re-run with --oss-backend-id <spot-id>\n")
+			opts.DriverToken = driverTok
+		default:
+			opts.DriverToken = driverTok
+		}
+	}
+
 	// Redeem the join token against the control plane. On success the cloud
 	// has created the host row and returns its id; the same token is now this
 	// host's durable bearer (the cloud reuses the token secret).
-	hostID, err := cloud.Enroll(cmd.Context(), controlPlane, token, cloudEnrollInsecure)
+	hostID, err := cloud.Enroll(cmd.Context(), controlPlane, token, cloudEnrollInsecure, opts)
 	if err != nil {
 		return err
 	}
@@ -200,6 +238,38 @@ func runCloudLogout(cmd *cobra.Command, _ []string) error {
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "✓ removed cloud enrollment (%s)\n", path)
 	return nil
+}
+
+// mintDriverToken reads this daemon's JWT secret and mints a short-lived admin
+// access token (cloud #554). The cloud seals + replays it to drive this host's
+// daemon through the sentinel peer-proxy; because it's signed with the host's
+// OWN secret, the host's daemon accepts it without the cloud ever learning the
+// secret. ttl is capped at the daemon max (30d) by the token manager, so the
+// cloud-stored token expires — re-run `cloud enroll` to rotate.
+func mintDriverToken(secretFile string, ttl time.Duration) (string, error) {
+	secretFile = strings.TrimSpace(secretFile)
+	if secretFile == "" {
+		return "", fmt.Errorf("no --jwt-secret-file")
+	}
+	secretBytes, err := os.ReadFile(secretFile) // #nosec G304 -- operator-provided daemon secret path
+	if err != nil {
+		return "", fmt.Errorf("read jwt secret %s: %w", secretFile, err)
+	}
+	secret := strings.TrimSpace(string(secretBytes))
+	if secret == "" {
+		return "", fmt.Errorf("jwt secret %s is empty", secretFile)
+	}
+	tm, err := auth.NewTokenManager(secret, "containarium")
+	if err != nil {
+		return "", fmt.Errorf("token manager: %w", err)
+	}
+	// admin role: the cloud drives container CRUD on this host through the
+	// driver — same privilege the region-primary driver token carries.
+	tok, err := tm.GenerateToken("cloud-byoc-driver", []string{"admin"}, ttl)
+	if err != nil {
+		return "", fmt.Errorf("mint driver token: %w", err)
+	}
+	return tok, nil
 }
 
 // redactToken shows only enough to recognize which token is stored, never the

--- a/internal/cmd/cloud_test.go
+++ b/internal/cmd/cloud_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+func TestMintDriverToken(t *testing.T) {
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "jwt.secret")
+	// A secret of adequate length (the token manager rejects short secrets).
+	secret := "this-is-a-sufficiently-long-jwt-signing-secret-0123456789"
+	if err := os.WriteFile(secretPath, []byte(secret+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("mints a token the host's own daemon would accept", func(t *testing.T) {
+		tok, err := mintDriverToken(secretPath, 24*time.Hour)
+		if err != nil {
+			t.Fatalf("mintDriverToken: %v", err)
+		}
+		// The token validates against the SAME secret (what the host daemon uses).
+		tm, err := auth.NewTokenManager(secret, "containarium")
+		if err != nil {
+			t.Fatal(err)
+		}
+		claims, err := tm.ValidateToken(tok)
+		if err != nil {
+			t.Fatalf("token should validate against the host secret: %v", err)
+		}
+		hasAdmin := false
+		for _, r := range claims.Roles {
+			if r == "admin" {
+				hasAdmin = true
+			}
+		}
+		if !hasAdmin {
+			t.Errorf("driver token should carry the admin role, got %v", claims.Roles)
+		}
+	})
+
+	t.Run("missing secret file errors", func(t *testing.T) {
+		if _, err := mintDriverToken(filepath.Join(dir, "nope"), time.Hour); err == nil {
+			t.Fatal("want error for missing secret file")
+		}
+	})
+
+	t.Run("empty path errors", func(t *testing.T) {
+		if _, err := mintDriverToken("  ", time.Hour); err == nil {
+			t.Fatal("want error for empty path")
+		}
+	})
+
+	t.Run("empty secret errors", func(t *testing.T) {
+		empty := filepath.Join(dir, "empty.secret")
+		if err := os.WriteFile(empty, []byte("  \n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := mintDriverToken(empty, time.Hour); err == nil {
+			t.Fatal("want error for empty secret")
+		}
+	})
+}

--- a/pkg/pb/containarium/cloud/v1/actuation_service.pb.go
+++ b/pkg/pb/containarium/cloud/v1/actuation_service.pb.go
@@ -771,7 +771,20 @@ type EnrollHostRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The join token, format "<host_id>.<secret>", from the cloud's
 	// `pool join` / `cloud enroll` one-liner.
-	JoinToken     string `protobuf:"bytes,1,opt,name=join_token,json=joinToken,proto3" json:"join_token,omitempty"`
+	JoinToken string `protobuf:"bytes,1,opt,name=join_token,json=joinToken,proto3" json:"join_token,omitempty"`
+	// driver_token is an admin JWT this host minted with its OWN daemon
+	// jwt.secret (`containarium token generate --roles admin --secret-file
+	// /etc/containarium/jwt.secret`). The cloud stores it sealed and replays
+	// it to drive this host's daemon through the sentinel peer-proxy (BYOC
+	// Option β, cloud #554). Optional: empty leaves the host enrolled but
+	// not cloud-drivable. The host stays sovereign — it signs with its own
+	// secret and rotates by re-enrolling.
+	DriverToken string `protobuf:"bytes,2,opt,name=driver_token,json=driverToken,proto3" json:"driver_token,omitempty"`
+	// oss_backend_id is the id this host's tunnel registered under at the
+	// sentinel (its `pool join` spot-id) — what the sentinel `/peer/<id>/`
+	// proxy keys on. The cloud records it to map a container's backend id
+	// back to this host. Empty if not (yet) a peer-proxy-routed BYOC backend.
+	OssBackendId  string `protobuf:"bytes,3,opt,name=oss_backend_id,json=ossBackendId,proto3" json:"oss_backend_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -809,6 +822,20 @@ func (*EnrollHostRequest) Descriptor() ([]byte, []int) {
 func (x *EnrollHostRequest) GetJoinToken() string {
 	if x != nil {
 		return x.JoinToken
+	}
+	return ""
+}
+
+func (x *EnrollHostRequest) GetDriverToken() string {
+	if x != nil {
+		return x.DriverToken
+	}
+	return ""
+}
+
+func (x *EnrollHostRequest) GetOssBackendId() string {
+	if x != nil {
+		return x.OssBackendId
 	}
 	return ""
 }
@@ -1148,10 +1175,12 @@ const file_containarium_cloud_v1_actuation_service_proto_rawDesc = "" +
 	"\x0fAssignmentBatch\x12C\n" +
 	"\vassignments\x18\x01 \x03(\v2!.containarium.cloud.v1.AssignmentR\vassignments\x12=\n" +
 	"\fgenerated_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vgeneratedAt\x12O\n" +
-	"\x10network_policies\x18\x03 \x03(\v2$.containarium.cloud.v1.NetworkPolicyR\x0fnetworkPolicies\"2\n" +
+	"\x10network_policies\x18\x03 \x03(\v2$.containarium.cloud.v1.NetworkPolicyR\x0fnetworkPolicies\"{\n" +
 	"\x11EnrollHostRequest\x12\x1d\n" +
 	"\n" +
-	"join_token\x18\x01 \x01(\tR\tjoinToken\"-\n" +
+	"join_token\x18\x01 \x01(\tR\tjoinToken\x12!\n" +
+	"\fdriver_token\x18\x02 \x01(\tR\vdriverToken\x12$\n" +
+	"\x0eoss_backend_id\x18\x03 \x01(\tR\fossBackendId\"-\n" +
 	"\x12EnrollHostResponse\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\"Q\n" +
 	"\x13HostCapabilityCheck\x12\x12\n" +

--- a/proto/containarium/cloud/v1/actuation_service.proto
+++ b/proto/containarium/cloud/v1/actuation_service.proto
@@ -210,6 +210,21 @@ message EnrollHostRequest {
   // The join token, format "<host_id>.<secret>", from the cloud's
   // `pool join` / `cloud enroll` one-liner.
   string join_token = 1;
+
+  // driver_token is an admin JWT this host minted with its OWN daemon
+  // jwt.secret (`containarium token generate --roles admin --secret-file
+  // /etc/containarium/jwt.secret`). The cloud stores it sealed and replays
+  // it to drive this host's daemon through the sentinel peer-proxy (BYOC
+  // Option β, cloud #554). Optional: empty leaves the host enrolled but
+  // not cloud-drivable. The host stays sovereign — it signs with its own
+  // secret and rotates by re-enrolling.
+  string driver_token = 2;
+
+  // oss_backend_id is the id this host's tunnel registered under at the
+  // sentinel (its `pool join` spot-id) — what the sentinel `/peer/<id>/`
+  // proxy keys on. The cloud records it to map a container's backend id
+  // back to this host. Empty if not (yet) a peer-proxy-routed BYOC backend.
+  string oss_backend_id = 3;
 }
 
 message EnrollHostResponse {


### PR DESCRIPTION
PR 3 of the cloud #554 BYOC stack — **the OSS side** (cloud-side PRs are FootprintAI/Containarium-cloud#555 + #556). After this, the BYO self-service flow hands the cloud everything it needs to place tenant workloads on a tunnel-joined host.

## What changes
`containarium cloud enroll` now (Option A — the host stays sovereign):
- **mints an admin JWT signed with THIS host's own `jwt.secret`** (`--jwt-secret-file`, default `/etc/containarium/jwt.secret`) and sends it as `EnrollHostRequest.driver_token`. Because it's signed with the host's own secret, the host's daemon accepts it and **the cloud never learns the secret** — it just seals + replays the token.
- **sends its tunnel/`pool join` spot-id as `oss_backend_id`** (`--oss-backend-id`) so the cloud can map a container's backend id → this host.
- is **best-effort**: an unreadable secret (non-root / non-BYOC host) warns and enrolls without a driver token (host still registers + heartbeats); `--no-driver-token` skips minting explicitly. A minted token without `--oss-backend-id` also warns (cloud can't route yet).

## proto
`EnrollHostRequest` gains `driver_token` (2) + `oss_backend_id` (3) — **field numbers synced with the cloud repo** for wire compatibility; regenerated `.pb.go` + swagger. `cloud.Enroll` takes `EnrollOptions{DriverToken, OSSBackendID}`.

## ⚠️ Token expiry / refresh
The daemon caps token expiry at **30 days** (`DefaultMaxTokenExpiry`) and forbids non-expiring tokens, so the minted driver token — and the cloud-stored copy — **expires**. Re-running `cloud enroll` rotates it. An automatic refresh (the daemon re-mints + re-pushes before expiry) is a **follow-up** (filed separately).

## Test
`go test ./internal/{cloud,cmd}/...` green (incl. a new `mintDriverToken` test that asserts the token validates against the host's own secret + carries `admin`, and `client_test` asserting the new fields go over the wire); `go vet` + `gofmt` clean; full `go build ./...` OK.

Refs #554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)