### PR TITLE
fix(egress): map username → <username>-container in StartEgressProxy (#808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   address, e.g. `10.100.0.0/24` → `10.100.0.1` — the address a box already
   reaches the daemon on), so egress works on every daemon, not just app-hosting
   ones.
+- **`StartEgressProxy` resolved the wrong Incus instance name (#808).** It
+  looked up the box by the bare username (`cld-abcd1234`), but Incus instances
+  are named `<username>-container`, so the lookup 404'd once the gateway fix
+  above let execution reach it. Now maps username → `<username>-container`
+  (tolerating an already-qualified name), matching every other container RPC.
 
 ## [0.46.0] - 2026-06-24
 

--- a/internal/server/network_server.go
+++ b/internal/server/network_server.go
@@ -1202,7 +1202,15 @@ func (s *NetworkServer) StartEgressProxy(ctx context.Context, req *pb.StartEgres
 	if s.incusClient == nil {
 		return nil, status.Error(codes.Unavailable, "container backend unavailable")
 	}
-	info, err := s.incusClient.GetContainer(name)
+	// The caller passes the box's username (e.g. "cld-abcd1234"); the Incus
+	// instance is "<username>-container" (the convention container_server.go
+	// uses everywhere). Map it before the lookup, tolerating a fully-qualified
+	// name in case a caller already passed the instance name.
+	instanceName := name
+	if !strings.HasSuffix(instanceName, "-container") {
+		instanceName += "-container"
+	}
+	info, err := s.incusClient.GetContainer(instanceName)
 	if err != nil || info == nil {
 		return nil, status.Errorf(codes.NotFound, "container %q not found", name)
 	}


### PR DESCRIPTION
Second egress bug (latent behind the proxyIP fix #814): `StartEgressProxy` looked up the box by the **bare username** via `GetContainer(name)`, but Incus instances are named `<username>-container`. `GetContainer → GetInstance(name)` takes the raw name, so it 404'd once the gateway fix let execution reach it. Now maps username → `<username>-container` (tolerating an already-qualified name), matching every other container RPC. Folded into the v0.46.1 changelog. Build/vet/gofmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)