### PR TITLE
fix(workspace): keep gemini-2.5-flash available alongside flash-latest (follow-up to #792)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chat (the UI streams nothing until reasoning finishes), and a pinned
   point-version can be retired by the provider out from under us (Google has
   already decommissioned `gemini-2.0-flash`, which 404s — and a 404 on the
-  streaming path hangs the client). The workspace now offers only
+  streaming path hangs the client). The workspace now defaults to
   `gemini-flash-latest` (auto-tracks the current flash, so it never points at a
-  retired model) for the model list, `titleModel`, and every skill-persona
-  modelSpec. Existing boxes are unaffected until redeployed; the two live
-  workspaces were patched out-of-band.
+  retired model) for `titleModel` and every skill-persona modelSpec, and offers
+  `["gemini-flash-latest", "gemini-2.5-flash"]` in the model list — keeping
+  `gemini-2.5-flash` available so conversations already pinned to it don't break
+  with "model not available". Only `gemini-2.5-pro` is dropped. Existing boxes
+  are unaffected until redeployed; the two live workspaces were patched
+  out-of-band.
 
 ## [0.43.2] - 2026-06-22
 

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -365,7 +365,7 @@ recipes:
       # gateway seeded → empty config, LibreChat falls back to its own provider.
       - |
         if [ -n "${CONTAINARIUM_MODEL_GATEWAY_URL:-}" ] && [ -n "${CONTAINARIUM_GATEWAY_TOKEN:-}" ]; then
-          printf 'version: 1.2.1\ncache: true\nendpoints:\n  custom:\n    - name: "Containarium (Gemini)"\n      apiKey: "${CTN_GATEWAY_TOKEN}"\n      baseURL: "%s/v1beta/openai"\n      models:\n        default: ["gemini-flash-latest"]\n        fetch: false\n      titleConvo: true\n      titleModel: "gemini-flash-latest"\n      modelDisplayLabel: "Containarium Gemini"\n' "$CONTAINARIUM_MODEL_GATEWAY_URL" > /opt/lc/librechat.yaml
+          printf 'version: 1.2.1\ncache: true\nendpoints:\n  custom:\n    - name: "Containarium (Gemini)"\n      apiKey: "${CTN_GATEWAY_TOKEN}"\n      baseURL: "%s/v1beta/openai"\n      models:\n        default: ["gemini-flash-latest", "gemini-2.5-flash"]\n        fetch: false\n      titleConvo: true\n      titleModel: "gemini-flash-latest"\n      modelDisplayLabel: "Containarium Gemini"\n' "$CONTAINARIUM_MODEL_GATEWAY_URL" > /opt/lc/librechat.yaml
         else
           printf 'version: 1.2.1\ncache: true\n' > /opt/lc/librechat.yaml
           echo 'librechat: no managed gateway seeded; configure a provider in LibreChat' >&2


### PR DESCRIPTION
## What

Follow-up to #792. Restores `gemini-2.5-flash` to the workspace model list so it
reads `["gemini-flash-latest", "gemini-2.5-flash"]` (was flash-latest only).

## Why

#792 narrowed the list to only `gemini-flash-latest`. That broke conversations
already pinned to `gemini-2.5-flash` — LibreChat rejects a conversation whose
model isn't in the endpoint's offered list:

> The model "gemini-2.5-flash" is not available for Containarium (Gemini).
> Please select a different model.

Keeping `gemini-2.5-flash` available resolves those sessions without the user
having to manually switch. `gemini-flash-latest` stays the **default** (first
entry) and is used by `titleModel` + every skill-persona modelSpec, so new
chats and personas still ride the auto-tracking pin. Only `gemini-2.5-pro`
remains dropped (the reasoning model whose pre-token think phase read as a hang).

## Scope

- **Recipe (this PR):** future boxes offer both flash models.
- **Live boxes (done out-of-band):** both running workspaces patched to
  `["gemini-flash-latest", "gemini-2.5-flash"]` and restarted; login pages 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
