### PR TITLE
fix(daemon): stop treating a boot-disk directory as persistent storage

### DIFF
--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/footprintai/containarium/internal/app"
 	"github.com/footprintai/containarium/internal/config"
+	"github.com/footprintai/containarium/internal/hostcheck"
 	"github.com/footprintai/containarium/internal/mtls"
 	"github.com/footprintai/containarium/internal/server"
 	"github.com/footprintai/containarium/pkg/core/container"
@@ -863,11 +864,26 @@ func resolvePublicBaseDomains(public []string, base string) []string {
 // saveRecoveryConfigToPersistentStorage saves recovery config to persistent disk
 // This enables auto-recovery after instance recreation
 func saveRecoveryConfigToPersistentStorage(networkCIDR, baseDomain, caddyAdminURL, jwtSecretFile string, appHosting bool) error {
-	// Only save if the persistent storage path exists
-	persistentDir := "/mnt/incus-data"
+	// Only save if the persistent storage path exists.
+	persistentDir := hostcheck.DefaultRecoveryDir
 	if _, err := os.Stat(persistentDir); os.IsNotExist(err) {
-		// Persistent storage not mounted, skip
+		// Nothing provisioned there at all — no recovery config to write.
 		return nil
+	}
+	// os.Stat proves the directory exists; it cannot prove the directory
+	// is durable. Any host where this path exists for an incidental
+	// reason — a leftover mkdir from the startup script, a partial
+	// migration — used to be treated as persistent storage, and the
+	// config was written to the boot disk and destroyed by exactly the
+	// event it exists to survive (#1154).
+	//
+	// The write still goes ahead: it remains useful for an in-place
+	// daemon restart, and skipping it would lose that for no gain. What
+	// changes is that the host no longer reports silent success — the
+	// condition is logged here and surfaced as a `containarium doctor`
+	// check, so it is visible before a recovery rather than during one.
+	if warning := hostcheck.DescribeDurability(persistentDir); warning != "" {
+		log.Print(warning)
 	}
 
 	// Try to get ZFS source from current storage pool

--- a/internal/hostcheck/durability.go
+++ b/internal/hostcheck/durability.go
@@ -1,0 +1,122 @@
+package hostcheck
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultRecoveryDir is where the daemon writes containarium-recovery.yaml.
+// The file exists to survive instance recreation, so it is only useful if
+// this path is backed by a disk that outlives the instance.
+const DefaultRecoveryDir = "/mnt/incus-data"
+
+// IsDurable reports whether path is its own mount point — i.e. backed by
+// a filesystem mounted there, rather than being a plain directory on some
+// ancestor's volume.
+//
+// This is the distinction os.Stat cannot make, and it is the whole of
+// #1154: the daemon gated its recovery-config write on the directory
+// merely existing. Any host where /mnt/incus-data existed for any reason
+// — a leftover mkdir from the startup script, a partial migration — was
+// treated as durable storage, and the config was written to the boot
+// disk, destroyed by exactly the event it exists to survive.
+//
+// An error means the answer is unknown; callers must not read that as
+// "not durable", because a guess presented as a fact is what caused the
+// original bug.
+func IsDurable(path string) (bool, error) {
+	return isOwnMount("/proc/mounts", path)
+}
+
+// isOwnMount is IsDurable with an injectable /proc/mounts, for tests.
+func isOwnMount(procMountsPath, target string) (bool, error) {
+	raw, err := os.ReadFile(procMountsPath) // #nosec G304 -- procMountsPath is /proc/mounts in production; the parameter exists so tests can supply a fixture
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", procMountsPath, err)
+	}
+
+	// Normalise so "/mnt/incus-data/" and "/mnt/incus-data" compare
+	// equal; filepath.Clean also collapses "." and duplicate separators.
+	target = filepath.Clean(target)
+
+	_, mountPoint := deviceForPath(string(raw), target)
+	if mountPoint == "" {
+		// No real device covers the path at all. Not durable, and not an
+		// error: an overlay-only or wholly pseudo-filesystem root is a
+		// legitimate host shape, just not a durable one.
+		return false, nil
+	}
+	return filepath.Clean(mountPoint) == target, nil
+}
+
+// recoveryConfigDurableCheck reports whether the recovery config's
+// directory is on storage that survives instance recreation.
+//
+// Surfaced through `containarium doctor` rather than left as a log line,
+// because the failure is silent by construction: the write succeeds, the
+// file looks current, and the problem is discovered during an actual
+// recovery — the worst possible moment (#1154).
+func recoveryConfigDurableCheck(p posturePaths) Check {
+	c := Check{Name: "recovery config on durable storage"}
+
+	dir := p.recoveryDir
+	if dir == "" {
+		dir = DefaultRecoveryDir
+	}
+
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			// No persistent storage provisioned. Reported as not-OK
+			// rather than OK: this host writes no recovery config at
+			// all, so it cannot be rebuilt after instance recreation —
+			// which is a true and actionable finding, not a pass.
+			//
+			// It is also what the posture contract requires: a check
+			// may not claim OK without positive evidence, and "the
+			// directory is missing" is the absence of evidence
+			// (TestRunPosture_UnknownHostReportsNoPasses).
+			c.Detail = fmt.Sprintf(
+				"%s does not exist: no persistent storage is provisioned, so no recovery config is "+
+					"written and this host cannot be rebuilt after instance recreation", dir)
+			return c
+		}
+		c.Detail = fmt.Sprintf("cannot stat %s: %v", dir, err)
+		return c
+	}
+
+	durable, err := isOwnMount(p.procMounts, dir)
+	if err != nil {
+		c.Detail = fmt.Sprintf("cannot determine whether %s is durable: %v", dir, err)
+		return c
+	}
+	if !durable {
+		c.Detail = fmt.Sprintf(
+			"%s is a directory on another filesystem, not its own mount: a recovery config written "+
+				"there does NOT survive instance recreation, which is the only event it exists for",
+			dir)
+		return c
+	}
+
+	c.OK = true
+	c.Detail = fmt.Sprintf("%s is its own mount point", dir)
+	return c
+}
+
+// DescribeDurability renders a one-line operator-facing warning for a
+// non-durable recovery directory, or "" when the location is fine or
+// undeterminable. Used by the daemon at write time so the condition is
+// visible in the startup log as well as in `doctor`.
+func DescribeDurability(dir string) string {
+	durable, err := IsDurable(dir)
+	if err != nil || durable {
+		return ""
+	}
+	return strings.Join([]string{
+		fmt.Sprintf("WARNING: %s is not its own mount point.", dir),
+		"The recovery config has been written, but it lives on the boot disk and will be",
+		"destroyed by instance recreation — the exact event it exists to survive.",
+		"Attach persistent storage there, or treat this host as non-recoverable.",
+	}, " ")
+}

