### PR TITLE
fix(recipes): make librechat auth_password optional (#667)

### DIFF
--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -310,9 +310,8 @@ recipes:
         default: Admin
       - name: auth_password
         label: Owner password
-        description: Password for the workspace owner login. Required — the box is never left open.
+        description: Password for the workspace owner login. If not supplied, the cloud control plane generates a strong random password and returns it in the deploy response (shown once in the webui). Never left open.
         type: password
-        required: true
       - name: librechat_version
         label: LibreChat image tag
         description: LibreChat image tag to run (pin for reproducibility).


### PR DESCRIPTION
## Summary

- Removes `required: true` from the librechat recipe's `auth_password` parameter
- The cloud control plane already generates a strong random password when none is supplied (cloud PR #699/v0.1.74); the daemon-level rejection was the only thing blocking optional passwords
- Updated the parameter description to explain the auto-generation behavior

## Paired with
Cloud: [fix/667-return-generated-password] — returns the generated password in the deploy response + shows it once in the webui

🤖 Generated with [Claude Code](https://claude.com/claude-code)