### PR TITLE
feat(mcp): delete_route tool (unexpose)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`delete_route` MCP tool (unexpose).** The MCP server had `expose_port` +
+  `list_routes` but no way to *remove* a route, so an agent that exposed an app
+  (or hit its subdomain quota on the cloud) couldn't take one down. Adds a
+  `delete_route` tool (domain → `DELETE /v1/network/routes/{domain}`, scoped to
+  `routes:write`, idempotent) and the backing `Client.DeleteRoute`. Pairs with
+  the cloud's `delete_route` REST verb so the in-chat workspace agent can wire
+  *and* unwire HTTP. (55 tools now.)
+
 - **Model-gateway request-lifecycle observability.** The gateway emitted only a
   single metering log on completion — and only for *non-streaming* responses —
   so for a streaming chat there was no way to tell whether a request was still

--- a/internal/mcp/backend.go
+++ b/internal/mcp/backend.go
@@ -64,6 +64,7 @@ type API interface {
 	// Routes / backends.
 	AddRoute(req AddRouteRequest) (*AddRouteResponse, error)
 	ListRoutes(username string, activeOnly bool) (*ListRoutesResponse, error)
+	DeleteRoute(domain string) error
 	ListBackends() (*ListBackendsResponse, error)
 	GetBackend(id string) (*Backend, error)
 	ValidateGPU(backendID, pci string) (*ValidateGPUResult, error)

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1020,6 +1020,16 @@ func (c *Client) AddRoute(req AddRouteRequest) (*AddRouteResponse, error) {
 	return &resp, nil
 }
 
+// DeleteRoute removes a proxy route by its domain — the unexpose counterpart
+// of AddRoute. Mirrors DELETE /v1/network/routes/{domain}; idempotent
+// server-side (a missing route is a no-op success), so the caller need not
+// pre-check existence. Used by the delete_route tool to free a hostname (and,
+// on the cloud, its subdomain-quota slot).
+func (c *Client) DeleteRoute(domain string) error {
+	_, err := c.doRequest("DELETE", "/v1/network/routes/"+url.PathEscape(domain), nil)
+	return err
+}
+
 // ListRoutes returns all proxy routes the sentinel currently serves. Both
 // filter params are optional — empty `username` or `activeOnly=false`
 // means "no filter on that dimension". Mirrors GET /v1/network/routes.

--- a/internal/mcp/k3_k4_api_token_test.go
+++ b/internal/mcp/k3_k4_api_token_test.go
@@ -79,3 +79,37 @@ func TestMCPClient_K4_ExposePortAcceptsAPIToken(t *testing.T) {
 		"expose_port should target the routes endpoint (got %q)", sawPath)
 	assert.Equal(t, http.MethodPost, sawMethod, "expose_port creates a route → POST")
 }
