### PR TITLE
chore: bump Go 1.25.11 → 1.25.12 (GO-2026-5856)

### DIFF
--- a/.github/workflows/distros-go-ci.yml
+++ b/.github/workflows/distros-go-ci.yml
@@ -38,7 +38,7 @@ jobs:
           # Pinned to match the version the daemon's release workflow
           # uses; drift would mean release-built daemon and CI-tested
           # distro stop sharing a toolchain.
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Verify module hygiene
         # `go mod tidy` should be a no-op on a clean PR. If it changes

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Install golangci-lint
         # Pinned to the version the config (version: "2") targets. `go install`

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
       - name: Build k8s variant
         run: go build -tags k8s ./...
       - name: Reconciler unit tests (fake clientset, no cluster)
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
       - name: Install kind
         run: |
           curl -fsSL -o ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64

--- a/.github/workflows/proxyproto-e2e.yml
+++ b/.github/workflows/proxyproto-e2e.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Windows client cross-compile guard
         # The release builds a client-only Windows binary (cmd/containarium for
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Cache built caddy binary
         id: cache-caddy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Install buf
         # `make build-release` transitively runs `make proto`, which
@@ -197,7 +197,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Install buf
         run: go install github.com/bufbuild/buf/cmd/buf@latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.12'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/footprintai/containarium
 
-go 1.25.11
+go 1.25.12
 
 require (
 	cloud.google.com/go/compute v1.64.0

--- a/images/agent-box/Dockerfile
+++ b/images/agent-box/Dockerfile
@@ -21,7 +21,7 @@
 # --- build agent-box -------------------------------------------------------
 # No `k8s` build tag here: agent-box is the in-box MCP and never imports
 # client-go, so this stays a small static binary.
-FROM golang:1.25.11-bookworm AS build
+FROM golang:1.25.12-bookworm AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
`govulncheck` fails repo-wide on **GO-2026-5856** (`crypto/tls`, standard library), which has a fix available in **go1.25.12**. The repo pins `1.25.11`, so the security gate is red on every PR (surfaced on #916, whose own code is otherwise fully green).

Bumps the toolchain everywhere it's pinned:
- `go.mod` → `go 1.25.12`
- `images/agent-box/Dockerfile` → `golang:1.25.12-bookworm`
- `.github/workflows/*.yml` → `go-version '1.25.12'` (all pins)

No code changes. Unblocks the `govulncheck` required check repo-wide (and thus #916).

🤖 Generated with [Claude Code](https://claude.com/claude-code)