### PR TITLE
ci: allow rehearsing release builds without publishing (#1119 follow-up)

### DIFF
--- a/.github/workflows/containarium-daemon.yml
+++ b/.github/workflows/containarium-daemon.yml
@@ -9,6 +9,23 @@ on:
     tags:
       - 'v*'   # e.g. v0.53.0
 
+  # Rehearsal trigger (#1119 follow-up). A tag push is currently the ONLY
+  # way these builds ever run, so the two release incidents this repo has
+  # recorded (v0.47.0's Windows cross-compile break, v0.48.0's web-ui build
+  # failure) were both invisible until the real release build failed — with a
+  # burned tag as the cost. This lets the identical build run on any ref
+  # WITHOUT publishing anything.
+  #
+  # Deliberately publish-free: nothing here pushes an image, uploads an
+  # artifact, or creates a Release. Publishing stays exclusively on tag push,
+  # so a rehearsal cannot become an accidental release.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build as (without v prefix), e.g. 0.61.0. Build only — publishes nothing.'
+        required: false
+        default: '0.0.0-dryrun'
+
 permissions:
   contents: read
   packages: write   # for GHCR push
@@ -33,7 +50,11 @@ jobs:
       - name: Derive image tags
         id: tags
         run: |
-          version="${GITHUB_REF#refs/tags/v}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            version="${{ inputs.version }}"
+          else
+            version="${GITHUB_REF#refs/tags/v}"
+          fi
           # Minor-series moving tag: 0.53.0 -> v0.53
           minor="v$(echo "$version" | cut -d. -f1-2)"
           base="ghcr.io/footprintai/containarium"
@@ -53,7 +74,8 @@ jobs:
           build-args: |
             VERSION=${{ steps.tags.outputs.version }}
           platforms: linux/amd64
-          push: true
+          # Push on tag only; a rehearsal builds the image and discards it.
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.tags.outputs.tags }}
           # Build provenance + SBOM (buildx-default on push); explicit so it's
           # reviewable, matching sidecars.yml.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,23 @@ on:
     tags:
       - 'v*'   # e.g. v0.16.4
 
+  # Rehearsal trigger (#1119 follow-up). A tag push is currently the ONLY
+  # way these builds ever run, so the two release incidents this repo has
+  # recorded (v0.47.0's Windows cross-compile break, v0.48.0's web-ui build
+  # failure) were both invisible until the real release build failed — with a
+  # burned tag as the cost. This lets the identical build run on any ref
+  # WITHOUT publishing anything.
+  #
+  # Deliberately publish-free: nothing here pushes an image, uploads an
+  # artifact, or creates a Release. Publishing stays exclusively on tag push,
+  # so a rehearsal cannot become an accidental release.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build as (without v prefix), e.g. 0.61.0. Build only — publishes nothing.'
+        required: false
+        default: '0.0.0-dryrun'
+
 permissions:
   contents: write
 
@@ -27,9 +44,16 @@ jobs:
         # still triggers buf generate; installing it satisfies that.
         run: go install github.com/bufbuild/buf/cmd/buf@latest
 
-      - name: Get version from tag
+      - name: Get version
         id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        # Tag push -> the tag. Rehearsal -> the dispatch input, since
+        # github.ref is a branch there and would yield a nonsense version.
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Compile eBPF network-policy object (#627)
         # Builds internal/netbpf/netpolicy.bpf.o so the next `make` invocation
@@ -149,6 +173,9 @@ jobs:
           EOF
 
       - name: Create GitHub Release
+        # Tag pushes only. A rehearsal builds every artifact above and stops
+        # here — that is the whole point of the workflow_dispatch trigger.
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
@@ -244,6 +271,10 @@ jobs:
         run: ls -lh dist/
 
       - name: Upload bundle to release
+        # Tag pushes only — same guard as the Release step in the job above.
+        # Without it a rehearsal would still attempt a real upload, which is
+        # exactly the accidental publish this trigger is designed to prevent.
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}

--- a/.github/workflows/sidecars.yml
+++ b/.github/workflows/sidecars.yml
@@ -9,6 +9,23 @@ on:
     tags:
       - 'v*'   # e.g. v0.16.11
 
