### PR TITLE
chore(release): cut v0.58.0 — hard CPU quota + delete-cancels-create (#1034, #1035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.58.0] - 2026-07-20
+
 ### Fixed
 
 - **A delete racing an in-flight async create no longer manufactures a

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.57.0"
+	Version = "0.58.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Two-file release cut per `docs/RELEASE-PROCESS.md`.

## Headline

**Behavior change — read before upgrading.** CPU limits are now a hard CFS quota rather than a soft scheduler share (#1034). `limits.cpu.allowance` was emitted as a percentage, which Incus applies only under contention: the cgroup's `cpu.max` stayed `max`, so a container burst past its nominal request whenever its neighbours were idle. It is now capped at that request. Existing containers keep their percentage allowance until they are next created or resized.

This is why the cut is a minor rather than a patch — both scoped changes are `fix` commits, but a runtime-behavior change for every tenant shouldn't hide in a patch bump.

Also in this release: a delete racing an in-flight async create is treated as a cancellation instead of manufacturing a fake "Async creation failed" in the journal, and delete-cascade tolerates a live SSH session when removing the host user (#1035).

## Scope

- [x] #1053 — fix(cpu): emit a hard CFS quota for `limits.cpu.allowance`, not a soft share (#1034)
- [x] #1052 — fix(create): treat a delete racing an in-flight async create as a cancellation (#1035)

## Checklist

- [x] `CHANGELOG.md`: `[Unreleased]` → `[0.58.0] - 2026-07-20`, empty Unreleased heading kept
- [x] `pkg/version/version.go`: `Version = "0.58.0"`
- [ ] CI green, merge
- [ ] Tag `v0.58.0` on `main` + push
- [ ] **Verify published artifacts** — all 10 binaries + `SHA256SUMS.txt` present, and `containarium version` on a fresh download reports the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)