### PR TITLE
feat(metrics-export): provisioning outcome series (attempts/failures/duration)

### DIFF
--- a/docs/METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md
+++ b/docs/METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md
@@ -157,3 +157,122 @@ Record the fired-incident screenshot / link in your operator log.
 - **Multi-cloud:** AWS export is not implemented yet; the equivalent
   there is a CloudWatch "missing data → breaching" alarm on the same
   heartbeat metric once an AWS sink lands.
+
+## Provisioning failure alert (#1083)
+
+**Goal:** page an operator when containers are genuinely failing to
+provision or tear down — not on every failed attempt (a single bad
+request from a client is normal noise) but on a sustained run of
+failures, which points at a real backend problem (image pull outage,
+disk full, k8s operator down).
+
+### The series
+
+| Field | Value |
+|---|---|
+| Metric (OTel instrument) | `containarium.platform.provision.failures` |
+| Cloud Monitoring metric type | `workload.googleapis.com/containarium.platform.provision.failures` |
+| Monitored resource | `gce_instance` |
+| Kind / value | cumulative counter |
+| Labels | `backend_id`, `hostname`, `region`, `operation` (`create` \| `delete`) |
+| Emit cadence | every export interval |
+
+`attempts` and `duration_seconds_sum` (same label set) are exported
+alongside `failures` for rate/latency dashboards, but the alert below
+watches `failures` only — attempts rising is not itself a problem.
+
+### Create the alert policy
+
+Write the policy to a file (`provision-failure-policy.json`), replacing
+`${PROJECT_ID}` and `${CHANNEL_ID}` as above:
+
+```json
+{
+  "displayName": "Containarium provisioning failures (sustained)",
+  "documentation": {
+    "content": "A backend has recorded at least one provisioning failure (create or delete) in every minute of the last 10 minutes. Check the backend's daemon log for the failing operation and username; likely causes are image pull failures, disk/CPU admission rejections, or (for the k8s Box path) the operator being unreachable.",
+    "mimeType": "text/markdown"
+  },
+  "combiner": "OR",
+  "conditions": [
+    {
+      "displayName": "Provisioning failures > 0 for 10m (per backend, per operation)",
+      "conditionThreshold": {
+        "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.platform.provision.failures\"",
+        "comparison": "COMPARISON_GT",
+        "thresholdValue": 0,
+        "duration": "600s",
+        "aggregations": [
+          {
+            "alignmentPeriod": "60s",
+            "perSeriesAligner": "ALIGN_DELTA",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": ["metric.label.backend_id", "metric.label.operation"]
+          }
+        ],
+        "trigger": { "count": 1 }
+      }
+    }
+  ],
+  "notificationChannels": [
+    "projects/${PROJECT_ID}/notificationChannels/${CHANNEL_ID}"
+  ],
+  "alertStrategy": {
+    "autoClose": "1800s"
+  }
+}
+```
+
+Create it:
+
+```bash
+gcloud alpha monitoring policies create \
+  --project="${PROJECT_ID}" \
+  --policy-from-file=provision-failure-policy.json
+```
+
+### Why these values
+
+- **`ALIGN_DELTA`** turns the cumulative counter into a per-minute
+  increment before thresholding — `conditionThreshold` compares aligned
+  points, not the raw running total, so this fires on *new* failures in
+  each window rather than latching forever once one failure has ever
+  happened.
+- **`duration: 600s`** (10 minutes) matches the acceptance criterion
+  ("failures > 0 for 10 min") and requires the delta to stay above zero
+  for the whole window, so one isolated failed request does not page —
+  it takes a sustained run.
+- **`groupByFields` on `backend_id` and `operation`** keeps `create` and
+  `delete` failures on separate evaluated series and keeps one bad
+  backend from being masked by healthy ones — same per-series semantics
+  as the heartbeat policy above.
+- **No filter on `region`/`hostname`**: those labels ride along on the
+  series for dashboard drill-down but aren't part of the alert's
+  identity — `backend_id` already uniquely identifies the backend.
+
+### Verify (live)
+
+Also not reproducible in CI — verify against a real project:
+
+1. Confirm the series in Metrics Explorer
+   (`workload.googleapis.com/containarium.platform.provision.failures`)
+   is present (it may be flat at 0 if the backend is healthy — that's
+   correct; #1083's collector emits an explicit 0 point rather than
+   omitting the series when there are no failures yet).
+2. Force a sustained failure run (e.g. an admission-gate misconfiguration
+   that rejects every create, or point `--username` requests at a
+   deliberately invalid resource spec) for at least 10 minutes.
+3. Confirm the policy transitions to **firing** and the notification
+   channel pages; confirm it clears once failures stop and `autoClose`
+   elapses.
+
+### Tuning notes
+
+- **Noisy tenants:** if a single misbehaving client is expected to
+  generate occasional failures as normal traffic (bad requests, quota
+  exhaustion), that's `attempts` rising without `failures` rising in
+  lockstep at the same rate — dashboard both series rather than tuning
+  the alert threshold above 0.
+- **Scope to one backend:** add
+  `AND metric.label.backend_id = "<backend-id>"` to the filter, same as
+  the heartbeat policy.

