### PR TITLE
fix(cmd): //go:build !windows on sentinel keygen (release build fix)

### DIFF
--- a/internal/cmd/sentinel_keygen.go
+++ b/internal/cmd/sentinel_keygen.go
@@ -1,3 +1,10 @@
+//go:build !windows
+
+// The sentinel command tree (sentinelCmd, defined in sentinel.go) is
+// !windows-only — the Windows build ships only the remote-client commands. This
+// subcommand attaches to sentinelCmd, so it must carry the same constraint or
+// the Windows cross-compile fails with "undefined: sentinelCmd".
+
 package cmd
 
 import (


### PR DESCRIPTION
The v0.45.0 release build **failed** on the Windows cross-compile:

```
internal/cmd/sentinel_keygen.go:37:2: undefined: sentinelCmd
make: *** [build-all] Error 1
```

`sentinel_keygen.go` (added in #802) attaches to `sentinelCmd`, which is defined in `sentinel.go` under `//go:build !windows` (the Windows build ships only the remote-client commands). The keygen file lacked the constraint, so the Windows target compiled keygen but excluded `sentinelCmd`. PR CI only builds linux, so it passed there; only the release workflow does the Windows cross-compile.

Fix: add `//go:build !windows` to match `sentinel.go` / `sentinel_service.go` / `pool_sentinel.go`. Verified `GOOS=windows go build ./cmd/containarium/` and the linux build both pass.

After merge, v0.45.0 will be re-cut on the fixed commit (the failed tag produced no release assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)