### PR TITLE
fix(netpolicy): exclude the control plane from tenant tagging (#780)

### DIFF
--- a/internal/server/network_policy_enforcer.go
+++ b/internal/server/network_policy_enforcer.go
@@ -726,6 +726,16 @@ func (e *NetworkPolicyEnforcer) gather(_ context.Context) ([]containerView, map[
 	idName := make(map[uint32]string)
 	running := make(map[string]bool, len(containers))
 	for _, c := range containers {
+		// The control plane is platform infrastructure, not a tenant (#780).
+		// Excluding it entirely means (1) its IP never enters ip_tenant, so a
+		// tenant reaching its auth-gated API hits the external/egress branch
+		// instead of the cross-tenant drop (reachable under the default egress);
+		// and (2) its own veth is never enforced, so it can actuate every box.
+		// Other core services (postgres, caddy, …) are deliberately NOT excluded
+		// here — they stay tenant-tagged and thus isolated from tenants.
+		if c.Role == incus.RoleControlPlane {
+			continue
+		}
 		tenant := resolveTenant(c.Tenant, c.Labels[cloudOrgIDLabel], c.Name)
 		if tenant == "" {
 			continue

--- a/internal/server/network_policy_enforcer_test.go
+++ b/internal/server/network_policy_enforcer_test.go
@@ -89,3 +89,38 @@ func TestGather_CachesVethToAvoidInspect(t *testing.T) {
 		t.Fatalf("GetRawInstance calls = %d, want 2 (re-inspect after restart)", got)
 	}
 }
+
+// TestGather_ExcludesControlPlaneFromTenantTagging locks down #780 step 3: the
+// control plane is infrastructure, not a tenant, so gather() must drop it from
+// the reconcile views entirely (keeping its IP out of ip_tenant so tenants can
+// reach its API as an external dest). Other core services stay tagged/isolated.
+func TestGather_ExcludesControlPlaneFromTenantTagging(t *testing.T) {
+	insp := &fakeInspector{
+		containers: []incus.ContainerInfo{
+			{Name: "cld-tenant-container", State: "stopped", IPAddress: "10.100.0.10"},
+			{Name: "core-postgres-container", State: "stopped", IPAddress: "10.100.0.11", Role: incus.RolePostgres},
+			{Name: "controlplane-container", State: "stopped", IPAddress: "10.100.0.200", Role: incus.RoleControlPlane},
+		},
+		rawCalls: map[string]int{},
+	}
+	e := NewNetworkPolicyEnforcer("", nil, NewMemTenantRegistry(), insp, nil, nil, false)
+	e.ctx = context.Background()
+
+	views, _, err := e.gather(context.Background())
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	tagged := map[string]bool{}
+	for _, v := range views {
+		tagged[v.Name] = true
+	}
+	if tagged["controlplane-container"] {
+		t.Error("control plane must be EXCLUDED from tenant tagging (reachable as infra, unenforced source)")
+	}
+	if !tagged["cld-tenant-container"] {
+		t.Error("tenant box must stay tagged (isolated)")
+	}
+	if !tagged["core-postgres-container"] {
+		t.Error("non-control-plane core services must stay tagged (still isolated from tenants)")
+	}
+}

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -291,6 +291,14 @@ const (
 	RoleSecurity        Role = "core-security"
 	RoleGuacamole       Role = "core-guacamole"
 	RoleOTelCollector   Role = "core-otelcollector"
+	// RoleControlPlane marks a control-plane container (e.g. a cloud control
+	// plane co-located on a backend host). It is platform infrastructure, not a
+	// tenant: tenants legitimately call its auth-gated API, and it must reach
+	// every box to actuate them. The network-policy enforcer excludes it from
+	// tenant tagging so it's reachable as an external destination and its own
+	// egress is unenforced (#780). Distinct from the co-tenant core services
+	// above, which stay tenant-isolated.
+	RoleControlPlane Role = "core-controlplane"
 )
 
 // IsCoreRole returns true if the role represents a core container.


### PR DESCRIPTION
Unblocks **#780 step 3** — the reason arming cross-org enforcement would break CI.

## Problem
Cross-org isolation works by tagging every managed container's IP with its tenant; the eBPF verdict allows a packet to a tenant-tagged destination only if it's the same tenant. That correctly isolates tenants — but it also **drops a tenant's traffic to the control plane** co-located on the same backend host, because the control plane is a container and gets tenant-tagged like any other.

The egress allow-list **cannot** fix this: the verdict (`experimental/ebpf-phaseA/netpolicy.bpf.c`) consults the egress list **only for non-container destinations** — a tenant-tagged control-plane IP is unreachable regardless of the egress CIDRs a policy lists. (This corrects an earlier assumption that adding the CP IP to a policy's egress list would work.)

## Fix
The control plane is **infrastructure, not a tenant**: tenants legitimately call its auth-gated API (CI runners, the isolation sentry), and it must reach every box to actuate them. Add a `RoleControlPlane` role and skip it in the enforcer's `gather()`:
- its IP never enters `ip_tenant` → a tenant reaching its API hits the external/egress branch instead of the cross-tenant drop (reachable under the default egress);
- its own veth is never enforced → actuation to any box is never dropped.

**Deliberately scoped to the control-plane role only.** Co-tenant core services (postgres, caddy, …) are **not** excluded — they stay tenant-tagged and isolated from tenants, so this doesn't widen their exposure.

## Deploy note
A host running the control plane must label that container `user.containarium.role=core-controlplane` for the exclusion to apply.

## Tests
`TestGather_ExcludesControlPlaneFromTenantTagging` — a control-plane container is dropped from the reconcile views while a tenant box and a non-control-plane core service stay tagged. `go build ./...`, `go vet`, `gofmt`, `go test ./internal/server/ -run Gather` all pass.

Part of #780 (Layer-4 cross-org isolation). Pairs with cloud #800 (policy sync to OSSBackend hosts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)