### PR TITLE
fix(pool): pool join preserves existing daemon ExecStart flags (#702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`pool join` no longer drops a host's existing daemon flags (#702).** It used
+  to reset the daemon `ExecStart` to a minimal command (`--rest
+  --jwt-secret-file` + `--pool`), silently dropping any extra flags
+  (e.g. `--app-hosting`, `--network-subnet <cidr>`) on the next restart — the
+  worst case being a bring-your-own-compute host already running workloads on a
+  custom bridge. `pool join` now reads the effective `ExecStart` (`systemctl
+  show`), preserves those flags, re-sets only the managed `--pool` /
+  `--base-domain` (idempotent on re-run), and warns + falls back to the minimal
+  baseline when it can't read an existing unit. New repeatable `--daemon-flag`
+  passes extra daemon flags through explicitly (preserve override / fresh-host
+  use).
+
 ### Added
 
 - **Gemini engine for the in-box agent loop (`agent-runtime`).** A third

--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -27,7 +27,15 @@ const (
 	tunnelUnitPath  = "/etc/systemd/system/containarium-tunnel.service"
 	daemonDropInDir = "/etc/systemd/system/containarium.service.d"
 	daemonDropIn    = daemonDropInDir + "/pool.conf"
+	daemonBinPath   = "/usr/local/bin/containarium"
 )
+
+// minimalDaemonArgv is the baseline daemon command used when no existing
+// ExecStart can be read (a fresh host). On a host that already runs the daemon
+// with extra flags, those flags are preserved instead (see resolvePoolDaemonArgv).
+func minimalDaemonArgv() []string {
+	return []string{daemonBinPath, "daemon", "--rest", "--jwt-secret-file", "/etc/containarium/jwt.secret"}
+}
 
 var (
 	poolJoinSentinel       string
@@ -39,6 +47,7 @@ var (
 	poolJoinPublicPort     int
 	poolJoinBaseDomain     string
 	poolJoinDryRun         bool
+	poolJoinDaemonFlags    []string
 )
 
 var poolJoinCmd = &cobra.Command{
@@ -72,6 +81,7 @@ func init() {
 	poolJoinCmd.Flags().IntVar(&poolJoinPublicPort, "public-port", 0, "Public TLS port the sentinel forwards via this tunnel (typically 443; required with --public-hostname)")
 	poolJoinCmd.Flags().StringVar(&poolJoinBaseDomain, "base-domain", "", "Base domain the daemon's Caddy auto-provisions HTTPS for (optional)")
 	poolJoinCmd.Flags().BoolVar(&poolJoinDryRun, "dry-run", false, "Print the unit files that would be written, then exit (no changes)")
+	poolJoinCmd.Flags().StringArrayVar(&poolJoinDaemonFlags, "daemon-flag", nil, "Extra daemon flag to carry into the unit (repeatable), e.g. --daemon-flag=--app-hosting --daemon-flag=--network-subnet=10.0.0.0/24. Use to add/override flags on top of the preserved/baseline set")
 }
 
 // tunnelUnitParams are the inputs to the tunnel systemd unit.
@@ -120,24 +130,101 @@ func renderTunnelUnit(p tunnelUnitParams) string {
 	return b.String()
 }
 
-// renderPoolDropIn renders the daemon drop-in that adds --pool (and an
-// optional --base-domain) on top of the canonical unit's ExecStart. Pure.
-func renderPoolDropIn(pool, baseDomain string) string {
+// renderPoolDropIn renders the daemon drop-in that sets ExecStart to the
+// resolved argv (which already carries the preserved/baseline flags + --pool /
+// --base-domain). Pure. systemd override semantics: clear then re-set.
+func renderPoolDropIn(argv []string) string {
 	var b strings.Builder
 	b.WriteString("[Service]\n")
-	// Clear then re-set ExecStart (systemd override semantics).
 	b.WriteString("ExecStart=\n")
-	b.WriteString("ExecStart=/usr/local/bin/containarium daemon \\\n")
-	b.WriteString("  --rest \\\n")
-	b.WriteString("  --jwt-secret-file /etc/containarium/jwt.secret")
+	b.WriteString("ExecStart=" + strings.Join(argv, " ") + "\n")
+	return b.String()
+}
+
+// parseExecStartArgv extracts the daemon argv from `systemctl show -p ExecStart
+// --value containarium` output, whose value looks like:
+//
+//	{ path=/usr/local/bin/containarium ; argv[]=/usr/local/bin/containarium daemon --rest … ; ignore_errors=no ; … }
+//
+// Returns (argv, true) only when the value clearly is the containarium daemon
+// command; (nil, false) otherwise (no unit, empty, or unrecognized). Pure.
+// Note: values containing spaces aren't recovered (systemd doesn't re-quote
+// them here) — daemon flag values (CIDRs, file paths, domains) don't have spaces.
+func parseExecStartArgv(showOutput string) ([]string, bool) {
+	i := strings.Index(showOutput, "argv[]=")
+	if i < 0 {
+		return nil, false
+	}
+	rest := showOutput[i+len("argv[]="):]
+	if j := strings.Index(rest, " ; "); j >= 0 {
+		rest = rest[:j]
+	}
+	fields := strings.Fields(rest)
+	if len(fields) < 2 || !strings.HasSuffix(fields[0], "containarium") || fields[1] != "daemon" {
+		return nil, false
+	}
+	return fields, true
+}
+
+// stripValuedFlag removes occurrences of a value-taking flag from argv, in both
+// `--flag value` and `--flag=value` forms, so a managed flag (--pool /
+// --base-domain) can be re-set to the current invocation's value without
+// duplicating it. Pure.
+func stripValuedFlag(argv []string, flag string) []string {
+	out := make([]string, 0, len(argv))
+	for i := 0; i < len(argv); i++ {
+		a := argv[i]
+		if a == flag {
+			// Skip the following value token too, if present and not itself a flag.
+			if i+1 < len(argv) && !strings.HasPrefix(argv[i+1], "-") {
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(a, flag+"=") {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// resolvePoolDaemonArgv builds the daemon ExecStart argv for the pool drop-in.
+// It PRESERVES the host's existing daemon flags (#702) — so onboarding a host
+// that already runs e.g. `--app-hosting --network-subnet <cidr>` doesn't
+// silently drop them — then re-sets the managed flags (--pool, --base-domain)
+// to this invocation's values, and finally appends any operator --daemon-flag
+// overrides. When no existing ExecStart is readable (fresh host), the minimal
+// baseline is used. Pure.
+func resolvePoolDaemonArgv(current []string, found bool, pool, baseDomain string, extra []string) []string {
+	var argv []string
+	if found && len(current) >= 2 {
+		argv = append(argv, current...)
+	} else {
+		argv = append(argv, minimalDaemonArgv()...)
+	}
+	// Re-set the flags we own so re-running is idempotent and value-updates take.
+	argv = stripValuedFlag(argv, "--pool")
+	argv = stripValuedFlag(argv, "--base-domain")
 	if pool != "" {
-		fmt.Fprintf(&b, " \\\n  --pool %s", pool)
+		argv = append(argv, "--pool", pool)
 	}
 	if baseDomain != "" {
-		fmt.Fprintf(&b, " \\\n  --base-domain %s", baseDomain)
+		argv = append(argv, "--base-domain", baseDomain)
 	}
-	b.WriteString("\n")
-	return b.String()
+	argv = append(argv, extra...)
+	return argv
+}
+
+// currentDaemonArgv reads the effective daemon ExecStart via systemctl. Returns
+// (nil, false) when the unit doesn't exist / isn't readable / isn't recognized
+// — the caller then falls back to the minimal baseline (and warns).
+func currentDaemonArgv() ([]string, bool) {
+	out, err := exec.Command("systemctl", "show", "-p", "ExecStart", "--value", "containarium").Output()
+	if err != nil {
+		return nil, false
+	}
+	return parseExecStartArgv(string(out))
 }
 
 func runPoolJoin(cmd *cobra.Command, args []string) error {
@@ -159,7 +246,20 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 		spotID = h
 	}
 
-	dropIn := renderPoolDropIn(poolJoinPool, poolJoinBaseDomain)
+	// Preserve the host's existing daemon flags (#702): read the effective
+	// ExecStart and carry its flags forward, rather than resetting to a minimal
+	// command and silently dropping e.g. --app-hosting / --network-subnet.
+	current, found := currentDaemonArgv()
+	daemonArgv := resolvePoolDaemonArgv(current, found, poolJoinPool, poolJoinBaseDomain, poolJoinDaemonFlags)
+	dropIn := renderPoolDropIn(daemonArgv)
+	if !found {
+		fmt.Println("# WARNING: could not read an existing daemon ExecStart.")
+		fmt.Println("#   Using the minimal baseline (--rest --jwt-secret-file). If this host")
+		fmt.Println("#   already ran the daemon with extra flags (e.g. --app-hosting,")
+		fmt.Println("#   --network-subnet), pass them via --daemon-flag to preserve them.")
+	} else {
+		fmt.Printf("# Preserving existing daemon ExecStart flags; resulting command:\n#   %s\n", strings.Join(daemonArgv, " "))
+	}
 	tunnel := renderTunnelUnit(tunnelUnitParams{
 		SentinelAddr:   poolJoinSentinel,
 		Token:          poolJoinToken,

--- a/internal/cmd/pool_join_test.go
+++ b/internal/cmd/pool_join_test.go
@@ -53,9 +53,9 @@ func TestRenderTunnelUnit_PublicPrimary(t *testing.T) {
 }
 
 func TestRenderPoolDropIn(t *testing.T) {
-	// ExecStart must be cleared then re-set (systemd override semantics) and
-	// carry --pool; empty base-domain is omitted.
-	d := renderPoolDropIn("prod", "")
+	// ExecStart must be cleared then re-set (systemd override semantics).
+	argv := resolvePoolDaemonArgv(nil, false, "prod", "", nil)
+	d := renderPoolDropIn(argv)
 	if !strings.Contains(d, "ExecStart=\nExecStart=/usr/local/bin/containarium daemon") {
 		t.Errorf("drop-in must clear+reset ExecStart:\n%s", d)
 	}
@@ -65,9 +65,102 @@ func TestRenderPoolDropIn(t *testing.T) {
 	if strings.Contains(d, "--base-domain") {
 		t.Errorf("drop-in should omit --base-domain when empty:\n%s", d)
 	}
-	// With a base domain it's included.
-	d2 := renderPoolDropIn("prod", "boxes.example.com")
+	d2 := renderPoolDropIn(resolvePoolDaemonArgv(nil, false, "prod", "boxes.example.com", nil))
 	if !strings.Contains(d2, "--base-domain boxes.example.com") {
 		t.Errorf("drop-in missing --base-domain when set:\n%s", d2)
+	}
+}
+
+func TestResolvePoolDaemonArgv_FreshHostUsesMinimal(t *testing.T) {
+	argv := resolvePoolDaemonArgv(nil, false, "prod", "", nil)
+	got := strings.Join(argv, " ")
+	want := "/usr/local/bin/containarium daemon --rest --jwt-secret-file /etc/containarium/jwt.secret --pool prod"
+	if got != want {
+		t.Errorf("fresh host argv = %q, want %q", got, want)
+	}
+}
+
+func TestResolvePoolDaemonArgv_PreservesExistingFlags(t *testing.T) {
+	// The #702 case: a host already running with extra flags must keep them.
+	current := []string{
+		"/usr/local/bin/containarium", "daemon", "--rest",
+		"--jwt-secret-file", "/etc/containarium/jwt.secret",
+		"--app-hosting", "--network-subnet", "10.0.5.0/24",
+	}
+	argv := resolvePoolDaemonArgv(current, true, "prod", "boxes.example.com", nil)
+	got := strings.Join(argv, " ")
+	for _, want := range []string{"--app-hosting", "--network-subnet 10.0.5.0/24", "--pool prod", "--base-domain boxes.example.com"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("preserved argv missing %q\n got: %s", want, got)
+		}
+	}
+}
+
+func TestResolvePoolDaemonArgv_ReRunDoesNotDuplicateManagedFlags(t *testing.T) {
+	// Re-running join (pool.conf already in effect) must re-set, not duplicate,
+	// the managed flags — and must pick up a changed --base-domain / --pool.
+	current := []string{
+		"/usr/local/bin/containarium", "daemon", "--rest",
+		"--jwt-secret-file", "/etc/containarium/jwt.secret",
+		"--app-hosting", "--pool", "old", "--base-domain", "old.example.com",
+	}
+	argv := resolvePoolDaemonArgv(current, true, "new", "new.example.com", nil)
+	got := strings.Join(argv, " ")
+	if strings.Count(got, "--pool ") != 1 || strings.Count(got, "--base-domain ") != 1 {
+		t.Errorf("managed flags must appear exactly once: %s", got)
+	}
+	if !strings.Contains(got, "--pool new") || !strings.Contains(got, "--base-domain new.example.com") {
+		t.Errorf("managed flags must update to new values: %s", got)
+	}
+	if strings.Contains(got, "old") {
+		t.Errorf("stale managed values must be stripped: %s", got)
+	}
+	if !strings.Contains(got, "--app-hosting") {
+		t.Errorf("non-managed flag must survive: %s", got)
+	}
+}
+
+func TestResolvePoolDaemonArgv_DaemonFlagOverride(t *testing.T) {
+	argv := resolvePoolDaemonArgv(nil, false, "prod", "", []string{"--app-hosting", "--network-subnet=10.1.0.0/24"})
+	got := strings.Join(argv, " ")
+	if !strings.Contains(got, "--app-hosting") || !strings.Contains(got, "--network-subnet=10.1.0.0/24") {
+		t.Errorf("operator --daemon-flag values must be appended: %s", got)
+	}
+}
+
+func TestStripValuedFlag(t *testing.T) {
+	cases := []struct {
+		in   []string
+		flag string
+		want string
+	}{
+		{[]string{"daemon", "--pool", "prod", "--rest"}, "--pool", "daemon --rest"},
+		{[]string{"daemon", "--pool=prod", "--rest"}, "--pool", "daemon --rest"},
+		{[]string{"daemon", "--rest"}, "--pool", "daemon --rest"},
+		{[]string{"daemon", "--base-domain", "x", "--base-domain", "y"}, "--base-domain", "daemon"},
+	}
+	for _, c := range cases {
+		if got := strings.Join(stripValuedFlag(c.in, c.flag), " "); got != c.want {
+			t.Errorf("stripValuedFlag(%v, %q) = %q, want %q", c.in, c.flag, got, c.want)
+		}
+	}
+}
+
+func TestParseExecStartArgv(t *testing.T) {
+	out := "{ path=/usr/local/bin/containarium ; argv[]=/usr/local/bin/containarium daemon --rest --jwt-secret-file /etc/containarium/jwt.secret --app-hosting ; ignore_errors=no ; start_time=[n/a] }"
+	argv, ok := parseExecStartArgv(out)
+	if !ok {
+		t.Fatalf("expected to parse argv from %q", out)
+	}
+	got := strings.Join(argv, " ")
+	want := "/usr/local/bin/containarium daemon --rest --jwt-secret-file /etc/containarium/jwt.secret --app-hosting"
+	if got != want {
+		t.Errorf("parsed argv = %q, want %q", got, want)
+	}
+	// Empty / unrecognized values yield (nil, false).
+	for _, bad := range []string{"", "{ path=/x ; argv[]= ; ignore_errors=no }", "{ argv[]=/usr/bin/other thing ; }"} {
+		if _, ok := parseExecStartArgv(bad); ok {
+			t.Errorf("parseExecStartArgv(%q) should be false", bad)
+		}
 	}
 }


### PR DESCRIPTION
## Problem (#702)

`pool join` wrote a systemd drop-in that **cleared and re-set** the daemon `ExecStart` to a minimal command (`--rest --jwt-secret-file` + `--pool`). On a host whose daemon already ran with extra flags, those were **silently dropped** on the next restart — worst case a bring-your-own-compute host already running workloads:

- `--network-subnet <cidr>` is the bridge its pre-existing containers live on → dropping it falls back to a default subnet and breaks their networking.
- `--app-hosting` disables local routing / Caddy management.

## Fix (preferred option 1 + 3, with 2 as override)

`pool join` now:

- **Preserves** the host's existing flags: reads the effective `ExecStart` (`systemctl show -p ExecStart --value containarium`) and carries its flags forward instead of resetting to minimal.
- **Re-sets only the managed flags** (`--pool`, `--base-domain`) — stripping any prior values first, so re-running is idempotent and a changed value takes effect (no duplicates).
- **Warns + falls back** to the minimal baseline (in both dry-run and real runs) when it can't read an existing unit, pointing the operator at the new repeatable **`--daemon-flag`** (explicit override / fresh-host path).

## Design

`renderPoolDropIn` now takes the resolved argv; the resolution (`resolvePoolDaemonArgv`), the systemctl-output parse (`parseExecStartArgv`), and the flag strip (`stripValuedFlag`) are **pure, unit-tested** helpers.

## Tests

fresh-host minimal · preserve extras (`--app-hosting`/`--network-subnet`) · idempotent re-run with changed `--pool`/`--base-domain` · `--daemon-flag` override · `stripValuedFlag` both `--f v` and `--f=v` forms · `parseExecStartArgv` happy/empty/foreign-binary.

Closes #702.

🤖 Generated with [Claude Code](https://claude.com/claude-code)