### PR TITLE
fix(build): gate upgrade-watchdog command to !windows (unbreaks release)

### DIFF
--- a/internal/cmd/upgrade_watchdog.go
+++ b/internal/cmd/upgrade_watchdog.go
@@ -1,3 +1,9 @@
+//go:build !windows
+
+// The upgrade watchdog drives the daemon's post-upgrade auto-rollback, so it
+// imports internal/server (which pulls in the Linux-only eBPF loader). The
+// Windows build is client-only — gate this command out of it, matching daemon.go.
+
 package cmd
 
 import (


### PR DESCRIPTION
## Problem

The **v0.47.0 release build failed** — `make build-all`'s Windows cross-compile (`cmd/containarium` for `GOOS=windows`) errored on `internal/netbpf` (`link.AttachTCX`, `link.TCXOptions`, `perf.Record`) and `internal/gateway` (`fileOwner`), so no artifacts were published.

## Root cause (bisected)

First bad commit: **#865** (post-upgrade auto-rollback watchdog), merged before v0.47.0. It added `internal/cmd/upgrade_watchdog.go`, which imports `internal/server` (→ the Linux-only eBPF loader) but **carried no build constraint**. Windows is client-only — `daemon.go` and the other server-importing cmd files are `//go:build !windows`, but this new file wasn't, so the Windows binary started pulling in the daemon + netbpf and failed to compile. v0.46.12 built Windows fine; v0.47.0 was simply the first release after #865.

## Fix

Add `//go:build !windows` to `upgrade_watchdog.go`, matching its siblings. The watchdog is a daemon-side command (Windows has no daemon), so it's correctly absent from the Windows client. Verified: Windows build passes, linux default + `-tags k8s` still clean, command is self-contained (no windows-reachable references).

After this merges, the v0.47.0 tag will be re-pointed to the fixed commit so the release rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)