### PR TITLE
feat(backup): one-copy policy + restore-tenant.sh

### DIFF
--- a/scripts/backup-all-tenants.sh
+++ b/scripts/backup-all-tenants.sh
@@ -2,6 +2,10 @@
 # Iterate the tenant config and create a GCS backup for each entry.
 # Designed to be driven by containarium-backup.{service,timer}.
 #
+# One-copy policy: before creating a new backup the script deletes any
+# existing backups for the same tenant, so there is always at most one dump
+# per tenant in the index.  restore-tenant.sh relies on this invariant.
+#
 # Config file format (/etc/containarium/backup-tenants.conf):
 #   # comment
 #   <tenant>  <database>  [PASSWORD_ENV_VAR]
@@ -11,7 +15,7 @@
 # (the common default — pg_dump runs as root inside the container on loopback).
 #
 # Required environment variables (set in /etc/containarium/backup.env):
-#   CONTAINARIUM_SERVER       daemon address, e.g. localhost:8080
+#   CONTAINARIUM_SERVER         daemon address, e.g. localhost:8080
 #   CONTAINARIUM_BACKUP_BUCKET  GCS bucket prefix, e.g. gs://my-backups/pg
 #
 # Optional:
@@ -33,7 +37,6 @@ if [[ ! -f "$CONF" ]]; then
   exit 1
 fi
 
-# Build auth flag once (empty string = no flag).
 auth_flags=()
 if [[ -n "$TOKEN" ]]; then
   auth_flags=(--token "$TOKEN")
@@ -43,14 +46,12 @@ failed=0
 total=0
 
 while IFS=$' \t' read -r tenant database pw_env _rest; do
