### PR TITLE
fix(mcp,sshkey,expose): in-box provisioning hardening — key idempotency + cap waits under MCP timeout (#837)

### DIFF
--- a/internal/mcp/connect.go
+++ b/internal/mcp/connect.go
@@ -14,10 +14,13 @@ import (
 // connectReadyTimeout bounds how long connect waits for a freshly-created box
 // to finish coming up, and connectPollInterval is the gap between re-checks.
 // An agent commonly creates a box then immediately connects, racing the
-// box's bring-up — waiting absorbs that race instead of erroring.
-// vars (not consts) so tests can shrink them.
+// box's bring-up — waiting absorbs that race instead of erroring. Kept under
+// the typical MCP client request timeout (~60s) so a not-yet-ready box returns
+// a clean "try again shortly" the agent can retry on, rather than blowing past
+// the client deadline as an opaque -32001 (#837). vars (not consts) so tests
+// can shrink them.
 var (
-	connectReadyTimeout = 90 * time.Second
+	connectReadyTimeout = 40 * time.Second
 	connectPollInterval = 3 * time.Second
 )
 

--- a/internal/mcp/sshexec.go
+++ b/internal/mcp/sshexec.go
@@ -123,7 +123,7 @@ func appendKnownHost(path, hostname string, key ssh.PublicKey) error {
 // propagation lag; non-auth failures (dial/connection/host-key) still fail
 // fast. vars (not consts) so tests can shrink them.
 var (
-	authRetryWindow   = 120 * time.Second
+	authRetryWindow   = 40 * time.Second
 	authRetryInterval = 8 * time.Second
 )
 

--- a/internal/sshkey/local.go
+++ b/internal/sshkey/local.go
@@ -67,14 +67,18 @@ type LocateOpts struct {
 // reading it would gratuitously require an unlock prompt on
 // passphrase-protected keys.
 //
-// Search order: id_ed25519.pub, then id_rsa.pub. Returns os.ErrNotExist
-// if neither exists (callers can choose to fall through to Generate).
+// Search order: id_ed25519.pub, id_rsa.pub, then the containarium-managed
+// key (containarium_ed25519.pub) that Generate writes. Including the managed
+// key LAST keeps the CLI's "reuse my personal key" behavior unchanged while
+// making LocateOrGenerate idempotent: a second call finds the key the first
+// call generated instead of Generate erroring "already exists" (#837). Returns
+// os.ErrNotExist if none exists (callers can fall through to Generate).
 func Locate(opts LocateOpts) (pubPath string, pub string, err error) {
 	dir, err := sshDir(opts.HomeDir)
 	if err != nil {
 		return "", "", err
 	}
-	for _, name := range []string{DefaultPublicKeyPath, FallbackPublicKeyPath} {
+	for _, name := range []string{DefaultPublicKeyPath, FallbackPublicKeyPath, containariumKeyName + containariumPubKeySuffix} {
 		p := filepath.Join(dir, name)
 		// #nosec G304 -- path is under the user's own ~/.ssh; not
 		// attacker-controlled.

--- a/internal/sshkey/local_test.go
+++ b/internal/sshkey/local_test.go
@@ -266,3 +266,29 @@ func TestLocate_RejectsEmbeddedNewlineKey(t *testing.T) {
 		t.Fatal("expected error on key with embedded newline")
 	}
 }
+
+// TestLocateOrGenerate_IdempotentOnGeneratedKey: the second call must reuse the
+// containarium key the first call generated (generated=false, no error) instead
+// of failing "already exists" — Locate now also searches the managed key (#837).
+func TestLocateOrGenerate_IdempotentOnGeneratedKey(t *testing.T) {
+	home := t.TempDir()
+
+	p1, k1, gen1, err := LocateOrGenerate(LocateOpts{HomeDir: home})
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if !gen1 {
+		t.Fatalf("first call should have generated a key (empty home), got generated=false")
+	}
+
+	p2, k2, gen2, err := LocateOrGenerate(LocateOpts{HomeDir: home})
+	if err != nil {
+		t.Fatalf("second call should reuse the generated key, got: %v", err)
+	}
+	if gen2 {
+		t.Errorf("second call should reuse (generated=false), got generated=true")
+	}
+	if p1 != p2 || k1 != k2 {
+		t.Errorf("second call returned a different key:\n  1: %s\n     %s\n  2: %s\n     %s", p1, k1, p2, k2)
+	}
+}

--- a/pkg/core/expose/expose.go
+++ b/pkg/core/expose/expose.go
@@ -23,7 +23,7 @@ import (
 // IP until it's RUNNING. Waiting absorbs that race instead of erroring (the
 // same create→ready fix connect got). vars (not consts) so tests can shrink.
 var (
-	exposeReadyTimeout = 90 * time.Second
+	exposeReadyTimeout = 40 * time.Second
 	exposePollInterval = 3 * time.Second
 )
 


### PR DESCRIPTION
Two contained fixes from the **#837** in-box-provisioning hardening epic (the others need design / cloud work — see below).

## #837.2 — `sshkey.LocateOrGenerate` not idempotent
`Generate` writes `containarium_ed25519{,.pub}`, but `Locate` only searched `id_ed25519.pub` / `id_rsa.pub` — so it never found the key it had just generated. Every call after the first fell to `Generate(force=false)` → `private key already exists`, which **broke every in-box `connect` after the first** (seen live: `locate or generate managed key: …/containarium_ed25519 already exists`). Fix: `Locate` now also searches the managed key, **last**, so the CLI's "reuse my personal key" behavior is unchanged but repeat calls are idempotent.

## #837.3 — waits longer than the MCP client timeout → opaque `-32001`
The create→ready waits (connect `90s`, connect auth-retry `120s`, expose `90s`) exceed the chat's MCP client request timeout (~60s), so a not-yet-ready box blew past the client deadline and surfaced as `MCP error -32001: Request timed out` instead of a clean, retryable message (seen live when a box was stuck `CREATING`). Cap all three to **40s** — within the client budget; the agent retries (resetting the timeout) for boxes that need longer.

## Tests
`go test ./internal/sshkey/ ./internal/mcp/ ./pkg/core/expose/` green. New: `LocateOrGenerate` idempotency. Daemon + mcp-server build; gofmt-s clean.

## Not in this PR (tracked in #837)
- **#837.1** — the SSH-apex DNS hijack (bridge dnsmasq wildcard `address=/<base>/<caddyIP>` at `dual_server.go:487` swallows the infra SSH apex and is stale). It's the actual connectivity blocker, but the fix is a **cross-cutting OSS↔cloud design decision** (narrow the wildcard / caddy L4 :22 / recipe apex override) — not safe to guess.
- **#837.4/#837.5** — the OSS daemon already returns `ERROR` for a failed async create (`container_server.go:776`), but the **cloud** doesn't propagate it (same gap as #698); a bad image stays stuck `CREATING`. Cloud-side fix.

Refs #837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)