### PR TITLE
refactor(config): migrate the NETWORK namespace into internal/config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,11 @@
 // remaining inline os.Getenv calls do — values cannot diverge.
 package config
 
-import "os"
+import (
+	"os"
+	"strconv"
+	"strings"
+)
 
 // getString returns the value of the environment variable key, or def when it
 // is unset or empty. It is the building block Load<Namespace>() functions use so
@@ -27,6 +31,30 @@ import "os"
 func getString(key, def string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
+	}
+	return def
+}
+
+// getBool reports whether the environment variable key is set to a truthy value
+// ("1", "true", "yes", "on", case-insensitive). Anything else — including unset
+// — is false. This is a superset of the historical `== "1"` convention, so
+// existing "1" settings keep working.
+func getBool(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// getInt returns the integer value of the environment variable key, or def when
+// it is unset or not a valid integer.
+func getInt(key string, def int) int {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
 	}
 	return def
 }

--- a/internal/config/k8s.go
+++ b/internal/config/k8s.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"fmt"
+)
+
+// CONTAINARIUM_K8S_* variable names — the single source of truth for the
+// Kubernetes-backend namespace. Reference these instead of string literals.
+const (
+	EnvK8sKubeconfig               = "CONTAINARIUM_K8S_KUBECONFIG"
+	EnvK8sGatewayNamespace         = "CONTAINARIUM_K8S_GATEWAY_NAMESPACE"
+	EnvK8sGatewayHost              = "CONTAINARIUM_K8S_GATEWAY_HOST"
+	EnvK8sGatewaySSHPort           = "CONTAINARIUM_K8S_GATEWAY_SSH_PORT"
+	EnvK8sTenantNSPrefix           = "CONTAINARIUM_K8S_TENANT_NS_PREFIX"
+	EnvK8sBoxImage                 = "CONTAINARIUM_K8S_BOX_IMAGE"
+	EnvK8sStorageClass             = "CONTAINARIUM_K8S_STORAGE_CLASS"
+	EnvK8sGatewayUpstreamPublicKey = "CONTAINARIUM_K8S_GATEWAY_UPSTREAM_PUBLIC_KEY"
+	// #nosec G101 -- this is the NAME of an environment variable, not a credential value.
+	EnvK8sGatewayUpstreamKeySecret = "CONTAINARIUM_K8S_GATEWAY_UPSTREAM_KEY_SECRET"
+	EnvK8sInsecureIgnoreHostKey    = "CONTAINARIUM_K8S_INSECURE_IGNORE_HOST_KEY"
+	EnvK8sDefaultMemoryRequest     = "CONTAINARIUM_K8S_DEFAULT_MEMORY_REQUEST"
+	EnvK8sDefaultMemoryLimit       = "CONTAINARIUM_K8S_DEFAULT_MEMORY_LIMIT"
+	EnvK8sDisableMemoryFloor       = "CONTAINARIUM_K8S_DISABLE_MEMORY_FLOOR"
+)
+
+// K8s defaults applied by LoadK8s when the variable is unset.
+const (
+	defaultK8sGatewayNamespace = "agent-gateway"
+	defaultK8sTenantNSPrefix   = "tenant-"
+	defaultK8sGatewaySSHPort   = 22
+)
+
+// K8s is the typed view of the CONTAINARIUM_K8S_* namespace — the wiring the
+// daemon needs to drive the Kubernetes agent-box backend. Load it once at
+// startup with LoadK8s; the server maps it onto pkg/core/box/k8s.Config (kept
+// env-agnostic so that package stays free of this internal config dependency).
+type K8s struct {
+	// Kubeconfig is the path to a kubeconfig file; empty means in-cluster config
+	// then the ambient loading rules. (EnvK8sKubeconfig)
+	Kubeconfig string
+
+	// GatewayNamespace is where the sshpiper Deployment + its LB Service live.
+	// (EnvK8sGatewayNamespace; default "agent-gateway")
+	GatewayNamespace string
+
+	// GatewayHost is the public SSH endpoint agents connect to (the sshpiper LB).
+	// (EnvK8sGatewayHost)
+	GatewayHost string
+
+	// GatewaySSHPort is the gateway SSH port. (EnvK8sGatewaySSHPort; default 22)
+	GatewaySSHPort int
+
+	// TenantNamespacePrefix prefixes each per-tenant namespace.
+	// (EnvK8sTenantNSPrefix; default "tenant-")
+	TenantNamespacePrefix string
+
+	// BoxImage is the agent-box image (sshd + agent-box) each box runs.
+	// (EnvK8sBoxImage)
+	BoxImage string
+
+	// StorageClass is the StorageClass for the box's data PVC; empty disables the
+	// PVC. (EnvK8sStorageClass)
+	StorageClass string
+
+	// GatewayUpstreamPublicKey is the public key authorized on each box so
+	// sshpiper can log in upstream. (EnvK8sGatewayUpstreamPublicKey)
+	GatewayUpstreamPublicKey string
+
+	// GatewayUpstreamKeySecret is the Secret (in GatewayNamespace) holding the
+	// matching private key. (EnvK8sGatewayUpstreamKeySecret)
+	GatewayUpstreamKeySecret string
+
+	// InsecureIgnoreHostKey keeps the pre-pinning behavior (Pipe sets
+	// ignore_hostkey). Default false = pin. (EnvK8sInsecureIgnoreHostKey)
+	InsecureIgnoreHostKey bool
+
+	// DefaultMemoryRequest / DefaultMemoryLimit override the per-box memory floor
+	// applied when a box sets no valid memory. Empty = built-in defaults; an
+	// invalid quantity degrades to the built-in default *in the backend*, so
+	// these are intentionally not hard-validated here. (EnvK8sDefaultMemory*)
+	DefaultMemoryRequest string
+	DefaultMemoryLimit   string
+
+	// DisableDefaultMemoryFloor turns the floor off entirely.
+	// (EnvK8sDisableMemoryFloor)
+	DisableDefaultMemoryFloor bool
+}
+
+// LoadK8s reads the CONTAINARIUM_K8S_* namespace from the environment once,
+// applying the documented defaults.
+func LoadK8s() K8s {
+	return K8s{
+		Kubeconfig:                getString(EnvK8sKubeconfig, ""),
+		GatewayNamespace:          getString(EnvK8sGatewayNamespace, defaultK8sGatewayNamespace),
+		GatewayHost:               getString(EnvK8sGatewayHost, ""),
+		GatewaySSHPort:            getInt(EnvK8sGatewaySSHPort, defaultK8sGatewaySSHPort),
+		TenantNamespacePrefix:     getString(EnvK8sTenantNSPrefix, defaultK8sTenantNSPrefix),
+		BoxImage:                  getString(EnvK8sBoxImage, ""),
+		StorageClass:              getString(EnvK8sStorageClass, ""),
+		GatewayUpstreamPublicKey:  getString(EnvK8sGatewayUpstreamPublicKey, ""),
+		GatewayUpstreamKeySecret:  getString(EnvK8sGatewayUpstreamKeySecret, ""),
+		InsecureIgnoreHostKey:     getBool(EnvK8sInsecureIgnoreHostKey),
+		DefaultMemoryRequest:      getString(EnvK8sDefaultMemoryRequest, ""),
+		DefaultMemoryLimit:        getString(EnvK8sDefaultMemoryLimit, ""),
+		DisableDefaultMemoryFloor: getBool(EnvK8sDisableMemoryFloor),
+	}
+}
+
+// Validate reports configuration errors that should fail daemon startup. It is
+// light by design: memory-floor quantities are resolved (and invalid ones
+// degraded) in the backend, so only the gateway SSH port is checked here.
+func (k K8s) Validate() error {
+	if k.GatewaySSHPort < 1 || k.GatewaySSHPort > 65535 {
+		return fmt.Errorf("%s=%d is not a valid TCP port (1-65535)", EnvK8sGatewaySSHPort, k.GatewaySSHPort)
+	}
+	return nil
+}

