### PR TITLE
chore(release): cut v0.59.1 — BYOC ingress listen-reconcile fix + SSH host-key hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.59.1] - 2026-07-22
+
+### Fixed
+
+- **BYOC ingress listener now actually appears on an already-provisioned
+  host** (#733 follow-up). `EnsureServerConfig` treated an existing Caddy
+  server config as fully done and never checked whether its listen array
+  matched the configured set — a host that set
+  `CONTAINARIUM_BYOC_INGRESS_ADDR` after its edge was already provisioned
+  would restart, log that the ingress listener was enabled, and Caddy
+  would silently keep listening on only `:80`/`:443`. Caught live during
+  the #733 slice-4 rollout. Fixed with a scoped reconcile that adds only
+  the missing listen entries without touching existing routes.
+- **SSH host-key checking in `transfer.go` upgraded from
+  insecure-ignore to accept-new`** (#1061); `go.mod` bumped to Go
+  1.26.5.
+
 ## [0.59.0] - 2026-07-20
 
 ### Fixed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.59.0"
+	Version = "0.59.1"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary
- Bumps `pkg/version/version.go` to 0.59.1
- CHANGELOG entries for #1062 (BYOC ingress listen-reconcile, found during live #733 slice-4 validation) and #1061 (SSH host-key checking hardening + Go 1.26.5)

## Test plan
- [x] CI green on #1062 before merge
- [ ] Deploy to the lab BYOC host, resume #733 slice-4 live validation