### PR TITLE
fix(gateway): route /__gateway/{status,healthz} at root in embedded daemon (#794)

### DIFF
--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -606,6 +606,20 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 	// platform JWT. The handler injects the real provider key and proxies.
 	if gs.modelGatewayHandler != nil {
 		httpMux.Handle("/v1/model/", gs.modelGatewayHandler)
+		// The gateway's own mux also serves /__gateway/* diagnostics, but
+		// mounting it only under /v1/model/ left those paths unreachable when
+		// embedded in the daemon: /__gateway/status fell through to the wake
+		// catch-all, and /v1/model/__gateway/status was parsed as a provider
+		// ("unknown provider: __gateway"). #794's live gauge was therefore
+		// invisible in the production (embedded) deployment. Route the
+		// non-sensitive diagnostics to the gateway handler at root so an
+		// operator can `curl localhost:<http-port>/__gateway/status`.
+		//
+		// /__gateway/usage is deliberately NOT exposed here — it carries
+		// per-tenant token counts and this handler is unwrapped by JWT auth;
+		// usage already flows to the metrics/billing pipeline via the OTLP sink.
+		httpMux.Handle("/__gateway/status", gs.modelGatewayHandler)
+		httpMux.Handle("/__gateway/healthz", gs.modelGatewayHandler)
 	}
 
 	// Core services endpoint (with authentication via CORS handler)

--- a/internal/gateway/model_gateway_route_test.go
+++ b/internal/gateway/model_gateway_route_test.go
@@ -1,0 +1,67 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/modelgateway"
+)
+
+// TestModelGatewayDiagnosticsRouting locks the embedded-daemon routing fix:
+// the model-gateway handler is mounted under /v1/model/, but its #794
+// /__gateway/status diagnostics gauge must ALSO be reachable at the daemon
+// root — otherwise it falls through to the wake catch-all (the bug this fix
+// addresses), and /v1/model/__gateway/status is parsed as a provider name.
+//
+// /__gateway/usage must NOT be exposed at root: it carries per-tenant token
+// counts and the handler is unwrapped by JWT auth.
+//
+// The test mirrors the relevant routes registered in GatewayServer.Start()
+// (the real mux is built there, intertwined with listener setup, so it isn't
+// unit-constructable) against the REAL model-gateway handler.
+func TestModelGatewayDiagnosticsRouting(t *testing.T) {
+	gw := modelgateway.New(modelgateway.Config{}).Handler()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		// Stand-in for the daemon's wake catch-all.
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("wake: no matching route"))
+	})
+	mux.Handle("/v1/model/", gw)
+	// The two lines under test (must match gateway.go Start()).
+	mux.Handle("/__gateway/status", gw)
+	mux.Handle("/__gateway/healthz", gw)
+
+	get := func(path string) (int, string) {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		return rec.Code, rec.Body.String()
+	}
+
+	// /__gateway/status is reachable at root and returns the inflight gauge.
+	code, body := get("/__gateway/status")
+	if code != http.StatusOK {
+		t.Fatalf("/__gateway/status: want 200, got %d (%s)", code, body)
+	}
+	var gauge map[string]any
+	if err := json.Unmarshal([]byte(body), &gauge); err != nil {
+		t.Fatalf("/__gateway/status body not JSON: %v (%s)", err, body)
+	}
+	if _, ok := gauge["inflight"]; !ok {
+		t.Errorf("/__gateway/status missing inflight gauge: %s", body)
+	}
+
+	// /__gateway/healthz is reachable at root.
+	if code, _ := get("/__gateway/healthz"); code != http.StatusOK {
+		t.Errorf("/__gateway/healthz: want 200, got %d", code)
+	}
+
+	// /__gateway/usage is NOT exposed at root → falls to the wake catch-all.
+	if _, body := get("/__gateway/usage"); !strings.Contains(body, "wake: no matching route") {
+		t.Errorf("/__gateway/usage must not be exposed at daemon root; got %q", body)
+	}
+}


### PR DESCRIPTION
#794's `/__gateway/status` live gauge (`{inflight,completed,failed}`) was **unreachable when the model-gateway is embedded in the daemon** — the production path. The handler is mounted only under `/v1/model/`, so:
- `/__gateway/status` at the daemon root → wake catch-all (`wake: no matching route`)
- `/v1/model/__gateway/status` → `unknown provider: __gateway`

It only worked in the standalone `cmd/model-gateway`. Found live while upgrading a host to v0.45.0 to recover model-gateway visibility.

**Fix:** route the non-sensitive diagnostics (`/__gateway/status`, `/__gateway/healthz`) to the gateway handler at the daemon root. `/__gateway/usage` is intentionally **not** exposed there — it carries per-tenant token counts and the handler is unwrapped by JWT auth (usage already flows to the metrics/billing pipeline via the OTLP sink).

**Test:** `TestModelGatewayDiagnosticsRouting` mirrors the `Start()` routes against the real model-gateway handler — status/healthz reachable, usage falls to the catch-all. The per-request START/END logging (the primary visibility) was already working in v0.45.0; this just restores the curl-able gauge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)