### PR TITLE
chore(release): cut v0.41.0 — workspace skills live-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.0] - 2026-06-22
+
 ### Added
 
 - **LibreChat workspace skills live-sync (no redeploy needed).** Installing or


### PR DESCRIPTION
Cuts **v0.41.0**. Ships in-box live-sync of workspace skills (#777) — panel install/uninstall reflects in a running box within ~60s, no redeploy. After merge, tag `v0.41.0` → release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)