### PR TITLE
feat(k8s): authorize the sentinel key at the in-cluster gateway

### DIFF
--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -88,6 +88,12 @@ type GatewayServer struct {
 	// handler here (boxes have no /home on the node). nil = default.
 	authorizedKeysHandler http.HandlerFunc
 
+	// sentinelKeyHandler overrides the default /authorized-keys/sentinel
+	// handler. The K8s runtime installs a Pipe-authorizing handler (the
+	// sentinel key belongs at the node gateway, not in box home dirs).
+	// nil = default.
+	sentinelKeyHandler http.HandlerFunc
+
 	// Wake handler (for serverless / wake-on-HTTP, set externally).
 	// Mounted at /wake/ and at the root catch-all when the daemon's
 	// wake feature is enabled. NOT wrapped by the JWT auth middleware
@@ -196,6 +202,13 @@ func (gs *GatewayServer) SetSentinelPublicKey(pub ed25519.PublicKey) {
 // (the LXC home-dir walker) — the K8s runtime installs a lister-backed one.
 func (gs *GatewayServer) SetAuthorizedKeysHandler(h http.HandlerFunc) {
 	gs.authorizedKeysHandler = h
+}
+
+// SetSentinelKeyHandler overrides the default /authorized-keys/sentinel
+// handler (the LXC home-dir writer) — the K8s runtime installs one that
+// authorizes the sentinel key at the in-cluster gateway.
+func (gs *GatewayServer) SetSentinelKeyHandler(h http.HandlerFunc) {
+	gs.sentinelKeyHandler = h
 }
 
 // SetContainerExistsFn wires the orphan filter for /authorized-keys.
@@ -758,7 +771,11 @@ func (gs *GatewayServer) Start(ctx context.Context) error {
 		authorizedKeysHandler = ServeAuthorizedKeys("", gs.containerExistsFn)
 	}
 	httpMux.Handle("/authorized-keys", sentinelVerifier.Middleware(authorizedKeysHandler))
-	httpMux.Handle("/authorized-keys/sentinel", sentinelVerifier.Middleware(ServeSentinelKey()))
+	sentinelKeyHandler := gs.sentinelKeyHandler
+	if sentinelKeyHandler == nil {
+		sentinelKeyHandler = ServeSentinelKey()
+	}
+	httpMux.Handle("/authorized-keys/sentinel", sentinelVerifier.Middleware(sentinelKeyHandler))
 
 	// Catch-all fallback: when wake-on-HTTP is enabled, Caddy
 	// forwards user traffic to this daemon while a container is

--- a/internal/gateway/keys_handler.go
+++ b/internal/gateway/keys_handler.go
@@ -45,6 +45,46 @@ type ClientKeyLister interface {
 	ListClientKeys(ctx context.Context) (map[string]string, error)
 }
 
+// SentinelKeyAuthorizer installs the sentinel's upstream pubkey at whatever
+// hop authenticates the sentinel on this runtime. The LXC runtime writes it
+// into every box's authorized_keys (ServeSentinelKey); the K8s runtime
+// authorizes it at the in-cluster gateway (the node's sshpiper Pipes).
+type SentinelKeyAuthorizer interface {
+	// SetSentinelKey persists pubKey and applies it. Returns how many boxes
+	// were (re)authorized and how many had a prior different sentinel key
+	// replaced.
+	SetSentinelKey(ctx context.Context, pubKey string) (updated, rotated int, err error)
+}
+
+// ServeSentinelKeyWithAuthorizer returns a /authorized-keys/sentinel handler
+// backed by a SentinelKeyAuthorizer (the K8s runtime path).
+func ServeSentinelKeyWithAuthorizer(a SentinelKeyAuthorizer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		var req SentinelKeyRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error":"invalid JSON body"}`, http.StatusBadRequest)
+			return
+		}
+		pubKey := strings.TrimSpace(req.PublicKey)
+		if pubKey == "" {
+			http.Error(w, `{"error":"public_key is required"}`, http.StatusBadRequest)
+			return
+		}
+		updated, rotated, err := a.SetSentinelKey(r.Context(), pubKey)
+		if err != nil {
+			log.Printf("[keys] sentinel-key authorize failed: %v", err)
+			http.Error(w, `{"error":"failed to apply sentinel key"}`, http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]int{"updated": updated, "rotated": rotated})
+	}
+}
+
 // ServeAuthorizedKeysFromLister returns a handler that answers
 // /authorized-keys from a ClientKeyLister and advertises sshPort as the
 // node's SSH ingress (KeysResponse.SSHPort) so the sentinel forwards to the

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1422,6 +1422,12 @@ skipAppHosting:
 				log.Printf("[gateway] /authorized-keys served from the K8s box backend (advertising the in-cluster gateway ingress)")
 			}
 		}
