### PR TITLE
fix(security,ttlsweeper): stop scanner-leak → dataset-busy → infinite ttlsweeper loop (#831, #832)

### DIFF
--- a/internal/security/scanner.go
+++ b/internal/security/scanner.go
@@ -54,6 +54,15 @@ func NewScanner(incusClient *incus.Client, store *Store) *Scanner {
 func (s *Scanner) Start(ctx context.Context) {
 	ctx, s.cancel = context.WithCancel(ctx)
 
+	// Reconcile away any scan-<box> devices leaked by a scan that a prior
+	// daemon restart interrupted (#832): ScanContainer removes its mount in a
+	// defer, which a kill/restart mid-scan skips. A leaked device's mount pins
+	// the target's storage volume (later delete → "dataset is busy" → the TTL
+	// sweeper loops forever), and a leaked device whose source was since
+	// deleted blocks the security container from starting. No scan survives a
+	// restart, so all such devices are stale.
+	s.reconcileStaleScanDevices(ctx)
+
 	// Start worker pool
 	s.startWorkers(ctx, maxConcurrentScans)
 
@@ -82,6 +91,46 @@ func (s *Scanner) Stop() {
 		s.cancel()
 	}
 	log.Printf("Security scanner stopped")
+}
+
+// scanDevicePrefix tags the disk devices ScanContainer attaches to the
+// security container ("scan-<box>"). Reconciliation keys off it.
+const scanDevicePrefix = "scan-"
+
+// reconcileStaleScanDevices removes every scan-<box> disk device left on the
+// security container — they only ever exist mid-scan, so any present at
+// startup leaked from a scan a prior daemon interrupted (#832). Best-effort:
+// a missing security container (fresh host) or a per-device failure is logged,
+// never fatal to startup.
+func (s *Scanner) reconcileStaleScanDevices(ctx context.Context) {
+	out, err := exec.CommandContext(ctx, "incus", "config", "device", "list",
+		SecurityContainerName).CombinedOutput()
+	if err != nil {
+		// Fresh host: the security container may not exist yet — not an error.
+		log.Printf("Security scan: skip stale scan-device reconcile (%s): %v",
+			SecurityContainerName, err)
+		return
+	}
+	removed := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		name := strings.TrimSpace(line)
+		if !strings.HasPrefix(name, scanDevicePrefix) {
+			continue
+		}
+		// #nosec G204 -- name is a device listed by incus on our own security
+		// container; removing a scan-* device is exactly this function's job.
+		if rmOut, rmErr := exec.CommandContext(ctx, "incus", "config", "device", "remove",
+			SecurityContainerName, name).CombinedOutput(); rmErr != nil {
+			log.Printf("Security scan: failed to remove stale scan device %s: %v (%s)",
+				name, rmErr, strings.TrimSpace(string(rmOut)))
+			continue
+		}
+		removed++
+	}
+	if removed > 0 {
+		log.Printf("Security scan: reconciled %d stale scan device(s) from %s",
+			removed, SecurityContainerName)
+	}
 }
 
 // runScanCycle enqueues scan jobs for all running user containers
@@ -215,7 +264,7 @@ func (s *Scanner) worker(ctx context.Context, id int) {
 // ScanContainer scans a single container's filesystem via disk device mount.
 // Each container gets a unique mount path so multiple scans can run concurrently.
 func (s *Scanner) ScanContainer(ctx context.Context, containerName, username string) error {
-	deviceName := fmt.Sprintf("scan-%s", strings.ReplaceAll(containerName, "/", "-"))
+	deviceName := scanDevicePrefix + strings.ReplaceAll(containerName, "/", "-")
 	mountPath := fmt.Sprintf("/mnt/scan-%s", strings.ReplaceAll(containerName, "/", "-"))
 	rootfsPath := fmt.Sprintf("/var/lib/incus/storage-pools/%s/containers/%s/rootfs", s.storagePool, containerName)
 

--- a/internal/ttlsweeper/manager.go
+++ b/internal/ttlsweeper/manager.go
@@ -13,6 +13,36 @@ import (
 // owns dozens of containers, not thousands.
 const DefaultInterval = 60 * time.Second
 
+const (
+	// failBackoffBase is the wait after a container's first failed delete; it
+	// doubles each consecutive failure up to failBackoffMax. A delete can fail
+	// permanently (e.g. a leaked scan mount pinning the ZFS dataset →
+	// "dataset is busy", #832) and Decide keeps returning the still-expired
+	// box every tick — without backoff the sweeper retries every 60s forever,
+	// flooding the journal and never progressing (#831). Backoff turns that
+	// into 1m, 2m, 4m, … so one wedged box is near-silent and can't starve the
+	// loop.
+	failBackoffBase = 1 * time.Minute
+	failBackoffMax  = 1 * time.Hour
+	// quarantineAfter is the consecutive-failure count past which the sweeper
+	// parks the box at failBackoffMax and logs ONCE at WARN — a permanently
+	// stuck delete becomes a single actionable line instead of an infinite
+	// loop. It still retries hourly in case the blocker clears on its own.
+	quarantineAfter = 10
+	// maxBackoffShift caps the exponent so failBackoffBase << shift can't
+	// overflow on a long-lived stuck entry (the result is clamped to
+	// failBackoffMax regardless).
+	maxBackoffShift = 16
+)
+
+// failState tracks one container's consecutive delete failures so the sweeper
+// can back off instead of hammering an undeletable box every tick (#831).
+type failState struct {
+	count       int
+	nextAttempt time.Time
+	quarantined bool
+}
+
 // IncusClient is the narrow slice of the daemon's container source
 // the sweeper actually needs. The wiring PR adapts the real
 // *incus.Client (or whatever persists TTL — Incus user.* config,
@@ -52,6 +82,11 @@ type Manager struct {
 	stopCh   chan struct{}
 	done     chan struct{}
 	stopOnce sync.Once
+
+	// failures tracks per-container consecutive delete failures for backoff
+	// (#831). Only ever touched from the single run goroutine's tick, so it
+	// needs no lock.
+	failures map[string]*failState
 }
 
 // Options bundles the optional knobs. Production callers should pass
@@ -86,6 +121,7 @@ func NewManager(inc IncusClient, deleter Deleter, opts Options) *Manager {
 		clock:    opts.Clock,
 		stopCh:   make(chan struct{}),
 		done:     make(chan struct{}),
+		failures: make(map[string]*failState),
 	}
 }
 
@@ -138,6 +174,13 @@ func (m *Manager) tick(ctx context.Context) {
 	}
 	now := m.clock()
 	expired := Decide(containers, now)
+
+	// Prune failure entries for boxes no longer expired (deleted elsewhere,
+	// woken, protected) so the map can't grow unbounded and a recreated box
+	// reusing the name starts with a clean slate. Done before the empty-expired
+	// early return so a box that vanishes entirely is still cleaned up.
+	m.pruneFailures(expired)
+
 	if len(expired) == 0 {
 		return
 	}
@@ -153,14 +196,71 @@ func (m *Manager) tick(ctx context.Context) {
 	}
 
 	for _, name := range expired {
+		// Honor backoff: a box whose delete keeps failing is retried on an
+		// exponential schedule, not every tick (#831).
+		if fs := m.failures[name]; fs != nil && now.Before(fs.nextAttempt) {
+			continue
+		}
 		reason := "ttl_expired"
 		if exp, ok := expiryByName[name]; ok {
 			reason = "ttl_expired at " + exp.UTC().Format(time.RFC3339)
 		}
 		if err := m.deleter.DeleteContainer(ctx, name, reason); err != nil {
-			log.Printf("[ttlsweeper] delete %s: %v", name, err)
+			m.recordFailure(name, err, now)
 			continue
 		}
+		delete(m.failures, name)
 		log.Printf("[ttlsweeper] deleted name=%s reason=%q", name, reason)
 	}
+}
+
+// pruneFailures drops failure records for any container not in the current
+// expired set — it was deleted elsewhere, woken, or protected, so its backoff
+// state is stale. Keeps the map bounded and lets a recreated box reusing the
+// name start clean.
+func (m *Manager) pruneFailures(expired []string) {
+	if len(m.failures) == 0 {
+		return
+	}
+	stillExpired := make(map[string]struct{}, len(expired))
+	for _, name := range expired {
+		stillExpired[name] = struct{}{}
+	}
+	for name := range m.failures {
+		if _, ok := stillExpired[name]; !ok {
+			delete(m.failures, name)
+		}
+	}
+}
+
+// recordFailure bumps a container's consecutive-failure count and schedules
+// the next attempt with exponential backoff, quarantining (parking at
+// failBackoffMax + a single WARN) once it crosses quarantineAfter (#831).
+func (m *Manager) recordFailure(name string, err error, now time.Time) {
+	fs := m.failures[name]
+	if fs == nil {
+		fs = &failState{}
+		m.failures[name] = fs
+	}
+	fs.count++
+
+	shift := fs.count - 1
+	if shift > maxBackoffShift {
+		shift = maxBackoffShift
+	}
+	backoff := failBackoffBase << uint(shift)
+	if backoff > failBackoffMax {
+		backoff = failBackoffMax
+	}
+	fs.nextAttempt = now.Add(backoff)
+
+	if fs.count >= quarantineAfter {
+		if !fs.quarantined {
+			fs.quarantined = true
+			log.Printf("[ttlsweeper] delete %s: %v — failed %d times, quarantining (retry every %s); manual cleanup likely needed",
+				name, err, fs.count, failBackoffMax)
+		}
+		return // already logged the once; stay quiet at the hourly cadence
+	}
+	log.Printf("[ttlsweeper] delete %s: %v (attempt %d, retry in %s)", name, err, fs.count, backoff)
 }

--- a/internal/ttlsweeper/manager_test.go
+++ b/internal/ttlsweeper/manager_test.go
@@ -339,3 +339,92 @@ func (f *fakeIncusCounting) ListContainers() ([]ContainerView, error) {
 	atomic.AddInt64(f.count, 1)
 	return nil, nil
 }
+
+// alwaysFailErrs returns a slice long enough that fakeDeleter fails every call
+// across a test (its errs are indexed per-call; a short slice falls back to nil).
+func alwaysFailErrs(n int) []error {
+	errs := make([]error, n)
+	for i := range errs {
+		errs[i] = errors.New("dataset is busy")
+	}
+	return errs
+}
+
+// TestManager_BackoffOnRepeatedFailure: a container whose delete keeps failing
+// is retried on an exponential schedule, not every tick (#831).
+func TestManager_BackoffOnRepeatedFailure(t *testing.T) {
+	cur := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	expiredAt := cur.Add(-time.Hour)
+	inc := &fakeIncus{containers: []ContainerView{{Name: "stuck-container", TTLExpiresAt: &expiredAt}}}
+	del := &fakeDeleter{errs: alwaysFailErrs(64)}
+	m := NewManager(inc, del, Options{Interval: time.Hour, Clock: func() time.Time { return cur }})
+
+	// First tick → one (failed) attempt; backoff is failBackoffBase (1m).
+	m.tick(context.Background())
+	if got := len(del.recorded()); got != 1 {
+		t.Fatalf("tick1 attempts=%d, want 1", got)
+	}
+
+	// Ticks within the backoff window must NOT retry.
+	for k := 0; k < 5; k++ {
+		cur = cur.Add(10 * time.Second)
+		m.tick(context.Background())
+	}
+	if got := len(del.recorded()); got != 1 {
+		t.Fatalf("attempts during backoff=%d, want 1 (no retry until backoff elapses)", got)
+	}
+
+	// Once the backoff elapses, the next tick retries.
+	cur = cur.Add(failBackoffBase)
+	m.tick(context.Background())
+	if got := len(del.recorded()); got != 2 {
+		t.Fatalf("attempts after backoff elapsed=%d, want 2", got)
+	}
+}
+
+// TestManager_QuarantineAfterThreshold: past quarantineAfter consecutive
+// failures the box is quarantined (parked, logged once) (#831).
+func TestManager_QuarantineAfterThreshold(t *testing.T) {
+	cur := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	expiredAt := cur.Add(-time.Hour)
+	inc := &fakeIncus{containers: []ContainerView{{Name: "stuck-container", TTLExpiresAt: &expiredAt}}}
+	del := &fakeDeleter{errs: alwaysFailErrs(64)}
+	m := NewManager(inc, del, Options{Interval: time.Hour, Clock: func() time.Time { return cur }})
+
+	// Advance well past each (capped) backoff so every tick actually retries.
+	for k := 0; k < quarantineAfter; k++ {
+		m.tick(context.Background())
+		cur = cur.Add(2 * failBackoffMax)
+	}
+	fs := m.failures["stuck-container"]
+	if fs == nil {
+		t.Fatal("expected a failure record for the stuck container")
+	}
+	if fs.count < quarantineAfter || !fs.quarantined {
+		t.Fatalf("expected quarantine after %d failures, got count=%d quarantined=%v",
+			quarantineAfter, fs.count, fs.quarantined)
+	}
+}
+
+// TestManager_FailureEntryPrunedWhenGone: once a previously-failing box is no
+// longer expired (deleted elsewhere / woken / protected), its failure entry is
+// pruned so the map can't grow unbounded.
+func TestManager_FailureEntryPrunedWhenGone(t *testing.T) {
+	cur := time.Date(2026, 5, 23, 12, 0, 0, 0, time.UTC)
+	expiredAt := cur.Add(-time.Hour)
+	inc := &fakeIncus{containers: []ContainerView{{Name: "stuck-container", TTLExpiresAt: &expiredAt}}}
+	del := &fakeDeleter{errs: alwaysFailErrs(8)}
+	m := NewManager(inc, del, Options{Interval: time.Hour, Clock: func() time.Time { return cur }})
+
+	m.tick(context.Background())
+	if m.failures["stuck-container"] == nil {
+		t.Fatal("expected a failure record after the failed delete")
+	}
+
+	// The box is gone from the listing now → its failure entry must be pruned.
+	inc.containers = nil
+	m.tick(context.Background())
+	if len(m.failures) != 0 {
+		t.Fatalf("expected failure map pruned to empty, got %d entries", len(m.failures))
+	}
+}


### PR DESCRIPTION
One incident, cause + symptom, fixed together. Both were root-caused and **remediated live** on a backend before this PR (scanner LXC cleaned of 13 leaked devices, the wedged container deleted, the loop confirmed stopped).

## Cause — #832 (`internal/security/scanner.go`)

`ScanContainer` attaches a `scan-<box>` read-only disk device to the `containarium-core-security` LXC to mount a target's rootfs for `clamdscan`, then removes it in a `defer`. A daemon kill/restart **mid-scan** — e.g. every workhorse roll — skips the defer, leaking the device **and** its bind mount. Consequences:

- the leaked mount pins the target's ZFS dataset → a later delete fails `dataset is busy`;
- a leaked device whose `source=` rootfs was since deleted → the security LXC fails start validation (`Missing source path`);
- no startup reconciliation → they accumulate (**13** found on the live host).

**Fix:** `reconcileStaleScanDevices()` runs on scanner `Start` and removes every `scan-*` device — none legitimately survives a restart.

## Symptom — #831 (`internal/ttlsweeper`)

`Decide` returns the still-expired box every tick, so a permanently-failing delete (the `dataset is busy` above) was retried **every 60s forever** — flooding the journal, never progressing.

**Fix:** per-container exponential backoff (`1m → 1h` cap) + **quarantine** after 10 consecutive failures (parks at the cap, logs once as actionable WARN) + pruning of failure records once a box is no longer expired (bounded map; recreated names start clean). One wedged box is now near-silent instead of an infinite loop.

## Tests

`go test ./internal/ttlsweeper/ ./internal/security/` green. New ttlsweeper cases: backoff-respected, quarantine-after-threshold, failure-entry-pruned. Daemon builds; gofmt -s clean. (The scanner reconcile drives the `incus` CLI, exercised live like the rest of that file.)

Fixes #831. Fixes #832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)