### PR TITLE
feat(recipes): agent-workspace — always-on coding agent you re-attach to over the web terminal

### DIFF
--- a/docs/AGENT-WORKSPACE-SPIKE.md
+++ b/docs/AGENT-WORKSPACE-SPIKE.md
@@ -1,0 +1,100 @@
+# Spike — always-on agent workspace via the `agent-workspace` recipe
+
+> Status: **Spike / proof-of-path.** Goal: prove that "a coding agent that
+> lives in your laptop tmux dies when the laptop sleeps; move it into an
+> always-on box you re-attach to over the browser" is buildable almost entirely
+> from **already-shipped** parts — no new runtime, no new transport, no new UI.
+> This note records what the spike does, what is proven in-tree, and what still
+> needs a live box to accept.
+
+## The idea in one line
+
+Run **Claude Code in a persistent tmux session inside an always-on box**, and
+**re-attach to it over the existing web terminal** — then ship what you build to
+a separate box via the platform MCP.
+
+## Why this is the lightest path
+
+Every moving part except the recipe already ships:
+
+| Part | Status | Where |
+|---|---|---|
+| Always-on box | shipped | core platform |
+| Browser terminal → box (xterm.js ↔ WS ↔ incus exec) | shipped | `web-ui/.../TerminalDialog.tsx`, `internal/gateway/terminal.go` |
+| Recipe deploy (provision box + run setup inside) | shipped | `RecipeService`, `internal/server/recipe_server.go` |
+| Ship-to-box (create + expose + HTTPS) | shipped | platform MCP / recipes |
+| **`agent-workspace` recipe (tmux + Claude Code + auto-attach)** | **this spike** | `pkg/core/recipes/recipes.yaml` |
+
+The spike adds **one recipe**. Nothing else.
+
+## How it works
+
+The web terminal execs `su - <user>` — a **login shell** — so it sources
+`/etc/profile.d/*.sh`. The recipe drops `zz-agent-workspace.sh` there, which on
+any interactive login that is not already inside tmux does:
+
+```sh
+exec tmux new-session -A -s agent "claude || true; exec bash"
+```
+
+- `new-session -A -s agent` **attaches** to the session named `agent` if it
+  exists, else **creates** it. So every browser attach reconnects to the *same*
+  running agent — the "re-attach to my server tmux" experience.
+- The tmux server keeps running as the box user after the websocket drops, so
+  the agent **survives disconnect** (the whole point).
+- `claude || true; exec bash` keeps the pane (and session) alive if the agent
+  exits or needs `/login`, so re-attach never lands on a dead session.
+- The hook is **username-agnostic** — it works whatever the box user is, so the
+  recipe needs no knowledge of the tenant name at deploy time.
+
+Contrast with the existing **`agent-runtime`** recipe: that one is the *headless,
+one-shot* sibling (seeded task in → `artifact.json` out, no human). This recipe
+is the *interactive, human-in-the-loop* sibling. They share the same box-as-
+agent substrate; they differ only in who drives the loop.
+
+## What is proven in-tree (this spike)
+
+- `go build ./pkg/core/recipes/... ./internal/server/...` — clean.
+- `go test ./pkg/core/recipes/... ./internal/server/...` — green, including the
+  new `TestAgentWorkspaceRecipe` (catalog loads the recipe; it is GPU-free,
+  port-free; post_start installs Claude Code + tmux and drops the auto-attach
+  hook; the API key is an optional `password` parameter).
+- Deploy wiring is **inherited, not new**: `DeployRecipe` provisions the box and
+  runs `post_start` exactly as it does for `ollama`/`agent-runtime`, and the web
+  terminal path is unchanged. No server, proto, CLI, or MCP change was needed —
+  `recipe deploy agent-workspace <name>` and the `deploy_recipe` MCP tool work
+  by virtue of the catalog entry.
+
+## What still needs a live box to accept (out of spike scope)
+
+1. **End-to-end deploy on a backend** — `containarium recipe deploy
+   agent-workspace ws1 --param anthropic_api_key=… --server <host>`, then open
+   the box's web terminal and confirm it lands directly in Claude Code, detach,
+   re-open, and confirm re-attach to the same session. (Same "live-acceptance-
+   pending" posture as #608's in-box loop.)
+2. **npm install footprint** — `@anthropic-ai/claude-code` global install size /
+   time on a 40GB box; pin a version for reproducibility.
+3. **Disconnect durability** — confirm the tmux session and a long-running agent
+   turn survive a websocket drop and reconnect.
+
+## Required hardening before this is a product (NOT spike scope)
+
+- **API key delivery.** The spike takes the Anthropic key as a recipe
+  *parameter* and writes it to a root-owned `/etc/containarium/agent-workspace.env`.
+  Production must seed it via the **tenant secrets mechanism** (AES-256-GCM,
+  mode 0400) per `AGENT-RUNTIME-INBOX-LOOP-DESIGN.md`, never as a deploy-time
+  parameter (parameters can land in audit logs / process args).
+- **Model access / metering.** Direct box → `api.anthropic.com` has no cost
+  control. The hosted-workspace product wants the central model gateway (per
+  project memory: model-gateway + pull-queue RFC) so usage is per-tenant
+  metered and key rotation is centralized.
+- **Co-work UI.** The web terminal proves the path, but the product wants a
+  chat-style co-work surface (stream agent output, not a raw TTY). That is the
+  next build after this spike validates, and feeds the PRD.
+
+## Verdict
+
+The path holds: an always-on, re-attachable coding agent is **one recipe** on
+top of shipped infrastructure. The spike is the proof; the PRD
+(`PRD-...`, to follow) can now be written against a working mechanism rather
+than a hypothesis.

--- a/docs/PRD-HOSTED-AGENT-WORKSPACE.md
+++ b/docs/PRD-HOSTED-AGENT-WORKSPACE.md
@@ -1,0 +1,145 @@
+# PRD — Hosted always-on agent workspace
+
+> Status: **Draft — for review.** Anchored on a working spike
+> (`docs/AGENT-WORKSPACE-SPIKE.md`, the `agent-workspace` recipe), not a
+> hypothesis. Generic mechanism only; opinionated agent images/skills ship
+> outside this repo per [AGENT-SKILLS-CREWS-DESIGN.md](./AGENT-SKILLS-CREWS-DESIGN.md).
+
+## 1. Problem
+
+A developer's coding agent (Claude Code, Cursor, …) runs on their **laptop**. A
+laptop is the wrong host for an agent: it sleeps, goes offline, and drops the
+session the moment you close the lid. The workaround people reach for —
+"SSH into a server and run the agent in tmux, reconnect when I'm back" — works
+but is a manual, expert-only ritual: provision a host, secure it, install the
+agent, manage the key, remember to `tmux attach`.
+
+**The job:** *"I want my coding agent to live somewhere always-on that I can
+re-attach to from any browser, keep working with it where I left off, and ship
+what we build — without running my own server."*
+
+## 2. Why now / why us
+
+This is the natural next turn of Containarium's thesis. We already have the
+pieces that make a *safe, always-on, browser-reachable* agent host trivial:
+
+- Always-on isolated boxes (per-tenant LXC).
+- A **browser terminal** straight into a box (shipped: `internal/gateway/terminal.go`).
+- One-command box provisioning with in-box setup (`RecipeService`).
+- eBPF network policy, audit logging, secrets — the trust fabric an agent with
+  real credentials needs.
+
+The spike proved the missing piece is **one recipe**, not a new platform. That
+is our unfair advantage: competitors selling "cloud agent workspaces" are
+building the isolation + networking + audit we already shipped.
+
+## 3. Target user & JTBD
+
+**Primary persona — "the always-on builder."** Already lives in a coding agent.
+Wants it off the laptop and on a URL, without becoming a sysadmin.
+
+**JTBD:** *"When I step away from my laptop, I want my agent to keep its place
+in a box I can re-open from a browser, and ship from there — so my work isn't
+tied to one machine being awake."*
+
+**Not this PRD:** the headless one-shot AgentSkill user (that is `agent-runtime`
+/ Phase 4a), and the multi-agent crew operator (Phases 1–3).
+
+## 4. The experience (target)
+
+1. **Launch** — user creates an agent workspace (one `deploy_recipe` /
+   `recipe deploy agent-workspace`). Box comes up always-on. *(spike: works)*
+2. **Attach** — user opens the workspace in the browser; lands directly in a
+   live Claude Code session. *(spike: via web terminal)*
+3. **Co-work** — converse with the agent, it edits files, runs commands,
+   builds. *(spike: raw TTY; v1 polish: chat surface)*
+4. **Walk away / re-attach** — close the tab; the agent session persists; re-open
+   from any browser and resume. *(spike: tmux session survives WS drop)*
+5. **Ship** — agent creates + exposes a *separate* box for the artifact
+   (workshop box ≠ product box). *(shipped: platform MCP create/expose)*
+
+## 5. Scope
+
+### In scope (v1)
+- The **`agent-workspace` recipe** as the supported launch path (spike → harden).
+- **Secrets-based model credential** delivery (replace the spike's parameter).
+- A **"workspace" affordance in the WebUI** — a first-class entry that opens the
+  agent session (initially the existing terminal; chat surface is a fast follow).
+- **Session durability** acceptance: re-attach resumes the same agent.
+- **Audit + scope gating** of workspace lifecycle (inherited).
+
+### Out of scope (v1, deferred)
+- **Chat-style co-work UI** (stream agent output as messages, not a TTY) — fast
+  follow once the terminal path is accepted.
+- **Central model gateway / metering** — needed for cost control at scale; v1 can
+  ship with per-tenant keys via secrets. (Project memory: model-gateway RFC.)
+- **Multi-agent / crews** ([AGENT-SKILLS-CREWS-DESIGN.md](./AGENT-SKILLS-CREWS-DESIGN.md)).
+- **Multiple parallel agents per user** (the cmux-style fan-out) — v2.
+- **Non-Claude agents** — v1 ships one reference (Claude Code); others are
+  outside-repo images on the same recipe pattern.
+
+## 6. Requirements
+
+| # | Requirement | Dependency status |
+|---|---|---|
+| R1 | One command launches an always-on box running a persistent coding agent. | **Spike-proven**; needs live acceptance. |
+| R2 | A browser attach lands in the live agent; detach/re-attach resumes the same session. | **Spike-proven** (tmux + web terminal); needs live acceptance. |
+| R3 | The agent survives websocket disconnect and laptop sleep. | **Spike-proven** by design; needs live acceptance. |
+| R4 | The model credential is delivered via the secrets mechanism, not a deploy parameter. | **New** — swap spike param for secrets seed. |
+| R5 | The workspace is reachable from a first-class WebUI entry, not just an admin terminal dialog. | **Partial** — terminal shipped; needs a "workspace" surface. |
+| R6 | Workspace create/attach/destroy is audit-logged and scope-gated. | **Shipped** (inherited). |
+| R7 | What the agent builds ships to a separate box. | **Shipped** (platform MCP). |
+
+**Read of the gap:** R1–R3, R6–R7 are done or proven. The only real build is
+**R4 (secrets)** and **R5 (a workspace UI entry)** — both small, both on shipped
+substrate.
+
+## 7. Success metrics
+
+- **North star — time-to-first-agent-turn**: launch → first agent response in
+  the browser, target **< 5 min** (dominated by box provision + npm install;
+  mitigate with a pre-baked image).
+- **Re-attach success rate**: % of re-opens that resume a live session > 99%.
+- **Activation**: % of new users who launch a workspace and reach ≥ 1 agent turn
+  in their first session.
+- **Stickiness signal**: median days a workspace stays alive (proves the
+  "always-on, my place is kept" value over laptop-local).
+
+## 8. Risks & open questions
+
+- **Cost / runaway model spend.** An always-on agent with a key is a spend risk.
+  v1 mitigations: per-tenant key via secrets, auto-sleep/idle TTL on the box
+  (shipped scale-down primitives), and surfacing usage. Real fix = model gateway
+  (deferred). *Decision needed: idle policy default.*
+- **Pre-baked vs install-on-deploy.** npm install at deploy hurts time-to-wow.
+  *Decision: bake an `agent-workspace` image vs keep post_start install.*
+- **TTY vs chat as the v1 surface.** Shipping the raw web terminal is faster but
+  less polished than a chat UI. *Recommendation: ship terminal-backed v1, chat as
+  immediate fast follow — don't block v1 on the UI.*
+- **Relationship to `agent-runtime`.** Two recipes (interactive vs headless) on
+  one substrate is intentional; messaging must not conflate them.
+- **Cloud packaging.** Pricing, quotas, idle billing belong in the
+  Containarium-cloud `prd/` tree; this note is the OSS-mechanism PRD. A cloud
+  companion PRD is the follow-up.
+
+## 9. Phasing
+
+- **Phase 0 — spike (DONE):** `agent-workspace` recipe; path proven in-tree.
+- **Phase 1 — v1 launch:** live acceptance of R1–R3; secrets-based key (R4);
+  pre-baked image; WebUI "workspace" entry (R5); idle/auto-sleep default.
+- **Phase 2 — co-work UI:** chat-style streaming surface over the in-box agent.
+- **Phase 3 — scale:** model gateway/metering; multiple/parallel agents;
+  non-Claude images.
+
+## 10. Relationship to existing plans
+
+- **Reuses**: `RecipeService`, the web terminal, secrets, scale-down, platform
+  MCP create/expose — all shipped.
+- **Sibling of** [AGENT-RUNTIME-INBOX-LOOP-DESIGN.md](./AGENT-RUNTIME-INBOX-LOOP-DESIGN.md):
+  same box-as-agent substrate; this is the *interactive, human-in-the-loop*
+  variant, that is the *headless one-shot* variant.
+- **Below** [AGENT-SKILLS-CREWS-DESIGN.md](./AGENT-SKILLS-CREWS-DESIGN.md): single
+  agent, single box; crews are the multi-agent superset.
+- **cmux** (`manaflow-ai/cmux`) is **not** a dependency: it is a *local* native
+  macOS multiplexer (opposite of cloud-hosted) and is **GPL-3.0** vs our
+  **Apache-2.0**. Borrow its agent-reattach / session-restore *concepts* only.

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -113,3 +113,69 @@ recipes:
       # Best-effort assembly: never fail provisioning if the release lacks the
       # artifacts (|| echo keeps the line green under `set -e`).
       - 'if [ -n "$CONTAINARIUM_PARAM_RELEASE" ]; then curl -fsSL "https://raw.githubusercontent.com/$CONTAINARIUM_PARAM_REPO/$CONTAINARIUM_PARAM_RELEASE/scripts/install-agent-runtime.sh" | REPO="$CONTAINARIUM_PARAM_REPO" RELEASE="$CONTAINARIUM_PARAM_RELEASE" bash || echo "agent-runtime assembly skipped/failed for release=$CONTAINARIUM_PARAM_RELEASE; box runs without the in-box loop"; fi'
+
+  # agent-workspace is the INTERACTIVE sibling of agent-runtime. Where
+  # agent-runtime runs a one-shot, headless AgentSkill loop (seeded task in →
+  # artifact.json out), agent-workspace is a persistent, human-in-the-loop
+  # coding agent you co-work with: an always-on Claude Code session living in a
+  # tmux session inside the box.
+  #
+  # The thesis (SPIKE — see docs/AGENT-WORKSPACE-SPIKE.md): a coding agent in a
+  # laptop tmux dies when the laptop sleeps. Move it into an always-on box and
+  # attach over the existing web terminal (internal/gateway/terminal.go execs
+  # `su - <user>`, a login shell). The profile.d hook below `exec`s every such
+  # login into ONE durable tmux session named `agent` — so each browser attach
+  # reconnects to the same running agent, exactly like re-attaching to a server
+  # tmux. Detaching (or the websocket dropping) leaves the agent running.
+  #
+  # No GPU, no exposed ports — co-working happens through the web terminal, and
+  # whatever the agent builds is shipped to a separate box via the platform MCP
+  # (create/expose), keeping this box the workshop and the shipped box the
+  # product.
+  #
+  # SPIKE CAVEAT: the Anthropic key is taken as a recipe parameter and written
+  # to a root-owned profile fragment for speed of proof. Production must seed it
+  # via the tenant secrets mechanism (AES-256-GCM, mode 0400) per
+  # AGENT-RUNTIME-INBOX-LOOP-DESIGN.md, not as a deploy-time parameter.
+  - id: agent-workspace
+    name: Agent Workspace
+    description: Always-on coding agent — a persistent Claude Code session in a tmux inside the box; attach over the web terminal to co-work, then ship what you build to a box.
+    image: images:ubuntu/24.04
+    requires_gpu: false
+    resources:
+      cpu: "4"
+      memory: 8GB
+      disk: 40GB
+    parameters:
+      # Optional: when empty, Claude Code starts unauthenticated and prompts
+      # the user to /login on first attach. SPIKE-only delivery path; see the
+      # caveat above.
+      - name: anthropic_api_key
+        label: Anthropic API key
+        description: API key for the in-box Claude Code agent. Leave blank to /login interactively on first attach. SPIKE-only — production seeds this via the secrets mechanism.
+        type: password
+    post_start:
+      - DEBIAN_FRONTEND=noninteractive apt-get update
+      - DEBIAN_FRONTEND=noninteractive apt-get install -y tmux git curl ca-certificates
+      - 'curl -fsSL https://deb.nodesource.com/setup_20.x | bash -'
+      - DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
+      - npm install -g @anthropic-ai/claude-code
+      # Stash the optional key in a root-only file the profile fragment sources.
+      - mkdir -p /etc/containarium
+      - 'install -m 0600 /dev/null /etc/containarium/agent-workspace.env'
+      - 'if [ -n "$CONTAINARIUM_PARAM_ANTHROPIC_API_KEY" ]; then printf "export ANTHROPIC_API_KEY=%s\n" "$CONTAINARIUM_PARAM_ANTHROPIC_API_KEY" > /etc/containarium/agent-workspace.env; fi'
+      # The auto-attach hook. On an interactive login shell that is not already
+      # inside tmux, replace the shell with a durable session named `agent`
+      # running Claude Code. `new-session -A` attaches if it exists, else
+      # creates it; `claude; exec bash` keeps the pane (and session) alive if
+      # the agent exits or needs /login, so re-attach always works.
+      - |
+        cat > /etc/profile.d/zz-agent-workspace.sh <<'EOF'
+        # Containarium agent-workspace: co-work with a persistent Claude Code agent.
+        case "$-" in *i*) ;; *) return ;; esac
+        [ -n "$TMUX" ] && return
+        [ -r /etc/containarium/agent-workspace.env ] && . /etc/containarium/agent-workspace.env
+        command -v tmux >/dev/null 2>&1 || return
+        exec tmux new-session -A -s agent "claude || true; exec bash"
+        EOF
+      - chmod 0644 /etc/profile.d/zz-agent-workspace.sh

