### PR TITLE
fix(daemon): orphan-reaper only reaps containarium-managed accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The orphan-reaper (#835) could delete a legitimate, manually-provisioned
+  admin account that happened to live under `/home` with its own SSH key.**
+  `RunOrphanReaper` swept every `/home/<name>` directory with an
+  `authorized_keys` file and no matching `<name>-container`, with no way to
+  tell a genuine Containarium tenant apart from an unrelated admin login
+  sharing the same directory shape. It now only reaps accounts whose login
+  shell is the containarium-managed shell wrapper — anything else (bash,
+  zsh, etc.) is left alone even with no matching container. A real incident:
+  upgrading a host's daemon (which enabled this reaper for the first time on
+  that host) `userdel -r`'d an operator's own admin account mid-session.
+
 ## [0.49.1] - 2026-07-09
 
 ### Added

--- a/pkg/core/container/orphan_reaper.go
+++ b/pkg/core/container/orphan_reaper.go
@@ -2,9 +2,12 @@ package container
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -36,7 +39,7 @@ func RunOrphanReaperWithRoot(ctx context.Context, homeRoot string, containerExis
 	case <-time.After(orphanReaperGracePeriod):
 	}
 
-	reapOnce(homeRoot, containerExistsFn)
+	reapOnce(homeRoot, containerExistsFn, userShell, DeleteJumpServerAccount)
 
 	ticker := time.NewTicker(orphanReaperInterval)
 	defer ticker.Stop()
@@ -45,12 +48,34 @@ func RunOrphanReaperWithRoot(ctx context.Context, homeRoot string, containerExis
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			reapOnce(homeRoot, containerExistsFn)
+			reapOnce(homeRoot, containerExistsFn, userShell, DeleteJumpServerAccount)
 		}
 	}
 }
 
