### PR TITLE
feat(mcp): add a Dockerfile for cmd/mcp-server

### DIFF
--- a/cmd/mcp-server/README.md
+++ b/cmd/mcp-server/README.md
@@ -16,6 +16,19 @@ export CONTAINARIUM_JWT_TOKEN="your-jwt-token"
 ./bin/mcp-server
 ```
 
+### Run in a container
+
+```bash
+docker build -f images/mcp-server/Dockerfile -t containarium-mcp-server .
+docker run -i --rm \
+  -e CONTAINARIUM_SERVER_URL="http://host.docker.internal:8080" \
+  -e CONTAINARIUM_JWT_TOKEN="your-jwt-token" \
+  containarium-mcp-server
+```
+
+The MCP protocol runs over stdio, so `-i` (attach stdin) is required; no
+ports are exposed.
+
 ### Configure Claude Desktop
 
 Add to `~/.config/claude/claude_desktop_config.json`:

--- a/images/mcp-server/Dockerfile
+++ b/images/mcp-server/Dockerfile
@@ -1,0 +1,43 @@
+# containarium-mcp-server
+#
+# The platform MCP server (cmd/mcp-server): the outside-the-box admin
+# surface (create_container, list_containers, expose_port, ...). Reached
+# over stdio (JSON-RPC), speaking HTTP + JWT Bearer to the Containarium
+# REST API — see cmd/mcp-server/README.md for the full contract.
+#
+# This image exists so the server can be built, deployed, and scored
+# (glama.ai) as a standalone MCP server (Containarium#967). It is a pure-Go
+# REST/gRPC client with no host-side dependencies (unlike cmd/agent-box,
+# which must run inside a Containarium box).
+#
+# Build (context is the repo root):
+#   docker build -f images/mcp-server/Dockerfile -t containarium-mcp-server .
+#
+# Run (stdio MCP transport — attach stdin/stdout, e.g. `docker run -i`):
+#   docker run -i --rm \
+#     -e CONTAINARIUM_SERVER_URL=http://host.docker.internal:8080 \
+#     -e CONTAINARIUM_JWT_TOKEN=... \
+#     containarium-mcp-server
+
+FROM golang:1.26.5-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/mcp-server ./cmd/mcp-server
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 --shell /usr/sbin/nologin mcp
+
+COPY --from=build /out/mcp-server /usr/local/bin/mcp-server
+
+USER mcp
+ENV HOME=/home/mcp
+# Required at runtime (see cmd/mcp-server/README.md):
+#   CONTAINARIUM_SERVER_URL, and one of CONTAINARIUM_JWT_TOKEN /
+#   CONTAINARIUM_JWT_TOKEN_FILE. No ports are exposed — the MCP protocol
+# runs over stdio, not a network listener.
+ENTRYPOINT ["/usr/local/bin/mcp-server"]


### PR DESCRIPTION
## Summary

Prep work for #967 (Add Glama scorecard for `cmd/mcp-server`).

Glama's release process needs a container build for a server before it
can be claimed, given a build spec, deploy-tested, and released. `cmd/mcp-server`
(the platform MCP — outside-the-box admin ops) had no Dockerfile; only
`cmd/agent-box` (in-box MCP, explicitly lower-priority for a Glama listing
per the issue since it can't run standalone outside a Containarium box)
and the web-ui/sidecar images did.

- Adds `images/mcp-server/Dockerfile`: multi-stage build, non-root user,
  minimal debian base — same pattern as the already-published
  `images/agent-box/Dockerfile`. No ports exposed; the MCP protocol runs
  over stdio.
- Documents `docker build`/`docker run` usage in `cmd/mcp-server/README.md`.

## What this PR does NOT cover

I verified against Glama's own docs (glama.ai/blog on their release process)
and their server-config schema: claiming the server, configuring the
build spec / CMD args / env-var schema, deploy-testing, and creating a
release all happen exclusively on glama.ai's admin UI
(`glama.ai/mcp/servers/{owner}/{repo}/admin/dockerfile`), gated on GitHub
OAuth login as a repo maintainer. `glama.json`'s schema only supports a
`maintainers` array (already present). None of that has a repo-side
file equivalent, so it's out of scope for a code PR — a maintainer with
Glama access needs to do steps 1/3/4 by hand once this Dockerfile lands.

## Test plan
- [x] `go build ./cmd/mcp-server` succeeds
- [ ] `docker build -f images/mcp-server/Dockerfile -t containarium-mcp-server .` — not verified in this sandbox (no docker daemon available); Dockerfile mirrors the proven `images/agent-box/Dockerfile` structure

Progresses #967 (repo-side portion only — see note above).