### PR TITLE
feat(agent): daemon serves the model-gateway; skill boxes use it (#674)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Daemon-served model-gateway for skill boxes (#674, productionizing #737).**
+  When the daemon holds a provider API key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
+  / `GEMINI_API_KEY` — `GOOGLE_API_KEY` also works for Gemini), it now serves the
+  model-gateway at `/v1/model/` and provisions every skill box to route its model
+  calls through it: `provisionSkillBox` mints a short-lived, per-skill **gateway
+  token** and seeds the box's SDK base-URL env (`gateway.env`, resolving the
+  host from the box's default route in-box), which the in-box runtime sources
+  before launch. The real provider key never enters a box, and every call is
+  metered per tenant/skill. It's an **env change, not a code change** — the
+  agent-runtime engines already honor these vars (Claude/OpenAI base-URL;
+  Gemini via `CONTAINARIUM_MODEL_GATEWAY_URL`). Inert when no provider key is
+  set — boxes run in direct mode (the OSS/self-hosted default). The `/v1/model/`
+  mount is unauthenticated by the platform JWT middleware; it verifies the box's
+  scoped gateway token itself.
+
 ### Fixed
 
 - **`pool join` no longer drops a host's existing daemon flags (#702).** It used

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -55,6 +55,12 @@ type GatewayServer struct {
 	// Backends handler (for multi-backend support, set externally)
 	backendsHandler http.HandlerFunc
 
+	// Model-gateway handler (#674). Set externally from dual_server when the
+	// daemon holds a provider API key. Mounted at /v1/model/ and NOT wrapped by
+	// the JWT auth middleware — it authenticates boxes with its OWN scoped
+	// gateway token (modelgateway.VerifyToken) and injects the real provider key.
+	modelGatewayHandler http.Handler
+
 	// sentinelAuthSecret is the shared HMAC secret used by the
 	// sentinel to authenticate calls to /authorized-keys and /certs.
 	// Set via CONTAINARIUM_SENTINEL_AUTH_SECRET. Nil/short means the
@@ -183,6 +189,14 @@ func (gs *GatewayServer) SetBackendsHandler(handler http.HandlerFunc) {
 // for API callers, not for incoming user requests).
 func (gs *GatewayServer) SetWakeHandler(handler http.Handler) {
 	gs.wakeHandler = handler
+}
+
+// SetModelGatewayHandler sets the model-gateway handler mounted at /v1/model/
+// (#674). Unauthenticated by the JWT middleware — the handler verifies the
+// box's scoped gateway token itself and injects the real provider key. Set
+// from dual_server only when a provider key is configured.
+func (gs *GatewayServer) SetModelGatewayHandler(handler http.Handler) {
+	gs.modelGatewayHandler = handler
 }
 
 // SetTerminalPeerProxy configures the terminal handler to proxy WebSocket
@@ -566,6 +580,15 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 	if gs.wakeHandler != nil {
 		httpMux.Handle("/wake/", gs.wakeHandler)
 		httpMux.Handle("/wake", gs.wakeHandler)
+	}
+
+	// Model-gateway (#674): the agent model egress. Mounted at /v1/model/ —
+	// more specific than the /v1/ gateway catch-all (http.ServeMux longest-prefix
+	// wins) — and deliberately UNWRAPPED by the JWT auth middleware: a box
+	// presents its scoped gateway token (verified inside the handler), not the
+	// platform JWT. The handler injects the real provider key and proxies.
+	if gs.modelGatewayHandler != nil {
+		httpMux.Handle("/v1/model/", gs.modelGatewayHandler)
 	}
 
 	// Core services endpoint (with authentication via CORS handler)

--- a/internal/server/agent_gateway.go
+++ b/internal/server/agent_gateway.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/footprintai/containarium/internal/modelgateway"
+)
+
+// Model-gateway provisioning for skill boxes (#674 design, productionization of
+// the #737 prototype). When the daemon holds a provider API key, it serves the
+// model-gateway (internal/modelgateway) on its HTTP port and provisions each
+// skill box to route its model calls through it: the box gets a short-lived,
+// per-skill *gateway token* and the SDK base-URL env, so the real key never
+// lives in a box and every call is metered per tenant/skill. This is an env
+// change in the box, not a code change — the agent-runtime engines already honor
+// these vars (Claude/OpenAI base-URL; Gemini via CONTAINARIUM_MODEL_GATEWAY_URL).
+
+// gatewayProvisioning is the daemon-resolved config the AgentSkillServer needs
+// to mint a box's gateway token and seed its env. nil ⇒ no provider key
+// configured ⇒ boxes run in direct mode (the OSS/self-hosted default).
+type gatewayProvisioning struct {
+	provider      string // the gateway's configured provider (anthropic|openai|gemini)
+	httpPort      int    // the daemon HTTP port the box dials (resolved to the host's default-route IP in-box)
+	secret        []byte // shared HMAC secret (daemon jwt.secret) — signs the gateway token
+	allowedModels []string
+}
+
+// gatewayProviderEnv is the per-provider env contract the agent-runtime engines
+// read. urlSuffix is appended to the daemon HTTP base to form the SDK base URL;
+// gemini takes the BARE base (its engine appends the /v1/model/gemini path).
+type gatewayProviderEnv struct {
+	urlVar    string
+	tokenVar  string
+	urlSuffix string
+}
+
+var gatewayProviderEnvs = map[string]gatewayProviderEnv{
+	"anthropic": {urlVar: "ANTHROPIC_BASE_URL", tokenVar: "ANTHROPIC_AUTH_TOKEN", urlSuffix: "/v1/model/anthropic"},
+	"openai":    {urlVar: "OPENAI_BASE_URL", tokenVar: "OPENAI_API_KEY", urlSuffix: "/v1/model/openai"},
+	"gemini":    {urlVar: "CONTAINARIUM_MODEL_GATEWAY_URL", tokenVar: "CONTAINARIUM_GATEWAY_TOKEN", urlSuffix: ""},
+}
+
+// mintGatewayToken mints a per-skill gateway token bound to this box's tenant +
+// skill + the configured provider, expiring with the in-box token (agentTokenTTL).
+func (g *gatewayProvisioning) mintGatewayToken(tenant, skillID string) (string, error) {
+	return modelgateway.MintToken(g.secret, modelgateway.GatewayClaims{
+		Tenant:        tenant,
+		SkillID:       skillID,
+		Provider:      g.provider,
+		AllowedModels: g.allowedModels,
+	}, agentTokenTTL)
+}
+
+// gatewayEnvScript returns a shell snippet (run inside the box, in the same exec
+// as the seed) that resolves the host's IP from the box's default route and
+// writes the provider env to <seedDir>/gateway.env. The base URL is resolved
+// IN-BOX (not baked at provision time) so it works regardless of the bridge
+// subnet — the same default-route approach validated for the worker poll path.
+// Pure: returns the script for the given provider/port/token; errors on an
+// unknown provider.
+func gatewayEnvScript(provider string, httpPort int, token, seedDir string) (string, error) {
+	pe, ok := gatewayProviderEnvs[provider]
+	if !ok {
+		return "", fmt.Errorf("model-gateway: unknown provider %q", provider)
+	}
+	var b strings.Builder
+	// Resolve the host (LXC bridge gateway) from the default route; the daemon's
+	// model-gateway listens on http://<that host>:<httpPort>.
+	b.WriteString("__ctn_host=\"$(ip route show default 2>/dev/null | awk '/default/ {print $3; exit}')\"\n")
+	b.WriteString("if [ -z \"$__ctn_host\" ]; then echo 'model-gateway: could not resolve host from default route' >&2; fi\n")
+	fmt.Fprintf(&b, "{\n")
+	// URL var: double-quoted so $__ctn_host expands at write time.
+	fmt.Fprintf(&b, "  printf 'export %s=%%s\\n' \"http://$__ctn_host:%d%s\"\n", pe.urlVar, httpPort, pe.urlSuffix)
+	// Token var: single-quoted literal (a JWT — no shell metachars, but be safe).
+	fmt.Fprintf(&b, "  printf 'export %s=%%s\\n' %s\n", pe.tokenVar, shellSingleQuote(token))
+	fmt.Fprintf(&b, "} > %s/gateway.env\n", seedDir)
+	fmt.Fprintf(&b, "chmod 600 %s/gateway.env\n", seedDir)
+	return b.String(), nil
+}
+
+// gatewayProviderKeysFromEnv reads provider API keys from the daemon env, one
+// per provider that has a key set. These keys are held ONLY in the daemon's
+// gateway process; a box never sees them. Gemini accepts GEMINI_API_KEY or
+// GOOGLE_API_KEY (mirrors the gemini engine's own lookup).
+func gatewayProviderKeysFromEnv() map[string]string {
+	out := map[string]string{}
+	if v := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")); v != "" {
+		out["anthropic"] = v
+	}
+	if v := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); v != "" {
+		out["openai"] = v
+	}
+	if v := strings.TrimSpace(os.Getenv("GEMINI_API_KEY")); v != "" {
+		out["gemini"] = v
+	} else if v := strings.TrimSpace(os.Getenv("GOOGLE_API_KEY")); v != "" {
+		out["gemini"] = v
+	}
+	return out
+}
+
+// gatewayPrimaryProvider picks the provider skill boxes are provisioned for when
+// several keys are configured, by a fixed precedence — anthropic first (the
+// agent-runtime default engine). "" when no key is set. Pure.
+func gatewayPrimaryProvider(keys map[string]string) string {
+	for _, p := range []string{"anthropic", "openai", "gemini"} {
+		if keys[p] != "" {
+			return p
+		}
+	}
+	return ""
+}
+
+// sourceGatewayEnvPrefix is the shell prefix that sources <seedDir>/gateway.env
+// (if present) into the environment before launching agent-runtime, so the
+// engine SDK picks up the gateway base-URL + token. A no-op in direct mode
+// (file absent). `set -a` exports everything the file sets.
+func sourceGatewayEnvPrefix(seedDir string) string {
+	return fmt.Sprintf("set -a; [ -f %s/gateway.env ] && . %s/gateway.env; set +a; ", seedDir, seedDir)
+}

