### PR TITLE
feat(librechat): zero-click iframe access (in-box proxy + auth bootstrap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Zero-click iframe access for the LibreChat workspace.** The `librechat`
+  recipe now fronts LibreChat with an in-box Caddy proxy (the exposed port is the
+  proxy, 8080, not LibreChat's 3080) plus a tiny stdlib auth helper. The helper
+  mints a single-use, 120-second handoff token (`/__mint`, reachable only in-box)
+  and a `/__ws_login?t=` bootstrap that does one fresh LibreChat login and
+  re-emits the session cookies as `SameSite=None; Secure` so they survive a
+  cross-site iframe; the proxy rewrites LibreChat's `SameSite=Strict` cookies to
+  `None` so refresh rotation keeps working embedded. `GetWorkspaceAccess` now
+  supports librechat (mints via the helper; falls back to the static
+  agent-workspace token), so the console can embed the workspace with no
+  re-login. LibreChat's own `/login` still works through the proxy as a fallback.
+
 ## [0.36.2] - 2026-06-21
 
 ### Fixed

--- a/internal/server/recipe_server.go
+++ b/internal/server/recipe_server.go
@@ -122,11 +122,12 @@ func (s *RecipeServer) GetRecipe(ctx context.Context, req *pb.GetRecipeRequest) 
 	return &pb.GetRecipeResponse{Recipe: r}, nil
 }
 
-// GetWorkspaceAccess returns a zero-click bootstrap URL for an agent-workspace
-// box: it reads the box's in-box auth proxy token (written to
-// /opt/wsauth/token by the agent-workspace recipe) and composes the
-// /__ws_login URL the console embeds in an iframe to authenticate the
-// workspace UI without showing a sign-in prompt.
+// GetWorkspaceAccess returns a zero-click bootstrap URL for a workspace box
+// (librechat or agent-workspace): it obtains the box's in-box auth token —
+// minted single-use by the librechat helper, or read from the static
+// /opt/wsauth/token for agent-workspace — and composes the /__ws_login URL the
+// console embeds in an iframe to authenticate the workspace UI without showing a
+// sign-in prompt.
 func (s *RecipeServer) GetWorkspaceAccess(ctx context.Context, req *pb.GetWorkspaceAccessRequest) (*pb.GetWorkspaceAccessResponse, error) {
 	// containers:write, not read: this mints an interactive-access credential
 	// (the in-box session token + a zero-click /__ws_login URL), so it is a
@@ -142,12 +143,32 @@ func (s *RecipeServer) GetWorkspaceAccess(ctx context.Context, req *pb.GetWorksp
 	}
 
 	containerName := req.Name + "-container"
-	stdout, _, err := s.containers.manager.ExecWithOutput(containerName, []string{"cat", "/opt/wsauth/token"})
-	if err != nil {
-		return nil, status.Errorf(codes.NotFound,
-			"no workspace token on %s (is this an agent-workspace box?): %v", containerName, err)
+
+	// Two workspace flavours expose a /__ws_login bootstrap, with different
+	// token semantics:
+	//   * librechat: an in-box helper mints a SINGLE-USE, short-lived token on
+	//     127.0.0.1:9099/__mint and does a fresh LibreChat login per access
+	//     (LibreChat rotates its refresh token, so a session can't be replayed).
+	//     Its exposed subdomain is "<name>-chat".
+	//   * agent-workspace: a STATIC per-box token in /opt/wsauth/token (the
+	//     proxy IS the auth). Its subdomain is "<name>-workspace".
+	// Probe the helper first (preferred, single-use); fall back to the static
+	// token so both recipe shapes work without the daemon tracking the recipe.
+	var token, subdomain string
+	if out, _, err := s.containers.manager.ExecWithOutput(containerName,
+		[]string{"curl", "-s", "--max-time", "3", "http://127.0.0.1:9099/__mint"}); err == nil {
+		if t := strings.TrimSpace(out); t != "" {
+			token, subdomain = t, req.Name+"-chat"
+		}
 	}
-	token := strings.TrimSpace(stdout)
+	if token == "" {
+		out, _, err := s.containers.manager.ExecWithOutput(containerName, []string{"cat", "/opt/wsauth/token"})
+		if err != nil {
+			return nil, status.Errorf(codes.NotFound,
+				"no workspace access on %s (is this a workspace box?): %v", containerName, err)
+		}
+		token, subdomain = strings.TrimSpace(out), req.Name+"-workspace"
+	}
 	if token == "" {
 		return nil, status.Errorf(codes.NotFound, "empty workspace token on %s", containerName)
 	}
@@ -155,10 +176,10 @@ func (s *RecipeServer) GetWorkspaceAccess(ctx context.Context, req *pb.GetWorksp
 	resp := &pb.GetWorkspaceAccessResponse{Token: token}
 	// Only compose a URL when routing is actually configured (same precondition
 	// as exposePorts): without a base domain the URL would be domain-less and
-	// unusable, so return just the token and let the caller surface that.
+	// unusable, so return just the token and let the caller surface that. (On the
+	// cloud the ossshim passthrough rebuilds the URL with the box's managed
+	// subdomain; this URL is for self-hosted OSS.)
 	if s.network != nil && s.network.baseDomain != "" {
-		// Mirror exposePorts' subdomain scheme: "<name>-workspace".
-		subdomain := req.Name + "-workspace"
 		resp.Url = "https://" + resolveFullDomain(subdomain, s.network.baseDomain) +
 			"/__ws_login?t=" + url.QueryEscape(token)
 	}

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -288,7 +288,14 @@ recipes:
       disk: 20GB
     model_gateway_provider: gemini-openai
     ports:
-      - container_port: 3080
+      # The exposed port is the in-box zero-click proxy (lcproxy / Caddy), NOT
+      # LibreChat directly. The proxy fronts LibreChat on 127.0.0.1:3080: it adds
+      # a /__ws_login?t= bootstrap (one-time login → SameSite=None session cookie)
+      # so the console can embed the workspace in an iframe with no re-login, and
+      # rewrites LibreChat's SameSite=Strict session cookies to None so they
+      # survive the cross-site iframe. LibreChat's own /login still works through
+      # the proxy as a fallback.
+      - container_port: 8080
         subdomain: chat
     parameters:
       - name: auth_email
@@ -323,7 +330,7 @@ recipes:
         type: password
     post_start:
       - mkdir -p /opt/lc /opt/lc/mongo
-      - command -v curl >/dev/null 2>&1 && command -v openssl >/dev/null 2>&1 || { export DEBIAN_FRONTEND=noninteractive; apt-get update -qq && apt-get install -y -qq curl openssl >/dev/null; }
+      - command -v curl >/dev/null 2>&1 && command -v openssl >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 || { export DEBIAN_FRONTEND=noninteractive; apt-get update -qq && apt-get install -y -qq curl openssl python3 >/dev/null; }
       - podman pull docker.io/library/mongo:7 >/dev/null
       - 'podman pull "ghcr.io/danny-avila/librechat:${CONTAINARIUM_PARAM_LIBRECHAT_VERSION}" >/dev/null'
       # LibreChat config: one custom endpoint at the platform gateway. apiKey is
@@ -392,3 +399,147 @@ recipes:
           >/dev/null 2>&1 || echo 'librechat: admin register failed (may already exist)' >&2
         sed -i 's/^ALLOW_REGISTRATION=true/ALLOW_REGISTRATION=false/' /opt/lc/.env
         podman restart librechat >/dev/null 2>&1 || true
+      # --- Zero-click iframe access ---------------------------------------
+      # LibreChat has its own login (JWT + refreshToken cookie) and rotates the
+      # refresh token on use, so a pre-stored session can't be replayed — the
+      # console must establish a FRESH session each time it embeds the workspace.
+      # Two in-box pieces do that, both on the box's host network:
+      #   * bootstrap.py (127.0.0.1:9099): /__mint issues a single-use, 120s
+      #     handoff token (only reachable in-box — the daemon's GetWorkspaceAccess
+      #     curls it); /__ws_login?t= validates+consumes the token, logs into
+      #     LibreChat once with the admin creds, and re-emits the session cookies
+      #     as SameSite=None;Secure so they survive a cross-site iframe.
+      #   * lcproxy (Caddy :8080, the EXPOSED port): routes /__ws_login* to the
+      #     helper and everything else to LibreChat :3080, rewriting LibreChat's
+      #     SameSite=Strict session cookies to None so rotation keeps working in
+      #     the iframe. /login still works through the proxy as a fallback.
+      - mkdir -p /opt/wsauth
+      - podman pull docker.io/library/caddy:2 >/dev/null
+      # Admin creds for the helper's server-side login. 0600: only root reads it;
+      # the user owns the box anyway (they set this password), and it never leaves
+      # the box. Written via python3 so any special chars in the password survive.
+      - |
+        python3 - <<'PYEOF'
+        import json, os
+        json.dump({"email": os.environ["CONTAINARIUM_PARAM_AUTH_EMAIL"],
+                   "password": os.environ["CONTAINARIUM_PARAM_AUTH_PASSWORD"]},
+                  open("/opt/wsauth/lc-creds", "w"))
+        PYEOF
+      - chmod 600 /opt/wsauth/lc-creds
+      - |
+        cat > /opt/wsauth/bootstrap.py <<'PYEOF'
+        # Zero-click auth bootstrap for the LibreChat workspace (stdlib only).
+        # /__mint        -> single-use, short-lived handoff token (in-box only)
+        # /__ws_login?t= -> consume token, fresh LibreChat login, set the session
+        #                   cookies rewritten to SameSite=None;Secure, redirect to /
+        import http.server, urllib.request, json, secrets, time, re
+        from urllib.parse import urlparse, parse_qs
+
+        LC = "http://127.0.0.1:3080"
+        CREDS = "/opt/wsauth/lc-creds"
+        TTL = 120
+        _tokens = {}  # token -> expiry epoch
+
+        def _gc():
+            now = time.time()
+            for k in [k for k, v in _tokens.items() if v < now]:
+                _tokens.pop(k, None)
+
+        def _samesite_none(c):
+            c = re.sub(r';\s*SameSite=\w+', '', c, flags=re.I)
+            if 'secure' not in c.lower():
+                c += '; Secure'
+            return c + '; SameSite=None'
+
+        class H(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                u = urlparse(self.path)
+                if u.path == "/__mint":
+                    _gc()
+                    t = secrets.token_urlsafe(24)
+                    _tokens[t] = time.time() + TTL
+                    self._raw(200, t.encode(), "text/plain")
+                    return
+                if u.path == "/__ws_login":
+                    _gc()
+                    t = (parse_qs(u.query).get("t") or [""])[0]
+                    if not t or _tokens.pop(t, None) is None:  # missing/expired/used
+                        self._redirect("/login")
+                        return
+                    cookies = self._login()
+                    if not cookies:
+                        self._redirect("/login")
+                        return
+                    self.send_response(302)
+                    self.send_header("Location", "/")
+                    for c in cookies:
+                        self.send_header("Set-Cookie", c)
+                    self.end_headers()
+                    return
+                self._raw(404, b"not found", "text/plain")
+
+            def _login(self):
+                try:
+                    creds = json.load(open(CREDS))
+                    body = json.dumps({"email": creds["email"],
+                                       "password": creds["password"]}).encode()
+                    req = urllib.request.Request(
+                        LC + "/api/auth/login", data=body,
+                        headers={"Content-Type": "application/json"}, method="POST")
+                    with urllib.request.urlopen(req, timeout=10) as r:
+                        return [_samesite_none(c) for c in (r.headers.get_all("Set-Cookie") or [])]
+                except Exception:
+                    return None
+
+            def _raw(self, code, body, ctype):
+                self.send_response(code)
+                self.send_header("Content-Type", ctype)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _redirect(self, loc):
+                self.send_response(302)
+                self.send_header("Location", loc)
+                self.end_headers()
+
+        if __name__ == "__main__":
+            http.server.HTTPServer(("127.0.0.1", 9099), H).serve_forever()
+        PYEOF
+      - |
+        cat > /etc/systemd/system/wsauth-bootstrap.service <<'EOF'
+        [Unit]
+        Description=LibreChat zero-click auth bootstrap
+        After=network.target
+        [Service]
+        ExecStart=/usr/bin/python3 /opt/wsauth/bootstrap.py
+        Restart=always
+        [Install]
+        WantedBy=multi-user.target
+        EOF
+        systemctl daemon-reload
+        systemctl enable --now wsauth-bootstrap.service >/dev/null 2>&1 || true
+      - |
+        cat > /opt/wsauth/Caddyfile <<'EOF'
+        {
+          auto_https off
+        }
+        :8080 {
+          handle /__ws_login* {
+            reverse_proxy 127.0.0.1:9099
+          }
+          handle {
+            reverse_proxy 127.0.0.1:3080 {
+              header_down Set-Cookie "SameSite=Strict" "SameSite=None"
+            }
+          }
+        }
+        EOF
+      - podman rm -f lcproxy 2>/dev/null || true
+      - |
+        podman run -d --name lcproxy --restart=always --network host \
+          -v /opt/wsauth/Caddyfile:/etc/caddy/Caddyfile:ro \
+          docker.io/library/caddy:2 >/dev/null


### PR DESCRIPTION
## Why

The cloud Workspace tab should embed the LibreChat workspace **in an iframe** with **no re-login** for the already-authenticated user. LibreChat has its own auth (JWT + `refreshToken` cookie) with two obstacles: (1) it sets cookies `SameSite=Strict`, which a cross-site iframe won't send; (2) it rotates/invalidates refresh tokens on use, so a pre-stored session can't be replayed. So zero-click requires a **fresh login per embed** plus a **cookie-SameSite rewrite**.

## What

The `librechat` recipe now fronts LibreChat with two in-box pieces (host network):

- **`bootstrap.py`** (`127.0.0.1:9099`, stdlib only, systemd-managed):
  - `GET /__mint` — issues a **single-use, 120s** handoff token. Reachable only in-box (Caddy doesn't route it); the daemon's `GetWorkspaceAccess` curls it.
  - `GET /__ws_login?t=` — validates + consumes the token, does **one fresh LibreChat login** with the admin creds (0600 file), and re-emits the session cookies as `SameSite=None; Secure`, then 302 → `/`.
- **`lcproxy`** (Caddy `:8080`, now the **exposed** port): `/__ws_login*` → helper; everything else → LibreChat `:3080`, rewriting `SameSite=Strict` cookies → `None` so refresh rotation keeps working embedded. LibreChat's own `/login` still works through the proxy as a fallback.

`GetWorkspaceAccess` generalised: probes the helper `/__mint` (librechat, single-use) and falls back to the static `/opt/wsauth/token` (agent-workspace), composing the `/__ws_login?t=` URL. On the cloud, the ossshim passthrough rebuilds the URL with the box's managed subdomain.

## Security

- Handoff token is **single-use + 120s** and only mintable in-box → the public `/__ws_login` can't be brute-forced or replayed.
- Admin creds live in a 0600 file the user already owns (single-tenant box); never leave the box.

Tests: `go test ./internal/server/ ./pkg/core/recipes/` green; recipe YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)