### PR TITLE
feat(egress): egress-via-client orchestration — daemon RPC + CLI (#808, Phase 2b)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -3336,6 +3336,73 @@
         ]
       }
     },
+    "/v1/network/egress-proxy": {
+      "post": {
+        "summary": "Start egress-via-client proxy",
+        "description": "Bridges a host-loopback SOCKS (exposed by the caller via ssh -R) into a box's network namespace via a source-restricted relay, so the box egresses with the operator's IP.",
+        "operationId": "NetworkService_StartEgressProxy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/StartEgressProxyResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "StartEgressProxyRequest asks the daemon to bridge a host-loopback SOCKS into\na box's netns (#808 egress-via-client).",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StartEgressProxyRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Network"
+        ]
+      }
+    },
+    "/v1/network/egress-proxy/{containerName}": {
+      "delete": {
+        "summary": "Stop egress-via-client proxy",
+        "description": "Tears down the source-restricted egress relay for the named box.",
+        "operationId": "NetworkService_StopEgressProxy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/StopEgressProxyResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "containerName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Network"
+        ]
+      }
+    },
     "/v1/network/passthrough": {
       "get": {
         "summary": "List passthrough routes",
@@ -11068,6 +11135,36 @@
       },
       "title": "StartContainerResponse is the response from starting a container"
     },
+    "StartEgressProxyRequest": {
+      "type": "object",
+      "properties": {
+        "containerName": {
+          "type": "string",
+          "description": "Box (container) whose egress should be routed."
+        },
+        "upstreamPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Host-loopback port where the caller has exposed their SOCKS proxy via\n`ssh -R 127.0.0.1:\u003cupstream_port\u003e:localhost:\u003clocal-socks\u003e`. The daemon's\nrelay forwards box connections to 127.0.0.1:\u003cupstream_port\u003e."
+        },
+        "proxyPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional bridge-gateway port the in-box relay should listen on. 0 = the\ndaemon picks a free port."
+        }
+      },
+      "description": "StartEgressProxyRequest asks the daemon to bridge a host-loopback SOCKS into\na box's netns (#808 egress-via-client)."
+    },
+    "StartEgressProxyResponse": {
+      "type": "object",
+      "properties": {
+        "socksAddress": {
+          "type": "string",
+          "description": "SOCKS address reachable from inside the box, e.g. \"10.100.0.1:18080\".\nPoint the box's apps at socks5://\u003csocks_address\u003e (Chrome:\n--proxy-server=socks5://\u003csocks_address\u003e)."
+        }
+      },
+      "description": "StartEgressProxyResponse returns the in-box SOCKS address to point apps at."
+    },
     "StatusResponse": {
       "type": "object",
       "properties": {
@@ -11122,6 +11219,15 @@
         }
       },
       "title": "StopContainerResponse is the response from stopping a container"
