### PR TITLE
feat(backup): back up every database automatically, don't require a name (#954)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -1160,7 +1160,7 @@
       },
       "post": {
         "summary": "Create a backup",
-        "description": "Runs pg_dump inside the tenant's container and stores the dump at the chosen off-host destination (local backup dir or GCS).",
+        "description": "Runs pg_dump inside the tenant's container and stores the dump at the chosen off-host destination (local backup dir or GCS). Leave connection.database empty to back up every non-template database found; set it to back up just one.",
         "operationId": "BackupService_CreateBackup",
         "responses": {
           "200": {
@@ -7317,7 +7317,7 @@
         },
         "connection": {
           "$ref": "#/definitions/PgConnection",
-          "description": "Connection parameters for pg_dump inside the container."
+          "description": "Connection parameters for pg_dump inside the container. Leave\nconnection.database empty to back up every non-template database\nfound (#954, the default); set it to back up just that one."
         },
         "destination": {
           "$ref": "#/definitions/BackupDestination",
@@ -7339,7 +7339,22 @@
         },
         "record": {
           "$ref": "#/definitions/BackupRecord",
-          "description": "The committed backup record."
+          "description": "The committed backup record. Populated only when connection.database\nnamed exactly one database (single-database create, back-compat\nshape). For a \"back up all\" create (connection.database empty),\nthis is unset — use records instead."
+        },
+        "records": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/BackupRecord"
+          },
+          "description": "Every committed backup record from this call. Always populated:\none entry for a single-database create (mirrors record above), or\none entry per database for a \"back up all\" create (#954)."
+        },
+        "failures": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Per-database failures from a \"back up all\" create — a database that\nfailed to dump (e.g. transient pg_dump error) does not abort the\nothers; its failure is reported here instead. Always empty for a\nsingle-database create (that path fails the whole RPC on error, as\nbefore)."
         }
       }
     },