--- a/internal/metrics/cloudexport/collector.go
+++ b/internal/metrics/cloudexport/collector.go
@@ -57,6 +57,18 @@ const (
 	// and server_error classes.
 	MetricPlatformAPIRequests = "containarium.platform.api.requests"
 	MetricPlatformAPIErrors   = "containarium.platform.api.errors"
+
+	// MetricPlatformProvisionAttempts / Failures / DurationSecondsSum are
+	// the platform group's provisioning-outcome series (#1083): a
+	// container create or delete, by operation. Attempts counts every
+	// attempt (success or not); Failures counts the subset that failed;
+	// DurationSecondsSum is the cumulative wall-clock time spent across
+	// all attempts for that operation, regardless of outcome — dividing
+	// it by Attempts in MQL/PromQL gives mean latency without a
+	// per-bucket-billed histogram.
+	MetricPlatformProvisionAttempts           = "containarium.platform.provision.attempts"
+	MetricPlatformProvisionFailures           = "containarium.platform.provision.failures"
+	MetricPlatformProvisionDurationSecondsSum = "containarium.platform.provision.duration_seconds_sum"
 )
 
 // Label keys — the complete allowlist. No org/tenant identifier ever
@@ -76,6 +88,10 @@ const (
 	// fixed-cardinality dimension the design uses instead of a raw route
 	// or gRPC code, which would blow up the billed cost surface.
 	LabelCodeClass = "code_class"
+	// LabelOperation tags the platform provisioning series with which
+	// kind of provisioning call this was (platformstats.Operation) —
+	// create or delete, never a per-request identifier.
+	LabelOperation = "operation"
 )
 
 // Labels is the fixed identity stamped on every exported series. These
@@ -121,6 +137,18 @@ func (l Labels) platformAttributeSet(class platformstats.CodeClass) attribute.Se
 		attribute.String(LabelHostname, l.Hostname),
 		attribute.String(LabelRegion, l.Region),
 		attribute.String(LabelCodeClass, string(class)),
+	)
+}
+
+// provisionAttributeSet is the platform provisioning-outcome label set
+// (backend_id, hostname, region, operation) — the host-series identity
+// plus which operation this point is for.
+func (l Labels) provisionAttributeSet(op platformstats.Operation) attribute.Set {
+	return attribute.NewSet(
+		attribute.String(LabelBackendID, l.BackendID),
+		attribute.String(LabelHostname, l.Hostname),
+		attribute.String(LabelRegion, l.Region),
+		attribute.String(LabelOperation, string(op)),
 	)
 }
 
@@ -360,12 +388,12 @@ func registerGroupInstruments(mp *sdkmetric.MeterProvider, group pb.CloudMetrics
 }
 
 // registerPlatformInstruments creates the platform group's API-health
-// counters (#1082) and wires one callback that pulls a single
-// APISnapshot per tick and observes both series, one point per
-// code_class. Counters, not gauges: OTel async-counter semantics expect
-// the current cumulative total on every observation (platformstats.Stats
-// already accumulates for the daemon's lifetime), which is exactly what
-// APISnapshot reports.
+// (#1082) and provisioning-outcome (#1083) counters and wires one
+// callback per concern, each pulling a single snapshot per tick.
+// Counters, not gauges: OTel async-counter semantics expect the current
+// cumulative total on every observation (platformstats.Stats already
+// accumulates for the daemon's lifetime), which is exactly what every
+// snapshot here reports.
 func registerPlatformInstruments(mp *sdkmetric.MeterProvider, sources PlatformSources, labels Labels) error {
 	meter := mp.Meter(meterName)
 
@@ -392,6 +420,42 @@ func registerPlatformInstruments(mp *sdkmetric.MeterProvider, sources PlatformSo
 			return nil
 		},
 		requests, apiErrors,
+	)
+	if err != nil {
+		return err
+	}
+
+	attempts, err := meter.Int64ObservableCounter(MetricPlatformProvisionAttempts,
+		metric.WithDescription("Cumulative count of container provisioning attempts (create/delete), by operation."))
+	if err != nil {
+		return err
+	}
+	failures, err := meter.Int64ObservableCounter(MetricPlatformProvisionFailures,
+		metric.WithDescription("Cumulative count of container provisioning attempts that failed, by operation."))
+	if err != nil {
+		return err
+	}
+	durationSum, err := meter.Float64ObservableCounter(MetricPlatformProvisionDurationSecondsSum,
+		metric.WithUnit("s"), metric.WithDescription("Cumulative wall-clock time spent on provisioning attempts, by operation — divide by attempts for mean latency."))
+	if err != nil {
+		return err
+	}
+
+	_, err = meter.RegisterCallback(
+		func(ctx context.Context, o metric.Observer) error {
+			snap := sources.ProvisionStats()
+			for op, n := range snap.Attempts {
+				o.ObserveInt64(attempts, n, metric.WithAttributeSet(labels.provisionAttributeSet(op)))
+			}
+			for op, n := range snap.Failures {
+				o.ObserveInt64(failures, n, metric.WithAttributeSet(labels.provisionAttributeSet(op)))
+			}
+			for op, n := range snap.DurationSecondsSum {
+				o.ObserveFloat64(durationSum, n, metric.WithAttributeSet(labels.provisionAttributeSet(op)))
+			}
+			return nil
+		},
+		attempts, failures, durationSum,
 	)
 	return err
 }

