### PR TITLE
feat(metrics-export): connectivity series — connected peers + per-peer tunnel state

### DIFF
--- a/internal/metrics/cloudexport/collector.go
+++ b/internal/metrics/cloudexport/collector.go
@@ -69,6 +69,15 @@ const (
 	MetricPlatformProvisionAttempts           = "containarium.platform.provision.attempts"
 	MetricPlatformProvisionFailures           = "containarium.platform.provision.failures"
 	MetricPlatformProvisionDurationSecondsSum = "containarium.platform.provision.duration_seconds_sum"
+
+	// MetricPlatformPeersConnected / MetricPlatformTunnelState are the
+	// platform group's connectivity series (#1084): how many registered
+	// BYOC peers this backend currently sees as healthy, and each one's
+	// individual tunnel up/down state. Complements #1078 (BYOC hosts
+	// can't export themselves) — the GCP primary exports connectivity on
+	// their behalf.
+	MetricPlatformPeersConnected = "containarium.platform.peers.connected"
+	MetricPlatformTunnelState    = "containarium.platform.tunnel.state"
 )
 
 // Label keys — the complete allowlist. No org/tenant identifier ever
@@ -92,6 +101,11 @@ const (
 	// kind of provisioning call this was (platformstats.Operation) —
 	// create or delete, never a per-request identifier.
 	LabelOperation = "operation"
+	// LabelPeerID tags the tunnel.state series with which registered
+	// peer a point is for (#1084). Always the enrolled host name — the
+	// enrollment path forbids org/tenant identifiers in it — never an
+	// org/tenant identifier itself.
+	LabelPeerID = "peer_id"
 )
 
 // Labels is the fixed identity stamped on every exported series. These
@@ -149,6 +163,18 @@ func (l Labels) provisionAttributeSet(op platformstats.Operation) attribute.Set 
 		attribute.String(LabelHostname, l.Hostname),
 		attribute.String(LabelRegion, l.Region),
 		attribute.String(LabelOperation, string(op)),
+	)
+}
+
+// tunnelAttributeSet is the platform tunnel-state label set (backend_id,
+// hostname, region, peer_id) — the host-series identity plus which peer
+// this point is for (#1084).
+func (l Labels) tunnelAttributeSet(peerID string) attribute.Set {
+	return attribute.NewSet(
+		attribute.String(LabelBackendID, l.BackendID),
+		attribute.String(LabelHostname, l.Hostname),
+		attribute.String(LabelRegion, l.Region),
+		attribute.String(LabelPeerID, peerID),
 	)
 }
 
