### PR TITLE
style: gofmt fixes (autoupdate, watchdog test, orphan_reaper)

### DIFF
--- a/internal/server/autoupdate.go
+++ b/internal/server/autoupdate.go
@@ -18,9 +18,9 @@ import (
 // AutoUpdater periodically checks the sentinel for a newer binary and
 // self-updates if a new version is available.
 type AutoUpdater struct {
-	sentinelURL     string // e.g. "http://10.130.0.13:8888"
-	binaryPath      string // e.g. "/usr/local/bin/containarium"
-	interval        time.Duration
+	sentinelURL       string // e.g. "http://10.130.0.13:8888"
+	binaryPath        string // e.g. "/usr/local/bin/containarium"
+	interval          time.Duration
 	watchdogHealthURL string // polled by upgrade-watchdog to confirm liveness (#507); defaults to http://localhost:8080/health
 }
 

--- a/internal/server/autoupdate_watchdog_test.go
+++ b/internal/server/autoupdate_watchdog_test.go
@@ -87,7 +87,7 @@ func TestWatchdogHealthy(t *testing.T) {
 
 	err := RunUpgradeWatchdog(binaryPath, srv.URL+"/health",
 		10*time.Second,
-		0,               // no initial delay
+		0, // no initial delay
 		200*time.Millisecond,
 		true,
 	)

--- a/pkg/core/container/orphan_reaper.go
+++ b/pkg/core/container/orphan_reaper.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	orphanReaperInterval  = 5 * time.Minute
-	orphanReaperHomeRoot  = "/home"
+	orphanReaperInterval    = 5 * time.Minute
+	orphanReaperHomeRoot    = "/home"
 	orphanReaperGracePeriod = 30 * time.Second // delay before first sweep to avoid racing startup
 )
 


### PR DESCRIPTION
## Summary

- Fixes three `gofmt` formatting issues flagged by golangci-lint after the recent merges (#865, #861):
  - `internal/server/autoupdate.go` — align struct field spacing in `AutoUpdater`
  - `internal/server/autoupdate_watchdog_test.go` — remove trailing space in arg list
  - `pkg/core/container/orphan_reaper.go` — align constant block spacing

No logic changes.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/server/ -run TestWatchdog` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)