### PR TITLE
feat(k8s): per-box StorageClass for data PVC + proto/CLI wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Containarium
+# Containarium — Agent Runtime
 
-**The open-source, self-hostable, agent-native sandbox.**
+> **Open-source agent runtime** · SSH-native isolation · eBPF egress policy · Kubernetes + LXC · MCP-native CLI · GPU passthrough
+
+**The open-source, self-hostable agent runtime for AI agents.**
+Each agent gets a persistent, SSH-reachable box with per-tenant network isolation — no kube-apiserver token, no host access, no cross-tenant leakage.
+
 Bring your own agent — Cursor, Claude Code, OpenCode, your own MCP client.
 We run the box.
 

--- a/README.md
+++ b/README.md
@@ -26,25 +26,27 @@ curl https://blog.example.com → hello world
 
 ---
 
-## Why "agent-native"?
+## Why an agent runtime?
 
 AI agents are increasingly the primary user of dev infrastructure. They
 want to build, install, deploy, and verify — not on the human's laptop
-(too noisy, too risky, too local) but on a sandbox that's:
+(too noisy, too risky, too local) but on a persistent, isolated runtime that's:
 
 - **Persistent**: state survives between agent runs.
-- **Isolated**: a misbehaving install doesn't touch your machine.
+- **Isolated**: a misbehaving install doesn't touch your machine or your cluster.
 - **Real**: a full Linux environment with `systemd`, real networking,
   and the ability to host things on the open internet.
 - **Driven by structured tools**: not by an agent typing commands into a
   TTY hoping nothing scrolls off-screen, but by MCP — typed,
   bounded, safe.
+- **Blast-radius-bounded**: the agent holds an SSH key, not a
+  kube-apiserver token. It can't reach the cluster control plane, the
+  host OS, or other tenants' boxes.
 
-That's the box Containarium gives you. It runs as a self-hosted
-single-host platform (one VM → many isolated LXC containers), exposes
-its admin surface over MCP, and ships a second MCP server that lives
-*inside* the container so the agent can `shell_exec` and edit files
-directly.
+That's the runtime Containarium gives you. It runs as a self-hosted
+platform on LXC or Kubernetes, exposes its admin surface over MCP, and
+ships a second MCP server that lives *inside* the box so the agent can
+`shell_exec` and edit files directly.
 
 You bring the agent. We run the box.
 
