### PR TITLE
fix(daemon): auto-restore jump-server accounts on startup after spot boot-disk loss (#1010)

### DIFF
--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -587,7 +587,54 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	}
 	log.Printf("Press Ctrl+C to stop")
 
+	// Spot boot-disk recovery (#1010): on an LXC host recreated after a spot
+	// preemption, the containers persist on the ZFS pool but the fresh VM's
+	// /etc/passwd is empty — every pre-preemption tenant is SSH-dark until its
+	// host jump-server account is re-provisioned. Previously this needed a
+	// manual `sync-accounts`; run it automatically on startup instead.
+	// Best-effort, non-blocking, never fatal; only meaningful for the LXC
+	// runtime (k8s has no host jump-server accounts).
+	if runtime != server.RuntimeK8s {
+		go recoverJumpServerAccounts()
+	}
+
 	return dualServer.Start(ctx)
+}
+
+// recoverJumpServerAccounts re-provisions any missing host jump-server accounts
+// from the running containers (spot boot-disk loss recovery, #1010). It waits
+// briefly for incus-autostarted containers to come up, then re-syncs. It never
+// aborts startup: a benign "no key" container (control-plane / CI / workspace
+// boxes) is expected and not treated as failure; a genuine failure (a key was
+// present but the account couldn't be created) is logged as a WARNING so it
+// surfaces rather than staying silent.
+func recoverJumpServerAccounts() {
+	// A just-booted host may still be starting its containers; give them a
+	// moment so ExtractSSHKey can read their keys.
+	time.Sleep(30 * time.Second)
+
+	mgr, err := container.New()
+	if err != nil {
+		log.Printf("[account-sync] skipped (cannot connect to Incus): %v", err)
+		return
+	}
+	res, err := mgr.SyncOwnerAccounts(false /*force*/, false /*dryRun*/, false /*verbose*/)
+	if err != nil {
+		log.Printf("[account-sync] skipped (list containers failed): %v", err)
+		return
+	}
+
+	if len(res.Restored) > 0 {
+		log.Printf("[account-sync] restored %d missing host account(s) on startup (spot boot-disk recovery): %s",
+			len(res.Restored), strings.Join(res.Restored, ", "))
+	} else {
+		log.Printf("[account-sync] host accounts up to date (%d present, %d container(s) without a tenant key)",
+			res.Skipped, len(res.NoKey))
+	}
+	if len(res.Failed) > 0 {
+		log.Printf("[account-sync] WARNING: %d container(s) had an SSH key but the host account could not be created — these tenants are SSH-dark and need attention: %s",
+			len(res.Failed), strings.Join(res.Failed, ", "))
+	}
 }
 
 // generateRandomSecret generates a random secret for development mode

--- a/internal/cmd/sync_accounts.go
+++ b/internal/cmd/sync_accounts.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/footprintai/containarium/internal/collaborator"
 	"github.com/footprintai/containarium/pkg/core/container"
@@ -60,80 +59,26 @@ func runSyncAccounts(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to connect to Incus: %w (is Incus running?)", err)
 	}
 
-	// List all containers
-	containers, err := mgr.List()
+	// Owner accounts: restore the host jump-server user for every persisted
+	// container. The shared helper classifies "no extractable key" (benign —
+	// infra/CP/workspace boxes) separately from real create failures, so the
+	// command no longer fails-closed on the former. See #1010.
+	res, err := mgr.SyncOwnerAccounts(syncForce, syncDryRun, verbose)
 	if err != nil {
-		return fmt.Errorf("failed to list containers: %w", err)
+		return fmt.Errorf("failed to sync owner accounts: %w", err)
 	}
