### PR TITLE
fix(cmd): tunnel-handshake token via EnvironmentFile, not ExecStart

### DIFF
--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -39,6 +39,16 @@ const (
 	// the sentinel's keysync/certsync requests never lands in a
 	// world-readable file.
 	sentinelAuthSecretFile = "/etc/containarium/sentinel-auth.env" // #nosec G101 -- a file PATH, not a credential
+
+	// tunnelTokenSecretFile holds CONTAINARIUM_TUNNEL_TOKEN for the
+	// EnvironmentFile= directive in the tunnel unit (see renderTunnelUnit).
+	// #935: the tunnel-handshake token used to be baked straight into the
+	// unit's world-readable (0644) ExecStart line — visible to any local
+	// user via `systemctl cat`/`systemctl show -p ExecStart`/`ps`. It's a
+	// bearer-equivalent credential (the tunnel-server's TokenPolicy grants
+	// standing tunnel access to whoever presents it), so it gets the same
+	// root-only-file treatment sentinelAuthSecretFile already established.
+	tunnelTokenSecretFile = "/etc/containarium/tunnel-token.env" // #nosec G101 -- a file PATH, not a credential
 )
 
 // minimalDaemonArgv is the baseline daemon command used when no existing
@@ -116,10 +126,13 @@ func init() {
 	poolJoinCmd.Flags().StringVar(&poolJoinSentinelAuthSecret, "sentinel-auth-secret", os.Getenv("CONTAINARIUM_SENTINEL_AUTH_SECRET"), "Fleet-wide HMAC secret (32+ bytes) matching the sentinel's CONTAINARIUM_SENTINEL_AUTH_SECRET. Without it, the sentinel's keysync/certsync requests to this host's /authorized-keys get rejected with 401 — this host stays joined to the tunnel but never gets an SSH pipe (#687). Defaults to $CONTAINARIUM_SENTINEL_AUTH_SECRET; written to a root-only env file, never into the world-readable drop-in")
 }
 
