### PR TITLE
fix(sentinel): event-driven SSH key resync so RUNNING means SSH-reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A box is now SSH-reachable as soon as it reports RUNNING** — the
+  sentinel learned about a box's SSH key only by polling each backend's
+  `/authorized-keys` on a 2-minute ticker, so a box created just after a
+  tick was RUNNING while sshpiper had no pipe for it and SSH answered
+  `Permission denied (publickey)` for up to two minutes (~50s typical).
+  Anything that trusted RUNNING as "ready" — CI, agents, the documented
+  create→ssh flow — failed its first connection attempts. The daemon now
+  calls a new HMAC-gated `POST /sentinel/keys/resync` whenever its
+  host-side key set changes (container create/delete, `AddSSHKey`,
+  `RemoveSSHKey`), and the sentinel re-pulls that backend's keys and
+  rewrites the sshpiper routing table immediately. Concurrent resyncs for
+  one backend coalesce on "a pull that started after this request
+  arrived", which is guaranteed to include the caller's key — never a
+  time-based skip, which is what would reintroduce the bug. The periodic
+  sync is unchanged and remains the convergence backstop, so a lost or
+  refused notification costs the old latency rather than reachability.
+  Revoked keys likewise stop routing at revocation instead of up to two
+  minutes later.
+
 ## [0.60.0] - 2026-07-23
 
 ### Added

--- a/docs/SSH-JUMP-SERVER-SETUP.md
+++ b/docs/SSH-JUMP-SERVER-SETUP.md
@@ -20,7 +20,7 @@ When using the sentinel + spot VM architecture, SSH traffic flows through sshpip
 
 - **sshpiper** (port 22) acts as an SSH reverse proxy on the sentinel. It sees real client IPs and bans brute-force attackers via the `failtoban` plugin (3 failures = 1h ban).
 - **sshd** on the sentinel listens on port 2222 for management/IAP access only.
-- Authorized keys are synced from the spot VM every 2 minutes. sshpiper routes each user to the spot VM automatically.
+- Authorized keys are synced from the spot VM whenever the daemon's key set changes — creating a box, deleting one, or adding/removing a key makes the daemon call the sentinel's `POST /sentinel/keys/resync`, so a new box is SSH-reachable as soon as it is running. A 2-minute periodic sync remains as the convergence backstop for anything a notification missed (sentinel restart, daemon crash mid-create). sshpiper routes each user to the spot VM automatically.
 - Client SSH config is unchanged — users connect to the sentinel's static IP on port 22 as before.
 
 ### Single VM (Development)

