### PR TITLE
feat(egress): egress-via-client can target the cloud (http client + selection) (#808)

### DIFF
--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -919,6 +919,61 @@ func (c *HTTPClient) DeleteContainer(username string, force bool) error {
 	return nil
 }
 
+// StartEgressProxy asks the control plane (or daemon) to bridge a host-loopback
+// SOCKS (exposed by the caller via ssh -R) into a box's netns (#808). Returns
+// the in-box SOCKS address. HTTP counterpart of GRPCClient.StartEgressProxy.
+func (c *HTTPClient) StartEgressProxy(containerName string, upstreamPort, proxyPort int32) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/network/egress-proxy", map[string]interface{}{
+		"containerName": containerName,
+		"upstreamPort":  upstreamPort,
+		"proxyPort":     proxyPort,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to start egress proxy: %w", err)
+	}
+	defer drainClose(resp)
+
+	if resp.StatusCode >= 400 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(bodyBytes, &errResp) == nil && errResp.Error != "" {
+			return "", fmt.Errorf("%s", errResp.Error)
+		}
+		return "", fmt.Errorf("failed to start egress proxy: status %d", resp.StatusCode)
+	}
+
+	var out struct {
+		SocksAddress string `json:"socksAddress"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("failed to decode egress proxy response: %w", err)
+	}
+	return out.SocksAddress, nil
+}
+
+// StopEgressProxy tears down the egress-via-client relay for a box. Idempotent
+// (a 404 — already gone — is success).
+func (c *HTTPClient) StopEgressProxy(containerName string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	resp, err := c.doRequest(ctx, http.MethodDelete, "/v1/network/egress-proxy/"+url.PathEscape(containerName), nil)
+	if err != nil {
+		return fmt.Errorf("failed to stop egress proxy: %w", err)
+	}
+	defer drainClose(resp)
+
+	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("failed to stop egress proxy: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
 // GetContainer gets information about a specific container via HTTP
 func (c *HTTPClient) GetContainer(username string) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/cmd/egress_via_client.go
+++ b/internal/cmd/egress_via_client.go
@@ -114,24 +114,47 @@ func runEgressViaClient(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Printf("ssh -R exposed your SOCKS on the box's host loopback :%d\n", hostPort)
 
-	// 3. Ask the daemon to bridge the host-loopback listener into the box.
-	grpcClient, err := client.NewGRPCClient(evcServer, certsDir, insecure)
+	// 3. Ask the control plane (or daemon) to bridge the host-loopback listener
+	//    into the box. --http targets the cloud REST surface (a ctnr_ token);
+	//    otherwise gRPC straight to a daemon (direct / BYOC).
+	ctrl, err := newEgressControlClient()
 	if err != nil {
-		return fmt.Errorf("connect to daemon: %w", err)
+		return fmt.Errorf("connect to control plane: %w", err)
 	}
-	defer func() { _ = grpcClient.Close() }()
+	defer func() { _ = ctrl.Close() }()
 
-	inBox, err := grpcClient.StartEgressProxy(box, int32(hostPort), 0) // #nosec G115 -- port is 1..65535
+	inBox, err := ctrl.StartEgressProxy(box, int32(hostPort), 0) // #nosec G115 -- port is 1..65535
 	if err != nil {
 		return err
 	}
-	defer func() { _ = grpcClient.StopEgressProxy(box) }()
+	defer func() { _ = ctrl.StopEgressProxy(box) }()
 
 	cmd.Printf("\n✅ egress wired. Inside the box, point apps at:\n    socks5://%s\n    (Chrome: --proxy-server=socks5://%s)\n\nCtrl-C to tear down.\n", inBox, inBox)
 
 	<-ctx.Done()
 	cmd.Printf("\ntearing down egress for %s...\n", box)
 	return nil
+}
+
+// egressControlClient is the control surface egress-via-client needs. Both
+// *client.GRPCClient and *client.HTTPClient satisfy it.
+type egressControlClient interface {
+	StartEgressProxy(containerName string, upstreamPort, proxyPort int32) (string, error)
+	StopEgressProxy(containerName string) error
+	Close() error
+}
+
+// newEgressControlClient picks the transport: --http targets the cloud REST
+// surface (a ctnr_ token via --token / $CONTAINARIUM_TOKEN, the cloud case);
+// otherwise gRPC straight to a daemon (direct / BYOC).
+func newEgressControlClient() (egressControlClient, error) {
+	if evcServer == "" {
+		return nil, fmt.Errorf("--server is required")
+	}
+	if httpMode {
+		return client.NewHTTPClient(evcServer, authToken)
+	}
+	return client.NewGRPCClient(evcServer, certsDir, insecure)
 }
 
 // readAllocatedPort scans ssh stderr for the dynamically-allocated reverse


### PR DESCRIPTION
Completes the **OSS side** of the cloud egress path (cloud forwarding = Containarium-cloud #694). `egress-via-client` was gRPC-only, so it couldn't reach a **cloud** box (the operator talks to the CP over REST, not the daemon's gRPC).

- **`internal/client/http.go`** — `StartEgressProxy`/`StopEgressProxy` over REST (`POST`/`DELETE /v1/network/egress-proxy`), mirroring the gRPC client; idempotent stop (404 = success).
- **`internal/cmd/egress_via_client.go`** — `newEgressControlClient` picks the transport: `--http` → cloud REST (a `ctnr_` token via `--token`/`$CONTAINARIUM_TOKEN`); otherwise gRPC to a daemon (direct/BYOC). The `egressControlClient` interface is satisfied by both `*GRPCClient` and `*HTTPClient`.

Usage (cloud box):
```
containarium egress-via-client cld-xxx --http --server https://cloud.containarium.dev \
  --ssh cld-xxx@<zone>.containarium.dev -i ~/.containarium/keys/cld-xxx
```

Build (incl. Windows) / vet / gofmt clean. With cloud #694 deployed, this makes the **NAT'd-operator + cloud-box** path work end-to-end. Refs #808, design `docs/EGRESS-VIA-CLIENT-DESIGN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)