### PR TITLE
feat(create): baked base images — image-bake command + create fast path (#1037)

### DIFF
--- a/internal/cmd/imagebake.go
+++ b/internal/cmd/imagebake.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/ostype"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+var (
+	bakeImage  string
+	bakePodman bool
+	bakeOSType string
+)
+
+var imageBakeCmd = &cobra.Command{
+	Use:   "image-bake",
+	Short: "Bake a provisioned base image so creates skip the in-container package install",
+	Long: `Bake a base image (#1037): launch a throwaway container from the source
+image, run the exact provisioning a create would (package repos, podman,
+services — no user, no stack), and publish the result as a local image under
+a deterministic alias.
+
+Afterwards, every stackless 'containarium create' for the same image/podman
+combination clones the baked image and skips the multi-minute in-container
+install — creates drop from minutes to roughly clone+boot+user setup.
+
+Re-run this on a schedule (cron/systemd timer) to pick up security updates:
+a re-bake re-points the alias at the fresh image and reaps the replaced one.
+Delete the alias ('incus image alias delete <alias>') to fall back to full
+per-create provisioning.
+
+Runs against the local Incus daemon on the backend host (like the daemon's
+own create path). Not available in remote --server mode.`,
+	Args: cobra.NoArgs,
+	RunE: runImageBake,
+}
+
+func init() {
+	rootCmd.AddCommand(imageBakeCmd)
+	imageBakeCmd.Flags().StringVar(&bakeImage, "image", "images:ubuntu/24.04", "Source image to bake from (same format as create --image)")
+	imageBakeCmd.Flags().BoolVar(&bakePodman, "podman", true, "Bake with Podman support (must match the creates that will use it)")
+	imageBakeCmd.Flags().StringVar(&bakeOSType, "os-type", "", "Container OS type: ubuntu, rocky9, rhel9 (overrides --image, same rule as create)")
+}
+
+func runImageBake(cmd *cobra.Command, args []string) error {
+	if serverAddr != "" {
+		return fmt.Errorf("image-bake runs on the backend host against local Incus; it is not available in --server mode (SSH to the host and run it there)")
+	}
+
+	osType := pb.OSType_OS_TYPE_UNSPECIFIED
+	if bakeOSType != "" {
+		osType = ostype.OSTypeFromString(bakeOSType)
+		if osType == pb.OSType_OS_TYPE_UNSPECIFIED {
+			return fmt.Errorf("invalid --os-type %q (expected ubuntu, rocky9, or rhel9)", bakeOSType)
+		}
+	}
+
+	mgr, err := container.New()
+	if err != nil {
+		return fmt.Errorf("failed to connect to Incus: %w", err)
+	}
+
+	res, err := mgr.BakeBaseImage(container.BakeOptions{
+		Image:        bakeImage,
+		OSType:       osType,
+		EnablePodman: bakePodman,
+		Verbose:      true,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Printf("✓ Baked %s\n", res.Alias)
+	fmt.Printf("  Source:      %s\n", res.SourceImage)
+	fmt.Printf("  Fingerprint: %s\n", res.Fingerprint)
+	fmt.Println()
+	fmt.Println("Stackless creates for this image/podman combination now clone the")
+	fmt.Println("baked image and skip the in-container package install. Re-run this")
+	fmt.Println("command periodically to pick up security updates.")
+	return nil
+}

--- a/pkg/core/container/bake.go
+++ b/pkg/core/container/bake.go
@@ -1,0 +1,158 @@
+package container
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/ostype"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/footprintai/containarium/pkg/version"
+)
+
+// Baked base images (#1037).
+//
+// Every create used to repeat identical, network-bound provisioning inside
+// the fresh instance (apt update, podman repo + install, service enablement)
+// — the dominant cost of a multi-minute create. BakeBaseImage runs that
+// provisioning ONCE into a local image under a deterministic alias;
+// Manager.Create then clones the baked image and skips the install step for
+// any stackless create whose (source image, podman) matches what was baked.
+//
+// The bake reuses installPackages itself — there is no parallel provisioning
+// implementation to drift. That works because installPackages is
+// user-independent by contract (the per-user podman durability step lives in
+// Create): keep it that way, or bakes and full creates will diverge.
+//
+// Image properties record what a bake contains; the create fast-path matches
+// on them, so a bake for a different source image or podman setting is never
+// silently reused. Re-bake on a schedule to pick up security updates —
+// PublishImage re-points the alias and reaps the replaced image.
+
+const (
+	bakedPropBaked         = "containarium.baked"
+	bakedPropSource        = "containarium.baked_source"
+	bakedPropPodman        = "containarium.baked_podman"
+	bakedPropFamily        = "containarium.baked_family"
+	bakedPropAt            = "containarium.baked_at"
+	bakedPropDaemonVersion = "containarium.baked_daemon_version"
+)
+
+// BakedImageAliasFor returns the deterministic local alias for a baked base
+// image of the given source image, e.g. "images:ubuntu/24.04" →
+// "containarium-base-images-ubuntu-24-04". The alias must stay free of ":"
+// and "/" so the incus client resolves it as a LOCAL alias (see
+// parseImageSource).
+func BakedImageAliasFor(image string) string {
+	s := strings.ToLower(image)
+	s = strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			return r
+		}
+		return '-'
+	}, s)
+	return "containarium-base-" + strings.Trim(s, "-")
+}
+
+// bakedImageMatches reports whether a baked image's properties cover a
+// create request for (image, enablePodman). Strict equality on both axes: a
+// bake for a different source image or without podman must never be
+// silently substituted.
+func bakedImageMatches(props map[string]string, image string, enablePodman bool) bool {
+	return props[bakedPropBaked] == "true" &&
+		props[bakedPropSource] == image &&
+		props[bakedPropPodman] == strconv.FormatBool(enablePodman)
+}
+
+// BakeOptions configures a base-image bake.
+type BakeOptions struct {
+	// Image is the source image to bake from (same format Create accepts,
+	// default images:ubuntu/24.04). OSType, when set, takes precedence —
+	// same rule as Create.
+	Image        string
+	OSType       pb.OSType
+	EnablePodman bool
+	Verbose      bool
+}
+
+// BakeResult reports what a bake produced.
+type BakeResult struct {
+	Alias       string
+	Fingerprint string
+	SourceImage string
+}
+
+// BakeBaseImage provisions a throwaway container from the source image with
+// the exact same installPackages a create would run (no stack, no user),
+// then publishes it as a local image under BakedImageAliasFor(source).
+// Subsequent stackless creates for the same (image, podman) clone the baked
+// image and skip the in-container install entirely.
+func (m *Manager) BakeBaseImage(opts BakeOptions) (*BakeResult, error) {
+	image := opts.Image
+	if opts.OSType != pb.OSType_OS_TYPE_UNSPECIFIED {
+		image = ostype.ImageForOSType(opts.OSType)
+	}
+	if image == "" {
+		return nil, fmt.Errorf("bake: an image (or os-type) is required")
+	}
+	if ostype.IsWindows(opts.OSType) {
+		return nil, fmt.Errorf("bake: Windows VMs are not bakeable (no in-container package install to skip)")
+	}
+
+	tempName := fmt.Sprintf("containarium-bake-%d", time.Now().Unix())
+	if opts.Verbose {
+		fmt.Printf("Baking base image from %s (podman=%v) via %s...\n", image, opts.EnablePodman, tempName)
+	}
+
+	if err := m.incus.CreateContainer(incus.ContainerConfig{
+		Name:          tempName,
+		Image:         image,
+		EnableNesting: opts.EnablePodman,
+	}); err != nil {
+		return nil, fmt.Errorf("bake: create %s: %w", tempName, err)
+	}
+	// The temp container is always removed — the bake's product is the
+	// image, never the container.
+	defer func() {
+		_ = m.incus.DeleteContainer(tempName)
+	}()
+
+	if err := m.incus.StartContainer(tempName); err != nil {
+		return nil, fmt.Errorf("bake: start %s: %w", tempName, err)
+	}
+	if _, err := m.incus.WaitForNetwork(tempName, 60*time.Second); err != nil {
+		return nil, fmt.Errorf("bake: network on %s: %w", tempName, err)
+	}
+
+	family := ostype.FamilyForOSType(opts.OSType)
+	if opts.Verbose {
+		fmt.Println("  Provisioning (same install a create runs)...")
+	}
+	if err := m.installPackages(tempName, opts.EnablePodman, "", nil, "", family); err != nil {
+		return nil, fmt.Errorf("bake: provisioning %s: %w", tempName, err)
+	}
+
+	if err := m.incus.StopContainer(tempName, true); err != nil {
+		return nil, fmt.Errorf("bake: stop %s: %w", tempName, err)
+	}
+
+	alias := BakedImageAliasFor(image)
+	props := map[string]string{
+		bakedPropBaked:         "true",
+		bakedPropSource:        image,
+		bakedPropPodman:        strconv.FormatBool(opts.EnablePodman),
+		bakedPropFamily:        string(family),
+		bakedPropAt:            time.Now().UTC().Format(time.RFC3339),
+		bakedPropDaemonVersion: version.GetVersion(),
+	}
+	if opts.Verbose {
+		fmt.Printf("  Publishing as %s...\n", alias)
+	}
+	fingerprint, err := m.incus.PublishImage(tempName, alias, props)
+	if err != nil {
+		return nil, fmt.Errorf("bake: publish: %w", err)
+	}
+	return &BakeResult{Alias: alias, Fingerprint: fingerprint, SourceImage: image}, nil
+}

