### PR TITLE
fix(terraform): add /mnt/incus-data to the startup-script unit's ReadWritePaths (follow-up to #1151)

### DIFF
--- a/terraform/gce/scripts/startup-spot.sh
+++ b/terraform/gce/scripts/startup-spot.sh
@@ -628,7 +628,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=-/var/lib/containarium /var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log
+ReadWritePaths=-/var/lib/containarium /var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log -/mnt/incus-data
 
 # StateDirectory= makes systemd create /var/lib/containarium (0750, root) before
 # the daemon starts and grants it write access. The backup service writes there

--- a/terraform/modules/containarium/scripts/startup-spot.sh
+++ b/terraform/modules/containarium/scripts/startup-spot.sh
@@ -881,7 +881,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=false
-ReadWritePaths=-/var/lib/containarium /var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log
+ReadWritePaths=-/var/lib/containarium /var/lib/incus /etc/containarium /etc /home /var/lock /run/lock -/opt/containarium /var/log -/mnt/incus-data
 
 # StateDirectory= makes systemd create /var/lib/containarium (0750, root) before
 # the daemon starts and grants it write access. The backup service writes there


### PR DESCRIPTION
Follow-up to #1151.

## The gap

#1151 added `-/mnt/incus-data` to `ReadWritePaths` so the daemon can write
`containarium-recovery.yaml` under `ProtectSystem=strict`. It fixed the two
copies I knew about at the time:

- `internal/cmd/service.go` — the template compiled into the binary and rendered
  by `containarium service install`
- `scripts/containarium.service` — the repo reference copy

The unit is actually written in **four** places. The two remaining copies are
inline heredocs in the GCE startup scripts:

- `terraform/gce/scripts/startup-spot.sh:631`
- `terraform/modules/containarium/scripts/startup-spot.sh:884`

Both were byte-identical to each other and to the pre-#1151 line. This PR brings
them in line, so all four copies now match exactly.

## Why these two are the ones that matter

The startup scripts run **at instance boot**, which is precisely the
instance-recreation path that `containarium-recovery.yaml` exists to serve. Left
unfixed, a rebuilt spot instance comes up with a unit that cannot persist the
recovery config — so it is unable to help with the *next* recreation. The fix
would have been silently undone by the exact event it was meant to survive.

Note that `scripts/deploy-binary.sh` does not deploy unit files at all (it stops
the service, copies the binary, restarts), so nothing in the normal upgrade path
would have corrected a host booted from the stale heredoc.

## Verification

- `bash -n` passes on both scripts.
- All four `ReadWritePaths=` lines now contain `-/mnt/incus-data`:

```
$ grep -rn "ReadWritePaths=-/var/lib/containarium" --include=*.sh --include=*.go --include=*.service . | grep -c mnt/incus-data
4
```

## Worth a follow-up

Four hand-maintained copies of one unit file is the actual defect here — this is
the second PR in a row to fix "the same" line. A test that asserts the heredocs
match the `service.go` template (or generating them from it) would make the next
drift impossible rather than merely caught. Filing that separately rather than
widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