+		// On the K8s runtime the sentinel's upstream key belongs at the node
+		// gateway (the box Pipes), not in box home dirs.
+		if authorizer, ok := containerServer.Boxes().(gateway.SentinelKeyAuthorizer); ok {
+			gatewayServer.SetSentinelKeyHandler(gateway.ServeSentinelKeyWithAuthorizer(authorizer))
+			log.Printf("[gateway] /authorized-keys/sentinel authorizes the sentinel at the K8s in-cluster gateway")
+		}
 
 		// Wire security store for CSV export
 		if securityStore != nil {

--- a/pkg/core/box/k8s/clientkeys.go
+++ b/pkg/core/box/k8s/clientkeys.go
@@ -95,3 +95,13 @@ func (b *Backend) upsertTenantSecret(ctx context.Context, tenant string, boxKeys
 	}
 	return err
 }
+
+// clientKeysOf reads a tenant's recorded client keys (empty when absent).
+// Used by SetSentinelKey to rebuild each Pipe's from-keys.
+func (b *Backend) clientKeysOf(ctx context.Context, tenant string) string {
+	sec, err := b.clientset.CoreV1().Secrets(b.namespaceFor(tenant)).Get(ctx, secretName(tenant), metav1.GetOptions{})
+	if err != nil {
+		return ""
+	}
+	return string(sec.Data[clientKeysKey])
+}

