### PR TITLE
fix(terraform): invalid sshd MOTD drop-in bricks SSH on reboot (spot startup)

### DIFF
--- a/terraform/modules/containarium/scripts/startup-spot.sh
+++ b/terraform/modules/containarium/scripts/startup-spot.sh
@@ -830,15 +830,23 @@ ALL ALL=(root) NOPASSWD: /usr/bin/incus exec *, /usr/bin/incus info *
 SUDOEOF
 chmod 0440 /etc/sudoers.d/containarium-incus
 
-# Suppress host MOTD for container users (admin users keep theirs).
+# Suppress host MOTD / last-login banner.
+# NOTE: PrintMotd and PrintLastLog are NOT valid inside a `Match` block — sshd
+# rejects the entire config and FAILS TO START on the next restart/reboot (it
+# only re-validates drop-ins on (re)start, so a bad one is latent until then,
+# then bricks SSH). Set them globally, and validate with `sshd -t` before
+# reloading so a malformed drop-in can never silently take sshd down.
 SSHD_DROPIN=/etc/ssh/sshd_config.d/containarium-motd.conf
 if [ -d /etc/ssh/sshd_config.d ]; then
     cat > "$SSHD_DROPIN" <<'SSHDEOF'
-Match User *,!ubuntu,!root
-    PrintMotd no
-    PrintLastLog no
+PrintMotd no
+PrintLastLog no
 SSHDEOF
-    systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null || true
+    if sshd -t 2>/dev/null; then
+        systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null || true
+    else
+        rm -f "$SSHD_DROPIN"
+    fi
 fi
 echo "✓ containarium-shell wrapper installed"
 


### PR DESCRIPTION
## Problem
The spot startup-script writes `/etc/ssh/sshd_config.d/containarium-motd.conf` with `PrintMotd`/`PrintLastLog` inside a `Match User` block. **Neither directive is allowed in a Match block** → sshd rejects its whole config and **fails to start on the next restart/reboot**. Because sshd only re-validates drop-ins on (re)start, the bad file is latent until a reboot — then it bricks SSH (`:22` → IAP "failed to connect to backend").

Hit live: a spot host (cloud-tenants pool) lost SSH after a machine-type resize/reboot; serial console showed `sshd: Directive 'PrintMotd' is not allowed within a Match block` → `ssh.service` failed → "start request repeated too quickly".

## Fix
- Set `PrintMotd no` / `PrintLastLog no` **globally** (the per-user intent isn't expressible via Match — neither is Match-allowed).
- Validate with `sshd -t` before reload; remove the drop-in if invalid, so a malformed config can never silently take sshd down again.

## Impact / note
This module is shared (dev `terraform/gce/` + prod). Any **spot** host rendered from this template has the latent bug and will lose SSH on its next reboot until this lands. `startup.sh` (standard) and `startup-sentinel.sh` don't write this drop-in, so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)