### PR TITLE
fix(keys): sentinel-key reconcile absorbs unmarked/duplicate copies (#687)

### DIFF
--- a/internal/gateway/keys_handler.go
+++ b/internal/gateway/keys_handler.go
@@ -196,17 +196,49 @@ func applySentinelKey(homeRoot, pubKey string) (updated, rotated int, err error)
 	return updated, rotated, nil
 }
 
+// sshKeyMaterial returns the "<type> <base64>" prefix of an authorized_keys
+// line, ignoring any trailing comment, and true when the line looks like a
+// public key. Two lines name the same key iff their material matches — the
+// comment field is cosmetic and must not defeat dedup.
+//
+// Sentinel upstream keys are written without an options prefix, so the type
+// is the first whitespace field; option-prefixed lines (which a sentinel key
+// never is) return false and are left untouched.
+func sshKeyMaterial(line string) (string, bool) {
+	f := strings.Fields(strings.TrimSpace(line))
+	if len(f) < 2 {
+		return "", false
+	}
+	switch {
+	case strings.HasPrefix(f[0], "ssh-"),
+		strings.HasPrefix(f[0], "ecdsa-"),
+		strings.HasPrefix(f[0], "sk-"):
+		return f[0] + " " + f[1], true
+	default:
+		return "", false
+	}
+}
+
 // rewriteSentinelBlock returns authorized_keys content with the sentinel
 // marker + one current pubKey, replacing any prior sentinel marker block
 // (and the key line that follows it).
