### PR TITLE
feat(agent): pin skill-box egress to the model-gateway (#674)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Skill-box egress pinned to the model-gateway (#674).** When the daemon serves
+  the model-gateway, a skill box's eBPF egress policy now allows only the gateway
+  host (the LXC bridge gateway — also the daemon API + DNS) plus its allowed
+  peers, and the direct provider domains (`api.anthropic.com`, …) are **dropped**
+  — so a box can't bypass the gateway to reach a provider with a key it doesn't
+  hold. Key-custody becomes enforced, not just convention. Pinning applies even
+  to a skill with no `allowed_peers`. Observe-only by default (LOG_ONLY); it
+  blocks only once eBPF enforcement is armed (`CONTAINARIUM_AGENT_NETWORK_POLICY_ENFORCE=1`).
+  Direct mode (no gateway) is unchanged — provider domains are served as before.
+
 - **Pull-based agent run-queue + poll-mode workers (#674).** An orthogonal
   delivery model to push: a producer `EnqueueAgentTask`s; long-lived worker
   boxes `LeaseAgentTask` (SQS-style visibility-timeout lease → at-most-one

--- a/internal/server/agent_gateway.go
+++ b/internal/server/agent_gateway.go
@@ -25,6 +25,11 @@ type gatewayProvisioning struct {
 	httpPort      int    // the daemon HTTP port the box dials (resolved to the host's default-route IP in-box)
 	secret        []byte // shared HMAC secret (daemon jwt.secret) — signs the gateway token
 	allowedModels []string
+	// egressCIDR is the host the box reaches the gateway on, as a /32 (the LXC
+	// bridge gateway IP — also the daemon API + DNS). When set, the skill box's
+	// egress policy allows ONLY this host (+ peers) for model calls and DROPS the
+	// direct provider domains — so a box can't bypass the gateway (#674 inc 4).
+	egressCIDR string
 }
 
 // gatewayProviderEnv is the per-provider env contract the agent-runtime engines

--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -66,9 +66,15 @@ func (s *AgentSkillServer) SetAuditStore(store *audit.Store) { s.audit = store }
 // its model calls route through the daemon-served gateway (key custody +
 // metering). Wired from dual_server when a provider key is configured; nil-safe
 // (no call ⇒ direct mode). provider is the gateway's configured provider,
-// httpPort the daemon HTTP port the box dials, secret the shared jwt secret.
-func (s *AgentSkillServer) SetGatewayProvisioning(provider string, httpPort int, secret []byte) {
-	s.gateway = &gatewayProvisioning{provider: provider, httpPort: httpPort, secret: secret}
+// httpPort the daemon HTTP port the box dials, secret the shared jwt secret,
+// hostIP the bridge gateway IP the box reaches the gateway/daemon/DNS on (used
+// to pin skill-box egress to the gateway, #674 inc 4; empty disables pinning).
+func (s *AgentSkillServer) SetGatewayProvisioning(provider string, httpPort int, secret []byte, hostIP string) {
+	g := &gatewayProvisioning{provider: provider, httpPort: httpPort, secret: secret}
+	if hostIP = strings.TrimSpace(hostIP); hostIP != "" {
+		g.egressCIDR = hostIP + "/32"
+	}
+	s.gateway = g
 }
 
 // NewAgentSkillServer wires the agent-skill service to the recipe server (for
@@ -345,20 +351,29 @@ func parseArtifactOutput(raw []byte) (string, error) {
 // needs (daemon API, DNS) — a peer-only allowlist would otherwise strand the
 // agent. Tracked in #574.
 func (s *AgentSkillServer) applyAllowedPeersPolicy(ctx context.Context, tenant string, skill *pb.AgentSkill) {
-	if s.netpolicy == nil || len(skill.AllowedPeers) == 0 {
+	// Gateway pinning (#674 inc 4): when the model-gateway is enabled, every
+	// skill box is pinned to it — even one with no allowed_peers — so model
+	// calls can ONLY go through the gateway. Without a gateway, only skills that
+	// declare allowed_peers get a policy (unchanged).
+	gatewayCIDR := ""
+	if s.gateway != nil {
+		gatewayCIDR = s.gateway.egressCIDR
+	}
+	if s.netpolicy == nil || (len(skill.AllowedPeers) == 0 && gatewayCIDR == "") {
 		return
 	}
 	extraCIDRs, extraDomains, enforce := agentNetworkPolicyConfig()
-	policy := compileAllowedPeersPolicy(tenant, skill.AllowedPeers, s.resolvePeerIP, extraCIDRs, extraDomains, enforce)
+	policy := compileAllowedPeersPolicy(tenant, skill.AllowedPeers, s.resolvePeerIP, extraCIDRs, extraDomains, gatewayCIDR, enforce)
 	if len(policy.EgressCidrs) == 0 && len(policy.EgressDomains) == 0 {
 		// Nothing to allow at all. Skip rather than install an empty allowlist
 		// (which, under ENFORCE, denies everything).
 		return
 	}
-	if enforce && len(policy.EgressDomains) == 0 {
+	if enforce && len(policy.EgressDomains) == 0 && gatewayCIDR == "" {
 		// #611: an armed agent with no model-provider egress is stranded — it
 		// can reach its peers but not the Claude/OpenAI API. Default domains
-		// prevent this; warn loudly if an operator cleared them.
+		// prevent this; warn loudly if an operator cleared them. (In gateway
+		// mode model egress is the gatewayCIDR, so this doesn't apply.)
 		log.Printf("[agent-skill] WARNING: ENFORCE armed for %q with no model egress (CONTAINARIUM_AGENT_EGRESS_DOMAINS empty) — the agent loop may be unable to reach its provider API", tenant)
 	}
 	// Compile (validate + normalize) before storing — same path the
@@ -458,7 +473,13 @@ func (s *AgentSkillServer) resolvePeerIP(peerID string) (string, bool) {
 // allowed_peers: each currently-running peer's box IP becomes an egress /32.
 // Pure (resolution is injected) so it is unit-testable without a daemon. The
 // policy is LOG_ONLY — observe, never drop — until Phase 2 enforcement is armed.
-func compileAllowedPeersPolicy(tenant string, allowedPeers []string, resolve func(peerID string) (string, bool), extraCIDRs, extraDomains []string, enforce bool) *pb.NetworkPolicy {
+// compileAllowedPeersPolicy builds a skill box's egress policy. gatewayCIDR
+// pins the box to the model-gateway (#674 inc 4): when set, the box's model
+// egress is the gateway host (gatewayCIDR — also the daemon API + DNS) and the
+// direct provider domains are DROPPED, so a box can't bypass the gateway to
+// reach a provider with a key it doesn't hold. When empty (direct mode) the
+// box gets the provider domains directly, as before.
+func compileAllowedPeersPolicy(tenant string, allowedPeers []string, resolve func(peerID string) (string, bool), extraCIDRs, extraDomains []string, gatewayCIDR string, enforce bool) *pb.NetworkPolicy {
 	var cidrs []string
 	for _, peer := range allowedPeers {
 		if ip, ok := resolve(peer); ok {
@@ -469,6 +490,15 @@ func compileAllowedPeersPolicy(tenant string, allowedPeers []string, resolve fun
 	// armed ENFORCE policy doesn't strand the agent.
 	cidrs = append(cidrs, extraCIDRs...)
 
+	// Gateway pinning: allow the gateway host (model calls go here) and serve no
+	// direct provider domains. Without a gateway, fall back to direct provider
+	// egress.
+	domains := extraDomains
+	if gatewayCIDR != "" {
+		cidrs = append(cidrs, gatewayCIDR)
+		domains = nil
+	}
+
 	mode := pb.NetworkPolicyMode_NETWORK_POLICY_MODE_LOG_ONLY
 	if enforce {
 		mode = pb.NetworkPolicyMode_NETWORK_POLICY_MODE_ENFORCE
@@ -477,9 +507,10 @@ func compileAllowedPeersPolicy(tenant string, allowedPeers []string, resolve fun
 		Tenant:           tenant,
 		AllowIntraTenant: false,
 		EgressCidrs:      cidrs,
-		// Model-provider egress (resolved to IPs by the enforcer's domain
-		// resolver) so the in-box loop can reach the Claude/OpenAI API (#611).
-		EgressDomains: extraDomains,
+		// Direct model-provider egress (resolved to IPs by the enforcer's domain
+		// resolver) so the in-box loop can reach the Claude/OpenAI API (#611) —
+		// EMPTY in gateway mode, where model calls go through gatewayCIDR instead.
+		EgressDomains: domains,
 		Mode:          mode,
 		AllowMetadata: false,
 		Source:        "agent-skill",

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -99,9 +100,55 @@ func TestAgentNetworkPolicyConfigDomains(t *testing.T) {
 func TestCompileAllowedPeersPolicySetsDomains(t *testing.T) {
 	p := compileAllowedPeersPolicy("agent-x", []string{"peer-a"},
 		func(string) (string, bool) { return "10.0.0.5", true },
-		nil, []string{"api.anthropic.com"}, true)
+		nil, []string{"api.anthropic.com"}, "", true)
 	if len(p.EgressDomains) != 1 || p.EgressDomains[0] != "api.anthropic.com" {
 		t.Errorf("egress_domains = %v, want [api.anthropic.com]", p.EgressDomains)
+	}
+}
+
+func TestCompileAllowedPeersPolicy_GatewayPinning(t *testing.T) {
+	// #674 inc 4: with a gatewayCIDR set, the box's model egress is the gateway
+	// host and the direct provider domains are DROPPED — so it can't bypass the
+	// gateway. Peers + platform CIDRs are still allowed.
+	resolve := func(string) (string, bool) { return "10.0.0.5", true }
+	p := compileAllowedPeersPolicy("agent-x", []string{"peer-a"}, resolve,
+		nil, []string{"api.anthropic.com", "api.openai.com"}, "10.100.0.1/32", true)
+
+	if len(p.EgressDomains) != 0 {
+		t.Errorf("gateway mode must drop direct provider domains, got %v", p.EgressDomains)
+	}
+	if !slices.Contains(p.EgressCidrs, "10.100.0.1/32") {
+		t.Errorf("gateway host must be in egress cidrs, got %v", p.EgressCidrs)
+	}
+	if !slices.Contains(p.EgressCidrs, "10.0.0.5/32") {
+		t.Errorf("peer must still be allowed, got %v", p.EgressCidrs)
+	}
+}
+
+func TestCompileAllowedPeersPolicy_NoGatewayKeepsDomains(t *testing.T) {
+	// Direct mode (no gatewayCIDR): provider domains are served as before, and
+	// the gateway host is NOT injected.
+	resolve := func(string) (string, bool) { return "10.0.0.5", true }
+	p := compileAllowedPeersPolicy("agent-x", []string{"peer-a"}, resolve,
+		nil, []string{"api.anthropic.com"}, "", false)
+	if len(p.EgressDomains) != 1 || p.EgressDomains[0] != "api.anthropic.com" {
+		t.Errorf("direct mode must keep provider domains, got %v", p.EgressDomains)
+	}
+	if slices.Contains(p.EgressCidrs, "10.100.0.1/32") {
+		t.Errorf("no gateway host should be injected in direct mode, got %v", p.EgressCidrs)
+	}
+}
+
+func TestSetGatewayProvisioning_EgressCIDR(t *testing.T) {
+	s := &AgentSkillServer{}
+	s.SetGatewayProvisioning("anthropic", 8080, []byte("secret"), "10.100.0.1")
+	if s.gateway.egressCIDR != "10.100.0.1/32" {
+		t.Errorf("egressCIDR = %q, want 10.100.0.1/32", s.gateway.egressCIDR)
+	}
+	// Empty host IP → no pinning CIDR (direct provider egress retained).
+	s.SetGatewayProvisioning("anthropic", 8080, []byte("secret"), "")
+	if s.gateway.egressCIDR != "" {
+		t.Errorf("empty hostIP must yield no egressCIDR, got %q", s.gateway.egressCIDR)
 	}
 }
 
@@ -172,7 +219,7 @@ func TestCompileAllowedPeersPolicy(t *testing.T) {
 	resolve := func(id string) (string, bool) { ip, ok := running[id]; return ip, ok }
 
 	// peer-c is not running, so it must be omitted from the allowlist.
-	p := compileAllowedPeersPolicy("agent-caller", []string{"peer-a", "peer-b", "peer-c"}, resolve, nil, nil, false)
+	p := compileAllowedPeersPolicy("agent-caller", []string{"peer-a", "peer-b", "peer-c"}, resolve, nil, nil, "", false)
 
 	if p.Tenant != "agent-caller" {
 		t.Errorf("tenant = %q, want agent-caller", p.Tenant)
@@ -200,7 +247,7 @@ func TestCompileAllowedPeersPolicy(t *testing.T) {
 func TestCompileAllowedPeersPolicyNoneRunning(t *testing.T) {
 	// No peer is running -> empty allowlist (the caller skips installing it
 	// rather than denying all egress under a future ENFORCE).
-	p := compileAllowedPeersPolicy("t", []string{"x", "y"}, func(string) (string, bool) { return "", false }, nil, nil, false)
+	p := compileAllowedPeersPolicy("t", []string{"x", "y"}, func(string) (string, bool) { return "", false }, nil, nil, "", false)
 	if len(p.EgressCidrs) != 0 {
 		t.Errorf("expected no egress cidrs when no peers run, got %v", p.EgressCidrs)
 	}
@@ -216,7 +263,7 @@ func TestCompileAllowedPeersPolicyEnforceAndExtraCIDRs(t *testing.T) {
 	// Armed ENFORCE + platform egress (e.g. daemon + DNS) so the agent isn't
 	// stranded by a peer-only allowlist.
 	extra := []string{"10.0.1.1/32", "10.0.1.2/32"}
-	p := compileAllowedPeersPolicy("agent-x", []string{"peer-a"}, resolve, extra, nil, true)
+	p := compileAllowedPeersPolicy("agent-x", []string{"peer-a"}, resolve, extra, nil, "", true)
 
 	if p.Mode != pb.NetworkPolicyMode_NETWORK_POLICY_MODE_ENFORCE {
 		t.Errorf("mode = %v, want ENFORCE when armed", p.Mode)

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1321,7 +1321,7 @@ skipAppHosting:
 			})
 			gatewayServer.SetModelGatewayHandler(gw.Handler())
 			primary := gatewayPrimaryProvider(keys)
-			agentSkillServer.SetGatewayProvisioning(primary, config.HTTPPort, []byte(config.JWTSecret))
+			agentSkillServer.SetGatewayProvisioning(primary, config.HTTPPort, []byte(config.JWTSecret), config.HostIP)
 			provs := make([]string, 0, len(keys))
 			for p := range keys {
 				provs = append(provs, p)


### PR DESCRIPTION
Increment 4 (capstone) of the agent/skill/sandbox push — makes key-custody **enforced, not just convention**.

## Why
Increments 1–3 route a skill box's model calls through the daemon-held gateway, but the box's egress policy still allowed the provider domains directly (`api.anthropic.com`, …). So a compromised box could **bypass the gateway** and call a provider with a key it smuggled in. This closes that.

## Change
When the gateway is enabled, a skill box's eBPF egress policy now:
- **allows the gateway host CIDR** (`config.HostIP/32` — the LXC bridge gateway, which is also the daemon API + DNS the box already reaches), plus its allowed peers;
- **drops the direct provider domains** — model calls can *only* go through the gateway.

- `gatewayProvisioning` gains `egressCIDR` (= host IP /32); `SetGatewayProvisioning` takes the host IP (wired from `config.HostIP`).
- `compileAllowedPeersPolicy` takes a `gatewayCIDR`: set ⇒ append the gateway host + serve no provider domains; empty (direct mode) ⇒ unchanged.
- `applyAllowedPeersPolicy` pins **even a no-peers skill** when the gateway is on, and skips the "stranded — no model egress" warning in gateway mode.

## Safety
**Observe-only by default** (LOG_ONLY) — it blocks only once eBPF enforcement is armed (`CONTAINARIUM_AGENT_NETWORK_POLICY_ENFORCE=1`), so it's safe to ship on. Direct mode (no gateway) is unchanged.

## Tests
gateway pinning drops provider domains + allows the gateway host + keeps peers; direct mode keeps domains + injects no gateway host; `SetGatewayProvisioning` derives the `/32`. Full `internal/server` suite + `go vet` clean. eBPF enforce-path validation is backend-gated.

Refs #674. Completes the four agent/skill/sandbox increments (#742 gateway, #743 pull-queue, #744 metering, this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)