### PR TITLE
feat(pool-join): chain cloud enrollment onto the tunnel handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`pool join --cloud-control-plane` — chain cloud self-registration onto
+  the tunnel handshake, using the same join token** (containarium-cloud#799).
+  Previously `pool join` only ever set up the tunnel; a host could connect
+  fine and still never appear in a cloud control plane's own host list,
+  because nothing called the separate `cloud enroll` step required to
+  register it — a gap only discoverable by reading the CLI source, not
+  documented anywhere a self-service BYOC user would see it. Now, when
+  `--cloud-control-plane` is set (e.g. by the cloud webui's generated
+  one-liner), `pool join` redeems the same token against `EnrollHost` right
+  after the tunnel comes up, deriving `oss_backend_id` as `tunnel-<spot-id>`
+  automatically. Best-effort: a cloud-enroll failure is a warning, not a
+  join failure — the tunnel is joined either way. Opt-in; omit the flag for
+  a plain OSS pool join with no cloud involvement.
+
 ## [0.49.2] - 2026-07-09
 
 ### Fixed

--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -7,8 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/footprintai/containarium/internal/cloud"
 )
 
 // pool join — the turnkey, one-command path that turns a fresh Linux host
@@ -38,17 +41,19 @@ func minimalDaemonArgv() []string {
 }
 
 var (
-	poolJoinSentinels      []string
-	poolJoinRegion         string
-	poolJoinToken          string
-	poolJoinPool           string
-	poolJoinSpotID         string
-	poolJoinPorts          string
-	poolJoinPublicHostname string
-	poolJoinPublicPort     int
-	poolJoinBaseDomain     string
-	poolJoinDryRun         bool
-	poolJoinDaemonFlags    []string
+	poolJoinSentinels         []string
+	poolJoinRegion            string
+	poolJoinToken             string
+	poolJoinPool              string
+	poolJoinSpotID            string
+	poolJoinPorts             string
+	poolJoinPublicHostname    string
+	poolJoinPublicPort        int
+	poolJoinBaseDomain        string
+	poolJoinDryRun            bool
+	poolJoinDaemonFlags       []string
+	poolJoinCloudControlPlane string
+	poolJoinCloudInsecure     bool
 )
 
 var poolJoinCmd = &cobra.Command{
@@ -73,7 +78,14 @@ Multi-region (probe + pick the closest sentinel from the host):
   sudo containarium pool join --region auto \
     --sentinel us=us.sentinel.example.com:443 \
     --sentinel eu=eu.sentinel.example.com:443 \
-    --pool prod --token <scoped-join-token>`,
+    --pool prod --token <scoped-join-token>
+
+BYO-compute (also register with a cloud control plane, using the same
+token — the webui's "Add compute" one-liner sets this automatically):
+  sudo containarium pool join \
+    --sentinel asia-east1.containarium.dev:443 \
+    --token <scoped-join-token> \
+    --cloud-control-plane https://cloud.containarium.dev`,
 	RunE: runPoolJoin,
 }
 
@@ -90,6 +102,8 @@ func init() {
 	poolJoinCmd.Flags().StringVar(&poolJoinBaseDomain, "base-domain", "", "Base domain the daemon's Caddy auto-provisions HTTPS for (optional)")
 	poolJoinCmd.Flags().BoolVar(&poolJoinDryRun, "dry-run", false, "Print the unit files that would be written, then exit (no changes)")
 	poolJoinCmd.Flags().StringArrayVar(&poolJoinDaemonFlags, "daemon-flag", nil, "Extra daemon flag to carry into the unit (repeatable), e.g. --daemon-flag=--app-hosting --daemon-flag=--network-subnet=10.0.0.0/24. Use to add/override flags on top of the preserved/baseline set")
+	poolJoinCmd.Flags().StringVar(&poolJoinCloudControlPlane, "cloud-control-plane", "", "Also self-register this host with a cloud control plane (e.g. https://cloud.containarium.dev) using the same --token, right after the tunnel comes up. Optional — omit for a plain OSS pool join with no cloud involvement. A failure here is a warning, not a join failure: the tunnel is joined either way.")
+	poolJoinCmd.Flags().BoolVar(&poolJoinCloudInsecure, "cloud-insecure", false, "Dial --cloud-control-plane without TLS (local dev only; ignored unless --cloud-control-plane is set)")
 }
 
 // tunnelUnitParams are the inputs to the tunnel systemd unit.