-  # Skip blank lines and comments.
   [[ -z "$tenant" || "$tenant" == \#* ]] && continue
 
   total=$((total + 1))
 
   pw_flags=()
   if [[ -n "${pw_env:-}" ]]; then
-    # Indirect expansion: read the named variable for the password.
     pw_value="${!pw_env:-}"
     if [[ -z "$pw_value" ]]; then
       echo "[backup] WARNING: $pw_env is not set; attempting without password (tenant=$tenant db=$database)" >&2
@@ -59,7 +60,21 @@ while IFS=$' \t' read -r tenant database pw_env _rest; do
     fi
   fi
 
-  echo "[backup] start tenant=$tenant db=$database"
+  # One-copy policy: delete any existing backup(s) for this tenant before
+  # creating a fresh one.  This keeps the index lean and makes restore trivial
+  # (the single record is always the current good dump).
+  while IFS= read -r old_id; do
+    [[ -z "$old_id" ]] && continue
+    echo "[backup] prune  tenant=$tenant id=$old_id"
+    "$CTN" backup delete "$old_id" \
+        --server "$SERVER" \
+        "${auth_flags[@]}" || true   # non-fatal: stale index entry, carry on
+  done < <("$CTN" backup list "$tenant" \
+      --server "$SERVER" \
+      "${auth_flags[@]}" 2>/dev/null \
+    | awk 'NR>1 {print $1}')
+
+  echo "[backup] start  tenant=$tenant db=$database"
   if "$CTN" backup create "$tenant" \
       --database "$database" \
       --dest gcs \
@@ -67,9 +82,9 @@ while IFS=$' \t' read -r tenant database pw_env _rest; do
       --server "$SERVER" \
       "${auth_flags[@]}" \
       "${pw_flags[@]}"; then
-    echo "[backup] ok    tenant=$tenant db=$database"
+    echo "[backup] ok     tenant=$tenant db=$database"
   else
-    echo "[backup] FAIL  tenant=$tenant db=$database" >&2
+    echo "[backup] FAIL   tenant=$tenant db=$database" >&2
     failed=$((failed + 1))
   fi
 done < "$CONF"

--- a/scripts/restore-tenant.sh
+++ b/scripts/restore-tenant.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Restore the single on-file backup for a tenant.
+#
+# Usage:
+#   restore-tenant.sh <tenant> [--database <name>] [--dry-run]
+#
+# One-copy policy: backup-all-tenants.sh keeps at most one backup per tenant.
+# This script locates that record, verifies exactly one exists, and runs
+# `containarium backup restore` with --clean (drops + recreates objects before
+# loading).
+#
+# Required environment variables (same as backup-all-tenants.sh, loaded from
+# /etc/containarium/backup.env by the operator or the calling shell):
+#   CONTAINARIUM_SERVER  daemon address, e.g. localhost:8080
+#
+# Optional:
+#   CONTAINARIUM_AUTH_TOKEN  JWT for --token
+#   CONTAINARIUM_BIN         path to containarium binary
+
+set -uo pipefail
+
+usage() {
+  echo "Usage: $0 <tenant> [--database <name>] [--dry-run]" >&2
+  exit 1
+}
+
+[[ $# -eq 0 ]] && usage
+
+TENANT="$1"; shift
+SERVER="${CONTAINARIUM_SERVER:?CONTAINARIUM_SERVER must be set}"
+CTN="${CONTAINARIUM_BIN:-/usr/local/bin/containarium}"
+TOKEN="${CONTAINARIUM_AUTH_TOKEN:-}"
+DATABASE=""
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --database) DATABASE="$2"; shift 2 ;;
+    --dry-run)  DRY_RUN=1; shift ;;
+    *) echo "[restore] unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+auth_flags=()
+if [[ -n "$TOKEN" ]]; then
+  auth_flags=(--token "$TOKEN")
+fi
+
+# Locate the single backup record for this tenant.
+mapfile -t ids < <("$CTN" backup list "$TENANT" \
+    --server "$SERVER" \
+    "${auth_flags[@]}" 2>/dev/null \
+  | awk 'NR>1 {print $1}')
+
+if [[ ${#ids[@]} -eq 0 ]]; then
+  echo "[restore] no backup found for tenant=$TENANT" >&2
+  exit 1
+fi
+
+if [[ ${#ids[@]} -gt 1 ]]; then
+  echo "[restore] ERROR: ${#ids[@]} backups found for tenant=$TENANT (expected 1)." >&2
+  echo "[restore] Run 'containarium backup list $TENANT' and delete extras, then retry." >&2
+  exit 1
+fi
+
+ID="${ids[0]}"
+echo "[restore] tenant=$TENANT id=$ID"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[restore] dry-run: would run: containarium backup restore $ID --clean${DATABASE:+ --database $DATABASE}"
+  exit 0
+fi
+
+db_flags=()
+if [[ -n "$DATABASE" ]]; then
+  db_flags=(--database "$DATABASE")
+fi
+
+echo "[restore] restoring (--clean: drops + recreates objects before loading)…"
+"$CTN" backup restore "$ID" \
+    --clean \
+    --server "$SERVER" \
+    "${auth_flags[@]}" \
+    "${db_flags[@]}"
+
+echo "[restore] done tenant=$TENANT id=$ID"


### PR DESCRIPTION
## Summary

Follow-up to #875.

- **`scripts/backup-all-tenants.sh`** — before creating a new dump, prune any existing backups for the same tenant (\`backup list | delete\` loop), so the index holds at most one record per tenant at any time
- **`scripts/restore-tenant.sh`** — locate the single on-file backup for a tenant and run \`backup restore --clean\`; errors explicitly if 0 or >1 records found; supports \`--database\` override and \`--dry-run\`

## Docker-in-LXC deployment note

When the tenant's Postgres runs **inside a Docker container within the LXC** (rather than as a native service on the LXC host), the daemon's default behaviour — exec into the LXC and run \`pg_dump -h 127.0.0.1:5432\` — won't reach the Postgres instance because the Docker container's port is on the internal bridge network, not the LXC host.

The operator fix is a thin \`/usr/local/bin/pg_dump\` wrapper in the LXC that routes to the Docker Postgres via Unix socket:

\`\`\`bash
#!/usr/bin/env bash
# Strip -h/-p/-U (daemon passes 127.0.0.1:5432/postgres; we override with socket).
# Intercept -f <path>: docker exec writes inside its own FS, so we redirect
# stdout to the LXC-side path instead so incus file get can read it.
outfile=""
args=()
skip=0; skip_f=0
for arg in "$@"; do
    if [[ $skip  -eq 1 ]]; then skip=0;  continue; fi
    if [[ $skip_f -eq 1 ]]; then outfile="$arg"; skip_f=0; continue; fi
    case "$arg" in
        -h|-p|-U) skip=1 ;;
        -h*|-p*|-U*) ;;
        -f)  skip_f=1 ;;
        -f*) outfile="${arg#-f}" ;;
        *) args+=("$arg") ;;
    esac
done
if [[ -n "$outfile" ]]; then
    docker exec -i <pg-container> pg_dump -U <pg-user> -h /var/run/postgresql "${args[@]}" > "$outfile"
else
    exec docker exec -i <pg-container> pg_dump -U <pg-user> -h /var/run/postgresql "${args[@]}"
fi
\`\`\`

The \`-f\` interception is necessary because the daemon passes \`-f /tmp/<id>.dump\` and then retrieves that path via \`incus file get\`; without it the file lands inside the Docker container's filesystem where the daemon can't see it.

Two additional operator-side systemd drop-ins are required for the \`containarium.service\` (when \`ProtectSystem=strict\` is in use):

- \`backup-rw.conf\`: add \`ReadWritePaths=/var/lib/containarium\` so the daemon can write the staging dump and JSON index
- \`gcs-exec.conf\`: set \`NoNewPrivileges=false\` so snap-packaged \`gcloud\` can transition its AppArmor profile on exec

## Test plan

- [ ] Run \`backup-all-tenants.sh\` twice for the same tenant — confirm only one backup appears in \`backup list\` after each run
- [ ] \`restore-tenant.sh <tenant> --dry-run\` prints the restore command without executing
- [ ] \`restore-tenant.sh <tenant>\` restores the single backup successfully
- [ ] \`restore-tenant.sh <unknown>\` exits 1 with "no backup found"
- [ ] Manually add a second backup record and confirm \`restore-tenant.sh\` exits 1 with ">1 backups found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)