### PR TITLE
fix(mcp): connect waits for a freshly-created box to come up (create→connect race)

### DIFF
--- a/internal/connectcore/connectcore.go
+++ b/internal/connectcore/connectcore.go
@@ -54,6 +54,22 @@ func IsRunning(state string) bool {
 	return state == "CONTAINER_STATE_RUNNING" || strings.EqualFold(state, "running")
 }
 
+// IsTransientState reports whether a box is in a short-lived bring-up state
+// (still being created/provisioned) that will reach RUNNING on its own. A
+// caller that just created a box and immediately wants to connect should
+// wait these out rather than failing — waiting succeeds, whereas "start it
+// first" is wrong (you can't start a box that's already coming up). protojson
+// emits the enum identifier; the friendly form is accepted defensively.
+func IsTransientState(state string) bool {
+	switch {
+	case state == "CONTAINER_STATE_CREATING", strings.EqualFold(state, "creating"):
+		return true
+	case state == "CONTAINER_STATE_PROVISIONING", strings.EqualFold(state, "provisioning"):
+		return true
+	}
+	return false
+}
+
 // PrettyState trims the proto enum prefix for human-facing messages.
 func PrettyState(state string) string {
 	s := strings.TrimPrefix(state, "CONTAINER_STATE_")

--- a/internal/mcp/connect.go
+++ b/internal/mcp/connect.go
@@ -5,9 +5,20 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/footprintai/containarium/internal/connectcore"
 	"github.com/footprintai/containarium/internal/sshkey"
+)
+
+// connectReadyTimeout bounds how long connect waits for a freshly-created box
+// to finish coming up, and connectPollInterval is the gap between re-checks.
+// An agent commonly creates a box then immediately connects, racing the
+// box's bring-up — waiting absorbs that race instead of erroring.
+// vars (not consts) so tests can shrink them.
+var (
+	connectReadyTimeout = 90 * time.Second
+	connectPollInterval = 3 * time.Second
 )
 
 // handleConnect is the agent-native half of `containarium connect` — the
