### PR TITLE
feat(agent): model-gateway usage → metering/billing pipeline (#674)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Model-gateway usage → metering/billing pipeline (#674).** The gateway gains a
+  pluggable `UsageSink` (kept free of an OTel dependency); the daemon wires an
+  OTLP sink that emits per-tenant/skill/provider/model token counters
+  (`model_gateway.calls`, `.input_tokens`, `.output_tokens`, `.cached_tokens`)
+  through the existing metrics pipeline (→ VictoriaMetrics → dashboards/billing),
+  on top of the in-memory `/__gateway/usage` readout. So model-call usage is now
+  durable + aggregatable per tenant, not just a live snapshot. Uses the global
+  meter — a no-op when monitoring is off, so it's always safe to wire; a nil sink
+  (standalone) keeps the in-memory meter working.
 - **Daemon-served model-gateway for skill boxes (#674, productionizing #737).**
   When the daemon holds a provider API key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
   / `GEMINI_API_KEY` — `GOOGLE_API_KEY` also works for Gemini), it now serves the

--- a/internal/modelgateway/gateway.go
+++ b/internal/modelgateway/gateway.go
@@ -12,11 +12,22 @@ import (
 	"strings"
 )
 
+// UsageSink receives every metered model call so token usage can be forwarded
+// to a durable/billing plane, in ADDITION to the in-memory Meter (which backs
+// /__gateway/usage). The daemon wires an OTLP sink that emits per-tenant counters
+// into the metrics pipeline (→ VictoriaMetrics → billing); standalone/test runs
+// leave it nil. Kept an interface here so modelgateway stays free of an OTel
+// dependency (the design's "metering plane writer", decoupled).
+type UsageSink interface {
+	RecordUsage(tenant, skill, provider string, u Usage)
+}
+
 // Config configures a Gateway.
 type Config struct {
 	Secret       []byte               // shared HMAC secret (the daemon's jwt.secret)
 	Providers    map[string]*Provider // provider registry (see DefaultProviders)
 	ProviderKeys map[string]string    // provider name -> REAL API key, held here only
+	Sink         UsageSink            // optional: durable/billing usage writer (nil = in-memory only)
 	Logger       *log.Logger
 }
 
@@ -159,6 +170,9 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 			if json.Unmarshal(body, &decoded) == nil {
 				u := prov.parseUsage(decoded, pathModel)
 				g.meter.record(claims.Tenant, claims.SkillID, provName, u)
+				if g.cfg.Sink != nil {
+					g.cfg.Sink.RecordUsage(claims.Tenant, claims.SkillID, provName, u)
+				}
 				g.cfg.Logger.Printf("model-gateway: tenant=%s skill=%s provider=%s model=%s in=%d out=%d cached=%d",
 					claims.Tenant, claims.SkillID, provName, u.Model, u.InputTokens, u.OutputTokens, u.CachedTokens)
 			}

--- a/internal/modelgateway/gateway_test.go
+++ b/internal/modelgateway/gateway_test.go
@@ -77,6 +77,86 @@ func TestGateway_Anthropic_KeyInjected_TokenStripped_Metered(t *testing.T) {
 	}
 }
 
