### PR TITLE
fix(cloud): driver-token refresh must not be silently disabled by a legacy cloud.yaml

### DIFF
--- a/internal/cloud/config.go
+++ b/internal/cloud/config.go
@@ -44,8 +44,60 @@ type Config struct {
 	// When set, the daemon's cloud actuation client re-mints a fresh driver
 	// token every ~⅔ of the 30-day cap and pushes it to the cloud via
 	// ReportHostStatus so the cloud-stored credential never expires.
-	// Written by `containarium cloud enroll`; empty disables auto-refresh.
+	// Written by `containarium cloud enroll`.
+	//
+	// EMPTY no longer disables auto-refresh (cloud#888/#903 postmortem): a
+	// cloud.yaml written by a pre-#557 enroll has no jwt_secret_file, and
+	// nothing backfills the config on daemon upgrades — so legacy-enrolled
+	// hosts silently never rotated and their cloud-stored driver token died
+	// at the 30-day cap. When empty, the daemon falls back to the default
+	// secret path if it's readable; set DriverTokenDisabled to genuinely
+	// opt out.
 	JWTSecretFile string `yaml:"jwt_secret_file,omitempty"`
+	// DriverTokenDisabled explicitly opts this host out of driver-token
+	// auto-refresh (the durable form of `--no-driver-token`): the cloud
+	// can't place workloads on the host, and the daemon must not push
+	// tokens that would silently re-enable drivability. Distinct from an
+	// EMPTY JWTSecretFile, which legacy enrollments produced without any
+	// intent to opt out.
+	DriverTokenDisabled bool `yaml:"driver_token_disabled,omitempty"`
+}
+
+// DefaultDaemonJWTSecretFile is where the daemon's JWT signing secret lives on
+// a standard install — the daemon-side fallback when cloud.yaml predates
+// jwt_secret_file (see JWTSecretFile), and the enroll CLI's flag default.
+const DefaultDaemonJWTSecretFile = "/etc/containarium/jwt.secret" // #nosec G101 -- a file PATH, not a credential
+
+// ResolveDriverSecretFile decides which JWT-secret path (if any) the daemon
+// should mint driver-token refreshes from (cloud#888/#903 postmortem):
+//
+//   - DriverTokenDisabled → "" (explicit opt-out, the durable
+//     `--no-driver-token`).
+//   - JWTSecretFile set → that path (the post-#557 enroll wrote it).
+//   - JWTSecretFile empty → DefaultDaemonJWTSecretFile IF it exists — a
+//     legacy (pre-#557) cloud.yaml simply predates the field; treating
+//     empty as "disabled" is what let legacy hosts' cloud-stored driver
+//     tokens silently expire at the 30-day cap.
+//   - Otherwise "" (nothing to mint from; caller warns loudly).
+//
+// statFn abstracts os.Stat for tests; pass nil for the real filesystem.
+func ResolveDriverSecretFile(cfg *Config, statFn func(string) error) string {
+	if cfg == nil || cfg.DriverTokenDisabled {
+		return ""
+	}
+	if cfg.JWTSecretFile != "" {
+		return cfg.JWTSecretFile
+	}
+	if statFn == nil {
+		statFn = func(p string) error {
+			_, err := os.Stat(p)
+			return err
+		}
+	}
+	if statFn(DefaultDaemonJWTSecretFile) == nil {
+		return DefaultDaemonJWTSecretFile
+	}
+	return ""
 }
 
 // DefaultPath resolves $HOME/.containarium/cloud.yaml.

