### PR TITLE
chore(release): cut v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-06-20
+
 ### Security
 
 - **Agent-skill box: default-deny egress for every box (#750).** `RunAgentSkill`


### PR DESCRIPTION
Finalizes `[Unreleased]` → `[0.34.0] - 2026-06-20`. After merge I'll tag `v0.34.0` to trigger the release workflow.

**Highlights since v0.33.0** (18 commits): daemon-served **model-gateway** (provider key held by the daemon; skill boxes route through a scoped, **revocable** gateway token), **gemini** agent-runtime engine, pull-based run-queue + poll workers, skill-box egress **default-deny** + pinned to the gateway, engine pinned to the gateway provider, and a **release-bundle engine guard** so a release can't ship missing an engine.

CHANGELOG-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)