### PR TITLE
Add glama.json for Glama MCP server directory

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "hsinatfootprintai"
+  ]
+}


### PR DESCRIPTION
Adds the glama.json manifest required by the Glama MCP server directory so the listing at https://glama.ai/mcp/servers/FootprintAI/Containarium can be claimed and scored.