### PR TITLE
fix(byoc): driver-token auto-refresh — daemon side (#557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **BYOC driver-token auto-refresh (#557).** A host enrolled with `cloud enroll`
+  now keeps itself cloud-drivable past the 30-day token-expiry cap with no manual
+  re-enroll. `cloud enroll` records the JWT-secret path in `cloud.yaml`
+  (`jwt_secret_file`); the daemon's actuation client then re-mints a fresh admin
+  driver token every ~20 days (⅔ of the cap) and pushes it to the cloud over the
+  existing `ReportHostStatus` channel (new optional `driver_token` field). The
+  cloud reseals and overwrites its stored credential, so it never expires.
+  Best-effort: a missed cycle leaves ~10 days of runway. Hosts enrolled with
+  `--no-driver-token` are unaffected.
 - **Gemini engine for the in-box agent loop (`agent-runtime`).** A third
   pluggable engine alongside Claude and Codex, selected with
   `CONTAINARIUM_AGENT_ENGINE=gemini`. It drives the loop with the Google Gen AI

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -10080,6 +10080,10 @@
             "type": "object",
             "$ref": "#/definitions/HostCapabilityCheck"
           }
+        },
+        "driverToken": {
+          "type": "string",
+          "description": "driver_token is a freshly-minted admin JWT from this host's own jwt.secret\n(#557). If non-empty the cloud reseals it and overwrites the stored driver\ntoken, keeping the cloud-stored credential from expiring after 30 days."
         }
       },
       "description": "ReportHostStatusRequest is a BYO host's push of its self-measured\ncapability profile + `doctor` self-check. Host-bearer authed; the host id\ncomes from the bearer, never the body."

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -28,6 +28,11 @@ const hostBearerMetadataKey = "host-bearer"
 // staleness threshold is ~3 missed beats; see the cloud container-actuation PRD.
 const defaultHeartbeatInterval = 30 * time.Second
 
+// driverRefreshInterval is how often the daemon re-mints and pushes a fresh
+// driver token (#557). Set to ⅔ of the 30-day OSS cap so there is always at
+// least 10 days of runway before expiry, even if one refresh cycle fails.
+const driverRefreshInterval = 20 * 24 * time.Hour
+
 // PolicySink receives each AssignmentBatch's per-org network policies so the
 // daemon can converge its NetworkPolicyStore (where the eBPF enforcer applies
 // them). The daemon implements this; keeping it an interface lets the client be
@@ -110,6 +115,12 @@ type StatusProbe interface {
 	Probe(ctx context.Context) (HostStatus, error)
 }
 
+// DriverMinter mints a fresh BYOC driver token (an admin JWT signed with this
+// host's own jwt.secret). Called by the driver-refresh loop (#557) ~every 20
+// days to keep the cloud-stored credential from reaching the 30-day expiry cap.
+// Returns the raw JWT string. The function is optional in Deps; nil = no refresh.
+type DriverMinter func() (string, error)
+
 // Deps are the daemon-provided collaborators. All optional: nil Policies
 // skips network-policy sync, nil Containers skips container reconcile, nil
 // Status skips capability reporting. With all nil the client is
@@ -118,6 +129,10 @@ type Deps struct {
 	Policies   PolicySink
 	Containers ContainerActuator
 	Status     StatusProbe
+	// Driver, when non-nil, enables autonomous driver-token refresh (#557).
+	// The daemon provides this when cloud.yaml has a JWTSecretFile set (i.e.
+	// the host enrolled as a BYOC backend with a driver token).
+	Driver DriverMinter
 }
 
 // unaryActuation is the subset of the actuation API the client drives over a
