### PR TITLE
fix(systemd): Wants=incus.service, not Requires=, so a transient incus failure isn't fatal

### DIFF
--- a/docs/API-SERVICE-DESIGN.md
+++ b/docs/API-SERVICE-DESIGN.md
@@ -286,7 +286,9 @@ func (s *ContainerServer) ListContainers(ctx context.Context, req *pb.ListContai
 [Unit]
 Description=Containarium Container Management Daemon
 After=network.target incus.service
-Requires=incus.service
+# Wants=, not Requires= -- a failed Requires= dependency kills this unit's
+# start job, and job failures are not retried by Restart=on-failure.
+Wants=incus.service
 
 [Service]
 Type=simple

--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -19,7 +19,13 @@ const systemdServiceTemplate = `[Unit]
 Description=Containarium Container Management Daemon
 Documentation=https://github.com/footprintai/Containarium
 After=network.target incus.service
-Requires=incus.service
+# Wants=, not Requires=. A Requires= dependency that fails takes this unit's
+# start job down with it, and a *job* failure is not something Restart=on-failure
+# retries -- so a single transient incus hiccup at boot leaves the daemon dead
+# until someone notices, which on a pool member means silently dropping out of
+# the pool. After= still guarantees ordering, and Restart=on-failure covers the
+# "incus not ready yet" case by retrying the daemon itself.
+Wants=incus.service
 StartLimitIntervalSec=0
 
 [Service]

--- a/internal/cmd/service_test.go
+++ b/internal/cmd/service_test.go
@@ -3,11 +3,47 @@
 package cmd
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/footprintai/containarium/internal/hostcheck"
 )
+
+// TestSystemdServiceDoesNotHardRequireIncus guards the boot-resilience contract.
+//
+// With Requires=incus.service, a transient incus failure at boot fails
+// containarium.service's *start job*. Restart=on-failure does not retry job
+// failures, so the daemon stays dead even after incus recovers seconds later --
+// observed on a pool member, where it means silently dropping out of the pool
+// until a human notices. After= alone gives the ordering; Wants= keeps a bad
+// incus start from being terminal, and Restart=on-failure handles "not ready yet".
+func TestSystemdServiceDoesNotHardRequireIncus(t *testing.T) {
+	var after, requires, wants []string
+	for _, line := range strings.Split(systemdServiceTemplate, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "#"):
+			continue
+		case strings.HasPrefix(line, "After="):
+			after = strings.Fields(strings.TrimPrefix(line, "After="))
+		case strings.HasPrefix(line, "Requires="):
+			requires = strings.Fields(strings.TrimPrefix(line, "Requires="))
+		case strings.HasPrefix(line, "Wants="):
+			wants = strings.Fields(strings.TrimPrefix(line, "Wants="))
+		}
+	}
+	if slices.Contains(requires, "incus.service") {
+		t.Error("systemdServiceTemplate has Requires=incus.service; use Wants= so a " +
+			"transient incus failure does not permanently kill the daemon's start job")
+	}
+	if !slices.Contains(wants, "incus.service") {
+		t.Errorf("systemdServiceTemplate should declare Wants=incus.service, got Wants=%v", wants)
+	}
+	if !slices.Contains(after, "incus.service") {
+		t.Errorf("systemdServiceTemplate must keep After=incus.service for ordering, got After=%v", after)
+	}
+}
 
 // TestSystemdServiceReadWritePathsCoverDoctorContract guards against the unit's
 // ProtectSystem=strict sandbox drifting away from the paths the daemon's own

--- a/internal/hostcheck/run.go
+++ b/internal/hostcheck/run.go
@@ -58,7 +58,7 @@ func Run() []Check {
 	// 4. The definitive capability-trap test: create + delete a throwaway user.
 	checks = append(checks, useraddProbe())
 
-	// 5. incus present (the unit Requires=incus.service).
+	// 5. incus present (the unit orders itself After=/Wants=incus.service).
 	_, err := exec.LookPath("incus")
 	checks = append(checks, Check{
 		Name: "incus binary present", OK: err == nil, Required: true,

--- a/scripts/containarium.service
+++ b/scripts/containarium.service
@@ -2,7 +2,10 @@
 Description=Containarium Container Management Daemon
 Documentation=https://github.com/footprintai/Containarium
 After=network.target incus.service
-Requires=incus.service
+# Wants=, not Requires= -- a failed Requires= dependency kills this unit's start
+# job, and job failures are not retried by Restart=on-failure. See the comment on
+# systemdServiceTemplate in internal/cmd/service.go.
+Wants=incus.service
 StartLimitIntervalSec=0
 
 [Service]

--- a/terraform/gce/scripts/startup-spot.sh
+++ b/terraform/gce/scripts/startup-spot.sh
@@ -610,7 +610,10 @@ if [ -f /usr/local/bin/containarium ]; then
 Description=Containarium Container Management Daemon
 Documentation=https://github.com/footprintai/Containarium
 After=network.target incus.service
-Requires=incus.service
+# Wants=, not Requires= -- a failed Requires= dependency kills this unit's start
+# job, and job failures are not retried by Restart=on-failure. See the comment on
+# systemdServiceTemplate in internal/cmd/service.go.
+Wants=incus.service
 StartLimitIntervalSec=0
 
 [Service]

--- a/terraform/modules/containarium/scripts/startup-spot.sh
+++ b/terraform/modules/containarium/scripts/startup-spot.sh
@@ -863,7 +863,10 @@ if [ -f /usr/local/bin/containarium ]; then
 Description=Containarium Container Management Daemon
 Documentation=https://github.com/footprintai/Containarium
 After=network.target incus.service
-Requires=incus.service
+# Wants=, not Requires= -- a failed Requires= dependency kills this unit's start
+# job, and job failures are not retried by Restart=on-failure. See the comment on
+# systemdServiceTemplate in internal/cmd/service.go.
+Wants=incus.service
 StartLimitIntervalSec=0
 
 [Service]


### PR DESCRIPTION
The daemon unit declares `Requires=incus.service`. A failed `Requires=`
dependency fails this unit's **start job**, and a job failure is not something
`Restart=on-failure` retries.

Observed at boot on a pool member:

```
04:39:11 systemd[1]: Starting incus.service - Incus - Daemon...
04:39:12 systemd[1]: incus.service: Control process exited, code=killed, status=9/KILL
04:39:13 systemd[1]: Dependency failed for containarium.service
04:39:13 systemd[1]: containarium.service: Job containarium.service/start failed with result 'dependency'
04:39:15 systemd[1]: incus.service: ... active
```

incus recovered three seconds later. The daemon did not, and stayed down until a
human looked — for a pool member, that means silently dropping out of the pool.

`After=incus.service` is what actually provides the ordering and is unchanged.
`Wants=` keeps a bad incus start from being terminal, and the unit's existing
`Restart=on-failure` covers the "incus not ready yet" case by retrying the daemon
itself.

**Operator note:** a drop-in cannot fix this on an already-running host. An empty
`Requires=` reset does not clear the dependency on systemd 255, and systemd does
not garbage-collect reverse dependencies on `daemon-reload` — `systemctl show
incus -p RequiredBy` keeps reporting the old edge until `daemon-reexec`. Hence
fixing it at the source.

## Scope

Applied to every copy of the unit: the template in `internal/cmd/service.go`
(written by both `service install` and `pool join`, so a re-join no longer reverts
a hand-patched host), the standalone `scripts/containarium.service`, and the two
GCE startup scripts. The design doc and a stale `hostcheck` comment are updated to
match.

## Tests

`TestSystemdServiceDoesNotHardRequireIncus` asserts `incus.service` is absent from
`Requires=`, present in `Wants=`, and still present in `After=`. Verified to
actually fail when the fix is reverted, not just pass.

`go build ./...`, `go vet`, and `go test ./internal/...` pass.

## Verification

Applied to a real pool member before being written up here. Three consecutive
reboots then came up clean — daemon, incus, and tunnel all active, no dependency
failures.

## Note on scope change

This PR originally also fixed the `/opt/containarium` `226/NAMESPACE` crashloop.
#1121 landed that same fix independently while this was open, so on rebase that
half was dropped rather than carried as a second, parallel implementation. What
remains here is only the `Requires=`/`Wants=` change, which `main` still needs.

One piece of the dropped half is not covered by #1121 and may be worth a
follow-up: prefixing `-` (ignore-if-absent) on the `ReadWritePaths=` entry, so a
*hand-installed* unit degrades to a legible `containarium doctor` finding instead
of an opaque `226/NAMESPACE` crashloop. #1121 creates the directory on the
installer path only, and does not touch the standalone unit file or the Terraform
scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
