### PR TITLE
feat(placement): opt-in CPU capacity admission on create (#1029 direction 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in CPU capacity admission** (#1029). A daemon can now refuse a
+  container create that would push its host's committed cores past
+  `physical_cores × --cpu-overcommit-factor`, closing the gap where a
+  host could accept far more committed CPU than it physically has and
+  let one tenant starve its co-located neighbours. Off by default
+  (`factor = 0`); `--cpu-overcommit-enforce` gates whether an enabled
+  check rejects (gRPC `ResourceExhausted`) or is advisory (logs what it
+  would reject, for observe-first rollout). The gate is per-host and
+  composes with pools — a peer-routed create is admitted by the target
+  peer's own daemon — excludes core-infra and the tenant being
+  recreated, and fails open if host capacity can't be read. Env
+  fallbacks `CONTAINARIUM_CPU_OVERCOMMIT_FACTOR` /
+  `CONTAINARIUM_CPU_OVERCOMMIT_ENFORCE`; see `docs/CPU-CAPACITY-ADMISSION.md`.
+
 ## [0.58.0] - 2026-07-20
 
 ### Fixed

--- a/docs/CPU-CAPACITY-ADMISSION.md
+++ b/docs/CPU-CAPACITY-ADMISSION.md
@@ -1,0 +1,82 @@
+# CPU capacity admission (#1029)
+
+By default a Containarium daemon places every container a caller asks for,
+regardless of how much CPU is already committed on the host. `limits.cpu` bounds
+*which* cores a container sees, and (since #1034) `limits.cpu.allowance` gives it
+a hard CFS quota — but nothing stops an operator from committing far more cores
+than the host physically has. On a shared multi-tenant host that overcommit is
+how one busy tenant degrades every co-located one.
+
+This is an **opt-in** admission gate: when enabled, a create is refused (or, in
+advisory mode, logged) if it would push the host's committed cores past
+`physical_cores × factor`.
+
+## Why opt-in, and why a *factor* rather than a hard 1×
+
+CPU is compressible — modest overcommit is normal and desirable, because tenants
+rarely peg their full allocation simultaneously. A hard 1× (no overcommit) would
+strand capacity. The factor lets each operator choose their own oversubscription
+ratio against their own workload mix.
+
+It is off by default because existing fleets are frequently already well past 1×
+(an 8-core host holding several `limits.cpu=8` tenants sits near ~14×); turning
+on strict enforcement globally would make those hosts refuse every new create
+until they were rebalanced. Enabling is a deliberate operator step.
+
+## Configuration
+
+Two daemon flags (each with an environment-variable fallback):
+
+| Flag | Env | Default | Meaning |
+| --- | --- | --- | --- |
+| `--cpu-overcommit-factor` | `CONTAINARIUM_CPU_OVERCOMMIT_FACTOR` | `0` | Ceiling multiple of physical cores. `0` (or negative) disables the gate. |
+| `--cpu-overcommit-enforce` | `CONTAINARIUM_CPU_OVERCOMMIT_ENFORCE` | `false` | When the factor is set, actually reject over-ceiling creates. When `false`, the gate is advisory (logs what it would reject). |
+
+Example — allow up to 4× overcommit, enforced:
+
+```
+containarium daemon --cpu-overcommit-factor 4 --cpu-overcommit-enforce
+```
+
+## Recommended rollout (advisory → enforce)
+
+Enforcing blind on a live fleet risks surprising rejections. Roll out the way
+the network-policy engine was rolled out — observe first:
+
+1. **Observe.** Set `--cpu-overcommit-factor` to your candidate ratio and leave
+   `--cpu-overcommit-enforce` off. The daemon logs one
+   `[cpu-admission] ADVISORY (not enforced): would reject …` line per create it
+   *would* have blocked, with the host's committed/requested/ceiling numbers.
+2. **Calibrate.** Watch those logs across your real workload. If legitimate
+   creates would be rejected, raise the factor (or rebalance hosts) until the
+   advisory line only fires on genuine overcommit.
+3. **Enforce.** Add `--cpu-overcommit-enforce`. Over-ceiling creates now fail
+   with gRPC `ResourceExhausted` and a message naming the numbers; the caller
+   can retry on a less-loaded backend/pool.
+
+## Semantics and scope
+
+- **Per-host, and it composes with pools.** The gate runs on the daemon that
+  actually creates the box. A pool/peer-routed create is forwarded to the target
+  peer's own daemon, which runs *its* gate against *its* host — so no
+  cross-host capacity view is needed, and each host enforces its own ceiling.
+- **What counts as committed.** The sum of every tenant container's committed
+  cores (`CommittedCores` over its `limits.cpu` / `limits.cpu.allowance`). Two
+  exclusions: **core-infra** containers (platform Postgres/Caddy — not tenant
+  workload) and the **tenant being recreated** (so a resize-by-recreate doesn't
+  count its own outgoing container against its replacement).
+- **Fail-open.** If the host's physical core count or its container list can't
+  be read, the create proceeds. A capacity check must never be the reason a box
+  can't be made.
+- **Runtime.** Applies to the LXC/Incus substrate. On the k8s runtime the Incus
+  resource read fails and the gate no-ops (Kubernetes does its own admission).
+
+## Not covered here (follow-ups)
+
+- **Capacity-aware placement ranking.** Today pool placement picks the first
+  healthy peer; a natural extension is to prefer the *least-committed* peer so
+  overcommit is spread rather than merely refused at the edge (#1029 direction 2,
+  "deprioritize" variant).
+- **A read surface for current commitment.** The advisory logs expose the
+  numbers; a first-class report (extending `GetSystemInfo` with committed cores)
+  would let operators see a host's overcommit without grepping logs.

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -31,35 +31,37 @@ import (
 )
 
 var (
-	daemonAddress      string
-	daemonPort         int
-	daemonHTTPPort     int
-	enableMTLS         bool
-	enableREST         bool
-	daemonCertsDir     string
-	jwtSecret          string
-	jwtSecretFile      string
-	swaggerDir         string
-	networkSubnet      string
-	skipInfraInit      bool
-	standaloneMode     bool
-	enableAppHosting   bool
-	postgresConnString string
-	baseDomain         string
-	caddyAdminURL      string
-	caddyCertDir       string
-	alertWebhookURL    string
-	alertWebhookSecret string
-	sentinelURL        string
-	sshHost            string
-	peerAddrs          []string
-	localBackendID     string
-	pool               string
-	region             string
-	publicHostname     string
-	publicAliases      []string
-	publicBaseDomains  []string
-	publicPort         int
+	daemonAddress        string
+	daemonPort           int
+	daemonHTTPPort       int
+	enableMTLS           bool
+	enableREST           bool
+	daemonCertsDir       string
+	jwtSecret            string
+	jwtSecretFile        string
+	swaggerDir           string
+	networkSubnet        string
+	skipInfraInit        bool
+	standaloneMode       bool
+	enableAppHosting     bool
+	postgresConnString   string
+	baseDomain           string
+	caddyAdminURL        string
+	caddyCertDir         string
+	alertWebhookURL      string
+	alertWebhookSecret   string
+	sentinelURL          string
+	sshHost              string
+	peerAddrs            []string
+	localBackendID       string
+	pool                 string
+	region               string
+	cpuOvercommitFactor  float64
+	cpuOvercommitEnforce bool
+	publicHostname       string
+	publicAliases        []string
+	publicBaseDomains    []string
+	publicPort           int
 
 	proxyProtocol        bool
 	proxyProtocolTrusted []string
@@ -160,6 +162,29 @@ func init() {
 
 	// Runtime selection
 	daemonCmd.Flags().StringVar(&daemonRuntime, "runtime", "", `Box backend: "lxc" (default) or "k8s". Falls back to CONTAINARIUM_RUNTIME env when unset.`)
+	daemonCmd.Flags().Float64Var(&cpuOvercommitFactor, "cpu-overcommit-factor", envFloat("CONTAINARIUM_CPU_OVERCOMMIT_FACTOR", 0), "Max CPU overcommit: refuse a create when committed cores would exceed physical-cores × this factor. 0 (default) disables the check. Env: CONTAINARIUM_CPU_OVERCOMMIT_FACTOR (#1029).")
+	daemonCmd.Flags().BoolVar(&cpuOvercommitEnforce, "cpu-overcommit-enforce", envBool("CONTAINARIUM_CPU_OVERCOMMIT_ENFORCE", false), "With --cpu-overcommit-factor > 0, actually reject over-ceiling creates. When false (default), the check is advisory (logs what it would reject). Env: CONTAINARIUM_CPU_OVERCOMMIT_ENFORCE (#1029).")
+}
+
+// envFloat reads name as a float64, returning def when unset or unparseable.
+func envFloat(name string, def float64) float64 {
+	if v := os.Getenv(name); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return def
+}
+
+// envBool reads name as a bool (strconv.ParseBool), returning def when unset or
+// unparseable.
+func envBool(name string, def bool) bool {
+	if v := os.Getenv(name); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b
+		}
+	}
+	return def
 }
 
 func runDaemon(cmd *cobra.Command, args []string) error {
@@ -519,6 +544,8 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		LocalBackendID:       resolveBackendID(localBackendID),
 		Pool:                 pool,
 		Region:               region,
+		CPUOvercommitFactor:  cpuOvercommitFactor,
+		CPUOvercommitEnforce: cpuOvercommitEnforce,
 		PublicHostname:       publicHostname,
 		PublicAliases:        publicAliases,
 		PublicBaseDomains:    resolvePublicBaseDomains(publicBaseDomains, baseDomain),

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -102,6 +102,15 @@ type ContainerServer struct {
 	// backend without a live Incus daemon. nil in production; the real probe
 	// runs.
 	localHealthCheckFn func() bool
+	// CPU overcommit admission (#1029 direction 2). cpuOvercommitFactor is the
+	// ceiling multiple of physical cores a host may commit; <= 0 disables the
+	// gate (the default). cpuOvercommitEnforce=false makes an enabled gate
+	// advisory (log-only). hostCoresFn is a test seam for the host's physical
+	// core count (mirrors localHealthCheckFn); nil reads Incus in production.
+	// See cpu_admission.go.
+	cpuOvercommitFactor  float64
+	cpuOvercommitEnforce bool
+	hostCoresFn          func() (float64, error)
 	// capacityStore holds this backend's spare-capacity advertise/withdraw
 	// state + local policy (#680). Lazily initialized so an unwired server
 	// (tests) still answers GetCapacityHeadroom with "not advertised".
@@ -454,6 +463,15 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	}
 	if spec.Resources.Disk == "" {
 		spec.Resources.Disk = "50GB"
+	}
+
+	// CPU capacity admission (#1029 direction 2). Runs once the effective CPU
+	// request is known and before any create sink (Box CR / async / sync), so
+	// all three paths are gated uniformly. No-op unless an operator enabled the
+	// gate; peer-routed creates already returned above and are gated by the
+	// target peer's own daemon. See cpu_admission.go.
+	if err := s.admitCPUCapacity(req.Username, spec.Resources.CPU); err != nil {
+		return nil, err
 	}
 
 	// Convergence (#995): when the Box operator is running, the imperative
@@ -3338,6 +3356,16 @@ func (s *ContainerServer) SetStartTime(t time.Time) {
 func (s *ContainerServer) SetCapabilityIdentity(region, reportedClass string) {
 	s.region = region
 	s.reportedClass = reportedClass
+}
+
+// SetCPUOvercommitPolicy configures create-time CPU capacity admission (#1029
+// direction 2). factor is the ceiling multiple of physical cores a host may
+// commit (<= 0 disables the gate — the default); enforce=false makes an
+// enabled gate advisory (log-only). Called once from DualServer setup. See
+// cpu_admission.go.
+func (s *ContainerServer) SetCPUOvercommitPolicy(factor float64, enforce bool) {
+	s.cpuOvercommitFactor = factor
+	s.cpuOvercommitEnforce = enforce
 }
 
 // SetSSHHost wires the public SSH host clients dial to reach this daemon's

--- a/internal/server/cpu_admission.go
+++ b/internal/server/cpu_admission.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"fmt"
+	"log"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// CPU capacity admission (#1029 direction 2).
+//
+// A whole-core `limits.cpu` only bounds WHICH cores a container can see, not
+// how much CPU time it may consume; #1034 made every request also carry a hard
+// CFS quota, but that still lets an operator pack far more committed cores onto
+// a host than it physically has ("~14× overcommit" was observed live on an
+// 8-core host holding many `limits.cpu=8` tenants). CPU is compressible, so
+// *some* overcommit is fine and even desirable — but unbounded overcommit is
+// how one busy tenant starves every co-located one.
+//
+// This gate refuses (or, in advisory mode, merely warns about) a create that
+// would push a host's committed cores past `physicalCores × factor`. It is:
+//
+//   - Off by default. `factor <= 0` disables it entirely — no list, no read,
+//     no behavior change. Existing already-overcommitted fleets keep working
+//     until an operator opts in.
+//   - Rollout-friendly. `factor > 0` with enforce=false logs what it *would*
+//     reject without blocking, so an operator can watch a real fleet for a
+//     while (mirroring how eBPF enforcement was rolled out observe-first)
+//     before flipping enforce=true.
+//   - Fail-open. If the host's core count or container list can't be read, the
+//     create proceeds — a capacity check must never be the reason a box can't
+//     be made.
+//
+// The gate is inherently per-host: it runs on the daemon that will actually
+// create the box. Peer-routed creates are forwarded to the target peer's own
+// daemon, which runs its own gate against its own host, so no cross-host
+// capacity view is needed here.
+
+// admitCPURequest is the pure policy core: adding requestCores to a host that
+// already commits committedCores of physicalCores, at the given overcommit
+// factor, fits iff the projected total stays within physicalCores × factor.
+// It also returns the projected overcommit ratio (committed+request : physical)
+// for logging. A non-positive physicalCores means "capacity unknown" and
+// always fits — the caller fails open.
+func admitCPURequest(physicalCores, committedCores, requestCores, factor float64) (ratio float64, fits bool) {
+	if physicalCores <= 0 {
+		return 0, true
+	}
+	projected := committedCores + requestCores
+	ratio = projected / physicalCores
+	return ratio, projected <= physicalCores*factor
+}
+
+// admitCPUCapacity applies the overcommit policy to one incoming create. It
+// returns a ResourceExhausted error only when the gate is enabled, enforcing,
+// and the request would exceed the ceiling; otherwise nil (including every
+// fail-open path). username is the tenant being (re)created — its own existing
+// container, if any, is excluded so a resize-by-recreate doesn't double-count.
+func (s *ContainerServer) admitCPUCapacity(username, cpuRequest string) error {
+	if s.cpuOvercommitFactor <= 0 {
+		return nil // gate disabled (the default)
+	}
+
+	physical, err := s.hostPhysicalCores()
+	if err != nil || physical <= 0 {
+		log.Printf("[cpu-admission] capacity check skipped (host cores unavailable: %v) — allowing create for %s", err, username)
+		return nil
+	}
+	committed, err := s.committedCoresExcluding(username)
+	if err != nil {
+		log.Printf("[cpu-admission] capacity check skipped (container list failed: %v) — allowing create for %s", err, username)
+		return nil
+	}
+	request := incus.CommittedCores(cpuRequest)
+
+	ratio, fits := admitCPURequest(physical, committed, request, s.cpuOvercommitFactor)
+	if fits {
+		return nil
+	}
+
+	detail := fmt.Sprintf(
+		"host has %.0f physical cores; %.2f already committed + %.2f requested = %.2f would exceed the %.2f× overcommit ceiling (%.2f cores) — projected %.2f×",
+		physical, committed, request, committed+request, s.cpuOvercommitFactor, physical*s.cpuOvercommitFactor, ratio)
+
+	if !s.cpuOvercommitEnforce {
+		log.Printf("[cpu-admission] ADVISORY (not enforced): would reject %s — %s", username, detail)
+		return nil
+	}
+	log.Printf("[cpu-admission] REJECT %s — %s", username, detail)
+	return status.Errorf(codes.ResourceExhausted,
+		"CPU capacity exceeded on this backend: %s. Retry on a less-loaded backend/pool or a larger host, or ask an operator to raise the overcommit factor.", detail)
+}
+
+// hostPhysicalCores reports the host's physical core count. The hostCoresFn
+// seam lets tests inject a count without a live Incus daemon (mirrors
+// localHealthCheckFn); in production it reads Incus's own resource inventory,
+// the same source GetSystemInfo uses.
+func (s *ContainerServer) hostPhysicalCores() (float64, error) {
+	if s.hostCoresFn != nil {
+		return s.hostCoresFn()
+	}
+	client, err := incus.New()
+	if err != nil {
+		return 0, err
+	}
+	res, err := client.GetSystemResources()
+	if err != nil {
+		return 0, err
+	}
+	return float64(res.TotalCPUs), nil
+}
+
+// committedCoresExcluding sums the committed cores of every tenant container on
+// this host, skipping core-infra boxes (postgres/caddy — not tenant workload)
+// and the tenant being (re)created (so its own current commitment isn't counted
+// against its replacement).
+func (s *ContainerServer) committedCoresExcluding(username string) (float64, error) {
+	containers, err := s.manager.List()
+	if err != nil {
+		return 0, err
+	}
+	selfName := username + "-container"
+	var sum float64
+	for i := range containers {
+		c := &containers[i]
+		if c.Role.IsCoreRole() {
+			continue
+		}
+		if c.Name == selfName || c.Tenant == username {
+			continue
+		}
+		sum += incus.CommittedCores(c.CPU)
+	}
+	return sum, nil
+}

--- a/internal/server/cpu_admission_test.go
+++ b/internal/server/cpu_admission_test.go
@@ -1,0 +1,136 @@
+package server
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+)
+
+// TestAdmitCPURequest pins the pure policy: fits iff committed+request stays
+// within physical×factor, and unknown capacity (physical<=0) always fits so
+// the caller can fail open.
+func TestAdmitCPURequest(t *testing.T) {
+	cases := []struct {
+		name                                 string
+		physical, committed, request, factor float64
+		wantFits                             bool
+		wantRatio                            float64
+	}{
+		{"empty host under 1x", 8, 0, 4, 1, true, 0.5},
+		{"exactly at ceiling fits", 8, 4, 4, 1, true, 1},
+		{"one core over ceiling", 8, 5, 4, 1, false, 9.0 / 8},
+		{"overcommit within 4x", 8, 20, 8, 4, true, 3.5},
+		{"overcommit past 4x", 8, 25, 8, 4, false, 33.0 / 8},
+		{"unknown capacity always fits", 0, 999, 8, 1, true, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ratio, fits := admitCPURequest(c.physical, c.committed, c.request, c.factor)
+			if fits != c.wantFits {
+				t.Fatalf("fits = %v, want %v", fits, c.wantFits)
+			}
+			if diff := ratio - c.wantRatio; diff > 1e-9 || diff < -1e-9 {
+				t.Fatalf("ratio = %v, want %v", ratio, c.wantRatio)
+			}
+		})
+	}
+}
+
+// seedServer builds a ContainerServer over a mock backend pre-loaded with the
+// given committed containers, plus a fixed physical-core count.
+func seedServer(t *testing.T, physicalCores float64, seed []incus.ContainerInfo) *ContainerServer {
+	t.Helper()
+	mock := incustest.NewMockBackend()
+	for i := range seed {
+		c := seed[i]
+		mock.Containers[c.Name] = &c
+	}
+	mgr := container.NewWithBackend(mock)
+	s := &ContainerServer{manager: mgr}
+	s.hostCoresFn = func() (float64, error) { return physicalCores, nil }
+	return s
+}
+
+func tenant(name, cpu string) incus.ContainerInfo {
+	return incus.ContainerInfo{Name: name + "-container", Tenant: name, CPU: cpu}
+}
+
+// TestAdmitCPUCapacity_Disabled: with no factor set (the default), the gate is
+// a pure no-op even on a wildly overcommitted host — existing fleets keep
+// working until an operator opts in.
+func TestAdmitCPUCapacity_Disabled(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{
+		tenant("a", "8"), tenant("b", "8"), tenant("c", "8"),
+	})
+	// factor stays 0
+	if err := s.admitCPUCapacity("newbie", "8"); err != nil {
+		t.Fatalf("disabled gate must never reject, got %v", err)
+	}
+}
+
+// TestAdmitCPUCapacity_Enforce: an enabled+enforcing gate rejects a create
+// that would push committed cores past physical×factor, with ResourceExhausted.
+func TestAdmitCPUCapacity_Enforce(t *testing.T) {
+	// 8-core host, 2x ceiling = 16 committed cores allowed.
+	s := seedServer(t, 8, []incus.ContainerInfo{
+		tenant("a", "8"), tenant("b", "4"), // 12 committed
+	})
+	s.SetCPUOvercommitPolicy(2, true)
+
+	// 12 + 4 = 16 == ceiling → fits.
+	if err := s.admitCPUCapacity("fits", "4"); err != nil {
+		t.Fatalf("at-ceiling create should fit, got %v", err)
+	}
+	// 12 + 8 = 20 > 16 → reject.
+	err := s.admitCPUCapacity("toobig", "8")
+	if err == nil {
+		t.Fatal("over-ceiling create should be rejected")
+	}
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("want ResourceExhausted, got %v (%v)", status.Code(err), err)
+	}
+}
+
+// TestAdmitCPUCapacity_Advisory: an enabled but non-enforcing gate never
+// rejects, even over the ceiling (it only logs).
+func TestAdmitCPUCapacity_Advisory(t *testing.T) {
+	s := seedServer(t, 8, []incus.ContainerInfo{tenant("a", "8"), tenant("b", "8")})
+	s.SetCPUOvercommitPolicy(2, false) // enabled, advisory
+	if err := s.admitCPUCapacity("toobig", "8"); err != nil {
+		t.Fatalf("advisory gate must not reject, got %v", err)
+	}
+}
+
+// TestAdmitCPUCapacity_ExcludesCoreAndSelf: infra (core-role) containers and
+// the tenant being recreated must not count toward committed cores.
+func TestAdmitCPUCapacity_ExcludesCoreAndSelf(t *testing.T) {
+	core := incus.ContainerInfo{Name: "postgres", CPU: "8", Role: incus.RolePostgres}
+	self := tenant("me", "8")
+	other := tenant("other", "4")
+	s := seedServer(t, 8, []incus.ContainerInfo{core, self, other})
+	s.SetCPUOvercommitPolicy(1, true) // 8-core ceiling, strict
+
+	// Committed should count ONLY `other` (4), excluding the 8-core core box
+	// and my own existing 8-core box. So recreating "me" at 4 cores → 4+4=8 == ceiling → fits.
+	// If core/self weren't excluded, committed would be 8+4(+8 self) and this would reject.
+	if err := s.admitCPUCapacity("me", "4"); err != nil {
+		t.Fatalf("core+self exclusion should let this fit, got %v", err)
+	}
+}
+
+// TestAdmitCPUCapacity_FailOpenOnUnknownCores: if the host core count can't be
+// read, the gate allows the create rather than blocking it.
+func TestAdmitCPUCapacity_FailOpenOnUnknownCores(t *testing.T) {
+	s := seedServer(t, 0, []incus.ContainerInfo{tenant("a", "8"), tenant("b", "8")})
+	s.hostCoresFn = func() (float64, error) { return 0, errors.New("incus unreachable") }
+	s.SetCPUOvercommitPolicy(1, true)
+	if err := s.admitCPUCapacity("newbie", "8"); err != nil {
+		t.Fatalf("must fail open when host cores unknown, got %v", err)
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -105,6 +105,12 @@ type DualServerConfig struct {
 	LocalBackendID string   // This daemon's backend ID (defaults to hostname)
 	Pool           string   // Pool name to filter sentinel peer discovery (empty = no filter)
 	Region         string   // Region this backend serves; recorded in the capability profile (#681). Falls back to Pool when empty.
+	// CPUOvercommitFactor is the max CPU overcommit ceiling (committed cores /
+	// physical cores) for create-time admission (#1029). <= 0 disables the gate.
+	CPUOvercommitFactor float64
+	// CPUOvercommitEnforce actually rejects over-ceiling creates when the gate
+	// is enabled; false keeps it advisory (log-only).
+	CPUOvercommitEnforce bool
 
 	// Sentinel primary registration (multi-pool routing). Empty PublicHostname
 	// disables registration; the daemon still works as a single-pool primary.
@@ -1812,6 +1818,18 @@ func (ds *DualServer) Start(ctx context.Context) error {
 			region = ds.config.Pool
 		}
 		ds.containerServer.SetCapabilityIdentity(region, ds.config.Pool)
+
+		// CPU capacity admission policy (#1029 direction 2). Off unless an
+		// operator set a factor; logs its posture at boot so an enabled gate
+		// is visible, not silent.
+		ds.containerServer.SetCPUOvercommitPolicy(ds.config.CPUOvercommitFactor, ds.config.CPUOvercommitEnforce)
+		if ds.config.CPUOvercommitFactor > 0 {
+			mode := "advisory (log-only)"
+			if ds.config.CPUOvercommitEnforce {
+				mode = "enforcing"
+			}
+			log.Printf("[cpu-admission] CPU overcommit gate enabled: factor=%.2f× mode=%s", ds.config.CPUOvercommitFactor, mode)
+		}
 
 		// Integrity self-measurement posture (#683): the policy/config state the
 		// daemon folds into its signed self-measurement so the control plane can

--- a/pkg/core/incus/committed_cores_test.go
+++ b/pkg/core/incus/committed_cores_test.go
@@ -1,0 +1,71 @@
+package incus
+
+import (
+	"math"
+	"testing"
+)
+
+// TestCommittedCores pins the request-string → committed-cores mapping the
+// #1029 capacity accounting sums over. It must agree with what CreateContainer
+// actually wrote (post-#1034 hard quotas), read legacy percentage allowances,
+// count CPU-set cardinality, and never blow up on junk (returns 0, since a
+// single bad entry must not make a whole host un-schedulable).
+func TestCommittedCores(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64
+	}{
+		{"", 0},
+		{"  ", 0},
+		{"1", 1},
+		{"4", 4},
+		{"8", 8},
+		{"250m", 0.25},
+		{"1500m", 1.5},
+		{"0.25", 0.25},
+		{"2.5", 2.5},
+		{"400ms/100ms", 4}, // hard quota read straight back
+		{"100ms/100ms", 1},
+		{"800%", 8},  // legacy soft-share allowance
+		{"200%", 2},  // legacy
+		{"0-3", 4},   // CPU set / range cardinality
+		{"0,2-4", 4}, // 0 + {2,3,4}
+		{"0-7", 8},
+		{"garbage", 0}, // unparseable → 0, not a panic
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got := CommittedCores(c.in)
+			if math.Abs(got-c.want) > 1e-9 {
+				t.Fatalf("CommittedCores(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestCommittedCoresRoundTripsParseCPULimit is the property that keeps the
+// accounting honest: whatever CreateContainer would set for a request, reading
+// it back as committed cores must equal the request's own core count. If
+// parseCPULimit changes how it encodes a request, this catches an accounting
+// drift immediately.
+func TestCommittedCoresRoundTripsParseCPULimit(t *testing.T) {
+	reqs := map[string]float64{
+		"1": 1, "4": 4, "8": 8,
+		"250m": 0.25, "1500m": 1.5,
+		"0.5": 0.5, "2.5": 2.5,
+	}
+	for req, cores := range reqs {
+		cl, err := parseCPULimit(req)
+		if err != nil {
+			t.Fatalf("parseCPULimit(%q): %v", req, err)
+		}
+		// Reconstruct the request string the way ContainerInfo.CPU would carry it.
+		read := formatCPULimitFromConfig(map[string]string{
+			"limits.cpu":           cl.Count,
+			"limits.cpu.allowance": cl.Allowance,
+		})
+		if got := CommittedCores(read); math.Abs(got-cores) > 1e-9 {
+			t.Errorf("request %q → stored %q → CommittedCores %v, want %v", req, read, got, cores)
+		}
+	}
+}

--- a/pkg/core/incus/cpu_limits.go
+++ b/pkg/core/incus/cpu_limits.go
@@ -196,3 +196,85 @@ func parseAllowanceCores(allowance string) (float64, bool) {
 	}
 	return quota / period, true
 }
+
+// CommittedCores resolves a Containarium CPU request string — the same form
+// stored on ContainerInfo.CPU — into the number of physical cores it commits,
+// for placement-level capacity accounting (#1029 direction 2). It is the
+// inverse of what CreateContainer wrote:
+//
+//	"4"           → 4     (whole-core; post-#1034 also carries an 800ms/100ms quota)
+//	"250m"        → 0.25  (millicpu)
+//	"1.5"         → 1.5   (decimal)
+//	"400ms/100ms" → 4     (a hard quota read straight back)
+//	"200%"        → 2     (a legacy soft-share allowance)
+//	"0-3"         → 4     (a CPU set / pinning range — its cardinality)
+//	""            → 0     (no limit recorded; contributes nothing to the sum)
+//
+// An unparseable request yields 0 rather than an error: capacity accounting is
+// advisory admission, and a single malformed entry must not make the whole
+// host un-schedulable. A "" / 0 result is deliberately conservative — an
+// unbounded container is under-counted, not over-counted — because the size
+// tiers that drive real tenants always carry an explicit request, so the only
+// things that land here empty are infra/legacy boxes the caller already
+// excludes.
+func CommittedCores(cpuRequest string) float64 {
+	s := strings.TrimSpace(cpuRequest)
+	if s == "" {
+		return 0
+	}
+	// A raw allowance string ("800%", "400ms/100ms") — the value some callers
+	// read straight off limits.cpu.allowance. ContainerInfo.CPU never carries
+	// this form (formatCPULimitFromConfig already normalizes it to "8"/"250m"),
+	// but accepting it keeps the helper total over any CPU/allowance string.
+	// parseAllowanceCores cleanly rejects request-forms ("4", "250m", "0-3"),
+	// which have no "%" and no "/", so they fall through to the request path.
+	if cores, ok := parseAllowanceCores(s); ok {
+		return cores
+	}
+	cl, err := parseCPULimit(s)
+	if err != nil {
+		return 0
+	}
+	if cl.Allowance != "" {
+		if cores, ok := parseAllowanceCores(cl.Allowance); ok {
+			return cores
+		}
+	}
+	// No allowance: Count is either a plain integer count or a CPU set/range
+	// ("0-3", "0,2-4") that parseCPULimit passed through verbatim.
+	return countCPUSet(cl.Count)
+}
+
+// countCPUSet returns the number of cores named by an Incus limits.cpu value:
+// a plain integer count ("8" → 8) or the cardinality of a set/range
+// ("0-3" → 4, "0,2-4" → 4). Malformed fragments are skipped.
+func countCPUSet(spec string) float64 {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return 0
+	}
+	if !strings.ContainsAny(spec, ",-") {
+		if n, err := strconv.Atoi(spec); err == nil && n >= 0 {
+			return float64(n)
+		}
+		return 0
+	}
+	var total float64
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		lo, hi, ok := strings.Cut(part, "-")
+		if !ok {
+			if _, err := strconv.Atoi(part); err == nil {
+				total++
+			}
+			continue
+		}
+		a, aerr := strconv.Atoi(strings.TrimSpace(lo))
+		b, berr := strconv.Atoi(strings.TrimSpace(hi))
+		if aerr != nil || berr != nil || b < a {
+			continue
+		}
+		total += float64(b - a + 1)
+	}
+	return total
+}


### PR DESCRIPTION
Reopens/addresses **#1029 direction 2** (placement-level CPU capacity accounting). Direction 1 (whole-core requests get a hard CFS quota) shipped in #1034/v0.58.0; this is the second half — a host shouldn't accept arbitrarily many committed cores in the first place.

## Problem

`limits.cpu` bounds *which* cores a container sees; #1034 gave every request a hard CFS quota. But nothing stops an operator from committing far more cores than a host physically has — ~14× was observed live on an 8-core host packed with `limits.cpu=8` tenants. On a shared host, unbounded overcommit is exactly how one busy tenant starves its co-located neighbours.

## What this adds

A per-host admission gate on `CreateContainer`: when enabled, a create is refused (or, in advisory mode, logged) if it would push the host's committed cores past `physical_cores × factor`.

| Flag | Env | Default |
| --- | --- | --- |
| `--cpu-overcommit-factor` | `CONTAINARIUM_CPU_OVERCOMMIT_FACTOR` | `0` (disabled) |
| `--cpu-overcommit-enforce` | `CONTAINARIUM_CPU_OVERCOMMIT_ENFORCE` | `false` (advisory) |

### Design decisions (this is #1029 direction 3 — "decide deliberately")

- **Off by default.** The current fleet already runs well past 1×; strict-by-default would make those hosts refuse every new create. Enabling is a deliberate operator step. With `factor <= 0` the gate does no list and no read — zero behavior change.
- **A factor, not a hard 1×.** CPU is compressible; modest overcommit is desirable. Operators pick their own ratio.
- **Advisory → enforce rollout.** `factor>0` + `enforce=false` logs what it *would* reject without blocking, so you can calibrate against a real fleet before flipping enforcement on (same observe-first shape the eBPF enforcement rollout used).
- **Fail-open.** If host cores or the container list can't be read, the create proceeds — a capacity check must never be why a box can't be made.
- **Per-host, pool-composing.** The gate runs on the daemon that creates the box. A pool/peer-routed create is forwarded to the target peer's own daemon, which runs *its* gate against *its* host — no cross-host capacity view needed.
- **Exclusions.** Core-infra (postgres/caddy — not tenant workload) and the tenant being recreated (a resize-by-recreate must not count its own outgoing box).

## Implementation

- `incus.CommittedCores(cpuRequest)` — request/allowance string → committed cores, reusing `parseAllowanceCores`. Handles `ms/ms` quotas, legacy `%`, plain counts, millicpu/decimal, and CPU-set cardinality. Total function (junk → `0`) so one malformed entry can't make a host un-schedulable.
- `admitCPURequest(physical, committed, request, factor) → (ratio, fits)` — pure policy; unknown capacity always fits.
- `ContainerServer.admitCPUCapacity` wires it into `CreateContainer` after defaults and before the Box-CR / async / sync fork, behind an `hostCoresFn` test seam (mirrors the existing `localHealthCheckFn`).
- Flags threaded through `DualServerConfig`; boot logs the posture when enabled.

## Tests

- `CommittedCores` mapping + a round-trip property vs `parseCPULimit` (catches accounting drift if the encoding changes).
- Pure `admitCPURequest` table.
- Admission integration over a seeded mock backend: disabled / advisory / enforce (`ResourceExhausted`), core+self exclusion, fail-open.

`go build ./...`, `go vet`, and `pkg/core/incus` + `internal/server` + `internal/cmd` tests all pass.

## Docs

`docs/CPU-CAPACITY-ADMISSION.md` — the deliberate decision plus the advisory→enforce rollout guide.

## Deliberately deferred (follow-ups, not in this PR)

- **Capacity-aware placement ranking** — prefer the *least-committed* peer in a pool (the "deprioritize" half of direction 2). Today pool placement picks the first healthy peer; this is refusal-at-the-edge, not spreading.
- **A read surface for current commitment** — the advisory logs expose the numbers; a first-class report (e.g. extending `GetSystemInfo` with committed cores) would let operators see overcommit without grepping logs.

I've left this **without auto-merge** — it introduces an operator-facing knob and a new admission behavior, so it deserves a review pass rather than a green-CI auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)