### PR TITLE
feat(container): accept encrypted + tenant_id on create, failing closed

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -7685,6 +7685,14 @@
             "type": "string"
           },
           "description": "GPU device IDs for passthrough — one entry per GPU to attach (device\nindex like \"0\"/\"1\" or PCI address like \"0000:0b:00.0\"). Supersedes the\nsingular `gpu` field: when non-empty `gpu` is ignored; when empty a\nnon-empty `gpu` is treated as a single-element list. Each device is\nresolved to a stable PCI address at create time."
+        },
+        "encrypted": {
+          "type": "boolean",
+          "description": "Encrypt the container's ZFS dataset with a tenant-scoped key rather\nthan the pool-wide key, so a co-tenant — or host root, once the\ncontainer is stopped and the key unloaded — sees ciphertext.\n\nRequires the daemon to be wired with a KeyProvider. Without one the\nrequest fails with FAILED_PRECONDITION; it never falls back to\nplaintext, because a create that silently ignores this flag would\nhand the caller an encryption guarantee they do not have.\n\nDefault false: existing containers keep their current posture\n(pool-level encryption, or none). See\ndocs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md."
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "Tenant that owns this container, scoping the encryption key: all of\na tenant's containers share one ZFS encryptionroot, and different\ntenants always have distinct ones.\n\nThe OSS daemon is single-tenant and accepts only \"\" or \"default\",\nrejecting anything else with INVALID_ARGUMENT; the multi-tenant\ncloud daemon accepts any non-empty value. The field is defined here\nso the wire shape stays stable across the OSS → cloud transition\nrather than changing when tenancy lands."
         }
       },
       "title": "CreateContainerRequest is the request to create a new container"

--- a/internal/client/grpc.go
+++ b/internal/client/grpc.go
@@ -160,7 +160,7 @@ func (c *GRPCClient) ListContainers() ([]incus.ContainerInfo, error) {
 }
 
 // CreateContainer creates a container via gRPC
-func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string) (*incus.ContainerInfo, error) {
+func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string, enc EncryptionOpts) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute) // Container creation can take time (includes ultra-aggressive retry logic for google_guest_agent)
 	defer cancel()
 
