### PR TITLE
fix(startup): avoid useradd primary-group collision on admin usernames

### DIFF
--- a/terraform/gce/scripts/startup-sentinel.sh
+++ b/terraform/gce/scripts/startup-sentinel.sh
@@ -64,7 +64,15 @@ for username in "$${USERS[@]}"; do
     username=$(echo "$username" | xargs)
     if [ -z "$username" ]; then continue; fi
     if ! id "$username" &>/dev/null; then
-        useradd -m -s /bin/bash -G sudo "$username"
+        # Create user without creating a new primary group (use existing or
+        # fall back to "users") — a bare useradd tries to auto-create a
+        # same-named primary group, which fails outright if a group of that
+        # name already exists (e.g. "admin" collides with a pre-existing
+        # system group shipped in the stock Ubuntu image; kafeido-infra#41).
+        # This script runs under `set -euo pipefail`, so an unhandled
+        # failure here previously aborted the ENTIRE sentinel bootstrap
+        # (sshpiper, containarium, everything) over one bad username.
+        useradd -m -s /bin/bash -N -G sudo "$username" || useradd -m -s /bin/bash -g users -G sudo "$username"
         echo "$username ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/"$username"
         chmod 440 /etc/sudoers.d/"$username"
         mkdir -p /home/"$username"/.ssh

--- a/terraform/gce/scripts/startup.sh
+++ b/terraform/gce/scripts/startup.sh
@@ -246,7 +246,12 @@ echo "==> Setting up admin users..."
 IFS=',' read -ra USERS <<< "$ADMIN_USERS"
 for username in "$${USERS[@]}"; do
     if ! id "$username" &>/dev/null; then
-        useradd -m -s /bin/bash -G sudo "$username"
+        # Create user without creating a new primary group (use existing or
+        # fall back to "users") — a bare useradd tries to auto-create a
+        # same-named primary group, which fails outright if a group of that
+        # name already exists (e.g. "admin" collides with a pre-existing
+        # system group shipped in the stock Ubuntu image; kafeido-infra#41).
+        useradd -m -s /bin/bash -N -G sudo "$username" || useradd -m -s /bin/bash -g users -G sudo "$username"
         echo "$username ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/"$username"
         chmod 0440 /etc/sudoers.d/"$username"
         echo "✓ Created user: $username"

--- a/terraform/modules/containarium/scripts/startup-sentinel.sh
+++ b/terraform/modules/containarium/scripts/startup-sentinel.sh
@@ -119,7 +119,15 @@ for username in "$${USERS[@]}"; do
     username=$(echo "$username" | xargs)
     if [ -z "$username" ]; then continue; fi
     if ! id "$username" &>/dev/null; then
-        useradd -m -s /bin/bash -G sudo "$username"
+        # Create user without creating a new primary group (use existing or
+        # fall back to "users") — a bare useradd tries to auto-create a
+        # same-named primary group, which fails outright if a group of that
+        # name already exists (e.g. "admin" collides with a pre-existing
+        # system group shipped in the stock Ubuntu image; kafeido-infra#41).
+        # This script runs under `set -euo pipefail`, so an unhandled
+        # failure here previously aborted the ENTIRE sentinel bootstrap
+        # (sshpiper, containarium, everything) over one bad username.
+        useradd -m -s /bin/bash -N -G sudo "$username" || useradd -m -s /bin/bash -g users -G sudo "$username"
         echo "$username ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/"$username"
         chmod 440 /etc/sudoers.d/"$username"
         mkdir -p /home/"$username"/.ssh

--- a/terraform/modules/containarium/scripts/startup.sh
+++ b/terraform/modules/containarium/scripts/startup.sh
@@ -258,7 +258,12 @@ echo "==> Setting up admin users..."
 IFS=',' read -ra USERS <<< "$ADMIN_USERS"
 for username in "$${USERS[@]}"; do
     if ! id "$username" &>/dev/null; then
-        useradd -m -s /bin/bash -G sudo "$username"
+        # Create user without creating a new primary group (use existing or
+        # fall back to "users") — a bare useradd tries to auto-create a
+        # same-named primary group, which fails outright if a group of that
+        # name already exists (e.g. "admin" collides with a pre-existing
+        # system group shipped in the stock Ubuntu image; kafeido-infra#41).
+        useradd -m -s /bin/bash -N -G sudo "$username" || useradd -m -s /bin/bash -g users -G sudo "$username"
         echo "$username ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/"$username"
         chmod 0440 /etc/sudoers.d/"$username"
         echo "✓ Created user: $username"


### PR DESCRIPTION
## Summary
Cross-referenced from [kafeido-infra#41](https://github.com/FootprintAI/kafeido-infra/issues/41).

`useradd -m -s /bin/bash -G sudo "$username"` tries to auto-create a same-named primary group. When the username is `admin` this collides with a pre-existing `admin` group shipped in the stock Ubuntu GCE image (a Canonical/polkit legacy artifact — `/usr/share/polkit-1/rules.d/49-ubuntu-admin.rules` references `unix-group:admin` as a legacy admin-authorization identity), so the create fails outright with `useradd: group admin exists` and that username is silently never provisioned.

Confirmed live on `containarium-jump-ase1-sentinel` (asia-east1) via serial console: only the `admin` username failed at boot; `ubuntu` and other pre-existing accounts provisioned/updated fine — this is a narrower bug than "any new username fails," it's specifically a reserved-group-name collision.

**On the two `startup-sentinel.sh` scripts this is worse than a silently-skipped account**: both run under `set -euo pipefail`, so an unhandled `useradd` failure aborts the *entire* bootstrap before sshpiper, the containarium binary, or the sentinel service ever get installed — a fresh sentinel recreate that happens to have `admin` in its `admin_ssh_keys` map would brick on first boot.

## Fix
`terraform/modules/containarium/scripts/startup-spot.sh` (and its legacy `terraform/gce/` twin) already carry the fix:
```sh
useradd -m -s /bin/bash -N -G sudo "$username" || useradd -m -s /bin/bash -g users -G sudo "$username"
```
`-N` skips primary-group auto-creation entirely (falls back to the existing/default group), with an explicit `-g users` fallback if that somehow still fails. This PR mirrors that exact, already-proven pattern into the four scripts that never got it: both `startup.sh` (non-sentinel jump/spot) and both `startup-sentinel.sh` copies (current + legacy `terraform/gce/` path).

## Test plan
- [x] `bash -n` on all 4 modified files — clean
- [x] Diff reviewed against the existing proven pattern in `startup-spot.sh` for consistency
- [ ] No live instance was touched — this is a startup-script change that only takes effect on the *next* boot of an instance provisioned from this module; existing running instances are unaffected until recreated
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)