@@ -33,14 +44,7 @@ func handleConnect(client API, args map[string]interface{}) (string, error) {
 	userOverride := getStringArg(args, "user", "")
 	hostOverride := getStringArg(args, "host", "")
 
-	c, err := mcpGetContainer(client, box)
-	if err != nil {
-		return "", err
-	}
-	if !connectcore.IsRunning(c.State) {
-		return "", fmt.Errorf("box %q is %s, not running — start it first", box, connectcore.PrettyState(c.State))
-	}
-	target, err := connectcore.BuildTarget(c, userOverride, hostOverride, 22)
+	target, err := mcpWaitConnectable(client, box, userOverride, hostOverride)
 	if err != nil {
 		return "", err
 	}
@@ -85,6 +89,45 @@ func handleConnect(client API, args map[string]interface{}) (string, error) {
 	// Exec mode: run the one-shot command in-process (pure-Go SSH, no system
 	// ssh binary) and return its output + exit code.
 	return runMCPSSHExec(target, privPath, execCmd)
+}
+
+// mcpWaitConnectable resolves a box to an SSH target, waiting out the
+// create→running race: an agent often creates a box then immediately calls
+// connect, so the box is still CREATING/PROVISIONING (or RUNNING but without
+// an IP yet). Rather than failing with the misleading "start it first" — you
+// cannot start a box that is already coming up — it polls until the box is
+// RUNNING with a usable target, or the deadline passes. A genuinely stopped
+// box returns the start-it-first guidance immediately, since waiting on it
+// would never succeed.
+func mcpWaitConnectable(client API, box, userOverride, hostOverride string) (connectcore.Target, error) {
+	deadline := time.Now().Add(connectReadyTimeout)
+	for {
+		c, err := mcpGetContainer(client, box)
+		if err != nil {
+			return connectcore.Target{}, err
+		}
+		switch {
+		case connectcore.IsRunning(c.State):
+			target, terr := connectcore.BuildTarget(c, userOverride, hostOverride, 22)
+			if terr == nil {
+				return target, nil
+			}
+			// Running but no IP/host assigned yet — keep waiting briefly.
+			if time.Now().After(deadline) {
+				return connectcore.Target{}, terr
+			}
+		case connectcore.IsTransientState(c.State):
+			if time.Now().After(deadline) {
+				return connectcore.Target{}, fmt.Errorf(
+					"box %q is still %s after %s — it may need longer to come up; try again shortly",
+					box, connectcore.PrettyState(c.State), connectReadyTimeout)
+			}
+		default:
+			// stopped / frozen / error — waiting would not help.
+			return connectcore.Target{}, fmt.Errorf("box %q is %s, not running — start it first", box, connectcore.PrettyState(c.State))
+		}
+		time.Sleep(connectPollInterval)
+	}
 }
 
 // mcpGetContainer GETs the box over the MCP client's daemon connection and

--- a/internal/mcp/connect_test.go
+++ b/internal/mcp/connect_test.go
@@ -1,0 +1,117 @@
+package mcp
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stateServer serves GET /v1/containers/<box> returning a sequence of
+// states (the last one repeats once exhausted), so a test can model a box
+// transitioning CREATING → RUNNING across polls.
+func stateServer(t *testing.T, states []string, ip string) (*httptest.Server, *int32) {
+	t.Helper()
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/v1/containers/") {
+			http.NotFound(w, r)
+			return
+		}
+		n := atomic.AddInt32(&calls, 1)
+		idx := int(n) - 1
+		if idx >= len(states) {
+			idx = len(states) - 1
+		}
+		state := states[idx]
+		ipField := ip
+		if state != "CONTAINER_STATE_RUNNING" {
+			ipField = "" // not assigned until running
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"container":{"username":"tester","state":%q,"sshHost":"","network":{"ipAddress":%q}}}`, state, ipField)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func TestMCPWaitConnectable_RunningImmediately(t *testing.T) {
+	srv, calls := stateServer(t, []string{"CONTAINER_STATE_RUNNING"}, "10.0.0.9")
+	c := NewClient(srv.URL, "t")
+
+	target, err := mcpWaitConnectable(c, "box", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if target.Host != "10.0.0.9" || target.User != "tester" {
+		t.Errorf("bad target: %+v", target)
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Errorf("expected 1 poll, got %d", got)
+	}
+}
+
+func TestMCPWaitConnectable_WaitsThroughCreating(t *testing.T) {
+	old := connectPollInterval
+	connectPollInterval = 5 * time.Millisecond
+	t.Cleanup(func() { connectPollInterval = old })
+
+	srv, calls := stateServer(t, []string{
+		"CONTAINER_STATE_CREATING",
+		"CONTAINER_STATE_PROVISIONING",
+		"CONTAINER_STATE_RUNNING",
+	}, "10.0.0.5")
+	c := NewClient(srv.URL, "t")
+
+	target, err := mcpWaitConnectable(c, "box", "", "")
+	if err != nil {
+		t.Fatalf("should have waited for running, got: %v", err)
+	}
+	if target.Host != "10.0.0.5" {
+		t.Errorf("bad target host: %q", target.Host)
+	}
+	if got := atomic.LoadInt32(calls); got < 3 {
+		t.Errorf("expected at least 3 polls (creating→provisioning→running), got %d", got)
+	}
+}
+
+func TestMCPWaitConnectable_StoppedFailsFast(t *testing.T) {
+	old := connectPollInterval
+	connectPollInterval = 5 * time.Millisecond
+	t.Cleanup(func() { connectPollInterval = old })
+
+	srv, calls := stateServer(t, []string{"CONTAINER_STATE_STOPPED"}, "")
+	c := NewClient(srv.URL, "t")
+
+	_, err := mcpWaitConnectable(c, "box", "", "")
+	if err == nil {
+		t.Fatal("expected an error for a stopped box")
+	}
+	if !strings.Contains(err.Error(), "start it first") {
+		t.Errorf("stopped box should advise starting; got: %v", err)
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Errorf("stopped box should fail on the first poll, got %d polls", got)
+	}
+}
+
+func TestMCPWaitConnectable_TransientTimesOut(t *testing.T) {
+	oldI, oldT := connectPollInterval, connectReadyTimeout
+	connectPollInterval = 5 * time.Millisecond
+	connectReadyTimeout = 25 * time.Millisecond
+	t.Cleanup(func() { connectPollInterval, connectReadyTimeout = oldI, oldT })
+
+	srv, _ := stateServer(t, []string{"CONTAINER_STATE_CREATING"}, "")
+	c := NewClient(srv.URL, "t")
+
+	_, err := mcpWaitConnectable(c, "box", "", "")
+	if err == nil {
+		t.Fatal("expected a timeout error for a box stuck creating")
+	}
+	if !strings.Contains(err.Error(), "still creating") {
+		t.Errorf("timeout should mention it's still creating; got: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem (caught live in the workspace chat)

The workspace chat now drives **create box → connect → run command** end-to-end (the pure-Go `connect` fix from #827 is live). But an agent that creates a box and immediately connects races the box's bring-up:

```
MCP error -32603: box "my-helloworld-app" is creating, not running — start it first
```

The box was fine — just still `CREATING`. And "start it first" is wrong for a transient box: you can't start one that's already coming up; you wait.

## Fix

`connect` now polls the box until it's `RUNNING` with a usable SSH target (up to 90s, every 3s), absorbing the create→ready race so *"create a box, then run a command in it"* works in one shot. Behavior by state:

- **RUNNING (with IP)** → proceed immediately.
- **CREATING / PROVISIONING** → wait, re-check; on deadline, return a clear *"still creating — try again shortly"*.
- **RUNNING but no IP yet** → wait briefly (covers the same race `expose_port` hit).
- **STOPPED / FROZEN / ERROR** → return the start-it-first guidance immediately (waiting won't help).

Adds `connectcore.IsTransientState` (shared predicate) + httptest-backed tests: running-immediately, wait-through-creating, stopped-fails-fast, transient-times-out.

`go test ./internal/mcp/ ./internal/connectcore/` green; gofmt -s clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)