### PR TITLE
security: accept-new host-key checking in transfer.go, bump go.mod to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/footprintai/containarium
 
-go 1.26.0
+go 1.26.5
 
 require (
 	cloud.google.com/go/compute v1.64.0

--- a/internal/transfer/transfer.go
+++ b/internal/transfer/transfer.go
@@ -123,15 +123,21 @@ func (o *Options) resolve() error {
 
 // sshBaseArgs returns the constant prefix used by every ssh invocation in
 // this package. Always uses IdentitiesOnly=yes to avoid the failtoban budget
-// burn the demo flow uncovered (see PR #132). Strict host key checking is
-// disabled because container-side host keys regenerate on every recreate.
+// burn the demo flow uncovered (see PR #132). Host key checking uses
+// accept-new (trust-on-first-use) against the default ~/.ssh/known_hosts,
+// matching connectcore.BuildSSHArgs and internal/mcp/sshexec.go's
+// tofuHostKeyCallback — the same pattern this codebase already uses for
+// other automated/agent-driven SSH flows. A first connection to a host
+// pins its key; a later mismatch (a real MITM, or a container recreated
+// with a fresh host key) is rejected rather than silently trusted. On a
+// legitimate recreate, the fix is the same one-line `ssh-keygen -R <host>`
+// any SSH user already knows — not a reason to disable checking outright.
 func (o *Options) sshBaseArgs() []string {
 	return []string{
 		"-i", o.KeyPath,
 		"-o", "IdentitiesOnly=yes",
 		"-o", "PreferredAuthentications=publickey",
-		"-o", "StrictHostKeyChecking=no",
-		"-o", "UserKnownHostsFile=/dev/null",
+		"-o", "StrictHostKeyChecking=accept-new",
 		"-o", "LogLevel=ERROR",
 		"-o", "ConnectTimeout=15",
 	}

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,6 +100,20 @@ func TestDefaultSyncExcludes_BlocksEnvFiles(t *testing.T) {
 		assert.False(t, matchesAny(p, DefaultSyncExcludes),
 			"DefaultSyncExcludes should not filter %q", p)
 	}
+}
+
+// TestSshBaseArgs_HostKeyCheckingIsAcceptNew locks in the fix for the
+// security-sweep finding (issue #1060): host key checking must use
+// accept-new against the default known_hosts, matching the pattern
+// connectcore.BuildSSHArgs and sshexec.go's tofuHostKeyCallback already
+// use elsewhere in this codebase — never StrictHostKeyChecking=no, and
+// never a UserKnownHostsFile=/dev/null that would make accept-new a no-op.
+func TestSshBaseArgs_HostKeyCheckingIsAcceptNew(t *testing.T) {
+	opt := &Options{KeyPath: "/k/id"}
+	joined := strings.Join(opt.sshBaseArgs(), " ")
+	assert.Contains(t, joined, "StrictHostKeyChecking=accept-new")
+	assert.NotContains(t, joined, "StrictHostKeyChecking=no")
+	assert.NotContains(t, joined, "UserKnownHostsFile=/dev/null")
 }
 
 // keep these vars used so go vet doesn't complain


### PR DESCRIPTION
Fixes #1060.

## What changed

**1. `internal/transfer/transfer.go`** — push/sync ssh invocations now use `StrictHostKeyChecking=accept-new` against the default `~/.ssh/known_hosts`, matching the trust-on-first-use pattern already used elsewhere in this codebase for the same class of automated SSH flows (`connectcore.BuildSSHArgs`, `internal/mcp/sshexec.go`'s `tofuHostKeyCallback`). Previously this package was the one outlier that disabled host-key checking entirely.

A first connection to a host pins its key; a later mismatch (a genuine MITM, or a container recreated with a fresh host key) is rejected instead of silently trusted. On a legitimate recreate, the fix is the same one-line `ssh-keygen -R <host>` any SSH user already knows — not a reason to disable checking outright.

**2. `go.mod`** — bumped `go 1.26.0` → `go 1.26.5`. The prior version is vulnerable to **GO-2026-5856** (a `crypto/tls` Encrypted Client Hello privacy leak). CI's `govulncheck` job pins `actions/setup-go@v6` to `go-version: '1.26.5'` before scanning, so CI always tested with the already-patched toolchain while the repo's own advertised minimum stayed exposed — the CI signal was blind to this by construction, not because the scan missed it.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/transfer/... ./internal/connectcore/... ./internal/mcp/...` — all pass, including a new test (`TestSshBaseArgs_HostKeyCheckingIsAcceptNew`) locking in the accept-new behavior
- `govulncheck ./...` — confirmed **GO-2026-5856 no longer appears** in the results after the go.mod bump. Remaining findings are all pre-existing `github.com/lxc/incus/v6` and `x/crypto/openpgp` items marked `Fixed in: N/A` (no upstream patch exists) — unrelated to this fix and already correctly triaged as non-blocking by CI's own gating logic.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/transfer/... ./internal/connectcore/... ./internal/mcp/...`
- [x] `govulncheck ./...` confirms GO-2026-5856 cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)