### PR TITLE
chore(release): cut v0.56.0 — baked base images + honest provisioning state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.56.0] - 2026-07-20
+
+### Added
+
+- **Baked base images — creates drop from ~3 minutes to roughly
+  clone + boot** (#1037, first slice). `containarium image-bake` runs the
+  exact per-create provisioning (package repos, podman, service
+  enablement) once into a local image under a deterministic alias;
+  stackless creates whose source image + podman setting match the bake's
+  recorded properties clone the baked image and skip the in-container
+  package install — also removing mid-create exposure to distro/repo
+  mirror outages. Opt-in by running `image-bake` on the host; no baked
+  image means the previous behavior, byte-identical. Re-bake on a
+  schedule to pick up security updates (the alias is re-pointed and the
+  replaced image reaped).
+
+### Fixed
+
+- **List responses are honest about provisioning** (#1036). A box
+  mid-provisioning (packages and SSH keys still installing) reported raw
+  incus `RUNNING` in list responses minutes before SSH could work,
+  inviting clients to connect too early — and cleanup deletes after
+  those failed attempts aborted creates that were still in progress.
+  `ListContainers` now reports `CREATING`/`PROVISIONING` from the same
+  pending-creation state `GetContainer` already used (including
+  synthetic entries for creates not yet visible in incus, with the
+  state filter applied to the reported state). `containarium create
+  --wait [--wait-timeout]` adds blocking ergonomics on top of the
+  still-async create, and the MCP create response now says explicitly
+  that provisioning takes minutes and to poll `get_container` until
+  `RUNNING` before SSH.
+
 ## [0.55.1] - 2026-07-19
 
 ### Fixed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.55.1"
+	Version = "0.56.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Version bump for the RC tracked in #1040.

- #1039 — baked base images (`image-bake` + create fast path, #1037 slice 1)
- #1038 — honest CREATING/PROVISIONING list state + `create --wait` (#1036)

## Test plan
- [x] `go build` clean
- [ ] Tag `v0.56.0` after merge, verify release.yml publishes all binaries + SHA256SUMS.txt and a fresh binary reports 0.56.0