+// captureSink records the usage the gateway forwards to a UsageSink (#674
+// increment 3 — the metering→billing writer).
+type captureSink struct {
+	tenant, skill, provider string
+	u                       Usage
+	calls                   int
+}
+
+func (c *captureSink) RecordUsage(tenant, skill, provider string, u Usage) {
+	c.tenant, c.skill, c.provider, c.u = tenant, skill, provider, u
+	c.calls++
+}
+
+func TestGateway_ForwardsUsageToSink(t *testing.T) {
+	secret := []byte("shared-secret")
+	up := fakeUpstream(t, func(*http.Request) {},
+		`{"model":"claude-test","usage":{"input_tokens":12,"output_tokens":4,"cache_read_input_tokens":2}}`)
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["anthropic"].UpstreamURL = up.URL
+	sink := &captureSink{}
+	gw := New(Config{Secret: secret, Providers: providers, ProviderKeys: map[string]string{"anthropic": "REAL-KEY"}, Sink: sink})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	tok, err := MintToken(secret, GatewayClaims{Tenant: "acme", SkillID: "s1", Provider: "anthropic"}, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/model/anthropic/v1/messages", strings.NewReader(`{"model":"claude-test"}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+
+	// The sink receives the same attribution + token counts as the in-memory meter.
+	if sink.calls != 1 {
+		t.Fatalf("sink calls = %d, want 1", sink.calls)
+	}
+	if sink.tenant != "acme" || sink.skill != "s1" || sink.provider != "anthropic" || sink.u.Model != "claude-test" {
+		t.Errorf("sink attribution wrong: %+v", sink)
+	}
+	if sink.u.InputTokens != 12 || sink.u.OutputTokens != 4 || sink.u.CachedTokens != 2 {
+		t.Errorf("sink token counts wrong: %+v", sink.u)
+	}
+}
+
+func TestGateway_NilSinkIsSafe(t *testing.T) {
+	// No sink configured (standalone / OSS default) — metering still works,
+	// nothing panics.
+	secret := []byte("s")
+	up := fakeUpstream(t, func(*http.Request) {}, `{"model":"m","usage":{"input_tokens":1}}`)
+	defer up.Close()
+	providers := DefaultProviders()
+	providers["anthropic"].UpstreamURL = up.URL
+	gw := New(Config{Secret: secret, Providers: providers, ProviderKeys: map[string]string{"anthropic": "K"}}) // Sink nil
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+	tok, _ := MintToken(secret, GatewayClaims{Tenant: "t", Provider: "anthropic"}, time.Minute)
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/model/anthropic/v1/messages", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	if len(gw.Meter().Snapshot()) != 1 {
+		t.Error("in-memory meter should still record with a nil sink")
+	}
+}
+
 func TestGateway_Gemini_PathModel_AllowedModelsEnforced(t *testing.T) {
 	secret := []byte("s")
 	var gKey string

--- a/internal/server/agent_gateway_metrics.go
+++ b/internal/server/agent_gateway_metrics.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+
+	"github.com/footprintai/containarium/internal/modelgateway"
+)
+
+// gatewayOTLPSink is the model-gateway's metering→billing writer (#674
+// increment 3): it implements modelgateway.UsageSink by emitting per-tenant /
+// skill / provider / model token counters through the daemon's OTel meter, so
+// model-call usage flows the same pipeline as every other metric (OTLP →
+// VictoriaMetrics → dashboards / billing). The in-memory Meter still backs
+// /__gateway/usage for a live readout; this is the durable, aggregatable side.
+//
+// Uses the GLOBAL meter provider: when monitoring is enabled it exports; when
+// not, the global is a no-op provider and every Add is a cheap no-op — so the
+// sink is always safe to wire.
+type gatewayOTLPSink struct {
+	calls  otelmetric.Int64Counter
+	input  otelmetric.Int64Counter
+	output otelmetric.Int64Counter
+	cached otelmetric.Int64Counter
+}
+
+// newGatewayOTLPSink builds the counters from the global OTel meter. Returns an
+// error only if instrument creation fails (it shouldn't for a valid provider);
+// the caller logs and falls back to in-memory-only metering.
+func newGatewayOTLPSink() (*gatewayOTLPSink, error) {
+	meter := otel.GetMeterProvider().Meter("containarium")
+	calls, err := meter.Int64Counter("model_gateway.calls",
+		otelmetric.WithDescription("Model-gateway calls brokered, by tenant/skill/provider/model"))
+	if err != nil {
+		return nil, err
+	}
+	input, err := meter.Int64Counter("model_gateway.input_tokens",
+		otelmetric.WithDescription("Model-gateway input tokens"), otelmetric.WithUnit("{token}"))
+	if err != nil {
+		return nil, err
+	}
+	output, err := meter.Int64Counter("model_gateway.output_tokens",
+		otelmetric.WithDescription("Model-gateway output tokens"), otelmetric.WithUnit("{token}"))
+	if err != nil {
+		return nil, err
+	}
+	cached, err := meter.Int64Counter("model_gateway.cached_tokens",
+		otelmetric.WithDescription("Model-gateway cached (prompt-cache) tokens"), otelmetric.WithUnit("{token}"))
+	if err != nil {
+		return nil, err
+	}
+	return &gatewayOTLPSink{calls: calls, input: input, output: output, cached: cached}, nil
+}
+
+// RecordUsage emits one call + its token counts, attributed for per-tenant
+// billing rollups. Skipped attributes (empty skill/model) are omitted so the
+// series cardinality stays bounded.
+func (s *gatewayOTLPSink) RecordUsage(tenant, skill, provider string, u modelgateway.Usage) {
+	attrs := []attribute.KeyValue{
+		attribute.String("tenant", tenant),
+		attribute.String("provider", provider),
+	}
+	if skill != "" {
+		attrs = append(attrs, attribute.String("skill", skill))
+	}
+	if u.Model != "" {
+		attrs = append(attrs, attribute.String("model", u.Model))
+	}
+	set := otelmetric.WithAttributes(attrs...)
+	ctx := context.Background()
+	s.calls.Add(ctx, 1, set)
+	if u.InputTokens > 0 {
+		s.input.Add(ctx, u.InputTokens, set)
+	}
+	if u.OutputTokens > 0 {
+		s.output.Add(ctx, u.OutputTokens, set)
+	}
+	if u.CachedTokens > 0 {
+		s.cached.Add(ctx, u.CachedTokens, set)
+	}
+}
+
+// compile-time assertion: gatewayOTLPSink satisfies modelgateway.UsageSink.
+var _ modelgateway.UsageSink = (*gatewayOTLPSink)(nil)

