### PR TITLE
fix(keysync,daemon): reap orphaned host users + sshpiper dirs (#835)

### DIFF
--- a/internal/gateway/keys_handler.go
+++ b/internal/gateway/keys_handler.go
@@ -59,6 +59,7 @@ func ServeAuthorizedKeys(homeRoot string, containerExistsFn func(username string
 		}
 
 		var keys []UserKeys
+		orphanCount := 0
 		for _, entry := range entries {
 			if !entry.IsDir() {
 				continue
@@ -78,13 +79,16 @@ func ServeAuthorizedKeys(homeRoot string, containerExistsFn func(username string
 				continue
 			}
 			if containerExistsFn != nil && !containerExistsFn(username) {
-				log.Printf("[keys] WARNING: orphan authorized_keys for %q — no live container; skipping (run `containarium delete %s` or `userdel -r %s` to clean up)", username, username, username)
+				orphanCount++
 				continue
 			}
 			keys = append(keys, UserKeys{
 				Username:       username,
 				AuthorizedKeys: content,
 			})
+		}
+		if orphanCount > 0 {
+			log.Printf("[keys] WARNING: %d orphan authorized_keys found (no live container); orphan-reaper will clean up on next tick", orphanCount)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/sentinel/keysync.go
+++ b/internal/sentinel/keysync.go
@@ -160,7 +160,9 @@ func (ks *KeyStore) Apply() error {
 	}
 
 	// Write per-user authorized_keys
+	liveUsers := make(map[string]bool, len(routes))
 	for _, r := range routes {
+		liveUsers[r.username] = true
 		userDir := filepath.Join(sshpiperUsersDir, r.username)
 		if err := os.MkdirAll(userDir, 0755); err != nil { // #nosec G301 -- sshpiper requires world-readable user dirs
 			log.Printf("[keysync] failed to create dir for %s: %v", r.username, err)
@@ -174,6 +176,28 @@ func (ks *KeyStore) Apply() error {
 			log.Printf("[keysync] failed to write authorized_keys for %s: %v", r.username, err)
 			continue
 		}
+	}
+
+	// Prune sshpiper user dirs for containers that no longer exist (#835).
+	// The sentinel accumulates one dir per historical container; without this
+	// step the directory grows without bound and keysync's O(dirs) work
+	// widens the first-connect race window.
+	pruned := 0
+	if entries, err := os.ReadDir(sshpiperUsersDir); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() || liveUsers[e.Name()] {
+				continue
+			}
+			stale := filepath.Join(sshpiperUsersDir, e.Name())
+			if rmErr := os.RemoveAll(stale); rmErr != nil {
+				log.Printf("[keysync] failed to prune stale sshpiper dir %s: %v", stale, rmErr)
+			} else {
+				pruned++
+			}
+		}
+	}
+	if pruned > 0 {
+		log.Printf("[keysync] pruned %d stale sshpiper user dirs", pruned)
 	}
 
 	// Generate sshpiper YAML config with per-user backend routing

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1904,6 +1904,19 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		ds.ttlSweeperManager.Start(ctx)
 	}
 
+	// Orphan reaper (#835): periodically userdel host accounts whose
+	// container no longer exists. userdel -r on container delete can fail
+	// under lock contention (google-guest-agent race on GCP), leaving stale
+	// /home/<user> dirs that flood keysync with per-orphan WARNINGs and
+	// widen the #830 first-connect race window.
+	if ds.containerServer != nil {
+		if mgr := ds.containerServer.GetManager(); mgr != nil {
+			go container.RunOrphanReaper(ctx, func(username string) bool {
+				return mgr.ContainerExists(username + "-container")
+			})
+		}
+	}
+
 	// Phase 4.3 Phase B-3 — file-mode secret reconciler.
 	// Periodically re-stamps tmpfs secrets on running
 	// containers so a bare `incus restart` not routed

--- a/pkg/core/container/orphan_reaper.go
+++ b/pkg/core/container/orphan_reaper.go
@@ -1,0 +1,93 @@
+package container
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	orphanReaperInterval  = 5 * time.Minute
+	orphanReaperHomeRoot  = "/home"
+	orphanReaperGracePeriod = 30 * time.Second // delay before first sweep to avoid racing startup
+)
+
+// RunOrphanReaper periodically removes host-user accounts whose container no
+// longer exists.  A deleted container whose `userdel -r` failed (lock
+// contention with google-guest-agent on GCP) leaves a stale `/home/<user>`
+// dir with an authorized_keys.  ServeAuthorizedKeys already filters these
+// from the keysync response, but without cleanup the dirs accumulate and the
+// O(orphans) walk + ssh-keygen per tick widens the #830 first-connect race.
+//
+// containerExistsFn returns true when a live container exists for username.
+// Blocks until ctx is cancelled.
+func RunOrphanReaper(ctx context.Context, containerExistsFn func(username string) bool) {
+	RunOrphanReaperWithRoot(ctx, orphanReaperHomeRoot, containerExistsFn)
+}
+
+// RunOrphanReaperWithRoot is the testable variant that accepts an explicit homeRoot.
+func RunOrphanReaperWithRoot(ctx context.Context, homeRoot string, containerExistsFn func(username string) bool) {
+	// Grace period: let the daemon finish startup before first sweep.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(orphanReaperGracePeriod):
+	}
+
+	reapOnce(homeRoot, containerExistsFn)
+
+	ticker := time.NewTicker(orphanReaperInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			reapOnce(homeRoot, containerExistsFn)
+		}
+	}
+}
+
+func reapOnce(homeRoot string, containerExistsFn func(username string) bool) {
+	entries, err := os.ReadDir(homeRoot)
+	if err != nil {
+		log.Printf("[orphan-reaper] failed to read %s: %v", homeRoot, err)
+		return
+	}
+
+	var orphans []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		username := e.Name()
+		akPath := filepath.Join(homeRoot, username, ".ssh", "authorized_keys")
+		if _, statErr := os.Stat(akPath); os.IsNotExist(statErr) {
+			continue // no authorized_keys → not a containarium user
+		}
+		if containerExistsFn(username) {
+			continue
+		}
+		orphans = append(orphans, username)
+	}
+
+	if len(orphans) == 0 {
+		return
+	}
+
+	log.Printf("[orphan-reaper] found %d orphaned host accounts; reaping", len(orphans))
+	reaped, failed := 0, 0
+	for _, username := range orphans {
+		if err := DeleteJumpServerAccount(username, false); err != nil {
+			log.Printf("[orphan-reaper] userdel %s failed: %v", username, err)
+			failed++
+		} else {
+			reaped++
+		}
+	}
+	if reaped > 0 || failed > 0 {
+		log.Printf("[orphan-reaper] reaped=%d failed=%d (failed entries retry next tick)", reaped, failed)
+	}
+}


