### PR TITLE
fix(modelgateway): preserve tool_calls + normalize finish_reason on gemini-openai (v0.46.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.46.3] - 2026-06-25
+
+### Fixed
+
+- **Model-gateway dropped/mis-tagged tool calls on the `gemini-openai` provider
+  → agent chats hung.** Gemini's OpenAI-compat surface is not OpenAI-conformant
+  for tool calls: it returns `finish_reason: "stop"` even when the response
+  carries a `tool_calls` delta. The gateway passed this through unchanged, so an
+  agent client (e.g. a hosted LibreChat workspace) never recognized the tool
+  call, and the generation hung until the client's stale-job reaper killed it
+  (surfacing as "Generation timed out"). Worse, the SSE leak-filter path (active
+  whenever a system prompt is present — the normal agent state) reconstructed
+  chunks from `content` + `finish_reason` only and **dropped the `tool_calls`
+  field entirely**. The gateway now (a) preserves `tool_calls` deltas verbatim on
+  both the filtered and pass-through SSE paths (a tool call is a structured
+  invocation, not a system-prompt-leak vector), and (b) normalizes
+  `finish_reason` `"stop"` → `"tool_calls"` once a tool call has been seen, on
+  the streaming and non-streaming OpenAI-shaped paths. Plain text turns are
+  untouched. This makes agentic tool-calling work through the managed gateway.
+
 ## [0.46.2] - 2026-06-24
 
 ### Fixed

--- a/internal/modelgateway/gateway.go
+++ b/internal/modelgateway/gateway.go
@@ -265,6 +265,18 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 					g.cfg.Sink.RecordUsage(claims.Tenant, claims.SkillID, provName, u)
 				}
 				captureUsage(u) // folded into the END lifecycle log
+
+				// Normalize Gemini's non-conformant tool-call finish_reason
+				// ("stop" -> "tool_calls") on the OpenAI-shaped surface, so an
+				// agent client runs the tool instead of hanging. Only rewrites
+				// when a tool call is actually present; normal responses untouched.
+				if (provName == "openai" || provName == "gemini-openai") && normalizeNonStreamToolFinish(decoded) {
+					if nb, merr := json.Marshal(decoded); merr == nil {
+						resp.Body = io.NopCloser(bytes.NewReader(nb))
+						resp.ContentLength = int64(len(nb))
+						resp.Header.Set("Content-Length", strconv.Itoa(len(nb)))
+					}
+				}
 			}
 			return nil
 		},

