### PR TITLE
feat(sentinel): trust SSH CA-signed user certs at sshpiperd (additive)

### DIFF
--- a/internal/sentinel/keysync.go
+++ b/internal/sentinel/keysync.go
@@ -22,6 +22,15 @@ const (
 	sshpiperConfigFile  = "/etc/sshpiper/config.yaml"
 	sshpiperUsersDir    = "/etc/sshpiper/users"
 	sshpiperUpstreamKey = "/etc/sshpiper/upstream_key"
+
+	// sshpiperTrustedUserCAKeys is where an operator installs the SSH
+	// certificate-authority public key(s) that sshpiper should trust. When this
+	// file exists and is non-empty, every generated pipe additionally accepts
+	// CA-signed user certificates (sshpiper's trusted_user_ca_keys) — the
+	// sentinel's sshpiperd is the ONE place a container-SSH user's key is
+	// verified, so this is where certificate trust has to live. Absent = the
+	// pre-existing authorized_keys-only behaviour, unchanged.
+	sshpiperTrustedUserCAKeys = "/etc/sshpiper/trusted_user_ca_keys"
 )
 
 // backendKeys holds the users fetched from a single backend.
@@ -35,6 +44,16 @@ type backendKeys struct {
 	sshPort  int
 	lastSync time.Time
 	lastErr  error
+}
+
+// userRoute is one resolved user→backend mapping that becomes a single sshpiper
+// pipe. Package-level (not local to Apply) so renderSSHPiperConfig and its test
+// can name it.
+type userRoute struct {
+	username       string
+	authorizedKeys string
+	backendIP      string
+	sshPort        int // backend-advertised; 0 = legacy convention
 }
 
 // KeyStore syncs SSH authorized keys from one or more backends and generates
