### PR TITLE
fix(list): report CREATING/PROVISIONING for in-flight async creates; add create --wait (#1036)

### DIFF
--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -42,6 +42,8 @@ var (
 	createIdleStop           string
 	createDeleteAfterStopped string
 	createStorageClass       string
+	createWait               bool
+	createWaitTimeout        time.Duration
 )
 
 var createCmd = &cobra.Command{
@@ -126,6 +128,8 @@ func init() {
 	createCmd.Flags().StringVar(&createIdleStop, "idle-stop", "", "Birth idle-stop — auto-STOP the box (free CPU/RAM, keep disk; wakes on access) after this long with no activity (Go duration: '20m', '1h'). Enables auto-sleep atomically at create, so a crashed/cancelled job still releases compute — no separate 'toggle_auto_sleep' needed (#524). An active SSH/exec session counts as activity, so a box being debugged is never stopped mid-session. Empty = no auto-sleep.")
 	createCmd.Flags().StringVar(&createDeleteAfterStopped, "delete-after-stopped", "", "Birth stopped→delete — auto-DELETE the box (reclaim disk) once it has been STOPPED this long (Go duration: '6h', '24h'). The second timer of the two-phase lifecycle: pair with --idle-stop to free CPU/RAM fast, then disk after a debug window (#525). The clock resets when the box is woken, so a box you keep investigating is never reaped. Separate opt-in from --idle-stop. Empty = never delete on stop.")
 	createCmd.Flags().StringVar(&createStorageClass, "storage-class", "", "K8s StorageClass for the box's data PVC (K8s backend only). Empty = use the cluster's default StorageClass. Example: 'fast-nvme', 'standard', 'ceph-block'. Ignored on the LXC backend.")
+	createCmd.Flags().BoolVar(&createWait, "wait", false, "Block until the box finishes provisioning (remote mode). A remote create is async: the daemon returns CREATING immediately and provisions for minutes — SSH only works once the state reaches RUNNING. --wait polls the daemon until then (or --wait-timeout), exiting non-zero if provisioning fails. Local mode provisions synchronously; --wait is a no-op there.")
+	createCmd.Flags().DurationVar(&createWaitTimeout, "wait-timeout", 5*time.Minute, "How long --wait polls before giving up (Go duration).")
 }
 
 // validateSSHKeyMode enforces "exactly one of --ssh-key / --no-ssh-key".
@@ -412,6 +416,29 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// --wait (#1036): a remote create is async — the daemon returns CREATING
+	// immediately and provisions (package install, key setup) for minutes.
+	// Poll until the box settles so scripts/agents get blocking ergonomics
+	// without a long-held server connection, and so the summary below prints
+	// the settled state + IP instead of CREATING. Local mode provisions
+	// synchronously inside createLocal, so there is nothing to wait for.
+	if createWait && serverAddr != "" {
+		getFn, closeFn, cerr := containerGetter()
+		if cerr != nil {
+			return cerr
+		}
+		defer closeFn()
+		final, werr := waitForContainerReady(getFn, username, createWaitTimeout)
+		if werr != nil {
+			return werr
+		}
+		if final != nil {
+			info = final
+		}
+	} else if createWait && verbose {
+		fmt.Println("  --wait: local create is synchronous; nothing to wait for")
+	}
+
 	// Success!
 	fmt.Println()
 	fmt.Printf("✓ Container %s created successfully!\n", info.Name)
@@ -619,6 +646,57 @@ func createLocal(username, image, cpu, memory, disk, staticIP string, sshKeys []
 }
 
 // parseLabels parses labels from key=value format
+// containerGetter builds a GetContainer function against the configured
+// remote (HTTP or gRPC, same mode selection as the create itself), plus a
+// close function for the underlying client. Used by --wait.
+func containerGetter() (func(string) (*incus.ContainerInfo, error), func(), error) {
+	if httpMode {
+		httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create HTTP client: %w", err)
+		}
+		return httpClient.GetContainer, func() { _ = httpClient.Close() }, nil
+	}
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to remote server: %w", err)
+	}
+	return grpcClient.GetContainer, func() { _ = grpcClient.Close() }, nil
+}
+
+// waitForContainerReady polls getFn until the box reaches a settled state
+// (#1036). Both clients report the proto enum name ("CONTAINER_STATE_RUNNING",
+// "...PROVISIONING", ...); normalize by trimming the prefix. Transient get
+// errors are tolerated (the box can briefly 404 between the daemon's pending
+// bookkeeping and incus visibility) — only the deadline or an explicit ERROR
+// state ends the wait early.
+func waitForContainerReady(getFn func(string) (*incus.ContainerInfo, error), username string, timeout time.Duration) (*incus.ContainerInfo, error) {
+	const pollInterval = 5 * time.Second
+	deadline := time.Now().Add(timeout)
+	lastState := ""
+	fmt.Printf("Waiting for provisioning to finish (timeout %s)...\n", timeout)
+	for {
+		info, err := getFn(username)
+		if err == nil {
+			state := strings.TrimPrefix(info.State, "CONTAINER_STATE_")
+			if state != lastState {
+				fmt.Printf("  state: %s\n", state)
+				lastState = state
+			}
+			switch state {
+			case "RUNNING", "STOPPED":
+				return info, nil
+			case "ERROR":
+				return nil, fmt.Errorf("provisioning failed for %s: daemon reports ERROR (see the daemon log for the cause)", username)
+			}
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out after %s waiting for %s to finish provisioning (last state: %s); the box may still come up — check with 'containarium list'", timeout, username, lastState)
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
 func parseLabels(labelSlice []string) map[string]string {
 	result := make(map[string]string)
 	for _, label := range labelSlice {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1417,6 +1417,11 @@ func handleCreateContainer(client API, args map[string]interface{}) (string, err
 	// their own ssh_keys got no connection guidance at all and tended to go
 	// hunting for the env var and give up (see issue #658).
 	result += "\n\n--- CONNECTING ---\n"
+	result += "⏳ PROVISIONING TAKES MINUTES: the create is async — the box installs\n"
+	result += "packages and SSH keys AFTER this response returns. Poll get_container\n"
+	result += "until state is RUNNING before attempting SSH; an early SSH failure is\n"
+	result += "NOT an error, and deleting the box because of one aborts a create that\n"
+	result += "was still in progress.\n\n"
 	if resp.Container.SSHHost != "" {
 		result += fmt.Sprintf("SSH target: %s@%s  (resolved from ssh_host — no env/config needed)\n",
 			resp.Container.Username, resp.Container.SSHHost)

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -723,7 +723,34 @@ func (s *ContainerServer) ListContainers(ctx context.Context, req *pb.ListContai
 		return nil, fmt.Errorf("failed to list containers: %w", err)
 	}
 
-	// Filter containers
+	// Snapshot in-flight async creations so list state is provisioning-aware
+	// (#1036). GetContainer has reported CREATING/PROVISIONING from this map
+	// since #837; list bypassed it, so a box ~30s into a multi-minute
+	// provisioning run showed raw incus RUNNING to every list consumer
+	// (control-plane state sync, CLI list) — inviting SSH long before the
+	// box was actually ready. Failed creates (Done + Error) stay out of the
+	// list on purpose: their instance is gone, and GetContainer owns
+	// surfacing the ERROR until its cleanup.
+	pendingStates := map[string]pb.ContainerState{}
+	s.pendingMu.RLock()
+	for u, p := range s.pendingCreations {
+		if p.Done {
+			continue
+		}
+		st := pb.ContainerState_CONTAINER_STATE_CREATING
+		if p.Provisioning {
+			st = pb.ContainerState_CONTAINER_STATE_PROVISIONING
+		}
+		pendingStates[u] = st
+	}
+	s.pendingMu.RUnlock()
+
+	// Filter containers. The state filter is NOT applied here: it must match
+	// the provisioning-aware state the response reports (overlaid below),
+	// not the raw incus state — otherwise state=RUNNING would wrongly
+	// include a mid-provisioning box. applyProvisioningOverlay re-applies it
+	// post-overlay for these local entries (peer entries never went through
+	// the state filter — unchanged).
 	var filtered []incus.ContainerInfo
 	for _, c := range containers {
 		// Exclude core containers (postgres, caddy) from user-facing listings
@@ -739,24 +766,6 @@ func (s *ContainerServer) ListContainers(ctx context.Context, req *pb.ListContai
 				username = c.Name[:len(c.Name)-10]
 			}
 			if username != req.Username {
-				continue
-			}
-		}
-
-		// Filter by state if specified
-		if req.State != pb.ContainerState_CONTAINER_STATE_UNSPECIFIED {
-			var containerState pb.ContainerState
-			switch c.State {
-			case "Running":
-				containerState = pb.ContainerState_CONTAINER_STATE_RUNNING
-			case "Stopped":
-				containerState = pb.ContainerState_CONTAINER_STATE_STOPPED
-			case "Frozen":
-				containerState = pb.ContainerState_CONTAINER_STATE_FROZEN
-			default:
-				containerState = pb.ContainerState_CONTAINER_STATE_UNSPECIFIED
-			}
-			if containerState != req.State {
 				continue
 			}
 		}
@@ -790,6 +799,9 @@ func (s *ContainerServer) ListContainers(ctx context.Context, req *pb.ListContai
 		protoContainers = append(protoContainers, pc)
 	}
 
+	protoContainers = applyProvisioningOverlay(protoContainers, pendingStates,
+		req.Username, req.State, len(req.LabelFilter) > 0, s.sshHost)
+
 	// Add containers from peer backends
 	if s.peerPool != nil {
 		authToken := extractAuthToken(ctx)
@@ -807,6 +819,62 @@ func (s *ContainerServer) ListContainers(ctx context.Context, req *pb.ListContai
 		Containers: protoContainers,
 		TotalCount: safecast.I32(len(protoContainers)),
 	}, nil
+}
+
+// applyProvisioningOverlay makes a list response honest about in-flight async
+// creations (#1036), in three steps:
+//
+//  1. A local entry whose username has a pending creation reports that
+//     pending state (CREATING/PROVISIONING) instead of the raw incus state —
+//     incus says "Running" the moment the instance boots, minutes before
+//     provisioning (package install, key setup) finishes and SSH works.
+//  2. A pending creation with no incus instance yet gets a synthetic entry
+//     (same shape GetContainer synthesizes), so a just-accepted create is
+//     visible in list at all. Synthetics are skipped when a label filter is
+//     in effect: a provisioning box's labels aren't stamped yet, so it can't
+//     genuinely match any label filter.
+//  3. The request's state filter is applied here, against the final overlaid
+//     state (the caller removed it from the raw-incus filtering pass).
+//
+// Pure function over the already-converted local entries so the overlay is
+// unit-testable without an incus-backed Manager.
+func applyProvisioningOverlay(local []*pb.Container, pending map[string]pb.ContainerState,
+	usernameFilter string, stateFilter pb.ContainerState, hasLabelFilter bool, sshHost string) []*pb.Container {
+
+	out := make([]*pb.Container, 0, len(local)+len(pending))
+	seen := make(map[string]bool, len(pending))
+	for _, pc := range local {
+		if st, ok := pending[pc.Username]; ok {
+			pc.State = st
+			seen[pc.Username] = true
+		}
+		if stateFilter != pb.ContainerState_CONTAINER_STATE_UNSPECIFIED && pc.State != stateFilter {
+			continue
+		}
+		out = append(out, pc)
+	}
+
+	if hasLabelFilter {
+		return out
+	}
+	for u, st := range pending {
+		if seen[u] {
+			continue
+		}
+		if usernameFilter != "" && u != usernameFilter {
+			continue
+		}
+		if stateFilter != pb.ContainerState_CONTAINER_STATE_UNSPECIFIED && st != stateFilter {
+			continue
+		}
+		out = append(out, &pb.Container{
+			Name:     u + "-container",
+			Username: u,
+			State:    st,
+			SshHost:  sshHost,
+		})
+	}
+	return out
 }
 
 // GetContainer gets information about a specific container

--- a/internal/server/provisioning_overlay_test.go
+++ b/internal/server/provisioning_overlay_test.go
@@ -1,0 +1,170 @@
+package server
+
+import (
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// mkListEntry builds the minimal local list entry the overlay operates on.
+func mkListEntry(username string, state pb.ContainerState) *pb.Container {
+	return &pb.Container{
+		Name:     username + "-container",
+		Username: username,
+		State:    state,
+	}
+}
+
+func stateOf(t *testing.T, out []*pb.Container, username string) pb.ContainerState {
+	t.Helper()
+	for _, c := range out {
+		if c.Username == username {
+			return c.State
+		}
+	}
+	t.Fatalf("container for %q not in overlay output", username)
+	return pb.ContainerState_CONTAINER_STATE_UNSPECIFIED
+}
+
+func has(out []*pb.Container, username string) bool {
+	for _, c := range out {
+		if c.Username == username {
+			return true
+		}
+	}
+	return false
+}
+
+// TestApplyProvisioningOverlay_ReplacesRawRunning is the #1036 core case: a
+// box mid-provisioning reads RUNNING from incus the moment it boots, minutes
+// before SSH works — list must report the pending state instead, exactly as
+// GetContainer already does.
+func TestApplyProvisioningOverlay_ReplacesRawRunning(t *testing.T) {
+	local := []*pb.Container{
+		mkListEntry("alice", pb.ContainerState_CONTAINER_STATE_RUNNING),
+		mkListEntry("bob", pb.ContainerState_CONTAINER_STATE_RUNNING),
+	}
+	pending := map[string]pb.ContainerState{
+		"alice": pb.ContainerState_CONTAINER_STATE_PROVISIONING,
+	}
+
+	out := applyProvisioningOverlay(local, pending, "", pb.ContainerState_CONTAINER_STATE_UNSPECIFIED, false, "ssh.example.com")
+
+	if got := stateOf(t, out, "alice"); got != pb.ContainerState_CONTAINER_STATE_PROVISIONING {
+		t.Fatalf("alice: got %v, want PROVISIONING (raw incus RUNNING must not leak mid-provisioning)", got)
+	}
+	if got := stateOf(t, out, "bob"); got != pb.ContainerState_CONTAINER_STATE_RUNNING {
+		t.Fatalf("bob: got %v, want RUNNING (non-pending entries untouched)", got)
+	}
+}
+
+// TestApplyProvisioningOverlay_SynthesizesNotYetVisible: a just-accepted
+// create has no incus instance yet — it must still appear in list (same
+// synthetic shape GetContainer returns), carrying the daemon's ssh host.
+func TestApplyProvisioningOverlay_SynthesizesNotYetVisible(t *testing.T) {
+	pending := map[string]pb.ContainerState{
+		"carol": pb.ContainerState_CONTAINER_STATE_CREATING,
+	}
+
+	out := applyProvisioningOverlay(nil, pending, "", pb.ContainerState_CONTAINER_STATE_UNSPECIFIED, false, "ssh.example.com")
+
+	if len(out) != 1 {
+		t.Fatalf("got %d entries, want 1 synthetic", len(out))
+	}
+	c := out[0]
+	if c.Name != "carol-container" || c.Username != "carol" {
+		t.Fatalf("synthetic identity wrong: name=%q username=%q", c.Name, c.Username)
+	}
+	if c.State != pb.ContainerState_CONTAINER_STATE_CREATING {
+		t.Fatalf("synthetic state: got %v, want CREATING", c.State)
+	}
+	if c.SshHost != "ssh.example.com" {
+		t.Fatalf("synthetic ssh host: got %q", c.SshHost)
+	}
+}
+
+// TestApplyProvisioningOverlay_StateFilterSeesOverlaidState: filtering
+// state=RUNNING must EXCLUDE a mid-provisioning box (its reported state is
+// PROVISIONING even though incus says Running), and filtering
+// state=PROVISIONING must include exactly it — the filter operates on what
+// the response reports, not on the raw incus state.
+func TestApplyProvisioningOverlay_StateFilterSeesOverlaidState(t *testing.T) {
+	local := []*pb.Container{
+		mkListEntry("alice", pb.ContainerState_CONTAINER_STATE_RUNNING), // provisioning underneath
+		mkListEntry("bob", pb.ContainerState_CONTAINER_STATE_RUNNING),   // genuinely running
+	}
+	pending := map[string]pb.ContainerState{
+		"alice": pb.ContainerState_CONTAINER_STATE_PROVISIONING,
+		"carol": pb.ContainerState_CONTAINER_STATE_CREATING, // synthetic candidate
+	}
+
+	running := applyProvisioningOverlay(local, pending, "", pb.ContainerState_CONTAINER_STATE_RUNNING, false, "")
+	if has(running, "alice") {
+		t.Fatal("state=RUNNING filter must exclude the mid-provisioning box")
+	}
+	if !has(running, "bob") {
+		t.Fatal("state=RUNNING filter must keep the genuinely running box")
+	}
+	if has(running, "carol") {
+		t.Fatal("state=RUNNING filter must exclude the CREATING synthetic")
+	}
+
+	prov := applyProvisioningOverlay(local, pending, "", pb.ContainerState_CONTAINER_STATE_PROVISIONING, false, "")
+	if !has(prov, "alice") || has(prov, "bob") || has(prov, "carol") {
+		t.Fatalf("state=PROVISIONING filter wrong: got %v", prov)
+	}
+}
+
+// TestApplyProvisioningOverlay_LabelFilterSuppressesSynthetics: a
+// provisioning box's labels aren't stamped yet, so it can't genuinely match
+// a label filter — synthetics are suppressed, but the overlay still applies
+// to real entries that passed the label filter upstream.
+func TestApplyProvisioningOverlay_LabelFilterSuppressesSynthetics(t *testing.T) {
+	local := []*pb.Container{
+		mkListEntry("alice", pb.ContainerState_CONTAINER_STATE_RUNNING),
+	}
+	pending := map[string]pb.ContainerState{
+		"alice": pb.ContainerState_CONTAINER_STATE_PROVISIONING,
+		"carol": pb.ContainerState_CONTAINER_STATE_CREATING,
+	}
+
+	out := applyProvisioningOverlay(local, pending, "", pb.ContainerState_CONTAINER_STATE_UNSPECIFIED, true, "")
+
+	if has(out, "carol") {
+		t.Fatal("synthetic must be suppressed under a label filter")
+	}
+	if got := stateOf(t, out, "alice"); got != pb.ContainerState_CONTAINER_STATE_PROVISIONING {
+		t.Fatalf("overlay must still apply to real entries under a label filter, got %v", got)
+	}
+}
+
+// TestApplyProvisioningOverlay_UsernameFilterScopesSynthetics: tenant
+// isolation — a synthetic for another tenant's pending create must not leak
+// into a username-scoped list (non-admin lists are always username-scoped).
+func TestApplyProvisioningOverlay_UsernameFilterScopesSynthetics(t *testing.T) {
+	pending := map[string]pb.ContainerState{
+		"alice":   pb.ContainerState_CONTAINER_STATE_CREATING,
+		"mallory": pb.ContainerState_CONTAINER_STATE_CREATING,
+	}
+
+	out := applyProvisioningOverlay(nil, pending, "alice", pb.ContainerState_CONTAINER_STATE_UNSPECIFIED, false, "")
+
+	if !has(out, "alice") || has(out, "mallory") {
+		t.Fatalf("username filter must scope synthetics to the caller, got %v", out)
+	}
+}
+
+// TestApplyProvisioningOverlay_NoPendingPassthrough: with nothing pending the
+// overlay is a pure state-filter pass — entries untouched, filter applied.
+func TestApplyProvisioningOverlay_NoPendingPassthrough(t *testing.T) {
+	local := []*pb.Container{
+		mkListEntry("alice", pb.ContainerState_CONTAINER_STATE_RUNNING),
+		mkListEntry("bob", pb.ContainerState_CONTAINER_STATE_STOPPED),
+	}
+
+	out := applyProvisioningOverlay(local, nil, "", pb.ContainerState_CONTAINER_STATE_RUNNING, false, "")
+
+	if !has(out, "alice") || has(out, "bob") {
+		t.Fatalf("passthrough state filter wrong: got %v", out)
+	}
+}


### PR DESCRIPTION
Closes #1036. The honest-state half of the create-UX pair (#1037 is the latency half).

## Problem
`GetContainer` has reported CREATING/PROVISIONING from `pendingCreations` since #837 — but `ListContainers` bypassed the map, so a box ~30s into a multi-minute provisioning run showed raw incus `RUNNING` to every list consumer (control-plane state sync, CLI `list`, peers). Clients SSH'd long before ready, concluded the platform was broken, and their cleanup deletes aborted in-flight creates — manufacturing the false failure evidence tracked in #1035 that kept a production misdiagnosis loop alive across multiple agents.

## Changes
- **`ListContainers` provisioning overlay**: in-flight boxes report their pending state; a pending box not yet visible in incus gets a synthetic CREATING entry (same shape `GetContainer` synthesizes, same tenant scoping); the request's state filter applies to the *overlaid* state. Extracted as a pure function (`applyProvisioningOverlay`) so it unit-tests without an incus-backed Manager. Synthetics are suppressed under a label filter (labels aren't stamped yet). Failed creates (Done+Error) deliberately stay out of list — their instance is gone; `GetContainer` owns surfacing the ERROR.
- **`containarium create --wait [--wait-timeout 5m]`** (CLI-first): polls until `RUNNING` (exit 0) or `ERROR` (exit non-zero, actionable message). The create itself stays async — no long-held connection, so control-plane proxies' request caps don't bite. No-op in local mode (already synchronous).
- **MCP `create_container` response** now leads the CONNECTING section with: provisioning takes minutes, poll `get_container` until RUNNING before SSH, and an early SSH failure + delete aborts a create still in progress.

## Test plan
- [x] 6 new unit tests for `applyProvisioningOverlay`: overlay-replaces-RUNNING, synthetic for not-yet-visible, state filter sees overlaid state (both directions), label filter suppresses synthetics but keeps overlay, username scoping of synthetics (tenant isolation), no-pending passthrough.
- [x] `go build ./...`, `go vet`, full `go test ./...` — green except the pre-existing environment-only `test/integration` package (needs a live daemon on :50051; identical on main, documented in #1031's test plan).