--- a/internal/server/agent_gateway_test.go
+++ b/internal/server/agent_gateway_test.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/modelgateway"
+)
+
+func TestGatewayEnvScript_Anthropic(t *testing.T) {
+	s, err := gatewayEnvScript("anthropic", 8080, "tok-abc", "/etc/containarium/agent")
+	if err != nil {
+		t.Fatalf("script: %v", err)
+	}
+	// Resolves the host from the default route in-box (not baked at provision).
+	if !strings.Contains(s, "ip route show default") {
+		t.Errorf("expected default-route resolution:\n%s", s)
+	}
+	for _, want := range []string{
+		"ANTHROPIC_BASE_URL",
+		"http://$__ctn_host:8080/v1/model/anthropic",
+		"ANTHROPIC_AUTH_TOKEN",
+		"tok-abc",
+		"> /etc/containarium/agent/gateway.env",
+		"chmod 600 /etc/containarium/agent/gateway.env",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("script missing %q\n%s", want, s)
+		}
+	}
+}
+
+func TestGatewayEnvScript_GeminiBareBase(t *testing.T) {
+	// Gemini's engine appends /v1/model/gemini itself, so the env var is the
+	// BARE daemon base — no path suffix.
+	s, err := gatewayEnvScript("gemini", 8080, "g-tok", "/seed")
+	if err != nil {
+		t.Fatalf("script: %v", err)
+	}
+	if !strings.Contains(s, "CONTAINARIUM_MODEL_GATEWAY_URL") || !strings.Contains(s, "CONTAINARIUM_GATEWAY_TOKEN") {
+		t.Errorf("gemini env vars missing:\n%s", s)
+	}
+	if strings.Contains(s, "/v1/model/gemini") {
+		t.Errorf("gemini base must be bare (no /v1/model/gemini suffix):\n%s", s)
+	}
+	if !strings.Contains(s, "http://$__ctn_host:8080\\n") && !strings.Contains(s, "http://$__ctn_host:8080\"") {
+		t.Errorf("gemini base should be the bare host:port:\n%s", s)
+	}
+}
+
+func TestGatewayEnvScript_UnknownProvider(t *testing.T) {
+	if _, err := gatewayEnvScript("bedrock", 8080, "t", "/seed"); err == nil {
+		t.Error("unknown provider must error")
+	}
+}
+
+func TestGatewayPrimaryProvider_Precedence(t *testing.T) {
+	cases := []struct {
+		keys map[string]string
+		want string
+	}{
+		{map[string]string{"anthropic": "a", "openai": "o", "gemini": "g"}, "anthropic"},
+		{map[string]string{"openai": "o", "gemini": "g"}, "openai"},
+		{map[string]string{"gemini": "g"}, "gemini"},
+		{map[string]string{}, ""},
+	}
+	for _, c := range cases {
+		if got := gatewayPrimaryProvider(c.keys); got != c.want {
+			t.Errorf("gatewayPrimaryProvider(%v) = %q, want %q", c.keys, got, c.want)
+		}
+	}
+}
+
+func TestGatewayProviderKeysFromEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "g-key") // gemini falls back to GOOGLE_API_KEY
+	keys := gatewayProviderKeysFromEnv()
+	if keys["anthropic"] != "sk-ant" {
+		t.Errorf("anthropic key = %q", keys["anthropic"])
+	}
+	if _, ok := keys["openai"]; ok {
+		t.Errorf("openai should be absent (empty env): %v", keys)
+	}
+	if keys["gemini"] != "g-key" {
+		t.Errorf("gemini should fall back to GOOGLE_API_KEY, got %q", keys["gemini"])
+	}
+}
+
+func TestMintGatewayToken_RoundTrips(t *testing.T) {
+	secret := []byte("test-shared-secret")
+	g := &gatewayProvisioning{provider: "anthropic", httpPort: 8080, secret: secret}
+	tok, err := g.mintGatewayToken("agent-hello", "hello-agent")
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	claims, err := modelgateway.VerifyToken(secret, tok)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if claims.Tenant != "agent-hello" || claims.SkillID != "hello-agent" || claims.Provider != "anthropic" {
+		t.Errorf("claims mismatch: %+v", claims)
+	}
+}
+
+func TestSourceGatewayEnvPrefix_NoopWhenAbsent(t *testing.T) {
+	p := sourceGatewayEnvPrefix("/seed")
+	// Must guard on file existence so direct-mode boxes (no gateway.env) are a no-op.
+	if !strings.Contains(p, "[ -f /seed/gateway.env ]") || !strings.Contains(p, ". /seed/gateway.env") {
+		t.Errorf("prefix must source-if-present: %q", p)
+	}
+}