@@ -140,7 +155,8 @@ type Client struct {
 	sink       PolicySink        // optional; nil = no policy reconcile
 	containers ContainerActuator // optional; nil = no container reconcile
 
-	status StatusProbe // optional; nil = no capability reporting
+	status StatusProbe  // optional; nil = no capability reporting
+	driver DriverMinter // optional; nil = no driver-token refresh (#557)
 
 	conn *grpc.ClientConn
 	// ac handles the unary actuation RPCs (heartbeat + status); it is either the
@@ -164,7 +180,11 @@ func New(cfg *Config, deps Deps) (*Client, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
-	return &Client{cfg: cfg, interval: defaultHeartbeatInterval, sink: deps.Policies, containers: deps.Containers, status: deps.Status}, nil
+	return &Client{
+		cfg: cfg, interval: defaultHeartbeatInterval,
+		sink: deps.Policies, containers: deps.Containers,
+		status: deps.Status, driver: deps.Driver,
+	}, nil
 }
 
 // Start dials the control plane and launches the heartbeat loop. A dial error is
@@ -203,8 +223,12 @@ func (c *Client) Start(ctx context.Context) error {
 		c.wg.Add(1)
 		go c.statusLoop()
 	}
-	log.Printf("[cloud] actuation client started: host=%s control-plane=%s (heartbeat %s, watch=%v, status=%v)",
-		c.cfg.HostID, c.cfg.ControlPlane, c.interval, watch, c.status != nil)
+	if c.driver != nil {
+		c.wg.Add(1)
+		go c.driverRefreshLoop()
+	}
+	log.Printf("[cloud] actuation client started: host=%s control-plane=%s (heartbeat %s, watch=%v, status=%v, driver-refresh=%v)",
+		c.cfg.HostID, c.cfg.ControlPlane, c.interval, watch, c.status != nil, c.driver != nil)
 	return nil
 }
 
@@ -324,6 +348,44 @@ func (c *Client) reportStatusOnce() {
 	}); err != nil {
 		log.Printf("[cloud] report host status: %v", err)
 	}
+}
+
+// driverRefreshLoop re-mints the BYOC driver token on a ~20-day cycle so the
+// cloud-stored credential never reaches the 30-day cap (#557). Fires once
+// immediately on startup so a freshly-enrolled daemon pushes a token right
+// away, then sleeps for driverRefreshInterval between rounds. Best-effort:
+// mint/RPC failures are logged and retried on the next cycle — one missed
+// refresh leaves ~10 days of runway before the old token expires.
+func (c *Client) driverRefreshLoop() {
+	defer c.wg.Done()
+	c.refreshDriverTokenOnce()
+	t := time.NewTicker(driverRefreshInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-t.C:
+			c.refreshDriverTokenOnce()
+		}
+	}
+}
+
+func (c *Client) refreshDriverTokenOnce() {
+	tok, err := c.driver()
+	if err != nil {
+		log.Printf("[cloud] driver-token refresh: mint failed: %v", err)
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.authContext(c.ctx), 10*time.Second)
+	defer cancel()
+	if _, err := c.ac.ReportHostStatus(ctx, &cloudv1.ReportHostStatusRequest{
+		DriverToken: tok,
+	}); err != nil {
+		log.Printf("[cloud] driver-token refresh: push failed: %v", err)
+		return
+	}
+	log.Printf("[cloud] driver-token refreshed (next in %s)", driverRefreshInterval)
 }
 
 func (c *Client) heartbeatLoop() {

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -325,6 +325,54 @@ func TestReportStatusOnce_SendsCapabilityWithBearer(t *testing.T) {
 	}
 }
 
