### PR TITLE
refactor(config): migrate the JWT namespace into internal/config

### DIFF
--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/footprintai/containarium/internal/config"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -117,7 +118,7 @@ func NewTokenManager(secretKey string, issuer string) (*TokenManager, error) {
 	}
 
 	audience := DefaultAudience
-	if env := os.Getenv("CONTAINARIUM_JWT_AUDIENCE"); env != "" {
+	if env := os.Getenv(config.EnvJWTAudience); env != "" {
 		audience = env
 	}
 

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/footprintai/containarium/internal/app"
+	"github.com/footprintai/containarium/internal/config"
 	"github.com/footprintai/containarium/internal/mtls"
 	"github.com/footprintai/containarium/internal/server"
 	"github.com/footprintai/containarium/pkg/core/container"
@@ -469,7 +470,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	var isRandomSecret bool
 	if enableREST {
 		// Priority 1: Environment variable (silent - production use)
-		if envSecret := os.Getenv("CONTAINARIUM_JWT_SECRET"); envSecret != "" {
+		if envSecret := os.Getenv(config.EnvJWTSecret); envSecret != "" {
 			finalJWTSecret = envSecret
 			log.Printf("Using JWT secret from CONTAINARIUM_JWT_SECRET environment variable")
 		} else if jwtSecretFile != "" {

--- a/internal/cmd/security.go
+++ b/internal/cmd/security.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/footprintai/containarium/internal/config"
 	"github.com/footprintai/containarium/internal/mcp"
 	"github.com/spf13/cobra"
 )
@@ -182,7 +183,7 @@ func newSecurityClient() (*mcp.Client, error) {
 	if serverURL == "" {
 		return nil, fmt.Errorf("set CONTAINARIUM_SERVER_URL or use --server")
 	}
-	token := os.Getenv("CONTAINARIUM_JWT_TOKEN")
+	token := os.Getenv(config.EnvJWTToken)
 	if token == "" {
 		return nil, fmt.Errorf("set CONTAINARIUM_JWT_TOKEN to a daemon-issued JWT")
 	}

--- a/internal/config/jwt.go
+++ b/internal/config/jwt.go
@@ -1,0 +1,34 @@
+package config
+
+// CONTAINARIUM_JWT_* variable names — REST/MCP bearer auth. The token names
+// contain "secret"/"token"; gosec G101 flags such constant identifiers assigned
+// a string literal, so each is annotated (they are env-var NAMES, not values).
+const (
+	EnvJWTSecret    = "CONTAINARIUM_JWT_SECRET"     // #nosec G101 -- env var name, not a credential value
+	EnvJWTToken     = "CONTAINARIUM_JWT_TOKEN"      // #nosec G101 -- env var name, not a credential value
+	EnvJWTTokenFile = "CONTAINARIUM_JWT_TOKEN_FILE" // #nosec G101 -- env var name, not a credential value
+	EnvJWTAudience  = "CONTAINARIUM_JWT_AUDIENCE"
+)
+
+// JWT is the typed view of the CONTAINARIUM_JWT_* namespace.
+type JWT struct {
+	// Secret is the REST API's JWT signing secret (server side). (EnvJWTSecret)
+	Secret string
+	// Token is the bearer token a client presents. (EnvJWTToken)
+	Token string
+	// TokenFile is a file holding the bearer token (read by the client).
+	// (EnvJWTTokenFile)
+	TokenFile string
+	// Audience is the expected `aud` claim. (EnvJWTAudience)
+	Audience string
+}
+
+// LoadJWT reads the CONTAINARIUM_JWT_* namespace once.
+func LoadJWT() JWT {
+	return JWT{
+		Secret:    getString(EnvJWTSecret, ""),
+		Token:     getString(EnvJWTToken, ""),
+		TokenFile: getString(EnvJWTTokenFile, ""),
+		Audience:  getString(EnvJWTAudience, ""),
+	}
+}

--- a/internal/config/jwt_test.go
+++ b/internal/config/jwt_test.go
@@ -1,0 +1,24 @@
+package config
+
+import "testing"
+
+func TestLoadJWTEmpty(t *testing.T) {
+	for _, k := range []string{EnvJWTSecret, EnvJWTToken, EnvJWTTokenFile, EnvJWTAudience} {
+		t.Setenv(k, "")
+	}
+	if got := LoadJWT(); got != (JWT{}) {
+		t.Errorf("LoadJWT with empty env = %+v, want zero value", got)
+	}
+}
+
+func TestLoadJWTReadsEnv(t *testing.T) {
+	t.Setenv(EnvJWTSecret, "s3cr3t")
+	t.Setenv(EnvJWTToken, "bearer-xyz")
+	t.Setenv(EnvJWTTokenFile, "/run/jwt.token")
+	t.Setenv(EnvJWTAudience, "containarium-api")
+
+	want := JWT{Secret: "s3cr3t", Token: "bearer-xyz", TokenFile: "/run/jwt.token", Audience: "containarium-api"}
+	if got := LoadJWT(); got != want {
+		t.Errorf("LoadJWT = %+v, want %+v", got, want)
+	}
+}

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/footprintai/containarium/internal/config"
 	"github.com/footprintai/containarium/internal/credentials"
 )
 
@@ -54,10 +55,11 @@ func LoadConfig() *Config {
 		debug, _ = strconv.ParseBool(debugStr)
 	}
 
+	jwt := config.LoadJWT()
 	cfg := &Config{
 		ServerURL:    os.Getenv("CONTAINARIUM_SERVER_URL"),
-		JWTToken:     os.Getenv("CONTAINARIUM_JWT_TOKEN"),
-		JWTTokenFile: os.Getenv("CONTAINARIUM_JWT_TOKEN_FILE"),
+		JWTToken:     jwt.Token,
+		JWTTokenFile: jwt.TokenFile,
 		Debug:        debug,
 	}
 


### PR DESCRIPTION
## What

Fifth namespace onto the `internal/config` pattern. Adds **`config.JWT`** — `Env*` name constants for the four `CONTAINARIUM_JWT_*` variables, a typed struct, and `LoadJWT()`.

## Why this one (cross-package de-sprawl)

The four JWT vars were read inline in **four different packages**: `internal/cmd` (security.go, daemon.go), `internal/auth` (token.go), `internal/mcp` (config.go). That cross-package spread is the duplication the pattern targets.

- All five reads now reference the `config.EnvJWT*` constants — **zero behavior change** (same keys).
- `mcp/config.go` adopts the typed `config.LoadJWT()` struct where it reads `JWT_TOKEN` + `JWT_TOKEN_FILE` together.
- The three credential-named constants (`Secret`/`Token`/`TokenFile`) get justified `// #nosec G101` (env-var *names*, not credentials) — verified locally (gosec G101: 0 issues).

## Tests

`internal/config` JWT tests (empty load, full env read). `go build ./...` + `-tags k8s` clean; `internal/{config,auth,mcp,cmd}` suites pass; gofmt + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)