### PR TITLE
chore(release): cut v0.51.1 — loopback-alias 2nd message format fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.1] - 2026-07-13
+
+### Fixed
+
+- **Sentinel loopback-alias idempotency fix (#927) missed a second
+  iproute2 already-exists message format** (#945). #927 treated
+  "alias already present" as success, but its detection only matched
+  `"File exists"` (older raw-netlink-style iproute2). A newer iproute2
+  build reports the identical condition as `"Error: ipv4: Address
+  already assigned."`, with no `"File exists"` substring at all —
+  live-confirmed blocking a real BYOC host's tunnel reconnect on every
+  single attempt, the exact "wedged forever" failure #927 set out to
+  eliminate. (#946)
+
 ## [0.51.0] - 2026-07-13
 
 ### Fixed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.51.0"
+	Version = "0.51.1"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary
Version bump + CHANGELOG for v0.51.1: the loopback-alias idempotency fix (#945/#946), live-confirmed as a real production failure blocking a BYOC host's tunnel reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mQUDm9FNhwDXNG25cxGxY