### PR TITLE
chore(release): cut v0.43.1 — fix streaming metering double-count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.1] - 2026-06-22
+
 ### Fixed
 
 - **Streaming token metering double-counted usage.** The provider emits usage


### PR DESCRIPTION
Patch: records streaming usage once (#788). After merge, tag `v0.43.1` → build → roll the workhorse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)