### PR TITLE
feat(sentinel): BYOC public HTTP ingress — TLS-terminate + plaintext-forward (#733, slice 1/3)

### DIFF
--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -199,6 +199,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 			tunnelServer.OnConnect = manager.OnTunnelConnect
 			tunnelServer.OnDisconnect = manager.OnTunnelDisconnect
 			manager.SetTunnelRegistry(registry)
+			manager.InitBYOCRoutes(sentinel.DefaultBYOCRouteStorePath)
 			manager.SetTunnelPolicy(tunnelPolicy)
 			manager.SetHTTPSListener(connMux.HTTPSChanListener())
 
@@ -285,6 +286,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 		tunnelServer.OnConnect = manager.OnTunnelConnect
 		tunnelServer.OnDisconnect = manager.OnTunnelDisconnect
 		manager.SetTunnelRegistry(registry)
+		manager.InitBYOCRoutes(sentinel.DefaultBYOCRouteStorePath)
 		manager.SetTunnelPolicy(tunnelPolicy)
 		manager.SetHTTPSListener(connMux.HTTPSChanListener())
 

--- a/internal/sentinel/binaryserver.go
+++ b/internal/sentinel/binaryserver.go
@@ -112,6 +112,12 @@ func StartBinaryServer(port int, manager *Manager) (stop func(), err error) {
 	// cluster-wide daemon HMAC secret. See TunnelTokenRegisterHandler.
 	mux.Handle("/sentinel/tunnel-tokens", auth.SentinelHMACMiddleware(manager.adminSecret, manager.TunnelTokenRegisterHandler()))
 
+	// Cloud pushes the authoritative BYOC public-ingress bindings
+	// (subdomain → tunnel host) here. Gated by the admin secret (an
+	// authority decision, like tunnel-token registration) — never the
+	// cluster-wide daemon secret. See #733.
+	mux.Handle("/sentinel/byoc-routes", auth.SentinelHMACMiddleware(manager.adminSecret, manager.BYOCRouteRegisterHandler()))
+
 	// Peer proxy — forwards /peer/<backend-id>/* to the tunnel backend's loopback
 	// This allows the primary daemon to reach tunnel backends through the sentinel
 	// without needing extra firewall rules for external ports.

--- a/internal/sentinel/byoc_ingress_test.go
+++ b/internal/sentinel/byoc_ingress_test.go
@@ -1,0 +1,109 @@
+package sentinel
+
+import (
+	"bufio"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBYOCRouteRegisterHandler_SyncsFullSet(t *testing.T) {
+	m := &Manager{byocRoutes: NewBYOCRouteRegistry(), byocRouteStorePath: t.TempDir() + "/byoc.json"}
+	h := m.BYOCRouteRegisterHandler()
+
+	// Non-POST rejected.
+	rr := httptest.NewRecorder()
+	h(rr, httptest.NewRequest(http.MethodGet, "/sentinel/byoc-routes", nil))
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET code = %d, want 405", rr.Code)
+	}
+
+	// POST a full set → stored + persisted.
+	body := `{"routes":[{"hostname":"x-acme.containarium.dev","backend_id":"tunnel-h1","port":8080}]}`
+	rr = httptest.NewRecorder()
+	h(rr, httptest.NewRequest(http.MethodPost, "/sentinel/byoc-routes", strings.NewReader(body)))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("POST code = %d, want 204", rr.Code)
+	}
+	if got, ok := m.byocRoutes.Lookup("x-acme.containarium.dev"); !ok || got.Port != 8080 {
+		t.Fatalf("route not stored: %+v ok=%v", got, ok)
+	}
+
+	// A second POST with a different set replaces the first (full-set sync).
+	rr = httptest.NewRecorder()
+	h(rr, httptest.NewRequest(http.MethodPost, "/sentinel/byoc-routes",
+		strings.NewReader(`{"routes":[{"hostname":"y.containarium.dev","backend_id":"tunnel-h2","port":9000}]}`)))
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("second POST code = %d", rr.Code)
+	}
+	if _, ok := m.byocRoutes.Lookup("x-acme.containarium.dev"); ok {
+		t.Fatal("full-set sync must drop the previous binding")
+	}
+	if _, ok := m.byocRoutes.Lookup("y.containarium.dev"); !ok {
+		t.Fatal("full-set sync must store the new binding")
+	}
+
+	// Disabled sentinel (nil registry) → 501.
+	rr = httptest.NewRecorder()
+	(&Manager{}).BYOCRouteRegisterHandler()(rr, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)))
+	if rr.Code != http.StatusNotImplemented {
+		t.Fatalf("nil-registry code = %d, want 501", rr.Code)
+	}
+}
+
+// TestServeBYOCIngress_TerminatesTLSAndProxiesOverTunnel drives the full path:
+// a TLS client → serveBYOCIngress (terminates TLS with the cert store) →
+// reverse-proxy → injected "tunnel" dial → a plaintext HTTP backend. Asserts
+// the box sees the preserved Host header and the client gets the box's body.
+func TestServeBYOCIngress_TerminatesTLSAndProxiesOverTunnel(t *testing.T) {
+	// The "box" behind the tunnel: a plaintext HTTP server that echoes Host.
+	var gotHost, gotSpotID string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		_, _ = io.WriteString(w, "hello from box")
+	}))
+	defer backend.Close()
+
+	m := &Manager{certStore: NewCertStore(), byocRoutes: NewBYOCRouteRegistry()}
+	m.byocDial = func(spotID string, port int) (net.Conn, error) {
+		gotSpotID = spotID // must be "tunnel-" stripped
+		return net.Dial("tcp", backend.Listener.Addr().String())
+	}
+	route := BYOCRoute{Hostname: "app-acme.containarium.dev", BackendID: "tunnel-h1", Port: 8080}
+
+	clientConn, serverConn := net.Pipe()
+	go m.serveBYOCIngress(serverConn, route)
+
+	tlsClient := tls.Client(clientConn, &tls.Config{
+		InsecureSkipVerify: true, // the cert store serves its self-signed fallback in this test
+		ServerName:         route.Hostname,
+	})
+	defer func() { _ = tlsClient.Close() }()
+	_ = tlsClient.SetDeadline(time.Now().Add(10 * time.Second))
+
+	req, _ := http.NewRequest(http.MethodGet, "https://"+route.Hostname+"/path", nil)
+	if err := req.Write(tlsClient); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(tlsClient), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	b, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK || string(b) != "hello from box" {
+		t.Fatalf("resp = %d %q", resp.StatusCode, string(b))
+	}
+	if gotHost != route.Hostname {
+		t.Fatalf("box saw Host = %q, want %q (Host must be preserved)", gotHost, route.Hostname)
+	}
+	if gotSpotID != "h1" {
+		t.Fatalf("dial spotID = %q, want %q (tunnel- prefix stripped)", gotSpotID, "h1")
+	}
+}

