### PR TITLE
fix(metrics-export): resume export after identity is wired, not with placeholder labels (#1080)

### DIFF
--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -260,10 +260,15 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	// default and resume-on-restart silently never fired (caught live
 	// on a GCP backend while validating #1070).
 	containerServer.SetDaemonConfigStore(config.DaemonConfigStore)
-	// Resume host-series export (#1070) if it was enabled before a
-	// restart. Best-effort — a failure here (e.g. ADC no longer
-	// resolvable) is logged, never fatal to boot.
-	containerServer.StartMetricsExportIfEnabled(context.Background())
+	// NOTE: metrics-export resume (StartMetricsExportIfEnabled) is
+	// deliberately NOT called here. The resumed collector snapshots the
+	// daemon's backend_id/region at build time, and neither is populated
+	// this early in NewDualServer — localBackendID() returns "local" and
+	// region is "" until SetPeerPool / SetCapabilityIdentity run in
+	// Start(). Resuming here re-emitted every host's series under a second
+	// ("local"/"") identity after each restart, splitting dashboards and
+	// alerts keyed on backend_id (#1080). Resume is sequenced in Start()
+	// after identity is wired instead.
 
 	// Create token manager. Refuses to start if the JWT secret is
 	// shorter than auth.MinSecretKeyLen — fail-closed on weak crypto
@@ -1946,6 +1951,17 @@ func (ds *DualServer) Start(ctx context.Context) error {
 			// Enable terminal WebSocket proxying to peer backends
 			ds.gatewayServer.SetTerminalPeerProxy(ds.peerPool)
 		}
+	}
+
+	// Resume cloud host-series export (#1070) if it was enabled before a
+	// restart. Sequenced here — after SetCapabilityIdentity and, when
+	// pooled, SetPeerPool above — so the resumed collector snapshots the
+	// daemon's real backend_id/region rather than the "local"/"" placeholders
+	// it captured when this ran inline in NewDualServer before identity was
+	// wired (#1080). Best-effort: a failure (e.g. ADC no longer resolvable)
+	// is logged, never fatal to boot.
+	if ds.containerServer != nil {
+		ds.containerServer.StartMetricsExportIfEnabled(ctx)
 	}
 
 	// Start traffic collector if available

--- a/internal/server/metrics_export_server.go
+++ b/internal/server/metrics_export_server.go
@@ -66,10 +66,11 @@ type daemonConfigKV interface {
 }
 
 // SetDaemonConfigStore wires the persistent daemon-config store the
-// metrics export config survives restarts through. NewDualServer MUST
-// call this before StartMetricsExportIfEnabled — the resume path
-// hydrates from this store, and hydrating before it is wired reads the
-// disabled default instead of the operator's persisted enable (the
+// metrics export config survives restarts through. This MUST run before
+// the resume path (StartMetricsExportIfEnabled, sequenced in
+// DualServer.Start) — the resume path hydrates from this store, and
+// hydrating before it is wired reads the disabled default instead of the
+// operator's persisted enable (the
 // #1070 live test on a GCP backend caught exactly that ordering: the
 // store used to be assigned only much later, via SetAlertManager, so
 // resume-on-restart never fired). Nil is ignored so a daemon without
@@ -289,18 +290,33 @@ func (s *ContainerServer) buildMetricsExportCollector(ctx context.Context, cfg c
 	}
 
 	return cloudexport.NewCollector(cloudexport.CollectorOptions{
-		Sources:  sources,
-		Exporter: exporter,
-		Resource: res,
-		Labels: cloudexport.Labels{
-			BackendID:     s.localBackendID(),
-			Hostname:      sources.Hostname(),
-			Region:        s.region,
-			DaemonVersion: version.GetVersion(),
-		},
+		Sources:         sources,
+		Exporter:        exporter,
+		Resource:        res,
+		Labels:          s.currentExportLabels(sources.Hostname()),
 		IntervalSeconds: cfg.IntervalSeconds,
 		Groups:          cfg.Groups,
 	}), nil
+}
+
+// currentExportLabels snapshots the daemon's identity labels for a
+// metrics-export collector at the moment it is built: the real backend
+// id and operator-set region as they stand now, plus the given hostname.
+// Both the runtime enable path (SetMetricsExport) and the startup resume
+// path (StartMetricsExportIfEnabled) capture labels through here, so a
+// resumed collector carries the same identity a runtime-enabled one
+// would — provided resume runs after the daemon's identity is wired
+// (SetCapabilityIdentity / SetPeerPool in DualServer.Start). Resume is
+// sequenced there, not inline in NewDualServer, precisely so this
+// snapshot sees the real identity and not the "local"/"" placeholders
+// localBackendID()/region return before identity init (#1080).
+func (s *ContainerServer) currentExportLabels(hostname string) cloudexport.Labels {
+	return cloudexport.Labels{
+		BackendID:     s.localBackendID(),
+		Hostname:      hostname,
+		Region:        s.region,
+		DaemonVersion: version.GetVersion(),
+	}
 }
 
 // swapMetricsExportCollector installs newC as the running collector

