### PR TITLE
fix(build): unbreak v0.48.0 release build — webui compile errors + PR-time guard

### DIFF
--- a/.github/workflows/proxyproto-e2e.yml
+++ b/.github/workflows/proxyproto-e2e.yml
@@ -34,6 +34,24 @@ jobs:
         # time instead of at release time (see #884 / v0.47.0).
         run: GOOS=windows GOARCH=amd64 go build -o /dev/null ./cmd/containarium/
 
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Web UI build guard
+        # `make build-release` runs a full `next build` (with TypeScript
+        # type-checking) that no PR-time job exercised — the same "only
+        # caught at release time" gap as the Windows guard above, just for
+        # the web UI. A prop destructure typo (#886) and two wrong-argument
+        # client calls broke v0.48.0's release build (webui compiled fine in
+        # `next dev`/lint, only `next build`'s full type-check caught it).
+        # Same fix shape as #884/#885: run the real release build at PR time.
+        working-directory: web-ui
+        run: |
+          npm ci
+          npm run build
+
       - name: Run sentinel + app tests
         # The skipped tests are pre-existing failures on unprivileged Linux
         # runners (they pass on darwin where loopback aliases are no-ops).

--- a/web-ui/src/components/containers/ContainerListView.tsx
+++ b/web-ui/src/components/containers/ContainerListView.tsx
@@ -75,6 +75,7 @@ function IconBtn({ title, onClick, className = '', children }: { title: string; 
 export default function ContainerListView({
   containers, metricsMap, securityBadgesMap, onDelete, onStart, onStop, onTerminal,
   onEditFirewall, onEditLabels, onResize, onManageCollaborators, onToggleAutoSleep,
+  onSecurityClick,
 }: ContainerListViewProps) {
   return (
     <div className="overflow-x-auto rounded-xl border border-[var(--border-subtle)]">

--- a/web-ui/src/components/security/PentestView.tsx
+++ b/web-ui/src/components/security/PentestView.tsx
@@ -230,7 +230,7 @@ export default function PentestView({ server }: PentestViewProps) {
         client.getPentestFindingSummary(),
         client.listPentestFindings({ ...baseParams, targetType: 'route', limit, offset: rowsPerPage === -1 ? 0 : domainPage * rowsPerPage }),
         client.listPentestFindings({ ...baseParams, targetType: 'container', limit, offset: rowsPerPage === -1 ? 0 : containerPage * rowsPerPage }),
-        client.listPentestScanRuns(10),
+        client.listPentestScanRuns(undefined, 10),
         client.getPentestConfig(),
       ]);
       setSummary(summaryResp.summary); setDomainFindings(domainResp.findings); setDomainTotalCount(domainResp.totalCount);
@@ -250,7 +250,7 @@ export default function PentestView({ server }: PentestViewProps) {
       setSnackMessage(result.message || `Scan started: ${result.scanRunId}`);
       const pollInterval = setInterval(async () => {
         try {
-          const runsResp = await client.listPentestScanRuns(5);
+          const runsResp = await client.listPentestScanRuns(undefined, 5);
           setScanRuns(runsResp.scanRuns);
           const latest = runsResp.scanRuns[0];
           if (latest && latest.id === result.scanRunId && latest.status !== 'running') { clearInterval(pollInterval); setScanning(false); loadData(); }


### PR DESCRIPTION
## Summary
`make build-release` (which runs a full `next build` with TypeScript type-checking) failed on the v0.48.0 tag with two genuine compile errors from #886, neither caught at PR time because **no CI job builds the web UI at all**:

- `ContainerListView.tsx` destructured props omitted `onSecurityClick` even though it's declared in the props interface, used in the JSX, and already passed in by `ContainerTopology.tsx` — a straight typo.
- `PentestView.tsx` called `client.listPentestScanRuns(<limit>)` as a bare number, but the method's first positional param is the optional `containerName` string, not `limit` — fixed both call sites to `listPentestScanRuns(undefined, <limit>)`.

This is the same failure class as #884 (Windows cross-compile only caught at release time) — closed the same way #885 did: added the real `next build` as a step in the already-required "Unit + default e2e" job.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` (full production build) succeeds
- [x] New CI step added mirrors the exact same job/precedent as the Windows guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)