--- a/internal/sentinel/byoc_route_handler.go
+++ b/internal/sentinel/byoc_route_handler.go
@@ -1,0 +1,71 @@
+package sentinel
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// BYOCRouteSyncRequest is the JSON body POSTed to BYOCRouteRegisterHandler
+// by the cloud to push the FULL authoritative set of BYOC public-ingress
+// bindings. Full-set (not delta): the sentinel replaces its map wholesale,
+// so a binding the cloud dropped disappears without a separate delete, and
+// the state converges after a sentinel restart or a missed event. #733.
+type BYOCRouteSyncRequest struct {
+	Routes []BYOCRoute `json:"routes"`
+}
+
+// BYOCRouteRegisterHandler lets the cloud control plane push the
+// authoritative `subdomain → BYOC host` bindings onto a running sentinel.
+// The sentinel's SNI router consults these to terminate TLS for a tenant
+// subdomain and plaintext-forward to the box over the tunnel (#733).
+//
+// Gated by CONTAINARIUM_SENTINEL_ADMIN_SECRET (the same higher-privilege
+// secret that guards tunnel-token registration) — deliberately NOT the
+// cluster-wide CONTAINARIUM_SENTINEL_AUTH_SECRET every daemon holds.
+// Binding a public hostname to a backend is an authority decision: only
+// the cloud may make it, and a host must never be able to claim a
+// hostname itself (anti-hijack).
+func (m *Manager) BYOCRouteRegisterHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		if m.byocRoutes == nil {
+			http.Error(w, `{"error":"byoc ingress not enabled on this sentinel","code":501}`, http.StatusNotImplemented)
+			return
+		}
+		var req BYOCRouteSyncRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+			return
+		}
+
+		m.byocRoutes.ReplaceAll(req.Routes)
+
+		// Persist the (validated) current set so it survives a restart
+		// without waiting for the cloud's next reconcile. Best-effort:
+		// a persistence failure must not fail the push — the bindings are
+		// already live for this process, and the cloud re-pushes on its
+		// loop anyway.
+		if err := m.persistBYOCRoutes(); err != nil {
+			log.Printf("[sentinel] WARNING: failed to persist byoc routes (won't survive a restart until next cloud sync): %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// persistBYOCRoutes writes the registry's current snapshot to the store
+// path. Safe to call with a nil store path (no-op) so tests and
+// unconfigured deployments don't error.
+func (m *Manager) persistBYOCRoutes() error {
+	if m.byocRoutes == nil {
+		return nil
+	}
+	path := m.byocRouteStorePath
+	if path == "" {
+		path = DefaultBYOCRouteStorePath
+	}
+	return SaveBYOCRouteStore(path, m.byocRoutes.Snapshot())
+}

--- a/internal/sentinel/byoc_routes.go
+++ b/internal/sentinel/byoc_routes.go
@@ -1,0 +1,145 @@
+package sentinel
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// DefaultBYOCRouteStorePath is where cloud-pushed BYOC public-ingress
+// bindings (see BYOCRouteRegisterHandler) are persisted so a sentinel
+// restart doesn't drop every tenant subdomain until the cloud's next
+// reconcile tick. Mirrors DefaultTunnelTokenStorePath. See #733.
+const DefaultBYOCRouteStorePath = "/etc/containarium/byoc-routes.json"
+
+// BYOCRoute is one authoritative `subdomain → BYOC host` binding, pushed
+// by the cloud (the sole authority — hosts never self-announce, which
+// would let a compromised host hijack another tenant's hostname). The
+// sentinel terminates TLS for Hostname with the wildcard it already
+// holds and plaintext-forwards to the box over the tunnel:
+// DialTunnel(BackendID, Port). See #733.
+type BYOCRoute struct {
+	// Hostname is the exact public name the cloud minted, e.g.
+	// "myapp-acme.containarium.dev". Matched against the TLS SNI.
+	Hostname string `json:"hostname"`
+
+	// BackendID is the tunnel spot id the box lives behind (the value
+	// the sentinel's tunnel registry keys on; a leading "tunnel-" prefix
+	// is tolerated and stripped at dial time, matching the primary path).
+	BackendID string `json:"backend_id"`
+
+	// Port is the plaintext port on the host (tunnel-forwarded) that
+	// reaches the box's HTTP, e.g. 8080.
+	Port int `json:"port"`
+}
+
+// BYOCRouteRegistry is the sentinel's in-memory, cloud-authoritative map
+// of BYOC public-ingress bindings, consulted by the SNI router. It is a
+// sibling of PrimaryRegistry/TunnelRegistry but is NEVER populated by a
+// host self-announce — only by ReplaceAll/Upsert from the admin-secret
+// -gated push endpoint. Concurrency-safe.
+type BYOCRouteRegistry struct {
+	mu     sync.RWMutex
+	routes map[string]BYOCRoute // keyed by Hostname
+}
+
+// NewBYOCRouteRegistry returns an empty registry.
+func NewBYOCRouteRegistry() *BYOCRouteRegistry {
+	return &BYOCRouteRegistry{routes: make(map[string]BYOCRoute)}
+}
+
+// Lookup returns the binding for a hostname, or ok=false.
+func (r *BYOCRouteRegistry) Lookup(hostname string) (BYOCRoute, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	route, ok := r.routes[hostname]
+	return route, ok
+}
+
+// ReplaceAll swaps the entire binding set atomically. This is the primary
+// mutation: the cloud pushes the full authoritative set each reconcile
+// tick, so a binding the cloud dropped disappears here without a separate
+// delete (idempotent, converges after a sentinel restart or a missed
+// delete). Entries with an empty Hostname/BackendID or non-positive Port
+// are skipped as malformed.
+func (r *BYOCRouteRegistry) ReplaceAll(routes []BYOCRoute) {
+	next := make(map[string]BYOCRoute, len(routes))
+	for _, rt := range routes {
+		if rt.Hostname == "" || rt.BackendID == "" || rt.Port <= 0 {
+			continue
+		}
+		next[rt.Hostname] = rt
+	}
+	r.mu.Lock()
+	r.routes = next
+	r.mu.Unlock()
+}
+
+// Snapshot returns the current bindings as a slice (for persistence).
+func (r *BYOCRouteRegistry) Snapshot() []BYOCRoute {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]BYOCRoute, 0, len(r.routes))
+	for _, rt := range r.routes {
+		out = append(out, rt)
+	}
+	return out
+}
+
+// LoadBYOCRouteStore reads previously-persisted bindings from path. A
+// missing file is not an error (fresh sentinel) — returns an empty slice.
+func LoadBYOCRouteStore(path string) ([]BYOCRoute, error) {
+	b, err := os.ReadFile(path) // #nosec G304 -- fixed, operator-controlled path
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read byoc route store %s: %w", path, err)
+	}
+	if len(b) == 0 {
+		return nil, nil
+	}
+	var routes []BYOCRoute
+	if err := json.Unmarshal(b, &routes); err != nil {
+		return nil, fmt.Errorf("parse byoc route store %s: %w", path, err)
+	}
+	return routes, nil
+}
+
+// SaveBYOCRouteStore atomically persists the full binding set to path at
+// mode 0600. Mirrors SaveTunnelTokenStore. (Bindings aren't secrets, but
+// 0600 matches the sentinel's other operator-state files and costs
+// nothing.)
+func SaveBYOCRouteStore(path string, routes []BYOCRoute) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create byoc route store dir %s: %w", dir, err)
+	}
+	b, err := json.Marshal(routes)
+	if err != nil {
+		return fmt.Errorf("marshal byoc route store: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".byoc-routes-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp byoc route store: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }() // no-op if the rename succeeded
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp byoc route store: %w", err)
+	}
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp byoc route store: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp byoc route store: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename byoc route store into place: %w", err)
+	}
+	return nil
+}

