### PR TITLE
fix(k8s): normalize incus-style disk quantities instead of panicking (#973)

### DIFF
--- a/pkg/core/box/k8s/k8s_test.go
+++ b/pkg/core/box/k8s/k8s_test.go
@@ -424,6 +424,47 @@ func TestPVCObjectBuilderDefaults(t *testing.T) {
 	}
 }
 
+// TestParseDiskQuantityValidK8s verifies a well-formed K8s quantity passes
+// through unchanged.
+func TestParseDiskQuantityValidK8s(t *testing.T) {
+	q := parseDiskQuantity("10Gi")
+	if q.String() != "10Gi" {
+		t.Errorf("parseDiskQuantity(%q) = %q, want %q", "10Gi", q.String(), "10Gi")
+	}
+}
+
+// TestParseDiskQuantityIncusStyle verifies an incus-style two-letter suffix
+// ("50GB", the CLI's own default disk size) normalizes to the K8s
+// single-letter equivalent instead of failing to parse.
+func TestParseDiskQuantityIncusStyle(t *testing.T) {
+	q := parseDiskQuantity("50GB")
+	if q.String() != "50G" {
+		t.Errorf("parseDiskQuantity(%q) = %q, want %q", "50GB", q.String(), "50G")
+	}
+}
+
+// TestParseDiskQuantityGarbageFallsBackToDefault is the regression test for
+// #973: a disk string that is neither a valid K8s quantity nor a
+// recognizable incus-style size must never panic the daemon — it degrades to
+// defaultDisk.
+func TestParseDiskQuantityGarbageFallsBackToDefault(t *testing.T) {
+	q := parseDiskQuantity("not-a-size")
+	if q.String() != defaultDisk {
+		t.Errorf("parseDiskQuantity(%q) = %q, want default %q", "not-a-size", q.String(), defaultDisk)
+	}
+}
+
+// TestPVCObjectBuilderIncusStyleDisk verifies pvcObject itself (the
+// CreateContainer path that panicked in #973) never panics on an incus-style
+// disk string and produces the normalized K8s quantity.
+func TestPVCObjectBuilderIncusStyleDisk(t *testing.T) {
+	pvc := pvcObject("tenant-carol", "carol", "standard", "50GB")
+	q := pvc.Spec.Resources.Requests["storage"]
+	if q.String() != "50G" {
+		t.Errorf("storage request = %q, want %q", q.String(), "50G")
+	}
+}
+
 // TestCreateProvisionsPVC verifies that Create provisions a PVC when
 // StorageClass is configured.
 func TestCreateProvisionsPVC(t *testing.T) {

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -2,6 +2,8 @@ package k8s
 
 import (
 	"fmt"
+	"log"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -84,12 +86,10 @@ func hostKeySecretName(tenant string) string { return tenant + "-host-key" }
 
 // pvcObject builds the PersistentVolumeClaim for the box's data volume.
 // storageClass "" disables PVC provisioning (caller must not call this).
-// disk is the requested size (e.g. "20Gi"); defaults to defaultDisk when empty.
+// disk is the requested size (e.g. "20Gi"); defaults to defaultDisk when empty
+// or unparseable (see parseDiskQuantity).
 func pvcObject(ns, tenant, storageClass, disk string) *corev1.PersistentVolumeClaim {
-	if disk == "" {
-		disk = defaultDisk
-	}
-	quantity := resource.MustParse(disk)
+	quantity := parseDiskQuantity(disk)
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pvcName,
@@ -111,6 +111,51 @@ func pvcObject(ns, tenant, storageClass, disk string) *corev1.PersistentVolumeCl
 	// Config.StorageClass semantics), so this branch is defensive-only.
 	pvc.Spec.StorageClassName = &storageClass
 	return pvc
+}
+
+// parseDiskQuantity resolves a caller-supplied disk size into a valid K8s
+// resource.Quantity, never panicking regardless of what the caller sent
+// (#973: an incus-style "50GB" — the CLI's own default — reached
+// resource.MustParse and killed the daemon; this is the CreateContainer
+// request path, so a bad string is remote-triggerable by any authenticated
+// caller). Empty defaults to defaultDisk. A valid K8s quantity ("20Gi")
+// passes straight through. An incus-style quantity (two-letter GB/MB/KB/...
+// suffix, decimal scale) is normalized to the K8s single-letter equivalent
+// (same decimal scale, so this is a straight rewrite, not a unit
+// conversion) and reparsed. Anything else — including total garbage —
+// degrades to defaultDisk with a log line, mirroring resourceRequirements'
+// lenient handling of invalid CPU/Memory strings elsewhere in this file.
+func parseDiskQuantity(disk string) resource.Quantity {
+	if disk == "" {
+		disk = defaultDisk
+	}
+	if q, err := resource.ParseQuantity(disk); err == nil {
+		return q
+	}
+	if normalized, ok := normalizeIncusDiskSuffix(disk); ok {
+		if q, err := resource.ParseQuantity(normalized); err == nil {
+			return q
+		}
+	}
+	log.Printf("[k8s] invalid disk quantity %q; falling back to default %q", disk, defaultDisk)
+	// defaultDisk is a package constant known to be a valid quantity, so
+	// MustParse here can't panic on caller input.
+	return resource.MustParse(defaultDisk)
+}
+
+// normalizeIncusDiskSuffix rewrites an incus-style two-letter decimal size
+// suffix (KB/MB/GB/TB/PB/EB) into the single-letter K8s equivalent
+// (K/M/G/T/P/E). Incus's GB etc. are decimal (10^3-scaled), matching K8s's
+// unsuffixed-i letters exactly, so no scale conversion is needed — just the
+// suffix rewrite. Returns ok=false when disk doesn't end in one of these
+// suffixes (e.g. it's already a K8s quantity, or garbage).
+func normalizeIncusDiskSuffix(disk string) (normalized string, ok bool) {
+	for _, suf := range []string{"KB", "MB", "GB", "TB", "PB", "EB"} {
+		if strings.HasSuffix(disk, suf) {
+			return strings.TrimSuffix(disk, suf) + suf[:1], true
+		}
+	}
+	return "", false
 }
 
 func int64p(i int64) *int64 { return &i }


### PR DESCRIPTION
## Bug

On the k8s runtime, `containarium create <box>` with the CLI's own default
disk size (`50GB`, incus-style) panicked the entire daemon:

```
panic: cannot parse '50GB': quantities must match the regular expression ...
k8s.io/apimachinery/pkg/api/resource.MustParse
github.com/footprintai/containarium/pkg/core/box/k8s.pvcObject (objects.go:92)
```

Any authenticated caller could kill the daemon with a single `CreateContainer`
request — a remote-DoS class bug, since `pvcObject` is on the request path.

## Root cause

`pvcObject` (`pkg/core/box/k8s/objects.go`) called `resource.MustParse(disk)`
directly on the raw, caller-supplied disk string. `resourceRequirements` in
the same file already handles invalid CPU/Memory quantities leniently (parse,
skip on error, fall back to the default floor) — disk was the one path that
panicked on bad input instead of degrading gracefully.

## Fix

Added `parseDiskQuantity`, used by `pvcObject` instead of the raw
`MustParse`:

1. Try `resource.ParseQuantity(disk)` — a well-formed K8s quantity (e.g.
   `"10Gi"`) passes straight through.
2. On failure, try a trivial incus -> K8s suffix rewrite: incus's two-letter
   decimal suffixes (`KB`/`MB`/`GB`/`TB`/`PB`/`EB`) map 1:1 to K8s's
   single-letter decimal suffixes (`K`/`M`/`G`/`T`/`P`/`E`) — same scale, so
   it's a string rewrite, not a unit conversion — and reparse.
3. If it's still unparseable (garbage input), log a line and fall back to
   the package's existing `defaultDisk` constant, mirroring the lenient
   pattern `resourceRequirements` already uses for CPU/Memory.

Also audited the rest of `pkg/core/box/k8s` for the same
`MustParse`-on-unvalidated-input pattern. The other `MustParse` calls in
`resourceRequirements` operate on values that are either pre-validated via
`ParseQuantity` in `newBackend` (the resolved memory defaults) or built from
`fmt.Sprintf("%d", gpuCount)` on an `int` (always parseable) — so they are
not reachable with unvalidated caller input and were left as-is.

## Tests

Added to `pkg/core/box/k8s/k8s_test.go` (build-tagged `k8s`, matching this
package's existing test convention):

- `TestParseDiskQuantityValidK8s` — a valid K8s quantity (`"10Gi"`) passes
  through unchanged.
- `TestParseDiskQuantityIncusStyle` — an incus-style quantity (`"50GB"`)
  normalizes to `"50G"`.
- `TestParseDiskQuantityGarbageFallsBackToDefault` — garbage input
  (`"not-a-size"`) falls back to `defaultDisk` without panicking (the direct
  regression test for #973).
- `TestPVCObjectBuilderIncusStyleDisk` — exercises `pvcObject` itself (the
  actual `CreateContainer` path that panicked) with an incus-style disk
  string end-to-end.

## Verification

```
go build ./...
go test -tags k8s ./pkg/core/box/k8s/...
```

Both pass; the full existing `k8s` package test suite (PVC lifecycle,
memory-floor, GPU resource tests, etc.) is unaffected.

Fixes #973
