### PR TITLE
feat(secrets): add a typed SecretDelivery enum alongside the string

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -11095,6 +11095,17 @@
       },
       "title": "ScanJob represents a queued ClamAV scan job"
     },
+    "SecretDelivery": {
+      "type": "string",
+      "enum": [
+        "SECRET_DELIVERY_UNSPECIFIED",
+        "SECRET_DELIVERY_ENV",
+        "SECRET_DELIVERY_FILE",
+        "SECRET_DELIVERY_COMPOSE"
+      ],
+      "default": "SECRET_DELIVERY_UNSPECIFIED",
+      "description": "SecretDelivery is how a secret is materialized inside the container.\nReplaces the free-string `delivery` field, per the repo's\n\"protobuf enums over magic strings\" convention (CLAUDE.md).\n\n - SECRET_DELIVERY_UNSPECIFIED: Unset. Callers that omit delivery_mode fall back to the legacy\n`delivery` string, then to ENV.\n - SECRET_DELIVERY_ENV: environment.\u003cNAME\u003e=\u003cvalue\u003e on the LXC — visible to every process in\nthe container via /proc/\u003cpid\u003e/environ. The pre-4.3 default.\n - SECRET_DELIVERY_FILE: Per-secret file at /run/secrets/\u003cNAME\u003e, mode 0440 root:\u003ctenant\u003e, on\ntmpfs. Same tenant isolation, narrower in-container access surface.\n - SECRET_DELIVERY_COMPOSE: Shared dotenv at /run/containarium/secrets.env (mode 0400, tmpfs)\nfor nested docker / docker-compose apps that consume `env_file:` and\ndo not inherit the LXC environment. Single-line values only."
+    },
     "SecretMetadata": {
       "type": "object",
       "properties": {
@@ -11120,7 +11131,11 @@
         },
         "delivery": {
           "type": "string",
-          "description": "Phase 4.3 — how the secret is delivered into the container.\n\"env\" (default): stamped as environment.\u003cNAME\u003e=\u003cvalue\u003e on the LXC,\nvisible to every process in the container via /proc/\u003cpid\u003e/environ.\n\"file\": written to a per-container tmpfs at /run/secrets/\u003cNAME\u003e,\nfile mode 0440 root:\u003ctenant\u003e. Same tenant isolation, narrower\nin-container access surface.\n\"compose\": written to a shared dotenv file at\n/run/containarium/secrets.env (mode 0400, tmpfs) that nested\ndocker / docker-compose apps consume via `env_file:` — they don't\ninherit the LXC environment (the same gap OTel solved). Single-line\nvalues only; rejected at set-time otherwise. See\ndocs/security/SECRETS-ENV-VAR-RISK.md."
+          "description": "Phase 4.3 — how the secret is delivered into the container.\n\"env\" (default): stamped as environment.\u003cNAME\u003e=\u003cvalue\u003e on the LXC,\nvisible to every process in the container via /proc/\u003cpid\u003e/environ.\n\"file\": written to a per-container tmpfs at /run/secrets/\u003cNAME\u003e,\nfile mode 0440 root:\u003ctenant\u003e. Same tenant isolation, narrower\nin-container access surface.\n\"compose\": written to a shared dotenv file at\n/run/containarium/secrets.env (mode 0400, tmpfs) that nested\ndocker / docker-compose apps consume via `env_file:` — they don't\ninherit the LXC environment (the same gap OTel solved). Single-line\nvalues only; rejected at set-time otherwise. See\ndocs/security/SECRETS-ENV-VAR-RISK.md.\n\nDeprecated: use delivery_mode. Still populated on every response so\nexisting REST/MCP clients keep working; a future major release drops it."
+        },
+        "deliveryMode": {
+          "$ref": "#/definitions/SecretDelivery",
+          "description": "Typed delivery mode — the same value as `delivery`, as an enum.\nBoth fields are always populated and always agree."
         }
       },
       "description": "SecretMetadata is the public-safe view of a stored secret.\n`value` is never returned by `ListSecrets` — only per-name `GetSecret`."
