### PR TITLE
docs: correct K8s isolation + audit claims to match shipped behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,8 @@ The sentinel itself is e2-micro (free tier). It:
 
 VictoriaMetrics + Grafana auto-provisioned. Per-container CPU,
 memory, disk, network. Alerting via webhooks. SSH audit logs per
-user.
+user (LXC backend; the Kubernetes backend records control-plane API
+audit but not in-box SSH sessions — see #1189).
 
 ### Security primitives
 

--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -164,11 +164,37 @@ wired via `CONTAINARIUM_K8S_GATEWAY_UPSTREAM_{PUBLIC_KEY,KEY_SECRET}`.
 
 Per tenant namespace:
 
-- **Default-deny ingress**, single allow rule: TCP/22 *from the sshpiper pod
-  only* (matched by `agent-gateway` namespace + pod label).
-- **Default-deny egress**, allowlist: cluster DNS + the control-plane API
-  endpoint. This is the K8s expression of the eBPF egress allowlist shipped
-  on the LXC backend.
+> ⚠️ **This section described the intended design; the shipped code is weaker.**
+> Corrected 2026-08-08 after reading `pkg/core/box/k8s/objects.go:221-245`
+> against it. The gap is tracked as **#1193**. What follows now describes what
+> actually ships, with the intent noted where they differ.
+
+**Intended:** default-deny ingress with a single allow rule — TCP/22 *from the
+sshpiper pod only* (matched by `agent-gateway` namespace + pod label) — and
+default-deny egress allowlisting cluster DNS plus the control-plane API
+endpoint.
+
+**Shipped** (one `default-deny` NetworkPolicy per tenant namespace,
+`objects.go:221`, created at `k8s.go:265`):
+
+- Its `podSelector` correctly scopes the policy to the tenant's box pods.
+- The **ingress rule carries `ports` but no `from`**, which per the
+  NetworkPolicy spec matches *all* sources. TCP/22 is therefore reachable from
+  anywhere the CNI permits — the `agent-gateway` namespace + pod-label
+  selector does not exist in code.
+- The **egress rule carries `ports` but no `to`**, so DNS (UDP/TCP 53) is
+  allowed to any destination rather than to cluster DNS.
+- There is **no control-plane API egress rule at all**.
+
+SSH authentication still gates entry to a box, so this is missing
+defense-in-depth rather than an open door — but in the namespace-per-tenant
+model, one tenant's pod can currently open TCP/22 to another tenant's box.
+See #1193 for the fix and its tests.
+
+This is also **not** the K8s expression of the eBPF egress allowlist: it is a
+static object written once at box-create and never reconciled against
+`NetworkPolicyService`. Tenant egress policy is not enforced on this backend
+at all — see #1188.
 
 ## Mapping to the existing (LXC) architecture
 
@@ -178,7 +204,7 @@ Per tenant namespace:
 | sshpiper on sentinel :22 | sshpiper Deployment + LB Service :22 |
 | sentinel key-sync → YAML | controller → `Pipe` CRD + Secret |
 | LXC box per tenant | agent-sandbox `Sandbox` CR (pod `box`) per tenant namespace |
-| eBPF deny-by-default + egress allowlist | default-deny NetworkPolicy + egress allowlist |
+| eBPF deny-by-default + egress allowlist, driven by `NetworkPolicyService` | static `default-deny` NetworkPolicy, **not** policy-driven (#1188), and weaker than documented (#1193) |
 | sshd 2222 (mgmt) vs sshpiper 22 | mgmt via `kubectl`/RBAC; sshpiper owns 22 |
 
 ## CLI-first surface


### PR DESCRIPTION
Docs only. Two places asserted isolation/audit coverage the code does not
provide. Found while checking whether the trust fabric ports to the K8s
backend (companion to #1191).

### 1. `K8S-AGENT-BOX-RUNTIME-DESIGN.md` — NetworkPolicy weaker than documented

The doc said the per-tenant NetworkPolicy allows TCP/22 *"from the sshpiper pod
only (matched by `agent-gateway` namespace + pod label)"* and egress to
*"cluster DNS + the control-plane API endpoint"*.

The shipped object (`objects.go:221`, created at `k8s.go:265`) has a correct
`podSelector`, but:

- its **ingress rule carries `ports` with no `from`** → per the NetworkPolicy
  spec, matches **all sources**;
- its **egress rule carries `ports` with no `to`** → DNS to **any**
  destination;
- there is **no control-plane API egress rule at all**.

SSH auth still gates a box, so this is missing defense-in-depth rather than an
open door — but in the namespace-per-tenant model one tenant's pod can reach
another tenant's box on :22, which the doc says is prevented. **Filed as
#1193** with tests that would have caught it (no test currently asserts a
`From`).

The same section called the static policy *"the K8s expression of the eBPF
egress allowlist"*. It isn't — it's written once at box-create and never
reconciled against `NetworkPolicyService`, so tenant egress policy is
unenforced on this backend (#1188). The mapping table row is corrected too.

### 2. `README.md` — unqualified SSH audit claim

*"SSH audit logs per user"* holds on the LXC backend. The K8s backend has no
in-box session audit, because the collector is incus-typed (#1189). Qualified
rather than removed.

### Why docs-first

The code fixes are #1193 (isolation) and #1189 (audit). This PR doesn't wait on
them: a doc that asserts a boundary which doesn't exist is worse than one that
admits the gap, and an operator reading the design note today would reasonably
believe tenant boxes are unreachable from other namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
