### PR TITLE
feat(model-gateway): prototype gateway for hosted API-key custody

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: help proto build build-bpf clean clean-ui clean-all install test lint fmt run-local web-ui swagger-ui build-mcp build-mcp-linux install-mcp build-agent-box build-agent-box-linux build-agent-box-all install-agent-box build-agent-runtime bundle-agent-runtime build-release sidecar-build-otel bundle-download-deps build-bundle build-bundle-all
+.PHONY: help proto build build-bpf clean clean-ui clean-all install test lint fmt run-local web-ui swagger-ui build-mcp build-mcp-linux install-mcp build-agent-box build-agent-box-linux build-agent-box-all install-agent-box build-agent-runtime bundle-agent-runtime build-release sidecar-build-otel bundle-download-deps build-bundle build-bundle-all build-model-gateway build-model-gateway-linux
 
 # Variables
 BINARY_NAME=containarium
 MCP_BINARY_NAME=mcp-server
 AGENTBOX_BINARY_NAME=agent-box
+GATEWAY_BINARY_NAME=model-gateway
 GIT_COMMIT?=$(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILD_DIR=bin
@@ -173,6 +174,18 @@ install-agent-box: build-agent-box ## Install agent-box to /usr/local/bin (requi
 	@echo "==> Installing $(AGENTBOX_BINARY_NAME) to /usr/local/bin..."
 	@sudo cp $(BUILD_DIR)/$(AGENTBOX_BINARY_NAME) /usr/local/bin/
 	@echo "==> Installed. Wire it into Claude Code/Cursor with: ssh user@box agent-box"
+
+build-model-gateway-linux: ## Build model-gateway for Linux (the typical deploy target — runs on the platform host)
+	@echo "==> Building model-gateway for Linux..."
+	@mkdir -p $(BUILD_DIR)
+	@GOOS=linux GOARCH=amd64 go build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(GATEWAY_BINARY_NAME)-linux-amd64 cmd/model-gateway/main.go
+	@echo "==> model-gateway built: $(BUILD_DIR)/$(GATEWAY_BINARY_NAME)-linux-amd64"
+
+build-model-gateway: ## Build model-gateway for the current platform
+	@echo "==> Building model-gateway..."
+	@mkdir -p $(BUILD_DIR)
+	@go build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(GATEWAY_BINARY_NAME) cmd/model-gateway/main.go
+	@echo "==> model-gateway built: $(BUILD_DIR)/$(GATEWAY_BINARY_NAME)"
 
 # Sidecar image build. Per docs/PLATFORM-SIDECAR-DESIGN.md, sidecar
 # images live at ghcr.io/footprintai/containarium-*-sidecar; on

--- a/agent-runtime/src/engines/gemini.ts
+++ b/agent-runtime/src/engines/gemini.ts
@@ -17,9 +17,19 @@ export class GeminiEngine implements Engine {
   readonly name = "gemini";
 
   async run(task: string, cfg: EngineConfig): Promise<EngineResult> {
-    const apiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY;
+    // Gateway mode: CONTAINARIUM_MODEL_GATEWAY_URL + CONTAINARIUM_GATEWAY_TOKEN
+    // route calls through the platform's model-gateway so the real Gemini key
+    // never lives in the box. Direct mode: GEMINI_API_KEY / GOOGLE_API_KEY hits
+    // the provider directly (OSS / self-hosted use case).
+    const gatewayUrl = process.env.CONTAINARIUM_MODEL_GATEWAY_URL;
+    const gatewayToken = process.env.CONTAINARIUM_GATEWAY_TOKEN;
+    const useGateway = !!(gatewayUrl && gatewayToken);
+
+    const apiKey = useGateway
+      ? gatewayToken!
+      : (process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY);
     if (!apiKey) {
-      throw new Error("GEMINI_API_KEY (or GOOGLE_API_KEY) is not set");
+      throw new Error("GEMINI_API_KEY (or GOOGLE_API_KEY) is not set — for hosted use, set CONTAINARIUM_MODEL_GATEWAY_URL + CONTAINARIUM_GATEWAY_TOKEN");
     }
 
     // Spawn agent-box as an MCP stdio server — the same tool surface the other
@@ -32,7 +42,15 @@ export class GeminiEngine implements Engine {
     await mcpClient.connect(transport);
 
     try {
-      const ai = new GoogleGenAI({ apiKey });
+      // When routing through the gateway the SDK sends x-goog-api-key (the
+      // gateway token) to `<gatewayUrl>/v1/model/gemini/<upstream-path>`.
+      // The gateway verifies the token, injects the real Gemini key, and
+      // proxies to generativelanguage.googleapis.com — so the key never leaves
+      // the gateway process.
+      const ai = new GoogleGenAI({
+        apiKey,
+        ...(useGateway ? { httpOptions: { baseUrl: `${gatewayUrl}/v1/model/gemini` } } : {}),
+      });
       const response = await ai.models.generateContent({
         model: cfg.model || "gemini-2.5-flash",
         contents: task,

--- a/cmd/model-gateway/README.md
+++ b/cmd/model-gateway/README.md
@@ -1,0 +1,116 @@
+# model-gateway
+
+A prototype of the agent model gateway described in
+`docs/AGENT-MODEL-GATEWAY-DESIGN.md`.
+
+The gateway is the **single egress point** that holds the real provider API
+keys. Agent boxes present short-lived, scoped **gateway tokens** (HS256 JWTs
+signed with the same shared secret as the platform JWT). The gateway verifies
+the token, injects the real key, proxies to the provider, and meters per-tenant
+token usage. The real key never leaves the gateway process and never touches a
+box.
+
+## Quick start
+
+```bash
+# Build
+make build-model-gateway-linux
+
+# Run (reads provider keys from env)
+GEMINI_API_KEY=<key> \
+  model-gateway serve \
+    --addr :8866 \
+    --secret-file /etc/containarium/jwt.secret
+
+# Mint a test token (stands in for provisionSkillBox in production)
+model-gateway mint \
+  --secret-file /etc/containarium/jwt.secret \
+  --tenant acme \
+  --provider gemini \
+  --skill hello-agent \
+  --allowed-models gemini-2.5-flash \
+  --ttl 1h
+```
+
+## Gateway routes
+
+| Path | Purpose |
+|---|---|
+| `POST /v1/model/<provider>/...` | Proxy to the upstream provider |
+| `GET /__gateway/usage` | In-memory usage rollup (JSON) |
+| `GET /__gateway/healthz` | Health probe |
+
+The `<provider>` segment must match a registered provider name
+(`anthropic`, `openai`, or `gemini`). The rest of the path is forwarded
+to the upstream as-is (the `/v1/model/<provider>` prefix is stripped).
+
+## Auth
+
+The box presents the gateway token in the same header the provider SDK uses:
+
+| Provider | Header |
+|---|---|
+| Anthropic / OpenAI | `Authorization: Bearer <token>` |
+| Gemini | `x-goog-api-key: <token>` |
+
+The gateway strips the inbound credential before proxying and injects the real
+provider key instead.
+
+## Agent-runtime integration
+
+### Gemini engine
+
+Set two env vars on the agent box (via secrets or the daemon's seed):
+
+```
+CONTAINARIUM_MODEL_GATEWAY_URL=http://model-gateway:8866
+CONTAINARIUM_GATEWAY_TOKEN=<gateway-token>
+```
+
+When both are set the Gemini engine routes through the gateway instead of
+hitting `generativelanguage.googleapis.com` directly. The real `GEMINI_API_KEY`
+stays in the gateway only.
+
+### Claude (Anthropic) engine
+
+The Anthropic SDK already honours `ANTHROPIC_BASE_URL` and
+`ANTHROPIC_AUTH_TOKEN`. Point them at the gateway:
+
+```
+ANTHROPIC_BASE_URL=http://model-gateway:8866/v1/model/anthropic
+ANTHROPIC_AUTH_TOKEN=<gateway-token>
+```
+
+### OpenAI / Codex engine
+
+The OpenAI SDK honours `OPENAI_BASE_URL` and `OPENAI_API_KEY`:
+
+```
+OPENAI_BASE_URL=http://model-gateway:8866/v1/model/openai
+OPENAI_API_KEY=<gateway-token>
+```
+
+## Token claims
+
+```json
+{
+  "tenant": "acme",
+  "skill_id": "hello-agent",
+  "run_id": "run-abc123",
+  "provider": "gemini",
+  "allowed_models": ["gemini-2.5-flash"],
+  "iss": "containarium-model-gateway",
+  "exp": 1750000000
+}
+```
+
+`allowed_models` is optional (empty = any). For Gemini the model is in the
+request path, so the gateway enforces it before proxying. For Anthropic /
+OpenAI the model is in the request body — body enforcement is a planned
+fast-follow.
+
+## Production wiring
+
+In production `provisionSkillBox` mints the gateway token alongside the
+platform JWT, using the same shared HMAC secret (`jwt.secret`). The `mint`
+subcommand is a development shortcut only.

--- a/cmd/model-gateway/main.go
+++ b/cmd/model-gateway/main.go
@@ -1,0 +1,114 @@
+// Command model-gateway is a prototype of the agent model gateway
+// (docs/AGENT-MODEL-GATEWAY-DESIGN.md). It holds the real provider API keys and
+// brokers every agent box's model calls so a key never lives in a box: a box
+// presents a short-lived, scoped gateway token; the gateway validates it,
+// injects the real key, proxies to the provider, and meters token usage per
+// tenant.
+//
+//	model-gateway serve  --secret-file /etc/containarium/jwt.secret   (keys from env)
+//	model-gateway mint   --secret-file ... --tenant T --provider gemini [--skill S] [--allowed-models a,b] [--ttl 1h]
+//
+// `mint` stands in for the daemon's provisionSkillBox, which mints the same
+// token alongside the platform JWT in production.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/modelgateway"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+	}
+	switch os.Args[1] {
+	case "serve":
+		serve(os.Args[2:])
+	case "mint":
+		mint(os.Args[2:])
+	default:
+		usage()
+	}
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: model-gateway <serve|mint> [flags]")
+	os.Exit(2)
+}
+
+func readSecret(path string) []byte {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("read secret %s: %v", path, err)
+	}
+	s := strings.TrimSpace(string(b))
+	if s == "" {
+		log.Fatalf("secret file %s is empty", path)
+	}
+	return []byte(s)
+}
+
+func serve(args []string) {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	addr := fs.String("addr", ":8866", "listen address")
+	secretFile := fs.String("secret-file", "/etc/containarium/jwt.secret", "shared HMAC secret (the daemon's jwt.secret)")
+	_ = fs.Parse(args)
+
+	secret := readSecret(*secretFile)
+	providers := modelgateway.DefaultProviders()
+
+	// The gateway holds the REAL provider keys (read from its OWN env, never a
+	// box). A provider with no key in env is simply not served.
+	keys := map[string]string{}
+	loaded := []string{}
+	for name, p := range providers {
+		if k := os.Getenv(p.KeyEnv); k != "" {
+			keys[name] = k
+			loaded = append(loaded, name)
+		}
+	}
+	if len(keys) == 0 {
+		log.Fatal("no provider keys in env — set one of ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY")
+	}
+
+	gw := modelgateway.New(modelgateway.Config{Secret: secret, Providers: providers, ProviderKeys: keys})
+	log.Printf("model-gateway: listening on %s, providers=%s (provider keys held in the gateway only)", *addr, strings.Join(loaded, ","))
+	log.Fatal(http.ListenAndServe(*addr, gw.Handler()))
+}
+
+func mint(args []string) {
+	fs := flag.NewFlagSet("mint", flag.ExitOnError)
+	secretFile := fs.String("secret-file", "/etc/containarium/jwt.secret", "shared HMAC secret")
+	tenant := fs.String("tenant", "", "tenant id (required)")
+	skill := fs.String("skill", "", "skill id")
+	run := fs.String("run", "", "run id")
+	provider := fs.String("provider", "", "provider: anthropic|openai|gemini (required)")
+	models := fs.String("allowed-models", "", "comma-separated allowed model ids (empty = any)")
+	ttl := fs.Duration("ttl", time.Hour, "token lifetime")
+	_ = fs.Parse(args)
+	if *tenant == "" || *provider == "" {
+		log.Fatal("mint: --tenant and --provider are required")
+	}
+	var allowed []string
+	if *models != "" {
+		allowed = strings.Split(*models, ",")
+	}
+	tok, err := modelgateway.MintToken(readSecret(*secretFile), modelgateway.GatewayClaims{
+		Tenant:        *tenant,
+		SkillID:       *skill,
+		RunID:         *run,
+		Provider:      *provider,
+		AllowedModels: allowed,
+	}, *ttl)
+	if err != nil {
+		log.Fatalf("mint: %v", err)
+	}
+	fmt.Println(tok)
+}

--- a/cmd/model-gateway/main.go
+++ b/cmd/model-gateway/main.go
@@ -44,7 +44,7 @@ func usage() {
 }
 
 func readSecret(path string) []byte {
-	b, err := os.ReadFile(path)
+	b, err := os.ReadFile(path) // #nosec G304 — path is an operator-supplied CLI flag, not user input
 	if err != nil {
 		log.Fatalf("read secret %s: %v", path, err)
 	}
@@ -80,7 +80,14 @@ func serve(args []string) {
 
 	gw := modelgateway.New(modelgateway.Config{Secret: secret, Providers: providers, ProviderKeys: keys})
 	log.Printf("model-gateway: listening on %s, providers=%s (provider keys held in the gateway only)", *addr, strings.Join(loaded, ","))
-	log.Fatal(http.ListenAndServe(*addr, gw.Handler()))
+	srv := &http.Server{
+		Addr:         *addr,
+		Handler:      gw.Handler(),
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 120 * time.Second, // model calls can take tens of seconds
+		IdleTimeout:  60 * time.Second,
+	}
+	log.Fatal(srv.ListenAndServe())
 }
 
 func mint(args []string) {

--- a/internal/modelgateway/gateway.go
+++ b/internal/modelgateway/gateway.go
@@ -1,0 +1,181 @@
+package modelgateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Config configures a Gateway.
+type Config struct {
+	Secret       []byte               // shared HMAC secret (the daemon's jwt.secret)
+	Providers    map[string]*Provider // provider registry (see DefaultProviders)
+	ProviderKeys map[string]string    // provider name -> REAL API key, held here only
+	Logger       *log.Logger
+}
+
+// Gateway brokers every agent box's model calls: it authenticates the box's
+// scoped gateway token, injects the real provider key (which never leaves the
+// gateway), proxies to the provider, and meters per-tenant token usage.
+type Gateway struct {
+	cfg   Config
+	meter *Meter
+}
+
+// New builds a Gateway.
+func New(cfg Config) *Gateway {
+	if cfg.Logger == nil {
+		cfg.Logger = log.Default()
+	}
+	return &Gateway{cfg: cfg, meter: NewMeter()}
+}
+
+// Meter exposes the usage rollups (for tests / the usage endpoint).
+func (g *Gateway) Meter() *Meter { return g.meter }
+
+const modelPrefix = "/v1/model/"
+
+// Handler returns the gateway's HTTP mux: the model data plane plus a usage
+// readout and a health check.
+func (g *Gateway) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(modelPrefix, g.handleModel)
+	mux.HandleFunc("/__gateway/usage", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(g.meter.Snapshot())
+	})
+	mux.HandleFunc("/__gateway/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	return mux
+}
+
+// bearer pulls the gateway token from the request, accepting the three shapes
+// the provider SDKs use when pointed at a proxy base URL: Authorization Bearer
+// (Anthropic ANTHROPIC_AUTH_TOKEN / OpenAI), x-api-key (Anthropic raw), and
+// x-goog-api-key (Gemini).
+func bearer(r *http.Request) string {
+	if h := r.Header.Get("Authorization"); strings.HasPrefix(h, "Bearer ") {
+		return strings.TrimSpace(strings.TrimPrefix(h, "Bearer "))
+	}
+	if v := r.Header.Get("x-api-key"); v != "" {
+		return v
+	}
+	if v := r.Header.Get("x-goog-api-key"); v != "" {
+		return v
+	}
+	return ""
+}
+
+func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
+	// path: /v1/model/<provider>/<upstream path...>
+	rest := strings.TrimPrefix(r.URL.Path, modelPrefix)
+	slash := strings.IndexByte(rest, '/')
+	if slash < 0 {
+		http.Error(w, "missing provider in path", http.StatusNotFound)
+		return
+	}
+	provName := rest[:slash]
+	upstreamPath := rest[slash:] // includes leading '/'
+	prov := g.cfg.Providers[provName]
+	if prov == nil {
+		http.Error(w, "unknown provider: "+provName, http.StatusNotFound)
+		return
+	}
+
+	tok := bearer(r)
+	if tok == "" {
+		http.Error(w, "missing gateway token", http.StatusUnauthorized)
+		return
+	}
+	claims, err := VerifyToken(g.cfg.Secret, tok)
+	if err != nil {
+		http.Error(w, "invalid gateway token: "+err.Error(), http.StatusUnauthorized)
+		return
+	}
+	if claims.Provider != provName {
+		http.Error(w, "token not valid for provider "+provName, http.StatusForbidden)
+		return
+	}
+
+	key := g.cfg.ProviderKeys[provName]
+	if key == "" {
+		http.Error(w, "gateway holds no key for provider "+provName, http.StatusBadGateway)
+		return
+	}
+
+	// Model ceiling (basic tiering): for Gemini the model is in the path, so we
+	// can enforce the token's allowed-model set before proxying.
+	pathModel := ""
+	if provName == "gemini" {
+		pathModel = geminiModelFromPath(upstreamPath)
+	}
+	if len(claims.AllowedModels) > 0 && pathModel != "" && !contains(claims.AllowedModels, pathModel) {
+		http.Error(w, "model not allowed by token: "+pathModel, http.StatusForbidden)
+		return
+	}
+
+	upstream, err := url.Parse(prov.UpstreamURL)
+	if err != nil {
+		http.Error(w, "bad upstream url", http.StatusInternalServerError)
+		return
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = upstream.Scheme
+			req.URL.Host = upstream.Host
+			req.Host = upstream.Host
+			req.URL.Path = upstreamPath
+			prov.inject(req.Header, key) // strip gateway token, inject real key
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			// Metering (Phase 1): best-effort on non-streaming, uncompressed
+			// JSON. Streaming (SSE) and compressed bodies pass through
+			// unmetered in the prototype.
+			if resp.Header.Get("Content-Encoding") != "" {
+				return nil
+			}
+			if !strings.Contains(resp.Header.Get("Content-Type"), "application/json") {
+				return nil
+			}
+			body, err := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if err != nil {
+				return err
+			}
+			resp.Body = io.NopCloser(bytes.NewReader(body))
+			resp.ContentLength = int64(len(body))
+			resp.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+			var decoded map[string]any
+			if json.Unmarshal(body, &decoded) == nil {
+				u := prov.parseUsage(decoded, pathModel)
+				g.meter.record(claims.Tenant, claims.SkillID, provName, u)
+				g.cfg.Logger.Printf("model-gateway: tenant=%s skill=%s provider=%s model=%s in=%d out=%d cached=%d",
+					claims.Tenant, claims.SkillID, provName, u.Model, u.InputTokens, u.OutputTokens, u.CachedTokens)
+			}
+			return nil
+		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			http.Error(w, "upstream error: "+err.Error(), http.StatusBadGateway)
+		},
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/modelgateway/gateway_test.go
+++ b/internal/modelgateway/gateway_test.go
@@ -1,0 +1,183 @@
+package modelgateway
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeUpstream stands in for the real provider API; it records the auth headers
+// it received and returns a canned usage body.
+func fakeUpstream(t *testing.T, record func(r *http.Request), body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+}
+
+func TestGateway_Anthropic_KeyInjected_TokenStripped_Metered(t *testing.T) {
+	secret := []byte("shared-secret")
+	var xKey, auth, gotPath string
+	up := fakeUpstream(t, func(r *http.Request) {
+		xKey = r.Header.Get("x-api-key")
+		auth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+	}, `{"model":"claude-test","usage":{"input_tokens":12,"output_tokens":4,"cache_read_input_tokens":2}}`)
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["anthropic"].UpstreamURL = up.URL
+	gw := New(Config{Secret: secret, Providers: providers, ProviderKeys: map[string]string{"anthropic": "REAL-KEY"}})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	tok, err := MintToken(secret, GatewayClaims{Tenant: "acme", SkillID: "s1", Provider: "anthropic"}, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/model/anthropic/v1/messages", strings.NewReader(`{"model":"claude-test"}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status %d: %s", resp.StatusCode, b)
+	}
+
+	if xKey != "REAL-KEY" {
+		t.Errorf("real provider key not injected upstream: x-api-key=%q", xKey)
+	}
+	if auth != "" {
+		t.Errorf("gateway token leaked upstream: Authorization=%q", auth)
+	}
+	if gotPath != "/v1/messages" {
+		t.Errorf("upstream path = %q, want /v1/messages (prefix not stripped)", gotPath)
+	}
+
+	rows := gw.Meter().Snapshot()
+	if len(rows) != 1 {
+		t.Fatalf("want 1 meter row, got %d: %+v", len(rows), rows)
+	}
+	r := rows[0]
+	if r.Tenant != "acme" || r.Skill != "s1" || r.Provider != "anthropic" || r.Model != "claude-test" {
+		t.Errorf("attribution wrong: %+v", r)
+	}
+	if r.InputTokens != 12 || r.OutputTokens != 4 || r.CachedTokens != 2 || r.Calls != 1 {
+		t.Errorf("token counts wrong: %+v", r)
+	}
+}
+
+func TestGateway_Gemini_PathModel_AllowedModelsEnforced(t *testing.T) {
+	secret := []byte("s")
+	var gKey string
+	up := fakeUpstream(t, func(r *http.Request) {
+		gKey = r.Header.Get("x-goog-api-key")
+	}, `{"usageMetadata":{"promptTokenCount":100,"candidatesTokenCount":20,"cachedContentTokenCount":50}}`)
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["gemini"].UpstreamURL = up.URL
+	gw := New(Config{Secret: secret, Providers: providers, ProviderKeys: map[string]string{"gemini": "GKEY"}})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	// token allows only gemini-2.5-flash
+	tok, _ := MintToken(secret, GatewayClaims{Tenant: "t", Provider: "gemini", AllowedModels: []string{"gemini-2.5-flash"}}, time.Minute)
+
+	do := func(model string) int {
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/model/gemini/v1beta/models/"+model+":generateContent", strings.NewReader("{}"))
+		req.Header.Set("x-goog-api-key", tok) // how @google/genai sends the key
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	if c := do("gemini-2.5-flash"); c != 200 {
+		t.Fatalf("allowed model: status %d, want 200", c)
+	}
+	if gKey != "GKEY" {
+		t.Errorf("gemini key not injected: x-goog-api-key=%q", gKey)
+	}
+	if c := do("gemini-2.5-pro"); c != 403 {
+		t.Fatalf("disallowed model: status %d, want 403", c)
+	}
+
+	rows := gw.Meter().Snapshot()
+	if len(rows) != 1 || rows[0].Model != "gemini-2.5-flash" {
+		t.Fatalf("gemini metering/attribution wrong: %+v", rows)
+	}
+	if rows[0].InputTokens != 100 || rows[0].OutputTokens != 20 || rows[0].CachedTokens != 50 {
+		t.Errorf("gemini token counts wrong: %+v", rows[0])
+	}
+}
+
+func TestGateway_RejectsBadTokens(t *testing.T) {
+	secret := []byte("s")
+	gw := New(Config{Secret: secret, Providers: DefaultProviders(), ProviderKeys: map[string]string{"anthropic": "k"}})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	post := func(hdr, val string) int {
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/model/anthropic/v1/messages", strings.NewReader("{}"))
+		if hdr != "" {
+			req.Header.Set(hdr, val)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	if c := post("", ""); c != 401 {
+		t.Errorf("missing token: want 401, got %d", c)
+	}
+
+	badSig, _ := MintToken([]byte("other-secret"), GatewayClaims{Tenant: "t", Provider: "anthropic"}, time.Minute)
+	if c := post("Authorization", "Bearer "+badSig); c != 401 {
+		t.Errorf("wrong-signature token: want 401, got %d", c)
+	}
+
+	expired, _ := MintToken(secret, GatewayClaims{Tenant: "t", Provider: "anthropic"}, -time.Minute)
+	if c := post("Authorization", "Bearer "+expired); c != 401 {
+		t.Errorf("expired token: want 401, got %d", c)
+	}
+
+	wrongProv, _ := MintToken(secret, GatewayClaims{Tenant: "t", Provider: "gemini"}, time.Minute)
+	if c := post("Authorization", "Bearer "+wrongProv); c != 403 {
+		t.Errorf("provider-mismatch token: want 403, got %d", c)
+	}
+}
+
+func TestMintVerify_RoundTrip(t *testing.T) {
+	secret := []byte("s")
+	tok, err := MintToken(secret, GatewayClaims{Tenant: "acme", Provider: "gemini", AllowedModels: []string{"gemini-2.5-flash"}}, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := VerifyToken(secret, tok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Tenant != "acme" || c.Provider != "gemini" || len(c.AllowedModels) != 1 {
+		t.Fatalf("claims round-trip wrong: %+v", c)
+	}
+	if _, err := VerifyToken([]byte("nope"), tok); err == nil {
+		t.Error("verify with wrong secret should fail")
+	}
+}

--- a/internal/modelgateway/meter.go
+++ b/internal/modelgateway/meter.go
@@ -1,0 +1,69 @@
+package modelgateway
+
+import (
+	"sort"
+	"sync"
+)
+
+// meterKey attributes usage to a tenant/skill/provider/model.
+type meterKey struct {
+	tenant, skill, provider, model string
+}
+
+// MeterRow is a snapshot of one attribution bucket.
+type MeterRow struct {
+	Tenant       string `json:"tenant"`
+	Skill        string `json:"skill,omitempty"`
+	Provider     string `json:"provider"`
+	Model        string `json:"model"`
+	Calls        int64  `json:"calls"`
+	InputTokens  int64  `json:"input_tokens"`
+	OutputTokens int64  `json:"output_tokens"`
+	CachedTokens int64  `json:"cached_tokens"`
+}
+
+// Meter is the in-memory per-tenant model-token writer the metering plane lacks
+// today. Prototype: in-memory only; production writes the same shape into
+// usage_rollups (see the design note's "metering/billing fit").
+type Meter struct {
+	mu   sync.Mutex
+	rows map[meterKey]*MeterRow
+}
+
+// NewMeter returns an empty Meter.
+func NewMeter() *Meter { return &Meter{rows: map[meterKey]*MeterRow{}} }
+
+func (m *Meter) record(tenant, skill, provider string, u Usage) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := meterKey{tenant, skill, provider, u.Model}
+	r := m.rows[k]
+	if r == nil {
+		r = &MeterRow{Tenant: tenant, Skill: skill, Provider: provider, Model: u.Model}
+		m.rows[k] = r
+	}
+	r.Calls++
+	r.InputTokens += u.InputTokens
+	r.OutputTokens += u.OutputTokens
+	r.CachedTokens += u.CachedTokens
+}
+
+// Snapshot returns the rollups in a stable order.
+func (m *Meter) Snapshot() []MeterRow {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]MeterRow, 0, len(m.rows))
+	for _, r := range m.rows {
+		out = append(out, *r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Tenant != out[j].Tenant {
+			return out[i].Tenant < out[j].Tenant
+		}
+		if out[i].Provider != out[j].Provider {
+			return out[i].Provider < out[j].Provider
+		}
+		return out[i].Model < out[j].Model
+	})
+	return out
+}

--- a/internal/modelgateway/providers.go
+++ b/internal/modelgateway/providers.go
@@ -1,0 +1,127 @@
+package modelgateway
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Provider describes one upstream model API the gateway brokers. The two
+// engines the agent-runtime ships (Anthropic, OpenAI) plus Gemini (the cheap
+// test engine) match the agent-runtime's three engines.
+type Provider struct {
+	Name        string
+	UpstreamURL string // scheme://host, no trailing slash
+	KeyEnv      string // env var the gateway reads the REAL provider key from
+
+	// inject sets the upstream's auth header from the real provider key and
+	// strips any inbound gateway credential, so the gateway token never leaks
+	// upstream and the real key never came from the box.
+	inject func(h http.Header, key string)
+	// parseUsage extracts token usage + model from a decoded JSON response.
+	// pathModel is the model id recovered from the request path (Gemini puts
+	// the model in the URL, not the response body).
+	parseUsage func(body map[string]any, pathModel string) Usage
+}
+
+// Usage is the metered token counts for one model call.
+type Usage struct {
+	Model        string
+	InputTokens  int64
+	OutputTokens int64
+	CachedTokens int64
+}
+
+func stripGatewayAuth(h http.Header) {
+	h.Del("Authorization")
+	h.Del("X-Api-Key")
+	h.Del("X-Goog-Api-Key")
+}
+
+func num(m map[string]any, k string) int64 {
+	if v, ok := m[k].(float64); ok {
+		return int64(v)
+	}
+	return 0
+}
+
+func subMap(m map[string]any, k string) map[string]any {
+	if v, ok := m[k].(map[string]any); ok {
+		return v
+	}
+	return nil
+}
+
+// DefaultProviders is the prototype's provider registry.
+func DefaultProviders() map[string]*Provider {
+	return map[string]*Provider{
+		"anthropic": {
+			Name:        "anthropic",
+			UpstreamURL: "https://api.anthropic.com",
+			KeyEnv:      "ANTHROPIC_API_KEY",
+			inject: func(h http.Header, key string) {
+				stripGatewayAuth(h)
+				h.Set("x-api-key", key)
+			},
+			parseUsage: func(b map[string]any, _ string) Usage {
+				u := subMap(b, "usage")
+				model, _ := b["model"].(string)
+				return Usage{
+					Model:        model,
+					InputTokens:  num(u, "input_tokens"),
+					OutputTokens: num(u, "output_tokens"),
+					CachedTokens: num(u, "cache_read_input_tokens"),
+				}
+			},
+		},
+		"openai": {
+			Name:        "openai",
+			UpstreamURL: "https://api.openai.com",
+			KeyEnv:      "OPENAI_API_KEY",
+			inject: func(h http.Header, key string) {
+				stripGatewayAuth(h)
+				h.Set("Authorization", "Bearer "+key)
+			},
+			parseUsage: func(b map[string]any, _ string) Usage {
+				u := subMap(b, "usage")
+				model, _ := b["model"].(string)
+				return Usage{
+					Model:        model,
+					InputTokens:  num(u, "prompt_tokens"),
+					OutputTokens: num(u, "completion_tokens"),
+				}
+			},
+		},
+		"gemini": {
+			Name:        "gemini",
+			UpstreamURL: "https://generativelanguage.googleapis.com",
+			KeyEnv:      "GEMINI_API_KEY",
+			inject: func(h http.Header, key string) {
+				stripGatewayAuth(h)
+				h.Set("x-goog-api-key", key)
+			},
+			parseUsage: func(b map[string]any, pathModel string) Usage {
+				u := subMap(b, "usageMetadata")
+				return Usage{
+					Model:        pathModel,
+					InputTokens:  num(u, "promptTokenCount"),
+					OutputTokens: num(u, "candidatesTokenCount"),
+					CachedTokens: num(u, "cachedContentTokenCount"),
+				}
+			},
+		},
+	}
+}
+
+// geminiModelFromPath pulls the model id out of a Gemini path like
+// /v1beta/models/gemini-2.5-flash:generateContent.
+func geminiModelFromPath(p string) string {
+	i := strings.Index(p, "/models/")
+	if i < 0 {
+		return ""
+	}
+	rest := p[i+len("/models/"):]
+	if c := strings.IndexAny(rest, ":/"); c >= 0 {
+		rest = rest[:c]
+	}
+	return rest
+}

--- a/internal/modelgateway/token.go
+++ b/internal/modelgateway/token.go
@@ -1,0 +1,85 @@
+// Package modelgateway is a prototype of the agent model gateway
+// (docs/AGENT-MODEL-GATEWAY-DESIGN.md): a single egress point that holds the
+// provider API key and brokers every agent box's model calls, so the key never
+// lives in a box. A box presents a short-lived, scoped *gateway token* instead
+// of a raw provider key; the gateway validates it, injects the real key (held
+// only here), proxies to the provider, and meters token usage per tenant.
+//
+// This implements Phase 0 (transparent proxy + key custody) and Phase 1
+// (metering) of the design note. Caching, central tiering, rate-limiting, and
+// persistent rollups are later phases. Mechanism-only — no named tenants,
+// skills, or packs.
+package modelgateway
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// gatewayTokenIssuer scopes the token to this gateway so a platform JWT minted
+// for another purpose can't be replayed against the model egress.
+const gatewayTokenIssuer = "containarium-model-gateway"
+
+// GatewayClaims is the model-gateway token: a scoped, short-lived credential a
+// box presents instead of a raw provider key. It is signed HS256 with the
+// daemon's shared secret (the same trust root as the platform JWT — no new
+// PKI), carries the attribution the gateway meters by, and the model ceiling it
+// enforces.
+//
+// In production this is minted inside the daemon's provisionSkillBox alongside
+// the platform JWT (the design's "no new mint verb" point); the prototype's
+// `mint` subcommand calls MintToken directly for testing.
+type GatewayClaims struct {
+	Tenant        string   `json:"tenant"`
+	SkillID       string   `json:"skill_id,omitempty"`
+	RunID         string   `json:"run_id,omitempty"`
+	Provider      string   `json:"provider"`
+	AllowedModels []string `json:"allowed_models,omitempty"`
+	jwt.RegisteredClaims
+}
+
+// MintToken signs a gateway token bound to one tenant/provider, expiring after
+// ttl.
+func MintToken(secret []byte, c GatewayClaims, ttl time.Duration) (string, error) {
+	if c.Tenant == "" {
+		return "", fmt.Errorf("tenant required")
+	}
+	if c.Provider == "" {
+		return "", fmt.Errorf("provider required")
+	}
+	jti := make([]byte, 16)
+	if _, err := rand.Read(jti); err != nil {
+		return "", err
+	}
+	now := time.Now()
+	c.RegisteredClaims = jwt.RegisteredClaims{
+		Issuer:    gatewayTokenIssuer,
+		Subject:   c.Tenant,
+		ID:        hex.EncodeToString(jti),
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
+	}
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, c).SignedString(secret)
+}
+
+// VerifyToken validates signature, issuer, and expiry, returning the claims.
+func VerifyToken(secret []byte, tokenString string) (*GatewayClaims, error) {
+	claims := &GatewayClaims{}
+	tok, err := jwt.ParseWithClaims(tokenString, claims, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return secret, nil
+	}, jwt.WithIssuer(gatewayTokenIssuer), jwt.WithValidMethods([]string{"HS256"}))
+	if err != nil {
+		return nil, err
+	}
+	if !tok.Valid {
+		return nil, fmt.Errorf("invalid token")
+	}
+	return claims, nil
+}

--- a/internal/modelgateway/token.go
+++ b/internal/modelgateway/token.go
@@ -20,9 +20,9 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-// gatewayTokenIssuer scopes the token to this gateway so a platform JWT minted
-// for another purpose can't be replayed against the model egress.
-const gatewayTokenIssuer = "containarium-model-gateway"
+// gatewayIssuer scopes the JWT to this gateway so a platform JWT minted for
+// another purpose can't be replayed against the model egress.
+const gatewayIssuer = "containarium-model-gateway"
 
 // GatewayClaims is the model-gateway token: a scoped, short-lived credential a
 // box presents instead of a raw provider key. It is signed HS256 with the
@@ -57,7 +57,7 @@ func MintToken(secret []byte, c GatewayClaims, ttl time.Duration) (string, error
 	}
 	now := time.Now()
 	c.RegisteredClaims = jwt.RegisteredClaims{
-		Issuer:    gatewayTokenIssuer,
+		Issuer:    gatewayIssuer,
 		Subject:   c.Tenant,
 		ID:        hex.EncodeToString(jti),
 		IssuedAt:  jwt.NewNumericDate(now),
@@ -74,7 +74,7 @@ func VerifyToken(secret []byte, tokenString string) (*GatewayClaims, error) {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
 		return secret, nil
-	}, jwt.WithIssuer(gatewayTokenIssuer), jwt.WithValidMethods([]string{"HS256"}))
+	}, jwt.WithIssuer(gatewayIssuer), jwt.WithValidMethods([]string{"HS256"}))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Adds `cmd/model-gateway` + `internal/modelgateway` — a reverse-proxy that holds the real provider API keys so agent boxes never touch them
- Boxes authenticate with short-lived, scoped **gateway tokens** (HS256 JWTs signed with the same shared secret as the platform JWT); the gateway verifies, injects the real key, proxies, and meters
- Gemini engine wired for gateway mode via `CONTAINARIUM_MODEL_GATEWAY_URL` + `CONTAINARIUM_GATEWAY_TOKEN`; Claude/OpenAI engines already honour their SDK's base-URL env vars (no code change)
- `make build-model-gateway-linux` builds the Linux binary

## What's in the prototype

| File | Role |
|---|---|
| `internal/modelgateway/token.go` | `GatewayClaims` JWT mint/verify |
| `internal/modelgateway/providers.go` | Provider registry (anthropic/openai/gemini) — key-inject + usage-parse |
| `internal/modelgateway/meter.go` | In-memory per-tenant/skill/model token rollup |
| `internal/modelgateway/gateway.go` | `Handler()` — auth, allowed-models ceiling, reverse-proxy, metering |
| `internal/modelgateway/gateway_test.go` | 4 tests — key injection, token stripping, metering, allowed-models enforcement, bad-token rejection |
| `cmd/model-gateway/main.go` | `serve` + `mint` subcommands |
| `cmd/model-gateway/README.md` | Operator quick-start + integration guide |

## Test plan

- [x] `go test ./internal/modelgateway/` — all 4 tests pass
- [x] `go build ./internal/modelgateway/ ./cmd/model-gateway/` — clean
- [x] `go vet` — clean
- [x] TypeScript `tsc --noEmit` — clean (gemini.ts gateway path type-checks)
- [ ] Live integration: deploy gateway on a platform host, provision a skill box with `CONTAINARIUM_MODEL_GATEWAY_URL` + `CONTAINARIUM_GATEWAY_TOKEN`, run a Gemini agent task, confirm usage appears in `/__gateway/usage`

Design: `docs/AGENT-MODEL-GATEWAY-DESIGN.md` (PR #674)
Security property: `docs/AGENT-DATA-PLANE-SEPARATION-DESIGN.md` (PR #735)

🤖 Generated with [Claude Code](https://claude.com/claude-code)