### PR TITLE
chore(release): cut v0.38.0 — workspace agent default + personalized owner + chat-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0] - 2026-06-21
+
 ### Added
 
 - **LibreChat workspace opens straight into a tool-equipped assistant.** The


### PR DESCRIPTION
Cuts OSS v0.38.0 (#764). CHANGELOG [Unreleased] → [0.38.0].

🤖 Generated with [Claude Code](https://claude.com/claude-code)