### PR TITLE
feat(rebake): weekly base-image re-bake timer + IMAGE-BAKE doc (#1037)

### DIFF
--- a/docs/IMAGE-BAKE.md
+++ b/docs/IMAGE-BAKE.md
@@ -1,0 +1,51 @@
+# Baked base images
+
+`containarium image-bake` (#1037, v0.56.0) runs the per-create provisioning
+(package repos, podman, service enablement) once into a local Incus image.
+Stackless creates whose source image + podman setting match the bake's
+recorded properties clone the baked image and skip the in-container package
+install — measured on a production backend: **~190s → ~72s per create**, and
+no mid-create exposure to distro/mirror outages.
+
+## One-time bake
+
+```sh
+sudo containarium image-bake                    # defaults: images:ubuntu/24.04, podman on
+sudo containarium image-bake --image images:ubuntu/22.04
+```
+
+The bake publishes a local image alias (`containarium-base-<image>`); creates
+pick it up automatically when it matches. No baked image = the previous
+full-provisioning behavior, unchanged. To disable the fast path:
+
+```sh
+incus image alias delete containarium-base-images-ubuntu-24-04
+```
+
+## Scheduled re-bake (recommended)
+
+A create from a baked image never re-runs the package install, so **only
+re-baking picks up security updates**. Ship the weekly timer:
+
+| File | Purpose |
+| --- | --- |
+| `scripts/containarium-rebake.service` | one re-bake run (`image-bake`, ~3-5 min) |
+| `scripts/containarium-rebake.timer` | fires it Sunday 03:30 (+ up to 30 min jitter), catches up after downtime |
+
+```sh
+sudo cp scripts/containarium-rebake.service scripts/containarium-rebake.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now containarium-rebake.timer
+
+# verify
+systemctl list-timers containarium-rebake.timer
+journalctl -u containarium-rebake -n 20      # after the first run
+```
+
+Non-default bakes: put flags in `/etc/containarium/rebake.env`, e.g.
+`REBAKE_FLAGS=--image images:ubuntu/22.04 --podman=true`.
+
+A failed re-bake (mirrors down, host wedged) is safe: the alias only moves on
+a successful publish, so creates keep using the previous bake. Check
+`systemctl status containarium-rebake` if `containarium.baked_at` (visible
+via `incus image show <alias>`) grows older than a week.

--- a/scripts/containarium-rebake.service
+++ b/scripts/containarium-rebake.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=Containarium weekly base-image re-bake
+Documentation=https://github.com/footprintai/Containarium/issues/1037
+# Needs the network (distro mirrors) and local Incus; runs alongside the
+# daemon but doesn't require it — image-bake talks straight to Incus.
+After=network-online.target incus.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+
+# Optional overrides (image / podman / os-type flags), e.g.:
+#   REBAKE_FLAGS=--image images:ubuntu/24.04 --podman=true
+# Absent file or empty var = bake the defaults, which match what stackless
+# creates request. To bake several variants, add drop-in ExecStart lines.
+EnvironmentFile=-/etc/containarium/rebake.env
+ExecStart=/bin/sh -c '/usr/local/bin/containarium image-bake ${REBAKE_FLAGS}'
+
+# Root, same as the daemon — image-bake drives Incus (create/exec/publish).
+User=root
+Group=root
+
+# A bake is one full provisioning run (~3-5 min normally). If it takes more
+# than 30 minutes the mirrors are down or the host is wedged — fail loudly
+# rather than block Monday's timer slot; creates keep using the previous
+# bake (the alias only moves on a successful publish).
+TimeoutStartSec=1800
+
+# Journal output: `journalctl -u containarium-rebake` shows the run log.
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=containarium-rebake

--- a/scripts/containarium-rebake.timer
+++ b/scripts/containarium-rebake.timer
@@ -1,0 +1,25 @@
+[Unit]
+Description=Containarium weekly base-image re-bake timer
+Documentation=https://github.com/footprintai/Containarium/issues/1037
+
+[Timer]
+# Fire weekly, early Sunday morning — after the nightly backup window
+# (containarium-backup.timer fires at 02:30). Weekly keeps the baked image's
+# packages at most a week behind the distro's security updates; a create from
+# a baked image never re-runs the package install, so ONLY re-baking picks
+# updates up.
+OnCalendar=Sun *-*-* 03:30:00
+
+# Spread firing up to 30 min so a fleet of backend hosts doesn't all pull
+# from the distro mirrors at the same instant.
+RandomizedDelaySec=1800
+
+# If the host was down Sunday 03:30 (spot preemption, maintenance), catch up
+# on the next boot rather than staying stale until the following Sunday.
+Persistent=true
+
+# Minute granularity is fine for a weekly job.
+AccuracySec=60
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes the remaining scope of #1037 (mechanism + fast path shipped in v0.56.0 and live-validated: ~190s → ~72s per create).

- `scripts/containarium-rebake.{service,timer}` — mirrors `containarium-backup.{service,timer}`'s conventions: weekly (Sun 03:30, after the nightly backup window) + 30 min jitter, `Persistent=true` catch-up, 30-min hard timeout. A failed re-bake is safe by construction: the alias only moves on a successful publish, so creates keep the previous bake. Flags overridable via `/etc/containarium/rebake.env`.
- `docs/IMAGE-BAKE.md` — bake, fast-path opt-out, timer install, staleness check (`containarium.baked_at` property).

## Test plan
- [x] Unit files lint clean by inspection against the backup pair's structure (no build surface)
- [ ] Post-merge: install + enable on both region backend hosts, verify `systemctl list-timers` shows the schedule and a manual `systemctl start containarium-rebake` completes a real bake