### PR TITLE
refactor(k8s): formalize the gatewayRouter seam

### DIFF
--- a/pkg/core/box/k8s/gateway.go
+++ b/pkg/core/box/k8s/gateway.go
@@ -2,15 +2,32 @@ package k8s
 
 import (
 	"context"
-	"encoding/base64"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// gatewayRouter programs SSH-gateway routing for a tenant's box: it maps an
+// incoming SSH connection (authenticated against the tenant's client keys) to
+// the tenant's box pod. It is the seam between the box lifecycle (Create /
+// Delete / SetAuthorizedKeys / sentinel re-key) and whatever SSH front end
+// fronts the cluster, so the lifecycle code never depends on sshpiper's Pipe
+// CRD directly. The sole implementation today is sshpiperRouter
+// (gateway_sshpiper.go).
+type gatewayRouter interface {
+	// Enabled reports whether routing should be programmed. When false, boxes
+	// are still reconciled but not fronted (a cluster without the gateway, or
+	// the core lifecycle e2e); ProgramRoute and RemoveRoute are then no-ops.
+	Enabled() bool
+	// ProgramRoute creates or updates the tenant's route so username=<tenant>
+	// reaches its box pod. clientKeys are the agent keys that may connect at the
+	// front; the router unions in any authorized sentinel keys itself.
+	ProgramRoute(ctx context.Context, tenant string, clientKeys []string) error
+	// RemoveRoute deletes the tenant's route. No-op when already gone or the
+	// gateway isn't configured.
+	RemoveRoute(ctx context.Context, tenant string) error
+}
 
 // ensureHostKey returns the box's stable host public key (authorized-key form),
 // generating + storing a per-box host keypair Secret on first call. The private
@@ -47,131 +64,4 @@ func (b *Backend) ensureHostKey(ctx context.Context, tenant string) (pubs []stri
 		return nil, err
 	}
 	return []string{edPub, rsaPub}, nil
-}
-
-// pipeGVR is the sshpiper Kubernetes plugin's CRD. The design note
-// (docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md) calls it "PiperUpstream"; the
-// maintained plugin's actual resource is `pipes` in group sshpiper.com/v1beta1
-// (kind Pipe). sshpiper watches a namespace for these and routes incoming SSH
-// by username — so programming a Pipe is how the gateway learns to forward a
-// tenant's connection to its box pod.
-var pipeGVR = schema.GroupVersionResource{Group: "sshpiper.com", Version: "v1beta1", Resource: "pipes"}
-
-func pipeName(tenant string) string { return "box-" + tenant }
-
-// gatewayEnabled reports whether SSH-gateway routing should be programmed: a
-// dynamic client plus a configured gateway namespace where Pipes live. When
-// off (no GatewayNamespace), boxes are still reconciled but not routed — useful
-// for clusters without sshpiper, and for the core lifecycle e2e.
-func (b *Backend) gatewayEnabled() bool {
-	return b.dyn != nil && b.cfg.GatewayNamespace != ""
-}
-
-// upstreamHost is the in-cluster DNS the gateway forwards the tenant's SSH to:
-// the Sandbox's controller-created headless Service (named after the Sandbox),
-// whose A record resolves to the box pod. Matches the Sandbox's
-// status.serviceFQDN; computed here rather than read from status so the Pipe
-// can be programmed at Create time, before the controller first reconciles.
-func (b *Backend) upstreamHost(tenant string) string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local:%d", sandboxName, b.namespaceFor(tenant), sshPort)
-}
-
-// pipeObject builds the sshpiper Pipe that routes username=<tenant> to the
-// tenant's box pod: the incoming connection authenticates against the box's
-// authorized keys (inline, base64), and the upstream host key is trusted
-// (ignore_hostkey — TOFU/known_hosts pinning is a follow-up).
-//
-// fromKeys is the union of the agent's client keys (direct node-gateway
-// access) and any authorized sentinel keys (hop 2 of the sentinel chain) —
-// both authenticate the incoming connection at the node gateway.
-func (b *Backend) pipeObject(tenant string, fromKeys []string, hostPubKeys []string) *unstructured.Unstructured {
-	var buf []byte
-	for _, k := range fromKeys {
-		buf = append(buf, []byte(k)...)
-		buf = append(buf, '\n')
-	}
-	to := map[string]any{
-		"host":     b.upstreamHost(tenant),
-		"username": boxSSHUser, // fixed box login user; tenant identity is enforced by from.username
-	}
-	// Host-key handling: pin the box's host keys (known_hosts_data) when we have
-	// them, else fall back to ignore_hostkey (the escape hatch / pre-pinning
-	// behavior). Both keys are pinned because sshpiper may negotiate either —
-	// stops a man-in-the-middle between sshpiper and the box.
-	if len(hostPubKeys) > 0 && !b.cfg.InsecureIgnoreHostKey {
-		to["known_hosts_data"] = knownHostsData(b.upstreamHost(tenant), hostPubKeys...)
-	} else {
-		to["ignore_hostkey"] = true
-	}
-	// The upstream credential: sshpiper authenticates to the box with this key
-	// (its public half is authorized on the box). Set only when configured.
-	if b.cfg.GatewayUpstreamKeySecret != "" {
-		to["private_key_secret"] = map[string]any{"name": b.cfg.GatewayUpstreamKeySecret}
-	}
-	return &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "sshpiper.com/v1beta1",
-		"kind":       "Pipe",
-		"metadata": map[string]any{
-			"name":      pipeName(tenant),
-			"namespace": b.cfg.GatewayNamespace,
-			"labels":    toAnyMap(boxLabels(tenant)),
-		},
-		"spec": map[string]any{
-			"from": []any{map[string]any{
-				"username":             tenant,
-				"authorized_keys_data": base64.StdEncoding.EncodeToString(buf),
-			}},
-			"to": to,
-		},
-	}}
-}
-
-// upsertPipe creates or updates the tenant's Pipe in the gateway namespace.
-// No-op when the gateway isn't configured. The Pipe's from-keys are the
-// agent's client keys plus any authorized sentinel keys (so a sentinel in
-// front of this node can complete hop 2).
-func (b *Backend) upsertPipe(ctx context.Context, tenant string, keys []string) error {
-	if !b.gatewayEnabled() {
-		return nil
-	}
-	ns := b.cfg.GatewayNamespace
-	hostPubs, err := b.ensureHostKey(ctx, tenant) // pin the box's stable host keys
-	if err != nil {
-		return fmt.Errorf("ensure host key: %w", err)
-	}
-	fromKeys := append(append([]string{}, keys...), b.sentinelKeys(ctx)...)
-	obj := b.pipeObject(tenant, fromKeys, hostPubs)
-	_, err = b.dyn.Resource(pipeGVR).Namespace(ns).Create(ctx, obj, metav1.CreateOptions{})
-	if apierrors.IsAlreadyExists(err) {
-		existing, gerr := b.dyn.Resource(pipeGVR).Namespace(ns).Get(ctx, pipeName(tenant), metav1.GetOptions{})
-		if gerr != nil {
-			return gerr
-		}
-		existing.Object["spec"] = obj.Object["spec"]
-		_, err = b.dyn.Resource(pipeGVR).Namespace(ns).Update(ctx, existing, metav1.UpdateOptions{})
-	}
-	return err
-}
-
-// deletePipe removes the tenant's Pipe. No-op when the gateway isn't configured
-// or the Pipe is already gone. (The Pipe lives in the gateway namespace, so the
-// per-tenant namespace delete does not cascade to it — it must be deleted
-// explicitly.)
-func (b *Backend) deletePipe(ctx context.Context, tenant string) error {
-	if !b.gatewayEnabled() {
-		return nil
-	}
-	err := b.dyn.Resource(pipeGVR).Namespace(b.cfg.GatewayNamespace).Delete(ctx, pipeName(tenant), metav1.DeleteOptions{})
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
-	return err
-}
-
-func toAnyMap(m map[string]string) map[string]any {
-	out := make(map[string]any, len(m))
-	for k, v := range m {
-		out[k] = v
-	}
-	return out
 }