--- a/internal/server/metrics_export_server_test.go
+++ b/internal/server/metrics_export_server_test.go
@@ -667,3 +667,121 @@ func TestMetricsExport_LateStoreWiring_NotCachedAsDisabled(t *testing.T) {
 		t.Fatal("persisted enabled=true was shadowed by a cached nil-store hydration")
 	}
 }
+
+// TestCurrentExportLabels pins the label snapshot a collector is built
+// with: it must read the daemon's identity as of the call, so identity
+// wired after the ContainerServer is constructed (as DualServer.Start
+// does) is reflected — not frozen at construction. This is the #1080
+// invariant: the resumed and runtime-enabled collectors share this one
+// snapshot function, so both carry the same backend_id/region.
+func TestCurrentExportLabels(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(*ContainerServer)
+		wantBackID string
+		wantRegion string
+	}{
+		{
+			name: "pooled backend with region -> real identity",
+			setup: func(s *ContainerServer) {
+				s.SetPeerPool(NewPeerPool("backend-live-7", "", nil, "us-central1"))
+				s.SetCapabilityIdentity("us-central1", "us-central1")
+			},
+			wantBackID: "backend-live-7",
+			wantRegion: "us-central1",
+		},
+		{
+			name: "identity applied after construction is reflected (not frozen early)",
+			setup: func(s *ContainerServer) {
+				// Emulate DualServer.Start wiring identity onto an
+				// already-constructed server, the exact sequence the
+				// #1080 fix depends on.
+				s.SetCapabilityIdentity("eu-west1", "eu-west1")
+				s.SetPeerPool(NewPeerPool("backend-eu-2", "", nil, "eu-west1"))
+			},
+			wantBackID: "backend-eu-2",
+			wantRegion: "eu-west1",
+		},
+		{
+			name:       "no pool, empty region -> documented single-host placeholder",
+			setup:      func(s *ContainerServer) {},
+			wantBackID: "local",
+			wantRegion: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &ContainerServer{}
+			tc.setup(s)
+			got := s.currentExportLabels("host-1")
+			if got.BackendID != tc.wantBackID || got.Region != tc.wantRegion {
+				t.Errorf("currentExportLabels() = {backend_id:%q region:%q}, want {backend_id:%q region:%q}",
+					got.BackendID, got.Region, tc.wantBackID, tc.wantRegion)
+			}
+			if got.Hostname != "host-1" {
+				t.Errorf("hostname = %q, want the passed-in host-1", got.Hostname)
+			}
+		})
+	}
+}
+
+// TestStartMetricsExportIfEnabled_ResumeCapturesLiveIdentity is the
+// #1080 regression. The live bug: StartMetricsExportIfEnabled ran inline
+// in NewDualServer, before SetPeerPool/SetCapabilityIdentity, so the
+// resumed collector snapshotted the "local"/"" placeholders instead of
+// the daemon's real backend_id/region — every daemon restart re-emitted
+// the host's series under a second identity, splitting dashboards and
+// alerts keyed on backend_id. This drives the real resume path and
+// observes, via the builder seam, exactly the identity the collector is
+// built with. The fix sequences resume after identity is wired
+// (DualServer.Start), so the "identity wired" case is the post-fix world
+// and the "identity absent" case documents what the old ordering emitted.
+func TestStartMetricsExportIfEnabled_ResumeCapturesLiveIdentity(t *testing.T) {
+	newEnabledResumeServer := func() (*ContainerServer, *cloudexport.Labels) {
+		s := &ContainerServer{}
+		s.SetMetricsExportSinks(map[pb.CloudMetricsProvider]cloudexport.Sink{
+			pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP: &fakeMetricsExportSink{},
+		})
+		s.daemonConfigStore = &fakeDaemonConfigKV{m: map[string]string{
+			cloudexport.ConfigStoreKey: `{"enabled":true,"provider":1,"interval_seconds":60}`,
+		}}
+		captured := &cloudexport.Labels{}
+		s.metricsExportBuilder = func(ctx context.Context, cfg cloudexport.Config, sink cloudexport.Sink) (*cloudexport.CloudExportCollector, error) {
+			// Snapshot identity the same way the real
+			// buildMetricsExportCollector does, at invoke time.
+			*captured = s.currentExportLabels("host-1")
+			return cloudexport.NewCollector(cloudexport.CollectorOptions{
+				Sources:  fakeExportSources{},
+				Exporter: &fakeExportExporter{},
+				Labels:   *captured,
+			}), nil
+		}
+		return s, captured
+	}
+
+	t.Run("identity wired before resume -> real labels (post-#1080-fix ordering)", func(t *testing.T) {
+		s, captured := newEnabledResumeServer()
+		s.SetPeerPool(NewPeerPool("backend-live-7", "", nil, "us-central1"))
+		s.SetCapabilityIdentity("us-central1", "us-central1")
+
+		s.StartMetricsExportIfEnabled(context.Background())
+
+		if captured.BackendID != "backend-live-7" || captured.Region != "us-central1" {
+			t.Fatalf("resumed collector labels = {backend_id:%q region:%q}, want the daemon's live identity {backend-live-7 us-central1}",
+				captured.BackendID, captured.Region)
+		}
+	})
+
+	t.Run("identity absent -> placeholder labels (the pre-fix NewDualServer ordering)", func(t *testing.T) {
+		s, captured := newEnabledResumeServer()
+		// No SetPeerPool / SetCapabilityIdentity: reproduces resume
+		// running before the daemon's identity was wired.
+		s.StartMetricsExportIfEnabled(context.Background())
+
+		if captured.BackendID != "local" || captured.Region != "" {
+			t.Fatalf("with identity unwired, labels = {backend_id:%q region:%q}, want the placeholder {local \"\"} the #1080 bug emitted",
+				captured.BackendID, captured.Region)
+		}
+	})
+}


