### PR TITLE
feat(workspace): model-gateway gemini-openai + LibreChat command-workspace recipe

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -10106,6 +10106,10 @@
             "type": "string"
           },
           "description": "Shell commands run inside the container after it is up (e.g. the\n`podman run ...` that starts the app, plus model warm-up). Same trust\nlevel as a stack's post_install: these ship in-tree and are reviewed."
+        },
+        "modelGatewayProvider": {
+          "type": "string",
+          "description": "When non-empty, the daemon brokers this recipe's model calls through the\nmanaged model-gateway for the named provider (e.g. \"gemini-openai\"): it\nmints a scoped, revocable gateway token and exports\nCONTAINARIUM_MODEL_GATEWAY_URL + CONTAINARIUM_GATEWAY_TOKEN into post_start,\nso the box uses the platform key (metered, never leaked) instead of one the\nuser supplies. Inert when the daemon holds no key for the provider — the\nbox then comes up unconfigured (self-hosted default)."
         }
       },
       "description": "Recipe is a declarative definition of a GPU/app workload that Containarium\ncan provision as a new dedicated container. The container is an LXC system\ncontainer; the recipe's image runs inside it via Podman (post_start),\nmirroring how the kubeflow stack runs k3s inside an LXC."

--- a/internal/modelgateway/gateway_test.go
+++ b/internal/modelgateway/gateway_test.go
@@ -205,6 +205,58 @@ func TestGateway_Gemini_PathModel_AllowedModelsEnforced(t *testing.T) {
 	}
 }
 
+// gemini-openai is the OpenAI-compatible Gemini route the hosted OpenHands
+// canvas uses: a Bearer-authenticated /chat/completions call, proxied to
+// Google's compat endpoint with the real key injected as Bearer and metered
+// from the OpenAI-shaped usage block.
+func TestGateway_GeminiOpenAI_BearerInjected_Metered(t *testing.T) {
+	secret := []byte("s")
+	var auth, upstreamPath string
+	up := fakeUpstream(t, func(r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		upstreamPath = r.URL.Path
+	}, `{"model":"gemini-2.5-flash","usage":{"prompt_tokens":100,"completion_tokens":20}}`)
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["gemini-openai"].UpstreamURL = up.URL
+	gw := New(Config{Secret: secret, Providers: providers, ProviderKeys: map[string]string{"gemini-openai": "GKEY"}})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	tok, err := MintToken(secret, GatewayClaims{Tenant: "acme", SkillID: "ws", Provider: "gemini-openai"}, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// LiteLLM's openai provider posts /chat/completions relative to the profile
+	// base URL (…/v1/model/gemini-openai/v1beta/openai), Bearer-authenticated.
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/model/gemini-openai/v1beta/openai/chat/completions", strings.NewReader(`{"model":"gemini-2.5-flash"}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d, want 200", resp.StatusCode)
+	}
+	_ = resp.Body.Close()
+
+	if auth != "Bearer GKEY" {
+		t.Errorf("real gemini key not injected as Bearer upstream: Authorization=%q", auth)
+	}
+	if upstreamPath != "/v1beta/openai/chat/completions" {
+		t.Errorf("upstream path not preserved: got %q", upstreamPath)
+	}
+	rows := gw.Meter().Snapshot()
+	if len(rows) != 1 || rows[0].Provider != "gemini-openai" || rows[0].Model != "gemini-2.5-flash" {
+		t.Fatalf("metering/attribution wrong: %+v", rows)
+	}
+	if rows[0].InputTokens != 100 || rows[0].OutputTokens != 20 {
+		t.Errorf("token counts wrong: %+v", rows[0])
+	}
+}
+
 func TestGateway_RejectsBadTokens(t *testing.T) {
 	secret := []byte("s")
 	gw := New(Config{Secret: secret, Providers: DefaultProviders(), ProviderKeys: map[string]string{"anthropic": "k"}})

--- a/internal/modelgateway/providers.go
+++ b/internal/modelgateway/providers.go
@@ -109,6 +109,35 @@ func DefaultProviders() map[string]*Provider {
 				}
 			},
 		},
+		// gemini-openai brokers Gemini through Google's *OpenAI-compatible*
+		// surface (/v1beta/openai/...), not the native generateContent API. It
+		// exists for clients that speak OpenAI's chat-completions protocol and
+		// authenticate with `Authorization: Bearer` — notably the hosted
+		// OpenHands canvas (via LiteLLM's openai provider), which can't drive the
+		// native gemini provider's `x-goog-api-key` path. Same real key
+		// (GEMINI_API_KEY); a box still only ever holds the scoped gateway token.
+		// The model is in the request body (not the path), so the token's
+		// AllowedModels ceiling is not enforced here — a follow-up once
+		// body-model parsing lands.
+		"gemini-openai": {
+			Name:        "gemini-openai",
+			UpstreamURL: "https://generativelanguage.googleapis.com",
+			KeyEnv:      "GEMINI_API_KEY",
+			inject: func(h http.Header, key string) {
+				stripGatewayAuth(h)
+				h.Set("Authorization", "Bearer "+key)
+			},
+			parseUsage: func(b map[string]any, _ string) Usage {
+				// OpenAI-shaped usage block (Google's compat endpoint mirrors it).
+				u := subMap(b, "usage")
+				model, _ := b["model"].(string)
+				return Usage{
+					Model:        model,
+					InputTokens:  num(u, "prompt_tokens"),
+					OutputTokens: num(u, "completion_tokens"),
+				}
+			},
+		},
 	}
 }
 

--- a/internal/server/agent_gateway.go
+++ b/internal/server/agent_gateway.go
@@ -85,6 +85,23 @@ func gatewayEnvScript(provider string, httpPort int, token, seedDir string) (str
 	return b.String(), nil
 }
 
