### PR TITLE
fix(mcp): connect exec uses pure-Go SSH so it works in minimal images (no system ssh)

### DIFF
--- a/internal/mcp/connect.go
+++ b/internal/mcp/connect.go
@@ -1,15 +1,10 @@
 package mcp
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
-	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/footprintai/containarium/internal/connectcore"
 	"github.com/footprintai/containarium/internal/sshkey"
@@ -79,102 +74,17 @@ func handleConnect(client API, args map[string]interface{}) (string, error) {
 		return runMCPSessionExec(target, privPath, session, execCmd)
 	}
 
-	sshArgs := connectcore.BuildSSHArgs(target, privPath, execCmd)
-
 	if execCmd == "" {
 		// Config mode: hand the ready invocation back for the human to run.
+		sshArgs := connectcore.BuildSSHArgs(target, privPath, execCmd)
 		fp, _ := sshkey.Fingerprint(pub)
 		return fmt.Sprintf(
 			"✓ %s is ready — key %s authorized.\nRun this in your terminal:\n\n    ssh %s\n",
 			box, fp, strings.Join(sshArgs, " ")), nil
 	}
-	// Exec mode: run the one-shot command and return its output + exit code.
-	return runMCPSSHExec(sshArgs)
-}
-
-// runMCPSSHExec runs ssh non-interactively, capturing stdout and stderr
-// separately, and returns a structured result. A non-zero remote exit is
-// NOT a tool error — the command ran; the agent needs the output and the
-// code. Only a failure to launch ssh is an error.
-func runMCPSSHExec(sshArgs []string) (string, error) {
-	sshBin, err := exec.LookPath("ssh")
-	if err != nil {
-		return "", fmt.Errorf("ssh not found in PATH: %w", err)
-	}
-	// #nosec G204 -- sshBin is the resolved `ssh` binary; sshArgs are built
-	// from a validated box name + daemon-resolved target. Running ssh is the
-	// tool's job.
-	cmd := exec.Command(sshBin, sshArgs...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	exitCode := 0
-	if runErr := cmd.Run(); runErr != nil {
-		var ee *exec.ExitError
-		if errors.As(runErr, &ee) {
-			exitCode = ee.ExitCode()
-		} else {
-			return "", fmt.Errorf("ssh: %w", runErr)
-		}
-	}
-
-	var b strings.Builder
-	fmt.Fprintf(&b, "exit_code: %d\n", exitCode)
-	if stdout.Len() > 0 {
-		fmt.Fprintf(&b, "\n--- stdout ---\n%s", stdout.String())
-	}
-	if stderr.Len() > 0 {
-		fmt.Fprintf(&b, "\n--- stderr ---\n%s", stderr.String())
-	}
-	return b.String(), nil
-}
-
-// runMCPSessionExec runs one command inside a named tmux session on the
-// box (Tier 2) and returns the framed output + exit code. Like
-// runMCPSSHExec, a non-zero remote exit is data, not a tool error.
-func runMCPSessionExec(target connectcore.Target, identity, session, command string) (string, error) {
-	marker, err := connectcore.NewMarker()
-	if err != nil {
-		return "", err
-	}
-	sshBin, err := exec.LookPath("ssh")
-	if err != nil {
-		return "", fmt.Errorf("ssh not found in PATH: %w", err)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
-	defer cancel()
-
-	args := connectcore.BuildSessionExecArgs(target, identity, session, marker, connectcore.EncodeCommand(command), 60)
-	// #nosec G204 -- sshBin is the resolved `ssh` binary; args are built from
-	// a validated box name + daemon-resolved target. Running ssh is the tool's
-	// job.
-	cmd := exec.CommandContext(ctx, sshBin, args...)
-	cmd.Stdin = strings.NewReader(connectcore.SessionExecScript())
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if runErr := cmd.Run(); runErr != nil {
-		var ee *exec.ExitError
-		if !errors.As(runErr, &ee) {
-			return "", fmt.Errorf("session exec: %w", runErr)
-		}
-		// Non-zero ssh exit still carries framed output we parse below.
-	}
-
-	out, code, perr := connectcore.ParseSessionResult(stdout.String(), marker)
-	if perr != nil {
-		if stderr.Len() > 0 {
-			return "", fmt.Errorf("%w (ssh: %s)", perr, strings.TrimSpace(stderr.String()))
-		}
-		return "", perr
-	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "session: %s\nexit_code: %d\n", session, code)
-	if out != "" {
-		fmt.Fprintf(&b, "\n--- output ---\n%s", out)
-	}
-	return b.String(), nil
+	// Exec mode: run the one-shot command in-process (pure-Go SSH, no system
+	// ssh binary) and return its output + exit code.
+	return runMCPSSHExec(target, privPath, execCmd)
 }
 
 // mcpGetContainer GETs the box over the MCP client's daemon connection and

--- a/internal/mcp/sshexec.go
+++ b/internal/mcp/sshexec.go
@@ -1,0 +1,222 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/connectcore"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// The in-box MCP `connect` tool runs INSIDE a box (e.g. the Alpine/musl
+// managed-workspace LXC), where there is no system `ssh` binary to shell
+// out to. So the exec/session paths use a pure-Go SSH client
+// (golang.org/x/crypto/ssh) — the same approach internal/runner uses to
+// provision boxes — making the mcp-server self-contained in any minimal
+// image. Config mode still hands the human a ready `ssh …` line to run in
+// their own terminal; only the non-interactive exec paths dial in-process.
+
+const (
+	mcpSSHDialTimeout = 15 * time.Second
+	mcpSSHExecTimeout = 90 * time.Second
+)
+
+// dialSSH opens a pure-Go SSH client to the target using the managed
+// private key at privPath. No system `ssh` binary required.
+func dialSSH(ctx context.Context, t connectcore.Target, privPath string) (*ssh.Client, error) {
+	keyBytes, err := os.ReadFile(privPath) // #nosec G304 -- privPath is the managed key sshkey.LocateOrGenerate resolved
+	if err != nil {
+		return nil, fmt.Errorf("read managed key %s: %w", privPath, err)
+	}
+	signer, err := ssh.ParsePrivateKey(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse managed key: %w", err)
+	}
+	hostKeyCB, err := tofuHostKeyCallback()
+	if err != nil {
+		return nil, err
+	}
+	cfg := &ssh.ClientConfig{
+		User:            t.User,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: hostKeyCB,
+		Timeout:         mcpSSHDialTimeout,
+	}
+	hostport := net.JoinHostPort(t.Host, strconv.Itoa(t.Port))
+	d := &net.Dialer{Timeout: mcpSSHDialTimeout}
+	conn, err := d.DialContext(ctx, "tcp", hostport)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", hostport, err)
+	}
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, hostport, cfg)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("ssh handshake %s: %w", hostport, err)
+	}
+	return ssh.NewClient(sshConn, chans, reqs), nil
+}
+
+// tofuHostKeyCallback returns an accept-new (trust-on-first-use) host-key
+// callback backed by ~/.ssh/known_hosts — the pure-Go equivalent of ssh's
+// StrictHostKeyChecking=accept-new the CLI uses: an unknown host is
+// recorded and trusted, but a CHANGED key for a known host is rejected
+// (MITM detection). This preserves the CLI's posture without shelling out.
+func tofuHostKeyCallback() (ssh.HostKeyCallback, error) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		home = os.TempDir() // minimal container with no HOME — still get in-file TOFU
+	}
+	khPath := filepath.Join(home, ".ssh", "known_hosts")
+	if err := os.MkdirAll(filepath.Dir(khPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create known_hosts dir: %w", err)
+	}
+	// knownhosts.New needs the file to exist; create it empty if absent.
+	f, err := os.OpenFile(khPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) // #nosec G304 -- fixed ~/.ssh/known_hosts path
+	if err != nil {
+		return nil, fmt.Errorf("open known_hosts: %w", err)
+	}
+	_ = f.Close()
+	known, err := knownhosts.New(khPath)
+	if err != nil {
+		return nil, fmt.Errorf("load known_hosts: %w", err)
+	}
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		verr := known(hostname, remote, key)
+		if verr == nil {
+			return nil
+		}
+		var keyErr *knownhosts.KeyError
+		if errors.As(verr, &keyErr) && len(keyErr.Want) == 0 {
+			// Unknown host → record it (accept-new), then trust.
+			return appendKnownHost(khPath, hostname, key)
+		}
+		// Known host whose key changed → reject (potential MITM).
+		return verr
+	}, nil
+}
+
+func appendKnownHost(path, hostname string, key ssh.PublicKey) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) // #nosec G304 -- fixed ~/.ssh/known_hosts path
+	if err != nil {
+		return fmt.Errorf("open known_hosts for append: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	line := knownhosts.Line([]string{knownhosts.Normalize(hostname)}, key)
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		return fmt.Errorf("record host key: %w", err)
+	}
+	return nil
+}
+
+// runMCPSSHExec runs one command over a pure-Go SSH session and returns its
+// stdout/stderr + exit code. A non-zero remote exit is NOT a tool error —
+// the command ran; the agent needs the output and the code. Only a failure
+// to connect or open the session is an error.
+func runMCPSSHExec(t connectcore.Target, privPath, execCmd string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), mcpSSHExecTimeout)
+	defer cancel()
+
+	client, err := dialSSH(ctx, t, privPath)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = client.Close() }()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return "", fmt.Errorf("ssh session: %w", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	var stdout, stderr bytes.Buffer
+	session.Stdout = &stdout
+	session.Stderr = &stderr
+
+	exitCode := 0
+	if runErr := session.Run(execCmd); runErr != nil {
+		var ee *ssh.ExitError
+		if errors.As(runErr, &ee) {
+			exitCode = ee.ExitStatus()
+		} else {
+			return "", fmt.Errorf("ssh run: %w", runErr)
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "exit_code: %d\n", exitCode)
+	if stdout.Len() > 0 {
+		fmt.Fprintf(&b, "\n--- stdout ---\n%s", stdout.String())
+	}
+	if stderr.Len() > 0 {
+		fmt.Fprintf(&b, "\n--- stderr ---\n%s", stderr.String())
+	}
+	return b.String(), nil
+}
+
+// runMCPSessionExec runs one command inside a named tmux session on the box
+// (Tier 2) over a pure-Go SSH session, piping the orchestration script on
+// stdin, and returns the framed output + exit code. Like runMCPSSHExec, a
+// non-zero remote exit is data, not a tool error.
+func runMCPSessionExec(target connectcore.Target, privPath, session, command string) (string, error) {
+	marker, err := connectcore.NewMarker()
+	if err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), mcpSSHExecTimeout)
+	defer cancel()
+
+	client, err := dialSSH(ctx, target, privPath)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = client.Close() }()
+
+	sess, err := client.NewSession()
+	if err != nil {
+		return "", fmt.Errorf("ssh session: %w", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	// The orchestration script reads positional args: $1 session $2 marker
+	// $3 base64-command $4 timeout. session is validated [A-Za-z0-9_-],
+	// marker is hex, the command is base64, timeout is an int — all safe as
+	// bare words, so no shell quoting is needed.
+	remote := "bash -s -- " + strings.Join([]string{
+		session, marker, connectcore.EncodeCommand(command), "60",
+	}, " ")
+
+	sess.Stdin = strings.NewReader(connectcore.SessionExecScript())
+	var stdout, stderr bytes.Buffer
+	sess.Stdout = &stdout
+	sess.Stderr = &stderr
+	if runErr := sess.Run(remote); runErr != nil {
+		var ee *ssh.ExitError
+		if !errors.As(runErr, &ee) {
+			return "", fmt.Errorf("session exec: %w", runErr)
+		}
+		// Non-zero ssh exit still carries framed output we parse below.
+	}
+
+	out, code, perr := connectcore.ParseSessionResult(stdout.String(), marker)
+	if perr != nil {
+		if stderr.Len() > 0 {
+			return "", fmt.Errorf("%w (ssh: %s)", perr, strings.TrimSpace(stderr.String()))
+		}
+		return "", perr
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "session: %s\nexit_code: %d\n", session, code)
+	if out != "" {
+		fmt.Fprintf(&b, "\n--- output ---\n%s", out)
+	}
+	return b.String(), nil
+}

--- a/internal/mcp/sshexec_test.go
+++ b/internal/mcp/sshexec_test.go
@@ -1,0 +1,71 @@
+package mcp
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// testSigner makes a throwaway host key to feed the callback.
+func testSigner(t *testing.T) ssh.PublicKey {
+	t.Helper()
+	_, privPEM, err := generateEphemeralSSHKey("hostkey")
+	if err != nil {
+		t.Fatalf("generateEphemeralSSHKey: %v", err)
+	}
+	signer, err := ssh.ParsePrivateKey(privPEM)
+	if err != nil {
+		t.Fatalf("ParsePrivateKey: %v", err)
+	}
+	return signer.PublicKey()
+}
+
+// TestTOFUHostKeyCallback verifies accept-new semantics: an unknown host is
+// recorded and trusted, the same key on a later connect still verifies, and
+// a CHANGED key for a known host is rejected (MITM detection).
+func TestTOFUHostKeyCallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	remote := &net.TCPAddr{IP: net.IPv4(192, 0, 2, 10), Port: 22}
+	const hostport = "192.0.2.10:22"
+	key1 := testSigner(t)
+
+	cb, err := tofuHostKeyCallback()
+	if err != nil {
+		t.Fatalf("tofuHostKeyCallback: %v", err)
+	}
+
+	// First contact with an unknown host → accept-new (recorded + trusted).
+	if err := cb(hostport, remote, key1); err != nil {
+		t.Fatalf("first contact should be accepted (accept-new), got: %v", err)
+	}
+
+	// known_hosts should now hold the entry.
+	kh := filepath.Join(home, ".ssh", "known_hosts")
+	data, err := os.ReadFile(kh)
+	if err != nil {
+		t.Fatalf("read known_hosts: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("known_hosts is empty after accept-new")
+	}
+
+	// A fresh callback (reloads known_hosts) must trust the same key.
+	cb2, err := tofuHostKeyCallback()
+	if err != nil {
+		t.Fatalf("tofuHostKeyCallback (reload): %v", err)
+	}
+	if err := cb2(hostport, remote, key1); err != nil {
+		t.Fatalf("known host with same key should verify, got: %v", err)
+	}
+
+	// A DIFFERENT key for the same host must be rejected (potential MITM).
+	key2 := testSigner(t)
+	if err := cb2(hostport, remote, key2); err == nil {
+		t.Fatal("changed host key should be rejected, but callback accepted it")
+	}
+}


### PR DESCRIPTION
## Problem

The in-box MCP `connect` tool ran ssh/session exec by shelling out to a system `ssh` binary (`exec.LookPath("ssh")`). When the mcp-server runs **inside** a box — e.g. the managed-workspace Alpine/musl LXC — there is no `ssh` binary, so every exec failed with:

```
Tool execution failed: ssh not found in PATH
```

This blocked the managed workspace chat from provisioning anything **inside** a box (install software, start a service), even though it could already create boxes and expose ports.

## Fix

Switch the two non-interactive exec paths (Tier-1 one-shot and Tier-2 tmux session) to a pure-Go SSH client (`golang.org/x/crypto/ssh`) — the same approach `internal/runner` already uses to provision boxes. The mcp-server is now self-contained: it dials the daemon-resolved target in-process with the managed key, needing no external binary, so `connect` exec works in any minimal image.

Host-key handling preserves the CLI's `StrictHostKeyChecking=accept-new` posture via a trust-on-first-use callback backed by `~/.ssh/known_hosts`: an unknown host is recorded and trusted; a **changed** key for a known host is rejected (MITM detection). `x/crypto` is already a direct dependency, so no new modules.

Config mode (handing a human a ready `ssh …` line) and the CLI verb (which legitimately shells out for PTY/interactive on the operator's machine) are unchanged.

## Test

- New `TestTOFUHostKeyCallback` covers accept-new + same-key-verify + changed-key-reject.
- `go build ./cmd/mcp-server`, `go test ./internal/mcp/ ./internal/connectcore/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)