### PR DESCRIPTION
Fixes #835 — 683 stale `/home/<user>` dirs and 1296 stale `/etc/sshpiper/users/<user>/` dirs accumulating without bound, flooding the journal with per-orphan WARNINGs every ~2 min and widening the #830 first-connect race.

## Root cause

`userdel -r` on container delete succeeds most of the time but fails under lock contention (google-guest-agent racing `/etc/passwd` on GCP). The orphaned home dir + authorized_keys survive and `ServeAuthorizedKeys` correctly filters them — but neither the sentinel keysync nor the backend have ever cleaned them up.

## Fix — three parts

**1. Sentinel sshpiper reaper** (`internal/sentinel/keysync.go`)  
After writing live users to `/etc/sshpiper/users/`, `Apply()` now scans the directory and removes any subdir not in the current live-user set. On the next keysync tick after deploy, the ~1296 stale dirs are pruned in one pass.

**2. Backend orphan reaper** (`pkg/core/container/orphan_reaper.go`, `internal/server/dual_server.go`)  
New `RunOrphanReaper()` goroutine started alongside the TTL sweeper. Every 5 min it walks `/home/`, finds dirs with an `authorized_keys` but no live container, and calls `DeleteJumpServerAccount` (which already uses `waitForLocksAndRun` / google-guest-agent stop-dance to handle GCP lock contention). 30s grace period avoids racing daemon startup. Failed reapers retry next tick.

**3. Rate-limit orphan WARNINGs** (`internal/gateway/keys_handler.go`)  
Collapses 683 per-orphan `log.Printf` calls per keysync tick into a single count-per-request summary line. The reaper drives the count toward zero; until then the journal gets one line, not hundreds.

## Test plan
- [ ] `go test ./pkg/core/container/... ./internal/sentinel/... ./internal/gateway/...` passes (CI gate)
- [ ] After deploy on a backend with stale dirs: orphan-reaper log line shows `found N orphaned host accounts; reaping` followed by `reaped=N failed=0` within 5 min
- [ ] After deploy on the sentinel: keysync log shows `pruned N stale sshpiper user dirs` on first apply
- [ ] `ServeAuthorizedKeys` journal: single `WARNING: N orphan authorized_keys found` line per tick instead of per-orphan lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)