### PR TITLE
test(debug): fix TestDiagnose for the ssh_ingress_host conditional (#1011 follow-up)

### DIFF
--- a/internal/server/debug_container_test.go
+++ b/internal/server/debug_container_test.go
@@ -53,7 +53,24 @@ func TestDiagnose(t *testing.T) {
 			wantFirstHas: "containarium-shell",
 		},
 		{
-			name: "running, all healthy",
+			// Sentinel-fronted backend (ssh_ingress_host advertised): the
+			// diagnosis points at the sentinel-side state to check next (#1011).
+			name: "running, all healthy, sentinel-fronted",
+			report: &pb.DebugContainerResponse{
+				ContainerState:      "running",
+				HostUserExists:      true,
+				HostUserShell:       "/usr/local/bin/containarium-shell",
+				HostUserShellExists: true,
+				SshIngressHost:      "asia-east1.containarium.dev",
+			},
+			wantCause:    "check sentinel-side state",
+			wantActionCt: 4,
+			wantFirstHas: "sshpiper",
+		},
+		{
+			// Direct / in-network backend (no ssh_ingress_host): #1011 suppresses
+			// the sentinel boilerplate — there is no sentinel hop to check.
+			name: "running, all healthy, no ssh ingress host",
 			report: &pb.DebugContainerResponse{
 				ContainerState:      "running",
 				HostUserExists:      true,
@@ -61,7 +78,8 @@ func TestDiagnose(t *testing.T) {
 				HostUserShellExists: true,
 			},
 			wantCause:    "no obvious host-side problem",
-			wantActionCt: 4,
+			wantActionCt: 3,
+			wantFirstHas: "connect directly",
 		},
 		{
 			name: "sshd accepted publickey recently",


### PR DESCRIPTION
## What

`TestDiagnose` has been **red on `main` since #1013 merged** (the required "Unit + default e2e" check was bypassed or raced auto-merge). This fixes it.

## Why it broke

#1011 made `diagnose()`'s "no obvious host-side problem" hints conditional on `ssh_ingress_host`:
- **sentinel-fronted** backend (ingress host advertised) → 4 sentinel-side hints
- **direct / in-network** backend (no ingress host) → 3 hints (no sentinel hop to check)

But the `running, all healthy` test case never set `SshIngressHost`, so it hit the new 3-action branch while still asserting `wantActionCt: 4`.

## Fix

Split the case so both #1011 branches are exercised:
- **`running, all healthy, sentinel-fronted`** — sets `SshIngressHost` → 4-action sentinel branch (cause `check sentinel-side state`, first hint `sshpiper`).
- **`running, all healthy, no ssh ingress host`** — empty → 3-action direct/in-network branch (cause `no obvious host-side problem`, first hint `connect directly`).

Test-only; `diagnose()` itself is unchanged. `go test ./internal/server/` green, `gofmt` clean.

## How it was found

Verifying `main` built clean after unrelated work — `go build`/`go vet`/`gofmt` were clean but this unit test failed. Bisected to the #1011/#1013 merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)