### PR TITLE
fix(jump): unlock the account in CreateJumpServerAccount too (#687/#808)

### DIFF
--- a/pkg/core/container/jump_server.go
+++ b/pkg/core/container/jump_server.go
@@ -57,12 +57,27 @@ func CreateJumpServerAccount(username string, sshPublicKey string, verbose bool)
 		if err := ensureProxyOnlyShell(username, verbose); err != nil {
 			return fmt.Errorf("failed to ensure proxy-only shell: %w", err)
 		}
+		// Self-heal a previously-locked account (created before this unlock fix).
+		if err := ensureAccountUnlocked(username); err != nil {
+			return err
+		}
 		return updateUserSSHKey(username, sshPublicKey, verbose)
 	}
 
 	// Create user with nologin shell (proxy-only, no shell access)
 	// Wait for lock files to clear and retry useradd if needed
 	if err := retryUseraddWithLockWait(username, verbose); err != nil {
+		return err
+	}
+
+	// Unlock: useradd creates locked ("!") accounts, and sshd with UsePAM=no
+	// (the hardened jump/BYOC-host setting) refuses a locked account even for
+	// public-key auth — the box accepts the client key but the sentinel->host
+	// upstream hop dies with "account is locked" (#687/#808). The Manager
+	// creates boxes through THIS function (manager.go), so the unlock must live
+	// here too; EnsureJumpServerAccount only covered the other create path.
+	if err := ensureAccountUnlocked(username); err != nil {
+		_ = exec.Command("userdel", "-r", username).Run()
 		return err
 	}
 


### PR DESCRIPTION
**The #798 unlock fix never covered the real box-create path.** #798 unlocked in `EnsureJumpServerAccount`, but boxes are created through the **Manager** (`manager.go:249`), which calls `CreateJumpServerAccount` — and that never unlocked. So every new box's host jump account stays `!`-locked.

On a `UsePAM=no` host (the hardened jump/BYOC setting) sshd refuses a locked account **even for pubkey**, so the sentinel→host upstream hop fails with "account is locked" — the **#687 SSH bug recurs for every new box**.

**Confirmed live:** a fresh box (`luckydraw10`) had shadow `!` despite the daemon running v0.46.1 (which has #798) — because `EnsureJumpServerAccount` isn't the path that creates it. It only didn't break SSH on the cloud workhorse because that host is `UsePAM=yes` (where `!` is benign for pubkey).

**Fix:** add `ensureAccountUnlocked` to `CreateJumpServerAccount` on both branches — after `useradd` (create path, userdel-cleanup on failure) and on the already-exists path (self-heals a previously-locked account on the next create/reconcile). Reuses the `ensureAccountUnlocked`/`shadowAccountLocked` helpers from #798/#799. Build/vet/gofmt/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)