### PR TITLE
feat(metrics-export): opt-in toggle + provider enum + ADC probe (#1069)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -4751,6 +4751,63 @@
         ]
       }
     },
+    "/v1/system/metrics-export": {
+      "get": {
+        "summary": "Get cloud-native metrics export status",
+        "description": "Returns whether cloud-native metrics export is enabled, the configured provider, the export interval, and last-known health (populated once the collector lands in #1070/#1071).",
+        "operationId": "ContainerService_GetMetricsExport",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/GetMetricsExportResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "tags": [
+          "Monitoring"
+        ]
+      },
+      "post": {
+        "summary": "Enable or disable cloud-native metrics export",
+        "description": "Opt-in export of host/container infra metrics to the host cloud's native monitoring (GCP Cloud Monitoring in the MVP). Enabling probes Application Default Credentials (monitoring-write scope) before persisting anything; a host with no resolvable ADC fails with FAILED_PRECONDITION and an IAM remediation hint. Disabling stops emission within one export interval. AWS is reserved and returns UNIMPLEMENTED.",
+        "operationId": "ContainerService_SetMetricsExport",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/SetMetricsExportResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "SetMetricsExportRequest enables or disables cloud-native metrics export.\nEnabling with provider=GCP triggers a synchronous Application Default\nCredentials probe (monitoring-write scope) before anything is persisted\nor started; enabling with an unresolvable ADC fails the call and leaves\nthe prior config untouched.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SetMetricsExportRequest"
+            }
+          }
+        ],
+        "tags": [
+          "Monitoring"
+        ]
+      }
+    },
     "/v1/system/monitoring": {
       "get": {
         "summary": "Get monitoring information",
@@ -6802,6 +6859,16 @@
       },
       "title": "CleanupDiskResponse is the response from cleaning up disk space"
     },
+    "CloudMetricsProvider": {
+      "type": "string",
+      "enum": [
+        "CLOUD_METRICS_PROVIDER_UNSPECIFIED",
+        "CLOUD_METRICS_PROVIDER_GCP",
+        "CLOUD_METRICS_PROVIDER_AWS"
+      ],
+      "default": "CLOUD_METRICS_PROVIDER_UNSPECIFIED",
+      "description": "CloudMetricsProvider identifies which host cloud's native monitoring\nreceives the opt-in export (#1069). Typed so the toggle can never be a\nmagic string. AWS is reserved for a future Sink implementation;\nSetMetricsExport rejects it with UNIMPLEMENTED until one exists.\n\n - CLOUD_METRICS_PROVIDER_UNSPECIFIED: Unset. SetMetricsExport rejects this with INVALID_ARGUMENT when\nenabled=true; GetMetricsExport returns it when export has never been\nconfigured.\n - CLOUD_METRICS_PROVIDER_GCP: Google Cloud Monitoring (Cloud Operations). The only implemented\nprovider in the MVP.\n - CLOUD_METRICS_PROVIDER_AWS: Amazon CloudWatch. Reserved — no Sink implementation yet;\nSetMetricsExport returns UNIMPLEMENTED."
+    },
     "Collaborator": {
       "type": "object",
       "properties": {
@@ -8519,6 +8586,39 @@
         }
       },
       "description": "GetLatestReleaseResponse reports the latest published release vs the\nrunning daemon version. See #354."
+    },
+    "GetMetricsExportResponse": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether export is currently enabled."
+        },
+        "provider": {
+          "$ref": "#/definitions/CloudMetricsProvider",
+          "description": "The configured provider. CLOUD_METRICS_PROVIDER_UNSPECIFIED when\nexport has never been configured on this host."
+        },
+        "intervalSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Export interval in seconds. Fixed default 60 in the MVP; #1069 does\nnot expose a knob to change it."
+        },
+        "lastSuccessAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Wall-clock time of the last successful export batch."
+        },
+        "lastError": {
+          "type": "string",
+          "description": "Human-readable detail of the most recent export failure, if any."
+        },
+        "exportFailures": {
+          "type": "string",
+          "format": "int64",
+          "description": "Count of failed export batches since the exporter was last (re)built."
+        }
+      },
+      "description": "GetMetricsExportResponse reports the current cloud-native metrics\nexport configuration and last-known health. last_success_at,\nlast_error, and export_failures are zero-valued until the collector\n(#1070/#1071) is wired — #1069 delivers the toggle, config\npersistence, and enable-time credential probe only."
     },
     "GetMetricsResponse": {
       "type": "object",
@@ -10966,6 +11066,41 @@
         }
       },
       "description": "SetContainerTTLResponse reports the new TTL state."
