### PR TITLE
fix(recipe): workspace tool-agent on gemini-2.5-flash-lite — round-trip tools (v0.46.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.46.7] - 2026-06-25
+
+### Fixed
+
+- **Workspace chat tool calls now complete the full round-trip.** The tool-using
+  workspace agent now runs on **`gemini-2.5-flash-lite`** instead of
+  `gemini-flash-latest`. Gemini 2.5's thinking models require a
+  `thought_signature` to be echoed back on EVERY tool-result round-trip on the
+  OpenAI-compat surface (round-2 otherwise 400s: "Function call is missing a
+  thought_signature"), and a LangChain/LibreChat client can't carry that
+  non-standard field — so the chat fired the tool but the turn terminated before
+  returning the result. `gemini-2.5-flash-lite` (non-thinking) uses standard
+  function-calling that round-trips cleanly (verified: round-2 = 200). The agent,
+  its model-spec, and the endpoint's model list now use the lite model; chat-only
+  skill personas keep `gemini-flash-latest`. Completes the agentic tool-calling
+  chain (v0.46.3 finish_reason + v0.46.4 envelope + v0.46.6 delta index). Existing
+  workspace boxes need a redeploy (the agent + spec are baked at deploy).
+
 ## [0.46.6] - 2026-06-25
 
 ### Fixed

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -365,7 +365,7 @@ recipes:
       # gateway seeded → empty config, LibreChat falls back to its own provider.
       - |
         if [ -n "${CONTAINARIUM_MODEL_GATEWAY_URL:-}" ] && [ -n "${CONTAINARIUM_GATEWAY_TOKEN:-}" ]; then
-          printf 'version: 1.2.1\ncache: true\nendpoints:\n  custom:\n    - name: "Containarium (Gemini)"\n      apiKey: "${CTN_GATEWAY_TOKEN}"\n      baseURL: "%s/v1beta/openai"\n      models:\n        default: ["gemini-flash-latest", "gemini-2.5-flash"]\n        fetch: false\n      titleConvo: true\n      titleModel: "gemini-flash-latest"\n      modelDisplayLabel: "Containarium Gemini"\n' "$CONTAINARIUM_MODEL_GATEWAY_URL" > /opt/lc/librechat.yaml
+          printf 'version: 1.2.1\ncache: true\nendpoints:\n  custom:\n    - name: "Containarium (Gemini)"\n      apiKey: "${CTN_GATEWAY_TOKEN}"\n      baseURL: "%s/v1beta/openai"\n      models:\n        default: ["gemini-2.5-flash-lite", "gemini-flash-latest", "gemini-2.5-flash"]\n        fetch: false\n      titleConvo: true\n      titleModel: "gemini-flash-latest"\n      modelDisplayLabel: "Containarium Gemini"\n' "$CONTAINARIUM_MODEL_GATEWAY_URL" > /opt/lc/librechat.yaml
         else
           printf 'version: 1.2.1\ncache: true\n' > /opt/lc/librechat.yaml
           echo 'librechat: no managed gateway seeded; configure a provider in LibreChat' >&2
@@ -493,7 +493,7 @@ recipes:
                  "instead of giving generic shell instructions. After a tool returns, "
                  "summarize the result clearly. Be concise.")
         body = {"name": "Containarium Workspace", "description": "Manages your Containarium boxes",
-                "provider": "Containarium (Gemini)", "model": "gemini-flash-latest",
+                "provider": "Containarium (Gemini)", "model": "gemini-2.5-flash-lite",
                 "instructions": instr, "tools": keys}
         try:
             print(json.loads(req("/api/agents", body)).get("id", ""))
@@ -587,7 +587,13 @@ recipes:
                 # carries the instructions + the tools; the spec just selects it.
                 out.append('        endpoint: "agents"')
                 out.append("        agent_id: " + json.dumps(AGENT_ID))
-                out.append('        model: "gemini-flash-latest"')
+                # gemini-2.5-flash-lite, NOT gemini-flash-latest: the 2.5 thinking
+                # model demands a thought_signature be echoed on every tool-result
+                # round-trip (OpenAI-compat), which LangChain/LibreChat can't carry,
+                # so multi-turn tool calls 400 ("missing thought_signature"). The
+                # lite (non-thinking) model uses standard function-calling that
+                # round-trips cleanly.
+                out.append('        model: "gemini-2.5-flash-lite"')
             else:
                 # Chat-only persona (skills) or no-MCP fallback: custom endpoint,
                 # prompt carried by the spec. No tools on this path.


### PR DESCRIPTION
## What
The workspace chat fired tools but never returned a result — after the tool call, round-2 (the tool-result turn) **400'd**: `Function call is missing a thought_signature in functionCall parts`. Gemini 2.5 thinking models require that `thought_signature` be echoed back on every tool round-trip (OpenAI-compat), and LangChain/LibreChat can't carry that non-standard field.

## Fix
Run the tool-using workspace agent on **`gemini-2.5-flash-lite`** (non-thinking → standard function-calling, no signature requirement). Updated the agent (`create_agent.py`), its `agents`-endpoint model-spec (`gen_modelspecs.py`), and the custom endpoint's `models` list. Chat-only skill personas keep `gemini-flash-latest`.

## Proof
2-round gateway probe: `gemini-flash-latest` round-2 = **400** (missing thought_signature, even with thinking off / signature-less round-1); `gemini-2.5-flash-lite` round-1 has no signature and round-2 = **200** with the summary. This completes the chain after v0.46.3 (finish_reason), v0.46.4 (envelope), v0.46.6 (delta index).

## Tests
`go test ./pkg/core/recipes/` green; recipes.yaml parses. Existing workspace boxes need a redeploy (agent + spec baked at deploy time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)