--- a/internal/sentinel/byoc_routes_test.go
+++ b/internal/sentinel/byoc_routes_test.go
@@ -1,0 +1,75 @@
+package sentinel
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestBYOCRouteRegistry_ReplaceAllAndLookup(t *testing.T) {
+	r := NewBYOCRouteRegistry()
+
+	if _, ok := r.Lookup("nope.containarium.dev"); ok {
+		t.Fatal("empty registry should not resolve anything")
+	}
+
+	r.ReplaceAll([]BYOCRoute{
+		{Hostname: "a-acme.containarium.dev", BackendID: "tunnel-h1", Port: 8080},
+		{Hostname: "b-acme.containarium.dev", BackendID: "tunnel-h2", Port: 3000},
+		// malformed entries must be dropped, not stored:
+		{Hostname: "", BackendID: "tunnel-h3", Port: 8080},
+		{Hostname: "c.containarium.dev", BackendID: "", Port: 8080},
+		{Hostname: "d.containarium.dev", BackendID: "tunnel-h4", Port: 0},
+	})
+
+	got, ok := r.Lookup("a-acme.containarium.dev")
+	if !ok || got.BackendID != "tunnel-h1" || got.Port != 8080 {
+		t.Fatalf("lookup a = %+v ok=%v", got, ok)
+	}
+	if _, ok := r.Lookup("c.containarium.dev"); ok {
+		t.Fatal("malformed (empty backend) entry must be dropped")
+	}
+	if _, ok := r.Lookup("d.containarium.dev"); ok {
+		t.Fatal("malformed (zero port) entry must be dropped")
+	}
+	if n := len(r.Snapshot()); n != 2 {
+		t.Fatalf("snapshot len = %d, want 2 (malformed dropped)", n)
+	}
+
+	// ReplaceAll is a full swap: a hostname absent from the new set is gone.
+	r.ReplaceAll([]BYOCRoute{{Hostname: "b-acme.containarium.dev", BackendID: "tunnel-h2", Port: 3000}})
+	if _, ok := r.Lookup("a-acme.containarium.dev"); ok {
+		t.Fatal("ReplaceAll must drop hostnames not in the new set")
+	}
+	if _, ok := r.Lookup("b-acme.containarium.dev"); !ok {
+		t.Fatal("ReplaceAll must keep hostnames in the new set")
+	}
+}
+
+func TestBYOCRouteStore_SaveLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "byoc-routes.json")
+
+	// Loading a missing file is not an error.
+	if routes, err := LoadBYOCRouteStore(path); err != nil || routes != nil {
+		t.Fatalf("missing file: routes=%v err=%v", routes, err)
+	}
+
+	want := []BYOCRoute{
+		{Hostname: "a.containarium.dev", BackendID: "tunnel-h1", Port: 8080},
+		{Hostname: "b.containarium.dev", BackendID: "tunnel-h2", Port: 3000},
+	}
+	if err := SaveBYOCRouteStore(path, want); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := LoadBYOCRouteStore(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	byHost := func(s []BYOCRoute) { sort.Slice(s, func(i, j int) bool { return s[i].Hostname < s[j].Hostname }) }
+	byHost(got)
+	byHost(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("roundtrip mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+}

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/http/httputil"
 	"os"
 	"strconv"
 	"strings"
@@ -96,6 +97,18 @@ type Manager struct {
 	// primaries instead of going through a loopback TCP proxy listener
 	// — which would collide with the sentinel's own ConnMux on :443.
 	tunnelRegistry *TunnelRegistry
+
+	// byocRoutes holds cloud-pushed BYOC public-ingress bindings
+	// (subdomain → tunnel host). The SNI router consults it to terminate
+	// TLS for a tenant subdomain and plaintext-forward to the box over the
+	// tunnel. Populated ONLY by the admin-secret-gated push endpoint (never
+	// by a host self-announce = anti-hijack). byocRouteStorePath overrides
+	// the default persist path (tests set it). See #733.
+	byocRoutes         *BYOCRouteRegistry
+	byocRouteStorePath string
+	// byocDial opens a plaintext stream to a box over the tunnel for BYOC
+	// ingress. Defaults to tunnelRegistry.DialTunnel; tests inject a fake.
+	byocDial func(spotID string, port int) (net.Conn, error)
 
 	stopMaintenance func() // stops the HTTP/HTTPS maintenance servers
 	certStore       *CertStore
@@ -289,12 +302,13 @@ func NewManager(config Config, provider CloudProvider) *Manager {
 		config.RecoveryBackoffMax = config.RecoveryBackoffInitial
 	}
 	m := &Manager{
-		config:    config,
-		provider:  provider,
-		backends:  NewBackendPool(),
-		primaries: NewPrimaryRegistry(),
-		certStore: NewCertStore(),
-		keyStore:  NewKeyStore(),
+		config:     config,
+		provider:   provider,
+		backends:   NewBackendPool(),
+		primaries:  NewPrimaryRegistry(),
+		byocRoutes: NewBYOCRouteRegistry(),
+		certStore:  NewCertStore(),
+		keyStore:   NewKeyStore(),
 	}
 	if raw := os.Getenv(appconfig.EnvSentinelAuthSecret); raw != "" {
 		if len(raw) < auth.SentinelMinSecretLen {
@@ -370,6 +384,29 @@ func NewManager(config Config, provider CloudProvider) *Manager {
 // the SNI router falls back to TCP-dialing the primary's IP:Port.
 func (m *Manager) SetTunnelRegistry(reg *TunnelRegistry) {
 	m.tunnelRegistry = reg
+}
+
+// InitBYOCRoutes sets the persist path for cloud-pushed BYOC public-ingress
+// bindings and loads any previously-persisted set into the registry, so a
+// restart re-serves tenant subdomains before the cloud's next reconcile tick.
+// A missing/unreadable store is logged and ignored. See #733.
+func (m *Manager) InitBYOCRoutes(storePath string) {
+	if storePath == "" {
+		storePath = DefaultBYOCRouteStorePath
+	}
+	m.byocRouteStorePath = storePath
+	if m.byocRoutes == nil {
+		m.byocRoutes = NewBYOCRouteRegistry()
+	}
+	routes, err := LoadBYOCRouteStore(storePath)
+	if err != nil {
+		log.Printf("[sentinel] WARNING: failed to load persisted byoc routes from %s: %v", storePath, err)
+		return
+	}
+	if len(routes) > 0 {
+		log.Printf("[sentinel] loaded %d persisted byoc route(s) from %s", len(routes), storePath)
+	}
+	m.byocRoutes.ReplaceAll(routes)
 }
 
 // SetTunnelPolicy wires in the token-authorization policy the tunnel
@@ -954,6 +991,18 @@ func (m *Manager) buildSNIRoutingHandler(fallbackTarget string) func(net.Conn) {
 			err error
 		)
 		if peekErr == nil && sni != "" {
+			// BYOC public ingress (#733): a cloud-pushed subdomain binding
+			// for a box on a tunnel host. Unlike the primary path (raw TLS
+			// passthrough to a host that terminates), the BYOC host has no
+			// cert — so the sentinel terminates TLS here with the wildcard
+			// it already holds and plaintext-forwards to the box over the
+			// tunnel. serveBYOCIngress takes over the connection entirely.
+			if m.byocRoutes != nil {
+				if route, ok := m.byocRoutes.Lookup(sni); ok {
+					m.serveBYOCIngress(peekedConn, route)
+					return
+				}
+			}
 			p := m.primaries.LookupByHostname(sni)
 			if p == nil {
 				p = m.primaries.LookupByBaseDomainSuffix(sni)
@@ -996,6 +1045,118 @@ func (m *Manager) buildSNIRoutingHandler(fallbackTarget string) func(net.Conn) {
 		go func() { _, _ = io.Copy(peekedConn, dst); done <- struct{}{} }()
 		<-done
 	}
+}
+
+// serveBYOCIngress serves one public-ingress connection for a BYOC tenant
+// subdomain (#733). Unlike the raw TLS passthrough the primary path uses, the
+// BYOC host has no cert — so the sentinel TERMINATES TLS here with the
+// `*.containarium.dev` wildcard it already syncs (CertStore.GetCertificate),
+// then reverse-proxies the decrypted HTTP to the box by PLAINTEXT-forwarding
+// over the tunnel: every request dials a fresh yamux stream via
+// DialTunnel(spotID, route.Port). The box (and host) need no cert.
+//
+// It takes over conn entirely (terminates + serves), so the caller must return
+// after invoking it rather than falling through to the passthrough copy.
+func (m *Manager) serveBYOCIngress(conn net.Conn, route BYOCRoute) {
+	dial := m.byocDial
+	if dial == nil && m.tunnelRegistry != nil {
+		dial = func(spotID string, port int) (net.Conn, error) {
+			return m.tunnelRegistry.DialTunnel(spotID, port)
+		}
+	}
+	if dial == nil || m.certStore == nil {
+		_ = conn.Close()
+		return
+	}
+
+	tlsConn := tls.Server(conn, &tls.Config{
+		MinVersion:     tls.VersionTLS12,
+		GetCertificate: m.certStore.GetCertificate,
+	})
+	if err := tlsConn.Handshake(); err != nil {
+		_ = tlsConn.Close()
+		return
+	}
+	defer func() { _ = tlsConn.Close() }()
+
+	// Dial target is the box's plaintext HTTP port over the tunnel; spotID is
+	// the tunnel key (mirror the primary path's "tunnel-" prefix stripping).
+	spotID := strings.TrimPrefix(route.BackendID, "tunnel-")
+	proxy := &httputil.ReverseProxy{
+		Director: func(r *http.Request) {
+			// Preserve the client's Host (r.Host) — the box's Caddy routes by
+			// it. The scheme is plaintext over the tunnel; the URL host is a
+			// placeholder (the dial ignores it and routes by spotID).
+			r.URL.Scheme = "http"
+			r.URL.Host = route.Hostname
+		},
+		Transport: &http.Transport{
+			// Every request opens a fresh tunnel stream — DialTunnel routes by
+			// spotID, so the dial address is ignored. No cross-request pooling
+			// over the tunnel (one yamux stream per request; correctness over
+			// throughput for v1).
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return dial(spotID, route.Port)
+			},
+			DisableKeepAlives: true,
+		},
+		ErrorLog: log.Default(),
+	}
+
+	// Serve HTTP over the single terminated-TLS connection. A blocking one-shot
+	// listener hands the conn to http.Server once, then blocks Accept until the
+	// conn closes — so Serve (and this func's deferred Close) doesn't tear the
+	// connection down mid-response. IdleTimeout bounds an idle keep-alive conn
+	// so the serving goroutine can't leak.
+	srv := &http.Server{
+		Handler:           proxy,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	_ = srv.Serve(newOneShotListener(tlsConn))
+}
+
+// oneShotListener feeds a single already-accepted conn to an http.Server, then
+// blocks Accept until that conn closes so Serve stays alive for the whole
+// (possibly keep-alive) connection and returns only once it's done. This avoids
+// the premature teardown a return-ErrClosed-immediately listener causes for a
+// proxied response. See #733.
+type oneShotListener struct {
+	ch     chan net.Conn
+	closed chan struct{}
+	conn   net.Conn
+}
+
+func newOneShotListener(conn net.Conn) *oneShotListener {
+	l := &oneShotListener{ch: make(chan net.Conn, 1), closed: make(chan struct{})}
+	nc := &notifyConn{Conn: conn, closed: l.closed}
+	l.conn = nc
+	l.ch <- nc
+	close(l.ch)
+	return l
+}
+
+func (l *oneShotListener) Accept() (net.Conn, error) {
+	if c, ok := <-l.ch; ok {
+		return c, nil
+	}
+	<-l.closed // block until the served conn is closed, then let Serve return
+	return nil, net.ErrClosed
+}
+func (l *oneShotListener) Close() error   { return nil }
+func (l *oneShotListener) Addr() net.Addr { return l.conn.LocalAddr() }
+
+// notifyConn closes `closed` exactly once when the wrapped conn is closed, so
+// oneShotListener learns the served connection is done.
+type notifyConn struct {
+	net.Conn
+	once   sync.Once
+	closed chan struct{}
+}
+
+func (c *notifyConn) Close() error {
+	c.once.Do(func() { close(c.closed) })
+	return c.Conn.Close()
 }
 
 // writeProxyHeader writes a PROXY v2 header to dst describing the client TCP


### PR DESCRIPTION
Part of #733 (per `docs/BYOC-PUBLIC-INGRESS-DESIGN.md`). **Slice 1 of 3: the sentinel-side surface.**

A box on a tunnel-joined BYOC host has no public HTTP path — terminating TLS on the host would leak a `*.containarium.dev` cert to third-party hosts, so the **sentinel terminates TLS with the wildcard it already syncs and plaintext-forwards to the box over the tunnel** (host needs no cert).

- **`BYOCRouteRegistry` + JSON store**: cloud-authoritative `hostname → {backendID, port}`, full-set `ReplaceAll`, persisted 0600 + reloaded at startup (mirrors the tunnel-token store).
- **SNI router**: on a byocRoutes SNI hit, `serveBYOCIngress` terminates TLS (`CertStore.GetCertificate` wildcard) + reverse-proxies to `DialTunnel(spotID, port)` plaintext, Host preserved. Blocking one-shot listener prevents mid-response teardown.
- **Push endpoint** `POST /sentinel/byoc-routes`, gated by the **admin secret** (authority decision; never a host self-announce = anti-hijack). Full-set sync + persist.

Tests: registry/store, handler (full-set sync, 405/501), and an e2e `serveBYOCIngress` that TLS-terminates a client and proxies to a plaintext backend via an injected tunnel dial (Host preserved, `tunnel-` prefix stripped). Full sentinel suite + vet + `go build ./...` green.

**Follow-ups:** slice 2 — cloud pushes the bindings (`SentinelAdminClient.SyncBYOCRoutes` + the subdomain reconciler's BYOC branch); slice 3 — host-side box-port plumbing so `DialTunnel(spotID, port)` reaches the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)