### PR TITLE
fix(systemd): grant the daemon /mnt/incus-data so recovery config can be written

### DIFF
--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -43,7 +43,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=-/var/lib/containarium /var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log
+ReadWritePaths=-/var/lib/containarium /var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log -/mnt/incus-data
 
 # StateDirectory= makes systemd create /var/lib/containarium (0750, root) before
 # the daemon starts and grants it write access. The backup service writes there

--- a/scripts/containarium.service
+++ b/scripts/containarium.service
@@ -28,9 +28,13 @@ ProtectHome=false
 # /var/lock, /run/lock - for useradd flock serialization
 # /var/log - useradd touches /var/log/lastlog (the "second capability trap")
 # /opt/containarium - runtime state/assets
+# /mnt/incus-data - the daemon writes containarium-recovery.yaml here when the
+#   persistent disk is mounted (see saveRecoveryConfigToPersistentStorage in
+#   internal/cmd/daemon.go and DefaultRecoveryConfigPath in internal/cmd/recover.go).
+#   "-" prefixed because the mount is optional; the daemon stat-gates the write.
 # This set MUST match internal/hostcheck.DaemonWritablePaths; a path the doctor
 # requires but ProtectSystem=strict denies makes the host boot DEGRADED.
-ReadWritePaths=-/var/lib/containarium /var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /var/log -/opt/containarium
+ReadWritePaths=-/var/lib/containarium /var/lib/incus /etc/containarium /etc /home /var/lock /run/lock /var/log -/opt/containarium -/mnt/incus-data
 
 # StateDirectory= makes systemd create /var/lib/containarium (0750, root) before
 # the daemon starts and grants it write access. The backup service writes there


### PR DESCRIPTION
## Problem

`saveRecoveryConfigToPersistentStorage` (`internal/cmd/daemon.go:857`) writes
`containarium-recovery.yaml` to `/mnt/incus-data` whenever that directory exists,
and `DefaultRecoveryConfigPath` (`internal/cmd/recover.go:48`) reads it back —
that file is what makes auto-recovery after an instance recreation possible.

Neither unit template listed `/mnt/incus-data` in `ReadWritePaths`. Under
`ProtectSystem=strict` the write therefore fails `EROFS` on **exactly the hosts
where the persistent disk is mounted** — so the recovery config is silently
never written precisely where the feature was meant to work. The daemon logs a
warning and carries on:

```
Warning: Failed to save recovery config: failed to write config file:
open /mnt/incus-data/containarium-recovery.yaml: read-only file system
```

Found on a production backend host while investigating unrelated CPU load; it
had been logging this on every daemon start.

The failure is quiet in the worst way: nothing is degraded at runtime, the
daemon starts fine, and the gap only becomes visible when someone recreates the
instance and discovers there is no recovery config to recover from.

## Fix

Add `-/mnt/incus-data` to `ReadWritePaths` in both unit templates
(`internal/cmd/service.go`, `scripts/containarium.service`), plus a comment
documenting the path and pointing at the two code sites that use it.

The `-` (ignore-if-absent) prefix is deliberate: the mount is optional, and the
daemon already stat-gates the write. This matches the existing treatment of
`-/opt/containarium` and `-/var/lib/containarium`.

## Why this is not added to `hostcheck.DaemonWritablePaths`

`DaemonWritablePaths` is what the doctor *requires*. Adding an optional mount
there would make any host without the persistent disk boot DEGRADED — the exact
trap the existing comment above `ReadWritePaths` warns about. The path needs to
be writable *when present*, which is what an ignore-if-absent `ReadWritePaths`
entry expresses and what `DaemonWritablePaths` cannot.

That asymmetry is why the contract test still passes: `ReadWritePaths` must be a
superset of `DaemonWritablePaths`, and adding an entry keeps it one.

## Testing

- `go build ./...` — clean
- `go test ./internal/cmd/... ./internal/hostcheck/...` — both pass

`internal/cmd` is the relevant suite: `service_test.go:88` enforces the
`ReadWritePaths` ⊇ `DaemonWritablePaths` invariant, and `service_test.go:129`
enforces the ignore-if-absent convention this change follows.

## Note for operators

A host already running a stale unit file will keep failing this write until the
unit is redeployed — the fix ships in the template, not in the binary. Worth a
`systemctl cat containarium | grep ReadWritePaths` on existing hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
