### PR TITLE
fix(netpolicy): converge ip_tenant deletes, not just adds (#923)

### DIFF
--- a/internal/netbpf/loader.go
+++ b/internal/netbpf/loader.go
@@ -279,6 +279,22 @@ func (l *Loader) SetIPTenant(ip [4]byte, tenantID uint32) error {
 	return nil
 }
 
+// DeleteIPTenant removes an IP -> tenant mapping. Used by the reconcile loop to
+// converge the map when a container's IP is no longer managed (stopped/deleted)
+// or is excluded from tagging (e.g. the control plane): a stale tag would let
+// the program treat a since-freed or re-purposed IP as a same-tenant peer. A
+// missing key is not an error (the desired state is already reached).
+func (l *Loader) DeleteIPTenant(ip [4]byte) error {
+	key := binary.LittleEndian.Uint32(ip[:])
+	if err := l.coll.Maps[mapIPTenant].Delete(&key); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return nil
+		}
+		return fmt.Errorf("netbpf: delete ip_tenant: %w", err)
+	}
+	return nil
+}
+
 // Stats reads the (seen, wouldDeny) counters — the validator's success signal,
 // mirroring the Phase 0 counter read.
 func (l *Loader) Stats() (seen, wouldDeny uint64, err error) {

--- a/internal/server/network_policy_enforcer.go
+++ b/internal/server/network_policy_enforcer.go
@@ -110,12 +110,13 @@ type NetworkPolicyEnforcer struct {
 	sigNames   map[uint16]string           // signature id -> name, for audit labelling (built at populate)
 	sigLoaded  string                      // last applied signature set fingerprint (skip redundant map writes)
 
-	mu              sync.Mutex
-	attached        map[int]string                      // ifindex -> container name currently attached
-	idName          map[uint32]string                   // tenant id -> name (for audit/log)
-	enforced        map[uint32]bool                     // tenant ids whose effective mode is ENFORCE (deny == dropped)
-	egressInstalled map[netbpf.EgressEntry]bool         // egress LPM entries currently in the map
-	denyInstalled   map[netbpf.DenyKey]netbpf.DenyEntry // virtual-patch deny entries currently in the map (#660)
+	mu                sync.Mutex
+	attached          map[int]string                      // ifindex -> container name currently attached
+	idName            map[uint32]string                   // tenant id -> name (for audit/log)
+	enforced          map[uint32]bool                     // tenant ids whose effective mode is ENFORCE (deny == dropped)
+	egressInstalled   map[netbpf.EgressEntry]bool         // egress LPM entries currently in the map
+	denyInstalled     map[netbpf.DenyKey]netbpf.DenyEntry // virtual-patch deny entries currently in the map (#660)
+	ipTenantInstalled map[[4]byte]uint32                  // ip_tenant entries currently in the map (#923: converge deletes)
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -124,24 +125,25 @@ type NetworkPolicyEnforcer struct {
 
 func NewNetworkPolicyEnforcer(objPath string, store NetworkPolicyStore, registry TenantRegistry, insp containerInspector, auditStore *audit.Store, bus *events.Bus, enforceEnabled bool) *NetworkPolicyEnforcer {
 	return &NetworkPolicyEnforcer{
-		objPath:         objPath,
-		store:           store,
-		registry:        registry,
-		insp:            insp,
-		audit:           auditStore,
-		bus:             bus,
-		interval:        defaultNetPolicyReconcileInterval,
-		enforceEnabled:  enforceEnabled,
-		resolver:        NewDomainResolver(nil),
-		domainRefresh:   defaultDomainRefreshInterval,
-		flowPoll:        defaultFlowPollInterval,
-		flowIdleTimeout: defaultFlowIdleTimeout,
-		vethCache:       make(map[string]string),
-		attached:        make(map[int]string),
-		idName:          make(map[uint32]string),
-		enforced:        make(map[uint32]bool),
-		egressInstalled: make(map[netbpf.EgressEntry]bool),
-		denyInstalled:   make(map[netbpf.DenyKey]netbpf.DenyEntry),
+		objPath:           objPath,
+		store:             store,
+		registry:          registry,
+		insp:              insp,
+		audit:             auditStore,
+		bus:               bus,
+		interval:          defaultNetPolicyReconcileInterval,
+		enforceEnabled:    enforceEnabled,
+		resolver:          NewDomainResolver(nil),
+		domainRefresh:     defaultDomainRefreshInterval,
+		flowPoll:          defaultFlowPollInterval,
+		flowIdleTimeout:   defaultFlowIdleTimeout,
+		vethCache:         make(map[string]string),
+		attached:          make(map[int]string),
+		idName:            make(map[uint32]string),
+		enforced:          make(map[uint32]bool),
+		egressInstalled:   make(map[netbpf.EgressEntry]bool),
+		denyInstalled:     make(map[netbpf.DenyKey]netbpf.DenyEntry),
+		ipTenantInstalled: make(map[[4]byte]uint32),
 	}
 }
 
@@ -632,12 +634,13 @@ func (e *NetworkPolicyEnforcer) reconcile(ctx context.Context) error {
 	// when the set is unchanged, so this is cheap every pass.
 	e.refreshSignatureSlots()
 
-	// ip_tenant: every managed container's IP -> its tenant id.
-	for ip, tid := range plan.ipTenant {
-		if err := e.loader.SetIPTenant(ip, tid); err != nil {
-			log.Printf("[netpolicy] set ip_tenant: %v", err)
-		}
-	}
+	// ip_tenant: every managed container's IP -> its tenant id. Converge the map
+	// (set desired, delete stale) like egress/deny below — an add-only pass would
+	// leak a tag once a container's IP is freed or an entity is excluded from
+	// tagging (e.g. the control plane), letting the program keep treating a
+	// since-freed or re-purposed IP as a same-tenant peer until a daemon restart
+	// rebuilt the maps (#923).
+	applyIPTenant(e.ipTenantInstalled, plan.ipTenant, e.loader)
 	// egress allow-list: converge the map (add new, delete stale). Deleting
 	// removed CIDRs is what makes a tightened policy actually take effect in
 	// enforce mode.

--- a/internal/server/network_policy_iptenant_test.go
+++ b/internal/server/network_policy_iptenant_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+// fakeIPTenantApplier records SetIPTenant/DeleteIPTenant calls and can be told
+// to fail a Set for a given IP, so applyIPTenant's apply/retry semantics are
+// testable without a kernel.
+type fakeIPTenantApplier struct {
+	set     map[[4]byte]uint32
+	deleted [][4]byte
+	failSet map[[4]byte]bool
+}
+
+func newFakeIPTenantApplier() *fakeIPTenantApplier {
+	return &fakeIPTenantApplier{set: map[[4]byte]uint32{}, failSet: map[[4]byte]bool{}}
+}
+
+func (f *fakeIPTenantApplier) SetIPTenant(ip [4]byte, tid uint32) error {
+	if f.failSet[ip] {
+		return fmt.Errorf("inject set failure")
+	}
+	f.set[ip] = tid
+	return nil
+}
+
+func (f *fakeIPTenantApplier) DeleteIPTenant(ip [4]byte) error {
+	f.deleted = append(f.deleted, ip)
+	return nil
+}
+
+func TestDiffIPTenant(t *testing.T) {
+	a := [4]byte{10, 0, 3, 1}
+	b := [4]byte{10, 0, 3, 2}
+	c := [4]byte{10, 0, 3, 3}
+
+	installed := map[[4]byte]uint32{
+		a: 1, // unchanged
+		b: 1, // tenant changes to 2 -> re-set
+		c: 1, // no longer desired -> delete
+	}
+	desired := map[[4]byte]uint32{
+		a: 1,
+		b: 2,
+	}
+
+	set, del := diffIPTenant(installed, desired)
+
+	if got, ok := set[b]; !ok || got != 2 {
+		t.Errorf("b should be re-set to tenant 2, got set=%v", set)
+	}
+	if _, ok := set[a]; ok {
+		t.Errorf("a is unchanged and must not be re-set, got set=%v", set)
+	}
+	if len(del) != 1 || del[0] != c {
+		t.Errorf("only c should be deleted, got del=%v", del)
+	}
+}
+
+// The regression this guards (#923): a tag whose container is gone (or whose
+// entity is excluded from tagging, e.g. the control plane) must be DELETED, not
+// left behind. The old add-only reconcile leaked it until a daemon restart.
+func TestApplyIPTenant_DeletesStaleTag(t *testing.T) {
+	cp := [4]byte{10, 0, 3, 241}   // e.g. the control-plane IP, now excluded
+	tenant := [4]byte{10, 0, 3, 7} // a live tenant container
+
+	installed := map[[4]byte]uint32{cp: 9, tenant: 1}
+	desired := map[[4]byte]uint32{tenant: 1} // cp no longer tagged
+
+	f := newFakeIPTenantApplier()
+	applyIPTenant(installed, desired, f)
+
+	if len(f.deleted) != 1 || f.deleted[0] != cp {
+		t.Fatalf("stale CP tag should be deleted, got deleted=%v", f.deleted)
+	}
+	if _, ok := installed[cp]; ok {
+		t.Errorf("installed must drop the deleted key, still has %v", cp)
+	}
+	if installed[tenant] != 1 {
+		t.Errorf("live tenant tag must survive, installed=%v", installed)
+	}
+}
+
+func TestApplyIPTenant_RetriesOnSetFailure(t *testing.T) {
+	ip := [4]byte{10, 0, 3, 5}
+	installed := map[[4]byte]uint32{}
+	desired := map[[4]byte]uint32{ip: 3}
+
+	f := newFakeIPTenantApplier()
+	f.failSet[ip] = true
+	applyIPTenant(installed, desired, f)
+
+	// A failed set must NOT be recorded as installed, so the next reconcile retries.
+	if _, ok := installed[ip]; ok {
+		t.Errorf("failed set must not be marked installed, installed=%v", installed)
+	}
+
+	// Next cycle succeeds -> now recorded.
+	f.failSet[ip] = false
+	applyIPTenant(installed, desired, f)
+	if installed[ip] != 3 {
+		t.Errorf("retry should install the tag, installed=%v", installed)
+	}
+}
+
+func TestApplyIPTenant_ConvergesToEmpty(t *testing.T) {
+	x := [4]byte{10, 0, 3, 8}
+	y := [4]byte{10, 0, 3, 9}
+	installed := map[[4]byte]uint32{x: 1, y: 2}
+
+	f := newFakeIPTenantApplier()
+	applyIPTenant(installed, map[[4]byte]uint32{}, f) // all containers gone
+
+	sort.Slice(f.deleted, func(i, j int) bool { return f.deleted[i][3] < f.deleted[j][3] })
+	if len(f.deleted) != 2 || f.deleted[0] != x || f.deleted[1] != y {
+		t.Errorf("both stale tags should be deleted, got %v", f.deleted)
+	}
+	if len(installed) != 0 {
+		t.Errorf("installed should be empty after full drain, got %v", installed)
+	}
+}

--- a/internal/server/network_policy_plan.go
+++ b/internal/server/network_policy_plan.go
@@ -202,3 +202,57 @@ func applyDeny(installed map[netbpf.DenyKey]netbpf.DenyEntry, desired []netbpf.D
 		delete(installed, dk)
 	}
 }
+
+// diffIPTenant computes the ip_tenant entries to set and the keys to delete so
+// the kernel map converges to the desired IP->tenant set (#923). An entry is
+// (re)set when its IP is new OR its tenant differs from what's installed; a key
+// is deleted when no desired entry uses that IP. Deleting stale keys is what
+// makes a freed or excluded IP actually stop being treated as a same-tenant
+// peer — without it the map is add-only and a stale tag survives until a daemon
+// restart rebuilds the maps.
+func diffIPTenant(installed, desired map[[4]byte]uint32) (toSet map[[4]byte]uint32, toDel [][4]byte) {
+	toSet = make(map[[4]byte]uint32)
+	for ip, tid := range desired {
+		if cur, ok := installed[ip]; !ok || cur != tid {
+			toSet[ip] = tid
+		}
+	}
+	for ip := range installed {
+		if _, ok := desired[ip]; !ok {
+			toDel = append(toDel, ip)
+		}
+	}
+	return toSet, toDel
+}
+
+// ipTenantApplier is the slice of the BPF loader the ip_tenant reconcile needs.
+// *netbpf.Loader satisfies it; an interface keeps applyIPTenant testable without
+// a kernel.
+type ipTenantApplier interface {
+	SetIPTenant(ip [4]byte, tenantID uint32) error
+	DeleteIPTenant(ip [4]byte) error
+}
+
+// applyIPTenant converges the kernel ip_tenant map from installed to desired via
+// the applier, updating installed in place (#923). Sets apply BEFORE deletes;
+// diffIPTenant guarantees the two sets never share a key, so a just-set entry is
+// never immediately deleted. A failed op is logged and skipped WITHOUT touching
+// installed, so the next reconcile retries it rather than recording a state the
+// kernel doesn't hold.
+func applyIPTenant(installed, desired map[[4]byte]uint32, a ipTenantApplier) {
+	set, del := diffIPTenant(installed, desired)
+	for ip, tid := range set {
+		if err := a.SetIPTenant(ip, tid); err != nil {
+			log.Printf("[netpolicy] set ip_tenant: %v", err)
+			continue
+		}
+		installed[ip] = tid
+	}
+	for _, ip := range del {
+		if err := a.DeleteIPTenant(ip); err != nil {
+			log.Printf("[netpolicy] delete ip_tenant: %v", err)
+			continue
+		}
+		delete(installed, ip)
+	}
+}


### PR DESCRIPTION
## What

The eBPF network-policy reconcile loop upserted every managed container's `ip_tenant` tag (IP → tenant id) but **never deleted stale ones** — unlike the `egress_cidr` and `deny_cidr` maps, which already diff-and-delete each cycle.

A tag therefore leaked whenever:
- a container's IP was freed (stopped/deleted), or
- an entity was **excluded** from tagging — e.g. the control plane, after the `gather()` skip added in #923.

Until a daemon restart rebuilt the maps from scratch, the program kept treating a since-freed or re-purposed IP as a *same-tenant* peer. Clearing the control plane's stale tag during the #780 isolation remediation required exactly such a restart — which is what surfaced this gap.

## Fix

- `netbpf.Loader.DeleteIPTenant(ip)` — mirrors `DeleteEgress`/`DeleteDeny` (tolerates `ErrKeyNotExist`).
- `diffIPTenant` / `applyIPTenant` — a pure diff + apply seam mirroring `diffDeny`/`applyDeny`: set desired (new or changed tenant), delete stale, track installed entries, skip-without-recording on error so the next reconcile retries.
- The reconcile loop now calls `applyIPTenant(e.ipTenantInstalled, plan.ipTenant, e.loader)` instead of the add-only loop.

Behaviour is unchanged for the steady state (same set → no-op); only stale entries now get cleaned, which is the point.

## Tests

Pure-function unit tests (no kernel needed), matching the deny-rule test style:
- `TestDiffIPTenant` — unchanged skipped, changed re-set, removed deleted.
- `TestApplyIPTenant_DeletesStaleTag` — the #923 regression: an excluded CP tag is deleted, live tenant survives.
- `TestApplyIPTenant_RetriesOnSetFailure` — a failed set isn't recorded installed; next cycle retries.
- `TestApplyIPTenant_ConvergesToEmpty` — full drain deletes all.

`go build ./...`, `go vet`, and the server + netbpf test suites all pass.

Closes #923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)