### PR TITLE
chore(release): cut v0.52.1 — fix image publishing (missing buildx setup)

### DIFF
--- a/.github/workflows/sidecars.yml
+++ b/.github/workflows/sidecars.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -104,6 +107,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.52.1] - 2026-07-15
+
+### Fixed
+
+- The v0.52.0 tag's image publishing failed before pushing anything: the new
+  `containarium-sshpiper` / `containarium-agent-box` jobs in `sidecars.yml`
+  were missing the Buildx setup step, and provenance/SBOM attestation is not
+  supported by the plain docker driver. v0.52.1 is the first tag where both
+  images actually publish. (The v0.52.0 binaries released fine.)
+
 ## [0.52.0] - 2026-07-15
 
 ### Changed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.52.0"
+	Version = "0.52.1"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
v0.52.0's new image-publish jobs failed before pushing anything —
provenance/SBOM attestation isn't supported by the plain docker driver and
the jobs were missing \`setup-buildx-action\` (the otel job had it; the new
jobs didn't). Adds the step to both, bumps to v0.52.1 so a fresh tag
publishes \`containarium-sshpiper\` + \`containarium-agent-box\` for real.
Binaries for v0.52.0 released fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)