--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -53,11 +53,22 @@ type AgentSkillServer struct {
 	tokens    *auth.TokenManager   // mints the skill's scoped in-box token
 	netpolicy *NetworkPolicyServer // compiles allowed_peers into a per-box egress policy (Phase 2)
 	audit     *audit.Store         // records A2A hops under a trace id (Phase 2); set once the pool is ready
+	gateway   *gatewayProvisioning // model-gateway provisioning (#674); nil ⇒ boxes run in direct mode
 }
 
 // SetAuditStore wires the audit store once the Postgres pool exists (it isn't
 // available at construction). A2A hop logging no-ops until then.
 func (s *AgentSkillServer) SetAuditStore(store *audit.Store) { s.audit = store }
+
+// SetGatewayProvisioning enables model-gateway provisioning for skill boxes:
+// each provisioned box gets a per-skill gateway token + the SDK base-URL env so
+// its model calls route through the daemon-served gateway (key custody +
+// metering). Wired from dual_server when a provider key is configured; nil-safe
+// (no call ⇒ direct mode). provider is the gateway's configured provider,
+// httpPort the daemon HTTP port the box dials, secret the shared jwt secret.
+func (s *AgentSkillServer) SetGatewayProvisioning(provider string, httpPort int, secret []byte) {
+	s.gateway = &gatewayProvisioning{provider: provider, httpPort: httpPort, secret: secret}
+}
 
 // NewAgentSkillServer wires the agent-skill service to the recipe server (for
 // box provisioning), the token manager (for minting scoped in-box tokens), and
