### PR TITLE
fix(client): type the ListSecrets response — --http printed <nil> for UPDATED

### DIFF
--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -901,7 +901,14 @@ func (c *HTTPClient) GetSecret(username, name string) (string, error) {
 // ListSecrets returns metadata for every secret owned by the tenant.
 // Each entry is the name/version/timestamps tuple — values are only
 // readable via GetSecret per-name.
-func (c *HTTPClient) ListSecrets(username string) ([]map[string]interface{}, error) {
+//
+// Decoded with protojson into the generated SecretMetadata, matching what
+// GRPCClient.ListSecrets returns, so both transports hand callers the
+// same type. The previous []map[string]interface{} return let a
+// field-name mismatch pass unnoticed: grpc-gateway is configured with
+// UseProtoNames=false, so it emits `updatedAt`, while the CLI read
+// `updated_at` and printed <nil> (#1219).
+func (c *HTTPClient) ListSecrets(username string) ([]*pb.SecretMetadata, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	path := fmt.Sprintf("/v1/secrets/%s", url.PathEscape(username))
@@ -914,11 +921,14 @@ func (c *HTTPClient) ListSecrets(username string) ([]map[string]interface{}, err
 	if resp.StatusCode >= 400 {
 		return nil, parseErr(b, resp.StatusCode, "list secrets")
 	}
-	var result struct {
-		Secrets []map[string]interface{} `json:"secrets"`
+	var result pb.ListSecretsResponse
+	// Unknown fields are tolerated so a newer daemon adding a field does
+	// not break an older CLI; a malformed body is still an error, which
+	// the old code discarded.
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(b, &result); err != nil {
+		return nil, fmt.Errorf("decode secrets response: %w", err)
 	}
-	_ = json.Unmarshal(b, &result)
-	return result.Secrets, nil
+	return result.GetSecrets(), nil
 }
 
 // DeleteSecret removes a tenant secret via HTTP.

--- a/internal/client/http_secrets_test.go
+++ b/internal/client/http_secrets_test.go
@@ -1,0 +1,138 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestListSecretsDecodesGatewayCamelCase is the regression guard for
+// #1219.
+//
+// The daemon serves this endpoint through grpc-gateway, whose marshaller
+// is configured with `UseProtoNames: false`
+// (internal/gateway/gateway.go). protojson therefore emits **lowerCamelCase**
+// field names: `createdAt`, `updatedAt`.
+//
+// The client used to return []map[string]interface{} and the CLI read
+// `row["updated_at"]` — a key the server never sends. That lookup yields
+// nil, so `containarium secrets list --http` printed `<nil>` in its
+// UPDATED column. Nothing failed; the column was simply wrong.
+//
+// That is the whole argument for typing this response: a snake_case/
+// camelCase mismatch is invisible to a map and a compile-or-decode
+// concern for a struct.
+func TestListSecretsDecodesGatewayCamelCase(t *testing.T) {
+	// Exactly what grpc-gateway emits for ListSecretsResponse.
+	const gatewayJSON = `{
+	  "secrets": [
+	    {
+	      "username": "alice",
+	      "name": "API_KEY",
+	      "version": 3,
+	      "createdAt": "2026-08-01T10:00:00Z",
+	      "updatedAt": "2026-08-07T12:30:00Z",
+	      "delivery": "compose"
+	    },
+	    {
+	      "username": "alice",
+	      "name": "DB_PASSWORD",
+	      "version": 1,
+	      "createdAt": "2026-08-02T09:00:00Z",
+	      "updatedAt": "2026-08-02T09:00:00Z",
+	      "delivery": "env"
+	    }
+	  ]
+	}`
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(gatewayJSON))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+
+	list, err := c.ListSecrets("alice")
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+	if gotPath != "/v1/secrets/alice" {
+		t.Errorf("path = %q, want /v1/secrets/alice", gotPath)
+	}
+	if len(list) != 2 {
+		t.Fatalf("got %d secrets, want 2", len(list))
+	}
+
+	first := list[0]
+	if first.GetName() != "API_KEY" {
+		t.Errorf("Name = %q, want API_KEY", first.GetName())
+	}
+	if first.GetUsername() != "alice" {
+		t.Errorf("Username = %q, want alice", first.GetUsername())
+	}
+	if first.GetVersion() != 3 {
+		t.Errorf("Version = %d, want 3", first.GetVersion())
+	}
+	// The two fields the old map-based path silently lost.
+	if first.GetUpdatedAt() != "2026-08-07T12:30:00Z" {
+		t.Errorf("UpdatedAt = %q — this is the field that printed as <nil>", first.GetUpdatedAt())
+	}
+	if first.GetCreatedAt() != "2026-08-01T10:00:00Z" {
+		t.Errorf("CreatedAt = %q", first.GetCreatedAt())
+	}
+	if first.GetDelivery() != "compose" {
+		t.Errorf("Delivery = %q, want compose", first.GetDelivery())
+	}
+
+	if list[1].GetName() != "DB_PASSWORD" || list[1].GetVersion() != 1 {
+		t.Errorf("second secret decoded wrong: %+v", list[1])
+	}
+}
+
+// An empty list decodes to an empty slice, not an error — the CLI prints
+// "(no secrets for X)" off the length.
+func TestListSecretsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	list, err := c.ListSecrets("alice")
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("got %d secrets, want 0", len(list))
+	}
+}
+
+// A malformed body must surface as an error rather than silently
+// decoding to an empty list — the old code discarded the unmarshal error
+// entirely (`_ = json.Unmarshal(...)`), so a broken response looked
+// identical to a tenant with no secrets.
+func TestListSecretsReportsDecodeFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"secrets": "not-an-array"}`))
+	}))
+	defer srv.Close()
+
+	c, err := NewHTTPClient(srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+	if _, err := c.ListSecrets("alice"); err == nil {
+		t.Error("a malformed response must be an error, not an empty list")
+	}
+}

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/footprintai/containarium/internal/client"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/spf13/cobra"
 )
 
@@ -186,42 +187,39 @@ func runSecretsList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--server is required for secrets commands")
 	}
 
+	// Both transports return []*pb.SecretMetadata, so the two branches
+	// differ only in how the client is built — the rendering is shared.
+	// It used to be duplicated, and the copies had drifted: the HTTP one
+	// read `updated_at` from an untyped map while grpc-gateway emits
+	// `updatedAt`, so its UPDATED column printed <nil> (#1219).
+	var list []*pb.SecretMetadata
 	if httpMode {
 		h, err := client.NewHTTPClient(serverAddr, authToken)
 		if err != nil {
 			return err
 		}
 		defer func() { _ = h.Close() }()
-		list, err := h.ListSecrets(username)
+		if list, err = h.ListSecrets(username); err != nil {
+			return err
+		}
+	} else {
+		g, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 		if err != nil {
 			return err
 		}
-		if len(list) == 0 {
-			fmt.Printf("(no secrets for %s)\n", username)
-			return nil
+		defer func() { _ = g.Close() }()
+		if list, err = g.ListSecrets(username); err != nil {
+			return err
 		}
-		fmt.Printf("%-32s %-8s %s\n", "NAME", "VERSION", "UPDATED")
-		for _, row := range list {
-			fmt.Printf("%-32s %-8v %v\n", row["name"], row["version"], row["updated_at"])
-		}
-		return nil
 	}
-	g, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = g.Close() }()
-	list, err := g.ListSecrets(username)
-	if err != nil {
-		return err
-	}
+
 	if len(list) == 0 {
 		fmt.Printf("(no secrets for %s)\n", username)
 		return nil
 	}
 	fmt.Printf("%-32s %-8s %s\n", "NAME", "VERSION", "UPDATED")
 	for _, row := range list {
-		fmt.Printf("%-32s %-8d %s\n", row.Name, row.Version, strings.TrimSuffix(row.UpdatedAt, "Z"))
+		fmt.Printf("%-32s %-8d %s\n", row.GetName(), row.GetVersion(), strings.TrimSuffix(row.GetUpdatedAt(), "Z"))
 	}
 	return nil
 }

--- a/internal/mcp/backend.go
+++ b/internal/mcp/backend.go
@@ -55,7 +55,7 @@ type API interface {
 	// Secrets / KMS.
 	SetSecret(username, name, value string) (*SecretResponse, error)
 	GetSecret(username, name string) (string, error)
-	ListSecrets(username string) ([]map[string]interface{}, error)
+	ListSecrets(username string) ([]SecretMetadata, error)
 	DeleteSecret(username, name string) error
 	RefreshSecrets(username string) (*RefreshSecretsResponse, error)
 	GetKMSStatus() (*KMSStatusResponse, error)

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -795,14 +795,31 @@ func (c *Client) GetSecret(username, name string) (string, error) {
 	return resp.Value, nil
 }
 
+// SecretMetadata mirrors the proto SecretMetadata on the response side.
+// Values are never included — they are readable only via GetSecret,
+// per-name and audit-logged.
+//
+// The tags are lowerCamelCase because grpc-gateway is configured with
+// UseProtoNames=false, so protojson emits `createdAt` / `updatedAt`.
+// Reading these through an untyped map is what hid #1219: the CLI looked
+// up `updated_at`, a key the daemon never sends.
+type SecretMetadata struct {
+	Username  string `json:"username"`
+	Name      string `json:"name"`
+	Version   int32  `json:"version"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+	Delivery  string `json:"delivery"`
+}
+
 // ListSecrets returns metadata for every tenant secret.