@@ -357,9 +383,9 @@ func (c *CloudExportCollector) buildMeterProvider(reader sdkmetric.Reader) (*sdk
 // to one metric group (#1081). This is the single dispatch point new
 // groups plug into: host registers the #1070 allowlist; container is
 // still reserved (per-container series land in #1071); platform
-// registers the #1082 API-health series when a PlatformSources is
-// wired, and nothing otherwise (#1083/#1084 add more platform series to
-// the same dispatch). Groups are normalized before they reach here, so
+// registers the #1082/#1083/#1084 API-health, provisioning-outcome, and
+// connectivity series when a PlatformSources is wired, and nothing
+// otherwise. Groups are normalized before they reach here, so
 // UNSPECIFIED never arrives; an unknown value is a programming error.
 //
 // Note the heartbeat is deliberately NOT a group: it is registered
@@ -388,12 +414,13 @@ func registerGroupInstruments(mp *sdkmetric.MeterProvider, group pb.CloudMetrics
 }
 
 // registerPlatformInstruments creates the platform group's API-health
-// (#1082) and provisioning-outcome (#1083) counters and wires one
-// callback per concern, each pulling a single snapshot per tick.
-// Counters, not gauges: OTel async-counter semantics expect the current
-// cumulative total on every observation (platformstats.Stats already
-// accumulates for the daemon's lifetime), which is exactly what every
-// snapshot here reports.
+// (#1082), provisioning-outcome (#1083), and connectivity (#1084)
+// instruments and wires one callback per concern, each pulling a single
+// snapshot per tick. API-health and provisioning are counters: OTel
+// async-counter semantics expect the current cumulative total on every
+// observation (platformstats.Stats already accumulates for the daemon's
+// lifetime), which is exactly what those snapshots report. Connectivity
+// is gauges: peer health is current state, not an accumulating count.
 func registerPlatformInstruments(mp *sdkmetric.MeterProvider, sources PlatformSources, labels Labels) error {
 	meter := mp.Meter(meterName)
 
@@ -456,6 +483,41 @@ func registerPlatformInstruments(mp *sdkmetric.MeterProvider, sources PlatformSo
 			return nil
 		},
 		attempts, failures, durationSum,
+	)
+	if err != nil {
+		return err
+	}
+
+	peersConnected, err := meter.Int64ObservableGauge(MetricPlatformPeersConnected,
+		metric.WithUnit("{peer}"), metric.WithDescription("Number of registered BYOC peers this backend currently sees as healthy (tunnel up)."))
+	if err != nil {
+		return err
+	}
+	tunnelState, err := meter.Int64ObservableGauge(MetricPlatformTunnelState,
+		metric.WithDescription("Per-peer tunnel state: 1 if the peer is currently healthy, 0 if not. peer_id is the enrolled host name."))
+	if err != nil {
+		return err
+	}
+
+	_, err = meter.RegisterCallback(
+		func(ctx context.Context, o metric.Observer) error {
+			peers := sources.Peers()
+			var connected int64
+			for _, peer := range peers {
+				state := int64(0)
+				if peer.Healthy {
+					connected++
+					state = 1
+				}
+				o.ObserveInt64(tunnelState, state, metric.WithAttributeSet(labels.tunnelAttributeSet(peer.ID)))
+			}
+			// Always observed, even at zero peers — a scalar summary
+			// like the host-series gauges, not a per-key breakdown, so
+			// there is no set of keys to fabricate or omit.
+			o.ObserveInt64(peersConnected, connected, metric.WithAttributeSet(labels.attributeSet()))
+			return nil
+		},
+		peersConnected, tunnelState,
 	)
 	return err
 }