+// gatewayRecipeEnvExports returns shell lines that resolve the daemon host from
+// the box's default route and EXPORT the managed model-gateway contract into the
+// post_start environment (not a file): CONTAINARIUM_MODEL_GATEWAY_URL, pointing
+// at the gateway's per-provider base (/v1/model/<provider>), and
+// CONTAINARIUM_GATEWAY_TOKEN. A recipe's post_start reads these to point its
+// in-box app at the gateway, appending any upstream sub-path. The URL is
+// resolved IN-BOX so it works regardless of the bridge subnet (same approach as
+// gatewayEnvScript). Pure: returns the snippet for the given provider/port/token.
+func gatewayRecipeEnvExports(provider string, httpPort int, token string) string {
+	var b strings.Builder
+	b.WriteString("__ctn_host=\"$(ip route show default 2>/dev/null | awk '/default/ {print $3; exit}')\"\n")
+	b.WriteString("if [ -z \"$__ctn_host\" ]; then echo 'model-gateway: could not resolve host from default route' >&2; fi\n")
+	fmt.Fprintf(&b, "export CONTAINARIUM_MODEL_GATEWAY_URL=\"http://$__ctn_host:%d/v1/model/%s\"\n", httpPort, provider)
+	fmt.Fprintf(&b, "export CONTAINARIUM_GATEWAY_TOKEN=%s\n", shellSingleQuote(token))
+	return b.String()
+}
+
 // gatewayProviderKeysFromEnv reads provider API keys from the daemon env, one
 // per provider that has a key set. These keys are held ONLY in the daemon's
 // gateway process; a box never sees them. Gemini accepts GEMINI_API_KEY or
@@ -101,6 +118,12 @@ func gatewayProviderKeysFromEnv() map[string]string {
 		out["gemini"] = v
 	} else if v := strings.TrimSpace(os.Getenv("GOOGLE_API_KEY")); v != "" {
 		out["gemini"] = v
+	}
+	// The Gemini key also backs the OpenAI-compatible Gemini provider
+	// (gemini-openai), which the hosted OpenHands canvas routes through. Same
+	// real key, different upstream protocol + auth header (see DefaultProviders).
+	if v := out["gemini"]; v != "" {
+		out["gemini-openai"] = v
 	}
 	return out
 }

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1326,6 +1326,10 @@ skipAppHosting:
 			for p := range keys {
 				provs = append(provs, p)
 			}
+			// Recipes that opt in (recipe.ModelGatewayProvider, e.g. the
+			// agent-workspace canvas) route their model calls through the same
+			// gateway — seed their post_start with a scoped token + base URL.
+			recipeServer.SetGatewayProvisioning(config.HTTPPort, []byte(config.JWTSecret), provs)
 			log.Printf("Model-gateway enabled (providers=%v, skill-box primary=%s) — agent boxes route model calls through the daemon; provider keys never leave the host",
 				provs, primary)
 		}