+// TestRefreshDriverTokenOnce_PushesMintedToken covers #557: the refresh loop
+// mints a fresh driver token and pushes it via ReportHostStatus with the host
+// bearer attached, so the cloud can reseal + overwrite the stored credential.
+func TestRefreshDriverTokenOnce_PushesMintedToken(t *testing.T) {
+	c, fake := newTestClient(t, &Config{
+		ControlPlane: "bufnet", HostID: "h1", Token: "h1.secret", Insecure: true,
+	})
+	c.driver = func() (string, error) { return "fresh.minted.jwt", nil }
+
+	c.refreshDriverTokenOnce()
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.statusReports != 1 {
+		t.Fatalf("want 1 status report, got %d", fake.statusReports)
+	}
+	if fake.statusBearer != "h1.secret" {
+		t.Errorf("driver-token refresh missing host bearer: got %q", fake.statusBearer)
+	}
+	if got := fake.statusReq.GetDriverToken(); got != "fresh.minted.jwt" {
+		t.Errorf("driver token not pushed: got %q", got)
+	}
+}
+
+// TestRefreshDriverTokenOnce_MintFailureSkipsPush confirms a mint error is
+// swallowed (logged) and no RPC is sent — the old token stays valid until the
+// next cycle.
+func TestRefreshDriverTokenOnce_MintFailureSkipsPush(t *testing.T) {
+	c, fake := newTestClient(t, &Config{
+		ControlPlane: "bufnet", HostID: "h1", Token: "h1.secret", Insecure: true,
+	})
+	c.driver = func() (string, error) { return "", errMintFailed }
+
+	c.refreshDriverTokenOnce()
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if fake.statusReports != 0 {
+		t.Fatalf("mint failure must not push a status report, got %d", fake.statusReports)
+	}
+}
+
+var errMintFailed = errorString("mint failed")
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
 func TestEnroll_RedeemsTokenAndReturnsHostID(t *testing.T) {
 	// Enroll dials its own connection, so use a real loopback TCP server
 	// (bufconn isn't reachable by grpc.NewClient(addr)).

--- a/internal/cloud/config.go
+++ b/internal/cloud/config.go
@@ -40,6 +40,12 @@ type Config struct {
 	// for a self-hosted plaintext control plane or local dev — never for a
 	// public cloud endpoint.
 	Insecure bool `yaml:"insecure,omitempty"`
+	// JWTSecretFile is the path to this daemon's JWT signing secret (#557).
+	// When set, the daemon's cloud actuation client re-mints a fresh driver
+	// token every ~⅔ of the 30-day cap and pushes it to the cloud via
+	// ReportHostStatus so the cloud-stored credential never expires.
+	// Written by `containarium cloud enroll`; empty disables auto-refresh.
+	JWTSecretFile string `yaml:"jwt_secret_file,omitempty"`
 }
 
 // DefaultPath resolves $HOME/.containarium/cloud.yaml.

--- a/internal/cloud/config_test.go
+++ b/internal/cloud/config_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestConfigRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "sub", "cloud.yaml")
-	in := &Config{ControlPlane: "cloud.example:443", HostID: "11111111-1111-1111-1111-111111111111", Token: "secret-bearer"}
+	in := &Config{ControlPlane: "cloud.example:443", HostID: "11111111-1111-1111-1111-111111111111", Token: "secret-bearer", JWTSecretFile: "/etc/containarium/jwt.secret"}
 	if err := Save(path, in); err != nil {
 		t.Fatalf("Save: %v", err)
 	}

--- a/internal/cloud/token.go
+++ b/internal/cloud/token.go
@@ -1,0 +1,40 @@
+package cloud
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+// MintDriverToken reads the daemon's JWT signing secret from secretFile and
+// mints an admin JWT valid for ttl. This is the BYOC driver token (#554/#557):
+// signed by the host's own secret, replayed by the cloud to drive this daemon
+// through the sentinel peer-proxy. The cloud-stored token is sealed at rest;
+// MintDriverToken is called at enroll time and then periodically by the
+// driverRefreshLoop so the cloud-stored credential never reaches the 30-day cap.
+func MintDriverToken(secretFile string, ttl time.Duration) (string, error) {
+	secretFile = strings.TrimSpace(secretFile)
+	if secretFile == "" {
+		return "", fmt.Errorf("no jwt-secret-file")
+	}
+	secretBytes, err := os.ReadFile(secretFile) // #nosec G304 -- operator-provided daemon secret path
+	if err != nil {
+		return "", fmt.Errorf("read jwt secret %s: %w", secretFile, err)
+	}
+	secret := strings.TrimSpace(string(secretBytes))
+	if secret == "" {
+		return "", fmt.Errorf("jwt secret %s is empty", secretFile)
+	}
+	tm, err := auth.NewTokenManager(secret, "containarium")
+	if err != nil {
+		return "", fmt.Errorf("token manager: %w", err)
+	}
+	tok, err := tm.GenerateToken("cloud-byoc-driver", []string{"admin"}, ttl)
+	if err != nil {
+		return "", fmt.Errorf("mint driver token: %w", err)
+	}
+	return tok, nil
+}

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/cloud"
 )
 
