### PR TITLE
feat(mcp): show resolved backend/pool in create/list/delete container output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **create/list/delete container output now shows the resolved backend + pool.**
+  The MCP container ops never displayed *where* a box landed, so a `backend_id`
+  that matched no host (and silently fell back to the default pool) was invisible
+  until a side effect — e.g. an egress-IP test — exposed it. Now `list_containers`
+  and `create_container` print `Backend:`/`Pool:`, `delete_container` reports the
+  backend it removed the box from (best-effort pre-fetch), and `create_container`
+  emits an explicit ⚠️ warning when the box lands on a backend other than the
+  one requested. Surfaces the silent-fallback footgun at the tool layer (cloud
+  #685/#686).
+
 - **`delete_route` MCP tool (unexpose).** The MCP server had `expose_port` +
   `list_routes` but no way to *remove* a route, so an agent that exposed an app
   (or hit its subdomain quota on the cloud) couldn't take one down. Adds a

--- a/internal/mcp/backend_display_test.go
+++ b/internal/mcp/backend_display_test.go
@@ -1,0 +1,95 @@
+package mcp
+
+// Asserts create/list/delete container output surfaces the RESOLVED backend/pool
+// — so a placement that silently fell back to the default (cloud #686) is
+// visible at the tool layer instead of via a later egress test.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListContainers_ShowsBackendAndPool(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"containers":[{"name":"box1","username":"cld-1","state":"running","backendId":"tunnel-fts-13700k","pool":"gpu-pool"}],"totalCount":1}`))
+	}))
+	defer server.Close()
+
+	out, err := handleListContainers(NewClient(server.URL, "t"), map[string]interface{}{})
+	require.NoError(t, err)
+	assert.Contains(t, out, "Backend: tunnel-fts-13700k")
+	assert.Contains(t, out, "Pool: gpu-pool")
+}
+
+func TestCreateContainer_ShowsBackend_AndFallbackWarning(t *testing.T) {
+	// Server reports the box landed on the default GCP backend, regardless of
+	// the requested backend_id — the silent-fallback case.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"container":{"name":"box1","username":"cld-1","state":"running","backendId":"containarium-jump-ase1-spot"},"message":"created"}`))
+	}))
+	defer server.Close()
+
+	out, err := handleCreateContainer(NewClient(server.URL, "t"), map[string]interface{}{
+		"username":   "cld-1",
+		"backend_id": "tunnel-fts-13700k", // requested
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out, "Backend: containarium-jump-ase1-spot")
+	assert.Contains(t, out, "⚠️", "must warn when the box landed on a different backend than requested")
+	assert.Contains(t, out, "tunnel-fts-13700k", "warning should name the requested backend")
+}
+
+func TestCreateContainer_NoWarningWhenBackendMatches(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"container":{"name":"box1","username":"cld-1","state":"running","backendId":"tunnel-fts-13700k"},"message":"created"}`))
+	}))
+	defer server.Close()
+
+	out, err := handleCreateContainer(NewClient(server.URL, "t"), map[string]interface{}{
+		"username":   "cld-1",
+		"backend_id": "tunnel-fts-13700k",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out, "Backend: tunnel-fts-13700k")
+	assert.NotContains(t, out, "⚠️", "no warning when landed backend == requested")
+}
+
+func TestDeleteContainer_ShowsBackend(t *testing.T) {
+	// Delete pre-fetches the box (GET) to learn its backend, then deletes.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"container":{"name":"box1","username":"cld-1","state":"running","backendId":"tunnel-fts-13700k"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"message":"container cld-1 deleted","containerName":"cld-1"}`))
+	}))
+	defer server.Close()
+
+	out, err := handleDeleteContainer(NewClient(server.URL, "t"), map[string]interface{}{"username": "cld-1"})
+	require.NoError(t, err)
+	assert.Contains(t, out, "deleted")
+	assert.Contains(t, out, "Backend: tunnel-fts-13700k")
+}
+
+// The GET pre-fetch is best-effort: if it fails, delete still succeeds (just
+// without the backend line).
+func TestDeleteContainer_LookupFailureIsNonFatal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(`{"message":"container cld-1 deleted","containerName":"cld-1"}`))
+	}))
+	defer server.Close()
+
+	out, err := handleDeleteContainer(NewClient(server.URL, "t"), map[string]interface{}{"username": "cld-1"})
+	require.NoError(t, err)
+	assert.Contains(t, out, "deleted")
+	assert.False(t, strings.Contains(out, "Backend:"), "no backend line when lookup failed")
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1359,6 +1359,20 @@ func handleCreateContainer(client API, args map[string]interface{}) (string, err
 	result += fmt.Sprintf("Name: %s\n", resp.Container.Name)
 	result += fmt.Sprintf("Username: %s\n", resp.Container.Username)
 	result += fmt.Sprintf("State: %s\n", resp.Container.State)
+	// Surface the RESOLVED backend/pool the box actually landed on. If a
+	// requested backend_id didn't match any host, placement silently falls back
+	// to the default (cloud #686) — showing where it really landed makes that
+	// immediately visible instead of discovering it later via an egress test.
+	if resp.Container.BackendID != "" {
+		result += fmt.Sprintf("Backend: %s\n", resp.Container.BackendID)
+	}
+	if resp.Container.Pool != "" {
+		result += fmt.Sprintf("Pool: %s\n", resp.Container.Pool)
+	}
+	if reqBackend := getStringArg(args, "backend_id", ""); reqBackend != "" && resp.Container.BackendID != "" && resp.Container.BackendID != reqBackend {
+		result += fmt.Sprintf("⚠️  Requested backend_id %q but the box landed on %q (the requested id matched no host; placement used the default).\n",
+			reqBackend, resp.Container.BackendID)
+	}
 	if resp.Container.Network != nil && resp.Container.Network.IPAddress != "" {
 		result += fmt.Sprintf("IP Address: %s\n", resp.Container.Network.IPAddress)
 	}
@@ -1461,6 +1475,15 @@ func handleListContainers(client API, args map[string]interface{}) (string, erro
 		result += fmt.Sprintf("📦 %s\n", container.Name)
 		result += fmt.Sprintf("   Username: %s\n", container.Username)
 		result += fmt.Sprintf("   State: %s\n", container.State)
+		// Show WHERE the box actually runs. A wrong/typo'd backend_id silently
+		// falls back to the default pool, so surfacing the resolved backend is
+		// the fastest way to catch a misplacement (see cloud #686).
+		if container.BackendID != "" {
+			result += fmt.Sprintf("   Backend: %s\n", container.BackendID)
+		}
+		if container.Pool != "" {
+			result += fmt.Sprintf("   Pool: %s\n", container.Pool)
+		}
 		if container.Network != nil && container.Network.IPAddress != "" {
 			result += fmt.Sprintf("   IP: %s\n", container.Network.IPAddress)
 		}
@@ -1641,12 +1664,28 @@ func handleDeleteContainer(client API, args map[string]interface{}) (string, err
 
 	force := getBoolArg(args, "force", false)
 
+	// Best-effort: capture WHERE the box ran before deleting, so the
+	// confirmation states which backend/pool it was removed from. The delete
+	// response doesn't carry placement, and a lookup failure is non-fatal — the
+	// delete still proceeds.
+	var backend, pool string
+	if info, gerr := client.GetContainer(username); gerr == nil && info != nil {
+		backend, pool = info.Container.BackendID, info.Container.Pool
+	}
+
 	resp, err := client.DeleteContainer(username, force)
 	if err != nil {
 		return "", fmt.Errorf("failed to delete container: %w", err)
 	}
 
-	return fmt.Sprintf("✅ %s", resp.Message), nil
+	out := fmt.Sprintf("✅ %s", resp.Message)
+	if backend != "" {
+		out += fmt.Sprintf("\n   Backend: %s", backend)
+	}
+	if pool != "" {
+		out += fmt.Sprintf("\n   Pool: %s", pool)
+	}
+	return out, nil
 }
 
 func handleStartContainer(client API, args map[string]interface{}) (string, error) {


### PR DESCRIPTION
## What

`create_container` / `list_containers` / `delete_container` now show the
**resolved backend + pool** the box actually runs on — and `create_container`
warns when a box lands on a backend other than the one requested.

## Why

The container ops never displayed *where* a box landed. So a `backend_id` that
matched no host — which placement silently falls back to the default for (cloud
#686) — was invisible at the tool layer. A CI/scrape runner aimed at a BYOC node
silently ran on the GCP datacenter, and the only thing that caught it was an
**egress-IP test**. Showing the resolved backend makes the misplacement obvious
the instant the box is created/listed.

## How

- **list_containers**: `Backend:` / `Pool:` per box.
- **create_container**: `Backend:` / `Pool:`, plus a ⚠️ warning when
  `landed_backend != requested backend_id` ("matched no host; placement used the
  default").
- **delete_container**: best-effort `GetContainer` pre-fetch to report which
  backend the box was removed from (the delete response doesn't carry placement;
  a lookup failure is non-fatal — the delete still proceeds).

## Tests

`go test ./internal/mcp` green. New: list shows backend/pool; create shows
backend + fires the warning on mismatch (and not on match); delete shows backend
via pre-fetch; delete lookup-failure is non-fatal.

## Related

Tool-layer companion to cloud #685 (`list_backends` hides BYOC/agent hosts) and
#686 (placement should fail closed on an unknown `backend_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
