### PR TITLE
chore(release): stamp CHANGELOG 0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.47.0] - 2026-06-30
+
 ### Added
 
 - **Per-box default memory floor on the Kubernetes backend.** Boxes created on


### PR DESCRIPTION
Version-stamps the CHANGELOG for the **v0.47.0** release: moves the Unreleased section (per-box memory floor, internal/config namespace migration, KMS env-free lift, docs/chores) under a `[0.47.0] - 2026-06-30` header ahead of the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)