### PR TITLE
fix(daemon): carve the SSH apex out of the bridge DNS hairpin wildcard (#837.1)

### DIFF
--- a/internal/egressproxy/manager_test.go
+++ b/internal/egressproxy/manager_test.go
@@ -16,14 +16,14 @@ func TestManager_StartStop_AndForward(t *testing.T) {
 	if err != nil {
 		t.Fatalf("upstream: %v", err)
 	}
-	defer up.Close()
+	defer func() { _ = up.Close() }()
 	go func() {
 		for {
 			c, err := up.Accept()
 			if err != nil {
 				return
 			}
-			go func() { _, _ = io.Copy(c, c); c.Close() }()
+			go func() { _, _ = io.Copy(c, c); _ = c.Close() }()
 		}
 	}()
 

--- a/internal/egressproxy/relay.go
+++ b/internal/egressproxy/relay.go
@@ -157,7 +157,7 @@ func (r *Relay) serveListener(ctx context.Context, ln net.Listener) error {
 }
 
 func (r *Relay) handle(c net.Conn) {
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	ap, ok := remoteAddrPort(c.RemoteAddr())
 	if !ok || !r.sourceAllowed(ap.Addr()) {
 		r.logf("egress-relay DENY %s (allow %v)", c.RemoteAddr(), r.allow)
@@ -168,7 +168,7 @@ func (r *Relay) handle(c net.Conn) {
 		r.logf("egress-relay upstream %s dial failed: %v", r.upstream, err)
 		return
 	}
-	defer up.Close()
+	defer func() { _ = up.Close() }()
 	// Bidirectional copy; both directions end when either side closes.
 	done := make(chan struct{}, 2)
 	go func() { _, _ = io.Copy(up, c); done <- struct{}{} }()

--- a/internal/egressproxy/relay_test.go
+++ b/internal/egressproxy/relay_test.go
@@ -61,14 +61,14 @@ func TestRelay_ForwardsAllowedSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("upstream listen: %v", err)
 	}
-	defer up.Close()
+	defer func() { _ = up.Close() }()
 	go func() {
 		for {
 			c, err := up.Accept()
 			if err != nil {
 				return
 			}
-			go func() { _, _ = io.Copy(c, c); c.Close() }()
+			go func() { _, _ = io.Copy(c, c); _ = c.Close() }()
 		}
 	}()
 
@@ -93,7 +93,7 @@ func TestRelay_ForwardsAllowedSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial relay: %v", err)
 	}
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	_ = c.SetDeadline(time.Now().Add(2 * time.Second))
 	if _, err := c.Write([]byte("ping")); err != nil {
 		t.Fatalf("write: %v", err)

--- a/internal/egressproxy/socks5.go
+++ b/internal/egressproxy/socks5.go
@@ -45,7 +45,7 @@ func ServeSOCKS5(ctx context.Context, listenAddr string, logf func(string, ...an
 }
 
 func socksHandle(c net.Conn) {
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	_ = c.SetDeadline(time.Now().Add(30 * time.Second))
 
 	// Greeting: VER, NMETHODS, METHODS...
@@ -102,7 +102,7 @@ func socksHandle(c net.Conn) {
 		_, _ = c.Write([]byte{0x05, 0x05, 0x00, 0x01, 0, 0, 0, 0, 0, 0}) // conn refused
 		return
 	}
-	defer up.Close()
+	defer func() { _ = up.Close() }()
 	if _, err := c.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
 		return
 	}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -192,6 +192,26 @@ type DualServer struct {
 	startTime             time.Time
 }
 
+// bridgeDNSRaw builds the incusbr0 `raw.dnsmasq` value for container DNS.
+//
+// The base rule `address=/<baseDomain>/<caddyIP>` makes boxes resolve
+// *.baseDomain to the local Caddy edge (hairpin-NAT avoidance for exposed
+// apps). But that wildcard also swallows the SSH apex (sshHost, e.g.
+// region-a.example.com), which must reach the sentinel/sshpiper on :22 —
+// Caddy serves only :80/:443. So when sshHost is set (and is a name the
+// wildcard would capture), we add the more-specific `server=/<sshHost>/#`,
+// which tells dnsmasq to resolve that exact name via the upstream resolvers
+// (→ the sentinel's public IP) instead of the address= override. dnsmasq's
+// longest-match makes the carve-out win. Without it, an in-box `connect`
+// dials the SSH apex and lands on Caddy (no :22) or a stale edge IP (#837.1).
+func bridgeDNSRaw(baseDomain, caddyIP, sshHost string) string {
+	raw := fmt.Sprintf("address=/%s/%s", baseDomain, caddyIP)
+	if sshHost != "" && sshHost != baseDomain {
+		raw += "\nserver=/" + sshHost + "/#"
+	}
+	return raw
+}
+
 // NewDualServer creates a new dual server instance
 func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	// Audit C-MED-1: when --proxy-protocol is on, the daemon
@@ -482,13 +502,16 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 							}
 						}
 
-						// Add DNS override so containers resolve *.baseDomain to Caddy
-						// internally instead of going through the external IP (hairpin NAT).
-						dnsOverride := fmt.Sprintf("address=/%s/%s", config.BaseDomain, caddyIP)
-						if out, err := exec.Command("incus", "network", "set", "incusbr0", "raw.dnsmasq", dnsOverride).CombinedOutput(); err != nil { // #nosec G204 -- dnsOverride is constructed from trusted BaseDomain and CaddyIP config values
+						// Resolve *.baseDomain to Caddy internally (hairpin NAT
+						// avoidance), carving out the SSH apex so it still reaches
+						// the sentinel (#837.1). Uses the LIVE caddy IP, so each
+						// (re)apply tracks Caddy's current address rather than a
+						// stale one (#837.D).
+						dnsOverride := bridgeDNSRaw(config.BaseDomain, caddyIP, config.SSHHost)
+						if out, err := exec.Command("incus", "network", "set", "incusbr0", "raw.dnsmasq", dnsOverride).CombinedOutput(); err != nil { // #nosec G204 -- dnsOverride is built from trusted BaseDomain/CaddyIP/SSHHost config values
 							log.Printf("Warning: failed to set DNS override for %s: %v (%s)", config.BaseDomain, err, string(out))
 						} else {
-							log.Printf("DNS override: *.%s -> %s (internal hairpin)", config.BaseDomain, caddyIP)
+							log.Printf("DNS override: *.%s -> %s (internal hairpin); SSH apex %q -> upstream", config.BaseDomain, caddyIP, config.SSHHost)
 						}
 					}
 				}

--- a/internal/server/dual_server_dns_test.go
+++ b/internal/server/dual_server_dns_test.go
@@ -1,0 +1,37 @@
+package server
+
+import "testing"
+
+// TestBridgeDNSRaw covers the incusbr0 raw.dnsmasq construction: the base
+// *.baseDomain -> caddy hairpin, plus the SSH-apex carve-out so the sentinel
+// apex isn't swallowed by the wildcard (#837.1).
+func TestBridgeDNSRaw(t *testing.T) {
+	cases := []struct {
+		name               string
+		base, caddyIP, ssh string
+		want               string
+	}{
+		{
+			name: "ssh apex carved out",
+			base: "example.com", caddyIP: "10.0.3.5", ssh: "region-a.example.com",
+			want: "address=/example.com/10.0.3.5\nserver=/region-a.example.com/#",
+		},
+		{
+			name: "no ssh host -> wildcard only (direct mode)",
+			base: "example.com", caddyIP: "10.0.3.5", ssh: "",
+			want: "address=/example.com/10.0.3.5",
+		},
+		{
+			name: "ssh host equal to base -> no carve-out (would self-collide)",
+			base: "example.com", caddyIP: "10.0.3.5", ssh: "example.com",
+			want: "address=/example.com/10.0.3.5",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bridgeDNSRaw(tc.base, tc.caddyIP, tc.ssh); got != tc.want {
+				t.Errorf("bridgeDNSRaw(%q,%q,%q)\n got: %q\nwant: %q", tc.base, tc.caddyIP, tc.ssh, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
Boxes resolve `*.<baseDomain>` to the local Caddy edge via an `incusbr0` `raw.dnsmasq` override (`address=/<base>/<caddyIP>`, for hairpin-NAT avoidance). That wildcard also captured the **SSH apex** (`config.SSHHost`, e.g. `region-a.example.com`), so an in-box `connect` — which dials the target's `ssh_host` (the apex) — landed on Caddy (only `:80/:443`, no `:22`), or on a stale edge IP → `connect: no route to host`. Net: a workspace box could **never** SSH into another box. (Confirmed live: boxes *can* reach the public sentinel `:22`; only DNS was wrong.)

## Fix (the chosen **A + D** from the #837 design proposal)
- **A** — add a more-specific `server=/<sshHost>/#`, so dnsmasq resolves the SSH apex via the **upstream resolvers** (→ the sentinel's public IP, reachable from boxes) instead of the `address=` wildcard. dnsmasq longest-match makes the carve-out win; the HTTP hairpin for app subdomains is unchanged.
- **D** — the override is built from the **live** caddy IP on each apply (`bridgeDNSRaw`), so re-applying tracks Caddy's current address rather than a stale one. (Eliminating drift on a *mid-run* Caddy recreate without a daemon restart remains the #240 caddy-stable-IP pin's job.)

Logic extracted to `bridgeDNSRaw()` and unit-tested (carve-out present; absent in direct mode; skipped when `sshHost == baseDomain`).

## Deploy note
This rewrites `incusbr0 raw.dnsmasq`. After rolling the daemon, confirm dnsmasq reloads cleanly and a box resolves the SSH apex to the sentinel (public) IP (and HTTP apps still hairpin to Caddy).

Fixes #837 (item 1). Companion: #838 (#837.2 key idempotency + #837.3 wait caps). Remaining: #837.4/#837.5 (cloud-side async-create-failure surfacing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)