--- a/pkg/core/box/k8s/gateway.go
+++ b/pkg/core/box/k8s/gateway.go
@@ -80,9 +80,13 @@ func (b *Backend) upstreamHost(tenant string) string {
 // tenant's box pod: the incoming connection authenticates against the box's
 // authorized keys (inline, base64), and the upstream host key is trusted
 // (ignore_hostkey — TOFU/known_hosts pinning is a follow-up).
-func (b *Backend) pipeObject(tenant string, keys []string, hostPubKeys []string) *unstructured.Unstructured {
+//
+// fromKeys is the union of the agent's client keys (direct node-gateway
+// access) and any authorized sentinel keys (hop 2 of the sentinel chain) —
+// both authenticate the incoming connection at the node gateway.
+func (b *Backend) pipeObject(tenant string, fromKeys []string, hostPubKeys []string) *unstructured.Unstructured {
 	var buf []byte
-	for _, k := range keys {
+	for _, k := range fromKeys {
 		buf = append(buf, []byte(k)...)
 		buf = append(buf, '\n')
 	}
@@ -123,7 +127,9 @@ func (b *Backend) pipeObject(tenant string, keys []string, hostPubKeys []string)
 }
 
 // upsertPipe creates or updates the tenant's Pipe in the gateway namespace.
-// No-op when the gateway isn't configured.
+// No-op when the gateway isn't configured. The Pipe's from-keys are the
+// agent's client keys plus any authorized sentinel keys (so a sentinel in
+// front of this node can complete hop 2).
 func (b *Backend) upsertPipe(ctx context.Context, tenant string, keys []string) error {
 	if !b.gatewayEnabled() {
 		return nil
@@ -133,7 +139,8 @@ func (b *Backend) upsertPipe(ctx context.Context, tenant string, keys []string) 
 	if err != nil {
 		return fmt.Errorf("ensure host key: %w", err)
 	}
-	obj := b.pipeObject(tenant, keys, hostPubs)
+	fromKeys := append(append([]string{}, keys...), b.sentinelKeys(ctx)...)
+	obj := b.pipeObject(tenant, fromKeys, hostPubs)
 	_, err = b.dyn.Resource(pipeGVR).Namespace(ns).Create(ctx, obj, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		existing, gerr := b.dyn.Resource(pipeGVR).Namespace(ns).Get(ctx, pipeName(tenant), metav1.GetOptions{})

--- a/pkg/core/box/k8s/sentinelkey.go
+++ b/pkg/core/box/k8s/sentinelkey.go
@@ -1,0 +1,113 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/footprintai/containarium/internal/gateway"
+)
+
+// The sentinel's upstream pubkey(s) are stored in this Secret in the gateway
+// namespace (restart-safe) and appended to every box Pipe's from-keys so a
+// sentinel fronting this node can complete hop 2 of the SSH chain
+// (agent → sentinel → node gateway → box). Distinct from the box's own
+// authorized_keys and the daemon's gateway-upstream key.
+const (
+	sentinelKeySecretName = "containarium-sentinel-keys"
+	sentinelKeysField     = "authorized_keys"
+)
+
+var _ gateway.SentinelKeyAuthorizer = (*Backend)(nil)
+
+// SetSentinelKey persists the sentinel's upstream pubkey and authorizes it at
+// the node gateway: it's stored in a Secret in the gateway namespace and
+// re-applied to every box's Pipe from-keys. Idempotent — re-posting the same
+// key rewrites the Pipes but reports rotated=0.
+//
+// Requires gateway-upstream mode: a sentinel three-hop chain needs the node
+// gateway to authenticate to boxes with its own key, so a sentinel in front
+// of a direct-mode node is unsupported and errors clearly.
+func (b *Backend) SetSentinelKey(ctx context.Context, pubKey string) (updated, rotated int, err error) {
+	pubKey = strings.TrimSpace(pubKey)
+	if pubKey == "" {
+		return 0, 0, fmt.Errorf("k8s: empty sentinel key")
+	}
+	if !b.gatewayEnabled() || b.cfg.GatewayUpstreamKeySecret == "" {
+		return 0, 0, fmt.Errorf("k8s: sentinel fronting requires gateway-upstream mode " +
+			"(set CONTAINARIUM_K8S_GATEWAY_NAMESPACE + _UPSTREAM_KEY_SECRET); refusing to authorize a sentinel key in direct mode")
+	}
+
+	prev := b.sentinelKeys(ctx)
+	if len(prev) == 1 && prev[0] == pubKey {
+		rotated = 0
+	} else if len(prev) > 0 {
+		rotated = 1 // a different prior sentinel key is being replaced
+	}
+
+	// Store exactly one current sentinel key (rotation replaces, not appends —
+	// mirrors the LXC marker-block semantics).
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sentinelKeySecretName,
+			Namespace: b.cfg.GatewayNamespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{sentinelKeysField: []byte(pubKey + "\n")},
+	}
+	if _, uerr := b.clientset.CoreV1().Secrets(b.cfg.GatewayNamespace).Update(ctx, sec, metav1.UpdateOptions{}); apierrors.IsNotFound(uerr) {
+		_, uerr = b.clientset.CoreV1().Secrets(b.cfg.GatewayNamespace).Create(ctx, sec, metav1.CreateOptions{})
+		if uerr != nil {
+			return 0, 0, fmt.Errorf("k8s: store sentinel key: %w", uerr)
+		}
+	} else if uerr != nil {
+		return 0, 0, fmt.Errorf("k8s: store sentinel key: %w", uerr)
+	}
+
+	// Re-program every box's Pipe so the sentinel key takes effect at hop 2.
+	boxes, lerr := b.List(ctx)
+	if lerr != nil {
+		return 0, rotated, fmt.Errorf("k8s: list boxes for sentinel re-key: %w", lerr)
+	}
+	for i := range boxes {
+		tenant := boxes[i].Ref.Tenant
+		clientKeys := splitKeys(b.clientKeysOf(ctx, tenant))
+		if perr := b.upsertPipe(ctx, tenant, clientKeys); perr != nil {
+			log.Printf("[k8s] sentinel re-key: box %s Pipe update failed: %v", tenant, perr)
+			continue
+		}
+		updated++
+	}
+	return updated, rotated, nil
+}
+
+// sentinelKeys reads the currently-authorized sentinel pubkey(s) from the
+// gateway-namespace Secret (empty when none / gateway off).
+func (b *Backend) sentinelKeys(ctx context.Context) []string {
+	if b.cfg.GatewayNamespace == "" {
+		return nil
+	}
+	sec, err := b.clientset.CoreV1().Secrets(b.cfg.GatewayNamespace).Get(ctx, sentinelKeySecretName, metav1.GetOptions{})
+	if err != nil {
+		return nil
+	}
+	return splitKeys(string(sec.Data[sentinelKeysField]))
+}
+
+// splitKeys turns an authorized_keys blob into non-empty, non-comment lines.
+func splitKeys(blob string) []string {
+	var out []string
+	for _, line := range strings.Split(blob, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}

--- a/pkg/core/box/k8s/sentinelkey_test.go
+++ b/pkg/core/box/k8s/sentinelkey_test.go
@@ -1,0 +1,110 @@
+//go:build k8s
+
+package k8s
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+)
+
+// TestSetSentinelKeyAppendsToPipes: authorizing the sentinel key adds it to
+// every box's Pipe from-keys alongside the agent's key, and persists it in
+// the gateway-namespace Secret so it survives a daemon restart.
+func TestSetSentinelKeyAppendsToPipes(t *testing.T) {
+	b, cs, _ := gatewayUpstreamBackend()
+	ctx := context.Background()
+	if _, err := b.Create(ctx, box.BoxSpec{
+		Ref:     box.BoxRef{Tenant: "alice"},
+		Image:   "x",
+		SSHKeys: []string{"ssh-ed25519 AGENTKEY agent@laptop"},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	updated, rotated, err := b.SetSentinelKey(ctx, "ssh-ed25519 SENTINELKEY sentinel@fleet")
+	if err != nil {
+		t.Fatalf("SetSentinelKey: %v", err)
+	}
+	if updated != 1 || rotated != 0 {
+		t.Errorf("SetSentinelKey = (updated %d, rotated %d), want (1, 0)", updated, rotated)
+	}
+
+	// Persisted in the gateway namespace.
+	sec, err := cs.CoreV1().Secrets("agent-gateway").Get(ctx, sentinelKeySecretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("sentinel key secret not stored: %v", err)
+	}
+	if !strings.Contains(string(sec.Data[sentinelKeysField]), "SENTINELKEY") {
+		t.Errorf("stored sentinel key = %q", sec.Data[sentinelKeysField])
+	}
+
+	// The Pipe's from-keys now contain BOTH the agent and the sentinel key.
+	from := pipeFromKeys(t, b, "alice")
+	if !strings.Contains(from, "AGENTKEY") {
+		t.Errorf("pipe from-keys lost the agent key: %q", from)
+	}
+	if !strings.Contains(from, "SENTINELKEY") {
+		t.Errorf("pipe from-keys missing the sentinel key: %q", from)
+	}
+}
+
+// TestSetSentinelKeyRotation: posting a different key reports rotated=1 and
+// replaces the old one (not append).
+func TestSetSentinelKeyRotation(t *testing.T) {
+	b, _, _ := gatewayUpstreamBackend()
+	ctx := context.Background()
+	if _, err := b.Create(ctx, box.BoxSpec{Ref: box.BoxRef{Tenant: "bob"}, Image: "x", SSHKeys: []string{"agent"}}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, _, err := b.SetSentinelKey(ctx, "ssh-ed25519 OLD old@fleet"); err != nil {
+		t.Fatalf("first SetSentinelKey: %v", err)
+	}
+	_, rotated, err := b.SetSentinelKey(ctx, "ssh-ed25519 NEW new@fleet")
+	if err != nil {
+		t.Fatalf("rotate SetSentinelKey: %v", err)
+	}
+	if rotated != 1 {
+		t.Errorf("rotated = %d, want 1", rotated)
+	}
+	from := pipeFromKeys(t, b, "bob")
+	if strings.Contains(from, "OLD") {
+		t.Errorf("old sentinel key not replaced: %q", from)
+	}
+	if !strings.Contains(from, "NEW") {
+		t.Errorf("new sentinel key missing: %q", from)
+	}
+}
+
+// TestSetSentinelKeyRequiresGatewayMode: direct mode (no gateway upstream)
+// must reject a sentinel key with a clear error.
+func TestSetSentinelKeyRequiresGatewayMode(t *testing.T) {
+	b, _, _ := testBackend() // no gateway upstream, no dynamic client
+	if _, _, err := b.SetSentinelKey(context.Background(), "ssh-ed25519 K sentinel"); err == nil {
+		t.Fatal("SetSentinelKey in direct mode should error")
+	} else if !strings.Contains(err.Error(), "gateway-upstream mode") {
+		t.Errorf("error = %v, want a gateway-upstream-mode message", err)
+	}
+}
+
+// pipeFromKeys decodes the base64 from.authorized_keys_data of a tenant's Pipe.
+func pipeFromKeys(t *testing.T, b *Backend, tenant string) string {
+	t.Helper()
+	p, err := b.dyn.Resource(pipeGVR).Namespace(b.cfg.GatewayNamespace).Get(context.Background(), pipeName(tenant), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pipe %s: %v", pipeName(tenant), err)
+	}
+	from, _, _ := unstructured.NestedSlice(p.Object, "spec", "from")
+	if len(from) == 0 {
+		t.Fatalf("pipe %s has no from", tenant)
+	}
+	f0 := from[0].(map[string]any)
+	raw, _ := base64.StdEncoding.DecodeString(f0["authorized_keys_data"].(string))
+	return string(raw)
+}


### PR DESCRIPTION
PR 3 of 4 for sentinel→K8s-node SSH chaining (stacked on #982).

When the sentinel pushes its upstream pubkey to `/authorized-keys/sentinel`,
the LXC path writes it into every box's home `authorized_keys` — meaningless
on a K8s node. The K8s mirror authorizes it at **hop 2** (the node's
in-cluster sshpiper) instead:

- `gateway.SentinelKeyAuthorizer` + `ServeSentinelKeyWithAuthorizer`;
  `dual_server` installs it when the backend implements the seam.
- `Backend.SetSentinelKey` persists the key in a gateway-namespace Secret
  (`containarium-sentinel-keys`, restart-safe) and re-programs every box's
  Pipe; `upsertPipe` appends the stored sentinel key(s) to the Pipe's
  from-keys alongside the agent's client keys, so both direct node-gateway
  access and the sentinel hop authenticate. New boxes pick it up
  automatically.
- Gateway-upstream mode required: errors clearly in direct mode.

Follow-up: PR 4 (tunnel dial map to reach the gateway Service + chain e2e +
docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)