### PR TITLE
fix(install): ensure Incus has a storage pool, not just a live daemon

### DIFF
--- a/hacks/install.sh
+++ b/hacks/install.sh
@@ -166,9 +166,20 @@ EOF
     INCUS_VERSION=$(incus --version | cut -d'-' -f1)
     log_success "Incus $INCUS_VERSION installed"
 
-    # Check if initialization is needed
+    # Check if initialization is needed.
+    #
+    # A freshly-installed Incus daemon answers `incus info` immediately, but it
+    # has NO storage pool or network yet. Testing `incus info` alone therefore
+    # misreports a brand-new install as "already initialized", skips
+    # `incus admin init`, and leaves the daemon pool-less — so the first
+    # container create fails much later with "Storage pool not found". Require a
+    # storage pool to exist before treating Incus as initialized.
     if ! incus info &> /dev/null; then
         log_info "Initializing Incus with default settings..."
+        incus admin init --auto
+        log_success "Incus initialized"
+    elif ! incus storage list --format csv 2>/dev/null | grep -q .; then
+        log_warn "Incus daemon is up but has no storage pool; initializing..."
         incus admin init --auto
         log_success "Incus initialized"
     else


### PR DESCRIPTION
## What

`hacks/install.sh` decided Incus was initialized whenever `incus info` succeeded. But a freshly-installed Incus daemon answers `incus info` immediately **while having no storage pool or network yet** — so on a truly fresh VM the installer logged "Incus already initialized", skipped `incus admin init --auto`, and left the daemon pool-less.

The failure surfaces much later, at the first container create:

```
Error: ... Failed loading storage pool: Storage pool not found
```

Fix: also require a storage pool to exist before treating Incus as initialized; if the daemon is up but has none, run `incus admin init --auto`.

```bash
elif ! incus storage list --format csv 2>/dev/null | grep -q .; then
    log_warn "Incus daemon is up but has no storage pool; initializing..."
    incus admin init --auto
```

## How it was found

Running `install.sh --quickstart alice --stack nodejs` (the #1123 bootstrap) on a **bare Ubuntu 24.04 VM**:

- installer reported success (Containarium + Incus installed, admin token written)
- `containarium create` failed with *"Storage pool not found"*
- `incus storage list` was **empty**; install.log showed **"Incus already initialized"**
- running `incus admin init --auto` created the `default` (dir) pool, and the create then succeeded (box `Running`)

So this is exactly what the installer-quickstart e2e (#1129) exercises end to end.

## Testing

`bash -n` clean, `shellcheck -S warning` clean on the changed block. Behavior verified live on a fresh VM as above (create fails before → succeeds after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)