### PR TITLE
feat(metrics-export): platform API health series (requests/errors by code class)

### DIFF
--- a/internal/metrics/cloudexport/collector.go
+++ b/internal/metrics/cloudexport/collector.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 
+	"github.com/footprintai/containarium/internal/metrics/platformstats"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
@@ -47,6 +48,15 @@ const (
 	// partitioned) that host-local alerting cannot report on because it
 	// fate-shares with the host.
 	MetricHeartbeat = "containarium.export.heartbeat"
+
+	// MetricPlatformAPIRequests / MetricPlatformAPIErrors are the
+	// platform group's API-health series (#1082): cumulative counts of
+	// completed API calls (native gRPC + REST-via-grpc-gateway, both
+	// converge on the same interceptor), by coarse code_class. Requests
+	// counts every completed call; errors counts only the client_error
+	// and server_error classes.
+	MetricPlatformAPIRequests = "containarium.platform.api.requests"
+	MetricPlatformAPIErrors   = "containarium.platform.api.errors"
 )
 
 // Label keys — the complete allowlist. No org/tenant identifier ever
@@ -61,6 +71,11 @@ const (
 	// series) with the daemon build, so a dead-man alert makes clear which
 	// version stopped reporting.
 	LabelDaemonVersion = "daemon_version"
+	// LabelCodeClass tags the platform API series with their coarse
+	// outcome bucket (platformstats.CodeClass) — the deliberately small,
+	// fixed-cardinality dimension the design uses instead of a raw route
+	// or gRPC code, which would blow up the billed cost surface.
+	LabelCodeClass = "code_class"
 )
 
 // Labels is the fixed identity stamped on every exported series. These
@@ -97,10 +112,28 @@ func (l Labels) heartbeatAttributeSet() attribute.Set {
 	)
 }
 
