### PR TITLE
feat(container): BYO registry mirror for warm-image cache (#908)

### DIFF
--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -20,6 +20,10 @@ import (
 // Manager handles container lifecycle operations
 type Manager struct {
 	incus incus.Backend
+	// mirrors are the operator-configured registry pull-through mirrors (#908)
+	// injected into each podman-enabled box's registries.conf.d. Empty = boxes
+	// pull from upstream registries as before. See registry_mirror.go.
+	mirrors []RegistryMirror
 }
 
 // CreateOptions holds options for creating a container
@@ -88,7 +92,7 @@ func New() (*Manager, error) {
 		return nil, fmt.Errorf("failed to create Incus client: %w", err)
 	}
 
-	return &Manager{incus: client}, nil
+	return &Manager{incus: client, mirrors: defaultRegistryMirrors()}, nil
 }
 
 // NewWithBackend creates a new container manager backed by the given Incus
@@ -561,6 +565,15 @@ func (m *Manager) installPackages(containerName string, enablePodman bool, stack
 		}
 		if err := m.incus.Exec(containerName, []string{"systemctl", "start", "podman"}); err != nil {
 			return fmt.Errorf("failed to start podman: %w", err)
+		}
+
+		// #908: point the box's podman at the operator-configured registry
+		// mirror(s) so multi-GB image pulls come from the LAN, not the WAN. A
+		// non-destructive registries.conf.d drop-in; no-op when no mirror is
+		// configured. Best-effort: a mirror-config failure must not fail box
+		// provisioning — podman still pulls from upstream (today's behavior).
+		if err := m.writeRegistryMirrors(containerName); err != nil {
+			log.Printf("Warning: registry-mirror config on %s: %v", containerName, err)
 		}
 
 		// Install podman-compose via pip

--- a/pkg/core/container/registry_mirror.go
+++ b/pkg/core/container/registry_mirror.go
@@ -1,0 +1,124 @@
+package container
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Warm-image cache via bring-your-own registry mirror (#908).
+//
+// Every box has its own ephemeral podman storage, so a fresh box re-pulls its
+// images from scratch — a multi-GB image over the WAN can blow a programmatic
+// consumer's readiness budget (the OpenHands SDK gives 300s; a ~3.8GB pull took
+// ~17min on a loaded host). Pull-through caching is a commodity, so Containarium
+// does NOT run a registry: it ships only the thin box-side wiring. An operator
+// points boxes at a mirror they already run (registry:2 proxy, Harbor, zot, a
+// cloud AR mirror) via CONTAINARIUM_REGISTRY_MIRRORS, and box provisioning drops
+// a non-destructive registries.conf.d entry so the box's podman resolves those
+// upstreams through the LAN mirror first. First box pulls through (WAN, once);
+// every box after pulls over the LAN. Fails safe: no config -> no drop-in ->
+// today's behavior; mirror down -> podman falls back to the upstream.
+//
+// See docs/WARM-IMAGE-CACHE-DESIGN.md.
+
+// envRegistryMirrors is the host/daemon env var declaring registry mirrors as a
+// comma-separated list of `upstream=mirror` pairs, e.g.
+//
+//	CONTAINARIUM_REGISTRY_MIRRORS="docker.io=http://mirror.lan:5000,ghcr.io=http://mirror.lan:5000"
+//
+// The mirror may carry a scheme: `http://` marks it insecure (plain-HTTP LAN
+// mirror); `https://` or a bare host:port is treated as secure.
+const envRegistryMirrors = "CONTAINARIUM_REGISTRY_MIRRORS"
+
+// registryMirrorsPath is the box-side drop-in. podman merges every file in
+// registries.conf.d over the base registries.conf, so this never clobbers the
+// image's defaults (unqualified-search-registries etc.).
+const registryMirrorsPath = "/etc/containers/registries.conf.d/00-containarium-mirrors.conf"
+
+// registryMirrorsDir is the drop-in directory (podman ships it, but a minimal
+// base image may not — we mkdir -p before writing).
+const registryMirrorsDir = "/etc/containers/registries.conf.d"
+
+// RegistryMirror is one upstream->mirror redirect for the box's podman.
+type RegistryMirror struct {
+	Upstream string // e.g. "docker.io", "ghcr.io"
+	Location string // mirror host[:port], no scheme, e.g. "mirror.lan:5000"
+	Insecure bool   // plain-HTTP mirror (no TLS)
+}
+
+// defaultRegistryMirrors reads the configured mirrors from the environment.
+func defaultRegistryMirrors() []RegistryMirror {
+	return parseRegistryMirrors(os.Getenv(envRegistryMirrors))
+}
+
+// parseRegistryMirrors parses the CONTAINARIUM_REGISTRY_MIRRORS value. Malformed
+// entries (no '=', empty upstream/mirror) are skipped rather than failing — a
+// bad env var must not brick box creation.
+func parseRegistryMirrors(s string) []RegistryMirror {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	var out []RegistryMirror
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		up, mir, ok := strings.Cut(part, "=")
+		up = strings.TrimSpace(up)
+		mir = strings.TrimSpace(mir)
+		if !ok || up == "" || mir == "" {
+			continue
+		}
+		insecure := false
+		if rest, found := strings.CutPrefix(mir, "http://"); found {
+			mir, insecure = rest, true
+		} else if rest, found := strings.CutPrefix(mir, "https://"); found {
+			mir = rest
+		}
+		mir = strings.Trim(strings.TrimRight(mir, "/"), " ")
+		if mir == "" {
+			continue
+		}
+		out = append(out, RegistryMirror{Upstream: up, Location: mir, Insecure: insecure})
+	}
+	return out
+}
+
+// renderMirrorsConf renders the registries.conf.d drop-in (containers-registries
+// v2 TOML). One [[registry]] block per upstream, each with a single mirror.
+func renderMirrorsConf(mirrors []RegistryMirror) string {
+	var b strings.Builder
+	b.WriteString("# Managed by Containarium (#908) — registry pull-through mirrors.\n")
+	b.WriteString("# Boxes resolve these upstreams via the operator-provided mirror\n")
+	b.WriteString("# first, falling back to the upstream on a miss or mirror outage.\n")
+	for _, m := range mirrors {
+		b.WriteString("\n[[registry]]\n")
+		fmt.Fprintf(&b, "location = %q\n", m.Upstream)
+		b.WriteString("[[registry.mirror]]\n")
+		fmt.Fprintf(&b, "location = %q\n", m.Location)
+		if m.Insecure {
+			b.WriteString("insecure = true\n")
+		}
+	}
+	return b.String()
+}
+
+// writeRegistryMirrors installs the mirror drop-in into a box. No-op when no
+// mirror is configured. Returns an error only on a substrate failure; the
+// caller treats it as best-effort (a good box must not be lost over mirror
+// config — podman still pulls upstream).
+func (m *Manager) writeRegistryMirrors(containerName string) error {
+	if len(m.mirrors) == 0 {
+		return nil
+	}
+	if err := m.incus.Exec(containerName, []string{"mkdir", "-p", registryMirrorsDir}); err != nil {
+		return fmt.Errorf("registry-mirror: mkdir %s: %w", registryMirrorsDir, err)
+	}
+	if err := m.incus.WriteFile(containerName, registryMirrorsPath, []byte(renderMirrorsConf(m.mirrors)), "0644"); err != nil {
+		return fmt.Errorf("registry-mirror: write %s: %w", registryMirrorsPath, err)
+	}
+	return nil
+}

--- a/pkg/core/container/registry_mirror_test.go
+++ b/pkg/core/container/registry_mirror_test.go
@@ -1,0 +1,134 @@
+package container
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+)
+
+func TestParseRegistryMirrors(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []RegistryMirror
+	}{
+		{"empty", "", nil},
+		{"whitespace", "   ", nil},
+		{
+			"single http is insecure",
+			"docker.io=http://mirror.lan:5000",
+			[]RegistryMirror{{Upstream: "docker.io", Location: "mirror.lan:5000", Insecure: true}},
+		},
+		{
+			"https is secure",
+			"ghcr.io=https://mirror.lan:5000",
+			[]RegistryMirror{{Upstream: "ghcr.io", Location: "mirror.lan:5000", Insecure: false}},
+		},
+		{
+			"bare host is secure",
+			"quay.io=mirror.lan:5000",
+			[]RegistryMirror{{Upstream: "quay.io", Location: "mirror.lan:5000", Insecure: false}},
+		},
+		{
+			"multiple, trailing slash trimmed, spaces tolerated",
+			" docker.io=http://mirror.lan:5000/ , ghcr.io=mirror.lan:5000 ",
+			[]RegistryMirror{
+				{Upstream: "docker.io", Location: "mirror.lan:5000", Insecure: true},
+				{Upstream: "ghcr.io", Location: "mirror.lan:5000", Insecure: false},
+			},
+		},
+		{
+			"malformed entries skipped (no '=', empty sides)",
+			"noequals,=onlymirror,onlyupstream=,docker.io=mirror:5000",
+			[]RegistryMirror{{Upstream: "docker.io", Location: "mirror:5000", Insecure: false}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseRegistryMirrors(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseRegistryMirrors(%q) = %+v, want %+v", tt.in, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("entry %d = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRenderMirrorsConf(t *testing.T) {
+	conf := renderMirrorsConf([]RegistryMirror{
+		{Upstream: "docker.io", Location: "mirror.lan:5000", Insecure: true},
+		{Upstream: "ghcr.io", Location: "mirror.lan:5000", Insecure: false},
+	})
+	for _, want := range []string{
+		`location = "docker.io"`,
+		`location = "ghcr.io"`,
+		`location = "mirror.lan:5000"`,
+		"[[registry.mirror]]",
+		"insecure = true",
+	} {
+		if !strings.Contains(conf, want) {
+			t.Errorf("rendered conf missing %q:\n%s", want, conf)
+		}
+	}
+	// The secure (ghcr.io) mirror must NOT carry insecure; exactly one insecure
+	// line for the single insecure entry.
+	if n := strings.Count(conf, "insecure = true"); n != 1 {
+		t.Errorf("insecure lines = %d, want 1 (only the http mirror):\n%s", n, conf)
+	}
+}
+
+func TestWriteRegistryMirrors(t *testing.T) {
+	t.Run("no mirrors configured is a no-op", func(t *testing.T) {
+		mock := incustest.NewMockBackend()
+		var wrote bool
+		mock.WriteFileFunc = func(_, _ string, _ []byte, _ string) error { wrote = true; return nil }
+		mgr := NewWithBackend(mock)
+		if err := mgr.writeRegistryMirrors("box"); err != nil {
+			t.Fatalf("writeRegistryMirrors: %v", err)
+		}
+		if wrote {
+			t.Error("no mirrors configured must not write any file")
+		}
+	})
+
+	t.Run("writes the drop-in with rendered content", func(t *testing.T) {
+		mock := incustest.NewMockBackend()
+		var gotPath, gotContent, gotMode string
+		var mkdirDir string
+		mock.WriteFileFunc = func(_, path string, content []byte, mode string) error {
+			gotPath, gotContent, gotMode = path, string(content), mode
+			return nil
+		}
+		mock.ExecFunc = func(_ string, cmd []string) error {
+			if len(cmd) >= 3 && cmd[0] == "mkdir" {
+				mkdirDir = cmd[len(cmd)-1]
+			}
+			return nil
+		}
+		mgr := NewWithBackend(mock)
+		mgr.mirrors = []RegistryMirror{{Upstream: "docker.io", Location: "mirror.lan:5000", Insecure: true}}
+
+		if err := mgr.writeRegistryMirrors("box"); err != nil {
+			t.Fatalf("writeRegistryMirrors: %v", err)
+		}
+		if mkdirDir != registryMirrorsDir {
+			t.Errorf("mkdir dir = %q, want %q", mkdirDir, registryMirrorsDir)
+		}
+		if gotPath != registryMirrorsPath {
+			t.Errorf("drop-in path = %q, want %q", gotPath, registryMirrorsPath)
+		}
+		if gotMode != "0644" {
+			t.Errorf("mode = %q, want 0644", gotMode)
+		}
+		if !strings.Contains(gotContent, `location = "docker.io"`) ||
+			!strings.Contains(gotContent, `location = "mirror.lan:5000"`) ||
+			!strings.Contains(gotContent, "insecure = true") {
+			t.Errorf("drop-in content missing expected entries:\n%s", gotContent)
+		}
+	})
+}


### PR DESCRIPTION
v1 of the #908 warm-image cache, following the approved **BYO-mirror** direction from the design RFC (#915). Containarium ships **only the thin box-side wiring** — not a registry.

## Problem
Each box has its own ephemeral podman storage, so a fresh box re-pulls multi-GB images from scratch — a ~3.8 GB image took **~17 min on a loaded host**, blowing programmatic readiness budgets (the OpenHands SDK gives 300 s). Pull-through caching is a commodity; we shouldn't build or run one.

## What this ships
- **Config knob** — `CONTAINARIUM_REGISTRY_MIRRORS`, a comma-separated list of `upstream=mirror` pairs (an `http://` mirror is marked `insecure`). Example: `docker.io=http://mirror.lan:5000,ghcr.io=http://mirror.lan:5000`.
- **Box-create injection** — at the podman-enable step (`manager.go`), the Manager drops a **non-destructive** `registries.conf.d` file into the box so its podman resolves those upstreams through the operator's LAN mirror first. Never overwrites the base `registries.conf`.
- **Fails safe** — no config → no drop-in → today's behavior; mirror down → podman falls back to the upstream.

First box pulls *through* the mirror (WAN, once per host); every box after pulls over the **LAN**.

## Files
- `pkg/core/container/registry_mirror.go` — `RegistryMirror`, env parse, `registries.conf.d` render, `writeRegistryMirrors` (mkdir + drop-in).
- `pkg/core/container/manager.go` — Manager holds parsed mirrors (from env in `New()`); podman-enable block writes the drop-in best-effort (a failure warns, never fails box creation).
- Tests: env parse (scheme→insecure, malformed skipped, trailing-slash/space tolerance), render (TOML shape, insecure only on http), injection (no-op when unconfigured; correct path/mode/content via the mock backend).

## Out of this v1 (follow-ups)
Running a registry (BYO), the shared RO image store (Dir 3, idmap-risky), and the `warm_images` warm-list declaration.

## Validation plan
On a backend host: configure `CONTAINARIUM_REGISTRY_MIRRORS` at an off-the-shelf `registry:2` pull-through proxy, then time a **second** box's agent-server pull (LAN) vs. the **first** (WAN) — expect seconds-to-tens-of-seconds vs. minutes.

`go build ./...`, `go vet`, `gofmt`, and `go test ./pkg/core/container/` all pass locally.

Design: #915 · Issue: #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)