### PR TITLE
fix(sentinel): persist dynamically-registered tunnel tokens across restarts

### DIFF
--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -92,6 +92,25 @@ func init() {
 	sentinelCmd.Flags().StringVar(&sentinelAlertWebhookURL, "alert-webhook-url", os.Getenv(config.EnvSentinelAlertWebhook), "Webhook POSTed on spot preempted/recovered (always-on alert path; the on-spot vmalert dies with the VM). Falls back to $CONTAINARIUM_SENTINEL_ALERT_WEBHOOK (#514)")
 }
 
+// loadPersistedTunnelTokens applies every dynamically-registered tunnel
+// token this sentinel has ever persisted (#936) on top of the
+// CLI-flag-built policy, so a restart doesn't silently forget a token
+// that a prior `sentinel register-token` call (or a cloud control
+// plane's BYOC join flow) made valid at runtime. A missing/unreadable
+// store is logged and otherwise ignored — the sentinel still starts and
+// serves its static CLI-flag tokens either way.
+func loadPersistedTunnelTokens(policy *sentinel.TokenPolicy) {
+	entries, err := sentinel.LoadTunnelTokenStore(sentinel.DefaultTunnelTokenStorePath)
+	if err != nil {
+		log.Printf("[sentinel] WARNING: failed to load persisted tunnel tokens from %s: %v", sentinel.DefaultTunnelTokenStorePath, err)
+		return
+	}
+	if len(entries) > 0 {
+		log.Printf("[sentinel] loaded %d persisted tunnel token(s) from %s", len(entries), sentinel.DefaultTunnelTokenStorePath)
+	}
+	sentinel.ApplyTunnelTokenStore(entries, policy)
+}
+
 func runSentinel(cmd *cobra.Command, args []string) error {
 	// Parse forwarded ports
 	ports, err := parseForwardedPorts(sentinelForwardedPorts)
@@ -175,6 +194,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 			if polErr != nil {
 				return polErr
 			}
+			loadPersistedTunnelTokens(tunnelPolicy)
 			tunnelServer := sentinel.NewTunnelServer("", tunnelPolicy, registry)
 			tunnelServer.OnConnect = manager.OnTunnelConnect
 			tunnelServer.OnDisconnect = manager.OnTunnelDisconnect
@@ -260,6 +280,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 		if polErr != nil {
 			return polErr
 		}
+		loadPersistedTunnelTokens(tunnelPolicy)
 		tunnelServer := sentinel.NewTunnelServer("", tunnelPolicy, registry)
 		tunnelServer.OnConnect = manager.OnTunnelConnect
 		tunnelServer.OnDisconnect = manager.OnTunnelDisconnect

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -151,6 +151,12 @@ type Manager struct {
 	// responds 501.
 	tunnelPolicy *TokenPolicy
 
+	// tunnelTokenStorePath is where TunnelTokenRegisterHandler persists
+	// each dynamic registration (#936) so a sentinel restart doesn't
+	// silently forget it. Empty means DefaultTunnelTokenStorePath; tests
+	// override via SetTunnelTokenStorePath to use a tmp dir.
+	tunnelTokenStorePath string
+
 	// pki holds the operator-bootstrapped peer-CA and the sentinel's
 	// own server cert. Set when CONTAINARIUM_CA_KEY_FILE points at a
 	// valid RSA key — see NewManager and SetCertProvisioner.
@@ -372,6 +378,36 @@ func (m *Manager) SetTunnelRegistry(reg *TunnelRegistry) {
 // after PolicyFromCLI builds the policy.
 func (m *Manager) SetTunnelPolicy(policy *TokenPolicy) {
 	m.tunnelPolicy = policy
+}
+
+// SetTunnelTokenStorePath overrides where dynamic tunnel-token
+// registrations are persisted (#936). Tests use this to point at a tmp
+// dir; production wiring (internal/cmd/sentinel.go) leaves it unset and
+// relies on the DefaultTunnelTokenStorePath fallback in
+// persistTunnelToken.
+func (m *Manager) SetTunnelTokenStorePath(path string) {
+	m.tunnelTokenStorePath = path
+}
+
+// persistTunnelToken upserts (token, pools) into the on-disk dynamic
+// tunnel-token store (#936) so a future sentinel restart re-applies it
+// via ApplyTunnelTokenStore instead of silently forgetting it. Best-effort
+// by design at the call site (TunnelTokenRegisterHandler still returns
+// success on a persistence failure) — the token is already valid in this
+// process's TokenPolicy either way; persistence only affects survival
+// across a restart, and a disk hiccup here must not block a legitimate
+// BYOC join.
+func (m *Manager) persistTunnelToken(token string, pools []Pool) error {
+	path := m.tunnelTokenStorePath
+	if path == "" {
+		path = DefaultTunnelTokenStorePath
+	}
+	entries, err := LoadTunnelTokenStore(path)
+	if err != nil {
+		return err
+	}
+	entries = upsertTunnelTokenEntry(entries, token, pools)
+	return SaveTunnelTokenStore(path, entries)
 }
 
 // SetAdminSecret wires the secret that gates POST

--- a/internal/sentinel/tunnel_token_handler.go
+++ b/internal/sentinel/tunnel_token_handler.go
@@ -2,6 +2,7 @@ package sentinel
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 )
 
@@ -61,6 +62,17 @@ func (m *Manager) TunnelTokenRegisterHandler() http.HandlerFunc {
 			pools = []Pool{PoolAny}
 		}
 		m.tunnelPolicy.Allow(req.Token, pools...)
+		// Persist so this registration survives a sentinel restart (#936) —
+		// TokenPolicy itself is pure in-memory and would otherwise silently
+		// forget every dynamically-registered token the moment this process
+		// exits, permanently locking out any host whose tunnel session
+		// needs to re-handshake after that restart. Best-effort: a
+		// persistence failure must not fail a legitimate BYOC join, since
+		// the token is already valid for this process's lifetime either
+		// way — it only affects survival across a *future* restart.
+		if err := m.persistTunnelToken(req.Token, pools); err != nil {
+			log.Printf("[sentinel] WARNING: failed to persist tunnel token registration (won't survive a restart): %v", err)
+		}
 		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/internal/sentinel/tunnel_token_handler_test.go
+++ b/internal/sentinel/tunnel_token_handler_test.go
@@ -19,6 +19,10 @@ func newManagerForTunnelTokenTest(t *testing.T, withPolicy bool) *Manager {
 	if withPolicy {
 		m.SetTunnelPolicy(NewTokenPolicy())
 	}
+	// Persist to a tmp dir, not the real /etc/containarium (#936) — a
+	// hermetic test must not depend on (or fail attempting) a real
+	// filesystem write to a root-owned path.
+	m.SetTunnelTokenStorePath(t.TempDir() + "/tunnel-tokens.json")
 	return m
 }
 
@@ -50,6 +54,47 @@ func TestTunnelTokenRegisterHandler_RegistersFreshToken(t *testing.T) {
 	}
 	if err := m.tunnelPolicy.Validate("fresh-token", "asia-east1"); err != nil {
 		t.Fatalf("token should match any pool (PoolAny default): %v", err)
+	}
+}
+
+// TestTunnelTokenRegisterHandler_PersistsAcrossRestart is the regression
+// guard for #936: a token registered at runtime must survive the sentinel
+// process restarting, not just be valid in the current process's
+// in-memory TokenPolicy. Simulates a restart by building a FRESH policy +
+// loading the persisted store into it, mirroring exactly what
+// internal/cmd/sentinel.go's loadPersistedTunnelTokens does at startup.
+func TestTunnelTokenRegisterHandler_PersistsAcrossRestart(t *testing.T) {
+	m := newManagerForTunnelTokenTest(t, true)
+
+	body, _ := json.Marshal(TunnelTokenRegisterRequest{Token: "byoc-token", Pools: []Pool{"asia-east1"}})
+	req := httptest.NewRequest(http.MethodPost, "/sentinel/tunnel-tokens", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(req, []byte(tunnelTokenAdminSecret))
+	rec := httptest.NewRecorder()
+	handler := auth.SentinelHMACMiddleware([]byte(tunnelTokenAdminSecret), m.TunnelTokenRegisterHandler())
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	// "Restart": a brand-new policy, as PolicyFromCLI would build at
+	// startup, with none of this process's registrations.
+	freshPolicy := NewTokenPolicy()
+	if err := freshPolicy.Validate("byoc-token", "asia-east1"); err == nil {
+		t.Fatal("sanity check: fresh policy should not yet know this token")
+	}
+
+	entries, err := LoadTunnelTokenStore(m.tunnelTokenStorePath)
+	if err != nil {
+		t.Fatalf("LoadTunnelTokenStore: %v", err)
+	}
+	ApplyTunnelTokenStore(entries, freshPolicy)
+
+	if err := freshPolicy.Validate("byoc-token", "asia-east1"); err != nil {
+		t.Fatalf("token must survive a restart via the persisted store: %v", err)
+	}
+	if err := freshPolicy.Validate("byoc-token", "us-west1"); err == nil {
+		t.Fatal("token was scoped to asia-east1 only; pool restriction must survive too")
 	}
 }
 

--- a/internal/sentinel/tunnel_token_store.go
+++ b/internal/sentinel/tunnel_token_store.go
@@ -1,0 +1,106 @@
+package sentinel
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// DefaultTunnelTokenStorePath is where dynamically-registered tunnel
+// tokens (see TunnelTokenRegisterHandler) are persisted so a sentinel
+// restart doesn't silently forget them (#936). TokenPolicy itself is a
+// pure in-memory value with no memory across process restarts; a token
+// registered via POST /sentinel/tunnel-tokens minutes or days before a
+// restart would otherwise vanish, permanently locking out every host
+// whose next handshake happens to land after that restart.
+const DefaultTunnelTokenStorePath = "/etc/containarium/tunnel-tokens.json"
+
+// TunnelTokenEntry is one persisted dynamic registration.
+type TunnelTokenEntry struct {
+	Token string `json:"token"`
+	Pools []Pool `json:"pools"`
+}
+
+// LoadTunnelTokenStore reads previously-persisted dynamic registrations
+// from path. A missing file is not an error — it means either a fresh
+// sentinel or one that has never served a dynamic registration yet;
+// callers get an empty slice and the sentinel starts with only its
+// static CLI-flag tokens, exactly as it did before this store existed.
+func LoadTunnelTokenStore(path string) ([]TunnelTokenEntry, error) {
+	b, err := os.ReadFile(path) // #nosec G304 -- fixed, operator-controlled path (DefaultTunnelTokenStorePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read tunnel token store %s: %w", path, err)
+	}
+	if len(b) == 0 {
+		return nil, nil
+	}
+	var entries []TunnelTokenEntry
+	if err := json.Unmarshal(b, &entries); err != nil {
+		return nil, fmt.Errorf("parse tunnel token store %s: %w", path, err)
+	}
+	return entries, nil
+}
+
+// ApplyTunnelTokenStore registers every persisted entry on policy. Called
+// at sentinel startup, right after PolicyFromCLI builds the static
+// policy, so a restart picks back up every token that was ever
+// dynamically registered — not just the ones baked into --tunnel-token /
+// --tunnel-token-policy.
+func ApplyTunnelTokenStore(entries []TunnelTokenEntry, policy *TokenPolicy) {
+	for _, e := range entries {
+		policy.Allow(e.Token, e.Pools...)
+	}
+}
+
+// SaveTunnelTokenStore atomically persists entries to path at mode 0600
+// (each entry is a bearer-equivalent secret). Overwrites the whole file
+// — the caller supplies the full current entry set, mirroring
+// internal/cloud/config.go's Save().
+func SaveTunnelTokenStore(path string, entries []TunnelTokenEntry) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create tunnel token store dir %s: %w", dir, err)
+	}
+	b, err := json.Marshal(entries)
+	if err != nil {
+		return fmt.Errorf("marshal tunnel token store: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".tunnel-tokens-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp tunnel token store: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }() // no-op if the rename succeeded
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp tunnel token store: %w", err)
+	}
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp tunnel token store: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp tunnel token store: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename tunnel token store into place: %w", err)
+	}
+	return nil
+}
+
+// upsertTunnelTokenEntry replaces entries[i] when its Token matches, or
+// appends a new entry otherwise. Pure — used by the register handler to
+// build the next full entry set before calling SaveTunnelTokenStore.
+func upsertTunnelTokenEntry(entries []TunnelTokenEntry, token string, pools []Pool) []TunnelTokenEntry {
+	for i := range entries {
+		if entries[i].Token == token {
+			entries[i].Pools = pools
+			return entries
+		}
+	}
+	return append(entries, TunnelTokenEntry{Token: token, Pools: pools})
+}