+// platformAttributeSet is the platform API-health label set (backend_id,
+// hostname, region, code_class) — the host-series identity plus the
+// per-point outcome class.
+func (l Labels) platformAttributeSet(class platformstats.CodeClass) attribute.Set {
+	return attribute.NewSet(
+		attribute.String(LabelBackendID, l.BackendID),
+		attribute.String(LabelHostname, l.Hostname),
+		attribute.String(LabelRegion, l.Region),
+		attribute.String(LabelCodeClass, string(class)),
+	)
+}
+
 // CollectorOptions are the construction inputs for a CloudExportCollector.
 type CollectorOptions struct {
 	// Sources is the seam over the daemon's metric collection. Required.
 	Sources Sources
+	// PlatformSources is the read-side seam over platform-domain facts
+	// (#1082/#1083/#1084). Optional — nil means the platform group, if
+	// enabled, registers no instruments (the same "reserved" behavior
+	// container/platform had before any of those issues landed), rather
+	// than erroring.
+	PlatformSources PlatformSources
 	// Exporter is the OTel SDK metric exporter to push batches through
 	// (a provider Sink's NewExporter result in production, a fake in
 	// tests). Required.
@@ -180,13 +213,14 @@ func (h *healthExporter) Export(ctx context.Context, rm *metricdata.ResourceMetr
 // cost surface, and keeping it isolated makes that surface explicit and
 // reviewable in one file.
 type CloudExportCollector struct {
-	sources  Sources
-	exporter sdkmetric.Exporter
-	resource *resource.Resource
-	labels   Labels
-	interval time.Duration
-	groups   []pb.CloudMetricsGroup
-	health   *healthState
+	sources         Sources
+	platformSources PlatformSources
+	exporter        sdkmetric.Exporter
+	resource        *resource.Resource
+	labels          Labels
+	interval        time.Duration
+	groups          []pb.CloudMetricsGroup
+	health          *healthState
 
 	mu      sync.Mutex
 	mp      *sdkmetric.MeterProvider
@@ -201,13 +235,14 @@ func NewCollector(opts CollectorOptions) *CloudExportCollector {
 		interval = floor
 	}
 	return &CloudExportCollector{
-		sources:  opts.Sources,
-		exporter: opts.Exporter,
-		resource: opts.Resource,
-		labels:   opts.Labels,
-		interval: interval,
-		groups:   NormalizeGroups(opts.Groups),
-		health:   &healthState{},
+		sources:         opts.Sources,
+		platformSources: opts.PlatformSources,
+		exporter:        opts.Exporter,
+		resource:        opts.Resource,
+		labels:          opts.Labels,
+		interval:        interval,
+		groups:          NormalizeGroups(opts.Groups),
+		health:          &healthState{},
 	}
 }
 
@@ -280,7 +315,7 @@ func (c *CloudExportCollector) buildMeterProvider(reader sdkmetric.Reader) (*sdk
 	}
 	mp := sdkmetric.NewMeterProvider(mpOpts...)
 	for _, g := range c.groups {
-		if err := registerGroupInstruments(mp, g, c.sources, c.labels); err != nil {
+		if err := registerGroupInstruments(mp, g, c.sources, c.platformSources, c.labels); err != nil {
 			return nil, err
 		}
 	}
@@ -292,11 +327,11 @@ func (c *CloudExportCollector) buildMeterProvider(reader sdkmetric.Reader) (*sdk
 
 // registerGroupInstruments registers exactly the instruments belonging
 // to one metric group (#1081). This is the single dispatch point new
-// groups plug into: host registers the #1070 allowlist; container and
-// platform are reserved enableable groups whose series land in
-// #1071/#1072 and #1082/#1083/#1084 — until then they register nothing,
-// so enabling them is a deliberate zero-series opt-in rather than a
-// no-such-group error. Groups are normalized before they reach here, so
+// groups plug into: host registers the #1070 allowlist; container is
+// still reserved (per-container series land in #1071); platform
+// registers the #1082 API-health series when a PlatformSources is
+// wired, and nothing otherwise (#1083/#1084 add more platform series to
+// the same dispatch). Groups are normalized before they reach here, so
 // UNSPECIFIED never arrives; an unknown value is a programming error.
 //
 // Note the heartbeat is deliberately NOT a group: it is registered
@@ -304,7 +339,7 @@ func (c *CloudExportCollector) buildMeterProvider(reader sdkmetric.Reader) (*sdk
 // whatever groups are enabled, because the dead-man signal must never be
 // gated by group selection or a Sources error (see
 // registerHeartbeatInstrument).
-func registerGroupInstruments(mp *sdkmetric.MeterProvider, group pb.CloudMetricsGroup, sources Sources, labels Labels) error {
+func registerGroupInstruments(mp *sdkmetric.MeterProvider, group pb.CloudMetricsGroup, sources Sources, platformSources PlatformSources, labels Labels) error {
 	switch group {
 	case pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST:
 		return registerHostInstruments(mp, sources, labels)
@@ -312,11 +347,53 @@ func registerGroupInstruments(mp *sdkmetric.MeterProvider, group pb.CloudMetrics
 		// Reserved: per-container series land in #1071/#1072.
 		return nil
 	case pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM:
-		// Reserved: platform series land in #1082/#1083/#1084.
-		return nil
+		if platformSources == nil {
+			// Not wired (e.g. an older daemon build, or a test that
+			// doesn't need it) — deliberate zero-series opt-in, same as
+			// the pre-#1082 "reserved" behavior, never an error.
+			return nil
+		}
+		return registerPlatformInstruments(mp, platformSources, labels)
 	default:
 		return fmt.Errorf("cloudexport: unregisterable metric group %v", group)
 	}
+}
+
+// registerPlatformInstruments creates the platform group's API-health
+// counters (#1082) and wires one callback that pulls a single
+// APISnapshot per tick and observes both series, one point per
+// code_class. Counters, not gauges: OTel async-counter semantics expect
+// the current cumulative total on every observation (platformstats.Stats
+// already accumulates for the daemon's lifetime), which is exactly what
+// APISnapshot reports.
+func registerPlatformInstruments(mp *sdkmetric.MeterProvider, sources PlatformSources, labels Labels) error {
+	meter := mp.Meter(meterName)
+
+	requests, err := meter.Int64ObservableCounter(MetricPlatformAPIRequests,
+		metric.WithDescription("Cumulative count of completed API requests (gRPC + REST-via-gateway), by coarse outcome class."))
+	if err != nil {
+		return err
+	}
+	apiErrors, err := meter.Int64ObservableCounter(MetricPlatformAPIErrors,
+		metric.WithDescription("Cumulative count of completed API requests that resulted in a client or server error, by coarse outcome class."))
+	if err != nil {
+		return err
+	}
+
+	_, err = meter.RegisterCallback(
+		func(ctx context.Context, o metric.Observer) error {
+			snap := sources.APIStats()
+			for class, n := range snap.RequestsByClass {
+				o.ObserveInt64(requests, n, metric.WithAttributeSet(labels.platformAttributeSet(class)))
+			}
+			for class, n := range snap.ErrorsByClass {
+				o.ObserveInt64(apiErrors, n, metric.WithAttributeSet(labels.platformAttributeSet(class)))
+			}
+			return nil
+		},
+		requests, apiErrors,
+	)
+	return err
 }
 
 // registerHeartbeatInstrument creates the heartbeat/up gauge (#1072) and

--- a/internal/metrics/cloudexport/collector_test.go
+++ b/internal/metrics/cloudexport/collector_test.go
@@ -11,6 +11,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
+	"github.com/footprintai/containarium/internal/metrics/platformstats"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
@@ -165,13 +166,58 @@ func TestExportedSeries_MatchesAllowlistGolden(t *testing.T) {
 	}
 }
 
+// fakePlatformSources is a PlatformSources whose API snapshot is fully
+// controlled by the test.
+type fakePlatformSources struct {
+	api platformstats.APISnapshot
+}
+
+func (f *fakePlatformSources) APIStats() platformstats.APISnapshot {
+	return f.api
+}
+
+// flattenPoints returns every emitted datapoint (gauge OR cumulative
+// counter) as (name, value, attributes). Separate from flattenGauges
+// (which deliberately fatals on anything but a gauge, locking in that
+// the #1070 host/heartbeat series are gauge-only) because the platform
+// group's api.requests/api.errors are Int64ObservableCounters —
+// asserting on them needs a helper that accepts Sum[int64] too.
+func flattenPoints(t *testing.T, rm metricdata.ResourceMetrics) []point {
+	t.Helper()
+	var pts []point
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch g := m.Data.(type) {
+			case metricdata.Gauge[float64]:
+				for _, dp := range g.DataPoints {
+					pts = append(pts, point{name: m.Name, fval: dp.Value, attrs: dp.Attributes})
+				}
+			case metricdata.Gauge[int64]:
+				for _, dp := range g.DataPoints {
+					pts = append(pts, point{name: m.Name, ival: dp.Value, isInt: true, attrs: dp.Attributes})
+				}
+			case metricdata.Sum[int64]:
+				for _, dp := range g.DataPoints {
+					pts = append(pts, point{name: m.Name, ival: dp.Value, isInt: true, attrs: dp.Attributes})
+				}
+			default:
+				t.Fatalf("metric %q has unhandled data type %T", m.Name, m.Data)
+			}
+		}
+	}
+	return pts
+}
+
 // collectGroupsOnce stands up a ManualReader-backed MeterProvider for a
 // specific set of enabled groups and pulls one collection, so the
 // per-group golden can assert exactly which series each group emits.
-func collectGroupsOnce(t *testing.T, groups []pb.CloudMetricsGroup, sources Sources, labels Labels) metricdata.ResourceMetrics {
+// platformSources may be nil — the platform group registers no
+// instruments without one, matching production's "not wired yet"
+// behavior.
+func collectGroupsOnce(t *testing.T, groups []pb.CloudMetricsGroup, sources Sources, platformSources PlatformSources, labels Labels) metricdata.ResourceMetrics {
 	t.Helper()
 	reader := sdkmetric.NewManualReader()
-	c := NewCollector(CollectorOptions{Sources: sources, Labels: labels, Groups: groups})
+	c := NewCollector(CollectorOptions{Sources: sources, PlatformSources: platformSources, Labels: labels, Groups: groups})
 	mp, err := c.buildMeterProvider(reader)
 	if err != nil {
 		t.Fatalf("buildMeterProvider: %v", err)
@@ -226,7 +272,7 @@ func TestExportedSeries_PerGroupGolden(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			rm := collectGroupsOnce(t, tc.groups, &fakeSources{sr: sampleResources()}, sampleLabels())
+			rm := collectGroupsOnce(t, tc.groups, &fakeSources{sr: sampleResources()}, nil, sampleLabels())
 			pts := flattenGauges(t, rm)
 
 			got := map[string]bool{}
@@ -496,5 +542,151 @@ func TestIntervalFloor(t *testing.T) {
 	c := NewCollector(CollectorOptions{IntervalSeconds: 120})
 	if got := c.interval; got != 120*time.Second {
 		t.Errorf("IntervalSeconds=120 -> interval %v, want 120s", got)
+	}
+}
+
+// samplePlatformSnapshot is a representative, non-trivial API snapshot
+// for the platform-series tests below.
+func samplePlatformSnapshot() platformstats.APISnapshot {
+	return platformstats.APISnapshot{
+		RequestsByClass: map[platformstats.CodeClass]int64{
+			platformstats.CodeClassOK:          42,
+			platformstats.CodeClassClientError: 3,
+			platformstats.CodeClassServerError: 1,
+		},
+		ErrorsByClass: map[platformstats.CodeClass]int64{
+			platformstats.CodeClassClientError: 3,
+			platformstats.CodeClassServerError: 1,
+		},
+	}
+}
+
+// pointsByNameAndClass indexes flattened points by (series name,
+// code_class label value) for easy per-class assertions.
+func pointsByNameAndClass(pts []point) map[string]map[string]point {
+	out := map[string]map[string]point{}
+	for _, p := range pts {
+		class, _ := p.attrs.Value(attribute.Key(LabelCodeClass))
+		if out[p.name] == nil {
+			out[p.name] = map[string]point{}
+		}
+		out[p.name][class.AsString()] = p
+	}
+	return out
+}
+
+// TestExportedSeries_PlatformAPIHealth is #1082's acceptance criterion:
+// enabling the platform group with a wired PlatformSources emits
+// containarium.platform.api.requests/.errors, one point per code_class,
+// with the exact cumulative values the snapshot reports.
+func TestExportedSeries_PlatformAPIHealth(t *testing.T) {
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{platform}, &fakeSources{sr: sampleResources()}, &fakePlatformSources{api: samplePlatformSnapshot()}, sampleLabels())
+	pts := flattenPoints(t, rm)
+	byNameClass := pointsByNameAndClass(pts)
+
+	wantRequests := map[string]int64{"ok": 42, "client_error": 3, "server_error": 1}
+	for class, want := range wantRequests {
+		p, ok := byNameClass[MetricPlatformAPIRequests][class]
+		if !ok {
+			t.Fatalf("missing %s{code_class=%q}", MetricPlatformAPIRequests, class)
+		}
+		if p.ival != want {
+			t.Errorf("%s{code_class=%q} = %d, want %d", MetricPlatformAPIRequests, class, p.ival, want)
+		}
+	}
+
+	// api.errors carries only the error classes — "ok" is never an error
+	// and must not appear as a series point at all.
+	wantErrors := map[string]int64{"client_error": 3, "server_error": 1}
+	for class, want := range wantErrors {
+		p, ok := byNameClass[MetricPlatformAPIErrors][class]
+		if !ok {
+			t.Fatalf("missing %s{code_class=%q}", MetricPlatformAPIErrors, class)
+		}
+		if p.ival != want {
+			t.Errorf("%s{code_class=%q} = %d, want %d", MetricPlatformAPIErrors, class, p.ival, want)
+		}
+	}
+	if _, ok := byNameClass[MetricPlatformAPIErrors]["ok"]; ok {
+		t.Errorf("%s must not emit a code_class=ok point (ok is never an error)", MetricPlatformAPIErrors)
+	}
+}
+
+// TestExportedSeries_PlatformGroupNilSourcesEmitsNothing guards the
+// "not wired yet" default: enabling the platform group without a
+// PlatformSources must emit zero platform series, never panic.
+func TestExportedSeries_PlatformGroupNilSourcesEmitsNothing(t *testing.T) {
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{platform}, &fakeSources{sr: sampleResources()}, nil, sampleLabels())
+	pts := flattenPoints(t, rm)
+	for _, p := range pts {
+		if p.name == MetricPlatformAPIRequests || p.name == MetricPlatformAPIErrors {
+			t.Errorf("platform series %q emitted with no PlatformSources wired", p.name)
+		}
+	}
+}
+
+// TestNoTenantLabels_PlatformSeries locks in #1082's cardinality
+// acceptance criterion: the platform API series carry exactly
+// backend_id/hostname/region/code_class and nothing else — no
+// per-route, per-user, or per-org label, even though platformstats
+// itself has no channel to supply one.
+func TestNoTenantLabels_PlatformSeries(t *testing.T) {
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{platform}, &fakeSources{sr: sampleResources()}, &fakePlatformSources{api: samplePlatformSnapshot()}, sampleLabels())
+	all := flattenPoints(t, rm)
+
+	// Enabling the platform group also emits the always-on heartbeat
+	// (buildMeterProvider registers it unconditionally, independent of
+	// groups) — it has its own label contract and its own test
+	// (TestHeartbeatLabels); only the two platform series belong here.
+	var pts []point
+	for _, p := range all {
+		if p.name == MetricPlatformAPIRequests || p.name == MetricPlatformAPIErrors {
+			pts = append(pts, p)
+		}
+	}
+	if len(pts) == 0 {
+		t.Fatal("no platform series emitted")
+	}
+
+	allowed := map[string]string{
+		LabelBackendID: "backend-xyz",
+		LabelHostname:  "host-1",
+		LabelRegion:    "us-central1",
+		// code_class value varies per point; checked separately below.
+	}
+	forbidden := []string{"org", "org_id", "tenant", "tenant_id", "username", "user", "uuid", "route", "method", "path"}
+
+	for _, p := range pts {
+		iter := p.attrs.Iter()
+		seen := map[string]bool{}
+		for iter.Next() {
+			kv := iter.Attribute()
+			key := string(kv.Key)
+			seen[key] = true
+			for _, f := range forbidden {
+				if key == f {
+					t.Errorf("series %q carries forbidden label %q", p.name, key)
+				}
+			}
+			if key == LabelCodeClass {
+				continue // value asserted by TestExportedSeries_PlatformAPIHealth
+			}
+			if wantVal, ok := allowed[key]; !ok {
+				t.Errorf("series %q carries non-allowlisted label %q", p.name, key)
+			} else if kv.Value.AsString() != wantVal {
+				t.Errorf("series %q label %q = %q, want %q", p.name, key, kv.Value.AsString(), wantVal)
+			}
+		}
+		for want := range allowed {
+			if !seen[want] {
+				t.Errorf("series %q missing allowlisted label %q", p.name, want)
+			}
+		}
+		if !seen[LabelCodeClass] {
+			t.Errorf("series %q missing required label %q", p.name, LabelCodeClass)
+		}
 	}
 }

--- a/internal/metrics/cloudexport/sources.go
+++ b/internal/metrics/cloudexport/sources.go
@@ -3,6 +3,7 @@ package cloudexport
 import (
 	"context"
 
+	"github.com/footprintai/containarium/internal/metrics/platformstats"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
@@ -52,4 +53,16 @@ type Sources interface {
 	// container name. Used by the #1071 container-series collector; not
 	// consulted by the #1070 host-series pipeline.
 	AllContainerMetrics(ctx context.Context) (map[string]*pb.ContainerMetrics, error)
+}
+
+// PlatformSources is the read-side seam over platform-domain facts the
+// platform metric group (#1082/#1083/#1084) observes at each export
+// tick — a snapshot read with no server import, so the collector stays
+// unit-testable with a fake. Extended incrementally as more platform
+// series land: #1083 adds provisioning outcomes, #1084 adds peer/tunnel
+// connectivity.
+type PlatformSources interface {
+	// APIStats returns the current cumulative API request/error counters
+	// by code_class (#1082).
+	APIStats() platformstats.APISnapshot
 }

--- a/internal/metrics/platformstats/interceptor.go
+++ b/internal/metrics/platformstats/interceptor.go
@@ -1,0 +1,25 @@
+package platformstats
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+// UnaryInterceptor returns a grpc.UnaryServerInterceptor that classifies
+// every completed unary RPC by its final gRPC status and records one
+// event into stats — the single choke point where both native gRPC
+// clients and REST-via-grpc-gateway callers converge, so counting here
+// covers both transports with no double counting.
+//
+// Purely observational: it never alters the request, the response, or
+// the error the wrapped handler returns, and it never fails a call — a
+// nil stats would panic, so callers must always pass a real *Stats.
+func UnaryInterceptor(stats *Stats) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		resp, err := handler(ctx, req)
+		stats.RecordAPIRequest(ClassifyCode(status.Code(err)))
+		return resp, err
+	}
+}

--- a/internal/metrics/platformstats/interceptor_test.go
+++ b/internal/metrics/platformstats/interceptor_test.go
@@ -1,0 +1,80 @@
+package platformstats
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestUnaryInterceptor_ClassifiesByFinalStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		handlerErr error
+		wantClass  CodeClass
+	}{
+		{"nil error is ok", nil, CodeClassOK},
+		{"InvalidArgument status is client_error", status.Error(codes.InvalidArgument, "bad"), CodeClassClientError},
+		{"NotFound status is client_error", status.Error(codes.NotFound, "missing"), CodeClassClientError},
+		{"Internal status is server_error", status.Error(codes.Internal, "boom"), CodeClassServerError},
+		{"plain non-status error maps to Unknown -> server_error", errors.New("plain error"), CodeClassServerError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stats := New()
+			interceptor := UnaryInterceptor(stats)
+
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return "resp", tc.handlerErr
+			}
+			info := &grpc.UnaryServerInfo{FullMethod: "/containarium.v1.ContainerService/CreateContainer"}
+
+			resp, err := interceptor(context.Background(), "req", info, handler)
+			if !errors.Is(err, tc.handlerErr) && tc.handlerErr != nil && err.Error() != tc.handlerErr.Error() {
+				t.Errorf("interceptor changed the error: got %v, want %v", err, tc.handlerErr)
+			}
+			if tc.handlerErr == nil && resp != "resp" {
+				t.Errorf("interceptor changed the response: got %v", resp)
+			}
+
+			snap := stats.SnapshotAPI()
+			if snap.RequestsByClass[tc.wantClass] != 1 {
+				t.Errorf("requests[%s] = %d, want 1 (full snapshot: %+v)", tc.wantClass, snap.RequestsByClass[tc.wantClass], snap.RequestsByClass)
+			}
+			for class, n := range snap.RequestsByClass {
+				if class != tc.wantClass && n != 0 {
+					t.Errorf("unexpected count in unrelated class %s: %d", class, n)
+				}
+			}
+		})
+	}
+}
+
+// TestUnaryInterceptor_PassesThroughHandler guards that the interceptor
+// is purely an observer — it must never alter the request, response, or
+// error the wrapped handler produces.
+func TestUnaryInterceptor_PassesThroughHandler(t *testing.T) {
+	stats := New()
+	interceptor := UnaryInterceptor(stats)
+
+	sentinelErr := status.Error(codes.PermissionDenied, "no")
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		if req != "the request" {
+			t.Fatalf("handler received %v, want %q", req, "the request")
+		}
+		return "the response", sentinelErr
+	}
+	info := &grpc.UnaryServerInfo{FullMethod: "/x/Y"}
+
+	resp, err := interceptor(context.Background(), "the request", info, handler)
+	if resp != "the response" {
+		t.Errorf("resp = %v, want %q", resp, "the response")
+	}
+	if err != sentinelErr {
+		t.Errorf("err = %v, want the exact sentinel error passed through unmodified", err)
+	}
+}

