### PR TITLE
chore(release): cut v0.51.3 — back up every database automatically (#954)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.3] - 2026-07-14
+
+### Added
+
+- **Backups: back up every database automatically, don't require a
+  name** (#954). Setting up a backup required typing the exact
+  database name — most users don't know it offhand, and no layer
+  validated it, so a typo just failed deep inside `pg_dump` with a
+  cryptic error; a scheduled backup with a bad name failed silently
+  forever with no notification. When `connection.database` is left
+  empty (the new default), the daemon enumerates every non-template
+  database (`Manager.ListDatabases`, reusing the same container-exec
+  plumbing `pg_dump` itself uses) and backs up each one
+  (`Manager.CreateAll`) — one database failing doesn't abort the
+  others. An explicit database still works exactly as before.
+  `CreateBackupResponse` gains `records` (always populated) and
+  `failures` (per-database errors) alongside the existing `record`
+  field.
+
 ## [0.51.2] - 2026-07-14
 
 ### Fixed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.51.2"
+	Version = "0.51.3"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary
Cuts v0.51.3, shipping #955 (back up every database automatically instead of requiring a name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)