### PR TITLE
chore(release): cut v0.32.0 — agent-workspace recipe + recipe deploy labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-06-18
+
 ### Added
 
 - **`DeployRecipeRequest` now carries `labels`, forwarded to the provisioned


### PR DESCRIPTION
Promotes the CHANGELOG `[Unreleased]` section to **`[0.32.0]`**.

### Highlights since v0.31.2
- **agent-workspace recipe** — a hosted web chat workspace in a box (OpenHands), with the `GetWorkspaceAccess` RPC, `recipe workspace-access` CLI, and a `web-ui` Workspace tab (#726).
- **`DeployRecipeRequest.labels`** forwarded to the provisioned container, so a control plane can attribute a recipe-deployed box by label (#727).
- **daemon unit `ReadWritePaths`** now covers the doctor's writable set so a fresh host no longer boots DEGRADED (#724).

### After merge
Tag **`v0.32.0`** on the merge commit to trigger the release binary build. This unblocks the **cloud** side: Containarium-cloud can then bump its OSS dep off `v0.24.0` to consume `DeployRecipeRequest.labels`, which the cloud `deploy_recipe` shim increment depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)