### PR TITLE
fix(model-gateway): make in-box gateway tokens revocable (#750)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Post-hoc container attribution endpoint (#746).** New
+  `SetContainerAttribution` RPC (`POST /v1/containers/{name}/attribution`) merges
+  labels onto an EXISTING container's config (merge, not replace — labels not
+  named are left intact). The daemon stamps cloud attribution
+  (`cloud_org_id` / `cloud_container_id` / `managed_by`) only at create today;
+  this lets the hosted control plane stamp them after the fact, which its adopt
+  flow (cloud #539) needs to bring a host's pre-existing (orphan) container under
+  org management. Backed by `manager.AddLabel` (writes under
+  `user.containarium.label.`); rejects core containers; 404 when the name
+  doesn't resolve. Cloud→daemon plumbing (like `/authorized-keys/sentinel`) — no
+  CLI verb. Typed clients gain `SetContainerAttribution` (gRPC + HTTP, the latter
+  mapping a 404 to `Unimplemented` for old daemons).
 - **Skill-box egress pinned to the model-gateway (#674).** When the daemon serves
   the model-gateway, a skill box's eBPF egress policy now allows only the gateway
   host (the LXC bridge gateway — also the daemon API + DNS) plus its allowed

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -1799,6 +1799,47 @@
         ]
       }
     },
+    "/v1/containers/{name}/attribution": {
+      "post": {
+        "summary": "Merge attribution labels onto an existing container",
+        "description": "Sets the given labels on a live container's config, leaving other labels intact (cloud #746). Lets the hosted control plane stamp cloud attribution (cloud_org_id / cloud_container_id / managed_by) on a pre-existing box so its adopt flow can bring it under management (cloud #539). 404 when the container doesn't resolve.",
+        "operationId": "ContainerService_SetContainerAttribution",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SetContainerAttributionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "description": "Container name — the bare username, matching the per-container RPC\nconvention (the handler resolves \u003cusername\u003e-container; see SetContainerTTL).",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SetContainerAttributionBody"
+            }
+          }
+        ],
+        "tags": [
+          "Container Operations"
+        ]
+      }
+    },
     "/v1/containers/{name}/delete-policy": {
       "post": {
         "summary": "Protect or unprotect a container from automated deletion",
@@ -10749,6 +10790,32 @@
         }
       },
       "description": "SendAgentTaskResponse returns the peer's artifact."
+    },
+    "SetContainerAttributionBody": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels to merge onto the container. Each entry is set; labels not named\nhere are left intact (merge, not replace). An empty map is rejected."
+        }
+      },
+      "description": "SetContainerAttributionRequest merges labels onto an existing container\n(cloud #746). Used by the hosted control plane's adopt flow (cloud #539) to\nstamp attribution (cloud_org_id / cloud_container_id / managed_by) on a\npre-existing box after the fact."
+    },
+    "SetContainerAttributionResponse": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Every label currently on the container after the merge."
+        }
+      },
+      "description": "SetContainerAttributionResponse reports the full label set now on the box."
     },
     "SetContainerDeletePolicyBody": {
       "type": "object",

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -294,6 +294,20 @@ func (c *GRPCClient) SetContainerDeletePolicy(username string, policy pb.DeleteP
 	})
 }
 
+// SetContainerAttribution merges labels onto an existing container (cloud #746)
+// — the daemon-side primitive the hosted control plane's adopt flow (cloud
+// #539) uses to stamp attribution on a pre-existing box. Cloud→daemon plumbing;
+// no CLI verb.
+func (c *GRPCClient) SetContainerAttribution(username string, labels map[string]string) (*pb.SetContainerAttributionResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	return c.client.SetContainerAttribution(ctx, &pb.SetContainerAttributionRequest{
+		Name:   username,
+		Labels: labels,
+	})
+}
+
 // StartContainer starts a stopped container via gRPC. When
 // waitForReady is true the server blocks until the container's
 // primary TCP port accepts or readyTimeoutSeconds elapses (0 falls

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -465,6 +465,44 @@ func (c *HTTPClient) SetContainerDeletePolicy(username string, policy pb.DeleteP
 	return out, nil
 }
 
+// SetContainerAttribution merges labels onto an existing container via the REST
+// shim (cloud #746) — the daemon-side primitive the hosted control plane's
+// adopt flow (cloud #539) uses to stamp attribution on a pre-existing box. A
+// 404 (daemon too old to expose the endpoint) maps to codes.Unimplemented, so a
+// caller can soft-path it the same way as SetContainerDeletePolicy.
+func (c *HTTPClient) SetContainerAttribution(username string, labels map[string]string) (*pb.SetContainerAttributionResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/v1/containers/%s/attribution", url.PathEscape(username))
+	body := map[string]interface{}{"labels": labels}
+	resp, err := c.doRequest(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("set attribution: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, status.Errorf(codes.Unimplemented, "server does not expose SetContainerAttribution (HTTP 404)")
+	}
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(bodyBytes, &errResp) == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("%s", errResp.Error)
+		}
+		return nil, fmt.Errorf("set attribution: status %d", resp.StatusCode)
+	}
+
+	out := &pb.SetContainerAttributionResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
 // StartContainer starts a stopped container via HTTP. When
 // waitForReady is true the daemon blocks until the container's
 // primary TCP port accepts (or readyTimeoutSeconds elapses).

--- a/internal/server/container_server_attribution.go
+++ b/internal/server/container_server_attribution.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"log"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/box"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// SetContainerAttribution merges labels onto an EXISTING container's config
+// (cloud #746). The hosted control plane stamps attribution labels
+// (cloud_org_id / cloud_container_id / managed_by) at CreateContainer today;
+// this lets it stamp them AFTER the fact, which the cloud's adopt flow (cloud
+// #539) needs to bring a host's pre-existing (orphan) container under org
+// management.
+//
+// Merge, not replace: each provided label is set via manager.AddLabel (which
+// writes incus.LabelPrefix+key), leaving labels not named here intact — so an
+// adopt can't clobber a box's monitoring / os-type / other labels. The labels
+// live on the Incus config, so they survive daemon restart and are read back on
+// list/get the same way create-time labels are. Like the other per-container
+// RPCs, req.Name carries the bare username and the manager resolves
+// <username>-container.
+//
+// Cloud→daemon plumbing (like /authorized-keys/sentinel), not a standalone
+// operator action — stamping cloud org UUIDs by hand is meaningless, so there's
+// no `containarium` CLI verb; the operator surface is the cloud's adopt flow.
+func (s *ContainerServer) SetContainerAttribution(ctx context.Context, req *pb.SetContainerAttributionRequest) (*pb.SetContainerAttributionResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeContainersWrite); err != nil {
+		return nil, err
+	}
+	if req.Name == "" {
+		return nil, status.Error(codes.InvalidArgument, "name is required")
+	}
+	if len(req.Labels) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "labels must not be empty")
+	}
+	for k := range req.Labels {
+		if k == "" {
+			return nil, status.Error(codes.InvalidArgument, "label key must not be empty")
+		}
+	}
+
+	username := req.Name
+	if err := auth.AuthorizeTenant(ctx, username); err != nil {
+		return nil, err
+	}
+
+	info, err := s.boxes().Get(ctx, box.BoxRef{Tenant: username})
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "container for user %s not found: %v", username, err)
+	}
+	if info == nil {
+		return nil, status.Errorf(codes.NotFound, "container for user %s not found", username)
+	}
+	if info.IsCore {
+		return nil, status.Errorf(codes.InvalidArgument, "container %s is a core container; attribution is for user containers only", info.Ref.Name)
+	}
+
+	for k, v := range req.Labels {
+		if err := s.manager.AddLabel(username, k, v); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to set label %q: %v", k, err)
+		}
+	}
+
+	labels, err := s.manager.GetLabels(username)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to read labels back: %v", err)
+	}
+	log.Printf("[attribution] container=%s labels+=%d", info.Ref.Name, len(req.Labels))
+	return &pb.SetContainerAttributionResponse{Labels: labels}, nil
+}

