### PR TITLE
fix(agent-runtime): record the Gemini default model in the artifact

### DIFF
--- a/agent-runtime/src/index.ts
+++ b/agent-runtime/src/index.ts
@@ -23,10 +23,15 @@ const agentBoxCommand = process.env.AGENT_BOX_BIN ?? "agent-box";
 const maxTurns = Number(process.env.CONTAINARIUM_AGENT_MAX_TURNS ?? "12");
 
 // Model default is engine-specific. Claude → claude-opus-4-8 (per the Claude
-// API guidance). Codex → empty, i.e. let Codex use its own configured default
-// (we don't hard-code an OpenAI model id). Override either with
-// CONTAINARIUM_AGENT_MODEL.
-const model = process.env.CONTAINARIUM_AGENT_MODEL ?? (engineName === "claude" ? "claude-opus-4-8" : "");
+// API guidance). Gemini → gemini-2.5-flash (so the effective model is recorded
+// in the artifact for audit, not just defaulted inside the engine). Codex →
+// empty, i.e. let Codex use its own configured default (we don't hard-code an
+// OpenAI model id). Override any with CONTAINARIUM_AGENT_MODEL.
+const engineModelDefaults: Record<string, string> = {
+  claude: "claude-opus-4-8",
+  gemini: "gemini-2.5-flash",
+};
+const model = process.env.CONTAINARIUM_AGENT_MODEL ?? (engineModelDefaults[engineName] ?? "");
 
 function pickEngine(name: string): Engine {
   switch (name) {


### PR DESCRIPTION
## What

The Gemini engine (added in #731) defaults to `gemini-2.5-flash` *inside the engine*, but `index.ts` only set the model default for `claude`. So a Gemini run wrote `artifact.model = ""` — the audit record didn't capture which model produced the output.

Fix: set the Gemini default at the index level (via a small engine→default map) so the effective model is both passed to the engine and recorded in the artifact. Codex stays empty (it uses its own configured default — unchanged).

## How it was found

A **live run of the Gemini engine on a cloud box** — the artifact came back with `"model": ""`. After the fix, a re-run on the same box produced:

```json
{ "outputJson": "The echoed string was \"hello-from-gemini\" and the OS name is Linux.",
  "engine": "gemini", "model": "gemini-2.5-flash", ... }
```

i.e. the engine connected to `agent-box` over MCP, ran the shell tool, and summarized the output — and the model is now correctly recorded.

## Verification

- `tsc --noEmit` + build clean against real SDK types.
- Live re-run on the box: `model` field now `gemini-2.5-flash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)