@@ -295,6 +297,30 @@ running on, `sbx` is the lighter tool. If you're giving your agent
 (or your customer's agent) a persistent Linux box on the public
 internet, Containarium is the shape.
 
+### vs. OSS Kubernetes agent runtimes (agent-sandbox, OpenShell)
+
+[`kubernetes-sigs/agent-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox)
+and [`NVIDIA/OpenShell`](https://github.com/NVIDIA/OpenShell) are the
+closest open-source peers on Kubernetes:
+
+- **SSH-native vs. exec-based**: both agent-sandbox and OpenShell reach
+  the sandbox via `kubectl exec` or a proprietary client, which requires
+  the agent to hold a kube-apiserver token or cluster credentials.
+  Containarium reaches the pod over SSH through sshpiper — the agent has
+  no path to the cluster control plane at all.
+- **MCP-native**: agent-sandbox and OpenShell expose REST APIs or custom
+  SDKs. Containarium's `agent-box` MCP server runs *inside* the box,
+  reachable over SSH stdio — any MCP-speaking agent (Claude Code, Cursor,
+  OpenCode) works with zero client library.
+- **LXC + K8s, one CLI**: Containarium runs on either Incus/LXC or
+  Kubernetes behind the same `containarium` CLI and `--runtime` flag. You
+  switch backends without changing anything for the agent.
+- **eBPF egress policy**: Containarium enforces per-tenant egress
+  allowlists at the kernel level via TC_INGRESS eBPF programs.
+  agent-sandbox has NetworkPolicy; OpenShell has eBPF but is
+  NVIDIA-stack-specific. Neither offers a portable, per-tenant eBPF
+  allowlist across LXC and K8s backends.
+
 ### vs. dev environment platforms (Codespaces, Gitpod, Coder)
 
 Those are persistent IDEs. Containarium is a persistent **box** —
@@ -320,10 +346,10 @@ config files in `/etc`, run a database, and reboot — LXC is the right
 shape. If your agent runs a single Python process, Docker or Modal is
 fine.
 
-It isn't either/or: Containarium can also run a box *as a pod* in a
+It isn't either/or: Containarium can run a box *as a pod* in a
 Kubernetes cluster you already operate — same SSH-native agent contract,
-no kube-apiserver token in the agent's hands. See the **Kubernetes
-backend** below.
+no kube-apiserver token in the agent's hands. Switch with
+`--runtime=k8s`. See the **Kubernetes backend** section below.
 
 ---
 
@@ -359,7 +385,7 @@ All containers from all backends appear in a single unified API.
 
 ### Kubernetes backend (experimental)
 
-Beyond the LXC/incus backend, Containarium can run a box as a **pod in a
+Beyond the LXC/Incus backend, Containarium can run a box as a **pod in a
 Kubernetes cluster you already operate** — reached over SSH exactly like
 an LXC box, so an agent can't tell which substrate it landed on. The
 daemon reconciles a per-tenant namespace + StatefulSet + headless Service
@@ -369,13 +395,26 @@ daemon reconciles a per-tenant namespace + StatefulSet + headless Service
 The pitch isn't "another way to run pods" — it's giving an agent a
 hardened, SSH-native foothold in your cluster **without handing it a
 kube-apiserver token**: the box runs with `automountServiceAccountToken:
-false` and satisfies the `restricted` Pod Security profile.
+false` and satisfies the `restricted` Pod Security profile. Compare this
+to `kubectl exec`-based runtimes where the agent necessarily holds cluster
+credentials.
 
-The backend is compiled behind a `k8s` build tag, so the default daemon
-never pulls in `client-go`. It is **experimental**: the control plane is
-implemented and CI-tested against [kind](https://kind.sigs.k8s.io/) on
-every change; the gateway data-plane (the agent-box image + end-to-end
-SSH through sshpiper) is still landing.
+**Runtime selection** (no recompile needed):
+
+```bash
+# LXC/Incus (default)
+containarium daemon
+
+# Kubernetes — uses in-cluster config or KUBECONFIG
+CONTAINARIUM_RUNTIME=k8s containarium daemon
+# or
+containarium daemon --runtime=k8s
+```
+
+Both backends share the same CLI, MCP tools, JWT auth, and REST/gRPC API.
+GPU passthrough is supported on K8s via `nvidia.com/gpu` resource limits.
+Local bring-up takes under 5 minutes with `kind` — see
+[docs/KIND-QUICKSTART.md](docs/KIND-QUICKSTART.md).
 
 Design, topology, and BYO-cluster integration:
 [docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md](docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md).
@@ -647,9 +686,13 @@ Docker-in-LXC works, persistent filesystem. If your agent will
 `apt install` and reboot, you want LXC.
 
 **Why not Kubernetes?**
-K8s orchestrates application containers across many nodes.
-Containarium runs many full Linux environments on one (or a few)
-nodes. Different shape, different problem.
+K8s orchestrates application containers across nodes — that's the
+infrastructure layer. Containarium is the agent runtime that runs *on
+top of* Kubernetes (or LXC), giving each agent a persistent, SSH-native
+box without handing it cluster credentials. If you're already on K8s,
+run `containarium daemon --runtime=k8s` and use your existing cluster as
+the backend. See the [Kubernetes backend](#kubernetes-backend-experimental)
+section and [docs/KIND-QUICKSTART.md](docs/KIND-QUICKSTART.md).
 
 **Why not Vagrant?**
 Vagrant orchestrates VMs on a developer's local machine. Containarium
@@ -725,10 +768,12 @@ Demoed Containarium somewhere? Open a PR and add it here.
 
 ## Roadmap
 
-- **Shipped (2026-06)**: experimental **[Kubernetes backend](#kubernetes-backend-experimental)**
+- **Shipped (2026-06)**: **[Kubernetes backend](#kubernetes-backend-experimental)**
   — run a box as a pod in a cluster you operate, reached over SSH like an LXC
-  box, with the sshpiper gateway, default-deny NetworkPolicy, and host-key
-  pinning. End-to-end validated on `kind`; behind the `k8s` build tag. See
+  box, with the sshpiper gateway, default-deny NetworkPolicy, CSI storage, and
+  `nvidia.com/gpu` passthrough. Selected at runtime via `--runtime=k8s` (no
+  recompile). End-to-end validated on `kind`; 5-minute local bring-up in
+  [docs/KIND-QUICKSTART.md](docs/KIND-QUICKSTART.md). See also
   [docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md](docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md).
 - **Q2 2026 (in flight)**: `agent-box` MCP, `ssh-config` CLI,
   `expose-port` CLI, demo recording.

--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -10508,6 +10508,10 @@
             "type": "string"
           },
           "description": "GPU device IDs for passthrough — one entry per GPU to attach (each is a\ndevice index like \"0\"/\"1\" or a PCI address like \"0000:0b:00.0\"). Empty\nmeans no GPU. Supersedes the singular `gpu` field."
+        },
+        "storageClass": {
+          "type": "string",
+          "description": "storage_class is the K8s StorageClass for the box's data PVC (K8s\nruntime only). Empty means use the backend's cluster-wide default\n(CONTAINARIUM_K8S_STORAGE_CLASS). Ignored by the LXC backend.\nExample: \"fast-nvme\", \"standard\", \"ceph-block\"."
         }
       },
       "title": "ResourceLimits defines resource constraints for a container"

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -160,16 +160,17 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 }
 
 // CreateContainer creates a container via gRPC
-func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
+func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute) // Container creation can take time (includes ultra-aggressive retry logic for google_guest_agent)
 	defer cancel()
 
 	req := &pb.CreateContainerRequest{
 		Username: username,
 		Resources: &pb.ResourceLimits{
-			Cpu:    cpu,
-			Memory: memory,
-			Disk:   disk,
+			Cpu:          cpu,
+			Memory:       memory,
+			Disk:         disk,
+			StorageClass: storageClass,
 		},
 		SshKeys:                   sshKeys,
 		Image:                     image,

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -297,8 +297,8 @@ func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, 
 		resources["storageClass"] = storageClass
 	}
 	reqBody := map[string]interface{}{
-		"username":  username,
-		"resources": resources,
+		"username":     username,
+		"resources":    resources,
 		"sshKeys":      sshKeys,
 		"image":        image,
 		"enablePodman": enablePodman,

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -284,17 +284,21 @@ type GitSourceOpts struct {
 	WorkspacePath string // empty defaults to /workspace
 }
 
-func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
+func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
+	resources := map[string]string{
+		"cpu":    cpu,
+		"memory": memory,
+		"disk":   disk,
+	}
+	if storageClass != "" {
+		resources["storageClass"] = storageClass
+	}
 	reqBody := map[string]interface{}{
-		"username": username,
-		"resources": map[string]string{
-			"cpu":    cpu,
-			"memory": memory,
-			"disk":   disk,
-		},
+		"username":  username,
+		"resources": resources,
 		"sshKeys":      sshKeys,
 		"image":        image,
 		"enablePodman": enablePodman,

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -41,6 +41,7 @@ var (
 	createTTL                string
 	createIdleStop           string
 	createDeleteAfterStopped string
+	createStorageClass       string
 )
 
 var createCmd = &cobra.Command{
@@ -124,6 +125,7 @@ func init() {
 	createCmd.Flags().StringVar(&createTTL, "ttl", "", "Birth TTL — auto-delete the box this long after creation (Go duration: '30m', '1h', '24h'; max 168h/7 days). The death date is stamped atomically at create, so the box is reaped even if the client dies right after — no separate 'ttl set' needed (#523). Empty = no TTL.")
 	createCmd.Flags().StringVar(&createIdleStop, "idle-stop", "", "Birth idle-stop — auto-STOP the box (free CPU/RAM, keep disk; wakes on access) after this long with no activity (Go duration: '20m', '1h'). Enables auto-sleep atomically at create, so a crashed/cancelled job still releases compute — no separate 'toggle_auto_sleep' needed (#524). An active SSH/exec session counts as activity, so a box being debugged is never stopped mid-session. Empty = no auto-sleep.")
 	createCmd.Flags().StringVar(&createDeleteAfterStopped, "delete-after-stopped", "", "Birth stopped→delete — auto-DELETE the box (reclaim disk) once it has been STOPPED this long (Go duration: '6h', '24h'). The second timer of the two-phase lifecycle: pair with --idle-stop to free CPU/RAM fast, then disk after a debug window (#525). The clock resets when the box is woken, so a box you keep investigating is never reaped. Separate opt-in from --idle-stop. Empty = never delete on stop.")
+	createCmd.Flags().StringVar(&createStorageClass, "storage-class", "", "K8s StorageClass for the box's data PVC (K8s backend only). Empty = use the cluster's default StorageClass. Example: 'fast-nvme', 'standard', 'ceph-block'. Ignored on the LXC backend.")
 }
 
 // validateSSHKeyMode enforces "exactly one of --ssh-key / --no-ssh-key".
@@ -387,13 +389,13 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if httpMode && serverAddr != "" {
 		// Remote mode via HTTP
-		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
+		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, createStorageClass)
 		if err != nil {
 			return fmt.Errorf("failed to create container via HTTP API: %w", err)
 		}
 	} else if serverAddr != "" {
 		// Remote mode via gRPC
-		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
+		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, createStorageClass)
 		if err != nil {
 			return fmt.Errorf("failed to create container via remote server: %w", err)
 		}
@@ -402,7 +404,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		if verbose {
 			fmt.Println("Creating container...")
 		}
-		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevices, osType, monitoring, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
+		info, err = createLocal(username, containerImage, cpuLimit, memoryLimit, diskLimit, staticIP, sshKeys, parsedLabels, enablePodman, stackID, gpuDevices, osType, monitoring, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, createStorageClass)
 		if err != nil {
 			// Cleanup jump server account on failure
 			_ = container.DeleteJumpServerAccount(username, false)
@@ -544,7 +546,7 @@ func resolveGitSourceOpts() (client.GitSourceOpts, error) {
 }
 
 // createLocal creates a container using local Incus daemon
-func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
+func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []string, labelMap map[string]string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, _ string) (*incus.ContainerInfo, error) {
 	mgr, err := container.New()
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
@@ -633,23 +635,23 @@ func parseLabels(labelSlice []string) map[string]string {
 }
 
 // createRemote creates a container using remote gRPC server
-func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
+func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string) (*incus.ContainerInfo, error) {
 	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = grpcClient.Close() }()
 
-	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
+	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, storageClass)
 }
 
 // createRemoteHTTP creates a container using remote HTTP API
-func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64) (*incus.ContainerInfo, error) {
+func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string) (*incus.ContainerInfo, error) {
 	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = httpClient.Close() }()
 
