### PR TITLE
feat(metrics-export): export per-container CPU/mem/disk/network series

### DIFF
--- a/internal/metrics/cloudexport/collector.go
+++ b/internal/metrics/cloudexport/collector.go
@@ -40,6 +40,22 @@ const (
 	MetricDiskTotal      = "containarium.host.disk.total_bytes"
 	MetricContainerCount = "containarium.host.container.count"
 
+	// MetricContainerCPUUsageSeconds / MemoryUsageBytes / DiskUsageBytes /
+	// NetworkRxBytes / NetworkTxBytes are the container group's
+	// per-container series (#1071): the same GetAllMetrics data the
+	// daemon's internal pipeline already collects, routed to the
+	// cloud-provider sink so one noisy container is distinguishable from
+	// host-level pressure. CPU/network are cumulative counters (matching
+	// incus's cumulative CPU-seconds and byte counters); memory/disk are
+	// point-in-time gauges. Collection re-enumerates live containers every
+	// tick, so a deleted container simply stops appearing — no separate
+	// deletion bookkeeping.
+	MetricContainerCPUUsageSeconds  = "containarium.container.cpu.usage_seconds"
+	MetricContainerMemoryUsageBytes = "containarium.container.memory.usage_bytes"
+	MetricContainerDiskUsageBytes   = "containarium.container.disk.usage_bytes"
+	MetricContainerNetworkRxBytes   = "containarium.container.network.rx_bytes"
+	MetricContainerNetworkTxBytes   = "containarium.container.network.tx_bytes"
+
 	// MetricHeartbeat is the liveness/up series (#1072): a constant 1
 	// emitted every export interval while the daemon runs. It is the
 	// out-of-band dead-man signal — a metric-absence alert policy in the
@@ -106,6 +122,12 @@ const (
 	// enrollment path forbids org/tenant identifiers in it — never an
 	// org/tenant identifier itself.
 	LabelPeerID = "peer_id"
+	// LabelContainerName tags the container-group series with which
+	// container a point is for (#1071). Deliberately the ONLY per-point
+	// label alongside backend_id — the container group's label set is
+	// narrower than host/platform (no hostname/region), per the design
+	// doc's allowlist.
+	LabelContainerName = "container_name"
 )
 
 // Labels is the fixed identity stamped on every exported series. These
@@ -175,6 +197,16 @@ func (l Labels) tunnelAttributeSet(peerID string) attribute.Set {
 		attribute.String(LabelHostname, l.Hostname),
 		attribute.String(LabelRegion, l.Region),
 		attribute.String(LabelPeerID, peerID),
+	)
+}
+
+// containerAttributeSet is the container-series label set (backend_id,
+// container_name) (#1071) — deliberately narrower than every other
+// group's label set: no hostname/region, per the design doc's allowlist.
+func (l Labels) containerAttributeSet(containerName string) attribute.Set {
+	return attribute.NewSet(
+		attribute.String(LabelBackendID, l.BackendID),
+		attribute.String(LabelContainerName, containerName),
 	)
 }
 
