### PR TITLE
fix(cpu): emit a hard CFS quota for limits.cpu.allowance, not a soft share (#1034)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an orphaned account until the reaper's next tick; the box is already
   gone at that point, so the remaining session is terminated and
   `userdel` retried once. Every other `userdel` failure is unchanged.
+- **CPU limits are now a hard CFS quota, not a soft scheduler share**
+  (#1034, completing #1029). `limits.cpu.allowance` was emitted as a
+  percentage (`400%`), which Incus applies only under contention — the
+  cgroup's `cpu.max` stayed `max`, so a single container still burst to
+  the whole host whenever its neighbours were idle. Containarium now
+  emits the time-slice form (`400ms/100ms`), the documented hard-quota
+  syntax, giving a request the bounded entitlement the platform bills
+  and schedules against and matching Kubernetes millicpu semantics.
+  Existing containers keep their percentage allowance until resized;
+  reading a CPU request back understands both forms.
 
 ## [0.57.0] - 2026-07-20
 

--- a/pkg/core/incus/cpu_limits.go
+++ b/pkg/core/incus/cpu_limits.go
@@ -10,8 +10,8 @@ import (
 // cpuLimit holds the Incus instance-config representation of a CPU request.
 //
 //   - Count     → set as `limits.cpu` (whole-core count "2" or CPU set "0-3").
-//   - Allowance → set as `limits.cpu.allowance` (share of those cores
-//     expressed as a percentage, e.g. "25%", "800%").
+//   - Allowance → set as `limits.cpu.allowance`, always in the time-slice form
+//     ("25ms/100ms", "800ms/100ms").
 //
 // Incus's `limits.cpu` key only accepts an integer core count or a set/range;
 // fractional CPU must go through `limits.cpu.allowance`. Passing millicpu
@@ -21,13 +21,28 @@ import (
 // Both whole-core and fractional requests set BOTH fields: Count is the
 // visible cpuset (so LXCFS can derive an honest /proc/cpuinfo processor
 // count — allowance-only containers otherwise report the host's full core
-// count, see #1019/#1021) and Allowance is the actual CFS-bandwidth throttle
-// scoped to that visible count. Without Allowance, `limits.cpu` only bounds
-// *which* cores are visible, not how much CPU *time* they may consume — a
-// whole-core request of "8" on an 8-core host was otherwise unthrottled
-// (see #1029). CPU-set / pinning notation ("0-3") is the one exception: it
-// sets only Count, since a meaningful percentage-of-visible-cores allowance
-// can't be derived from an arbitrary core-index set.
+// count, see #1019/#1021) and Allowance is the CFS-bandwidth quota scoped to
+// that visible count. Without Allowance, `limits.cpu` only bounds *which*
+// cores are visible, not how much CPU *time* they may consume — a whole-core
+// request of "8" on an 8-core host was otherwise unthrottled (see #1029).
+// CPU-set / pinning notation ("0-3") is the one exception: it sets only
+// Count, since a meaningful allowance can't be derived from an arbitrary
+// core-index set.
+//
+// The time-slice form is deliberate (#1034). Incus reads the two allowance
+// syntaxes differently:
+//
+//	400%          → soft share, applied only under contention; cpu.max stays "max"
+//	400ms/100ms   → hard CFS quota; cpu.max reads "400000 100000"
+//
+// A soft share is work-conserving and utilization-friendly, but it does not
+// give a tenant a *bounded* entitlement: with idle neighbours a single
+// container still bursts to the whole host, which is exactly the shape that
+// saturated a backend host and wedged `incus exec` for every other tenant in
+// #1029. We bill and schedule against the nominal request, and the request
+// syntax is Kubernetes millicpu — whose `limits.cpu` is likewise a hard CFS
+// quota — so a hard ceiling is the semantic that matches both the contract
+// and the caller's expectation.
 type cpuLimit struct {
 	Count     string
 	Allowance string
@@ -37,16 +52,16 @@ type cpuLimit struct {
 // config key(s) it maps to.
 //
 // Accepted inputs:
-//   - whole-core count:    "1", "4"           → limits.cpu "1"/"4" + limits.cpu.allowance "100%"/"400%"
+//   - whole-core count:    "1", "4"           → limits.cpu "1"/"4" + limits.cpu.allowance "100ms/100ms"/"400ms/100ms"
 //   - CPU set / pinning:   "0-3", "0,2-4"     → limits.cpu (passed through, no allowance)
-//   - Kubernetes millicpu: "250m" (0.25 core) → limits.cpu "1" + limits.cpu.allowance "25%"
-//   - decimal cores:       "0.25", "1.5"      → limits.cpu "1"/"2" + limits.cpu.allowance "25%"/"150%"
+//   - Kubernetes millicpu: "250m" (0.25 core) → limits.cpu "1" + limits.cpu.allowance "25ms/100ms"
+//   - decimal cores:       "0.25", "1.5"      → limits.cpu "1"/"2" + limits.cpu.allowance "25ms/100ms"/"150ms/100ms"
 //
 // Every numeric request (whole or fractional) sets both limits.cpu
 // (ceil(cores), so LXCFS can report an honest /proc/cpuinfo processor count)
-// and limits.cpu.allowance (the actual CFS-bandwidth throttle, cores*100%) —
-// see the cpuLimit doc comment and #1029. Only CPU-set/pinning notation sets
-// Count alone. An empty request returns a zero cpuLimit (no keys to set).
+// and limits.cpu.allowance (the hard CFS quota) — see the cpuLimit doc
+// comment, #1029 and #1034. Only CPU-set/pinning notation sets Count alone.
+// An empty request returns a zero cpuLimit (no keys to set).
 func parseCPULimit(cpu string) (cpuLimit, error) {
 	cpu = strings.TrimSpace(cpu)
 	if cpu == "" {
@@ -82,44 +97,64 @@ func parseCPULimit(cpu string) (cpuLimit, error) {
 	}
 
 	// Whole-core requests map to an integer limits.cpu count, plus a matching
-	// allowance so the visible cores are also throttle-bounded (#1029) — a
-	// bare limits.cpu on an N-core host otherwise leaves N cores fully
-	// unthrottled. 4 cores → limits.cpu="4", limits.cpu.allowance="400%".
+	// quota so the visible cores are also time-bounded (#1029) — a bare
+	// limits.cpu on an N-core host otherwise leaves N cores fully
+	// unthrottled. 4 cores → limits.cpu="4", allowance="400ms/100ms".
 	if cores == float64(int64(cores)) {
-		count := int64(cores)
-		pct := cores * 100
 		return cpuLimit{
-			Count:     strconv.FormatInt(count, 10),
-			Allowance: strconv.FormatFloat(pct, 'f', -1, 64) + "%",
+			Count:     strconv.FormatInt(int64(cores), 10),
+			Allowance: cpuQuota(cores),
 		}, nil
 	}
 
-	// Fractional requests become a percentage allowance, plus a whole-core
-	// ceiling count so LXCFS can report an honest /proc/cpuinfo processor
-	// count instead of the host's full core count (#1019/#1021).
-	// 0.25 core → limits.cpu="1", limits.cpu.allowance="25%".
-	pct := cores * 100
+	// Fractional requests get the same quota, plus a whole-core ceiling count
+	// so LXCFS can report an honest /proc/cpuinfo processor count instead of
+	// the host's full core count (#1019/#1021).
+	// 0.25 core → limits.cpu="1", allowance="25ms/100ms".
 	return cpuLimit{
 		Count:     strconv.FormatInt(int64(math.Ceil(cores)), 10),
-		Allowance: strconv.FormatFloat(pct, 'f', -1, 64) + "%",
+		Allowance: cpuQuota(cores),
 	}, nil
+}
+
+// cpuQuotaPeriodMs is the CFS period the quota is expressed against. 100ms is
+// the kernel default and what Incus's own documentation uses, so an operator
+// reading `limits.cpu.allowance` sees the same shape they'd type by hand.
+const cpuQuotaPeriodMs = 100
+
+// cpuQuota renders a core count as Incus's hard-quota allowance form.
+// Granularity is 1ms of quota == 1% of a core; a request finer than that
+// (below ~10m) rounds up to the 1ms floor rather than to zero, since a zero
+// quota would be rejected by Incus and a container that may never run is
+// never what the caller meant.
+func cpuQuota(cores float64) string {
+	ms := int64(math.Round(cores * cpuQuotaPeriodMs))
+	if ms < 1 {
+		ms = 1
+	}
+	return fmt.Sprintf("%dms/%dms", ms, cpuQuotaPeriodMs)
 }
 
 // formatCPULimitFromConfig renders the CPU request stored in an Incus instance
 // config back into the Containarium representation, for display in container
 // info. `limits.cpu.allowance` is checked first and, if present, converted
-// back to Kubernetes millicpu ("25%" → "250m") — requests set both
+// back to Kubernetes millicpu ("25ms/100ms" → "250m") — requests set both
 // `limits.cpu` (a whole-core ceiling, for LXCFS) and `limits.cpu.allowance`
-// (the actual throttle), and allowance is the precise value; falling back to
+// (the actual quota), and allowance is the precise value; falling back to
 // `limits.cpu` first would display a "250m" request back as "1", losing the
-// fractional precision. An allowance that's an exact multiple of 100% (a
-// whole-core request, see #1029) formats back as the plain core count
-// ("400%" → "4") rather than millicpu ("4000m") — the two are numerically
-// equivalent, but the plain count matches what the caller originally typed.
+// fractional precision. An allowance that resolves to a whole number of cores
+// formats back as the plain core count ("400ms/100ms" → "4") rather than
+// millicpu ("4000m") — numerically equivalent, but the plain count matches
+// what the caller originally typed.
+//
+// Both allowance syntaxes are accepted on the way back: the time-slice form
+// this package now writes (#1034) and the percentage form written before it,
+// which containers created by an older daemon still carry.
+//
 // `limits.cpu` is used verbatim only when no allowance is set (a CPU
-// set/range, or a pre-#1029 whole-core config with no allowance key yet). A
-// non-percentage (time-slice) allowance has no millicpu equivalent and is
-// returned as-is. Returns "" when neither key is set.
+// set/range, or a pre-#1029 whole-core config with no allowance key yet). An
+// allowance in neither recognised form is returned as-is. Returns "" when
+// neither key is set.
 func formatCPULimitFromConfig(config map[string]string) string {
 	allowance, ok := config["limits.cpu.allowance"]
 	if !ok || allowance == "" {
@@ -128,16 +163,36 @@ func formatCPULimitFromConfig(config map[string]string) string {
 		}
 		return ""
 	}
-	if !strings.HasSuffix(allowance, "%") {
+	cores, ok := parseAllowanceCores(allowance)
+	if !ok {
 		return allowance
 	}
-	pct, err := strconv.ParseFloat(strings.TrimSuffix(allowance, "%"), 64)
-	if err != nil {
-		return allowance
-	}
-	if cores := pct / 100; cores == float64(int64(cores)) {
+	if cores == float64(int64(cores)) {
 		return strconv.FormatInt(int64(cores), 10)
 	}
-	milli := int64(pct * 10) // 25% → 250m
+	milli := int64(math.Round(cores * 1000)) // 0.25 core → 250m
 	return strconv.FormatInt(milli, 10) + "m"
+}
+
+// parseAllowanceCores resolves a `limits.cpu.allowance` value back to a core
+// count: "400ms/100ms" → 4, "25%" → 0.25. Reports false for anything it
+// doesn't recognise (including a zero period, which would divide by zero).
+func parseAllowanceCores(allowance string) (float64, bool) {
+	if pctStr, ok := strings.CutSuffix(allowance, "%"); ok {
+		pct, err := strconv.ParseFloat(pctStr, 64)
+		if err != nil {
+			return 0, false
+		}
+		return pct / 100, true
+	}
+	quotaStr, periodStr, ok := strings.Cut(allowance, "/")
+	if !ok {
+		return 0, false
+	}
+	quota, qerr := strconv.ParseFloat(strings.TrimSuffix(quotaStr, "ms"), 64)
+	period, perr := strconv.ParseFloat(strings.TrimSuffix(periodStr, "ms"), 64)
+	if qerr != nil || perr != nil || period == 0 {
+		return 0, false
+	}
+	return quota / period, true
 }

--- a/pkg/core/incus/cpu_limits_test.go
+++ b/pkg/core/incus/cpu_limits_test.go
@@ -1,6 +1,9 @@
 package incus
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseCPULimit(t *testing.T) {
 	tests := []struct {
@@ -11,20 +14,20 @@ func TestParseCPULimit(t *testing.T) {
 		wantErr       bool
 	}{
 		{name: "empty", cpu: "", wantCount: "", wantAllowance: ""},
-		{name: "single core", cpu: "1", wantCount: "1", wantAllowance: "100%"},
-		{name: "multiple cores", cpu: "4", wantCount: "4", wantAllowance: "400%"},
-		{name: "whole host", cpu: "8", wantCount: "8", wantAllowance: "800%"},
+		{name: "single core", cpu: "1", wantCount: "1", wantAllowance: "100ms/100ms"},
+		{name: "multiple cores", cpu: "4", wantCount: "4", wantAllowance: "400ms/100ms"},
+		{name: "whole host", cpu: "8", wantCount: "8", wantAllowance: "800ms/100ms"},
 		{name: "cpu range", cpu: "0-3", wantCount: "0-3"},
 		{name: "cpu set", cpu: "0,2-4", wantCount: "0,2-4"},
-		{name: "millicpu quarter core", cpu: "250m", wantCount: "1", wantAllowance: "25%"},
-		{name: "millicpu half core", cpu: "500m", wantCount: "1", wantAllowance: "50%"},
-		{name: "millicpu whole core", cpu: "1000m", wantCount: "1", wantAllowance: "100%"},
-		{name: "millicpu one and a half", cpu: "1500m", wantCount: "2", wantAllowance: "150%"},
-		{name: "decimal quarter core", cpu: "0.25", wantCount: "1", wantAllowance: "25%"},
-		{name: "decimal whole core", cpu: "2.0", wantCount: "2", wantAllowance: "200%"},
-		{name: "decimal one and a half", cpu: "1.5", wantCount: "2", wantAllowance: "150%"},
-		{name: "decimal two and a half", cpu: "2.5", wantCount: "3", wantAllowance: "250%"},
-		{name: "whitespace trimmed", cpu: "  250m  ", wantCount: "1", wantAllowance: "25%"},
+		{name: "millicpu quarter core", cpu: "250m", wantCount: "1", wantAllowance: "25ms/100ms"},
+		{name: "millicpu half core", cpu: "500m", wantCount: "1", wantAllowance: "50ms/100ms"},
+		{name: "millicpu whole core", cpu: "1000m", wantCount: "1", wantAllowance: "100ms/100ms"},
+		{name: "millicpu one and a half", cpu: "1500m", wantCount: "2", wantAllowance: "150ms/100ms"},
+		{name: "decimal quarter core", cpu: "0.25", wantCount: "1", wantAllowance: "25ms/100ms"},
+		{name: "decimal whole core", cpu: "2.0", wantCount: "2", wantAllowance: "200ms/100ms"},
+		{name: "decimal one and a half", cpu: "1.5", wantCount: "2", wantAllowance: "150ms/100ms"},
+		{name: "decimal two and a half", cpu: "2.5", wantCount: "3", wantAllowance: "250ms/100ms"},
+		{name: "whitespace trimmed", cpu: "  250m  ", wantCount: "1", wantAllowance: "25ms/100ms"},
 		{name: "invalid millicpu", cpu: "abcm", wantErr: true},
 		{name: "invalid decimal", cpu: "xyz", wantErr: true},
 		{name: "negative", cpu: "-1.5", wantErr: true},
@@ -54,6 +57,40 @@ func TestParseCPULimit(t *testing.T) {
 	}
 }
 
+// TestCPUAllowanceIsAHardQuota is the point of #1034 and the one property
+// that must not silently regress: Incus reads a PERCENTAGE allowance as a
+// soft scheduler share (cpu.max stays "max", so an idle host lets one tenant
+// take all of it) and the ms/ms form as a hard CFS quota. Emitting a
+// percentage would look correct in `incus config show` while enforcing
+// nothing — exactly the failure #1030 shipped with.
+func TestCPUAllowanceIsAHardQuota(t *testing.T) {
+	for _, in := range []string{"1", "4", "8", "250m", "1500m", "0.25", "2.5"} {
+		cl, err := parseCPULimit(in)
+		if err != nil {
+			t.Fatalf("parseCPULimit(%q): %v", in, err)
+		}
+		if strings.HasSuffix(cl.Allowance, "%") {
+			t.Errorf("parseCPULimit(%q).Allowance = %q — a percentage is a SOFT share and does not throttle", in, cl.Allowance)
+		}
+		if !strings.HasSuffix(cl.Allowance, "ms/100ms") {
+			t.Errorf("parseCPULimit(%q).Allowance = %q, want the hard-quota form <N>ms/100ms", in, cl.Allowance)
+		}
+	}
+}
+
+// TestCPUQuotaFloor: a request finer than the 1ms quota granularity must
+// round up to 1ms, never to 0 — Incus rejects a zero quota, and a container
+// that may never be scheduled is never what the caller asked for.
+func TestCPUQuotaFloor(t *testing.T) {
+	cl, err := parseCPULimit("1m") // 0.001 core → 0.1ms of quota
+	if err != nil {
+		t.Fatalf("parseCPULimit(\"1m\"): %v", err)
+	}
+	if cl.Allowance != "1ms/100ms" {
+		t.Fatalf("parseCPULimit(\"1m\").Allowance = %q, want %q", cl.Allowance, "1ms/100ms")
+	}
+}
+
 func TestParseCPULimitNegativeMillicpu(t *testing.T) {
 	if _, err := parseCPULimit("-250m"); err == nil {
 		t.Fatal("parseCPULimit(\"-250m\") = nil error, want error")
@@ -69,27 +106,41 @@ func TestFormatCPULimitFromConfig(t *testing.T) {
 		{name: "no limits", config: map[string]string{}, want: ""},
 		{name: "whole core, no allowance (pre-#1029 config)", config: map[string]string{"limits.cpu": "4"}, want: "4"},
 		{name: "cpu set", config: map[string]string{"limits.cpu": "0-3"}, want: "0-3"},
-		{name: "allowance percentage", config: map[string]string{"limits.cpu.allowance": "25%"}, want: "250m"},
-		{name: "allowance half", config: map[string]string{"limits.cpu.allowance": "50%"}, want: "500m"},
-		{name: "allowance over one core", config: map[string]string{"limits.cpu.allowance": "150%"}, want: "1500m"},
-		{name: "time slice allowance passthrough", config: map[string]string{"limits.cpu.allowance": "25ms/100ms"}, want: "25ms/100ms"},
+		{name: "quota quarter core", config: map[string]string{"limits.cpu.allowance": "25ms/100ms"}, want: "250m"},
+		{name: "quota half core", config: map[string]string{"limits.cpu.allowance": "50ms/100ms"}, want: "500m"},
+		{name: "quota over one core", config: map[string]string{"limits.cpu.allowance": "150ms/100ms"}, want: "1500m"},
 		{
 			name:   "allowance wins over limits.cpu (fractional request sets both)",
-			config: map[string]string{"limits.cpu": "1", "limits.cpu.allowance": "25%"},
+			config: map[string]string{"limits.cpu": "1", "limits.cpu.allowance": "25ms/100ms"},
 			want:   "250m",
 		},
-		{name: "empty limits.cpu falls through to allowance", config: map[string]string{"limits.cpu": "", "limits.cpu.allowance": "25%"}, want: "250m"},
+		{name: "empty limits.cpu falls through to allowance", config: map[string]string{"limits.cpu": "", "limits.cpu.allowance": "25ms/100ms"}, want: "250m"},
 		{name: "empty allowance falls through to limits.cpu", config: map[string]string{"limits.cpu": "4", "limits.cpu.allowance": ""}, want: "4"},
 		{
-			name:   "whole-core allowance formats as plain core count, not millicpu (#1029)",
-			config: map[string]string{"limits.cpu": "8", "limits.cpu.allowance": "800%"},
+			name:   "whole-core quota formats as plain core count, not millicpu (#1029)",
+			config: map[string]string{"limits.cpu": "8", "limits.cpu.allowance": "800ms/100ms"},
 			want:   "8",
 		},
 		{
-			name:   "single-core allowance formats as plain core count",
-			config: map[string]string{"limits.cpu": "1", "limits.cpu.allowance": "100%"},
+			name:   "single-core quota formats as plain core count",
+			config: map[string]string{"limits.cpu": "1", "limits.cpu.allowance": "100ms/100ms"},
 			want:   "1",
 		},
+
+		// Containers created before #1034 carry the percentage form; a daemon
+		// upgrade must keep displaying their request correctly rather than
+		// dumping the raw Incus value at the caller.
+		{name: "legacy percentage fractional", config: map[string]string{"limits.cpu.allowance": "25%"}, want: "250m"},
+		{name: "legacy percentage whole core", config: map[string]string{"limits.cpu": "4", "limits.cpu.allowance": "400%"}, want: "4"},
+
+		// An operator-set allowance against a non-default period is still a
+		// valid quota and resolves to its true core count.
+		{name: "non-default period", config: map[string]string{"limits.cpu.allowance": "100ms/200ms"}, want: "500m"},
+
+		// Unparseable allowances pass through untouched — better to show the
+		// raw Incus value than to invent a number.
+		{name: "garbage allowance passthrough", config: map[string]string{"limits.cpu.allowance": "sometimes"}, want: "sometimes"},
+		{name: "zero period passthrough", config: map[string]string{"limits.cpu.allowance": "100ms/0ms"}, want: "100ms/0ms"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #1034.

## Decision

The issue asked for a deliberate choice between a soft share and a hard ceiling. **Hard ceiling.**

Incus reads the two `limits.cpu.allowance` syntaxes differently:

| value | semantics | `cpu.max` |
| --- | --- | --- |
| `400%` | soft share, applied only under contention | `max 100000` (unthrottled) |
| `400ms/100ms` | hard CFS quota | `400000 100000` |

We were emitting the percentage form, so #1029's stated goal — a request should be CFS-throttled to its nominal entitlement — was only half met. Fair-share weighting under contention is real and useful, but it gives no *bounded* entitlement: with idle neighbours a single tenant still bursts to the whole host, which is exactly the shape that saturated a backend host and wedged `incus exec` for every other tenant. Inside the container `cpu.max` read `max` either way, so nothing looked limited.

Why hard: we bill and schedule against the nominal request, and the request syntax is Kubernetes millicpu — whose `limits.cpu` is likewise a hard CFS quota. Matching that is what a caller typing `250m` expects. The rationale now lives in `cpu_limits.go`'s doc comment rather than only in an issue.

## Changes

- `parseCPULimit` emits `<N>ms/100ms` for every numeric request (whole-core and fractional). The 100ms period is the kernel default and what Incus's own docs use, so an operator reading the key sees the shape they'd type by hand.
- Granularity is 1ms of quota == 1% of a core; a finer request (below ~10m) rounds **up** to the 1ms floor rather than to zero — Incus rejects a zero quota, and a container that may never be scheduled is never what was asked for.
- `formatCPULimitFromConfig` accepts both forms on read-back, including a non-default period. Containers created before this change still carry a percentage and must keep displaying their request correctly across a daemon upgrade; they move to a quota on their next resize.
- CPU-set / pinning notation (`0-3`) is unchanged — still `limits.cpu` only.

## Note on the issue's framing

The issue described #1030 as setting `cores*100%` for *whole-core* requests. That is accurate on `main` (#1030 extended the allowance to whole cores precisely so an 8-core request on an 8-core host wasn't unthrottled). The `cores == host cores` no-op observation also stands for the share form — and is resolved here, since `800ms/100ms` is a genuine cap even when it equals the host.

Placement-level capacity accounting (#1029 direction 2, the ~14x overcommit) remains open and is not addressed here.

## Tests

- `TestCPUAllowanceIsAHardQuota` — the regression guard: no request may emit a `%` allowance.
- `TestCPUQuotaFloor` — sub-granularity requests round up to 1ms, never 0.
- `TestParseCPULimit` / `TestCPULimitRoundTrip` updated to the quota form.
- `TestFormatCPULimitFromConfig` gains legacy-percentage, non-default-period, garbage, and zero-period cases.

`go build ./...` clean; `pkg/core/incus` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)