--- a/internal/metrics/cloudexport/collector_test.go
+++ b/internal/metrics/cloudexport/collector_test.go
@@ -166,14 +166,19 @@ func TestExportedSeries_MatchesAllowlistGolden(t *testing.T) {
 	}
 }
 
-// fakePlatformSources is a PlatformSources whose API snapshot is fully
+// fakePlatformSources is a PlatformSources whose snapshots are fully
 // controlled by the test.
 type fakePlatformSources struct {
-	api platformstats.APISnapshot
+	api       platformstats.APISnapshot
+	provision platformstats.ProvisionSnapshot
 }
 
 func (f *fakePlatformSources) APIStats() platformstats.APISnapshot {
 	return f.api
+}
+
+func (f *fakePlatformSources) ProvisionStats() platformstats.ProvisionSnapshot {
+	return f.provision
 }
 
 // flattenPoints returns every emitted datapoint (gauge OR cumulative
@@ -199,6 +204,10 @@ func flattenPoints(t *testing.T, rm metricdata.ResourceMetrics) []point {
 			case metricdata.Sum[int64]:
 				for _, dp := range g.DataPoints {
 					pts = append(pts, point{name: m.Name, ival: dp.Value, isInt: true, attrs: dp.Attributes})
+				}
+			case metricdata.Sum[float64]:
+				for _, dp := range g.DataPoints {
+					pts = append(pts, point{name: m.Name, fval: dp.Value, attrs: dp.Attributes})
 				}
 			default:
 				t.Fatalf("metric %q has unhandled data type %T", m.Name, m.Data)
@@ -687,6 +696,163 @@ func TestNoTenantLabels_PlatformSeries(t *testing.T) {
 		}
 		if !seen[LabelCodeClass] {
 			t.Errorf("series %q missing required label %q", p.name, LabelCodeClass)
+		}
+	}
+}
+
+// sampleProvisionSnapshot is a representative, non-trivial provisioning
+// snapshot for the tests below — mirrors what Stats.SnapshotProvision()
+// always returns: both operations present, even one with zero failures.
+func sampleProvisionSnapshot() platformstats.ProvisionSnapshot {
+	return platformstats.ProvisionSnapshot{
+		Attempts: map[platformstats.Operation]int64{
+			platformstats.OperationCreate: 10,
+			platformstats.OperationDelete: 4,
+		},
+		Failures: map[platformstats.Operation]int64{
+			platformstats.OperationCreate: 2,
+			platformstats.OperationDelete: 0,
+		},
+		DurationSecondsSum: map[platformstats.Operation]float64{
+			platformstats.OperationCreate: 55.5,
+			platformstats.OperationDelete: 8.0,
+		},
+	}
+}
+
+// pointsByNameAndOperation indexes flattened points by (series name,
+// operation label value), the provisioning-series analog of
+// pointsByNameAndClass.
+func pointsByNameAndOperation(pts []point) map[string]map[string]point {
+	out := map[string]map[string]point{}
+	for _, p := range pts {
+		op, _ := p.attrs.Value(attribute.Key(LabelOperation))
+		if out[p.name] == nil {
+			out[p.name] = map[string]point{}
+		}
+		out[p.name][op.AsString()] = p
+	}
+	return out
+}
+
+// TestExportedSeries_PlatformProvisionOutcome is #1083's acceptance
+// criterion: enabling the platform group with a wired PlatformSources
+// emits containarium.platform.provision.attempts/.failures/
+// .duration_seconds_sum, one point per operation, with the exact
+// cumulative values the snapshot reports — including a zero-failure
+// operation (delete), which must still appear as an explicit 0 point,
+// not be silently absent.
+func TestExportedSeries_PlatformProvisionOutcome(t *testing.T) {
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{platform}, &fakeSources{sr: sampleResources()}, &fakePlatformSources{provision: sampleProvisionSnapshot()}, sampleLabels())
+	pts := flattenPoints(t, rm)
+	byNameOp := pointsByNameAndOperation(pts)
+
+	wantAttempts := map[string]int64{"create": 10, "delete": 4}
+	for op, want := range wantAttempts {
+		p, ok := byNameOp[MetricPlatformProvisionAttempts][op]
+		if !ok {
+			t.Fatalf("missing %s{operation=%q}", MetricPlatformProvisionAttempts, op)
+		}
+		if p.ival != want {
+			t.Errorf("%s{operation=%q} = %d, want %d", MetricPlatformProvisionAttempts, op, p.ival, want)
+		}
+	}
+
+	wantFailures := map[string]int64{"create": 2, "delete": 0}
+	for op, want := range wantFailures {
+		p, ok := byNameOp[MetricPlatformProvisionFailures][op]
+		if !ok {
+			t.Fatalf("missing %s{operation=%q} — a zero-failure operation must still emit an explicit 0 point", MetricPlatformProvisionFailures, op)
+		}
+		if p.ival != want {
+			t.Errorf("%s{operation=%q} = %d, want %d", MetricPlatformProvisionFailures, op, p.ival, want)
+		}
+	}
+
+	wantDuration := map[string]float64{"create": 55.5, "delete": 8.0}
+	for op, want := range wantDuration {
+		p, ok := byNameOp[MetricPlatformProvisionDurationSecondsSum][op]
+		if !ok {
+			t.Fatalf("missing %s{operation=%q}", MetricPlatformProvisionDurationSecondsSum, op)
+		}
+		if p.fval != want {
+			t.Errorf("%s{operation=%q} = %v, want %v", MetricPlatformProvisionDurationSecondsSum, op, p.fval, want)
+		}
+	}
+}
+
+// TestExportedSeries_PlatformGroup_ProvisionZeroWhenNotWired guards the
+// "not wired yet" default for the provisioning series specifically: a
+// PlatformSources whose ProvisionStats returns the zero value (as an
+// older adapter or a minimal fake might) must not panic and must not
+// fabricate an operation the snapshot didn't report.
+func TestExportedSeries_PlatformGroup_ProvisionZeroWhenNotWired(t *testing.T) {
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{platform}, &fakeSources{sr: sampleResources()}, &fakePlatformSources{}, sampleLabels())
+	pts := flattenPoints(t, rm)
+	for _, p := range pts {
+		switch p.name {
+		case MetricPlatformProvisionAttempts, MetricPlatformProvisionFailures, MetricPlatformProvisionDurationSecondsSum:
+			t.Errorf("provisioning series %q emitted a point from a zero-value ProvisionSnapshot", p.name)
+		}
+	}
+}
+
+// TestNoTenantLabels_ProvisionSeries locks in #1083's cardinality
+// acceptance criterion: the provisioning series carry exactly
+// backend_id/hostname/region/operation and nothing else.
+func TestNoTenantLabels_ProvisionSeries(t *testing.T) {
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{platform}, &fakeSources{sr: sampleResources()}, &fakePlatformSources{provision: sampleProvisionSnapshot()}, sampleLabels())
+	all := flattenPoints(t, rm)
+
+	var pts []point
+	for _, p := range all {
+		switch p.name {
+		case MetricPlatformProvisionAttempts, MetricPlatformProvisionFailures, MetricPlatformProvisionDurationSecondsSum:
+			pts = append(pts, p)
+		}
+	}
+	if len(pts) == 0 {
+		t.Fatal("no provisioning series emitted")
+	}
+
+	allowed := map[string]string{
+		LabelBackendID: "backend-xyz",
+		LabelHostname:  "host-1",
+		LabelRegion:    "us-central1",
+	}
+	forbidden := []string{"org", "org_id", "tenant", "tenant_id", "username", "user", "uuid", "route", "method", "path"}
+
+	for _, p := range pts {
+		iter := p.attrs.Iter()
+		seen := map[string]bool{}
+		for iter.Next() {
+			kv := iter.Attribute()
+			key := string(kv.Key)
+			seen[key] = true
+			for _, f := range forbidden {
+				if key == f {
+					t.Errorf("series %q carries forbidden label %q", p.name, key)
+				}
+			}
+			if key == LabelOperation {
+				continue // value asserted by TestExportedSeries_PlatformProvisionOutcome
+			}
+			if wantVal, ok := allowed[key]; !ok {
+				t.Errorf("series %q carries non-allowlisted label %q", p.name, key)
+			} else if kv.Value.AsString() != wantVal {
+				t.Errorf("series %q label %q = %q, want %q", p.name, key, kv.Value.AsString(), wantVal)
+			}
+		}
+		for want := range allowed {
+			if !seen[want] {
+				t.Errorf("series %q missing allowlisted label %q", p.name, want)
+			}
+		}
+		if !seen[LabelOperation] {
+			t.Errorf("series %q missing required label %q", p.name, LabelOperation)
 		}
 	}
 }

