### PR TITLE
fix(otel): stamp the cloud UUID as container.id when cloud-managed (#893)

### DIFF
--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -1465,7 +1465,7 @@ func (s *ContainerServer) AdoptMigratedContainer(ctx context.Context, req *pb.Ad
 			// works (collector remains open).
 			bearer, _ := LoadOrCreateOTelBearer()
 			envVars := container.OTelEnvVarsForMigrationWithBearer(
-				req.Username, containerName, s.localBackendID(), s.otelCollectorEndpoint, bearer,
+				req.Username, container.OTelContainerID(info.Labels, containerName), s.localBackendID(), s.otelCollectorEndpoint, bearer,
 			)
 			for k, v := range envVars {
 				if err := s.manager.SetEnv(containerName, k, v); err != nil {
@@ -1597,7 +1597,7 @@ func (s *ContainerServer) ToggleMonitoring(ctx context.Context, req *pb.ToggleMo
 		// works for the operator.
 		bearer, _ := LoadOrCreateOTelBearer()
 		envVars := container.OTelEnvVarsForMigrationWithBearer(
-			req.Username, containerName, s.localBackendID(), s.otelCollectorEndpoint, bearer,
+			req.Username, container.OTelContainerID(info.Labels, containerName), s.localBackendID(), s.otelCollectorEndpoint, bearer,
 		)
 		for k, v := range envVars {
 			if err := s.manager.SetEnv(containerName, k, v); err != nil {

--- a/pkg/core/container/otel.go
+++ b/pkg/core/container/otel.go
@@ -82,7 +82,31 @@ func otelEnvVars(opts CreateOptions, containerName string) map[string]string {
 		log.Printf("[otel] container %s requested monitoring=true but daemon has no collector endpoint configured; skipping env-var injection", containerName)
 		return nil
 	}
-	return buildOTelEnvMap(opts.Username, containerName, opts.BackendID, opts.OTelCollectorEndpoint, opts.OTelBearer)
+	return buildOTelEnvMap(opts.Username, OTelContainerID(opts.Labels, containerName), opts.BackendID, opts.OTelCollectorEndpoint, opts.OTelBearer)
+}
+
+// CloudContainerIDLabelKey is the Incus label key Containarium-cloud
+// stamps at create time with the container's cloud UUID
+// (ossprimary.LabelCloudContainerID = "cloud_container_id" in that
+// repo). OTelContainerID prefers it over the OSS-side LXC name so
+// cloud-daemon's container_id-keyed metrics queries — which filter on
+// the cloud UUID, not the derived "cld-<8hex>-container" name — actually
+// match. See issue #893.
+const CloudContainerIDLabelKey = "cloud_container_id"
+
+// OTelContainerID picks the identity to stamp as container.id /
+// CONTAINARIUM_CONTAINER_ID. Cloud-managed containers carry the real
+// cloud UUID in labels[CloudContainerIDLabelKey]; everything else
+// (operator-created containers, or any caller that never set the
+// label) falls back to the OSS-side LXC name, matching pre-#893
+// behavior exactly. Exported so internal/server's re-stamp call sites
+// (adopt/migrate, ToggleMonitoring) can reuse the same rule with a
+// container's already-persisted labels rather than raw create-time opts.
+func OTelContainerID(labels map[string]string, fallback string) string {
+	if v := labels[CloudContainerIDLabelKey]; v != "" {
+		return v
+	}
+	return fallback
 }
 
 // OTelEnvVarsForMigration returns the same env-var set as

--- a/pkg/core/container/otel_test.go
+++ b/pkg/core/container/otel_test.go
@@ -112,6 +112,69 @@ func TestOtelEnvVars_FullyConfigured(t *testing.T) {
 	}
 }
 
+func TestOtelEnvVars_CloudLabelPreferredOverContainerName(t *testing.T) {
+	// #893: a cloud-managed container carries the real cloud UUID in
+	// labels[CloudContainerIDLabelKey] — that must win over the
+	// derived "alice-container" LXC name so cloud-daemon's
+	// container_id-keyed metrics queries actually match.
+	opts := CreateOptions{
+		Username:              "cld-30dc0e41",
+		Monitoring:            true,
+		OTelCollectorEndpoint: "http://10.0.0.1:4318",
+		BackendID:             "local",
+		Labels: map[string]string{
+			CloudContainerIDLabelKey: "30dc0e41-1234-4abc-9def-000000000001",
+		},
+	}
+	got := otelEnvVars(opts, "cld-30dc0e41-container")
+	if got == nil {
+		t.Fatal("expected non-nil env vars")
+	}
+	want := "30dc0e41-1234-4abc-9def-000000000001"
+	if got["CONTAINARIUM_CONTAINER_ID"] != want {
+		t.Errorf("CONTAINARIUM_CONTAINER_ID = %q, want %q", got["CONTAINARIUM_CONTAINER_ID"], want)
+	}
+	if !strings.Contains(got["OTEL_RESOURCE_ATTRIBUTES"], "container.id="+want) {
+		t.Errorf("OTEL_RESOURCE_ATTRIBUTES missing container.id=%s: %q", want, got["OTEL_RESOURCE_ATTRIBUTES"])
+	}
+}
+
+func TestOtelEnvVars_NoCloudLabelFallsBackToContainerName(t *testing.T) {
+	// Operator-created containers (or any caller that never set the
+	// label) must keep exactly the pre-#893 behavior.
+	opts := CreateOptions{
+		Username:              "alice",
+		Monitoring:            true,
+		OTelCollectorEndpoint: "http://10.0.0.1:4318",
+		BackendID:             "local",
+	}
+	got := otelEnvVars(opts, "alice-container")
+	if got["CONTAINARIUM_CONTAINER_ID"] != "alice-container" {
+		t.Errorf("CONTAINARIUM_CONTAINER_ID = %q, want %q (fallback)", got["CONTAINARIUM_CONTAINER_ID"], "alice-container")
+	}
+}
+
+func TestOTelContainerID(t *testing.T) {
+	cases := []struct {
+		name     string
+		labels   map[string]string
+		fallback string
+		want     string
+	}{
+		{"label present", map[string]string{CloudContainerIDLabelKey: "cloud-uuid-1"}, "alice-container", "cloud-uuid-1"},
+		{"label absent", map[string]string{"other": "x"}, "alice-container", "alice-container"},
+		{"nil labels", nil, "alice-container", "alice-container"},
+		{"label present but empty", map[string]string{CloudContainerIDLabelKey: ""}, "alice-container", "alice-container"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := OTelContainerID(tc.labels, tc.fallback); got != tc.want {
+				t.Errorf("OTelContainerID(%v, %q) = %q, want %q", tc.labels, tc.fallback, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestOTelEnvVarsForMigration_EmptyEndpoint(t *testing.T) {
 	if got := OTelEnvVarsForMigration("alice", "alice", "local", ""); got != nil {
 		t.Fatalf("expected nil for empty endpoint, got %v", got)


### PR DESCRIPTION
## Summary

Fixes #893. Containarium-cloud already sends the container's cloud UUID at create time via `labels["cloud_container_id"]` (`ossprimary.LabelCloudContainerID`), but every OTel env-var stamping path in this repo — create-time (`otelEnvVars`), adopt/migrate re-stamp, and `ToggleMonitoring` re-stamp — ignored that label and stamped the derived `cld-<8hex>-container` OSS-side name into `container.id` / `CONTAINARIUM_CONTAINER_ID` instead.

Since Containarium-cloud's `MetricsService` filters strictly on `container_id="<cloud uuid>"` (by design, per its threat model), every cloud-managed container's app-emitted metrics were silently unqueryable — the cloud dashboard shows "monitoring not enabled" even though telemetry is actually flowing under the wrong label.

- New `container.OTelContainerID(labels, fallback)`: prefers `labels[CloudContainerIDLabelKey]` (`"cloud_container_id"`) when present, else returns `fallback` — exact pre-fix behavior for operator-created containers or any caller that never sets the label.
- Wired into all 3 stamping call sites: `otelEnvVars` (create), and both `OTelEnvVarsForMigrationWithBearer` call sites (adopt/migrate, `ToggleMonitoring`) via `info.Labels`, which already persists across the container's lifetime (`SetLabels`/`GetLabels`).
- No cross-repo change needed — Containarium-cloud was already sending the right label; this repo just wasn't reading it.

## Test plan
- [x] `go build ./pkg/core/container/... ./internal/server/...`
- [x] `go vet` on both packages
- [x] New unit tests: `TestOtelEnvVars_CloudLabelPreferredOverContainerName`, `TestOtelEnvVars_NoCloudLabelFallsBackToContainerName`, `TestOTelContainerID` (table-driven: label present / absent / nil / empty-string)
- [x] Full existing `pkg/core/container` + `internal/server` suites pass unchanged
- [x] `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)