### PR TITLE
feat(metrics-export): heartbeat series + dead-man alert recipe (#1072)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -6859,6 +6859,17 @@
       },
       "title": "CleanupDiskResponse is the response from cleaning up disk space"
     },
+    "CloudMetricsGroup": {
+      "type": "string",
+      "enum": [
+        "CLOUD_METRICS_GROUP_UNSPECIFIED",
+        "CLOUD_METRICS_GROUP_HOST",
+        "CLOUD_METRICS_GROUP_CONTAINER",
+        "CLOUD_METRICS_GROUP_PLATFORM"
+      ],
+      "default": "CLOUD_METRICS_GROUP_UNSPECIFIED",
+      "description": "CloudMetricsGroup names an independently enableable set of exported\nseries (#1081). Export is organized into groups so the billed sample\nsurface — custom metrics are billed per ingested sample — stays a\ndeliberate, per-group choice rather than an all-or-nothing switch.\nTyped so a group can never be a magic string. Absent/empty on the wire\nmeans \"host only\" (CLOUD_METRICS_GROUP_HOST), which is exactly the\nv0.60.0 behavior a persisted config resumes into.\n\n - CLOUD_METRICS_GROUP_UNSPECIFIED: Unset. Never a valid element of an explicit groups list;\nSetMetricsExport rejects a request whose groups contain it. An empty\ngroups list (not a list of UNSPECIFIED) is what means \"default to\nhost\".\n - CLOUD_METRICS_GROUP_HOST: Host-infrastructure series (CPU load, memory, disk, container count)\n— the complete #1070 allowlist. The default when no group is named.\n - CLOUD_METRICS_GROUP_CONTAINER: Per-container series. Reserved by #1081 as an enableable group; the\nseries themselves land in #1071/#1072, so enabling it today exports\nno additional series.\n - CLOUD_METRICS_GROUP_PLATFORM: Platform-level series (API request/error counts, provisioning\noutcomes, peer connectivity). Reserved by #1081 as an enableable\ngroup; the series themselves land in #1082/#1083/#1084, so enabling\nit today exports no additional series."
+    },
     "CloudMetricsProvider": {
       "type": "string",
       "enum": [
@@ -8616,6 +8627,13 @@
           "type": "string",
           "format": "int64",
           "description": "Count of failed export batches since the exporter was last (re)built."
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CloudMetricsGroup"
+          },
+          "description": "The set of enabled metric groups (#1081). Normalized: a host that has\nnever configured groups (or a v0.60.0 config with none persisted)\nreports [CLOUD_METRICS_GROUP_HOST]."
         }
       },
       "description": "GetMetricsExportResponse reports the current cloud-native metrics\nexport configuration and last-known health. last_success_at,\nlast_error, and export_failures are zero-valued until the collector\n(#1070/#1071) is wired — #1069 delivers the toggle, config\npersistence, and enable-time credential probe only."
@@ -11077,6 +11095,13 @@
         "provider": {
           "$ref": "#/definitions/CloudMetricsProvider",
           "description": "Target cloud provider. Required when enabled=true. Must not be\nCLOUD_METRICS_PROVIDER_UNSPECIFIED (INVALID_ARGUMENT) or\nCLOUD_METRICS_PROVIDER_AWS (UNIMPLEMENTED — MVP is GCP-only)."
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CloudMetricsGroup"
+          },
+          "description": "The metric groups to export (#1081). Enables exactly these groups;\nan empty list defaults to [CLOUD_METRICS_GROUP_HOST], preserving the\nv0.60.0 host-only behavior. Every element must be a defined group\nother than CLOUD_METRICS_GROUP_UNSPECIFIED (INVALID_ARGUMENT\notherwise). Ignored when enabled=false."
         }
       },
       "description": "SetMetricsExportRequest enables or disables cloud-native metrics export.\nEnabling with provider=GCP triggers a synchronous Application Default\nCredentials probe (monitoring-write scope) before anything is persisted\nor started; enabling with an unresolvable ADC fails the call and leaves\nthe prior config untouched."
@@ -11098,6 +11123,13 @@
         "intervalSeconds": {
           "type": "integer",
           "format": "int32"
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CloudMetricsGroup"
+          },
+          "description": "The effective set of enabled metric groups after the call (#1081),\nnormalized: an omitted/empty request list resolves to\n[CLOUD_METRICS_GROUP_HOST]."
         }
       },
       "description": "SetMetricsExportResponse reports the effective state after the toggle."

--- a/docs/CLOUD-NATIVE-METRICS-EXPORT-DESIGN.md
+++ b/docs/CLOUD-NATIVE-METRICS-EXPORT-DESIGN.md
@@ -114,7 +114,11 @@ the next interval because collection enumerates live containers each tick.
 4. Disable: rebuilds without the reader; emission stops within one interval.
 5. Host/daemon death: emission stops ⇒ the operator's metric-absence policy on
    `containarium.export.heartbeat` fires. This is the out-of-band property: no
-   component on the host needs to survive for the alert to work.
+   component on the host needs to survive for the alert to work. The heartbeat
+   is emitted on its own callback, independent of `Sources`, so a transient
+   source error skips the host series for a tick but never suppresses the
+   heartbeat — only real daemon/host death does. The exact absence-policy recipe
+   (`gcloud`/JSON) lives in `docs/METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md`.
 
 ## Contracts
 

