### PR TITLE
fix(release): guard the agent-runtime bundle ships every engine + runtime deps (#748)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fell back to the default claude engine and failed (`Not logged in`) because the
   default engine reads the wrong gateway env vars.
 
+### Changed
+
+- **Release bundle verifies it ships every engine (#748).** `make
+  bundle-agent-runtime` (and the release workflow) now runs
+  `scripts/verify-agent-runtime-bundle.sh`, which fails the build unless the
+  packaged `agent-runtime-bundle` contains a compiled `dist/engines/<name>.js`
+  for every `src/engines/<name>.ts` **and** declares each runtime SDK
+  (`@google/genai`, etc.) as a non-dev dependency. This prevents the silent
+  engine-drop that left the gemini engine out of v0.33.0 (the tag predated the
+  engine merge) — a future cut can no longer ship a bundle missing an engine.
+
 ### Added
 
 - **Post-hoc container attribution endpoint (#746).** New

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ bundle-agent-runtime: build-agent-runtime ## Package agent-runtime as a release 
 	@echo "==> Packaging agent-runtime bundle..."
 	@mkdir -p $(BUILD_DIR)
 	@tar -czf $(BUILD_DIR)/agent-runtime-bundle.tar.gz -C agent-runtime dist package.json package-lock.json
+	@scripts/verify-agent-runtime-bundle.sh $(BUILD_DIR)/agent-runtime-bundle.tar.gz
 	@echo "==> agent-runtime bundle: $(BUILD_DIR)/agent-runtime-bundle.tar.gz (publish alongside agent-box-linux-amd64; scripts/install-agent-runtime.sh consumes both)"
 
 build-agent-box-linux: ## Build agent-box for Linux (the typical install target — agent-box runs INSIDE LXC containers)

--- a/scripts/verify-agent-runtime-bundle.sh
+++ b/scripts/verify-agent-runtime-bundle.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# verify-agent-runtime-bundle.sh — guard the release bundle's contract (#748).
+#
+# Asserts the packaged agent-runtime-bundle ships:
+#   1. a compiled dist/engines/<name>.js for EVERY engine in src/engines/<name>.ts
+#      (so an engine can't silently drop from a release — e.g. gemini was missing
+#      from v0.33.0 because that tag predated the engine; this fails the build if
+#      tsc/packaging ever skips one), and
+#   2. each runtime SDK as a package.json *dependency* (not devDependency), so the
+#      box's `npm ci --omit=dev` actually installs it.
+#
+# Run by `make bundle-agent-runtime` after packaging, and in the release workflow.
+#
+# Usage: verify-agent-runtime-bundle.sh <bundle.tar.gz> [src-engines-dir]
+set -euo pipefail
+
+BUNDLE="${1:?usage: verify-agent-runtime-bundle.sh <bundle.tar.gz> [src-engines-dir]}"
+SRC_ENGINES_DIR="${2:-agent-runtime/src/engines}"
+# Runtime SDKs the engines import; each must be a (non-dev) dependency.
+REQUIRED_DEPS=(@anthropic-ai/claude-agent-sdk @openai/codex-sdk @google/genai @modelcontextprotocol/sdk)
+
+[ -f "$BUNDLE" ] || { echo "verify-bundle: no such bundle: $BUNDLE" >&2; exit 2; }
+[ -d "$SRC_ENGINES_DIR" ] || { echo "verify-bundle: no src engines dir: $SRC_ENGINES_DIR" >&2; exit 2; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+tar -xzf "$BUNDLE" -C "$tmp"
+
+fail=0
+
+# 1. Every source engine has a compiled engine in the bundle.
+for ts in "$SRC_ENGINES_DIR"/*.ts; do
+  name="$(basename "$ts" .ts)"
+  if [ ! -f "$tmp/dist/engines/$name.js" ]; then
+    echo "MISSING ENGINE: src has $name.ts but the bundle has no dist/engines/$name.js" >&2
+    fail=1
+  fi
+done
+
+# 2. Every runtime SDK is a (non-dev) dependency, so `npm ci --omit=dev` keeps it.
+for dep in "${REQUIRED_DEPS[@]}"; do
+  if ! node -e 'const p=require(process.argv[1]); process.exit(((p.dependencies)||{})[process.argv[2]]?0:1)' \
+       "$tmp/package.json" "$dep" 2>/dev/null; then
+    echo "MISSING DEP: $dep is not in package.json \"dependencies\" (npm ci --omit=dev would skip it)" >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "verify-bundle: FAILED — the agent-runtime bundle is missing an engine or a runtime dep" >&2
+  exit 1
+fi
+echo "verify-bundle: OK — engines: $(cd "$tmp/dist/engines" && ls *.js | tr '\n' ' ')"


### PR DESCRIPTION
Closes #748. The first half (daemon pins `CONTAINARIUM_AGENT_ENGINE` to the gateway provider) shipped in #751; this is the bundle half.

## Why

v0.33.0's `agent-runtime-bundle` shipped only `claude.js` + `codex.js` — the gemini engine merged *after* the tag was cut, and **nothing caught it**. A gemini box then couldn't auto-assemble and needed manual bundle surgery. The bundle build is otherwise fine (`tsc` compiles every engine; `@google/genai` is already a runtime dependency), so the gap is a **guard** so an engine/dep can't silently drop again.

## What

`scripts/verify-agent-runtime-bundle.sh`, run from `make bundle-agent-runtime` (and thus the release workflow). It **fails the build** unless the packaged bundle:
- has a compiled `dist/engines/<name>.js` for **every** `src/engines/<name>.ts` (derived from source — a new engine auto-extends the check), and
- declares each runtime SDK (`@google/genai`, `@anthropic-ai/claude-agent-sdk`, `@openai/codex-sdk`, `@modelcontextprotocol/sdk`) as a **non-dev** dependency, so the box's `npm ci --omit=dev` installs it.

## Verified

- **FAILS** on the v0.33.0 bundle: `MISSING ENGINE: ... gemini.js` + `MISSING DEP: @google/genai` — catches the exact regression.
- **PASSES** a complete bundle (all three engines + deps).

Follow-up idea (not here): also run the guard on PRs touching `agent-runtime/` so it's caught pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)