### PR TITLE
fix(daemon): don't block startup pinging an unreachable Postgres on k8s (#1007)

### DIFF
--- a/internal/collaborator/store.go
+++ b/internal/collaborator/store.go
@@ -48,8 +48,12 @@ func NewStore(ctx context.Context, connectionString string) (*Store, error) {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
 
-	// Test the connection
-	if err := pool.Ping(ctx); err != nil {
+	// Test the connection under a bounded deadline. pgx's dial has no timeout of
+	// its own, so an unreachable Postgres would otherwise block here forever —
+	// which stalls daemon startup before it binds its servers (#1007).
+	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := pool.Ping(pingCtx); err != nil {
 		pool.Close()
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -836,7 +836,12 @@ skipAppHosting:
 	// postgresConnString was set by app hosting setup above, or from config
 	if postgresConnString == "" {
 		postgresConnString = os.Getenv("CONTAINARIUM_POSTGRES_URL")
-		if postgresConnString == "" {
+		// The 10.100.0.2 default is the LXC deployment's Incus-hosted Postgres;
+		// the K8s runtime has no such host. Defaulting to it there makes the
+		// daemon block on startup dialing an unreachable address (#1007), so
+		// skip the default on K8s — an unset URL just disables the
+		// (LXC-oriented) collaborator store instead.
+		if postgresConnString == "" && config.Runtime != RuntimeK8s {
 			postgresConnString = "postgres://containarium:containarium@10.100.0.2:5432/containarium?sslmode=disable" // #nosec G101 -- default dev credentials for local Incus container Postgres
 		}
 	}


### PR DESCRIPTION
Closes #1007.

The daemon hung during startup — before binding its gRPC/REST servers — when run
in a minimal environment (the `containarium-k8s` Helm deploy or a bare pod).

## Root cause (goroutine dump)

`NewDualServer` → `collaborator.NewStore` → `pgxpool.Pool.Ping` blocked forever:

- `dual_server.go` defaulted `postgresConnString` to the LXC deployment's
  Incus-hosted Postgres (`10.100.0.2:5432`) whenever unset — **including on the
  K8s runtime**, where no such host exists, so the daemon dialed an unreachable
  address.
- `collaborator.NewStore` pinged with the caller's context (no deadline), so an
  unreachable Postgres blocked indefinitely instead of failing fast (the retry
  loop above it never even got a turn).

## Fix

- Skip the `10.100.0.2` default on the K8s runtime — an unset URL just disables
  the (LXC-oriented) collaborator store.
- Bound the connection ping to 5s so any unreachable Postgres fails fast.

## Verified on the k8s-sandbox VM

The K8s-runtime daemon now reaches `Containarium daemon starting… gRPC:
0.0.0.0:50051 / HTTP/REST: 0.0.0.0:8080` and serves `/health` (200) instead of
hanging; the collaborator store is cleanly skipped.

Pairs with #1006 (daemon image) — together they make `helm install` of the
operator actually reach Ready. (#1006 also carries the chart probe-path fix
`/healthz`→`/health`.)