### PR TITLE
feat(cloud-enroll): --adopt-foreign to acknowledge foreign co-residency

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -8162,6 +8162,10 @@
         "ossBackendId": {
           "type": "string",
           "description": "oss_backend_id is the id this host's tunnel registered under at the\nsentinel (its `pool join` spot-id) — what the sentinel `/peer/\u003cid\u003e/`\nproxy keys on. The cloud records it to map a container's backend id\nback to this host. Empty if not (yet) a peer-proxy-routed BYOC backend."
+        },
+        "adoptForeign": {
+          "type": "boolean",
+          "description": "adopt_foreign acknowledges that this host already runs cloud-managed\ncontainers belonging to OTHER organizations, and enrolls it anyway\n(cloud #1006). Default false: the cloud REFUSES such a host with\nFailedPrecondition rather than silently claiming it around the existing\nresidents. Set by `containarium cloud enroll --adopt-foreign`.\n\nThe check runs control-plane-side — the cloud probes this host's daemon\nover the sentinel peer-proxy and reads the containers' `cloud_org_id`\nlabels itself, so the host cannot under-report. The cloud records the\noverride on its host audit trail."
         }
       },
       "description": "EnrollHostRequest carries the single-use join token a BYO host redeems to\nregister itself with the cloud (BYO-compute report path). Unlike every other\nActuationService RPC this one is NOT host-bearer authed — the host row\ndoesn't exist yet; the cloud validates + single-use-redeems the token."

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -270,6 +270,12 @@ type EnrollOptions struct {
 	// OSSBackendID is this host's tunnel/`pool join` spot-id — what the
 	// sentinel `/peer/<id>/` proxy keys on.
 	OSSBackendID string
+	// AdoptForeign acknowledges that this host already runs cloud-managed
+	// containers belonging to other organizations, and enrolls it anyway
+	// (cloud #1006). Default false: the cloud refuses such a host rather than
+	// silently claiming it around the existing residents. The cloud makes and
+	// audits the decision — this flag only carries the operator's consent.
+	AdoptForeign bool
 }
 
 // Enroll redeems a single-use join token against the control plane and
