### PR TITLE
fix(cloud): rebuild host bearer from returned host id on re-enroll

### DIFF
--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -272,22 +272,34 @@ type EnrollOptions struct {
 	OSSBackendID string
 }
 
-// Enroll redeems a single-use join token against the control plane and returns
-// the registered host id. One-shot (no running client / host bearer yet — the
-// token authenticates itself in the body). Used by `containarium cloud enroll`
-// for the BYO self-service flow; after this, the same token is the host's
-// durable bearer (the cloud reuses the token secret as the host bearer).
+// Enroll redeems a single-use join token against the control plane and
+// returns the registered host id plus the durable host bearer to persist.
+// One-shot (no running client / host bearer yet — the token authenticates
+// itself in the body). Used by `containarium cloud enroll` for the BYO
+// self-service flow.
+//
+// On a FIRST enroll, the returned host id matches the join token's own
+// embedded host_id, so the bearer is (coincidentally) the join token itself.
+// On a RE-enroll (cloud #572, an existing host row matched by oss_backend_id),
+// the cloud updates the EXISTING row's bearer hash but returns that row's own,
+// different id — the join token's embedded host_id was only ever a throwaway,
+// never itself created as a host row. Persisting the raw join token in that
+// case produces a bearer whose embedded host_id resolves to nothing, and
+// every subsequent heartbeat/status call permanently 401s. bearerToken is
+// therefore always reconstructed as "<returned host id>.<token's secret
+// half>" rather than returning the raw joinToken — correct in both cases,
+// and a no-op string-rebuild on first enroll.
 //
 // opts optionally carries the BYOC driver token + backend id (cloud #554) so a
 // tunnel-joined host becomes cloud-drivable in the same round-trip.
-func Enroll(ctx context.Context, controlPlane, joinToken string, insecureTLS bool, opts EnrollOptions) (string, error) {
+func Enroll(ctx context.Context, controlPlane, joinToken string, insecureTLS bool, opts EnrollOptions) (hostID, bearerToken string, err error) {
 	// REST control plane (#722): redeem over grpc-gateway instead of gRPC.
 	if isRESTControlPlane(controlPlane) {
 		return enrollREST(ctx, controlPlane, joinToken, opts)
 	}
 	conn, err := dialControlPlane(controlPlane, insecureTLS)
 	if err != nil {
-		return "", fmt.Errorf("cloud: dial control plane %s: %w", controlPlane, err)
+		return "", "", fmt.Errorf("cloud: dial control plane %s: %w", controlPlane, err)
 	}
 	defer func() { _ = conn.Close() }()
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
@@ -298,9 +310,24 @@ func Enroll(ctx context.Context, controlPlane, joinToken string, insecureTLS boo
 		OssBackendId: opts.OSSBackendID,
 	})
 	if err != nil {
-		return "", fmt.Errorf("cloud: enroll: %w", err)
+		return "", "", fmt.Errorf("cloud: enroll: %w", err)
 	}
-	return resp.GetHostId(), nil
+	return resp.GetHostId(), rebuildBearer(resp.GetHostId(), joinToken), nil
+}
+
+// rebuildBearer reconstructs a "<hostID>.<secret>" host bearer from a freshly
+// enrolled/re-enrolled host id and the join token presented to redeem it. The
+// join token is itself "<throwaway host_id>.<secret>" — only the secret half
+// is reused; the durable bearer's host_id is always the id the cloud actually
+// returned. Falls back to the raw joinToken if it isn't in the expected
+// "<id>.<secret>" shape (defensive; the server would already have rejected a
+// malformed token before responding).
+func rebuildBearer(hostID, joinToken string) string {
+	_, secret, ok := strings.Cut(joinToken, ".")
+	if !ok || secret == "" {
+		return joinToken
+	}
+	return hostID + "." + secret
 }
 
 // statusLoop reports the host's capability profile + self-check on the same

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -26,7 +26,11 @@ type fakeActuation struct {
 	enrollHostID    string
 	enrollDriverTok string
 	enrollBackendID string
-	statusBearer    string
+	// enrollHostIDOverride, when set, makes EnrollHost return this id instead
+	// of the join token's own embedded id — simulating a cloud #572 re-enroll,
+	// where the cloud resolves to a pre-existing host row with a different id.
+	enrollHostIDOverride string
+	statusBearer         string
 	statusReq       *cloudv1.ReportHostStatusRequest
 	statusReports   int
 }
