### PR TITLE
fix(incus): set limits.cpu.allowance for whole-core CPU requests

### DIFF
--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -648,7 +648,9 @@ func (c *Client) CreateContainer(config ContainerConfig) error {
 
 	// Resource limits. CPU may be a whole-core count, a CPU set, or a
 	// fractional request (millicpu / decimal) — translate to the correct
-	// Incus key (limits.cpu vs limits.cpu.allowance). See issue #401.
+	// Incus key(s): limits.cpu always, plus limits.cpu.allowance for the
+	// CFS-bandwidth throttle on numeric (non-CPU-set) requests. See
+	// issues #401 and #1029.
 	if config.CPU != "" {
 		cl, err := parseCPULimit(config.CPU)
 		if err != nil {
@@ -1501,10 +1503,11 @@ func imageDescriptionFromConfig(config map[string]string) string {
 }
 
 // SetCPULimit updates a container's CPU limit, translating the request into
-// the correct Incus key — limits.cpu for whole-core counts and CPU sets, or
-// limits.cpu.allowance for fractional requests (millicpu / decimal). It clears
-// the other key first so a fractional→whole-core resize (or vice versa) never
-// leaves a stale, conflicting limit behind. See issue #401.
+// the correct Incus key(s) — limits.cpu for the visible core count/set, plus
+// limits.cpu.allowance for the CFS-bandwidth throttle on numeric requests
+// (whole-core or fractional; CPU-set/pinning notation sets limits.cpu only).
+// It clears both keys first so a resize between request shapes never leaves
+// a stale, conflicting limit behind. See issues #401 and #1029.
 func (c *Client) SetCPULimit(containerName, cpu string) error {
 	cl, err := parseCPULimit(cpu)
 	if err != nil {

--- a/pkg/core/incus/cpu_limits.go
+++ b/pkg/core/incus/cpu_limits.go
@@ -10,20 +10,24 @@ import (
 // cpuLimit holds the Incus instance-config representation of a CPU request.
 //
 //   - Count     → set as `limits.cpu` (whole-core count "2" or CPU set "0-3").
-//   - Allowance → set as `limits.cpu.allowance` (fractional share expressed as
-//     a percentage, e.g. "25%").
+//   - Allowance → set as `limits.cpu.allowance` (share of those cores
+//     expressed as a percentage, e.g. "25%", "800%").
 //
 // Incus's `limits.cpu` key only accepts an integer core count or a set/range;
 // fractional CPU must go through `limits.cpu.allowance`. Passing millicpu
 // notation ("250m") straight to `limits.cpu` is rejected by Incus with
 // "Invalid CPU limit syntax". See issue #401.
 //
-// Fractional requests set BOTH fields: Count is the ceiling whole-core count
-// (so LXCFS has a cpuset to derive an honest /proc/cpuinfo processor count
-// from — allowance-only containers otherwise report the host's full core
+// Both whole-core and fractional requests set BOTH fields: Count is the
+// visible cpuset (so LXCFS can derive an honest /proc/cpuinfo processor
+// count — allowance-only containers otherwise report the host's full core
 // count, see #1019/#1021) and Allowance is the actual CFS-bandwidth throttle
-// within that visible core count. Whole-core / CPU-set requests set only
-// Count.
+// scoped to that visible count. Without Allowance, `limits.cpu` only bounds
+// *which* cores are visible, not how much CPU *time* they may consume — a
+// whole-core request of "8" on an 8-core host was otherwise unthrottled
+// (see #1029). CPU-set / pinning notation ("0-3") is the one exception: it
+// sets only Count, since a meaningful percentage-of-visible-cores allowance
+// can't be derived from an arbitrary core-index set.
 type cpuLimit struct {
 	Count     string
 	Allowance string
@@ -33,17 +37,16 @@ type cpuLimit struct {
 // config key(s) it maps to.
 //
 // Accepted inputs:
-//   - whole-core count:    "1", "4"           → limits.cpu
-//   - CPU set / pinning:   "0-3", "0,2-4"     → limits.cpu (passed through)
+//   - whole-core count:    "1", "4"           → limits.cpu "1"/"4" + limits.cpu.allowance "100%"/"400%"
+//   - CPU set / pinning:   "0-3", "0,2-4"     → limits.cpu (passed through, no allowance)
 //   - Kubernetes millicpu: "250m" (0.25 core) → limits.cpu "1" + limits.cpu.allowance "25%"
 //   - decimal cores:       "0.25", "1.5"      → limits.cpu "1"/"2" + limits.cpu.allowance "25%"/"150%"
 //
-// Millicpu / decimals that resolve to a whole number of cores ("1000m",
-// "2.0") map back to limits.cpu as an integer count, with no allowance set.
-// Other fractional requests set both limits.cpu (ceil(cores), so LXCFS can
-// report an honest /proc/cpuinfo processor count) and limits.cpu.allowance
-// (the actual throttle) — see the cpuLimit doc comment. An empty request
-// returns a zero cpuLimit (no keys to set).
+// Every numeric request (whole or fractional) sets both limits.cpu
+// (ceil(cores), so LXCFS can report an honest /proc/cpuinfo processor count)
+// and limits.cpu.allowance (the actual CFS-bandwidth throttle, cores*100%) —
+// see the cpuLimit doc comment and #1029. Only CPU-set/pinning notation sets
+// Count alone. An empty request returns a zero cpuLimit (no keys to set).
 func parseCPULimit(cpu string) (cpuLimit, error) {
 	cpu = strings.TrimSpace(cpu)
 	if cpu == "" {
@@ -78,9 +81,17 @@ func parseCPULimit(cpu string) (cpuLimit, error) {
 		return cpuLimit{}, fmt.Errorf("CPU request %q resolves to zero cores", cpu)
 	}
 
-	// Whole-core requests map to an integer limits.cpu count.
+	// Whole-core requests map to an integer limits.cpu count, plus a matching
+	// allowance so the visible cores are also throttle-bounded (#1029) — a
+	// bare limits.cpu on an N-core host otherwise leaves N cores fully
+	// unthrottled. 4 cores → limits.cpu="4", limits.cpu.allowance="400%".
 	if cores == float64(int64(cores)) {
-		return cpuLimit{Count: strconv.FormatInt(int64(cores), 10)}, nil
+		count := int64(cores)
+		pct := cores * 100
+		return cpuLimit{
+			Count:     strconv.FormatInt(count, 10),
+			Allowance: strconv.FormatFloat(pct, 'f', -1, 64) + "%",
+		}, nil
 	}
 
 	// Fractional requests become a percentage allowance, plus a whole-core
@@ -97,14 +108,18 @@ func parseCPULimit(cpu string) (cpuLimit, error) {
 // formatCPULimitFromConfig renders the CPU request stored in an Incus instance
 // config back into the Containarium representation, for display in container
 // info. `limits.cpu.allowance` is checked first and, if present, converted
-// back to Kubernetes millicpu ("25%" → "250m") — fractional requests set both
+// back to Kubernetes millicpu ("25%" → "250m") — requests set both
 // `limits.cpu` (a whole-core ceiling, for LXCFS) and `limits.cpu.allowance`
 // (the actual throttle), and allowance is the precise value; falling back to
 // `limits.cpu` first would display a "250m" request back as "1", losing the
-// fractional precision. `limits.cpu` is used verbatim only when no allowance
-// is set (genuine whole-core count or CPU set/range). A non-percentage
-// (time-slice) allowance has no millicpu equivalent and is returned as-is.
-// Returns "" when neither key is set.
+// fractional precision. An allowance that's an exact multiple of 100% (a
+// whole-core request, see #1029) formats back as the plain core count
+// ("400%" → "4") rather than millicpu ("4000m") — the two are numerically
+// equivalent, but the plain count matches what the caller originally typed.
+// `limits.cpu` is used verbatim only when no allowance is set (a CPU
+// set/range, or a pre-#1029 whole-core config with no allowance key yet). A
+// non-percentage (time-slice) allowance has no millicpu equivalent and is
+// returned as-is. Returns "" when neither key is set.
 func formatCPULimitFromConfig(config map[string]string) string {
 	allowance, ok := config["limits.cpu.allowance"]
 	if !ok || allowance == "" {
@@ -119,6 +134,9 @@ func formatCPULimitFromConfig(config map[string]string) string {
 	pct, err := strconv.ParseFloat(strings.TrimSuffix(allowance, "%"), 64)
 	if err != nil {
 		return allowance
+	}
+	if cores := pct / 100; cores == float64(int64(cores)) {
+		return strconv.FormatInt(int64(cores), 10)
 	}
 	milli := int64(pct * 10) // 25% → 250m
 	return strconv.FormatInt(milli, 10) + "m"

--- a/pkg/core/incus/cpu_limits_test.go
+++ b/pkg/core/incus/cpu_limits_test.go
@@ -11,16 +11,17 @@ func TestParseCPULimit(t *testing.T) {
 		wantErr       bool
 	}{
 		{name: "empty", cpu: "", wantCount: "", wantAllowance: ""},
-		{name: "whole core", cpu: "1", wantCount: "1"},
-		{name: "multiple cores", cpu: "4", wantCount: "4"},
+		{name: "single core", cpu: "1", wantCount: "1", wantAllowance: "100%"},
+		{name: "multiple cores", cpu: "4", wantCount: "4", wantAllowance: "400%"},
+		{name: "whole host", cpu: "8", wantCount: "8", wantAllowance: "800%"},
 		{name: "cpu range", cpu: "0-3", wantCount: "0-3"},
 		{name: "cpu set", cpu: "0,2-4", wantCount: "0,2-4"},
 		{name: "millicpu quarter core", cpu: "250m", wantCount: "1", wantAllowance: "25%"},
 		{name: "millicpu half core", cpu: "500m", wantCount: "1", wantAllowance: "50%"},
-		{name: "millicpu whole core", cpu: "1000m", wantCount: "1"},
+		{name: "millicpu whole core", cpu: "1000m", wantCount: "1", wantAllowance: "100%"},
 		{name: "millicpu one and a half", cpu: "1500m", wantCount: "2", wantAllowance: "150%"},
 		{name: "decimal quarter core", cpu: "0.25", wantCount: "1", wantAllowance: "25%"},
-		{name: "decimal whole core", cpu: "2.0", wantCount: "2"},
+		{name: "decimal whole core", cpu: "2.0", wantCount: "2", wantAllowance: "200%"},
 		{name: "decimal one and a half", cpu: "1.5", wantCount: "2", wantAllowance: "150%"},
 		{name: "decimal two and a half", cpu: "2.5", wantCount: "3", wantAllowance: "250%"},
 		{name: "whitespace trimmed", cpu: "  250m  ", wantCount: "1", wantAllowance: "25%"},
@@ -66,7 +67,7 @@ func TestFormatCPULimitFromConfig(t *testing.T) {
 		want   string
 	}{
 		{name: "no limits", config: map[string]string{}, want: ""},
-		{name: "whole core", config: map[string]string{"limits.cpu": "4"}, want: "4"},
+		{name: "whole core, no allowance (pre-#1029 config)", config: map[string]string{"limits.cpu": "4"}, want: "4"},
 		{name: "cpu set", config: map[string]string{"limits.cpu": "0-3"}, want: "0-3"},
 		{name: "allowance percentage", config: map[string]string{"limits.cpu.allowance": "25%"}, want: "250m"},
 		{name: "allowance half", config: map[string]string{"limits.cpu.allowance": "50%"}, want: "500m"},
@@ -79,6 +80,16 @@ func TestFormatCPULimitFromConfig(t *testing.T) {
 		},
 		{name: "empty limits.cpu falls through to allowance", config: map[string]string{"limits.cpu": "", "limits.cpu.allowance": "25%"}, want: "250m"},
 		{name: "empty allowance falls through to limits.cpu", config: map[string]string{"limits.cpu": "4", "limits.cpu.allowance": ""}, want: "4"},
+		{
+			name:   "whole-core allowance formats as plain core count, not millicpu (#1029)",
+			config: map[string]string{"limits.cpu": "8", "limits.cpu.allowance": "800%"},
+			want:   "8",
+		},
+		{
+			name:   "single-core allowance formats as plain core count",
+			config: map[string]string{"limits.cpu": "1", "limits.cpu.allowance": "100%"},
+			want:   "1",
+		},
 	}
 
 	for _, tt := range tests {
@@ -90,10 +101,12 @@ func TestFormatCPULimitFromConfig(t *testing.T) {
 	}
 }
 
-// TestCPULimitRoundTrip confirms a fractional request survives the
-// translate-then-read-back cycle as the same millicpu value.
+// TestCPULimitRoundTrip confirms a request survives the
+// translate-then-read-back cycle as the same value: fractional requests as
+// the same millicpu value, whole-core requests as the same plain core count
+// (#1029 — despite now also carrying a limits.cpu.allowance).
 func TestCPULimitRoundTrip(t *testing.T) {
-	for _, in := range []string{"250m", "500m", "1500m"} {
+	for _, in := range []string{"250m", "500m", "1500m", "1", "4", "8"} {
 		cl, err := parseCPULimit(in)
 		if err != nil {
 			t.Fatalf("parseCPULimit(%q): %v", in, err)


### PR DESCRIPTION
## Summary
- Whole-core CPU requests ("1".."8") previously set only `limits.cpu` (an Incus cpuset — which cores are *visible*) and never `limits.cpu.allowance` (the actual CFS-bandwidth throttle — how much CPU *time* those cores may consume). Only fractional requests ("0.25", "250m") got both keys. Since every real-world size tier resolves to a whole number, almost no tenant had an enforced CPU ceiling — confirmed live on production: `cat /sys/fs/cgroup/cpu.max` inside a whole-core container read `"max 100000"`, fully unthrottled.
- `pkg/core/incus/cpu_limits.go`: the whole-core branch of `parseCPULimit` now also sets `Allowance` to `N*100%` (e.g. `"8"` → `Count: "8", Allowance: "800%"`), the same pattern the fractional branch already used. CPU-set/pinning notation (`"0-3"`, `"0,2-4"`) is untouched — that's a different semantic (explicit core pinning) and out of scope.
- `formatCPULimitFromConfig` now formats an exact-multiple-of-100% allowance back as a plain integer core count (`"800%"` → `"8"`, not `"8000m"`) to avoid a display regression on the whole-core round-trip.
- Updated doc comments on `cpuLimit`, `parseCPULimit`, `formatCPULimitFromConfig`, and the two call sites in `client.go` (`CreateContainer`, `SetCPULimit`).

## Test plan
- [x] `pkg/core/incus/cpu_limits_test.go`: whole-core cases now assert both `Count` and `Allowance` (`"1"→100%`, `"4"→400%`, `"8"→800%`); millicpu/decimal inputs that resolve to whole cores (`"1000m"`, `"2.0"`) updated to match; new round-trip test cases for whole-core allowance formatting
- [x] `go build ./...` clean
- [x] `go test ./pkg/core/incus/...` all pass
- [x] `go test ./...` — all pass except two pre-existing, unrelated `test/integration` failures requiring a live gRPC server on `localhost:50051` (not touched by this change)

Closes #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)