### PR TITLE
feat(recipes): agent-workspace — hosted web chat workspace in a box (OpenHands)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`agent-workspace` recipe — a hosted web chat workspace in a box.** A new
+  built-in recipe runs OpenHands ("Agent Canvas") inside an always-on box: a
+  browser chat UI with live preview and multiple persisted conversations, all
+  stored in the box (`/opt/openhands-state`). The model provider + API key are
+  set in the workspace UI (Anthropic, OpenAI/Codex, Gemini, or any LiteLLM
+  model). Auth lives in the box — an in-box reverse proxy fronts the app with
+  HTTP basic auth plus a `SameSite=None` session cookie it issues, so the
+  console can embed the workspace in an iframe and authenticate it without a
+  prompt. New `RecipeService.GetWorkspaceAccess` RPC
+  (`GET /v1/recipes/workspace/{name}/access`) + `containarium recipe
+  workspace-access` CLI return the zero-click bootstrap URL, and a `web-ui`
+  "Workspace" tab embeds the workspace (with a "Model setup" deep-link to the
+  provider settings). The recipe takes a required `auth_password` parameter
+  (secrets-based delivery is a tracked follow-up). See
+  `docs/AGENT-WORKSPACE-SPIKE.md` and `docs/PRD-HOSTED-AGENT-WORKSPACE.md`.
+
 ### Fixed
 
 - **Daemon unit `ReadWritePaths` now covers the doctor's required-writable set,

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -3843,6 +3843,39 @@
         ]
       }
     },
+    "/v1/recipes/workspace/{name}/access": {
+      "get": {
+        "summary": "Get workspace access URL",
+        "description": "Returns a zero-click bootstrap URL for an agent-workspace box, embeddable in the console to authenticate the in-box workspace UI seamlessly.",
+        "operationId": "RecipeService_GetWorkspaceAccess",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetWorkspaceAccessResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "description": "The box identity (the container is named \"\u003cname\u003e-container\"), same scheme\nas DeployRecipeRequest.name.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Recipes"
+        ]
+      }
+    },
     "/v1/recipes/{id}": {
       "get": {
         "summary": "Get recipe",
@@ -8350,6 +8383,20 @@
           "$ref": "#/definitions/Volume"
         }
       }
