### PR TITLE
feat(agent-box): developer-box mode — interactive shell over SSH (opt-in)

### DIFF
--- a/charts/containarium-k8s/templates/daemon-deployment.yaml
+++ b/charts/containarium-k8s/templates/daemon-deployment.yaml
@@ -41,6 +41,8 @@ spec:
               value: "22"
             - name: CONTAINARIUM_K8S_BOX_IMAGE
               value: {{ .Values.agentBox.image | quote }}
+            - name: CONTAINARIUM_K8S_BOX_MODE
+              value: {{ .Values.agentBox.mode | quote }}
             - name: CONTAINARIUM_K8S_TENANT_NS_PREFIX
               value: {{ .Values.tenantNamespacePrefix | quote }}
             - name: CONTAINARIUM_K8S_STORAGE_CLASS

--- a/charts/containarium-k8s/values-devbox.yaml
+++ b/charts/containarium-k8s/values-devbox.yaml
@@ -1,0 +1,21 @@
+# Values preset for developer boxes: an interactive SSH login shell instead of
+# the forced-command MCP endpoint.
+#
+# Every box this daemon creates runs its agent-box image in shell mode
+# (AGENTBOX_MODE=shell), so `ssh <box>@<gateway>` lands in a real /bin/bash —
+# a developer-style SSH machine on Kubernetes rather than an MCP-only box.
+#
+# Compose it with a cloud preset, e.g. developer boxes on GKE:
+#
+#   helm install containarium ./charts/containarium-k8s \
+#     -f charts/containarium-k8s/values-gke.yaml \
+#     -f charts/containarium-k8s/values-devbox.yaml \
+#     --set daemon.jwtSecret="$(openssl rand -hex 24)"
+#
+# Security note: shell mode trades the forced-command blast-radius guarantee
+# (a key can only drive MCP, never a shell) for a general shell. Pair it with a
+# default-deny NetworkPolicy so the shell can't reach the cluster network, and
+# scope who can create boxes accordingly.
+
+agentBox:
+  mode: shell

--- a/charts/containarium-k8s/values.yaml
+++ b/charts/containarium-k8s/values.yaml
@@ -16,9 +16,13 @@ daemon:
     port: 8080
   resources: {}
 
-# -- Box image deployed per tenant (sshd + agent-box, ForceCommand-pinned)
+# -- Box image deployed per tenant (sshd + agent-box)
 agentBox:
   image: ghcr.io/footprintai/containarium-agent-box:latest
+  # -- Session behavior: "" or "mcp" pins every SSH session to the agent-box
+  # MCP server (forced command — the secure default); "shell" gives an
+  # interactive login shell (developer-box). See values-devbox.yaml.
+  mode: ""
 
 # -- SSH gateway configuration (sshpiper routes SSH connections to box pods)
 gateway:

--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -112,6 +112,16 @@ AllowTcpForwarding  no                          # no pivoting out of the box
 `ForceCommand` is the load-bearing line: even a misbehaving client cannot get
 a shell — it gets `agent-box` and nothing else.
 
+**Interactive-shell mode (opt-in).** Setting `AGENTBOX_MODE=shell` in the
+container env drops the forced command so a session lands in the agent user's
+`/bin/bash` — turning the box into a developer-style SSH machine rather than an
+MCP-only endpoint. The default (`AGENTBOX_MODE=mcp`) keeps the forced-command
+guarantee above. Shell mode deliberately trades that guarantee for a general
+shell, so anyone who can authenticate gets shell access inside the box: use it
+only when that's the intent, and pair it with a default-deny NetworkPolicy so
+the shell cannot reach the cluster network. Everything else — key-only auth, no
+port forwarding, non-root on `:2222` — is unchanged between the two modes.
+
 **Shipped image (`images/agent-box/`):** the config above is the contract; the
 actual image realizes it with **dropbear** rather than OpenSSH — dropbear runs
 cleanly rootless and takes a forced command (`-c agent-box`), so the box runs