-	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds)
+	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, storageClass)
 }

--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -383,6 +383,7 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 				0,                      // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
 				0,                      // idle-stop: runner boxes are long-lived; not auto-slept
 				0,                      // delete-after-stopped: not applicable to runner boxes
+				"",                     // storage-class: runner boxes use cluster default
 			)
 			if err != nil {
 				return "", "", err
@@ -420,6 +421,7 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 			0,                      // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
 			0,                      // idle-stop: runner boxes are long-lived; not auto-slept
 			0,                      // delete-after-stopped: not applicable to runner boxes
+			"",                     // storage-class: runner boxes use cluster default
 		)
 		if err != nil {
 			return "", "", err

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -384,6 +384,7 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		spec.Resources.CPU = req.Resources.Cpu
 		spec.Resources.Memory = req.Resources.Memory
 		spec.Resources.Disk = req.Resources.Disk
+		spec.Resources.StorageClass = req.Resources.StorageClass
 	}
 
 	// Use defaults if not specified (os_type takes precedence in manager.go)
@@ -497,9 +498,10 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 				Username: req.Username,
 				State:    pb.ContainerState_CONTAINER_STATE_CREATING,
 				Resources: &pb.ResourceLimits{
-					Cpu:    spec.Resources.CPU,
-					Memory: spec.Resources.Memory,
-					Disk:   spec.Resources.Disk,
+					Cpu:          spec.Resources.CPU,
+					Memory:       spec.Resources.Memory,
+					Disk:         spec.Resources.Disk,
+					StorageClass: spec.Resources.StorageClass,
 				},
 			},
 			Message: fmt.Sprintf("Container creation started for user %s. Poll GET /v1/containers/%s to check status.", req.Username, req.Username),