--- a/pkg/core/recipes/recipes_test.go
+++ b/pkg/core/recipes/recipes_test.go
@@ -1,6 +1,7 @@
 package recipes
 
 import (
+	"strings"
 	"testing"
 
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -26,6 +27,53 @@ func TestEmbeddedCatalogLoads(t *testing.T) {
 		if !r.RequiresGpu {
 			t.Errorf("recipe %q expected requires_gpu=true", id)
 		}
+	}
+}
+
+func TestAgentWorkspaceRecipe(t *testing.T) {
+	m := New()
+	if err := m.LoadEmbedded(); err != nil {
+		t.Fatalf("LoadEmbedded: %v", err)
+	}
+	r, err := m.Get("agent-workspace")
+	if err != nil {
+		t.Fatalf("expected built-in recipe agent-workspace: %v", err)
+	}
+	if r.RequiresGpu {
+		t.Error("agent-workspace should not require a GPU")
+	}
+	if len(r.Ports) != 0 {
+		t.Errorf("agent-workspace exposes no ports (co-work via web terminal); got %d", len(r.Ports))
+	}
+	// The interactive proof: post_start must install the agent, install tmux,
+	// and drop the auto-attach profile hook that lands a web-terminal login in
+	// a durable tmux session.
+	joined := strings.Join(r.PostStart, "\n")
+	for _, want := range []string{
+		"@anthropic-ai/claude-code",
+		"tmux",
+		"/etc/profile.d/zz-agent-workspace.sh",
+		"new-session -A -s agent",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("agent-workspace post_start missing %q", want)
+		}
+	}
+	// The API key is an optional, password-typed parameter (spike delivery).
+	var key *pb.RecipeParam
+	for _, p := range r.Parameters {
+		if p.Name == "anthropic_api_key" {
+			key = p
+		}
+	}
+	if key == nil {
+		t.Fatal("agent-workspace should declare an anthropic_api_key parameter")
+	}
+	if key.Required {
+		t.Error("anthropic_api_key should be optional (blank → interactive /login)")
+	}
+	if key.Type != "password" {
+		t.Errorf("anthropic_api_key type: got %q want password", key.Type)
 	}
 }
 


