### PR TITLE
fix(model-gateway): record streaming usage once (was double-counting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Streaming token metering double-counted usage.** The provider emits usage
+  cumulatively across multiple SSE chunks; the gateway recorded *each* usage
+  event, inflating the metered total (a single turn logged twice — `out=13` then
+  `out=20`). It now records usage **once**, with the final cumulative value.
+  (Regression in the v0.43.0 streaming metering.)
+
 ## [0.43.0] - 2026-06-22
 
 ### Added

--- a/internal/modelgateway/sse.go
+++ b/internal/modelgateway/sse.go
@@ -166,6 +166,10 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 	var pending strings.Builder // assembled, not-yet-emitted content
 	var emitted strings.Builder // already emitted content (for leak context)
 	redacted := false
+	// Usage arrives cumulatively across one or more events; record only the
+	// FINAL value once (recording each event would double-count).
+	var lastUsage Usage
+	haveUsage := false
 
 	writeContent := func(s string) error {
 		if s == "" {
@@ -203,8 +207,9 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 			}
 			continue
 		}
-		if ch.Usage != nil && onUsage != nil {
-			onUsage(parse(map[string]any{"usage": ch.Usage}))
+		if ch.Usage != nil {
+			lastUsage = parse(map[string]any{"usage": ch.Usage})
+			haveUsage = true
 		}
 
 		// Metering-only (no system prompt / filter disabled): pass the original
@@ -273,6 +278,11 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 	}
 	if loopErr == nil {
 		_, _ = dst.Write([]byte("data: [DONE]\n\n"))
+	}
+	// Meter once, with the final cumulative usage (recording each usage event
+	// would double-count — usage arrives cumulatively across chunks).
+	if haveUsage && onUsage != nil {
+		onUsage(lastUsage)
 	}
 	_ = dst.CloseWithError(loopErr)
 }

--- a/internal/modelgateway/sse_test.go
+++ b/internal/modelgateway/sse_test.go
@@ -140,3 +140,27 @@ func TestExtractSystemPrompt(t *testing.T) {
 		t.Fatal("requestModel failed")
 	}
 }
+
+// TestSSE_UsageRecordedOnceFinal: usage arrives cumulatively across chunks; the
+// meter must fire ONCE with the final value (not once per usage event).
+func TestSSE_UsageRecordedOnceFinal(t *testing.T) {
+	sse := chunk("hi", "stop") +
+		`data: {"choices":[],"usage":{"prompt_tokens":64,"completion_tokens":13}}` + "\n\n" +
+		`data: {"choices":[],"usage":{"prompt_tokens":64,"completion_tokens":20}}` + "\n\n" +
+		"data: [DONE]\n\n"
+	parse := func(b map[string]any) Usage {
+		u := subMap(b, "usage")
+		return Usage{InputTokens: num(u, "prompt_tokens"), OutputTokens: num(u, "completion_tokens")}
+	}
+	var calls int
+	var last Usage
+	pr, pw := io.Pipe()
+	go filterSSEStream(pw, io.NopCloser(strings.NewReader(sse)), "", parse, func(u Usage) { calls++; last = u })
+	_, _ = io.ReadAll(pr)
+	if calls != 1 {
+		t.Fatalf("onUsage called %d times, want 1 (no double-count)", calls)
+	}
+	if last.OutputTokens != 20 || last.InputTokens != 64 {
+		t.Fatalf("final usage = in:%d out:%d, want in:64 out:20", last.InputTokens, last.OutputTokens)
+	}
+}


### PR DESCRIPTION
Found during live verification of v0.43.0: a single streaming turn metered twice (`out=13` then `out=20`, same `in=64`) — the provider emits usage cumulatively across SSE chunks and `filterSSEStream` recorded each event. Now records usage **once** with the final cumulative value. Regression test added (two cumulative usage events → one record, final value). Patch to v0.43.0 → v0.43.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)