--- a/pkg/core/container/bake_test.go
+++ b/pkg/core/container/bake_test.go
@@ -1,0 +1,63 @@
+package container
+
+import "testing"
+
+// TestBakedImageAliasFor pins the alias derivation: deterministic, and free
+// of ":" and "/" so the incus client resolves it as a LOCAL alias (a ":"
+// would read as a remote prefix, a "/" as a simplestreams path — either
+// would silently turn the fast path into a network pull).
+func TestBakedImageAliasFor(t *testing.T) {
+	cases := []struct {
+		image string
+		want  string
+	}{
+		{"images:ubuntu/24.04", "containarium-base-images-ubuntu-24-04"},
+		{"ubuntu:24.04", "containarium-base-ubuntu-24-04"},
+		{"ubuntu/24.04", "containarium-base-ubuntu-24-04"},
+		{"UBUNTU/24.04", "containarium-base-ubuntu-24-04"},
+	}
+	for _, c := range cases {
+		got := BakedImageAliasFor(c.image)
+		if got != c.want {
+			t.Errorf("BakedImageAliasFor(%q) = %q, want %q", c.image, got, c.want)
+		}
+		for _, forbidden := range []byte{':', '/'} {
+			for i := 0; i < len(got); i++ {
+				if got[i] == forbidden {
+					t.Errorf("alias %q contains %q — would not resolve as a local alias", got, string(forbidden))
+				}
+			}
+		}
+	}
+}
+
+// TestBakedImageMatches pins the fast-path gate: only an image explicitly
+// baked for this exact (source, podman) combination is substituted — a bake
+// for a different source or podman setting, or an image merely carrying the
+// alias without the marker property, must never be silently reused.
+func TestBakedImageMatches(t *testing.T) {
+	baked := map[string]string{
+		bakedPropBaked:  "true",
+		bakedPropSource: "images:ubuntu/24.04",
+		bakedPropPodman: "true",
+	}
+
+	if !bakedImageMatches(baked, "images:ubuntu/24.04", true) {
+		t.Error("exact match must be accepted")
+	}
+	if bakedImageMatches(baked, "images:ubuntu/22.04", true) {
+		t.Error("different source image must be rejected")
+	}
+	if bakedImageMatches(baked, "images:ubuntu/24.04", false) {
+		t.Error("different podman setting must be rejected")
+	}
+	if bakedImageMatches(map[string]string{
+		bakedPropSource: "images:ubuntu/24.04",
+		bakedPropPodman: "true",
+	}, "images:ubuntu/24.04", true) {
+		t.Error("missing baked marker must be rejected")
+	}
+	if bakedImageMatches(nil, "images:ubuntu/24.04", true) {
+		t.Error("nil properties must be rejected")
+	}
+}

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -144,6 +144,26 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 
 	isWindows := ostype.IsWindows(opts.OSType)
 
