### PR TITLE
build(image): publish the daemon image + fix chart daemon args (#1005)

### DIFF
--- a/.github/workflows/containarium-daemon.yml
+++ b/.github/workflows/containarium-daemon.yml
@@ -1,0 +1,61 @@
+name: Build daemon image
+
+# Publishes the Containarium daemon image (the control plane the
+# containarium-k8s chart deploys) on every release tag, mirroring the sidecar
+# images in sidecars.yml. Before this, the chart's daemon.image
+# (ghcr.io/footprintai/containarium) was never built by CI — see #1005.
+on:
+  push:
+    tags:
+      - 'v*'   # e.g. v0.53.0
+
+permissions:
+  contents: read
+  packages: write   # for GHCR push
+
+jobs:
+  daemon:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: tags
+        run: |
+          version="${GITHUB_REF#refs/tags/v}"
+          # Minor-series moving tag: 0.53.0 -> v0.53
+          minor="v$(echo "$version" | cut -d. -f1-2)"
+          base="ghcr.io/footprintai/containarium"
+          {
+            echo "version=${version}"
+            # :latest is the chart default (Chart.yaml appVersion: latest);
+            # keep it in sync with the newest release tag.
+            echo "tags=${base}:v${version},${base}:${minor},${base}:latest"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push daemon image
+        uses: docker/build-push-action@v7
+        with:
+          # Repo root context: the Dockerfile builds ./cmd/containarium.
+          context: .
+          file: ./images/daemon/Dockerfile
+          build-args: |
+            VERSION=${{ steps.tags.outputs.version }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          # Build provenance + SBOM (buildx-default on push); explicit so it's
+          # reviewable, matching sidecars.yml.
+          provenance: true
+          sbom: true

--- a/charts/containarium-k8s/templates/daemon-deployment.yaml
+++ b/charts/containarium-k8s/templates/daemon-deployment.yaml
@@ -25,7 +25,7 @@ spec:
           image: {{ include "containarium-k8s.daemonImage" . }}
           imagePullPolicy: {{ .Values.daemon.image.pullPolicy }}
           args:
-            - serve
+            - daemon
             - --runtime=k8s
           env:
             - name: CONTAINARIUM_JWT_SECRET
@@ -59,13 +59,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /health
               port: api
             initialDelaySeconds: 10
             periodSeconds: 20
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /health
               port: api
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/images/daemon/Dockerfile
+++ b/images/daemon/Dockerfile
@@ -1,0 +1,44 @@
+# containarium (daemon)
+#
+# The Containarium daemon image for the Kubernetes runtime: the control plane
+# the containarium-k8s Helm chart deploys (charts/containarium-k8s/). It serves
+# the gRPC + REST API, drives the box backend, and — when
+# CONTAINARIUM_K8S_OPERATOR is set — runs the Box CRD controller.
+#
+# Published per-release as ghcr.io/footprintai/containarium:vX.Y.Z / :latest by
+# .github/workflows/containarium-daemon.yml (release tags), mirroring the
+# sidecar images. Build context is the repo root:
+#   docker build -f images/daemon/Dockerfile --build-arg VERSION=0.53.0 -t containarium .
+#
+# Note: built WITHOUT `-tags embed_bpf`. The eBPF network-isolation features
+# (phase A) need a pre-compiled BPF object; they're not part of the k8s-runtime
+# daemon image, which isolates tenants via NetworkPolicy. eBPF-embedded builds
+# remain the binary release (`make build-release`).
+
+# --- build the daemon ------------------------------------------------------
+FROM golang:1.26.5-bookworm AS build
+ARG VERSION=dev
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+# CGO_ENABLED=0 → a fully static binary (matches make build-release). The k8s
+# backend has no build tag on non-test sources, so a plain build includes it.
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
+    -ldflags="-s -w -X github.com/footprintai/containarium/pkg/version.Version=${VERSION}" \
+    -o /out/containarium ./cmd/containarium
+
+# --- runtime ---------------------------------------------------------------
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 --shell /usr/sbin/nologin containarium
+
+COPY --from=build /out/containarium /usr/local/bin/containarium
+
+USER containarium
+ENV HOME=/home/containarium
+# gRPC (50051) + REST (8080) — documentation only; the daemon binds these.
+EXPOSE 8080 50051
+ENTRYPOINT ["/usr/local/bin/containarium"]


### PR DESCRIPTION
Closes #1005.

The `containarium-k8s` chart's `daemon.image` (`ghcr.io/footprintai/containarium`)
was **never built by any CI workflow** — `sidecars.yml` only publishes the three
sidecars. So `helm install` ImagePullBackOff'd and the Box operator (#996) /
developer-box (#993) couldn't be deployed via Helm.

## Changes

- **`images/daemon/Dockerfile`** — multi-stage build of `cmd/containarium`
  (static, `CGO_ENABLED=0`, version via a `VERSION` build-arg → ldflags),
  debian-slim runtime, non-root uid 1000. No `embed_bpf` (the k8s-runtime daemon
  isolates via NetworkPolicy; eBPF-embedded builds remain the binary release).
- **`.github/workflows/containarium-daemon.yml`** — build+push on release tags,
  mirroring `sidecars.yml`. Publishes `:vX.Y.Z`, `:vX.Y`, and `:latest` (the
  chart's `appVersion` default).
- **chart fix** — the daemon Deployment invoked `serve`, but the CLI subcommand
  is `daemon`. A latent bug that never surfaced because the image never existed.
  Now `daemon --runtime=k8s`.

## Validated live (kind, k8s-sandbox VM)

- Image builds; `docker run … version` → `Containarium v0.53.0-test`; `daemon`
  subcommand present; runs as uid 1000.
- Loaded into kind + `helm install --set operator.enabled=true` → the
  chart-deployed daemon runs the **Box operator in-cluster under the chart's
  RBAC**, and a `Box` CR reconciles to **Running** end to end (Sandbox + Pipe +
  Secret + pod), endpoint populated, **no RBAC gaps**.

## Known follow-up (separate, pre-existing)

The daemon blocks in `NewDualServer` before binding its gRPC/REST servers in a
minimal pod, so `/healthz` is refused and the readiness probe fails (liveness
restarts it). The operator works regardless (it doesn't need the REST API).
Filed separately — it predates this change and affects any containerized daemon
deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)