--- a/internal/metrics/cloudexport/collector_test.go
+++ b/internal/metrics/cloudexport/collector_test.go
@@ -171,6 +171,7 @@ func TestExportedSeries_MatchesAllowlistGolden(t *testing.T) {
 type fakePlatformSources struct {
 	api       platformstats.APISnapshot
 	provision platformstats.ProvisionSnapshot
+	peers     []PeerState
 }
 
 func (f *fakePlatformSources) APIStats() platformstats.APISnapshot {
@@ -179,6 +180,10 @@ func (f *fakePlatformSources) APIStats() platformstats.APISnapshot {
 
 func (f *fakePlatformSources) ProvisionStats() platformstats.ProvisionSnapshot {
 	return f.provision
+}
+
+func (f *fakePlatformSources) Peers() []PeerState {
+	return f.peers
 }
 
 // flattenPoints returns every emitted datapoint (gauge OR cumulative
@@ -854,5 +859,224 @@ func TestNoTenantLabels_ProvisionSeries(t *testing.T) {
 		if !seen[LabelOperation] {
 			t.Errorf("series %q missing required label %q", p.name, LabelOperation)
 		}
+	}
+}
+
+// sampleConnectivitySnapshot is a representative peer snapshot for the
+// tests below: one healthy peer, one unhealthy — so both tunnel.state
+// values (1 and 0) and a partial peers.connected count are exercised in
+// one fixture.
+func sampleConnectivitySnapshot() []PeerState {
+	return []PeerState{
+		{ID: "byoc-host-a", Healthy: true},
+		{ID: "byoc-host-b", Healthy: false},
+	}
+}
+
+// pointsByNameAndPeer indexes flattened points by (series name, peer_id
+// label value), the connectivity-series analog of pointsByNameAndClass /
+// pointsByNameAndOperation. Points with no peer_id label (peers.connected)
+// are indexed under the empty string.
+func pointsByNameAndPeer(pts []point) map[string]map[string]point {
+	out := map[string]map[string]point{}
+	for _, p := range pts {
+		peerID, _ := p.attrs.Value(attribute.Key(LabelPeerID))
+		if out[p.name] == nil {
+			out[p.name] = map[string]point{}
+		}
+		out[p.name][peerID.AsString()] = p
+	}
+	return out
+}
+
+// TestExportedSeries_PlatformConnectivity is #1084's acceptance
+// criterion: enabling the platform group with a wired PlatformSources
+// emits containarium.platform.peers.connected as the count of healthy
+// peers, and containarium.platform.tunnel.state as one 0/1 point per
+// registered peer, keyed by peer_id.
+func TestExportedSeries_PlatformConnectivity(t *testing.T) {
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{platform}, &fakeSources{sr: sampleResources()}, &fakePlatformSources{peers: sampleConnectivitySnapshot()}, sampleLabels())
+	pts := flattenPoints(t, rm)
+	byNamePeer := pointsByNameAndPeer(pts)
+
+	connected, ok := byNamePeer[MetricPlatformPeersConnected][""]
+	if !ok {
+		t.Fatalf("missing %s", MetricPlatformPeersConnected)
+	}
+	if connected.ival != 1 {
+		t.Errorf("%s = %d, want 1 (one healthy peer of two)", MetricPlatformPeersConnected, connected.ival)
+	}
+
+	wantTunnelState := map[string]int64{"byoc-host-a": 1, "byoc-host-b": 0}
+	for peerID, want := range wantTunnelState {
+		p, ok := byNamePeer[MetricPlatformTunnelState][peerID]
+		if !ok {
+			t.Fatalf("missing %s{peer_id=%q} — an unhealthy peer must still emit an explicit 0 point", MetricPlatformTunnelState, peerID)
+		}
+		if p.ival != want {
+			t.Errorf("%s{peer_id=%q} = %d, want %d", MetricPlatformTunnelState, peerID, p.ival, want)
+		}
+	}
+}
+
+// TestTunnelState_FlipsOnHealthChange locks in the issue's literal
+// acceptance criterion at the collector level: a peer flipping from
+// healthy to unhealthy (and back) between two ticks flips its
+// tunnel.state point accordingly, and peers.connected moves with it.
+// The real end-to-end timing (a stopped tunnel reflected within 2 export
+// intervals) is a live property of the peer-pool health check + export
+// cadence, not reproducible in a unit test — this pins the collector's
+// half of that contract: it always reports whatever PlatformSources
+// currently says, with no caching or debouncing of its own.
+func TestTunnelState_FlipsOnHealthChange(t *testing.T) {
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+	src := &fakePlatformSources{peers: []PeerState{{ID: "byoc-host-a", Healthy: true}}}
+
+	reader := sdkmetric.NewManualReader()
+	c := NewCollector(CollectorOptions{Sources: &fakeSources{sr: sampleResources()}, PlatformSources: src, Labels: sampleLabels(), Groups: []pb.CloudMetricsGroup{platform}})
+	mp, err := c.buildMeterProvider(reader)
+	if err != nil {
+		t.Fatalf("buildMeterProvider: %v", err)
+	}
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect (tick 1): %v", err)
+	}
+	byNamePeer := pointsByNameAndPeer(flattenPoints(t, rm))
+	if p := byNamePeer[MetricPlatformTunnelState]["byoc-host-a"]; p.ival != 1 {
+		t.Fatalf("tick 1: tunnel.state = %d, want 1 (healthy)", p.ival)
+	}
+	if p := byNamePeer[MetricPlatformPeersConnected][""]; p.ival != 1 {
+		t.Fatalf("tick 1: peers.connected = %d, want 1", p.ival)
+	}
+
+	// Tunnel drops.
+	src.peers = []PeerState{{ID: "byoc-host-a", Healthy: false}}
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect (tick 2): %v", err)
+	}
+	byNamePeer = pointsByNameAndPeer(flattenPoints(t, rm))
+	if p := byNamePeer[MetricPlatformTunnelState]["byoc-host-a"]; p.ival != 0 {
+		t.Fatalf("tick 2: tunnel.state = %d, want 0 (dropped)", p.ival)
+	}
+	if p := byNamePeer[MetricPlatformPeersConnected][""]; p.ival != 0 {
+		t.Fatalf("tick 2: peers.connected = %d, want 0", p.ival)
+	}
+
+	// Tunnel reconnects.
+	src.peers = []PeerState{{ID: "byoc-host-a", Healthy: true}}
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect (tick 3): %v", err)
+	}
+	byNamePeer = pointsByNameAndPeer(flattenPoints(t, rm))
+	if p := byNamePeer[MetricPlatformTunnelState]["byoc-host-a"]; p.ival != 1 {
+		t.Fatalf("tick 3: tunnel.state = %d, want 1 (reconnected)", p.ival)
+	}
+	if p := byNamePeer[MetricPlatformPeersConnected][""]; p.ival != 1 {
+		t.Fatalf("tick 3: peers.connected = %d, want 1", p.ival)
+	}
+}
+
+// TestExportedSeries_PlatformGroup_ConnectivityZeroWhenNotWired guards
+// the zero-peers default: a PlatformSources whose Peers() returns nil
+// (an older adapter, or a backend with no registered peers) must not
+// panic. peers.connected is a scalar summary — unlike the per-key
+// provisioning series, there is no key to fabricate or omit — so it
+// still emits an explicit 0; tunnel.state has no peer to report and
+// emits nothing.
+func TestExportedSeries_PlatformGroup_ConnectivityZeroWhenNotWired(t *testing.T) {
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{platform}, &fakeSources{sr: sampleResources()}, &fakePlatformSources{}, sampleLabels())
+	pts := flattenPoints(t, rm)
+	byNamePeer := pointsByNameAndPeer(pts)
+
+	connected, ok := byNamePeer[MetricPlatformPeersConnected][""]
+	if !ok {
+		t.Fatalf("missing %s — must still emit an explicit 0 with zero peers", MetricPlatformPeersConnected)
+	}
+	if connected.ival != 0 {
+		t.Errorf("%s = %d, want 0", MetricPlatformPeersConnected, connected.ival)
+	}
+
+	for _, p := range pts {
+		if p.name == MetricPlatformTunnelState {
+			t.Errorf("tunnel.state emitted a point %+v with zero registered peers", p)
+		}
+	}
+}
+
+// TestNoTenantLabels_ConnectivitySeries locks in #1084's cardinality
+// acceptance criterion: peers.connected carries exactly backend_id/
+// hostname/region (no peer_id — it is a backend-wide scalar);
+// tunnel.state carries exactly backend_id/hostname/region/peer_id, and
+// peer_id is always the enrolled host name passed in by PlatformSources,
+// never an org/tenant identifier.
+func TestNoTenantLabels_ConnectivitySeries(t *testing.T) {
+	platform := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{platform}, &fakeSources{sr: sampleResources()}, &fakePlatformSources{peers: sampleConnectivitySnapshot()}, sampleLabels())
+	all := flattenPoints(t, rm)
+
+	forbidden := []string{"org", "org_id", "tenant", "tenant_id", "username", "user", "uuid", "route", "method", "path"}
+	baseAllowed := map[string]string{
+		LabelBackendID: "backend-xyz",
+		LabelHostname:  "host-1",
+		LabelRegion:    "us-central1",
+	}
+	validPeerIDs := map[string]bool{"byoc-host-a": true, "byoc-host-b": true}
+
+	var sawConnected, sawTunnel bool
+	for _, p := range all {
+		switch p.name {
+		case MetricPlatformPeersConnected:
+			sawConnected = true
+		case MetricPlatformTunnelState:
+			sawTunnel = true
+		default:
+			continue
+		}
+
+		iter := p.attrs.Iter()
+		seen := map[string]bool{}
+		for iter.Next() {
+			kv := iter.Attribute()
+			key := string(kv.Key)
+			seen[key] = true
+			for _, f := range forbidden {
+				if key == f {
+					t.Errorf("series %q carries forbidden label %q", p.name, key)
+				}
+			}
+			if key == LabelPeerID {
+				if p.name == MetricPlatformPeersConnected {
+					t.Errorf("%s carries peer_id label — it is a backend-wide scalar", MetricPlatformPeersConnected)
+				}
+				if !validPeerIDs[kv.Value.AsString()] {
+					t.Errorf("%s peer_id = %q, want one of the enrolled peer IDs the fixture passed in", p.name, kv.Value.AsString())
+				}
+				continue
+			}
+			if wantVal, ok := baseAllowed[key]; !ok {
+				t.Errorf("series %q carries non-allowlisted label %q", p.name, key)
+			} else if kv.Value.AsString() != wantVal {
+				t.Errorf("series %q label %q = %q, want %q", p.name, key, kv.Value.AsString(), wantVal)
+			}
+		}
+		for want := range baseAllowed {
+			if !seen[want] {
+				t.Errorf("series %q missing allowlisted label %q", p.name, want)
+			}
+		}
+		if p.name == MetricPlatformTunnelState && !seen[LabelPeerID] {
+			t.Errorf("series %q missing required label %q", p.name, LabelPeerID)
+		}
+	}
+	if !sawConnected {
+		t.Fatal("no peers.connected series emitted")
+	}
+	if !sawTunnel {
+		t.Fatal("no tunnel.state series emitted")
 	}
 }

