### PR TITLE
docs(k8s): EKS/GKE reference architecture — run agent boxes on managed Kubernetes

### DIFF
--- a/charts/containarium-k8s/templates/sshpiper-service.yaml
+++ b/charts/containarium-k8s/templates/sshpiper-service.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: {{ .Values.gateway.namespace }}
   labels:
     {{- include "containarium-k8s.labels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
+  {{- $svcAnnotations := mustMergeOverwrite (deepCopy (.Values.commonAnnotations | default dict)) (.Values.gateway.service.annotations | default dict) }}
+  {{- with $svcAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/containarium-k8s/values-eks.yaml
+++ b/charts/containarium-k8s/values-eks.yaml
@@ -1,0 +1,31 @@
+# Values preset for EKS (managed Kubernetes on AWS).
+#
+# Runs the whole agent-box stack on managed nodes, fronted by an AWS Network
+# Load Balancer — no sentinel, no bare-metal. The cluster's own control plane,
+# node autoscaling (managed node groups / Karpenter), and EBS provisioning are
+# the shared infra; Containarium is the access + lifecycle layer on top.
+#
+#   helm install containarium ./charts/containarium-k8s \
+#     -f charts/containarium-k8s/values-eks.yaml \
+#     --set daemon.jwtSecret="$(openssl rand -hex 24)"
+#
+# Prereqs: an EKS cluster, the AWS Load Balancer Controller (provisions the
+# NLB from the Service annotations below), the EBS CSI driver plus a "gp3"
+# StorageClass, and the agent-sandbox controller. See docs/EKS-GKE-DEPLOY.md.
+
+gateway:
+  service:
+    # One public SSH endpoint, provisioned as an AWS Network Load Balancer via
+    # the AWS Load Balancer Controller.
+    type: LoadBalancer
+    port: 22
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: "external"
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+      # Public NLB; switch to "internal" for a VPC-private gateway.
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+
+# EBS gp3 volume for each box's workspace. Requires the EBS CSI driver and a
+# StorageClass named "gp3" (EKS does not create one by default — see the deploy
+# guide for the one-object StorageClass to apply).
+storageClass: "gp3"

--- a/charts/containarium-k8s/values-gke.yaml
+++ b/charts/containarium-k8s/values-gke.yaml
@@ -1,0 +1,30 @@
+# Values preset for GKE (managed Kubernetes on Google Cloud).
+#
+# Runs the whole agent-box stack on managed nodes, fronted by a Google Cloud
+# L4 LoadBalancer — no sentinel, no bare-metal. The cluster's own control
+# plane, node autoscaling, and disk provisioning are the shared infra;
+# Containarium is the access + lifecycle layer on top.
+#
+#   helm install containarium ./charts/containarium-k8s \
+#     -f charts/containarium-k8s/values-gke.yaml \
+#     --set daemon.jwtSecret="$(openssl rand -hex 24)"
+#
+# Prereqs: a GKE cluster (Standard or Autopilot) and the agent-sandbox
+# controller. See docs/EKS-GKE-DEPLOY.md for the full walkthrough.
+
+gateway:
+  service:
+    # One public SSH endpoint, provisioned as a Google Cloud L4 LoadBalancer.
+    type: LoadBalancer
+    port: 22
+    annotations:
+      # Regional external passthrough L4 LB (backend-service based, the modern
+      # replacement for target-pool LBs).
+      cloud.google.com/l4-rbs: "enabled"
+      # For a VPC-internal gateway instead of a public one, drop the line above
+      # and use:
+      #   networking.gke.io/load-balancer-type: "Internal"
+
+# Balanced persistent disk for each box's workspace. GKE ships this class by
+# default; use "premium-rwo" for SSD-backed disks.
+storageClass: "standard-rwo"

--- a/charts/containarium-k8s/values.yaml
+++ b/charts/containarium-k8s/values.yaml
@@ -27,11 +27,16 @@ gateway:
   # -- Deploy sshpiper as part of this chart. Set false to bring your own.
   enabled: true
   service:
-    # -- Use NodePort for kind / LoadBalancer for cloud clusters
+    # -- NodePort for kind; LoadBalancer for cloud. See values-gke.yaml /
+    # values-eks.yaml for ready-made managed-Kubernetes presets.
     type: NodePort
     port: 22
     # -- NodePort for kind (access via localhost:32022)
     nodePort: 32022
+    # -- Extra annotations for the gateway Service. This is where cloud
+    # LoadBalancer knobs go (NLB type on EKS, L4 mode / internal on GKE);
+    # merged over commonAnnotations. See the cloud value presets.
+    annotations: {}
   sshpiper:
     # -- Containarium's own gateway image (pinned upstream sshpiperd release +
     # kubernetes-plugin entrypoint), published per Containarium release by

--- a/docs/EKS-GKE-DEPLOY.md
+++ b/docs/EKS-GKE-DEPLOY.md
@@ -1,0 +1,185 @@
+# Running agent boxes on managed Kubernetes (EKS / GKE)
+
+This guide runs the whole agent-box stack — SSH-reachable, MCP-native boxes —
+on a **managed Kubernetes cluster** (Amazon EKS or Google GKE), fronted by a
+**cloud LoadBalancer**. No sentinel, no bare-metal, no LXC.
+
+The point is leverage: the cloud's managed control plane, node autoscaling, and
+disk provisioning are shared infrastructure you don't operate. Containarium is
+the thin layer on top that the cloud doesn't give you — credential-scoped
+SSH/MCP access, the gateway key choreography, per-tenant isolation, and box
+lifecycle (start / stop / suspend / TTL).
+
+## Architecture
+
+```
+                         one public SSH endpoint
+                    (cloud LoadBalancer: NLB / GCP L4)
+                                  │
+                          ┌───────▼────────┐
+                          │  sshpiper      │  routes by SSH username,
+                          │  (gateway)     │  reads Pipe CRs
+                          └───────┬────────┘
+              ┌───────────────────┼───────────────────┐
+        ┌─────▼─────┐       ┌─────▼─────┐       ┌─────▼─────┐
+        │ box (pod) │       │ box (pod) │       │ box (pod) │   Sandbox CRs,
+        │ agent-box │       │ agent-box │       │ agent-box │   one per tenant
+        │  :2222    │       │  :2222    │       │  :2222    │   (managed nodes)
+        └───────────┘       └───────────┘       └───────────┘
+              persistent workspace = cloud disk (EBS / PD)
+
+   Containarium daemon (in-cluster) programs the Pipes + key Secrets and owns
+   box lifecycle. The agent-sandbox controller turns each Sandbox CR into a pod
+   + headless Service. Everything is ordinary Kubernetes — it runs the same on
+   EKS, GKE, or kind.
+```
+
+**What is the cloud's job vs. Containarium's job**
+
+| Layer | Provided by |
+| --- | --- |
+| Control plane, node autoscaling, upgrades | EKS / GKE (managed) |
+| The one public SSH endpoint | Cloud LoadBalancer (NLB / GCP L4) |
+| Per-box persistent workspace | Cloud block storage (EBS gp3 / PD) |
+| Pod lifecycle (create/suspend/resume/TTL) | agent-sandbox `Sandbox` CRD |
+| Credential-scoped SSH → MCP access | Containarium `agent-box` + sshpiper gateway |
+| Username→box routing, key choreography | Containarium daemon (programs `Pipe` CRs) |
+
+The sentinel and yamux tunnel are **not** used here — they're the
+*multi-cluster federation* path (one address across several clusters/clouds),
+covered at the end. A single EKS or GKE cluster needs only its own cloud LB.
+
+## Prerequisites
+
+Common:
+
+- A managed cluster: **EKS** (any supported version) or **GKE** (Standard or
+  Autopilot).
+- [Helm](https://helm.sh/) 3.x and `kubectl` pointed at the cluster.
+- The **agent-sandbox controller** installed
+  ([install guide](https://agent-sandbox.sigs.k8s.io/docs/getting_started/)).
+- An SSH host key for the gateway (created below).
+
+EKS-only:
+
+- The [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/)
+  — it turns the Service annotations into a real NLB.
+- The [EBS CSI driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver)
+  and a `gp3` StorageClass. EKS doesn't ship one by default; apply:
+
+  ```yaml
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: gp3
+  provisioner: ebs.csi.aws.com
+  volumeBindingMode: WaitForFirstConsumer
+  parameters:
+    type: gp3
+  ```
+
+GKE-only:
+
+- Nothing extra — the L4 LoadBalancer and the `standard-rwo` StorageClass are
+  built in.
+
+## 1. Create the gateway host-key Secret
+
+The gateway presents a stable SSH host key so clients can pin it. Generate one
+and store it in the gateway namespace:
+
+```bash
+kubectl create namespace agent-gateway
+ssh-keygen -t ed25519 -f gateway_host_key -N ""
+kubectl -n agent-gateway create secret generic sshpiper-server-key \
+  --from-file=server_key=gateway_host_key
+```
+
+## 2. Install the chart with the cloud preset
+
+Pick the preset for your cloud — it sets the gateway Service to `LoadBalancer`
+with the right annotations and selects a cloud StorageClass for box workspaces.
+
+```bash
+# GKE
+helm install containarium ./charts/containarium-k8s \
+  -f charts/containarium-k8s/values-gke.yaml \
+  --set daemon.jwtSecret="$(openssl rand -hex 24)"
+
+# EKS
+helm install containarium ./charts/containarium-k8s \
+  -f charts/containarium-k8s/values-eks.yaml \
+  --set daemon.jwtSecret="$(openssl rand -hex 24)"
+```
+
+This deploys the Containarium daemon (`--runtime=k8s`), the sshpiper gateway,
+RBAC, and the `Pipe` CRD. For a VPC-internal gateway instead of a public one,
+see the commented annotations in the preset file.
+
+## 3. Get the public endpoint
+
+The cloud provisions the LoadBalancer asynchronously; wait for its address:
+
+```bash
+kubectl -n agent-gateway get svc containarium-containarium-k8s-sshpiper \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}{.status.loadBalancer.ingress[0].hostname}'
+```
+
+Call that `<gateway>` below (an IP on GKE, an NLB hostname on EKS).
+
+## 4. Create a box and connect
+
+Boxes are created through the daemon (which programs the gateway Pipe and key
+Secrets for you). Reach the daemon API — for admin use, port-forward it:
+
+```bash
+kubectl port-forward svc/containarium-containarium-k8s-daemon 8080:8080 &
+export CONTAINARIUM_SERVER=http://localhost:8080
+
+# create a box named <box>, registering the agent's public key (a file path)
+containarium create <box> --ssh-key ~/.ssh/id_ed25519.pub
+```
+
+Then connect over the public gateway — the username selects the box, the agent
+holds only its SSH key, and every session is the forced-command MCP server:
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"0.0.1"}}}' \
+  | ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new \
+      -p 22 <box>@<gateway>
+# -> {"result":{...,"serverInfo":{"name":"containarium-agent-box",...}}}
+```
+
+Point any MCP client at `ssh -i ~/.ssh/id_ed25519 -p 22 <box>@<gateway>` and it
+speaks to the box with zero cluster credentials in its path.
+
+> For a developer-style **interactive shell** instead of the MCP endpoint, the
+> box image supports `AGENTBOX_MODE=shell` (opt-in; drops the forced command).
+> See [K8S-AGENT-BOX-RUNTIME-DESIGN.md](K8S-AGENT-BOX-RUNTIME-DESIGN.md).
+
+## Production notes
+
+- **Pin the gateway host key.** The chart defaults to
+  `CONTAINARIUM_K8S_INSECURE_IGNORE_HOST_KEY=1` for out-of-the-box dev. In
+  production, unset it and distribute the gateway host key so clients use
+  `StrictHostKeyChecking=yes` against a known `known_hosts` entry.
+- **Default-deny NetworkPolicy.** Pair each box namespace with a default-deny
+  egress policy (enforced by the CNI — Calico on EKS, Dataplane V2 / Cilium on
+  GKE) so a box can't reach the cluster network even under shell mode.
+- **Elastic capacity.** Because boxes are ordinary pods, the cluster autoscaler
+  (managed node groups / Karpenter on EKS, node auto-provisioning / Autopilot
+  on GKE) scales nodes to fit them. Combine with the Sandbox CRD's
+  suspend/`shutdownTime` to release idle boxes and their nodes.
+- **Internal gateways.** Flip the preset's LB annotations to the internal
+  variant for a VPC-private endpoint reached over a bastion or VPN.
+
+## Multi-cluster / multi-cloud (optional)
+
+Everything above is single-cluster. When you want **one address across several
+clusters or clouds** (GKE *and* EKS behind a single SSH endpoint), that's where
+the Containarium sentinel comes in: it fronts many in-cluster gateways over a
+tunnel and routes by username across all of them. Start each cluster's daemon
+with `--ssh-host <sentinel>` and run `containarium tunnel`; see
+[SENTINEL-DESIGN.md](SENTINEL-DESIGN.md) and the three-hop chain in
+[K8S-AGENT-BOX-RUNTIME-DESIGN.md](K8S-AGENT-BOX-RUNTIME-DESIGN.md). For a single
+managed cluster you don't need it — the cloud LoadBalancer is the endpoint.


### PR DESCRIPTION
## What

Makes managed Kubernetes (**EKS / GKE**) a first-class substrate for the
agent-box stack — SSH-reachable, MCP-native boxes fronted by a **cloud
LoadBalancer** instead of the sentinel/bare-metal path.

The framing: the cloud's managed control plane, node autoscaling, and disk
provisioning are the shared infra you don't operate; Containarium is the thin
layer on top (credential-scoped SSH/MCP access, gateway key choreography,
per-tenant isolation, box lifecycle).

## Changes

- **Chart** — the gateway `Service` gains a `gateway.service.annotations` knob
  (merged over `commonAnnotations`) so cloud LoadBalancer config goes in values,
  not a fork of the template. The default kind/NodePort path is untouched.
- **`values-gke.yaml` / `values-eks.yaml`** — ready-made presets: a
  `LoadBalancer` gateway with the correct cloud annotations (GCP L4 / AWS NLB)
  plus a cloud `StorageClass` for box workspaces (`standard-rwo` / `gp3`).
- **`docs/EKS-GKE-DEPLOY.md`** — the reference guide: architecture (cloud
  substrate vs. Containarium access/lifecycle layer, with a responsibility
  table), per-cloud prereqs, `helm install` with the preset, getting the LB
  endpoint, create + connect a box, and production notes (host-key pinning,
  default-deny NetworkPolicy, autoscaling). The sentinel is documented as the
  optional **multi-cluster federation** path, not a requirement.

## Verification

- `helm lint` clean; `helm template` with each preset renders the gateway
  Service as `LoadBalancer` with the right annotations, and the default path
  still renders `NodePort` + `nodePort: 32022`.
- CLI/service references in the guide checked against the code (`create
  --ssh-key <path>`, `CONTAINARIUM_SERVER`, rendered service names/ports).
- No behavior change to existing deployments — the cloud path is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)