### PR TITLE
fix(systemd): create /var/lib/containarium via StateDirectory= in the backup unit

### DIFF
--- a/internal/cmd/service_test.go
+++ b/internal/cmd/service_test.go
@@ -3,12 +3,54 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/footprintai/containarium/internal/hostcheck"
 )
+
+// TestBackupUnitStateDirectory covers the sibling unit shipped as a plain file
+// (scripts/containarium-backup.service) rather than generated from a Go
+// template, so nothing else in the build would notice it regressing.
+//
+// That unit runs ProtectSystem=strict and needs /var/lib/containarium writable
+// for the backup JSON index. Nothing on the host creates that directory --
+// hacks/install.sh declares DATA_DIR=/var/lib/containarium but never creates it,
+// and the one `mkdir -p /var/lib/containarium` in the tree runs inside a
+// container via incus exec. StateDirectory= is what makes systemd create it and
+// grant write access; an ignore-if-absent ReadWritePaths entry alone would let
+// the unit start with the path read-only, so the index could not be written.
+func TestBackupUnitStateDirectory(t *testing.T) {
+	// Relative to this package dir; the unit ships in the repo, not embedded.
+	raw, err := os.ReadFile(filepath.Join("..", "..", "scripts", "containarium-backup.service"))
+	if err != nil {
+		t.Fatalf("read backup unit: %v", err)
+	}
+	var stateDir string
+	var rwFields []string
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "#"):
+			continue
+		case strings.HasPrefix(line, "StateDirectory="):
+			stateDir = strings.TrimPrefix(line, "StateDirectory=")
+		case strings.HasPrefix(line, "ReadWritePaths="):
+			rwFields = strings.Fields(strings.TrimPrefix(line, "ReadWritePaths="))
+		}
+	}
+	if stateDir != "containarium" {
+		t.Errorf("expected StateDirectory=containarium (creates + grants /var/lib/containarium), got %q", stateDir)
+	}
+	// If the path is also listed explicitly, it must be ignore-if-absent so the
+	// entry itself can never fail namespace setup.
+	if slices.Contains(rwFields, "/var/lib/containarium") {
+		t.Errorf("ReadWritePaths lists /var/lib/containarium without the \"-\" ignore-if-absent prefix: %v", rwFields)
+	}
+}
 
 // TestOptContainariumIsIgnoreIfAbsent pins the "-" prefix on the one
 // ReadWritePaths entry Containarium owns rather than inherits.

--- a/scripts/containarium-backup.service
+++ b/scripts/containarium-backup.service
@@ -32,4 +32,21 @@ SyslogIdentifier=containarium-backup
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=/var/lib/containarium /etc/containarium /tmp
+
+# StateDirectory= makes systemd create /var/lib/containarium before the unit
+# runs and grants it write access. Nothing else on the host does: hacks/install.sh
+# declares DATA_DIR=/var/lib/containarium but never creates it, and the only
+# `mkdir -p /var/lib/containarium` in the tree runs *inside* a container via
+# incus exec, not on the host. Without this, ProtectSystem=strict fails the
+# mount-namespace setup before ExecStart ever runs ("Failed to set up mount
+# namespacing: /var/lib/containarium: No such file or directory",
+# status=226/NAMESPACE) -- and merely marking the path ignore-if-absent would
+# instead let the unit start with the directory read-only, so the backup index
+# could not be written.
+StateDirectory=containarium
+StateDirectoryMode=0750
+
+# -/var/lib/containarium is belt-and-braces: StateDirectory= already creates and
+# grants it, and the "-" (ignore-if-absent) means this entry can never itself be
+# the thing that fails namespace setup.
+ReadWritePaths=-/var/lib/containarium /etc/containarium /tmp


### PR DESCRIPTION
Third and last of the `ProtectSystem=strict` / `226/NAMESPACE` traps in the
shipped units, after #1121 and #1125. This one is the worst of the three, because
nothing on the host creates the directory at all.

## The failure

