### PR TITLE
feat(librechat): optionally inject the Containarium MCP into the workspace

### DIFF
--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -306,6 +306,21 @@ recipes:
         description: LibreChat image tag to run (pin for reproducibility).
         type: string
         default: latest
+      # Optional: inject the Containarium MCP so the chat agent can operate the
+      # platform from the conversation (list/deploy boxes, expose ports, run
+      # skills). Both must be set to enable it. The TOKEN must be scoped +
+      # revocable and LEAST-PRIVILEGE — a chat agent is prompt-injectable, so it
+      # should carry only read + recipes:deploy + agents:run scopes, never
+      # delete / secrets / route-write. Scoping is the minter's job (the cloud
+      # mints an org-scoped token at deploy); the recipe wires what it's handed.
+      - name: mcp_server_url
+        label: MCP target API URL
+        description: Containarium API URL the in-box MCP targets (e.g. https://cloud.containarium.dev). Empty disables MCP injection.
+        type: string
+      - name: mcp_token
+        label: MCP scoped token
+        description: Scoped, revocable least-privilege Containarium token for the in-box MCP. Empty disables MCP injection.
+        type: password
     post_start:
       - mkdir -p /opt/lc /opt/lc/mongo
       - command -v curl >/dev/null 2>&1 && command -v openssl >/dev/null 2>&1 || { export DEBIAN_FRONTEND=noninteractive; apt-get update -qq && apt-get install -y -qq curl openssl >/dev/null; }
@@ -321,6 +336,25 @@ recipes:
         else
           printf 'version: 1.2.1\ncache: true\n' > /opt/lc/librechat.yaml
           echo 'librechat: no managed gateway seeded; configure a provider in LibreChat' >&2
+        fi
+      # Optional MCP injection: when mcp_server_url + mcp_token are set, install
+      # the Containarium MCP (stdio) and wire it into LibreChat so the chat agent
+      # can operate the platform (list/deploy boxes, expose ports, run skills),
+      # scoped to whatever the token allows (enforced server-side). LibreChat
+      # spawns the MCP command INSIDE its own container, so the binary + token are
+      # mounted in via $LC_MCP_MOUNTS (added to the librechat run below).
+      - |
+        LC_MCP_MOUNTS=""
+        if [ -n "${CONTAINARIUM_PARAM_MCP_SERVER_URL:-}" ] && [ -n "${CONTAINARIUM_PARAM_MCP_TOKEN:-}" ]; then
+          if curl -fsSL https://github.com/FootprintAI/Containarium/releases/latest/download/mcp-server-linux-amd64 -o /opt/lc/mcp-server 2>/dev/null; then
+            chmod +x /opt/lc/mcp-server
+            printf '%s' "$CONTAINARIUM_PARAM_MCP_TOKEN" > /opt/lc/ctn-token
+            chmod 600 /opt/lc/ctn-token
+            printf 'mcpServers:\n  containarium:\n    command: /usr/local/bin/mcp-server\n    env:\n      CONTAINARIUM_SERVER_URL: "%s"\n      CONTAINARIUM_JWT_TOKEN_FILE: "/opt/lc/ctn-token"\n' "$CONTAINARIUM_PARAM_MCP_SERVER_URL" >> /opt/lc/librechat.yaml
+            LC_MCP_MOUNTS="-v /opt/lc/mcp-server:/usr/local/bin/mcp-server:ro -v /opt/lc/ctn-token:/opt/lc/ctn-token:ro"
+          else
+            echo 'librechat: mcp-server download failed; skipping MCP injection' >&2
+          fi
         fi
       - |
         {
@@ -339,7 +373,7 @@ recipes:
         } > /opt/lc/.env
       - podman rm -f mongo librechat 2>/dev/null || true
       - podman run -d --name mongo --restart=always --network host -v /opt/lc/mongo:/data/db docker.io/library/mongo:7 >/dev/null
-      - 'podman run -d --name librechat --restart=always --network host --env-file /opt/lc/.env -v /opt/lc/librechat.yaml:/app/librechat.yaml:ro "ghcr.io/danny-avila/librechat:${CONTAINARIUM_PARAM_LIBRECHAT_VERSION}" >/dev/null'
+      - 'podman run -d --name librechat --restart=always --network host --env-file /opt/lc/.env -v /opt/lc/librechat.yaml:/app/librechat.yaml:ro ${LC_MCP_MOUNTS:-} "ghcr.io/danny-avila/librechat:${CONTAINARIUM_PARAM_LIBRECHAT_VERSION}" >/dev/null'
       # Wait for the API, create the admin from params (first user = admin), then
       # lock self-registration off and restart so only the admin can sign in.
       - |


### PR DESCRIPTION
Lets the LibreChat chat agent **operate the platform from the conversation** — list/deploy boxes, expose ports, run skills — by wiring our stdio `mcp-server` into LibreChat's `mcpServers`.

## What
Two new optional params on the `librechat` recipe: `mcp_server_url` + `mcp_token`. When **both** are set, post_start:
- pulls `mcp-server` from the latest release,
- writes the token to a `0600` file,
- appends an `mcpServers.containarium` block to `librechat.yaml` (command + `CONTAINARIUM_SERVER_URL` + token file),
- mounts the binary + token into the LibreChat container (LibreChat spawns the MCP command **inside** its own container).

Empty params → no MCP (safe default).

## Security
A chat agent is prompt-injectable, so the token **must be scoped, revocable, least-privilege** — read + `recipes:deploy` + `agents:run` only; never delete / secrets / route-write. The recipe wires whatever token it's handed; **scoping is the minter's job**. Scope enforcement is server-side, so an over-broad tool call is rejected by the API regardless of what the chat asks.

## Follow-up (the other half)
The **cloud mints an org-scoped token at deploy** and passes `mcp_server_url=https://cloud.containarium.dev` + `mcp_token=<scoped>` — that's the cloud-side change that turns this on for tenants (where org isolation must be enforced by the cloud CP, not a direct daemon hit). This PR lands the recipe mechanism; self-host operators can pass their own daemon URL + a scoped token today.

Validated: recipe loads with the new params + wiring step; `go test ./pkg/core/recipes/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)