--- a/internal/config/k8s_test.go
+++ b/internal/config/k8s_test.go
@@ -1,0 +1,113 @@
+package config
+
+import "testing"
+
+// allK8sEnvKeys lists every variable LoadK8s reads, so tests can isolate from
+// ambient environment.
+var allK8sEnvKeys = []string{
+	EnvK8sKubeconfig, EnvK8sGatewayNamespace, EnvK8sGatewayHost, EnvK8sGatewaySSHPort,
+	EnvK8sTenantNSPrefix, EnvK8sBoxImage, EnvK8sStorageClass,
+	EnvK8sGatewayUpstreamPublicKey, EnvK8sGatewayUpstreamKeySecret,
+	EnvK8sInsecureIgnoreHostKey, EnvK8sDefaultMemoryRequest, EnvK8sDefaultMemoryLimit,
+	EnvK8sDisableMemoryFloor,
+}
+
+func clearK8sEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range allK8sEnvKeys {
+		t.Setenv(k, "")
+	}
+}
+
+// TestLoadK8sDefaults verifies the documented defaults apply when nothing is set.
+func TestLoadK8sDefaults(t *testing.T) {
+	clearK8sEnv(t)
+	got := LoadK8s()
+	want := K8s{
+		GatewayNamespace:      defaultK8sGatewayNamespace,
+		TenantNamespacePrefix: defaultK8sTenantNSPrefix,
+		GatewaySSHPort:        defaultK8sGatewaySSHPort,
+	}
+	if got != want {
+		t.Errorf("LoadK8s defaults = %+v, want %+v", got, want)
+	}
+}
+
+// TestLoadK8sReadsEnv verifies each variable maps to its field, including the
+// int and bool conversions.
+func TestLoadK8sReadsEnv(t *testing.T) {
+	clearK8sEnv(t)
+	t.Setenv(EnvK8sKubeconfig, "/home/agent/.kube/config")
+	t.Setenv(EnvK8sGatewayNamespace, "gw")
+	t.Setenv(EnvK8sGatewayHost, "gw.example.com")
+	t.Setenv(EnvK8sGatewaySSHPort, "2222")
+	t.Setenv(EnvK8sTenantNSPrefix, "t-")
+	t.Setenv(EnvK8sBoxImage, "ghcr.io/x/agent-box:latest")
+	t.Setenv(EnvK8sStorageClass, "standard")
+	t.Setenv(EnvK8sGatewayUpstreamPublicKey, "ssh-ed25519 AAA")
+	t.Setenv(EnvK8sGatewayUpstreamKeySecret, "gw-upstream-key")
+	t.Setenv(EnvK8sInsecureIgnoreHostKey, "1")
+	t.Setenv(EnvK8sDefaultMemoryRequest, "512Mi")
+	t.Setenv(EnvK8sDefaultMemoryLimit, "2Gi")
+	t.Setenv(EnvK8sDisableMemoryFloor, "true")
+
+	got := LoadK8s()
+	want := K8s{
+		Kubeconfig:                "/home/agent/.kube/config",
+		GatewayNamespace:          "gw",
+		GatewayHost:               "gw.example.com",
+		GatewaySSHPort:            2222,
+		TenantNamespacePrefix:     "t-",
+		BoxImage:                  "ghcr.io/x/agent-box:latest",
+		StorageClass:              "standard",
+		GatewayUpstreamPublicKey:  "ssh-ed25519 AAA",
+		GatewayUpstreamKeySecret:  "gw-upstream-key",
+		InsecureIgnoreHostKey:     true,
+		DefaultMemoryRequest:      "512Mi",
+		DefaultMemoryLimit:        "2Gi",
+		DisableDefaultMemoryFloor: true,
+	}
+	if got != want {
+		t.Errorf("LoadK8s = %+v\nwant %+v", got, want)
+	}
+}
+
+// TestLoadK8sInvalidPortFallsBackToDefault verifies a non-numeric port degrades
+// to the default rather than 0 (which would fail Validate).
+func TestLoadK8sInvalidPortFallsBackToDefault(t *testing.T) {
+	clearK8sEnv(t)
+	t.Setenv(EnvK8sGatewaySSHPort, "notaport")
+	if got := LoadK8s().GatewaySSHPort; got != defaultK8sGatewaySSHPort {
+		t.Errorf("GatewaySSHPort = %d, want default %d", got, defaultK8sGatewaySSHPort)
+	}
+}
+
+// TestK8sValidate covers the gateway-port range check.
+func TestK8sValidate(t *testing.T) {
+	if err := (K8s{GatewaySSHPort: 22}).Validate(); err != nil {
+		t.Errorf("port 22 should be valid: %v", err)
+	}
+	if err := (K8s{GatewaySSHPort: 0}).Validate(); err == nil {
+		t.Error("port 0 should be invalid")
+	}
+	if err := (K8s{GatewaySSHPort: 70000}).Validate(); err == nil {
+		t.Error("port 70000 should be invalid")
+	}
+}
+
+// TestGetBoolTruthyValues verifies the accepted truthy spellings (superset of
+// the historical "1").
+func TestGetBoolTruthyValues(t *testing.T) {
+	for _, v := range []string{"1", "true", "TRUE", "Yes", "on"} {
+		t.Setenv(EnvK8sDisableMemoryFloor, v)
+		if !getBool(EnvK8sDisableMemoryFloor) {
+			t.Errorf("getBool(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"", "0", "false", "no", "off", "maybe"} {
+		t.Setenv(EnvK8sDisableMemoryFloor, v)
+		if getBool(EnvK8sDisableMemoryFloor) {
+			t.Errorf("getBool(%q) = true, want false", v)
+		}
+	}
+}

--- a/internal/config/network.go
+++ b/internal/config/network.go
@@ -1,0 +1,39 @@
+package config
+
+// CONTAINARIUM_NETWORK_* variable names — the single source of truth for the
+// in-kernel network-policy (eBPF) namespace.
+const (
+	EnvNetworkPolicyBPFObject  = "CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT"
+	EnvNetworkPolicyEnforce    = "CONTAINARIUM_NETWORK_POLICY_ENFORCE"
+	EnvNetworkPolicySignatures = "CONTAINARIUM_NETWORK_POLICY_SIGNATURES"
+)
+
+// Network is the typed view of the CONTAINARIUM_NETWORK_* namespace — the eBPF
+// network-policy enforcer's startup wiring. Both arming flags are off unless
+// explicitly set, matching the deny→audit (observation-only) default posture.
+type Network struct {
+	// PolicyBPFObject is the path to the loaded in-kernel network-policy program
+	// object. Empty disables the enforcer entirely. Kept as the raw value;
+	// consumers TrimSpace where they need to. (EnvNetworkPolicyBPFObject)
+	PolicyBPFObject string
+
+	// PolicyEnforce arms packet drops (the second opt-in). Off = observation-only:
+	// even a stored enforce-mode policy only audits would-deny flows.
+	// (EnvNetworkPolicyEnforce)
+	PolicyEnforce bool
+
+	// PolicySignatures arms inbound cleartext exploit-signature scanning (Tier 2,
+	// #661) — separate from PolicyEnforce. (EnvNetworkPolicySignatures)
+	PolicySignatures bool
+}
+
+// LoadNetwork reads the CONTAINARIUM_NETWORK_* namespace once. The two arming
+// flags use the shared truthy convention (1/true/yes/on), matching the switch /
+// envTruthy parsing they replace.
+func LoadNetwork() Network {
+	return Network{
+		PolicyBPFObject:  getString(EnvNetworkPolicyBPFObject, ""),
+		PolicyEnforce:    getBool(EnvNetworkPolicyEnforce),
+		PolicySignatures: getBool(EnvNetworkPolicySignatures),
+	}
+}

--- a/internal/config/network_test.go
+++ b/internal/config/network_test.go
@@ -1,0 +1,50 @@
+package config
+
+import "testing"
+
+func clearNetworkEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{EnvNetworkPolicyBPFObject, EnvNetworkPolicyEnforce, EnvNetworkPolicySignatures} {
+		t.Setenv(k, "")
+	}
+}
+
+// TestLoadNetworkDefaults verifies the observation-only default posture: enforcer
+// disabled, both arming flags off.
+func TestLoadNetworkDefaults(t *testing.T) {
+	clearNetworkEnv(t)
+	if got := LoadNetwork(); got != (Network{}) {
+		t.Errorf("LoadNetwork with empty env = %+v, want zero value", got)
+	}
+}
+
+// TestLoadNetworkReadsEnv verifies the field mapping and that the arming flags
+// honor the truthy convention.
+func TestLoadNetworkReadsEnv(t *testing.T) {
+	clearNetworkEnv(t)
+	t.Setenv(EnvNetworkPolicyBPFObject, "/opt/containarium/netpolicy.bpf.o")
+	t.Setenv(EnvNetworkPolicyEnforce, "1")
+	t.Setenv(EnvNetworkPolicySignatures, "yes")
+
+	want := Network{
+		PolicyBPFObject:  "/opt/containarium/netpolicy.bpf.o",
+		PolicyEnforce:    true,
+		PolicySignatures: true,
+	}
+	if got := LoadNetwork(); got != want {
+		t.Errorf("LoadNetwork = %+v, want %+v", got, want)
+	}
+}
+
+// TestLoadNetworkArmingFlagsOffByDefault verifies that an unset or non-truthy
+// arming flag stays off — a safety-relevant default for the eBPF enforcer.
+func TestLoadNetworkArmingFlagsOffByDefault(t *testing.T) {
+	clearNetworkEnv(t)
+	t.Setenv(EnvNetworkPolicyBPFObject, "/x.o")
+	for _, v := range []string{"", "0", "false", "off", "no"} {
+		t.Setenv(EnvNetworkPolicyEnforce, v)
+		if LoadNetwork().PolicyEnforce {
+			t.Errorf("PolicyEnforce=true for %q, want off", v)
+		}
+	}
+}

--- a/internal/server/boxbackend_factory.go
+++ b/internal/server/boxbackend_factory.go
@@ -5,9 +5,8 @@ package server
 import (
 	"fmt"
 	"log"
-	"os"
-	"strconv"
 
+	"github.com/footprintai/containarium/internal/config"
 	"github.com/footprintai/containarium/pkg/core/box"
 	boxk8s "github.com/footprintai/containarium/pkg/core/box/k8s"
 	boxlxc "github.com/footprintai/containarium/pkg/core/box/lxc"
@@ -53,33 +52,26 @@ func newBoxBackend(runtime string, mgr *container.Manager) (box.BoxBackend, erro
 }
 
 func newK8sBackend() (box.BoxBackend, error) {
-	port, _ := strconv.Atoi(os.Getenv("CONTAINARIUM_K8S_GATEWAY_SSH_PORT"))
-	if port == 0 {
-		port = 22
+	// The CONTAINARIUM_K8S_* namespace is read + defaulted once via internal/config
+	// (typed, validated); pkg/core/box/k8s.Config stays env-agnostic, so we map
+	// the fields across here.
+	cfg := config.LoadK8s()
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("k8s config: %w", err)
 	}
 	return boxk8s.New(boxk8s.Config{
-		Kubeconfig:               os.Getenv("CONTAINARIUM_K8S_KUBECONFIG"),
-		GatewayNamespace:         envOr("CONTAINARIUM_K8S_GATEWAY_NAMESPACE", "agent-gateway"),
-		GatewayHost:              os.Getenv("CONTAINARIUM_K8S_GATEWAY_HOST"),
-		GatewaySSHPort:           port,
-		TenantNamespacePrefix:    envOr("CONTAINARIUM_K8S_TENANT_NS_PREFIX", "tenant-"),
-		BoxImage:                 os.Getenv("CONTAINARIUM_K8S_BOX_IMAGE"),
-		StorageClass:             os.Getenv("CONTAINARIUM_K8S_STORAGE_CLASS"),
-		GatewayUpstreamPublicKey: os.Getenv("CONTAINARIUM_K8S_GATEWAY_UPSTREAM_PUBLIC_KEY"),
-		GatewayUpstreamKeySecret: os.Getenv("CONTAINARIUM_K8S_GATEWAY_UPSTREAM_KEY_SECRET"),
-		InsecureIgnoreHostKey:    os.Getenv("CONTAINARIUM_K8S_INSECURE_IGNORE_HOST_KEY") == "1",
-		// Per-box default memory floor. Empty = built-in defaults (256Mi/1Gi);
-		// an invalid quantity degrades to the built-in default. Disable turns the
-		// floor off so boxes with no explicit memory run unconstrained.
-		DefaultMemoryRequest:      os.Getenv("CONTAINARIUM_K8S_DEFAULT_MEMORY_REQUEST"),
-		DefaultMemoryLimit:        os.Getenv("CONTAINARIUM_K8S_DEFAULT_MEMORY_LIMIT"),
-		DisableDefaultMemoryFloor: os.Getenv("CONTAINARIUM_K8S_DISABLE_MEMORY_FLOOR") == "1",
+		Kubeconfig:                cfg.Kubeconfig,
+		GatewayNamespace:          cfg.GatewayNamespace,
+		GatewayHost:               cfg.GatewayHost,
+		GatewaySSHPort:            cfg.GatewaySSHPort,
+		TenantNamespacePrefix:     cfg.TenantNamespacePrefix,
+		BoxImage:                  cfg.BoxImage,
+		StorageClass:              cfg.StorageClass,
+		GatewayUpstreamPublicKey:  cfg.GatewayUpstreamPublicKey,
+		GatewayUpstreamKeySecret:  cfg.GatewayUpstreamKeySecret,
+		InsecureIgnoreHostKey:     cfg.InsecureIgnoreHostKey,
+		DefaultMemoryRequest:      cfg.DefaultMemoryRequest,
+		DefaultMemoryLimit:        cfg.DefaultMemoryLimit,
+		DisableDefaultMemoryFloor: cfg.DisableDefaultMemoryFloor,
 	})
-}
-
-func envOr(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
 }

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/capabilities"
 	"github.com/footprintai/containarium/internal/capacity"
+	appconfig "github.com/footprintai/containarium/internal/config"
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/guacamole"
 	"github.com/footprintai/containarium/internal/integrity"
@@ -2780,7 +2781,7 @@ func (s *ContainerServer) computeSelfMeasurement() (integrity.Measurement, error
 	// Loaded in-kernel network-policy program object(s). The daemon arms the
 	// per-veth enforcer only when CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT points
 	// at an object on disk; that object's bytes are exactly what we attest.
-	if bpfObj := strings.TrimSpace(os.Getenv("CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT")); bpfObj != "" {
+	if bpfObj := strings.TrimSpace(os.Getenv(appconfig.EnvNetworkPolicyBPFObject)); bpfObj != "" {
 		in.Programs = append(in.Programs, integrity.ProgramObject{Name: bpfObj, Path: bpfObj})
 	}
 

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1215,7 +1215,8 @@ skipAppHosting:
 	// would-deny flows. The tenant→u32 ID registry is persisted in Postgres when
 	// available (IDs must be stable across restarts) and in-memory otherwise.
 	var networkPolicyEnforcer *NetworkPolicyEnforcer
-	if bpfObj := os.Getenv("CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT"); bpfObj != "" && networkIncusClient != nil {
+	netCfg := appconfig.LoadNetwork()
+	if bpfObj := netCfg.PolicyBPFObject; bpfObj != "" && networkIncusClient != nil {
 		var tenantRegistry TenantRegistry
 		if postgresConnString != "" {
 			if regPool, perr := connectToPostgres(postgresConnString, 5, 3*time.Second); perr != nil {
@@ -1235,20 +1236,12 @@ skipAppHosting:
 		// also arms it. Without this, even a stored `--mode enforce` policy stays
 		// observation-only — so an operator soaks in log_only, watches the
 		// would-deny logs, finishes the allow-list, then arms enforce.
-		enforceArmed := false
-		switch strings.ToLower(strings.TrimSpace(os.Getenv("CONTAINARIUM_NETWORK_POLICY_ENFORCE"))) {
-		case "1", "true", "yes", "on":
-			enforceArmed = true
-		}
+		enforceArmed := netCfg.PolicyEnforce
 		networkPolicyEnforcer = NewNetworkPolicyEnforcer(bpfObj, npServer.Store(), tenantRegistry, networkIncusClient, auditStore, events.GetBus(), enforceArmed)
 		// Tier 2 (#661): opt into inbound cleartext exploit-signature scanning.
 		// Separate from ENFORCE — loading signatures is harmless in observation
 		// mode (logs matches), but the per-packet scan cost only runs when set.
-		var sigArmed bool
-		switch strings.ToLower(strings.TrimSpace(os.Getenv("CONTAINARIUM_NETWORK_POLICY_SIGNATURES"))) {
-		case "1", "true", "yes", "on":
-			sigArmed = true
-		}
+		sigArmed := netCfg.PolicySignatures
 		networkPolicyEnforcer.SetSignaturesEnabled(sigArmed)
 		networkPolicyEnforcer.SetSignatureStore(npServer.SignatureStore()) // #661 PR-B: merge operator signatures
 		if enforceArmed {
@@ -1783,11 +1776,11 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		// detect tampering of a backend's control plane. Generic, integrity-
 		// relevant config only — base domain + network-policy enforcement posture.
 		netPolicyEnforce := "0"
-		switch strings.ToLower(strings.TrimSpace(os.Getenv("CONTAINARIUM_NETWORK_POLICY_ENFORCE"))) {
+		switch strings.ToLower(strings.TrimSpace(os.Getenv(appconfig.EnvNetworkPolicyEnforce))) {
 		case "1", "true", "yes", "on":
 			netPolicyEnforce = "1"
 		}
-		netPolicyObj := strings.TrimSpace(os.Getenv("CONTAINARIUM_NETWORK_POLICY_BPF_OBJECT"))
+		netPolicyObj := strings.TrimSpace(os.Getenv(appconfig.EnvNetworkPolicyBPFObject))
 		ds.containerServer.SetIntegrityConfig(map[string]string{
 			"base_domain":            ds.config.BaseDomain,
 			"pool":                   ds.config.Pool,
@@ -2076,7 +2069,7 @@ func (ds *DualServer) Start(ctx context.Context) error {
 			switch strings.ToLower(strings.TrimSpace(os.Getenv("CONTAINARIUM_WAF_INSPECT"))) {
 			case "1", "true", "yes", "on":
 				cfg.Inspector = waf.NewBuiltinInspector()
-				switch strings.ToLower(strings.TrimSpace(os.Getenv("CONTAINARIUM_NETWORK_POLICY_ENFORCE"))) {
+				switch strings.ToLower(strings.TrimSpace(os.Getenv(appconfig.EnvNetworkPolicyEnforce))) {
 				case "1", "true", "yes", "on":
 					cfg.EnforceBlock = true
 				}
@@ -2327,7 +2320,7 @@ func wafIngressFromEnv(pm *app.ProxyManager) *app.ProxyManager {
 	if !envTruthy(os.Getenv("CONTAINARIUM_WAF_INGRESS")) {
 		return pm
 	}
-	enforce := envTruthy(os.Getenv("CONTAINARIUM_NETWORK_POLICY_ENFORCE"))
+	enforce := envTruthy(os.Getenv(appconfig.EnvNetworkPolicyEnforce))
 	mode := "DetectionOnly (observe)"
 	if enforce {
 		mode = "On (blocking)"


### PR DESCRIPTION
## What

Third namespace onto the `internal/config` pattern (after SENTINEL #872, K8S #873). Adds **`config.Network`** for the three `CONTAINARIUM_NETWORK_POLICY_*` variables — `Env*` name constants, a typed struct, and `LoadNetwork()`.

## Why this one earns its keep (real de-sprawl)

This namespace had genuine duplication: `POLICY_ENFORCE` was read at **4 sites** and `POLICY_BPF_OBJECT` at **3**, each re-parsing the value inline with its own `switch strings.ToLower(strings.TrimSpace(...))` (or `envTruthy`). I verified all of those parsers are **byte-identical** to the package's `getBool` (`1/true/yes/on`, trimmed, case-insensitive).

- The main enforcer-setup block now loads `config.Network` once and uses the typed fields, **collapsing two identical inline switches** → net **−6 lines** in `dual_server.go`.
- The other read sites are converted to the **name constants** with their existing parsing left exactly as-is — provably zero behavior change.

The eBPF enforcer's **observation-only default posture** (both arming flags off unless explicitly set) is preserved; `PolicyEnforce`/`PolicySignatures` default to `false`.

## Safety

These reads live in security-critical eBPF enforcement startup, so the scope is deliberately conservative: exactly one block adopts the struct (where 3 vars are read together and the equivalence is obvious), everything else is a literal→constant swap. `appconfig` import alias matches the existing convention in `dual_server.go`.

## Tests

`internal/config` Network tests: defaults (observation-only zero value), full env read, and arming-flags-off-by-default. `go build ./...` + `-tags k8s` clean; `internal/server` suite passes; gosec clean (non-credential names, no new G101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)