### PR TITLE
fix(recipes): librechat MCP block needs type:stdio + args:[] (was crash-looping)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.1] - 2026-06-21
+
+### Fixed
+
+- **LibreChat crash-looped when the MCP was injected.** The `librechat` recipe
+  wrote an `mcpServers.containarium` block with only `command` + `env`, but
+  LibreChat's config schema requires the stdio MCP variant to carry `type: stdio`
+  and an `args` array. Without them the discriminated union fell through to the
+  URL-based variants and validation failed (`ZodError: args/url Required`), so
+  LibreChat exited on every boot and the box served 502. The block now emits
+  `type: stdio` and `args: []`. (Existing boxes need a redeploy or a one-line
+  config patch; new boxes are correct.)
+
 ## [0.36.0] - 2026-06-21
 
 ### Added

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -350,7 +350,7 @@ recipes:
             chmod +x /opt/lc/mcp-server
             printf '%s' "$CONTAINARIUM_PARAM_MCP_TOKEN" > /opt/lc/ctn-token
             chmod 600 /opt/lc/ctn-token
-            printf 'mcpServers:\n  containarium:\n    command: /usr/local/bin/mcp-server\n    env:\n      CONTAINARIUM_SERVER_URL: "%s"\n      CONTAINARIUM_JWT_TOKEN_FILE: "/opt/lc/ctn-token"\n' "$CONTAINARIUM_PARAM_MCP_SERVER_URL" >> /opt/lc/librechat.yaml
+            printf 'mcpServers:\n  containarium:\n    type: stdio\n    command: /usr/local/bin/mcp-server\n    args: []\n    env:\n      CONTAINARIUM_SERVER_URL: "%s"\n      CONTAINARIUM_JWT_TOKEN_FILE: "/opt/lc/ctn-token"\n' "$CONTAINARIUM_PARAM_MCP_SERVER_URL" >> /opt/lc/librechat.yaml
             LC_MCP_MOUNTS="-v /opt/lc/mcp-server:/usr/local/bin/mcp-server:ro -v /opt/lc/ctn-token:/opt/lc/ctn-token:ro"
           else
             echo 'librechat: mcp-server download failed; skipping MCP injection' >&2


### PR DESCRIPTION
## Problem

A LibreChat workspace box with the Containarium MCP injected (`mcp_server_url` + `mcp_token` set) **crash-loops on boot** and serves **502**. The recipe's post_start wrote:

```yaml
mcpServers:
  containarium:
    command: /usr/local/bin/mcp-server
    env: ...
```

LibreChat's config schema (v1.2.1 / LibreChat v0.8.6) treats `mcpServers.*` as a discriminated union. The stdio variant requires **`args`** (array) and the canonical form carries **`type: stdio`**; without them the value can't match the stdio variant and falls through to the URL-based variants, so validation fails:

```
ZodError: mcpServers.containarium.args  Required (expected array)
ZodError: mcpServers.containarium.url   Required (expected string)
error: Exiting due to invalid configuration.
```

→ LibreChat exits every boot, never binds :3080, box 502s. Found live on a deployed workspace box (RestartCount 296).

## Fix

Emit `type: stdio` and `args: []` in the injected block.

```yaml
mcpServers:
  containarium:
    type: stdio
    command: /usr/local/bin/mcp-server
    args: []
    env: ...
```

`make test ./pkg/core/recipes/` green. Existing boxes need a redeploy (or a one-line config patch); new boxes are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)