### PR TITLE
chore(release): stamp CHANGELOG + bump version for 0.48.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.3] - 2026-07-08
+
+### Fixed
+
+- **The per-org network-policy enforcer couldn't identify containers
+  created via the cloud's direct (push-mode) actuation path** — only
+  containers created through the pull-based cloud-actuation client
+  received `user.containarium.tenant`. Push-mode containers already
+  carry the owning org's UUID under a different, pre-existing
+  attribution label (`cloud_org_id`); `resolveTenant` now falls back to
+  it when the explicit tenant label is absent, so both actuation modes
+  are covered by the same enforcer logic. (#906)
+
 ## [0.48.2] - 2026-07-08
 
 ### Fixed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.48.2"
+	Version = "0.48.3"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary
- Cuts v0.48.3: stamps CHANGELOG.md and bumps pkg/version/version.go's fallback constant for #906 (network-policy enforcer resolves tenant from the cloud_org_id label for push-mode-actuated containers too), merged into main.
- No functional code changes beyond the version/changelog stamp.

## Test plan
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)