### PR TITLE
feat(skills): ship a generic code-review skill in OSS + CLI demo script

### DIFF
--- a/docs/demos/agent-box-gateway-demo.sh
+++ b/docs/demos/agent-box-gateway-demo.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Containarium — DEMO: an AI agent in a throwaway, isolated box,
+#                       talking to models through YOUR own gateway.
+#
+#   Self-hosted · Apache-2.0 · your compute · your key · your audit log
+#   Target length when recorded: ~90 seconds.
+#
+# THE WEDGE (what this demo proves in one minute):
+#   1. A skill = a packaged agent (a box recipe + a typed manifest).
+#   2. `agent run` spins a disposable, network-isolated box, mints a token
+#      scoped to EXACTLY that skill's permissions, and runs the agent.
+#   3. The agent's model calls are brokered by the daemon's model-gateway:
+#      the provider API key lives on the HOST and NEVER enters the box —
+#      the box only ever holds a short-lived, revocable token. Every call
+#      is metered per tenant/skill/model.
+#   4. It's a box: tear it down, zero blast radius.
+#
+# -----------------------------------------------------------------------------
+# PREREQUISITES (operator, one-time — do this BEFORE recording):
+#
+#   * A reachable Containarium daemon ($SERVER below). Self-host:
+#       curl -fsSL https://containarium.dev/install.sh | sh   # (or build OSS)
+#
+#   * Turn on the gateway by giving the DAEMON one provider key in its env,
+#     then (re)start it. The key turns the model-gateway on automatically:
+#       # /etc/containarium/daemon.env
+#       GEMINI_API_KEY=...            # or ANTHROPIC_API_KEY / OPENAI_API_KEY
+#     The daemon logs on boot:
+#       "Model-gateway enabled (providers=[gemini ...]) — provider keys never leave the host"
+#
+#   The `code-review` skill below ships in OSS, so no extra pack is needed.
+#   (Opinionated/domain skills — PM, compliance — load from a pack via
+#    CONTAINARIUM_SKILLS_DIR; `hello-agent` is the zero-config smoke test.)
+#
+SERVER="${SERVER:-https://YOUR-DAEMON:8080}"
+SKILL="${SKILL:-code-review}"
+INPUT="${INPUT:-{\"brief\":\"Review this Go handler for bugs and security issues: func GetUser(w http.ResponseWriter, r *http.Request) { id := r.URL.Query().Get(\\\"id\\\"); row := db.QueryRow(\\\"SELECT name FROM users WHERE id = \\\" + id); ... }\"}}"
+# =============================================================================
+
+set -euo pipefail
+say() { printf '\n\033[1;36m# %s\033[0m\n' "$*"; sleep 1; }
+run() { printf '\033[1;32m$ %s\033[0m\n' "$*"; eval "$*"; }
+
+clear
+say "Containarium: run an AI agent in a disposable, isolated box — on your own model gateway."
+sleep 1
+
+# ---------------------------------------------------------------------------
+say "1/4  Skills are packaged agents: a box recipe + a typed manifest"
+say "      (system prompt, the scopes it's allowed, the peers it may call)."
+run "containarium agent list --server $SERVER"
+
+# ---------------------------------------------------------------------------
+say "2/4  Run one — ONE command. Notice: we never type an API key."
+run "containarium agent run $SKILL --input '$INPUT' --server $SERVER"
+say "      Containarium just: created an isolated LXC box, minted a JWT scoped to"
+say "      exactly this skill's permissions, ran the agent, and printed its review."
+
+# ---------------------------------------------------------------------------
+say "3/4  Custody + metering. The model call was brokered by YOUR gateway."
+say "      The provider key stayed on the host; the box held only a revocable token."
+say "      On the daemon host, every call is logged + metered:"
+printf '\033[1;32m$ journalctl -u containarium-daemon -n 20 | grep model-gateway\033[0m\n'
+printf '  model-gateway: tenant=agent-%s provider=gemini model=gemini-2.5-flash in=… out=…\n' "$SKILL"
+say "      (metering also streams to your metrics backend for per-tenant billing)."
+
+# ---------------------------------------------------------------------------
+say "4/4  It's a box. Disposable, isolated — tear it down, zero blast radius."
+run "containarium list --server $SERVER"
+say "      Remove the agent box (name shown above, e.g. agent-$SKILL):"
+printf '\033[1;32m$ containarium delete agent-%s --server %s\033[0m\n' "$SKILL" "$SERVER"
+
+# ---------------------------------------------------------------------------
+say "Self-hosted. Apache-2.0. Your compute, your key, your audit log."
+say "  github.com/FootprintAI/Containarium"

--- a/pkg/core/skills/skills.yaml
+++ b/pkg/core/skills/skills.yaml
@@ -5,10 +5,13 @@
 # allowed_scopes, seeds the system prompt + token + task input under
 # /etc/containarium/agent, and the in-box agent loop takes it from there.
 #
