### PR TITLE
fix(workspace): pin gemini-flash-latest, drop the slow pro pick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **LibreChat workspace recipe pins `gemini-flash-latest` and drops the `pro`
+  pick.** The recipe offered `["gemini-2.5-flash", "gemini-2.5-pro"]`; the `pro`
+  option is a reasoning model whose long pre-token think phase reads as a hung
+  chat (the UI streams nothing until reasoning finishes), and a pinned
+  point-version can be retired by the provider out from under us (Google has
+  already decommissioned `gemini-2.0-flash`, which 404s — and a 404 on the
+  streaming path hangs the client). The workspace now offers only
+  `gemini-flash-latest` (auto-tracks the current flash, so it never points at a
+  retired model) for the model list, `titleModel`, and every skill-persona
+  modelSpec. Existing boxes are unaffected until redeployed; the two live
+  workspaces were patched out-of-band.
+
 ## [0.43.2] - 2026-06-22
 
 ### Fixed

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -365,7 +365,7 @@ recipes:
       # gateway seeded → empty config, LibreChat falls back to its own provider.
       - |
         if [ -n "${CONTAINARIUM_MODEL_GATEWAY_URL:-}" ] && [ -n "${CONTAINARIUM_GATEWAY_TOKEN:-}" ]; then
-          printf 'version: 1.2.1\ncache: true\nendpoints:\n  custom:\n    - name: "Containarium (Gemini)"\n      apiKey: "${CTN_GATEWAY_TOKEN}"\n      baseURL: "%s/v1beta/openai"\n      models:\n        default: ["gemini-2.5-flash", "gemini-2.5-pro"]\n        fetch: false\n      titleConvo: true\n      titleModel: "gemini-2.5-flash"\n      modelDisplayLabel: "Containarium Gemini"\n' "$CONTAINARIUM_MODEL_GATEWAY_URL" > /opt/lc/librechat.yaml
+          printf 'version: 1.2.1\ncache: true\nendpoints:\n  custom:\n    - name: "Containarium (Gemini)"\n      apiKey: "${CTN_GATEWAY_TOKEN}"\n      baseURL: "%s/v1beta/openai"\n      models:\n        default: ["gemini-flash-latest"]\n        fetch: false\n      titleConvo: true\n      titleModel: "gemini-flash-latest"\n      modelDisplayLabel: "Containarium Gemini"\n' "$CONTAINARIUM_MODEL_GATEWAY_URL" > /opt/lc/librechat.yaml
         else
           printf 'version: 1.2.1\ncache: true\n' > /opt/lc/librechat.yaml
           echo 'librechat: no managed gateway seeded; configure a provider in LibreChat' >&2
@@ -523,7 +523,7 @@ recipes:
             out.append("      preset:")
             out.append('        endpoint: "Containarium (Gemini)"')
             out.append('        endpointType: "custom"')
-            out.append('        model: "gemini-2.5-flash"')
+            out.append('        model: "gemini-flash-latest"')
             out.append("        promptPrefix: " + json.dumps(instr))
         print("\n".join(out))
         PYEOF


### PR DESCRIPTION
## What

The LibreChat workspace recipe now offers **only `gemini-flash-latest`** instead
of `["gemini-2.5-flash", "gemini-2.5-pro"]` — for the model list, `titleModel`,
and every skill-persona modelSpec.

## Why ("gemini is hanging")

Two distinct causes, both presenting as a hung chat:

1. **`gemini-2.5-pro` think latency.** Pro is a reasoning model — it streams
   nothing until its think phase completes, so the UI spins for many seconds on
   any pick of pro. Looks hung; eventually completes.
2. **Pinned point-versions get retired.** Google has already decommissioned
   `gemini-2.0-flash` (`404 "no longer available"`). A 404 on the **streaming**
   path hangs the client (it waits for SSE that never comes) rather than erroring
   cleanly. A pinned `gemini-2.5-flash` can meet the same fate later.

`gemini-flash-latest` auto-tracks the current flash release, so it never points
at a retired model, and flash has no long pre-token think phase.

## Verification

Through the in-box gateway path (`/v1/model/gemini-openai/v1beta/openai`,
real `CTN_GATEWAY_TOKEN`): `gemini-flash-latest` streams **200 in 1.4s**. The
gateway, key, and SSE filter were all confirmed healthy; this is purely a model
pin.

## Scope

- **Recipe (this PR):** future boxes get flash-latest.
- **Live boxes (done out-of-band):** the two running workspaces
  (`my-workspace111`, `cld-c0bc85ff`) were patched to flash-latest + pro dropped
  and LibreChat restarted, for immediate effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
