### PR TITLE
fix(cli): expose-port and route add/list/delete honor --http (#909)

### DIFF
--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -1720,3 +1720,113 @@ func (c *HTTPClient) GetLabels(username string) (map[string]string, error) {
 
 	return result.Labels, nil
 }
+
+// --- Proxy routes (#909) ---------------------------------------------------
+//
+// These mirror the GRPCClient route methods 1:1 so the CLI can pick either
+// transport behind one seam. The REST surface already exists via grpc-gateway
+// (GET/POST/DELETE /v1/network/routes[...]); only the typed HTTP client was
+// missing, which made expose-port / route add|list|delete gRPC-only.
+
+// AddRoute registers a domain → target IP:port mapping in the sentinel reverse
+// proxy (POST /v1/network/routes). Mirrors GRPCClient.AddRoute.
+func (c *HTTPClient) AddRoute(domain, targetIP string, targetPort int32, containerName, description string) (*pb.ProxyRoute, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	body := map[string]interface{}{
+		"domain":         domain,
+		"target_ip":      targetIP,
+		"target_port":    targetPort,
+		"container_name": containerName,
+		"description":    description,
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/network/routes", body)
+	if err != nil {
+		return nil, fmt.Errorf("add route: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, httpErr("add route", resp.StatusCode, bodyBytes)
+	}
+	out := &pb.AddRouteResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode add-route response: %w", err)
+	}
+	return out.GetRoute(), nil
+}
+
+// ListRoutes returns the proxy routes (GET /v1/network/routes), optionally
+// filtered by username / active-only via query params. Mirrors
+// GRPCClient.ListRoutes.
+func (c *HTTPClient) ListRoutes(username string, activeOnly bool) ([]*pb.ProxyRoute, int32, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	q := url.Values{}
+	if username != "" {
+		q.Set("username", username)
+	}
+	if activeOnly {
+		q.Set("active_only", "true")
+	}
+	path := "/v1/network/routes"
+	if enc := q.Encode(); enc != "" {
+		path += "?" + enc
+	}
+	resp, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list routes: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, 0, httpErr("list routes", resp.StatusCode, bodyBytes)
+	}
+	out := &pb.GetRoutesResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, 0, fmt.Errorf("decode list-routes response: %w", err)
+	}
+	return out.GetRoutes(), out.GetTotalCount(), nil
+}
+
+// DeleteRoute removes the proxy route for a domain (DELETE
+// /v1/network/routes/{domain}). Mirrors GRPCClient.DeleteRoute.
+func (c *HTTPClient) DeleteRoute(domain string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	path := "/v1/network/routes/" + url.PathEscape(domain)
+	resp, err := c.doRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return fmt.Errorf("delete route: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return httpErr("delete route", resp.StatusCode, bodyBytes)
+	}
+	return nil
+}
+
+// httpErr builds an error from a >=400 REST response, preferring the daemon's
+// {"error": ...} body over a bare status code.
+func httpErr(op string, status int, body []byte) error {
+	var e struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(body, &e) == nil {
+		if e.Error != "" {
+			return fmt.Errorf("%s: %s", op, e.Error)
+		}
+		if e.Message != "" {
+			return fmt.Errorf("%s: %s", op, e.Message)
+		}
+	}
+	return fmt.Errorf("%s: status %d", op, status)
+}

--- a/internal/cmd/expose_port.go
+++ b/internal/cmd/expose_port.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/footprintai/containarium/internal/client"
 	"github.com/footprintai/containarium/pkg/core/expose"
 	"github.com/spf13/cobra"
 )
@@ -55,13 +54,13 @@ func runExposePort(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--server is required")
 	}
 
-	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	apiClient, err := newRouteClient()
 	if err != nil {
 		return fmt.Errorf("failed to connect to server: %w", err)
 	}
-	defer func() { _ = grpcClient.Close() }()
+	defer func() { _ = apiClient.Close() }()
 
