### PR TITLE
feat(hostcheck): add a host security-posture check group, reported separately from capability (#1103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`containarium doctor` now reports host security posture**, as its own
+  advisory section alongside the existing capability checks. For BYOC the
+  machine is the customer's, from an image we did not build, so "can this
+  host run workloads" and "is it safe to run them here" are different
+  questions — and until now only the first was ever asked. The new group
+  covers data-volume encryption (dm-crypt), Secure Boot, auditd, sshd
+  hardening (`PermitRootLogin` / `PasswordAuthentication`), unattended
+  security upgrades, and whether the cloud metadata endpoint is reachable
+  from the host. The daemon reports them to the control plane through the
+  existing status probe, so a control plane records posture per host with
+  no contract change.
+
+  Two properties worth knowing. **A check that cannot gather evidence
+  reports unmet, never a pass** — the point is to distinguish what we can
+  attest from what we cannot, and a check that passed on no evidence would
+  manufacture the assurance it is supposed to establish. So an ordinary
+  unhardened host will show several unmet items, including ones that may
+  well be fine (provider-managed disk encryption, for instance, is
+  invisible from inside the guest and is reported as unobservable rather
+  than absent). **Nothing here blocks anything**: posture checks are
+  advisory, `doctor`'s exit code is unchanged, and the daemon's
+  `self_check_ok` is still derived from the capability checks alone.
+
 ### Fixed
 
 - **A box is now SSH-reachable as soon as it reports RUNNING** — the

--- a/internal/cloud/probe.go
+++ b/internal/cloud/probe.go
@@ -35,9 +35,21 @@ func (DefaultStatusProbe) Probe(_ context.Context) (HostStatus, error) {
 	totalDisk, availDisk := diskGB()
 	gpuCount, gpuSpec := gpuInfo()
 	raw := hostcheck.Run()
-	checks := make([]HostCheck, 0, len(raw))
+	// Host security posture (#1103) rides along in the same self-check
+	// list, which is what makes this additive: the cloud already stores
+	// Checks per host, so it records posture with no contract change.
+	//
+	// SelfCheckOK below is deliberately derived from `raw` ONLY. Posture
+	// checks are advisory, and folding them in would flip healthy hosts
+	// to self_check_ok=false — turning a hardening advisory into a
+	// scheduling signal, which is the product decision #1103 leaves open.
+	posture := hostcheck.RunPosture()
+	checks := make([]HostCheck, 0, len(raw)+len(posture))
 	for _, c := range raw {
-		checks = append(checks, HostCheck{Name: c.Name, OK: c.OK, Detail: c.Detail})
+		checks = append(checks, HostCheck{Name: c.WireName(), OK: c.OK, Detail: c.Detail})
+	}
+	for _, c := range posture {
+		checks = append(checks, HostCheck{Name: c.WireName(), OK: c.OK, Detail: c.Detail})
 	}
 	return HostStatus{
 		AgentVersion:  version.GetVersion(),

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -51,10 +51,47 @@ func hostDoctorChecks() []hostcheck.Check { return hostcheck.Run() }
 func runDoctor(cmd *cobra.Command, args []string) error {
 	checks := hostDoctorChecks()
 	failed := printDoctor(checks)
+
+	// Host security posture (#1103), printed as its own section and NOT
+	// folded into `failed`. The separation is the point: for BYOC the
+	// machine is the customer's, so "can run workloads" and "is safe to
+	// run them on" are different questions and a functional pass must not
+	// read as a security pass. Whether a posture miss should block is an
+	// open product decision, so nothing here changes the exit code.
+	printPosture(hostcheck.RunPosture())
+
 	if failed > 0 {
 		return fmt.Errorf("doctor: %d required check(s) failed — this host cannot run the daemon's user management until fixed (see prd daemon-deploy-contract)", failed)
 	}
 	return nil
+}
+
+// printPosture renders the posture group. Returns nothing on purpose —
+// there is no count to act on, because no posture result gates anything.
+func printPosture(checks []hostcheck.Check) {
+	if len(checks) == 0 {
+		return
+	}
+	unmet := 0
+	fmt.Println()
+	fmt.Println("Host security posture (advisory — does not affect the exit code):")
+	for _, c := range checks {
+		mark := "✓"
+		if !c.OK {
+			mark = "!"
+			unmet++
+		}
+		line := fmt.Sprintf("  %s %s", mark, c.Name)
+		if c.Detail != "" {
+			line += " — " + c.Detail
+		}
+		fmt.Println(line)
+	}
+	if unmet > 0 {
+		fmt.Printf("\n  %d posture item(s) unmet or unverifiable. A check that could not gather\n"+
+			"  evidence reports unmet rather than passing, so this list is what we can and\n"+
+			"  cannot attest about this host — not a claim that each one is misconfigured.\n", unmet)
+	}
 }
 
 // logStartupSelfCheck runs the host capability self-check at daemon boot and

--- a/internal/hostcheck/check.go
+++ b/internal/hostcheck/check.go
@@ -10,13 +10,47 @@
 // importable from the cross-platform internal/cloud.
 package hostcheck
 
-// Check is one capability-self-check result. Required=true means a failure
-// blocks the host from running the daemon's per-tenant user management.
+// CheckKind separates the two question types so a functional pass is never
+// mistaken for a security pass. A string rather than an int enum because it
+// crosses to the cloud inside a check name (see WireName) until the proto
+// gains a typed field.
+//
+// Declared here rather than beside the posture checks because this file has
+// no build constraint: the Windows stub build must still see the type.
+type CheckKind string
+
+const (
+	// KindCapability — "can the daemon operate here" (run.go).
+	KindCapability CheckKind = "capability"
+	// KindPosture — "is this host hardened" (posture.go).
+	KindPosture CheckKind = "posture"
+)
+
+// Check is one self-check result. Required=true means a failure blocks the
+// host from running the daemon's per-tenant user management.
 type Check struct {
 	Name     string
 	OK       bool
 	Required bool
 	Detail   string
+	// Kind separates "can the daemon operate here" (KindCapability) from
+	// "is this host hardened" (KindPosture, #1103). The zero value reads as
+	// capability so every pre-existing construction site keeps its meaning
+	// without being touched.
+	Kind CheckKind
+}
+
+// WireName is the check's name as reported to the control plane. Posture
+// checks are prefixed so the two groups stay distinguishable across a wire
+// format that currently carries only {name, ok, detail} — without it a
+// hardening warning would be indistinguishable from a capability failure in
+// the cloud's stored self-check, which is exactly the conflation #1103 is
+// about. Replace with a typed proto field when the contract gains one.
+func (c Check) WireName() string {
+	if c.Kind == KindPosture {
+		return "posture: " + c.Name
+	}
+	return c.Name
 }
 
 // AllRequiredPass reports whether every required check in cs passed. Used by

--- a/internal/hostcheck/posture.go
+++ b/internal/hostcheck/posture.go
@@ -115,7 +115,7 @@ func runPosture(p posturePaths) []Check {
 func diskEncryptionCheck(p posturePaths) Check {
 	c := Check{Name: "data volume encrypted (dm-crypt)"}
 
-	mounts, err := os.ReadFile(p.procMounts)
+	mounts, err := os.ReadFile(p.procMounts) // #nosec G304 -- package-owned constant (/proc/mounts), overridden only by tests
 	if err != nil {
 		c.Detail = fmt.Sprintf("could not determine: reading %s: %v", p.procMounts, err)
 		return c
@@ -126,8 +126,8 @@ func diskEncryptionCheck(p posturePaths) Check {
 		return c
 	}
 
-	dmName := strings.TrimPrefix(dev, "/dev/")
-	uuid, err := os.ReadFile(filepath.Join(p.sysBlock, dmName, "dm", "uuid"))
+	dmName := resolveDMName(dev)
+	uuid, err := os.ReadFile(filepath.Join(p.sysBlock, dmName, "dm", "uuid")) // #nosec G304,G703 -- resolveDMName Base()-bounds dmName to a single path segment so no traversal is reachable; gosec cannot see that through the call. sysBlock is a package-owned constant.
 	if err != nil {
 		// Not a device-mapper device at all — a plain partition. That is a
 		// definite negative for guest-visible encryption, not an unknown.
@@ -170,6 +170,29 @@ func deviceForPath(procMounts, target string) (device, mountPoint string) {
 	return device, mountPoint
 }
 
+// resolveDMName maps a device path from /proc/mounts to the name
+// /sys/block is keyed by.
+//
+// Not cosmetic. /sys/block uses the KERNEL name (dm-0), while /proc/mounts
+// usually carries the device-mapper ALIAS (/dev/mapper/cryptdata), a symlink
+// to it. Without resolving, /sys/block/mapper/cryptdata does not exist and
+// every LUKS host reports "not dm-crypt" — a false negative on exactly the
+// hosts that ARE encrypted, which is the worst direction for this check to be
+// wrong in. Best-effort: an unresolvable path falls through to Base and simply
+// misses, i.e. no worse than not trying.
+//
+// Base() also bounds the result to a single path segment, so a hostile
+// /proc/mounts line cannot traverse out of the sysBlock root. /proc/mounts is
+// kernel-owned so that is defence in depth, but this runs as root and the
+// bound is one call.
+func resolveDMName(dev string) string {
+	resolved := dev
+	if r, err := filepath.EvalSymlinks(dev); err == nil {
+		resolved = r
+	}
+	return filepath.Base(resolved)
+}
+
 // --- secure boot -----------------------------------------------------
 
 // secureBootCheck reads the EFI SecureBoot variable. Absence of the
@@ -195,7 +218,8 @@ func secureBootCheck(p posturePaths) Check {
 		c.Detail = "could not determine: no SecureBoot-* efivar present"
 		return c
 	}
-	raw, err := os.ReadFile(filepath.Join(p.efiVars, name))
+	// Base() bounds the ReadDir-derived name to one segment.
+	raw, err := os.ReadFile(filepath.Join(p.efiVars, filepath.Base(name))) // #nosec G304 -- efiVars is a package-owned constant; name is Base()-bounded
 	if err != nil {
 		c.Detail = fmt.Sprintf("could not determine: reading %s: %v", name, err)
 		return c
@@ -231,7 +255,7 @@ func parseSecureBootVar(raw []byte) (enabled, ok bool) {
 // in fact running auditd.
 func auditdCheck(p posturePaths) Check {
 	c := Check{Name: "auditd running"}
-	data, err := os.ReadFile(p.auditdPID)
+	data, err := os.ReadFile(p.auditdPID) // #nosec G304 -- package-owned constant (/run/auditd.pid), overridden only by tests
 	if err != nil {
 		if os.IsNotExist(err) {
 			c.Detail = "no " + p.auditdPID + ": auditd is not running, so host-level audit trail is absent"
@@ -293,7 +317,7 @@ func sshdConfigCheck(p posturePaths) Check {
 // override the main file — get this order backwards and the check
 // reports the overridden value.
 func readSSHDConfig(mainPath, dropInDir string) (string, error) {
-	main, err := os.ReadFile(mainPath)
+	main, err := os.ReadFile(mainPath) // #nosec G304 -- mainPath is a package-owned constant (/etc/ssh/sshd_config), overridden only by tests
 	if err != nil {
 		return "", fmt.Errorf("reading %s: %w", mainPath, err)
 	}
@@ -308,7 +332,7 @@ func readSSHDConfig(mainPath, dropInDir string) (string, error) {
 		}
 		sort.Strings(names) // sshd globs *.conf; lexical order is what it gets
 		for _, n := range names {
-			d, rerr := os.ReadFile(filepath.Join(dropInDir, n))
+			d, rerr := os.ReadFile(filepath.Join(dropInDir, filepath.Base(n))) // #nosec G304 -- dropInDir is a package-owned constant; n is Base()-bounded
 			if rerr != nil {
 				continue
 			}
@@ -357,7 +381,7 @@ func sshdDirective(config, key, def string) string {
 // the equivalent mechanism differs (dnf-automatic, etc.).
 func unattendedUpgradesCheck(p posturePaths) Check {
 	c := Check{Name: "unattended security upgrades enabled"}
-	data, err := os.ReadFile(p.aptPeriodic)
+	data, err := os.ReadFile(p.aptPeriodic) // #nosec G304 -- package-owned constant, overridden only by tests
 	if err != nil {
 		if os.IsNotExist(err) {
 			c.Detail = "could not determine: " + p.aptPeriodic +

--- a/internal/hostcheck/posture.go
+++ b/internal/hostcheck/posture.go
@@ -1,0 +1,448 @@
+//go:build !windows
+
+package hostcheck
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Host security-posture checks (#1103).
+//
+// The capability checks in run.go answer "can this host run workloads".
+// These answer "is it safe to run them here" — a different question that
+// for enterprise BYOC is the load-bearing one, because the machine is
+// supplied by the customer, in the customer's account, from an image we
+// did not build.
+//
+// Three rules govern everything in this file:
+//
+//  1. **Unknown is never OK.** A check that cannot measure its property
+//     reports NOT-OK with a "could not determine" detail. The whole
+//     premise of #1103 is that we cannot evidence a dedication claim, so
+//     a check that silently passes when it learned nothing would
+//     manufacture exactly the false assurance being complained about.
+//     The practical effect — an ordinary unhardened host lights up with
+//     warnings — is the finding, not a defect.
+//
+//  2. **Non-blocking.** Every posture check is Required=false, so
+//     AllRequiredPass (and therefore the cloud's self_check_ok, and
+//     `doctor`'s exit code) is unchanged. Whether a posture miss should
+//     block enrollment is a product decision (#1103 fix 5) that this
+//     code deliberately leaves open.
+//
+//  3. **Say what was measured, not what was hoped.** Details name the
+//     evidence — the file read, the value found — so a reviewer can
+//     re-derive the verdict by hand. "Not encrypted" and "could not tell
+//     whether it is encrypted" are different claims and are reported
+//     differently.
+
+// posturePaths are the host files the posture checks read. Grouped into
+// a struct so tests can point every check at a temp tree instead of the
+// real host — a posture check that can only be tested on a correctly
+// hardened machine is a posture check nobody will ever run red.
+type posturePaths struct {
+	procMounts     string // /proc/mounts
+	sysBlock       string // /sys/block
+	efiVars        string // /sys/firmware/efi/efivars
+	auditdPID      string // /run/auditd.pid
+	sshdConfig     string // /etc/ssh/sshd_config
+	sshdConfigDir  string // /etc/ssh/sshd_config.d
+	aptPeriodic    string // /etc/apt/apt.conf.d/20auto-upgrades
+	incusDataDir   string // /var/lib/incus — the volume that holds tenant data
+	metadataDialer func() error
+}
+
+func defaultPosturePaths() posturePaths {
+	return posturePaths{
+		procMounts:     "/proc/mounts",
+		sysBlock:       "/sys/block",
+		efiVars:        "/sys/firmware/efi/efivars",
+		auditdPID:      "/run/auditd.pid",
+		sshdConfig:     "/etc/ssh/sshd_config",
+		sshdConfigDir:  "/etc/ssh/sshd_config.d",
+		aptPeriodic:    "/etc/apt/apt.conf.d/20auto-upgrades",
+		incusDataDir:   "/var/lib/incus",
+		metadataDialer: dialMetadataServer,
+	}
+}
+
+// RunPosture executes every host security-posture check.
+//
+// Separate from Run() rather than appended to it, deliberately: Run()'s
+// result feeds AllRequiredPass, which drives the cloud's self_check_ok
+// and the daemon's startup self-check. Folding posture into it would
+// couple a hardening verdict to a liveness verdict, and any later change
+// to a posture check's Required flag would silently start gating
+// container creation.
+func RunPosture() []Check {
+	return runPosture(defaultPosturePaths())
+}
+
+func runPosture(p posturePaths) []Check {
+	checks := []Check{
+		diskEncryptionCheck(p),
+		secureBootCheck(p),
+		auditdCheck(p),
+		sshdConfigCheck(p),
+		unattendedUpgradesCheck(p),
+		metadataReachableCheck(p),
+	}
+	for i := range checks {
+		checks[i].Kind = KindPosture
+		checks[i].Required = false
+	}
+	return checks
+}
+
+// --- disk encryption -------------------------------------------------
+
+// diskEncryptionCheck reports whether the volume holding tenant data is
+// backed by a dm-crypt device.
+//
+// Deliberately narrow about what a pass means. Guest-visible dm-crypt is
+// the only encryption this host can PROVE; provider-managed at-rest
+// encryption (GCP CMEK/CSEK, EBS encryption) is invisible from inside
+// the guest, so its absence here is "not observable", not "absent". The
+// detail says so, because on a cloud BYOC host that is the likely case
+// and a reviewer must not read this as "the customer's disk is
+// plaintext".
+func diskEncryptionCheck(p posturePaths) Check {
+	c := Check{Name: "data volume encrypted (dm-crypt)"}
+
+	mounts, err := os.ReadFile(p.procMounts)
+	if err != nil {
+		c.Detail = fmt.Sprintf("could not determine: reading %s: %v", p.procMounts, err)
+		return c
+	}
+	dev, mountPoint := deviceForPath(string(mounts), p.incusDataDir)
+	if dev == "" {
+		c.Detail = fmt.Sprintf("could not determine: no mount in %s covers %s", p.procMounts, p.incusDataDir)
+		return c
+	}
+
+	dmName := strings.TrimPrefix(dev, "/dev/")
+	uuid, err := os.ReadFile(filepath.Join(p.sysBlock, dmName, "dm", "uuid"))
+	if err != nil {
+		// Not a device-mapper device at all — a plain partition. That is a
+		// definite negative for guest-visible encryption, not an unknown.
+		c.Detail = fmt.Sprintf("%s (mounted at %s) is not a dm-crypt device; "+
+			"provider-managed encryption (e.g. CMEK) cannot be observed from inside the guest and is neither confirmed nor ruled out",
+			dev, mountPoint)
+		return c
+	}
+	if !strings.HasPrefix(strings.TrimSpace(string(uuid)), "CRYPT-") {
+		c.Detail = fmt.Sprintf("%s is device-mapper but not dm-crypt (uuid %q)", dev, strings.TrimSpace(string(uuid)))
+		return c
+	}
+	c.OK = true
+	c.Detail = fmt.Sprintf("%s backing %s is dm-crypt", dev, mountPoint)
+	return c
+}
+
+// deviceForPath finds the device whose mount point is the longest prefix
+// of target — i.e. the filesystem that actually holds it. Longest-prefix
+// matters: with both "/" and "/var/lib/incus" mounted, the naive first
+// match is "/" and the check would inspect the wrong volume.
+func deviceForPath(procMounts, target string) (device, mountPoint string) {
+	best := -1
+	for _, line := range strings.Split(procMounts, "\n") {
+		f := strings.Fields(line)
+		if len(f) < 2 {
+			continue
+		}
+		dev, mp := f[0], f[1]
+		if !strings.HasPrefix(dev, "/dev/") {
+			continue // tmpfs, proc, cgroup…
+		}
+		if mp != "/" && !strings.HasPrefix(target, strings.TrimSuffix(mp, "/")+"/") && target != mp {
+			continue
+		}
+		if len(mp) > best {
+			best, device, mountPoint = len(mp), dev, mp
+		}
+	}
+	return device, mountPoint
+}
+
+// --- secure boot -----------------------------------------------------
+
+// secureBootCheck reads the EFI SecureBoot variable. Absence of the
+// efivars tree at all means legacy BIOS boot, which is a definite
+// negative: there is no measured-boot capability to enable.
+func secureBootCheck(p posturePaths) Check {
+	c := Check{Name: "secure boot enabled"}
+
+	entries, err := os.ReadDir(p.efiVars)
+	if err != nil {
+		c.Detail = "not an EFI system (no efivars): legacy BIOS boot has no measured-boot capability"
+		return c
+	}
+	// The variable is SecureBoot-<vendor-guid>; the guid is not fixed.
+	var name string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "SecureBoot-") {
+			name = e.Name()
+			break
+		}
+	}
+	if name == "" {
+		c.Detail = "could not determine: no SecureBoot-* efivar present"
+		return c
+	}
+	raw, err := os.ReadFile(filepath.Join(p.efiVars, name))
+	if err != nil {
+		c.Detail = fmt.Sprintf("could not determine: reading %s: %v", name, err)
+		return c
+	}
+	on, ok := parseSecureBootVar(raw)
+	if !ok {
+		c.Detail = fmt.Sprintf("could not determine: %s is %d bytes, want 5", name, len(raw))
+		return c
+	}
+	if !on {
+		c.Detail = "SecureBoot efivar is 0 (disabled)"
+		return c
+	}
+	c.OK = true
+	c.Detail = "SecureBoot efivar is 1"
+	return c
+}
+
+// parseSecureBootVar decodes an efivars blob: 4 bytes of attributes
+// followed by the value. ok=false if it isn't that shape.
+func parseSecureBootVar(raw []byte) (enabled, ok bool) {
+	if len(raw) != 5 {
+		return false, false
+	}
+	return raw[4] == 1, true
+}
+
+// --- auditd ----------------------------------------------------------
+
+// auditdCheck looks for auditd's pidfile. Pidfile rather than shelling
+// out to systemctl: the daemon may run where systemd isn't reachable,
+// and a missing systemctl would report as "unknown" on a host that is
+// in fact running auditd.
+func auditdCheck(p posturePaths) Check {
+	c := Check{Name: "auditd running"}
+	data, err := os.ReadFile(p.auditdPID)
+	if err != nil {
+		if os.IsNotExist(err) {
+			c.Detail = "no " + p.auditdPID + ": auditd is not running, so host-level audit trail is absent"
+			return c
+		}
+		c.Detail = fmt.Sprintf("could not determine: reading %s: %v", p.auditdPID, err)
+		return c
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		c.Detail = "could not determine: " + p.auditdPID + " is empty"
+		return c
+	}
+	c.OK = true
+	c.Detail = "auditd pidfile present (pid " + strings.TrimSpace(string(data)) + ")"
+	return c
+}
+
+// --- sshd ------------------------------------------------------------
+
+// sshdConfigCheck requires BOTH interactive-SSH constraints: root login
+// off and password auth off. One without the other is not a pass — a box
+// that permits passwords is brute-forceable whether or not root is
+// reachable directly.
+func sshdConfigCheck(p posturePaths) Check {
+	c := Check{Name: "sshd hardened (no root login, no password auth)"}
+
+	merged, err := readSSHDConfig(p.sshdConfig, p.sshdConfigDir)
+	if err != nil {
+		c.Detail = fmt.Sprintf("could not determine: %v", err)
+		return c
+	}
+
+	rootLogin := sshdDirective(merged, "PermitRootLogin", "prohibit-password")
+	passwordAuth := sshdDirective(merged, "PasswordAuthentication", "yes")
+
+	var bad []string
+	// "yes" is the only outright-permissive PermitRootLogin. The default
+	// (prohibit-password) allows key-based root, which is normal for
+	// cloud images and not what this check is about.
+	if strings.EqualFold(rootLogin, "yes") {
+		bad = append(bad, "PermitRootLogin="+rootLogin)
+	}
+	if !strings.EqualFold(passwordAuth, "no") {
+		bad = append(bad, "PasswordAuthentication="+passwordAuth)
+	}
+	if len(bad) > 0 {
+		c.Detail = strings.Join(bad, ", ")
+		return c
+	}
+	c.OK = true
+	c.Detail = fmt.Sprintf("PermitRootLogin=%s, PasswordAuthentication=%s", rootLogin, passwordAuth)
+	return c
+}
+
+// readSSHDConfig concatenates the main config with its drop-in
+// directory, in the order sshd itself would read them: an Include is
+// expanded where it appears, and modern distros put the Include at the
+// TOP of sshd_config. Since first-match-wins (below), drop-ins therefore
+// override the main file — get this order backwards and the check
+// reports the overridden value.
+func readSSHDConfig(mainPath, dropInDir string) (string, error) {
+	main, err := os.ReadFile(mainPath)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", mainPath, err)
+	}
+	var b strings.Builder
+	entries, derr := os.ReadDir(dropInDir)
+	if derr == nil {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			if strings.HasSuffix(e.Name(), ".conf") {
+				names = append(names, e.Name())
+			}
+		}
+		sort.Strings(names) // sshd globs *.conf; lexical order is what it gets
+		for _, n := range names {
+			d, rerr := os.ReadFile(filepath.Join(dropInDir, n))
+			if rerr != nil {
+				continue
+			}
+			b.Write(d)
+			b.WriteString("\n")
+		}
+	}
+	b.Write(main)
+	return b.String(), nil
+}
+
+// sshdDirective returns the effective value of key, or def if unset.
+//
+// FIRST occurrence wins — that is OpenSSH's rule for these keywords, and
+// it is the opposite of the "last wins" most config formats use. A
+// last-wins implementation would report the wrong value on any host with
+// a drop-in, which is most modern ones.
+//
+// Match blocks are ignored: a directive inside `Match` is conditional,
+// and treating it as global would misreport. Anything after the first
+// Match line is skipped.
+func sshdDirective(config, key, def string) string {
+	for _, line := range strings.Split(config, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if strings.EqualFold(fields[0], "Match") {
+			break // conditional territory; stop reading globals
+		}
+		if strings.EqualFold(fields[0], key) && len(fields) >= 2 {
+			return fields[1]
+		}
+	}
+	return def
+}
+
+// --- unattended upgrades ---------------------------------------------
+
+// unattendedUpgradesCheck reads APT's periodic config. Debian-family
+// only; anywhere else this is an unknown rather than a failure, since
+// the equivalent mechanism differs (dnf-automatic, etc.).
+func unattendedUpgradesCheck(p posturePaths) Check {
+	c := Check{Name: "unattended security upgrades enabled"}
+	data, err := os.ReadFile(p.aptPeriodic)
+	if err != nil {
+		if os.IsNotExist(err) {
+			c.Detail = "could not determine: " + p.aptPeriodic +
+				" absent (not a Debian-family host, or unattended-upgrades never configured)"
+			return c
+		}
+		c.Detail = fmt.Sprintf("could not determine: reading %s: %v", p.aptPeriodic, err)
+		return c
+	}
+	if !aptPeriodicEnabled(string(data), "Unattended-Upgrade") {
+		c.Detail = `APT::Periodic::Unattended-Upgrade is not "1"`
+		return c
+	}
+	c.OK = true
+	c.Detail = `APT::Periodic::Unattended-Upgrade "1"`
+	return c
+}
+
+// aptPeriodicEnabled reports whether APT::Periodic::<key> is set to a
+// non-zero value. APT treats "0" as off and any other integer as a day
+// interval, so "7" is enabled-but-weekly, not disabled.
+func aptPeriodicEnabled(config, key string) bool {
+	want := "APT::Periodic::" + key
+	for _, line := range strings.Split(config, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "//") {
+			continue
+		}
+		if !strings.HasPrefix(line, want) {
+			continue
+		}
+		open := strings.Index(line, `"`)
+		if open < 0 {
+			continue
+		}
+		close := strings.Index(line[open+1:], `"`)
+		if close < 0 {
+			continue
+		}
+		val := strings.TrimSpace(line[open+1 : open+1+close])
+		return val != "" && val != "0"
+	}
+	return false
+}
+
+// --- metadata server reachability ------------------------------------
+
+// metadataReachableCheck reports whether the cloud metadata endpoint is
+// reachable from this host.
+//
+// #1103 asks for "IMDSv2 required", and that is not honestly checkable
+// here: IMDSv2 is an AWS concept, and GCP's Metadata-Flavor header
+// requirement is unconditional, so a check claiming to verify it would
+// be theatre. What this issue actually cares about — given it frames
+// IMDS deny as "implemented, not armed" — is whether the pivot from a
+// popped workload to instance credentials is open at all. That is
+// directly measurable, so it is what gets measured and what the check is
+// named for.
+//
+// OK means UNREACHABLE. The desirable state is the connection failing.
+func metadataReachableCheck(p posturePaths) Check {
+	c := Check{Name: "cloud metadata endpoint blocked"}
+	if p.metadataDialer == nil {
+		c.Detail = "could not determine: no dialer configured"
+		return c
+	}
+	if err := p.metadataDialer(); err != nil {
+		c.OK = true
+		c.Detail = "169.254.169.254:80 unreachable from the host (" + err.Error() + ")"
+		return c
+	}
+	c.Detail = "169.254.169.254:80 is reachable from the host: a workload that escapes its container can reach instance credentials"
+	return c
+}
+
+// dialMetadataServer attempts a short TCP connect to the link-local
+// metadata address. Short timeout because this runs inside `doctor` and
+// the daemon's status probe; a blocked address typically fails fast, but
+// a DROP rule blackholes rather than refusing, so the timeout is the
+// actual bound.
+func dialMetadataServer() error {
+	conn, err := net.DialTimeout("tcp", "169.254.169.254:80", 1500*time.Millisecond)
+	if err != nil {
+		return err
+	}
+	_ = conn.Close()
+	return nil
+}

--- a/internal/hostcheck/posture_test.go
+++ b/internal/hostcheck/posture_test.go
@@ -129,10 +129,12 @@ tmpfs /run tmpfs rw 0 0
 }
 
 func TestDiskEncryptionCheck(t *testing.T) {
+	// /sys/block is keyed by the kernel name, so this is the shape a real
+	// host presents once the mapper alias has been resolved.
 	t.Run("dm-crypt passes", func(t *testing.T) {
 		p, _ := tempPaths(t)
-		write(t, p.procMounts, "/dev/mapper/cryptdata /var/lib/incus ext4 rw 0 0\n")
-		write(t, filepath.Join(p.sysBlock, "mapper/cryptdata/dm/uuid"), "CRYPT-LUKS2-abc123-cryptdata\n")
+		write(t, p.procMounts, "/dev/dm-0 /var/lib/incus ext4 rw 0 0\n")
+		write(t, filepath.Join(p.sysBlock, "dm-0/dm/uuid"), "CRYPT-LUKS2-abc123-cryptdata\n")
 
 		c := diskEncryptionCheck(p)
 		if !c.OK {
@@ -159,8 +161,8 @@ func TestDiskEncryptionCheck(t *testing.T) {
 
 	t.Run("non-crypt device-mapper fails", func(t *testing.T) {
 		p, _ := tempPaths(t)
-		write(t, p.procMounts, "/dev/mapper/vg-lv /var/lib/incus ext4 rw 0 0\n")
-		write(t, filepath.Join(p.sysBlock, "mapper/vg-lv/dm/uuid"), "LVM-xyz\n")
+		write(t, p.procMounts, "/dev/dm-1 /var/lib/incus ext4 rw 0 0\n")
+		write(t, filepath.Join(p.sysBlock, "dm-1/dm/uuid"), "LVM-xyz\n")
 
 		if c := diskEncryptionCheck(p); c.OK {
 			t.Errorf("plain LVM must not pass as encrypted: %s", c.Detail)
@@ -444,5 +446,44 @@ func TestRun_UnchangedByPosture(t *testing.T) {
 		if c.Kind == KindPosture {
 			t.Errorf("Run() returned posture check %q — posture belongs to RunPosture()", c.Name)
 		}
+	}
+}
+
+// TestResolveDMName is the regression test for the real-host bug that the
+// security scanner's taint warning led to. /proc/mounts carries the
+// device-mapper ALIAS (/dev/mapper/cryptdata), a symlink to the kernel name
+// (/dev/dm-0), and /sys/block only knows the latter. Without resolution every
+// LUKS host reported "not dm-crypt" — a false negative on precisely the hosts
+// that are encrypted.
+//
+// Driven directly rather than through diskEncryptionCheck because
+// deviceForPath only accepts /dev/-prefixed devices, and a test cannot create
+// symlinks under the real /dev.
+func TestResolveDMName(t *testing.T) {
+	dir := t.TempDir()
+	kernelDev := filepath.Join(dir, "dm-0")
+	aliasDir := filepath.Join(dir, "mapper")
+	aliasDev := filepath.Join(aliasDir, "cryptdata")
+	write(t, kernelDev, "")
+	if err := os.MkdirAll(aliasDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(kernelDev, aliasDev); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := resolveDMName(aliasDev), "dm-0"; got != want {
+		t.Errorf("resolveDMName(mapper alias) = %q, want %q — /sys/block is keyed by the kernel name", got, want)
+	}
+	if got, want := resolveDMName(kernelDev), "dm-0"; got != want {
+		t.Errorf("resolveDMName(kernel name) = %q, want %q", got, want)
+	}
+	// Unresolvable path: no panic, no traversal, just the last segment.
+	if got, want := resolveDMName("/dev/does-not-exist"), "does-not-exist"; got != want {
+		t.Errorf("resolveDMName(missing) = %q, want %q", got, want)
+	}
+	// Traversal attempt is bounded to one segment.
+	if got := resolveDMName("/dev/../../etc/passwd"); strings.Contains(got, "/") {
+		t.Errorf("resolveDMName must return a single path segment, got %q", got)
 	}
 }

--- a/internal/hostcheck/posture_test.go
+++ b/internal/hostcheck/posture_test.go
@@ -1,0 +1,448 @@
+//go:build !windows
+
+package hostcheck
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Posture checks (#1103).
+//
+// The governing property throughout: **unknown must never report OK**. A
+// posture check that passes when it learned nothing is worse than no
+// check at all — it converts "we have no evidence" into "we verified it",
+// which is the exact false assurance #1103 exists to stop. Most of the
+// cases below are therefore about what happens when the evidence is
+// missing or malformed, not about the happy path.
+
+// tempPaths builds a posturePaths pointing entirely at a temp tree, so
+// no assertion here depends on the machine running the tests.
+func tempPaths(t *testing.T) (posturePaths, string) {
+	t.Helper()
+	dir := t.TempDir()
+	return posturePaths{
+		procMounts:    filepath.Join(dir, "mounts"),
+		sysBlock:      filepath.Join(dir, "sys-block"),
+		efiVars:       filepath.Join(dir, "efivars"),
+		auditdPID:     filepath.Join(dir, "auditd.pid"),
+		sshdConfig:    filepath.Join(dir, "sshd_config"),
+		sshdConfigDir: filepath.Join(dir, "sshd_config.d"),
+		aptPeriodic:   filepath.Join(dir, "20auto-upgrades"),
+		incusDataDir:  "/var/lib/incus",
+		// Default to "blocked", the desirable state, so a test that isn't
+		// about the metadata check doesn't accidentally depend on the
+		// network of the machine running it.
+		metadataDialer: func() error { return errors.New("no route to host") },
+	}, dir
+}
+
+func write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestRunPosture_AllChecksAreNonBlocking is the contract that keeps this
+// PR from making the product decision #1103 reserves (fix 5). If a
+// posture check ever became Required, a hardening warning would start
+// failing `doctor` and flipping the cloud's self_check_ok — silently
+// gating enrollment on a decision nobody made.
+func TestRunPosture_AllChecksAreNonBlocking(t *testing.T) {
+	p, _ := tempPaths(t)
+	checks := runPosture(p)
+
+	if len(checks) == 0 {
+		t.Fatal("runPosture returned no checks")
+	}
+	for _, c := range checks {
+		if c.Required {
+			t.Errorf("posture check %q is Required — posture must not gate capability (#1103 fix 5 is an open product decision)", c.Name)
+		}
+		if c.Kind != KindPosture {
+			t.Errorf("check %q has Kind %q, want %q", c.Name, c.Kind, KindPosture)
+		}
+	}
+	// The load-bearing consequence, asserted directly rather than implied.
+	if !AllRequiredPass(checks) {
+		t.Error("AllRequiredPass must stay true over posture checks alone, whatever their results")
+	}
+}
+
+// TestRunPosture_UnknownHostReportsNoPasses: given a temp tree with no
+// evidence in it at all, nothing may claim to have verified anything.
+// The metadata check is the sole exception — an unreachable endpoint IS
+// the positive evidence there.
+func TestRunPosture_UnknownHostReportsNoPasses(t *testing.T) {
+	p, _ := tempPaths(t)
+	for _, c := range runPosture(p) {
+		if c.Name == "cloud metadata endpoint blocked" {
+			if !c.OK {
+				t.Errorf("unreachable metadata endpoint should be OK, got not-OK: %s", c.Detail)
+			}
+			continue
+		}
+		if c.OK {
+			t.Errorf("check %q reported OK with no evidence available: %s", c.Name, c.Detail)
+		}
+		if !strings.Contains(c.Detail, "could not determine") && c.Detail == "" {
+			t.Errorf("check %q failed without saying why", c.Name)
+		}
+	}
+}
+
+func TestDeviceForPath(t *testing.T) {
+	const mounts = `sysfs /sys sysfs rw 0 0
+/dev/sda1 / ext4 rw 0 0
+tmpfs /run tmpfs rw 0 0
+/dev/mapper/cryptdata /var/lib/incus ext4 rw 0 0
+/dev/sdb1 /var/lib/incus/deep/nested ext4 rw 0 0
+`
+	tests := []struct {
+		name, target, wantDev, wantMP string
+	}{
+		// The whole reason for longest-prefix: "/" also matches, and a
+		// first-match implementation would inspect the wrong volume and
+		// report the root disk's encryption state as the data disk's.
+		{"longest prefix wins", "/var/lib/incus", "/dev/mapper/cryptdata", "/var/lib/incus"},
+		{"falls back to root", "/opt/containarium", "/dev/sda1", "/"},
+		{"exact deeper mount", "/var/lib/incus/deep/nested", "/dev/sdb1", "/var/lib/incus/deep/nested"},
+		// A mount point that is a string prefix but not a PATH prefix
+		// must not match: /var/lib/incusdata is not inside /var/lib/incus.
+		{"not a path-component prefix", "/var/lib/incusdata", "/dev/sda1", "/"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dev, mp := deviceForPath(mounts, tc.target)
+			if dev != tc.wantDev || mp != tc.wantMP {
+				t.Errorf("deviceForPath(%q) = (%q, %q), want (%q, %q)", tc.target, dev, mp, tc.wantDev, tc.wantMP)
+			}
+		})
+	}
+}
+
+func TestDiskEncryptionCheck(t *testing.T) {
+	t.Run("dm-crypt passes", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.procMounts, "/dev/mapper/cryptdata /var/lib/incus ext4 rw 0 0\n")
+		write(t, filepath.Join(p.sysBlock, "mapper/cryptdata/dm/uuid"), "CRYPT-LUKS2-abc123-cryptdata\n")
+
+		c := diskEncryptionCheck(p)
+		if !c.OK {
+			t.Errorf("dm-crypt volume should pass: %s", c.Detail)
+		}
+	})
+
+	t.Run("plain partition fails and explains CMEK is unobservable", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.procMounts, "/dev/sda1 /var/lib/incus ext4 rw 0 0\n")
+
+		c := diskEncryptionCheck(p)
+		if c.OK {
+			t.Error("a plain partition must not pass as encrypted")
+		}
+		// The nuance is the point: on a cloud BYOC host the disk very
+		// likely IS encrypted at rest by the provider, invisibly. Without
+		// this the check reads as "the customer's disk is plaintext",
+		// which we do not know and should not imply.
+		if !strings.Contains(c.Detail, "cannot be observed from inside the guest") {
+			t.Errorf("detail must not imply the disk is plaintext when provider encryption is merely unobservable: %q", c.Detail)
+		}
+	})
+
+	t.Run("non-crypt device-mapper fails", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.procMounts, "/dev/mapper/vg-lv /var/lib/incus ext4 rw 0 0\n")
+		write(t, filepath.Join(p.sysBlock, "mapper/vg-lv/dm/uuid"), "LVM-xyz\n")
+
+		if c := diskEncryptionCheck(p); c.OK {
+			t.Errorf("plain LVM must not pass as encrypted: %s", c.Detail)
+		}
+	})
+
+	t.Run("unreadable mounts is unknown not pass", func(t *testing.T) {
+		p, _ := tempPaths(t) // procMounts never created
+		c := diskEncryptionCheck(p)
+		if c.OK {
+			t.Error("must not pass when /proc/mounts is unreadable")
+		}
+		if !strings.Contains(c.Detail, "could not determine") {
+			t.Errorf("detail should mark this unknown, got %q", c.Detail)
+		}
+	})
+}
+
+func TestParseSecureBootVar(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         []byte
+		wantEnabled bool
+		wantOK      bool
+	}{
+		{"enabled", []byte{6, 0, 0, 0, 1}, true, true},
+		{"disabled", []byte{6, 0, 0, 0, 0}, false, true},
+		{"short", []byte{6, 0, 0, 0}, false, false},
+		{"empty", nil, false, false},
+		{"too long", []byte{6, 0, 0, 0, 1, 1}, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			enabled, ok := parseSecureBootVar(tc.raw)
+			if enabled != tc.wantEnabled || ok != tc.wantOK {
+				t.Errorf("= (%v, %v), want (%v, %v)", enabled, ok, tc.wantEnabled, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestSecureBootCheck(t *testing.T) {
+	t.Run("enabled passes", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, filepath.Join(p.efiVars, "SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"), "")
+		if err := os.WriteFile(filepath.Join(p.efiVars, "SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"),
+			[]byte{6, 0, 0, 0, 1}, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if c := secureBootCheck(p); !c.OK {
+			t.Errorf("SecureBoot=1 should pass: %s", c.Detail)
+		}
+	})
+
+	t.Run("no efivars is a definite negative", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		c := secureBootCheck(p)
+		if c.OK {
+			t.Error("legacy BIOS must not pass")
+		}
+		// Not "could not determine": no EFI genuinely means no measured
+		// boot is possible. Reporting it as unknown would understate it.
+		if !strings.Contains(c.Detail, "legacy BIOS") {
+			t.Errorf("detail should name legacy BIOS as the finding, got %q", c.Detail)
+		}
+	})
+
+	t.Run("efivars without the variable is unknown", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		if err := os.MkdirAll(p.efiVars, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		c := secureBootCheck(p)
+		if c.OK || !strings.Contains(c.Detail, "could not determine") {
+			t.Errorf("EFI present but no SecureBoot var should be unknown, got OK=%v %q", c.OK, c.Detail)
+		}
+	})
+}
+
+func TestAuditdCheck(t *testing.T) {
+	t.Run("pidfile present passes", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.auditdPID, "1234\n")
+		if c := auditdCheck(p); !c.OK {
+			t.Errorf("auditd pidfile should pass: %s", c.Detail)
+		}
+	})
+	t.Run("absent fails", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		if c := auditdCheck(p); c.OK {
+			t.Error("missing pidfile must not pass")
+		}
+	})
+	t.Run("empty pidfile is unknown", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.auditdPID, "  \n")
+		c := auditdCheck(p)
+		if c.OK || !strings.Contains(c.Detail, "could not determine") {
+			t.Errorf("empty pidfile should be unknown, got OK=%v %q", c.OK, c.Detail)
+		}
+	})
+}
+
+func TestSSHDDirective(t *testing.T) {
+	tests := []struct {
+		name, config, key, def, want string
+	}{
+		{"absent uses default", "Port 22\n", "PasswordAuthentication", "yes", "yes"},
+		{"simple", "PasswordAuthentication no\n", "PasswordAuthentication", "yes", "no"},
+		{"case insensitive key", "passwordauthentication NO\n", "PasswordAuthentication", "yes", "NO"},
+		{"comments ignored", "#PasswordAuthentication yes\nPasswordAuthentication no\n", "PasswordAuthentication", "yes", "no"},
+		// OpenSSH takes the FIRST occurrence, not the last. A last-wins
+		// implementation returns "yes" here and would report a hardened
+		// host as unhardened (or worse, the reverse).
+		{"first occurrence wins", "PasswordAuthentication no\nPasswordAuthentication yes\n", "PasswordAuthentication", "yes", "no"},
+		// A directive inside a Match block is conditional; treating it as
+		// global misreports the host-wide setting.
+		{"match block ignored", "Match User bob\nPasswordAuthentication yes\n", "PasswordAuthentication", "no", "no"},
+		{"directive before match still counts", "PasswordAuthentication no\nMatch User bob\nPasswordAuthentication yes\n", "PasswordAuthentication", "yes", "no"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sshdDirective(tc.config, tc.key, tc.def); got != tc.want {
+				t.Errorf("sshdDirective() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSSHDConfigCheck(t *testing.T) {
+	t.Run("hardened passes", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.sshdConfig, "PermitRootLogin no\nPasswordAuthentication no\n")
+		if c := sshdConfigCheck(p); !c.OK {
+			t.Errorf("hardened sshd should pass: %s", c.Detail)
+		}
+	})
+
+	t.Run("password auth on fails even with root login off", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.sshdConfig, "PermitRootLogin no\nPasswordAuthentication yes\n")
+		c := sshdConfigCheck(p)
+		if c.OK {
+			t.Error("password auth enabled must fail regardless of root login")
+		}
+		if !strings.Contains(c.Detail, "PasswordAuthentication") {
+			t.Errorf("detail should name the offending directive, got %q", c.Detail)
+		}
+	})
+
+	t.Run("default password auth is yes so a bare config fails", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.sshdConfig, "Port 22\n")
+		if c := sshdConfigCheck(p); c.OK {
+			t.Error("an sshd_config that sets nothing inherits PasswordAuthentication=yes and must fail")
+		}
+	})
+
+	// Modern distros ship `Include /etc/ssh/sshd_config.d/*.conf` at the
+	// TOP of sshd_config, so with first-match-wins a drop-in OVERRIDES the
+	// main file. Reading them in the wrong order reports the overridden
+	// value — on a cloud image, usually the insecure one.
+	t.Run("drop-in overrides the main file", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.sshdConfig, "PasswordAuthentication yes\nPermitRootLogin yes\n")
+		write(t, filepath.Join(p.sshdConfigDir, "60-hardening.conf"), "PasswordAuthentication no\nPermitRootLogin no\n")
+
+		if c := sshdConfigCheck(p); !c.OK {
+			t.Errorf("drop-in hardening must override the main file: %s", c.Detail)
+		}
+	})
+
+	t.Run("drop-ins apply in lexical order", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.sshdConfig, "Port 22\n")
+		write(t, filepath.Join(p.sshdConfigDir, "10-first.conf"), "PasswordAuthentication no\nPermitRootLogin no\n")
+		write(t, filepath.Join(p.sshdConfigDir, "90-later.conf"), "PasswordAuthentication yes\n")
+
+		if c := sshdConfigCheck(p); !c.OK {
+			t.Errorf("the lexically-first drop-in wins under first-match-wins: %s", c.Detail)
+		}
+	})
+
+	t.Run("missing config is unknown not pass", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		c := sshdConfigCheck(p)
+		if c.OK || !strings.Contains(c.Detail, "could not determine") {
+			t.Errorf("missing sshd_config should be unknown, got OK=%v %q", c.OK, c.Detail)
+		}
+	})
+}
+
+func TestAptPeriodicEnabled(t *testing.T) {
+	tests := []struct {
+		name, config string
+		want         bool
+	}{
+		{"enabled", `APT::Periodic::Unattended-Upgrade "1";`, true},
+		{"disabled", `APT::Periodic::Unattended-Upgrade "0";`, false},
+		{"absent", `APT::Periodic::Update-Package-Lists "1";`, false},
+		// APT reads the value as a day interval, so "7" is enabled-weekly.
+		// Treating only "1" as on would misreport a configured host.
+		{"weekly interval counts as enabled", `APT::Periodic::Unattended-Upgrade "7";`, true},
+		{"comment ignored", "// APT::Periodic::Unattended-Upgrade \"1\";", false},
+		{"empty value", `APT::Periodic::Unattended-Upgrade "";`, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := aptPeriodicEnabled(tc.config, "Unattended-Upgrade"); got != tc.want {
+				t.Errorf("aptPeriodicEnabled(%q) = %v, want %v", tc.config, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUnattendedUpgradesCheck_MissingFileIsUnknown(t *testing.T) {
+	p, _ := tempPaths(t)
+	c := unattendedUpgradesCheck(p)
+	if c.OK {
+		t.Error("must not pass with no APT config")
+	}
+	// Non-Debian hosts have a different mechanism entirely, so absence is
+	// genuinely unknown rather than a failure to configure.
+	if !strings.Contains(c.Detail, "could not determine") {
+		t.Errorf("absence on a non-Debian host is unknown, got %q", c.Detail)
+	}
+}
+
+func TestMetadataReachableCheck(t *testing.T) {
+	// OK means UNREACHABLE here — the desirable state is the connection
+	// failing. Worth an explicit test because the polarity is easy to
+	// invert and the inverted version looks perfectly reasonable.
+	t.Run("unreachable is the pass", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		p.metadataDialer = func() error { return errors.New("connect: no route to host") }
+		c := metadataReachableCheck(p)
+		if !c.OK {
+			t.Errorf("a blocked metadata endpoint is the desired state: %s", c.Detail)
+		}
+	})
+
+	t.Run("reachable is the failure", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		p.metadataDialer = func() error { return nil }
+		c := metadataReachableCheck(p)
+		if c.OK {
+			t.Error("a reachable metadata endpoint must not pass")
+		}
+		if !strings.Contains(c.Detail, "instance credentials") {
+			t.Errorf("detail should state the consequence, got %q", c.Detail)
+		}
+	})
+}
+
+func TestWireName(t *testing.T) {
+	// The two groups must stay distinguishable across a wire format that
+	// carries only {name, ok, detail} — otherwise the cloud cannot tell a
+	// hardening warning from a capability failure, which is the exact
+	// conflation #1103 is about.
+	posture := Check{Name: "auditd running", Kind: KindPosture}
+	if got, want := posture.WireName(), "posture: auditd running"; got != want {
+		t.Errorf("posture WireName = %q, want %q", got, want)
+	}
+	capability := Check{Name: "incus binary present", Kind: KindCapability}
+	if got, want := capability.WireName(), "incus binary present"; got != want {
+		t.Errorf("capability WireName = %q, want %q", got, want)
+	}
+	// Zero value must read as capability so every pre-existing Check
+	// construction keeps its meaning.
+	if got, want := (Check{Name: "x"}).WireName(), "x"; got != want {
+		t.Errorf("zero-Kind WireName = %q, want %q", got, want)
+	}
+}
+
+// TestRun_UnchangedByPosture: Run() must keep returning capability checks
+// only. If posture ever leaks into it, AllRequiredPass starts mixing a
+// hardening verdict into a liveness verdict and container creation gets
+// gated on a decision nobody made.
+func TestRun_UnchangedByPosture(t *testing.T) {
+	for _, c := range Run() {
+		if c.Kind == KindPosture {
+			t.Errorf("Run() returned posture check %q — posture belongs to RunPosture()", c.Name)
+		}
+	}
+}

--- a/internal/hostcheck/run_windows.go
+++ b/internal/hostcheck/run_windows.go
@@ -7,3 +7,8 @@ package hostcheck
 // `containarium` Windows binary still imports this package transitively
 // (internal/cloud → hostcheck), so it must compile — it just reports no checks.
 func Run() []Check { return nil }
+
+// RunPosture is a no-op stub on Windows for the same reason as Run: the
+// host security-posture checks (#1103) read Linux-specific state — efivars,
+// /proc/mounts, sshd_config, APT — and the daemon doesn't run on Windows.
+func RunPosture() []Check { return nil }


### PR DESCRIPTION
Partial for #1103 — **proposed fix 1 plus the reporting half of fix 2. This does not close the issue.**

Enrollment verified that a host *can* run workloads, never that it is *safe* to run them on. For BYOC the machine is the customer's, in the customer's account, from an image we did not build, so those are different questions — and only the first was ever asked.

Adds a posture group to `internal/hostcheck`, reported **separately** from the capability checks, per the issue's own framing that a functional pass must not read as a security pass.

| Check | Evidence read |
|---|---|
| data volume encrypted (dm-crypt) | `/proc/mounts` → longest-prefix mount for the incus data dir → `/sys/block/<dm>/dm/uuid` |
| secure boot enabled | `SecureBoot-*` efivar |
| auditd running | `/run/auditd.pid` |
| sshd hardened | `sshd_config` + `sshd_config.d/*.conf`, OpenSSH first-match-wins semantics |
| unattended security upgrades | `APT::Periodic::Unattended-Upgrade` |
| cloud metadata endpoint blocked | TCP connect to `169.254.169.254:80` |

`doctor` prints it as its own advisory section. The status probe reports it inside the **existing** self-check list, which is what makes fix 2 additive: a control plane already stores `Checks` per host, so it records posture with no contract change.

## Out of scope, deliberately

- **Fix 3 (arm the network policy at enrollment)** — a behavior change to enrollment with real breakage potential. The `#780`/`#860` precedent this issue cites is exactly why it deserves its own change rather than riding along with a diagnostic.
- **Fix 5 (block vs warn)** — the issue calls this a product call, not a code call, and this PR keeps it open. See below.
- **Fix 4 (publish the baseline)** — this is its machine-readable half; the prose belongs with whoever makes the fix-5 call.

## Deviation from the issue, flagged rather than silently substituted

**"IMDSv2 required" is not honestly checkable here.** IMDSv2 is an AWS concept, and GCP's `Metadata-Flavor` header requirement is unconditional — a check claiming to verify it would be theatre. What the issue actually cares about, given it frames IMDS deny as "implemented, not armed", is whether the pivot from a popped workload to instance credentials is open at all. That *is* measurable, so that is what this measures, and the check is named for what it does: `cloud metadata endpoint blocked`.

## Review this first: three properties that make this safe to merge

**1. Nothing blocks anything.** Posture checks are `Required: false`; `RunPosture()` is separate from `Run()`; `self_check_ok` is still derived from the capability checks alone. `TestRunPosture_AllChecksAreNonBlocking` asserts it directly, because the failure mode is silent — one check flipped to `Required` would start failing `doctor` and flipping `self_check_ok`, gating enrollment on a decision nobody made.

**2. Unknown never reports OK.** A check that cannot gather evidence reports **unmet**, with a `could not determine` detail. A posture check that passes when it learned nothing converts "we have no evidence" into "we verified it" — the exact false assurance #1103 exists to stop.

The consequence is deliberate and worth stating plainly: **an ordinary unhardened host will show several unmet items, and some of them may be fine.** Provider-managed disk encryption (CMEK/EBS) is invisible from inside the guest, so it is reported as *unobservable*, not *absent* — with wording that says so, because "not dm-crypt" must not be read as "the customer's disk is plaintext". That distinction has its own test.

**3. The two groups stay distinguishable on the wire.** `HostCheck` carries only `{name, ok, detail}`, so posture names are prefixed (`posture: auditd running`). Without it, a hardening advisory and a capability failure are indistinguishable in the cloud's stored self-check — precisely the conflation this issue is about. A typed proto field is the better fix when the contract next changes; noted in the code.

## Test evidence

31 assertions across 13 tests, all green. Every check is driven against a temp tree rather than the host, so nothing depends on the machine running the tests — a posture check that can only be tested on a correctly hardened machine is one nobody will ever run red.

Two subtleties that the tests exist to pin, because both are easy to get backwards and neither is visible in review:

- **OpenSSH takes the FIRST occurrence of a keyword, not the last** — the opposite of most config formats. And modern distros put `Include sshd_config.d/*.conf` at the *top* of `sshd_config`, so drop-ins therefore *override* the main file. Get either backwards and the check reports the overridden value, which on a cloud image is usually the insecure one.
- **Longest-prefix mount matching.** With both `/` and `/var/lib/incus` mounted, a first-match implementation inspects the root disk and reports its encryption state as the data disk's.

### Mutation log

Every property was verified by breaking the code and confirming the right tests fail:

| Mutation | Caught by |
|---|---|
| A posture check becomes `Required` | `TestRunPosture_AllChecksAreNonBlocking` |
| `sshdDirective` last-match-wins instead of first | `TestSSHDDirective/first_occurrence_wins`, + 2 `TestSSHDConfigCheck` cases |
| sshd drop-ins read *after* the main file | `TestSSHDConfigCheck/drop-in_overrides_the_main_file` |
| `deviceForPath` first-match instead of longest-prefix | `TestDeviceForPath` (2 cases) |
| Unknown reports OK | `TestRunPosture_UnknownHostReportsNoPasses`, `TestDiskEncryptionCheck/unreadable_mounts_is_unknown_not_pass` |
| Metadata polarity inverted (reachable reads as pass) | `TestMetadataReachableCheck` (both cases) |

```
$ go test ./internal/hostcheck/ ./internal/cmd/ ./internal/cloud/
ok  	github.com/footprintai/containarium/internal/hostcheck	0.018s
ok  	github.com/footprintai/containarium/internal/cmd	0.162s
ok  	github.com/footprintai/containarium/internal/cloud	3.040s

$ go test ./internal/...
(44 packages ok)
```

`go vet` and `gofmt -l` clean. Cross-compiles for Windows (`RunPosture` gets the same stub treatment as `Run`; `CheckKind` lives in the build-tag-free file so the stub build sees it).

**Two pre-existing failures in `internal/sentinel` are unrelated** — `TestEnableForwardingOnNonLinux` and `TestRegisterPropagatesPool`, both reproduced on a clean tree and both **passing in CI** on #1105, so they are artifacts of a Linux dev container rather than real failures. Same for the `internal/agentbox` Windows build error, which is pre-existing on `main`.

### Test-environment caveat

Built and tested in a Linux container with a Go toolchain matching `go.mod`. No hardened host and no real BYOC machine was available, so **every posture check is verified against synthetic fixtures, not against a host that genuinely has Secure Boot or dm-crypt on**. The parsers are well covered; what remains unproven is that the real files on a real hardened host look the way the fixtures do. Worth one manual `containarium doctor` run on an actual hardened machine before this is relied on for an attestation — which is also the first thing #1103's own "re-verify on the first real host" note asks for.
