### PR TITLE
fix(zap): fail fast instead of a 120s timeout when ZAP isn't installed (#960)

### DIFF
--- a/docs/ZAP-INSTALL-RUNBOOK.md
+++ b/docs/ZAP-INSTALL-RUNBOOK.md
@@ -1,0 +1,74 @@
+# ZAP install — per-host setup and how to detect a missed one (#960)
+
+OWASP ZAP (the DAST scanner behind `security_scan --kind=zap`) is **not**
+bundled with the daemon and is **not** installed automatically. Each host
+that should run ZAP scans needs an explicit, one-time `InstallZap` call
+against that host's daemon — there is no fleet-wide default-on install.
+
+## Why this is a separate step
+
+`InstallZap` downloads a multi-hundred-MB release from
+`github.com/zaproxy/zaproxy`, installs a JRE if missing, and extracts it into
+`/opt/zap` inside the host's security container (`containarium-core-security`,
+see `internal/zap/installer.go`). That's a meaningful amount of work and
+external network I/O to run unconditionally on every daemon boot, so it's
+gated behind an admin-triggered call instead.
+
+## Symptom of a missed install (fixed in #960)
+
+Before #960, a host where `InstallZap` was never run would fail ZAP scan
+jobs silently and repeatedly: `EnsureDaemonRunning` tried to start
+`zap.sh` regardless of whether it existed. Because the start command is
+backgrounded (`&`) inside `bash -c` via `incus exec`, the "command not
+found" only landed in a log file inside the container — `incus exec`
+itself still exited 0. The readiness loop then polled for the full 120
+seconds before giving up with a generic timeout, indistinguishable from a
+genuinely slow-starting daemon, and this repeated on every subsequent scan
+job forever (no code path ever installed ZAP on its own).
+
+As of #960, `EnsureDaemonRunning` checks installation status first and
+fails immediately with a clear "ZAP is not installed" error instead. That
+turns the symptom from "mysterious 120s timeouts in the logs, forever"
+into an unambiguous, fast error — but you still have to notice it and run
+the install.
+
+## Detecting an uninstalled host proactively
+
+Don't wait for a scan job to fail. Check before it matters:
+
+```bash
+# CLI — exit code / message tells you directly
+containarium zap-install
+# → "ZAP install OK: ..." (freshly installed) or
+#   "ZAP install OK: ZAP is already installed and active" (no-op, safe to re-run)
+```
+
+Or read status without mutating anything, via `GET /v1/zap/config`
+(`zap_available` in the response) — this is what
+`Manager.ZapAvailable()` / `Scanner.Available()` report, and what the
+webui's ZAP panel and `security_scan`'s preconditions are backed by.
+
+Run this check as part of onboarding any new host into the fleet, right
+alongside the sentinel-auth-secret and other per-host setup steps (see
+[SENTINEL-AUTH-SECRET.md](./SENTINEL-AUTH-SECRET.md) for that pattern) —
+"add a host" checklists should include "confirm `zap_available: true`" the
+same way they include "confirm the sentinel secret is provisioned."
+
+## Installing
+
+```bash
+export CONTAINARIUM_SERVER_URL=http://localhost:8080   # or your daemon's address
+export CONTAINARIUM_JWT_TOKEN=<admin-scoped JWT>        # RequireRole(RoleAdmin)
+
+containarium zap-install
+```
+
+This calls the same underlying Go function (`ZapServer.InstallZap` →
+`Installer.InstallZap`) that the `install_zap` MCP tool and the raw
+`POST /v1/zap/install` REST endpoint use — one code path, three surfaces,
+per this repo's CLI-first convention. It's idempotent: running it again on
+an already-installed host reports success without redoing the download.
+
+Expect the download + extract step to take on the order of a minute or two
+depending on the host's network link to GitHub — this is a one-time cost
+per host, not per scan.

--- a/internal/cmd/security.go
+++ b/internal/cmd/security.go
@@ -83,6 +83,28 @@ product's hosted security-patch agent territory.`,
 	RunE: runSecurityRemediate,
 }
 
