### PR TITLE
fix(recipes): harden librechat mcp-server download with retries + size check (#772)

### DIFF
--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -379,7 +379,21 @@ recipes:
       - |
         LC_MCP_MOUNTS=""
         if [ -n "${CONTAINARIUM_PARAM_MCP_SERVER_URL:-}" ] && [ -n "${CONTAINARIUM_PARAM_MCP_TOKEN:-}" ]; then
-          if curl -fsSL https://github.com/FootprintAI/Containarium/releases/latest/download/mcp-server-linux-amd64 -o /opt/lc/mcp-server 2>/dev/null; then
+          MCP_DL_URL="https://github.com/FootprintAI/Containarium/releases/latest/download/mcp-server-linux-amd64"
+          MCP_MIN_BYTES=5242880
+          MCP_DL_OK=0
+          if curl --retry 3 --retry-delay 2 --retry-all-errors -fSL -m 180 \
+               "$MCP_DL_URL" -o /opt/lc/mcp-server; then
+            ACTUAL=$(stat -c%s /opt/lc/mcp-server 2>/dev/null || echo 0)
+            if [ "$ACTUAL" -ge "$MCP_MIN_BYTES" ]; then
+              MCP_DL_OK=1
+            else
+              echo "librechat: mcp-server download truncated (${ACTUAL}B < ${MCP_MIN_BYTES}B); skipping MCP injection" >&2
+            fi
+          else
+            echo 'librechat: mcp-server download failed after retries; skipping MCP injection' >&2
+          fi
+          if [ "$MCP_DL_OK" = "1" ]; then
             chmod +x /opt/lc/mcp-server
             printf '%s' "$CONTAINARIUM_PARAM_MCP_TOKEN" > /opt/lc/ctn-token
             # Owned by the in-image 'node' user (uid 1000) with 0600. The
@@ -419,8 +433,6 @@ recipes:
             # timer (the units are written + enabled further down, after they
             # exist — this MCP step runs before them).
             printf 'SKILLS_URL=%s/v1/recipes/workspace/skills\nTOKEN_FILE=/opt/lc/ctn-token\nAPEX_HOST=%s\n' "$MCP_URL" "$APEX_HOST" > /opt/lc/skills-sync.env
-          else
-            echo 'librechat: mcp-server download failed; skipping MCP injection' >&2
           fi
         fi
       - |


### PR DESCRIPTION
Fixes #772.

## What changed

The `librechat` recipe's MCP binary download was a single no-retry `curl -fsSL … 2>/dev/null` — a transient CDN hiccup or a truncated body silently skipped the entire MCP injection, leaving a chat that works but has no platform tools.

**Before:** one attempt, errors hidden, no size check — any transient failure → silent skip
**After:**
- `--retry 3 --retry-delay 2 --retry-all-errors -m 180` — up to 3 retries on any failure (connect/DNS/HTTP error)
- Errors go to stderr (was `2>/dev/null`) so post-provision logs show what failed
- Size guard: if the downloaded file is < 5 MiB the download is treated as truncated and MCP injection is skipped with a clear message; the previous silent corruption (a ~1 KB body that passes `curl -f` with a 200 but is not a valid ELF) is now caught
- Renamed internal `MCP_DL_URL` to avoid shadowing the later `MCP_URL` (apex-resolved server URL)

## Test plan
- [ ] Fresh `librechat` deploy — MCP injection succeeds as before
- [ ] Simulate truncated download (set `MCP_MIN_BYTES` to a large value temporarily) — skip message appears in post_start log, chat still starts
- [ ] Verify `mcp-server` binary is functional: `containarium connect` inside the box succeeds, `list_containers` tool is available in LibreChat

🤖 Generated with [Claude Code](https://claude.com/claude-code)