### PR TITLE
feat(mcp): connect with a short-lived SSH certificate when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`connect` uses a short-lived SSH certificate when the server can sign one.**
+  The MCP `connect` tool authorized a managed long-lived key on the box and
+  dialed with it. That leaves a durable credential on every box an agent has
+  ever touched, and those copies drift — after a host restart a box can be left
+  with stale `authorized_keys` and no working login.
+
+  Against a control plane that signs SSH certificates, `connect` now generates a
+  throwaway keypair, has it signed for exactly that box, and uses a certificate
+  that expires in minutes. Nothing is installed on the box, so nothing is left
+  behind and nothing goes stale. The ephemeral key lives in a `0700` directory
+  for the duration of the call and is removed when it returns.
+
+  **Capability-detected, not configured.** A plain daemon has no signing
+  endpoint, and a flag describing which kind of server you pointed at is a flag
+  you will get wrong — so `connect` tries to issue and falls back to the managed
+  key when the endpoint is absent. Existing deployments are unaffected. A server
+  that *can* sign and then fails is surfaced rather than silently downgraded:
+  falling back there would install a long-lived key to paper over a
+  control-plane fault and never mention it.
+
 ### Fixed
 
 - **Sentinel no longer tears down a backend's own reconnect (#769).** After a

--- a/internal/mcp/connect.go
+++ b/internal/mcp/connect.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -52,17 +53,42 @@ func handleConnect(client API, args map[string]interface{}) (string, error) {
 		return "", err
 	}
 
