### PR TITLE
fix(sentinel): TCP keepalives on upstream conns + SSH -R/-L docs (#769, #808)

### DIFF
--- a/docs/SSH-JUMP-SERVER-SETUP.md
+++ b/docs/SSH-JUMP-SERVER-SETUP.md
@@ -434,6 +434,38 @@ EOF
 
 ---
 
+## Known Limitations
+
+### SSH `-R`/`-L` port-forwards bind in the host network namespace, not the box
+
+When you open a port-forward against a box (`ssh -R`/`-L`), the tunnel endpoint lives in the **host** network namespace on the jump server — not inside the box. This is a direct consequence of how sshpiper works: the SSH transport terminates on the host sshd, which then executes `containarium-shell` to proxy commands into the box via `incus exec`. The forwarded socket is opened before the `incus exec` hand-off, so it never enters the box's network namespace.
+
+**What this means in practice:**
+
+- `ssh -R 1080 user@host` creates a listener at `host:127.0.0.1:1080`. A process **inside the box** cannot reach that listener because the box's `127.0.0.1` is a separate network namespace.
+- `ssh -L 8080:localhost:80 user@host` similarly binds on your **local** machine, but the tunnel's upstream (`localhost:80`) is resolved in the host netns, not the box's.
+
+**Recommended workaround — initiate the tunnel from inside the box:**
+
+Instead of forwarding a port *to* the box, run the SSH client *from* inside the box so the listener is created in the right network namespace:
+
+```bash
+# 1. SSH into the box normally
+ssh <username>@<sentinel-host>
+
+# 2. From inside the box, establish a SOCKS or local-forward tunnel
+#    outbound to your workstation (which runs a SOCKS server or target port):
+ssh -fN -L 1080:127.0.0.1:1080 <you>@<your-workstation>
+
+# 3. Any process inside the box can now use socks5://127.0.0.1:1080
+```
+
+This is safe for multi-tenant deployments: the listener binds inside the box's netns and is not reachable by other tenants.
+
+> **Note:** There is no single-command solution today for "create an in-box listener reachable inside the box from an outside SSH session" — this requires a design change to run an sshd inside each box. See [issue #808](https://github.com/FootprintAI/Containarium/issues/808) for discussion.
+
+---
+
 ## Best Practices
 
 1. **Use SSH ProxyJump** instead of port forwarding for better security

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -29,6 +29,12 @@ const (
 	StateMaintenance State = "maintenance"
 )
 
+// sentinelDialer is used for all sentinel→backend TCP dials. The 15s
+// KeepAlive causes the OS to probe idle connections so a hard-reset
+// backend (no TCP RST sent) is detected within ~45 s instead of
+// never, preventing goroutine/FD leaks from stuck io.Copy pairs (#769).
+var sentinelDialer = &net.Dialer{Timeout: 5 * time.Second, KeepAlive: 15 * time.Second}
+
 // Config holds the sentinel configuration.
 type Config struct {
 	HealthPort         int
@@ -878,13 +884,13 @@ func (m *Manager) buildSNIRoutingHandler(fallbackTarget string) func(net.Conn) {
 				} else {
 					// In-VPC primary: TCP dial.
 					target := net.JoinHostPort(p.IP, fmt.Sprintf("%d", p.Port))
-					dst, err = net.DialTimeout("tcp", target, 5*time.Second)
+					dst, err = sentinelDialer.Dial("tcp", target)
 				}
 			}
 		}
 		if dst == nil {
 			// No primary match (or yamux/TCP failed): fall back.
-			dst, err = net.DialTimeout("tcp", fallbackTarget, 5*time.Second)
+			dst, err = sentinelDialer.Dial("tcp", fallbackTarget)
 		}
 		if err != nil || dst == nil {
 			return

--- a/internal/sentinel/tunnel_mux.go
+++ b/internal/sentinel/tunnel_mux.go
@@ -235,7 +235,7 @@ func (hp *HTTPSProxy) Serve(ln net.Listener) error {
 func (hp *HTTPSProxy) proxy(src net.Conn) {
 	defer func() { _ = src.Close() }()
 
-	dst, err := net.DialTimeout("tcp", hp.target, 5*time.Second)
+	dst, err := sentinelDialer.Dial("tcp", hp.target)
 	if err != nil {
 		log.Printf("[https-proxy] failed to connect to %s: %v", hp.target, err)
 		return

--- a/internal/sentinel/userspace_forwarder.go
+++ b/internal/sentinel/userspace_forwarder.go
@@ -37,7 +37,11 @@ type userspaceForwarder struct {
 // once with the backend address and ports to serve.
 func newUserspaceForwarder(emitProxyV2 bool) *userspaceForwarder {
 	return &userspaceForwarder{
-		dialer:    &net.Dialer{Timeout: 5 * time.Second},
+		// KeepAlive detects dead backend connections (e.g. a same-IP hard
+		// reboot where the kernel resets the TCP stack without sending RSTs).
+		// Without it, stale io.Copy goroutine pairs accumulate without bound
+		// and can exhaust the sentinel's FDs / goroutines (#769).
+		dialer:    &net.Dialer{Timeout: 5 * time.Second, KeepAlive: 15 * time.Second},
 		emitProxy: emitProxyV2,
 	}
 }


### PR DESCRIPTION
## #769 — sentinel forwarder goroutine leak on hard-reset backend reboot

A `gcloud compute instances reset` (hard reboot) resets the backend's TCP stack without sending RSTs. Without TCP keepalives, every in-flight forwarded connection leaves two `io.Copy` goroutines blocked indefinitely on the dead upstream, accumulating FDs + goroutines. On an e2-micro sentinel (1 vCPU, 1 GB RAM) this exhausted resources and froze the VM.

**Fix:** set `KeepAlive: 15s` on the sentinel→backend dialer in all three forwarding paths:

| File | Path |
|------|------|
| `userspace_forwarder.go` | `userspaceForwarder` (single GCP spot VM mode) |
| `manager.go` | `buildSNIRoutingHandler` in-VPC TCP fall-through |
| `tunnel_mux.go` | `HTTPSProxy.proxy()` |

With Linux defaults, 15 s keepalive idle + 3 probes × 15 s = ~60 s to detect a dead backend and unblock `io.Copy`. Also introduces a shared `sentinelDialer` so the dial config lives in one place.

New connections re-dial fresh every time (already the case), so recovery after the backend is back up is instant regardless of keepalive.

## #808 — SSH `-R`/`-L` port-forwards land in host netns, not the box

Documents the known limitation and the recommended workaround (initiate the tunnel from **inside** the box) in `docs/SSH-JUMP-SERVER-SETUP.md`. The failure mode is opaque — users see no listener inside the box and don't know why.

## Test plan
- [ ] `go test ./internal/sentinel/...` passes (CI gate)
- [ ] On a backend with active connections: `gcloud compute instances reset <backend>` — confirm forwarder goroutines drain within ~60 s (logs: connection reset / EOF) rather than leaking indefinitely
- [ ] After reset, new connections to the apex succeed once the backend is back

🤖 Generated with [Claude Code](https://claude.com/claude-code)