### PR TITLE
fix(jump): verify unlock via shadow "!" prefix, not passwd -S (#687)

### DIFF
--- a/pkg/core/container/jump_server.go
+++ b/pkg/core/container/jump_server.go
@@ -189,7 +189,8 @@ func ensureJumpAccountState(username string) error {
 }
 
 // ensureAccountUnlocked guarantees the account's password is disabled but the
-// account is NOT locked (shadow state "NP"/"P", never "L").
+// account is NOT locked from sshd's perspective (shadow password must not start
+// with "!").
 //
 // useradd creates accounts locked ("!" password). With `UsePAM no` — the
 // hardened setting on jump/BYOC hosts — OpenSSH performs its OWN locked-account
@@ -201,39 +202,47 @@ func ensureJumpAccountState(username string) error {
 // (a single earlier failure must not strand the box), and its result must be
 // verified rather than swallowed.
 //
-// `usermod -p '*'` sets "no valid password" without the lock prefix; it is
-// idempotent and safe to re-run, and (unlike `passwd -d`'s empty password)
-// portable across distros.
+// `usermod -p '*'` sets the password field to "*" — "no valid password" but NOT
+// the "!" lock prefix; it is idempotent, safe to re-run, and (unlike
+// `passwd -d`'s empty password) portable across distros. OpenSSH accepts "*"
+// (and an empty field) for public-key auth; it rejects only "!"-prefixed.
 func ensureAccountUnlocked(username string) error {
 	// #nosec G204 -- callers validate username via isValidUsername
 	if out, err := exec.Command("usermod", "-p", "*", username).CombinedOutput(); err != nil {
 		return fmt.Errorf("unlock account %s: %w (output: %s)", username, err, strings.TrimSpace(string(out)))
 	}
 
-	// Verify the account is no longer locked. `passwd -S` prints
-	// "<user> <L|P|NP> <date> ...". A lingering "L" means SSH will keep
-	// failing, so surface it instead of reporting success.
+	// Verify the account is no longer locked. We must read the shadow password
+	// field directly, NOT `passwd -S`: that tool reports both "!" (truly locked,
+	// sshd rejects) and "*" (the value we just set, which sshd accepts) as "L",
+	// so it cannot tell a working account from a broken one. sshd's locked check
+	// keys off the "!" prefix, so we do the same.
 	// #nosec G204 -- callers validate username via isValidUsername
-	out, err := exec.Command("passwd", "-S", username).Output()
+	out, err := exec.Command("getent", "shadow", username).Output()
 	if err != nil {
-		// passwd -S unavailable / not permitted in this environment: the
-		// usermod above already succeeded, so don't fail the whole ensure on
-		// a verification gap.
+		// getent/shadow unavailable or not permitted: the usermod above already
+		// succeeded, so don't fail the whole ensure on a verification gap.
 		return nil
 	}
-	if passwdStatusLocked(string(out)) {
-		return fmt.Errorf("account %s still locked after unlock attempt (passwd -S: %q)", username, strings.TrimSpace(string(out)))
+	if shadowAccountLocked(string(out)) {
+		// Deliberately does NOT echo the shadow line (it carries the hash).
+		return fmt.Errorf("account %s still locked after unlock attempt", username)
 	}
 	return nil
 }
 
-// passwdStatusLocked reports whether `passwd -S` output indicates a locked
-// account. The status is the second whitespace field: "L" (locked), "P"
-// (usable password), or "NP" (no password). Anything we can't parse is treated
-// as not-locked so a quirky passwd implementation can't wedge provisioning.
-func passwdStatusLocked(passwdSOutput string) bool {
-	fields := strings.Fields(passwdSOutput)
-	return len(fields) >= 2 && fields[1] == "L"
+// shadowAccountLocked reports whether a getent-shadow line shows an account
+// OpenSSH treats as locked: the password field (2nd colon-separated field)
+// starts with "!". An empty field ("NP") or "*" ("disabled, not locked") is NOT
+// locked — both permit public-key auth under `UsePAM no`. A line we can't parse
+// is treated as not-locked so a quirky environment can't wedge provisioning.
+func shadowAccountLocked(getentShadowLine string) bool {
+	line := strings.TrimRight(getentShadowLine, "\r\n")
+	parts := strings.SplitN(line, ":", 3)
+	if len(parts) < 2 {
+		return false
+	}
+	return strings.HasPrefix(parts[1], "!")
 }
 
 // isValidUsername checks if username contains only allowed characters

--- a/pkg/core/container/jump_server_test.go
+++ b/pkg/core/container/jump_server_test.go
@@ -7,26 +7,30 @@ import (
 	"time"
 )
 
-func TestPasswdStatusLocked(t *testing.T) {
-	// Inputs are real `passwd -S` lines observed on a BYOC host: the broken
-	// jump account was "L" while working siblings were "NP".
+func TestShadowAccountLocked(t *testing.T) {
+	// Inputs are real getent-shadow shapes seen on a BYOC host. The crux:
+	// "*" (what our unlock sets) and "" (NP sibling) are NOT locked and SSH
+	// works; only "!"-prefixed is locked. `passwd -S` cannot tell "*" from "!"
+	// (reports both as "L"), which is exactly why we parse the field directly.
 	tests := []struct {
 		name string
-		out  string
+		line string
 		want bool
 	}{
-		{"locked account (the bug)", "cld-9c09f73a L 2026-06-23 0 99999 7 -1", true},
-		{"no-password sibling", "apibox-dev-3090 NP 2026-04-02 0 99999 7 -1", false},
-		{"usable password", "alice P 2026-01-01 0 99999 7 -1", false},
-		{"empty output", "", false},
-		{"single field", "weird", false},
-		{"trailing newline locked", "bob L 2026-06-23\n", true},
-		{"locked-substring not status", "Llama NP 2026-01-01", false},
+		{"locked bang (the bug)", "cld-9c09f73a:!:20000:0:99999:7:::", true},
+		{"locked bangbang", "u:!!:20000:0:99999:7:::", true},
+		{"locked bang+hash", "u:!$6$abc$def:20000:0:99999:7:::", true},
+		{"star = disabled not locked (works)", "cld-9c09f73a:*:20000:0:99999:7:::", false},
+		{"empty NP sibling (works)", "apibox-dev-3090::20000:0:99999:7:::", false},
+		{"real password not locked", "alice:$6$salt$hash:20000:0:99999:7:::", false},
+		{"trailing newline locked", "bob:!:20000\n", true},
+		{"empty input", "", false},
+		{"no colon", "garbage", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := passwdStatusLocked(tt.out); got != tt.want {
-				t.Errorf("passwdStatusLocked(%q) = %v, want %v", tt.out, got, tt.want)
+			if got := shadowAccountLocked(tt.line); got != tt.want {
+				t.Errorf("shadowAccountLocked(%q) = %v, want %v", tt.line, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Follow-up to #798 — fixes a false-positive in the unlock verification

#798 verified the unlock with `passwd -S`, but that tool reports **both** `!` (truly locked — sshd rejects) **and** `*` (the value our `usermod -p '*'` unlock sets — sshd *accepts*) as status **`L`**. So after a *successful* unlock the check sees `L`, wrongly concludes "still locked", returns an error, and `ensureJumpAccountState` bails out **before writing the sudoers entry** → broken new-box provisioning on hosts where `*` reads as `L`.

This was caught live: the just-unlocked account has shadow field `*`, **SSH works end-to-end**, yet `passwd -S` reports `L`:

```
$ ssh -i ~/.containarium/keys/cld-9c09f73a cld-9c09f73a@asia-east1.containarium.dev 'hostname; id'
cld-9c09f73a-container
uid=1001(cld-9c09f73a) ... groups=...,27(sudo),...
$ sudo passwd -S cld-9c09f73a      # => L   (but SSH clearly works)
$ sudo getent shadow cld-9c09f73a  # field 2 => "*"
```

## Fix

Verify by reading the **shadow password field** directly and treat the account as locked **only when it starts with `!`** — exactly sshd's own locked-account check under `UsePAM no`. `*` and an empty field (`NP`) are accepted for public-key auth.

- Replace `passwdStatusLocked` with `shadowAccountLocked` (getent-shadow parser).
- The error no longer echoes the shadow line (it carries the password hash).
- Test updated with the real `!` / `*` / `NP` shapes.

## Validation
BYOC SSH proof now confirmed working end-to-end from the client (above). `go build` / `vet` / `gofmt` / full `pkg/core/container` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)