### PR TITLE
refactor(config+secrets): migrate KMS namespaces (AWS/VAULT/GCP) — keep pkg/core env-free

### DIFF
--- a/internal/cmd/secrets_migrate.go
+++ b/internal/cmd/secrets_migrate.go
@@ -181,7 +181,7 @@ func openSecretsStoreWithKMS(ctx context.Context, masterKeyPath string) (*intern
 	if err != nil {
 		return nil, nil, fmt.Errorf("build cipher: %w", err)
 	}
-	kms, kmsDesc, err := corecrypto.LoadKMSClient(masterKey)
+	kms, kmsDesc, err := internalsecrets.LoadKMSClient(masterKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load KMS backend: %w", err)
 	}

--- a/internal/config/kms.go
+++ b/internal/config/kms.go
@@ -1,0 +1,43 @@
+package config
+
+// KMS / cloud-credential variable names. This namespace differs from the others
+// in this package: its values are consumed inside pkg/core/secrets, which pulls
+// in cloud provider SDKs. To keep internal/config lightweight (stdlib-only, so
+// every importer stays cheap), config owns only the *names* here — the single
+// source of truth for the namespace's identity. The read+resolve+validate
+// factory that turns these into a KMS client lives in the app layer
+// (internal/secrets.LoadKMSClient), where the SDK dependency already exists.
+//
+// Several names contain "secret"/"token"; gosec G101 flags constant identifiers
+// like those assigned a string literal as "potential hardcoded credentials".
+// These are env-var NAMES, not credentials, so each is annotated //nosec G101.
+const (
+	// KMS backend selector: none | inproc | vault | gcp | aws.
+	EnvKMSBackend = "CONTAINARIUM_KMS_BACKEND"
+
+	// AWS KMS.
+	EnvAWSKMSRegion           = "CONTAINARIUM_AWS_KMS_REGION"
+	EnvAWSKMSKeyID            = "CONTAINARIUM_AWS_KMS_KEY_ID"
+	EnvAWSAccessKeyID         = "CONTAINARIUM_AWS_ACCESS_KEY_ID"
+	EnvAWSKMSEndpoint         = "CONTAINARIUM_AWS_KMS_ENDPOINT"
+	EnvAWSSecretAccessKey     = "CONTAINARIUM_AWS_SECRET_ACCESS_KEY"      // #nosec G101 -- env var name, not a credential value
+	EnvAWSSecretAccessKeyFile = "CONTAINARIUM_AWS_SECRET_ACCESS_KEY_FILE" // #nosec G101 -- env var name, not a credential value
+	EnvAWSSessionToken        = "CONTAINARIUM_AWS_SESSION_TOKEN"          // #nosec G101 -- env var name, not a credential value
+	EnvAWSSessionTokenFile    = "CONTAINARIUM_AWS_SESSION_TOKEN_FILE"     // #nosec G101 -- env var name, not a credential value
+	EnvAWSKMSTimeout          = "CONTAINARIUM_AWS_KMS_TIMEOUT"
+
+	// Vault Transit.
+	EnvVaultAddr         = "CONTAINARIUM_VAULT_ADDR"
+	EnvVaultTransitMount = "CONTAINARIUM_VAULT_TRANSIT_MOUNT"
+	EnvVaultTransitKey   = "CONTAINARIUM_VAULT_TRANSIT_KEY"
+	EnvVaultToken        = "CONTAINARIUM_VAULT_TOKEN"      // #nosec G101 -- env var name, not a credential value
+	EnvVaultTokenFile    = "CONTAINARIUM_VAULT_TOKEN_FILE" // #nosec G101 -- env var name, not a credential value
+	EnvVaultTimeout      = "CONTAINARIUM_VAULT_TIMEOUT"
+
+	// GCP Cloud KMS.
+	EnvGCPKMSKeyName   = "CONTAINARIUM_GCP_KMS_KEY_NAME"
+	EnvGCPKMSEndpoint  = "CONTAINARIUM_GCP_KMS_ENDPOINT"
+	EnvGCPKMSToken     = "CONTAINARIUM_GCP_KMS_TOKEN"      // #nosec G101 -- env var name, not a credential value
+	EnvGCPKMSTokenFile = "CONTAINARIUM_GCP_KMS_TOKEN_FILE" // #nosec G101 -- env var name, not a credential value
+	EnvGCPKMSTimeout   = "CONTAINARIUM_GCP_KMS_TIMEOUT"
+)

--- a/internal/secrets/kms_factory.go
+++ b/internal/secrets/kms_factory.go
@@ -5,26 +5,22 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/footprintai/containarium/internal/config"
+	corecrypto "github.com/footprintai/containarium/pkg/core/secrets"
 )
 
 // Phase 4.1 — KMS backend selector. Audit C-HIGH-6.
 //
