### PR TITLE
feat(recipes): oci-service — generic always-on OCI service in a box

### DIFF
--- a/pkg/core/recipes/recipes.yaml
+++ b/pkg/core/recipes/recipes.yaml
@@ -783,3 +783,65 @@ recipes:
         podman run -d --name lcproxy --restart=always --network host \
           -v /opt/wsauth/Caddyfile:/etc/caddy/Caddyfile:ro \
           docker.io/library/caddy:2 >/dev/null
+
+  # oci-service is the GENERIC single-container service mechanism: run ANY
+  # caller-specified OCI image as an always-on service in an isolated box.
+  # It is deliberately application-agnostic (open-core line: OSS ships the
+  # mechanism); higher layers parameterize it — e.g. the cloud runtime API
+  # deploys OpenHands' agent-server image through it. The service's container
+  # port is published on the box's port 8080 (the recipe's exposed port), so
+  # ingress/expose machinery has one stable port to route regardless of what
+  # the image listens on.
+  - id: oci-service
+    name: OCI Service
+    description: Run an OCI image as an always-on service in an isolated box — pull, run with --restart=always, publish one port. Application-agnostic building block.
+    image: images:ubuntu/24.04
+    requires_gpu: false
+    resources:
+      cpu: "4"
+      memory: 8GB
+      disk: 30GB
+    ports:
+      - container_port: 8080
+        subdomain: svc
+    parameters:
+      - name: oci_image
+        label: OCI image
+        description: Fully-qualified image reference to run (e.g. ghcr.io/org/app:tag). Must be pullable from the box.
+        type: string
+        required: true
+      - name: service_port
+        label: Service port
+        description: Port the service listens on INSIDE its container. Published on box port 8080.
+        type: string
+        default: "8080"
+      - name: command
+        label: Command
+        description: Optional command override — the first token becomes the container entrypoint, the rest its arguments. Empty keeps the image's own entrypoint/cmd.
+        type: string
+        default: ""
+      - name: env_lines
+        label: Environment
+        description: Optional newline-separated KEY=VALUE lines injected into the container (podman --env-file semantics — everything after '=' is literal, no shell quoting).
+        type: string
+        default: ""
+    post_start:
+      - mkdir -p /opt/ocisvc
+      # env-file semantics keep values literal (commas/spaces safe) — never
+      # bash-source this file.
+      - 'printf "%s\n" "${CONTAINARIUM_PARAM_ENV_LINES}" > /opt/ocisvc/env'
+      - 'podman pull "${CONTAINARIUM_PARAM_OCI_IMAGE}" >/dev/null'
+      # Split the optional command into entrypoint + args. An image whose
+      # entrypoint already launches the service would otherwise re-receive
+      # its own path as an argument.
+      - |
+        set -- ${CONTAINARIUM_PARAM_COMMAND}
+        ENTRY="${1:-}"
+        [ "$#" -gt 0 ] && shift
+        podman rm -f ocisvc >/dev/null 2>&1 || true
+        podman run -d --name ocisvc --restart=always \
+          -p "8080:${CONTAINARIUM_PARAM_SERVICE_PORT}" \
+          --env-file /opt/ocisvc/env \
+          ${ENTRY:+--entrypoint "$ENTRY"} \
+          "${CONTAINARIUM_PARAM_OCI_IMAGE}" "$@" >/dev/null
+        echo "oci-service: ${CONTAINARIUM_PARAM_OCI_IMAGE} up on box port 8080 (container port ${CONTAINARIUM_PARAM_SERVICE_PORT})"

--- a/pkg/core/recipes/recipes_test.go
+++ b/pkg/core/recipes/recipes_test.go
@@ -86,6 +86,49 @@ func TestAgentWorkspaceRecipe(t *testing.T) {
 	}
 }
 
+func TestOCIServiceRecipe(t *testing.T) {
+	m := New()
+	if err := m.LoadEmbedded(); err != nil {
+		t.Fatalf("LoadEmbedded: %v", err)
+	}
+	r, err := m.Get("oci-service")
+	if err != nil {
+		t.Fatalf("expected built-in recipe oci-service: %v", err)
+	}
+	if r.RequiresGpu {
+		t.Error("oci-service should not require a GPU")
+	}
+	// One stable exposed port regardless of what the image listens on.
+	if len(r.Ports) != 1 || r.Ports[0].ContainerPort != 8080 {
+		t.Errorf("oci-service should expose box port 8080; got %+v", r.Ports)
+	}
+	// oci_image is the one required parameter; everything else defaults.
+	var img *pb.RecipeParam
+	for _, p := range r.Parameters {
+		if p.Name == "oci_image" {
+			img = p
+		}
+	}
+	if img == nil || !img.Required || img.Default != "" {
+		t.Errorf("oci_image must be required with no default; got %+v", img)
+	}
+	if _, err := ResolveParameters(r, map[string]string{}); err == nil {
+		t.Error("resolving without oci_image should fail (required)")
+	}
+	joined := strings.Join(r.PostStart, "\n")
+	for _, want := range []string{
+		"--restart=always", // survives box reboot and SSH logout
+		"--env-file",       // literal env semantics, never bash-sourced
+		"--entrypoint",     // command's first token overrides entrypoint
+		"CONTAINARIUM_PARAM_OCI_IMAGE",
+		"CONTAINARIUM_PARAM_SERVICE_PORT",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("oci-service post_start missing %q", want)
+		}
+	}
+}
+
 func TestGetUnknown(t *testing.T) {
 	m := New()
 	_ = m.LoadEmbedded()


### PR DESCRIPTION
## What

A new built-in recipe, `oci-service`: run any caller-specified OCI image as an always-on service in an isolated box. Pull → `podman run --restart=always` → publish the image's service port on the box's stable `:8080`.

Parameters:
- `oci_image` (required) — fully-qualified image reference
- `service_port` — port the service listens on inside its container (published on box :8080)
- `command` — optional override; the **first token becomes the container entrypoint**, the rest its arguments (an image whose entrypoint already launches the service must not re-receive its own path as an argument)
- `env_lines` — newline-separated KEY=VALUE lines written to an env file and injected via `podman --env-file` (literal semantics; deliberately never bash-sourced)

## Why

Application-agnostic on purpose — OSS ships the generic mechanism, higher layers parameterize it. First consumer: the cloud runtime API (Containarium-cloud #790) hosts OpenHands agent-server sandboxes through it (contract validated E2E by `poc/openhands-runtime-shim`), but nothing here is OpenHands-specific: it's the minimal "host a single-container service in a box" building block.

Root podman + `--restart=always` is the proven recipe pattern (survives SSH logout and box reboot). The pull runs inside the daemon-side async post_start, so no client connection spans it.

## Tests

`TestOCIServiceRecipe`: catalog loads, port shape, `oci_image` required with no default (ResolveParameters rejects when absent), and post_start carries the load-bearing constructs (--restart=always, --env-file, --entrypoint split, param env names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)