### PR TITLE
fix(librechat): give the workspace agent a system prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Workspace agent gets a system prompt.** The pre-created `librechat` agent had
+  no `instructions`, so the model inferred its whole role from its tool names and
+  deflected everything else with "I can only manage containers". It now ships with
+  a system prompt making it a helpful workspace assistant that *also* has the
+  platform tools, set via a PATCH after create (LibreChat's agent CREATE can drop
+  fields; PATCH persists `instructions` + `tools` reliably).
+
 ## [0.38.0] - 2026-06-21
 
 ### Added

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -425,10 +425,19 @@ recipes:
           if [ -n "${CONTAINARIUM_PARAM_MCP_SERVER_URL:-}" ] && [ -n "${CONTAINARIUM_PARAM_MCP_TOKEN:-}" ]; then
             TOOLS='["list_containers_mcp_containarium","get_container_mcp_containarium","get_metrics_mcp_containarium","list_recipes_mcp_containarium","deploy_recipe_mcp_containarium","list_routes_mcp_containarium","run_agent_skill_mcp_containarium","call_agent_mcp_containarium","run_crew_mcp_containarium"]'
           fi
+          # System prompt — without it the model infers its whole role from the
+          # tool names and deflects everything else with "I can only manage
+          # containers". This makes it a helpful workspace assistant that ALSO
+          # has platform tools. (Single line, no double quotes → safe in JSON.)
+          INSTR="You are the Containarium workspace assistant. Help the user with software development, DevOps, and general technical questions, and operate their Containarium platform when asked using your tools (list and deploy boxes, expose ports, run agent skills). Be concise and helpful. If you genuinely should not do something, say why on the merits — do not claim you can only manage containers."
           AID=$(curl -s -A "$UA" -X POST http://127.0.0.1:3080/api/agents -H "Authorization: Bearer $T" -H 'Content-Type: application/json' \
-            -d "{\"name\":\"Containarium Assistant\",\"provider\":\"Containarium (Gemini)\",\"model\":\"gemini-2.5-flash\",\"tools\":$TOOLS}" \
+            -d "{\"name\":\"Containarium Assistant\",\"provider\":\"Containarium (Gemini)\",\"model\":\"gemini-2.5-flash\",\"instructions\":\"$INSTR\",\"tools\":$TOOLS}" \
             | sed -E 's/.*"id":"(agent_[^"]+)".*/\1/')
           if printf '%s' "$AID" | grep -q '^agent_'; then
+            # Re-assert instructions + tools via PATCH: LibreChat's agent CREATE
+            # can drop some fields, and PATCH reliably persists them.
+            curl -s -A "$UA" -X PATCH "http://127.0.0.1:3080/api/agents/$AID" -H "Authorization: Bearer $T" -H 'Content-Type: application/json' \
+              -d "{\"instructions\":\"$INSTR\",\"tools\":$TOOLS}" >/dev/null 2>&1 || true
             printf 'modelSpecs:\n  enforce: true\n  prioritize: true\n  list:\n    - name: "containarium-workspace"\n      label: "Containarium Workspace"\n      default: true\n      preset:\n        endpoint: "agents"\n        agent_id: "%s"\n' "$AID" >> /opt/lc/librechat.yaml
           else
             echo 'librechat: agent pre-create failed; leaving default endpoints' >&2


### PR DESCRIPTION
The pre-created agent had no `instructions`, so the model inferred its role from its tool names and deflected non-platform requests with "I can only manage containers" (a framing bug, not a deliberate guardrail). Adds a system prompt (helpful workspace assistant that *also* has the platform tools) and re-asserts `instructions`+`tools` via PATCH after create (LibreChat's agent CREATE can drop fields). `go test ./pkg/core/recipes/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)