+  # Rehearsal trigger (#1119 follow-up). A tag push is currently the ONLY
+  # way these builds ever run, so the two release incidents this repo has
+  # recorded (v0.47.0's Windows cross-compile break, v0.48.0's web-ui build
+  # failure) were both invisible until the real release build failed — with a
+  # burned tag as the cost. This lets the identical build run on any ref
+  # WITHOUT publishing anything.
+  #
+  # Deliberately publish-free: nothing here pushes an image, uploads an
+  # artifact, or creates a Release. Publishing stays exclusively on tag push,
+  # so a rehearsal cannot become an accidental release.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build as (without v prefix), e.g. 0.61.0. Build only — publishes nothing.'
+        required: false
+        default: '0.0.0-dryrun'
+
 permissions:
   contents: read
   packages: write   # for GHCR push
@@ -37,7 +54,11 @@ jobs:
         id: tags
         run: |
           # Strip the leading 'v' from the tag to get e.g. 0.16.10
-          version="${GITHUB_REF#refs/tags/v}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            version="${{ inputs.version }}"
+          else
+            version="${GITHUB_REF#refs/tags/v}"
+          fi
           # Derive the minor-series moving tag: 0.16.10 -> v0.16
           minor="v$(echo "$version" | cut -d. -f1-2)"
 
@@ -58,7 +79,8 @@ jobs:
           # linux/amd64 only for v1 — bare-metal peers may want arm64
           # later but our prod fleet is amd64 today.
           platforms: linux/amd64
-          push: true
+          # Push on tag only; a rehearsal builds the image and discards it.
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.tags.outputs.tags }}
           # Build provenance + SBOM are GHA-default for buildx push;
           # explicit so it's reviewable.
@@ -84,7 +106,11 @@ jobs:
       - name: Derive image tags
         id: tags
         run: |
-          version="${GITHUB_REF#refs/tags/v}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            version="${{ inputs.version }}"
+          else
+            version="${GITHUB_REF#refs/tags/v}"
+          fi
           minor="v$(echo "$version" | cut -d. -f1-2)"
           base="ghcr.io/footprintai/containarium-sshpiper"
           {
@@ -97,7 +123,8 @@ jobs:
           context: ./images/sshpiper
           file: ./images/sshpiper/Dockerfile
           platforms: linux/amd64
-          push: true
+          # Push on tag only; a rehearsal builds the image and discards it.
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.tags.outputs.tags }}
           provenance: true
           sbom: true
@@ -121,7 +148,11 @@ jobs:
       - name: Derive image tags
         id: tags
         run: |
