### PR TITLE
feat(k8s): serve /authorized-keys from box metadata + advertise gateway ingress

### DIFF
--- a/internal/config/k8s.go
+++ b/internal/config/k8s.go
@@ -18,6 +18,8 @@ const (
 	// #nosec G101 -- this is the NAME of an environment variable, not a credential value.
 	EnvK8sGatewayUpstreamKeySecret = "CONTAINARIUM_K8S_GATEWAY_UPSTREAM_KEY_SECRET"
 	EnvK8sInsecureIgnoreHostKey    = "CONTAINARIUM_K8S_INSECURE_IGNORE_HOST_KEY"
+	EnvK8sGatewayService           = "CONTAINARIUM_K8S_GATEWAY_SERVICE"
+	EnvK8sGatewayAdvertisePort     = "CONTAINARIUM_K8S_GATEWAY_ADVERTISE_PORT"
 	EnvK8sDefaultMemoryRequest     = "CONTAINARIUM_K8S_DEFAULT_MEMORY_REQUEST"
 	EnvK8sDefaultMemoryLimit       = "CONTAINARIUM_K8S_DEFAULT_MEMORY_LIMIT"
 	EnvK8sDisableMemoryFloor       = "CONTAINARIUM_K8S_DISABLE_MEMORY_FLOOR"
@@ -28,6 +30,7 @@ const (
 	defaultK8sGatewayNamespace = "agent-gateway"
 	defaultK8sTenantNSPrefix   = "tenant-"
 	defaultK8sGatewaySSHPort   = 22
+	defaultK8sGatewayService   = "sshpiper"
 )
 
 // K8s is the typed view of the CONTAINARIUM_K8S_* namespace — the wiring the
@@ -61,6 +64,18 @@ type K8s struct {
 	// StorageClass is the StorageClass for the box's data PVC; empty disables the
 	// PVC. (EnvK8sStorageClass)
 	StorageClass string
+
+	// GatewayService is the name of the in-cluster sshpiper Service in
+	// GatewayNamespace, used to auto-resolve the node's advertised SSH
+	// ingress (its NodePort) for the sentinel's /authorized-keys sync.
+	// (EnvK8sGatewayService; default "sshpiper")
+	GatewayService string
+
+	// GatewayAdvertisePort overrides the auto-resolved SSH ingress port
+	// advertised to the sentinel. 0 = resolve from GatewayService; useful
+	// when the gateway is exposed via a hostPort/LB the Service lookup
+	// can't see. (EnvK8sGatewayAdvertisePort)
+	GatewayAdvertisePort int
 
 	// GatewayUpstreamPublicKey is the public key authorized on each box so
 	// sshpiper can log in upstream. (EnvK8sGatewayUpstreamPublicKey)
@@ -100,6 +115,8 @@ func LoadK8s() K8s {
 		GatewayUpstreamPublicKey:  getString(EnvK8sGatewayUpstreamPublicKey, ""),
 		GatewayUpstreamKeySecret:  getString(EnvK8sGatewayUpstreamKeySecret, ""),
 		InsecureIgnoreHostKey:     getBool(EnvK8sInsecureIgnoreHostKey),
+		GatewayService:            getString(EnvK8sGatewayService, defaultK8sGatewayService),
+		GatewayAdvertisePort:      getInt(EnvK8sGatewayAdvertisePort, 0),
 		DefaultMemoryRequest:      getString(EnvK8sDefaultMemoryRequest, ""),
 		DefaultMemoryLimit:        getString(EnvK8sDefaultMemoryLimit, ""),
 		DisableDefaultMemoryFloor: getBool(EnvK8sDisableMemoryFloor),

--- a/internal/config/k8s_test.go
+++ b/internal/config/k8s_test.go
@@ -9,7 +9,7 @@ var allK8sEnvKeys = []string{
 	EnvK8sTenantNSPrefix, EnvK8sBoxImage, EnvK8sStorageClass,
 	EnvK8sGatewayUpstreamPublicKey, EnvK8sGatewayUpstreamKeySecret,
 	EnvK8sInsecureIgnoreHostKey, EnvK8sDefaultMemoryRequest, EnvK8sDefaultMemoryLimit,
-	EnvK8sDisableMemoryFloor,
+	EnvK8sDisableMemoryFloor, EnvK8sGatewayService, EnvK8sGatewayAdvertisePort,
 }
 
 func clearK8sEnv(t *testing.T) {
@@ -27,6 +27,7 @@ func TestLoadK8sDefaults(t *testing.T) {
 		GatewayNamespace:      defaultK8sGatewayNamespace,
 		TenantNamespacePrefix: defaultK8sTenantNSPrefix,
 		GatewaySSHPort:        defaultK8sGatewaySSHPort,
+		GatewayService:        defaultK8sGatewayService,
 	}
 	if got != want {
 		t.Errorf("LoadK8s defaults = %+v, want %+v", got, want)
@@ -47,6 +48,8 @@ func TestLoadK8sReadsEnv(t *testing.T) {
 	t.Setenv(EnvK8sGatewayUpstreamPublicKey, "ssh-ed25519 AAA")
 	t.Setenv(EnvK8sGatewayUpstreamKeySecret, "gw-upstream-key")
 	t.Setenv(EnvK8sInsecureIgnoreHostKey, "1")
+	t.Setenv(EnvK8sGatewayService, "my-gw")
+	t.Setenv(EnvK8sGatewayAdvertisePort, "31000")
 	t.Setenv(EnvK8sDefaultMemoryRequest, "512Mi")
 	t.Setenv(EnvK8sDefaultMemoryLimit, "2Gi")
 	t.Setenv(EnvK8sDisableMemoryFloor, "true")
@@ -63,6 +66,8 @@ func TestLoadK8sReadsEnv(t *testing.T) {
 		GatewayUpstreamPublicKey:  "ssh-ed25519 AAA",
 		GatewayUpstreamKeySecret:  "gw-upstream-key",
 		InsecureIgnoreHostKey:     true,
+		GatewayService:            "my-gw",
+		GatewayAdvertisePort:      31000,
 		DefaultMemoryRequest:      "512Mi",
 		DefaultMemoryLimit:        "2Gi",
 		DisableDefaultMemoryFloor: true,

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -83,6 +83,11 @@ type GatewayServer struct {
 	// Wired from dual_server using the container manager.
 	containerExistsFn func(username string) bool
 
+	// authorizedKeysHandler overrides the default home-dir-walking
+	// /authorized-keys handler. The K8s runtime installs a lister-backed
+	// handler here (boxes have no /home on the node). nil = default.
+	authorizedKeysHandler http.HandlerFunc
+
 	// Wake handler (for serverless / wake-on-HTTP, set externally).
 	// Mounted at /wake/ and at the root catch-all when the daemon's
 	// wake feature is enabled. NOT wrapped by the JWT auth middleware
@@ -185,6 +190,12 @@ func (gs *GatewayServer) SetSentinelAuthSecret(secret []byte) {
 // including BYOC, since a verifier cannot forge requests.
 func (gs *GatewayServer) SetSentinelPublicKey(pub ed25519.PublicKey) {
 	gs.sentinelPubKey = pub
+}
+
+// SetAuthorizedKeysHandler overrides the default /authorized-keys handler
+// (the LXC home-dir walker) — the K8s runtime installs a lister-backed one.
+func (gs *GatewayServer) SetAuthorizedKeysHandler(h http.HandlerFunc) {
+	gs.authorizedKeysHandler = h
 }
 
 // SetContainerExistsFn wires the orphan filter for /authorized-keys.
@@ -742,7 +753,11 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 	// neither is configured, all requests get 401. See A-CRIT-4 / A-HIGH-2.
 	sentinelVerifier := auth.NewSentinelVerifier(gs.sentinelPubKey, gs.sentinelAuthSecret)
 	httpMux.Handle("/certs", sentinelVerifier.Middleware(ServeCerts(gs.caddyCertDir)))
-	httpMux.Handle("/authorized-keys", sentinelVerifier.Middleware(ServeAuthorizedKeys("", gs.containerExistsFn)))
+	authorizedKeysHandler := gs.authorizedKeysHandler
+	if authorizedKeysHandler == nil {
+		authorizedKeysHandler = ServeAuthorizedKeys("", gs.containerExistsFn)
+	}
+	httpMux.Handle("/authorized-keys", sentinelVerifier.Middleware(authorizedKeysHandler))
 	httpMux.Handle("/authorized-keys/sentinel", sentinelVerifier.Middleware(ServeSentinelKey()))
 
 	// Catch-all fallback: when wake-on-HTTP is enabled, Caddy

--- a/internal/gateway/keys_handler.go
+++ b/internal/gateway/keys_handler.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -34,6 +35,43 @@ type KeysResponse struct {
 // SentinelKeyRequest is the JSON body for POST /authorized-keys/sentinel.
 type SentinelKeyRequest struct {
 	PublicKey string `json:"public_key"`
+}
+
+// ClientKeyLister is the runtime-neutral source of tenant → authorized_keys
+// for /authorized-keys. The LXC runtime uses the home-dir walker
+// (ServeAuthorizedKeys); the K8s runtime supplies a lister backed by box
+// metadata (nothing lives in /home on a K8s node).
+type ClientKeyLister interface {
+	ListClientKeys(ctx context.Context) (map[string]string, error)
+}
+
+// ServeAuthorizedKeysFromLister returns a handler that answers
+// /authorized-keys from a ClientKeyLister and advertises sshPort as the
+// node's SSH ingress (KeysResponse.SSHPort) so the sentinel forwards to the
+// in-cluster gateway rather than the node's :22. Used on the K8s runtime.
+func ServeAuthorizedKeysFromLister(lister ClientKeyLister, sshPort func() int) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		m, err := lister.ListClientKeys(r.Context())
+		if err != nil {
+			log.Printf("[keys] lister failed: %v", err)
+			http.Error(w, `{"error":"failed to list client keys"}`, http.StatusInternalServerError)
+			return
+		}
+		keys := make([]UserKeys, 0, len(m))
+		for username, ak := range m {
+			content := strings.TrimSpace(ak)
+			if content == "" {
+				continue
+			}
+			keys = append(keys, UserKeys{Username: username, AuthorizedKeys: content})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(KeysResponse{Keys: keys, SSHPort: sshPort()})
+	}
 }
 
 // ServeAuthorizedKeys returns an HTTP handler that walks

--- a/internal/server/boxbackend_factory.go
+++ b/internal/server/boxbackend_factory.go
@@ -64,6 +64,8 @@ func newK8sBackend() (box.BoxBackend, error) {
 		GatewayNamespace:          cfg.GatewayNamespace,
 		GatewayHost:               cfg.GatewayHost,
 		GatewaySSHPort:            cfg.GatewaySSHPort,
+		GatewayService:            cfg.GatewayService,
+		GatewayAdvertisePort:      cfg.GatewayAdvertisePort,
 		TenantNamespacePrefix:     cfg.TenantNamespacePrefix,
 		BoxImage:                  cfg.BoxImage,
 		StorageClass:              cfg.StorageClass,

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -232,6 +232,11 @@ func (s *ContainerServer) boxes() box.BoxBackend {
 	return boxlxc.New(s.manager)
 }
 
+// Boxes exposes the box backend so daemon wiring (dual_server) can
+// type-assert runtime-specific capabilities — e.g. the K8s backend's
+// ClientKeyLister for the /authorized-keys handler.
+func (s *ContainerServer) Boxes() box.BoxBackend { return s.boxes() }
+
 // k8sBoxes returns the box backend when the daemon runs the k8s runtime.
 // Lifecycle handlers use it to route their action through the backend seam:
 // s.manager is the LXC/incus surface, which is wired to an unavailable stub

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1406,6 +1406,23 @@ skipAppHosting:
 			})
 		}
 
+		// On the K8s runtime, boxes have no /home on the node — serve
+		// /authorized-keys from box metadata instead (the client keys the
+		// K8s backend records per tenant), and advertise the in-cluster
+		// gateway's SSH ingress so the sentinel forwards there.
+		if lister, ok := containerServer.Boxes().(gateway.ClientKeyLister); ok {
+			if portResolver, ok := containerServer.Boxes().(interface {
+				GatewayIngressPort(context.Context) int
+			}); ok {
+				gatewayServer.SetAuthorizedKeysHandler(
+					gateway.ServeAuthorizedKeysFromLister(lister, func() int {
+						return portResolver.GatewayIngressPort(context.Background())
+					}),
+				)
+				log.Printf("[gateway] /authorized-keys served from the K8s box backend (advertising the in-cluster gateway ingress)")
+			}
+		}
+
 		// Wire security store for CSV export
 		if securityStore != nil {
 			gatewayServer.SetSecurityStore(securityStore)

--- a/pkg/core/box/k8s/clientkeys.go
+++ b/pkg/core/box/k8s/clientkeys.go
@@ -1,0 +1,97 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Client (agent) keys are recorded on the per-tenant Secret under this field,
+// SEPARATE from authorized_keys (which is what the box's dropbear reads and,
+// in gateway-upstream mode, holds the gateway key instead). The sentinel's
+// keysync consumes these via ListClientKeys → /authorized-keys so the
+// sentinel authenticates the AGENT at hop 1 — deriving them from the Pipe's
+// from.authorized_keys_data would be wrong once the sentinel's own key is
+// appended there.
+const clientKeysKey = "client_keys"
+
+// ClientKeyLister is the seam the daemon's /authorized-keys handler consumes
+// on the k8s runtime (the LXC runtime walks /home instead).
+type ClientKeyLister interface {
+	ListClientKeys(ctx context.Context) (map[string]string, error)
+}
+
+var _ ClientKeyLister = (*Backend)(nil)
+
+// ListClientKeys returns tenant → client authorized_keys content for every
+// box this backend manages, read from the client_keys field of each
+// per-tenant Secret. Boxes created before the field existed are skipped with
+// a log line (their keys re-appear on the next SetAuthorizedKeys).
+func (b *Backend) ListClientKeys(ctx context.Context) (map[string]string, error) {
+	boxes, err := b.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("k8s: list boxes for client keys: %w", err)
+	}
+	out := make(map[string]string, len(boxes))
+	for i := range boxes {
+		tenant := boxes[i].Ref.Tenant
+		sec, gerr := b.clientset.CoreV1().Secrets(b.namespaceFor(tenant)).Get(ctx, secretName(tenant), metav1.GetOptions{})
+		if gerr != nil {
+			log.Printf("[k8s] client keys for %s unavailable: %v (skipping)", tenant, gerr)
+			continue
+		}
+		keys := string(sec.Data[clientKeysKey])
+		if keys == "" {
+			log.Printf("[k8s] box %s has no recorded client_keys (created pre-advertisement?); skipping until next key rotation", tenant)
+			continue
+		}
+		out[tenant] = keys
+	}
+	return out, nil
+}
+
+// GatewayIngressPort resolves the SSH ingress port on this node that the
+// sentinel should forward box traffic to. Precedence: the explicit
+// Config.GatewayAdvertisePort override, else the gateway Service's NodePort.
+// Returns 0 (advertise nothing → sentinel legacy convention) with a warning
+// when neither is available — a sentinel-fronted K8s node without a
+// resolvable ingress cannot be routed to.
+func (b *Backend) GatewayIngressPort(ctx context.Context) int {
+	if b.cfg.GatewayAdvertisePort > 0 {
+		return b.cfg.GatewayAdvertisePort
+	}
+	svc, err := b.clientset.CoreV1().Services(b.cfg.GatewayNamespace).Get(ctx, b.cfg.GatewayService, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		log.Printf("[k8s] gateway service %s/%s not found; advertising no SSH ingress (set %s or deploy the gateway)",
+			b.cfg.GatewayNamespace, b.cfg.GatewayService, "CONTAINARIUM_K8S_GATEWAY_ADVERTISE_PORT")
+		return 0
+	}
+	if err != nil {
+		log.Printf("[k8s] gateway service lookup failed: %v; advertising no SSH ingress", err)
+		return 0
+	}
+	for _, p := range svc.Spec.Ports {
+		if p.NodePort > 0 && (p.Name == "ssh" || len(svc.Spec.Ports) == 1) {
+			return int(p.NodePort)
+		}
+	}
+	log.Printf("[k8s] gateway service %s/%s has no NodePort; advertising no SSH ingress (expose it or set the advertise-port override)",
+		b.cfg.GatewayNamespace, b.cfg.GatewayService)
+	return 0
+}
+
+// upsertTenantSecret writes the per-tenant Secret with both halves: the keys
+// the box itself authorizes (boxKeys — the gateway upstream key in gateway
+// mode, the client keys in direct mode) and the client_keys record the
+// sentinel sync reads.
+func (b *Backend) upsertTenantSecret(ctx context.Context, tenant string, boxKeys, clientKeys []string) error {
+	sec := secretObject(b.namespaceFor(tenant), tenant, boxKeys, clientKeys)
+	_, err := b.clientset.CoreV1().Secrets(b.namespaceFor(tenant)).Update(ctx, sec, metav1.UpdateOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = b.clientset.CoreV1().Secrets(b.namespaceFor(tenant)).Create(ctx, sec, metav1.CreateOptions{})
+	}
+	return err
+}

--- a/pkg/core/box/k8s/clientkeys_test.go
+++ b/pkg/core/box/k8s/clientkeys_test.go
@@ -1,0 +1,150 @@
+//go:build k8s
+
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	sandboxfake "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned/fake"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+)
+
+// gatewayUpstreamBackend builds a backend in gateway-upstream mode (box
+// authorizes the gateway key; agent key lives in client_keys / the Pipe).
+func gatewayUpstreamBackend() (*Backend, *fake.Clientset, *sandboxfake.Clientset) {
+	cs := fake.NewSimpleClientset()
+	sc := sandboxfake.NewSimpleClientset()
+	scheme := runtime.NewScheme()
+	dyn := dynfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{pipeGVR: "PipeList"})
+	b := NewWithClients(cs, sc, dyn, Config{
+		BoxImage:                 "registry.k8s.io/pause:3.9",
+		GatewayNamespace:         "agent-gateway",
+		GatewayService:           "sshpiper",
+		GatewayUpstreamPublicKey: "ssh-ed25519 GATEWAYPUB gateway",
+		GatewayUpstreamKeySecret: "sshpiper-upstream-key",
+	})
+	return b, cs, sc
+}
+
+func mustCreateNodePortService(t *testing.T, cs *fake.Clientset, ns, name string, nodePort int32) {
+	t.Helper()
+	_, err := cs.CoreV1().Services(ns).Create(context.Background(), &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeNodePort,
+			Ports: []corev1.ServicePort{{Name: "ssh", Port: 22, NodePort: nodePort}},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create nodeport service: %v", err)
+	}
+}
+
+// TestClientKeysRecordedSeparately verifies Create records the agent's keys
+// under client_keys (for the sentinel sync) distinct from authorized_keys
+// (what the box authorizes). In gateway-upstream mode the two MUST differ:
+// authorized_keys is the gateway key, client_keys is the agent key.
+func TestClientKeysRecordedSeparately(t *testing.T) {
+	b, cs, _ := testBackend()
+	ctx := context.Background()
+	if _, err := b.Create(ctx, box.BoxSpec{
+		Ref:     box.BoxRef{Tenant: "alice"},
+		Image:   "x",
+		SSHKeys: []string{"ssh-ed25519 AGENTKEY agent@laptop"},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sec, err := cs.CoreV1().Secrets("tenant-alice").Get(ctx, secretName("alice"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	// No gateway upstream configured in testBackend → box authorizes the
+	// agent key directly, and client_keys mirrors it.
+	if got := string(sec.Data[clientKeysKey]); got != "ssh-ed25519 AGENTKEY agent@laptop\n" {
+		t.Errorf("client_keys = %q, want the agent key", got)
+	}
+
+	keys, err := b.ListClientKeys(ctx)
+	if err != nil {
+		t.Fatalf("ListClientKeys: %v", err)
+	}
+	if keys["alice"] != "ssh-ed25519 AGENTKEY agent@laptop\n" {
+		t.Errorf("ListClientKeys[alice] = %q", keys["alice"])
+	}
+}
+
+// TestClientKeysGatewayModeSplit: with a gateway upstream key configured,
+// authorized_keys holds the GATEWAY key while client_keys holds the AGENT
+// key — the split the sentinel sync relies on.
+func TestClientKeysGatewayModeSplit(t *testing.T) {
+	b, cs, _ := gatewayUpstreamBackend()
+	ctx := context.Background()
+	if _, err := b.Create(ctx, box.BoxSpec{
+		Ref:     box.BoxRef{Tenant: "bob"},
+		Image:   "x",
+		SSHKeys: []string{"ssh-ed25519 AGENTKEY agent@laptop"},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	sec, _ := cs.CoreV1().Secrets("tenant-bob").Get(ctx, secretName("bob"), metav1.GetOptions{})
+	if got := string(sec.Data[authorizedKeysKey]); got != "ssh-ed25519 GATEWAYPUB gateway\n" {
+		t.Errorf("authorized_keys = %q, want the gateway key", got)
+	}
+	if got := string(sec.Data[clientKeysKey]); got != "ssh-ed25519 AGENTKEY agent@laptop\n" {
+		t.Errorf("client_keys = %q, want the agent key", got)
+	}
+}
+
+// TestSetAuthorizedKeysUpdatesClientKeys: a key rotation must update the
+// client_keys record so the sentinel sees the new agent key.
+func TestSetAuthorizedKeysUpdatesClientKeys(t *testing.T) {
+	b, cs, _ := testBackend()
+	ctx := context.Background()
+	ref := box.BoxRef{Tenant: "carol"}
+	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref, Image: "x", SSHKeys: []string{"old-key"}}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := b.SetAuthorizedKeys(ctx, ref, []string{"rotated-key"}); err != nil {
+		t.Fatalf("SetAuthorizedKeys: %v", err)
+	}
+	sec, _ := cs.CoreV1().Secrets("tenant-carol").Get(ctx, secretName("carol"), metav1.GetOptions{})
+	if got := string(sec.Data[clientKeysKey]); got != "rotated-key\n" {
+		t.Errorf("client_keys after rotation = %q, want rotated-key", got)
+	}
+}
+
+// TestGatewayIngressPortResolvesNodePort verifies the SSH-ingress resolver
+// reads the gateway Service's NodePort, and honors the explicit override.
+func TestGatewayIngressPortResolvesNodePort(t *testing.T) {
+	b, cs, _ := gatewayUpstreamBackend() // GatewayNamespace=agent-gateway, GatewayService=sshpiper
+	ctx := context.Background()
+	mustCreateNodePortService(t, cs, "agent-gateway", "sshpiper", 32022)
+
+	if got := b.GatewayIngressPort(ctx); got != 32022 {
+		t.Errorf("GatewayIngressPort = %d, want 32022", got)
+	}
+
+	// Explicit override wins over the Service lookup.
+	b.cfg.GatewayAdvertisePort = 40000
+	if got := b.GatewayIngressPort(ctx); got != 40000 {
+		t.Errorf("GatewayIngressPort with override = %d, want 40000", got)
+	}
+}
+
+// TestGatewayIngressPortMissingService: no Service, no override → 0 (advertise
+// nothing; sentinel falls back to its legacy convention).
+func TestGatewayIngressPortMissingService(t *testing.T) {
+	b, _, _ := gatewayUpstreamBackend()
+	if got := b.GatewayIngressPort(context.Background()); got != 0 {
+		t.Errorf("GatewayIngressPort with no service = %d, want 0", got)
+	}
+}

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -40,6 +40,15 @@ type Config struct {
 	GatewayHost    string
 	GatewaySSHPort int
 
+	// GatewayService is the in-cluster sshpiper Service name in
+	// GatewayNamespace, used to resolve the node's SSH ingress (NodePort)
+	// advertised to the sentinel. Defaults to "sshpiper".
+	GatewayService string
+
+	// GatewayAdvertisePort overrides the resolved ingress port advertised
+	// to the sentinel (0 = resolve from GatewayService).
+	GatewayAdvertisePort int
+
 	// TenantNamespacePrefix prefixes the per-tenant namespace
 	// (e.g. "tenant-" → "tenant-<tenant>"). Defaults to "tenant-".
 	TenantNamespacePrefix string
@@ -148,6 +157,9 @@ func newBackend(cs kubernetes.Interface, sc sandboxclient.Interface, dyn dynamic
 	if cfg.GatewaySSHPort == 0 {
 		cfg.GatewaySSHPort = 22
 	}
+	if cfg.GatewayService == "" {
+		cfg.GatewayService = "sshpiper"
+	}
 	// Resolve the default memory floor once: built-in defaults when unset, the
 	// built-in default when an operator value isn't a valid K8s quantity (a typo
 	// degrades to the safe floor rather than silently leaving boxes unconstrained),
@@ -227,7 +239,7 @@ func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus,
 			return nil, fmt.Errorf("k8s: ensure pvc: %w", err)
 		}
 	}
-	if _, err := b.clientset.CoreV1().Secrets(ns).Create(ctx, secretObject(ns, tenant, b.boxAuthorizedKeys(spec.SSHKeys)), metav1.CreateOptions{}); ignoreExists(err) != nil {
+	if _, err := b.clientset.CoreV1().Secrets(ns).Create(ctx, secretObject(ns, tenant, b.boxAuthorizedKeys(spec.SSHKeys), spec.SSHKeys), metav1.CreateOptions{}); ignoreExists(err) != nil {
 		return nil, fmt.Errorf("k8s: ensure secret: %w", err)
 	}
 	if _, err := b.clientset.NetworkingV1().NetworkPolicies(ns).Create(ctx, networkPolicyObject(ns, tenant), metav1.CreateOptions{}); ignoreExists(err) != nil {
@@ -397,16 +409,11 @@ func (b *Backend) Resolve(ctx context.Context, ref box.BoxRef) (*box.BoxEndpoint
 // in the Pipe's spec.from, so we only re-program the Pipe. In the direct path
 // the agent's keys authorize the box itself, so we update the box Secret too.
 func (b *Backend) SetAuthorizedKeys(ctx context.Context, ref box.BoxRef, keys []string) error {
-	ns := b.namespaceFor(ref.Tenant)
-	if !b.gatewayEnabled() || b.cfg.GatewayUpstreamPublicKey == "" {
-		sec := secretObject(ns, ref.Tenant, keys)
-		_, err := b.clientset.CoreV1().Secrets(ns).Update(ctx, sec, metav1.UpdateOptions{})
-		if apierrors.IsNotFound(err) {
-			_, err = b.clientset.CoreV1().Secrets(ns).Create(ctx, sec, metav1.CreateOptions{})
-		}
-		if err != nil {
-			return err
-		}
+	// The Secret is always rewritten: the box-authorized half follows the
+	// access mode (gateway key vs client keys) and the client_keys record
+	// must track rotations in both modes — the sentinel sync reads it.
+	if err := b.upsertTenantSecret(ctx, ref.Tenant, b.boxAuthorizedKeys(keys), keys); err != nil {
+		return err
 	}
 	// Re-program the gateway Pipe so the rotated client keys take effect at the
 	// front (no-op when the gateway isn't configured).

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -134,17 +134,25 @@ func namespaceObject(name, tenant string) *corev1.Namespace {
 	}
 }
 
-// secretObject holds the box's authorized_keys.
-func secretObject(ns, tenant string, keys []string) *corev1.Secret {
-	var buf []byte
-	for _, k := range keys {
-		buf = append(buf, []byte(k)...)
-		buf = append(buf, '\n')
+// secretObject holds the box's authorized_keys (what dropbear reads — the
+// gateway upstream key in gateway mode) plus the client_keys record (the
+// agent's own keys, served to the sentinel via /authorized-keys).
+func secretObject(ns, tenant string, boxKeys, clientKeys []string) *corev1.Secret {
+	join := func(keys []string) []byte {
+		var buf []byte
+		for _, k := range keys {
+			buf = append(buf, []byte(k)...)
+			buf = append(buf, '\n')
+		}
+		return buf
 	}
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: secretName(tenant), Namespace: ns, Labels: boxLabels(tenant)},
 		Type:       corev1.SecretTypeOpaque,
-		Data:       map[string][]byte{authorizedKeysKey: buf},
+		Data: map[string][]byte{
+			authorizedKeysKey: join(boxKeys),
+			clientKeysKey:     join(clientKeys),
+		},
 	}
 }
 


### PR DESCRIPTION
PR 2 of 4 for sentinel→K8s-node SSH chaining (PR 1 #981 merged).

On a K8s node nothing lives in `/home`, so the LXC home-dir `/authorized-keys`
handler returns nothing and the sentinel routes no boxes. This wires the
runtime-neutral path:

- The per-tenant Secret gains a `client_keys` field recording the **agent's**
  keys, separate from `authorized_keys` (which in gateway-upstream mode holds
  the gateway key). `ListClientKeys` enumerates it via the box List.
- `gateway.ClientKeyLister` + `ServeAuthorizedKeysFromLister`: the k8s daemon
  serves `/authorized-keys` from box metadata and advertises the in-cluster
  gateway's SSH ingress in `KeysResponse.ssh_port` (resolved from the gateway
  Service NodePort, or `CONTAINARIUM_K8S_GATEWAY_ADVERTISE_PORT`).
- `dual_server` installs the lister-backed handler only when the backend
  implements the seam (LXC keeps the walker); `SetAuthorizedKeysHandler` +
  exported `ContainerServer.Boxes()`.

Follow-ups: PR 3 (`/authorized-keys/sentinel` → sentinel key into node Pipes),
PR 4 (tunnel dial map + chain e2e + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)