### PR TITLE
fix(deploy): daemon unit ReadWritePaths must cover the doctor's writable set (no DEGRADED on fresh install)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Daemon unit `ReadWritePaths` now covers the doctor's required-writable set,
+  so a freshly-installed host no longer boots DEGRADED.** With
+  `ProtectSystem=strict`, every path the daemon's capability self-check
+  (`hostcheck.DaemonWritablePaths`) requires writable must be in the unit's
+  `ReadWritePaths` — otherwise the path is read-only to the daemon and the
+  self-check fails. The shipped units omitted `/var/log` (which `useradd`
+  touches via `/var/log/lastlog` — the "second capability trap") and, in the
+  Terraform startup scripts, `/etc/containarium` + `/opt/containarium`. Fixed in
+  all four unit sources (`containarium service install`, `scripts/containarium.service`,
+  and both `terraform/.../startup-spot.sh`); a new test ties the generated unit's
+  `ReadWritePaths` to `hostcheck.DaemonWritablePaths` so they can't drift again.
+  Existing hosts heal on the next unit redeploy (or a drop-in adding the missing
+  paths + `daemon-reload` + daemon restart).
+
 ## [0.31.2] - 2026-06-17
 
 ### Added

--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -36,7 +36,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /opt/containarium
+ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /opt/containarium /var/log
 
 StandardOutput=journal
 StandardError=journal

--- a/internal/cmd/service_test.go
+++ b/internal/cmd/service_test.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/hostcheck"
+)
+
+// TestSystemdServiceReadWritePathsCoverDoctorContract guards against the unit's
+// ProtectSystem=strict sandbox drifting away from the paths the daemon's own
+// doctor self-check requires writable. A path the doctor requires but the unit
+// denies makes a freshly-installed host boot DEGRADED (this is exactly what
+// happened when /var/log — which useradd touches via /var/log/lastlog — was
+// missing from ReadWritePaths). The generated unit's ReadWritePaths must be a
+// superset of hostcheck.DaemonWritablePaths.
+func TestSystemdServiceReadWritePathsCoverDoctorContract(t *testing.T) {
+	var rwLine string
+	for _, line := range strings.Split(systemdServiceTemplate, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "ReadWritePaths=") {
+			rwLine = strings.TrimSpace(line)
+			break
+		}
+	}
+	if rwLine == "" {
+		t.Fatal("systemdServiceTemplate has no ReadWritePaths= line")
+	}
+	granted := make(map[string]bool)
+	for _, p := range strings.Fields(strings.TrimPrefix(rwLine, "ReadWritePaths=")) {
+		granted[p] = true
+	}
+	for _, required := range hostcheck.DaemonWritablePaths {
+		if !granted[required] {
+			t.Errorf("ReadWritePaths is missing %q (required by hostcheck.DaemonWritablePaths); "+
+				"the host would boot DEGRADED. ReadWritePaths=%v", required, rwLine)
+		}
+	}
+}

--- a/scripts/containarium.service
+++ b/scripts/containarium.service
@@ -23,7 +23,11 @@ ProtectHome=false
 # /home - for creating user home directories and SSH keys
 # /var/lib/incus - for container management
 # /var/lock, /run/lock - for useradd flock serialization
-ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock
+# /var/log - useradd touches /var/log/lastlog (the "second capability trap")
+# /opt/containarium - runtime state/assets
+# This set MUST match internal/hostcheck.DaemonWritablePaths; a path the doctor
+# requires but ProtectSystem=strict denies makes the host boot DEGRADED.
+ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /var/log /opt/containarium
 
 StandardOutput=journal
 StandardError=journal

--- a/terraform/gce/scripts/startup-spot.sh
+++ b/terraform/gce/scripts/startup-spot.sh
@@ -625,7 +625,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=/var/lib/incus /etc /home /var/lock /run/lock
+ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /opt/containarium /var/log
 
 StandardOutput=journal
 StandardError=journal

--- a/terraform/modules/containarium/scripts/startup-spot.sh
+++ b/terraform/modules/containarium/scripts/startup-spot.sh
@@ -870,7 +870,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=/var/lib/incus /etc /home /var/lock /run/lock
+ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /opt/containarium /var/log
 
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
## Why

With `ProtectSystem=strict`, any path the daemon's capability self-check (`hostcheck.DaemonWritablePaths`) requires **writable** must appear in the unit's `ReadWritePaths` — otherwise it is read-only *to the daemon* and the self-check fails. A failing self-check makes the host report **DEGRADED** to the cloud (and to `containarium doctor`).

The shipped units omitted **`/var/log`** — which `useradd` touches via `/var/log/lastlog` (the "second capability trap" the deploy contract calls out) — so a freshly-installed host booted **DEGRADED** with a single failing check (`writable: /var/log :: read-only file system`), even on a perfectly healthy rw disk. The two Terraform startup scripts also omitted `/etc/containarium` and `/opt/containarium`.

This was found while onboarding a BYO-compute host: it reported full capacity (24 cores / 128 GB / RTX 3090) over the new REST actuation transport (#722) but showed DEGRADED **solely** because its generated unit lacked `/var/log` in `ReadWritePaths`.

## What

Align all four unit sources with `hostcheck.DaemonWritablePaths`:

| Source | Change |
| --- | --- |
| `internal/cmd/service.go` (`containarium service install`) | `+ /var/log` |
| `scripts/containarium.service` | `+ /var/log /opt/containarium` |
| `terraform/gce/scripts/startup-spot.sh` | `+ /etc/containarium /opt/containarium /var/log` |
| `terraform/modules/containarium/scripts/startup-spot.sh` | `+ /etc/containarium /opt/containarium /var/log` |

Add `internal/cmd/service_test.go` asserting the generated unit's `ReadWritePaths` is a **superset** of `hostcheck.DaemonWritablePaths`, so the sandbox and the doctor contract can't silently drift apart again. (The test fails on the pre-fix template.)

## Healing existing hosts

Existing hosts heal on the next unit redeploy, or in place via a drop-in:

```
printf '[Service]\nReadWritePaths=/var/log\n' \
  > /etc/systemd/system/containarium.service.d/10-var-log-rw.conf
systemctl daemon-reload && systemctl restart containarium
```

(`ReadWritePaths` from drop-ins is additive.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)