-func (c *Client) ListSecrets(username string) ([]map[string]interface{}, error) {
+func (c *Client) ListSecrets(username string) ([]SecretMetadata, error) {
 	respBody, err := c.doRequest("GET", fmt.Sprintf("/v1/secrets/%s", username), nil)
 	if err != nil {
 		return nil, err
 	}
 	var resp struct {
-		Secrets []map[string]interface{} `json:"secrets"`
+		Secrets []SecretMetadata `json:"secrets"`
 	}
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		return nil, fmt.Errorf("decode: %w", err)
@@ -1617,8 +1634,12 @@ type ResizeContainerResponse struct {
 }
 
 type SecretResponse struct {
-	Message string                 `json:"message"`
-	Secret  map[string]interface{} `json:"secret"`
+	Message string `json:"message"`
+	// The created/updated secret's metadata (never its value). Typed for
+	// the same reason as ListSecrets (#1219): the gateway emits
+	// lowerCamelCase, and a map hides a key mismatch until someone reads
+	// a blank field.
+	Secret SecretMetadata `json:"secret"`
 }
 
 type RefreshSecretsResponse struct {

--- a/internal/mcp/secrets_test.go
+++ b/internal/mcp/secrets_test.go
@@ -1,0 +1,59 @@
+package mcp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestListSecretsDecodesGatewayCamelCase pins the JSON tags on
+// SecretMetadata (#1219).
+//
+// The daemon serves this through grpc-gateway with UseProtoNames=false,
+// so protojson emits lowerCamelCase: `createdAt`, `updatedAt`. These tags
+// are hand-written on the MCP side (this client does not import the
+// generated protos), which makes a snake_case typo the exact failure this
+// issue is about — the field decodes to "" and the agent sees a blank
+// value, with nothing failing.
+func TestListSecretsDecodesGatewayCamelCase(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/v1/secrets/alice" {
+			t.Errorf("path = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"secrets":[{
+			"username":"alice",
+			"name":"API_KEY",
+			"version":3,
+			"createdAt":"2026-08-01T10:00:00Z",
+			"updatedAt":"2026-08-07T12:30:00Z",
+			"delivery":"compose"
+		}]}`))
+	}))
+	defer srv.Close()
+
+	list, err := NewClient(srv.URL, "t").ListSecrets("alice")
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("got %d secrets, want 1", len(list))
+	}
+
+	got := list[0]
+	for _, tc := range []struct{ field, got, want string }{
+		{"Username", got.Username, "alice"},
+		{"Name", got.Name, "API_KEY"},
+		{"CreatedAt", got.CreatedAt, "2026-08-01T10:00:00Z"},
+		{"UpdatedAt", got.UpdatedAt, "2026-08-07T12:30:00Z"},
+		{"Delivery", got.Delivery, "compose"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q — check the json tag against the gateway's camelCase output",
+				tc.field, tc.got, tc.want)
+		}
+	}
+	if got.Version != 3 {
+		t.Errorf("Version = %d, want 3", got.Version)
+	}
+}


### PR DESCRIPTION
Closes #1219.

> **Stacked on #1220** (`fix/887-http-body-double-marshal`), which is its base branch — both touch `internal/client/http.go`, and the "`interface{}` down to the generic constraint" claim only holds with that landed. Review #1220 first; this diff is the 6 files above it. Retarget to `main` once #1220 merges.

## This was hiding a live bug

`containarium secrets list --http` has been printing `<nil>` in its UPDATED column.

`internal/gateway/gateway.go:382` sets `UseProtoNames: false`, so protojson emits **lowerCamelCase** — the daemon sends `updatedAt`. The CLI read `row["updated_at"]` off an untyped map. That key is never present, so the lookup yields nil and `%v` prints `<nil>`. Nothing errored; the column was simply wrong, and had been for as long as the HTTP path existed.

The gRPC path was already typed and correct, so the two transports disagreed about the shape of the same call.

## What changed

- **`HTTPClient.ListSecrets` returns `[]*pb.SecretMetadata`**, decoded with protojson, matching `GRPCClient.ListSecrets`. The proto message already existed — the HTTP path just wasn't using it.
- **The duplicated rendering in `runSecretsList` collapses to one path.** The two branches had already drifted: gRPC trimmed the trailing `Z` from the timestamp, HTTP didn't. With one return type they can't diverge again.
- **`ListSecrets` no longer discards its unmarshal error.** It was `_ = json.Unmarshal(...)`, so a malformed response was indistinguishable from a tenant with no secrets.
- **MCP client gets a `SecretMetadata` struct** and a typed `SecretResponse.Secret` (the set-secret path had the same untyped shape).

## Review this first

The MCP client hand-writes its JSON tags — it doesn't import the generated protos, following the existing pattern there (`BackupRecord` etc.). That makes a snake_case typo the *same* defect this PR fixes, just relocated. So those tags are pinned by `TestListSecretsDecodesGatewayCamelCase` in `internal/mcp`, and I mutation-checked it:

```
# revert `json:"updatedAt"` -> `json:"updated_at"`
--- FAIL: TestListSecretsDecodesGatewayCamelCase
    UpdatedAt = "", want "2026-08-07T12:30:00Z" — check the json tag
    against the gateway's camelCase output
```

That's the original bug, reproduced and caught.

The `internal/client` side decodes via protojson against the generated type, which accepts both camelCase and snake_case, so it's robust regardless — the win there is that it's typed at all.

## Test evidence

Written first; the client tests failed to compile against the untyped return (`map[string]interface{} has no field or method GetName`), which is the point.

```
ok  github.com/footprintai/containarium/internal/client  0.025s
ok  github.com/footprintai/containarium/internal/cmd     0.188s
ok  github.com/footprintai/containarium/internal/mcp     0.271s
```

New tests: decode of gateway-shaped camelCase, empty-list handling, malformed-body-is-an-error, and the MCP tag pin.

## Test environment

Clean disposable `golang:1.26` container via podman (build, vet, full suite). The three failures there — `internal/sentinel TestRegisterPropagatesPool`, `test/integration TestStorageQuotaEnforcement` / `TestStoragePersistence` — **reproduce identically on `main` in the same box** and this PR touches neither package.

**Not verified against a live daemon** — the camelCase response shape is asserted against an `httptest` server reproducing what the configured gateway emits, not against a running one. Blocked on the same missing environment as #1200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)