### PR TITLE
fix(agent): default-deny egress for every skill box + pin engine to gateway provider (#750, #748)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Agent-skill box: default-deny egress for every box (#750).** `RunAgentSkill`
+  now installs a network policy for **every** provisioned box, including leaf
+  skills (`allowed_peers: []`) in direct mode — previously such a box got no
+  policy at all, so under ENFORCE it had no eBPF program and unrestricted egress.
+  A leaf box's egress is now just the provider domains (+ operator CIDRs), with
+  metadata and intra-tenant denied. (Behaviour is observe-only until ENFORCE is
+  armed, as before; this ensures the box is actually covered once it is.)
+- **Agent-skill box: pin the engine to the gateway provider (#748).** When the
+  daemon serves a model-gateway it now sets `CONTAINARIUM_AGENT_ENGINE` to the
+  engine matching the gateway's provider (anthropic→claude, gemini→gemini,
+  openai→codex) on the in-box exec. Without this, a gemini/openai gateway run
+  fell back to the default claude engine and failed (`Not logged in`) because the
+  default engine reads the wrong gateway env vars.
+
 ### Added
 
 - **Post-hoc container attribution endpoint (#746).** New

--- a/internal/server/agent_server.go
+++ b/internal/server/agent_server.go
@@ -272,6 +272,39 @@ func (s *AgentSkillServer) provisionSkillBox(ctx context.Context, skill *pb.Agen
 	return containerName, container, nil
 }
 
+// engineForProvider maps a gateway provider to the agent-runtime engine that
+// speaks it. Empty for an unknown provider (caller then leaves the engine
+// unset, so the box falls back to its own default).
+func engineForProvider(provider string) string {
+	switch provider {
+	case "anthropic":
+		return "claude"
+	case "gemini":
+		return "gemini"
+	case "openai":
+		return "codex"
+	default:
+		return ""
+	}
+}
+
+// engineEnvPrefix returns a `CONTAINARIUM_AGENT_ENGINE=<engine> ` command prefix
+// pinning the box to the engine that matches the gateway provider (#748). When
+// the daemon serves a gateway it knows the provider, so it must tell the box
+// which engine to run — otherwise the box uses its default (claude) and a
+// gemini/openai gateway run fails ("Not logged in") because the default engine
+// looks for the wrong gateway env vars. Empty in direct mode (no gateway): the
+// box's own env/default decides.
+func (s *AgentSkillServer) engineEnvPrefix() string {
+	if s.gateway == nil {
+		return ""
+	}
+	if eng := engineForProvider(s.gateway.provider); eng != "" {
+		return "CONTAINARIUM_AGENT_ENGINE=" + eng + " "
+	}
+	return ""
+}
+
 // startServeMode launches the in-box agent-runtime in serve mode (the A2A
 // server on :8674) as a background process, so peers/crews can delegate tasks
 // to this box. Best-effort: until the box image ships agent-runtime this is a
@@ -280,7 +313,7 @@ func (s *AgentSkillServer) startServeMode(containerName string) {
 	if s.recipes == nil || s.recipes.containers == nil || s.recipes.containers.manager == nil {
 		return
 	}
-	cmd := sourceGatewayEnvPrefix(agentSeedDir) + "CONTAINARIUM_AGENT_MODE=serve AGENT_SEED_DIR=" + agentSeedDir +
+	cmd := sourceGatewayEnvPrefix(agentSeedDir) + s.engineEnvPrefix() + "CONTAINARIUM_AGENT_MODE=serve AGENT_SEED_DIR=" + agentSeedDir +
 		" setsid agent-runtime >/var/log/agent-runtime.log 2>&1 &"
 	if _, stderr, err := s.recipes.containers.manager.ExecWithOutput(containerName,
 		[]string{"bash", "-lc", cmd}); err != nil {
@@ -302,7 +335,7 @@ func (s *AgentSkillServer) runInBoxAgent(containerName string) string {
 	mgr := s.recipes.containers.manager
 
 	if _, stderr, err := mgr.ExecWithOutput(containerName,
-		[]string{"bash", "-lc", sourceGatewayEnvPrefix(agentSeedDir) + "AGENT_SEED_DIR=" + agentSeedDir + " agent-runtime"}); err != nil {
+		[]string{"bash", "-lc", sourceGatewayEnvPrefix(agentSeedDir) + s.engineEnvPrefix() + "AGENT_SEED_DIR=" + agentSeedDir + " agent-runtime"}); err != nil {
 		log.Printf("[agent-skill] in-box runtime did not run on %s (image may not ship it yet): %v; stderr=%s",
 			containerName, err, strings.TrimSpace(stderr))
 		return ""
@@ -353,13 +386,19 @@ func parseArtifactOutput(raw []byte) (string, error) {
 func (s *AgentSkillServer) applyAllowedPeersPolicy(ctx context.Context, tenant string, skill *pb.AgentSkill) {
 	// Gateway pinning (#674 inc 4): when the model-gateway is enabled, every
 	// skill box is pinned to it — even one with no allowed_peers — so model
-	// calls can ONLY go through the gateway. Without a gateway, only skills that
-	// declare allowed_peers get a policy (unchanged).
+	// calls can ONLY go through the gateway.
 	gatewayCIDR := ""
 	if s.gateway != nil {
 		gatewayCIDR = s.gateway.egressCIDR
 	}
-	if s.netpolicy == nil || (len(skill.AllowedPeers) == 0 && gatewayCIDR == "") {
+	// Default-deny (#750): install a policy for EVERY skill box, not only ones
+	// that declare allowed_peers or run under a gateway. A leaf skill
+	// (allowed_peers: []) in direct mode still gets a policy whose egress is just
+	// the provider domains (+ operator CIDRs), with metadata and intra-tenant
+	// denied — so under ENFORCE the box is locked down rather than left with no
+	// eBPF program (i.e. unrestricted egress). The empty-allowlist guard below
+	// still skips the degenerate "nothing allowed" case.
+	if s.netpolicy == nil {
 		return
 	}
 	extraCIDRs, extraDomains, enforce := agentNetworkPolicyConfig()

--- a/internal/server/agent_server_test.go
+++ b/internal/server/agent_server_test.go
@@ -279,6 +279,56 @@ func TestCompileAllowedPeersPolicyEnforceAndExtraCIDRs(t *testing.T) {
 	}
 }
 
+func TestCompileAllowedPeersPolicyLeafIsDefaultDeny(t *testing.T) {
+	// #750: a leaf skill (no allowed_peers) in direct mode (no gateway) still
+	// gets a restrictive policy — provider domains only, with metadata and
+	// intra-tenant denied. applyAllowedPeersPolicy now installs this for every
+	// box (it no longer short-circuits on "no peers"), so under ENFORCE a leaf
+	// box is locked down instead of left with no eBPF program.
+	p := compileAllowedPeersPolicy("agent-x", nil, func(string) (string, bool) { return "", false },
+		nil, defaultAgentEgressDomains, "", false)
+	if len(p.EgressCidrs) != 0 {
+		t.Errorf("leaf: expected no egress cidrs, got %v", p.EgressCidrs)
+	}
+	if len(p.EgressDomains) != len(defaultAgentEgressDomains) {
+		t.Errorf("leaf: expected the provider domains as the only egress, got %v", p.EgressDomains)
+	}
+	if p.AllowIntraTenant {
+		t.Error("leaf: intra-tenant must be denied")
+	}
+	if p.AllowMetadata {
+		t.Error("leaf: metadata must be denied")
+	}
+}
+
+func TestEngineForProvider(t *testing.T) {
+	cases := map[string]string{
+		"anthropic": "claude",
+		"gemini":    "gemini",
+		"openai":    "codex",
+		"":          "",
+		"bogus":     "",
+	}
+	for provider, want := range cases {
+		if got := engineForProvider(provider); got != want {
+			t.Errorf("engineForProvider(%q) = %q, want %q", provider, got, want)
+		}
+	}
+}
+
+func TestEngineEnvPrefix(t *testing.T) {
+	// No gateway (direct mode): no engine pin — the box's own default decides.
+	if got := (&AgentSkillServer{}).engineEnvPrefix(); got != "" {
+		t.Errorf("no gateway: prefix = %q, want empty", got)
+	}
+	// Gateway with a known provider: pin the matching engine (#748) so the box
+	// doesn't fall back to claude on a gemini gateway.
+	s := &AgentSkillServer{gateway: &gatewayProvisioning{provider: "gemini"}}
+	if got := s.engineEnvPrefix(); got != "CONTAINARIUM_AGENT_ENGINE=gemini " {
+		t.Errorf("gemini gateway: prefix = %q, want CONTAINARIUM_AGENT_ENGINE=gemini ", got)
+	}
+}
+
 func TestPeerAllowed(t *testing.T) {
 	s := &AgentSkillServer{catalog: skills.GetDefault()}
 


### PR DESCRIPTION
Two access-control fixes on the agent-skill box (`agent-<id>-container`), surfaced by the live `RunAgentSkill` → gateway validation.

## #750 — default-deny egress for every box

`applyAllowedPeersPolicy` short-circuited and installed **no** policy when a skill had `allowed_peers: []` *and* no gateway:

```go
if s.netpolicy == nil || (len(skill.AllowedPeers) == 0 && gatewayCIDR == "") { return }
```

So a leaf skill (e.g. the whole `packs/general` set) in direct mode got no eBPF program → **unrestricted egress** once ENFORCE is armed. Now a policy is installed for **every** box; a leaf box's egress is just the provider domains (+ operator `CONTAINARIUM_AGENT_EGRESS_CIDRS`), with `AllowMetadata:false` + `AllowIntraTenant:false`. The existing empty-allowlist guard still skips the degenerate "nothing allowed" case. (Still observe-only until ENFORCE is armed — this ensures the box is actually *covered* once it is.)

## #748 (gap 2) — pin the engine to the gateway provider

`runInBoxAgent` / `startServeMode` exec'd the loop without setting `CONTAINARIUM_AGENT_ENGINE`, so the box used its **default engine (claude)**. On a gemini/openai gateway the box is seeded with that provider's gateway env, but the claude engine reads `ANTHROPIC_*` → run returns `Not logged in`. The daemon knows `s.gateway.provider`, so it now pins the matching engine (anthropic→claude, gemini→gemini, openai→codex) on the exec. Direct mode (no gateway) leaves it unset, as before.

This is exactly the manual step the live gemini validation needed (`/etc/profile.d` engine pin); with this, a gemini-provider daemon drives a gemini box with no surgery (paired with the bundle fix, #748 gap 1).

## Tests

- `compileAllowedPeersPolicy` with no peers / no gateway → default-deny (provider domains only, metadata + intra-tenant denied).
- `engineForProvider` mapping (incl. unknown → empty).
- `engineEnvPrefix` (nil gateway → empty; gemini gateway → `CONTAINARIUM_AGENT_ENGINE=gemini `).

`go test ./internal/server/ -run 'Agent|Crew|Gateway|NetworkPolicy'` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)