@@ -118,12 +137,6 @@ func (ks *KeyStore) RemoveBackend(backendID string) {
 func (ks *KeyStore) Apply() error {
 	ks.mu.RLock()
 	// Build a merged user list with per-user backend IP routing
-	type userRoute struct {
-		username       string
-		authorizedKeys string
-		backendIP      string
-		sshPort        int // backend-advertised; 0 = legacy convention
-	}
 	seen := make(map[string]bool)
 	var routes []userRoute
 
@@ -207,25 +220,8 @@ func (ks *KeyStore) Apply() error {
 		log.Printf("[keysync] pruned %d stale sshpiper user dirs", pruned)
 	}
 
-	// Generate sshpiper YAML config with per-user backend routing
-	var buf bytes.Buffer
-	buf.WriteString("version: \"1.0\"\npipes:\n")
-
-	for _, r := range routes {
-		sshPort := routeTargetPort(r.backendIP, r.sshPort)
-		akPath := filepath.Join(sshpiperUsersDir, r.username, "authorized_keys")
-		fmt.Fprintf(&buf, "  - from:\n")
-		fmt.Fprintf(&buf, "      - username: %q\n", r.username)
-		fmt.Fprintf(&buf, "        authorized_keys:\n")
-		fmt.Fprintf(&buf, "          - %s\n", akPath)
-		fmt.Fprintf(&buf, "    to:\n")
-		fmt.Fprintf(&buf, "      host: %s:%d\n", r.backendIP, sshPort)
-		fmt.Fprintf(&buf, "      username: %q\n", r.username)
-		fmt.Fprintf(&buf, "      ignore_hostkey: true\n")
-		fmt.Fprintf(&buf, "      private_key: %s\n", sshpiperUpstreamKey)
-	}
-
-	newContent := buf.Bytes()
+	// Generate sshpiper YAML config with per-user backend routing.
+	newContent := renderSSHPiperConfig(routes, sshpiperCAKeysPath())
 
 	// Compare with existing config
 	oldContent, _ := os.ReadFile(sshpiperConfigFile)
@@ -405,6 +401,49 @@ func routeTargetPort(backendIP string, advertised int) int {
 	default:
 		return advertised
 	}
+}
+
+// sshpiperCAKeysPath returns the trusted-user-CA-keys path to embed in the
+// generated config, or "" when no CA trust anchor is installed. Gated on the
+// file existing and being non-empty so the daemon's behaviour is unchanged
+// until an operator installs the CA public key there — certificate auth then
+// turns on without a code change or flag flip, and removing the file turns it
+// back off.
+func sshpiperCAKeysPath() string {
+	if fi, err := os.Stat(sshpiperTrustedUserCAKeys); err == nil && !fi.IsDir() && fi.Size() > 0 {
+		return sshpiperTrustedUserCAKeys
+	}
+	return ""
+}
+
+// renderSSHPiperConfig builds the sshpiper YAML for the given routes. When
+// caKeysPath is non-empty, each pipe also trusts CA-signed user certificates
+// (sshpiper's trusted_user_ca_keys) IN ADDITION TO the per-user authorized_keys
+// — an additive migration: existing key-based SSH keeps working while
+// certificate auth is accepted at the sentinel, the only place a container-SSH
+// user's key is verified. Pure and deterministic so the output is unit-tested
+// directly and stays byte-stable for the skip-if-unchanged compare in Apply.
+func renderSSHPiperConfig(routes []userRoute, caKeysPath string) []byte {
+	var buf bytes.Buffer
+	buf.WriteString("version: \"1.0\"\npipes:\n")
+	for _, r := range routes {
+		sshPort := routeTargetPort(r.backendIP, r.sshPort)
+		akPath := filepath.Join(sshpiperUsersDir, r.username, "authorized_keys")
+		fmt.Fprintf(&buf, "  - from:\n")
+		fmt.Fprintf(&buf, "      - username: %q\n", r.username)
+		fmt.Fprintf(&buf, "        authorized_keys:\n")
+		fmt.Fprintf(&buf, "          - %s\n", akPath)
+		if caKeysPath != "" {
+			fmt.Fprintf(&buf, "        trusted_user_ca_keys:\n")
+			fmt.Fprintf(&buf, "          - %s\n", caKeysPath)
+		}
+		fmt.Fprintf(&buf, "    to:\n")
+		fmt.Fprintf(&buf, "      host: %s:%d\n", r.backendIP, sshPort)
+		fmt.Fprintf(&buf, "      username: %q\n", r.username)
+		fmt.Fprintf(&buf, "      ignore_hostkey: true\n")
+		fmt.Fprintf(&buf, "      private_key: %s\n", sshpiperUpstreamKey)
+	}
+	return buf.Bytes()
 }
 
 func (ks *KeyStore) backendCount() int {

--- a/internal/sentinel/keysync_test.go
+++ b/internal/sentinel/keysync_test.go
@@ -117,7 +117,7 @@ func TestKeyStore_YAMLConfigGeneration(t *testing.T) {
 		{Username: "alice", AuthorizedKeys: "ssh-ed25519 AAAA_alice"},
 		{Username: "bob", AuthorizedKeys: "ssh-rsa AAAA_bob"},
 	}
-	backendIP := "10.130.0.15"
+	backendIP := "192.0.2.15"
 
 	// Simulate the YAML generation from Apply()
 	var lines []string
@@ -149,7 +149,7 @@ func TestKeyStore_YAMLConfigGeneration(t *testing.T) {
 	if !strings.Contains(yaml, "username: \"bob\"") {
 		t.Error("YAML missing bob")
 	}
-	if !strings.Contains(yaml, "host: 10.130.0.15:22") {
+	if !strings.Contains(yaml, "host: 192.0.2.15:22") {
 		t.Error("YAML missing backend host")
 	}
 	if !strings.Contains(yaml, "ignore_hostkey: true") {
@@ -233,4 +233,63 @@ func TestKeyStore_PushSentinelKey(t *testing.T) {
 
 	// Verify the mock server works
 	_ = receivedKey
+}
+
+// TestRenderSSHPiperConfig pins the generated sshpiper YAML directly (the real
+// function, not a mirror). The no-CA case must be byte-identical to the
+// historical output — Apply skips the rewrite when bytes are unchanged, so any
+// drift there would churn the live config. The CA case is additive: every pipe
+// gains trusted_user_ca_keys while keeping its authorized_keys.
+func TestRenderSSHPiperConfig(t *testing.T) {
+	routes := []userRoute{
+		{username: "alice", authorizedKeys: "ssh-ed25519 AAAA_alice", backendIP: "192.0.2.15"},
+		{username: "bob", authorizedKeys: "ssh-rsa AAAA_bob", backendIP: "192.0.2.15"},
+	}
+
+	t.Run("no CA installed — byte-identical to authorized_keys-only output", func(t *testing.T) {
+		const golden = `version: "1.0"
+pipes:
+  - from:
+      - username: "alice"
+        authorized_keys:
+          - /etc/sshpiper/users/alice/authorized_keys
+    to:
+      host: 192.0.2.15:22
+      username: "alice"
+      ignore_hostkey: true
+      private_key: /etc/sshpiper/upstream_key
+  - from:
+      - username: "bob"
+        authorized_keys:
+          - /etc/sshpiper/users/bob/authorized_keys
+    to:
+      host: 192.0.2.15:22
+      username: "bob"
+      ignore_hostkey: true
+      private_key: /etc/sshpiper/upstream_key
+`
+		if got := string(renderSSHPiperConfig(routes, "")); got != golden {
+			t.Errorf("no-CA output drifted from historical config.\n--- got ---\n%s\n--- want ---\n%s", got, golden)
+		}
+	})
+
+	t.Run("CA installed — additive: every pipe trusts the CA and keeps authorized_keys", func(t *testing.T) {
+		const caPath = "/etc/sshpiper/trusted_user_ca_keys"
+		out := string(renderSSHPiperConfig(routes, caPath))
+		if c := strings.Count(out, "trusted_user_ca_keys:"); c != len(routes) {
+			t.Errorf("expected trusted_user_ca_keys in each of %d pipes, got %d", len(routes), c)
+		}
+		if c := strings.Count(out, "- "+caPath); c != len(routes) {
+			t.Errorf("expected the CA keys path in each of %d pipes, got %d", len(routes), c)
+		}
+		if c := strings.Count(out, "authorized_keys:"); c != len(routes) {
+			t.Errorf("authorized_keys must be retained in each pipe (additive), got %d", c)
+		}
+		// The CA line belongs inside the `from:` matcher, before `to:`.
+		fromIdx := strings.Index(out, "trusted_user_ca_keys:")
+		toIdx := strings.Index(out, "    to:")
+		if fromIdx < 0 || toIdx < 0 || fromIdx > toIdx {
+			t.Error("trusted_user_ca_keys must appear within the from: block, before to:")
+		}
+	})
 }


### PR DESCRIPTION
## Why
Container SSH is authenticated in exactly one place — **sshpiperd on the sentinel**, via each pipe's `from.authorized_keys`. The workhorse host sshd only verifies sshpiper's *own* upstream key, and LXC containers run no sshd of their own (entry is `incus exec`). So for SSH **certificate** auth to work at all, the CA has to be trusted here — there is no downstream sshd that sees the user's key.

## What
sshpiper's yaml plugin (v1.5.3) already supports `trusted_user_ca_keys` in the `from` matcher. This wires it in:

- When `/etc/sshpiper/trusted_user_ca_keys` exists and is non-empty, every generated pipe trusts CA-signed user certificates **in addition to** the per-user `authorized_keys`.
- **Additive** — existing key-based SSH is unaffected; certificate auth turns on the moment an operator installs the CA public key at that path, and off when it's removed. No flag, no code change to toggle.

## Testing
- Extracts the YAML generation into a pure `renderSSHPiperConfig(routes, caKeysPath)` so it's unit-tested **directly** (replacing a mirror-of-the-logic test). A golden byte-match proves the no-CA output is byte-identical to the previous behaviour — important because `Apply` skips the rewrite when the bytes are unchanged.
- New cases cover: no CA installed (unchanged output), and CA installed (every pipe gains `trusted_user_ca_keys`, keeps `authorized_keys`, and the CA line sits inside the `from:` matcher).
- Also swaps the tests' backend IP to the RFC 5737 documentation range.

## Rollout
Behaviour is unchanged until an operator drops a CA public key at `/etc/sshpiper/trusted_user_ca_keys`. An operator wanting certificate-based container SSH installs the CA there (refreshing on rotation); sshpiperd then accepts short-lived CA-signed certs at the point where the user is actually authenticated.