@@ -227,8 +238,23 @@ func (s *AgentSkillServer) provisionSkillBox(ctx context.Context, skill *pb.Agen
 		}
 	}
 	containerName := name + "-container"
+	seedScript := buildAgentSeedScript(skill.SystemPrompt, token, inputJSON, cardJSON)
+	// Model-gateway provisioning (#674): when the daemon serves a gateway, mint a
+	// per-skill gateway token and append the env-seeding to the same exec, so the
+	// box's engine routes model calls through the gateway (real key never enters
+	// the box). Best-effort: a mint/script error logs and falls back to direct
+	// mode rather than failing provisioning.
+	if s.gateway != nil {
+		if gwTok, gerr := s.gateway.mintGatewayToken(name, skill.Id); gerr != nil {
+			log.Printf("[agent-skill] gateway token mint failed for %s (box runs direct mode): %v", name, gerr)
+		} else if envScript, eerr := gatewayEnvScript(s.gateway.provider, s.gateway.httpPort, gwTok, agentSeedDir); eerr != nil {
+			log.Printf("[agent-skill] gateway env script failed for %s (box runs direct mode): %v", name, eerr)
+		} else {
+			seedScript += "\n" + envScript
+		}
+	}
 	if err := s.recipes.containers.manager.Exec(containerName,
-		[]string{"bash", "-c", buildAgentSeedScript(skill.SystemPrompt, token, inputJSON, cardJSON)}); err != nil {
+		[]string{"bash", "-c", seedScript}); err != nil {
 		return "", nil, status.Errorf(codes.Internal, "failed to seed agent box %s: %v", containerName, err)
 	}
 