+	// Baked-image fast path (#1037): when an operator has baked a base image
+	// for this exact (source image, podman) combination (`containarium
+	// image-bake`), clone the baked image and skip the multi-minute
+	// in-container package install below — the bake ran the identical
+	// installPackages. Stacks are not baked, so a stack request keeps the
+	// full path. No baked alias (or a lookup error) → today's path,
+	// byte-identical.
+	usingBakedImage := false
+	if opts.Stack == "" && !isWindows {
+		alias := BakedImageAliasFor(image)
+		if props, ok, err := m.incus.GetImageAliasProperties(alias); err == nil && ok &&
+			bakedImageMatches(props, image, opts.EnablePodman) {
+			if opts.Verbose {
+				fmt.Printf("  Using baked base image %s (baked %s)\n", alias, props[bakedPropAt])
+			}
+			image = alias
+			usingBakedImage = true
+		}
+	}
+
 	config := incus.ContainerConfig{
 		Name:                   containerName,
 		Image:                  image,
@@ -316,9 +336,25 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 	}
 
 	family := ostype.FamilyForOSType(opts.OSType)
-	if err := m.installPackages(containerName, opts.EnablePodman, opts.Stack, opts.StackParameters, opts.Username, family); err != nil {
+	if usingBakedImage {
+		// Baked base image (#1037): the bake already ran this exact
+		// installPackages (same image, same podman setting, no stack) into
+		// the image this box was cloned from — the multi-minute in-container
+		// package install is the whole cost the bake exists to skip.
+		if opts.Verbose {
+			fmt.Println("  [5/7] Package install pre-baked into the base image — skipping")
+		}
+	} else if err := m.installPackages(containerName, opts.EnablePodman, opts.Stack, opts.StackParameters, opts.Username, family); err != nil {
 		_ = m.cleanup(containerName)
 		return nil, fmt.Errorf("failed to install packages: %w", err)
+	}
+
+	// Make podman workloads reboot-durable (#387). Runs on BOTH the baked
+	// and full paths: the rootful half is already enabled in a baked image
+	// (idempotent re-enable, harmless), but the rootless half is per-user
+	// (linger + user service) and can only run once the tenant is known.
+	if opts.EnablePodman {
+		m.enablePodmanRestartDurability(containerName, opts.Username)
 	}
 
 	// Step 6: Create user
@@ -585,11 +621,9 @@ func (m *Manager) installPackages(containerName string, enablePodman bool, stack
 			}
 		}
 