+//
+// It also absorbs any *unmarked* stray copy of the current sentinel key: an
+// older seeding path or a manual injection can leave the upstream key in the
+// file without the marker, which the marker scan alone would never reconcile,
+// so it accumulates across rotations. Dropping every line whose key material
+// equals pubKey (regardless of marker or comment) guarantees the canonical
+// block appended below is the sole occurrence.
 //
 // Returns the new content, whether a prior sentinel block existed, and
 // whether the prior key (if any) differed from pubKey.
 func rewriteSentinelBlock(existing, pubKey string) (newContent string, hadPrior, priorDiffers bool) {
 	lines := strings.Split(existing, "\n")
 	out := make([]string, 0, len(lines)+2)
+	targetMat, haveTarget := sshKeyMaterial(pubKey)
 
-	// Drop every "marker + next-non-empty-line" pair from the input.
+	// Drop every "marker + next-non-empty-line" pair from the input, plus
+	// any stray (unmarked) copy of the current sentinel key.
 	for i := 0; i < len(lines); i++ {
 		line := lines[i]
 		if strings.TrimSpace(line) == sentinelKeyMarker {
@@ -218,12 +250,21 @@ func rewriteSentinelBlock(existing, pubKey string) (newContent string, hadPrior,
 			}
 			if j < len(lines) {
 				prior := strings.TrimSpace(lines[j])
-				if prior != pubKey {
+				// Compare by key material so a comment-only difference on
+				// the same key is not mistaken for a rotation.
+				if pm, ok := sshKeyMaterial(prior); !ok || !haveTarget || pm != targetMat {
 					priorDiffers = true
 				}
 				i = j // skip the prior key line as well
 			}
 			continue
+		}
+		// Silently dedup an unmarked copy of the current key; the canonical
+		// block re-adds it once below.
+		if haveTarget {
+			if m, ok := sshKeyMaterial(line); ok && m == targetMat {
+				continue
+			}
 		}
 		out = append(out, line)
 	}

--- a/internal/gateway/keys_handler_test.go
+++ b/internal/gateway/keys_handler_test.go
@@ -300,6 +300,74 @@ func TestRewriteSentinelBlock_MultipleStaleMarkers(t *testing.T) {
 	}
 }
 
+func TestRewriteSentinelBlock_AbsorbsUnmarkedDuplicate(t *testing.T) {
+	// The live BYOC failure mode: an older seeding path / manual injection
+	// left the current upstream key in the file WITHOUT the marker, so the
+	// marker scan alone never reconciled it and copies accumulated. The
+	// rewrite must absorb the unmarked copy into the single canonical block.
+	key := "ssh-ed25519 AAAA_sentinel sentinel@sshpiper"
+	existing := "ssh-ed25519 AAAA_user user@laptop\n" +
+		key + " stray-comment\n" + // unmarked copy (different comment)
+		sentinelKeyMarker + "\n" +
+		key + "\n" +
+		key + "\n" // a second bare unmarked dup
+
+	out, _, _ := rewriteSentinelBlock(existing, key)
+	if got := strings.Count(out, "AAAA_sentinel"); got != 1 {
+		t.Errorf("expected the sentinel key exactly once, got %d:\n%s", got, out)
+	}
+	if strings.Count(out, sentinelKeyMarker) != 1 {
+		t.Errorf("expected exactly one marker, got %d:\n%s",
+			strings.Count(out, sentinelKeyMarker), out)
+	}
+	if !strings.Contains(out, "AAAA_user user@laptop") {
+		t.Errorf("user key must be preserved:\n%s", out)
+	}
+	// Idempotent on the cleaned-up content.
+	out2, _, _ := rewriteSentinelBlock(out, key)
+	if out != out2 {
+		t.Errorf("not idempotent after absorbing dup:\nfirst:\n%s\nsecond:\n%s", out, out2)
+	}
+}
+
+func TestRewriteSentinelBlock_CommentOnlyDiffIsNotRotation(t *testing.T) {
+	// Same key material, different comment, behind the marker: this is the
+	// same key, not a rotation — priorDiffers must stay false.
+	existing := sentinelKeyMarker + "\n" +
+		"ssh-ed25519 AAAA_sentinel old-comment\n"
+	key := "ssh-ed25519 AAAA_sentinel new-comment"
+
+	_, hadPrior, priorDiffers := rewriteSentinelBlock(existing, key)
+	if !hadPrior {
+		t.Error("expected hadPrior=true")
+	}
+	if priorDiffers {
+		t.Error("comment-only difference must not be treated as a rotation")
+	}
+}
+
+func TestSSHKeyMaterial(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   string
+		wantOk bool
+	}{
+		{"ssh-ed25519 AAAA comment", "ssh-ed25519 AAAA", true},
+		{"  ssh-rsa BBBB  ", "ssh-rsa BBBB", true},
+		{"ecdsa-sha2-nistp256 CCCC host", "ecdsa-sha2-nistp256 CCCC", true},
+		{"sk-ssh-ed25519@openssh.com DDDD", "sk-ssh-ed25519@openssh.com DDDD", true},
+		{sentinelKeyMarker, "", false},
+		{"", "", false},
+		{"ssh-ed25519", "", false}, // type only, no material
+	}
+	for _, c := range cases {
+		got, ok := sshKeyMaterial(c.in)
+		if got != c.want || ok != c.wantOk {
+			t.Errorf("sshKeyMaterial(%q) = (%q,%v), want (%q,%v)", c.in, got, ok, c.want, c.wantOk)
+		}
+	}
+}
+
 func TestApplySentinelKey_FirstInstall(t *testing.T) {
 	tmpHome := t.TempDir()
 	mkUser(t, tmpHome, "alice", "ssh-ed25519 AAAA_alice alice@laptop\n")


### PR DESCRIPTION
## What

`rewriteSentinelBlock` (the host-side `authorized_keys` reconcile the sentinel keysync drives via `POST /authorized-keys/sentinel`) only removed a sentinel upstream key when it was preceded by the `# sshpiper sentinel upstream key` marker.

A copy of the upstream key seeded by an **older path or injected manually** lands **without** the marker. The marker scan never reconciled it, so copies accumulated across rotations — observed live on a BYOC host where the current upstream key appeared twice with only one behind a marker, leaving a messy `authorized_keys`.

## Change

- `rewriteSentinelBlock` now also drops every line whose **key material** (`<type> <base64>`, comment ignored) equals the current key — marked or not — so the canonical block appended at the end is the **sole** occurrence. Idempotent and self-healing.
- New `sshKeyMaterial()` helper; comparing by material also stops a comment-only difference behind the marker from being miscounted as a rotation.
- Tests: unmarked-duplicate absorb (the live failure shape), comment-only no-rotation, and the material parser.

## Scope

This is the contained, fail-safe slice of the BYOC sentinel-auth work (#687/#688). It hardens reconcile hygiene; it does **not** change the sentinel↔daemon trust model. **Per-host / asymmetric sentinel auth** (replacing the deployment-wide HMAC secret so a BYOC node can't push keys to the multi-tenant workhorse) remains a separate, reviewed change — tracked under #688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)