### PR TITLE
feat(recipe): async post_start so a slow deploy survives a proxy timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-06-19
+
+### Added
+
+- **`DeployRecipeRequest.async` — run a recipe's `post_start` in the background.**
+  When set, `DeployRecipe` returns as soon as the container is created (state
+  `CREATING`) instead of blocking until `post_start` finishes, then runs
+  `post_start` + the port expose on a detached context. This is needed when a
+  recipe is deployed over a connection with a request/idle timeout shorter than
+  the work — e.g. a control plane reaching a BYOC host through the sentinel
+  peer-proxy: a recipe that pulls a multi-GB image (like `agent-workspace`'s
+  OpenHands) can exceed that timeout, and a synchronous deploy would be cut
+  mid-pull (`EOF`), leaving the box half-provisioned. The CLI leaves `async`
+  false so a human still sees `post_start`'s result inline. The box becomes
+  fully functional once the background `post_start` completes; poll the
+  container / its workspace access for readiness. Additive proto field
+  (`async = 9`); existing callers are unaffected.
+
 ## [0.32.0] - 2026-06-18
 
 ### Added

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -7548,6 +7548,10 @@
             "type": "string"
           },
           "description": "Custom labels stamped on the provisioned container (forwarded to\nCreateContainer). Lets a control plane attribute a recipe-deployed box to\na tenant/org the same way it does for a plain CreateContainer — without\nlabels, a cloud front-end that filters containers by label can't see a\nrecipe-deployed box. Same key/value rules as CreateContainerRequest.labels."
+        },
+        "async": {
+          "type": "boolean",
+          "description": "async runs the recipe's post_start in the background: the RPC returns as\nsoon as the container is created (state CREATING) instead of blocking until\npost_start finishes. Set this when the deploy is driven over a connection\nwith a request/idle timeout shorter than the post_start (e.g. a control\nplane reaching a BYOC host through a peer-proxy): a recipe that pulls a\nmulti-GB image can exceed that timeout, which would otherwise abort the\ndeploy mid-pull. The CLI leaves this false so a human sees post_start's\nresult inline. The box becomes fully functional once the background\npost_start completes; poll the container / its workspace access to detect\nreadiness."
         }
       },
       "description": "DeployRecipeRequest provisions a new dedicated container from a recipe."

--- a/internal/server/recipe_server.go
+++ b/internal/server/recipe_server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/url"
 	"strings"
 
@@ -188,6 +189,39 @@ func (s *RecipeServer) deploy(ctx context.Context, req *pb.DeployRecipeRequest) 
 	}
 
 	containerName := req.Name + "-container"
+
+	// Async path: decouple post_start from the RPC. A recipe's post_start can
+	// pull multi-GB images (e.g. agent-workspace), taking longer than the
+	// request/idle timeout of a caller reaching this daemon through a peer-proxy
+	// — holding the call open would get it cut mid-pull, aborting the deploy.
+	// Run post_start (and the port expose) in the background on a detached
+	// context and return the freshly-created box now (state CREATING). The box
+	// becomes fully functional once post_start completes; the caller polls.
+	if req.Async {
+		go func() {
+			bg := context.WithoutCancel(ctx)
+			if len(recipe.PostStart) > 0 {
+				script := buildPostStartScript(recipe, params)
+				if err := s.containers.manager.Exec(containerName, []string{"bash", "-c", script}); err != nil {
+					log.Printf("[recipe] async post_start failed on %s (recipe %q): %v", containerName, recipe.Id, err)
+					return
+				}
+			}
+			if _, warnings := s.exposePorts(bg, recipe, req.Name); len(warnings) > 0 {
+				log.Printf("[recipe] async expose warnings on %s: %s", containerName, strings.Join(warnings, "; "))
+			}
+		}()
+		info, _ := s.containers.manager.Get(req.Name)
+		var container *pb.Container
+		if info != nil {
+			st := boxlxc.StatusFromInfo(info)
+			container = toProtoContainer(&st)
+		}
+		return &pb.DeployRecipeResponse{
+			Container: container,
+			Message:   fmt.Sprintf("Recipe %q deploying as %s (post_start running in background)", recipe.Id, containerName),
+		}, nil
+	}
 
 	// 2. Run the recipe's post_start commands inside the container, with env
 	//    and parameters exported. Same trust level as a stack's post_install.

