### PR TITLE
fix(modelgateway): close round-1 SSE at finish on tool turns (v0.46.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.46.8] - 2026-06-25
+
+### Fixed
+
+- **Workspace chat tool turns hung the gateway → "terminated" before the result
+  round.** On a tool turn the gateway kept reading the provider after the
+  `finish_reason` arrived, waiting for Gemini to close the SSE stream — but
+  Gemini's OpenAI-compat doesn't reliably close a tool stream, and a LangChain
+  agent client (LibreChat) abandons round-1 the instant it has the `tool_call`.
+  The result: the round-1 gateway request never completed (no END), and the
+  client's HTTP stream "terminated", aborting the turn before it could run the
+  tool-result round. The gateway now **stops reading and emits its own `[DONE]` +
+  closes immediately when a tool turn's `finish_reason` is seen**, so round-1
+  completes promptly and the client proceeds to round-2. Content turns are
+  unchanged (they drain fully, preserving any trailing usage chunk). This is the
+  final piece of the agentic tool-calling chain (v0.46.3/4/6/7).
+
 ## [0.46.7] - 2026-06-25
 
 ### Fixed

--- a/internal/modelgateway/sse.go
+++ b/internal/modelgateway/sse.go
@@ -417,6 +417,11 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 				loopErr = err
 				break
 			}
+			// Finish on a tool turn: stop reading + close promptly (see the envelope
+			// note below). Content turns drain fully, so they don't break here.
+			if sawToolCall && len(ch.Choices) > 0 && ch.Choices[0].FinishReason != nil {
+				break
+			}
 			continue
 		}
 
@@ -443,6 +448,10 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 			}
 			if _, err := dst.Write([]byte("data: " + normalizeToolFinish(standardizeToolCalls(payload)) + "\n\n")); err != nil {
 				loopErr = err
+				break
+			}
+			// If this chunk also carried the finish, stop now (see note below).
+			if len(ch.Choices) > 0 && ch.Choices[0].FinishReason != nil {
 				break
 			}
 			continue
@@ -494,6 +503,15 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 			eb, _ := json.Marshal(c)
 			if _, err := dst.Write([]byte("data: " + string(eb) + "\n\n")); err != nil {
 				loopErr = err
+				break
+			}
+			// Finish on a TOOL turn: stop reading the provider; the post-loop emits
+			// [DONE] + closes NOW. An agent client abandons round-1 the instant it
+			// has the tool_call, and Gemini's OpenAI-compat doesn't reliably close
+			// the tool stream — so waiting deadlocks the response (no END) and the
+			// client reports "terminated" before round-2. (Content turns drain
+			// fully, so we DON'T break — that preserves any trailing usage chunk.)
+			if finish != nil && sawToolCall {
 				break
 			}
 		}

--- a/internal/modelgateway/sse_test.go
+++ b/internal/modelgateway/sse_test.go
@@ -210,6 +210,34 @@ func TestStandardizeToolCalls(t *testing.T) {
 	}
 }
 
+// The gateway must STOP at finish_reason and emit its own [DONE] promptly rather
+// than waiting for the provider to close the stream — Gemini doesn't reliably
+// close a tool stream and an agent client abandons round-1 the instant it has
+// the tool_call, which otherwise deadlocks the response ("terminated").
+func TestSSE_StopsAtFinish(t *testing.T) {
+	// A TOOL turn: tool_call, then finish, then the provider KEEPS sending
+	// (mimics Gemini not closing the tool stream). The gateway must stop at finish
+	// and emit [DONE]; the trailing content must never leak. Content turns are
+	// covered by the other tests (they drain fully and preserve trailing usage).
+	sse := `data: {"choices":[{"delta":{"tool_calls":[{"function":{"name":"list_containers","arguments":"{}"},"id":"a","type":"function"}]},"index":0}]}` + "\n\n" +
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":3,"completion_tokens":4}}` + "\n\n" +
+		chunk("LEAKED-AFTER-FINISH", "") +
+		"data: [DONE]\n\n"
+	out, u := runFilter(t, sse, "") // filter off → passthrough path
+	if !strings.Contains(out, "list_containers") {
+		t.Fatalf("tool call missing: %q", out)
+	}
+	if strings.Contains(out, "LEAKED-AFTER-FINISH") {
+		t.Fatalf("content after finish was emitted: %q", out)
+	}
+	if !strings.Contains(out, "[DONE]") {
+		t.Fatalf("missing [DONE] terminator")
+	}
+	if u.OutputTokens != 4 {
+		t.Fatalf("usage out=%d want 4 (from the finish chunk)", u.OutputTokens)
+	}
+}
+
 func TestNormalizeNonStreamToolFinish(t *testing.T) {
 	// finish_reason "stop" WITH message.tool_calls → rewritten.
 	withTool := map[string]any{}


### PR DESCRIPTION
## What
On a tool turn the workspace chat fired the tool but the turn `terminated` before the result came back. Root cause: the gateway kept reading the provider after `finish_reason`, waiting for Gemini to close the SSE — but Gemini's OpenAI-compat doesn't reliably close a tool stream, and LibreChat (LangChain) abandons round-1 the instant it has the `tool_call`. So round-1's gateway request never ENDed (stuck inflight) and the client's HTTP stream `terminated`, aborting before the tool-result round.

## Fix
The gateway now **stops reading and emits its own `[DONE]` + closes immediately when a tool turn's `finish_reason` is seen** — round-1 completes promptly so the client runs round-2. Gated on `sawToolCall`: content turns drain fully (preserving trailing usage) and are unchanged.

## Proof
An early-close client (reading only to `finish_reason`, like LibreChat) left the gateway request **stuck inflight with no END** — confirming the deadlock. DEBUG trace showed LibreChat `terminated` ~21ms after `ON_TOOL_EXECUTE`, i.e. the round-1 stream dying as the tool started.

## Tests
`go test ./internal/modelgateway/` green; added `TestSSE_StopsAtFinish` (tool turn stops at finish, trailing content not leaked, usage from the finish chunk preserved); existing content-turn usage tests still pass (not gated).

Final piece after v0.46.3 (finish_reason), v0.46.4 (envelope), v0.46.6 (delta index), v0.46.7 (flash-lite). Daemon-side — existing boxes benefit after a workhorse roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)