### PR TITLE
fix(service): create /opt/containarium so the daemon doesn't crash-loop on fresh installs

### DIFF
--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -146,7 +146,7 @@ func ensureDaemonUnitAndSecret() error {
 	// install. Every other entry (/var/lib/incus, /etc, /home, /var/log, ...) already
 	// exists; /opt/containarium is the daemon's state dir and may not, so create it
 	// here — the same one place the unit that references it is authored.
-	if err := os.MkdirAll("/opt/containarium", 0755); err != nil {
+	if err := os.MkdirAll("/opt/containarium", 0750); err != nil {
 		return fmt.Errorf("failed to create state directory: %w", err)
 	}
 	// #nosec G306 -- systemd unit, world-readable config by convention; no secrets

--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -141,6 +141,14 @@ func ensureDaemonUnitAndSecret() error {
 	} else {
 		log.Printf("JWT secret already exists: %s", jwtPath)
 	}
+	// ProtectSystem=strict makes systemd fail namespace setup (status=226/NAMESPACE)
+	// if any ReadWritePaths entry is missing, crash-looping the daemon on a fresh
+	// install. Every other entry (/var/lib/incus, /etc, /home, /var/log, ...) already
+	// exists; /opt/containarium is the daemon's state dir and may not, so create it
+	// here — the same one place the unit that references it is authored.
+	if err := os.MkdirAll("/opt/containarium", 0755); err != nil {
+		return fmt.Errorf("failed to create state directory: %w", err)
+	}
 	// #nosec G306 -- systemd unit, world-readable config by convention; no secrets
 	if err := os.WriteFile(systemdServicePath, []byte(systemdServiceTemplate), 0644); err != nil {
 		return fmt.Errorf("failed to write service file: %w", err)


### PR DESCRIPTION
## Problem

On a **fresh** machine, `curl -fsSL https://containarium.dev/install.sh | sudo bash` (→ `containarium service install`) produces a daemon that **crash-loops and never starts**:

```
containarium.service: Failed to set up mount namespacing: /opt/containarium: No such file or directory
containarium.service: Main process exited, code=exited, status=226/NAMESPACE
```

The generated unit uses `ProtectSystem=strict` with:

```
ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /opt/containarium /var/log
```

systemd requires **every** `ReadWritePaths` entry to exist, or mount-namespace setup fails (`226/NAMESPACE`). `ensureDaemonUnitAndSecret()` creates `/etc/containarium` but not `/opt/containarium`. The Terraform startup scripts happen to `mkdir -p /opt/containarium/...`, which is why cloud-provisioned hosts work — but the binary's own `service install` (the documented quick-start path) does not, so the published quick-start yields a dead daemon.

## Fix

Create `/opt/containarium` in `ensureDaemonUnitAndSecret()` — the single place the unit is authored (shared by `service install` and `pool join`) — right before writing the unit. Every other `ReadWritePaths` entry already exists on a normal system.

## Verification (end-to-end, fresh Ubuntu 24.04 VM)

- **Before:** daemon looped on `status=226/NAMESPACE`; REST API never came up.
- **After** `mkdir -p /opt/containarium` + restart: daemon active, `GET /v1/containers` → 200, and `containarium create alice` provisioned a running box (`10.100.0.66`).

This PR bakes that `mkdir` into `service install` so a fresh install works with no manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)