### PR TITLE
feat(k8s): replace the StatefulSet box backend with agent-sandbox Sandbox CRs

### DIFF
--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     paths:
       - 'pkg/core/box/**'
-      - 'internal/server/boxbackend_k8s.go'
+      - 'internal/server/boxbackend_factory.go'
       - 'scripts/k8s-e2e.sh'
       - '.github/workflows/k8s-e2e.yml'
       - 'go.mod'
@@ -18,7 +18,7 @@ on:
     branches: [main]
     paths:
       - 'pkg/core/box/**'
-      - 'internal/server/boxbackend_k8s.go'
+      - 'internal/server/boxbackend_factory.go'
       - 'scripts/k8s-e2e.sh'
       - '.github/workflows/k8s-e2e.yml'
       - 'go.mod'

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
+	sigs.k8s.io/agent-sandbox v0.5.1
 )
 
 require (
@@ -136,6 +137,7 @@ require (
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
+	sigs.k8s.io/controller-runtime v0.24.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -384,6 +384,10 @@ k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a h1:xCeOEAOoGYl2jnJoHkC3hk
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 h1:kBawHLSnx/mYHmRnNUf9d4CpjREbeZuxoSGOX/J+aYM=
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
+sigs.k8s.io/agent-sandbox v0.5.1 h1:fD6vRdkpJ6oDwrScBCDg200K46BEUCcNp9EXzHtot7I=
+sigs.k8s.io/agent-sandbox v0.5.1/go.mod h1:ueMeA+ze1Rd1957IBz2iskFSxDQT2tBHRweg+I0LHew=
+sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=
+sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/pkg/core/box/k8s/doc.go
+++ b/pkg/core/box/k8s/doc.go
@@ -1,4 +1,5 @@
-// Package k8s implements box.BoxBackend on Kubernetes: a per-tenant pod an
+// Package k8s implements box.BoxBackend on Kubernetes, declaring one
+// kubernetes-sigs/agent-sandbox Sandbox CR per box: a per-tenant pod an
 // agent reaches over SSH, serving the same agent-box stdio MCP surface as the
 // LXC backend. See docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md.
 //

--- a/pkg/core/box/k8s/e2e_test.go
+++ b/pkg/core/box/k8s/e2e_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	sandboxclient "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned"
 
 	"github.com/footprintai/containarium/pkg/core/box"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -45,7 +46,8 @@ func TestE2E_BoxLifecycle(t *testing.T) {
 	ref := box.BoxRef{Tenant: "e2e"}
 	t.Cleanup(func() { _ = b.Delete(context.Background(), ref, true) })
 
-	// Create reconciles namespace + Secret + Service + NetworkPolicy + StatefulSet.
+	// Create reconciles namespace + Secrets + NetworkPolicy + the Sandbox CR;
+	// the agent-sandbox controller creates the pod and headless Service.
 	if _, err := b.Create(ctx, box.BoxSpec{
 		Ref:       ref,
 		Image:     "registry.k8s.io/pause:3.9",
@@ -61,13 +63,13 @@ func TestE2E_BoxLifecycle(t *testing.T) {
 		t.Errorf("running box has no pod IP")
 	}
 
-	// Stop scales to 0 → STOPPED.
+	// Stop suspends the Sandbox (controller deletes the pod) → STOPPED.
 	if err := b.Stop(ctx, ref, false); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
 	waitForState(t, b, ref, pb.ContainerState_CONTAINER_STATE_STOPPED, time.Minute)
 
-	// Start scales back to 1 → RUNNING.
+	// Start resumes the Sandbox (controller recreates the pod) → RUNNING.
 	if err := b.Start(ctx, ref); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -172,7 +174,7 @@ func TestE2E_GatewayPipe(t *testing.T) {
 		t.Fatalf("get pipe: %v", err)
 	}
 	host, _, _ := unstructured.NestedString(p.Object, "spec", "to", "host")
-	if host != "box-0.boxes.tenant-gw-e2e.svc.cluster.local:2222" {
+	if host != "box.tenant-gw-e2e.svc.cluster.local:2222" {
 		t.Errorf("pipe to.host = %q", host)
 	}
 
@@ -245,12 +247,16 @@ func TestE2E_CSIStorage(t *testing.T) {
 		t.Errorf("PVC storage request = %q, want 1Gi", q.String())
 	}
 
-	ss, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{})
+	sbc, err := sandboxclient.NewForConfig(restCfg)
 	if err != nil {
-		t.Fatalf("StatefulSet not found: %v", err)
+		t.Fatalf("agent-sandbox clientset: %v", err)
+	}
+	sb, err := sbc.AgentsV1beta1().Sandboxes(ns).Get(ctx, sandboxName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Sandbox not found: %v", err)
 	}
 	mounts := map[string]string{}
-	for _, m := range ss.Spec.Template.Spec.Containers[0].VolumeMounts {
+	for _, m := range sb.Spec.PodTemplate.Spec.Containers[0].VolumeMounts {
 		mounts[m.MountPath] = m.Name
 	}
 	if mounts[dataMount] == "" {
@@ -267,8 +273,8 @@ func TestE2E_CSIStorage(t *testing.T) {
 	if _, err := cs.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{}); err != nil {
 		t.Errorf("PVC removed by Delete: %v", err)
 	}
-	if _, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{}); err == nil {
-		t.Error("StatefulSet still present after Delete")
+	if _, err := sbc.AgentsV1beta1().Sandboxes(ns).Get(ctx, sandboxName, metav1.GetOptions{}); err == nil {
+		t.Error("Sandbox still present after Delete")
 	}
 
 	// Purge: PVC and namespace gone. Namespace deletion is asynchronous in K8s
@@ -316,10 +322,6 @@ func TestE2E_GPUResourceLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rest config: %v", err)
 	}
-	cs, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		t.Fatalf("clientset: %v", err)
-	}
 
 	ctx := context.Background()
 	ref := box.BoxRef{Tenant: "gpu-e2e"}
@@ -334,15 +336,19 @@ func TestE2E_GPUResourceLimit(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	ss, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{})
+	sbc, err := sandboxclient.NewForConfig(restCfg)
 	if err != nil {
-		t.Fatalf("StatefulSet not found: %v", err)
+		t.Fatalf("agent-sandbox clientset: %v", err)
 	}
-	c := ss.Spec.Template.Spec.Containers[0]
+	sb, err := sbc.AgentsV1beta1().Sandboxes(ns).Get(ctx, sandboxName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Sandbox not found: %v", err)
+	}
+	c := sb.Spec.PodTemplate.Spec.Containers[0]
 	if v := c.Resources.Limits[nvidiaGPUResource]; v.Value() != 2 {
 		t.Errorf("nvidia.com/gpu limit = %v, want 2", v.Value())
 	}
-	if ann := ss.Spec.Template.Annotations[gpuCountAnnotation]; ann != "2" {
+	if ann := sb.Spec.PodTemplate.ObjectMeta.Annotations[gpuCountAnnotation]; ann != "2" {
 		t.Errorf("gpu-count annotation = %q, want 2", ann)
 	}
 }

--- a/pkg/core/box/k8s/gateway.go
+++ b/pkg/core/box/k8s/gateway.go
@@ -68,9 +68,12 @@ func (b *Backend) gatewayEnabled() bool {
 }
 
 // upstreamHost is the in-cluster DNS the gateway forwards the tenant's SSH to:
-// the headless Service's stable per-pod name (box-0.boxes.<ns>.svc).
+// the Sandbox's controller-created headless Service (named after the Sandbox),
+// whose A record resolves to the box pod. Matches the Sandbox's
+// status.serviceFQDN; computed here rather than read from status so the Pipe
+// can be programmed at Create time, before the controller first reconciles.
 func (b *Backend) upstreamHost(tenant string) string {
-	return fmt.Sprintf("%s-0.%s.%s.svc.cluster.local:%d", statefulSetName, serviceName, b.namespaceFor(tenant), sshPort)
+	return fmt.Sprintf("%s.%s.svc.cluster.local:%d", sandboxName, b.namespaceFor(tenant), sshPort)
 }
 
 // pipeObject builds the sshpiper Pipe that routes username=<tenant> to the

--- a/pkg/core/box/k8s/gateway_test.go
+++ b/pkg/core/box/k8s/gateway_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	sandboxfake "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned/fake"
 
 	"github.com/footprintai/containarium/pkg/core/box"
 )
@@ -25,7 +26,7 @@ func gatewayBackend() (*Backend, *dynfake.FakeDynamicClient) {
 	scheme := runtime.NewScheme()
 	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 		map[schema.GroupVersionResource]string{pipeGVR: "PipeList"})
-	b := NewWithClients(fake.NewSimpleClientset(), dyn, Config{
+	b := NewWithClients(fake.NewSimpleClientset(), sandboxfake.NewSimpleClientset(), dyn, Config{
 		GatewayNamespace: "sshpiper",
 		GatewayHost:      "gw.example.com",
 	})
@@ -69,7 +70,7 @@ func TestCreateProgramsPipe(t *testing.T) {
 	}
 
 	host, _, _ := unstructured.NestedString(p.Object, "spec", "to", "host")
-	if host != "box-0.boxes.tenant-alice.svc.cluster.local:2222" {
+	if host != "box.tenant-alice.svc.cluster.local:2222" {
 		t.Errorf("to.host = %q", host)
 	}
 	user, _, _ := unstructured.NestedString(p.Object, "spec", "to", "username")
@@ -87,10 +88,10 @@ func TestCreateProgramsPipe(t *testing.T) {
 	}
 	raw, _ := base64.StdEncoding.DecodeString(khd)
 	// Both host keys pinned (sshpiper may negotiate either), bracketed [host]:port.
-	if !strings.Contains(string(raw), "[box-0.boxes.tenant-alice.svc.cluster.local]:2222 ssh-ed25519 ") {
+	if !strings.Contains(string(raw), "[box.tenant-alice.svc.cluster.local]:2222 ssh-ed25519 ") {
 		t.Errorf("known_hosts missing ed25519 line: %q", raw)
 	}
-	if !strings.Contains(string(raw), "[box-0.boxes.tenant-alice.svc.cluster.local]:2222 ssh-rsa ") {
+	if !strings.Contains(string(raw), "[box.tenant-alice.svc.cluster.local]:2222 ssh-rsa ") {
 		t.Errorf("known_hosts missing rsa line: %q", raw)
 	}
 }
@@ -135,7 +136,7 @@ func TestGatewayUpstreamCredential(t *testing.T) {
 	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
 		map[schema.GroupVersionResource]string{pipeGVR: "PipeList"})
 	cs := fake.NewSimpleClientset()
-	b := NewWithClients(cs, dyn, Config{
+	b := NewWithClients(cs, sandboxfake.NewSimpleClientset(), dyn, Config{
 		GatewayNamespace:         "sshpiper",
 		GatewayHost:              "gw.example.com",
 		GatewayUpstreamPublicKey: "ssh-ed25519 GATEWAYPUB gateway",
@@ -178,7 +179,7 @@ func TestGatewayUpstreamCredential(t *testing.T) {
 func TestGatewayDisabledSkipsPipe(t *testing.T) {
 	// No dynamic client (NewWithClientset) → gateway off → Create still succeeds
 	// and programs no Pipe.
-	b := NewWithClientset(fake.NewSimpleClientset(), Config{GatewayNamespace: "sshpiper"})
+	b := NewWithClientset(fake.NewSimpleClientset(), sandboxfake.NewSimpleClientset(), Config{GatewayNamespace: "sshpiper"})
 	if b.gatewayEnabled() {
 		t.Fatal("gateway should be disabled without a dynamic client")
 	}

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -16,13 +16,16 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	sandboxclient "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned"
 
 	"github.com/footprintai/containarium/pkg/core/box"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
-// Config is the K8s backend's wiring, supplied at daemon start when the `k8s`
-// build variant selects this backend. See docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md.
+// Config is the K8s backend's wiring, supplied at daemon start when
+// CONTAINARIUM_RUNTIME=k8s selects this backend. See
+// docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md.
 type Config struct {
 	// Kubeconfig is the path to a kubeconfig file. Empty means: try in-cluster
 	// config, then the ambient loading rules ($KUBECONFIG / ~/.kube/config).
@@ -83,7 +86,12 @@ type Config struct {
 	InsecureIgnoreHostKey bool
 }
 
-// Backend implements box.BoxBackend on Kubernetes.
+// Backend implements box.BoxBackend on Kubernetes, on top of the
+// kubernetes-sigs/agent-sandbox Sandbox CRD: the daemon owns the per-tenant
+// namespace, Secrets, NetworkPolicy, data PVC, and gateway Pipe, and declares
+// one Sandbox CR per box — the agent-sandbox controller owns the pod and the
+// headless Service under it. The controller must be installed in the cluster
+// (its v0.5.1 release asset `manifest.yaml`).
 //
 // Capability note: it deliberately does NOT implement box.ExecCapable — the
 // K8s agent-box is ForceCommand-pinned and provisioning is image-baked, so
@@ -92,14 +100,15 @@ type Config struct {
 type Backend struct {
 	cfg       Config
 	clientset kubernetes.Interface
+	sandboxes sandboxclient.Interface
 	dyn       dynamic.Interface // for the sshpiper Pipe CRD; nil disables gateway routing
 }
 
 var _ box.BoxBackend = (*Backend)(nil)
 
-// New constructs a K8s backend: it builds a client-go clientset + dynamic
-// client (in-cluster, an explicit kubeconfig, or the ambient rules) and applies
-// config defaults.
+// New constructs a K8s backend: it builds a client-go clientset, the
+// agent-sandbox typed clientset, and a dynamic client (in-cluster, an explicit
+// kubeconfig, or the ambient rules) and applies config defaults.
 func New(cfg Config) (*Backend, error) {
 	restCfg, err := buildRestConfig(cfg.Kubeconfig)
 	if err != nil {
@@ -109,26 +118,30 @@ func New(cfg Config) (*Backend, error) {
 	if err != nil {
 		return nil, fmt.Errorf("k8s: build clientset: %w", err)
 	}
+	sc, err := sandboxclient.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("k8s: build agent-sandbox clientset: %w", err)
+	}
 	dyn, err := dynamic.NewForConfig(restCfg)
 	if err != nil {
 		return nil, fmt.Errorf("k8s: build dynamic client: %w", err)
 	}
-	return newBackend(cs, dyn, cfg), nil
+	return newBackend(cs, sc, dyn, cfg), nil
 }
 
-// NewWithClientset builds a Backend over an injected clientset, with gateway
+// NewWithClientset builds a Backend over injected clientsets, with gateway
 // (Pipe) routing disabled (no dynamic client). Used by lifecycle unit tests.
-func NewWithClientset(cs kubernetes.Interface, cfg Config) *Backend {
-	return newBackend(cs, nil, cfg)
+func NewWithClientset(cs kubernetes.Interface, sc sandboxclient.Interface, cfg Config) *Backend {
+	return newBackend(cs, sc, nil, cfg)
 }
 
-// NewWithClients builds a Backend over injected clientset + dynamic client
+// NewWithClients builds a Backend over injected clientsets + dynamic client
 // (fakes for unit tests, a kind cluster for e2e), exercising gateway routing.
-func NewWithClients(cs kubernetes.Interface, dyn dynamic.Interface, cfg Config) *Backend {
-	return newBackend(cs, dyn, cfg)
+func NewWithClients(cs kubernetes.Interface, sc sandboxclient.Interface, dyn dynamic.Interface, cfg Config) *Backend {
+	return newBackend(cs, sc, dyn, cfg)
 }
 
-func newBackend(cs kubernetes.Interface, dyn dynamic.Interface, cfg Config) *Backend {
+func newBackend(cs kubernetes.Interface, sc sandboxclient.Interface, dyn dynamic.Interface, cfg Config) *Backend {
 	if cfg.TenantNamespacePrefix == "" {
 		cfg.TenantNamespacePrefix = "tenant-"
 	}
@@ -146,7 +159,7 @@ func newBackend(cs kubernetes.Interface, dyn dynamic.Interface, cfg Config) *Bac
 		cfg.DefaultMemoryRequest = resolveQuantity(cfg.DefaultMemoryRequest, defaultMemoryRequest)
 		cfg.DefaultMemoryLimit = resolveQuantity(cfg.DefaultMemoryLimit, defaultMemoryLimit)
 	}
-	return &Backend{cfg: cfg, clientset: cs, dyn: dyn}
+	return &Backend{cfg: cfg, clientset: cs, sandboxes: sc, dyn: dyn}
 }
 
 // resolveQuantity returns v when it is a valid K8s resource quantity, else the
@@ -186,10 +199,11 @@ func (b *Backend) namespaceFor(tenant string) string {
 	return b.cfg.TenantNamespacePrefix + tenant
 }
 
-// Create reconciles the per-tenant namespace + Secret + headless Service +
-// default-deny NetworkPolicy + StatefulSet, then returns the box's status.
-// Each step is idempotent (AlreadyExists is success) so re-create reuses the
-// box rather than erroring (#669).
+// Create reconciles the per-tenant namespace + Secrets + default-deny
+// NetworkPolicy + the Sandbox CR, then returns the box's status. The
+// agent-sandbox controller creates the pod and the headless Service from the
+// Sandbox. Each step is idempotent (AlreadyExists is success) so re-create
+// reuses the box rather than erroring (#669).
 func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus, error) {
 	ns := b.namespaceFor(spec.Ref.Tenant)
 	tenant := spec.Ref.Tenant
@@ -200,7 +214,7 @@ func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus,
 	if _, err := b.clientset.CoreV1().Namespaces().Create(ctx, namespaceObject(ns, tenant), metav1.CreateOptions{}); ignoreExists(err) != nil {
 		return nil, fmt.Errorf("k8s: ensure namespace: %w", err)
 	}
-	// Provision the data PVC before the StatefulSet so the pod can mount it on
+	// Provision the data PVC before the Sandbox so the pod can mount it on
 	// first start. Per-box spec.Resources.StorageClass takes precedence over the
 	// global Config.StorageClass; skipped when both are empty (backward compat).
 	storageClass := b.cfg.StorageClass
@@ -216,19 +230,16 @@ func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus,
 	if _, err := b.clientset.CoreV1().Secrets(ns).Create(ctx, secretObject(ns, tenant, b.boxAuthorizedKeys(spec.SSHKeys)), metav1.CreateOptions{}); ignoreExists(err) != nil {
 		return nil, fmt.Errorf("k8s: ensure secret: %w", err)
 	}
-	if _, err := b.clientset.CoreV1().Services(ns).Create(ctx, serviceObject(ns, tenant), metav1.CreateOptions{}); ignoreExists(err) != nil {
-		return nil, fmt.Errorf("k8s: ensure service: %w", err)
-	}
 	if _, err := b.clientset.NetworkingV1().NetworkPolicies(ns).Create(ctx, networkPolicyObject(ns, tenant), metav1.CreateOptions{}); ignoreExists(err) != nil {
 		return nil, fmt.Errorf("k8s: ensure networkpolicy: %w", err)
 	}
-	// Stable per-box host key Secret — created before the StatefulSet, which
+	// Stable per-box host key Secret — created before the Sandbox, whose pod
 	// mounts it (and dropbear uses it so the gateway can pin it).
 	if _, err := b.ensureHostKey(ctx, tenant); err != nil {
 		return nil, fmt.Errorf("k8s: ensure host key: %w", err)
 	}
-	if _, err := b.clientset.AppsV1().StatefulSets(ns).Create(ctx, statefulSetObject(ns, spec, storageClass != "", b.memDefaults()), metav1.CreateOptions{}); ignoreExists(err) != nil {
-		return nil, fmt.Errorf("k8s: ensure statefulset: %w", err)
+	if _, err := b.sandboxes.AgentsV1beta1().Sandboxes(ns).Create(ctx, sandboxObject(ns, spec, storageClass != "", b.memDefaults()), metav1.CreateOptions{}); ignoreExists(err) != nil {
+		return nil, fmt.Errorf("k8s: ensure sandbox: %w", err)
 	}
 	// Program the SSH gateway so username=<tenant> routes to this box (no-op
 	// when the gateway isn't configured).
@@ -238,58 +249,56 @@ func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus,
 	return b.Get(ctx, spec.Ref)
 }
 
-// Get reads the box's StatefulSet (and pod) into a BoxStatus, or (nil, nil)
-// when the box does not exist.
+// Get reads the box's Sandbox CR into a BoxStatus, or (nil, nil) when the box
+// does not exist.
 func (b *Backend) Get(ctx context.Context, ref box.BoxRef) (*box.BoxStatus, error) {
 	ns := b.namespaceFor(ref.Tenant)
-	ss, err := b.clientset.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{})
+	sb, err := b.sandboxes.AgentsV1beta1().Sandboxes(ns).Get(ctx, sandboxName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-
-	st := &box.BoxStatus{
-		Ref:       box.BoxRef{Tenant: ref.Tenant, Name: statefulSetName},
-		State:     stateOf(ss),
-		Resources: resourcesOf(ss),
-		Labels:    metaFromAnnotations(ss.Annotations),
-		BackendID: "k8s",
-	}
-	// Pod IP, best-effort (the pod may not exist yet while replicas=0).
-	if pod, perr := b.clientset.CoreV1().Pods(ns).Get(ctx, statefulSetName+"-0", metav1.GetOptions{}); perr == nil {
-		st.IPAddress = pod.Status.PodIP
-	}
-	return st, nil
+	return b.statusOf(ref.Tenant, sb), nil
 }
 
 // List returns every box this backend manages (all namespaces, by label).
 func (b *Backend) List(ctx context.Context) ([]box.BoxStatus, error) {
-	ssl, err := b.clientset.AppsV1().StatefulSets("").List(ctx, metav1.ListOptions{
+	sbl, err := b.sandboxes.AgentsV1beta1().Sandboxes("").List(ctx, metav1.ListOptions{
 		LabelSelector: managedByLabel + "=" + managedByValue,
 	})
 	if err != nil {
 		return nil, err
 	}
-	out := make([]box.BoxStatus, 0, len(ssl.Items))
-	for i := range ssl.Items {
-		ss := &ssl.Items[i]
-		out = append(out, box.BoxStatus{
-			Ref:       box.BoxRef{Tenant: ss.Labels[tenantLabel], Name: statefulSetName},
-			State:     stateOf(ss),
-			Resources: resourcesOf(ss),
-			Labels:    metaFromAnnotations(ss.Annotations),
-			BackendID: "k8s",
-		})
+	out := make([]box.BoxStatus, 0, len(sbl.Items))
+	for i := range sbl.Items {
+		sb := &sbl.Items[i]
+		out = append(out, *b.statusOf(sb.Labels[tenantLabel], sb))
 	}
 	return out, nil
 }
 
-// Delete removes the box's compute objects (StatefulSet, Service, Secrets,
-// NetworkPolicy, gateway Pipe) but retains the PVC and namespace so the
-// persistent data survives. Call Purge to permanently remove the PVC and
-// namespace.
+// statusOf maps a Sandbox CR onto the runtime-neutral BoxStatus.
+func (b *Backend) statusOf(tenant string, sb *sandboxv1beta1.Sandbox) *box.BoxStatus {
+	st := &box.BoxStatus{
+		Ref:       box.BoxRef{Tenant: tenant, Name: sandboxName},
+		State:     stateOf(sb),
+		Resources: resourcesOf(sb),
+		Labels:    metaFromAnnotations(sb.Annotations),
+		BackendID: "k8s",
+	}
+	// Pod IP, populated by the controller once the pod is scheduled.
+	if len(sb.Status.PodIPs) > 0 {
+		st.IPAddress = sb.Status.PodIPs[0]
+	}
+	return st
+}
+
+// Delete removes the box's compute objects (the Sandbox CR — which cascades
+// to its pod and Service — plus Secrets, NetworkPolicy, gateway Pipe) but
+// retains the PVC and namespace so the persistent data survives. Call Purge
+// to permanently remove the PVC and namespace.
 //
 // When StorageClass is unset (no PVC), Delete falls back to removing the entire
 // namespace (original behaviour, backward compat).
@@ -307,12 +316,12 @@ func (b *Backend) Delete(ctx context.Context, ref box.BoxRef, force bool) error 
 		return err
 	}
 	// Persistent storage: delete compute objects individually; keep namespace+PVC.
+	// Deleting the Sandbox cascades to its controller-owned children (pod +
+	// headless Service) via owner references; the daemon-owned data PVC carries
+	// no owner reference and survives.
 	dels := []func() error{
 		func() error {
-			return ignoreNotFound(b.clientset.AppsV1().StatefulSets(ns).Delete(ctx, statefulSetName, metav1.DeleteOptions{}))
-		},
-		func() error {
-			return ignoreNotFound(b.clientset.CoreV1().Services(ns).Delete(ctx, serviceName, metav1.DeleteOptions{}))
+			return ignoreNotFound(b.sandboxes.AgentsV1beta1().Sandboxes(ns).Delete(ctx, sandboxName, metav1.DeleteOptions{}))
 		},
 		func() error {
 			return ignoreNotFound(b.clientset.NetworkingV1().NetworkPolicies(ns).Delete(ctx, "default-deny", metav1.DeleteOptions{}))
@@ -349,18 +358,25 @@ func (b *Backend) Purge(ctx context.Context, ref box.BoxRef) error {
 	return err
 }
 
-// Start scales the box StatefulSet to 1 replica.
-func (b *Backend) Start(ctx context.Context, ref box.BoxRef) error { return b.scale(ctx, ref, 1) }
-
-// Stop scales the box StatefulSet to 0 replicas.
-func (b *Backend) Stop(ctx context.Context, ref box.BoxRef, force bool) error {
-	return b.scale(ctx, ref, 0)
+// Start resumes the box: operatingMode=Running makes the agent-sandbox
+// controller (re)create the pod, reattaching the retained PVC and identity.
+func (b *Backend) Start(ctx context.Context, ref box.BoxRef) error {
+	return b.setOperatingMode(ctx, ref, sandboxv1beta1.SandboxOperatingModeRunning)
 }
 
-func (b *Backend) scale(ctx context.Context, ref box.BoxRef, replicas int32) error {
-	patch := []byte(fmt.Sprintf(`{"spec":{"replicas":%d}}`, replicas))
-	_, err := b.clientset.AppsV1().StatefulSets(b.namespaceFor(ref.Tenant)).
-		Patch(ctx, statefulSetName, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+// Stop suspends the box: operatingMode=Suspended makes the controller delete
+// only the pod — PVC, Service, Secrets, and the Sandbox identity all persist.
+func (b *Backend) Stop(ctx context.Context, ref box.BoxRef, force bool) error {
+	return b.setOperatingMode(ctx, ref, sandboxv1beta1.SandboxOperatingModeSuspended)
+}
+
+// setOperatingMode merge-patches spec.operatingMode. A merge patch (not
+// strategic) — CRDs don't support strategic merge, and for a scalar field the
+// two are equivalent.
+func (b *Backend) setOperatingMode(ctx context.Context, ref box.BoxRef, mode sandboxv1beta1.SandboxOperatingMode) error {
+	patch := []byte(fmt.Sprintf(`{"spec":{"operatingMode":%q}}`, mode))
+	_, err := b.sandboxes.AgentsV1beta1().Sandboxes(b.namespaceFor(ref.Tenant)).
+		Patch(ctx, sandboxName, types.MergePatchType, patch, metav1.PatchOptions{})
 	return err
 }
 
@@ -407,8 +423,17 @@ func (b *Backend) boxAuthorizedKeys(agentKeys []string) []string {
 	return agentKeys
 }
 
-// Resize patches the box container's resource limits. Unparseable (incus-native)
-// quantities are skipped; a no-op resize returns nil.
+// Resize updates the box container's resource limits on the Sandbox's pod
+// template. Unparseable (incus-native) quantities are skipped; a no-op resize
+// returns nil.
+//
+// Get→mutate→Update rather than a patch: CRDs don't support strategic merge,
+// and a plain merge patch would replace the whole containers list.
+//
+// Behavioral note vs the old StatefulSet path: the agent-sandbox controller
+// does not recreate a live pod on template drift, so a resize takes effect at
+// the NEXT pod creation (the next Stop→Start cycle), not immediately. The
+// server-side dispatch layer decides whether to bounce the box.
 func (b *Backend) Resize(ctx context.Context, ref box.BoxRef, r box.ResourceLimits) error {
 	// Resize does not change GPU count, and passes no memory default: the floor
 	// is a create-time concern, so an explicit resize honors "empty = unchanged"
@@ -417,29 +442,21 @@ func (b *Backend) Resize(ctx context.Context, ref box.BoxRef, r box.ResourceLimi
 	if res == nil {
 		return nil
 	}
-	patch := map[string]any{
-		"spec": map[string]any{
-			"template": map[string]any{
-				"spec": map[string]any{
-					"containers": []map[string]any{{
-						"name":      "agent-box",
-						"resources": res,
-					}},
-				},
-			},
-		},
-	}
-	body, err := json.Marshal(patch)
+	ns := b.namespaceFor(ref.Tenant)
+	sb, err := b.sandboxes.AgentsV1beta1().Sandboxes(ns).Get(ctx, sandboxName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
-	_, err = b.clientset.AppsV1().StatefulSets(b.namespaceFor(ref.Tenant)).
-		Patch(ctx, statefulSetName, types.StrategicMergePatchType, body, metav1.PatchOptions{})
+	for i := range sb.Spec.PodTemplate.Spec.Containers {
+		if sb.Spec.PodTemplate.Spec.Containers[i].Name == "agent-box" {
+			sb.Spec.PodTemplate.Spec.Containers[i].Resources = *res
+		}
+	}
+	_, err = b.sandboxes.AgentsV1beta1().Sandboxes(ns).Update(ctx, sb, metav1.UpdateOptions{})
 	return err
 }
 
-// SetMeta writes the runtime-neutral metadata as prefixed StatefulSet
-// annotations.
+// SetMeta writes the runtime-neutral metadata as prefixed Sandbox annotations.
 func (b *Backend) SetMeta(ctx context.Context, ref box.BoxRef, meta map[string]string) error {
 	ann := map[string]string{}
 	for k, v := range meta {
@@ -449,31 +466,33 @@ func (b *Backend) SetMeta(ctx context.Context, ref box.BoxRef, meta map[string]s
 	if err != nil {
 		return err
 	}
-	_, err = b.clientset.AppsV1().StatefulSets(b.namespaceFor(ref.Tenant)).
-		Patch(ctx, statefulSetName, types.MergePatchType, patch, metav1.PatchOptions{})
+	_, err = b.sandboxes.AgentsV1beta1().Sandboxes(b.namespaceFor(ref.Tenant)).
+		Patch(ctx, sandboxName, types.MergePatchType, patch, metav1.PatchOptions{})
 	return err
 }
 
 // GetMeta reads the prefixed annotations back into the metadata map.
 func (b *Backend) GetMeta(ctx context.Context, ref box.BoxRef) (map[string]string, error) {
-	ss, err := b.clientset.AppsV1().StatefulSets(b.namespaceFor(ref.Tenant)).Get(ctx, statefulSetName, metav1.GetOptions{})
+	sb, err := b.sandboxes.AgentsV1beta1().Sandboxes(b.namespaceFor(ref.Tenant)).Get(ctx, sandboxName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	return metaFromAnnotations(ss.Annotations), nil
+	return metaFromAnnotations(sb.Annotations), nil
 }
 
-// stateOf maps a StatefulSet's replica/ready counts to the proto state: 0
-// desired replicas → STOPPED; ready → RUNNING; otherwise still coming up.
-func stateOf(ss *appsv1.StatefulSet) pb.ContainerState {
-	desired := int32(0)
-	if ss.Spec.Replicas != nil {
-		desired = *ss.Spec.Replicas
-	}
-	if desired == 0 {
+// stateOf maps a Sandbox onto the proto state. spec.operatingMode is the
+// desired state (Suspended → STOPPED, the CR-native replicas=0); within
+// Running, the controller-set conditions distinguish a Ready pod (RUNNING)
+// from one still coming up (PROVISIONING). Finished means the pod hit a
+// terminal phase — for a long-lived SSH box that is effectively stopped.
+func stateOf(sb *sandboxv1beta1.Sandbox) pb.ContainerState {
+	if sb.Spec.OperatingMode == sandboxv1beta1.SandboxOperatingModeSuspended {
 		return pb.ContainerState_CONTAINER_STATE_STOPPED
 	}
-	if ss.Status.ReadyReplicas >= 1 {
+	if apimeta.IsStatusConditionTrue(sb.Status.Conditions, string(sandboxv1beta1.SandboxConditionFinished)) {
+		return pb.ContainerState_CONTAINER_STATE_STOPPED
+	}
+	if apimeta.IsStatusConditionTrue(sb.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady)) {
 		return pb.ContainerState_CONTAINER_STATE_RUNNING
 	}
 	return pb.ContainerState_CONTAINER_STATE_PROVISIONING
@@ -481,9 +500,9 @@ func stateOf(ss *appsv1.StatefulSet) pb.ContainerState {
 
 // resourcesOf reads the box container's limits back into the runtime-neutral
 // shape (K8s quantity strings, e.g. "2"/"4Gi").
-func resourcesOf(ss *appsv1.StatefulSet) box.ResourceLimits {
+func resourcesOf(sb *sandboxv1beta1.Sandbox) box.ResourceLimits {
 	var r box.ResourceLimits
-	for _, c := range ss.Spec.Template.Spec.Containers {
+	for _, c := range sb.Spec.PodTemplate.Spec.Containers {
 		if c.Name != "agent-box" {
 			continue
 		}

--- a/pkg/core/box/k8s/k8s_test.go
+++ b/pkg/core/box/k8s/k8s_test.go
@@ -8,6 +8,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	sandboxfake "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned/fake"
 
 	"github.com/footprintai/containarium/pkg/core/box"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -17,13 +19,24 @@ import (
 // in plain `go test -tags k8s` with no cluster. The kind e2e (e2e_test.go)
 // covers behavior against a real apiserver.
 
-func testBackend() (*Backend, *fake.Clientset) {
+func testBackend() (*Backend, *fake.Clientset, *sandboxfake.Clientset) {
 	cs := fake.NewSimpleClientset()
-	return NewWithClientset(cs, Config{BoxImage: "registry.k8s.io/pause:3.9", GatewayHost: "gw.example.com"}), cs
+	sc := sandboxfake.NewSimpleClientset()
+	return NewWithClientset(cs, sc, Config{BoxImage: "registry.k8s.io/pause:3.9", GatewayHost: "gw.example.com"}), cs, sc
+}
+
+// getSandbox fetches the tenant's Sandbox CR from the fake clientset.
+func getSandbox(t *testing.T, sc *sandboxfake.Clientset, ns string) *sandboxv1beta1.Sandbox {
+	t.Helper()
+	sb, err := sc.AgentsV1beta1().Sandboxes(ns).Get(context.Background(), sandboxName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("sandbox not created: %v", err)
+	}
+	return sb
 }
 
 func TestKindAndCapabilities(t *testing.T) {
-	b, _ := testBackend()
+	b, _, _ := testBackend()
 	if b.Kind() != box.KindK8s {
 		t.Fatalf("Kind() = %q, want %q", b.Kind(), box.KindK8s)
 	}
@@ -34,7 +47,7 @@ func TestKindAndCapabilities(t *testing.T) {
 }
 
 func TestCreateReconcilesObjects(t *testing.T) {
-	b, cs := testBackend()
+	b, cs, sc := testBackend()
 	ctx := context.Background()
 	st, err := b.Create(ctx, box.BoxSpec{
 		Ref:       box.BoxRef{Tenant: "alice"},
@@ -45,7 +58,7 @@ func TestCreateReconcilesObjects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if st == nil || st.Ref.Tenant != "alice" || st.Ref.Name != statefulSetName {
+	if st == nil || st.Ref.Tenant != "alice" || st.Ref.Name != sandboxName {
 		t.Fatalf("status = %+v", st)
 	}
 
@@ -53,36 +66,35 @@ func TestCreateReconcilesObjects(t *testing.T) {
 	if _, err := cs.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{}); err != nil {
 		t.Errorf("namespace not created: %v", err)
 	}
-	ss, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{})
-	if err != nil {
-		t.Errorf("statefulset not created: %v", err)
-	} else {
+	sb := getSandbox(t, sc, ns)
+	podSpec := sb.Spec.PodTemplate.Spec
+	{
 		// restricted-PSA hardening the box image is built for.
-		sc := ss.Spec.Template.Spec.Containers[0].SecurityContext
-		if sc == nil || sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
-			t.Errorf("container not runAsNonRoot: %+v", sc)
+		csc := podSpec.Containers[0].SecurityContext
+		if csc == nil || csc.RunAsNonRoot == nil || !*csc.RunAsNonRoot {
+			t.Errorf("container not runAsNonRoot: %+v", csc)
 		}
-		if sc != nil && (sc.Capabilities == nil || len(sc.Capabilities.Drop) != 1 || string(sc.Capabilities.Drop[0]) != "ALL") {
-			t.Errorf("container does not drop ALL caps: %+v", sc.Capabilities)
+		if csc != nil && (csc.Capabilities == nil || len(csc.Capabilities.Drop) != 1 || string(csc.Capabilities.Drop[0]) != "ALL") {
+			t.Errorf("container does not drop ALL caps: %+v", csc.Capabilities)
 		}
-		if pscPort := ss.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort; pscPort != 2222 {
+		if pscPort := podSpec.Containers[0].Ports[0].ContainerPort; pscPort != 2222 {
 			t.Errorf("container port = %d, want 2222", pscPort)
 		}
 		// authorized_keys mounted where the image reads it (or the box rejects
 		// every login — found in live test), and the stable host key mounted
 		// (so the gateway can pin it).
 		mounts := map[string]string{} // mountPath set
-		for _, m := range ss.Spec.Template.Spec.Containers[0].VolumeMounts {
+		for _, m := range podSpec.Containers[0].VolumeMounts {
 			mounts[m.MountPath] = m.Name
 		}
 		if mounts["/etc/agent-box"] == "" {
-			t.Errorf("authorized_keys not mounted at /etc/agent-box: %+v", ss.Spec.Template.Spec.Containers[0].VolumeMounts)
+			t.Errorf("authorized_keys not mounted at /etc/agent-box: %+v", podSpec.Containers[0].VolumeMounts)
 		}
 		if mounts["/etc/agent-box-hostkey"] == "" {
 			t.Errorf("host key not mounted at /etc/agent-box-hostkey")
 		}
 		vols := map[string]string{} // volume name -> secret name
-		for _, v := range ss.Spec.Template.Spec.Volumes {
+		for _, v := range podSpec.Volumes {
 			if v.Secret != nil {
 				vols[v.Name] = v.Secret.SecretName
 			}
@@ -94,8 +106,9 @@ func TestCreateReconcilesObjects(t *testing.T) {
 			t.Errorf("host-key volume secret = %q", vols[hostKeyVolume])
 		}
 	}
-	if _, err := cs.CoreV1().Services(ns).Get(ctx, serviceName, metav1.GetOptions{}); err != nil {
-		t.Errorf("service not created: %v", err)
+	// The controller owns the headless Service; the Sandbox must ask for it.
+	if sb.Spec.Service == nil || !*sb.Spec.Service {
+		t.Error("sandbox spec.service not enabled; the gateway needs the headless Service")
 	}
 	if _, err := cs.NetworkingV1().NetworkPolicies(ns).Get(ctx, "default-deny", metav1.GetOptions{}); err != nil {
 		t.Errorf("networkpolicy not created: %v", err)
@@ -114,7 +127,7 @@ func TestCreateReconcilesObjects(t *testing.T) {
 }
 
 func TestCreateIdempotent(t *testing.T) {
-	b, _ := testBackend()
+	b, _, _ := testBackend()
 	ctx := context.Background()
 	spec := box.BoxSpec{Ref: box.BoxRef{Tenant: "bob"}, Image: "x", AutoStart: true}
 	if _, err := b.Create(ctx, spec); err != nil {
@@ -126,7 +139,7 @@ func TestCreateIdempotent(t *testing.T) {
 }
 
 func TestGetMissing(t *testing.T) {
-	b, _ := testBackend()
+	b, _, _ := testBackend()
 	st, err := b.Get(context.Background(), box.BoxRef{Tenant: "ghost"})
 	if err != nil || st != nil {
 		t.Fatalf("Get(missing) = (%+v, %v), want (nil, nil)", st, err)
@@ -134,34 +147,31 @@ func TestGetMissing(t *testing.T) {
 }
 
 func TestStartStopScale(t *testing.T) {
-	b, cs := testBackend()
+	b, _, sc := testBackend()
 	ctx := context.Background()
 	ref := box.BoxRef{Tenant: "carol"}
 	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref, Image: "x"}); err != nil { // AutoStart false → 0
 		t.Fatalf("Create: %v", err)
 	}
-	ss, _ := cs.AppsV1().StatefulSets("tenant-carol").Get(ctx, statefulSetName, metav1.GetOptions{})
-	if *ss.Spec.Replicas != 0 {
-		t.Fatalf("created replicas = %d, want 0", *ss.Spec.Replicas)
+	if sb := getSandbox(t, sc, "tenant-carol"); sb.Spec.OperatingMode != sandboxv1beta1.SandboxOperatingModeSuspended {
+		t.Fatalf("created operatingMode = %q, want Suspended", sb.Spec.OperatingMode)
 	}
 	if err := b.Start(ctx, ref); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	ss, _ = cs.AppsV1().StatefulSets("tenant-carol").Get(ctx, statefulSetName, metav1.GetOptions{})
-	if *ss.Spec.Replicas != 1 {
-		t.Errorf("after Start replicas = %d, want 1", *ss.Spec.Replicas)
+	if sb := getSandbox(t, sc, "tenant-carol"); sb.Spec.OperatingMode != sandboxv1beta1.SandboxOperatingModeRunning {
+		t.Errorf("after Start operatingMode = %q, want Running", sb.Spec.OperatingMode)
 	}
 	if err := b.Stop(ctx, ref, false); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
-	ss, _ = cs.AppsV1().StatefulSets("tenant-carol").Get(ctx, statefulSetName, metav1.GetOptions{})
-	if *ss.Spec.Replicas != 0 {
-		t.Errorf("after Stop replicas = %d, want 0", *ss.Spec.Replicas)
+	if sb := getSandbox(t, sc, "tenant-carol"); sb.Spec.OperatingMode != sandboxv1beta1.SandboxOperatingModeSuspended {
+		t.Errorf("after Stop operatingMode = %q, want Suspended", sb.Spec.OperatingMode)
 	}
 }
 
 func TestDeleteRemovesNamespace(t *testing.T) {
-	b, cs := testBackend()
+	b, cs, _ := testBackend()
 	ctx := context.Background()
 	ref := box.BoxRef{Tenant: "dave"}
 	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref, Image: "x", AutoStart: true}); err != nil {
@@ -180,7 +190,7 @@ func TestDeleteRemovesNamespace(t *testing.T) {
 }
 
 func TestSetGetMeta(t *testing.T) {
-	b, _ := testBackend()
+	b, _, _ := testBackend()
 	ctx := context.Background()
 	ref := box.BoxRef{Tenant: "erin"}
 	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref, Image: "x", AutoStart: true}); err != nil {
@@ -199,7 +209,7 @@ func TestSetGetMeta(t *testing.T) {
 }
 
 func TestResolveGatewayEndpoint(t *testing.T) {
-	b, _ := testBackend()
+	b, _, _ := testBackend()
 	ep, err := b.Resolve(context.Background(), box.BoxRef{Tenant: "alice"})
 	if err != nil || ep == nil {
 		t.Fatalf("Resolve = (%+v, %v)", ep, err)
@@ -213,7 +223,7 @@ func TestResolveGatewayEndpoint(t *testing.T) {
 // nvidia.com/gpu limit on the container, and that the pod carries the
 // gpu-count annotation for observability.
 func TestGPUResourceRequirements(t *testing.T) {
-	b, cs := testBackend()
+	b, _, sc := testBackend()
 	ctx := context.Background()
 	ref := box.BoxRef{Tenant: "gpu-user"}
 	if _, err := b.Create(ctx, box.BoxSpec{
@@ -224,13 +234,10 @@ func TestGPUResourceRequirements(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	ns := "tenant-gpu-user"
-	ss, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("StatefulSet not found: %v", err)
-	}
+	sb := getSandbox(t, sc, ns)
 
 	// Container must carry nvidia.com/gpu: 2 in both limits and requests.
-	c := ss.Spec.Template.Spec.Containers[0]
+	c := sb.Spec.PodTemplate.Spec.Containers[0]
 	gpuLimit := c.Resources.Limits[nvidiaGPUResource]
 	if gpuLimit.Value() != 2 {
 		t.Errorf("nvidia.com/gpu limit = %v, want 2", gpuLimit.Value())
@@ -241,7 +248,7 @@ func TestGPUResourceRequirements(t *testing.T) {
 	}
 
 	// Pod template must carry the gpu-count annotation.
-	ann := ss.Spec.Template.Annotations[gpuCountAnnotation]
+	ann := sb.Spec.PodTemplate.ObjectMeta.Annotations[gpuCountAnnotation]
 	if ann != "2" {
 		t.Errorf("gpu-count annotation = %q, want 2", ann)
 	}
@@ -250,23 +257,20 @@ func TestGPUResourceRequirements(t *testing.T) {
 // TestNoGPUResourceWhenGPUsEmpty verifies no nvidia.com/gpu limit is set and
 // no gpu-count annotation is added when GPUs is nil/empty.
 func TestNoGPUResourceWhenGPUsEmpty(t *testing.T) {
-	b, cs := testBackend()
+	b, _, sc := testBackend()
 	ctx := context.Background()
 	ref := box.BoxRef{Tenant: "no-gpu"}
 	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref, Image: "x"}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	ns := "tenant-no-gpu"
-	ss, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("StatefulSet not found: %v", err)
-	}
-	c := ss.Spec.Template.Spec.Containers[0]
+	sb := getSandbox(t, sc, ns)
+	c := sb.Spec.PodTemplate.Spec.Containers[0]
 	if _, ok := c.Resources.Limits[nvidiaGPUResource]; ok {
 		t.Error("nvidia.com/gpu limit set on non-GPU box")
 	}
-	if ss.Spec.Template.Annotations[gpuCountAnnotation] != "" {
-		t.Errorf("gpu-count annotation unexpectedly set: %q", ss.Spec.Template.Annotations[gpuCountAnnotation])
+	if sb.Spec.PodTemplate.ObjectMeta.Annotations[gpuCountAnnotation] != "" {
+		t.Errorf("gpu-count annotation unexpectedly set: %q", sb.Spec.PodTemplate.ObjectMeta.Annotations[gpuCountAnnotation])
 	}
 }
 
@@ -357,7 +361,7 @@ func TestDefaultRequestClampedToLimit(t *testing.T) {
 // rather than disabling the floor.
 func TestConfigOverrideMemoryFloor(t *testing.T) {
 	// Valid overrides flow through.
-	b := NewWithClientset(fake.NewSimpleClientset(), Config{
+	b := NewWithClientset(fake.NewSimpleClientset(), sandboxfake.NewSimpleClientset(), Config{
 		DefaultMemoryRequest: "512Mi",
 		DefaultMemoryLimit:   "2Gi",
 	})
@@ -366,13 +370,13 @@ func TestConfigOverrideMemoryFloor(t *testing.T) {
 	}
 
 	// A typo'd limit degrades to the built-in default (not unconstrained).
-	bad := NewWithClientset(fake.NewSimpleClientset(), Config{DefaultMemoryLimit: "2GB"})
+	bad := NewWithClientset(fake.NewSimpleClientset(), sandboxfake.NewSimpleClientset(), Config{DefaultMemoryLimit: "2GB"})
 	if d := bad.memDefaults(); d.limit != defaultMemoryLimit {
 		t.Errorf("invalid override limit = %q, want built-in %q", d.limit, defaultMemoryLimit)
 	}
 
 	// Disable clears the floor entirely.
-	off := NewWithClientset(fake.NewSimpleClientset(), Config{DisableDefaultMemoryFloor: true})
+	off := NewWithClientset(fake.NewSimpleClientset(), sandboxfake.NewSimpleClientset(), Config{DisableDefaultMemoryFloor: true})
 	if d := off.memDefaults(); d.limit != "" || d.request != "" {
 		t.Errorf("disabled memDefaults = %+v, want empty", d)
 	}
@@ -380,13 +384,14 @@ func TestConfigOverrideMemoryFloor(t *testing.T) {
 
 // testBackendWithStorage returns a backend with a StorageClass set, exercising
 // the CSI PVC lifecycle paths.
-func testBackendWithStorage() (*Backend, *fake.Clientset) {
+func testBackendWithStorage() (*Backend, *fake.Clientset, *sandboxfake.Clientset) {
 	cs := fake.NewSimpleClientset()
-	return NewWithClientset(cs, Config{
+	sc := sandboxfake.NewSimpleClientset()
+	return NewWithClientset(cs, sc, Config{
 		BoxImage:     "registry.k8s.io/pause:3.9",
 		GatewayHost:  "gw.example.com",
 		StorageClass: "standard",
-	}), cs
+	}), cs, sc
 }
 
 // TestPVCObjectBuilder verifies that pvcObject produces a well-formed PVC with
@@ -422,7 +427,7 @@ func TestPVCObjectBuilderDefaults(t *testing.T) {
 // TestCreateProvisionsPVC verifies that Create provisions a PVC when
 // StorageClass is configured.
 func TestCreateProvisionsPVC(t *testing.T) {
-	b, cs := testBackendWithStorage()
+	b, cs, sc := testBackendWithStorage()
 	ctx := context.Background()
 	ref := box.BoxRef{Tenant: "frank"}
 	if _, err := b.Create(ctx, box.BoxSpec{
@@ -446,24 +451,36 @@ func TestCreateProvisionsPVC(t *testing.T) {
 		t.Errorf("storage request = %q, want 30Gi", q.String())
 	}
 
-	// StatefulSet must mount the data volume at /home/agent.
-	ss, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("StatefulSet not found: %v", err)
+	// The Sandbox pod template must mount the data volume at /home/agent as a
+	// plain persistentVolumeClaim volume (NOT a volumeClaimTemplate, which the
+	// controller would owner-reference and GC with the Sandbox).
+	sb := getSandbox(t, sc, ns)
+	if len(sb.Spec.VolumeClaimTemplates) != 0 {
+		t.Errorf("sandbox uses volumeClaimTemplates; the data PVC must stay daemon-owned")
 	}
 	mounts := map[string]string{}
-	for _, m := range ss.Spec.Template.Spec.Containers[0].VolumeMounts {
+	for _, m := range sb.Spec.PodTemplate.Spec.Containers[0].VolumeMounts {
 		mounts[m.MountPath] = m.Name
 	}
 	if mounts[dataMount] == "" {
 		t.Errorf("data volume not mounted at %s: mounts=%v", dataMount, mounts)
+	}
+	var claims []string
+	for _, v := range sb.Spec.PodTemplate.Spec.Volumes {
+		if v.PersistentVolumeClaim != nil {
+			claims = append(claims, v.PersistentVolumeClaim.ClaimName)
+		}
+	}
+	if len(claims) != 1 || claims[0] != pvcName {
+		t.Errorf("pod volumes reference claims %v, want [%s]", claims, pvcName)
 	}
 }
 
 // TestCreateNoPVCWhenStorageClassEmpty verifies backward compat: no PVC when
 // StorageClass is unset, and the StatefulSet has no data volume mount.
 func TestCreateNoPVCWhenStorageClassEmpty(t *testing.T) {
-	b, cs := testBackend() // no StorageClass
+	b, cs, sc := testBackend() // no StorageClass
+	_ = sc
 	ctx := context.Background()
 	if _, err := b.Create(ctx, box.BoxSpec{Ref: box.BoxRef{Tenant: "grace"}, Image: "x"}); err != nil {
 		t.Fatalf("Create: %v", err)
@@ -473,8 +490,8 @@ func TestCreateNoPVCWhenStorageClassEmpty(t *testing.T) {
 	if err != nil || len(pvcs.Items) != 0 {
 		t.Errorf("expected no PVCs when StorageClass is empty, got %d", len(pvcs.Items))
 	}
-	ss, _ := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{})
-	for _, m := range ss.Spec.Template.Spec.Containers[0].VolumeMounts {
+	sb := getSandbox(t, sc, ns)
+	for _, m := range sb.Spec.PodTemplate.Spec.Containers[0].VolumeMounts {
 		if m.MountPath == dataMount {
 			t.Errorf("data volume mounted even without StorageClass")
 		}
@@ -484,7 +501,7 @@ func TestCreateNoPVCWhenStorageClassEmpty(t *testing.T) {
 // TestDeleteRetainsPVC verifies that Delete removes box compute objects but
 // keeps the namespace and PVC when StorageClass is configured.
 func TestDeleteRetainsPVC(t *testing.T) {
-	b, cs := testBackendWithStorage()
+	b, cs, sc := testBackendWithStorage()
 	ctx := context.Background()
 	ref := box.BoxRef{Tenant: "henry"}
 	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref, Image: "x"}); err != nil {
@@ -503,16 +520,16 @@ func TestDeleteRetainsPVC(t *testing.T) {
 	if _, err := cs.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{}); err != nil {
 		t.Errorf("PVC removed by Delete: %v", err)
 	}
-	// StatefulSet must be gone.
-	if _, err := cs.AppsV1().StatefulSets(ns).Get(ctx, statefulSetName, metav1.GetOptions{}); err == nil {
-		t.Error("StatefulSet still present after Delete")
+	// The Sandbox must be gone (its pod + Service go with it via owner refs).
+	if _, err := sc.AgentsV1beta1().Sandboxes(ns).Get(ctx, sandboxName, metav1.GetOptions{}); err == nil {
+		t.Error("Sandbox still present after Delete")
 	}
 }
 
 // TestPurgeRemovesPVCAndNamespace verifies that Purge removes both the PVC and
 // the namespace, and is a no-op on an absent box.
 func TestPurgeRemovesPVCAndNamespace(t *testing.T) {
-	b, cs := testBackendWithStorage()
+	b, cs, _ := testBackendWithStorage()
 	ctx := context.Background()
 	ref := box.BoxRef{Tenant: "iris"}
 	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref, Image: "x"}); err != nil {
@@ -538,7 +555,7 @@ func TestPurgeRemovesPVCAndNamespace(t *testing.T) {
 // TestCreatePerBoxStorageClassOverride verifies that a per-box
 // spec.Resources.StorageClass takes precedence over the global Config.StorageClass.
 func TestCreatePerBoxStorageClassOverride(t *testing.T) {
-	b, cs := testBackendWithStorage() // Config.StorageClass = "standard"
+	b, cs, _ := testBackendWithStorage() // Config.StorageClass = "standard"
 	ctx := context.Background()
 	ref := box.BoxRef{Tenant: "jane"}
 
@@ -565,7 +582,7 @@ func TestCreatePerBoxStorageClassOverride(t *testing.T) {
 // TestCreatePerBoxStorageClassEmpty verifies that an empty per-box StorageClass
 // falls back to the global Config.StorageClass.
 func TestCreatePerBoxStorageClassEmpty(t *testing.T) {
-	b, cs := testBackendWithStorage() // Config.StorageClass = "standard"
+	b, cs, _ := testBackendWithStorage() // Config.StorageClass = "standard"
 	ctx := context.Background()
 	ref := box.BoxRef{Tenant: "ken"}
 

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"fmt"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -13,16 +12,20 @@ import (
 	"github.com/footprintai/containarium/pkg/core/box"
 )
 
-// Object naming + labels. One box per tenant namespace: the StatefulSet is
-// always "box" (pod "box-0"), fronted by the headless Service "boxes".
+// Object naming + labels. One box per tenant namespace: the agent-sandbox
+// Sandbox CR is always "box"; its controller creates the pod (also "box") and
+// a headless Service (also "box") that gives the pod stable in-cluster DNS.
 const (
-	statefulSetName = "box"
-	serviceName     = "boxes"
-	sshPortName     = "ssh"
+	sandboxName = "box"
+	sshPortName = "ssh"
 
 	// pvcName is the PersistentVolumeClaim name inside the tenant namespace.
-	// It holds the box's persistent data (home directory). Created before the
-	// StatefulSet and retained on Delete; removed only by Purge.
+	// It holds the box's persistent data (home directory). Owned by the daemon,
+	// NOT declared via the Sandbox's volumeClaimTemplates: template-derived PVCs
+	// are owner-referenced to the Sandbox and garbage-collected with it, which
+	// would break delete-retains-data. Created before the Sandbox, mounted as a
+	// plain persistentVolumeClaim volume, retained on Delete; removed only by
+	// Purge.
 	pvcName     = "data"
 	dataMount   = "/home/agent"
 	dataVolume  = "data"
@@ -110,7 +113,6 @@ func pvcObject(ns, tenant, storageClass, disk string) *corev1.PersistentVolumeCl
 	return pvc
 }
 
-func int32p(i int32) *int32 { return &i }
 func int64p(i int64) *int64 { return &i }
 func boolp(b bool) *bool    { return &b }
 
@@ -143,24 +145,6 @@ func secretObject(ns, tenant string, keys []string) *corev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{Name: secretName(tenant), Namespace: ns, Labels: boxLabels(tenant)},
 		Type:       corev1.SecretTypeOpaque,
 		Data:       map[string][]byte{authorizedKeysKey: buf},
-	}
-}
-
-// serviceObject is the headless Service that gives the pod a stable DNS name
-// (box-0.boxes.<ns>.svc) the gateway routes to.
-func serviceObject(ns, tenant string) *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns, Labels: boxLabels(tenant)},
-		Spec: corev1.ServiceSpec{
-			ClusterIP: corev1.ClusterIPNone, // headless
-			Selector:  boxLabels(tenant),
-			Ports: []corev1.ServicePort{{
-				Name:       sshPortName,
-				Port:       sshPort,
-				TargetPort: intstr.FromInt(sshPort),
-				Protocol:   corev1.ProtocolTCP,
-			}},
-		},
 	}
 }
 
@@ -199,103 +183,6 @@ func networkPolicyObject(ns, tenant string) *networkingv1.NetworkPolicy {
 type memDefaults struct {
 	request string
 	limit   string
-}
-
-// statefulSetObject builds the per-tenant box. replicas is 1 when the spec
-// asks to auto-start, else 0 (created stopped). withPVC mounts the data PVC
-// at dataMount (/home/agent) when true; the PVC must already exist. def is the
-// resolved default memory floor applied when the spec sets no explicit memory.
-func statefulSetObject(ns string, spec box.BoxSpec, withPVC bool, def memDefaults) *appsv1.StatefulSet {
-	replicas := int32(0)
-	if spec.AutoStart {
-		replicas = 1
-	}
-	labels := boxLabels(spec.Ref.Tenant)
-
-	// restricted-PSA container hardening: non-root, no privilege escalation,
-	// all capabilities dropped, default seccomp. The box image (dropbear on
-	// :2222) is built to run under exactly this.
-	gpuCount := len(spec.GPUs)
-	container := corev1.Container{
-		Name:  "agent-box",
-		Image: spec.Image,
-		Ports: []corev1.ContainerPort{{Name: sshPortName, ContainerPort: sshPort, Protocol: corev1.ProtocolTCP}},
-		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: boolp(false),
-			RunAsNonRoot:             boolp(true),
-			RunAsUser:                int64p(1000),
-			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-		},
-		// Mount the box's authorized_keys (so it accepts logins) and its stable
-		// host key (so the gateway can pin it). Without the first the box
-		// rejects every login.
-		VolumeMounts: []corev1.VolumeMount{
-			{Name: authorizedKeysVolume, MountPath: authorizedKeysMount, ReadOnly: true},
-			{Name: hostKeyVolume, MountPath: hostKeyMount, ReadOnly: true},
-		},
-	}
-	if res := resourceRequirements(spec.Resources, gpuCount, def); res != nil {
-		container.Resources = *res
-	}
-
-	volumes := []corev1.Volume{
-		{
-			Name: authorizedKeysVolume,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{SecretName: secretName(spec.Ref.Tenant)},
-			},
-		},
-		{
-			Name: hostKeyVolume,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{SecretName: hostKeySecretName(spec.Ref.Tenant)},
-			},
-		},
-	}
-	if withPVC {
-		volumes = append(volumes, corev1.Volume{
-			Name: dataVolume,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: pvcName,
-				},
-			},
-		})
-		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-			Name:      dataVolume,
-			MountPath: dataMount,
-		})
-	}
-
-	podMeta := metav1.ObjectMeta{Labels: labels}
-	if gpuCount > 0 {
-		podMeta.Annotations = map[string]string{
-			gpuCountAnnotation: fmt.Sprintf("%d", gpuCount),
-		}
-	}
-
-	return &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{Name: statefulSetName, Namespace: ns, Labels: labels},
-		Spec: appsv1.StatefulSetSpec{
-			Replicas:    int32p(replicas),
-			ServiceName: serviceName,
-			Selector:    &metav1.LabelSelector{MatchLabels: labels},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: podMeta,
-				Spec: corev1.PodSpec{
-					AutomountServiceAccountToken: boolp(false), // the box is a leaf, never a kube-apiserver client
-					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot:   boolp(true),
-						RunAsUser:      int64p(1000),
-						SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-					},
-					Containers: []corev1.Container{container},
-					Volumes:    volumes,
-				},
-			},
-		},
-	}
 }
 
 // resourceRequirements maps the runtime-neutral limits onto K8s requests/limits.

--- a/pkg/core/box/k8s/sandbox.go
+++ b/pkg/core/box/k8s/sandbox.go
@@ -1,0 +1,121 @@
+package k8s
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+)
+
+// sandboxObject builds the agent-sandbox Sandbox CR for a tenant box. The
+// agent-sandbox controller owns the children: it creates the pod (named after
+// the Sandbox) and, because spec.service is true, a headless Service (also
+// named after the Sandbox) that gives the pod stable in-cluster DNS — the name
+// the gateway Pipe routes to.
+//
+// AutoStart maps onto spec.operatingMode: Running creates the pod immediately,
+// Suspended parks the Sandbox with no pod (the CR-native form of the old
+// replicas=0). withPVC mounts the daemon-owned data PVC at dataMount
+// (/home/agent) as a plain persistentVolumeClaim volume — deliberately not a
+// volumeClaimTemplate, which the controller would owner-reference and GC on
+// Sandbox deletion, breaking delete-retains-data. def is the resolved default
+// memory floor applied when the spec sets no explicit memory.
+func sandboxObject(ns string, spec box.BoxSpec, withPVC bool, def memDefaults) *sandboxv1beta1.Sandbox {
+	labels := boxLabels(spec.Ref.Tenant)
+
+	// restricted-PSA container hardening: non-root, no privilege escalation,
+	// all capabilities dropped, default seccomp. The box image (dropbear on
+	// :2222) is built to run under exactly this.
+	gpuCount := len(spec.GPUs)
+	container := corev1.Container{
+		Name:  "agent-box",
+		Image: spec.Image,
+		Ports: []corev1.ContainerPort{{Name: sshPortName, ContainerPort: sshPort, Protocol: corev1.ProtocolTCP}},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolp(false),
+			RunAsNonRoot:             boolp(true),
+			RunAsUser:                int64p(1000),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+		},
+		// Mount the box's authorized_keys (so it accepts logins) and its stable
+		// host key (so the gateway can pin it). Without the first the box
+		// rejects every login.
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: authorizedKeysVolume, MountPath: authorizedKeysMount, ReadOnly: true},
+			{Name: hostKeyVolume, MountPath: hostKeyMount, ReadOnly: true},
+		},
+	}
+	if res := resourceRequirements(spec.Resources, gpuCount, def); res != nil {
+		container.Resources = *res
+	}
+
+	volumes := []corev1.Volume{
+		{
+			Name: authorizedKeysVolume,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: secretName(spec.Ref.Tenant)},
+			},
+		},
+		{
+			Name: hostKeyVolume,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: hostKeySecretName(spec.Ref.Tenant)},
+			},
+		},
+	}
+	if withPVC {
+		volumes = append(volumes, corev1.Volume{
+			Name: dataVolume,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: pvcName,
+				},
+			},
+		})
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      dataVolume,
+			MountPath: dataMount,
+		})
+	}
+
+	// Pod labels propagate from the template (the controller merges them onto
+	// the pod), keeping the NetworkPolicy pod selector matching.
+	podMeta := sandboxv1beta1.PodMetadata{Labels: labels}
+	if gpuCount > 0 {
+		podMeta.Annotations = map[string]string{
+			gpuCountAnnotation: fmt.Sprintf("%d", gpuCount),
+		}
+	}
+
+	mode := sandboxv1beta1.SandboxOperatingModeSuspended
+	if spec.AutoStart {
+		mode = sandboxv1beta1.SandboxOperatingModeRunning
+	}
+
+	return &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxName, Namespace: ns, Labels: labels},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					ObjectMeta: podMeta,
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: boolp(false), // the box is a leaf, never a kube-apiserver client
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot:   boolp(true),
+							RunAsUser:      int64p(1000),
+							SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+						},
+						Containers: []corev1.Container{container},
+						Volumes:    volumes,
+					},
+				},
+				Service: boolp(true), // headless Service = the gateway's routing target
+			},
+			OperatingMode: mode,
+		},
+	}
+}

--- a/scripts/k8s-e2e.sh
+++ b/scripts/k8s-e2e.sh
@@ -7,9 +7,10 @@
 # Keep cluster: E2E_KEEP=1 bash scripts/k8s-e2e.sh   (skips teardown for debugging)
 # CI:           invoked by .github/workflows/k8s-e2e.yml on an ubuntu runner.
 #
-# Requirements: kind, go, and a working Docker daemon (preinstalled on the
-# GitHub ubuntu-latest runner). kubectl is NOT required — the e2e talks to the
-# apiserver via client-go, not the CLI.
+# Requirements: kind, kubectl, go, and a working Docker daemon (all
+# preinstalled on the GitHub ubuntu-latest runner). kubectl installs the
+# agent-sandbox controller; the e2e itself talks to the apiserver via
+# client-go.
 #
 # Note: kind's default CNI (kindnet) does NOT enforce NetworkPolicy, so this
 # suite asserts the reconciler creates the right objects + the pod lifecycle,
@@ -37,6 +38,18 @@ trap cleanup EXIT
 
 echo "==> creating kind cluster '$CLUSTER'"
 kind create cluster --name "$CLUSTER" --wait 120s
+
+# The box backend declares agent-sandbox Sandbox CRs; the agent-sandbox
+# controller (kubernetes-sigs/agent-sandbox) owns the pod + Service under
+# them, so it must run in the cluster for the lifecycle e2e to converge.
+# Note: v0.5.1's install asset is manifest.yaml (their README still says
+# sandbox-with-extensions.yaml, which 404s).
+AGENT_SANDBOX_VERSION="${AGENT_SANDBOX_VERSION:-v0.5.1}"
+echo "==> installing agent-sandbox controller ${AGENT_SANDBOX_VERSION}"
+command -v kubectl >/dev/null || { echo "kubectl is required to install the agent-sandbox controller" >&2; exit 1; }
+kubectl apply -f "https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/manifest.yaml"
+kubectl wait --for=condition=available deployment -A \
+  -l control-plane=controller-manager --timeout=180s
 
 echo "==> running K8s agent-box e2e (reconciler vs. the kind apiserver)"
 CONTAINARIUM_K8S_E2E=1 go test -tags k8s -run TestE2E -timeout 12m -v ./pkg/core/box/k8s/


### PR DESCRIPTION
#### What this PR does / why we need it:

PR 2 of 4 in the agent-sandbox adoption: the K8s box backend now declares one
kubernetes-sigs/agent-sandbox `Sandbox` CR (agents.x-k8s.io/v1beta1) per box —
the agent-sandbox controller owns the pod + headless Service under it — instead
of hand-managing a StatefulSet `box` + Service `boxes`. The daemon keeps owning
what the CRD doesn't model: per-tenant namespace, authorized-keys + host-key
Secrets, default-deny NetworkPolicy, the data PVC, and the sshpiper Pipe.

Highlights:
- **Start/Stop → `spec.operatingMode`** (Running/Suspended): suspend deletes
  only the pod, retaining PVC + Service + identity — the CR-native form of the
  old replicas=0/1 scaling.
- **Data PVC stays daemon-owned**, mounted as a plain `persistentVolumeClaim`
  pod volume rather than a `volumeClaimTemplate` — template-derived PVCs are
  owner-referenced and GC'd with the Sandbox, which would break
  delete-retains-data (verified against the upstream reconciler).
- **Pipe upstream** moves to the Sandbox's controller-created Service DNS
  (`box.<ns>.svc...`, matching `status.serviceFQDN`).
- **Resize** becomes Get→mutate→Update (CRDs have no strategic merge);
  the controller doesn't restart a live pod on template drift, so a resize now
  applies at the next pod creation — server-side bounce lands in PR 3.
- **e2e**: `scripts/k8s-e2e.sh` installs the agent-sandbox controller (v0.5.1
  `manifest.yaml`) before the suite; fixed the workflow's stale
  `boxbackend_k8s.go` path filter.
- `sigs.k8s.io/agent-sandbox v0.5.1` lands in go.mod here (a require without an
  import doesn't survive `go mod tidy`, hence not in the deps PR).

Stacked on #968. Verified: `go build ./...`, `go test ./...` (pre-existing
live-daemon `test/integration` failures only), `go test -tags k8s
./pkg/core/box/k8s/` green; kind e2e runs via the k8s-e2e workflow once this
lands on a branch CI can see.

Follow-ups: PR 3 (TTL via `lifecycle.shutdownTime` + Start/Stop/Delete/Resize
RPC dispatch through the box backend), PR 4 (chart RBAC + docs + migration
note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)