--- a/internal/metrics/cloudexport/sources.go
+++ b/internal/metrics/cloudexport/sources.go
@@ -55,6 +55,17 @@ type Sources interface {
 	AllContainerMetrics(ctx context.Context) (map[string]*pb.ContainerMetrics, error)
 }
 
+// PeerState is a point-in-time health snapshot of one registered peer
+// (#1084), read via PlatformSources.Peers(). ID is the enrolled host
+// name — the enrollment path already forbids org/tenant identifiers in
+// it — so the tunnel.state series' peer_id label can never carry a
+// tenant identifier; the no-tenant-label golden test asserts this stays
+// true on the exported side too.
+type PeerState struct {
+	ID      string
+	Healthy bool
+}
+
 // PlatformSources is the read-side seam over platform-domain facts the
 // platform metric group (#1082/#1083/#1084) observes at each export
 // tick — a snapshot read with no server import, so the collector stays
@@ -69,4 +80,10 @@ type PlatformSources interface {
 	// ProvisionStats returns the current cumulative provisioning
 	// attempt/failure/duration counters by operation (#1083).
 	ProvisionStats() platformstats.ProvisionSnapshot
+
+	// Peers returns a point-in-time snapshot of every currently
+	// registered peer's health (#1084) — whatever is registered at the
+	// instant of the call, with no isolation from concurrent registry
+	// mutation beyond what the underlying registry itself provides.
+	Peers() []PeerState
 }