--- a/pkg/core/box/k8s/gateway_sshpiper.go
+++ b/pkg/core/box/k8s/gateway_sshpiper.go
@@ -1,0 +1,148 @@
+package k8s
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// sshpiperRouter is the sshpiper-backed gatewayRouter: it programs one Pipe CR
+// per tenant in the gateway namespace, which the sshpiper Kubernetes plugin
+// watches to route incoming SSH by username to the tenant's box pod. It is the
+// only gatewayRouter implementation today; the seam (gateway.go) exists so a
+// different SSH front end could replace it without touching box lifecycle.
+type sshpiperRouter struct{ b *Backend }
+
+var _ gatewayRouter = (*sshpiperRouter)(nil)
+
+// pipeGVR is the sshpiper Kubernetes plugin's CRD. The design note
+// (docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md) calls it "PiperUpstream"; the
+// maintained plugin's actual resource is `pipes` in group sshpiper.com/v1beta1
+// (kind Pipe). sshpiper watches a namespace for these and routes incoming SSH
+// by username — so programming a Pipe is how the gateway learns to forward a
+// tenant's connection to its box pod.
+var pipeGVR = schema.GroupVersionResource{Group: "sshpiper.com", Version: "v1beta1", Resource: "pipes"}
+
+func pipeName(tenant string) string { return "box-" + tenant }
+
+// Enabled reports whether SSH-gateway routing should be programmed: a dynamic
+// client plus a configured gateway namespace where Pipes live. When off (no
+// GatewayNamespace), boxes are still reconciled but not routed — useful for
+// clusters without sshpiper, and for the core lifecycle e2e.
+func (r *sshpiperRouter) Enabled() bool {
+	return r.b.dyn != nil && r.b.cfg.GatewayNamespace != ""
+}
+
+// upstreamHost is the in-cluster DNS the gateway forwards the tenant's SSH to:
+// the Sandbox's controller-created headless Service (named after the Sandbox),
+// whose A record resolves to the box pod. Matches the Sandbox's
+// status.serviceFQDN; computed here rather than read from status so the Pipe
+// can be programmed at Create time, before the controller first reconciles.
+func (r *sshpiperRouter) upstreamHost(tenant string) string {
+	return fmt.Sprintf("%s.%s.svc.cluster.local:%d", sandboxName, r.b.namespaceFor(tenant), sshPort)
+}
+
+// pipeObject builds the sshpiper Pipe that routes username=<tenant> to the
+// tenant's box pod: the incoming connection authenticates against the box's
+// authorized keys (inline, base64), and the upstream host key is trusted
+// (ignore_hostkey — TOFU/known_hosts pinning is a follow-up).
+//
+// fromKeys is the union of the agent's client keys (direct node-gateway
+// access) and any authorized sentinel keys (hop 2 of the sentinel chain) —
+// both authenticate the incoming connection at the node gateway.
+func (r *sshpiperRouter) pipeObject(tenant string, fromKeys []string, hostPubKeys []string) *unstructured.Unstructured {
+	var buf []byte
+	for _, k := range fromKeys {
+		buf = append(buf, []byte(k)...)
+		buf = append(buf, '\n')
+	}
+	to := map[string]any{
+		"host":     r.upstreamHost(tenant),
+		"username": boxSSHUser, // fixed box login user; tenant identity is enforced by from.username
+	}
+	// Host-key handling: pin the box's host keys (known_hosts_data) when we have
+	// them, else fall back to ignore_hostkey (the escape hatch / pre-pinning
+	// behavior). Both keys are pinned because sshpiper may negotiate either —
+	// stops a man-in-the-middle between sshpiper and the box.
+	if len(hostPubKeys) > 0 && !r.b.cfg.InsecureIgnoreHostKey {
+		to["known_hosts_data"] = knownHostsData(r.upstreamHost(tenant), hostPubKeys...)
+	} else {
+		to["ignore_hostkey"] = true
+	}
+	// The upstream credential: sshpiper authenticates to the box with this key
+	// (its public half is authorized on the box). Set only when configured.
+	if r.b.cfg.GatewayUpstreamKeySecret != "" {
+		to["private_key_secret"] = map[string]any{"name": r.b.cfg.GatewayUpstreamKeySecret}
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "sshpiper.com/v1beta1",
+		"kind":       "Pipe",
+		"metadata": map[string]any{
+			"name":      pipeName(tenant),
+			"namespace": r.b.cfg.GatewayNamespace,
+			"labels":    toAnyMap(boxLabels(tenant)),
+		},
+		"spec": map[string]any{
+			"from": []any{map[string]any{
+				"username":             tenant,
+				"authorized_keys_data": base64.StdEncoding.EncodeToString(buf),
+			}},
+			"to": to,
+		},
+	}}
+}
+
+// ProgramRoute creates or updates the tenant's Pipe in the gateway namespace.
+// No-op when the gateway isn't configured. The Pipe's from-keys are the
+// agent's client keys plus any authorized sentinel keys (so a sentinel in
+// front of this node can complete hop 2).
+func (r *sshpiperRouter) ProgramRoute(ctx context.Context, tenant string, keys []string) error {
+	if !r.Enabled() {
+		return nil
+	}
+	ns := r.b.cfg.GatewayNamespace
+	hostPubs, err := r.b.ensureHostKey(ctx, tenant) // pin the box's stable host keys
+	if err != nil {
+		return fmt.Errorf("ensure host key: %w", err)
+	}
+	fromKeys := append(append([]string{}, keys...), r.b.sentinelKeys(ctx)...)
+	obj := r.pipeObject(tenant, fromKeys, hostPubs)
+	_, err = r.b.dyn.Resource(pipeGVR).Namespace(ns).Create(ctx, obj, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		existing, gerr := r.b.dyn.Resource(pipeGVR).Namespace(ns).Get(ctx, pipeName(tenant), metav1.GetOptions{})
+		if gerr != nil {
+			return gerr
+		}
+		existing.Object["spec"] = obj.Object["spec"]
+		_, err = r.b.dyn.Resource(pipeGVR).Namespace(ns).Update(ctx, existing, metav1.UpdateOptions{})
+	}
+	return err
+}
+
+// RemoveRoute removes the tenant's Pipe. No-op when the gateway isn't configured
+// or the Pipe is already gone. (The Pipe lives in the gateway namespace, so the
+// per-tenant namespace delete does not cascade to it — it must be deleted
+// explicitly.)
+func (r *sshpiperRouter) RemoveRoute(ctx context.Context, tenant string) error {
+	if !r.Enabled() {
+		return nil
+	}
+	err := r.b.dyn.Resource(pipeGVR).Namespace(r.b.cfg.GatewayNamespace).Delete(ctx, pipeName(tenant), metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func toAnyMap(m map[string]string) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/core/box/k8s/gateway_test.go
+++ b/pkg/core/box/k8s/gateway_test.go
@@ -180,7 +180,7 @@ func TestGatewayDisabledSkipsPipe(t *testing.T) {
 	// No dynamic client (NewWithClientset) → gateway off → Create still succeeds
 	// and programs no Pipe.
 	b := NewWithClientset(fake.NewSimpleClientset(), sandboxfake.NewSimpleClientset(), Config{GatewayNamespace: "sshpiper"})
-	if b.gatewayEnabled() {
+	if b.router.Enabled() {
 		t.Fatal("gateway should be disabled without a dynamic client")
 	}
 	if _, err := b.Create(context.Background(), box.BoxSpec{Ref: box.BoxRef{Tenant: "dave"}, Image: "x", AutoStart: true}); err != nil {

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -111,6 +111,7 @@ type Backend struct {
 	clientset kubernetes.Interface
 	sandboxes sandboxclient.Interface
 	dyn       dynamic.Interface // for the sshpiper Pipe CRD; nil disables gateway routing
+	router    gatewayRouter     // SSH-gateway routing seam; sshpiperRouter today
 }
 
 var _ box.BoxBackend = (*Backend)(nil)
@@ -171,7 +172,9 @@ func newBackend(cs kubernetes.Interface, sc sandboxclient.Interface, dyn dynamic
 		cfg.DefaultMemoryRequest = resolveQuantity(cfg.DefaultMemoryRequest, defaultMemoryRequest)
 		cfg.DefaultMemoryLimit = resolveQuantity(cfg.DefaultMemoryLimit, defaultMemoryLimit)
 	}
-	return &Backend{cfg: cfg, clientset: cs, sandboxes: sc, dyn: dyn}
+	b := &Backend{cfg: cfg, clientset: cs, sandboxes: sc, dyn: dyn}
+	b.router = &sshpiperRouter{b: b}
+	return b
 }
 
 // resolveQuantity returns v when it is a valid K8s resource quantity, else the
@@ -255,7 +258,7 @@ func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus,
 	}
 	// Program the SSH gateway so username=<tenant> routes to this box (no-op
 	// when the gateway isn't configured).
-	if err := b.upsertPipe(ctx, tenant, spec.SSHKeys); err != nil {
+	if err := b.router.ProgramRoute(ctx, tenant, spec.SSHKeys); err != nil {
 		return nil, fmt.Errorf("k8s: ensure gateway pipe: %w", err)
 	}
 	return b.Get(ctx, spec.Ref)
@@ -316,7 +319,7 @@ func (b *Backend) statusOf(tenant string, sb *sandboxv1beta1.Sandbox) *box.BoxSt
 // namespace (original behaviour, backward compat).
 func (b *Backend) Delete(ctx context.Context, ref box.BoxRef, force bool) error {
 	ns := b.namespaceFor(ref.Tenant)
-	if err := b.deletePipe(ctx, ref.Tenant); err != nil {
+	if err := b.router.RemoveRoute(ctx, ref.Tenant); err != nil {
 		return fmt.Errorf("k8s: delete gateway pipe: %w", err)
 	}
 	// No persistent storage: delete the whole namespace (original behaviour).
@@ -417,14 +420,14 @@ func (b *Backend) SetAuthorizedKeys(ctx context.Context, ref box.BoxRef, keys []
 	}
 	// Re-program the gateway Pipe so the rotated client keys take effect at the
 	// front (no-op when the gateway isn't configured).
-	return b.upsertPipe(ctx, ref.Tenant, keys)
+	return b.router.ProgramRoute(ctx, ref.Tenant, keys)
 }
 
 // boxAuthorizedKeys returns the keys the box itself should authorize: the
 // gateway's upstream key when routing through sshpiper, else the agent's keys
 // (direct access).
 func (b *Backend) boxAuthorizedKeys(agentKeys []string) []string {
-	if b.gatewayEnabled() && b.cfg.GatewayUpstreamPublicKey != "" {
+	if b.router.Enabled() && b.cfg.GatewayUpstreamPublicKey != "" {
 		return []string{b.cfg.GatewayUpstreamPublicKey}
 	}
 	return agentKeys

--- a/pkg/core/box/k8s/sentinelkey.go
+++ b/pkg/core/box/k8s/sentinelkey.go
@@ -38,7 +38,7 @@ func (b *Backend) SetSentinelKey(ctx context.Context, pubKey string) (updated, r
 	if pubKey == "" {
 		return 0, 0, fmt.Errorf("k8s: empty sentinel key")
 	}
-	if !b.gatewayEnabled() || b.cfg.GatewayUpstreamKeySecret == "" {
+	if !b.router.Enabled() || b.cfg.GatewayUpstreamKeySecret == "" {
 		return 0, 0, fmt.Errorf("k8s: sentinel fronting requires gateway-upstream mode " +
 			"(set CONTAINARIUM_K8S_GATEWAY_NAMESPACE + _UPSTREAM_KEY_SECRET); refusing to authorize a sentinel key in direct mode")
 	}
@@ -77,7 +77,7 @@ func (b *Backend) SetSentinelKey(ctx context.Context, pubKey string) (updated, r
 	for i := range boxes {
 		tenant := boxes[i].Ref.Tenant
 		clientKeys := splitKeys(b.clientKeysOf(ctx, tenant))
-		if perr := b.upsertPipe(ctx, tenant, clientKeys); perr != nil {
+		if perr := b.router.ProgramRoute(ctx, tenant, clientKeys); perr != nil {
 			log.Printf("[k8s] sentinel re-key: box %s Pipe update failed: %v", tenant, perr)
 			continue
 		}


### PR DESCRIPTION
## What

Formalizes the SSH-gateway routing seam in the K8s box backend. The
routing methods that were hung directly on `*Backend`
(`gatewayEnabled`, `upsertPipe`, `deletePipe`, plus the Pipe object
builders `pipeObject`/`upstreamHost`/`toAnyMap`) now live behind an
explicit `gatewayRouter` interface with one implementation,
`sshpiperRouter`, in a new `gateway_sshpiper.go`.

```go
type gatewayRouter interface {
    Enabled() bool
    ProgramRoute(ctx context.Context, tenant string, clientKeys []string) error
    RemoveRoute(ctx context.Context, tenant string) error
}
```

`Backend` gains a `router gatewayRouter` field wired in `newBackend`
(`b.router = &sshpiperRouter{b: b}`). The lifecycle call sites — `Create`,
`Delete`, `SetAuthorizedKeys`, `boxAuthorizedKeys`, and the sentinel
re-key in `sentinelkey.go` — now go through `b.router.{ProgramRoute,
RemoveRoute,Enabled}` instead of touching sshpiper's Pipe CRD directly.

## Why

The box lifecycle no longer depends on the `sshpiper.com/v1beta1` Pipe
shape. A different SSH front end could replace `sshpiperRouter` without
touching box create/delete/rekey. It also isolates the one piece of the
backend that knows a specific third-party CRD behind a named boundary.

## Scope

Pure refactor, no behavior change. `ensureHostKey` and `sentinelKeys`
stay on `Backend` (shared across the router and the sentinel-key path).
`pipeGVR`/`pipeName` stay package-level (the test suites reference them).

## Verification

- `go build ./...`
- `go test -tags k8s ./pkg/core/box/k8s/` (gateway + sentinel-key + e2e suites)
- `go test ./internal/server/ ./pkg/core/box/...`
- `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)