### PR TITLE
feat(auth): wire ed25519 sentinel auth + keygen (#688, PR 2/2)

### DIFF
--- a/internal/cmd/sentinel_keygen.go
+++ b/internal/cmd/sentinel_keygen.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var sentinelKeygenCmd = &cobra.Command{
+	Use:   "keygen",
+	Short: "Generate an ed25519 keypair for sentinel→daemon authentication (#688)",
+	Long: `Generate an ed25519 keypair for the asymmetric sentinel→daemon auth scheme.
+
+The sentinel signs keysync/certsync requests (and the peer-discovery response)
+with the PRIVATE key; every daemon verifies with only the PUBLIC key. Because a
+daemon never holds the private key, the public key is safe to distribute to any
+host — including untrusted BYO-compute (BYOC) hosts — without granting the
+ability to forge a sentinel request.
+
+This prints two values:
+
+  CONTAINARIUM_SENTINEL_SIGNING_KEY   set on the SENTINEL only (keep secret)
+  CONTAINARIUM_SENTINEL_PUBLIC_KEY    set on EVERY daemon (safe to distribute)
+
+Rollout order matters: distribute the public key to ALL daemons first, THEN set
+the signing key on the sentinel. Otherwise a daemon that hasn't received the
+public key yet will reject the sentinel's ed25519 signatures and keysync breaks.
+During migration both the new keys and the legacy CONTAINARIUM_SENTINEL_AUTH_SECRET
+are accepted; once every daemon verifies ed25519, drop the shared secret.`,
+	RunE: runSentinelKeygen,
+}
+
+func init() {
+	sentinelCmd.AddCommand(sentinelKeygenCmd)
+}
+
+func runSentinelKeygen(cmd *cobra.Command, args []string) error {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate ed25519 key: %w", err)
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, "# Sentinel→daemon ed25519 keypair (#688).")
+	fmt.Fprintln(out, "# Distribute the PUBLIC key to every daemon FIRST, then set the")
+	fmt.Fprintln(out, "# SIGNING key on the sentinel. Keep the signing key secret.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "# On the SENTINEL only:")
+	fmt.Fprintf(out, "CONTAINARIUM_SENTINEL_SIGNING_KEY=%s\n", base64.StdEncoding.EncodeToString(priv))
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "# On EVERY daemon (safe to distribute, incl. BYOC):")
+	fmt.Fprintf(out, "CONTAINARIUM_SENTINEL_PUBLIC_KEY=%s\n", base64.StdEncoding.EncodeToString(pub))
+	return nil
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -68,6 +69,13 @@ type GatewayServer struct {
 	// acceptable default for these endpoints (see audit C-CRIT-4 and
 	// A-CRIT-4).
 	sentinelAuthSecret []byte
+
+	// sentinelPubKey is the sentinel's ed25519 PUBLIC key (#688). When
+	// set (CONTAINARIUM_SENTINEL_PUBLIC_KEY) the sentinel endpoints
+	// accept ed25519-signed requests in addition to (or instead of) the
+	// legacy HMAC. A daemon holding only this public key can verify the
+	// sentinel but cannot forge a request — the BYOC-safe configuration.
+	sentinelPubKey ed25519.PublicKey
 
 	// containerExistsFn is the orphan filter used by
 	// /authorized-keys (#343). When set, the handler drops users
@@ -168,6 +176,15 @@ func (gs *GatewayServer) SetRecordDeliveryFn(fn func(ctx context.Context, alertN
 // the daemon and the sentinel.
 func (gs *GatewayServer) SetSentinelAuthSecret(secret []byte) {
 	gs.sentinelAuthSecret = secret
+}
+
+// SetSentinelPublicKey configures the sentinel's ed25519 public key (#688).
+// When set, the sentinel endpoints additionally accept ed25519-signed requests
+// (dual-accept with any configured HMAC secret). Source is
+// CONTAINARIUM_SENTINEL_PUBLIC_KEY; the key is safe to distribute to any host,
+// including BYOC, since a verifier cannot forge requests.
+func (gs *GatewayServer) SetSentinelPublicKey(pub ed25519.PublicKey) {
+	gs.sentinelPubKey = pub
 }
 
 // SetContainerExistsFn wires the orphan filter for /authorized-keys.
@@ -705,13 +722,14 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 
 	// Sentinel-facing endpoints: /certs and /authorized-keys[/sentinel].
 	// Previously "no auth — VPC-internal only"; that comment never
-	// stopped a firewall misconfiguration. Now gated by HMAC over
-	// CONTAINARIUM_SENTINEL_AUTH_SECRET (auth.SentinelHMACMiddleware).
-	// Fail-closed: if the secret isn't configured, all requests get
-	// 401. See findings A-CRIT-4 and A-HIGH-2.
-	httpMux.Handle("/certs", auth.SentinelHMACMiddleware(gs.sentinelAuthSecret, ServeCerts(gs.caddyCertDir)))
-	httpMux.Handle("/authorized-keys", auth.SentinelHMACMiddleware(gs.sentinelAuthSecret, ServeAuthorizedKeys("", gs.containerExistsFn)))
-	httpMux.Handle("/authorized-keys/sentinel", auth.SentinelHMACMiddleware(gs.sentinelAuthSecret, ServeSentinelKey()))
+	// stopped a firewall misconfiguration. Now gated by a SentinelVerifier
+	// that accepts ed25519 (CONTAINARIUM_SENTINEL_PUBLIC_KEY, #688) and/or
+	// the legacy HMAC (CONTAINARIUM_SENTINEL_AUTH_SECRET). Fail-closed: if
+	// neither is configured, all requests get 401. See A-CRIT-4 / A-HIGH-2.
+	sentinelVerifier := auth.NewSentinelVerifier(gs.sentinelPubKey, gs.sentinelAuthSecret)
+	httpMux.Handle("/certs", sentinelVerifier.Middleware(ServeCerts(gs.caddyCertDir)))
+	httpMux.Handle("/authorized-keys", sentinelVerifier.Middleware(ServeAuthorizedKeys("", gs.containerExistsFn)))
+	httpMux.Handle("/authorized-keys/sentinel", sentinelVerifier.Middleware(ServeSentinelKey()))
 
 	// Catch-all fallback: when wake-on-HTTP is enabled, Caddy
 	// forwards user traffic to this daemon while a container is

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -2,6 +2,7 @@ package sentinel
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -386,14 +387,19 @@ func (m *Manager) PeersHandler() http.HandlerFunc {
 			return
 		}
 
-		// HMAC-sign the response so a compromised network path (or
-		// future sentinel-impersonator) can't inject attacker peer
-		// URLs. The daemon verifies before trusting any peer entry.
-		// When the secret is unset, no headers are written and the
-		// daemon's verifier will fail-closed — operators see the
-		// peer-discovery failure rather than silently trusting an
-		// unsigned list. See finding C-CRIT-2.
-		auth.SignSentinelResponse(w, m.hmacSecret, body)
+		// Sign the response so a compromised network path (or future
+		// sentinel-impersonator) can't inject attacker peer URLs. The
+		// daemon verifies before trusting any peer entry. Prefer ed25519
+		// (#688) when a signing key is configured; else fall back to the
+		// shared-secret HMAC. When neither is set, no headers are written
+		// and the daemon's verifier fails closed — operators see the
+		// peer-discovery failure rather than silently trusting an unsigned
+		// list. See finding C-CRIT-2.
+		if priv := loadSentinelSigningKey(); len(priv) == ed25519.PrivateKeySize {
+			auth.SignSentinelResponseEd25519(w, priv, body)
+		} else {
+			auth.SignSentinelResponse(w, m.hmacSecret, body)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(body)

--- a/internal/sentinel/sentinel_auth.go
+++ b/internal/sentinel/sentinel_auth.go
@@ -1,10 +1,12 @@
 package sentinel
 
 import (
+	"crypto/ed25519"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -35,11 +37,35 @@ var (
 	sentinelSecretOnce sync.Once
 	sentinelSecret     []byte
 
+	// sentinelSigningKey is the sentinel's ed25519 PRIVATE key (#688),
+	// loaded once from CONTAINARIUM_SENTINEL_SIGNING_KEY. When present it
+	// is preferred over the HMAC secret for signing outbound requests +
+	// responses — daemons verify with only the matching public key and so
+	// cannot forge. Nil when unset/invalid (→ HMAC fallback).
+	sentinelSigningKeyOnce sync.Once
+	sentinelSigningKey     ed25519.PrivateKey
+
 	// lastMisconfigLogNs is the unix-nanos of the last per-call
 	// WARNING. atomic.Int64 so concurrent keysync + certsync calls
 	// don't double-log every minute.
 	lastMisconfigLogNs atomic.Int64
 )
+
+// loadSentinelSigningKey returns the sentinel's ed25519 private key
+// (CONTAINARIUM_SENTINEL_SIGNING_KEY), or nil when unset/invalid.
+func loadSentinelSigningKey() ed25519.PrivateKey {
+	sentinelSigningKeyOnce.Do(func() {
+		if raw := strings.TrimSpace(os.Getenv("CONTAINARIUM_SENTINEL_SIGNING_KEY")); raw != "" {
+			if priv, err := auth.ParseSentinelSigningKey(raw); err != nil {
+				log.Printf("[sentinel-auth] WARNING: CONTAINARIUM_SENTINEL_SIGNING_KEY is set but invalid (%v) — falling back to HMAC signing", err)
+			} else {
+				sentinelSigningKey = priv
+				log.Printf("[sentinel-auth] ed25519 signing key configured — outbound sentinel→daemon requests/responses are ed25519-signed")
+			}
+		}
+	})
+	return sentinelSigningKey
+}
 
 func loadSentinelSecret() []byte {
 	sentinelSecretOnce.Do(func() {
@@ -70,7 +96,11 @@ func newSignedRequest(method, url string, body io.Reader) (*http.Request, error)
 	if err != nil {
 		return nil, err
 	}
-	if secret := loadSentinelSecret(); len(secret) >= auth.SentinelMinSecretLen {
+	// Prefer ed25519 (#688) when a signing key is configured; else fall
+	// back to the legacy shared-secret HMAC.
+	if priv := loadSentinelSigningKey(); len(priv) == ed25519.PrivateKeySize {
+		auth.SignSentinelRequestEd25519(req, priv)
+	} else if secret := loadSentinelSecret(); len(secret) >= auth.SentinelMinSecretLen {
 		auth.SignSentinelRequest(req, secret)
 	} else {
 		logSentinelMisconfigOncePerInterval()

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1354,6 +1354,21 @@ skipAppHosting:
 			log.Printf("WARNING: CONTAINARIUM_SENTINEL_AUTH_SECRET is unset — /certs, /authorized-keys, /authorized-keys/sentinel will return 401 until configured")
 		}
 
+		// Sentinel ed25519 public key (#688). When set, the sentinel
+		// endpoints additionally accept ed25519-signed requests — the
+		// asymmetric successor to the shared HMAC. A daemon (incl. BYOC)
+		// holding only this public key can verify the sentinel but cannot
+		// forge a request, so it's safe to distribute everywhere. Optional:
+		// when unset the daemon stays on HMAC-only (no behavior change).
+		if pubB64 := strings.TrimSpace(os.Getenv("CONTAINARIUM_SENTINEL_PUBLIC_KEY")); pubB64 != "" {
+			if pub, err := auth.ParseSentinelPublicKey(pubB64); err != nil {
+				log.Printf("WARNING: CONTAINARIUM_SENTINEL_PUBLIC_KEY is set but invalid (%v) — falling back to HMAC-only for sentinel endpoints", err)
+			} else {
+				gatewayServer.SetSentinelPublicKey(pub)
+				log.Printf("Sentinel ed25519 public key configured — /certs, /authorized-keys[/sentinel] accept ed25519-signed requests")
+			}
+		}
+
 		// Orphan filter for /authorized-keys (#343). When a container
 		// is deleted but its host user / home dir survives (userdel
 		// failed under lock contention, or the user was provisioned

--- a/internal/server/peer.go
+++ b/internal/server/peer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"crypto/ed25519"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -291,6 +292,27 @@ func loadSentinelHMACSecret() []byte {
 	return sentinelHMACSecret
 }
 
+// sentinelPubKey caches the sentinel's ed25519 public key
+// (CONTAINARIUM_SENTINEL_PUBLIC_KEY, #688) used to verify the signed
+// /sentinel/peers response. Nil when unset or invalid.
+var (
+	sentinelPubKeyOnce sync.Once
+	sentinelPubKey     ed25519.PublicKey
+)
+
+func loadSentinelPublicKey() ed25519.PublicKey {
+	sentinelPubKeyOnce.Do(func() {
+		if raw := strings.TrimSpace(os.Getenv("CONTAINARIUM_SENTINEL_PUBLIC_KEY")); raw != "" {
+			if pub, err := auth.ParseSentinelPublicKey(raw); err != nil {
+				log.Printf("[peers] CONTAINARIUM_SENTINEL_PUBLIC_KEY invalid (%v) — falling back to HMAC for discovery verification", err)
+			} else {
+				sentinelPubKey = pub
+			}
+		}
+	})
+	return sentinelPubKey
+}
+
 // discover fetches peer list from sentinel's /sentinel/peers endpoint.
 // When p.pool is non-empty, ?pool=<name> is appended so the sentinel returns
 // only peers tagged with that pool.
@@ -332,16 +354,19 @@ func (p *PeerPool) discover() {
 	// Verify the sentinel signed the response. Fail-closed: an
 	// unsigned or tampered response leaves the peer map unchanged
 	// rather than silently trusting unauthenticated discovery data.
-	if secret := loadSentinelHMACSecret(); len(secret) >= auth.SentinelMinSecretLen {
-		if err := auth.VerifySentinelResponse(resp, secret, body, time.Now()); err != nil {
-			log.Printf("[peers] discovery signature verify failed; refusing to update peer map (set CONTAINARIUM_SENTINEL_AUTH_SECRET on the sentinel to match the daemon's): %v", err)
+	// Dual-accept (#688): ed25519 (CONTAINARIUM_SENTINEL_PUBLIC_KEY) and/or
+	// the legacy HMAC (CONTAINARIUM_SENTINEL_AUTH_SECRET).
+	verifier := auth.NewSentinelVerifier(loadSentinelPublicKey(), loadSentinelHMACSecret())
+	if verifier.Configured() {
+		if err := verifier.VerifyResponse(resp, body, time.Now()); err != nil {
+			log.Printf("[peers] discovery signature verify failed; refusing to update peer map (set CONTAINARIUM_SENTINEL_PUBLIC_KEY or _AUTH_SECRET to match the sentinel): %v", err)
 			return
 		}
 	} else {
 		// Loud warning, but stay backwards-compatible while operators
-		// roll out the env var on both ends. Once 100% of fleets carry
-		// the secret this branch should become an unconditional return.
-		log.Printf("[peers] CONTAINARIUM_SENTINEL_AUTH_SECRET is unset on this daemon — accepting unsigned discovery response (vulnerable to C-CRIT-2 until configured)")
+		// roll out the keys on both ends. Once 100% of fleets carry a
+		// sentinel key this branch should become an unconditional return.
+		log.Printf("[peers] no sentinel verifier configured (set CONTAINARIUM_SENTINEL_PUBLIC_KEY or _AUTH_SECRET) — accepting unsigned discovery response (vulnerable to C-CRIT-2 until configured)")
 	}
 
 	var result struct {


### PR DESCRIPTION
**Epic #688 — PR 2/2.** Wires the ed25519 `SentinelVerifier` from PR 1 (#801) into config + call sites and adds the keygen helper.

**Safe by default:** with no ed25519 env set, every path behaves exactly as today (HMAC). This is a no-op until an operator opts in — so it can land ahead of the sequenced rollout.

## Daemon (verifier)
- **gateway** — stores the sentinel ed25519 public key; `/certs`, `/authorized-keys`, `/authorized-keys/sentinel` now use `auth.NewSentinelVerifier(pub, hmacSecret).Middleware` (dual-accept).
- **dual_server** — loads `CONTAINARIUM_SENTINEL_PUBLIC_KEY` → `SetSentinelPublicKey` (logs + falls back to HMAC on invalid).
- **peer.go** — verifies the `/sentinel/peers` response via the same dual verifier.

## Sentinel (signer)
- **sentinel_auth.go** — loads `CONTAINARIUM_SENTINEL_SIGNING_KEY`; prefers `SignSentinelRequestEd25519` for outbound keysync/certsync, else HMAC.
- **manager.go** — signs the `/sentinel/peers` response with ed25519 when the signing key is set, else HMAC.

## CLI
- `containarium sentinel keygen` — emits a base64 keypair with both env var names + the rollout-order note.

## Security goal (#688)
A daemon (incl. BYOC) configured with **only the public key** can verify the sentinel but **cannot forge** a request — closing the cross-tenant escalation where a BYOC host holding the symmetric secret could push keys to the multi-tenant workhorse. The daemon→sentinel PKI bootstrap (`/sentinel/ca`, `/sentinel/peer-cert`) stays on HMAC (separate direction).

## Rollout (sequenced — see #688)
1. Ship a release carrying PR 1 + PR 2 everywhere (keys unset ⇒ HMAC, no change).
2. `CONTAINARIUM_SENTINEL_PUBLIC_KEY` on **every** daemon first.
3. `CONTAINARIUM_SENTINEL_SIGNING_KEY` on the sentinel → ed25519 signing; daemons dual-accept.
4. Drop `CONTAINARIUM_SENTINEL_AUTH_SECRET` from daemons → ed25519-only.

## Test
`go build` / `vet` / `gofmt` clean across gateway/server/sentinel/cmd/auth; `internal/auth` + `internal/sentinel` suites green; `sentinel keygen` smoke-tested. Live validation on the BYOC host is the operator step (per #688).

🤖 Generated with [Claude Code](https://claude.com/claude-code)