-	// Reuse (or generate once) the managed key the `ssh setup` flow uses,
-	// so the operator never hand-manages a key. The MCP server runs on the
-	// operator's machine, so this is the same key material the CLI sees.
-	pubPath, pub, _, err := sshkey.LocateOrGenerate(sshkey.LocateOpts{})
-	if err != nil {
-		return "", fmt.Errorf("locate or generate managed key: %w", err)
-	}
-	privPath := strings.TrimSuffix(pubPath, ".pub")
+	// Prefer a short-lived certificate when the server can sign one: nothing
+	// is installed on the box, so nothing is left behind and nothing goes
+	// stale after a host restart. Capability-detected — a plain daemon has no
+	// signing endpoint, and falls through to the managed key below.
+	//
+	// `pub` stays empty on the certificate path; it is only used to report
+	// which key was authorized, and on this path none was.
+	var (
+		privPath string
+		pub      string
+		cert     *issuedCert
+	)
+	cert, err = issueCertForBox(client, target.User)
+	switch {
+	case err == nil:
+		defer cert.Cleanup()
+		privPath = cert.PrivateKeyPath
+	case errors.Is(err, errCertUnsupported):
+		// Reuse (or generate once) the managed key the `ssh setup` flow uses,
+		// so the operator never hand-manages a key. The MCP server runs on the
+		// operator's machine, so this is the same key material the CLI sees.
+		var pubPath string
+		pubPath, pub, _, err = sshkey.LocateOrGenerate(sshkey.LocateOpts{})
+		if err != nil {
+			return "", fmt.Errorf("locate or generate managed key: %w", err)
+		}
+		privPath = strings.TrimSuffix(pubPath, ".pub")
 
-	if err := mcpAuthorizeKey(client, box, pub); err != nil {
-		return "", fmt.Errorf("authorize key on %q: %w", box, err)
+		if err := mcpAuthorizeKey(client, box, pub); err != nil {
+			return "", fmt.Errorf("authorize key on %q: %w", box, err)
+		}
+	default:
+		// The server COULD sign and something went wrong. Falling back here
+		// would install a long-lived key to paper over a control-plane fault
+		// and never mention it, so surface it instead.
+		return "", fmt.Errorf("issue certificate for %q: %w", box, err)
 	}
 
 	// Tier 2 — stateful tmux session on the box. State (cd, exports,
@@ -84,6 +110,16 @@ func handleConnect(client API, args map[string]interface{}) (string, error) {
 	if execCmd == "" {
 		// Config mode: hand the ready invocation back for the human to run.
 		sshArgs := connectcore.BuildSSHArgs(target, privPath, execCmd)
+		if cert != nil {
+			// The identity is deleted when this call returns, so a copied
+			// command would fail later with an unexplained "no such file".
+			// Say so rather than hand over an invocation that quietly rots.
+			return fmt.Sprintf(
+				"✓ %s is ready — issued %s (no key installed on the box).\n"+
+					"This certificate lives only for the duration of this call; run `connect` with `exec` to use it,\n"+
+					"or re-run `connect` when you want a fresh one for your terminal.\n",
+				box, certTTLNote(cert, time.Now())), nil
+		}
 		fp, _ := sshkey.Fingerprint(pub)
 		return fmt.Sprintf(
 			"✓ %s is ready — key %s authorized.\nRun this in your terminal:\n\n    ssh %s\n",

--- a/internal/mcp/sshcert.go
+++ b/internal/mcp/sshcert.go
@@ -1,0 +1,170 @@
+package mcp
+
+// Short-lived SSH certificates for the `connect` tool.
+//
+// `connect` authorizes a managed long-lived key on the box
+// (POST /v1/containers/<box>/ssh-keys) and dials with it. That works, but it
+// leaves a durable credential on every box the agent has ever touched, and
+// those copies drift — after a host restart a box can be left with stale
+// authorized_keys and no working login.
+//
+// When the server is a control plane that can sign certificates, there is a
+// better answer: generate a throwaway keypair, have it signed for exactly this
+// box, and use a certificate that expires in minutes. Nothing is installed on
+// the box, so nothing is left behind and nothing can go stale.
+//
+// CAPABILITY-DETECTED, NOT CONFIGURED. A plain Containarium daemon has no
+// signing endpoint, and asking a user to set a flag to describe which kind of
+// server they pointed at is a flag they will get wrong. So `connect` tries to
+// issue, and falls back to the managed key when the endpoint is absent. The
+// fallback is the common path today and is what the tests exercise hardest.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// certIssuePath is the control-plane endpoint that signs a public key.
+const certIssuePath = "/v1/ssh/certificates:issue"
+
+// errCertUnsupported means the server does not sign certificates — a plain
+// daemon rather than a control plane. Callers fall back to the managed key.
+//
+// Distinct from every other failure on purpose: "this server cannot do
+// certificates" is a routine deployment fact, while "the server could and
+// refused" is a real problem the operator should see rather than have silently
+// papered over by a fallback.
+var errCertUnsupported = errors.New("this server does not issue SSH certificates")
+
+// issuedCert is a signed certificate plus the ephemeral key it belongs to.
+type issuedCert struct {
+	// PrivateKeyPath is a throwaway key in a 0700 dir. Cleanup removes it.
+	PrivateKeyPath string
+	Principals     []string
+	ValidBefore    time.Time
+	// Cleanup removes the key material. Always non-nil when err == nil, and
+	// callers must defer it — a certificate login that leaves its key behind
+	// has given up the property it exists for.
+	Cleanup func()
+}
+
+// issueCertForBox asks the server for a certificate scoped to one box.
+//
+// box is the SSH login name (`cld-<short>`), which is what an MCP client has:
+// the OSS container projection carries no cloud UUID. The control plane
+// accepts either.
+func issueCertForBox(client API, box string) (*issuedCert, error) {
+	// Reuse the package's existing generator rather than a second copy of
+	// the same 10 lines.
+	pubAuthorized, privPEM, err := generateEphemeralSSHKey("containarium mcp connect")
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := client.doRequest("POST", certIssuePath, map[string]any{
+		"public_key": pubAuthorized,
+		// Scoped to this box alone. Sending an empty list would ask for every
+		// container the token can reach, which on an org-wide token is a
+		// certificate for the whole org — the opposite of what a per-box
+		// connect should hold.
+		"container_ids": []string{box},
+	})
+	if err != nil {
+		if isCertUnsupported(err) {
+			return nil, errCertUnsupported
+		}
+		return nil, fmt.Errorf("issue certificate for %q: %w", box, err)
+	}
+
+	var resp struct {
+		Certificate string   `json:"certificate"`
+		Principals  []string `json:"principals"`
+		ValidBefore string   `json:"validBefore"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("decode certificate response: %w", err)
+	}
+	if strings.TrimSpace(resp.Certificate) == "" {
+		// A 200 with no certificate is not something to fall back from
+		// quietly: the server claimed to sign and produced nothing.
+		return nil, errors.New("the server returned an empty certificate")
+	}
+
+	dir, err := os.MkdirTemp("", "containarium-cert-")
+	if err != nil {
+		return nil, fmt.Errorf("create identity dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+
+	keyPath := filepath.Join(dir, "id_ed25519")
+	// 0600 — ssh refuses a looser private key, and is right to.
+	if err := os.WriteFile(keyPath, privPEM, 0o600); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("write ephemeral key: %w", err)
+	}
+	cert := resp.Certificate
+	if !strings.HasSuffix(cert, "\n") {
+		cert += "\n"
+	}
+	// OpenSSH only presents a certificate that sits next to its private key
+	// as "<key>-cert.pub"; anywhere else and it is silently ignored.
+	if err := os.WriteFile(keyPath+"-cert.pub", []byte(cert), 0o600); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("write certificate: %w", err)
+	}
+
+	out := &issuedCert{
+		PrivateKeyPath: keyPath,
+		Principals:     resp.Principals,
+		Cleanup:        cleanup,
+	}
+	if resp.ValidBefore != "" {
+		if t, perr := time.Parse(time.RFC3339, resp.ValidBefore); perr == nil {
+			out.ValidBefore = t
+		}
+	}
+	return out, nil
+}
+
+// isCertUnsupported reports whether an error means the endpoint is not there,
+// as opposed to being there and refusing.
+//
+// Matching on the message is unlovely, but doRequest flattens the status code
+// into an error string, and widening that seam for this one caller would touch
+// every backend implementation. The trade is contained by failing toward
+// "supported": anything unrecognised is surfaced to the operator rather than
+// silently downgraded to the long-lived-key path, so a real failure cannot
+// hide behind the fallback.
+func isCertUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"404",
+		"not found",
+		"501",
+		"not implemented",
+		"unimplemented",
+		"unknown method",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// certTTLNote renders the remaining lifetime for the human-facing config-mode
+// output, so it is obvious the invocation is perishable.
+func certTTLNote(c *issuedCert, now time.Time) string {
+	if c.ValidBefore.IsZero() {
+		return "a short-lived certificate"
+	}
+	return fmt.Sprintf("a certificate valid for %s", c.ValidBefore.Sub(now).Round(time.Second))
+}

--- a/internal/mcp/sshcert_test.go
+++ b/internal/mcp/sshcert_test.go
@@ -1,0 +1,315 @@
+package mcp
+
+// Tests for certificate-based `connect` (cloud #1083).
+//
+// The fallback is the path that matters most today: a plain Containarium
+// daemon has no signing endpoint, so every existing deployment takes it. A
+// regression there breaks `connect` for everyone, while a regression on the
+// certificate path breaks it only where certificates are available. The tests
+// weight accordingly.
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// certStubAPI is an API whose doRequest is scripted per path, so a test can
+// say "the signing endpoint 404s" or "it returns this body" without a daemon.
+type certStubAPI struct {
+	API
+	responses map[string][]byte
+	errs      map[string]error
+	// calls records every path hit, so a test can assert that the managed-key
+	// authorize endpoint was NOT called on the certificate path.
+	calls []string
+}
+
+func (s *certStubAPI) doRequest(method, path string, _ interface{}) ([]byte, error) {
+	s.calls = append(s.calls, method+" "+path)
+	if err, ok := s.errs[path]; ok {
+		return nil, err
+	}
+	if body, ok := s.responses[path]; ok {
+		return body, nil
+	}
+	return nil, errors.New("unexpected path " + path)
+}
+
+func (s *certStubAPI) called(substr string) bool {
+	for _, c := range s.calls {
+		if strings.Contains(c, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestIssueCertForBox_FallsBackWhenServerCannotSign(t *testing.T) {
+	// Every error shape a daemon without the endpoint can produce.
+	for _, msg := range []string{
+		"POST /v1/ssh/certificates:issue: HTTP 404: Not Found",
+		"HTTP 501: Not Implemented",
+		"rpc error: code = Unimplemented desc = unknown method",
+	} {
+		t.Run(msg, func(t *testing.T) {
+			api := &certStubAPI{errs: map[string]error{certIssuePath: errors.New(msg)}}
+			_, err := issueCertForBox(api, "cld-abc")
+			if !errors.Is(err, errCertUnsupported) {
+				t.Fatalf("issueCertForBox() = %v, want errCertUnsupported so connect falls back", err)
+			}
+		})
+	}
+}
+
+// The other half of the fallback contract: a server that CAN sign and fails
+// must not be papered over. Falling back would install a long-lived key to
+// work around a control-plane fault and never mention it.
+func TestIssueCertForBox_RealFailuresAreNotSwallowed(t *testing.T) {
+	for _, msg := range []string{
+		"HTTP 403: permission denied",
+		"HTTP 500: issue certificate failed",
+		"HTTP 401: invalid or expired token",
+		"dial tcp: connection refused",
+	} {
+		t.Run(msg, func(t *testing.T) {
+			api := &certStubAPI{errs: map[string]error{certIssuePath: errors.New(msg)}}
+			_, err := issueCertForBox(api, "cld-abc")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if errors.Is(err, errCertUnsupported) {
+				t.Fatalf("a real failure (%q) was misread as 'server cannot sign' — connect would silently install a long-lived key", msg)
+			}
+		})
+	}
+}
+
+// A 200 carrying no certificate is a server that claimed to sign and produced
+// nothing. That must be an error, not a fallback.
+func TestIssueCertForBox_EmptyCertificateIsAnError(t *testing.T) {
+	api := &certStubAPI{responses: map[string][]byte{
+		certIssuePath: []byte(`{"certificate":"","principals":[]}`),
+	}}
+	_, err := issueCertForBox(api, "cld-abc")
+	if err == nil {
+		t.Fatal("an empty certificate must be an error")
+	}
+	if errors.Is(err, errCertUnsupported) {
+		t.Fatal("an empty certificate must not read as 'server cannot sign'")
+	}
+}
+
+func TestIssueCertForBox_WritesAUsableIdentity(t *testing.T) {
+	// Sign a real certificate so the on-disk layout is exercised end to end.
+	caSigner, _ := newCertTestCA(t)
+	var captured struct {
+		PublicKey    string   `json:"public_key"`
+		ContainerIDs []string `json:"container_ids"`
+	}
+
+	api := &recordingCertAPI{
+		certStubAPI: certStubAPI{},
+		sign: func(body interface{}) ([]byte, error) {
+			raw, _ := json.Marshal(body)
+			_ = json.Unmarshal(raw, &captured)
+
+			pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(captured.PublicKey))
+			if err != nil {
+				return nil, err
+			}
+			cert := &ssh.Certificate{
+				Key:             pub,
+				CertType:        ssh.UserCert,
+				KeyId:           "user=test",
+				ValidPrincipals: []string{"cld-abc"},
+				ValidAfter:      0,
+				ValidBefore:     ssh.CertTimeInfinity,
+			}
+			if err := cert.SignCert(cryptoRand(), caSigner); err != nil {
+				return nil, err
+			}
+			return json.Marshal(map[string]any{
+				"certificate": string(ssh.MarshalAuthorizedKey(cert)),
+				"principals":  []string{"cld-abc"},
+				"validBefore": time.Now().Add(5 * time.Minute).UTC().Format(time.RFC3339),
+			})
+		},
+	}
+
+	got, err := issueCertForBox(api, "cld-abc")
+	if err != nil {
+		t.Fatalf("issueCertForBox() error = %v", err)
+	}
+	defer got.Cleanup()
+
+	// Scoped to the one box. An empty list would ask for every container the
+	// token can reach — on an org-wide token, a certificate for the whole org.
+	if len(captured.ContainerIDs) != 1 || captured.ContainerIDs[0] != "cld-abc" {
+		t.Errorf("container_ids = %v, want exactly [cld-abc]", captured.ContainerIDs)
+	}
+
+	fi, err := os.Stat(got.PrivateKeyPath)
+	if err != nil {
+		t.Fatalf("private key not written: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("private key mode = %o, want 0600 (ssh refuses looser)", perm)
+	}
+	// OpenSSH only presents a certificate that sits next to its key as
+	// "<key>-cert.pub"; anywhere else and it is silently ignored.
+	certPath := got.PrivateKeyPath + "-cert.pub"
+	raw, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("certificate not written next to the key: %v", err)
+	}
+	parsed, _, _, _, err := ssh.ParseAuthorizedKey(raw)
+	if err != nil {
+		t.Fatalf("written certificate does not parse: %v", err)
+	}
+	if _, ok := parsed.(*ssh.Certificate); !ok {
+		t.Fatalf("written file is %T, not a certificate", parsed)
+	}
+
+	// The identity must not outlive the call — that is the whole property.
+	got.Cleanup()
+	if _, err := os.Stat(got.PrivateKeyPath); !os.IsNotExist(err) {
+		t.Error("ephemeral key survived Cleanup — a certificate login that leaves its key behind gives up what it exists for")
+	}
+}
+
+func TestCertTTLNote(t *testing.T) {
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	if got := certTTLNote(&issuedCert{ValidBefore: now.Add(5 * time.Minute)}, now); !strings.Contains(got, "5m0s") {
+		t.Errorf("certTTLNote = %q, want the remaining lifetime", got)
+	}
+	// An absent expiry must still read sensibly rather than as a huge or
+	// negative duration.
+	if got := certTTLNote(&issuedCert{}, now); !strings.Contains(got, "short-lived") {
+		t.Errorf("certTTLNote with no expiry = %q", got)
+	}
+}
+
+// --- helpers ---
+
+// recordingCertAPI lets a test sign the exact key the code under test
+// generated, so the certificate is real rather than a fixture string.
+type recordingCertAPI struct {
+	certStubAPI
+	sign func(body interface{}) ([]byte, error)
+}
+
+func (r *recordingCertAPI) doRequest(method, path string, body interface{}) ([]byte, error) {
+	r.calls = append(r.calls, method+" "+path)
+	if path == certIssuePath && r.sign != nil {
+		return r.sign(body)
+	}
+	return r.certStubAPI.doRequest(method, path, body)
+}
+
+func newCertTestCA(t *testing.T) (ssh.Signer, ssh.PublicKey) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signer, signer.PublicKey()
+}
+
+func cryptoRand() io.Reader { return rand.Reader }
+
+// TestConnect_CertificatePathInstallsNoKeyOnTheBox is the headline claim of
+// the feature, asserted where it can actually be observed: when the server can
+// sign, `connect` must NOT call the authorize-key endpoint. If it does, a
+// long-lived key is on the box and the certificate bought nothing.
+func TestConnect_CertificatePathInstallsNoKeyOnTheBox(t *testing.T) {
+	caSigner, _ := newCertTestCA(t)
+	api := &connectFixtureAPI{caSigner: caSigner, canSign: true}
+
+	// Config mode (no `exec`) so the test stops before dialling SSH — the
+	// credential decision has already been made by then, which is what is
+	// under test.
+	out, err := handleConnect(api, map[string]interface{}{"box": "cld-abc"})
+	if err != nil {
+		t.Fatalf("handleConnect() error = %v", err)
+	}
+
+	if api.called("/ssh-keys") {
+		t.Error("connect authorized a long-lived key on the box despite the server signing certificates — the certificate bought nothing")
+	}
+	if !api.called(certIssuePath) {
+		t.Error("connect did not ask for a certificate")
+	}
+	if !strings.Contains(out, "no key installed") {
+		t.Errorf("output should tell the operator no key was installed:\n%s", out)
+	}
+}
+
+// The fallback, asserted the same way: with a server that cannot sign, the
+// managed-key path must still run. This is every existing deployment.
+func TestConnect_FallsBackToTheManagedKey(t *testing.T) {
+	api := &connectFixtureAPI{canSign: false}
+
+	if _, err := handleConnect(api, map[string]interface{}{"box": "cld-abc"}); err != nil {
+		t.Fatalf("handleConnect() error = %v", err)
+	}
+	if !api.called("/ssh-keys") {
+		t.Error("connect did not authorize the managed key on a server that cannot issue certificates — connect would be broken for every plain daemon")
+	}
+}
+
+// connectFixtureAPI serves the minimum handleConnect needs: one running box,
+// and a signing endpoint that either works or 404s.
+type connectFixtureAPI struct {
+	certStubAPI
+	caSigner ssh.Signer
+	canSign  bool
+}
+
+func (f *connectFixtureAPI) doRequest(method, path string, body interface{}) ([]byte, error) {
+	f.calls = append(f.calls, method+" "+path)
+	switch {
+	case strings.HasSuffix(path, "/ssh-keys"):
+		return []byte(`{}`), nil
+	case path == certIssuePath:
+		if !f.canSign {
+			return nil, errors.New("POST " + path + ": HTTP 404: Not Found")
+		}
+		var req struct {
+			PublicKey string `json:"public_key"`
+		}
+		raw, _ := json.Marshal(body)
+		_ = json.Unmarshal(raw, &req)
+		pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(req.PublicKey))
+		if err != nil {
+			return nil, err
+		}
+		cert := &ssh.Certificate{
+			Key: pub, CertType: ssh.UserCert, KeyId: "user=test",
+			ValidPrincipals: []string{"cld-abc"}, ValidBefore: ssh.CertTimeInfinity,
+		}
+		if err := cert.SignCert(cryptoRand(), f.caSigner); err != nil {
+			return nil, err
+		}
+		return json.Marshal(map[string]any{
+			"certificate": string(ssh.MarshalAuthorizedKey(cert)),
+			"principals":  []string{"cld-abc"},
+			"validBefore": time.Now().Add(5 * time.Minute).UTC().Format(time.RFC3339),
+		})
+	case strings.HasPrefix(path, "/v1/containers/"):
+		return []byte(`{"container":{"username":"cld-abc","state":"RUNNING","network":{"ipAddress":"10.0.0.5"}}}`), nil
+	}
+	return nil, errors.New("unexpected path " + path)
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -955,7 +955,11 @@ func (s *Server) registerTools() {
 				"name: the command runs inside a named tmux session ON THE BOX, so a later call " +
 				"with the same `session` sees the same shell — `cd /app` then `pwd` returns " +
 				"/app. A human can `tmux attach` to that session too. The SSH target is the " +
-				"box's ssh_host (or its IP if the daemon reports none) and its SSH username.",
+				"box's ssh_host (or its IP if the daemon reports none) and its SSH username.\n\n" +
+				"Credential: against a control plane that can sign SSH certificates, connect uses a " +
+				"short-lived certificate scoped to this box and installs NOTHING on it — nothing to " +
+				"rotate and nothing left behind after a restart. Against a plain daemon it falls back " +
+				"to authorizing a managed key, as before. You do not configure which; it is detected.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{


### PR DESCRIPTION
## The problem

The MCP `connect` tool authorizes a **managed long-lived key** on the box (`POST /v1/containers/<box>/ssh-keys`) and dials with it. That works, but it leaves a durable credential on every box an agent has ever touched, and those copies drift — after a host restart a box can be left with stale `authorized_keys` and no working login.

## The change

Against a server that can sign SSH certificates, `connect` generates a throwaway keypair, has it signed for exactly that box, and uses a certificate that expires in minutes. **Nothing is installed on the box** — nothing to rotate, nothing left behind after a restart. The ephemeral key lives in a `0700` dir for the duration of the call and is removed on return.

## Capability-detected, not configured

A plain daemon has no signing endpoint, and a flag describing which kind of server you pointed at is a flag you will get wrong. So `connect` tries to issue and falls back to the managed key when the endpoint is absent.

**Every existing deployment takes the fallback**, so that is the path the tests weight most heavily — a regression there breaks `connect` for everyone, while a regression on the certificate path breaks it only where certificates exist.

Two things deliberately do **not** fall back:

- **A server that *can* sign and then fails.** Falling back would install a long-lived key to paper over a control-plane fault and never mention it. `TestIssueCertForBox_RealFailuresAreNotSwallowed` covers 403 / 500 / 401 / dial-refused.
- **A 200 carrying no certificate.** The server claimed to sign and produced nothing; that is an error, not a downgrade.

The `isCertUnsupported` seam matches on the error message, which is unlovely — `doRequest` flattens the status code into a string, and widening that seam for one caller would touch every backend implementation. The trade is contained by **failing toward "supported"**: anything unrecognised is surfaced rather than silently downgraded.

## Scoping

The request names the one box by its SSH login name. Sending an empty list would ask for every container the token can reach — on an org-wide token, a certificate for the whole org, which is the opposite of what a per-box `connect` should hold.

## Test evidence

```
$ go build ./... && go vet ./internal/mcp/ && go test ./internal/mcp/ -count=1
ok  	github.com/footprintai/containarium/internal/mcp	0.300s
$ golangci-lint run ./internal/mcp/...   → 0 issues
```

| test | covers |
|---|---|
| `TestConnect_CertificatePathInstallsNoKeyOnTheBox` | the headline claim — asserts the authorize-key endpoint is **not** called |
| `TestConnect_FallsBackToTheManagedKey` | the path every existing deployment takes |
| `TestIssueCertForBox_FallsBackWhenServerCannotSign` (3) | 404 / 501 / Unimplemented |
| `TestIssueCertForBox_RealFailuresAreNotSwallowed` (4) | a real failure must not hide behind the fallback |
| `TestIssueCertForBox_EmptyCertificateIsAnError` | a 200 with no cert |
| `TestIssueCertForBox_WritesAUsableIdentity` | `0600` key, cert at `<key>-cert.pub` (OpenSSH ignores it anywhere else), scoped request, cleanup actually removes it |

Mutation-checked: forcing the managed-key path — i.e. making the feature do nothing — turns `TestConnect_CertificatePathInstallsNoKeyOnTheBox` red on both assertions.

The certificate in the tests is **really signed** by a throwaway CA and re-parsed, rather than a fixture string, so the on-disk layout is exercised the way OpenSSH will read it.

## Reviewer notes

- **Start at the file comment in `internal/mcp/sshcert.go`** — it states the fallback contract; the rest follows.
- **This is inert against a plain daemon**, which is every deployment of this repo today. It only activates against a control plane that serves a signing endpoint, and even there the target's `sshd` must trust the CA before a certificate login can succeed. Until both are true, `connect` behaves exactly as it does now.
- I could not test against a live signing control plane; the certificate path is covered by unit tests with a real signer, not by an end-to-end run.
- Existing `connect` behaviour, args and output are unchanged on the fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)