@@ -381,12 +413,12 @@ func (c *CloudExportCollector) buildMeterProvider(reader sdkmetric.Reader) (*sdk
 
 // registerGroupInstruments registers exactly the instruments belonging
 // to one metric group (#1081). This is the single dispatch point new
-// groups plug into: host registers the #1070 allowlist; container is
-// still reserved (per-container series land in #1071); platform
-// registers the #1082/#1083/#1084 API-health, provisioning-outcome, and
-// connectivity series when a PlatformSources is wired, and nothing
-// otherwise. Groups are normalized before they reach here, so
-// UNSPECIFIED never arrives; an unknown value is a programming error.
+// groups plug into: host registers the #1070 allowlist; container
+// registers the #1071 per-container series; platform registers the
+// #1082/#1083/#1084 API-health, provisioning-outcome, and connectivity
+// series when a PlatformSources is wired, and nothing otherwise. Groups
+// are normalized before they reach here, so UNSPECIFIED never arrives;
+// an unknown value is a programming error.
 //
 // Note the heartbeat is deliberately NOT a group: it is registered
 // unconditionally by buildMeterProvider alongside (and independent of)
@@ -398,8 +430,7 @@ func registerGroupInstruments(mp *sdkmetric.MeterProvider, group pb.CloudMetrics
 	case pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_HOST:
 		return registerHostInstruments(mp, sources, labels)
 	case pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER:
-		// Reserved: per-container series land in #1071/#1072.
-		return nil
+		return registerContainerInstruments(mp, sources, labels)
 	case pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_PLATFORM:
 		if platformSources == nil {
 			// Not wired (e.g. an older daemon build, or a test that
@@ -628,6 +659,74 @@ func registerHostInstruments(mp *sdkmetric.MeterProvider, sources Sources, label
 			return nil
 		},
 		load1, load5, load15, memUsed, memTotal, diskUsed, diskTotal, containerCount,
+	)
+	return err
+}
+
+// registerContainerInstruments creates the container group's five
+// per-container series (#1071) and wires one callback that pulls a
+// single AllContainerMetrics snapshot per tick and observes all five for
+// every container currently reported. CPU/network are counters
+// (cumulative, matching incus's own CPU-seconds and byte counters);
+// memory/disk are gauges (point-in-time). A container absent from the
+// snapshot — because AllContainerMetrics enumerates live containers
+// fresh every tick — simply has no point observed for it this tick,
+// which is exactly the "deleted container's series stop at the next
+// interval" behavior the design doc requires: no separate
+// deletion-tracking state to fall out of sync.
+func registerContainerInstruments(mp *sdkmetric.MeterProvider, sources Sources, labels Labels) error {
+	meter := mp.Meter(meterName)
+
+	cpu, err := meter.Int64ObservableCounter(MetricContainerCPUUsageSeconds,
+		metric.WithUnit("s"), metric.WithDescription("Cumulative CPU time used by the container, in seconds."))
+	if err != nil {
+		return err
+	}
+	mem, err := meter.Int64ObservableGauge(MetricContainerMemoryUsageBytes,
+		metric.WithUnit("By"), metric.WithDescription("Current memory usage of the container, in bytes."))
+	if err != nil {
+		return err
+	}
+	disk, err := meter.Int64ObservableGauge(MetricContainerDiskUsageBytes,
+		metric.WithUnit("By"), metric.WithDescription("Current root-filesystem disk usage of the container, in bytes."))
+	if err != nil {
+		return err
+	}
+	rx, err := meter.Int64ObservableCounter(MetricContainerNetworkRxBytes,
+		metric.WithUnit("By"), metric.WithDescription("Cumulative network bytes received by the container (all interfaces except loopback)."))
+	if err != nil {
+		return err
+	}
+	tx, err := meter.Int64ObservableCounter(MetricContainerNetworkTxBytes,
+		metric.WithUnit("By"), metric.WithDescription("Cumulative network bytes transmitted by the container (all interfaces except loopback)."))
+	if err != nil {
+		return err
+	}
+
+	_, err = meter.RegisterCallback(
+		func(ctx context.Context, o metric.Observer) error {
+			containers, err := sources.AllContainerMetrics(ctx)
+			if err != nil {
+				// Skip this tick: log and emit nothing, same contract as
+				// the host series' SystemResources error handling. Never
+				// panic, never crash the daemon.
+				log.Printf("[cloudexport] skipping container series tick: AllContainerMetrics: %v", err)
+				return nil
+			}
+			for name, m := range containers {
+				if m == nil {
+					continue
+				}
+				observeOpt := metric.WithAttributeSet(labels.containerAttributeSet(name))
+				o.ObserveInt64(cpu, m.CpuUsageSeconds, observeOpt)
+				o.ObserveInt64(mem, m.MemoryUsageBytes, observeOpt)
+				o.ObserveInt64(disk, m.DiskUsageBytes, observeOpt)
+				o.ObserveInt64(rx, m.NetworkRxBytes, observeOpt)
+				o.ObserveInt64(tx, m.NetworkTxBytes, observeOpt)
+			}
+			return nil
+		},
+		cpu, mem, disk, rx, tx,
 	)
 	return err
 }

--- a/internal/metrics/cloudexport/collector_test.go
+++ b/internal/metrics/cloudexport/collector_test.go
@@ -15,12 +15,14 @@ import (
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
-// fakeSources is a Sources whose SystemResources snapshot and error are
-// fully controlled by the test. AllContainerMetrics is present to
-// satisfy the interface (the #1070 host collector never calls it).
+// fakeSources is a Sources whose SystemResources/AllContainerMetrics
+// snapshots and errors are fully controlled by the test.
 type fakeSources struct {
 	sr  *SystemResources
 	err error
+
+	containers    map[string]*pb.ContainerMetrics
+	containersErr error
 }
 
 func (f *fakeSources) SystemResources(ctx context.Context) (*SystemResources, error) {
@@ -31,7 +33,10 @@ func (f *fakeSources) SystemResources(ctx context.Context) (*SystemResources, er
 }
 
 func (f *fakeSources) AllContainerMetrics(ctx context.Context) (map[string]*pb.ContainerMetrics, error) {
-	return nil, nil
+	if f.containersErr != nil {
+		return nil, f.containersErr
+	}
+	return f.containers, nil
 }
 
 func sampleResources() *SystemResources {
@@ -1079,4 +1084,224 @@ func TestNoTenantLabels_ConnectivitySeries(t *testing.T) {
 	if !sawTunnel {
 		t.Fatal("no tunnel.state series emitted")
 	}
+}
+
+// sampleContainerMetrics is a representative two-container fixture for
+// the #1071 container-series tests below.
+func sampleContainerMetrics() map[string]*pb.ContainerMetrics {
+	return map[string]*pb.ContainerMetrics{
+		"alice-container": {
+			Name:             "alice-container",
+			CpuUsageSeconds:  120,
+			MemoryUsageBytes: 256 << 20,
+			DiskUsageBytes:   2 << 30,
+			NetworkRxBytes:   1000,
+			NetworkTxBytes:   500,
+		},
+		"bob-container": {
+			Name:             "bob-container",
+			CpuUsageSeconds:  30,
+			MemoryUsageBytes: 128 << 20,
+			DiskUsageBytes:   1 << 30,
+			NetworkRxBytes:   200,
+			NetworkTxBytes:   100,
+		},
+	}
+}
+
+// containerMetricNames is the complete #1071 per-container instrument
+// allowlist, used to filter the always-on heartbeat (and, in these
+// container-only-group tests, nothing else) out of flattened points.
+var containerMetricNames = map[string]bool{
+	MetricContainerCPUUsageSeconds:  true,
+	MetricContainerMemoryUsageBytes: true,
+	MetricContainerDiskUsageBytes:   true,
+	MetricContainerNetworkRxBytes:   true,
+	MetricContainerNetworkTxBytes:   true,
+}
+
+// pointsByNameAndContainer indexes flattened points by (series name,
+// container_name label value), the container-series analog of
+// pointsByNameAndOperation / pointsByNameAndPeer.
+func pointsByNameAndContainer(pts []point) map[string]map[string]point {
+	out := map[string]map[string]point{}
+	for _, p := range pts {
+		name, _ := p.attrs.Value(attribute.Key(LabelContainerName))
+		if out[p.name] == nil {
+			out[p.name] = map[string]point{}
+		}
+		out[p.name][name.AsString()] = p
+	}
+	return out
+}
+
+// TestExportedSeries_ContainerGolden is #1071's acceptance criterion:
+// enabling the container group with a wired Sources emits all five
+// per-container series, one point per running container, with the exact
+// values AllContainerMetrics reports.
+func TestExportedSeries_ContainerGolden(t *testing.T) {
+	containerGroup := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{containerGroup}, &fakeSources{containers: sampleContainerMetrics()}, nil, sampleLabels())
+	pts := flattenPoints(t, rm)
+	byNameContainer := pointsByNameAndContainer(pts)
+
+	type want struct{ cpu, mem, disk, rx, tx int64 }
+	wants := map[string]want{
+		"alice-container": {cpu: 120, mem: 256 << 20, disk: 2 << 30, rx: 1000, tx: 500},
+		"bob-container":   {cpu: 30, mem: 128 << 20, disk: 1 << 30, rx: 200, tx: 100},
+	}
+
+	for containerName, w := range wants {
+		checks := []struct {
+			metric string
+			want   int64
+		}{
+			{MetricContainerCPUUsageSeconds, w.cpu},
+			{MetricContainerMemoryUsageBytes, w.mem},
+			{MetricContainerDiskUsageBytes, w.disk},
+			{MetricContainerNetworkRxBytes, w.rx},
+			{MetricContainerNetworkTxBytes, w.tx},
+		}
+		for _, c := range checks {
+			p, ok := byNameContainer[c.metric][containerName]
+			if !ok {
+				t.Errorf("missing %s{container_name=%q}", c.metric, containerName)
+				continue
+			}
+			if p.ival != c.want {
+				t.Errorf("%s{container_name=%q} = %d, want %d", c.metric, containerName, p.ival, c.want)
+			}
+		}
+	}
+
+	var total int
+	for metricName, byContainer := range byNameContainer {
+		if containerMetricNames[metricName] {
+			total += len(byContainer)
+		}
+	}
+	if total != 10 {
+		t.Errorf("got %d container-series points, want 10 (2 containers x 5 series)", total)
+	}
+}
+
+// TestDeletedContainerSeriesStop is the design doc's explicit acceptance
+// criterion: a container that disappears from AllContainerMetrics (i.e.
+// was deleted) stops emitting at the very next observation — collection
+// re-enumerates live containers every tick, so there is no separate
+// deletion-tracking state to get stale.
+func TestDeletedContainerSeriesStop(t *testing.T) {
+	containerGroup := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER
+	src := &fakeSources{containers: sampleContainerMetrics()}
+
+	reader := sdkmetric.NewManualReader()
+	c := NewCollector(CollectorOptions{Sources: src, Labels: sampleLabels(), Groups: []pb.CloudMetricsGroup{containerGroup}})
+	mp, err := c.buildMeterProvider(reader)
+	if err != nil {
+		t.Fatalf("buildMeterProvider: %v", err)
+	}
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect (tick 1): %v", err)
+	}
+	byNameContainer := pointsByNameAndContainer(flattenPoints(t, rm))
+	if _, ok := byNameContainer[MetricContainerCPUUsageSeconds]["bob-container"]; !ok {
+		t.Fatal("tick 1: expected bob-container present before deletion")
+	}
+
+	// bob-container is deleted: the next tick's AllContainerMetrics no
+	// longer reports it.
+	src.containers = map[string]*pb.ContainerMetrics{
+		"alice-container": sampleContainerMetrics()["alice-container"],
+	}
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect (tick 2): %v", err)
+	}
+	byNameContainer = pointsByNameAndContainer(flattenPoints(t, rm))
+	for metricName := range containerMetricNames {
+		if _, ok := byNameContainer[metricName]["bob-container"]; ok {
+			t.Errorf("tick 2: %s still reports deleted container bob-container", metricName)
+		}
+		if _, ok := byNameContainer[metricName]["alice-container"]; !ok {
+			t.Errorf("tick 2: %s missing still-live container alice-container", metricName)
+		}
+	}
+}
+
+// TestNoTenantLabels_ContainerSeries locks in #1071's cardinality
+// acceptance criterion: container series carry exactly backend_id +
+// container_name — deliberately narrower than the host/platform series'
+// backend_id/hostname/region, per the design doc's label table.
+func TestNoTenantLabels_ContainerSeries(t *testing.T) {
+	containerGroup := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{containerGroup}, &fakeSources{containers: sampleContainerMetrics()}, nil, sampleLabels())
+	all := flattenPoints(t, rm)
+
+	var pts []point
+	for _, p := range all {
+		if containerMetricNames[p.name] {
+			pts = append(pts, p)
+		}
+	}
+	if len(pts) == 0 {
+		t.Fatal("no container series emitted")
+	}
+
+	allowed := map[string]string{LabelBackendID: "backend-xyz"}
+	forbidden := []string{
+		"org", "org_id", "tenant", "tenant_id", "username", "user", "uuid", "route", "method", "path",
+		// Container series are deliberately narrower than host/platform:
+		// no hostname/region.
+		LabelHostname, LabelRegion,
+	}
+
+	for _, p := range pts {
+		iter := p.attrs.Iter()
+		seen := map[string]bool{}
+		for iter.Next() {
+			kv := iter.Attribute()
+			key := string(kv.Key)
+			seen[key] = true
+			for _, f := range forbidden {
+				if key == f {
+					t.Errorf("series %q carries forbidden label %q", p.name, key)
+				}
+			}
+			if key == LabelContainerName {
+				continue // value asserted by TestExportedSeries_ContainerGolden
+			}
+			if wantVal, ok := allowed[key]; !ok {
+				t.Errorf("series %q carries non-allowlisted label %q", p.name, key)
+			} else if kv.Value.AsString() != wantVal {
+				t.Errorf("series %q label %q = %q, want %q", p.name, key, kv.Value.AsString(), wantVal)
+			}
+		}
+		for want := range allowed {
+			if !seen[want] {
+				t.Errorf("series %q missing allowlisted label %q", p.name, want)
+			}
+		}
+		if !seen[LabelContainerName] {
+			t.Errorf("series %q missing required label %q", p.name, LabelContainerName)
+		}
+	}
+}
+
+// TestContainerGroup_SourcesErrorSkipsTickWithoutPanic mirrors the host
+// series' TestSourceErrorSkipsTickWithoutPanic: an AllContainerMetrics
+// error is skipped cleanly for that tick — no panic, no stale points —
+// without suppressing the Sources-independent heartbeat.
+func TestContainerGroup_SourcesErrorSkipsTickWithoutPanic(t *testing.T) {
+	containerGroup := pb.CloudMetricsGroup_CLOUD_METRICS_GROUP_CONTAINER
+	rm := collectGroupsOnce(t, []pb.CloudMetricsGroup{containerGroup}, &fakeSources{containersErr: errors.New("incus unavailable")}, nil, sampleLabels())
+	pts := flattenPoints(t, rm)
+
+	for _, p := range pts {
+		if containerMetricNames[p.name] {
+			t.Errorf("expected no container series on an AllContainerMetrics error, got %q", p.name)
+		}
+	}
+	heartbeatOf(t, pts) // heartbeat still present; fails if absent.
 }