-func reapOnce(homeRoot string, containerExistsFn func(username string) bool) {
+// userShell returns username's login shell from the passwd database (the
+// 7th colon-separated field of `getent passwd`), used to gate reaping to
+// accounts actually running containerShellPath. Errors (unknown user,
+// getent unavailable) are surfaced to the caller, which treats them as
+// "don't reap" — see reapOnce.
+func userShell(username string) (string, error) {
+	out, err := exec.Command("getent", "passwd", username).Output()
+	if err != nil {
+		return "", err
+	}
+	fields := strings.Split(strings.TrimRight(string(out), "\n"), ":")
+	if len(fields) < 7 {
+		return "", fmt.Errorf("unexpected getent passwd output for %q: %q", username, out)
+	}
+	return fields[6], nil
+}
+
+func reapOnce(
+	homeRoot string,
+	containerExistsFn func(username string) bool,
+	userShellFn func(username string) (string, error),
+	deleteFn func(username string, verbose bool) error,
+) {
 	entries, err := os.ReadDir(homeRoot)
 	if err != nil {
 		log.Printf("[orphan-reaper] failed to read %s: %v", homeRoot, err)
@@ -67,6 +92,18 @@ func reapOnce(homeRoot string, containerExistsFn func(username string) bool) {
 		if _, statErr := os.Stat(akPath); os.IsNotExist(statErr) {
 			continue // no authorized_keys → not a containarium user
 		}
+		// A home directory with authorized_keys is not, by itself,
+		// proof the reaper created it — a manually-provisioned admin
+		// account can happen to live under the same homeRoot with its
+		// own SSH key. Only reap accounts actually running the
+		// containarium-managed shell; anything else (bash, zsh, etc.)
+		// is left alone even if no matching container exists. A real
+		// incident: an operator's own admin login shared this
+		// heuristic's shape and got userdel'd by an upgrade that
+		// enabled this reaper for the first time.
+		if shell, err := userShellFn(username); err != nil || shell != containerShellPath {
+			continue
+		}
 		if containerExistsFn(username) {
 			continue
 		}
@@ -80,7 +117,7 @@ func reapOnce(homeRoot string, containerExistsFn func(username string) bool) {
 	log.Printf("[orphan-reaper] found %d orphaned host accounts; reaping", len(orphans))
 	reaped, failed := 0, 0
 	for _, username := range orphans {
-		if err := DeleteJumpServerAccount(username, false); err != nil {
+		if err := deleteFn(username, false); err != nil {
 			log.Printf("[orphan-reaper] userdel %s failed: %v", username, err)
 			failed++
 		} else {

--- a/pkg/core/container/orphan_reaper.go
+++ b/pkg/core/container/orphan_reaper.go
@@ -59,6 +59,9 @@ func RunOrphanReaperWithRoot(ctx context.Context, homeRoot string, containerExis
 // getent unavailable) are surfaced to the caller, which treats them as
 // "don't reap" — see reapOnce.
 func userShell(username string) (string, error) {
+	// #nosec G204 -- callers validate username via isValidUsername (see
+	// reapOnce), same invariant as the sibling getent-shadow call in
+	// jump_server.go.
 	out, err := exec.Command("getent", "passwd", username).Output()
 	if err != nil {
 		return "", err
@@ -88,6 +91,9 @@ func reapOnce(
 			continue
 		}
 		username := e.Name()
+		if !isValidUsername(username) {
+			continue // directory name isn't a containarium username shape at all
+		}
 		akPath := filepath.Join(homeRoot, username, ".ssh", "authorized_keys")
 		if _, statErr := os.Stat(akPath); os.IsNotExist(statErr) {
 			continue // no authorized_keys → not a containarium user

--- a/pkg/core/container/orphan_reaper_test.go
+++ b/pkg/core/container/orphan_reaper_test.go
@@ -1,0 +1,145 @@
+package container
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// makeHomeDir creates homeRoot/username[/.ssh/authorized_keys] for test
+// fixtures. withKey=false leaves out the .ssh/authorized_keys file
+// entirely, matching a directory the reaper should never consider.
+func makeHomeDir(t *testing.T, homeRoot, username string, withKey bool) {
+	t.Helper()
+	dir := filepath.Join(homeRoot, username)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", dir, err)
+	}
+	if !withKey {
+		return
+	}
+	sshDir := filepath.Join(dir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", sshDir, err)
+	}
+	akPath := filepath.Join(sshDir, "authorized_keys")
+	if err := os.WriteFile(akPath, []byte("ssh-ed25519 AAAA fake\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%s): %v", akPath, err)
+	}
+}
+
+// TestReapOnce_OnlyReapsContainariumManagedShell is the regression test for
+// the real incident: an operator's own admin account (real login shell, no
+// matching container) must never be reaped just because it lives under
+// homeRoot with an authorized_keys file. Only accounts whose shell is
+// exactly containerShellPath are eligible.
+func TestReapOnce_OnlyReapsContainariumManagedShell(t *testing.T) {
+	homeRoot := t.TempDir()
+
+	makeHomeDir(t, homeRoot, "orphaned-tenant", true) // containarium-shell, no container -> reap
+	makeHomeDir(t, homeRoot, "admin-user", true)      // /bin/bash, no container -> must NOT reap
+	makeHomeDir(t, homeRoot, "live-tenant", true)     // containarium-shell, HAS container -> must NOT reap
+	makeHomeDir(t, homeRoot, "no-key-dir", false)     // no authorized_keys -> never considered
+
+	shells := map[string]string{
+		"orphaned-tenant": containerShellPath,
+		"admin-user":      "/bin/bash",
+		"live-tenant":     containerShellPath,
+	}
+	userShellFn := func(username string) (string, error) {
+		shell, ok := shells[username]
+		if !ok {
+			return "", fmt.Errorf("user %q not found", username)
+		}
+		return shell, nil
+	}
+
+	containerExistsFn := func(username string) bool {
+		return username == "live-tenant"
+	}
+
+	var deleted []string
+	deleteFn := func(username string, verbose bool) error {
+		deleted = append(deleted, username)
+		return nil
+	}
+
+	reapOnce(homeRoot, containerExistsFn, userShellFn, deleteFn)
+
+	if len(deleted) != 1 || deleted[0] != "orphaned-tenant" {
+		t.Fatalf("deleted = %v, want exactly [orphaned-tenant]", deleted)
+	}
+}
+
+// TestReapOnce_UnknownShellIsNotReaped covers the fail-safe path: if the
+// passwd lookup errors (e.g. the directory has no matching passwd entry at
+// all — a stale artifact, not a live account), the reaper must not delete
+// anything rather than guessing.
+func TestReapOnce_UnknownShellIsNotReaped(t *testing.T) {
+	homeRoot := t.TempDir()
+	makeHomeDir(t, homeRoot, "stale-dir", true)
+
+	userShellFn := func(username string) (string, error) {
+		return "", fmt.Errorf("user %q not found", username)
+	}
+	containerExistsFn := func(username string) bool { return false }
+
+	var deleted []string
+	deleteFn := func(username string, verbose bool) error {
+		deleted = append(deleted, username)
+		return nil
+	}
+
+	reapOnce(homeRoot, containerExistsFn, userShellFn, deleteFn)
+
+	if len(deleted) != 0 {
+		t.Fatalf("deleted = %v, want none", deleted)
+	}
+}
+
+// TestReapOnce_NoAuthorizedKeysNeverConsidered ensures a plain directory
+// under homeRoot with no .ssh/authorized_keys never reaches the shell
+// lookup or delete path at all.
+func TestReapOnce_NoAuthorizedKeysNeverConsidered(t *testing.T) {
+	homeRoot := t.TempDir()
+	makeHomeDir(t, homeRoot, "plain-dir", false)
+
+	userShellFn := func(username string) (string, error) {
+		t.Fatalf("userShellFn should not be called for %q", username)
+		return "", nil
+	}
+	containerExistsFn := func(username string) bool { return false }
+	deleteFn := func(username string, verbose bool) error {
+		t.Fatalf("deleteFn should not be called for %q", username)
+		return nil
+	}
+
+	reapOnce(homeRoot, containerExistsFn, userShellFn, deleteFn)
+}
+
+func TestUserShell_ParsesGetentOutput(t *testing.T) {
+	if _, err := exec.LookPath("getent"); err != nil {
+		t.Skip("getent not available on this platform (Linux-only tool; CI runs Linux)")
+	}
+	// root always exists on Linux CI runners and never runs
+	// containerShellPath, so this exercises the real getent path
+	// without requiring a fixture user.
+	shell, err := userShell("root")
+	if err != nil {
+		t.Fatalf("userShell(root): %v", err)
+	}
+	if shell == "" {
+		t.Fatal("userShell(root) returned empty shell")
+	}
+	if shell == containerShellPath {
+		t.Fatalf("root should never have shell %q", containerShellPath)
+	}
+}
+
+func TestUserShell_UnknownUser(t *testing.T) {
+	if _, err := userShell("nonexistent_user_12345"); err == nil {
+		t.Fatal("userShell(nonexistent_user_12345) should error")
+	}
+}

--- a/pkg/core/container/orphan_reaper_test.go
+++ b/pkg/core/container/orphan_reaper_test.go
@@ -119,6 +119,30 @@ func TestReapOnce_NoAuthorizedKeysNeverConsidered(t *testing.T) {
 	reapOnce(homeRoot, containerExistsFn, userShellFn, deleteFn)
 }
 
+// TestReapOnce_InvalidUsernameShapeNeverConsidered ensures a directory
+// whose name isn't a valid containarium username (e.g. contains shell
+// metacharacters) never reaches the getent/exec.Command call at all —
+// gosec G204 defense-in-depth, not just a shell-invocation non-issue.
+func TestReapOnce_InvalidUsernameShapeNeverConsidered(t *testing.T) {
+	homeRoot := t.TempDir()
+	// ';' isn't a valid path separator, so this is one directory named
+	// literally "weird;name" — invalid per isValidUsername, but a legal
+	// (if unusual) single filesystem entry.
+	makeHomeDir(t, homeRoot, "weird;name", true)
+
+	userShellFn := func(username string) (string, error) {
+		t.Fatalf("userShellFn should not be called for %q", username)
+		return "", nil
+	}
+	containerExistsFn := func(username string) bool { return false }
+	deleteFn := func(username string, verbose bool) error {
+		t.Fatalf("deleteFn should not be called for %q", username)
+		return nil
+	}
+
+	reapOnce(homeRoot, containerExistsFn, userShellFn, deleteFn)
+}
+
 func TestUserShell_ParsesGetentOutput(t *testing.T) {
 	if _, err := exec.LookPath("getent"); err != nil {
 		t.Skip("getent not available on this platform (Linux-only tool; CI runs Linux)")


### PR DESCRIPTION
## Summary
- `RunOrphanReaper` (#835) scans `/home/<name>` for any directory with an `authorized_keys` file and deletes the account if no `<name>-container` exists. This heuristic can't distinguish a genuine leftover Containarium tenant from an unrelated admin account that happens to share the same directory shape.
- **Real incident**: upgrading a lab host's daemon (which enabled this reaper for the first time on that host, since older versions only warned) `userdel -r`'d an operator's own admin login mid-session — it had `authorized_keys` under `/home` and no matching container, so it looked identical to a genuine orphan.
- Fix: gate reaping on the account's login shell actually being the containarium-managed shell wrapper (`containerShellPath`). Real tenant accounts always run this shell; a manually-provisioned admin account (bash/zsh/etc.) never does, regardless of directory shape.

## Test plan
- [x] `go build ./...`
- [x] New tests in `orphan_reaper_test.go`: only containarium-shell + no-container accounts get reaped; a bash-shell account is never reaped even with no matching container; unknown/lookup-failure accounts are never reaped (fail-safe); directories with no `authorized_keys` never reach the shell lookup at all.
- [x] `go vet ./...`