### PR TITLE
chore(release): cut v0.55.0 — fractional-CPU fix + BYOC ingress host listener (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.55.0] - 2026-07-18
+
+### Added
+
+- **BYOC public HTTP ingress — host listener** (#733, slice 3 of 3; opt-in,
+  inert by default). The host daemon's edge Caddy can serve one extra
+  loopback-only **plaintext** listener that Host-routes the same routes as
+  `:443` without TLS — the endpoint the sentinel plaintext-forwards to over the
+  tunnel in the sentinel-terminate model, so the host needs no cert. Enabled
+  only when `CONTAINARIUM_BYOC_INGRESS_ADDR` is set (conventional
+  `127.0.0.1:8081`); empty (default) leaves region hosts and existing
+  deployments byte-identical. End-to-end BYOC public ingress also needs its
+  cloud counterpart and live validation, so the path is not yet active on a
+  fresh deploy.
+
+### Fixed
+
+- **Fractional-CPU limits are enforced again** (#1022). The incus driver now
+  sets `limits.cpu` alongside `limits.cpu.allowance`, so a sub-core CPU request
+  (e.g. `0.5`) is actually capped rather than silently ignored.
+
 ## [0.54.0] - 2026-07-18
 
 ### Added

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.54.0"
+	Version = "0.55.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Release cut for **v0.55.0**. Closes the RC checklist in #1026.

Two-file bump only:
- `CHANGELOG.md`: new `## [0.55.0] - 2026-07-18` section (Added: #1023 BYOC host listener, opt-in/inert; Fixed: #1022 fractional-CPU).
- `pkg/version/version.go`: `Version` → `0.55.0`.

Headline: **#1022** (fractional-CPU cap enforced) is the user-facing fix. **#1023** ships the BYOC slice-3 host listener but it's **opt-in and inert** (`CONTAINARIUM_BYOC_INGRESS_ADDR` unset by default) — do not enable in prod before slice-4 validation (#733).

After merge: tag `v0.55.0` on `main` → `release.yml` → verify all 10 binaries + `SHA256SUMS.txt` + daemon image, and `containarium version` reports `v0.55.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)