--- a/internal/server/container_server_attribution_test.go
+++ b/internal/server/container_server_attribution_test.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	boxlxc "github.com/footprintai/containarium/pkg/core/box/lxc"
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// newAttributionTestServer wires a ContainerServer over a *MockBackend seeded
+// with the given containers. AddLabel merges into an in-memory label store
+// (prefix-stripped, like the real GetLabels) and GetLabels reads it back, so a
+// test can assert the merged result the handler returns.
+func newAttributionTestServer(t *testing.T, seed map[string]*incus.ContainerInfo) (*ContainerServer, map[string]map[string]string) {
+	t.Helper()
+	mock := incustest.NewMockBackend()
+	for name, info := range seed {
+		mock.Containers[name] = info
+	}
+	var mu sync.Mutex
+	// per-container label store (unprefixed keys, mirroring extractLabelsFromConfig).
+	labels := make(map[string]map[string]string)
+	mock.AddLabelFunc = func(name, key, value string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		if labels[name] == nil {
+			labels[name] = map[string]string{}
+		}
+		labels[name][key] = value
+		return nil
+	}
+	mock.GetLabelsFunc = func(name string) (map[string]string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		out := map[string]string{}
+		for k, v := range labels[name] {
+			out[k] = v
+		}
+		return out, nil
+	}
+	mgr := container.NewWithBackend(mock)
+	return &ContainerServer{manager: mgr, boxBackend: boxlxc.New(mgr)}, labels
+}
+
+// TestSetContainerAttribution_MergesLabels — the happy path: each provided
+// label is stamped and the response echoes the merged set.
+func TestSetContainerAttribution_MergesLabels(t *testing.T) {
+	s, store := newAttributionTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Running"},
+	})
+	// Pre-existing unrelated label must survive the merge.
+	store["alice-container"] = map[string]string{"os-type": "ubuntu"}
+
+	resp, err := s.SetContainerAttribution(testCtx(), &pb.SetContainerAttributionRequest{
+		Name: "alice",
+		Labels: map[string]string{
+			"cloud_org_id":       "org-A",
+			"cloud_container_id": "cc-1",
+			"managed_by":         "containarium-cloud",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	for k, want := range map[string]string{
+		"cloud_org_id": "org-A", "cloud_container_id": "cc-1",
+		"managed_by": "containarium-cloud", "os-type": "ubuntu",
+	} {
+		if resp.Labels[k] != want {
+			t.Errorf("label %q = %q, want %q (full: %+v)", k, resp.Labels[k], want, resp.Labels)
+		}
+	}
+}
+
+// TestSetContainerAttribution_EmptyLabelsRejected — an empty map is a no-op the
+// caller shouldn't make; reject it rather than silently succeed.
+func TestSetContainerAttribution_EmptyLabelsRejected(t *testing.T) {
+	s, _ := newAttributionTestServer(t, map[string]*incus.ContainerInfo{
+		"alice-container": {Name: "alice-container", State: "Running"},
+	})
+	_, err := s.SetContainerAttribution(testCtx(), &pb.SetContainerAttributionRequest{Name: "alice"})
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("error = %v, want InvalidArgument", err)
+	}
+}
+
+// TestSetContainerAttribution_MissingName — universal precondition check.
+func TestSetContainerAttribution_MissingName(t *testing.T) {
+	s := &ContainerServer{}
+	_, err := s.SetContainerAttribution(testCtx(), &pb.SetContainerAttributionRequest{
+		Labels: map[string]string{"cloud_org_id": "org-A"},
+	})
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("error = %v, want InvalidArgument", err)
+	}
+}
+
+// TestSetContainerAttribution_UnknownContainer — NotFound, not Internal.
+func TestSetContainerAttribution_UnknownContainer(t *testing.T) {
+	mock := incustest.NewMockBackend()
+	mock.GetContainerFunc = func(name string) (*incus.ContainerInfo, error) {
+		return nil, errors.New("container not found: " + name)
+	}
+	mgr := container.NewWithBackend(mock)
+	s := &ContainerServer{manager: mgr, boxBackend: boxlxc.New(mgr)}
+	_, err := s.SetContainerAttribution(testCtx(), &pb.SetContainerAttributionRequest{
+		Name:   "ghost",
+		Labels: map[string]string{"cloud_org_id": "org-A"},
+	})
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.NotFound {
+		t.Errorf("error = %v, want NotFound", err)
+	}
+}
+
+// TestSetContainerAttribution_CoreContainerRejected — attribution is for user
+// containers only (symmetry with the TTL / delete-policy core guards).
+func TestSetContainerAttribution_CoreContainerRejected(t *testing.T) {
+	s, _ := newAttributionTestServer(t, map[string]*incus.ContainerInfo{
+		"caddy-container": {Name: "caddy-container", State: "Running", Role: incus.RoleCaddy},
+	})
+	_, err := s.SetContainerAttribution(testCtx(), &pb.SetContainerAttributionRequest{
+		Name:   "caddy",
+		Labels: map[string]string{"cloud_org_id": "org-A"},
+	})
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("error = %v, want InvalidArgument", err)
+	}
+}

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -2456,6 +2456,112 @@ func (x *SetContainerDeletePolicyResponse) GetDeletePolicy() DeletePolicy {
 	return DeletePolicy_DELETE_POLICY_UNSPECIFIED
 }
 