-// The daemon and the migration CLI both need to build a
-// KMSClient based on operator configuration. Centralizing
-// the dispatch here means:
-//
-//   - One env-var contract for operators
-//     (CONTAINARIUM_KMS_BACKEND=inproc|vault|none) instead
-//     of every callsite re-implementing the switch.
-//   - Future backends (GCP KMS, AWS KMS, …) slot in by
-//     adding one case to this file; no daemon-startup or
-//     CLI surgery.
-//   - Misconfigurations surface as a single, descriptive
-//     startup error.
+// The daemon and the migration CLI both need to build a KMSClient based on
+// operator configuration. This factory lives in the app layer (not in
+// pkg/core/secrets) so the core crypto package stays free of environment
+// reading: it exposes only the typed *Config structs + constructors, and this
+// file reads the environment (via internal/config name constants), resolves
+// credential files, validates, and dispatches to the right backend.
 
-// Recognized backend names. The default is "none" — no
-// KMS configured, behavior identical to pre-Phase-4.1.
-// Operators opt in by setting the env var.
+// Recognized backend names. The default is "none" — no KMS configured, behavior
+// identical to pre-Phase-4.1. Operators opt in by setting CONTAINARIUM_KMS_BACKEND.
 const (
 	KMSBackendNone   = "none"
 	KMSBackendInProc = "inproc"
@@ -33,19 +29,16 @@ const (
 	KMSBackendAWS    = "aws"
 )
 
-// LoadKMSClient picks a backend based on
-// CONTAINARIUM_KMS_BACKEND and returns a constructed
-// KMSClient plus a human-readable description for the
-// startup log. Returns (nil, "disabled", nil) when the
-// backend is "none" or the env var is unset.
+// LoadKMSClient picks a backend based on CONTAINARIUM_KMS_BACKEND and returns a
+// constructed KMSClient plus a human-readable description for the startup log.
+// Returns (nil, "disabled", nil) when the backend is "none" or the env var is
+// unset.
 //
-// masterKey is the daemon's existing master key from
-// LoadOrCreateMasterKey. The InProc backend wraps DEKs
-// against it (cryptographically equivalent to legacy);
-// other backends ignore it (Vault wraps via its
-// KMS-resident Transit key).
-func LoadKMSClient(masterKey []byte) (KMSClient, string, error) {
-	backend := strings.ToLower(strings.TrimSpace(os.Getenv("CONTAINARIUM_KMS_BACKEND")))
+// masterKey is the daemon's existing master key from LoadOrCreateMasterKey. The
+// InProc backend wraps DEKs against it (cryptographically equivalent to legacy);
+// other backends ignore it (Vault wraps via its KMS-resident Transit key).
+func LoadKMSClient(masterKey []byte) (corecrypto.KMSClient, string, error) {
+	backend := strings.ToLower(strings.TrimSpace(os.Getenv(config.EnvKMSBackend)))
 	if backend == "" {
 		backend = KMSBackendNone
 	}
@@ -53,7 +46,7 @@ func LoadKMSClient(masterKey []byte) (KMSClient, string, error) {
 	case KMSBackendNone, "off", "disabled":
 		return nil, "disabled (CONTAINARIUM_KMS_BACKEND=none)", nil
 	case KMSBackendInProc:
-		k, err := NewInProcKMS(masterKey)
+		k, err := corecrypto.NewInProcKMS(masterKey)
 		if err != nil {
 			return nil, "", fmt.Errorf("KMS backend inproc: %w", err)
 		}
@@ -63,7 +56,7 @@ func LoadKMSClient(masterKey []byte) (KMSClient, string, error) {
 		if err != nil {
 			return nil, "", fmt.Errorf("KMS backend vault: %w", err)
 		}
-		k, err := NewVaultKMS(cfg)
+		k, err := corecrypto.NewVaultKMS(cfg)
 		if err != nil {
 			return nil, "", fmt.Errorf("KMS backend vault: %w", err)
 		}
@@ -74,7 +67,7 @@ func LoadKMSClient(masterKey []byte) (KMSClient, string, error) {
 		if err != nil {
 			return nil, "", fmt.Errorf("KMS backend gcp: %w", err)
 		}
-		k, err := NewGCPKMS(cfg)
+		k, err := corecrypto.NewGCPKMS(cfg)
 		if err != nil {
 			return nil, "", fmt.Errorf("KMS backend gcp: %w", err)
 		}
@@ -84,7 +77,7 @@ func LoadKMSClient(masterKey []byte) (KMSClient, string, error) {
 		if err != nil {
 			return nil, "", fmt.Errorf("KMS backend aws: %w", err)
 		}
-		k, err := NewAWSKMS(cfg)
+		k, err := corecrypto.NewAWSKMS(cfg)
 		if err != nil {
 			return nil, "", fmt.Errorf("KMS backend aws: %w", err)
 		}
@@ -94,17 +87,15 @@ func LoadKMSClient(masterKey []byte) (KMSClient, string, error) {
 	}
 }
 
-// vaultConfigFromEnv reads the Vault Transit config from
-// env. Required: CONTAINARIUM_VAULT_ADDR,
-// CONTAINARIUM_VAULT_TOKEN (or _TOKEN_FILE),
-// CONTAINARIUM_VAULT_TRANSIT_KEY. Optional:
-// CONTAINARIUM_VAULT_TRANSIT_MOUNT (default "transit"),
-// CONTAINARIUM_VAULT_TIMEOUT (default 5s).
-func vaultConfigFromEnv() (VaultConfig, error) {
-	cfg := VaultConfig{
-		Address: strings.TrimSpace(os.Getenv("CONTAINARIUM_VAULT_ADDR")),
-		Mount:   strings.TrimSpace(os.Getenv("CONTAINARIUM_VAULT_TRANSIT_MOUNT")),
-		KeyName: strings.TrimSpace(os.Getenv("CONTAINARIUM_VAULT_TRANSIT_KEY")),
+// vaultConfigFromEnv reads the Vault Transit config from env. Required:
+// CONTAINARIUM_VAULT_ADDR, CONTAINARIUM_VAULT_TOKEN (or _TOKEN_FILE),
+// CONTAINARIUM_VAULT_TRANSIT_KEY. Optional: CONTAINARIUM_VAULT_TRANSIT_MOUNT
+// (default "transit"), CONTAINARIUM_VAULT_TIMEOUT (default 5s).
+func vaultConfigFromEnv() (corecrypto.VaultConfig, error) {
+	cfg := corecrypto.VaultConfig{
+		Address: strings.TrimSpace(os.Getenv(config.EnvVaultAddr)),
+		Mount:   strings.TrimSpace(os.Getenv(config.EnvVaultTransitMount)),
+		KeyName: strings.TrimSpace(os.Getenv(config.EnvVaultTransitKey)),
 	}
 	if cfg.Address == "" {
 		return cfg, fmt.Errorf("CONTAINARIUM_VAULT_ADDR is required")
@@ -113,12 +104,11 @@ func vaultConfigFromEnv() (VaultConfig, error) {
 		return cfg, fmt.Errorf("CONTAINARIUM_VAULT_TRANSIT_KEY is required")
 	}
 
-	// Token: env wins over file. Either is fine; file is
-	// the recommended path for long-lived daemons (Vault
-	// Agent writes a fresh token there and renews it).
-	if tok := strings.TrimSpace(os.Getenv("CONTAINARIUM_VAULT_TOKEN")); tok != "" {
+	// Token: env wins over file. Either is fine; file is the recommended path for
+	// long-lived daemons (Vault Agent writes a fresh token there and renews it).
+	if tok := strings.TrimSpace(os.Getenv(config.EnvVaultToken)); tok != "" {
 		cfg.Token = tok
-	} else if path := strings.TrimSpace(os.Getenv("CONTAINARIUM_VAULT_TOKEN_FILE")); path != "" {
+	} else if path := strings.TrimSpace(os.Getenv(config.EnvVaultTokenFile)); path != "" {
 		tok, err := readBearerLikeFile(path)
 		if err != nil {
 			return cfg, fmt.Errorf("read CONTAINARIUM_VAULT_TOKEN_FILE: %w", err)
@@ -129,7 +119,7 @@ func vaultConfigFromEnv() (VaultConfig, error) {
 		return cfg, fmt.Errorf("set either CONTAINARIUM_VAULT_TOKEN or CONTAINARIUM_VAULT_TOKEN_FILE")
 	}
 
-	if t := strings.TrimSpace(os.Getenv("CONTAINARIUM_VAULT_TIMEOUT")); t != "" {
+	if t := strings.TrimSpace(os.Getenv(config.EnvVaultTimeout)); t != "" {
 		d, err := time.ParseDuration(t)
 		if err != nil {
 			return cfg, fmt.Errorf("CONTAINARIUM_VAULT_TIMEOUT: %w", err)
@@ -139,15 +129,14 @@ func vaultConfigFromEnv() (VaultConfig, error) {
 	return cfg, nil
 }
 
-// gcpConfigFromEnv reads the Cloud KMS config from env.
-// Required: CONTAINARIUM_GCP_KMS_KEY_NAME and one of
-// CONTAINARIUM_GCP_KMS_TOKEN / _TOKEN_FILE. Optional:
-// CONTAINARIUM_GCP_KMS_ENDPOINT (private-endpoint deployments
-// override this), CONTAINARIUM_GCP_KMS_TIMEOUT (default 5s).
-func gcpConfigFromEnv() (GCPConfig, error) {
-	cfg := GCPConfig{
-		KeyName:  strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_KEY_NAME")),
-		Endpoint: strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_ENDPOINT")),
+// gcpConfigFromEnv reads the Cloud KMS config from env. Required:
+// CONTAINARIUM_GCP_KMS_KEY_NAME and one of CONTAINARIUM_GCP_KMS_TOKEN /
+// _TOKEN_FILE. Optional: CONTAINARIUM_GCP_KMS_ENDPOINT (private-endpoint
+// deployments override this), CONTAINARIUM_GCP_KMS_TIMEOUT (default 5s).
+func gcpConfigFromEnv() (corecrypto.GCPConfig, error) {
+	cfg := corecrypto.GCPConfig{
+		KeyName:  strings.TrimSpace(os.Getenv(config.EnvGCPKMSKeyName)),
+		Endpoint: strings.TrimSpace(os.Getenv(config.EnvGCPKMSEndpoint)),
 	}
 	if cfg.KeyName == "" {
 		return cfg, fmt.Errorf("CONTAINARIUM_GCP_KMS_KEY_NAME is required (e.g. projects/<p>/locations/<l>/keyRings/<r>/cryptoKeys/<k>)")
@@ -158,8 +147,8 @@ func gcpConfigFromEnv() (GCPConfig, error) {
 	// out-of-band sidecar refreshes (gcloud auth print-access-token / the GCE
 	// metadata server, written atomically). The backend re-reads the file before
 	// each call, so a refresh takes effect without a daemon restart. #300.
-	cfg.Token = strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_TOKEN"))
-	cfg.TokenFile = strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_TOKEN_FILE"))
+	cfg.Token = strings.TrimSpace(os.Getenv(config.EnvGCPKMSToken))
+	cfg.TokenFile = strings.TrimSpace(os.Getenv(config.EnvGCPKMSTokenFile))
 	if cfg.Token == "" && cfg.TokenFile == "" {
 		return cfg, fmt.Errorf("set either CONTAINARIUM_GCP_KMS_TOKEN or CONTAINARIUM_GCP_KMS_TOKEN_FILE")
 	}
@@ -171,7 +160,7 @@ func gcpConfigFromEnv() (GCPConfig, error) {
 		}
 	}
 
-	if t := strings.TrimSpace(os.Getenv("CONTAINARIUM_GCP_KMS_TIMEOUT")); t != "" {
+	if t := strings.TrimSpace(os.Getenv(config.EnvGCPKMSTimeout)); t != "" {
 		d, err := time.ParseDuration(t)
 		if err != nil {
 			return cfg, fmt.Errorf("CONTAINARIUM_GCP_KMS_TIMEOUT: %w", err)
@@ -181,20 +170,18 @@ func gcpConfigFromEnv() (GCPConfig, error) {
 	return cfg, nil
 }
 
-// awsConfigFromEnv reads the AWS KMS config from env.
-// Required: CONTAINARIUM_AWS_KMS_REGION,
-// CONTAINARIUM_AWS_KMS_KEY_ID, CONTAINARIUM_AWS_ACCESS_KEY_ID,
-// and one of CONTAINARIUM_AWS_SECRET_ACCESS_KEY / _FILE.
-// Optional: CONTAINARIUM_AWS_SESSION_TOKEN / _FILE (STS temp
-// creds), CONTAINARIUM_AWS_KMS_ENDPOINT (VPC-endpoint /
-// air-gapped deployments override this),
-// CONTAINARIUM_AWS_KMS_TIMEOUT (default 5s).
-func awsConfigFromEnv() (AWSConfig, error) {
-	cfg := AWSConfig{
-		Region:      strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_KMS_REGION")),
-		KeyID:       strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_KMS_KEY_ID")),
-		AccessKeyID: strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_ACCESS_KEY_ID")),
-		Endpoint:    strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_KMS_ENDPOINT")),
+// awsConfigFromEnv reads the AWS KMS config from env. Required:
+// CONTAINARIUM_AWS_KMS_REGION, CONTAINARIUM_AWS_KMS_KEY_ID,
+// CONTAINARIUM_AWS_ACCESS_KEY_ID, and one of CONTAINARIUM_AWS_SECRET_ACCESS_KEY
+// / _FILE. Optional: CONTAINARIUM_AWS_SESSION_TOKEN / _FILE (STS temp creds),
+// CONTAINARIUM_AWS_KMS_ENDPOINT (VPC-endpoint / air-gapped deployments override
+// this), CONTAINARIUM_AWS_KMS_TIMEOUT (default 5s).
+func awsConfigFromEnv() (corecrypto.AWSConfig, error) {
+	cfg := corecrypto.AWSConfig{
+		Region:      strings.TrimSpace(os.Getenv(config.EnvAWSKMSRegion)),
+		KeyID:       strings.TrimSpace(os.Getenv(config.EnvAWSKMSKeyID)),
+		AccessKeyID: strings.TrimSpace(os.Getenv(config.EnvAWSAccessKeyID)),
+		Endpoint:    strings.TrimSpace(os.Getenv(config.EnvAWSKMSEndpoint)),
 	}
 	if cfg.Region == "" {
 		return cfg, fmt.Errorf("CONTAINARIUM_AWS_KMS_REGION is required")
@@ -206,12 +193,12 @@ func awsConfigFromEnv() (AWSConfig, error) {
 		return cfg, fmt.Errorf("CONTAINARIUM_AWS_ACCESS_KEY_ID is required")
 	}
 
-	// Secret access key: env wins over file. File is the
-	// recommended long-lived path — an IRSA / IMDS sidecar
-	// refreshes the credential and writes it atomically.
-	if sk := os.Getenv("CONTAINARIUM_AWS_SECRET_ACCESS_KEY"); sk != "" {
+	// Secret access key: env wins over file. File is the recommended long-lived
+	// path — an IRSA / IMDS sidecar refreshes the credential and writes it
+	// atomically.
+	if sk := os.Getenv(config.EnvAWSSecretAccessKey); sk != "" {
 		cfg.SecretAccessKey = sk
-	} else if path := strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_SECRET_ACCESS_KEY_FILE")); path != "" {
+	} else if path := strings.TrimSpace(os.Getenv(config.EnvAWSSecretAccessKeyFile)); path != "" {
 		sk, err := readBearerLikeFile(path)
 		if err != nil {
 			return cfg, fmt.Errorf("read CONTAINARIUM_AWS_SECRET_ACCESS_KEY_FILE: %w", err)
@@ -222,11 +209,11 @@ func awsConfigFromEnv() (AWSConfig, error) {
 		return cfg, fmt.Errorf("set either CONTAINARIUM_AWS_SECRET_ACCESS_KEY or CONTAINARIUM_AWS_SECRET_ACCESS_KEY_FILE")
 	}
 
-	// Session token: optional (only for STS temp creds).
-	// Same env-wins-over-file contract.
-	if st := os.Getenv("CONTAINARIUM_AWS_SESSION_TOKEN"); st != "" {
+	// Session token: optional (only for STS temp creds). Same env-wins-over-file
+	// contract.
+	if st := os.Getenv(config.EnvAWSSessionToken); st != "" {
 		cfg.SessionToken = st
-	} else if path := strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_SESSION_TOKEN_FILE")); path != "" {
+	} else if path := strings.TrimSpace(os.Getenv(config.EnvAWSSessionTokenFile)); path != "" {
 		st, err := readBearerLikeFile(path)
 		if err != nil {
 			return cfg, fmt.Errorf("read CONTAINARIUM_AWS_SESSION_TOKEN_FILE: %w", err)
@@ -234,7 +221,7 @@ func awsConfigFromEnv() (AWSConfig, error) {
 		cfg.SessionToken = st
 	}
 
-	if t := strings.TrimSpace(os.Getenv("CONTAINARIUM_AWS_KMS_TIMEOUT")); t != "" {
+	if t := strings.TrimSpace(os.Getenv(config.EnvAWSKMSTimeout)); t != "" {
 		d, err := time.ParseDuration(t)
 		if err != nil {
 			return cfg, fmt.Errorf("CONTAINARIUM_AWS_KMS_TIMEOUT: %w", err)
@@ -244,13 +231,9 @@ func awsConfigFromEnv() (AWSConfig, error) {
 	return cfg, nil
 }
 
-// readBearerLikeFile reads a credential file with the
-// same perm contract as the JWT / Postgres secret files:
-// mode must be ≤ 0600. Whitespace trimmed.
-//
-// Local helper so this file doesn't import the gateway/
-// auth package. The contract is duplicated by intent —
-// each secret-file reader stays self-contained.
+// readBearerLikeFile reads a credential file with the same perm contract as the
+// JWT / Postgres secret files: mode must be ≤ 0600. Whitespace trimmed. The
+// contract is duplicated by intent — each secret-file reader stays self-contained.
 func readBearerLikeFile(path string) (string, error) {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/internal/secrets/kms_factory_test.go
+++ b/internal/secrets/kms_factory_test.go
@@ -6,9 +6,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	corecrypto "github.com/footprintai/containarium/pkg/core/secrets"
 )
 
-// Phase 4.1 — KMS backend selector tests.
+// Phase 4.1 — KMS backend selector tests. Moved here with the factory: the
+// env-reading + dispatch now lives in the app layer (internal/secrets), while
+// pkg/core/secrets keeps only the env-free *Config structs + constructors.
 
 func clearKMSEnv(t *testing.T) {
 	t.Helper()
@@ -41,7 +45,7 @@ func clearKMSEnv(t *testing.T) {
 
 func mkMaster(t *testing.T) []byte {
 	t.Helper()
-	k := make([]byte, MasterKeySize)
+	k := make([]byte, corecrypto.MasterKeySize)
 	if _, err := io.ReadFull(rand.Reader, k); err != nil {
 		t.Fatalf("rand: %v", err)
 	}
@@ -81,7 +85,7 @@ func TestLoadKMSClient_InProcReturnsImpl(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if _, ok := c.(*InProcKMS); !ok {
+	if _, ok := c.(*corecrypto.InProcKMS); !ok {
 		t.Fatalf("expected *InProcKMS; got %T", c)
 	}
 	if desc == "" {
@@ -136,7 +140,7 @@ func TestLoadKMSClient_VaultTokenFromFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if _, ok := c.(*VaultKMS); !ok {
+	if _, ok := c.(*corecrypto.VaultKMS); !ok {
 		t.Fatalf("expected *VaultKMS; got %T", c)
 	}
 	if desc == "" {
@@ -293,7 +297,7 @@ func TestLoadKMSClient_AWSFromEnvSucceeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if _, ok := c.(*AWSKMS); !ok {
+	if _, ok := c.(*corecrypto.AWSKMS); !ok {
 		t.Fatalf("expected *AWSKMS; got %T", c)
 	}
 	if desc == "" || desc[:3] != "aws" {
@@ -356,7 +360,7 @@ func TestLoadKMSClient_AWSSecretFromFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if _, ok := c.(*AWSKMS); !ok {
+	if _, ok := c.(*corecrypto.AWSKMS); !ok {
 		t.Fatalf("expected *AWSKMS from secret-file path; got %T", c)
 	}
 }

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -627,7 +627,7 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 						// On err the store still opens in legacy mode
 						// (no envelope) — operators see the WARNING
 						// rather than the daemon refusing to start.
-						kms, kdesc, kerr := corecryptosecrets.LoadKMSClient(key)
+						kms, kdesc, kerr := secretsstore.LoadKMSClient(key)
 						if kerr != nil {
 							log.Printf("Warning: KMS backend config error: %v. Secrets store falling back to legacy mode.", kerr)
 							kms = nil

--- a/pkg/core/secrets/credfile.go
+++ b/pkg/core/secrets/credfile.go
@@ -1,0 +1,34 @@
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// readBearerLikeFile reads a credential file with the same perm contract as the
+// JWT / Postgres secret files: mode must be ≤ 0600. Whitespace trimmed.
+//
+// The GCP KMS backend re-reads its token file via this helper before each call
+// so an out-of-band refresh takes effect without a daemon restart (#300). The
+// app-layer KMS factory (internal/secrets) keeps its own copy for load-time
+// resolution — the contract is duplicated by intent so each secret-file reader
+// stays self-contained.
+func readBearerLikeFile(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("stat %s: %w", path, err)
+	}
+	if mode := info.Mode().Perm(); mode&0o077 != 0 {
+		return "", fmt.Errorf("%s has insecure permissions %#o (any non-owner read/write bit set); chmod 0600", path, mode)
+	}
+	b, err := os.ReadFile(path) // #nosec G304 -- operator-supplied, perm-checked
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	s := strings.TrimSpace(string(b))
+	if s == "" {
+		return "", fmt.Errorf("%s is empty", path)
+	}
+	return s, nil
+}


### PR DESCRIPTION
## What

Fourth migration onto the `internal/config` pattern — the KMS-credential namespaces (`CONTAINARIUM_KMS_BACKEND` + `AWS_*` / `VAULT_*` / `GCP_*`). These are different from the prior three: their values are consumed **inside `pkg/core/secrets`** (which pulls in cloud-provider SDKs), and loading them involves credential **file-fallbacks**, per-backend **validation**, and **duration parsing**.

## Boundary decision: (b) — keep `pkg/core` clean

- **`internal/config`** owns the namespace *identity* only: the `Env*` **name constants** (stdlib-only, so `internal/config` stays lightweight and no cloud SDK is dragged into its many importers).
- The **read + resolve + validate + dispatch factory** moves from `pkg/core/secrets/kms_factory.go` to **`internal/secrets`** (the app layer, which already imports `pkg/core/secrets` as `corecrypto`). Its env literals now reference the config constants.
- **`pkg/core/secrets` becomes env-free for KMS** — it keeps only the typed `*Config` structs + constructors. `readBearerLikeFile` is retained there (new `credfile.go`) because the **GCP backend re-reads its token file per call at runtime** (#300) — duplicated by intent, exactly as the original code documented.

## Safety

- The full factory test suite **moves with the factory** (24 cases; type assertions become `corecrypto.*`). `pkg/core/secrets` constructor tests still pass.
- Both callers — `secrets_migrate.go` (CLI) and `dual_server.go` (daemon) — switch to `internal/secrets.LoadKMSClient`; one-liners, their other uses of the core package keep the existing import.
- The factory logic is moved **verbatim** (only type prefixes + literal→constant), so backend behavior is unchanged.
- 8 credential-named constants get justified `// #nosec G101` (env-var *names*, not credentials), matching the SENTINEL/K8S precedent — verified locally (gosec G101: 0 issues).

## Verify

`go build ./...` + `-tags k8s` clean; `internal/{config,secrets,cmd,server}` + `pkg/core/secrets` suites green; gofmt + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)