### PR TITLE
fix: sentinel-auth-secret on pool join (#687) + surface container image (#870)

### DIFF
--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -38,7 +38,7 @@ const (
 	// #341) so the fleet-wide HMAC secret this host needs to authenticate
 	// the sentinel's keysync/certsync requests never lands in a
 	// world-readable file.
-	sentinelAuthSecretFile = "/etc/containarium/sentinel-auth.env"
+	sentinelAuthSecretFile = "/etc/containarium/sentinel-auth.env" // #nosec G101 -- a file PATH, not a credential
 )
 
 // minimalDaemonArgv is the baseline daemon command used when no existing

--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -31,6 +31,14 @@ const (
 	daemonDropInDir = "/etc/systemd/system/containarium.service.d"
 	daemonDropIn    = daemonDropInDir + "/pool.conf"
 	daemonBinPath   = "/usr/local/bin/containarium"
+
+	// sentinelAuthSecretFile holds CONTAINARIUM_SENTINEL_AUTH_SECRET for the
+	// EnvironmentFile= directive in the pool drop-in (see renderPoolDropIn).
+	// Separate from daemonDropIn (which stays 0644/no-secrets by convention,
+	// #341) so the fleet-wide HMAC secret this host needs to authenticate
+	// the sentinel's keysync/certsync requests never lands in a
+	// world-readable file.
+	sentinelAuthSecretFile = "/etc/containarium/sentinel-auth.env"
 )
 
 // minimalDaemonArgv is the baseline daemon command used when no existing
@@ -41,19 +49,20 @@ func minimalDaemonArgv() []string {
 }
 
 var (
-	poolJoinSentinels         []string
-	poolJoinRegion            string
-	poolJoinToken             string
-	poolJoinPool              string
-	poolJoinSpotID            string
-	poolJoinPorts             string
-	poolJoinPublicHostname    string
-	poolJoinPublicPort        int
-	poolJoinBaseDomain        string
-	poolJoinDryRun            bool
-	poolJoinDaemonFlags       []string
-	poolJoinCloudControlPlane string
-	poolJoinCloudInsecure     bool
+	poolJoinSentinels          []string
+	poolJoinRegion             string
+	poolJoinToken              string
+	poolJoinPool               string
+	poolJoinSpotID             string
+	poolJoinPorts              string
+	poolJoinPublicHostname     string
+	poolJoinPublicPort         int
+	poolJoinBaseDomain         string
+	poolJoinDryRun             bool
+	poolJoinDaemonFlags        []string
+	poolJoinCloudControlPlane  string
+	poolJoinCloudInsecure      bool
+	poolJoinSentinelAuthSecret string
 )
 
 var poolJoinCmd = &cobra.Command{
@@ -104,6 +113,7 @@ func init() {
 	poolJoinCmd.Flags().StringArrayVar(&poolJoinDaemonFlags, "daemon-flag", nil, "Extra daemon flag to carry into the unit (repeatable), e.g. --daemon-flag=--app-hosting --daemon-flag=--network-subnet=10.0.0.0/24. Use to add/override flags on top of the preserved/baseline set")
 	poolJoinCmd.Flags().StringVar(&poolJoinCloudControlPlane, "cloud-control-plane", "", "Also self-register this host with a cloud control plane (e.g. https://cloud.containarium.dev) using the same --token, right after the tunnel comes up. Optional — omit for a plain OSS pool join with no cloud involvement. A failure here is a warning, not a join failure: the tunnel is joined either way.")
 	poolJoinCmd.Flags().BoolVar(&poolJoinCloudInsecure, "cloud-insecure", false, "Dial --cloud-control-plane without TLS (local dev only; ignored unless --cloud-control-plane is set)")
+	poolJoinCmd.Flags().StringVar(&poolJoinSentinelAuthSecret, "sentinel-auth-secret", os.Getenv("CONTAINARIUM_SENTINEL_AUTH_SECRET"), "Fleet-wide HMAC secret (32+ bytes) matching the sentinel's CONTAINARIUM_SENTINEL_AUTH_SECRET. Without it, the sentinel's keysync/certsync requests to this host's /authorized-keys get rejected with 401 — this host stays joined to the tunnel but never gets an SSH pipe (#687). Defaults to $CONTAINARIUM_SENTINEL_AUTH_SECRET; written to a root-only env file, never into the world-readable drop-in")
 }
 
 // tunnelUnitParams are the inputs to the tunnel systemd unit.
@@ -155,9 +165,17 @@ func renderTunnelUnit(p tunnelUnitParams) string {
 // renderPoolDropIn renders the daemon drop-in that sets ExecStart to the
 // resolved argv (which already carries the preserved/baseline flags + --pool /
 // --base-domain). Pure. systemd override semantics: clear then re-set.
-func renderPoolDropIn(argv []string) string {
+//
+// authSecretFile, when non-empty, adds an EnvironmentFile= directive pointing
+// at the root-only file holding CONTAINARIUM_SENTINEL_AUTH_SECRET (#687) —
+// never inline as Environment=, since this drop-in itself stays 0644/no-secrets
+// by convention (#341).
+func renderPoolDropIn(argv []string, authSecretFile string) string {
 	var b strings.Builder
 	b.WriteString("[Service]\n")
+	if authSecretFile != "" {
+		fmt.Fprintf(&b, "EnvironmentFile=%s\n", authSecretFile)
+	}
 	b.WriteString("ExecStart=\n")
 	b.WriteString("ExecStart=" + strings.Join(argv, " ") + "\n")
 	return b.String()
@@ -259,6 +277,9 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 	if poolJoinPublicHostname != "" && poolJoinPublicPort == 0 {
 		return fmt.Errorf("--public-port is required when --public-hostname is set")
 	}
+	if poolJoinSentinelAuthSecret != "" && len(poolJoinSentinelAuthSecret) < 32 {
+		return fmt.Errorf("--sentinel-auth-secret must be at least 32 characters (got %d)", len(poolJoinSentinelAuthSecret))
+	}
 	spotID := poolJoinSpotID
 	if spotID == "" {
 		h, err := os.Hostname()
@@ -292,7 +313,11 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 	// command and silently dropping e.g. --app-hosting / --network-subnet.
 	current, found := currentDaemonArgv()
 	daemonArgv := resolvePoolDaemonArgv(current, found, poolJoinPool, poolJoinBaseDomain, poolJoinDaemonFlags)
-	dropIn := renderPoolDropIn(daemonArgv)
+	authSecretFile := ""
+	if poolJoinSentinelAuthSecret != "" {
+		authSecretFile = sentinelAuthSecretFile
+	}
+	dropIn := renderPoolDropIn(daemonArgv, authSecretFile)
 	if !found {
 		fmt.Println("# WARNING: could not read an existing daemon ExecStart.")
 		fmt.Println("#   Using the minimal baseline (--rest --jwt-secret-file). If this host")
@@ -300,6 +325,13 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 		fmt.Println("#   --network-subnet), pass them via --daemon-flag to preserve them.")
 	} else {
 		fmt.Printf("# Preserving existing daemon ExecStart flags; resulting command:\n#   %s\n", strings.Join(daemonArgv, " "))
+	}
+	if authSecretFile == "" {
+		fmt.Println("# WARNING: --sentinel-auth-secret not set (and $CONTAINARIUM_SENTINEL_AUTH_SECRET is")
+		fmt.Println("#   empty). This host will join the tunnel but the sentinel's keysync/certsync")
+		fmt.Println("#   requests to it will be rejected with 401 — SSH to containers on this host")
+		fmt.Println("#   will silently never work (#687). Pass --sentinel-auth-secret matching the")
+		fmt.Println("#   sentinel's value to fix this now, or re-run with it set later.")
 	}
 	tunnel := renderTunnelUnit(tunnelUnitParams{
 		SentinelAddr:   sentinelAddr,
@@ -313,6 +345,9 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 
 	if poolJoinDryRun {
 		fmt.Printf("# would ensure the canonical daemon unit (%s) + JWT secret\n\n", systemdServicePath)
+		if authSecretFile != "" {
+			fmt.Printf("# %s (mode 0600, contents redacted)\nCONTAINARIUM_SENTINEL_AUTH_SECRET=<redacted, %d bytes>\n\n", authSecretFile, len(poolJoinSentinelAuthSecret))
+		}
 		fmt.Printf("# %s\n%s\n", daemonDropIn, dropIn)
 		fmt.Printf("# %s\n%s\n", tunnelUnitPath, tunnel)
 		fmt.Println("# (dry-run: nothing written; re-run without --dry-run as root to apply)")
@@ -326,6 +361,17 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 	// 1. Canonical hardened daemon unit + JWT secret (shared with `service install`).
 	if err := ensureDaemonUnitAndSecret(); err != nil {
 		return err
+	}
+	// 1b. Sentinel HMAC auth secret (#687) — root-only, referenced by the
+	// drop-in's EnvironmentFile= rather than embedded in it.
+	if authSecretFile != "" {
+		if err := os.MkdirAll("/etc/containarium", 0700); err != nil {
+			return fmt.Errorf("create config directory: %w", err)
+		}
+		content := fmt.Sprintf("CONTAINARIUM_SENTINEL_AUTH_SECRET=%s\n", poolJoinSentinelAuthSecret)
+		if err := os.WriteFile(authSecretFile, []byte(content), 0600); err != nil {
+			return fmt.Errorf("write sentinel auth secret file: %w", err)
+		}
 	}
 	// 2. --pool drop-in on the daemon unit.
 	// #nosec G301 -- systemd drop-in dir, world-readable config by convention (no secrets)

--- a/internal/cmd/pool_join_test.go
+++ b/internal/cmd/pool_join_test.go
@@ -73,7 +73,7 @@ func TestRenderTunnelUnit_PublicPrimary(t *testing.T) {
 func TestRenderPoolDropIn(t *testing.T) {
 	// ExecStart must be cleared then re-set (systemd override semantics).
 	argv := resolvePoolDaemonArgv(nil, false, "prod", "", nil)
-	d := renderPoolDropIn(argv)
+	d := renderPoolDropIn(argv, "")
 	if !strings.Contains(d, "ExecStart=\nExecStart=/usr/local/bin/containarium daemon") {
 		t.Errorf("drop-in must clear+reset ExecStart:\n%s", d)
 	}
@@ -83,9 +83,26 @@ func TestRenderPoolDropIn(t *testing.T) {
 	if strings.Contains(d, "--base-domain") {
 		t.Errorf("drop-in should omit --base-domain when empty:\n%s", d)
 	}
-	d2 := renderPoolDropIn(resolvePoolDaemonArgv(nil, false, "prod", "boxes.example.com", nil))
+	if strings.Contains(d, "EnvironmentFile") {
+		t.Errorf("drop-in should omit EnvironmentFile when no auth secret file given:\n%s", d)
+	}
+	d2 := renderPoolDropIn(resolvePoolDaemonArgv(nil, false, "prod", "boxes.example.com", nil), "")
 	if !strings.Contains(d2, "--base-domain boxes.example.com") {
 		t.Errorf("drop-in missing --base-domain when set:\n%s", d2)
+	}
+}
+
+// TestRenderPoolDropIn_SentinelAuthSecret pins #687's fix: the drop-in must
+// reference the auth-secret file via EnvironmentFile=, never embed the
+// secret value inline (the drop-in itself stays 0644/world-readable).
+func TestRenderPoolDropIn_SentinelAuthSecret(t *testing.T) {
+	argv := resolvePoolDaemonArgv(nil, false, "prod", "", nil)
+	d := renderPoolDropIn(argv, "/etc/containarium/sentinel-auth.env")
+	if !strings.Contains(d, "EnvironmentFile=/etc/containarium/sentinel-auth.env") {
+		t.Errorf("drop-in missing EnvironmentFile directive:\n%s", d)
+	}
+	if strings.Contains(d, "CONTAINARIUM_SENTINEL_AUTH_SECRET") {
+		t.Errorf("drop-in must never embed the secret value inline:\n%s", d)
 	}
 }
 

--- a/internal/sentinel/keysync.go
+++ b/internal/sentinel/keysync.go
@@ -307,6 +307,13 @@ func (ks *KeyStore) RunSyncLoopLegacy(ctx context.Context, backendIP string, htt
 func (ks *KeyStore) syncAndApply(backendID, backendIP string, httpPort int) {
 	if err := ks.Sync(backendID, backendIP, httpPort); err != nil {
 		log.Printf("[keysync] sync failed for %s: %v", backendID, err)
+		if strings.Contains(err.Error(), "unexpected status 401") {
+			log.Printf("[keysync] backend %s rejected the signed /authorized-keys request with 401 — "+
+				"this backend's CONTAINARIUM_SENTINEL_AUTH_SECRET doesn't match this sentinel's (or is unset). "+
+				"Until fixed, this backend never gets an sshpiper pipe entry and SSH to its containers silently "+
+				"fails with 'no matching pipe' (#687). Fix: set matching CONTAINARIUM_SENTINEL_AUTH_SECRET on both ends "+
+				"(BYOC hosts: `pool join --sentinel-auth-secret ...`).", backendID)
+		}
 		return
 	}
 

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -2985,6 +2985,7 @@ func toProtoContainer(st *box.BoxStatus) *pb.Container {
 		MonitoringEnabled:    st.MonitoringEnabled,
 		AutoSleepEnabled:     st.AutoSleepEnabled,
 		IdleThresholdMinutes: st.IdleThresholdMinutes,
+		Image:                st.Image,
 	}
 	// TTL — populated by SetContainerTTL on the writer side. Zero value means
 	// no TTL set (parser silently drops missing/unparseable keys; a corrupted

--- a/pkg/core/box/box.go
+++ b/pkg/core/box/box.go
@@ -150,6 +150,11 @@ type BoxStatus struct {
 	StoppedAt                 time.Time
 	DeleteAfterStoppedSeconds int64
 	DeletePolicy              string // "protected" or "" (unprotected)
+
+	// Image is a human-readable label for the image the box was launched
+	// from (LXC: Incus's image.description / volatile.base_image config
+	// keys). Empty when the backend has no such data.
+	Image string
 }
 
 // BoxMetrics is the runtime-neutral form of a box's runtime metrics.

--- a/pkg/core/box/lxc/lxc.go
+++ b/pkg/core/box/lxc/lxc.go
@@ -214,6 +214,7 @@ func StatusFromInfo(info *incus.ContainerInfo) box.BoxStatus {
 		StoppedAt:                 info.StoppedAt,
 		DeleteAfterStoppedSeconds: info.DeleteAfterStoppedSeconds,
 		DeletePolicy:              info.DeletePolicy,
+		Image:                     info.Image,
 	}
 }
 

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -375,6 +375,12 @@ type ContainerInfo struct {
 	// auto-reap, `containarium prune`) skips the box — only a deliberate
 	// single-box delete can remove it. Empty = unprotected (today's default).
 	DeletePolicy string
+
+	// Image is a human-readable description of the image the container was
+	// launched from (Incus's auto-populated image.description config key,
+	// falling back to the volatile.base_image fingerprint). Empty if Incus
+	// never recorded either — e.g. a container created by a very old client.
+	Image string
 }
 
 // AutoSleepEnabledKey is the Incus config key storing the per-container
@@ -791,6 +797,7 @@ func (c *Client) ListContainers() ([]ContainerInfo, error) {
 			StoppedAt:                 parseStoppedAt(inst.Config),
 			DeleteAfterStoppedSeconds: parseDeleteAfterStoppedSeconds(inst.Config),
 			DeletePolicy:              inst.Config[DeletePolicyKey],
+			Image:                     imageDescriptionFromConfig(inst.Config),
 		}
 
 		// Get CPU and memory limits from config
@@ -916,6 +923,7 @@ func (c *Client) GetContainer(name string) (*ContainerInfo, error) {
 		LastStartedAt:        parseLastStartedAt(inst.Config),
 		TTLExpiresAt:         parseTTLExpiresAt(inst.Config),
 		DeletePolicy:         inst.Config[DeletePolicyKey],
+		Image:                imageDescriptionFromConfig(inst.Config),
 	}
 
 	// Get resource limits
@@ -1442,6 +1450,20 @@ func (c *Client) GetContainerImageFingerprint(containerName string) (string, err
 		return "", fmt.Errorf("get instance for fingerprint: %w", err)
 	}
 	return inst.Config["volatile.base_image"], nil
+}
+
+// imageDescriptionFromConfig returns a human-readable label for the image a
+// container was launched from. Prefers Incus's auto-populated
+// image.description (e.g. "Ubuntu 24.04 LTS server"), falling back to the
+// volatile.base_image fingerprint when the description is missing — both
+// are set by Incus itself at launch, so this needs no extra plumbing on
+// either cloud-created or pre-existing BYOC containers. Empty when neither
+// key is present (e.g. a container from a very old client).
+func imageDescriptionFromConfig(config map[string]string) string {
+	if desc := config["image.description"]; desc != "" {
+		return desc
+	}
+	return config["volatile.base_image"]
 }
 
 // SetCPULimit updates a container's CPU limit, translating the request into


### PR DESCRIPTION
## Summary

Two independent fixes found while closing out BYOC host `ubuntu-VirtualBox`'s onboarding (Containarium-cloud#863):

### #687 — SSH via sentinel fails for BYOC/tunnel-joined hosts

Root cause confirmed live: the sentinel's per-backend keysync mechanism already covers tunnel/BYOC backends (it's not architecturally local-only, as first suspected) — but `keysync.Sync`'s `GET /authorized-keys` call is HMAC-signed with `CONTAINARIUM_SENTINEL_AUTH_SECRET`, and `pool join` never provisioned that secret on the joining daemon. Every sync cycle 401s, so the host never accumulates users and never gets an sshpiper pipe entry:

```
[keysync] sync failed for tunnel-ubuntu-VirtualBox: key sync: unexpected status 401 from http://127.0.0.216:8080/authorized-keys
```

Terraform-provisioned GCP workhorses get this secret automatically via their startup script; hosts joined via `pool join` (the BYO-compute path) never did.

- Adds `--sentinel-auth-secret` to `pool join` (defaults to `$CONTAINARIUM_SENTINEL_AUTH_SECRET`).
- Value goes into a root-only 0600 env file, referenced via `EnvironmentFile=` in the drop-in — never embedded inline, since the drop-in itself stays 0644/no-secrets by convention (#341).
- Missing secret now prints an explicit warning instead of silently leaving SSH broken.
- `keysync`'s own logging now names the likely cause + fix on a 401, instead of just the raw HTTP error.

### #870 — AdoptContainer/webui shows `image: unknown` for adopted containers

Not a discarded field — OSS never computed/returned an image at any layer. The proto field and cloud-side plumbing were already fully wired end-to-end; they just always received an empty string. Incus already auto-populates `image.description`/`volatile.base_image` on every launch (cloud-created or pre-existing BYOC), so this is just reading a key that was already there — no new plumbing needed.

Threads `incus.ContainerInfo.Image` → `box.BoxStatus.Image` → `pb.Container.Image` through `ListContainers`/`GetContainer`, `StatusFromInfo`, and `toProtoContainer`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/cmd/... ./internal/sentinel/... ./internal/server/... ./pkg/core/...` — all pass
- [x] New tests: `TestRenderPoolDropIn_SentinelAuthSecret` (drop-in references the secret file, never embeds the value)
- [ ] Live re-verify against `ubuntu-VirtualBox` once deployed: re-run `pool join --sentinel-auth-secret ...`, confirm sshpiper picks up its users and SSH works
- [ ] Live re-verify an adopted container's `image` field is populated (not `unknown`) after this OSS build reaches a sentinel + the daemon on the BYOC host

🤖 Generated with [Claude Code](https://claude.com/claude-code)