### PR TITLE
fix(test): agent egress default-domains test expects Gemini too

### DIFF
--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -80,8 +80,11 @@ func TestAgentNetworkPolicyConfigDomains(t *testing.T) {
 	t.Run("defaults to the model providers when unset", func(t *testing.T) {
 		_ = os.Unsetenv("CONTAINARIUM_AGENT_EGRESS_DOMAINS")
 		_, domains, _ := agentNetworkPolicyConfig()
-		if len(domains) != 2 || domains[0] != "api.anthropic.com" {
-			t.Errorf("default domains = %v, want the provider defaults", domains)
+		// The provider defaults: Anthropic, OpenAI, and Gemini (the Gemini engine
+		// added generativelanguage.googleapis.com so an ENFORCE policy doesn't
+		// strand a Gemini agent). Assert against the source-of-truth slice.
+		if len(domains) != len(defaultAgentEgressDomains) || domains[0] != "api.anthropic.com" {
+			t.Errorf("default domains = %v, want %v", domains, defaultAgentEgressDomains)
 		}
 	})
 	t.Run("operator override wins", func(t *testing.T) {


### PR DESCRIPTION
## Problem

`main` is **red** on `go test ./internal/server/`: the Gemini engine change added `generativelanguage.googleapis.com` to `defaultAgentEgressDomains` (3 entries, so an ENFORCE network policy doesn't strand a Gemini agent), but `TestAgentNetworkPolicyConfigDomains/defaults_to_the_model_providers_when_unset` still asserted exactly **2** default domains.

```
default domains = [api.anthropic.com api.openai.com generativelanguage.googleapis.com], want the provider defaults
```

## Fix

Assert against the source-of-truth slice (`len(domains) == len(defaultAgentEgressDomains)` + anthropic first) so the test tracks the provider set rather than a hard-coded count. Verified `go test ./internal/server/ -run TestAgentNetworkPolicyConfigDomains` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)