### PR TITLE
feat(sentinel): route SSH to a backend-advertised ingress port

### DIFF
--- a/internal/gateway/keys_handler.go
+++ b/internal/gateway/keys_handler.go
@@ -21,6 +21,14 @@ type UserKeys struct {
 // KeysResponse is the JSON response from the /authorized-keys endpoint.
 type KeysResponse struct {
 	Keys []UserKeys `json:"keys"`
+
+	// SSHPort is the port on this node the sentinel should forward SSH to
+	// for every user in Keys. 0 (or absent — pre-advertisement daemons)
+	// means the legacy convention: 22 direct, 20022 through a tunnel
+	// loopback. A K8s-runtime node advertises its in-cluster gateway
+	// ingress here (e.g. the sshpiper Service's NodePort), since nothing
+	// listens on the node's :22 for boxes.
+	SSHPort int `json:"ssh_port,omitempty"`
 }
 
 // SentinelKeyRequest is the JSON body for POST /authorized-keys/sentinel.
@@ -105,6 +113,9 @@ func ServeAuthorizedKeys(homeRoot string, containerExistsFn func(username string
 		}
 
 		w.Header().Set("Content-Type", "application/json")
+		// SSHPort deliberately omitted (0): on the LXC runtime boxes are
+		// reached on the node's own sshd port, which is the sentinel's
+		// legacy 22/20022 convention.
 		_ = json.NewEncoder(w).Encode(KeysResponse{Keys: keys})
 	}
 }

--- a/internal/sentinel/keysync.go
+++ b/internal/sentinel/keysync.go
@@ -29,8 +29,12 @@ type backendKeys struct {
 	backendID string
 	backendIP string
 	users     []gateway.UserKeys
-	lastSync  time.Time
-	lastErr   error
+	// sshPort is the SSH ingress the backend advertised in its
+	// /authorized-keys response (KeysResponse.SSHPort). 0 = legacy
+	// convention (22 direct / 20022 tunnel-loopback) — see routeTargetPort.
+	sshPort  int
+	lastSync time.Time
+	lastErr  error
 }
 
 // KeyStore syncs SSH authorized keys from one or more backends and generates
@@ -86,6 +90,7 @@ func (ks *KeyStore) Sync(backendID, backendIP string, httpPort int) error {
 	ks.mu.Lock()
 	bk := ks.ensureBackendLocked(backendID, backendIP)
 	bk.users = keysResp.Keys
+	bk.sshPort = keysResp.SSHPort
 	bk.lastSync = time.Now()
 	bk.lastErr = nil
 	ks.mu.Unlock()
@@ -117,6 +122,7 @@ func (ks *KeyStore) Apply() error {
 		username       string
 		authorizedKeys string
 		backendIP      string
+		sshPort        int // backend-advertised; 0 = legacy convention
 	}
 	seen := make(map[string]bool)
 	var routes []userRoute
@@ -140,6 +146,7 @@ func (ks *KeyStore) Apply() error {
 				username:       u.Username,
 				authorizedKeys: u.AuthorizedKeys,
 				backendIP:      bk.backendIP,
+				sshPort:        bk.sshPort,
 			})
 		}
 	}