--- a/internal/server/agent_gateway_metrics_test.go
+++ b/internal/server/agent_gateway_metrics_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/footprintai/containarium/internal/modelgateway"
+)
+
+// TestGatewayOTLPSink_EmitsTokenCounters wires a manual-reader MeterProvider as
+// the global, builds the sink, records one usage, and asserts the token counters
+// carry the right value + per-tenant attribution (#674 increment 3).
+func TestGatewayOTLPSink_EmitsTokenCounters(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+
+	sink, err := newGatewayOTLPSink()
+	if err != nil {
+		t.Fatalf("newGatewayOTLPSink: %v", err)
+	}
+	sink.RecordUsage("acme", "s1", "anthropic", modelgateway.Usage{
+		Model: "claude-test", InputTokens: 12, OutputTokens: 4, CachedTokens: 2,
+	})
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	want := map[string]int64{
+		"model_gateway.calls":         1,
+		"model_gateway.input_tokens":  12,
+		"model_gateway.output_tokens": 4,
+		"model_gateway.cached_tokens": 2,
+	}
+	got := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if sum, ok := m.Data.(metricdata.Sum[int64]); ok {
+				for _, dp := range sum.DataPoints {
+					got[m.Name] = dp.Value
+					// Attribution must be present for billing rollups.
+					if m.Name == "model_gateway.input_tokens" {
+						assertAttr(t, dp, "tenant", "acme")
+						assertAttr(t, dp, "skill", "s1")
+						assertAttr(t, dp, "provider", "anthropic")
+						assertAttr(t, dp, "model", "claude-test")
+					}
+				}
+			}
+		}
+	}
+	for name, wantVal := range want {
+		if got[name] != wantVal {
+			t.Errorf("%s = %d, want %d", name, got[name], wantVal)
+		}
+	}
+}
+
+func assertAttr(t *testing.T, dp metricdata.DataPoint[int64], key, want string) {
+	t.Helper()
+	v, ok := dp.Attributes.Value(attribute.Key(key))
+	if !ok || v.AsString() != want {
+		t.Errorf("attribute %s = %q (present=%v), want %q", key, v.AsString(), ok, want)
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1303,10 +1303,21 @@ skipAppHosting:
 		// boxes to route model calls through it (key custody + per-tenant
 		// metering). Inert when no provider key is set — boxes run in direct mode.
 		if keys := gatewayProviderKeysFromEnv(); len(keys) > 0 {
+			// Metering→billing (#674 increment 3): forward per-tenant token usage
+			// to the OTel pipeline (→ VictoriaMetrics → billing) on top of the
+			// in-memory /__gateway/usage readout. Uses the global meter — a no-op
+			// when monitoring is off, so it's always safe to wire.
+			var gwSink modelgateway.UsageSink
+			if sink, serr := newGatewayOTLPSink(); serr != nil {
+				log.Printf("Warning: model-gateway OTLP usage sink unavailable (%v); usage is in-memory only", serr)
+			} else {
+				gwSink = sink
+			}
 			gw := modelgateway.New(modelgateway.Config{
 				Secret:       []byte(config.JWTSecret),
 				Providers:    modelgateway.DefaultProviders(),
 				ProviderKeys: keys,
+				Sink:         gwSink,
 			})
 			gatewayServer.SetModelGatewayHandler(gw.Handler())
 			primary := gatewayPrimaryProvider(keys)


### PR DESCRIPTION
Increment 3 of the agent/skill/sandbox push (after #742 daemon-served gateway). The gateway's per-tenant token metering was an **in-memory snapshot only** (`/__gateway/usage`) — lost on restart, not aggregatable. This makes it the durable **"metering plane writer"** the #674 design calls for.

## Change
- **`modelgateway`**: a pluggable **`UsageSink`** (`RecordUsage`) on the gateway `Config`, called alongside the in-memory `Meter` on every metered call. Kept an interface so `modelgateway` stays free of an OTel dependency.
- **`internal/server`**: `gatewayOTLPSink` implements `UsageSink` by emitting per-tenant/skill/provider/model token counters — `model_gateway.calls`, `.input_tokens`, `.output_tokens`, `.cached_tokens` — via the daemon's OTel meter → the existing **OTLP → VictoriaMetrics → dashboards/billing** pipeline. Empty skill/model attributes are omitted to bound series cardinality.
- **`dual_server`**: wires the OTLP sink into the gateway `Config` when a provider key is set. Uses the **global** meter, a no-op provider when monitoring is off — so it's always safe to wire; a nil sink keeps the in-memory meter working (standalone/OSS default).

## Why OTLP (not a new table)
Token usage flows the same path as every other daemon metric — no new migration/store, and it lands where the metering/billing plane already reads (VictoriaMetrics). The in-memory `/__gateway/usage` readout stays for a live view.

## Tests
- gateway forwards usage to the sink with correct attribution + token counts; **nil sink is safe** (in-memory meter still records);
- the OTLP sink emits the right counter **values + per-tenant attributes**, verified with a manual metric reader.
- `gofmt` + `go vet` clean; `go test ./internal/modelgateway/ ./internal/server/ -run 'Gateway|Queue'` green.

Refs #674. Next increment: eBPF egress-pinning so a skill box can *only* reach the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)