### PR TITLE
docs(readme): short containarium.dev/install.sh in the install one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ You bring the agent. We run the box.
 ### 1. Self-host on a fresh Ubuntu VM (5 minutes)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/footprintai/containarium/main/hacks/install.sh \
-  | sudo bash
+curl -fsSL https://containarium.dev/install.sh | sudo bash
 ```
 
 That installs Containarium + Incus + dependencies, starts the daemon,
@@ -578,8 +577,7 @@ least-privilege scope catalog.
 ### Manual install (recommended for getting started)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/footprintai/containarium/main/hacks/install.sh \
-  | sudo bash
+curl -fsSL https://containarium.dev/install.sh | sudo bash
 ```
 
 See [`hacks/README.md`](hacks/README.md) for what the script does.


### PR DESCRIPTION
Replaces the long `raw.githubusercontent.com/.../hacks/install.sh` URL with the short vanity URL **`https://containarium.dev/install.sh`** in both the **Quick start** and **Deployment → Manual install** sections, so the copy-paste command matches the one shown in the demo gif.

The short URL is a **302 redirect** to the same canonical `hacks/install.sh`, and `curl -fsSL` follows redirects — so the install behavior is byte-for-byte identical, just a shorter command.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)