### PR TITLE
ci(release): actually publish containarium-agent-box on release tags

### DIFF
--- a/.github/workflows/sidecars.yml
+++ b/.github/workflows/sidecars.yml
@@ -98,3 +98,38 @@ jobs:
           tags: ${{ steps.tags.outputs.tags }}
           provenance: true
           sbom: true
+
+  agent-box:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: tags
+        run: |
+          version="${GITHUB_REF#refs/tags/v}"
+          minor="v$(echo "$version" | cut -d. -f1-2)"
+          base="ghcr.io/footprintai/containarium-agent-box"
+          {
+            echo "tags=${base}:v${version},${base}:${minor},${base}:latest-stable"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push containarium-agent-box
+        uses: docker/build-push-action@v7
+        with:
+          # Repo root context: the Dockerfile builds ./cmd/agent-box.
+          context: .
+          file: ./images/agent-box/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          provenance: true
+          sbom: true

--- a/images/agent-box/Dockerfile
+++ b/images/agent-box/Dockerfile
@@ -14,7 +14,8 @@
 #   - dropbear instead of OpenSSH: it runs cleanly rootless and supports a
 #     forced command, so there's no sshd privsep/PAM/root dance.
 #
-# Published per-release as ghcr.io/footprintai/containarium-agent-box:vX.Y.Z.
+# Published per-release as ghcr.io/footprintai/containarium-agent-box:vX.Y.Z
+# by .github/workflows/sidecars.yml (release tags).
 # Build context is the repo root:
 #   docker build -f images/agent-box/Dockerfile -t containarium-agent-box .
 


### PR DESCRIPTION
#### What this PR does / why we need it:

The agent-box Dockerfile has claimed "published per-release as
\`ghcr.io/footprintai/containarium-agent-box\`" since it landed, but no
workflow ever pushed it — \`agent-box-image.yml\` is build-only and
\`release.yml\` ships only the raw binary. The image 403s on pull today, so
every consumer (KIND-QUICKSTART, the kubernetes-sigs/agent-sandbox example)
must build from source.

Adds the publish job to \`sidecars.yml\` alongside otel-sidecar and
containarium-sshpiper (#977), same per-release tag scheme
(\`:vX.Y.Z\`, \`:vX.Y\`, \`:latest-stable\`). First publish happens on the next
release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)