### PR TITLE
chore(release): cut v0.61.0 — platform-domain metrics export, host posture checks, sentinel peer-proxy now authenticated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.61.0] - 2026-07-27
+
 ### Added
+
+- **Cloud metrics export now covers the platform domain, not just the
+  host.** v0.60.0 shipped the export toggle and the host series; this
+  round adds the groups that make an exported dashboard answer
+  operational questions rather than just "is the box alive":
+  a **heartbeat** series with a dead-man alert recipe, so the failure
+  class where the host or daemon simply dies is caught by metric
+  *absence* rather than going unnoticed (#1090); **API health** —
+  requests and errors bucketed by `code_class` via grpc-gateway's own
+  status mapping (#1092); **provisioning outcomes** — attempts,
+  failures and duration keyed by `create`/`delete` (#1094);
+  **connectivity** — healthy peer count plus each peer's tunnel
+  up/down state, which is how a BYOC peer gets represented at all
+  given it cannot export for itself (#1095); and **per-container**
+  CPU/memory/disk/network series, the last unimplemented piece of the
+  export design (#1098).
+
+- **`containarium cloud enroll --adopt-foreign`** — acknowledges, in
+  one explicit flag, that the host being enrolled already runs
+  cloud-managed containers belonging to another organization. The
+  control-plane half refuses such a host by default; this is the
+  operator's deliberate override. Note the flag must be in operators'
+  hands *before* the control-plane guard is deployed, since the guard
+  fails closed and this is the only way past it (#1104).
 
 - **`containarium doctor` now reports host security posture**, as its own
   advisory section alongside the existing capability checks. For BYOC the
@@ -30,9 +56,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   invisible from inside the guest and is reported as unobservable rather
   than absent). **Nothing here blocks anything**: posture checks are
   advisory, `doctor`'s exit code is unchanged, and the daemon's
-  `self_check_ok` is still derived from the capability checks alone.
+  `self_check_ok` is still derived from the capability checks alone (#1106).
 
 ### Fixed
+
+- **A resumed metrics export no longer re-emits under a placeholder
+  identity.** A daemon that resumed export on restart published its
+  host series as `backend_id="local", region=""` instead of its real
+  identity, splitting the host across two `backend_id` streams and
+  silently dropping it from any dashboard or alert keyed on
+  `backend_id` — the failure was invisible precisely where it
+  mattered. Export now waits until identity is wired (#1087).
 
 - **A box is now SSH-reachable as soon as it reports RUNNING** — the
   sentinel learned about a box's SSH key only by polling each backend's
@@ -51,7 +85,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sync is unchanged and remains the convergence backstop, so a lost or
   refused notification costs the old latency rather than reachability.
   Revoked keys likewise stop routing at revocation instead of up to two
-  minutes later.
+  minutes later (#1100).
+
+### Documentation
+
+- Cloud-native metrics export: PRD for application-domain metrics
+  (#1086), the platform-domain metric-group design (#1088), the
+  committed GCM dashboard's platform group plus quickstart (#1096),
+  the BYOC no-export posture with a corrected heartbeat claim (#1097),
+  and a bare-VM quickstart carrying a real measured cost estimate
+  (#1099).
 
 ### Security
 
@@ -80,7 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sentinel, set that secret **and** make sure the caller signs its
   `/peer/` requests before rolling this out; otherwise those backends
   become undrivable. The sentinel logs this loudly at startup when the
-  secret is absent.
+  secret is absent (#1105).
 
 
 ## [0.60.0] - 2026-07-23

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var (
 	// ldflags (`make build-release VERSION=<tag>` in .github/workflows/release.yml),
 	// so the tag is the source of truth; keep this constant in sync as the
 	// fallback for plain `make build` / `go build`.
-	Version = "0.60.0"
+	Version = "0.61.0"
 
 	// GitCommit is the git commit hash (set by build flag via ldflags)
 	GitCommit = ""


### PR DESCRIPTION
Release prep for **v0.61.0**, following `docs/RELEASE-PROCESS.md`: the two files that process names (`CHANGELOG.md`, `pkg/version/version.go`), one commit. **Tagging happens after this merges** — this PR does not publish anything.

## Version: v0.61.0 (minor)

`v0.60.0` → `v0.61.0`. Minor rather than major **despite an operator-breaking change** in #1105: the project is `0.x`, where semver puts breaking changes in the minor position. Going to `v1.0.0` would be a deliberate API-stability statement, not a mechanical consequence of this scope — worth a separate decision if the team wants it.

The break is called out under `### Security` with the required operator action, not buried in a bullet.

## Scope: 15 PRs merged since v0.60.0

Every line in the release section cites a real merged PR — verified 15/15, not inferred from titles. **Eleven of these had no changelog entry at all**: the metrics-export series and `--adopt-foreign` merged after v0.60.0 without ever being documented, so a release cut from `[Unreleased]` alone would have shipped notes describing three PRs out of fifteen.

| Category | PRs |
|---|---|
| Added | #1090, #1092, #1094, #1095, #1098 (metrics-export platform domain), #1104 (`--adopt-foreign`), #1106 (host posture checks) |
| Fixed | #1087 (export identity), #1100 (SSH resync) |
| Documentation | #1086, #1088, #1096, #1097, #1099 |
| Security | #1105 (peer-proxy authentication) |

## ⚠️ The operator-breaking change, restated

After this release, **a sentinel with no `CONTAINARIUM_SENTINEL_ADMIN_SECRET` rejects every `/peer/` request with 401.** That secret is currently optional — unset is a supported configuration that only disables `/sentinel/tunnel-tokens` — so this makes it mandatory for anyone using the peer proxy.

Fail-closed is deliberate: a fail-open fallback would skip the fix precisely on the hosts whose operator never configured the secret. The startup log says so explicitly, and the changelog carries the upgrade note.

## Why this release matters beyond its contents

It carries **`containarium cloud enroll --adopt-foreign`** (#1104), which is a prerequisite for deploying the control-plane enrollment guard (FootprintAI/Containarium-cloud#1010). That guard **fails closed**, and this flag is the operator's only override — so the guard should not be deployed until this release is in operators' hands. Cutting this release unblocks that chain.

## Verification

- `main` @ `636ace8` green across all three workflows before branching.
- `go build ./...` clean with the bumped constant.
- Changelog ordering follows Keep a Changelog; an empty `## [Unreleased]` is retained for the next round, per the process doc.

## After merge

Tag the merged commit and push — `release.yml` fires on `v*` and both builds and publishes the GitHub Release (10 artifacts + `SHA256SUMS.txt`), so no manual `gh release create`. `containarium-daemon.yml` also fires on the same tag. I will confirm both runs go green and report; a red build means the release is reported failed, not "tagged".
