### PR TITLE
fix(sentinel): loopback-alias idempotency fix misses a 2nd message format (#945)

### DIFF
--- a/internal/sentinel/tunnel_registry.go
+++ b/internal/sentinel/tunnel_registry.go
@@ -308,13 +308,25 @@ func addLoopbackAlias(ip string) error {
 }
 
 // isAlreadyExistsErr reports whether `ip addr add`'s output indicates the
-// alias already exists (iproute2 prints "RTNETLINK answers: File exists"
-// and exits 2) rather than some other, genuinely fatal failure (bad
+// alias already exists rather than some other, genuinely fatal failure (bad
 // address, missing interface, permission denied, ...). Split out from
 // addLoopbackAlias so the detection logic is unit-testable without
 // shelling out to `ip` or needing CAP_NET_ADMIN.
+//
+// Matches TWO distinct message formats for the identical condition, since
+// different iproute2 builds phrase it differently:
+//   - "RTNETLINK answers: File exists" (older/raw-netlink-style iproute2)
+//   - "Error: ipv4: Address already assigned." (newer libnl-style iproute2)
+//
+// Live-confirmed gap: the original fix (#927) only matched "File exists",
+// so a sentinel running the newer message format still hit the exact fatal
+// error #927 set out to eliminate — found live when a BYOC host's tunnel
+// registration kept failing with "Error: ipv4: Address already assigned."
+// on every reconnect attempt, indistinguishable from a genuine fatal error
+// on the client side beyond an opaque "exit status 2".
 func isAlreadyExistsErr(cmdOutput []byte) bool {
-	return strings.Contains(string(cmdOutput), "File exists")
+	out := string(cmdOutput)
+	return strings.Contains(out, "File exists") || strings.Contains(out, "Address already assigned")
 }
 
 // removeLoopbackAlias removes an IP alias from the loopback interface.

--- a/internal/sentinel/tunnel_registry_loopback_test.go
+++ b/internal/sentinel/tunnel_registry_loopback_test.go
@@ -3,9 +3,9 @@ package sentinel
 import "testing"
 
 // TestIsAlreadyExistsErr pins the detection logic behind addLoopbackAlias's
-// idempotency fix: only "RTNETLINK answers: File exists" (the alias is
-// already there — safe to treat as success) should be swallowed. Anything
-// else must still surface as a real failure.
+// idempotency fix: two distinct iproute2 message formats for the identical
+// "alias already there — safe to treat as success" condition must both be
+// swallowed. Anything else must still surface as a real failure.
 func TestIsAlreadyExistsErr(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -13,13 +13,22 @@ func TestIsAlreadyExistsErr(t *testing.T) {
 		want   bool
 	}{
 		{
-			name:   "real iproute2 already-exists output",
+			name:   "real iproute2 already-exists output (older/raw-netlink style)",
 			output: "RTNETLINK answers: File exists\n",
 			want:   true,
 		},
 		{
 			name:   "already-exists text embedded in a longer message",
 			output: "Error: ipv4: Address already assigned.\nRTNETLINK answers: File exists\n",
+			want:   true,
+		},
+		// Live-confirmed production output (newer libnl-style iproute2) —
+		// this alone, with NO "File exists" substring anywhere, is what
+		// actually failed a real BYOC host's tunnel registration on every
+		// reconnect until this case was added.
+		{
+			name:   "standalone newer-iproute2 already-assigned output, no File exists substring",
+			output: "Error: ipv4: Address already assigned.\n",
 			want:   true,
 		},
 		{


### PR DESCRIPTION
## Summary
- #927 fixed `addLoopbackAlias` to treat "alias already present" as success, but its detection only matched `"File exists"` (older raw-netlink-style iproute2). A newer iproute2 build reports the identical condition as `"Error: ipv4: Address already assigned."` — no `"File exists"` substring at all.
- **Live-confirmed**: this exact gap was actively blocking a real BYOC host's tunnel reconnect on every single attempt — the precise "wedged forever, opaque exit status 2 on the client side" failure mode #927 was written to eliminate, just via a message format its string-match didn't cover.
- `isAlreadyExistsErr` now matches both formats. New test case uses the exact standalone production output.

Fixes #945

## Test plan
- [x] `go build ./internal/sentinel/...`, `go vet`, `gofmt -l` clean
- [x] `go test ./internal/sentinel/...` — all pass, including the new regression case
- [x] Root cause confirmed via live production sentinel logs before writing the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mQUDm9FNhwDXNG25cxGxY