@@ -42,6 +46,9 @@ func (f *fakeActuation) EnrollHost(_ context.Context, req *cloudv1.EnrollHostReq
 	id := req.GetJoinToken()
 	if i := indexByte(id, '.'); i >= 0 {
 		id = id[:i]
+	}
+	if f.enrollHostIDOverride != "" {
+		id = f.enrollHostIDOverride
 	}
 	f.enrollHostID = id
 	return &cloudv1.EnrollHostResponse{HostId: id}, nil
@@ -386,13 +393,16 @@ func TestEnroll_RedeemsTokenAndReturnsHostID(t *testing.T) {
 	go func() { _ = srv.Serve(lis) }()
 	t.Cleanup(srv.Stop)
 
-	hostID, err := Enroll(context.Background(), lis.Addr().String(), "host-uuid.secret", true,
+	hostID, bearer, err := Enroll(context.Background(), lis.Addr().String(), "host-uuid.secret", true,
 		EnrollOptions{DriverToken: "admin.jwt.tok", OSSBackendID: "tunnel-gpu-1"})
 	if err != nil {
 		t.Fatalf("Enroll: %v", err)
 	}
 	if hostID != "host-uuid" {
 		t.Errorf("want host id host-uuid, got %q", hostID)
+	}
+	if bearer != "host-uuid.secret" {
+		t.Errorf("want bearer host-uuid.secret, got %q", bearer)
 	}
 	fake.mu.Lock()
 	defer fake.mu.Unlock()
@@ -404,6 +414,35 @@ func TestEnroll_RedeemsTokenAndReturnsHostID(t *testing.T) {
 	}
 	if fake.enrollBackendID != "tunnel-gpu-1" {
 		t.Errorf("server saw backend id %q", fake.enrollBackendID)
+	}
+}
+
+// TestEnroll_ReEnrollRebuildsBearerFromReturnedHostID pins the cloud #572
+// re-enroll case over gRPC (mirrors TestEnrollREST_ReEnroll for the REST
+// transport): the server resolves the join token to an EXISTING host row
+// whose id differs from the token's own embedded (throwaway) id. The
+// persisted bearer must be rebuilt from the RETURNED id, or every subsequent
+// heartbeat 401s forever.
+func TestEnroll_ReEnrollRebuildsBearerFromReturnedHostID(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	fake := &fakeActuation{enrollHostIDOverride: "existing-host-999"}
+	cloudv1.RegisterActuationServiceServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	hostID, bearer, err := Enroll(context.Background(), lis.Addr().String(), "throwaway-host-123.secret", true, EnrollOptions{})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if hostID != "existing-host-999" {
+		t.Errorf("want host id existing-host-999, got %q", hostID)
+	}
+	if bearer != "existing-host-999.secret" {
+		t.Errorf("want bearer rebuilt from the returned id (existing-host-999.secret), got %q", bearer)
 	}
 }
 

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -31,8 +31,8 @@ type fakeActuation struct {
 	// where the cloud resolves to a pre-existing host row with a different id.
 	enrollHostIDOverride string
 	statusBearer         string
-	statusReq       *cloudv1.ReportHostStatusRequest
-	statusReports   int
+	statusReq            *cloudv1.ReportHostStatusRequest
+	statusReports        int
 }
 
 // EnrollHost echoes back the host id embedded in the join token (first

--- a/internal/cloud/rest.go
+++ b/internal/cloud/rest.go
@@ -113,19 +113,20 @@ func (r *restActuation) post(ctx context.Context, path string, in, out proto.Mes
 }
 
 // enrollREST redeems a join token over REST (POST /v1/actuation/enroll). The
-// join token self-authenticates in the body, so no host bearer is sent.
-func enrollREST(ctx context.Context, controlPlane, joinToken string, opts EnrollOptions) (string, error) {
+// join token self-authenticates in the body, so no host bearer is sent. See
+// Enroll's doc comment for why the returned bearer is rebuilt rather than the
+// raw joinToken being reused verbatim.
+func enrollREST(ctx context.Context, controlPlane, joinToken string, opts EnrollOptions) (hostID, bearerToken string, err error) {
 	r := newRESTActuation(controlPlane, "")
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	var resp cloudv1.EnrollHostResponse
-	err := r.post(ctx, "/v1/actuation/enroll", &cloudv1.EnrollHostRequest{
+	if err := r.post(ctx, "/v1/actuation/enroll", &cloudv1.EnrollHostRequest{
 		JoinToken:    joinToken,
 		DriverToken:  opts.DriverToken,
 		OssBackendId: opts.OSSBackendID,
-	}, &resp)
-	if err != nil {
-		return "", fmt.Errorf("cloud: enroll (REST): %w", err)
+	}, &resp); err != nil {
+		return "", "", fmt.Errorf("cloud: enroll (REST): %w", err)
 	}
-	return resp.GetHostId(), nil
+	return resp.GetHostId(), rebuildBearer(resp.GetHostId(), joinToken), nil
 }

--- a/internal/cloud/rest_test.go
+++ b/internal/cloud/rest_test.go
@@ -78,7 +78,7 @@ func TestEnrollREST(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	id, err := enrollREST(context.Background(), srv.URL, "host-123.secret",
+	id, bearer, err := enrollREST(context.Background(), srv.URL, "host-123.secret",
 		EnrollOptions{DriverToken: "admin.jwt", OSSBackendID: "tunnel-fts-13700k"})
 	if err != nil {
 		t.Fatalf("enrollREST: %v", err)
@@ -86,7 +86,35 @@ func TestEnrollREST(t *testing.T) {
 	if id != "host-123" {
 		t.Errorf("host id = %q, want host-123", id)
 	}
+	if bearer != "host-123.secret" {
+		t.Errorf("bearer = %q, want host-123.secret (first enroll: response id matches the token's own id)", bearer)
+	}
 	if got.GetJoinToken() != "host-123.secret" || got.GetDriverToken() != "admin.jwt" || got.GetOssBackendId() != "tunnel-fts-13700k" {
 		t.Errorf("server saw join=%q driver=%q backend=%q", got.GetJoinToken(), got.GetDriverToken(), got.GetOssBackendId())
+	}
+}
+
+// TestEnrollREST_ReEnroll pins the cloud #572 re-enroll case: the cloud
+// resolves the join token to an EXISTING host row (matched on oss_backend_id)
+// whose id differs from the throwaway id embedded in the join token itself.
+// The bearer persisted client-side must use the RETURNED host id, not the
+// token's own id — otherwise every heartbeat after a re-enroll 401s forever
+// (the throwaway id was never created as an actual host row).
+func TestEnrollREST_ReEnroll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"hostId":"existing-host-999"}`))
+	}))
+	defer srv.Close()
+
+	id, bearer, err := enrollREST(context.Background(), srv.URL, "throwaway-host-123.secret", EnrollOptions{})
+	if err != nil {
+		t.Fatalf("enrollREST: %v", err)
+	}
+	if id != "existing-host-999" {
+		t.Errorf("host id = %q, want existing-host-999", id)
+	}
+	if bearer != "existing-host-999.secret" {
+		t.Errorf("bearer = %q, want existing-host-999.secret (rebuilt from the returned id, not the token's own throwaway id)", bearer)
 	}
 }

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -183,14 +183,14 @@ func runCloudEnroll(cmd *cobra.Command, _ []string) error {
 	// Redeem the join token against the control plane. On success the cloud
 	// has created the host row and returns its id; the same token is now this
 	// host's durable bearer (the cloud reuses the token secret).
-	hostID, err := cloud.Enroll(cmd.Context(), controlPlane, token, cloudEnrollInsecure, opts)
+	hostID, bearer, err := cloud.Enroll(cmd.Context(), controlPlane, token, cloudEnrollInsecure, opts)
 	if err != nil {
 		return err
 	}
 	cfg := &cloud.Config{
 		ControlPlane: controlPlane,
 		HostID:       hostID,
-		Token:        token,
+		Token:        bearer,
 		Insecure:     cloudEnrollInsecure,
 		// Persist the JWT secret path so the daemon can re-mint the driver
 		// token autonomously before it expires (#557). Only set when the

--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -452,14 +452,14 @@ func cloudEnrollAfterPoolJoin(cmd *cobra.Command, controlPlane, token, ossBacken
 		opts.DriverToken = driverTok
 	}
 
-	hostID, err := cloud.Enroll(cmd.Context(), controlPlane, token, insecure, opts)
+	hostID, bearer, err := cloud.Enroll(cmd.Context(), controlPlane, token, insecure, opts)
 	if err != nil {
 		return err
 	}
 	cfg := &cloud.Config{
 		ControlPlane: controlPlane,
 		HostID:       hostID,
-		Token:        token,
+		Token:        bearer,
 		Insecure:     insecure,
 		JWTSecretFile: func() string {
 			if opts.DriverToken == "" {


### PR DESCRIPTION
## Summary
- Re-running `cloud enroll` / `pool join --cloud-control-plane` against a control plane that already has a host row for the same machine (matched on `oss_backend_id`) permanently broke every heartbeat/status call afterward with `401 invalid host bearer`.
- Root cause: a join token embeds its own throwaway `host_id`, minted fresh per token and never itself created as a host row. On first enroll the server creates the host row using that id, so persisting the raw token as the bearer works by coincidence. On re-enroll the cloud control plane instead updates an **existing** row's bearer hash but returns that row's own, different id — the client kept writing the raw join token (with the wrong, non-existent `host_id`) into `cloud.yaml`.
- `Enroll`/`enrollREST` now return the durable bearer as `<returned host id>.<token's secret half>` instead of the raw token, so both `containarium cloud enroll` and `pool join --cloud-control-plane` persist a bearer that actually resolves after a re-enroll.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cloud/... ./internal/cmd/...` — includes new regression tests for both the gRPC (`TestEnroll_ReEnrollRebuildsBearerFromReturnedHostID`) and REST (`TestEnrollREST_ReEnroll`) transports pinning the re-enroll case