### PR TITLE
chore(release): cut v0.49.0 — oci-service recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.0] - 2026-07-08
+
+### Added
+
+- **`oci-service` recipe** (#910) — generic run-an-OCI-image-as-an-always-on-
+  service mechanism: pull a caller-specified image, run it via root podman
+  with `--restart=always`, and publish its service port on the box's stable
+  `:8080`. Parameters: `oci_image` (required), `service_port`, `command`
+  (first token overrides the container entrypoint), `env_lines` (podman
+  `--env-file` literal semantics). Application-agnostic building block; the
+  first consumer is the cloud runtime API's agent sandboxes.
+
+
 ## [0.48.3] - 2026-07-08
 
 ### Fixed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.48.3"
+	Version = "0.49.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Release stamp for v0.49.0 per docs/RELEASE-PROCESS.md (CHANGELOG + pkg/version/version.go), carrying #910 (oci-service recipe). Tag `v0.49.0` follows on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)