### PR TITLE
feat(pool): pool join --region auto — latency-based sentinel selection (#699)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`pool join --region auto` — latency-based sentinel selection (#699).** A host
+  joining a multi-region pool can now pass several candidate sentinels
+  (`--sentinel region=host:port`, repeatable) and `--region auto`; the host
+  probes each (median of TCP-connect RTTs) and self-selects the closest before
+  writing the tunnel unit — latency can only be measured from the host, not the
+  control plane. Fallbacks are explicit: one candidate skips probing, a
+  candidate that fails to probe is excluded, and all-failed errors (never
+  silently picks none). `--region <name>` picks a labeled candidate; a single
+  `--sentinel` is unchanged (back-compatible). New `containarium pool regions
+  --probe` prints the region/RTT table without joining. Pairs with the control
+  plane returning the candidate list (cloud #538).
 - **BYOC driver-token auto-refresh (#557).** A host enrolled with `cloud enroll`
   now keeps itself cloud-drivable past the 30-day token-expiry cap with no manual
   re-enroll. `cloud enroll` records the JWT-secret path in `cloud.yaml`

--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -38,7 +38,8 @@ func minimalDaemonArgv() []string {
 }
 
 var (
-	poolJoinSentinel       string
+	poolJoinSentinels      []string
+	poolJoinRegion         string
 	poolJoinToken          string
 	poolJoinPool           string
 	poolJoinSpotID         string
@@ -66,13 +67,20 @@ Example:
     --sentinel sentinel.example.com:443 \
     --pool prod \
     --token <scoped-join-token> \
-    --public-hostname node1.example.com --public-port 443`,
+    --public-hostname node1.example.com --public-port 443
+
+Multi-region (probe + pick the closest sentinel from the host):
+  sudo containarium pool join --region auto \
+    --sentinel us=us.sentinel.example.com:443 \
+    --sentinel eu=eu.sentinel.example.com:443 \
+    --pool prod --token <scoped-join-token>`,
 	RunE: runPoolJoin,
 }
 
 func init() {
 	poolCmd.AddCommand(poolJoinCmd)
-	poolJoinCmd.Flags().StringVar(&poolJoinSentinel, "sentinel", "", "Sentinel address host:port this host dials (required)")
+	poolJoinCmd.Flags().StringArrayVar(&poolJoinSentinels, "sentinel", nil, "Sentinel this host dials, as host:port or region=host:port (repeatable). Pass several with --region auto to probe-and-select the closest (required)")
+	poolJoinCmd.Flags().StringVar(&poolJoinRegion, "region", "", "With multiple --sentinel candidates: 'auto' probes RTT and picks the closest, or a region name picks that one. Single --sentinel ignores this")
 	poolJoinCmd.Flags().StringVar(&poolJoinToken, "token", "", "Scoped join token for the tunnel handshake (required)")
 	poolJoinCmd.Flags().StringVar(&poolJoinPool, "pool", "", "Pool to join (scopes daemon discovery + tunnel registration)")
 	poolJoinCmd.Flags().StringVar(&poolJoinSpotID, "spot-id", "", "Unique id for this host in the pool (default: hostname)")
@@ -228,8 +236,8 @@ func currentDaemonArgv() ([]string, bool) {
 }
 
 func runPoolJoin(cmd *cobra.Command, args []string) error {
-	if poolJoinSentinel == "" {
-		return fmt.Errorf("--sentinel is required (the sentinel host:port this host dials)")
+	if len(poolJoinSentinels) == 0 {
+		return fmt.Errorf("--sentinel is required (the sentinel host:port this host dials; repeatable with --region auto)")
 	}
 	if poolJoinToken == "" {
 		return fmt.Errorf("--token is required (the scoped join token)")
@@ -246,6 +254,25 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 		spotID = h
 	}
 
+	// Resolve which sentinel to dial (#699). With one candidate this is a no-op;
+	// with several + --region auto the host probes RTT and self-selects the
+	// closest (latency can only be measured from here, not the control plane).
+	cands, err := parseSentinelCandidates(poolJoinSentinels)
+	if err != nil {
+		return err
+	}
+	chosen, rows, err := resolveSentinel(cands, poolJoinRegion, nil)
+	if err != nil {
+		return err
+	}
+	if len(rows) > 0 { // probed (--region auto with >1 candidate)
+		fmt.Printf("# Sentinel RTT probe:\n%s", formatRTTTable(rows))
+	}
+	if len(cands) > 1 {
+		fmt.Printf("# Selected sentinel %s (region %q)\n", chosen.Addr, chosen.Region)
+	}
+	sentinelAddr := chosen.Addr
+
 	// Preserve the host's existing daemon flags (#702): read the effective
 	// ExecStart and carry its flags forward, rather than resetting to a minimal
 	// command and silently dropping e.g. --app-hosting / --network-subnet.
@@ -261,7 +288,7 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 		fmt.Printf("# Preserving existing daemon ExecStart flags; resulting command:\n#   %s\n", strings.Join(daemonArgv, " "))
 	}
 	tunnel := renderTunnelUnit(tunnelUnitParams{
-		SentinelAddr:   poolJoinSentinel,
+		SentinelAddr:   sentinelAddr,
 		Token:          poolJoinToken,
 		SpotID:         spotID,
 		Ports:          poolJoinPorts,
@@ -326,7 +353,7 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println()
-	fmt.Printf("Joined pool %q via sentinel %s (spot-id %s).\n", poolJoinPool, poolJoinSentinel, spotID)
+	fmt.Printf("Joined pool %q via sentinel %s (spot-id %s).\n", poolJoinPool, sentinelAddr, spotID)
 	fmt.Println()
 	fmt.Println("  Daemon:  sudo systemctl status containarium")
 	fmt.Println("  Tunnel:  sudo systemctl status containarium-tunnel")

--- a/internal/cmd/pool_regions.go
+++ b/internal/cmd/pool_regions.go
@@ -1,0 +1,64 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// `pool regions --probe` (#699): print the region/RTT table for a set of
+// candidate sentinels WITHOUT joining — the same measurement `pool join
+// --region auto` uses to self-select, exposed standalone so an operator can see
+// which region is closest before committing.
+
+var poolRegionsSentinels []string
+var poolRegionsProbe bool
+
+var poolRegionsCmd = &cobra.Command{
+	Use:   "regions",
+	Short: "List candidate sentinels and (with --probe) their latency from this host",
+	Long: `Show the candidate sentinels for a pool join and, with --probe, the measured
+RTT from THIS host to each — the same latency measurement 'pool join --region
+auto' uses to self-select the closest sentinel.
+
+Example:
+  containarium pool regions --probe \
+    --sentinel us=us.sentinel.example.com:443 \
+    --sentinel eu=eu.sentinel.example.com:443`,
+	RunE: runPoolRegions,
+}
+
+func init() {
+	poolCmd.AddCommand(poolRegionsCmd)
+	poolRegionsCmd.Flags().StringArrayVar(&poolRegionsSentinels, "sentinel", nil, "Candidate sentinel as host:port or region=host:port (repeatable)")
+	poolRegionsCmd.Flags().BoolVar(&poolRegionsProbe, "probe", false, "Measure RTT from this host to each candidate")
+}
+
+func runPoolRegions(cmd *cobra.Command, _ []string) error {
+	cands, err := parseSentinelCandidates(poolRegionsSentinels)
+	if err != nil {
+		return err
+	}
+	w := cmd.OutOrStdout()
+	if !poolRegionsProbe {
+		for _, c := range cands {
+			region := c.Region
+			if region == "" {
+				region = "-"
+			}
+			fmt.Fprintf(w, "  %-12s %s\n", region, c.Addr)
+		}
+		fmt.Fprintln(w, "\n(pass --probe to measure latency from this host)")
+		return nil
+	}
+	rows := probeCandidates(cands, defaultProbeAttempts, defaultProbeTimeout)
+	fmt.Fprint(w, formatRTTTable(rows))
+	if chosen, perr := pickLowestRTT(rows); perr == nil {
+		fmt.Fprintf(w, "\nClosest: %s (region %q)\n", chosen.Addr, chosen.Region)
+	} else {
+		return perr
+	}
+	return nil
+}

--- a/internal/cmd/pool_sentinel.go
+++ b/internal/cmd/pool_sentinel.go
@@ -1,0 +1,175 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Sentinel selection for `pool join` (#699). A host joining a multi-region pool
+// should dial its LOWEST-LATENCY sentinel, and latency can only be measured
+// from the host. So the operator (or the control plane's "add compute" flow)
+// passes the candidate sentinels and the host probes + self-selects.
+
+const (
+	defaultProbeAttempts = 3
+	defaultProbeTimeout  = 2 * time.Second
+)
+
+// sentinelCandidate is one dialable sentinel, optionally labeled with a region.
+type sentinelCandidate struct {
+	Region string // "" when the operator passed a bare host:port
+	Addr   string // host:port
+}
+
+// rttRow is a candidate's probe result — RTT on success, Err on failure.
+type rttRow struct {
+	Cand sentinelCandidate
+	RTT  time.Duration
+	Err  error
+}
+
+// parseSentinelCandidates parses repeated --sentinel values, each either
+// "host:port" (unlabeled) or "region=host:port". Pure.
+func parseSentinelCandidates(vals []string) ([]sentinelCandidate, error) {
+	out := make([]sentinelCandidate, 0, len(vals))
+	for _, v := range vals {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		var c sentinelCandidate
+		// Split on the FIRST '=' so a region label is optional; host:port has no '='.
+		if i := strings.Index(v, "="); i >= 0 {
+			c.Region = strings.TrimSpace(v[:i])
+			c.Addr = strings.TrimSpace(v[i+1:])
+			if c.Region == "" {
+				return nil, fmt.Errorf("invalid --sentinel %q: empty region before '='", v)
+			}
+		} else {
+			c.Addr = v
+		}
+		if c.Addr == "" {
+			return nil, fmt.Errorf("invalid --sentinel %q: empty host:port", v)
+		}
+		out = append(out, c)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no sentinel candidates")
+	}
+	return out, nil
+}
+
+// pickLowestRTT returns the candidate with the lowest successful median RTT.
+// Candidates that failed to probe are excluded; if none succeeded it returns an
+// error listing what was tried (never silently picks nothing). Pure.
+func pickLowestRTT(rows []rttRow) (sentinelCandidate, error) {
+	best := -1
+	for i, r := range rows {
+		if r.Err != nil {
+			continue
+		}
+		if best < 0 || r.RTT < rows[best].RTT {
+			best = i
+		}
+	}
+	if best < 0 {
+		var tried []string
+		for _, r := range rows {
+			tried = append(tried, fmt.Sprintf("%s (%v)", r.Cand.Addr, r.Err))
+		}
+		return sentinelCandidate{}, fmt.Errorf("all sentinel candidates failed to probe: %s", strings.Join(tried, "; "))
+	}
+	return rows[best].Cand, nil
+}
+
+// probeRTT measures the median TCP-connect RTT to addr over `attempts` dials
+// with a per-dial timeout. Returns an error only when every attempt failed.
+func probeRTT(addr string, attempts int, timeout time.Duration) (time.Duration, error) {
+	if attempts < 1 {
+		attempts = 1
+	}
+	var samples []time.Duration
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		start := time.Now()
+		conn, err := net.DialTimeout("tcp", addr, timeout)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		samples = append(samples, time.Since(start))
+		_ = conn.Close()
+	}
+	if len(samples) == 0 {
+		return 0, lastErr
+	}
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+	return samples[len(samples)/2], nil
+}
+
+// probeCandidates probes each candidate and returns a row per candidate (in
+// input order). Impure (dials the network).
+func probeCandidates(cands []sentinelCandidate, attempts int, timeout time.Duration) []rttRow {
+	rows := make([]rttRow, 0, len(cands))
+	for _, c := range cands {
+		rtt, err := probeRTT(c.Addr, attempts, timeout)
+		rows = append(rows, rttRow{Cand: c, RTT: rtt, Err: err})
+	}
+	return rows
+}
+
+// resolveSentinel picks the sentinel to dial from the parsed candidates:
+//   - exactly one candidate → use it, skip probing (regardless of region).
+//   - region == "auto" → probe all, pick lowest RTT (returns the probe table).
+//   - region == "<name>" → pick the candidate with that label.
+//   - region == "" with >1 candidate → ambiguous, error.
+//
+// probe is injected for testability (nil → the real network probe).
+func resolveSentinel(cands []sentinelCandidate, region string, probe func([]sentinelCandidate) []rttRow) (sentinelCandidate, []rttRow, error) {
+	switch {
+	case len(cands) == 0:
+		return sentinelCandidate{}, nil, fmt.Errorf("no sentinel candidates")
+	case len(cands) == 1:
+		return cands[0], nil, nil
+	case region == "auto":
+		if probe == nil {
+			probe = func(cs []sentinelCandidate) []rttRow {
+				return probeCandidates(cs, defaultProbeAttempts, defaultProbeTimeout)
+			}
+		}
+		rows := probe(cands)
+		chosen, err := pickLowestRTT(rows)
+		return chosen, rows, err
+	case region != "":
+		for _, c := range cands {
+			if c.Region == region {
+				return c, nil, nil
+			}
+		}
+		return sentinelCandidate{}, nil, fmt.Errorf("no --sentinel candidate labeled region %q", region)
+	default:
+		return sentinelCandidate{}, nil, fmt.Errorf("multiple --sentinel candidates given; pass --region auto to probe-and-select, or --region <name> to pick one")
+	}
+}
+
+// formatRTTTable renders a human-readable region/RTT table for logging.
+func formatRTTTable(rows []rttRow) string {
+	var b strings.Builder
+	for _, r := range rows {
+		region := r.Cand.Region
+		if region == "" {
+			region = "-"
+		}
+		if r.Err != nil {
+			fmt.Fprintf(&b, "  %-12s %-24s unreachable (%v)\n", region, r.Cand.Addr, r.Err)
+			continue
+		}
+		fmt.Fprintf(&b, "  %-12s %-24s %v\n", region, r.Cand.Addr, r.RTT.Round(time.Millisecond))
+	}
+	return b.String()
+}

--- a/internal/cmd/pool_sentinel_test.go
+++ b/internal/cmd/pool_sentinel_test.go
@@ -1,0 +1,120 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestParseSentinelCandidates(t *testing.T) {
+	cands, err := parseSentinelCandidates([]string{"us=us.example.com:443", "plain.example.com:443", " eu = eu.example.com:443 "})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(cands) != 3 {
+		t.Fatalf("want 3 candidates, got %d", len(cands))
+	}
+	if cands[0].Region != "us" || cands[0].Addr != "us.example.com:443" {
+		t.Errorf("labeled parse wrong: %+v", cands[0])
+	}
+	if cands[1].Region != "" || cands[1].Addr != "plain.example.com:443" {
+		t.Errorf("bare parse wrong: %+v", cands[1])
+	}
+	if cands[2].Region != "eu" || cands[2].Addr != "eu.example.com:443" {
+		t.Errorf("whitespace-trim parse wrong: %+v", cands[2])
+	}
+}
+
+func TestParseSentinelCandidates_Errors(t *testing.T) {
+	for _, in := range [][]string{
+		{},            // none
+		{"=host:443"}, // empty region
+		{"us="},       // empty addr
+		{"   "},       // blank → none
+	} {
+		if _, err := parseSentinelCandidates(in); err == nil {
+			t.Errorf("parseSentinelCandidates(%v) expected error", in)
+		}
+	}
+}
+
+func TestPickLowestRTT(t *testing.T) {
+	rows := []rttRow{
+		{Cand: sentinelCandidate{Region: "us", Addr: "a"}, RTT: 30 * time.Millisecond},
+		{Cand: sentinelCandidate{Region: "eu", Addr: "b"}, RTT: 10 * time.Millisecond},
+		{Cand: sentinelCandidate{Region: "ap", Addr: "c"}, Err: errors.New("timeout")},
+	}
+	got, err := pickLowestRTT(rows)
+	if err != nil {
+		t.Fatalf("pick: %v", err)
+	}
+	if got.Region != "eu" {
+		t.Errorf("want eu (lowest RTT), got %+v", got)
+	}
+}
+
+func TestPickLowestRTT_AllFailed(t *testing.T) {
+	rows := []rttRow{
+		{Cand: sentinelCandidate{Addr: "a"}, Err: errors.New("x")},
+		{Cand: sentinelCandidate{Addr: "b"}, Err: errors.New("y")},
+	}
+	if _, err := pickLowestRTT(rows); err == nil {
+		t.Error("all-failed must error, not silently pick none")
+	}
+}
+
+func TestResolveSentinel_SingleSkipsProbe(t *testing.T) {
+	probed := false
+	probe := func([]sentinelCandidate) []rttRow { probed = true; return nil }
+	c := []sentinelCandidate{{Region: "us", Addr: "only:443"}}
+	got, rows, err := resolveSentinel(c, "auto", probe)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if probed {
+		t.Error("single candidate must skip probing")
+	}
+	if got.Addr != "only:443" || rows != nil {
+		t.Errorf("unexpected result: %+v rows=%v", got, rows)
+	}
+}
+
+func TestResolveSentinel_AutoPicksLowest(t *testing.T) {
+	c := []sentinelCandidate{{Region: "us", Addr: "u"}, {Region: "eu", Addr: "e"}}
+	probe := func(cs []sentinelCandidate) []rttRow {
+		return []rttRow{
+			{Cand: cs[0], RTT: 50 * time.Millisecond},
+			{Cand: cs[1], RTT: 5 * time.Millisecond},
+		}
+	}
+	got, rows, err := resolveSentinel(c, "auto", probe)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got.Region != "eu" {
+		t.Errorf("auto should pick lowest RTT (eu), got %+v", got)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected probe table of 2 rows, got %d", len(rows))
+	}
+}
+
+func TestResolveSentinel_NamedRegion(t *testing.T) {
+	c := []sentinelCandidate{{Region: "us", Addr: "u"}, {Region: "eu", Addr: "e"}}
+	got, _, err := resolveSentinel(c, "eu", nil)
+	if err != nil || got.Addr != "e" {
+		t.Fatalf("named region: got %+v err=%v", got, err)
+	}
+	if _, _, err := resolveSentinel(c, "nope", nil); err == nil {
+		t.Error("unknown region must error")
+	}
+}
+
+func TestResolveSentinel_MultipleNoRegionIsAmbiguous(t *testing.T) {
+	c := []sentinelCandidate{{Addr: "a"}, {Addr: "b"}}
+	if _, _, err := resolveSentinel(c, "", nil); err == nil {
+		t.Error("multiple candidates with no --region must error (ambiguous), not pick arbitrarily")
+	}
+}


### PR DESCRIPTION
## Problem (#699)

A host joining a multi-region pool must be told which sentinel to dial. Pick the wrong one and every tunneled connection eats avoidable latency for the life of the host. **Latency can only be measured from the joining host** — the control plane knows its own RTT to each sentinel, not the host's — so the host must self-select.

## Change

`pool join` now accepts repeated `--sentinel` candidates (`host:port` or `region=host:port`) plus `--region`:

- **`--region auto`** — probe each candidate (median of TCP-connect RTTs, short per-dial timeout), pick the lowest, log the region/RTT table, then proceed exactly as today.
- **`--region <name>`** — pick the labeled candidate.
- **single `--sentinel`** — skips probing (back-compatible).

Fallbacks are explicit (no surprises): one candidate → use it; a candidate that fails to probe → excluded (logged); all fail → error listing what was tried (never silently picks none); multiple candidates with no `--region` → ambiguous error.

New **`containarium pool regions --probe`** prints the region/RTT table without joining.

## Design

Selection is split into pure, unit-tested helpers (`internal/cmd/pool_sentinel.go`): `parseSentinelCandidates`, `pickLowestRTT`, and `resolveSentinel` (the network probe is injected so the orchestration is tested without dialing).

## Tests

candidate parsing (labeled/bare/whitespace + error cases) · lowest-RTT pick · all-failed errors · single-skips-probe · auto-picks-lowest · named-region + unknown-region error · multiple-no-region ambiguous error.

Pairs with the control plane returning the candidate sentinel list (cloud #538).

Closes #699.

🤖 Generated with [Claude Code](https://claude.com/claude-code)