@@ -181,6 +181,8 @@ func (c *GRPCClient) CreateContainer(username, image, cpu, memory, disk string, 
 		Monitoring:                monitoring,
 		Pool:                      pool,
 		BackendId:                 backendID,
+		Encrypted:                 enc.Encrypted,
+		TenantId:                  enc.TenantID,
 		GitSource:                 git.Source,
 		GitRef:                    git.Ref,
 		GitCredential:             git.Credential,

--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -282,6 +282,22 @@ func (c *HTTPClient) ListContainers() ([]incus.ContainerInfo, error) {
 // parameters. Zero value (Source == "") means "no git source" and the
 // daemon skips provisioning. Kept as a struct so CreateContainer's
 // already-long signature doesn't grow four more positional strings.
+// EncryptionOpts carries the per-tenant dataset-encryption request
+// (#1198). Bundled into a struct rather than added as two more
+// positional parameters: CreateContainer already takes eighteen, and a
+// bare `encrypted bool` would sit next to `monitoring bool` where a
+// transposed argument compiles cleanly and silently creates the wrong
+// container.
+type EncryptionOpts struct {
+	// Encrypted requests a tenant-scoped ZFS key for this container's
+	// dataset. The daemon rejects it with FAILED_PRECONDITION when no
+	// KeyProvider is configured — it never falls back to plaintext.
+	Encrypted bool
+	// TenantID scopes the key. Empty or "default" on a single-tenant
+	// daemon; any other value is rejected there with INVALID_ARGUMENT.
+	TenantID string
+}
+
 type GitSourceOpts struct {
 	Source        string // clone URL; empty disables git provisioning
 	Ref           string // SHA / branch / tag / refs/pull/N/merge; empty = default branch
@@ -289,7 +305,7 @@ type GitSourceOpts struct {
 	WorkspacePath string // empty defaults to /workspace
 }
 
-func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string) (*incus.ContainerInfo, error) {
+func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string, enc EncryptionOpts) (*incus.ContainerInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
@@ -310,6 +326,8 @@ func (c *HTTPClient) CreateContainer(username, image, cpu, memory, disk string, 
 		Monitoring:   monitoring,
 		Pool:         pool,
 		BackendID:    backendID,
+		Encrypted:    enc.Encrypted,
+		TenantID:     enc.TenantID,
 	}
 	// The four git fields travel together: all present (even when empty)
 	// when a source is given, all absent otherwise.

--- a/internal/client/http_requests.go
+++ b/internal/client/http_requests.go
@@ -63,6 +63,11 @@ type createContainerRequest struct {
 	GitCredential *string `json:"gitCredential,omitempty"`
 	WorkspacePath *string `json:"workspacePath,omitempty"`
 
+	// Per-tenant dataset encryption (#1198). Absent unless requested, so
+	// a plain create's body is unchanged.
+	Encrypted bool   `json:"encrypted,omitempty"`
+	TenantID  string `json:"tenantId,omitempty"`
+
 	// Birth TTL (#523), idle-stop (#524), stopped→delete (#525): absent
 	// unless enabled, so a plain create's body is unchanged.
 	TTLSeconds                int64 `json:"ttlSeconds,omitempty"`

--- a/internal/cmd/create.go
+++ b/internal/cmd/create.go
@@ -32,6 +32,8 @@ var (
 	gpuDevices               []string
 	osTypeStr                string
 	monitoring               bool
+	createEncrypted          bool
+	createTenantID           string
 	createPool               string
 	createBackendID          string
 	createAutoRestartCompose string
@@ -142,6 +144,8 @@ func init() {
 	createCmd.Flags().BoolVar(&forceRecreate, "force", false, "Delete and recreate if container already exists")
 	createCmd.Flags().StringVar(&osTypeStr, "os-type", "", "Container OS type: ubuntu, rocky9, rhel9 (overrides --image)")
 	createCmd.Flags().BoolVar(&monitoring, "monitoring", false, "Opt into application-emitted OpenTelemetry. When set, the daemon stamps the container with OTEL_EXPORTER_OTLP_ENDPOINT etc. pointing at the platform's OTel collector, so any OTel SDK inside the container ships telemetry without app-side config. Default off.")
+	createCmd.Flags().BoolVar(&createEncrypted, "encrypted", false, "Encrypt the container's ZFS dataset with a tenant-scoped key instead of the pool-wide key. Requires the daemon to have a KeyProvider configured; the request is refused rather than silently creating an unencrypted container. Default off.")
+	createCmd.Flags().StringVar(&createTenantID, "tenant", "", "Tenant that owns the container, scoping its encryption key. A single-tenant daemon accepts only an empty value or \"default\".")
 	createCmd.Flags().StringVar(&createPool, "pool", "", "Place the container on any healthy backend tagged with this pool (e.g., 'demo', 'lab'). Empty means the local/primary backend. Mutually exclusive with --backend-id unless the chosen backend is in the named pool.")
 	createCmd.Flags().StringVar(&createBackendID, "backend-id", "", "Place the container on a specific backend by ID (e.g., 'tunnel-node-a-gpu'). Use 'containarium backends' to list available backend IDs.")
 	createCmd.Flags().StringVar(&createAutoRestartCompose, "auto-restart-compose", "",
@@ -425,18 +429,32 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if httpMode && serverAddr != "" {
 		// Remote mode via HTTP
-		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, createStorageClass)
+		info, err = createRemoteHTTP(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, createStorageClass, client.EncryptionOpts{Encrypted: createEncrypted, TenantID: createTenantID})
 		if err != nil {
 			return fmt.Errorf("failed to create container via HTTP API: %w", err)
 		}
 	} else if serverAddr != "" {
 		// Remote mode via gRPC
-		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, createStorageClass)
+		info, err = createRemote(username, containerImage, cpuLimit, memoryLimit, diskLimit, sshKeys, enablePodman, stackID, gpuDevices, osType, monitoring, createPool, createBackendID, gitOpts, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, createStorageClass, client.EncryptionOpts{Encrypted: createEncrypted, TenantID: createTenantID})
 		if err != nil {
 			return fmt.Errorf("failed to create container via remote server: %w", err)
 		}
 	} else {
-		// Local mode via Incus
+		// Local mode via Incus.
+		//
+		// Per-tenant encryption is a daemon feature: the KeyProvider and
+		// the lifecycle hooks live server-side, so this path has no way
+		// to honour --encrypted. Refuse rather than create an
+		// unencrypted container while the caller believes otherwise
+		// (#1198) — the same fail-closed posture the daemon takes when
+		// no KeyProvider is configured.
+		if createEncrypted {
+			return fmt.Errorf("--encrypted requires a daemon (--server): local Incus creates cannot resolve a tenant key, " +
+				"and creating an unencrypted container here would silently ignore the flag")
+		}
+		if createTenantID != "" {
+			return fmt.Errorf("--tenant requires a daemon (--server): local Incus creates are single-tenant by construction")
+		}
 		if verbose {
 			fmt.Println("Creating container...")
 		}
@@ -745,23 +763,23 @@ func parseLabels(labelSlice []string) map[string]string {
 }
 
 // createRemote creates a container using remote gRPC server
-func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string) (*incus.ContainerInfo, error) {
+func createRemote(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string, enc client.EncryptionOpts) (*incus.ContainerInfo, error) {
 	grpcClient, err := client.NewGRPCClient(serverAddr, certsDir, insecure)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = grpcClient.Close() }()
 
-	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, storageClass)
+	return grpcClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, storageClass, enc)
 }
 
 // createRemoteHTTP creates a container using remote HTTP API
-func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string) (*incus.ContainerInfo, error) {
+func createRemoteHTTP(username, image, cpu, memory, disk string, sshKeys []string, enablePodman bool, stack string, gpus []string, osType pb.OSType, monitoring bool, pool, backendID string, git client.GitSourceOpts, ttlSeconds int64, idleStopMinutes int32, deleteAfterStoppedSeconds int64, storageClass string, enc client.EncryptionOpts) (*incus.ContainerInfo, error) {
 	httpClient, err := client.NewHTTPClient(serverAddr, authToken)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = httpClient.Close() }()
 
-	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, storageClass)
+	return httpClient.CreateContainer(username, image, cpu, memory, disk, sshKeys, enablePodman, stack, gpus, osType, monitoring, pool, backendID, git, ttlSeconds, idleStopMinutes, deleteAfterStoppedSeconds, storageClass, enc)
 }

--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -377,14 +377,15 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 				"",   // stack
 				nil,  // gpus
 				ostype.OSTypeFromString("ubuntu"),
-				false,                  // monitoring
-				"",                     // pool
-				"",                     // backend-id
-				client.GitSourceOpts{}, // no git-source for runner boxes
-				0,                      // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
-				0,                      // idle-stop: runner boxes are long-lived; not auto-slept
-				0,                      // delete-after-stopped: not applicable to runner boxes
-				"",                     // storage-class: runner boxes use cluster default
+				false,                   // monitoring
+				"",                      // pool
+				"",                      // backend-id
+				client.GitSourceOpts{},  // no git-source for runner boxes
+				0,                       // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
+				0,                       // idle-stop: runner boxes are long-lived; not auto-slept
+				0,                       // delete-after-stopped: not applicable to runner boxes
+				"",                      // storage-class: runner boxes use cluster default
+				client.EncryptionOpts{}, // encryption: runner boxes carry no tenant data (#1198)
 			)
 			if err != nil {
 				return "", "", err
@@ -418,11 +419,12 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 			false,
 			"",
 			"",
-			client.GitSourceOpts{}, // no git-source for runner boxes
-			0,                      // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
-			0,                      // idle-stop: runner boxes are long-lived; not auto-slept
-			0,                      // delete-after-stopped: not applicable to runner boxes
-			"",                     // storage-class: runner boxes use cluster default
+			client.GitSourceOpts{},  // no git-source for runner boxes
+			0,                       // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
+			0,                       // idle-stop: runner boxes are long-lived; not auto-slept
+			0,                       // delete-after-stopped: not applicable to runner boxes
+			"",                      // storage-class: runner boxes use cluster default
+			client.EncryptionOpts{}, // encryption: runner boxes carry no tenant data (#1198)
 		)
 		if err != nil {
 			return "", "", err

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1568,6 +1568,16 @@ type CreateContainerRequest struct {
 	// docs/OTEL-COLLECTOR-DESIGN.md for the full design.
 	Monitoring bool `json:"monitoring,omitempty"`
 
+	// Encrypted requests a tenant-scoped ZFS key for the container's
+	// dataset instead of the pool-wide key (#1198). The daemon refuses
+	// the create with FAILED_PRECONDITION when no KeyProvider is
+	// configured — it never falls back to plaintext.
+	Encrypted bool `json:"encrypted,omitempty"`
+
+	// TenantID scopes the encryption key. A single-tenant daemon accepts
+	// only an empty value or "default".
+	TenantID string `json:"tenantId,omitempty"`
+
 	// Pool selects placement by pool tag. When set with an empty
 	// BackendID, the daemon picks any healthy backend in the pool.
 	// When set with BackendID, the daemon validates that BackendID

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -196,6 +196,14 @@ func (s *Server) registerTools() {
 						"type":        "boolean",
 						"description": "Opt the container into application-emitted OpenTelemetry. When true, the daemon stamps the LXC with OTEL_EXPORTER_OTLP_ENDPOINT (and related env vars) pointing at the platform's core OTel collector, so any OTel SDK inside the container ships telemetry without app-side configuration. Default false. The daemon's own cgroup-level metrics for the container (CPU/mem/disk/net) are independent of this flag and continue for every container regardless.",
 					},
+					"encrypted": map[string]interface{}{
+						"type":        "boolean",
+						"description": "Encrypt the container's ZFS dataset with a tenant-scoped key rather than the pool-wide key, so a co-tenant — or host root once the box is stopped — sees ciphertext. Requires the daemon to have a KeyProvider configured: without one the create is REFUSED (FAILED_PRECONDITION) rather than silently producing an unencrypted container. Default false. Mirrors `containarium create --encrypted`.",
+					},
+					"tenant_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Tenant that owns the container, scoping its encryption key. A single-tenant daemon accepts only an empty value or 'default' and rejects anything else with INVALID_ARGUMENT.",
+					},
 					"pool": map[string]interface{}{
 						"type":        "string",
 						"description": "Place the container on any healthy backend tagged with this pool (e.g., 'demo', 'lab', 'prod'). When omitted, the request lands on the primary/local backend. Use list_backends to see available pools. Mutually exclusive with backend_id unless the chosen backend is already in this pool (the daemon validates consistency).",
@@ -1402,6 +1410,8 @@ func handleCreateContainer(client API, args map[string]interface{}) (string, err
 		GPU:          getStringArg(args, "gpu", ""),
 		GPUs:         getStringSliceArg(args, "gpus"),
 		Monitoring:   getBoolArg(args, "monitoring", false),
+		Encrypted:    getBoolArg(args, "encrypted", false),
+		TenantID:     getStringArg(args, "tenant_id", ""),
 		Pool:         getStringArg(args, "pool", ""),
 		BackendID:    getStringArg(args, "backend_id", ""),
 	}

--- a/internal/server/container_encryption.go
+++ b/internal/server/container_encryption.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Request validation for per-tenant dataset encryption (#1198), phase 2
+// of docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md.
+//
+// The flag is accepted and validated here; the lifecycle hooks that
+// actually create an encrypted dataset land in #1199/#1201. Until then a
+// daemon with no KeyProvider — which is every OSS daemon today — rejects
+// an encrypted create outright, so there is no window in which the API
+// accepts "encrypt this" and produces plaintext.
+
+// defaultTenantID is the only tenant a single-tenant daemon recognises.
+// Callers may also leave the field unset.
+const defaultTenantID = "default"
+
+// validateEncryption rejects an encrypted create when the daemon has no
+// key custody wired.
+//
+// Failing closed is the whole point: silently provisioning an
+// unencrypted dataset would hand the caller a guarantee they do not
+// have, and they would discover it during an audit rather than at create
+// time. FAILED_PRECONDITION rather than INVALID_ARGUMENT because the
+// request is well-formed — it is the daemon that is not configured for
+// it, so the fix is an operator action, not a caller one.
+func validateEncryption(req *pb.CreateContainerRequest, provider zfskey.KeyProvider) error {
+	if req == nil || !req.GetEncrypted() {
+		return nil
+	}
+	if provider == nil {
+		return status.Error(codes.FailedPrecondition,
+			"encrypted=true requires this daemon to be wired with a KeyProvider for per-tenant dataset encryption, "+
+				"and none is configured; refusing rather than creating an unencrypted container. "+
+				"See docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md")
+	}
+	return nil
+}
+
+// validateTenantID enforces the single-tenant contract of the OSS daemon.
+//
+// The field exists on the proto so the wire shape is stable across the
+// OSS → cloud transition (design resolved decision #1), but accepting a
+// real tenant here would be a lie: this build has no tenancy, so every
+// "tenant" would end up sharing one encryptionroot and the isolation the
+// field implies would not exist. The multi-tenant cloud daemon relaxes
+// this; OSS does not pretend.
+func validateTenantID(tenantID string) error {
+	// Exact match only. Deliberately not trimmed: "  " is an explicit
+	// value the caller sent, not an unset field, and quietly reading it
+	// as the default would accept a tenant this daemon cannot isolate.
+	if tenantID == "" || tenantID == defaultTenantID {
+		return nil
+	}
+	return status.Errorf(codes.InvalidArgument,
+		"tenant_id %q is not available on this daemon: it is a single-tenant build, which accepts only "+
+			"an unset tenant_id or %q. Multi-tenant placement is a cloud-build feature",
+		tenantID, defaultTenantID)
+}

--- a/internal/server/container_encryption_test.go
+++ b/internal/server/container_encryption_test.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// AC: `encrypted=true` with no KeyProvider wired fails with
+// FAILED_PRECONDITION — never a silent fall back to plaintext.
+//
+// This is the criterion the whole flag exists for. A create that accepts
+// "encrypt this" and quietly provisions an unencrypted dataset hands the
+// caller a guarantee they do not have, and they find out during an audit
+// rather than at create time.
+func TestValidateEncryptionRequiresAKeyProvider(t *testing.T) {
+	err := validateEncryption(&pb.CreateContainerRequest{Encrypted: true}, nil)
+	if err == nil {
+		t.Fatal("encrypted=true was accepted with no KeyProvider — the request must fail rather than silently produce plaintext")
+	}
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", got)
+	}
+	if !strings.Contains(err.Error(), "KeyProvider") {
+		t.Errorf("error should name the missing dependency, got %q", err)
+	}
+}
+
+// With a provider wired, an encrypted create is accepted.
+func TestValidateEncryptionAcceptedWithAProvider(t *testing.T) {
+	provider, err := zfskey.NewFileKeyProvider(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileKeyProvider: %v", err)
+	}
+	if err := validateEncryption(&pb.CreateContainerRequest{Encrypted: true}, provider); err != nil {
+		t.Errorf("encrypted create rejected despite a wired provider: %v", err)
+	}
+}
+
+// AC: the default path is unchanged. encrypted=false must not require a
+// provider — the overwhelming majority of creates are unencrypted and
+// must not start failing on a daemon with no key custody configured.
+func TestValidateEncryptionIgnoredWhenNotRequested(t *testing.T) {
+	if err := validateEncryption(&pb.CreateContainerRequest{}, nil); err != nil {
+		t.Errorf("a plain create must not need a KeyProvider: %v", err)
+	}
+	if err := validateEncryption(&pb.CreateContainerRequest{Encrypted: false}, nil); err != nil {
+		t.Errorf("encrypted=false must not need a KeyProvider: %v", err)
+	}
+}
+
+// AC: the OSS daemon rejects a non-default tenant_id with
+// INVALID_ARGUMENT.
+//
+// The field is defined on the proto so the wire shape stays stable into
+// the multi-tenant cloud build, but accepting a tenant here would be a
+// lie: this daemon has no tenancy, so every "tenant" would share one
+// encryptionroot and the isolation the field implies would not exist.
+func TestValidateTenantIDRejectsRealTenantsOnOSS(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		tenantID string
+		wantErr  bool
+	}{
+		{"unset is fine", "", false},
+		{"explicit default is fine", "default", false},
+		{"a real tenant is rejected", "acme-corp", true},
+		{"another tenant is rejected", "org-alice", true},
+		{"whitespace is not a smuggled default", "  ", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTenantID(tc.tenantID)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("tenant_id %q was accepted by a single-tenant daemon", tc.tenantID)
+				}
+				if got := status.Code(err); got != codes.InvalidArgument {
+					t.Errorf("code = %v, want InvalidArgument", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("tenant_id %q rejected: %v", tc.tenantID, err)
+			}
+		})
+	}
+}
+
+// The rejection has to explain itself: an operator hitting this is using
+// a field the proto documents as valid, and needs to know it is the
+// build, not the request, that is limited.
+func TestTenantIDRejectionIsActionable(t *testing.T) {
+	err := validateTenantID("acme-corp")
+	if err == nil {
+		t.Fatal("expected rejection")
+	}
+	msg := strings.ToLower(err.Error())
+	for _, want := range []string{"tenant", "single-tenant"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message should mention %q so the caller understands why; got %q", want, err)
+		}
+	}
+}

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/footprintai/containarium/pkg/core/incus"
 	"github.com/footprintai/containarium/pkg/core/ostype"
 	"github.com/footprintai/containarium/pkg/core/stacks"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 	"github.com/footprintai/containarium/pkg/version"
 	"google.golang.org/grpc/codes"
