### PR TITLE
feat(debug): expose ssh_ingress_host — stop the generic sentinel boilerplate (#1011)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -7674,6 +7674,10 @@
         "daemonVersion": {
           "type": "string",
           "description": "Daemon version (containarium binary) that generated this report.\nPair with source_repo to read code at the exact commit/tag."
+        },
+        "sshIngressHost": {
+          "type": "string",
+          "description": "Public SSH entrypoint (the sentinel host) clients dial to reach\ncontainers on this backend — the daemon's advertised --ssh-host.\n**Empty means this backend advertises NO external SSH entrypoint**\n(direct / in-network mode: reach the container by IP, or deploy through\nan in-network pipeline). When empty, the sentinel-side remediation hints\ndon't apply — there is no sentinel to check. Lets an agent stop hunting\nfor a jump host that doesn't exist. See #1011."
         }
       },
       "title": "DebugContainerResponse is the structured diagnostic report"
@@ -11398,6 +11402,10 @@
         "daemonVersion": {
           "type": "string",
           "description": "Containarium daemon version of this backend (e.g. \"0.21.0\"), so the\nfleet's running versions + drift are visible via get_system_info and\n/v1/backends without SSHing each host. See #354."
+        },
+        "sshIngressHost": {
+          "type": "string",
+          "description": "Public SSH entrypoint (the sentinel host) clients dial to reach this\nbackend's containers — the daemon's advertised --ssh-host. **Empty means\nthis backend advertises NO external SSH entrypoint** (direct / in-network\nmode: reach containers by IP, or deploy through an in-network pipeline).\nSurfaced so an agent can tell, from get_system_info alone, whether an\nexternal SSH/deploy entrypoint exists and what host it is — instead of\nassuming a sentinel that may not exist. See #1011."
         }
       },
       "title": "SystemInfo contains information about the host system"

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1445,6 +1445,10 @@ type DebugContainerResponse struct {
 	NextActions          []string `json:"nextActions"`
 	SourceRepo           string   `json:"sourceRepo,omitempty"`
 	DaemonVersion        string   `json:"daemonVersion,omitempty"`
+	// SSHIngressHost is the advertised public SSH entrypoint (sentinel host),
+	// or empty for direct/in-network mode (no external SSH entrypoint — reach
+	// the container by IP or via an in-network deploy pipeline). See #1011.
+	SSHIngressHost string `json:"sshIngressHost,omitempty"`
 }
 
 type DeleteContainerResponse struct {
@@ -1654,4 +1658,10 @@ type SystemInfo struct {
 	// daemon has no OTel collector. Surfaced so an agent can configure
 	// docker-in-LXC apps that don't inherit the env-stamped value. #370.
 	OTelCollectorEndpoint string `json:"otelCollectorEndpoint"`
+	// SSHIngressHost is the advertised public SSH entrypoint (sentinel host)
+	// clients dial to reach this backend's containers, or empty for
+	// direct/in-network mode (no external SSH entrypoint). Lets an agent tell
+	// whether an external SSH/deploy entrypoint exists and what host it is,
+	// instead of assuming a sentinel that may not exist. See #1011.
+	SSHIngressHost string `json:"sshIngressHost,omitempty"`
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -252,7 +252,11 @@ func (s *Server) registerTools() {
 				"    …\" reason\n\n" +
 				"Returns a JSON object with: containerState, hostUserExists, hostUserShell, " +
 				"hostUserShellExists, recentSshdRejections, likelyCause, nextActions, " +
-				"sourceRepo, daemonVersion. When the structured fields are inconclusive, " +
+				"sourceRepo, daemonVersion, and sshIngressHost — the advertised public " +
+					"SSH entrypoint (sentinel host); EMPTY means NO external SSH entrypoint " +
+					"(direct/in-network mode), so next_actions drop the sentinel hints and " +
+					"there is no jump host to chase (reach the container by IP or its " +
+					"in-network deploy pipeline). When the structured fields are inconclusive, " +
 				"use sourceRepo + daemonVersion to fetch the daemon's source and dig " +
 				"deeper (grep internal/sentinel/, pkg/core/, etc.). Read-only — no side effects.",
 			InputSchema: map[string]interface{}{

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -253,10 +253,10 @@ func (s *Server) registerTools() {
 				"Returns a JSON object with: containerState, hostUserExists, hostUserShell, " +
 				"hostUserShellExists, recentSshdRejections, likelyCause, nextActions, " +
 				"sourceRepo, daemonVersion, and sshIngressHost — the advertised public " +
-					"SSH entrypoint (sentinel host); EMPTY means NO external SSH entrypoint " +
-					"(direct/in-network mode), so next_actions drop the sentinel hints and " +
-					"there is no jump host to chase (reach the container by IP or its " +
-					"in-network deploy pipeline). When the structured fields are inconclusive, " +
+				"SSH entrypoint (sentinel host); EMPTY means NO external SSH entrypoint " +
+				"(direct/in-network mode), so next_actions drop the sentinel hints and " +
+				"there is no jump host to chase (reach the container by IP or its " +
+				"in-network deploy pipeline). When the structured fields are inconclusive, " +
 				"use sourceRepo + daemonVersion to fetch the daemon's source and dig " +
 				"deeper (grep internal/sentinel/, pkg/core/, etc.). Read-only — no side effects.",
 			InputSchema: map[string]interface{}{

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -2287,6 +2287,10 @@ func (s *ContainerServer) GetSystemInfo(ctx context.Context, req *pb.GetSystemIn
 		// This backend's daemon version, so the fleet's running versions +
 		// drift are visible via get_system_info / /v1/backends. See #354.
 		DaemonVersion: version.GetVersion(),
+		// Advertised public SSH entrypoint (sentinel host), or empty for
+		// direct/in-network mode — so an agent can tell from get_system_info
+		// whether an external SSH/deploy entrypoint exists. See #1011.
+		SshIngressHost: s.sshHost,
 	}
 
 	// Populate GPU info

--- a/internal/server/debug_container.go
+++ b/internal/server/debug_container.go
@@ -69,6 +69,11 @@ func (s *ContainerServer) DebugContainer(ctx context.Context, req *pb.DebugConta
 
 	resp.RecentSshdRejections = recentSshdLines(req.Username, 8)
 
+	// Advertised SSH entrypoint (sentinel host), or empty for direct/in-network
+	// mode. Populated before diagnose() so the remediation hints can drop the
+	// sentinel boilerplate when there is no sentinel to check (#1011).
+	resp.SshIngressHost = s.sshHost
+
 	resp.LikelyCause, resp.NextActions = diagnose(req.Username, resp)
 
 	resp.SourceRepo = SourceRepo
@@ -248,20 +253,38 @@ func diagnose(username string, r *pb.DebugContainerResponse) (string, []string) 
 			return "sshd reports the user as invalid (account exists but not allowed)",
 				[]string{"check AllowUsers in /etc/ssh/sshd_config and /etc/ssh/sshd_config.d/"}
 		case strings.Contains(lower, "accepted publickey"):
-			return "sshd accepted publickey for this user recently — the path through sshd works; if your client still fails, the problem is in the sshpiper hop or the client's own ssh options",
+			if host := strings.TrimSpace(r.SshIngressHost); host != "" {
+				return "sshd accepted publickey for this user recently — the path through sshd works; if your client still fails, the problem is in the sentinel/sshpiper hop or the client's own ssh options",
+					[]string{
+						fmt.Sprintf("retry with: ssh -i <key> -o IdentitiesOnly=yes %s@%s", username, host),
+						fmt.Sprintf("check sshpiper sync on the sentinel %s (the user must appear in /etc/sshpiper/users/%s/)", host, username),
+					}
+			}
+			return "sshd accepted publickey for this user recently — the path through sshd works. This backend advertises no external SSH entrypoint (direct/in-network mode): there is no sentinel/sshpiper hop to check",
 				[]string{
-					"verify you used: ssh -i <key> -o IdentitiesOnly=yes <user>@<sentinel-host>",
-					"check sshpiper sync on the sentinel (the user must appear in /etc/sshpiper/users/<user>/)",
+					"connect directly to the container's IP (see ip_address in its container record); no sentinel fronts this backend",
+					"if you reach this backend through an in-network CI/CD pipeline, verify that path — external SSH from outside the backend's network isn't the route here",
 				}
 		}
 	}
 
-	return "no obvious host-side problem; check sentinel-side state (sshpiper sync, failtoban ban table) — these are not visible to the daemon yet",
+	// No host-side problem found. Whether there's a sentinel to check next
+	// depends on ssh_ingress_host — don't emit sentinel boilerplate when this
+	// backend advertises no external entrypoint (#1011).
+	if host := strings.TrimSpace(r.SshIngressHost); host != "" {
+		return fmt.Sprintf("no obvious host-side problem; check sentinel-side state on %s (sshpiper sync, fail2ban ban table) — these are not visible to the daemon yet", host),
+			[]string{
+				fmt.Sprintf("verify the user appears in the sentinel's /etc/sshpiper/users/%s/ (sshpiper sync is on a 2 min interval)", username),
+				"verify your client IP is not in the sentinel's fail2ban ban table",
+				fmt.Sprintf("retry with: ssh -i <key> -o IdentitiesOnly=yes %s@%s", username, host),
+				"for deeper investigation, see source_repo + daemon_version in this report — grep internal/sentinel/ for the keysync code path",
+			}
+	}
+	return "no obvious host-side problem, and this backend advertises no external SSH entrypoint (ssh_ingress_host is empty: direct/in-network mode) — there is no sentinel to check",
 		[]string{
-			"verify the user appears in the sentinel's /etc/sshpiper/users/<user>/ (sshpiper sync is on a 2 min interval)",
-			"verify your laptop IP is not in the sentinel's failtoban ban table",
-			"retry with: ssh -i <key> -o IdentitiesOnly=yes <user>@<sentinel-host>",
-			"for deeper investigation, see source_repo + daemon_version in this report — grep internal/sentinel/ for the keysync code path",
+			"connect directly to the container's IP (see ip_address in its container record); no sentinel/sshpiper fronts this backend",
+			"if this backend is deployed to via an in-network CI/CD pipeline, route through that pipeline — external SSH isn't the path here",
+			"if you expected an external SSH host, the daemon's --ssh-host is unset; set it so ssh_ingress_host is advertised",
 		}
 }
 

--- a/pkg/pb/containarium/v1/config.pb.go
+++ b/pkg/pb/containarium/v1/config.pb.go
@@ -1030,8 +1030,16 @@ type SystemInfo struct {
 	// fleet's running versions + drift are visible via get_system_info and
 	// /v1/backends without SSHing each host. See #354.
 	DaemonVersion string `protobuf:"bytes,21,opt,name=daemon_version,json=daemonVersion,proto3" json:"daemon_version,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Public SSH entrypoint (the sentinel host) clients dial to reach this
+	// backend's containers — the daemon's advertised --ssh-host. **Empty means
+	// this backend advertises NO external SSH entrypoint** (direct / in-network
+	// mode: reach containers by IP, or deploy through an in-network pipeline).
+	// Surfaced so an agent can tell, from get_system_info alone, whether an
+	// external SSH/deploy entrypoint exists and what host it is — instead of
+	// assuming a sentinel that may not exist. See #1011.
+	SshIngressHost string `protobuf:"bytes,22,opt,name=ssh_ingress_host,json=sshIngressHost,proto3" json:"ssh_ingress_host,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *SystemInfo) Reset() {
@@ -1207,6 +1215,13 @@ func (x *SystemInfo) GetOtelCollectorEndpoint() string {
 func (x *SystemInfo) GetDaemonVersion() string {
 	if x != nil {
 		return x.DaemonVersion
+	}
+	return ""
+}
+
+func (x *SystemInfo) GetSshIngressHost() string {
+	if x != nil {
+		return x.SshIngressHost
 	}
 	return ""
 }
@@ -4522,7 +4537,7 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"updateMask\"a\n" +
 	"\x14UpdateConfigResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12/\n" +
-	"\x06config\x18\x02 \x01(\v2\x17.containarium.v1.ConfigR\x06config\"\xd0\x06\n" +
+	"\x06config\x18\x02 \x01(\v2\x17.containarium.v1.ConfigR\x06config\"\xfa\x06\n" +
 	"\n" +
 	"SystemInfo\x12#\n" +
 	"\rincus_version\x18\x01 \x01(\tR\fincusVersion\x12\x0e\n" +
@@ -4548,7 +4563,8 @@ const file_containarium_v1_config_proto_rawDesc = "" +
 	"\n" +
 	"backend_id\x18\x13 \x01(\tR\tbackendId\x126\n" +
 	"\x17otel_collector_endpoint\x18\x14 \x01(\tR\x15otelCollectorEndpoint\x12%\n" +
-	"\x0edaemon_version\x18\x15 \x01(\tR\rdaemonVersion\"\x97\x02\n" +
+	"\x0edaemon_version\x18\x15 \x01(\tR\rdaemonVersion\x12(\n" +
+	"\x10ssh_ingress_host\x18\x16 \x01(\tR\x0esshIngressHost\"\x97\x02\n" +
 	"\aGPUInfo\x122\n" +
 	"\x06vendor\x18\x01 \x01(\x0e2\x1a.containarium.v1.GPUVendorR\x06vendor\x12/\n" +
 	"\x05model\x18\x02 \x01(\x0e2\x19.containarium.v1.GPUModelR\x05model\x12\x1d\n" +

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -1537,8 +1537,16 @@ type DebugContainerResponse struct {
 	// Daemon version (containarium binary) that generated this report.
 	// Pair with source_repo to read code at the exact commit/tag.
 	DaemonVersion string `protobuf:"bytes,9,opt,name=daemon_version,json=daemonVersion,proto3" json:"daemon_version,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Public SSH entrypoint (the sentinel host) clients dial to reach
+	// containers on this backend — the daemon's advertised --ssh-host.
+	// **Empty means this backend advertises NO external SSH entrypoint**
+	// (direct / in-network mode: reach the container by IP, or deploy through
+	// an in-network pipeline). When empty, the sentinel-side remediation hints
+	// don't apply — there is no sentinel to check. Lets an agent stop hunting
+	// for a jump host that doesn't exist. See #1011.
+	SshIngressHost string `protobuf:"bytes,10,opt,name=ssh_ingress_host,json=sshIngressHost,proto3" json:"ssh_ingress_host,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *DebugContainerResponse) Reset() {
@@ -1630,6 +1638,13 @@ func (x *DebugContainerResponse) GetSourceRepo() string {
 func (x *DebugContainerResponse) GetDaemonVersion() string {
 	if x != nil {
 		return x.DaemonVersion
+	}
+	return ""
+}
+
+func (x *DebugContainerResponse) GetSshIngressHost() string {
+	if x != nil {
+		return x.SshIngressHost
 	}
 	return ""
 }
@@ -4531,7 +4546,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\tcontainer\x18\x01 \x01(\v2\x1a.containarium.v1.ContainerR\tcontainer\x12;\n" +
 	"\ametrics\x18\x02 \x01(\v2!.containarium.v1.ContainerMetricsR\ametrics\"3\n" +
 	"\x15DebugContainerRequest\x12\x1a\n" +
-	"\busername\x18\x01 \x01(\tR\busername\"\x8c\x03\n" +
+	"\busername\x18\x01 \x01(\tR\busername\"\xb6\x03\n" +
 	"\x16DebugContainerResponse\x12'\n" +
 	"\x0fcontainer_state\x18\x01 \x01(\tR\x0econtainerState\x12(\n" +
 	"\x10host_user_exists\x18\x02 \x01(\bR\x0ehostUserExists\x12&\n" +
@@ -4542,7 +4557,9 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\fnext_actions\x18\a \x03(\tR\vnextActions\x12\x1f\n" +
 	"\vsource_repo\x18\b \x01(\tR\n" +
 	"sourceRepo\x12%\n" +
-	"\x0edaemon_version\x18\t \x01(\tR\rdaemonVersion\"J\n" +
+	"\x0edaemon_version\x18\t \x01(\tR\rdaemonVersion\x12(\n" +
+	"\x10ssh_ingress_host\x18\n" +
+	" \x01(\tR\x0esshIngressHost\"J\n" +
 	"\x16DeleteContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x14\n" +
 	"\x05force\x18\x02 \x01(\bR\x05force\"Z\n" +

--- a/proto/containarium/v1/config.proto
+++ b/proto/containarium/v1/config.proto
@@ -203,6 +203,15 @@ message SystemInfo {
   // fleet's running versions + drift are visible via get_system_info and
   // /v1/backends without SSHing each host. See #354.
   string daemon_version = 21;
+
+  // Public SSH entrypoint (the sentinel host) clients dial to reach this
+  // backend's containers — the daemon's advertised --ssh-host. **Empty means
+  // this backend advertises NO external SSH entrypoint** (direct / in-network
+  // mode: reach containers by IP, or deploy through an in-network pipeline).
+  // Surfaced so an agent can tell, from get_system_info alone, whether an
+  // external SSH/deploy entrypoint exists and what host it is — instead of
+  // assuming a sentinel that may not exist. See #1011.
+  string ssh_ingress_host = 22;
 }
 
 // GPU vendor enum

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -505,6 +505,15 @@ message DebugContainerResponse {
   // Daemon version (containarium binary) that generated this report.
   // Pair with source_repo to read code at the exact commit/tag.
   string daemon_version = 9;
+
+  // Public SSH entrypoint (the sentinel host) clients dial to reach
+  // containers on this backend — the daemon's advertised --ssh-host.
+  // **Empty means this backend advertises NO external SSH entrypoint**
+  // (direct / in-network mode: reach the container by IP, or deploy through
+  // an in-network pipeline). When empty, the sentinel-side remediation hints
+  // don't apply — there is no sentinel to check. Lets an agent stop hunting
+  // for a jump host that doesn't exist. See #1011.
+  string ssh_ingress_host = 10;
 }
 
 // DeleteContainerRequest is the request to delete a container


### PR DESCRIPTION
Closes #1011.

`debug_container`/`get_system_info` never exposed which sentinel fronts a backend, and `debug_container` emitted "check sentinel-side state" for **every** environment — even backends with no external SSH entrypoint (direct / in-network-CI-deploy). Agents then hunted a jump host that doesn't exist.

- **New `ssh_ingress_host`** on `DebugContainerResponse` + `SystemInfo` (proto+regen): the advertised `--ssh-host`, or **empty = no external SSH entrypoint** (direct/in-network mode). Machine-readable via both RPCs.
- `diagnose()` **drops the sentinel hints when empty** and says so; when set, substitutes the real host into the ssh/sshpiper suggestions.
- MCP client structs + `debug_container` tool description updated.

`go build ./...`, `go vet`, server+mcp tests all green. Proto regenerated in-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)