-	res, err := expose.Run(context.Background(), &grpcExposeAdapter{c: grpcClient}, expose.Options{
+	res, err := expose.Run(context.Background(), &exposeAdapter{c: apiClient}, expose.Options{
 		Username:      args[0],
 		ContainerPort: exposePortPort,
 		Domain:        exposePortDomain,
@@ -85,44 +84,6 @@ func runExposePort(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// grpcExposeAdapter implements expose.APIClient against the gRPC client.
-// LookupContainer is implemented via ListContainers + linear scan because
-// the gRPC surface doesn't expose a "by-name" lookup; this is fine for
-// the typical scale (tens of containers) and saves us a new RPC.
-type grpcExposeAdapter struct{ c *client.GRPCClient }
-
-func (a *grpcExposeAdapter) LookupContainer(_ context.Context, username string) (string, string, string, error) {
-	containers, err := a.c.ListContainers()
-	if err != nil {
-		return "", "", "", err
-	}
-	for _, ci := range containers {
-		// Container names follow the "<username>-container" convention
-		// per internal/cmd/list.go; accept either the full name or the
-		// bare username for ergonomic ergonomics.
-		if ci.Name == username || ci.Name == username+"-container" {
-			return ci.Name, ci.IPAddress, ci.State, nil
-		}
-	}
-	return "", "", "", fmt.Errorf("container %q not found", username)
-}
-
-func (a *grpcExposeAdapter) CreateRoute(_ context.Context, p expose.AddRouteParams) (*expose.RouteResult, error) {
-	route, err := a.c.AddRoute(p.Domain, p.TargetIP, p.TargetPort, p.ContainerName, p.Description)
-	if err != nil {
-		return nil, err
-	}
-	// The proto's ProxyRoute response doesn't echo ContainerName or
-	// the request's Domain field (it carries FullDomain); fall back to
-	// what the caller asked for so the result is always populated.
-	domain := route.FullDomain
-	if domain == "" {
-		domain = p.Domain
-	}
-	return &expose.RouteResult{
-		Domain:        domain,
-		ContainerName: p.ContainerName,
-		ContainerIP:   route.ContainerIp,
-		Port:          route.Port,
-	}, nil
-}
+// The expose.APIClient adapter (exposeAdapter) and transport selection
+// (newRouteClient) live in route_client.go and are shared with the
+// route add/list/delete verbs so all of them honor --http (#909).

--- a/internal/cmd/route_add.go
+++ b/internal/cmd/route_add.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/footprintai/containarium/internal/client"
 	"github.com/spf13/cobra"
 )
 
@@ -63,13 +62,13 @@ func runRouteAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid port: %s", parts[1])
 	}
 
-	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	apiClient, err := newRouteClient()
 	if err != nil {
 		return fmt.Errorf("failed to connect to server: %w", err)
 	}
-	defer func() { _ = grpcClient.Close() }()
+	defer func() { _ = apiClient.Close() }()
 
-	route, err := grpcClient.AddRoute(domain, targetIP, int32(targetPort), routeAddContainer, routeAddDescription)
+	route, err := apiClient.AddRoute(domain, targetIP, int32(targetPort), routeAddContainer, routeAddDescription)
 	if err != nil {
 		return fmt.Errorf("failed to add route: %w", err)
 	}

--- a/internal/cmd/route_client.go
+++ b/internal/cmd/route_client.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/footprintai/containarium/internal/client"
+	"github.com/footprintai/containarium/pkg/core/expose"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// routeAPI is the subset of client methods the route / expose-port verbs need.
+// Both *client.GRPCClient and *client.HTTPClient satisfy it, so those verbs can
+// honor --http the same way list / create / connect / … already do — instead
+// of hardcoding gRPC and failing with an opaque name-resolver error against an
+// https:// server. See #909.
+type routeAPI interface {
+	AddRoute(domain, targetIP string, targetPort int32, containerName, description string) (*pb.ProxyRoute, error)
+	ListRoutes(username string, activeOnly bool) ([]*pb.ProxyRoute, int32, error)
+	DeleteRoute(domain string) error
+	ListContainers() ([]incus.ContainerInfo, error)
+	Close() error
+}
+
+// newRouteClient returns an HTTP client in --http mode (when a --server is set)
+// and a gRPC client otherwise, mirroring how the other verbs pick their
+// transport. Caller must Close() the result.
+func newRouteClient() (routeAPI, error) {
+	if httpMode && serverAddr != "" {
+		return client.NewHTTPClient(serverAddr, authToken)
+	}
+	return client.NewGRPCClient(serverAddr, certsDir, insecure)
+}
+
+// exposeAdapter implements expose.APIClient over either transport. LookupContainer
+// is a ListContainers + linear scan (the surface has no by-name lookup); this is
+// fine at the typical scale and matches the previous gRPC-only adapter.
+type exposeAdapter struct{ c routeAPI }
+
+func (a *exposeAdapter) LookupContainer(_ context.Context, username string) (string, string, string, error) {
+	containers, err := a.c.ListContainers()
+	if err != nil {
+		return "", "", "", err
+	}
+	for _, ci := range containers {
+		// Names follow the "<username>-container" convention; accept either
+		// the full name or the bare username.
+		if ci.Name == username || ci.Name == username+"-container" {
+			return ci.Name, ci.IPAddress, ci.State, nil
+		}
+	}
+	return "", "", "", fmt.Errorf("container %q not found", username)
+}
+
+func (a *exposeAdapter) CreateRoute(_ context.Context, p expose.AddRouteParams) (*expose.RouteResult, error) {
+	route, err := a.c.AddRoute(p.Domain, p.TargetIP, p.TargetPort, p.ContainerName, p.Description)
+	if err != nil {
+		return nil, err
+	}
+	// The ProxyRoute response carries FullDomain, not the request's Domain /
+	// ContainerName; fall back to what the caller asked for.
+	domain := route.GetFullDomain()
+	if domain == "" {
+		domain = p.Domain
+	}
+	return &expose.RouteResult{
+		Domain:        domain,
+		ContainerName: p.ContainerName,
+		ContainerIP:   route.GetContainerIp(),
+		Port:          route.GetPort(),
+	}, nil
+}

--- a/internal/cmd/route_delete.go
+++ b/internal/cmd/route_delete.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/footprintai/containarium/internal/client"
 	"github.com/spf13/cobra"
 )
 
@@ -31,13 +30,13 @@ func runRouteDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--server is required")
 	}
 
-	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	apiClient, err := newRouteClient()
 	if err != nil {
 		return fmt.Errorf("failed to connect to server: %w", err)
 	}
-	defer func() { _ = grpcClient.Close() }()
+	defer func() { _ = apiClient.Close() }()
 
-	if err := grpcClient.DeleteRoute(domain); err != nil {
+	if err := apiClient.DeleteRoute(domain); err != nil {
 		return fmt.Errorf("failed to delete route: %w", err)
 	}
 

--- a/internal/cmd/route_list.go
+++ b/internal/cmd/route_list.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/footprintai/containarium/internal/client"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/spf13/cobra"
 )
@@ -40,13 +39,13 @@ func runRouteList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--server is required")
 	}
 