--- a/internal/metrics/cloudexport/sources.go
+++ b/internal/metrics/cloudexport/sources.go
@@ -65,4 +65,8 @@ type PlatformSources interface {
 	// APIStats returns the current cumulative API request/error counters
 	// by code_class (#1082).
 	APIStats() platformstats.APISnapshot
+
+	// ProvisionStats returns the current cumulative provisioning
+	// attempt/failure/duration counters by operation (#1083).
+	ProvisionStats() platformstats.ProvisionSnapshot
 }

--- a/internal/metrics/platformstats/stats.go
+++ b/internal/metrics/platformstats/stats.go
@@ -14,6 +14,7 @@ package platformstats
 
 import (
 	"sync/atomic"
+	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc/codes"
@@ -48,6 +49,15 @@ func ClassifyCode(code codes.Code) CodeClass {
 	}
 }
 
+// Operation is the coarse provisioning-outcome label (#1083): which kind
+// of provisioning call this was.
+type Operation string
+
+const (
+	OperationCreate Operation = "create"
+	OperationDelete Operation = "delete"
+)
+
 // APISnapshot is a point-in-time read of the API request/error counters
 // by code_class, consumed by the cloudexport platform group at each
 // export tick. RequestsByClass counts every completed call classified
@@ -58,16 +68,35 @@ type APISnapshot struct {
 	ErrorsByClass   map[CodeClass]int64
 }
 