-// tunnelUnitParams are the inputs to the tunnel systemd unit.
+// tunnelUnitParams are the inputs to the tunnel systemd unit. The token
+// itself is NOT a field here (#935) — it never appears in the rendered
+// unit text. It's written separately to tunnelTokenSecretFile (root-only,
+// 0600) and referenced via EnvironmentFile=, which `containarium tunnel`
+// already reads via $CONTAINARIUM_TUNNEL_TOKEN (see internal/cmd/tunnel.go).
 type tunnelUnitParams struct {
 	SentinelAddr   string
-	Token          string
 	SpotID         string
 	Ports          string
 	Pool           string
@@ -139,9 +152,9 @@ func renderTunnelUnit(p tunnelUnitParams) string {
 	b.WriteString("Documentation=https://github.com/footprintai/Containarium\n")
 	b.WriteString("After=network-online.target\nWants=network-online.target\n\n")
 	b.WriteString("[Service]\nType=simple\n")
+	fmt.Fprintf(&b, "EnvironmentFile=%s\n", tunnelTokenSecretFile)
 	b.WriteString("ExecStart=/usr/local/bin/containarium tunnel \\\n")
 	fmt.Fprintf(&b, "  --sentinel-addr %s \\\n", p.SentinelAddr)
-	fmt.Fprintf(&b, "  --token %s \\\n", p.Token)
 	fmt.Fprintf(&b, "  --spot-id %s \\\n", p.SpotID)
 	fmt.Fprintf(&b, "  --ports %s", p.Ports)
 	if p.Pool != "" {
@@ -335,7 +348,6 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 	}
 	tunnel := renderTunnelUnit(tunnelUnitParams{
 		SentinelAddr:   sentinelAddr,
-		Token:          poolJoinToken,
 		SpotID:         spotID,
 		Ports:          poolJoinPorts,
 		Pool:           poolJoinPool,
@@ -348,6 +360,7 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 		if authSecretFile != "" {
 			fmt.Printf("# %s (mode 0600, contents redacted)\nCONTAINARIUM_SENTINEL_AUTH_SECRET=<redacted, %d bytes>\n\n", authSecretFile, len(poolJoinSentinelAuthSecret))
 		}
+		fmt.Printf("# %s (mode 0600, contents redacted)\nCONTAINARIUM_TUNNEL_TOKEN=<redacted, %d bytes>\n\n", tunnelTokenSecretFile, len(poolJoinToken))
 		fmt.Printf("# %s\n%s\n", daemonDropIn, dropIn)
 		fmt.Printf("# %s\n%s\n", tunnelUnitPath, tunnel)
 		fmt.Println("# (dry-run: nothing written; re-run without --dry-run as root to apply)")
@@ -372,6 +385,16 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 		if err := os.WriteFile(authSecretFile, []byte(content), 0600); err != nil {
 			return fmt.Errorf("write sentinel auth secret file: %w", err)
 		}
+	}
+	// 1c. Tunnel-handshake token (#935) — root-only, referenced by the
+	// tunnel unit's EnvironmentFile= rather than embedded in its
+	// world-readable ExecStart line.
+	if err := os.MkdirAll("/etc/containarium", 0700); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+	tokenContent := fmt.Sprintf("CONTAINARIUM_TUNNEL_TOKEN=%s\n", poolJoinToken)
+	if err := os.WriteFile(tunnelTokenSecretFile, []byte(tokenContent), 0600); err != nil {
+		return fmt.Errorf("write tunnel token secret file: %w", err)
 	}
 	// 2. --pool drop-in on the daemon unit.
 	// #nosec G301 -- systemd drop-in dir, world-readable config by convention (no secrets)

--- a/internal/cmd/pool_join_test.go
+++ b/internal/cmd/pool_join_test.go
@@ -28,14 +28,12 @@ func testCmd() *cobra.Command {
 func TestRenderTunnelUnit_RequiredFlags(t *testing.T) {
 	u := renderTunnelUnit(tunnelUnitParams{
 		SentinelAddr: "sentinel.example.com:443",
-		Token:        "tok-123",
 		SpotID:       "node1",
 		Ports:        "22,8080,443",
 		Pool:         "prod",
 	})
 	for _, want := range []string{
 		"--sentinel-addr sentinel.example.com:443",
-		"--token tok-123",
 		"--spot-id node1",
 		"--ports 22,8080,443",
 		"--pool prod",
@@ -52,10 +50,31 @@ func TestRenderTunnelUnit_RequiredFlags(t *testing.T) {
 	}
 }
 
+// TestRenderTunnelUnit_TokenNeverInExecStart is the regression guard for
+// #935: the tunnel-handshake token is a bearer-equivalent credential (the
+// sentinel's TokenPolicy grants standing tunnel access to whoever presents
+// it) and must never appear in the world-readable (0644) unit's ExecStart
+// line — it's supplied via EnvironmentFile= instead (see
+// tunnelTokenSecretFile), which `containarium tunnel` already reads as
+// $CONTAINARIUM_TUNNEL_TOKEN.
+func TestRenderTunnelUnit_TokenNeverInExecStart(t *testing.T) {
+	u := renderTunnelUnit(tunnelUnitParams{
+		SentinelAddr: "sentinel.example.com:443",
+		SpotID:       "node1",
+		Ports:        "22,8080,443",
+		Pool:         "prod",
+	})
+	if strings.Contains(u, "--token") {
+		t.Errorf("tunnel unit must not embed --token in ExecStart:\n%s", u)
+	}
+	if !strings.Contains(u, "EnvironmentFile="+tunnelTokenSecretFile) {
+		t.Errorf("tunnel unit missing EnvironmentFile=%s:\n%s", tunnelTokenSecretFile, u)
+	}
+}
+
 func TestRenderTunnelUnit_PublicPrimary(t *testing.T) {
 	u := renderTunnelUnit(tunnelUnitParams{
 		SentinelAddr:   "s:443",
-		Token:          "t",
 		SpotID:         "n",
 		Ports:          "443",
 		Pool:           "prod",

--- a/internal/cmd/pool_leave.go
+++ b/internal/cmd/pool_leave.go
@@ -44,6 +44,7 @@ func runPoolLeave(cmd *cobra.Command, args []string) error {
 		fmt.Println("Would leave the pool:")
 		fmt.Printf("  - systemctl disable --now containarium-tunnel  (deregisters from the sentinel)\n")
 		fmt.Printf("  - rm %s\n", tunnelUnitPath)
+		fmt.Printf("  - rm %s   (tunnel-handshake token, #935)\n", tunnelTokenSecretFile)
 		fmt.Printf("  - rm %s   (daemon returns to standalone)\n", daemonDropIn)
 		fmt.Printf("  - systemctl daemon-reload && systemctl try-restart containarium\n")
 		fmt.Println("  (dry-run: nothing changed; the daemon + your containers are untouched)")
@@ -63,8 +64,9 @@ func runPoolLeave(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// 2. Remove the tunnel unit + the --pool drop-in (idempotent).
-	for _, p := range []string{tunnelUnitPath, daemonDropIn} {
+	// 2. Remove the tunnel unit + its token secret file + the --pool drop-in
+	// (idempotent).
+	for _, p := range []string{tunnelUnitPath, tunnelTokenSecretFile, daemonDropIn} {
 		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove %s: %w", p, err)
 		}


### PR DESCRIPTION
## Summary
Fixes #935 (partially — see scope note below).

- `pool join` baked the tunnel-handshake token directly into the world-readable (0644) `containarium-tunnel.service` unit's `ExecStart` line, visible to any local user via `systemctl cat` / `systemctl show -p ExecStart` / `ps`. The token is a bearer-equivalent credential (the sentinel's `TokenPolicy` grants standing tunnel access to whoever presents it), so it now gets the same root-only-file treatment `sentinelAuthSecretFile` already established for the sentinel HMAC secret (#687): written to `/etc/containarium/tunnel-token.env` (mode 0600) and referenced via the unit's `EnvironmentFile=`, which `containarium tunnel` already reads as `$CONTAINARIUM_TUNNEL_TOKEN` — no client-side changes needed, that fallback already existed.
- `pool leave` now also removes the token secret file on cleanup.

## Scope note

#935's investigation also traced a claimed "15-minute TTL expiry" causing the token to eventually stop working — but the sentinel's `TokenPolicy.Validate` has no expiry/consumption logic at all (confirmed while investigating #936, filed and fixed separately in #964). The observed permanent-lockout symptom was actually caused by #936 (the sentinel forgetting dynamic registrations across a restart), not real token expiry.

This PR addresses the credential-storage-hygiene half of #935 (never expose the token in a world-readable file); #964 addresses the functional failure mode. A "cloud mints a separate, non-enrollment durable tunnel credential" architecture (the deeper redesign #935 originally proposed) would need cross-repo changes to Containarium-cloud and is out of scope here.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/cmd/...`
- [x] `go test ./internal/cmd/...` — updated `TestRenderTunnelUnit_RequiredFlags`/`_PublicPrimary`, new `TestRenderTunnelUnit_TokenNeverInExecStart` regression guard.