@@ -354,11 +368,71 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 
 	fmt.Println()
 	fmt.Printf("Joined pool %q via sentinel %s (spot-id %s).\n", poolJoinPool, sentinelAddr, spotID)
+
+	// 6. Cloud self-registration (opt-in, --cloud-control-plane). Chains the
+	// same join token into `cloud enroll` so a BYOC host shows up in the
+	// cloud's own host list right away, instead of tunnel-connected-but-
+	// invisible until an operator separately discovers and runs `cloud
+	// enroll` by hand (containarium-cloud#799). Best-effort: the tunnel is
+	// already joined by this point regardless of how this goes.
+	if cp := strings.TrimSpace(poolJoinCloudControlPlane); cp != "" {
+		fmt.Println()
+		if err := cloudEnrollAfterPoolJoin(cmd, cp, poolJoinToken, "tunnel-"+spotID, poolJoinCloudInsecure); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "⚠ cloud enrollment failed (%v)\n  the tunnel is joined regardless; re-run `containarium cloud enroll --control-plane %s --token-file <token-file> --oss-backend-id tunnel-%s` once fixed\n", err, cp, spotID)
+		}
+	}
+
 	fmt.Println()
 	fmt.Println("  Daemon:  sudo systemctl status containarium")
 	fmt.Println("  Tunnel:  sudo systemctl status containarium-tunnel")
 	fmt.Println("  Verify:  containarium pool list --server http://localhost:8080")
 	fmt.Println()
 	fmt.Println("NOTE (MVP): scoped-token minting and binary fetch are not yet wired.")
+	return nil
+}
+
+// cloudEnrollAfterPoolJoin redeems the same join token used for the tunnel
+// handshake against a cloud control plane's EnrollHost, mirroring `cloud
+// enroll` (internal/cmd/cloud.go) — the join-token format (`<host_id>.
+// <secret>`) is shared between the two steps, so no separate token is
+// needed. Mints a driver token best-effort (same as `cloud enroll`); a
+// mint failure is a warning inside cloud.Enroll's caller pattern, not
+// treated as fatal here either.
+func cloudEnrollAfterPoolJoin(cmd *cobra.Command, controlPlane, token, ossBackendID string, insecure bool) error {
+	opts := cloud.EnrollOptions{OSSBackendID: ossBackendID}
+	if driverTok, mintErr := mintDriverToken(defaultDaemonJWTSecretFile, 30*24*time.Hour); mintErr != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "⚠ no driver token minted (%v)\n  host will cloud-enroll but the cloud can't place workloads on it yet\n", mintErr)
+	} else {
+		opts.DriverToken = driverTok
+	}
+
+	hostID, err := cloud.Enroll(cmd.Context(), controlPlane, token, insecure, opts)
+	if err != nil {
+		return err
+	}
+	cfg := &cloud.Config{
+		ControlPlane: controlPlane,
+		HostID:       hostID,
+		Token:        token,
+		Insecure:     insecure,
+		JWTSecretFile: func() string {
+			if opts.DriverToken == "" {
+				return ""
+			}
+			return defaultDaemonJWTSecretFile
+		}(),
+	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	path, err := cloud.DefaultPath()
+	if err != nil {
+		return err
+	}
+	if err := cloud.Save(path, cfg); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "✓ also enrolled with cloud control plane %s\n  host-id: %s\n  config:  %s (restart the daemon to start actuating + reporting)\n",
+		controlPlane, hostID, path)
 	return nil
 }

--- a/internal/cmd/pool_join_test.go
+++ b/internal/cmd/pool_join_test.go
@@ -3,9 +3,27 @@
 package cmd
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	cloudv1 "github.com/footprintai/containarium/pkg/pb/containarium/cloud/v1"
 )
