### PR TITLE
feat(egress): host-side egress-relay for egress-via-client (#808, Phase 2a)

### DIFF
--- a/internal/cmd/egress_relay.go
+++ b/internal/cmd/egress_relay.go
@@ -1,0 +1,75 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/footprintai/containarium/internal/egressproxy"
+	"github.com/spf13/cobra"
+)
+
+var (
+	egressRelayListen   string
+	egressRelayUpstream string
+	egressRelayAllow    []string
+)
+
+var egressRelayCmd = &cobra.Command{
+	Use:   "egress-relay",
+	Short: "Bridge a box to a host-reachable SOCKS proxy (egress via client, #808)",
+	Long: `Run a source-restricted TCP relay that lets a box egress through a
+host-reachable upstream — typically the operator's SOCKS proxy reachable from
+this host (e.g. over Tailscale). This is the host-side ("Phase 2a") piece of
+"egress via client".
+
+Why it's needed: a box runs in its own network namespace and can reach the
+host's bridge gateway, but not a host-side ssh -R listener (host loopback) or an
+off-box network directly. Bind --listen on a bridge-gateway address the box can
+reach; the relay forwards to --upstream and accepts ONLY --allow source IPs (the
+target box), which is the multi-tenant boundary. The box's apps point at the
+relay as their SOCKS proxy (the SOCKS handshake passes straight through).
+
+Example (box 10.100.0.156, bridge gw 10.100.0.1, operator SOCKS on a tailnet IP):
+
+  containarium egress-relay \
+    --listen 10.100.0.1:18080 \
+    --upstream 100.124.9.5:1080 \
+    --allow 10.100.0.156
+
+  # then inside the box:  curl --proxy socks5h://10.100.0.1:18080 https://ifconfig.me
+  # (or Chrome --proxy-server=socks5://10.100.0.1:18080)
+
+Runs in the foreground until interrupted.`,
+	RunE: runEgressRelay,
+}
+
+func init() {
+	rootCmd.AddCommand(egressRelayCmd)
+	egressRelayCmd.Flags().StringVar(&egressRelayListen, "listen", "", "host bind address the box can reach, e.g. 10.100.0.1:18080 (required)")
+	egressRelayCmd.Flags().StringVar(&egressRelayUpstream, "upstream", "", "host-reachable SOCKS proxy to forward to, e.g. 100.124.9.5:1080 (required)")
+	egressRelayCmd.Flags().StringArrayVar(&egressRelayAllow, "allow", nil, "permitted source IP or CIDR (the target box); repeatable; required (empty = deny all)")
+}
+
+func runEgressRelay(cmd *cobra.Command, args []string) error {
+	if egressRelayListen == "" || egressRelayUpstream == "" {
+		return fmt.Errorf("--listen and --upstream are required")
+	}
+	if len(egressRelayAllow) == 0 {
+		return fmt.Errorf("--allow is required (a relay with no allowed source forwards for no one)")
+	}
+
+	r, err := egressproxy.New(egressRelayListen, egressRelayUpstream, egressRelayAllow, log.Printf)
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return r.Serve(ctx)
+}

