### PR TITLE
fix(mcp): connect retries the SSH dial through the keysync-propagation race (#830)

### DIFF
--- a/internal/mcp/sshexec.go
+++ b/internal/mcp/sshexec.go
@@ -25,10 +25,7 @@ import (
 // image. Config mode still hands the human a ready `ssh …` line to run in
 // their own terminal; only the non-interactive exec paths dial in-process.
 
-const (
-	mcpSSHDialTimeout = 15 * time.Second
-	mcpSSHExecTimeout = 90 * time.Second
-)
+const mcpSSHDialTimeout = 15 * time.Second
 
 // dialSSH opens a pure-Go SSH client to the target using the managed
 // private key at privPath. No system `ssh` binary required.
@@ -117,15 +114,55 @@ func appendKnownHost(path, hostname string, key ssh.PublicKey) error {
 	return nil
 }
 
+// authRetryWindow / authRetryInterval bound how long the exec path retries the
+// SSH dial when the handshake fails to AUTHENTICATE. handleConnect authorizes
+// the managed key immediately before dialing, but that key lands in the host
+// authorized_keys instantly while the sentinel keysync only mirrors it into
+// sshpiper on its next tick (~2m). So a first connect to a freshly-authorized
+// box can race that sync and get publickey-denied (#830). Retrying absorbs the
+// propagation lag; non-auth failures (dial/connection/host-key) still fail
+// fast. vars (not consts) so tests can shrink them.
+var (
+	authRetryWindow   = 120 * time.Second
+	authRetryInterval = 8 * time.Second
+)
+
+// dialSSHWithAuthRetry dials the box, retrying ONLY on an authentication
+// failure (the keysync-propagation race, #830) until authRetryWindow elapses.
+func dialSSHWithAuthRetry(t connectcore.Target, privPath string) (*ssh.Client, error) {
+	deadline := time.Now().Add(authRetryWindow)
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), mcpSSHDialTimeout+5*time.Second)
+		client, err := dialSSH(ctx, t, privPath)
+		cancel()
+		if err == nil {
+			return client, nil
+		}
+		if !isSSHAuthError(err) || !time.Now().Before(deadline) {
+			return nil, err
+		}
+		time.Sleep(authRetryInterval)
+	}
+}
+
+// isSSHAuthError reports whether an SSH dial failed because the server rejected
+// our key (vs. a connection/host-key/other error). x/crypto surfaces this as a
+// "handshake failed: ssh: unable to authenticate …" error.
+func isSSHAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "unable to authenticate") ||
+		strings.Contains(s, "no supported methods remain")
+}
+
 // runMCPSSHExec runs one command over a pure-Go SSH session and returns its
 // stdout/stderr + exit code. A non-zero remote exit is NOT a tool error —
 // the command ran; the agent needs the output and the code. Only a failure
 // to connect or open the session is an error.
 func runMCPSSHExec(t connectcore.Target, privPath, execCmd string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), mcpSSHExecTimeout)
-	defer cancel()
-
-	client, err := dialSSH(ctx, t, privPath)
+	client, err := dialSSHWithAuthRetry(t, privPath)
 	if err != nil {
 		return "", err
 	}
@@ -171,10 +208,8 @@ func runMCPSessionExec(target connectcore.Target, privPath, session, command str
 	if err != nil {
 		return "", err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), mcpSSHExecTimeout)
-	defer cancel()
 
-	client, err := dialSSH(ctx, target, privPath)
+	client, err := dialSSHWithAuthRetry(target, privPath)
 	if err != nil {
 		return "", err
 	}

--- a/internal/mcp/sshexec_test.go
+++ b/internal/mcp/sshexec_test.go
@@ -8,7 +8,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/footprintai/containarium/internal/connectcore"
 	"golang.org/x/crypto/ssh"
@@ -87,6 +89,11 @@ type fakeSSHServer struct {
 	stderr   string
 	exitCode uint32
 	wg       sync.WaitGroup
+	// rejectFirstN rejects that many otherwise-valid auth attempts before
+	// accepting, to simulate the keysync-propagation race (#830). 0 = accept
+	// immediately. authAttempts counts valid-key auth attempts seen.
+	rejectFirstN int32
+	authAttempts int32
 }
 
 func newFakeSSHServer(t *testing.T, authKey ssh.PublicKey, stdout, stderr string, exitCode uint32) *fakeSSHServer {
@@ -105,7 +112,7 @@ func newFakeSSHServer(t *testing.T, authKey ssh.PublicKey, stdout, stderr string
 	}
 	s := &fakeSSHServer{ln: ln, hostKey: hostSigner, authKey: authKey, stdout: stdout, stderr: stderr, exitCode: exitCode}
 	s.wg.Add(1)
-	go s.serveOne(t)
+	go s.serve()
 	return s
 }
 
@@ -116,27 +123,38 @@ func (s *fakeSSHServer) close() {
 	s.wg.Wait()
 }
 
