### PR TITLE
fix(expose): wait for a freshly-created box to get its IP (create→expose race)

### DIFF
--- a/pkg/core/expose/expose.go
+++ b/pkg/core/expose/expose.go
@@ -13,6 +13,18 @@ package expose
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+)
+
+// exposeReadyTimeout / exposePollInterval bound how long Run waits for a
+// freshly-created box to get its IP before failing. An agent commonly creates
+// a box and immediately exposes a port, racing the box's bring-up — it has no
+// IP until it's RUNNING. Waiting absorbs that race instead of erroring (the
+// same create→ready fix connect got). vars (not consts) so tests can shrink.
+var (
+	exposeReadyTimeout = 90 * time.Second
+	exposePollInterval = 3 * time.Second
 )
 
 // APIClient is the minimal transport surface this package needs. The
@@ -82,12 +94,9 @@ func Run(ctx context.Context, c APIClient, opts Options) (*RouteResult, error) {
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}
-	name, ip, state, err := c.LookupContainer(ctx, opts.Username)
+	name, ip, err := waitForIP(ctx, c, opts.Username)
 	if err != nil {
-		return nil, fmt.Errorf("failed to look up container %q: %w", opts.Username, err)
-	}
-	if ip == "" {
-		return nil, fmt.Errorf("container %q has no IP address yet (state: %s)", opts.Username, state)
+		return nil, err
 	}
 	res, err := c.CreateRoute(ctx, AddRouteParams{
 		Domain:   opts.Domain,
@@ -102,4 +111,44 @@ func Run(ctx context.Context, c APIClient, opts Options) (*RouteResult, error) {
 		return nil, fmt.Errorf("failed to add route: %w", err)
 	}
 	return res, nil
+}
+
+// waitForIP resolves the container to (name, ip), polling until the box has an
+// IP or the deadline passes. A freshly-created box has no IP until it reaches
+// RUNNING, and agents routinely create-then-expose in one breath; waiting
+// absorbs that race instead of failing. A box in a state that will never yield
+// an IP (stopped/error/etc.) fails fast rather than burning the whole window.
+func waitForIP(ctx context.Context, c APIClient, username string) (name, ip string, err error) {
+	deadline := time.Now().Add(exposeReadyTimeout)
+	for {
+		var state string
+		name, ip, state, err = c.LookupContainer(ctx, username)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to look up container %q: %w", username, err)
+		}
+		if ip != "" {
+			return name, ip, nil
+		}
+		if !isComingUp(state) || !time.Now().Before(deadline) {
+			return "", "", fmt.Errorf("container %q has no IP address yet (state: %s)", username, state)
+		}
+		select {
+		case <-ctx.Done():
+			return "", "", ctx.Err()
+		case <-time.After(exposePollInterval):
+		}
+	}
+}
+
+// isComingUp reports whether a container state is a transient bring-up state
+// that will plausibly yield an IP shortly. RUNNING is included because there
+// is a brief window where a box is running but its IP isn't reported yet.
+// Accepts the proto enum identifier and the friendly form.
+func isComingUp(state string) bool {
+	s := strings.TrimPrefix(strings.ToUpper(strings.TrimSpace(state)), "CONTAINER_STATE_")
+	switch s {
+	case "CREATING", "PROVISIONING", "STARTING", "PENDING", "RUNNING":
+		return true
+	}
+	return false
 }

