### PR TITLE
fix(librechat): route box→cloud via core-caddy (fixes in-box MCP + skill live-sync)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Workspace box can now reach the cloud API (fixes in-box MCP + skill
+  live-sync).** A box on the workhorse host can't reach the public cloud apex —
+  it hairpins back to the same host — so the in-box MCP (`CONTAINARIUM_SERVER_URL`)
+  and the skill live-sync poll both got connection failures. The `librechat`
+  recipe now resolves **core-caddy** (the host reverse proxy that already serves
+  the apex vhost, reachable on the container bridge by name), adds an `/etc/hosts`
+  entry mapping the apex hostname to it, and uses `http://` (core-caddy `:443`
+  needs PROXY-protocol; `:80` is open and routes by `Host`). Both the MCP server
+  URL and the live-sync `SKILLS_URL` use this internal route; the sync script
+  self-heals the `/etc/hosts` entry each run. Falls back to the original URL when
+  core-caddy isn't resolvable (standalone / non-cloud deploys reach the apex
+  directly). Refs the cloud hairpin issue.
+
 ## [0.41.0] - 2026-06-22
 
 ### Added

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -388,14 +388,30 @@ recipes:
             # silently fails to start. The box is single-tenant and the token is
             # already a scoped, revocable, least-privilege credential.
             chmod 644 /opt/lc/ctn-token
-            printf 'mcpServers:\n  containarium:\n    type: stdio\n    command: /usr/local/bin/mcp-server\n    args: []\n    env:\n      CONTAINARIUM_SERVER_URL: "%s"\n      CONTAINARIUM_JWT_TOKEN_FILE: "/opt/lc/ctn-token"\n' "$CONTAINARIUM_PARAM_MCP_SERVER_URL" >> /opt/lc/librechat.yaml
+            # Box→cloud reachability: a box on the workhorse host CAN'T reach the
+            # public cloud apex — it hairpins back to the same host (so both the
+            # in-box MCP and the skill live-sync would get connection failures).
+            # But core-caddy — the host reverse proxy that already serves the apex
+            # vhost — is reachable on the container bridge BY NAME. So point the
+            # apex hostname at core-caddy via /etc/hosts and use http:// (core-caddy
+            # :443 requires PROXY-protocol, which a box can't send; :80 is open and
+            # routes by Host header). Falls back to the original URL when core-caddy
+            # isn't resolvable (standalone / non-cloud deploys reach the apex directly).
+            APEX_HOST=$(printf '%s' "$CONTAINARIUM_PARAM_MCP_SERVER_URL" | sed -E 's#^[a-z]+://##; s#/.*##; s#:.*##')
+            CADDY_IP=$(getent hosts containarium-core-caddy 2>/dev/null | awk '{print $1}' | head -1)
+            if [ -n "$CADDY_IP" ] && [ -n "$APEX_HOST" ]; then
+              grep -q " $APEX_HOST\$" /etc/hosts 2>/dev/null || echo "$CADDY_IP $APEX_HOST" >> /etc/hosts
+              MCP_URL="http://$APEX_HOST"
+            else
+              MCP_URL="$CONTAINARIUM_PARAM_MCP_SERVER_URL"
+            fi
+            printf 'mcpServers:\n  containarium:\n    type: stdio\n    command: /usr/local/bin/mcp-server\n    args: []\n    env:\n      CONTAINARIUM_SERVER_URL: "%s"\n      CONTAINARIUM_JWT_TOKEN_FILE: "/opt/lc/ctn-token"\n' "$MCP_URL" >> /opt/lc/librechat.yaml
             LC_MCP_MOUNTS="-v /opt/lc/mcp-server:/usr/local/bin/mcp-server:ro -v /opt/lc/ctn-token:/opt/lc/ctn-token:ro"
