### PR TITLE
feat(modelgateway): request-lifecycle observability (START/END + inflight gauge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Model-gateway request-lifecycle observability.** The gateway emitted only a
+  single metering log on completion — and only for *non-streaming* responses —
+  so for a streaming chat there was no way to tell whether a request was still
+  generating, finished, or hung. Every accepted request now logs a `START` and a
+  matching `END` line keyed by a monotonic request id, with status (ok/error),
+  HTTP code, stream flag, duration, and token usage; a streaming response that
+  ends without a usage event is flagged `warn=stream-ended-without-usage` (the
+  classic "looks hung" case). A new `GET /__gateway/status` endpoint exposes the
+  live gauge — `{inflight, completed, failed}` — so `inflight` stuck above zero
+  with no new completions is a directly observable "hung request" signal. The
+  per-usage metering log is folded into `END`; billing via the OTel sink is
+  unchanged.
+
 ### Changed
 
 - **LibreChat workspace recipe pins `gemini-flash-latest` and drops the `pro`

--- a/internal/modelgateway/gateway.go
+++ b/internal/modelgateway/gateway.go
@@ -10,6 +10,9 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 )
 
 // UsageSink receives every metered model call so token usage can be forwarded
@@ -41,6 +44,16 @@ type Config struct {
 type Gateway struct {
 	cfg   Config
 	meter *Meter
+
+	// Request-lifecycle observability: a monotonic request id, a live
+	// in-flight gauge, and lifetime completed/failed counters. These make
+	// "did the gateway finish this request or is it still running/hung?"
+	// answerable — from the START/END log pair per request and the live
+	// counts on /__gateway/status.
+	reqSeq    atomic.Uint64
+	inflight  atomic.Int64
+	completed atomic.Uint64
+	failed    atomic.Uint64
 }
 
 // New builds a Gateway.
@@ -68,6 +81,18 @@ func (g *Gateway) Handler() http.Handler {
 	mux.HandleFunc("/__gateway/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
+	})
+	// Live request-lifecycle gauge: how many model calls are in flight right
+	// now, and how many have completed/failed over the gateway's lifetime.
+	// `inflight` stuck above zero with no new completions is the "hung request"
+	// signal the per-request START/END logs let you drill into.
+	mux.HandleFunc("/__gateway/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"inflight":  g.inflight.Load(),
+			"completed": g.completed.Load(),
+			"failed":    g.failed.Load(),
+		})
 	})
 	return mux
 }
@@ -163,6 +188,22 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 		sysPrompt = "" // redaction disabled → meter-only (filterSSEStream skips it)
 	}
 
+	logModel := reqModel
+	if logModel == "" {
+		logModel = pathModel
+	}
+	// Request-lifecycle capture, read after ServeHTTP returns. Mutex-guarded
+	// because the streaming usage callback runs in filterSSEStream's goroutine
+	// (the non-streaming path sets them inline in ModifyResponse).
+	var (
+		mu       sync.Mutex
+		streamed bool
+		metered  bool
+		lastU    Usage
+	)
+	markStreamed := func() { mu.Lock(); streamed = true; mu.Unlock() }
+	captureUsage := func(u Usage) { mu.Lock(); metered = true; lastU = u; mu.Unlock() }
+
 	proxy := &httputil.ReverseProxy{
 		// Flush streamed (SSE) responses promptly so chat tokens aren't buffered.
 		FlushInterval: -1,
@@ -180,6 +221,7 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 				if meterModel == "" {
 					meterModel = pathModel
 				}
+				markStreamed()
 				onUsage := func(u Usage) {
 					if u.Model == "" {
 						u.Model = meterModel
@@ -188,8 +230,7 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 					if g.cfg.Sink != nil {
 						g.cfg.Sink.RecordUsage(claims.Tenant, claims.SkillID, provName, u)
 					}
-					g.cfg.Logger.Printf("model-gateway: tenant=%s skill=%s provider=%s model=%s in=%d out=%d cached=%d stream=1",
-						claims.Tenant, claims.SkillID, provName, u.Model, u.InputTokens, u.OutputTokens, u.CachedTokens)
+					captureUsage(u) // folded into the END lifecycle log
 				}
 				pr, pw := io.Pipe()
 				go filterSSEStream(pw, resp.Body, sysPrompt,
@@ -223,8 +264,7 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 				if g.cfg.Sink != nil {
 					g.cfg.Sink.RecordUsage(claims.Tenant, claims.SkillID, provName, u)
 				}
-				g.cfg.Logger.Printf("model-gateway: tenant=%s skill=%s provider=%s model=%s in=%d out=%d cached=%d",
-					claims.Tenant, claims.SkillID, provName, u.Model, u.InputTokens, u.OutputTokens, u.CachedTokens)
+				captureUsage(u) // folded into the END lifecycle log
 			}
 			return nil
 		},
@@ -232,7 +272,69 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "upstream error: "+err.Error(), http.StatusBadGateway)
 		},
 	}