+
+// TestMCPClient_DeleteRoute — the unexpose flow: client.DeleteRoute →
+// DELETE /v1/network/routes/{domain}, with the bearer forwarded and the
+// domain path-escaped into the URL.
+func TestMCPClient_DeleteRoute(t *testing.T) {
+	const apiToken = "ctnr_del123.0011223344556677"
+
+	var sawHeader, sawPath, sawMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawHeader = r.Header.Get("Authorization")
+		sawPath = r.URL.Path
+		sawMethod = r.Method
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, apiToken)
+	err := c.DeleteRoute("alice-myapp.example.dev")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer "+apiToken, sawHeader,
+		"delete_route must forward the API token verbatim")
+	assert.Equal(t, http.MethodDelete, sawMethod, "delete_route removes a route → DELETE")
+	assert.Equal(t, "/v1/network/routes/alice-myapp.example.dev", sawPath,
+		"delete_route should target /v1/network/routes/{domain} (got %q)", sawPath)
+}
+
+// TestHandleDeleteRoute_RequiresDomain — the handler rejects a missing domain
+// before hitting the client.
+func TestHandleDeleteRoute_RequiresDomain(t *testing.T) {
+	_, err := handleDeleteRoute(nil, map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "domain is required")
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,8 +22,8 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584).
-	assert.Len(t, server.tools, 54, "Should have 54 tools registered")
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route.
+	assert.Len(t, server.tools, 55, "Should have 55 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -127,8 +127,8 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584).
-	assert.Len(t, tools, 54)
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route.
+	assert.Len(t, tools, 55)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -954,6 +954,30 @@ func (s *Server) registerTools() {
 			Handler: handleListRoutes,
 		},
 		{
+			Name: "delete_route",
+			Description: "Remove a proxy route by its domain — the unexpose counterpart of " +
+				"`expose_port`. After this, https://<domain>/ no longer reaches any container, " +
+				"and (on the cloud) the subdomain's quota slot is freed for reuse.\n\n" +
+				"Use this to:\n" +
+				"  - Take an app offline / retire a public hostname.\n" +
+				"  - Clean up a stale route left by a deleted container.\n" +
+				"  - Free a subdomain slot when you've hit your route quota and need to " +
+				"    expose something else.\n\n" +
+				"Idempotent: deleting an already-gone route succeeds (no error). Pass the " +
+				"full domain as shown by `list_routes` (`fullDomain`).",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"domain": map[string]interface{}{
+						"type":        "string",
+						"description": "The route's domain to remove, e.g. 'blog-acme.containarium.dev' (the `fullDomain` from list_routes).",
+					},
+				},
+				"required": []string{"domain"},
+			},
+			Handler: handleDeleteRoute,
+		},
+		{
 			Name: "expose_port",
 			Description: "Expose a container's port on a public hostname. Resolves the " +
 				"container's IP, then registers a domain → container:port route in the " +
@@ -1230,8 +1254,9 @@ func toolScopeAssignments() map[string]string {
 		"get_secret":      auth.ScopeSecretsRead,
 		"list_secrets":    auth.ScopeSecretsRead,
 		// routes / network exposure
-		"list_routes": auth.ScopeRoutesRead,
-		"expose_port": auth.ScopeRoutesWrite,
+		"list_routes":  auth.ScopeRoutesRead,
+		"expose_port":  auth.ScopeRoutesWrite,
+		"delete_route": auth.ScopeRoutesWrite,
 		// recipes — declarative GPU/app deploys
 		"list_recipes":  auth.ScopeContainersRead,
 		"deploy_recipe": auth.ScopeContainersWrite,
@@ -1938,6 +1963,17 @@ func handleListRoutes(client API, args map[string]interface{}) (string, error) {
 		return "", fmt.Errorf("failed to marshal response: %w", err)
 	}
 	return string(out), nil
+}
+
+func handleDeleteRoute(client API, args map[string]interface{}) (string, error) {
+	domain := getStringArg(args, "domain", "")
+	if domain == "" {
+		return "", fmt.Errorf("domain is required")
+	}
+	if err := client.DeleteRoute(domain); err != nil {
+		return "", fmt.Errorf("failed to delete route %s: %w", domain, err)
+	}
+	return fmt.Sprintf("✅ Deleted route %s — it no longer reaches any container.", domain), nil
 }
 
 func handleExposePort(client API, args map[string]interface{}) (string, error) {


### PR DESCRIPTION
## What

Adds the **`delete_route`** (unexpose) MCP tool — the counterpart to
`expose_port`. Completes the route lifecycle for the in-chat workspace agent.

## Why

The MCP server had `expose_port` + `list_routes` but **no way to remove a
route**. So an agent that exposed an app couldn't take it down, and — on the
cloud — a workspace at its subdomain quota had no way to free a slot. (This is
the OSS half of the cloud `delete_route` verb shipped in Containarium-cloud
#683; together they let the workspace agent wire *and* unwire HTTP.)

## How

The OSS daemon already had `NetworkService.DeleteRoute` (+ a `route delete` CLI
and a gRPC client method) — only the MCP surface was missing:

- `API.DeleteRoute(domain) error` (backend.go) — both backends inherit it from
  `*Client`.
- `Client.DeleteRoute` → `DELETE /v1/network/routes/{domain}` (path-escaped;
  idempotent server-side).
- `delete_route` tool (tools.go): `domain` arg, **`routes:write`** scope,
  `handleDeleteRoute`.

## Tests

`go test ./internal/mcp` green. New: client forwards the bearer + targets
`DELETE /v1/network/routes/{domain}`; handler rejects a missing domain; tool
count 54→55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
