### PR TITLE
docs(metrics-export): platform group on the committed GCM dashboard + quickstart

### DIFF
--- a/deploy/monitoring/dashboard_test.go
+++ b/deploy/monitoring/dashboard_test.go
@@ -1,0 +1,119 @@
+// Package monitoring holds committed GCM configuration data (dashboard
+// JSON, reproducible via `gcloud monitoring dashboards create`) rather
+// than deployable Go code. This test file exists solely to pin the
+// dashboard JSON against metric-name drift: every widget must reference
+// one of cloudexport's actual exported instrument names, so a renamed
+// or removed series is caught here instead of silently going stale in a
+// committed artifact nobody re-generates.
+package monitoring
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/metrics/cloudexport"
+)
+
+// knownMetricTypes is the complete set of GCM metric types the
+// cloudexport collector can emit, derived from its exported instrument
+// name consts (the same allowlist the collector's own golden tests
+// pin). Prefixed with workload.googleapis.com/, matching how GCP's
+// OTel exporter namespaces custom metrics.
+func knownMetricTypes() map[string]bool {
+	names := []string{
+		cloudexport.MetricCPULoad1m,
+		cloudexport.MetricCPULoad5m,
+		cloudexport.MetricCPULoad15m,
+		cloudexport.MetricMemoryUsed,
+		cloudexport.MetricMemoryTotal,
+		cloudexport.MetricDiskUsed,
+		cloudexport.MetricDiskTotal,
+		cloudexport.MetricContainerCount,
+		cloudexport.MetricHeartbeat,
+		cloudexport.MetricPlatformAPIRequests,
+		cloudexport.MetricPlatformAPIErrors,
+		cloudexport.MetricPlatformProvisionAttempts,
+		cloudexport.MetricPlatformProvisionFailures,
+		cloudexport.MetricPlatformProvisionDurationSecondsSum,
+		cloudexport.MetricPlatformPeersConnected,
+		cloudexport.MetricPlatformTunnelState,
+	}
+	out := make(map[string]bool, len(names))
+	for _, n := range names {
+		out["workload.googleapis.com/"+n] = true
+	}
+	return out
+}
+
+// TestDashboardJSON_ValidAndReferencesKnownMetrics loads the committed
+// dashboard and asserts (1) it is valid JSON gcloud can accept, and (2)
+// every metric.type filter it contains names a series the collector
+// actually exports — catching a typo or a renamed/removed instrument
+// that a hand-edited dashboard JSON would otherwise drift from silently.
+func TestDashboardJSON_ValidAndReferencesKnownMetrics(t *testing.T) {
+	data, err := os.ReadFile("gcm-containarium-hosts.json")
+	if err != nil {
+		t.Fatalf("read dashboard JSON: %v", err)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("dashboard JSON is invalid: %v", err)
+	}
+
+	if _, ok := doc["displayName"]; !ok {
+		t.Error("dashboard JSON missing displayName")
+	}
+
+	known := knownMetricTypes()
+	foundHost := false
+	requiredPlatform := []string{cloudexport.MetricPlatformAPIErrors, cloudexport.MetricPlatformProvisionFailures, cloudexport.MetricPlatformPeersConnected}
+	foundPlatform := map[string]bool{}
+	for _, m := range requiredPlatform {
+		foundPlatform[m] = false
+	}
+
+	// metric.type filters are buried in nested xyChart/timeSeriesQuery
+	// widgets; rather than modeling the full GCM dashboard schema, walk
+	// the raw JSON text for every metric.type = "..." filter fragment —
+	// robust to layout (xyChart vs. scorecard vs. mosaic) and exactly
+	// what matters for the drift check this test exists for.
+	text := string(data)
+	const marker = `metric.type = \"`
+	for idx := strings.Index(text, marker); idx != -1; {
+		rest := text[idx+len(marker):]
+		end := strings.Index(rest, `\"`)
+		if end == -1 {
+			t.Fatalf("unterminated metric.type filter near offset %d", idx)
+		}
+		metricType := rest[:end]
+		if !known[metricType] {
+			t.Errorf("dashboard references unknown metric type %q — not one of cloudexport's exported instruments", metricType)
+		}
+		if strings.HasSuffix(metricType, "containarium.host.cpu.load_1m") {
+			foundHost = true
+		}
+		for _, want := range requiredPlatform {
+			if strings.HasSuffix(metricType, want) {
+				foundPlatform[want] = true
+			}
+		}
+
+		next := strings.Index(rest[end+2:], marker)
+		if next == -1 {
+			break
+		}
+		idx = idx + len(marker) + end + 2 + next
+	}
+
+	if !foundHost {
+		t.Error("dashboard is missing a host-series chart (e.g. CPU load) alongside the platform charts")
+	}
+	for _, metric := range requiredPlatform {
+		if !foundPlatform[metric] {
+			t.Errorf("dashboard is missing a chart for required platform series %q (#1085 acceptance criterion)", metric)
+		}
+	}
+}

