### PR TITLE
feat(cloud): REST actuation transport for BYOC hosts on a REST-only control plane (#722)

### DIFF
--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -120,6 +120,15 @@ type Deps struct {
 	Status     StatusProbe
 }
 
+// unaryActuation is the subset of the actuation API the client drives over a
+// unary transport (heartbeat + capability report). Both the gRPC
+// ActuationServiceClient and the REST transport (#722) satisfy it; the
+// CallOption args are part of the gRPC signature and ignored by REST.
+type unaryActuation interface {
+	Heartbeat(context.Context, *cloudv1.HeartbeatRequest, ...grpc.CallOption) (*cloudv1.HeartbeatResponse, error)
+	ReportHostStatus(context.Context, *cloudv1.ReportHostStatusRequest, ...grpc.CallOption) (*cloudv1.ReportHostStatusResponse, error)
+}
+
 // Client is the host-side cloud-actuation client. Slice 3 implements the
 // heartbeat; WatchAssignments + the reconciler land in slice 4. The actuation
 // proto is vendored (proto/containarium/cloud/v1), so this builds in the default
@@ -134,7 +143,12 @@ type Client struct {
 	status StatusProbe // optional; nil = no capability reporting
 
 	conn *grpc.ClientConn
-	ac   cloudv1.ActuationServiceClient
+	// ac handles the unary actuation RPCs (heartbeat + status); it is either the
+	// gRPC client or the REST transport (#722). watchAC is the gRPC client used
+	// for the WatchAssignments stream — nil in REST mode, where a (push-driven)
+	// BYOC host pulls no assignments and the watch loop is not started.
+	ac      unaryActuation
+	watchAC cloudv1.ActuationServiceClient
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -157,17 +171,30 @@ func New(cfg *Config, deps Deps) (*Client, error) {
 // returned; per-beat errors are logged and retried (a control-plane outage must
 // not crash the daemon or stop local containers).
 func (c *Client) Start(ctx context.Context) error {
-	conn, err := c.dial()
-	if err != nil {
-		return fmt.Errorf("cloud: dial control plane %s: %w", c.cfg.ControlPlane, err)
+	if isRESTControlPlane(c.cfg.ControlPlane) {
+		// REST transport (#722): no gRPC dial. WatchAssignments (streaming) is
+		// unavailable over REST, so the watch loop is skipped — a BYOC host on a
+		// REST-only control plane is push-driven (the cloud drives it via the
+		// sentinel peer-proxy) and pulls no assignments.
+		c.ac = newRESTActuation(c.cfg.ControlPlane, c.cfg.Token)
+	} else {
+		conn, err := c.dial()
+		if err != nil {
+			return fmt.Errorf("cloud: dial control plane %s: %w", c.cfg.ControlPlane, err)
+		}
+		c.conn = conn
+		gc := cloudv1.NewActuationServiceClient(conn)
+		c.ac, c.watchAC = gc, gc
 	}
-	c.conn = conn
-	c.ac = cloudv1.NewActuationServiceClient(conn)
 	c.ctx, c.cancel = context.WithCancel(ctx)
 
 	c.wg.Add(1)
 	go c.heartbeatLoop()
-	watch := c.sink != nil || c.containers != nil
+	wantWatch := c.sink != nil || c.containers != nil
+	watch := wantWatch && c.watchAC != nil
+	if wantWatch && c.watchAC == nil {
+		log.Printf("[cloud] REST transport: assignment-watch disabled (push-driven host; policy/container pull is gRPC-only)")
+	}
 	if watch {
 		c.wg.Add(1)
 		go c.watchLoop()
@@ -230,6 +257,10 @@ type EnrollOptions struct {
 // opts optionally carries the BYOC driver token + backend id (cloud #554) so a
 // tunnel-joined host becomes cloud-drivable in the same round-trip.
 func Enroll(ctx context.Context, controlPlane, joinToken string, insecureTLS bool, opts EnrollOptions) (string, error) {
+	// REST control plane (#722): redeem over grpc-gateway instead of gRPC.
+	if isRESTControlPlane(controlPlane) {
+		return enrollREST(ctx, controlPlane, joinToken, opts)
+	}
 	conn, err := dialControlPlane(controlPlane, insecureTLS)
 	if err != nil {
 		return "", fmt.Errorf("cloud: dial control plane %s: %w", controlPlane, err)
@@ -383,7 +414,7 @@ func (c *Client) watchLoop() {
 // only via a successful reconnect cycle (kept simple: any return re-enters the
 // loop). Returns the stream error (nil on a clean server close).
 func (c *Client) watchOnce() error {
-	stream, err := c.ac.WatchAssignments(c.authContext(c.ctx), &cloudv1.WatchAssignmentsRequest{})
+	stream, err := c.watchAC.WatchAssignments(c.authContext(c.ctx), &cloudv1.WatchAssignmentsRequest{})
 	if err != nil {
 		return err
 	}
@@ -449,11 +480,16 @@ func (c *Client) reconcileAssignment(a *cloudv1.Assignment) {
 	}
 }
 
-// report sends observed container state back to the cloud (best-effort).
+// report sends observed container state back to the cloud (best-effort). Part
+// of the pull/reconcile path, so it only runs in gRPC mode (the REST transport
+// runs no watch loop); watchAC is nil otherwise.
 func (c *Client) report(containerID, state string) {
+	if c.watchAC == nil {
+		return
+	}
 	ctx, cancel := context.WithTimeout(c.authContext(c.ctx), 10*time.Second)
 	defer cancel()
-	if _, err := c.ac.ReportContainerState(ctx, &cloudv1.ReportContainerStateRequest{
+	if _, err := c.watchAC.ReportContainerState(ctx, &cloudv1.ReportContainerStateRequest{
 		ContainerId: containerID, State: state,
 	}); err != nil {
 		log.Printf("[cloud] report state %s=%s: %v", containerID, state, err)

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -162,7 +162,8 @@ func newTestClient(t *testing.T, cfg *Config) (*Client, *fakeActuation) {
 	}
 	t.Cleanup(func() { _ = conn.Close() })
 
-	c := &Client{cfg: cfg, interval: defaultHeartbeatInterval, ac: cloudv1.NewActuationServiceClient(conn)}
+	gc := cloudv1.NewActuationServiceClient(conn)
+	c := &Client{cfg: cfg, interval: defaultHeartbeatInterval, ac: gc, watchAC: gc}
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 	t.Cleanup(c.cancel)
 	return c, fake

--- a/internal/cloud/rest.go
+++ b/internal/cloud/rest.go
@@ -1,0 +1,131 @@
+package cloud
+
+// REST transport for the cloud actuation channel (OSS #722).
+//
+// The gRPC transport (client.go) only works against a control plane that
+// serves native gRPC. A managed cloud (e.g. cloud.containarium.dev) often
+// fronts the API as REST/grpc-gateway ONLY — native gRPC over :443 there
+// returns 403/text-html. A BYO-compute host enrolled against such a control
+// plane therefore couldn't enroll, heartbeat, or report its capability, which
+// left the host's capacity "unknown" in the operator view and made the
+// host-sweeper treat the never-heartbeating host as stranded.
+//
+// This transport speaks the SAME actuation RPCs over their grpc-gateway REST
+// mappings (POST /v1/actuation/{heartbeat,status,enroll}), carrying the host
+// bearer as the `Grpc-Metadata-Host-Bearer` header — grpc-gateway strips the
+// `Grpc-Metadata-` prefix and forwards it as the `host-bearer` metadata the
+// HostBearerInterceptor authenticates on. Requests/responses are the OSS proto
+// types via protojson, so the wire matches the gateway by construction.
+//
+// WatchAssignments (server-streaming) is NOT implemented here: a BYOC host is
+// push-driven (the cloud drives it via the sentinel peer-proxy), so it has no
+// assignments to pull. REST mode therefore runs heartbeat + status only.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	cloudv1 "github.com/footprintai/containarium/pkg/pb/containarium/cloud/v1"
+)
+
+// isRESTControlPlane reports whether the control-plane address is an http(s)
+// URL (REST/grpc-gateway) rather than a gRPC host:port. An https:// or http://
+// prefix selects the REST transport.
+func isRESTControlPlane(controlPlane string) bool {
+	cp := strings.TrimSpace(controlPlane)
+	return strings.HasPrefix(cp, "https://") || strings.HasPrefix(cp, "http://")
+}
+
+// restActuation implements the unary actuation RPCs (Heartbeat, ReportHostStatus)
+// over grpc-gateway REST. It satisfies the unaryActuation interface the client
+// uses; the gRPC CallOption args are accepted and ignored.
+type restActuation struct {
+	base   string // control-plane base URL, no trailing slash
+	bearer string // host bearer, sent as Grpc-Metadata-Host-Bearer (empty for enroll, which self-auths via the join token)
+	hc     *http.Client
+}
+
+func newRESTActuation(controlPlane, bearer string) *restActuation {
+	return &restActuation{
+		base:   strings.TrimRight(strings.TrimSpace(controlPlane), "/"),
+		bearer: bearer,
+		hc:     &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (r *restActuation) Heartbeat(ctx context.Context, req *cloudv1.HeartbeatRequest, _ ...grpc.CallOption) (*cloudv1.HeartbeatResponse, error) {
+	var resp cloudv1.HeartbeatResponse
+	if err := r.post(ctx, "/v1/actuation/heartbeat", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (r *restActuation) ReportHostStatus(ctx context.Context, req *cloudv1.ReportHostStatusRequest, _ ...grpc.CallOption) (*cloudv1.ReportHostStatusResponse, error) {
+	var resp cloudv1.ReportHostStatusResponse
+	if err := r.post(ctx, "/v1/actuation/status", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// post sends one protojson request to the control plane and decodes the
+// protojson response. The host bearer (when set) rides the
+// `Grpc-Metadata-Host-Bearer` header → `host-bearer` gRPC metadata at the gateway.
+func (r *restActuation) post(ctx context.Context, path string, in, out proto.Message) error {
+	body, err := protojson.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("cloud-rest: marshal %s: %w", path, err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, r.base+path, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("cloud-rest: build %s: %w", path, err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if r.bearer != "" {
+		httpReq.Header.Set("Grpc-Metadata-Host-Bearer", r.bearer)
+	}
+	resp, err := r.hc.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("cloud-rest: POST %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("cloud-rest: POST %s: %d %s", path, resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("cloud-rest: decode %s: %w", path, err)
+	}
+	return nil
+}
+
+// enrollREST redeems a join token over REST (POST /v1/actuation/enroll). The
+// join token self-authenticates in the body, so no host bearer is sent.
+func enrollREST(ctx context.Context, controlPlane, joinToken string, opts EnrollOptions) (string, error) {
+	r := newRESTActuation(controlPlane, "")
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	var resp cloudv1.EnrollHostResponse
+	err := r.post(ctx, "/v1/actuation/enroll", &cloudv1.EnrollHostRequest{
+		JoinToken:    joinToken,
+		DriverToken:  opts.DriverToken,
+		OssBackendId: opts.OSSBackendID,
+	}, &resp)
+	if err != nil {
+		return "", fmt.Errorf("cloud: enroll (REST): %w", err)
+	}
+	return resp.GetHostId(), nil
+}

--- a/internal/cloud/rest_test.go
+++ b/internal/cloud/rest_test.go
@@ -1,0 +1,92 @@
+package cloud
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	cloudv1 "github.com/footprintai/containarium/pkg/pb/containarium/cloud/v1"
+)
+
+func TestIsRESTControlPlane(t *testing.T) {
+	cases := map[string]bool{
+		"https://cloud.containarium.dev": true,
+		"http://localhost:8080":          true,
+		"cloud.containarium.dev:443":     false,
+		"10.0.0.5:50051":                 false,
+		"":                               false,
+	}
+	for cp, want := range cases {
+		if got := isRESTControlPlane(cp); got != want {
+			t.Errorf("isRESTControlPlane(%q) = %v, want %v", cp, got, want)
+		}
+	}
+}
+
+func TestRESTActuation_HeartbeatAndStatus(t *testing.T) {
+	var gotPaths []string
+	var gotBearer string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPaths = append(gotPaths, r.URL.Path)
+		gotBearer = r.Header.Get("Grpc-Metadata-Host-Bearer")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	r := newRESTActuation(srv.URL, "host-bearer-tok")
+	if _, err := r.Heartbeat(context.Background(), &cloudv1.HeartbeatRequest{}); err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+	if _, err := r.ReportHostStatus(context.Background(), &cloudv1.ReportHostStatusRequest{CpuCores: 24, TotalRamMb: 128000}); err != nil {
+		t.Fatalf("ReportHostStatus: %v", err)
+	}
+	if len(gotPaths) != 2 || gotPaths[0] != "/v1/actuation/heartbeat" || gotPaths[1] != "/v1/actuation/status" {
+		t.Errorf("paths = %v, want [/v1/actuation/heartbeat /v1/actuation/status]", gotPaths)
+	}
+	if gotBearer != "host-bearer-tok" {
+		t.Errorf("host bearer header = %q, want it forwarded as Grpc-Metadata-Host-Bearer", gotBearer)
+	}
+}
+
+func TestRESTActuation_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"code":16,"message":"bad bearer"}`))
+	}))
+	defer srv.Close()
+	r := newRESTActuation(srv.URL, "x")
+	if _, err := r.Heartbeat(context.Background(), &cloudv1.HeartbeatRequest{}); err == nil {
+		t.Fatal("a 401 must surface as an error")
+	}
+}
+
+func TestEnrollREST(t *testing.T) {
+	var got cloudv1.EnrollHostRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/actuation/enroll" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = protojson.Unmarshal(raw, &got)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"hostId":"host-123"}`))
+	}))
+	defer srv.Close()
+
+	id, err := enrollREST(context.Background(), srv.URL, "host-123.secret",
+		EnrollOptions{DriverToken: "admin.jwt", OSSBackendID: "tunnel-fts-13700k"})
+	if err != nil {
+		t.Fatalf("enrollREST: %v", err)
+	}
+	if id != "host-123" {
+		t.Errorf("host id = %q, want host-123", id)
+	}
+	if got.GetJoinToken() != "host-123.secret" || got.GetDriverToken() != "admin.jwt" || got.GetOssBackendId() != "tunnel-fts-13700k" {
+		t.Errorf("server saw join=%q driver=%q backend=%q", got.GetJoinToken(), got.GetDriverToken(), got.GetOssBackendId())
+	}
+}


### PR DESCRIPTION
## Why

The gRPC actuation client (`internal/cloud`) only works against a control plane that serves **native gRPC**. The managed cloud (`cloud.containarium.dev`) fronts its API as **REST/grpc-gateway only** — native gRPC over :443 returns `403 text/html`.

A BYO-compute host enrolled against such a control plane therefore could not enroll, heartbeat, or report its capability. The visible symptoms (both seen live on `fts-13700k`):

- the host's capacity shows **"unknown" / 0** in the admin Backends view, and
- the host-sweeper treats the never-heartbeating host as **stranded**.

This is the systemic fix behind OSS #722 (and the cause of the capacity-unknown + stranding follow-ups).

## What

A REST transport that speaks the **same** actuation RPCs over their grpc-gateway mappings:

- `POST /v1/actuation/heartbeat`
- `POST /v1/actuation/status`
- `POST /v1/actuation/enroll`

It carries the host bearer as the `Grpc-Metadata-Host-Bearer` header — the gateway strips the `Grpc-Metadata-` prefix and forwards it as the `host-bearer` metadata the `HostBearerInterceptor` authenticates on. Requests/responses are the OSS proto types via `protojson`, so the wire matches the gateway by construction.

### Mechanism

- `isRESTControlPlane(cp)` — an `http(s)://` prefix selects the REST transport; a bare `host:port` stays gRPC.
- `Client.ac` is split into:
  - `ac unaryActuation` — heartbeat + status; satisfied by **both** the gRPC `ActuationServiceClient` and the REST transport.
  - `watchAC cloudv1.ActuationServiceClient` — the gRPC-only `WatchAssignments` stream; **nil in REST mode**.
- REST mode **skips the watch loop**: a BYOC host on a REST-only control plane is push-driven (the cloud drives it via the sentinel peer-proxy) and pulls no assignments. `report()` is part of that pull path and no-ops when `watchAC == nil`.
- `Enroll()` branches to `enrollREST()` for a REST control plane.

## Test

`internal/cloud/rest_test.go` (httptest server):
- `isRESTControlPlane` truth table.
- Heartbeat + ReportHostStatus hit the right paths and forward `Grpc-Metadata-Host-Bearer`.
- A 4xx surfaces as an error.
- `enrollREST` posts join/driver/backend-id and decodes the host id.

`go build ./...`, `go test ./internal/cloud/`, `go vet`, `gofmt -l` all clean.

## Follow-up (not in this PR)

After this lands + a release, `fts-13700k`'s daemon is reconfigured to point its actuation client at the REST control plane so it heartbeats + reports capability, which populates the admin Backends capacity and stops the stranding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)