### PR DESCRIPTION
## What & why

Adds an **interactive** sibling to the headless `agent-runtime` recipe: a persistent **Claude Code** session living in a `tmux` inside an **always-on box**, re-attachable from any browser via the **existing web terminal**.

This closes the gap between *"my coding agent lives in a laptop tmux and dies when the laptop sleeps"* and *"my agent lives in a box I reconnect to."* It's the lightest path to a hosted, always-on agent workspace — **one recipe**, no new server/proto/CLI/MCP code.

## How it works

- `post_start` installs `tmux` + Claude Code (`@anthropic-ai/claude-code`) into the base Ubuntu LXC.
- A `/etc/profile.d/zz-agent-workspace.sh` hook `exec`s every interactive login into **one durable tmux session** named `agent` running `claude`. The web terminal does `su - <user>` (a login shell that sources `profile.d`), so **each browser attach reconnects to the same running agent**. Username-agnostic; survives websocket drop / laptop sleep.
- Deploy + attach **reuse** `DeployRecipe` and `internal/gateway/terminal.go` unchanged — the recipe catalog entry is the whole change.

Contrast with `agent-runtime`: same box-as-agent substrate, but that one is headless/one-shot (seeded task → `artifact.json`); this one is interactive/human-in-the-loop.

## Spike posture (please read before merge)

This is **proof-of-path**, not a finished product:
- ⚠️ The Anthropic key is taken as a **recipe parameter** for speed of proof. **Production must seed it via the secrets mechanism** (AES-256-GCM, mode 0400) — called out as R4 in the PRD.
- ⚠️ **Live end-to-end acceptance on a backend is still pending** (open browser → land in Claude Code → detach → re-attach to the same session). Same posture as #608.

## Docs

- `docs/AGENT-WORKSPACE-SPIKE.md` — what's proven in-tree vs. what needs a live box.
- `docs/PRD-HOSTED-AGENT-WORKSPACE.md` — product framing. v1 build reduces to **secrets-based key delivery + a WebUI workspace entry**; everything else is shipped or spike-proven. (cmux noted as non-dependency: local macOS multiplexer, GPL-3.0 vs our Apache-2.0 — borrow concepts only.)

## Tests

- New `TestAgentWorkspaceRecipe` (catalog loads; GPU-free, port-free; post_start installs Claude Code + tmux + the auto-attach hook; key param is optional/password).
- `go build` clean; `go test ./pkg/core/recipes/... ./internal/server/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)