### PR TITLE
fix(sentinel): allow runtime registration of tunnel-join tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`POST /sentinel/tunnel-tokens` — register a tunnel-join token on a
+  running sentinel without a restart** (#799). The sentinel's
+  `TokenPolicy` was previously built once at startup from
+  `--tunnel-token`/`--tunnel-token-policy` and never updated again, so
+  any token minted afterwards (e.g. by a BYOC join flow that issues a
+  fresh token per request) was permanently rejected with "invalid
+  token" — not a transient failure, a structural one. Gated by a new,
+  deliberately separate `CONTAINARIUM_SENTINEL_ADMIN_SECRET` (not the
+  cluster-wide `CONTAINARIUM_SENTINEL_AUTH_SECRET` every daemon already
+  holds for keysync/certsync — admitting a new node into a pool is a
+  bigger capability than that). New CLI: `containarium sentinel
+  register-token --url <sentinel> --token <token> [--pool <pool>]`.
+
 ## [0.49.0] - 2026-07-08
 
 ### Added

--- a/docs/SENTINEL-AUTH-SECRET.md
+++ b/docs/SENTINEL-AUTH-SECRET.md
@@ -1,5 +1,14 @@
 # Sentinel ↔ daemon HMAC secret (`CONTAINARIUM_SENTINEL_AUTH_SECRET`)
 
+> **This is not the only sentinel secret.** `CONTAINARIUM_SENTINEL_ADMIN_SECRET`
+> gates `POST /sentinel/tunnel-tokens` (registering a tunnel-join token at
+> runtime — see #799) and is deliberately a *different* value: every daemon in
+> the cluster holds the auth secret below, but admitting a brand-new node into
+> a pool is a bigger capability than keysync/certsync, so it isn't gated by a
+> secret every daemon already has. Generate and distribute it the same way as
+> below, to whoever issues join tokens (an operator, or the cloud control
+> plane's token-issuance service) — not to every daemon.
+
 > **As of v0.45.0 there is a stronger, asymmetric successor.** The shared HMAC
 > secret below is symmetric — every daemon that can verify the sentinel can also
 > forge a request, which is a cross-tenant escalation on multi-tenant / BYOC

--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -179,6 +179,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 			tunnelServer.OnConnect = manager.OnTunnelConnect
 			tunnelServer.OnDisconnect = manager.OnTunnelDisconnect
 			manager.SetTunnelRegistry(registry)
+			manager.SetTunnelPolicy(tunnelPolicy)
 			manager.SetHTTPSListener(connMux.HTTPSChanListener())
 
 			sigChan := make(chan os.Signal, 1)
@@ -263,6 +264,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 		tunnelServer.OnConnect = manager.OnTunnelConnect
 		tunnelServer.OnDisconnect = manager.OnTunnelDisconnect
 		manager.SetTunnelRegistry(registry)
+		manager.SetTunnelPolicy(tunnelPolicy)
 		manager.SetHTTPSListener(connMux.HTTPSChanListener())
 
 		// Graceful shutdown on signals

--- a/internal/cmd/sentinel_register_token.go
+++ b/internal/cmd/sentinel_register_token.go
@@ -1,0 +1,111 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/config"
+	"github.com/footprintai/containarium/internal/sentinel"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sentinelRegisterTokenSentinelURL string
+	sentinelRegisterTokenToken       string
+	sentinelRegisterTokenPools       []string
+	sentinelRegisterTokenSecret      string
+)
+
+var sentinelRegisterTokenCmd = &cobra.Command{
+	Use:   "register-token",
+	Short: "Register a freshly-minted tunnel-join token on a running sentinel (#799)",
+	Long: `POST to the sentinel's binary server, authorizing a tunnel-join token that
+was minted after the sentinel started.
+
+The sentinel's token policy is otherwise built once at startup from
+--tunnel-token/--tunnel-token-policy — a token issued afterwards (e.g. by a
+cloud control plane's BYOC join flow) has no way to become valid without
+this call, and every handshake using it fails with "invalid token"
+regardless of how correctly-formed the token is.
+
+The request is authenticated with a DIFFERENT secret than sentinel
+fetch-release/ca/peer-cert use: CONTAINARIUM_SENTINEL_ADMIN_SECRET, not
+CONTAINARIUM_SENTINEL_AUTH_SECRET. Every cluster daemon holds the auth
+secret for keysync/certsync; admitting a brand-new node into a pool is a
+bigger capability than that, so it is gated separately.
+
+Examples:
+
+  # Authorize a token for any pool (the common BYOC case)
+  containarium sentinel register-token \
+      --url http://asia-east1.containarium.dev:8888 \
+      --token 453e7e86-47d3-4063-96a8-46c220dda28d.YPkBcGdCNVTqmRNtdjJ0rGslmGdQBM5uwyZS13xEbbg
+
+  # Restrict a token to specific pools
+  containarium sentinel register-token \
+      --url http://asia-east1.containarium.dev:8888 \
+      --token <token> --pool lab --pool prod`,
+	RunE: runSentinelRegisterToken,
+}
+
+func init() {
+	sentinelCmd.AddCommand(sentinelRegisterTokenCmd)
+
+	sentinelRegisterTokenCmd.Flags().StringVar(&sentinelRegisterTokenSentinelURL, "url", "", "Sentinel binary-server base URL, e.g. http://asia-east1.containarium.dev:8888 (required)")
+	sentinelRegisterTokenCmd.Flags().StringVar(&sentinelRegisterTokenToken, "token", "", "Tunnel-join token to authorize (required)")
+	sentinelRegisterTokenCmd.Flags().StringSliceVar(&sentinelRegisterTokenPools, "pool", nil, "Pool this token may join. Repeatable. Omit for any pool (PoolAny) — the common case for a one-off BYOC token.")
+	sentinelRegisterTokenCmd.Flags().StringVar(&sentinelRegisterTokenSecret, "secret", os.Getenv(config.EnvSentinelAdminSecret), "Sentinel admin secret (defaults to $CONTAINARIUM_SENTINEL_ADMIN_SECRET)")
+
+	_ = sentinelRegisterTokenCmd.MarkFlagRequired("url")
+	_ = sentinelRegisterTokenCmd.MarkFlagRequired("token")
+}
+
+func runSentinelRegisterToken(cmd *cobra.Command, args []string) error {
+	if sentinelRegisterTokenSecret == "" {
+		return fmt.Errorf("sentinel admin secret is required — pass --secret or set CONTAINARIUM_SENTINEL_ADMIN_SECRET")
+	}
+
+	pools := make([]sentinel.Pool, len(sentinelRegisterTokenPools))
+	for i, p := range sentinelRegisterTokenPools {
+		pools[i] = sentinel.Pool(p)
+	}
+
+	body, err := json.Marshal(sentinel.TunnelTokenRegisterRequest{
+		Token: sentinelRegisterTokenToken,
+		Pools: pools,
+	})
+	if err != nil {
+		return err
+	}
+
+	endpoint := sentinelRegisterTokenSentinelURL + "/sentinel/tunnel-tokens"
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(req, []byte(sentinelRegisterTokenSecret))
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("POST %s: %w", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("sentinel returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "token registered\n")
+	return nil
+}

--- a/internal/config/sentinel.go
+++ b/internal/config/sentinel.go
@@ -13,12 +13,21 @@ const (
 	EnvSentinelAlertWebhook = "CONTAINARIUM_SENTINEL_ALERT_WEBHOOK"
 	// #nosec G101 -- this is the NAME of an environment variable, not a credential value.
 	EnvSentinelAuthSecret = "CONTAINARIUM_SENTINEL_AUTH_SECRET"
-	EnvSentinelCertSANs   = "CONTAINARIUM_SENTINEL_CERT_SANS"
-	EnvSentinelHost       = "CONTAINARIUM_SENTINEL_HOST"
-	EnvSentinelHTTPSPort  = "CONTAINARIUM_SENTINEL_HTTPS_PORT"
-	EnvSentinelPublicKey  = "CONTAINARIUM_SENTINEL_PUBLIC_KEY"
-	EnvSentinelSigningKey = "CONTAINARIUM_SENTINEL_SIGNING_KEY"
-	EnvSentinelURL        = "CONTAINARIUM_SENTINEL_URL"
+	// #nosec G101 -- this is the NAME of an environment variable, not a credential value.
+	//
+	// Deliberately separate from EnvSentinelAuthSecret: the auth secret is
+	// held by every daemon in the cluster (keysync/certsync), so reusing it
+	// here would let a compromised daemon mint tunnel-join tokens for any
+	// pool. This secret is held only by whoever is trusted to admit new
+	// nodes — an operator, or the cloud control plane's token-issuance
+	// service. See sentinel.TunnelTokenRegisterHandler.
+	EnvSentinelAdminSecret = "CONTAINARIUM_SENTINEL_ADMIN_SECRET"
+	EnvSentinelCertSANs    = "CONTAINARIUM_SENTINEL_CERT_SANS"
+	EnvSentinelHost        = "CONTAINARIUM_SENTINEL_HOST"
+	EnvSentinelHTTPSPort   = "CONTAINARIUM_SENTINEL_HTTPS_PORT"
+	EnvSentinelPublicKey   = "CONTAINARIUM_SENTINEL_PUBLIC_KEY"
+	EnvSentinelSigningKey  = "CONTAINARIUM_SENTINEL_SIGNING_KEY"
+	EnvSentinelURL         = "CONTAINARIUM_SENTINEL_URL"
 )
 
 // Sentinel is the typed view of the CONTAINARIUM_SENTINEL_* namespace — the

--- a/internal/sentinel/binaryserver.go
+++ b/internal/sentinel/binaryserver.go
@@ -107,6 +107,11 @@ func StartBinaryServer(port int, manager *Manager) (stop func(), err error) {
 	mux.Handle("/sentinel/peer-cert", auth.SentinelHMACMiddleware(manager.hmacSecret, manager.PeerCertHandler()))
 	mux.Handle("/sentinel/fetch-release", auth.SentinelHMACMiddleware(manager.hmacSecret, fetchReleaseHandler(binaryPath)))
 
+	// Runtime tunnel-token registration — gated by the separate
+	// admin secret (CONTAINARIUM_SENTINEL_ADMIN_SECRET), not the
+	// cluster-wide daemon HMAC secret. See TunnelTokenRegisterHandler.
+	mux.Handle("/sentinel/tunnel-tokens", auth.SentinelHMACMiddleware(manager.adminSecret, manager.TunnelTokenRegisterHandler()))
+
 	// Peer proxy — forwards /peer/<backend-id>/* to the tunnel backend's loopback
 	// This allows the primary daemon to reach tunnel backends through the sentinel
 	// without needing extra firewall rules for external ports.

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -134,6 +134,23 @@ type Manager struct {
 	// CONTAINARIUM_SENTINEL_AUTH_SECRET at startup.
 	hmacSecret []byte
 
+	// adminSecret gates POST /sentinel/tunnel-tokens (registering a
+	// freshly-minted tunnel-join token at runtime). Deliberately a
+	// different secret than hmacSecret — see EnvSentinelAdminSecret.
+	// Loaded from CONTAINARIUM_SENTINEL_ADMIN_SECRET in NewManager;
+	// tests can override with SetAdminSecret.
+	adminSecret []byte
+
+	// tunnelPolicy is the token-authorization policy the tunnel
+	// server was constructed with (see PolicyFromCLI in
+	// internal/cmd/sentinel.go). Wired in via SetTunnelPolicy so the
+	// TunnelTokenRegisterHandler can add tokens at runtime — the
+	// policy is otherwise 100% static after startup. nil in modes
+	// that don't run a tunnel server (e.g. provider=gcp with no
+	// tunnel token configured), in which case the register endpoint
+	// responds 501.
+	tunnelPolicy *TokenPolicy
+
 	// pki holds the operator-bootstrapped peer-CA and the sentinel's
 	// own server cert. Set when CONTAINARIUM_CA_KEY_FILE points at a
 	// valid RSA key — see NewManager and SetCertProvisioner.
@@ -285,6 +302,18 @@ func NewManager(config Config, provider CloudProvider) *Manager {
 	} else {
 		log.Printf("[sentinel] WARNING: CONTAINARIUM_SENTINEL_AUTH_SECRET is unset — /sentinel/peers responses will be unsigned (daemons in rollout mode accept them with a warning; once fully rolled out they will reject)")
 	}
+	if raw := os.Getenv(appconfig.EnvSentinelAdminSecret); raw != "" {
+		if len(raw) < auth.SentinelMinSecretLen {
+			// #nosec G706 -- both args are ints (len(raw) and a
+			// const) so there is no log-injection vector; gosec's
+			// taint chases `raw` upstream and flags any descendant.
+			log.Printf("[sentinel] WARNING: CONTAINARIUM_SENTINEL_ADMIN_SECRET is %d bytes, want >=%d — /sentinel/tunnel-tokens will reject every request",
+				len(raw), auth.SentinelMinSecretLen)
+		}
+		m.adminSecret = []byte(raw)
+	} else {
+		log.Printf("[sentinel] CONTAINARIUM_SENTINEL_ADMIN_SECRET is unset — /sentinel/tunnel-tokens is disabled (fresh tunnel-join tokens can only be added by restarting the sentinel with --tunnel-token-policy)")
+	}
 
 	// Phase 0.5: peer-CA bootstrap. Operators provision a single
 	// RSA private key on the sentinel (mode 0400) and point this
@@ -335,6 +364,22 @@ func NewManager(config Config, provider CloudProvider) *Manager {
 // the SNI router falls back to TCP-dialing the primary's IP:Port.
 func (m *Manager) SetTunnelRegistry(reg *TunnelRegistry) {
 	m.tunnelRegistry = reg
+}
+
+// SetTunnelPolicy wires in the token-authorization policy the tunnel
+// server was constructed with, so TunnelTokenRegisterHandler can add
+// tokens to it at runtime. Called from internal/cmd/sentinel.go right
+// after PolicyFromCLI builds the policy.
+func (m *Manager) SetTunnelPolicy(policy *TokenPolicy) {
+	m.tunnelPolicy = policy
+}
+
+// SetAdminSecret wires the secret that gates POST
+// /sentinel/tunnel-tokens. Tests can use this to inject a secret
+// without setting CONTAINARIUM_SENTINEL_ADMIN_SECRET in the
+// environment.
+func (m *Manager) SetAdminSecret(secret []byte) {
+	m.adminSecret = secret
 }
 
 // SetHTTPSListener sets a ConnMux HTTPS chanListener for tunnel/hybrid mode.

--- a/internal/sentinel/tunnel_token_handler.go
+++ b/internal/sentinel/tunnel_token_handler.go
@@ -1,0 +1,66 @@
+package sentinel
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// TunnelTokenRegisterRequest is the JSON body POSTed to
+// TunnelTokenRegisterHandler to make a freshly-issued join token valid
+// on this already-running sentinel.
+type TunnelTokenRegisterRequest struct {
+	// Token is the tunnel-handshake token to authorize (opaque string,
+	// matched verbatim against TunnelHandshake.Token).
+	Token string `json:"token"`
+
+	// Pools lists the pools this token may join. Empty/omitted means
+	// PoolAny — the common case for a one-off BYOC join token, which
+	// isn't scoped to a specific pool ahead of time.
+	Pools []Pool `json:"pools,omitempty"`
+}
+
+// TunnelTokenRegisterHandler lets an authorized caller (the cloud
+// control plane's token-issuance service, or an operator) register a
+// tunnel-join token on a running sentinel without a restart.
+//
+// The sentinel's TokenPolicy is otherwise 100% static — built once at
+// startup from --tunnel-token/--tunnel-token-policy CLI flags (see
+// PolicyFromCLI) — so a token minted after the sentinel started had no
+// way to ever become valid; every handshake using it failed with
+// "invalid token" regardless of how fresh or correctly-formed the
+// token was. This endpoint is the missing runtime path.
+//
+// Gated by CONTAINARIUM_SENTINEL_ADMIN_SECRET — deliberately not the
+// same secret as CONTAINARIUM_SENTINEL_AUTH_SECRET, which every
+// cluster daemon already holds for keysync/certsync. Admitting a
+// brand-new node into a pool is a materially bigger capability than
+// those intra-cluster operations; a compromised daemon shouldn't be
+// able to mint join tokens for other pools just because it has the
+// cluster-wide keysync secret.
+func (m *Manager) TunnelTokenRegisterHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		if m.tunnelPolicy == nil {
+			http.Error(w, `{"error":"tunnel mode not enabled on this sentinel","code":501}`, http.StatusNotImplemented)
+			return
+		}
+		var req TunnelTokenRegisterRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+			return
+		}
+		if req.Token == "" {
+			http.Error(w, `{"error":"token is required"}`, http.StatusBadRequest)
+			return
+		}
+		pools := req.Pools
+		if len(pools) == 0 {
+			pools = []Pool{PoolAny}
+		}
+		m.tunnelPolicy.Allow(req.Token, pools...)
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/sentinel/tunnel_token_handler_test.go
+++ b/internal/sentinel/tunnel_token_handler_test.go
@@ -1,0 +1,144 @@
+package sentinel
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+const tunnelTokenAdminSecret = "zyxwvutsrqponmlkjihgfedcba9876543210ZYXW" // 40 bytes
+
+func newManagerForTunnelTokenTest(t *testing.T, withPolicy bool) *Manager {
+	t.Helper()
+	m := &Manager{backends: NewBackendPool()}
+	m.SetAdminSecret([]byte(tunnelTokenAdminSecret))
+	if withPolicy {
+		m.SetTunnelPolicy(NewTokenPolicy())
+	}
+	return m
+}
+
+func TestTunnelTokenRegisterHandler_RegistersFreshToken(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+
+	// Before registration, the token is unknown — this is the exact
+	// "invalid token" rejection reported in #799.
+	if err := m.tunnelPolicy.Validate("fresh-token", ""); err == nil {
+		t.Fatal("expected fresh token to be rejected before registration")
+	}
+
+	body, _ := json.Marshal(TunnelTokenRegisterRequest{Token: "fresh-token"})
+	req := httptest.NewRequest(http.MethodPost, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(req, []byte(tunnelTokenAdminSecret))
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenRegisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	// No pools specified => PoolAny, so it matches any pool including
+	// the empty one BYOC's `pool join` (no --pool flag) actually uses.
+	if err := m.tunnelPolicy.Validate("fresh-token", ""); err != nil {
+		t.Fatalf("token still rejected after registration: %v", err)
+	}
+	if err := m.tunnelPolicy.Validate("fresh-token", "asia-east1"); err != nil {
+		t.Fatalf("token should match any pool (PoolAny default): %v", err)
+	}
+}
+
+func TestTunnelTokenRegisterHandler_RestrictsToSpecifiedPools(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+
+	body, _ := json.Marshal(TunnelTokenRegisterRequest{Token: "scoped-token", Pools: []Pool{"lab"}})
+	req := httptest.NewRequest(http.MethodPost, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(req, []byte(tunnelTokenAdminSecret))
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenRegisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if err := m.tunnelPolicy.Validate("scoped-token", "lab"); err != nil {
+		t.Fatalf("token should be valid for lab: %v", err)
+	}
+	if err := m.tunnelPolicy.Validate("scoped-token", "prod"); err == nil {
+		t.Fatal("token should NOT be valid for prod")
+	}
+}
+
+func TestTunnelTokenRegisterHandler_501WhenTunnelModeDisabled(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, false) // no SetTunnelPolicy call
+
+	body, _ := json.Marshal(TunnelTokenRegisterRequest{Token: "x"})
+	req := httptest.NewRequest(http.MethodPost, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(req, []byte(tunnelTokenAdminSecret))
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenRegisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("want 501, got %d", rec.Code)
+	}
+}
+
+func TestTunnelTokenRegisterHandler_400OnMissingToken(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+
+	body, _ := json.Marshal(TunnelTokenRegisterRequest{})
+	req := httptest.NewRequest(http.MethodPost, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(req, []byte(tunnelTokenAdminSecret))
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenRegisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}
+
+func TestTunnelTokenRegisterHandler_RejectsUnsignedRequest(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+
+	body, _ := json.Marshal(TunnelTokenRegisterRequest{Token: "x"})
+	req := httptest.NewRequest(http.MethodPost, "/sentinel/tunnel-tokens", bytes.NewReader(body)) // no SignSentinelRequest
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenRegisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unsigned request must be rejected; got %d", rec.Code)
+	}
+}
+
+// TestTunnelTokenRegisterHandler_AdminSecretIndependentOfHMACSecret guards
+// the core security property of #799's fix: possessing the cluster-wide
+// daemon HMAC secret (CONTAINARIUM_SENTINEL_AUTH_SECRET) must NOT be
+// sufficient to register new tunnel-join tokens.
+func TestTunnelTokenRegisterHandler_AdminSecretIndependentOfHMACSecret(t *testing.T) {
+	m := &Manager{backends: NewBackendPool()}
+	m.SetHMACSecret([]byte(phase05Secret)) // cluster-wide daemon secret
+	m.SetAdminSecret([]byte(tunnelTokenAdminSecret))
+	m.SetTunnelPolicy(NewTokenPolicy())
+
+	body, _ := json.Marshal(TunnelTokenRegisterRequest{Token: "x"})
+	req := httptest.NewRequest(http.MethodPost, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+	auth.SignSentinelRequest(req, []byte(phase05Secret)) // signed with the WRONG secret
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware(m.adminSecret, m.TunnelTokenRegisterHandler())
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("HMAC secret must not authorize admin token registration; got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- Root cause of the BYOC join failures reported in `FootprintAI/Containarium-cloud#799`: the sentinel's `TokenPolicy` is built once at startup from `--tunnel-token`/`--tunnel-token-policy` and never updated again, so a token minted **after** the sentinel started (e.g. a fresh per-request BYOC join token) had no way to ever become valid — every handshake failed with `"invalid token"` by construction, not by chance.
- Adds `POST /sentinel/tunnel-tokens` to register a token on a running sentinel at runtime, gated by a new `CONTAINARIUM_SENTINEL_ADMIN_SECRET` — deliberately **not** the same secret as `CONTAINARIUM_SENTINEL_AUTH_SECRET` (every cluster daemon already holds that one for keysync/certsync; admitting a brand-new node into a pool is a bigger capability than intra-cluster operations, so a compromised daemon shouldn't be able to do it).
- New CLI: `containarium sentinel register-token --url <sentinel> --token <token> [--pool <pool>]`.

## Follow-up needed (not in this PR, tracked in cloud#799)
This closes the OSS-side gap only. To fully unblock BYOC joins:
1. Provision `CONTAINARIUM_SENTINEL_ADMIN_SECRET` on the `asia-east1`/`us-west1` sentinels (same distribute-then-restart process as the existing auth secret — see updated `docs/SENTINEL-AUTH-SECRET.md`).
2. containarium-cloud's token-issuance service needs to call this new endpoint (or the CLI) right after minting a BYOC join token.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/sentinel/... ./internal/cmd/... ./internal/config/...` — new tests cover: fresh-token registration, pool-scoped registration, 501 when tunnel mode disabled, 400 on missing token, rejection of unsigned requests, and a privilege-separation check that the existing daemon HMAC secret does **not** authorize this endpoint.
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)