### PR TITLE
docs(k8s): chart RBAC + docs for the agent-sandbox Sandbox-CRD backend

### DIFF
--- a/charts/containarium-k8s/templates/clusterrole.yaml
+++ b/charts/containarium-k8s/templates/clusterrole.yaml
@@ -9,7 +9,16 @@ rules:
   - apiGroups: [""]
     resources: [namespaces]
     verbs: [get, list, watch, create, update, patch, delete]
-  # Manage box workloads in tenant namespaces
+  # Manage box workloads in tenant namespaces: one agent-sandbox Sandbox CR
+  # per box; the agent-sandbox controller owns the pod + Service under it.
+  # Requires the agent-sandbox controller to be installed in the cluster —
+  # see docs/KIND-QUICKSTART.md.
+  - apiGroups: [agents.x-k8s.io]
+    resources: [sandboxes]
+    verbs: [get, list, watch, create, update, patch, delete]
+  # Legacy: pre-Sandbox deployments managed a StatefulSet per box. Kept one
+  # release for the migration window (delete of old boxes on the previous
+  # object shape); drop after that.
   - apiGroups: ["apps"]
     resources: [statefulsets]
     verbs: [get, list, watch, create, update, patch, delete]

--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -58,20 +58,34 @@ are explicitly **out of scope for v1** — see "Deferred".
                    └──────┬───────────────┬────────┘
                           │ route by user │
               ┌───────────▼───┐     ┌─────▼─────────┐
-   ns:tenant-a │ StatefulSet │     │ StatefulSet  │ ns:tenant-b
-              │ box-0 (sshd + │     │ box-0 (...)  │
-              │ agent-box)    │     │              │
+   ns:tenant-a │ Sandbox CR   │     │ Sandbox CR   │ ns:tenant-b
+              │ └ pod "box"   │     │ └ pod "box"  │
+              │   (sshd +     │     │   (...)      │
+              │    agent-box) │     │              │
               │ NetworkPolicy │     │ NetworkPolicy│
               │ default-deny  │     │ default-deny │
               └───────────────┘     └──────────────┘
+
+  (pod + headless Service are created by the kubernetes-sigs/agent-sandbox
+   controller from the Sandbox CR; the daemon owns everything else)
 ```
 
 ## Components
 
-### 1. The box (per-tenant StatefulSet)
+### 1. The box (per-tenant agent-sandbox `Sandbox` CR)
 
-StatefulSet (not Deployment) for the **stable per-pod DNS name** sshpiper
-routes to: `box-0.boxes.<tenant>.svc.cluster.local`.
+One [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox)
+`Sandbox` CR (agents.x-k8s.io/v1beta1) per tenant. The agent-sandbox
+controller — a required install alongside the daemon — creates the pod and a
+headless Service from it, giving sshpiper a **stable DNS name** to route to:
+`box.<tenant-ns>.svc.cluster.local` (the CR's `status.serviceFQDN`). The CRD
+also gives us suspend/resume (`spec.operatingMode`) and a native absolute
+expiry (`spec.lifecycle.shutdownTime`) instead of hand-rolled replica scaling
+and sweeper-only TTL.
+
+(Originally this was a hand-managed StatefulSet `box-0` fronted by a
+headless Service `boxes`; replaced when SIG Apps standardized exactly this
+workload shape as the Sandbox CRD.)
 
 - One container: `sshd` + the `agent-box` binary on PATH.
 - `automountServiceAccountToken: false` — the box is a **leaf**, never a
@@ -119,7 +133,8 @@ The new piece is a thin **upstream controller** replacing the sentinel's
 - Programs the sshpiper upstream map via the maintained sshpiper **Kubernetes
   plugin** CRD — the `Pipe` resource (`sshpiper.com/v1beta1`, plural `pipes`;
   earlier drafts of this note called it "PiperUpstream"): `spec.from[].username
-  = <tenant>` → `spec.to.host = box-0.boxes.<tenant>.svc:2222` (the box's
+  = <tenant>` → `spec.to.host = box.<tenant-ns>.svc:2222` (the Sandbox's
+  controller-created headless Service; the box's
   internal SSH port), upstream user `agent`, with the box's
   authorized keys inline as `authorized_keys_data`. The daemon manages Pipes via
   the dynamic client (no sshpiper Go types imported). CRD-driven removes the
@@ -152,7 +167,7 @@ Per tenant namespace:
 | `agent-box` over stdio, SSH-wrapped | identical — same binary, same `ForceCommand` |
 | sshpiper on sentinel :22 | sshpiper Deployment + LB Service :22 |
 | sentinel key-sync → YAML | controller → `Pipe` CRD + Secret |
