### PR TITLE
feat(webui): add domain filter to the ZAP security tab

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -5409,7 +5409,7 @@
     "/v1/zap/alerts": {
       "get": {
         "summary": "List ZAP alerts",
-        "description": "Returns ZAP security alerts with optional filtering by risk level and status.",
+        "description": "Returns ZAP security alerts with optional filtering by risk level, status, and domain.",
         "operationId": "ZapService_ListZapAlerts",
         "responses": {
           "200": {
@@ -5455,6 +5455,13 @@
             "required": false,
             "type": "integer",
             "format": "int32"
+          },
+          {
+            "name": "domain",
+            "description": "Filter by domain/host — substring-matched against the alert's target\nURL (optional). E.g. \"wordpress.kafeido.app\" matches any alert whose\nurl contains that host.",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [

--- a/internal/server/zap_server.go
+++ b/internal/server/zap_server.go
@@ -102,6 +102,7 @@ func (s *ZapServer) ListZapAlerts(ctx context.Context, req *pb.ListZapAlertsRequ
 	params := zapscanner.AlertListParams{
 		Risk:   req.Risk,
 		Status: req.Status,
+		Domain: req.Domain,
 		Limit:  int(req.Limit),
 		Offset: int(req.Offset),
 	}

--- a/internal/zap/store.go
+++ b/internal/zap/store.go
@@ -349,6 +349,11 @@ func (s *Store) SaveAlerts(ctx context.Context, scanRunID string, alerts []Alert
 type AlertListParams struct {
 	Risk   string
 	Status string
+	// Domain filters to alerts whose url contains this host — substring
+	// matched (ILIKE) against the stored url column rather than a
+	// dedicated host column, since url is the only place the target is
+	// recorded today (#zap-domain-filter).
+	Domain string
 	Limit  int
 	Offset int
 }
@@ -382,6 +387,12 @@ func (s *Store) ListAlerts(ctx context.Context, params AlertListParams) ([]Alert
 		baseQuery += fmt.Sprintf(" AND status = $%d", argIdx)
 		countQuery += fmt.Sprintf(" AND status = $%d", argIdx)
 		args = append(args, params.Status)
+		argIdx++
+	}
+	if params.Domain != "" {
+		baseQuery += fmt.Sprintf(" AND url ILIKE $%d", argIdx)
+		countQuery += fmt.Sprintf(" AND url ILIKE $%d", argIdx)
+		args = append(args, "%"+params.Domain+"%")
 		argIdx++
 	}
 

--- a/pkg/pb/containarium/v1/zap.pb.go
+++ b/pkg/pb/containarium/v1/zap.pb.go
@@ -810,7 +810,11 @@ type ListZapAlertsRequest struct {
 	// Maximum number of alerts to return (default: 50)
 	Limit int32 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
 	// Offset for pagination
-	Offset        int32 `protobuf:"varint,4,opt,name=offset,proto3" json:"offset,omitempty"`
+	Offset int32 `protobuf:"varint,4,opt,name=offset,proto3" json:"offset,omitempty"`
+	// Filter by domain/host — substring-matched against the alert's target
+	// URL (optional). E.g. "wordpress.kafeido.app" matches any alert whose
+	// url contains that host.
+	Domain        string `protobuf:"bytes,5,opt,name=domain,proto3" json:"domain,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -871,6 +875,13 @@ func (x *ListZapAlertsRequest) GetOffset() int32 {
 		return x.Offset
 	}
 	return 0
+}
+
+func (x *ListZapAlertsRequest) GetDomain() string {
+	if x != nil {
+		return x.Domain
+	}
+	return ""
 }
 
 type ListZapAlertsResponse struct {
@@ -1475,12 +1486,13 @@ const file_containarium_v1_zap_proto_rawDesc = "" +
 	"\x17ListZapScanRunsResponse\x128\n" +
 	"\tscan_runs\x18\x01 \x03(\v2\x1b.containarium.v1.ZapScanRunR\bscanRuns\x12\x1f\n" +
 	"\vtotal_count\x18\x02 \x01(\x05R\n" +
-	"totalCount\"p\n" +
+	"totalCount\"\x88\x01\n" +
 	"\x14ListZapAlertsRequest\x12\x12\n" +
 	"\x04risk\x18\x01 \x01(\tR\x04risk\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x14\n" +
 	"\x05limit\x18\x03 \x01(\x05R\x05limit\x12\x16\n" +
-	"\x06offset\x18\x04 \x01(\x05R\x06offset\"k\n" +
+	"\x06offset\x18\x04 \x01(\x05R\x06offset\x12\x16\n" +
+	"\x06domain\x18\x05 \x01(\tR\x06domain\"k\n" +
 	"\x15ListZapAlertsResponse\x121\n" +
 	"\x06alerts\x18\x01 \x03(\v2\x19.containarium.v1.ZapAlertR\x06alerts\x12\x1f\n" +
 	"\vtotal_count\x18\x02 \x01(\x05R\n" +
@@ -1506,15 +1518,15 @@ const file_containarium_v1_zap_proto_rawDesc = "" +
 	"\x11InstallZapRequest\"H\n" +
 	"\x12InstallZapResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage2\x8e\x0e\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage2\x98\x0e\n" +
 	"\n" +
 	"ZapService\x12\xd8\x01\n" +
 	"\x0eTriggerZapScan\x12&.containarium.v1.TriggerZapScanRequest\x1a'.containarium.v1.TriggerZapScanResponse\"u\x92A[\n" +
 	"\x03ZAP\x12\x10Trigger ZAP scan\x1aBTriggers an on-demand OWASP ZAP scan across all exposed endpoints.\x82\xd3\xe4\x93\x02\x11:\x01*\"\f/v1/zap/scan\x12\xd9\x01\n" +
 	"\x0fListZapScanRuns\x12'.containarium.v1.ListZapScanRunsRequest\x1a(.containarium.v1.ListZapScanRunsResponse\"s\x92A[\n" +
-	"\x03ZAP\x12\x12List ZAP scan runs\x1a@Returns recent ZAP scan runs with their status and alert counts.\x82\xd3\xe4\x93\x02\x0f\x12\r/v1/zap/scans\x12\xde\x01\n" +
-	"\rListZapAlerts\x12%.containarium.v1.ListZapAlertsRequest\x1a&.containarium.v1.ListZapAlertsResponse\"~\x92Ae\n" +
-	"\x03ZAP\x12\x0fList ZAP alerts\x1aMReturns ZAP security alerts with optional filtering by risk level and status.\x82\xd3\xe4\x93\x02\x10\x12\x0e/v1/zap/alerts\x12\xf9\x01\n" +
+	"\x03ZAP\x12\x12List ZAP scan runs\x1a@Returns recent ZAP scan runs with their status and alert counts.\x82\xd3\xe4\x93\x02\x0f\x12\r/v1/zap/scans\x12\xe8\x01\n" +
+	"\rListZapAlerts\x12%.containarium.v1.ListZapAlertsRequest\x1a&.containarium.v1.ListZapAlertsResponse\"\x87\x01\x92An\n" +
+	"\x03ZAP\x12\x0fList ZAP alerts\x1aVReturns ZAP security alerts with optional filtering by risk level, status, and domain.\x82\xd3\xe4\x93\x02\x10\x12\x0e/v1/zap/alerts\x12\xf9\x01\n" +
 	"\x12GetZapAlertSummary\x12*.containarium.v1.GetZapAlertSummaryRequest\x1a+.containarium.v1.GetZapAlertSummaryResponse\"\x89\x01\x92Ah\n" +
 	"\x03ZAP\x12\x15Get ZAP alert summary\x1aJReturns aggregate statistics of ZAP alerts including counts by risk level.\x82\xd3\xe4\x93\x02\x18\x12\x16/v1/zap/alerts/summary\x12\xe4\x01\n" +
 	"\x10SuppressZapAlert\x12(.containarium.v1.SuppressZapAlertRequest\x1a).containarium.v1.SuppressZapAlertResponse\"{\x92AK\n" +

--- a/proto/containarium/v1/zap.proto
+++ b/proto/containarium/v1/zap.proto
@@ -188,6 +188,11 @@ message ListZapAlertsRequest {
 
   // Offset for pagination
   int32 offset = 4;
+
+  // Filter by domain/host — substring-matched against the alert's target
+  // URL (optional). E.g. "wordpress.kafeido.app" matches any alert whose
+  // url contains that host.
+  string domain = 5;
 }
 
 message ListZapAlertsResponse {
@@ -281,7 +286,7 @@ service ZapService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "List ZAP alerts";
-      description: "Returns ZAP security alerts with optional filtering by risk level and status.";
+      description: "Returns ZAP security alerts with optional filtering by risk level, status, and domain.";
       tags: "ZAP";
     };
   }

--- a/web-ui/src/components/security/ZapView.tsx
+++ b/web-ui/src/components/security/ZapView.tsx
@@ -108,6 +108,8 @@ export default function ZapView({ server }: ZapViewProps) {
   const [snackMessage, setSnackMessage] = useState<string | null>(null);
   const [riskFilter, setRiskFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('open');
+  const [domainInput, setDomainInput] = useState('');
+  const [domainFilter, setDomainFilter] = useState('');
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(25);
   const [suppressId, setSuppressId] = useState<number | null>(null);
@@ -121,6 +123,12 @@ export default function ZapView({ server }: ZapViewProps) {
     if (snackMessage) { const t = setTimeout(() => setSnackMessage(null), 5000); return () => clearTimeout(t); }
   }, [snackMessage]);
 
+  // Debounce the free-text domain filter so it doesn't re-query on every keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => { setDomainFilter(domainInput.trim()); setPage(0); }, 400);
+    return () => clearTimeout(t);
+  }, [domainInput]);
+
   const loadData = useCallback(async () => {
     try {
       const client = getClient(server);
@@ -128,7 +136,7 @@ export default function ZapView({ server }: ZapViewProps) {
       const offset = rowsPerPage === -1 ? 0 : page * rowsPerPage;
       const [summaryResp, alertsResp, runsResp, configResp] = await Promise.all([
         client.getZapAlertSummary(),
-        client.listZapAlerts({ risk: riskFilter || undefined, status: statusFilter || undefined, limit, offset }),
+        client.listZapAlerts({ risk: riskFilter || undefined, status: statusFilter || undefined, domain: domainFilter || undefined, limit, offset }),
         client.listZapScanRuns(10),
         client.getZapConfig(),
       ]);
@@ -136,7 +144,7 @@ export default function ZapView({ server }: ZapViewProps) {
       setScanRuns(runsResp.scanRuns); setConfig(configResp.config); setError(null);
     } catch (err) { setError(err instanceof Error ? err.message : 'Failed to load ZAP data'); }
     finally { setIsLoading(false); }
-  }, [server, riskFilter, statusFilter, page, rowsPerPage]);
+  }, [server, riskFilter, statusFilter, domainFilter, page, rowsPerPage]);
 
   useEffect(() => { loadData(); const interval = setInterval(loadData, 60000); return () => clearInterval(interval); }, [loadData]);
 
@@ -171,7 +179,7 @@ export default function ZapView({ server }: ZapViewProps) {
     setDownloading(true);
     try {
       const client = getClient(server);
-      const resp = await client.listZapAlerts({ risk: riskFilter || undefined, status: statusFilter || undefined, limit: 1000, offset: 0 });
+      const resp = await client.listZapAlerts({ risk: riskFilter || undefined, status: statusFilter || undefined, domain: domainFilter || undefined, limit: 1000, offset: 0 });
       const all = resp.alerts;
       const dateStr = new Date().toISOString().slice(0, 10);
       let blob: Blob; let filename: string;
@@ -289,6 +297,8 @@ export default function ZapView({ server }: ZapViewProps) {
           <option value="resolved">Resolved</option>
           <option value="suppressed">Suppressed</option>
         </select>
+        <input type="text" value={domainInput} onChange={e => setDomainInput(e.target.value)} placeholder="Filter by domain..."
+          className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface-2)] px-3 py-1.5 text-xs text-[var(--text)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent)] focus:outline-none" style={{ width: 180 }} />
         <span className="text-xs text-[var(--text-muted)]">{totalCount} alerts</span>
         <div className="ml-auto flex items-center gap-2">
           <select value={downloadFormat} onChange={e => setDownloadFormat(e.target.value as 'csv' | 'json')} className={selectCls} style={{ width: 70 }}>

--- a/web-ui/src/lib/api/client.ts
+++ b/web-ui/src/lib/api/client.ts
@@ -1359,6 +1359,7 @@ export class ContaineriumClient {
     if (params) {
       if (params.risk) queryParams.risk = params.risk;
       if (params.status) queryParams.status = params.status;
+      if (params.domain) queryParams.domain = params.domain;
       if (params.limit !== undefined) queryParams.limit = params.limit;
       if (params.offset !== undefined) queryParams.offset = params.offset;
     }

--- a/web-ui/src/types/security.ts
+++ b/web-ui/src/types/security.ts
@@ -301,6 +301,8 @@ export interface InstallZapResponse {
 export interface ListZapAlertsParams {
   risk?: string;
   status?: string;
+  /** Substring-matched against each alert's target url. */
+  domain?: string;
   limit?: number;
   offset?: number;
 }


### PR DESCRIPTION
## Summary
- The ZAP security tab already had risk-level and status filters, but no way to narrow findings to a specific domain — with routes scanned cluster-wide, a real finding on one site could get buried in a long combined list.
- Adds `domain` to `ListZapAlertsRequest` (proto + regenerated stubs), threaded through `internal/server/zap_server.go` into `zap.AlertListParams`, matched via an `ILIKE` substring match against the stored `url` column in `internal/zap/store.go` — no new column/migration needed, since `url` is the only place the target is recorded today.
- Frontend: a debounced text input next to the existing risk/status dropdowns in `ZapView.tsx`, wired into both the alert-list query and the existing CSV/JSON download so exports respect the active filter too.

## Test plan
- [x] `go build ./...`, `go vet ./internal/server/... ./internal/zap/...`
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` (full production build) — clean, including the type-check pass that broke v0.47.0/v0.48.0's releases
- [ ] Live browser verification against real ZAP data — **not done**. The ZAP store is Postgres-only (no in-memory fallback), and no Docker/Postgres was available in this environment to stand one up. Flagging honestly rather than claiming full E2E coverage; would appreciate a manual check on a real deployment before merge if that matters for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)