### PR TITLE
fix(server): give DebugContainer the same peer fallback as GetContainer/GetMetrics

### DIFF
--- a/internal/server/debug_container.go
+++ b/internal/server/debug_container.go
@@ -9,6 +9,8 @@ import (
 	"os/user"
 	"strings"
 
+	"google.golang.org/protobuf/encoding/protojson"
+
 	"github.com/footprintai/containarium/internal/auth"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/footprintai/containarium/pkg/version"
@@ -42,6 +44,21 @@ func (s *ContainerServer) DebugContainer(ctx context.Context, req *pb.DebugConta
 	resp := &pb.DebugContainerResponse{}
 
 	resp.ContainerState = s.debugContainerState(req.Username)
+
+	// Not found on this backend's local manager — the container may live on
+	// a peer. Forward the whole diagnostic there instead of reporting
+	// "missing" against this host's (irrelevant) host-user/sshd state.
+	if resp.ContainerState == "missing" && s.peerPool != nil {
+		authToken := extractAuthToken(ctx)
+		if peer := s.peerPool.FindContainerPeer(req.Username, authToken); peer != nil {
+			if body, err := peer.ForwardDebugContainer(authToken, req.Username); err == nil {
+				var peerResp pb.DebugContainerResponse
+				if jsonErr := protojson.Unmarshal(body, &peerResp); jsonErr == nil {
+					return &peerResp, nil
+				}
+			}
+		}
+	}
 
 	exists, shell, _ := lookupHostUserShell(req.Username)
 	resp.HostUserExists = exists

--- a/internal/server/peer.go
+++ b/internal/server/peer.go
@@ -781,6 +781,19 @@ func (pc *PeerClient) ForwardGetMetrics(authToken string, username string) ([]by
 	return body, nil
 }
 
+// ForwardDebugContainer fetches a debug diagnostic for a container from a peer.
+func (pc *PeerClient) ForwardDebugContainer(authToken string, username string) ([]byte, error) {
+	path := fmt.Sprintf("/v1/containers/%s/debug", username)
+	body, status, err := pc.ForwardRequest("GET", path, authToken, nil)
+	if err != nil {
+		return nil, fmt.Errorf("forward debug to %s: %w", pc.ID, err)
+	}
+	if status >= 400 {
+		return nil, fmt.Errorf("peer %s returned status %d for debug", pc.ID, status)
+	}
+	return body, nil
+}
+
 // refreshCachedInfo fetches system info from a peer and caches key fields.
 func (pc *PeerClient) refreshCachedInfo() {
 	body, err := pc.ForwardGetSystemInfo("")


### PR DESCRIPTION
## Summary

Fixes #999.

`DebugContainer` resolved container state via `s.manager.Get(username)` directly, with no peer awareness — unlike `GetContainer` and `GetMetrics`, which both fall back to `peerPool` when the container isn't in the local manager's index. This meant a container living on a peer backend was unconditionally reported `"missing"` by `debug_container`, even though `get_container`/`get_metrics` resolved the exact same username fine.

## Changes

- `internal/server/peer.go`: add `PeerClient.ForwardDebugContainer(authToken, username string) ([]byte, error)`, modeled on the existing `ForwardGetMetrics`, hitting `GET /v1/containers/{username}/debug` on the peer.
- `internal/server/debug_container.go`: when local state resolves to `"missing"`, look up the owning peer via `peerPool.FindContainerPeer()` and forward the whole diagnostic there, returning the peer's response instead of reporting a false "missing" against this host's irrelevant local host-user/sshd state.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/server/...`
- [x] `go test ./internal/server/...` (10.9s, all pass)
- No dedicated unit test added for `ForwardDebugContainer` — consistent with sibling forwarding methods (`ForwardGetMetrics`, `ForwardGetSystemInfo`, etc.), which also have no dedicated tests and are only exercised via integration coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mQUDm9FNhwDXNG25cxGxY