### PR TITLE
chore(release): cut v0.43.0 — streaming chat metering + prompt-leak filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.0] - 2026-06-22
+
 ### Added
 
 - **Model-gateway meters the streaming chat path (input/output tokens).**


### PR DESCRIPTION
Cuts **v0.43.0**. Ships streaming chat token metering + the #670 layer-2 output filter (#786). After merge, tag `v0.43.0` → release build → roll the workhorse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)