@@ -246,7 +272,7 @@ func (s *AgentSkillServer) startServeMode(containerName string) {
 	if s.recipes == nil || s.recipes.containers == nil || s.recipes.containers.manager == nil {
 		return
 	}
-	cmd := "CONTAINARIUM_AGENT_MODE=serve AGENT_SEED_DIR=" + agentSeedDir +
+	cmd := sourceGatewayEnvPrefix(agentSeedDir) + "CONTAINARIUM_AGENT_MODE=serve AGENT_SEED_DIR=" + agentSeedDir +
 		" setsid agent-runtime >/var/log/agent-runtime.log 2>&1 &"
 	if _, stderr, err := s.recipes.containers.manager.ExecWithOutput(containerName,
 		[]string{"bash", "-lc", cmd}); err != nil {
@@ -268,7 +294,7 @@ func (s *AgentSkillServer) runInBoxAgent(containerName string) string {
 	mgr := s.recipes.containers.manager
 
 	if _, stderr, err := mgr.ExecWithOutput(containerName,
-		[]string{"bash", "-lc", "AGENT_SEED_DIR=" + agentSeedDir + " agent-runtime"}); err != nil {
+		[]string{"bash", "-lc", sourceGatewayEnvPrefix(agentSeedDir) + "AGENT_SEED_DIR=" + agentSeedDir + " agent-runtime"}); err != nil {
 		log.Printf("[agent-skill] in-box runtime did not run on %s (image may not ship it yet): %v; stderr=%s",
 			containerName, err, strings.TrimSpace(stderr))
 		return ""

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/footprintai/containarium/internal/gateway"
 	"github.com/footprintai/containarium/internal/guacamole"
 	"github.com/footprintai/containarium/internal/metrics"
+	"github.com/footprintai/containarium/internal/modelgateway"
 	"github.com/footprintai/containarium/internal/mtls"
 	"github.com/footprintai/containarium/internal/pentest"
 	secretsstore "github.com/footprintai/containarium/internal/secrets"
@@ -1296,6 +1297,27 @@ skipAppHosting:
 			certsDir,
 			config.CaddyCertDir,
 		)
+
+		// Model-gateway (#674 productionization of #737): when the daemon holds a
+		// provider API key, serve the gateway on the HTTP port and provision skill
+		// boxes to route model calls through it (key custody + per-tenant
+		// metering). Inert when no provider key is set — boxes run in direct mode.
+		if keys := gatewayProviderKeysFromEnv(); len(keys) > 0 {
+			gw := modelgateway.New(modelgateway.Config{
+				Secret:       []byte(config.JWTSecret),
+				Providers:    modelgateway.DefaultProviders(),
+				ProviderKeys: keys,
+			})
+			gatewayServer.SetModelGatewayHandler(gw.Handler())
+			primary := gatewayPrimaryProvider(keys)
+			agentSkillServer.SetGatewayProvisioning(primary, config.HTTPPort, []byte(config.JWTSecret))
+			provs := make([]string, 0, len(keys))
+			for p := range keys {
+				provs = append(provs, p)
+			}
+			log.Printf("Model-gateway enabled (providers=%v, skill-box primary=%s) — agent boxes route model calls through the daemon; provider keys never leave the host",
+				provs, primary)
+		}
 
 		// Sentinel-facing HMAC secret for /certs, /authorized-keys,
 		// /authorized-keys/sentinel. If unset (or shorter than the


### PR DESCRIPTION
Increment 1 of the agent/skill/sandbox push. Productionizes the merged model-gateway prototype (#737) into the live agent path so a skill box does its model calls **through the daemon-held gateway** — the real provider key never lives in a box, and every call is metered per tenant/skill.

## Daemon side (`dual_server` + `internal/gateway`)
- When a provider key is configured (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY`, or `GOOGLE_API_KEY` for Gemini), build the gateway from those keys + the jwt secret and mount its handler at **`/v1/model/`** on the daemon HTTP port.
- The mount is **not** behind the JWT middleware — the gateway verifies the box's *own* scoped token and injects the real key (`modelgateway.VerifyToken`). More-specific than the `/v1/` catch-all (ServeMux longest-prefix).
- **Inert when no key is set** → boxes run in direct mode (the OSS/self-hosted default).

## Provisioning side (`agent_server`)
- `provisionSkillBox` mints a short-lived, **per-skill gateway token** (box tenant + skill + configured provider) and appends an env-seeding step to the box's seed exec: it resolves the host from the box's **default route in-box** (the worker-poll-validated approach) and writes the SDK base-URL env to `<seed>/gateway.env`.
- `runInBoxAgent` + `startServeMode` source `gateway.env` before launching `agent-runtime`, so the engine SDK routes through the gateway. An **env change, not a code change** — engines already honor these vars (Claude/OpenAI base-URL; Gemini `CONTAINARIUM_MODEL_GATEWAY_URL`).

## Pure, tested core — `internal/server/agent_gateway.go`
Per-provider env contract, the in-box env script, the source-if-present prefix, env-key reading, provider precedence, token mint.

## Tests
Env script per provider (incl. Gemini's bare-base quirk + unknown-provider error), provider precedence, env-key reading (incl. `GOOGLE_API_KEY` fallback), token round-trip, no-op-when-absent source prefix. Verified locally: `go test ./internal/server/ -run 'Gateway|MintGatewayToken'` green, `go vet ./internal/server/ ./internal/gateway/` clean, `internal/modelgateway` tests green.

**Scope note:** full box→model E2E is backend-gated (needs a host running agent-runtime + a real key); the daemon mount + token mint + env seeding are unit-tested + vetted. This is the foundation; **metering→billing** and **eBPF egress-pinning** (so a box can *only* reach the gateway) are the next increments.

Refs #674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)