### PR TITLE
feat(cli): derive --stack help from the catalog, showing each id with its name

### DIFF
--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/footprintai/containarium/pkg/core/container"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/pkg/core/ostype"
+	"github.com/footprintai/containarium/pkg/core/stacks"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/spf13/cobra"
 )
@@ -57,7 +58,7 @@ The container will be created with:
   - SSH server configured
   - User account with sudo privileges
   - Configurable resource limits
-  - Optional software stack (nodejs, python, golang, rust, datascience, devops, database, fullstack)
+  - Optional software stack (see --stack for the available ids and what each one is)
 
 Examples:
   # Create container with default settings
@@ -85,6 +86,37 @@ Examples:
 	RunE: runCreate,
 }
 
+// stackFlagUsage builds the --stack usage string from the live stack catalog,
+// rendering each id with its human name: "database (Database Clients)".
+//
+// Two reasons not to hard-code the list. It drifts -- the previous literal named
+// eight stacks while the catalog shipped fifteen, so docker, the gpu variants,
+// android and kind-kubeflow were undiscoverable from the CLI. And an id alone can
+// actively mislead: "database" reads as "give this container a database" when the
+// stack installs PostgreSQL/MySQL/Redis *clients* and no server, which is silent
+// until something in the container reaches for a server that was never part of the
+// deal (#1128). The name disambiguates it at the point of use.
+//
+// Reads through stacks.GetDefault(), so an operator's /etc/containarium/stacks.yaml
+// is reflected too rather than the compiled-in default being asserted over it.
+func stackFlagUsage() string {
+	all := stacks.GetDefault().GetAllStacks()
+	if len(all) == 0 {
+		// Catalog unreadable (malformed override with no embedded fallback);
+		// a usable flag with a vague description beats a panic in init().
+		return "Software stack to install"
+	}
+	parts := make([]string, 0, len(all))
+	for _, s := range all {
+		if s.Name == "" || s.Name == s.ID {
+			parts = append(parts, s.ID)
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s (%s)", s.ID, s.Name))
+	}
+	return "Software stack to install: " + strings.Join(parts, ", ")
+}
+
 func init() {
 	rootCmd.AddCommand(createCmd)
 
@@ -104,7 +136,7 @@ func init() {
 	createCmd.Flags().StringVar(&staticIP, "static-ip", "", "Static IP address (e.g., 10.100.0.100) - empty for DHCP")
 	createCmd.Flags().StringVar(&containerImage, "image", "images:ubuntu/24.04", "Container image to use")
 	createCmd.Flags().BoolVar(&enablePodman, "podman", true, "Enable Podman support (nesting)")
-	createCmd.Flags().StringVar(&stackID, "stack", "", "Software stack to install (nodejs, python, golang, rust, datascience, devops, database, fullstack)")
+	createCmd.Flags().StringVar(&stackID, "stack", "", stackFlagUsage())
 	createCmd.Flags().StringSliceVar(&gpuDevices, "gpu", nil, "GPU device(s) for passthrough — index ('0') or PCI address. Repeat or comma-separate for multiple GPUs (e.g., --gpu 0 --gpu 1 or --gpu 0,1)")
 	createCmd.Flags().StringSliceVar(&labels, "labels", []string{}, "Labels in key=value format (can be specified multiple times)")
 	createCmd.Flags().BoolVar(&forceRecreate, "force", false, "Delete and recreate if container already exists")

--- a/internal/cmd/create_stackhelp_test.go
+++ b/internal/cmd/create_stackhelp_test.go
@@ -1,0 +1,63 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/stacks"
+)
+
+// TestStackFlagUsageShowsNames guards the --stack usage string against the two
+// ways it was previously wrong: a hard-coded list that drifted from the catalog
+// (eight ids listed, fifteen shipped) and ids shown without their human name, so
+// "database" read as "a database server" when the stack is clients-only (#1128).
+//
+// Asserted against the live catalog rather than a literal, so the test cannot
+// itself go stale the way the string it replaced did.
+func TestStackFlagUsageShowsNames(t *testing.T) {
+	usage := stackFlagUsage()
+	all := stacks.GetDefault().GetAllStacks()
+	if len(all) == 0 {
+		t.Skip("no stack catalog available in this environment")
+	}
+
+	for _, s := range all {
+		want := s.ID
+		if s.Name != "" && s.Name != s.ID {
+			want = fmt.Sprintf("%s (%s)", s.ID, s.Name)
+		}
+		if !strings.Contains(usage, want) {
+			t.Errorf("--stack usage is missing %q; a stack absent from the help is\n"+
+				"undiscoverable from the CLI. usage=%q", want, usage)
+		}
+	}
+}
+
+// TestStackFlagUsageDisambiguatesClientOnlyStacks pins the specific confusion that
+// prompted #1128: an id that names a category ("database") while the stack installs
+// only clients. Whatever the catalog calls it, the id must not appear bare.
+func TestStackFlagUsageDisambiguatesClientOnlyStacks(t *testing.T) {
+	all := stacks.GetDefault().GetAllStacks()
+	var target *stacks.Stack
+	for i := range all {
+		if all[i].ID == "database" {
+			target = &all[i]
+			break
+		}
+	}
+	if target == nil {
+		t.Skip("no 'database' stack in this catalog")
+	}
+	if target.Name == "" || target.Name == target.ID {
+		t.Fatalf("the 'database' stack has no distinguishing name to surface (name=%q); "+
+			"without one the CLI cannot tell the user it is clients-only", target.Name)
+	}
+	usage := stackFlagUsage()
+	if !strings.Contains(usage, fmt.Sprintf("database (%s)", target.Name)) {
+		t.Errorf("--stack usage should render 'database (%s)' so the id is not mistaken "+
+			"for a database server; usage=%q", target.Name, usage)
+	}
+}


### PR DESCRIPTION
Closes #1128.

## Before / after

```
# before
--stack string   Software stack to install (nodejs, python, golang, rust, datascience, devops, database, fullstack)

# after
--stack string   Software stack to install: nodejs (Node.js Development), python (Python Development),
                 golang (Go Development), rust (Rust Development), datascience (Data Science),
                 devops (DevOps Tools), database (Database Clients), docker (Docker Development),
                 fullstack (Full Stack Web)
```

## Why the literal was wrong in two ways

**It had drifted.** The hard-coded string named eight stacks; the catalog ships
fifteen. `docker`, both `gpu` variants, both `android` stacks and `kind-kubeflow`
were undiscoverable from the CLI entirely — you had to read `stacks.yaml` to learn
they existed.

**It showed ids without names**, and for one id that actively misleads.
`--stack database` reads as "give this container a database". The stack installs
`postgresql-client`, `mysql-client`, `redis-tools` — and no server. It's silent at
create time, since `psql` and `pg_dump` are both on `PATH`, and only surfaces later
when something reaches for a server that was never part of the deal. It also means
such a container can never be a `containarium backup` target, because `pg_dump` runs
against a database *inside* the container.

Note the stack itself is fine: it is named `Database Clients` and its description
says "PostgreSQL, MySQL, and Redis command-line clients". The catalog was honest;
only the CLI was hiding what it said. Hence a presentation fix, not a stack change.

## Approach

`stackFlagUsage()` renders `id (Name)` from `stacks.GetDefault()`:

- the help cannot drift from the catalog again
- it reads through the same loader the rest of the CLI uses, so an operator's
  `/etc/containarium/stacks.yaml` is reflected rather than the compiled-in default
  being asserted over it
- an unreadable catalog degrades to a plain `"Software stack to install"` rather
  than panicking in `init()`

The stale literal in the long help is replaced by a pointer to `--stack`, rather
than a second list to keep in sync.

Option 1 from #1128. I did not add a `containarium stacks list` subcommand
(option 2) — worth doing if the list keeps growing, but it is a new command surface
and this closes the reported confusion on its own.

## Tests

Both verified to fail against the exact string they replace, not merely to pass:

- `TestStackFlagUsageShowsNames` — every catalog stack appears with its name,
  asserted against the live catalog rather than a literal, so the test cannot go
  stale the way the string did. Against the old literal it reports
  `--stack usage is missing "nodejs (Node.js Development)"` and so on.
- `TestStackFlagUsageDisambiguatesClientOnlyStacks` — pins the #1128 case: the
  `database` id must not appear bare, and fails loudly if the catalog ever drops
  the distinguishing name.

`go build ./...`, `go vet`, `go test ./internal/...` (51 packages) and
`gosec -include=G301,G304` all clean.

## Unrelated drift found on the way, not fixed here

There are two stack catalogs and they disagree:

| file | stacks |
| --- | --- |
| `configs/stacks.yaml` | 10 |
| `pkg/core/stacks/stacks.yaml` (embedded) | 15 |

`DefaultConfigPaths` prefers `./configs/stacks.yaml` over the embedded copy, so
running the CLI from a repo checkout sees 10 stacks while a deployed host sees 15 —
which is why the `--stack` help above lists 9 rather than the full set when
rendered from the repo root.

Deployments are unaffected: `hacks/install.sh` does not ship a `stacks.yaml` to
`/etc/containarium`, so hosts fall back to the embedded catalog. So this is a
developer-visible inconsistency rather than a user-facing bug — flagging it rather
than folding a second concern into this PR. Happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
