### PR TITLE
fix(e2e): wait on the agent-sandbox controller by name, not by label

### DIFF
--- a/scripts/k8s-e2e.sh
+++ b/scripts/k8s-e2e.sh
@@ -48,8 +48,12 @@ AGENT_SANDBOX_VERSION="${AGENT_SANDBOX_VERSION:-v0.5.1}"
 echo "==> installing agent-sandbox controller ${AGENT_SANDBOX_VERSION}"
 command -v kubectl >/dev/null || { echo "kubectl is required to install the agent-sandbox controller" >&2; exit 1; }
 kubectl apply -f "https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/manifest.yaml"
-kubectl wait --for=condition=available deployment -A \
-  -l control-plane=controller-manager --timeout=180s
+# The manifest installs Deployment agent-sandbox-controller in namespace
+# agent-sandbox-system (it does NOT carry the kubebuilder-conventional
+# control-plane=controller-manager label — a label-selector wait matches
+# nothing and kubectl exits "no matching resources found").
+kubectl -n agent-sandbox-system wait --for=condition=available \
+  deployment/agent-sandbox-controller --timeout=180s
 
 echo "==> running K8s agent-box e2e (reconciler vs. the kind apiserver)"
 CONTAINARIUM_K8S_E2E=1 go test -tags k8s -run TestE2E -timeout 12m -v ./pkg/core/box/k8s/


### PR DESCRIPTION
#### What this PR does / why we need it:

The kind e2e job on #969 failed at the controller-ready wait and merged
anyway (kind e2e is not a required check). Root cause: the agent-sandbox
v0.5.1 manifest installs Deployment `agent-sandbox-controller` in namespace
`agent-sandbox-system` **without** the kubebuilder-conventional
`control-plane=controller-manager` label, so the label-selector wait matched
nothing and `set -e` killed the script before the e2e suite ever ran.

Waits on the concrete deployment name instead. This PR's own kind e2e run is
the first full CI execution of the rewritten Sandbox-CRD e2e suite
(lifecycle / gateway Pipe / CSI storage / GPU) — watch that check, not just
the required ones.

Ref #969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)