-		// Make podman workloads reboot-durable. The LXC already carries
-		// boot.autostart=true, so it comes back after a host reboot/preemption;
-		// these steps ensure podman containers that carry a restart policy
-		// (--restart=always / unless-stopped) come back with it. See issue #387.
-		m.enablePodmanRestartDurability(containerName, username)
+		// Per-user podman reboot durability runs from Create (not here):
+		// installPackages must stay user-independent so BakeBaseImage
+		// (#1037) can run it into a shared base image. See issue #387.
 	}
 
 	sshService := pkgMgr.SSHServiceName()

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -70,6 +70,13 @@ type Backend interface {
 
 	// Image inspection (Phase 3.1 Phase-C)
 	GetContainerImageFingerprint(containerName string) (string, error)
+
+	// Baked base images (#1037): publish a provisioned container as a local
+	// image under a stable alias (re-pointing the alias and reaping the
+	// replaced image on re-bake), and read an alias's image properties so
+	// the create fast-path can check what a baked image contains.
+	PublishImage(containerName, alias string, properties map[string]string) (string, error)
+	GetImageAliasProperties(alias string) (map[string]string, bool, error)
 }
 
 // DiskDevice represents a disk device configuration
@@ -1486,6 +1493,74 @@ func (c *Client) GetContainerImageFingerprint(containerName string) (string, err
 		return "", fmt.Errorf("get instance for fingerprint: %w", err)
 	}
 	return inst.Config["volatile.base_image"], nil