-| LXC box per tenant | StatefulSet `box-0` per tenant namespace |
+| LXC box per tenant | agent-sandbox `Sandbox` CR (pod `box`) per tenant namespace |
 | eBPF deny-by-default + egress allowlist | default-deny NetworkPolicy + egress allowlist |
 | sshd 2222 (mgmt) vs sshpiper 22 | mgmt via `kubectl`/RBAC; sshpiper owns 22 |
 
@@ -165,8 +180,9 @@ vocabulary**, not a new verb tree:
 containarium box create --runtime=k8s --tenant=<t>
 ```
 
-templates the namespace + StatefulSet + headless Service + NetworkPolicy +
-`Pipe` CRD + per-tenant key Secret. The platform MCP tool wraps the
+templates the namespace + `Sandbox` CR + NetworkPolicy + `Pipe` CRD +
+per-tenant key Secrets (the controller derives pod + headless Service from
+the Sandbox). The platform MCP tool wraps the
 **same Go function** the CLI handler calls. The backend is selected behind a
 runtime interface; LXC stays the default.
 
@@ -236,7 +252,7 @@ type BoxBackend interface {
 ```go
 type BoxRef struct {
     Tenant string // routing key / SSH username
-    Name   string // box name (LXC: "<tenant>-container"; K8s: StatefulSet "box-0")
+    Name   string // box name (LXC: "<tenant>-container"; K8s: Sandbox "box")
 }
 
 type BoxSpec struct {
@@ -472,7 +488,8 @@ clusters cleanly. That is a feature: the RBAC ask is small and auditable.
 
 | Verb scope | Resources | Boundary |
 | --- | --- | --- |
-| create/get/delete | StatefulSet, Service, Secret, NetworkPolicy | **label-selected tenant namespaces only** |
+| create/get/delete | `Sandbox` (agents.x-k8s.io), Secret, NetworkPolicy, PVC | **label-selected tenant namespaces only** |
+| (controller-owned) | Pod, Service | created by the agent-sandbox controller from the Sandbox, not by the daemon |
 | CRUD | `Pipe` | gateway namespace only |
 | create | Namespace | only if the controller owns tenant-namespace lifecycle |
 
@@ -568,10 +585,13 @@ Each box optionally gets a `PersistentVolumeClaim` for its home directory
 
 - **Empty (default):** no PVC; namespace is deleted on `Delete` (original
   behavior, backward-compatible).
-- **Non-empty:** PVC named `data` is created before the StatefulSet;
-  `Delete` removes compute objects (StatefulSet, Service, NetworkPolicy,
-  Secrets) but **retains the namespace + PVC** so data survives a node
-  reap. `Purge` removes both PVC and namespace when the tenant is gone.
+- **Non-empty:** PVC named `data` is created before the Sandbox and mounted
+  as a **plain pod volume, not a `volumeClaimTemplate`** — template-derived
+  PVCs are owner-referenced to the Sandbox and garbage-collected with it,
+  which would break this contract. `Delete` removes compute objects (the
+  Sandbox — cascading to pod + Service — plus NetworkPolicy, Secrets) but
+  **retains the namespace + PVC** so data survives a node reap. `Purge`
+  removes both PVC and namespace when the tenant is gone.
 
 This design lets autoscaled GCE VMs be reaped without data loss — the PV is
 CSI-managed (GKE, EKS, or kind local-path) and outlives any compute node.
@@ -598,11 +618,53 @@ The GPU *type* (L4, A100, etc.) is expressed via node affinity, driven by a
 node. This is deliberately different from the LXC/GCE path, where the daemon
 selects the exact machine type; on K8s, the scheduler owns that decision.
 
+## Sandbox-CRD semantics worth knowing
+
+- **Stop/Start = suspend/resume.** Stop patches `spec.operatingMode:
+  Suspended` — the controller deletes only the pod; PVC, Service, Secrets,
+  and the Sandbox identity persist. Start patches back to `Running` and the
+  pod is recreated with the same PVC.
+- **Resize restarts the pod.** The agent-sandbox controller does not restart
+  a live pod on podTemplate drift, so after patching resources the daemon
+  bounces a running box (suspend → resume) to apply them now — comparable
+  downtime to the StatefulSet rolling restart the old path triggered.
+- **TTL is two mechanisms in one patch.** `SetContainerTTL` stamps the
+  Sandbox's `spec.shutdownTime` with `shutdownPolicy: Retain` (the controller
+  stops the pod at the deadline even if the daemon is down) plus a mirrored
+  `ttl_expires_at` meta annotation that the daemon's TTL sweeper reads; the
+  sweeper routes the actual delete through the full `DeleteContainer`
+  cascade. Retain — not Delete — because a controller-side Sandbox delete
+  would orphan the daemon-owned Pipe, Secrets, PVC, namespace, and routes.
+
+## Migrating a pre-Sandbox deployment
+
+Deployments created by the StatefulSet-era backend must recreate their boxes
+(the daemon no longer manages the old object shape):
+
+1. On the old build: `containarium container delete <tenant>` per box — or,
+   post-upgrade, `kubectl delete statefulset box; kubectl delete svc boxes`
+   in each `tenant-*` namespace.
+2. Upgrade the daemon; ensure the agent-sandbox controller is installed.
+3. `containarium container create` again. With a StorageClass configured,
+   home data survives: the new backend reuses the same daemon-owned PVC
+   `data` as a plain pod volume.
+
+The chart's ClusterRole keeps the legacy `apps/statefulsets` rule for one
+release so the post-upgrade cleanup in step 1 works, then it gets dropped.
+
 ## Deferred (not in v1)
 
 - **Hard isolation** (gVisor/Kata `RuntimeClass`) — for tenants needing a
   VM/syscall boundary closer to the LXC trust boundary.
 - **Ephemeral / pooled lifecycles** — spin-up-on-connect or warm-pool leasing.
