### PR TITLE
fix(peer): renew the internal service token instead of a one-shot 30-day mint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Internal peer service token now renews instead of expiring after 30
+  days.** The daemon-to-peer admin token (used for peer metrics and the
+  #1029 capacity-ranking probe) was minted once for the 30-day maximum
+  and held forever; a daemon running longer than a month then silently
+  `401`'d every internal peer call — the same silent-credential-death
+  shape as the BYOC driver-token expiry (#903). A shared renewing token
+  source now re-mints ahead of expiry, which also shrinks a leaked
+  internal token's useful life from a month to an hour.
+
 ### Added
 
 - **Opt-in capacity-aware pool placement** (#1029). When a pool create

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1853,6 +1853,18 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		})
 	}
 
+	// Renewing source for the internal admin ("_system") token the daemon uses
+	// to call peers' admin-only endpoints — peer metrics and the #1029
+	// capacity-ranking probe. Shared by both so neither falls off a one-shot
+	// 30-day token (the silent-401-after-a-month footgun the renewal replaces).
+	// Lazy: no token is minted until a consumer first calls Token().
+	svcTokens := newServiceTokenSource(
+		func() (string, error) {
+			return ds.tokenManager.GenerateToken("_system", []string{"admin"}, serviceTokenTTL)
+		},
+		serviceTokenTTL, serviceTokenRenewBefore,
+	)
+
 	// Start peer discovery for multi-backend support
 	if ds.peerPool != nil {
 		// Phase 0.5: bootstrap the daemon's peer-CA + leaf cert
@@ -1872,10 +1884,13 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		// (physical cores) and container lists (committed cores); if minting it
 		// fails, ranking stays off and placement falls back to first-healthy.
 		if ds.config.PlacementCPUAware {
-			if token, err := ds.tokenManager.GenerateToken("_system", []string{"admin"}, 30*24*time.Hour); err != nil {
+			// Prove the token can be minted before arming ranking, so a broken
+			// signer surfaces at boot rather than as silent first-healthy
+			// fallback; the source then renews it for the daemon's lifetime.
+			if _, err := svcTokens.Token(); err != nil {
 				log.Printf("[placement] capacity-aware ranking requested but service token mint failed (%v) — staying on first-healthy placement", err)
 			} else {
-				ds.peerPool.EnableCapacityRanking(token)
+				ds.peerPool.EnableCapacityRanking(svcTokens.Token)
 				log.Printf("[placement] capacity-aware pool ranking enabled: pool creates prefer the least CPU-committed peer")
 			}
 		}
@@ -2026,18 +2041,15 @@ func (ds *DualServer) Start(ctx context.Context) error {
 
 	// Start OTel metrics collector if available
 	if ds.metricsCollector != nil {
-		// Wire peer metrics fetcher so peer container metrics are pushed to VictoriaMetrics
+		// Wire peer metrics fetcher so peer container metrics are pushed to
+		// VictoriaMetrics. The renewing token source (built above) replaces the
+		// former one-shot 30-day token, so metrics fetching doesn't 401 after a
+		// month on a long-lived daemon.
 		if ds.peerPool != nil {
-			// Generate a long-lived service token for internal peer API calls
-			serviceToken, err := ds.tokenManager.GenerateToken("_system", []string{"admin"}, 30*24*time.Hour)
-			if err != nil {
-				log.Printf("Warning: failed to generate service token for peer metrics: %v", err)
-			} else {
-				ds.metricsCollector.SetPeerFetcher(&PeerMetricsFetcherAdapter{
-					Pool:         ds.peerPool,
-					ServiceToken: serviceToken,
-				})
-			}
+			ds.metricsCollector.SetPeerFetcher(&PeerMetricsFetcherAdapter{
+				Pool:    ds.peerPool,
+				TokenFn: svcTokens.Token,
+			})
 		}
 		// Wire the egress fan-out fetcher (crawler-detection signal) when the
 		// conntrack traffic collector is available.

--- a/internal/server/peer.go
+++ b/internal/server/peer.go
@@ -89,12 +89,15 @@ type PeerPool struct {
 	pki *peerPKI
 
 	// Capacity-aware placement ranking (#1029 direction 2). When
-	// capacityRanking is true and capacityServiceToken is set, the discovery
-	// loop also refreshes each healthy peer's CPU commitment, and
+	// capacityRanking is true and capacityTokenFn is set, the discovery loop
+	// also refreshes each healthy peer's CPU commitment, and
 	// PickLeastCommittedInPool ranks candidates by it. Both are set once via
-	// EnableCapacityRanking; empty/false leaves placement at first-healthy.
-	capacityRanking      bool
-	capacityServiceToken string
+	// EnableCapacityRanking; unset leaves placement at first-healthy.
+	// capacityTokenFn returns the renewing internal admin token (see
+	// serviceTokenSource) — a func, not a stored string, so the daemon can't
+	// fall off a one-shot token after 30 days.
+	capacityRanking bool
+	capacityTokenFn func() (string, error)
 }
 
 // CapacityRankingEnabled reports whether commitment-ranked placement is active.
@@ -105,17 +108,18 @@ func (p *PeerPool) CapacityRankingEnabled() bool {
 }
 
 // EnableCapacityRanking turns on per-peer CPU-commitment tracking and
-// commitment-ranked placement (#1029 direction 2). serviceToken is the
+// commitment-ranked placement (#1029 direction 2). tokenFn returns the
 // admin-scoped internal token used to read each peer's system-info (physical
-// cores) and container list (committed cores) — both are admin-only endpoints.
-// A no-op if the token is empty. Idempotent; call once during setup.
-func (p *PeerPool) EnableCapacityRanking(serviceToken string) {
-	if serviceToken == "" {
+// cores) and container list (committed cores) — both admin-only endpoints —
+// and is expected to renew the token itself (serviceTokenSource). A no-op if
+// tokenFn is nil. Idempotent; call once during setup.
+func (p *PeerPool) EnableCapacityRanking(tokenFn func() (string, error)) {
+	if tokenFn == nil {
 		return
 	}
 	p.mu.Lock()
 	p.capacityRanking = true
-	p.capacityServiceToken = serviceToken
+	p.capacityTokenFn = tokenFn
 	p.mu.Unlock()
 }
 
@@ -487,9 +491,9 @@ func (p *PeerPool) discover() {
 	}
 
 	// Cache system info for healthy peers (best-effort, no auth needed for internal calls)
-	rankToken := ""
+	var rankTokenFn func() (string, error)
 	if p.capacityRanking {
-		rankToken = p.capacityServiceToken
+		rankTokenFn = p.capacityTokenFn // copy the func under the lock; call it in the goroutine
 	}
 	for _, pc := range p.peers {
 		if !pc.Healthy {
@@ -499,8 +503,8 @@ func (p *PeerPool) discover() {
 		// Placement-ranking capacity (#1029 direction 2), best-effort and only
 		// when ranking is enabled — the two extra admin-scoped reads per peer
 		// per tick are wasted work otherwise.
-		if rankToken != "" {
-			go p.refreshPeerCapacity(pc, rankToken)
+		if rankTokenFn != nil {
+			go p.refreshPeerCapacity(pc, rankTokenFn)
 		}
 	}
 }
@@ -511,7 +515,12 @@ func (p *PeerPool) discover() {
 // error the peer keeps its previous cached value (and stays unknown until the
 // first success), so a transient blip never makes it look idle or overloaded.
 // The HTTP calls run without any lock held; only the cache write is guarded.
-func (p *PeerPool) refreshPeerCapacity(pc *PeerClient, serviceToken string) {
+func (p *PeerPool) refreshPeerCapacity(pc *PeerClient, tokenFn func() (string, error)) {
+	serviceToken, err := tokenFn()
+	if err != nil {
+		log.Printf("[placement] capacity probe for %s skipped: internal token unavailable: %v", pc.ID, err)
+		return
+	}
 	physical, perr := pc.fetchPhysicalCores(serviceToken)
 	if perr != nil {
 		return
@@ -1086,8 +1095,27 @@ func (pp *PeerPool) PeerTerminalURL(username, authToken string) (string, error) 
 
 // PeerMetricsFetcherAdapter adapts PeerPool to the metrics.PeerMetricsFetcher interface.
 type PeerMetricsFetcherAdapter struct {
-	Pool         *PeerPool
-	ServiceToken string // JWT token for authenticating internal requests to peers
+	Pool *PeerPool
+	// TokenFn mints/returns the internal admin JWT for peer calls when the
+	// caller passes no auth token. Backed by a renewing serviceTokenSource so
+	// a long-lived daemon never falls off a one-shot token. May be nil (then
+	// only an explicit authToken is used).
+	TokenFn func() (string, error)
+}
+
+// serviceToken returns the internal token from TokenFn, or "" if unset/failed.
+// Callers treat "" as "no token" and skip (peer admin endpoints will 401),
+// which is the same best-effort posture as before — never a hard failure.
+func (a *PeerMetricsFetcherAdapter) serviceToken() string {
+	if a.TokenFn == nil {
+		return ""
+	}
+	tok, err := a.TokenFn()
+	if err != nil {
+		log.Printf("[peer-metrics] internal service token unavailable: %v", err)
+		return ""
+	}
+	return tok
 }
 
 // FetchPeerMetrics implements metrics.PeerMetricsFetcher.
@@ -1099,7 +1127,7 @@ func (a *PeerMetricsFetcherAdapter) FetchPeerMetrics(authToken string) []peerMet
 	// Use service token if no auth token provided
 	token := authToken
 	if token == "" {
-		token = a.ServiceToken
+		token = a.serviceToken()
 	}
 	peers := a.Pool.Peers()
 	if len(peers) == 0 {
@@ -1160,7 +1188,7 @@ func (a *PeerMetricsFetcherAdapter) FetchPeerSystemMetrics(authToken string) []m
 	}
 	token := authToken
 	if token == "" {
-		token = a.ServiceToken
+		token = a.serviceToken()
 	}
 	for _, peer := range a.Pool.Peers() {
 		if !peer.Healthy {

--- a/internal/server/placement_ranking_test.go
+++ b/internal/server/placement_ranking_test.go
@@ -99,7 +99,7 @@ func TestResolvePoolPlacement_CapacityRanking(t *testing.T) {
 
 	t.Run("ranking on: least-committed wins", func(t *testing.T) {
 		p := newPool()
-		p.EnableCapacityRanking("service-token")
+		p.EnableCapacityRanking(func() (string, error) { return "service-token", nil })
 		s := &ContainerServer{peerPool: p}
 		req := &pb.CreateContainerRequest{Pool: "demo"}
 		if err := s.resolvePoolPlacement(req); err != nil {
@@ -128,7 +128,7 @@ func TestResolvePoolPlacement_CapacityRanking(t *testing.T) {
 
 	t.Run("ranking on but no healthy peer errors", func(t *testing.T) {
 		p := NewPeerPool("local-prod", "", nil, "prod")
-		p.EnableCapacityRanking("service-token")
+		p.EnableCapacityRanking(func() (string, error) { return "service-token", nil })
 		s := &ContainerServer{peerPool: p}
 		req := &pb.CreateContainerRequest{Pool: "demo"}
 		if err := s.resolvePoolPlacement(req); err == nil {
@@ -137,11 +137,11 @@ func TestResolvePoolPlacement_CapacityRanking(t *testing.T) {
 	})
 }
 
-// TestEnableCapacityRanking_EmptyTokenNoop: an empty token must not flip
+// TestEnableCapacityRanking_NilTokenNoop: a nil token provider must not flip
 // ranking on (we'd fetch nothing and rank on always-unknown capacity).
-func TestEnableCapacityRanking_EmptyTokenNoop(t *testing.T) {
+func TestEnableCapacityRanking_NilTokenNoop(t *testing.T) {
 	p := NewPeerPool("local", "", nil, "prod")
-	p.EnableCapacityRanking("")
+	p.EnableCapacityRanking(nil)
 	if p.CapacityRankingEnabled() {
 		t.Fatal("empty token must leave ranking off")
 	}

--- a/internal/server/service_token.go
+++ b/internal/server/service_token.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"sync"
+	"time"
+)
+
+// serviceTokenTTL / serviceTokenRenewBefore configure the internal admin
+// token's lifetime and renewal margin. A short TTL (vs. the old 30-day max)
+// bounds a leaked internal token's usefulness; renewBefore re-mints well
+// ahead of expiry so no in-flight peer call ever races the cutover.
+const (
+	serviceTokenTTL         = 1 * time.Hour
+	serviceTokenRenewBefore = 10 * time.Minute
+)
+
+// serviceTokenSource mints and caches the internal admin ("_system") JWT the
+// daemon uses to call peers' admin-only endpoints (peer metrics, and the
+// #1029 capacity-ranking probe), re-minting it before it expires.
+//
+// It replaces the previous pattern of minting ONE token for the full 30-day
+// max and holding the string forever: a daemon that outlived the token then
+// 401'd every internal peer call, silently and with no log line — the same
+// silent-credential-death shape as the BYOC driver-token expiry (#903). A
+// short TTL with automatic renewal removes that cliff and shrinks the blast
+// radius of a leaked internal token to `ttl` rather than a month.
+//
+// Token() is safe for concurrent use.
+type serviceTokenSource struct {
+	mint        func() (string, error) // mints a fresh token with lifetime ttl
+	ttl         time.Duration          // lifetime requested from mint
+	renewBefore time.Duration          // re-mint once less than this remains
+	now         func() time.Time       // clock seam for tests
+
+	mu     sync.Mutex
+	token  string
+	expiry time.Time
+}
+
+// newServiceTokenSource builds a source that mints tokens of lifetime ttl and
+// renews them once less than renewBefore remains. mint is expected to request a
+// token of (at least) ttl; the source assumes the minted token is good for ttl
+// from now.
+func newServiceTokenSource(mint func() (string, error), ttl, renewBefore time.Duration) *serviceTokenSource {
+	return &serviceTokenSource{
+		mint:        mint,
+		ttl:         ttl,
+		renewBefore: renewBefore,
+		now:         time.Now,
+	}
+}
+
+// Token returns a currently-valid token, minting a fresh one when the cache is
+// empty or within renewBefore of expiry. If a re-mint fails but the cached
+// token is still valid (not yet expired), the cached token is returned so a
+// transient signer hiccup doesn't break internal calls; only an empty cache
+// surfaces the mint error.
+func (s *serviceTokenSource) Token() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	if s.token != "" && now.Before(s.expiry.Add(-s.renewBefore)) {
+		return s.token, nil
+	}
+
+	tok, err := s.mint()
+	if err != nil {
+		if s.token != "" && now.Before(s.expiry) {
+			return s.token, nil // fall back to the still-valid cached token
+		}
+		return "", err
+	}
+	s.token = tok
+	s.expiry = now.Add(s.ttl)
+	return tok, nil
+}

--- a/internal/server/service_token_test.go
+++ b/internal/server/service_token_test.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// mintCounter returns a mint func that hands out "tok-1", "tok-2", … and counts
+// calls, so a test can prove exactly when a re-mint happened.
+func mintCounter(n *int) func() (string, error) {
+	return func() (string, error) {
+		*n++
+		return fmt.Sprintf("tok-%d", *n), nil
+	}
+}
+
+func TestServiceTokenSource_CachesAndRenews(t *testing.T) {
+	var mints int
+	now := time.Unix(0, 0)
+	s := newServiceTokenSource(mintCounter(&mints), time.Hour, 10*time.Minute)
+	s.now = func() time.Time { return now }
+
+	// First call mints.
+	if tok, err := s.Token(); err != nil || tok != "tok-1" {
+		t.Fatalf("first Token() = %q,%v; want tok-1,nil", tok, err)
+	}
+	// Well before the renewal window: cached, no new mint.
+	now = now.Add(40 * time.Minute)
+	if tok, _ := s.Token(); tok != "tok-1" || mints != 1 {
+		t.Fatalf("cached call = %q (mints=%d); want tok-1 (1)", tok, mints)
+	}
+	// Inside the renewal window (< 10m to expiry): re-mints.
+	now = now.Add(15 * time.Minute) // now 55m in, 5m to expiry
+	if tok, _ := s.Token(); tok != "tok-2" || mints != 2 {
+		t.Fatalf("renewal call = %q (mints=%d); want tok-2 (2)", tok, mints)
+	}
+	// The fresh token resets the clock: next call is cached again.
+	now = now.Add(1 * time.Minute)
+	if tok, _ := s.Token(); tok != "tok-2" || mints != 2 {
+		t.Fatalf("post-renewal cached = %q (mints=%d); want tok-2 (2)", tok, mints)
+	}
+}
+
+func TestServiceTokenSource_MintErrorFallsBackToValidCache(t *testing.T) {
+	now := time.Unix(0, 0)
+	fail := false
+	mints := 0
+	s := newServiceTokenSource(func() (string, error) {
+		if fail {
+			return "", errors.New("signer down")
+		}
+		mints++
+		return fmt.Sprintf("tok-%d", mints), nil
+	}, time.Hour, 10*time.Minute)
+	s.now = func() time.Time { return now }
+
+	if _, err := s.Token(); err != nil { // mints tok-1
+		t.Fatalf("seed mint failed: %v", err)
+	}
+	// Enter the renewal window and make minting fail: the cached token is still
+	// valid (not past expiry), so it must be returned rather than an error.
+	now = now.Add(55 * time.Minute)
+	fail = true
+	if tok, err := s.Token(); err != nil || tok != "tok-1" {
+		t.Fatalf("renewal-with-failing-mint = %q,%v; want tok-1,nil (fall back to valid cache)", tok, err)
+	}
+	// Past expiry with minting still broken: no valid cache to fall back on → error.
+	now = now.Add(10 * time.Minute) // now 65m in, token (expiry 60m) is dead
+	if tok, err := s.Token(); err == nil {
+		t.Fatalf("expired cache + failing mint should error, got %q", tok)
+	}
+}
+
+func TestServiceTokenSource_EmptyCacheSurfacesMintError(t *testing.T) {
+	s := newServiceTokenSource(func() (string, error) { return "", errors.New("nope") }, time.Hour, time.Minute)
+	if _, err := s.Token(); err == nil {
+		t.Fatal("first mint failure with empty cache must return the error")
+	}
+}
+
+func TestServiceTokenSource_ConcurrentSafe(t *testing.T) {
+	var mints int
+	s := newServiceTokenSource(mintCounter(&mints), time.Hour, time.Minute)
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := s.Token(); err != nil {
+				t.Errorf("Token() error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
The hardening follow-up flagged in review of #1057 (and #1055's reviewer noted the same class). Addresses the latent silent-expiry before cutting the release that ships #1055 + #1057.

## Problem

The daemon minted its internal admin (`_system`) peer token **once for the 30-day maximum** and held the string for the process lifetime — in two places: the peer **metrics fetcher** and the #1029 **capacity-ranking** probe. A daemon running longer than 30 days then `401`'d every internal peer call, **silently and with no log line**:

- peer metrics fetching stops;
- capacity ranking silently **freezes on stale commitment data** — `CapacityKnown` is only ever set `true`, never reset, so a peer keeps ranking on its month-old numbers forever.

Same silent-credential-death shape as the BYOC driver-token expiry (#903) we chased earlier this line of work.

## Fix

A `serviceTokenSource` that mints a short-lived (1h) admin token and re-mints it 10m before expiry — thread-safe, with a clock seam for tests. On a mint failure it returns the still-valid cached token (so a transient signer hiccup doesn't break internal calls); only an empty or expired cache surfaces the error.

Both consumers now take a **token provider** (`func() (string, error)`) instead of a stored string:
- `PeerMetricsFetcherAdapter.ServiceToken` → `TokenFn`
- `PeerPool.EnableCapacityRanking(string)` → `EnableCapacityRanking(func() (string, error))`

One source is built in `DualServer.Start` and **shared** by both, so neither can fall off the token. Ranking still proves the token mints at boot (fail-fast to first-healthy) before arming.

Bonus: shrinks a leaked internal token's useful life from a month to an hour.

## Scope note

This deliberately fixes **both** mint sites, not just the ranking one — the metrics fetcher carried the identical footgun, and fixing half would leave the same bug in the other half. It does not touch the token *format* or the auth model, just the lifetime/renewal.

## Tests

`service_token_test.go`: caches within TTL, re-mints inside the renewal window (and resets the clock), falls back to a valid cache on mint failure, surfaces the error on empty/expired cache, concurrent-safe. Existing placement + peer-metrics tests updated to the provider signature. Full `internal/server` suite green incl. `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)