### PR TITLE
fix(sentinel): make loopback-alias registration idempotent

### DIFF
--- a/internal/sentinel/tunnel_registry.go
+++ b/internal/sentinel/tunnel_registry.go
@@ -296,7 +296,7 @@ func addLoopbackAlias(ip string) error {
 		log.Printf("[tunnel-registry] loopback alias %s: skipping on %s", ip, runtime.GOOS)
 		return nil
 	}
-	out, err := exec.Command("ip", "addr", "add", ip+"/32", "dev", "lo").CombinedOutput()
+	out, err := exec.Command("ip", "addr", "add", ip+"/32", "dev", "lo").CombinedOutput() // #nosec G204 -- ip is "127.0.0.<octet>", built internally by allocateOctet, never user input
 	if err != nil {
 		if isAlreadyExistsErr(out) {
 			log.Printf("[tunnel-registry] loopback alias %s already present (stale from a prior crash?) — reusing", ip)

--- a/internal/sentinel/tunnel_registry.go
+++ b/internal/sentinel/tunnel_registry.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -268,13 +269,52 @@ func preferredOctet(spotID string) byte {
 	return byte(2 + (h.Sum32() % 253))
 }
 
-// addLoopbackAlias adds an IP alias to the loopback interface.
+// addLoopbackAlias adds an IP alias to the loopback interface. Idempotent:
+// if the alias is already present, that's treated as success rather than
+// an error.
+//
+// This matters because allocateOctet's slot for a given spotID is a pure
+// function of spotID (#342) but the registry's usedIPs bookkeeping is
+// purely in-memory — it has no cross-restart memory. If the sentinel
+// process ever exits without running UnregisterAll (a crash, an OOM kill,
+// `kill -9`, anything that skips the graceful-shutdown path — the same
+// failure class #337 already flagged for restarts), the OS-level alias
+// for a still-connected spot survives the process death. On the next
+// startup, usedIPs starts empty, so allocateOctet freely reassigns that
+// spot's (deterministic, unchanged) preferred octet — and `ip addr add`
+// then fails with "RTNETLINK answers: File exists" because the address is
+// still there. Before this fix, that error aborted Register() and the
+// spot's tunnel client would retry, hash to the exact same octet, and
+// hit the exact same "already exists" error — forever, with no operator
+// visibility beyond an opaque "exit status 2" on the client side (found
+// live: a BYOC peer's tunnel silently wedged this way for a full week).
+// Since the goal of addLoopbackAlias is just "make sure this alias
+// exists," an already-present alias already satisfies that — so treat it
+// as success instead of a fatal error.
 func addLoopbackAlias(ip string) error {
 	if runtime.GOOS != "linux" {
 		log.Printf("[tunnel-registry] loopback alias %s: skipping on %s", ip, runtime.GOOS)
 		return nil
 	}
-	return exec.Command("ip", "addr", "add", ip+"/32", "dev", "lo").Run()
+	out, err := exec.Command("ip", "addr", "add", ip+"/32", "dev", "lo").CombinedOutput()
+	if err != nil {
+		if isAlreadyExistsErr(out) {
+			log.Printf("[tunnel-registry] loopback alias %s already present (stale from a prior crash?) — reusing", ip)
+			return nil
+		}
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// isAlreadyExistsErr reports whether `ip addr add`'s output indicates the
+// alias already exists (iproute2 prints "RTNETLINK answers: File exists"
+// and exits 2) rather than some other, genuinely fatal failure (bad
+// address, missing interface, permission denied, ...). Split out from
+// addLoopbackAlias so the detection logic is unit-testable without
+// shelling out to `ip` or needing CAP_NET_ADMIN.
+func isAlreadyExistsErr(cmdOutput []byte) bool {
+	return strings.Contains(string(cmdOutput), "File exists")
 }
 
 // removeLoopbackAlias removes an IP alias from the loopback interface.

--- a/internal/sentinel/tunnel_registry_loopback_test.go
+++ b/internal/sentinel/tunnel_registry_loopback_test.go
@@ -1,0 +1,53 @@
+package sentinel
+
+import "testing"
+
+// TestIsAlreadyExistsErr pins the detection logic behind addLoopbackAlias's
+// idempotency fix: only "RTNETLINK answers: File exists" (the alias is
+// already there — safe to treat as success) should be swallowed. Anything
+// else must still surface as a real failure.
+func TestIsAlreadyExistsErr(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "real iproute2 already-exists output",
+			output: "RTNETLINK answers: File exists\n",
+			want:   true,
+		},
+		{
+			name:   "already-exists text embedded in a longer message",
+			output: "Error: ipv4: Address already assigned.\nRTNETLINK answers: File exists\n",
+			want:   true,
+		},
+		{
+			name:   "empty output (e.g. success)",
+			output: "",
+			want:   false,
+		},
+		{
+			name:   "invalid address",
+			output: "Error: any valid prefix is expected rather than \"bogus\".\n",
+			want:   false,
+		},
+		{
+			name:   "missing interface",
+			output: "Cannot find device \"lo\"\n",
+			want:   false,
+		},
+		{
+			name:   "permission denied",
+			output: "RTNETLINK answers: Operation not permitted\n",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAlreadyExistsErr([]byte(tc.output)); got != tc.want {
+				t.Errorf("isAlreadyExistsErr(%q) = %v, want %v", tc.output, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`addLoopbackAlias` errored on `RTNETLINK answers: File exists`, which fires whenever a spot's loopback alias survives the sentinel process (an ungraceful crash, OOM kill, anything that skips `UnregisterAll`'s cleanup — the restart class #337 already flagged). Since `allocateOctet`'s slot is a deterministic function of spot ID, and the registry's `usedIPs` bookkeeping is purely in-memory, a sentinel restart after an ungraceful exit means the same spot always retries the exact same octet on reconnect and hits the exact same "already exists" error — an infinite reconnect loop with no operator-visible detail beyond an opaque `exit status 2` on the client side.

Found live: a BYOC peer's tunnel to a region sentinel was silently wedged this way for a full week before being traced back to a stale loopback alias.

## Fix

- `addLoopbackAlias` now treats an already-present alias as success (the goal was just "make sure this alias exists," which a pre-existing one already satisfies).
- Any other failure now surfaces the actual `ip` command output instead of a bare exit code, for faster diagnosis next time.
- Detection logic (`isAlreadyExistsErr`) is split out so it's unit-testable without shelling out to `ip` or needing `CAP_NET_ADMIN`.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/sentinel/...` — full suite green
- [x] New `TestIsAlreadyExistsErr` table test covers real iproute2 output, embedded-message case, and non-matching failures (invalid address, missing interface, permission denied) that must NOT be swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)