+// ProvisionSnapshot is a point-in-time read of the provisioning outcome
+// counters by operation (#1083), consumed by the cloudexport platform
+// group at each export tick.
+type ProvisionSnapshot struct {
+	Attempts           map[Operation]int64
+	Failures           map[Operation]int64
+	DurationSecondsSum map[Operation]float64
+}
+
 // Stats accumulates platform-domain facts for the lifetime of the
 // daemon process. Every counter is a plain atomic.Int64: recording an
 // event is a single atomic add, and a snapshot is a plain load — no
-// lock, no allocation on the hot path.
+// lock, no allocation on the hot path. Provisioning duration is
+// accumulated as nanoseconds in an atomic.Int64 (atomic float64 add
+// isn't available), converted to fractional seconds only at snapshot
+// read time — no precision lost for durations up to ~292 years.
 type Stats struct {
 	apiRequestsOK          atomic.Int64
 	apiRequestsClientError atomic.Int64
 	apiRequestsServerError atomic.Int64
 	apiErrorsClientError   atomic.Int64
 	apiErrorsServerError   atomic.Int64
+
+	provisionAttemptsCreate      atomic.Int64
+	provisionAttemptsDelete      atomic.Int64
+	provisionFailuresCreate      atomic.Int64
+	provisionFailuresDelete      atomic.Int64
+	provisionDurationNanosCreate atomic.Int64
+	provisionDurationNanosDelete atomic.Int64
 }
 
 // New returns a zeroed Stats. (atomic.Int64 is itself zero-value-usable,
@@ -107,6 +136,49 @@ func (s *Stats) SnapshotAPI() APISnapshot {
 		ErrorsByClass: map[CodeClass]int64{
 			CodeClassClientError: s.apiErrorsClientError.Load(),
 			CodeClassServerError: s.apiErrorsServerError.Load(),
+		},
+	}
+}
+
+// RecordProvisionAttempt records the outcome of one provisioning attempt
+// (a container create or delete): attempts[op] always increments;
+// failures[op] increments when success is false; duration is added to
+// durationSecondsSum[op] regardless of outcome, so a slow failure still
+// shows up in the mean-latency signal derivable from
+// durationSecondsSum/attempts.
+func (s *Stats) RecordProvisionAttempt(op Operation, success bool, duration time.Duration) {
+	nanos := duration.Nanoseconds()
+	switch op {
+	case OperationCreate:
+		s.provisionAttemptsCreate.Add(1)
+		if !success {
+			s.provisionFailuresCreate.Add(1)
+		}
+		s.provisionDurationNanosCreate.Add(nanos)
+	case OperationDelete:
+		s.provisionAttemptsDelete.Add(1)
+		if !success {
+			s.provisionFailuresDelete.Add(1)
+		}
+		s.provisionDurationNanosDelete.Add(nanos)
+	}
+}
+
+// SnapshotProvision returns the current cumulative provisioning
+// counters. Same copy contract as SnapshotAPI.
+func (s *Stats) SnapshotProvision() ProvisionSnapshot {
+	return ProvisionSnapshot{
+		Attempts: map[Operation]int64{
+			OperationCreate: s.provisionAttemptsCreate.Load(),
+			OperationDelete: s.provisionAttemptsDelete.Load(),
+		},
+		Failures: map[Operation]int64{
+			OperationCreate: s.provisionFailuresCreate.Load(),
+			OperationDelete: s.provisionFailuresDelete.Load(),
+		},
+		DurationSecondsSum: map[Operation]float64{
+			OperationCreate: time.Duration(s.provisionDurationNanosCreate.Load()).Seconds(),
+			OperationDelete: time.Duration(s.provisionDurationNanosDelete.Load()).Seconds(),
 		},
 	}
 }

