### PR TITLE
feat(backup): systemd timer + script for nightly per-tenant pg_dump

### DIFF
--- a/docs/DB-BACKUP-OPERATIONS.md
+++ b/docs/DB-BACKUP-OPERATIONS.md
@@ -71,26 +71,76 @@ The same operations are available as MCP tools (`create_backup`,
 all call the one `BackupService`, so an agent, a human shell, and CI have
 an identical surface.
 
-## Scheduling (cron-driven in v1)
+## Scheduling (systemd timer — recommended)
 
 v1 has no in-daemon scheduler — and for an audit that is a feature, not a
-gap: a cron entry is an explicit, reviewable, timestamped artifact. Put
-this on the daemon host (or any host with the CLI + credentials):
+gap: a timer unit is an explicit, reviewable, timestamped artifact whose
+history is preserved in the journal.
 
-```cron
-# /etc/cron.d/containarium-backup  — nightly per-tenant dump to GCS at 02:30
-30 2 * * *  root  /usr/local/bin/containarium backup create <tenant> \
-  --database app --dest gcs --gcs-bucket gs://<your-backup-bucket>/pg \
-  --server <host> >> /var/log/containarium-backup.log 2>&1
+The repo ships three files under `scripts/`:
+
+| File | Purpose |
+|---|---|
+| `scripts/backup-all-tenants.sh` | iterates `/etc/containarium/backup-tenants.conf`, one `backup create` per tenant |
+| `scripts/containarium-backup.service` | oneshot service that runs the script |
+| `scripts/containarium-backup.timer` | fires the service at 02:30 every night |
+
+### Installation on the daemon host
+
+```bash
+# 1. Install the script.
+cp scripts/backup-all-tenants.sh /usr/local/bin/
+chmod +x /usr/local/bin/backup-all-tenants.sh
+
+# 2. Install the systemd units.
+cp scripts/containarium-backup.{service,timer} /etc/systemd/system/
+systemctl daemon-reload
+
+# 3. Create the environment file (mode 0600 — contains credentials).
+cat > /etc/containarium/backup.env <<'ENV'
+CONTAINARIUM_SERVER=localhost:8080
+CONTAINARIUM_BACKUP_BUCKET=gs://<your-backup-bucket>/pg
+# CONTAINARIUM_AUTH_TOKEN=<jwt>  # omit when running on the daemon host as root
+ENV
+chmod 0600 /etc/containarium/backup.env
+
+# 4. Create the tenant config (one line per database to back up).
+#    Format: <tenant>  <database>  [OPTIONAL_PASSWORD_ENV_VAR]
+cat > /etc/containarium/backup-tenants.conf <<'CONF'
+# tenant          database
+<tenant-a>        app
+<tenant-b>        app
+CONF
+
+# 5. Enable and start the timer.
+systemctl enable --now containarium-backup.timer
+
+# 6. Verify the timer is queued.
+systemctl list-timers containarium-backup.timer
 ```
+
+### Watching and alerting
+
+```bash
+# Tail the current run log.
+journalctl -u containarium-backup -f
+
+# Check the last run's exit status.
+systemctl status containarium-backup.service
+
+# Alert on absence: the service exits 1 if any tenant failed, which marks
+# the unit as "failed". Wire this into your monitoring:
+systemctl is-failed containarium-backup.service && alert "backup failed"
+```
+
+The service exits non-zero if **any** tenant fails, so a monitoring check on
+`systemctl is-failed containarium-backup.service` catches both partial and
+total failures. Alert on **absence** too — a timer that was disabled emits
+no failure line, only silence.
 
 For a tighter RPO than "nightly," add Postgres WAL archiving inside the
 container (`archive_command` → GCS) on top of these base dumps; that gives
 point-in-time recovery with an RPO of minutes, still cheaply.
-
-> A scheduled job is only as good as its alerting. Pipe the log to your
-> monitoring and alert on **absence** of a success line, not just on
-> error lines — a cron that never runs emits no errors.
 
 ## GCS bucket setup + retention lifecycle
 

--- a/scripts/backup-all-tenants.sh
+++ b/scripts/backup-all-tenants.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Iterate the tenant config and create a GCS backup for each entry.
+# Designed to be driven by containarium-backup.{service,timer}.
+#
+# Config file format (/etc/containarium/backup-tenants.conf):
+#   # comment
+#   <tenant>  <database>  [PASSWORD_ENV_VAR]
+#
+# The optional third field names an env variable whose value is passed as
+# --db-password.  Omit it when the in-container Postgres uses peer/trust auth
+# (the common default — pg_dump runs as root inside the container on loopback).
+#
+# Required environment variables (set in /etc/containarium/backup.env):
+#   CONTAINARIUM_SERVER       daemon address, e.g. localhost:8080
+#   CONTAINARIUM_BACKUP_BUCKET  GCS bucket prefix, e.g. gs://my-backups/pg
+#
+# Optional:
+#   CONTAINARIUM_BACKUP_CONF  path to config file (default below)
+#   CONTAINARIUM_BIN          path to containarium binary (default below)
+#   CONTAINARIUM_AUTH_TOKEN   JWT for --token (omit when running on daemon host
+#                             with a root service token or peer auth)
+
+set -uo pipefail
+
+CONF="${CONTAINARIUM_BACKUP_CONF:-/etc/containarium/backup-tenants.conf}"
+SERVER="${CONTAINARIUM_SERVER:?CONTAINARIUM_SERVER must be set}"
+BUCKET="${CONTAINARIUM_BACKUP_BUCKET:?CONTAINARIUM_BACKUP_BUCKET must be set}"
+CTN="${CONTAINARIUM_BIN:-/usr/local/bin/containarium}"
+TOKEN="${CONTAINARIUM_AUTH_TOKEN:-}"
+
+if [[ ! -f "$CONF" ]]; then
+  echo "[backup] config not found: $CONF" >&2
+  exit 1
+fi
+
+# Build auth flag once (empty string = no flag).
+auth_flags=()
+if [[ -n "$TOKEN" ]]; then
+  auth_flags=(--token "$TOKEN")
+fi
+
+failed=0
+total=0
+
+while IFS=$' \t' read -r tenant database pw_env _rest; do
+  # Skip blank lines and comments.
+  [[ -z "$tenant" || "$tenant" == \#* ]] && continue
+
+  total=$((total + 1))
+
+  pw_flags=()
+  if [[ -n "${pw_env:-}" ]]; then
+    # Indirect expansion: read the named variable for the password.
+    pw_value="${!pw_env:-}"
+    if [[ -z "$pw_value" ]]; then
+      echo "[backup] WARNING: $pw_env is not set; attempting without password (tenant=$tenant db=$database)" >&2
+    else
+      pw_flags=(--db-password "$pw_value")
+    fi
+  fi
+
+  echo "[backup] start tenant=$tenant db=$database"
+  if "$CTN" backup create "$tenant" \
+      --database "$database" \
+      --dest gcs \
+      --gcs-bucket "$BUCKET" \
+      --server "$SERVER" \
+      "${auth_flags[@]}" \
+      "${pw_flags[@]}"; then
+    echo "[backup] ok    tenant=$tenant db=$database"
+  else
+    echo "[backup] FAIL  tenant=$tenant db=$database" >&2
+    failed=$((failed + 1))
+  fi
+done < "$CONF"
+
+if [[ "$total" -eq 0 ]]; then
+  echo "[backup] no tenants configured in $CONF — nothing to do"
+  exit 0
+fi
+
+if [[ "$failed" -gt 0 ]]; then
+  echo "[backup] $failed/$total tenant(s) failed" >&2
+  exit 1
+fi
+
+echo "[backup] all $total tenant(s) done"

--- a/scripts/containarium-backup.service
+++ b/scripts/containarium-backup.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Containarium nightly database backup
+Documentation=https://github.com/footprintai/Containarium/blob/main/docs/DB-BACKUP-OPERATIONS.md
+# Start after network and the daemon itself are up.
+After=network-online.target containarium.service
+Requires=containarium.service
+# Triggered by the companion timer; don't start on boot.
+RefuseManualStart=no
+
+[Service]
+Type=oneshot
+# Load server address, bucket, auth token, and per-tenant passwords.
+# Create this file on the host: /etc/containarium/backup.env
+EnvironmentFile=/etc/containarium/backup.env
+
+ExecStart=/usr/local/bin/backup-all-tenants.sh
+
+# Run as root (same as the daemon) so it can exec into containers.
+User=root
+Group=root
+
+# Hard cap: if the full sweep takes more than 2 hours something is wrong.
+TimeoutStartSec=7200
+
+# Journal output lets `journalctl -u containarium-backup` show the run log.
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=containarium-backup
+
+# Harden: no new capabilities, but still needs /etc for config and
+# /var/lib/containarium/backups for the JSON index sidecars.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=false
+ReadWritePaths=/var/lib/containarium /etc/containarium /tmp

--- a/scripts/containarium-backup.timer
+++ b/scripts/containarium-backup.timer
@@ -1,0 +1,20 @@
+[Unit]
+Description=Containarium nightly database backup timer
+Documentation=https://github.com/footprintai/Containarium/blob/main/docs/DB-BACKUP-OPERATIONS.md
+
+[Timer]
+# Fire at 02:30 every night.
+OnCalendar=*-*-* 02:30:00
+
+# Spread firing up to 15 min to avoid a thundering herd if multiple hosts
+# run this timer simultaneously.
+RandomizedDelaySec=900
+
+# If the host was down at 02:30, catch up on the next boot.
+Persistent=true
+
+# 1-minute granularity is fine for a nightly job.
+AccuracySec=60
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- Add `scripts/backup-all-tenants.sh` — iterates `/etc/containarium/backup-tenants.conf` and calls `containarium backup create --dest gcs` for each tenant; exits non-zero if any tenant fails (so `systemctl is-failed` works as an alert surface)
- Add `scripts/containarium-backup.service` — oneshot unit, loads credentials from `/etc/containarium/backup.env`, 2-hour hard timeout, runs as root alongside the daemon
- Add `scripts/containarium-backup.timer` — fires at 02:30 nightly with a 15-min random spread (`RandomizedDelaySec=900`), `Persistent=true` so a missed run catches up on next boot
- Update `docs/DB-BACKUP-OPERATIONS.md` — replace the raw cron snippet with the systemd installation procedure (copy/paste steps + alerting guidance)

**Context:** `containarium backup create` has existed since the backup feature shipped, but no scheduling was ever wired up. Prod currently shows zero recorded backups across all running containers — this PR closes that gap.

## Test plan

- [ ] `bash -n scripts/backup-all-tenants.sh` — syntax check passes
- [ ] `systemd-analyze verify scripts/containarium-backup.{service,timer}` on a Linux host — no warnings
- [ ] On the daemon host: install per the doc steps, run `systemctl start containarium-backup.service` manually, confirm `containarium backup list` shows entries and `systemctl status` shows exit 0
- [ ] Disable one tenant's container, re-run — confirm the service exits 1 and `systemctl is-failed` returns true
- [ ] `systemctl enable containarium-backup.timer` + `list-timers` confirms next fire time

🤖 Generated with [Claude Code](https://claude.com/claude-code)