### PR TITLE
fix(systemd): grant the daemon /var/lib/containarium so backups can be written

### DIFF
--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -42,7 +42,17 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log
+ReadWritePaths=-/var/lib/containarium /var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log
+
+# StateDirectory= makes systemd create /var/lib/containarium (0750, root) before
+# the daemon starts and grants it write access. The backup service writes there
+# on every destination -- pkg/core/backup stages the dump and its sidecar index
+# under /var/lib/containarium/backups even for GCS -- and nothing else on the
+# host creates that directory, so without this ProtectSystem=strict makes those
+# writes fail EROFS. The "-" on the ReadWritePaths entry above keeps that
+# (now redundant) grant from ever being the thing that fails namespace setup.
+StateDirectory=containarium
+StateDirectoryMode=0750
 
 StandardOutput=journal
 StandardError=journal

--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
@@ -139,6 +140,40 @@ func runServiceInstall(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// daemonOwnedDirs are the unit's ReadWritePaths entries that Containarium owns
+// rather than inherits from the base system, so they may not exist on a fresh
+// host. Everything else the unit grants (/var/lib/incus, /etc, /home, /var/log,
+// /var/lock, /run/lock) already exists or is created by incus.
+//
+// Two reasons these must be created at install time:
+//
+//   - ProtectSystem=strict makes systemd build the mount namespace from
+//     ReadWritePaths= *before* the daemon executes, and a missing listed path
+//     fails that setup with status=226/NAMESPACE — an opaque crashloop naming
+//     neither the path nor the setting.
+//   - They are in hostcheck.DaemonWritablePaths, which the doctor treats as
+//     Required. `pool join` runs its capability self-check after this function,
+//     so creating them here is what lets that check pass on a fresh host
+//     instead of aborting the join.
+//
+// StateDirectory= in the unit covers /var/lib/containarium at runtime too, but
+// only once the unit starts — which is after the doctor has already run.
+var daemonOwnedDirs = []string{"/opt/containarium", "/var/lib/containarium"}
+
+// ensureDaemonOwnedDirs creates the Containarium-owned directories the unit
+// sandbox and the doctor both expect. root is prepended to each path so tests
+// can exercise this without touching the real filesystem; callers pass "/".
+func ensureDaemonOwnedDirs(root string) error {
+	for _, dir := range daemonOwnedDirs {
+		// 0750: every consumer is root (the daemon, the Terraform startup
+		// scripts' markers, logrotate, the backup sidecar index).
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o750); err != nil {
+			return fmt.Errorf("failed to create %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
 // ensureDaemonUnitAndSecret makes the daemon's JWT secret and the canonical
 // hardened systemd unit exist (idempotent). Shared by `service install` and
 // `pool join` so the daemon unit is authored in exactly ONE place
@@ -157,13 +192,8 @@ func ensureDaemonUnitAndSecret() error {
 	} else {
 		log.Printf("JWT secret already exists: %s", jwtPath)
 	}
-	// ProtectSystem=strict makes systemd fail namespace setup (status=226/NAMESPACE)
-	// if any ReadWritePaths entry is missing, crash-looping the daemon on a fresh
-	// install. Every other entry (/var/lib/incus, /etc, /home, /var/log, ...) already
-	// exists; /opt/containarium is the daemon's state dir and may not, so create it
-	// here — the same one place the unit that references it is authored.
-	if err := os.MkdirAll("/opt/containarium", 0750); err != nil {
-		return fmt.Errorf("failed to create state directory: %w", err)
+	if err := ensureDaemonOwnedDirs("/"); err != nil {
+		return err
 	}
 	// #nosec G306 -- systemd unit, world-readable config by convention; no secrets
 	if err := os.WriteFile(systemdServicePath, []byte(systemdServiceTemplate), 0644); err != nil {

--- a/internal/cmd/service_test.go
+++ b/internal/cmd/service_test.go
@@ -52,6 +52,45 @@ func TestBackupUnitStateDirectory(t *testing.T) {
 	}
 }
 
+// TestDaemonUnitGrantsBackupStateDir guards the daemon's ability to write its
+// backup state. pkg/core/backup MkdirAll+WriteFiles under
+// /var/lib/containarium/backups on *every* destination (a GCS backup is staged
+// locally first), plus the sidecar index, list, and restore temp files. That is
+// the daemon process, under ProtectSystem=strict -- so without an explicit grant
+// /var/lib is read-only and every backup fails EROFS. Nothing else on the host
+// creates the directory, hence StateDirectory= rather than a bare path grant.
+func TestDaemonUnitGrantsBackupStateDir(t *testing.T) {
+	var stateDir string
+	var rwFields []string
+	for _, line := range strings.Split(systemdServiceTemplate, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "#"):
+			continue
+		case strings.HasPrefix(line, "StateDirectory="):
+			stateDir = strings.TrimPrefix(line, "StateDirectory=")
+		case strings.HasPrefix(line, "ReadWritePaths="):
+			rwFields = strings.Fields(strings.TrimPrefix(line, "ReadWritePaths="))
+		}
+	}
+	if stateDir != "containarium" {
+		t.Errorf("expected StateDirectory=containarium so systemd creates and grants "+
+			"/var/lib/containarium for the backup service, got %q", stateDir)
+	}
+	granted := false
+	for _, f := range rwFields {
+		if strings.TrimPrefix(f, "-") == "/var/lib/containarium" {
+			granted = true
+			if !strings.HasPrefix(f, "-") {
+				t.Errorf("/var/lib/containarium should be ignore-if-absent (\"-\" prefixed) in ReadWritePaths, got %q", f)
+			}
+		}
+	}
+	if !granted {
+		t.Errorf("ReadWritePaths does not mention /var/lib/containarium: %v", rwFields)
+	}
+}
+
 // TestOptContainariumIsIgnoreIfAbsent pins the "-" prefix on the one
 // ReadWritePaths entry Containarium owns rather than inherits.
 //

--- a/internal/cmd/service_test.go
+++ b/internal/cmd/service_test.go
@@ -52,6 +52,50 @@ func TestBackupUnitStateDirectory(t *testing.T) {
 	}
 }
 
+// TestEnsureDaemonOwnedDirsCreatesThem covers the install-time half of the
+// contract: these paths are Required in hostcheck.DaemonWritablePaths AND listed
+// in the unit's ReadWritePaths, so if they are absent the doctor fails (aborting
+// `pool join`, which runs its self-check after ensureDaemonUnitAndSecret) and
+// systemd fails namespace setup with 226/NAMESPACE.
+func TestEnsureDaemonOwnedDirsCreatesThem(t *testing.T) {
+	root := t.TempDir()
+	if err := ensureDaemonOwnedDirs(root); err != nil {
+		t.Fatalf("ensureDaemonOwnedDirs: %v", err)
+	}
+	for _, dir := range daemonOwnedDirs {
+		fi, err := os.Stat(filepath.Join(root, dir))
+		if err != nil {
+			t.Errorf("%s was not created: %v", dir, err)
+			continue
+		}
+		if !fi.IsDir() {
+			t.Errorf("%s exists but is not a directory", dir)
+		}
+	}
+	// `pool join` is documented idempotent, so re-running must not error.
+	if err := ensureDaemonOwnedDirs(root); err != nil {
+		t.Errorf("second call should be idempotent, got: %v", err)
+	}
+}
+
+// TestDaemonOwnedDirsCoverContainariumOwnedWritablePaths is the join between the
+// doctor contract and what we create. Any Required writable path under a
+// Containarium-owned prefix must be in daemonOwnedDirs — otherwise the doctor
+// demands a directory nothing creates, and `pool join` aborts on a fresh host.
+// System paths (/etc, /home, /var/log, ...) are deliberately excluded: we must
+// not create or re-mode those.
+func TestDaemonOwnedDirsCoverContainariumOwnedWritablePaths(t *testing.T) {
+	for _, required := range hostcheck.DaemonWritablePaths {
+		if required != "/opt/containarium" && required != "/var/lib/containarium" {
+			continue // inherited from the base system
+		}
+		if !slices.Contains(daemonOwnedDirs, required) {
+			t.Errorf("hostcheck.DaemonWritablePaths requires %q but daemonOwnedDirs does not "+
+				"create it; the doctor would fail and pool join would abort on a fresh host", required)
+		}
+	}
+}
+
 // TestDaemonUnitGrantsBackupStateDir guards the daemon's ability to write its
 // backup state. pkg/core/backup MkdirAll+WriteFiles under
 // /var/lib/containarium/backups on *every* destination (a GCS backup is staged

--- a/internal/hostcheck/run.go
+++ b/internal/hostcheck/run.go
@@ -27,9 +27,14 @@ var RequiredCaps = []struct {
 // DaemonWritablePaths must be writable for the daemon (the unit's
 // ReadWritePaths) plus /var/log — useradd touches /var/log/lastlog, the
 // "second, independent trap" the deploy contract calls out.
+// /var/lib/containarium holds the backup sidecar index and staged dumps
+// (pkg/core/backup writes there for every destination, not just LOCAL), so the
+// daemon needs it writable or every backup fails EROFS under
+// ProtectSystem=strict.
 var DaemonWritablePaths = []string{
 	"/var/lib/incus", "/etc/containarium", "/etc", "/home",
-	"/var/lock", "/run/lock", "/opt/containarium", "/var/log",
+	"/var/lock", "/run/lock", "/opt/containarium", "/var/lib/containarium",
+	"/var/log",
 }
 
 // Run executes every host capability check and returns the results. Pure of

--- a/scripts/containarium.service
+++ b/scripts/containarium.service
@@ -30,7 +30,17 @@ ProtectHome=false
 # /opt/containarium - runtime state/assets
 # This set MUST match internal/hostcheck.DaemonWritablePaths; a path the doctor
 # requires but ProtectSystem=strict denies makes the host boot DEGRADED.
-ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /var/log -/opt/containarium
+ReadWritePaths=-/var/lib/containarium /var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /var/log -/opt/containarium
+
+# StateDirectory= makes systemd create /var/lib/containarium (0750, root) before
+# the daemon starts and grants it write access. The backup service writes there
+# on every destination -- pkg/core/backup stages the dump and its sidecar index
+# under /var/lib/containarium/backups even for GCS -- and nothing else on the
+# host creates that directory, so without this ProtectSystem=strict makes those
+# writes fail EROFS. The "-" on the ReadWritePaths entry above keeps that
+# (now redundant) grant from ever being the thing that fails namespace setup.
+StateDirectory=containarium
+StateDirectoryMode=0750
 
 StandardOutput=journal
 StandardError=journal

--- a/terraform/gce/scripts/startup-spot.sh
+++ b/terraform/gce/scripts/startup-spot.sh
@@ -628,7 +628,17 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log
+ReadWritePaths=-/var/lib/containarium /var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log
+
+# StateDirectory= makes systemd create /var/lib/containarium (0750, root) before
+# the daemon starts and grants it write access. The backup service writes there
+# on every destination -- pkg/core/backup stages the dump and its sidecar index
+# under /var/lib/containarium/backups even for GCS -- and nothing else on the
+# host creates that directory, so without this ProtectSystem=strict makes those
+# writes fail EROFS. The "-" on the ReadWritePaths entry above keeps that
+# (now redundant) grant from ever being the thing that fails namespace setup.
+StateDirectory=containarium
+StateDirectoryMode=0750
 
 StandardOutput=journal
 StandardError=journal

--- a/terraform/modules/containarium/scripts/startup-spot.sh
+++ b/terraform/modules/containarium/scripts/startup-spot.sh
@@ -881,7 +881,17 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=/var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log
+ReadWritePaths=-/var/lib/containarium /var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log
+
+# StateDirectory= makes systemd create /var/lib/containarium (0750, root) before
+# the daemon starts and grants it write access. The backup service writes there
+# on every destination -- pkg/core/backup stages the dump and its sidecar index
+# under /var/lib/containarium/backups even for GCS -- and nothing else on the
+# host creates that directory, so without this ProtectSystem=strict makes those
+# writes fail EROFS. The "-" on the ReadWritePaths entry above keeps that
+# (now redundant) grant from ever being the thing that fails namespace setup.
+StateDirectory=containarium
+StateDirectoryMode=0750
 
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
Follow-up to #1126, which fixed the same directory for the *timer* unit. This is
the daemon side, and it is a functional bug rather than a startup one: on a
default install every backup fails.

Two commits — the sandbox grant, then the doctor contract.

## 1. The failure

The daemon serves `BackupService` — `dual_server.go` registers
`NewBackupServer(containerServer)` — and `pkg/core/backup` writes under
`/var/lib/containarium/backups`:

- `MkdirAll(m.dir, 0o700)` then `WriteFile` the staged dump
- the `<id>.meta.json` sidecar index
- `ReadDir(m.dir)` on list
- a `.restore.tmp` on restore

This is **not** a LOCAL-only path — a GCS backup stages the dump locally first,
then uploads and removes it, and the sidecar index stays local for every
destination.

The daemon unit runs `ProtectSystem=strict` and did not grant that path, so
`/var/lib` is read-only for the daemon and all of the above fail `EROFS`. Nothing
in the tree sets `CONTAINARIUM_BACKUP_DIR`, so `defaultBackupDir` is always the
path in play.

## Why StateDirectory= rather than a bare grant

Nothing on the host creates `/var/lib/containarium` — the same finding as #1126:
`hacks/install.sh` declares `DATA_DIR=/var/lib/containarium` and never uses it,
and the only `mkdir -p` for it runs *inside a container* via `incusClient.Exec`.

So a plain `ReadWritePaths=/var/lib/containarium` would convert a runtime `EROFS`
into a boot-time `226/NAMESPACE` crashloop — trading one bug for a worse one.
`StateDirectory=containarium` makes systemd create the directory (0750, root)
before the daemon starts *and* grant write access. The path is also listed in
`ReadWritePaths`, `-` prefixed, so that now-redundant grant can never itself fail
namespace setup.

## 2. The doctor contract

`/var/lib/containarium` is now in `hostcheck.DaemonWritablePaths`, so the doctor
verifies what the daemon actually needs.

That needs care, and is why it is a separate commit. Those entries are
`Required: true`, and `containarium doctor` runs **outside** the unit where
`StateDirectory=` has not applied — so adding the path alone would make the doctor
hard-fail and `pool join` abort on a fresh host. That is precisely the failure
class #1121/#1125 were about.

What makes it safe is creating the directory at install time, in
`ensureDaemonUnitAndSecret()` — which `pool join` calls at pool_join.go:375, well
before its capability self-check at pool_join.go:433. StateDirectory= guarantees
the path for the *running daemon*; install-time creation guarantees it for the
*doctor*, which runs first. Complementary, not redundant.

The single inline `MkdirAll` from #1121 becomes `daemonOwnedDirs` now that there
are two such paths. Everything else the unit grants (`/etc`, `/home`, `/var/log`,
`/var/lock`, `/run/lock`, `/var/lib/incus`) is a system path we must not create or
re-mode.

## Tests

Four tests across the two commits, each verified to fail when its half is
reverted rather than merely passing:

- `TestDaemonUnitGrantsBackupStateDir` — `StateDirectory=containarium` present,
  and `/var/lib/containarium` in `ReadWritePaths` `-` prefixed.
- `TestEnsureDaemonOwnedDirsCreatesThem` — directories created; second call is a
  no-op, since `pool join` is documented idempotent.
- `TestDaemonOwnedDirsCoverContainariumOwnedWritablePaths` — the join between the
  two halves: any Required writable path under a Containarium-owned prefix must be
  in `daemonOwnedDirs`, so the doctor can never again demand a directory nothing
  creates. Dropping the entry fails with exactly that message:
  ```
  hostcheck.DaemonWritablePaths requires "/var/lib/containarium" but daemonOwnedDirs
  does not create it; the doctor would fail and pool join would abort on a fresh host
  ```
- the pre-existing `ReadWritePaths`/doctor superset test now also covers the new
  path for free.

`go build ./...`, `go vet`, `go test ./internal/...` (51 packages) and
`gosec -include=G301` all clean. Applied to all four copies of the unit (Go
template, standalone unit file, two GCE startup scripts), consistent with
#1124/#1125.

## Caveat on verification

As with #1126, I could not exercise this on a systemd host — it rests on documented
`systemd.exec(5)` semantics, not an observed run. The convincing check would be a
`containarium backup` against a LOCAL destination on a fresh host, which should
currently fail `EROFS` on `main` and succeed with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