@@ -193,6 +192,15 @@ func runCloudEnroll(cmd *cobra.Command, _ []string) error {
 		HostID:       hostID,
 		Token:        token,
 		Insecure:     cloudEnrollInsecure,
+		// Persist the JWT secret path so the daemon can re-mint the driver
+		// token autonomously before it expires (#557). Only set when the
+		// enroll actually minted a driver token (no-driver-token = no refresh).
+		JWTSecretFile: func() string {
+			if cloudEnrollNoDriverToken || opts.DriverToken == "" {
+				return ""
+			}
+			return cloudEnrollJWTSecretFile
+		}(),
 	}
 	if err := cfg.Validate(); err != nil {
 		return err
@@ -240,36 +248,10 @@ func runCloudLogout(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// mintDriverToken reads this daemon's JWT secret and mints a short-lived admin
-// access token (cloud #554). The cloud seals + replays it to drive this host's
-// daemon through the sentinel peer-proxy; because it's signed with the host's
-// OWN secret, the host's daemon accepts it without the cloud ever learning the
-// secret. ttl is capped at the daemon max (30d) by the token manager, so the
-// cloud-stored token expires — re-run `cloud enroll` to rotate.
+// mintDriverToken is a thin wrapper around cloud.MintDriverToken kept for the
+// cmd package tests. See internal/cloud/token.go for the shared implementation.
 func mintDriverToken(secretFile string, ttl time.Duration) (string, error) {
-	secretFile = strings.TrimSpace(secretFile)
-	if secretFile == "" {
-		return "", fmt.Errorf("no --jwt-secret-file")
-	}
-	secretBytes, err := os.ReadFile(secretFile) // #nosec G304 -- operator-provided daemon secret path
-	if err != nil {
-		return "", fmt.Errorf("read jwt secret %s: %w", secretFile, err)
-	}
-	secret := strings.TrimSpace(string(secretBytes))
-	if secret == "" {
-		return "", fmt.Errorf("jwt secret %s is empty", secretFile)
-	}
-	tm, err := auth.NewTokenManager(secret, "containarium")
-	if err != nil {
-		return "", fmt.Errorf("token manager: %w", err)
-	}
-	// admin role: the cloud drives container CRUD on this host through the
-	// driver — same privilege the region-primary driver token carries.
-	tok, err := tm.GenerateToken("cloud-byoc-driver", []string{"admin"}, ttl)
-	if err != nil {
-		return "", fmt.Errorf("mint driver token: %w", err)
-	}
-	return tok, nil
+	return cloud.MintDriverToken(secretFile, ttl)
 }
 
 // redactToken shows only enough to recognize which token is stored, never the

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -913,6 +913,15 @@ skipAppHosting:
 		} else {
 			cloudDeps.Containers = cloudActuator // only set when non-nil (avoid nil-iface trap)
 		}
+		// Driver-token auto-refresh (#557): if cloud.yaml has a JWTSecretFile,
+		// provide a minter so the actuation client keeps the cloud-stored
+		// driver credential from reaching the 30-day OSS cap.
+		if cloudCfg.JWTSecretFile != "" {
+			secretFile := cloudCfg.JWTSecretFile // capture for closure
+			cloudDeps.Driver = func() (string, error) {
+				return cloud.MintDriverToken(secretFile, 30*24*time.Hour)
+			}
+		}
 		if cc, nerr := cloud.New(cloudCfg, cloudDeps); nerr != nil {
 			log.Printf("Warning: cloud-actuation config invalid: %v (running single-tenant)", nerr)
 		} else {

--- a/pkg/pb/containarium/cloud/v1/actuation_service.pb.go
+++ b/pkg/pb/containarium/cloud/v1/actuation_service.pb.go
@@ -966,6 +966,10 @@ type ReportHostStatusRequest struct {
 	AvailGpuCount int32                  `protobuf:"varint,9,opt,name=avail_gpu_count,json=availGpuCount,proto3" json:"avail_gpu_count,omitempty"`
 	SelfCheckOk   bool                   `protobuf:"varint,10,opt,name=self_check_ok,json=selfCheckOk,proto3" json:"self_check_ok,omitempty"`
 	Checks        []*HostCapabilityCheck `protobuf:"bytes,11,rep,name=checks,proto3" json:"checks,omitempty"`
+	// driver_token is a freshly-minted admin JWT from this host's own jwt.secret
+	// (#557). If non-empty the cloud reseals it and overwrites the stored driver
+	// token, keeping the cloud-stored credential from expiring after 30 days.
+	DriverToken   string `protobuf:"bytes,12,opt,name=driver_token,json=driverToken,proto3" json:"driver_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1077,6 +1081,13 @@ func (x *ReportHostStatusRequest) GetChecks() []*HostCapabilityCheck {
 	return nil
 }
 
+func (x *ReportHostStatusRequest) GetDriverToken() string {
+	if x != nil {
+		return x.DriverToken
+	}
+	return ""
+}
+
 type ReportHostStatusResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ReceivedAt    *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=received_at,json=receivedAt,proto3" json:"received_at,omitempty"`
@@ -1186,7 +1197,7 @@ const file_containarium_cloud_v1_actuation_service_proto_rawDesc = "" +
 	"\x13HostCapabilityCheck\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02ok\x18\x02 \x01(\bR\x02ok\x12\x16\n" +
-	"\x06detail\x18\x03 \x01(\tR\x06detail\"\xba\x03\n" +
+	"\x06detail\x18\x03 \x01(\tR\x06detail\"\xdd\x03\n" +
 	"\x17ReportHostStatusRequest\x12#\n" +
 	"\ragent_version\x18\x01 \x01(\tR\fagentVersion\x12\x1b\n" +
 	"\tcpu_cores\x18\x02 \x01(\x05R\bcpuCores\x12 \n" +
@@ -1201,7 +1212,8 @@ const file_containarium_cloud_v1_actuation_service_proto_rawDesc = "" +
 	"\x0favail_gpu_count\x18\t \x01(\x05R\ravailGpuCount\x12\"\n" +
 	"\rself_check_ok\x18\n" +
 	" \x01(\bR\vselfCheckOk\x12B\n" +
-	"\x06checks\x18\v \x03(\v2*.containarium.cloud.v1.HostCapabilityCheckR\x06checks\"W\n" +
+	"\x06checks\x18\v \x03(\v2*.containarium.cloud.v1.HostCapabilityCheckR\x06checks\x12!\n" +
+	"\fdriver_token\x18\f \x01(\tR\vdriverToken\"W\n" +
 	"\x18ReportHostStatusResponse\x12;\n" +
 	"\vreceived_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"receivedAt*{\n" +

--- a/proto/containarium/cloud/v1/actuation_service.proto
+++ b/proto/containarium/cloud/v1/actuation_service.proto
@@ -258,6 +258,10 @@ message ReportHostStatusRequest {
   int32 avail_gpu_count = 9;
   bool self_check_ok = 10;
   repeated HostCapabilityCheck checks = 11;
+  // driver_token is a freshly-minted admin JWT from this host's own jwt.secret
+  // (#557). If non-empty the cloud reseals it and overwrites the stored driver
+  // token, keeping the cloud-stored credential from expiring after 30 days.
+  string driver_token = 12;
 }
 
 message ReportHostStatusResponse {


### PR DESCRIPTION
## Problem

A host enrolled with `containarium cloud enroll` mints a BYOC driver token (an admin JWT signed with its own `jwt.secret`) that the control plane replays to drive the host. The daemon caps token TTL at 30 days, so after that the control plane can no longer drive the host until the operator manually re-enrolls.

## Change (daemon half)

Keep the cloud-stored token fresh autonomously:

- `cloud enroll` records the JWT-secret path in `cloud.yaml` (new `jwt_secret_file`), **only** when a driver token was actually minted (`--no-driver-token` leaves it empty → no refresh).
- The actuation client gains a **driver-refresh loop**: when `cloud.yaml` has a `JWTSecretFile`, it re-mints a fresh admin token every **~20 days** (⅔ of the 30-day cap → always ≥10 days of runway) and pushes it via `ReportHostStatus`'s new optional `driver_token` field. Fires once on startup so a freshly-enrolled daemon pushes immediately.
- The mint logic moves to `internal/cloud/token.go` (`MintDriverToken`) so the CLI enroll path and the daemon refresh loop share one implementation; `cmd/cloud.go` keeps a thin wrapper for its tests.

Best-effort throughout: a mint or push failure is logged and retried next cycle.

## Pairing & ordering

Pairs with the control-plane-side reseal+overwrite (counterpart PR, same issue). Proto field 12 matches the control-plane side and is **forward-compatible** — no deploy-ordering hazard.

## Tests

- `TestRefreshDriverTokenOnce_PushesMintedToken` — mints + pushes with the host bearer attached.
- `TestRefreshDriverTokenOnce_MintFailureSkipsPush` — a mint error sends no RPC.
- `TestConfigRoundTrip` — extended to cover `jwt_secret_file` persistence.

Closes #557 (daemon half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)