### PR TITLE
fix(modelgateway): coalesce [DONE] into final tool-turn chunk (v0.46.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.46.9] - 2026-06-25
+
+### Fixed
+
+- **Workspace tool calls hung the gateway because `[DONE]` was a separate write
+  the agent client never drained.** A LangChain agent client (LibreChat) stops
+  reading round-1 the instant it has the tool_call, to go execute the tool. The
+  gateway then wrote `[DONE]` as a SEPARATE write — which blocks on the
+  unbuffered response pipe when the client has stopped draining, so the round-1
+  request never completed (no END) and the client's stream `terminated` before
+  round-2. The gateway now **coalesces the final tool-turn chunk and `[DONE]`
+  into a single write**, so the client receives the stream terminator in the same
+  read it already does (before it stops draining) — round-1 ends cleanly and the
+  client runs the tool-result round. (Direct/draining clients are unaffected;
+  the post-loop no longer double-sends `[DONE]`.) Final piece of the agentic
+  tool-calling chain (v0.46.3–v0.46.8). Daemon-side — existing boxes benefit
+  after a workhorse roll.
+
 ## [0.46.8] - 2026-06-25
 
 ### Fixed

--- a/internal/modelgateway/sse.go
+++ b/internal/modelgateway/sse.go
@@ -339,6 +339,10 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 	// tool call we rewrite that to the OpenAI-conformant "tool_calls" so the
 	// agent client runs the tool instead of hanging.
 	sawToolCall := false
+	// doneSent: a tool turn coalesces its final chunk + [DONE] into ONE write (so
+	// an agent client that stops draining right after the tool_call still receives
+	// [DONE] in the same read); the post-loop must then NOT write [DONE] again.
+	doneSent := false
 
 	// Envelope fields captured from the first upstream chunk, so the chunks WE
 	// synthesize (held-back content, redaction note, finish envelope) carry the
@@ -413,13 +417,18 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 			} else if sawToolCall && len(ch.Choices) > 0 && ch.Choices[0].FinishReason != nil && *ch.Choices[0].FinishReason == "stop" {
 				out = "data: " + normalizeToolFinish(payload)
 			}
-			if _, err := dst.Write([]byte(out + "\n")); err != nil {
-				loopErr = err
+			if sawToolCall && len(ch.Choices) > 0 && ch.Choices[0].FinishReason != nil {
+				// Tool turn ending: coalesce [DONE] into the SAME write — the agent
+				// client stops draining right after the tool_call, so a separate
+				// [DONE] write would block (deadlock). Then close.
+				if _, err := dst.Write([]byte(out + "\n" + "data: [DONE]\n\n")); err != nil {
+					loopErr = err
+				}
+				doneSent = true
 				break
 			}
-			// Finish on a tool turn: stop reading + close promptly (see the envelope
-			// note below). Content turns drain fully, so they don't break here.
-			if sawToolCall && len(ch.Choices) > 0 && ch.Choices[0].FinishReason != nil {
+			if _, err := dst.Write([]byte(out + "\n")); err != nil {
+				loopErr = err
 				break
 			}
 			continue
@@ -446,12 +455,18 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 				emitted.WriteString(pending.String())
 				pending.Reset()
 			}
-			if _, err := dst.Write([]byte("data: " + normalizeToolFinish(standardizeToolCalls(payload)) + "\n\n")); err != nil {
-				loopErr = err
+			tcOut := "data: " + normalizeToolFinish(standardizeToolCalls(payload)) + "\n\n"
+			if len(ch.Choices) > 0 && ch.Choices[0].FinishReason != nil {
+				// tool_call + finish in one chunk: append [DONE] to the SAME write so
+				// the client receives both before it stops draining, then close.
+				if _, err := dst.Write([]byte(tcOut + "data: [DONE]\n\n")); err != nil {
+					loopErr = err
+				}
+				doneSent = true
 				break
 			}
-			// If this chunk also carried the finish, stop now (see note below).
-			if len(ch.Choices) > 0 && ch.Choices[0].FinishReason != nil {
+			if _, err := dst.Write([]byte(tcOut)); err != nil {
+				loopErr = err
 				break
 			}
 			continue
@@ -501,17 +516,20 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 				}
 			}
 			eb, _ := json.Marshal(c)
-			if _, err := dst.Write([]byte("data: " + string(eb) + "\n\n")); err != nil {
-				loopErr = err
+			envOut := "data: " + string(eb) + "\n\n"
+			if finish != nil && sawToolCall {
+				// Separate finish chunk on a tool turn: coalesce [DONE] into the SAME
+				// write so the client receives it before it stops draining (a separate
+				// write would block on the non-draining client), then close. Content
+				// turns drain fully, so they fall through (preserving trailing usage).
+				if _, err := dst.Write([]byte(envOut + "data: [DONE]\n\n")); err != nil {
+					loopErr = err
+				}
+				doneSent = true
 				break
 			}
-			// Finish on a TOOL turn: stop reading the provider; the post-loop emits
-			// [DONE] + closes NOW. An agent client abandons round-1 the instant it
-			// has the tool_call, and Gemini's OpenAI-compat doesn't reliably close
-			// the tool stream — so waiting deadlocks the response (no END) and the
-			// client reports "terminated" before round-2. (Content turns drain
-			// fully, so we DON'T break — that preserves any trailing usage chunk.)
-			if finish != nil && sawToolCall {
+			if _, err := dst.Write([]byte(envOut)); err != nil {
+				loopErr = err
 				break
 			}
 		}
@@ -521,7 +539,7 @@ func filterSSEStream(dst *io.PipeWriter, src io.ReadCloser, sysPrompt string, pa
 	if loopErr == nil && !redacted {
 		_ = writeContent(pending.String())
 	}
-	if loopErr == nil {
+	if loopErr == nil && !doneSent {
 		_, _ = dst.Write([]byte("data: [DONE]\n\n"))
 	}
 	// Meter once, with the final cumulative usage (recording each usage event


### PR DESCRIPTION
## What
The workspace chat fired the tool but `terminated` before the result. A LangChain agent client (LibreChat) stops reading round-1 the instant it has the tool_call (to execute it). The gateway wrote `[DONE]` as a **separate** write, which blocks on the unbuffered response pipe once the client stops draining — so the round-1 request never completed (no END) and the client's stream `terminated`.

## Fix
Coalesce the final tool-turn chunk (tool_call/finish) **and `[DONE]` into one write**, so the client receives the terminator in the same read it already does, before it stops draining. `doneSent` prevents the post-loop double-send. Content/draining clients unaffected.

## Mechanism (confirmed)
An early-close client (reads only to `finish_reason`, like LibreChat) left the gateway req **stuck inflight with no END**; direct draining clients (curl, 1 or 55 tools) always completed in ~1s. The deadlock was the separate `[DONE]` write to the non-draining client — this removes it.

## Tests
`go test ./internal/modelgateway/` green (`TestSSE_StopsAtFinish` covers the tool-turn terminator). Daemon-side — existing boxes benefit after a workhorse roll. Last piece after v0.46.3 (finish_reason), v0.46.4 (envelope), v0.46.6 (delta index), v0.46.7 (flash-lite), v0.46.8 (break-at-finish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)