### PR TITLE
chore(release): cut v0.37.0 — zero-click iframe workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-06-21
+
 ### Added
 
 - **Zero-click iframe access for the LibreChat workspace.** The `librechat`


### PR DESCRIPTION
Cuts OSS v0.37.0 (zero-click iframe access for the LibreChat workspace; in-box proxy + auth bootstrap, #762). CHANGELOG [Unreleased] → [0.37.0].

🤖 Generated with [Claude Code](https://claude.com/claude-code)