### PR TITLE
refactor(config): migrate small server namespaces (OTEL/WAF/GATEWAY)

### DIFF
--- a/internal/config/gateway.go
+++ b/internal/config/gateway.go
@@ -1,0 +1,7 @@
+package config
+
+// CONTAINARIUM_GATEWAY_* variable names — the model/output gateway.
+const (
+	// EnvGatewayOutputFilter — output filtering is on unless set to "0".
+	EnvGatewayOutputFilter = "CONTAINARIUM_GATEWAY_OUTPUT_FILTER"
+)

--- a/internal/config/otel.go
+++ b/internal/config/otel.go
@@ -1,0 +1,7 @@
+package config
+
+// CONTAINARIUM_OTEL_* variable names — the daemon's core OTel collector.
+const (
+	EnvOTELRequireAuth   = "CONTAINARIUM_OTEL_REQUIRE_AUTH"
+	EnvOTELCollectorBind = "CONTAINARIUM_OTEL_COLLECTOR_BIND"
+)

--- a/internal/config/waf.go
+++ b/internal/config/waf.go
@@ -1,0 +1,10 @@
+package config
+
+// CONTAINARIUM_WAF_* variable names — the in-daemon WAF (tproxy inspection +
+// ingress). WAF_INSPECT / WAF_INGRESS use the shared truthy convention
+// (1/true/yes/on) at their read sites.
+const (
+	EnvWAFTProxyAddr = "CONTAINARIUM_WAF_TPROXY_ADDR"
+	EnvWAFInspect    = "CONTAINARIUM_WAF_INSPECT"
+	EnvWAFIngress    = "CONTAINARIUM_WAF_INGRESS"
+)

--- a/internal/server/core_otel_collector.go
+++ b/internal/server/core_otel_collector.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	appconfig "github.com/footprintai/containarium/internal/config"
 	"github.com/footprintai/containarium/pkg/core/incus"
 )
 
@@ -260,7 +261,7 @@ func (cs *CoreServices) applyOTelCollectorConfig(vmIP string, dropLabels []strin
 //     container without the header drops silently (and
 //     that's the signal to find the laggard).
 func collectorBearerForConfig() string {
-	raw := strings.TrimSpace(os.Getenv("CONTAINARIUM_OTEL_REQUIRE_AUTH"))
+	raw := strings.TrimSpace(os.Getenv(appconfig.EnvOTELRequireAuth))
 	on := false
 	switch strings.ToLower(raw) {
 	case "1", "true", "yes", "on":
@@ -398,7 +399,7 @@ func mergeOTelDropLabels(base, extra []string) []string {
 // collector's specific bridge IP) so the listen socket is pinned
 // to the bridge interface explicitly.
 func otelReceiverBindAddress() string {
-	if v := strings.TrimSpace(os.Getenv("CONTAINARIUM_OTEL_COLLECTOR_BIND")); v != "" {
+	if v := strings.TrimSpace(os.Getenv(appconfig.EnvOTELCollectorBind)); v != "" {
 		return v
 	}
 	return "0.0.0.0"

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1343,7 +1343,7 @@ skipAppHosting:
 				// chat path (#670 layer 2). Default on; set
 				// CONTAINARIUM_GATEWAY_OUTPUT_FILTER=0 to disable. Streaming token
 				// metering is independent and always on.
-				OutputFilter: os.Getenv("CONTAINARIUM_GATEWAY_OUTPUT_FILTER") != "0",
+				OutputFilter: os.Getenv(appconfig.EnvGatewayOutputFilter) != "0",
 			})
 			gatewayServer.SetModelGatewayHandler(gw.Handler())
 			primary := gatewayPrimaryProvider(keys)
@@ -2058,7 +2058,7 @@ func (ds *DualServer) Start(ctx context.Context) error {
 	// operator-applied nft TPROXY rule (see the runbook), so an existing
 	// deployment is unaffected. Forward-only at this stage (no inspection); the
 	// Coraza WAF lands in PR-2. A bind failure is non-fatal.
-	if wafAddr := strings.TrimSpace(os.Getenv("CONTAINARIUM_WAF_TPROXY_ADDR")); wafAddr != "" {
+	if wafAddr := strings.TrimSpace(os.Getenv(appconfig.EnvWAFTProxyAddr)); wafAddr != "" {
 		if !waf.ListenAddrValid(wafAddr) {
 			log.Printf("Warning: CONTAINARIUM_WAF_TPROXY_ADDR=%q is not a valid host:port; WAF steering disabled", wafAddr)
 		} else {
@@ -2066,7 +2066,7 @@ func (ds *DualServer) Start(ctx context.Context) error {
 			// PR-2: attach the reference inspector when CONTAINARIUM_WAF_INSPECT=1.
 			// Observe-only unless ENFORCE is also armed (same gate as the kernel
 			// drop path). Blocks audit as network_policy.waf_block.
-			switch strings.ToLower(strings.TrimSpace(os.Getenv("CONTAINARIUM_WAF_INSPECT"))) {
+			switch strings.ToLower(strings.TrimSpace(os.Getenv(appconfig.EnvWAFInspect))) {
 			case "1", "true", "yes", "on":
 				cfg.Inspector = waf.NewBuiltinInspector()
 				switch strings.ToLower(strings.TrimSpace(os.Getenv(appconfig.EnvNetworkPolicyEnforce))) {
@@ -2317,7 +2317,7 @@ func stripHostFromURL(rawURL string) string {
 // default: ingress routes are unchanged unless an operator opts in (and the
 // Caddy binary must be built with the coraza module — CaddyConfig.WAF).
 func wafIngressFromEnv(pm *app.ProxyManager) *app.ProxyManager {
-	if !envTruthy(os.Getenv("CONTAINARIUM_WAF_INGRESS")) {
+	if !envTruthy(os.Getenv(appconfig.EnvWAFIngress)) {
 		return pm
 	}
 	enforce := envTruthy(os.Getenv(appconfig.EnvNetworkPolicyEnforce))


### PR DESCRIPTION
## What

Completes the `internal/config` namespace sweep with the remaining low-volume server-side namespaces. Adds `Env*` name constants for `CONTAINARIUM_OTEL_*` (2), `CONTAINARIUM_WAF_*` (3), `CONTAINARIUM_GATEWAY_*` (1), and points their **6** `os.Getenv` reads (`core_otel_collector.go`, `dual_server.go`) at the constants.

## Scope: names-only, zero behavior change

These are single-reader namespaces with bespoke parsing at each site (`TrimSpace`, a `switch`, `envTruthy`, `!= "0"`). So this is intentionally a **names-only** migration — each read keeps its exact surrounding logic, only the variable string becomes a constant. No structs/`Load` (there's no load-once value for a single reader), and the names carry no credential words so **no gosec suppressions** are needed.

This is the low-de-sprawl tail of the migration; the high-value multi-reader namespaces (SENTINEL, K8S, NETWORK, KMS, JWT) landed in earlier PRs.

## Verify

`go build ./...` + `-tags k8s` clean; `internal/{config,server}` suites pass; gofmt + vet clean; gosec G101 = 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)