--- a/internal/metrics/platformstats/stats_test.go
+++ b/internal/metrics/platformstats/stats_test.go
@@ -3,6 +3,7 @@ package platformstats
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/codes"
 )
@@ -113,5 +114,72 @@ func TestStats_ConcurrentRecordAPIRequest(t *testing.T) {
 	want := int64(goroutines * perGoroutine)
 	if snap.RequestsByClass[CodeClassOK] != want {
 		t.Errorf("requests[ok] = %d, want %d (lost or duplicated increments under concurrency)", snap.RequestsByClass[CodeClassOK], want)
+	}
+}
+
+func TestStats_RecordAndSnapshotProvision(t *testing.T) {
+	s := New()
+
+	snap := s.SnapshotProvision()
+	if snap.Attempts[OperationCreate] != 0 || snap.Failures[OperationDelete] != 0 {
+		t.Fatalf("fresh Stats should snapshot all zero, got %+v", snap)
+	}
+
+	s.RecordProvisionAttempt(OperationCreate, true, 2*time.Second)
+	s.RecordProvisionAttempt(OperationCreate, true, 4*time.Second)
+	s.RecordProvisionAttempt(OperationCreate, false, 1*time.Second)
+	s.RecordProvisionAttempt(OperationDelete, true, 500*time.Millisecond)
+
+	snap = s.SnapshotProvision()
+	if snap.Attempts[OperationCreate] != 3 {
+		t.Errorf("attempts[create] = %d, want 3", snap.Attempts[OperationCreate])
+	}
+	if snap.Failures[OperationCreate] != 1 {
+		t.Errorf("failures[create] = %d, want 1", snap.Failures[OperationCreate])
+	}
+	// 2s + 4s + 1s = 7s across all three create attempts, success or not —
+	// duration is measured regardless of outcome so a slow failure still
+	// shows up in the mean-latency signal.
+	if got, want := snap.DurationSecondsSum[OperationCreate], 7.0; got != want {
+		t.Errorf("durationSecondsSum[create] = %v, want %v", got, want)
+	}
+	if snap.Attempts[OperationDelete] != 1 {
+		t.Errorf("attempts[delete] = %d, want 1", snap.Attempts[OperationDelete])
+	}
+	if snap.Failures[OperationDelete] != 0 {
+		t.Errorf("failures[delete] = %d, want 0 (the one delete succeeded)", snap.Failures[OperationDelete])
+	}
+	if got, want := snap.DurationSecondsSum[OperationDelete], 0.5; got != want {
+		t.Errorf("durationSecondsSum[delete] = %v, want %v", got, want)
+	}
+}
+
+// TestStats_ConcurrentRecordProvisionAttempt mirrors the API-counter
+// concurrency guard for the provisioning counters — run with -race.
+func TestStats_ConcurrentRecordProvisionAttempt(t *testing.T) {
+	s := New()
+	const goroutines = 50
+	const perGoroutine = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				s.RecordProvisionAttempt(OperationCreate, j%2 == 0, 10*time.Millisecond)
+			}
+		}()
+	}
+	wg.Wait()
+
+	snap := s.SnapshotProvision()
+	wantAttempts := int64(goroutines * perGoroutine)
+	if snap.Attempts[OperationCreate] != wantAttempts {
+		t.Errorf("attempts[create] = %d, want %d", snap.Attempts[OperationCreate], wantAttempts)
+	}
+	wantFailures := int64(goroutines * perGoroutine / 2)
+	if snap.Failures[OperationCreate] != wantFailures {
+		t.Errorf("failures[create] = %d, want %d", snap.Failures[OperationCreate], wantFailures)
 	}
 }

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -326,7 +326,7 @@ func (s *ContainerServer) k8sBoxes() (box.BoxBackend, bool) {
 }
 
 // CreateContainer creates a new container
-func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (*pb.CreateContainerResponse, error) {
+func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateContainerRequest) (resp *pb.CreateContainerResponse, err error) {
 	if err := auth.RequireScope(ctx, auth.ScopeContainersWrite); err != nil {
 		return nil, err
 	}
@@ -510,10 +510,41 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		return nil, err
 	}
 