-	proxy.ServeHTTP(w, r)
+
+	// --- request lifecycle: START → serve → END ---
+	// Every accepted request gets a START and a matching END line keyed by a
+	// monotonic req id, plus the live inflight gauge. For a streaming response
+	// ServeHTTP blocks until the piped SSE stream is fully drained, so END marks
+	// the true end of generation — turning "is it done or hung?" into a fact.
+	reqID := g.reqSeq.Add(1)
+	start := time.Now()
+	inflight := g.inflight.Add(1)
+	g.cfg.Logger.Printf("model-gateway: req=%d START tenant=%s skill=%s provider=%s model=%s inflight=%d",
+		reqID, claims.Tenant, claims.SkillID, provName, logModel, inflight)
+
+	sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+	proxy.ServeHTTP(sw, r)
+
+	mu.Lock()
+	st, md, lu := streamed, metered, lastU
+	mu.Unlock()
+	dur := time.Since(start)
+	status := "ok"
+	if sw.status >= 400 {
+		status = "error"
+		g.failed.Add(1)
+	} else {
+		g.completed.Add(1)
+	}
+	warn := ""
+	if st && !md {
+		// A streaming response that ended without ever emitting a usage event:
+		// the upstream stream was cut/abandoned — the classic "looks hung" case.
+		warn = " warn=stream-ended-without-usage"
+	}
+	g.cfg.Logger.Printf("model-gateway: req=%d END status=%s http=%d stream=%t dur=%s in=%d out=%d cached=%d inflight=%d%s",
+		reqID, status, sw.status, st, dur.Round(time.Millisecond),
+		lu.InputTokens, lu.OutputTokens, lu.CachedTokens, g.inflight.Add(-1), warn)
+}
+
+// statusWriter wraps http.ResponseWriter to capture the response status code for
+// the END lifecycle log while preserving http.Flusher, so streamed (SSE)
+// responses still flush each chunk promptly.
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+	wrote  bool
+}
+
+func (s *statusWriter) WriteHeader(code int) {
+	if !s.wrote {
+		s.status = code
+		s.wrote = true
+	}
+	s.ResponseWriter.WriteHeader(code)
+}
+
+func (s *statusWriter) Write(b []byte) (int, error) {
+	s.wrote = true // an implicit 200 if WriteHeader was never called
+	return s.ResponseWriter.Write(b)
+}
+
+func (s *statusWriter) Flush() {
+	if f, ok := s.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 }
 
 func contains(s []string, v string) bool {

--- a/internal/modelgateway/gateway_test.go
+++ b/internal/modelgateway/gateway_test.go
@@ -1,13 +1,64 @@
 package modelgateway
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
+
+// syncBuffer is a concurrency-safe io.Writer for capturing logger output: the
+// gateway writes the END line from its handler goroutine while the test reads.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// waitFor polls cond up to ~1s. The END log + lifecycle counters are written
+// AFTER the response is flushed to the client (correct: END marks the server
+// finishing), so a test that inspects them right after the HTTP call must wait.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	for i := 0; i < 200; i++ {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func gatewayStatus(t *testing.T, base string) (inflight, completed, failed int64) {
+	t.Helper()
+	resp, err := http.Get(base + "/__gateway/status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var st struct{ Inflight, Completed, Failed int64 }
+	if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+		t.Fatal(err)
+	}
+	return st.Inflight, st.Completed, st.Failed
+}
 
 // fakeUpstream stands in for the real provider API; it records the auth headers
 // it received and returns a canned usage body.