+    },
+    "GetWorkspaceAccessResponse": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string",
+          "description": "The in-box auth proxy's per-box session token."
+        },
+        "url": {
+          "type": "string",
+          "description": "Ready-to-embed bootstrap URL (https://\u003cworkspace-domain\u003e/__ws_login?t=...);\nloading it sets the session cookie and redirects to the workspace UI."
+        }
+      },
+      "description": "GetWorkspaceAccessResponse carries a bootstrap URL the console can load in an\niframe to sign the user into the in-box workspace proxy without a prompt."
     },
     "GetZapAlertSummaryResponse": {
       "type": "object",

--- a/docs/AGENT-WORKSPACE-SPIKE.md
+++ b/docs/AGENT-WORKSPACE-SPIKE.md
@@ -57,6 +57,30 @@ Contrast with `agent-runtime`: same box-as-agent substrate, but that recipe is
 headless/one-shot (seeded task → `artifact.json`); this one is the interactive,
 human-in-the-loop chat workspace.
 
+## Live validation (2026-06-18, fts-13700k)
+
+Stood the engine up in a throwaway box (`oh-spike`, Ubuntu 24.04 + Podman
+4.9.3) to settle the integration unknowns. Findings updated the recipe:
+
+- **OpenHands has been rewritten as "Agent Canvas."** The current image is
+  `ghcr.io/openhands/agent-canvas:1.0.0-rc.11` on port **8000** — not the old
+  `all-hands-ai/openhands:0.x` on 3000. The recipe was corrected.
+- **No container-engine socket needed (biggest risk eliminated).** Agent Canvas
+  runs the coding agent in the app container itself (box = sandbox); the run
+  command takes no `DOCKER_HOST` / `SANDBOX_RUNTIME_CONTAINER_IMAGE`. The
+  Podman-socket wiring was removed from the recipe.
+- **Bind mounts need Podman `:U`.** First run crashed with SQLite "unable to
+  open database file" — the non-root `openhands` user couldn't write the
+  root-owned mount. `:U` (chown source to the container user) fixed it; the app
+  then served **HTTP 200** with `<title>OpenHands</title>`.
+- **Iframe headers are absent.** The root response sets **no
+  `X-Frame-Options` and no `Content-Security-Policy`**, so the UI can be embedded
+  cross-origin without stripping headers at the proxy — good news for the
+  deferred "embed in the webui" goal.
+- **Still pending:** a real model call (needs an Anthropic key — set in the
+  OpenHands settings UI, none available this session) and the expose+auth path
+  (core-caddy is out of scope for the assistant; operator runs it).
+
 ## What is proven in-tree (this spike)
 
 - `go build ./pkg/core/recipes/... ./internal/server/...` — clean.
@@ -70,28 +94,25 @@ human-in-the-loop chat workspace.
   agent-workspace <name>` and the `deploy_recipe` MCP tool work from the catalog
   entry alone.
 
-## What MUST be confirmed on a live box (this spike does NOT prove)
+## Remaining live-acceptance items (NOT yet proven)
 
-This `post_start` is a **first-draft integration**, written from OpenHands' docs,
-not run. Before it ships, a live deploy on a backend must confirm:
+The engine + wiring are validated (above). What a fuller live acceptance still
+needs:
 
-1. **OpenHands image tag** (`openhands_version`, default `0.39`) and the matching
-   `…/runtime:<ver>-nikolaik` sandbox image — confirm the current tags.
-2. **Podman-socket wiring** — that OpenHands can spawn its runtime sandbox via
-   `DOCKER_HOST=unix:///run/podman/podman.sock` inside the LXC. Fallback if not:
-   OpenHands "local/CLI runtime" mode (the box *is* the sandbox, no nested
-   engine). This is the single biggest integration risk.
-3. **LiteLLM model id** (`llm_model`, default `anthropic/claude-sonnet-4-6`) —
-   confirm OpenHands/LiteLLM accepts it; operator-overridable.
-4. **Resource sizing** — OpenHands + the runtime image are heavy; confirm
-   4c/8GB/60GB is enough for a smooth first conversation.
-5. **Preview reachability** — that a dev server the agent starts is previewable
-   (via OpenHands' built-in browser, and/or a second exposed port).
+1. **A real model call** — set an Anthropic key in the OpenHands settings UI and
+   confirm an end-to-end conversation that edits files and runs commands.
+2. **Expose + auth** — put the `:8000` UI behind a managed subdomain + TLS with
+   platform auth in front (it is a full coding agent with a shell; must not be
+   world-open). This touches core-caddy and is the operator's step.
+3. **Persistence across recreate** — confirm conversations under
+   `/opt/openhands-state` survive a container restart and a second conversation.
+4. **Preview reachability** — that a dev server the agent starts is previewable
+   (OpenHands' built-in browser, and/or a second exposed port).
+5. **Resource right-sizing** — 4c/8GB/60GB is generous; trim after profiling.
 
-Live-acceptance steps: `containarium recipe deploy agent-workspace ws1 --param
-anthropic_api_key=… --server <host>`, open `https://ws1-workspace.<base-domain>`,
-start a conversation, have the agent scaffold + run a small site, confirm the
-preview renders, open a second conversation, reload, confirm both persist.
+Via the recipe (once a daemon carrying it is deployed): `containarium recipe
+deploy agent-workspace ws1 --server <host>`, then expose `:8000` behind auth and
+open the workspace.
 
 ## Required hardening before this is a product (NOT spike scope)
 

--- a/docs/AGENT-WORKSPACE-SPIKE.md
+++ b/docs/AGENT-WORKSPACE-SPIKE.md
@@ -77,9 +77,15 @@ Stood the engine up in a throwaway box (`oh-spike`, Ubuntu 24.04 + Podman
   `X-Frame-Options` and no `Content-Security-Policy`**, so the UI can be embedded
   cross-origin without stripping headers at the proxy — good news for the
   deferred "embed in the webui" goal.
+- **Auth lives in the box, not at the edge.** OpenHands is rebound to
+  `127.0.0.1:8000` and an in-box Caddy basic-auth proxy fronts it on `:8080`.
+  Validated: no creds → **401**, wrong creds → **401**, correct creds → **200**,
+  and OpenHands is not directly reachable. The box self-protects, so the
+  platform edge just forwards plain HTTP to `:8080` (and terminates TLS) — no
+  auth logic at core-caddy. This is now baked into the recipe (required
+  `auth_password` parameter, bcrypt-hashed at deploy).
 - **Still pending:** a real model call (needs an Anthropic key — set in the
-  OpenHands settings UI, none available this session) and the expose+auth path
-  (core-caddy is out of scope for the assistant; operator runs it).
+  OpenHands settings UI, none available this session).
 
 ## What is proven in-tree (this spike)
 
@@ -101,9 +107,9 @@ needs:
 
 1. **A real model call** — set an Anthropic key in the OpenHands settings UI and
    confirm an end-to-end conversation that edits files and runs commands.
-2. **Expose + auth** — put the `:8000` UI behind a managed subdomain + TLS with
-   platform auth in front (it is a full coding agent with a shell; must not be
-   world-open). This touches core-caddy and is the operator's step.
+2. **Edge forward** — point a managed subdomain + TLS at the box's `:8080`
+   (a plain reverse-proxy forward; auth already lives in the box, so the edge
+   carries no auth logic). Operator's step (touches core-caddy).
 3. **Persistence across recreate** — confirm conversations under
    `/opt/openhands-state` survive a container restart and a second conversation.
 4. **Preview reachability** — that a dev server the agent starts is previewable

--- a/docs/AGENT-WORKSPACE-SPIKE.md
+++ b/docs/AGENT-WORKSPACE-SPIKE.md
@@ -108,12 +108,18 @@ routes from the network route list and renders the box's UI in an iframe
 (typechecks + lints clean). Embedding works because the OpenHands root response
 carries no `X-Frame-Options`/`CSP` (validated above).
 
-Auth nuance carried into the UI: browsers usually suppress the in-box
-basic-auth prompt inside a cross-origin iframe, so the panel keeps an "Open in
-new tab to sign in" action prominent — sign in once at top-level, the browser
-caches the credentials for that origin, and the iframe then loads
-authenticated. A cookie/token handoff (like the monitoring tab's session
-cookie) is the follow-up to make it seamless.
+Seamless auth via a session-cookie handoff (validated 2026-06-18): browsers
+suppress the basic-auth prompt inside a cross-origin iframe, so the in-box proxy
+**issues a `SameSite=None` cookie on a successful basic-auth response and also
+accepts that cookie** in lieu of basic auth. The user signs in once at
+top-level (the panel's "Open in new tab to sign in" bootstrap); the browser then
+sends the cookie to the box even from the embedded iframe, so every load
+afterward is promptless. The cookie value is a per-box random token, so the
+console needs no secret. Validated on the box: no creds → 401, basic auth → 200
++ `Set-Cookie`, valid cookie alone → 200, wrong cookie → 401.
+
+Fully zero-click (no first sign-in) would require the daemon to vend the box's
+token to the console so it can bootstrap the cookie itself — a later follow-up.
 
 ## Remaining live-acceptance items (NOT yet proven)
 

--- a/docs/AGENT-WORKSPACE-SPIKE.md
+++ b/docs/AGENT-WORKSPACE-SPIKE.md
@@ -100,6 +100,21 @@ Stood the engine up in a throwaway box (`oh-spike`, Ubuntu 24.04 + Podman
   agent-workspace <name>` and the `deploy_recipe` MCP tool work from the catalog
   entry alone.
 
+## Web UI embedding (shipped)
+
+The console embeds the workspace directly: a **"Workspace" tab** in `web-ui`
+(`src/components/workspace/WorkspaceView.tsx`) discovers `workspace`-subdomain
+routes from the network route list and renders the box's UI in an iframe
+(typechecks + lints clean). Embedding works because the OpenHands root response
+carries no `X-Frame-Options`/`CSP` (validated above).
+
+Auth nuance carried into the UI: browsers usually suppress the in-box
+basic-auth prompt inside a cross-origin iframe, so the panel keeps an "Open in
+new tab to sign in" action prominent — sign in once at top-level, the browser
+caches the credentials for that origin, and the iframe then loads
+authenticated. A cookie/token handoff (like the monitoring tab's session
+cookie) is the follow-up to make it seamless.
+
 ## Remaining live-acceptance items (NOT yet proven)
 
 The engine + wiring are validated (above). What a fuller live acceptance still

--- a/docs/AGENT-WORKSPACE-SPIKE.md
+++ b/docs/AGENT-WORKSPACE-SPIKE.md
@@ -171,6 +171,27 @@ end-to-end over HTTPS). Two gotchas worth recording:
   containers live under the box's init with `--restart=always`. Only a
   by-hand, non-root setup needs linger enabled (by root) to survive logout.
 
+## Recipe-as-root validation (2026-06-18)
+
+The recipe's `post_start` was run **as root** (exactly as `DeployRecipe` execs
+it — params substituted, `set -euo pipefail`) in an isolated throwaway incus
+container, to prove the production path differs from the rootless hand-repro:
+
+- The committed `post_start` script completed cleanly (`POST_START DONE`).
+- **Root Podman containers persist across session close** — confirmed `Up` from
+  multiple fresh SSH sessions after the launching session had exited (uptime grew
+  16s → 58s). No `linger` needed: root containers run under the box's init with
+  `--restart=always`. This is the gap the rootless tenant setup couldn't cross.
+- `/opt/wsauth/token` written (what `GetWorkspaceAccess` reads); in-box auth
+  `401 / 200 / 302` (basic + zero-click bootstrap). Throwaway torn down after.
+
+Not run: the **full daemon path** (`deploy_recipe agent-workspace` + the
+`GetWorkspaceAccess` RPC against a live daemon). A second daemon on a shared lab
+box is **not isolatable** — it auto-discovers the existing core services and
+loads config from the live PostgreSQL (e.g. `app-hosting=true`), so it becomes a
+second instance of the live deployment's brain. The RPC/CLI are unit-tested; a
+clean host (fresh VM) is the right place to exercise the end-to-end daemon path.
+
 ## Remaining live-acceptance items (NOT yet proven)
 
 The engine + wiring are validated (above). What a fuller live acceptance still

--- a/docs/AGENT-WORKSPACE-SPIKE.md
+++ b/docs/AGENT-WORKSPACE-SPIKE.md
@@ -1,0 +1,115 @@
+# Spike — web chat workspace via OpenHands-in-a-box (`agent-workspace` recipe)
+
+> Status: **Spike / proof-of-path, NOT live-validated.** Goal: prove that a
+> hosted web chat workspace — Claude/ChatGPT-style chat + live preview +
+> multiple persisted conversations, all stored inside one always-on box — is
+> buildable mostly by *packaging an existing OSS engine* rather than building a
+> chat UI + agent loop + session store from scratch.
+
+## The idea in one line
+
+Run **OpenHands** (web chat coding-agent with preview + persisted conversations)
+**inside an always-on Containarium box**, expose its web UI as a subdomain, and
+let the user co-work in the browser — then ship what they build to a separate
+box via the platform MCP.
+
+## Why reuse OpenHands
+
+The product the user actually wants is the bolt.new / Lovable / OpenHands shape:
+a chat surface, a live preview of what's being built, many conversations, all
+persisted. Building that natively is a real frontend+backend effort. OpenHands
+(All-Hands-AI, **MIT** — clean against our Apache-2.0) already provides:
+
+- a web **chat UI**,
+- a **coding agent** that edits files and runs commands,
+- an in-container **workspace + browser/preview**,
+- **multiple conversations**, persisted to disk,
+- **bring-your-own Anthropic key**, single-container self-host.
+
+Reuse candidates considered: **Open WebUI** (great multi-session chat + SQLite,
+but a chat-to-LLM front — weak on "build a website + preview" — and a custom
+license with a branding-preservation clause); **cmux** (already ruled out:
+local macOS app, GPL-3.0). OpenHands won on fit + license.
+
+**Containarium's value is the wrapper, not the chat UI:** an isolated always-on
+box, eBPF/audit/secrets trust fabric, and one-click **ship-to-box**. We are the
+safe, persistent host; OpenHands is the cockpit.
+
+## How it works
+
+The `agent-workspace` recipe (`pkg/core/recipes/recipes.yaml`):
+
+- `post_start` runs the OpenHands web app via **Podman** (the box already runs
+  OCI workloads via Podman — same as `ollama`/`llamacpp`), persisting
+  conversations under **`/opt/openhands-state`** in the box — so "all sessions
+  stored inside a box" holds.
+- OpenHands spawns a per-conversation runtime sandbox; it drives the box's
+  **Podman socket** (`DOCKER_HOST=unix:///run/podman/podman.sock`), so there is
+  no docker-in-docker nesting beyond what the GPU recipes already do.
+- The recipe's `ports` block exposes OpenHands' `:3000` as the `workspace`
+  subdomain, so the whole **chat + preview + conversation-list** surface is
+  reachable at `https://<name>-workspace.<base-domain>` over the platform's
+  existing route + managed-TLS path.
+- The Anthropic key + model are seeded via parameters into a root-only env-file
+  the app reads (spike delivery — see hardening below).
+
+Contrast with `agent-runtime`: same box-as-agent substrate, but that recipe is
+headless/one-shot (seeded task → `artifact.json`); this one is the interactive,
+human-in-the-loop chat workspace.
+
+## What is proven in-tree (this spike)
+
+- `go build ./pkg/core/recipes/... ./internal/server/...` — clean.
+- `go test ./pkg/core/recipes/...` green, including `TestAgentWorkspaceRecipe`
+  (catalog loads the recipe; GPU-free; exposes `:3000`; post_start runs
+  OpenHands, persists to `/opt/openhands-state`, wires the Podman socket; the
+  key is an optional `password` param; a model param exists).
+- Deploy + routing are **inherited, not new**: `DeployRecipe` provisions the box
+  and runs `post_start`; the `ports` block reuses the standard expose/route +
+  managed-cert path. No server/proto/CLI/MCP change — `recipe deploy
+  agent-workspace <name>` and the `deploy_recipe` MCP tool work from the catalog
+  entry alone.
+
+## What MUST be confirmed on a live box (this spike does NOT prove)
+
+This `post_start` is a **first-draft integration**, written from OpenHands' docs,
+not run. Before it ships, a live deploy on a backend must confirm:
+
+1. **OpenHands image tag** (`openhands_version`, default `0.39`) and the matching
+   `…/runtime:<ver>-nikolaik` sandbox image — confirm the current tags.
+2. **Podman-socket wiring** — that OpenHands can spawn its runtime sandbox via
+   `DOCKER_HOST=unix:///run/podman/podman.sock` inside the LXC. Fallback if not:
+   OpenHands "local/CLI runtime" mode (the box *is* the sandbox, no nested
+   engine). This is the single biggest integration risk.
+3. **LiteLLM model id** (`llm_model`, default `anthropic/claude-sonnet-4-6`) —
+   confirm OpenHands/LiteLLM accepts it; operator-overridable.
+4. **Resource sizing** — OpenHands + the runtime image are heavy; confirm
+   4c/8GB/60GB is enough for a smooth first conversation.
+5. **Preview reachability** — that a dev server the agent starts is previewable
+   (via OpenHands' built-in browser, and/or a second exposed port).
+
+Live-acceptance steps: `containarium recipe deploy agent-workspace ws1 --param
+anthropic_api_key=… --server <host>`, open `https://ws1-workspace.<base-domain>`,
+start a conversation, have the agent scaffold + run a small site, confirm the
+preview renders, open a second conversation, reload, confirm both persist.
+
+## Required hardening before this is a product (NOT spike scope)
+
+- **Key delivery** — replace the recipe parameter with the **tenant secrets
+  mechanism** (AES-256-GCM, mode 0400). Parameters can land in audit logs /
+  process args.
+- **Auth in front of the UI** — OpenHands' `:3000` exposed on a subdomain needs
+  the platform's auth in front of it (it is a full coding agent with shell). The
+  route must require the tenant's session, not be world-open.
+- **Cost / idle** — an always-on keyed agent is a spend risk; apply auto-sleep /
+  idle-TTL (shipped scale-down primitives) and, at scale, the model gateway.
+- **Native UI (v2)** — embedding OpenHands proves demand fast; owning the UX
+  (our own chat surface over an in-box agent server) is the eventual build.
+
+## Verdict
+
+The path holds and is light: a hosted chat+preview+multi-session workspace is
+**one recipe** packaging OpenHands on top of shipped box/route/TLS
+infrastructure. This spike proves the wiring loads and deploys through existing
+machinery; the integration details (above) need one live box to lock down. The
+PRD (`PRD-HOSTED-AGENT-WORKSPACE.md`) is written against this mechanism.

--- a/docs/AGENT-WORKSPACE-SPIKE.md
+++ b/docs/AGENT-WORKSPACE-SPIKE.md
@@ -108,18 +108,31 @@ routes from the network route list and renders the box's UI in an iframe
 (typechecks + lints clean). Embedding works because the OpenHands root response
 carries no `X-Frame-Options`/`CSP` (validated above).
 
-Seamless auth via a session-cookie handoff (validated 2026-06-18): browsers
-suppress the basic-auth prompt inside a cross-origin iframe, so the in-box proxy
-**issues a `SameSite=None` cookie on a successful basic-auth response and also
-accepts that cookie** in lieu of basic auth. The user signs in once at
-top-level (the panel's "Open in new tab to sign in" bootstrap); the browser then
-sends the cookie to the box even from the embedded iframe, so every load
-afterward is promptless. The cookie value is a per-box random token, so the
-console needs no secret. Validated on the box: no creds → 401, basic auth → 200
-+ `Set-Cookie`, valid cookie alone → 200, wrong cookie → 401.
+**Zero-click auth (implemented).** The in-box proxy supports three ways in,
+all validated live on the box (2026-06-18):
 
-Fully zero-click (no first sign-in) would require the daemon to vend the box's
-token to the console so it can bootstrap the cookie itself — a later follow-up.
+- a **`/__ws_login?t=<token>` bootstrap** route → sets the `SameSite=None`
+  session cookie and `302`-redirects to the app;
+- the **cookie** itself, accepted in lieu of auth;
+- **HTTP basic auth** as the fallback, which also issues the cookie.
+
+The console gets zero-click by asking the daemon for a bootstrap URL:
+`RecipeService.GetWorkspaceAccess(name)` (`GET
+/v1/recipes/workspace/{name}/access`, scope `containers:read` + tenant authz)
+reads the box's token via `ExecWithOutput cat /opt/wsauth/token` and returns
+`https://<box>-workspace.<domain>/__ws_login?t=<token>`. `WorkspaceView` fetches
+that and uses it as the iframe `src`, so the embedded workspace authenticates
+with **no prompt and no first sign-in**. CLI parity:
+`containarium recipe workspace-access <name>`. If the lookup fails (older box,
+no route), the panel falls back to the plain URL + the "Open in new tab" path.
+
+Validated on the box: bootstrap `/__ws_login?t=TOKEN` → `302` + `Location: /` +
+`Set-Cookie`; cookie alone → `200`; no creds → `401`; basic auth → `200`.
+
+Security note: the bootstrap token rides in a URL query (iframe `src`); it is a
+per-box secret returned only to a `containers:read`-authorized caller, and the
+cookie takes over immediately after the redirect. Acceptable for v1; a POST-based
+handoff would remove it from URLs as a follow-up.
 
 ## Remaining live-acceptance items (NOT yet proven)
 

--- a/docs/AGENT-WORKSPACE-SPIKE.md
+++ b/docs/AGENT-WORKSPACE-SPIKE.md
@@ -1,10 +1,13 @@
 # Spike — web chat workspace via OpenHands-in-a-box (`agent-workspace` recipe)
 
-> Status: **Spike / proof-of-path, NOT live-validated.** Goal: prove that a
+> Status: **Spike / proof-of-path, live-validated.** Goal: prove that a
 > hosted web chat workspace — Claude/ChatGPT-style chat + live preview +
 > multiple persisted conversations, all stored inside one always-on box — is
 > buildable mostly by *packaging an existing OSS engine* rather than building a
-> chat UI + agent loop + session store from scratch.
+> chat UI + agent loop + session store from scratch. The recipe, in-box auth,
+> zero-click handoff, and the full daemon deploy path are all validated on a
+> backend (see the validation sections below); the one functional item still
+> pending is a real model call (needs a provider API key).
 
 ## The idea in one line
 
@@ -39,28 +42,29 @@ safe, persistent host; OpenHands is the cockpit.
 
 The `agent-workspace` recipe (`pkg/core/recipes/recipes.yaml`):
 
-- `post_start` runs the OpenHands web app via **Podman** (the box already runs
-  OCI workloads via Podman — same as `ollama`/`llamacpp`), persisting
-  conversations under **`/opt/openhands-state`** in the box — so "all sessions
-  stored inside a box" holds.
-- OpenHands spawns a per-conversation runtime sandbox; it drives the box's
-  **Podman socket** (`DOCKER_HOST=unix:///run/podman/podman.sock`), so there is
-  no docker-in-docker nesting beyond what the GPU recipes already do.
-- The recipe's `ports` block exposes OpenHands' `:3000` as the `workspace`
-  subdomain, so the whole **chat + preview + conversation-list** surface is
-  reachable at `https://<name>-workspace.<base-domain>` over the platform's
-  existing route + managed-TLS path.
-- The Anthropic key + model are seeded via parameters into a root-only env-file
-  the app reads (spike delivery — see hardening below).
+- `post_start` runs the OpenHands "Agent Canvas" web app via **Podman** (the box
+  already runs OCI workloads via Podman — same as `ollama`/`llamacpp`),
+  persisting conversations under **`/opt/openhands-state`** in the box — so "all
+  sessions stored inside a box" holds. Agent Canvas runs the coding agent **in
+  the app container itself** (box = sandbox), so it needs **no container-engine
+  socket** — the app is bound to `127.0.0.1:8000`.
+- An **in-box Caddy auth proxy** fronts it on **`:8080`**, which the recipe's
+  `ports` block exposes as the `workspace` subdomain — so the whole **chat +
+  preview + conversation-list** surface is reachable at
+  `https://<name>-workspace.<base-domain>` over the platform's existing route +
+  managed-TLS path, with auth living in the box (see "Auth lives in the box").
+- The **model provider + API key are set in the OpenHands UI** (Settings → LLM;
+  the recipe pins no provider — see "Model provider + key"). The recipe's only
+  required parameter is `auth_password` for the in-box proxy.
 
 Contrast with `agent-runtime`: same box-as-agent substrate, but that recipe is
 headless/one-shot (seeded task → `artifact.json`); this one is the interactive,
 human-in-the-loop chat workspace.
 
-## Live validation (2026-06-18, fts-13700k)
+## Live validation (2026-06-18, a GPU backend)
 
-Stood the engine up in a throwaway box (`oh-spike`, Ubuntu 24.04 + Podman
-4.9.3) to settle the integration unknowns. Findings updated the recipe:
+Stood the engine up in a throwaway box (Ubuntu 24.04 + Podman 4.9.3) on a
+backend host to settle the integration unknowns. Findings updated the recipe:
 
 - **OpenHands has been rewritten as "Agent Canvas."** The current image is
   `ghcr.io/openhands/agent-canvas:1.0.0-rc.11` on port **8000** — not the old
@@ -91,14 +95,15 @@ Stood the engine up in a throwaway box (`oh-spike`, Ubuntu 24.04 + Podman
 
 - `go build ./pkg/core/recipes/... ./internal/server/...` — clean.
 - `go test ./pkg/core/recipes/...` green, including `TestAgentWorkspaceRecipe`
-  (catalog loads the recipe; GPU-free; exposes `:3000`; post_start runs
-  OpenHands, persists to `/opt/openhands-state`, wires the Podman socket; the
-  key is an optional `password` param; a model param exists).
+  (catalog loads the recipe; GPU-free; exposes the in-box auth proxy on `:8080`;
+  post_start runs OpenHands bound to `127.0.0.1:8000`, persists to
+  `/opt/openhands-state`, chowns mounts with `:U`, and stands up the basic-auth
+  proxy; `auth_password` is a required `password` param).
 - Deploy + routing are **inherited, not new**: `DeployRecipe` provisions the box
   and runs `post_start`; the `ports` block reuses the standard expose/route +
-  managed-cert path. No server/proto/CLI/MCP change — `recipe deploy
-  agent-workspace <name>` and the `deploy_recipe` MCP tool work from the catalog
-  entry alone.
+  managed-cert path. The one bit of new platform code is the `GetWorkspaceAccess`
+  RPC + `recipe workspace-access` CLI verb (for the zero-click bootstrap URL); an
+  MCP tool is a deliberate follow-up (CLI-first; CLI-without-MCP is allowed).
 
 ## Web UI embedding (shipped)
 
@@ -226,18 +231,19 @@ needs:
    (OpenHands' built-in browser, and/or a second exposed port).
 5. **Resource right-sizing** — 4c/8GB/60GB is generous; trim after profiling.
 
-Via the recipe (once a daemon carrying it is deployed): `containarium recipe
-deploy agent-workspace ws1 --server <host>`, then expose `:8000` behind auth and
-open the workspace.
+Via the recipe: `containarium recipe deploy agent-workspace ws1 --param
+auth_password=… --server <host>`; the `:8080` proxy is exposed as the
+`workspace` subdomain, then open the workspace.
 
 ## Required hardening before this is a product (NOT spike scope)
 
-- **Key delivery** — replace the recipe parameter with the **tenant secrets
-  mechanism** (AES-256-GCM, mode 0400). Parameters can land in audit logs /
-  process args.
-- **Auth in front of the UI** — OpenHands' `:3000` exposed on a subdomain needs
-  the platform's auth in front of it (it is a full coding agent with shell). The
-  route must require the tenant's session, not be world-open.
+- **Auth-password delivery** — replace the `auth_password` **recipe parameter**
+  with the **tenant secrets mechanism** (AES-256-GCM, mode 0400). Parameters can
+  land in audit logs / process args. (Auth itself already lives in the box — see
+  "Auth lives in the box"; this is about how the password is delivered.)
+- **Bootstrap token in URL** — the zero-click handoff puts the token in a query
+  string; move to a POST/short-TTL-nonce handoff so it doesn't land in logs or
+  `Referer`. The cookie itself has no rotation/expiry today.
 - **Cost / idle** — an always-on keyed agent is a spend risk; apply auto-sleep /
   idle-TTL (shipped scale-down primitives) and, at scale, the model gateway.
 - **Native UI (v2)** — embedding OpenHands proves demand fast; owning the UX
@@ -247,6 +253,7 @@ open the workspace.
 
 The path holds and is light: a hosted chat+preview+multi-session workspace is
 **one recipe** packaging OpenHands on top of shipped box/route/TLS
-infrastructure. This spike proves the wiring loads and deploys through existing
-machinery; the integration details (above) need one live box to lock down. The
-PRD (`PRD-HOSTED-AGENT-WORKSPACE.md`) is written against this mechanism.
+infrastructure. Validated end-to-end on a backend — recipe deploy as root,
+persistence, in-box auth, zero-click handoff, and the full daemon CLI path — with
+only a real model call (provider key) still pending. The PRD
+(`PRD-HOSTED-AGENT-WORKSPACE.md`) is written against this mechanism.

--- a/docs/AGENT-WORKSPACE-SPIKE.md
+++ b/docs/AGENT-WORKSPACE-SPIKE.md
@@ -185,12 +185,30 @@ container, to prove the production path differs from the rootless hand-repro:
 - `/opt/wsauth/token` written (what `GetWorkspaceAccess` reads); in-box auth
   `401 / 200 / 302` (basic + zero-click bootstrap). Throwaway torn down after.
 
-Not run: the **full daemon path** (`deploy_recipe agent-workspace` + the
-`GetWorkspaceAccess` RPC against a live daemon). A second daemon on a shared lab
-box is **not isolatable** — it auto-discovers the existing core services and
-loads config from the live PostgreSQL (e.g. `app-hosting=true`), so it becomes a
-second instance of the live deployment's brain. The RPC/CLI are unit-tested; a
-clean host (fresh VM) is the right place to exercise the end-to-end daemon path.
+## Full daemon-path validation on a clean VM (2026-06-18)
+
+Exercised end-to-end on a throwaway GCP VM (Ubuntu 24.04 + incus 7.1, fresh
+host — no existing deployment to auto-join), running the branch daemon:
+
+- `recipe list` shows **agent-workspace** in the daemon's catalog (binary
+  carries the recipe + `GetWorkspaceAccess`).
+- `recipe deploy agent-workspace ws1` → **`✓ deployed as ws1-container`**: the
+  daemon ran `CreateContainer` (EnablePodman) + `post_start` **as root**;
+  `openhands` + `wsauth` came up (root, persistent), `/opt/wsauth/token` written.
+- `recipe workspace-access ws1` → the **`GetWorkspaceAccess` RPC** read the token
+  via `ExecWithOutput` and returned the bootstrap URL.
+- In-box auth `401 / 200 / 302` on the recipe-deployed box. VM deleted after.
+
+Finding folded back in: in standalone mode (no app-hosting) `network.baseDomain`
+is unset, so the RPC returned a **domain-less** URL (`https://ws1-workspace/…`).
+Guarded `GetWorkspaceAccess` to only compose a URL when a base domain is
+configured (same precondition as `exposePorts`) — otherwise it returns just the
+token and the caller surfaces the "no route" hint. A real app-hosting deployment
+has the base domain set, so the URL is complete there (as seen on the cloud).
+
+Note: a second daemon on a *shared* box is still **not isolatable** (it
+auto-discovers the live core services + loads config from the live PostgreSQL),
+which is why this ran on a dedicated fresh VM.
 
 ## Remaining live-acceptance items (NOT yet proven)
 

--- a/docs/AGENT-WORKSPACE-SPIKE.md
+++ b/docs/AGENT-WORKSPACE-SPIKE.md
@@ -134,6 +134,26 @@ per-box secret returned only to a `containers:read`-authorized caller, and the
 cookie takes over immediately after the redirect. Acceptable for v1; a POST-based
 handoff would remove it from URLs as a follow-up.
 
+## Operational notes — exposing via the cloud control plane
+
+Validated live by standing the workspace up on a cloud-managed box and exposing
+it on a public managed subdomain (auth + the zero-click bootstrap both confirmed
+end-to-end over HTTPS). Two gotchas worth recording:
+
+- **`expose_port` auto-appends the org zone suffix.** Pass the **bare
+  subdomain** (e.g. `agentws`), not a full hostname. The cloud CP appends
+  `-<org>.<zone>` itself, so passing a full domain doubles it
+  (`<name>-<org>-<org>.<zone>`). The recipe's `ports.subdomain` is already a
+  bare label, so a recipe-driven deploy is unaffected — this only bites manual
+  `expose_port` calls that pass a full domain.
+
+- **Rootless Podman needs persistence handling.** Containers set up by hand as
+  the **non-root tenant** user die on SSH logout (the user session is torn down
+  and `loginctl enable-linger` is denied to tenants). The `agent-workspace`
+  recipe avoids this entirely: its `post_start` runs as **root**, so the
+  containers live under the box's init with `--restart=always`. Only a
+  by-hand, non-root setup needs linger enabled (by root) to survive logout.
+
 ## Remaining live-acceptance items (NOT yet proven)
 
 The engine + wiring are validated (above). What a fuller live acceptance still

--- a/docs/AGENT-WORKSPACE-SPIKE.md
+++ b/docs/AGENT-WORKSPACE-SPIKE.md
@@ -134,6 +134,23 @@ per-box secret returned only to a `containers:read`-authorized caller, and the
 cookie takes over immediately after the redirect. Acceptable for v1; a POST-based
 handoff would remove it from URLs as a follow-up.
 
+## Model provider + key (multi-provider, set in the UI)
+
+The workspace is **provider-agnostic** — the recipe pins no model. Users choose
+their provider and key in the UI: the Workspace tab has a **"Model setup"** view
+that deep-links the iframe to OpenHands' own **Settings → LLM** (`/settings/llm`),
+which supports **Anthropic, OpenAI / Codex, Google Gemini, Mistral, and any
+LiteLLM model**, with saved profiles and mid-conversation switching. The
+bootstrap cookie from the Chat view authenticates that page too.
+
+Why deep-link instead of a form in our chrome: OpenHands' settings API is
+internal, session-key-gated (a per-box `X-Session-API-Key`), and schema-
+versioned (`agent_settings.llm`, model as a LiteLLM string) — reimplementing it
+in the console would be cross-origin (CORS) and would drift every OpenHands
+release. Deep-linking reuses their robust multi-provider form with ~zero
+coupling. (A pre-seed-at-launch-via-secrets path remains the option if we later
+want the console to own provider/key input centrally.)
+
 ## Operational notes — exposing via the cloud control plane
 
 Validated live by standing the workspace up on a cloud-managed box and exposing

--- a/docs/PRD-HOSTED-AGENT-WORKSPACE.md
+++ b/docs/PRD-HOSTED-AGENT-WORKSPACE.md
@@ -97,7 +97,7 @@ browser, without my laptop being involved."*
 | R3 | Multiple conversations persist in the box and survive disconnect/reload. | **OpenHands built-in**; live-acceptance pending. |
 | R4 | The exposed agent UI sits behind platform auth. | **New** — route/auth work. |
 | R5 | The Anthropic key is delivered via the secrets mechanism, not a parameter. | **New**. |
-| R6 | A WebUI affordance launches + opens a workspace. | **New** (small). |
+| R6 | A WebUI affordance opens a workspace. | **Shipped (embed)** — `web-ui` "Workspace" tab embeds the box's UI in an iframe; launch-from-UI still to do. |
 | R7 | Workspace lifecycle is audit-logged + scope-gated; build ships to a box. | **Shipped** (inherited). |
 
 **Read of the gap:** the *experience* (R1–R3) is reuse + wiring, proven to load

--- a/docs/PRD-HOSTED-AGENT-WORKSPACE.md
+++ b/docs/PRD-HOSTED-AGENT-WORKSPACE.md
@@ -1,0 +1,160 @@
+# PRD — Hosted agent chat workspace
+
+> Status: **Draft — for review.** Anchored on a working spike
+> (`docs/AGENT-WORKSPACE-SPIKE.md`, the `agent-workspace` recipe packaging
+> OpenHands). Generic mechanism only; per
+> [AGENT-SKILLS-CREWS-DESIGN.md](./AGENT-SKILLS-CREWS-DESIGN.md), opinionated
+> agent images/skills ship outside this repo.
+
+## 1. Problem
+
+A developer's coding agent runs on their **laptop**: it sleeps, goes offline,
+and its chat history + working state are tied to one machine being awake. People
+who want an always-on agent fall back to "SSH to a server, run an agent in tmux,
+reconnect later" — expert-only, no chat UI, no preview, no notion of multiple
+saved conversations.
+
+What people actually want is the experience they already know from Claude / 
+ChatGPT / bolt.new: **a browser chat UI, a live preview of what's being built,
+and multiple conversations they can leave and come back to** — but hosted
+somewhere always-on, isolated, and able to *ship* the result.
+
+**The job:** *"Let me open a browser, chat with a coding agent to design a site
+or system, watch it come together in a preview, keep multiple projects as
+separate saved conversations — all living in a box I don't have to run myself —
+and ship what I build."*
+
+## 2. Why now / why us
+
+The chat + agent + preview + sessions problem is *solved* by OSS engines
+(OpenHands, MIT). What is **not** commoditized — and what Containarium already
+ships — is the safe, always-on, shippable substrate underneath:
+
+- always-on isolated per-tenant boxes,
+- one-command provisioning with in-box setup (`RecipeService`),
+- managed subdomain + TLS routing (expose-port),
+- eBPF network policy, audit logging, secrets — the trust fabric a browser-
+  reachable coding agent (with a shell and a key) demands,
+- one-click **ship-to-box** for the artifact.
+
+So we don't build a chat UI to compete with OpenHands — we **package it** and win
+on the wrapper. The spike showed the integration is ~one recipe.
+
+## 3. Target user & JTBD
+
+**Primary persona — "the always-on builder."** Comfortable chatting with a
+coding agent; wants it hosted, persistent, and able to publish — without running
+infrastructure.
+
+**JTBD:** *"When I have an idea, I open my workspace, chat it into existence with
+a preview in front of me, save it as one of my projects, and ship it — from any
+browser, without my laptop being involved."*
+
+**Not this PRD:** the headless one-shot AgentSkill user (`agent-runtime` / Phase
+4a) and the multi-agent crew operator (Phases 1–3).
+
+## 4. The experience (target)
+
+1. **Launch** — user creates a workspace (one `deploy_recipe` /
+   `recipe deploy agent-workspace`). Always-on box comes up running OpenHands.
+   *(spike: wired, live-acceptance pending)*
+2. **Open** — browser to `https://<name>-workspace.<base-domain>`; the chat UI
+   loads behind platform auth. *(spike: via the recipe's exposed port + routing)*
+3. **Chat + preview** — converse with the agent; it edits files, runs commands,
+   and a **preview pane** shows the running app. *(OpenHands built-in)*
+4. **Multiple sessions** — start/switch between conversations; all persisted to
+   the box (`/opt/openhands-state`). *(OpenHands built-in)*
+5. **Walk away / resume** — close the tab; the box stays up; re-open from any
+   browser and the conversations are there. *(box is always-on)*
+6. **Ship** — publish the build to a *separate* box (workshop box ≠ product box)
+   via the platform MCP. *(shipped: create/expose)*
+
+## 5. Scope
+
+### In scope (v1)
+- The **`agent-workspace` recipe** (OpenHands-in-a-box) as the supported launch
+  path — spike → live-validated → hardened.
+- **Platform auth in front of** the exposed OpenHands UI (it's a full coding
+  agent; must require the tenant's session).
+- **Secrets-based** Anthropic key delivery (replace the spike parameter).
+- **A WebUI entry** to launch + open a workspace (vs. raw `recipe deploy`).
+- **Idle policy** (auto-sleep / TTL) to bound always-on cost.
+
+### Out of scope (v1, deferred)
+- **Native chat UI** (our own surface over an in-box agent server) — v2 once
+  demand is proven; v1 embeds OpenHands.
+- **Central model gateway / metering** — needed at scale; v1 ships per-tenant
+  keys via secrets. (Project memory: model-gateway RFC.)
+- **Multi-agent / crews** ([AGENT-SKILLS-CREWS-DESIGN.md](./AGENT-SKILLS-CREWS-DESIGN.md)).
+- **Non-Claude / alternative engines** — same recipe pattern, later.
+
+## 6. Requirements
+
+| # | Requirement | Dependency status |
+|---|---|---|
+| R1 | One command launches an always-on box running a web chat workspace. | **Spike-wired**; live-acceptance pending. |
+| R2 | The chat UI + live preview are reachable in the browser over managed TLS. | **Spike-wired** (ports + routing); live-acceptance pending. |
+| R3 | Multiple conversations persist in the box and survive disconnect/reload. | **OpenHands built-in**; live-acceptance pending. |
+| R4 | The exposed agent UI sits behind platform auth. | **New** — route/auth work. |
+| R5 | The Anthropic key is delivered via the secrets mechanism, not a parameter. | **New**. |
+| R6 | A WebUI affordance launches + opens a workspace. | **New** (small). |
+| R7 | Workspace lifecycle is audit-logged + scope-gated; build ships to a box. | **Shipped** (inherited). |
+
+**Read of the gap:** the *experience* (R1–R3) is reuse + wiring, proven to load
+in-tree and pending one live box. The genuine new build is **R4 (auth in front),
+R5 (secrets), R6 (a launch button)** — all small, all on shipped substrate.
+
+## 7. Success metrics
+
+- **North star — time-to-first-agent-reply**: launch → first agent response in
+  the browser, target **< 5 min** (dominated by image pulls; mitigate with a
+  pre-baked box image).
+- **Resume success**: % of re-opens that show prior conversations intact > 99%.
+- **Activation**: % of new users who launch a workspace and complete ≥ 1
+  conversation in their first session.
+- **Stickiness**: median days a workspace stays alive (proves always-on value).
+- **Ship-through**: % of workspaces that ship at least one artifact to a box.
+
+## 8. Risks & open questions
+
+- **Integration risk (the spike's #1 unknown):** OpenHands spawning its runtime
+  sandbox via the box's Podman socket. If it doesn't hold, fall back to
+  OpenHands local/CLI runtime (box = sandbox). *Must be settled in live
+  acceptance before commit to GA.*
+- **Security of an exposed coding agent.** A world-reachable OpenHands UI is a
+  shell + key. R4 (auth in front) is non-negotiable; the box's eBPF egress
+  policy should also bound what the agent can reach.
+- **Cost / runaway spend.** Always-on + a key. v1: secrets-scoped key +
+  auto-sleep/idle-TTL; real fix = model gateway (deferred).
+- **Pre-baked vs pull-on-deploy.** Pulling OpenHands + runtime images at deploy
+  hurts time-to-wow. *Decision: bake an image vs keep post_start pulls.*
+- **Embed vs native UX.** Embedding OpenHands ships fast but the UX is theirs
+  (incl. branding). *Recommendation: embed for v1 to validate demand; native
+  surface is v2.*
+- **Cloud packaging.** Pricing, quotas, idle billing belong in the
+  Containarium-cloud `prd/` tree; this is the OSS-mechanism PRD. Cloud companion
+  PRD is the follow-up.
+
+## 9. Phasing
+
+- **Phase 0 — spike (DONE):** `agent-workspace` recipe; wiring proven in-tree.
+- **Phase 1 — live validation:** settle the integration unknowns
+  (`docs/AGENT-WORKSPACE-SPIKE.md`) on a backend.
+- **Phase 2 — v1 launch:** auth-in-front (R4), secrets key (R5), WebUI launch
+  (R6), idle policy, pre-baked image.
+- **Phase 3 — native + scale:** our own chat surface over an in-box agent
+  server; model gateway/metering; alternative engines.
+
+## 10. Relationship to existing plans & reuse decision
+
+- **Reuses**: `RecipeService`, expose-port + managed TLS, secrets, scale-down,
+  platform MCP create/expose — all shipped.
+- **Reuse engine — OpenHands** (MIT, Apache-compatible): packaged, not forked.
+  Considered and rejected: **Open WebUI** (chat-only fit + branding-restricted
+  license); **cmux** (local macOS app, GPL-3.0). See
+  `docs/AGENT-WORKSPACE-SPIKE.md` §"Why reuse OpenHands".
+- **Sibling of** [AGENT-RUNTIME-INBOX-LOOP-DESIGN.md](./AGENT-RUNTIME-INBOX-LOOP-DESIGN.md):
+  same box-as-agent substrate; this is interactive/human-in-the-loop, that is
+  headless/one-shot.
+- **Below** [AGENT-SKILLS-CREWS-DESIGN.md](./AGENT-SKILLS-CREWS-DESIGN.md):
+  single agent, single box; crews are the multi-agent superset.

--- a/docs/PRD-HOSTED-AGENT-WORKSPACE.md
+++ b/docs/PRD-HOSTED-AGENT-WORKSPACE.md
@@ -97,7 +97,7 @@ browser, without my laptop being involved."*
 | R3 | Multiple conversations persist in the box and survive disconnect/reload. | **OpenHands built-in**; live-acceptance pending. |
 | R4 | The exposed agent UI sits behind platform auth. | **New** — route/auth work. |
 | R5 | The Anthropic key is delivered via the secrets mechanism, not a parameter. | **New**. |
-| R6 | A WebUI affordance opens a workspace. | **Shipped (embed)** — `web-ui` "Workspace" tab embeds the box's UI in an iframe; launch-from-UI still to do. |
+| R6 | A WebUI affordance opens a workspace. | **Shipped (embed + zero-click auth)** — `web-ui` "Workspace" tab embeds the box's UI in an iframe and authenticates it seamlessly via `GetWorkspaceAccess` bootstrap; launch-from-UI still to do. |
 | R7 | Workspace lifecycle is audit-logged + scope-gated; build ships to a box. | **Shipped** (inherited). |
 
 **Read of the gap:** the *experience* (R1–R3) is reuse + wiring, proven to load

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -579,6 +579,19 @@ func (c *GRPCClient) GetRecipe(id string) (*pb.Recipe, error) {
 	return resp.Recipe, nil
 }
 
+// GetWorkspaceAccess fetches the zero-click bootstrap URL for an
+// agent-workspace box via gRPC.
+func (c *GRPCClient) GetWorkspaceAccess(name string) (*pb.GetWorkspaceAccessResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := c.recipeClient.GetWorkspaceAccess(ctx, &pb.GetWorkspaceAccessRequest{Name: name})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workspace access: %w", err)
+	}
+	return resp, nil
+}
+
 // DeployRecipe provisions a new dedicated container from a recipe via gRPC.
 func (c *GRPCClient) DeployRecipe(recipeID, name, gpu, backendID, pool string, params map[string]string) (*pb.DeployRecipeResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute) // image + model pulls can take time

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -1034,6 +1034,30 @@ func (c *HTTPClient) GetRecipe(id string) (*pb.Recipe, error) {
 	return out.Recipe, nil
 }
 
+// GetWorkspaceAccess fetches the zero-click bootstrap URL for an
+// agent-workspace box via HTTP.
+func (c *HTTPClient) GetWorkspaceAccess(name string) (*pb.GetWorkspaceAccessResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/recipes/workspace/%s/access", url.PathEscape(name))
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get workspace access: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpError(bodyBytes, resp.StatusCode, "get workspace access")
+	}
+	out := &pb.GetWorkspaceAccessResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
 // DeployRecipe provisions a new dedicated container from a recipe via HTTP.
 func (c *HTTPClient) DeployRecipe(recipeID, name, gpu, backendID, pool string, params map[string]string) (*pb.DeployRecipeResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute) // image + model pulls can take time

--- a/internal/cmd/recipe.go
+++ b/internal/cmd/recipe.go
@@ -31,6 +31,7 @@ type recipeAPI interface {
 	ListRecipes() ([]*pb.Recipe, error)
 	GetRecipe(id string) (*pb.Recipe, error)
 	DeployRecipe(recipeID, name, gpu, backendID, pool string, params map[string]string) (*pb.DeployRecipeResponse, error)
+	GetWorkspaceAccess(name string) (*pb.GetWorkspaceAccessResponse, error)
 	Close() error
 }
 

--- a/internal/cmd/recipe_workspace_access.go
+++ b/internal/cmd/recipe_workspace_access.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var recipeWorkspaceAccessCmd = &cobra.Command{
+	Use:   "workspace-access <name>",
+	Short: "Print the zero-click access URL for an agent-workspace box",
+	Long: `Print a zero-click bootstrap URL for an agent-workspace box.
+
+The daemon reads the box's in-box auth token and returns a URL of the form
+https://<box>-workspace.<domain>/__ws_login?t=<token>. Loading it sets the
+in-box session cookie and redirects to the workspace UI, so the embedded
+console panel authenticates without a sign-in prompt.
+
+  containarium recipe workspace-access ws1 --server <host>`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRecipeWorkspaceAccess,
+}
+
+func init() {
+	recipeCmd.AddCommand(recipeWorkspaceAccessCmd)
+}
+
+func runRecipeWorkspaceAccess(cmd *cobra.Command, args []string) error {
+	c, err := newRecipeClient()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Close() }()
+
+	resp, err := c.GetWorkspaceAccess(args[0])
+	if err != nil {
+		return err
+	}
+	if resp.Url != "" {
+		fmt.Println(resp.Url)
+		return nil
+	}
+	fmt.Printf("token: %s\n", resp.Token)
+	fmt.Println("(no workspace route found; expose container port 8080 to get a URL)")
+	return nil
+}

--- a/internal/server/recipe_server.go
+++ b/internal/server/recipe_server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"google.golang.org/grpc/codes"
@@ -61,6 +62,43 @@ func (s *RecipeServer) GetRecipe(ctx context.Context, req *pb.GetRecipeRequest) 
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
 	return &pb.GetRecipeResponse{Recipe: r}, nil
+}
+
+// GetWorkspaceAccess returns a zero-click bootstrap URL for an agent-workspace
+// box: it reads the box's in-box auth proxy token (written to
+// /opt/wsauth/token by the agent-workspace recipe) and composes the
+// /__ws_login URL the console embeds in an iframe to authenticate the
+// workspace UI without showing a sign-in prompt.
+func (s *RecipeServer) GetWorkspaceAccess(ctx context.Context, req *pb.GetWorkspaceAccessRequest) (*pb.GetWorkspaceAccessResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeContainersRead); err != nil {
+		return nil, err
+	}
+	if req.Name == "" {
+		return nil, status.Error(codes.InvalidArgument, "name is required")
+	}
+	if err := auth.AuthorizeTenant(ctx, req.Name); err != nil {
+		return nil, err
+	}
+
+	containerName := req.Name + "-container"
+	stdout, _, err := s.containers.manager.ExecWithOutput(containerName, []string{"cat", "/opt/wsauth/token"})
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound,
+			"no workspace token on %s (is this an agent-workspace box?): %v", containerName, err)
+	}
+	token := strings.TrimSpace(stdout)
+	if token == "" {
+		return nil, status.Errorf(codes.NotFound, "empty workspace token on %s", containerName)
+	}
+
+	resp := &pb.GetWorkspaceAccessResponse{Token: token}
+	if s.network != nil {
+		// Mirror exposePorts' subdomain scheme: "<name>-workspace".
+		subdomain := req.Name + "-workspace"
+		resp.Url = "https://" + resolveFullDomain(subdomain, s.network.baseDomain) +
+			"/__ws_login?t=" + url.QueryEscape(token)
+	}
+	return resp, nil
 }
 
 // DeployRecipe provisions a new dedicated container from a recipe, runs the

--- a/internal/server/recipe_server.go
+++ b/internal/server/recipe_server.go
@@ -92,7 +92,10 @@ func (s *RecipeServer) GetWorkspaceAccess(ctx context.Context, req *pb.GetWorksp
 	}
 
 	resp := &pb.GetWorkspaceAccessResponse{Token: token}
-	if s.network != nil {
+	// Only compose a URL when routing is actually configured (same precondition
+	// as exposePorts): without a base domain the URL would be domain-less and
+	// unusable, so return just the token and let the caller surface that.
+	if s.network != nil && s.network.baseDomain != "" {
 		// Mirror exposePorts' subdomain scheme: "<name>-workspace".
 		subdomain := req.Name + "-workspace"
 		resp.Url = "https://" + resolveFullDomain(subdomain, s.network.baseDomain) +

--- a/internal/server/recipe_server.go
+++ b/internal/server/recipe_server.go
@@ -70,7 +70,10 @@ func (s *RecipeServer) GetRecipe(ctx context.Context, req *pb.GetRecipeRequest) 
 // /__ws_login URL the console embeds in an iframe to authenticate the
 // workspace UI without showing a sign-in prompt.
 func (s *RecipeServer) GetWorkspaceAccess(ctx context.Context, req *pb.GetWorkspaceAccessRequest) (*pb.GetWorkspaceAccessResponse, error) {
-	if err := auth.RequireScope(ctx, auth.ScopeContainersRead); err != nil {
+	// containers:write, not read: this mints an interactive-access credential
+	// (the in-box session token + a zero-click /__ws_login URL), so it is a
+	// write-class operation — a read-only token must not be able to obtain it.
+	if err := auth.RequireScope(ctx, auth.ScopeContainersWrite); err != nil {
 		return nil, err
 	}
 	if req.Name == "" {

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -139,15 +139,22 @@ recipes:
   # and serves the chat UI; bind mounts need Podman's `:U` so the non-root
   # `openhands` user can write its SQLite DB.
   #
+  # Auth lives IN the box, not at the edge: OpenHands binds to 127.0.0.1 and an
+  # in-box Caddy basic-auth proxy fronts it on the exposed port (:8080). So the
+  # box self-protects — the platform edge just forwards plain HTTP to :8080 and
+  # terminates TLS — and a box is never reachable without credentials. The
+  # auth_password parameter is required for exactly that reason. Validated live
+  # (2026-06-18): no/wrong creds → 401, correct creds → 200; OpenHands itself is
+  # not directly reachable. Auth + transport flow validated end to end in-box.
+  #
   # The Anthropic key/model are set in the OpenHands settings UI on first visit
   # (the run command takes no LLM env). Production hardening: seed credentials
-  # via the tenant secrets mechanism once the env contract is confirmed, and put
-  # platform auth in front of the exposed UI (it is a full coding agent with a
-  # shell). Still pending live acceptance: a real model call (needs a key) and
-  # the expose+auth path. Resource sizing is generous; trim after profiling.
+  # via the tenant secrets mechanism once the env contract is confirmed. Still
+  # pending live acceptance: a real model call (needs a key). Resource sizing is
+  # generous; trim after profiling.
   - id: agent-workspace
     name: Agent Workspace
-    description: Web chat workspace (chat + live preview + multiple persisted sessions) running OpenHands inside an always-on box; co-work with a coding agent in the browser, then ship to a box.
+    description: Web chat workspace (chat + live preview + multiple persisted sessions) running OpenHands inside an always-on box, behind in-box basic auth; co-work with a coding agent in the browser, then ship to a box.
     image: images:ubuntu/24.04
     requires_gpu: false
     resources:
@@ -155,23 +162,56 @@ recipes:
       memory: 8GB
       disk: 60GB
     ports:
-      # The OpenHands web UI — chat, preview, and the conversation list.
-      - container_port: 8000
+      # The in-box auth proxy — fronts the OpenHands UI (chat + preview +
+      # conversation list). OpenHands itself stays on 127.0.0.1.
+      - container_port: 8080
         subdomain: workspace
     parameters:
+      - name: auth_password
+        label: Workspace password
+        description: Password for the in-box basic-auth proxy in front of the workspace UI. Required — the box is never exposed without it.
+        type: password
+        required: true
+      - name: auth_user
+        label: Workspace username
+        description: Username for the in-box basic-auth proxy.
+        type: string
+        default: admin
       - name: openhands_version
         label: OpenHands version
         description: OpenHands Agent Canvas image tag to run (pin for reproducibility).
         type: string
         default: 1.0.0-rc.11
     post_start:
-      - mkdir -p /opt/openhands-state /opt/openhands-projects
-      # Run the OpenHands web app: chat + preview + persisted conversations on
-      # :8000. `:U` chowns the bind mounts to the container's non-root user so
-      # it can write its SQLite state (validated 2026-06-18).
+      - mkdir -p /opt/openhands-state /opt/openhands-projects /opt/wsauth
+      - podman pull docker.io/library/caddy:2 >/dev/null
+      # Run the OpenHands web app bound to localhost: chat + preview + persisted
+      # conversations. `:U` chowns the bind mounts to the container's non-root
+      # user so it can write its SQLite state (validated 2026-06-18).
       - |
         podman run -d --name openhands --restart=always \
-          -p 8000:8000 \
+          -p 127.0.0.1:8000:8000 \
           -v /opt/openhands-state:/home/openhands/.openhands:U \
           -v /opt/openhands-projects:/projects:U \
           "ghcr.io/openhands/agent-canvas:${CONTAINARIUM_PARAM_OPENHANDS_VERSION}"
+      # In-box basic-auth proxy on :8080 → 127.0.0.1:8000. The password is
+      # bcrypt-hashed at deploy; the hash's '$' come from variable expansion and
+      # are not re-expanded by the heredoc. auto_https off: the edge terminates
+      # TLS, the in-box proxy speaks plain HTTP.
+      - |
+        WS_HASH=$(podman run --rm docker.io/library/caddy:2 caddy hash-password --plaintext "$CONTAINARIUM_PARAM_AUTH_PASSWORD")
+        cat > /opt/wsauth/Caddyfile <<EOF
+        {
+          auto_https off
+        }
+        :8080 {
+          basic_auth {
+            $CONTAINARIUM_PARAM_AUTH_USER $WS_HASH
+          }
+          reverse_proxy 127.0.0.1:8000
+        }
+        EOF
+      - |
+        podman run -d --name wsauth --restart=always --network host \
+          -v /opt/wsauth/Caddyfile:/etc/caddy/Caddyfile:ro \
+          docker.io/library/caddy:2

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -113,3 +113,82 @@ recipes:
       # Best-effort assembly: never fail provisioning if the release lacks the
       # artifacts (|| echo keeps the line green under `set -e`).
       - 'if [ -n "$CONTAINARIUM_PARAM_RELEASE" ]; then curl -fsSL "https://raw.githubusercontent.com/$CONTAINARIUM_PARAM_REPO/$CONTAINARIUM_PARAM_RELEASE/scripts/install-agent-runtime.sh" | REPO="$CONTAINARIUM_PARAM_REPO" RELEASE="$CONTAINARIUM_PARAM_RELEASE" bash || echo "agent-runtime assembly skipped/failed for release=$CONTAINARIUM_PARAM_RELEASE; box runs without the in-box loop"; fi'
+
+  # agent-workspace is the HUMAN-IN-THE-LOOP chat workspace: a web chat UI
+  # (Claude/ChatGPT-style) with a live preview pane and multiple persisted
+  # conversations, all running inside one always-on box. Where agent-runtime is
+  # headless (seeded task → artifact.json), this is a place a user sits and
+  # co-works with a coding agent, then ships what they build to a separate box.
+  #
+  # Rather than build a chat UI + agent loop + session store from scratch, this
+  # recipe packages OpenHands (https://github.com/All-Hands-AI/OpenHands, MIT)
+  # as the in-box engine. OpenHands already gives us: a web chat UI, a coding
+  # agent, an in-container workspace + browser/preview, multiple conversations
+  # persisted to disk, and bring-your-own Anthropic key. Containarium's value is
+  # the wrapper: an isolated always-on box, eBPF/audit/secrets trust fabric, and
+  # one-click ship-to-box via the platform MCP. OpenHands' web port is exposed
+  # as a subdomain (the `ports` block) so the whole chat+preview surface is
+  # reachable in the browser; conversations live under /opt/openhands-state in
+  # the box, so "all sessions stored inside a box" holds.
+  #
+  # OpenHands drives a container engine to spawn its per-conversation runtime
+  # sandbox; here it talks to the box's Podman socket (the box already runs OCI
+  # workloads via Podman, same as the ollama/llamacpp recipes), so no
+  # docker-in-docker nesting beyond what those recipes already do.
+  #
+  # SPIKE CAVEAT — this is a first-draft integration, NOT live-validated. Three
+  # things MUST be confirmed on a real box before it ships (see
+  # docs/AGENT-WORKSPACE-SPIKE.md): the OpenHands image tag, the Podman-socket
+  # wiring, and the LiteLLM model id. The Anthropic key is taken as a parameter
+  # for proof-of-path; production must seed it via the secrets mechanism
+  # (AES-256-GCM, mode 0400), never as a deploy-time parameter.
+  - id: agent-workspace
+    name: Agent Workspace
+    description: Web chat workspace (chat + live preview + multiple persisted sessions) running OpenHands inside an always-on box; co-work with a coding agent in the browser, then ship to a box.
+    image: images:ubuntu/24.04
+    requires_gpu: false
+    resources:
+      cpu: "4"
+      memory: 8GB
+      disk: 60GB
+    ports:
+      # The OpenHands web UI — chat, preview, and the conversation list.
+      - container_port: 3000
+        subdomain: workspace
+    parameters:
+      # Optional: blank → OpenHands prompts for the key in its own settings UI
+      # on first visit. SPIKE-only delivery path; production uses secrets.
+      - name: anthropic_api_key
+        label: Anthropic API key
+        description: API key for the in-box coding agent. Leave blank to set it in the OpenHands UI on first visit. SPIKE-only — production seeds this via the secrets mechanism.
+        type: password
+      - name: llm_model
+        label: LLM model
+        description: LiteLLM model id OpenHands passes to the provider (operator-overridable; confirm the current id at live acceptance).
+        type: string
+        default: anthropic/claude-sonnet-4-6
+      - name: openhands_version
+        label: OpenHands version
+        description: OpenHands image tag to run (pin for reproducibility; confirm the latest tag at live acceptance).
+        type: string
+        default: "0.39"
+    post_start:
+      - mkdir -p /etc/containarium /opt/openhands-state
+      # Seed the agent's LLM config into a root-only env-file the app reads.
+      - 'install -m 0600 /dev/null /etc/containarium/agent-workspace.env'
+      - 'printf "LLM_MODEL=%s\n" "$CONTAINARIUM_PARAM_LLM_MODEL" >> /etc/containarium/agent-workspace.env'
+      - 'if [ -n "$CONTAINARIUM_PARAM_ANTHROPIC_API_KEY" ]; then printf "LLM_API_KEY=%s\n" "$CONTAINARIUM_PARAM_ANTHROPIC_API_KEY" >> /etc/containarium/agent-workspace.env; fi'
+      # Expose the box's Podman socket so OpenHands can spawn its runtime sandbox.
+      - systemctl enable --now podman.socket
+      # Run the OpenHands web app: chat + preview + persisted conversations on
+      # :3000, sessions under /opt/openhands-state, talking to Podman for its
+      # per-conversation sandbox.
+      - |
+        podman run -d --name openhands --restart=always \
+          -e SANDBOX_RUNTIME_CONTAINER_IMAGE="docker.all-hands.dev/all-hands-ai/runtime:${CONTAINARIUM_PARAM_OPENHANDS_VERSION}-nikolaik" \
+          -e DOCKER_HOST=unix:///run/podman/podman.sock \
+          --env-file /etc/containarium/agent-workspace.env \
+          -v /run/podman/podman.sock:/run/podman/podman.sock \
+          -v /opt/openhands-state:/.openhands \
+          -p 3000:3000 \
+          "docker.all-hands.dev/all-hands-ai/openhands:${CONTAINARIUM_PARAM_OPENHANDS_VERSION}"

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -194,21 +194,36 @@ recipes:
           -v /opt/openhands-state:/home/openhands/.openhands:U \
           -v /opt/openhands-projects:/projects:U \
           "ghcr.io/openhands/agent-canvas:${CONTAINARIUM_PARAM_OPENHANDS_VERSION}"
-      # In-box basic-auth proxy on :8080 → 127.0.0.1:8000. The password is
-      # bcrypt-hashed at deploy; the hash's '$' come from variable expansion and
-      # are not re-expanded by the heredoc. auto_https off: the edge terminates
-      # TLS, the in-box proxy speaks plain HTTP.
+      # In-box auth proxy on :8080 → 127.0.0.1:8000. Two ways in: HTTP basic
+      # auth, OR a session cookie the proxy itself issues on a successful
+      # basic-auth response. The cookie is SameSite=None so the browser sends it
+      # to this box even from an iframe embedded in the console on another
+      # origin — so after one top-level sign-in the embedded workspace loads with
+      # no prompt (browsers suppress basic-auth prompts in cross-origin iframes).
+      # The cookie value is a per-box random token; the console needs no secret.
+      # The password is bcrypt-hashed at deploy; the hash's '$' come from
+      # variable expansion and are not re-expanded by the heredoc. auto_https
+      # off: the edge terminates TLS, the in-box proxy speaks plain HTTP.
       - |
         WS_HASH=$(podman run --rm docker.io/library/caddy:2 caddy hash-password --plaintext "$CONTAINARIUM_PARAM_AUTH_PASSWORD")
+        WS_TOKEN=$(head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')
         cat > /opt/wsauth/Caddyfile <<EOF
         {
           auto_https off
         }
         :8080 {
-          basic_auth {
-            $CONTAINARIUM_PARAM_AUTH_USER $WS_HASH
+          @authed header_regexp Cookie "ws_auth=$WS_TOKEN"
+          handle @authed {
+            reverse_proxy 127.0.0.1:8000
           }
-          reverse_proxy 127.0.0.1:8000
+          handle {
+            basic_auth {
+              $CONTAINARIUM_PARAM_AUTH_USER $WS_HASH
+            }
+            reverse_proxy 127.0.0.1:8000 {
+              header_down +Set-Cookie "ws_auth=$WS_TOKEN; Path=/; HttpOnly; Secure; SameSite=None"
+            }
+          }
         }
         EOF
       - |

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -207,15 +207,34 @@ recipes:
       - |
         WS_HASH=$(podman run --rm docker.io/library/caddy:2 caddy hash-password --plaintext "$CONTAINARIUM_PARAM_AUTH_PASSWORD")
         WS_TOKEN=$(head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')
+        # Persist the token (mode 0600) so the daemon can read it and hand the
+        # console a zero-click bootstrap URL (RecipeService.GetWorkspaceAccess).
+        printf '%s' "$WS_TOKEN" > /opt/wsauth/token
+        chmod 600 /opt/wsauth/token
         cat > /opt/wsauth/Caddyfile <<EOF
         {
           auto_https off
         }
         :8080 {
+          # Zero-click bootstrap: the console opens /__ws_login?t=<token>; the
+          # proxy sets the SameSite=None cookie and redirects to the app, so no
+          # sign-in prompt is ever shown in the embedded iframe.
+          @login {
+            path /__ws_login
+            query t=$WS_TOKEN
+          }
+          handle @login {
+            header +Set-Cookie "ws_auth=$WS_TOKEN; Path=/; HttpOnly; Secure; SameSite=None"
+            # `redir * / 302`: the explicit `*` matcher keeps Caddy from reading
+            # the leading `/` as a path matcher (which makes the redirect a no-op).
+            redir * / 302
+          }
+          # Cookie path: seamless once the cookie is set.
           @authed header_regexp Cookie "ws_auth=$WS_TOKEN"
           handle @authed {
             reverse_proxy 127.0.0.1:8000
           }
+          # Fallback: HTTP basic auth, which also issues the cookie.
           handle {
             basic_auth {
               $CONTAINARIUM_PARAM_AUTH_USER $WS_HASH

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -185,6 +185,9 @@ recipes:
     post_start:
       - mkdir -p /opt/openhands-state /opt/openhands-projects /opt/wsauth
       - podman pull docker.io/library/caddy:2 >/dev/null
+      # Idempotent: drop any prior containers so a re-run of post_start (retry,
+      # re-deploy) doesn't abort under `set -e` on "name already in use".
+      - podman rm -f openhands wsauth 2>/dev/null || true
       # Run the OpenHands web app bound to localhost: chat + preview + persisted
       # conversations. `:U` chowns the bind mounts to the container's non-root
       # user so it can write its SQLite state (validated 2026-06-18).
@@ -207,6 +210,9 @@ recipes:
       - |
         WS_HASH=$(podman run --rm docker.io/library/caddy:2 caddy hash-password --plaintext "$CONTAINARIUM_PARAM_AUTH_PASSWORD")
         WS_TOKEN=$(head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')
+        # Fail loudly rather than write a malformed auth config (empty hash →
+        # a degenerate basic_auth entry, empty token → no cookie gate).
+        [ -n "$WS_HASH" ] && [ -n "$WS_TOKEN" ] || { echo "agent-workspace: empty auth hash/token; aborting" >&2; exit 1; }
         # Persist the token (mode 0600) so the daemon can read it and hand the
         # console a zero-click bootstrap URL (RecipeService.GetWorkspaceAccess).
         printf '%s' "$WS_TOKEN" > /opt/wsauth/token
@@ -229,8 +235,10 @@ recipes:
             # the leading `/` as a path matcher (which makes the redirect a no-op).
             redir * / 302
           }
-          # Cookie path: seamless once the cookie is set.
-          @authed header_regexp Cookie "ws_auth=$WS_TOKEN"
+          # Cookie path: seamless once the cookie is set. Anchored to the
+          # cookie name=value boundary so a crafted cookie can't slip the token
+          # in as a substring of another value.
+          @authed header_regexp Cookie "(^|;\s*)ws_auth=$WS_TOKEN($|;)"
           handle @authed {
             reverse_proxy 127.0.0.1:8000
           }

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -131,17 +131,20 @@ recipes:
   # reachable in the browser; conversations live under /opt/openhands-state in
   # the box, so "all sessions stored inside a box" holds.
   #
-  # OpenHands drives a container engine to spawn its per-conversation runtime
-  # sandbox; here it talks to the box's Podman socket (the box already runs OCI
-  # workloads via Podman, same as the ollama/llamacpp recipes), so no
-  # docker-in-docker nesting beyond what those recipes already do.
+  # The OpenHands "Agent Canvas" build runs the coding agent IN the app
+  # container (the box is the sandbox) — no docker/podman socket, no separate
+  # runtime image. Conversations persist to the mounted state dir, so "all
+  # sessions stored inside a box" holds. Validated live on a backend
+  # (2026-06-18, see docs/AGENT-WORKSPACE-SPIKE.md): the app comes up on :8000
+  # and serves the chat UI; bind mounts need Podman's `:U` so the non-root
+  # `openhands` user can write its SQLite DB.
   #
-  # SPIKE CAVEAT — this is a first-draft integration, NOT live-validated. Three
-  # things MUST be confirmed on a real box before it ships (see
-  # docs/AGENT-WORKSPACE-SPIKE.md): the OpenHands image tag, the Podman-socket
-  # wiring, and the LiteLLM model id. The Anthropic key is taken as a parameter
-  # for proof-of-path; production must seed it via the secrets mechanism
-  # (AES-256-GCM, mode 0400), never as a deploy-time parameter.
+  # The Anthropic key/model are set in the OpenHands settings UI on first visit
+  # (the run command takes no LLM env). Production hardening: seed credentials
+  # via the tenant secrets mechanism once the env contract is confirmed, and put
+  # platform auth in front of the exposed UI (it is a full coding agent with a
+  # shell). Still pending live acceptance: a real model call (needs a key) and
+  # the expose+auth path. Resource sizing is generous; trim after profiling.
   - id: agent-workspace
     name: Agent Workspace
     description: Web chat workspace (chat + live preview + multiple persisted sessions) running OpenHands inside an always-on box; co-work with a coding agent in the browser, then ship to a box.
@@ -153,42 +156,22 @@ recipes:
       disk: 60GB
     ports:
       # The OpenHands web UI — chat, preview, and the conversation list.
-      - container_port: 3000
+      - container_port: 8000
         subdomain: workspace
     parameters:
-      # Optional: blank → OpenHands prompts for the key in its own settings UI
-      # on first visit. SPIKE-only delivery path; production uses secrets.
-      - name: anthropic_api_key
-        label: Anthropic API key
-        description: API key for the in-box coding agent. Leave blank to set it in the OpenHands UI on first visit. SPIKE-only — production seeds this via the secrets mechanism.
-        type: password
-      - name: llm_model
-        label: LLM model
-        description: LiteLLM model id OpenHands passes to the provider (operator-overridable; confirm the current id at live acceptance).
-        type: string
-        default: anthropic/claude-sonnet-4-6
       - name: openhands_version
         label: OpenHands version
-        description: OpenHands image tag to run (pin for reproducibility; confirm the latest tag at live acceptance).
+        description: OpenHands Agent Canvas image tag to run (pin for reproducibility).
         type: string
-        default: "0.39"
+        default: 1.0.0-rc.11
     post_start:
-      - mkdir -p /etc/containarium /opt/openhands-state
-      # Seed the agent's LLM config into a root-only env-file the app reads.
-      - 'install -m 0600 /dev/null /etc/containarium/agent-workspace.env'
-      - 'printf "LLM_MODEL=%s\n" "$CONTAINARIUM_PARAM_LLM_MODEL" >> /etc/containarium/agent-workspace.env'
-      - 'if [ -n "$CONTAINARIUM_PARAM_ANTHROPIC_API_KEY" ]; then printf "LLM_API_KEY=%s\n" "$CONTAINARIUM_PARAM_ANTHROPIC_API_KEY" >> /etc/containarium/agent-workspace.env; fi'
-      # Expose the box's Podman socket so OpenHands can spawn its runtime sandbox.
-      - systemctl enable --now podman.socket
+      - mkdir -p /opt/openhands-state /opt/openhands-projects
       # Run the OpenHands web app: chat + preview + persisted conversations on
-      # :3000, sessions under /opt/openhands-state, talking to Podman for its
-      # per-conversation sandbox.
+      # :8000. `:U` chowns the bind mounts to the container's non-root user so
+      # it can write its SQLite state (validated 2026-06-18).
       - |
         podman run -d --name openhands --restart=always \
-          -e SANDBOX_RUNTIME_CONTAINER_IMAGE="docker.all-hands.dev/all-hands-ai/runtime:${CONTAINARIUM_PARAM_OPENHANDS_VERSION}-nikolaik" \
-          -e DOCKER_HOST=unix:///run/podman/podman.sock \
-          --env-file /etc/containarium/agent-workspace.env \
-          -v /run/podman/podman.sock:/run/podman/podman.sock \
-          -v /opt/openhands-state:/.openhands \
-          -p 3000:3000 \
-          "docker.all-hands.dev/all-hands-ai/openhands:${CONTAINARIUM_PARAM_OPENHANDS_VERSION}"
+          -p 8000:8000 \
+          -v /opt/openhands-state:/home/openhands/.openhands:U \
+          -v /opt/openhands-projects:/projects:U \
+          "ghcr.io/openhands/agent-canvas:${CONTAINARIUM_PARAM_OPENHANDS_VERSION}"

--- a/pkg/core/recipes/recipes_test.go
+++ b/pkg/core/recipes/recipes_test.go
@@ -1,6 +1,7 @@
 package recipes
 
 import (
+	"strings"
 	"testing"
 
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -26,6 +27,57 @@ func TestEmbeddedCatalogLoads(t *testing.T) {
 		if !r.RequiresGpu {
 			t.Errorf("recipe %q expected requires_gpu=true", id)
 		}
+	}
+}
+
+func TestAgentWorkspaceRecipe(t *testing.T) {
+	m := New()
+	if err := m.LoadEmbedded(); err != nil {
+		t.Fatalf("LoadEmbedded: %v", err)
+	}
+	r, err := m.Get("agent-workspace")
+	if err != nil {
+		t.Fatalf("expected built-in recipe agent-workspace: %v", err)
+	}
+	if r.RequiresGpu {
+		t.Error("agent-workspace should not require a GPU")
+	}
+	// The web chat UI must be exposed as a subdomain so chat + preview are
+	// reachable in the browser.
+	if len(r.Ports) != 1 || r.Ports[0].ContainerPort != 3000 {
+		t.Errorf("agent-workspace should expose the OpenHands web UI on :3000; got %+v", r.Ports)
+	}
+	// post_start must run OpenHands, persist sessions in the box, and wire the
+	// container engine socket for its runtime sandbox.
+	joined := strings.Join(r.PostStart, "\n")
+	for _, want := range []string{
+		"all-hands-ai/openhands",
+		"/opt/openhands-state", // conversations stored inside the box
+		"podman.socket",
+		"-p 3000:3000",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("agent-workspace post_start missing %q", want)
+		}
+	}
+	// The API key is an optional, password-typed parameter (spike delivery);
+	// the model is operator-overridable.
+	params := map[string]*pb.RecipeParam{}
+	for _, p := range r.Parameters {
+		params[p.Name] = p
+	}
+	key := params["anthropic_api_key"]
+	if key == nil {
+		t.Fatal("agent-workspace should declare an anthropic_api_key parameter")
+	}
+	if key.Required {
+		t.Error("anthropic_api_key should be optional (blank → set in OpenHands UI)")
+	}
+	if key.Type != "password" {
+		t.Errorf("anthropic_api_key type: got %q want password", key.Type)
+	}
+	if params["llm_model"] == nil {
+		t.Error("agent-workspace should declare an llm_model parameter")
 	}
 }
 

--- a/pkg/core/recipes/recipes_test.go
+++ b/pkg/core/recipes/recipes_test.go
@@ -43,41 +43,35 @@ func TestAgentWorkspaceRecipe(t *testing.T) {
 		t.Error("agent-workspace should not require a GPU")
 	}
 	// The web chat UI must be exposed as a subdomain so chat + preview are
-	// reachable in the browser.
-	if len(r.Ports) != 1 || r.Ports[0].ContainerPort != 3000 {
-		t.Errorf("agent-workspace should expose the OpenHands web UI on :3000; got %+v", r.Ports)
+	// reachable in the browser (OpenHands Agent Canvas serves on :8000).
+	if len(r.Ports) != 1 || r.Ports[0].ContainerPort != 8000 {
+		t.Errorf("agent-workspace should expose the OpenHands web UI on :8000; got %+v", r.Ports)
 	}
-	// post_start must run OpenHands, persist sessions in the box, and wire the
-	// container engine socket for its runtime sandbox.
+	// post_start must run OpenHands Agent Canvas, persist conversations inside
+	// the box, and chown the bind mounts to the container user (validated live).
 	joined := strings.Join(r.PostStart, "\n")
 	for _, want := range []string{
-		"all-hands-ai/openhands",
+		"openhands/agent-canvas",
 		"/opt/openhands-state", // conversations stored inside the box
-		"podman.socket",
-		"-p 3000:3000",
+		":U",                   // bind mount chowned to the non-root container user
+		"-p 8000:8000",
 	} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("agent-workspace post_start missing %q", want)
 		}
 	}
-	// The API key is an optional, password-typed parameter (spike delivery);
-	// the model is operator-overridable.
-	params := map[string]*pb.RecipeParam{}
+	// The image tag is a pinned, overridable parameter.
+	var ver *pb.RecipeParam
 	for _, p := range r.Parameters {
-		params[p.Name] = p
+		if p.Name == "openhands_version" {
+			ver = p
+		}
 	}
-	key := params["anthropic_api_key"]
-	if key == nil {
-		t.Fatal("agent-workspace should declare an anthropic_api_key parameter")
+	if ver == nil {
+		t.Fatal("agent-workspace should declare an openhands_version parameter")
 	}
-	if key.Required {
-		t.Error("anthropic_api_key should be optional (blank → set in OpenHands UI)")
-	}
-	if key.Type != "password" {
-		t.Errorf("anthropic_api_key type: got %q want password", key.Type)
-	}
-	if params["llm_model"] == nil {
-		t.Error("agent-workspace should declare an llm_model parameter")
+	if ver.Default == "" {
+		t.Error("openhands_version should be pinned to a default tag")
 	}
 }
 

--- a/pkg/core/recipes/recipes_test.go
+++ b/pkg/core/recipes/recipes_test.go
@@ -57,6 +57,8 @@ func TestAgentWorkspaceRecipe(t *testing.T) {
 		"127.0.0.1:8000:8000",  // OpenHands not directly reachable
 		"caddy hash-password",  // password bcrypt-hashed at deploy
 		"basic_auth",           // in-box auth proxy
+		"ws_auth=",             // session-cookie handoff for seamless iframe auth
+		"SameSite=None",        // cookie sent cross-origin from the embedded iframe
 	} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("agent-workspace post_start missing %q", want)

--- a/pkg/core/recipes/recipes_test.go
+++ b/pkg/core/recipes/recipes_test.go
@@ -59,6 +59,8 @@ func TestAgentWorkspaceRecipe(t *testing.T) {
 		"basic_auth",           // in-box auth proxy
 		"ws_auth=",             // session-cookie handoff for seamless iframe auth
 		"SameSite=None",        // cookie sent cross-origin from the embedded iframe
+		"/opt/wsauth/token",    // token persisted for the daemon to vend
+		"/__ws_login",          // zero-click bootstrap route
 	} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("agent-workspace post_start missing %q", want)

--- a/pkg/core/recipes/recipes_test.go
+++ b/pkg/core/recipes/recipes_test.go
@@ -42,36 +42,43 @@ func TestAgentWorkspaceRecipe(t *testing.T) {
 	if r.RequiresGpu {
 		t.Error("agent-workspace should not require a GPU")
 	}
-	// The web chat UI must be exposed as a subdomain so chat + preview are
-	// reachable in the browser (OpenHands Agent Canvas serves on :8000).
-	if len(r.Ports) != 1 || r.Ports[0].ContainerPort != 8000 {
-		t.Errorf("agent-workspace should expose the OpenHands web UI on :8000; got %+v", r.Ports)
+	// The exposed port is the in-box auth proxy (:8080), not OpenHands directly.
+	if len(r.Ports) != 1 || r.Ports[0].ContainerPort != 8080 {
+		t.Errorf("agent-workspace should expose the in-box auth proxy on :8080; got %+v", r.Ports)
 	}
-	// post_start must run OpenHands Agent Canvas, persist conversations inside
-	// the box, and chown the bind mounts to the container user (validated live).
+	// post_start must run OpenHands Agent Canvas bound to localhost, persist
+	// conversations in the box, chown the bind mounts, and stand up the in-box
+	// basic-auth proxy (all validated live 2026-06-18).
 	joined := strings.Join(r.PostStart, "\n")
 	for _, want := range []string{
 		"openhands/agent-canvas",
 		"/opt/openhands-state", // conversations stored inside the box
 		":U",                   // bind mount chowned to the non-root container user
-		"-p 8000:8000",
+		"127.0.0.1:8000:8000",  // OpenHands not directly reachable
+		"caddy hash-password",  // password bcrypt-hashed at deploy
+		"basic_auth",           // in-box auth proxy
 	} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("agent-workspace post_start missing %q", want)
 		}
 	}
-	// The image tag is a pinned, overridable parameter.
-	var ver *pb.RecipeParam
+	// The auth password is required (a box is never exposed without it).
+	params := map[string]*pb.RecipeParam{}
 	for _, p := range r.Parameters {
-		if p.Name == "openhands_version" {
-			ver = p
+		params[p.Name] = p
+	}
+	if pw := params["auth_password"]; pw == nil {
+		t.Fatal("agent-workspace should declare an auth_password parameter")
+	} else {
+		if !pw.Required {
+			t.Error("auth_password must be required (box never exposed without auth)")
+		}
+		if pw.Type != "password" {
+			t.Errorf("auth_password type: got %q want password", pw.Type)
 		}
 	}
-	if ver == nil {
-		t.Fatal("agent-workspace should declare an openhands_version parameter")
-	}
-	if ver.Default == "" {
-		t.Error("openhands_version should be pinned to a default tag")
+	if params["openhands_version"] == nil || params["openhands_version"].Default == "" {
+		t.Error("agent-workspace should pin openhands_version to a default tag")
 	}
 }
 

--- a/pkg/pb/containarium/v1/recipe.pb.go
+++ b/pkg/pb/containarium/v1/recipe.pb.go
@@ -774,6 +774,111 @@ func (x *DeployRecipeResponse) GetMessage() string {
 	return ""
 }
 
+// GetWorkspaceAccessRequest fetches a zero-click access URL for an
+// agent-workspace box.
+type GetWorkspaceAccessRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The box identity (the container is named "<name>-container"), same scheme
+	// as DeployRecipeRequest.name.
+	Name          string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWorkspaceAccessRequest) Reset() {
+	*x = GetWorkspaceAccessRequest{}
+	mi := &file_containarium_v1_recipe_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWorkspaceAccessRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWorkspaceAccessRequest) ProtoMessage() {}
+
+func (x *GetWorkspaceAccessRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_recipe_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWorkspaceAccessRequest.ProtoReflect.Descriptor instead.
+func (*GetWorkspaceAccessRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_recipe_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *GetWorkspaceAccessRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+// GetWorkspaceAccessResponse carries a bootstrap URL the console can load in an
+// iframe to sign the user into the in-box workspace proxy without a prompt.
+type GetWorkspaceAccessResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The in-box auth proxy's per-box session token.
+	Token string `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
+	// Ready-to-embed bootstrap URL (https://<workspace-domain>/__ws_login?t=...);
+	// loading it sets the session cookie and redirects to the workspace UI.
+	Url           string `protobuf:"bytes,2,opt,name=url,proto3" json:"url,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWorkspaceAccessResponse) Reset() {
+	*x = GetWorkspaceAccessResponse{}
+	mi := &file_containarium_v1_recipe_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWorkspaceAccessResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWorkspaceAccessResponse) ProtoMessage() {}
+
+func (x *GetWorkspaceAccessResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_recipe_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWorkspaceAccessResponse.ProtoReflect.Descriptor instead.
+func (*GetWorkspaceAccessResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_recipe_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *GetWorkspaceAccessResponse) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
+func (x *GetWorkspaceAccessResponse) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
 var File_containarium_v1_recipe_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_recipe_proto_rawDesc = "" +
@@ -840,8 +945,15 @@ const file_containarium_v1_recipe_proto_rawDesc = "" +
 	"\x14DeployRecipeResponse\x128\n" +
 	"\tcontainer\x18\x01 \x01(\v2\x1a.containarium.v1.ContainerR\tcontainer\x12\x10\n" +
 	"\x03url\x18\x02 \x01(\tR\x03url\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage2\x86\x06\n" +
-	"\rRecipeService\x12\xd3\x01\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"/\n" +
+	"\x19GetWorkspaceAccessRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"D\n" +
+	"\x1aGetWorkspaceAccessResponse\x12\x14\n" +
+	"\x05token\x18\x01 \x01(\tR\x05token\x12\x10\n" +
+	"\x03url\x18\x02 \x01(\tR\x03url2\xda\b\n" +
+	"\rRecipeService\x12\xd1\x02\n" +
+	"\x12GetWorkspaceAccess\x12*.containarium.v1.GetWorkspaceAccessRequest\x1a+.containarium.v1.GetWorkspaceAccessResponse\"\xe1\x01\x92A\xb2\x01\n" +
+	"\aRecipes\x12\x18Get workspace access URL\x1a\x8c\x01Returns a zero-click bootstrap URL for an agent-workspace box, embeddable in the console to authenticate the in-box workspace UI seamlessly.\x82\xd3\xe4\x93\x02%\x12#/v1/recipes/workspace/{name}/access\x12\xd3\x01\n" +
 	"\vListRecipes\x12#.containarium.v1.ListRecipesRequest\x1a$.containarium.v1.ListRecipesResponse\"y\x92Ac\n" +
 	"\aRecipes\x12\fList recipes\x1aJReturns all built-in recipes that can be deployed as dedicated containers.\x82\xd3\xe4\x93\x02\r\x12\v/v1/recipes\x12\xe9\x01\n" +
 	"\tGetRecipe\x12!.containarium.v1.GetRecipeRequest\x1a\".containarium.v1.GetRecipeResponse\"\x94\x01\x92Ay\n" +
@@ -862,42 +974,46 @@ func file_containarium_v1_recipe_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_recipe_proto_rawDescData
 }
 
-var file_containarium_v1_recipe_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_containarium_v1_recipe_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_containarium_v1_recipe_proto_goTypes = []any{
-	(*RecipeResources)(nil),      // 0: containarium.v1.RecipeResources
-	(*RecipePort)(nil),           // 1: containarium.v1.RecipePort
-	(*RecipeVolume)(nil),         // 2: containarium.v1.RecipeVolume
-	(*RecipeParam)(nil),          // 3: containarium.v1.RecipeParam
-	(*Recipe)(nil),               // 4: containarium.v1.Recipe
-	(*ListRecipesRequest)(nil),   // 5: containarium.v1.ListRecipesRequest
-	(*ListRecipesResponse)(nil),  // 6: containarium.v1.ListRecipesResponse
-	(*GetRecipeRequest)(nil),     // 7: containarium.v1.GetRecipeRequest
-	(*GetRecipeResponse)(nil),    // 8: containarium.v1.GetRecipeResponse
-	(*DeployRecipeRequest)(nil),  // 9: containarium.v1.DeployRecipeRequest
-	(*DeployRecipeResponse)(nil), // 10: containarium.v1.DeployRecipeResponse
-	nil,                          // 11: containarium.v1.Recipe.EnvEntry
-	nil,                          // 12: containarium.v1.DeployRecipeRequest.ParametersEntry
-	(*Container)(nil),            // 13: containarium.v1.Container
+	(*RecipeResources)(nil),            // 0: containarium.v1.RecipeResources
+	(*RecipePort)(nil),                 // 1: containarium.v1.RecipePort
+	(*RecipeVolume)(nil),               // 2: containarium.v1.RecipeVolume
+	(*RecipeParam)(nil),                // 3: containarium.v1.RecipeParam
+	(*Recipe)(nil),                     // 4: containarium.v1.Recipe
+	(*ListRecipesRequest)(nil),         // 5: containarium.v1.ListRecipesRequest
+	(*ListRecipesResponse)(nil),        // 6: containarium.v1.ListRecipesResponse
+	(*GetRecipeRequest)(nil),           // 7: containarium.v1.GetRecipeRequest
+	(*GetRecipeResponse)(nil),          // 8: containarium.v1.GetRecipeResponse
+	(*DeployRecipeRequest)(nil),        // 9: containarium.v1.DeployRecipeRequest
+	(*DeployRecipeResponse)(nil),       // 10: containarium.v1.DeployRecipeResponse
+	(*GetWorkspaceAccessRequest)(nil),  // 11: containarium.v1.GetWorkspaceAccessRequest
+	(*GetWorkspaceAccessResponse)(nil), // 12: containarium.v1.GetWorkspaceAccessResponse
+	nil,                                // 13: containarium.v1.Recipe.EnvEntry
+	nil,                                // 14: containarium.v1.DeployRecipeRequest.ParametersEntry
+	(*Container)(nil),                  // 15: containarium.v1.Container
 }
 var file_containarium_v1_recipe_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.Recipe.resources:type_name -> containarium.v1.RecipeResources
 	1,  // 1: containarium.v1.Recipe.ports:type_name -> containarium.v1.RecipePort
 	2,  // 2: containarium.v1.Recipe.volumes:type_name -> containarium.v1.RecipeVolume
-	11, // 3: containarium.v1.Recipe.env:type_name -> containarium.v1.Recipe.EnvEntry
+	13, // 3: containarium.v1.Recipe.env:type_name -> containarium.v1.Recipe.EnvEntry
 	3,  // 4: containarium.v1.Recipe.parameters:type_name -> containarium.v1.RecipeParam
 	4,  // 5: containarium.v1.ListRecipesResponse.recipes:type_name -> containarium.v1.Recipe
 	4,  // 6: containarium.v1.GetRecipeResponse.recipe:type_name -> containarium.v1.Recipe
-	12, // 7: containarium.v1.DeployRecipeRequest.parameters:type_name -> containarium.v1.DeployRecipeRequest.ParametersEntry
+	14, // 7: containarium.v1.DeployRecipeRequest.parameters:type_name -> containarium.v1.DeployRecipeRequest.ParametersEntry
 	0,  // 8: containarium.v1.DeployRecipeRequest.resource_overrides:type_name -> containarium.v1.RecipeResources
-	13, // 9: containarium.v1.DeployRecipeResponse.container:type_name -> containarium.v1.Container
-	5,  // 10: containarium.v1.RecipeService.ListRecipes:input_type -> containarium.v1.ListRecipesRequest
-	7,  // 11: containarium.v1.RecipeService.GetRecipe:input_type -> containarium.v1.GetRecipeRequest
-	9,  // 12: containarium.v1.RecipeService.DeployRecipe:input_type -> containarium.v1.DeployRecipeRequest
-	6,  // 13: containarium.v1.RecipeService.ListRecipes:output_type -> containarium.v1.ListRecipesResponse
-	8,  // 14: containarium.v1.RecipeService.GetRecipe:output_type -> containarium.v1.GetRecipeResponse
-	10, // 15: containarium.v1.RecipeService.DeployRecipe:output_type -> containarium.v1.DeployRecipeResponse
-	13, // [13:16] is the sub-list for method output_type
-	10, // [10:13] is the sub-list for method input_type
+	15, // 9: containarium.v1.DeployRecipeResponse.container:type_name -> containarium.v1.Container
+	11, // 10: containarium.v1.RecipeService.GetWorkspaceAccess:input_type -> containarium.v1.GetWorkspaceAccessRequest
+	5,  // 11: containarium.v1.RecipeService.ListRecipes:input_type -> containarium.v1.ListRecipesRequest
+	7,  // 12: containarium.v1.RecipeService.GetRecipe:input_type -> containarium.v1.GetRecipeRequest
+	9,  // 13: containarium.v1.RecipeService.DeployRecipe:input_type -> containarium.v1.DeployRecipeRequest
+	12, // 14: containarium.v1.RecipeService.GetWorkspaceAccess:output_type -> containarium.v1.GetWorkspaceAccessResponse
+	6,  // 15: containarium.v1.RecipeService.ListRecipes:output_type -> containarium.v1.ListRecipesResponse
+	8,  // 16: containarium.v1.RecipeService.GetRecipe:output_type -> containarium.v1.GetRecipeResponse
+	10, // 17: containarium.v1.RecipeService.DeployRecipe:output_type -> containarium.v1.DeployRecipeResponse
+	14, // [14:18] is the sub-list for method output_type
+	10, // [10:14] is the sub-list for method input_type
 	10, // [10:10] is the sub-list for extension type_name
 	10, // [10:10] is the sub-list for extension extendee
 	0,  // [0:10] is the sub-list for field type_name
@@ -915,7 +1031,7 @@ func file_containarium_v1_recipe_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_recipe_proto_rawDesc), len(file_containarium_v1_recipe_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/pb/containarium/v1/recipe.pb.gw.go
+++ b/pkg/pb/containarium/v1/recipe.pb.gw.go
@@ -35,6 +35,45 @@ var (
 	_ = metadata.Join
 )
 
+func request_RecipeService_GetWorkspaceAccess_0(ctx context.Context, marshaler runtime.Marshaler, client RecipeServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetWorkspaceAccessRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+	protoReq.Name, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+	msg, err := client.GetWorkspaceAccess(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_RecipeService_GetWorkspaceAccess_0(ctx context.Context, marshaler runtime.Marshaler, server RecipeServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetWorkspaceAccessRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+	protoReq.Name, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+	msg, err := server.GetWorkspaceAccess(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_RecipeService_ListRecipes_0(ctx context.Context, marshaler runtime.Marshaler, client RecipeServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq ListRecipesRequest
@@ -146,6 +185,26 @@ func local_request_RecipeService_DeployRecipe_0(ctx context.Context, marshaler r
 // Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterRecipeServiceHandlerFromEndpoint instead.
 // GRPC interceptors will not work for this type of registration. To use interceptors, you must use the "runtime.WithMiddlewares" option in the "runtime.NewServeMux" call.
 func RegisterRecipeServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux, server RecipeServiceServer) error {
+	mux.Handle(http.MethodGet, pattern_RecipeService_GetWorkspaceAccess_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.RecipeService/GetWorkspaceAccess", runtime.WithHTTPPathPattern("/v1/recipes/workspace/{name}/access"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_RecipeService_GetWorkspaceAccess_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_RecipeService_GetWorkspaceAccess_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_RecipeService_ListRecipes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -246,6 +305,23 @@ func RegisterRecipeServiceHandler(ctx context.Context, mux *runtime.ServeMux, co
 // doesn't go through the normal gRPC flow (creating a gRPC client etc.) then it will be up to the passed in
 // "RecipeServiceClient" to call the correct interceptors. This client ignores the HTTP middlewares.
 func RegisterRecipeServiceHandlerClient(ctx context.Context, mux *runtime.ServeMux, client RecipeServiceClient) error {
+	mux.Handle(http.MethodGet, pattern_RecipeService_GetWorkspaceAccess_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.RecipeService/GetWorkspaceAccess", runtime.WithHTTPPathPattern("/v1/recipes/workspace/{name}/access"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_RecipeService_GetWorkspaceAccess_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_RecipeService_GetWorkspaceAccess_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_RecipeService_ListRecipes_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -301,13 +377,15 @@ func RegisterRecipeServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 }
 
 var (
-	pattern_RecipeService_ListRecipes_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "recipes"}, ""))
-	pattern_RecipeService_GetRecipe_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "recipes", "id"}, ""))
-	pattern_RecipeService_DeployRecipe_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "recipes", "recipe_id", "deploy"}, ""))
+	pattern_RecipeService_GetWorkspaceAccess_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"v1", "recipes", "workspace", "name", "access"}, ""))
+	pattern_RecipeService_ListRecipes_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "recipes"}, ""))
+	pattern_RecipeService_GetRecipe_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "recipes", "id"}, ""))
+	pattern_RecipeService_DeployRecipe_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "recipes", "recipe_id", "deploy"}, ""))
 )
 
 var (
-	forward_RecipeService_ListRecipes_0  = runtime.ForwardResponseMessage
-	forward_RecipeService_GetRecipe_0    = runtime.ForwardResponseMessage
-	forward_RecipeService_DeployRecipe_0 = runtime.ForwardResponseMessage
+	forward_RecipeService_GetWorkspaceAccess_0 = runtime.ForwardResponseMessage
+	forward_RecipeService_ListRecipes_0        = runtime.ForwardResponseMessage
+	forward_RecipeService_GetRecipe_0          = runtime.ForwardResponseMessage
+	forward_RecipeService_DeployRecipe_0       = runtime.ForwardResponseMessage
 )

--- a/pkg/pb/containarium/v1/recipe_grpc.pb.go
+++ b/pkg/pb/containarium/v1/recipe_grpc.pb.go
@@ -19,9 +19,10 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	RecipeService_ListRecipes_FullMethodName  = "/containarium.v1.RecipeService/ListRecipes"
-	RecipeService_GetRecipe_FullMethodName    = "/containarium.v1.RecipeService/GetRecipe"
-	RecipeService_DeployRecipe_FullMethodName = "/containarium.v1.RecipeService/DeployRecipe"
+	RecipeService_GetWorkspaceAccess_FullMethodName = "/containarium.v1.RecipeService/GetWorkspaceAccess"
+	RecipeService_ListRecipes_FullMethodName        = "/containarium.v1.RecipeService/ListRecipes"
+	RecipeService_GetRecipe_FullMethodName          = "/containarium.v1.RecipeService/GetRecipe"
+	RecipeService_DeployRecipe_FullMethodName       = "/containarium.v1.RecipeService/DeployRecipe"
 )
 
 // RecipeServiceClient is the client API for RecipeService service.
@@ -31,6 +32,10 @@ const (
 // RecipeService provides one-command deployment of declarative GPU/app
 // recipes onto Containarium backends.
 type RecipeServiceClient interface {
+	// GetWorkspaceAccess returns a zero-click bootstrap URL for an
+	// agent-workspace box: it reads the box's in-box auth token and composes the
+	// URL the console embeds to sign the user in without a prompt.
+	GetWorkspaceAccess(ctx context.Context, in *GetWorkspaceAccessRequest, opts ...grpc.CallOption) (*GetWorkspaceAccessResponse, error)
 	// ListRecipes returns all available built-in recipes.
 	ListRecipes(ctx context.Context, in *ListRecipesRequest, opts ...grpc.CallOption) (*ListRecipesResponse, error)
 	// GetRecipe returns a single recipe definition by ID.
@@ -45,6 +50,16 @@ type recipeServiceClient struct {
 
 func NewRecipeServiceClient(cc grpc.ClientConnInterface) RecipeServiceClient {
 	return &recipeServiceClient{cc}
+}
+
+func (c *recipeServiceClient) GetWorkspaceAccess(ctx context.Context, in *GetWorkspaceAccessRequest, opts ...grpc.CallOption) (*GetWorkspaceAccessResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetWorkspaceAccessResponse)
+	err := c.cc.Invoke(ctx, RecipeService_GetWorkspaceAccess_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *recipeServiceClient) ListRecipes(ctx context.Context, in *ListRecipesRequest, opts ...grpc.CallOption) (*ListRecipesResponse, error) {
@@ -84,6 +99,10 @@ func (c *recipeServiceClient) DeployRecipe(ctx context.Context, in *DeployRecipe
 // RecipeService provides one-command deployment of declarative GPU/app
 // recipes onto Containarium backends.
 type RecipeServiceServer interface {
+	// GetWorkspaceAccess returns a zero-click bootstrap URL for an
+	// agent-workspace box: it reads the box's in-box auth token and composes the
+	// URL the console embeds to sign the user in without a prompt.
+	GetWorkspaceAccess(context.Context, *GetWorkspaceAccessRequest) (*GetWorkspaceAccessResponse, error)
 	// ListRecipes returns all available built-in recipes.
 	ListRecipes(context.Context, *ListRecipesRequest) (*ListRecipesResponse, error)
 	// GetRecipe returns a single recipe definition by ID.
@@ -100,6 +119,9 @@ type RecipeServiceServer interface {
 // pointer dereference when methods are called.
 type UnimplementedRecipeServiceServer struct{}
 
+func (UnimplementedRecipeServiceServer) GetWorkspaceAccess(context.Context, *GetWorkspaceAccessRequest) (*GetWorkspaceAccessResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetWorkspaceAccess not implemented")
+}
 func (UnimplementedRecipeServiceServer) ListRecipes(context.Context, *ListRecipesRequest) (*ListRecipesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListRecipes not implemented")
 }
@@ -128,6 +150,24 @@ func RegisterRecipeServiceServer(s grpc.ServiceRegistrar, srv RecipeServiceServe
 		t.testEmbeddedByValue()
 	}
 	s.RegisterService(&RecipeService_ServiceDesc, srv)
+}
+
+func _RecipeService_GetWorkspaceAccess_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetWorkspaceAccessRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RecipeServiceServer).GetWorkspaceAccess(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RecipeService_GetWorkspaceAccess_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RecipeServiceServer).GetWorkspaceAccess(ctx, req.(*GetWorkspaceAccessRequest))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _RecipeService_ListRecipes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -191,6 +231,10 @@ var RecipeService_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "containarium.v1.RecipeService",
 	HandlerType: (*RecipeServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "GetWorkspaceAccess",
+			Handler:    _RecipeService_GetWorkspaceAccess_Handler,
+		},
 		{
 			MethodName: "ListRecipes",
 			Handler:    _RecipeService_ListRecipes_Handler,

--- a/proto/containarium/v1/recipe.proto
+++ b/proto/containarium/v1/recipe.proto
@@ -163,9 +163,42 @@ message DeployRecipeResponse {
   string message = 3;
 }
 
+// GetWorkspaceAccessRequest fetches a zero-click access URL for an
+// agent-workspace box.
+message GetWorkspaceAccessRequest {
+  // The box identity (the container is named "<name>-container"), same scheme
+  // as DeployRecipeRequest.name.
+  string name = 1;
+}
+
+// GetWorkspaceAccessResponse carries a bootstrap URL the console can load in an
+// iframe to sign the user into the in-box workspace proxy without a prompt.
+message GetWorkspaceAccessResponse {
+  // The in-box auth proxy's per-box session token.
+  string token = 1;
+
+  // Ready-to-embed bootstrap URL (https://<workspace-domain>/__ws_login?t=...);
+  // loading it sets the session cookie and redirects to the workspace UI.
+  string url = 2;
+}
+
 // RecipeService provides one-command deployment of declarative GPU/app
 // recipes onto Containarium backends.
 service RecipeService {
+  // GetWorkspaceAccess returns a zero-click bootstrap URL for an
+  // agent-workspace box: it reads the box's in-box auth token and composes the
+  // URL the console embeds to sign the user in without a prompt.
+  rpc GetWorkspaceAccess(GetWorkspaceAccessRequest) returns (GetWorkspaceAccessResponse) {
+    option (google.api.http) = {
+      get: "/v1/recipes/workspace/{name}/access"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get workspace access URL";
+      description: "Returns a zero-click bootstrap URL for an agent-workspace box, embeddable in the console to authenticate the in-box workspace UI seamlessly.";
+      tags: "Recipes";
+    };
+  }
+
   // ListRecipes returns all available built-in recipes.
   rpc ListRecipes(ListRecipesRequest) returns (ListRecipesResponse) {
     option (google.api.http) = {

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -324,7 +324,7 @@ export default function Home() {
             {viewTab === 6 && <AuditView server={activeServer} />}
             {viewTab === 7 && <AlertsView server={activeServer} />}
             {viewTab === 8 && <VersionsView server={activeServer} />}
-            {viewTab === 9 && <WorkspaceView routes={routes} />}
+            {viewTab === 9 && <WorkspaceView server={activeServer} routes={routes} />}
           </div>
         </>
       ) : (

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -5,7 +5,7 @@ import dynamic from 'next/dynamic';
 import { usePathname } from 'next/navigation';
 import {
   Server as ServerIcon, LayoutGrid, Network, Activity, BarChart2,
-  Shield, ClipboardList, Bell, Loader2, RefreshCw
+  Shield, ClipboardList, Bell, Loader2, RefreshCw, Bot
 } from 'lucide-react';
 import AppBar from '@/src/components/layout/AppBar';
 import ServerTabs from '@/src/components/layout/ServerTabs';
@@ -26,6 +26,7 @@ import SecurityView from '@/src/components/security/SecurityView';
 import AuditView from '@/src/components/audit/AuditView';
 import AlertsView from '@/src/components/alerts/AlertsView';
 import VersionsView from '@/src/components/versions/VersionsView';
+import WorkspaceView from '@/src/components/workspace/WorkspaceView';
 import { useServers } from '@/src/lib/hooks/useServers';
 import { useContainers, CreateContainerProgress } from '@/src/lib/hooks/useContainers';
 import { useMetrics } from '@/src/lib/hooks/useMetrics';
@@ -41,7 +42,7 @@ const TerminalDialog = dynamic(
   { ssr: false }
 );
 
-const TAB_PATHS = ['/containers/', '/apps/', '/network/', '/traffic/', '/monitoring/', '/security/', '/audit/', '/alerts/', '/versions/'] as const;
+const TAB_PATHS = ['/containers/', '/apps/', '/network/', '/traffic/', '/monitoring/', '/security/', '/audit/', '/alerts/', '/versions/', '/workspace/'] as const;
 const TAB_INDICES: Record<string, number> = {
   '/': 0,
   '/containers/': 0,
@@ -53,6 +54,7 @@ const TAB_INDICES: Record<string, number> = {
   '/audit/': 6,
   '/alerts/': 7,
   '/versions/': 8,
+  '/workspace/': 9,
 };
 
 const TABS = [
@@ -65,6 +67,7 @@ const TABS = [
   { label: 'Audit',      icon: ClipboardList },
   { label: 'Alerts',     icon: Bell },
   { label: 'Versions',   icon: RefreshCw },
+  { label: 'Workspace',  icon: Bot },
 ] as const;
 
 export default function Home() {
@@ -321,6 +324,7 @@ export default function Home() {
             {viewTab === 6 && <AuditView server={activeServer} />}
             {viewTab === 7 && <AlertsView server={activeServer} />}
             {viewTab === 8 && <VersionsView server={activeServer} />}
+            {viewTab === 9 && <WorkspaceView routes={routes} />}
           </div>
         </>
       ) : (

--- a/web-ui/src/components/workspace/WorkspaceView.tsx
+++ b/web-ui/src/components/workspace/WorkspaceView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo, useEffect, useCallback } from 'react';
-import { Bot, ExternalLink, RefreshCw, Loader2 } from 'lucide-react';
+import { Bot, ExternalLink, RefreshCw, Loader2, MessagesSquare, SlidersHorizontal } from 'lucide-react';
 import { ProxyRoute } from '@/src/types/app';
 import { Server } from '@/src/types/server';
 import { getClient } from '@/src/lib/api/client';
@@ -15,11 +15,16 @@ import { getClient } from '@/src/lib/api/client';
  * container port 8080); we discover those routes from the network route list.
  *
  * Zero-click auth: the daemon's GetWorkspaceAccess returns a bootstrap URL
- * (https://<box>-workspace.<domain>/__ws_login?t=<token>). Loading it in the
- * iframe sets the in-box SameSite=None session cookie and redirects to the
- * workspace UI, so no sign-in prompt is ever shown. If that lookup fails (older
- * box, no route), we fall back to the plain workspace URL and surface the
- * "Open in new tab to sign in" path.
+ * (https://<box>-workspace.<domain>/__ws_login?t=<token>) that sets the in-box
+ * SameSite=None session cookie and redirects to the workspace UI, so no sign-in
+ * prompt is shown.
+ *
+ * Model provider + key: rather than reimplement OpenHands' (internal, fast-
+ * moving, session-key-gated) settings API in our chrome, the "Model setup"
+ * view deep-links the iframe to OpenHands' own Settings → LLM page
+ * (/settings/llm), which already supports Anthropic, OpenAI/Codex, Gemini,
+ * Mistral, and any LiteLLM provider, plus saved profiles. The bootstrap cookie
+ * set by the chat view authenticates that page too.
  */
 export default function WorkspaceView({ server, routes }: { server: Server; routes: ProxyRoute[] }) {
   const workspaces = useMemo(
@@ -35,9 +40,10 @@ export default function WorkspaceView({ server, routes }: { server: Server; rout
   const activeDomain = active?.fullDomain;
   const activeName = active?.username;
 
-  const [src, setSrc] = useState<string>('');
+  const [bootstrapSrc, setBootstrapSrc] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const [needsSignin, setNeedsSignin] = useState(false);
+  const [tab, setTab] = useState<'chat' | 'settings'>('chat');
   const [reloadKey, setReloadKey] = useState(0);
 
   const loadAccess = useCallback(async () => {
@@ -46,17 +52,15 @@ export default function WorkspaceView({ server, routes }: { server: Server; rout
     setLoading(true);
     setNeedsSignin(false);
     try {
-      // Prefer the zero-click bootstrap URL from the daemon.
       const access = activeName ? await getClient(server).getWorkspaceAccess(activeName) : null;
       if (access?.url) {
-        setSrc(access.url);
+        setBootstrapSrc(access.url);
       } else {
-        setSrc(fallback);
+        setBootstrapSrc(fallback);
         setNeedsSignin(true);
       }
     } catch {
-      // Older box / no token endpoint — fall back to manual sign-in.
-      setSrc(fallback);
+      setBootstrapSrc(fallback);
       setNeedsSignin(true);
     } finally {
       setLoading(false);
@@ -82,9 +86,28 @@ export default function WorkspaceView({ server, routes }: { server: Server; rout
     );
   }
 
+  // Chat view loads the bootstrap URL (sets the cookie, lands on the app).
+  // Model setup deep-links to OpenHands' own LLM settings; the cookie set by the
+  // chat view's bootstrap load authenticates it.
+  const iframeSrc = tab === 'settings' ? `https://${activeDomain}/settings/llm` : bootstrapSrc;
+
+  const tabBtn = (id: 'chat' | 'settings', label: string, Icon: typeof MessagesSquare) => (
+    <button
+      onClick={() => setTab(id)}
+      className={[
+        'flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs transition-colors',
+        tab === id
+          ? 'bg-[var(--surface-2)] text-[var(--text)]'
+          : 'text-[var(--text-secondary)] hover:bg-[var(--surface-2)]',
+      ].join(' ')}
+    >
+      <Icon size={13} /> {label}
+    </button>
+  );
+
   return (
     <div className="flex h-[calc(100vh-150px)] flex-col">
-      <div className="flex items-center gap-3 border-b border-[var(--border-subtle)] bg-[var(--surface)] px-4 py-2 shrink-0">
+      <div className="flex items-center gap-2 border-b border-[var(--border-subtle)] bg-[var(--surface)] px-4 py-2 shrink-0">
         <Bot size={14} className="text-[var(--accent)]" />
         {workspaces.length > 1 ? (
           <select
@@ -101,6 +124,10 @@ export default function WorkspaceView({ server, routes }: { server: Server; rout
         ) : (
           <span className="text-xs font-medium text-[var(--text)]">{activeDomain}</span>
         )}
+        <div className="ml-2 flex items-center gap-1">
+          {tabBtn('chat', 'Chat', MessagesSquare)}
+          {tabBtn('settings', 'Model setup', SlidersHorizontal)}
+        </div>
         {needsSignin && (
           <span className="text-xs text-[var(--c-amber)]">sign in once in a new tab →</span>
         )}
@@ -113,7 +140,7 @@ export default function WorkspaceView({ server, routes }: { server: Server; rout
             <RefreshCw size={13} />
           </button>
           <a
-            href={src || `https://${activeDomain}`}
+            href={iframeSrc || `https://${activeDomain}`}
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-1.5 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
@@ -122,15 +149,20 @@ export default function WorkspaceView({ server, routes }: { server: Server; rout
           </a>
         </div>
       </div>
+      {tab === 'settings' && (
+        <div className="border-b border-[var(--border-subtle)] bg-[var(--surface)] px-4 py-1.5 text-xs text-[var(--text-muted)]">
+          Pick your provider and paste an API key — Anthropic, OpenAI / Codex, Google Gemini, Mistral, or any LiteLLM model. Saved per box; you can keep multiple profiles.
+        </div>
+      )}
       <div className="relative flex-1">
-        {loading || !src ? (
+        {loading || !iframeSrc ? (
           <div className="flex h-full items-center justify-center">
             <Loader2 size={22} className="animate-spin text-[var(--text-secondary)]" />
           </div>
         ) : (
           <iframe
-            key={`${src}-${reloadKey}`}
-            src={src}
+            key={`${tab}-${activeDomain}-${reloadKey}`}
+            src={iframeSrc}
             className="absolute inset-0 h-full w-full border-0"
             title={`Agent workspace — ${activeDomain}`}
           />

--- a/web-ui/src/components/workspace/WorkspaceView.tsx
+++ b/web-ui/src/components/workspace/WorkspaceView.tsx
@@ -13,12 +13,13 @@ import { ProxyRoute } from '@/src/types/app';
  * container port 8080). We discover those routes from the network route list
  * rather than calling a new endpoint.
  *
- * Auth nuance: the workspace is protected by in-box HTTP basic auth, and
- * browsers usually suppress the basic-auth prompt inside a cross-origin
- * iframe. So the flow is: open the workspace once in a new tab to sign in
- * (the browser then caches the credentials for that origin), after which the
- * embedded iframe loads authenticated. The "Open in new tab" action is kept
- * prominent for exactly that reason.
+ * Auth nuance: the workspace is protected by an in-box auth proxy, and
+ * browsers suppress the basic-auth prompt inside a cross-origin iframe. So the
+ * flow is: sign in ONCE in a new tab — the in-box proxy then issues a
+ * SameSite=None session cookie, which the browser sends to the box even from
+ * this embedded iframe, so every load afterward is seamless (no prompt). The
+ * "Open in new tab to sign in" action is the one-time bootstrap; "Reload"
+ * re-renders the iframe once the cookie is set.
  */
 export default function WorkspaceView({ routes }: { routes: ProxyRoute[] }) {
   const workspaces = useMemo(

--- a/web-ui/src/components/workspace/WorkspaceView.tsx
+++ b/web-ui/src/components/workspace/WorkspaceView.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { Bot, ExternalLink, RefreshCw } from 'lucide-react';
+import { ProxyRoute } from '@/src/types/app';
+
+/**
+ * WorkspaceView embeds an agent-workspace box's web chat UI (OpenHands,
+ * deployed via the `agent-workspace` recipe) in an iframe, so users can
+ * co-work with a coding agent without leaving the console.
+ *
+ * The box exposes its in-box auth proxy on the `workspace` subdomain (recipe
+ * container port 8080). We discover those routes from the network route list
+ * rather than calling a new endpoint.
+ *
+ * Auth nuance: the workspace is protected by in-box HTTP basic auth, and
+ * browsers usually suppress the basic-auth prompt inside a cross-origin
+ * iframe. So the flow is: open the workspace once in a new tab to sign in
+ * (the browser then caches the credentials for that origin), after which the
+ * embedded iframe loads authenticated. The "Open in new tab" action is kept
+ * prominent for exactly that reason.
+ */
+export default function WorkspaceView({ routes }: { routes: ProxyRoute[] }) {
+  const workspaces = useMemo(
+    () =>
+      (routes || []).filter(
+        (r) => r.active && (r.subdomain?.includes('workspace') || r.port === 8080)
+      ),
+    [routes]
+  );
+
+  const [selected, setSelected] = useState<string>('');
+  const active = workspaces.find((w) => w.fullDomain === selected) ?? workspaces[0];
+  const [reloadKey, setReloadKey] = useState(0);
+
+  if (workspaces.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-24">
+        <Bot size={28} className="text-[var(--text-muted)]" />
+        <p className="text-sm font-medium text-[var(--text-secondary)]">No agent workspace found</p>
+        <p className="max-w-md text-center text-xs text-[var(--text-muted)]">
+          Deploy one, then expose its UI on the <code className="rounded bg-[var(--surface-2)] px-1">workspace</code> subdomain:
+        </p>
+        <code className="rounded bg-[var(--surface-2)] px-2 py-1 text-xs text-[var(--text-secondary)]">
+          containarium recipe deploy agent-workspace ws1 --param auth_password=…
+        </code>
+      </div>
+    );
+  }
+
+  const src = `https://${active.fullDomain}`;
+
+  return (
+    <div className="flex h-[calc(100vh-150px)] flex-col">
+      <div className="flex items-center gap-3 border-b border-[var(--border-subtle)] bg-[var(--surface)] px-4 py-2 shrink-0">
+        <Bot size={14} className="text-[var(--accent)]" />
+        {workspaces.length > 1 ? (
+          <select
+            value={active.fullDomain}
+            onChange={(e) => setSelected(e.target.value)}
+            className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-2)] px-2 py-1 text-xs text-[var(--text)]"
+          >
+            {workspaces.map((w) => (
+              <option key={w.fullDomain} value={w.fullDomain}>
+                {w.username ? `${w.username} — ` : ''}{w.fullDomain}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span className="text-xs font-medium text-[var(--text)]">{active.fullDomain}</span>
+        )}
+        <div className="ml-auto flex items-center gap-1.5">
+          <button
+            onClick={() => setReloadKey((k) => k + 1)}
+            title="Reload"
+            className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] p-1.5 text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
+          >
+            <RefreshCw size={13} />
+          </button>
+          <a
+            href={src}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
+          >
+            <ExternalLink size={13} /> Open in new tab to sign in
+          </a>
+        </div>
+      </div>
+      <div className="relative flex-1">
+        <iframe
+          key={reloadKey}
+          src={src}
+          className="absolute inset-0 h-full w-full border-0"
+          title={`Agent workspace — ${active.fullDomain}`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web-ui/src/components/workspace/WorkspaceView.tsx
+++ b/web-ui/src/components/workspace/WorkspaceView.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useState, useMemo } from 'react';
-import { Bot, ExternalLink, RefreshCw } from 'lucide-react';
+import { useState, useMemo, useEffect, useCallback } from 'react';
+import { Bot, ExternalLink, RefreshCw, Loader2 } from 'lucide-react';
 import { ProxyRoute } from '@/src/types/app';
+import { Server } from '@/src/types/server';
+import { getClient } from '@/src/lib/api/client';
 
 /**
  * WorkspaceView embeds an agent-workspace box's web chat UI (OpenHands,
@@ -10,18 +12,16 @@ import { ProxyRoute } from '@/src/types/app';
  * co-work with a coding agent without leaving the console.
  *
  * The box exposes its in-box auth proxy on the `workspace` subdomain (recipe
- * container port 8080). We discover those routes from the network route list
- * rather than calling a new endpoint.
+ * container port 8080); we discover those routes from the network route list.
  *
- * Auth nuance: the workspace is protected by an in-box auth proxy, and
- * browsers suppress the basic-auth prompt inside a cross-origin iframe. So the
- * flow is: sign in ONCE in a new tab — the in-box proxy then issues a
- * SameSite=None session cookie, which the browser sends to the box even from
- * this embedded iframe, so every load afterward is seamless (no prompt). The
- * "Open in new tab to sign in" action is the one-time bootstrap; "Reload"
- * re-renders the iframe once the cookie is set.
+ * Zero-click auth: the daemon's GetWorkspaceAccess returns a bootstrap URL
+ * (https://<box>-workspace.<domain>/__ws_login?t=<token>). Loading it in the
+ * iframe sets the in-box SameSite=None session cookie and redirects to the
+ * workspace UI, so no sign-in prompt is ever shown. If that lookup fails (older
+ * box, no route), we fall back to the plain workspace URL and surface the
+ * "Open in new tab to sign in" path.
  */
-export default function WorkspaceView({ routes }: { routes: ProxyRoute[] }) {
+export default function WorkspaceView({ server, routes }: { server: Server; routes: ProxyRoute[] }) {
   const workspaces = useMemo(
     () =>
       (routes || []).filter(
@@ -32,7 +32,40 @@ export default function WorkspaceView({ routes }: { routes: ProxyRoute[] }) {
 
   const [selected, setSelected] = useState<string>('');
   const active = workspaces.find((w) => w.fullDomain === selected) ?? workspaces[0];
+  const activeDomain = active?.fullDomain;
+  const activeName = active?.username;
+
+  const [src, setSrc] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const [needsSignin, setNeedsSignin] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
+
+  const loadAccess = useCallback(async () => {
+    if (!activeDomain) return;
+    const fallback = `https://${activeDomain}`;
+    setLoading(true);
+    setNeedsSignin(false);
+    try {
+      // Prefer the zero-click bootstrap URL from the daemon.
+      const access = activeName ? await getClient(server).getWorkspaceAccess(activeName) : null;
+      if (access?.url) {
+        setSrc(access.url);
+      } else {
+        setSrc(fallback);
+        setNeedsSignin(true);
+      }
+    } catch {
+      // Older box / no token endpoint — fall back to manual sign-in.
+      setSrc(fallback);
+      setNeedsSignin(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [server, activeDomain, activeName]);
+
+  useEffect(() => {
+    loadAccess();
+  }, [loadAccess]);
 
   if (workspaces.length === 0) {
     return (
@@ -49,15 +82,13 @@ export default function WorkspaceView({ routes }: { routes: ProxyRoute[] }) {
     );
   }
 
-  const src = `https://${active.fullDomain}`;
-
   return (
     <div className="flex h-[calc(100vh-150px)] flex-col">
       <div className="flex items-center gap-3 border-b border-[var(--border-subtle)] bg-[var(--surface)] px-4 py-2 shrink-0">
         <Bot size={14} className="text-[var(--accent)]" />
         {workspaces.length > 1 ? (
           <select
-            value={active.fullDomain}
+            value={active?.fullDomain ?? ''}
             onChange={(e) => setSelected(e.target.value)}
             className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-2)] px-2 py-1 text-xs text-[var(--text)]"
           >
@@ -68,33 +99,42 @@ export default function WorkspaceView({ routes }: { routes: ProxyRoute[] }) {
             ))}
           </select>
         ) : (
-          <span className="text-xs font-medium text-[var(--text)]">{active.fullDomain}</span>
+          <span className="text-xs font-medium text-[var(--text)]">{activeDomain}</span>
+        )}
+        {needsSignin && (
+          <span className="text-xs text-[var(--c-amber)]">sign in once in a new tab →</span>
         )}
         <div className="ml-auto flex items-center gap-1.5">
           <button
-            onClick={() => setReloadKey((k) => k + 1)}
+            onClick={() => { setReloadKey((k) => k + 1); loadAccess(); }}
             title="Reload"
             className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] p-1.5 text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
           >
             <RefreshCw size={13} />
           </button>
           <a
-            href={src}
+            href={src || `https://${activeDomain}`}
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-1.5 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-2)]"
           >
-            <ExternalLink size={13} /> Open in new tab to sign in
+            <ExternalLink size={13} /> Open in new tab
           </a>
         </div>
       </div>
       <div className="relative flex-1">
-        <iframe
-          key={reloadKey}
-          src={src}
-          className="absolute inset-0 h-full w-full border-0"
-          title={`Agent workspace — ${active.fullDomain}`}
-        />
+        {loading || !src ? (
+          <div className="flex h-full items-center justify-center">
+            <Loader2 size={22} className="animate-spin text-[var(--text-secondary)]" />
+          </div>
+        ) : (
+          <iframe
+            key={`${src}-${reloadKey}`}
+            src={src}
+            className="absolute inset-0 h-full w-full border-0"
+            title={`Agent workspace — ${activeDomain}`}
+          />
+        )}
       </div>
     </div>
   );

--- a/web-ui/src/components/workspace/WorkspaceView.tsx
+++ b/web-ui/src/components/workspace/WorkspaceView.tsx
@@ -27,11 +27,11 @@ import { getClient } from '@/src/lib/api/client';
  * set by the chat view authenticates that page too.
  */
 export default function WorkspaceView({ server, routes }: { server: Server; routes: ProxyRoute[] }) {
+  // Identify agent-workspace boxes by the recipe's `workspace` subdomain, not by
+  // a generic port (8080 is a common app port — matching it would misclassify
+  // unrelated apps as workspaces).
   const workspaces = useMemo(
-    () =>
-      (routes || []).filter(
-        (r) => r.active && (r.subdomain?.includes('workspace') || r.port === 8080)
-      ),
+    () => (routes || []).filter((r) => r.active && !!r.subdomain?.includes('workspace')),
     [routes]
   );
 

--- a/web-ui/src/lib/api/client.ts
+++ b/web-ui/src/lib/api/client.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance, AxiosError } from 'axios';
 import { Container, ContainerMetrics, CreateContainerRequest, CreateContainerResponse, ListContainersResponse, MetricsResponse, SystemInfo, Collaborator, AddCollaboratorRequest, BackendInfo, Stack } from '@/src/types/container';
 import { Server } from '@/src/types/server';
-import { App, NetworkACL, ProxyRoute, NetworkTopology, ACLPresetInfo, DNSRecord, PassthroughRoute } from '@/src/types/app';
+import { App, NetworkACL, ProxyRoute, NetworkTopology, ACLPresetInfo, DNSRecord, PassthroughRoute, WorkspaceAccess } from '@/src/types/app';
 import { Connection, ConnectionSummary, HistoricalConnection, TrafficAggregate, GetConnectionsResponse, GetConnectionSummaryResponse, QueryTrafficHistoryResponse, GetTrafficAggregatesResponse } from '@/src/types/traffic';
 import { ClamavSummaryResponse, ClamavReportsResponse, ListClamavReportsParams, TriggerScanResponse, ScanStatusResponse, PentestScanRunsResponse, PentestFindingsResponse, PentestFindingSummaryResponse, PentestConfigResponse, TriggerPentestScanResponse, ListPentestFindingsParams, InstallPentestToolResponse, ZapScanRunsResponse, ZapAlertsResponse, ZapAlertSummaryResponse, ZapConfigResponse, TriggerZapScanResponse, ZapReportResponse, InstallZapResponse, ListZapAlertsParams } from '@/src/types/security';
 import { AuditLogsResponse, AuditLogsParams } from '@/src/types/audit';
@@ -507,6 +507,16 @@ export class ContaineriumClient {
     const params = username ? { username } : {};
     const response = await this.client.get<{ routes?: ProxyRoute[] }>('/network/routes', { params });
     return response.data.routes || [];
+  }
+
+  /**
+   * Get the zero-click bootstrap URL for an agent-workspace box.
+   */
+  async getWorkspaceAccess(name: string): Promise<WorkspaceAccess> {
+    const response = await this.client.get<{ token?: string; url?: string }>(
+      `/recipes/workspace/${encodeURIComponent(name)}/access`
+    );
+    return { token: response.data.token || '', url: response.data.url || '' };
   }
 
   /**

--- a/web-ui/src/types/app.ts
+++ b/web-ui/src/types/app.ts
@@ -58,6 +58,16 @@ export interface AppResources {
 }
 
 /**
+ * Zero-click access info for an agent-workspace box. `url` is a bootstrap URL
+ * (/__ws_login?t=...) that sets the in-box session cookie and redirects to the
+ * workspace UI, so the embedded iframe authenticates without a prompt.
+ */
+export interface WorkspaceAccess {
+  token: string;
+  url: string;
+}
+
+/**
  * Proxy route configuration
  */
 export interface ProxyRoute {


### PR DESCRIPTION
## What & why

A new built-in **`agent-workspace` recipe**: a hosted **web chat workspace in a box** — a browser chat UI with **live preview** and **multiple persisted conversations**, all stored inside one always-on box. Co-work with a coding agent in the browser, then ship what you build to a separate box.

Instead of building a chat UI + agent loop + session store, it **packages OpenHands "Agent Canvas"** (MIT) as the in-box engine. Containarium's value is the wrapper: isolated always-on box, trust fabric, managed-TLS subdomain, and one-click ship-to-box.

## How it works (one recipe + one small RPC)

- `post_start` runs OpenHands via Podman bound to `127.0.0.1:8000`, conversations persisted under `/opt/openhands-state` (no container-engine socket — the agent runs in the app container).
- **Auth lives in the box:** an in-box Caddy proxy on `:8080` fronts the app with HTTP basic auth **plus a `SameSite=None` session cookie it issues**, so the console can embed the workspace in an iframe and authenticate **zero-click**. Exposed as the `workspace` subdomain.
- **Model provider + key in the UI:** the recipe pins no provider — users pick Anthropic / OpenAI(Codex) / Gemini / any LiteLLM model in OpenHands' Settings → LLM (the Workspace tab has a "Model setup" deep-link).
- New **`RecipeService.GetWorkspaceAccess`** RPC (`GET /v1/recipes/workspace/{name}/access`, proto-first) + `containarium recipe workspace-access` CLI return the zero-click bootstrap URL; **web-ui "Workspace" tab** embeds it.

## Validation (live, on a backend)

- Recipe `post_start` runs **as root** and **persists** across restarts (`--restart=always` under the box init); rootless variant also validated. In-box auth: `401 / 200 / 302` (basic + zero-click bootstrap).
- **Full daemon path** on a clean throwaway VM: `recipe deploy agent-workspace ws1` → daemon `CreateContainer` + `post_start` → `recipe workspace-access ws1` → `GetWorkspaceAccess` returns the bootstrap URL. (Found+fixed: domain-less URL when no base domain is configured.)
- `go build` + recipes/server tests green; web-ui `tsc --noEmit` + eslint clean.

## Code review (high-effort) — addressed

- Recipe: idempotent `podman rm -f` before runs; fail loudly on empty hash/token; **anchored cookie matcher** (no substring slip).
- Server: `GetWorkspaceAccess` requires **containers:write** (it mints an access credential).
- web-ui: identify workspaces by the `workspace` subdomain, not the generic port 8080.
- Docs reconciled to the validated state; lab hostname anonymized per CLAUDE.md.

## Deliberate follow-ups (documented, not blockers)

- `auth_password` via the **secrets mechanism** instead of a recipe parameter.
- Bootstrap **token-in-URL → POST/short-TTL handoff**; cookie rotation.
- A **real model call** acceptance (needs a provider key).
- MCP tool for `get_workspace_access` (CLI-first; CLI-without-MCP is allowed).

Docs: `docs/AGENT-WORKSPACE-SPIKE.md` (validation record + gotchas), `docs/PRD-HOSTED-AGENT-WORKSPACE.md` (product framing). CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)