--- a/internal/server/recipe_server.go
+++ b/internal/server/recipe_server.go
@@ -6,11 +6,13 @@ import (
 	"log"
 	"net/url"
 	"strings"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/modelgateway"
 	boxlxc "github.com/footprintai/containarium/pkg/core/box/lxc"
 	"github.com/footprintai/containarium/pkg/core/recipes"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -21,6 +23,22 @@ import (
 // mirroring how the kubeflow stack runs k3s inside an LXC.
 const recipeBaseImage = "images:ubuntu/24.04"
 
+// recipeGatewayTokenTTL bounds a workspace recipe's gateway token. Unlike a
+// skill run (minutes), a recipe box like agent-workspace is long-lived, so the
+// token must outlive a session — here a year. The kill-switch is revocation
+// (#752), not expiry; refreshing a live box's token is a follow-up.
+const recipeGatewayTokenTTL = 365 * 24 * time.Hour
+
+// recipeGateway is what RecipeServer needs to broker a recipe's model calls
+// through the daemon's model-gateway: the daemon HTTP port the box dials, the
+// HMAC secret that signs the scoped token, and the set of providers the gateway
+// actually brokers (has a key for). nil ⇒ no gateway ⇒ recipes run unmanaged.
+type recipeGateway struct {
+	httpPort  int
+	secret    []byte
+	providers map[string]bool
+}
+
 // RecipeServer implements the gRPC RecipeService. It is pure orchestration:
 // DeployRecipe composes the existing CreateContainer + in-container exec +
 // route-expose primitives. It lives in package server so it can reuse the
@@ -30,6 +48,45 @@ type RecipeServer struct {
 	catalog    *recipes.Manager
 	containers *ContainerServer
 	network    *NetworkServer // may be nil when app hosting / routing is off
+	gateway    *recipeGateway // nil unless the daemon serves the model-gateway
+}
+
+// SetGatewayProvisioning enables managed model-gateway seeding for recipes that
+// opt in (recipe.ModelGatewayProvider). Called by the daemon when it holds a
+// provider key; mirrors AgentSkillServer.SetGatewayProvisioning for the skill
+// path. providers is the set the gateway brokers.
+func (s *RecipeServer) SetGatewayProvisioning(httpPort int, secret []byte, providers []string) {
+	set := make(map[string]bool, len(providers))
+	for _, p := range providers {
+		set[p] = true
+	}
+	s.gateway = &recipeGateway{httpPort: httpPort, secret: secret, providers: set}
+}
+
+// gatewayEnvForRecipe returns the shell snippet that exports the managed
+// model-gateway env into a recipe's post_start, or "" when the recipe doesn't
+// opt in / the daemon can't broker its provider. It mints a long-lived scoped
+// token bound to this box + recipe + provider. Best-effort: a mint failure logs
+// and degrades to unmanaged (the box still comes up, just unconfigured).
+func (s *RecipeServer) gatewayEnvForRecipe(recipe *pb.Recipe, boxName string) string {
+	prov := recipe.ModelGatewayProvider
+	if prov == "" || s.gateway == nil {
+		return ""
+	}
+	if !s.gateway.providers[prov] {
+		log.Printf("[recipe] %q requests model-gateway provider %q but the daemon holds no key for it; box comes up unconfigured", recipe.Id, prov)
+		return ""
+	}
+	tok, err := modelgateway.MintToken(s.gateway.secret, modelgateway.GatewayClaims{
+		Tenant:   boxName,
+		SkillID:  recipe.Id,
+		Provider: prov,
+	}, recipeGatewayTokenTTL)
+	if err != nil {
+		log.Printf("[recipe] mint gateway token for %s failed (box runs unmanaged): %v", boxName, err)
+		return ""
+	}
+	return gatewayRecipeEnvExports(prov, s.gateway.httpPort, tok)
 }
 
 // NewRecipeServer wires the recipe service to the existing container and
@@ -190,6 +247,11 @@ func (s *RecipeServer) deploy(ctx context.Context, req *pb.DeployRecipeRequest) 
 
 	containerName := req.Name + "-container"
 
+	// Managed model-gateway: if the recipe opts in and the daemon brokers its
+	// provider, mint a scoped token + env exports to prepend to post_start (so
+	// the box uses the platform key, metered, never leaked). "" otherwise.
+	gatewayEnv := s.gatewayEnvForRecipe(recipe, req.Name)
+
 	// Async path: decouple post_start from the RPC. A recipe's post_start can
 	// pull multi-GB images (e.g. agent-workspace), taking longer than the
 	// request/idle timeout of a caller reaching this daemon through a peer-proxy
@@ -201,7 +263,7 @@ func (s *RecipeServer) deploy(ctx context.Context, req *pb.DeployRecipeRequest) 
 		go func() {
 			bg := context.WithoutCancel(ctx)
 			if len(recipe.PostStart) > 0 {
-				script := buildPostStartScript(recipe, params)
+				script := buildPostStartScript(recipe, params, gatewayEnv)
 				if err := s.containers.manager.Exec(containerName, []string{"bash", "-c", script}); err != nil {
 					log.Printf("[recipe] async post_start failed on %s (recipe %q): %v", containerName, recipe.Id, err)
 					return
@@ -226,7 +288,7 @@ func (s *RecipeServer) deploy(ctx context.Context, req *pb.DeployRecipeRequest) 
 	// 2. Run the recipe's post_start commands inside the container, with env
 	//    and parameters exported. Same trust level as a stack's post_install.
 	if len(recipe.PostStart) > 0 {
-		script := buildPostStartScript(recipe, params)
+		script := buildPostStartScript(recipe, params, gatewayEnv)
 		if err := s.containers.manager.Exec(containerName, []string{"bash", "-c", script}); err != nil {
 			return nil, status.Errorf(codes.Internal, "post_start failed on %s: %v", containerName, err)
 		}
@@ -275,9 +337,15 @@ func resourceLimits(recipe *pb.Recipe, override *pb.RecipeResources) *pb.Resourc
 // buildPostStartScript assembles a single bash script that exports the
 // recipe's static env and resolved parameters, then runs each post_start line.
 // Values are single-quote escaped to prevent shell injection from parameters.
-func buildPostStartScript(recipe *pb.Recipe, params map[string]string) string {
+// gatewayEnv, when non-empty, is the managed model-gateway export snippet
+// (gatewayEnvForRecipe) prepended before the recipe's own env so post_start
+// sees CONTAINARIUM_MODEL_GATEWAY_URL/_TOKEN.
+func buildPostStartScript(recipe *pb.Recipe, params map[string]string, gatewayEnv string) string {
 	var b strings.Builder
 	b.WriteString("set -euo pipefail\n")
+	if gatewayEnv != "" {
+		b.WriteString(gatewayEnv)
+	}
 	for k, v := range recipe.Env {
 		fmt.Fprintf(&b, "export %s=%s\n", k, shellSingleQuote(v))
 	}

--- a/internal/server/recipe_server_test.go
+++ b/internal/server/recipe_server_test.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/modelgateway"
 	"github.com/footprintai/containarium/pkg/core/recipes"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"google.golang.org/grpc/codes"
@@ -90,4 +92,75 @@ func TestRecipeServer_DeployRecipe_RemoteBackendUnsupported(t *testing.T) {
 	if status.Code(err) != codes.Unimplemented {
 		t.Fatalf("got %v want Unimplemented", err)
 	}
+}
+
+// A recipe that doesn't opt into the gateway (or whose provider the daemon
+// can't broker) seeds no gateway env — the box runs unmanaged.
+func TestRecipeServer_GatewayEnv_OptOutAndUnavailable(t *testing.T) {
+	s := newTestRecipeServer()
+	// No gateway configured at all.
+	if got := s.gatewayEnvForRecipe(&pb.Recipe{Id: "r", ModelGatewayProvider: "gemini-openai"}, "box1"); got != "" {
+		t.Fatalf("no gateway set: want empty, got %q", got)
+	}
+	// Gateway set, but recipe doesn't opt in.
+	s.SetGatewayProvisioning(8080, []byte("secret"), []string{"gemini-openai"})
+	if got := s.gatewayEnvForRecipe(&pb.Recipe{Id: "r"}, "box1"); got != "" {
+		t.Fatalf("recipe opted out: want empty, got %q", got)
+	}
+	// Gateway set, recipe opts into a provider the daemon doesn't broker.
+	if got := s.gatewayEnvForRecipe(&pb.Recipe{Id: "r", ModelGatewayProvider: "anthropic"}, "box1"); got != "" {
+		t.Fatalf("provider unavailable: want empty, got %q", got)
+	}
+}
+
+// An opted-in recipe whose provider the daemon brokers gets a gateway env that
+// exports the per-provider base URL + a valid scoped token, and that env is
+// prepended into the post_start script.
+func TestRecipeServer_GatewayEnv_SeedsTokenAndURL(t *testing.T) {
+	s := newTestRecipeServer()
+	secret := []byte("secret")
+	s.SetGatewayProvisioning(8080, secret, []string{"gemini", "gemini-openai"})
+
+	recipe := &pb.Recipe{Id: "agent-workspace", ModelGatewayProvider: "gemini-openai"}
+	env := s.gatewayEnvForRecipe(recipe, "box1")
+	if env == "" {
+		t.Fatal("want gateway env, got empty")
+	}
+	if !strings.Contains(env, "/v1/model/gemini-openai") {
+		t.Errorf("env missing per-provider base URL: %q", env)
+	}
+	if !strings.Contains(env, "CONTAINARIUM_MODEL_GATEWAY_URL=") ||
+		!strings.Contains(env, "CONTAINARIUM_GATEWAY_TOKEN=") {
+		t.Errorf("env missing gateway contract vars: %q", env)
+	}
+	// The exported token must verify against the gateway secret, scoped to the
+	// box + provider.
+	tok := extractExport(env, "CONTAINARIUM_GATEWAY_TOKEN")
+	claims, err := modelgateway.VerifyToken(secret, tok)
+	if err != nil {
+		t.Fatalf("seeded token does not verify: %v", err)
+	}
+	if claims.Provider != "gemini-openai" || claims.Tenant != "box1" {
+		t.Errorf("token claims wrong: provider=%q tenant=%q", claims.Provider, claims.Tenant)
+	}
+
+	// The env is prepended into the post_start script.
+	script := buildPostStartScript(recipe, map[string]string{}, env)
+	if !strings.Contains(script, "CONTAINARIUM_MODEL_GATEWAY_URL=") {
+		t.Errorf("post_start script missing gateway env:\n%s", script)
+	}
+}
+
+// extractExport pulls the value of `export NAME=<value>` from a shell snippet,
+// stripping one layer of single quotes.
+func extractExport(script, name string) string {
+	for _, line := range strings.Split(script, "\n") {
+		prefix := "export " + name + "="
+		if strings.HasPrefix(line, prefix) {
+			v := strings.TrimPrefix(line, prefix)
+			v = strings.TrimSuffix(strings.TrimPrefix(v, "'"), "'")
+			return v
+		}
+	}
+	return ""
 }

--- a/pkg/core/recipes/recipes.go
+++ b/pkg/core/recipes/recipes.go
@@ -61,6 +61,9 @@ type recipeDef struct {
 	Env         map[string]string `yaml:"env,omitempty"`
 	Parameters  []paramDef        `yaml:"parameters,omitempty"`
 	PostStart   []string          `yaml:"post_start,omitempty"`
+	// ModelGatewayProvider opts the recipe into the managed model-gateway for the
+	// named provider (e.g. "gemini-openai"); see the proto field for semantics.
+	ModelGatewayProvider string `yaml:"model_gateway_provider,omitempty"`
 }
 
 // ToProto converts a recipeDef to its pb.Recipe representation.
@@ -73,6 +76,8 @@ func (r *recipeDef) ToProto() *pb.Recipe {
 		RequiresGpu: r.RequiresGPU,
 		Env:         r.Env,
 		PostStart:   r.PostStart,
+
+		ModelGatewayProvider: r.ModelGatewayProvider,
 	}
 	if r.Resources != nil {
 		out.Resources = &pb.RecipeResources{

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -157,12 +157,6 @@ recipes:
     description: Web chat workspace (chat + live preview + multiple persisted sessions) running OpenHands inside an always-on box, behind in-box basic auth; co-work with a coding agent in the browser, then ship to a box.
     image: images:ubuntu/24.04
     requires_gpu: false
-    # Route the canvas's model calls through the managed model-gateway (Gemini
-    # via Google's OpenAI-compatible surface). When the daemon holds the key,
-    # post_start seeds OpenHands with gateway-backed profiles (no user key) and
-    # the in-box proxy locks the model-config UI to switching only. Inert on a
-    # self-hosted daemon with no key — the canvas then comes up for manual config.
-    model_gateway_provider: gemini-openai
     resources:
       cpu: "4"
       memory: 8GB
@@ -203,52 +197,6 @@ recipes:
           -v /opt/openhands-state:/home/openhands/.openhands:U \
           -v /opt/openhands-projects:/projects:U \
           "ghcr.io/openhands/agent-canvas:${CONTAINARIUM_PARAM_OPENHANDS_VERSION}"
-      # Seed the model config from the managed gateway, so the canvas uses the
-      # platform key (metered, never in the box) and the user never enters one.
-      # The daemon exports CONTAINARIUM_MODEL_GATEWAY_URL/_TOKEN here only for a
-      # recipe with model_gateway_provider set and a daemon that holds the key;
-      # absent (self-hosted, no key) this whole step is skipped and OpenHands
-      # comes up for manual BYO-key config. We talk to OpenHands' OWN API on
-      # 127.0.0.1:8000 (unauthenticated in OSS mode) — self-validating, and it
-      # bypasses the in-box lock below (which guards the public :8080 only).
-      - |
-        if [ -n "${CONTAINARIUM_MODEL_GATEWAY_URL:-}" ] && [ -n "${CONTAINARIUM_GATEWAY_TOKEN:-}" ]; then
-          if ! command -v curl >/dev/null 2>&1; then
-            export DEBIAN_FRONTEND=noninteractive
-            apt-get update -qq >/dev/null 2>&1 && apt-get install -y -qq curl >/dev/null 2>&1 || true
-          fi
-          if ! command -v curl >/dev/null 2>&1; then
-            echo 'agent-workspace: curl unavailable; skipped model-gateway seed' >&2
-          else
-            OH=http://127.0.0.1:8000
-            # Google's OpenAI-compatible surface sits under /v1beta/openai of the
-            # gateway's per-provider base; LiteLLM's openai handler appends
-            # /chat/completions and Bearer-authenticates with the scoped token.
-            BASE="${CONTAINARIUM_MODEL_GATEWAY_URL}/v1beta/openai"
-            TOK="$CONTAINARIUM_GATEWAY_TOKEN"
-            # Wait for the freshly-started OpenHands API to accept requests
-            # (if/then, not `[ ] && break`, so `set -e` doesn't abort the wait).
-            for i in $(seq 1 90); do
-              code=$(curl -s -o /dev/null -w '%{http_code}' "$OH/api/v1/settings" || echo 000)
-              if [ "$code" != "000" ]; then break; fi
-              sleep 2
-            done
-            # 1. Create the base settings doc + set the active LLM (deep-merged).
-            curl -fsS -X POST "$OH/api/v1/settings" -H 'Content-Type: application/json' \
-              -d "{\"agent_settings_diff\":{\"llm\":{\"model\":\"openai/gemini-2.5-flash\",\"base_url\":\"$BASE\",\"api_key\":\"$TOK\"}}}" \
-              >/dev/null || echo 'agent-workspace: base settings POST failed' >&2
-            # 2. Seed the switchable Gemini profiles (all gateway-backed, same token).
-            for nm in gemini-flash:gemini-2.5-flash gemini-pro:gemini-2.5-pro; do
-              name="${nm%%:*}"; model="${nm##*:}"
-              curl -fsS -X POST "$OH/api/v1/settings/profiles/$name" -H 'Content-Type: application/json' \
-                -d "{\"llm\":{\"model\":\"openai/$model\",\"base_url\":\"$BASE\",\"api_key\":\"$TOK\"},\"include_secrets\":true}" \
-                >/dev/null || echo "agent-workspace: profile $name POST failed" >&2
-            done
-            # 3. Activate the default profile (points active + agent_settings.llm at it).
-            curl -fsS -X POST "$OH/api/v1/settings/profiles/gemini-flash/activate" \
-              >/dev/null || echo 'agent-workspace: activate failed' >&2
-          fi
-        fi
       # In-box auth proxy on :8080 → 127.0.0.1:8000. Two ways in: HTTP basic
       # auth, OR a session cookie the proxy itself issues on a successful
       # basic-auth response. The cookie is SameSite=None so the browser sends it
@@ -274,28 +222,6 @@ recipes:
           auto_https off
         }
         :8080 {
-          # Lock the model config to the platform-managed profiles: switching the
-          # active model (activate) and reading settings stay open, but creating
-          # or editing a profile, the generic settings write, and provider-secret
-          # writes are denied — so the canvas can only use the managed gateway and
-          # a user can't paste their own key or point it elsewhere. These deny
-          # handles run before the auth/proxy handles below; denying pre-auth is
-          # safe (never a downgrade). Seeding bypasses this (it hits :8000).
-          # Only the bare /profiles/{name} (one segment) is a save — */activate
-          # and */rename have an extra segment, matched precisely with path_regexp.
-          @settings_write { method POST; path /api/v1/settings }
-          @profile_save { method POST; path_regexp ^/api/v1/settings/profiles/[^/]+$ }
-          @profile_rename { method POST; path_regexp ^/api/v1/settings/profiles/[^/]+/rename$ }
-          @profile_delete { method DELETE; path /api/v1/settings/profiles/* }
-          @secrets_write {
-            method POST PUT DELETE
-            path /api/v1/secrets /api/v1/secrets/*
-          }
-          handle @settings_write { respond "model configuration is managed by the platform" 403 }
-          handle @profile_save { respond "model configuration is managed by the platform" 403 }
-          handle @profile_rename { respond "model configuration is managed by the platform" 403 }
-          handle @profile_delete { respond "model configuration is managed by the platform" 403 }
-          handle @secrets_write { respond "model configuration is managed by the platform" 403 }
           # Zero-click bootstrap: the console opens /__ws_login?t=<token>; the
           # proxy sets the SameSite=None cookie and redirects to the app, so no
           # sign-in prompt is ever shown in the embedded iframe.
@@ -331,3 +257,99 @@ recipes:
         podman run -d --name wsauth --restart=always --network host \
           -v /opt/wsauth/Caddyfile:/etc/caddy/Caddyfile:ro \
           docker.io/library/caddy:2
+
+  # librechat is the MANAGED CHAT WORKSPACE: LibreChat (github.com/danny-avila/
+  # LibreChat, MIT) packaged in a box and wired to the platform model-gateway.
+  # Where agent-workspace (OpenHands) is a bring-your-own-key coding canvas, this
+  # is the command-center surface: the OPERATOR picks the models, the box talks
+  # to them through the daemon's gateway (provider key on the HOST, never in the
+  # box, metered), and a user can SWITCH among the curated models but cannot
+  # supply their own key — LibreChat's custom endpoint takes its key from the
+  # box env (the seeded gateway token), so there is no user-key field to lock.
+  #
+  # The gateway wiring is automatic via `model_gateway_provider: gemini-openai`:
+  # the daemon seeds CONTAINARIUM_MODEL_GATEWAY_URL + CONTAINARIUM_GATEWAY_TOKEN
+  # into post_start (internal/server/recipe_server.go gatewayEnvForRecipe). On a
+  # self-hosted daemon with no provider key those are absent and the box comes up
+  # with an empty endpoint set (LibreChat then uses its own config — OSS fallback).
+  #
+  # LibreChat + MongoDB run via Podman on the box's host network; the web UI
+  # (:3080) is exposed as a subdomain. The admin user is created from the
+  # auth_email/auth_password params (first user = admin), then self-registration
+  # is locked off so only that admin can sign in.
+  - id: librechat
+    name: LibreChat Workspace
+    description: Managed chat workspace — LibreChat wired to the platform model-gateway (curated models, no user keys) in an isolated always-on box.
+    image: images:ubuntu/24.04
+    requires_gpu: false
+    resources:
+      cpu: "4"
+      memory: 4GB
+      disk: 20GB
+    model_gateway_provider: gemini-openai
+    ports:
+      - container_port: 3080
+        subdomain: chat
+    parameters:
+      - name: auth_email
+        label: Admin email
+        description: Email for the workspace admin login (created at deploy; self-registration is then disabled).
+        type: string
+        default: admin@workspace.local
+      - name: auth_password
+        label: Admin password
+        description: Password for the workspace admin login. Required — the box is never left open.
+        type: password
+        required: true
+      - name: librechat_version
+        label: LibreChat image tag
+        description: LibreChat image tag to run (pin for reproducibility).
+        type: string
+        default: latest
+    post_start:
+      - mkdir -p /opt/lc /opt/lc/mongo
+      - command -v curl >/dev/null 2>&1 && command -v openssl >/dev/null 2>&1 || { export DEBIAN_FRONTEND=noninteractive; apt-get update -qq && apt-get install -y -qq curl openssl >/dev/null; }
+      - podman pull docker.io/library/mongo:7 >/dev/null
+      - 'podman pull "ghcr.io/danny-avila/librechat:${CONTAINARIUM_PARAM_LIBRECHAT_VERSION}" >/dev/null'
+      # LibreChat config: one custom endpoint at the platform gateway. apiKey is
+      # the seeded gateway token (LibreChat env-expands ${CTN_GATEWAY_TOKEN}), so
+      # the box holds no real provider key and users can't supply their own. No
+      # gateway seeded → empty config, LibreChat falls back to its own provider.
+      - |
+        if [ -n "${CONTAINARIUM_MODEL_GATEWAY_URL:-}" ] && [ -n "${CONTAINARIUM_GATEWAY_TOKEN:-}" ]; then
+          printf 'version: 1.2.1\ncache: true\nendpoints:\n  custom:\n    - name: "Containarium (Gemini)"\n      apiKey: "${CTN_GATEWAY_TOKEN}"\n      baseURL: "%s/v1beta/openai"\n      models:\n        default: ["gemini-2.5-flash", "gemini-2.5-pro"]\n        fetch: false\n      titleConvo: true\n      titleModel: "gemini-2.5-flash"\n      modelDisplayLabel: "Containarium Gemini"\n' "$CONTAINARIUM_MODEL_GATEWAY_URL" > /opt/lc/librechat.yaml
+        else
+          printf 'version: 1.2.1\ncache: true\n' > /opt/lc/librechat.yaml
+          echo 'librechat: no managed gateway seeded; configure a provider in LibreChat' >&2
+        fi
+      - |
+        {
+          echo "HOST=0.0.0.0"
+          echo "PORT=3080"
+          echo "MONGO_URI=mongodb://127.0.0.1:27017/LibreChat"
+          echo "CONFIG_PATH=/app/librechat.yaml"
+          echo "ALLOW_REGISTRATION=true"
+          echo "ALLOW_EMAIL_LOGIN=true"
+          echo "SEARCH=false"
+          echo "JWT_SECRET=$(openssl rand -hex 32)"
+          echo "JWT_REFRESH_SECRET=$(openssl rand -hex 32)"
+          echo "CREDS_KEY=$(openssl rand -hex 32)"
+          echo "CREDS_IV=$(openssl rand -hex 16)"
+          echo "CTN_GATEWAY_TOKEN=${CONTAINARIUM_GATEWAY_TOKEN:-}"
+        } > /opt/lc/.env
+      - podman rm -f mongo librechat 2>/dev/null || true
+      - podman run -d --name mongo --restart=always --network host -v /opt/lc/mongo:/data/db docker.io/library/mongo:7 >/dev/null
+      - 'podman run -d --name librechat --restart=always --network host --env-file /opt/lc/.env -v /opt/lc/librechat.yaml:/app/librechat.yaml:ro "ghcr.io/danny-avila/librechat:${CONTAINARIUM_PARAM_LIBRECHAT_VERSION}" >/dev/null'
+      # Wait for the API, create the admin from params (first user = admin), then
+      # lock self-registration off and restart so only the admin can sign in.
+      - |
+        for i in $(seq 1 60); do
+          code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3080/ 2>/dev/null || echo 000)
+          if [ "$code" = "200" ]; then break; fi
+          sleep 3
+        done
+        curl -fsS -X POST http://127.0.0.1:3080/api/auth/register -H 'Content-Type: application/json' \
+          -d "{\"name\":\"Admin\",\"username\":\"admin\",\"email\":\"$CONTAINARIUM_PARAM_AUTH_EMAIL\",\"password\":\"$CONTAINARIUM_PARAM_AUTH_PASSWORD\",\"confirm_password\":\"$CONTAINARIUM_PARAM_AUTH_PASSWORD\"}" \
+          >/dev/null 2>&1 || echo 'librechat: admin register failed (may already exist)' >&2
+        sed -i 's/^ALLOW_REGISTRATION=true/ALLOW_REGISTRATION=false/' /opt/lc/.env
+        podman restart librechat >/dev/null 2>&1 || true

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -157,6 +157,12 @@ recipes:
     description: Web chat workspace (chat + live preview + multiple persisted sessions) running OpenHands inside an always-on box, behind in-box basic auth; co-work with a coding agent in the browser, then ship to a box.
     image: images:ubuntu/24.04
     requires_gpu: false
+    # Route the canvas's model calls through the managed model-gateway (Gemini
+    # via Google's OpenAI-compatible surface). When the daemon holds the key,
+    # post_start seeds OpenHands with gateway-backed profiles (no user key) and
+    # the in-box proxy locks the model-config UI to switching only. Inert on a
+    # self-hosted daemon with no key — the canvas then comes up for manual config.
+    model_gateway_provider: gemini-openai
     resources:
       cpu: "4"
       memory: 8GB
@@ -197,6 +203,52 @@ recipes:
           -v /opt/openhands-state:/home/openhands/.openhands:U \
           -v /opt/openhands-projects:/projects:U \
           "ghcr.io/openhands/agent-canvas:${CONTAINARIUM_PARAM_OPENHANDS_VERSION}"
+      # Seed the model config from the managed gateway, so the canvas uses the
+      # platform key (metered, never in the box) and the user never enters one.
+      # The daemon exports CONTAINARIUM_MODEL_GATEWAY_URL/_TOKEN here only for a
+      # recipe with model_gateway_provider set and a daemon that holds the key;
+      # absent (self-hosted, no key) this whole step is skipped and OpenHands
+      # comes up for manual BYO-key config. We talk to OpenHands' OWN API on
+      # 127.0.0.1:8000 (unauthenticated in OSS mode) — self-validating, and it
+      # bypasses the in-box lock below (which guards the public :8080 only).
+      - |
+        if [ -n "${CONTAINARIUM_MODEL_GATEWAY_URL:-}" ] && [ -n "${CONTAINARIUM_GATEWAY_TOKEN:-}" ]; then
+          if ! command -v curl >/dev/null 2>&1; then
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update -qq >/dev/null 2>&1 && apt-get install -y -qq curl >/dev/null 2>&1 || true
+          fi
+          if ! command -v curl >/dev/null 2>&1; then
+            echo 'agent-workspace: curl unavailable; skipped model-gateway seed' >&2
+          else
+            OH=http://127.0.0.1:8000
+            # Google's OpenAI-compatible surface sits under /v1beta/openai of the
+            # gateway's per-provider base; LiteLLM's openai handler appends
+            # /chat/completions and Bearer-authenticates with the scoped token.
+            BASE="${CONTAINARIUM_MODEL_GATEWAY_URL}/v1beta/openai"
+            TOK="$CONTAINARIUM_GATEWAY_TOKEN"
+            # Wait for the freshly-started OpenHands API to accept requests
+            # (if/then, not `[ ] && break`, so `set -e` doesn't abort the wait).
+            for i in $(seq 1 90); do
+              code=$(curl -s -o /dev/null -w '%{http_code}' "$OH/api/v1/settings" || echo 000)
+              if [ "$code" != "000" ]; then break; fi
+              sleep 2
+            done
+            # 1. Create the base settings doc + set the active LLM (deep-merged).
+            curl -fsS -X POST "$OH/api/v1/settings" -H 'Content-Type: application/json' \
+              -d "{\"agent_settings_diff\":{\"llm\":{\"model\":\"openai/gemini-2.5-flash\",\"base_url\":\"$BASE\",\"api_key\":\"$TOK\"}}}" \
+              >/dev/null || echo 'agent-workspace: base settings POST failed' >&2
+            # 2. Seed the switchable Gemini profiles (all gateway-backed, same token).
+            for nm in gemini-flash:gemini-2.5-flash gemini-pro:gemini-2.5-pro; do
+              name="${nm%%:*}"; model="${nm##*:}"
+              curl -fsS -X POST "$OH/api/v1/settings/profiles/$name" -H 'Content-Type: application/json' \
+                -d "{\"llm\":{\"model\":\"openai/$model\",\"base_url\":\"$BASE\",\"api_key\":\"$TOK\"},\"include_secrets\":true}" \
+                >/dev/null || echo "agent-workspace: profile $name POST failed" >&2
+            done
+            # 3. Activate the default profile (points active + agent_settings.llm at it).
+            curl -fsS -X POST "$OH/api/v1/settings/profiles/gemini-flash/activate" \
+              >/dev/null || echo 'agent-workspace: activate failed' >&2
+          fi
+        fi
       # In-box auth proxy on :8080 → 127.0.0.1:8000. Two ways in: HTTP basic
       # auth, OR a session cookie the proxy itself issues on a successful
       # basic-auth response. The cookie is SameSite=None so the browser sends it
@@ -222,6 +274,28 @@ recipes:
           auto_https off
         }
         :8080 {
+          # Lock the model config to the platform-managed profiles: switching the
+          # active model (activate) and reading settings stay open, but creating
+          # or editing a profile, the generic settings write, and provider-secret
+          # writes are denied — so the canvas can only use the managed gateway and
+          # a user can't paste their own key or point it elsewhere. These deny
+          # handles run before the auth/proxy handles below; denying pre-auth is
+          # safe (never a downgrade). Seeding bypasses this (it hits :8000).
+          # Only the bare /profiles/{name} (one segment) is a save — */activate
+          # and */rename have an extra segment, matched precisely with path_regexp.
+          @settings_write { method POST; path /api/v1/settings }
+          @profile_save { method POST; path_regexp ^/api/v1/settings/profiles/[^/]+$ }
+          @profile_rename { method POST; path_regexp ^/api/v1/settings/profiles/[^/]+/rename$ }
+          @profile_delete { method DELETE; path /api/v1/settings/profiles/* }
+          @secrets_write {
+            method POST PUT DELETE
+            path /api/v1/secrets /api/v1/secrets/*
+          }
+          handle @settings_write { respond "model configuration is managed by the platform" 403 }
+          handle @profile_save { respond "model configuration is managed by the platform" 403 }
+          handle @profile_rename { respond "model configuration is managed by the platform" 403 }
+          handle @profile_delete { respond "model configuration is managed by the platform" 403 }
+          handle @secrets_write { respond "model configuration is managed by the platform" 403 }
           # Zero-click bootstrap: the console opens /__ws_login?t=<token>; the
           # proxy sets the SameSite=None cookie and redirects to the app, so no
           # sign-in prompt is ever shown in the embedded iframe.

--- a/pkg/pb/containarium/v1/recipe.pb.go
+++ b/pkg/pb/containarium/v1/recipe.pb.go
@@ -324,9 +324,17 @@ type Recipe struct {
 	// Shell commands run inside the container after it is up (e.g. the
 	// `podman run ...` that starts the app, plus model warm-up). Same trust
 	// level as a stack's post_install: these ship in-tree and are reviewed.
-	PostStart     []string `protobuf:"bytes,11,rep,name=post_start,json=postStart,proto3" json:"post_start,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	PostStart []string `protobuf:"bytes,11,rep,name=post_start,json=postStart,proto3" json:"post_start,omitempty"`
+	// When non-empty, the daemon brokers this recipe's model calls through the
+	// managed model-gateway for the named provider (e.g. "gemini-openai"): it
+	// mints a scoped, revocable gateway token and exports
+	// CONTAINARIUM_MODEL_GATEWAY_URL + CONTAINARIUM_GATEWAY_TOKEN into post_start,
+	// so the box uses the platform key (metered, never leaked) instead of one the
+	// user supplies. Inert when the daemon holds no key for the provider — the
+	// box then comes up unconfigured (self-hosted default).
+	ModelGatewayProvider string `protobuf:"bytes,12,opt,name=model_gateway_provider,json=modelGatewayProvider,proto3" json:"model_gateway_provider,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Recipe) Reset() {
@@ -434,6 +442,13 @@ func (x *Recipe) GetPostStart() []string {
 		return x.PostStart
 	}
 	return nil
+}
+
+func (x *Recipe) GetModelGatewayProvider() string {
+	if x != nil {
+		return x.ModelGatewayProvider
+	}
+	return ""
 }
 
 // ListRecipesRequest is the request to list available recipes.
@@ -932,7 +947,7 @@ const file_containarium_v1_recipe_proto_rawDesc = "" +
 	"\vdescription\x18\x03 \x01(\tR\vdescription\x12\x12\n" +
 	"\x04type\x18\x04 \x01(\tR\x04type\x12\x18\n" +
 	"\adefault\x18\x05 \x01(\tR\adefault\x12\x1a\n" +
-	"\brequired\x18\x06 \x01(\bR\brequired\"\xfc\x03\n" +
+	"\brequired\x18\x06 \x01(\bR\brequired\"\xb2\x04\n" +
 	"\x06Recipe\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
@@ -948,7 +963,8 @@ const file_containarium_v1_recipe_proto_rawDesc = "" +
 	" \x03(\v2\x1c.containarium.v1.RecipeParamR\n" +
 	"parameters\x12\x1d\n" +
 	"\n" +
-	"post_start\x18\v \x03(\tR\tpostStart\x1a6\n" +
+	"post_start\x18\v \x03(\tR\tpostStart\x124\n" +
+	"\x16model_gateway_provider\x18\f \x01(\tR\x14modelGatewayProvider\x1a6\n" +
 	"\bEnvEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x14\n" +

--- a/proto/containarium/v1/recipe.proto
+++ b/proto/containarium/v1/recipe.proto
@@ -105,6 +105,15 @@ message Recipe {
   // `podman run ...` that starts the app, plus model warm-up). Same trust
   // level as a stack's post_install: these ship in-tree and are reviewed.
   repeated string post_start = 11;
+
+  // When non-empty, the daemon brokers this recipe's model calls through the
+  // managed model-gateway for the named provider (e.g. "gemini-openai"): it
+  // mints a scoped, revocable gateway token and exports
+  // CONTAINARIUM_MODEL_GATEWAY_URL + CONTAINARIUM_GATEWAY_TOKEN into post_start,
+  // so the box uses the platform key (metered, never leaked) instead of one the
+  // user supplies. Inert when the daemon holds no key for the provider — the
+  // box then comes up unconfigured (self-hosted default).
+  string model_gateway_provider = 12;
 }
 
 // ListRecipesRequest is the request to list available recipes.


### PR DESCRIPTION
## What
The managed **command-workspace**: LibreChat in an isolated box, wired to the platform model-gateway so the operator picks the models, the key stays on the host, and users can switch among curated models but can't bring their own.

Three reusable gateway pieces + the recipe that consumes them:

1. **Gateway `gemini-openai` provider** (`internal/modelgateway/providers.go`) — Gemini via Google's OpenAI-compatible surface, real key injected as Bearer (matches what LibreChat/LiteLLM speaks; our gateway already reads the scoped token from `Authorization`). Same `GEMINI_API_KEY`.
2. **`Recipe.model_gateway_provider`** (proto field 12) — when set and the daemon brokers that provider, `RecipeServer.gatewayEnvForRecipe` mints a scoped, revocable token and exports `CONTAINARIUM_MODEL_GATEWAY_URL/_TOKEN` into post_start. Inert on a keyless self-host daemon.
3. **`librechat` recipe** (`pkg/core/recipes/recipes.yaml`) — LibreChat + MongoDB via Podman; a custom endpoint pointed at the gateway with the token from env (no real key in the box, **no user-key field to lock**); curated models `gemini-2.5-flash/pro`; admin created from params, then self-registration locked off.

## Why LibreChat (not the earlier OpenHands seeding)
The first cut tried to seed/lock OpenHands' settings, but `agent-canvas` (OpenHands v1.28.1) has a per-version, **auth-gated** settings API — a losing fight (documented in this PR's history). LibreChat consumes the managed-model pattern **natively via config** (`apiKey` from env, `userProvide:false`), so the integration is config-driven: no API-seeding, no Caddy lock, no version chase. Validated end-to-end in a cloud-box spike (LibreChat → our gateway → Gemini, metered, user keys disabled). agent-workspace (OpenHands) is restored to its original BYO-key form — it stays the optional coding-canvas box.

## Verification
`go build`/`vet`/`test` green; gateway provider tests (gemini-openai proxy/Bearer/metering) + recipe gateway-seeding tests; `librechat` recipe loads with `model_gateway_provider=gemini-openai`. The `gemini-openai` path was live-proven (real Gemini completion, metered) during the spike.

## Follow-up
Live-validate the `librechat` recipe end-to-end on a cloud box (needs the workhorse on this branch — authorized swap, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)