+// --- containarium zap-install -----------------------------------------------
+
+var zapInstallCmd = &cobra.Command{
+	Use:   "zap-install",
+	Short: "Install OWASP ZAP into this host's security container",
+	Long: `Downloads and installs OWASP ZAP into the daemon host's security
+container. Admin-only, one-time-per-host setup step.
+
+Without this having been run, ZAP scan jobs on this host fail — since
+#960, that's now a fast, clear "ZAP is not installed" error rather than
+the old failure mode: every attempt silently backgrounding a "command
+not found" and burning a full 120-second readiness poll before timing
+out, forever, on every subsequent scan.
+
+Takes no arguments: a daemon manages exactly one security container, so
+there's no per-container or per-host identifier to pass. Safe to run
+again on an already-installed host — it reports "already installed"
+instead of erroring.`,
+	Args: cobra.NoArgs,
+	RunE: runZapInstall,
+}
+
 func init() {
 	rootCmd.AddCommand(securityScanCmd)
 	securityScanCmd.Flags().StringVar(&scanKind, "kind", "all", "clamav | pentest | zap | all")
@@ -91,6 +113,29 @@ func init() {
 	securityFindingsCmd.Flags().StringVar(&findKind, "kind", "all", "clamav | pentest | zap | all")
 
 	rootCmd.AddCommand(securityRemediateCmd)
+
+	rootCmd.AddCommand(zapInstallCmd)
+}
+
+// runZapInstall dispatches through the same mcp.Client.InstallZap call
+// the install_zap MCP tool uses — one Go function, two surfaces, per
+// CLAUDE.md's CLI-first convention. Previously the only way to trigger
+// InstallZap was a raw authenticated REST call (#960).
+func runZapInstall(_ *cobra.Command, _ []string) error {
+	c, err := newSecurityClient()
+	if err != nil {
+		return err
+	}
+	resp, err := c.InstallZap()
+	if err != nil {
+		return err
+	}
+	if !resp.Success {
+		fmt.Printf("ZAP install FAILED: %s\n", resp.Message)
+		return fmt.Errorf("zap install reported failure")
+	}
+	fmt.Printf("ZAP install OK: %s\n", resp.Message)
+	return nil
 }
 
 // runSecurityScan dispatches the scan via the same Go code path the

--- a/internal/mcp/backend.go
+++ b/internal/mcp/backend.go
@@ -83,6 +83,10 @@ type API interface {
 	DebugContainer(username string) (*DebugContainerResponse, error)
 	TriggerUpgrade(backendID string, force bool) (*TriggerUpgradeResponse, error)
 	GetUpgradeStatus(upgradeID string) (*UpgradeStatusResponse, error)
+	// InstallZap downloads and installs OWASP ZAP into this host's
+	// security container. Host-level — a daemon manages exactly one
+	// security container, so there's no per-tenant scoping.
+	InstallZap() (*InstallZapResponse, error)
 
 	// Transport-level escape hatches used by handlers that issue a raw
 	// request (compose, move, connect) or need the effective token (scope
@@ -137,6 +141,10 @@ func (cloudClient) TriggerUpgrade(string, bool) (*TriggerUpgradeResponse, error)
 
 func (cloudClient) GetUpgradeStatus(string) (*UpgradeStatusResponse, error) {
 	return nil, errUnsupportedOnCloud("get_upgrade_status", "")
+}
+
+func (cloudClient) InstallZap() (*InstallZapResponse, error) {
+	return nil, errUnsupportedOnCloud("install_zap", "the platform provisions ZAP on managed hosts")
 }
 
 // newBackend builds the API the handlers use, classifying the target from the

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1357,6 +1357,25 @@ func (c *Client) RemediateSecurityFinding(findingID int64) (*SecurityRemediateRe
 	return &resp, nil
 }
 
+// InstallZap calls the daemon's InstallZap RPC, which downloads and
+// installs OWASP ZAP into the host's security container. Admin-only on
+// the daemon side (RequireRole(RoleAdmin)); this is the one Go call both
+// the `containarium zap-install` CLI subcommand and the install_zap MCP
+// tool go through, per this repo's CLI-first convention. Host-level —
+// there is no per-container scoping, since each daemon manages exactly
+// one security container.
+func (c *Client) InstallZap() (*InstallZapResponse, error) {
+	body, err := c.doRequest("POST", "/v1/zap/install", struct{}{})
+	if err != nil {
+		return nil, err
+	}
+	var resp InstallZapResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse install response: %w", err)
+	}
+	return &resp, nil
+}
+
 // API Request/Response types
 
 type CreateContainerRequest struct {

--- a/internal/mcp/security.go
+++ b/internal/mcp/security.go
@@ -52,6 +52,12 @@ type SecurityRemediateResponse struct {
 	NewVersion  string `json:"newVersion,omitempty"`
 }
 
+// InstallZapResponse mirrors the daemon's InstallZapResponse.
+type InstallZapResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
 // --- MCP handlers ----------------------------------------------------------
 
 // handleSecurityScan triggers one or more scanners against a container.
@@ -130,6 +136,20 @@ func handleSecurityRemediate(client API, args map[string]interface{}) (string, e
 	resp, err := client.RemediateSecurityFinding(fid)
 	if err != nil {
 		return "", fmt.Errorf("remediate: %w", err)
+	}
+	out, _ := json.MarshalIndent(resp, "", "  ")
+	return string(out), nil
+}
+
+// handleInstallZap downloads and installs OWASP ZAP into this host's
+// security container. Admin-only operator action — see #960: without
+// this having been run at least once, every ZAP scan job on the host
+// fails fast with a clear "not installed" error (rather than the old
+// behavior of silently retrying forever with a generic 120s timeout).
+func handleInstallZap(client API, _ map[string]interface{}) (string, error) {
+	resp, err := client.InstallZap()
+	if err != nil {
+		return "", fmt.Errorf("install zap: %w", err)
 	}
 	out, _ := json.MarshalIndent(resp, "", "  ")
 	return string(out), nil

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,8 +22,8 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route.
-	assert.Len(t, server.tools, 55, "Should have 55 tools registered")
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960).
+	assert.Len(t, server.tools, 56, "Should have 56 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -127,8 +127,8 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route.
-	assert.Len(t, tools, 55)
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960).
+	assert.Len(t, tools, 56)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -839,6 +839,24 @@ func (s *Server) registerTools() {
 			Handler: handleSecurityRemediate,
 		},
 		{
+			Name: "install_zap",
+			Description: "Download and install OWASP ZAP into this host's security container. " +
+				"Admin-only, one-time-per-host setup — `security_scan` (kind=zap) and the " +
+				"scheduled ZAP scan cycle both require this to have been run at least once.\n\n" +
+				"Without it, every ZAP scan job on an uninstalled host used to fail after a " +
+				"generic 120-second timeout, indistinguishable from a slow daemon start, and " +
+				"repeat forever on every subsequent scan (#960) — this call is what closes " +
+				"that gap. Safe to call again on an already-installed host; it reports " +
+				"'already installed' instead of erroring.\n\n" +
+				"Takes no arguments — a daemon manages exactly one security container, so " +
+				"there's no per-container or per-host identifier to pass.",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+			Handler: handleInstallZap,
+		},
+		{
 			Name: "sync_ssh_config",
 			Description: "Generate a self-contained ssh_config covering every reachable container " +
 				"and write it to ~/.containarium/ssh_config. After this call, `ssh <username>` " +
@@ -1278,6 +1296,10 @@ func toolScopeAssignments() map[string]string {
 		"security_scan":      auth.ScopeSecurityWrite,
 		"security_remediate": auth.ScopeSecurityWrite,
 		"security_findings":  auth.ScopeSecurityRead,
+		// install_zap is admin-only (the daemon also enforces
+		// RoleAdmin server-side); scope-gated the same as the other
+		// security-write tools at the MCP layer.
+		"install_zap": auth.ScopeSecurityWrite,
 		// developer-loop tools
 		"push":            auth.ScopeCodeWrite,
 		"sync":            auth.ScopeCodeWrite,

--- a/internal/zap/scanner_test.go
+++ b/internal/zap/scanner_test.go
@@ -1,0 +1,54 @@
+package zap
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestEnsureDaemonRunning_FailsFastWhenNotInstalled locks down the fix for
+// #960: EnsureDaemonRunning must check Scanner.Available() (which delegates
+// to Installer.IsInstalled(), an `incus exec ... test -x .../zap.sh` shell
+// call) before attempting to start the daemon, and return immediately with
+// a clear error instead of backgrounding a doomed start command and burning
+// the full 120-second readiness poll.
+//
+// No incus daemon or security container exists in the CI/test environment,
+// so IsInstalled() naturally reports "not installed" here (the underlying
+// `incus` binary is either absent or the container doesn't exist) — this
+// exercises the real code path end to end rather than mocking it.
+func TestEnsureDaemonRunning_FailsFastWhenNotInstalled(t *testing.T) {
+	s := NewScanner()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err := s.EnsureDaemonRunning(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error when ZAP is not installed, got nil")
+	}
+	if !strings.Contains(err.Error(), "not installed") {
+		t.Errorf("expected a clear 'not installed' error, got: %v", err)
+	}
+	// The old behavior polled for up to 120 seconds before giving up. The
+	// fail-fast check must short-circuit well before that — give it a
+	// generous ceiling (well under the old 120s timeout) so this test
+	// isn't flaky on a slow CI box, while still catching a regression back
+	// to the old poll-for-120-seconds behavior.
+	if elapsed >= 10*time.Second {
+		t.Errorf("EnsureDaemonRunning took %s — expected a fast failure, not a slow poll", elapsed)
+	}
+}
+
+// TestScanner_Available mirrors the same not-installed path via the public
+// Available() accessor, which EnsureDaemonRunning calls first.
+func TestScanner_Available(t *testing.T) {
+	s := NewScanner()
+	if s.Available() {
+		t.Skip("ZAP appears to be installed in this environment; not-installed path can't be exercised here")
+	}
+}


### PR DESCRIPTION
## Summary

Issue #960 reported that on a host where ZAP was never installed (`InstallZap` is a separate, admin-triggered RPC that has to be run per host), every ZAP scan job retried forever with an indistinguishable generic timeout:

- `EnsureDaemonRunning` unconditionally tried to start `zap.sh` without first checking whether it was installed.
- The start command is backgrounded (`&`) inside `bash -c` via `incus exec`, so `incus exec` exits 0 even when `zap.sh` doesn't exist — the "command not found" only lands in a log file inside the container, invisible to the Go code.
- The readiness loop then polled for the full 120 seconds before giving up with a generic timeout message, repeating on every subsequent scan job forever (nothing in that path ever installs ZAP).

**The core fix (fail fast via `Scanner.Available()` → `Installer.IsInstalled()` before attempting to start the daemon) already landed on `main` in #961.** This PR closes the remaining gaps #960 tracked and adds the missing regression test:

- **Primary / regression coverage**: added `internal/zap/scanner_test.go`, asserting `EnsureDaemonRunning` returns a fast, clear "ZAP is not installed" error rather than the old 120-second poll. No incus daemon or security container exists in CI, so `IsInstalled()` naturally reports not-installed — this exercises the real code path rather than mocking it. (`0.01s` per the test run, vs. the old worst case of 120s.)

- **Secondary (CLI-first convention)**: `InstallZap` (`POST /v1/zap/install`) had no `containarium <verb>` subcommand — the only way to trigger it was a raw authenticated REST call, which the repo's CLAUDE.md flags as an anti-pattern. Added:
  - `containarium zap-install` cobra subcommand (`internal/cmd/security.go`), matching the existing `security-scan` / `security-findings` / `security-remediate` pattern.
  - `install_zap` MCP tool (`internal/mcp/tools.go`), wired through the same `API` interface / `cloudClient` host-level-op pattern already used for `get_system_info`, `upgrade_backend`, etc. (returns "not available on the hosted control plane" on cloud, since installing a system tool on a specific host has no tenant-safe meaning there).
  - `Client.InstallZap()` (`internal/mcp/client.go`) is the single Go call both the CLI and the MCP tool go through.

- **Tertiary (operator runbook)**: added `docs/ZAP-INSTALL-RUNBOOK.md`, in the style of `docs/SENTINEL-AUTH-SECRET.md`, explaining that ZAP requires an explicit per-host install and how to check `zap_available` (via `GET /v1/zap/config` or `containarium zap-install`) proactively instead of waiting for a scan job to fail.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/zap/...` — new regression test passes in `0.01s`
- [x] `go test ./internal/mcp/...` — updated the two tool-count assertions (55 → 56) for the new `install_zap` tool
- [x] `go test ./internal/cmd/...`, `go test ./internal/server/...`
- [x] `go vet ./...`

Fixes #960