### PR TITLE
fix(zap): fail fast when ZAP isn't installed instead of a 120s timeout

### DIFF
--- a/internal/zap/scanner.go
+++ b/internal/zap/scanner.go
@@ -75,6 +75,16 @@ func getContainerIP() (string, error) {
 
 // EnsureDaemonRunning starts the ZAP daemon in the security container if it's not already running
 func (s *Scanner) EnsureDaemonRunning(ctx context.Context) error {
+	// Fail fast if ZAP was never installed (InstallZap RPC never run on this
+	// host). Without this check, every scan job silently backgrounds a
+	// "command not found" inside the container and then burns the full
+	// 120-second readiness poll before reporting the generic timeout below —
+	// indistinguishable from a slow-starting daemon, and it repeats forever
+	// since nothing here ever installs ZAP.
+	if !s.Available() {
+		return fmt.Errorf("ZAP is not installed in the security container (run the InstallZap RPC/API for this host first)")
+	}
+
 	// Get container IP
 	ip, err := getContainerIP()
 	if err != nil {


### PR DESCRIPTION
## Summary
- `EnsureDaemonRunning` now checks `Scanner.Available()` (→ `Installer.IsInstalled()`) before attempting to start the ZAP daemon, returning immediately with a clear error instead of silently backgrounding a "command not found" and burning the full 120-second readiness poll.
- Found live: a production GPU host (`fts-13700k`) had ZAP scan jobs failing repeatedly over 24+ hours because `InstallZap` had never been run for that host's security container — every attempt paid the full 120s timeout before reporting a generic, indistinguishable-from-slow-start error.
- Full root-cause writeup and two follow-ups (no CLI counterpart for `InstallZap`; no operator runbook) filed as #960.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/zap/...`
- [x] Live-verified against `fts-13700k`: confirmed `/opt/zap` was missing (root cause), installed ZAP via the REST endpoint, confirmed the binary now exists in the security container.