### PR TITLE
chore(release): cut v0.59.0 — CPU capacity admission + placement ranking + service-token renewal (#1029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.59.0] - 2026-07-20
+
 ### Fixed
 
 - **Internal peer service token now renews instead of expiring after 30

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.58.0"
+	Version = "0.59.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Two-file release cut per `docs/RELEASE-PROCESS.md`.

## Scope (v0.58.0 → main)

- [x] #1055 — feat: opt-in CPU capacity admission on create (#1029 direction 2)
- [x] #1057 — feat: capacity-aware pool ranking — prefer least-committed peer (#1029 direction 2)
- [x] #1058 — fix: renew the internal service token instead of a one-shot 30-day mint

Two `feat`s ⇒ minor bump. Everything is **off / renewing by default**, so no behavior change unless an operator opts in with `--cpu-overcommit-factor` / `--placement-cpu-aware`.

## Headline

Completes **#1029 direction 2**. Direction 1 (hard CFS quota) shipped in v0.58.0; this adds the placement/admission half:
- **CPU capacity admission** — a daemon can refuse a create that would push its host past `logical_cpus × factor` (advisory or enforcing).
- **Capacity-aware pool ranking** — pool creates route to the least CPU-committed peer instead of an arbitrary one.
- **Service-token renewal** — the internal daemon-to-peer admin token no longer silently 401s after 30 days (same silent-credential-death class as the BYOC driver-token bug).

## Checklist

- [x] `CHANGELOG.md`: `[Unreleased]` → `[0.59.0] - 2026-07-20`, empty Unreleased kept
- [x] `pkg/version/version.go`: `Version = "0.59.0"`
- [ ] CI green, merge
- [ ] Tag `v0.59.0` on `main` + push
- [ ] **Verify published artifacts** — all 10 binaries + `SHA256SUMS.txt`, and `containarium version` on a fresh download reports the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)