### PR TITLE
fix(librechat): in-box MCP over HTTPS + secure token perms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **In-box MCP now actually works (HTTPS + token perms).** The v0.42.0
+  reachability fix routed the in-box MCP over `http://core-caddy`, but the
+  `mcp-server` client refuses plaintext base URLs (security guard) — so the MCP
+  was reachable but rejected. core-caddy already serves the apex's **valid
+  wildcard cert** and accepts a bridge client's plain TLS (its `:443`
+  proxy-protocol wrapper only *requires* PROXY from the sentinel subnet), so the
+  recipe now keeps `https://` for the `/etc/hosts → core-caddy` route — same
+  scheme + valid TLS as an external client, only the name resolution is internal.
+  Also: the in-box token is now owned by the image's `node` user (uid 1000) with
+  `0600` (was world-readable `0644`) — the MCP refuses insecure token perms, and
+  a root-owned `0600` would be unreadable by `node`; uid-1000-owned `0600`
+  satisfies both. Verified: the real `mcp-server` lists the org's containers and
+  LibreChat reports `[MCP] Initialized with … 54 tools`.
+
 ## [0.43.1] - 2026-06-22
 
 ### Fixed

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -382,26 +382,33 @@ recipes:
           if curl -fsSL https://github.com/FootprintAI/Containarium/releases/latest/download/mcp-server-linux-amd64 -o /opt/lc/mcp-server 2>/dev/null; then
             chmod +x /opt/lc/mcp-server
             printf '%s' "$CONTAINARIUM_PARAM_MCP_TOKEN" > /opt/lc/ctn-token
-            # 0644, not 0600: LibreChat (and the mcp-server it spawns) run as the
-            # in-image 'node' user (uid 1000), and the token is bind-mounted in
-            # read-only — a root-only 0600 file is unreadable by node and the MCP
-            # silently fails to start. The box is single-tenant and the token is
-            # already a scoped, revocable, least-privilege credential.
-            chmod 644 /opt/lc/ctn-token
+            # Owned by the in-image 'node' user (uid 1000) with 0600. The
+            # mcp-server runs as node and REFUSES a token file with any non-owner
+            # r/w bit (insecure-perms guard) — so 0644 is rejected — but a
+            # root-owned 0600 is unreadable by node. uid-1000-owned 0600 satisfies
+            # both (rootful podman maps container uid 1000 → host uid 1000). The
+            # token is bind-mounted read-only; it's a scoped, revocable,
+            # least-privilege credential.
+            chown 1000:1000 /opt/lc/ctn-token
+            chmod 600 /opt/lc/ctn-token
             # Box→cloud reachability: a box on the workhorse host CAN'T reach the
             # public cloud apex — it hairpins back to the same host (so both the
             # in-box MCP and the skill live-sync would get connection failures).
             # But core-caddy — the host reverse proxy that already serves the apex
-            # vhost — is reachable on the container bridge BY NAME. So point the
-            # apex hostname at core-caddy via /etc/hosts and use http:// (core-caddy
-            # :443 requires PROXY-protocol, which a box can't send; :80 is open and
-            # routes by Host header). Falls back to the original URL when core-caddy
-            # isn't resolvable (standalone / non-cloud deploys reach the apex directly).
+            # vhost (with the valid wildcard cert) — is reachable on the container
+            # bridge BY NAME. So point the apex hostname at core-caddy via
+            # /etc/hosts and keep using https:// — core-caddy's :443 proxy_protocol
+            # wrapper only REQUIRES a PROXY header from the sentinel subnet; a
+            # bridge client's plain TLS is accepted and matched to the wildcard
+            # cert by SNI. Same scheme + valid TLS as an external client; the only
+            # change is the internal name resolution. Falls back to the original
+            # URL when core-caddy isn't resolvable (standalone / non-cloud deploys
+            # reach the apex directly).
             APEX_HOST=$(printf '%s' "$CONTAINARIUM_PARAM_MCP_SERVER_URL" | sed -E 's#^[a-z]+://##; s#/.*##; s#:.*##')
             CADDY_IP=$(getent hosts containarium-core-caddy 2>/dev/null | awk '{print $1}' | head -1)
             if [ -n "$CADDY_IP" ] && [ -n "$APEX_HOST" ]; then
               grep -q " $APEX_HOST\$" /etc/hosts 2>/dev/null || echo "$CADDY_IP $APEX_HOST" >> /etc/hosts
-              MCP_URL="http://$APEX_HOST"
+              MCP_URL="https://$APEX_HOST"
             else
               MCP_URL="$CONTAINARIUM_PARAM_MCP_SERVER_URL"
             fi


### PR DESCRIPTION
Completes the in-box MCP fix (your preference: real HTTPS, like the laptop — no plaintext).

## Two issues, both fixed in the recipe

1. **HTTPS, not http.** v0.42.0 routed the in-box MCP over `http://core-caddy`, but the `mcp-server` client **refuses plaintext base URLs** (security guard) — so the MCP reached the cloud but the request was rejected (this is the `list_containers` failure you hit). Turns out **no infra change is needed**: core-caddy serves the apex's **valid wildcard cert** and accepts a bridge client's plain TLS (its `:443` proxy-protocol wrapper only *requires* PROXY from the sentinel subnet; a bridge TLS handshake is matched to the cert by SNI). So the recipe keeps `https://` for the `/etc/hosts → core-caddy` route — same scheme + valid TLS as an external client.

2. **Token perms.** The token was world-readable `0644` (so the in-container `node` user could read it), but the MCP refuses insecure token perms. Now owned by `node` (uid 1000) + `0600` — readable by the MCP's own user and not flagged insecure.

## Verified live (real `mcp-server`, not curl)
- `list_containers` over HTTPS returned the org's containers.
- LibreChat: `[MCP][containarium] Initialized in: 57ms` / `[MCP] Initialized with 1 configured server and 54 tools`.

## Rollout
OSS release + workhorse roll; new/redeployed boxes get a working in-box MCP. (Applied live to `my-workspace111` already, so its MCP works now.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)