--- a/pkg/core/expose/expose_test.go
+++ b/pkg/core/expose/expose_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 // fakeClient is a minimal APIClient for unit-testing Run() without a
@@ -15,6 +16,11 @@ type fakeClient struct {
 	lookupErr                         error
 	lookupCalls                       int
 
+	// ipAfterCall, when > 0, models a box still coming up: LookupContainer
+	// returns an empty IP until the Nth call, then returns lookupIP (the box
+	// "got its IP"). Used to test the create→expose wait.
+	ipAfterCall int
+
 	// CreateRoute behavior
 	createResult *RouteResult
 	createErr    error
@@ -24,6 +30,9 @@ type fakeClient struct {
 
 func (f *fakeClient) LookupContainer(_ context.Context, _ string) (string, string, string, error) {
 	f.lookupCalls++
+	if f.ipAfterCall > 0 && f.lookupCalls < f.ipAfterCall {
+		return f.lookupName, "", f.lookupState, f.lookupErr
+	}
 	return f.lookupName, f.lookupIP, f.lookupState, f.lookupErr
 }
 
@@ -134,5 +143,56 @@ func TestRun_PropagatesCreateError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected create error to propagate")
+	}
+}
+
+// TestRun_WaitsForIPThroughCreating: a box that has no IP yet (still CREATING)
+// is waited out — Run polls LookupContainer until the IP appears, then exposes.
+// This is the create→expose race an agent hits when it exposes right after
+// create.
+func TestRun_WaitsForIPThroughCreating(t *testing.T) {
+	oldT, oldI := exposeReadyTimeout, exposePollInterval
+	exposeReadyTimeout = 2 * time.Second
+	exposePollInterval = 5 * time.Millisecond
+	defer func() { exposeReadyTimeout, exposePollInterval = oldT, oldI }()
+
+	c := &fakeClient{
+		lookupName:   "alice-container",
+		lookupIP:     "10.0.3.42",
+		lookupState:  "Creating",
+		ipAfterCall:  3, // IP appears on the 3rd lookup
+		createResult: &RouteResult{Domain: "x.example", ContainerIP: "10.0.3.42", Port: 8080},
+	}
+	got, err := Run(context.Background(), c, Options{Username: "alice", ContainerPort: 8080, Domain: "x.example"})
+	if err != nil {
+		t.Fatalf("expected Run to wait for the IP, got: %v", err)
+	}
+	if c.lookupCalls < 3 {
+		t.Errorf("expected ≥3 lookups (polled until IP), got %d", c.lookupCalls)
+	}
+	if c.createCalls != 1 || c.lastParams.TargetIP != "10.0.3.42" {
+		t.Errorf("expected one CreateRoute with the resolved IP; create=%d ip=%q", c.createCalls, c.lastParams.TargetIP)
+	}
+	_ = got
+}
+
+// TestRun_TimesOutStillCreating: a box stuck CREATING with no IP past the
+// deadline returns the actionable "no IP address yet" error (and never routes).
+func TestRun_TimesOutStillCreating(t *testing.T) {
+	oldT, oldI := exposeReadyTimeout, exposePollInterval
+	exposeReadyTimeout = 30 * time.Millisecond
+	exposePollInterval = 5 * time.Millisecond
+	defer func() { exposeReadyTimeout, exposePollInterval = oldT, oldI }()
+
+	c := &fakeClient{lookupName: "alice-container", lookupIP: "", lookupState: "Creating"}
+	_, err := Run(context.Background(), c, Options{Username: "alice", ContainerPort: 8080, Domain: "x.example"})
+	if err == nil {
+		t.Fatal("expected a timeout error for a box stuck creating")
+	}
+	if c.lookupCalls < 2 {
+		t.Errorf("expected the box to be polled more than once, got %d", c.lookupCalls)
+	}
+	if c.createCalls != 0 {
+		t.Errorf("must not route a box with no IP")
 	}
 }


### PR DESCRIPTION
## Problem (hit live by the workspace chat)

Creating a box then immediately exposing a port races the box's bring-up — it has no IP until it reaches RUNNING, so `expose_port` failed outright:

```
container "hellopy" has no IP address yet (state: CONTAINER_STATE_CREATING)
```

Same class as the create→connect race fixed in #829, but on the expose path.

## Fix

`expose.Run` (the shared core behind both `containarium expose-port` and the MCP `expose_port` tool — the latter is what the in-box workspace chat uses) now **polls `LookupContainer` until the box has an IP** (up to 90s), then routes. A box in a state that will never yield an IP (stopped/error/…) still **fails fast**; a box stuck creating past the deadline returns the same actionable message as before.

## Tests

`go test ./pkg/core/expose/` green. New: waits-through-creating (IP appears on a later poll → routes with the resolved IP) and times-out-still-creating; existing fail-fast-when-stopped and happy-path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)