### PR TITLE
fix(ssh-proxy): resolve collaborator sessions to the owner container (#1140)

### DIFF
--- a/scripts/setup-ssh-container-proxy.sh
+++ b/scripts/setup-ssh-container-proxy.sh
@@ -34,6 +34,16 @@ cat > "$WRAPPER_SCRIPT" << 'SHELLEOF'
 
 USERNAME="$(whoami)"
 CONTAINER="${USERNAME}-container"
+# Collaborator jump accounts are "<owner>-container-<collab>" (see
+# CollaboratorManager.AddCollaborator); the container they access is
+# "<owner>-container", NOT "<login>-container". Owner logins never contain the
+# "-container-" infix, so they are unaffected. Without this a collaborator
+# session resolves to "<owner>-container-<collab>-container" and dies with
+# "Container ... not found" — the SSH-session half of the #1140 fix (the other
+# half is the keysync orphan filter, fixed separately).
+case "$USERNAME" in
+    *-container-*) CONTAINER="${USERNAME%-container-*}-container" ;;
+esac
 
 # Check if container exists and is running
 if ! sudo incus info "$CONTAINER" &>/dev/null; then


### PR DESCRIPTION
## Problem (SSH-session half of #1140)

The `containarium-shell` login wrapper (the sshpiper→incus-exec relay) resolves a session's container as `${USERNAME}-container`, where `USERNAME` is the jump-server login. Correct for box owners (`cld-x` → `cld-x-container`) but wrong for **collaborators**, whose jump login is already `<owner>-container-<collab>` (`CollaboratorManager.AddCollaborator`). It resolves to `<owner>-container-<collab>-container`, which never exists, so every collaborator SSH session dies with **"Container ... not found"** immediately after authenticating.

Verified live: after the keysync fix (#1181 / v0.64.2), a machine-principal SSH-in stopped failing with *publickey denied* and instead failed here — `Error: Container cld-…-container-…-container not found`.

## Fix

Map a collaborator login back to the owner container before the incus lookup:
```sh
CONTAINER="${USERNAME}-container"
case "$USERNAME" in
    *-container-*) CONTAINER="${USERNAME%-container-*}-container" ;;
esac
```
- Owner logins never contain the `-container-` infix → unaffected.
- The in-container `su - "$USERNAME"` is already correct (the collaborator's in-container account is named for the full jump login, per `createCollaboratorUser`).

## The two halves of #1140

| Half | Where | PR |
|---|---|---|
| keysync `/authorized-keys` orphan filter + reaper | `internal/server/dual_server.go` | #1181 (merged, v0.64.2) |
| **this** — session container resolution | `scripts/setup-ssh-container-proxy.sh` | **this PR** |

With both, a collaborator/machine-principal key syncs to the sentinel, authenticates, **and** lands in the owner's container. Fixes machine principals and the base human-collaborator feature.

## Deploy note

This wrapper is a **per-host script**, not daemon-written — existing backends need it re-deployed (re-run `setup-ssh-container-proxy.sh`); a binary upgrade alone won't update it.

`bash -n` on the outer script and the extracted wrapper both pass; `shellcheck -S error` clean.

Refs FootprintAI/Containarium-cloud#1140.
