### PR TITLE
fix(jump): ensure jump account unlocked on every ensure, not just create (#687)

### DIFF
--- a/pkg/core/container/jump_server.go
+++ b/pkg/core/container/jump_server.go
@@ -141,26 +141,33 @@ func EnsureJumpServerAccount(username string) error {
 		// Ensure shell is containarium-shell
 		// #nosec G204 -- username validated by isValidUsername above (alphanumeric, dash, underscore only)
 		_ = exec.Command("usermod", "-s", shellPath, username).Run()
-		return nil
+	} else {
+		// Create user with containarium-shell
+		// #nosec G204 -- username validated by isValidUsername above
+		if err := exec.Command("useradd", "-m", "-s", shellPath,
+			"-c", fmt.Sprintf("Containarium user - %s", username),
+			username).Run(); err != nil {
+			return fmt.Errorf("useradd failed: %w", err)
+		}
 	}
 
-	// Create user with containarium-shell
-	// #nosec G204 -- username validated by isValidUsername above
-	if err := exec.Command("useradd", "-m", "-s", shellPath,
-		"-c", fmt.Sprintf("Containarium user - %s", username),
-		username).Run(); err != nil {
-		return fmt.Errorf("useradd failed: %w", err)
+	// Everything below is idempotent and runs on BOTH the freshly-created and
+	// the already-exists paths. The already-exists path previously only fixed
+	// the shell and returned — so an account left in a bad state (most
+	// importantly: locked) never self-healed. Ensuring full state every call
+	// makes a misprovisioned account recover on the next create/reconcile.
+	return ensureJumpAccountState(username)
+}
+
+// ensureJumpAccountState applies the idempotent host-side state a jump account
+// needs to be reachable through sshpiper: unlocked, world-readable home,
+// owned .ssh dir, and the incus sudoers entry. Safe to re-run.
+func ensureJumpAccountState(username string) error {
+	if err := ensureAccountUnlocked(username); err != nil {
+		return err
 	}
 
-	// Unlock account (useradd creates locked accounts, sshd rejects them).
-	// Set password to '*' which means "no valid password" but account is not
-	// locked. This allows public key auth while preventing password login.
-	// Note: passwd -d sets an empty password which some distros reject;
-	// usermod -p '*' is the portable approach.
-	// #nosec G204 -- username validated by isValidUsername above
-	_ = exec.Command("usermod", "-p", "*", username).Run()
-
-	// Set home dir permissions (sshd requires 755 or stricter)
+	// Set home dir permissions (sshd requires 755 or stricter).
 	_ = os.Chmod(fmt.Sprintf("/home/%s", username), 0755) // #nosec G302 -- sshd requires home dir to be world-readable
 
 	// Create .ssh dir
@@ -168,7 +175,7 @@ func EnsureJumpServerAccount(username string) error {
 	if err := os.MkdirAll(sshDir, 0700); err != nil {
 		return fmt.Errorf("failed to create .ssh dir: %w", err)
 	}
-	// #nosec G204 -- username validated by isValidUsername above
+	// #nosec G204 -- username validated by isValidUsername (callers)
 	_ = exec.Command("chown", "-R", username+":"+username, sshDir).Run()
 
 	// Sudoers entry for incus access (containarium-shell needs it)
@@ -179,6 +186,54 @@ func EnsureJumpServerAccount(username string) error {
 	}
 
 	return nil
+}
+
+// ensureAccountUnlocked guarantees the account's password is disabled but the
+// account is NOT locked (shadow state "NP"/"P", never "L").
+//
+// useradd creates accounts locked ("!" password). With `UsePAM no` — the
+// hardened setting on jump/BYOC hosts — OpenSSH performs its OWN locked-account
+// check and refuses a locked account *even for public-key auth*. The box still
+// accepts the client key downstream, but the sshpiper→host upstream hop dies
+// with "User <u> not allowed because account is locked", which surfaces on the
+// client as a confusing "authenticated with partial success" loop ending in
+// Permission denied. So the unlock is load-bearing, must run on every ensure
+// (a single earlier failure must not strand the box), and its result must be
+// verified rather than swallowed.
+//
+// `usermod -p '*'` sets "no valid password" without the lock prefix; it is
+// idempotent and safe to re-run, and (unlike `passwd -d`'s empty password)
+// portable across distros.
+func ensureAccountUnlocked(username string) error {
+	// #nosec G204 -- callers validate username via isValidUsername
+	if out, err := exec.Command("usermod", "-p", "*", username).CombinedOutput(); err != nil {
+		return fmt.Errorf("unlock account %s: %w (output: %s)", username, err, strings.TrimSpace(string(out)))
+	}
+
+	// Verify the account is no longer locked. `passwd -S` prints
+	// "<user> <L|P|NP> <date> ...". A lingering "L" means SSH will keep
+	// failing, so surface it instead of reporting success.
+	// #nosec G204 -- callers validate username via isValidUsername
+	out, err := exec.Command("passwd", "-S", username).Output()
+	if err != nil {
+		// passwd -S unavailable / not permitted in this environment: the
+		// usermod above already succeeded, so don't fail the whole ensure on
+		// a verification gap.
+		return nil
+	}
+	if passwdStatusLocked(string(out)) {
+		return fmt.Errorf("account %s still locked after unlock attempt (passwd -S: %q)", username, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// passwdStatusLocked reports whether `passwd -S` output indicates a locked
+// account. The status is the second whitespace field: "L" (locked), "P"
+// (usable password), or "NP" (no password). Anything we can't parse is treated
+// as not-locked so a quirky passwd implementation can't wedge provisioning.
+func passwdStatusLocked(passwdSOutput string) bool {
+	fields := strings.Fields(passwdSOutput)
+	return len(fields) >= 2 && fields[1] == "L"
 }
 
 // isValidUsername checks if username contains only allowed characters

--- a/pkg/core/container/jump_server_test.go
+++ b/pkg/core/container/jump_server_test.go
@@ -7,6 +7,31 @@ import (
 	"time"
 )
 
+func TestPasswdStatusLocked(t *testing.T) {
+	// Inputs are real `passwd -S` lines observed on a BYOC host: the broken
+	// jump account was "L" while working siblings were "NP".
+	tests := []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{"locked account (the bug)", "cld-9c09f73a L 2026-06-23 0 99999 7 -1", true},
+		{"no-password sibling", "apibox-dev-3090 NP 2026-04-02 0 99999 7 -1", false},
+		{"usable password", "alice P 2026-01-01 0 99999 7 -1", false},
+		{"empty output", "", false},
+		{"single field", "weird", false},
+		{"trailing newline locked", "bob L 2026-06-23\n", true},
+		{"locked-substring not status", "Llama NP 2026-01-01", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := passwdStatusLocked(tt.out); got != tt.want {
+				t.Errorf("passwdStatusLocked(%q) = %v, want %v", tt.out, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsValidUsername(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Root cause (BYOC SSH proof, #687)

A cloud box on a BYOC host accepted the client key at sshpiper but the **sentinel→host upstream hop** failed with a `partial success` loop → `Permission denied`. Live diagnosis on the BYOC host:

```
sshd: User cld-9c09f73a not allowed because account is locked   (×11, at the trigger)
```

The host-side jump account was shadow-state **`L`** (locked) while every working sibling was **`NP`**. The keys were all correct (upstream + tenant present). With **`UsePAM no`** (the hardened setting on jump/BYOC hosts), OpenSSH runs its *own* locked-account check and refuses a locked account **even for public-key auth** — so the lock alone made the box unreachable.

## The bug

`EnsureJumpServerAccount` (`pkg/core/container/jump_server.go`):
- The unlock (`usermod -p '*'`) ran **only on the create path**. The already-exists branch fixed the shell and returned — so an account left locked **never self-healed**.
- The create-path unlock **swallowed its error** (`_ = …Run()`), so one failed `usermod` left the account permanently `L`.

## Fix

- Extract `ensureJumpAccountState` (unlock + home perms + `.ssh` + sudoers) and run it on **both** the create and already-exists paths → a misprovisioned account recovers on the next create/reconcile (`EnsureJumpServerAccount` is called on every container create).
- `ensureAccountUnlocked` **verifies** the result with `passwd -S` and returns an error if the account is still `L`, instead of swallowing the unlock.
- `passwdStatusLocked` parses the status field; unit-tested with the real `L` vs `NP` shapes seen live.

## Test
- `TestPasswdStatusLocked` (new) covers locked/NP/P/empty/malformed.
- `go build` / `go vet` / `gofmt` / full `pkg/core/container` suite green.

## Scope
This is the host-account half of the BYOC SSH work (#687/#688). It self-heals existing locked accounts on the next ensure. (Per-host/asymmetric sentinel auth remains separate under #688.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)