--- a/internal/egressproxy/relay.go
+++ b/internal/egressproxy/relay.go
@@ -1,0 +1,169 @@
+// Package egressproxy implements the host-side relay for "egress via client"
+// (#808, Phase 2a).
+//
+// A box runs in its own network namespace and can reach the host's bridge
+// gateway, but NOT a host-side `ssh -R` listener (host loopback) or, directly,
+// an off-box network like the operator's tailnet. The relay bridges the two:
+// it binds a bridge-gateway address the box can reach, accepts ONLY the target
+// box's source IP (the multi-tenant boundary), and forwards each connection to
+// a host-reachable upstream — typically the operator's SOCKS proxy reachable
+// from the host (e.g. over Tailscale). The box's apps point at the relay as
+// their SOCKS proxy and egress with the operator's IP.
+//
+// The relay is intentionally protocol-agnostic raw TCP: a SOCKS handshake from
+// the box passes straight through to the upstream SOCKS server.
+package egressproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Relay is a source-restricted TCP forwarder. The zero value is not usable;
+// construct with New.
+type Relay struct {
+	listen   string
+	upstream string
+	allow    []netip.Prefix
+	logf     func(string, ...any)
+
+	mu sync.Mutex
+	ln net.Listener
+}
+
+// New builds a relay. listen and upstream are host:port. allow is a list of
+// source prefixes (CIDR) or bare IPs (treated as /32 or /128) permitted to use
+// the relay; an empty allow list denies everyone (fail-closed). logf may be nil.
+func New(listen, upstream string, allow []string, logf func(string, ...any)) (*Relay, error) {
+	if _, _, err := net.SplitHostPort(listen); err != nil {
+		return nil, fmt.Errorf("invalid --listen %q: %w", listen, err)
+	}
+	if _, _, err := net.SplitHostPort(upstream); err != nil {
+		return nil, fmt.Errorf("invalid --upstream %q: %w", upstream, err)
+	}
+	prefixes, err := parseAllow(allow)
+	if err != nil {
+		return nil, err
+	}
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	return &Relay{listen: listen, upstream: upstream, allow: prefixes, logf: logf}, nil
+}
+
+// parseAllow turns CIDR/bare-IP strings into prefixes. A bare IP becomes a
+// host route (/32 or /128).
+func parseAllow(allow []string) ([]netip.Prefix, error) {
+	var out []netip.Prefix
+	for _, a := range allow {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if strings.Contains(a, "/") {
+			p, err := netip.ParsePrefix(a)
+			if err != nil {
+				return nil, fmt.Errorf("invalid --allow %q: %w", a, err)
+			}
+			out = append(out, p)
+			continue
+		}
+		ip, err := netip.ParseAddr(a)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --allow %q: %w", a, err)
+		}
+		out = append(out, netip.PrefixFrom(ip, ip.BitLen()))
+	}
+	return out, nil
+}
+
+// sourceAllowed reports whether src is permitted. Fail-closed: no prefixes ⇒
+// nothing allowed.
+func (r *Relay) sourceAllowed(src netip.Addr) bool {
+	src = src.Unmap()
+	for _, p := range r.allow {
+		if p.Contains(src) {
+			return true
+		}
+	}
+	return false
+}
+
+// Serve listens and forwards until ctx is cancelled or a fatal accept error
+// occurs. Close (or ctx cancel) makes it return.
+func (r *Relay) Serve(ctx context.Context) error {
+	ln, err := net.Listen("tcp", r.listen)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", r.listen, err)
+	}
+	r.mu.Lock()
+	r.ln = ln
+	r.mu.Unlock()
+	r.logf("egress-relay %s -> %s (allow %v)", r.listen, r.upstream, r.allow)
+
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	for {
+		c, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				return fmt.Errorf("accept: %w", err)
+			}
+		}
+		go r.handle(c)
+	}
+}
+
+func (r *Relay) handle(c net.Conn) {
+	defer c.Close()
+	ap, ok := remoteAddrPort(c.RemoteAddr())
+	if !ok || !r.sourceAllowed(ap.Addr()) {
+		r.logf("egress-relay DENY %s (allow %v)", c.RemoteAddr(), r.allow)
+		return
+	}
+	up, err := net.DialTimeout("tcp", r.upstream, 15*time.Second)
+	if err != nil {
+		r.logf("egress-relay upstream %s dial failed: %v", r.upstream, err)
+		return
+	}
+	defer up.Close()
+	// Bidirectional copy; both directions end when either side closes.
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(up, c); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(c, up); done <- struct{}{} }()
+	<-done
+}
+
+// remoteAddrPort extracts a netip.AddrPort from a net.Addr (TCP).
+func remoteAddrPort(a net.Addr) (netip.AddrPort, bool) {
+	if ta, ok := a.(*net.TCPAddr); ok {
+		return ta.AddrPort(), true
+	}
+	ap, err := netip.ParseAddrPort(a.String())
+	if err != nil {
+		return netip.AddrPort{}, false
+	}
+	return ap, true
+}
+
+// Close stops the relay.
+func (r *Relay) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.ln != nil {
+		return r.ln.Close()
+	}
+	return nil
+}