+}
+
+// PublishImage publishes a (stopped) container as a local image and points
+// alias at it (#1037). Re-baking is the expected lifecycle: an existing alias
+// is re-pointed to the fresh image and the replaced image is reaped
+// (best-effort), so the alias is always the newest bake and old bakes don't
+// accumulate. Returns the new image fingerprint.
+func (c *Client) PublishImage(containerName, alias string, properties map[string]string) (string, error) {
+	// Remember the image currently behind the alias so it can be reaped
+	// after the alias moves.
+	var oldFingerprint string
+	if a, _, err := c.server.GetImageAlias(alias); err == nil && a != nil {
+		oldFingerprint = a.Target
+	}
+
+	op, err := c.server.CreateImage(api.ImagesPost{
+		Source: &api.ImagesPostSource{
+			Type: "instance",
+			Name: containerName,
+		},
+		ImagePut: api.ImagePut{Properties: properties},
+	}, nil)
+	if err != nil {
+		return "", fmt.Errorf("publish image from %s: %w", containerName, err)
+	}
+	if err := op.Wait(); err != nil {
+		return "", fmt.Errorf("publish image from %s: %w", containerName, err)
+	}
+	fingerprint, _ := op.Get().Metadata["fingerprint"].(string)
+	if fingerprint == "" {
+		return "", fmt.Errorf("publish image from %s: operation returned no fingerprint", containerName)
+	}
+
+	// Re-point the alias. DeleteImageAlias errors when the alias doesn't
+	// exist — fine either way, CreateImageAlias below is authoritative.
+	_ = c.server.DeleteImageAlias(alias)
+	if err := c.server.CreateImageAlias(api.ImageAliasesPost{
+		ImageAliasesEntry: api.ImageAliasesEntry{
+			Name:                 alias,
+			ImageAliasesEntryPut: api.ImageAliasesEntryPut{Target: fingerprint},
+		},
+	}); err != nil {
+		return "", fmt.Errorf("alias %s -> %s: %w", alias, fingerprint, err)
+	}
+
+	// Reap the replaced image. Best-effort: a failure leaves an unaliased
+	// image behind (disk cost), never a broken alias.
+	if oldFingerprint != "" && oldFingerprint != fingerprint {
+		if delOp, derr := c.server.DeleteImage(oldFingerprint); derr == nil {
+			_ = delOp.Wait()
+		}
+	}
+	return fingerprint, nil
+}
+
+// GetImageAliasProperties resolves a local image alias and returns the
+// image's properties. ok=false (no error) when the alias doesn't exist —
+// callers treat that as "no baked image; use the slow path", not a failure.
+func (c *Client) GetImageAliasProperties(alias string) (map[string]string, bool, error) {
+	a, _, err := c.server.GetImageAlias(alias)
+	if err != nil || a == nil {
+		return nil, false, nil
+	}
+	img, _, err := c.server.GetImage(a.Target)
+	if err != nil {
+		return nil, false, fmt.Errorf("get image %s for alias %s: %w", a.Target, alias, err)
+	}
+	return img.Properties, true, nil
 }
 
 // imageDescriptionFromConfig returns a human-readable label for the image a