+	// #1083: everything past this point is a genuine attempt to provision
+	// a container — Box CR, async, or sync. Everything before it (auth,
+	// request validation, pool/peer routing, admission) is a client-side
+	// or routing rejection, not a provisioning attempt, and is
+	// deliberately not counted.
+	//
+	// The defer covers the Box CR and sync paths uniformly via the named
+	// return values (any of their many `return nil, err` statements below
+	// sets `err` before this runs, exactly as if written by hand at each
+	// site). The async path is different: its own synchronous return is
+	// always "accepted" (CREATING, no error), not the real outcome — that
+	// resolves later inside its background goroutine, which records its
+	// own attempt via the same provisionStart. asyncHandledInline, set
+	// once that goroutine is actually spawned, tells this defer to stand
+	// down so the async case isn't double-counted.
+	provisionStart := time.Now()
+	asyncHandledInline := false
+	defer func() {
+		if asyncHandledInline {
+			return
+		}
+		s.platformStats.RecordProvisionAttempt(platformstats.OperationCreate, err == nil, time.Since(provisionStart))
+	}()
+
 	// Convergence (#995): when the Box operator is running, the imperative
 	// create writes a Box CR and the reconciler builds the box — one builder
 	// for both the imperative and declarative (kubectl apply / GitOps) paths.
 	// Returns CREATING regardless of req.Async; the caller polls GET to track it.
+	//
+	// #1083: the top-level defer's success determination for this path means
+	// "the Box CR was accepted by the k8s operator for reconciliation," not
+	// "the box actually finished being built." The real reconciliation
+	// outcome lives in the k8s Box operator's own status/events and is out
+	// of scope for this PR — a future issue could feed that back into
+	// platformStats once the operator exposes it.
 	if s.boxWriter != nil {
 		if err := s.boxWriter.Upsert(ctx, spec); err != nil {
 			return nil, fmt.Errorf("create Box CR for %s: %w", req.Username, err)
@@ -561,6 +592,12 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 
 		// Start async creation. Use a background context — the request ctx is
 		// cancelled once this handler returns the CREATING response.
+		//
+		// #1083: from here on the goroutine owns recording this attempt's
+		// outcome (its real completion, not this handler's synchronous
+		// "accepted" return) — stand the top-level defer down so it isn't
+		// double-counted.
+		asyncHandledInline = true
 		go func() {
 			info, err := s.boxes().Create(context.Background(), spec)
 
@@ -639,6 +676,15 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 				}
 				return
 			}
+
+			// #1083: this is the REAL outcome of an async create — the
+			// synchronous return below is only "accepted", not "succeeded"
+			// (see asyncHandledInline above, which stood the top-level
+			// defer down so this is the only place an async attempt gets
+			// recorded). A cancelled-by-delete run already returned above
+			// without reaching here, matching the existing #1035 rule that
+			// a delete-cancelled create isn't a creation failure.
+			s.platformStats.RecordProvisionAttempt(platformstats.OperationCreate, err == nil, time.Since(provisionStart))
 
 			if err != nil {
 				log.Printf("Async container creation failed for %s: %v", req.Username, err)
@@ -743,7 +789,7 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	// Emit container created event
 	s.emitter.EmitContainerCreated(protoContainer)
 
-	resp := &pb.CreateContainerResponse{
+	resp = &pb.CreateContainerResponse{
 		Container: protoContainer,
 		Message:   fmt.Sprintf("Container %s created successfully", info.Ref.Name),
 	}
@@ -1066,7 +1112,7 @@ func (s *ContainerServer) GetContainer(ctx context.Context, req *pb.GetContainer
 }
 
 // DeleteContainer deletes a container
-func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteContainerRequest) (*pb.DeleteContainerResponse, error) {
+func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteContainerRequest) (resp *pb.DeleteContainerResponse, err error) {
 	if err := auth.RequireScope(ctx, auth.ScopeContainersWrite); err != nil {
 		return nil, err
 	}
@@ -1078,6 +1124,17 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 	}
 
 	containerName := fmt.Sprintf("%s-container", req.Username)
+
+	// #1083: everything past this point is a genuine attempt to delete a
+	// container — k8s, peer-forwarded, or local-manager. Auth/validation
+	// above is a client-side rejection, not a provisioning attempt, and is
+	// deliberately not counted. Unlike CreateContainer, delete has no async
+	// path — every branch below resolves synchronously, so one defer over
+	// the named returns covers all three uniformly.
+	provisionStart := time.Now()
+	defer func() {
+		s.platformStats.RecordProvisionAttempt(platformstats.OperationDelete, err == nil, time.Since(provisionStart))
+	}()
 
 	// Claim any in-flight async creation before touching the instance (#1035).
 	// Provisioning takes minutes, so a delete very often lands mid-run; without
@@ -1109,7 +1166,7 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 		}, nil
 	}
 
