### PR TITLE
feat(recipes): DeployRecipeRequest carries labels, forwarded to the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`DeployRecipeRequest` now carries `labels`, forwarded to the provisioned
+  container.** A recipe-deployed box is now labeled like a plain
+  `CreateContainer` (the `deploy()` body forwards `req.Labels` into the inner
+  `CreateContainerRequest`). Without this, a control plane that attributes
+  containers to a tenant/org by label (e.g. the cloud's `cloud_org_id`
+  filter) could not see a recipe-deployed box — so it couldn't front
+  `deploy_recipe` for the `agent-workspace` recipe. Additive proto field
+  (`labels = 8`); existing callers are unaffected.
+
 - **`agent-workspace` recipe — a hosted web chat workspace in a box.** A new
   built-in recipe runs OpenHands ("Agent Canvas") inside an always-on box: a
   browser chat UI with live preview and multiple persisted conversations, all

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -7541,6 +7541,13 @@
         "resourceOverrides": {
           "$ref": "#/definitions/RecipeResources",
           "description": "Optional overrides for the recipe's default resource limits."
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom labels stamped on the provisioned container (forwarded to\nCreateContainer). Lets a control plane attribute a recipe-deployed box to\na tenant/org the same way it does for a plain CreateContainer — without\nlabels, a cloud front-end that filters containers by label can't see a\nrecipe-deployed box. Same key/value rules as CreateContainerRequest.labels."
         }
       },
       "description": "DeployRecipeRequest provisions a new dedicated container from a recipe."

--- a/internal/server/recipe_server.go
+++ b/internal/server/recipe_server.go
@@ -168,11 +168,15 @@ func (s *RecipeServer) deploy(ctx context.Context, req *pb.DeployRecipeRequest) 
 
 	// 1. Provision the dedicated container locally (reuses all of
 	//    CreateContainer's validation, image allowlist, GPU wiring, etc.).
+	//    Caller labels (e.g. a control plane's tenant-attribution labels) are
+	//    forwarded so a recipe-deployed box is labeled the same as a plain
+	//    CreateContainer — otherwise a label-filtering front-end can't see it.
 	createReq := &pb.CreateContainerRequest{
 		Username:     req.Name,
 		Image:        recipeBaseImage,
 		EnablePodman: true,
 		Resources:    resourceLimits(recipe, req.ResourceOverrides),
+		Labels:       req.Labels,
 	}
 	// A recipe requests a single GPU device; map it onto the container's
 	// repeated `gpus` (the singular `gpu` is no longer honored — #673).