-            # Drop the live-sync config (URL + token path). The same MCP token
-            # lets the box poll the cloud's installed-skill set and re-render
-            # personas without a redeploy. This file's PRESENCE later arms the
+            # Drop the live-sync config (URL + token path + apex host for the sync
+            # script /etc/hosts self-heal). This file's PRESENCE later arms the
             # timer (the units are written + enabled further down, after they
             # exist — this MCP step runs before them).
-            printf 'SKILLS_URL=%s/v1/recipes/workspace/skills\nTOKEN_FILE=/opt/lc/ctn-token\n' "$CONTAINARIUM_PARAM_MCP_SERVER_URL" > /opt/lc/skills-sync.env
+            printf 'SKILLS_URL=%s/v1/recipes/workspace/skills\nTOKEN_FILE=/opt/lc/ctn-token\nAPEX_HOST=%s\n' "$MCP_URL" "$APEX_HOST" > /opt/lc/skills-sync.env
           else
             echo 'librechat: mcp-server download failed; skipping MCP injection' >&2
           fi
@@ -524,6 +540,14 @@ recipes:
         [ -f /opt/lc/gen_modelspecs.py ] || exit 0
         TOK=$(cat "${TOKEN_FILE:-/opt/lc/ctn-token}" 2>/dev/null) || exit 0
         [ -n "$TOK" ] || exit 0
+        # Self-heal the apex->core-caddy /etc/hosts entry (a box restart can
+        # regenerate /etc/hosts, which would break the http-to-core-caddy route).
+        if [ -n "${APEX_HOST:-}" ]; then
+          CADDY_IP=$(getent hosts containarium-core-caddy 2>/dev/null | awk '{print $1}' | head -1)
+          if [ -n "$CADDY_IP" ] && ! grep -q " $APEX_HOST\$" /etc/hosts 2>/dev/null; then
+            echo "$CADDY_IP $APEX_HOST" >> /etc/hosts
+          fi
+        fi
         JSON=$(curl -fsS -m 10 -H "Authorization: Bearer $TOK" "$SKILLS_URL" 2>/dev/null) || exit 0
         NEW=$(printf '%s' "$JSON" | python3 /opt/lc/gen_modelspecs.py) || exit 0
         [ -n "$NEW" ] || exit 0


### PR DESCRIPTION
Implements the real fix for the hairpin issue (Containarium-cloud#679).

## Problem

A tenant box on the workhorse host **can't reach the public cloud apex** — it
hairpins back to the same host. So the **in-box MCP** (`CONTAINARIUM_SERVER_URL`)
and the **skill live-sync** poll both get connection failures (`000`). Only
features using the local model gateway work.

## Fix (recipe-only — no daemon/cloud change)

core-caddy — the host reverse proxy that already serves the apex vhost — **is
reachable on the container bridge by name** (`getent hosts containarium-core-caddy`).
The `librechat` recipe now, when MCP is wired:

1. Resolves `containarium-core-caddy` → its bridge IP.
2. Adds `/etc/hosts`: `<caddy-ip> <apex-host>`.
3. Uses `http://<apex>` for **both** the MCP `CONTAINARIUM_SERVER_URL` and the
   live-sync `SKILLS_URL` (core-caddy `:443` needs PROXY-protocol a box can't
   send; `:80` is open and routes by `Host`).
4. The sync script **self-heals** the `/etc/hosts` entry each run (a box restart
   can regenerate `/etc/hosts`).

Falls back to the original URL when core-caddy isn't resolvable (standalone /
non-cloud deploys reach the apex directly).

## Validation

Prototype (recorded on #679): `box → http://<apex>` with the apex routed to
core-caddy `:80` returns the skills JSON (200), and a corrupt-then-sync **healed
the box from the live cloud set**. This recipe automates exactly that.
`go test ./pkg/core/recipes/` + YAML parse green; apex-host extraction verified
for scheme/port/path variants.

## Rollout

Needs an OSS release + workhorse roll (recipe is daemon-embedded); then new/
redeployed boxes get both a working in-box MCP and live-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)