-func (s *fakeSSHServer) serveOne(t *testing.T) {
+func (s *fakeSSHServer) serve() {
 	defer s.wg.Done()
 	cfg := &ssh.ServerConfig{
 		PublicKeyCallback: func(_ ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
-			if string(key.Marshal()) == string(s.authKey.Marshal()) {
-				return &ssh.Permissions{}, nil
+			if string(key.Marshal()) != string(s.authKey.Marshal()) {
+				return nil, errUnauthorizedKey
 			}
-			return nil, errUnauthorizedKey
+			// Reject the first rejectFirstN otherwise-valid auths to simulate
+			// the keysync-propagation race (#830): the key isn't live yet,
+			// then becomes valid on a later attempt.
+			if atomic.AddInt32(&s.authAttempts, 1) <= atomic.LoadInt32(&s.rejectFirstN) {
+				return nil, errUnauthorizedKey
+			}
+			return &ssh.Permissions{}, nil
 		},
 	}
 	cfg.AddHostKey(s.hostKey)
-
-	conn, err := s.ln.Accept()
-	if err != nil {
-		return // listener closed
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		s.handleConn(conn, cfg)
 	}
+}
+
+func (s *fakeSSHServer) handleConn(conn net.Conn, cfg *ssh.ServerConfig) {
 	defer func() { _ = conn.Close() }()
 
 	sconn, chans, reqs, err := ssh.NewServerConn(conn, cfg)
 	if err != nil {
-		return
+		return // auth failed (expected during the reject window)
 	}
 	defer func() { _ = sconn.Close() }()
 	go ssh.DiscardRequests(reqs)
@@ -260,5 +278,65 @@ func TestRunMCPSSHExec_NonZeroExit(t *testing.T) {
 	}
 	if !strings.Contains(out, "exit_code: 7") {
 		t.Errorf("expected exit_code 7 in:\n%s", out)
+	}
+}
+
+// TestRunMCPSSHExec_RetriesThroughAuthRace proves the exec path retries the
+// dial when the key isn't live yet (the keysync-propagation race, #830): the
+// server rejects the first two otherwise-valid auths, then accepts, and
+// runMCPSSHExec still succeeds.
+func TestRunMCPSSHExec_RetriesThroughAuthRace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Shrink the retry knobs so the test is fast.
+	oldW, oldI := authRetryWindow, authRetryInterval
+	authRetryWindow = 5 * time.Second
+	authRetryInterval = 50 * time.Millisecond
+	t.Cleanup(func() { authRetryWindow, authRetryInterval = oldW, oldI })
+
+	privPath, pub := writeManagedKey(t)
+	srv := newFakeSSHServer(t, pub, "CONNECT_OK\n", "", 0)
+	srv.rejectFirstN = 2 // first two auths denied (key not propagated yet)
+	defer srv.close()
+
+	host, portStr, _ := net.SplitHostPort(srv.addr())
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+	target := connectcore.Target{User: "tester", Host: host, Port: port}
+
+	out, err := runMCPSSHExec(target, privPath, "echo hi")
+	if err != nil {
+		t.Fatalf("expected retry to succeed past the auth race, got: %v", err)
+	}
+	if !strings.Contains(out, "CONNECT_OK") {
+		t.Errorf("stdout not surfaced after retry:\n%s", out)
+	}
+	if got := atomic.LoadInt32(&srv.authAttempts); got < 3 {
+		t.Errorf("expected ≥3 auth attempts (2 rejected + 1 accepted), got %d", got)
+	}
+}
+
+// TestRunMCPSSHExec_NonAuthErrorFailsFast confirms a non-auth dial failure
+// (nothing listening) is NOT retried for the whole window.
+func TestRunMCPSSHExec_NonAuthErrorFailsFast(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	oldW, oldI := authRetryWindow, authRetryInterval
+	authRetryWindow = 10 * time.Second
+	authRetryInterval = 50 * time.Millisecond
+	t.Cleanup(func() { authRetryWindow, authRetryInterval = oldW, oldI })
+
+	privPath, _ := writeManagedKey(t)
+	// 127.0.0.1:1 — nothing listening → connection refused (not an auth error).
+	target := connectcore.Target{User: "tester", Host: "127.0.0.1", Port: 1}
+
+	start := time.Now()
+	_, err := runMCPSSHExec(target, privPath, "echo hi")
+	if err == nil {
+		t.Fatal("expected a dial error")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Errorf("non-auth error should fail fast, took %s (retried the whole window?)", elapsed)
 	}
 }


### PR DESCRIPTION
## Root cause (re-diagnosed live)

#830 was filed as "librechat boxes reject platform-connect (plain boxes OK)". Tracing the full SSH path on the live host disproved that framing:

- the librechat box's **host-side** `authorized_keys` has the managed key (identical to a plain box);
- it is **not** dropped by the `/authorized-keys` orphan filter (the container is live);
- the **sentinel sshpiper** config for it is identical to a plain box (same key, valid route);
- and **connect to it succeeds now**.

The real cause is **keysync propagation latency**: `connect` writes the key to the host `authorized_keys` instantly, but the sentinel keysync only mirrors it into sshpiper on its next ~2-minute tick (the `AddSSHKey` response literally says "propagate within ~2m"). A **first** connect to a freshly-key-authorized box races that sync and gets `publickey`-denied. The librechat boxes just happened to be the freshly-authorized ones; the "working" plain boxes had been connected to earlier, so their key was already synced. Not librechat-specific.

## Fix

Same shape as #829's wait-for-ready: the exec/session paths retry the dial on an **authentication** failure for a bounded window (~the keysync interval) instead of failing on the first `publickey`. `handleConnect` authorizes the key immediately before dialing, so an immediate auth failure is almost always propagation lag. Non-auth failures (connection refused, host-key mismatch, …) still fail fast.

## Tests

`go test ./internal/mcp/` green. New: `RetriesThroughAuthRace` (server rejects the first N otherwise-valid auths, then accepts → exec still succeeds) and `NonAuthErrorFailsFast` (connection-refused isn't retried for the whole window).

## Related (not fixed here)

While tracing this I found **683 orphaned `/home/<user>` dirs** on the backend and **1296 `/etc/sshpiper/users/` dirs** on the sentinel — `userdel`-on-delete is failing and keysync never prunes deleted users, so keysync walks/writes all of them every ~2 min, which will worsen this very race over time. Worth a follow-up (reliable userdel-on-delete + keysync pruning).

Fixes #830.

🤖 Generated with [Claude Code](https://claude.com/claude-code)