### PR TITLE
feat(k8s): nvidia.com/gpu resource limit from BoxSpec.GPUs

### DIFF
--- a/pkg/core/box/k8s/e2e_test.go
+++ b/pkg/core/box/k8s/e2e_test.go
@@ -293,6 +293,60 @@ func TestE2E_CSIStorage(t *testing.T) {
 	}
 }
 
+// TestE2E_GPUResourceLimit verifies that a box created with a non-empty GPUs
+// slice carries nvidia.com/gpu limits + the gpu-count annotation against a real
+// apiserver. The kind cluster has no GPU nodes, so the pod stays Pending — we
+// assert the spec shape only, not that the pod schedules.
+func TestE2E_GPUResourceLimit(t *testing.T) {
+	if os.Getenv("CONTAINARIUM_K8S_E2E") == "" {
+		t.Skip("set CONTAINARIUM_K8S_E2E=1 (and KUBECONFIG) to run the kind e2e")
+	}
+	kubeconfig := os.Getenv("KUBECONFIG")
+
+	b, err := New(Config{
+		Kubeconfig:  kubeconfig,
+		BoxImage:    "registry.k8s.io/pause:3.9",
+		GatewayHost: "gateway.example.com",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	restCfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("rest config: %v", err)
+	}
+	cs, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		t.Fatalf("clientset: %v", err)
+	}
+
+	ctx := context.Background()
+	ref := box.BoxRef{Tenant: "gpu-e2e"}
+	ns := "tenant-gpu-e2e"
+	t.Cleanup(func() { _ = b.Delete(context.Background(), ref, true) })
+
+	if _, err := b.Create(ctx, box.BoxSpec{
+		Ref:   ref,
+		Image: "registry.k8s.io/pause:3.9",
+		GPUs:  []string{"gpu", "gpu1"}, // 2 GPUs
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	ss, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("StatefulSet not found: %v", err)
+	}
+	c := ss.Spec.Template.Spec.Containers[0]
+	if v := c.Resources.Limits[nvidiaGPUResource]; v.Value() != 2 {
+		t.Errorf("nvidia.com/gpu limit = %v, want 2", v.Value())
+	}
+	if ann := ss.Spec.Template.Annotations[gpuCountAnnotation]; ann != "2" {
+		t.Errorf("gpu-count annotation = %q, want 2", ann)
+	}
+}
+
 // installPipeCRD applies a minimal sshpiper Pipe CRD (open schema via
 // x-kubernetes-preserve-unknown-fields) and waits for it to be Established.
 func installPipeCRD(t *testing.T, dyn dynamic.Interface) {

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -358,7 +358,7 @@ func (b *Backend) boxAuthorizedKeys(agentKeys []string) []string {
 // Resize patches the box container's resource limits. Unparseable (incus-native)
 // quantities are skipped; a no-op resize returns nil.
 func (b *Backend) Resize(ctx context.Context, ref box.BoxRef, r box.ResourceLimits) error {
-	res := resourceRequirements(r)
+	res := resourceRequirements(r, 0) // Resize does not change GPU count
 	if res == nil {
 		return nil
 	}

--- a/pkg/core/box/k8s/k8s_test.go
+++ b/pkg/core/box/k8s/k8s_test.go
@@ -209,6 +209,67 @@ func TestResolveGatewayEndpoint(t *testing.T) {
 	}
 }
 
+// TestGPUResourceRequirements verifies that a non-empty GPUs list maps to an
+// nvidia.com/gpu limit on the container, and that the pod carries the
+// gpu-count annotation for observability.
+func TestGPUResourceRequirements(t *testing.T) {
+	b, cs := testBackend()
+	ctx := context.Background()
+	ref := box.BoxRef{Tenant: "gpu-user"}
+	if _, err := b.Create(ctx, box.BoxSpec{
+		Ref:   ref,
+		Image: "x",
+		GPUs:  []string{"gpu", "gpu1"}, // 2 GPUs
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	ns := "tenant-gpu-user"
+	ss, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("StatefulSet not found: %v", err)
+	}
+
+	// Container must carry nvidia.com/gpu: 2 in both limits and requests.
+	c := ss.Spec.Template.Spec.Containers[0]
+	gpuLimit := c.Resources.Limits[nvidiaGPUResource]
+	if gpuLimit.Value() != 2 {
+		t.Errorf("nvidia.com/gpu limit = %v, want 2", gpuLimit.Value())
+	}
+	gpuReq := c.Resources.Requests[nvidiaGPUResource]
+	if gpuReq.Value() != 2 {
+		t.Errorf("nvidia.com/gpu request = %v, want 2", gpuReq.Value())
+	}
+
+	// Pod template must carry the gpu-count annotation.
+	ann := ss.Spec.Template.Annotations[gpuCountAnnotation]
+	if ann != "2" {
+		t.Errorf("gpu-count annotation = %q, want 2", ann)
+	}
+}
+
+// TestNoGPUResourceWhenGPUsEmpty verifies no nvidia.com/gpu limit is set and
+// no gpu-count annotation is added when GPUs is nil/empty.
+func TestNoGPUResourceWhenGPUsEmpty(t *testing.T) {
+	b, cs := testBackend()
+	ctx := context.Background()
+	ref := box.BoxRef{Tenant: "no-gpu"}
+	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref, Image: "x"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	ns := "tenant-no-gpu"
+	ss, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("StatefulSet not found: %v", err)
+	}
+	c := ss.Spec.Template.Spec.Containers[0]
+	if _, ok := c.Resources.Limits[nvidiaGPUResource]; ok {
+		t.Error("nvidia.com/gpu limit set on non-GPU box")
+	}
+	if ss.Spec.Template.Annotations[gpuCountAnnotation] != "" {
+		t.Errorf("gpu-count annotation unexpectedly set: %q", ss.Spec.Template.Annotations[gpuCountAnnotation])
+	}
+}
+
 // testBackendWithStorage returns a backend with a StorageClass set, exercising
 // the CSI PVC lifecycle paths.
 func testBackendWithStorage() (*Backend, *fake.Clientset) {

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -3,6 +3,8 @@
 package k8s
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -40,6 +42,11 @@ const (
 	managedByValue       = "containarium"
 	tenantLabel          = "containarium.dev/tenant"
 	metaAnnotationPrefix = "containarium.dev/meta."
+	gpuCountAnnotation   = "containarium.dev/gpu-count"
+
+	// nvidiaGPUResource is the K8s extended-resource name for NVIDIA GPUs.
+	// A non-zero limit causes the cluster autoscaler to scale up a GPU node pool.
+	nvidiaGPUResource = corev1.ResourceName("nvidia.com/gpu")
 
 	authorizedKeysKey = "authorized_keys"
 	// authorizedKeysMount is where the box image (dropbear entrypoint) reads
@@ -187,6 +194,7 @@ func statefulSetObject(ns string, spec box.BoxSpec, withPVC bool) *appsv1.Statef
 	// restricted-PSA container hardening: non-root, no privilege escalation,
 	// all capabilities dropped, default seccomp. The box image (dropbear on
 	// :2222) is built to run under exactly this.
+	gpuCount := len(spec.GPUs)
 	container := corev1.Container{
 		Name:  "agent-box",
 		Image: spec.Image,
@@ -206,7 +214,7 @@ func statefulSetObject(ns string, spec box.BoxSpec, withPVC bool) *appsv1.Statef
 			{Name: hostKeyVolume, MountPath: hostKeyMount, ReadOnly: true},
 		},
 	}
-	if res := resourceRequirements(spec.Resources); res != nil {
+	if res := resourceRequirements(spec.Resources, gpuCount); res != nil {
 		container.Resources = *res
 	}
 
@@ -239,6 +247,13 @@ func statefulSetObject(ns string, spec box.BoxSpec, withPVC bool) *appsv1.Statef
 		})
 	}
 
+	podMeta := metav1.ObjectMeta{Labels: labels}
+	if gpuCount > 0 {
+		podMeta.Annotations = map[string]string{
+			gpuCountAnnotation: fmt.Sprintf("%d", gpuCount),
+		}
+	}
+
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{Name: statefulSetName, Namespace: ns, Labels: labels},
 		Spec: appsv1.StatefulSetSpec{
@@ -246,7 +261,7 @@ func statefulSetObject(ns string, spec box.BoxSpec, withPVC bool) *appsv1.Statef
 			ServiceName: serviceName,
 			Selector:    &metav1.LabelSelector{MatchLabels: labels},
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				ObjectMeta: podMeta,
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: boolp(false), // the box is a leaf, never a kube-apiserver client
 					SecurityContext: &corev1.PodSecurityContext{
@@ -262,11 +277,13 @@ func statefulSetObject(ns string, spec box.BoxSpec, withPVC bool) *appsv1.Statef
 	}
 }
 
-// resourceRequirements maps the runtime-neutral limits onto K8s requests/limits,
-// skipping any field that isn't a valid K8s quantity (the incus-native strings
-// like "4GB" aren't K8s quantities; "4Gi"/"2"/"500m" are). Returns nil when
-// nothing parsed, so the pod runs unconstrained rather than failing admission.
-func resourceRequirements(r box.ResourceLimits) *corev1.ResourceRequirements {
+// resourceRequirements maps the runtime-neutral limits onto K8s requests/limits.
+// CPU and Memory strings that aren't valid K8s quantities (e.g. incus-native
+// "4GB") are silently skipped so the pod runs unconstrained rather than failing
+// admission. gpuCount > 0 adds nvidia.com/gpu; the cluster autoscaler uses this
+// to scale up a GPU node pool when no schedulable node exists.
+// Returns nil when nothing parsed.
+func resourceRequirements(r box.ResourceLimits, gpuCount int) *corev1.ResourceRequirements {
 	limits := corev1.ResourceList{}
 	if r.CPU != "" {
 		if q, err := resource.ParseQuantity(r.CPU); err == nil {
@@ -277,6 +294,10 @@ func resourceRequirements(r box.ResourceLimits) *corev1.ResourceRequirements {
 		if q, err := resource.ParseQuantity(r.Memory); err == nil {
 			limits[corev1.ResourceMemory] = q
 		}
+	}
+	if gpuCount > 0 {
+		q := resource.MustParse(fmt.Sprintf("%d", gpuCount))
+		limits[nvidiaGPUResource] = q
 	}
 	if len(limits) == 0 {
 		return nil


### PR DESCRIPTION
## Summary

- `BoxSpec.GPUs []string` (device IDs) maps to `nvidia.com/gpu: N` in the container's resource limits/requests, where N = `len(GPUs)`. The K8s cluster autoscaler uses this to scale a GPU node pool when no schedulable GPU node exists.
- `containarium.dev/gpu-count: "N"` annotation on the pod template for observability.
- `Resize` passes `gpuCount=0` — resize does not change GPU allocation.
- No change to the `BoxBackend` interface; fully backward-compatible (`GPUs` nil/empty = no limit set).

## Tests

- 2 new unit tests (`TestGPUResourceRequirements`, `TestNoGPUResourceWhenGPUsEmpty`) against fake clientset.
- 1 new kind e2e test (`TestE2E_GPUResourceLimit`) validates the spec shape against a real apiserver. The pod stays Pending (kind has no GPU nodes) — we assert the limit/annotation, not scheduling.

## Test plan

- [x] `go test -tags k8s ./pkg/core/box/k8s/...` — all tests pass
- [x] `go build -tags k8s ./...` — clean build
- [ ] Kind e2e via `scripts/k8s-e2e.sh` (runs in CI)

Closes #845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)