--- a/internal/server/metrics_export_server.go
+++ b/internal/server/metrics_export_server.go
@@ -291,7 +291,7 @@ func (s *ContainerServer) buildMetricsExportCollector(ctx context.Context, cfg c
 
 	return cloudexport.NewCollector(cloudexport.CollectorOptions{
 		Sources:         sources,
-		PlatformSources: serverPlatformSources{stats: s.platformStats},
+		PlatformSources: serverPlatformSources{stats: s.platformStats, peers: s.peerPool},
 		Exporter:        exporter,
 		Resource:        res,
 		Labels:          s.currentExportLabels(sources.Hostname()),

--- a/internal/server/metrics_export_sources.go
+++ b/internal/server/metrics_export_sources.go
@@ -89,9 +89,11 @@ func (s *serverMetricsSources) AllContainerMetrics(ctx context.Context) (map[str
 // serverPlatformSources is the production cloudexport.PlatformSources
 // adapter (#1082): a thin wrapper over the daemon's platformstats.Stats,
 // the same instance the gRPC unary interceptor records into (see
-// DualServer's interceptor chain). No independent state of its own.
+// DualServer's interceptor chain), plus the daemon's *PeerPool (#1084)
+// for connectivity. No independent state of its own.
 type serverPlatformSources struct {
 	stats *platformstats.Stats
+	peers *PeerPool
 }
 
 // APIStats returns the current cumulative API counters. Nil-safe: a
@@ -113,4 +115,14 @@ func (s serverPlatformSources) ProvisionStats() platformstats.ProvisionSnapshot 
 		return platformstats.ProvisionSnapshot{}
 	}
 	return s.stats.SnapshotProvision()
+}
+
+// Peers returns the current peer-health snapshot (#1084). Nil-safe: a
+// ContainerServer without a wired PeerPool degrades to no peers, same
+// as every other seam in this package.
+func (s serverPlatformSources) Peers() []cloudexport.PeerState {
+	if s.peers == nil {
+		return nil
+	}
+	return s.peers.Snapshot()
 }

--- a/internal/server/peer.go
+++ b/internal/server/peer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/internal/config"
 	metricsPackage "github.com/footprintai/containarium/internal/metrics"
+	"github.com/footprintai/containarium/internal/metrics/cloudexport"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
@@ -609,6 +610,24 @@ func (p *PeerPool) HealthyPeersInPool(pool string) []*PeerClient {
 			continue
 		}
 		result = append(result, peer)
+	}
+	return result
+}
+
+// Snapshot returns a point-in-time health snapshot of every currently
+// registered peer (#1084), for the cloudexport platform group's
+// connectivity series. ID is always the enrolled host name — the
+// enrollment path already forbids org/tenant identifiers in it — so the
+// exported tunnel.state series' peer_id label can never carry a tenant
+// identifier. Isolated from concurrent registry mutation only up to the
+// RLock's hold; a peer registered or removed mid-discovery-churn simply
+// appears or not, same as every other read of p.peers.
+func (p *PeerPool) Snapshot() []cloudexport.PeerState {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	result := make([]cloudexport.PeerState, 0, len(p.peers))
+	for _, peer := range p.peers {
+		result = append(result, cloudexport.PeerState{ID: peer.ID, Healthy: peer.Healthy})
 	}
 	return result
 }

--- a/internal/server/peer_test.go
+++ b/internal/server/peer_test.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+
+	"github.com/footprintai/containarium/internal/metrics/cloudexport"
 )
 
 func TestNewPeerPool(t *testing.T) {
@@ -39,6 +42,68 @@ func TestPeerPool_Get(t *testing.T) {
 	if pool.Get("nonexistent") != nil {
 		t.Error("expected nil for nonexistent peer")
 	}
+}
+
+// TestPeerPool_Snapshot is the design doc's peer-snapshot unit test
+// (#1084): registered healthy/unhealthy peers appear in the snapshot
+// with their correct state, keyed by the enrolled host name (peer.ID),
+// never anything else.
+func TestPeerPool_Snapshot(t *testing.T) {
+	pool := NewPeerPool("local", "", []string{"peer-1", "peer-2"}, "")
+	pool.Get("peer-1").Healthy = true
+	// peer-2 stays unhealthy (zero value) — the point of this fixture is
+	// to exercise both states in one snapshot.
+
+	snap := pool.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("expected 2 peers in snapshot, got %d", len(snap))
+	}
+
+	byID := map[string]cloudexport.PeerState{}
+	for _, s := range snap {
+		byID[s.ID] = s
+	}
+	if p, ok := byID["peer-1"]; !ok || !p.Healthy {
+		t.Errorf("expected peer-1 present and healthy in snapshot, got %+v (ok=%v)", p, ok)
+	}
+	if p, ok := byID["peer-2"]; !ok || p.Healthy {
+		t.Errorf("expected peer-2 present and unhealthy in snapshot, got %+v (ok=%v)", p, ok)
+	}
+}
+
+// TestPeerPool_Snapshot_Empty guards the no-peers case the collector's
+// zero-value test depends on: an empty pool returns an empty (not nil)
+// slice, never a panic.
+func TestPeerPool_Snapshot_Empty(t *testing.T) {
+	pool := NewPeerPool("local", "", nil, "")
+	if snap := pool.Snapshot(); len(snap) != 0 {
+		t.Errorf("expected empty snapshot, got %d entries", len(snap))
+	}
+}
+
+// TestPeerPool_Snapshot_ConcurrentSafe is the design doc's -race
+// requirement: Snapshot() alongside concurrent registry mutation
+// (discovery churn flipping a peer's Healthy field) must not race.
+func TestPeerPool_Snapshot_ConcurrentSafe(t *testing.T) {
+	pool := NewPeerPool("local", "", []string{"peer-1"}, "")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			_ = pool.Snapshot()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			pool.mu.Lock()
+			pool.peers["peer-1"].Healthy = !pool.peers["peer-1"].Healthy
+			pool.mu.Unlock()
+		}
+	}()
+	wg.Wait()
 }
 
 func TestPeerClient_ForwardRequest(t *testing.T) {


### PR DESCRIPTION
Closes #1084

## Summary

- Adds the connectivity platform metric group per `docs/architecture/cloud-export-domain-metrics.md`: how many registered BYOC peers this backend currently sees as healthy, and each peer's individual tunnel up/down state. Complements #1078 (BYOC hosts can't export themselves, so the GCP primary exports their connectivity on their behalf).
- `internal/metrics/cloudexport`: `PeerState{ID, Healthy}` + `PlatformSources.Peers()` seam; two new OTel gauges — `containarium.platform.peers.connected` (backend_id/hostname/region) and `containarium.platform.tunnel.state` (same + peer_id, 0/1) — registered alongside the existing #1082/#1083 platform instruments.
- `internal/server/peer.go`: `PeerPool.Snapshot()` — a point-in-time, lock-guarded read of every registered peer's health, keyed by the enrolled host name.
- `serverPlatformSources` wired to the daemon's `*PeerPool` (nil-safe, same pattern as the existing stats fields).

