### PR TITLE
fix(sentinel): don't tear down a backend's own reconnect (#769)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sentinel no longer tears down a backend's own reconnect (#769).** After a
+  backend host reboots — a routine event when it runs on preemptible capacity
+  — it reconnects its tunnel under the same spot id. `TunnelRegistry.Register`
+  closes the previous yamux session in order to replace the entry, and that
+  close woke the goroutine monitoring the OLD session, which then ran its
+  ordinary disconnect cleanup against the registration that had just replaced
+  it: proxy listeners closed, loopback alias removed, the spot unregistered,
+  and `OnDisconnect` fired, which strips that backend's users out of the
+  sshpiper config. The tunnel was up and healthy; nothing routed over it. SSH
+  to that host's containers stayed broken until an operator restarted the
+  sentinel by hand.
+
+  Each registration now carries a generation, and every teardown step is
+  conditional on that generation still being the current one — checked under
+  the same lock as the mutation it guards, so a superseded watcher cannot race
+  a fresh registration. A genuine disconnect is unaffected and still cleans up
+  fully. A reconnect now re-keys on its own (keysync applies immediately on
+  connect), so the manual `systemctl restart` workaround is no longer needed.
+
 ### Added
 
 - **Live host load per backend in `list_backends` / `GET /v1/backends`** —

--- a/internal/sentinel/pool_test.go
+++ b/internal/sentinel/pool_test.go
@@ -151,7 +151,7 @@ func TestOnTunnelConnect_PeerOnlyDoesNotPromote(t *testing.T) {
 // into the TunnelSpot.
 func TestRegisterPropagatesPool(t *testing.T) {
 	r := NewTunnelRegistry()
-	_, err := r.Register(&TunnelHandshake{SpotID: "spot-1", Ports: []int{8080}, Pool: "prod"}, nil)
+	_, _, err := r.Register(&TunnelHandshake{SpotID: "spot-1", Ports: []int{8080}, Pool: "prod"}, nil)
 	assert.NoError(t, err)
 
 	spot := r.Get("spot-1")
@@ -159,7 +159,7 @@ func TestRegisterPropagatesPool(t *testing.T) {
 	assert.Equal(t, Pool("prod"), spot.Pool)
 
 	// Empty pool stays empty (back-compat).
-	_, err = r.Register(&TunnelHandshake{SpotID: "spot-2", Ports: []int{8080}}, nil)
+	_, _, err = r.Register(&TunnelHandshake{SpotID: "spot-2", Ports: []int{8080}}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, Pool(""), r.Get("spot-2").Pool)
 }

--- a/internal/sentinel/tunnel_registry.go
+++ b/internal/sentinel/tunnel_registry.go
@@ -36,13 +36,34 @@ type TunnelSpot struct {
 	PublicAliases     []string
 	PublicBaseDomains []string
 	PublicPort        int
+
+	// Generation distinguishes successive registrations of the SAME spotID.
+	// A spot that reconnects (the normal case after a backend reboot or spot
+	// preemption) replaces its own entry, and the goroutines watching the
+	// PREVIOUS session are still alive and about to wake up. Without a way to
+	// tell "my registration" from "the one that replaced me", that stale
+	// watcher tears down the fresh one — see UnregisterIfCurrent (#769).
+	Generation uint64
 }
+
+// addLoopbackAliasFn / removeLoopbackAliasFn are indirection seams over the
+// `ip addr` calls. Configuring a loopback alias needs CAP_NET_ADMIN, which a
+// unit test does not have and should not need in order to exercise
+// registration bookkeeping — the same reason isAlreadyExistsErr was split out
+// below. Production always uses the real functions.
+var (
+	addLoopbackAliasFn    = addLoopbackAlias
+	removeLoopbackAliasFn = removeLoopbackAlias
+)
 
 // TunnelRegistry tracks connected tunnel clients and assigns loopback aliases.
 type TunnelRegistry struct {
 	mu      sync.RWMutex
 	spots   map[string]*TunnelSpot
 	usedIPs map[byte]string // octet -> spotID
+	// nextGen hands out registration generations. Monotonic across all
+	// spots; only comparisons within one spotID are meaningful.
+	nextGen uint64
 }
 
 // NewTunnelRegistry creates a new TunnelRegistry.
@@ -58,7 +79,7 @@ func NewTunnelRegistry() *TunnelRegistry {
 // Pool, PublicHostname, PublicAliases, PublicPort are read off the
 // handshake; PublicHostname being set means the sentinel will promote
 // this tunnel into a primary registry entry on connect.
-func (r *TunnelRegistry) Register(hs *TunnelHandshake, session *yamux.Session) (string, error) {
+func (r *TunnelRegistry) Register(hs *TunnelHandshake, session *yamux.Session) (string, uint64, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -70,7 +91,9 @@ func (r *TunnelRegistry) Register(hs *TunnelHandshake, session *yamux.Session) (
 	var octet byte
 	if old, ok := r.spots[spotID]; ok {
 		log.Printf("[tunnel-registry] spot %q reconnecting, reusing IP %s", spotID, old.LocalIP)
-		_ = old.Session.Close()
+		if old.Session != nil {
+			_ = old.Session.Close()
+		}
 		localIP = old.LocalIP
 		for o, id := range r.usedIPs {
 			if id == spotID {
@@ -83,16 +106,19 @@ func (r *TunnelRegistry) Register(hs *TunnelHandshake, session *yamux.Session) (
 		var err error
 		octet, err = r.allocateOctet(spotID)
 		if err != nil {
-			return "", err
+			return "", 0, err
 		}
 		localIP = fmt.Sprintf("127.0.0.%d", octet)
-		if err := addLoopbackAlias(localIP); err != nil {
+		if err := addLoopbackAliasFn(localIP); err != nil {
 			delete(r.usedIPs, octet)
-			return "", fmt.Errorf("add loopback alias %s: %w", localIP, err)
+			return "", 0, fmt.Errorf("add loopback alias %s: %w", localIP, err)
 		}
 	}
 
 	externalPort := ExternalPortBase + int(octet)
+
+	r.nextGen++
+	gen := r.nextGen
 
 	spot := &TunnelSpot{
 		ID:                spotID,
@@ -106,11 +132,44 @@ func (r *TunnelRegistry) Register(hs *TunnelHandshake, session *yamux.Session) (
 		PublicBaseDomains: hs.PublicBaseDomains,
 		PublicPort:        hs.PublicPort,
 		Connected:         time.Now(),
+		Generation:        gen,
 	}
 	r.spots[spotID] = spot
 
-	log.Printf("[tunnel-registry] registered spot %q at %s (ports: %v, pool: %q, primary_host: %q)", spotID, localIP, hs.Ports, hs.Pool, hs.PublicHostname)
-	return localIP, nil
+	log.Printf("[tunnel-registry] registered spot %q at %s gen=%d (ports: %v, pool: %q, primary_host: %q)", spotID, localIP, gen, hs.Ports, hs.Pool, hs.PublicHostname)
+	return localIP, gen, nil
+}
+
+// UnregisterIfCurrent removes the spot ONLY when the registered entry is still
+// generation gen, and reports the spot it removed (nil when it removed
+// nothing).
+//
+// This is the fix for #769's "stale forwarding after a backend reboot". When a
+// spot reconnects, Register closes the previous yamux session and installs a
+// fresh entry under the same spotID. That close wakes the goroutine monitoring
+// the OLD session, which then runs its ordinary disconnect cleanup — closing
+// proxy listeners, dropping the loopback alias, removing the backend's users
+// from the sshpiper config — except the thing it tears down is now the LIVE
+// registration that replaced it. The tunnel is up, and nothing routes over it
+// until the sentinel is restarted by hand.
+//
+// The generation check makes the compare-and-remove atomic under the registry
+// lock, so a superseded watcher can observe that it no longer owns the entry
+// and leave it alone.
+func (r *TunnelRegistry) UnregisterIfCurrent(spotID string, gen uint64) *TunnelSpot {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	spot, ok := r.spots[spotID]
+	if !ok {
+		return nil
+	}
+	if spot.Generation != gen {
+		log.Printf("[tunnel-registry] ignoring cleanup for superseded spot %q gen=%d (current gen=%d)", spotID, gen, spot.Generation)
+		return nil
+	}
+	r.unregisterLocked(spotID)
+	return spot
 }
 
 // UnregisterAll iterates every registered spot and unregisters it.
@@ -138,14 +197,21 @@ func (r *TunnelRegistry) UnregisterAll() {
 func (r *TunnelRegistry) Unregister(spotID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.unregisterLocked(spotID)
+}
 
+// unregisterLocked is the shared body of Unregister / UnregisterIfCurrent.
+// Caller holds r.mu.
+func (r *TunnelRegistry) unregisterLocked(spotID string) {
 	spot, ok := r.spots[spotID]
 	if !ok {
 		return
 	}
 
-	_ = spot.Session.Close()
-	removeLoopbackAlias(spot.LocalIP)
+	if spot.Session != nil {
+		_ = spot.Session.Close()
+	}
+	removeLoopbackAliasFn(spot.LocalIP)
 	delete(r.spots, spotID)
 
 	for octet, id := range r.usedIPs {
@@ -155,7 +221,7 @@ func (r *TunnelRegistry) Unregister(spotID string) {
 		}
 	}
 
-	log.Printf("[tunnel-registry] unregistered spot %q (was at %s)", spotID, spot.LocalIP)
+	log.Printf("[tunnel-registry] unregistered spot %q gen=%d (was at %s)", spotID, spot.Generation, spot.LocalIP)
 }
 
 // DialTunnel opens a yamux stream to the spot's local service on the given

--- a/internal/sentinel/tunnel_reregister_test.go
+++ b/internal/sentinel/tunnel_reregister_test.go
@@ -1,0 +1,289 @@
+package sentinel
+
+// Regression tests for #769: after a backend reboot / spot preemption the
+// backend reconnects under the SAME spot id, and the sentinel used to tear the
+// FRESH registration down — leaving a live tunnel that nothing routed over
+// until an operator ran `systemctl restart` on the sentinel by hand.
+//
+// The mechanism: TunnelRegistry.Register closes the previous yamux session in
+// order to replace the entry. That close wakes the goroutine monitoring the
+// OLD session, which then runs its ordinary disconnect cleanup — closing proxy
+// listeners, dropping the loopback alias, and (via OnDisconnect) stripping the
+// backend's users out of the sshpiper config. All of it aimed at the
+// registration that had just replaced it.
+//
+// These tests pin the generation guard that stops it.
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/require"
+)
+
+// stubLoopbackAliases replaces the `ip addr` calls for the duration of a test.
+// Registration bookkeeping does not need CAP_NET_ADMIN to be worth testing.
+func stubLoopbackAliases(t *testing.T) {
+	t.Helper()
+	origAdd, origRemove := addLoopbackAliasFn, removeLoopbackAliasFn
+	addLoopbackAliasFn = func(string) error { return nil }
+	removeLoopbackAliasFn = func(string) {}
+	t.Cleanup(func() {
+		addLoopbackAliasFn, removeLoopbackAliasFn = origAdd, origRemove
+	})
+}
+
+// newSessionPair returns a live yamux session pair over an in-memory pipe.
+// The "sentinel side" is the one the registry stores.
+func newSessionPair(t *testing.T) (sentinelSide *yamux.Session, cleanup func()) {
+	t.Helper()
+	backendConn, sentinelConn := net.Pipe()
+	backendSession, err := yamux.Server(backendConn, nil)
+	require.NoError(t, err)
+	sentinelSession, err := yamux.Client(sentinelConn, nil)
+	require.NoError(t, err)
+	return sentinelSession, func() {
+		_ = sentinelSession.Close()
+		_ = backendSession.Close()
+		_ = sentinelConn.Close()
+		_ = backendConn.Close()
+	}
+}
+
+func handshake(spotID string) *TunnelHandshake {
+	return &TunnelHandshake{SpotID: spotID, Ports: []int{22, 8080}, Pool: "prod"}
+}
+
+// closeProxiesOnCleanup releases every listener the server installed. Proxy
+// listen ports are derived from the remote port (fixed, e.g. 22 -> 20022), so
+// without this a test leaves a bound port behind and the next one silently
+// gets zero listeners.
+func closeProxiesOnCleanup(t *testing.T, ts *TunnelServer) {
+	t.Helper()
+	t.Cleanup(func() {
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+		for id := range ts.proxies {
+			ts.closeProxiesLocked(id)
+		}
+	})
+}
+
+// TestReconnectKeepsTheNewRegistration is the #769 regression. Without the
+// generation guard the stale monitor unregisters the spot, so the backend
+// disappears from the registry while its tunnel is up.
+func TestReconnectKeepsTheNewRegistration(t *testing.T) {
+	stubLoopbackAliases(t)
+	r := NewTunnelRegistry()
+
+	firstSession, closeFirst := newSessionPair(t)
+	defer closeFirst()
+	firstIP, firstGen, err := r.Register(handshake("spot-1"), firstSession)
+	require.NoError(t, err)
+
+	// The backend reboots and reconnects under the same id. Register closes
+	// the previous session as part of replacing it.
+	secondSession, closeSecond := newSessionPair(t)
+	defer closeSecond()
+	secondIP, secondGen, err := r.Register(handshake("spot-1"), secondSession)
+	require.NoError(t, err)
+
+	require.Equal(t, firstIP, secondIP, "a reconnect must reuse the loopback alias, or sshpiper's config goes stale")
+	require.Greater(t, secondGen, firstGen, "each registration needs a distinct generation to be distinguishable")
+
+	// The stale watcher now wakes up and tries to clean up. It must decline.
+	removed := r.UnregisterIfCurrent("spot-1", firstGen)
+	require.Nil(t, removed,
+		"the superseded registration must not unregister the one that replaced it — this is #769")
+
+	live := r.Get("spot-1")
+	require.NotNil(t, live, "the spot must still be registered after its own reconnect")
+	require.Equal(t, secondGen, live.Generation)
+	require.Same(t, secondSession, live.Session, "the registry must point at the NEW session")
+}
+
+// A genuine disconnect must still clean up — the guard must not turn the
+// teardown path into a no-op.
+func TestGenuineDisconnectStillUnregisters(t *testing.T) {
+	stubLoopbackAliases(t)
+	r := NewTunnelRegistry()
+
+	session, closeSession := newSessionPair(t)
+	defer closeSession()
+	_, gen, err := r.Register(handshake("spot-1"), session)
+	require.NoError(t, err)
+
+	removed := r.UnregisterIfCurrent("spot-1", gen)
+	require.NotNil(t, removed, "the current generation must be able to unregister itself")
+	require.Nil(t, r.Get("spot-1"))
+
+	// Idempotent: a second cleanup for the same generation finds nothing.
+	require.Nil(t, r.UnregisterIfCurrent("spot-1", gen))
+}
+
+// TestMonitorSessionIgnoresSupersededGeneration drives the real code path:
+// startProxies + monitorSession, with a reconnect in between. Without the
+// guard the stale monitor closes the fresh listeners and fires OnDisconnect
+// for a backend that is up — which in production strips that backend's users
+// out of the sshpiper config (Manager.OnTunnelDisconnect) and is exactly why
+// container SSH stayed broken until the sentinel was restarted.
+func TestMonitorSessionIgnoresSupersededGeneration(t *testing.T) {
+	stubLoopbackAliases(t)
+
+	registry := NewTunnelRegistry()
+	ts := NewTunnelServer("127.0.0.1:0", NewTokenPolicy(), registry)
+	closeProxiesOnCleanup(t, ts)
+
+	var mu sync.Mutex
+	var disconnects []string
+	ts.OnDisconnect = func(spot *TunnelSpot) {
+		mu.Lock()
+		defer mu.Unlock()
+		disconnects = append(disconnects, spot.ID)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// First registration, with its listeners and its monitor.
+	firstSession, closeFirst := newSessionPair(t)
+	defer closeFirst()
+	_, firstGen, err := registry.Register(handshake("spot-1"), firstSession)
+	require.NoError(t, err)
+	// Bind on 127.0.0.1 rather than the (stubbed, non-existent) alias.
+	ts.startProxies(ctx, "spot-1", firstGen, "127.0.0.1", 0, []int{22}, firstSession)
+
+	monitorDone := make(chan struct{})
+	go func() {
+		ts.monitorSession("spot-1", firstGen, firstSession)
+		close(monitorDone)
+	}()
+
+	// Reconnect: Register closes firstSession, which wakes the monitor above.
+	secondSession, closeSecond := newSessionPair(t)
+	defer closeSecond()
+	_, secondGen, err := registry.Register(handshake("spot-1"), secondSession)
+	require.NoError(t, err)
+	ts.startProxies(ctx, "spot-1", secondGen, "127.0.0.1", 0, []int{22}, secondSession)
+
+	select {
+	case <-monitorDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the monitor for the superseded session never returned")
+	}
+
+	// The spot is still registered, on the new generation.
+	live := registry.Get("spot-1")
+	require.NotNil(t, live, "the stale monitor unregistered a live backend — #769")
+	require.Equal(t, secondGen, live.Generation)
+
+	// Its listeners are still the new generation's, and still open.
+	ts.mu.Lock()
+	set, ok := ts.proxies["spot-1"]
+	ts.mu.Unlock()
+	require.True(t, ok, "the stale monitor closed the fresh registration's proxy listeners — #769")
+	require.Equal(t, secondGen, set.gen)
+	require.NotEmpty(t, set.listeners)
+	for _, ln := range set.listeners {
+		conn, dialErr := net.DialTimeout("tcp", ln.Addr().String(), 2*time.Second)
+		require.NoError(t, dialErr, "a listener installed by the live registration must still accept connections")
+		_ = conn.Close()
+	}
+
+	// And the manager was never told the backend went away — that callback is
+	// what removes the backend's users from the sshpiper config.
+	mu.Lock()
+	got := append([]string(nil), disconnects...)
+	mu.Unlock()
+	require.Empty(t, got, "OnDisconnect fired for a backend whose tunnel is up — sshpiper would drop its users")
+}
+
+// The mirror case: when the CURRENT session ends, the monitor must do the full
+// teardown, including telling the manager.
+func TestMonitorSessionCleansUpCurrentGeneration(t *testing.T) {
+	stubLoopbackAliases(t)
+
+	registry := NewTunnelRegistry()
+	ts := NewTunnelServer("127.0.0.1:0", NewTokenPolicy(), registry)
+	closeProxiesOnCleanup(t, ts)
+
+	disconnected := make(chan string, 1)
+	ts.OnDisconnect = func(spot *TunnelSpot) { disconnected <- spot.ID }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session, closeSession := newSessionPair(t)
+	defer closeSession()
+	_, gen, err := registry.Register(handshake("spot-1"), session)
+	require.NoError(t, err)
+	ts.startProxies(ctx, "spot-1", gen, "127.0.0.1", 0, []int{8080}, session)
+
+	ts.mu.Lock()
+	listeners := append([]net.Listener(nil), ts.proxies["spot-1"].listeners...)
+	ts.mu.Unlock()
+	require.NotEmpty(t, listeners)
+
+	go ts.monitorSession("spot-1", gen, session)
+
+	// A real disconnect.
+	_ = session.Close()
+
+	select {
+	case id := <-disconnected:
+		require.Equal(t, "spot-1", id)
+	case <-time.After(5 * time.Second):
+		t.Fatal("a genuine disconnect did not reach OnDisconnect")
+	}
+
+	require.Nil(t, registry.Get("spot-1"), "a genuine disconnect must unregister the spot")
+
+	ts.mu.Lock()
+	_, stillThere := ts.proxies["spot-1"]
+	ts.mu.Unlock()
+	require.False(t, stillThere, "a genuine disconnect must drop the proxy listeners")
+
+	for _, ln := range listeners {
+		_, dialErr := net.DialTimeout("tcp", ln.Addr().String(), time.Second)
+		require.Error(t, dialErr, "listeners must actually be closed, not just forgotten")
+	}
+}
+
+// startProxies must not let a late, superseded call clobber the listeners a
+// newer registration already installed.
+func TestStartProxiesRefusesToClobberANewerGeneration(t *testing.T) {
+	stubLoopbackAliases(t)
+
+	registry := NewTunnelRegistry()
+	ts := NewTunnelServer("127.0.0.1:0", NewTokenPolicy(), registry)
+	closeProxiesOnCleanup(t, ts)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session, closeSession := newSessionPair(t)
+	defer closeSession()
+
+	ts.startProxies(ctx, "spot-1", 7, "127.0.0.1", 0, []int{9090}, session)
+	ts.mu.Lock()
+	current := ts.proxies["spot-1"]
+	ts.mu.Unlock()
+	require.Equal(t, uint64(7), current.gen)
+	require.NotEmpty(t, current.listeners)
+
+	// An older registration's call arriving late must be ignored outright.
+	ts.startProxies(ctx, "spot-1", 3, "127.0.0.1", 0, []int{9090}, session)
+
+	ts.mu.Lock()
+	after := ts.proxies["spot-1"]
+	ts.mu.Unlock()
+	require.Equal(t, uint64(7), after.gen, "a stale startProxies replaced the live generation's listeners")
+
+	conn, err := net.DialTimeout("tcp", after.listeners[0].Addr().String(), 2*time.Second)
+	require.NoError(t, err, "the live generation's listener must still be open")
+	_ = conn.Close()
+}

--- a/internal/sentinel/tunnel_server.go
+++ b/internal/sentinel/tunnel_server.go
@@ -25,10 +25,19 @@ type TunnelServer struct {
 	OnConnect    func(spot *TunnelSpot)
 	OnDisconnect func(spot *TunnelSpot)
 
-	// Active proxy listeners per spot (spotID -> list of listeners)
+	// Active proxy listeners per spot. Keyed by spotID and tagged with the
+	// registration generation that installed them, so a superseded watcher
+	// cannot close the listeners belonging to the registration that replaced
+	// it (#769).
 	mu        sync.Mutex
-	proxies   map[string][]net.Listener
+	proxies   map[string]proxySet
 	cancelCtx context.CancelFunc
+}
+
+// proxySet is one registration's listeners plus the generation that owns them.
+type proxySet struct {
+	gen       uint64
+	listeners []net.Listener
 }
 
 // NewTunnelServer creates a new tunnel server with a token-bound pool
@@ -43,7 +52,7 @@ func NewTunnelServer(listenAddr string, policy *TokenPolicy, registry *TunnelReg
 		listenAddr: listenAddr,
 		policy:     policy,
 		registry:   registry,
-		proxies:    make(map[string][]net.Listener),
+		proxies:    make(map[string]proxySet),
 	}
 }
 
@@ -133,7 +142,7 @@ func (ts *TunnelServer) handleConnection(ctx context.Context, conn net.Conn) {
 	}
 
 	// Register in the registry (assigns loopback alias)
-	localIP, err := ts.registry.Register(hs, session)
+	localIP, gen, err := ts.registry.Register(hs, session)
 	if err != nil {
 		log.Printf("[tunnel-server] registration failed for %s: %v", hs.SpotID, err)
 		_ = writeHandshakeResponse(conn, &TunnelHandshakeResponse{OK: false, Error: err.Error()})
@@ -170,7 +179,7 @@ func (ts *TunnelServer) handleConnection(ctx context.Context, conn net.Conn) {
 		}
 		loopbackPorts = filtered
 	}
-	ts.startProxies(ctx, hs.SpotID, localIP, externalPort, loopbackPorts, session)
+	ts.startProxies(ctx, hs.SpotID, gen, localIP, externalPort, loopbackPorts, session)
 
 	// Notify manager
 	spot := ts.registry.Get(hs.SpotID)
@@ -178,8 +187,10 @@ func (ts *TunnelServer) handleConnection(ctx context.Context, conn net.Conn) {
 		ts.OnConnect(spot)
 	}
 
-	// Monitor session — when it closes, clean up
-	go ts.monitorSession(hs.SpotID, session)
+	// Monitor session — when it closes, clean up. The generation is what
+	// keeps this cleanup from firing against a LATER registration of the same
+	// spot (#769).
+	go ts.monitorSession(hs.SpotID, gen, session)
 }
 
 // startProxies opens a local TCP listener on localIP:port for each port.
@@ -188,11 +199,18 @@ func (ts *TunnelServer) handleConnection(ctx context.Context, conn net.Conn) {
 // it falls back to 127.0.0.1.
 // For the health port (8080), it also binds on 0.0.0.0:externalPort so that
 // the primary daemon on another VM can reach this tunnel backend's API.
-func (ts *TunnelServer) startProxies(ctx context.Context, spotID, localIP string, externalPort int, ports []int, session *yamux.Session) {
+func (ts *TunnelServer) startProxies(ctx context.Context, spotID string, gen uint64, localIP string, externalPort int, ports []int, session *yamux.Session) {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
 
-	// Close any existing proxies for this spot
+	// Close any existing proxies for this spot — this registration supersedes
+	// whatever was there.
+	if existing, ok := ts.proxies[spotID]; ok && existing.gen > gen {
+		// A newer registration already installed its listeners while we were
+		// getting here; ours are the stale ones. Bail rather than clobber.
+		log.Printf("[tunnel-server] not installing proxies for spot %q gen=%d — gen=%d is already current", spotID, gen, existing.gen)
+		return
+	}
 	ts.closeProxiesLocked(spotID)
 
 	var listeners []net.Listener
@@ -236,7 +254,7 @@ func (ts *TunnelServer) startProxies(ctx context.Context, spotID, localIP string
 			}
 		}
 	}
-	ts.proxies[spotID] = listeners
+	ts.proxies[spotID] = proxySet{gen: gen, listeners: listeners}
 }
 
 // proxyLoop accepts connections on the local listener and forwards them
@@ -298,26 +316,52 @@ func (ts *TunnelServer) proxyConnection(localConn net.Conn, port int, session *y
 }
 
 // monitorSession watches for the yamux session to close and triggers cleanup.
-func (ts *TunnelServer) monitorSession(spotID string, session *yamux.Session) {
+// monitorSession waits for one registration's session to end and tears that
+// registration down.
+//
+// gen is load-bearing. A reconnecting spot (the normal case after a backend
+// reboot or spot preemption) re-registers under the same spotID, and
+// TunnelRegistry.Register closes the PREVIOUS session to do it — which wakes
+// this goroutine for the old session. Running the ordinary cleanup then would
+// close the fresh listeners, drop the loopback alias, and strip the backend's
+// users out of the sshpiper config, leaving a live tunnel that nothing routes
+// over until someone restarts the sentinel by hand. That is #769.
+//
+// So every step here is conditional on this generation still being the current
+// one, and the check happens under the same lock as the mutation it guards.
+func (ts *TunnelServer) monitorSession(spotID string, gen uint64, session *yamux.Session) {
 	// Wait for the session to close (this blocks until the underlying conn dies
 	// or the session is explicitly closed)
 	<-session.CloseChan()
 
-	log.Printf("[tunnel-server] spot %q session closed, cleaning up", spotID)
-
-	// Get spot info before unregistering (for callback)
-	spot := ts.registry.Get(spotID)
-
-	// Close proxy listeners
+	// Close proxy listeners — only the ones this generation installed.
 	ts.mu.Lock()
-	ts.closeProxiesLocked(spotID)
+	current, ok := ts.proxies[spotID]
+	superseded := ok && current.gen != gen
+	if !superseded {
+		ts.closeProxiesLocked(spotID)
+	}
 	ts.mu.Unlock()
 
-	// Unregister from registry (removes loopback alias)
-	ts.registry.Unregister(spotID)
+	if superseded {
+		log.Printf("[tunnel-server] spot %q session gen=%d closed but gen=%d is already serving — leaving it alone (reconnect, not a disconnect)",
+			spotID, gen, current.gen)
+		return
+	}
+
+	// Unregister from registry (removes loopback alias) — again only if this
+	// generation is still the registered one. A nil result means a newer
+	// registration owns the spot and there is nothing to tear down.
+	spot := ts.registry.UnregisterIfCurrent(spotID, gen)
+	if spot == nil {
+		log.Printf("[tunnel-server] spot %q session gen=%d closed but the registration was superseded — no cleanup", spotID, gen)
+		return
+	}
+
+	log.Printf("[tunnel-server] spot %q session gen=%d closed, cleaning up", spotID, gen)
 
 	// Notify manager
-	if spot != nil && ts.OnDisconnect != nil {
+	if ts.OnDisconnect != nil {
 		ts.OnDisconnect(spot)
 	}
 }
@@ -333,8 +377,8 @@ func isClosedErr(err error) bool {
 }
 
 func (ts *TunnelServer) closeProxiesLocked(spotID string) {
-	if listeners, ok := ts.proxies[spotID]; ok {
-		for _, ln := range listeners {
+	if set, ok := ts.proxies[spotID]; ok {
+		for _, ln := range set.listeners {
 			_ = ln.Close()
 		}
 		delete(ts.proxies, spotID)


### PR DESCRIPTION
Re-opens and fixes the SSH half of #769.

#769 was closed by #862, which fixed the **`:443` data plane** with TCP keepalives on the upstream dialer. The **tunnel control path** has a separate bug with the same symptom, and it is the one that keeps `systemctl restart containarium-sentinel` in the runbook.

## The bug

When a backend host reboots it reconnects its tunnel under the **same spot id**. `TunnelRegistry.Register` closes the previous yamux session in order to replace the entry:

```go
if old, ok := r.spots[spotID]; ok {
    _ = old.Session.Close()   // <- wakes the OLD session's monitor
    ...
}
```

That close wakes `monitorSession` for the *old* session, which had no way to tell "my session died" from "I was replaced". It ran its ordinary disconnect cleanup — against the registration that had just replaced it:

- `closeProxiesLocked(spotID)` closed the **fresh** proxy listeners (including the `20022` hop sshpiper routes container SSH through);
- `registry.Unregister(spotID)` closed the **new** session, dropped the loopback alias, removed the entry;
- `OnDisconnect(spot)` reached `Manager.OnTunnelDisconnect`, which unregisters the primary, removes the backend, and calls `keyStore.RemoveBackend` + `Apply()` — **stripping that backend's users out of the sshpiper config**.

Net effect: the tunnel is up and healthy, and nothing routes over it. SSH to that host's containers stays broken until an operator restarts the sentinel by hand. On preemptible capacity, where reboots are routine, that made a manual restart part of normal operation.

## The fix

Each registration carries a **generation**, and every teardown step is conditional on that generation still being current — checked under the same lock as the mutation it guards, so a superseded watcher cannot race a fresh registration.

- `TunnelRegistry.UnregisterIfCurrent(spotID, gen)` compares and removes atomically, returning the removed spot (nil when superseded).
- `TunnelServer.proxies` becomes `map[string]proxySet{gen, listeners}`; `monitorSession` closes only its own set, and `startProxies` declines to clobber a newer one.
- `OnDisconnect` fires **only** when something was actually unregistered, so the manager is never told a live backend went away.

A genuine disconnect is unaffected and still cleans up fully. Because keysync applies immediately on connect (`RunSyncLoop` syncs before its first tick), a reconnect now **re-keys on its own** — which is what removes the manual-restart step.

`addLoopbackAlias` / `removeLoopbackAlias` move behind package vars so registration bookkeeping is testable without `CAP_NET_ADMIN`. Production behaviour is unchanged.

## Test evidence

Five new tests in `internal/sentinel/tunnel_reregister_test.go`, over **real yamux sessions** on `net.Pipe` (not fakes) and real TCP listeners:

```
--- PASS: TestReconnectKeepsTheNewRegistration
--- PASS: TestGenuineDisconnectStillUnregisters
--- PASS: TestMonitorSessionIgnoresSupersededGeneration
--- PASS: TestMonitorSessionCleansUpCurrentGeneration
--- PASS: TestStartProxiesRefusesToClobberANewerGeneration
ok  	github.com/footprintai/containarium/internal/sentinel
```

**They were verified to fail against the pre-fix behaviour**, not just to pass against the new one. Reverting the two generation guards:

```
--- FAIL: TestReconnectKeepsTheNewRegistration
--- FAIL: TestMonitorSessionIgnoresSupersededGeneration
```

`TestMonitorSessionIgnoresSupersededGeneration` drives the real path — `Register` → `startProxies` → `monitorSession`, with a reconnect in between — and then asserts the three things that were broken in production: the spot is still registered on the new generation, its listeners still **accept a live TCP connection**, and `OnDisconnect` never fired. Its mirror, `TestMonitorSessionCleansUpCurrentGeneration`, asserts a real disconnect still tears everything down and that the listeners are genuinely closed, not just forgotten — so the guard cannot pass by making cleanup a no-op.

`go build ./...`, `go vet ./internal/sentinel/` and `golangci-lint run ./internal/sentinel/...` (v2.12.2) are clean.

**Two pre-existing failures in this package are unrelated to this change**: `TestEnableForwardingOnNonLinux` and `TestRegisterPropagatesPool` both fail on unmodified `main` in an unprivileged environment (`RTNETLINK answers: Operation not permitted` — they need `CAP_NET_ADMIN` to add a loopback alias). Verified identical before and after by stashing the change. I left them alone rather than pull an unrelated fix into this PR, though the new test seam would now make them runnable unprivileged if you want that as a follow-up.

## Reviewer notes

- **Start at `monitorSession`** — the comment there carries the reasoning; the rest is plumbing to make its guard checkable.
- The registry and the server hold **separate locks**, so this deliberately does not attempt one atomic cross-structure operation. Each structure's check-and-act is atomic within its own lock, which is what the race needed.
- `Register`'s signature gains the generation (`(string, uint64, error)`). Only two call sites existed, one of them a test.
- Generations are monotonic across all spots; only comparisons **within** one spot id are meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)