@@ -80,7 +81,13 @@ type ContainerServer struct {
 	// imperative create path write a Box CR instead of calling boxBackend
 	// directly — the operator then reconciles it, so both the imperative and
 	// declarative paths converge on one builder (#995, slice 4).
-	boxWriter           *controller.BoxWriter
+	boxWriter *controller.BoxWriter
+	// keyProvider supplies per-tenant ZFS encryption keys. Nil on a
+	// daemon with no key custody configured — which is every OSS daemon
+	// today — in which case an encrypted create is refused rather than
+	// silently producing plaintext (#1198). The lifecycle hooks that
+	// consume it land in #1199/#1201.
+	keyProvider         zfskey.KeyProvider
 	collaboratorManager *container.CollaboratorManager
 	emitter             *events.Emitter
 	pendingCreations    map[string]*PendingCreation
@@ -360,6 +367,16 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	// 0 = never delete on stop; > 0 reaps a box left stopped that long.
 	if req.DeleteAfterStoppedSeconds < 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "delete_after_stopped_seconds must be >= 0, got %d", req.DeleteAfterStoppedSeconds)
+	}
+	// Per-tenant dataset encryption (#1198): refuse before provisioning
+	// anything. A create that accepts encrypted=true and then produces a
+	// plaintext dataset is worse than a rejected one — the caller would
+	// believe they had encryption at rest.
+	if err := validateTenantID(req.TenantId); err != nil {
+		return nil, err
+	}
+	if err := validateEncryption(req, s.keyProvider); err != nil {
+		return nil, err
 	}
 
 	// Pool resolution — if a pool is requested, either validate that

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -1110,7 +1110,30 @@ type CreateContainerRequest struct {
 	// singular `gpu` field: when non-empty `gpu` is ignored; when empty a
 	// non-empty `gpu` is treated as a single-element list. Each device is
 	// resolved to a stable PCI address at create time.
-	Gpus          []string `protobuf:"bytes,23,rep,name=gpus,proto3" json:"gpus,omitempty"`
+	Gpus []string `protobuf:"bytes,23,rep,name=gpus,proto3" json:"gpus,omitempty"`
+	// Encrypt the container's ZFS dataset with a tenant-scoped key rather
+	// than the pool-wide key, so a co-tenant — or host root, once the
+	// container is stopped and the key unloaded — sees ciphertext.
+	//
+	// Requires the daemon to be wired with a KeyProvider. Without one the
+	// request fails with FAILED_PRECONDITION; it never falls back to
+	// plaintext, because a create that silently ignores this flag would
+	// hand the caller an encryption guarantee they do not have.
+	//
+	// Default false: existing containers keep their current posture
+	// (pool-level encryption, or none). See
+	// docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md.
+	Encrypted bool `protobuf:"varint,24,opt,name=encrypted,proto3" json:"encrypted,omitempty"`
+	// Tenant that owns this container, scoping the encryption key: all of
+	// a tenant's containers share one ZFS encryptionroot, and different
+	// tenants always have distinct ones.
+	//
+	// The OSS daemon is single-tenant and accepts only "" or "default",
+	// rejecting anything else with INVALID_ARGUMENT; the multi-tenant
+	// cloud daemon accepts any non-empty value. The field is defined here
+	// so the wire shape stays stable across the OSS → cloud transition
+	// rather than changing when tenancy lands.
+	TenantId      string `protobuf:"bytes,25,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1304,6 +1327,20 @@ func (x *CreateContainerRequest) GetGpus() []string {
 		return x.Gpus
 	}
 	return nil
+}
+
+func (x *CreateContainerRequest) GetEncrypted() bool {
+	if x != nil {
+		return x.Encrypted
+	}
+	return false
+}
+
+func (x *CreateContainerRequest) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
 }
 
 // CreateContainerResponse is the response from creating a container
@@ -4921,7 +4958,7 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x10disk_usage_bytes\x18\x05 \x01(\x03R\x0ediskUsageBytes\x12(\n" +
 	"\x10network_rx_bytes\x18\x06 \x01(\x03R\x0enetworkRxBytes\x12(\n" +
 	"\x10network_tx_bytes\x18\a \x01(\x03R\x0enetworkTxBytes\x12#\n" +
-	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\x86\b\n" +
+	"\rprocess_count\x18\b \x01(\x05R\fprocessCount\"\xc1\b\n" +
 	"\x16CreateContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12=\n" +
 	"\tresources\x18\x02 \x01(\v2\x1f.containarium.v1.ResourceLimitsR\tresources\x12\x19\n" +
@@ -4951,7 +4988,9 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"ttlSeconds\x12*\n" +
 	"\x11idle_stop_minutes\x18\x15 \x01(\x05R\x0fidleStopMinutes\x12?\n" +
 	"\x1cdelete_after_stopped_seconds\x18\x16 \x01(\x03R\x19deleteAfterStoppedSeconds\x12\x12\n" +
-	"\x04gpus\x18\x17 \x03(\tR\x04gpus\x1a9\n" +
+	"\x04gpus\x18\x17 \x03(\tR\x04gpus\x12\x1c\n" +
+	"\tencrypted\x18\x18 \x01(\bR\tencrypted\x12\x1b\n" +
+	"\ttenant_id\x18\x19 \x01(\tR\btenantId\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aB\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -415,6 +415,31 @@ message CreateContainerRequest {
   // non-empty `gpu` is treated as a single-element list. Each device is
   // resolved to a stable PCI address at create time.
   repeated string gpus = 23;
+
+  // Encrypt the container's ZFS dataset with a tenant-scoped key rather
+  // than the pool-wide key, so a co-tenant — or host root, once the
+  // container is stopped and the key unloaded — sees ciphertext.
+  //
+  // Requires the daemon to be wired with a KeyProvider. Without one the
+  // request fails with FAILED_PRECONDITION; it never falls back to
+  // plaintext, because a create that silently ignores this flag would
+  // hand the caller an encryption guarantee they do not have.
+  //
+  // Default false: existing containers keep their current posture
+  // (pool-level encryption, or none). See
+  // docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md.
+  bool encrypted = 24;
+
+  // Tenant that owns this container, scoping the encryption key: all of
+  // a tenant's containers share one ZFS encryptionroot, and different
+  // tenants always have distinct ones.
+  //
+  // The OSS daemon is single-tenant and accepts only "" or "default",
+  // rejecting anything else with INVALID_ARGUMENT; the multi-tenant
+  // cloud daemon accepts any non-empty value. The field is defined here
+  // so the wire shape stays stable across the OSS → cloud transition
+  // rather than changing when tenancy lands.
+  string tenant_id = 25;
 }
 
 // CreateContainerResponse is the response from creating a container

--- a/test/integration/storage_test.go
+++ b/test/integration/storage_test.go
@@ -107,6 +107,7 @@ func testCreateContainerWithQuota(t *testing.T, ctx context.Context, grpcClient 
 		0,                            // No idle-stop
 		0,                            // No stopped→delete
 		"",                           // No storage-class override
+		client.EncryptionOpts{},      // No per-tenant dataset encryption (#1198)
 	)
 	require.NoError(t, err, "Failed to create container")
 	require.NotNil(t, container)
@@ -152,13 +153,14 @@ func testQuotaEnforcement(t *testing.T, ctx context.Context, grpcClient *client.
 		nil,
 		0, // Default OS type
 		false,
-		"",                     // No pool
-		"",                     // No backend ID
-		client.GitSourceOpts{}, // No git provisioning
-		0,                      // No birth TTL
-		0,                      // No idle-stop
-		0,                      // No stopped→delete
-		"",                     // No storage-class override
+		"",                      // No pool
+		"",                      // No backend ID
+		client.GitSourceOpts{},  // No git provisioning
+		0,                       // No birth TTL
+		0,                       // No idle-stop
+		0,                       // No stopped→delete
+		"",                      // No storage-class override
+		client.EncryptionOpts{}, // No per-tenant dataset encryption (#1198)
 	)
 	require.NoError(t, err)
 	require.NotNil(t, container)
@@ -195,11 +197,11 @@ func testMultiContainerIsolation(t *testing.T, ctx context.Context, grpcClient *
 	t.Log("Creating multiple containers to test quota isolation...")
 
 	// Create two containers with different quotas
-	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "")
+	_, err := grpcClient.CreateContainer(user1, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "", client.EncryptionOpts{})
 	require.NoError(t, err)
 	defer func() { _ = grpcClient.DeleteContainer(user1, true) }()
 
-	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "")
+	_, err = grpcClient.CreateContainer(user2, "images:ubuntu/24.04", "1", "1GB", "15GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "", client.EncryptionOpts{})
 	require.NoError(t, err)
 	defer func() { _ = grpcClient.DeleteContainer(user2, true) }()
 
@@ -225,7 +227,7 @@ func testCompression(t *testing.T, ctx context.Context, grpcClient *client.GRPCC
 
 	t.Log("Creating container to test compression...")
 
-	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "")
+	_, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "1", "1GB", "10GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "", client.EncryptionOpts{})
 	require.NoError(t, err)
 	defer func() { _ = grpcClient.DeleteContainer(username, true) }()
 
@@ -248,7 +250,7 @@ func testPrepareRebootData(t *testing.T, ctx context.Context, grpcClient *client
 	t.Logf("Creating container for persistence test: %s", username)
 
 	// Create container
-	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "")
+	container, err := grpcClient.CreateContainer(username, "images:ubuntu/24.04", "2", "2GB", "20GB", []string{}, false, "", nil, 0, false, "", "", client.GitSourceOpts{}, 0, 0, 0, "", client.EncryptionOpts{})
 	require.NoError(t, err)
 	require.NotNil(t, container)
 


### PR DESCRIPTION
Closes #1198. Part of #1205 (Sprint 2026-W32).

Phase 2 of `docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md` — the API surface for per-tenant dataset encryption, built on the `KeyProvider` from #1197. Proto first, then CLI, then MCP as a thin wrapper.

## The flag lands before the hooks, so everything fails closed

The lifecycle hooks that actually create an encrypted dataset are #1199/#1201. Shipping the flag first is only safe because **no path can accept the request and quietly produce plaintext**:

- **`encrypted=true` with no `KeyProvider` → `FAILED_PRECONDITION`.** Every OSS daemon is in that state today, so there is no window where the API says yes and returns an unencrypted container. `FailedPrecondition` rather than `InvalidArgument` deliberately: the request is well-formed, the *daemon* isn't configured, so the fix is an operator action not a caller one.
- **`containarium create --encrypted` without `--server` is refused.** The local Incus path bypasses the daemon entirely and has no way to resolve a tenant key, so accepting the flag there would silently ignore it. Verified against the built binary:
  ```
  $ containarium create testuser --no-ssh-key --encrypted
  Error: --encrypted requires a daemon (--server): local Incus creates cannot
  resolve a tenant key, and creating an unencrypted container here would
  silently ignore the flag
  ```
- **`tenant_id` accepts only `""` or `"default"`.** The field is on the proto so the wire shape is stable into the cloud build (design resolved decision #1), but this daemon has no tenancy — accepting a real tenant would imply an isolation that doesn't exist, since every "tenant" would land on one encryptionroot.

## Review this first — why `EncryptionOpts` and not two more parameters

`CreateContainer` already takes **eighteen positional parameters**. A bare `encrypted bool` would sit directly beside `monitoring bool`, where transposing two arguments compiles cleanly and creates the wrong container — a silent, security-relevant failure.

So the two fields travel as `client.EncryptionOpts`, mirroring the `GitSourceOpts` idiom already present in that same signature. One parameter, named fields, no adjacent-bool hazard.

The signature change is what touched `test/integration/storage_test.go` and `internal/cmd/runner.go` — those call sites pass `EncryptionOpts{}` (runner boxes carry no tenant data).

## Test evidence

Written before the implementation, red on `undefined: validateEncryption` / `undefined: validateTenantID`.

| AC | Test |
|---|---|
| No provider → FAILED_PRECONDITION, never plaintext | `TestValidateEncryptionRequiresAKeyProvider` |
| Accepted once a provider is wired | `TestValidateEncryptionAcceptedWithAProvider` |
| Default path unchanged — no provider needed | `TestValidateEncryptionIgnoredWhenNotRequested` |
| Non-default `tenant_id` → INVALID_ARGUMENT | `TestValidateTenantIDRejectsRealTenantsOnOSS` (5 cases) |
| The rejection explains itself | `TestTenantIDRejectionIsActionable` |

`"  "` is a case worth noting: it trims to empty but is an explicit value the caller sent, so it's rejected rather than read as the default.

```
ok  github.com/footprintai/containarium/internal/server    7.720s
ok  github.com/footprintai/containarium/internal/client    0.008s
ok  github.com/footprintai/containarium/internal/cmd       0.131s
ok  github.com/footprintai/containarium/internal/mcp       0.223s
ok  github.com/footprintai/containarium/pkg/core/zfskey    0.005s
```

gosec: **55 findings on `main`, 55 on this branch** — none introduced. Proto regenerated via `make proto`, not hand-edited; unrelated gateway churn from the local codegen version reverted.

## Test environment

Clean disposable `golang:1.26` container via podman (build, vet, full suite). The three failures there — `internal/sentinel TestRegisterPropagatesPool`, `test/integration TestStorageQuotaEnforcement` / `TestStoragePersistence` — **reproduce identically on `main` in the same box**.

**Nothing here is verified against a live daemon or real ZFS**, and per #1200 that is now known to be impossible from this environment: it is itself an LXC container with no zfs module registered in `/proc/devices` and no `/dev/kvm`. This PR needs neither — it validates and refuses — but #1199/#1201 will, and that gap is escalated on #1200 and #1205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)