### PR TITLE
fix(modelgateway): standardize gemini tool_calls deltas — unblock round-2 (v0.46.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.46.6] - 2026-06-25
+
+### Fixed
+
+- **Workspace chat tool calls aborted after firing ("terminated") — now
+  complete.** Gemini's OpenAI-compat surface streams `tool_calls` deltas that
+  OMIT the `index` field and add a non-standard `extra_content`
+  (`thought_signature`). A LangChain-based client (LibreChat v0.8.6) merges
+  streamed tool-call deltas BY `index`; without it the stream parser throws and
+  aborts the turn (`sendCompletion … terminated`) right after the tool call is
+  emitted — so the tool fired but the result/summary never came back. The
+  model-gateway now standardizes tool_calls deltas on the OpenAI-shaped paths:
+  it injects a position-based `index` where missing and strips `extra_content`,
+  so the client assembles the call, runs the tool, and the model summarizes the
+  result. Completes the agentic tool-calling chain for the managed workspace
+  (with v0.46.3 finish_reason + v0.46.4 envelope fixes). Daemon-side — existing
+  workspace boxes benefit after a workhorse roll, no redeploy.
+
 ## [0.46.5] - 2026-06-25
 
 ### Fixed

--- a/internal/modelgateway/sse.go
+++ b/internal/modelgateway/sse.go
@@ -229,6 +229,60 @@ func normalizeToolFinish(payload string) string {
 	return string(nb)
 }
 
+// standardizeToolCalls rewrites an OpenAI streaming chunk's tool_calls deltas to
+// the spec shape a LangChain-based client (LibreChat v0.8.6) requires: each
+// entry MUST carry an `index` (used to merge streamed tool-call deltas) and only
+// the standard fields. Gemini's OpenAI-compat surface OMITS `index` and adds a
+// non-standard `extra_content` (a `thought_signature`); without the index the
+// client's stream parser throws and aborts the turn ("terminated") before it can
+// run the tool, and the stray field can trip strict decoders. We inject a
+// position-based index where missing and drop `extra_content`. Fail-open:
+// returns the input unchanged on any shape it doesn't recognise or no change.
+func standardizeToolCalls(payload string) string {
+	var m map[string]any
+	if json.Unmarshal([]byte(payload), &m) != nil {
+		return payload
+	}
+	chs, ok := m["choices"].([]any)
+	if !ok {
+		return payload
+	}
+	changed := false
+	for _, c := range chs {
+		cm, _ := c.(map[string]any)
+		if cm == nil {
+			continue
+		}
+		delta, _ := cm["delta"].(map[string]any)
+		if delta == nil {
+			continue
+		}
+		tcs, _ := delta["tool_calls"].([]any)
+		for i, tc := range tcs {
+			tcm, _ := tc.(map[string]any)
+			if tcm == nil {
+				continue
+			}
+			if _, has := tcm["index"]; !has {
+				tcm["index"] = i
+				changed = true
+			}
+			if _, has := tcm["extra_content"]; has {
+				delete(tcm, "extra_content")
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return payload
+	}
+	nb, err := json.Marshal(m)
+	if err != nil {
+		return payload
+	}
+	return string(nb)
+}
+
 // normalizeNonStreamToolFinish rewrites finish_reason "stop" -> "tool_calls" on
 // a NON-streaming OpenAI chat response when the choice actually carries a
 // message.tool_calls array (Gemini returns "stop" there too). Mutates decoded
@@ -354,7 +408,9 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 		// through verbatim.
 		if !filtering {
 			out := line
-			if sawToolCall && len(ch.Choices) > 0 && ch.Choices[0].FinishReason != nil && *ch.Choices[0].FinishReason == "stop" {
+			if chunkHasToolCalls(ch) {
+				out = "data: " + normalizeToolFinish(standardizeToolCalls(payload))
+			} else if sawToolCall && len(ch.Choices) > 0 && ch.Choices[0].FinishReason != nil && *ch.Choices[0].FinishReason == "stop" {
 				out = "data: " + normalizeToolFinish(payload)
 			}
 			if _, err := dst.Write([]byte(out + "\n")); err != nil {
@@ -385,7 +441,7 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 				emitted.WriteString(pending.String())
 				pending.Reset()
 			}
-			if _, err := dst.Write([]byte("data: " + normalizeToolFinish(payload) + "\n\n")); err != nil {
+			if _, err := dst.Write([]byte("data: " + normalizeToolFinish(standardizeToolCalls(payload)) + "\n\n")); err != nil {
 				loopErr = err
 				break
 			}

--- a/internal/modelgateway/sse_test.go
+++ b/internal/modelgateway/sse_test.go
@@ -189,6 +189,27 @@ func TestSSE_FilterOn_FullChunkShape(t *testing.T) {
 	}
 }
 
+// standardizeToolCalls must inject a position index (LangChain clients merge
+// streamed tool-call deltas by index) and drop Gemini's non-standard
+// extra_content — without this LibreChat aborts the turn ("terminated").
+func TestStandardizeToolCalls(t *testing.T) {
+	in := `{"choices":[{"delta":{"tool_calls":[{"extra_content":{"google":{"thought_signature":"x"}},"function":{"name":"list_containers","arguments":"{}"},"id":"abc","type":"function"}]}}]}`
+	out := standardizeToolCalls(in)
+	if !strings.Contains(out, `"index":0`) {
+		t.Fatalf("index not injected: %s", out)
+	}
+	if strings.Contains(out, "extra_content") || strings.Contains(out, "thought_signature") {
+		t.Fatalf("extra_content not stripped: %s", out)
+	}
+	if !strings.Contains(out, `"name":"list_containers"`) {
+		t.Fatalf("tool call dropped: %s", out)
+	}
+	plain := `{"choices":[{"delta":{"content":"hi"}}]}`
+	if standardizeToolCalls(plain) != plain {
+		t.Fatalf("plain content chunk must be unchanged")
+	}
+}
+
 func TestNormalizeNonStreamToolFinish(t *testing.T) {
 	// finish_reason "stop" WITH message.tool_calls → rewritten.
 	withTool := map[string]any{}


### PR DESCRIPTION
## What
After the tool fired, the workspace chat aborted with `sendCompletion … Unhandled error type terminated` and never returned a result. Gemini's OpenAI-compat `tool_calls` deltas **omit `index`** and add a non-standard **`extra_content`** (`thought_signature`). LibreChat (LangChain) merges streamed tool-call deltas **by `index`** — without it the parser throws and aborts the turn right after the call is emitted.

## Fix
The gateway now standardizes `tool_calls` deltas on the OpenAI-shaped SSE paths: inject a position-based `index` where missing, drop `extra_content`. The client then assembles the call, runs the tool, and the model summarizes — completing the agentic chain (with v0.46.3 finish_reason + v0.46.4 envelope fixes).

## Evidence
Live: the recipe-baked agent fired `list_containers` but the gateway req had no END and librechat logged `terminated`; the raw delta had `extra_content` + no `index` (confirmed via direct gateway probe).

## Tests
`go test ./internal/modelgateway/` green; added `TestStandardizeToolCalls` (index injected, extra_content dropped, plain chunks untouched).

Daemon-side — existing workspace boxes benefit after a workhorse roll (no redeploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)