### PR TITLE
docs: compare Containarium to google/ax, record the harness spike (NO-GO)

### DIFF
--- a/docs/AX-COMPARISON.md
+++ b/docs/AX-COMPARISON.md
@@ -1,0 +1,156 @@
+# Containarium vs. Google AX (Agent Executor)
+
+A comparison of Containarium against [google/ax](https://github.com/google/ax)
+— "an open source distributed agent runtime", announced 2026-05-21
+alongside GKE Agent Sandbox GA and the Agent Substrate preview.
+
+**tl;dr:** Google published a three-layer decomposition of the stack
+Containarium has been building as one vertical. Their Layer 1 is
+literally the same code we already run on the K8s backend
+(`sigs.k8s.io/agent-sandbox`). The layer that is genuinely *not* the
+same is AX itself: its whole thesis is **durable execution — an event
+log and a resumption protocol**, and that is the one part of our agent
+surface that is explicitly in-memory today.
+
+## The layering
+
+Google's stack, per the
+[GKE announcement](https://cloud.google.com/blog/products/containers-kubernetes/bringing-you-agent-sandbox-on-gke-and-agent-substrate):
+
+| Layer | Google | What it does |
+|---|---|---|
+| 3 — runtime / harness | **AX** (`google/ax`) | Coordinates the agentic loop; event log; resumption; harness + skill + MCP-tool isolation |
+| 2 — actor control plane | **Agent Substrate** | Maps actors onto warm worker pods; create/destroy/suspend/resume/route; density |
+| 1 — secure runtime | **Agent Sandbox** (`kubernetes-sigs/agent-sandbox`) | Sandbox CRD, pod snapshots, warm pools, gVisor/Kata isolation, default-deny NetworkPolicy |
+
+Containarium's equivalent, all in one repo:
+
+| Layer | Containarium | Where |
+|---|---|---|
+| 3 | `AgentSkillService` / `CrewService` / the `agent-runtime` in-box loop / pull queue | `proto/containarium/v1/agent.proto`, `internal/server/agent_*.go`, `crew_server.go` |
+| 2 | The daemon: placement, multi-backend fleet, tenant registry, TTL/auto-sleep, routing | `internal/server/`, `pkg/core/box/` |
+| 1 | Unprivileged LXC/Incus **or** `sigs.k8s.io/agent-sandbox` on K8s | `pkg/core/incus/`, `pkg/core/box/k8s/` |
+
+## The strongest similarity: we already run their Layer 1
+
+`pkg/core/box/k8s/sandbox.go` imports
+`sigs.k8s.io/agent-sandbox/api/v1beta1` and builds the same `Sandbox`
+CR that Agent Substrate and AX sit on. Two consequences worth naming:
+
+- We already use `SandboxOperatingModeSuspended` / `…Running` for
+  autostart (`sandbox.go:125-157`) — i.e. the suspend/resume primitive
+  is in our hands on the K8s path, not just Google's.
+- We already support gVisor: `podOptions.RuntimeClass` is passed
+  verbatim to `RuntimeClassName`, so `runsc` puts a box in a gVisor
+  sandbox. It is unset by default (`sandbox_test.go` guards that as a
+  no-regression), so it's opt-in rather than native-by-default.
+
+This is convergent evolution, not imitation in either direction — both
+projects landed on the same CRD because it's the K8s-native way to
+express "isolated, stateful, singleton workload."
+
+## Where the designs agree
+
+| Concern | AX | Containarium |
+|---|---|---|
+| Not a framework | "not an agentic framework"; framework-agnostic | Same thesis, stated in `docs/AGENT-SKILLS-CREWS-DESIGN.md`: "Containarium is the trust fabric, not another agent framework" |
+| Self-hosted | "not a managed service" | Self-hosted daemon; cloud is a separate wrapper |
+| Isolated env per agent | Dynamically provisioned isolated environments | One box per agent/skill (`RunAgentSkill` provisions a box with a scoped JWT) |
+| Skills + MCP tools | Agent Skills + MCP-compliant tools, run in isolation | `AgentSkill` proto + `cmd/agent-box` in-the-box MCP |
+| Language | Go (+ Python) | Go |
+| License / maturity | Apache 2.0, "active early development", breaking changes expected | Apache 2.0; agent surface is Phase 0–3 with prototype-marked pieces |
+| Worker crash recovery | Resumption protocol | Lease + visibility-timeout redelivery (`internal/server/agent_task_queue.go`) |
+
+## Where they genuinely differ
+
+### 1. Durability — AX's core claim, our known gap
+
+> **Corrected 2026-08-07 after running the spike**
+> ([`AX-HARNESS-ADAPTER-SPIKE.md`](AX-HARNESS-ADAPTER-SPIKE.md)): the
+> resumption claim below is AX's *stated* positioning, and it is **not
+> implemented** at `f327e23`. Resuming an incomplete execution is a TODO
+> (`internal/controller/controller.go:72`), `ExecRequest.last_step` is never
+> read by the server, and a resume attempt fails before reaching the harness.
+> The durable event log itself is real and works. Read this section as "what
+> AX intends", not "what AX has" — and note that it makes the gap between us
+> narrower than this comparison originally implied.
+
+AX is built around a durable event log: interrupted executions are
+*intended* to continue by **replaying missed events** rather than rewinding
+the conversation. Ours does not survive a daemon restart, and the code says so:
+
+- `internal/server/crew_run_store.go`: *"Phase 3 keeps runs in memory
+  (they don't survive a daemon restart)."*
+- `internal/server/agent_task_queue.go`: *"Durability (survive daemon
+  restart), per-tenant fairness, and dead-letter handling are
+  follow-ups; Phase 0 is memory-only."*
+
+We have **worker**-crash recovery (lease expiry → redelivery). We do
+not have **controller**-restart recovery, and there is no event log to
+replay from. `EventService` is a subscribe-only stream
+(`events.proto`), not a durable log.
+
+This is the sharpest and most actionable difference.
+
+### 2. Resume latency
+
+Agent Substrate snapshots an idle actor's RAM + filesystem and
+reactivates in under a second; GKE claims 90% of sandbox allocations
+inside 200ms. Our `auto_sleep` **stops** the box; coming back is a cold
+start. `docs/EPHEMERAL-SANDBOX-DESIGN.md` already logged this gap
+(filed against CubeSandbox's MicroVM cold-start, same underlying
+issue) and it remains unbuilt.
+
+### 3. Deployment surface
+
+AX and Substrate are Kubernetes-shaped. Containarium's primary backend
+is bare LXC hosts — including BYOC hardware with no cluster at all —
+with K8s as *one* backend behind the same box vocabulary. For an
+operator who doesn't run Kubernetes, AX isn't an option and we are.
+
+### 4. What the agent talks to
+
+Ours is SSH → `ForceCommand agent-box` → stdio MCP, deliberately so any
+off-the-shelf agent (Claude Code, Cursor, a customer-built agent) drives
+a box unmodified — the BYOA shape. AX asks you to implement a
+**harness** against its contract. Ours is a lower bar to adopt; theirs
+gives the runtime more to work with (which is what buys the event log).
+
+### 5. Multi-tenancy and the trust fabric
+
+AX describes a "multi-tenant gRPC controller." Containarium's tenancy
+story is considerably wider and is the thing we should not concede:
+per-tenant eBPF egress policy (`internal/netbpf`), audit logging to
+Postgres, scope-gated JWTs, KMS/secrets with audit-on-read, ingress /
+routing / DNS / custom domains, GPU passthrough, metering. AX is
+execution reliability; it is not a network, identity, or ingress
+platform.
+
+### 6. Where the agent's credential lives
+
+AX runs the harness *inside* the isolated environment. Our
+`docs/AGENT-DATA-PLANE-SEPARATION-DESIGN.md` argues the opposite
+direction: the box is data + tools only; the skill logic and the model
+credential stay with the agent *outside* the box, so a compromised box
+yields neither. This is a real design disagreement, not a maturity gap
+— and it's defensible positioning.
+
+## Read
+
+The similarity is close enough that "how is this different from
+Google's AX?" is now a question we should expect from any technical
+buyer, and the honest answer has three parts: we share their Layer 1;
+we sit on hardware they don't serve; and they have a durable event log
+today while our run state is in memory — but **neither of us can resume
+an interrupted run**, theirs being a TODO rather than a shipped feature.
+
+The gap worth closing is durability — not because AX exists, but
+because "a daemon restart loses in-flight crew runs" is a defect on its
+own terms, and our own code comments have flagged it as a follow-up
+since Phase 0.
+
+## Sources
+
+- [google/ax](https://github.com/google/ax)
+- [Bringing you Agent Sandbox on GKE and Agent Substrate](https://cloud.google.com/blog/products/containers-kubernetes/bringing-you-agent-sandbox-on-gke-and-agent-substrate) (2026-05-21)
+- [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox)

--- a/docs/AX-HARNESS-ADAPTER-SPIKE.md
+++ b/docs/AX-HARNESS-ADAPTER-SPIKE.md
@@ -1,0 +1,166 @@
+# Spike — Containarium as an AX harness (`HarnessService` adapter)
+
+> Status: **Executed 2026-08-07 — result: NO-GO for now.** The spike was built
+> and run against `google/ax@f327e23` (2026-07-28). Two of four measurements
+> passed; the two that carried the value failed. **The premise this spike was
+> written on turned out to be false** — see [Correction](#correction) — and the
+> durability gap it was meant to close is not closeable this way today.
+>
+> Read alongside [`AX-COMPARISON.md`](AX-COMPARISON.md) and
+> [`product/agent-substrate-roadmap-position.md`](product/agent-substrate-roadmap-position.md).
+
+## What was built
+
+Two throwaway programs (scratchpad, not committed):
+
+- **`harnessd`** — implements `ax.HarnessService.Connect`. Receives a turn,
+  streams N `HarnessOutputs` frames, terminates with one `HarnessEnd`. It logs
+  exactly what AX hands it on a first call vs. a resume.
+- **`spike`** — drives the *real* AX controller with the *real* SQLite event
+  log against `harnessd` over a plain dialed endpoint. Lives inside a clone of
+  the ax module because `controller/` and `eventlog/` are under `internal/`.
+
+## Correction
+
+The proposal version of this doc claimed:
+
+> *"AX replays history to the harness. `HarnessStart` carries
+> `repeated Message messages`… a harness is stateless per execution, so
+> adopting it doesn't just save us writing a durable store — it removes the
+> requirement to have one."*
+
+**That is wrong, and it was the whole reason to do this.** `HarnessStart.messages`
+carries only the inputs supplied to *that* `Exec` call — never the conversation
+history from the event log. Measured directly: a second turn on a conversation
+with 7 logged events delivered `messages=1`, containing only the new input.
+
+The implication inverts: a harness **must hold its own durable per-conversation
+state**, keyed by `conversation_id`. AX's own `Harness` doc comment says so, and
+I quoted it earlier without registering what it meant — *"a harness that durably
+persists per-conversation state may use a last-write-wins store without
+compare-and-swap."* The event log is the controller's **client-facing
+transcript**, not a mechanism that relieves the harness of state.
+
+So adopting AX would give us *more* state to keep, not less.
+
+## Results
+
+| # | Measurement | Result |
+|---|---|---|
+| 1 | Turn-model fit | **PASS** |
+| 2 | How much of our state disappears | **FAIL — none** |
+| 3 | Controller-restart resumption | **FAIL — not implemented** |
+| 4 | Weight on a no-cluster host | **PASS** |
+
+### 1. Turn-model fit — PASS
+
+Incremental `HarnessOutputs` stream through live, each becoming its own event-log
+step. Our in-box loop can yield mid-turn; we would not lose streaming.
+
+```
+11:44:47 [FIRST call#1] conversation="c1" messages=1
+11:44:48   <- step=2  chunk 1/5
+11:44:49   <- step=3  chunk 2/5
+...                       (1s apart on both sides — genuinely incremental)
+```
+
+The event log persisted all of it: 7 rows for one turn, terminal
+`STATE_COMPLETED` recorded.
+
+### 2. State that disappears — FAIL
+
+Nothing. Per the [correction](#correction), history is never replayed to the
+harness. Neither `agent_task_queue.go` nor `crew_run_store.go` could be deleted;
+we would additionally need a durable per-conversation store *inside* the harness
+to make resumption mean anything.
+
+### 3. Controller-restart resumption — FAIL
+
+Killed the controller mid-turn (2 of 5 chunks written), leaving the conversation
+`STATE_PENDING` with 3 events. Re-ran against the same `conversation_id`:
+
+```
+Exec conv="c2" inputs=0
+Exec: harness execution failed: no input messages queued for execution turn
+```
+
+The resume **never reached the harness** — `harnessd` logged no second call. The
+controller's resume branch calls `Start` + `Run` having queued nothing, and the
+reference harness rejects an empty turn (`internal/harness/antigravity/antigravity.go:177-178`).
+That error is itself the proof that the controller queues zero messages on resume.
+
+This matches the code: `internal/controller/controller.go:72` —
+`// TODO(jbd): Resume an incomplete execution if there exists one.` The
+`last_step` field on `ExecRequest` is likewise **sent by the CLI and never read
+by the server** — the only non-generated references are in `cmd/ax/exec.go`.
+So client-side "replay missed events on reconnect" is not implemented either.
+
+**Resumption — the reason to adopt AX — is a documented TODO, not a feature.**
+
+Related, and worse: after the controller died the harness kept running, emitted
+into a dead stream, and abandoned the turn. Its work was lost and nothing
+recorded that it had happened. A controller crash orphans in-flight harness work.
+
+### 4. Weight on a no-cluster host — PASS
+
+The controller plus the SQLite event log plus a plain-dial harness links into a
+**30.5 MB** static binary and ran on a laptop with no Kubernetes anywhere. The
+event log was 12 KB after three conversations. `harnessd` itself is 15.3 MB.
+
+AX's *core* genuinely does not need a cluster, even though the packaged
+`ax serve` path pushes you toward Substrate.
+
+## Two things the spike proved that are worth keeping
+
+1. **The adapter is buildable with the public package alone.** `harnessd`
+   depends on exactly one ax package — `go list -deps` returns
+   `github.com/google/ax/proto` and nothing else. No `internal/` needed. If we
+   ever revisit this, the integration is not blocked by packaging.
+2. **The plain-endpoint slot works — but only with a patched binary.** Stock
+   `ax serve` hardcodes `autoStart=true` for the built-in harness
+   (`cmd/ax/internal/cliutil/cliutil.go:113`), and the sidecar will
+   `killOrphanProcessOnAddr` any process already listening, then refuse to start
+   with *"endpoint is already in use by another process"*
+   (`internal/pythonsidecar/sidecar.go:91-97`). Our spike bypassed this by
+   driving the controller directly. Upstream, the fix is one condition — pass
+   `autoStart=false` when `endpoint` is explicitly configured — but external PRs
+   are paused.
+
+## Verdict against the stated go/no-go
+
+The proposal set four go criteria. Two failed:
+
+- ✅ In-box loop yields incremental outputs inside the turn model.
+- ❌ At least the task queue is deletable — **nothing is deletable**.
+- ❌ Controller-restart resumption demonstrated — **it is a TODO upstream**.
+- ✅ Runs on a single host without Kubernetes.
+
+**NO-GO.** Build the durable run store ourselves — the ~300 lines of Postgres
+already scoped against `crew_run_store.go` and `agent_task_queue.go`. It is
+strictly less work than adopting AX *and then still* having to build
+per-conversation harness state to make AX's resumption work once upstream
+implements it.
+
+## What to keep from AX regardless
+
+- **The single-writer invariant.** At most one execution per conversation,
+  which is what licenses last-write-wins with no compare-and-swap. We are
+  multi-backend and distributed and have no such guarantee today. This is the
+  most valuable idea in their repo and it costs nothing.
+- **The event-log shape.** `conversation_log(conversation_id, step, payload)`,
+  protojson payloads, monotonic step as the ordering key, terminal state as its
+  own row. ~290 lines total for the interface plus SQLite and Postgres drivers.
+  A good model for ours.
+
+## Re-check trigger
+
+Revisit when `controller.go:72` stops being a TODO — i.e. when AX actually
+implements resuming an incomplete execution, and decides whether the controller
+replays history to the harness or the harness owns that state. That decision
+determines whether this integration is ever attractive. Nothing else about AX
+needs re-checking before then.
+
+## Reproducing
+
+Sources are in this session's scratchpad (`harnessd/`, `ax/internal/cmd/spike/`),
+not committed — they are throwaway instruments, and the spike is closed.

--- a/docs/product/agent-substrate-roadmap-position.md
+++ b/docs/product/agent-substrate-roadmap-position.md
@@ -1,0 +1,130 @@
+# Roadmap position — the agent substrate is consolidating on Kubernetes
+
+**Date:** 2026-08-06
+**Status:** thinking-out-loud / not a commitment
+**Context:** written off the back of [`docs/AX-COMPARISON.md`](../AX-COMPARISON.md)
+
+This is a roadmap *position* note, not a PRD. It argues one thing: the
+open-source agent-infrastructure field is consolidating on Kubernetes
+as the orchestration layer, we are the only serious project that is
+substrate-agnostic by construction, and that is currently an unpriced
+asset — we pay the tax of two backends without collecting the premium.
+
+## The observation, sharpened
+
+The loose version — "everyone is building on K8s" — is directionally
+right but blurs two different layers that are moving independently.
+
+**Orchestration is consolidating on K8s.** The
+`kubernetes-sigs/agent-sandbox` CRD has become the de-facto object for
+"isolated, stateful, singleton agent workload." Google's whole
+three-layer stack (Agent Sandbox → Agent Substrate → AX) sits on it.
+Beam and Daytona deploy into K8s. We do too — `pkg/core/box/k8s/sandbox.go`
+imports `sigs.k8s.io/agent-sandbox/api/v1beta1`. Four independent
+projects, one object model.
+
+**Isolation is *not* consolidating — it's bifurcating.** The real
+competitive axis underneath is the strength of the boundary:
+
+| Tier | Boundary | Who |
+|---|---|---|
+| Shared kernel | namespaces + LSM | **Containarium (LXC default)**, Daytona (Docker) |
+| Userspace kernel | gVisor / `runsc` | Modal; Agent Sandbox native; **our K8s path, opt-in** |
+| Guest kernel, VM | Kata | Agent Sandbox pluggable |
+| Guest kernel, microVM | Firecracker | E2B, CubeSandbox |
+
+E2B — the category's mindshare leader — is Firecracker on
+Nomad/Consul, not K8s at all. So the honest read is: **K8s is winning
+the scheduling argument, not the isolation argument.** Those are
+separable bets and we should stop treating them as one.
+
+## Where that leaves us
+
+We are the only project in that table that runs the *same box
+vocabulary* over two substrates: unprivileged LXC on bare hosts, and
+the agent-sandbox CRD on K8s, behind one `--runtime` flag. Nobody else
+has that seam. Today we treat it as an implementation detail. It is
+closer to being the product.
+
+But it cuts both ways, and the roadmap has to pick:
+
+**The cost of *not* leaning into K8s.** Everything the ecosystem builds
+— pod snapshots, warm pools, gVisor-by-default, Substrate's actor
+density, and AX's event log — lands on the K8s path for free. Every
+quarter we treat K8s as the secondary backend, we hand-build on LXC
+what the CRD gives away, and the two paths' capability sets diverge
+further. `docs/EPHEMERAL-SANDBOX-DESIGN.md` is exactly this: a design
+for warm pools and fast-start sandboxes that is *unbuilt on LXC* and
+largely *already solved upstream on K8s*.
+
+**The cost of chasing K8s.** All of it requires the customer to have a
+cluster. Our actual installed base — BYOC bare metal, a GPU node under
+someone's desk, an SSH-native dev box a human lives in for a month —
+mostly doesn't, and won't. AX is simply not an option for them, and
+that is a real, defensible market that the whole field has walked away
+from. If we make K8s primary, we become a worse-funded Agent Substrate.
+
+## The position I'd argue for: an explicit barbell, with the box as the contract
+
+Not a hedge — a deliberate split with different jobs and, importantly,
+an explicit list of things we stop building.
+
+**K8s track — inherit, don't invent.** Treat the ecosystem as our R&D
+department. When agent-sandbox ships snapshotting, warm pools, or
+Kata, we consume it rather than reimplement it. Concretely: make
+gVisor the *default* RuntimeClass on the K8s path rather than opt-in
+(`podOptions.RuntimeClass` already carries it, unset by default), and
+wire suspend/resume through `SandboxOperatingMode` — which
+`sandbox.go:125` already uses for autostart — instead of the cold
+stop/start `auto_sleep` does today.
+
+**LXC track — own the substrate nobody else serves.** Bare host, no
+cluster, GPU passthrough, SSH-native, BYOC. Stop trying to reach
+feature parity with the K8s path on things K8s gives away for free.
+Specifically: I would *not* build MicroVM-grade isolation or
+RAM-snapshot fast resume on the LXC path. That is a losing race against
+Firecracker and against the CRD simultaneously.
+
+**The seam is the moat.** The value we alone can claim: one control
+plane, one tenancy model, one audit trail, one identity surface, across
+both. A customer with a cluster *and* a GPU box under a desk gets one
+platform. Nobody else in that table can say it.
+
+## The uncomfortable open question
+
+Our stated differentiators — per-tenant eBPF egress policy
+(`internal/netbpf`), audit-to-Postgres, scope-gated JWTs, KMS — are
+described in `docs/AGENT-SKILLS-CREWS-DESIGN.md` as "the trust fabric,
+and that is the moat." Almost all of it is **LXC-path-native**. On the
+K8s path, eBPF policy becomes NetworkPolicy, which agent-sandbox
+already does default-deny.
+
+So the barbell only holds if the trust fabric genuinely ports to K8s.
+If it doesn't, the two tracks aren't one product with two backends —
+they're two products, and the "one control plane" claim is marketing
+rather than architecture. **I don't currently know which it is, and I
+think that's the highest-value thing to find out before committing the
+roadmap.** It's a day or two of reading `internal/netbpf` and the K8s
+box path side by side, not a quarter of work.
+
+## What this note deliberately does not say
+
+- It doesn't propose we adopt AX. We'd be handing our Layer 3 to a
+  project in "active early development" with breaking changes promised,
+  in exchange for an event log we could build ourselves. **Settled
+  2026-08-07:** a spike ([`AX-HARNESS-ADAPTER-SPIKE.md`](../AX-HARNESS-ADAPTER-SPIKE.md))
+  returned NO-GO — AX never replays history to a harness, and resuming an
+  interrupted execution is a TODO upstream, so adopting it would add state to
+  our side rather than remove it.
+- It doesn't propose we drop LXC. That's where the customers are.
+- It doesn't resolve durability. That gap (`crew_run_store.go`,
+  `agent_task_queue.go` — both in-memory, both flagged in their own
+  comments) is a defect on its own terms and should be fixed regardless
+  of which substrate wins. It is not a strategic question.
+
+## Sources
+
+- [`docs/AX-COMPARISON.md`](../AX-COMPARISON.md) — the underlying comparison
+- [Agent Sandbox on GKE + Agent Substrate](https://cloud.google.com/blog/products/containers-kubernetes/bringing-you-agent-sandbox-on-gke-and-agent-substrate) (2026-05-21)
+- [Comparing AI agent sandbox platforms](https://blog.logrocket.com/comparing-ai-agent-sandbox-platforms-e2b-modal-daytona-and-more/) — LogRocket
+- [awesome-sandbox](https://github.com/restyler/awesome-sandbox) — field survey


### PR DESCRIPTION
Three docs, no code. Google announced its agent stack (Agent Sandbox →
Agent Substrate → AX) on 2026-05-21, and it decomposes into three layers we
have been building as one vertical — so "how is this different from Google's
AX?" is now a question we should expect from technical buyers. These notes
answer it, and record a spike that tested whether we should just adopt AX.

### `docs/AX-COMPARISON.md`

Where the designs agree and where they don't. The headline: **we already run
their Layer 1** — `pkg/core/box/k8s/sandbox.go` imports
`sigs.k8s.io/agent-sandbox/api/v1beta1`, the same Sandbox CRD that Agent
Substrate and AX sit on. We also already use `SandboxOperatingModeSuspended`
and pass `RuntimeClass` through for gVisor. Convergent evolution, not
derivative in either direction.

### `docs/product/agent-substrate-roadmap-position.md`

A roadmap position note, not a PRD. Argues that the loose reading — "everyone
is building on Kubernetes" — blurs two layers moving independently:
orchestration *is* consolidating on K8s (the agent-sandbox CRD is now the
de-facto object), while isolation is bifurcating separately across
runc / gVisor / Kata / Firecracker. E2B, the category's mindshare leader, is
Firecracker on Nomad and not on K8s at all.

Proposes an explicit barbell — the K8s track inherits from the ecosystem
rather than reinventing it; the LXC track owns the no-cluster substrate and
stops racing Firecracker on isolation — and flags the uncomfortable open
question: our stated moat (eBPF egress policy, audit, scope-gated JWTs, KMS)
is almost entirely LXC-path-native. If it doesn't port to the K8s path, those
aren't one product with two backends. That's a day of reading to settle, and
it's the cheapest high-value item in the note.

### `docs/AX-HARNESS-ADAPTER-SPIKE.md` — executed, **NO-GO**

Tested delegating durable agent execution to AX via its `HarnessService`
contract, measured against a real controller and a real SQLite event log at
`google/ax@f327e23` — not against the README.

**It falsified its own founding premise.** The proposal claimed AX replays
conversation history to the harness, making a harness stateless and deleting
our durability problem rather than solving it. Measured: a second turn on a
conversation with 7 logged events delivered `messages=1`, only the new input.
A harness must hold its own durable per-conversation state, so adopting AX
would *add* state on our side.

Resumption is also not implemented — `controller.go:72` is
`// TODO(jbd): Resume an incomplete execution if there exists one`, and
`ExecRequest.last_step` is sent by their CLI but never read by the server. A
resume attempt fails before reaching the harness.

| # | Measurement | Result |
|---|---|---|
| 1 | Turn-model fit | ✅ incremental outputs stream live |
| 2 | State that disappears | ❌ none |
| 3 | Controller-restart resumption | ❌ TODO upstream |
| 4 | No-cluster weight | ✅ 30.5 MB binary, no K8s |

Two passes are kept for the re-check trigger, along with the finding that the
adapter is buildable with the public package alone (`go list -deps` on the
spike harness returns exactly `github.com/google/ax/proto`).

### Note on the corrections

The claim the spike falsified is marked **inline** in the two earlier notes
rather than quietly edited out. Someone reading `AX-COMPARISON.md` later needs
to see that "AX has durable resumption" was checked and found aspirational —
not find a doc that always happened to say the right thing.

### Follow-up

Durable run store filed as #1182 — `crew_run_store.go` and
`agent_task_queue.go` are both in-memory and say so in their own comments.
That defect stands on its own terms; the spike only ruled out outsourcing it.

The spike programs were throwaway instruments and are not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
