### PR TITLE
fix(k8s): drop format:int64 from the Box CRD (silence kubectl warning, #997)

### DIFF
--- a/charts/containarium-k8s/crds/box.yaml
+++ b/charts/containarium-k8s/crds/box.yaml
@@ -5,6 +5,9 @@
 # Sandbox + gateway Pipe + authorized-keys Secret + NetworkPolicy). See issue
 # #995. Hand-authored to match `controller-gen crd` output; regenerate with:
 #   controller-gen crd paths=./apis/containarium/v1alpha1/... output:crd:dir=charts/containarium-k8s/crds
+# Note: `format: int64` is intentionally omitted from the integer fields — it is
+# valid but makes `kubectl apply` print `Warning: unrecognized format "int64"`
+# (#997). If you regenerate with controller-gen, strip it again.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -122,7 +125,6 @@ spec:
                   description: >-
                     Expire the box this many seconds after creation, when set.
                   type: integer
-                  format: int64
                   minimum: 0
             status:
               description: BoxStatus is the observed state of a Box.
@@ -138,7 +140,6 @@ spec:
                   type: string
                 observedGeneration:
                   type: integer
-                  format: int64
                 conditions:
                   type: array
                   items:
@@ -158,7 +159,6 @@ spec:
                         maxLength: 32768
                       observedGeneration:
                         type: integer
-                        format: int64
                         minimum: 0
                       reason:
                         type: string


### PR DESCRIPTION
Closes #997.

`kubectl apply` of the Box CRD printed `Warning: unrecognized format "int64"` —
kubectl's client-side schema validation doesn't recognize the `int64` format on
the integer fields. It's cosmetic (the CRD installs and the operator lifecycle
works), but noisy on every apply.

Removed `format: int64` from `spec.ttlSeconds`, `status.observedGeneration`, and
the condition's `observedGeneration`. `type: integer` alone validates the values
correctly; the format was only a metadata hint. The valid `date-time` format on
`lastTransitionTime` is kept. A header note records the omission so a
`controller-gen` regeneration strips it again.

## Verified live (kind, k8s-sandbox VM)

- `kubectl apply -f box.yaml` → `boxes.containarium.dev configured` with **no warning**.
- `kubectl apply --dry-run=server` of a Box with `ttlSeconds: 3600` → accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)