### PR TITLE
fix(netpolicy): resolve tenant from cloud_org_id label too (push-mode)

### DIFF
--- a/internal/server/network_policy_enforcer.go
+++ b/internal/server/network_policy_enforcer.go
@@ -726,7 +726,7 @@ func (e *NetworkPolicyEnforcer) gather(_ context.Context) ([]containerView, map[
 	idName := make(map[uint32]string)
 	running := make(map[string]bool, len(containers))
 	for _, c := range containers {
-		tenant := resolveTenant(c.Tenant, c.Name)
+		tenant := resolveTenant(c.Tenant, c.Labels[cloudOrgIDLabel], c.Name)
 		if tenant == "" {
 			continue
 		}
@@ -842,14 +842,28 @@ func (e *NetworkPolicyEnforcer) refreshDomains() {
 	e.resolver.Refresh(cctx, domains)
 }
 
+// cloudOrgIDLabel is the generic attribution label (incus.LabelPrefix +
+// this key) the cloud control plane stamps on every container it creates via
+// the OSS-primary driver (push-mode actuation, prd/cloud/oss-primary-driver.md)
+// — cloud_org_id / cloud_container_id / managed_by. Distinct from
+// incus.TenantLabelKey (user.containarium.tenant), which only the pull-based
+// cloud-actuation client (cloudContainerActuator, #354) stamps. Both label a
+// container with the same data (its owning org UUID); resolveTenant checks
+// both so the network-policy enforcer works under either actuation mode.
+const cloudOrgIDLabel = "cloud_org_id"
+
 // resolveTenant determines a container's owning tenant. An explicit tenant
 // label (user.containarium.tenant) wins — it decouples tenant identity from the
 // container name, which is what lets cloud-assigned containers (named
 // cld-<uuid>, not <tenant>-container) be policed too (#315 "Cloud extension").
-// Falls back to the <tenant>-container naming convention; "" if neither yields
-// a tenant (the container is then left unmanaged).
-func resolveTenant(tenantLabel, containerName string) string {
+// Falls back to the cloud_org_id attribution label (see cloudOrgIDLabel), then
+// the <tenant>-container naming convention; "" if none yield a tenant (the
+// container is then left unmanaged).
+func resolveTenant(tenantLabel, cloudOrgID, containerName string) string {
 	if t := strings.TrimSpace(tenantLabel); t != "" {
+		return t
+	}
+	if t := strings.TrimSpace(cloudOrgID); t != "" {
 		return t
 	}
 	return tenantOf(containerName)

--- a/internal/server/network_policy_plan_test.go
+++ b/internal/server/network_policy_plan_test.go
@@ -19,18 +19,22 @@ func compiled(t *testing.T, p *pb.NetworkPolicy) netpolicy.CompiledPolicy {
 
 func TestResolveTenant(t *testing.T) {
 	cases := []struct {
-		label, name, want string
+		label, cloudOrgID, name, want string
 	}{
-		{"acme", "cld-1a2b3c", "acme"},          // label wins for a cloud-named container
-		{"acme", "alice-container", "acme"},     // label wins over name
-		{"", "alice-container", "alice"},        // fall back to name convention
-		{"  ", "alice-container", "alice"},      // blank label ignored
-		{"", "cld-1a2b3c", ""},                  // cloud name, no label → unmanaged
-		{" tenant7 ", "x-container", "tenant7"}, // label trimmed
+		{"acme", "", "cld-1a2b3c", "acme"},          // label wins for a cloud-named container
+		{"acme", "", "alice-container", "acme"},     // label wins over name
+		{"", "", "alice-container", "alice"},        // fall back to name convention
+		{"  ", "", "alice-container", "alice"},      // blank label ignored
+		{"", "", "cld-1a2b3c", ""},                  // cloud name, no label → unmanaged
+		{" tenant7 ", "", "x-container", "tenant7"}, // label trimmed
+		{"", "org-42", "cld-1a2b3c", "org-42"},      // push-mode (OSS-primary): no tenant label, cloud_org_id fills in
+		{"acme", "org-42", "cld-1a2b3c", "acme"},    // explicit tenant label still wins over cloud_org_id
+		{"", " org-42 ", "cld-1a2b3c", "org-42"},    // cloud_org_id trimmed
+		{"", "", "", ""},                            // nothing at all → unmanaged
 	}
 	for _, c := range cases {
-		if got := resolveTenant(c.label, c.name); got != c.want {
-			t.Errorf("resolveTenant(%q, %q) = %q, want %q", c.label, c.name, got, c.want)
+		if got := resolveTenant(c.label, c.cloudOrgID, c.name); got != c.want {
+			t.Errorf("resolveTenant(%q, %q, %q) = %q, want %q", c.label, c.cloudOrgID, c.name, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Found while re-verifying containarium-cloud #780's isolation sentry: containers created via the cloud's push-mode actuation (the cloud calls `ContainerService.CreateContainer` directly — no local `cloud-actuation` client involved) never get `user.containarium.tenant`, so #903's reconcile self-heal never runs for them at all — that fix lives entirely inside the pull-based client, which this actuation mode doesn't use.
- These containers already carry the owning org's UUID under a different, pre-existing label: `user.containarium.label.cloud_org_id`, stamped by the cloud's OSS-primary driver at create time (per `prd/cloud/oss-primary-driver.md`'s original "Org attribution via labels" design). Verified live on a production host: every push-mode-created container has this label set correctly; `ListContainers()` already parses it into `ContainerInfo.Labels`, so no new Incus calls are needed to use it.
- `resolveTenant` now checks the `cloud_org_id` label as a fallback (after the explicit tenant label, before the `<tenant>-container` name convention) — covers both actuation modes with one small change, instead of a wire-protocol extension or migrating host scheduling kinds.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/server/...`
- [x] `go test ./internal/server/...` — full package green, extended `TestResolveTenant` with push-mode cases (cloud_org_id fills in when tenant label is empty; explicit tenant label still wins when both are present)
- [x] Verified live against production: the `cloud_org_id` label is present and correct on every checked container of a push-mode-actuated host.

Refs containarium-cloud#780

🤖 Generated with [Claude Code](https://claude.com/claude-code)