--- a/images/agent-box/entrypoint.sh
+++ b/images/agent-box/entrypoint.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 #
 # agent-box image entrypoint: prepare authorized_keys + host key, then run
-# dropbear in the foreground with a forced command pinning every session to
-# agent-box. See images/agent-box/Dockerfile.
+# dropbear in the foreground. By default every session is pinned by a forced
+# command to agent-box (the in-box MCP server); set AGENTBOX_MODE=shell for an
+# interactive login shell instead (opt-in — see the mode note below).
+# See images/agent-box/Dockerfile.
 set -euo pipefail
 
 # The daemon mounts the box's authorized_keys Secret at
@@ -49,5 +51,28 @@ fi
 #   -F  foreground (PID 1)            -E  log to stderr
 #   -s  disable password auth         -j -k  no local/remote port forwarding
 #   -p 2222  unprivileged port        -r  host key file (repeatable)
-#   -c  forced command — every session runs agent-box, nothing else
-exec dropbear -F -E -s -j -k -p 2222 -r "$ED_HOSTKEY" -r "$RSA_HOSTKEY" -c /usr/local/bin/agent-box
+dropbear_flags=(-F -E -s -j -k -p 2222 -r "$ED_HOSTKEY" -r "$RSA_HOSTKEY")
+
+# Session mode (AGENTBOX_MODE, default "mcp"):
+#   mcp    every session is a forced command into agent-box — the key can start
+#          the MCP server and nothing else, so a leaked key's blast radius is one
+#          box's MCP surface, never a shell. This is the default and the property
+#          the K8s agent-box design is built around.
+#   shell  interactive login shell (the agent user's /bin/bash). Opt-in: it
+#          trades the forced-command guarantee for a general shell, so anyone who
+#          can authenticate gets shell access inside the box. Use it for a
+#          developer-style SSH box, and pair it with a default-deny NetworkPolicy
+#          so the shell can't reach the cluster network.
+case "${AGENTBOX_MODE:-mcp}" in
+  mcp)
+    exec dropbear "${dropbear_flags[@]}" -c /usr/local/bin/agent-box
+    ;;
+  shell)
+    echo "[agent-box-entrypoint] AGENTBOX_MODE=shell — interactive shell enabled, forced-command MCP disabled" >&2
+    exec dropbear "${dropbear_flags[@]}"
+    ;;
+  *)
+    echo "[agent-box-entrypoint] unknown AGENTBOX_MODE='${AGENTBOX_MODE}' (want: mcp | shell)" >&2
+    exit 1
+    ;;
+esac

