### PR TITLE
chore(release): stamp CHANGELOG + bump version for 0.48.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.2] - 2026-07-08
+
+### Fixed
+
+- **Cloud-assigned containers could permanently miss their `user.containarium.tenant`
+  label, leaving them unmatched by the per-org network-policy enforcer.**
+  `cloudContainerActuator.create()` stamps the tenant label correctly, but
+  only the first time a container is created — the reconcile path for an
+  already-existing container never re-checked it. A container created
+  before this labeling logic was live on a given host would stay
+  unmanaged indefinitely, regardless of how its org's network policy was
+  configured. `EnsureRunning` now self-heals the label on every reconcile
+  of an existing container (best-effort; a stamp failure doesn't block
+  start/route convergence). (#903)
+
 ## [0.48.1] - 2026-07-03
 
 ### Fixed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.31.1"
+	Version = "0.48.2"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary
- Cuts v0.48.2: stamps CHANGELOG.md and bumps pkg/version/version.go's fallback constant for #903 (per-org network-policy tenant-label reconcile self-heal, merged into main).
- No functional code changes beyond the version/changelog stamp.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/version/... ./internal/server/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)