--- a/internal/hostcheck/durability.go
+++ b/internal/hostcheck/durability.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package hostcheck
 
 import (

--- a/internal/hostcheck/durability_test.go
+++ b/internal/hostcheck/durability_test.go
@@ -1,0 +1,150 @@
+package hostcheck
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestIsOwnMount distinguishes a path that is its own mount point from a
+// plain directory sitting on some ancestor's filesystem.
+//
+// This is the durability test for #1154. `os.Stat` cannot tell the two
+// apart — the directory exists either way — which is how the daemon came
+// to write a recovery config onto the boot disk and report success. The
+// file exists only to survive instance recreation, so writing it
+// somewhere that dies with the instance is worse than not writing it: an
+// operator finds a current, well-formed recovery config with a recent
+// mtime and reasonably concludes recovery is covered.
+func TestIsOwnMount(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mounts  string
+		target  string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:   "persistent disk mounted at the target",
+			mounts: "/dev/sda1 / ext4 rw 0 0\n/dev/sdb1 /mnt/incus-data ext4 rw 0 0\n",
+			target: "/mnt/incus-data",
+			want:   true,
+		},
+		{
+			name:   "plain directory on the boot disk",
+			mounts: "/dev/sda1 / ext4 rw 0 0\n",
+			target: "/mnt/incus-data",
+			want:   false,
+		},
+		{
+			name: "nested mount does not count as the target's own",
+			// A disk mounted *below* the target does not make the
+			// target durable.
+			mounts: "/dev/sda1 / ext4 rw 0 0\n/dev/sdb1 /mnt/incus-data/sub ext4 rw 0 0\n",
+			target: "/mnt/incus-data",
+			want:   false,
+		},
+		{
+			name:   "trailing slash on the target is not a different path",
+			mounts: "/dev/sda1 / ext4 rw 0 0\n/dev/sdb1 /mnt/incus-data ext4 rw 0 0\n",
+			target: "/mnt/incus-data/",
+			want:   true,
+		},
+		{
+			name: "longest prefix wins",
+			// With both / and /mnt mounted, a naive first match picks
+			// "/" and would call the target durable when it is not.
+			mounts: "/dev/sda1 / ext4 rw 0 0\n/dev/sdb1 /mnt ext4 rw 0 0\n",
+			target: "/mnt/incus-data",
+			want:   false,
+		},
+		{
+			name:   "pseudo-filesystems are ignored",
+			mounts: "tmpfs /mnt/incus-data tmpfs rw 0 0\n/dev/sda1 / ext4 rw 0 0\n",
+			target: "/mnt/incus-data",
+			// tmpfs is not a /dev/ device, so the covering real
+			// filesystem is "/" — and a tmpfs would not be durable
+			// anyway.
+			want: false,
+		},
+		{
+			name:    "unreadable mounts is an error, not a false verdict",
+			mounts:  "",
+			target:  "/mnt/incus-data",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "mounts")
+			if !tc.wantErr {
+				write(t, path, tc.mounts)
+			}
+
+			got, err := isOwnMount(path, tc.target)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("want an error when /proc/mounts cannot be read — reporting " +
+						"'not durable' on a read failure would be a guess presented as a fact")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("isOwnMount: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("isOwnMount(%q) = %v, want %v\nmounts:\n%s", tc.target, got, tc.want, tc.mounts)
+			}
+		})
+	}
+}
+
+// The recovery-config check must surface in `containarium doctor`, not
+// only in a log line an operator will miss. A recovery config on the
+// boot disk is discovered during a recovery otherwise — the worst
+// possible moment.
+func TestRecoveryConfigDurableCheck(t *testing.T) {
+	t.Run("durable when the path is its own mount", func(t *testing.T) {
+		p, dir := tempPaths(t)
+		write(t, p.procMounts, "/dev/sda1 / ext4 rw 0 0\n/dev/sdb1 "+dir+" ext4 rw 0 0\n")
+		p.recoveryDir = dir
+
+		c := recoveryConfigDurableCheck(p)
+		if !c.OK {
+			t.Errorf("want OK, got %+v", c)
+		}
+	})
+
+	t.Run("not durable when it is a boot-disk directory", func(t *testing.T) {
+		p, dir := tempPaths(t)
+		write(t, p.procMounts, "/dev/sda1 / ext4 rw 0 0\n")
+		p.recoveryDir = dir
+
+		c := recoveryConfigDurableCheck(p)
+		if c.OK {
+			t.Error("a plain directory on the boot disk was reported as durable — this is the #1154 bug")
+		}
+		if c.Detail == "" {
+			t.Error("a failing check must explain itself")
+		}
+	})
+
+	t.Run("absent directory does not claim a pass", func(t *testing.T) {
+		p, _ := tempPaths(t)
+		write(t, p.procMounts, "/dev/sda1 / ext4 rw 0 0\n")
+		p.recoveryDir = filepath.Join(t.TempDir(), "does-not-exist")
+
+		c := recoveryConfigDurableCheck(p)
+		// A host with no persistent storage writes no recovery config
+		// and cannot be rebuilt after instance recreation. That is a
+		// real finding, not a pass — and the posture contract
+		// (TestRunPosture_UnknownHostReportsNoPasses) forbids claiming
+		// OK without positive evidence either way.
+		if c.OK {
+			t.Error("reported OK for a host with no persistent storage: nothing was verified")
+		}
+		if !strings.Contains(c.Detail, "instance recreation") {
+			t.Errorf("detail should say what the operator loses, got %q", c.Detail)
+		}
+	})
+}