--- a/internal/modelgateway/sse.go
+++ b/internal/modelgateway/sse.go
@@ -142,11 +142,89 @@ func leaks(resp, sysNorm string) bool {
 type sseChunk struct {
 	Choices []struct {
 		Delta struct {
-			Content string `json:"content"`
+			Content   string          `json:"content"`
+			ToolCalls json.RawMessage `json:"tool_calls"`
 		} `json:"delta"`
 		FinishReason *string `json:"finish_reason"`
 	} `json:"choices"`
 	Usage map[string]any `json:"usage"`
+}
+
+// chunkHasToolCalls reports whether a streaming choice carries a non-empty
+// tool_calls array — the delta that asks the client to invoke a function.
+func chunkHasToolCalls(ch sseChunk) bool {
+	if len(ch.Choices) == 0 {
+		return false
+	}
+	raw := strings.TrimSpace(string(ch.Choices[0].Delta.ToolCalls))
+	return raw != "" && raw != "null" && raw != "[]"
+}
+
+// normalizeToolFinish rewrites finish_reason "stop" -> "tool_calls" in an
+// OpenAI chat chunk payload. Gemini's OpenAI-compat surface returns "stop" even
+// when it emitted a tool call, which is NOT OpenAI-conformant: an agent client
+// (e.g. LibreChat) then never runs the tool and the turn hangs until reaped.
+// Only choices whose finish_reason is exactly "stop" are touched; the tool_calls
+// themselves and any provider extras are preserved. Fail-open: returns the input
+// unchanged on any shape it doesn't recognise or if nothing changed.
+func normalizeToolFinish(payload string) string {
+	var m map[string]any
+	if json.Unmarshal([]byte(payload), &m) != nil {
+		return payload
+	}
+	chs, ok := m["choices"].([]any)
+	if !ok {
+		return payload
+	}
+	changed := false
+	for _, c := range chs {
+		cm, _ := c.(map[string]any)
+		if cm == nil {
+			continue
+		}
+		if fr, _ := cm["finish_reason"].(string); fr == "stop" {
+			cm["finish_reason"] = "tool_calls"
+			changed = true
+		}
+	}
+	if !changed {
+		return payload
+	}
+	nb, err := json.Marshal(m)
+	if err != nil {
+		return payload
+	}
+	return string(nb)
+}
+
+// normalizeNonStreamToolFinish rewrites finish_reason "stop" -> "tool_calls" on
+// a NON-streaming OpenAI chat response when the choice actually carries a
+// message.tool_calls array (Gemini returns "stop" there too). Mutates decoded
+// in place; reports whether anything changed.
+func normalizeNonStreamToolFinish(decoded map[string]any) bool {
+	chs, ok := decoded["choices"].([]any)
+	if !ok {
+		return false
+	}
+	changed := false
+	for _, c := range chs {
+		cm, _ := c.(map[string]any)
+		if cm == nil {
+			continue
+		}
+		if fr, _ := cm["finish_reason"].(string); fr != "stop" {
+			continue
+		}
+		msg, _ := cm["message"].(map[string]any)
+		if msg == nil {
+			continue
+		}
+		if tc, ok := msg["tool_calls"].([]any); ok && len(tc) > 0 {
+			cm["finish_reason"] = "tool_calls"
+			changed = true
+		}
+	}
+	return changed
 }
 
 // filterSSEStream copies an OpenAI-style SSE stream from src to dst, holding
@@ -170,6 +248,10 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 	// FINAL value once (recording each event would double-count).
 	var lastUsage Usage
 	haveUsage := false
+	// Gemini ends a tool-call turn with finish_reason "stop"; once we've seen a
+	// tool call we rewrite that to the OpenAI-conformant "tool_calls" so the
+	// agent client runs the tool instead of hanging.
+	sawToolCall := false
 
 	writeContent := func(s string) error {
 		if s == "" {
@@ -211,11 +293,21 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 			lastUsage = parse(map[string]any{"usage": ch.Usage})
 			haveUsage = true
 		}
+		if chunkHasToolCalls(ch) {
+			sawToolCall = true
+		}
 
 		// Metering-only (no system prompt / filter disabled): pass the original
-		// chunk through unchanged — no hold-back, no re-serialization.
+		// chunk through unchanged — no hold-back, no re-serialization — except we
+		// still normalize a tool-call turn's finish_reason ("stop" -> "tool_calls")
+		// so the agent client runs the tool. The tool_calls delta itself passes
+		// through verbatim.
 		if !filtering {
-			if _, err := dst.Write([]byte(line + "\n")); err != nil {
+			out := line
+			if sawToolCall && len(ch.Choices) > 0 && ch.Choices[0].FinishReason != nil && *ch.Choices[0].FinishReason == "stop" {
+				out = "data: " + normalizeToolFinish(payload)
+			}
+			if _, err := dst.Write([]byte(out + "\n")); err != nil {
 				loopErr = err
 				break
 			}
@@ -227,6 +319,27 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 		if len(ch.Choices) > 0 {
 			content = ch.Choices[0].Delta.Content
 			finish = ch.Choices[0].FinishReason
+		}
+
+		// Tool-call chunks pass through verbatim (with finish_reason normalized).
+		// A tool call is a structured function invocation, not free-text content,
+		// so it is NOT a system-prompt-leak vector and must not be dropped or held
+		// back — dropping it is exactly what hangs the agent. Flush any pending
+		// safe content first to preserve ordering.
+		if chunkHasToolCalls(ch) {
+			if !redacted && pending.Len() > 0 {
+				if err := writeContent(pending.String()); err != nil {
+					loopErr = err
+					break
+				}
+				emitted.WriteString(pending.String())
+				pending.Reset()
+			}
+			if _, err := dst.Write([]byte("data: " + normalizeToolFinish(payload) + "\n\n")); err != nil {
+				loopErr = err
+				break
+			}
+			continue
 		}
 
 		if content != "" && !redacted {
@@ -259,7 +372,13 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 		if finish != nil || ch.Usage != nil {
 			env := map[string]any{}
 			if finish != nil {
-				env["choices"] = []map[string]any{{"index": 0, "delta": map[string]any{}, "finish_reason": *finish}}
+				fr := *finish
+				// Gemini ends a tool-call turn with "stop"; the agent client needs
+				// the OpenAI-conformant "tool_calls" to run the tool.
+				if fr == "stop" && sawToolCall {
+					fr = "tool_calls"
+				}
+				env["choices"] = []map[string]any{{"index": 0, "delta": map[string]any{}, "finish_reason": fr}}
 			}
 			if ch.Usage != nil {
 				env["usage"] = ch.Usage

--- a/internal/modelgateway/sse_test.go
+++ b/internal/modelgateway/sse_test.go
@@ -117,6 +117,75 @@ func TestSSE_UnknownChunkPassthrough(t *testing.T) {
 	}
 }
 
+// toolSSE mimics Gemini's OpenAI-compat streaming for a tool call: a chunk with
+// a tool_calls delta, then a SEPARATE finish chunk with the non-conformant
+// finish_reason "stop" (Gemini's quirk) + usage, then [DONE].
+const toolSSE = `data: {"choices":[{"delta":{"role":"assistant","tool_calls":[{"function":{"arguments":"{}","name":"list_containers"},"id":"abc","type":"function"}]},"index":0}]}` + "\n\n" +
+	`data: {"choices":[{"delta":{"role":"assistant"},"finish_reason":"stop","index":0}],"usage":{"prompt_tokens":33,"completion_tokens":10}}` + "\n\n" +
+	"data: [DONE]\n\n"
+
+// With the leak filter ON (a system prompt is present — the workspace agent's
+// normal state), tool calls must NOT be dropped and the turn's finish_reason
+// must be normalized "stop" -> "tool_calls" so the agent client runs the tool.
+func TestSSE_ToolCall_FilterOn_PreservesCallAndNormalizesFinish(t *testing.T) {
+	out, u := runFilter(t, toolSSE, "You are a senior product manager. Ask clarifying questions before proposing anything.")
+	if !strings.Contains(out, `"name":"list_containers"`) {
+		t.Fatalf("tool_calls dropped by filter; out=%q", out)
+	}
+	if !strings.Contains(out, `"finish_reason":"tool_calls"`) {
+		t.Fatalf("finish_reason not normalized to tool_calls; out=%q", out)
+	}
+	if strings.Contains(out, `"finish_reason":"stop"`) {
+		t.Fatalf("non-conformant finish_reason \"stop\" leaked to client; out=%q", out)
+	}
+	if u.OutputTokens != 10 {
+		t.Fatalf("usage out = %d, want 10 (metered on a tool-call turn)", u.OutputTokens)
+	}
+}
+
+// With the filter OFF (no system prompt), tool calls already pass through, but
+// the finish_reason still needs normalizing.
+func TestSSE_ToolCall_FilterOff_NormalizesFinish(t *testing.T) {
+	out, _ := runFilter(t, toolSSE, "")
+	if !strings.Contains(out, `"name":"list_containers"`) {
+		t.Fatalf("tool_calls missing; out=%q", out)
+	}
+	if !strings.Contains(out, `"finish_reason":"tool_calls"`) || strings.Contains(out, `"finish_reason":"stop"`) {
+		t.Fatalf("finish_reason not normalized; out=%q", out)
+	}
+}
+
+// A plain text turn (no tool call) must keep finish_reason "stop" — we only
+// rewrite when a tool call was actually seen.
+func TestSSE_PlainStop_NotRewritten(t *testing.T) {
+	out, _ := runFilter(t, chunk("hi", "stop")+"data: [DONE]\n\n", "")
+	if !strings.Contains(out, `"finish_reason":"stop"`) {
+		t.Fatalf("plain stop should be preserved; out=%q", out)
+	}
+	if strings.Contains(out, `"finish_reason":"tool_calls"`) {
+		t.Fatalf("plain stop wrongly rewritten to tool_calls; out=%q", out)
+	}
+}
+
+func TestNormalizeNonStreamToolFinish(t *testing.T) {
+	// finish_reason "stop" WITH message.tool_calls → rewritten.
+	withTool := map[string]any{}
+	_ = json.Unmarshal([]byte(`{"choices":[{"finish_reason":"stop","message":{"tool_calls":[{"id":"x"}]}}]}`), &withTool)
+	if !normalizeNonStreamToolFinish(withTool) {
+		t.Fatalf("expected change when tool_calls present with stop")
+	}
+	chs := withTool["choices"].([]any)
+	if chs[0].(map[string]any)["finish_reason"] != "tool_calls" {
+		t.Fatalf("finish_reason not rewritten: %v", chs[0])
+	}
+	// finish_reason "stop" WITHOUT tool_calls → untouched.
+	noTool := map[string]any{}
+	_ = json.Unmarshal([]byte(`{"choices":[{"finish_reason":"stop","message":{"content":"hi"}}]}`), &noTool)
+	if normalizeNonStreamToolFinish(noTool) {
+		t.Fatalf("must not change a plain stop response")
+	}
+}
+
 func TestEnsureStreamUsage(t *testing.T) {
 	out, streaming := ensureStreamUsage([]byte(`{"model":"gemini-2.5-flash","stream":true,"messages":[]}`))
 	if !streaming {


### PR DESCRIPTION
## What

The `gemini-openai` model-gateway provider broke agentic tool-calling for hosted LibreChat workspaces. Two bugs:

1. **Wrong `finish_reason`.** Gemini's OpenAI-compat surface returns `finish_reason:"stop"` even when it emits a `tool_calls` delta (not OpenAI-conformant). The agent client never recognizes the tool call → the generation hangs until the client's 20-min stale-job reaper kills it → surfaces as **"Generation timed out"**.
2. **Dropped tool calls.** The SSE leak-filter path (active whenever a system prompt is present — i.e. every agent turn) rebuilt chunks from `content` + `finish_reason` only and **dropped `tool_calls` entirely**, so the call never reached the client at all.

## Fix

On both the streaming (`sse.go filterSSEStream`) and non-streaming (`gateway.go`) OpenAI-shaped paths:
- **Preserve `tool_calls` deltas verbatim** (incl. provider extras like Gemini's `thought_signature`). A tool call is a structured function invocation, not free-text content, so it's not a system-prompt-leak vector and must never be dropped/redacted.
- **Normalize `finish_reason` `"stop"` → `"tool_calls"`** once a tool call has been seen in the turn. Plain text turns are untouched (verified by a test).

## Diagnosis

Captured live from the workspace box: the gateway emitted `delta.tool_calls=[list_containers]` followed by a `finish_reason:"stop"` chunk; the daemon logged `stream-ended-without-usage` and the LibreChat box logged `InMemoryJobStore Reaped 1 stale running job exceeding 1200000ms` + `sendCompletion Operation aborted`. A non-streaming call worked, isolating it to the streaming/tool path.

## Tests

`go test ./internal/modelgateway/` green — added filter-on, filter-off, plain-stop-not-rewritten, and non-streaming-normalizer cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)