--- a/internal/config/k8s.go
+++ b/internal/config/k8s.go
@@ -13,6 +13,7 @@ const (
 	EnvK8sGatewaySSHPort           = "CONTAINARIUM_K8S_GATEWAY_SSH_PORT"
 	EnvK8sTenantNSPrefix           = "CONTAINARIUM_K8S_TENANT_NS_PREFIX"
 	EnvK8sBoxImage                 = "CONTAINARIUM_K8S_BOX_IMAGE"
+	EnvK8sBoxMode                  = "CONTAINARIUM_K8S_BOX_MODE"
 	EnvK8sStorageClass             = "CONTAINARIUM_K8S_STORAGE_CLASS"
 	EnvK8sGatewayUpstreamPublicKey = "CONTAINARIUM_K8S_GATEWAY_UPSTREAM_PUBLIC_KEY"
 	// #nosec G101 -- this is the NAME of an environment variable, not a credential value.
@@ -60,6 +61,12 @@ type K8s struct {
 	// BoxImage is the agent-box image (sshd + agent-box) each box runs.
 	// (EnvK8sBoxImage)
 	BoxImage string
+
+	// BoxMode selects the box's SSH session behavior, passed to the agent-box
+	// image as AGENTBOX_MODE: "" or "mcp" pins every session to the agent-box
+	// MCP server (forced command — the secure default); "shell" gives an
+	// interactive login shell (developer-box). (EnvK8sBoxMode)
+	BoxMode string
 
 	// StorageClass is the StorageClass for the box's data PVC; empty disables the
 	// PVC. (EnvK8sStorageClass)
@@ -111,6 +118,7 @@ func LoadK8s() K8s {
 		GatewaySSHPort:            getInt(EnvK8sGatewaySSHPort, defaultK8sGatewaySSHPort),
 		TenantNamespacePrefix:     getString(EnvK8sTenantNSPrefix, defaultK8sTenantNSPrefix),
 		BoxImage:                  getString(EnvK8sBoxImage, ""),
+		BoxMode:                   getString(EnvK8sBoxMode, ""),
 		StorageClass:              getString(EnvK8sStorageClass, ""),
 		GatewayUpstreamPublicKey:  getString(EnvK8sGatewayUpstreamPublicKey, ""),
 		GatewayUpstreamKeySecret:  getString(EnvK8sGatewayUpstreamKeySecret, ""),
@@ -129,6 +137,11 @@ func LoadK8s() K8s {
 func (k K8s) Validate() error {
 	if k.GatewaySSHPort < 1 || k.GatewaySSHPort > 65535 {
 		return fmt.Errorf("%s=%d is not a valid TCP port (1-65535)", EnvK8sGatewaySSHPort, k.GatewaySSHPort)
+	}
+	switch k.BoxMode {
+	case "", "mcp", "shell":
+	default:
+		return fmt.Errorf("%s=%q is not valid (want: mcp | shell)", EnvK8sBoxMode, k.BoxMode)
 	}
 	return nil
 }

--- a/internal/config/k8s_test.go
+++ b/internal/config/k8s_test.go
@@ -6,7 +6,7 @@ import "testing"
 // ambient environment.
 var allK8sEnvKeys = []string{
 	EnvK8sKubeconfig, EnvK8sGatewayNamespace, EnvK8sGatewayHost, EnvK8sGatewaySSHPort,
-	EnvK8sTenantNSPrefix, EnvK8sBoxImage, EnvK8sStorageClass,
+	EnvK8sTenantNSPrefix, EnvK8sBoxImage, EnvK8sBoxMode, EnvK8sStorageClass,
 	EnvK8sGatewayUpstreamPublicKey, EnvK8sGatewayUpstreamKeySecret,
 	EnvK8sInsecureIgnoreHostKey, EnvK8sDefaultMemoryRequest, EnvK8sDefaultMemoryLimit,
 	EnvK8sDisableMemoryFloor, EnvK8sGatewayService, EnvK8sGatewayAdvertisePort,
@@ -44,6 +44,7 @@ func TestLoadK8sReadsEnv(t *testing.T) {
 	t.Setenv(EnvK8sGatewaySSHPort, "2222")
 	t.Setenv(EnvK8sTenantNSPrefix, "t-")
 	t.Setenv(EnvK8sBoxImage, "ghcr.io/x/agent-box:latest")
+	t.Setenv(EnvK8sBoxMode, "shell")
 	t.Setenv(EnvK8sStorageClass, "standard")
 	t.Setenv(EnvK8sGatewayUpstreamPublicKey, "ssh-ed25519 AAA")
 	t.Setenv(EnvK8sGatewayUpstreamKeySecret, "gw-upstream-key")
@@ -62,6 +63,7 @@ func TestLoadK8sReadsEnv(t *testing.T) {
 		GatewaySSHPort:            2222,
 		TenantNamespacePrefix:     "t-",
 		BoxImage:                  "ghcr.io/x/agent-box:latest",
+		BoxMode:                   "shell",
 		StorageClass:              "standard",
 		GatewayUpstreamPublicKey:  "ssh-ed25519 AAA",
 		GatewayUpstreamKeySecret:  "gw-upstream-key",
@@ -97,6 +99,14 @@ func TestK8sValidate(t *testing.T) {
 	}
 	if err := (K8s{GatewaySSHPort: 70000}).Validate(); err == nil {
 		t.Error("port 70000 should be invalid")
+	}
+	for _, m := range []string{"", "mcp", "shell"} {
+		if err := (K8s{GatewaySSHPort: 22, BoxMode: m}).Validate(); err != nil {
+			t.Errorf("BoxMode %q should be valid: %v", m, err)
+		}
+	}
+	if err := (K8s{GatewaySSHPort: 22, BoxMode: "vm"}).Validate(); err == nil {
+		t.Error("BoxMode 'vm' should be invalid")
 	}
 }
 

--- a/internal/server/boxbackend_factory.go
+++ b/internal/server/boxbackend_factory.go
@@ -68,6 +68,7 @@ func newK8sBackend() (box.BoxBackend, error) {
 		GatewayAdvertisePort:      cfg.GatewayAdvertisePort,
 		TenantNamespacePrefix:     cfg.TenantNamespacePrefix,
 		BoxImage:                  cfg.BoxImage,
+		BoxMode:                   cfg.BoxMode,
 		StorageClass:              cfg.StorageClass,
 		GatewayUpstreamPublicKey:  cfg.GatewayUpstreamPublicKey,
 		GatewayUpstreamKeySecret:  cfg.GatewayUpstreamKeySecret,

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -56,6 +56,11 @@ type Config struct {
 	// BoxImage is the agent-box image (sshd + agent-box) the box runs.
 	BoxImage string
 
+	// BoxMode is passed to the box as the AGENTBOX_MODE env var: "" or "mcp"
+	// keeps the forced-command MCP session (default), "shell" gives the box an
+	// interactive login shell (developer-box). Empty leaves the image default.
+	BoxMode string
+
 	// StorageClass is reserved for the box PVC (not wired in this slice).
 	StorageClass string
 
@@ -253,7 +258,7 @@ func (b *Backend) Create(ctx context.Context, spec box.BoxSpec) (*box.BoxStatus,
 	if _, err := b.ensureHostKey(ctx, tenant); err != nil {
 		return nil, fmt.Errorf("k8s: ensure host key: %w", err)
 	}
-	if _, err := b.sandboxes.AgentsV1beta1().Sandboxes(ns).Create(ctx, sandboxObject(ns, spec, storageClass != "", b.memDefaults()), metav1.CreateOptions{}); ignoreExists(err) != nil {
+	if _, err := b.sandboxes.AgentsV1beta1().Sandboxes(ns).Create(ctx, sandboxObject(ns, spec, storageClass != "", b.memDefaults(), b.cfg.BoxMode), metav1.CreateOptions{}); ignoreExists(err) != nil {
 		return nil, fmt.Errorf("k8s: ensure sandbox: %w", err)
 	}
 	// Program the SSH gateway so username=<tenant> routes to this box (no-op

--- a/pkg/core/box/k8s/sandbox.go
+++ b/pkg/core/box/k8s/sandbox.go
@@ -25,7 +25,7 @@ import (
 // which the controller would owner-reference and GC on Sandbox deletion,
 // breaking delete-retains-data. def is the resolved default memory floor
 // applied when the spec sets no explicit memory.
-func sandboxObject(ns string, spec box.BoxSpec, withPVC bool, def memDefaults) *sandboxv1beta1.Sandbox {
+func sandboxObject(ns string, spec box.BoxSpec, withPVC bool, def memDefaults, boxMode string) *sandboxv1beta1.Sandbox {
 	labels := boxLabels(spec.Ref.Tenant)
 
 	// restricted-PSA container hardening: non-root, no privilege escalation,
@@ -53,6 +53,13 @@ func sandboxObject(ns string, spec box.BoxSpec, withPVC bool, def memDefaults) *
 	}
 	if res := resourceRequirements(spec.Resources, gpuCount, def); res != nil {
 		container.Resources = *res
+	}
+	// AGENTBOX_MODE selects the box's SSH session behavior in the image
+	// entrypoint (images/agent-box/entrypoint.sh): "shell" swaps the
+	// forced-command MCP session for an interactive login shell. Left unset the
+	// image defaults to the forced-command MCP session.
+	if boxMode != "" {
+		container.Env = append(container.Env, corev1.EnvVar{Name: "AGENTBOX_MODE", Value: boxMode})
 	}
 
 	volumes := []corev1.Volume{

--- a/pkg/core/box/k8s/sandbox_test.go
+++ b/pkg/core/box/k8s/sandbox_test.go
@@ -1,0 +1,35 @@
+//go:build k8s
+
+package k8s
+
+import (
+	"testing"
+
+	box "github.com/footprintai/containarium/pkg/core/box"
+)
+
+// boxContainerEnv returns the agent-box container's env as a name→value map.
+func boxContainerEnv(t *testing.T, boxMode string) map[string]string {
+	t.Helper()
+	sb := sandboxObject("tenant-x", box.BoxSpec{Ref: box.BoxRef{Tenant: "x"}, Image: "img", AutoStart: true}, false, memDefaults{}, boxMode)
+	containers := sb.Spec.SandboxBlueprint.PodTemplate.Spec.Containers
+	if len(containers) != 1 {
+		t.Fatalf("want 1 container, got %d", len(containers))
+	}
+	env := map[string]string{}
+	for _, e := range containers[0].Env {
+		env[e.Name] = e.Value
+	}
+	return env
+}
+
+// TestSandboxObjectBoxMode covers AGENTBOX_MODE injection: set for an explicit
+// mode, absent when unset (the image then defaults to forced-command MCP).
+func TestSandboxObjectBoxMode(t *testing.T) {
+	if got := boxContainerEnv(t, "shell")["AGENTBOX_MODE"]; got != "shell" {
+		t.Errorf("boxMode=shell: AGENTBOX_MODE = %q, want \"shell\"", got)
+	}
+	if _, ok := boxContainerEnv(t, "")["AGENTBOX_MODE"]; ok {
+		t.Error("boxMode=\"\": AGENTBOX_MODE should not be set (image default is MCP)")
+	}
+}


### PR DESCRIPTION
## What

Adds an **opt-in developer-box mode**: instead of the forced-command MCP
endpoint, a box can run an **interactive SSH login shell** — a developer-style
machine on Kubernetes. The forced-command MCP session stays the default.

Wired end to end so it's a real deployment option, not just an image env:

- **Image** (`images/agent-box/entrypoint.sh`): `AGENTBOX_MODE` (default
  `mcp`). `shell` drops the forced command; the image already gives `agent` a
  `/bin/bash` login shell, so everything else (key-only auth, no port
  forwarding, non-root on `:2222`, host keys) is identical between modes.
  Unknown values fail fast.
- **Backend**: `k8s.Config` gains `BoxMode`; `sandboxObject` injects
  `AGENTBOX_MODE` into the box container when set. Threaded through
  `internal/config` (`CONTAINARIUM_K8S_BOX_MODE`, validated to `mcp|shell`) and
  the box-backend factory.
- **Chart**: `agentBox.mode` value → daemon env, plus a `values-devbox.yaml`
  preset that composes with the cloud presets (developer boxes on GKE/EKS:
  `-f values-gke.yaml -f values-devbox.yaml`).
- **Docs**: `K8S-AGENT-BOX-RUNTIME-DESIGN.md` documents the mode and its
  tradeoff.

## Why opt-in

Shell mode trades the forced-command blast-radius guarantee (a key can only
drive MCP, never a shell) for a general shell. It's off by default and
documented to pair with a default-deny NetworkPolicy.

## Verification

- `go build ./...`; `go test ./internal/config/ ./internal/server/`;
  `go test -tags k8s ./pkg/core/box/k8s/`; `gofmt` clean.
- New tests: config round-trip + `Validate` (accepts `mcp`/`shell`, rejects
  others); `sandboxObject` sets `AGENTBOX_MODE` only when configured.
- `helm template` with `values-devbox.yaml` renders
  `CONTAINARIUM_K8S_BOX_MODE: "shell"`; default path unchanged.

Complements #992 (EKS/GKE reference architecture) — compose the presets for
developer boxes on managed Kubernetes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)