### PR TITLE
fix(systemd): mark /opt/containarium ignore-if-absent in ReadWritePaths

### DIFF
--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -42,7 +42,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /opt/containarium /var/log
+ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log
 
 StandardOutput=journal
 StandardError=journal

--- a/internal/cmd/service_test.go
+++ b/internal/cmd/service_test.go
@@ -10,6 +10,34 @@ import (
 	"github.com/footprintai/containarium/internal/hostcheck"
 )
 
+// TestOptContainariumIsIgnoreIfAbsent pins the "-" prefix on the one
+// ReadWritePaths entry Containarium owns rather than inherits.
+//
+// ProtectSystem=strict makes systemd build the unit's mount namespace before
+// the daemon executes, and a listed path that does not exist fails that setup
+// with status=226/NAMESPACE -- an opaque crashloop naming neither the path nor
+// the setting. Every other entry is a standard system directory that already
+// exists; /opt/containarium is ours and may not. `service install` / `pool
+// join` create it, but a hand-installed unit (scripts/containarium.service,
+// the Terraform startup scripts) has no such guarantee, so the prefix is what
+// degrades that case into a legible `containarium doctor` finding.
+func TestOptContainariumIsIgnoreIfAbsent(t *testing.T) {
+	var fields []string
+	for _, line := range strings.Split(systemdServiceTemplate, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "ReadWritePaths=") {
+			fields = strings.Fields(strings.TrimPrefix(line, "ReadWritePaths="))
+			break
+		}
+	}
+	if len(fields) == 0 {
+		t.Fatal("systemdServiceTemplate has no ReadWritePaths= line")
+	}
+	if !slices.Contains(fields, "-/opt/containarium") {
+		t.Errorf("expected -/opt/containarium (ignore-if-absent) in ReadWritePaths, got %v", fields)
+	}
+}
+
 // TestSystemdServiceDoesNotHardRequireIncus guards the boot-resilience contract.
 //
 // With Requires=incus.service, a transient incus failure at boot fails
@@ -65,7 +93,10 @@ func TestSystemdServiceReadWritePathsCoverDoctorContract(t *testing.T) {
 	}
 	granted := make(map[string]bool)
 	for _, p := range strings.Fields(strings.TrimPrefix(rwLine, "ReadWritePaths=")) {
-		granted[p] = true
+		// A leading "-" means "ignore if absent" (systemd.exec(5)); it is a
+		// modifier, not part of the path, and the doctor contract is about
+		// the path itself.
+		granted[strings.TrimPrefix(p, "-")] = true
 	}
 	for _, required := range hostcheck.DaemonWritablePaths {
 		if !granted[required] {

--- a/scripts/containarium.service
+++ b/scripts/containarium.service
@@ -30,7 +30,7 @@ ProtectHome=false
 # /opt/containarium - runtime state/assets
 # This set MUST match internal/hostcheck.DaemonWritablePaths; a path the doctor
 # requires but ProtectSystem=strict denies makes the host boot DEGRADED.
-ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /var/log /opt/containarium
+ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /var/log -/opt/containarium
 
 StandardOutput=journal
 StandardError=journal

--- a/terraform/gce/scripts/startup-spot.sh
+++ b/terraform/gce/scripts/startup-spot.sh
@@ -628,7 +628,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /opt/containarium /var/log
+ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log
 
 StandardOutput=journal
 StandardError=journal

--- a/terraform/modules/containarium/scripts/startup-spot.sh
+++ b/terraform/modules/containarium/scripts/startup-spot.sh
@@ -881,7 +881,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /opt/containarium /var/log
+ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log
 
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
Follow-up to #1121. That PR made `service install` / `pool join` create
`/opt/containarium`, which fixes the installer path. The unit is also installed
**by hand** — `scripts/containarium.service` and the two Terraform startup
scripts write it directly — and those paths have no such guarantee.

## The failure this closes

With the directory missing, `ProtectSystem=strict` makes systemd fail the
mount-namespace setup *before* the daemon executes:

```
containarium.service: Failed to set up mount namespacing: /opt/containarium: No such file or directory
containarium.service: Main process exited, code=exited, status=226/NAMESPACE
```

Nothing there names the setting responsible. Downstream it surfaces only as
`pool join` reporting `1 required capability check(s) FAILED`, plus an endless
`failed to connect to local 127.0.0.1:8080` from the tunnel, because the API
never binds. None of those point at a missing directory.

## The change

The `-` prefix (systemd.exec(5)) makes systemd skip a listed path that does not
exist. The daemon then starts, and the missing directory shows up as what it
actually is — a legible `containarium doctor` finding:

```
✗ writable: /opt/containarium — missing: stat /opt/containarium: no such file or directory
```

`/opt/containarium` is the only `ReadWritePaths=` entry Containarium owns rather
than inherits; every other one is a standard system directory that already
exists. So it is the only entry that needs this.

Applied to all four copies of the unit: the template in `internal/cmd/service.go`,
`scripts/containarium.service`, and the two GCE startup scripts.

## Prior art in-tree

`scripts/install-lab-phase-b.sh` already hand-rolls a workaround for exactly this:

```sh
# The unit's ReadWritePaths= includes /opt/containarium. systemd refuses
# to start a service with a missing ReadWritePaths entry ("Failed to set
# up mount namespacing: /opt/containarium: No such file or directory"),
# so create it up-front. The daemon writes its persistent state here.
install -d -m 0755 /opt/containarium
```

That workaround is the trap this makes unnecessary to know about. It stays
correct either way — creating the directory is still better than skipping it,
since the daemon does want to write there.

## Interaction with #1121

Complementary, not redundant. #1121 creates the directory so the *normal* path
has it and the doctor check passes; this makes a *missing* directory
non-catastrophic on paths that don't run the installer. Belt and braces on a
failure mode whose symptom points nowhere near its cause.

## Tests

`TestOptContainariumIsIgnoreIfAbsent` pins the prefix — verified to fail when the
prefix is removed, not just pass:

```
--- FAIL: TestOptContainariumIsIgnoreIfAbsent
    expected -/opt/containarium (ignore-if-absent) in ReadWritePaths, got
    [/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /opt/containarium /var/log]
```

The existing `ReadWritePaths`/doctor test now strips the `-` when parsing, since
it is a systemd modifier rather than part of the path — without that it would
read `-/opt/containarium` as a different path and fail spuriously.

`go build ./...`, `go vet`, and the `internal/cmd` + `internal/hostcheck` suites
pass.

## Adjacent, not addressed here

`scripts/containarium-backup.service` lists `/var/lib/containarium`, which has the
same shape of exposure. It is created by `hacks/install.sh` on the supported path
(and removed by `hacks/uninstall.sh`), so it is not obviously broken today —
flagging it rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