@@ -11382,7 +11397,11 @@
         },
         "delivery": {
           "type": "string",
-          "description": "Phase 4.3 — delivery mode for the secret. Accepts \"env\"\n(default; same behavior as pre-4.3), \"file\" (per-secret tmpfs\n/run/secrets/\u003cNAME\u003e), or \"compose\" (shared dotenv at\n/run/containarium/secrets.env for docker-compose `env_file:`;\nsingle-line values only). Unknown values are rejected at the\nAPI boundary."
+          "description": "Phase 4.3 — delivery mode for the secret. Accepts \"env\"\n(default; same behavior as pre-4.3), \"file\" (per-secret tmpfs\n/run/secrets/\u003cNAME\u003e), or \"compose\" (shared dotenv at\n/run/containarium/secrets.env for docker-compose `env_file:`;\nsingle-line values only). Unknown values are rejected at the\nAPI boundary.\n\nDeprecated: use delivery_mode. Accepted for backward compatibility;\nwhen both are set they must agree, or the request is rejected rather\nthan silently preferring one."
+        },
+        "deliveryMode": {
+          "$ref": "#/definitions/SecretDelivery",
+          "description": "Typed delivery mode. UNSPECIFIED falls back to `delivery`, and if\nthat is empty too, to SECRET_DELIVERY_ENV."
         }
       },
       "description": "SetSecretRequest creates or updates a tenant secret. Idempotent —\nrepeated calls with the same (username, name) bump the version and\nreplace the value."

--- a/internal/client/http_secrets_test.go
+++ b/internal/client/http_secrets_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
 // TestListSecretsDecodesGatewayCamelCase is the regression guard for