`containarium-backup.service` runs `ProtectSystem=strict` and lists
`/var/lib/containarium` in `ReadWritePaths=` for the backup JSON index sidecars.
Nothing ever creates it:

- `hacks/install.sh` declares `DATA_DIR="/var/lib/containarium"` — and never uses it
- the only `mkdir -p /var/lib/containarium` in the tree runs **inside a container**
  via `incusClient.Exec` (`internal/server/core_otel_collector.go`), not on the host
- `pkg/core/backup` does `MkdirAll(m.dir, 0o700)` at write time, but `m.dir` is
  `/var/lib/containarium/backups`; the parent is outside the sandbox's writable set
  until it exists

So on a fresh host the unit fails namespace setup before `ExecStart` ever runs:

```
Failed to set up mount namespacing: /var/lib/containarium: No such file or directory
Main process exited, code=exited, status=226/NAMESPACE
```

## Why the #1125 approach is not enough here

#1125 used the `-` (ignore-if-absent) prefix. That was right there: the installer
creates `/opt/containarium`, and the prefix is only a backstop for hand-installed
units.

Here nothing creates the directory, so skipping the path would let the unit start
with `/var/lib/containarium` read-only and the backup index silently unwritable —
trading a loud failure for a quiet one. That's strictly worse for a backup job.

`StateDirectory=containarium` is the right primitive: systemd creates
`/var/lib/containarium` before the unit runs *and* grants it write access.
`StateDirectoryMode=0750` keeps it tight; the `backups` subdirectory is still
created `0700` by `pkg/core/backup` and is unaffected.

The explicit `ReadWritePaths=` entry is kept but `-` prefixed, so it is
redundant-but-harmless rather than able to fail namespace setup itself.

## Deliberately not changed

`Requires=containarium.service` on this unit stays. Unlike the daemon in #1124,
this is a timer-triggered `Type=oneshot` job: if the daemon is down the backup
genuinely cannot run, so failing the job is the correct outcome — it retries on the
next timer rather than needing to survive a transient dependency failure. Flagging
it so it reads as considered rather than missed.

## Tests

`TestBackupUnitStateDirectory` parses the shipped unit file rather than a Go
template — this unit isn't generated, so nothing else in the build would notice it
regressing. It asserts `StateDirectory=containarium` is present, and that any
explicit `/var/lib/containarium` in `ReadWritePaths=` carries the `-` prefix.

Verified to fail both ways it could regress, not just pass:

```
# StateDirectory removed
expected StateDirectory=containarium (creates + grants /var/lib/containarium), got ""

# original pre-fix form
ReadWritePaths lists /var/lib/containarium without the "-" ignore-if-absent prefix:
  [/var/lib/containarium /etc/containarium /tmp]
```

`go build ./...`, `go vet`, and the `internal/cmd` + `internal/hostcheck` suites
pass.

## Caveat on verification

Unlike #1124, I could not exercise this on a systemd host — the `StateDirectory=`
behaviour here rests on documented semantics (systemd.exec(5): state directories
are created before the service starts and are implicitly writable), not on an
observed boot. Worth a reviewer's eye, or one run of
`systemctl start containarium-backup` on a host without `/var/lib/containarium`.

## Related daemon-side finding, not fixed here

`containarium.service` does **not** list `/var/lib/containarium` in its
`ReadWritePaths=` at all, but the daemon is what writes the backup index —
`NewBackupServer` (`internal/server/dual_server.go:442`) defaults to
`/var/lib/containarium/backups`, and `pkg/core/backup` `MkdirAll`s it at write
time. Under `ProtectSystem=strict` that path is read-only for the daemon, so a
LOCAL backup issued through the API looks like it should fail on a default install.

I did not fold that in: adding a writable path to the daemon's sandbox is a
security-relevant widening and a maintainer call, and it is a different unit from
the one this PR is about. Happy to open it as a follow-up (probably the same
`StateDirectory=containarium` on the daemon unit) if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
