### PR TITLE
chore(release): cut v0.42.0 — box→cloud reachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0] - 2026-06-22
+
 ### Fixed
 
 - **Workspace box can now reach the cloud API (fixes in-box MCP + skill


### PR DESCRIPTION
Cuts **v0.42.0**. Ships the box→cloud reachability fix (#784) — the in-box MCP + skill live-sync now reach the cloud via core-caddy. After merge, tag `v0.42.0` → release build → roll the workhorse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)