@@ -32,7 +34,8 @@ func TestListSecretsDecodesGatewayCamelCase(t *testing.T) {
 	      "version": 3,
 	      "createdAt": "2026-08-01T10:00:00Z",
 	      "updatedAt": "2026-08-07T12:30:00Z",
-	      "delivery": "compose"
+	      "delivery": "compose",
+	      "deliveryMode": "SECRET_DELIVERY_COMPOSE"
 	    },
 	    {
 	      "username": "alice",
@@ -40,7 +43,8 @@ func TestListSecretsDecodesGatewayCamelCase(t *testing.T) {
 	      "version": 1,
 	      "createdAt": "2026-08-02T09:00:00Z",
 	      "updatedAt": "2026-08-02T09:00:00Z",
-	      "delivery": "env"
+	      "delivery": "env",
+	      "deliveryMode": "SECRET_DELIVERY_ENV"
 	    }
 	  ]
 	}`
@@ -86,8 +90,19 @@ func TestListSecretsDecodesGatewayCamelCase(t *testing.T) {
 	if first.GetCreatedAt() != "2026-08-01T10:00:00Z" {
 		t.Errorf("CreatedAt = %q", first.GetCreatedAt())
 	}
+	// The typed field is the one new code reads.
+	if first.GetDeliveryMode() != pb.SecretDelivery_SECRET_DELIVERY_COMPOSE {
+		t.Errorf("DeliveryMode = %v, want SECRET_DELIVERY_COMPOSE", first.GetDeliveryMode())
+	}
+	// The legacy string must keep decoding alongside it. This assertion
+	// deliberately reads the deprecated field: the enum migration's whole
+	// contract is that responses populate both and they always agree, so
+	// dropping this check would remove the only guard on the half of that
+	// promise existing REST/MCP clients actually depend on.
+	//nolint:staticcheck // SA1019: exercising the deprecated field is the point
 	if first.GetDelivery() != "compose" {
-		t.Errorf("Delivery = %q, want compose", first.GetDelivery())
+		//nolint:staticcheck // SA1019: see above
+		t.Errorf("legacy Delivery = %q, want compose — back-compat broken", first.GetDelivery())
 	}
 
 	if list[1].GetName() != "DB_PASSWORD" || list[1].GetVersion() != 1 {

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -140,8 +140,8 @@ func runSecretsSet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	deliverySuffix := ""
-	if meta != nil && meta.Delivery != "" && meta.Delivery != "env" {
-		deliverySuffix = fmt.Sprintf(" delivery=%s", meta.Delivery)
+	if label := secretDeliveryLabel(meta.GetDeliveryMode()); label != "" && label != "env" {
+		deliverySuffix = fmt.Sprintf(" delivery=%s", label)
 	}
 	fmt.Printf("✓ %s (version=%d%s)\n", msg, meta.Version, deliverySuffix)
 	return nil
@@ -288,4 +288,24 @@ func runSecretsRefresh(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("✓ %s (stamped=%d)\n", msg, stamped)
 	return nil
+}
+
+// secretDeliveryLabel renders the delivery enum as the short operator-facing
+// word ("env" / "file" / "compose") rather than its proto name. Mirrors
+// destLabel in backup.go.
+//
+// Reads the typed field rather than the deprecated `delivery` string: both
+// are populated and always agree, but the string is the one scheduled for
+// removal, so new reads go through the enum.
+func secretDeliveryLabel(d pb.SecretDelivery) string {
+	switch d {
+	case pb.SecretDelivery_SECRET_DELIVERY_ENV:
+		return "env"
+	case pb.SecretDelivery_SECRET_DELIVERY_FILE:
+		return "file"
+	case pb.SecretDelivery_SECRET_DELIVERY_COMPOSE:
+		return "compose"
+	default:
+		return ""
+	}
 }

--- a/internal/server/secrets_delivery.go
+++ b/internal/server/secrets_delivery.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/footprintai/containarium/internal/secrets"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// secrets_delivery.go — conversion between the storage layer's delivery
+// string and the proto SecretDelivery enum.
+//
+// The enum is the contract going forward (CLAUDE.md: "protobuf enums over
+// magic strings"); the legacy `delivery` string stays on the wire so
+// existing REST/MCP clients keep working. The DB column also still stores
+// the string, so these two functions are the only seam that needs to know
+// both representations.
+
+// deliveryToProto maps a storage delivery string onto the enum. An empty
+// string means "unset" at the storage layer, which the store normalizes to
+// env — so it maps to ENV rather than UNSPECIFIED, keeping the enum a
+// faithful view of what will actually happen.
+func deliveryToProto(s string) pb.SecretDelivery {
+	switch s {
+	case secrets.DeliveryFile:
+		return pb.SecretDelivery_SECRET_DELIVERY_FILE
+	case secrets.DeliveryCompose:
+		return pb.SecretDelivery_SECRET_DELIVERY_COMPOSE
+	case secrets.DeliveryEnv, "":
+		return pb.SecretDelivery_SECRET_DELIVERY_ENV
+	default:
+		// Unknown values are rejected at the API boundary before they
+		// reach storage, so this is unreachable in practice; report
+		// UNSPECIFIED rather than guessing a mode.
+		return pb.SecretDelivery_SECRET_DELIVERY_UNSPECIFIED
+	}
+}
+
+// deliveryFromProto maps the enum onto the storage string. UNSPECIFIED
+// returns "" so the caller can fall back to the legacy field.
+func deliveryFromProto(d pb.SecretDelivery) string {
+	switch d {
+	case pb.SecretDelivery_SECRET_DELIVERY_ENV:
+		return secrets.DeliveryEnv
+	case pb.SecretDelivery_SECRET_DELIVERY_FILE:
+		return secrets.DeliveryFile
+	case pb.SecretDelivery_SECRET_DELIVERY_COMPOSE:
+		return secrets.DeliveryCompose
+	default:
+		return ""
+	}
+}
+
+// resolveDelivery picks the delivery mode from a SetSecretRequest that may
+// carry the typed field, the legacy string, or both.
+//
+// When both are set they must agree. Silently preferring one would make a
+// client that sent contradictory values believe the other took effect —
+// the same class of silent divergence as a backend accepting a call it
+// cannot honor. Fail loudly instead.
+func resolveDelivery(mode pb.SecretDelivery, legacy string) (string, error) {
+	typed := deliveryFromProto(mode)
+	switch {
+	case typed == "" && legacy == "":
+		// Neither set: the store normalizes "" to env.
+		return "", nil
+	case typed == "":
+		return legacy, nil
+	case legacy == "":
+		return typed, nil
+	case typed == legacy:
+		return typed, nil
+	default:
+		return "", fmt.Errorf("delivery_mode (%s) and delivery (%q) disagree; set one or make them match", mode, legacy)
+	}
+}

--- a/internal/server/secrets_delivery_test.go
+++ b/internal/server/secrets_delivery_test.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/footprintai/containarium/internal/secrets"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+func TestDeliveryToProto(t *testing.T) {
+	tests := []struct {
+		in   string
+		want pb.SecretDelivery
+	}{
+		{secrets.DeliveryEnv, pb.SecretDelivery_SECRET_DELIVERY_ENV},
+		{secrets.DeliveryFile, pb.SecretDelivery_SECRET_DELIVERY_FILE},
+		{secrets.DeliveryCompose, pb.SecretDelivery_SECRET_DELIVERY_COMPOSE},
+		// "" is "unset" in storage, which the store normalizes to env — so
+		// the enum must report ENV, not UNSPECIFIED, or the typed view would
+		// disagree with what actually happens to the secret.
+		{"", pb.SecretDelivery_SECRET_DELIVERY_ENV},
+		{"bogus", pb.SecretDelivery_SECRET_DELIVERY_UNSPECIFIED},
+	}
+	for _, tc := range tests {
+		if got := deliveryToProto(tc.in); got != tc.want {
+			t.Errorf("deliveryToProto(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDeliveryFromProto(t *testing.T) {
+	tests := []struct {
+		in   pb.SecretDelivery
+		want string
+	}{
+		{pb.SecretDelivery_SECRET_DELIVERY_ENV, secrets.DeliveryEnv},
+		{pb.SecretDelivery_SECRET_DELIVERY_FILE, secrets.DeliveryFile},
+		{pb.SecretDelivery_SECRET_DELIVERY_COMPOSE, secrets.DeliveryCompose},
+		{pb.SecretDelivery_SECRET_DELIVERY_UNSPECIFIED, ""},
+	}
+	for _, tc := range tests {
+		if got := deliveryFromProto(tc.in); got != tc.want {
+			t.Errorf("deliveryFromProto(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// Every mode must survive a round trip, or the enum and the DB column drift.
+func TestDeliveryRoundTrip(t *testing.T) {
+	for _, mode := range []string{secrets.DeliveryEnv, secrets.DeliveryFile, secrets.DeliveryCompose} {
+		if got := deliveryFromProto(deliveryToProto(mode)); got != mode {
+			t.Errorf("round trip %q → %v → %q", mode, deliveryToProto(mode), got)
+		}
+	}
+}
+
+func TestResolveDelivery(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    pb.SecretDelivery
+		legacy  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "neither set defers to the store's default",
+			want: "",
+		},
+		{
+			name: "typed only",
+			mode: pb.SecretDelivery_SECRET_DELIVERY_FILE,
+			want: secrets.DeliveryFile,
+		},
+		{
+			name:   "legacy only — an existing REST/MCP client keeps working",
+			legacy: secrets.DeliveryCompose,
+			want:   secrets.DeliveryCompose,
+		},
+		{
+			name:   "both set and agreeing",
+			mode:   pb.SecretDelivery_SECRET_DELIVERY_FILE,
+			legacy: secrets.DeliveryFile,
+			want:   secrets.DeliveryFile,
+		},
+		{
+			// The important case. Silently preferring one would let a client
+			// that sent contradictory values believe the other took effect.
+			name:    "both set and disagreeing is rejected, not silently resolved",
+			mode:    pb.SecretDelivery_SECRET_DELIVERY_FILE,
+			legacy:  secrets.DeliveryEnv,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveDelivery(tc.mode, tc.legacy)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("resolveDelivery(%v, %q) = %q, want error", tc.mode, tc.legacy, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveDelivery(%v, %q) = %q, want %q", tc.mode, tc.legacy, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/secrets_server.go
+++ b/internal/server/secrets_server.go
@@ -40,7 +40,12 @@ func (s *ContainerServer) SetSecret(ctx context.Context, req *pb.SetSecretReques
 		return nil, err
 	}
 
-	meta, err := s.secretsStore.Set(ctx, req.Username, req.Name, req.Value, req.Delivery)
+	delivery, err := resolveDelivery(req.DeliveryMode, req.Delivery) //nolint:staticcheck // req.Delivery is deprecated but still accepted
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	meta, err := s.secretsStore.Set(ctx, req.Username, req.Name, req.Value, delivery)
 	if err != nil {
 		return nil, mapSecretError(err)
 	}
@@ -396,6 +401,9 @@ func toProtoSecretMetadata(m *secrets.SecretMetadata) *pb.SecretMetadata {
 		Version:   m.Version,
 		CreatedAt: m.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
 		UpdatedAt: m.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z"),
-		Delivery:  m.Delivery,
+		// Both forms are always populated and always agree: the enum is
+		// the contract, the string keeps existing REST/MCP clients working.
+		Delivery:     m.Delivery, //nolint:staticcheck // deprecated but still served
+		DeliveryMode: deliveryToProto(m.Delivery),
 	}
 }

--- a/pkg/pb/containarium/v1/secrets.pb.go
+++ b/pkg/pb/containarium/v1/secrets.pb.go
@@ -21,6 +21,70 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// SecretDelivery is how a secret is materialized inside the container.
+// Replaces the free-string `delivery` field, per the repo's
+// "protobuf enums over magic strings" convention (CLAUDE.md).
+type SecretDelivery int32
+
+const (
+	// Unset. Callers that omit delivery_mode fall back to the legacy
+	// `delivery` string, then to ENV.
+	SecretDelivery_SECRET_DELIVERY_UNSPECIFIED SecretDelivery = 0
+	// environment.<NAME>=<value> on the LXC — visible to every process in
+	// the container via /proc/<pid>/environ. The pre-4.3 default.
+	SecretDelivery_SECRET_DELIVERY_ENV SecretDelivery = 1
+	// Per-secret file at /run/secrets/<NAME>, mode 0440 root:<tenant>, on
+	// tmpfs. Same tenant isolation, narrower in-container access surface.
+	SecretDelivery_SECRET_DELIVERY_FILE SecretDelivery = 2
+	// Shared dotenv at /run/containarium/secrets.env (mode 0400, tmpfs)
+	// for nested docker / docker-compose apps that consume `env_file:` and
+	// do not inherit the LXC environment. Single-line values only.
+	SecretDelivery_SECRET_DELIVERY_COMPOSE SecretDelivery = 3
+)
+
+// Enum value maps for SecretDelivery.
+var (
+	SecretDelivery_name = map[int32]string{
+		0: "SECRET_DELIVERY_UNSPECIFIED",
+		1: "SECRET_DELIVERY_ENV",
+		2: "SECRET_DELIVERY_FILE",
+		3: "SECRET_DELIVERY_COMPOSE",
+	}
+	SecretDelivery_value = map[string]int32{
+		"SECRET_DELIVERY_UNSPECIFIED": 0,
+		"SECRET_DELIVERY_ENV":         1,
+		"SECRET_DELIVERY_FILE":        2,
+		"SECRET_DELIVERY_COMPOSE":     3,
+	}
+)
+
+func (x SecretDelivery) Enum() *SecretDelivery {
+	p := new(SecretDelivery)
+	*p = x
+	return p
+}
+
+func (x SecretDelivery) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SecretDelivery) Descriptor() protoreflect.EnumDescriptor {
+	return file_containarium_v1_secrets_proto_enumTypes[0].Descriptor()
+}
+
+func (SecretDelivery) Type() protoreflect.EnumType {
+	return &file_containarium_v1_secrets_proto_enumTypes[0]
+}
+
+func (x SecretDelivery) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SecretDelivery.Descriptor instead.
+func (SecretDelivery) EnumDescriptor() ([]byte, []int) {
+	return file_containarium_v1_secrets_proto_rawDescGZIP(), []int{0}
+}
+
 // SecretMetadata is the public-safe view of a stored secret.
 // `value` is never returned by `ListSecrets` — only per-name `GetSecret`.
 type SecretMetadata struct {
@@ -49,7 +113,15 @@ type SecretMetadata struct {
 	// inherit the LXC environment (the same gap OTel solved). Single-line
 	// values only; rejected at set-time otherwise. See
 	// docs/security/SECRETS-ENV-VAR-RISK.md.
-	Delivery      string `protobuf:"bytes,6,opt,name=delivery,proto3" json:"delivery,omitempty"`
+	//
+	// Deprecated: use delivery_mode. Still populated on every response so
+	// existing REST/MCP clients keep working; a future major release drops it.
+	//
+	// Deprecated: Marked as deprecated in containarium/v1/secrets.proto.
+	Delivery string `protobuf:"bytes,6,opt,name=delivery,proto3" json:"delivery,omitempty"`
+	// Typed delivery mode — the same value as `delivery`, as an enum.
+	// Both fields are always populated and always agree.
+	DeliveryMode  SecretDelivery `protobuf:"varint,7,opt,name=delivery_mode,json=deliveryMode,proto3,enum=containarium.v1.SecretDelivery" json:"delivery_mode,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -119,11 +191,19 @@ func (x *SecretMetadata) GetUpdatedAt() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in containarium/v1/secrets.proto.
 func (x *SecretMetadata) GetDelivery() string {
 	if x != nil {
 		return x.Delivery
 	}
 	return ""
+}
+
+func (x *SecretMetadata) GetDeliveryMode() SecretDelivery {
+	if x != nil {
+		return x.DeliveryMode
+	}
+	return SecretDelivery_SECRET_DELIVERY_UNSPECIFIED
 }
 
 // SetSecretRequest creates or updates a tenant secret. Idempotent —