### PR DESCRIPTION
Closes #1080

## What

A daemon that **resumed** cloud metrics export on restart re-emitted its host
series under `backend_id="local", region=""` instead of its real identity — so
every restart split the host across two `backend_id` streams and silently
dropped it from dashboards and alerts keyed on `backend_id`.

Root cause: `StartMetricsExportIfEnabled` ran inline in `NewDualServer`, before
`SetPeerPool` / `SetCapabilityIdentity`. The collector freezes its label set at
build time from `localBackendID()` and `s.region`, and both return their
placeholders (`"local"` / `""`) until identity is wired in `Start()`. The
runtime-enable path (`SetMetricsExport` RPC) was correct only because it always
runs after `Start()`.

- **Sequence resume in `DualServer.Start()`**, after identity is wired
  (`SetCapabilityIdentity`, and `SetPeerPool` when pooled), instead of inline in
  `NewDualServer`. Resume now shares the exact "identity ready before build"
  precondition the runtime-enable path already relies on.
- **Extract the label snapshot into `currentExportLabels`** so both the resume
  and runtime-enable paths capture identity through one tested seam, and a future
  freeze-at-construction regression is caught by a unit test.
- No proto, dependency, config, or env changes; label *semantics* (fixed snapshot,
  no tenant/org labels) are unchanged — only *when* the snapshot is taken.

This is the issue's fix direction #1 (defer resume until identity is ready),
chosen over #2 (late-bind labels per tick) to keep the blast radius off the
shared `collector.go` contract and its golden tests, and preserve the design's
fixed-snapshot label model.

## Test evidence

`go test ./internal/server/ -run 'Metrics|CurrentExportLabels' -v` — all green:

- **`TestStartMetricsExportIfEnabled_ResumeCapturesLiveIdentity`** (#1080 regression) —
  drives the real resume path and observes the identity the collector is built
  with via the builder seam:
  - `identity wired before resume -> real labels` — post-fix ordering yields
    `backend_id=backend-live-7, region=us-central1`.
  - `identity absent -> placeholder labels` — documents the exact `local`/`""`
    the pre-fix `NewDualServer` ordering emitted.
- **`TestCurrentExportLabels`** — the extracted snapshot reads identity as of the
  call (incl. an "applied after construction is reflected" case guarding against
  a freeze-at-construction regression); single-host `local`/`""` is preserved as
  the documented steady state.
- Pre-existing `TestStartMetricsExportIfEnabled_ResumesFromPersistedConfig` and
  `TestMetricsExport_LateStoreWiring_NotCachedAsDisabled` (the #1076/#1069
  resume + late-store guards) still pass — the reordering doesn't regress them.

```
ok  	github.com/footprintai/containarium/internal/server	2.294s
```

**Mutation check (proves the tests aren't tautologies):** freezing
`currentExportLabels` to return `"local"`/`""` makes
`ResumeCapturesLiveIdentity/identity wired before resume` fail with
`labels = {backend_id:"local" region:""}, want {backend-live-7 us-central1}`.
Reverted after.

## For the reviewer

- **One disclosed limitation:** the `Start()` ordering itself is not covered by an
  automated test — `DualServer.Start()` needs Incus/sentinel and isn't
  constructed in any unit test in this suite (see `TestDefaultMetricsExportSinks_RegistersGCP`,
  which verifies its one-line wiring by source-reading for the same reason). The
  fix is guarded structurally: a strong NOTE comment at the old call site in
  `NewDualServer` and the label-mechanism tests above. Moving the call back early
  would not be caught by CI — flagging so a reviewer weighs whether that's
  acceptable or wants the late-bind approach (#2) for ordering-proof robustness.
- **Environment:** built + tested locally on a freshly-resolved module cache
  (`go.mod` untouched — no new deps, env vars, or config to shake out on a clean
  box, so the fresh-box rationale doesn't bite here). `go vet ./internal/server/`
  clean.
