### PR TITLE
fix(modelgateway): strip Accept-Encoding upstream — decode gzipped streams (v0.46.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.46.10] - 2026-06-25
+
+### Fixed
+
+- **Model-gateway corrupted streamed responses for gzip-requesting clients — the
+  root cause of the managed workspace chat failing to use tools.** The gateway
+  forwarded the client's `Accept-Encoding` header to the upstream provider. A
+  client that requests gzip (LibreChat / Node's undici) therefore made the
+  provider **gzip the SSE stream**, and the streaming filter read the **raw
+  compressed bytes as text** — so every chunk (content, `tool_calls`,
+  `finish_reason`) was garbage, the tool-call processing never ran, and the
+  agent client received a corrupted stream and aborted (`terminated`) before it
+  could run the tool-result round. (`curl` probes never sent `Accept-Encoding`,
+  so they always worked — masking the bug.) The gateway now **strips
+  `Accept-Encoding` before proxying upstream**, so Go's transport owns the
+  encoding and transparently decompresses, and the filter reads plain SSE. This
+  is the keystone of the agentic tool-calling chain: v0.46.3 (finish_reason),
+  v0.46.4 (envelope), v0.46.6 (delta index), v0.46.7 (flash-lite), v0.46.8/9
+  (finish/[DONE]) fixed the *parsed-chunk* conformance — this makes the bytes
+  actually parseable. The managed workspace chat now calls platform tools and
+  returns results end-to-end (verified live). Daemon-side — existing boxes
+  benefit after a workhorse roll.
+
 ## [0.46.9] - 2026-06-25
 
 ### Fixed

--- a/internal/modelgateway/gateway.go
+++ b/internal/modelgateway/gateway.go
@@ -213,6 +213,14 @@ func (g *Gateway) handleModel(w http.ResponseWriter, r *http.Request) {
 			req.Host = upstream.Host
 			req.URL.Path = upstreamPath
 			prov.inject(req.Header, key) // strip gateway token, inject real key
+			// Drop the client's Accept-Encoding so the upstream returns identity
+			// (and Go's transport transparently decompresses any gzip). Otherwise a
+			// client that asks for gzip (e.g. LibreChat/undici) makes the provider
+			// gzip the SSE stream, and the streaming filter below reads raw
+			// compressed bytes as text — corrupting tool_call chunks so the agent
+			// client gets garbage and aborts ("terminated"). The non-streaming path
+			// already skips compressed bodies; this keeps the streaming path safe.
+			req.Header.Del("Accept-Encoding")
 		},
 		ModifyResponse: func(resp *http.Response) error {
 			// Streaming (SSE): intercept to meter usage + redact prompt leakage.

--- a/internal/modelgateway/gateway_test.go
+++ b/internal/modelgateway/gateway_test.go
@@ -2,6 +2,7 @@ package modelgateway
 
 import (
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"io"
 	"log"
@@ -125,6 +126,53 @@ func TestGateway_Anthropic_KeyInjected_TokenStripped_Metered(t *testing.T) {
 	}
 	if r.InputTokens != 12 || r.OutputTokens != 4 || r.CachedTokens != 2 || r.Calls != 1 {
 		t.Errorf("token counts wrong: %+v", r)
+	}
+}
+
+// TestGateway_DecodesGzippedStream pins the GZIP fix: a client that asks for
+// gzip (LibreChat/undici) must NOT make the gateway forward raw compressed
+// bytes to the streaming filter. By stripping the client's Accept-Encoding in
+// the Director, Go's transport owns the gzip and transparently decompresses —
+// so the filter reads plain SSE and tool_call chunks aren't corrupted (the
+// pre-fix bug surfaced as the agent client "terminating").
+func TestGateway_DecodesGzippedStream(t *testing.T) {
+	secret := []byte("shared-secret")
+	sse := `data: {"choices":[{"delta":{"content":"hello-decoded"}}]}` + "\n\n" + "data: [DONE]\n\n"
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// The transport (after the Director strips the client's AE) requests gzip;
+		// honor it with a gzipped body — the gateway must decode it.
+		if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			w.Header().Set("Content-Encoding", "gzip")
+			gz := gzip.NewWriter(w)
+			_, _ = io.WriteString(gz, sse)
+			_ = gz.Close()
+			return
+		}
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer up.Close()
+
+	providers := DefaultProviders()
+	providers["gemini-openai"].UpstreamURL = up.URL
+	gw := New(Config{Secret: secret, Providers: providers, ProviderKeys: map[string]string{"gemini-openai": "REAL-KEY"}})
+	srv := httptest.NewServer(gw.Handler())
+	defer srv.Close()
+
+	tok, _ := MintToken(secret, GatewayClaims{Tenant: "acme", SkillID: "s1", Provider: "gemini-openai"}, time.Minute)
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/model/gemini-openai/v1beta/openai/chat/completions",
+		strings.NewReader(`{"model":"gemini-2.5-flash-lite","stream":true}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Encoding", "gzip") // the offending client header
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "hello-decoded") {
+		t.Fatalf("gateway did not decode the gzipped stream; got %q", string(body))
 	}
 }
 


### PR DESCRIPTION
## What — the root cause
The managed workspace chat fired tools but the result never returned (`terminated`). After 7 fixes addressing parsed-chunk conformance, **gateway response-lifecycle instrumentation** found the real bug in one shot: the gateway forwarded the **client's `Accept-Encoding`** to the upstream. A client that requests gzip (LibreChat / Node undici) thus made gemini **gzip the SSE stream**, and `filterSSEStream` read the **raw compressed bytes as text** — so the captured "non-data" line was literally `\x1f\x8b\x08…` (gzip magic). None of the tool_call/finish processing ever ran; the client got corrupted bytes and aborted.

`curl` probes never sent `Accept-Encoding`, so they always returned plain text — which is why every direct test passed and masked the bug.

## Fix
Strip `Accept-Encoding` in the `Director` before proxying upstream. Go's transport then adds its own gzip handling and **transparently decompresses**, so the filter reads plain SSE.

## Proof
Live E2E after deploying the fix: `FOUND_REAL_BOXES: True`, 2 gateway rounds (tool call → summary, `END status=ok in=13291 out=831`), and the chat returned the actual container list. `go test ./internal/modelgateway/` green; added `TestGateway_DecodesGzippedStream`.

Keystone after v0.46.3 (finish_reason), v0.46.4 (envelope), v0.46.6 (delta index), v0.46.7 (flash-lite), v0.46.8/9 (finish/[DONE]). Daemon-side — existing boxes benefit after a workhorse roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)