### PR TITLE
chore(release): cut v0.49.1 — sentinel runtime tunnel-token registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.1] - 2026-07-09
+
 ### Added
 
 - **`POST /sentinel/tunnel-tokens` — register a tunnel-join token on a

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.49.0"
+	Version = "0.49.1"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary
- Bumps CHANGELOG.md and pkg/version/version.go for v0.49.1, which contains #918 (sentinel runtime tunnel-token registration, fixing the BYOC join blocker in containarium-cloud#799).

## Test plan
- [x] Version bump only, no code changes beyond what's already merged in #918