@@ -255,6 +306,88 @@ func TestGateway_GeminiOpenAI_BearerInjected_Metered(t *testing.T) {
 	if rows[0].InputTokens != 100 || rows[0].OutputTokens != 20 {
 		t.Errorf("token counts wrong: %+v", rows[0])
 	}
+}
+
+// TestGateway_RequestLifecycleObservability pins the "did it finish?" signal:
+// every accepted request emits a START + matching END log, and the live
+// /__gateway/status gauge returns to inflight=0 with completed incremented.
+func TestGateway_RequestLifecycleObservability(t *testing.T) {
+	secret := []byte("s")
+	up := fakeUpstream(t, func(*http.Request) {},
+		`{"model":"gemini-2.5-flash","usage":{"prompt_tokens":7,"completion_tokens":3}}`)
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["gemini-openai"].UpstreamURL = up.URL
+	logbuf := &syncBuffer{}
+	gw := New(Config{
+		Secret: secret, Providers: providers,
+		ProviderKeys: map[string]string{"gemini-openai": "GKEY"},
+		Logger:       log.New(logbuf, "", 0),
+	})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	tok, _ := MintToken(secret, GatewayClaims{Tenant: "acme", SkillID: "ws", Provider: "gemini-openai"}, time.Minute)
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/model/gemini-openai/v1beta/openai/chat/completions", strings.NewReader(`{"model":"gemini-2.5-flash"}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	waitFor(t, "END lifecycle log", func() bool { return strings.Contains(logbuf.String(), "req=1 END") })
+	logs := logbuf.String()
+	if !strings.Contains(logs, "req=1 START") {
+		t.Errorf("missing START lifecycle log:\n%s", logs)
+	}
+	if !strings.Contains(logs, "req=1 END status=ok") {
+		t.Errorf("missing END status=ok lifecycle log:\n%s", logs)
+	}
+	if !strings.Contains(logs, "out=3") {
+		t.Errorf("END log should carry token usage (out=3):\n%s", logs)
+	}
+
+	waitFor(t, "completed=1", func() bool {
+		inflight, completed, _ := gatewayStatus(t, srv.URL)
+		return inflight == 0 && completed == 1
+	})
+	if _, _, failed := gatewayStatus(t, srv.URL); failed != 0 {
+		t.Errorf("failed = %d, want 0", failed)
+	}
+}
+
+// TestGateway_LifecycleFailedCounter asserts an upstream error response is
+// counted as failed (not completed) and clears in-flight.
+func TestGateway_LifecycleFailedCounter(t *testing.T) {
+	secret := []byte("s")
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["gemini-openai"].UpstreamURL = up.URL
+	gw := New(Config{Secret: secret, Providers: providers, ProviderKeys: map[string]string{"gemini-openai": "K"}})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	tok, _ := MintToken(secret, GatewayClaims{Tenant: "t", Provider: "gemini-openai"}, time.Minute)
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/model/gemini-openai/v1beta/openai/chat/completions", strings.NewReader(`{"model":"m"}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	waitFor(t, "failed=1", func() bool {
+		inflight, _, failed := gatewayStatus(t, srv.URL)
+		return inflight == 0 && failed == 1
+	})
 }
 
 func TestGateway_RejectsBadTokens(t *testing.T) {


### PR DESCRIPTION
## What

Adds request-lifecycle observability to the model gateway so "did the gateway
finish this request, or is it still running / hung?" is answerable.

## Why

The gateway emitted exactly one observable event — a metering log — and **only
for non-streaming JSON responses**. The workspace chat path is **streaming**
(`stream:true`), so for those requests there was:

- no "started" signal, no completion signal, no in-flight count, no duration,
  and no error log on a stalled stream.

That blind spot is exactly why "gemini is hanging" earlier was so hard to pin
down — there was no way to see, from the gateway, whether a request had finished.

## How

- **Per-request START + END logs**, keyed by a monotonic `req=<n>`:
  - `START tenant=… skill=… provider=… model=… inflight=N`
  - `END status=ok|error http=… stream=… dur=… in=… out=… cached=… inflight=N`
- **Hung-stream flag**: a streaming response that ends with no usage event →
  `warn=stream-ended-without-usage`.
- **Live gauge** at `GET /__gateway/status` → `{inflight, completed, failed}`.
  `inflight` stuck above zero with no new completions = an observable hang.
- `statusWriter` captures the response code while preserving `http.Flusher`, so
  SSE still streams chunk-by-chunk. For a streaming response `ServeHTTP` blocks
  until the piped stream drains, so `END` marks true end-of-generation.
- The old per-usage metering log is folded into `END`; OTel billing sink is
  unchanged.

## Tests

`go test ./internal/modelgateway -race` green. New: START/END + status gauge
(happy path), failed counter (upstream 500). Uses a sync-safe log buffer +
polling because `END`/counters are recorded just *after* the response is flushed
to the client (correct — `END` marks the server finishing).

## Note

This is the **observability** layer. If you later want alerting/dashboards, the
`{inflight, completed, failed}` gauge + the `warn=` flag are the hooks to scrape;
a Prometheus/OTel export of the same counters would be a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