--- a/internal/sentinel/binaryserver.go
+++ b/internal/sentinel/binaryserver.go
@@ -107,6 +107,15 @@ func StartBinaryServer(port int, manager *Manager) (stop func(), err error) {
 	mux.Handle("/sentinel/peer-cert", auth.SentinelHMACMiddleware(manager.hmacSecret, manager.PeerCertHandler()))
 	mux.Handle("/sentinel/fetch-release", auth.SentinelHMACMiddleware(manager.hmacSecret, fetchReleaseHandler(binaryPath)))
 
+	// Event-driven SSH key resync — a daemon calls this the moment its
+	// host-side authorized_keys set changes, so a freshly created box is
+	// SSH-reachable immediately instead of waiting up to a full keysync
+	// tick (cloud #971). Gated by the same daemon HMAC secret that
+	// authenticates the sentinel's own /authorized-keys pull; it triggers
+	// that pull rather than accepting key material, so it grants no
+	// authority the caller doesn't already have.
+	mux.Handle("/sentinel/keys/resync", auth.SentinelHMACMiddleware(manager.hmacSecret, manager.KeyResyncHandler()))
+
 	// Runtime tunnel-token registration — gated by the separate
 	// admin secret (CONTAINARIUM_SENTINEL_ADMIN_SECRET), not the
 	// cluster-wide daemon HMAC secret. See TunnelTokenRegisterHandler.

--- a/internal/sentinel/key_resync_handler.go
+++ b/internal/sentinel/key_resync_handler.go
@@ -1,0 +1,200 @@
+package sentinel
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Event-driven key resync (cloud #971).
+//
+// The sentinel learns about a box's SSH key by polling each backend's
+// /authorized-keys on a ticker (RunSyncLoop, default 2m). A box created just
+// after a tick is therefore RUNNING — and correct in every other respect —
+// while sshpiper has no pipe for it, so SSH answers
+// `Permission denied (publickey)` until the next tick. That is a 0–120s
+// window, mean ~60s, which is exactly the ~50s users measured.
+//
+// This endpoint closes the window without shortening the tick: the daemon
+// tells the sentinel "my key set changed, pull it now" whenever it installs
+// or removes a host-side authorized_keys entry. The ticker stays as the
+// convergence backstop for anything the notification missed (daemon crash
+// mid-create, sentinel restart, a notification lost in flight).
+
+// KeyResyncRequest is the JSON body POSTed to KeyResyncHandler by a daemon
+// whose host-side authorized_keys set just changed.
+type KeyResyncRequest struct {
+	// BackendID identifies which backend to re-pull. Empty falls back to
+	// resolving the backend by the request's source IP, which covers a
+	// daemon that hasn't been told its own backend ID.
+	BackendID string `json:"backend_id,omitempty"`
+
+	// Reason is free-form and logged only (e.g. "create_container
+	// cld-1a2b3c") so an operator reading sentinel logs can tell an
+	// event-driven sync from a periodic one.
+	Reason string `json:"reason,omitempty"`
+}
+
+// KeyResyncResponse reports what the resync did, so the daemon can log
+// something more useful than "sent".
+type KeyResyncResponse struct {
+	// Synced is true when this call resulted in the backend's key set
+	// being current — either this call pulled it, or a concurrent pull
+	// that started after this request arrived already covered it.
+	Synced bool `json:"synced"`
+
+	// Users is the number of users the sentinel now routes for this
+	// backend.
+	Users int `json:"users"`
+
+	// Coalesced is true when a concurrent resync covered this request and
+	// no additional upstream fetch was issued.
+	Coalesced bool `json:"coalesced,omitempty"`
+}
+
+// KeyResyncHandler pulls a backend's authorized keys immediately instead of
+// waiting for the periodic tick, then rewrites the sshpiper routing table.
+//
+// Gated by the cluster-wide daemon HMAC secret
+// (CONTAINARIUM_SENTINEL_AUTH_SECRET) at the mux, the same secret that
+// already authenticates the sentinel's own pull of /authorized-keys. This is
+// deliberately NOT the admin secret: re-reading a backend's own key set is
+// not an authority decision, and the worst a holder of the daemon secret can
+// do here is ask the sentinel to do work it already does on a timer. The
+// handler never accepts key material from the request — it only triggers the
+// authenticated pull, so a caller cannot inject a key for a box it doesn't
+// own.
+func (m *Manager) KeyResyncHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		if m.keyStore == nil {
+			http.Error(w, `{"error":"keysync not enabled on this sentinel","code":501}`, http.StatusNotImplemented)
+			return
+		}
+
+		var req KeyResyncRequest
+		// An empty body is a valid "resync whoever I am" request (the
+		// backend is then resolved by source IP), so only malformed JSON
+		// is a client error.
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+			return
+		}
+
+		backend := m.resolveResyncBackend(req.BackendID, r.RemoteAddr)
+		if backend == nil {
+			http.Error(w, `{"error":"unknown backend","code":404}`, http.StatusNotFound)
+			return
+		}
+
+		coalesced := m.resyncBackendKeys(backend)
+
+		// Report what actually happened, not merely that we tried:
+		// syncAndApply swallows a failed pull (it logs and lets the next
+		// tick retry), so without this the daemon would log "key is live"
+		// for a backend whose keys never arrived — the exact false
+		// confidence this endpoint exists to remove.
+		users, syncErr := m.keyStore.lastSyncResult(backend.ID)
+		log.Printf("[keysync] event-driven resync for backend %s: %d users (coalesced=%v, ok=%v, reason=%q)",
+			backend.ID, users, coalesced, syncErr == nil, req.Reason)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(KeyResyncResponse{
+			Synced:    syncErr == nil,
+			Users:     users,
+			Coalesced: coalesced,
+		})
+	}
+}
+
+// resolveResyncBackend finds the backend to re-pull: by ID when the caller
+// supplied one, otherwise by matching the request's source IP against the
+// registered backends. Returns nil when neither resolves.
+func (m *Manager) resolveResyncBackend(backendID, remoteAddr string) *Backend {
+	if backendID != "" {
+		return m.backends.Get(backendID)
+	}
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	if host == "" {
+		return nil
+	}
+	for _, b := range m.backends.All() {
+		if b.IP == host {
+			return b
+		}
+	}
+	return nil
+}
+
+// resyncBackendKeys pulls one backend's keys and rewrites the sshpiper
+// config, serializing concurrent resyncs for the same backend. It returns
+// true when a concurrent resync already covered this caller.
+//
+// Coalescing is correctness-preserving, not a rate limit: a sync pulls the
+// backend's FULL key set, so any sync that started after this call arrived
+// necessarily contains this caller's key. Skipping on that condition alone
+// can never drop a key — whereas a time-based "synced recently, skip it"
+// rate limit would, by matching a caller against a sync that ran before its
+// key existed. That distinction is the whole bug this endpoint fixes, so it
+// must not be reintroduced here.
+func (m *Manager) resyncBackendKeys(b *Backend) bool {
+	arrived := time.Now()
+
+	gate := m.resyncGate(b.ID)
+	gate.mu.Lock()
+	defer gate.mu.Unlock()
+
+	if gate.lastStart.After(arrived) {
+		return true
+	}
+	gate.lastStart = time.Now()
+	m.keyStore.syncAndApply(b.ID, b.IP, m.config.HealthPort)
+	return false
+}
+
+// resyncGate returns the per-backend serialization gate, creating it on
+// first use.
+func (m *Manager) resyncGate(backendID string) *keyResyncGate {
+	m.keyResyncMu.Lock()
+	defer m.keyResyncMu.Unlock()
+	if m.keyResyncGates == nil {
+		m.keyResyncGates = make(map[string]*keyResyncGate)
+	}
+	g, ok := m.keyResyncGates[backendID]
+	if !ok {
+		g = &keyResyncGate{}
+		m.keyResyncGates[backendID] = g
+	}
+	return g
+}
+
+// keyResyncGate serializes resyncs for one backend and records when the last
+// one started, so a waiting caller can tell whether it was already covered.
+type keyResyncGate struct {
+	mu        sync.Mutex
+	lastStart time.Time
+}
+
+// lastSyncResult reports how many users the store currently routes for a
+// backend and the error from that backend's most recent pull (nil when it
+// succeeded). A backend that has never been synced reports (0, nil).
+func (ks *KeyStore) lastSyncResult(backendID string) (int, error) {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+	bk, ok := ks.backends[backendID]
+	if !ok {
+		return 0, nil
+	}
+	return len(bk.users), bk.lastErr
+}