@@ -2949,9 +2951,10 @@ func toProtoContainer(st *box.BoxStatus) *pb.Container {
 		Username: st.Ref.Tenant,
 		State:    st.State,
 		Resources: &pb.ResourceLimits{
-			Cpu:    st.Resources.CPU,
-			Memory: st.Resources.Memory,
-			Disk:   st.Resources.Disk,
+			Cpu:          st.Resources.CPU,
+			Memory:       st.Resources.Memory,
+			Disk:         st.Resources.Disk,
+			StorageClass: st.Resources.StorageClass,
 		},
 		Network: &pb.NetworkInfo{
 			IpAddress: st.IPAddress,

--- a/internal/server/peer.go
+++ b/internal/server/peer.go
@@ -689,9 +689,10 @@ func (pc *PeerClient) ForwardCreateContainer(authToken string, pbReq *pb.CreateC
 				IPAddress string `json:"ipAddress"`
 			} `json:"network"`
 			Resources struct {
-				CPU    string `json:"cpu"`
-				Memory string `json:"memory"`
-				Disk   string `json:"disk"`
+				CPU          string `json:"cpu"`
+				Memory       string `json:"memory"`
+				Disk         string `json:"disk"`
+				StorageClass string `json:"storageClass"`
 			} `json:"resources"`
 		} `json:"container"`
 		Message    string `json:"message"`
@@ -710,9 +711,10 @@ func (pc *PeerClient) ForwardCreateContainer(authToken string, pbReq *pb.CreateC
 				IpAddress: data.Container.Network.IPAddress,
 			},
 			Resources: &pb.ResourceLimits{
-				Cpu:    data.Container.Resources.CPU,
-				Memory: data.Container.Resources.Memory,
-				Disk:   data.Container.Resources.Disk,
+				Cpu:          data.Container.Resources.CPU,
+				Memory:       data.Container.Resources.Memory,
+				Disk:         data.Container.Resources.Disk,
+				StorageClass: data.Container.Resources.StorageClass,
 			},
 		},
 		Message:    data.Message,

