### PR TITLE
chore(release): cut v0.50.0 — control-plane netpolicy exclusion (#780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.0] - 2026-07-10
+
+### Fixed
+
+- **Network policy: exclude the control plane from tenant tagging**
+  (containarium-cloud#780). Cross-org isolation tags every managed
+  container's IP with its tenant and drops cross-tenant traffic — but that
+  also dropped a tenant's calls to a control plane co-located on the same
+  backend host, since the control plane is a container and got tenant-tagged
+  like any other (the eBPF egress allow-list can't override this — it's
+  consulted only for non-container destinations). A new
+  `core-controlplane` role, skipped by the enforcer's reconcile, keeps the
+  control plane's IP out of the tenant map: tenants reach its auth-gated API
+  as an external destination, and its own egress stays unenforced so it can
+  actuate every box. Scoped to the control-plane role only — other core
+  services stay tenant-isolated. Label the control-plane container
+  `user.containarium.role=core-controlplane` to apply it.
+
 ### Added
 
 - **`pool join --cloud-control-plane` — chain cloud self-registration onto

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.49.2"
+	Version = "0.50.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Release **v0.50.0**.

- `pkg/version/version.go`: `0.49.2` → `0.50.0`
- `CHANGELOG.md`: v0.50.0 section

Bundles everything on `main` since v0.49.2:
- **#923** — network policy: exclude the control plane from tenant tagging (#780 step 3).
- **#922** — `pool join --cloud-control-plane` cloud self-registration.

Tag `v0.50.0` after merge → `release.yml` builds + publishes artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)