+    },
+    "SetMetricsExportRequest": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Desired state. true enables export (provider is required and is\nprobed before persisting). false disables it; provider is ignored."
+        },
+        "provider": {
+          "$ref": "#/definitions/CloudMetricsProvider",
+          "description": "Target cloud provider. Required when enabled=true. Must not be\nCLOUD_METRICS_PROVIDER_UNSPECIFIED (INVALID_ARGUMENT) or\nCLOUD_METRICS_PROVIDER_AWS (UNIMPLEMENTED — MVP is GCP-only)."
+        }
+      },
+      "description": "SetMetricsExportRequest enables or disables cloud-native metrics export.\nEnabling with provider=GCP triggers a synchronous Application Default\nCredentials probe (monitoring-write scope) before anything is persisted\nor started; enabling with an unresolvable ADC fails the call and leaves\nthe prior config untouched."
+    },
+    "SetMetricsExportResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "Operator-facing summary of what changed (e.g. \"cloud metrics export\nenabled for gcp\")."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "The effective config after the call — mirrors GetMetricsExportResponse."
+        },
+        "provider": {
+          "$ref": "#/definitions/CloudMetricsProvider"
+        },
+        "intervalSeconds": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "description": "SetMetricsExportResponse reports the effective state after the toggle."
     },
     "SetNetworkPolicyRequest": {
       "type": "object",

--- a/docs/CLOUD-NATIVE-METRICS-EXPORT-DESIGN.md
+++ b/docs/CLOUD-NATIVE-METRICS-EXPORT-DESIGN.md
@@ -1,0 +1,216 @@
+# Design: Cloud-native metrics export (GCP Cloud Monitoring first)
+
+**Date:** 2026-07-23
+**Status:** proposed
+**Stack:** Go 1.26 + protobuf/gRPC (grpc-gateway) / no frontend component / ships inside the existing daemon binary
+**Stories:** #1069 (toggle), #1070 (host series), #1071 (container series), #1072 (heartbeat/dead-man), #1073 (quickstart doc)
+
+## Problem
+
+All daemon metrics terminate in the host-local VictoriaMetrics LXC; alerting
+(vmalert) fate-shares with the host it monitors, so a wedged or dead backend
+stops being able to report that it is wedged or dead. Operators on GCP/AWS
+already run the provider's monitoring and alerting. This feature adds an
+**opt-in, out-of-band export** of host + container infra series to the host
+cloud's native monitoring (GCP Cloud Monitoring in MVP), authenticated by the
+machine's ambient identity (ADC) — no key files, no new monitoring product.
+
+## Design
+
+**One decision up front (the fork the PRD left open): the exporter lives
+in-process in the daemon**, not in the core-otelcollector LXC. Reasons:
+
+1. **Dead-man semantics.** #1072's alert must mean "daemon/host is dead." If a
+   separate collector LXC did the exporting, its own death would fire the same
+   alert (false positive) and its survival could mask a dead daemon until the
+   next scrape gap. Daemon-emits ⇒ absence of the series means exactly one thing.
+2. **No new deployable.** The daemon already owns metric collection
+   (`internal/metrics/otel.go`); the core-otelcollector LXC is an opt-in
+   app-telemetry component that is not guaranteed present on every backend.
+3. **Typed config.** The toggle becomes a normal proto RPC + daemon config
+   field, not YAML surgery on a collector container.
+
+### Components
+
+```mermaid
+flowchart LR
+    subgraph daemon["containarium daemon (existing binary)"]
+        SRC["metrics sources (existing)\nGetSystemResources / GetAllMetrics"]
+        COL["internal/metrics Collector (existing)\nOTLP push"]
+        CE["internal/metrics/cloudexport (NEW)\nCloudExportCollector + Sink"]
+        CFG["daemon config (existing store)\n+ MetricsExport field"]
+    end
+    VM["VictoriaMetrics LXC\n(existing, unchanged)"]
+    GCM["GCP Cloud Monitoring\nCreateTimeSeries"]
+    CLI["containarium monitoring export\nenable|disable|status (NEW)"]
+    MCP["MCP tool (thin wrapper)"]
+
+    SRC --> COL --> VM
+    SRC --> CE -->|"OTel PeriodicReader → GCP exporter (ADC)"| GCM
+    CLI -->|"SetMetricsExport RPC"| CFG --> CE
+    MCP --> CLI
+```
+
+| Component | Responsibility | Language / location |
+|---|---|---|
+| `cloudexport.CloudExportCollector` | Own a dedicated OTel `MeterProvider` + `PeriodicReader` wired to a provider `Sink`; register exactly the allowlisted instruments; emit heartbeat | Go, `internal/metrics/cloudexport/collector.go` |
+| `cloudexport.Sink` (interface) + `gcpSink` | Provider abstraction: construct the OTel metric exporter for one provider. MVP implements GCP via `opentelemetry-operations-go/exporter/metric`; AWS is a future second implementation | Go, `internal/metrics/cloudexport/{sink.go,gcp.go}` |
+| `cloudexport.Sources` (interface) | Seam over the existing collection funcs (`GetSystemResources`, `GetAllMetrics`) so the collector is unit-testable without incus | Go, `internal/metrics/cloudexport/sources.go` |
+| `SetMetricsExport` / `GetMetricsExport` RPCs | Typed enable/disable/status; validates provider enum + credential resolvability at enable time | proto + `internal/server/` |
+| `containarium monitoring export` subcommand | CLI-first surface; `enable --provider gcp`, `disable`, `status` | Go, `internal/cmd/monitoring_export.go` |
+| MCP tool `set_metrics_export` | Thin wrapper over the same client function as the CLI handler | Go, `internal/mcp/tools.go` |
+| Quickstart doc | Bare GCP VM → visible metrics + dead-man alert in <10 min, with IAM + cost numbers | `docs/CLOUD-NATIVE-METRICS-EXPORT.md` (#1073) |
+
+### Why a dedicated MeterProvider (not a second reader on the existing one)
+
+The internal Collector exports its full instrument set (system, container,
+egress fan-out, backend health…). Cloud-provider custom metrics are **billed
+per ingested sample**, so the exported set must be a deliberate allowlist, not
+"everything we happen to record." A second `MeterProvider` whose instruments
+are exactly the exported series makes the cost surface explicit in code and
+reviewable in one file. The collection cost is negligible (the sources are
+cheap incus-state reads already performed on a similar cadence).
+
+### Exported series (the complete MVP set — additions require touching this list)
+
+Resource: detected `gce_instance` (GCP resource detector) → series land under
+the exporter's workload prefix in Metrics Explorer.
+
+| Series | Kind | Labels (allowlist) |
+|---|---|---|
+| `containarium.host.cpu.load_1m/_5m/_15m` | gauge | backend_id, hostname, region |
+| `containarium.host.memory.used_bytes` / `.total_bytes` | gauge | backend_id, hostname, region |
+| `containarium.host.disk.used_bytes` / `.total_bytes` | gauge | backend_id, hostname, region |
+| `containarium.host.container.count` | gauge | backend_id, hostname, region |
+| `containarium.container.cpu.usage_seconds` | counter | backend_id, container_name |
+| `containarium.container.memory.usage_bytes` | gauge | backend_id, container_name |
+| `containarium.container.disk.usage_bytes` | gauge | backend_id, container_name |
+| `containarium.container.network.rx_bytes` / `.tx_bytes` | counter | backend_id, container_name |
+| `containarium.export.heartbeat` | gauge (=1) | backend_id, hostname, daemon_version |
+
+Hard rules: no org/tenant UUID labels ever (reuse the intent of
+`DefaultOTelDropLabels`, `internal/server/core_otel_collector.go:45`); interval
+fixed default 60s, floor 60s (cost guard); a deleted container's series stop at
+the next interval because collection enumerates live containers each tick.
+
+### Data flow, including failure paths
+
+1. Enable: CLI → `SetMetricsExport{provider: GCP}` → server validates enum ≠
+   `UNSPECIFIED`/`AWS` (Unimplemented for AWS), **resolves ADC and performs one
+   dry-run `CreateTimeSeries`-scope token fetch**; failure returns
+   `FailedPrecondition` with the IAM remediation hint and persists nothing.
+   Success persists the typed config field and (re)builds the
+   `CloudExportCollector`. No daemon restart (mirrors the rebuild pattern used
+   elsewhere in the daemon; config write goes through the full-config
+   read-modify-write path).
+2. Steady state: every interval, the PeriodicReader observes the gauges
+   (callbacks pull from `Sources`) and the GCP exporter pushes one
+   `CreateTimeSeries` batch.
+3. Export failure (quota, IAM revoked, network): the OTel SDK logs and drops;
+   we additionally count `export_failures` and surface last-error +
+   last-success-time in `GetMetricsExport` status. **Export failure never
+   affects daemon operation or the internal VM pipeline** — the two pipelines
+   share sources, nothing else.
+4. Disable: rebuilds without the reader; emission stops within one interval.
+5. Host/daemon death: emission stops ⇒ the operator's metric-absence policy on
+   `containarium.export.heartbeat` fires. This is the out-of-band property: no
+   component on the host needs to survive for the alert to work.
+
+## Contracts
+
+| Boundary | Contract | Source of truth |
+|---|---|---|
+| Client ↔ daemon | `SetMetricsExportRequest{provider: CloudMetricsProvider enum, enabled: bool}` / `GetMetricsExportResponse{enabled, provider, interval_seconds, last_success_at, last_error, export_failures}`; RPCs annotated `google.api.http` (`POST /v1/system/metrics-export`, `GET /v1/system/metrics-export`) + openapiv2 descriptions; placed beside the existing Monitoring-tagged RPCs (`service.proto:195-206,601`) | `proto/containarium/v1/service.proto`, regenerated via `make proto` — gRPC, REST, swagger, typed client all derive from it |
+| enum | `CloudMetricsProvider { CLOUD_METRICS_PROVIDER_UNSPECIFIED=0; GCP=1; AWS=2 (reserved, Unimplemented) }` — no string provider anywhere | same proto |
+| cloudexport ↔ collection | `Sources interface { SystemResources(ctx) (*SystemResources, error); AllContainerMetrics(ctx) (map[string]*pb.ContainerMetrics, error) }` | `internal/metrics/cloudexport/sources.go` |
+| cloudexport ↔ provider | `Sink interface { NewExporter(ctx, SinkConfig) (sdkmetric.Exporter, error); Probe(ctx) error }` | `internal/metrics/cloudexport/sink.go` |
+| daemon ↔ GCP | Cloud Monitoring v3 `CreateTimeSeries` via `opentelemetry-operations-go/exporter/metric` (NEW dependency); auth = ADC only | vendored module |
+| config | typed `MetricsExportConfig{Enabled, Provider, IntervalSeconds}` on the daemon config struct — no map plumbing | daemon config package |
+
+## Test strategy
+
+**`cloudexport` package** (core; no network, no incus):
+- Table-driven unit tests with a fake `Sources` and the SDK's in-memory
+  manualreader: `TestExportedSeries_MatchesAllowlistGolden` (the exact series
+  set + labels above is a golden — any drift fails), `TestNoTenantLabels`
+  (inject sources returning org-UUID-looking names → asserted absent from
+  labels), `TestDeletedContainerSeriesStop` (source drops a container →
+  next observation has no series), `TestHeartbeatEmittedEveryInterval`,
+  `TestSourceErrorSkipsTickWithoutPanic`.
+- Toggle lifecycle: `TestEnableDisableRebuild` — enable→observe→disable→
+  assert reader shutdown and no further observations.
+- `gcpSink` contract test against a **fake Cloud Monitoring gRPC server**
+  (in-process listener; exporter pointed at it with auth disabled):
+  `TestCreateTimeSeriesRequestShape` asserts metric types, gce_instance
+  resource mapping, batch cadence, and that a 429 response is dropped-and-
+  counted, not retried into the next tick. Real exporter code path; only the
+  Google endpoint is fake.
+- `TestProbe_ADCMissing` — credential lookup injected; table of (no ADC /
+  wrong-scope token / ok) → (FailedPrecondition+hint / FailedPrecondition /
+  nil).
+
+**Server RPCs** (`internal/server`): table-driven handler tests mirroring the
+existing monitoring-RPC tests — enum validation (UNSPECIFIED → InvalidArgument,
+AWS → Unimplemented), probe-failure persists nothing, status round-trip,
+admin/tenant scoping consistent with `GetSystemInfo`.
+
+**CLI** (`internal/cmd`): handler tests against the fake typed client (existing
+pattern): flag parsing (`--provider gcp`), error rendering of
+FailedPrecondition hint, `status` output. MCP correctness follows from the
+shared client function (per CLI-first convention) — one smoke test that the
+tool routes to it.
+
+**Integration slice** (CI, no cloud account): daemon test harness with fake
+Sources + fake Cloud Monitoring server — enable via the real REST gateway path
+→ assert TimeSeries arrive; kill the collector → assert heartbeat absence
+(this is the automatable proxy for the dead-man alert).
+
+**Live e2e** (manual, release gate — pairs with #1072/#1073 acceptance): on a
+real GCP VM: enable → Metrics Explorer shows series ≤2 min → create the
+documented absence policy → stop daemon → alert fires. Result recorded in the
+quickstart doc.
+
+Mocked vs real: Cloud Monitoring endpoint always faked in CI (real one only in
+the manual gate); Sources faked in unit tests, real in the live gate; ADC
+resolution real code with injected lookup; incus never mocked at a deeper
+layer than `Sources`.
+
+## Deviations from the default stack
+
+- **New dependency**: `github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric`
+  (+ transitive `cloud.google.com/go/monitoring`). Justified: official OTel→GCM
+  bridge; hand-rolling `CreateTimeSeries` batching/rate handling is exactly the
+  wheel it exists to avoid. Contained: imported only inside
+  `internal/metrics/cloudexport/gcp.go`; the rest of the daemon sees the `Sink`
+  interface.
+- No other deviations: Go, proto-first, grpc-gateway REST, typed config, no
+  frontend, no new deployable.
+
+## At 10x
+
+100+ containers/backend ⇒ ~500 container series/backend: still under GCM's
+200-series-per-write batch handling (exporter chunks) but cost grows linearly —
+the documented cost table in #1073 is per-container-count; if it bites, the
+next knob is a per-container export opt-out label, not a redesign. Multi-cloud
+(AWS) and tenant-facing cross-project export slot in as new `Sink`
+implementations + a credential field on the config message (already an enum,
+already an interface).
+
+## Rejected alternatives
+
+1. **otel-collector-contrib (`googlecloudexporter`) inside the
+   core-otelcollector LXC.** Rejected: weakens #1072's dead-man semantics (a
+   dead collector LXC is indistinguishable from a dead host), the LXC is
+   opt-in app-telemetry and not present on every backend, the toggle would be
+   collector-YAML mutation instead of a typed RPC, and it ships a ~200MB
+   contrib binary for one exporter.
+2. **GCP Ops Agent scraping a new daemon Prometheus `/metrics` endpoint.**
+   Rejected: introduces a host agent we don't deploy or version, a pull model
+   alien to the existing push architecture, and no AWS symmetry (different
+   agent, different config language). The daemon deliberately has no
+   Prometheus endpoint today — adding one *just* as an agent shim creates a
+   second, unauthenticated metrics surface to secure.
+3. **VictoriaMetrics-side forwarding (remote-write → GCM).** Rejected: GCM has
+   no Prometheus remote-write ingest for custom metrics without an
+   intermediary, and it re-introduces the fate-shared hop this feature exists
+   to remove.

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.54.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	google.golang.org/api v0.289.0
@@ -133,7 +134,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -240,6 +240,32 @@ func (c *GRPCClient) ToggleMonitoring(username string, enabled bool) (string, bo
 	return resp.Message, resp.MonitoringEnabled, nil
 }
 
+// SetMetricsExport enables or disables opt-in export of host/container
+// infra metrics to the host cloud's native monitoring (#1069). Enabling
+// requires a supported provider and passes the daemon's synchronous
+// credential probe (e.g. GCP ADC resolution); a failed probe or an
+// unsupported provider (AWS, UNSPECIFIED) returns the daemon's error
+// unwrapped so the CLI can render the gRPC code (FailedPrecondition /
+// InvalidArgument / Unimplemented) directly.
+func (c *GRPCClient) SetMetricsExport(enabled bool, provider pb.CloudMetricsProvider) (*pb.SetMetricsExportResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	return c.client.SetMetricsExport(ctx, &pb.SetMetricsExportRequest{
+		Enabled:  enabled,
+		Provider: provider,
+	})
+}
+
+// GetMetricsExport returns the current cloud-native metrics export
+// configuration and last-known health (#1069).
+func (c *GRPCClient) GetMetricsExport() (*pb.GetMetricsExportResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	return c.client.GetMetricsExport(ctx, &pb.GetMetricsExportRequest{})
+}
+
 // ToggleAutoSleep writes the per-container auto-sleep opt-in metadata.
 // idleThresholdMinutes is ignored when enabled is false; 0 means
 // "leave the existing key or fall back to the 15-minute default".

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -616,6 +616,88 @@ func (c *HTTPClient) ToggleMonitoring(username string, enabled bool) (string, bo
 	return result.Message, result.MonitoringEnabled, nil
 }
 
+// SetMetricsExport enables or disables opt-in export of host/container
+// infra metrics to the host cloud's native monitoring (#1069) via HTTP.
+// Enabling with an unresolvable provider credential (e.g. no GCP ADC)
+// or an unsupported provider (AWS, UNSPECIFIED) fails with the
+// server's error message intact — grpc-gateway maps FAILED_PRECONDITION
+// and INVALID_ARGUMENT to HTTP 400 and UNIMPLEMENTED to HTTP 501, but
+// the CLI only needs the message text, which carries the IAM
+// remediation hint for the credential-probe case.
+func (c *HTTPClient) SetMetricsExport(enabled bool, provider pb.CloudMetricsProvider) (*pb.SetMetricsExportResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	body := map[string]interface{}{
+		"enabled": enabled,
+		// Emit the enum by its proto JSON name so grpc-gateway decodes it
+		// into the CloudMetricsProvider enum.
+		"provider": provider.String(),
+	}
+	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/system/metrics-export", body)
+	if err != nil {
+		return nil, fmt.Errorf("set metrics export: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotImplemented {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		msg := "server does not support this metrics export provider"
+		if json.Unmarshal(bodyBytes, &errResp) == nil && errResp.Error != "" {
+			msg = errResp.Error
+		}
+		return nil, status.Error(codes.Unimplemented, msg)
+	}
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(bodyBytes, &errResp) == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("%s", errResp.Error)
+		}
+		return nil, fmt.Errorf("set metrics export: status %d", resp.StatusCode)
+	}
+
+	out := &pb.SetMetricsExportResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
+// GetMetricsExport returns the current cloud-native metrics export
+// configuration and last-known health via HTTP (#1069).
+func (c *HTTPClient) GetMetricsExport() (*pb.GetMetricsExportResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	resp, err := c.doRequest(ctx, http.MethodGet, "/v1/system/metrics-export", nil)
+	if err != nil {
+		return nil, fmt.Errorf("get metrics export: %w", err)
+	}
+	defer drainClose(resp)
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(bodyBytes, &errResp) == nil && errResp.Error != "" {
+			return nil, fmt.Errorf("%s", errResp.Error)
+		}
+		return nil, fmt.Errorf("get metrics export: status %d", resp.StatusCode)
+	}
+
+	out := &pb.GetMetricsExportResponse{}
+	if err := protojson.Unmarshal(bodyBytes, out); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
 // RefreshToken exchanges a refresh token for a new
 // (access, refresh) pair. Unauthenticated endpoint —
 // the refresh token in the body IS the credential.

--- a/internal/cmd/monitoring_export.go
+++ b/internal/cmd/monitoring_export.go
@@ -1,0 +1,225 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/footprintai/containarium/internal/client"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/spf13/cobra"
+)
+
+// metricsExportProvider backs the --provider flag on `monitoring export
+// enable`. #1069 only ships GCP; AWS is accepted here so the CLI's
+// error message ("not yet implemented") comes from the same server
+// validation the RPC enforces, rather than a second copy of the
+// allow-list living in the CLI.
+var metricsExportProvider string
+
+var monitoringExportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Enable, disable, or inspect cloud-native metrics export",
+	Long: `Opt-in export of host/container infra metrics to the host cloud's
+native monitoring (GCP Cloud Monitoring in the MVP). Disabled by
+default, reversible any time. Enabling probes the host's credentials
+before persisting anything — on GCP this resolves Application Default
+Credentials with the monitoring-write scope; a host with no usable ADC
+fails with an actionable error and nothing is enabled or exported.
+
+Examples:
+  containarium monitoring export enable --provider gcp
+  containarium monitoring export status
+  containarium monitoring export disable`,
+}
+
+var monitoringExportEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable cloud-native metrics export",
+	Long: `Enable opt-in export to the given cloud provider's native
+monitoring. Requires --provider. The daemon probes the host's
+credentials synchronously before persisting anything — on GCP this
+resolves Application Default Credentials (ADC) with the
+monitoring-write scope; failure returns an actionable error (with an
+IAM remediation hint) and nothing is enabled. Takes effect immediately,
+no daemon restart required.
+
+Examples:
+  containarium monitoring export enable --provider gcp`,
+	Args: cobra.NoArgs,
+	RunE: runMetricsExportEnable,
+}
+
+var monitoringExportDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable cloud-native metrics export",
+	Long: `Disable cloud-native metrics export. Emission stops within one
+export interval; no daemon restart required.
+
+Examples:
+  containarium monitoring export disable`,
+	Args: cobra.NoArgs,
+	RunE: runMetricsExportDisable,
+}
+
+var monitoringExportStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show cloud-native metrics export status",
+	Long: `Print whether cloud-native metrics export is enabled, which
+provider it targets, the export interval, and last-known health
+(last success time, last error, failure count — populated once the
+metrics collector lands in a follow-up issue).
+
+Examples:
+  containarium monitoring export status`,
+	Args: cobra.NoArgs,
+	RunE: runMetricsExportStatus,
+}
+
+func init() {
+	monitoringExportEnableCmd.Flags().StringVar(&metricsExportProvider, "provider", "", "cloud provider to export to (gcp)")
+
+	monitoringCmd.AddCommand(monitoringExportCmd)
+	monitoringExportCmd.AddCommand(monitoringExportEnableCmd)
+	monitoringExportCmd.AddCommand(monitoringExportDisableCmd)
+	monitoringExportCmd.AddCommand(monitoringExportStatusCmd)
+}
+
+// parseMetricsExportProvider maps the CLI's lowercase --provider flag
+// to the typed CloudMetricsProvider enum. No magic strings past this
+// boundary — every other layer (client, server, config) speaks the
+// enum. Unknown strings are rejected here (a client-side typo like
+// "gpc"); UNSPECIFIED and AWS are passed through so the server's own
+// validation (InvalidArgument / Unimplemented) is the single source of
+// truth for "is this provider usable".
+func parseMetricsExportProvider(s string) (pb.CloudMetricsProvider, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED, fmt.Errorf("--provider is required (e.g. --provider gcp)")
+	case "gcp":
+		return pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP, nil
+	case "aws":
+		return pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_AWS, nil
+	default:
+		return pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED, fmt.Errorf("unknown provider %q (supported: gcp)", s)
+	}
+}
+
+func runMetricsExportEnable(cmd *cobra.Command, args []string) error {
+	provider, err := parseMetricsExportProvider(metricsExportProvider)
+	if err != nil {
+		return err
+	}
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required for metrics export (no local fallback)")
+	}
+
+	resp, err := setMetricsExportClient(true, provider)
+	if err != nil {
+		return fmt.Errorf("failed to enable cloud metrics export: %w", err)
+	}
+
+	fmt.Printf("✓ cloud metrics export enabled (provider=%s, interval=%ds)\n",
+		metricsExportProviderLabel(resp.Provider), resp.IntervalSeconds)
+	if resp.Message != "" {
+		fmt.Println(resp.Message)
+	}
+	return nil
+}
+
+func runMetricsExportDisable(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required for metrics export (no local fallback)")
+	}
+
+	resp, err := setMetricsExportClient(false, pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED)
+	if err != nil {
+		return fmt.Errorf("failed to disable cloud metrics export: %w", err)
+	}
+
+	fmt.Println("✓ cloud metrics export disabled")
+	if resp.Message != "" {
+		fmt.Println(resp.Message)
+	}
+	return nil
+}
+
+func runMetricsExportStatus(cmd *cobra.Command, args []string) error {
+	if serverAddr == "" {
+		return fmt.Errorf("--server is required for metrics export (no local fallback)")
+	}
+
+	resp, err := getMetricsExportClient()
+	if err != nil {
+		return fmt.Errorf("failed to get cloud metrics export status: %w", err)
+	}
+
+	if !resp.Enabled {
+		fmt.Println("cloud metrics export: disabled")
+		return nil
+	}
+
+	fmt.Printf("cloud metrics export: enabled (provider=%s, interval=%ds)\n",
+		metricsExportProviderLabel(resp.Provider), resp.IntervalSeconds)
+	if resp.LastSuccessAt != nil && resp.LastSuccessAt.IsValid() && resp.LastSuccessAt.AsTime().Unix() > 0 {
+		fmt.Printf("  last success: %s\n", resp.LastSuccessAt.AsTime().Local().Format("2006-01-02 15:04:05 MST"))
+	}
+	if resp.LastError != "" {
+		fmt.Printf("  last error: %s\n", resp.LastError)
+	}
+	if resp.ExportFailures > 0 {
+		fmt.Printf("  export failures: %d\n", resp.ExportFailures)
+	}
+	return nil
+}
+
+// metricsExportProviderLabel renders the enum the way an operator
+// expects to type it back on the CLI (lowercase, matching --provider).
+func metricsExportProviderLabel(p pb.CloudMetricsProvider) string {
+	switch p {
+	case pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP:
+		return "gcp"
+	case pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_AWS:
+		return "aws"
+	default:
+		return "unspecified"
+	}
+}
+
+// setMetricsExportClient and getMetricsExportClient route through
+// whichever transport is active (gRPC or REST), mirroring
+// runMonitoringToggle's httpMode branch in internal/cmd/monitoring.go.
+// This is the one function the MCP tool also calls (internal/mcp/tools.go)
+// — CLI-first per the repo convention.
+func setMetricsExportClient(enabled bool, provider pb.CloudMetricsProvider) (*pb.SetMetricsExportResponse, error) {
+	if httpMode {
+		httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = httpClient.Close() }()
+		return httpClient.SetMetricsExport(enabled, provider)
+	}
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = grpcClient.Close() }()
+	return grpcClient.SetMetricsExport(enabled, provider)
+}
+
+func getMetricsExportClient() (*pb.GetMetricsExportResponse, error) {
+	if httpMode {
+		httpClient, err := client.NewHTTPClient(serverAddr, authToken)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = httpClient.Close() }()
+		return httpClient.GetMetricsExport()
+	}
+	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = grpcClient.Close() }()
+	return grpcClient.GetMetricsExport()
+}