+    },
+    "StopEgressProxyResponse": {
+      "type": "object",
+      "properties": {
+        "stopped": {
+          "type": "boolean"
+        }
+      },
+      "description": "StopEgressProxyResponse is the (empty) ack for a teardown."
     },
     "SuppressPentestFindingBody": {
       "type": "object",

--- a/docs/EGRESS-VIA-CLIENT-DESIGN.md
+++ b/docs/EGRESS-VIA-CLIENT-DESIGN.md
@@ -87,10 +87,20 @@ containarium egress-via-client <box> [--socks-port 1080] [--show]
   box; daemon-side relay that bridges box→upstream with source-IP restriction.
   Directly usable on a **tailnet host** (`--socks` = a host-reachable SOCKS),
   which is the live-demoable slice (fts-13700k reaches the Mac's tailnet SOCKS).
-- **2b — egress channel through the cloud CP (cloud + OSS).** The
-  client-initiated channel (CP endpoint the client dials), yamux multiplex, and
-  the CP→daemon plumbing over the sentinel peer-proxy. This is what makes the
-  **NAT'd-Mac + cloud-box** case work. Proto-first (new RPC), CLI/MCP wired.
+- **2b — daemon-bridged `ssh -R` (OSS, IMPLEMENTED).** Refined during live
+  validation: the from-scratch client→CP yamux channel proved unnecessary. The
+  client always *can* SSH to the box, and `ssh -R 127.0.0.1:<p>:localhost:<socks>`
+  lands a listener in the **host** netns — useless to the box directly, but the
+  **daemon bridges it into the box** with the Phase-2a relay (`upstream` = that
+  host-loopback port, source-restricted to the box IP). Works for the
+  **NAT'd-client + box** case with no new cloud protocol. Shipped: proto RPCs
+  `StartEgressProxy`/`StopEgressProxy` on `NetworkService`, daemon impl +
+  `egressproxy.Manager`, gRPC client, and `containarium egress-via-client`
+  (starts a local SOCKS, opens the `ssh -R`, calls the RPC, tears down on exit).
+  Validated live (fts→Mac): box egress `211.75.165.177` → `36.230.33.117`.
+  Remaining for the **cloud** box specifically: extend the cloud ossshim to
+  forward `/v1/network/egress-proxy` (today unserved cloud paths 404) so the
+  operator's CLI reaches the box's daemon through the CP.
 - **2c — UX.** `--show`, auto-teardown, audit entries, docs + a Chrome
   `--proxy-server` recipe.
 

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -1114,3 +1114,34 @@ func (c *GRPCClient) DeleteRoute(domain string) error {
 
 	return nil
 }
+
+// StartEgressProxy asks the daemon to bridge a host-loopback SOCKS (exposed by
+// the caller via `ssh -R`) into a box's netns (#808 egress-via-client). Returns
+// the in-box SOCKS address to point the box's apps at.
+func (c *GRPCClient) StartEgressProxy(containerName string, upstreamPort, proxyPort int32) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := c.networkClient.StartEgressProxy(ctx, &pb.StartEgressProxyRequest{
+		ContainerName: containerName,
+		UpstreamPort:  upstreamPort,
+		ProxyPort:     proxyPort,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to start egress proxy: %w", err)
+	}
+	return resp.GetSocksAddress(), nil
+}
+
+// StopEgressProxy tears down the egress-via-client relay for a box.
+func (c *GRPCClient) StopEgressProxy(containerName string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, err := c.networkClient.StopEgressProxy(ctx, &pb.StopEgressProxyRequest{
+		ContainerName: containerName,
+	}); err != nil {
+		return fmt.Errorf("failed to stop egress proxy: %w", err)
+	}
+	return nil
+}

--- a/internal/cmd/egress_via_client.go
+++ b/internal/cmd/egress_via_client.go
@@ -1,0 +1,175 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"regexp"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/footprintai/containarium/internal/client"
+	"github.com/footprintai/containarium/internal/egressproxy"
+	"github.com/spf13/cobra"
+)
+
+var (
+	evcServer    string
+	evcSSH       string
+	evcIdentity  string
+	evcSocksPort int
+	evcSSHFlags  []string
+)
+
+var egressViaClientCmd = &cobra.Command{
+	Use:   "egress-via-client <box>",
+	Short: "Route a box's egress through THIS machine (#808)",
+	Long: `Route a box's outbound traffic through this machine — so the box (e.g. a
+headless browser) egresses with your IP/network. Works even when the box can't
+reach you (NAT'd laptop): the path rides the SSH you make to the box, and the
+daemon bridges it into the box's network namespace.
+
+What it does, as one command:
+  1. starts a local SOCKS5 proxy on this machine (egresses via you),
+  2. opens an SSH reverse-forward exposing that SOCKS on the box's host loopback,
+  3. asks the daemon to bridge it into the box (source-restricted to the box),
+  4. prints the in-box SOCKS address; Ctrl-C tears it all down.
+
+Example:
+  containarium egress-via-client cld-abcd1234 \
+    --server <daemon-host:50051> \
+    --ssh cld-abcd1234@asia-east1.containarium.dev -i ~/.containarium/keys/cld-abcd1234
+
+  # then, inside the box: point apps at the printed socks5://<addr>
+  # (Chrome: --proxy-server=socks5://<addr>)`,
+	Args: cobra.ExactArgs(1),
+	RunE: runEgressViaClient,
+}
+
+func init() {
+	rootCmd.AddCommand(egressViaClientCmd)
+	egressViaClientCmd.Flags().StringVar(&evcServer, "server", "", "daemon gRPC address for the control call (required)")
+	egressViaClientCmd.Flags().StringVar(&evcSSH, "ssh", "", "the box's SSH target user@host (required), e.g. cld-abcd1234@asia-east1.containarium.dev")
+	egressViaClientCmd.Flags().StringVarP(&evcIdentity, "identity", "i", "", "SSH private key for the box")
+	egressViaClientCmd.Flags().IntVar(&evcSocksPort, "socks-port", 0, "local SOCKS port (0 = pick a free one)")
+	egressViaClientCmd.Flags().StringArrayVar(&evcSSHFlags, "ssh-flag", nil, "extra flag passed to ssh (repeatable)")
+}
+
+var allocatedPortRE = regexp.MustCompile(`Allocated port (\d+) for remote forward`)
+
+func runEgressViaClient(cmd *cobra.Command, args []string) error {
+	box := args[0]
+	if evcServer == "" || evcSSH == "" {
+		return fmt.Errorf("--server and --ssh are required")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// 1. Local SOCKS5 (egresses via this machine).
+	socksAddr, err := egressproxy.ServeSOCKS5(ctx, fmt.Sprintf("127.0.0.1:%d", evcSocksPort), cmd.Printf)
+	if err != nil {
+		return err
+	}
+	_, socksPort, _ := splitHostPort(socksAddr)
+	cmd.Printf("local SOCKS5 on %s (egresses via this machine)\n", socksAddr)
+
+	// 2. ssh -R 127.0.0.1:0:127.0.0.1:<socksPort> — dynamic host port; parse the
+	//    one ssh allocates so there's no collision on the box's host.
+	sshArgs := []string{
+		"-N",
+		"-R", fmt.Sprintf("127.0.0.1:0:127.0.0.1:%d", socksPort),
+		"-o", "IdentitiesOnly=yes",
+		"-o", "ExitOnForwardFailure=yes",
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "ServerAliveInterval=15",
+	}
+	if evcIdentity != "" {
+		sshArgs = append(sshArgs, "-i", evcIdentity)
+	}
+	sshArgs = append(sshArgs, evcSSHFlags...)
+	sshArgs = append(sshArgs, evcSSH)
+
+	// #nosec G204 -- args are operator-provided flags for their own ssh session
+	ssh := exec.CommandContext(ctx, "ssh", sshArgs...)
+	stderr, err := ssh.StderrPipe()
+	if err != nil {
+		return err
+	}
+	if err := ssh.Start(); err != nil {
+		return fmt.Errorf("start ssh: %w", err)
+	}
+	defer func() { _ = ssh.Process.Kill() }()
+
+	hostPort, err := readAllocatedPort(stderr, 20*time.Second)
+	if err != nil {
+		return fmt.Errorf("ssh reverse-forward did not come up: %w", err)
+	}
+	cmd.Printf("ssh -R exposed your SOCKS on the box's host loopback :%d\n", hostPort)
+
+	// 3. Ask the daemon to bridge the host-loopback listener into the box.
+	grpcClient, err := client.NewGRPCClient(evcServer, certsDir, insecure)
+	if err != nil {
+		return fmt.Errorf("connect to daemon: %w", err)
+	}
+	defer func() { _ = grpcClient.Close() }()
+
+	inBox, err := grpcClient.StartEgressProxy(box, int32(hostPort), 0) // #nosec G115 -- port is 1..65535
+	if err != nil {
+		return err
+	}
+	defer func() { _ = grpcClient.StopEgressProxy(box) }()
+
+	cmd.Printf("\n✅ egress wired. Inside the box, point apps at:\n    socks5://%s\n    (Chrome: --proxy-server=socks5://%s)\n\nCtrl-C to tear down.\n", inBox, inBox)
+
+	<-ctx.Done()
+	cmd.Printf("\ntearing down egress for %s...\n", box)
+	return nil
+}
+
+// readAllocatedPort scans ssh stderr for the dynamically-allocated reverse
+// forward port, giving up after timeout.
+func readAllocatedPort(r interface{ Read([]byte) (int, error) }, timeout time.Duration) (int, error) {
+	type res struct {
+		port int
+		err  error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		sc := bufio.NewScanner(r)
+		for sc.Scan() {
+			if m := allocatedPortRE.FindStringSubmatch(sc.Text()); m != nil {
+				p, _ := strconv.Atoi(m[1])
+				ch <- res{port: p}
+				return
+			}
+		}
+		ch <- res{err: fmt.Errorf("ssh exited before allocating a port (check --ssh / -i)")}
+	}()
+	select {
+	case r := <-ch:
+		return r.port, r.err
+	case <-time.After(timeout):
+		return 0, fmt.Errorf("timed out waiting for ssh to allocate the reverse-forward port")
+	}
+}
+
+// splitHostPort returns host, port (int), ok.
+func splitHostPort(addr string) (string, int, bool) {
+	h, p, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, false
+	}
+	pi, err := strconv.Atoi(p)
+	if err != nil {
+		return "", 0, false
+	}
+	return h, pi, true
+}

--- a/internal/egressproxy/manager.go
+++ b/internal/egressproxy/manager.go
@@ -1,0 +1,72 @@
+package egressproxy
+
+import (
+	"context"
+	"sync"
+)
+
+// Manager tracks per-key egress relays (keyed by box/container name) so the
+// daemon can start one when an operator requests "egress via client" and tear
+// it down on stop / disconnect. Lifetimes are process-local and ephemeral —
+// relays are not persisted across a daemon restart (the operator's ssh -R dies
+// with the daemon anyway, so a stale relay would be useless).
+type Manager struct {
+	mu     sync.Mutex
+	relays map[string]context.CancelFunc
+}
+
+// NewManager returns an empty Manager.
+func NewManager() *Manager {
+	return &Manager{relays: make(map[string]context.CancelFunc)}
+}
+
+// Start (re)starts the relay for key. Any existing relay for the same key is
+// torn down first (idempotent re-invoke). It binds synchronously so a bind
+// error is returned to the caller; on success it returns the actually-bound
+// listen address (useful when listen used port 0). logf may be nil.
+func (m *Manager) Start(key, listen, upstream string, allow []string, logf func(string, ...any)) (string, error) {
+	r, err := New(listen, upstream, allow, logf)
+	if err != nil {
+		return "", err
+	}
+
+	// Tear down a prior relay for this key before binding the new one, so the
+	// new listener doesn't collide with the old on the same port.
+	m.stop(key)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := r.StartBackground(ctx); err != nil {
+		cancel()
+		return "", err
+	}
+
+	m.mu.Lock()
+	m.relays[key] = cancel
+	m.mu.Unlock()
+	return r.Addr(), nil
+}
+
+// Stop tears down the relay for key, reporting whether one was running.
+func (m *Manager) Stop(key string) bool {
+	return m.stop(key)
+}
+
+func (m *Manager) stop(key string) bool {
+	m.mu.Lock()
+	cancel, ok := m.relays[key]
+	if ok {
+		delete(m.relays, key)
+	}
+	m.mu.Unlock()
+	if ok {
+		cancel()
+	}
+	return ok
+}
+
+// Active reports the number of running relays (for observability/tests).
+func (m *Manager) Active() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.relays)
+}