--- a/pkg/pb/containarium/v1/recipe.pb.go
+++ b/pkg/pb/containarium/v1/recipe.pb.go
@@ -627,8 +627,14 @@ type DeployRecipeRequest struct {
 	Parameters map[string]string `protobuf:"bytes,6,rep,name=parameters,proto3" json:"parameters,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Optional overrides for the recipe's default resource limits.
 	ResourceOverrides *RecipeResources `protobuf:"bytes,7,opt,name=resource_overrides,json=resourceOverrides,proto3" json:"resource_overrides,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// Custom labels stamped on the provisioned container (forwarded to
+	// CreateContainer). Lets a control plane attribute a recipe-deployed box to
+	// a tenant/org the same way it does for a plain CreateContainer — without
+	// labels, a cloud front-end that filters containers by label can't see a
+	// recipe-deployed box. Same key/value rules as CreateContainerRequest.labels.
+	Labels        map[string]string `protobuf:"bytes,8,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *DeployRecipeRequest) Reset() {
@@ -706,6 +712,13 @@ func (x *DeployRecipeRequest) GetParameters() map[string]string {
 func (x *DeployRecipeRequest) GetResourceOverrides() *RecipeResources {
 	if x != nil {
 		return x.ResourceOverrides
+	}
+	return nil
+}
+
+func (x *DeployRecipeRequest) GetLabels() map[string]string {
+	if x != nil {
+		return x.Labels
 	}
 	return nil
 }
@@ -927,7 +940,7 @@ const file_containarium_v1_recipe_proto_rawDesc = "" +
 	"\x10GetRecipeRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"D\n" +
 	"\x11GetRecipeResponse\x12/\n" +
-	"\x06recipe\x18\x01 \x01(\v2\x17.containarium.v1.RecipeR\x06recipe\"\xf1\x02\n" +
+	"\x06recipe\x18\x01 \x01(\v2\x17.containarium.v1.RecipeR\x06recipe\"\xf6\x03\n" +
 	"\x13DeployRecipeRequest\x12\x1b\n" +
 	"\trecipe_id\x18\x01 \x01(\tR\brecipeId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x10\n" +
@@ -938,8 +951,12 @@ const file_containarium_v1_recipe_proto_rawDesc = "" +
 	"\n" +
 	"parameters\x18\x06 \x03(\v24.containarium.v1.DeployRecipeRequest.ParametersEntryR\n" +
 	"parameters\x12O\n" +
-	"\x12resource_overrides\x18\a \x01(\v2 .containarium.v1.RecipeResourcesR\x11resourceOverrides\x1a=\n" +
+	"\x12resource_overrides\x18\a \x01(\v2 .containarium.v1.RecipeResourcesR\x11resourceOverrides\x12H\n" +
+	"\x06labels\x18\b \x03(\v20.containarium.v1.DeployRecipeRequest.LabelsEntryR\x06labels\x1a=\n" +
 	"\x0fParametersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a9\n" +
+	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"|\n" +
 	"\x14DeployRecipeResponse\x128\n" +
@@ -974,7 +991,7 @@ func file_containarium_v1_recipe_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_recipe_proto_rawDescData
 }
 
-var file_containarium_v1_recipe_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_containarium_v1_recipe_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_containarium_v1_recipe_proto_goTypes = []any{
 	(*RecipeResources)(nil),            // 0: containarium.v1.RecipeResources
 	(*RecipePort)(nil),                 // 1: containarium.v1.RecipePort
@@ -991,7 +1008,8 @@ var file_containarium_v1_recipe_proto_goTypes = []any{
 	(*GetWorkspaceAccessResponse)(nil), // 12: containarium.v1.GetWorkspaceAccessResponse
 	nil,                                // 13: containarium.v1.Recipe.EnvEntry
 	nil,                                // 14: containarium.v1.DeployRecipeRequest.ParametersEntry
-	(*Container)(nil),                  // 15: containarium.v1.Container
+	nil,                                // 15: containarium.v1.DeployRecipeRequest.LabelsEntry
+	(*Container)(nil),                  // 16: containarium.v1.Container
 }
 var file_containarium_v1_recipe_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.Recipe.resources:type_name -> containarium.v1.RecipeResources
@@ -1003,20 +1021,21 @@ var file_containarium_v1_recipe_proto_depIdxs = []int32{
 	4,  // 6: containarium.v1.GetRecipeResponse.recipe:type_name -> containarium.v1.Recipe
 	14, // 7: containarium.v1.DeployRecipeRequest.parameters:type_name -> containarium.v1.DeployRecipeRequest.ParametersEntry
 	0,  // 8: containarium.v1.DeployRecipeRequest.resource_overrides:type_name -> containarium.v1.RecipeResources
-	15, // 9: containarium.v1.DeployRecipeResponse.container:type_name -> containarium.v1.Container
-	11, // 10: containarium.v1.RecipeService.GetWorkspaceAccess:input_type -> containarium.v1.GetWorkspaceAccessRequest
-	5,  // 11: containarium.v1.RecipeService.ListRecipes:input_type -> containarium.v1.ListRecipesRequest
-	7,  // 12: containarium.v1.RecipeService.GetRecipe:input_type -> containarium.v1.GetRecipeRequest
-	9,  // 13: containarium.v1.RecipeService.DeployRecipe:input_type -> containarium.v1.DeployRecipeRequest
-	12, // 14: containarium.v1.RecipeService.GetWorkspaceAccess:output_type -> containarium.v1.GetWorkspaceAccessResponse
-	6,  // 15: containarium.v1.RecipeService.ListRecipes:output_type -> containarium.v1.ListRecipesResponse
-	8,  // 16: containarium.v1.RecipeService.GetRecipe:output_type -> containarium.v1.GetRecipeResponse
-	10, // 17: containarium.v1.RecipeService.DeployRecipe:output_type -> containarium.v1.DeployRecipeResponse
-	14, // [14:18] is the sub-list for method output_type
-	10, // [10:14] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	15, // 9: containarium.v1.DeployRecipeRequest.labels:type_name -> containarium.v1.DeployRecipeRequest.LabelsEntry
+	16, // 10: containarium.v1.DeployRecipeResponse.container:type_name -> containarium.v1.Container
+	11, // 11: containarium.v1.RecipeService.GetWorkspaceAccess:input_type -> containarium.v1.GetWorkspaceAccessRequest
+	5,  // 12: containarium.v1.RecipeService.ListRecipes:input_type -> containarium.v1.ListRecipesRequest
+	7,  // 13: containarium.v1.RecipeService.GetRecipe:input_type -> containarium.v1.GetRecipeRequest
+	9,  // 14: containarium.v1.RecipeService.DeployRecipe:input_type -> containarium.v1.DeployRecipeRequest
+	12, // 15: containarium.v1.RecipeService.GetWorkspaceAccess:output_type -> containarium.v1.GetWorkspaceAccessResponse
+	6,  // 16: containarium.v1.RecipeService.ListRecipes:output_type -> containarium.v1.ListRecipesResponse
+	8,  // 17: containarium.v1.RecipeService.GetRecipe:output_type -> containarium.v1.GetRecipeResponse
+	10, // 18: containarium.v1.RecipeService.DeployRecipe:output_type -> containarium.v1.DeployRecipeResponse
+	15, // [15:19] is the sub-list for method output_type
+	11, // [11:15] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_recipe_proto_init() }
@@ -1031,7 +1050,7 @@ func file_containarium_v1_recipe_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_recipe_proto_rawDesc), len(file_containarium_v1_recipe_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   15,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/containarium/v1/recipe.proto
+++ b/proto/containarium/v1/recipe.proto
@@ -149,6 +149,13 @@ message DeployRecipeRequest {
 
   // Optional overrides for the recipe's default resource limits.
   RecipeResources resource_overrides = 7;
+
+  // Custom labels stamped on the provisioned container (forwarded to
+  // CreateContainer). Lets a control plane attribute a recipe-deployed box to
+  // a tenant/org the same way it does for a plain CreateContainer — without
+  // labels, a cloud front-end that filters containers by label can't see a
+  // recipe-deployed box. Same key/value rules as CreateContainerRequest.labels.
+  map<string, string> labels = 8;
 }
 
 // DeployRecipeResponse is the result of a recipe deployment.


### PR DESCRIPTION
## What & why

Adds a `labels` field to `DeployRecipeRequest` and forwards it into the inner `CreateContainerRequest`, so a **recipe-deployed box is labeled like a plain `CreateContainer`**.

This is the OSS-first unblock for the **cloud `deploy_recipe` increment**. The cloud control plane attributes every container to an org via a `cloud_org_id` **label** and lists a tenant's boxes by filtering on it. `DeployRecipeRequest` had no `labels` field and `deploy()` forwarded none — so a recipe-deployed box was unlabeled and **invisible to the cloud**, blocking the cloud from fronting `deploy_recipe` for the `agent-workspace` recipe (FootprintAI/Containarium-cloud#584 follow-up).

## Change

- `proto`: add `map<string,string> labels = 8;` to `DeployRecipeRequest` (additive; existing callers unaffected). Regenerated stubs + swagger.
- `internal/server/recipe_server.go`: `deploy()` sets `createReq.Labels = req.Labels`.

## Tests

`go build` + `internal/server` + `pkg/core/recipes` tests green. The change is a one-line forward on top of the existing, tested deploy path; the server test harness exercises only pre-backend validation (nil container deps), so a capturing fake for a label assertion would be disproportionate for an additive forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)