### PR TITLE
fix(gateway): keysync orphan WARNING now matches the reaper's shell gate

### DIFF
--- a/internal/gateway/keys_handler.go
+++ b/internal/gateway/keys_handler.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/footprintai/containarium/pkg/core/container"
 )
 
 // UserKeys holds a username and their authorized_keys content.
@@ -79,7 +81,18 @@ func ServeAuthorizedKeys(homeRoot string, containerExistsFn func(username string
 				continue
 			}
 			if containerExistsFn != nil && !containerExistsFn(username) {
-				orphanCount++
+				// Only count/warn about accounts the orphan-reaper will
+				// actually touch. reapOnce (orphan_reaper.go) refuses to
+				// delete anything whose login shell isn't the
+				// containarium-managed wrapper — a real host admin login
+				// (e.g. the VM's own cloud-init "ubuntu" user) can share
+				// this directory shape without ever being reap-eligible.
+				// Without this gate the WARNING claims "orphan-reaper will
+				// clean up on next tick" forever for an account the reaper
+				// will never touch.
+				if shell, shellErr := container.UserLoginShell(username); shellErr == nil && container.IsContainerManagedShell(shell) {
+					orphanCount++
+				}
 				continue
 			}
 			keys = append(keys, UserKeys{

--- a/internal/gateway/keys_handler_test.go
+++ b/internal/gateway/keys_handler_test.go
@@ -3,9 +3,11 @@ package gateway
 import (
 	"bytes"
 	"encoding/json"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -64,6 +66,54 @@ func TestServeAuthorizedKeys_OrphanFiltered(t *testing.T) {
 	}
 	if resp.Keys[0].Username != "alice" {
 		t.Errorf("expected alice, got %s", resp.Keys[0].Username)
+	}
+}
+
+// TestServeAuthorizedKeys_OrphanWarningSkipsNonContainerShell is the
+// regression guard for the "ubuntu" incident: a real host admin account
+// (getent-resolvable, but never running the containarium-shell wrapper) can
+// share the orphan directory shape (authorized_keys under homeRoot, no
+// matching container) without ever being orphan-reaper-eligible — see
+// pkg/core/container's IsContainerManagedShell. The keysync WARNING must not
+// claim "orphan-reaper will clean up on next tick" for an account the
+// reaper will never touch; exclusion from the response itself (#343) is
+// unaffected.
+func TestServeAuthorizedKeys_OrphanWarningSkipsNonContainerShell(t *testing.T) {
+	if _, err := exec.LookPath("getent"); err != nil {
+		t.Skip("getent not available on this platform (Linux-only tool; CI runs Linux)")
+	}
+
+	tmpHome := t.TempDir()
+	// "root" always exists via getent and never runs the containarium-shell
+	// wrapper — same fixture-free approach as
+	// pkg/core/container's TestUserShell_ParsesGetentOutput.
+	mkUser(t, tmpHome, "root", "ssh-ed25519 AAAA_root root@admin\n")
+
+	exists := func(string) bool { return false } // no container for anyone
+
+	var logBuf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(orig)
+
+	handler := ServeAuthorizedKeys(tmpHome, exists)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/authorized-keys", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var resp KeysResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range resp.Keys {
+		if k.Username == "root" {
+			t.Fatal("root should still be excluded from the keys response (no matching container) — unaffected by this fix")
+		}
+	}
+	if strings.Contains(logBuf.String(), "orphan authorized_keys found") {
+		t.Errorf("WARNING must not fire for a non-containarium-shell account (the reaper will never touch it); got log: %s", logBuf.String())
 	}
 }
 

--- a/pkg/core/container/orphan_reaper.go
+++ b/pkg/core/container/orphan_reaper.go
@@ -53,6 +53,25 @@ func RunOrphanReaperWithRoot(ctx context.Context, homeRoot string, containerExis
 	}
 }
 
+// UserLoginShell exports userShell for packages outside pkg/core/container
+// (e.g. the keysync HTTP handler) that need the exact same
+// orphan-reaper-eligibility check without duplicating the getent logic —
+// see IsContainerManagedShell.
+func UserLoginShell(username string) (string, error) {
+	return userShell(username)
+}
+
+// IsContainerManagedShell reports whether shell is the containarium-shell
+// wrapper reapOnce requires before it will ever touch an account (line
+// ~110 below). A host account with any other shell — including a normal
+// admin login that happens to share this heuristic's directory shape — is
+// never reaped. Exported so callers outside this package (the keysync
+// WARNING log) can describe "will the reaper actually clean this up?"
+// without duplicating containerShellPath.
+func IsContainerManagedShell(shell string) bool {
+	return shell == containerShellPath
+}
+
 // userShell returns username's login shell from the passwd database (the
 // 7th colon-separated field of `getent passwd`), used to gate reaping to
 // accounts actually running containerShellPath. Errors (unknown user,


### PR DESCRIPTION
## Summary
- The keysync `/authorized-keys` handler's "orphan authorized_keys found ... orphan-reaper will clean up on next tick" WARNING fired for any account with no matching container, without checking whether the reaper would ever actually touch it.
- `reapOnce` (`pkg/core/container/orphan_reaper.go`) already refuses to delete anything whose login shell isn't the containarium-managed wrapper — fixed in #920 after a real incident where an operator's own admin login got `userdel`'d — but the WARNING had no equivalent gate, so a real host admin account sharing the orphan directory shape logs a permanently misleading "will clean up on next tick" that never happens.
- Found live: `fts-13700k`'s own admin login (`ubuntu`) triggered this WARNING every ~2 minutes indefinitely, even after the host was upgraded past #920 and the reaper correctly stopped touching it.
- Exports `UserLoginShell`/`IsContainerManagedShell` from `pkg/core/container` so the keysync handler applies the exact same eligibility check instead of duplicating the `getent` + constant logic. The exclusion-from-response behavior (#343) is unchanged — only the WARNING's accuracy.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/gateway/... ./pkg/core/container/...`
- [x] `go test ./internal/gateway/... ./pkg/core/container/...` — new regression test `TestServeAuthorizedKeys_OrphanWarningSkipsNonContainerShell` (skips on non-Linux, mirrors the existing `getent`-based test pattern; will run on CI)