--- a/internal/cloud/resolve_driver_secret_test.go
+++ b/internal/cloud/resolve_driver_secret_test.go
@@ -1,0 +1,61 @@
+package cloud
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestResolveDriverSecretFile pins the cloud#888/#903 postmortem semantics:
+// an EMPTY jwt_secret_file (what every pre-#557 enroll wrote) must fall back
+// to the default daemon secret rather than silently disabling refresh — that
+// silence is exactly how legacy hosts' cloud-stored driver tokens expired at
+// the 30-day cap unnoticed. Only the explicit driver_token_disabled marker
+// opts out.
+func TestResolveDriverSecretFile(t *testing.T) {
+	exists := func(string) error { return nil }
+	missing := func(string) error { return errors.New("no such file") }
+
+	cases := []struct {
+		name string
+		cfg  *Config
+		stat func(string) error
+		want string
+	}{
+		{"explicit path wins without stat", &Config{JWTSecretFile: "/custom/jwt.secret"}, missing, "/custom/jwt.secret"},
+		{"legacy empty falls back to default when readable", &Config{}, exists, DefaultDaemonJWTSecretFile},
+		{"legacy empty with no default file resolves empty", &Config{}, missing, ""},
+		{"explicit opt-out beats an existing default", &Config{DriverTokenDisabled: true}, exists, ""},
+		{"explicit opt-out beats an explicit path", &Config{DriverTokenDisabled: true, JWTSecretFile: "/custom/jwt.secret"}, exists, ""},
+		{"nil config resolves empty", nil, exists, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ResolveDriverSecretFile(c.cfg, c.stat); got != c.want {
+				t.Fatalf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestConfigRoundTripsDriverTokenDisabled: the durable --no-driver-token
+// marker must survive a Save/Load cycle, or the daemon's fallback would
+// re-enable drivability on the next restart against the operator's choice.
+func TestConfigRoundTripsDriverTokenDisabled(t *testing.T) {
+	path := t.TempDir() + "/cloud.yaml"
+	in := &Config{
+		ControlPlane:        "https://cp.example.com",
+		HostID:              "0f000000-0000-0000-0000-000000000001",
+		Token:               "0f000000-0000-0000-0000-000000000001.secret",
+		DriverTokenDisabled: true,
+	}
+	if err := Save(path, in); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	out, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if out == nil || !out.DriverTokenDisabled {
+		t.Fatalf("DriverTokenDisabled lost in round-trip: %+v", out)
+	}
+}

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -11,10 +11,10 @@ import (
 	"github.com/footprintai/containarium/internal/cloud"
 )
 
-// defaultDaemonJWTSecretFile is where the daemon's JWT signing secret lives on
-// a standard host install — the same secret `cloud enroll` mints the BYOC
-// driver token against so the host's own daemon will accept it.
-const defaultDaemonJWTSecretFile = "/etc/containarium/jwt.secret" // #nosec G101 -- a file PATH, not a credential
+// defaultDaemonJWTSecretFile aliases the cloud package's shared default so
+// the enroll CLI and the daemon-side refresh fallback can never disagree on
+// where the secret lives.
+const defaultDaemonJWTSecretFile = cloud.DefaultDaemonJWTSecretFile
 
 // cloudCmd is the parent for `containarium cloud <verb>` — host enrollment with
 // a cloud control plane (#354, docs/CLOUD-ACTUATION-CLIENT-DESIGN.md). This is
@@ -194,13 +194,18 @@ func runCloudEnroll(cmd *cobra.Command, _ []string) error {
 		Insecure:     cloudEnrollInsecure,
 		// Persist the JWT secret path so the daemon can re-mint the driver
 		// token autonomously before it expires (#557). Only set when the
-		// enroll actually minted a driver token (no-driver-token = no refresh).
+		// enroll actually minted a driver token.
 		JWTSecretFile: func() string {
 			if cloudEnrollNoDriverToken || opts.DriverToken == "" {
 				return ""
 			}
 			return cloudEnrollJWTSecretFile
 		}(),
+		// --no-driver-token is a durable opt-out, not just "skip this once":
+		// without the marker, the daemon's legacy-config fallback
+		// (cloud#888/#903) would start pushing driver tokens on the next
+		// restart and silently re-enable cloud drivability.
+		DriverTokenDisabled: cloudEnrollNoDriverToken,
 	}
 	if err := cfg.Validate(); err != nil {
 		return err

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -948,14 +948,27 @@ skipAppHosting:
 		} else {
 			cloudDeps.Containers = cloudActuator // only set when non-nil (avoid nil-iface trap)
 		}
-		// Driver-token auto-refresh (#557): if cloud.yaml has a JWTSecretFile,
-		// provide a minter so the actuation client keeps the cloud-stored
-		// driver credential from reaching the 30-day OSS cap.
-		if cloudCfg.JWTSecretFile != "" {
-			secretFile := cloudCfg.JWTSecretFile // capture for closure
-			cloudDeps.Driver = func() (string, error) {
-				return cloud.MintDriverToken(secretFile, 30*24*time.Hour)
+		// Driver-token auto-refresh (#557). Gating this on cloud.yaml's
+		// jwt_secret_file alone turned out to be a production trap
+		// (cloud#888/#903 postmortem): a cloud.yaml written by a pre-#557
+		// enroll has no jwt_secret_file, nothing backfills the config on
+		// daemon upgrades, and the refresh loop silently never armed — so
+		// legacy-enrolled hosts' cloud-stored driver tokens all died at the
+		// 30-day cap and every cloud→host driver call 401'd forever. When
+		// the config doesn't name a secret file, fall back to the default
+		// daemon secret path if it's readable; only an explicit
+		// driver_token_disabled opts out of refresh entirely.
+		switch secretFile := cloud.ResolveDriverSecretFile(cloudCfg, nil); {
+		case secretFile != "":
+			if cloudCfg.JWTSecretFile == "" {
+				log.Printf("Cloud driver-token refresh: cloud.yaml has no jwt_secret_file (legacy enroll); falling back to %s", secretFile)
 			}
+			sf := secretFile // capture for closure
+			cloudDeps.Driver = func() (string, error) {
+				return cloud.MintDriverToken(sf, 30*24*time.Hour)
+			}
+		case !cloudCfg.DriverTokenDisabled:
+			log.Printf("WARNING: cloud driver-token refresh DISABLED (no jwt_secret_file in cloud.yaml and no readable %s) — the cloud-stored driver token will expire within 30 days and cloud→host operations will start failing 401; re-run `containarium cloud enroll` to fix", cloud.DefaultDaemonJWTSecretFile)
 		}
 		if cc, nerr := cloud.New(cloudCfg, cloudDeps); nerr != nil {
 			log.Printf("Warning: cloud-actuation config invalid: %v (running single-tenant)", nerr)


### PR DESCRIPTION
Fixes the stale-driver-token half of [Containarium-cloud#903](https://github.com/FootprintAI/Containarium-cloud/issues/903) / follow-on of [Containarium-cloud#888](https://github.com/FootprintAI/Containarium-cloud/issues/888).

## Root cause chain (live-traced)
- The #557 auto-refresh loop (shipped v0.34.0) only arms when \`cloud.yaml\` has \`jwt_secret_file\` — a field only written by post-#557 enrolls.
- A production BYOC host enrolled on a pre-#557 release has a config without the field; upgrading the daemon binary never backfills it.
- Result: the refresh loop silently never starts, the cloud-stored driver token hits the 30-day cap, and every cloud→host driver op (metrics, upgrade, reconciler) 401s forever — while heartbeats stay green (their bearer was separately fixed by #957/v0.51.4).

## Fix
- **\`ResolveDriverSecretFile\`** (new, table-tested): empty \`jwt_secret_file\` falls back to the default daemon secret path when readable; empty no longer means disabled.
- **Explicit opt-out survives**: \`cloud enroll --no-driver-token\` now writes a durable \`driver_token_disabled: true\`, distinguishable from a legacy-empty config (previously identical), so the fallback can't re-enable drivability against an operator's choice.
- **Loud failure**: when neither a configured nor default secret exists, the daemon logs a warning naming the 30-day consequence, instead of nothing.
- \`DefaultDaemonJWTSecretFile\` moves to the \`cloud\` package (single source of truth for CLI + daemon).

Once this ships and the affected hosts upgrade + restart, they self-heal on the next status beat (the refresh loop fires immediately at startup) — no re-enroll needed.

## Test plan
- [x] 6-case table test for the resolution semantics (explicit path, legacy fallback, no-file, opt-out×2, nil)
- [x] Save/Load round-trip test for the new \`driver_token_disabled\` marker
- [x] \`go build ./...\", vet, and the \`internal/cloud\` + \`internal/server\` + \`internal/cmd\` suites green