-          version="${GITHUB_REF#refs/tags/v}"
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            version="${{ inputs.version }}"
+          else
+            version="${GITHUB_REF#refs/tags/v}"
+          fi
           minor="v$(echo "$version" | cut -d. -f1-2)"
           base="ghcr.io/footprintai/containarium-agent-box"
           {
@@ -135,7 +166,8 @@ jobs:
           context: .
           file: ./images/agent-box/Dockerfile
           platforms: linux/amd64
-          push: true
+          # Push on tag only; a rehearsal builds the image and discards it.
+          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           tags: ${{ steps.tags.outputs.tags }}
           provenance: true
           sbom: true

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -93,12 +93,33 @@ permanently on PyPI, whereas on GitHub it only costs a dead tag (as with
 v0.48.0 below).
 
 That asymmetry is the reason not to push a tag "to see if the build
-works". Note there is currently **no way to exercise these builds
-without publishing**: only `distros-py-release.yml` has a
-`workflow_dispatch` trigger (for recovering from a PyPI infra blip, and
-it publishes too). The other three are tag-push only. So the tag push
-*is* the test, which is exactly why steps 1-3 above — merged, green,
-version bumped — are not optional ceremony.
+works" — and the reason you don't have to.
+
+### Rehearsing a release build without publishing
+
+`release.yml`, `containarium-daemon.yml` and `sidecars.yml` each accept
+a `workflow_dispatch` trigger that runs the **identical** build against
+any ref and publishes nothing: no Release, no artifact upload, no image
+push. Use it before tagging, especially when the diff touches the build
+itself (new `cmd/` files, web-ui changes, Dockerfiles, `Makefile`).
+
+```bash
+gh workflow run release.yml --ref main -f version=0.61.0-rc
+gh workflow run containarium-daemon.yml --ref main -f version=0.61.0-rc
+gh workflow run sidecars.yml --ref main -f version=0.61.0-rc
+```
+
+`version` is optional (defaults to `0.0.0-dryrun`) and only labels the
+build — nothing is published under it. Publishing is gated on the ref
+being a tag, so a rehearsal cannot become an accidental release.
+
+This directly covers the two incidents below: both were build failures
+invisible until a real tag had already been pushed, costing a burned
+tag. A rehearsal on the merge commit would have caught either one.
+
+**`distros-py-release.yml` is the exception** — its `workflow_dispatch`
+exists for recovering from a PyPI infra blip and it **does** publish. Do
+not use it as a rehearsal.
 
 ## Why step 5 matters: two real incidents
 


### PR DESCRIPTION
Follow-up to #1119, which documented that a `v*` tag fires four workflows and that **none of the three build workflows could be run without publishing**. That was true when written; this fixes it.

A tag push was the only way these builds ever ran. The two release incidents this repo already records were both a direct consequence:

- **v0.47.0** — Windows CLI cross-compile broke on a missing `//go:build !windows` guard. PR CI never cross-compiled for Windows.
- **v0.48.0** — `make build-release`'s production `next build` failed on two real web-ui compile errors. No PR job ran a full production web-ui build. **No artifacts were ever published from that tag** — it's dead, superseded by v0.48.1.

Both were invisible until the real release build failed, each costing a burned tag. A rehearsal on the merge commit would have caught either.

## What changed

`workflow_dispatch` on `release.yml`, `containarium-daemon.yml`, `sidecars.yml`. The build is identical; publishing is not:

```yaml
# artifacts / Release
if: startsWith(github.ref, 'refs/tags/v')
# images
push: ${{ startsWith(github.ref, 'refs/tags/v') }}
```

So a rehearsal builds everything and publishes nothing — no Release, no artifact upload, no image push. Publishing stays exclusively on tag push.

```bash
gh workflow run release.yml --ref main -f version=0.61.0-rc
```

`version` is optional (defaults `0.0.0-dryrun`) and only labels the build. It's needed because on a dispatch `github.ref` is a branch, so the existing `${GITHUB_REF#refs/tags/v}` would yield a nonsense version.

## ⚠️ Review this first: five publish points, not four

The obvious reading finds four — one Release step, three image pushes. **`release.yml` has a second `softprops/action-gh-release` step**, in the separate `build-bundle` job that uploads the air-gapped bundle. I missed it on the first pass and caught it by enumerating publish steps programmatically rather than by reading:

```
build-and-release: Create GitHub Release   -> if=startsWith(github.ref, 'refs/tags/v')
build-bundle:      Upload bundle to release -> if=startsWith(github.ref, 'refs/tags/v')
```

Left unguarded, a rehearsal would still have attempted a real upload against a nonexistent tag — precisely the accidental publish this change exists to prevent, shipped inside the change meant to prevent it. Worth a reviewer confirming there isn't a sixth I also missed; the enumeration above is the check I'd repeat.

## `distros-py-release.yml` deliberately untouched

It already has `workflow_dispatch`, but that trigger exists to recover from a PyPI infra blip and **it publishes**. PyPI does not allow re-uploading a version even after deletion, so adding a dry-run mode beside a publishing trigger on that particular workflow is a footgun. The doc now says explicitly not to use it as a rehearsal.

## Verification

- All three files re-parsed as YAML after editing; triggers and guards confirmed programmatically (output above), not by eye.
- `grep -c 'push: true'` is **0** across all three — no unguarded image push remains.
- Docs updated in the same commit: the "no way to exercise these builds without publishing" paragraph is replaced with the rehearsal instructions.

**Not verified:** I have not run a dispatch, because the trigger only becomes available once this is on `main`. First real exercise is the next release — worth someone doing a rehearsal run then and confirming it publishes nothing.