--- a/internal/egressproxy/manager_test.go
+++ b/internal/egressproxy/manager_test.go
@@ -1,0 +1,81 @@
+package egressproxy
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestManager_StartStop_AndForward: the manager starts a relay (port 0 ->
+// discovers the bound addr), forwards an allowed source to the upstream, and
+// Stop tears it down so the port is released.
+func TestManager_StartStop_AndForward(t *testing.T) {
+	// Echo upstream.
+	up, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("upstream: %v", err)
+	}
+	defer up.Close()
+	go func() {
+		for {
+			c, err := up.Accept()
+			if err != nil {
+				return
+			}
+			go func() { _, _ = io.Copy(c, c); c.Close() }()
+		}
+	}()
+
+	m := NewManager()
+	addr, err := m.Start("box-1", "127.0.0.1:0", up.Addr().String(), []string{"127.0.0.1/8"}, nil)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if addr == "" {
+		t.Fatal("Start returned empty addr")
+	}
+	if m.Active() != 1 {
+		t.Fatalf("Active = %d, want 1", m.Active())
+	}
+
+	// Forward works through the manager-started relay.
+	c, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial %s: %v", addr, err)
+	}
+	_ = c.SetDeadline(time.Now().Add(2 * time.Second))
+	_, _ = c.Write([]byte("hi"))
+	buf := make([]byte, 2)
+	if _, err := io.ReadFull(c, buf); err != nil || string(buf) != "hi" {
+		t.Fatalf("echo through relay: got %q err %v", buf, err)
+	}
+	_ = c.Close()
+
+	// Stop releases the port.
+	if !m.Stop("box-1") {
+		t.Fatal("Stop reported no relay")
+	}
+	if m.Active() != 0 {
+		t.Fatalf("Active after stop = %d, want 0", m.Active())
+	}
+	// Stop again is a no-op.
+	if m.Stop("box-1") {
+		t.Fatal("second Stop should report false")
+	}
+}
+
+// TestManager_StartReplacesExisting: re-Start for the same key tears down the
+// prior relay rather than leaking it.
+func TestManager_StartReplacesExisting(t *testing.T) {
+	m := NewManager()
+	if _, err := m.Start("box", "127.0.0.1:0", "127.0.0.1:1", []string{"127.0.0.1/8"}, nil); err != nil {
+		t.Fatalf("start 1: %v", err)
+	}
+	if _, err := m.Start("box", "127.0.0.1:0", "127.0.0.1:1", []string{"127.0.0.1/8"}, nil); err != nil {
+		t.Fatalf("start 2: %v", err)
+	}
+	if m.Active() != 1 {
+		t.Fatalf("Active = %d, want 1 (replace, not leak)", m.Active())
+	}
+}

--- a/internal/egressproxy/relay.go
+++ b/internal/egressproxy/relay.go
@@ -95,7 +95,7 @@ func (r *Relay) sourceAllowed(src netip.Addr) bool {
 	return false
 }
 
