### PR TITLE
feat(placement): capacity-aware pool ranking — prefer least-committed peer (#1029 direction 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Opt-in capacity-aware pool placement** (#1029). When a pool create
+  has no explicit backend, `--placement-cpu-aware` routes it to the
+  least CPU-committed healthy peer (committed cores / physical cores)
+  instead of an arbitrary first-healthy one, spreading load before the
+  admission gate has to refuse it. The daemon caches each peer's
+  commitment on the existing 30s discovery cadence (no per-create
+  round-trip); peers whose capacity isn't known yet fall back to
+  first-healthy. Off by default; the local-backend preference is
+  unchanged. Env `CONTAINARIUM_PLACEMENT_CPU_AWARE`; see
+  `docs/CPU-CAPACITY-ADMISSION.md`.
 - **Opt-in CPU capacity admission** (#1029). A daemon can now refuse a
   container create that would push its host's committed cores past
   `physical_cores × --cpu-overcommit-factor`, closing the gap where a

--- a/docs/CPU-CAPACITY-ADMISSION.md
+++ b/docs/CPU-CAPACITY-ADMISSION.md
@@ -9,7 +9,7 @@ how one busy tenant degrades every co-located one.
 
 This is an **opt-in** admission gate: when enabled, a create is refused (or, in
 advisory mode, logged) if it would push the host's committed cores past
-`physical_cores × factor`.
+`logical_cpus × factor` (Incus counts logical CPUs — vCPUs incl. SMT threads — matching the unit `limits.cpu` uses).
 
 ## Why opt-in, and why a *factor* rather than a hard 1×
 
@@ -29,7 +29,7 @@ Two daemon flags (each with an environment-variable fallback):
 
 | Flag | Env | Default | Meaning |
 | --- | --- | --- | --- |
-| `--cpu-overcommit-factor` | `CONTAINARIUM_CPU_OVERCOMMIT_FACTOR` | `0` | Ceiling multiple of physical cores. `0` (or negative) disables the gate. |
+| `--cpu-overcommit-factor` | `CONTAINARIUM_CPU_OVERCOMMIT_FACTOR` | `0` | Ceiling multiple of the host's logical CPUs (vCPUs). `0` (or negative) disables the gate. |
 | `--cpu-overcommit-enforce` | `CONTAINARIUM_CPU_OVERCOMMIT_ENFORCE` | `false` | When the factor is set, actually reject over-ceiling creates. When `false`, the gate is advisory (logs what it would reject). |
 
 Example — allow up to 4× overcommit, enforced:
@@ -65,18 +65,45 @@ the network-policy engine was rolled out — observe first:
   exclusions: **core-infra** containers (platform Postgres/Caddy — not tenant
   workload) and the **tenant being recreated** (so a resize-by-recreate doesn't
   count its own outgoing container against its replacement).
-- **Fail-open.** If the host's physical core count or its container list can't
+- **Fail-open.** If the host's logical CPU count or its container list can't
   be read, the create proceeds. A capacity check must never be the reason a box
   can't be made.
 - **Runtime.** Applies to the LXC/Incus substrate. On the k8s runtime the Incus
   resource read fails and the gate no-ops (Kubernetes does its own admission).
 
+## Capacity-aware pool placement (`--placement-cpu-aware`)
+
+Admission refuses an over-committed host; ranking keeps hosts from getting there
+by *spreading* new containers. With `--placement-cpu-aware`
+(`CONTAINARIUM_PLACEMENT_CPU_AWARE`), a pool create with no explicit backend is
+routed to the **least CPU-committed** healthy peer — lowest committed-cores /
+logical-CPU ratio — instead of the arbitrary first-healthy peer picked today.
+
+```
+containarium daemon --placement-cpu-aware
+```
+
+- **No per-create cost.** Each peer's committed and logical-CPU counts are cached on
+  the existing ~30s peer-discovery cadence (via the daemon's internal admin
+  token); placement reads the cache. Ratios are therefore slightly stale, which
+  is fine for spreading.
+- **Ratio, not absolute cores** — so a lightly loaded 32-core host outranks a
+  near-full 8-core host.
+- **Unknown falls back.** A peer just discovered (or whose last capacity fetch
+  failed) is "unknown" and ranks after every peer whose load we do know; it
+  becomes known within a discovery tick. If *no* peer's capacity is known,
+  placement is plain first-healthy.
+- **Scope.** Peer ranking only. The "local backend wins when healthy"
+  short-circuit is deliberately unchanged — letting local participate in the
+  ranking is a larger behavior change (data gravity, latency) best decided
+  separately. Pairs naturally with, but is independent of, the admission gate
+  above.
+
 ## Not covered here (follow-ups)
 
-- **Capacity-aware placement ranking.** Today pool placement picks the first
-  healthy peer; a natural extension is to prefer the *least-committed* peer so
-  overcommit is spread rather than merely refused at the edge (#1029 direction 2,
-  "deprioritize" variant).
+- **Local participation in ranking.** Today an in-pool healthy local backend
+  still wins unconditionally; a future option could rank local alongside peers.
 - **A read surface for current commitment.** The advisory logs expose the
   numbers; a first-class report (extending `GetSystemInfo` with committed cores)
-  would let operators see a host's overcommit without grepping logs.
+  would let operators see a host's overcommit — and a peer's — without grepping
+  logs.

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -58,6 +58,7 @@ var (
 	region               string
 	cpuOvercommitFactor  float64
 	cpuOvercommitEnforce bool
+	placementCPUAware    bool
 	publicHostname       string
 	publicAliases        []string
 	publicBaseDomains    []string
@@ -162,8 +163,9 @@ func init() {
 
 	// Runtime selection
 	daemonCmd.Flags().StringVar(&daemonRuntime, "runtime", "", `Box backend: "lxc" (default) or "k8s". Falls back to CONTAINARIUM_RUNTIME env when unset.`)
-	daemonCmd.Flags().Float64Var(&cpuOvercommitFactor, "cpu-overcommit-factor", envFloat("CONTAINARIUM_CPU_OVERCOMMIT_FACTOR", 0), "Max CPU overcommit: refuse a create when committed cores would exceed physical-cores × this factor. 0 (default) disables the check. Env: CONTAINARIUM_CPU_OVERCOMMIT_FACTOR (#1029).")
+	daemonCmd.Flags().Float64Var(&cpuOvercommitFactor, "cpu-overcommit-factor", envFloat("CONTAINARIUM_CPU_OVERCOMMIT_FACTOR", 0), "Max CPU overcommit: refuse a create when committed cores would exceed logical-CPUs (vCPUs, incl. SMT threads) × this factor. 0 (default) disables the check. Env: CONTAINARIUM_CPU_OVERCOMMIT_FACTOR (#1029).")
 	daemonCmd.Flags().BoolVar(&cpuOvercommitEnforce, "cpu-overcommit-enforce", envBool("CONTAINARIUM_CPU_OVERCOMMIT_ENFORCE", false), "With --cpu-overcommit-factor > 0, actually reject over-ceiling creates. When false (default), the check is advisory (logs what it would reject). Env: CONTAINARIUM_CPU_OVERCOMMIT_ENFORCE (#1029).")
+	daemonCmd.Flags().BoolVar(&placementCPUAware, "placement-cpu-aware", envBool("CONTAINARIUM_PLACEMENT_CPU_AWARE", false), "When a pool create has no explicit backend, place it on the least CPU-committed healthy peer instead of an arbitrary one. Off by default (first-healthy). Env: CONTAINARIUM_PLACEMENT_CPU_AWARE (#1029).")
 }
 
 // envFloat reads name as a float64, returning def when unset or unparseable.
@@ -546,6 +548,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		Region:               region,
 		CPUOvercommitFactor:  cpuOvercommitFactor,
 		CPUOvercommitEnforce: cpuOvercommitEnforce,
+		PlacementCPUAware:    placementCPUAware,
 		PublicHostname:       publicHostname,
 		PublicAliases:        publicAliases,
 		PublicBaseDomains:    resolvePublicBaseDomains(publicBaseDomains, baseDomain),

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -3567,6 +3567,18 @@ func (s *ContainerServer) resolvePoolPlacement(req *pb.CreateContainerRequest) e
 		req.BackendId = s.peerPool.LocalBackendID()
 		return nil
 	}
+	// Capacity-aware ranking (#1029 direction 2): prefer the least-committed
+	// peer instead of an arbitrary (map-order) first-healthy one. Opt-in; when
+	// off, or if no peer's capacity is known yet, this falls back to
+	// first-healthy. See placement_ranking.go.
+	if s.peerPool.CapacityRankingEnabled() {
+		if pick := s.peerPool.PickLeastCommittedInPool(req.Pool); pick != nil {
+			req.BackendId = pick.ID
+			return nil
+		}
+		return fmt.Errorf("no healthy backend found in pool %q", req.Pool)
+	}
+
 	candidates := s.peerPool.HealthyPeersInPool(req.Pool)
 	if len(candidates) == 0 {
 		return fmt.Errorf("no healthy backend found in pool %q", req.Pool)

--- a/internal/server/cpu_admission.go
+++ b/internal/server/cpu_admission.go
@@ -82,7 +82,7 @@ func (s *ContainerServer) admitCPUCapacity(username, cpuRequest string) error {
 	}
 
 	detail := fmt.Sprintf(
-		"host has %.0f physical cores; %.2f already committed + %.2f requested = %.2f would exceed the %.2f× overcommit ceiling (%.2f cores) — projected %.2f×",
+		"host has %.0f logical CPUs; %.2f already committed + %.2f requested = %.2f would exceed the %.2f× overcommit ceiling (%.2f cores) — projected %.2f×",
 		physical, committed, request, committed+request, s.cpuOvercommitFactor, physical*s.cpuOvercommitFactor, ratio)
 
 	if !s.cpuOvercommitEnforce {
@@ -94,10 +94,11 @@ func (s *ContainerServer) admitCPUCapacity(username, cpuRequest string) error {
 		"CPU capacity exceeded on this backend: %s. Retry on a less-loaded backend/pool or a larger host, or ask an operator to raise the overcommit factor.", detail)
 }
 
-// hostPhysicalCores reports the host's physical core count. The hostCoresFn
-// seam lets tests inject a count without a live Incus daemon (mirrors
-// localHealthCheckFn); in production it reads Incus's own resource inventory,
-// the same source GetSystemInfo uses.
+// hostPhysicalCores reports the host's logical CPU count (vCPUs — Incus's
+// TotalCPUs sums hardware threads, so this counts SMT threads, matching the
+// unit limits.cpu itself uses). The hostCoresFn seam lets tests inject a count
+// without a live Incus daemon (mirrors localHealthCheckFn); in production it
+// reads Incus's own resource inventory, the same source GetSystemInfo uses.
 func (s *ContainerServer) hostPhysicalCores() (float64, error) {
 	if s.hostCoresFn != nil {
 		return s.hostCoresFn()

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -111,6 +111,9 @@ type DualServerConfig struct {
 	// CPUOvercommitEnforce actually rejects over-ceiling creates when the gate
 	// is enabled; false keeps it advisory (log-only).
 	CPUOvercommitEnforce bool
+	// PlacementCPUAware ranks pool placement by peer CPU commitment (least
+	// committed wins) instead of first-healthy (#1029 direction 2).
+	PlacementCPUAware bool
 
 	// Sentinel primary registration (multi-pool routing). Empty PublicHostname
 	// disables registration; the daemon still works as a single-pool primary.
@@ -1863,6 +1866,20 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		} else {
 			ds.peerPool.StartCertRenewal(ctx)
 		}
+		// Capacity-aware placement ranking (#1029 direction 2). Enable BEFORE
+		// discovery starts so the very first poll already caches peer
+		// commitment. Needs an admin-scoped token to read peers' system-info
+		// (physical cores) and container lists (committed cores); if minting it
+		// fails, ranking stays off and placement falls back to first-healthy.
+		if ds.config.PlacementCPUAware {
+			if token, err := ds.tokenManager.GenerateToken("_system", []string{"admin"}, 30*24*time.Hour); err != nil {
+				log.Printf("[placement] capacity-aware ranking requested but service token mint failed (%v) — staying on first-healthy placement", err)
+			} else {
+				ds.peerPool.EnableCapacityRanking(token)
+				log.Printf("[placement] capacity-aware pool ranking enabled: pool creates prefer the least CPU-committed peer")
+			}
+		}
+
 		ds.peerPool.StartDiscovery(ctx)
 		ds.containerServer.SetPeerPool(ds.peerPool)
 

--- a/internal/server/peer.go
+++ b/internal/server/peer.go
@@ -39,6 +39,27 @@ type PeerClient struct {
 	CachedOS             string
 	CachedVersion        string
 	CachedContainerCount int32
+
+	// Cached CPU capacity for placement ranking (#1029 direction 2). Refreshed
+	// on the discovery cadence when capacity ranking is enabled; read by the
+	// placement ranker. All three are written under PeerPool.mu and must be
+	// read under it too (PickLeastCommittedInPool does). CapacityKnown gates
+	// use: until the first successful fetch the peer is treated as
+	// unknown-capacity and ranked after peers whose load we do know.
+	CachedPhysicalCores  float64
+	CachedCommittedCores float64
+	CapacityKnown        bool
+}
+
+// commitRatio reports this peer's CPU overcommit ratio (committed cores /
+// physical cores) and whether it is known. Unknown when no successful capacity
+// fetch has happened yet or the peer reports no cores. Callers must hold the
+// owning PeerPool's lock (fields are written under it).
+func (pc *PeerClient) commitRatio() (float64, bool) {
+	if !pc.CapacityKnown || pc.CachedPhysicalCores <= 0 {
+		return 0, false
+	}
+	return pc.CachedCommittedCores / pc.CachedPhysicalCores, true
 }
 
 // urlScheme returns "http" or "https" — defaults to "http" for
@@ -66,6 +87,36 @@ type PeerPool struct {
 	// 0.5 HTTPS peer-to-peer. Nil when no CA is configured —
 	// peer.go then falls back to plain HTTP (pre-0.5 behavior).
 	pki *peerPKI
+
+	// Capacity-aware placement ranking (#1029 direction 2). When
+	// capacityRanking is true and capacityServiceToken is set, the discovery
+	// loop also refreshes each healthy peer's CPU commitment, and
+	// PickLeastCommittedInPool ranks candidates by it. Both are set once via
+	// EnableCapacityRanking; empty/false leaves placement at first-healthy.
+	capacityRanking      bool
+	capacityServiceToken string
+}
+
+// CapacityRankingEnabled reports whether commitment-ranked placement is active.
+func (p *PeerPool) CapacityRankingEnabled() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.capacityRanking
+}
+
+// EnableCapacityRanking turns on per-peer CPU-commitment tracking and
+// commitment-ranked placement (#1029 direction 2). serviceToken is the
+// admin-scoped internal token used to read each peer's system-info (physical
+// cores) and container list (committed cores) — both are admin-only endpoints.
+// A no-op if the token is empty. Idempotent; call once during setup.
+func (p *PeerPool) EnableCapacityRanking(serviceToken string) {
+	if serviceToken == "" {
+		return
+	}
+	p.mu.Lock()
+	p.capacityRanking = true
+	p.capacityServiceToken = serviceToken
+	p.mu.Unlock()
 }
 
 // NewPeerPool creates a new peer pool.
@@ -436,12 +487,67 @@ func (p *PeerPool) discover() {
 	}
 
 	// Cache system info for healthy peers (best-effort, no auth needed for internal calls)
+	rankToken := ""
+	if p.capacityRanking {
+		rankToken = p.capacityServiceToken
+	}
 	for _, pc := range p.peers {
 		if !pc.Healthy {
 			continue
 		}
 		go pc.refreshCachedInfo()
+		// Placement-ranking capacity (#1029 direction 2), best-effort and only
+		// when ranking is enabled — the two extra admin-scoped reads per peer
+		// per tick are wasted work otherwise.
+		if rankToken != "" {
+			go p.refreshPeerCapacity(pc, rankToken)
+		}
 	}
+}
+
+// refreshPeerCapacity fetches a peer's physical core count (system-info) and
+// its committed tenant cores (container list, already core-infra-filtered
+// server-side), then caches them for the placement ranker. Best-effort: on any
+// error the peer keeps its previous cached value (and stays unknown until the
+// first success), so a transient blip never makes it look idle or overloaded.
+// The HTTP calls run without any lock held; only the cache write is guarded.
+func (p *PeerPool) refreshPeerCapacity(pc *PeerClient, serviceToken string) {
+	physical, perr := pc.fetchPhysicalCores(serviceToken)
+	if perr != nil {
+		return
+	}
+	containers, cerr := pc.fetchContainers(serviceToken)
+	if cerr != nil {
+		return
+	}
+	var committed float64
+	for i := range containers {
+		committed += incus.CommittedCores(containers[i].CPU)
+	}
+
+	p.mu.Lock()
+	pc.CachedPhysicalCores = physical
+	pc.CachedCommittedCores = committed
+	pc.CapacityKnown = true
+	p.mu.Unlock()
+}
+
+// fetchPhysicalCores reads a peer's total physical core count from its
+// (admin-only) system-info endpoint.
+func (pc *PeerClient) fetchPhysicalCores(serviceToken string) (float64, error) {
+	body, err := pc.ForwardGetSystemInfo(serviceToken)
+	if err != nil {
+		return 0, err
+	}
+	var result struct {
+		Info struct {
+			TotalCpus int32 `json:"totalCpus"`
+		} `json:"info"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return 0, err
+	}
+	return float64(result.Info.TotalCpus), nil
 }
 
 // LocalBackendID returns this daemon's backend ID.

--- a/internal/server/placement_ranking.go
+++ b/internal/server/placement_ranking.go
@@ -1,0 +1,67 @@
+package server
+
+import "sort"
+
+// Capacity-aware pool placement ranking (#1029 direction 2).
+//
+// Today resolvePoolPlacement takes the first healthy peer in a pool, in
+// nondeterministic Go-map order — so a new container lands on an effectively
+// arbitrary backend, and nothing stops several creates in a row from piling
+// onto the same host while its neighbours sit idle. #1055's admission gate
+// refuses an over-committed host; this spreads load *before* the gate has to.
+//
+// When enabled (EnableCapacityRanking), the discovery loop caches each peer's
+// CPU overcommit ratio (committed cores / logical CPUs) and placement prefers
+// the least-committed peer. This is peer-only: the "local backend wins when
+// healthy" short-circuit in resolvePoolPlacement is deliberately left unchanged
+// (letting local participate in the ranking is a larger behavior change — data
+// gravity, latency — best decided on its own).
+
+// leastCommitted returns the candidate that should take the next placement,
+// ranked by CPU commitment. Ordering, most-preferred first:
+//
+//  1. peers with KNOWN capacity, lowest overcommit ratio first;
+//  2. peers with UNKNOWN capacity (not yet probed, or last probe failed) —
+//     after every known peer, because a host we know is idle is a safer bet
+//     than one we can't see. "Unknown" is transient: the discovery loop fills
+//     it within one tick of a peer appearing.
+//
+// Ties (equal ratio, or two unknowns) break by ID so the choice is
+// deterministic rather than map-order-arbitrary. Returns nil for no candidates.
+// Callers must hold the owning PeerPool's read lock: commitRatio reads fields
+// the discovery loop writes under the write lock.
+func leastCommitted(candidates []*PeerClient) *PeerClient {
+	if len(candidates) == 0 {
+		return nil
+	}
+	ranked := make([]*PeerClient, len(candidates))
+	copy(ranked, candidates)
+	sort.SliceStable(ranked, func(i, j int) bool {
+		ri, iknown := ranked[i].commitRatio()
+		rj, jknown := ranked[j].commitRatio()
+		if iknown != jknown {
+			return iknown // known sorts before unknown
+		}
+		if iknown && ri != rj {
+			return ri < rj // lower commitment first
+		}
+		return ranked[i].ID < ranked[j].ID // deterministic tie-break
+	})
+	return ranked[0]
+}
+
+// PickLeastCommittedInPool returns the healthy peer in the pool with the lowest
+// CPU commitment (see leastCommitted), or nil if the pool has no healthy peer.
+// Reads capacity fields under the pool read lock. Falls back to plain
+// first-healthy semantics for any peer whose capacity isn't known yet.
+func (p *PeerPool) PickLeastCommittedInPool(pool string) *PeerClient {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	var candidates []*PeerClient
+	for _, pc := range p.peers {
+		if pc.Pool == pool && pc.Healthy {
+			candidates = append(candidates, pc)
+		}
+	}
+	return leastCommitted(candidates)
+}

--- a/internal/server/placement_ranking_test.go
+++ b/internal/server/placement_ranking_test.go
@@ -1,0 +1,148 @@
+package server
+
+import (
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// known builds a PeerClient with a known committed/physical capacity.
+func known(id, pool string, committed, physical float64) *PeerClient {
+	return &PeerClient{
+		ID: id, Pool: pool, Healthy: true,
+		CachedCommittedCores: committed, CachedPhysicalCores: physical, CapacityKnown: true,
+	}
+}
+
+// TestLeastCommitted pins the ranking: lowest known overcommit ratio wins;
+// unknown-capacity peers rank after every known one; ties break by ID so the
+// choice is deterministic rather than map-order-arbitrary.
+func TestLeastCommitted(t *testing.T) {
+	t.Run("nil for empty", func(t *testing.T) {
+		if leastCommitted(nil) != nil {
+			t.Fatal("want nil for no candidates")
+		}
+	})
+
+	t.Run("lowest ratio wins across different host sizes", func(t *testing.T) {
+		// 8-core host at 6 committed = 0.75; 32-core host at 10 = 0.31.
+		small := known("small", "p", 6, 8)
+		big := known("big", "p", 10, 32)
+		if got := leastCommitted([]*PeerClient{small, big}); got != big {
+			t.Fatalf("want big (ratio 0.31), got %s", got.ID)
+		}
+	})
+
+	t.Run("known beats unknown even when known is busier", func(t *testing.T) {
+		busy := known("busy", "p", 30, 8) // 3.75x — but we KNOW it
+		unknown := &PeerClient{ID: "mystery", Pool: "p", Healthy: true}
+		if got := leastCommitted([]*PeerClient{unknown, busy}); got != busy {
+			t.Fatalf("want busy (known), got %s", got.ID)
+		}
+	})
+
+	t.Run("two unknowns break by ID", func(t *testing.T) {
+		a := &PeerClient{ID: "aaa", Pool: "p", Healthy: true}
+		b := &PeerClient{ID: "bbb", Pool: "p", Healthy: true}
+		if got := leastCommitted([]*PeerClient{b, a}); got != a {
+			t.Fatalf("want aaa (ID tie-break), got %s", got.ID)
+		}
+	})
+
+	t.Run("equal ratio breaks by ID", func(t *testing.T) {
+		z := known("zzz", "p", 4, 8)  // 0.5
+		a := known("aaa", "p", 8, 16) // 0.5
+		if got := leastCommitted([]*PeerClient{z, a}); got != a {
+			t.Fatalf("want aaa (ID tie-break at equal ratio), got %s", got.ID)
+		}
+	})
+
+	t.Run("physical<=0 is treated as unknown", func(t *testing.T) {
+		bogus := &PeerClient{ID: "bogus", Pool: "p", Healthy: true, CapacityKnown: true, CachedPhysicalCores: 0, CachedCommittedCores: 4}
+		real := known("real", "p", 7, 8) // 0.875, known
+		if got := leastCommitted([]*PeerClient{bogus, real}); got != real {
+			t.Fatalf("want real (bogus has no physical cores), got %s", got.ID)
+		}
+	})
+}
+
+// TestPickLeastCommittedInPool: the pool method filters to healthy peers in the
+// named pool before ranking.
+func TestPickLeastCommittedInPool(t *testing.T) {
+	p := NewPeerPool("local-prod", "", nil, "prod")
+	p.peers["idle-demo"] = known("idle-demo", "demo", 2, 8) // 0.25
+	p.peers["busy-demo"] = known("busy-demo", "demo", 7, 8) // 0.875
+	p.peers["idle-lab"] = known("idle-lab", "lab", 0, 8)    // other pool
+	p.peers["down-demo"] = known("down-demo", "demo", 0, 8) // idlest but unhealthy
+	p.peers["down-demo"].Healthy = false
+
+	got := p.PickLeastCommittedInPool("demo")
+	if got == nil || got.ID != "idle-demo" {
+		t.Fatalf("want idle-demo, got %v", got)
+	}
+	if p.PickLeastCommittedInPool("nonexistent") != nil {
+		t.Fatal("want nil for a pool with no healthy peers")
+	}
+}
+
+// TestResolvePoolPlacement_CapacityRanking: with ranking enabled,
+// resolvePoolPlacement routes to the least-committed peer; with it off, it
+// keeps first-healthy behavior. Local is out of the target pool here so the
+// peer path is exercised.
+func TestResolvePoolPlacement_CapacityRanking(t *testing.T) {
+	newPool := func() *PeerPool {
+		p := NewPeerPool("local-prod", "", nil, "prod")
+		p.peers["busy"] = known("busy", "demo", 7, 8)
+		p.peers["idle"] = known("idle", "demo", 1, 8)
+		return p
+	}
+
+	t.Run("ranking on: least-committed wins", func(t *testing.T) {
+		p := newPool()
+		p.EnableCapacityRanking("service-token")
+		s := &ContainerServer{peerPool: p}
+		req := &pb.CreateContainerRequest{Pool: "demo"}
+		if err := s.resolvePoolPlacement(req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if req.BackendId != "idle" {
+			t.Fatalf("want idle, got %q", req.BackendId)
+		}
+	})
+
+	t.Run("ranking off: unchanged first-healthy path", func(t *testing.T) {
+		p := newPool() // ranking not enabled
+		s := &ContainerServer{peerPool: p}
+		if p.CapacityRankingEnabled() {
+			t.Fatal("ranking should be off")
+		}
+		req := &pb.CreateContainerRequest{Pool: "demo"}
+		if err := s.resolvePoolPlacement(req); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// first-healthy is map-order-arbitrary; just assert it picked one.
+		if req.BackendId != "idle" && req.BackendId != "busy" {
+			t.Fatalf("want a demo peer, got %q", req.BackendId)
+		}
+	})
+
+	t.Run("ranking on but no healthy peer errors", func(t *testing.T) {
+		p := NewPeerPool("local-prod", "", nil, "prod")
+		p.EnableCapacityRanking("service-token")
+		s := &ContainerServer{peerPool: p}
+		req := &pb.CreateContainerRequest{Pool: "demo"}
+		if err := s.resolvePoolPlacement(req); err == nil {
+			t.Fatal("want error when no healthy peer in pool")
+		}
+	})
+}
+
+// TestEnableCapacityRanking_EmptyTokenNoop: an empty token must not flip
+// ranking on (we'd fetch nothing and rank on always-unknown capacity).
+func TestEnableCapacityRanking_EmptyTokenNoop(t *testing.T) {
+	p := NewPeerPool("local", "", nil, "prod")
+	p.EnableCapacityRanking("")
+	if p.CapacityRankingEnabled() {
+		t.Fatal("empty token must leave ranking off")
+	}
+}


### PR DESCRIPTION
The **"deprioritize" half** of #1029 direction 2 — the follow-up to the admission gate (#1055, merged).

> Reopens #1056, which GitHub auto-closed when #1055's branch was deleted on merge (a closed PR whose base branch is gone can't be reopened/retargeted). This is the same branch, rebased onto `main` (no conflicts — it recognized #1055's squashed commit) with an added wording fix from review.

## Why

#1055's admission gate *refuses* an over-committed host. This keeps hosts from getting there by *spreading* new containers. Today `resolvePoolPlacement` takes the first healthy peer in **nondeterministic Go-map order**. With `--placement-cpu-aware`, a pool create with no explicit backend routes to the **least CPU-committed** healthy peer (committed cores / logical CPUs). Opt-in; off by default keeps first-healthy.

## How (no per-create round-trip)

There's no pre-aggregated cross-host signal to rank on, so each peer's logical-CPU count (system-info) and committed cores (its `/v1/containers` list, already core-infra-filtered server-side, summed via `incus.CommittedCores`) are cached on the **existing ~30s discovery cadence** using the same admin service token the metrics fetcher already mints. Placement reads the cache.

## Ranking (`leastCommitted`, pure + unit-tested)

Known capacity lowest-ratio first; unknown peers (just discovered / last fetch failed) rank after all known and become known within a tick; if none known, plain first-healthy. Ties break by ID → deterministic.

## Scope — peer ranking only

The "local backend wins when healthy" short-circuit is **unchanged** (data-gravity/latency call left for its own review).

## Review

Two independent adversarial reviews (of #1055 and this) found **no merge-blocking bugs**. The ranking review verified the concurrency end-to-end: all capacity-field reads under `RLock`, writes under `Lock`, no half-update, no HTTP-under-lock, token authority sufficient, `totalCpus` JSON field correct, core-infra excluded server-side.

Applied from review: corrected user-facing wording — `TotalCPUs` is the **logical** CPU (thread) count, not physical cores; doc, flag help, and the admission log line now say "logical CPUs (vCPUs)". The accounting is unit-consistent (`limits.cpu` is logical CPUs too) and errs toward allowing more, so no behavior change.

**Deferred follow-ups** (from review, non-blocking, both pre-existing codebase patterns): the 30-day `_system` service token has no renewal (after expiry, ranking silently uses frozen commitment data — same pattern as the metrics fetcher); and a pre-existing lock-free read of `pc.Addr` in the refresh goroutine (worth snapshotting under the lock for both refresh goroutines).

## Tests

`placement_ranking_test.go`: pure ranker (ratio ordering, known-beats-unknown, ID tie-breaks, zero-cores), pool filter, `resolvePoolPlacement` on/off, empty-token no-op. `go build`/`vet` clean; `internal/server` (incl. `-race`), `internal/cmd`, `pkg/core/incus` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)