-	err := s.manager.Delete(req.Username, req.Force)
+	err = s.manager.Delete(req.Username, req.Force)
 	if err != nil {
 		// Not found locally — try peers
 		if s.peerPool != nil {

--- a/internal/server/metrics_export_sources.go
+++ b/internal/server/metrics_export_sources.go
@@ -105,3 +105,12 @@ func (s serverPlatformSources) APIStats() platformstats.APISnapshot {
 	}
 	return s.stats.SnapshotAPI()
 }
+
+// ProvisionStats returns the current cumulative provisioning counters
+// (#1083). Nil-safe for the same reason as APIStats.
+func (s serverPlatformSources) ProvisionStats() platformstats.ProvisionSnapshot {
+	if s.stats == nil {
+		return platformstats.ProvisionSnapshot{}
+	}
+	return s.stats.SnapshotProvision()
+}


### PR DESCRIPTION
Closes #1083

## Summary

- Adds a provisioning-outcome platform metric group per `docs/architecture/cloud-export-domain-metrics.md`: `attempts`, `failures`, and `duration_seconds_sum` counters keyed by `operation` (`create`/`delete`).
- `internal/metrics/platformstats`: `Operation` type, `ProvisionSnapshot`, lock-free atomic counters on `Stats`, recorded via `RecordProvisionAttempt(op, success, duration)`.
- `internal/metrics/cloudexport`: `PlatformSources.ProvisionStats()` seam + 3 new OTel observable instruments (`containarium.platform.provision.{attempts,failures,duration_seconds_sum}`), registered alongside the existing #1082 API-health group.
- `internal/server/container_server.go`: `CreateContainer` and `DeleteContainer` instrumented via named returns + a single top-level `defer`, so every early-return error path is captured uniformly. `CreateContainer`'s three provisioning paths (Box CR, async, sync) are each handled correctly — the async path's synchronous "accepted" return is not the real outcome, so its background goroutine records the true result itself and the top-level defer stands down (`asyncHandledInline`) to avoid double-counting. A delete-cancelled async create (#1035) still isn't counted as a creation failure, matching existing behavior.
- `docs/METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md`: extended with a provisioning-failure alert recipe (failures > 0 for 10m, `ALIGN_DELTA` so the cumulative counter thresholds on new failures per window, not the running total).

## Deviation from the issue text (flagged)

The issue's acceptance criteria list `backend_id`/`operation` as the label set; the architecture design doc specifies `backend_id`/`hostname`/`region`/`operation`. Implemented per the design doc — consistent with the #1082 precedent (same deviation, same reasoning) and needed for per-host/region drill-down when the alert fires.

## Test evidence

- `platformstats`: `TestStats_RecordAndSnapshotProvision`, `TestStats_ConcurrentRecordProvisionAttempt` (50 goroutines × 100 iters, `-race` clean)
- `cloudexport`: `TestExportedSeries_PlatformProvisionOutcome` (exact attempts/failures/duration per operation, including an explicit zero point for a failure-free operation — not silently absent), `TestExportedSeries_PlatformGroup_ProvisionZeroWhenNotWired`, `TestNoTenantLabels_ProvisionSeries` (label allowlist)
- `go build ./...`, `go vet ./...`, `gofmt -l` (clean), `golangci-lint run` (0 issues, v2.12.2 — matches CI)
- `go test -race -count=1 ./internal/server/... ./internal/metrics/... ./internal/cmd/...` — all green
- Full repo `go test -count=1 ./...` green, except `test/integration` (excluded from CI per `.github/workflows/proxyproto-e2e.yml`, requires a live gRPC server on `localhost:50051` — pre-existing, unrelated to this change)

## Acceptance criteria mapping

1. ✅ Successful create increments `attempts`; failed create increments `attempts`+`failures` — covered by `TestExportedSeries_PlatformProvisionOutcome` and the `CreateContainer` instrumentation across all three provisioning paths.
2. ⚠️ Labels: implemented as `backend_id`/`hostname`/`region`/`operation` per the design doc, not `backend_id`/`operation` per the issue text (see Deviation above) — covered by `TestNoTenantLabels_ProvisionSeries`.
3. ✅ GCM alert recipe documented (failures > 0 for 10 min) — new section in `docs/METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md`.

## Testing gap (flagged, not silently skipped)

No fake `box.BoxBackend` or RPC-level test harness exists for `CreateContainer`/`DeleteContainer` (confirmed via grep — only `container_server_cancel_create_test.go` exercises the narrow `pendingCreations` bookkeeping directly). Building that harness is out of scope for this issue. The instrumentation's wiring is verified by build+vet+existing-suite staying green after the refactor, not a new end-to-end test. A fresh Containarium Cloud box would not add coverage here either — it can't run nested incus/LXC, so the RPC-level create/delete path can't be exercised there any more than locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)