### PR TITLE
fix(cloud): self-heal container tenant label on every reconcile (#780 follow-up)

### DIFF
--- a/internal/server/cloud_container_actuator.go
+++ b/internal/server/cloud_container_actuator.go
@@ -39,6 +39,15 @@ func newCloudContainerActuator(routes *app.RouteStore) (*cloudContainerActuator,
 
 // EnsureRunning creates the container (stamping the tenant label) if absent,
 // ensures it is started, and converges its edge routes. Idempotent.
+//
+// Also self-heals the tenant label on every reconcile of an already-existing
+// container, not just at creation (#780 follow-up) — a container created
+// before this labeling logic shipped (or whose label was lost some other
+// way) would otherwise stay permanently unmatched by the network-policy
+// enforcer, since create() only runs once. The reconcile loop already
+// carries org_id for every live assignment each cycle, so this converges the
+// whole fleet within one watchPollInterval of a daemon restart, no separate
+// backfill tool needed.
 func (a *cloudContainerActuator) EnsureRunning(ctx context.Context, spec cloud.ContainerSpec) error {
 	info, err := a.incus.GetContainer(spec.LocalName)
 	if err != nil {
@@ -47,15 +56,38 @@ func (a *cloudContainerActuator) EnsureRunning(ctx context.Context, spec cloud.C
 		if cerr := a.create(spec); cerr != nil {
 			return cerr
 		}
-	} else if isRunning(info.State) {
-		a.applyRoutes(ctx, spec) // already running — still converge routes
-		return nil
+	} else {
+		// Best-effort: a stamp failure here shouldn't block start/route
+		// convergence for an otherwise-healthy container — it retries next cycle.
+		if terr := a.ensureTenantLabel(spec.LocalName, spec.OrgID, info.Tenant); terr != nil {
+			log.Printf("[cloud] stamp tenant label on %s: %v", spec.LocalName, terr)
+		}
+		if isRunning(info.State) {
+			a.applyRoutes(ctx, spec) // already running — still converge routes
+			return nil
+		}
 	}
 	if err := a.incus.StartContainer(spec.LocalName); err != nil {
 		return fmt.Errorf("start %s: %w", spec.LocalName, err)
 	}
 	a.applyRoutes(ctx, spec)
 	return nil
+}
+
+// ensureTenantLabel stamps localName's tenant label when it doesn't already
+// match orgID.
+func (a *cloudContainerActuator) ensureTenantLabel(localName, orgID, currentTenant string) error {
+	if !tenantLabelStale(orgID, currentTenant) {
+		return nil
+	}
+	return a.incus.SetConfig(localName, incus.TenantLabelKey, orgID)
+}
+
+// tenantLabelStale reports whether a container's tenant label needs
+// (re)stamping: orgID is known and differs from what's currently set. Pure
+// so the decision is unit-testable without an Incus client.
+func tenantLabelStale(orgID, currentTenant string) bool {
+	return orgID != "" && currentTenant != orgID
 }
 
 // EnsureStopped stops the container if it exists and is running. Idempotent.

--- a/internal/server/cloud_container_actuator_test.go
+++ b/internal/server/cloud_container_actuator_test.go
@@ -54,6 +54,32 @@ func TestRouteRecordFor(t *testing.T) {
 	}
 }
 
+// TestTenantLabelStale locks in the #780 follow-up fix: a container whose
+// tenant label predates the labeling code (empty) or drifted from its
+// current org must be flagged for re-stamping on every reconcile, not just
+// at creation.
+func TestTenantLabelStale(t *testing.T) {
+	cases := []struct {
+		name          string
+		orgID         string
+		currentTenant string
+		want          bool
+	}{
+		{"already correct", "org-1", "org-1", false},
+		{"never labeled", "org-1", "", true},
+		{"stale from a reassignment", "org-1", "org-0", true},
+		{"no org known yet — nothing to stamp", "", "", false},
+		{"no org known yet — leave existing label alone", "", "org-1", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := tenantLabelStale(c.orgID, c.currentTenant); got != c.want {
+				t.Errorf("tenantLabelStale(%q, %q) = %v, want %v", c.orgID, c.currentTenant, got, c.want)
+			}
+		})
+	}
+}
+
 func TestBuildContainerConfig_MinimalOmitsDevices(t *testing.T) {
 	cfg := buildContainerConfig(cloud.ContainerSpec{LocalName: "cld-x", Image: "alpine"})
 	if cfg.Memory != "" {


### PR DESCRIPTION
## Summary
- Found while validating the cloud-side network-policy remediation (containarium-cloud #780): every cloud-created container on a live production host had an **empty** `user.containarium.tenant` label, even with org policies correctly seeded and synced down. Root cause: `cloudContainerActuator.create()` only stamps the label the first time a container is created — `EnsureRunning`'s "already running" path never re-checked it. Any container that existed before this labeling code shipped on a given host stays permanently unmatched by the per-tenant network-policy enforcer, regardless of `CONTAINARIUM_NETWORK_POLICY_ENFORCE` or how complete the org-policy backfill is on the cloud side.
- `EnsureRunning` now calls a new `ensureTenantLabel` helper on every reconcile of an already-existing container, not just at creation. Best-effort — a stamp failure doesn't block start/route convergence, it just retries next cycle.
- Since the reconcile loop already receives `org_id` for every live assignment on each ~30s batch, this self-heals an entire fleet automatically within one reconcile cycle of a daemon restart — no separate one-time backfill tool needed.
- Extracted the pure decision (`tenantLabelStale`) so it's unit-testable without an Incus client, matching this file's existing test style (pure-function tests only).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/server/...`
- [x] `go test ./internal/server/...` — full package green, including new `TestTenantLabelStale` table test
- [x] Verified live against a production host: before the fix, all cloud-created containers had an empty tenant label (confirmed via `incus config get <name> user.containarium.tenant`); this PR fixes the code path that caused it.

Refs containarium-cloud#780

🤖 Generated with [Claude Code](https://claude.com/claude-code)