### PR TITLE
fix(k8s): mount data PVC at /home/agent/workspace, not over /home/agent

### DIFF
--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -580,8 +580,10 @@ env-agnostic `pkg/core/box/k8s.Config` — so `pkg/core` reads no environment.
 
 ### CSI persistent storage (#841 / #844)
 
-Each box optionally gets a `PersistentVolumeClaim` for its home directory
-(`/home/agent`). Controlled by `CONTAINARIUM_K8S_STORAGE_CLASS`:
+Each box optionally gets a `PersistentVolumeClaim` for a persistent working
+directory, mounted at **`/home/agent/workspace`** — a subdirectory of the
+image's home directory, not the home directory itself. Controlled by
+`CONTAINARIUM_K8S_STORAGE_CLASS`:
 
 - **Empty (default):** no PVC; namespace is deleted on `Delete` (original
   behavior, backward-compatible).
@@ -598,6 +600,33 @@ CSI-managed (GKE, EKS, or kind local-path) and outlives any compute node.
 
 Disk size is read from `BoxSpec.Resources.Disk` (e.g., `"20Gi"`); defaults to
 `10Gi` when unset.
+
+**Mount path is `/home/agent/workspace`, not `/home/agent` (#974).** An
+earlier revision mounted the PVC directly over `/home/agent`. That replaced
+the box image's real home directory with the provisioner's fresh volume
+root — 0777 root:root on kind/local-path, 0755 root:root on a typical CSI
+ext4 root — either of which broke SSH: dropbear's strict `modes` check
+rejects a group/world-writable home directory outright, and a 0755
+root:root root additionally leaves uid-1000 `agent` unable to write (or in
+some cases even read) its own home. Every login to a storage-backed box
+failed with `Permission denied (publickey)` even though the
+`authorized_keys` Secret was mounted and matched the client key. Neither the
+unit tests nor the kind e2e caught it because they asserted the PVC existed
+and was mounted, never that SSH auth actually succeeded afterward.
+
+The fix mounts the PVC one level down, at `/home/agent/workspace`, leaving
+`/home/agent` itself exactly as the image built it — owned by `agent`,
+dropbear-compatible permissions, with the `authorized_keys` Secret layered
+in via its own separate volume mount (unaffected by this change either way).
+
+**Data-contract change:** before #974, the *entire* home directory persisted
+across box recreation on storage-backed boxes. After #974, only
+`/home/agent/workspace` persists — files written elsewhere under
+`/home/agent` (e.g. shell rc files, caches outside the workspace dir) reset
+to the image defaults on recreate, the same as on non-storage-backed boxes.
+Agents and tooling that assumed the whole home directory was durable on K8s
+storage-backed boxes should keep persistent state under
+`/home/agent/workspace`.
 
 ### GPU resource requests (#845)
 

--- a/pkg/core/box/k8s/e2e_test.go
+++ b/pkg/core/box/k8s/e2e_test.go
@@ -196,6 +196,21 @@ func TestE2E_GatewayPipe(t *testing.T) {
 // The PVC stays in Pending until a pod is scheduled (local-path binds on pod
 // assignment); we assert the object exists, not that it is Bound — the mount
 // wiring is what matters for storage correctness.
+//
+// It also guards against #974 regressing: the data volume must land at
+// dataMount (a subdirectory of the home directory), never directly at
+// /home/agent — mounting the PVC over the home directory itself replaces the
+// box image's real home (dropbear-strict-modes-compatible ownership/perms)
+// with the provisioner's fresh volume root, which dropbear's strict `modes`
+// check rejects (kind/local-path: 0777 root:root) or which locks uid-1000
+// `agent` out of its own home entirely (a typical CSI ext4 root: 0755
+// root:root) — either way every SSH login fails. This test uses the
+// shell-less `pause` image, so it cannot drive an actual SSH login or stat
+// the mounted directory's live permissions against a real apiserver; that
+// finer-grained check (mount path is a home subdirectory, authorized_keys
+// mount unaffected) is covered by the unit-level
+// TestDataMountDoesNotOverrideHomeDirectory in k8s_test.go, which runs
+// without a cluster.
 func TestE2E_CSIStorage(t *testing.T) {
 	if os.Getenv("CONTAINARIUM_K8S_E2E") == "" {
 		t.Skip("set CONTAINARIUM_K8S_E2E=1 (and KUBECONFIG) to run the kind e2e")
@@ -226,7 +241,8 @@ func TestE2E_CSIStorage(t *testing.T) {
 	ns := "tenant-csi-e2e"
 	t.Cleanup(func() { _ = b.Purge(context.Background(), ref) })
 
-	// Create: PVC provisioned, StatefulSet mounts it at /home/agent.
+	// Create: PVC provisioned, Sandbox pod template mounts it at dataMount
+	// (/home/agent/workspace — not directly over /home/agent, see #974).
 	if _, err := b.Create(ctx, box.BoxSpec{
 		Ref:       ref,
 		Image:     "registry.k8s.io/pause:3.9",
@@ -261,6 +277,9 @@ func TestE2E_CSIStorage(t *testing.T) {
 	}
 	if mounts[dataMount] == "" {
 		t.Errorf("data volume not mounted at %s; mounts: %v", dataMount, mounts)
+	}
+	if _, ok := mounts["/home/agent"]; ok {
+		t.Errorf("data volume mounted directly at /home/agent — this overrides the image's home directory and breaks dropbear strict modes (#974); mounts: %v", mounts)
 	}
 
 	// Delete: compute objects removed; namespace + PVC retained so data survives a node reap.

--- a/pkg/core/box/k8s/k8s_test.go
+++ b/pkg/core/box/k8s/k8s_test.go
@@ -4,6 +4,7 @@ package k8s
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -451,9 +452,10 @@ func TestCreateProvisionsPVC(t *testing.T) {
 		t.Errorf("storage request = %q, want 30Gi", q.String())
 	}
 
-	// The Sandbox pod template must mount the data volume at /home/agent as a
-	// plain persistentVolumeClaim volume (NOT a volumeClaimTemplate, which the
-	// controller would owner-reference and GC with the Sandbox).
+	// The Sandbox pod template must mount the data volume at
+	// /home/agent/workspace as a plain persistentVolumeClaim volume (NOT a
+	// volumeClaimTemplate, which the controller would owner-reference and GC
+	// with the Sandbox).
 	sb := getSandbox(t, sc, ns)
 	if len(sb.Spec.VolumeClaimTemplates) != 0 {
 		t.Errorf("sandbox uses volumeClaimTemplates; the data PVC must stay daemon-owned")
@@ -473,6 +475,66 @@ func TestCreateProvisionsPVC(t *testing.T) {
 	}
 	if len(claims) != 1 || claims[0] != pvcName {
 		t.Errorf("pod volumes reference claims %v, want [%s]", claims, pvcName)
+	}
+}
+
+// TestDataMountDoesNotOverrideHomeDirectory is a regression test for #974:
+// the data PVC must never be mounted directly at /home/agent, because that
+// replaces the image's real home directory (owned by `agent`,
+// dropbear-strict-modes-compatible permissions) with the provisioner's fresh
+// volume root — typically root:root and group/world-writable or otherwise
+// wrong for the non-root `agent` user — which makes dropbear reject every
+// SSH login outright. The PVC must land one level down, at a subdirectory of
+// the home directory, so the home directory itself is untouched. It also
+// confirms the authorized_keys Secret mount (dropbear's login credential
+// source) is unaffected: same path, still read-only, still a Secret volume.
+func TestDataMountDoesNotOverrideHomeDirectory(t *testing.T) {
+	if dataMount == "/home/agent" {
+		t.Fatalf("dataMount = %q, must not be the home directory itself (#974)", dataMount)
+	}
+	if !strings.HasPrefix(dataMount, "/home/agent/") {
+		t.Fatalf("dataMount = %q, want a subdirectory of /home/agent", dataMount)
+	}
+
+	b, cs, sc := testBackendWithStorage()
+	ctx := context.Background()
+	ref := box.BoxRef{Tenant: "ivy"}
+	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref, Image: "x"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	_ = cs
+
+	sb := getSandbox(t, sc, "tenant-ivy")
+	container := sb.Spec.PodTemplate.Spec.Containers[0]
+
+	var dataMountFound, homeMountFound, authKeysFound bool
+	for _, m := range container.VolumeMounts {
+		switch m.MountPath {
+		case dataMount:
+			dataMountFound = true
+			if m.Name != dataVolume {
+				t.Errorf("mount at %s uses volume %q, want %q", dataMount, m.Name, dataVolume)
+			}
+		case "/home/agent":
+			homeMountFound = true
+		case authorizedKeysMount:
+			authKeysFound = true
+			if !m.ReadOnly {
+				t.Errorf("authorized_keys mount at %s is writable, want read-only", authorizedKeysMount)
+			}
+			if m.Name != authorizedKeysVolume {
+				t.Errorf("authorized_keys mount uses volume %q, want %q", m.Name, authorizedKeysVolume)
+			}
+		}
+	}
+	if !dataMountFound {
+		t.Errorf("no volume mount found at dataMount (%s)", dataMount)
+	}
+	if homeMountFound {
+		t.Errorf("a volume is mounted directly at /home/agent — this overrides the image's home directory and breaks dropbear strict modes (#974)")
+	}
+	if !authKeysFound {
+		t.Errorf("authorized_keys Secret mount at %s missing — unaffected by the data-PVC mount path change", authorizedKeysMount)
 	}
 }
 

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -20,15 +20,29 @@ const (
 	sshPortName = "ssh"
 
 	// pvcName is the PersistentVolumeClaim name inside the tenant namespace.
-	// It holds the box's persistent data (home directory). Owned by the daemon,
-	// NOT declared via the Sandbox's volumeClaimTemplates: template-derived PVCs
-	// are owner-referenced to the Sandbox and garbage-collected with it, which
-	// would break delete-retains-data. Created before the Sandbox, mounted as a
-	// plain persistentVolumeClaim volume, retained on Delete; removed only by
-	// Purge.
-	pvcName     = "data"
-	dataMount   = "/home/agent"
-	dataVolume  = "data"
+	// It holds the box's persistent data, mounted at dataMount below. Owned by
+	// the daemon, NOT declared via the Sandbox's volumeClaimTemplates:
+	// template-derived PVCs are owner-referenced to the Sandbox and
+	// garbage-collected with it, which would break delete-retains-data.
+	// Created before the Sandbox, mounted as a plain persistentVolumeClaim
+	// volume, retained on Delete; removed only by Purge.
+	pvcName    = "data"
+	dataVolume = "data"
+	// dataMount is a subdirectory of the home directory, NOT the home
+	// directory itself (#974). Mounting the PVC directly at /home/agent
+	// replaces the image's real home with the provisioner's fresh volume
+	// root — typically 0777 root:root (kind/local-path) or 0755 root:root
+	// (a typical CSI ext4 root) — either of which either fails dropbear's
+	// strict-modes home-directory check (group/world-writable) or leaves
+	// uid-1000 `agent` unable to write its own home at all. Mounting one
+	// level down keeps /home/agent itself exactly as the image built it
+	// (owned by `agent`, dropbear-compatible perms, authorized_keys layered
+	// in via a separate Secret mount) while still giving the box a
+	// persistent, per-tenant working directory. Trade-off: only this
+	// subdirectory survives box recreation now, not the whole home — see
+	// the CSI persistent storage section in
+	// docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md.
+	dataMount   = "/home/agent/workspace"
 	defaultDisk = "10Gi"
 
 	// Default per-box memory bounds, applied when a box's spec carries no valid

--- a/pkg/core/box/k8s/sandbox.go
+++ b/pkg/core/box/k8s/sandbox.go
@@ -19,10 +19,12 @@ import (
 // AutoStart maps onto spec.operatingMode: Running creates the pod immediately,
 // Suspended parks the Sandbox with no pod (the CR-native form of the old
 // replicas=0). withPVC mounts the daemon-owned data PVC at dataMount
-// (/home/agent) as a plain persistentVolumeClaim volume — deliberately not a
-// volumeClaimTemplate, which the controller would owner-reference and GC on
-// Sandbox deletion, breaking delete-retains-data. def is the resolved default
-// memory floor applied when the spec sets no explicit memory.
+// (/home/agent/workspace — a subdirectory of the home dir, not the home dir
+// itself; see the dataMount doc comment in objects.go for why, #974) as a
+// plain persistentVolumeClaim volume — deliberately not a volumeClaimTemplate,
+// which the controller would owner-reference and GC on Sandbox deletion,
+// breaking delete-retains-data. def is the resolved default memory floor
+// applied when the spec sets no explicit memory.
 func sandboxObject(ns string, spec box.BoxSpec, withPVC bool, def memDefaults) *sandboxv1beta1.Sandbox {
 	labels := boxLabels(spec.Ref.Tenant)
 


### PR DESCRIPTION
## Bug

On the K8s runtime with a StorageClass configured (`CONTAINARIUM_K8S_STORAGE_CLASS`), every SSH login to a storage-backed box was rejected with `Permission denied (publickey)`, even though the `authorized_keys` Secret was correctly mounted and matched the client key.

Root cause: the data PVC was mounted directly at `/home/agent`, replacing the box image's home directory with the provisioner's fresh volume root — owned `root:root` with provisioner-dependent permissions (`0777` on kind/local-path). dropbear's strict `modes` check rejects a group/world-writable home directory, so auth always failed. On provisioners that instead create `0755 root:root` roots (a typical CSI ext4 root), uid-1000 `agent` additionally can't write (or in some cases read) its own home at all.

Neither the unit tests nor the kind e2e caught it: `TestE2E_CSIStorage` asserted the PVC existed and was mounted but never authenticated over SSH, and `TestE2E_BoxLifecycle` runs without a StorageClass configured at all.

## Fix

Mount the PVC one level down, at **`/home/agent/workspace`**, instead of directly at `/home/agent`. This keeps the box image's actual home directory — its dropbear-compatible ownership/permissions, and the separate `authorized_keys` Secret volume mount — completely untouched, while still giving the box a persistent, per-tenant working directory under the home tree (matching what an agent user would expect over SSH).

Changed:
- `pkg/core/box/k8s/objects.go` — `dataMount` constant: `/home/agent` → `/home/agent/workspace`, with an expanded doc comment explaining why.
- `pkg/core/box/k8s/sandbox.go` — doc comment update (mount path only; the mount-building code itself needed no change beyond the constant).
- `pkg/core/box/k8s/k8s_test.go` — new regression test `TestDataMountDoesNotOverrideHomeDirectory` asserting the data volume never lands directly on `/home/agent` and that the `authorized_keys` mount is unaffected (same path, still read-only, still backed by its Secret volume).
- `pkg/core/box/k8s/e2e_test.go` — `TestE2E_CSIStorage` gets the same "not directly on /home/agent" assertion against a real apiserver, plus an updated doc comment.
- `docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md` — CSI persistent storage section updated to describe the new mount path and explain the bug this fixes.

## Heads-up for reviewers: data-contract change

Before this fix, the **entire home directory** persisted across box recreation on storage-backed K8s boxes (that was the intent, just broken by the mount path). After this fix, **only `/home/agent/workspace` persists** — files written elsewhere under `/home/agent` (shell rc files, caches outside the workspace dir, etc.) reset to the image defaults on recreate, same as non-storage-backed boxes. Anything that assumed the whole home directory was durable on K8s storage-backed boxes should keep persistent state under `/home/agent/workspace` going forward. This is called out explicitly in the design doc.

## Testing

- `go build ./...` — clean.
- `go test -tags k8s ./pkg/core/box/k8s/...` — passes, including the new regression test.
- `go test ./...` — passes except two pre-existing, unrelated failures in `test/integration` that require a live gRPC server on `localhost:50051` (not present in this sandbox; unrelated to this change).
- The kind e2e (`TestE2E_CSIStorage`, gated on `CONTAINARIUM_K8S_E2E=1` + a live kind cluster) was not run live — kind can't run nested in this sandbox — but was updated with the same regression assertion and reviewed for correctness against the fake-clientset unit test's equivalent.
- A true live-SSH-auth check wasn't feasible in either suite (fake clientset has no real filesystem; the e2e's `pause` image has no shell to stat live permissions), so the fix is locked down at the mount-path level instead, per the issue's own suggested fallback.

Fixes #974