--- a/pkg/pb/containarium/v1/recipe.pb.go
+++ b/pkg/pb/containarium/v1/recipe.pb.go
@@ -632,7 +632,18 @@ type DeployRecipeRequest struct {
 	// a tenant/org the same way it does for a plain CreateContainer — without
 	// labels, a cloud front-end that filters containers by label can't see a
 	// recipe-deployed box. Same key/value rules as CreateContainerRequest.labels.
-	Labels        map[string]string `protobuf:"bytes,8,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels map[string]string `protobuf:"bytes,8,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// async runs the recipe's post_start in the background: the RPC returns as
+	// soon as the container is created (state CREATING) instead of blocking until
+	// post_start finishes. Set this when the deploy is driven over a connection
+	// with a request/idle timeout shorter than the post_start (e.g. a control
+	// plane reaching a BYOC host through a peer-proxy): a recipe that pulls a
+	// multi-GB image can exceed that timeout, which would otherwise abort the
+	// deploy mid-pull. The CLI leaves this false so a human sees post_start's
+	// result inline. The box becomes fully functional once the background
+	// post_start completes; poll the container / its workspace access to detect
+	// readiness.
+	Async         bool `protobuf:"varint,9,opt,name=async,proto3" json:"async,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -721,6 +732,13 @@ func (x *DeployRecipeRequest) GetLabels() map[string]string {
 		return x.Labels
 	}
 	return nil
+}
+
+func (x *DeployRecipeRequest) GetAsync() bool {
+	if x != nil {
+		return x.Async
+	}
+	return false
 }
 
 // DeployRecipeResponse is the result of a recipe deployment.
@@ -940,7 +958,7 @@ const file_containarium_v1_recipe_proto_rawDesc = "" +
 	"\x10GetRecipeRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"D\n" +
 	"\x11GetRecipeResponse\x12/\n" +
-	"\x06recipe\x18\x01 \x01(\v2\x17.containarium.v1.RecipeR\x06recipe\"\xf6\x03\n" +
+	"\x06recipe\x18\x01 \x01(\v2\x17.containarium.v1.RecipeR\x06recipe\"\x8c\x04\n" +
 	"\x13DeployRecipeRequest\x12\x1b\n" +
 	"\trecipe_id\x18\x01 \x01(\tR\brecipeId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x10\n" +
@@ -952,7 +970,8 @@ const file_containarium_v1_recipe_proto_rawDesc = "" +
 	"parameters\x18\x06 \x03(\v24.containarium.v1.DeployRecipeRequest.ParametersEntryR\n" +
 	"parameters\x12O\n" +
 	"\x12resource_overrides\x18\a \x01(\v2 .containarium.v1.RecipeResourcesR\x11resourceOverrides\x12H\n" +
-	"\x06labels\x18\b \x03(\v20.containarium.v1.DeployRecipeRequest.LabelsEntryR\x06labels\x1a=\n" +
+	"\x06labels\x18\b \x03(\v20.containarium.v1.DeployRecipeRequest.LabelsEntryR\x06labels\x12\x14\n" +
+	"\x05async\x18\t \x01(\bR\x05async\x1a=\n" +
 	"\x0fParametersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a9\n" +

--- a/proto/containarium/v1/recipe.proto
+++ b/proto/containarium/v1/recipe.proto
@@ -156,6 +156,18 @@ message DeployRecipeRequest {
   // labels, a cloud front-end that filters containers by label can't see a
   // recipe-deployed box. Same key/value rules as CreateContainerRequest.labels.
   map<string, string> labels = 8;
+
+  // async runs the recipe's post_start in the background: the RPC returns as
+  // soon as the container is created (state CREATING) instead of blocking until
+  // post_start finishes. Set this when the deploy is driven over a connection
+  // with a request/idle timeout shorter than the post_start (e.g. a control
+  // plane reaching a BYOC host through a peer-proxy): a recipe that pulls a
+  // multi-GB image can exceed that timeout, which would otherwise abort the
+  // deploy mid-pull. The CLI leaves this false so a human sees post_start's
+  // result inline. The box becomes fully functional once the background
+  // post_start completes; poll the container / its workspace access to detect
+  // readiness.
+  bool async = 9;
 }
 
 // DeployRecipeResponse is the result of a recipe deployment.


### PR DESCRIPTION
## Problem

Deploying the `agent-workspace` recipe onto a BYOC host **through the cloud** failed with `EOF`. The recipe's `post_start` pulls a multi-GB image (OpenHands), but `deploy()` ran `post_start` **synchronously** — holding the RPC (and the sentinel peer-proxy connection) open for the entire pull. The peer-proxy / server closes the connection at **~7 min**, cutting `post_start` mid-pull and leaving the box half-provisioned (no in-box token, app not running).

(The cloud side already returns fast / detaches from the inbound request — Containarium-cloud #593 — so it beats Cloudflare's 100s cap. This is the *next* timeout down the stack, and it's OSS-side.)

## Fix

Add **`DeployRecipeRequest.async`** (additive, field 9). When set:
- `DeployRecipe` returns as soon as the container is created (state `CREATING`).
- `post_start` + the port expose run in a **detached goroutine** (`context.WithoutCancel`), so no connection/request timeout can abort them.

The box becomes fully functional once the background `post_start` finishes; the caller polls the container / its workspace access for readiness. The **CLI leaves `async` false**, so a human deploying a recipe still sees `post_start`'s result inline.

## Test
`go build ./...` + `go test ./internal/server/...` green. (The recipe-server test harness covers pre-provisioning validation only — no manager wired — so the async branch is exercised in live validation, same scope as the existing deploy tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)