### PR TITLE
chore(release): cut v0.43.2 — in-box MCP over HTTPS + secure token perms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.2] - 2026-06-22
+
 ### Fixed
 
 - **In-box MCP now actually works (HTTPS + token perms).** The v0.42.0


### PR DESCRIPTION
Patch: in-box MCP now works (https to core-caddy + node-owned 0600 token) (#790). After merge, tag `v0.43.2` → build → roll the workhorse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)