### PR TITLE
chore(release): cut v0.40.0 — workspace skills as hidden personas + full LibreChat UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.0] - 2026-06-22
+
 ### Added
 
 - **Workspace skills are hidden personas in the chat (`skills` param).** A skill


### PR DESCRIPTION
Cuts **v0.40.0**. Moves `[Unreleased]` under `## [0.40.0] - 2026-06-22`.

Ships the workspace skills work:
- Skills as hidden model-spec personas (`skills` param) — #775
- Full LibreChat UI embed by default (`librechat_ui` param) — #774
- Fix: workspace chat hung on "Model spec mismatch" — #771

After merge, tag `v0.40.0` on main → triggers the release build (binaries incl. the static `mcp-server`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)