### PR TITLE
fix(sentinel): gate the peer proxy with the admin secret and make rejections uniform (#1102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **The sentinel's peer proxy now requires authentication.**
+  `/peer/<backend-id>/*` on the sentinel's binary-server port forwards to
+  that backend's daemon, and was the only route on that mux registered
+  with no middleware while every neighbouring `/sentinel/*` route was
+  HMAC-gated. The backend-id namespace on a sentinel is flat and global,
+  so anything able to reach that port could address every tunnel-joined
+  backend the sentinel fronts, across all organizations — enumerating
+  them and probing whatever each daemon exposes pre-auth. The daemon's
+  own authentication still stood behind it, so this was a
+  lateral-movement surface rather than an open door, but it is the layer
+  meant to stop the probing. It is now gated by the sentinel **admin**
+  secret, the same authority secret `/sentinel/tunnel-tokens` and
+  `/sentinel/byoc-routes` already use. Rejections are also uniform now:
+  an unknown backend id and a malformed path return a byte-identical 404
+  that no longer echoes the requested id back, so an authorized caller
+  cannot map a sentinel's backends by diffing error responses.
+
+  **Operator action required before upgrading.** A sentinel with no
+  `CONTAINARIUM_SENTINEL_ADMIN_SECRET` set now rejects every `/peer/`
+  request with 401 — fail-closed, since a fail-open fallback would skip
+  the fix precisely on the hosts whose operator never configured the
+  secret. If a control plane drives tunnel-joined backends through this
+  sentinel, set that secret **and** make sure the caller signs its
+  `/peer/` requests before rolling this out; otherwise those backends
+  become undrivable. The sentinel logs this loudly at startup when the
+  secret is absent.
+
 ### Fixed
 
 - **A box is now SSH-reachable as soon as it reports RUNNING** — the

--- a/internal/sentinel/binaryserver.go
+++ b/internal/sentinel/binaryserver.go
@@ -9,11 +9,8 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/footprintai/containarium/internal/auth"
@@ -42,17 +39,13 @@ type StatusJSON struct {
 	SentinelAuthDetail        string `json:"sentinel_auth_detail,omitempty"`
 }
 
-// StartBinaryServer starts an HTTP server that serves the containarium binary
-// for the spot VM to download, plus a /status JSON endpoint.
-// This runs on an internal-only port (default 8888).
-func StartBinaryServer(port int, manager *Manager) (stop func(), err error) {
-	binaryPath := defaultBinaryPath
-
-	// Verify binary exists
-	if _, err := os.Stat(binaryPath); err != nil {
-		return nil, fmt.Errorf("binary not found at %s: %w", binaryPath, err)
-	}
-
+// buildBinaryServerMux registers every binary-server route on a fresh
+// mux. Split out of StartBinaryServer so tests can exercise the REAL
+// route table — in particular which middleware each route is registered
+// behind (#1102). A test that builds its own mux proves only that the
+// handler works when someone remembers to gate it, which is exactly the
+// mistake being fixed here.
+func buildBinaryServerMux(binaryPath string, manager *Manager) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/containarium", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/octet-stream")
@@ -128,35 +121,16 @@ func StartBinaryServer(port int, manager *Manager) (stop func(), err error) {
 	mux.Handle("/sentinel/byoc-routes", auth.SentinelHMACMiddleware(manager.adminSecret, manager.BYOCRouteRegisterHandler()))
 
 	// Peer proxy — forwards /peer/<backend-id>/* to the tunnel backend's loopback
-	// This allows the primary daemon to reach tunnel backends through the sentinel
-	// without needing extra firewall rules for external ports.
-	mux.HandleFunc("/peer/", func(w http.ResponseWriter, r *http.Request) {
-		// Parse path: /peer/<backend-id>/v1/containers → backend-id, /v1/containers
-		path := strings.TrimPrefix(r.URL.Path, "/peer/")
-		slashIdx := strings.Index(path, "/")
-		if slashIdx < 0 {
-			http.Error(w, "invalid peer path", http.StatusBadRequest)
-			return
-		}
-		backendID := path[:slashIdx]
-		remainingPath := path[slashIdx:]
-
-		// Find the backend's loopback IP
-		backend := manager.backends.Get(backendID)
-		if backend == nil {
-			http.Error(w, fmt.Sprintf("backend %q not found", backendID), http.StatusNotFound)
-			return
-		}
-
-		target := &url.URL{
-			Scheme: "http",
-			Host:   fmt.Sprintf("%s:%d", backend.IP, manager.config.HealthPort),
-		}
-		proxy := httputil.NewSingleHostReverseProxy(target)
-		r.URL.Path = remainingPath
-		r.Host = target.Host
-		proxy.ServeHTTP(w, r)
-	})
+	// so the control plane can reach tunnel backends through the sentinel without
+	// extra firewall rules for external ports.
+	//
+	// Gated by the ADMIN secret, like /sentinel/tunnel-tokens and
+	// /sentinel/byoc-routes: driving another machine's daemon is a
+	// control-plane authority operation, and the control plane is the only
+	// legitimate caller. Before #1102 this was the one ungated route on this
+	// mux, which made it an unauthenticated lateral-movement surface across
+	// every tenant's backend for anything that could reach this port.
+	mux.Handle("/peer/", auth.SentinelHMACMiddleware(manager.adminSecret, manager.PeerProxyHandler()))
 
 	// Status JSON endpoint — always available
 	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
@@ -195,6 +169,22 @@ func StartBinaryServer(port int, manager *Manager) (stop func(), err error) {
 	// scraper can alert on the net — the on-spot VictoriaMetrics dies with
 	// the spot it would be reporting on.
 	mux.HandleFunc("/metrics", manager.MetricsHandler())
+
+	return mux
+}
+
+// StartBinaryServer starts an HTTP server that serves the containarium binary
+// for the spot VM to download, plus a /status JSON endpoint.
+// This runs on an internal-only port (default 8888).
+func StartBinaryServer(port int, manager *Manager) (stop func(), err error) {
+	binaryPath := defaultBinaryPath
+
+	// Verify binary exists
+	if _, err := os.Stat(binaryPath); err != nil {
+		return nil, fmt.Errorf("binary not found at %s: %w", binaryPath, err)
+	}
+
+	mux := buildBinaryServerMux(binaryPath, manager)
 
 	srv := &http.Server{
 		Addr:         fmt.Sprintf(":%d", port),

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -340,7 +340,7 @@ func NewManager(config Config, provider CloudProvider) *Manager {
 		}
 		m.adminSecret = []byte(raw)
 	} else {
-		log.Printf("[sentinel] CONTAINARIUM_SENTINEL_ADMIN_SECRET is unset — /sentinel/tunnel-tokens is disabled (fresh tunnel-join tokens can only be added by restarting the sentinel with --tunnel-token-policy)")
+		log.Printf("[sentinel] WARNING: CONTAINARIUM_SENTINEL_ADMIN_SECRET is unset — /sentinel/tunnel-tokens is disabled (fresh tunnel-join tokens can only be added by restarting the sentinel with --tunnel-token-policy), AND /peer/ now rejects every request with 401 (#1102). If a control plane drives tunnel-joined backends through this sentinel, set this secret or those backends become undrivable.")
 	}
 
 	// Phase 0.5: peer-CA bootstrap. Operators provision a single

--- a/internal/sentinel/peer_proxy_handler.go
+++ b/internal/sentinel/peer_proxy_handler.go
@@ -1,0 +1,91 @@
+package sentinel
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+// Peer proxy — `/peer/<backend-id>/*` forwards to that tunnel backend's
+// daemon on the health port, so the control plane can drive a
+// tunnel-joined host without opening extra external ports (#1102).
+//
+// Two properties this handler is responsible for:
+//
+//  1. It is registered behind SentinelHMACMiddleware(adminSecret) in
+//     binaryserver.go. Every neighbouring /sentinel/* route is gated;
+//     this one was not, which made it an unauthenticated hop to every
+//     backend the sentinel fronts. The backend-id namespace here is flat
+//     and global — every tunnel-joined backend across all organizations
+//     is addressable — so an ungated caller could enumerate and probe
+//     other tenants' daemons. The daemon's own auth still stood behind
+//     it, so this closes a lateral-movement surface rather than an open
+//     door, but it is the layer that is supposed to stop the probing.
+//
+//  2. Every rejection is byte-identical. A caller must not be able to
+//     tell "that backend is not on this sentinel" from "that path is
+//     malformed", and the response must never echo the requested id
+//     back. Distinguishable rejections turn an authenticated-but-curious
+//     caller into a fleet enumerator, one id at a time.
+
+// peerNotFoundBody is the single rejection this handler ever produces.
+// Deliberately says nothing about WHY — not the id, not whether it
+// parsed, not whether such a backend exists elsewhere.
+const peerNotFoundBody = "not found"
+
+// PeerProxyHandler reverse-proxies /peer/<backend-id>/<rest> to that
+// backend's daemon. Named-method shape (rather than the previous inline
+// closure) so the gating and the uniform-404 behaviour are testable
+// without standing up the whole binary server — matching CAHandler,
+// PeerCertHandler and TunnelTokenRegisterHandler on this same mux.
+func (m *Manager) PeerProxyHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendID, remainingPath, ok := splitPeerPath(r.URL.Path)
+		if !ok {
+			peerNotFound(w)
+			return
+		}
+
+		backend := m.backends.Get(backendID)
+		if backend == nil {
+			// Same response as a malformed path, on purpose — see the
+			// file comment. Previously this was `backend %q not found`,
+			// which both confirmed the id was well-formed and reflected
+			// it back to the caller.
+			peerNotFound(w)
+			return
+		}
+
+		target := &url.URL{
+			Scheme: "http",
+			Host:   fmt.Sprintf("%s:%d", backend.IP, m.config.HealthPort),
+		}
+		proxy := httputil.NewSingleHostReverseProxy(target)
+		r.URL.Path = remainingPath
+		r.Host = target.Host
+		proxy.ServeHTTP(w, r)
+	})
+}
+
+// splitPeerPath parses `/peer/<backend-id>/<rest>` into its id and the
+// daemon-relative remainder. ok is false for anything that doesn't carry
+// both parts.
+//
+// Note the caller must treat !ok and "unknown backend" identically; this
+// function only reports which it was so the proxy path can be skipped.
+func splitPeerPath(p string) (backendID, remaining string, ok bool) {
+	rest := strings.TrimPrefix(p, "/peer/")
+	slashIdx := strings.Index(rest, "/")
+	if slashIdx <= 0 {
+		// No slash at all (`/peer/abc`), or a leading one (`/peer//v1/x`,
+		// i.e. an empty backend id). Neither addresses a backend.
+		return "", "", false
+	}
+	return rest[:slashIdx], rest[slashIdx:], true
+}
+
+func peerNotFound(w http.ResponseWriter) {
+	http.Error(w, peerNotFoundBody, http.StatusNotFound)
+}

