### PR TITLE
deploy(incus-watchdog): auto-recover a wedged incusd (#755)

### DIFF
--- a/deploy/incus-watchdog/README.md
+++ b/deploy/incus-watchdog/README.md
@@ -1,0 +1,50 @@
+# incus-watchdog
+
+Force-recovers a wedged incus API (#755).
+
+## The problem
+
+`incusd` can hang with its process alive but its unix-socket API unresponsive:
+a cgo call into liblxc's command protocol blocks forever in `recvmsg()` on an
+unresponsive container monitor (the command socket has **no receive timeout**),
+holding a lock that wedges every other API request behind it. It recurs under
+container-churn workloads (create/delete storms — e.g. CI verifiers). Root cause
++ upstream fix: [lxc/lxc#4708](https://github.com/lxc/lxc/pull/4708).
+
+`systemctl restart incus` does **not** reliably recover it — incusd's own
+SIGTERM/SIGQUIT handlers are part of the deadlock, so the stop hangs until
+`TimeoutStopSec` (incus ships a long one). The reliable recovery is **SIGKILL to
+the main process** (unblockable). Because instances run in their own
+`lxc.payload.*` scopes — not as children of incusd — **they survive** the restart.
+
+## What it does
+
+A tiny systemd service loops: probe the incus API on an interval; after N
+**consecutive** probe timeouts, `systemctl kill -s SIGKILL --kill-who=main
+incus.service` then `systemctl start`. Two consecutive failures are required so
+one slow probe doesn't cause a needless restart.
+
+## Install (per host running incus)
+
+```bash
+sudo install -m 0755 incus-watchdog.sh /usr/local/bin/incus-watchdog.sh
+sudo install -m 0644 incus-watchdog.service /etc/systemd/system/incus-watchdog.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now incus-watchdog.service
+sudo systemctl status incus-watchdog.service --no-pager
+journalctl -t incus-watchdog -f      # watch probes / recoveries
+```
+
+## Tuning (env in the unit, or an EnvironmentFile)
+
+| var | default | meaning |
+| --- | --- | --- |
+| `INCUS_WATCHDOG_INTERVAL` | `45` | seconds between probes |
+| `INCUS_WATCHDOG_PROBE_TIMEOUT` | `25` | seconds before a probe is deemed failed |
+| `INCUS_WATCHDOG_FAIL_THRESHOLD` | `2` | consecutive fails before a restart |
+| `INCUS_WATCHDOG_UNIT` | `incus.service` | unit to recover |
+| `INCUS_WATCHDOG_SETTLE` | `15` | seconds to wait after a restart before probing |
+
+With the defaults, a wedged API is recovered within ~2 minutes (two failed
+probes), and a healthy host is never touched. This is a bridge until the
+upstream liblxc receive-timeout (lxc/lxc#4708) ships and is built into incus.

--- a/deploy/incus-watchdog/incus-watchdog.service
+++ b/deploy/incus-watchdog/incus-watchdog.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=incus API watchdog — force-recover a wedged incusd (#755)
+Documentation=https://github.com/lxc/lxc/pull/4708
+# Start after incus so the API exists to probe; don't fail if incus is down —
+# the watchdog is exactly what brings a wedged incus back.
+After=incus.service
+Wants=incus.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/incus-watchdog.sh
+# Tune per host without editing the script; see the script header for keys.
+# Environment=INCUS_WATCHDOG_INTERVAL=45
+# Environment=INCUS_WATCHDOG_FAIL_THRESHOLD=2
+Restart=always
+RestartSec=10
+# The watchdog itself must never be OOM-killed or throttled away.
+OOMScoreAdjust=-500
+Nice=-5
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/incus-watchdog/incus-watchdog.sh
+++ b/deploy/incus-watchdog/incus-watchdog.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# incus-watchdog — detect a wedged incus API and force-recover it (#755).
+#
+# incusd can hang with its process alive but its unix-socket API unresponsive:
+# a cgo call into liblxc's command protocol blocks forever in recvmsg() on an
+# unresponsive container monitor (the command socket has no receive timeout),
+# and the goroutine holds a lock the whole time, so every API request wedges
+# behind it. It recurs under container-churn workloads (create/delete storms).
+# See the upstream fix proposal (lxc/lxc#4708) for the root cause.
+#
+# incusd's own SIGTERM/SIGQUIT handlers run on goroutines that are part of the
+# same deadlock, so `systemctl restart` hangs in "deactivating" until
+# TimeoutStopSec (incus ships a long one). SIGKILL to the MAIN process is
+# unblockable and — because instances run in their own lxc.payload.* scopes,
+# not as children of incusd — they SURVIVE the restart.
+#
+# This watchdog probes the API on an interval and, after N consecutive probe
+# timeouts, SIGKILLs the main incusd and starts it again. Two consecutive
+# failures (not one) are required so a single slow probe doesn't trigger a
+# needless restart.
+#
+# Config via env (systemd EnvironmentFile or the unit's Environment=):
+#   INCUS_WATCHDOG_INTERVAL         seconds between probes           (default 45)
+#   INCUS_WATCHDOG_PROBE_TIMEOUT    seconds before a probe is failed (default 25)
+#   INCUS_WATCHDOG_FAIL_THRESHOLD   consecutive fails before restart (default 2)
+#   INCUS_WATCHDOG_UNIT             systemd unit to recover          (default incus.service)
+#   INCUS_WATCHDOG_SETTLE           seconds to wait after a restart  (default 15)
+set -uo pipefail
+
+INTERVAL="${INCUS_WATCHDOG_INTERVAL:-45}"
+PROBE_TIMEOUT="${INCUS_WATCHDOG_PROBE_TIMEOUT:-25}"
+FAIL_THRESHOLD="${INCUS_WATCHDOG_FAIL_THRESHOLD:-2}"
+UNIT="${INCUS_WATCHDOG_UNIT:-incus.service}"
+SETTLE="${INCUS_WATCHDOG_SETTLE:-15}"
+
+log() { logger -t incus-watchdog -- "$*" 2>/dev/null || true; echo "incus-watchdog: $*"; }
+
+# probe returns 0 if the incus API answers within PROBE_TIMEOUT, non-zero
+# otherwise. `</dev/null` guards the incus-exec-inherits-stdin gotcha; a light
+# `list` is enough — the whole API shares the wedged lock, so any call hangs.
+probe() {
+	timeout "${PROBE_TIMEOUT}" incus list --format csv -c n </dev/null >/dev/null 2>&1
+}
+
+recover() {
+	log "threshold reached (${FAIL_THRESHOLD}) — force-recovering ${UNIT}: SIGKILL main incusd (instances survive), then start"
+	systemctl kill -s SIGKILL --kill-who=main "${UNIT}" || true
+	sleep 3
+	systemctl start "${UNIT}" || log "WARNING: 'systemctl start ${UNIT}' returned non-zero"
+	log "restart issued; new MainPID=$(systemctl show -p MainPID --value "${UNIT}" 2>/dev/null)"
+}
+
+log "started (interval=${INTERVAL}s probe_timeout=${PROBE_TIMEOUT}s threshold=${FAIL_THRESHOLD} unit=${UNIT})"
+
+fails=0
+while true; do
+	if probe; then
+		if [ "${fails}" -ne 0 ]; then
+			log "incus API recovered after ${fails} failed probe(s)"
+		fi
+		fails=0
+	else
+		fails=$((fails + 1))
+		log "incus API probe FAILED (${fails}/${FAIL_THRESHOLD}) — list timed out or errored"
+		if [ "${fails}" -ge "${FAIL_THRESHOLD}" ]; then
+			recover
+			fails=0
+			sleep "${SETTLE}" # let incus come back up before probing again
+		fi
+	fi
+	sleep "${INTERVAL}"
+done


### PR DESCRIPTION
A small host-side watchdog that force-recovers a wedged incus API (#755) — installed and running on the workhorse.

## Why
`incusd` hangs with the process alive but its unix-socket API unresponsive: a cgo call into liblxc's command protocol blocks forever in `recvmsg()` on an unresponsive container monitor (no receive timeout), holding a lock that wedges every API request. It **recurs under container-churn** (CI verifiers — the isolation/actuation jobs re-tripped it). `systemctl restart` doesn't recover it (incusd's SIGTERM/SIGQUIT handlers are part of the deadlock → stop hangs on `TimeoutStopSec`); only **SIGKILL to the main process** works, and instances survive it (own `lxc.payload.*` scopes).

## What
`incus-watchdog.service` loops: probe the API on an interval; after **2 consecutive** timeouts, `systemctl kill -s SIGKILL --kill-who=main incus.service` + start. Silent when healthy; recovers a wedge in ~2 min; never touches a healthy host.

- `deploy/incus-watchdog/incus-watchdog.sh` — probe/recover loop (env-tunable interval / probe-timeout / threshold / unit)
- `deploy/incus-watchdog/incus-watchdog.service` — systemd unit
- `deploy/incus-watchdog/README.md` — install + tuning

## Status
Installed + enabled on the workhorse (`active`, probing every 45s). This is the **durable bridge** for #755 until the upstream liblxc receive-timeout ([lxc/lxc#4708](https://github.com/lxc/lxc/pull/4708)) ships and is built into incus. It also unblocks the #780 isolation sentry, whose own create/delete churn was re-wedging the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)