@@ -308,6 +314,7 @@ func Enroll(ctx context.Context, controlPlane, joinToken string, insecureTLS boo
 		JoinToken:    joinToken,
 		DriverToken:  opts.DriverToken,
 		OssBackendId: opts.OSSBackendID,
+		AdoptForeign: opts.AdoptForeign,
 	})
 	if err != nil {
 		return "", "", fmt.Errorf("cloud: enroll: %w", err)

--- a/internal/cloud/client_test.go
+++ b/internal/cloud/client_test.go
@@ -26,6 +26,9 @@ type fakeActuation struct {
 	enrollHostID    string
 	enrollDriverTok string
 	enrollBackendID string
+	// enrollAdoptForeign records the #1006 acknowledgement flag, so a test can
+	// prove `cloud enroll --adopt-foreign` actually reaches the control plane.
+	enrollAdoptForeign bool
 	// enrollHostIDOverride, when set, makes EnrollHost return this id instead
 	// of the join token's own embedded id — simulating a cloud #572 re-enroll,
 	// where the cloud resolves to a pre-existing host row with a different id.
@@ -43,6 +46,7 @@ func (f *fakeActuation) EnrollHost(_ context.Context, req *cloudv1.EnrollHostReq
 	f.enrollToken = req.GetJoinToken()
 	f.enrollDriverTok = req.GetDriverToken()
 	f.enrollBackendID = req.GetOssBackendId()
+	f.enrollAdoptForeign = req.GetAdoptForeign()
 	id := req.GetJoinToken()
 	if i := indexByte(id, '.'); i >= 0 {
 		id = id[:i]

--- a/internal/cloud/enroll_adopt_foreign_test.go
+++ b/internal/cloud/enroll_adopt_foreign_test.go
@@ -1,0 +1,105 @@
+package cloud
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	cloudv1 "github.com/footprintai/containarium/pkg/pb/containarium/cloud/v1"
+)
+
+// `cloud enroll --adopt-foreign` (cloud #1006).
+//
+// The cloud refuses to enroll a host that already runs other organizations'
+// cloud-managed containers — the root cause of the cloud#1001 co-residency.
+// This flag is the operator's explicit acknowledgement. The decision is made
+// and audited control-plane-side; the host's only job is to transmit the flag
+// faithfully on BOTH transports, so these tests pin exactly that.
+
+func TestEnroll_CarriesAdoptForeign(t *testing.T) {
+	tests := []struct {
+		name string
+		opts EnrollOptions
+		want bool
+	}{
+		{
+			name: "default is false — the guard stays armed unless asked",
+			opts: EnrollOptions{DriverToken: "admin.jwt", OSSBackendID: "tunnel-1"},
+			want: false,
+		},
+		{
+			name: "explicit acknowledgement is transmitted",
+			opts: EnrollOptions{DriverToken: "admin.jwt", OSSBackendID: "tunnel-1", AdoptForeign: true},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lis, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("listen: %v", err)
+			}
+			srv := grpc.NewServer()
+			fake := &fakeActuation{}
+			cloudv1.RegisterActuationServiceServer(srv, fake)
+			go func() { _ = srv.Serve(lis) }()
+			t.Cleanup(srv.Stop)
+
+			if _, _, err := Enroll(context.Background(), lis.Addr().String(), "host-uuid.secret", true, tc.opts); err != nil {
+				t.Fatalf("Enroll: %v", err)
+			}
+
+			fake.mu.Lock()
+			defer fake.mu.Unlock()
+			if fake.enrollAdoptForeign != tc.want {
+				t.Errorf("control plane saw adopt_foreign = %v, want %v", fake.enrollAdoptForeign, tc.want)
+			}
+		})
+	}
+}
+
+func TestEnrollREST_CarriesAdoptForeign(t *testing.T) {
+	tests := []struct {
+		name string
+		opts EnrollOptions
+		want bool
+	}{
+		{
+			name: "default is false",
+			opts: EnrollOptions{DriverToken: "admin.jwt", OSSBackendID: "tunnel-1"},
+			want: false,
+		},
+		{
+			name: "explicit acknowledgement is transmitted",
+			opts: EnrollOptions{DriverToken: "admin.jwt", OSSBackendID: "tunnel-1", AdoptForeign: true},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got cloudv1.EnrollHostRequest
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				raw, _ := io.ReadAll(r.Body)
+				_ = protojson.Unmarshal(raw, &got)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"hostId":"host-123"}`))
+			}))
+			defer srv.Close()
+
+			if _, _, err := enrollREST(context.Background(), srv.URL, "host-123.secret", tc.opts); err != nil {
+				t.Fatalf("enrollREST: %v", err)
+			}
+			if got.GetAdoptForeign() != tc.want {
+				t.Errorf("control plane saw adopt_foreign = %v, want %v", got.GetAdoptForeign(), tc.want)
+			}
+		})
+	}
+}

--- a/internal/cloud/rest.go
+++ b/internal/cloud/rest.go
@@ -125,6 +125,7 @@ func enrollREST(ctx context.Context, controlPlane, joinToken string, opts Enroll
 		JoinToken:    joinToken,
 		DriverToken:  opts.DriverToken,
 		OssBackendId: opts.OSSBackendID,
+		AdoptForeign: opts.AdoptForeign,
 	}, &resp); err != nil {
 		return "", "", fmt.Errorf("cloud: enroll (REST): %w", err)
 	}

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -63,6 +63,7 @@ var (
 	cloudEnrollBackendID     string
 	cloudEnrollNoDriverToken bool
 	cloudEnrollDriverTTL     time.Duration
+	cloudEnrollAdoptForeign  bool
 )
 
 var cloudEnrollCmd = &cobra.Command{
@@ -113,6 +114,7 @@ func init() {
 	cloudEnrollCmd.Flags().StringVar(&cloudEnrollBackendID, "oss-backend-id", "", "this host's tunnel/`pool join` spot-id (what the sentinel peer-proxy keys on); enables the cloud to route container ops to this host")
 	cloudEnrollCmd.Flags().BoolVar(&cloudEnrollNoDriverToken, "no-driver-token", false, "enroll without minting a driver token (host registers + heartbeats but the cloud cannot place workloads on it)")
 	cloudEnrollCmd.Flags().DurationVar(&cloudEnrollDriverTTL, "driver-token-ttl", 30*24*time.Hour, "driver token lifetime (capped at the daemon max, 30d); re-run `cloud enroll` before it expires to rotate")
+	cloudEnrollCmd.Flags().BoolVar(&cloudEnrollAdoptForeign, "adopt-foreign", false, "enroll even if this host already runs cloud-managed containers belonging to OTHER organizations (the cloud refuses by default); only use when the co-residency is understood and intended")
 	_ = cloudEnrollCmd.MarkFlagRequired("control-plane")
 	_ = cloudEnrollCmd.MarkFlagRequired("token-file")
 }
@@ -163,7 +165,14 @@ func runCloudEnroll(cmd *cobra.Command, _ []string) error {
 	// isn't readable (e.g. not running as root, or a non-BYOC host), we warn and
 	// enroll without it — the host still registers + heartbeats, it just isn't
 	// cloud-drivable. --no-driver-token skips minting entirely.
-	opts := cloud.EnrollOptions{OSSBackendID: strings.TrimSpace(cloudEnrollBackendID)}
+	opts := cloud.EnrollOptions{
+		OSSBackendID: strings.TrimSpace(cloudEnrollBackendID),
+		// The cloud refuses to claim a host that already runs other orgs'
+		// cloud-managed containers (cloud #1006); --adopt-foreign is the
+		// operator's explicit acknowledgement. The cloud decides and audits —
+		// this only forwards the consent.
+		AdoptForeign: cloudEnrollAdoptForeign,
+	}
 	if !cloudEnrollNoDriverToken {
 		driverTok, mintErr := mintDriverToken(cloudEnrollJWTSecretFile, cloudEnrollDriverTTL)
 		switch {

--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -447,7 +447,11 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 	if cp := strings.TrimSpace(poolJoinCloudControlPlane); cp != "" {
 		fmt.Println()
 		if err := cloudEnrollAfterPoolJoin(cmd, cp, poolJoinToken, "tunnel-"+spotID, poolJoinCloudInsecure); err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "⚠ cloud enrollment failed (%v)\n  the tunnel is joined regardless; re-run `containarium cloud enroll --control-plane %s --token-file <token-file> --oss-backend-id tunnel-%s` once fixed\n", err, cp, spotID)
+			// A refusal here is expected when the host already runs other orgs'
+			// cloud-managed containers (cloud #1006) — surface --adopt-foreign
+			// as the deliberate way through, since the automated join
+			// intentionally never sets it.
+			fmt.Fprintf(cmd.ErrOrStderr(), "⚠ cloud enrollment failed (%v)\n  the tunnel is joined regardless; re-run `containarium cloud enroll --control-plane %s --token-file <token-file> --oss-backend-id tunnel-%s` once fixed\n  (if the cloud refused because this host already runs OTHER organizations' containers, add --adopt-foreign only if that co-residency is intended)\n", err, cp, spotID)
 		}
 	}
 

--- a/pkg/pb/containarium/cloud/v1/actuation_service.pb.go
+++ b/pkg/pb/containarium/cloud/v1/actuation_service.pb.go
@@ -784,7 +784,18 @@ type EnrollHostRequest struct {
 	// sentinel (its `pool join` spot-id) — what the sentinel `/peer/<id>/`
 	// proxy keys on. The cloud records it to map a container's backend id
 	// back to this host. Empty if not (yet) a peer-proxy-routed BYOC backend.
-	OssBackendId  string `protobuf:"bytes,3,opt,name=oss_backend_id,json=ossBackendId,proto3" json:"oss_backend_id,omitempty"`
+	OssBackendId string `protobuf:"bytes,3,opt,name=oss_backend_id,json=ossBackendId,proto3" json:"oss_backend_id,omitempty"`
+	// adopt_foreign acknowledges that this host already runs cloud-managed
+	// containers belonging to OTHER organizations, and enrolls it anyway
+	// (cloud #1006). Default false: the cloud REFUSES such a host with
+	// FailedPrecondition rather than silently claiming it around the existing
+	// residents. Set by `containarium cloud enroll --adopt-foreign`.
+	//
+	// The check runs control-plane-side — the cloud probes this host's daemon
+	// over the sentinel peer-proxy and reads the containers' `cloud_org_id`
+	// labels itself, so the host cannot under-report. The cloud records the
+	// override on its host audit trail.
+	AdoptForeign  bool `protobuf:"varint,4,opt,name=adopt_foreign,json=adoptForeign,proto3" json:"adopt_foreign,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -838,6 +849,13 @@ func (x *EnrollHostRequest) GetOssBackendId() string {
 		return x.OssBackendId
 	}
 	return ""
+}
+
+func (x *EnrollHostRequest) GetAdoptForeign() bool {
+	if x != nil {
+		return x.AdoptForeign
+	}
+	return false
 }
 
 type EnrollHostResponse struct {
@@ -1186,12 +1204,13 @@ const file_containarium_cloud_v1_actuation_service_proto_rawDesc = "" +
 	"\x0fAssignmentBatch\x12C\n" +
 	"\vassignments\x18\x01 \x03(\v2!.containarium.cloud.v1.AssignmentR\vassignments\x12=\n" +
 	"\fgenerated_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\vgeneratedAt\x12O\n" +
-	"\x10network_policies\x18\x03 \x03(\v2$.containarium.cloud.v1.NetworkPolicyR\x0fnetworkPolicies\"{\n" +
+	"\x10network_policies\x18\x03 \x03(\v2$.containarium.cloud.v1.NetworkPolicyR\x0fnetworkPolicies\"\xa0\x01\n" +
 	"\x11EnrollHostRequest\x12\x1d\n" +
 	"\n" +
 	"join_token\x18\x01 \x01(\tR\tjoinToken\x12!\n" +
 	"\fdriver_token\x18\x02 \x01(\tR\vdriverToken\x12$\n" +
-	"\x0eoss_backend_id\x18\x03 \x01(\tR\fossBackendId\"-\n" +
+	"\x0eoss_backend_id\x18\x03 \x01(\tR\fossBackendId\x12#\n" +
+	"\radopt_foreign\x18\x04 \x01(\bR\fadoptForeign\"-\n" +
 	"\x12EnrollHostResponse\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\"Q\n" +
 	"\x13HostCapabilityCheck\x12\x12\n" +

--- a/proto/containarium/cloud/v1/actuation_service.proto
+++ b/proto/containarium/cloud/v1/actuation_service.proto
@@ -225,6 +225,18 @@ message EnrollHostRequest {
   // proxy keys on. The cloud records it to map a container's backend id
   // back to this host. Empty if not (yet) a peer-proxy-routed BYOC backend.
   string oss_backend_id = 3;
+
+  // adopt_foreign acknowledges that this host already runs cloud-managed
+  // containers belonging to OTHER organizations, and enrolls it anyway
+  // (cloud #1006). Default false: the cloud REFUSES such a host with
+  // FailedPrecondition rather than silently claiming it around the existing
+  // residents. Set by `containarium cloud enroll --adopt-foreign`.
+  //
+  // The check runs control-plane-side — the cloud probes this host's daemon
+  // over the sentinel peer-proxy and reads the containers' `cloud_org_id`
+  // labels itself, so the host cannot under-report. The cloud records the
+  // override on its host audit trail.
+  bool adopt_foreign = 4;
 }
 
 message EnrollHostResponse {


### PR DESCRIPTION
Host-side half of FootprintAI/Containarium-cloud#1006. Paired with FootprintAI/Containarium-cloud#1010, which carries the guard itself.

## Why

The control plane now refuses to claim a BYOC host that already runs cloud-managed containers belonging to **other** organizations. That is the root cause of cloud#1001, where running `cloud enroll` on a self-hosted box silently re-attributed another org's 7-week-old containers to the enrolling org.

The decision and its audit record are entirely control-plane-side — the cloud probes this host's daemon over the sentinel peer-proxy and reads the containers' `cloud_org_id` labels itself, so a host cannot under-report its own residents. This change only lets an operator transmit *consent*.

## What changed

- **Vendored proto sync**: `EnrollHostRequest.adopt_foreign`, matching the cloud repo (source of truth per `docs/CLOUD-ACTUATION-CLIENT-DESIGN.md`). Regenerated stubs + swagger via `make proto`; the diff is the new field only, no incidental churn.
- **`containarium cloud enroll --adopt-foreign`** forwards the acknowledgement on **both** transports — gRPC (`internal/cloud/client.go`) and REST (`internal/cloud/rest.go`). A missing flag on one transport would be a silently-armed guard on the other, hence the paired tests.
- **`pool join` auto-enrollment deliberately never sets it** — an unattended join must not adopt a stranger's containers. Its failure hint now names the flag as the deliberate way through, since that is where an operator first meets the refusal.

## Reviewer: start here

`internal/cmd/cloud.go` — the flag's help text is the only user-facing description of a security-relevant override, so it deserves a wording check.

## Test evidence

```
$ go test ./internal/cloud/ -run TestEnroll -v
--- PASS: TestEnroll_RedeemsTokenAndReturnsHostID
--- PASS: TestEnroll_ReEnrollRebuildsBearerFromReturnedHostID
--- PASS: TestEnroll_CarriesAdoptForeign
--- PASS: TestEnrollREST_CarriesAdoptForeign
--- PASS: TestEnrollREST
--- PASS: TestEnrollREST_ReEnroll
ok  github.com/footprintai/containarium/internal/cloud

$ go test ./internal/cloud/ ./internal/cmd/
ok  github.com/footprintai/containarium/internal/cloud  0.570s
ok  github.com/footprintai/containarium/internal/cmd    0.303s

$ go build ./... && go vet ./internal/cloud/ ./internal/cmd/ && gofmt -l internal/
(clean)
```

`TestEnroll_CarriesAdoptForeign` / `TestEnrollREST_CarriesAdoptForeign` are table-driven over both values, so the **default-false** case (guard stays armed unless explicitly asked) is pinned as tightly as the true case. Pre-existing enroll tests pass unmodified.

**Test environment caveat.** Per our workflow these should have run on a fresh Containarium Cloud box. Neither prescribed environment was reachable from this session: no `containarium-cloud` MCP server is wired, no `containarium` CLI or cloud enrollment exists here, and the VirtualBox fallback host (`lab-hsin-tailscale`) does not resolve. The runs above are from this session's own sandbox; the suite is hermetic, but the clean-box guarantee is not covered — CI is the first clean-environment signal.

## Compatibility

Wire-compatible and order-independent with the cloud PR: an old host omits the field (the server reads `false`, i.e. guard armed — the safe default), and a new host against an old server has the field ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)