### PR TITLE
fix(lint): clear golangci-lint failures on main (errcheck, staticcheck, gofmt)

### DIFF
--- a/internal/egressproxy/manager_test.go
+++ b/internal/egressproxy/manager_test.go
@@ -16,14 +16,14 @@ func TestManager_StartStop_AndForward(t *testing.T) {
 	if err != nil {
 		t.Fatalf("upstream: %v", err)
 	}
-	defer up.Close()
+	defer func() { _ = up.Close() }()
 	go func() {
 		for {
 			c, err := up.Accept()
 			if err != nil {
 				return
 			}
-			go func() { _, _ = io.Copy(c, c); c.Close() }()
+			go func() { _, _ = io.Copy(c, c); _ = c.Close() }()
 		}
 	}()
 

--- a/internal/egressproxy/relay.go
+++ b/internal/egressproxy/relay.go
@@ -157,7 +157,7 @@ func (r *Relay) serveListener(ctx context.Context, ln net.Listener) error {
 }
 
 func (r *Relay) handle(c net.Conn) {
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	ap, ok := remoteAddrPort(c.RemoteAddr())
 	if !ok || !r.sourceAllowed(ap.Addr()) {
 		r.logf("egress-relay DENY %s (allow %v)", c.RemoteAddr(), r.allow)
@@ -168,7 +168,7 @@ func (r *Relay) handle(c net.Conn) {
 		r.logf("egress-relay upstream %s dial failed: %v", r.upstream, err)
 		return
 	}
-	defer up.Close()
+	defer func() { _ = up.Close() }()
 	// Bidirectional copy; both directions end when either side closes.
 	done := make(chan struct{}, 2)
 	go func() { _, _ = io.Copy(up, c); done <- struct{}{} }()

--- a/internal/egressproxy/relay_test.go
+++ b/internal/egressproxy/relay_test.go
@@ -61,14 +61,14 @@ func TestRelay_ForwardsAllowedSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("upstream listen: %v", err)
 	}
-	defer up.Close()
+	defer func() { _ = up.Close() }()
 	go func() {
 		for {
 			c, err := up.Accept()
 			if err != nil {
 				return
 			}
-			go func() { _, _ = io.Copy(c, c); c.Close() }()
+			go func() { _, _ = io.Copy(c, c); _ = c.Close() }()
 		}
 	}()
 
@@ -93,7 +93,7 @@ func TestRelay_ForwardsAllowedSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial relay: %v", err)
 	}
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	_ = c.SetDeadline(time.Now().Add(2 * time.Second))
 	if _, err := c.Write([]byte("ping")); err != nil {
 		t.Fatalf("write: %v", err)

--- a/internal/egressproxy/socks5.go
+++ b/internal/egressproxy/socks5.go
@@ -45,7 +45,7 @@ func ServeSOCKS5(ctx context.Context, listenAddr string, logf func(string, ...an
 }
 
 func socksHandle(c net.Conn) {
-	defer c.Close()
+	defer func() { _ = c.Close() }()
 	_ = c.SetDeadline(time.Now().Add(30 * time.Second))
 
 	// Greeting: VER, NMETHODS, METHODS...
@@ -102,7 +102,7 @@ func socksHandle(c net.Conn) {
 		_, _ = c.Write([]byte{0x05, 0x05, 0x00, 0x01, 0, 0, 0, 0, 0, 0}) // conn refused
 		return
 	}
-	defer up.Close()
+	defer func() { _ = up.Close() }()
 	if _, err := c.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0}); err != nil {
 		return
 	}

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -328,7 +328,7 @@ func (b *Backend) Resolve(ctx context.Context, ref box.BoxRef) (*box.BoxEndpoint
 // the agent's keys authorize the box itself, so we update the box Secret too.
 func (b *Backend) SetAuthorizedKeys(ctx context.Context, ref box.BoxRef, keys []string) error {
 	ns := b.namespaceFor(ref.Tenant)
-	if !(b.gatewayEnabled() && b.cfg.GatewayUpstreamPublicKey != "") {
+	if !b.gatewayEnabled() || b.cfg.GatewayUpstreamPublicKey == "" {
 		sec := secretObject(ns, ref.Tenant, keys)
 		_, err := b.clientset.CoreV1().Secrets(ns).Update(ctx, sec, metav1.UpdateOptions{})
 		if apierrors.IsNotFound(err) {

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -23,10 +23,10 @@ const (
 	// pvcName is the PersistentVolumeClaim name inside the tenant namespace.
 	// It holds the box's persistent data (home directory). Created before the
 	// StatefulSet and retained on Delete; removed only by Purge.
-	pvcName      = "data"
-	dataMount    = "/home/agent"
-	dataVolume   = "data"
-	defaultDisk  = "10Gi"
+	pvcName     = "data"
+	dataMount   = "/home/agent"
+	dataVolume  = "data"
+	defaultDisk = "10Gi"
 	// sshPort is the box's in-pod SSH port. 2222 (unprivileged) so the box
 	// runs fully non-root with no added capabilities — the agent connects to
 	// the gateway on :22; this is the internal sshpiper→pod hop.


### PR DESCRIPTION
## What

The **`golangci-lint`** job is red on `main` ([run](https://github.com/FootprintAI/Containarium/actions/runs/28333832681/job/83936514371)) with 11 pre-existing findings. This clears all of them — no behavior change.

## Findings fixed

| Linter | Count | Where | Fix |
|---|---|---|---|
| `errcheck` | 9 | `internal/egressproxy/{relay,socks5}.go` + `{manager,relay}_test.go` | `defer x.Close()` → `defer func() { _ = x.Close() }()`; inline `c.Close()` → `_ = c.Close()` |
| `staticcheck` QF1001 | 1 | `pkg/core/box/k8s/k8s.go:331` | De Morgan: `!(a && b)` → `!a \|\| !b` |
| `gofmt` | 1 | `pkg/core/box/k8s/objects.go` | reformat |

## Verified

- `go vet ./internal/egressproxy/... ./pkg/core/box/k8s/...` — clean
- `go test ./internal/egressproxy/...` — pass
- `gofmt -l` on all touched files — clean

(These predate today's social-card merge #851, which touched no Go; the lint job just runs on every push to `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)