### PR TITLE
fix(security): mask host PCI enumeration for non-GPU containers (#951)

### DIFF
--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -130,6 +130,28 @@ type GPUDevice struct {
 	PCI string
 }
 
+// pciMaskRawLXC hides the host's PCI device enumeration from a container's
+// /proc and /sys, closing the hardware-fingerprinting leak described where
+// it's applied (security#951). Live-validated on a real GPU host (RTX
+// 3090): both mounts apply cleanly, the container restarts and remains
+// otherwise fully functional, /proc/bus/pci/devices reads back empty, and
+// /sys/bus/pci/devices/ lists zero entries — while an unmasked sibling
+// container on the same host still shows the real device table.
+const pciMaskRawLXC = "lxc.mount.entry = /dev/null proc/bus/pci/devices none bind,optional,create=file 0 0\n" +
+	"lxc.mount.entry = tmpfs sys/bus/pci/devices tmpfs rw,size=1k,mode=0755,optional,create=dir 0 0"
+
+// appendRawLXC adds lines to the container's raw.lxc config, appending to
+// (rather than clobbering) any value already set by an earlier config
+// decision — e.g. Docker-in-Docker's AppArmor override and the PCI-masking
+// mount entries can both apply to the same container.
+func appendRawLXC(cfg map[string]string, lines string) {
+	if existing, ok := cfg["raw.lxc"]; ok && existing != "" {
+		cfg["raw.lxc"] = existing + "\n" + lines
+	} else {
+		cfg["raw.lxc"] = lines
+	}
+}
+
 // gpuDeviceName returns the Incus device name for the i-th attached GPU.
 // The first GPU keeps the legacy "gpu" name so single-GPU containers are
 // byte-identical to the pre-multi-GPU config; subsequent GPUs are "gpu1",
@@ -654,7 +676,19 @@ func (c *Client) CreateContainer(config ContainerConfig) error {
 	// This is required for Docker to run properly inside the container
 	if config.EnablePodmanPrivileged {
 		req.Config["security.privileged"] = "true"
-		req.Config["raw.lxc"] = "lxc.apparmor.profile=unconfined"
+		appendRawLXC(req.Config, "lxc.apparmor.profile=unconfined")
+	}
+
+	// PCI device enumeration isn't namespaced by the Linux kernel (unlike
+	// network/mount/PID), so even an unprivileged container with no GPU
+	// device attached can read /proc/bus/pci/devices and
+	// /sys/bus/pci/devices to fingerprint the host's hardware — including
+	// whether it has a GPU and its exact model (security#951). Mask both
+	// for containers that weren't granted a GPU device; a GPU-passthrough
+	// container legitimately needs to see its own device, so this only
+	// applies when no GPU was requested.
+	if len(config.GPUs) == 0 {
+		appendRawLXC(req.Config, pciMaskRawLXC)
 	}
 
 	// Auto-start on boot

--- a/pkg/core/incus/pci_mask_test.go
+++ b/pkg/core/incus/pci_mask_test.go
@@ -1,0 +1,35 @@
+package incus
+
+import "testing"
+
+// TestAppendRawLXC pins the append-not-clobber contract: raw.lxc is a
+// single string config key, so two independent config decisions (e.g.
+// Docker-in-Docker's AppArmor override and PCI masking) that both need to
+// contribute lxc.* lines must be joined, not have one overwrite the other.
+func TestAppendRawLXC(t *testing.T) {
+	cfg := map[string]string{}
+	appendRawLXC(cfg, "lxc.apparmor.profile=unconfined")
+	if got := cfg["raw.lxc"]; got != "lxc.apparmor.profile=unconfined" {
+		t.Fatalf("first append = %q", got)
+	}
+
+	appendRawLXC(cfg, pciMaskRawLXC)
+	want := "lxc.apparmor.profile=unconfined\n" + pciMaskRawLXC
+	if got := cfg["raw.lxc"]; got != want {
+		t.Errorf("appended raw.lxc = %q, want %q", got, want)
+	}
+}
+
+// TestPCIMaskRawLXC pins the exact mount-entry syntax live-validated on a
+// real GPU host (RTX 3090): applied via `incus config set` + restart, the
+// container stayed healthy, /proc/bus/pci/devices read back empty, and
+// /sys/bus/pci/devices/ listed zero entries. Any edit to this string should
+// be re-validated the same way before merging — a malformed lxc.mount.entry
+// can prevent the container from starting at all.
+func TestPCIMaskRawLXC(t *testing.T) {
+	want := "lxc.mount.entry = /dev/null proc/bus/pci/devices none bind,optional,create=file 0 0\n" +
+		"lxc.mount.entry = tmpfs sys/bus/pci/devices tmpfs rw,size=1k,mode=0755,optional,create=dir 0 0"
+	if pciMaskRawLXC != want {
+		t.Errorf("pciMaskRawLXC = %q, want %q", pciMaskRawLXC, want)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #951. PCI device enumeration isn't namespaced by the Linux kernel (unlike network/mount/PID), so a container with no GPU device attached could still read `/proc/bus/pci/devices` and `/sys/bus/pci/devices` to fingerprint the host's hardware — including whether it has a GPU and its exact model. This was live-confirmed on a real GPU host: a throwaway container created without a GPU could read the full host PCI table (including the `10de:2204` NVIDIA RTX 3090 entry) via these paths, even though it correctly could **not** open any `/dev/nvidia*`/`/dev/dri` device node.

## Fix

Adds two `raw.lxc` bind-mounts for any container that wasn't granted a GPU device (`len(config.GPUs) == 0`):
- `/dev/null` over `/proc/bus/pci/devices` (a file — reads back empty)
- an empty `tmpfs` over `/sys/bus/pci/devices/` (a directory — lists zero entries)

A GPU-passthrough container is unaffected (needs to see its own device), since the mask only applies when no GPU was requested.

## Validation

This touches container-creation config for every non-GPU container, so I validated the exact mount-entry syntax live before writing any Go code:
1. Created a throwaway container on a real GPU host (RTX 3090) without requesting a GPU.
2. Applied the exact `raw.lxc` string via `incus config set` + `incus restart`.
3. Confirmed: container restarts cleanly, `/proc/bus/pci/devices` reads back empty, `/sys/bus/pci/devices/` lists zero entries, and basic container health (`whoami`, `uname`, filesystem, network) is unaffected.
4. Deleted the test container.

Added `pci_mask_test.go` pinning the exact validated string and the `appendRawLXC` join behavior (so it composes correctly with the existing Docker-in-Docker AppArmor override rather than clobbering it).

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/core/incus/...` — new tests pass
- [x] `go test ./...` — no regressions (2 pre-existing integration-test failures, both requiring a live daemon on `localhost:50051`, unrelated to this change)
- [x] Live-validated the exact mount syntax on a real GPU host before merging any code

🤖 Generated with [Claude Code](https://claude.com/claude-code)