--- a/internal/metrics/platformstats/stats.go
+++ b/internal/metrics/platformstats/stats.go
@@ -1,0 +1,112 @@
+// Package platformstats accumulates platform-domain facts the
+// cloud-native metrics export platform group (#1082/#1083/#1084)
+// observes at each export tick: API request/error counts today,
+// provisioning outcomes and connectivity state in follow-up issues.
+//
+// Deliberately dependency-free and lock-free (atomic counters, not a
+// mutex): this sits on the request hot path via a gRPC interceptor, so
+// recording an event must cost nothing more than an atomic add, and the
+// package must never import anything that could pull the daemon's own
+// dependency graph back in — the whole point is a package the
+// cloudexport collector (and its tests) can use without needing a real
+// server.
+package platformstats
+
+import (
+	"sync/atomic"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/grpc/codes"
+)
+
+// CodeClass is the coarse API outcome bucket every platform.api.* series
+// is labeled with — deliberately not a raw gRPC code or HTTP status: the
+// billed cost surface stays a fixed, small cardinality regardless of how
+// many distinct gRPC codes a handler can return.
+type CodeClass string
+
+const (
+	CodeClassOK          CodeClass = "ok"
+	CodeClassClientError CodeClass = "client_error"
+	CodeClassServerError CodeClass = "server_error"
+)
+
+// ClassifyCode buckets a gRPC status code into its CodeClass using
+// grpc-gateway's own gRPC->HTTP status mapping — the same mapping a
+// REST-via-gateway caller actually sees — so native gRPC and REST
+// traffic land in the same bucket for the same logical outcome, and a
+// future new gRPC code is classified by the same rule everything else
+// is instead of needing a new case here.
+func ClassifyCode(code codes.Code) CodeClass {
+	switch status := runtime.HTTPStatusFromCode(code); {
+	case status >= 500:
+		return CodeClassServerError
+	case status >= 400:
+		return CodeClassClientError
+	default:
+		return CodeClassOK
+	}
+}
+
+// APISnapshot is a point-in-time read of the API request/error counters
+// by code_class, consumed by the cloudexport platform group at each
+// export tick. RequestsByClass counts every completed call classified
+// into that bucket; ErrorsByClass counts the subset of those that were
+// errors (client_error and server_error only — "ok" is never an error).
+type APISnapshot struct {
+	RequestsByClass map[CodeClass]int64
+	ErrorsByClass   map[CodeClass]int64
+}
+
+// Stats accumulates platform-domain facts for the lifetime of the
+// daemon process. Every counter is a plain atomic.Int64: recording an
+// event is a single atomic add, and a snapshot is a plain load — no
+// lock, no allocation on the hot path.
+type Stats struct {
+	apiRequestsOK          atomic.Int64
+	apiRequestsClientError atomic.Int64
+	apiRequestsServerError atomic.Int64
+	apiErrorsClientError   atomic.Int64
+	apiErrorsServerError   atomic.Int64
+}
+
+// New returns a zeroed Stats. (atomic.Int64 is itself zero-value-usable,
+// so &Stats{} works too — New exists for call-site clarity and to leave
+// room for future non-zero defaults without an API break.)
+func New() *Stats {
+	return &Stats{}
+}
+
+// RecordAPIRequest classifies one completed API call and increments the
+// matching counters: requests[class] always, plus errors[class] when
+// class is a client or server error.
+func (s *Stats) RecordAPIRequest(class CodeClass) {
+	switch class {
+	case CodeClassOK:
+		s.apiRequestsOK.Add(1)
+	case CodeClassClientError:
+		s.apiRequestsClientError.Add(1)
+		s.apiErrorsClientError.Add(1)
+	case CodeClassServerError:
+		s.apiRequestsServerError.Add(1)
+		s.apiErrorsServerError.Add(1)
+	}
+}
+
+// SnapshotAPI returns the current cumulative API counters. The result is
+// a fresh map on every call — mutating it never affects Stats, and
+// Stats is never affected by anything done to a previously returned
+// snapshot.
+func (s *Stats) SnapshotAPI() APISnapshot {
+	return APISnapshot{
+		RequestsByClass: map[CodeClass]int64{
+			CodeClassOK:          s.apiRequestsOK.Load(),
+			CodeClassClientError: s.apiRequestsClientError.Load(),
+			CodeClassServerError: s.apiRequestsServerError.Load(),
+		},
+		ErrorsByClass: map[CodeClass]int64{
+			CodeClassClientError: s.apiErrorsClientError.Load(),
+			CodeClassServerError: s.apiErrorsServerError.Load(),
+		},
+	}
+}

