### PR TITLE
feat(k8s): TTL via Sandbox shutdownTime + lifecycle RPC dispatch on the k8s runtime

### DIFF
--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -232,6 +232,20 @@ func (s *ContainerServer) boxes() box.BoxBackend {
 	return boxlxc.New(s.manager)
 }
 
+// k8sBoxes returns the box backend when the daemon runs the k8s runtime.
+// Lifecycle handlers use it to route their action through the backend seam:
+// s.manager is the LXC/incus surface, which is wired to an unavailable stub
+// on the k8s runtime — so without this branch Start/Stop/Delete/Resize would
+// error on every call there. The incus-config side effects those handlers
+// stamp (autosleep timestamps, stopped_at, secrets re-stamping) are
+// LXC-runtime features and are skipped on k8s.
+func (s *ContainerServer) k8sBoxes() (box.BoxBackend, bool) {
+	if bb := s.boxes(); bb.Kind() == box.KindK8s {
+		return bb, true
+	}
+	return nil, false
+}
+
 // CreateContainer creates a new container
 func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*pb.CreateContainerResponse, error) {
 	if err := auth.RequireScope(ctx, auth.ScopeContainersWrite); err != nil {
@@ -463,7 +477,7 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 			// stampBirthTTL deletes the box on failure so an ephemeral box
 			// never leaks just because the async stamp lost a race.
 			if err == nil && info != nil && req.TtlSeconds > 0 {
-				if terr := s.stampBirthTTL(info.Ref.Name, req.Username, req.TtlSeconds); terr != nil {
+				if terr := s.stampBirthTTL(context.Background(), info.Ref.Name, req.Username, req.TtlSeconds); terr != nil {
 					err = terr
 					info = nil
 				}
@@ -543,7 +557,7 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	// errors if it can't honor the requested TTL — an ephemeral box that
 	// would leak is worse than no box.
 	if req.TtlSeconds > 0 {
-		if err := s.stampBirthTTL(info.Ref.Name, req.Username, req.TtlSeconds); err != nil {
+		if err := s.stampBirthTTL(ctx, info.Ref.Name, req.Username, req.TtlSeconds); err != nil {
 			return nil, err
 		}
 	}
@@ -861,6 +875,21 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 	// Before deleting, deregister Guacamole connection if this is a Windows VM
 	s.deregisterGuacamoleConnection(req.Username)
 
+	if bb, isK8s := s.k8sBoxes(); isK8s {
+		// K8s runtime: deleting the Sandbox cascades to its pod + Service via
+		// owner refs; the backend keeps the namespace + data PVC (its
+		// delete-retains-data contract) and removes the gateway Pipe + Secrets.
+		if err := bb.Delete(ctx, box.BoxRef{Tenant: req.Username}, req.Force); err != nil {
+			return nil, fmt.Errorf("failed to delete container: %w", err)
+		}
+		s.cascadeContainerCleanup(ctx, containerName, req.Username)
+		s.emitter.EmitContainerDeleted(containerName)
+		return &pb.DeleteContainerResponse{
+			Message:       fmt.Sprintf("Container for user %s deleted successfully", req.Username),
+			ContainerName: containerName,
+		}, nil
+	}
+
 	err := s.manager.Delete(req.Username, req.Force)
 	if err != nil {
 		// Not found locally — try peers
@@ -978,54 +1007,62 @@ func (s *ContainerServer) StartContainer(ctx context.Context, req *pb.StartConta
 		return nil, err
 	}
 
-	if err := s.manager.Start(req.Username); err != nil {
-		// Try peer
-		if s.peerPool != nil {
-			authToken := extractAuthToken(ctx)
-			peer := s.peerPool.FindContainerPeer(req.Username, authToken)
-			if peer != nil {
-				body, _ := json.Marshal(map[string]interface{}{
-					"wait_for_ready":        req.WaitForReady,
-					"ready_timeout_seconds": req.ReadyTimeoutSeconds,
-				})
-				_, _, fwdErr := peer.ForwardRequest("POST", fmt.Sprintf("/v1/containers/%s/start", req.Username), authToken, body)
-				if fwdErr == nil {
-					return &pb.StartContainerResponse{
-						Message: fmt.Sprintf("Container for user %s started on backend %s", req.Username, peer.ID),
-					}, nil
+	if bb, isK8s := s.k8sBoxes(); isK8s {
+		// K8s runtime: resume the Sandbox (operatingMode=Running); the
+		// agent-sandbox controller recreates the pod with the retained PVC.
+		if err := bb.Start(ctx, box.BoxRef{Tenant: req.Username}); err != nil {
+			return nil, fmt.Errorf("failed to start container: %w", err)
+		}
+	} else {
+		if err := s.manager.Start(req.Username); err != nil {
+			// Try peer
+			if s.peerPool != nil {
+				authToken := extractAuthToken(ctx)
+				peer := s.peerPool.FindContainerPeer(req.Username, authToken)
+				if peer != nil {
+					body, _ := json.Marshal(map[string]interface{}{
+						"wait_for_ready":        req.WaitForReady,
+						"ready_timeout_seconds": req.ReadyTimeoutSeconds,
+					})
+					_, _, fwdErr := peer.ForwardRequest("POST", fmt.Sprintf("/v1/containers/%s/start", req.Username), authToken, body)
+					if fwdErr == nil {
+						return &pb.StartContainerResponse{
+							Message: fmt.Sprintf("Container for user %s started on backend %s", req.Username, peer.ID),
+						}, nil
+					}
 				}
 			}
+			return nil, fmt.Errorf("failed to start container: %w", err)
 		}
-		return nil, fmt.Errorf("failed to start container: %w", err)
-	}
 
-	// Stamp last-start timestamp so the Phase 2 auto-sleep ticker can
-	// enforce its anti-thrash window (don't sleep within 2× threshold
-	// of the most recent start). Best-effort — if the SetConfig fails
-	// the container is already running, and the worst case is one
-	// extra wake → sleep flap.
-	if err := s.manager.SetConfig(req.Username+"-container", incus.LastStartedAtKey, time.Now().UTC().Format(time.RFC3339)); err != nil {
-		log.Printf("[autosleep] failed to stamp %s on %s: %v (continuing)", incus.LastStartedAtKey, req.Username, err)
-	}
+		// Stamp last-start timestamp so the Phase 2 auto-sleep ticker can
+		// enforce its anti-thrash window (don't sleep within 2× threshold
+		// of the most recent start). Best-effort — if the SetConfig fails
+		// the container is already running, and the worst case is one
+		// extra wake → sleep flap.
+		if err := s.manager.SetConfig(req.Username+"-container", incus.LastStartedAtKey, time.Now().UTC().Format(time.RFC3339)); err != nil {
+			log.Printf("[autosleep] failed to stamp %s on %s: %v (continuing)", incus.LastStartedAtKey, req.Username, err)
+		}
 
-	// Two-phase reaping (#525): the box is running again, so clear stopped_at.
-	// This resets the stopped→delete timer — a box someone keeps waking to
-	// investigate never gets reaped; only a box left continuously stopped past
-	// its window does. Best-effort + idempotent (UnsetConfig of an absent key
-	// is a no-op).
-	if err := s.manager.UnsetConfig(req.Username+"-container", incus.StoppedAtKey); err != nil {
-		log.Printf("[ttl] failed to clear %s on %s: %v (continuing)", incus.StoppedAtKey, req.Username, err)
-	}
+		// Two-phase reaping (#525): the box is running again, so clear stopped_at.
+		// This resets the stopped→delete timer — a box someone keeps waking to
+		// investigate never gets reaped; only a box left continuously stopped past
+		// its window does. Best-effort + idempotent (UnsetConfig of an absent key
+		// is a no-op).
+		if err := s.manager.UnsetConfig(req.Username+"-container", incus.StoppedAtKey); err != nil {
+			log.Printf("[ttl] failed to clear %s on %s: %v (continuing)", incus.StoppedAtKey, req.Username, err)
+		}
 
-	// Re-stamp tenant secrets from the current DB state. Picks up
-	// any rotations that happened while the container was stopped;
-	// existing processes won't see the change (POSIX inherit-at-fork),
-	// but new execs will.
-	if s.secretsStore != nil {
-		if n, err := s.stampSecretsOnLXC(ctx, req.Username); err != nil {
-			log.Printf("[secrets] failed to re-stamp on start of %s-container: %v (continuing)", req.Username, err)
-		} else if n > 0 {
-			log.Printf("[secrets] re-stamped %d secret(s) on %s-container at start time", n, req.Username)
+		// Re-stamp tenant secrets from the current DB state. Picks up
+		// any rotations that happened while the container was stopped;
+		// existing processes won't see the change (POSIX inherit-at-fork),
+		// but new execs will.
+		if s.secretsStore != nil {
+			if n, err := s.stampSecretsOnLXC(ctx, req.Username); err != nil {
+				log.Printf("[secrets] failed to re-stamp on start of %s-container: %v (continuing)", req.Username, err)
+			} else if n > 0 {
+				log.Printf("[secrets] re-stamped %d secret(s) on %s-container at start time", n, req.Username)
+			}
 		}
 	}
 
@@ -1126,7 +1163,13 @@ func (s *ContainerServer) StopContainer(ctx context.Context, req *pb.StopContain
 		return nil, err
 	}
 
-	if err := s.manager.Stop(req.Username, req.Force); err != nil {
+	if bb, isK8s := s.k8sBoxes(); isK8s {
+		// K8s runtime: suspend the Sandbox (operatingMode=Suspended); the
+		// controller deletes only the pod — PVC + Service + identity persist.
+		if err := bb.Stop(ctx, box.BoxRef{Tenant: req.Username}, req.Force); err != nil {
+			return nil, fmt.Errorf("failed to stop container: %w", err)
+		}
+	} else if err := s.manager.Stop(req.Username, req.Force); err != nil {
 		// Try peer
 		if s.peerPool != nil {
 			authToken := extractAuthToken(ctx)
@@ -1157,9 +1200,12 @@ func (s *ContainerServer) StopContainer(ctx context.Context, req *pb.StopContain
 	// stamp just means the stopped→delete clock doesn't start until a later
 	// stop restamps it; it never fails the stop. Only matters for boxes that
 	// opted into delete_after_stopped, but stamping unconditionally keeps the
-	// timestamp honest for any box and costs one config write.
-	if serr := s.manager.SetConfig(info.Ref.Name, incus.StoppedAtKey, time.Now().UTC().Format(time.RFC3339)); serr != nil {
-		log.Printf("[ttl] failed to stamp %s on %s: %v (stopped→delete timer not started)", incus.StoppedAtKey, info.Ref.Name, serr)
+	// timestamp honest for any box and costs one config write. LXC-only: the
+	// stopped→delete rule isn't modeled on the k8s runtime yet.
+	if _, isK8s := s.k8sBoxes(); !isK8s {
+		if serr := s.manager.SetConfig(info.Ref.Name, incus.StoppedAtKey, time.Now().UTC().Format(time.RFC3339)); serr != nil {
+			log.Printf("[ttl] failed to stamp %s on %s: %v (stopped→delete timer not started)", incus.StoppedAtKey, info.Ref.Name, serr)
+		}
 	}
 
 	s.emitter.EmitContainerStopped(toProtoContainer(info))
@@ -1230,6 +1276,37 @@ func (s *ContainerServer) ResizeContainer(ctx context.Context, req *pb.ResizeCon
 	}
 
 	containerName := fmt.Sprintf("%s-container", req.Username)
+
+	if bb, isK8s := s.k8sBoxes(); isK8s {
+		ref := box.BoxRef{Tenant: req.Username}
+		if err := bb.Resize(ctx, ref, box.ResourceLimits{CPU: req.Cpu, Memory: req.Memory, Disk: req.Disk}); err != nil {
+			return nil, fmt.Errorf("failed to resize container: %w", err)
+		}
+		// The agent-sandbox controller doesn't restart a live pod on template
+		// drift, so bounce a running box (suspend → resume, i.e. pod recreate)
+		// to apply the new limits now — same downtime as the StatefulSet
+		// rolling restart the old path triggered. A stopped box just picks the
+		// limits up at its next start.
+		if cur, gerr := bb.Get(ctx, ref); gerr == nil && cur != nil && cur.State == pb.ContainerState_CONTAINER_STATE_RUNNING {
+			if err := bb.Stop(ctx, ref, false); err != nil {
+				return nil, fmt.Errorf("resized but failed to restart (stop) container: %w", err)
+			}
+			if err := bb.Start(ctx, ref); err != nil {
+				return nil, fmt.Errorf("resized but failed to restart (start) container: %w", err)
+			}
+		}
+		info, err := s.boxes().Get(ctx, ref)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get updated container info: %w", err)
+		}
+		if info == nil {
+			return nil, fmt.Errorf("container resized but not found on read-back")
+		}
+		return &pb.ResizeContainerResponse{
+			Message:   fmt.Sprintf("Container %s resized successfully", containerName),
+			Container: toProtoContainer(info),
+		}, nil
+	}
 
 	// Perform resize — try local first, then peer
 	if err := s.manager.Resize(containerName, req.Cpu, req.Memory, req.Disk, false); err != nil {

--- a/internal/server/container_server_birth_ttl_test.go
+++ b/internal/server/container_server_birth_ttl_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func TestStampBirthTTL_StampsExpiry(t *testing.T) {
 	mock.DeleteContainerFunc = func(string) error { deleted = true; return nil }
 
 	before := time.Now().UTC()
-	if err := s.stampBirthTTL("alice-container", "alice", 1800); err != nil {
+	if err := s.stampBirthTTL(context.Background(), "alice-container", "alice", 1800); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	after := time.Now().UTC()
@@ -67,7 +68,7 @@ func TestStampBirthTTL_FailureDeletesBox(t *testing.T) {
 	deletedName := ""
 	mock.DeleteContainerFunc = func(name string) error { deletedName = name; return nil }
 
-	err := s.stampBirthTTL("alice-container", "alice", 1800)
+	err := s.stampBirthTTL(context.Background(), "alice-container", "alice", 1800)
 	if err == nil {
 		t.Fatal("expected an error when the TTL stamp fails")
 	}

--- a/internal/server/container_server_ttl.go
+++ b/internal/server/container_server_ttl.go
@@ -74,6 +74,27 @@ func (s *ContainerServer) SetContainerTTL(ctx context.Context, req *pb.SetContai
 	containerName := info.Ref.Name
 
 	resp := &pb.SetContainerTTLResponse{}
+
+	// TTL-capable backends (K8s: agent-sandbox spec.shutdownTime) persist the
+	// expiry natively; the Incus-config path below is the LXC persistence.
+	if tc, ok := s.boxes().(box.TTLCapable); ok {
+		ref := box.BoxRef{Tenant: username}
+		if req.DurationSeconds == 0 {
+			if err := tc.SetTTL(ctx, ref, nil); err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to clear ttl: %v", err)
+			}
+			log.Printf("[ttl] cleared container=%s", containerName)
+			return resp, nil
+		}
+		expiresAt := time.Now().Add(time.Duration(req.DurationSeconds) * time.Second).UTC()
+		if err := tc.SetTTL(ctx, ref, &expiresAt); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to set ttl: %v", err)
+		}
+		log.Printf("[ttl] set container=%s expires_at=%s (duration=%ds)", containerName, expiresAt.Format(time.RFC3339), req.DurationSeconds)
+		resp.TtlExpiresAt = timestamppb.New(expiresAt)
+		return resp, nil
+	}
+
 	if req.DurationSeconds == 0 {
 		// Clear: remove the key entirely so parseTTLExpiresAt and the
 		// sweeper see "absent" rather than "empty string". UnsetConfig
@@ -120,13 +141,21 @@ func validateTTLSeconds(seconds int64) error {
 // ran. On failure it DELETES the box and returns an error rather than hand
 // back a box that was asked to be ephemeral but would otherwise leak forever:
 // default-dead, not default-alive (#522). ttlSeconds must be > 0 (the zero
-// case is "no TTL" and never reaches here). containerName is the incus name
-// (info.Name) for the config write + logs; username is what manager.Delete
-// keys on.
-func (s *ContainerServer) stampBirthTTL(containerName, username string, ttlSeconds int64) error {
-	expiresAt, err := s.stampTTL(containerName, ttlSeconds)
+// case is "no TTL" and never reaches here). containerName is the backend box
+// name (info.Ref.Name) for logs and the LXC config write; username keys the
+// cleanup delete.
+func (s *ContainerServer) stampBirthTTL(ctx context.Context, containerName, username string, ttlSeconds int64) error {
+	var expiresAt time.Time
+	var err error
+	if tc, ok := s.boxes().(box.TTLCapable); ok {
+		// Native persistence (K8s: Sandbox spec.shutdownTime).
+		expiresAt = time.Now().Add(time.Duration(ttlSeconds) * time.Second).UTC()
+		err = tc.SetTTL(ctx, box.BoxRef{Tenant: username}, &expiresAt)
+	} else {
+		expiresAt, err = s.stampTTL(containerName, ttlSeconds)
+	}
 	if err != nil {
-		if delErr := s.manager.Delete(username, true); delErr != nil {
+		if delErr := s.boxes().Delete(ctx, box.BoxRef{Tenant: username}, true); delErr != nil {
 			log.Printf("[ttl] birth TTL stamp failed AND cleanup-delete failed for %s: stamp=%v delete=%v", containerName, err, delErr)
 		}
 		return status.Errorf(codes.Internal, "failed to set birth TTL on %s (box deleted to avoid a leak): %v", containerName, err)

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/footprintai/containarium/internal/waf"
 	"github.com/footprintai/containarium/internal/wake"
 	zapscanner "github.com/footprintai/containarium/internal/zap"
+	"github.com/footprintai/containarium/pkg/core/box"
 	"github.com/footprintai/containarium/pkg/core/catalogsig"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/crews"
@@ -1889,15 +1890,27 @@ func (ds *DualServer) Start(ctx context.Context) error {
 	// Naturally cooperates with autosleep — if both ticks decide on
 	// the same container in the same second, deletion is final and
 	// the autosleep stop becomes a no-op against a missing container.
-	if incusClient, err := incus.New(); err != nil {
-		log.Printf("[ttlsweeper] incus client unavailable: %v (sweeper disabled)", err)
-	} else {
+	if incusClient, err := incus.New(); err == nil {
 		ds.ttlSweeperManager = ttlsweeper.NewManager(
 			&ttlsweeperIncusAdapter{ic: incusClient},
 			&ttlsweeperDeleter{cs: ds.containerServer},
 			ttlsweeper.Options{},
 		)
 		ds.ttlSweeperManager.Start(ctx)
+	} else if ds.containerServer != nil && ds.containerServer.boxes().Kind() == box.KindK8s {
+		// No Incus, but the K8s box backend persists TTL natively (Sandbox
+		// spec.shutdownTime + the mirrored ttl_expires_at meta). Sweep off the
+		// backend's List instead so expiry still routes through the full
+		// DeleteContainer cascade on the k8s runtime.
+		ds.ttlSweeperManager = ttlsweeper.NewManager(
+			&ttlsweeperBoxAdapter{bb: ds.containerServer.boxes()},
+			&ttlsweeperDeleter{cs: ds.containerServer},
+			ttlsweeper.Options{},
+		)
+		ds.ttlSweeperManager.Start(ctx)
+		log.Printf("[ttlsweeper] incus unavailable (%v); sweeping via the k8s box backend", err)
+	} else {
+		log.Printf("[ttlsweeper] incus client unavailable: %v (sweeper disabled)", err)
 	}
 
 	// Orphan reaper (#835): periodically userdel host accounts whose

--- a/internal/server/ttlsweeper_boxes_adapter.go
+++ b/internal/server/ttlsweeper_boxes_adapter.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/footprintai/containarium/internal/ttlsweeper"
+	"github.com/footprintai/containarium/pkg/core/box"
+)
+
+// ttlsweeperBoxAdapter bridges box.BoxBackend → ttlsweeper.IncusClient for
+// runtimes with no Incus (the K8s backend). Sibling of ttlsweeperIncusAdapter:
+// same one-method seam, different source.
+//
+// The view is deliberately thinner than the Incus adapter's: only the
+// absolute TTL rule is fed (from the backend's ttl_expires_at meta, which the
+// K8s backend mirrors off the Sandbox's spec.shutdownTime). Stopped→delete
+// (#525) and protected boxes (#284) aren't modeled by the K8s backend yet, so
+// those fields stay zero and Decide skips their rules.
+//
+// Names are surfaced in "<tenant>-container" form so ttlsweeperDeleter's
+// suffix-strip recovers the username exactly as it does for LXC boxes.
+type ttlsweeperBoxAdapter struct {
+	bb box.BoxBackend
+}
+
+func (a *ttlsweeperBoxAdapter) ListContainers() ([]ttlsweeper.ContainerView, error) {
+	// The sweeper interface is synchronous; bound the backend call so a hung
+	// apiserver can't wedge the tick loop forever.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	boxes, err := a.bb.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ttlsweeper.ContainerView, 0, len(boxes))
+	for i := range boxes {
+		b := boxes[i]
+		v := ttlsweeper.ContainerView{Name: b.Ref.Tenant + "-container"}
+		if raw := b.Labels["ttl_expires_at"]; raw != "" {
+			if t, perr := time.Parse(time.RFC3339, raw); perr == nil {
+				v.TTLExpiresAt = &t
+			}
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}

--- a/pkg/core/box/box.go
+++ b/pkg/core/box/box.go
@@ -234,3 +234,16 @@ type MetricsCapable interface {
 type GPUCapable interface {
 	ResolveGPU(ctx context.Context, input string) (deviceID string, err error)
 }
+
+// TTLCapable is an optional capability: backends that can persist a box's
+// absolute auto-delete time natively in their substrate implement it. The K8s
+// backend maps it onto the agent-sandbox Sandbox's spec.shutdownTime (with
+// shutdownPolicy Retain — the controller stops the pod at the deadline even
+// if the daemon is down; the daemon's sweeper then completes the delete
+// through the full DeleteContainer cascade). LXC persists TTL via Incus
+// config keys on the server side instead and does not implement this.
+//
+// expiresAt nil clears the TTL (the box persists indefinitely).
+type TTLCapable interface {
+	SetTTL(ctx context.Context, ref BoxRef, expiresAt *time.Time) error
+}

--- a/pkg/core/box/k8s/ttl.go
+++ b/pkg/core/box/k8s/ttl.go
@@ -1,0 +1,49 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+)
+
+// metaTTLExpiresAtKey is the meta key (under metaAnnotationPrefix) mirroring
+// the Sandbox's spec.shutdownTime. The daemon's TTL sweeper reads box meta
+// (BoxStatus.Labels, fed from these annotations) — it never parses the CRD —
+// so the expiry is mirrored here in the same RFC3339 form the sweeper already
+// understands from the Incus path.
+const metaTTLExpiresAtKey = "ttl_expires_at"
+
+var _ box.TTLCapable = (*Backend)(nil)
+
+// SetTTL stamps (or clears, expiresAt == nil) the box's absolute auto-delete
+// time.
+//
+// Two cooperating mechanisms, one patch:
+//   - spec.shutdownTime + shutdownPolicy Retain: the agent-sandbox controller
+//     stops the pod at the deadline even if the daemon is down (defense in
+//     depth). Retain — not Delete — because a controller-side Sandbox delete
+//     would orphan everything the daemon owns around it (Pipe, Secrets, PVC,
+//     namespace, Caddy routes) and skip the DeleteContainer audit cascade.
+//   - the ttl_expires_at meta annotation: the daemon's sweeper reads it off
+//     List() and routes the actual delete through DeleteContainer, so the
+//     full cascade fires exactly as it does for an LXC box.
+func (b *Backend) SetTTL(ctx context.Context, ref box.BoxRef, expiresAt *time.Time) error {
+	var patch []byte
+	if expiresAt == nil {
+		// Merge-patch nulls delete the map key / clear the scalar.
+		patch = fmt.Appendf(nil, `{"metadata":{"annotations":{%q:null}},"spec":{"shutdownTime":null}}`,
+			metaAnnotationPrefix+metaTTLExpiresAtKey)
+	} else {
+		ts := expiresAt.UTC().Format(time.RFC3339)
+		patch = fmt.Appendf(nil, `{"metadata":{"annotations":{%q:%q}},"spec":{"shutdownTime":%q,"shutdownPolicy":"Retain"}}`,
+			metaAnnotationPrefix+metaTTLExpiresAtKey, ts, ts)
+	}
+	_, err := b.sandboxes.AgentsV1beta1().Sandboxes(b.namespaceFor(ref.Tenant)).
+		Patch(ctx, sandboxName, types.MergePatchType, patch, metav1.PatchOptions{})
+	return err
+}

--- a/pkg/core/box/k8s/ttl_test.go
+++ b/pkg/core/box/k8s/ttl_test.go
@@ -1,0 +1,73 @@
+//go:build k8s
+
+package k8s
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes/fake"
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	sandboxfake "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned/fake"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+)
+
+// TestSetTTLStampsShutdownTimeAndMeta verifies SetTTL writes both halves of
+// the TTL contract in one patch: spec.shutdownTime (+ Retain policy) for the
+// controller-side stop, and the ttl_expires_at meta annotation the daemon's
+// sweeper reads via List/GetMeta.
+func TestSetTTLStampsShutdownTimeAndMeta(t *testing.T) {
+	b, _, sc := testBackend()
+	ctx := context.Background()
+	ref := box.BoxRef{Tenant: "ttl-user"}
+	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref, Image: "x", AutoStart: true}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	expiresAt := time.Now().Add(30 * time.Minute).UTC().Truncate(time.Second)
+	if err := b.SetTTL(ctx, ref, &expiresAt); err != nil {
+		t.Fatalf("SetTTL: %v", err)
+	}
+
+	sb := getSandbox(t, sc, "tenant-ttl-user")
+	if sb.Spec.ShutdownTime == nil || !sb.Spec.ShutdownTime.Time.Equal(expiresAt) {
+		t.Errorf("shutdownTime = %v, want %v", sb.Spec.ShutdownTime, expiresAt)
+	}
+	if sb.Spec.ShutdownPolicy == nil || *sb.Spec.ShutdownPolicy != sandboxv1beta1.ShutdownPolicyRetain {
+		t.Errorf("shutdownPolicy = %v, want Retain (Delete would orphan the daemon-owned Pipe/Secrets/PVC)", sb.Spec.ShutdownPolicy)
+	}
+
+	// The sweeper reads the expiry off box meta (BoxStatus.Labels via List).
+	meta, err := b.GetMeta(ctx, ref)
+	if err != nil {
+		t.Fatalf("GetMeta: %v", err)
+	}
+	got, perr := time.Parse(time.RFC3339, meta[metaTTLExpiresAtKey])
+	if perr != nil || !got.Equal(expiresAt) {
+		t.Errorf("meta %s = %q (parse err %v), want %v", metaTTLExpiresAtKey, meta[metaTTLExpiresAtKey], perr, expiresAt)
+	}
+
+	// Clear: both halves removed.
+	if err := b.SetTTL(ctx, ref, nil); err != nil {
+		t.Fatalf("SetTTL(clear): %v", err)
+	}
+	sb = getSandbox(t, sc, "tenant-ttl-user")
+	if sb.Spec.ShutdownTime != nil {
+		t.Errorf("shutdownTime not cleared: %v", sb.Spec.ShutdownTime)
+	}
+	meta, _ = b.GetMeta(ctx, ref)
+	if _, ok := meta[metaTTLExpiresAtKey]; ok {
+		t.Errorf("meta %s not cleared: %q", metaTTLExpiresAtKey, meta[metaTTLExpiresAtKey])
+	}
+}
+
+// TestTTLCapableAssertion pins the capability discovery the server relies on:
+// the k8s backend must satisfy box.TTLCapable via a plain type assertion.
+func TestTTLCapableAssertion(t *testing.T) {
+	b := NewWithClientset(fake.NewSimpleClientset(), sandboxfake.NewSimpleClientset(), Config{})
+	if _, ok := interface{}(b).(box.TTLCapable); !ok {
+		t.Fatal("k8s Backend must implement box.TTLCapable")
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

PR 3 of 4 in the agent-sandbox adoption (stacked on #969 → #968). Two gaps
made the k8s runtime's lifecycle surface incomplete:

**TTL was dead on the k8s runtime.** `SetContainerTTL` persisted expiry as
Incus config keys, and the sweeper disabled itself whenever incus was
unreachable — exactly the k8s-runtime case. This adds:
- `box.TTLCapable{SetTTL}` — implemented by the k8s backend as one merge patch
  stamping both halves of the contract: `spec.shutdownTime` +
  `shutdownPolicy: Retain` (the agent-sandbox controller stops the pod at the
  deadline **even if the daemon is down** — defense in depth), plus a mirrored
  `ttl_expires_at` meta annotation the daemon's sweeper reads off `List()`.
  Retain, not Delete: a controller-side Sandbox delete would orphan the
  daemon-owned Pipe/Secrets/PVC/namespace/routes and skip the DeleteContainer
  audit cascade.
- `ttlsweeperBoxAdapter` feeding the sweeper from the box backend, wired when
  incus is unavailable but the runtime is k8s — expiry still routes the actual
  delete through the full `DeleteContainer` cascade.
- `SetContainerTTL` + the birth-TTL path branch on the capability; the
  birth-TTL failure cleanup now uses `boxes().Delete` so the ephemeral-box
  leak guard holds on both runtimes.

**Start/Stop/Delete/Resize RPCs were unreachable on k8s.** They called
`s.manager.*` (the incus surface, an unavailable stub on the k8s runtime), so
PR 2's suspend/resume mapping had no API path to it. Each handler now routes
through the box backend when `Kind()==KindK8s`; Resize additionally bounces a
running box (suspend→resume) so new limits apply immediately — the
agent-sandbox controller doesn't restart a live pod on template drift.
Incus-config side effects (autosleep stamps, `stopped_at`, secrets
re-stamping) stay LXC-only.

Verified: `go build ./...`, `go test ./internal/... ./pkg/...` green,
`go test -tags k8s ./pkg/core/box/k8s/` green including new TTL patch-shape
tests.

Follow-up: PR 4 (chart RBAC + docs + migration note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)