-	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	apiClient, err := newRouteClient()
 	if err != nil {
 		return fmt.Errorf("failed to connect to server: %w", err)
 	}
-	defer func() { _ = grpcClient.Close() }()
+	defer func() { _ = apiClient.Close() }()
 
-	routes, totalCount, err := grpcClient.ListRoutes("", false)
+	routes, totalCount, err := apiClient.ListRoutes("", false)
 	if err != nil {
 		return fmt.Errorf("failed to list routes: %w", err)
 	}


### PR DESCRIPTION
Closes #909.

`expose-port` and `route add|list|delete` hardcoded the gRPC client, so against an `https://` REST server they failed with an opaque gRPC name-resolver error even with `--http` — unlike every other verb. The REST surface already existed (grpc-gateway + the MCP `expose_port` tool use it); only the typed HTTP client + wiring were missing.

- **HTTP client**: add `AddRoute`/`ListRoutes`/`DeleteRoute` mirroring the gRPC signatures (protojson-decoded, like the other 52 methods).
- **New `route_client.go`**: a `routeAPI` seam both clients satisfy, `newRouteClient()` (HTTP in `--http` mode else gRPC), and a shared `exposeAdapter` — same selection list/create/… use.
- The four verbs now pick their transport via `newRouteClient()`.

`go build ./...`, `go vet`, expose+client tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)