## Design choices

- `peers.connected` is a scalar summary and is always observed, even at zero peers — matching the host-series convention (there's no per-key breakdown to fabricate or omit, unlike the provisioning series).
- `tunnel.state` emits one point per peer actually present in the snapshot, including unhealthy ones — an explicit 0, never silently absent, so a dropped peer is visible rather than the series just disappearing.

## Test evidence

- `cloudexport`: `TestExportedSeries_PlatformConnectivity` (exact `peers.connected` + per-peer `tunnel.state` values), `TestTunnelState_FlipsOnHealthChange` (collector-level pin of the issue's literal "stopping a peer's tunnel flips tunnel.state to 0; reconnect flips it back" across 3 ticks), `TestExportedSeries_PlatformGroup_ConnectivityZeroWhenNotWired`, `TestNoTenantLabels_ConnectivitySeries`
- `internal/server`: `TestPeerPool_Snapshot`, `TestPeerPool_Snapshot_Empty`, `TestPeerPool_Snapshot_ConcurrentSafe` (`-race`, per the design doc's test strategy)
- `go build ./...`, `go vet ./...`, `gofmt -l` (clean), `golangci-lint run` (0 issues, v2.12.2 — matches CI)
- `go test -race -count=1 ./internal/server/... ./internal/metrics/... ./internal/cmd/...` all green
- Full repo `go test -count=1 ./...` green except `test/integration` (excluded from CI, requires a live gRPC server — pre-existing, unrelated to this change)

## Acceptance criteria mapping

1. ✅ Stopping a peer's tunnel flips `tunnel.state` to 0; reconnect flips it back — `TestTunnelState_FlipsOnHealthChange` pins the collector's half of this contract (it always reports whatever `PlatformSources` currently says, with no caching of its own). The live "within 2 export intervals" timing is a property of the peer-pool health check + export cadence, verified manually per the design doc's integration slice — not reproducible in a unit test.
2. ✅ `peer_id` is the enrolled host name, never an org/tenant identifier — `PeerPool.Snapshot()` reads `peer.ID` directly (the enrollment path already forbids tenant identifiers there); `TestNoTenantLabels_ConnectivitySeries` asserts the exported label matches.

No deviation from the design doc this time — the label sets and series kinds implemented exactly match the architecture doc's connectivity table.

## Testing gap (flagged, not silently skipped)

The live "within 2 export intervals" timing and the real PeerPool health-check → tunnel-drop detection path aren't covered by a new integration test — same reasoning as #1083's testing-gap note: no fake peer/tunnel harness exists, and building one is out of scope for this issue. The design doc's own integration slice (enable `host,platform` on a GCP backend → force a tunnel drop → assert in GCM) is the intended manual verification path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)