### PR TITLE
docs(k8s): add developer-box mode to the EKS/GKE deploy guide

### DIFF
--- a/docs/EKS-GKE-DEPLOY.md
+++ b/docs/EKS-GKE-DEPLOY.md
@@ -116,6 +116,10 @@ This deploys the Containarium daemon (`--runtime=k8s`), the sshpiper gateway,
 RBAC, and the `Pipe` CRD. For a VPC-internal gateway instead of a public one,
 see the commented annotations in the preset file.
 
+> **Developer boxes?** Add `-f charts/containarium-k8s/values-devbox.yaml` to
+> the install to give every box an interactive shell instead of the MCP
+> endpoint — see [Developer-box mode](#developer-box-mode-interactive-shell).
+
 ## 3. Get the public endpoint
 
 The cloud provisions the LoadBalancer asynchronously; wait for its address:
@@ -153,9 +157,38 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":
 Point any MCP client at `ssh -i ~/.ssh/id_ed25519 -p 22 <box>@<gateway>` and it
 speaks to the box with zero cluster credentials in its path.
 
-> For a developer-style **interactive shell** instead of the MCP endpoint, the
-> box image supports `AGENTBOX_MODE=shell` (opt-in; drops the forced command).
-> See [K8S-AGENT-BOX-RUNTIME-DESIGN.md](K8S-AGENT-BOX-RUNTIME-DESIGN.md).
+## Developer-box mode (interactive shell)
+
+By default every box is an MCP endpoint: `ssh <box>@<gateway>` runs the
+forced-command `agent-box` server and nothing else. To make boxes **interactive
+developer machines** instead — where `ssh <box>@<gateway>` lands in a real
+`/bin/bash` — install with the `values-devbox.yaml` preset composed onto the
+cloud preset:
+
+```bash
+# developer boxes on GKE (compose with values-eks.yaml on EKS)
+helm install containarium ./charts/containarium-k8s \
+  -f charts/containarium-k8s/values-gke.yaml \
+  -f charts/containarium-k8s/values-devbox.yaml \
+  --set daemon.jwtSecret="$(openssl rand -hex 24)"
+```
+
+The preset sets `agentBox.mode=shell` (the box image's `AGENTBOX_MODE`), so a
+box created exactly as in step 4 gives you a shell instead of the MCP loop:
+
+```bash
+ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new -p 22 <box>@<gateway>
+# -> lands in /bin/bash inside the box
+```
+
+**Tradeoff.** Shell mode drops the forced-command guarantee — anyone who can
+authenticate gets a general shell in the box, not just its MCP surface. Pair it
+with the default-deny NetworkPolicy from [Production notes](#production-notes)
+so the shell can't reach the cluster network, and scope who may create boxes. To
+run MCP and developer boxes side by side, deploy two daemon releases (one with
+the preset, one without). See
+[K8S-AGENT-BOX-RUNTIME-DESIGN.md](K8S-AGENT-BOX-RUNTIME-DESIGN.md) for the
+image-level detail.
 
 ## Production notes
 


### PR DESCRIPTION
## What

Follow-up to #993 (developer-box mode) and #992 (EKS/GKE guide), both merged.
The guide previously only had a one-line note pointing at the raw
`AGENTBOX_MODE` env var; now that #993 shipped the `values-devbox.yaml` chart
preset, wire it into the managed-Kubernetes guide properly.

- New **Developer-box mode (interactive shell)** section: compose
  `values-devbox.yaml` onto the cloud preset, connect to a real `/bin/bash`,
  and the NetworkPolicy tradeoff.
- A pointer from the install step so it's discoverable.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)