@@ -9983,7 +9998,7 @@
       "properties": {
         "database": {
           "type": "string",
-          "description": "Logical database to dump or restore into. Required."
+          "description": "Logical database to dump or restore into. For CreateBackup, leave\nempty to back up EVERY non-template database in the container (#954)\n— the default, no-guessing path; a caller doesn't need to already\nknow a database name, and there's no name left to typo. Set an\nexplicit name to dump just that one database instead. For\nRestoreBackup, empty means \"the backup record's own database\"\n(restore in place) — always required in practice there since a\nrecord always names exactly one database."
         },
         "user": {
           "type": "string",

--- a/internal/cmd/backup_create.go
+++ b/internal/cmd/backup_create.go
@@ -19,16 +19,21 @@ var (
 
 var backupCreateCmd = &cobra.Command{
 	Use:   "create <username>",
-	Short: "Dump a container's database and store it off-host",
+	Short: "Dump a container's database(s) and store them off-host",
 	Long: `Run pg_dump inside the tenant's container and store the compressed
-dump at the chosen destination.
+dump(s) at the chosen destination.
+
+Omit --database to back up EVERY non-template database found in the
+container — the default. This is usually what you want: no need to
+already know a database name, and there's no name to get wrong. Pass
+--database to dump just that one instead.
 
 Connection defaults target a per-container local Postgres on loopback
 (user "postgres", host 127.0.0.1, port 5432). The password, if needed, is
 passed to pg_dump via PGPASSWORD inside the container — never on argv.
 
 Examples:
-  containarium backup create alice --database app --dest local --server <host>
+  containarium backup create alice --dest local --server <host>
   containarium backup create alice --database app --dest gcs \
       --gcs-bucket gs://my-backups/pg --db-password "$PGPW" --server <host>`,
 	Args: cobra.ExactArgs(1),
@@ -38,7 +43,7 @@ Examples:
 func init() {
 	backupCmd.AddCommand(backupCreateCmd)
 	f := backupCreateCmd.Flags()
-	f.StringVar(&backupCreateDatabase, "database", "", "database name to dump (required)")
+	f.StringVar(&backupCreateDatabase, "database", "", "database name to dump; omit to back up every non-template database found (default)")
 	f.StringVar(&backupCreateDest, "dest", "local", "destination: 'local' or 'gcs'")
 	f.StringVar(&backupCreateBucket, "gcs-bucket", "", "GCS bucket/prefix for --dest gcs, e.g. gs://my-backups/pg")
 	f.StringVar(&backupCreateDBUser, "db-user", "", "Postgres role (default: postgres)")
@@ -49,9 +54,6 @@ func init() {
 
 func runBackupCreate(cmd *cobra.Command, args []string) error {
 	username := args[0]
-	if backupCreateDatabase == "" {
-		return fmt.Errorf("--database is required")
-	}
 	dest, err := parseDestination(backupCreateDest)
 	if err != nil {
 		return err
@@ -66,7 +68,11 @@ func runBackupCreate(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = c.Close() }()
 
-	fmt.Printf("Backing up %s database %q to %s...\n", username, backupCreateDatabase, backupCreateDest)
+	if backupCreateDatabase == "" {
+		fmt.Printf("Backing up every database in %s to %s...\n", username, backupCreateDest)
+	} else {
+		fmt.Printf("Backing up %s database %q to %s...\n", username, backupCreateDatabase, backupCreateDest)
+	}
 	resp, err := c.CreateBackup(&pb.CreateBackupRequest{
 		Username:    username,
 		Destination: dest,
@@ -84,11 +90,14 @@ func runBackupCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("\n✓ %s\n", resp.Message)
-	if r := resp.Record; r != nil {
-		fmt.Printf("  ID:       %s\n", r.Id)
-		fmt.Printf("  Size:     %s\n", humanBytes(r.SizeBytes))
-		fmt.Printf("  SHA-256:  %s\n", r.Sha256)
-		fmt.Printf("  Location: %s\n", r.Location)
+	for _, r := range resp.Records {
+		fmt.Printf("  - %s (db: %s)\n", r.Id, r.Database)
+		fmt.Printf("      Size:     %s\n", humanBytes(r.SizeBytes))
+		fmt.Printf("      SHA-256:  %s\n", r.Sha256)
+		fmt.Printf("      Location: %s\n", r.Location)
+	}
+	for _, f := range resp.Failures {
+		fmt.Printf("  ✗ %s\n", f)
 	}
 	return nil
 }

--- a/internal/server/backup_server.go
+++ b/internal/server/backup_server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -76,13 +77,45 @@ func (s *BackupServer) CreateBackup(ctx context.Context, req *pb.CreateBackupReq
 		return nil, status.Errorf(codes.NotFound, "container for user %s not found: %v", req.Username, err)
 	}
 
-	rec, err := s.mgr.Create(backup.CreateOptions{
+	opts := backup.CreateOptions{
 		Username:      req.Username,
 		ContainerName: info.Name,
 		Conn:          connFromProto(req.Connection),
 		Destination:   dest,
 		GCSBucket:     req.GcsBucket,
-	})
+	}
+
+	// Empty database → back up every non-template database found (#954),
+	// the default, no-guessing path. An explicit database keeps today's
+	// single-database behavior and response shape exactly as before.
+	if opts.Conn.Database == "" {
+		records, errs := s.mgr.CreateAll(opts)
+		if len(records) == 0 {
+			msg := "no databases were backed up"
+			if len(errs) > 0 {
+				msg = errs[0].Error()
+			}
+			return nil, status.Errorf(codes.Internal, "backup failed: %s", msg)
+		}
+		resp := &pb.CreateBackupResponse{
+			Records: make([]*pb.BackupRecord, 0, len(records)),
+		}
+		for _, r := range records {
+			resp.Records = append(resp.Records, recordToProto(r))
+			log.Printf("[backup] created id=%s user=%s db=%s dest=%s size=%d", r.ID, r.Username, r.Database, r.Destination, r.SizeBytes)
+		}
+		for _, e := range errs {
+			resp.Failures = append(resp.Failures, e.Error())
+			log.Printf("[backup] partial failure user=%s: %v", req.Username, e)
+		}
+		resp.Message = fmt.Sprintf("backed up %d database(s)", len(records))
+		if len(errs) > 0 {
+			resp.Message += fmt.Sprintf(", %d failed", len(errs))
+		}
+		return resp, nil
+	}
+
+	rec, err := s.mgr.Create(opts)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "backup failed: %v", err)
 	}
@@ -90,6 +123,7 @@ func (s *BackupServer) CreateBackup(ctx context.Context, req *pb.CreateBackupReq
 	return &pb.CreateBackupResponse{
 		Message: "backup created: " + rec.ID,
 		Record:  recordToProto(rec),
+		Records: []*pb.BackupRecord{recordToProto(rec)},
 	}, nil
 }
 

--- a/pkg/core/backup/backup.go
+++ b/pkg/core/backup/backup.go
@@ -242,6 +242,73 @@ func (m *Manager) Create(opts CreateOptions) (*Record, error) {
 	return record, nil
 }
 
+// ListDatabases enumerates the non-template databases visible inside the
+// container's Postgres — the same connection info used for pg_dump/
+// pg_restore, just pointed at the always-present "postgres" maintenance
+// database to run a catalog query instead of a dump. Used by CreateAll so
+// a backup never requires the caller to already know a database name (#954).
+func (m *Manager) ListDatabases(containerName string, conn PgConn) ([]string, error) {
+	conn = conn.withDefaults()
+	if containerName == "" {
+		return nil, fmt.Errorf("container name is required")
+	}
+	const query = "SELECT datname FROM pg_database WHERE NOT datistemplate ORDER BY datname;"
+	script := fmt.Sprintf(
+		"psql -h %s -p %d -U %s -d postgres -Atc %s",
+		shellQuote(conn.Host), conn.Port, shellQuote(conn.User), shellQuote(query),
+	)
+	stdout, stderr, err := m.ops.ExecWithOutput(containerName, wrapPg(conn.Password, script))
+	if err != nil {
+		return nil, fmt.Errorf("list databases: %w: %s", err, strings.TrimSpace(stderr))
+	}
+	var dbs []string
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			dbs = append(dbs, line)
+		}
+	}
+	return dbs, nil
+}
+
+// CreateAll backs up every non-template database in the container — the
+// default, no-guessing path (#954): the caller doesn't need to already
+// know a database name, and a scheduled backup can't fail because of a
+// typo'd one, since no name is ever supplied. opts.Conn.Database is
+// ignored (overwritten per database); every other CreateOptions field
+// (container, destination, credentials) applies to each dump the same way
+// a single Create call would.
+//
+// Reuses Create as-is per database rather than duplicating its dump/stage/
+// upload logic, so the two paths can never drift. One failing database
+// doesn't abort the others — errs collects a per-database failure
+// alongside the record for every database that DID succeed, so a caller
+// can surface "7 of 8 databases backed up, orders_db failed: <reason>"
+// instead of an all-or-nothing result.
+func (m *Manager) CreateAll(opts CreateOptions) ([]*Record, []error) {
+	dbs, err := m.ListDatabases(opts.ContainerName, opts.Conn)
+	if err != nil {
+		return nil, []error{fmt.Errorf("list databases: %w", err)}
+	}
+	if len(dbs) == 0 {
+		return nil, []error{fmt.Errorf("no databases found to back up")}
+	}
+
+	var records []*Record
+	var errs []error
+	for _, db := range dbs {
+		o := opts
+		o.Conn.Database = db
+		r, err := m.Create(o)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("database %q: %w", db, err))
+			continue
+		}
+		records = append(records, r)
+	}
+	return records, errs
+}
+
 // List returns stored records, newest first, optionally filtered by
 // tenant.
 func (m *Manager) List(username string) ([]*Record, error) {

--- a/pkg/core/backup/backup_test.go
+++ b/pkg/core/backup/backup_test.go
@@ -16,6 +16,17 @@ type fakeOps struct {
 	written     map[string][]byte // in-container path -> content (restore)
 	execLog     []string
 	failExec    bool
+
+	// listDatabasesOut, when set, is returned verbatim as stdout for a
+	// `psql ... -Atc` listing call (ListDatabases); listDatabasesErr, when
+	// set, makes that call fail instead. Dump/restore calls are
+	// unaffected by either field.
+	listDatabasesOut string
+	listDatabasesErr error
+	// failDatabases, when set, makes Create's own pg_dump step fail only
+	// for these specific database names — lets tests exercise CreateAll's
+	// partial-failure path without failing every database.
+	failDatabases map[string]bool
 }
 
 func newFakeOps(payload []byte) *fakeOps {
@@ -29,6 +40,18 @@ func (f *fakeOps) Exec(container string, command []string) error {
 
 func (f *fakeOps) ExecWithOutput(container string, command []string) (string, string, error) {
 	f.execLog = append(f.execLog, strings.Join(command, " "))
+	full := strings.Join(command, " ")
+	if strings.Contains(full, "psql") && strings.Contains(full, "-Atc") {
+		if f.listDatabasesErr != nil {
+			return "", "connection refused", f.listDatabasesErr
+		}
+		return f.listDatabasesOut, "", nil
+	}
+	for db := range f.failDatabases {
+		if strings.Contains(full, "-d '"+db+"'") {
+			return "", "FATAL: database \"" + db + "\" does not exist", errExec
+		}
+	}
 	if f.failExec {
 		return "", "FATAL: database \"missing\" does not exist", errExec
 	}
@@ -347,4 +370,148 @@ func (f *fakeUploader) Delete(destURI string) error {
 	delete(f.blobs, destURI)
 	delete(f.uploaded, destURI)
 	return nil
+}
+
+func TestListDatabases(t *testing.T) {
+	ops := newFakeOps([]byte("payload"))
+	ops.listDatabasesOut = "postgres\napp_production\nanalytics\n"
+	m := newTestManager(t, ops)
+
+	dbs, err := m.ListDatabases("alice-container", PgConn{})
+	if err != nil {
+		t.Fatalf("ListDatabases: %v", err)
+	}
+	want := []string{"postgres", "app_production", "analytics"}
+	if len(dbs) != len(want) {
+		t.Fatalf("got %v, want %v", dbs, want)
+	}
+	for i, w := range want {
+		if dbs[i] != w {
+			t.Errorf("dbs[%d] = %q, want %q", i, dbs[i], w)
+		}
+	}
+}
+
+func TestListDatabases_EmptyOutput(t *testing.T) {
+	ops := newFakeOps([]byte("payload"))
+	ops.listDatabasesOut = ""
+	m := newTestManager(t, ops)
+
+	dbs, err := m.ListDatabases("alice-container", PgConn{})
+	if err != nil {
+		t.Fatalf("ListDatabases: %v", err)
+	}
+	if len(dbs) != 0 {
+		t.Errorf("got %v, want empty", dbs)
+	}
+}
+
+func TestListDatabases_ExecFails(t *testing.T) {
+	ops := newFakeOps([]byte("payload"))
+	ops.listDatabasesErr = errExec
+	m := newTestManager(t, ops)
+
+	if _, err := m.ListDatabases("alice-container", PgConn{}); err == nil {
+		t.Fatal("expected an error")
+	}
+}
+
+// TestCreateAll_BacksUpEveryDatabase pins #954's core behavior: no database
+// name is supplied by the caller — CreateAll discovers and backs up every
+// one found, producing one Record per database (same shape a single Create
+// call already produces, just looped).
+func TestCreateAll_BacksUpEveryDatabase(t *testing.T) {
+	ops := newFakeOps([]byte("PGDMP-fake-archive-bytes"))
+	ops.listDatabasesOut = "app_production\nanalytics\n"
+	m := newTestManager(t, ops)
+
+	records, errs := m.CreateAll(CreateOptions{
+		Username:      "alice",
+		ContainerName: "alice-container",
+		Destination:   DestLocal,
+	})
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(records) != 2 {
+		t.Fatalf("got %d records, want 2", len(records))
+	}
+	gotDBs := map[string]bool{}
+	for _, r := range records {
+		gotDBs[r.Database] = true
+	}
+	if !gotDBs["app_production"] || !gotDBs["analytics"] {
+		t.Errorf("records = %+v, want app_production and analytics", records)
+	}
+
+	// Each database's record is independently listable/gettable, same as
+	// today's single-database Create — CreateAll doesn't change storage
+	// shape, just how many Creates happen per call.
+	listed, err := m.List("alice")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(listed) != 2 {
+		t.Errorf("List returned %d records, want 2", len(listed))
+	}
+}
+
+// TestCreateAll_PartialFailureStillBacksUpTheRest pins the resilience
+// property: one database failing pg_dump must not abort the others.
+func TestCreateAll_PartialFailureStillBacksUpTheRest(t *testing.T) {
+	ops := newFakeOps([]byte("PGDMP-fake-archive-bytes"))
+	ops.listDatabasesOut = "app_production\nbroken_db\nanalytics\n"
+	ops.failDatabases = map[string]bool{"broken_db": true}
+	m := newTestManager(t, ops)
+
+	records, errs := m.CreateAll(CreateOptions{
+		Username:      "alice",
+		ContainerName: "alice-container",
+		Destination:   DestLocal,
+	})
+	if len(records) != 2 {
+		t.Fatalf("got %d records, want 2 (broken_db should be the only failure)", len(records))
+	}
+	if len(errs) != 1 {
+		t.Fatalf("got %d errors, want 1", len(errs))
+	}
+	if !strings.Contains(errs[0].Error(), "broken_db") {
+		t.Errorf("error %q doesn't name the failing database", errs[0].Error())
+	}
+}
+
+func TestCreateAll_NoDatabasesFound(t *testing.T) {
+	ops := newFakeOps([]byte("payload"))
+	ops.listDatabasesOut = ""
+	m := newTestManager(t, ops)
+
+	records, errs := m.CreateAll(CreateOptions{
+		Username:      "alice",
+		ContainerName: "alice-container",
+		Destination:   DestLocal,
+	})
+	if len(records) != 0 {
+		t.Errorf("got %d records, want 0", len(records))
+	}
+	if len(errs) != 1 {
+		t.Fatalf("got %d errors, want 1", len(errs))
+	}
+}
+
+func TestCreateAll_ListDatabasesFails(t *testing.T) {
+	ops := newFakeOps([]byte("payload"))
+	ops.listDatabasesErr = errExec
+	m := newTestManager(t, ops)
+
+	records, errs := m.CreateAll(CreateOptions{
+		Username:      "alice",
+		ContainerName: "alice-container",
+		Destination:   DestLocal,
+	})
+	if len(records) != 0 {
+		t.Errorf("got %d records, want 0", len(records))
+	}
+	if len(errs) != 1 {
+		t.Fatalf("got %d errors, want 1", len(errs))
+	}
 }

--- a/pkg/pb/containarium/v1/backup.pb.go
+++ b/pkg/pb/containarium/v1/backup.pb.go
@@ -213,7 +213,14 @@ func (x *BackupRecord) GetEngine() string {
 // child process via the PGPASSWORD environment variable, not argv.
 type PgConnection struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Logical database to dump or restore into. Required.
+	// Logical database to dump or restore into. For CreateBackup, leave
+	// empty to back up EVERY non-template database in the container (#954)
+	// — the default, no-guessing path; a caller doesn't need to already
+	// know a database name, and there's no name left to typo. Set an
+	// explicit name to dump just that one database instead. For
+	// RestoreBackup, empty means "the backup record's own database"
+	// (restore in place) — always required in practice there since a
+	// record always names exactly one database.
 	Database string `protobuf:"bytes,1,opt,name=database,proto3" json:"database,omitempty"`
 	// Postgres role. Defaults to "postgres" when empty.
 	User string `protobuf:"bytes,2,opt,name=user,proto3" json:"user,omitempty"`
@@ -299,7 +306,9 @@ type CreateBackupRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Tenant (username) whose container holds the database.
 	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
-	// Connection parameters for pg_dump inside the container.
+	// Connection parameters for pg_dump inside the container. Leave
+	// connection.database empty to back up every non-template database
+	// found (#954, the default); set it to back up just that one.
 	Connection *PgConnection `protobuf:"bytes,2,opt,name=connection,proto3" json:"connection,omitempty"`
 	// Where to store the dump.
 	Destination BackupDestination `protobuf:"varint,3,opt,name=destination,proto3,enum=containarium.v1.BackupDestination" json:"destination,omitempty"`
@@ -372,8 +381,21 @@ type CreateBackupResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Operator-facing summary.
 	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
-	// The committed backup record.
-	Record        *BackupRecord `protobuf:"bytes,2,opt,name=record,proto3" json:"record,omitempty"`
+	// The committed backup record. Populated only when connection.database
+	// named exactly one database (single-database create, back-compat
+	// shape). For a "back up all" create (connection.database empty),
+	// this is unset — use records instead.
+	Record *BackupRecord `protobuf:"bytes,2,opt,name=record,proto3" json:"record,omitempty"`
+	// Every committed backup record from this call. Always populated:
+	// one entry for a single-database create (mirrors record above), or
+	// one entry per database for a "back up all" create (#954).
+	Records []*BackupRecord `protobuf:"bytes,3,rep,name=records,proto3" json:"records,omitempty"`
+	// Per-database failures from a "back up all" create — a database that
+	// failed to dump (e.g. transient pg_dump error) does not abort the
+	// others; its failure is reported here instead. Always empty for a
+	// single-database create (that path fails the whole RPC on error, as
+	// before).
+	Failures      []string `protobuf:"bytes,4,rep,name=failures,proto3" json:"failures,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -418,6 +440,20 @@ func (x *CreateBackupResponse) GetMessage() string {
 func (x *CreateBackupResponse) GetRecord() *BackupRecord {
 	if x != nil {
 		return x.Record
+	}
+	return nil
+}
+
+func (x *CreateBackupResponse) GetRecords() []*BackupRecord {
+	if x != nil {
+		return x.Records
+	}
+	return nil
+}
+
+func (x *CreateBackupResponse) GetFailures() []string {
+	if x != nil {
+		return x.Failures
 	}
 	return nil
 }
@@ -835,10 +871,12 @@ const file_containarium_v1_backup_proto_rawDesc = "" +
 	"connection\x12D\n" +
 	"\vdestination\x18\x03 \x01(\x0e2\".containarium.v1.BackupDestinationR\vdestination\x12\x1d\n" +
 	"\n" +
-	"gcs_bucket\x18\x04 \x01(\tR\tgcsBucket\"g\n" +
+	"gcs_bucket\x18\x04 \x01(\tR\tgcsBucket\"\xbc\x01\n" +
 	"\x14CreateBackupResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x125\n" +
-	"\x06record\x18\x02 \x01(\v2\x1d.containarium.v1.BackupRecordR\x06record\"0\n" +
+	"\x06record\x18\x02 \x01(\v2\x1d.containarium.v1.BackupRecordR\x06record\x127\n" +
+	"\arecords\x18\x03 \x03(\v2\x1d.containarium.v1.BackupRecordR\arecords\x12\x1a\n" +
+	"\bfailures\x18\x04 \x03(\tR\bfailures\"0\n" +
 	"\x12ListBackupsRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\"N\n" +
 	"\x13ListBackupsResponse\x127\n" +
@@ -862,10 +900,11 @@ const file_containarium_v1_backup_proto_rawDesc = "" +
 	"\x11BackupDestination\x12\"\n" +
 	"\x1eBACKUP_DESTINATION_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18BACKUP_DESTINATION_LOCAL\x10\x01\x12\x1a\n" +
-	"\x16BACKUP_DESTINATION_GCS\x10\x022\xb3\t\n" +
-	"\rBackupService\x12\x90\x02\n" +
-	"\fCreateBackup\x12$.containarium.v1.CreateBackupRequest\x1a%.containarium.v1.CreateBackupResponse\"\xb2\x01\x92A\x98\x01\n" +
-	"\aBackups\x12\x0fCreate a backup\x1a|Runs pg_dump inside the tenant's container and stores the dump at the chosen off-host destination (local backup dir or GCS).\x82\xd3\xe4\x93\x02\x10:\x01*\"\v/v1/backups\x12\xd3\x01\n" +
+	"\x16BACKUP_DESTINATION_GCS\x10\x022\x9e\n" +
+	"\n" +
+	"\rBackupService\x12\xfb\x02\n" +
+	"\fCreateBackup\x12$.containarium.v1.CreateBackupRequest\x1a%.containarium.v1.CreateBackupResponse\"\x9d\x02\x92A\x83\x02\n" +
+	"\aBackups\x12\x0fCreate a backup\x1a\xe6\x01Runs pg_dump inside the tenant's container and stores the dump at the chosen off-host destination (local backup dir or GCS). Leave connection.database empty to back up every non-template database found; set it to back up just one.\x82\xd3\xe4\x93\x02\x10:\x01*\"\v/v1/backups\x12\xd3\x01\n" +
 	"\vListBackups\x12#.containarium.v1.ListBackupsRequest\x1a$.containarium.v1.ListBackupsResponse\"y\x92Ac\n" +
 	"\aBackups\x12\fList backups\x1aJLists stored backup records (newest first), optionally filtered by tenant.\x82\xd3\xe4\x93\x02\r\x12\v/v1/backups\x12\xb8\x01\n" +
 	"\tGetBackup\x12!.containarium.v1.GetBackupRequest\x1a\".containarium.v1.GetBackupResponse\"d\x92AI\n" +
@@ -909,24 +948,25 @@ var file_containarium_v1_backup_proto_depIdxs = []int32{
 	2,  // 1: containarium.v1.CreateBackupRequest.connection:type_name -> containarium.v1.PgConnection
 	0,  // 2: containarium.v1.CreateBackupRequest.destination:type_name -> containarium.v1.BackupDestination
 	1,  // 3: containarium.v1.CreateBackupResponse.record:type_name -> containarium.v1.BackupRecord
-	1,  // 4: containarium.v1.ListBackupsResponse.records:type_name -> containarium.v1.BackupRecord
-	1,  // 5: containarium.v1.GetBackupResponse.record:type_name -> containarium.v1.BackupRecord
-	2,  // 6: containarium.v1.RestoreBackupRequest.connection:type_name -> containarium.v1.PgConnection
-	3,  // 7: containarium.v1.BackupService.CreateBackup:input_type -> containarium.v1.CreateBackupRequest
-	5,  // 8: containarium.v1.BackupService.ListBackups:input_type -> containarium.v1.ListBackupsRequest
-	7,  // 9: containarium.v1.BackupService.GetBackup:input_type -> containarium.v1.GetBackupRequest
-	9,  // 10: containarium.v1.BackupService.RestoreBackup:input_type -> containarium.v1.RestoreBackupRequest
-	11, // 11: containarium.v1.BackupService.DeleteBackup:input_type -> containarium.v1.DeleteBackupRequest
-	4,  // 12: containarium.v1.BackupService.CreateBackup:output_type -> containarium.v1.CreateBackupResponse
-	6,  // 13: containarium.v1.BackupService.ListBackups:output_type -> containarium.v1.ListBackupsResponse
-	8,  // 14: containarium.v1.BackupService.GetBackup:output_type -> containarium.v1.GetBackupResponse
-	10, // 15: containarium.v1.BackupService.RestoreBackup:output_type -> containarium.v1.RestoreBackupResponse
-	12, // 16: containarium.v1.BackupService.DeleteBackup:output_type -> containarium.v1.DeleteBackupResponse
-	12, // [12:17] is the sub-list for method output_type
-	7,  // [7:12] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	1,  // 4: containarium.v1.CreateBackupResponse.records:type_name -> containarium.v1.BackupRecord
+	1,  // 5: containarium.v1.ListBackupsResponse.records:type_name -> containarium.v1.BackupRecord
+	1,  // 6: containarium.v1.GetBackupResponse.record:type_name -> containarium.v1.BackupRecord
+	2,  // 7: containarium.v1.RestoreBackupRequest.connection:type_name -> containarium.v1.PgConnection
+	3,  // 8: containarium.v1.BackupService.CreateBackup:input_type -> containarium.v1.CreateBackupRequest
+	5,  // 9: containarium.v1.BackupService.ListBackups:input_type -> containarium.v1.ListBackupsRequest
+	7,  // 10: containarium.v1.BackupService.GetBackup:input_type -> containarium.v1.GetBackupRequest
+	9,  // 11: containarium.v1.BackupService.RestoreBackup:input_type -> containarium.v1.RestoreBackupRequest
+	11, // 12: containarium.v1.BackupService.DeleteBackup:input_type -> containarium.v1.DeleteBackupRequest
+	4,  // 13: containarium.v1.BackupService.CreateBackup:output_type -> containarium.v1.CreateBackupResponse
+	6,  // 14: containarium.v1.BackupService.ListBackups:output_type -> containarium.v1.ListBackupsResponse
+	8,  // 15: containarium.v1.BackupService.GetBackup:output_type -> containarium.v1.GetBackupResponse
+	10, // 16: containarium.v1.BackupService.RestoreBackup:output_type -> containarium.v1.RestoreBackupResponse
+	12, // 17: containarium.v1.BackupService.DeleteBackup:output_type -> containarium.v1.DeleteBackupResponse
+	13, // [13:18] is the sub-list for method output_type
+	8,  // [8:13] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_backup_proto_init() }

--- a/proto/containarium/v1/backup.proto
+++ b/proto/containarium/v1/backup.proto
@@ -67,7 +67,14 @@ message BackupRecord {
 // reached over loopback. db_password is never logged and is passed to the
 // child process via the PGPASSWORD environment variable, not argv.
 message PgConnection {
-  // Logical database to dump or restore into. Required.
+  // Logical database to dump or restore into. For CreateBackup, leave
+  // empty to back up EVERY non-template database in the container (#954)
+  // — the default, no-guessing path; a caller doesn't need to already
+  // know a database name, and there's no name left to typo. Set an
+  // explicit name to dump just that one database instead. For
+  // RestoreBackup, empty means "the backup record's own database"
+  // (restore in place) — always required in practice there since a
+  // record always names exactly one database.
   string database = 1;
 
   // Postgres role. Defaults to "postgres" when empty.
@@ -90,7 +97,9 @@ message CreateBackupRequest {
   // Tenant (username) whose container holds the database.
   string username = 1;
 
-  // Connection parameters for pg_dump inside the container.
+  // Connection parameters for pg_dump inside the container. Leave
+  // connection.database empty to back up every non-template database
+  // found (#954, the default); set it to back up just that one.
   PgConnection connection = 2;
 
   // Where to store the dump.
@@ -105,8 +114,23 @@ message CreateBackupResponse {
   // Operator-facing summary.
   string message = 1;
 
-  // The committed backup record.
+  // The committed backup record. Populated only when connection.database
+  // named exactly one database (single-database create, back-compat
+  // shape). For a "back up all" create (connection.database empty),
+  // this is unset — use records instead.
   BackupRecord record = 2;
+
+  // Every committed backup record from this call. Always populated:
+  // one entry for a single-database create (mirrors record above), or
+  // one entry per database for a "back up all" create (#954).
+  repeated BackupRecord records = 3;
+
+  // Per-database failures from a "back up all" create — a database that
+  // failed to dump (e.g. transient pg_dump error) does not abort the
+  // others; its failure is reported here instead. Always empty for a
+  // single-database create (that path fails the whole RPC on error, as
+  // before).
+  repeated string failures = 4;
 }
 
 // ListBackupsRequest enumerates stored backups, newest first.
@@ -173,7 +197,7 @@ service BackupService {
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Create a backup";
-      description: "Runs pg_dump inside the tenant's container and stores the dump at the chosen off-host destination (local backup dir or GCS).";
+      description: "Runs pg_dump inside the tenant's container and stores the dump at the chosen off-host destination (local backup dir or GCS). Leave connection.database empty to back up every non-template database found; set it to back up just one.";
       tags: "Backups";
     };
   }


### PR DESCRIPTION
## Summary

Fixes #954. Setting up a backup required typing the exact database name into a free-text field — most users don't know it offhand, and there was no validation anywhere in the pipeline (webui → cloud API → OSS daemon → `pg_dump`), so a typo just failed deep inside the exec call with a cryptic error. Worse, scheduled backups with a bad name failed silently forever with no notification.

This removes the need to know a name at all.

## Change

When `connection.database` is left empty (the new default), the daemon:
1. Enumerates every non-template database via a new `Manager.ListDatabases` — reuses the exact same container-exec plumbing `pg_dump` itself already uses, just runs a `psql -Atc "SELECT datname FROM pg_database WHERE NOT datistemplate"` instead of a dump.
2. Loops `pg_dump -Fc` over each one via a new `Manager.CreateAll` — same per-database custom-format dump mechanism as today, just applied to everything instead of one name. One database failing doesn't abort the others.

An explicit `--database`/`connection.database` still works exactly as before (single-database create, unchanged response shape).

## Wire changes

`CreateBackupResponse` gains:
- `records` (always populated: one entry per database, mirrors `record` for the single-database case)
- `failures` (per-database error strings from a back-up-all call; always empty for a single-database create)

`record` (singular) stays populated only for the single-database path — back-compat for existing callers.

## Test plan

- [x] `go build ./...`
- [x] New tests: `TestListDatabases*`, `TestCreateAll_BacksUpEveryDatabase`, `TestCreateAll_PartialFailureStillBacksUpTheRest`, `TestCreateAll_NoDatabasesFound`, `TestCreateAll_ListDatabasesFails`
- [x] `go test ./pkg/core/backup/... ./internal/server/... ./internal/cmd/...` — all pass
- [x] `go test ./...` — no regressions (2 pre-existing integration-test failures needing a live daemon on `localhost:50051`, unrelated)
- [x] `make proto` regenerated cleanly, no manual edits to generated files

## Follow-up (cloud repo)

The cloud API/scheduler/webui side (proto passthrough, `BackupsSection.tsx`'s free-text field removal) is tracked as a follow-up PR in `Containarium-cloud`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)