--- a/internal/sentinel/peer_proxy_handler_test.go
+++ b/internal/sentinel/peer_proxy_handler_test.go
@@ -1,0 +1,230 @@
+package sentinel
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+// #1102: /peer/ was the one route on the binary-server mux with no
+// authentication, while every neighbouring /sentinel/* route is HMAC
+// gated. These tests pin both halves of the fix — the gate itself, and
+// the uniform rejection that stops an authorized caller from using the
+// route to enumerate which backends a sentinel fronts.
+
+const testAdminSecret = "peer-proxy-admin-secret-32-bytes-long!"
+
+// newPeerProxyTestServer serves the REAL binary-server route table over
+// a manager holding one backend that points at a stub daemon.
+//
+// It deliberately calls buildBinaryServerMux rather than registering
+// /peer/ itself. An earlier version of this file built its own mux, and
+// mutation testing showed the consequence: removing the HMAC middleware
+// from binaryserver.go entirely — i.e. reverting the whole fix — left
+// every test in this file green, because they were exercising a route
+// table the test had wired correctly by hand. Which middleware a route
+// is registered behind IS the fix for #1102, so it has to be the real
+// registration under test.
+func newPeerProxyTestServer(t *testing.T, adminSecret string) (*httptest.Server, string) {
+	t.Helper()
+
+	// Stub daemon standing in for the backend's health-port listener.
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "daemon saw "+r.URL.Path)
+	}))
+	t.Cleanup(daemon.Close)
+
+	du, err := url.Parse(daemon.URL)
+	if err != nil {
+		t.Fatalf("parse daemon url: %v", err)
+	}
+	port, err := strconv.Atoi(du.Port())
+	if err != nil {
+		t.Fatalf("daemon port: %v", err)
+	}
+
+	m := &Manager{
+		backends:    NewBackendPool(),
+		adminSecret: []byte(adminSecret),
+	}
+	m.config.HealthPort = port
+	m.backends.Add(&Backend{ID: "tunnel-known-1", Type: BackendTunnel, IP: du.Hostname()})
+
+	// binaryPath only feeds the /containarium download routes, which these
+	// tests never call; a path that doesn't exist is fine here (StartBinaryServer
+	// is what stats it, and we deliberately don't go through that — it binds a
+	// real port and requires the installed binary).
+	srv := httptest.NewServer(buildBinaryServerMux("/nonexistent/containarium", m))
+	t.Cleanup(srv.Close)
+	return srv, daemon.URL
+}
+
+// doPeer issues a request to path, signing it with secret when signed.
+func doPeer(t *testing.T, srv *httptest.Server, path, secret string, signed bool) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, srv.URL+path, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if signed {
+		auth.SignSentinelRequest(req, []byte(secret))
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+// TestPeerProxy_UnsignedRequestRejected is the core of #1102: this route
+// used to serve anyone who could reach the port.
+func TestPeerProxy_UnsignedRequestRejected(t *testing.T) {
+	srv, _ := newPeerProxyTestServer(t, testAdminSecret)
+
+	code, _ := doPeer(t, srv, "/peer/tunnel-known-1/v1/containers", "", false)
+	if code != http.StatusUnauthorized {
+		t.Errorf("unsigned /peer/ = %d, want 401 — the route must not be reachable unauthenticated", code)
+	}
+}
+
+// TestPeerProxy_WrongSecretRejected: holding *a* sentinel secret is not
+// enough. The daemon-wide HMAC secret is distributed to every backend
+// host; the admin secret is the control plane's. Gating on the wrong one
+// would leave the route reachable from any host in the fleet, which is
+// exactly the population #1102 is worried about.
+func TestPeerProxy_WrongSecretRejected(t *testing.T) {
+	srv, _ := newPeerProxyTestServer(t, testAdminSecret)
+
+	code, _ := doPeer(t, srv, "/peer/tunnel-known-1/v1/containers", "a-different-secret-of-sufficient-length", true)
+	if code != http.StatusUnauthorized {
+		t.Errorf("wrongly-signed /peer/ = %d, want 401", code)
+	}
+}
+
+// TestPeerProxy_SignedRequestProxies is the control. Without it every
+// assertion here would pass on a route that rejects everything.
+func TestPeerProxy_SignedRequestProxies(t *testing.T) {
+	srv, _ := newPeerProxyTestServer(t, testAdminSecret)
+
+	code, body := doPeer(t, srv, "/peer/tunnel-known-1/v1/containers", testAdminSecret, true)
+	if code != http.StatusOK {
+		t.Fatalf("signed /peer/ = %d, want 200: %s", code, body)
+	}
+	// The daemon must receive the path with the /peer/<id> prefix
+	// stripped — the proxy rewrite still has to work behind the gate.
+	if want := "daemon saw /v1/containers"; body != want {
+		t.Errorf("daemon got %q, want %q", body, want)
+	}
+}
+
+// TestPeerProxy_UnknownBackendIsNotDistinguishable is the enumeration
+// half. A caller past the gate must not be able to map which backends
+// this sentinel fronts by diffing rejections — the id namespace is flat
+// and global across every org on the sentinel.
+func TestPeerProxy_UnknownBackendIsNotDistinguishable(t *testing.T) {
+	srv, _ := newPeerProxyTestServer(t, testAdminSecret)
+
+	unknownCode, unknownBody := doPeer(t, srv, "/peer/tunnel-someone-elses/v1/containers", testAdminSecret, true)
+	malformedCode, malformedBody := doPeer(t, srv, "/peer/tunnel-someone-elses", testAdminSecret, true)
+
+	if unknownCode != http.StatusNotFound {
+		t.Errorf("unknown backend = %d, want 404", unknownCode)
+	}
+	if malformedCode != unknownCode {
+		t.Errorf("malformed path = %d but unknown backend = %d; rejections must be indistinguishable",
+			malformedCode, unknownCode)
+	}
+	if malformedBody != unknownBody {
+		t.Errorf("rejection bodies differ:\n malformed: %q\n unknown:   %q", malformedBody, unknownBody)
+	}
+}
+
+// TestPeerProxy_RejectionDoesNotEchoBackendID: the old handler replied
+// `backend "tunnel-x" not found`, reflecting caller-controlled input
+// straight back. Beyond confirming the id parsed, a reflected value in
+// an error body is the ingredient for response-splitting and for
+// log-poisoning downstream.
+func TestPeerProxy_RejectionDoesNotEchoBackendID(t *testing.T) {
+	srv, _ := newPeerProxyTestServer(t, testAdminSecret)
+
+	const probe = "tunnel-victim-org-gpu-box"
+	_, body := doPeer(t, srv, "/peer/"+probe+"/v1/containers", testAdminSecret, true)
+	if strings.Contains(body, probe) {
+		t.Errorf("rejection echoed the requested backend id back: %q", body)
+	}
+}
+
+// TestPeerProxy_EmptyBackendIDRejected: `/peer//v1/x` parses to an empty
+// id, which BackendPool.Get would look up as "" — a miss today, but the
+// handler must not depend on that staying true. Rejected at parse time.
+//
+// Driven against the handler directly rather than through the test
+// server: both net/http's client and ServeMux collapse the `//` before
+// the handler ever sees it, so an end-to-end request cannot express this
+// input at all (it arrives as `/peer/v1/containers`, a different case).
+// Going through the stack here would test URL normalization and report
+// it as coverage of this guard.
+func TestPeerProxy_EmptyBackendIDRejected(t *testing.T) {
+	m := &Manager{backends: NewBackendPool(), adminSecret: []byte(testAdminSecret)}
+
+	req := httptest.NewRequest(http.MethodGet, "http://sentinel/x", nil)
+	req.URL.Path = "/peer//v1/containers" // set post-parse so it survives verbatim
+	rec := httptest.NewRecorder()
+
+	m.PeerProxyHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("empty backend id = %d, want 404", rec.Code)
+	}
+}
+
+// TestPeerProxy_UnconfiguredAdminSecretFailsClosed pins the deployment
+// contract, and it is the one behaviour change an operator can be bitten
+// by: a sentinel with no CONTAINARIUM_SENTINEL_ADMIN_SECRET now refuses
+// the peer proxy outright rather than serving it to anyone.
+//
+// Fail-closed is the deliberate choice — a fail-open fallback would mean
+// the fix is absent exactly on the hosts whose operator never configured
+// the secret, which is the population most likely to need it. NewManager
+// logs this at startup so it is diagnosable.
+func TestPeerProxy_UnconfiguredAdminSecretFailsClosed(t *testing.T) {
+	srv, _ := newPeerProxyTestServer(t, "")
+
+	code, _ := doPeer(t, srv, "/peer/tunnel-known-1/v1/containers", "", false)
+	if code != http.StatusUnauthorized {
+		t.Errorf("unconfigured admin secret = %d, want 401 (fail closed)", code)
+	}
+}
+
+func TestSplitPeerPath(t *testing.T) {
+	tests := []struct {
+		name, path      string
+		wantID, wantRem string
+		wantOK          bool
+	}{
+		{"normal", "/peer/tunnel-a/v1/containers", "tunnel-a", "/v1/containers", true},
+		{"root path", "/peer/tunnel-a/", "tunnel-a", "/", true},
+		{"nested", "/peer/tunnel-a/v1/containers/abc/ssh-keys", "tunnel-a", "/v1/containers/abc/ssh-keys", true},
+		{"no trailing segment", "/peer/tunnel-a", "", "", false},
+		{"empty id", "/peer//v1/containers", "", "", false},
+		{"bare prefix", "/peer/", "", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, rem, ok := splitPeerPath(tc.path)
+			if ok != tc.wantOK || id != tc.wantID || rem != tc.wantRem {
+				t.Errorf("splitPeerPath(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.path, id, rem, ok, tc.wantID, tc.wantRem, tc.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1102.

`/peer/<backend-id>/*` reverse-proxies to that backend's daemon and was the only route on the binary-server mux registered with no middleware, while every neighbouring `/sentinel/*` route was HMAC-gated. Now gated by the **admin** secret — the same authority secret `/sentinel/tunnel-tokens` and `/sentinel/byoc-routes` already use, since driving another machine's daemon is the same class of operation.

- **Gated** — `auth.SentinelHMACMiddleware(manager.adminSecret, …)`, per the issue's suggested fix 1.
- **Uniform rejections** — an unknown backend id and a malformed path now return a byte-identical 404. Previously they differed (404 vs 400) *and* the 404 echoed the requested id back (`backend "tunnel-x" not found`), so an authorized caller could map a sentinel's backends by diffing error responses. Suggested fix 2.
- **Tests** for both, plus the parse helper. Suggested fix 3.

Suggested fix 4 (narrowing the Terraform rule so tenant-workload hosts can't reach the port at all) is **not** in this PR — it's an infrastructure change, not a daemon one, and it stays worth doing as defence in depth even with this landed.

## ⚠️ Read this before merging: deployment order

**A caller that does not sign its `/peer/` requests gets a 401 after this lands.** Any control plane driving tunnel-joined backends through a sentinel must be signing *before* this is deployed, or those backends become undrivable.

**Operator action:** a sentinel with no `CONTAINARIUM_SENTINEL_ADMIN_SECRET` now rejects **every** `/peer/` request. That secret is currently optional — unset is a supported configuration that only disables `/sentinel/tunnel-tokens` — so this makes it mandatory for anyone using the peer proxy.

Fail-closed is deliberate. A fail-open fallback ("no secret ⇒ serve unauthenticated") would skip the fix precisely on the hosts whose operator never configured the secret, which is the population most likely to need it. To keep the failure diagnosable rather than mysterious, the existing startup log line now says so explicitly, and `CHANGELOG.md` carries the operator note.

## Review this first: the tests were wrong in an instructive way

Every property here was verified by **mutation** — breaking the code and confirming the right tests fail. The first version of this test file built its own mux and registered the middleware itself. All tests passed. They also passed with the middleware removed from `binaryserver.go` **entirely** — that is, with the whole fix reverted — because they were exercising a route table the test had wired up correctly by hand.

Which middleware a route sits behind *is* the fix for #1102, so the registration itself has to be under test. That is the only reason `buildBinaryServerMux` is split out of `StartBinaryServer`: `StartBinaryServer` stats `/usr/local/bin/containarium` and binds a real port, so it can't be called from a test, and the route table was unreachable without the split. No route registration changed in the extraction other than `/peer/`.

## Test evidence

11 assertions across 7 tests + 6 table cases, all green:

| Property | Test |
|---|---|
| Unsigned request rejected | `TestPeerProxy_UnsignedRequestRejected` |
| Daemon-wide HMAC secret is *not* sufficient (only the admin secret is) | `TestPeerProxy_WrongSecretRejected` |
| Signed request still proxies, prefix correctly stripped | `TestPeerProxy_SignedRequestProxies` |
| Unknown id vs malformed path indistinguishable | `TestPeerProxy_UnknownBackendIsNotDistinguishable` |
| Rejection never echoes the requested id | `TestPeerProxy_RejectionDoesNotEchoBackendID` |
| Empty backend id rejected at parse time | `TestPeerProxy_EmptyBackendIDRejected` |
| No admin secret ⇒ fails closed | `TestPeerProxy_UnconfiguredAdminSecretFailsClosed` |
| Path parsing | `TestSplitPeerPath` (6 cases) |

`TestPeerProxy_WrongSecretRejected` earns its place: gating on the daemon-wide `hmacSecret` instead of `adminSecret` would look correct and still leave the route reachable from every backend host in the fleet — which is exactly the population the issue identifies as the realistic attacker location.

`TestPeerProxy_EmptyBackendIDRejected` drives the handler directly rather than going through the server, because both `net/http`'s client and `ServeMux` collapse `//` before a handler sees it. Routing it through the stack would have tested URL normalization and reported it as coverage of the guard.

### Mutation log

| Mutation | Caught by |
|---|---|
| Middleware removed from the `/peer/` registration (pre-fix state) | `UnsignedRequestRejected`, `WrongSecretRejected`, `UnconfiguredAdminSecretFailsClosed` |
| Gated on `hmacSecret` instead of `adminSecret` | `SignedRequestProxies`, `UnknownBackendIsNotDistinguishable` |
| Old echoing/distinguishable 404 restored | `UnknownBackendIsNotDistinguishable`, `RejectionDoesNotEchoBackendID` |

The first two are the ones that escaped the hand-built mux and drove the `buildBinaryServerMux` split.

```
$ go test ./internal/sentinel/ -run 'TestPeerProxy|TestSplitPeerPath'
ok  	github.com/footprintai/containarium/internal/sentinel	0.010s

$ go test ./internal/...
(44 packages ok)
```

`go vet` and `gofmt -l` are clean.

**Two pre-existing failures in `internal/sentinel` are unrelated to this change** and were confirmed on a clean tree at `95eab9b` with these files removed: `TestEnableForwardingOnNonLinux` (`expected nil error on non-Linux` — the test's premise doesn't hold in a Linux dev container with iptables present) and `TestRegisterPropagatesPool`.

### Test-environment caveat

Built and tested in a Linux container with a Go toolchain matching `go.mod`; no dedicated clean-box environment was reachable from this session, so CI is the first independent signal.
