### PR TITLE
feat(byoc-ingress): host-side plaintext ingress listener for sentinel-terminate BYOC HTTP (#733, slice 3)

### DIFF
--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -37,6 +37,20 @@ type ProxyManager struct {
 	// module. wafDirectives is the SecLang the engine loads (CRS + engine mode).
 	wafEnabled    bool
 	wafDirectives string
+	// byocIngressAddr, when non-empty, adds one extra plaintext listener to the
+	// edge server (e.g. "127.0.0.1:8081") that serves the SAME Host-matched
+	// routes as :443 but WITHOUT TLS — the sentinel-terminate BYOC public HTTP
+	// ingress data path (#733 slice 3). On a BYOC host the sentinel terminates
+	// TLS with the wildcard it holds and plaintext-forwards over the tunnel to
+	// this listener, which Host-routes to the box; the host needs no cert.
+	//
+	// MUST be loopback-scoped ("127.0.0.1:<port>") so it is reachable only via
+	// the tunnel client (which dials 127.0.0.1:<port>) and never from the LAN —
+	// it serves tenant routes in the clear. Empty = disabled (default): region
+	// hosts and non-BYOC deployments are byte-identical to before. Because it is
+	// not Caddy's http_port (80), automatic-HTTPS redirects don't apply — the
+	// listener serves the reverse_proxy routes directly as plaintext HTTP.
+	byocIngressAddr string
 }
 
 // RouteProtocol represents the protocol type for a route
@@ -121,6 +135,32 @@ func (p *ProxyManager) WithWAF(directives string) *ProxyManager {
 
 // WAFEnabled reports whether ingress WAF inspection is on.
 func (p *ProxyManager) WAFEnabled() bool { return p.wafEnabled }
+
+// WithBYOCIngress adds a loopback-scoped plaintext ingress listener to the edge
+// server for the sentinel-terminate BYOC public-HTTP-ingress path (#733). addr
+// should be "127.0.0.1:<port>"; an empty addr is a no-op (default: disabled).
+// Returns the manager for chaining. See the byocIngressAddr field doc.
+func (p *ProxyManager) WithBYOCIngress(addr string) *ProxyManager {
+	p.byocIngressAddr = strings.TrimSpace(addr)
+	return p
+}
+
+// BYOCIngressAddr returns the configured plaintext ingress listener address
+// (empty when disabled).
+func (p *ProxyManager) BYOCIngressAddr() string { return p.byocIngressAddr }
+
+// listenAddrs returns the edge server's listen set: always :80 and :443, plus
+// the BYOC plaintext ingress listener when configured (#733 slice 3). Centralised
+// so every place that (re)builds the server config — createHTTPApp and
+// createServerConfig, both reached by the #400 self-heal rebuild — agrees, so a
+// Caddy revert-and-rebuild doesn't silently drop the ingress listener.
+func (p *ProxyManager) listenAddrs() []string {
+	addrs := []string{":80", ":443"}
+	if p.byocIngressAddr != "" {
+		addrs = append(addrs, p.byocIngressAddr)
+	}
+	return addrs
+}
 
 // SetServerName sets the Caddy server name (useful when Caddy uses a custom server name)
 func (p *ProxyManager) SetServerName(name string) {
@@ -760,7 +800,7 @@ func (p *ProxyManager) createHTTPApp() error {
 	httpApp := CaddyHTTPApp{
 		Servers: map[string]*CaddyServerConfig{
 			p.serverName: {
-				Listen: []string{":80", ":443"},
+				Listen: p.listenAddrs(),
 				Routes: []CaddyRouteTyped{},
 			},
 		},
@@ -982,7 +1022,7 @@ func (p *ProxyManager) loadConfig(config map[string]interface{}) error {
 // createServerConfig creates the initial Caddy server configuration
 func (p *ProxyManager) createServerConfig() error {
 	config := CaddyServerConfig{
-		Listen: []string{":80", ":443"},
+		Listen: p.listenAddrs(),
 		Routes: []CaddyRouteTyped{},
 	}
 

--- a/internal/app/proxy_selfheal_test.go
+++ b/internal/app/proxy_selfheal_test.go
@@ -218,3 +218,105 @@ func TestBaseConfigIntact_MissingWrappersWhenProxyEnabled(t *testing.T) {
 		t.Error("expected intact=true for a present server when PROXY not configured")
 	}
 }
+
+// --- BYOC public-HTTP-ingress plaintext listener (#733 slice 3) ---
+
+// listenSetFromRebuild rebuilds the base config from a stub and returns srv0's
+// listen set as a string slice.
+func listenSetFromRebuild(t *testing.T, pm *ProxyManager, fc *rwFakeCaddy) []string {
+	t.Helper()
+	if _, err := pm.EnsureBaseConfig(); err != nil {
+		t.Fatalf("EnsureBaseConfig: %v", err)
+	}
+	srvNode := getMapField(getMapField(getMapField(getMapField(fc.config, "apps"), "http"), "servers"), DefaultCaddyServerName)
+	if srvNode == nil {
+		t.Fatal("expected srv0 present after rebuild")
+	}
+	raw, ok := srvNode["listen"].([]interface{})
+	if !ok {
+		t.Fatalf("srv0.listen is not a list: %T", srvNode["listen"])
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		out = append(out, v.(string))
+	}
+	return out
+}
+
+func TestListenAddrs_DefaultUnchanged(t *testing.T) {
+	pm := NewProxyManager("http://unused", "containarium.dev")
+	got := pm.listenAddrs()
+	want := []string{":80", ":443"}
+	if len(got) != len(want) {
+		t.Fatalf("default listen set = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("default listen set = %v, want %v", got, want)
+		}
+	}
+	if pm.BYOCIngressAddr() != "" {
+		t.Errorf("BYOCIngressAddr should be empty by default, got %q", pm.BYOCIngressAddr())
+	}
+}
+
+func TestListenAddrs_WithBYOCIngress(t *testing.T) {
+	pm := NewProxyManager("http://unused", "containarium.dev").WithBYOCIngress("127.0.0.1:8081")
+	got := pm.listenAddrs()
+	want := []string{":80", ":443", "127.0.0.1:8081"}
+	if len(got) != len(want) {
+		t.Fatalf("listen set = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("listen set = %v, want %v", got, want)
+		}
+	}
+	if pm.BYOCIngressAddr() != "127.0.0.1:8081" {
+		t.Errorf("BYOCIngressAddr = %q, want 127.0.0.1:8081", pm.BYOCIngressAddr())
+	}
+}
+
+func TestWithBYOCIngress_TrimsAndEmptyIsNoop(t *testing.T) {
+	pm := NewProxyManager("http://unused", "containarium.dev").WithBYOCIngress("  127.0.0.1:9000  ")
+	if pm.BYOCIngressAddr() != "127.0.0.1:9000" {
+		t.Errorf("addr should be trimmed, got %q", pm.BYOCIngressAddr())
+	}
+	pm.WithBYOCIngress("   ")
+	if pm.BYOCIngressAddr() != "" {
+		t.Errorf("blank addr should disable, got %q", pm.BYOCIngressAddr())
+	}
+}
+
+// The ingress listener must survive the #400 self-heal rebuild — a Caddy revert
+// then EnsureBaseConfig must re-emit srv0 with the plaintext listener, else a
+// Caddy reload would silently drop the BYOC data path.
+func TestBYOCIngress_SurvivesSelfHealRebuild(t *testing.T) {
+	srv, fc := newRWFakeCaddy(stubConfig())
+	defer srv.Close()
+	pm := NewProxyManager(srv.URL, "containarium.dev").WithBYOCIngress("127.0.0.1:8081")
+
+	got := listenSetFromRebuild(t, pm, fc)
+	found := false
+	for _, a := range got {
+		if a == "127.0.0.1:8081" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("rebuilt srv0.listen = %v, want it to include the BYOC ingress listener 127.0.0.1:8081", got)
+	}
+}
+
+// A manager WITHOUT the ingress configured must rebuild to exactly :80,:443 —
+// region hosts are byte-identical to before #733.
+func TestBYOCIngress_DisabledRebuildIsUnchanged(t *testing.T) {
+	srv, fc := newRWFakeCaddy(stubConfig())
+	defer srv.Close()
+	pm := NewProxyManager(srv.URL, "containarium.dev")
+
+	got := listenSetFromRebuild(t, pm, fc)
+	if len(got) != 2 || got[0] != ":80" || got[1] != ":443" {
+		t.Errorf("rebuilt srv0.listen = %v, want exactly [:80 :443] when BYOC ingress is off", got)
+	}
+}

--- a/internal/config/byoc.go
+++ b/internal/config/byoc.go
@@ -1,0 +1,23 @@
+package config
+
+// BYOC (bring-your-own-compute) host-daemon variable names.
+//
+// CONTAINARIUM_BYOC_INGRESS_ADDR opts a host into the sentinel-terminate BYOC
+// public-HTTP-ingress data path (#733 slice 3). When set to a loopback-scoped
+// address ("127.0.0.1:<port>"), the daemon's edge Caddy adds one extra plaintext
+// listener there that serves the same Host-matched routes as :443 but WITHOUT
+// TLS. The sentinel terminates TLS with the wildcard it holds and
+// plaintext-forwards over the tunnel to this listener, which Host-routes to the
+// box — so the BYOC host needs no cert. Empty (default) = disabled: region hosts
+// and non-BYOC deployments are unchanged.
+//
+// MUST be loopback-scoped so it is reachable only via the tunnel client (which
+// dials 127.0.0.1:<port>) and never from the LAN — it serves tenant routes in
+// the clear.
+const EnvBYOCIngressAddr = "CONTAINARIUM_BYOC_INGRESS_ADDR"
+
+// DefaultBYOCIngressAddr is the conventional loopback address to set
+// CONTAINARIUM_BYOC_INGRESS_ADDR to on a BYOC host. 8081 avoids the edge's :80
+// (HTTP→HTTPS redirect) and :443 (TLS), so automatic-HTTPS redirects don't apply
+// and the listener serves reverse_proxy routes directly as plaintext.
+const DefaultBYOCIngressAddr = "127.0.0.1:8081"

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -692,7 +692,7 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 					var proxyManager *app.ProxyManager
 
 					if caddyAdminURL != "" {
-						proxyManager = wafIngressFromEnv(app.NewProxyManager(caddyAdminURL, config.BaseDomain).WithDNSChallenge(app.DNSChallengeFromEnv()))
+						proxyManager = byocIngressFromEnv(wafIngressFromEnv(app.NewProxyManager(caddyAdminURL, config.BaseDomain).WithDNSChallenge(app.DNSChallengeFromEnv())))
 						// Ensure Caddy has basic server config for routes
 						if err := proxyManager.EnsureServerConfig(); err != nil {
 							log.Printf("Warning: Failed to ensure Caddy server config: %v", err)
@@ -881,7 +881,7 @@ skipAppHosting:
 				log.Printf("Warning: Failed to create route store: %v", err)
 				pool.Close()
 			} else {
-				proxyManager := wafIngressFromEnv(app.NewProxyManager(caddyAdminURL, config.BaseDomain).WithDNSChallenge(app.DNSChallengeFromEnv()))
+				proxyManager := byocIngressFromEnv(wafIngressFromEnv(app.NewProxyManager(caddyAdminURL, config.BaseDomain).WithDNSChallenge(app.DNSChallengeFromEnv())))
 				if err := proxyManager.EnsureServerConfig(); err != nil {
 					log.Printf("Warning: Failed to ensure Caddy server config: %v", err)
 				}
@@ -2368,6 +2368,20 @@ func wafIngressFromEnv(pm *app.ProxyManager) *app.ProxyManager {
 	}
 	log.Printf("Ingress WAF (coraza-caddy) enabled: SecRuleEngine %s — requires a Caddy build with the coraza module", mode)
 	return pm.WithWAF(app.DefaultWAFDirectives(enforce))
+}
+
+// byocIngressFromEnv enables the sentinel-terminate BYOC public-HTTP-ingress
+// plaintext listener (#733 slice 3) when CONTAINARIUM_BYOC_INGRESS_ADDR is set.
+// The value should be a loopback-scoped "127.0.0.1:<port>"; empty (default)
+// leaves the edge config unchanged. Composes with wafIngressFromEnv — either,
+// both, or neither may be applied.
+func byocIngressFromEnv(pm *app.ProxyManager) *app.ProxyManager {
+	addr := strings.TrimSpace(os.Getenv(appconfig.EnvBYOCIngressAddr))
+	if addr == "" {
+		return pm
+	}
+	log.Printf("BYOC public-HTTP-ingress plaintext listener enabled on %s — sentinel terminates TLS and plaintext-forwards over the tunnel (#733)", addr)
+	return pm.WithBYOCIngress(addr)
 }
 
 // envTruthy reports whether an env value is an explicit on-toggle.


### PR DESCRIPTION
## What

Slice 3 of BYOC public HTTP ingress (#733). Slices **1** (sentinel data path, #1017) and **2** (cloud pushes the bindings, cloud#905) are merged. This slice adds the **last hop**: the host-side plaintext endpoint the sentinel plaintext-forwards to over the tunnel.

## The data path

The product model terminates TLS **on the sentinel** (which holds the `*.containarium.dev` wildcard) and forwards **plaintext HTTP** over the tunnel to the box — the BYOC host needs no cert.

```
client ──TLS──▶ sentinel:443  (terminates with the wildcard it holds)
                  │ route by HTTP Host = <box>-<org>.containarium.dev
                  │ lookup → BYOC host spotID   (cloud-pushed, slice 2)
                  ▼
            DialTunnel(spotID, ingress-port) ──yamux──▶ host 127.0.0.1:<ingress-port>
                                                          host Caddy (plaintext) Host-routes → box:appPort
```

`DialTunnel(spotID, port)` isn't gated on the advertised port set, and the tunnel client already dials `127.0.0.1:<port>` for whatever port the sentinel requests — so **no `pool join` / tunnel change is needed**. What was missing was a **plaintext, Host-routing endpoint** on the host at that loopback port. This PR adds it.

## Changes

- **`ProxyManager.WithBYOCIngress(addr)`** adds one extra listener to the edge server that serves the **same Host-matched routes** as `:443` but **without TLS**. Because it isn't Caddy's `http_port` (80), automatic-HTTPS redirects don't apply — it serves the `reverse_proxy` routes directly as plaintext. A centralised `listenAddrs()` feeds **both** `createHTTPApp` and `createServerConfig`, so the #400 self-heal rebuild re-emits the listener instead of silently dropping the BYOC data path on a Caddy revert.
- **`CONTAINARIUM_BYOC_INGRESS_ADDR`** (`internal/config/byoc.go`) opts a host in; `byocIngressFromEnv` wires it onto the edge `ProxyManager` in `dual_server.go`, composing with `wafIngressFromEnv`. **Empty (default) = disabled**: region hosts and non-BYOC deployments are byte-identical to before. Conventional value `127.0.0.1:8081` (`DefaultBYOCIngressAddr`).
- **Loopback-scoped by contract**: the listener serves tenant routes in the clear, so it must bind `127.0.0.1` only — reachable via the tunnel client, never from the LAN.

## Tests

`listenAddrs` default (`:80,:443` unchanged) vs `+ingress`; trim/empty handling; the ingress listener **survives the self-heal rebuild**; disabled rebuild stays exactly `:80,:443`. `go build ./...`, `go vet`, `gofmt` clean.

## Not in this PR

- **Cloud follow-up**: the subdomain-route reconciler must push `route.Port` = the host ingress port (slice 2 currently pushes the box's `TargetPort`) **and** `AddRoute` the cloud-minted hostname through the per-host driver so the host Caddy has a route to Host-match. That's a cloud-side change.
- **Slice 4**: live e2e on a lab BYOC host (browser → `https://<box>-<org>.containarium.dev`, valid wildcard cert sentinel-terminated, in-box auth intact).

> ⚠️ This is opt-in and inert by default, but the end-to-end BYOC path needs **live validation on a BYOC host** (the cloud follow-up + slice 4) before it's usable in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)