--- a/internal/sentinel/key_resync_handler_test.go
+++ b/internal/sentinel/key_resync_handler_test.go
@@ -1,0 +1,298 @@
+package sentinel
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/gateway"
+)
+
+// backendKeyServer stands in for a daemon's /authorized-keys endpoint. keys
+// is swapped between requests to simulate a box being created after the
+// sentinel's last periodic sync.
+type backendKeyServer struct {
+	mu    sync.Mutex
+	keys  []gateway.UserKeys
+	fetch atomic.Int32
+	srv   *httptest.Server
+}
+
+func newBackendKeyServer(t *testing.T, initial ...gateway.UserKeys) *backendKeyServer {
+	t.Helper()
+	b := &backendKeyServer{keys: initial}
+	b.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/authorized-keys":
+			b.fetch.Add(1)
+			b.mu.Lock()
+			resp := gateway.KeysResponse{Keys: append([]gateway.UserKeys(nil), b.keys...)}
+			b.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/authorized-keys/sentinel":
+			// The sentinel's upstream-key push. Irrelevant here; the
+			// sentinel treats a failure as non-fatal either way.
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(b.srv.Close)
+	return b
+}
+
+// setKeys replaces the key set the backend will serve on the next fetch.
+func (b *backendKeyServer) setKeys(keys ...gateway.UserKeys) {
+	b.mu.Lock()
+	b.keys = keys
+	b.mu.Unlock()
+}
+
+// hostPort splits the test server's address into the IP and port the
+// sentinel's Backend/Config pair expects.
+func (b *backendKeyServer) hostPort(t *testing.T) (string, int) {
+	t.Helper()
+	addr := b.srv.Listener.Addr().String()
+	i := strings.LastIndex(addr, ":")
+	port, err := strconv.Atoi(addr[i+1:])
+	if err != nil {
+		t.Fatalf("parse test server port from %q: %v", addr, err)
+	}
+	return addr[:i], port
+}
+
+// managerWithBackend wires a Manager whose single registered backend is the
+// given key server — enough for the resync handler, no networking beyond it.
+func managerWithBackend(t *testing.T, backendID string, b *backendKeyServer) *Manager {
+	t.Helper()
+	ip, port := b.hostPort(t)
+	m := &Manager{
+		config:   Config{HealthPort: port},
+		backends: NewBackendPool(),
+		keyStore: NewKeyStore(),
+	}
+	m.backends.Add(&Backend{ID: backendID, IP: ip, Healthy: true})
+	return m
+}
+
+// syncedUsers returns the usernames the KeyStore currently holds for a
+// backend — what the next sshpiper config write would be built from.
+func syncedUsers(ks *KeyStore, backendID string) []string {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+	bk, ok := ks.backends[backendID]
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(bk.users))
+	for _, u := range bk.users {
+		out = append(out, u.Username)
+	}
+	return out
+}
+
+func postResync(t *testing.T, h http.HandlerFunc, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/sentinel/keys/resync", bytes.NewReader(buf))
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}
+
+// The core of cloud #971: a box created between two periodic ticks must not
+// wait for the next tick. One resync call and its key is live.
+func TestKeyResyncHandler_SyncsNewBoxWithoutWaitingForTick(t *testing.T) {
+	backend := newBackendKeyServer(t, gateway.UserKeys{Username: "cld-existing", AuthorizedKeys: "ssh-ed25519 AAAA_existing a@b"})
+	m := managerWithBackend(t, "backend-a", backend)
+
+	// The state after the last periodic tick: only the pre-existing box.
+	m.keyStore.syncAndApply("backend-a", mustIP(t, backend), m.config.HealthPort)
+	if got := syncedUsers(m.keyStore, "backend-a"); len(got) != 1 {
+		t.Fatalf("precondition: synced users = %v, want 1", got)
+	}
+
+	// A box is created on the daemon. Its key exists on the backend but the
+	// sentinel doesn't know yet — this is the ~50s window.
+	backend.setKeys(
+		gateway.UserKeys{Username: "cld-existing", AuthorizedKeys: "ssh-ed25519 AAAA_existing a@b"},
+		gateway.UserKeys{Username: "cld-fresh", AuthorizedKeys: "ssh-ed25519 AAAA_fresh a@b"},
+	)
+
+	rec := postResync(t, m.KeyResyncHandler(), KeyResyncRequest{BackendID: "backend-a"})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q; want 200", rec.Code, rec.Body.String())
+	}
+
+	var resp KeyResyncResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response %q: %v", rec.Body.String(), err)
+	}
+	if !resp.Synced {
+		t.Errorf("Synced = false, want true")
+	}
+	if resp.Users != 2 {
+		t.Errorf("Users = %d, want 2", resp.Users)
+	}
+
+	got := syncedUsers(m.keyStore, "backend-a")
+	if len(got) != 2 || !contains(got, "cld-fresh") {
+		t.Fatalf("synced users = %v, want the fresh box included", got)
+	}
+}
+
+// A resync that arrives while another is in flight is covered by that one:
+// the sync is a full pull of the backend's key set, so any sync that STARTS
+// after the request arrived already contains the caller's key. It must be
+// reported as covered, never as a skip that drops the key on the floor.
+func TestKeyResyncHandler_ConcurrentCallsAllSeeTheirKey(t *testing.T) {
+	backend := newBackendKeyServer(t, gateway.UserKeys{Username: "cld-a", AuthorizedKeys: "ssh-ed25519 AAAA_a a@b"})
+	m := managerWithBackend(t, "backend-a", backend)
+	h := m.KeyResyncHandler()
+
+	const callers = 8
+	var wg sync.WaitGroup
+	codes := make([]int, callers)
+	for i := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			buf, _ := json.Marshal(KeyResyncRequest{BackendID: "backend-a"})
+			req := httptest.NewRequest(http.MethodPost, "/sentinel/keys/resync", bytes.NewReader(buf))
+			rec := httptest.NewRecorder()
+			h(rec, req)
+			codes[i] = rec.Code
+		}()
+	}
+	wg.Wait()
+
+	for i, c := range codes {
+		if c != http.StatusOK {
+			t.Errorf("caller %d: status = %d, want 200", i, c)
+		}
+	}
+	// Every caller is covered by at most one fetch each, and a burst must
+	// collapse rather than issue one fetch per caller unconditionally.
+	if n := backend.fetch.Load(); n < 1 || n > callers {
+		t.Fatalf("upstream fetches = %d, want between 1 and %d", n, callers)
+	}
+}
+
+// The sentinel swallows a failed pull (logs it, lets the next tick retry),
+// so the response must not claim the keys are live. A daemon told
+// Synced=true for a backend whose pull 401'd would log "SSH is ready" over
+// a box nobody can reach.
+func TestKeyResyncHandler_ReportsFailedPull(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"invalid token"}`, http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	addr := srv.Listener.Addr().String()
+	i := strings.LastIndex(addr, ":")
+	port, err := strconv.Atoi(addr[i+1:])
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+	m := &Manager{
+		config:   Config{HealthPort: port},
+		backends: NewBackendPool(),
+		keyStore: NewKeyStore(),
+	}
+	m.backends.Add(&Backend{ID: "backend-a", IP: addr[:i], Healthy: true})
+
+	rec := postResync(t, m.KeyResyncHandler(), KeyResyncRequest{BackendID: "backend-a"})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (the call was accepted; the pull is what failed)", rec.Code)
+	}
+	var resp KeyResyncResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response %q: %v", rec.Body.String(), err)
+	}
+	if resp.Synced {
+		t.Fatal("Synced = true after a failed upstream pull; must report the truth")
+	}
+}
+
+func TestKeyResyncHandler_UnknownBackend(t *testing.T) {
+	backend := newBackendKeyServer(t)
+	m := managerWithBackend(t, "backend-a", backend)
+
+	rec := postResync(t, m.KeyResyncHandler(), KeyResyncRequest{BackendID: "backend-nope"})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %q; want 404", rec.Code, rec.Body.String())
+	}
+}
+
+func TestKeyResyncHandler_MissingBackendIDFallsBackToRemoteAddr(t *testing.T) {
+	backend := newBackendKeyServer(t, gateway.UserKeys{Username: "cld-a", AuthorizedKeys: "ssh-ed25519 AAAA_a a@b"})
+	ip, port := backend.hostPort(t)
+	m := &Manager{
+		config:   Config{HealthPort: port},
+		backends: NewBackendPool(),
+		keyStore: NewKeyStore(),
+	}
+	m.backends.Add(&Backend{ID: "backend-a", IP: ip, Healthy: true})
+
+	buf, _ := json.Marshal(KeyResyncRequest{})
+	req := httptest.NewRequest(http.MethodPost, "/sentinel/keys/resync", bytes.NewReader(buf))
+	req.RemoteAddr = fmt.Sprintf("%s:54321", ip)
+	rec := httptest.NewRecorder()
+	m.KeyResyncHandler()(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q; want 200 (backend resolved by source IP)", rec.Code, rec.Body.String())
+	}
+	if got := syncedUsers(m.keyStore, "backend-a"); len(got) != 1 {
+		t.Fatalf("synced users = %v, want 1", got)
+	}
+}
+
+func TestKeyResyncHandler_RejectsNonPost(t *testing.T) {
+	backend := newBackendKeyServer(t)
+	m := managerWithBackend(t, "backend-a", backend)
+
+	req := httptest.NewRequest(http.MethodGet, "/sentinel/keys/resync", nil)
+	rec := httptest.NewRecorder()
+	m.KeyResyncHandler()(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+// A sentinel with no key store (not wired for keysync) must answer clearly
+// rather than panic — the daemon treats it as "nothing to do".
+func TestKeyResyncHandler_NoKeyStore(t *testing.T) {
+	m := &Manager{config: Config{HealthPort: 8080}, backends: NewBackendPool()}
+	rec := postResync(t, m.KeyResyncHandler(), KeyResyncRequest{BackendID: "backend-a"})
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501", rec.Code)
+	}
+}
+
+func mustIP(t *testing.T, b *backendKeyServer) string {
+	t.Helper()
+	ip, _ := b.hostPort(t)
+	return ip
+}
+
+func contains(hay []string, needle string) bool {
+	for _, s := range hay {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -114,6 +114,14 @@ type Manager struct {
 	certStore       *CertStore
 	keyStore        *KeyStore
 
+	// keyResyncGates serializes event-driven key resyncs per backend so a
+	// burst of container creates collapses into the minimum number of
+	// upstream pulls without any caller's key being skipped (cloud #971).
+	// Lazily populated by resyncGate; keyResyncMu guards the map only, not
+	// the per-backend gate locks inside it.
+	keyResyncMu    sync.Mutex
+	keyResyncGates map[string]*keyResyncGate
+
 	// Tunnel/hybrid mode: ConnMux-based HTTPS handling
 	httpsDispatch *dispatchListener // from ConnMux, dispatches to proxy or maintenance
 

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -694,6 +694,13 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 			if err == nil && info != nil {
 				s.refreshContainerIPMap()
 				s.emitter.EmitContainerCreated(toProtoContainer(info))
+				// Same SSH-readiness push as the sync path (cloud #971).
+				// It matters more here: this is the path the cloud control
+				// plane uses, so this is the transition the caller sees as
+				// CREATING → RUNNING and immediately tries to SSH into.
+				// context.Background() because the request context died
+				// with the CREATING response long before this ran.
+				s.notifySentinelKeyChange(context.Background(), "create_container "+req.Username)
 			}
 		}()
 
@@ -788,6 +795,12 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 
 	// Emit container created event
 	s.emitter.EmitContainerCreated(protoContainer)
+
+	// Push the new box's SSH key into the sentinel's sshpiper routing table
+	// before returning, so RUNNING actually means SSH-reachable (cloud
+	// #971). Without this the caller races a 2-minute keysync tick and its
+	// first connections get `Permission denied (publickey)`.
+	s.notifySentinelKeyChange(ctx, "create_container "+req.Username)
 
 	resp = &pb.CreateContainerResponse{
 		Container: protoContainer,
@@ -1160,6 +1173,9 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 		}
 		s.cascadeContainerCleanup(ctx, containerName, req.Username)
 		s.emitter.EmitContainerDeleted(containerName)
+		// Retire the box's sshpiper pipe now, not on the next tick — see
+		// the LXC delete path below for why (cloud #971).
+		s.notifySentinelKeyChange(ctx, "delete_container "+req.Username)
 		return &pb.DeleteContainerResponse{
 			Message:       fmt.Sprintf("Container for user %s deleted successfully", req.Username),
 			ContainerName: containerName,
@@ -1208,6 +1224,13 @@ func (s *ContainerServer) DeleteContainer(ctx context.Context, req *pb.DeleteCon
 
 	// Emit container deleted event
 	s.emitter.EmitContainerDeleted(containerName)
+
+	// Drop the box's pipe from the sentinel's routing table now rather than
+	// leaving it live until the next tick (cloud #971 is the same clock,
+	// read from the other end: a deleted box's key stays routable for up to
+	// two minutes). Apply()'s stale-dir prune (#835) does the removal; this
+	// just stops it waiting on the timer.
+	s.notifySentinelKeyChange(ctx, "delete_container "+req.Username)
 
 	// Refresh the collector's IP map so the deleted container's IP
 	// is no longer claimed in source-IP attribution.
@@ -2119,8 +2142,10 @@ func (s *ContainerServer) ToggleAutoSleep(ctx context.Context, req *pb.ToggleAut
 //
 // The intended use case is recovery after a lost ephemeral key: an
 // agent or operator generates a fresh keypair locally, calls this RPC
-// with the public half, and within ~2 minutes (next sentinel keysync
-// tick) the new key is live for SSH access.
+// with the public half, and the key is live for SSH by the time this
+// returns — the sentinel is told to re-pull immediately rather than
+// the caller waiting out the keysync tick (cloud #971). If the
+// sentinel is unreachable the key still goes live on that next tick.
 //
 // Idempotent — a key already present is a no-op success.
 func (s *ContainerServer) AddSSHKey(ctx context.Context, req *pb.AddSSHKeyRequest) (*pb.AddSSHKeyResponse, error) {
@@ -2149,8 +2174,10 @@ func (s *ContainerServer) AddSSHKey(ctx context.Context, req *pb.AddSSHKeyReques
 		total = 0
 	}
 
+	s.notifySentinelKeyChange(ctx, "add_ssh_key "+req.Username)
+
 	return &pb.AddSSHKeyResponse{
-		Message:   fmt.Sprintf("SSH key added for %s (sentinel keysync will propagate within ~2m)", req.Username),
+		Message:   fmt.Sprintf("SSH key added for %s (sentinel resynced; falls back to the periodic keysync if it was unreachable)", req.Username),
 		TotalKeys: total,
 	}, nil
 }
@@ -2180,6 +2207,10 @@ func (s *ContainerServer) RemoveSSHKey(ctx context.Context, req *pb.RemoveSSHKey
 		log.Printf("[remove-ssh-key] count after remove failed for %s: %v", req.Username, err)
 		total = 0
 	}
+
+	// A revoked key that stays in sshpiper's table is still a working
+	// credential, so this one is worth not leaving on a timer.
+	s.notifySentinelKeyChange(ctx, "remove_ssh_key "+req.Username)
 
 	return &pb.RemoveSSHKeyResponse{
 		Message:   fmt.Sprintf("SSH key removed for %s", req.Username),

--- a/internal/server/peer.go
+++ b/internal/server/peer.go
@@ -565,6 +565,17 @@ func (p *PeerPool) LocalBackendID() string {
 	return p.localBackendID
 }
 
+// SentinelURL returns the sentinel base URL this daemon was configured with
+// (e.g. "http://10.128.0.5:8888"), or "" when none was set. Nil-safe so
+// callers on an unwired daemon (standalone, tests) can treat "no sentinel"
+// as "nothing to notify".
+func (p *PeerPool) SentinelURL() string {
+	if p == nil {
+		return ""
+	}
+	return p.sentinelURL
+}
+
 // IdentitySigner returns the daemon's node identity key (the
 // sentinel-issued peer leaf) as a crypto.Signer plus the leaf cert
 // PEM, for signing the integrity self-measurement (#683). Returns

--- a/internal/server/sentinel_key_notify.go
+++ b/internal/server/sentinel_key_notify.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/sentinel"
+)
+
+// Event-driven SSH key propagation (cloud #971).
+//
+// A box's host-side authorized_keys entry only becomes usable once the
+// sentinel has pulled it into sshpiper's routing table. That pull runs on a
+// 2-minute ticker, so a box created just after a tick reports RUNNING while
+// SSH still answers `Permission denied (publickey)` — for up to two minutes,
+// ~50s in the field. Every caller that trusts RUNNING (CI, agents, the
+// create→ssh flow in the docs) fails its first connections.
+//
+// The daemon therefore tells the sentinel the moment its key set changes.
+// The ticker stays exactly as it was: this is an accelerator, not a
+// replacement, so a lost notification costs the old latency rather than
+// leaving a box permanently unreachable.
+
+// keyResyncTimeout bounds the notification. Long enough for the sentinel to
+// pull the daemon's own /authorized-keys and rewrite the routing table on the
+// same LAN hop, short enough that an unreachable sentinel can't stall a
+// create for a user-visible amount of time.
+const keyResyncTimeout = 5 * time.Second
+
+// notifySentinelKeyChange asks the sentinel to re-pull this daemon's
+// authorized keys now instead of on its next tick.
+//
+// Best-effort and synchronous. Synchronous because the point is that the key
+// is live before the caller is told the box is ready — returning first and
+// syncing after would restore the race in a narrower window. Best-effort
+// because SSH readiness is not a precondition for the box existing: a
+// sentinel that is unreachable, unconfigured, or too old to serve the
+// endpoint leaves the box exactly as reachable as it was before this
+// existed, and the periodic tick still converges.
+func (s *ContainerServer) notifySentinelKeyChange(ctx context.Context, reason string) {
+	sentinelURL := s.peerPool.SentinelURL()
+	if sentinelURL == "" {
+		// Standalone daemon (no sentinel in front of it): nothing routes
+		// SSH through sshpiper, so there is nothing to resync.
+		return
+	}
+	secret := loadSentinelHMACSecret()
+	if len(secret) < auth.SentinelMinSecretLen {
+		// The same misconfiguration that already breaks the sentinel's
+		// periodic pull (#687). Logged there in detail; don't repeat it on
+		// every create.
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, keyResyncTimeout)
+	defer cancel()
+
+	resp, err := postKeyResync(ctx, sentinelURL, s.peerPool.LocalBackendID(), reason, secret)
+	if err != nil {
+		log.Printf("[keysync-notify] sentinel resync after %s failed: %v "+
+			"(the box is created; SSH becomes reachable on the sentinel's next periodic keysync instead)", reason, err)
+		return
+	}
+	if !resp.Synced {
+		// The sentinel accepted the call but its own pull of this daemon's
+		// /authorized-keys failed — most often a mismatched
+		// CONTAINARIUM_SENTINEL_AUTH_SECRET (#687), which the sentinel logs
+		// in full. Say so rather than reporting a success the box can't
+		// cash: SSH stays broken until that is fixed, tick or no tick.
+		log.Printf("[keysync-notify] sentinel accepted the resync after %s but its key pull from this daemon failed "+
+			"— SSH will not work until that is fixed; check the sentinel log for the keysync error", reason)
+		return
+	}
+	log.Printf("[keysync-notify] sentinel resynced after %s: %d users routed (coalesced=%v)", reason, resp.Users, resp.Coalesced)
+}
+
+// postKeyResync sends one signed resync request and decodes the reply. Split
+// from notifySentinelKeyChange so the wire contract is testable without a
+// wired ContainerServer.
+func postKeyResync(ctx context.Context, sentinelURL, backendID, reason string, secret []byte) (*sentinel.KeyResyncResponse, error) {
+	body, err := json.Marshal(sentinel.KeyResyncRequest{BackendID: backendID, Reason: reason})
+	if err != nil {
+		return nil, fmt.Errorf("marshal resync request: %w", err)
+	}
+
+	url := strings.TrimRight(sentinelURL, "/") + "/sentinel/keys/resync"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build resync request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	auth.SignSentinelRequest(req, secret)
+
+	resp, err := (&http.Client{Timeout: keyResyncTimeout}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("POST %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("POST %s: status %d: %s", url, resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var out sentinel.KeyResyncResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode resync response: %w", err)
+	}
+	return &out, nil
+}

--- a/internal/server/sentinel_key_notify_test.go
+++ b/internal/server/sentinel_key_notify_test.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/sentinel"
+)
+
+// testHMACSecret is long enough to satisfy auth.SentinelMinSecretLen.
+var testHMACSecret = []byte("0123456789abcdef0123456789abcdef")
+
+// The daemon's notification must pass the sentinel's real HMAC gate — a
+// request the middleware rejects would leave the box unreachable for the
+// full tick, which is the bug this whole path exists to fix.
+func TestPostKeyResync_PassesSentinelHMACGate(t *testing.T) {
+	var gotBody atomic.Value
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req sentinel.KeyResyncRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		gotBody.Store(req)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sentinel.KeyResyncResponse{Synced: true, Users: 3})
+	})
+
+	mux := http.NewServeMux()
+	mux.Handle("/sentinel/keys/resync", auth.SentinelHMACMiddleware(testHMACSecret, inner))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := postKeyResync(context.Background(), srv.URL, "backend-a", "create_container cld-1a2b", testHMACSecret)
+	if err != nil {
+		t.Fatalf("postKeyResync: %v", err)
+	}
+	if !resp.Synced || resp.Users != 3 {
+		t.Fatalf("response = %+v, want Synced=true Users=3", resp)
+	}
+
+	req, _ := gotBody.Load().(sentinel.KeyResyncRequest)
+	if req.BackendID != "backend-a" {
+		t.Errorf("BackendID = %q, want %q", req.BackendID, "backend-a")
+	}
+	if req.Reason != "create_container cld-1a2b" {
+		t.Errorf("Reason = %q, want the create reason", req.Reason)
+	}
+}
+
+func TestPostKeyResync_WrongSecretRejected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.Handle("/sentinel/keys/resync", auth.SentinelHMACMiddleware(testHMACSecret, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler must not be reached with a mismatched secret")
+	})))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	_, err := postKeyResync(context.Background(), srv.URL, "backend-a", "test", []byte("ffffffffffffffffffffffffffffffff"))
+	if err == nil {
+		t.Fatal("expected an error for a mismatched HMAC secret")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Fatalf("error = %v, want it to report the 401", err)
+	}
+}
+
+// A sentinel too old to serve the endpoint (or any other non-200) must
+// surface as an error the caller logs, never as a silent success.
+func TestPostKeyResync_NotFoundIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	if _, err := postKeyResync(context.Background(), srv.URL, "backend-a", "test", testHMACSecret); err == nil {
+		t.Fatal("expected an error for a 404 from the sentinel")
+	}
+}
+
+func TestPostKeyResync_TrailingSlashInSentinelURL(t *testing.T) {
+	var path atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path.Store(r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sentinel.KeyResyncResponse{Synced: true})
+	}))
+	defer srv.Close()
+
+	if _, err := postKeyResync(context.Background(), srv.URL+"/", "backend-a", "test", testHMACSecret); err != nil {
+		t.Fatalf("postKeyResync: %v", err)
+	}
+	if got, _ := path.Load().(string); got != "/sentinel/keys/resync" {
+		t.Fatalf("path = %q, want /sentinel/keys/resync", got)
+	}
+}
+
+// A daemon with no sentinel in front of it (standalone, or a test server)
+// has nothing to notify. It must no-op rather than panic on the nil pool —
+// this runs on every create.
+func TestNotifySentinelKeyChange_NoSentinelIsNoOp(t *testing.T) {
+	s := &ContainerServer{}
+	s.notifySentinelKeyChange(context.Background(), "create_container test")
+
+	s = &ContainerServer{peerPool: NewPeerPool("backend-a", "", nil, "pool-a")}
+	s.notifySentinelKeyChange(context.Background(), "create_container test")
+}


### PR DESCRIPTION
## Problem

A freshly created box reports `RUNNING`, but SSH through the sentinel answers
`Permission denied (publickey)` for up to two minutes afterwards — ~50s
typically — and then starts working with no intervention. Anything that
trusts `RUNNING` as "ready" (CI, agents, the documented create→ssh flow)
fails its first connection attempts.

The cause is not a state-machine ordering bug or a propagation race. The box
really is up; the missing piece is one hop upstream. The sentinel learns
about a box's SSH key **only** by polling each backend's `/authorized-keys`
on a ticker:

- `internal/sentinel/keysync.go` — `RunSyncLoop` syncs once at startup, then
  only on `time.NewTicker(interval)`. Nothing else triggers `syncAndApply`.
- `internal/cmd/sentinel.go` — `--key-sync-interval` defaults to **2 minutes**.

So a box created just after a tick waits for the next one before sshpiper has
a pipe for it: a 0–120s window, mean ~60s. That also explains sibling boxes
created in the same minute becoming reachable at the same moment — they were
waiting on the same tick, not on independent timers.

## What this changes

**Sentinel — a new `POST /sentinel/keys/resync`** (`internal/sentinel/key_resync_handler.go`).
Re-pulls one backend's authorized keys and rewrites the sshpiper routing
table on demand.

Gated by the cluster-wide daemon HMAC secret at the mux — the same secret
that already authenticates the sentinel's own pull of `/authorized-keys`, and
deliberately *not* the admin secret. Re-reading a backend's own key set is not
an authority decision, and the handler never accepts key material: it triggers
the authenticated pull, so a caller cannot inject a key for a box it doesn't
own, and the worst a secret-holder can do is ask the sentinel to do work it
already does on a timer.

**Daemon — notify whenever the host-side key set changes**
(`internal/server/sentinel_key_notify.go`): container create (sync, async,
and Box-CR/k8s paths), delete, `AddSSHKey`, `RemoveSSHKey`.

- **Synchronous**, because the whole point is that the key is live before the
  caller is told the box is ready. Returning first and syncing after would
  just narrow the race.
- **Best-effort**, because SSH readiness is not a precondition for the box
  existing. A sentinel that is unreachable, unconfigured, or too old to serve
  the endpoint leaves the box exactly as reachable as it was before this
  existed, bounded by a 5s timeout.

**The periodic sync is untouched.** This is an accelerator, not a
replacement — it remains the convergence backstop for anything a notification
missed (sentinel restart, daemon crash mid-create, a notification lost in
flight).

## Two design points worth reviewing closely

**Coalescing is on causality, not elapsed time.** Concurrent resyncs for one
backend collapse only when a pull *started after this request arrived* — such
a pull provably contains the caller's key, because a pull fetches the backend's
full key set. A time-based "synced recently, skip it" rate limit would match a
caller against a pull that ran *before* its key existed, silently dropping it
for a full tick. That is precisely the bug being fixed, so it must not be
reintroduced here; the reasoning is written into the code so a future
optimization doesn't quietly undo it.

**The response reports whether the pull actually succeeded.** `syncAndApply`
swallows a failed pull (logs it, lets the next tick retry). Without an honest
`synced` field the daemon would log "key is live" for a backend whose pull
401'd on a mismatched `CONTAINARIUM_SENTINEL_AUTH_SECRET` (#687) — false
confidence over a box nobody can reach. The daemon logs that case distinctly.

## Also corrected

`AddSSHKey`'s doc comment and response message promised propagation "within
~2 minutes (next sentinel keysync tick)" — the same defect surface, now
accurate. Same for the sync cadence line in `docs/SSH-JUMP-SERVER-SETUP.md`.

## Tests

12 new tests, all passing under `-race`. The central one
(`TestKeyResyncHandler_SyncsNewBoxWithoutWaitingForTick`) reproduces the
actual failure shape: sync the backend, *then* add a box's key upstream, and
assert one resync call makes it live — the state the old code could only reach
by waiting out a tick. Others cover the concurrent-burst path, an upstream
pull that fails, backend resolution by ID and by source IP, method/404/501
handling, the daemon's request passing the real HMAC middleware, a mismatched
secret, and the no-sentinel no-op.

Full `internal/server`, `internal/gateway`, `internal/auth`, and `pkg/core/...`
suites pass.

**Pre-existing failures, not regressions:** `internal/sentinel` has 5 tests
that fail in a sandbox without `NET_ADMIN` (`RTNETLINK answers: Operation not
permitted` when adding loopback aliases) —
`TestRegisterPropagatesPool`, `TestTunnelIntegration`, `TestTunnelEndToEnd`,
`TestConnMuxWithTunnelClient`, `TestEnableForwardingOnNonLinux`. Verified
failing identically on a clean `origin/main` worktree.

## Not verified here

The end-to-end timing against a live sentinel + backend. The tests prove a
resync propagates a key the periodic sync had not yet seen; confirming the
~50s window is gone in production needs a real create→ssh run on a deployment.

Fixes FootprintAI/Containarium-cloud#971

🤖 Generated with [Claude Code](https://claude.com/claude-code)
