### PR TITLE
fix(incus): retry transient "Instance not found" on GetInstanceState

### DIFF
--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -840,7 +840,7 @@ func (c *Client) ListContainers() ([]ContainerInfo, error) {
 
 		// Get IP address - need to get state separately
 		// Priority: eth0 (Incus bridge) > other non-container interfaces > container bridge (docker0/podman0)
-		state, _, err := c.server.GetInstanceState(inst.Name)
+		state, _, err := c.getInstanceStateWithRetry("list "+inst.Name, inst.Name)
 		if err == nil && state.Network != nil {
 			var fallbackIP string
 
@@ -966,7 +966,7 @@ func (c *Client) GetContainer(name string) (*ContainerInfo, error) {
 
 	// Get IP address - need to get state separately
 	// Priority: eth0 (Incus bridge) > other non-container interfaces > container bridge (docker0/podman0)
-	state, _, err := c.server.GetInstanceState(name)
+	state, _, err := c.getInstanceStateWithRetry("get "+name, name)
 	if err == nil && state.Network != nil {
 		var fallbackIP string
 
@@ -1055,6 +1055,60 @@ func execWithRetry(what string, attempt func() error) error {
 		time.Sleep(time.Duration(i) * execBackoffBase)
 	}
 	return err
+}
+
+// stateMaxAttempts bounds retries of an incus GetInstanceState call on the
+// transient "Instance not found" failure (see isTransientStateErr). Same
+// 4-attempts/linear-backoff shape as execWithRetry — this is the
+// GetInstanceState sibling of that fix, for the same class of liblxc-socket
+// flakiness (OSS #931).
+const stateMaxAttempts = 4
+
+// stateBackoffBase is the linear backoff unit between GetInstanceState
+// retries. A var (not const) so tests can zero it; production keeps the
+// default.
+var stateBackoffBase = 150 * time.Millisecond
+
+// isTransientStateErr reports whether a GetInstanceState error is the
+// transient "Instance not found" failure a running instance can
+// spuriously report on some hosts (OSS #931): the daemon's single
+// long-lived Incus connection gets wedged for one specific instance —
+// `incus list` / `incus info` against the SAME host, at the SAME moment,
+// correctly report it RUNNING — while GetInstanceState keeps returning
+// "Instance not found" until a retry unwedges it. Retrying absorbs it; an
+// instance that's ACTUALLY gone keeps returning this on every attempt and
+// surfaces the same error once retries are exhausted, so this never masks
+// a real deletion.
+func isTransientStateErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Instance not found")
+}
+
+// getInstanceStateWithRetry runs c.server.GetInstanceState up to
+// stateMaxAttempts times, retrying ONLY the transient "Instance not found"
+// error (isTransientStateErr) with a linear backoff — the GetInstanceState
+// sibling of execWithRetry.
+func (c *Client) getInstanceStateWithRetry(what, name string) (*api.InstanceState, string, error) {
+	return stateWithRetry(what, func() (*api.InstanceState, string, error) {
+		return c.server.GetInstanceState(name)
+	})
+}
+
+// stateWithRetry is the generic retry loop behind getInstanceStateWithRetry,
+// split out (mirroring execWithRetry) so tests can exercise the retry/backoff
+// behavior against a fake attempt func without a real Incus server.
+func stateWithRetry(what string, attempt func() (*api.InstanceState, string, error)) (*api.InstanceState, string, error) {
+	var state *api.InstanceState
+	var etag string
+	var err error
+	for i := 1; i <= stateMaxAttempts; i++ {
+		state, etag, err = attempt()
+		if err == nil || !isTransientStateErr(err) || i == stateMaxAttempts {
+			return state, etag, err
+		}
+		log.Printf("[incus] %s: transient state error (attempt %d/%d), retrying: %v", what, i, stateMaxAttempts, err)
+		time.Sleep(time.Duration(i) * stateBackoffBase)
+	}
+	return state, etag, err
 }
 
 // Exec executes a command inside a container
@@ -1550,7 +1604,7 @@ func (c *Client) ensureZFSQuotaHeadroom(containerName, pool, targetSize string) 
 
 // GetContainerMetrics gets runtime metrics for a container
 func (c *Client) GetContainerMetrics(name string) (*ContainerMetrics, error) {
-	state, _, err := c.server.GetInstanceState(name)
+	state, _, err := c.getInstanceStateWithRetry("metrics "+name, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get container state: %w", err)
 	}

--- a/pkg/core/incus/state_retry_test.go
+++ b/pkg/core/incus/state_retry_test.go
@@ -1,0 +1,104 @@
+package incus
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/lxc/incus/v6/shared/api"
+)
+
+// noStateBackoff zeroes stateBackoffBase for the duration of a test so the
+// retry loop doesn't actually sleep.
+func noStateBackoff(t *testing.T) {
+	t.Helper()
+	old := stateBackoffBase
+	stateBackoffBase = 0
+	t.Cleanup(func() { stateBackoffBase = old })
+}
+
+// errTransientState mimics the real error text GetInstanceState surfaces
+// for a wedged-connection ghost instance (OSS #931) — verbatim, so the
+// substring match in isTransientStateErr is exercised.
+var errTransientState = errors.New(`Failed to fetch instance "cld-example-container" in project "default": Instance not found`) //nolint:staticcheck // ST1005: mirrors verbatim incus error text
+
+func TestIsTransientStateErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"transient ghost instance", errTransientState, true},
+		{"wrapped transient", fmt.Errorf("failed to get container state: %w", errTransientState), true},
+		{"other failure", errors.New("connection refused"), false},
+	}
+	for _, c := range cases {
+		if got := isTransientStateErr(c.err); got != c.want {
+			t.Errorf("%s: isTransientStateErr = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestStateWithRetry_RetriesTransientThenSucceeds: the transient
+// "Instance not found" error is retried and a later success is returned
+// cleanly — reproducing the exact live behavior observed on OSS #931 (the
+// same call succeeding on a subsequent attempt with nothing else changed).
+func TestStateWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
+	noStateBackoff(t)
+	calls := 0
+	want := &api.InstanceState{Status: "Running"}
+	state, _, err := stateWithRetry("test", func() (*api.InstanceState, string, error) {
+		calls++
+		if calls < 3 {
+			return nil, "", errTransientState
+		}
+		return want, "etag", nil
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil after transient retries", err)
+	}
+	if state != want {
+		t.Errorf("state = %v, want %v", state, want)
+	}
+	if calls != 3 {
+		t.Errorf("attempts = %d, want 3 (2 transient + 1 success)", calls)
+	}
+}
+
+// TestStateWithRetry_DoesNotRetryRealError: a genuine (non-transient)
+// failure must return immediately, on the first attempt.
+func TestStateWithRetry_DoesNotRetryRealError(t *testing.T) {
+	noStateBackoff(t)
+	calls := 0
+	realErr := errors.New("connection refused")
+	_, _, err := stateWithRetry("test", func() (*api.InstanceState, string, error) {
+		calls++
+		return nil, "", realErr
+	})
+	if !errors.Is(err, realErr) {
+		t.Fatalf("err = %v, want the real error", err)
+	}
+	if calls != 1 {
+		t.Errorf("attempts = %d, want 1 (no retry on a real failure)", calls)
+	}
+}
+
+// TestStateWithRetry_ExhaustsAndReturnsLast: a persistently transient error
+// (a genuinely deleted instance) is retried up to the cap, then the same
+// error is returned — this must NEVER be silently swallowed into a fake
+// success.
+func TestStateWithRetry_ExhaustsAndReturnsLast(t *testing.T) {
+	noStateBackoff(t)
+	calls := 0
+	_, _, err := stateWithRetry("test", func() (*api.InstanceState, string, error) {
+		calls++
+		return nil, "", errTransientState
+	})
+	if !isTransientStateErr(err) {
+		t.Fatalf("err = %v, want the transient error after exhaustion", err)
+	}
+	if calls != stateMaxAttempts {
+		t.Errorf("attempts = %d, want stateMaxAttempts (%d)", calls, stateMaxAttempts)
+	}
+}


### PR DESCRIPTION
## Summary
- `GetInstanceState` (via `GetContainerMetrics`/`ListContainers`/`GetContainer`) can spuriously return `"Instance not found"` for an instance that `incus list`/`incus info` confirm is genuinely running — the daemon's single long-lived Incus connection gets wedged for that specific instance. Live-confirmed: restarting the daemon clears it, but it recurs within hours under normal polling load.
- Extends the existing `execWithRetry` precedent (already in this file, for a sibling liblxc transient-error class) to `GetInstanceState`: a narrow, string-matched, capped retry with linear backoff. A genuinely deleted instance still fails cleanly once retries are exhausted — this never masks a real failure.

Fixes #931

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/core/incus/...`
- [x] `go test ./pkg/core/incus/...` — new `state_retry_test.go` covers: retries-then-succeeds, does-not-retry-a-real-error, exhausts-and-returns-last-error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mQUDm9FNhwDXNG25cxGxY