### PR TITLE
ci: broaden the required unit job to the full tree (close the coverage gap)

### DIFF
--- a/.github/workflows/proxyproto-e2e.yml
+++ b/.github/workflows/proxyproto-e2e.yml
@@ -52,16 +52,22 @@ jobs:
           npm ci
           npm run build
 
-      - name: Run sentinel + app tests
-        # The skipped tests are pre-existing failures on unprivileged Linux
-        # runners (they pass on darwin where loopback aliases are no-ops).
-        # Cause: tunnel_registry.addLoopbackAlias runs `ip addr add` which
-        # needs root, and TestEnableForwardingOnNonLinux has no GOOS guard.
-        # Unrelated to this PR; tracked for a follow-up cleanup.
+      - name: Run unit tests (full tree, minus infra integration)
+        # Runs the WHOLE module's unit tests, not just sentinel+app, so a
+        # regression anywhere — e.g. internal/server's TestDiagnose (#1024),
+        # which slipped onto main precisely because this job only tested
+        # sentinel+app — is gated at PR time. test/integration is excluded: it
+        # needs live infra (incus/storage) not present on the runner and fails
+        # closed without it.
+        #
+        # The -skip list is the pre-existing set that needs root on unprivileged
+        # Linux runners (tunnel_registry.addLoopbackAlias runs `ip addr add`;
+        # TestEnableForwardingOnNonLinux has no GOOS guard). They pass on darwin
+        # where loopback aliases are no-ops. Tracked for a follow-up cleanup.
         run: |
-          go test -v -race -timeout 5m \
+          go test -race -timeout 8m \
             -skip 'TestEnableForwardingOnNonLinux|TestRegisterPropagatesPool|TestTunnelIntegration|TestTunnelEndToEnd|TestConnMuxWithTunnelClient' \
-            ./internal/sentinel/... ./internal/app/...
+            $(go list ./... | grep -v '/test/integration')
 
   real-caddy-e2e:
     name: Real Caddy wire-compat e2e


### PR DESCRIPTION
## What

The required **"Unit + default e2e"** check only ran `go test` on `./internal/sentinel/...` and `./internal/app/...`. Any regression **outside** those two packages was never gated by a required check — which is exactly how `internal/server`'s `TestDiagnose` broke and rode onto `main` (fixed in #1024): the check stayed green because it never ran that package.

## Change

Run the **whole module** instead:

```sh
go test -race -timeout 8m -skip '<root-needing tests>' $(go list ./... | grep -v '/test/integration')
```

- **Excludes `test/integration`** — it needs live infra (incus/storage) not present on the runner and fails closed without it (verified locally: it's the *only* package that fails a bare `go test ./...`).
- **`-skip` list unchanged** — the same pre-existing tests that need root on unprivileged Linux runners (`tunnel_registry` `ip addr add`; the non-Linux forwarding test without a GOOS guard).
- Timeout `5m → 8m` for the wider set; dropped `-v` to keep logs manageable.

## Validation

Locally (`go test ./...`, darwin) only `test/integration` failed; everything else — including `internal/server` — passed. This PR's own run on the ubuntu runner is the real check: if the broader scope surfaces any further runner-specific failures, I'll add targeted skips here **before** merging, so `main` is never gated by a red required check.

## Follow-ups (not in this PR — need your authorization, branch-protection API on a shared repo)
- `strict: true` (require up-to-date-with-main before merge) to catch semantic conflicts (green PR + green PR → red main).
- `enforce_admins: true` so an admin merge can't bypass required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)