### PR TITLE
feat(tunnel): dial-map for K8s gateways + sentinel-chain e2e + docs

### DIFF
--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -618,6 +618,48 @@ The GPU *type* (L4, A100, etc.) is expressed via node affinity, driven by a
 node. This is deliberately different from the LXC/GCE path, where the daemon
 selects the exact machine type; on K8s, the scheduler owns that decision.
 
+## Fronting a K8s node with the fleet sentinel
+
+Everything above describes a K8s node reached at its *own* in-cluster gateway
+(`ssh <box>@<node-gateway>`). In a multi-node fleet, the Containarium
+**sentinel** is the single public SSH entrypoint and chains to each node's
+gateway — so `ssh <box>@<sentinel>` reaches a box on any node, K8s or LXC,
+with the client holding only its agent key:
+
+```
+agent ──agent key──▶ sentinel sshpiper :22
+                         │  (keysync: username → node:<ssh_port>)
+                         ▼
+        node in-cluster sshpiper (NodePort/LB)
+                         │  (Pipe: username → box pod, node upstream key)
+                         ▼
+                   box pod :2222 (dropbear ForceCommand → agent-box MCP)
+```
+
+Three hops; each key authenticates exactly one:
+
+- **agent → sentinel**: the agent's key, in the sentinel's per-user
+  `authorized_keys` (synced from the node's `/authorized-keys`).
+- **sentinel → node gateway**: the sentinel's upstream key, authorized at the
+  node gateway (appended to every box's Pipe `from` by the daemon when the
+  sentinel POSTs `/authorized-keys/sentinel`). Requires gateway-upstream mode.
+- **node gateway → box**: the node's own upstream key (the box authorizes it).
+
+How the node participates:
+
+- Start the daemon with `--ssh-host <sentinel>` so boxes surface the sentinel
+  as their `ssh_host` (stamped runtime-neutrally, same as LXC).
+- The node advertises its gateway ingress port to the sentinel automatically
+  (`/authorized-keys` `ssh_port`, resolved from the gateway Service NodePort
+  or `CONTAINARIUM_K8S_GATEWAY_ADVERTISE_PORT`).
+- Attach to the sentinel like any backend: direct (routable node IP) or via
+  the yamux tunnel. A tunnel-attached node forwards its gateway port to the
+  Service's reachable address — `containarium tunnel --forward
+  <port>=<addr>`; see [TUNNEL-REVERSE-PROXY.md](TUNNEL-REVERSE-PROXY.md).
+
+End-to-end verification: `scripts/k8s-sentinel-e2e.sh` (kind node gateway + a
+stand-in sentinel sshpiperd + a two-hop MCP handshake).
+
 ## Sandbox-CRD semantics worth knowing
 
 - **Stop/Start = suspend/resume.** Stop patches `spec.operatingMode:

--- a/docs/MULTI-BACKEND-PEERS.md
+++ b/docs/MULTI-BACKEND-PEERS.md
@@ -115,12 +115,50 @@ Client                  Sentinel (sshpiper)           Backend Host
   │                          ├─ Route to backend:          │
   │                          │   Same VPC: host:22         │
   │                          │   Tunnel:   127.0.0.x:20022 │
+  │                          │   K8s node: host:<ssh_port> │
   │                          ├─ Auth with upstream key ───►│
   │                          │                            ├─ sshd accepts key
   │                          │                            ├─ containarium-shell
   │                          │                            ├─ incus exec {user}-container
   │◄─── interactive shell ───┤◄───────────────────────────┤
 ```
+
+### K8s-runtime backends: a second gateway hop
+
+An LXC backend runs its own sshd on the routed port (22, or 20022 through a
+tunnel). A **K8s-runtime node** has no per-box sshd on the host — boxes are
+pods, reached through an *in-cluster* sshpiper. So the sentinel forwards to
+that node's gateway ingress rather than to :22, and the chain grows a hop:
+
+```
+agent ──agent key──▶ sentinel sshpiper ──sentinel upstream key──▶
+    node in-cluster sshpiper (NodePort/LB) ──node upstream key──▶ box pod → agent-box MCP
+```
+
+Each key is scoped to one hop (a leak reaches one hop, not the cluster). The
+mechanism reuses the existing sentinel plumbing:
+
+- The node's daemon advertises its gateway SSH ingress in the
+  `/authorized-keys` response (`ssh_port`); keysync routes `username →
+  <backend>:<ssh_port>` instead of assuming :22. Absent/0 keeps the legacy
+  22/20022 convention, so LXC backends and old daemons are unchanged.
+- The node serves `/authorized-keys` from box metadata (the agent keys the
+  K8s backend records per tenant) — there is no `/home` on a K8s node.
+- When the sentinel pushes its upstream key, the node authorizes it at its
+  in-cluster gateway (appended to every box's sshpiper Pipe), not in box home
+  dirs. Requires gateway-upstream mode.
+
+For a **tunnel-attached** K8s node, the tunnel must forward the advertised
+gateway port to the in-cluster sshpiper Service's *reachable* address — a
+LoadBalancer ingress, or `<nodeIP>:<NodePort>` (NodePorts aren't reliably
+reachable on 127.0.0.1). Use `containarium tunnel --forward
+<port>=<addr>`; the daemon logs the resolved target
+(`ResolveGatewayDialTarget`: LB ingress first, else node InternalIP +
+NodePort). See [TUNNEL-REVERSE-PROXY.md](TUNNEL-REVERSE-PROXY.md).
+
+> **Username collisions** are resolved first-backend-wins (by backend-ID
+> sort) — the same exposure the LXC multi-backend fleet has today. Box names
+> are globally unique in practice, so this is a note, not a guard.
 
 ### containarium-shell
 

--- a/docs/TUNNEL-REVERSE-PROXY.md
+++ b/docs/TUNNEL-REVERSE-PROXY.md
@@ -85,6 +85,27 @@ When the sentinel needs to forward a connection to the spot (e.g., an SSH sessio
 
 The spot reads the port number, connects to `127.0.0.1:<port>` locally, and proxies the data.
 
+#### Overriding the local dial target (`--forward`)
+
+`127.0.0.1:<port>` is right when the advertised service listens on the spot's
+own loopback (an LXC node's sshd, a local Caddy). A **K8s node** is different:
+its box gateway is an in-cluster sshpiper reached through a Kubernetes
+Service, and NodePorts are *not* reliably reachable on `127.0.0.1` (kube-proxy
+`iptablesLocalhostNodePorts` is off by default). So the tunnel client accepts
+a per-port dial override:
+
+```bash
+containarium tunnel --ports 32022 --forward 32022=<gateway-addr>
+```
+
+`<gateway-addr>` is the Service's reachable address — a LoadBalancer ingress
+(`<lb>:22`) or `<nodeIP>:<NodePort>`. The daemon resolves and logs the
+recommended value (`k8s.Backend.ResolveGatewayDialTarget`: LB ingress first,
+else a node InternalIP + the NodePort). The port advertised to the sentinel
+(via `/authorized-keys` `ssh_port`) and the tunnel listener stay on the same
+number; only the *local* dial target changes. See
+[MULTI-BACKEND-PEERS.md](MULTI-BACKEND-PEERS.md#k8s-runtime-backends-a-second-gateway-hop).
+
 ### 4. Loopback Aliases
 
 Each connected tunnel spot gets a loopback alias on the sentinel (e.g., `127.0.0.2`). The tunnel server opens TCP proxy listeners on `127.0.0.2:<port>` for each advertised port. This makes the tunneled spot look like a directly reachable IP to the existing sentinel code:

--- a/internal/cmd/tunnel.go
+++ b/internal/cmd/tunnel.go
@@ -6,8 +6,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/footprintai/containarium/internal/sentinel"
@@ -24,6 +27,7 @@ var (
 	tunnelPublicAliases     []string
 	tunnelPublicBaseDomains []string
 	tunnelPublicPort        int
+	tunnelForward           []string
 )
 
 var tunnelCmd = &cobra.Command{
@@ -57,6 +61,7 @@ func init() {
 	tunnelCmd.Flags().StringSliceVar(&tunnelPublicAliases, "public-aliases", nil, "Additional hostnames the primary's Caddy serves (e.g. api.example.com,voice.example.com)")
 	tunnelCmd.Flags().StringSliceVar(&tunnelPublicBaseDomains, "public-base-domain", nil, "Suffix-match anchor advertised to the sentinel — inbound SNI of the form <anything>.<public-base-domain> routes through this tunnel without each subdomain being a registered alias. Repeatable: list multiple to host workloads under different parent domains on the same backend. See docs/PER-POOL-BASE-DOMAIN.md.")
 	tunnelCmd.Flags().IntVar(&tunnelPublicPort, "public-port", 0, "Public TLS port the sentinel forwards to via this tunnel (typically 443; required with --public-hostname)")
+	tunnelCmd.Flags().StringSliceVar(&tunnelForward, "forward", nil, "Override the local dial target for an advertised port: PORT=HOST:PORT (repeatable). Use on a K8s node to point its gateway port at the in-cluster sshpiper Service's reachable address, e.g. --forward 32022=10.0.0.5:32022, since NodePorts aren't reliably reachable on 127.0.0.1.")
 }
 
 func runTunnel(cmd *cobra.Command, args []string) error {
@@ -78,6 +83,11 @@ func runTunnel(cmd *cobra.Command, args []string) error {
 	ports, err := parseForwardedPorts(tunnelPorts)
 	if err != nil {
 		return fmt.Errorf("invalid ports: %w", err)
+	}
+
+	forward, err := parseForwardMap(tunnelForward)
+	if err != nil {
+		return fmt.Errorf("invalid --forward: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -102,8 +112,39 @@ func runTunnel(cmd *cobra.Command, args []string) error {
 		PublicAliases:     tunnelPublicAliases,
 		PublicBaseDomains: tunnelPublicBaseDomains,
 		PublicPort:        tunnelPublicPort,
+		Forward:           forward,
 	}
 
 	log.Printf("[tunnel] connecting to sentinel at %s as %q (ports: %v, pool: %q, primary_host: %q)", tunnelSentinelAddr, tunnelSpotID, ports, tunnelPool, tunnelPublicHostname)
 	return client.Run(ctx)
+}
+
+// parseForwardMap parses repeated "PORT=HOST:PORT" entries into a
+// map[advertisedPort]dialTarget for TunnelClient.Forward. Empty input
+// yields a nil map (default 127.0.0.1:port dialing).
+func parseForwardMap(entries []string) (map[int]string, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	m := make(map[int]string, len(entries))
+	for _, e := range entries {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		key, target, ok := strings.Cut(e, "=")
+		if !ok {
+			return nil, fmt.Errorf("entry %q is not PORT=HOST:PORT", e)
+		}
+		port, err := strconv.Atoi(strings.TrimSpace(key))
+		if err != nil || port < 1 || port > 65535 {
+			return nil, fmt.Errorf("entry %q: invalid port %q", e, key)
+		}
+		target = strings.TrimSpace(target)
+		if _, _, err := net.SplitHostPort(target); err != nil {
+			return nil, fmt.Errorf("entry %q: invalid target %q (want HOST:PORT)", e, target)
+		}
+		m[port] = target
+	}
+	return m, nil
 }

--- a/internal/cmd/tunnel_forward_test.go
+++ b/internal/cmd/tunnel_forward_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import "testing"
+
+func TestParseForwardMap(t *testing.T) {
+	t.Run("empty is nil", func(t *testing.T) {
+		m, err := parseForwardMap(nil)
+		if err != nil || m != nil {
+			t.Fatalf("parseForwardMap(nil) = (%v, %v), want (nil, nil)", m, err)
+		}
+	})
+	t.Run("valid entries", func(t *testing.T) {
+		m, err := parseForwardMap([]string{"32022=10.0.0.5:32022", "443=lb.example.com:443"})
+		if err != nil {
+			t.Fatalf("parseForwardMap: %v", err)
+		}
+		if m[32022] != "10.0.0.5:32022" || m[443] != "lb.example.com:443" {
+			t.Errorf("map = %v", m)
+		}
+	})
+	for _, bad := range []string{"noequals", "0=host:1", "70000=host:1", "32022=nohostport"} {
+		t.Run("rejects "+bad, func(t *testing.T) {
+			if _, err := parseForwardMap([]string{bad}); err == nil {
+				t.Errorf("parseForwardMap(%q) should error", bad)
+			}
+		})
+	}
+}

--- a/internal/sentinel/tunnel_client.go
+++ b/internal/sentinel/tunnel_client.go
@@ -27,6 +27,14 @@ type TunnelClient struct {
 	PublicAliases     []string
 	PublicBaseDomains []string // suffix-match anchors; see docs/PER-POOL-BASE-DOMAIN.md
 	PublicPort        int
+
+	// Forward maps an advertised port to a custom local dial target
+	// (host:port). Without an entry, a stream for port N dials
+	// 127.0.0.1:N. A K8s node uses this to point its advertised gateway
+	// port at the in-cluster sshpiper Service's reachable address (a
+	// LoadBalancer ingress or <nodeIP>:<NodePort>), since NodePorts are
+	// not reliably reachable on 127.0.0.1.
+	Forward map[int]string
 }
 
 // Run connects to the sentinel and serves tunnel traffic.
@@ -156,8 +164,13 @@ func (tc *TunnelClient) handleStream(stream net.Conn) {
 	}
 	port := int(portBuf[0])<<8 | int(portBuf[1])
 
-	// Connect to the local service on that port
+	// Connect to the local service on that port. A Forward entry overrides
+	// the default 127.0.0.1:port target — used to reach an in-cluster
+	// gateway Service that isn't localhost-reachable.
 	localAddr := fmt.Sprintf("127.0.0.1:%d", port)
+	if target, ok := tc.Forward[port]; ok && target != "" {
+		localAddr = target
+	}
 	localConn, err := net.DialTimeout("tcp", localAddr, 5*time.Second)
 	if err != nil {
 		log.Printf("[tunnel-client] failed to connect to local %s: %v", localAddr, err)

--- a/internal/sentinel/tunnel_client_forward_test.go
+++ b/internal/sentinel/tunnel_client_forward_test.go
@@ -1,0 +1,61 @@
+package sentinel
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestHandleStreamHonorsForward verifies a Forward entry overrides the
+// default 127.0.0.1:port dial: a stream for the mapped port reaches the
+// custom target (a local listener on a different port), proving the K8s
+// gateway-dial override works.
+func TestHandleStreamHonorsForward(t *testing.T) {
+	// Target listener stands in for the in-cluster gateway address.
+	target, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen target: %v", err)
+	}
+	defer func() { _ = target.Close() }()
+
+	got := make(chan string, 1)
+	go func() {
+		c, err := target.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		buf := make([]byte, 5)
+		_, _ = io.ReadFull(c, buf)
+		got <- string(buf)
+	}()
+
+	// Advertised port 32022 forwards to the target listener's real address.
+	tc := &TunnelClient{Forward: map[int]string{32022: target.Addr().String()}}
+
+	// A pipe stands in for the yamux stream: write the 2-byte port header +
+	// payload, then handleStream should relay it to the target.
+	clientEnd, streamEnd := net.Pipe()
+	go tc.handleStream(streamEnd)
+
+	hdr := make([]byte, 2)
+	binary.BigEndian.PutUint16(hdr, 32022)
+	if _, err := clientEnd.Write(hdr); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if _, err := clientEnd.Write([]byte("hello")); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	select {
+	case s := <-got:
+		if s != "hello" {
+			t.Errorf("target received %q, want hello", s)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("payload never reached the forwarded target")
+	}
+	_ = clientEnd.Close()
+}

--- a/pkg/core/box/k8s/clientkeys.go
+++ b/pkg/core/box/k8s/clientkeys.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -81,6 +82,52 @@ func (b *Backend) GatewayIngressPort(ctx context.Context) int {
 	log.Printf("[k8s] gateway service %s/%s has no NodePort; advertising no SSH ingress (expose it or set the advertise-port override)",
 		b.cfg.GatewayNamespace, b.cfg.GatewayService)
 	return 0
+}
+
+// ResolveGatewayDialTarget returns the host:port a tunnel-attached node
+// should forward its advertised gateway port to (TunnelClient.Forward) — the
+// in-cluster sshpiper Service's reachable address. NodePorts aren't reliably
+// reachable on 127.0.0.1, so the tunnel needs an explicit target. Precedence:
+// a LoadBalancer ingress address, else <node InternalIP>:<NodePort>. Empty
+// when neither resolves (advertise nothing). Best-effort, logs on miss.
+func (b *Backend) ResolveGatewayDialTarget(ctx context.Context) string {
+	svc, err := b.clientset.CoreV1().Services(b.cfg.GatewayNamespace).Get(ctx, b.cfg.GatewayService, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("[k8s] gateway dial target: service %s/%s lookup failed: %v", b.cfg.GatewayNamespace, b.cfg.GatewayService, err)
+		return ""
+	}
+	// LoadBalancer ingress wins: routable from anywhere, dial the Service port.
+	for _, ing := range svc.Status.LoadBalancer.Ingress {
+		addr := ing.IP
+		if addr == "" {
+			addr = ing.Hostname
+		}
+		if addr != "" {
+			for _, p := range svc.Spec.Ports {
+				if p.Name == "ssh" || len(svc.Spec.Ports) == 1 {
+					return fmt.Sprintf("%s:%d", addr, p.Port)
+				}
+			}
+		}
+	}
+	// Else a node InternalIP + the NodePort.
+	nodePort := b.GatewayIngressPort(ctx)
+	if nodePort == 0 {
+		return ""
+	}
+	nodes, err := b.clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil || len(nodes.Items) == 0 {
+		log.Printf("[k8s] gateway dial target: no nodes to resolve an InternalIP: %v", err)
+		return ""
+	}
+	for _, n := range nodes.Items {
+		for _, a := range n.Status.Addresses {
+			if a.Type == corev1.NodeInternalIP && a.Address != "" {
+				return fmt.Sprintf("%s:%d", a.Address, nodePort)
+			}
+		}
+	}
+	return ""
 }
 
 // upsertTenantSecret writes the per-tenant Secret with both halves: the keys

--- a/pkg/core/box/k8s/clientkeys_test.go
+++ b/pkg/core/box/k8s/clientkeys_test.go
@@ -148,3 +148,55 @@ func TestGatewayIngressPortMissingService(t *testing.T) {
 		t.Errorf("GatewayIngressPort with no service = %d, want 0", got)
 	}
 }
+
+// TestResolveGatewayDialTargetNodePort: with a NodePort Service and a node
+// InternalIP, the tunnel dial target is <nodeIP>:<NodePort> — never
+// 127.0.0.1 (the whole point: NodePorts aren't localhost-reachable).
+func TestResolveGatewayDialTargetNodePort(t *testing.T) {
+	b, cs, _ := gatewayUpstreamBackend()
+	ctx := context.Background()
+	mustCreateNodePortService(t, cs, "agent-gateway", "sshpiper", 32022)
+	mustCreateNode(t, cs, "node-1", "10.0.0.7")
+
+	if got := b.ResolveGatewayDialTarget(ctx); got != "10.0.0.7:32022" {
+		t.Errorf("ResolveGatewayDialTarget = %q, want 10.0.0.7:32022", got)
+	}
+}
+
+// TestResolveGatewayDialTargetLoadBalancer: a LoadBalancer ingress wins over
+// the NodePort path — dial the LB address on the Service port.
+func TestResolveGatewayDialTargetLoadBalancer(t *testing.T) {
+	b, cs, _ := gatewayUpstreamBackend()
+	ctx := context.Background()
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "sshpiper", Namespace: "agent-gateway"},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Name: "ssh", Port: 22, NodePort: 32022}},
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{IP: "203.0.113.9"}},
+			},
+		},
+	}
+	if _, err := cs.CoreV1().Services("agent-gateway").Create(ctx, svc, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create lb service: %v", err)
+	}
+	if got := b.ResolveGatewayDialTarget(ctx); got != "203.0.113.9:22" {
+		t.Errorf("ResolveGatewayDialTarget = %q, want 203.0.113.9:22", got)
+	}
+}
+
+func mustCreateNode(t *testing.T, cs *fake.Clientset, name, internalIP string) {
+	t.Helper()
+	_, err := cs.CoreV1().Nodes().Create(context.Background(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: internalIP}},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+}

--- a/scripts/k8s-sentinel-e2e.sh
+++ b/scripts/k8s-sentinel-e2e.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+#
+# k8s-sentinel-e2e.sh — prove the sentinel→K8s-node SSH chain end to end:
+#
+#   agent ──agent key──▶ sentinel sshpiper ──sentinel upstream key──▶
+#     node in-cluster sshpiper (NodePort) ──node upstream key──▶ box pod → MCP
+#
+# A kind cluster stands in for the K8s node (its in-cluster sshpiper is the
+# node gateway); a second sshpiperd, run directly on the runner with a
+# generated yaml config, stands in for the fleet sentinel. Both hops are
+# real sshpiperd; only the daemon is faked (we program the node gateway's
+# Pipe + the box Secret directly rather than running the Containarium daemon,
+# which would need Postgres etc.).
+#
+# Status: manual/local verification tool. Not yet wired into a required CI
+# gate — the stand-in sentinel's exact sshpiperd yaml-plugin invocation needs
+# a live shakeout on a real runner before it becomes a gate. The unit tests
+# (tunnel Forward map, ResolveGatewayDialTarget) and the existing k8s-e2e
+# cover the code paths; this script proves the full two-hop chain end to end.
+#
+# Local use:    bash scripts/k8s-sentinel-e2e.sh
+# Keep cluster: E2E_KEEP=1 bash scripts/k8s-sentinel-e2e.sh
+#
+# Requirements: kind, kubectl, docker, ssh, ssh-keygen, base64 (all on the
+# GitHub ubuntu-latest runner). The node gateway image is
+# ghcr.io/footprintai/containarium-sshpiper (published per release); the box
+# image is ghcr.io/footprintai/containarium-agent-box. Override with
+# AGENT_BOX_IMAGE / SSHPIPER_IMAGE.
+set -euo pipefail
+
+CLUSTER="${KIND_CLUSTER:-containarium-sentinel-e2e}"
+AGENT_SANDBOX_VERSION="${AGENT_SANDBOX_VERSION:-v0.5.1}"
+AGENT_BOX_IMAGE="${AGENT_BOX_IMAGE:-ghcr.io/footprintai/containarium-agent-box:latest-stable}"
+SSHPIPER_IMAGE="${SSHPIPER_IMAGE:-ghcr.io/footprintai/containarium-sshpiper:latest-stable}"
+KEYDIR="$(mktemp -d)"
+SENTINEL_PORT=32222 # host port the "sentinel" sshpiperd listens on
+NODE_NODEPORT=32022 # kind NodePort for the node gateway
+
+cleanup() {
+  [ -n "${SENTINEL_PID:-}" ] && kill "${SENTINEL_PID}" 2>/dev/null || true
+  if [ "${E2E_KEEP:-}" != "1" ]; then
+    kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$KEYDIR"
+}
+trap cleanup EXIT
+
+echo "==> keys: agent, sentinel-upstream, node-upstream, host keys"
+ssh-keygen -t ed25519 -f "$KEYDIR/agent" -N "" -q
+ssh-keygen -t ed25519 -f "$KEYDIR/sentinel_upstream" -N "" -q # sentinel → node gateway
+ssh-keygen -t ed25519 -f "$KEYDIR/node_upstream" -N "" -q     # node gateway → box
+ssh-keygen -t ed25519 -f "$KEYDIR/sentinel_host" -N "" -q
+ssh-keygen -t ed25519 -f "$KEYDIR/node_host" -N "" -q
+
+echo "==> kind cluster + agent-sandbox controller + Pipe CRD"
+kind create cluster --name "$CLUSTER" --config - >/dev/null <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: ${NODE_NODEPORT}
+        hostPort: ${NODE_NODEPORT}
+EOF
+kubectl apply -f "https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${AGENT_SANDBOX_VERSION}/manifest.yaml" >/dev/null
+kubectl -n agent-sandbox-system wait --for=condition=available deployment/agent-sandbox-controller --timeout=180s
+kubectl apply -f "https://raw.githubusercontent.com/tg123/sshpiper/master/plugin/kubernetes/crd.yaml" >/dev/null
+kubectl create namespace agent-gateway >/dev/null
+
+echo "==> node gateway (in-cluster sshpiper) on NodePort ${NODE_NODEPORT}"
+kubectl -n agent-gateway create secret generic sshpiper-server-key --from-file=server_key="$KEYDIR/node_host" >/dev/null
+kubectl -n agent-gateway create secret generic node-upstream-key --type=kubernetes.io/ssh-auth \
+  --from-file=ssh-privatekey="$KEYDIR/node_upstream" >/dev/null
+kubectl apply -f - >/dev/null <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: sshpiper, namespace: agent-gateway}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: {name: sshpiper, namespace: agent-gateway}
+rules:
+  - {apiGroups: [sshpiper.com], resources: [pipes], verbs: [get, list, watch]}
+  - {apiGroups: [""], resources: [secrets], verbs: [get, list, watch]}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: {name: sshpiper, namespace: agent-gateway}
+roleRef: {apiGroup: rbac.authorization.k8s.io, kind: Role, name: sshpiper}
+subjects: [{kind: ServiceAccount, name: sshpiper, namespace: agent-gateway}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: sshpiper, namespace: agent-gateway}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: sshpiper}}
+  template:
+    metadata: {labels: {app: sshpiper}}
+    spec:
+      serviceAccountName: sshpiper
+      containers:
+        - name: sshpiper
+          image: ${SSHPIPER_IMAGE}
+          env:
+            - {name: PLUGIN, value: kubernetes}
+            - {name: SSHPIPERD_SERVER_KEY, value: /serverkey/ssh_host_ed25519_key}
+          ports: [{name: ssh, containerPort: 2222}]
+          volumeMounts: [{name: server-key, mountPath: /serverkey/, readOnly: true}]
+      volumes:
+        - name: server-key
+          secret:
+            secretName: sshpiper-server-key
+            items: [{key: server_key, path: ssh_host_ed25519_key}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: sshpiper, namespace: agent-gateway}
+spec:
+  type: NodePort
+  selector: {app: sshpiper}
+  ports: [{name: ssh, port: 22, targetPort: 2222, nodePort: ${NODE_NODEPORT}}]
+EOF
+kubectl -n agent-gateway rollout status deployment/sshpiper --timeout=180s
+
+echo "==> box: agent-box Sandbox + authorized_keys Secret (node upstream key) + host key"
+kubectl create namespace tenant-mybox >/dev/null
+# The box authorizes the NODE gateway's upstream key (hop 3).
+kubectl -n tenant-mybox create secret generic mybox-authorized-keys \
+  --from-file=authorized_keys="$KEYDIR/node_upstream.pub" >/dev/null
+# Stable box host key so the node gateway can dial it (ignore_hostkey in the Pipe below).
+kubectl -n tenant-mybox create secret generic mybox-host-key \
+  --from-file=host_key="$KEYDIR/node_host" >/dev/null
+docker pull -q "$AGENT_BOX_IMAGE" >/dev/null
+kind load docker-image "$AGENT_BOX_IMAGE" --name "$CLUSTER" >/dev/null 2>&1 || true
+kubectl apply -f - >/dev/null <<EOF
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata: {name: box, namespace: tenant-mybox, labels: {app.kubernetes.io/managed-by: containarium, containarium.dev/tenant: mybox}}
+spec:
+  service: true
+  operatingMode: Running
+  podTemplate:
+    metadata: {labels: {app.kubernetes.io/managed-by: containarium, containarium.dev/tenant: mybox}}
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: agent-box
+          image: ${AGENT_BOX_IMAGE}
+          ports: [{name: ssh, containerPort: 2222}]
+          volumeMounts:
+            - {name: authorized-keys, mountPath: /etc/agent-box, readOnly: true}
+      volumes:
+        - {name: authorized-keys, secret: {secretName: mybox-authorized-keys}}
+EOF
+kubectl -n tenant-mybox wait --for=create pod --selector=containarium.dev/tenant=mybox --timeout=60s
+kubectl -n tenant-mybox wait --for=condition=ready pod --selector=containarium.dev/tenant=mybox --timeout=180s
+
+echo "==> node gateway Pipe: username mybox → box pod, from-keys = agent + sentinel-upstream"
+FROM_B64=$(cat "$KEYDIR/agent.pub" "$KEYDIR/sentinel_upstream.pub" | base64 -w0)
+kubectl apply -f - >/dev/null <<EOF
+apiVersion: sshpiper.com/v1beta1
+kind: Pipe
+metadata: {name: box-mybox, namespace: agent-gateway}
+spec:
+  from:
+    - {username: mybox, authorized_keys_data: ${FROM_B64}}
+  to:
+    host: box.tenant-mybox.svc.cluster.local:2222
+    username: agent
+    ignore_hostkey: true
+    private_key_secret: {name: node-upstream-key}
+EOF
+
+echo "==> sentinel: a second sshpiperd on the runner routing mybox → the kind NodePort"
+mkdir -p "$KEYDIR/sentinel/users/mybox"
+cp "$KEYDIR/agent.pub" "$KEYDIR/sentinel/users/mybox/authorized_keys"
+# Paths in the config are the CONTAINER paths (see the volume mounts below):
+# the sentinel config dir mounts at /sentinel, the upstream key at
+# /sentinel_upstream. The yaml plugin refuses a world-readable config, so
+# chmod 600 (the real sentinel does the same — startup-sentinel.sh).
+cat > "$KEYDIR/sentinel/config.yaml" <<EOF
+version: "1.0"
+pipes:
+  - from:
+      - username: "mybox"
+        authorized_keys:
+          - /sentinel/users/mybox/authorized_keys
+    to:
+      host: 127.0.0.1:${NODE_NODEPORT}
+      username: "mybox"
+      ignore_hostkey: true
+      private_key: /sentinel_upstream
+EOF
+chmod 600 "$KEYDIR/sentinel/config.yaml"
+# sshpiperd CLI: global flags, then the plugin (by full path — the plugins
+# aren't on PATH in this image), then plugin flags. Matches the sentinel's
+# own unit (terraform/.../sshpiper.service.tmpl). Override the image
+# entrypoint, which otherwise hardcodes the kubernetes plugin.
+docker run -d --rm --name sentinel-sshpiper --network host \
+  --entrypoint /sshpiperd/sshpiperd \
+  -v "$KEYDIR/sentinel:/sentinel:ro" \
+  -v "$KEYDIR/sentinel_host:/host_key:ro" \
+  -v "$KEYDIR/sentinel_upstream:/sentinel_upstream:ro" \
+  "$SSHPIPER_IMAGE" \
+  -i /host_key -p "${SENTINEL_PORT}" --log-level info \
+  /sshpiperd/plugins/yaml --config /sentinel/config.yaml >/dev/null
+SENTINEL_PID=1 # sentinel runs as a docker container; cleanup kills it below
+trap 'docker rm -f sentinel-sshpiper >/dev/null 2>&1 || true; [ "${E2E_KEEP:-}" != "1" ] && kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true; rm -rf "$KEYDIR"' EXIT
+sleep 4
+
+echo "==> MCP initialize through BOTH hops (agent key only, ssh mybox@sentinel)"
+INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"sentinel-e2e","version":"0.0.1"}}}'
+RESP=$(printf '%s\n' "$INIT" | timeout 25 ssh -i "$KEYDIR/agent" -p "$SENTINEL_PORT" \
+  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes \
+  mybox@127.0.0.1)
+if ! printf '%s' "$RESP" | grep -q '"containarium-agent-box"'; then
+  echo "FAIL: no MCP initialize response through the sentinel→node→box chain" >&2
+  echo "Got: $RESP" >&2
+  docker logs sentinel-sshpiper 2>&1 | tail -20 >&2 || true
+  kubectl -n agent-gateway logs deployment/sshpiper --tail=20 >&2 || true
+  exit 1
+fi
+echo "OK: agent-box answered MCP through sentinel → node gateway → box (agent held only its SSH key)."
+echo "Test finished."


### PR DESCRIPTION
PR 4 of 4 — completes sentinel→K8s-node SSH chaining (stacked on #983).

A tunnel-attached K8s node must forward its advertised gateway port to the
in-cluster sshpiper Service's **reachable** address — NodePorts aren't
reliably reachable on `127.0.0.1`, so the fixed `127.0.0.1:<port>` tunnel
dial fails for the gateway hop.

- `TunnelClient.Forward` (advertised-port → dial-target) + `handleStream`
  override; CLI `containarium tunnel --forward PORT=HOST:PORT`.
- `k8s.Backend.ResolveGatewayDialTarget`: LoadBalancer ingress first, else
  `<node InternalIP>:<NodePort>` (the LB/ClusterIP-over-localhost preference).
- `scripts/k8s-sentinel-e2e.sh`: full two-hop proof (kind node gateway +
  stand-in sentinel sshpiperd + MCP handshake `sentinel → node → box`, agent
  holding only its SSH key). Shipped as a manual/local tool for now — the
  stand-in sentinel's exact sshpiperd invocation needs a live shakeout before
  becoming a CI gate; unit tests + k8s-e2e cover the code paths.
- Docs: three-hop chain across MULTI-BACKEND-PEERS / TUNNEL-REVERSE-PROXY /
  K8S-AGENT-BOX-RUNTIME-DESIGN.

Result: `ssh <box>@<sentinel>` reaches a box on any node, K8s or LXC, each
key scoped to one hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)