--- a/internal/egressproxy/relay_test.go
+++ b/internal/egressproxy/relay_test.go
@@ -1,0 +1,130 @@
+package egressproxy
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+)
+
+func TestParseAllow_AndSourceAllowed(t *testing.T) {
+	r, err := New("127.0.0.1:0", "127.0.0.1:1", []string{"10.100.0.156", "192.168.0.0/16"}, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"10.100.0.156", true},  // exact box IP (/32)
+		{"10.100.0.157", false}, // sibling box on the same bridge — must be denied
+		{"192.168.5.9", true},   // inside the CIDR
+		{"10.0.0.1", false},     // unrelated
+	}
+	for _, c := range cases {
+		got := r.sourceAllowed(mustAddr(t, c.ip))
+		if got != c.want {
+			t.Errorf("sourceAllowed(%s) = %v, want %v", c.ip, got, c.want)
+		}
+	}
+}
+
+func TestSourceAllowed_EmptyAllowDeniesAll(t *testing.T) {
+	r, err := New("127.0.0.1:0", "127.0.0.1:1", nil, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if r.sourceAllowed(mustAddr(t, "10.100.0.156")) {
+		t.Error("empty allow list must deny everyone (fail-closed)")
+	}
+}
+
+func TestNew_RejectsBadInput(t *testing.T) {
+	if _, err := New("no-port", "127.0.0.1:1", nil, nil); err == nil {
+		t.Error("expected error on bad listen")
+	}
+	if _, err := New("127.0.0.1:1", "no-port", nil, nil); err == nil {
+		t.Error("expected error on bad upstream")
+	}
+	if _, err := New("127.0.0.1:1", "127.0.0.1:2", []string{"not-an-ip"}, nil); err == nil {
+		t.Error("expected error on bad allow")
+	}
+}
+
+// TestRelay_ForwardsAllowedSource: an allowed source's bytes reach the upstream
+// and the reply comes back. Loopback (127.0.0.1) is the source, so allow it.
+func TestRelay_ForwardsAllowedSource(t *testing.T) {
+	// Echo upstream.
+	up, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("upstream listen: %v", err)
+	}
+	defer up.Close()
+	go func() {
+		for {
+			c, err := up.Accept()
+			if err != nil {
+				return
+			}
+			go func() { _, _ = io.Copy(c, c); c.Close() }()
+		}
+	}()
+
+	r, err := New("127.0.0.1:0", up.Addr().String(), []string{"127.0.0.1/8"}, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Bind explicitly so the test knows the relay address.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("relay listen: %v", err)
+	}
+	r.listen = ln.Addr().String()
+	_ = ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = r.Serve(ctx) }()
+	waitListen(t, r.listen)
+
+	c, err := net.DialTimeout("tcp", r.listen, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial relay: %v", err)
+	}
+	defer c.Close()
+	_ = c.SetDeadline(time.Now().Add(2 * time.Second))
+	if _, err := c.Write([]byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(c, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Fatalf("got %q, want ping (echo through relay)", buf)
+	}
+}
+
+func mustAddr(t *testing.T, s string) netip.Addr {
+	t.Helper()
+	a, err := netip.ParseAddr(s)
+	if err != nil {
+		t.Fatalf("parse %s: %v", s, err)
+	}
+	return a
+}
+
+func waitListen(t *testing.T, addr string) {
+	t.Helper()
+	for i := 0; i < 50; i++ {
+		c, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("relay never came up on %s", addr)
+}


### PR DESCRIPTION
Ships the host-side piece of **egress via client** (#808) as a real command — productizing the manual relay from the live **fts→Mac demo**.

### Validated live
```
box DIRECT egress IP:        211.75.165.177   (fts's network)
box VIA Mac (socks relay):   36.230.33.117    (operator's Mac)
```
The box (own netns) → relay on the bridge gateway (source-restricted to the box) → over Tailscale → Mac SOCKS → internet.

### What's here
- **`internal/egressproxy`** — `Relay`, a source-restricted TCP forwarder. Fail-closed on empty allow-list; raw TCP so a SOCKS handshake passes through. Tests: allow/deny (incl. **sibling-box-on-same-bridge denied** = the multi-tenant boundary), empty-allow, bad input, end-to-end forward through an echo upstream.
- **`containarium egress-relay --listen --upstream --allow`** — CLI-first host command. `!windows` (host tool); Windows cross-compile verified (learned from the v0.45.0 keygen break).

### Usage
```
containarium egress-relay --listen 10.100.0.1:18080 --upstream 100.124.9.5:1080 --allow 10.100.0.156
# in box: curl --proxy socks5h://10.100.0.1:18080 https://ifconfig.me  (or Chrome --proxy-server)
```

### Scope
Phase 2a (host-reachable upstream — e.g. a tailnet host). **Phase 2b** (the cloud-CP egress channel for a NAT'd client + cloud box, the original luckydraw case) builds on this. Design of record: `docs/EGRESS-VIA-CLIENT-DESIGN.md` (#809).

🤖 Generated with [Claude Code](https://claude.com/claude-code)