### PR TITLE
chore(release): cut v0.55.1 — whole-core CPU throttle + auto-placement health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.55.1] - 2026-07-19
+
+### Fixed
+
+- **Whole-core CPU requests are now actually throttled** (#1030). Every
+  whole-number `limits.cpu` request (`1`..`8`) previously set only the
+  cpuset (which cores are visible) with no CFS-bandwidth cap on how much
+  CPU time those cores may consume — only fractional requests (`0.25`,
+  `250m`) got a real throttle. Since every cloud size-tier bundle resolves
+  to a whole-core count, the overwhelming majority of tenant containers
+  had no enforced CPU ceiling at all, letting one noisy tenant starve
+  every other co-located tenant regardless of nominal tier.
+- **Auto-placement no longer picks a backend it would itself report
+  unhealthy** (#1031). `resolvePoolPlacement` picked the local backend
+  unconditionally when a create's pool matched the daemon's local pool,
+  with no health check — while the peer-candidate branch two lines below
+  has always required a healthy peer. A bounded (3s), fail-closed
+  liveness probe now gates both call sites; an unhealthy local backend
+  falls through to a healthy peer instead of being chosen blindly.
+
 ## [0.55.0] - 2026-07-18
 
 ### Added

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.55.0"
+	Version = "0.55.1"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Version bump for the RC tracked in #1032.

- #1030 — whole-core CPU requests now get a real CFS-bandwidth throttle, not just a cpuset.
- #1031 — auto-placement no longer picks a local backend it would itself report unhealthy.

## Test plan
- [x] `go build ./...` clean
- [ ] Tag `v0.55.1` after merge, confirm `release.yml` publishes all 10 binaries + SHA256SUMS.txt