--- a/pkg/core/box/box.go
+++ b/pkg/core/box/box.go
@@ -46,6 +46,10 @@ type ResourceLimits struct {
 	CPU    string
 	Memory string
 	Disk   string
+	// StorageClass is the K8s StorageClass for the box's data PVC.
+	// Empty = use the backend's default (Config.StorageClass).
+	// Only meaningful on the K8s backend; ignored by LXC.
+	StorageClass string
 }
 
 // BoxSpec is the declarative input to Create. The backend makes a box matching

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -151,10 +151,14 @@ func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus,
 		return nil, fmt.Errorf("k8s: ensure namespace: %w", err)
 	}
 	// Provision the data PVC before the StatefulSet so the pod can mount it on
-	// first start. Skipped when StorageClass is unset (backward compat: existing
-	// deployments that don't need persistent storage keep the old behaviour).
-	if b.cfg.StorageClass != "" {
-		pvc := pvcObject(ns, tenant, b.cfg.StorageClass, spec.Resources.Disk)
+	// first start. Per-box spec.Resources.StorageClass takes precedence over the
+	// global Config.StorageClass; skipped when both are empty (backward compat).
+	storageClass := b.cfg.StorageClass
+	if spec.Resources.StorageClass != "" {
+		storageClass = spec.Resources.StorageClass
+	}
+	if storageClass != "" {
+		pvc := pvcObject(ns, tenant, storageClass, spec.Resources.Disk)
 		if _, err := b.clientset.CoreV1().PersistentVolumeClaims(ns).Create(ctx, pvc, metav1.CreateOptions{}); ignoreExists(err) != nil {
 			return nil, fmt.Errorf("k8s: ensure pvc: %w", err)
 		}
@@ -173,7 +177,7 @@ func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus,
 	if _, err := b.ensureHostKey(ctx, tenant); err != nil {
 		return nil, fmt.Errorf("k8s: ensure host key: %w", err)
 	}
-	if _, err := b.clientset.AppsV1().StatefulSets(ns).Create(ctx, statefulSetObject(ns, spec, b.cfg.StorageClass != ""), metav1.CreateOptions{}); ignoreExists(err) != nil {
+	if _, err := b.clientset.AppsV1().StatefulSets(ns).Create(ctx, statefulSetObject(ns, spec, storageClass != ""), metav1.CreateOptions{}); ignoreExists(err) != nil {
 		return nil, fmt.Errorf("k8s: ensure statefulset: %w", err)
 	}
 	// Program the SSH gateway so username=<tenant> routes to this box (no-op

--- a/pkg/core/box/k8s/k8s_test.go
+++ b/pkg/core/box/k8s/k8s_test.go
@@ -426,3 +426,55 @@ func TestPurgeRemovesPVCAndNamespace(t *testing.T) {
 		t.Errorf("Purge(missing) = %v, want nil", err)
 	}
 }
+
+// TestCreatePerBoxStorageClassOverride verifies that a per-box
+// spec.Resources.StorageClass takes precedence over the global Config.StorageClass.
+func TestCreatePerBoxStorageClassOverride(t *testing.T) {
+	b, cs := testBackendWithStorage() // Config.StorageClass = "standard"
+	ctx := context.Background()
+	ref := box.BoxRef{Tenant: "jane"}
+
+	if _, err := b.Create(ctx, box.BoxSpec{
+		Ref:   ref,
+		Image: "x",
+		Resources: box.ResourceLimits{
+			StorageClass: "fast-nvme", // per-box override
+		},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	ns := "tenant-jane"
+	pvc, err := cs.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("PVC not created: %v", err)
+	}
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != "fast-nvme" {
+		t.Errorf("StorageClassName = %v; want fast-nvme", pvc.Spec.StorageClassName)
+	}
+}
+
+// TestCreatePerBoxStorageClassEmpty verifies that an empty per-box StorageClass
+// falls back to the global Config.StorageClass.
+func TestCreatePerBoxStorageClassEmpty(t *testing.T) {
+	b, cs := testBackendWithStorage() // Config.StorageClass = "standard"
+	ctx := context.Background()
+	ref := box.BoxRef{Tenant: "ken"}
+
+	if _, err := b.Create(ctx, box.BoxSpec{
+		Ref:       ref,
+		Image:     "x",
+		Resources: box.ResourceLimits{}, // no per-box override
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	ns := "tenant-ken"
+	pvc, err := cs.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("PVC not created: %v", err)
+	}
+	if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != "standard" {
+		t.Errorf("StorageClassName = %v; want standard (global default)", pvc.Spec.StorageClassName)
+	}
+}

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -277,7 +277,12 @@ type ResourceLimits struct {
 	// GPU device IDs for passthrough — one entry per GPU to attach (each is a
 	// device index like "0"/"1" or a PCI address like "0000:0b:00.0"). Empty
 	// means no GPU. Supersedes the singular `gpu` field.
-	Gpus          []string `protobuf:"bytes,5,rep,name=gpus,proto3" json:"gpus,omitempty"`
+	Gpus []string `protobuf:"bytes,5,rep,name=gpus,proto3" json:"gpus,omitempty"`
+	// storage_class is the K8s StorageClass for the box's data PVC (K8s
+	// runtime only). Empty means use the backend's cluster-wide default
+	// (CONTAINARIUM_K8S_STORAGE_CLASS). Ignored by the LXC backend.
+	// Example: "fast-nvme", "standard", "ceph-block".
+	StorageClass  string `protobuf:"bytes,6,opt,name=storage_class,json=storageClass,proto3" json:"storage_class,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -345,6 +350,13 @@ func (x *ResourceLimits) GetGpus() []string {
 		return x.Gpus
 	}
 	return nil
+}
+
+func (x *ResourceLimits) GetStorageClass() string {
+	if x != nil {
+		return x.StorageClass
+	}
+	return ""
 }
 
 // NetworkInfo contains network configuration for a container
@@ -4393,13 +4405,14 @@ var File_containarium_v1_container_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_container_proto_rawDesc = "" +
 	"\n" +
-	"\x1fcontainarium/v1/container.proto\x12\x0fcontainarium.v1\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"t\n" +
+	"\x1fcontainarium/v1/container.proto\x12\x0fcontainarium.v1\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x99\x01\n" +
 	"\x0eResourceLimits\x12\x10\n" +
 	"\x03cpu\x18\x01 \x01(\tR\x03cpu\x12\x16\n" +
 	"\x06memory\x18\x02 \x01(\tR\x06memory\x12\x12\n" +
 	"\x04disk\x18\x03 \x01(\tR\x04disk\x12\x10\n" +
 	"\x03gpu\x18\x04 \x01(\tR\x03gpu\x12\x12\n" +
-	"\x04gpus\x18\x05 \x03(\tR\x04gpus\"\x83\x01\n" +
+	"\x04gpus\x18\x05 \x03(\tR\x04gpus\x12#\n" +
+	"\rstorage_class\x18\x06 \x01(\tR\fstorageClass\"\x83\x01\n" +
 	"\vNetworkInfo\x12\x1d\n" +
 	"\n" +
 	"ip_address\x18\x01 \x01(\tR\tipAddress\x12\x1f\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -102,6 +102,12 @@ message ResourceLimits {
   // device index like "0"/"1" or a PCI address like "0000:0b:00.0"). Empty
   // means no GPU. Supersedes the singular `gpu` field.
   repeated string gpus = 5;
+
+  // storage_class is the K8s StorageClass for the box's data PVC (K8s
+  // runtime only). Empty means use the backend's cluster-wide default
+  // (CONTAINARIUM_K8S_STORAGE_CLASS). Ignored by the LXC backend.
+  // Example: "fast-nvme", "standard", "ceph-block".
+  string storage_class = 6;
 }
 
 // NetworkInfo contains network configuration for a container

--- a/test/integration/storage_test.go
+++ b/test/integration/storage_test.go
@@ -106,6 +106,7 @@ func testCreateContainerWithQuota(t *testing.T, ctx context.Context, grpcClient 
 		0,                            // No birth TTL
 		0,                            // No idle-stop
 		0,                            // No stopped→delete
+		"",                           // No storage-class override
 	)
 	require.NoError(t, err, "Failed to create container")
 	require.NotNil(t, container)
@@ -157,6 +158,7 @@ func testQuotaEnforcement(t *testing.T, ctx context.Context, grpcClient *client.
 		0,                      // No birth TTL
 		0,                      // No idle-stop
 		0,                      // No stopped→delete
+		"",                     // No storage-class override
 	)
 	require.NoError(t, err)
 	require.NotNil(t, container)
@@ -193,11 +195,11 @@ func testMultiContainerIsolation(t *testing.T, ctx context.Context, grpcClient *
 	t.Log("Creating multiple containers to test quota isolation...")
 
 	// Create two containers with different quotas
-	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
+	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "")
 	require.NoError(t, err)
 	defer func() { _ = grpcClient.DeleteContainer(user1, true) }()
 
-	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
+	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "")
 	require.NoError(t, err)
 	defer func() { _ = grpcClient.DeleteContainer(user2, true) }()
 
@@ -223,7 +225,7 @@ func testCompression(t *testing.T, ctx context.Context, grpcClient *client.GRPCC
 
 	t.Log("Creating container to test compression...")
 
-	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
+	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "")
 	require.NoError(t, err)
 	defer func() { _ = grpcClient.DeleteContainer(username, true) }()
 
@@ -246,7 +248,7 @@ func testPrepareRebootData(t *testing.T, ctx context.Context, grpcClient *client
 	t.Logf("Creating container for persistence test: %s", username)
 
 	// Create container
-	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0)
+	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "")
 	require.NoError(t, err)
 	require.NotNil(t, container)
 


### PR DESCRIPTION
## Summary

- Add `storage_class = 6` to `ResourceLimits` proto message; regenerate `pkg/pb/` and swagger
- Add `StorageClass string` to `box.ResourceLimits` Go struct; K8s backend resolves per-box override before creating the data PVC (empty falls back to `Config.StorageClass`)
- Wire `StorageClass` end-to-end: server (request + response + `containerToProto` + peer forwarding), gRPC client, HTTP client, CLI (`--storage-class`)
- Fix `peer.go` inline JSON struct to include `storageClass` so cross-peer forwarding round-trips correctly
- Also includes two docs/README commits (agent runtime reframing)

New CLI flag:
```
containarium create alice --ssh-key ~/.ssh/id_rsa.pub --storage-class fast-nvme
```
Empty (default) = use the cluster's `default` StorageClass. Ignored on LXC backend.

## Test plan
- [ ] `go build ./...` — clean
- [ ] `go test ./internal/client/... ./internal/cmd/... ./internal/server/... ./pkg/core/box/...` — green
- [ ] `containarium create --help` shows `--storage-class` flag
- [ ] K8s box created with `--storage-class fast-nvme` provisions PVC with `storageClassName: fast-nvme`
- [ ] K8s box created without `--storage-class` uses cluster-default StorageClass

🤖 Generated with [Claude Code](https://claude.com/claude-code)