### PR TITLE
fix(create): treat a delete racing an in-flight async create as a cancellation (#1035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A delete racing an in-flight async create no longer manufactures a
+  fake "Async creation failed"** (#1035). Provisioning runs for minutes,
+  so a delete frequently lands mid-run and pulls the instance out from
+  under the creating goroutine; the resulting `Instance not found` was
+  logged as a creation failure, indistinguishable in the journal from a
+  genuine one. (During one incident investigation this manufactured at
+  least eight false "confirmations" of an already-fixed bug.) The delete
+  now claims the pending creation, which logs a single unambiguous
+  cancellation line, drops out of the `CREATING`/`PROVISIONING` state
+  Get/List report, and reaps the box if the creation happened to finish
+  after its own delete. Genuine failures still surface as `ERROR`.
+- **Delete-cascade tolerates a live SSH session when removing the host
+  user** (#1035). `userdel: user X is currently used by process N` left
+  an orphaned account until the reaper's next tick; the box is already
+  gone at that point, so the remaining session is terminated and
+  `userdel` retried once. Every other `userdel` failure is unchanged.
+
 ## [0.57.0] - 2026-07-20
 
 ### Added

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -48,7 +48,21 @@ type PendingCreation struct {
 	Error        error
 	Done         bool
 	Provisioning bool // container is running but installing stack/packages
+	// Cancelled records that a DeleteContainer arrived while this creation
+	// was still in flight (#1035). Provisioning runs for minutes; a delete
+	// pulls the instance out from under the goroutine, which then fails with
+	// "Instance not found" — indistinguishable, in the journal, from a
+	// genuine create failure. Flagging the cancellation lets the goroutine
+	// log what actually happened, and keeps the doomed creation out of the
+	// CREATING/ERROR state that Get/List would otherwise report.
+	Cancelled bool
 }
+
+// active reports whether this creation is still legitimately in flight —
+// neither finished nor cancelled by a delete. Read/List overlays must use
+// this rather than !Done, or a cancelled create keeps reporting CREATING
+// for the rest of its (now pointless) provisioning run.
+func (p *PendingCreation) active() bool { return p != nil && !p.Done && !p.Cancelled }
 
 // ContainerServer implements the gRPC ContainerService
 type ContainerServer struct {
@@ -538,12 +552,39 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 				s.stampBirthDeleteAfterStopped(info.Ref.Name, req.DeleteAfterStoppedSeconds)
 			}
 
+			// A delete that landed mid-provisioning owns this outcome, not
+			// the creation (#1035): drop the tracking entry and log the one
+			// line that describes what happened. Reporting it as a failure
+			// is what let cleanup deletes masquerade as independent
+			// confirmations of a create bug during cloud#920.
 			s.pendingMu.Lock()
-			if pending, exists := s.pendingCreations[req.Username]; exists {
+			pending, exists := s.pendingCreations[req.Username]
+			cancelled := exists && pending.Cancelled
+			switch {
+			case cancelled:
+				delete(s.pendingCreations, req.Username)
+			case exists:
 				pending.Done = true
 				pending.Error = err
 			}
 			s.pendingMu.Unlock()
+
+			if cancelled {
+				log.Printf("Async container creation for %s cancelled by delete request (provisioning aborted; any error above is a consequence of the delete, not a creation failure)", req.Username)
+				// The delete can land in the narrow window before the
+				// instance exists, in which case it deleted nothing and
+				// this goroutine went on to finish the box. Reap it —
+				// otherwise the caller's delete silently leaves behind the
+				// container it asked to remove.
+				if err == nil && info != nil {
+					if delErr := s.manager.Delete(req.Username, true); delErr != nil {
+						log.Printf("Async container creation for %s completed after its delete; removing it failed: %v", req.Username, delErr)
+					} else {
+						log.Printf("Async container creation for %s completed after its delete; removed the late box", req.Username)
+					}
+				}
+				return
+			}
 
 			if err != nil {
 				log.Printf("Async container creation failed for %s: %v", req.Username, err)
@@ -734,7 +775,7 @@ func (s *ContainerServer) ListContainers(ctx context.Context, req *pb.ListContai
 	pendingStates := map[string]pb.ContainerState{}
 	s.pendingMu.RLock()
 	for u, p := range s.pendingCreations {
-		if p.Done {
+		if !p.active() {
 			continue
 		}
 		st := pb.ContainerState_CONTAINER_STATE_CREATING
@@ -894,7 +935,7 @@ func (s *ContainerServer) GetContainer(ctx context.Context, req *pb.GetContainer
 	pending, hasPending := s.pendingCreations[req.Username]
 	s.pendingMu.RUnlock()
 
-	if hasPending && !pending.Done {
+	if pending.active() {
 		// Determine if creating or provisioning
 		state := pb.ContainerState_CONTAINER_STATE_CREATING
 		if pending.Provisioning {
@@ -984,6 +1025,17 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 
 	containerName := fmt.Sprintf("%s-container", req.Username)
 
+	// Claim any in-flight async creation before touching the instance (#1035).
+	// Provisioning takes minutes, so a delete very often lands mid-run; without
+	// this the goroutine reports the resulting "Instance not found" as
+	// "Async container creation failed", which reads in the journal exactly
+	// like a genuine create bug. Marking first (not after) matters: the
+	// misleading exec errors are produced by the delete itself.
+	cancelledCreate := s.cancelPendingCreation(req.Username)
+	if cancelledCreate {
+		log.Printf("Delete for %s arrived while its creation was still provisioning; cancelling the create", req.Username)
+	}
+
 	// Before deleting, deregister Guacamole connection if this is a Windows VM
 	s.deregisterGuacamoleConnection(req.Username)
 
@@ -992,6 +1044,7 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 		// owner refs; the backend keeps the namespace + data PVC (its
 		// delete-retains-data contract) and removes the gateway Pipe + Secrets.
 		if err := bb.Delete(ctx, box.BoxRef{Tenant: req.Username}, req.Force); err != nil {
+			s.uncancelPendingCreation(req.Username, cancelledCreate)
 			return nil, fmt.Errorf("failed to delete container: %w", err)
 		}
 		s.cascadeContainerCleanup(ctx, containerName, req.Username)
@@ -1015,9 +1068,11 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 				}
 				_, statusCode, fwdErr := peer.ForwardRequest("DELETE", fmt.Sprintf("/v1/containers/%s%s", req.Username, forceParam), authToken, nil)
 				if fwdErr != nil {
+					s.uncancelPendingCreation(req.Username, cancelledCreate)
 					return nil, fmt.Errorf("failed to delete container on peer %s: %w", peer.ID, fwdErr)
 				}
 				if statusCode >= 400 {
+					s.uncancelPendingCreation(req.Username, cancelledCreate)
 					return nil, fmt.Errorf("peer %s returned status %d for delete", peer.ID, statusCode)
 				}
 				return &pb.DeleteContainerResponse{
@@ -1026,6 +1081,7 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 				}, nil
 			}
 		}
+		s.uncancelPendingCreation(req.Username, cancelledCreate)
 		return nil, fmt.Errorf("failed to delete container: %w", err)
 	}
 
@@ -1050,6 +1106,38 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 		Message:       fmt.Sprintf("Container for user %s deleted successfully", req.Username),
 		ContainerName: containerName,
 	}, nil
+}
+
+// cancelPendingCreation flags an in-flight async creation for this user as
+// cancelled-by-delete and reports whether it found one (#1035). The creating
+// goroutine can't be aborted mid-step — it's deep inside an image launch or a
+// package install — so cancellation is about attribution, not interruption:
+// the goroutine reads the flag on completion and logs a cancellation instead
+// of a failure, and Get/List stop reporting CREATING for a box that is being
+// torn down.
+func (s *ContainerServer) cancelPendingCreation(username string) bool {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	pending, exists := s.pendingCreations[username]
+	if !exists || pending.Done || pending.Cancelled {
+		return false
+	}
+	pending.Cancelled = true
+	return true
+}
+
+// uncancelPendingCreation reverts a cancellation whose delete then failed, so
+// a creation that is still genuinely running keeps reporting its real state.
+// No-op unless this delete is the one that set the flag.
+func (s *ContainerServer) uncancelPendingCreation(username string, cancelled bool) {
+	if !cancelled {
+		return
+	}
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	if pending, exists := s.pendingCreations[username]; exists {
+		pending.Cancelled = false
+	}
 }
 
 // cascadeContainerCleanup removes the resources that DeleteContainer's

--- a/internal/server/container_server_cancel_create_test.go
+++ b/internal/server/container_server_cancel_create_test.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// newPendingServer builds the minimal ContainerServer needed to exercise the
+// pending-creation bookkeeping (#1035) — no manager, no backend.
+func newPendingServer(entries ...*PendingCreation) *ContainerServer {
+	s := &ContainerServer{pendingCreations: map[string]*PendingCreation{}}
+	for _, e := range entries {
+		s.pendingCreations[e.Username] = e
+	}
+	return s
+}
+
+// TestCancelPendingCreation pins the state machine a delete-during-create
+// relies on: only a genuinely in-flight creation can be claimed, and claiming
+// it is idempotent so a retried delete doesn't double-report.
+func TestCancelPendingCreation(t *testing.T) {
+	cases := []struct {
+		name    string
+		pending *PendingCreation
+		want    bool
+	}{
+		{"in flight is claimed", &PendingCreation{Username: "alice", StartedAt: time.Now()}, true},
+		{"provisioning is claimed", &PendingCreation{Username: "alice", Provisioning: true}, true},
+		{"finished is not claimed", &PendingCreation{Username: "alice", Done: true}, false},
+		{"already cancelled is not re-claimed", &PendingCreation{Username: "alice", Cancelled: true}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := newPendingServer(c.pending)
+			if got := s.cancelPendingCreation("alice"); got != c.want {
+				t.Fatalf("cancelPendingCreation = %v, want %v", got, c.want)
+			}
+		})
+	}
+
+	t.Run("no pending creation", func(t *testing.T) {
+		if newPendingServer().cancelPendingCreation("alice") {
+			t.Fatal("claimed a creation that does not exist")
+		}
+	})
+}
+
+// TestCancelledCreationIsNotActive: a cancelled-but-still-running creation
+// must drop out of the Get/List provisioning overlay immediately. Otherwise
+// the box the caller just deleted keeps reporting CREATING for the remaining
+// minutes of a provisioning run that no longer has an instance behind it.
+func TestCancelledCreationIsNotActive(t *testing.T) {
+	cases := []struct {
+		name    string
+		pending *PendingCreation
+		want    bool
+	}{
+		{"in flight", &PendingCreation{}, true},
+		{"cancelled", &PendingCreation{Cancelled: true}, false},
+		{"done", &PendingCreation{Done: true}, false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.pending.active(); got != c.want {
+				t.Fatalf("active() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestUncancelPendingCreation: a delete that fails must not leave the creation
+// flagged — the create is still genuinely running and must keep reporting its
+// real state. Only the delete that set the flag may clear it.
+func TestUncancelPendingCreation(t *testing.T) {
+	s := newPendingServer(&PendingCreation{Username: "alice"})
+	if !s.cancelPendingCreation("alice") {
+		t.Fatal("expected to claim the in-flight creation")
+	}
+	s.uncancelPendingCreation("alice", true)
+	if !s.pendingCreations["alice"].active() {
+		t.Fatal("a failed delete left the creation cancelled")
+	}
+
+	// A concurrent delete that never claimed the creation must not clear
+	// another delete's flag.
+	if !s.cancelPendingCreation("alice") {
+		t.Fatal("expected to re-claim after uncancel")
+	}
+	s.uncancelPendingCreation("alice", false)
+	if s.pendingCreations["alice"].active() {
+		t.Fatal("a non-claiming delete cleared someone else's cancellation")
+	}
+}
+
+// TestErrorStateStillReportedForRealFailures guards the fix's blast radius:
+// suppressing the cancellation noise must not suppress genuine create
+// failures, which GetContainer still surfaces as ERROR.
+func TestErrorStateStillReportedForRealFailures(t *testing.T) {
+	p := &PendingCreation{Username: "alice", Done: true, Error: errors.New("image pull failed")}
+	if p.active() {
+		t.Fatal("a finished creation must not be active")
+	}
+	if p.Cancelled {
+		t.Fatal("a genuine failure must not be flagged as cancelled")
+	}
+}

--- a/pkg/core/container/jump_server.go
+++ b/pkg/core/container/jump_server.go
@@ -124,11 +124,7 @@ func DeleteJumpServerAccount(username string, verbose bool) error {
 
 	// Delete user and home directory - wait for locks to clear
 	if err := waitForLocksAndRun(func() error {
-		cmd := exec.Command("userdel", "-r", username)
-		if output, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("failed to delete user %s: %w\nOutput: %s", username, err, output)
-		}
-		return nil
+		return runUserdel(username, verbose)
 	}, verbose); err != nil {
 		return err
 	}
@@ -138,6 +134,48 @@ func DeleteJumpServerAccount(username string, verbose bool) error {
 	}
 
 	return nil
+}
+
+// runUserdel deletes the account, tolerating the one failure mode that is
+// routine rather than exceptional: `userdel: user X is currently used by
+// process N` (exit 8), which happens whenever the caller still has an SSH
+// session open to the box they just deleted (#1035). The box itself is
+// already gone by the time delete-cascade runs, so any surviving session is
+// a dead shell with nothing behind it — killing it and retrying once is
+// strictly better than leaving an orphaned host account for the reaper.
+//
+// Every other userdel failure propagates unchanged.
+func runUserdel(username string, verbose bool) error {
+	// #nosec G204 -- username is gated by userExists + isValidUsername below
+	out, err := exec.Command("userdel", "-r", username).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	if !userdelBusy(out) || !isValidUsername(username) {
+		return fmt.Errorf("failed to delete user %s: %w\nOutput: %s", username, err, out)
+	}
+
+	if verbose {
+		fmt.Printf("  %s still has a live session; terminating it and retrying userdel\n", username)
+	}
+	// pkill exits 1 when nothing matched — a benign race (the session ended
+	// between the two calls), so the status is deliberately ignored.
+	// #nosec G204 -- username validated by isValidUsername above
+	_ = exec.Command("pkill", "-KILL", "-u", username).Run()
+	time.Sleep(500 * time.Millisecond)
+
+	// #nosec G204 -- username validated by isValidUsername above
+	if out, err := exec.Command("userdel", "-r", username).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to delete user %s after terminating its sessions: %w\nOutput: %s", username, err, out)
+	}
+	return nil
+}
+
+// userdelBusy reports whether userdel's output is the "user is currently used
+// by process" refusal. Matched on the message rather than the exit status
+// because shadow-utils reuses exit 8 for a couple of unrelated conditions.
+func userdelBusy(output []byte) bool {
+	return strings.Contains(string(output), "currently used by process")
 }
 
 // EnsureJumpServerAccount creates a host-level user with containarium-shell

--- a/pkg/core/container/jump_server_userdel_test.go
+++ b/pkg/core/container/jump_server_userdel_test.go
@@ -1,0 +1,27 @@
+package container
+
+import "testing"
+
+// TestUserdelBusy pins the one userdel failure the delete-cascade retries
+// instead of surfacing (#1035): a live SSH session to the box that was just
+// deleted. Everything else must stay a hard error — silently swallowing, say,
+// a permission failure would leave an orphaned account with no log trail.
+func TestUserdelBusy(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"live session", "userdel: user alice is currently used by process 12345\n", true},
+		{"permission denied", "userdel: Permission denied.\n", false},
+		{"missing user", "userdel: user 'alice' does not exist\n", false},
+		{"empty", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := userdelBusy([]byte(c.output)); got != c.want {
+				t.Fatalf("userdelBusy(%q) = %v, want %v", c.output, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1035.

## Problem

Async provisioning runs for minutes (image launch → package install → podman enable), so a `DeleteContainer` very often lands mid-run. It tore the instance out from under the creating goroutine, which then logged:

```
transient exec error … Failed to retrieve PID of executing child process   (×N)
Async container creation failed … Instance not found
```

Reading the journal later, that is **indistinguishable from a genuine create failure**. During one incident investigation the standard probe loop several agents used — `create` → SSH immediately (fails, box is still CREATING) → conclude "broken" → `delete` as cleanup — had its own cleanup delete write a fresh "Async creation failed" into the journal, which the next investigator read as another independent confirmation. At least eight "confirmations" were manufactured this way, surviving the deployment of every real fix.

## Fix

`DeleteContainer` claims the pending creation **before** touching the instance — marking afterwards would be too late, since the misleading exec errors are produced by the delete itself. The goroutine can't be aborted mid-step (it's deep inside an image launch or a package install), so cancellation is about attribution, not interruption:

- the goroutine logs one unambiguous `cancelled by delete request` line instead of a failure, and drops its tracking entry rather than parking an `ERROR`;
- `GetContainer` / `ListContainers` stop reporting `CREATING`/`PROVISIONING` for a box being torn down;
- if the delete lost the race (the instance didn't exist yet, so it deleted nothing) and the creation finished anyway, the late box is reaped — otherwise the delete silently leaves behind the container it was asked to remove;
- a delete that then **fails** reverts the flag, so a still-running creation keeps reporting its real state.

Genuine create failures are untouched and still surface as `ERROR`.

Also addresses ask 3: the delete-cascade's host-user cleanup tolerates a live session. `userdel: user X is currently used by process N` (typically the caller's own SSH session) left an orphaned account until the reaper's next tick; the box is already gone at that point, so the surviving session is a dead shell — terminate it and retry `userdel` once. Matched on the message rather than exit 8, which shadow-utils reuses for unrelated conditions; every other `userdel` failure propagates unchanged.

## Tests

- `TestCancelPendingCreation` — only a genuinely in-flight creation is claimable; claiming is idempotent.
- `TestCancelledCreationIsNotActive` — a cancelled creation drops out of the Get/List overlay immediately.
- `TestUncancelPendingCreation` — a failed delete reverts; a non-claiming delete can't clear someone else's flag.
- `TestErrorStateStillReportedForRealFailures` — blast-radius guard: real failures aren't suppressed.
- `TestUserdelBusy` — only the busy-user message is retried; permission/missing-user stay hard errors.

`go build ./... && go vet` clean; `internal/server` and `pkg/core/container` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)