--- a/internal/sentinel/tunnel_token_store.go
+++ b/internal/sentinel/tunnel_token_store.go
@@ -14,7 +14,7 @@ import (
 // registered via POST /sentinel/tunnel-tokens minutes or days before a
 // restart would otherwise vanish, permanently locking out every host
 // whose next handshake happens to land after that restart.
-const DefaultTunnelTokenStorePath = "/etc/containarium/tunnel-tokens.json"
+const DefaultTunnelTokenStorePath = "/etc/containarium/tunnel-tokens.json" // #nosec G101 -- a file PATH, not a credential
 
 // TunnelTokenEntry is one persisted dynamic registration.
 type TunnelTokenEntry struct {

--- a/internal/sentinel/tunnel_token_store_test.go
+++ b/internal/sentinel/tunnel_token_store_test.go
@@ -1,0 +1,98 @@
+package sentinel
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadTunnelTokenStore_MissingFileIsNotError(t *testing.T) {
+	entries, err := LoadTunnelTokenStore(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err != nil {
+		t.Fatalf("missing file must not be an error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no entries, got %d", len(entries))
+	}
+}
+
+func TestSaveTunnelTokenStore_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tunnel-tokens.json")
+	want := []TunnelTokenEntry{
+		{Token: "tok-a", Pools: []Pool{PoolAny}},
+		{Token: "tok-b", Pools: []Pool{"lab", "prod"}},
+	}
+	if err := SaveTunnelTokenStore(path, want); err != nil {
+		t.Fatalf("SaveTunnelTokenStore: %v", err)
+	}
+	got, err := LoadTunnelTokenStore(path)
+	if err != nil {
+		t.Fatalf("LoadTunnelTokenStore: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("entry count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Token != want[i].Token {
+			t.Errorf("entry %d token = %q, want %q", i, got[i].Token, want[i].Token)
+		}
+	}
+}
+
+func TestApplyTunnelTokenStore_MergesIntoPolicy(t *testing.T) {
+	policy := NewTokenPolicy()
+	entries := []TunnelTokenEntry{
+		{Token: "tok-a", Pools: []Pool{PoolAny}},
+		{Token: "tok-b", Pools: []Pool{"lab"}},
+	}
+	ApplyTunnelTokenStore(entries, policy)
+
+	if err := policy.Validate("tok-a", "anything"); err != nil {
+		t.Errorf("tok-a should validate for any pool: %v", err)
+	}
+	if err := policy.Validate("tok-b", "lab"); err != nil {
+		t.Errorf("tok-b should validate for lab: %v", err)
+	}
+	if err := policy.Validate("tok-b", "prod"); err == nil {
+		t.Error("tok-b should NOT validate for prod")
+	}
+	if err := policy.Validate("unknown", ""); err == nil {
+		t.Error("an unregistered token must still be rejected")
+	}
+}
+
+func TestUpsertTunnelTokenEntry_AppendsNew(t *testing.T) {
+	entries := []TunnelTokenEntry{{Token: "existing", Pools: []Pool{PoolAny}}}
+	got := upsertTunnelTokenEntry(entries, "new-token", []Pool{"lab"})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+	if got[1].Token != "new-token" {
+		t.Errorf("appended entry token = %q, want new-token", got[1].Token)
+	}
+}
+
+func TestUpsertTunnelTokenEntry_ReplacesExistingPools(t *testing.T) {
+	entries := []TunnelTokenEntry{{Token: "tok-a", Pools: []Pool{"lab"}}}
+	got := upsertTunnelTokenEntry(entries, "tok-a", []Pool{"prod", "staging"})
+	if len(got) != 1 {
+		t.Fatalf("re-registering an existing token must not duplicate the entry, got %d entries", len(got))
+	}
+	if len(got[0].Pools) != 2 || got[0].Pools[0] != "prod" {
+		t.Errorf("pools not replaced: %+v", got[0].Pools)
+	}
+}
+
+func TestSaveTunnelTokenStore_FileMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tunnel-tokens.json")
+	if err := SaveTunnelTokenStore(path, []TunnelTokenEntry{{Token: "tok-a", Pools: []Pool{PoolAny}}}); err != nil {
+		t.Fatalf("SaveTunnelTokenStore: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("tunnel token store mode = %o, want 0600 (each entry is a bearer-equivalent secret)", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #936.

- `TokenPolicy` is a pure in-memory allow-list. A token registered at runtime via `POST /sentinel/tunnel-tokens` (the path a cloud control plane's BYOC join flow uses) had no way to survive a sentinel process restart — the registration simply vanished, and nothing re-applied it. Any host whose tunnel session was established before the sentinel's last restart was left running on a credential the sentinel no longer recognized, invisible until that host's tunnel happened to need a fresh handshake, at which point it failed permanently with `handshake rejected: invalid token` and never recovered on its own.
- `TunnelTokenRegisterHandler` now persists each registration to `/etc/containarium/tunnel-tokens.json` (root-only, 0600 — each entry is a bearer-equivalent credential) via the new `internal/sentinel/tunnel_token_store.go`.
- `internal/cmd/sentinel.go` loads and re-applies the persisted store on top of the static CLI-flag policy at startup, in both the tunnel-only and hybrid (GCP+tunnel) code paths.
- Persistence is best-effort at the call site: a disk write failure logs a warning but still returns success for the registration itself — a disk hiccup must not block a legitimate BYOC join.
- Found live: a production BYOC host's tunnel could not reconnect after a routine sentinel restart, while a second, durably-configured host on the same sentinel reconnected with no issue.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/sentinel/... ./internal/cmd/...`
- [x] `go test ./internal/sentinel/... ./internal/cmd/...` — new tests: `TestTunnelTokenRegisterHandler_PersistsAcrossRestart` (simulates a restart by loading the persisted store into a fresh `TokenPolicy`), plus unit tests for the store's load/save/apply/upsert functions and file mode (0600).