### PR TITLE
feat(images): ship containarium-sshpiper; fix the chart's unpullable gateway image (#976)

### DIFF
--- a/.github/workflows/sidecars.yml
+++ b/.github/workflows/sidecars.yml
@@ -64,3 +64,37 @@ jobs:
           # explicit so it's reviewable.
           provenance: true
           sbom: true
+
+  sshpiper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: tags
+        run: |
+          version="${GITHUB_REF#refs/tags/v}"
+          minor="v$(echo "$version" | cut -d. -f1-2)"
+          base="ghcr.io/footprintai/containarium-sshpiper"
+          {
+            echo "tags=${base}:v${version},${base}:${minor},${base}:latest-stable"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push containarium-sshpiper
+        uses: docker/build-push-action@v7
+        with:
+          context: ./images/sshpiper
+          file: ./images/sshpiper/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          provenance: true
+          sbom: true

--- a/.github/workflows/sshpiper-image.yml
+++ b/.github/workflows/sshpiper-image.yml
@@ -1,0 +1,43 @@
+name: sshpiper image
+
+# Build-checks the containarium-sshpiper gateway image (images/sshpiper/) —
+# pinned upstream sshpiperd release + our entrypoint. Build only (no push);
+# publishing to ghcr.io/footprintai/containarium-sshpiper happens on release
+# tags via sidecars.yml.
+on:
+  pull_request:
+    paths:
+      - 'images/sshpiper/**'
+      - '.github/workflows/sshpiper-image.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'images/sshpiper/**'
+      - '.github/workflows/sshpiper-image.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build sshpiper image
+        run: docker build -f images/sshpiper/Dockerfile -t containarium-sshpiper:ci images/sshpiper
+      - name: Smoke-check the image
+        # sshpiperd + the kubernetes plugin must be present, the entrypoint
+        # executable, and the runtime user non-root.
+        run: |
+          docker run --rm --entrypoint /bin/sh containarium-sshpiper:ci -c '
+            set -e
+            test -x /sshpiperd/sshpiperd
+            test -x /sshpiperd/plugins/kubernetes
+            test -x /sshpiperd/entrypoint.sh
+            id -u | grep -qx 1000
+          '

--- a/charts/containarium-k8s/templates/sshpiper-deployment.yaml
+++ b/charts/containarium-k8s/templates/sshpiper-deployment.yaml
@@ -27,14 +27,29 @@ spec:
         - name: sshpiper
           image: {{ .Values.gateway.sshpiper.image }}
           imagePullPolicy: IfNotPresent
-          args:
-            - --address=:2222
+          env:
+            # Route by the Pipe CRDs the daemon programs in this namespace.
+            - name: PLUGIN
+              value: kubernetes
+            - name: SSHPIPERD_SERVER_KEY
+              value: /serverkey/ssh_host_ed25519_key
           ports:
             - name: ssh
               containerPort: 2222
               protocol: TCP
+          volumeMounts:
+            - name: server-key
+              mountPath: /serverkey/
+              readOnly: true
           {{- with .Values.gateway.sshpiper.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      volumes:
+        - name: server-key
+          secret:
+            secretName: {{ .Values.gateway.sshpiper.serverKeySecret }}
+            items:
+              - key: server_key
+                path: ssh_host_ed25519_key
 {{- end }}

--- a/charts/containarium-k8s/values.yaml
+++ b/charts/containarium-k8s/values.yaml
@@ -33,7 +33,16 @@ gateway:
     # -- NodePort for kind (access via localhost:32022)
     nodePort: 32022
   sshpiper:
-    image: ghcr.io/tg123/sshpiper/sshpiperd-kubernetes:v1.5.3
+    # -- Containarium's own gateway image (pinned upstream sshpiperd release +
+    # kubernetes-plugin entrypoint), published per Containarium release by
+    # sidecars.yml. The previously pinned ghcr.io/tg123/... path was never
+    # published upstream and 403s on pull (#976).
+    image: ghcr.io/footprintai/containarium-sshpiper:latest-stable
+    # -- Secret holding sshpiperd's host key under the `server_key` field.
+    # Create before enabling the gateway:
+    #   ssh-keygen -t ed25519 -f host_key -N ""
+    #   kubectl -n <gateway ns> create secret generic sshpiper-server-key --from-file=server_key=host_key
+    serverKeySecret: sshpiper-server-key
     resources: {}
 
 # -- Prefix for per-tenant Kubernetes namespaces (tenant → tenant-<name>)

--- a/deploy/k8s/sshpiper/30-deployment.yaml
+++ b/deploy/k8s/sshpiper/30-deployment.yaml
@@ -23,7 +23,9 @@ spec:
       containers:
         - name: sshpiperd
           # Pin to a release tag in production rather than :latest.
-          image: farmer1992/sshpiperd:latest
+          # Containarium-published gateway image (pinned upstream release inside);
+          # published per release by .github/workflows/sidecars.yml.
+          image: ghcr.io/footprintai/containarium-sshpiper:latest-stable
           env:
             # Activates the kubernetes plugin (watches Pipes in this namespace).
             - name: PLUGIN

--- a/images/sshpiper/Dockerfile
+++ b/images/sshpiper/Dockerfile
@@ -1,0 +1,40 @@
+# containarium-sshpiper
+#
+# The SSH gateway image for the Kubernetes backend: sshpiperd with its
+# bundled plugins, from the SAME pinned upstream release the sentinel
+# installs (terraform startup-sentinel.sh pins SSHPIPER_VERSION) — one
+# canonical gateway version across the LXC and K8s worlds, published under
+# our registry so the chart never depends on a third-party :latest tag
+# (Containarium#976).
+#
+# Published per-release as ghcr.io/footprintai/containarium-sshpiper (see
+# .github/workflows/sidecars.yml). Build:
+#   docker build -f images/sshpiper/Dockerfile -t containarium-sshpiper images/sshpiper
+#
+# Runtime contract (drop-in for the deployment shape the chart/example use):
+#   - PLUGIN selects the routing plugin (default: kubernetes)
+#   - SSHPIPERD_* env flows through to sshpiperd (SERVER_KEY, LOG_LEVEL, ...)
+#   - listens on :2222, runs as non-root uid 1000
+
+FROM debian:bookworm-slim AS fetch
+ARG SSHPIPER_VERSION=v1.5.3
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /sshpiperd \
+    && curl -fsSL "https://github.com/tg123/sshpiper/releases/download/${SSHPIPER_VERSION}/sshpiperd_with_plugins_linux_x86_64.tar.gz" \
+       | tar -xz -C /sshpiperd \
+    && test -x /sshpiperd/sshpiperd
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 --shell /usr/sbin/nologin sshpiper
+COPY --from=fetch /sshpiperd /sshpiperd
+COPY entrypoint.sh /sshpiperd/entrypoint.sh
+RUN chmod 0755 /sshpiperd/entrypoint.sh
+
+USER sshpiper
+EXPOSE 2222
+ENTRYPOINT ["/sshpiperd/entrypoint.sh"]

--- a/images/sshpiper/entrypoint.sh
+++ b/images/sshpiper/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# containarium-sshpiper entrypoint: run sshpiperd with the plugin named by
+# $PLUGIN (default kubernetes — the K8s backend's Pipe-CRD routing).
+# Mirrors the upstream image's contract so deployments written against
+# farmer1992/sshpiperd (PLUGIN env + SSHPIPERD_* env) work unchanged.
+set -eu
+
+PLUGIN="${PLUGIN:-kubernetes}"
+PLUGIN_BIN="/sshpiperd/plugins/${PLUGIN}"
+if [ ! -x "$PLUGIN_BIN" ]; then
+  echo "unknown sshpiper plugin '${PLUGIN}'; available:" >&2
+  ls /sshpiperd/plugins >&2
+  exit 1
+fi
+
+exec /sshpiperd/sshpiperd "$PLUGIN_BIN" "$@"


### PR DESCRIPTION
#### What this PR does / why we need it:

The K8s gateway depended on third-party images — the chart's pin
(`ghcr.io/tg123/sshpiper/sshpiperd-kubernetes:v1.5.3`) was never published
upstream and 403s on pull (ImagePullBackOff on `gateway.enabled=true`), and
`deploy/k8s` used an unpinned `farmer1992/sshpiperd:latest`.

- **`images/sshpiper/`**: `containarium-sshpiper`, built from the same pinned
  upstream release the sentinel installs (v1.5.3, `sshpiperd_with_plugins`),
  entrypoint honoring `PLUGIN` (default `kubernetes`), non-root uid 1000.
  One canonical gateway version across the LXC and K8s worlds.
- **Publishing**: per release tag as `ghcr.io/footprintai/containarium-sshpiper`
  via `sidecars.yml` (same scheme as the otel sidecar); PR build-check via
  `sshpiper-image.yml`.
- **Chart (#976)**: image swap plus the template was missing plugin selection
  and the server host key entirely — now sets `PLUGIN=kubernetes` and mounts
  the key from `gateway.sshpiper.serverKeySecret` (documented in values).

Verified live on a kind cluster: gateway rolled out on this image, MCP
handshake through NodePort 32022 (two-hop key chain, no kubectl in the
agent's path).

Note: the image first publishes on the next release tag — until then the
chart's `latest-stable` reference is forward-looking.

Fixes #976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)