### PR TITLE
fix(recipes): auto-attach MCP tools via ephemeralAgent.mcp on custom endpoint (#773)

### DIFF
--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/footprintai/containarium/internal/alert"
 	"github.com/footprintai/containarium/internal/app"
+	"github.com/footprintai/containarium/internal/audit"
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/capabilities"
 	"github.com/footprintai/containarium/internal/capacity"
@@ -169,6 +170,11 @@ type ContainerServer struct {
 	// Empty (direct mode / no sentinel) leaves ssh_host empty and clients fall
 	// back to network.ip_address.
 	sshHost string
+
+	// auditStore records admin-initiated operations (TriggerUpgrade, etc.).
+	// Nil on daemons without a Postgres pool; nil is safe (ops are logged but
+	// not persisted). #354.
+	auditStore *audit.Store
 
 	// autoUpdater drives on-demand daemon upgrades (TriggerUpgrade). Nil on
 	// daemons started without an auto-update source (e.g. no sentinel), in
@@ -2018,6 +2024,7 @@ func (s *ContainerServer) TriggerUpgrade(ctx context.Context, req *pb.TriggerUpg
 
 	subject, _, _ := auth.SubjectFromGRPCContext(ctx)
 	log.Printf("[upgrade] triggered by %q on backend %q (from %s, force=%v, job=%s)", subject, backendKey, current, req.Force, id)
+	s.logUpgradeAudit(ctx, subject, backendKey, id, "triggered", "")
 
 	// Run async: TriggerNow restarts the daemon on a successful swap, so neither
 	// this goroutine nor the in-memory job survives a local upgrade. We still
@@ -2036,11 +2043,16 @@ func (s *ContainerServer) TriggerUpgrade(ctx context.Context, req *pb.TriggerUpg
 			job.errMsg = err.Error()
 			job.completedAt = time.Now().UTC().Format(time.RFC3339)
 			log.Printf("[upgrade] job %s failed: %v", id, err)
+			s.logUpgradeAudit(upgradeCtx, subject, backendKey, id, "failed", err.Error())
 		case !changed:
 			job.status = "noop"
 			job.completedAt = time.Now().UTC().Format(time.RFC3339)
+			s.logUpgradeAudit(upgradeCtx, subject, backendKey, id, "noop", "")
 		default:
-			// changed: restart imminent; leave status "in_progress".
+			// changed: restart imminent; daemon will not record "completed" since
+			// it is about to die. The post-restart version in ListBackends is the
+			// canonical confirmation.
+			s.logUpgradeAudit(upgradeCtx, subject, backendKey, id, "binary_swapped", "")
 		}
 	}()
 
@@ -3065,6 +3077,39 @@ func sshCommandFor(username, sshHost, ip string) string {
 // returning Unavailable. #354.
 func (s *ContainerServer) SetAutoUpdater(u *AutoUpdater) {
 	s.autoUpdater = u
+}
+
+// SetAuditStore wires the audit store so admin-initiated operations like
+// TriggerUpgrade are persisted. Nil is safe — ops are still log.Printf'd.
+func (s *ContainerServer) SetAuditStore(store *audit.Store) {
+	s.auditStore = store
+}
+
+// logUpgradeAudit records a TriggerUpgrade outcome. Best-effort — audit must
+// never fail the call. No-op until the audit store is wired.
+func (s *ContainerServer) logUpgradeAudit(ctx context.Context, subject, backendID, upgradeID, outcome, detail string) {
+	if s.auditStore == nil {
+		return
+	}
+	username := subject
+	if username == "" {
+		username = "_unknown"
+	}
+	payload, _ := json.Marshal(map[string]string{
+		"upgrade_id": upgradeID,
+		"backend_id": backendID,
+		"outcome":    outcome,
+		"detail":     detail,
+	})
+	if err := s.auditStore.Log(ctx, &audit.AuditEntry{
+		Username:     username,
+		Action:       "backend.upgrade",
+		ResourceType: "backend",
+		ResourceID:   backendID,
+		Detail:       string(payload),
+	}); err != nil {
+		log.Printf("[upgrade] audit %s/%s: %v", upgradeID, outcome, err)
+	}
 }
 
 // SetOTelCollectorEndpoint wires the OTLP/HTTP URL of this daemon's

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1421,6 +1421,8 @@ skipAppHosting:
 			gatewayServer.SetAuditStore(auditStore)
 			// Agent-skill service logs A2A hops under a trace id (Phase 2 / #575).
 			agentSkillServer.SetAuditStore(auditStore)
+			// Container server logs admin-initiated upgrade operations (#354).
+			containerServer.SetAuditStore(auditStore)
 		}
 
 		// Wire Grafana reverse proxy if VictoriaMetrics is configured

--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -470,59 +470,6 @@ recipes:
         curl -fsS -A "$UA" -X POST http://127.0.0.1:3080/api/auth/register -H 'Content-Type: application/json' \
           -d "{\"name\":\"$CONTAINARIUM_PARAM_AUTH_NAME\",\"username\":\"$LC_USER\",\"email\":\"$CONTAINARIUM_PARAM_AUTH_EMAIL\",\"password\":\"$CONTAINARIUM_PARAM_AUTH_PASSWORD\",\"confirm_password\":\"$CONTAINARIUM_PARAM_AUTH_PASSWORD\"}" \
           >/dev/null 2>&1 || echo 'librechat: owner register failed (may already exist)' >&2
-      # Tool-equipped agent: custom endpoints don't expose MCP tools — only the
-      # agents endpoint does. When the MCP is wired, create an agent carrying the
-      # MCP tools so the default workspace spec (agents endpoint) can CALL platform
-      # tools. Its id (→ /opt/lc/agent-id) makes gen_modelspecs.py emit the
-      # agents-endpoint default spec. Written to a FILE so the logic is reusable;
-      # best-effort — no agent → gen falls back to the chat-only custom spec.
-      - |
-        cat > /opt/lc/create_agent.py <<'PYEOF'
-        import sys, json, urllib.request, time
-        LC = "http://127.0.0.1:3080"
-        UA = "Mozilla/5.0 (X11; Linux x86_64) Chrome/120 Safari/537.36"
-        tok = sys.argv[1]
-        def req(path, data=None):
-            h = {"Content-Type": "application/json", "User-Agent": UA, "Authorization": "Bearer " + tok}
-            r = urllib.request.Request(LC + path, data=(json.dumps(data).encode() if data is not None else None), headers=h, method=("POST" if data is not None else "GET"))
-            with urllib.request.urlopen(r, timeout=30) as resp:
-                return resp.read().decode()
-        keys = []
-        for _ in range(20):
-            try:
-                j = json.loads(req("/api/mcp/tools"))
-                keys = [t["pluginKey"] for t in j.get("servers", {}).get("containarium", {}).get("tools", [])]
-            except Exception:
-                keys = []
-            if keys:
-                break
-            time.sleep(3)
-        if not keys:
-            sys.exit(0)
-        instr = ("You are the Containarium workspace assistant. You manage the user's "
-                 "Containarium boxes using the provided tools. When the user asks to list, "
-                 "create, expose, deploy, resize, or delete boxes, CALL the appropriate tool "
-                 "instead of giving generic shell instructions. After a tool returns, "
-                 "summarize the result clearly. Be concise.")
-        body = {"name": "Containarium Workspace", "description": "Manages your Containarium boxes",
-                "provider": "Containarium (Gemini)", "model": "gemini-2.5-flash-lite",
-                "instructions": instr, "tools": keys}
-        try:
-            print(json.loads(req("/api/agents", body)).get("id", ""))
-        except Exception:
-            pass
-        PYEOF
-      - |
-        if [ -f /opt/lc/mcp-server ] && [ -f /opt/lc/ctn-token ] && [ -n "${CONTAINARIUM_MODEL_GATEWAY_URL:-}" ]; then
-          UA="Mozilla/5.0 (X11; Linux x86_64) Chrome/120 Safari/537.36"
-          ATOK=$(curl -fsS -A "$UA" -X POST http://127.0.0.1:3080/api/auth/login -H 'Content-Type: application/json' \
-            -d "{\"email\":\"$CONTAINARIUM_PARAM_AUTH_EMAIL\",\"password\":\"$CONTAINARIUM_PARAM_AUTH_PASSWORD\"}" 2>/dev/null \
-            | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null || true)
-          if [ -n "$ATOK" ]; then
-            AID=$(python3 /opt/lc/create_agent.py "$ATOK" 2>/dev/null | tail -1 || true)
-            if [ -n "$AID" ]; then printf '%s' "$AID" > /opt/lc/agent-id; echo "librechat: created tool agent $AID" >&2; fi
-          fi
-        fi
       # Model-specs = SKILLS as hidden personas. Each installed skill becomes a
       # model-spec the user picks BY NAME in LibreChat's selector; the whole
       # conversation then runs under that skill's `promptPrefix` (its hidden
@@ -532,25 +479,23 @@ recipes:
       # builder; a model-spec promptPrefix does not). A default "Containarium
       # Workspace" general assistant is always present and is the default pick.
       #
-      # The DEFAULT "Containarium Workspace" spec targets the AGENTS endpoint
-      # (preset endpoint:"agents" + agent_id) when the MCP is wired — that is the
-      # ONLY endpoint that exposes the MCP tools, so the chat can actually CALL
-      # platform tools (list/create/expose/delete boxes). The tool-equipped agent
-      # is created in post_start (above) and its id drives gen_modelspecs.py; the
-      # SPA submits the spec's exact preset, so it matches. Skill personas stay on
-      # the custom endpoint (chat-only, advisory — no tools); with no MCP/agent
-      # the default also falls back to custom. Skills come from the `skills` param (JSON, the cloud
-      # injects the org's installed set). Built with python3 so multi-line
-      # SKILL.md prompts serialize safely (json.dumps → valid YAML scalars).
-      # Needs the gateway; emits nothing without it (LibreChat falls back).
-      # The model-spec generator is written to a FILE (not run inline) so the
-      # live-sync timer below can re-run it on the same logic. It reads a skills
-      # JSON on stdin — either a bare array or a {"skills":[...]} object (the
-      # cloud's /v1/recipes/workspace/skills shape) — and emits the modelSpecs
-      # YAML (json.dumps → safe scalars for multi-line SKILL.md prompts).
+      # The DEFAULT "Containarium Workspace" spec uses the CUSTOM endpoint with
+      # ephemeralAgent.mcp: ["containarium"] when MCP is wired (#773). This
+      # auto-attaches the in-box MCP tools without routing through the agents
+      # endpoint (which enforced specs don't reach — #771). Skill personas stay on
+      # the custom endpoint (chat-only, advisory — no tools); with no MCP the
+      # default also uses the custom endpoint with no tools. Skills come from the
+      # `skills` param (JSON, the cloud injects the org's installed set). Built
+      # with python3 so multi-line SKILL.md prompts serialize safely
+      # (json.dumps → valid YAML scalars). Needs the gateway; emits nothing without
+      # it (LibreChat falls back). The model-spec generator is written to a FILE
+      # (not run inline) so the live-sync timer below can re-run it on the same
+      # logic. It reads a skills JSON on stdin — either a bare array or a
+      # {"skills":[...]} object (the cloud's /v1/recipes/workspace/skills shape) —
+      # and emits the modelSpecs YAML.
       - |
         cat > /opt/lc/gen_modelspecs.py <<'PYEOF'
-        import json, sys
+        import json, sys, os
         DEFAULT = ("You are the Containarium workspace assistant. Help the user with "
                    "software development, DevOps, system design, and general technical "
                    "questions. Be concise and helpful. If you genuinely should not do "
@@ -563,10 +508,7 @@ recipes:
                 skills = []
         except Exception:
             skills = []
-        try:
-            AGENT_ID = open("/opt/lc/agent-id").read().strip()
-        except Exception:
-            AGENT_ID = ""
+        MCP_WIRED = os.path.exists("/opt/lc/mcp-server")
         def slug(name):
             s = "".join(c.lower() if c.isalnum() else "-" for c in name).strip("-")
             while "--" in s:
@@ -593,24 +535,21 @@ recipes:
             out.append("      label: " + json.dumps(label))
             out.append("      default: " + ("true" if dflt else "false"))
             out.append("      preset:")
-            if dflt and AGENT_ID:
-                # Tool-equipped default: only the agents endpoint exposes the MCP
-                # tools (custom endpoints don't). The agent (created in post_start)
-                # carries the instructions + the tools; the spec just selects it.
-                out.append('        endpoint: "agents"')
-                out.append("        agent_id: " + json.dumps(AGENT_ID))
-                # gemini-2.5-flash-lite, NOT gemini-flash-latest: the 2.5 thinking
-                # model demands a thought_signature be echoed on every tool-result
-                # round-trip (OpenAI-compat), which LangChain/LibreChat can't carry,
-                # so multi-turn tool calls 400 ("missing thought_signature"). The
-                # lite (non-thinking) model uses standard function-calling that
-                # round-trips cleanly.
+            out.append('        endpoint: "Containarium (Gemini)"')
+            out.append('        endpointType: "custom"')
+            if dflt and MCP_WIRED:
+                # Tool-equipped default: custom endpoint + ephemeralAgent.mcp
+                # auto-attaches the in-box MCP server without the agents endpoint
+                # (enforced specs don't route there — #773). gemini-2.5-flash-lite
+                # uses standard function-calling; the thinking model requires a
+                # thought_signature echo that LibreChat can't carry (#771).
                 out.append('        model: "gemini-2.5-flash-lite"')
+                out.append("        promptPrefix: " + json.dumps(instr))
+                out.append('        ephemeralAgent:')
+                out.append('          mcp:')
+                out.append('            - "containarium"')
             else:
-                # Chat-only persona (skills) or no-MCP fallback: custom endpoint,
-                # prompt carried by the spec. No tools on this path.
-                out.append('        endpoint: "Containarium (Gemini)"')
-                out.append('        endpointType: "custom"')
+                # Chat-only persona (skills) or no-MCP fallback.
                 out.append('        model: "gemini-flash-latest"')
                 out.append("        promptPrefix: " + json.dumps(instr))
         print("\n".join(out))


### PR DESCRIPTION
## Summary

- Switches the default "Containarium Workspace" model-spec from `endpoint: "agents"` + `agent_id` to the custom endpoint + `ephemeralAgent.mcp: ["containarium"]`
- `ephemeralAgent.mcp` attaches the in-box MCP server to conversations without routing through the agents endpoint (which enforced specs don't reach — #771)
- Trigger changes from "agent-id file exists" → "mcp-server binary present", so MCP wires automatically on any workspace with the binary installed
- Removes the now-orphaned `create_agent.py` generation + execution block (~60 lines)
- `gemini-2.5-flash-lite` retained for the tool-equipped path (the thinking model needs a `thought_signature` echo that LibreChat can't carry — #771)

## What the emitted YAML looks like when MCP is wired

```yaml
modelSpecs:
  enforce: true
  prioritize: true
  list:
    - name: "containarium-workspace"
      label: "Containarium Workspace"
      default: true
      preset:
        endpoint: "Containarium (Gemini)"
        endpointType: "custom"
        model: "gemini-2.5-flash-lite"
        promptPrefix: "You are the Containarium workspace assistant..."
        ephemeralAgent:
          mcp:
            - "containarium"
```

## Test plan

- [ ] CI green
- [ ] Deploy a workspace box with MCP wired — confirm default chat opens with Containarium tools available in the tool picker without manual toggle
- [ ] Deploy a workspace box without MCP — confirm default chat opens cleanly (no tools, no error)
- [ ] Skill personas still work (custom endpoint, no `ephemeralAgent`)

**Note:** `ephemeralAgent.mcp` behaviour is LibreChat-version-dependent — needs live validation on the deployed image tag before closing #773.

Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)