+  agent-sandbox ships SandboxTemplate/SandboxWarmPool/SandboxClaim for this,
+  but claim adoption is same-namespace-only (`ErrCrossNamespaceAdoption`), so
+  warm capacity cannot be shared across per-tenant namespaces — a shared pool
+  would require collapsing the tenancy model, and per-tenant pools invert the
+  economics (N tenants × idle warm replicas). Until that tension is resolved
+  (upstream cross-namespace pools, or a tenancy redesign), most of the
+  fast-create win comes from pre-pulling the agent-box image (DaemonSet) +
+  suspend/resume, since resume is just pod creation on a warm node.
 - **Cross-cluster / multi-pool** fan-out (the K8s analog of multi-backend
   peers).
 - **GPU node affinity by spec** — the `gpu-spec` label → node affinity mapping

--- a/docs/KIND-QUICKSTART.md
+++ b/docs/KIND-QUICKSTART.md
@@ -27,14 +27,23 @@ one command.
 # 1. Create the cluster
 kind create cluster --name containarium
 
-# 2. Install the chart from the repo
+# 2. Install the agent-sandbox controller (kubernetes-sigs/agent-sandbox).
+#    The daemon declares one Sandbox CR per box; the controller owns the
+#    pod + headless Service under it. Note: the v0.5.1 release asset is
+#    manifest.yaml (upstream's README still references
+#    sandbox-with-extensions.yaml, which 404s).
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.1/manifest.yaml
+kubectl -n agent-sandbox-system wait --for=condition=available \
+  deployment/agent-sandbox-controller --timeout=180s
+
+# 3. Install the chart from the repo
 cd Containarium
 helm install containarium ./charts/containarium-k8s \
   --set daemon.jwtSecret="$(openssl rand -hex 32)" \
   --set storageClass=standard \
   --wait
 
-# 3. Create a box
+# 4. Create a box
 export CTN_URL="http://localhost:8080"
 export CTN_JWT="$(kubectl get secret containarium-containarium-k8s-daemon \
   -o jsonpath='{.data.jwt-secret}' | base64 -d)"
@@ -43,8 +52,8 @@ kubectl port-forward svc/containarium-containarium-k8s-daemon 8080:8080 &
 ./containarium container create myorg/mybox \
   --url "$CTN_URL" --token "$CTN_JWT"
 
-# 4. Verify isolation: no SA token in the box pod
-kubectl exec -n tenant-mybox box-0 -- \
+# 5. Verify isolation: no SA token in the box pod
+kubectl exec -n tenant-mybox box -- \
   cat /var/run/secrets/kubernetes.io/serviceaccount/token 2>&1
 # cat: can't open '...token': No such file or directory  ← expected
 ```
@@ -86,7 +95,20 @@ cd Containarium
 go build -o containarium ./cmd/containarium
 ```
 
-## 3. Create the gateway namespace
+## 3. Install the agent-sandbox controller
+
+The daemon's K8s backend declares one `Sandbox` CR (agents.x-k8s.io/v1beta1)
+per box; the [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox)
+controller creates the pod and headless Service under it. Without the CRD +
+controller installed, `container create` fails on the Sandbox create.
+
+```sh
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.1/manifest.yaml
+kubectl -n agent-sandbox-system wait --for=condition=available \
+  deployment/agent-sandbox-controller --timeout=180s
+```
+
+## 4. Create the gateway namespace
 
 The daemon programs SSH routing via the sshpiper `Pipe` CRD. For a local
 quickstart without a real sshpiper deployment, create the namespace so the
@@ -96,7 +118,7 @@ daemon doesn't error on Pipe operations:
 kubectl create namespace agent-gateway
 ```
 
-## 4. Start the daemon
+## 5. Start the daemon
 
 ```sh
 export KUBECONFIG="$(kind get kubeconfig --name containarium 2>/dev/null || echo ~/.kube/config)"