### PR DESCRIPTION
Closes #1071

## Summary

- Wires the `container` metric group's five per-container series per `docs/CLOUD-NATIVE-METRICS-EXPORT-DESIGN.md` — the last unimplemented piece of that design (host, heartbeat, and the platform group all shipped in earlier issues). `AllContainerMetrics` was already part of the `Sources` interface and already wired to real data (`serverMetricsSources` → `manager.GetAllMetrics()`, from #1070); this issue was purely the collector-side instrument registration, previously a no-op "reserved" stub for the `CONTAINER` group.
- 5 new instrument consts: `containarium.container.{cpu.usage_seconds,memory.usage_bytes,disk.usage_bytes,network.rx_bytes,network.tx_bytes}`. CPU/network are counters (cumulative); memory/disk are gauges (point-in-time).
- New `containerAttributeSet` label set — deliberately narrower than every other group: `backend_id` + `container_name` only, no `hostname`/`region`, per the design doc's allowlist.
- A deleted container simply stops appearing in the next `AllContainerMetrics` snapshot, so its series stop at the very next tick with no separate deletion-tracking state to fall out of sync.

## Test evidence

- `TestExportedSeries_ContainerGolden` — all five series, exact values, one point per container.
- `TestDeletedContainerSeriesStop` — the design doc's named test.
- `TestNoTenantLabels_ContainerSeries` — asserts the label set is exactly `backend_id` + `container_name`, explicitly checking `hostname`/`region` are absent.
- `TestContainerGroup_SourcesErrorSkipsTickWithoutPanic` — error path skipped cleanly, heartbeat unaffected.
- `go build ./...`, `go vet ./...`, `gofmt -l` (clean), `golangci-lint run ./internal/metrics/...` (0 issues, v2.12.2 — matches CI)
- `go test -race -count=1 ./internal/metrics/... ./internal/server/... ./internal/cmd/...` all green
- Full repo `go test -count=1 ./...` (excluding `test/integration`, which requires a live gRPC server) green

## Acceptance criteria mapping

1. ✅ Every running container emits all five series; a deleted container stops within one interval — `TestExportedSeries_ContainerGolden` + `TestDeletedContainerSeriesStop`.
2. ⚠️ A sustained-CPU-load container is identifiable by name in Metrics Explorer within 2 minutes — this is a live-GCM, QA-reproducible criterion; **not exercised in this PR** (see Testing gap).
3. ✅ Label allowlist: container name + backend id only, no tenant/org UUIDs — `TestNoTenantLabels_ContainerSeries`.

## Testing gap (flagged, not silently skipped)

Criterion 2's live Metrics-Explorer verification wasn't performed this session — no fresh GCP backend was spun up and throttled to confirm the series renders identifiable-by-name within the stated 2-minute window. Same reasoning as prior PRs in this sprint (#1082-#1085): the unit-level collector contract is fully covered; this is an explicit, flagged gap, not a claimed pass.

## Note on #1093

PR #1093 (external contributor, still draft) touches the same `collector.go`/`collector_test.go` files fixing a goroutine leak in `Start()`'s error path (#1077). No overlap in the actual lines changed as of this PR — flagging in case both land close together so a rebase check happens before either merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)