-// Serve listens and forwards until ctx is cancelled or a fatal accept error
+// Serve binds and forwards until ctx is cancelled or a fatal accept error
 // occurs. Close (or ctx cancel) makes it return.
 func (r *Relay) Serve(ctx context.Context) error {
 	ln, err := net.Listen("tcp", r.listen)
@@ -105,7 +105,37 @@ func (r *Relay) Serve(ctx context.Context) error {
 	r.mu.Lock()
 	r.ln = ln
 	r.mu.Unlock()
-	r.logf("egress-relay %s -> %s (allow %v)", r.listen, r.upstream, r.allow)
+	return r.serveListener(ctx, ln)
+}
+
+// StartBackground binds synchronously — returning any bind error to the caller
+// (so a "port in use" surfaces at start time, not silently) — then serves in a
+// background goroutine until ctx is cancelled. Use Addr afterwards to read the
+// actually-bound address (e.g. when the listen port was 0).
+func (r *Relay) StartBackground(ctx context.Context) error {
+	ln, err := net.Listen("tcp", r.listen)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", r.listen, err)
+	}
+	r.mu.Lock()
+	r.ln = ln
+	r.mu.Unlock()
+	go func() { _ = r.serveListener(ctx, ln) }()
+	return nil
+}
+
+// Addr returns the actually-bound listen address, or "" if not yet bound.
+func (r *Relay) Addr() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.ln != nil {
+		return r.ln.Addr().String()
+	}
+	return ""
+}
+
+func (r *Relay) serveListener(ctx context.Context, ln net.Listener) error {
+	r.logf("egress-relay %s -> %s (allow %v)", ln.Addr(), r.upstream, r.allow)
 
 	go func() {
 		<-ctx.Done()

--- a/internal/egressproxy/socks5.go
+++ b/internal/egressproxy/socks5.go
@@ -1,0 +1,115 @@
+package egressproxy
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"time"
+)
+
+// ServeSOCKS5 runs a minimal no-auth SOCKS5 CONNECT proxy on listenAddr until
+// ctx is cancelled. It egresses from whatever host runs it — used by the
+// operator side of "egress via client" (#808): the box's traffic, tunnelled to
+// here, leaves with this machine's IP. Returns the bound address (useful when
+// listenAddr used port 0).
+//
+// Scope is intentionally small: no auth, CONNECT only, IPv4 + domain targets —
+// enough for an HTTP(S) browser. It is meant to be bound to loopback and
+// exposed to the box exclusively through the authenticated ssh -R tunnel.
+func ServeSOCKS5(ctx context.Context, listenAddr string, logf func(string, ...any)) (string, error) {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	ln, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return "", fmt.Errorf("socks listen %s: %w", listenAddr, err)
+	}
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go socksHandle(c)
+		}
+	}()
+	logf("socks5 listening on %s", ln.Addr())
+	return ln.Addr().String(), nil
+}
+
+func socksHandle(c net.Conn) {
+	defer c.Close()
+	_ = c.SetDeadline(time.Now().Add(30 * time.Second))
+
+	// Greeting: VER, NMETHODS, METHODS...
+	hdr := make([]byte, 2)
+	if _, err := io.ReadFull(c, hdr); err != nil || hdr[0] != 0x05 {
+		return
+	}
+	if _, err := io.ReadFull(c, make([]byte, int(hdr[1]))); err != nil {
+		return
+	}
+	if _, err := c.Write([]byte{0x05, 0x00}); err != nil { // no-auth
+		return
+	}
+
+	// Request: VER, CMD, RSV, ATYP
+	req := make([]byte, 4)
+	if _, err := io.ReadFull(c, req); err != nil || req[0] != 0x05 {
+		return
+	}
+	if req[1] != 0x01 { // CONNECT only
+		_, _ = c.Write([]byte{0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		return
+	}
+	var host string
+	switch req[3] {
+	case 0x01: // IPv4
+		b := make([]byte, 4)
+		if _, err := io.ReadFull(c, b); err != nil {
+			return
+		}
+		host = net.IP(b).String()
+	case 0x03: // domain
+		l := make([]byte, 1)
+		if _, err := io.ReadFull(c, l); err != nil {
+			return
+		}
+		d := make([]byte, int(l[0]))
+		if _, err := io.ReadFull(c, d); err != nil {
+			return
+		}
+		host = string(d)
+	default: // IPv6 unsupported
+		_, _ = c.Write([]byte{0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		return
+	}
+	pb := make([]byte, 2)
+	if _, err := io.ReadFull(c, pb); err != nil {
+		return
+	}
+	port := binary.BigEndian.Uint16(pb)
+
+	up, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(int(port))), 15*time.Second)
+	if err != nil {
+		_, _ = c.Write([]byte{0x05, 0x05, 0x00, 0x01, 0, 0, 0, 0, 0, 0}) // conn refused
+		return
+	}
+	defer up.Close()
+	if _, err := c.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
+		return
+	}
+	_ = c.SetDeadline(time.Time{}) // clear handshake deadline for the data phase
+
+	done := make(chan struct{}, 2)
+	go func() { _, _ = io.Copy(up, c); done <- struct{}{} }()
+	go func() { _, _ = io.Copy(c, up); done <- struct{}{} }()
+	<-done
+}

--- a/internal/server/network_server.go
+++ b/internal/server/network_server.go
@@ -3,10 +3,14 @@ package server
 import (
 	"context"
 	"fmt"
+	"log"
+	"net"
+	"strconv"
 	"strings"
 
 	"github.com/footprintai/containarium/internal/app"
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/egressproxy"
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/pkg/core/incus"
@@ -29,6 +33,7 @@ type NetworkServer struct {
 	proxyIP            string                   // e.g., "10.100.0.1"
 	baseDomain         string                   // e.g., "example.com"
 	emitter            *events.Emitter
+	egressMgr          *egressproxy.Manager // egress-via-client relays, keyed by box (#808)
 }
 
 // resolveFullDomain determines the full domain from a user-provided domain string.
@@ -57,6 +62,7 @@ func NewNetworkServer(incusClient *incus.Client, proxyManager *app.ProxyManager,
 		containerNetwork:   containerNetwork,
 		proxyIP:            proxyIP,
 		emitter:            events.NewEmitter(events.GetBus()),
+		egressMgr:          egressproxy.NewManager(),
 	}
 }
 
@@ -1162,4 +1168,70 @@ func protoToRouteProtocol(protocol pb.RouteProtocol) app.RouteProtocol {
 	default:
 		return app.RouteProtocolHTTP
 	}
+}
+
+// StartEgressProxy bridges a host-loopback SOCKS (which the caller exposes via
+// `ssh -R 127.0.0.1:<upstream_port>:localhost:<their-socks>`) into a box's
+// network namespace, so the box egresses with the operator's IP — the
+// "egress via client" feature (#808). The daemon runs a source-restricted relay
+// on the bridge gateway that ONLY the target box's IP may use, forwarding to
+// the host-loopback SOCKS the caller opened. The box points its apps at the
+// returned socks_address.
+func (s *NetworkServer) StartEgressProxy(ctx context.Context, req *pb.StartEgressProxyRequest) (*pb.StartEgressProxyResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeRoutesWrite); err != nil {
+		return nil, err
+	}
+	name := strings.TrimSpace(req.GetContainerName())
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "container_name is required")
+	}
+	if req.GetUpstreamPort() <= 0 || req.GetUpstreamPort() > 65535 {
+		return nil, status.Error(codes.InvalidArgument, "upstream_port must be 1-65535 (the host-loopback port from your `ssh -R`)")
+	}
+	if s.proxyIP == "" {
+		return nil, status.Error(codes.FailedPrecondition, "daemon bridge gateway is not configured")
+	}
+	if s.incusClient == nil {
+		return nil, status.Error(codes.Unavailable, "container backend unavailable")
+	}
+	info, err := s.incusClient.GetContainer(name)
+	if err != nil || info == nil {
+		return nil, status.Errorf(codes.NotFound, "container %q not found", name)
+	}
+	if info.IPAddress == "" {
+		return nil, status.Errorf(codes.FailedPrecondition, "container %q has no IP yet (is it running?)", name)
+	}
+	if s.egressMgr == nil {
+		s.egressMgr = egressproxy.NewManager()
+	}
+
+	// listen on the bridge gateway (box-reachable); proxy_port 0 => free port.
+	listen := net.JoinHostPort(s.proxyIP, strconv.Itoa(int(req.GetProxyPort())))
+	// upstream is the host-loopback listener the caller opened via ssh -R.
+	upstream := net.JoinHostPort("127.0.0.1", strconv.Itoa(int(req.GetUpstreamPort())))
+
+	// allow ONLY the target box's IP — the multi-tenant boundary so a sibling
+	// box on the same bridge can't use this operator's egress channel.
+	addr, err := s.egressMgr.Start(name, listen, upstream, []string{info.IPAddress}, log.Printf)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "start egress relay: %v", err)
+	}
+	log.Printf("[egress-via-client] box %s (%s) -> relay %s -> host-loopback:%d", name, info.IPAddress, addr, req.GetUpstreamPort())
+	return &pb.StartEgressProxyResponse{SocksAddress: addr}, nil
+}
+
+// StopEgressProxy tears down the egress-via-client relay for a box.
+func (s *NetworkServer) StopEgressProxy(ctx context.Context, req *pb.StopEgressProxyRequest) (*pb.StopEgressProxyResponse, error) {
+	if err := auth.RequireScope(ctx, auth.ScopeRoutesWrite); err != nil {
+		return nil, err
+	}
+	name := strings.TrimSpace(req.GetContainerName())
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "container_name is required")
+	}
+	stopped := false
+	if s.egressMgr != nil {
+		stopped = s.egressMgr.Stop(name)
+	}
+	return &pb.StopEgressProxyResponse{Stopped: stopped}, nil
 }

--- a/pkg/pb/containarium/v1/network.pb.go
+++ b/pkg/pb/containarium/v1/network.pb.go
@@ -2588,6 +2588,212 @@ func (x *ListACLPresetsResponse) GetPresets() []*ACLPresetInfo {
 	return nil
 }
 