--- a/docs/METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md
+++ b/docs/METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md
@@ -1,0 +1,159 @@
+# Runbook: dead-man alert for backend liveness (GCP Cloud Monitoring)
+
+**Applies to:** the opt-in cloud-native metrics export (`containarium
+monitoring export`, design: `docs/CLOUD-NATIVE-METRICS-EXPORT-DESIGN.md`).
+**Goal:** page an operator when a backend goes silent — host or daemon
+dead, wedged, or network-partitioned from the cloud — *out of band*, so
+the alert does not fate-share with the thing it is watching.
+
+## Why this exists
+
+Host-local alerting (vmalert on the backend's own VictoriaMetrics LXC)
+cannot report that its host is dead: when the host dies, the alerter dies
+with it. The metrics export emits a **heartbeat series** to the cloud
+provider's own monitoring every interval; a **metric-absence** alert
+policy there fires precisely when that series stops arriving. Nothing on
+the backend needs to survive for the alert to work — that is the whole
+point.
+
+## The heartbeat series
+
+| Field | Value |
+|---|---|
+| Metric (OTel instrument) | `containarium.export.heartbeat` |
+| Cloud Monitoring metric type | `workload.googleapis.com/containarium.export.heartbeat` |
+| Monitored resource | `gce_instance` (GCP resource detector) |
+| Kind / value | gauge, constant `1` |
+| Labels | `backend_id`, `hostname`, `daemon_version` |
+| Emit cadence | every export interval (default 60s, floor 60s) |
+
+The heartbeat is emitted on its own callback, **independent of the host
+metric sources**. A transient source error (e.g. incus briefly
+unavailable) skips the host series for that tick but still emits the
+heartbeat — a source hiccup is not backend death and must not trip this
+alert. The series stops if and only if the daemon stops exporting: host
+down, daemon down, or the daemon cannot reach Cloud Monitoring.
+
+## Prerequisites
+
+1. Export enabled on the backend and confirmed healthy:
+
+   ```bash
+   containarium monitoring export enable --provider gcp
+   containarium monitoring export status   # last_success_at recent, no last_error
+   ```
+
+2. The series is arriving in the project. Confirm the metric descriptor
+   exists (it is created on first ingest, usually within ~2 minutes):
+
+   ```bash
+   gcloud monitoring metrics-descriptors list \
+     --project="${PROJECT_ID}" \
+     --filter='metric.type = "workload.googleapis.com/containarium.export.heartbeat"'
+   ```
+
+3. A notification channel to page (email/PagerDuty/Slack/etc.). To list
+   existing ones:
+
+   ```bash
+   gcloud alpha monitoring channels list --project="${PROJECT_ID}" \
+     --format='table(name, type, displayName)'
+   ```
+
+## Create the dead-man alert policy
+
+Write the policy to a file (`deadman-heartbeat-policy.json`). Replace
+`${PROJECT_ID}` and `${CHANNEL_ID}` with your project and notification
+channel id.
+
+```json
+{
+  "displayName": "Containarium backend dead-man (heartbeat absent)",
+  "documentation": {
+    "content": "The containarium.export.heartbeat series stopped arriving from a backend. The daemon or host is dead, wedged, or network-partitioned from Cloud Monitoring. Check the backend host and the containarium daemon; this alert fires precisely because the backend went silent, so host-local dashboards may be unreachable.",
+    "mimeType": "text/markdown"
+  },
+  "combiner": "OR",
+  "conditions": [
+    {
+      "displayName": "Heartbeat absent for 5m (per backend)",
+      "conditionAbsent": {
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.export.heartbeat\"",
+        "duration": "300s",
+        "aggregations": [
+          {
+            "alignmentPeriod": "60s",
+            "perSeriesAligner": "ALIGN_MEAN"
+          }
+        ],
+        "trigger": { "count": 1 }
+      }
+    }
+  ],
+  "notificationChannels": [
+    "projects/${PROJECT_ID}/notificationChannels/${CHANNEL_ID}"
+  ],
+  "alertStrategy": {
+    "autoClose": "1800s"
+  }
+}
+```
+
+Create it:
+
+```bash
+gcloud alpha monitoring policies create \
+  --project="${PROJECT_ID}" \
+  --policy-from-file=deadman-heartbeat-policy.json
+```
+
+### Why these values
+
+- **`conditionAbsent`** is the metric-absence ("dead-man") condition
+  type — it fires when *no* data matches the filter for `duration`,
+  which is exactly what a stopped heartbeat looks like. A threshold
+  condition would not fire on absence.
+- **`duration: 300s`** with a **60s** export interval tolerates a few
+  dropped batches (transient export failure, one slow tick) before
+  paging — five missed heartbeats, not one. Raise it if your interval is
+  longer; keep it at a small multiple of the interval.
+- **`alignmentPeriod: 60s`** matches the emit cadence so each interval is
+  one aligned point.
+- The **filter has no `backend_id`**, so the policy covers every backend
+  exporting into the project. Cloud Monitoring evaluates absence
+  per-time-series, so one silent backend fires while the others stay
+  green. To scope to a single backend, add
+  `AND metric.label.backend_id = "<backend-id>"`.
+- **`autoClose: 1800s`** clears the incident once heartbeats resume.
+
+## Verify (live)
+
+This is the acceptance test for the alert and can only be done against a
+real project with real ingestion — it is not reproducible in CI:
+
+1. With export enabled and the policy created, confirm the series in
+   Metrics Explorer (metric
+   `workload.googleapis.com/containarium.export.heartbeat`) shows a flat
+   line at `1`.
+2. Stop the daemon on the backend (`systemctl stop containarium` or the
+   equivalent for your deployment).
+3. Wait for `duration` + one alignment period (~6 minutes with the values
+   above). The policy transitions to **firing** and the notification
+   channel pages.
+4. Restart the daemon; heartbeats resume within one interval and the
+   incident auto-closes.
+
+Record the fired-incident screenshot / link in your operator log.
+
+## Tuning notes
+
+- **False pages on export flakiness:** if the provider endpoint or the
+  backend's egress is intermittently slow, widen `duration` (e.g. to
+  `600s`) rather than lowering the export interval — the interval floor
+  is a cost guard (custom metrics are billed per sample) and dropping it
+  is not supported.
+- **Cost:** one extra series per backend at one sample per interval;
+  negligible next to the host/container series already exported.
+- **Multi-cloud:** AWS export is not implemented yet; the equivalent
+  there is a CloudWatch "missing data → breaching" alarm on the same
+  heartbeat metric once an AWS sink lands.

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -247,13 +247,14 @@ func (c *GRPCClient) ToggleMonitoring(username string, enabled bool) (string, bo
 // unsupported provider (AWS, UNSPECIFIED) returns the daemon's error
 // unwrapped so the CLI can render the gRPC code (FailedPrecondition /
 // InvalidArgument / Unimplemented) directly.
-func (c *GRPCClient) SetMetricsExport(enabled bool, provider pb.CloudMetricsProvider) (*pb.SetMetricsExportResponse, error) {
+func (c *GRPCClient) SetMetricsExport(enabled bool, provider pb.CloudMetricsProvider, groups []pb.CloudMetricsGroup) (*pb.SetMetricsExportResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	return c.client.SetMetricsExport(ctx, &pb.SetMetricsExportRequest{
 		Enabled:  enabled,
 		Provider: provider,
+		Groups:   groups,
 	})
 }
 

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -624,7 +624,7 @@ func (c *HTTPClient) ToggleMonitoring(username string, enabled bool) (string, bo
 // and INVALID_ARGUMENT to HTTP 400 and UNIMPLEMENTED to HTTP 501, but
 // the CLI only needs the message text, which carries the IAM
 // remediation hint for the credential-probe case.
-func (c *HTTPClient) SetMetricsExport(enabled bool, provider pb.CloudMetricsProvider) (*pb.SetMetricsExportResponse, error) {
+func (c *HTTPClient) SetMetricsExport(enabled bool, provider pb.CloudMetricsProvider, groups []pb.CloudMetricsGroup) (*pb.SetMetricsExportResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -633,6 +633,17 @@ func (c *HTTPClient) SetMetricsExport(enabled bool, provider pb.CloudMetricsProv
 		// Emit the enum by its proto JSON name so grpc-gateway decodes it
 		// into the CloudMetricsProvider enum.
 		"provider": provider.String(),
+	}
+	// Emit groups by their proto JSON names so grpc-gateway decodes the
+	// repeated CloudMetricsGroup enum (#1081). Omitted when empty so a
+	// host-only call stays byte-identical to the pre-groups request and
+	// lets the server apply its host default.
+	if len(groups) > 0 {
+		groupNames := make([]string, 0, len(groups))
+		for _, g := range groups {
+			groupNames = append(groupNames, g.String())
+		}
+		body["groups"] = groupNames
 	}
 	resp, err := c.doRequest(ctx, http.MethodPost, "/v1/system/metrics-export", body)
 	if err != nil {

--- a/internal/cmd/monitoring_export.go
+++ b/internal/cmd/monitoring_export.go
@@ -16,6 +16,12 @@ import (
 // allow-list living in the CLI.
 var metricsExportProvider string
 
+// metricsExportGroups backs the --groups flag on `monitoring export
+// enable` (#1081): a comma-separated list of metric groups to enable
+// (host, container, platform). Omitted keeps today's behavior — the
+// server defaults an empty selection to host.
+var metricsExportGroups string
+
 var monitoringExportCmd = &cobra.Command{
 	Use:   "export",
 	Short: "Enable, disable, or inspect cloud-native metrics export",
@@ -43,8 +49,11 @@ monitoring-write scope; failure returns an actionable error (with an
 IAM remediation hint) and nothing is enabled. Takes effect immediately,
 no daemon restart required.
 
-Examples:
-  containarium monitoring export enable --provider gcp`,
+Groups (#1081) select which independently-billed series sets export.
+Omit --groups to keep host-only (the default); name others to opt in:
+
+  containarium monitoring export enable --provider gcp
+  containarium monitoring export enable --provider gcp --groups host,platform`,
 	Args: cobra.NoArgs,
 	RunE: runMetricsExportEnable,
 }
@@ -77,6 +86,7 @@ Examples:
 
 func init() {
 	monitoringExportEnableCmd.Flags().StringVar(&metricsExportProvider, "provider", "", "cloud provider to export to (gcp)")
+	monitoringExportEnableCmd.Flags().StringVar(&metricsExportGroups, "groups", "", "comma-separated metric groups to enable (host,container,platform); omit for host only")
 
 	monitoringCmd.AddCommand(monitoringExportCmd)
 	monitoringExportCmd.AddCommand(monitoringExportEnableCmd)
@@ -104,8 +114,65 @@ func parseMetricsExportProvider(s string) (pb.CloudMetricsProvider, error) {
 	}
 }
 
+// parseMetricsExportGroups maps the CLI's comma-separated --groups flag
+// to a typed CloudMetricsGroup list. No magic strings past this boundary
+// — every other layer (client, server, config, collector) speaks the
+// enum. An empty flag returns nil so the server applies its host-only
+// default; an unknown token is rejected here (a client-side typo like
+// "hosts") with the supported list. Whitespace and empty elements are
+// tolerated so `--groups "host, platform"` works.
+func parseMetricsExportGroups(s string) ([]pb.CloudMetricsGroup, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, nil
+	}
+	var groups []pb.CloudMetricsGroup
+	for _, tok := range strings.Split(s, ",") {
+		switch strings.ToLower(strings.TrimSpace(tok)) {
+		case "":
+			continue
+		case "host":
+			groups = append(groups, pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST)
+		case "container":
+			groups = append(groups, pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER)
+		case "platform":
+			groups = append(groups, pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM)
+		default:
+			return nil, fmt.Errorf("unknown metric group %q (supported: host, container, platform)", strings.TrimSpace(tok))
+		}
+	}
+	return groups, nil
+}
+
+// metricsExportGroupsLabel renders a group list the way an operator types
+// it back on the CLI (lowercase, comma-separated). An empty list renders
+// as "host" — the server's effective default — so status output never
+// shows a blank group set.
+func metricsExportGroupsLabel(groups []pb.CloudMetricsGroup) string {
+	if len(groups) == 0 {
+		return "host"
+	}
+	labels := make([]string, 0, len(groups))
+	for _, g := range groups {
+		switch g {
+		case pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST:
+			labels = append(labels, "host")
+		case pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER:
+			labels = append(labels, "container")
+		case pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM:
+			labels = append(labels, "platform")
+		default:
+			labels = append(labels, strings.ToLower(g.String()))
+		}
+	}
+	return strings.Join(labels, ",")
+}
+
 func runMetricsExportEnable(cmd *cobra.Command, args []string) error {
 	provider, err := parseMetricsExportProvider(metricsExportProvider)
+	if err != nil {
+		return err
+	}
+	groups, err := parseMetricsExportGroups(metricsExportGroups)
 	if err != nil {
 		return err
 	}
@@ -113,13 +180,13 @@ func runMetricsExportEnable(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--server is required for metrics export (no local fallback)")
 	}
 
-	resp, err := setMetricsExportClient(true, provider)
+	resp, err := setMetricsExportClient(true, provider, groups)
 	if err != nil {
 		return fmt.Errorf("failed to enable cloud metrics export: %w", err)
 	}
 
-	fmt.Printf("✓ cloud metrics export enabled (provider=%s, interval=%ds)\n",
-		metricsExportProviderLabel(resp.Provider), resp.IntervalSeconds)
+	fmt.Printf("✓ cloud metrics export enabled (provider=%s, groups=%s, interval=%ds)\n",
+		metricsExportProviderLabel(resp.Provider), metricsExportGroupsLabel(resp.Groups), resp.IntervalSeconds)
 	if resp.Message != "" {
 		fmt.Println(resp.Message)
 	}
@@ -131,7 +198,7 @@ func runMetricsExportDisable(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--server is required for metrics export (no local fallback)")
 	}
 
-	resp, err := setMetricsExportClient(false, pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED)
+	resp, err := setMetricsExportClient(false, pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED, nil)
 	if err != nil {
 		return fmt.Errorf("failed to disable cloud metrics export: %w", err)
 	}
@@ -158,8 +225,8 @@ func runMetricsExportStatus(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Printf("cloud metrics export: enabled (provider=%s, interval=%ds)\n",
-		metricsExportProviderLabel(resp.Provider), resp.IntervalSeconds)
+	fmt.Printf("cloud metrics export: enabled (provider=%s, groups=%s, interval=%ds)\n",
+		metricsExportProviderLabel(resp.Provider), metricsExportGroupsLabel(resp.Groups), resp.IntervalSeconds)
 	if resp.LastSuccessAt != nil && resp.LastSuccessAt.IsValid() && resp.LastSuccessAt.AsTime().Unix() > 0 {
 		fmt.Printf("  last success: %s\n", resp.LastSuccessAt.AsTime().Local().Format("2006-01-02 15:04:05 MST"))
 	}
@@ -190,21 +257,21 @@ func metricsExportProviderLabel(p pb.CloudMetricsProvider) string {
 // runMonitoringToggle's httpMode branch in internal/cmd/monitoring.go.
 // This is the one function the MCP tool also calls (internal/mcp/tools.go)
 // — CLI-first per the repo convention.
-func setMetricsExportClient(enabled bool, provider pb.CloudMetricsProvider) (*pb.SetMetricsExportResponse, error) {
+func setMetricsExportClient(enabled bool, provider pb.CloudMetricsProvider, groups []pb.CloudMetricsGroup) (*pb.SetMetricsExportResponse, error) {
 	if httpMode {
 		httpClient, err := client.NewHTTPClient(serverAddr, authToken)
 		if err != nil {
 			return nil, err
 		}
 		defer func() { _ = httpClient.Close() }()
-		return httpClient.SetMetricsExport(enabled, provider)
+		return httpClient.SetMetricsExport(enabled, provider, groups)
 	}
 	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = grpcClient.Close() }()
-	return grpcClient.SetMetricsExport(enabled, provider)
+	return grpcClient.SetMetricsExport(enabled, provider, groups)
 }
 
 func getMetricsExportClient() (*pb.GetMetricsExportResponse, error) {

--- a/internal/cmd/monitoring_export_test.go
+++ b/internal/cmd/monitoring_export_test.go
@@ -75,6 +75,84 @@ func TestParseMetricsExportProvider(t *testing.T) {
 	}
 }
 
+// TestParseMetricsExportGroups covers --groups flag parsing: the empty
+// case (omitted ⇒ nil ⇒ server defaults to host), each known group,
+// case-insensitivity and whitespace tolerance, multi-group lists, and
+// the client-side rejection of an unknown group name.
+func TestParseMetricsExportGroups(t *testing.T) {
+	host := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST
+	container := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+
+	tests := []struct {
+		name      string
+		input     string
+		want      []pb.CloudMetricsGroup
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "empty omits (server defaults host)", input: "", want: nil},
+		{name: "host", input: "host", want: []pb.CloudMetricsGroup{host}},
+		{name: "container", input: "container", want: []pb.CloudMetricsGroup{container}},
+		{name: "platform", input: "platform", want: []pb.CloudMetricsGroup{platform}},
+		{name: "host,platform", input: "host,platform", want: []pb.CloudMetricsGroup{host, platform}},
+		{name: "whitespace tolerated", input: " host , platform ", want: []pb.CloudMetricsGroup{host, platform}},
+		{name: "case-insensitive", input: "HOST,Platform", want: []pb.CloudMetricsGroup{host, platform}},
+		{name: "empty elements skipped", input: "host,,platform", want: []pb.CloudMetricsGroup{host, platform}},
+		{name: "unknown group rejected", input: "host,bogus", wantErr: true, errSubstr: "unknown metric group"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMetricsExportGroups(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseMetricsExportGroups(%q) = %v, nil; want error containing %q", tc.input, got, tc.errSubstr)
+				}
+				if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Errorf("error = %q, want substring %q", err.Error(), tc.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("parseMetricsExportGroups(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("parseMetricsExportGroups(%q)[%d] = %v, want %v", tc.input, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMetricsExportGroupsLabel(t *testing.T) {
+	tests := []struct {
+		name   string
+		groups []pb.CloudMetricsGroup
+		want   string
+	}{
+		{"empty is host default", nil, "host"},
+		{"single", []pb.CloudMetricsGroup{pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST}, "host"},
+		{
+			"multi",
+			[]pb.CloudMetricsGroup{
+				pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST,
+				pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM,
+			},
+			"host,platform",
+		},
+	}
+	for _, tc := range tests {
+		if got := metricsExportGroupsLabel(tc.groups); got != tc.want {
+			t.Errorf("metricsExportGroupsLabel(%v) = %q, want %q", tc.groups, got, tc.want)
+		}
+	}
+}
+
 func TestMetricsExportProviderLabel(t *testing.T) {
 	tests := []struct {
 		provider pb.CloudMetricsProvider

--- a/internal/mcp/backend.go
+++ b/internal/mcp/backend.go
@@ -88,7 +88,7 @@ type API interface {
 	// monitoring. Host-level like GetSystemInfo — the credential probe
 	// (GCP ADC) is specific to the box the daemon runs on, so it has no
 	// tenant-safe meaning on the hosted control plane.
-	SetMetricsExport(enabled bool, provider string) (*SetMetricsExportResponse, error)
+	SetMetricsExport(enabled bool, provider string, groups []string) (*SetMetricsExportResponse, error)
 	GetMetricsExport() (*GetMetricsExportResponse, error)
 	// InstallZap downloads and installs OWASP ZAP into this host's
 	// security container. Host-level — a daemon manages exactly one
@@ -154,7 +154,7 @@ func (cloudClient) InstallZap() (*InstallZapResponse, error) {
 	return nil, errUnsupportedOnCloud("install_zap", "the platform provisions ZAP on managed hosts")
 }
 
-func (cloudClient) SetMetricsExport(bool, string) (*SetMetricsExportResponse, error) {
+func (cloudClient) SetMetricsExport(bool, string, []string) (*SetMetricsExportResponse, error) {
 	return nil, errUnsupportedOnCloud("set_metrics_export", "the credential probe is specific to a BYOC host; run this against the host's own daemon")
 }
 

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -909,11 +909,31 @@ func metricsExportProviderWireName(provider string) (string, error) {
 	}
 }
 
+// metricsExportGroupWireName maps a CLI-facing lowercase metric-group
+// name ("host"/"container"/"platform") to the full CloudMetricsGroup
+// enum name the wire protocol (protojson) expects (#1081). Mirrors
+// internal/cmd/monitoring_export.go's parseMetricsExportGroups without
+// importing pkg/pb — this package keeps its own plain-struct wire types.
+func metricsExportGroupWireName(group string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(group)) {
+	case "host":
+		return "CLOUD_METRICS_GROUP_HOST", nil
+	case "container":
+		return "CLOUD_METRICS_GROUP_CONTAINER", nil
+	case "platform":
+		return "CLOUD_METRICS_GROUP_PLATFORM", nil
+	default:
+		return "", fmt.Errorf("unknown metric group %q (supported: host, container, platform)", group)
+	}
+}
+
 // SetMetricsExport enables or disables opt-in export of host/container
 // infra metrics to the host cloud's native monitoring (#1069). provider
 // is required when enabled=true ("gcp"; "aws" is accepted and rejected
-// server-side with Unimplemented) and ignored when disabling.
-func (c *Client) SetMetricsExport(enabled bool, provider string) (*SetMetricsExportResponse, error) {
+// server-side with Unimplemented) and ignored when disabling. groups
+// (#1081) selects which series sets export ("host"/"container"/
+// "platform"); empty keeps today's host-only default.
+func (c *Client) SetMetricsExport(enabled bool, provider string, groups []string) (*SetMetricsExportResponse, error) {
 	wireProvider := "CLOUD_METRICS_PROVIDER_UNSPECIFIED"
 	if enabled {
 		wp, err := metricsExportProviderWireName(provider)
@@ -923,10 +943,23 @@ func (c *Client) SetMetricsExport(enabled bool, provider string) (*SetMetricsExp
 		wireProvider = wp
 	}
 
-	body, err := json.Marshal(map[string]interface{}{
+	reqBody := map[string]interface{}{
 		"enabled":  enabled,
 		"provider": wireProvider,
-	})
+	}
+	if len(groups) > 0 {
+		wireGroups := make([]string, 0, len(groups))
+		for _, g := range groups {
+			wg, err := metricsExportGroupWireName(g)
+			if err != nil {
+				return nil, err
+			}
+			wireGroups = append(wireGroups, wg)
+		}
+		reqBody["groups"] = wireGroups
+	}
+
+	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
@@ -1572,10 +1605,11 @@ type GetSystemInfoResponse struct {
 // SetMetricsExportResponse mirrors the wire response of
 // ContainerService.SetMetricsExport (#1069).
 type SetMetricsExportResponse struct {
-	Message         string `json:"message"`
-	Enabled         bool   `json:"enabled"`
-	Provider        string `json:"provider"`
-	IntervalSeconds int32  `json:"intervalSeconds"`
+	Message         string   `json:"message"`
+	Enabled         bool     `json:"enabled"`
+	Provider        string   `json:"provider"`
+	IntervalSeconds int32    `json:"intervalSeconds"`
+	Groups          []string `json:"groups,omitempty"`
 }
 
 // GetMetricsExportResponse mirrors the wire response of
@@ -1586,6 +1620,7 @@ type GetMetricsExportResponse struct {
 	Enabled         bool      `json:"enabled"`
 	Provider        string    `json:"provider"`
 	IntervalSeconds int32     `json:"intervalSeconds"`
+	Groups          []string  `json:"groups,omitempty"`
 	LastSuccessAt   string    `json:"lastSuccessAt,omitempty"`
 	LastError       string    `json:"lastError,omitempty"`
 	ExportFailures  flexInt64 `json:"exportFailures,omitempty"`

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -437,6 +437,11 @@ func (s *Server) registerTools() {
 						"description": "Cloud provider to export to. Required when enabled=true. Only \"gcp\" is implemented; \"aws\" is a reserved value the daemon rejects with an unimplemented error.",
 						"enum":        []string{"gcp", "aws"},
 					},
+					"groups": map[string]interface{}{
+						"type":        "array",
+						"items":       map[string]interface{}{"type": "string", "enum": []string{"host", "container", "platform"}},
+						"description": "Metric groups to enable (#1081). Omit to keep host-only (the default). Each group is an independently billed series set; \"container\" and \"platform\" are reserved (their series land in follow-up issues) so enabling them today exports no extra series. Ignored when enabled=false.",
+					},
 				},
 				"required": []string{"enabled"},
 			},
@@ -1735,13 +1740,28 @@ func handleSetMetricsExport(client API, args map[string]interface{}) (string, er
 	if enabled && provider == "" {
 		return "", fmt.Errorf("provider is required when enabled=true (e.g. \"gcp\")")
 	}
+	groups := getStringSliceArg(args, "groups")
 
-	resp, err := client.SetMetricsExport(enabled, provider)
+	resp, err := client.SetMetricsExport(enabled, provider, groups)
 	if err != nil {
 		return "", fmt.Errorf("failed to set metrics export: %w", err)
 	}
-	return fmt.Sprintf("✅ %s (enabled=%v, provider=%s, interval_seconds=%d)",
-		resp.Message, resp.Enabled, resp.Provider, resp.IntervalSeconds), nil
+	return fmt.Sprintf("✅ %s (enabled=%v, provider=%s, groups=%s, interval_seconds=%d)",
+		resp.Message, resp.Enabled, resp.Provider, metricsExportGroupsDisplay(resp.Groups), resp.IntervalSeconds), nil
+}
+
+// metricsExportGroupsDisplay renders the wire group-enum names as the
+// lowercase tokens an operator uses on the CLI (#1081); an empty set
+// shows as "host", the server's effective default.
+func metricsExportGroupsDisplay(groups []string) string {
+	if len(groups) == 0 {
+		return "host"
+	}
+	out := make([]string, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, strings.ToLower(strings.TrimPrefix(g, "CLOUD_METRICS_GROUP_")))
+	}
+	return strings.Join(out, ",")
 }
 
 // handleGetMetricsExport is a thin wrapper over client.GetMetricsExport
@@ -1755,7 +1775,7 @@ func handleGetMetricsExport(client API, args map[string]interface{}) (string, er
 	if !resp.Enabled {
 		return "cloud metrics export: disabled", nil
 	}
-	msg := fmt.Sprintf("cloud metrics export: enabled (provider=%s, interval_seconds=%d)", resp.Provider, resp.IntervalSeconds)
+	msg := fmt.Sprintf("cloud metrics export: enabled (provider=%s, groups=%s, interval_seconds=%d)", resp.Provider, metricsExportGroupsDisplay(resp.Groups), resp.IntervalSeconds)
 	if resp.LastSuccessAt != "" {
 		msg += fmt.Sprintf(", last_success_at=%s", resp.LastSuccessAt)
 	}

--- a/internal/metrics/cloudexport/collector.go
+++ b/internal/metrics/cloudexport/collector.go
@@ -2,6 +2,7 @@ package cloudexport
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -11,6 +12,8 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
 // meterName is the instrumentation scope all exported host series are
@@ -81,6 +84,11 @@ type CollectorOptions struct {
 	// IntervalSeconds is the requested export cadence. Clamped up to
 	// MinIntervalSeconds; <= 0 uses MinIntervalSeconds.
 	IntervalSeconds int32
+	// Groups selects which independently-enableable series groups this
+	// collector registers (#1081). Normalized at construction: an empty
+	// selection resolves to [HOST], so a collector built from a v0.60.0
+	// config exports exactly the #1070 host series.
+	Groups []pb.CloudMetricsGroup
 }
 
 // healthState is the collector's live export health, surfaced through
@@ -147,6 +155,7 @@ type CloudExportCollector struct {
 	resource *resource.Resource
 	labels   Labels
 	interval time.Duration
+	groups   []pb.CloudMetricsGroup
 	health   *healthState
 
 	mu      sync.Mutex
@@ -167,6 +176,7 @@ func NewCollector(opts CollectorOptions) *CloudExportCollector {
 		resource: opts.Resource,
 		labels:   opts.Labels,
 		interval: interval,
+		groups:   NormalizeGroups(opts.Groups),
 		health:   &healthState{},
 	}
 }
@@ -239,10 +249,35 @@ func (c *CloudExportCollector) buildMeterProvider(reader sdkmetric.Reader) (*sdk
 		mpOpts = append(mpOpts, sdkmetric.WithResource(c.resource))
 	}
 	mp := sdkmetric.NewMeterProvider(mpOpts...)
-	if err := registerHostInstruments(mp, c.sources, c.labels); err != nil {
-		return nil, err
+	for _, g := range c.groups {
+		if err := registerGroupInstruments(mp, g, c.sources, c.labels); err != nil {
+			return nil, err
+		}
 	}
 	return mp, nil
+}
+
+// registerGroupInstruments registers exactly the instruments belonging
+// to one metric group (#1081). This is the single dispatch point new
+// groups plug into: host registers the #1070 allowlist; container and
+// platform are reserved enableable groups whose series land in
+// #1071/#1072 and #1082/#1083/#1084 — until then they register nothing,
+// so enabling them is a deliberate zero-series opt-in rather than a
+// no-such-group error. Groups are normalized before they reach here, so
+// UNSPECIFIED never arrives; an unknown value is a programming error.
+func registerGroupInstruments(mp *sdkmetric.MeterProvider, group pb.CloudMetricsGroup, sources Sources, labels Labels) error {
+	switch group {
+	case pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST:
+		return registerHostInstruments(mp, sources, labels)
+	case pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER:
+		// Reserved: per-container series land in #1071/#1072.
+		return nil
+	case pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM:
+		// Reserved: platform series land in #1082/#1083/#1084.
+		return nil
+	default:
+		return fmt.Errorf("cloudexport: unregisterable metric group %v", group)
+	}
 }
 
 // registerHostInstruments creates the eight allowlisted host gauges and

--- a/internal/metrics/cloudexport/collector.go
+++ b/internal/metrics/cloudexport/collector.go
@@ -38,6 +38,15 @@ const (
 	MetricDiskUsed       = "containarium.host.disk.used_bytes"
 	MetricDiskTotal      = "containarium.host.disk.total_bytes"
 	MetricContainerCount = "containarium.host.container.count"
+
+	// MetricHeartbeat is the liveness/up series (#1072): a constant 1
+	// emitted every export interval while the daemon runs. It is the
+	// out-of-band dead-man signal — a metric-absence alert policy in the
+	// cloud provider's monitoring fires when this series stops arriving,
+	// catching the failure class (host or daemon dead / network-
+	// partitioned) that host-local alerting cannot report on because it
+	// fate-shares with the host.
+	MetricHeartbeat = "containarium.export.heartbeat"
 )
 
 // Label keys — the complete allowlist. No org/tenant identifier ever
@@ -48,22 +57,43 @@ const (
 	LabelBackendID = "backend_id"
 	LabelHostname  = "hostname"
 	LabelRegion    = "region"
+	// LabelDaemonVersion tags the heartbeat series only (not the host
+	// series) with the daemon build, so a dead-man alert makes clear which
+	// version stopped reporting.
+	LabelDaemonVersion = "daemon_version"
 )
 
 // Labels is the fixed identity stamped on every exported series. These
-// are host-level facts (which backend, which machine, which region),
-// not per-tick data — so they live on the collector, not in Sources.
+// are host-level facts (which backend, which machine, which region, which
+// daemon build), not per-tick data — so they live on the collector, not
+// in Sources. Not every series carries every field: the host series use
+// backend_id/hostname/region; the heartbeat uses backend_id/hostname/
+// daemon_version.
 type Labels struct {
-	BackendID string
-	Hostname  string
-	Region    string
+	BackendID     string
+	Hostname      string
+	Region        string
+	DaemonVersion string
 }
 
+// attributeSet is the host-series label set (backend_id, hostname,
+// region).
 func (l Labels) attributeSet() attribute.Set {
 	return attribute.NewSet(
 		attribute.String(LabelBackendID, l.BackendID),
 		attribute.String(LabelHostname, l.Hostname),
 		attribute.String(LabelRegion, l.Region),
+	)
+}
+
+// heartbeatAttributeSet is the heartbeat label set (backend_id, hostname,
+// daemon_version) — deliberately distinct from the host-series set: the
+// dead-man alert cares which daemon build went silent, not which region.
+func (l Labels) heartbeatAttributeSet() attribute.Set {
+	return attribute.NewSet(
+		attribute.String(LabelBackendID, l.BackendID),
+		attribute.String(LabelHostname, l.Hostname),
+		attribute.String(LabelDaemonVersion, l.DaemonVersion),
 	)
 }
 
@@ -254,6 +284,9 @@ func (c *CloudExportCollector) buildMeterProvider(reader sdkmetric.Reader) (*sdk
 			return nil, err
 		}
 	}
+	if err := registerHeartbeatInstrument(mp, c.labels); err != nil {
+		return nil, err
+	}
 	return mp, nil
 }
 
@@ -265,6 +298,12 @@ func (c *CloudExportCollector) buildMeterProvider(reader sdkmetric.Reader) (*sdk
 // so enabling them is a deliberate zero-series opt-in rather than a
 // no-such-group error. Groups are normalized before they reach here, so
 // UNSPECIFIED never arrives; an unknown value is a programming error.
+//
+// Note the heartbeat is deliberately NOT a group: it is registered
+// unconditionally by buildMeterProvider alongside (and independent of)
+// whatever groups are enabled, because the dead-man signal must never be
+// gated by group selection or a Sources error (see
+// registerHeartbeatInstrument).
 func registerGroupInstruments(mp *sdkmetric.MeterProvider, group pb.CloudMetricsGroup, sources Sources, labels Labels) error {
 	switch group {
 	case pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST:
@@ -278,6 +317,35 @@ func registerGroupInstruments(mp *sdkmetric.MeterProvider, group pb.CloudMetrics
 	default:
 		return fmt.Errorf("cloudexport: unregisterable metric group %v", group)
 	}
+}
+
+// registerHeartbeatInstrument creates the heartbeat/up gauge (#1072) and
+// wires a callback that observes a constant 1 on every tick, deliberately
+// in its OWN callback with no dependency on Sources. That independence is
+// the dead-man contract: the series is present iff the daemon is alive and
+// its export pipeline is delivering to the cloud, so its absence means
+// exactly one thing — the host or daemon died (or was partitioned from the
+// provider). A transient Sources error (incus briefly unavailable) skips
+// the host series for that tick but must not suppress the heartbeat, or an
+// incus hiccup would masquerade as backend death and page the operator.
+// For the same reason the heartbeat is not modeled as a metric group: it
+// accompanies every collector regardless of which groups are enabled.
+func registerHeartbeatInstrument(mp *sdkmetric.MeterProvider, labels Labels) error {
+	meter := mp.Meter(meterName)
+	heartbeat, err := meter.Int64ObservableGauge(MetricHeartbeat,
+		metric.WithDescription("Liveness heartbeat: constant 1 emitted every export interval while the daemon runs. Absence is the dead-man signal for a metric-absence alert policy."))
+	if err != nil {
+		return err
+	}
+	observeOpt := metric.WithAttributeSet(labels.heartbeatAttributeSet())
+	_, err = meter.RegisterCallback(
+		func(ctx context.Context, o metric.Observer) error {
+			o.ObserveInt64(heartbeat, 1, observeOpt)
+			return nil
+		},
+		heartbeat,
+	)
+	return err
 }
 
 // registerHostInstruments creates the eight allowlisted host gauges and

--- a/internal/metrics/cloudexport/collector_test.go
+++ b/internal/metrics/cloudexport/collector_test.go
@@ -162,6 +162,98 @@ func TestExportedSeries_MatchesAllowlistGolden(t *testing.T) {
 	}
 }
 
+// collectGroupsOnce stands up a ManualReader-backed MeterProvider for a
+// specific set of enabled groups and pulls one collection, so the
+// per-group golden can assert exactly which series each group emits.
+func collectGroupsOnce(t *testing.T, groups []pb.CloudMetricsGroup, sources Sources, labels Labels) metricdata.ResourceMetrics {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	c := NewCollector(CollectorOptions{Sources: sources, Labels: labels, Groups: groups})
+	mp, err := c.buildMeterProvider(reader)
+	if err != nil {
+		t.Fatalf("buildMeterProvider: %v", err)
+	}
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	return rm
+}
+
+// TestExportedSeries_PerGroupGolden is the #1081 per-group golden: it
+// pins the exact set of series names each combination of enabled groups
+// emits, so the billed sample surface stays reviewable in one file (the
+// #1070 rule, now scoped per group). host emits the eight-series #1070
+// allowlist; container and platform are reserved by #1081 (their series
+// land in #1071/#1072 and #1082/#1083/#1084 respectively) so they add
+// nothing yet — enabling them today is a deliberate, zero-series opt-in.
+// Any drift in what a group exports fails here.
+func TestExportedSeries_PerGroupGolden(t *testing.T) {
+	host := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST
+	container := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+
+	hostSeries := []string{
+		MetricCPULoad1m, MetricCPULoad5m, MetricCPULoad15m,
+		MetricMemoryUsed, MetricMemoryTotal,
+		MetricDiskUsed, MetricDiskTotal, MetricContainerCount,
+	}
+
+	tests := []struct {
+		name   string
+		groups []pb.CloudMetricsGroup
+		want   []string
+	}{
+		{"default (nil) is host", nil, hostSeries},
+		{"host only", []pb.CloudMetricsGroup{host}, hostSeries},
+		{"container reserved, no series", []pb.CloudMetricsGroup{container}, nil},
+		{"platform reserved, no series", []pb.CloudMetricsGroup{platform}, nil},
+		{"host and platform is host series", []pb.CloudMetricsGroup{host, platform}, hostSeries},
+		{"host and container is host series", []pb.CloudMetricsGroup{host, container}, hostSeries},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rm := collectGroupsOnce(t, tc.groups, &fakeSources{sr: sampleResources()}, sampleLabels())
+			pts := flattenGauges(t, rm)
+
+			got := map[string]bool{}
+			for _, p := range pts {
+				if got[p.name] {
+					t.Fatalf("series %q emitted more than once", p.name)
+				}
+				got[p.name] = true
+			}
+
+			wantSet := map[string]bool{}
+			for _, n := range tc.want {
+				wantSet[n] = true
+			}
+
+			if len(got) != len(wantSet) {
+				var names []string
+				for n := range got {
+					names = append(names, n)
+				}
+				sort.Strings(names)
+				t.Fatalf("groups %v emitted %d series %v, want exactly %d", tc.groups, len(got), names, len(wantSet))
+			}
+			for n := range wantSet {
+				if !got[n] {
+					t.Errorf("groups %v missing expected series %q", tc.groups, n)
+				}
+			}
+			for n := range got {
+				if !wantSet[n] {
+					t.Errorf("groups %v emitted unexpected series %q", tc.groups, n)
+				}
+			}
+		})
+	}
+}
+
 // TestNoTenantLabels asserts every emitted series carries exactly the
 // three allowlisted labels and nothing else — no org/tenant identifier —
 // even when a hostile Sources snapshot exists. The labels come from the

--- a/internal/metrics/cloudexport/collector_test.go
+++ b/internal/metrics/cloudexport/collector_test.go
@@ -132,6 +132,9 @@ func TestExportedSeries_MatchesAllowlistGolden(t *testing.T) {
 		MetricDiskUsed:       {isInt: true, ival: 100 << 30},
 		MetricDiskTotal:      {isInt: true, ival: 500 << 30},
 		MetricContainerCount: {isInt: true, ival: 7},
+		// Heartbeat/up series (#1072): constant 1, emitted alongside the
+		// host series every tick.
+		MetricHeartbeat: {isInt: true, ival: 1},
 	}
 
 	if len(got) != len(golden) {
@@ -190,6 +193,13 @@ func collectGroupsOnce(t *testing.T, groups []pb.CloudMetricsGroup, sources Sour
 // land in #1071/#1072 and #1082/#1083/#1084 respectively) so they add
 // nothing yet — enabling them today is a deliberate, zero-series opt-in.
 // Any drift in what a group exports fails here.
+//
+// The heartbeat/up series (#1072) is deliberately NOT a group: it is
+// registered unconditionally by buildMeterProvider, independent of which
+// groups are enabled, so it accompanies every combination below —
+// including the reserved-only cases, which therefore emit the heartbeat
+// alone rather than nothing. Each want set below lists the group-specific
+// series; the harness adds the always-on heartbeat before asserting.
 func TestExportedSeries_PerGroupGolden(t *testing.T) {
 	host := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST
 	container := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER
@@ -231,6 +241,10 @@ func TestExportedSeries_PerGroupGolden(t *testing.T) {
 			for _, n := range tc.want {
 				wantSet[n] = true
 			}
+			// The heartbeat rides every collector regardless of groups
+			// (registered unconditionally by buildMeterProvider, #1072),
+			// so it is part of the emitted set for every case here.
+			wantSet[MetricHeartbeat] = true
 
 			if len(got) != len(wantSet) {
 				var names []string
@@ -266,14 +280,26 @@ func TestNoTenantLabels(t *testing.T) {
 		t.Fatal("no series emitted")
 	}
 
-	allowed := map[string]string{
+	// Per-series allowlist: host series carry backend_id/hostname/region;
+	// the heartbeat carries backend_id/hostname/daemon_version. Neither
+	// may carry any org/tenant identifier.
+	hostAllowed := map[string]string{
 		LabelBackendID: "backend-xyz",
 		LabelHostname:  "host-1",
 		LabelRegion:    "us-central1",
 	}
+	heartbeatAllowed := map[string]string{
+		LabelBackendID:     "backend-xyz",
+		LabelHostname:      "host-1",
+		LabelDaemonVersion: "", // sampleLabels leaves DaemonVersion empty; value asserted in TestHeartbeatLabels.
+	}
 	forbidden := []string{"org", "org_id", "tenant", "tenant_id", "username", "user", "uuid"}
 
 	for _, p := range pts {
+		allowed := hostAllowed
+		if p.name == MetricHeartbeat {
+			allowed = heartbeatAllowed
+		}
 		iter := p.attrs.Iter()
 		seen := map[string]bool{}
 		for iter.Next() {
@@ -300,25 +326,42 @@ func TestNoTenantLabels(t *testing.T) {
 	}
 }
 
+// hostSeriesCount counts emitted series that are not the heartbeat — the
+// host gauges whose values come from Sources.
+func hostSeriesCount(pts []point) int {
+	n := 0
+	for _, p := range pts {
+		if p.name != MetricHeartbeat {
+			n++
+		}
+	}
+	return n
+}
+
 // TestSourceErrorSkipsTickWithoutPanic asserts that a Sources error mid-
-// tick is skipped cleanly: no panic, no crash, and no series emitted for
-// that tick (so no stale values reach the cloud).
+// tick is skipped cleanly: no panic, no crash, and no host series emitted
+// for that tick (so no stale values reach the cloud). The heartbeat, which
+// does not depend on Sources, still emits — a Sources error is not daemon
+// death and must not trip the dead-man alert.
 func TestSourceErrorSkipsTickWithoutPanic(t *testing.T) {
 	rm := collectOnce(t, &fakeSources{err: errors.New("incus unavailable")}, sampleLabels())
 	pts := flattenGauges(t, rm)
-	if len(pts) != 0 {
-		t.Fatalf("expected no series on a Sources error, got %d", len(pts))
+	if got := hostSeriesCount(pts); got != 0 {
+		t.Fatalf("expected no host series on a Sources error, got %d", got)
 	}
+	heartbeatOf(t, pts) // heartbeat still present; fails if absent.
 }
 
 // TestNilSnapshotSkipsTick guards the nil-without-error edge: a Sources
-// that returns (nil, nil) is skipped, not dereferenced.
+// that returns (nil, nil) is skipped, not dereferenced — again without
+// suppressing the Sources-independent heartbeat.
 func TestNilSnapshotSkipsTick(t *testing.T) {
 	rm := collectOnce(t, &fakeSources{sr: nil}, sampleLabels())
 	pts := flattenGauges(t, rm)
-	if len(pts) != 0 {
-		t.Fatalf("expected no series on a nil snapshot, got %d", len(pts))
+	if got := hostSeriesCount(pts); got != 0 {
+		t.Fatalf("expected no host series on a nil snapshot, got %d", got)
 	}
+	heartbeatOf(t, pts) // heartbeat still present; fails if absent.
 }
 
 // recordingExporter is a fake sdkmetric.Exporter that counts Export
@@ -374,9 +417,11 @@ func TestEnableDisableRebuild(t *testing.T) {
 	if exp.exports == 0 {
 		t.Fatal("expected at least one export after ForceFlush")
 	}
-	if got := len(flattenGauges(t, exp.last)); got != 8 {
-		t.Fatalf("expected 8 host series exported, got %d", got)
+	exported := flattenGauges(t, exp.last)
+	if got := len(exported); got != 9 {
+		t.Fatalf("expected 9 series exported (8 host + heartbeat), got %d", got)
 	}
+	heartbeatOf(t, exported) // the heartbeat rides the same export batch.
 
 	if err := c.Stop(ctx); err != nil {
 		t.Fatalf("Stop: %v", err)

--- a/internal/metrics/cloudexport/config.go
+++ b/internal/metrics/cloudexport/config.go
@@ -28,6 +28,14 @@ type Config struct {
 	Enabled         bool                    `json:"enabled"`
 	Provider        pb.CloudMetricsProvider `json:"provider"`
 	IntervalSeconds int32                   `json:"interval_seconds"`
+
+	// Groups is the set of enabled metric groups (#1081). Omitted from a
+	// v0.60.0 config (which predates groups) — an absent or empty value
+	// is treated as [HOST] by NormalizeGroups everywhere it is consumed,
+	// so an old config resumes exactly today's host-only behavior.
+	// `omitempty` keeps a host-only config byte-identical to the pre-#1081
+	// persisted form.
+	Groups []pb.CloudMetricsGroup `json:"groups,omitempty"`
 }
 
 // DefaultConfig returns the zero-value config: export disabled, no

--- a/internal/metrics/cloudexport/groups.go
+++ b/internal/metrics/cloudexport/groups.go
@@ -1,0 +1,70 @@
+package cloudexport
+
+import (
+	"fmt"
+	"sort"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// definedGroups is the set of metric groups #1081 recognizes as
+// independently enableable. UNSPECIFIED is deliberately excluded — it is
+// the "no group named" sentinel, never a valid element of an explicit
+// list. New groups (e.g. a future apps group) are added here and to the
+// collector's per-group registration in one place.
+var definedGroups = map[pb.CloudMetricsGroup]bool{
+	pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST:      true,
+	pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER: true,
+	pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM:  true,
+}
+
+// DefaultGroup is the group an absent/empty selection resolves to — the
+// #1070 host-infra series. Keeping this a named constant makes the
+// "absent groups ⇒ host" backward-compatibility rule (v0.60.0 configs
+// resume unchanged) explicit at every use site.
+const DefaultGroup = pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST
+
+// NormalizeGroups returns the effective set of metric groups to export:
+// the input with UNSPECIFIED and duplicates removed and the result sorted
+// ascending by enum value for a deterministic persisted form and golden
+// series set. An input that is empty (or resolves to empty after dropping
+// UNSPECIFIED) becomes [DefaultGroup] — the backward-compatibility rule
+// that lets a v0.60.0 host-only config resume exactly as before.
+func NormalizeGroups(groups []pb.CloudMetricsGroup) []pb.CloudMetricsGroup {
+	seen := map[pb.CloudMetricsGroup]bool{}
+	out := make([]pb.CloudMetricsGroup, 0, len(groups))
+	for _, g := range groups {
+		if g == pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_UNSPECIFIED {
+			continue
+		}
+		if seen[g] {
+			continue
+		}
+		seen[g] = true
+		out = append(out, g)
+	}
+	if len(out) == 0 {
+		return []pb.CloudMetricsGroup{DefaultGroup}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// ValidateGroups rejects an explicit groups list that carries
+// CLOUD_METRICS_GROUP_UNSPECIFIED or a value outside the defined set —
+// both are client errors the server surfaces as INVALID_ARGUMENT. An
+// empty list is valid: it means "default to host", handled by
+// NormalizeGroups. Validation is intentionally separate from
+// normalization so the server can return a precise error before silently
+// coercing a malformed request.
+func ValidateGroups(groups []pb.CloudMetricsGroup) error {
+	for _, g := range groups {
+		if g == pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_UNSPECIFIED {
+			return fmt.Errorf("metric group %q is not a valid selection (name a concrete group such as host, container, or platform)", g)
+		}
+		if !definedGroups[g] {
+			return fmt.Errorf("unknown metric group %d", int32(g))
+		}
+	}
+	return nil
+}

--- a/internal/metrics/cloudexport/groups_test.go
+++ b/internal/metrics/cloudexport/groups_test.go
@@ -1,0 +1,82 @@
+package cloudexport
+
+import (
+	"reflect"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// TestNormalizeGroups pins the backward-compatibility rule at the heart
+// of #1081: an absent/empty (or all-UNSPECIFIED) groups list resolves to
+// [HOST] — exactly the v0.60.0 host-only behavior a persisted config
+// resumes into — and any explicit list is deduped and ordered so the
+// persisted form and the golden series set are deterministic.
+func TestNormalizeGroups(t *testing.T) {
+	host := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST
+	container := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+	unspecified := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_UNSPECIFIED
+
+	tests := []struct {
+		name string
+		in   []pb.CloudMetricsGroup
+		want []pb.CloudMetricsGroup
+	}{
+		{"nil defaults to host", nil, []pb.CloudMetricsGroup{host}},
+		{"empty defaults to host", []pb.CloudMetricsGroup{}, []pb.CloudMetricsGroup{host}},
+		{"unspecified-only defaults to host", []pb.CloudMetricsGroup{unspecified}, []pb.CloudMetricsGroup{host}},
+		{"host stays host", []pb.CloudMetricsGroup{host}, []pb.CloudMetricsGroup{host}},
+		{"platform alone", []pb.CloudMetricsGroup{platform}, []pb.CloudMetricsGroup{platform}},
+		{"host and platform", []pb.CloudMetricsGroup{host, platform}, []pb.CloudMetricsGroup{host, platform}},
+		{"reordered is sorted", []pb.CloudMetricsGroup{platform, host}, []pb.CloudMetricsGroup{host, platform}},
+		{"duplicates collapse", []pb.CloudMetricsGroup{host, host}, []pb.CloudMetricsGroup{host}},
+		{"unspecified dropped from mix", []pb.CloudMetricsGroup{host, unspecified, platform}, []pb.CloudMetricsGroup{host, platform}},
+		{"all three sorted", []pb.CloudMetricsGroup{container, platform, host}, []pb.CloudMetricsGroup{host, container, platform}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NormalizeGroups(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("NormalizeGroups(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateGroups pins the server-side guard: an explicit list may not
+// carry UNSPECIFIED or an out-of-range value (those are client errors),
+// while an empty list is valid because it means "default to host".
+func TestValidateGroups(t *testing.T) {
+	host := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST
+	container := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+	unspecified := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_UNSPECIFIED
+
+	tests := []struct {
+		name    string
+		in      []pb.CloudMetricsGroup
+		wantErr bool
+	}{
+		{"nil is valid", nil, false},
+		{"empty is valid", []pb.CloudMetricsGroup{}, false},
+		{"host is valid", []pb.CloudMetricsGroup{host}, false},
+		{"all three valid", []pb.CloudMetricsGroup{host, container, platform}, false},
+		{"unspecified alone rejected", []pb.CloudMetricsGroup{unspecified}, true},
+		{"unspecified in mix rejected", []pb.CloudMetricsGroup{host, unspecified}, true},
+		{"out-of-range rejected", []pb.CloudMetricsGroup{pb.CloudMetricsGroup(99)}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGroups(tc.in)
+			if tc.wantErr && err == nil {
+				t.Errorf("ValidateGroups(%v) = nil, want error", tc.in)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("ValidateGroups(%v) = %v, want nil", tc.in, err)
+			}
+		})
+	}
+}

--- a/internal/metrics/cloudexport/heartbeat_test.go
+++ b/internal/metrics/cloudexport/heartbeat_test.go
@@ -1,0 +1,138 @@
+package cloudexport
+
+import (
+	"errors"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// heartbeatOf returns the single heartbeat datapoint from a flattened
+// collection, or fails if it is absent or duplicated. Isolating the
+// lookup keeps the heartbeat tests focused on the one series they assert.
+func heartbeatOf(t *testing.T, pts []point) point {
+	t.Helper()
+	var found []point
+	for _, p := range pts {
+		if p.name == MetricHeartbeat {
+			found = append(found, p)
+		}
+	}
+	if len(found) == 0 {
+		t.Fatalf("heartbeat series %q not emitted", MetricHeartbeat)
+	}
+	if len(found) > 1 {
+		t.Fatalf("heartbeat series %q emitted %d times, want exactly 1", MetricHeartbeat, len(found))
+	}
+	return found[0]
+}
+
+// TestHeartbeatEmittedEveryInterval covers acceptance criterion #1: a
+// heartbeat/up series is emitted on every export interval while the daemon
+// runs. The ManualReader stands in for the PeriodicReader; each Collect is
+// one interval tick. The heartbeat must be present, integer-typed, and
+// exactly 1 on every tick.
+func TestHeartbeatEmittedEveryInterval(t *testing.T) {
+	sources := &fakeSources{sr: sampleResources()}
+	// Three consecutive ticks: the heartbeat is present with value 1 on
+	// each, never drifting or dropping out.
+	for tick := 1; tick <= 3; tick++ {
+		rm := collectOnce(t, sources, sampleLabels())
+		hb := heartbeatOf(t, flattenGauges(t, rm))
+		if !hb.isInt {
+			t.Fatalf("tick %d: heartbeat must be an int64 gauge, got float", tick)
+		}
+		if hb.ival != 1 {
+			t.Fatalf("tick %d: heartbeat = %d, want 1", tick, hb.ival)
+		}
+	}
+}
+
+// TestHeartbeatSurvivesSourceError is the dead-man correctness guard: the
+// heartbeat means "the daemon is alive and its export pipeline reaches the
+// cloud," so a transient Sources error (e.g. incus briefly unavailable)
+// must NOT suppress it — otherwise an incus hiccup masquerades as backend
+// death and pages the operator. The host series are still skipped for that
+// tick (no stale values); only the heartbeat survives.
+func TestHeartbeatSurvivesSourceError(t *testing.T) {
+	cases := map[string]*fakeSources{
+		"sources error": {err: errors.New("incus unavailable")},
+		"nil snapshot":  {sr: nil},
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			pts := flattenGauges(t, collectOnce(t, src, sampleLabels()))
+			hb := heartbeatOf(t, pts)
+			if hb.ival != 1 {
+				t.Fatalf("heartbeat = %d, want 1 even when Sources fails", hb.ival)
+			}
+			// The heartbeat is the ONLY series on a failed tick: no host
+			// gauge leaks a stale value.
+			if len(pts) != 1 {
+				t.Fatalf("expected only the heartbeat on a failed tick, got %d series", len(pts))
+			}
+		})
+	}
+}
+
+// TestHeartbeatLabels locks the heartbeat's label allowlist from the design
+// (backend_id, hostname, daemon_version) — note daemon_version, not region:
+// a dead-man alert wants to see which daemon build stopped reporting. No
+// tenant/org label ever appears.
+func TestHeartbeatLabels(t *testing.T) {
+	labels := Labels{
+		BackendID:     "backend-xyz",
+		Hostname:      "host-1",
+		Region:        "us-central1",
+		DaemonVersion: "v0.60.0",
+	}
+	pts := flattenGauges(t, collectOnce(t, &fakeSources{sr: sampleResources()}, labels))
+	hb := heartbeatOf(t, pts)
+
+	want := map[string]string{
+		LabelBackendID:     "backend-xyz",
+		LabelHostname:      "host-1",
+		LabelDaemonVersion: "v0.60.0",
+	}
+	got := map[string]string{}
+	iter := hb.attrs.Iter()
+	for iter.Next() {
+		kv := iter.Attribute()
+		got[string(kv.Key)] = kv.Value.AsString()
+	}
+	// region is a host-series label, not a heartbeat label — its presence
+	// here would be a leak of the wrong allowlist.
+	if _, ok := got[LabelRegion]; ok {
+		t.Errorf("heartbeat carries host-series label %q; heartbeat uses daemon_version, not region", LabelRegion)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("heartbeat has labels %v, want exactly %v", keysOf(got), keysOf(want))
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("heartbeat label %q = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func keysOf(m map[string]string) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}
+
+// TestHeartbeatAttributeSet is a direct unit check that the heartbeat
+// label set is derived from daemon identity, isolated from the collection
+// path, so a Sources implementation has no channel to inject a label.
+func TestHeartbeatAttributeSet(t *testing.T) {
+	l := Labels{BackendID: "b", Hostname: "h", Region: "r", DaemonVersion: "v"}
+	set := l.heartbeatAttributeSet()
+	if v, ok := set.Value(attribute.Key(LabelDaemonVersion)); !ok || v.AsString() != "v" {
+		t.Errorf("daemon_version = %q (ok=%v), want %q", v.AsString(), ok, "v")
+	}
+	if _, ok := set.Value(attribute.Key(LabelRegion)); ok {
+		t.Errorf("heartbeat attribute set must not carry region")
+	}
+}

--- a/internal/server/metrics_export_server.go
+++ b/internal/server/metrics_export_server.go
@@ -184,7 +184,17 @@ func (s *ContainerServer) SetMetricsExport(ctx context.Context, req *pb.SetMetri
 			Enabled:         false,
 			Provider:        current.Provider,
 			IntervalSeconds: current.IntervalSeconds,
+			// Groups are sticky across a disable (like Provider): report
+			// the persisted selection so a bare re-enable is symmetric.
+			Groups: cloudexport.NormalizeGroups(current.Groups),
 		}, nil
+	}
+
+	// Reject a malformed group selection (UNSPECIFIED or out-of-range)
+	// before the credential probe — a typed-input error is the operator's
+	// mistake, not a precondition failure, and nothing is persisted.
+	if err := cloudexport.ValidateGroups(req.Groups); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid metric groups: %v", err)
 	}
 
 	switch req.Provider {
@@ -210,6 +220,9 @@ func (s *ContainerServer) SetMetricsExport(ctx context.Context, req *pb.SetMetri
 		Enabled:         true,
 		Provider:        req.Provider,
 		IntervalSeconds: cloudexport.DefaultIntervalSeconds,
+		// Persist the normalized selection so the stored form is
+		// deterministic and an absent list is materialized as [HOST].
+		Groups: cloudexport.NormalizeGroups(req.Groups),
 	}
 
 	// Build and start the real host-series collector before persisting
@@ -231,6 +244,7 @@ func (s *ContainerServer) SetMetricsExport(ctx context.Context, req *pb.SetMetri
 		Enabled:         true,
 		Provider:        req.Provider,
 		IntervalSeconds: newCfg.IntervalSeconds,
+		Groups:          newCfg.Groups,
 	}, nil
 }
 
@@ -282,6 +296,7 @@ func (s *ContainerServer) buildMetricsExportCollector(ctx context.Context, cfg c
 			Region:    s.region,
 		},
 		IntervalSeconds: cfg.IntervalSeconds,
+		Groups:          cfg.Groups,
 	}), nil
 }
 
@@ -342,6 +357,9 @@ func (s *ContainerServer) GetMetricsExport(ctx context.Context, req *pb.GetMetri
 		Enabled:         cfg.Enabled,
 		Provider:        cfg.Provider,
 		IntervalSeconds: cfg.IntervalSeconds,
+		// Normalized so a never-configured host and a v0.60.0 config (no
+		// persisted groups) both report [HOST] rather than an empty set.
+		Groups: cloudexport.NormalizeGroups(cfg.Groups),
 	}
 
 	s.metricsExportMu.RLock()

--- a/internal/server/metrics_export_server.go
+++ b/internal/server/metrics_export_server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/metrics/cloudexport"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"github.com/footprintai/containarium/pkg/version"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -261,9 +262,10 @@ func (s *ContainerServer) buildCollector(ctx context.Context, cfg cloudexport.Co
 // series collector for cfg: the production Sources adapter over the
 // daemon's Manager/Incus, the provider exporter from sink.NewExporter,
 // the provider's monitored-resource identity (gce_instance for GCP) when
-// the sink offers one, and the fixed backend_id/hostname/region label
-// set. Returns an error if the daemon lacks a Manager or the exporter
-// can't be built.
+// the sink offers one, and the fixed identity labels (backend_id/hostname/
+// region for the host series; backend_id/hostname/daemon_version for the
+// heartbeat). Returns an error if the daemon lacks a Manager or the
+// exporter can't be built.
 func (s *ContainerServer) buildMetricsExportCollector(ctx context.Context, cfg cloudexport.Config, sink cloudexport.Sink) (*cloudexport.CloudExportCollector, error) {
 	if s.manager == nil {
 		return nil, fmt.Errorf("no container manager wired")
@@ -291,9 +293,10 @@ func (s *ContainerServer) buildMetricsExportCollector(ctx context.Context, cfg c
 		Exporter: exporter,
 		Resource: res,
 		Labels: cloudexport.Labels{
-			BackendID: s.localBackendID(),
-			Hostname:  sources.Hostname(),
-			Region:    s.region,
+			BackendID:     s.localBackendID(),
+			Hostname:      sources.Hostname(),
+			Region:        s.region,
+			DaemonVersion: version.GetVersion(),
 		},
 		IntervalSeconds: cfg.IntervalSeconds,
 		Groups:          cfg.Groups,

--- a/internal/server/metrics_export_server_test.go
+++ b/internal/server/metrics_export_server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -411,6 +412,167 @@ func TestSetMetricsExport_NoSinkRegistered_Unimplemented(t *testing.T) {
 	})
 	if status.Code(err) != codes.Unimplemented {
 		t.Fatalf("error = %v, want Unimplemented", err)
+	}
+}
+
+// groupSet turns an unordered slice of groups into a set for
+// order-independent comparison in the group assertions below.
+func groupSet(groups []pb.CloudMetricsGroup) map[pb.CloudMetricsGroup]bool {
+	m := map[pb.CloudMetricsGroup]bool{}
+	for _, g := range groups {
+		m[g] = true
+	}
+	return m
+}
+
+// TestSetMetricsExport_EmptyGroupsDefaultsHost pins the backward-compat
+// acceptance criterion: enabling without naming any groups keeps today's
+// behavior — the effective set is [HOST] on both the enable response and
+// a follow-up status read.
+func TestSetMetricsExport_EmptyGroupsDefaultsHost(t *testing.T) {
+	s, _ := newMetricsExportTestServer(nil)
+
+	resp, err := s.SetMetricsExport(testCtx(), &pb.SetMetricsExportRequest{
+		Enabled:  true,
+		Provider: pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP,
+		// Groups intentionally omitted.
+	})
+	if err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	wantHost := []pb.CloudMetricsGroup{pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST}
+	if !reflect.DeepEqual(resp.Groups, wantHost) {
+		t.Errorf("enable response groups = %v, want %v", resp.Groups, wantHost)
+	}
+
+	statusResp, err := s.GetMetricsExport(testCtx(), &pb.GetMetricsExportRequest{})
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !reflect.DeepEqual(statusResp.Groups, wantHost) {
+		t.Errorf("status groups = %v, want %v", statusResp.Groups, wantHost)
+	}
+}
+
+// TestSetMetricsExport_EnablesExactlyRequestedGroups covers the headline
+// #1081 acceptance criterion: --groups host,platform enables exactly
+// those two groups (typed on the wire), reflected on the enable response
+// and the status read.
+func TestSetMetricsExport_EnablesExactlyRequestedGroups(t *testing.T) {
+	s, _ := newMetricsExportTestServer(nil)
+
+	want := groupSet([]pb.CloudMetricsGroup{
+		pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST,
+		pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM,
+	})
+
+	resp, err := s.SetMetricsExport(testCtx(), &pb.SetMetricsExportRequest{
+		Enabled:  true,
+		Provider: pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP,
+		Groups: []pb.CloudMetricsGroup{
+			pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM,
+			pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST,
+		},
+	})
+	if err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if got := groupSet(resp.Groups); !reflect.DeepEqual(got, want) {
+		t.Errorf("enable response groups = %v, want %v", resp.Groups, want)
+	}
+
+	statusResp, err := s.GetMetricsExport(testCtx(), &pb.GetMetricsExportRequest{})
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if got := groupSet(statusResp.Groups); !reflect.DeepEqual(got, want) {
+		t.Errorf("status groups = %v, want %v", statusResp.Groups, want)
+	}
+}
+
+// TestSetMetricsExport_RejectsInvalidGroups pins the typed-input guard: a
+// request naming CLOUD_METRICS_GROUP_UNSPECIFIED (or an out-of-range
+// value) is rejected with InvalidArgument before anything is persisted.
+func TestSetMetricsExport_RejectsInvalidGroups(t *testing.T) {
+	s, _ := newMetricsExportTestServer(nil)
+
+	_, err := s.SetMetricsExport(testCtx(), &pb.SetMetricsExportRequest{
+		Enabled:  true,
+		Provider: pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP,
+		Groups: []pb.CloudMetricsGroup{
+			pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_UNSPECIFIED,
+		},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("error = %v, want InvalidArgument", err)
+	}
+
+	// Nothing persisted: status still reports disabled.
+	statusResp, statusErr := s.GetMetricsExport(testCtx(), &pb.GetMetricsExportRequest{})
+	if statusErr != nil {
+		t.Fatalf("status: %v", statusErr)
+	}
+	if statusResp.Enabled {
+		t.Errorf("export enabled after a rejected groups request, want disabled")
+	}
+}
+
+// TestSetMetricsExport_GroupsPersistAndResume pins that the enabled
+// groups survive a daemon restart exactly like the enable toggle: enable
+// [host,platform] on one server persists to the store; a fresh server
+// sharing that store resumes with both groups.
+func TestSetMetricsExport_GroupsPersistAndResume(t *testing.T) {
+	kv := &fakeDaemonConfigKV{}
+
+	first, _ := newMetricsExportTestServer(nil)
+	first.daemonConfigStore = kv
+	if _, err := first.SetMetricsExport(testCtx(), &pb.SetMetricsExportRequest{
+		Enabled:  true,
+		Provider: pb.CloudMetricsProvider_CLOUD_METRICS_PROVIDER_GCP,
+		Groups: []pb.CloudMetricsGroup{
+			pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST,
+			pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM,
+		},
+	}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	restarted, _ := newMetricsExportTestServer(nil)
+	restarted.daemonConfigStore = kv
+	restarted.StartMetricsExportIfEnabled(context.Background())
+
+	got, err := restarted.GetMetricsExport(testCtx(), &pb.GetMetricsExportRequest{})
+	if err != nil {
+		t.Fatalf("status after resume: %v", err)
+	}
+	want := groupSet([]pb.CloudMetricsGroup{
+		pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST,
+		pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM,
+	})
+	if gotSet := groupSet(got.Groups); !reflect.DeepEqual(gotSet, want) {
+		t.Errorf("resumed groups = %v, want %v", got.Groups, want)
+	}
+}
+
+// TestGetMetricsExport_V060ConfigDefaultsHost pins the JSON
+// compatibility path: a config persisted by v0.60.0 (no groups field)
+// reports [HOST] rather than an empty group set.
+func TestGetMetricsExport_V060ConfigDefaultsHost(t *testing.T) {
+	kv := &fakeDaemonConfigKV{}
+	kv.m = map[string]string{
+		cloudexport.ConfigStoreKey: `{"enabled":true,"provider":1,"interval_seconds":60}`,
+	}
+
+	s, _ := newMetricsExportTestServer(nil)
+	s.daemonConfigStore = kv
+
+	got, err := s.GetMetricsExport(testCtx(), &pb.GetMetricsExportRequest{})
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	wantHost := []pb.CloudMetricsGroup{pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST}
+	if !reflect.DeepEqual(got.Groups, wantHost) {
+		t.Errorf("v0.60.0 config groups = %v, want %v", got.Groups, wantHost)
 	}
 }
 

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -319,6 +319,78 @@ func (CloudMetricsProvider) EnumDescriptor() ([]byte, []int) {
 	return file_containarium_v1_container_proto_rawDescGZIP(), []int{4}
 }
 
+// CloudMetricsGroup names an independently enableable set of exported
+// series (#1081). Export is organized into groups so the billed sample
+// surface — custom metrics are billed per ingested sample — stays a
+// deliberate, per-group choice rather than an all-or-nothing switch.
+// Typed so a group can never be a magic string. Absent/empty on the wire
+// means "host only" (CLOUD_METRICS_GROUP_HOST), which is exactly the
+// v0.60.0 behavior a persisted config resumes into.
+type CloudMetricsGroup int32
+
+const (
+	// Unset. Never a valid element of an explicit groups list;
+	// SetMetricsExport rejects a request whose groups contain it. An empty
+	// groups list (not a list of UNSPECIFIED) is what means "default to
+	// host".
+	CloudMetricsGroup_CLOUD_METRICS_GROUP_UNSPECIFIED CloudMetricsGroup = 0
+	// Host-infrastructure series (CPU load, memory, disk, container count)
+	// — the complete #1070 allowlist. The default when no group is named.
+	CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST CloudMetricsGroup = 1
+	// Per-container series. Reserved by #1081 as an enableable group; the
+	// series themselves land in #1071/#1072, so enabling it today exports
+	// no additional series.
+	CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER CloudMetricsGroup = 2
+	// Platform-level series (API request/error counts, provisioning
+	// outcomes, peer connectivity). Reserved by #1081 as an enableable
+	// group; the series themselves land in #1082/#1083/#1084, so enabling
+	// it today exports no additional series.
+	CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM CloudMetricsGroup = 3
+)
+
+// Enum value maps for CloudMetricsGroup.
+var (
+	CloudMetricsGroup_name = map[int32]string{
+		0: "CLOUD_METRICS_GROUP_UNSPECIFIED",
+		1: "CLOUD_METRICS_GROUP_HOST",
+		2: "CLOUD_METRICS_GROUP_CONTAINER",
+		3: "CLOUD_METRICS_GROUP_PLATFORM",
+	}
+	CloudMetricsGroup_value = map[string]int32{
+		"CLOUD_METRICS_GROUP_UNSPECIFIED": 0,
+		"CLOUD_METRICS_GROUP_HOST":        1,
+		"CLOUD_METRICS_GROUP_CONTAINER":   2,
+		"CLOUD_METRICS_GROUP_PLATFORM":    3,
+	}
+)
+
+func (x CloudMetricsGroup) Enum() *CloudMetricsGroup {
+	p := new(CloudMetricsGroup)
+	*p = x
+	return p
+}
+
+func (x CloudMetricsGroup) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CloudMetricsGroup) Descriptor() protoreflect.EnumDescriptor {
+	return file_containarium_v1_container_proto_enumTypes[5].Descriptor()
+}
+
+func (CloudMetricsGroup) Type() protoreflect.EnumType {
+	return &file_containarium_v1_container_proto_enumTypes[5]
+}
+
+func (x CloudMetricsGroup) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CloudMetricsGroup.Descriptor instead.
+func (CloudMetricsGroup) EnumDescriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{5}
+}
+
 // ResourceLimits defines resource constraints for a container
 type ResourceLimits struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -4164,7 +4236,13 @@ type SetMetricsExportRequest struct {
 	// Target cloud provider. Required when enabled=true. Must not be
 	// CLOUD_METRICS_PROVIDER_UNSPECIFIED (INVALID_ARGUMENT) or
 	// CLOUD_METRICS_PROVIDER_AWS (UNIMPLEMENTED — MVP is GCP-only).
-	Provider      CloudMetricsProvider `protobuf:"varint,2,opt,name=provider,proto3,enum=containarium.v1.CloudMetricsProvider" json:"provider,omitempty"`
+	Provider CloudMetricsProvider `protobuf:"varint,2,opt,name=provider,proto3,enum=containarium.v1.CloudMetricsProvider" json:"provider,omitempty"`
+	// The metric groups to export (#1081). Enables exactly these groups;
+	// an empty list defaults to [CLOUD_METRICS_GROUP_HOST], preserving the
+	// v0.60.0 host-only behavior. Every element must be a defined group
+	// other than CLOUD_METRICS_GROUP_UNSPECIFIED (INVALID_ARGUMENT
+	// otherwise). Ignored when enabled=false.
+	Groups        []CloudMetricsGroup `protobuf:"varint,3,rep,packed,name=groups,proto3,enum=containarium.v1.CloudMetricsGroup" json:"groups,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4213,6 +4291,13 @@ func (x *SetMetricsExportRequest) GetProvider() CloudMetricsProvider {
 	return CloudMetricsProvider_CLOUD_METRICS_PROVIDER_UNSPECIFIED
 }
 
+func (x *SetMetricsExportRequest) GetGroups() []CloudMetricsGroup {
+	if x != nil {
+		return x.Groups
+	}
+	return nil
+}
+
 // SetMetricsExportResponse reports the effective state after the toggle.
 type SetMetricsExportResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -4223,8 +4308,12 @@ type SetMetricsExportResponse struct {
 	Enabled         bool                 `protobuf:"varint,2,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	Provider        CloudMetricsProvider `protobuf:"varint,3,opt,name=provider,proto3,enum=containarium.v1.CloudMetricsProvider" json:"provider,omitempty"`
 	IntervalSeconds int32                `protobuf:"varint,4,opt,name=interval_seconds,json=intervalSeconds,proto3" json:"interval_seconds,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// The effective set of enabled metric groups after the call (#1081),
+	// normalized: an omitted/empty request list resolves to
+	// [CLOUD_METRICS_GROUP_HOST].
+	Groups        []CloudMetricsGroup `protobuf:"varint,5,rep,packed,name=groups,proto3,enum=containarium.v1.CloudMetricsGroup" json:"groups,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SetMetricsExportResponse) Reset() {
@@ -4283,6 +4372,13 @@ func (x *SetMetricsExportResponse) GetIntervalSeconds() int32 {
 		return x.IntervalSeconds
 	}
 	return 0
+}
+
+func (x *SetMetricsExportResponse) GetGroups() []CloudMetricsGroup {
+	if x != nil {
+		return x.Groups
+	}
+	return nil
 }
 
 // GetMetricsExportRequest requests the current cloud-native metrics
@@ -4344,8 +4440,12 @@ type GetMetricsExportResponse struct {
 	LastError string `protobuf:"bytes,5,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`
 	// Count of failed export batches since the exporter was last (re)built.
 	ExportFailures int64 `protobuf:"varint,6,opt,name=export_failures,json=exportFailures,proto3" json:"export_failures,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// The set of enabled metric groups (#1081). Normalized: a host that has
+	// never configured groups (or a v0.60.0 config with none persisted)
+	// reports [CLOUD_METRICS_GROUP_HOST].
+	Groups        []CloudMetricsGroup `protobuf:"varint,7,rep,packed,name=groups,proto3,enum=containarium.v1.CloudMetricsGroup" json:"groups,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetMetricsExportResponse) Reset() {
@@ -4418,6 +4518,13 @@ func (x *GetMetricsExportResponse) GetExportFailures() int64 {
 		return x.ExportFailures
 	}
 	return 0
+}
+
+func (x *GetMetricsExportResponse) GetGroups() []CloudMetricsGroup {
+	if x != nil {
+		return x.Groups
+	}
+	return nil
 }
 
 // MoveContainerRequest is the source-side request to migrate a
@@ -5044,16 +5151,18 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12\x1f\n" +
 	"\vgrafana_url\x18\x02 \x01(\tR\n" +
 	"grafanaUrl\x120\n" +
-	"\x14victoria_metrics_url\x18\x03 \x01(\tR\x12victoriaMetricsUrl\"v\n" +
+	"\x14victoria_metrics_url\x18\x03 \x01(\tR\x12victoriaMetricsUrl\"\xb2\x01\n" +
 	"\x17SetMetricsExportRequest\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12A\n" +
-	"\bprovider\x18\x02 \x01(\x0e2%.containarium.v1.CloudMetricsProviderR\bprovider\"\xbc\x01\n" +
+	"\bprovider\x18\x02 \x01(\x0e2%.containarium.v1.CloudMetricsProviderR\bprovider\x12:\n" +
+	"\x06groups\x18\x03 \x03(\x0e2\".containarium.v1.CloudMetricsGroupR\x06groups\"\xf8\x01\n" +
 	"\x18SetMetricsExportResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12\x18\n" +
 	"\aenabled\x18\x02 \x01(\bR\aenabled\x12A\n" +
 	"\bprovider\x18\x03 \x01(\x0e2%.containarium.v1.CloudMetricsProviderR\bprovider\x12)\n" +
-	"\x10interval_seconds\x18\x04 \x01(\x05R\x0fintervalSeconds\"\x19\n" +
-	"\x17GetMetricsExportRequest\"\xae\x02\n" +
+	"\x10interval_seconds\x18\x04 \x01(\x05R\x0fintervalSeconds\x12:\n" +
+	"\x06groups\x18\x05 \x03(\x0e2\".containarium.v1.CloudMetricsGroupR\x06groups\"\x19\n" +
+	"\x17GetMetricsExportRequest\"\xea\x02\n" +
 	"\x18GetMetricsExportResponse\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12A\n" +
 	"\bprovider\x18\x02 \x01(\x0e2%.containarium.v1.CloudMetricsProviderR\bprovider\x12)\n" +
@@ -5061,7 +5170,8 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x0flast_success_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\rlastSuccessAt\x12\x1d\n" +
 	"\n" +
 	"last_error\x18\x05 \x01(\tR\tlastError\x12'\n" +
-	"\x0fexport_failures\x18\x06 \x01(\x03R\x0eexportFailures\"\xd9\x01\n" +
+	"\x0fexport_failures\x18\x06 \x01(\x03R\x0eexportFailures\x12:\n" +
+	"\x06groups\x18\a \x03(\x0e2\".containarium.v1.CloudMetricsGroupR\x06groups\"\xd9\x01\n" +
 	"\x14MoveContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12*\n" +
 	"\x11target_backend_id\x18\x02 \x01(\tR\x0ftargetBackendId\x12%\n" +
@@ -5105,7 +5215,12 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x14CloudMetricsProvider\x12&\n" +
 	"\"CLOUD_METRICS_PROVIDER_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aCLOUD_METRICS_PROVIDER_GCP\x10\x01\x12\x1e\n" +
-	"\x1aCLOUD_METRICS_PROVIDER_AWS\x10\x02:B\n" +
+	"\x1aCLOUD_METRICS_PROVIDER_AWS\x10\x02*\x9b\x01\n" +
+	"\x11CloudMetricsGroup\x12#\n" +
+	"\x1fCLOUD_METRICS_GROUP_UNSPECIFIED\x10\x00\x12\x1c\n" +
+	"\x18CLOUD_METRICS_GROUP_HOST\x10\x01\x12!\n" +
+	"\x1dCLOUD_METRICS_GROUP_CONTAINER\x10\x02\x12 \n" +
+	"\x1cCLOUD_METRICS_GROUP_PLATFORM\x10\x03:B\n" +
 	"\n" +
 	"state_name\x12!.google.protobuf.EnumValueOptions\x18ц\x03 \x01(\tR\tstateNameBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
 
@@ -5121,7 +5236,7 @@ func file_containarium_v1_container_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_container_proto_rawDescData
 }
 
-var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
 var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
 var file_containarium_v1_container_proto_goTypes = []any{
 	(OSType)(0),                              // 0: containarium.v1.OSType
@@ -5129,121 +5244,125 @@ var file_containarium_v1_container_proto_goTypes = []any{
 	(ContainerState)(0),                      // 2: containarium.v1.ContainerState
 	(DeletePolicy)(0),                        // 3: containarium.v1.DeletePolicy
 	(CloudMetricsProvider)(0),                // 4: containarium.v1.CloudMetricsProvider
-	(*ResourceLimits)(nil),                   // 5: containarium.v1.ResourceLimits
-	(*NetworkInfo)(nil),                      // 6: containarium.v1.NetworkInfo
-	(*Container)(nil),                        // 7: containarium.v1.Container
-	(*ContainerMetrics)(nil),                 // 8: containarium.v1.ContainerMetrics
-	(*CreateContainerRequest)(nil),           // 9: containarium.v1.CreateContainerRequest
-	(*CreateContainerResponse)(nil),          // 10: containarium.v1.CreateContainerResponse
-	(*ListContainersRequest)(nil),            // 11: containarium.v1.ListContainersRequest
-	(*ListContainersResponse)(nil),           // 12: containarium.v1.ListContainersResponse
-	(*GetContainerRequest)(nil),              // 13: containarium.v1.GetContainerRequest
-	(*GetContainerResponse)(nil),             // 14: containarium.v1.GetContainerResponse
-	(*DebugContainerRequest)(nil),            // 15: containarium.v1.DebugContainerRequest
-	(*DebugContainerResponse)(nil),           // 16: containarium.v1.DebugContainerResponse
-	(*DeleteContainerRequest)(nil),           // 17: containarium.v1.DeleteContainerRequest
-	(*DeleteContainerResponse)(nil),          // 18: containarium.v1.DeleteContainerResponse
-	(*StartContainerRequest)(nil),            // 19: containarium.v1.StartContainerRequest
-	(*StartContainerResponse)(nil),           // 20: containarium.v1.StartContainerResponse
-	(*StopContainerRequest)(nil),             // 21: containarium.v1.StopContainerRequest
-	(*StopContainerResponse)(nil),            // 22: containarium.v1.StopContainerResponse
-	(*ToggleMonitoringRequest)(nil),          // 23: containarium.v1.ToggleMonitoringRequest
-	(*ToggleMonitoringResponse)(nil),         // 24: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepRequest)(nil),           // 25: containarium.v1.ToggleAutoSleepRequest
-	(*ToggleAutoSleepResponse)(nil),          // 26: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLRequest)(nil),           // 27: containarium.v1.SetContainerTTLRequest
-	(*SetContainerTTLResponse)(nil),          // 28: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyRequest)(nil),  // 29: containarium.v1.SetContainerDeletePolicyRequest
-	(*SetContainerDeletePolicyResponse)(nil), // 30: containarium.v1.SetContainerDeletePolicyResponse
-	(*SetContainerAttributionRequest)(nil),   // 31: containarium.v1.SetContainerAttributionRequest
-	(*SetContainerAttributionResponse)(nil),  // 32: containarium.v1.SetContainerAttributionResponse
-	(*AddSSHKeyRequest)(nil),                 // 33: containarium.v1.AddSSHKeyRequest
-	(*AddSSHKeyResponse)(nil),                // 34: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyRequest)(nil),              // 35: containarium.v1.RemoveSSHKeyRequest
-	(*RemoveSSHKeyResponse)(nil),             // 36: containarium.v1.RemoveSSHKeyResponse
-	(*GetMetricsRequest)(nil),                // 37: containarium.v1.GetMetricsRequest
-	(*GetMetricsResponse)(nil),               // 38: containarium.v1.GetMetricsResponse
-	(*ResizeContainerRequest)(nil),           // 39: containarium.v1.ResizeContainerRequest
-	(*ResizeContainerResponse)(nil),          // 40: containarium.v1.ResizeContainerResponse
-	(*Collaborator)(nil),                     // 41: containarium.v1.Collaborator
-	(*AddCollaboratorRequest)(nil),           // 42: containarium.v1.AddCollaboratorRequest
-	(*AddCollaboratorResponse)(nil),          // 43: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorRequest)(nil),        // 44: containarium.v1.RemoveCollaboratorRequest
-	(*RemoveCollaboratorResponse)(nil),       // 45: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsRequest)(nil),         // 46: containarium.v1.ListCollaboratorsRequest
-	(*ListCollaboratorsResponse)(nil),        // 47: containarium.v1.ListCollaboratorsResponse
-	(*CleanupDiskRequest)(nil),               // 48: containarium.v1.CleanupDiskRequest
-	(*CleanupDiskResponse)(nil),              // 49: containarium.v1.CleanupDiskResponse
-	(*InstallStackRequest)(nil),              // 50: containarium.v1.InstallStackRequest
-	(*InstallStackResponse)(nil),             // 51: containarium.v1.InstallStackResponse
-	(*StackParameter)(nil),                   // 52: containarium.v1.StackParameter
-	(*StackInfo)(nil),                        // 53: containarium.v1.StackInfo
-	(*ListStacksRequest)(nil),                // 54: containarium.v1.ListStacksRequest
-	(*ListStacksResponse)(nil),               // 55: containarium.v1.ListStacksResponse
-	(*GetMonitoringInfoRequest)(nil),         // 56: containarium.v1.GetMonitoringInfoRequest
-	(*GetMonitoringInfoResponse)(nil),        // 57: containarium.v1.GetMonitoringInfoResponse
-	(*SetMetricsExportRequest)(nil),          // 58: containarium.v1.SetMetricsExportRequest
-	(*SetMetricsExportResponse)(nil),         // 59: containarium.v1.SetMetricsExportResponse
-	(*GetMetricsExportRequest)(nil),          // 60: containarium.v1.GetMetricsExportRequest
-	(*GetMetricsExportResponse)(nil),         // 61: containarium.v1.GetMetricsExportResponse
-	(*MoveContainerRequest)(nil),             // 62: containarium.v1.MoveContainerRequest
-	(*MoveContainerResponse)(nil),            // 63: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerRequest)(nil),    // 64: containarium.v1.AdoptMigratedContainerRequest
-	(*AdoptMigratedContainerResponse)(nil),   // 65: containarium.v1.AdoptMigratedContainerResponse
-	nil,                                      // 66: containarium.v1.Container.LabelsEntry
-	nil,                                      // 67: containarium.v1.CreateContainerRequest.LabelsEntry
-	nil,                                      // 68: containarium.v1.CreateContainerRequest.StackParametersEntry
-	nil,                                      // 69: containarium.v1.ListContainersRequest.LabelFilterEntry
-	nil,                                      // 70: containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	nil,                                      // 71: containarium.v1.SetContainerAttributionResponse.LabelsEntry
-	(*timestamppb.Timestamp)(nil),            // 72: google.protobuf.Timestamp
-	(*descriptorpb.EnumValueOptions)(nil),    // 73: google.protobuf.EnumValueOptions
+	(CloudMetricsGroup)(0),                   // 5: containarium.v1.CloudMetricsGroup
+	(*ResourceLimits)(nil),                   // 6: containarium.v1.ResourceLimits
+	(*NetworkInfo)(nil),                      // 7: containarium.v1.NetworkInfo
+	(*Container)(nil),                        // 8: containarium.v1.Container
+	(*ContainerMetrics)(nil),                 // 9: containarium.v1.ContainerMetrics
+	(*CreateContainerRequest)(nil),           // 10: containarium.v1.CreateContainerRequest
+	(*CreateContainerResponse)(nil),          // 11: containarium.v1.CreateContainerResponse
+	(*ListContainersRequest)(nil),            // 12: containarium.v1.ListContainersRequest
+	(*ListContainersResponse)(nil),           // 13: containarium.v1.ListContainersResponse
+	(*GetContainerRequest)(nil),              // 14: containarium.v1.GetContainerRequest
+	(*GetContainerResponse)(nil),             // 15: containarium.v1.GetContainerResponse
+	(*DebugContainerRequest)(nil),            // 16: containarium.v1.DebugContainerRequest
+	(*DebugContainerResponse)(nil),           // 17: containarium.v1.DebugContainerResponse
+	(*DeleteContainerRequest)(nil),           // 18: containarium.v1.DeleteContainerRequest
+	(*DeleteContainerResponse)(nil),          // 19: containarium.v1.DeleteContainerResponse
+	(*StartContainerRequest)(nil),            // 20: containarium.v1.StartContainerRequest
+	(*StartContainerResponse)(nil),           // 21: containarium.v1.StartContainerResponse
+	(*StopContainerRequest)(nil),             // 22: containarium.v1.StopContainerRequest
+	(*StopContainerResponse)(nil),            // 23: containarium.v1.StopContainerResponse
+	(*ToggleMonitoringRequest)(nil),          // 24: containarium.v1.ToggleMonitoringRequest
+	(*ToggleMonitoringResponse)(nil),         // 25: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepRequest)(nil),           // 26: containarium.v1.ToggleAutoSleepRequest
+	(*ToggleAutoSleepResponse)(nil),          // 27: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLRequest)(nil),           // 28: containarium.v1.SetContainerTTLRequest
+	(*SetContainerTTLResponse)(nil),          // 29: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyRequest)(nil),  // 30: containarium.v1.SetContainerDeletePolicyRequest
+	(*SetContainerDeletePolicyResponse)(nil), // 31: containarium.v1.SetContainerDeletePolicyResponse
+	(*SetContainerAttributionRequest)(nil),   // 32: containarium.v1.SetContainerAttributionRequest
+	(*SetContainerAttributionResponse)(nil),  // 33: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyRequest)(nil),                 // 34: containarium.v1.AddSSHKeyRequest
+	(*AddSSHKeyResponse)(nil),                // 35: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyRequest)(nil),              // 36: containarium.v1.RemoveSSHKeyRequest
+	(*RemoveSSHKeyResponse)(nil),             // 37: containarium.v1.RemoveSSHKeyResponse
+	(*GetMetricsRequest)(nil),                // 38: containarium.v1.GetMetricsRequest
+	(*GetMetricsResponse)(nil),               // 39: containarium.v1.GetMetricsResponse
+	(*ResizeContainerRequest)(nil),           // 40: containarium.v1.ResizeContainerRequest
+	(*ResizeContainerResponse)(nil),          // 41: containarium.v1.ResizeContainerResponse
+	(*Collaborator)(nil),                     // 42: containarium.v1.Collaborator
+	(*AddCollaboratorRequest)(nil),           // 43: containarium.v1.AddCollaboratorRequest
+	(*AddCollaboratorResponse)(nil),          // 44: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorRequest)(nil),        // 45: containarium.v1.RemoveCollaboratorRequest
+	(*RemoveCollaboratorResponse)(nil),       // 46: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsRequest)(nil),         // 47: containarium.v1.ListCollaboratorsRequest
+	(*ListCollaboratorsResponse)(nil),        // 48: containarium.v1.ListCollaboratorsResponse
+	(*CleanupDiskRequest)(nil),               // 49: containarium.v1.CleanupDiskRequest
+	(*CleanupDiskResponse)(nil),              // 50: containarium.v1.CleanupDiskResponse
+	(*InstallStackRequest)(nil),              // 51: containarium.v1.InstallStackRequest
+	(*InstallStackResponse)(nil),             // 52: containarium.v1.InstallStackResponse
+	(*StackParameter)(nil),                   // 53: containarium.v1.StackParameter
+	(*StackInfo)(nil),                        // 54: containarium.v1.StackInfo
+	(*ListStacksRequest)(nil),                // 55: containarium.v1.ListStacksRequest
+	(*ListStacksResponse)(nil),               // 56: containarium.v1.ListStacksResponse
+	(*GetMonitoringInfoRequest)(nil),         // 57: containarium.v1.GetMonitoringInfoRequest
+	(*GetMonitoringInfoResponse)(nil),        // 58: containarium.v1.GetMonitoringInfoResponse
+	(*SetMetricsExportRequest)(nil),          // 59: containarium.v1.SetMetricsExportRequest
+	(*SetMetricsExportResponse)(nil),         // 60: containarium.v1.SetMetricsExportResponse
+	(*GetMetricsExportRequest)(nil),          // 61: containarium.v1.GetMetricsExportRequest
+	(*GetMetricsExportResponse)(nil),         // 62: containarium.v1.GetMetricsExportResponse
+	(*MoveContainerRequest)(nil),             // 63: containarium.v1.MoveContainerRequest
+	(*MoveContainerResponse)(nil),            // 64: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerRequest)(nil),    // 65: containarium.v1.AdoptMigratedContainerRequest
+	(*AdoptMigratedContainerResponse)(nil),   // 66: containarium.v1.AdoptMigratedContainerResponse
+	nil,                                      // 67: containarium.v1.Container.LabelsEntry
+	nil,                                      // 68: containarium.v1.CreateContainerRequest.LabelsEntry
+	nil,                                      // 69: containarium.v1.CreateContainerRequest.StackParametersEntry
+	nil,                                      // 70: containarium.v1.ListContainersRequest.LabelFilterEntry
+	nil,                                      // 71: containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	nil,                                      // 72: containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	(*timestamppb.Timestamp)(nil),            // 73: google.protobuf.Timestamp
+	(*descriptorpb.EnumValueOptions)(nil),    // 74: google.protobuf.EnumValueOptions
 }
 var file_containarium_v1_container_proto_depIdxs = []int32{
 	2,  // 0: containarium.v1.Container.state:type_name -> containarium.v1.ContainerState
-	5,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
-	6,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
-	66, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
+	6,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
+	7,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
+	67, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
 	0,  // 4: containarium.v1.Container.os_type:type_name -> containarium.v1.OSType
 	1,  // 5: containarium.v1.Container.access_type:type_name -> containarium.v1.AccessType
-	72, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
-	72, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
+	73, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	73, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
 	3,  // 8: containarium.v1.Container.delete_policy:type_name -> containarium.v1.DeletePolicy
-	5,  // 9: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
-	67, // 10: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
+	6,  // 9: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
+	68, // 10: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
 	0,  // 11: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
-	68, // 12: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
-	7,  // 13: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
+	69, // 12: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
+	8,  // 13: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
 	2,  // 14: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
-	69, // 15: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
-	7,  // 16: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
-	7,  // 17: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
-	8,  // 18: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
-	7,  // 19: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
-	7,  // 20: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
-	72, // 21: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	70, // 15: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
+	8,  // 16: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
+	8,  // 17: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
+	9,  // 18: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
+	8,  // 19: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
+	8,  // 20: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
+	73, // 21: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
 	3,  // 22: containarium.v1.SetContainerDeletePolicyRequest.delete_policy:type_name -> containarium.v1.DeletePolicy
 	3,  // 23: containarium.v1.SetContainerDeletePolicyResponse.delete_policy:type_name -> containarium.v1.DeletePolicy
-	70, // 24: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	71, // 25: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
-	8,  // 26: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
-	7,  // 27: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
-	41, // 28: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
-	41, // 29: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
-	7,  // 30: containarium.v1.CleanupDiskResponse.container:type_name -> containarium.v1.Container
-	7,  // 31: containarium.v1.InstallStackResponse.container:type_name -> containarium.v1.Container
-	52, // 32: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
-	53, // 33: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
+	71, // 24: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	72, // 25: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	9,  // 26: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
+	8,  // 27: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
+	42, // 28: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
+	42, // 29: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
+	8,  // 30: containarium.v1.CleanupDiskResponse.container:type_name -> containarium.v1.Container
+	8,  // 31: containarium.v1.InstallStackResponse.container:type_name -> containarium.v1.Container
+	53, // 32: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
+	54, // 33: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
 	4,  // 34: containarium.v1.SetMetricsExportRequest.provider:type_name -> containarium.v1.CloudMetricsProvider
-	4,  // 35: containarium.v1.SetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
-	4,  // 36: containarium.v1.GetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
-	72, // 37: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
-	73, // 38: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
-	39, // [39:39] is the sub-list for method output_type
-	39, // [39:39] is the sub-list for method input_type
-	39, // [39:39] is the sub-list for extension type_name
-	38, // [38:39] is the sub-list for extension extendee
-	0,  // [0:38] is the sub-list for field type_name
+	5,  // 35: containarium.v1.SetMetricsExportRequest.groups:type_name -> containarium.v1.CloudMetricsGroup
+	4,  // 36: containarium.v1.SetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
+	5,  // 37: containarium.v1.SetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
+	4,  // 38: containarium.v1.GetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
+	73, // 39: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
+	5,  // 40: containarium.v1.GetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
+	74, // 41: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
+	42, // [42:42] is the sub-list for method output_type
+	42, // [42:42] is the sub-list for method input_type
+	42, // [42:42] is the sub-list for extension type_name
+	41, // [41:42] is the sub-list for extension extendee
+	0,  // [0:41] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_container_proto_init() }
@@ -5256,7 +5375,7 @@ func file_containarium_v1_container_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_container_proto_rawDesc), len(file_containarium_v1_container_proto_rawDesc)),
-			NumEnums:      5,
+			NumEnums:      6,
 			NumMessages:   67,
 			NumExtensions: 1,
 			NumServices:   0,

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -986,6 +986,36 @@ enum CloudMetricsProvider {
   CLOUD_METRICS_PROVIDER_AWS = 2;
 }
 
+// CloudMetricsGroup names an independently enableable set of exported
+// series (#1081). Export is organized into groups so the billed sample
+// surface — custom metrics are billed per ingested sample — stays a
+// deliberate, per-group choice rather than an all-or-nothing switch.
+// Typed so a group can never be a magic string. Absent/empty on the wire
+// means "host only" (CLOUD_METRICS_GROUP_HOST), which is exactly the
+// v0.60.0 behavior a persisted config resumes into.
+enum CloudMetricsGroup {
+  // Unset. Never a valid element of an explicit groups list;
+  // SetMetricsExport rejects a request whose groups contain it. An empty
+  // groups list (not a list of UNSPECIFIED) is what means "default to
+  // host".
+  CLOUD_METRICS_GROUP_UNSPECIFIED = 0;
+
+  // Host-infrastructure series (CPU load, memory, disk, container count)
+  // — the complete #1070 allowlist. The default when no group is named.
+  CLOUD_METRICS_GROUP_HOST = 1;
+
+  // Per-container series. Reserved by #1081 as an enableable group; the
+  // series themselves land in #1071/#1072, so enabling it today exports
+  // no additional series.
+  CLOUD_METRICS_GROUP_CONTAINER = 2;
+
+  // Platform-level series (API request/error counts, provisioning
+  // outcomes, peer connectivity). Reserved by #1081 as an enableable
+  // group; the series themselves land in #1082/#1083/#1084, so enabling
+  // it today exports no additional series.
+  CLOUD_METRICS_GROUP_PLATFORM = 3;
+}
+
 // SetMetricsExportRequest enables or disables cloud-native metrics export.
 // Enabling with provider=GCP triggers a synchronous Application Default
 // Credentials probe (monitoring-write scope) before anything is persisted
@@ -1000,6 +1030,13 @@ message SetMetricsExportRequest {
   // CLOUD_METRICS_PROVIDER_UNSPECIFIED (INVALID_ARGUMENT) or
   // CLOUD_METRICS_PROVIDER_AWS (UNIMPLEMENTED — MVP is GCP-only).
   CloudMetricsProvider provider = 2;
+
+  // The metric groups to export (#1081). Enables exactly these groups;
+  // an empty list defaults to [CLOUD_METRICS_GROUP_HOST], preserving the
+  // v0.60.0 host-only behavior. Every element must be a defined group
+  // other than CLOUD_METRICS_GROUP_UNSPECIFIED (INVALID_ARGUMENT
+  // otherwise). Ignored when enabled=false.
+  repeated CloudMetricsGroup groups = 3;
 }
 
 // SetMetricsExportResponse reports the effective state after the toggle.
@@ -1012,6 +1049,11 @@ message SetMetricsExportResponse {
   bool enabled = 2;
   CloudMetricsProvider provider = 3;
   int32 interval_seconds = 4;
+
+  // The effective set of enabled metric groups after the call (#1081),
+  // normalized: an omitted/empty request list resolves to
+  // [CLOUD_METRICS_GROUP_HOST].
+  repeated CloudMetricsGroup groups = 5;
 }
 
 // GetMetricsExportRequest requests the current cloud-native metrics
@@ -1043,6 +1085,11 @@ message GetMetricsExportResponse {
 
   // Count of failed export batches since the exporter was last (re)built.
   int64 export_failures = 6;
+
+  // The set of enabled metric groups (#1081). Normalized: a host that has
+  // never configured groups (or a v0.60.0 config with none persisted)
+  // reports [CLOUD_METRICS_GROUP_HOST].
+  repeated CloudMetricsGroup groups = 7;
 }
 
 // MoveContainerRequest is the source-side request to migrate a


### PR DESCRIPTION
Closes #1072

## Summary
- Emit a constant-`1` `containarium.export.heartbeat` gauge every export interval on the existing `CloudExportCollector`'s `PeriodicReader`, so a **metric-absence ("dead-man")** alert policy in the cloud provider's monitoring catches the out-of-band failure class — host or daemon dead / network-partitioned — that host-local alerting cannot report because it fate-shares with the host.
- The heartbeat is registered on its **own callback, independent of `Sources`**: a transient source error (e.g. incus briefly unavailable) skips the host series for that tick but never suppresses the heartbeat. This preserves the design's dead-man invariant (design lines 23–26) — series absence means exactly one thing, the daemon stopped exporting, not "incus hiccuped."
- Heartbeat labels are `backend_id` / `hostname` / `daemon_version` per the design's series table (distinct from the host-series `region`); `daemon_version` is wired from `version.GetVersion()` in the server, exactly as `region`/`hostname` are already wired.
- New runbook `docs/METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md` with the exact `gcloud`/JSON `conditionAbsent` alert-policy recipe, plus a pointer added from the design doc.

Stays inside the #1070 collector/allowlist-golden pattern; no proto change, no new dependency, no scope creep into #1071/#1073 or the #1081–#1085 platform-domain work.

## Test evidence
`go test ./internal/metrics/cloudexport/... ./internal/server/...` — all green.

New tests (`internal/metrics/cloudexport/heartbeat_test.go`):
- `TestHeartbeatEmittedEveryInterval` — **AC #1**: heartbeat present, int-typed, value `1` on every tick (3 consecutive collections).
- `TestHeartbeatSurvivesSourceError` (sources-error + nil-snapshot subtests) — dead-man correctness: heartbeat still emits when `Sources` fails, and is the *only* series (no stale host values).
- `TestHeartbeatLabels` — locks the `backend_id`/`hostname`/`daemon_version` allowlist; asserts `region` and tenant labels absent.
- `TestHeartbeatAttributeSet` — the label set is derived from daemon identity, not the collection path.

Existing tests updated to account for the new series (made **more precise, not weakened**):
- `TestExportedSeries_MatchesAllowlistGolden` — heartbeat added to the golden (now 9 series).
- `TestNoTenantLabels` — now series-aware (host → region, heartbeat → daemon_version); still forbids every tenant/org label on every series.
- `TestSourceErrorSkipsTickWithoutPanic` / `TestNilSnapshotSkipsTick` — now assert **host** series are suppressed *and* the heartbeat survives.
- `TestEnableDisableRebuild` — 8 → 9 series exported; asserts the heartbeat rides the batch.

`gofmt -l` clean, `go vet` clean, `go build ./...` clean.

> Environment note: no fresh Containarium Cloud box was available in this environment, so build/test were run locally in the worktree.

## Live-only acceptance criterion — flagged unverified in this PR
AC #2 ("stopping the daemon triggers a metric-absence alert — verified live with a real Cloud Monitoring alert policy") **cannot be verified in CI / this environment** — it needs a live GCP project with real ingestion. This PR delivers everything CI can verify (the series emitted correctly against the in-memory reader harness) plus the exact operator recipe and live verification procedure in the runbook. This matches how #1070 / PR #1076 handled the same class of live-only criterion.