@@ -205,13 +212,7 @@ func (ks *KeyStore) Apply() error {
 	buf.WriteString("version: \"1.0\"\npipes:\n")
 
 	for _, r := range routes {
-		// Tunnel backends use loopback aliases (127.0.0.x where x >= 10) with
-		// SSH on port 20022 to avoid conflicting with sshpiper's *:22 listener.
-		// Direct backends (e.g., 10.x.x.x) use the standard port 22.
-		sshPort := 22
-		if isTunnelLoopback(r.backendIP) {
-			sshPort = 20022
-		}
+		sshPort := routeTargetPort(r.backendIP, r.sshPort)
 		akPath := filepath.Join(sshpiperUsersDir, r.username, "authorized_keys")
 		fmt.Fprintf(&buf, "  - from:\n")
 		fmt.Fprintf(&buf, "      - username: %q\n", r.username)
@@ -378,6 +379,32 @@ func cleanAuthorizedKeys(raw string) string {
 // These addresses are assigned by the TunnelRegistry for tunnel-connected backends.
 func isTunnelLoopback(ip string) bool {
 	return strings.HasPrefix(ip, "127.0.0.") && len(ip) > 8 && ip != "127.0.0.1"
+}
+
+// routeTargetPort resolves the port the sentinel forwards a user's SSH to.
+//
+// advertised is the backend's KeysResponse.SSHPort:
+//   - 0 (pre-advertisement daemons, and the LXC runtime): the legacy
+//     convention — 22 for direct backends, 20022 through a tunnel loopback
+//     (the TunnelServer remaps an advertised port 22 to a 20022 listener to
+//     stay clear of sshpiper's own *:22).
+//   - 22 on a tunnel loopback: same 20022 remap — the backend means "my
+//     sshd", and the tunnel listener for it is on 20022.
+//   - anything else: used as-is. Tunnel listeners for non-22 ports keep
+//     their advertised number, so a K8s node's gateway ingress (e.g. 32022)
+//     is the same port on the loopback alias as on the node directly.
+func routeTargetPort(backendIP string, advertised int) int {
+	tunnel := isTunnelLoopback(backendIP)
+	switch {
+	case advertised == 0 && tunnel:
+		return 20022
+	case advertised == 0:
+		return 22
+	case advertised == 22 && tunnel:
+		return 20022
+	default:
+		return advertised
+	}
 }
 
 func (ks *KeyStore) backendCount() int {

--- a/internal/sentinel/keysync_port_test.go
+++ b/internal/sentinel/keysync_port_test.go
@@ -157,3 +157,62 @@ func TestApply_YAMLContainsTunnelPort(t *testing.T) {
 func portStr(p int) string {
 	return fmt.Sprintf("%d", p)
 }
+
+// TestRouteTargetPort pins the forwarding-port resolution: legacy backends
+// (no advertised port) keep the 22/20022 convention; a backend-advertised
+// ingress (a K8s node's in-cluster gateway, e.g. 32022) is used as-is on
+// both direct and tunnel paths, because tunnel listeners for non-22 ports
+// keep their advertised number.
+func TestRouteTargetPort(t *testing.T) {
+	tests := []struct {
+		name       string
+		backendIP  string
+		advertised int
+		want       int
+	}{
+		{"legacy direct", "10.130.0.15", 0, 22},
+		{"legacy tunnel", "127.0.0.10", 0, 20022},
+		{"advertised 22 direct", "10.130.0.15", 22, 22},
+		{"advertised 22 tunnel remaps", "127.0.0.10", 22, 20022},
+		{"k8s gateway direct", "10.130.0.15", 32022, 32022},
+		{"k8s gateway via tunnel", "127.0.0.10", 32022, 32022},
+	}
+	for _, tt := range tests {
+		if got := routeTargetPort(tt.backendIP, tt.advertised); got != tt.want {
+			t.Errorf("%s: routeTargetPort(%q, %d) = %d, want %d",
+				tt.name, tt.backendIP, tt.advertised, got, tt.want)
+		}
+	}
+}
+
+// TestApply_AdvertisedPortRouting drives Sync's decode of ssh_port through
+// to the route emission shape (the same simulation style as
+// TestApply_TunnelPortRouting): a K8s-runtime backend advertising 32022
+// must be routed to backendIP:32022, not the legacy 22.
+func TestApply_AdvertisedPortRouting(t *testing.T) {
+	ks := NewKeyStore()
+	ks.mu.Lock()
+	ks.backends["k8s-node"] = &backendKeys{
+		backendID: "k8s-node",
+		backendIP: "10.130.0.20",
+		sshPort:   32022,
+		users: []gateway.UserKeys{
+			{Username: "mybox", AuthorizedKeys: "ssh-ed25519 AAAA_mybox agent@laptop"},
+		},
+	}
+	ks.mu.Unlock()
+
+	// Mirror Apply's route-emission logic (Apply itself writes to
+	// /etc/sshpiper — not testable here; same approach as the tunnel test).
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+	for _, bk := range ks.backends {
+		for range bk.users {
+			port := routeTargetPort(bk.backendIP, bk.sshPort)
+			hostLine := fmt.Sprintf("host: %s:%d", bk.backendIP, port)
+			if !strings.Contains(hostLine, "10.130.0.20:32022") {
+				t.Errorf("route host = %q, want 10.130.0.20:32022", hostLine)
+			}
+		}
+	}
+}


### PR DESCRIPTION
PR 1 of 4 for sentinel→K8s-node SSH chaining (`agent → sentinel :22 → node
in-cluster gateway → box pod`, one public address for boxes on any node).

- `KeysResponse` gains optional top-level `ssh_port`: absent/0 = legacy
  convention (22 direct, 20022 tunnel-loopback) so old daemons and the LXC
  runtime produce byte-identical sentinel config; a K8s-runtime node will
  advertise its in-cluster gateway ingress (e.g. NodePort 32022) — nothing
  on its :22 serves boxes.
- keysync resolves the forwarding port via a pure `routeTargetPort` helper:
  advertised ports are used as-is on direct AND tunnel paths (the
  TunnelServer's listeners for non-22 ports keep their advertised number;
  only 22 carries the historical 20022 remap).

Follow-ups: PR 2 (K8s `/authorized-keys` from box meta + gateway Service
address resolution), PR 3 (K8s `/authorized-keys/sentinel` → sentinel key
into node-gateway Pipes), PR 4 (tunnel dial map + chain e2e + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)