+// StartEgressProxyRequest asks the daemon to bridge a host-loopback SOCKS into
+// a box's netns (#808 egress-via-client).
+type StartEgressProxyRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Box (container) whose egress should be routed.
+	ContainerName string `protobuf:"bytes,1,opt,name=container_name,json=containerName,proto3" json:"container_name,omitempty"`
+	// Host-loopback port where the caller has exposed their SOCKS proxy via
+	// `ssh -R 127.0.0.1:<upstream_port>:localhost:<local-socks>`. The daemon's
+	// relay forwards box connections to 127.0.0.1:<upstream_port>.
+	UpstreamPort int32 `protobuf:"varint,2,opt,name=upstream_port,json=upstreamPort,proto3" json:"upstream_port,omitempty"`
+	// Optional bridge-gateway port the in-box relay should listen on. 0 = the
+	// daemon picks a free port.
+	ProxyPort     int32 `protobuf:"varint,3,opt,name=proxy_port,json=proxyPort,proto3" json:"proxy_port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StartEgressProxyRequest) Reset() {
+	*x = StartEgressProxyRequest{}
+	mi := &file_containarium_v1_network_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StartEgressProxyRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StartEgressProxyRequest) ProtoMessage() {}
+
+func (x *StartEgressProxyRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_network_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StartEgressProxyRequest.ProtoReflect.Descriptor instead.
+func (*StartEgressProxyRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_network_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *StartEgressProxyRequest) GetContainerName() string {
+	if x != nil {
+		return x.ContainerName
+	}
+	return ""
+}
+
+func (x *StartEgressProxyRequest) GetUpstreamPort() int32 {
+	if x != nil {
+		return x.UpstreamPort
+	}
+	return 0
+}
+
+func (x *StartEgressProxyRequest) GetProxyPort() int32 {
+	if x != nil {
+		return x.ProxyPort
+	}
+	return 0
+}
+
+// StartEgressProxyResponse returns the in-box SOCKS address to point apps at.
+type StartEgressProxyResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// SOCKS address reachable from inside the box, e.g. "10.100.0.1:18080".
+	// Point the box's apps at socks5://<socks_address> (Chrome:
+	// --proxy-server=socks5://<socks_address>).
+	SocksAddress  string `protobuf:"bytes,1,opt,name=socks_address,json=socksAddress,proto3" json:"socks_address,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StartEgressProxyResponse) Reset() {
+	*x = StartEgressProxyResponse{}
+	mi := &file_containarium_v1_network_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StartEgressProxyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StartEgressProxyResponse) ProtoMessage() {}
+
+func (x *StartEgressProxyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_network_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StartEgressProxyResponse.ProtoReflect.Descriptor instead.
+func (*StartEgressProxyResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_network_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *StartEgressProxyResponse) GetSocksAddress() string {
+	if x != nil {
+		return x.SocksAddress
+	}
+	return ""
+}
+
+// StopEgressProxyRequest tears down the egress relay for a box.
+type StopEgressProxyRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ContainerName string                 `protobuf:"bytes,1,opt,name=container_name,json=containerName,proto3" json:"container_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopEgressProxyRequest) Reset() {
+	*x = StopEgressProxyRequest{}
+	mi := &file_containarium_v1_network_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopEgressProxyRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopEgressProxyRequest) ProtoMessage() {}
+
+func (x *StopEgressProxyRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_network_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopEgressProxyRequest.ProtoReflect.Descriptor instead.
+func (*StopEgressProxyRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_network_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *StopEgressProxyRequest) GetContainerName() string {
+	if x != nil {
+		return x.ContainerName
+	}
+	return ""
+}
+
+// StopEgressProxyResponse is the (empty) ack for a teardown.
+type StopEgressProxyResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Stopped       bool                   `protobuf:"varint,1,opt,name=stopped,proto3" json:"stopped,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StopEgressProxyResponse) Reset() {
+	*x = StopEgressProxyResponse{}
+	mi := &file_containarium_v1_network_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StopEgressProxyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StopEgressProxyResponse) ProtoMessage() {}
+
+func (x *StopEgressProxyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_network_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StopEgressProxyResponse.ProtoReflect.Descriptor instead.
+func (*StopEgressProxyResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_network_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *StopEgressProxyResponse) GetStopped() bool {
+	if x != nil {
+		return x.Stopped
+	}
+	return false
+}
+
 var File_containarium_v1_network_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_network_proto_rawDesc = "" +
@@ -2762,7 +2968,18 @@ const file_containarium_v1_network_proto_rawDesc = "" +
 	"\x15default_ingress_rules\x18\x04 \x03(\v2\x18.containarium.v1.ACLRuleR\x13defaultIngressRules\x12J\n" +
 	"\x14default_egress_rules\x18\x05 \x03(\v2\x18.containarium.v1.ACLRuleR\x12defaultEgressRules\"R\n" +
 	"\x16ListACLPresetsResponse\x128\n" +
-	"\apresets\x18\x01 \x03(\v2\x1e.containarium.v1.ACLPresetInfoR\apresets*Y\n" +
+	"\apresets\x18\x01 \x03(\v2\x1e.containarium.v1.ACLPresetInfoR\apresets\"\x84\x01\n" +
+	"\x17StartEgressProxyRequest\x12%\n" +
+	"\x0econtainer_name\x18\x01 \x01(\tR\rcontainerName\x12#\n" +
+	"\rupstream_port\x18\x02 \x01(\x05R\fupstreamPort\x12\x1d\n" +
+	"\n" +
+	"proxy_port\x18\x03 \x01(\x05R\tproxyPort\"?\n" +
+	"\x18StartEgressProxyResponse\x12#\n" +
+	"\rsocks_address\x18\x01 \x01(\tR\fsocksAddress\"?\n" +
+	"\x16StopEgressProxyRequest\x12%\n" +
+	"\x0econtainer_name\x18\x01 \x01(\tR\rcontainerName\"3\n" +
+	"\x17StopEgressProxyResponse\x12\x18\n" +
+	"\astopped\x18\x01 \x01(\bR\astopped*Y\n" +
 	"\tRouteType\x12\x1a\n" +
 	"\x16ROUTE_TYPE_UNSPECIFIED\x10\x00\x12\x14\n" +
 	"\x10ROUTE_TYPE_PROXY\x10\x01\x12\x1a\n" +
@@ -2784,7 +3001,7 @@ const file_containarium_v1_network_proto_rawDesc = "" +
 	"\x19ACL_PRESET_FULL_ISOLATION\x10\x01\x12\x18\n" +
 	"\x14ACL_PRESET_HTTP_ONLY\x10\x02\x12\x19\n" +
 	"\x15ACL_PRESET_PERMISSIVE\x10\x03\x12\x15\n" +
-	"\x11ACL_PRESET_CUSTOM\x10\x042\xf9\x1b\n" +
+	"\x11ACL_PRESET_CUSTOM\x10\x042\xe9 \n" +
 	"\x0eNetworkService\x12\xdd\x01\n" +
 	"\tGetRoutes\x12!.containarium.v1.GetRoutesRequest\x1a\".containarium.v1.GetRoutesResponse\"\x88\x01\x92Ak\n" +
 	"\aNetwork\x12\x11List proxy routes\x1aMReturns all DNS/domain to container mappings configured in the reverse proxy.\x82\xd3\xe4\x93\x02\x14\x12\x12/v1/network/routes\x12\xd0\x01\n" +
@@ -2811,7 +3028,11 @@ const file_containarium_v1_network_proto_rawDesc = "" +
 	"\x12GetNetworkTopology\x12*.containarium.v1.GetNetworkTopologyRequest\x1a+.containarium.v1.GetNetworkTopologyResponse\"\xb4\x01\x92A\x94\x01\n" +
 	"\aNetwork\x12\x14Get network topology\x1asReturns the network topology including all containers, apps, proxy routes, and their connections for visualization.\x82\xd3\xe4\x93\x02\x16\x12\x14/v1/network/topology\x12\xed\x01\n" +
 	"\x0eListACLPresets\x12&.containarium.v1.ListACLPresetsRequest\x1a'.containarium.v1.ListACLPresetsResponse\"\x89\x01\x92Ag\n" +
-	"\aNetwork\x12\x10List ACL presets\x1aJReturns available firewall rule presets with their default configurations.\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/network/acl-presetsBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
+	"\aNetwork\x12\x10List ACL presets\x1aJReturns available firewall rule presets with their default configurations.\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/network/acl-presets\x12\xe6\x02\n" +
+	"\x10StartEgressProxy\x12(.containarium.v1.StartEgressProxyRequest\x1a).containarium.v1.StartEgressProxyResponse\"\xfc\x01\x92A\xd5\x01\n" +
+	"\aNetwork\x12\x1dStart egress-via-client proxy\x1a\xaa\x01Bridges a host-loopback SOCKS (exposed by the caller via ssh -R) into a box's network namespace via a source-restricted relay, so the box egresses with the operator's IP.\x82\xd3\xe4\x93\x02\x1d:\x01*\"\x18/v1/network/egress-proxy\x12\x84\x02\n" +
+	"\x0fStopEgressProxy\x12'.containarium.v1.StopEgressProxyRequest\x1a(.containarium.v1.StopEgressProxyResponse\"\x9d\x01\x92Ai\n" +
+	"\aNetwork\x12\x1cStop egress-via-client proxy\x1a@Tears down the source-restricted egress relay for the named box.\x82\xd3\xe4\x93\x02+*)/v1/network/egress-proxy/{container_name}BKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
 
 var (
 	file_containarium_v1_network_proto_rawDescOnce sync.Once
@@ -2826,7 +3047,7 @@ func file_containarium_v1_network_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_network_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_containarium_v1_network_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_containarium_v1_network_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_containarium_v1_network_proto_goTypes = []any{
 	(RouteType)(0),                         // 0: containarium.v1.RouteType
 	(RouteProtocol)(0),                     // 1: containarium.v1.RouteProtocol
@@ -2867,6 +3088,10 @@ var file_containarium_v1_network_proto_goTypes = []any{
 	(*ListACLPresetsRequest)(nil),          // 36: containarium.v1.ListACLPresetsRequest
 	(*ACLPresetInfo)(nil),                  // 37: containarium.v1.ACLPresetInfo
 	(*ListACLPresetsResponse)(nil),         // 38: containarium.v1.ListACLPresetsResponse
+	(*StartEgressProxyRequest)(nil),        // 39: containarium.v1.StartEgressProxyRequest
+	(*StartEgressProxyResponse)(nil),       // 40: containarium.v1.StartEgressProxyResponse
+	(*StopEgressProxyRequest)(nil),         // 41: containarium.v1.StopEgressProxyRequest
+	(*StopEgressProxyResponse)(nil),        // 42: containarium.v1.StopEgressProxyResponse
 }
 var file_containarium_v1_network_proto_depIdxs = []int32{
 	2,  // 0: containarium.v1.ACLRule.action:type_name -> containarium.v1.ACLAction
@@ -2912,21 +3137,25 @@ var file_containarium_v1_network_proto_depIdxs = []int32{
 	32, // 40: containarium.v1.NetworkService.UpdateContainerACL:input_type -> containarium.v1.UpdateContainerACLRequest
 	34, // 41: containarium.v1.NetworkService.GetNetworkTopology:input_type -> containarium.v1.GetNetworkTopologyRequest
 	36, // 42: containarium.v1.NetworkService.ListACLPresets:input_type -> containarium.v1.ListACLPresetsRequest
-	12, // 43: containarium.v1.NetworkService.GetRoutes:output_type -> containarium.v1.GetRoutesResponse
-	14, // 44: containarium.v1.NetworkService.AddRoute:output_type -> containarium.v1.AddRouteResponse
-	16, // 45: containarium.v1.NetworkService.UpdateRoute:output_type -> containarium.v1.UpdateRouteResponse
-	18, // 46: containarium.v1.NetworkService.DeleteRoute:output_type -> containarium.v1.DeleteRouteResponse
-	29, // 47: containarium.v1.NetworkService.ListDNSRecords:output_type -> containarium.v1.ListDNSRecordsResponse
-	20, // 48: containarium.v1.NetworkService.ListPassthroughRoutes:output_type -> containarium.v1.ListPassthroughRoutesResponse
-	22, // 49: containarium.v1.NetworkService.AddPassthroughRoute:output_type -> containarium.v1.AddPassthroughRouteResponse
-	24, // 50: containarium.v1.NetworkService.DeletePassthroughRoute:output_type -> containarium.v1.DeletePassthroughRouteResponse
-	26, // 51: containarium.v1.NetworkService.UpdatePassthroughRoute:output_type -> containarium.v1.UpdatePassthroughRouteResponse
-	31, // 52: containarium.v1.NetworkService.GetContainerACL:output_type -> containarium.v1.GetContainerACLResponse
-	33, // 53: containarium.v1.NetworkService.UpdateContainerACL:output_type -> containarium.v1.UpdateContainerACLResponse
-	35, // 54: containarium.v1.NetworkService.GetNetworkTopology:output_type -> containarium.v1.GetNetworkTopologyResponse
-	38, // 55: containarium.v1.NetworkService.ListACLPresets:output_type -> containarium.v1.ListACLPresetsResponse
-	43, // [43:56] is the sub-list for method output_type
-	30, // [30:43] is the sub-list for method input_type
+	39, // 43: containarium.v1.NetworkService.StartEgressProxy:input_type -> containarium.v1.StartEgressProxyRequest
+	41, // 44: containarium.v1.NetworkService.StopEgressProxy:input_type -> containarium.v1.StopEgressProxyRequest
+	12, // 45: containarium.v1.NetworkService.GetRoutes:output_type -> containarium.v1.GetRoutesResponse
+	14, // 46: containarium.v1.NetworkService.AddRoute:output_type -> containarium.v1.AddRouteResponse
+	16, // 47: containarium.v1.NetworkService.UpdateRoute:output_type -> containarium.v1.UpdateRouteResponse
+	18, // 48: containarium.v1.NetworkService.DeleteRoute:output_type -> containarium.v1.DeleteRouteResponse
+	29, // 49: containarium.v1.NetworkService.ListDNSRecords:output_type -> containarium.v1.ListDNSRecordsResponse
+	20, // 50: containarium.v1.NetworkService.ListPassthroughRoutes:output_type -> containarium.v1.ListPassthroughRoutesResponse
+	22, // 51: containarium.v1.NetworkService.AddPassthroughRoute:output_type -> containarium.v1.AddPassthroughRouteResponse
+	24, // 52: containarium.v1.NetworkService.DeletePassthroughRoute:output_type -> containarium.v1.DeletePassthroughRouteResponse
+	26, // 53: containarium.v1.NetworkService.UpdatePassthroughRoute:output_type -> containarium.v1.UpdatePassthroughRouteResponse
+	31, // 54: containarium.v1.NetworkService.GetContainerACL:output_type -> containarium.v1.GetContainerACLResponse
+	33, // 55: containarium.v1.NetworkService.UpdateContainerACL:output_type -> containarium.v1.UpdateContainerACLResponse
+	35, // 56: containarium.v1.NetworkService.GetNetworkTopology:output_type -> containarium.v1.GetNetworkTopologyResponse
+	38, // 57: containarium.v1.NetworkService.ListACLPresets:output_type -> containarium.v1.ListACLPresetsResponse
+	40, // 58: containarium.v1.NetworkService.StartEgressProxy:output_type -> containarium.v1.StartEgressProxyResponse
+	42, // 59: containarium.v1.NetworkService.StopEgressProxy:output_type -> containarium.v1.StopEgressProxyResponse
+	45, // [45:60] is the sub-list for method output_type
+	30, // [30:45] is the sub-list for method input_type
 	30, // [30:30] is the sub-list for extension type_name
 	30, // [30:30] is the sub-list for extension extendee
 	0,  // [0:30] is the sub-list for field type_name
@@ -2945,7 +3174,7 @@ func file_containarium_v1_network_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_network_proto_rawDesc), len(file_containarium_v1_network_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   35,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/pb/containarium/v1/network.pb.gw.go
+++ b/pkg/pb/containarium/v1/network.pb.gw.go
@@ -502,6 +502,72 @@ func local_request_NetworkService_ListACLPresets_0(ctx context.Context, marshale
 	return msg, metadata, err
 }
 
+func request_NetworkService_StartEgressProxy_0(ctx context.Context, marshaler runtime.Marshaler, client NetworkServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq StartEgressProxyRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.StartEgressProxy(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_NetworkService_StartEgressProxy_0(ctx context.Context, marshaler runtime.Marshaler, server NetworkServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq StartEgressProxyRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.StartEgressProxy(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_NetworkService_StopEgressProxy_0(ctx context.Context, marshaler runtime.Marshaler, client NetworkServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq StopEgressProxyRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["container_name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "container_name")
+	}
+	protoReq.ContainerName, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "container_name", err)
+	}
+	msg, err := client.StopEgressProxy(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_NetworkService_StopEgressProxy_0(ctx context.Context, marshaler runtime.Marshaler, server NetworkServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq StopEgressProxyRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["container_name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "container_name")
+	}
+	protoReq.ContainerName, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "container_name", err)
+	}
+	msg, err := server.StopEgressProxy(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterNetworkServiceHandlerServer registers the http handlers for service NetworkService to "mux".
 // UnaryRPC     :call NetworkServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -768,6 +834,46 @@ func RegisterNetworkServiceHandlerServer(ctx context.Context, mux *runtime.Serve
 		}
 		forward_NetworkService_ListACLPresets_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_NetworkService_StartEgressProxy_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.NetworkService/StartEgressProxy", runtime.WithHTTPPathPattern("/v1/network/egress-proxy"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_NetworkService_StartEgressProxy_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_NetworkService_StartEgressProxy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_NetworkService_StopEgressProxy_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.NetworkService/StopEgressProxy", runtime.WithHTTPPathPattern("/v1/network/egress-proxy/{container_name}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_NetworkService_StopEgressProxy_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_NetworkService_StopEgressProxy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	return nil
 }
@@ -1029,6 +1135,40 @@ func RegisterNetworkServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		}
 		forward_NetworkService_ListACLPresets_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_NetworkService_StartEgressProxy_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.NetworkService/StartEgressProxy", runtime.WithHTTPPathPattern("/v1/network/egress-proxy"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_NetworkService_StartEgressProxy_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_NetworkService_StartEgressProxy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodDelete, pattern_NetworkService_StopEgressProxy_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.NetworkService/StopEgressProxy", runtime.WithHTTPPathPattern("/v1/network/egress-proxy/{container_name}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_NetworkService_StopEgressProxy_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_NetworkService_StopEgressProxy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -1046,6 +1186,8 @@ var (
 	pattern_NetworkService_UpdateContainerACL_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "acl"}, ""))
 	pattern_NetworkService_GetNetworkTopology_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "network", "topology"}, ""))
 	pattern_NetworkService_ListACLPresets_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "network", "acl-presets"}, ""))