--- a/deploy/monitoring/gcm-containarium-hosts.json
+++ b/deploy/monitoring/gcm-containarium-hosts.json
@@ -1,0 +1,246 @@
+{
+  "displayName": "Containarium backends",
+  "labels": {
+    "containarium": "true"
+  },
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "yPos": 0, "xPos": 0, "width": 6, "height": 4,
+        "widget": {
+          "title": "Host CPU load (1m/5m/15m)",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.host.cpu.load_1m\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN" }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${resource.label.instance_id} load_1m"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.host.cpu.load_5m\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN" }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${resource.label.instance_id} load_5m"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "yPos": 0, "xPos": 6, "width": 6, "height": 4,
+        "widget": {
+          "title": "Host memory used / total",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.host.memory.used_bytes\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN" }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${resource.label.instance_id} used"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.host.memory.total_bytes\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN" }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${resource.label.instance_id} total"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "yPos": 4, "xPos": 0, "width": 6, "height": 4,
+        "widget": {
+          "title": "Host disk used / total",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.host.disk.used_bytes\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN" }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${resource.label.instance_id} used"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.host.disk.total_bytes\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN" }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${resource.label.instance_id} total"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "yPos": 4, "xPos": 6, "width": 6, "height": 4,
+        "widget": {
+          "title": "Containers + heartbeat",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.host.container.count\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN" }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${resource.label.instance_id} containers"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.export.heartbeat\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN" }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${metric.label.backend_id} heartbeat"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "yPos": 8, "xPos": 0, "width": 6, "height": 4,
+        "widget": {
+          "title": "Platform: API requests / errors by code_class",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.platform.api.requests\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_RATE", "groupByFields": ["metric.label.code_class"] }
+                  }
+                },
+                "plotType": "STACKED_BAR",
+                "legendTemplate": "requests ${metric.label.code_class}"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.platform.api.errors\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_RATE", "groupByFields": ["metric.label.code_class"] }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "errors ${metric.label.code_class}"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "yPos": 8, "xPos": 6, "width": 6, "height": 4,
+        "widget": {
+          "title": "Platform: provisioning attempts / failures by operation",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.platform.provision.attempts\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_RATE", "groupByFields": ["metric.label.operation"] }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "attempts ${metric.label.operation}"
+              },
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.platform.provision.failures\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_RATE", "groupByFields": ["metric.label.operation"] }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "failures ${metric.label.operation}"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "yPos": 12, "xPos": 0, "width": 6, "height": 4,
+        "widget": {
+          "title": "Platform: provisioning mean duration by operation",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.platform.provision.duration_seconds_sum\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_RATE", "groupByFields": ["metric.label.operation"] }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "duration_seconds_sum rate ${metric.label.operation}"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "yPos": 12, "xPos": 6, "width": 3, "height": 4,
+        "widget": {
+          "title": "Platform: peers connected",
+          "scorecard": {
+            "timeSeriesQuery": {
+              "timeSeriesFilter": {
+                "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.platform.peers.connected\"",
+                "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN" }
+              }
+            },
+            "sparkChartView": { "sparkChartType": "SPARK_LINE" }
+          }
+        }
+      },
+      {
+        "yPos": 12, "xPos": 9, "width": 3, "height": 4,
+        "widget": {
+          "title": "Platform: per-peer tunnel state",
+          "xyChart": {
+            "dataSets": [
+              {
+                "timeSeriesQuery": {
+                  "timeSeriesFilter": {
+                    "filter": "resource.type = \"gce_instance\" AND metric.type = \"workload.googleapis.com/containarium.platform.tunnel.state\"",
+                    "aggregation": { "alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN", "groupByFields": ["metric.label.peer_id"] }
+                  }
+                },
+                "plotType": "LINE",
+                "legendTemplate": "${metric.label.peer_id}"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/docs/CLOUD-NATIVE-METRICS-EXPORT.md
+++ b/docs/CLOUD-NATIVE-METRICS-EXPORT.md
@@ -1,0 +1,94 @@
+# Quickstart: cloud-native metrics export (host + platform groups)
+
+**Scope of this doc (#1085):** enabling the `host` and `platform` metric
+groups together, importing the committed GCM dashboard, and creating one
+platform alert — the single pane of glass the design doc
+(`docs/architecture/cloud-export-domain-metrics.md`) describes.
+
+**Not in scope here:** the full "bare GCP VM → visible metrics" onboarding
+walkthrough with a measured per-container-count cost estimate and
+third-party live verification is tracked separately as
+[#1073](https://github.com/FootprintAI/Containarium/issues/1073) — still
+open pending a real GCP verification pass. This file gains that end-to-end
+walkthrough once #1073 lands; until then it assumes export is already
+enabled at the `host` level (see #1073 / the design doc's prerequisites)
+and focuses on the `platform` group specifically.
+
+## Prerequisites
+
+- A backend already exporting the `host` group successfully:
+
+  ```bash
+  containarium monitoring export status   # last_success_at recent, no last_error
+  ```
+
+- `roles/monitoring.metricWriter` on the service account the daemon's
+  ambient credentials (ADC) resolve to — no key files, no separate
+  credential to manage.
+
+## Enable both groups
+
+```bash
+containarium monitoring export enable --provider gcp --groups host,platform
+```
+
+`--groups` is additive over `host` alone; omitting it keeps the pre-#1081
+host-only default, so this is purely opt-in. Confirm both groups are live:
+
+```bash
+containarium monitoring export status
+# cloud metrics export: enabled (provider=gcp, groups=host,platform, interval=60s)
+```
+
+Within ~2 minutes, the platform series appear in Metrics Explorer
+alongside the existing host series:
+
+| Series | What it shows |
+|---|---|
+| `containarium.platform.api.requests` / `.api.errors` | API traffic by coarse outcome class (`code_class`) — [#1082](https://github.com/FootprintAI/Containarium/issues/1082) |
+| `containarium.platform.provision.attempts` / `.failures` / `.duration_seconds_sum` | Container create/delete outcomes by `operation` — [#1083](https://github.com/FootprintAI/Containarium/issues/1083) |
+| `containarium.platform.peers.connected` / `.tunnel.state` | BYOC peer connectivity, `peer_id` = enrolled host name — [#1084](https://github.com/FootprintAI/Containarium/issues/1084) |
+
+## Import the committed dashboard
+
+The platform charts (API errors, provisioning failures, peers connected)
+sit alongside the host charts (CPU/memory/disk/containers) on one
+dashboard, committed at
+[`deploy/monitoring/gcm-containarium-hosts.json`](../deploy/monitoring/gcm-containarium-hosts.json)
+so it's reproducible rather than a hand-built, undocumented artifact:
+
+```bash
+gcloud monitoring dashboards create \
+  --project="${PROJECT_ID}" \
+  --config-from-file=deploy/monitoring/gcm-containarium-hosts.json
+```
+
+Re-run the same command with `dashboards update` (matching the dashboard's
+assigned name) after pulling a change to the committed JSON, so the live
+dashboard never silently drifts from what's in the repo.
+
+## Create one platform alert
+
+Any of the platform series can back a Cloud Monitoring alert policy the
+same way the host-side dead-man alert does. The fully worked example —
+`gcloud`/JSON, a `conditionThreshold` on `containarium.platform.provision.
+failures` that fires on a sustained run of provisioning failures (not a
+single bad request) — is documented in
+[`docs/METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md`](METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md#provisioning-failure-alert-1083):
+create it exactly as written there. That runbook is also where the
+underlying heartbeat dead-man alert (the `host`-group prerequisite this
+doc assumes is already live) is documented, so it's the one place to look
+for every alert policy this feature ships, regardless of which group it
+watches.
+
+## Verify (live)
+
+Not reproducible in CI — verify against a real project, same as the
+runbook's own verification sections:
+
+1. `containarium monitoring export status` shows `groups=host,platform`.
+2. Both group's series appear in Metrics Explorer within ~2 minutes.
+3. The imported dashboard renders all charts (host + platform) with real
+   data, not "no data."
+4. The platform alert policy created above fires under the condition it
+   describes and clears once the condition resolves.


### PR DESCRIPTION
Closes #1085

## Summary

- `deploy/monitoring/gcm-containarium-hosts.json` (NEW): a dashboard, reproducible via `gcloud monitoring dashboards create --config-from-file=...`, with the host charts (CPU/memory/disk/containers/heartbeat) alongside the required platform charts: API errors (#1082), provisioning failures (#1083), peers connected + per-peer tunnel state (#1084).
- `deploy/monitoring/dashboard_test.go` (NEW): pins the dashboard against metric-name drift — every `metric.type` filter in the committed JSON is checked against `cloudexport`'s actual exported instrument name consts, and the three required platform charts are asserted present.
- `docs/CLOUD-NATIVE-METRICS-EXPORT.md` (NEW): enabling `--groups host,platform`, importing the dashboard, and creating one platform alert (linked to the existing provisioning-failure recipe in `METRICS-EXPORT-DEADMAN-ALERT-RUNBOOK.md` rather than duplicating the gcloud/JSON a second time).

## Scope note (flagged)

The design doc names `docs/CLOUD-NATIVE-METRICS-EXPORT.md` as a file shared with #1073 ("10-minute quickstart — bare GCP VM to visible metrics + dead-man alert"), but #1073 is still open — it's explicitly gated on a live-measured per-container-count cost number and third-party e2e verification, and was carried over rather than shipped with a hand-waved estimate. Since that file didn't exist yet, this PR creates it scoped exactly to #1085's own acceptance criteria (enabling both groups + one platform alert), with an explicit header noting the full bare-VM walkthrough is #1073's separate, harder-gated deliverable. This isn't silently expanding #1085's scope to cover #1073's unmet criteria, and it isn't blocking #1085 on #1073's live-verification dependency either — #1073 can extend this same file once it lands.

## Test evidence

- `deploy/monitoring`: `TestDashboardJSON_ValidAndReferencesKnownMetrics` — written first against the not-yet-existing JSON file (confirmed red: "no such file or directory"), then green once the JSON was added. Validates the JSON, checks every `metric.type` filter against real `cloudexport` instrument names, and asserts all three required platform charts are present.
- `go build ./...`, `go vet ./...`, `gofmt -l` (clean), `golangci-lint run ./deploy/...` (0 issues, v2.12.2 — matches CI); `jq` validated the JSON independently.
- Full repo `go test -count=1 ./...` (excluding `test/integration`, which requires a live gRPC server — pre-existing, unrelated) green.

## Acceptance criteria mapping

1. ✅ Dashboard JSON committed, includes API errors/provision failures/peers connected alongside host charts — `gcm-containarium-hosts.json` + `TestDashboardJSON_ValidAndReferencesKnownMetrics`.
2. ✅ Quickstart shows enabling both groups and creating one platform alert — `docs/CLOUD-NATIVE-METRICS-EXPORT.md`.

This is the last of the five P0 stories (#1081-#1085) in the platform-domain metrics-export sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)