@@ -122,7 +144,7 @@ CONTAINARIUM_K8S_GATEWAY_HOST="localhost" \
 
 The daemon logs `Box runtime: k8s` on startup.
 
-## 5. Create a box
+## 6. Create a box
 
 In a second terminal:
 
@@ -139,17 +161,19 @@ Verify the pod is scheduled:
 
 ```sh
 kubectl get pods -n tenant-mybox
-# NAME    READY   STATUS    RESTARTS   AGE
-# box-0   1/1     Running   0          10s
+# NAME   READY   STATUS    RESTARTS   AGE
+# box    1/1     Running   0          10s
 ```
 
-And the per-tenant objects:
+And the per-tenant objects (the Sandbox is the daemon's object; the pod and
+Service under it are the agent-sandbox controller's):
 
 ```sh
-kubectl get ns,sts,svc,netpol -l containarium.dev/tenant=mybox
+kubectl get ns,sandbox,netpol -l containarium.dev/tenant=mybox
+kubectl get pods,svc -n tenant-mybox
 ```
 
-## 6. Persistent storage (optional)
+## 7. Persistent storage (optional)
 
 kind ships a `standard` StorageClass backed by the local-path provisioner.
 Pass `CONTAINARIUM_K8S_STORAGE_CLASS=standard` to enable PVC-per-box:
@@ -177,11 +201,11 @@ kubectl get pvc -n tenant-mybox
 The PVC stays Pending until a pod with `AutoStart=true` schedules (the
 local-path provisioner binds on pod assignment, not on PVC creation).
 
-## 7. Verify isolation
+## 8. Verify isolation
 
 ```sh
 # No service-account token is mounted in the box pod.
-kubectl exec -n tenant-mybox box-0 -- cat /var/run/secrets/kubernetes.io/serviceaccount/token 2>&1
+kubectl exec -n tenant-mybox box -- cat /var/run/secrets/kubernetes.io/serviceaccount/token 2>&1
 # cat: can't open '/var/run/secrets/kubernetes.io/serviceaccount/token': No such file or directory
 
 # Default-deny NetworkPolicy is in place.
@@ -190,7 +214,7 @@ kubectl get netpol -n tenant-mybox
 # default-deny   …              …
 ```
 
-## 8. Teardown
+## 9. Teardown
 
 ```sh
 # Delete the box (retains PVC when StorageClass is set).
@@ -206,8 +230,10 @@ kind delete cluster --name containarium
 |---|---|---|
 | `Box runtime: lxc` in logs | env var not set | Check `CONTAINARIUM_RUNTIME=k8s` is exported |
 | `failed to select box backend: k8s: build rest config` | Kubeconfig missing | Set `CONTAINARIUM_K8S_KUBECONFIG` |
-| Pod stays `Pending` forever | No schedulable node | `kubectl describe pod -n tenant-mybox box-0` for events |
+| Pod stays `Pending` forever | No schedulable node | `kubectl describe pod -n tenant-mybox box` for events |
 | `Pipe` errors in daemon log | Gateway namespace missing | `kubectl create namespace agent-gateway` |
+| `ensure sandbox: ... no matches for kind "Sandbox"` | agent-sandbox controller/CRD not installed | Step 3: apply the agent-sandbox `manifest.yaml` |
+| Pod never appears for a created box | Controller not running | `kubectl get pods -n agent-sandbox-system` |
 
 ## CI / automated testing
 


### PR DESCRIPTION
#### What this PR does / why we need it:

PR 4 of 4 in the agent-sandbox adoption (stacked on #970 → #969 → #968).

- **Chart ClusterRole**: adds `agents.x-k8s.io sandboxes` CRUD for the daemon;
  keeps the legacy `apps/statefulsets` rule for one release (migration window),
  to be dropped after.
- **KIND-QUICKSTART**: the agent-sandbox controller is now a hard
  prerequisite — install steps added to both the Helm and manual paths, pod
  name updates (`box-0` → `box`), and new troubleshooting rows for the
  missing-CRD / controller-not-running failure modes.
- **K8S-AGENT-BOX-RUNTIME-DESIGN**: substrate sections rewritten from the
  hand-managed StatefulSet to the Sandbox CR, plus new sections on CRD
  semantics (suspend/resume, resize-restarts-pod, two-mechanism TTL with
  `shutdownPolicy: Retain`), the migration path for pre-Sandbox deployments
  (home data survives via the daemon-owned PVC), and the WarmPool deferral
  rationale (same-namespace-only claim adoption vs per-tenant namespaces).

Verified: `helm template` renders the new RBAC rule; docs greps show no stale
`box-0`/`boxes`-service references outside the intentional historical note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)