### PR TITLE
docs(mcp-server): complete env-var schema for Glama build spec (#967)

### DIFF
--- a/cmd/mcp-server/README.md
+++ b/cmd/mcp-server/README.md
@@ -53,9 +53,23 @@ See [docs/MCP-INTEGRATION.md](../../docs/MCP-INTEGRATION.md) for complete docume
 
 ## Environment Variables
 
-- `CONTAINARIUM_SERVER_URL` (required): REST API URL
-- `CONTAINARIUM_JWT_TOKEN` (required): JWT authentication token
-- `CONTAINARIUM_DEBUG` (optional): Enable debug logging
+Full schema (required/optional, description, example placeholder) — this is
+the source of truth to copy into Glama's build-spec "environment-variable
+schema" step (Containarium#967):
+
+| Variable | Required | Description | Example |
+|----------|----------|--------------|---------|
+| `CONTAINARIUM_SERVER_URL` | Yes* | REST API base URL | `http://localhost:8080` |
+| `CONTAINARIUM_JWT_TOKEN` | Yes** | JWT authentication token, captured once at startup | `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` |
+| `CONTAINARIUM_JWT_TOKEN_FILE` | Yes** | Path to a file holding the JWT; re-read on every request, so rotating the token is `mv newtoken oldpath` — no restart needed. Alternative to `CONTAINARIUM_JWT_TOKEN`; set at most one. | `/etc/containarium/mcp-token` |
+| `CONTAINARIUM_DEBUG` | No | Enable debug logging | `true` or `false` |
+| `CONTAINARIUM_KEYS_DIR` | No | Directory the server writes ephemeral SSH private keys to (from container-creation tools). Defaults to `$HOME/.containarium/keys`. | `/home/mcp/.containarium/keys` |
+
+\* Optional only when `~/.containarium/credentials.json` (written by
+`containarium login`) has a `default_server`.
+\*\* One of `CONTAINARIUM_JWT_TOKEN` / `CONTAINARIUM_JWT_TOKEN_FILE` is
+required unless that same credentials file supplies a token for the
+resolved server.
 
 ## Architecture
 

--- a/docs/MCP-INTEGRATION.md
+++ b/docs/MCP-INTEGRATION.md
@@ -347,9 +347,17 @@ The MCP server is configured through environment variables:
 
 | Variable | Required | Description | Example |
 |----------|----------|-------------|---------|
-| `CONTAINARIUM_SERVER_URL` | Yes | REST API base URL | `http://localhost:8080` |
-| `CONTAINARIUM_JWT_TOKEN` | Yes | JWT authentication token | `eyJhbGci...` |
+| `CONTAINARIUM_SERVER_URL` | Yes* | REST API base URL | `http://localhost:8080` |
+| `CONTAINARIUM_JWT_TOKEN` | Yes** | JWT authentication token, captured once at startup | `eyJhbGci...` |
+| `CONTAINARIUM_JWT_TOKEN_FILE` | Yes** | Path to a file holding the JWT; re-read on every request, so rotating the token is `mv newtoken oldpath` — no restart needed. Alternative to `CONTAINARIUM_JWT_TOKEN`; set at most one. | `/etc/containarium/mcp-token` |
 | `CONTAINARIUM_DEBUG` | No | Enable debug logging | `true` or `false` |
+| `CONTAINARIUM_KEYS_DIR` | No | Directory the server writes ephemeral SSH private keys to (from container-creation tools). Defaults to `$HOME/.containarium/keys`. | `/home/mcp/.containarium/keys` |
+
+\* Optional only when `~/.containarium/credentials.json` (written by
+`containarium login`) has a `default_server`.
+\*\* One of `CONTAINARIUM_JWT_TOKEN` / `CONTAINARIUM_JWT_TOKEN_FILE` is
+required unless that same credentials file supplies a token for the
+resolved server.
 
 ### JWT Token Requirements
 


### PR DESCRIPTION
## Summary

Re-verifying #967's prior conclusion (that everything left is Glama-admin-UI-only) turned up one genuine repo-side gap: `cmd/mcp-server/README.md` and `docs/MCP-INTEGRATION.md` documented only 3 of the 5 environment variables `cmd/mcp-server` actually reads at startup.

`internal/mcp/config.go` and `cmd/mcp-server/main.go`'s `printUsage()` already knew about `CONTAINARIUM_JWT_TOKEN_FILE` (rotation-safe alternative to `CONTAINARIUM_JWT_TOKEN`) and `CONTAINARIUM_KEYS_DIR` (optional override for where ephemeral SSH keys get written), but neither doc mentioned them. Issue #967 explicitly flags this as an open question: *"Env-var schema for Glama's placeholder-parameter config needs to match whatever `cmd/mcp-server` currently expects at startup."* This PR closes that gap so the env-var schema a maintainer copies into Glama's Dockerfile admin page (`build spec` step) is complete.

- `cmd/mcp-server/README.md`: full 5-row table (was a 3-item bullet list)
- `docs/MCP-INTEGRATION.md`: same 2 rows added to its existing table

## Investigation notes (for #967)

Also re-verified, no further repo-side action found:
- `glama.json`'s schema (https://glama.ai/mcp/schemas/server.json) supports only a `maintainers` array — already correctly set. No mechanism exists for listing multiple servers/subdirectories per repo (Glama's URL scheme `glama.ai/mcp/servers/{owner}/{repo}/...` is 1:1 with a repo), so `cmd/agent-box` can't be "added as a server" via this file — matches the issue's own note that it's deferred/lower priority.
- `images/mcp-server/Dockerfile` (from #987) statically checks out against `cmd/mcp-server/main.go`'s actual startup requirements: multi-stage Go build, no CGO, no exposed ports (stdio-only MCP transport), runs as non-root, ENTRYPOINT takes no CMD args. Not build-verified locally in this session (no Docker/Podman in this environment) but the build steps are standard and match the existing `images/agent-box/Dockerfile` pattern that's already in production use.
- Issue #967's newest comment (from the maintainer, today) independently confirms via the live scorecard that the only failing/incomplete items are the Glama release step (which unlocks Coherence + Tool Definition Quality scoring) and a "Maintenance: Grade C" signal to sanity-check — both are on Glama's side, not fixable from this repo.

## Test plan

- [x] Reviewed diff — docs only, no code/proto/CLI changes
- [x] Confirmed the env vars listed match `internal/mcp/config.go` and `cmd/mcp-server/main.go`'s `printUsage()` exactly
- [ ] n/a — no build/test surface for a docs-only change