--- a/internal/cmd/monitoring_export_test.go
+++ b/internal/cmd/monitoring_export_test.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// TestParseMetricsExportProvider covers --provider flag parsing:
+// happy path (gcp), the reserved-but-known aws value (passed through
+// so the server's Unimplemented is the single source of truth), and
+// the client-side-only rejections (empty, typo).
+func TestParseMetricsExportProvider(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      pb.CloudMetricsProvider
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:  "gcp",
+			input: "gcp",
+			want:  pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP,
+		},
+		{
+			name:  "GCP uppercase is case-insensitive",
+			input: "GCP",
+			want:  pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP,
+		},
+		{
+			name:  "  gcp  trims whitespace",
+			input: "  gcp  ",
+			want:  pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP,
+		},
+		{
+			name:  "aws is parsed and passed through (server rejects it)",
+			input: "aws",
+			want:  pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_AWS,
+		},
+		{
+			name:      "empty is required",
+			input:     "",
+			wantErr:   true,
+			errSubstr: "required",
+		},
+		{
+			name:      "unknown provider is rejected client-side",
+			input:     "gpc",
+			wantErr:   true,
+			errSubstr: "unknown provider",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMetricsExportProvider(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseMetricsExportProvider(%q) = %v, nil; want error containing %q", tc.input, got, tc.errSubstr)
+				}
+				if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Errorf("error = %q, want substring %q", err.Error(), tc.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("parseMetricsExportProvider(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMetricsExportProviderLabel(t *testing.T) {
+	tests := []struct {
+		provider pb.CloudMetricsProvider
+		want     string
+	}{
+		{pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP, "gcp"},
+		{pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_AWS, "aws"},
+		{pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED, "unspecified"},
+	}
+	for _, tc := range tests {
+		if got := metricsExportProviderLabel(tc.provider); got != tc.want {
+			t.Errorf("metricsExportProviderLabel(%v) = %q, want %q", tc.provider, got, tc.want)
+		}
+	}
+}
+
+// TestRunMetricsExportEnable_RequiresProvider covers the "no --server,
+// no --provider" client-side failure paths without touching the
+// network: parseMetricsExportProvider fires before the --server check,
+// so a bare `enable` with neither flag fails on the provider message.
+func TestRunMetricsExportEnable_RequiresProvider(t *testing.T) {
+	origProvider := metricsExportProvider
+	origServer := serverAddr
+	defer func() {
+		metricsExportProvider = origProvider
+		serverAddr = origServer
+	}()
+
+	metricsExportProvider = ""
+	serverAddr = ""
+
+	err := runMetricsExportEnable(monitoringExportEnableCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --provider is missing")
+	}
+	if !strings.Contains(err.Error(), "--provider is required") {
+		t.Errorf("error = %q, want it to mention --provider", err.Error())
+	}
+}
+
+// TestRunMetricsExportEnable_RequiresServer locks that a valid
+// --provider still needs --server (no local fallback — mirrors
+// runMonitoringToggle's rule in internal/cmd/monitoring.go).
+func TestRunMetricsExportEnable_RequiresServer(t *testing.T) {
+	origProvider := metricsExportProvider
+	origServer := serverAddr
+	defer func() {
+		metricsExportProvider = origProvider
+		serverAddr = origServer
+	}()
+
+	metricsExportProvider = "gcp"
+	serverAddr = ""
+
+	err := runMetricsExportEnable(monitoringExportEnableCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --server is missing")
+	}
+	if !strings.Contains(err.Error(), "--server is required") {
+		t.Errorf("error = %q, want it to mention --server", err.Error())
+	}
+}
+
+func TestRunMetricsExportDisable_RequiresServer(t *testing.T) {
+	origServer := serverAddr
+	defer func() { serverAddr = origServer }()
+	serverAddr = ""
+
+	err := runMetricsExportDisable(monitoringExportDisableCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --server is missing")
+	}
+	if !strings.Contains(err.Error(), "--server is required") {
+		t.Errorf("error = %q, want it to mention --server", err.Error())
+	}
+}
+
+func TestRunMetricsExportStatus_RequiresServer(t *testing.T) {
+	origServer := serverAddr
+	defer func() { serverAddr = origServer }()
+	serverAddr = ""
+
+	err := runMetricsExportStatus(monitoringExportStatusCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when --server is missing")
+	}
+	if !strings.Contains(err.Error(), "--server is required") {
+		t.Errorf("error = %q, want it to mention --server", err.Error())
+	}
+}

--- a/internal/mcp/backend.go
+++ b/internal/mcp/backend.go
@@ -83,6 +83,13 @@ type API interface {
 	DebugContainer(username string) (*DebugContainerResponse, error)
 	TriggerUpgrade(backendID string, force bool) (*TriggerUpgradeResponse, error)
 	GetUpgradeStatus(upgradeID string) (*UpgradeStatusResponse, error)
+	// SetMetricsExport / GetMetricsExport (#1069) toggle and inspect
+	// opt-in export of this host's infra metrics to its cloud's native
+	// monitoring. Host-level like GetSystemInfo — the credential probe
+	// (GCP ADC) is specific to the box the daemon runs on, so it has no
+	// tenant-safe meaning on the hosted control plane.
+	SetMetricsExport(enabled bool, provider string) (*SetMetricsExportResponse, error)
+	GetMetricsExport() (*GetMetricsExportResponse, error)
 	// InstallZap downloads and installs OWASP ZAP into this host's
 	// security container. Host-level — a daemon manages exactly one
 	// security container, so there's no per-tenant scoping.
@@ -145,6 +152,14 @@ func (cloudClient) GetUpgradeStatus(string) (*UpgradeStatusResponse, error) {
 
 func (cloudClient) InstallZap() (*InstallZapResponse, error) {
 	return nil, errUnsupportedOnCloud("install_zap", "the platform provisions ZAP on managed hosts")
+}
+
+func (cloudClient) SetMetricsExport(bool, string) (*SetMetricsExportResponse, error) {
+	return nil, errUnsupportedOnCloud("set_metrics_export", "the credential probe is specific to a BYOC host; run this against the host's own daemon")
+}
+
+func (cloudClient) GetMetricsExport() (*GetMetricsExportResponse, error) {
+	return nil, errUnsupportedOnCloud("get_metrics_export", "")
 }
 
 // newBackend builds the API the handlers use, classifying the target from the

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -889,6 +889,74 @@ func (c *Client) GetSystemInfo() (*GetSystemInfoResponse, error) {
 	return &resp, nil
 }
 
+// metricsExportProviderWireName maps the CLI-facing lowercase provider
+// name ("gcp") to the full CloudMetricsProvider enum name the wire
+// protocol (protojson) expects. Mirrors internal/cmd/monitoring_export.go's
+// parseMetricsExportProvider without importing pkg/pb — this package
+// deliberately keeps its own plain-struct wire types rather than the
+// generated proto types (see the ListBackendsResponse comment above).
+func metricsExportProviderWireName(provider string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "gcp":
+		return "CLOUD_METRICS_PROVIDER_GCP", nil
+	case "aws":
+		// Passed through deliberately — the daemon's Unimplemented for
+		// AWS is the single source of truth, not a second copy of the
+		// allow-list here.
+		return "CLOUD_METRICS_PROVIDER_AWS", nil
+	default:
+		return "", fmt.Errorf("unknown cloud metrics export provider %q (supported: gcp)", provider)
+	}
+}
+
+// SetMetricsExport enables or disables opt-in export of host/container
+// infra metrics to the host cloud's native monitoring (#1069). provider
+// is required when enabled=true ("gcp"; "aws" is accepted and rejected
+// server-side with Unimplemented) and ignored when disabling.
+func (c *Client) SetMetricsExport(enabled bool, provider string) (*SetMetricsExportResponse, error) {
+	wireProvider := "CLOUD_METRICS_PROVIDER_UNSPECIFIED"
+	if enabled {
+		wp, err := metricsExportProviderWireName(provider)
+		if err != nil {
+			return nil, err
+		}
+		wireProvider = wp
+	}
+
+	body, err := json.Marshal(map[string]interface{}{
+		"enabled":  enabled,
+		"provider": wireProvider,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	respBody, err := c.doRequest("POST", "/v1/system/metrics-export", body)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp SetMetricsExportResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
+// GetMetricsExport returns the current cloud-native metrics export
+// configuration and last-known health (#1069).
+func (c *Client) GetMetricsExport() (*GetMetricsExportResponse, error) {
+	respBody, err := c.doRequest("GET", "/v1/system/metrics-export", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp GetMetricsExportResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return &resp, nil
+}
+
 // LatestReleaseResponse is the GET /v1/releases/latest body (#354).
 type LatestReleaseResponse struct {
 	LatestRelease   string `json:"latestRelease"`
@@ -1499,6 +1567,28 @@ type GetMetricsResponse struct {
 
 type GetSystemInfoResponse struct {
 	Info SystemInfo `json:"info"`
+}
+
+// SetMetricsExportResponse mirrors the wire response of
+// ContainerService.SetMetricsExport (#1069).
+type SetMetricsExportResponse struct {
+	Message         string `json:"message"`
+	Enabled         bool   `json:"enabled"`
+	Provider        string `json:"provider"`
+	IntervalSeconds int32  `json:"intervalSeconds"`
+}
+
+// GetMetricsExportResponse mirrors the wire response of
+// ContainerService.GetMetricsExport (#1069). LastSuccessAt, LastError,
+// and ExportFailures are zero-valued until the metrics collector
+// (#1070/#1071) is wired.
+type GetMetricsExportResponse struct {
+	Enabled         bool      `json:"enabled"`
+	Provider        string    `json:"provider"`
+	IntervalSeconds int32     `json:"intervalSeconds"`
+	LastSuccessAt   string    `json:"lastSuccessAt,omitempty"`
+	LastError       string    `json:"lastError,omitempty"`
+	ExportFailures  flexInt64 `json:"exportFailures,omitempty"`
 }
 
 // ListBackendsResponse mirrors the /v1/backends wire shape — the proto-first

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -22,8 +22,8 @@ func TestServerCreation(t *testing.T) {
 	assert.NotNil(t, server)
 	assert.Equal(t, config, server.config)
 	assert.NotNil(t, server.client)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960).
-	assert.Len(t, server.tools, 56, "Should have 56 tools registered")
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069).
+	assert.Len(t, server.tools, 58, "Should have 58 tools registered")
 }
 
 // TestServerTools tests tool registration
@@ -127,8 +127,8 @@ func TestHandleToolsList(t *testing.T) {
 
 	tools, ok := result["tools"].([]map[string]interface{})
 	require.True(t, ok)
-	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960).
-	assert.Len(t, tools, 56)
+	// 30 base (+check_for_updates +upgrade_backend +get_upgrade_status, #354) + 3 runner-provision + 4 compose-autostart (#325) + 2 recipes + 3 backups + connect (#453) + 2 agent-skills (#562) + call_agent (#570) + 2 crews (#584) + delete_route + install_zap (#960) + set_metrics_export + get_metrics_export (#1069).
+	assert.Len(t, tools, 58)
 
 	// Check first tool structure
 	firstTool := tools[0]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -423,6 +423,35 @@ func (s *Server) registerTools() {
 			Handler: handleToggleMonitoring,
 		},
 		{
+			Name:        "set_metrics_export",
+			Description: "Enable or disable opt-in export of this host's infra metrics to its cloud's native monitoring (GCP Cloud Monitoring in the MVP; disabled by default). Enabling probes the host's credentials synchronously before persisting anything — on GCP this resolves Application Default Credentials with the monitoring-write scope; a host with no usable ADC fails with an actionable error and nothing is exported. Disabling stops emission within one export interval. No daemon restart required either way. Host-level — not available on the hosted control plane, run it against the host's own daemon.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"enabled": map[string]interface{}{
+						"type":        "boolean",
+						"description": "true to enable export (provider is required), false to disable it (provider is ignored)",
+					},
+					"provider": map[string]interface{}{
+						"type":        "string",
+						"description": "Cloud provider to export to. Required when enabled=true. Only \"gcp\" is implemented; \"aws\" is a reserved value the daemon rejects with an unimplemented error.",
+						"enum":        []string{"gcp", "aws"},
+					},
+				},
+				"required": []string{"enabled"},
+			},
+			Handler: handleSetMetricsExport,
+		},
+		{
+			Name:        "get_metrics_export",
+			Description: "Get the current cloud-native metrics export configuration and last-known health for this host (enabled, provider, interval, last success time, last error, failure count). Host-level — not available on the hosted control plane, run it against the host's own daemon.",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+			Handler: handleGetMetricsExport,
+		},
+		{
 			Name:        "delete_container",
 			Description: "Delete a container permanently",
 			InputSchema: map[string]interface{}{
@@ -1266,6 +1295,12 @@ func toolScopeAssignments() map[string]string {
 		"get_upgrade_status": auth.ScopeContainersRead,
 		"list_backends":      auth.ScopeContainersRead,
 		"get_backend":        auth.ScopeContainersRead,
+		// cloud-native metrics export toggle — a system/daemon-level
+		// setting, scoped the same as its closest sibling
+		// (toggle_monitoring / get_system_info) rather than introducing
+		// a new scope for one feature.
+		"set_metrics_export": auth.ScopeContainersWrite,
+		"get_metrics_export": auth.ScopeContainersRead,
 		// validate-gpu creates+deletes a throwaway container (a write op);
 		// the daemon additionally enforces admin role.
 		"backend_validate_gpu": auth.ScopeContainersWrite,
@@ -1685,6 +1720,52 @@ func handleToggleMonitoring(client API, args map[string]interface{}) (string, er
 		return "", fmt.Errorf("failed to toggle monitoring: %w", err)
 	}
 	return fmt.Sprintf("✅ %s (monitoring_enabled=%v)", resp.Message, resp.MonitoringEnabled), nil
+}
+
+// handleSetMetricsExport is a thin wrapper over client.SetMetricsExport
+// (#1069) — the same client method the CLI's `containarium monitoring
+// export enable/disable` calls (internal/cmd/monitoring_export.go),
+// per the repo's CLI-first convention.
+func handleSetMetricsExport(client API, args map[string]interface{}) (string, error) {
+	enabled, ok := args["enabled"].(bool)
+	if !ok {
+		return "", fmt.Errorf("enabled (bool) is required")
+	}
+	provider, _ := args["provider"].(string)
+	if enabled && provider == "" {
+		return "", fmt.Errorf("provider is required when enabled=true (e.g. \"gcp\")")
+	}
+
+	resp, err := client.SetMetricsExport(enabled, provider)
+	if err != nil {
+		return "", fmt.Errorf("failed to set metrics export: %w", err)
+	}
+	return fmt.Sprintf("✅ %s (enabled=%v, provider=%s, interval_seconds=%d)",
+		resp.Message, resp.Enabled, resp.Provider, resp.IntervalSeconds), nil
+}
+
+// handleGetMetricsExport is a thin wrapper over client.GetMetricsExport
+// (#1069) — the same client method the CLI's `containarium monitoring
+// export status` calls.
+func handleGetMetricsExport(client API, args map[string]interface{}) (string, error) {
+	resp, err := client.GetMetricsExport()
+	if err != nil {
+		return "", fmt.Errorf("failed to get metrics export status: %w", err)
+	}
+	if !resp.Enabled {
+		return "cloud metrics export: disabled", nil
+	}
+	msg := fmt.Sprintf("cloud metrics export: enabled (provider=%s, interval_seconds=%d)", resp.Provider, resp.IntervalSeconds)
+	if resp.LastSuccessAt != "" {
+		msg += fmt.Sprintf(", last_success_at=%s", resp.LastSuccessAt)
+	}
+	if resp.LastError != "" {
+		msg += fmt.Sprintf(", last_error=%s", resp.LastError)
+	}
+	if resp.ExportFailures > 0 {
+		msg += fmt.Sprintf(", export_failures=%d", resp.ExportFailures)
+	}
+	return msg, nil
 }
 
 func handleDeleteContainer(client API, args map[string]interface{}) (string, error) {

--- a/internal/metrics/cloudexport/config.go
+++ b/internal/metrics/cloudexport/config.go
@@ -1,0 +1,42 @@
+package cloudexport
+
+import (
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// DefaultIntervalSeconds is the fixed export cadence for the MVP. #1069
+// does not expose an operator knob to change it — see the "cost guard"
+// floor in docs/CLOUD-NATIVE-METRICS-EXPORT-DESIGN.md (custom metrics
+// are billed per ingested sample).
+const DefaultIntervalSeconds = 60
+
+// ConfigStoreKey is the single daemon-config-store key the whole Config
+// struct is persisted under (JSON-encoded). One key holding the
+// complete struct — rather than spreading Enabled/Provider/
+// IntervalSeconds across three loose keys — means every read and write
+// is a full-config round trip by construction, not a partial update
+// that could clobber a sibling field (the failure mode fixed for the
+// BYOC ingress "listen" array in #1062/#1064).
+const ConfigStoreKey = "metrics_export_config"
+
+// Config is the typed, persisted state of the cloud-native metrics
+// export toggle (#1069): whether export is on, which provider it
+// targets, and the export cadence. It round-trips through
+// SetMetricsExport / GetMetricsExport and survives a daemon restart via
+// the daemon's existing config store.
+type Config struct {
+	Enabled         bool                    `json:"enabled"`
+	Provider        pb.CloudMetricsProvider `json:"provider"`
+	IntervalSeconds int32                   `json:"interval_seconds"`
+}
+
+// DefaultConfig returns the zero-value config: export disabled, no
+// provider configured, the fixed default interval. This is what a host
+// that has never called SetMetricsExport reports from GetMetricsExport.
+func DefaultConfig() Config {
+	return Config{
+		Enabled:         false,
+		Provider:        pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED,
+		IntervalSeconds: DefaultIntervalSeconds,
+	}
+}

--- a/internal/metrics/cloudexport/gcp.go
+++ b/internal/metrics/cloudexport/gcp.go
@@ -1,0 +1,62 @@
+package cloudexport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"golang.org/x/oauth2/google"
+)
+
+// monitoringWriteScope is the OAuth2 scope required to write custom
+// metrics to Google Cloud Monitoring (CreateTimeSeries).
+const monitoringWriteScope = "https://www.googleapis.com/auth/monitoring.write"
+
+// gcpCredentialsLookup resolves Application Default Credentials scoped
+// for Cloud Monitoring writes. It is a package-level var — rather than a
+// direct call to google.FindDefaultCredentials — so tests can inject a
+// fake lookup (missing ADC, or a credential whose token source fails)
+// without touching the network or the real ADC search path
+// (GOOGLE_APPLICATION_CREDENTIALS, gcloud's well-known file, or the GCE
+// metadata server).
+var gcpCredentialsLookup = func(ctx context.Context) (*google.Credentials, error) {
+	return google.FindDefaultCredentials(ctx, monitoringWriteScope)
+}
+
+// gcpSink implements Sink for Google Cloud Monitoring.
+type gcpSink struct{}
+
+// NewGCPSink returns the GCP Sink implementation.
+func NewGCPSink() Sink { return &gcpSink{} }
+
+// NewExporter is not yet implemented — the Cloud Monitoring OTel
+// exporter and the CloudExportCollector that would call this land with
+// #1070/#1071. #1069 only needs Probe to gate the enable-time
+// credential check.
+func (g *gcpSink) NewExporter(ctx context.Context, cfg SinkConfig) (sdkmetric.Exporter, error) {
+	return nil, errors.New("cloudexport: gcp exporter not yet implemented (lands with #1070/#1071)")
+}
+
+// Probe resolves ADC with the Cloud Monitoring write scope and confirms
+// a token can actually be minted from it. A host with no ADC configured,
+// or ADC that can't produce a usable token (revoked, wrong scope, no
+// service account attached), fails with an actionable IAM hint —
+// SetMetricsExport surfaces this as FAILED_PRECONDITION and persists
+// nothing.
+func (g *gcpSink) Probe(ctx context.Context) error {
+	const iamHint = "run 'gcloud auth application-default login' for a workstation, " +
+		"or attach a service account with the roles/monitoring.metricWriter IAM role to this VM"
+
+	creds, err := gcpCredentialsLookup(ctx)
+	if err != nil {
+		return fmt.Errorf("no Application Default Credentials found for GCP Cloud Monitoring (%s): %w", iamHint, err)
+	}
+	if creds == nil || creds.TokenSource == nil {
+		return fmt.Errorf("resolved GCP Application Default Credentials have no usable token source (%s)", iamHint)
+	}
+	if _, err := creds.TokenSource.Token(); err != nil {
+		return fmt.Errorf("GCP Application Default Credentials could not mint a monitoring-write token (%s): %w", iamHint, err)
+	}
+	return nil
+}

--- a/internal/metrics/cloudexport/gcp_test.go
+++ b/internal/metrics/cloudexport/gcp_test.go
@@ -1,0 +1,112 @@
+package cloudexport
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// fakeTokenSource lets tests simulate a credential that resolves but
+// can't actually mint a token (revoked, wrong scope, expired refresh
+// token, ...) without any network call.
+type fakeTokenSource struct {
+	token *oauth2.Token
+	err   error
+}
+
+func (f *fakeTokenSource) Token() (*oauth2.Token, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.token, nil
+}
+
+// TestProbe_ADC is the table from the design doc's test strategy:
+// (no ADC / wrong-scope token / ok) -> (actionable error / actionable
+// error / nil). No network or filesystem ADC search is exercised —
+// gcpCredentialsLookup is swapped for the duration of each case.
+func TestProbe_ADC(t *testing.T) {
+	tests := []struct {
+		name    string
+		lookup  func(ctx context.Context) (*google.Credentials, error)
+		wantErr bool
+		wantSub string // substring the error must contain, if wantErr
+	}{
+		{
+			name: "no ADC configured",
+			lookup: func(ctx context.Context) (*google.Credentials, error) {
+				return nil, errors.New("could not find default credentials")
+			},
+			wantErr: true,
+			wantSub: "roles/monitoring.metricWriter",
+		},
+		{
+			name: "credentials resolve but token source is nil",
+			lookup: func(ctx context.Context) (*google.Credentials, error) {
+				return &google.Credentials{}, nil
+			},
+			wantErr: true,
+			wantSub: "roles/monitoring.metricWriter",
+		},
+		{
+			name: "credentials resolve but token mint fails (revoked / wrong scope)",
+			lookup: func(ctx context.Context) (*google.Credentials, error) {
+				return &google.Credentials{
+					TokenSource: &fakeTokenSource{err: errors.New("invalid_grant: token has been revoked")},
+				}, nil
+			},
+			wantErr: true,
+			wantSub: "roles/monitoring.metricWriter",
+		},
+		{
+			name: "ok",
+			lookup: func(ctx context.Context) (*google.Credentials, error) {
+				return &google.Credentials{
+					TokenSource: &fakeTokenSource{token: &oauth2.Token{
+						AccessToken: "fake-token",
+						Expiry:      time.Now().Add(time.Hour),
+					}},
+				}, nil
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := gcpCredentialsLookup
+			gcpCredentialsLookup = tc.lookup
+			defer func() { gcpCredentialsLookup = orig }()
+
+			sink := NewGCPSink()
+			err := sink.Probe(context.Background())
+
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			if tc.wantErr && tc.wantSub != "" && !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q does not contain expected hint %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestGCPSink_NewExporter_NotYetImplemented locks the #1069 scope
+// decision: the actual Cloud Monitoring exporter lands with
+// #1070/#1071, so NewExporter must fail loudly (not silently no-op)
+// until then.
+func TestGCPSink_NewExporter_NotYetImplemented(t *testing.T) {
+	sink := NewGCPSink()
+	_, err := sink.NewExporter(context.Background(), SinkConfig{})
+	if err == nil {
+		t.Fatal("expected NewExporter to error until #1070/#1071 wire the real exporter")
+	}
+}

--- a/internal/metrics/cloudexport/sink.go
+++ b/internal/metrics/cloudexport/sink.go
@@ -1,0 +1,46 @@
+// Package cloudexport is the seam for opt-in export of Containarium's
+// host/container infra metrics to a host cloud's native monitoring
+// (GCP Cloud Monitoring first — #1069/#1070/#1071).
+//
+// #1069 delivers the toggle (enable/disable/status), typed config
+// persistence, and the enable-time credential probe. The full collector
+// (CloudExportCollector + Sources + the allowlisted OTel instrument set
+// described in docs/CLOUD-NATIVE-METRICS-EXPORT-DESIGN.md) lands with
+// #1070 (host series) and #1071 (container series); this package is the
+// skeleton those land into.
+package cloudexport
+
+import (
+	"context"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// SinkConfig carries the parameters a Sink needs to build its OTel metric
+// exporter. Provider-specific fields (GCP project ID, AWS region, ...)
+// land here as #1070/#1071 wire the collector; #1069 only needs enough
+// surface to define the interface.
+type SinkConfig struct {
+	// ProjectID is the GCP project the exported series should land in.
+	// Empty lets the resource detector infer it from the metadata server.
+	ProjectID string
+}
+
+// Sink abstracts one cloud provider's metrics backend. GCP is the only
+// implementation in the MVP (gcpSink, gcp.go); AWS is a reserved
+// CloudMetricsProvider enum value with no Sink registered — the server
+// layer returns Unimplemented for it before ever reaching this
+// interface.
+type Sink interface {
+	// NewExporter builds the OTel SDK metric exporter that pushes to
+	// this provider. Not implemented by any Sink as of #1069 — the
+	// CloudExportCollector that would call it lands with #1070/#1071.
+	NewExporter(ctx context.Context, cfg SinkConfig) (sdkmetric.Exporter, error)
+
+	// Probe verifies the host can authenticate to this provider's
+	// monitoring API right now, without emitting anything. Returns nil
+	// when export can proceed; otherwise an error carrying an
+	// actionable remediation hint. The server layer maps a non-nil
+	// error to FAILED_PRECONDITION and persists nothing.
+	Probe(ctx context.Context) error
+}

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/guacamole"
 	"github.com/footprintai/containarium/internal/integrity"
+	"github.com/footprintai/containarium/internal/metrics/cloudexport"
 	"github.com/footprintai/containarium/internal/releasecheck"
 	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/internal/secrets"
@@ -97,6 +98,20 @@ type ContainerServer struct {
 	coreServices       *CoreServices
 	daemonConfigStore  *app.DaemonConfigStore
 	peerPool           *PeerPool
+	// Cloud-native metrics export (#1069). metricsExportMu guards the
+	// in-memory config so SetMetricsExport/GetMetricsExport round-trip
+	// without a daemon restart; daemonConfigStore (when present) makes
+	// the toggle survive one. metricsExportSinks maps a provider enum
+	// value to its Sink so the enable-time credential probe is
+	// injectable in tests without touching real GCP ADC. Both are wired
+	// once at startup (DualServer calls SetMetricsExportSinks with the
+	// real gcpSink) and otherwise left nil, which GetMetricsExport
+	// treats as "never configured" and SetMetricsExport treats as
+	// Unimplemented for that provider.
+	metricsExportMu           sync.RWMutex
+	metricsExportConfig       cloudexport.Config
+	metricsExportConfigLoaded bool
+	metricsExportSinks        map[pb.CloudMetricsProvider]cloudexport.Sink
 	// localHealthCheckFn overrides localBackendHealthy's real Incus liveness
 	// probe (#920) — set by tests to simulate a wedged/unresponsive local
 	// backend without a live Incus daemon. nil in production; the real probe

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -249,6 +249,11 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 		return nil, fmt.Errorf("failed to create container server: %w", err)
 	}
 
+	// Wire the real cloud-metrics-export sinks (#1069). Without this,
+	// SetMetricsExport always falls through the nil-sink path and
+	// returns Unimplemented even with valid GCP credentials.
+	containerServer.SetMetricsExportSinks(defaultMetricsExportSinks())
+
 	// Create token manager. Refuses to start if the JWT secret is
 	// shorter than auth.MinSecretKeyLen — fail-closed on weak crypto
 	// (audit finding A-MED-2).

--- a/internal/server/metrics_export_server.go
+++ b/internal/server/metrics_export_server.go
@@ -13,13 +13,28 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// defaultMetricsExportSinks is the production sink registry passed to
+// SetMetricsExportSinks by NewDualServer at startup. Extracted to its
+// own named, unit-tested function rather than an inline map literal at
+// the call site — a PR review of #1069 caught exactly this call being
+// silently absent from production startup (sinks only ever injected by
+// hand in tests), which made every real daemon return Unimplemented
+// for GCP regardless of valid credentials. AWS has no Sink
+// implementation yet and is intentionally left unregistered — the
+// enum-validation check in SetMetricsExport rejects it before any sink
+// lookup happens.
+func defaultMetricsExportSinks() map[pb.CloudMetricsProvider]cloudexport.Sink {
+	return map[pb.CloudMetricsProvider]cloudexport.Sink{
+		pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP: cloudexport.NewGCPSink(),
+	}
+}
+
 // SetMetricsExportSinks wires the provider -> Sink map consulted by
 // SetMetricsExport's enable-time credential probe. Called once by
-// DualServer at startup with the real gcpSink (internal/metrics/
-// cloudexport.NewGCPSink()); tests inject fakes so the probe never
-// touches real GCP ADC. A provider absent from the map (including AWS,
-// which has no Sink implementation yet) makes SetMetricsExport return
-// Unimplemented.
+// DualServer at startup with defaultMetricsExportSinks(); tests inject
+// fakes so the probe never touches real GCP ADC. A provider absent from
+// the map (including AWS, which has no Sink implementation yet) makes
+// SetMetricsExport return Unimplemented.
 func (s *ContainerServer) SetMetricsExportSinks(sinks map[pb.CloudMetricsProvider]cloudexport.Sink) {
 	s.metricsExportMu.Lock()
 	defer s.metricsExportMu.Unlock()

--- a/internal/server/metrics_export_server.go
+++ b/internal/server/metrics_export_server.go
@@ -1,0 +1,197 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/metrics/cloudexport"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// SetMetricsExportSinks wires the provider -> Sink map consulted by
+// SetMetricsExport's enable-time credential probe. Called once by
+// DualServer at startup with the real gcpSink (internal/metrics/
+// cloudexport.NewGCPSink()); tests inject fakes so the probe never
+// touches real GCP ADC. A provider absent from the map (including AWS,
+// which has no Sink implementation yet) makes SetMetricsExport return
+// Unimplemented.
+func (s *ContainerServer) SetMetricsExportSinks(sinks map[pb.CloudMetricsProvider]cloudexport.Sink) {
+	s.metricsExportMu.Lock()
+	defer s.metricsExportMu.Unlock()
+	s.metricsExportSinks = sinks
+}
+
+func (s *ContainerServer) metricsExportSink(provider pb.CloudMetricsProvider) cloudexport.Sink {
+	s.metricsExportMu.RLock()
+	defer s.metricsExportMu.RUnlock()
+	if s.metricsExportSinks == nil {
+		return nil
+	}
+	return s.metricsExportSinks[provider]
+}
+
+// getMetricsExportConfig returns the current cloud metrics export
+// config, hydrating from the persisted store on first access so a
+// daemon restart doesn't silently forget an enabled export. Once
+// loaded, the in-memory copy is authoritative — SetMetricsExport keeps
+// it and the store in sync on every write.
+func (s *ContainerServer) getMetricsExportConfig(ctx context.Context) cloudexport.Config {
+	s.metricsExportMu.RLock()
+	loaded := s.metricsExportConfigLoaded
+	cfg := s.metricsExportConfig
+	s.metricsExportMu.RUnlock()
+	if loaded {
+		return cfg
+	}
+
+	cfg = cloudexport.DefaultConfig()
+	if s.daemonConfigStore != nil {
+		if raw, err := s.daemonConfigStore.Get(ctx, cloudexport.ConfigStoreKey); err == nil && raw != "" {
+			var persisted cloudexport.Config
+			if jsonErr := json.Unmarshal([]byte(raw), &persisted); jsonErr == nil {
+				cfg = persisted
+			} else {
+				log.Printf("Warning: failed to parse persisted metrics export config, using defaults: %v", jsonErr)
+			}
+		}
+	}
+
+	s.metricsExportMu.Lock()
+	s.metricsExportConfig = cfg
+	s.metricsExportConfigLoaded = true
+	s.metricsExportMu.Unlock()
+	return cfg
+}
+
+// saveMetricsExportConfig updates the in-memory config (so a subsequent
+// GetMetricsExport reflects it with no daemon restart) and, when a
+// daemonConfigStore is wired, persists the whole struct as one
+// JSON-encoded value under cloudexport.ConfigStoreKey. One key holding
+// the complete struct is a full-config round trip by construction on
+// every write — there is no partial-field update that could clobber a
+// sibling setting the way a scoped PUT once did to the BYOC ingress
+// "listen" array (#1062/#1064).
+func (s *ContainerServer) saveMetricsExportConfig(ctx context.Context, cfg cloudexport.Config) {
+	s.metricsExportMu.Lock()
+	s.metricsExportConfig = cfg
+	s.metricsExportConfigLoaded = true
+	s.metricsExportMu.Unlock()
+
+	if s.daemonConfigStore == nil {
+		return
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		log.Printf("Warning: failed to marshal metrics export config: %v", err)
+		return
+	}
+	if err := s.daemonConfigStore.Set(ctx, cloudexport.ConfigStoreKey, string(raw)); err != nil {
+		log.Printf("Warning: failed to persist metrics export config: %v", err)
+	}
+}
+
+// SetMetricsExport enables or disables opt-in export of host/container
+// infra metrics to the host cloud's native monitoring (#1069). Enabling
+// requires a supported provider (currently just GCP — AWS is a reserved
+// enum value that returns Unimplemented) and a synchronous credential
+// probe against that provider; a failed probe returns FailedPrecondition
+// with the sink's remediation hint and persists nothing. Disabling
+// always succeeds and stops emission within one export interval once
+// the collector (#1070/#1071) is wired — for #1069 it flips the
+// persisted flag immediately, which is what a not-yet-built collector
+// would poll.
+func (s *ContainerServer) SetMetricsExport(ctx context.Context, req *pb.SetMetricsExportRequest) (*pb.SetMetricsExportResponse, error) {
+	// Mirrors GetSystemInfo: this exposes/controls host-level
+	// configuration, not anything tenant-scoped. A user token has no
+	// legitimate reason to flip a host's cloud-billing-relevant export
+	// toggle.
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+
+	current := s.getMetricsExportConfig(ctx)
+
+	if !req.Enabled {
+		current.Enabled = false
+		if current.IntervalSeconds == 0 {
+			current.IntervalSeconds = cloudexport.DefaultIntervalSeconds
+		}
+		s.saveMetricsExportConfig(ctx, current)
+		return &pb.SetMetricsExportResponse{
+			Message:         "cloud metrics export disabled",
+			Enabled:         false,
+			Provider:        current.Provider,
+			IntervalSeconds: current.IntervalSeconds,
+		}, nil
+	}
+
+	switch req.Provider {
+	case pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED:
+		return nil, status.Error(codes.InvalidArgument, "provider is required to enable cloud metrics export")
+	case pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_AWS:
+		return nil, status.Error(codes.Unimplemented, "AWS cloud metrics export is not yet implemented — only gcp is supported")
+	case pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP:
+		// supported, fall through to the probe below.
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unknown cloud metrics export provider %v", req.Provider)
+	}
+
+	sink := s.metricsExportSink(req.Provider)
+	if sink == nil {
+		return nil, status.Errorf(codes.Unimplemented, "no metrics export sink registered for provider %v", req.Provider)
+	}
+	if err := sink.Probe(ctx); err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "cloud metrics export credential check failed: %v", err)
+	}
+
+	newCfg := cloudexport.Config{
+		Enabled:         true,
+		Provider:        req.Provider,
+		IntervalSeconds: cloudexport.DefaultIntervalSeconds,
+	}
+	s.saveMetricsExportConfig(ctx, newCfg)
+
+	return &pb.SetMetricsExportResponse{
+		Message:         fmt.Sprintf("cloud metrics export enabled for %s", metricsExportProviderLabel(req.Provider)),
+		Enabled:         true,
+		Provider:        req.Provider,
+		IntervalSeconds: newCfg.IntervalSeconds,
+	}, nil
+}
+
+// GetMetricsExport reports the current cloud metrics export
+// configuration and last-known health. last_success_at, last_error, and
+// export_failures are zero-valued until the collector (#1070/#1071) is
+// wired — #1069 delivers the toggle, config persistence, and the
+// enable-time credential probe only.
+func (s *ContainerServer) GetMetricsExport(ctx context.Context, req *pb.GetMetricsExportRequest) (*pb.GetMetricsExportResponse, error) {
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+
+	cfg := s.getMetricsExportConfig(ctx)
+	return &pb.GetMetricsExportResponse{
+		Enabled:         cfg.Enabled,
+		Provider:        cfg.Provider,
+		IntervalSeconds: cfg.IntervalSeconds,
+	}, nil
+}
+
+func metricsExportProviderLabel(p pb.CloudMetricsProvider) string {
+	switch p {
+	case pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP:
+		return "gcp"
+	case pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_AWS:
+		return "aws"
+	default:
+		return "unspecified"
+	}
+}

--- a/internal/server/metrics_export_server_test.go
+++ b/internal/server/metrics_export_server_test.go
@@ -14,6 +14,32 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// TestDefaultMetricsExportSinks_RegistersGCP pins exactly the gap a PR
+// review of #1069 found: NewDualServer must actually call
+// SetMetricsExportSinks(defaultMetricsExportSinks()) at startup, or
+// every real daemon returns Unimplemented for GCP regardless of valid
+// credentials — a failure mode the handler tests above can't catch
+// because they inject a fake sink directly into a bare ContainerServer.
+// This test pins defaultMetricsExportSinks' own contract (GCP
+// registered, AWS deliberately absent); dual_server.go wiring it into
+// NewDualServer is a one-line call, verified by reading the source
+// rather than booting a full daemon (NewContainerServer needs a real
+// incus/runtime backend unavailable in unit tests).
+func TestDefaultMetricsExportSinks_RegistersGCP(t *testing.T) {
+	sinks := defaultMetricsExportSinks()
+
+	gcpSink, ok := sinks[pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP]
+	if !ok || gcpSink == nil {
+		t.Fatalf("defaultMetricsExportSinks() has no GCP sink registered: %+v", sinks)
+	}
+	if _, aws := sinks[pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_AWS]; aws {
+		t.Errorf("AWS should not be registered yet (no Sink implementation) — SetMetricsExport's enum check must reject it before any sink lookup")
+	}
+	if len(sinks) != 1 {
+		t.Errorf("defaultMetricsExportSinks() = %d entries, want exactly 1 (GCP only)", len(sinks))
+	}
+}
+
 // fakeMetricsExportSink lets handler tests control Probe's outcome
 // without touching real GCP ADC.
 type fakeMetricsExportSink struct {

--- a/internal/server/metrics_export_server_test.go
+++ b/internal/server/metrics_export_server_test.go
@@ -1,0 +1,226 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/metrics/cloudexport"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeMetricsExportSink lets handler tests control Probe's outcome
+// without touching real GCP ADC.
+type fakeMetricsExportSink struct {
+	probeErr error
+	probed   int
+}
+
+func (f *fakeMetricsExportSink) NewExporter(ctx context.Context, cfg cloudexport.SinkConfig) (sdkmetric.Exporter, error) {
+	return nil, errors.New("not used in tests")
+}
+
+func (f *fakeMetricsExportSink) Probe(ctx context.Context) error {
+	f.probed++
+	return f.probeErr
+}
+
+// newMetricsExportTestServer builds a bare ContainerServer wired with a
+// fake GCP sink so SetMetricsExport's probe never touches the network.
+func newMetricsExportTestServer(gcpProbeErr error) (*ContainerServer, *fakeMetricsExportSink) {
+	sink := &fakeMetricsExportSink{probeErr: gcpProbeErr}
+	s := &ContainerServer{}
+	s.SetMetricsExportSinks(map[pb.CloudMetricsProvider]cloudexport.Sink{
+		pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP: sink,
+	})
+	return s, sink
+}
+
+func TestSetMetricsExport_RejectsNonAdmin(t *testing.T) {
+	s, _ := newMetricsExportTestServer(nil)
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "user")
+
+	_, err := s.SetMetricsExport(ctx, &pb.SetMetricsExportRequest{
+		Enabled:  true,
+		Provider: pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP,
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin must be denied; got %v (%v)", status.Code(err), err)
+	}
+}
+
+func TestGetMetricsExport_RejectsNonAdmin(t *testing.T) {
+	s, _ := newMetricsExportTestServer(nil)
+	ctx := auth.ContextWithTestSubject(context.Background(), "alice", "user")
+
+	_, err := s.GetMetricsExport(ctx, &pb.GetMetricsExportRequest{})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("non-admin must be denied; got %v (%v)", status.Code(err), err)
+	}
+}
+
+// TestSetMetricsExport_EnumValidation is the design doc's table:
+// UNSPECIFIED -> InvalidArgument, AWS -> Unimplemented, GCP -> ok
+// (probe permitting).
+func TestSetMetricsExport_EnumValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider pb.CloudMetricsProvider
+		wantCode codes.Code
+	}{
+		{
+			name:     "unspecified provider is InvalidArgument",
+			provider: pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED,
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:     "AWS is Unimplemented",
+			provider: pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_AWS,
+			wantCode: codes.Unimplemented,
+		},
+		{
+			name:     "GCP with a healthy probe succeeds",
+			provider: pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP,
+			wantCode: codes.OK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := newMetricsExportTestServer(nil)
+			resp, err := s.SetMetricsExport(testCtx(), &pb.SetMetricsExportRequest{
+				Enabled:  true,
+				Provider: tc.provider,
+			})
+			if tc.wantCode == codes.OK {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !resp.Enabled || resp.Provider != tc.provider {
+					t.Errorf("response = %+v, want enabled=true provider=%v", resp, tc.provider)
+				}
+				return
+			}
+			if status.Code(err) != tc.wantCode {
+				t.Fatalf("error = %v, want code %v", err, tc.wantCode)
+			}
+		})
+	}
+}
+
+// TestSetMetricsExport_ProbeFailure_PersistsNothing locks the
+// acceptance criterion: a host with no resolvable GCP credentials fails
+// the enable call with FailedPrecondition and the config remains
+// disabled/unconfigured afterward.
+func TestSetMetricsExport_ProbeFailure_PersistsNothing(t *testing.T) {
+	s, sink := newMetricsExportTestServer(errors.New("no Application Default Credentials found (attach roles/monitoring.metricWriter)"))
+
+	_, err := s.SetMetricsExport(testCtx(), &pb.SetMetricsExportRequest{
+		Enabled:  true,
+		Provider: pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP,
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("error = %v, want FailedPrecondition", err)
+	}
+	if !strings.Contains(err.Error(), "roles/monitoring.metricWriter") {
+		t.Errorf("error %q does not carry the IAM remediation hint", err)
+	}
+	if sink.probed != 1 {
+		t.Fatalf("expected exactly one probe call, got %d", sink.probed)
+	}
+
+	// Nothing was persisted: status still reports disabled/unconfigured.
+	statusResp, statusErr := s.GetMetricsExport(testCtx(), &pb.GetMetricsExportRequest{})
+	if statusErr != nil {
+		t.Fatalf("unexpected error from GetMetricsExport: %v", statusErr)
+	}
+	if statusResp.Enabled {
+		t.Errorf("GetMetricsExport.Enabled = true after a failed probe, want false")
+	}
+	if statusResp.Provider != pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED {
+		t.Errorf("GetMetricsExport.Provider = %v after a failed probe, want UNSPECIFIED", statusResp.Provider)
+	}
+}
+
+// TestSetMetricsExport_EnableDisableStatusRoundTrip covers the headline
+// acceptance criterion: enable -> status reflects it -> disable ->
+// status reflects it, all without a daemon restart (same in-process
+// ContainerServer throughout).
+func TestSetMetricsExport_EnableDisableStatusRoundTrip(t *testing.T) {
+	s, _ := newMetricsExportTestServer(nil)
+
+	// Initially unconfigured.
+	initial, err := s.GetMetricsExport(testCtx(), &pb.GetMetricsExportRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if initial.Enabled {
+		t.Fatalf("expected export disabled by default, got enabled")
+	}
+
+	// Enable.
+	enableResp, err := s.SetMetricsExport(testCtx(), &pb.SetMetricsExportRequest{
+		Enabled:  true,
+		Provider: pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error enabling: %v", err)
+	}
+	if !enableResp.Enabled || enableResp.Provider != pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP {
+		t.Fatalf("enable response = %+v", enableResp)
+	}
+	if enableResp.IntervalSeconds != cloudexport.DefaultIntervalSeconds {
+		t.Errorf("interval_seconds = %d, want default %d", enableResp.IntervalSeconds, cloudexport.DefaultIntervalSeconds)
+	}
+
+	afterEnable, err := s.GetMetricsExport(testCtx(), &pb.GetMetricsExportRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !afterEnable.Enabled || afterEnable.Provider != pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP {
+		t.Fatalf("status after enable = %+v, want enabled=true provider=GCP", afterEnable)
+	}
+
+	// Disable.
+	disableResp, err := s.SetMetricsExport(testCtx(), &pb.SetMetricsExportRequest{Enabled: false})
+	if err != nil {
+		t.Fatalf("unexpected error disabling: %v", err)
+	}
+	if disableResp.Enabled {
+		t.Fatalf("disable response still reports enabled: %+v", disableResp)
+	}
+
+	afterDisable, err := s.GetMetricsExport(testCtx(), &pb.GetMetricsExportRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if afterDisable.Enabled {
+		t.Fatalf("status after disable = %+v, want enabled=false", afterDisable)
+	}
+	// Provider is sticky across a disable (operationally useful: a bare
+	// `enable` after `disable` doesn't need --provider again). Only
+	// enabled flips.
+	if afterDisable.Provider != pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP {
+		t.Errorf("status after disable dropped the provider: got %v, want it to stay GCP", afterDisable.Provider)
+	}
+}
+
+// TestSetMetricsExport_NoSinkRegistered_Unimplemented covers a host
+// where SetMetricsExportSinks was never called (e.g. an older daemon
+// build or a runtime with no sinks wired) — enabling GCP must fail
+// closed, not panic on a nil map lookup.
+func TestSetMetricsExport_NoSinkRegistered_Unimplemented(t *testing.T) {
+	s := &ContainerServer{}
+	_, err := s.SetMetricsExport(testCtx(), &pb.SetMetricsExportRequest{
+		Enabled:  true,
+		Provider: pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP,
+	})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("error = %v, want Unimplemented", err)
+	}
+}

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -259,6 +259,66 @@ func (DeletePolicy) EnumDescriptor() ([]byte, []int) {
 	return file_containarium_v1_container_proto_rawDescGZIP(), []int{3}
 }
 
+// CloudMetricsProvider identifies which host cloud's native monitoring
+// receives the opt-in export (#1069). Typed so the toggle can never be a
+// magic string. AWS is reserved for a future Sink implementation;
+// SetMetricsExport rejects it with UNIMPLEMENTED until one exists.
+type CloudMetricsProvider int32
+
+const (
+	// Unset. SetMetricsExport rejects this with INVALID_ARGUMENT when
+	// enabled=true; GetMetricsExport returns it when export has never been
+	// configured.
+	CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED CloudMetricsProvider = 0
+	// Google Cloud Monitoring (Cloud Operations). The only implemented
+	// provider in the MVP.
+	CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP CloudMetricsProvider = 1
+	// Amazon CloudWatch. Reserved — no Sink implementation yet;
+	// SetMetricsExport returns UNIMPLEMENTED.
+	CloudMetricsProvider_CLOUD_METRICS_PROVIDER_AWS CloudMetricsProvider = 2
+)
+
+// Enum value maps for CloudMetricsProvider.
+var (
+	CloudMetricsProvider_name = map[int32]string{
+		0: "CLOUD_METRICS_PROVIDER_UNSPECIFIED",
+		1: "CLOUD_METRICS_PROVIDER_GCP",
+		2: "CLOUD_METRICS_PROVIDER_AWS",
+	}
+	CloudMetricsProvider_value = map[string]int32{
+		"CLOUD_METRICS_PROVIDER_UNSPECIFIED": 0,
+		"CLOUD_METRICS_PROVIDER_GCP":         1,
+		"CLOUD_METRICS_PROVIDER_AWS":         2,
+	}
+)
+
+func (x CloudMetricsProvider) Enum() *CloudMetricsProvider {
+	p := new(CloudMetricsProvider)
+	*p = x
+	return p
+}
+
+func (x CloudMetricsProvider) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CloudMetricsProvider) Descriptor() protoreflect.EnumDescriptor {
+	return file_containarium_v1_container_proto_enumTypes[4].Descriptor()
+}
+
+func (CloudMetricsProvider) Type() protoreflect.EnumType {
+	return &file_containarium_v1_container_proto_enumTypes[4]
+}
+
+func (x CloudMetricsProvider) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CloudMetricsProvider.Descriptor instead.
+func (CloudMetricsProvider) EnumDescriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{4}
+}
+
 // ResourceLimits defines resource constraints for a container
 type ResourceLimits struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -4091,6 +4151,275 @@ func (x *GetMonitoringInfoResponse) GetVictoriaMetricsUrl() string {
 	return ""
 }
 
+// SetMetricsExportRequest enables or disables cloud-native metrics export.
+// Enabling with provider=GCP triggers a synchronous Application Default
+// Credentials probe (monitoring-write scope) before anything is persisted
+// or started; enabling with an unresolvable ADC fails the call and leaves
+// the prior config untouched.
+type SetMetricsExportRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Desired state. true enables export (provider is required and is
+	// probed before persisting). false disables it; provider is ignored.
+	Enabled bool `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// Target cloud provider. Required when enabled=true. Must not be
+	// CLOUD_METRICS_PROVIDER_UNSPECIFIED (INVALID_ARGUMENT) or
+	// CLOUD_METRICS_PROVIDER_AWS (UNIMPLEMENTED — MVP is GCP-only).
+	Provider      CloudMetricsProvider `protobuf:"varint,2,opt,name=provider,proto3,enum=containarium.v1.CloudMetricsProvider" json:"provider,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetMetricsExportRequest) Reset() {
+	*x = SetMetricsExportRequest{}
+	mi := &file_containarium_v1_container_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetMetricsExportRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetMetricsExportRequest) ProtoMessage() {}
+
+func (x *SetMetricsExportRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetMetricsExportRequest.ProtoReflect.Descriptor instead.
+func (*SetMetricsExportRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *SetMetricsExportRequest) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *SetMetricsExportRequest) GetProvider() CloudMetricsProvider {
+	if x != nil {
+		return x.Provider
+	}
+	return CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED
+}
+
+// SetMetricsExportResponse reports the effective state after the toggle.
+type SetMetricsExportResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Operator-facing summary of what changed (e.g. "cloud metrics export
+	// enabled for gcp").
+	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	// The effective config after the call — mirrors GetMetricsExportResponse.
+	Enabled         bool                 `protobuf:"varint,2,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	Provider        CloudMetricsProvider `protobuf:"varint,3,opt,name=provider,proto3,enum=containarium.v1.CloudMetricsProvider" json:"provider,omitempty"`
+	IntervalSeconds int32                `protobuf:"varint,4,opt,name=interval_seconds,json=intervalSeconds,proto3" json:"interval_seconds,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *SetMetricsExportResponse) Reset() {
+	*x = SetMetricsExportResponse{}
+	mi := &file_containarium_v1_container_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetMetricsExportResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetMetricsExportResponse) ProtoMessage() {}
+
+func (x *SetMetricsExportResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetMetricsExportResponse.ProtoReflect.Descriptor instead.
+func (*SetMetricsExportResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *SetMetricsExportResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *SetMetricsExportResponse) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *SetMetricsExportResponse) GetProvider() CloudMetricsProvider {
+	if x != nil {
+		return x.Provider
+	}
+	return CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED
+}
+
+func (x *SetMetricsExportResponse) GetIntervalSeconds() int32 {
+	if x != nil {
+		return x.IntervalSeconds
+	}
+	return 0
+}
+
+// GetMetricsExportRequest requests the current cloud-native metrics
+// export configuration and health.
+type GetMetricsExportRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMetricsExportRequest) Reset() {
+	*x = GetMetricsExportRequest{}
+	mi := &file_containarium_v1_container_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMetricsExportRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMetricsExportRequest) ProtoMessage() {}
+
+func (x *GetMetricsExportRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMetricsExportRequest.ProtoReflect.Descriptor instead.
+func (*GetMetricsExportRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{55}
+}
+
+// GetMetricsExportResponse reports the current cloud-native metrics
+// export configuration and last-known health. last_success_at,
+// last_error, and export_failures are zero-valued until the collector
+// (#1070/#1071) is wired — #1069 delivers the toggle, config
+// persistence, and enable-time credential probe only.
+type GetMetricsExportResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Whether export is currently enabled.
+	Enabled bool `protobuf:"varint,1,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	// The configured provider. CLOUD_METRICS_PROVIDER_UNSPECIFIED when
+	// export has never been configured on this host.
+	Provider CloudMetricsProvider `protobuf:"varint,2,opt,name=provider,proto3,enum=containarium.v1.CloudMetricsProvider" json:"provider,omitempty"`
+	// Export interval in seconds. Fixed default 60 in the MVP; #1069 does
+	// not expose a knob to change it.
+	IntervalSeconds int32 `protobuf:"varint,3,opt,name=interval_seconds,json=intervalSeconds,proto3" json:"interval_seconds,omitempty"`
+	// Wall-clock time of the last successful export batch.
+	LastSuccessAt *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=last_success_at,json=lastSuccessAt,proto3" json:"last_success_at,omitempty"`
+	// Human-readable detail of the most recent export failure, if any.
+	LastError string `protobuf:"bytes,5,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`
+	// Count of failed export batches since the exporter was last (re)built.
+	ExportFailures int64 `protobuf:"varint,6,opt,name=export_failures,json=exportFailures,proto3" json:"export_failures,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *GetMetricsExportResponse) Reset() {
+	*x = GetMetricsExportResponse{}
+	mi := &file_containarium_v1_container_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMetricsExportResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMetricsExportResponse) ProtoMessage() {}
+
+func (x *GetMetricsExportResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMetricsExportResponse.ProtoReflect.Descriptor instead.
+func (*GetMetricsExportResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *GetMetricsExportResponse) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *GetMetricsExportResponse) GetProvider() CloudMetricsProvider {
+	if x != nil {
+		return x.Provider
+	}
+	return CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED
+}
+
+func (x *GetMetricsExportResponse) GetIntervalSeconds() int32 {
+	if x != nil {
+		return x.IntervalSeconds
+	}
+	return 0
+}
+
+func (x *GetMetricsExportResponse) GetLastSuccessAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastSuccessAt
+	}
+	return nil
+}
+
+func (x *GetMetricsExportResponse) GetLastError() string {
+	if x != nil {
+		return x.LastError
+	}
+	return ""
+}
+
+func (x *GetMetricsExportResponse) GetExportFailures() int64 {
+	if x != nil {
+		return x.ExportFailures
+	}
+	return 0
+}
+
 // MoveContainerRequest is the source-side request to migrate a
 // container to a peer daemon.
 type MoveContainerRequest struct {
@@ -4126,7 +4455,7 @@ type MoveContainerRequest struct {
 
 func (x *MoveContainerRequest) Reset() {
 	*x = MoveContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[53]
+	mi := &file_containarium_v1_container_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4138,7 +4467,7 @@ func (x *MoveContainerRequest) String() string {
 func (*MoveContainerRequest) ProtoMessage() {}
 
 func (x *MoveContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[53]
+	mi := &file_containarium_v1_container_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4151,7 +4480,7 @@ func (x *MoveContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MoveContainerRequest.ProtoReflect.Descriptor instead.
 func (*MoveContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{53}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *MoveContainerRequest) GetUsername() string {
@@ -4214,7 +4543,7 @@ type MoveContainerResponse struct {
 
 func (x *MoveContainerResponse) Reset() {
 	*x = MoveContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[54]
+	mi := &file_containarium_v1_container_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4226,7 +4555,7 @@ func (x *MoveContainerResponse) String() string {
 func (*MoveContainerResponse) ProtoMessage() {}
 
 func (x *MoveContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[54]
+	mi := &file_containarium_v1_container_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4239,7 +4568,7 @@ func (x *MoveContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MoveContainerResponse.ProtoReflect.Descriptor instead.
 func (*MoveContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{54}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *MoveContainerResponse) GetMessage() string {
@@ -4300,7 +4629,7 @@ type AdoptMigratedContainerRequest struct {
 
 func (x *AdoptMigratedContainerRequest) Reset() {
 	*x = AdoptMigratedContainerRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[55]
+	mi := &file_containarium_v1_container_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4312,7 +4641,7 @@ func (x *AdoptMigratedContainerRequest) String() string {
 func (*AdoptMigratedContainerRequest) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[55]
+	mi := &file_containarium_v1_container_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4325,7 +4654,7 @@ func (x *AdoptMigratedContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerRequest.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{55}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *AdoptMigratedContainerRequest) GetUsername() string {
@@ -4357,7 +4686,7 @@ type AdoptMigratedContainerResponse struct {
 
 func (x *AdoptMigratedContainerResponse) Reset() {
 	*x = AdoptMigratedContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[56]
+	mi := &file_containarium_v1_container_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4369,7 +4698,7 @@ func (x *AdoptMigratedContainerResponse) String() string {
 func (*AdoptMigratedContainerResponse) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[56]
+	mi := &file_containarium_v1_container_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4382,7 +4711,7 @@ func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerResponse.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{56}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *AdoptMigratedContainerResponse) GetMessage() string {
@@ -4715,7 +5044,24 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1f\n" +
 	"\vgrafana_url\x18\x02 \x01(\tR\n" +
 	"grafanaUrl\x120\n" +
-	"\x14victoria_metrics_url\x18\x03 \x01(\tR\x12victoriaMetricsUrl\"\xd9\x01\n" +
+	"\x14victoria_metrics_url\x18\x03 \x01(\tR\x12victoriaMetricsUrl\"v\n" +
+	"\x17SetMetricsExportRequest\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\x12A\n" +
+	"\bprovider\x18\x02 \x01(\x0e2%.containarium.v1.CloudMetricsProviderR\bprovider\"\xbc\x01\n" +
+	"\x18SetMetricsExportResponse\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x12\x18\n" +
+	"\aenabled\x18\x02 \x01(\bR\aenabled\x12A\n" +
+	"\bprovider\x18\x03 \x01(\x0e2%.containarium.v1.CloudMetricsProviderR\bprovider\x12)\n" +
+	"\x10interval_seconds\x18\x04 \x01(\x05R\x0fintervalSeconds\"\x19\n" +
+	"\x17GetMetricsExportRequest\"\xae\x02\n" +
+	"\x18GetMetricsExportResponse\x12\x18\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\x12A\n" +
+	"\bprovider\x18\x02 \x01(\x0e2%.containarium.v1.CloudMetricsProviderR\bprovider\x12)\n" +
+	"\x10interval_seconds\x18\x03 \x01(\x05R\x0fintervalSeconds\x12B\n" +
+	"\x0flast_success_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\rlastSuccessAt\x12\x1d\n" +
+	"\n" +
+	"last_error\x18\x05 \x01(\tR\tlastError\x12'\n" +
+	"\x0fexport_failures\x18\x06 \x01(\x03R\x0eexportFailures\"\xd9\x01\n" +
 	"\x14MoveContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12*\n" +
 	"\x11target_backend_id\x18\x02 \x01(\tR\x0ftargetBackendId\x12%\n" +
@@ -4755,7 +5101,11 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x1cCONTAINER_STATE_PROVISIONING\x10\x06\x1a\x10\x8a\xb5\x18\fProvisioning*J\n" +
 	"\fDeletePolicy\x12\x1d\n" +
 	"\x19DELETE_POLICY_UNSPECIFIED\x10\x00\x12\x1b\n" +
-	"\x17DELETE_POLICY_PROTECTED\x10\x01:B\n" +
+	"\x17DELETE_POLICY_PROTECTED\x10\x01*~\n" +
+	"\x14CloudMetricsProvider\x12&\n" +
+	"\"CLOUD_METRICS_PROVIDER_UNSPECIFIED\x10\x00\x12\x1e\n" +
+	"\x1aCLOUD_METRICS_PROVIDER_GCP\x10\x01\x12\x1e\n" +
+	"\x1aCLOUD_METRICS_PROVIDER_AWS\x10\x02:B\n" +
 	"\n" +
 	"state_name\x12!.google.protobuf.EnumValueOptions\x18ц\x03 \x01(\tR\tstateNameBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
 
@@ -4771,120 +5121,129 @@ func file_containarium_v1_container_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_container_proto_rawDescData
 }
 
-var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 63)
+var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
 var file_containarium_v1_container_proto_goTypes = []any{
 	(OSType)(0),                              // 0: containarium.v1.OSType
 	(AccessType)(0),                          // 1: containarium.v1.AccessType
 	(ContainerState)(0),                      // 2: containarium.v1.ContainerState
 	(DeletePolicy)(0),                        // 3: containarium.v1.DeletePolicy
-	(*ResourceLimits)(nil),                   // 4: containarium.v1.ResourceLimits
-	(*NetworkInfo)(nil),                      // 5: containarium.v1.NetworkInfo
-	(*Container)(nil),                        // 6: containarium.v1.Container
-	(*ContainerMetrics)(nil),                 // 7: containarium.v1.ContainerMetrics
-	(*CreateContainerRequest)(nil),           // 8: containarium.v1.CreateContainerRequest
-	(*CreateContainerResponse)(nil),          // 9: containarium.v1.CreateContainerResponse
-	(*ListContainersRequest)(nil),            // 10: containarium.v1.ListContainersRequest
-	(*ListContainersResponse)(nil),           // 11: containarium.v1.ListContainersResponse
-	(*GetContainerRequest)(nil),              // 12: containarium.v1.GetContainerRequest
-	(*GetContainerResponse)(nil),             // 13: containarium.v1.GetContainerResponse
-	(*DebugContainerRequest)(nil),            // 14: containarium.v1.DebugContainerRequest
-	(*DebugContainerResponse)(nil),           // 15: containarium.v1.DebugContainerResponse
-	(*DeleteContainerRequest)(nil),           // 16: containarium.v1.DeleteContainerRequest
-	(*DeleteContainerResponse)(nil),          // 17: containarium.v1.DeleteContainerResponse
-	(*StartContainerRequest)(nil),            // 18: containarium.v1.StartContainerRequest
-	(*StartContainerResponse)(nil),           // 19: containarium.v1.StartContainerResponse
-	(*StopContainerRequest)(nil),             // 20: containarium.v1.StopContainerRequest
-	(*StopContainerResponse)(nil),            // 21: containarium.v1.StopContainerResponse
-	(*ToggleMonitoringRequest)(nil),          // 22: containarium.v1.ToggleMonitoringRequest
-	(*ToggleMonitoringResponse)(nil),         // 23: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepRequest)(nil),           // 24: containarium.v1.ToggleAutoSleepRequest
-	(*ToggleAutoSleepResponse)(nil),          // 25: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLRequest)(nil),           // 26: containarium.v1.SetContainerTTLRequest
-	(*SetContainerTTLResponse)(nil),          // 27: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyRequest)(nil),  // 28: containarium.v1.SetContainerDeletePolicyRequest
-	(*SetContainerDeletePolicyResponse)(nil), // 29: containarium.v1.SetContainerDeletePolicyResponse
-	(*SetContainerAttributionRequest)(nil),   // 30: containarium.v1.SetContainerAttributionRequest
-	(*SetContainerAttributionResponse)(nil),  // 31: containarium.v1.SetContainerAttributionResponse
-	(*AddSSHKeyRequest)(nil),                 // 32: containarium.v1.AddSSHKeyRequest
-	(*AddSSHKeyResponse)(nil),                // 33: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyRequest)(nil),              // 34: containarium.v1.RemoveSSHKeyRequest
-	(*RemoveSSHKeyResponse)(nil),             // 35: containarium.v1.RemoveSSHKeyResponse
-	(*GetMetricsRequest)(nil),                // 36: containarium.v1.GetMetricsRequest
-	(*GetMetricsResponse)(nil),               // 37: containarium.v1.GetMetricsResponse
-	(*ResizeContainerRequest)(nil),           // 38: containarium.v1.ResizeContainerRequest
-	(*ResizeContainerResponse)(nil),          // 39: containarium.v1.ResizeContainerResponse
-	(*Collaborator)(nil),                     // 40: containarium.v1.Collaborator
-	(*AddCollaboratorRequest)(nil),           // 41: containarium.v1.AddCollaboratorRequest
-	(*AddCollaboratorResponse)(nil),          // 42: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorRequest)(nil),        // 43: containarium.v1.RemoveCollaboratorRequest
-	(*RemoveCollaboratorResponse)(nil),       // 44: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsRequest)(nil),         // 45: containarium.v1.ListCollaboratorsRequest
-	(*ListCollaboratorsResponse)(nil),        // 46: containarium.v1.ListCollaboratorsResponse
-	(*CleanupDiskRequest)(nil),               // 47: containarium.v1.CleanupDiskRequest
-	(*CleanupDiskResponse)(nil),              // 48: containarium.v1.CleanupDiskResponse
-	(*InstallStackRequest)(nil),              // 49: containarium.v1.InstallStackRequest
-	(*InstallStackResponse)(nil),             // 50: containarium.v1.InstallStackResponse
-	(*StackParameter)(nil),                   // 51: containarium.v1.StackParameter
-	(*StackInfo)(nil),                        // 52: containarium.v1.StackInfo
-	(*ListStacksRequest)(nil),                // 53: containarium.v1.ListStacksRequest
-	(*ListStacksResponse)(nil),               // 54: containarium.v1.ListStacksResponse
-	(*GetMonitoringInfoRequest)(nil),         // 55: containarium.v1.GetMonitoringInfoRequest
-	(*GetMonitoringInfoResponse)(nil),        // 56: containarium.v1.GetMonitoringInfoResponse
-	(*MoveContainerRequest)(nil),             // 57: containarium.v1.MoveContainerRequest
-	(*MoveContainerResponse)(nil),            // 58: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerRequest)(nil),    // 59: containarium.v1.AdoptMigratedContainerRequest
-	(*AdoptMigratedContainerResponse)(nil),   // 60: containarium.v1.AdoptMigratedContainerResponse
-	nil,                                      // 61: containarium.v1.Container.LabelsEntry
-	nil,                                      // 62: containarium.v1.CreateContainerRequest.LabelsEntry
-	nil,                                      // 63: containarium.v1.CreateContainerRequest.StackParametersEntry
-	nil,                                      // 64: containarium.v1.ListContainersRequest.LabelFilterEntry
-	nil,                                      // 65: containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	nil,                                      // 66: containarium.v1.SetContainerAttributionResponse.LabelsEntry
-	(*timestamppb.Timestamp)(nil),            // 67: google.protobuf.Timestamp
-	(*descriptorpb.EnumValueOptions)(nil),    // 68: google.protobuf.EnumValueOptions
+	(CloudMetricsProvider)(0),                // 4: containarium.v1.CloudMetricsProvider
+	(*ResourceLimits)(nil),                   // 5: containarium.v1.ResourceLimits
+	(*NetworkInfo)(nil),                      // 6: containarium.v1.NetworkInfo
+	(*Container)(nil),                        // 7: containarium.v1.Container
+	(*ContainerMetrics)(nil),                 // 8: containarium.v1.ContainerMetrics
+	(*CreateContainerRequest)(nil),           // 9: containarium.v1.CreateContainerRequest
+	(*CreateContainerResponse)(nil),          // 10: containarium.v1.CreateContainerResponse
+	(*ListContainersRequest)(nil),            // 11: containarium.v1.ListContainersRequest
+	(*ListContainersResponse)(nil),           // 12: containarium.v1.ListContainersResponse
+	(*GetContainerRequest)(nil),              // 13: containarium.v1.GetContainerRequest
+	(*GetContainerResponse)(nil),             // 14: containarium.v1.GetContainerResponse
+	(*DebugContainerRequest)(nil),            // 15: containarium.v1.DebugContainerRequest
+	(*DebugContainerResponse)(nil),           // 16: containarium.v1.DebugContainerResponse
+	(*DeleteContainerRequest)(nil),           // 17: containarium.v1.DeleteContainerRequest
+	(*DeleteContainerResponse)(nil),          // 18: containarium.v1.DeleteContainerResponse
+	(*StartContainerRequest)(nil),            // 19: containarium.v1.StartContainerRequest
+	(*StartContainerResponse)(nil),           // 20: containarium.v1.StartContainerResponse
+	(*StopContainerRequest)(nil),             // 21: containarium.v1.StopContainerRequest
+	(*StopContainerResponse)(nil),            // 22: containarium.v1.StopContainerResponse
+	(*ToggleMonitoringRequest)(nil),          // 23: containarium.v1.ToggleMonitoringRequest
+	(*ToggleMonitoringResponse)(nil),         // 24: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepRequest)(nil),           // 25: containarium.v1.ToggleAutoSleepRequest
+	(*ToggleAutoSleepResponse)(nil),          // 26: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLRequest)(nil),           // 27: containarium.v1.SetContainerTTLRequest
+	(*SetContainerTTLResponse)(nil),          // 28: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyRequest)(nil),  // 29: containarium.v1.SetContainerDeletePolicyRequest
+	(*SetContainerDeletePolicyResponse)(nil), // 30: containarium.v1.SetContainerDeletePolicyResponse
+	(*SetContainerAttributionRequest)(nil),   // 31: containarium.v1.SetContainerAttributionRequest
+	(*SetContainerAttributionResponse)(nil),  // 32: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyRequest)(nil),                 // 33: containarium.v1.AddSSHKeyRequest
+	(*AddSSHKeyResponse)(nil),                // 34: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyRequest)(nil),              // 35: containarium.v1.RemoveSSHKeyRequest
+	(*RemoveSSHKeyResponse)(nil),             // 36: containarium.v1.RemoveSSHKeyResponse
+	(*GetMetricsRequest)(nil),                // 37: containarium.v1.GetMetricsRequest
+	(*GetMetricsResponse)(nil),               // 38: containarium.v1.GetMetricsResponse
+	(*ResizeContainerRequest)(nil),           // 39: containarium.v1.ResizeContainerRequest
+	(*ResizeContainerResponse)(nil),          // 40: containarium.v1.ResizeContainerResponse
+	(*Collaborator)(nil),                     // 41: containarium.v1.Collaborator
+	(*AddCollaboratorRequest)(nil),           // 42: containarium.v1.AddCollaboratorRequest
+	(*AddCollaboratorResponse)(nil),          // 43: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorRequest)(nil),        // 44: containarium.v1.RemoveCollaboratorRequest
+	(*RemoveCollaboratorResponse)(nil),       // 45: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsRequest)(nil),         // 46: containarium.v1.ListCollaboratorsRequest
+	(*ListCollaboratorsResponse)(nil),        // 47: containarium.v1.ListCollaboratorsResponse
+	(*CleanupDiskRequest)(nil),               // 48: containarium.v1.CleanupDiskRequest
+	(*CleanupDiskResponse)(nil),              // 49: containarium.v1.CleanupDiskResponse
+	(*InstallStackRequest)(nil),              // 50: containarium.v1.InstallStackRequest
+	(*InstallStackResponse)(nil),             // 51: containarium.v1.InstallStackResponse
+	(*StackParameter)(nil),                   // 52: containarium.v1.StackParameter
+	(*StackInfo)(nil),                        // 53: containarium.v1.StackInfo
+	(*ListStacksRequest)(nil),                // 54: containarium.v1.ListStacksRequest
+	(*ListStacksResponse)(nil),               // 55: containarium.v1.ListStacksResponse
+	(*GetMonitoringInfoRequest)(nil),         // 56: containarium.v1.GetMonitoringInfoRequest
+	(*GetMonitoringInfoResponse)(nil),        // 57: containarium.v1.GetMonitoringInfoResponse
+	(*SetMetricsExportRequest)(nil),          // 58: containarium.v1.SetMetricsExportRequest
+	(*SetMetricsExportResponse)(nil),         // 59: containarium.v1.SetMetricsExportResponse
+	(*GetMetricsExportRequest)(nil),          // 60: containarium.v1.GetMetricsExportRequest
+	(*GetMetricsExportResponse)(nil),         // 61: containarium.v1.GetMetricsExportResponse
+	(*MoveContainerRequest)(nil),             // 62: containarium.v1.MoveContainerRequest
+	(*MoveContainerResponse)(nil),            // 63: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerRequest)(nil),    // 64: containarium.v1.AdoptMigratedContainerRequest
+	(*AdoptMigratedContainerResponse)(nil),   // 65: containarium.v1.AdoptMigratedContainerResponse
+	nil,                                      // 66: containarium.v1.Container.LabelsEntry
+	nil,                                      // 67: containarium.v1.CreateContainerRequest.LabelsEntry
+	nil,                                      // 68: containarium.v1.CreateContainerRequest.StackParametersEntry
+	nil,                                      // 69: containarium.v1.ListContainersRequest.LabelFilterEntry
+	nil,                                      // 70: containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	nil,                                      // 71: containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	(*timestamppb.Timestamp)(nil),            // 72: google.protobuf.Timestamp
+	(*descriptorpb.EnumValueOptions)(nil),    // 73: google.protobuf.EnumValueOptions
 }
 var file_containarium_v1_container_proto_depIdxs = []int32{
 	2,  // 0: containarium.v1.Container.state:type_name -> containarium.v1.ContainerState
-	4,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
-	5,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
-	61, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
+	5,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
+	6,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
+	66, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
 	0,  // 4: containarium.v1.Container.os_type:type_name -> containarium.v1.OSType
 	1,  // 5: containarium.v1.Container.access_type:type_name -> containarium.v1.AccessType
-	67, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
-	67, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
+	72, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	72, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
 	3,  // 8: containarium.v1.Container.delete_policy:type_name -> containarium.v1.DeletePolicy
-	4,  // 9: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
-	62, // 10: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
+	5,  // 9: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
+	67, // 10: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
 	0,  // 11: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
-	63, // 12: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
-	6,  // 13: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
+	68, // 12: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
+	7,  // 13: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
 	2,  // 14: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
-	64, // 15: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
-	6,  // 16: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
-	6,  // 17: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
-	7,  // 18: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
-	6,  // 19: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
-	6,  // 20: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
-	67, // 21: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	69, // 15: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
+	7,  // 16: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
+	7,  // 17: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
+	8,  // 18: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
+	7,  // 19: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
+	7,  // 20: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
+	72, // 21: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
 	3,  // 22: containarium.v1.SetContainerDeletePolicyRequest.delete_policy:type_name -> containarium.v1.DeletePolicy
 	3,  // 23: containarium.v1.SetContainerDeletePolicyResponse.delete_policy:type_name -> containarium.v1.DeletePolicy
-	65, // 24: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	66, // 25: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
-	7,  // 26: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
-	6,  // 27: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
-	40, // 28: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
-	40, // 29: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
-	6,  // 30: containarium.v1.CleanupDiskResponse.container:type_name -> containarium.v1.Container
-	6,  // 31: containarium.v1.InstallStackResponse.container:type_name -> containarium.v1.Container
-	51, // 32: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
-	52, // 33: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
-	68, // 34: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
-	35, // [35:35] is the sub-list for method output_type
-	35, // [35:35] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	34, // [34:35] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	70, // 24: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	71, // 25: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	8,  // 26: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
+	7,  // 27: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
+	41, // 28: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
+	41, // 29: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
+	7,  // 30: containarium.v1.CleanupDiskResponse.container:type_name -> containarium.v1.Container
+	7,  // 31: containarium.v1.InstallStackResponse.container:type_name -> containarium.v1.Container
+	52, // 32: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
+	53, // 33: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
+	4,  // 34: containarium.v1.SetMetricsExportRequest.provider:type_name -> containarium.v1.CloudMetricsProvider
+	4,  // 35: containarium.v1.SetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
+	4,  // 36: containarium.v1.GetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
+	72, // 37: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
+	73, // 38: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
+	39, // [39:39] is the sub-list for method output_type
+	39, // [39:39] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	38, // [38:39] is the sub-list for extension extendee
+	0,  // [0:38] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_container_proto_init() }
@@ -4897,8 +5256,8 @@ func file_containarium_v1_container_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_container_proto_rawDesc), len(file_containarium_v1_container_proto_rawDesc)),
-			NumEnums:      4,
-			NumMessages:   63,
+			NumEnums:      5,
+			NumMessages:   67,
 			NumExtensions: 1,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2ˊ\x01\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xac\x92\x01\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -111,7 +111,13 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x06System\x12\x13Poll upgrade status\x1a\xd6\x01Returns the status of an upgrade started by TriggerUpgrade. Note: a local self-upgrade restarts the daemon and drops job state, returning 'unknown' afterward; compare the backend version in ListBackends to confirm.\x82\xd3\xe4\x93\x02\x1b\x12\x19/v1/upgrades/{upgrade_id}\x12\xb7\x02\n" +
 	"\x11GetMonitoringInfo\x12).containarium.v1.GetMonitoringInfoRequest\x1a*.containarium.v1.GetMonitoringInfoResponse\"\xca\x01\x92A\xa9\x01\n" +
 	"\n" +
-	"Monitoring\x12\x1aGet monitoring information\x1a\x7fReturns monitoring configuration including Grafana and VictoriaMetrics URLs. Used by the web UI to embed the Grafana dashboard.\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/system/monitoring\x12\x87\x02\n" +
+	"Monitoring\x12\x1aGet monitoring information\x1a\x7fReturns monitoring configuration including Grafana and VictoriaMetrics URLs. Used by the web UI to embed the Grafana dashboard.\x82\xd3\xe4\x93\x02\x17\x12\x15/v1/system/monitoring\x12\xe5\x04\n" +
+	"\x10SetMetricsExport\x12(.containarium.v1.SetMetricsExportRequest\x1a).containarium.v1.SetMetricsExportResponse\"\xfb\x03\x92A\xd3\x03\n" +
+	"\n" +
+	"Monitoring\x12-Enable or disable cloud-native metrics export\x1a\x95\x03Opt-in export of host/container infra metrics to the host cloud's native monitoring (GCP Cloud Monitoring in the MVP). Enabling probes Application Default Credentials (monitoring-write scope) before persisting anything; a host with no resolvable ADC fails with FAILED_PRECONDITION and an IAM remediation hint. Disabling stops emission within one export interval. AWS is reserved and returns UNIMPLEMENTED.\x82\xd3\xe4\x93\x02\x1e:\x01*\"\x19/v1/system/metrics-export\x12\xf6\x02\n" +
+	"\x10GetMetricsExport\x12(.containarium.v1.GetMetricsExportRequest\x1a).containarium.v1.GetMetricsExportResponse\"\x8c\x02\x92A\xe7\x01\n" +
+	"\n" +
+	"Monitoring\x12&Get cloud-native metrics export status\x1a\xb0\x01Returns whether cloud-native metrics export is enabled, the configured provider, the export interval, and last-known health (populated once the collector lands in #1070/#1071).\x82\xd3\xe4\x93\x02\x1b\x12\x19/v1/system/metrics-export\x12\x87\x02\n" +
 	"\x0fCreateAlertRule\x12'.containarium.v1.CreateAlertRuleRequest\x1a(.containarium.v1.CreateAlertRuleResponse\"\xa0\x01\x92A\x87\x01\n" +
 	"\x06Alerts\x12\x11Create alert rule\x1ajCreates a new custom alert rule. The rule is persisted in PostgreSQL and synced to vmalert for evaluation.\x82\xd3\xe4\x93\x02\x0f:\x01*\"\n" +
 	"/v1/alerts\x12\xca\x01\n" +
@@ -192,73 +198,77 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*TriggerUpgradeRequest)(nil),            // 34: containarium.v1.TriggerUpgradeRequest
 	(*GetUpgradeStatusRequest)(nil),          // 35: containarium.v1.GetUpgradeStatusRequest
 	(*GetMonitoringInfoRequest)(nil),         // 36: containarium.v1.GetMonitoringInfoRequest
-	(*CreateAlertRuleRequest)(nil),           // 37: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),            // 38: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),              // 39: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),           // 40: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),           // 41: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),           // 42: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),     // 43: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),      // 44: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),               // 45: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),     // 46: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),                 // 47: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),                 // 48: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),               // 49: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),              // 50: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),            // 51: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),          // 52: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),           // 53: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),             // 54: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),           // 55: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),          // 56: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),           // 57: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),            // 58: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),          // 59: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),            // 60: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerResponse)(nil),   // 61: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),         // 62: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),          // 63: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),          // 64: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyResponse)(nil), // 65: containarium.v1.SetContainerDeletePolicyResponse
-	(*SetContainerAttributionResponse)(nil),  // 66: containarium.v1.SetContainerAttributionResponse
-	(*AddSSHKeyResponse)(nil),                // 67: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),             // 68: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),          // 69: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),       // 70: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),        // 71: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),               // 72: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),              // 73: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),             // 74: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),               // 75: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),            // 76: containarium.v1.GetSystemInfoResponse
-	(*ListBackendsResponse)(nil),             // 77: containarium.v1.ListBackendsResponse
-	(*AdvertiseCapacityResponse)(nil),        // 78: containarium.v1.AdvertiseCapacityResponse
-	(*WithdrawCapacityResponse)(nil),         // 79: containarium.v1.WithdrawCapacityResponse
-	(*GetCapacityHeadroomResponse)(nil),      // 80: containarium.v1.GetCapacityHeadroomResponse
-	(*ProfileBackendResponse)(nil),           // 81: containarium.v1.ProfileBackendResponse
-	(*GetCapabilityProfileResponse)(nil),     // 82: containarium.v1.GetCapabilityProfileResponse
-	(*GetSelfMeasurementResponse)(nil),       // 83: containarium.v1.GetSelfMeasurementResponse
-	(*GetLatestReleaseResponse)(nil),         // 84: containarium.v1.GetLatestReleaseResponse
-	(*ValidateGPUResponse)(nil),              // 85: containarium.v1.ValidateGPUResponse
-	(*TriggerUpgradeResponse)(nil),           // 86: containarium.v1.TriggerUpgradeResponse
-	(*GetUpgradeStatusResponse)(nil),         // 87: containarium.v1.GetUpgradeStatusResponse
-	(*GetMonitoringInfoResponse)(nil),        // 88: containarium.v1.GetMonitoringInfoResponse
-	(*CreateAlertRuleResponse)(nil),          // 89: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),           // 90: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),             // 91: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),          // 92: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),          // 93: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),          // 94: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),    // 95: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),     // 96: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),              // 97: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),    // 98: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),                // 99: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),                // 100: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),              // 101: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),             // 102: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),           // 103: containarium.v1.RefreshSecretsResponse
+	(*SetMetricsExportRequest)(nil),          // 37: containarium.v1.SetMetricsExportRequest
+	(*GetMetricsExportRequest)(nil),          // 38: containarium.v1.GetMetricsExportRequest
+	(*CreateAlertRuleRequest)(nil),           // 39: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),            // 40: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),              // 41: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),           // 42: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),           // 43: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),           // 44: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),     // 45: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),      // 46: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),               // 47: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),     // 48: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),                 // 49: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),                 // 50: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),               // 51: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),              // 52: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),            // 53: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),          // 54: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),           // 55: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),             // 56: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),           // 57: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),          // 58: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),           // 59: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),            // 60: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),          // 61: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),            // 62: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerResponse)(nil),   // 63: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),         // 64: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),          // 65: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),          // 66: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyResponse)(nil), // 67: containarium.v1.SetContainerDeletePolicyResponse
+	(*SetContainerAttributionResponse)(nil),  // 68: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyResponse)(nil),                // 69: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),             // 70: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),          // 71: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),       // 72: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),        // 73: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),               // 74: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),              // 75: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),             // 76: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),               // 77: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),            // 78: containarium.v1.GetSystemInfoResponse
+	(*ListBackendsResponse)(nil),             // 79: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityResponse)(nil),        // 80: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityResponse)(nil),         // 81: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomResponse)(nil),      // 82: containarium.v1.GetCapacityHeadroomResponse
+	(*ProfileBackendResponse)(nil),           // 83: containarium.v1.ProfileBackendResponse
+	(*GetCapabilityProfileResponse)(nil),     // 84: containarium.v1.GetCapabilityProfileResponse
+	(*GetSelfMeasurementResponse)(nil),       // 85: containarium.v1.GetSelfMeasurementResponse
+	(*GetLatestReleaseResponse)(nil),         // 86: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),              // 87: containarium.v1.ValidateGPUResponse
+	(*TriggerUpgradeResponse)(nil),           // 88: containarium.v1.TriggerUpgradeResponse
+	(*GetUpgradeStatusResponse)(nil),         // 89: containarium.v1.GetUpgradeStatusResponse
+	(*GetMonitoringInfoResponse)(nil),        // 90: containarium.v1.GetMonitoringInfoResponse
+	(*SetMetricsExportResponse)(nil),         // 91: containarium.v1.SetMetricsExportResponse
+	(*GetMetricsExportResponse)(nil),         // 92: containarium.v1.GetMetricsExportResponse
+	(*CreateAlertRuleResponse)(nil),          // 93: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),           // 94: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),             // 95: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),          // 96: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),          // 97: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),          // 98: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),    // 99: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),     // 100: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),              // 101: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),    // 102: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),                // 103: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),                // 104: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),              // 105: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),             // 106: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),           // 107: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,   // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -298,75 +308,79 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	34,  // 34: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
 	35,  // 35: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
 	36,  // 36: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	37,  // 37: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	38,  // 38: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	39,  // 39: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	40,  // 40: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	41,  // 41: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	42,  // 42: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	43,  // 43: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	44,  // 44: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	45,  // 45: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	46,  // 46: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	47,  // 47: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	48,  // 48: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	49,  // 49: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	50,  // 50: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	51,  // 51: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	52,  // 52: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	53,  // 53: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	54,  // 54: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	55,  // 55: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	56,  // 56: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	57,  // 57: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	58,  // 58: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	59,  // 59: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	60,  // 60: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	61,  // 61: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	62,  // 62: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	63,  // 63: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	64,  // 64: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	65,  // 65: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
-	66,  // 66: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
-	67,  // 67: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	68,  // 68: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	69,  // 69: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	70,  // 70: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	71,  // 71: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	72,  // 72: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	73,  // 73: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	74,  // 74: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	75,  // 75: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	76,  // 76: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	77,  // 77: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
-	78,  // 78: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
-	79,  // 79: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
-	80,  // 80: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
-	81,  // 81: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
-	82,  // 82: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
-	83,  // 83: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
-	84,  // 84: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	85,  // 85: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
-	86,  // 86: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
-	87,  // 87: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
-	88,  // 88: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	89,  // 89: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	90,  // 90: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	91,  // 91: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	92,  // 92: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	93,  // 93: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	94,  // 94: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	95,  // 95: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	96,  // 96: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	97,  // 97: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	98,  // 98: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	99,  // 99: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	100, // 100: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	101, // 101: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	102, // 102: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	103, // 103: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	52,  // [52:104] is the sub-list for method output_type
-	0,   // [0:52] is the sub-list for method input_type
+	37,  // 37: containarium.v1.ContainerService.SetMetricsExport:input_type -> containarium.v1.SetMetricsExportRequest
+	38,  // 38: containarium.v1.ContainerService.GetMetricsExport:input_type -> containarium.v1.GetMetricsExportRequest
+	39,  // 39: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	40,  // 40: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	41,  // 41: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	42,  // 42: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	43,  // 43: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	44,  // 44: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	45,  // 45: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	46,  // 46: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	47,  // 47: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	48,  // 48: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	49,  // 49: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	50,  // 50: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	51,  // 51: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	52,  // 52: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	53,  // 53: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	54,  // 54: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	55,  // 55: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	56,  // 56: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	57,  // 57: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	58,  // 58: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	59,  // 59: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	60,  // 60: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	61,  // 61: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	62,  // 62: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	63,  // 63: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	64,  // 64: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	65,  // 65: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	66,  // 66: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	67,  // 67: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
+	68,  // 68: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
+	69,  // 69: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	70,  // 70: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	71,  // 71: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	72,  // 72: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	73,  // 73: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	74,  // 74: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	75,  // 75: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	76,  // 76: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	77,  // 77: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	78,  // 78: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	79,  // 79: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
+	80,  // 80: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
+	81,  // 81: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
+	82,  // 82: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
+	83,  // 83: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
+	84,  // 84: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
+	85,  // 85: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
+	86,  // 86: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	87,  // 87: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	88,  // 88: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
+	89,  // 89: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
+	90,  // 90: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	91,  // 91: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
+	92,  // 92: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
+	93,  // 93: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	94,  // 94: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	95,  // 95: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	96,  // 96: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	97,  // 97: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	98,  // 98: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	99,  // 99: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	100, // 100: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	101, // 101: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	102, // 102: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	103, // 103: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	104, // 104: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	105, // 105: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	106, // 106: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	107, // 107: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	54,  // [54:108] is the sub-list for method output_type
+	0,   // [0:54] is the sub-list for method input_type
 	0,   // [0:0] is the sub-list for extension type_name
 	0,   // [0:0] is the sub-list for extension extendee
 	0,   // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -1459,6 +1459,54 @@ func local_request_ContainerService_GetMonitoringInfo_0(ctx context.Context, mar
 	return msg, metadata, err
 }
 
+func request_ContainerService_SetMetricsExport_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SetMetricsExportRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.SetMetricsExport(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_SetMetricsExport_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SetMetricsExportRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.SetMetricsExport(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+func request_ContainerService_GetMetricsExport_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetMetricsExportRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.GetMetricsExport(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_GetMetricsExport_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetMetricsExportRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.GetMetricsExport(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_CreateAlertRule_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq CreateAlertRuleRequest
@@ -2748,6 +2796,46 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_GetMonitoringInfo_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_SetMetricsExport_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/SetMetricsExport", runtime.WithHTTPPathPattern("/v1/system/metrics-export"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_SetMetricsExport_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_SetMetricsExport_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_GetMetricsExport_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/GetMetricsExport", runtime.WithHTTPPathPattern("/v1/system/metrics-export"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_GetMetricsExport_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_GetMetricsExport_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_CreateAlertRule_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3734,6 +3822,40 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_GetMonitoringInfo_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_SetMetricsExport_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/SetMetricsExport", runtime.WithHTTPPathPattern("/v1/system/metrics-export"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_SetMetricsExport_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_SetMetricsExport_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_ContainerService_GetMetricsExport_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/GetMetricsExport", runtime.WithHTTPPathPattern("/v1/system/metrics-export"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_GetMetricsExport_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_GetMetricsExport_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_CreateAlertRule_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -4031,6 +4153,8 @@ var (
 	pattern_ContainerService_TriggerUpgrade_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "backends", "upgrade"}, ""))
 	pattern_ContainerService_GetUpgradeStatus_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "upgrades", "upgrade_id"}, ""))
 	pattern_ContainerService_GetMonitoringInfo_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "monitoring"}, ""))
+	pattern_ContainerService_SetMetricsExport_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "metrics-export"}, ""))
+	pattern_ContainerService_GetMetricsExport_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "metrics-export"}, ""))
 	pattern_ContainerService_CreateAlertRule_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "alerts"}, ""))
 	pattern_ContainerService_ListAlertRules_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "alerts"}, ""))
 	pattern_ContainerService_GetAlertRule_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "alerts", "id"}, ""))
@@ -4087,6 +4211,8 @@ var (
 	forward_ContainerService_TriggerUpgrade_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_GetUpgradeStatus_0         = runtime.ForwardResponseMessage
 	forward_ContainerService_GetMonitoringInfo_0        = runtime.ForwardResponseMessage
+	forward_ContainerService_SetMetricsExport_0         = runtime.ForwardResponseMessage
+	forward_ContainerService_GetMetricsExport_0         = runtime.ForwardResponseMessage
 	forward_ContainerService_CreateAlertRule_0          = runtime.ForwardResponseMessage
 	forward_ContainerService_ListAlertRules_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_GetAlertRule_0             = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -56,6 +56,8 @@ const (
 	ContainerService_TriggerUpgrade_FullMethodName           = "/containarium.v1.ContainerService/TriggerUpgrade"
 	ContainerService_GetUpgradeStatus_FullMethodName         = "/containarium.v1.ContainerService/GetUpgradeStatus"
 	ContainerService_GetMonitoringInfo_FullMethodName        = "/containarium.v1.ContainerService/GetMonitoringInfo"
+	ContainerService_SetMetricsExport_FullMethodName         = "/containarium.v1.ContainerService/SetMetricsExport"
+	ContainerService_GetMetricsExport_FullMethodName         = "/containarium.v1.ContainerService/GetMetricsExport"
 	ContainerService_CreateAlertRule_FullMethodName          = "/containarium.v1.ContainerService/CreateAlertRule"
 	ContainerService_ListAlertRules_FullMethodName           = "/containarium.v1.ContainerService/ListAlertRules"
 	ContainerService_GetAlertRule_FullMethodName             = "/containarium.v1.ContainerService/GetAlertRule"
@@ -245,6 +247,22 @@ type ContainerServiceClient interface {
 	GetUpgradeStatus(ctx context.Context, in *GetUpgradeStatusRequest, opts ...grpc.CallOption) (*GetUpgradeStatusResponse, error)
 	// GetMonitoringInfo gets monitoring configuration (Grafana/VictoriaMetrics URLs)
 	GetMonitoringInfo(ctx context.Context, in *GetMonitoringInfoRequest, opts ...grpc.CallOption) (*GetMonitoringInfoResponse, error)
+	// SetMetricsExport enables or disables opt-in export of host/container
+	// infra metrics to the host cloud's native monitoring (GCP Cloud
+	// Monitoring in the MVP; AWS is a reserved enum value that returns
+	// UNIMPLEMENTED). Enabling validates the provider and, for GCP, resolves
+	// Application Default Credentials with the monitoring-write scope as a
+	// synchronous dry run — a host with no usable ADC gets FAILED_PRECONDITION
+	// with an IAM remediation hint and nothing is persisted or started.
+	// Disabling stops emission within one export interval. Neither direction
+	// requires a daemon restart. #1069 delivers the toggle, config
+	// persistence, and the credential probe; the metrics collector itself
+	// lands with #1070/#1071.
+	SetMetricsExport(ctx context.Context, in *SetMetricsExportRequest, opts ...grpc.CallOption) (*SetMetricsExportResponse, error)
+	// GetMetricsExport returns the current cloud-native metrics export
+	// configuration and last-known health (last success time, last error,
+	// failure count — populated once #1070/#1071 wire the collector).
+	GetMetricsExport(ctx context.Context, in *GetMetricsExportRequest, opts ...grpc.CallOption) (*GetMetricsExportResponse, error)
 	// CreateAlertRule creates a new custom alert rule
 	CreateAlertRule(ctx context.Context, in *CreateAlertRuleRequest, opts ...grpc.CallOption) (*CreateAlertRuleResponse, error)
 	// ListAlertRules lists all alert rules
@@ -665,6 +683,26 @@ func (c *containerServiceClient) GetMonitoringInfo(ctx context.Context, in *GetM
 	return out, nil
 }
 
+func (c *containerServiceClient) SetMetricsExport(ctx context.Context, in *SetMetricsExportRequest, opts ...grpc.CallOption) (*SetMetricsExportResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetMetricsExportResponse)
+	err := c.cc.Invoke(ctx, ContainerService_SetMetricsExport_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) GetMetricsExport(ctx context.Context, in *GetMetricsExportRequest, opts ...grpc.CallOption) (*GetMetricsExportResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetMetricsExportResponse)
+	err := c.cc.Invoke(ctx, ContainerService_GetMetricsExport_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *containerServiceClient) CreateAlertRule(ctx context.Context, in *CreateAlertRuleRequest, opts ...grpc.CallOption) (*CreateAlertRuleResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(CreateAlertRuleResponse)
@@ -987,6 +1025,22 @@ type ContainerServiceServer interface {
 	GetUpgradeStatus(context.Context, *GetUpgradeStatusRequest) (*GetUpgradeStatusResponse, error)
 	// GetMonitoringInfo gets monitoring configuration (Grafana/VictoriaMetrics URLs)
 	GetMonitoringInfo(context.Context, *GetMonitoringInfoRequest) (*GetMonitoringInfoResponse, error)
+	// SetMetricsExport enables or disables opt-in export of host/container
+	// infra metrics to the host cloud's native monitoring (GCP Cloud
+	// Monitoring in the MVP; AWS is a reserved enum value that returns
+	// UNIMPLEMENTED). Enabling validates the provider and, for GCP, resolves
+	// Application Default Credentials with the monitoring-write scope as a
+	// synchronous dry run — a host with no usable ADC gets FAILED_PRECONDITION
+	// with an IAM remediation hint and nothing is persisted or started.
+	// Disabling stops emission within one export interval. Neither direction
+	// requires a daemon restart. #1069 delivers the toggle, config
+	// persistence, and the credential probe; the metrics collector itself
+	// lands with #1070/#1071.
+	SetMetricsExport(context.Context, *SetMetricsExportRequest) (*SetMetricsExportResponse, error)
+	// GetMetricsExport returns the current cloud-native metrics export
+	// configuration and last-known health (last success time, last error,
+	// failure count — populated once #1070/#1071 wire the collector).
+	GetMetricsExport(context.Context, *GetMetricsExportRequest) (*GetMetricsExportResponse, error)
 	// CreateAlertRule creates a new custom alert rule
 	CreateAlertRule(context.Context, *CreateAlertRuleRequest) (*CreateAlertRuleResponse, error)
 	// ListAlertRules lists all alert rules
@@ -1147,6 +1201,12 @@ func (UnimplementedContainerServiceServer) GetUpgradeStatus(context.Context, *Ge
 }
 func (UnimplementedContainerServiceServer) GetMonitoringInfo(context.Context, *GetMonitoringInfoRequest) (*GetMonitoringInfoResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetMonitoringInfo not implemented")
+}
+func (UnimplementedContainerServiceServer) SetMetricsExport(context.Context, *SetMetricsExportRequest) (*SetMetricsExportResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetMetricsExport not implemented")
+}
+func (UnimplementedContainerServiceServer) GetMetricsExport(context.Context, *GetMetricsExportRequest) (*GetMetricsExportResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetMetricsExport not implemented")
 }
 func (UnimplementedContainerServiceServer) CreateAlertRule(context.Context, *CreateAlertRuleRequest) (*CreateAlertRuleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateAlertRule not implemented")
@@ -1880,6 +1940,42 @@ func _ContainerService_GetMonitoringInfo_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ContainerService_SetMetricsExport_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetMetricsExportRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).SetMetricsExport(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_SetMetricsExport_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).SetMetricsExport(ctx, req.(*SetMetricsExportRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_GetMetricsExport_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetMetricsExportRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).GetMetricsExport(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_GetMetricsExport_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).GetMetricsExport(ctx, req.(*GetMetricsExportRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ContainerService_CreateAlertRule_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CreateAlertRuleRequest)
 	if err := dec(in); err != nil {
@@ -2304,6 +2400,14 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetMonitoringInfo",
 			Handler:    _ContainerService_GetMonitoringInfo_Handler,
+		},
+		{
+			MethodName: "SetMetricsExport",
+			Handler:    _ContainerService_SetMetricsExport_Handler,
+		},
+		{
+			MethodName: "GetMetricsExport",
+			Handler:    _ContainerService_GetMetricsExport_Handler,
 		},
 		{
 			MethodName: "CreateAlertRule",

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -967,6 +967,84 @@ message GetMonitoringInfoResponse {
   string victoria_metrics_url = 3;
 }
 
+// CloudMetricsProvider identifies which host cloud's native monitoring
+// receives the opt-in export (#1069). Typed so the toggle can never be a
+// magic string. AWS is reserved for a future Sink implementation;
+// SetMetricsExport rejects it with UNIMPLEMENTED until one exists.
+enum CloudMetricsProvider {
+  // Unset. SetMetricsExport rejects this with INVALID_ARGUMENT when
+  // enabled=true; GetMetricsExport returns it when export has never been
+  // configured.
+  CLOUD_METRICS_PROVIDER_UNSPECIFIED = 0;
+
+  // Google Cloud Monitoring (Cloud Operations). The only implemented
+  // provider in the MVP.
+  CLOUD_METRICS_PROVIDER_GCP = 1;
+
+  // Amazon CloudWatch. Reserved — no Sink implementation yet;
+  // SetMetricsExport returns UNIMPLEMENTED.
+  CLOUD_METRICS_PROVIDER_AWS = 2;
+}
+
+// SetMetricsExportRequest enables or disables cloud-native metrics export.
+// Enabling with provider=GCP triggers a synchronous Application Default
+// Credentials probe (monitoring-write scope) before anything is persisted
+// or started; enabling with an unresolvable ADC fails the call and leaves
+// the prior config untouched.
+message SetMetricsExportRequest {
+  // Desired state. true enables export (provider is required and is
+  // probed before persisting). false disables it; provider is ignored.
+  bool enabled = 1;
+
+  // Target cloud provider. Required when enabled=true. Must not be
+  // CLOUD_METRICS_PROVIDER_UNSPECIFIED (INVALID_ARGUMENT) or
+  // CLOUD_METRICS_PROVIDER_AWS (UNIMPLEMENTED — MVP is GCP-only).
+  CloudMetricsProvider provider = 2;
+}
+
+// SetMetricsExportResponse reports the effective state after the toggle.
+message SetMetricsExportResponse {
+  // Operator-facing summary of what changed (e.g. "cloud metrics export
+  // enabled for gcp").
+  string message = 1;
+
+  // The effective config after the call — mirrors GetMetricsExportResponse.
+  bool enabled = 2;
+  CloudMetricsProvider provider = 3;
+  int32 interval_seconds = 4;
+}
+
+// GetMetricsExportRequest requests the current cloud-native metrics
+// export configuration and health.
+message GetMetricsExportRequest {}
+
+// GetMetricsExportResponse reports the current cloud-native metrics
+// export configuration and last-known health. last_success_at,
+// last_error, and export_failures are zero-valued until the collector
+// (#1070/#1071) is wired — #1069 delivers the toggle, config
+// persistence, and enable-time credential probe only.
+message GetMetricsExportResponse {
+  // Whether export is currently enabled.
+  bool enabled = 1;
+
+  // The configured provider. CLOUD_METRICS_PROVIDER_UNSPECIFIED when
+  // export has never been configured on this host.
+  CloudMetricsProvider provider = 2;
+
+  // Export interval in seconds. Fixed default 60 in the MVP; #1069 does
+  // not expose a knob to change it.
+  int32 interval_seconds = 3;
+
+  // Wall-clock time of the last successful export batch.
+  google.protobuf.Timestamp last_success_at = 4;
+
+  // Human-readable detail of the most recent export failure, if any.
+  string last_error = 5;
+
+  // Count of failed export batches since the exporter was last (re)built.
+  int64 export_failures = 6;
+}
+
 // MoveContainerRequest is the source-side request to migrate a
 // container to a peer daemon.
 message MoveContainerRequest {

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -610,6 +610,43 @@ service ContainerService {
     };
   }
 
+  // SetMetricsExport enables or disables opt-in export of host/container
+  // infra metrics to the host cloud's native monitoring (GCP Cloud
+  // Monitoring in the MVP; AWS is a reserved enum value that returns
+  // UNIMPLEMENTED). Enabling validates the provider and, for GCP, resolves
+  // Application Default Credentials with the monitoring-write scope as a
+  // synchronous dry run — a host with no usable ADC gets FAILED_PRECONDITION
+  // with an IAM remediation hint and nothing is persisted or started.
+  // Disabling stops emission within one export interval. Neither direction
+  // requires a daemon restart. #1069 delivers the toggle, config
+  // persistence, and the credential probe; the metrics collector itself
+  // lands with #1070/#1071.
+  rpc SetMetricsExport(SetMetricsExportRequest) returns (SetMetricsExportResponse) {
+    option (google.api.http) = {
+      post: "/v1/system/metrics-export"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Enable or disable cloud-native metrics export";
+      description: "Opt-in export of host/container infra metrics to the host cloud's native monitoring (GCP Cloud Monitoring in the MVP). Enabling probes Application Default Credentials (monitoring-write scope) before persisting anything; a host with no resolvable ADC fails with FAILED_PRECONDITION and an IAM remediation hint. Disabling stops emission within one export interval. AWS is reserved and returns UNIMPLEMENTED.";
+      tags: "Monitoring";
+    };
+  }
+
+  // GetMetricsExport returns the current cloud-native metrics export
+  // configuration and last-known health (last success time, last error,
+  // failure count — populated once #1070/#1071 wire the collector).
+  rpc GetMetricsExport(GetMetricsExportRequest) returns (GetMetricsExportResponse) {
+    option (google.api.http) = {
+      get: "/v1/system/metrics-export"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get cloud-native metrics export status";
+      description: "Returns whether cloud-native metrics export is enabled, the configured provider, the export interval, and last-known health (populated once the collector lands in #1070/#1071).";
+      tags: "Monitoring";
+    };
+  }
+
   // CreateAlertRule creates a new custom alert rule
   rpc CreateAlertRule(CreateAlertRuleRequest) returns (CreateAlertRuleResponse) {
     option (google.api.http) = {


### PR DESCRIPTION
## What / why

Adds the opt-in enable/disable/status surface for **cloud-native metrics export** (PRD: `prd/cloud/cloud-native-metrics-export.md` in the cloud repo; design: `docs/CLOUD-NATIVE-METRICS-EXPORT-DESIGN.md`, included in this PR).

- New `.proto` contract: `CloudMetricsProvider` enum (`UNSPECIFIED`, `GCP`, `AWS` reserved) + `SetMetricsExport`/`GetMetricsExport` RPCs with `google.api.http` + openapiv2 annotations, regenerated via `make proto` (no hand-edited generated code).
- New `internal/metrics/cloudexport` package: a `Sink` interface (`NewExporter`, `Probe`) and a `gcpSink` whose `Probe()` resolves GCP Application Default Credentials scoped for Cloud Monitoring writes — with an injectable credentials-lookup var so it's unit-testable without any network call. `NewExporter` is intentionally a stub; the real exporter/collector lands with #1070/#1071 per the design doc.
- Server: enum validation (`UNSPECIFIED` → `InvalidArgument`, `AWS` → `Unimplemented`), probe-failure persists nothing, typed config persistence, status round-trip.
- CLI: `containarium monitoring export enable --provider gcp|disable|status`.
- Client: `SetMetricsExport`/`GetMetricsExport` wired in `internal/client/{grpc.go,http.go}`.
- MCP: `set_metrics_export`/`get_metrics_export` thin wrappers over the same client path, scoped `containers:write`/`containers:read` (following the `toggle_monitoring`/`get_system_info` precedent rather than introducing a new scope for one feature).

## Test evidence

```
go build ./...   → clean
go vet ./...     → clean
go test $(go list ./... | grep -v /test/integration)   → all packages ok (no failures, no skips)
```

Covers: enum validation table tests, ADC-probe table tests (fake credential lookup, no network), CLI handler tests, MCP scope-assignment test (`TestEveryToolHasScope`), MCP tool-count golden test (updated 56→58 with the two new tools, per repo convention of documenting each addition inline).

`test/integration/...` (`TestStorageQuotaEnforcement` et al.) fails on `main` too — it dials a live daemon on `localhost:50051` which isn't running in this environment; confirmed pre-existing via `git stash` against a clean `main` checkout, unrelated to this change.

## Notes

- Grepped the diff for concrete instance/tenant names per this repo's OSS-anonymization convention — none found.
- `go.mod`: `golang.org/x/oauth2` promoted from indirect to direct (now imported directly by `gcp.go`), via `go mod tidy`.

Closes #1069
Part of #1074

🤖 Generated with [Claude Code](https://claude.com/claude-code)