-
-	if len(containers) == 0 {
-		fmt.Println("No containers found.")
-		return nil
-	}
-
-	fmt.Printf("Found %d container(s)\n\n", len(containers))
-
-	var restored, skipped, failed int
-
-	for _, c := range containers {
-		// Extract username from container name (format: username-container)
-		username := strings.TrimSuffix(c.Name, "-container")
-		if username == c.Name {
-			// Container name doesn't follow our naming convention
-			if verbose {
-				fmt.Printf("  Skipping %s: doesn't follow naming convention\n", c.Name)
-			}
-			skipped++
-			continue
-		}
-
-		fmt.Printf("Processing: %s (container: %s)\n", username, c.Name)
-
-		// Check if jump server account already exists
-		if !syncForce && container.UserExists(username) {
-			fmt.Printf("  ✓ Jump server account already exists, skipping\n")
-			skipped++
-			continue
-		}
-
-		// Extract SSH key from container
-		sshKey, err := mgr.ExtractSSHKey(c.Name, username, verbose)
-		if err != nil {
-			fmt.Printf("  ⚠ Failed to extract SSH key: %v\n", err)
-			failed++
-			continue
-		}
-
-		if sshKey == "" {
-			fmt.Printf("  ⚠ No SSH key found in container\n")
-			failed++
-			continue
-		}
-
-		if verbose {
-			// Show truncated key for verification
-			keyPreview := sshKey
-			if len(keyPreview) > 60 {
-				keyPreview = keyPreview[:60] + "..."
-			}
-			fmt.Printf("  Found SSH key: %s\n", keyPreview)
-		}
-
+	for _, u := range res.Restored {
 		if syncDryRun {
-			fmt.Printf("  [DRY RUN] Would create jump server account for %s\n", username)
-			restored++
-			continue
+			fmt.Printf("  [DRY RUN] Would create jump server account for %s\n", u)
+		} else {
+			fmt.Printf("  ✓ Jump server account restored for %s\n", u)
 		}
-
-		// Create jump server account
-		if err := container.CreateJumpServerAccount(username, sshKey, verbose); err != nil {
-			fmt.Printf("  ✗ Failed to create jump server account: %v\n", err)
-			failed++
-			continue
-		}
-
-		fmt.Printf("  ✓ Jump server account restored for %s\n", username)
-		restored++
+	}
+	for _, u := range res.NoKey {
+		fmt.Printf("  – No SSH key in container %s-container (infra/CP/workspace box?) — skipped\n", u)
+	}
+	for _, u := range res.Failed {
+		fmt.Printf("  ✗ Failed to create jump server account for %s\n", u)
 	}
 
 	// Sync collaborator accounts from PostgreSQL
@@ -146,12 +91,13 @@ func runSyncAccounts(cmd *cobra.Command, args []string) error {
 	fmt.Println("==========================================")
 	fmt.Println("Owner Accounts:")
 	if syncDryRun {
-		fmt.Printf("  Would restore: %d accounts\n", restored)
+		fmt.Printf("  Would restore: %d accounts\n", len(res.Restored))
 	} else {
-		fmt.Printf("  Restored:      %d accounts\n", restored)
+		fmt.Printf("  Restored:      %d accounts\n", len(res.Restored))
 	}
-	fmt.Printf("  Skipped:       %d accounts\n", skipped)
-	fmt.Printf("  Failed:        %d accounts\n", failed)
+	fmt.Printf("  Skipped:       %d accounts\n", res.Skipped)
+	fmt.Printf("  No key (ok):   %d accounts\n", len(res.NoKey))
+	fmt.Printf("  Failed:        %d accounts\n", len(res.Failed))
 	fmt.Println()
 	fmt.Println("Collaborator Accounts:")
 	if syncDryRun {
@@ -163,7 +109,10 @@ func runSyncAccounts(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Failed:        %d accounts\n", collabFailed)
 	fmt.Println("==========================================")
 
-	totalFailed := failed + collabFailed
+	// Fail-close ONLY on genuine failures (a key existed but the account
+	// couldn't be created) — never on the benign no-key containers, which
+	// previously made a startup hook / CI treat a healthy host as failed.
+	totalFailed := len(res.Failed) + collabFailed
 	if totalFailed > 0 {
 		return fmt.Errorf("%d account(s) failed to sync", totalFailed)
 	}

--- a/pkg/core/container/account_sync.go
+++ b/pkg/core/container/account_sync.go
@@ -1,0 +1,88 @@
+//go:build !windows
+
+package container
+
+import (
+	"fmt"
+	"strings"
+)
+
+// OwnerSyncResult summarizes a jump-server owner-account sync pass.
+//
+// NoKey and Failed are deliberately distinct: a container with no extractable
+// SSH key is BENIGN (control-plane / CI / workspace containers legitimately
+// carry no tenant authorized_keys), whereas Failed is the actionable case — a
+// key was found but the host account could not be (re)created. Callers should
+// fail-close (non-zero exit, alert) only on Failed, never on NoKey. See #1010.
+type OwnerSyncResult struct {
+	// Restored is the usernames whose host account was (re)created — or, in a
+	// dry run, would be.
+	Restored []string
+	// Skipped counts containers whose account already exists (and force is
+	// off), plus containers whose name doesn't follow the "<user>-container"
+	// convention.
+	Skipped int
+	// NoKey is the usernames whose container had no extractable SSH key
+	// (missing/unreadable authorized_keys). Benign — not a failure.
+	NoKey []string
+	// Failed is the usernames where a key WAS found but CreateJumpServerAccount
+	// failed — the only genuinely actionable failure.
+	Failed []string
+}
+
+// SyncOwnerAccounts restores host jump-server accounts for every persisted
+// container whose account is missing, by extracting each container's SSH key
+// and (re)creating the matching host user.
+//
+// It exists for spot-instance boot-disk loss recovery: the containers persist
+// on the ZFS pool, but the recreated VM's /etc/passwd is empty, leaving the
+// running containers SSH-dark until their host accounts are re-provisioned.
+// The daemon runs this on startup (best-effort) so recovery is automatic
+// rather than a manual `sync-accounts` step; the CLI uses it too.
+//
+// force recreates even when the account already exists; dryRun reports what
+// would change without touching the host.
+func (m *Manager) SyncOwnerAccounts(force, dryRun, verbose bool) (OwnerSyncResult, error) {
+	var res OwnerSyncResult
+
+	containers, err := m.List()
+	if err != nil {
+		return res, fmt.Errorf("list containers: %w", err)
+	}
+
+	for _, c := range containers {
+		// Container names follow "<username>-container"; anything else isn't a
+		// tenant box we own an account for.
+		username := strings.TrimSuffix(c.Name, "-container")
+		if username == c.Name {
+			res.Skipped++
+			continue
+		}
+
+		if !force && UserExists(username) {
+			res.Skipped++
+			continue
+		}
+
+		sshKey, err := m.ExtractSSHKey(c.Name, username, verbose)
+		if err != nil || sshKey == "" {
+			// No tenant key in the container — benign (infra/CP/workspace
+			// boxes). Record separately so callers don't fail-close on it.
+			res.NoKey = append(res.NoKey, username)
+			continue
+		}
+
+		if dryRun {
+			res.Restored = append(res.Restored, username)
+			continue
+		}
+
+		if err := CreateJumpServerAccount(username, sshKey, verbose); err != nil {
+			res.Failed = append(res.Failed, username)
+			continue
+		}
+		res.Restored = append(res.Restored, username)
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
Closes #1010.

A recreated spot backend loses boot-disk `/etc/passwd` while containers persist on the ZFS pool → every pre-preemption tenant is silently SSH-dark until someone runs `sync-accounts` by hand. Prod hit this: 9 tenants SSH-dark after an ase1-spot preemption (found via a support report; see the argus investigation).

**Changes**
- New `container.Manager.SyncOwnerAccounts` — reusable restore that classifies benign "no key" containers (CP/CI/workspace boxes) apart from real failures.
- **Daemon runs it on startup** (best-effort, non-blocking, LXC-only) so a recreated spot host self-heals SSH access; logs restored accounts + a WARNING naming any tenant left SSH-dark.
- `sync-accounts` CLI reuses it and **no longer fails-closed on benign no-key misses** (which previously made a healthy host exit non-zero).

Pairs with an interim systemd `sync-accounts` timer already deployed on the spot host. `go build ./... ` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)