+
+// testCmd returns a *cobra.Command with a real context — a bare
+// &cobra.Command{} has a nil Context() (unlike OutOrStdout/ErrOrStderr,
+// which do fall back), which panics deep inside net/context on first use.
+func testCmd() *cobra.Command {
+	c := &cobra.Command{}
+	c.SetContext(context.Background())
+	return c
+}
 
 func TestRenderTunnelUnit_RequiredFlags(t *testing.T) {
 	u := renderTunnelUnit(tunnelUnitParams{
@@ -162,5 +180,71 @@ func TestParseExecStartArgv(t *testing.T) {
 		if _, ok := parseExecStartArgv(bad); ok {
 			t.Errorf("parseExecStartArgv(%q) should be false", bad)
 		}
+	}
+}
+
+// TestCloudEnrollAfterPoolJoin_RedeemsSameToken locks in the containarium-cloud#799
+// fix: `pool join --cloud-control-plane` chains the SAME join token into
+// EnrollHost, with oss_backend_id derived as "tunnel-"+spotID (matching the
+// sentinel's own OnTunnelConnect prefixing) — not left for the operator to
+// separately discover and pass by hand.
+func TestCloudEnrollAfterPoolJoin_RedeemsSameToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolate cloud.Save's ~/.containarium/cloud.yaml write
+
+	var got cloudv1.EnrollHostRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/actuation/enroll" {
+			t.Errorf("path = %s, want /v1/actuation/enroll", r.URL.Path)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = protojson.Unmarshal(raw, &got)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"hostId":"host-abc"}`))
+	}))
+	defer srv.Close()
+
+	cmd := testCmd()
+	err := cloudEnrollAfterPoolJoin(cmd, srv.URL, "host-abc.secret", "tunnel-lab-node1", false)
+	if err != nil {
+		t.Fatalf("cloudEnrollAfterPoolJoin: %v", err)
+	}
+	if got.GetJoinToken() != "host-abc.secret" {
+		t.Errorf("server saw join_token = %q, want the same token pool join used", got.GetJoinToken())
+	}
+	if got.GetOssBackendId() != "tunnel-lab-node1" {
+		t.Errorf("server saw oss_backend_id = %q, want tunnel-lab-node1", got.GetOssBackendId())
+	}
+}
+
+// TestCloudEnrollAfterPoolJoin_SurfacesServerError ensures a failed enroll
+// (e.g. expired/redeemed token) is returned as an error, not swallowed —
+// runPoolJoin's caller is what decides to downgrade it to a warning.
+func TestCloudEnrollAfterPoolJoin_SurfacesServerError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"code":9,"message":"join token expired"}`))
+	}))
+	defer srv.Close()
+
+	cmd := testCmd()
+	if err := cloudEnrollAfterPoolJoin(cmd, srv.URL, "host-abc.secret", "tunnel-lab-node1", false); err == nil {
+		t.Fatal("expected an error from an expired join token, got nil")
+	}
+}
+
+// TestPoolJoinFlags_CloudControlPlaneIsOptOut confirms the cloud-enroll
+// chaining flags exist and default to off — a plain OSS pool join with no
+// --cloud-control-plane must not attempt any cloud call.
+func TestPoolJoinFlags_CloudControlPlaneIsOptOut(t *testing.T) {
+	if poolJoinCmd.Flags().Lookup("cloud-control-plane") == nil {
+		t.Fatal("expected a --cloud-control-plane flag on pool join")
+	}
+	if poolJoinCmd.Flags().Lookup("cloud-insecure") == nil {
+		t.Fatal("expected a --cloud-insecure flag on pool join")
+	}
+	if poolJoinCloudControlPlane != "" {
+		t.Errorf("--cloud-control-plane default = %q, want empty (opt-in)", poolJoinCloudControlPlane)
 	}
 }


### PR DESCRIPTION
## Summary
- `pool join` only ever set up the tunnel — a host could connect fine and still never appear in a cloud control plane's own host list, because nothing called the separate `cloud enroll` step required to register it (containarium-cloud#799). That gap was only discoverable by reading the CLI source; the cloud webui's generated one-liner never mentions the second step at all.
- Adds `--cloud-control-plane` (opt-in, empty by default — a plain OSS pool join with no cloud involvement is unaffected): when set, `pool join` redeems the same join token against `EnrollHost` right after the tunnel comes up, deriving `oss_backend_id` as `tunnel-<spot-id>` automatically (matching the sentinel's own `OnTunnelConnect` prefixing convention). Best-effort — a cloud-enroll failure is a warning printed to stderr, not a join failure; the tunnel is joined either way.
- New `--cloud-insecure` alongside it (mirrors `cloud enroll --insecure`, local-dev-only TLS bypass).
- This is the OSS half of a two-repo fix; the companion containarium-cloud change updates the webui's generated `pool join` one-liner to include `--cloud-control-plane` automatically, so a self-service BYOC user needs only one command going forward.

## Test plan
- [x] `go build ./...`
- [x] New tests in `pool_join_test.go`: `cloudEnrollAfterPoolJoin` redeems the same token + correctly derives `oss_backend_id`, surfaces server errors, and the new flags exist and default to opt-out.
- [x] Existing `pool_join_test.go`/`cloud_test.go` suites unaffected.
- [x] `go vet ./...`, `gosec ./internal/cmd/...` — no findings in changed files.