### PR TITLE
fix(mcp,recipes): static mcp-server + readable token so the in-box MCP connects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.2] - 2026-06-21
+
+### Fixed
+
+- **In-box MCP never connected in a LibreChat workspace.** Two bugs, both in the
+  `librechat` recipe path:
+  - **`mcp-server` couldn't execute in the LibreChat container.** It was built
+    natively on a linux/amd64 runner with CGO enabled → a glibc-dynamic binary
+    (needs `/lib64/ld-linux-x86-64.so.2`), but LibreChat's image is Alpine/musl,
+    so the spawn failed with `exec: No such file or directory` and the MCP loaded
+    0 tools. `mcp-server` is a pure-Go REST/gRPC client; it's now built with
+    `CGO_ENABLED=0` (fully static, runs on any libc).
+  - **The MCP token was unreadable.** The recipe wrote `ctn-token` as `0600`
+    owned by root, but LibreChat (and the `mcp-server` it spawns) run as the
+    `node` user (uid 1000) and the token is bind-mounted read-only → permission
+    denied. The recipe now writes it `0644` (single-tenant box; the token is a
+    scoped, revocable, least-privilege credential).
+
 ## [0.36.1] - 2026-06-21
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -114,24 +114,29 @@ build-all: proto web-ui swagger-ui ## Build for all platforms (includes Swagger 
 	@GOOS=windows GOARCH=amd64 go build $(GO_TAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-windows-amd64.exe cmd/containarium/main.go
 	@echo "==> Binaries built in $(BUILD_DIR)/"
 
+# NOTE: mcp-server is a pure-Go REST/gRPC client and is dropped into arbitrary
+# containers (e.g. LibreChat's Alpine/musl image as a stdio MCP). A native
+# linux/amd64 build leaves CGO enabled → a glibc-dynamic binary that fails with
+# "exec: No such file or directory" on musl (no /lib64/ld-linux-x86-64.so.2).
+# Force CGO_ENABLED=0 so the binary is fully static and runs on any libc.
 build-mcp: ## Build the MCP server binary
 	@echo "==> Building MCP server..."
 	@mkdir -p $(BUILD_DIR)
-	@go build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(MCP_BINARY_NAME) cmd/mcp-server/main.go
+	@CGO_ENABLED=0 go build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(MCP_BINARY_NAME) cmd/mcp-server/main.go
 	@echo "==> MCP server built: $(BUILD_DIR)/$(MCP_BINARY_NAME)"
 
 build-mcp-linux: ## Build MCP server for Linux (for deployment)
 	@echo "==> Building MCP server for Linux..."
 	@mkdir -p $(BUILD_DIR)
-	@GOOS=linux GOARCH=amd64 go build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(MCP_BINARY_NAME)-linux-amd64 cmd/mcp-server/main.go
+	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(MCP_BINARY_NAME)-linux-amd64 cmd/mcp-server/main.go
 	@echo "==> MCP server built: $(BUILD_DIR)/$(MCP_BINARY_NAME)-linux-amd64"
 
 build-mcp-all: ## Build MCP server for all platforms
 	@echo "==> Building MCP server for all platforms..."
 	@mkdir -p $(BUILD_DIR)
-	@GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(MCP_BINARY_NAME)-linux-amd64 cmd/mcp-server/main.go
-	@GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(MCP_BINARY_NAME)-darwin-amd64 cmd/mcp-server/main.go
-	@GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(MCP_BINARY_NAME)-darwin-arm64 cmd/mcp-server/main.go
+	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(MCP_BINARY_NAME)-linux-amd64 cmd/mcp-server/main.go
+	@CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(MCP_BINARY_NAME)-darwin-amd64 cmd/mcp-server/main.go
+	@CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o $(BUILD_DIR)/$(MCP_BINARY_NAME)-darwin-arm64 cmd/mcp-server/main.go
 	@echo "==> MCP server binaries built in $(BUILD_DIR)/"
 
 install-mcp: build-mcp ## Install the MCP server binary to /usr/local/bin (requires sudo)

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -349,7 +349,12 @@ recipes:
           if curl -fsSL https://github.com/FootprintAI/Containarium/releases/latest/download/mcp-server-linux-amd64 -o /opt/lc/mcp-server 2>/dev/null; then
             chmod +x /opt/lc/mcp-server
             printf '%s' "$CONTAINARIUM_PARAM_MCP_TOKEN" > /opt/lc/ctn-token
-            chmod 600 /opt/lc/ctn-token
+            # 0644, not 0600: LibreChat (and the mcp-server it spawns) run as the
+            # in-image 'node' user (uid 1000), and the token is bind-mounted in
+            # read-only — a root-only 0600 file is unreadable by node and the MCP
+            # silently fails to start. The box is single-tenant and the token is
+            # already a scoped, revocable, least-privilege credential.
+            chmod 644 /opt/lc/ctn-token
             printf 'mcpServers:\n  containarium:\n    type: stdio\n    command: /usr/local/bin/mcp-server\n    args: []\n    env:\n      CONTAINARIUM_SERVER_URL: "%s"\n      CONTAINARIUM_JWT_TOKEN_FILE: "/opt/lc/ctn-token"\n' "$CONTAINARIUM_PARAM_MCP_SERVER_URL" >> /opt/lc/librechat.yaml
             LC_MCP_MOUNTS="-v /opt/lc/mcp-server:/usr/local/bin/mcp-server:ro -v /opt/lc/ctn-token:/opt/lc/ctn-token:ro"
           else


### PR DESCRIPTION
## Problem

A LibreChat workspace box loads its configured MCP server but ends up with **0 tools** (`[MCP][containarium] Failed to connect to MCP server "containarium"`). The "operate the platform from chat" feature has never worked on any release. Two independent bugs:

### 1. `mcp-server` can't execute in the LibreChat container
LibreChat's image is **Alpine/musl**. The released `mcp-server-linux-amd64` is **glibc-dynamically-linked** — it requests `/lib64/ld-linux-x86-64.so.2`, which Alpine doesn't have:

```
$ readelf -l mcp-server | grep interpreter
  [Requesting program interpreter: /lib64/ld-linux-x86-64.so.2]
$ podman exec librechat /usr/local/bin/mcp-server
exec: No such file or directory          # ELF interpreter missing
```

Cause: the Makefile builds it on a native linux/amd64 runner **without `CGO_ENABLED=0`**, so CGO stays on and the `net`/`os/user` packages pull in a glibc dynamic link. `mcp-server` is a pure-Go REST/gRPC client and needs no CGO.

**Fix:** build all `mcp-server` targets with `CGO_ENABLED=0` → fully static, runs on musl / scratch / distroless / anywhere. Verified: `file` now reports `statically linked`.

### 2. The MCP token is unreadable
The `librechat` recipe wrote `ctn-token` as `0600` owned by root, but LibreChat (and the `mcp-server` it spawns) run as the `node` user (uid 1000) over a read-only bind mount → `Permission denied`.

**Fix:** write the token `0644`. The box is single-tenant and the token is already a scoped, revocable, least-privilege credential.

## Verification
- `CGO_ENABLED=0 ... go build cmd/mcp-server` → `ELF ... statically linked`
- `make build-mcp-linux` → static binary
- `go test ./pkg/core/recipes/` green

Existing boxes need the new static binary dropped in + the token chmod'd (or a redeploy); new boxes are correct after a workhorse roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)