--- a/internal/metrics/platformstats/stats_test.go
+++ b/internal/metrics/platformstats/stats_test.go
@@ -1,0 +1,117 @@
+package platformstats
+
+import (
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+)
+
+func TestClassifyCode(t *testing.T) {
+	tests := []struct {
+		name string
+		code codes.Code
+		want CodeClass
+	}{
+		{"ok", codes.OK, CodeClassOK},
+		{"invalid argument (400) is client error", codes.InvalidArgument, CodeClassClientError},
+		{"not found (404) is client error", codes.NotFound, CodeClassClientError},
+		{"permission denied (403) is client error", codes.PermissionDenied, CodeClassClientError},
+		{"unauthenticated (401) is client error", codes.Unauthenticated, CodeClassClientError},
+		{"internal (500) is server error", codes.Internal, CodeClassServerError},
+		{"unavailable (503) is server error", codes.Unavailable, CodeClassServerError},
+		{"unimplemented (501) is server error", codes.Unimplemented, CodeClassServerError},
+		{"unknown (500-mapped) is server error", codes.Unknown, CodeClassServerError},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyCode(tc.code); got != tc.want {
+				t.Errorf("ClassifyCode(%v) = %q, want %q", tc.code, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStats_RecordAndSnapshotAPI(t *testing.T) {
+	s := New()
+
+	snap := s.SnapshotAPI()
+	if snap.RequestsByClass[CodeClassOK] != 0 || snap.ErrorsByClass[CodeClassClientError] != 0 {
+		t.Fatalf("fresh Stats should snapshot all zero, got %+v", snap)
+	}
+
+	s.RecordAPIRequest(CodeClassOK)
+	s.RecordAPIRequest(CodeClassOK)
+	s.RecordAPIRequest(CodeClassClientError)
+	s.RecordAPIRequest(CodeClassServerError)
+	s.RecordAPIRequest(CodeClassServerError)
+	s.RecordAPIRequest(CodeClassServerError)
+
+	snap = s.SnapshotAPI()
+	if snap.RequestsByClass[CodeClassOK] != 2 {
+		t.Errorf("requests[ok] = %d, want 2", snap.RequestsByClass[CodeClassOK])
+	}
+	if snap.RequestsByClass[CodeClassClientError] != 1 {
+		t.Errorf("requests[client_error] = %d, want 1", snap.RequestsByClass[CodeClassClientError])
+	}
+	if snap.RequestsByClass[CodeClassServerError] != 3 {
+		t.Errorf("requests[server_error] = %d, want 3", snap.RequestsByClass[CodeClassServerError])
+	}
+
+	// "ok" is never an error — only client/server error classes ever
+	// increment the errors counters, and requests[ok] never leaks into
+	// errors[ok].
+	if v, ok := snap.ErrorsByClass[CodeClassOK]; ok && v != 0 {
+		t.Errorf("errors[ok] = %d, want absent or 0", v)
+	}
+	if snap.ErrorsByClass[CodeClassClientError] != 1 {
+		t.Errorf("errors[client_error] = %d, want 1", snap.ErrorsByClass[CodeClassClientError])
+	}
+	if snap.ErrorsByClass[CodeClassServerError] != 3 {
+		t.Errorf("errors[server_error] = %d, want 3", snap.ErrorsByClass[CodeClassServerError])
+	}
+}
+
+// TestStats_SnapshotIsACopy guards against a future refactor handing out
+// a live view: mutating the returned snapshot must never affect the
+// Stats it came from, and a later snapshot must reflect only what was
+// recorded after the first, not any tampering with the earlier copy.
+func TestStats_SnapshotIsACopy(t *testing.T) {
+	s := New()
+	s.RecordAPIRequest(CodeClassOK)
+
+	first := s.SnapshotAPI()
+	first.RequestsByClass[CodeClassOK] = 9999
+
+	second := s.SnapshotAPI()
+	if second.RequestsByClass[CodeClassOK] != 1 {
+		t.Errorf("mutating a returned snapshot leaked back into Stats: second snapshot = %d, want 1", second.RequestsByClass[CodeClassOK])
+	}
+}
+
+// TestStats_ConcurrentRecordAPIRequest locks in the lock-free contract:
+// concurrent recorders must never lose or double-count an increment.
+// Run with -race.
+func TestStats_ConcurrentRecordAPIRequest(t *testing.T) {
+	s := New()
+	const goroutines = 50
+	const perGoroutine = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				s.RecordAPIRequest(CodeClassOK)
+			}
+		}()
+	}
+	wg.Wait()
+
+	snap := s.SnapshotAPI()
+	want := int64(goroutines * perGoroutine)
+	if snap.RequestsByClass[CodeClassOK] != want {
+		t.Errorf("requests[ok] = %d, want %d (lost or duplicated increments under concurrency)", snap.RequestsByClass[CodeClassOK], want)
+	}
+}

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/footprintai/containarium/internal/guacamole"
 	"github.com/footprintai/containarium/internal/integrity"
 	"github.com/footprintai/containarium/internal/metrics/cloudexport"
+	"github.com/footprintai/containarium/internal/metrics/platformstats"
 	"github.com/footprintai/containarium/internal/releasecheck"
 	"github.com/footprintai/containarium/internal/safecast"
 	"github.com/footprintai/containarium/internal/secrets"
@@ -123,6 +124,14 @@ type ContainerServer struct {
 	// level tests inject a fake that returns a collector over fake
 	// sources/exporter. nil in production (the real builder runs).
 	metricsExportBuilder func(ctx context.Context, cfg cloudexport.Config, sink cloudexport.Sink) (*cloudexport.CloudExportCollector, error)
+	// platformStats accumulates platform-domain facts (#1082 API
+	// request/error counts today; #1083/#1084 add more) for the platform
+	// metric group to observe at export tick. Recorded on the gRPC
+	// unary-interceptor hot path (DualServer wires
+	// platformstats.UnaryInterceptor over this same instance), read
+	// through cloudexport.PlatformSources by buildMetricsExportCollector.
+	// Lock-free (atomic counters inside), so no mutex needed here.
+	platformStats *platformstats.Stats
 	// localHealthCheckFn overrides localBackendHealthy's real Incus liveness
 	// probe (#920) — set by tests to simulate a wedged/unresponsive local
 	// backend without a live Incus daemon. nil in production; the real probe
@@ -281,6 +290,7 @@ func NewContainerServer(runtime string) (*ContainerServer, error) {
 		boxWriter:        newBoxWriterIfEnabled(runtime),
 		emitter:          events.NewEmitter(events.GetBus()),
 		pendingCreations: make(map[string]*PendingCreation),
+		platformStats:    platformstats.New(),
 	}, nil
 }
 

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/footprintai/containarium/internal/gateway"
 	"github.com/footprintai/containarium/internal/guacamole"
 	"github.com/footprintai/containarium/internal/metrics"
+	"github.com/footprintai/containarium/internal/metrics/platformstats"
 	"github.com/footprintai/containarium/internal/modelgateway"
 	"github.com/footprintai/containarium/internal/mtls"
 	"github.com/footprintai/containarium/internal/pentest"
@@ -304,13 +305,26 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 
 		grpcServer = grpc.NewServer(
 			grpc.Creds(creds),
-			grpc.UnaryInterceptor(auth.RequireMTLSUnaryInterceptor()),
+			// Auth interceptor runs OUTER (first): a call mTLS rejects
+			// never reaches the platform-stats interceptor, so
+			// unauthenticated noise never pollutes the platform.api.*
+			// series (#1082) — those series are meant to reflect
+			// application-level API health, not authentication traffic.
+			grpc.ChainUnaryInterceptor(
+				auth.RequireMTLSUnaryInterceptor(),
+				platformstats.UnaryInterceptor(containerServer.platformStats),
+			),
 			grpc.StreamInterceptor(auth.RequireMTLSStreamInterceptor()),
 		)
 		log.Printf("gRPC server: mTLS enabled (interceptor verifies peer cert on every call)")
 	} else {
 		grpcServer = grpc.NewServer(
-			grpc.UnaryInterceptor(authMiddleware.GRPCUnaryInterceptor()),
+			// Same ordering rationale as the mTLS branch above: auth
+			// outer, platform-stats inner.
+			grpc.ChainUnaryInterceptor(
+				authMiddleware.GRPCUnaryInterceptor(),
+				platformstats.UnaryInterceptor(containerServer.platformStats),
+			),
 			grpc.StreamInterceptor(authMiddleware.GRPCStreamInterceptor()),
 		)
 		log.Printf("WARNING: gRPC server running in INSECURE mode")

--- a/internal/server/metrics_export_server.go
+++ b/internal/server/metrics_export_server.go
@@ -291,6 +291,7 @@ func (s *ContainerServer) buildMetricsExportCollector(ctx context.Context, cfg c
 
 	return cloudexport.NewCollector(cloudexport.CollectorOptions{
 		Sources:         sources,
+		PlatformSources: serverPlatformSources{stats: s.platformStats},
 		Exporter:        exporter,
 		Resource:        res,
 		Labels:          s.currentExportLabels(sources.Hostname()),

--- a/internal/server/metrics_export_sources.go
+++ b/internal/server/metrics_export_sources.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/footprintai/containarium/internal/metrics/cloudexport"
+	"github.com/footprintai/containarium/internal/metrics/platformstats"
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -83,4 +84,24 @@ func (s *serverMetricsSources) AllContainerMetrics(ctx context.Context) (map[str
 		out[m.Name] = toProtoMetrics(m)
 	}
 	return out, nil
+}
+
+// serverPlatformSources is the production cloudexport.PlatformSources
+// adapter (#1082): a thin wrapper over the daemon's platformstats.Stats,
+// the same instance the gRPC unary interceptor records into (see
+// DualServer's interceptor chain). No independent state of its own.
+type serverPlatformSources struct {
+	stats *platformstats.Stats
+}
+
+// APIStats returns the current cumulative API counters. Nil-safe: a
+// ContainerServer constructed directly (bypassing NewContainerServer,
+// as some tests do) may have a nil platformStats, and this must degrade
+// to an empty snapshot rather than panic — consistent with every other
+// seam in this package never crashing the export tick.
+func (s serverPlatformSources) APIStats() platformstats.APISnapshot {
+	if s.stats == nil {
+		return platformstats.APISnapshot{}
+	}
+	return s.stats.SnapshotAPI()
 }


### PR DESCRIPTION
Closes #1082. Part of #1089.

## What changed
- **`internal/metrics/platformstats`** (new package): lock-free (atomic) `Stats` accumulating API request/error counts by `code_class`. `ClassifyCode` buckets a gRPC status via grpc-gateway's own `HTTPStatusFromCode` mapping (>=500 → `server_error`, >=400 → `client_error`, else `ok`), so native gRPC and REST-via-gateway traffic land in the same bucket for the same logical outcome.
- **`platformstats.UnaryInterceptor`**: the single choke point both transports converge on. Wired into `DualServer`'s gRPC server via `grpc.ChainUnaryInterceptor`, deliberately **inside** the existing auth interceptor — an auth-rejected call never reaches it, so `platform.api.*` reflects application-level API health, not authentication noise.
- **`cloudexport.PlatformSources`** (new seam) + `CollectorOptions.PlatformSources`: the platform group's dispatch now registers `containarium.platform.api.requests` / `.api.errors` when a `PlatformSources` is wired, and nothing when it isn't (same zero-series default the reserved groups had before this — no behavior change for anyone not opting in).
- **`ContainerServer.platformStats`** + `serverPlatformSources` production adapter (nil-safe: a directly-constructed test server degrades to an empty snapshot rather than panicking).

## Test evidence (all green, `-race`)
- `platformstats`: `TestClassifyCode` (9 cases, full gRPC→code_class mapping incl. Unimplemented/Unknown), `TestStats_RecordAndSnapshotAPI`, `TestStats_SnapshotIsACopy`, `TestStats_ConcurrentRecordAPIRequest`, `TestUnaryInterceptor_ClassifiesByFinalStatus` (5 cases incl. a plain non-status error), `TestUnaryInterceptor_PassesThroughHandler`.
- `cloudexport`: `TestExportedSeries_PlatformAPIHealth` (AC1+AC2 — series appear with correct code_class-bucketed values through the same OTel `ManualReader` pipeline production uses), `TestExportedSeries_PlatformGroupNilSourcesEmitsNothing`, `TestNoTenantLabels_PlatformSeries` (AC3 — exactly `backend_id`/`hostname`/`region`/`code_class`, no route/user/org label). Existing `TestExportedSeries_PerGroupGolden` / `TestNoTenantLabels` updated for the new `PlatformSources` parameter, still green.
- `go build ./...`, `go vet ./...`, `gofmt -l` clean, `golangci-lint` (CI-pinned v2.12.2): 0 issues.

Test environment note: verified locally (build/vet/race-test/lint), not on a fresh Containarium Cloud box — this is pure Go logic with no new external runtime dependency, so I judged local verification sufficient. Flagging per the skill's transparency requirement rather than silently skipping the step.

## Acceptance criteria mapping
- [x] "Series appear in GCM within 2 export intervals" — mechanically verified through the OTel collector pipeline (same code path production uses); actual live-GCM visibility needs a deploy, which is out of scope for this implementation PR (devops-deploy is a separate step).
- [x] "A forced 5xx increments `.api.errors{code_class=...}`" — covered end-to-end (interceptor → Stats → collector callback).
- [x] "No per-route, per-user, or per-org labels" — `TestNoTenantLabels_PlatformSeries`.

## Deviation flagged
The PRD's issue text says `code_class 2xx/4xx/5xx`; this follows the **architecture design doc's** documented choice of `ok`/`client_error`/`server_error` instead (`docs/architecture/cloud-export-domain-metrics.md`), since raw HTTP-style buckets would misrepresent native gRPC callers that never had an HTTP status in the first place. Design doc already resolved this; implementing per design, not per the shorthand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)