### PR TITLE
chore(release): cut v0.59.2 — fix BYOC ingress listen reconcile 409 (#1062 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.59.2] - 2026-07-22
+
+### Fixed
+
+- **BYOC ingress listen-array fix (#733 follow-up), corrected.** v0.59.1's
+  fix used a scoped `PUT .../listen`, which Caddy's admin API rejects with
+  `409 key already exists` once that key already holds a value — so the
+  listener was never actually added on any host past its first-ever
+  provision. Caught live deploying v0.59.1 to a lab BYOC host. Switched to
+  the same `getFullConfig`/`loadConfig` atomic-swap round trip already
+  used elsewhere in this file (`EnableProxyProtocol`); every existing
+  route survives untouched.
+
 ## [0.59.1] - 2026-07-22
 
 ### Fixed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.59.1"
+	Version = "0.59.2"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
## Summary
- Bumps `pkg/version/version.go` to 0.59.2
- CHANGELOG entry for #1064 (corrects v0.59.1's #1062 fix, which used a scoped PUT that 409s on Caddy's admin API)

## Test plan
- [x] CI green on #1064 before merge
- [ ] Redeploy to the lab BYOC host, confirm the listener actually appears in Caddy's live config, resume #733 slice-4 validation