### PR TITLE
test(sentinel): pin USE policy for go-proxyproto v0.15.0 (supersedes #939)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/lxc/incus/v6 v6.23.0
 	github.com/mark3labs/mcp-go v0.56.0
-	github.com/pires/go-proxyproto v0.14.0
+	github.com/pires/go-proxyproto v0.15.0
 	github.com/rs/cors v1.11.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/opencontainers/runtime-spec v1.3.0 h1:YZupQUdctfhpZy3TM39nN9Ika5CBWT5
 github.com/opencontainers/runtime-spec v1.3.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/umoci v0.6.1-0.20251213054154-70fc5ee1f4df h1:9hvwN64VeuL1L0Jgp8bxTPmd5IZQoHmeXGWrVqsEhN0=
 github.com/opencontainers/umoci v0.6.1-0.20251213054154-70fc5ee1f4df/go.mod h1:s6d/s4QJAZTF92hEU6ozuHjE0+VRc6kVe1QIWfvL7KY=
-github.com/pires/go-proxyproto v0.14.0 h1:2vIGIfVG8eVRsKF0xukEoeT5RWhDXxBU0uv6smLOKdI=
-github.com/pires/go-proxyproto v0.14.0/go.mod h1:OXsCrKwrK2tXS9YrI5tkHx5xaQlO8FH3lFW76orFh24=
+github.com/pires/go-proxyproto v0.15.0 h1:dTshmNbFm/D+0+sbrxUuddPOZ5Y0B7c5NhtsBkm6LqI=
+github.com/pires/go-proxyproto v0.15.0/go.mod h1:OXsCrKwrK2tXS9YrI5tkHx5xaQlO8FH3lFW76orFh24=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/sentinel/proxyproto_e2e_test.go
+++ b/internal/sentinel/proxyproto_e2e_test.go
@@ -61,15 +61,27 @@ func runProxyProtoE2E(t *testing.T, useProxyProto bool) {
 	defer func() { _ = rawBackendLn.Close() }()
 	backendAddr := rawBackendLn.Addr().(*net.TCPAddr)
 
-	// We always wrap the backend with proxyproto.Listener using the default
-	// USE policy. This is the realistic configuration: Caddy's
-	// proxy_protocol listener wrapper does the same. With USE:
+	// We always wrap the backend with proxyproto.Listener under an explicit
+	// USE policy. This is the realistic configuration: Caddy's proxy_protocol
+	// listener wrapper accepts a connection whether or not it carries a PROXY
+	// header. With USE:
 	//   - PROXY header present → conn.RemoteAddr() = parsed source
 	//   - PROXY header absent  → conn.RemoteAddr() = the actual TCP peer
 	// So the assertion changes between the two scenarios but the backend
 	// configuration stays identical, which mirrors how production rolls
 	// out (deploy backend first, then flip sentinel flag).
-	ppLn := &proxyproto.Listener{Listener: rawBackendLn}
+	//
+	// USE must be set explicitly: go-proxyproto v0.15.0 changed the default
+	// policy from USE to REQUIRE, so a header-less connection now fails its
+	// first read with ErrNoProxyProtocol instead of passing through. That
+	// would break the without-proxy-protocol case, which is exactly the
+	// baseline this test asserts.
+	ppLn := &proxyproto.Listener{
+		Listener: rawBackendLn,
+		ConnPolicy: func(proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+			return proxyproto.USE, nil
+		},
+	}
 
 	cert, err := generateSelfSignedCert()
 	require.NoError(t, err)


### PR DESCRIPTION
## What

Bumps `github.com/pires/go-proxyproto` v0.14.0 → v0.15.0 (the bump
Dependabot proposed in #939) **and** fixes the e2e test that the bump
breaks, so the two land together and green.

## Why #939 fails

v0.15.0 changed the default `Listener` policy from `USE` to `REQUIRE`
(`DefaultPolicy = REQUIRE`). Under REQUIRE, a connection that does not
open with a PROXY header fails its first `Read` with
`ErrNoProxyProtocol` ("proxy protocol signature not present") instead of
passing through as a direct connection.

`TestProxyProtocolE2E/without_proxy_protocol_backend_sees_sentinel_ip`
wraps its backend listener with the library default and relies on
header-less **pass-through** as the baseline it asserts — so under
v0.15.0 the backend rejected the plain TLS connection before the
handshake and the subtest failed.

## Fix

Set `ConnPolicy → USE` explicitly on the test's `proxyproto.Listener`,
restoring the documented intent (present header → parsed source; absent
header → real TCP peer). This is the faithful mirror of production,
where Caddy's `proxy_protocol` wrapper accepts a connection with or
without the header.

## Scope

`go-proxyproto` is a **test-only** dependency — no non-test file imports
it; production terminates PROXY protocol via Caddy's `proxy_protocol`
listener, not this Go type. So the bump touches nothing but this one
test file.

## Verification

- `go build ./...`
- `go test ./internal/sentinel/` (full suite, both TestProxyProtocolE2E subtests pass)
- `gofmt -l` clean

Closes #939.

🤖 Generated with [Claude Code](https://claude.com/claude-code)