--- a/pkg/core/incus/incustest/mock.go
+++ b/pkg/core/incus/incustest/mock.go
@@ -51,6 +51,10 @@ type MockBackend struct {
 
 	// Phase 3.1 Phase-C — post-pull fingerprint check.
 	GetContainerImageFingerprintFunc func(name string) (string, error)
+
+	// Baked base images (#1037).
+	PublishImageFunc            func(containerName, alias string, properties map[string]string) (string, error)
+	GetImageAliasPropertiesFunc func(alias string) (map[string]string, bool, error)
 }
 
 // NewMockBackend returns a ready-to-use MockBackend with an initialized
@@ -255,6 +259,20 @@ func (m *MockBackend) GetContainerImageFingerprint(name string) (string, error) 
 		return m.GetContainerImageFingerprintFunc(name)
 	}
 	return "", nil
+}
+
+func (m *MockBackend) PublishImage(containerName, alias string, properties map[string]string) (string, error) {
+	if m.PublishImageFunc != nil {
+		return m.PublishImageFunc(containerName, alias, properties)
+	}
+	return "", nil
+}
+
+func (m *MockBackend) GetImageAliasProperties(alias string) (map[string]string, bool, error) {
+	if m.GetImageAliasPropertiesFunc != nil {
+		return m.GetImageAliasPropertiesFunc(alias)
+	}
+	return nil, false, nil
 }
 
 func (m *MockBackend) UpdateContainerConfig(name, key, value string) error {

--- a/pkg/core/incus/unavailable.go
+++ b/pkg/core/incus/unavailable.go
@@ -70,3 +70,9 @@ func (*UnavailableBackend) GetContainerMetrics(string) (*ContainerMetrics, error
 func (*UnavailableBackend) GetContainerImageFingerprint(string) (string, error) {
 	return "", ErrUnavailable
 }
+func (*UnavailableBackend) PublishImage(string, string, map[string]string) (string, error) {
+	return "", ErrUnavailable
+}
+func (*UnavailableBackend) GetImageAliasProperties(string) (map[string]string, bool, error) {
+	return nil, false, ErrUnavailable
+}


### PR DESCRIPTION
First slice of #1037 — the latency half of the create-UX pair (#1038/#1036 was the honest-state half, merged).

## What
- **`containarium image-bake`** (CLI-first, local mode): launches a throwaway container from the source image, runs the *exact* provisioning a create would (`installPackages` — no parallel implementation to drift), publishes it as a local image under a deterministic alias (`containarium-base-<image>`), with image properties recording source/podman/family/bake-time/daemon-version. Re-bake re-points the alias and reaps the replaced image.
- **Create fast path**: a stackless create whose (source image, podman) strictly matches a baked alias's properties clones the baked image and skips the in-container install — the measured ~2.5-minute dominant cost. No baked alias (or any mismatch) → today's path, byte-identical.
- **Refactor enabling both**: the one user-scoped step inside `installPackages` (per-user podman restart durability, #387) moves to `Create` — same relative order, runs on both paths — making `installPackages` user-independent by contract (documented in bake.go's header).
- `PublishImage` / `GetImageAliasProperties` added to the incus `Backend` interface (+ stub, mock).

## Why the alias has no ":" or "/"
`parseImageSource` treats those as remote/simplestreams markers — the alias must resolve locally or the "fast path" would silently become a network pull. Pinned by test.

## Test plan
- [x] `TestBakedImageAliasFor` (derivation + no-forbidden-chars), `TestBakedImageMatches` (strict gate: wrong source/podman/missing marker/nil all rejected)
- [x] `go build ./...`, `go vet`, full `go test ./...` green except the pre-existing environment-only `test/integration` package (needs a live daemon on :50051; identical on main)
- [ ] Live validation on a backend host: run `image-bake`, then a create — confirm the skip line, measure wall-clock delta, and confirm SSH + podman work in the resulting box (will do post-merge on a staging host before recommending fleet rollout)

## Out of scope (issue stays open)
Scheduled re-bake automation/runbook; per-stack bakes.