### PR TITLE
fix(collaborator): terminate the account's live session on removal (#1177)

### DIFF
--- a/pkg/core/container/collaborator.go
+++ b/pkg/core/container/collaborator.go
@@ -259,14 +259,32 @@ func (cm *CollaboratorManager) RemoveCollaborator(ownerUsername, collaboratorUse
 	return nil
 }
 
-// removeCollaboratorUser removes a collaborator user from the container
+// removeCollaboratorUser removes a collaborator user from the container.
+//
+// Revoking a collaborator must END their access now, not merely block the next
+// reconnect: a plain `userdel -r` neither kills the account's live SSH session
+// nor — without -f — even succeeds while the account is in use (it exits with
+// "user is currently used by process"), so an active shell survives the revoke.
+// So we terminate the account's sessions/processes first, then force-remove it.
+// This mirrors the host-side jump-server account deletion, which already kills a
+// live session before userdel (see runUserdel, #1035); this is the same fix for
+// the in-container account.
 func (cm *CollaboratorManager) removeCollaboratorUser(containerName, accountName string) error {
 	// Remove sudoers file
 	sudoersPath := fmt.Sprintf("/etc/sudoers.d/%s", accountName)
 	_ = cm.manager.incus.Exec(containerName, []string{"rm", "-f", sudoersPath})
 
-	// Delete user and home directory
-	if err := cm.manager.incus.Exec(containerName, []string{"userdel", "-r", accountName}); err != nil {
+	// Terminate any live session/processes owned by the account BEFORE deleting
+	// it. Both are best-effort: loginctl exists only on systemd-based images,
+	// and pkill exits non-zero when nothing matched (a benign race), so their
+	// statuses are deliberately ignored — the KILL is what drops the shell.
+	_ = cm.manager.incus.Exec(containerName, []string{"loginctl", "terminate-user", accountName})
+	_ = cm.manager.incus.Exec(containerName, []string{"pkill", "-KILL", "-u", accountName})
+
+	// Delete user and home directory. -f forces removal even if the account was
+	// referenced a moment ago, so a lingering process can't block the delete
+	// (and can't leave a re-loginnable account behind).
+	if err := cm.manager.incus.Exec(containerName, []string{"userdel", "-rf", accountName}); err != nil {
 		return fmt.Errorf("failed to delete user: %w", err)
 	}
 

--- a/pkg/core/container/collaborator_session_test.go
+++ b/pkg/core/container/collaborator_session_test.go
@@ -1,0 +1,124 @@
+package container
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// recordingBackend records the argv of every Exec issued into the container.
+// It embeds incus.Backend so it satisfies the 28-method interface with nil
+// method bodies for everything the test doesn't exercise; only Exec is real.
+type recordingBackend struct {
+	incus.Backend
+	calls       [][]string
+	userdelErr  error // injected failure for the userdel step
+	userdelSeen bool
+}
+
+func (r *recordingBackend) Exec(_ string, command []string) error {
+	r.calls = append(r.calls, command)
+	if len(command) > 0 && command[0] == "userdel" {
+		r.userdelSeen = true
+		return r.userdelErr
+	}
+	return nil
+}
+
+func (r *recordingBackend) index(cmd string) int {
+	for i, c := range r.calls {
+		if len(c) > 0 && c[0] == cmd {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestRemoveCollaboratorUser_TerminatesSessionThenForceDeletes pins the #1177
+// contract: revoking a collaborator kills the account's live session BEFORE
+// deleting it, and the delete is forced (-f) so an in-use account can't block
+// removal or survive re-loginnable.
+func TestRemoveCollaboratorUser_TerminatesSessionThenForceDeletes(t *testing.T) {
+	fake := &recordingBackend{}
+	cm := &CollaboratorManager{manager: &Manager{incus: fake}}
+
+	const account = "owner-container-alice"
+	if err := cm.removeCollaboratorUser("owner-container", account); err != nil {
+		t.Fatalf("removeCollaboratorUser: %v", err)
+	}
+
+	pkillIdx := fake.index("pkill")
+	loginctlIdx := fake.index("loginctl")
+	userdelIdx := fake.index("userdel")
+
+	if loginctlIdx == -1 {
+		t.Errorf("expected a loginctl terminate-user call: %v", fake.calls)
+	}
+	if pkillIdx == -1 {
+		t.Fatalf("expected a pkill call to terminate the session: %v", fake.calls)
+	}
+	if userdelIdx == -1 {
+		t.Fatalf("expected a userdel call: %v", fake.calls)
+	}
+
+	// Session termination must happen BEFORE the account is deleted — otherwise
+	// the live shell survives the revoke.
+	if pkillIdx > userdelIdx {
+		t.Errorf("pkill (@%d) must run before userdel (@%d): %v", pkillIdx, userdelIdx, fake.calls)
+	}
+
+	// pkill targets the account's UID with SIGKILL.
+	if got := fake.calls[pkillIdx]; !equalArgs(got, []string{"pkill", "-KILL", "-u", account}) {
+		t.Errorf("pkill args = %v, want [pkill -KILL -u %s]", got, account)
+	}
+
+	// userdel must force-remove (-f) so an in-use account can't block the
+	// delete or be left re-loginnable.
+	if got := fake.calls[userdelIdx]; !hasForceFlag(got) {
+		t.Errorf("userdel must use -f (force): %v", got)
+	}
+}
+
+// TestRemoveCollaboratorUser_UserdelErrorSurfaces keeps the existing contract:
+// a genuine userdel failure still propagates (the best-effort session-kill
+// steps don't mask it).
+func TestRemoveCollaboratorUser_UserdelErrorSurfaces(t *testing.T) {
+	fake := &recordingBackend{userdelErr: fmt.Errorf("permission denied")}
+	cm := &CollaboratorManager{manager: &Manager{incus: fake}}
+
+	err := cm.removeCollaboratorUser("owner-container", "owner-container-bob")
+	if err == nil {
+		t.Fatal("expected the userdel error to propagate")
+	}
+	if !fake.userdelSeen {
+		t.Error("userdel was never attempted")
+	}
+	if !strings.Contains(err.Error(), "delete user") {
+		t.Errorf("error should wrap the delete-user failure: %v", err)
+	}
+}
+
+func equalArgs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// hasForceFlag reports whether any combined short-flag arg (e.g. -rf, -f)
+// carries the force flag.
+func hasForceFlag(argv []string) bool {
+	for _, a := range argv {
+		if strings.HasPrefix(a, "-") && !strings.HasPrefix(a, "--") && strings.Contains(a, "f") {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

`CollaboratorManager.RemoveCollaborator` deletes a collaborator's container account with `userdel -r` (`removeCollaboratorUser`). That does **not** terminate an active SSH session, and without `-f` it fails outright when the collaborator is currently logged in (`userdel: user X is currently used by process N`) — precisely the case revocation exists for. So a revoked collaborator's live shell survived; removal only blocked the next reconnect.

Fixes #1177.

## Fix

Terminate the account's sessions/processes **before** deleting it, then force-remove:

```go
loginctl terminate-user <account>   // best-effort (systemd images only)
pkill -KILL -u <account>            // drops the shell; benign non-zero when nothing matched
userdel -rf <account>              // -f so an in-use account can't block the delete
```

This mirrors the existing **host-side** jump-server account deletion, which already kills a live session before `userdel` (`runUserdel`, #1035) — this applies the same treatment to the **in-container** account. Kill-before-delete, force the delete.

The session-kill steps are best-effort by design (`loginctl` is absent on non-systemd images; `pkill` exits non-zero when nothing matched), so their statuses are ignored — the SIGKILL is what drops the shell. A genuine `userdel` failure still propagates unchanged.

## Test

`collaborator_session_test.go` drives `removeCollaboratorUser` through a recording `incus.Backend` fake (embeds the interface, records `Exec` argv):
- the session is terminated (`pkill -KILL -u`) **before** `userdel`, and `userdel` carries `-f`;
- a real `userdel` error still surfaces.

`go test ./pkg/core/container/` green; `go vet` clean.

## Note for downstream

This is the missing half of a revoke actually ending access; a control-plane caller that revokes time-bounded, auto-expiring grants relies on it to terminate a live session rather than only block reconnect.