@@ -146,7 +226,16 @@ type SetSecretRequest struct {
 	// /run/containarium/secrets.env for docker-compose `env_file:`;
 	// single-line values only). Unknown values are rejected at the
 	// API boundary.
-	Delivery      string `protobuf:"bytes,4,opt,name=delivery,proto3" json:"delivery,omitempty"`
+	//
+	// Deprecated: use delivery_mode. Accepted for backward compatibility;
+	// when both are set they must agree, or the request is rejected rather
+	// than silently preferring one.
+	//
+	// Deprecated: Marked as deprecated in containarium/v1/secrets.proto.
+	Delivery string `protobuf:"bytes,4,opt,name=delivery,proto3" json:"delivery,omitempty"`
+	// Typed delivery mode. UNSPECIFIED falls back to `delivery`, and if
+	// that is empty too, to SECRET_DELIVERY_ENV.
+	DeliveryMode  SecretDelivery `protobuf:"varint,5,opt,name=delivery_mode,json=deliveryMode,proto3,enum=containarium.v1.SecretDelivery" json:"delivery_mode,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -202,11 +291,19 @@ func (x *SetSecretRequest) GetValue() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in containarium/v1/secrets.proto.
 func (x *SetSecretRequest) GetDelivery() string {
 	if x != nil {
 		return x.Delivery
 	}
 	return ""
+}
+
+func (x *SetSecretRequest) GetDeliveryMode() SecretDelivery {
+	if x != nil {
+		return x.DeliveryMode
+	}
+	return SecretDelivery_SECRET_DELIVERY_UNSPECIFIED
 }
 
 type SetSecretResponse struct {
@@ -675,7 +772,7 @@ var File_containarium_v1_secrets_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_secrets_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/secrets.proto\x12\x0fcontainarium.v1\"\xb4\x01\n" +
+	"\x1dcontainarium/v1/secrets.proto\x12\x0fcontainarium.v1\"\xfe\x01\n" +
 	"\x0eSecretMetadata\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
@@ -683,13 +780,15 @@ const file_containarium_v1_secrets_proto_rawDesc = "" +
 	"\n" +
 	"created_at\x18\x04 \x01(\tR\tcreatedAt\x12\x1d\n" +
 	"\n" +
-	"updated_at\x18\x05 \x01(\tR\tupdatedAt\x12\x1a\n" +
-	"\bdelivery\x18\x06 \x01(\tR\bdelivery\"t\n" +
+	"updated_at\x18\x05 \x01(\tR\tupdatedAt\x12\x1e\n" +
+	"\bdelivery\x18\x06 \x01(\tB\x02\x18\x01R\bdelivery\x12D\n" +
+	"\rdelivery_mode\x18\a \x01(\x0e2\x1f.containarium.v1.SecretDeliveryR\fdeliveryMode\"\xbe\x01\n" +
 	"\x10SetSecretRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
-	"\x05value\x18\x03 \x01(\tR\x05value\x12\x1a\n" +
-	"\bdelivery\x18\x04 \x01(\tR\bdelivery\"f\n" +
+	"\x05value\x18\x03 \x01(\tR\x05value\x12\x1e\n" +
+	"\bdelivery\x18\x04 \x01(\tB\x02\x18\x01R\bdelivery\x12D\n" +
+	"\rdelivery_mode\x18\x05 \x01(\x0e2\x1f.containarium.v1.SecretDeliveryR\fdeliveryMode\"f\n" +
 	"\x11SetSecretResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x127\n" +
 	"\x06secret\x18\x02 \x01(\v2\x1f.containarium.v1.SecretMetadataR\x06secret\"B\n" +
@@ -712,7 +811,12 @@ const file_containarium_v1_secrets_proto_rawDesc = "" +
 	"\busername\x18\x01 \x01(\tR\busername\"L\n" +
 	"\x16RefreshSecretsResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12\x18\n" +
-	"\astamped\x18\x02 \x01(\x05R\astampedBKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
+	"\astamped\x18\x02 \x01(\x05R\astamped*\x81\x01\n" +
+	"\x0eSecretDelivery\x12\x1f\n" +
+	"\x1bSECRET_DELIVERY_UNSPECIFIED\x10\x00\x12\x17\n" +
+	"\x13SECRET_DELIVERY_ENV\x10\x01\x12\x18\n" +
+	"\x14SECRET_DELIVERY_FILE\x10\x02\x12\x1b\n" +
+	"\x17SECRET_DELIVERY_COMPOSE\x10\x03BKZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
 
 var (
 	file_containarium_v1_secrets_proto_rawDescOnce sync.Once
@@ -726,29 +830,33 @@ func file_containarium_v1_secrets_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_secrets_proto_rawDescData
 }
 
+var file_containarium_v1_secrets_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_containarium_v1_secrets_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_containarium_v1_secrets_proto_goTypes = []any{
-	(*SecretMetadata)(nil),         // 0: containarium.v1.SecretMetadata
-	(*SetSecretRequest)(nil),       // 1: containarium.v1.SetSecretRequest
-	(*SetSecretResponse)(nil),      // 2: containarium.v1.SetSecretResponse
-	(*GetSecretRequest)(nil),       // 3: containarium.v1.GetSecretRequest
-	(*GetSecretResponse)(nil),      // 4: containarium.v1.GetSecretResponse
-	(*ListSecretsRequest)(nil),     // 5: containarium.v1.ListSecretsRequest
-	(*ListSecretsResponse)(nil),    // 6: containarium.v1.ListSecretsResponse
-	(*DeleteSecretRequest)(nil),    // 7: containarium.v1.DeleteSecretRequest
-	(*DeleteSecretResponse)(nil),   // 8: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsRequest)(nil),  // 9: containarium.v1.RefreshSecretsRequest
-	(*RefreshSecretsResponse)(nil), // 10: containarium.v1.RefreshSecretsResponse
+	(SecretDelivery)(0),            // 0: containarium.v1.SecretDelivery
+	(*SecretMetadata)(nil),         // 1: containarium.v1.SecretMetadata
+	(*SetSecretRequest)(nil),       // 2: containarium.v1.SetSecretRequest
+	(*SetSecretResponse)(nil),      // 3: containarium.v1.SetSecretResponse
+	(*GetSecretRequest)(nil),       // 4: containarium.v1.GetSecretRequest
+	(*GetSecretResponse)(nil),      // 5: containarium.v1.GetSecretResponse
+	(*ListSecretsRequest)(nil),     // 6: containarium.v1.ListSecretsRequest
+	(*ListSecretsResponse)(nil),    // 7: containarium.v1.ListSecretsResponse
+	(*DeleteSecretRequest)(nil),    // 8: containarium.v1.DeleteSecretRequest
+	(*DeleteSecretResponse)(nil),   // 9: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsRequest)(nil),  // 10: containarium.v1.RefreshSecretsRequest
+	(*RefreshSecretsResponse)(nil), // 11: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_secrets_proto_depIdxs = []int32{
-	0, // 0: containarium.v1.SetSecretResponse.secret:type_name -> containarium.v1.SecretMetadata
-	0, // 1: containarium.v1.GetSecretResponse.secret:type_name -> containarium.v1.SecretMetadata
-	0, // 2: containarium.v1.ListSecretsResponse.secrets:type_name -> containarium.v1.SecretMetadata
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	0, // 0: containarium.v1.SecretMetadata.delivery_mode:type_name -> containarium.v1.SecretDelivery
+	0, // 1: containarium.v1.SetSecretRequest.delivery_mode:type_name -> containarium.v1.SecretDelivery
+	1, // 2: containarium.v1.SetSecretResponse.secret:type_name -> containarium.v1.SecretMetadata
+	1, // 3: containarium.v1.GetSecretResponse.secret:type_name -> containarium.v1.SecretMetadata
+	1, // 4: containarium.v1.ListSecretsResponse.secrets:type_name -> containarium.v1.SecretMetadata
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_secrets_proto_init() }
@@ -761,13 +869,14 @@ func file_containarium_v1_secrets_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_secrets_proto_rawDesc), len(file_containarium_v1_secrets_proto_rawDesc)),
-			NumEnums:      0,
+			NumEnums:      1,
 			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_containarium_v1_secrets_proto_goTypes,
 		DependencyIndexes: file_containarium_v1_secrets_proto_depIdxs,
+		EnumInfos:         file_containarium_v1_secrets_proto_enumTypes,
 		MessageInfos:      file_containarium_v1_secrets_proto_msgTypes,
 	}.Build()
 	File_containarium_v1_secrets_proto = out.File

--- a/proto/containarium/v1/secrets.proto
+++ b/proto/containarium/v1/secrets.proto
@@ -4,6 +4,28 @@ package containarium.v1;
 
 option go_package = "github.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1";
 
+// SecretDelivery is how a secret is materialized inside the container.
+// Replaces the free-string `delivery` field, per the repo's
+// "protobuf enums over magic strings" convention (CLAUDE.md).
+enum SecretDelivery {
+  // Unset. Callers that omit delivery_mode fall back to the legacy
+  // `delivery` string, then to ENV.
+  SECRET_DELIVERY_UNSPECIFIED = 0;
+
+  // environment.<NAME>=<value> on the LXC — visible to every process in
+  // the container via /proc/<pid>/environ. The pre-4.3 default.
+  SECRET_DELIVERY_ENV = 1;
+
+  // Per-secret file at /run/secrets/<NAME>, mode 0440 root:<tenant>, on
+  // tmpfs. Same tenant isolation, narrower in-container access surface.
+  SECRET_DELIVERY_FILE = 2;
+
+  // Shared dotenv at /run/containarium/secrets.env (mode 0400, tmpfs)
+  // for nested docker / docker-compose apps that consume `env_file:` and
+  // do not inherit the LXC environment. Single-line values only.
+  SECRET_DELIVERY_COMPOSE = 3;
+}
+
 // SecretMetadata is the public-safe view of a stored secret.
 // `value` is never returned by `ListSecrets` — only per-name `GetSecret`.
 message SecretMetadata {
@@ -35,7 +57,14 @@ message SecretMetadata {
   // inherit the LXC environment (the same gap OTel solved). Single-line
   // values only; rejected at set-time otherwise. See
   // docs/security/SECRETS-ENV-VAR-RISK.md.
-  string delivery = 6;
+  //
+  // Deprecated: use delivery_mode. Still populated on every response so
+  // existing REST/MCP clients keep working; a future major release drops it.
+  string delivery = 6 [deprecated = true];
+
+  // Typed delivery mode — the same value as `delivery`, as an enum.
+  // Both fields are always populated and always agree.
+  SecretDelivery delivery_mode = 7;
 }
 
 // SetSecretRequest creates or updates a tenant secret. Idempotent —
@@ -60,7 +89,15 @@ message SetSecretRequest {
   // /run/containarium/secrets.env for docker-compose `env_file:`;
   // single-line values only). Unknown values are rejected at the
   // API boundary.
-  string delivery = 4;
+  //
+  // Deprecated: use delivery_mode. Accepted for backward compatibility;
+  // when both are set they must agree, or the request is rejected rather
+  // than silently preferring one.
+  string delivery = 4 [deprecated = true];
+
+  // Typed delivery mode. UNSPECIFIED falls back to `delivery`, and if
+  // that is empty too, to SECRET_DELIVERY_ENV.
+  SecretDelivery delivery_mode = 5;
 }
 
 message SetSecretResponse {


### PR DESCRIPTION
From the #1190 design review: `delivery` is a bare `string` with a comment listing its accepted values (`env` / `file` / `compose`). `CLAUDE.md` names that exact shape as an anti-pattern and says it should be a proto enum.

### Why additive rather than in place

Converting `string delivery` to an enum on the same field number breaks twice over:

- **gRPC wire type changes** — length-delimited → varint.
- **REST JSON changes** — `"delivery": "env"` → `"SECRET_DELIVERY_ENV"`.

Both are real exposure: the field is in the published swagger, and our own MCP client sends it as a JSON string (`internal/mcp/client.go:812`). So the enum lands **alongside** the string, which is kept and marked deprecated.

- Responses populate **both**, always agreeing.
- Requests accept **either**.
- When both are set they must **match**, or the request is rejected.

That last one is deliberate. Silently preferring one would let a client that sent contradictory values believe the other took effect — the same silent-divergence class as a backend accepting a call it can't honor (cf. #1188, #1193).

### One subtlety

`deliveryToProto("")` returns `ENV`, not `UNSPECIFIED`. Empty means "unset" in storage and the store normalizes it to env, so reporting `UNSPECIFIED` would make the typed view disagree with what actually happens to the secret. Pinned by a test.

### Generated-code hygiene

`make proto` also produced churn in 15 `.pb.gw.go` files — 279 insertions / 279 deletions that only **relocate an `io.Copy` block**, i.e. local `protoc-gen-grpc-gateway` version drift, not a semantic change. **Reverted**, so this diff stays scoped. Worth noting `secrets.pb.gw.go` was untouched by regeneration, confirming this change needs no gateway update.

### Tests

Nine cases: both conversion directions, a round-trip guard so the enum and DB column can't drift, and the resolution matrix including the disagreement rejection. All pass locally; `go build ./...` clean.

### Not included

Migrating internal call sites and the CLI `--delivery` flag to the enum. Storage still keeps the string (the DB column stores it literally), so `secrets_delivery.go` is the single seam that knows both representations — the right place to expand from later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)