### PR TITLE
fix(byoc-ingress): reconcile the listen array on an already-provisioned host (#733 follow-up)

### DIFF
--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -673,6 +673,84 @@ func (p *ProxyManager) EnsureServerConfig() error {
 		return p.createServerConfig()
 	}
 
+	// The server config already exists — createServerConfig() (a full PUT of
+	// {Listen, Routes: []}) would clobber every route Caddy already holds, so
+	// it must never be called here. Instead reconcile just the listen array:
+	// a host that flips on CONTAINARIUM_BYOC_INGRESS_ADDR (#733 slice 3) after
+	// its edge was already provisioned needs the new loopback listener added
+	// to a live config, and this was the only path that could add it.
+	//
+	// Decode into a minimal struct with only `listen` — CaddyServerConfig.Routes
+	// is []CaddyRouteTyped, whose Handle field is the []CaddyHandler interface
+	// slice encoding/json cannot unmarshal into. A real server with concrete
+	// routes would fail full-struct decode exactly like the ensureHTTPApp bug
+	// this file already carries a regression test for.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read existing server config: %w", err)
+	}
+	var existing struct {
+		Listen []string `json:"listen"`
+	}
+	if err := json.Unmarshal(body, &existing); err != nil {
+		return fmt.Errorf("failed to parse existing server config: %w", err)
+	}
+	return p.ensureListenAddrs(existing.Listen)
+}
+
+// ensureListenAddrs reconciles the live "listen" array against listenAddrs()
+// (:80, :443, plus the BYOC ingress addr when configured). Caddy's admin API
+// lets a PUT target a specific config subpath, so this replaces only the
+// listen array — routes and everything else under this server are untouched.
+func (p *ProxyManager) ensureListenAddrs(current []string) error {
+	want := p.listenAddrs()
+	have := make(map[string]bool, len(current))
+	for _, a := range current {
+		have[a] = true
+	}
+	missing := false
+	for _, a := range want {
+		if !have[a] {
+			missing = true
+			break
+		}
+	}
+	if !missing {
+		return nil
+	}
+
+	merged := append([]string{}, current...)
+	for _, a := range want {
+		if !have[a] {
+			merged = append(merged, a)
+			have[a] = true
+		}
+	}
+
+	configJSON, err := json.Marshal(merged)
+	if err != nil {
+		return fmt.Errorf("failed to marshal listen addrs: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/config/apps/http/servers/%s/listen", p.caddyAdminURL, p.serverName)
+	req, err := http.NewRequest("PUT", url, bytes.NewReader(configJSON))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to update listen addrs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("caddy returned error updating listen addrs (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	log.Printf("Caddy listen addrs updated: %v", merged)
 	return nil
 }
 

--- a/internal/app/proxy_test.go
+++ b/internal/app/proxy_test.go
@@ -693,6 +693,87 @@ func TestProxyManager_EnsureHTTPApp_AcceptsExistingConfigWithHandlers(t *testing
 	}
 }
 
+// Regression (live-caught during the #733 slice-4 rollout on an already-running
+// BYOC host): EnsureServerConfig used to treat "server config already exists"
+// as fully done, never checking whether its listen array matched
+// listenAddrs(). A host that flips on CONTAINARIUM_BYOC_INGRESS_ADDR after its
+// edge was already provisioned would restart, log that the ingress listener
+// was "enabled", and Caddy would silently keep listening on only :80/:443 —
+// the log line lied. This must add the missing listener via a scoped PUT to
+// .../listen, and must NOT touch the server's existing routes.
+func TestProxyManager_EnsureServerConfig_AddsBYOCIngressListener_ToExistingConfig(t *testing.T) {
+	cfg := intactConfig()
+	httpApp := cfg["apps"].(map[string]interface{})["http"].(map[string]interface{})
+	servers := httpApp["servers"].(map[string]interface{})
+	srv0 := servers[DefaultCaddyServerName].(map[string]interface{})
+	srv0["routes"] = []interface{}{
+		map[string]interface{}{
+			"@id": "existing.containarium.dev",
+			"match": []interface{}{
+				map[string]interface{}{"host": []interface{}{"existing.containarium.dev"}},
+			},
+			"handle": []interface{}{
+				map[string]interface{}{"handler": "reverse_proxy", "upstreams": []interface{}{
+					map[string]interface{}{"dial": "10.0.0.5:8080"},
+				}},
+			},
+		},
+	}
+
+	srv, fc := newRWFakeCaddy(cfg)
+	defer srv.Close()
+
+	pm := NewProxyManager(srv.URL, "containarium.dev").WithBYOCIngress("127.0.0.1:8081")
+	if err := pm.EnsureServerConfig(); err != nil {
+		t.Fatalf("EnsureServerConfig err = %v", err)
+	}
+
+	gotSrv0 := fc.config["apps"].(map[string]interface{})["http"].(map[string]interface{})["servers"].(map[string]interface{})[DefaultCaddyServerName].(map[string]interface{})
+
+	listen, _ := gotSrv0["listen"].([]interface{})
+	found := false
+	for _, a := range listen {
+		if a == "127.0.0.1:8081" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("listen = %v, want it to include 127.0.0.1:8081 after EnsureServerConfig", listen)
+	}
+	if len(listen) != 3 {
+		t.Errorf("listen = %v, want exactly 3 entries (:80, :443, 127.0.0.1:8081)", listen)
+	}
+
+	routes, _ := gotSrv0["routes"].([]interface{})
+	if len(routes) != 1 {
+		t.Fatalf("routes = %v, want the pre-existing route untouched (len 1)", routes)
+	}
+	route := routes[0].(map[string]interface{})
+	if route["@id"] != "existing.containarium.dev" {
+		t.Errorf("existing route was clobbered: %v", route)
+	}
+
+	if fc.loads != 0 {
+		t.Errorf("expected EnsureServerConfig to use a scoped PUT to .../listen, not a whole-config /load — got %d loads", fc.loads)
+	}
+}
+
+// Companion no-op case: a host with no BYOC ingress configured, and a config
+// already at exactly [:80, :443], must not trigger a spurious write on every
+// daemon restart.
+func TestProxyManager_EnsureServerConfig_NoBYOCIngress_IsNoOp(t *testing.T) {
+	srv, fc := newRWFakeCaddy(intactConfig())
+	defer srv.Close()
+
+	pm := NewProxyManager(srv.URL, "containarium.dev")
+	if err := pm.EnsureServerConfig(); err != nil {
+		t.Fatalf("EnsureServerConfig err = %v", err)
+	}
+	if fc.puts != 0 {
+		t.Errorf("expected no writes when listen is already [:80 :443] and BYOC ingress is off, got %d puts", fc.puts)
+	}
+}
+
 // TestProxyManager_RemoveTLSSubject_StripsFromAllPolicies covers the
 // container-delete cascade case (#69): when a container is deleted, its
 // hostname must come out of Caddy's TLS automation subjects so Caddy


### PR DESCRIPTION
## Summary
- `EnsureServerConfig` treated an existing Caddy server config as fully done and never checked whether its `listen` array matched `listenAddrs()`.
- A host that sets `CONTAINARIUM_BYOC_INGRESS_ADDR` after its edge Caddy was already provisioned would restart, log that the ingress listener was "enabled", and Caddy would silently keep listening on only `:80`/`:443` — the log line lied. Caught live rolling this out on a lab BYOC host during the #733 slice-4 validation.
- Added `ensureListenAddrs()`: reads the live listen array and PUTs only the missing entries to the `.../listen` subpath (a scoped Caddy admin-API write), leaving routes untouched — `createServerConfig()` can't be reused here since it's a full PUT of `{Listen, Routes: []}` that would wipe every route the host already holds.
- Decodes only `{listen}` from the GET response rather than the full `CaddyServerConfig`, avoiding the `[]CaddyHandler` interface-decode landmine already documented elsewhere in this file.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/app/... ./internal/server/...` clean
- [x] `go test ./internal/app/... ./internal/server/...` — all pass, including two new regression tests: one confirming the listener is added to an existing config without touching its routes, one confirming a no-BYOC-ingress host with an already-correct listen array makes zero writes
- [ ] Re-run the #733 slice-4 live validation on the BYOC host once this is deployed