### PR TITLE
ci: guard the Windows client cross-compile in the required unit job

### DIFF
--- a/.github/workflows/proxyproto-e2e.yml
+++ b/.github/workflows/proxyproto-e2e.yml
@@ -26,6 +26,14 @@ jobs:
         with:
           go-version: '1.25.11'
 
+      - name: Windows client cross-compile guard
+        # The release builds a client-only Windows binary (cmd/containarium for
+        # GOOS=windows). It must not pull in the daemon, which imports the
+        # Linux-only eBPF loader (internal/netbpf). This catches a new cmd file
+        # importing internal/server without a //go:build !windows guard at PR
+        # time instead of at release time (see #884 / v0.47.0).
+        run: GOOS=windows GOARCH=amd64 go build -o /dev/null ./cmd/containarium/
+
       - name: Run sentinel + app tests
         # The skipped tests are pre-existing failures on unprivileged Linux
         # runners (they pass on darwin where loopback aliases are no-ops).


### PR DESCRIPTION
## Why

The v0.47.0 release build failed because a new cmd file (#865's upgrade-watchdog) imported `internal/server` → the Linux-only `internal/netbpf` loader without a `//go:build !windows` guard, breaking the client-only Windows binary. Today the Windows binary is **only** exercised by the release tag, so this class of regression isn't caught until a release is cut (fixed reactively in #884).

## What

Adds a `GOOS=windows GOARCH=amd64 go build ./cmd/containarium/` step to the already-required **Unit + default e2e** job. Now any PR that drags the daemon/eBPF into the Windows client build fails its required check — caught at PR time, not release time. Gating it under an existing required check means no branch-protection change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)