--- a/internal/hostcheck/durability_test.go
+++ b/internal/hostcheck/durability_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package hostcheck
 
 import (

--- a/internal/hostcheck/posture.go
+++ b/internal/hostcheck/posture.go
@@ -55,6 +55,7 @@ type posturePaths struct {
 	sshdConfigDir  string // /etc/ssh/sshd_config.d
 	aptPeriodic    string // /etc/apt/apt.conf.d/20auto-upgrades
 	incusDataDir   string // /var/lib/incus — the volume that holds tenant data
+	recoveryDir    string // /mnt/incus-data — where containarium-recovery.yaml is written (#1154)
 	metadataDialer func() error
 }
 
@@ -68,6 +69,7 @@ func defaultPosturePaths() posturePaths {
 		sshdConfigDir:  "/etc/ssh/sshd_config.d",
 		aptPeriodic:    "/etc/apt/apt.conf.d/20auto-upgrades",
 		incusDataDir:   "/var/lib/incus",
+		recoveryDir:    DefaultRecoveryDir,
 		metadataDialer: dialMetadataServer,
 	}
 }
@@ -92,6 +94,7 @@ func runPosture(p posturePaths) []Check {
 		sshdConfigCheck(p),
 		unattendedUpgradesCheck(p),
 		metadataReachableCheck(p),
+		recoveryConfigDurableCheck(p),
 	}
 	for i := range checks {
 		checks[i].Kind = KindPosture


### PR DESCRIPTION
Closes #1154.

## The bug

`saveRecoveryConfigToPersistentStorage` gated its write on the directory merely existing:

```go
if _, err := os.Stat(persistentDir); os.IsNotExist(err) { return nil }
```

`os.Stat` cannot tell a mounted persistent disk from an ordinary directory on the boot disk. Any host where `/mnt/incus-data` existed for an incidental reason — a leftover `mkdir` from the startup script, a partial migration — was treated as durable storage.

The recovery config records the network CIDR, ZFS source, storage pool and daemon flags so a rebuilt host can run `containarium recover`. Writing it to the boot disk means **it is destroyed by exactly the event it exists to survive.**

And it fails silently, which is the part that actually bites: an operator inspecting the host finds a current, well-formed `containarium-recovery.yaml` with a recent mtime and reasonably concludes recovery is covered. The failure surfaces during an actual recovery — the worst possible moment.

## The fix

- **`hostcheck.IsDurable(path)`** answers what `os.Stat` cannot: is this path *its own mount point*? Built on the existing `deviceForPath`, per the issue's suggestion, so `/proc/mounts` parsing stays in one place rather than gaining a second parser in `internal/cmd`.
- **The write still happens.** It remains useful for an in-place daemon restart, and skipping it would lose that for no gain. What changes is that the host no longer reports silent success — the condition is logged at write time *and* surfaced as a `containarium doctor` check, so it's visible before a recovery rather than during one. (The issue leaned this way too; the log line alone would be missed, which is why the doctor check is the part that actually protects operators.)

Live on this host:

```
$ containarium doctor
  ! recovery config on durable storage — /mnt/incus-data does not exist: no
    persistent storage is provisioned, so no recovery config is written and
    this host cannot be rebuilt after instance recreation
```

## Two judgment calls worth review

**An unreadable `/proc/mounts` is an error, not a "not durable" verdict.** Presenting a guess as a fact is precisely what caused the original bug, so the caller has to decide what to do with "unknown" rather than being handed a confident wrong answer.

**The absent-directory case reports not-OK, not OK.** My first version returned OK — "nothing provisioned, nothing to be wrong about" — and the existing `TestRunPosture_UnknownHostReportsNoPasses` caught it. That contract is right: a posture check may not claim OK without positive evidence. It's also the more honest answer, since such a host writes no recovery config at all and genuinely cannot be rebuilt after instance recreation. Worth confirming you want that surfaced on every host without persistent storage rather than stayed silent about.

## Test evidence

Written before the implementation. 10 cases covering longest-prefix matching (with both `/` and `/mnt` mounted, a naive first match calls the target durable when it isn't), nested mounts, trailing slashes, pseudo-filesystems, and the read-failure path.

Mutation-tested by reintroducing the original bug — making `isOwnMount` always return true, which is the `os.Stat` gate's behaviour:

```
--- FAIL: TestIsOwnMount/plain_directory_on_the_boot_disk
    isOwnMount("/mnt/incus-data") = true, want false
    mounts:
    /dev/sda1 / ext4 rw 0 0
--- FAIL: TestIsOwnMount/nested_mount_does_not_count_as_the_target's_own
```

```
ok  github.com/footprintai/containarium/internal/hostcheck  4.515s
ok  github.com/footprintai/containarium/internal/cmd        0.273s
```

## Test environment

Clean disposable `golang:1.26` container via podman (build, vet, full suite). The three failures there — `internal/sentinel TestRegisterPropagatesPool`, `test/integration TestStorageQuotaEnforcement` / `TestStoragePersistence` — **reproduce identically on `main` in the same box** and this PR touches neither package.

Note the issue's context: this became reachable only after #1151/#1153 fixed the `EROFS` failure under `ProtectSystem=strict`. That fix turned a loud, harmless failure into a silent, misleading success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)