### PR TITLE
feat(sentinel): wire sentinel_admin_secret terraform var (#935/#936)

### DIFF
--- a/terraform/modules/containarium/scripts/startup-sentinel.sh
+++ b/terraform/modules/containarium/scripts/startup-sentinel.sh
@@ -290,16 +290,24 @@ chmod 0700 /etc/containarium
 # Empty terraform var → file omitted → daemon logs a loud WARNING
 # and the audit-known endpoints stay vulnerable.
 SENTINEL_AUTH_SECRET="${sentinel_auth_secret}"
-if [ -n "$SENTINEL_AUTH_SECRET" ]; then
+# CONTAINARIUM_SENTINEL_ADMIN_SECRET gates POST /sentinel/tunnel-tokens —
+# see variables.tf's sentinel_admin_secret doc comment. Separate secret from
+# CONTAINARIUM_SENTINEL_AUTH_SECRET on purpose (bigger capability).
+SENTINEL_ADMIN_SECRET="${sentinel_admin_secret}"
+if [ -n "$SENTINEL_AUTH_SECRET" ] || [ -n "$SENTINEL_ADMIN_SECRET" ]; then
     umask 077
-    cat > /etc/containarium/env.secrets <<EOF
-CONTAINARIUM_SENTINEL_AUTH_SECRET=$SENTINEL_AUTH_SECRET
-EOF
+    : > /etc/containarium/env.secrets
+    if [ -n "$SENTINEL_AUTH_SECRET" ]; then
+        echo "CONTAINARIUM_SENTINEL_AUTH_SECRET=$SENTINEL_AUTH_SECRET" >> /etc/containarium/env.secrets
+    fi
+    if [ -n "$SENTINEL_ADMIN_SECRET" ]; then
+        echo "CONTAINARIUM_SENTINEL_ADMIN_SECRET=$SENTINEL_ADMIN_SECRET" >> /etc/containarium/env.secrets
+    fi
     chmod 0600 /etc/containarium/env.secrets
-    echo "✓ /etc/containarium/env.secrets written from terraform var"
+    echo "✓ /etc/containarium/env.secrets written from terraform vars"
 else
     rm -f /etc/containarium/env.secrets
-    echo "⚠ sentinel_auth_secret terraform var is empty — Phase 0.4/0.6 disabled, sentinel endpoints return 401 / unsigned"
+    echo "⚠ sentinel_auth_secret and sentinel_admin_secret terraform vars are both empty — Phase 0.4/0.6 disabled (sentinel endpoints return 401/unsigned) AND /sentinel/tunnel-tokens is disabled (dynamic BYOC join-token registration will not work — Containarium#935/#936)"
 fi
 
 # Peer-CA private key (Phase 0.5). Auto-generated on first boot if
@@ -341,6 +349,8 @@ if [ -f /usr/local/bin/containarium ]; then
     #   - CONTAINARIUM_SENTINEL_AUTH_SECRET  (HMAC for /authorized-keys,
     #     /certs, /sentinel/ca, /sentinel/peer-cert; signs
     #     /sentinel/peers response)
+    #   - CONTAINARIUM_SENTINEL_ADMIN_SECRET (HMAC gating POST
+    #     /sentinel/tunnel-tokens — dynamic BYOC join-token registration)
     #   - CONTAINARIUM_CA_KEY_FILE           (peer-CA private key path)
     #
     # `EnvironmentFile=-/path` with the leading dash tells systemd to

--- a/terraform/modules/containarium/sentinel.tf
+++ b/terraform/modules/containarium/sentinel.tf
@@ -75,6 +75,7 @@ resource "google_compute_instance" "sentinel" {
       project_id              = var.project_id
       enable_proxy_protocol   = var.enable_proxy_protocol
       sentinel_auth_secret    = var.sentinel_auth_secret
+      sentinel_admin_secret   = var.sentinel_admin_secret
       enable_peer_mtls        = var.enable_peer_mtls
     })
   }

--- a/terraform/modules/containarium/variables.tf
+++ b/terraform/modules/containarium/variables.tf
@@ -198,6 +198,32 @@ variable "sentinel_auth_secret" {
   default     = ""
 }
 
+# `sentinel_admin_secret` gates POST /sentinel/tunnel-tokens — the runtime
+# path that lets an authorized caller (a cloud control plane's token-issuance
+# service, or an operator) register a freshly-minted tunnel-join token on an
+# already-running sentinel without a restart. Deliberately a SEPARATE secret
+# from sentinel_auth_secret: registering a brand-new node into a pool is a
+# materially bigger capability than the intra-cluster keysync/certsync
+# operations sentinel_auth_secret gates, so a compromised daemon holding only
+# the cluster-wide HMAC secret shouldn't also be able to mint tunnel access.
+#
+# When empty, the sentinel's TunnelTokenRegisterHandler stays disabled (its
+# own default, safe state) — a freshly-minted BYOC join token then has no way
+# to become valid on the sentinel except a full sentinel restart with
+# --tunnel-token-policy, which is exactly the gap that leaves BYOC hosts
+# unable to reconnect after enrollment (Containarium#935/#936).
+#
+# Generate with:
+#   openssl rand -base64 48
+#
+# Must be at least 32 bytes after any encoding (sentinel.SentinelMinSecretLen).
+variable "sentinel_admin_secret" {
+  description = "Shared HMAC secret gating POST /sentinel/tunnel-tokens (dynamic BYOC join-token registration). 32+ bytes. Empty = the endpoint stays disabled and freshly-minted join tokens are never registered with the sentinel."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 # `enable_peer_mtls` turns on the Phase 0.5 peer-CA path. When true,
 # the sentinel auto-generates an RSA-4096 CA private key at
 # `/etc/containarium/ca.key` on first boot, mints itself a server


### PR DESCRIPTION
## Summary
- Adds the `sentinel_admin_secret` module variable + its `EnvironmentFile` plumbing (`CONTAINARIUM_SENTINEL_ADMIN_SECRET`), mirroring the existing `sentinel_auth_secret` pattern.
- Makes it possible to configure the existing (but previously unreachable-in-practice) `POST /sentinel/tunnel-tokens` runtime path — the sentinel's own `TunnelTokenRegisterHandler` and its systemd wiring already existed; nothing set this secret before, so the endpoint has effectively always been disabled by default.
- Terraform-only: no new Go code in this repo. Companion to a Containarium-cloud PR that actually calls this endpoint from `MintHostJoinToken`.

Related to #935 / #936

## Test plan
- [x] `terraform validate` clean on `terraform/modules/containarium`
- [x] `bash -n` clean on the modified startup script
- No live apply performed — a real secret value still needs to be set per-environment (this PR only makes it possible to configure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mQUDm9FNhwDXNG25cxGxY