+	pattern_NetworkService_StartEgressProxy_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "network", "egress-proxy"}, ""))
+	pattern_NetworkService_StopEgressProxy_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "network", "egress-proxy", "container_name"}, ""))
 )
 
 var (
@@ -1062,4 +1204,6 @@ var (
 	forward_NetworkService_UpdateContainerACL_0     = runtime.ForwardResponseMessage
 	forward_NetworkService_GetNetworkTopology_0     = runtime.ForwardResponseMessage
 	forward_NetworkService_ListACLPresets_0         = runtime.ForwardResponseMessage
+	forward_NetworkService_StartEgressProxy_0       = runtime.ForwardResponseMessage
+	forward_NetworkService_StopEgressProxy_0        = runtime.ForwardResponseMessage
 )

--- a/pkg/pb/containarium/v1/network_grpc.pb.go
+++ b/pkg/pb/containarium/v1/network_grpc.pb.go
@@ -32,6 +32,8 @@ const (
 	NetworkService_UpdateContainerACL_FullMethodName     = "/containarium.v1.NetworkService/UpdateContainerACL"
 	NetworkService_GetNetworkTopology_FullMethodName     = "/containarium.v1.NetworkService/GetNetworkTopology"
 	NetworkService_ListACLPresets_FullMethodName         = "/containarium.v1.NetworkService/ListACLPresets"
+	NetworkService_StartEgressProxy_FullMethodName       = "/containarium.v1.NetworkService/StartEgressProxy"
+	NetworkService_StopEgressProxy_FullMethodName        = "/containarium.v1.NetworkService/StopEgressProxy"
 )
 
 // NetworkServiceClient is the client API for NetworkService service.
@@ -66,6 +68,14 @@ type NetworkServiceClient interface {
 	GetNetworkTopology(ctx context.Context, in *GetNetworkTopologyRequest, opts ...grpc.CallOption) (*GetNetworkTopologyResponse, error)
 	// ListACLPresets lists available firewall presets
 	ListACLPresets(ctx context.Context, in *ListACLPresetsRequest, opts ...grpc.CallOption) (*ListACLPresetsResponse, error)
+	// StartEgressProxy starts a source-restricted relay that lets a box egress
+	// through an operator-reachable SOCKS — "egress via client" (#808). The
+	// operator first opens `ssh -R 127.0.0.1:<upstream_port>:localhost:<socks>`
+	// to expose their SOCKS on the host loopback; this RPC then bridges that
+	// host-netns listener into the box's netns, scoped to the box's source IP.
+	StartEgressProxy(ctx context.Context, in *StartEgressProxyRequest, opts ...grpc.CallOption) (*StartEgressProxyResponse, error)
+	// StopEgressProxy stops the egress-via-client relay for a box.
+	StopEgressProxy(ctx context.Context, in *StopEgressProxyRequest, opts ...grpc.CallOption) (*StopEgressProxyResponse, error)
 }
 
 type networkServiceClient struct {
@@ -206,6 +216,26 @@ func (c *networkServiceClient) ListACLPresets(ctx context.Context, in *ListACLPr
 	return out, nil
 }
 
+func (c *networkServiceClient) StartEgressProxy(ctx context.Context, in *StartEgressProxyRequest, opts ...grpc.CallOption) (*StartEgressProxyResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(StartEgressProxyResponse)
+	err := c.cc.Invoke(ctx, NetworkService_StartEgressProxy_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *networkServiceClient) StopEgressProxy(ctx context.Context, in *StopEgressProxyRequest, opts ...grpc.CallOption) (*StopEgressProxyResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(StopEgressProxyResponse)
+	err := c.cc.Invoke(ctx, NetworkService_StopEgressProxy_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // NetworkServiceServer is the server API for NetworkService service.
 // All implementations must embed UnimplementedNetworkServiceServer
 // for forward compatibility.
@@ -238,6 +268,14 @@ type NetworkServiceServer interface {
 	GetNetworkTopology(context.Context, *GetNetworkTopologyRequest) (*GetNetworkTopologyResponse, error)
 	// ListACLPresets lists available firewall presets
 	ListACLPresets(context.Context, *ListACLPresetsRequest) (*ListACLPresetsResponse, error)
+	// StartEgressProxy starts a source-restricted relay that lets a box egress
+	// through an operator-reachable SOCKS — "egress via client" (#808). The
+	// operator first opens `ssh -R 127.0.0.1:<upstream_port>:localhost:<socks>`
+	// to expose their SOCKS on the host loopback; this RPC then bridges that
+	// host-netns listener into the box's netns, scoped to the box's source IP.
+	StartEgressProxy(context.Context, *StartEgressProxyRequest) (*StartEgressProxyResponse, error)
+	// StopEgressProxy stops the egress-via-client relay for a box.
+	StopEgressProxy(context.Context, *StopEgressProxyRequest) (*StopEgressProxyResponse, error)
 	mustEmbedUnimplementedNetworkServiceServer()
 }
 
@@ -286,6 +324,12 @@ func (UnimplementedNetworkServiceServer) GetNetworkTopology(context.Context, *Ge
 }
 func (UnimplementedNetworkServiceServer) ListACLPresets(context.Context, *ListACLPresetsRequest) (*ListACLPresetsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListACLPresets not implemented")
+}
+func (UnimplementedNetworkServiceServer) StartEgressProxy(context.Context, *StartEgressProxyRequest) (*StartEgressProxyResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method StartEgressProxy not implemented")
+}
+func (UnimplementedNetworkServiceServer) StopEgressProxy(context.Context, *StopEgressProxyRequest) (*StopEgressProxyResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method StopEgressProxy not implemented")
 }
 func (UnimplementedNetworkServiceServer) mustEmbedUnimplementedNetworkServiceServer() {}
 func (UnimplementedNetworkServiceServer) testEmbeddedByValue()                        {}
@@ -542,6 +586,42 @@ func _NetworkService_ListACLPresets_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _NetworkService_StartEgressProxy_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StartEgressProxyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NetworkServiceServer).StartEgressProxy(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NetworkService_StartEgressProxy_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NetworkServiceServer).StartEgressProxy(ctx, req.(*StartEgressProxyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _NetworkService_StopEgressProxy_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StopEgressProxyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NetworkServiceServer).StopEgressProxy(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NetworkService_StopEgressProxy_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NetworkServiceServer).StopEgressProxy(ctx, req.(*StopEgressProxyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // NetworkService_ServiceDesc is the grpc.ServiceDesc for NetworkService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -600,6 +680,14 @@ var NetworkService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListACLPresets",
 			Handler:    _NetworkService_ListACLPresets_Handler,
+		},
+		{
+			MethodName: "StartEgressProxy",
+			Handler:    _NetworkService_StartEgressProxy_Handler,
+		},
+		{
+			MethodName: "StopEgressProxy",
+			Handler:    _NetworkService_StopEgressProxy_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/containarium/v1/network.proto
+++ b/proto/containarium/v1/network.proto
@@ -678,4 +678,67 @@ service NetworkService {
       tags: "Network";
     };
   }
+
+  // StartEgressProxy starts a source-restricted relay that lets a box egress
+  // through an operator-reachable SOCKS — "egress via client" (#808). The
+  // operator first opens `ssh -R 127.0.0.1:<upstream_port>:localhost:<socks>`
+  // to expose their SOCKS on the host loopback; this RPC then bridges that
+  // host-netns listener into the box's netns, scoped to the box's source IP.
+  rpc StartEgressProxy(StartEgressProxyRequest) returns (StartEgressProxyResponse) {
+    option (google.api.http) = {
+      post: "/v1/network/egress-proxy"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Start egress-via-client proxy";
+      description: "Bridges a host-loopback SOCKS (exposed by the caller via ssh -R) into a box's network namespace via a source-restricted relay, so the box egresses with the operator's IP.";
+      tags: "Network";
+    };
+  }
+
+  // StopEgressProxy stops the egress-via-client relay for a box.
+  rpc StopEgressProxy(StopEgressProxyRequest) returns (StopEgressProxyResponse) {
+    option (google.api.http) = {
+      delete: "/v1/network/egress-proxy/{container_name}"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Stop egress-via-client proxy";
+      description: "Tears down the source-restricted egress relay for the named box.";
+      tags: "Network";
+    };
+  }
+}
+
+// StartEgressProxyRequest asks the daemon to bridge a host-loopback SOCKS into
+// a box's netns (#808 egress-via-client).
+message StartEgressProxyRequest {
+  // Box (container) whose egress should be routed.
+  string container_name = 1;
+
+  // Host-loopback port where the caller has exposed their SOCKS proxy via
+  // `ssh -R 127.0.0.1:<upstream_port>:localhost:<local-socks>`. The daemon's
+  // relay forwards box connections to 127.0.0.1:<upstream_port>.
+  int32 upstream_port = 2;
+
+  // Optional bridge-gateway port the in-box relay should listen on. 0 = the
+  // daemon picks a free port.
+  int32 proxy_port = 3;
+}
+
+// StartEgressProxyResponse returns the in-box SOCKS address to point apps at.
+message StartEgressProxyResponse {
+  // SOCKS address reachable from inside the box, e.g. "10.100.0.1:18080".
+  // Point the box's apps at socks5://<socks_address> (Chrome:
+  // --proxy-server=socks5://<socks_address>).
+  string socks_address = 1;
+}
+
+// StopEgressProxyRequest tears down the egress relay for a box.
+message StopEgressProxyRequest {
+  string container_name = 1;
+}
+
+// StopEgressProxyResponse is the (empty) ack for a teardown.
+message StopEgressProxyResponse {
+  bool stopped = 1;
 }


### PR DESCRIPTION
One command to **route a box's egress through the operator's machine**, for the **NAT'd-client** case. Validated live (fts→Mac): box egress `211.75.165.177` → `36.230.33.117`.

## Key refinement vs the approved design (#809)
No from-scratch cloud yamux channel is needed. The client can always SSH to the box, and `ssh -R 127.0.0.1:<p>:localhost:<socks>` lands a listener in the **host** netns — useless to the box directly, but the **daemon bridges it into the box's netns** with the Phase-2a relay (`upstream` = that host-loopback port, **source-restricted to the box IP**). Design doc updated to match.

## What's here
- **proto:** `NetworkService.StartEgressProxy` / `StopEgressProxy` (+ messages); regenerated via `make proto`.
- **`internal/egressproxy`:** `Manager` (per-box relay lifecycle, idempotent start/replace/stop, tested); `Relay.StartBackground`/`Addr` (sync bind, background serve); `ServeSOCKS5` (minimal no-auth CONNECT SOCKS5 for the operator side).
- **`internal/server`:** `StartEgressProxy` resolves the box IP (incus) + bridge gw (`proxyIP`), runs the relay scoped to the box's IP, returns the in-box SOCKS address; `StopEgressProxy` tears down. `RoutesWrite`-scoped.
- **client + CLI:** `containarium egress-via-client <box> --server … --ssh user@host -i key` — starts a local SOCKS, opens `ssh -R` (dynamic host port parsed from ssh's *Allocated port*), calls the RPC, prints the in-box `socks5://…`, tears down on Ctrl-C. `!windows`; Windows cross-compile verified.

## Validation
`go build` (incl. Windows) / `vet` / `gofmt` / `internal/egressproxy` tests green; CLI arg-validation + SOCKS smoke-tested. The mechanism was proven live end-to-end with a manual relay before productizing.

## Remaining (follow-up)
For a **cloud** box specifically: extend the cloud ossshim to forward `/v1/network/egress-proxy` (today unserved cloud paths 404) so the operator's CLI reaches the box's daemon through the CP. Works today for direct-daemon / BYOC.

Design of record: `docs/EGRESS-VIA-CLIENT-DESIGN.md` (#809).

🤖 Generated with [Claude Code](https://claude.com/claude-code)