-# This catalog is the GENERIC MECHANISM only. The single entry below is a
-# deliberately task-agnostic reference skill that proves the runtime
-# end-to-end. Opinionated/domain skills (compliance packs, research crews,
-# etc.) are built on this mechanism and ship OUTSIDE this repo.
+# This catalog ships the GENERIC MECHANISM plus a small set of broadly-useful,
+# task-AGNOSTIC skills that work for any user (a neutral reference skill and a
+# code reviewer). OPINIONATED / DOMAIN catalogs — product-management packs,
+# compliance packs (ISO 27001, …), research crews, customer-specific
+# workflows — are built on this same mechanism and ship as EXTERNAL packs,
+# loaded at runtime via CONTAINARIUM_SKILLS_DIR (and, for the curated set,
+# Containarium Cloud). Keep this file generic; domain skills do not belong here.
 #
 # Invariants enforced at load (see skills.go validate):
 #   - recipe_id, system_prompt, and >=1 allowed_scope are required.
@@ -57,3 +60,35 @@ skills:
       description: A neutral reference agent that relays a task to a peer.
       capabilities:
         - relay
+
+  # code-review is a generic, broadly-useful developer skill — the first
+  # "does real work" skill in OSS. It's deliberately domain-AGNOSTIC (any
+  # codebase, any language) so it belongs in the open catalog, unlike the
+  # opinionated PM / compliance packs that ship as external/Cloud packs.
+  # No `model` is pinned: it runs on whatever engine the box's gateway
+  # provider selects, so the same manifest works through any provider.
+  - id: code-review
+    name: Code Review
+    description: Reviews code or a diff for correctness bugs, security issues, and high-value improvements; returns a structured JSON review.
+    recipe_id: agent-runtime
+    system_prompt: >-
+      You are a precise, senior code reviewer. Read the task input — a diff, a
+      file, or a description of code — and review it for correctness bugs,
+      security vulnerabilities, and concrete, high-value improvements. Prefer
+      actionable findings over style nits, and cite the specific location.
+      Return ONLY a JSON artifact of the form: {"summary": "<one paragraph>",
+      "findings": [{"file": "<path>", "line": <int>, "severity":
+      "high|medium|low", "issue": "<what is wrong and why>", "suggestion":
+      "<concrete fix>"}]}. If the input contains no reviewable code, say so in
+      "summary" and return an empty "findings" array.
+    allowed_scopes:
+      - containers:read
+    allowed_peers: []
+    agent_card:
+      id: code-review
+      name: Code Review
+      description: Reviews code/diffs for bugs, security issues, and improvements; returns structured findings.
+      capabilities:
+        - code-review
+        - bug-detection
+        - security-review

--- a/pkg/core/skills/skills_test.go
+++ b/pkg/core/skills/skills_test.go
@@ -113,6 +113,26 @@ func TestEmbeddedCatalogLoads(t *testing.T) {
 	if len(hello.AllowedScopes) == 0 {
 		t.Error("hello-agent declares no allowed_scopes")
 	}
+
+	// The generic code-review skill ships in OSS and must be well-formed.
+	cr, err := m.Get("code-review")
+	if err != nil {
+		t.Fatalf("code-review skill missing: %v", err)
+	}
+	if cr.GetRecipeId() != "agent-runtime" {
+		t.Errorf("code-review recipe_id = %q, want agent-runtime", cr.GetRecipeId())
+	}
+	if cr.SystemPrompt == "" {
+		t.Error("code-review has empty system_prompt")
+	}
+	if len(cr.AllowedScopes) == 0 {
+		t.Error("code-review declares no allowed_scopes")
+	}
+	// Provider-agnostic: no model pinned, so it runs on whatever engine the
+	// box's gateway provider selects.
+	if cr.Model != "" {
+		t.Errorf("code-review should not pin a model (provider-agnostic), got %q", cr.Model)
+	}
 }
 
 func TestValidateRejectsBadManifests(t *testing.T) {


### PR DESCRIPTION
## Why
OSS only shipped neutral reference skills (`hello-agent` / `relay-agent`) — they prove the runtime but don't do real work, so a demo or first-run lands flat. This adds the first **does-real-work** skill to the open catalog and a recordable CLI demo to show the wedge.

## What
- **`code-review` skill** (`pkg/core/skills/skills.yaml`): a broadly-useful, **domain-agnostic** developer skill (any codebase/language) that returns a structured JSON review — `{summary, findings:[{file,line,severity,issue,suggestion}]}`. No `model` pinned, so it runs on whatever engine the box's gateway provider selects (same manifest works through any provider).
- **Catalog header updated** to draw the open-core line explicitly: *OSS = mechanism + generic skills; opinionated/domain catalogs (PM packs, compliance packs, research crews) ship as external packs via `CONTAINARIUM_SKILLS_DIR` / Cloud.* Keeps domain content out of OSS by design.
- **`docs/demos/agent-box-gateway-demo.sh`**: a ~90-second recordable CLI demo of the wedge — `agent run` spins a disposable isolated box, mints a token scoped to exactly the skill's permissions, runs the agent through the daemon's model-gateway (**provider key on the host, never in the box, metered**), then teardown. Defaults to `code-review`.

## Verification
`go test ./pkg/core/skills/` green (new assertions for code-review: present, recipe `agent-runtime`, non-empty prompt, ≥1 scope, no pinned model). `agent list` shows the skill. `bash -n` clean on the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)