+// SetContainerAttributionRequest merges labels onto an existing container
+// (cloud #746). Used by the hosted control plane's adopt flow (cloud #539) to
+// stamp attribution (cloud_org_id / cloud_container_id / managed_by) on a
+// pre-existing box after the fact.
+type SetContainerAttributionRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Container name — the bare username, matching the per-container RPC
+	// convention (the handler resolves <username>-container; see SetContainerTTL).
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Labels to merge onto the container. Each entry is set; labels not named
+	// here are left intact (merge, not replace). An empty map is rejected.
+	Labels        map[string]string `protobuf:"bytes,2,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetContainerAttributionRequest) Reset() {
+	*x = SetContainerAttributionRequest{}
+	mi := &file_containarium_v1_container_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetContainerAttributionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetContainerAttributionRequest) ProtoMessage() {}
+
+func (x *SetContainerAttributionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetContainerAttributionRequest.ProtoReflect.Descriptor instead.
+func (*SetContainerAttributionRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *SetContainerAttributionRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *SetContainerAttributionRequest) GetLabels() map[string]string {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
+}
+
+// SetContainerAttributionResponse reports the full label set now on the box.
+type SetContainerAttributionResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Every label currently on the container after the merge.
+	Labels        map[string]string `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetContainerAttributionResponse) Reset() {
+	*x = SetContainerAttributionResponse{}
+	mi := &file_containarium_v1_container_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetContainerAttributionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetContainerAttributionResponse) ProtoMessage() {}
+
+func (x *SetContainerAttributionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetContainerAttributionResponse.ProtoReflect.Descriptor instead.
+func (*SetContainerAttributionResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *SetContainerAttributionResponse) GetLabels() map[string]string {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
+}
+
 // AddSSHKeyRequest is the request to add an SSH key to a container
 type AddSSHKeyRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -2469,7 +2575,7 @@ type AddSSHKeyRequest struct {
 
 func (x *AddSSHKeyRequest) Reset() {
 	*x = AddSSHKeyRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[26]
+	mi := &file_containarium_v1_container_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2481,7 +2587,7 @@ func (x *AddSSHKeyRequest) String() string {
 func (*AddSSHKeyRequest) ProtoMessage() {}
 
 func (x *AddSSHKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[26]
+	mi := &file_containarium_v1_container_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2494,7 +2600,7 @@ func (x *AddSSHKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddSSHKeyRequest.ProtoReflect.Descriptor instead.
 func (*AddSSHKeyRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{26}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *AddSSHKeyRequest) GetUsername() string {
@@ -2524,7 +2630,7 @@ type AddSSHKeyResponse struct {
 
 func (x *AddSSHKeyResponse) Reset() {
 	*x = AddSSHKeyResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[27]
+	mi := &file_containarium_v1_container_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2536,7 +2642,7 @@ func (x *AddSSHKeyResponse) String() string {
 func (*AddSSHKeyResponse) ProtoMessage() {}
 
 func (x *AddSSHKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[27]
+	mi := &file_containarium_v1_container_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2549,7 +2655,7 @@ func (x *AddSSHKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddSSHKeyResponse.ProtoReflect.Descriptor instead.
 func (*AddSSHKeyResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{27}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *AddSSHKeyResponse) GetMessage() string {
@@ -2579,7 +2685,7 @@ type RemoveSSHKeyRequest struct {
 
 func (x *RemoveSSHKeyRequest) Reset() {
 	*x = RemoveSSHKeyRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[28]
+	mi := &file_containarium_v1_container_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2591,7 +2697,7 @@ func (x *RemoveSSHKeyRequest) String() string {
 func (*RemoveSSHKeyRequest) ProtoMessage() {}
 
 func (x *RemoveSSHKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[28]
+	mi := &file_containarium_v1_container_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2604,7 +2710,7 @@ func (x *RemoveSSHKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSSHKeyRequest.ProtoReflect.Descriptor instead.
 func (*RemoveSSHKeyRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{28}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *RemoveSSHKeyRequest) GetUsername() string {
@@ -2634,7 +2740,7 @@ type RemoveSSHKeyResponse struct {
 
 func (x *RemoveSSHKeyResponse) Reset() {
 	*x = RemoveSSHKeyResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[29]
+	mi := &file_containarium_v1_container_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2646,7 +2752,7 @@ func (x *RemoveSSHKeyResponse) String() string {
 func (*RemoveSSHKeyResponse) ProtoMessage() {}
 
 func (x *RemoveSSHKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[29]
+	mi := &file_containarium_v1_container_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2659,7 +2765,7 @@ func (x *RemoveSSHKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveSSHKeyResponse.ProtoReflect.Descriptor instead.
 func (*RemoveSSHKeyResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{29}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *RemoveSSHKeyResponse) GetMessage() string {
@@ -2687,7 +2793,7 @@ type GetMetricsRequest struct {
 
 func (x *GetMetricsRequest) Reset() {
 	*x = GetMetricsRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[30]
+	mi := &file_containarium_v1_container_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2699,7 +2805,7 @@ func (x *GetMetricsRequest) String() string {
 func (*GetMetricsRequest) ProtoMessage() {}
 
 func (x *GetMetricsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[30]
+	mi := &file_containarium_v1_container_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2712,7 +2818,7 @@ func (x *GetMetricsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMetricsRequest.ProtoReflect.Descriptor instead.
 func (*GetMetricsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{30}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *GetMetricsRequest) GetUsername() string {
@@ -2733,7 +2839,7 @@ type GetMetricsResponse struct {
 
 func (x *GetMetricsResponse) Reset() {
 	*x = GetMetricsResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[31]
+	mi := &file_containarium_v1_container_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2745,7 +2851,7 @@ func (x *GetMetricsResponse) String() string {
 func (*GetMetricsResponse) ProtoMessage() {}
 
 func (x *GetMetricsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[31]
+	mi := &file_containarium_v1_container_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2758,7 +2864,7 @@ func (x *GetMetricsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMetricsResponse.ProtoReflect.Descriptor instead.
 func (*GetMetricsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{31}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *GetMetricsResponse) GetMetrics() []*ContainerMetrics {
@@ -2786,7 +2892,7 @@ type ResizeContainerRequest struct {
 
 func (x *ResizeContainerRequest) Reset() {
 	*x = ResizeContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[32]
+	mi := &file_containarium_v1_container_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2798,7 +2904,7 @@ func (x *ResizeContainerRequest) String() string {
 func (*ResizeContainerRequest) ProtoMessage() {}
 
 func (x *ResizeContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[32]
+	mi := &file_containarium_v1_container_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2811,7 +2917,7 @@ func (x *ResizeContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResizeContainerRequest.ProtoReflect.Descriptor instead.
 func (*ResizeContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{32}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ResizeContainerRequest) GetUsername() string {
@@ -2855,7 +2961,7 @@ type ResizeContainerResponse struct {
 
 func (x *ResizeContainerResponse) Reset() {
 	*x = ResizeContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[33]
+	mi := &file_containarium_v1_container_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2867,7 +2973,7 @@ func (x *ResizeContainerResponse) String() string {
 func (*ResizeContainerResponse) ProtoMessage() {}
 
 func (x *ResizeContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[33]
+	mi := &file_containarium_v1_container_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2880,7 +2986,7 @@ func (x *ResizeContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResizeContainerResponse.ProtoReflect.Descriptor instead.
 func (*ResizeContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{33}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ResizeContainerResponse) GetMessage() string {
@@ -2926,7 +3032,7 @@ type Collaborator struct {
 
 func (x *Collaborator) Reset() {
 	*x = Collaborator{}
-	mi := &file_containarium_v1_container_proto_msgTypes[34]
+	mi := &file_containarium_v1_container_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2938,7 +3044,7 @@ func (x *Collaborator) String() string {
 func (*Collaborator) ProtoMessage() {}
 
 func (x *Collaborator) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[34]
+	mi := &file_containarium_v1_container_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2951,7 +3057,7 @@ func (x *Collaborator) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Collaborator.ProtoReflect.Descriptor instead.
 func (*Collaborator) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{34}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *Collaborator) GetId() string {
@@ -3049,7 +3155,7 @@ type AddCollaboratorRequest struct {
 
 func (x *AddCollaboratorRequest) Reset() {
 	*x = AddCollaboratorRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[35]
+	mi := &file_containarium_v1_container_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3061,7 +3167,7 @@ func (x *AddCollaboratorRequest) String() string {
 func (*AddCollaboratorRequest) ProtoMessage() {}
 
 func (x *AddCollaboratorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[35]
+	mi := &file_containarium_v1_container_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3074,7 +3180,7 @@ func (x *AddCollaboratorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddCollaboratorRequest.ProtoReflect.Descriptor instead.
 func (*AddCollaboratorRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{35}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *AddCollaboratorRequest) GetOwnerUsername() string {
@@ -3134,7 +3240,7 @@ type AddCollaboratorResponse struct {
 
 func (x *AddCollaboratorResponse) Reset() {
 	*x = AddCollaboratorResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[36]
+	mi := &file_containarium_v1_container_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3146,7 +3252,7 @@ func (x *AddCollaboratorResponse) String() string {
 func (*AddCollaboratorResponse) ProtoMessage() {}
 
 func (x *AddCollaboratorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[36]
+	mi := &file_containarium_v1_container_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3159,7 +3265,7 @@ func (x *AddCollaboratorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddCollaboratorResponse.ProtoReflect.Descriptor instead.
 func (*AddCollaboratorResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{36}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *AddCollaboratorResponse) GetMessage() string {
@@ -3196,7 +3302,7 @@ type RemoveCollaboratorRequest struct {
 
 func (x *RemoveCollaboratorRequest) Reset() {
 	*x = RemoveCollaboratorRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[37]
+	mi := &file_containarium_v1_container_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3208,7 +3314,7 @@ func (x *RemoveCollaboratorRequest) String() string {
 func (*RemoveCollaboratorRequest) ProtoMessage() {}
 
 func (x *RemoveCollaboratorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[37]
+	mi := &file_containarium_v1_container_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3221,7 +3327,7 @@ func (x *RemoveCollaboratorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCollaboratorRequest.ProtoReflect.Descriptor instead.
 func (*RemoveCollaboratorRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{37}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *RemoveCollaboratorRequest) GetOwnerUsername() string {
@@ -3249,7 +3355,7 @@ type RemoveCollaboratorResponse struct {
 
 func (x *RemoveCollaboratorResponse) Reset() {
 	*x = RemoveCollaboratorResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[38]
+	mi := &file_containarium_v1_container_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3261,7 +3367,7 @@ func (x *RemoveCollaboratorResponse) String() string {
 func (*RemoveCollaboratorResponse) ProtoMessage() {}
 
 func (x *RemoveCollaboratorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[38]
+	mi := &file_containarium_v1_container_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3274,7 +3380,7 @@ func (x *RemoveCollaboratorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveCollaboratorResponse.ProtoReflect.Descriptor instead.
 func (*RemoveCollaboratorResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{38}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *RemoveCollaboratorResponse) GetMessage() string {
@@ -3295,7 +3401,7 @@ type ListCollaboratorsRequest struct {
 
 func (x *ListCollaboratorsRequest) Reset() {
 	*x = ListCollaboratorsRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[39]
+	mi := &file_containarium_v1_container_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3307,7 +3413,7 @@ func (x *ListCollaboratorsRequest) String() string {
 func (*ListCollaboratorsRequest) ProtoMessage() {}
 
 func (x *ListCollaboratorsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[39]
+	mi := &file_containarium_v1_container_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3320,7 +3426,7 @@ func (x *ListCollaboratorsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCollaboratorsRequest.ProtoReflect.Descriptor instead.
 func (*ListCollaboratorsRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{39}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ListCollaboratorsRequest) GetOwnerUsername() string {
@@ -3343,7 +3449,7 @@ type ListCollaboratorsResponse struct {
 
 func (x *ListCollaboratorsResponse) Reset() {
 	*x = ListCollaboratorsResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[40]
+	mi := &file_containarium_v1_container_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3355,7 +3461,7 @@ func (x *ListCollaboratorsResponse) String() string {
 func (*ListCollaboratorsResponse) ProtoMessage() {}
 
 func (x *ListCollaboratorsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[40]
+	mi := &file_containarium_v1_container_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3368,7 +3474,7 @@ func (x *ListCollaboratorsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListCollaboratorsResponse.ProtoReflect.Descriptor instead.
 func (*ListCollaboratorsResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{40}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ListCollaboratorsResponse) GetCollaborators() []*Collaborator {
@@ -3396,7 +3502,7 @@ type CleanupDiskRequest struct {
 
 func (x *CleanupDiskRequest) Reset() {
 	*x = CleanupDiskRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[41]
+	mi := &file_containarium_v1_container_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3408,7 +3514,7 @@ func (x *CleanupDiskRequest) String() string {
 func (*CleanupDiskRequest) ProtoMessage() {}
 
 func (x *CleanupDiskRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[41]
+	mi := &file_containarium_v1_container_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3421,7 +3527,7 @@ func (x *CleanupDiskRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CleanupDiskRequest.ProtoReflect.Descriptor instead.
 func (*CleanupDiskRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{41}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *CleanupDiskRequest) GetUsername() string {
@@ -3446,7 +3552,7 @@ type CleanupDiskResponse struct {
 
 func (x *CleanupDiskResponse) Reset() {
 	*x = CleanupDiskResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[42]
+	mi := &file_containarium_v1_container_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3458,7 +3564,7 @@ func (x *CleanupDiskResponse) String() string {
 func (*CleanupDiskResponse) ProtoMessage() {}
 
 func (x *CleanupDiskResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[42]
+	mi := &file_containarium_v1_container_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3471,7 +3577,7 @@ func (x *CleanupDiskResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CleanupDiskResponse.ProtoReflect.Descriptor instead.
 func (*CleanupDiskResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{42}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *CleanupDiskResponse) GetMessage() string {
@@ -3508,7 +3614,7 @@ type InstallStackRequest struct {
 
 func (x *InstallStackRequest) Reset() {
 	*x = InstallStackRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[43]
+	mi := &file_containarium_v1_container_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3520,7 +3626,7 @@ func (x *InstallStackRequest) String() string {
 func (*InstallStackRequest) ProtoMessage() {}
 
 func (x *InstallStackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[43]
+	mi := &file_containarium_v1_container_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3533,7 +3639,7 @@ func (x *InstallStackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InstallStackRequest.ProtoReflect.Descriptor instead.
 func (*InstallStackRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{43}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *InstallStackRequest) GetUsername() string {
@@ -3563,7 +3669,7 @@ type InstallStackResponse struct {
 
 func (x *InstallStackResponse) Reset() {
 	*x = InstallStackResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[44]
+	mi := &file_containarium_v1_container_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3575,7 +3681,7 @@ func (x *InstallStackResponse) String() string {
 func (*InstallStackResponse) ProtoMessage() {}
 
 func (x *InstallStackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[44]
+	mi := &file_containarium_v1_container_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3588,7 +3694,7 @@ func (x *InstallStackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InstallStackResponse.ProtoReflect.Descriptor instead.
 func (*InstallStackResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{44}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *InstallStackResponse) GetMessage() string {
@@ -3628,7 +3734,7 @@ type StackParameter struct {
 
 func (x *StackParameter) Reset() {
 	*x = StackParameter{}
-	mi := &file_containarium_v1_container_proto_msgTypes[45]
+	mi := &file_containarium_v1_container_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3640,7 +3746,7 @@ func (x *StackParameter) String() string {
 func (*StackParameter) ProtoMessage() {}
 
 func (x *StackParameter) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[45]
+	mi := &file_containarium_v1_container_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3653,7 +3759,7 @@ func (x *StackParameter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StackParameter.ProtoReflect.Descriptor instead.
 func (*StackParameter) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{45}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *StackParameter) GetName() string {
@@ -3712,7 +3818,7 @@ type StackInfo struct {
 
 func (x *StackInfo) Reset() {
 	*x = StackInfo{}
-	mi := &file_containarium_v1_container_proto_msgTypes[46]
+	mi := &file_containarium_v1_container_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3724,7 +3830,7 @@ func (x *StackInfo) String() string {
 func (*StackInfo) ProtoMessage() {}
 
 func (x *StackInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[46]
+	mi := &file_containarium_v1_container_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3737,7 +3843,7 @@ func (x *StackInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StackInfo.ProtoReflect.Descriptor instead.
 func (*StackInfo) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{46}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *StackInfo) GetId() string {
@@ -3784,7 +3890,7 @@ type ListStacksRequest struct {
 
 func (x *ListStacksRequest) Reset() {
 	*x = ListStacksRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[47]
+	mi := &file_containarium_v1_container_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3796,7 +3902,7 @@ func (x *ListStacksRequest) String() string {
 func (*ListStacksRequest) ProtoMessage() {}
 
 func (x *ListStacksRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[47]
+	mi := &file_containarium_v1_container_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3809,7 +3915,7 @@ func (x *ListStacksRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStacksRequest.ProtoReflect.Descriptor instead.
 func (*ListStacksRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{47}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{49}
 }
 
 // ListStacksResponse returns all configured software stacks.
@@ -3822,7 +3928,7 @@ type ListStacksResponse struct {
 
 func (x *ListStacksResponse) Reset() {
 	*x = ListStacksResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[48]
+	mi := &file_containarium_v1_container_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3834,7 +3940,7 @@ func (x *ListStacksResponse) String() string {
 func (*ListStacksResponse) ProtoMessage() {}
 
 func (x *ListStacksResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[48]
+	mi := &file_containarium_v1_container_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3847,7 +3953,7 @@ func (x *ListStacksResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStacksResponse.ProtoReflect.Descriptor instead.
 func (*ListStacksResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{48}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *ListStacksResponse) GetStacks() []*StackInfo {
@@ -3866,7 +3972,7 @@ type GetMonitoringInfoRequest struct {
 
 func (x *GetMonitoringInfoRequest) Reset() {
 	*x = GetMonitoringInfoRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[49]
+	mi := &file_containarium_v1_container_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3878,7 +3984,7 @@ func (x *GetMonitoringInfoRequest) String() string {
 func (*GetMonitoringInfoRequest) ProtoMessage() {}
 
 func (x *GetMonitoringInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[49]
+	mi := &file_containarium_v1_container_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3891,7 +3997,7 @@ func (x *GetMonitoringInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMonitoringInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetMonitoringInfoRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{49}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{51}
 }
 
 // GetMonitoringInfoResponse is the response with monitoring configuration
@@ -3909,7 +4015,7 @@ type GetMonitoringInfoResponse struct {
 
 func (x *GetMonitoringInfoResponse) Reset() {
 	*x = GetMonitoringInfoResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[50]
+	mi := &file_containarium_v1_container_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3921,7 +4027,7 @@ func (x *GetMonitoringInfoResponse) String() string {
 func (*GetMonitoringInfoResponse) ProtoMessage() {}
 
 func (x *GetMonitoringInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[50]
+	mi := &file_containarium_v1_container_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3934,7 +4040,7 @@ func (x *GetMonitoringInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMonitoringInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetMonitoringInfoResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{50}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *GetMonitoringInfoResponse) GetEnabled() bool {
@@ -3993,7 +4099,7 @@ type MoveContainerRequest struct {
 
 func (x *MoveContainerRequest) Reset() {
 	*x = MoveContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[51]
+	mi := &file_containarium_v1_container_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4005,7 +4111,7 @@ func (x *MoveContainerRequest) String() string {
 func (*MoveContainerRequest) ProtoMessage() {}
 
 func (x *MoveContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[51]
+	mi := &file_containarium_v1_container_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4018,7 +4124,7 @@ func (x *MoveContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MoveContainerRequest.ProtoReflect.Descriptor instead.
 func (*MoveContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{51}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *MoveContainerRequest) GetUsername() string {
@@ -4081,7 +4187,7 @@ type MoveContainerResponse struct {
 
 func (x *MoveContainerResponse) Reset() {
 	*x = MoveContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[52]
+	mi := &file_containarium_v1_container_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4093,7 +4199,7 @@ func (x *MoveContainerResponse) String() string {
 func (*MoveContainerResponse) ProtoMessage() {}
 
 func (x *MoveContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[52]
+	mi := &file_containarium_v1_container_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4106,7 +4212,7 @@ func (x *MoveContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MoveContainerResponse.ProtoReflect.Descriptor instead.
 func (*MoveContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{52}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *MoveContainerResponse) GetMessage() string {
@@ -4167,7 +4273,7 @@ type AdoptMigratedContainerRequest struct {
 
 func (x *AdoptMigratedContainerRequest) Reset() {
 	*x = AdoptMigratedContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[53]
+	mi := &file_containarium_v1_container_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4179,7 +4285,7 @@ func (x *AdoptMigratedContainerRequest) String() string {
 func (*AdoptMigratedContainerRequest) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[53]
+	mi := &file_containarium_v1_container_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4192,7 +4298,7 @@ func (x *AdoptMigratedContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerRequest.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{53}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *AdoptMigratedContainerRequest) GetUsername() string {
@@ -4224,7 +4330,7 @@ type AdoptMigratedContainerResponse struct {
 
 func (x *AdoptMigratedContainerResponse) Reset() {
 	*x = AdoptMigratedContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[54]
+	mi := &file_containarium_v1_container_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4236,7 +4342,7 @@ func (x *AdoptMigratedContainerResponse) String() string {
 func (*AdoptMigratedContainerResponse) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[54]
+	mi := &file_containarium_v1_container_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4249,7 +4355,7 @@ func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerResponse.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{54}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *AdoptMigratedContainerResponse) GetMessage() string {
@@ -4468,7 +4574,18 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12B\n" +
 	"\rdelete_policy\x18\x02 \x01(\x0e2\x1d.containarium.v1.DeletePolicyR\fdeletePolicy\"f\n" +
 	" SetContainerDeletePolicyResponse\x12B\n" +
-	"\rdelete_policy\x18\x01 \x01(\x0e2\x1d.containarium.v1.DeletePolicyR\fdeletePolicy\"T\n" +
+	"\rdelete_policy\x18\x01 \x01(\x0e2\x1d.containarium.v1.DeletePolicyR\fdeletePolicy\"\xc4\x01\n" +
+	"\x1eSetContainerAttributionRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12S\n" +
+	"\x06labels\x18\x02 \x03(\v2;.containarium.v1.SetContainerAttributionRequest.LabelsEntryR\x06labels\x1a9\n" +
+	"\vLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb2\x01\n" +
+	"\x1fSetContainerAttributionResponse\x12T\n" +
+	"\x06labels\x18\x01 \x03(\v2<.containarium.v1.SetContainerAttributionResponse.LabelsEntryR\x06labels\x1a9\n" +
+	"\vLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"T\n" +
 	"\x10AddSSHKeyRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12$\n" +
 	"\x0essh_public_key\x18\x02 \x01(\tR\fsshPublicKey\"L\n" +
@@ -4625,7 +4742,7 @@ func file_containarium_v1_container_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 59)
+var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 63)
 var file_containarium_v1_container_proto_goTypes = []any{
 	(OSType)(0),                              // 0: containarium.v1.OSType
 	(AccessType)(0),                          // 1: containarium.v1.AccessType
@@ -4657,81 +4774,87 @@ var file_containarium_v1_container_proto_goTypes = []any{
 	(*SetContainerTTLResponse)(nil),          // 27: containarium.v1.SetContainerTTLResponse
 	(*SetContainerDeletePolicyRequest)(nil),  // 28: containarium.v1.SetContainerDeletePolicyRequest
 	(*SetContainerDeletePolicyResponse)(nil), // 29: containarium.v1.SetContainerDeletePolicyResponse
-	(*AddSSHKeyRequest)(nil),                 // 30: containarium.v1.AddSSHKeyRequest
-	(*AddSSHKeyResponse)(nil),                // 31: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyRequest)(nil),              // 32: containarium.v1.RemoveSSHKeyRequest
-	(*RemoveSSHKeyResponse)(nil),             // 33: containarium.v1.RemoveSSHKeyResponse
-	(*GetMetricsRequest)(nil),                // 34: containarium.v1.GetMetricsRequest
-	(*GetMetricsResponse)(nil),               // 35: containarium.v1.GetMetricsResponse
-	(*ResizeContainerRequest)(nil),           // 36: containarium.v1.ResizeContainerRequest
-	(*ResizeContainerResponse)(nil),          // 37: containarium.v1.ResizeContainerResponse
-	(*Collaborator)(nil),                     // 38: containarium.v1.Collaborator
-	(*AddCollaboratorRequest)(nil),           // 39: containarium.v1.AddCollaboratorRequest
-	(*AddCollaboratorResponse)(nil),          // 40: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorRequest)(nil),        // 41: containarium.v1.RemoveCollaboratorRequest
-	(*RemoveCollaboratorResponse)(nil),       // 42: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsRequest)(nil),         // 43: containarium.v1.ListCollaboratorsRequest
-	(*ListCollaboratorsResponse)(nil),        // 44: containarium.v1.ListCollaboratorsResponse
-	(*CleanupDiskRequest)(nil),               // 45: containarium.v1.CleanupDiskRequest
-	(*CleanupDiskResponse)(nil),              // 46: containarium.v1.CleanupDiskResponse
-	(*InstallStackRequest)(nil),              // 47: containarium.v1.InstallStackRequest
-	(*InstallStackResponse)(nil),             // 48: containarium.v1.InstallStackResponse
-	(*StackParameter)(nil),                   // 49: containarium.v1.StackParameter
-	(*StackInfo)(nil),                        // 50: containarium.v1.StackInfo
-	(*ListStacksRequest)(nil),                // 51: containarium.v1.ListStacksRequest
-	(*ListStacksResponse)(nil),               // 52: containarium.v1.ListStacksResponse
-	(*GetMonitoringInfoRequest)(nil),         // 53: containarium.v1.GetMonitoringInfoRequest
-	(*GetMonitoringInfoResponse)(nil),        // 54: containarium.v1.GetMonitoringInfoResponse
-	(*MoveContainerRequest)(nil),             // 55: containarium.v1.MoveContainerRequest
-	(*MoveContainerResponse)(nil),            // 56: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerRequest)(nil),    // 57: containarium.v1.AdoptMigratedContainerRequest
-	(*AdoptMigratedContainerResponse)(nil),   // 58: containarium.v1.AdoptMigratedContainerResponse
-	nil,                                      // 59: containarium.v1.Container.LabelsEntry
-	nil,                                      // 60: containarium.v1.CreateContainerRequest.LabelsEntry
-	nil,                                      // 61: containarium.v1.CreateContainerRequest.StackParametersEntry
-	nil,                                      // 62: containarium.v1.ListContainersRequest.LabelFilterEntry
-	(*timestamppb.Timestamp)(nil),            // 63: google.protobuf.Timestamp
-	(*descriptorpb.EnumValueOptions)(nil),    // 64: google.protobuf.EnumValueOptions
+	(*SetContainerAttributionRequest)(nil),   // 30: containarium.v1.SetContainerAttributionRequest
+	(*SetContainerAttributionResponse)(nil),  // 31: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyRequest)(nil),                 // 32: containarium.v1.AddSSHKeyRequest
+	(*AddSSHKeyResponse)(nil),                // 33: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyRequest)(nil),              // 34: containarium.v1.RemoveSSHKeyRequest
+	(*RemoveSSHKeyResponse)(nil),             // 35: containarium.v1.RemoveSSHKeyResponse
+	(*GetMetricsRequest)(nil),                // 36: containarium.v1.GetMetricsRequest
+	(*GetMetricsResponse)(nil),               // 37: containarium.v1.GetMetricsResponse
+	(*ResizeContainerRequest)(nil),           // 38: containarium.v1.ResizeContainerRequest
+	(*ResizeContainerResponse)(nil),          // 39: containarium.v1.ResizeContainerResponse
+	(*Collaborator)(nil),                     // 40: containarium.v1.Collaborator
+	(*AddCollaboratorRequest)(nil),           // 41: containarium.v1.AddCollaboratorRequest
+	(*AddCollaboratorResponse)(nil),          // 42: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorRequest)(nil),        // 43: containarium.v1.RemoveCollaboratorRequest
+	(*RemoveCollaboratorResponse)(nil),       // 44: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsRequest)(nil),         // 45: containarium.v1.ListCollaboratorsRequest
+	(*ListCollaboratorsResponse)(nil),        // 46: containarium.v1.ListCollaboratorsResponse
+	(*CleanupDiskRequest)(nil),               // 47: containarium.v1.CleanupDiskRequest
+	(*CleanupDiskResponse)(nil),              // 48: containarium.v1.CleanupDiskResponse
+	(*InstallStackRequest)(nil),              // 49: containarium.v1.InstallStackRequest
+	(*InstallStackResponse)(nil),             // 50: containarium.v1.InstallStackResponse
+	(*StackParameter)(nil),                   // 51: containarium.v1.StackParameter
+	(*StackInfo)(nil),                        // 52: containarium.v1.StackInfo
+	(*ListStacksRequest)(nil),                // 53: containarium.v1.ListStacksRequest
+	(*ListStacksResponse)(nil),               // 54: containarium.v1.ListStacksResponse
+	(*GetMonitoringInfoRequest)(nil),         // 55: containarium.v1.GetMonitoringInfoRequest
+	(*GetMonitoringInfoResponse)(nil),        // 56: containarium.v1.GetMonitoringInfoResponse
+	(*MoveContainerRequest)(nil),             // 57: containarium.v1.MoveContainerRequest
+	(*MoveContainerResponse)(nil),            // 58: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerRequest)(nil),    // 59: containarium.v1.AdoptMigratedContainerRequest
+	(*AdoptMigratedContainerResponse)(nil),   // 60: containarium.v1.AdoptMigratedContainerResponse
+	nil,                                      // 61: containarium.v1.Container.LabelsEntry
+	nil,                                      // 62: containarium.v1.CreateContainerRequest.LabelsEntry
+	nil,                                      // 63: containarium.v1.CreateContainerRequest.StackParametersEntry
+	nil,                                      // 64: containarium.v1.ListContainersRequest.LabelFilterEntry
+	nil,                                      // 65: containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	nil,                                      // 66: containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	(*timestamppb.Timestamp)(nil),            // 67: google.protobuf.Timestamp
+	(*descriptorpb.EnumValueOptions)(nil),    // 68: google.protobuf.EnumValueOptions
 }
 var file_containarium_v1_container_proto_depIdxs = []int32{
 	2,  // 0: containarium.v1.Container.state:type_name -> containarium.v1.ContainerState
 	4,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
 	5,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
-	59, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
+	61, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
 	0,  // 4: containarium.v1.Container.os_type:type_name -> containarium.v1.OSType
 	1,  // 5: containarium.v1.Container.access_type:type_name -> containarium.v1.AccessType
-	63, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
-	63, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
+	67, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	67, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
 	3,  // 8: containarium.v1.Container.delete_policy:type_name -> containarium.v1.DeletePolicy
 	4,  // 9: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
-	60, // 10: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
+	62, // 10: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
 	0,  // 11: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
-	61, // 12: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
+	63, // 12: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
 	6,  // 13: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
 	2,  // 14: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
-	62, // 15: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
+	64, // 15: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
 	6,  // 16: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
 	6,  // 17: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
 	7,  // 18: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	6,  // 19: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
 	6,  // 20: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
-	63, // 21: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	67, // 21: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
 	3,  // 22: containarium.v1.SetContainerDeletePolicyRequest.delete_policy:type_name -> containarium.v1.DeletePolicy
 	3,  // 23: containarium.v1.SetContainerDeletePolicyResponse.delete_policy:type_name -> containarium.v1.DeletePolicy
-	7,  // 24: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
-	6,  // 25: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
-	38, // 26: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
-	38, // 27: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
-	6,  // 28: containarium.v1.CleanupDiskResponse.container:type_name -> containarium.v1.Container
-	6,  // 29: containarium.v1.InstallStackResponse.container:type_name -> containarium.v1.Container
-	49, // 30: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
-	50, // 31: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
-	64, // 32: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
-	33, // [33:33] is the sub-list for method output_type
-	33, // [33:33] is the sub-list for method input_type
-	33, // [33:33] is the sub-list for extension type_name
-	32, // [32:33] is the sub-list for extension extendee
-	0,  // [0:32] is the sub-list for field type_name
+	65, // 24: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	66, // 25: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	7,  // 26: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
+	6,  // 27: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
+	40, // 28: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
+	40, // 29: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
+	6,  // 30: containarium.v1.CleanupDiskResponse.container:type_name -> containarium.v1.Container
+	6,  // 31: containarium.v1.InstallStackResponse.container:type_name -> containarium.v1.Container
+	51, // 32: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
+	52, // 33: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
+	68, // 34: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
+	35, // [35:35] is the sub-list for method output_type
+	35, // [35:35] is the sub-list for method input_type
+	35, // [35:35] is the sub-list for extension type_name
+	34, // [34:35] is the sub-list for extension extendee
+	0,  // [0:34] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_container_proto_init() }
@@ -4745,7 +4868,7 @@ func file_containarium_v1_container_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_container_proto_rawDesc), len(file_containarium_v1_container_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   59,
+			NumMessages:   63,
 			NumExtensions: 1,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\x8b\x86\x01\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2ˊ\x01\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -60,7 +60,9 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x0fSetContainerTTL\x12'.containarium.v1.SetContainerTTLRequest\x1a(.containarium.v1.SetContainerTTLResponse\"\x85\x03\x92A\xdd\x02\n" +
 	"\x14Container Operations\x12/Schedule or clear a container's auto-delete TTL\x1a\x93\x02Stamps the container with a wall-clock auto-delete time consumed by the daemon's TTL sweeper. duration_seconds=0 clears any existing TTL; > 0 sets it to now()+duration. Capped at 604800 (7 days). Used by the containarium-run GitHub Action to auto-clean failed-CI debug boxes.\x82\xd3\xe4\x93\x02\x1e:\x01*\"\x19/v1/containers/{name}/ttl\x12\xae\x04\n" +
 	"\x18SetContainerDeletePolicy\x120.containarium.v1.SetContainerDeletePolicyRequest\x1a1.containarium.v1.SetContainerDeletePolicyResponse\"\xac\x03\x92A\xfa\x02\n" +
-	"\x14Container Operations\x128Protect or unprotect a container from automated deletion\x1a\xa7\x02Sets the container's delete policy (#284). DELETE_POLICY_PROTECTED makes the ttlsweeper auto-reap and `containarium prune` skip the box (e.g. a persistent runner); DELETE_POLICY_UNSPECIFIED returns it to the default (eligible for both). A deliberate single-box delete always succeeds regardless.\x82\xd3\xe4\x93\x02(:\x01*\"#/v1/containers/{name}/delete-policy\x12\x9a\x02\n" +
+	"\x14Container Operations\x128Protect or unprotect a container from automated deletion\x1a\xa7\x02Sets the container's delete policy (#284). DELETE_POLICY_PROTECTED makes the ttlsweeper auto-reap and `containarium prune` skip the box (e.g. a persistent runner); DELETE_POLICY_UNSPECIFIED returns it to the default (eligible for both). A deliberate single-box delete always succeeds regardless.\x82\xd3\xe4\x93\x02(:\x01*\"#/v1/containers/{name}/delete-policy\x12\xbd\x04\n" +
+	"\x17SetContainerAttribution\x12/.containarium.v1.SetContainerAttributionRequest\x1a0.containarium.v1.SetContainerAttributionResponse\"\xbe\x03\x92A\x8e\x03\n" +
+	"\x14Container Operations\x123Merge attribution labels onto an existing container\x1a\xc0\x02Sets the given labels on a live container's config, leaving other labels intact (cloud #746). Lets the hosted control plane stamp cloud attribution (cloud_org_id / cloud_container_id / managed_by) on a pre-existing box so its adopt flow can bring it under management (cloud #539). 404 when the container doesn't resolve.\x82\xd3\xe4\x93\x02&:\x01*\"!/v1/containers/{name}/attribution\x12\x9a\x02\n" +
 	"\tAddSSHKey\x12!.containarium.v1.AddSSHKeyRequest\x1a\".containarium.v1.AddSSHKeyResponse\"\xc5\x01\x92A\x94\x01\n" +
 	"\x0eSSH Management\x12\vAdd SSH key\x1auAdds an SSH public key to a container's authorized_keys file, allowing SSH access with the corresponding private key.\x82\xd3\xe4\x93\x02':\x01*\"\"/v1/containers/{username}/ssh-keys\x12\xce\x02\n" +
 	"\fRemoveSSHKey\x12$.containarium.v1.RemoveSSHKeyRequest\x1a%.containarium.v1.RemoveSSHKeyResponse\"\xf0\x01\x92A\xb1\x01\n" +
@@ -167,94 +169,96 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*ToggleAutoSleepRequest)(nil),           // 11: containarium.v1.ToggleAutoSleepRequest
 	(*SetContainerTTLRequest)(nil),           // 12: containarium.v1.SetContainerTTLRequest
 	(*SetContainerDeletePolicyRequest)(nil),  // 13: containarium.v1.SetContainerDeletePolicyRequest
-	(*AddSSHKeyRequest)(nil),                 // 14: containarium.v1.AddSSHKeyRequest
-	(*RemoveSSHKeyRequest)(nil),              // 15: containarium.v1.RemoveSSHKeyRequest
-	(*AddCollaboratorRequest)(nil),           // 16: containarium.v1.AddCollaboratorRequest
-	(*RemoveCollaboratorRequest)(nil),        // 17: containarium.v1.RemoveCollaboratorRequest
-	(*ListCollaboratorsRequest)(nil),         // 18: containarium.v1.ListCollaboratorsRequest
-	(*GetMetricsRequest)(nil),                // 19: containarium.v1.GetMetricsRequest
-	(*CleanupDiskRequest)(nil),               // 20: containarium.v1.CleanupDiskRequest
-	(*InstallStackRequest)(nil),              // 21: containarium.v1.InstallStackRequest
-	(*ListStacksRequest)(nil),                // 22: containarium.v1.ListStacksRequest
-	(*GetSystemInfoRequest)(nil),             // 23: containarium.v1.GetSystemInfoRequest
-	(*ListBackendsRequest)(nil),              // 24: containarium.v1.ListBackendsRequest
-	(*AdvertiseCapacityRequest)(nil),         // 25: containarium.v1.AdvertiseCapacityRequest
-	(*WithdrawCapacityRequest)(nil),          // 26: containarium.v1.WithdrawCapacityRequest
-	(*GetCapacityHeadroomRequest)(nil),       // 27: containarium.v1.GetCapacityHeadroomRequest
-	(*ProfileBackendRequest)(nil),            // 28: containarium.v1.ProfileBackendRequest
-	(*GetCapabilityProfileRequest)(nil),      // 29: containarium.v1.GetCapabilityProfileRequest
-	(*GetSelfMeasurementRequest)(nil),        // 30: containarium.v1.GetSelfMeasurementRequest
-	(*GetLatestReleaseRequest)(nil),          // 31: containarium.v1.GetLatestReleaseRequest
-	(*ValidateGPURequest)(nil),               // 32: containarium.v1.ValidateGPURequest
-	(*TriggerUpgradeRequest)(nil),            // 33: containarium.v1.TriggerUpgradeRequest
-	(*GetUpgradeStatusRequest)(nil),          // 34: containarium.v1.GetUpgradeStatusRequest
-	(*GetMonitoringInfoRequest)(nil),         // 35: containarium.v1.GetMonitoringInfoRequest
-	(*CreateAlertRuleRequest)(nil),           // 36: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),            // 37: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),              // 38: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),           // 39: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),           // 40: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),           // 41: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),     // 42: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),      // 43: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),               // 44: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),     // 45: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),                 // 46: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),                 // 47: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),               // 48: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),              // 49: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),            // 50: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),          // 51: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),           // 52: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),             // 53: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),           // 54: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),          // 55: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),           // 56: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),            // 57: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),          // 58: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),            // 59: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerResponse)(nil),   // 60: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),         // 61: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),          // 62: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),          // 63: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyResponse)(nil), // 64: containarium.v1.SetContainerDeletePolicyResponse
-	(*AddSSHKeyResponse)(nil),                // 65: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),             // 66: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),          // 67: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),       // 68: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),        // 69: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),               // 70: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),              // 71: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),             // 72: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),               // 73: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),            // 74: containarium.v1.GetSystemInfoResponse
-	(*ListBackendsResponse)(nil),             // 75: containarium.v1.ListBackendsResponse
-	(*AdvertiseCapacityResponse)(nil),        // 76: containarium.v1.AdvertiseCapacityResponse
-	(*WithdrawCapacityResponse)(nil),         // 77: containarium.v1.WithdrawCapacityResponse
-	(*GetCapacityHeadroomResponse)(nil),      // 78: containarium.v1.GetCapacityHeadroomResponse
-	(*ProfileBackendResponse)(nil),           // 79: containarium.v1.ProfileBackendResponse
-	(*GetCapabilityProfileResponse)(nil),     // 80: containarium.v1.GetCapabilityProfileResponse
-	(*GetSelfMeasurementResponse)(nil),       // 81: containarium.v1.GetSelfMeasurementResponse
-	(*GetLatestReleaseResponse)(nil),         // 82: containarium.v1.GetLatestReleaseResponse
-	(*ValidateGPUResponse)(nil),              // 83: containarium.v1.ValidateGPUResponse
-	(*TriggerUpgradeResponse)(nil),           // 84: containarium.v1.TriggerUpgradeResponse
-	(*GetUpgradeStatusResponse)(nil),         // 85: containarium.v1.GetUpgradeStatusResponse
-	(*GetMonitoringInfoResponse)(nil),        // 86: containarium.v1.GetMonitoringInfoResponse
-	(*CreateAlertRuleResponse)(nil),          // 87: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),           // 88: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),             // 89: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),          // 90: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),          // 91: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),          // 92: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),    // 93: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),     // 94: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),              // 95: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),    // 96: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),                // 97: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),                // 98: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),              // 99: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),             // 100: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),           // 101: containarium.v1.RefreshSecretsResponse
+	(*SetContainerAttributionRequest)(nil),   // 14: containarium.v1.SetContainerAttributionRequest
+	(*AddSSHKeyRequest)(nil),                 // 15: containarium.v1.AddSSHKeyRequest
+	(*RemoveSSHKeyRequest)(nil),              // 16: containarium.v1.RemoveSSHKeyRequest
+	(*AddCollaboratorRequest)(nil),           // 17: containarium.v1.AddCollaboratorRequest
+	(*RemoveCollaboratorRequest)(nil),        // 18: containarium.v1.RemoveCollaboratorRequest
+	(*ListCollaboratorsRequest)(nil),         // 19: containarium.v1.ListCollaboratorsRequest
+	(*GetMetricsRequest)(nil),                // 20: containarium.v1.GetMetricsRequest
+	(*CleanupDiskRequest)(nil),               // 21: containarium.v1.CleanupDiskRequest
+	(*InstallStackRequest)(nil),              // 22: containarium.v1.InstallStackRequest
+	(*ListStacksRequest)(nil),                // 23: containarium.v1.ListStacksRequest
+	(*GetSystemInfoRequest)(nil),             // 24: containarium.v1.GetSystemInfoRequest
+	(*ListBackendsRequest)(nil),              // 25: containarium.v1.ListBackendsRequest
+	(*AdvertiseCapacityRequest)(nil),         // 26: containarium.v1.AdvertiseCapacityRequest
+	(*WithdrawCapacityRequest)(nil),          // 27: containarium.v1.WithdrawCapacityRequest
+	(*GetCapacityHeadroomRequest)(nil),       // 28: containarium.v1.GetCapacityHeadroomRequest
+	(*ProfileBackendRequest)(nil),            // 29: containarium.v1.ProfileBackendRequest
+	(*GetCapabilityProfileRequest)(nil),      // 30: containarium.v1.GetCapabilityProfileRequest
+	(*GetSelfMeasurementRequest)(nil),        // 31: containarium.v1.GetSelfMeasurementRequest
+	(*GetLatestReleaseRequest)(nil),          // 32: containarium.v1.GetLatestReleaseRequest
+	(*ValidateGPURequest)(nil),               // 33: containarium.v1.ValidateGPURequest
+	(*TriggerUpgradeRequest)(nil),            // 34: containarium.v1.TriggerUpgradeRequest
+	(*GetUpgradeStatusRequest)(nil),          // 35: containarium.v1.GetUpgradeStatusRequest
+	(*GetMonitoringInfoRequest)(nil),         // 36: containarium.v1.GetMonitoringInfoRequest
+	(*CreateAlertRuleRequest)(nil),           // 37: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),            // 38: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),              // 39: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),           // 40: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),           // 41: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),           // 42: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),     // 43: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),      // 44: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),               // 45: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),     // 46: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),                 // 47: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),                 // 48: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),               // 49: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),              // 50: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),            // 51: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),          // 52: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),           // 53: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),             // 54: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),           // 55: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),          // 56: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),           // 57: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),            // 58: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),          // 59: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),            // 60: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerResponse)(nil),   // 61: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),         // 62: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),          // 63: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),          // 64: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyResponse)(nil), // 65: containarium.v1.SetContainerDeletePolicyResponse
+	(*SetContainerAttributionResponse)(nil),  // 66: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyResponse)(nil),                // 67: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),             // 68: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),          // 69: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),       // 70: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),        // 71: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),               // 72: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),              // 73: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),             // 74: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),               // 75: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),            // 76: containarium.v1.GetSystemInfoResponse
+	(*ListBackendsResponse)(nil),             // 77: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityResponse)(nil),        // 78: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityResponse)(nil),         // 79: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomResponse)(nil),      // 80: containarium.v1.GetCapacityHeadroomResponse
+	(*ProfileBackendResponse)(nil),           // 81: containarium.v1.ProfileBackendResponse
+	(*GetCapabilityProfileResponse)(nil),     // 82: containarium.v1.GetCapabilityProfileResponse
+	(*GetSelfMeasurementResponse)(nil),       // 83: containarium.v1.GetSelfMeasurementResponse
+	(*GetLatestReleaseResponse)(nil),         // 84: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),              // 85: containarium.v1.ValidateGPUResponse
+	(*TriggerUpgradeResponse)(nil),           // 86: containarium.v1.TriggerUpgradeResponse
+	(*GetUpgradeStatusResponse)(nil),         // 87: containarium.v1.GetUpgradeStatusResponse
+	(*GetMonitoringInfoResponse)(nil),        // 88: containarium.v1.GetMonitoringInfoResponse
+	(*CreateAlertRuleResponse)(nil),          // 89: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),           // 90: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),             // 91: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),          // 92: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),          // 93: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),          // 94: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),    // 95: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),     // 96: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),              // 97: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),    // 98: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),                // 99: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),                // 100: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),              // 101: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),             // 102: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),           // 103: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,   // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -271,96 +275,98 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	11,  // 11: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
 	12,  // 12: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
 	13,  // 13: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
-	14,  // 14: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
-	15,  // 15: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
-	16,  // 16: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
-	17,  // 17: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
-	18,  // 18: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
-	19,  // 19: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
-	20,  // 20: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
-	21,  // 21: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
-	22,  // 22: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
-	23,  // 23: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
-	24,  // 24: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
-	25,  // 25: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
-	26,  // 26: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
-	27,  // 27: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
-	28,  // 28: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
-	29,  // 29: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
-	30,  // 30: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
-	31,  // 31: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
-	32,  // 32: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
-	33,  // 33: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
-	34,  // 34: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
-	35,  // 35: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	36,  // 36: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	37,  // 37: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	38,  // 38: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	39,  // 39: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	40,  // 40: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	41,  // 41: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	42,  // 42: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	43,  // 43: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	44,  // 44: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	45,  // 45: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	46,  // 46: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	47,  // 47: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	48,  // 48: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	49,  // 49: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	50,  // 50: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	51,  // 51: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	52,  // 52: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	53,  // 53: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	54,  // 54: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	55,  // 55: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	56,  // 56: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	57,  // 57: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	58,  // 58: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	59,  // 59: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	60,  // 60: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	61,  // 61: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	62,  // 62: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	63,  // 63: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	64,  // 64: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
-	65,  // 65: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	66,  // 66: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	67,  // 67: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	68,  // 68: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	69,  // 69: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	70,  // 70: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	71,  // 71: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	72,  // 72: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	73,  // 73: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	74,  // 74: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	75,  // 75: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
-	76,  // 76: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
-	77,  // 77: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
-	78,  // 78: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
-	79,  // 79: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
-	80,  // 80: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
-	81,  // 81: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
-	82,  // 82: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	83,  // 83: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
-	84,  // 84: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
-	85,  // 85: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
-	86,  // 86: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	87,  // 87: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	88,  // 88: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	89,  // 89: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	90,  // 90: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	91,  // 91: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	92,  // 92: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	93,  // 93: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	94,  // 94: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	95,  // 95: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	96,  // 96: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	97,  // 97: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	98,  // 98: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	99,  // 99: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	100, // 100: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	101, // 101: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	51,  // [51:102] is the sub-list for method output_type
-	0,   // [0:51] is the sub-list for method input_type
+	14,  // 14: containarium.v1.ContainerService.SetContainerAttribution:input_type -> containarium.v1.SetContainerAttributionRequest
+	15,  // 15: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
+	16,  // 16: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
+	17,  // 17: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
+	18,  // 18: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
+	19,  // 19: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
+	20,  // 20: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
+	21,  // 21: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
+	22,  // 22: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
+	23,  // 23: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
+	24,  // 24: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
+	25,  // 25: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
+	26,  // 26: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
+	27,  // 27: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
+	28,  // 28: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
+	29,  // 29: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
+	30,  // 30: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
+	31,  // 31: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
+	32,  // 32: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
+	33,  // 33: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
+	34,  // 34: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
+	35,  // 35: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
+	36,  // 36: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	37,  // 37: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	38,  // 38: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	39,  // 39: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	40,  // 40: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	41,  // 41: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	42,  // 42: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	43,  // 43: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	44,  // 44: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	45,  // 45: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	46,  // 46: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	47,  // 47: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	48,  // 48: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	49,  // 49: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	50,  // 50: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	51,  // 51: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	52,  // 52: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	53,  // 53: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	54,  // 54: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	55,  // 55: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	56,  // 56: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	57,  // 57: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	58,  // 58: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	59,  // 59: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	60,  // 60: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	61,  // 61: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	62,  // 62: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	63,  // 63: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	64,  // 64: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	65,  // 65: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
+	66,  // 66: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
+	67,  // 67: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	68,  // 68: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	69,  // 69: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	70,  // 70: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	71,  // 71: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	72,  // 72: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	73,  // 73: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	74,  // 74: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	75,  // 75: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	76,  // 76: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	77,  // 77: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
+	78,  // 78: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
+	79,  // 79: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
+	80,  // 80: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
+	81,  // 81: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
+	82,  // 82: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
+	83,  // 83: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
+	84,  // 84: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	85,  // 85: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	86,  // 86: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
+	87,  // 87: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
+	88,  // 88: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	89,  // 89: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	90,  // 90: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	91,  // 91: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	92,  // 92: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	93,  // 93: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	94,  // 94: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	95,  // 95: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	96,  // 96: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	97,  // 97: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	98,  // 98: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	99,  // 99: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	100, // 100: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	101, // 101: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	102, // 102: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	103, // 103: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	52,  // [52:104] is the sub-list for method output_type
+	0,   // [0:52] is the sub-list for method input_type
 	0,   // [0:0] is the sub-list for extension type_name
 	0,   // [0:0] is the sub-list for extension extendee
 	0,   // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -633,6 +633,51 @@ func local_request_ContainerService_SetContainerDeletePolicy_0(ctx context.Conte
 	return msg, metadata, err
 }
 
+func request_ContainerService_SetContainerAttribution_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SetContainerAttributionRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+	protoReq.Name, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+	msg, err := client.SetContainerAttribution(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_SetContainerAttribution_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SetContainerAttributionRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+	protoReq.Name, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+	msg, err := server.SetContainerAttribution(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_AddSSHKey_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq AddSSHKeyRequest
@@ -2223,6 +2268,26 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_SetContainerDeletePolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_SetContainerAttribution_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/SetContainerAttribution", runtime.WithHTTPPathPattern("/v1/containers/{name}/attribution"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_SetContainerAttribution_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_SetContainerAttribution_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_AddSSHKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3261,6 +3326,23 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_SetContainerDeletePolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_SetContainerAttribution_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/SetContainerAttribution", runtime.WithHTTPPathPattern("/v1/containers/{name}/attribution"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_SetContainerAttribution_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_SetContainerAttribution_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_AddSSHKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3925,6 +4007,7 @@ var (
 	pattern_ContainerService_ToggleAutoSleep_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "auto-sleep"}, ""))
 	pattern_ContainerService_SetContainerTTL_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "name", "ttl"}, ""))
 	pattern_ContainerService_SetContainerDeletePolicy_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "name", "delete-policy"}, ""))
+	pattern_ContainerService_SetContainerAttribution_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "name", "attribution"}, ""))
 	pattern_ContainerService_AddSSHKey_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "ssh-keys"}, ""))
 	pattern_ContainerService_RemoveSSHKey_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"v1", "containers", "username", "ssh-keys", "ssh_public_key"}, ""))
 	pattern_ContainerService_AddCollaborator_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "owner_username", "collaborators"}, ""))
@@ -3980,6 +4063,7 @@ var (
 	forward_ContainerService_ToggleAutoSleep_0          = runtime.ForwardResponseMessage
 	forward_ContainerService_SetContainerTTL_0          = runtime.ForwardResponseMessage
 	forward_ContainerService_SetContainerDeletePolicy_0 = runtime.ForwardResponseMessage
+	forward_ContainerService_SetContainerAttribution_0  = runtime.ForwardResponseMessage
 	forward_ContainerService_AddSSHKey_0                = runtime.ForwardResponseMessage
 	forward_ContainerService_RemoveSSHKey_0             = runtime.ForwardResponseMessage
 	forward_ContainerService_AddCollaborator_0          = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -33,6 +33,7 @@ const (
 	ContainerService_ToggleAutoSleep_FullMethodName          = "/containarium.v1.ContainerService/ToggleAutoSleep"
 	ContainerService_SetContainerTTL_FullMethodName          = "/containarium.v1.ContainerService/SetContainerTTL"
 	ContainerService_SetContainerDeletePolicy_FullMethodName = "/containarium.v1.ContainerService/SetContainerDeletePolicy"
+	ContainerService_SetContainerAttribution_FullMethodName  = "/containarium.v1.ContainerService/SetContainerAttribution"
 	ContainerService_AddSSHKey_FullMethodName                = "/containarium.v1.ContainerService/AddSSHKey"
 	ContainerService_RemoveSSHKey_FullMethodName             = "/containarium.v1.ContainerService/RemoveSSHKey"
 	ContainerService_AddCollaborator_FullMethodName          = "/containarium.v1.ContainerService/AddCollaborator"
@@ -151,6 +152,15 @@ type ContainerServiceClient interface {
 	// the Incus config under user.containarium.delete_policy, so it survives
 	// daemon restart with no separate store — read back on list/get.
 	SetContainerDeletePolicy(ctx context.Context, in *SetContainerDeletePolicyRequest, opts ...grpc.CallOption) (*SetContainerDeletePolicyResponse, error)
+	// SetContainerAttribution merges labels onto an EXISTING container's config
+	// (cloud #746). The hosted control plane stamps attribution labels
+	// (cloud_org_id / cloud_container_id / managed_by) at create time today; this
+	// endpoint lets it stamp them AFTER the fact, which the cloud's adopt flow
+	// (cloud #539) needs to bring a host's pre-existing (orphan) container under
+	// org management. Merge semantics: each provided label is set; labels not
+	// named are left intact. Cloud→daemon plumbing (like /authorized-keys/sentinel),
+	// not a standalone operator action — no CLI verb.
+	SetContainerAttribution(ctx context.Context, in *SetContainerAttributionRequest, opts ...grpc.CallOption) (*SetContainerAttributionResponse, error)
 	// AddSSHKey adds an SSH public key to a container
 	AddSSHKey(ctx context.Context, in *AddSSHKeyRequest, opts ...grpc.CallOption) (*AddSSHKeyResponse, error)
 	// RemoveSSHKey removes an SSH public key from a container
@@ -419,6 +429,16 @@ func (c *containerServiceClient) SetContainerDeletePolicy(ctx context.Context, i
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(SetContainerDeletePolicyResponse)
 	err := c.cc.Invoke(ctx, ContainerService_SetContainerDeletePolicy_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) SetContainerAttribution(ctx context.Context, in *SetContainerAttributionRequest, opts ...grpc.CallOption) (*SetContainerAttributionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetContainerAttributionResponse)
+	err := c.cc.Invoke(ctx, ContainerService_SetContainerAttribution_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -874,6 +894,15 @@ type ContainerServiceServer interface {
 	// the Incus config under user.containarium.delete_policy, so it survives
 	// daemon restart with no separate store — read back on list/get.
 	SetContainerDeletePolicy(context.Context, *SetContainerDeletePolicyRequest) (*SetContainerDeletePolicyResponse, error)
+	// SetContainerAttribution merges labels onto an EXISTING container's config
+	// (cloud #746). The hosted control plane stamps attribution labels
+	// (cloud_org_id / cloud_container_id / managed_by) at create time today; this
+	// endpoint lets it stamp them AFTER the fact, which the cloud's adopt flow
+	// (cloud #539) needs to bring a host's pre-existing (orphan) container under
+	// org management. Merge semantics: each provided label is set; labels not
+	// named are left intact. Cloud→daemon plumbing (like /authorized-keys/sentinel),
+	// not a standalone operator action — no CLI verb.
+	SetContainerAttribution(context.Context, *SetContainerAttributionRequest) (*SetContainerAttributionResponse, error)
 	// AddSSHKey adds an SSH public key to a container
 	AddSSHKey(context.Context, *AddSSHKeyRequest) (*AddSSHKeyResponse, error)
 	// RemoveSSHKey removes an SSH public key from a container
@@ -1049,6 +1078,9 @@ func (UnimplementedContainerServiceServer) SetContainerTTL(context.Context, *Set
 }
 func (UnimplementedContainerServiceServer) SetContainerDeletePolicy(context.Context, *SetContainerDeletePolicyRequest) (*SetContainerDeletePolicyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetContainerDeletePolicy not implemented")
+}
+func (UnimplementedContainerServiceServer) SetContainerAttribution(context.Context, *SetContainerAttributionRequest) (*SetContainerAttributionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetContainerAttribution not implemented")
 }
 func (UnimplementedContainerServiceServer) AddSSHKey(context.Context, *AddSSHKeyRequest) (*AddSSHKeyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddSSHKey not implemented")
@@ -1430,6 +1462,24 @@ func _ContainerService_SetContainerDeletePolicy_Handler(srv interface{}, ctx con
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ContainerServiceServer).SetContainerDeletePolicy(ctx, req.(*SetContainerDeletePolicyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_SetContainerAttribution_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetContainerAttributionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).SetContainerAttribution(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_SetContainerAttribution_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).SetContainerAttribution(ctx, req.(*SetContainerAttributionRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2162,6 +2212,10 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetContainerDeletePolicy",
 			Handler:    _ContainerService_SetContainerDeletePolicy_Handler,
+		},
+		{
+			MethodName: "SetContainerAttribution",
+			Handler:    _ContainerService_SetContainerAttribution_Handler,
 		},
 		{
 			MethodName: "AddSSHKey",

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -673,6 +673,26 @@ message SetContainerDeletePolicyResponse {
   DeletePolicy delete_policy = 1;
 }
 
+// SetContainerAttributionRequest merges labels onto an existing container
+// (cloud #746). Used by the hosted control plane's adopt flow (cloud #539) to
+// stamp attribution (cloud_org_id / cloud_container_id / managed_by) on a
+// pre-existing box after the fact.
+message SetContainerAttributionRequest {
+  // Container name — the bare username, matching the per-container RPC
+  // convention (the handler resolves <username>-container; see SetContainerTTL).
+  string name = 1;
+
+  // Labels to merge onto the container. Each entry is set; labels not named
+  // here are left intact (merge, not replace). An empty map is rejected.
+  map<string, string> labels = 2;
+}
+
+// SetContainerAttributionResponse reports the full label set now on the box.
+message SetContainerAttributionResponse {
+  // Every label currently on the container after the merge.
+  map<string, string> labels = 1;
+}
+
 // AddSSHKeyRequest is the request to add an SSH key to a container
 message AddSSHKeyRequest {
   // Username of the container

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -275,6 +275,26 @@ service ContainerService {
     };
   }
 
+  // SetContainerAttribution merges labels onto an EXISTING container's config
+  // (cloud #746). The hosted control plane stamps attribution labels
+  // (cloud_org_id / cloud_container_id / managed_by) at create time today; this
+  // endpoint lets it stamp them AFTER the fact, which the cloud's adopt flow
+  // (cloud #539) needs to bring a host's pre-existing (orphan) container under
+  // org management. Merge semantics: each provided label is set; labels not
+  // named are left intact. Cloud→daemon plumbing (like /authorized-keys/sentinel),
+  // not a standalone operator action — no CLI verb.
+  rpc SetContainerAttribution(SetContainerAttributionRequest) returns (SetContainerAttributionResponse) {
+    option (google.api.http) = {
+      post: "/v1/containers/{name}/attribution"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Merge attribution labels onto an existing container";
+      description: "Sets the given labels on a live container's config, leaving other labels intact (cloud #746). Lets the hosted control plane stamp cloud attribution (cloud_org_id / cloud_container_id / managed_by) on a pre-existing box so its adopt flow can bring it under management (cloud #539). 404 when the container doesn't resolve.";
+      tags: "Container Operations";
+    };
+  }
+
   // AddSSHKey adds an SSH public key to a container
   rpc AddSSHKey(AddSSHKeyRequest) returns (AddSSHKeyResponse) {
     option (google.api.http) = {


### PR DESCRIPTION
Closes the second half of #750 (the first — default-deny egress + engine pin — shipped in #751).

## Problem

The model-gateway minted each box's gateway token with a `jti` but **never consulted a revocation list** (`VerifyToken` checks signature/issuer/expiry/provider only). A leaked gateway token was therefore usable until its 30-min TTL — no kill-switch, unlike platform JWTs which have `token revoke` + the `jwt_revocations` store.

## Fix

- `modelgateway.Config` gains a `Revocations RevocationChecker` field (a narrow local interface `IsRevoked(ctx, jti) (bool, error)` — keeps `modelgateway` free of an `auth` import; satisfied by the platform's `*auth.PgRevocationStore`).
- `handleModel` checks `claims.ID` against it after the provider check, before injecting the real key. **Fail-open** on a lookup error (the list is a kill-switch, not the primary gate — matching `auth.TokenManager.ValidateToken`).
- The daemon injects the **same revocation store it already wires** for platform JWTs. That store is **issuer-agnostic** (keyed on jti only), so `containarium token revoke --jti <id>` kills a gateway token too — **no new CLI / RPC / schema**.
- Guards the typed-nil-interface trap: the `*PgRevocationStore` is only assigned to the interface field when non-nil (else a nil-pointer wrapped in a non-nil interface would pass `!= nil` and panic).

## Tests

- revoked jti → `401` and never reaches the provider upstream.
- revocation lookup error → fail-open `200`.

`go test ./internal/modelgateway/` + `./internal/server/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)