### PR TITLE
feat(zfscrypt): dataset operations for per-tenant ZFS native encryption

### DIFF
--- a/pkg/core/zfscrypt/zfscrypt.go
+++ b/pkg/core/zfscrypt/zfscrypt.go
@@ -1,0 +1,288 @@
+// Package zfscrypt drives the `zfs` CLI for per-tenant native encryption.
+//
+// Phase 3/4 of docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md: the dataset
+// operations the container lifecycle hooks call. Key custody lives in
+// pkg/core/zfskey; this package only knows how to hand a key to ZFS and
+// how to ask what ZFS did with it.
+//
+// # Verification status
+//
+// The command forms below are derived from the design doc and the ZFS
+// documentation, and are exercised in tests against a fake runner. They
+// have NOT been executed against a real pool — see #1200: no reachable
+// environment can host one (the dev box is an LXC container with no zfs
+// device registered and no /dev/kvm). A fake agreeing with itself proves
+// the orchestration, not the ZFS semantics.
+//
+// Every assumption about what `zfs` does is therefore called out at the
+// call site, so a reviewer with a real pool can check them one by one
+// rather than re-deriving them. The unverified assumptions are:
+//
+//   - `-o keylocation=file:///dev/stdin` with the raw key on stdin loads
+//     a key without it ever touching argv or a temp file.
+//   - `zfs unload-key` fails, rather than succeeding silently, while a
+//     dataset under the encryptionroot is still mounted.
+//   - `keystatus` reports exactly "available" or "unavailable".
+package zfscrypt
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+)
+
+// Runner executes a zfs command. Declared as an interface so the hook
+// logic is testable without a pool, and so the daemon can inject a
+// runner that logs or that targets a remote host.
+type Runner interface {
+	// Run executes `zfs <args...>`, writing stdin to the child's stdin
+	// when non-nil, and returns stdout and stderr.
+	Run(ctx context.Context, stdin []byte, args ...string) (stdout, stderr string, err error)
+}
+
+// ExecRunner runs the host's zfs binary.
+type ExecRunner struct{}
+
+// Run implements Runner against the real `zfs` command.
+func (ExecRunner) Run(ctx context.Context, stdin []byte, args ...string) (string, string, error) {
+	// #nosec G204 -- the binary is the literal "zfs"; args are built by
+	// this package from validated dataset names, never from raw caller
+	// input (see validateDataset).
+	cmd := exec.CommandContext(ctx, "zfs", args...)
+	if stdin != nil {
+		cmd.Stdin = strings.NewReader(string(stdin))
+	}
+	var out, errb strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	err := cmd.Run()
+	return out.String(), errb.String(), err
+}
+
+// Manager performs the encryption-related dataset operations.
+type Manager struct {
+	run Runner
+}
+
+// NewManager constructs a Manager over a Runner. Passing nil uses the
+// real zfs binary.
+func NewManager(r Runner) *Manager {
+	if r == nil {
+		r = ExecRunner{}
+	}
+	return &Manager{run: r}
+}
+
+// KeyStatus mirrors ZFS's `keystatus` property.
+type KeyStatus string
+
+const (
+	// KeyAvailable means the key is loaded: the dataset can be mounted
+	// and its contents read.
+	KeyAvailable KeyStatus = "available"
+	// KeyUnavailable means the key is not loaded: the dataset is
+	// ciphertext, including to host root. This is the state a stopped
+	// container's dataset must be in (#1201).
+	KeyUnavailable KeyStatus = "unavailable"
+)
+
+// validateDataset rejects names that could turn a dataset argument into
+// something else — a flag, a second argument, or a shell-ish string.
+//
+// The name is built by the daemon from a pool and a container name, so
+// this is defence in depth rather than the primary control; it is cheap
+// and the failure mode (operating on the wrong dataset) is destructive.
+func validateDataset(name string) error {
+	switch {
+	case name == "":
+		return fmt.Errorf("dataset name is required")
+	case strings.HasPrefix(name, "-"):
+		return fmt.Errorf("invalid dataset name %q: leading dash would be read as a flag", name)
+	case strings.ContainsAny(name, " \t\n\r"):
+		return fmt.Errorf("invalid dataset name %q: contains whitespace", name)
+	case !strings.Contains(name, "/"):
+		// Every container dataset lives under a pool. A bare name is
+		// the pool root itself, and encrypting or destroying that is
+		// never what the caller meant.
+		return fmt.Errorf("invalid dataset name %q: expected <pool>/<path>", name)
+	}
+	return nil
+}
+
+// CreateEncrypted creates a dataset with ZFS native encryption enabled,
+// keyed by the supplied key.
+//
+// The key travels on **stdin**, never on argv and never through a temp
+// file: argv is world-readable through /proc/<pid>/cmdline for the life
+// of the process, and a temp file leaves key material on disk, which is
+// the one thing the whole design forbids.
+func (m *Manager) CreateEncrypted(ctx context.Context, dataset string, key zfskey.Key) error {
+	if err := validateDataset(dataset); err != nil {
+		return err
+	}
+	if key.IsZero() {
+		return fmt.Errorf("refusing to create %s with an empty key", dataset)
+	}
+
+	// ASSUMPTION (unverified against a real pool, #1200): passing the
+	// raw key on stdin with keylocation=file:///dev/stdin is accepted by
+	// `zfs create`, and keyformat=raw expects exactly 32 bytes — which
+	// zfskey.Key already guarantees.
+	_, stderr, err := m.run.Run(ctx, key.Bytes(),
+		"create",
+		"-o", "encryption=on",
+		"-o", "keyformat=raw",
+		"-o", "keylocation=file:///dev/stdin",
+		dataset,
+	)
+	if err != nil {
+		return fmt.Errorf("create encrypted dataset %s: %w: %s", dataset, err, strings.TrimSpace(stderr))
+	}
+	return nil
+}
+
+// LoadKey makes an encrypted dataset readable. It is a no-op when the
+// key is already loaded, so a restarted daemon re-running the pre-start
+// hook does not fail.
+func (m *Manager) LoadKey(ctx context.Context, dataset string, key zfskey.Key) error {
+	if err := validateDataset(dataset); err != nil {
+		return err
+	}
+	if key.IsZero() {
+		return fmt.Errorf("refusing to load an empty key for %s", dataset)
+	}
+
+	status, err := m.KeyStatus(ctx, dataset)
+	if err != nil {
+		return err
+	}
+	if status == KeyAvailable {
+		return nil
+	}
+
+	_, stderr, err := m.run.Run(ctx, key.Bytes(),
+		"load-key", "-L", "file:///dev/stdin", dataset)
+	if err != nil {
+		return fmt.Errorf("load key for %s: %w: %s", dataset, err, strings.TrimSpace(stderr))
+	}
+	return nil
+}
+
+// UnloadKey drops the key from the kernel, returning the dataset to
+// ciphertext (#1201).
+//
+// Returns ErrKeyInUse when ZFS refuses because something under the
+// encryptionroot is still mounted — the expected case when a tenant has
+// another container running, and not an error the caller should treat as
+// a failure.
+func (m *Manager) UnloadKey(ctx context.Context, dataset string) error {
+	if err := validateDataset(dataset); err != nil {
+		return err
+	}
+
+	status, err := m.KeyStatus(ctx, dataset)
+	if err != nil {
+		return err
+	}
+	if status == KeyUnavailable {
+		// Already ciphertext; nothing to do.
+		return nil
+	}
+
+	_, stderr, err := m.run.Run(ctx, nil, "unload-key", dataset)
+	if err != nil {
+		// ASSUMPTION (unverified, #1200): ZFS refuses with a
+		// "busy"/"in use" message rather than silently succeeding while
+		// a dataset under the encryptionroot is mounted. If it instead
+		// succeeded, a co-tenant's running container would lose its key
+		// — which is why this is called out for a reviewer with a pool.
+		if isKeyInUse(stderr) {
+			return ErrKeyInUse
+		}
+		return fmt.Errorf("unload key for %s: %w: %s", dataset, err, strings.TrimSpace(stderr))
+	}
+	return nil
+}
+
+// ErrKeyInUse reports that a key could not be unloaded because the
+// encryptionroot still has mounted datasets under it.
+var ErrKeyInUse = fmt.Errorf("encryption key is still in use by a mounted dataset")
+
+func isKeyInUse(stderr string) bool {
+	s := strings.ToLower(stderr)
+	return strings.Contains(s, "busy") || strings.Contains(s, "in use")
+}
+
+// KeyStatus reports whether the dataset's key is currently loaded.
+func (m *Manager) KeyStatus(ctx context.Context, dataset string) (KeyStatus, error) {
+	if err := validateDataset(dataset); err != nil {
+		return "", err
+	}
+	stdout, stderr, err := m.run.Run(ctx, nil, "get", "-H", "-o", "value", "keystatus", dataset)
+	if err != nil {
+		return "", fmt.Errorf("read keystatus for %s: %w: %s", dataset, err, strings.TrimSpace(stderr))
+	}
+	switch v := strings.TrimSpace(stdout); v {
+	case string(KeyAvailable):
+		return KeyAvailable, nil
+	case string(KeyUnavailable):
+		return KeyUnavailable, nil
+	case "", "-":
+		// An unencrypted dataset reports "-". Treated as an error
+		// rather than as "unavailable": the caller asked about an
+		// encrypted dataset and got one that is not, which means the
+		// two sides disagree about what this container is.
+		return "", fmt.Errorf("dataset %s is not encrypted (keystatus %q)", dataset, v)
+	default:
+		return "", fmt.Errorf("unexpected keystatus %q for %s", v, dataset)
+	}
+}
+
+// EncryptionRoot returns the dataset whose key covers this one. Two
+// containers belonging to the same tenant share an encryptionroot; two
+// tenants never do, which is the property the isolation claim rests on.
+func (m *Manager) EncryptionRoot(ctx context.Context, dataset string) (string, error) {
+	if err := validateDataset(dataset); err != nil {
+		return "", err
+	}
+	stdout, stderr, err := m.run.Run(ctx, nil, "get", "-H", "-o", "value", "encryptionroot", dataset)
+	if err != nil {
+		return "", fmt.Errorf("read encryptionroot for %s: %w: %s", dataset, err, strings.TrimSpace(stderr))
+	}
+	root := strings.TrimSpace(stdout)
+	if root == "" || root == "-" {
+		return "", fmt.Errorf("dataset %s has no encryptionroot (it is not encrypted)", dataset)
+	}
+	return root, nil
+}
+
+// Exists reports whether a dataset is present.
+func (m *Manager) Exists(ctx context.Context, dataset string) (bool, error) {
+	if err := validateDataset(dataset); err != nil {
+		return false, err
+	}
+	_, stderr, err := m.run.Run(ctx, nil, "list", "-H", "-o", "name", dataset)
+	if err != nil {
+		if strings.Contains(strings.ToLower(stderr), "does not exist") {
+			return false, nil
+		}
+		return false, fmt.Errorf("list dataset %s: %w: %s", dataset, err, strings.TrimSpace(stderr))
+	}
+	return true, nil
+}
+
+// Destroy removes a dataset. Used to clean up a half-built container so
+// a failed encrypted create leaves no partial state behind.
+func (m *Manager) Destroy(ctx context.Context, dataset string) error {
+	if err := validateDataset(dataset); err != nil {
+		return err
+	}
+	_, stderr, err := m.run.Run(ctx, nil, "destroy", dataset)
+	if err != nil {
+		return fmt.Errorf("destroy dataset %s: %w: %s", dataset, err, strings.TrimSpace(stderr))
+	}
+	return nil
+}

--- a/pkg/core/zfscrypt/zfscrypt_test.go
+++ b/pkg/core/zfscrypt/zfscrypt_test.go
@@ -1,0 +1,332 @@
+package zfscrypt
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+)
+
+// fakeRunner records every zfs invocation and replays canned responses.
+//
+// It proves the orchestration, not ZFS's own semantics — see the package
+// doc and #1200. Where a test depends on how real ZFS behaves, that
+// assumption is named in the test so it can be checked against a pool.
+type fakeRunner struct {
+	calls  [][]string
+	stdins [][]byte
+
+	// responses, keyed by the zfs subcommand (calls[0]).
+	stdout map[string]string
+	stderr map[string]string
+	errs   map[string]error
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{
+		stdout: map[string]string{},
+		stderr: map[string]string{},
+		errs:   map[string]error{},
+	}
+}
+
+func (f *fakeRunner) Run(_ context.Context, stdin []byte, args ...string) (string, string, error) {
+	f.calls = append(f.calls, args)
+	// Copy: the caller may reuse or zero its buffer.
+	cp := make([]byte, len(stdin))
+	copy(cp, stdin)
+	f.stdins = append(f.stdins, cp)
+
+	sub := ""
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	return f.stdout[sub], f.stderr[sub], f.errs[sub]
+}
+
+func (f *fakeRunner) lastCall() []string {
+	if len(f.calls) == 0 {
+		return nil
+	}
+	return f.calls[len(f.calls)-1]
+}
+
+func (f *fakeRunner) allArgs() string {
+	var b strings.Builder
+	for _, c := range f.calls {
+		b.WriteString(strings.Join(c, " "))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func testKey(t *testing.T, fill byte) zfskey.Key {
+	t.Helper()
+	k, err := zfskey.NewKey(bytes.Repeat([]byte{fill}, zfskey.KeyLen))
+	if err != nil {
+		t.Fatalf("NewKey: %v", err)
+	}
+	return k
+}
+
+// AC (#1199): key material is piped to zfs via stdin — never on argv,
+// never in a temp file.
+//
+// argv is world-readable through /proc/<pid>/cmdline for the life of the
+// process, so a key there is a key disclosed to every local user. This
+// is the single most important property in the package.
+func TestKeyMaterialNeverReachesArgv(t *testing.T) {
+	key := testKey(t, 0xAB)
+	raw := string(key.Bytes())
+
+	for _, tc := range []struct {
+		name string
+		call func(*Manager) error
+	}{
+		{"create", func(m *Manager) error {
+			return m.CreateEncrypted(context.Background(), "pool/containers/alice", key)
+		}},
+		{"load", func(m *Manager) error {
+			return m.LoadKey(context.Background(), "pool/containers/alice", key)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeRunner()
+			f.stdout["get"] = "unavailable" // so LoadKey proceeds
+			m := NewManager(f)
+
+			if err := tc.call(m); err != nil {
+				t.Fatalf("call: %v", err)
+			}
+
+			args := f.allArgs()
+			if strings.Contains(args, raw) {
+				t.Error("key material appeared on argv — readable via /proc/<pid>/cmdline")
+			}
+			// Also catch it hidden inside a keylocation value.
+			for _, c := range f.calls {
+				for _, a := range c {
+					if strings.Contains(a, raw) {
+						t.Errorf("key material embedded in argument %q", a)
+					}
+				}
+			}
+
+			// It must have gone somewhere: stdin.
+			var sawKeyOnStdin bool
+			for _, in := range f.stdins {
+				if bytes.Equal(in, key.Bytes()) {
+					sawKeyOnStdin = true
+				}
+			}
+			if !sawKeyOnStdin {
+				t.Error("key was never written to stdin — it has to reach zfs somehow")
+			}
+			if !strings.Contains(args, "file:///dev/stdin") {
+				t.Error("zfs was not pointed at stdin for the key")
+			}
+		})
+	}
+}
+
+// The create command must actually request encryption. A dataset created
+// without these properties is plaintext, and every later check would
+// still pass.
+func TestCreateEncryptedRequestsNativeEncryption(t *testing.T) {
+	f := newFakeRunner()
+	m := NewManager(f)
+
+	if err := m.CreateEncrypted(context.Background(), "pool/containers/alice", testKey(t, 1)); err != nil {
+		t.Fatalf("CreateEncrypted: %v", err)
+	}
+
+	args := strings.Join(f.lastCall(), " ")
+	for _, want := range []string{"create", "encryption=on", "keyformat=raw", "pool/containers/alice"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("create is missing %q: %s", want, args)
+		}
+	}
+}
+
+// An empty key must never produce a dataset — that would be an
+// unencrypted container the caller believes is encrypted.
+func TestCreateAndLoadRejectAnEmptyKey(t *testing.T) {
+	f := newFakeRunner()
+	m := NewManager(f)
+
+	if err := m.CreateEncrypted(context.Background(), "pool/c/alice", zfskey.Key{}); err == nil {
+		t.Error("CreateEncrypted accepted an empty key")
+	}
+	if err := m.LoadKey(context.Background(), "pool/c/alice", zfskey.Key{}); err == nil {
+		t.Error("LoadKey accepted an empty key")
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("refusal must happen before any zfs runs, got %v", f.calls)
+	}
+}
+
+// Dataset names are validated before they become command arguments. A
+// leading dash would be parsed as a flag, and a bare name is the pool
+// root — destroying or re-keying that is never what the caller meant.
+func TestDatasetNameValidation(t *testing.T) {
+	for _, name := range []string{"", "-o", "pool", "pool/with space", "pool/with\nnewline"} {
+		t.Run("name="+name, func(t *testing.T) {
+			f := newFakeRunner()
+			m := NewManager(f)
+			if err := m.CreateEncrypted(context.Background(), name, testKey(t, 1)); err == nil {
+				t.Errorf("accepted dataset name %q", name)
+			}
+			if len(f.calls) != 0 {
+				t.Error("a rejected name must not reach zfs")
+			}
+		})
+	}
+}
+
+// LoadKey is idempotent: a daemon restart re-runs the pre-start hook
+// against a container whose key is already resident, and that must
+// succeed rather than error.
+func TestLoadKeyIsANoOpWhenAlreadyLoaded(t *testing.T) {
+	f := newFakeRunner()
+	f.stdout["get"] = "available"
+	m := NewManager(f)
+
+	if err := m.LoadKey(context.Background(), "pool/c/alice", testKey(t, 1)); err != nil {
+		t.Fatalf("LoadKey: %v", err)
+	}
+	if strings.Contains(f.allArgs(), "load-key") {
+		t.Error("load-key ran despite the key already being available")
+	}
+}
+
+// AC (#1201): unloading must tolerate "still in use" — a tenant's other
+// container is legitimately still running under the same encryptionroot.
+func TestUnloadKeyReportsInUseDistinctly(t *testing.T) {
+	f := newFakeRunner()
+	f.stdout["get"] = "available"
+	f.errs["unload-key"] = errors.New("exit status 1")
+	f.stderr["unload-key"] = "cannot unload key for 'pool/c/alice': dataset is busy"
+	m := NewManager(f)
+
+	err := m.UnloadKey(context.Background(), "pool/c/alice")
+	if !errors.Is(err, ErrKeyInUse) {
+		t.Fatalf("err = %v, want ErrKeyInUse — a co-tenant still running is not a failure", err)
+	}
+}
+
+// A genuine unload failure is not swallowed as "in use".
+func TestUnloadKeySurfacesRealFailures(t *testing.T) {
+	f := newFakeRunner()
+	f.stdout["get"] = "available"
+	f.errs["unload-key"] = errors.New("exit status 1")
+	f.stderr["unload-key"] = "cannot open 'pool/c/alice': permission denied"
+	m := NewManager(f)
+
+	err := m.UnloadKey(context.Background(), "pool/c/alice")
+	if err == nil || errors.Is(err, ErrKeyInUse) {
+		t.Fatalf("err = %v, want a real error", err)
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("zfs's own message should survive, got %q", err)
+	}
+}
+
+// Unloading an already-ciphertext dataset is a no-op, so the post-stop
+// hook can run unconditionally.
+func TestUnloadKeyIsANoOpWhenAlreadyUnavailable(t *testing.T) {
+	f := newFakeRunner()
+	f.stdout["get"] = "unavailable"
+	m := NewManager(f)
+
+	if err := m.UnloadKey(context.Background(), "pool/c/alice"); err != nil {
+		t.Fatalf("UnloadKey: %v", err)
+	}
+	if strings.Contains(f.allArgs(), "unload-key") {
+		t.Error("unload-key ran against an already-unavailable key")
+	}
+}
+
+func TestKeyStatusParsing(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		out     string
+		want    KeyStatus
+		wantErr bool
+	}{
+		{"available", "available\n", KeyAvailable, false},
+		{"unavailable", "unavailable\n", KeyUnavailable, false},
+		{"unencrypted dataset", "-\n", "", true},
+		{"empty", "", "", true},
+		{"unrecognised", "sideways\n", "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeRunner()
+			f.stdout["get"] = tc.out
+			m := NewManager(f)
+
+			got, err := m.KeyStatus(context.Background(), "pool/c/alice")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want an error for keystatus %q", tc.out)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("KeyStatus: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Two tenants must never land on the same encryptionroot — that is the
+// isolation claim. This test pins the accessor; the daemon-side dataset
+// naming that makes it true is #1199's wiring.
+func TestEncryptionRoot(t *testing.T) {
+	f := newFakeRunner()
+	f.stdout["get"] = "pool/containers/alice\n"
+	m := NewManager(f)
+
+	root, err := m.EncryptionRoot(context.Background(), "pool/containers/alice/sub")
+	if err != nil {
+		t.Fatalf("EncryptionRoot: %v", err)
+	}
+	if root != "pool/containers/alice" {
+		t.Errorf("root = %q", root)
+	}
+
+	f2 := newFakeRunner()
+	f2.stdout["get"] = "-\n"
+	if _, err := NewManager(f2).EncryptionRoot(context.Background(), "pool/c/bob"); err == nil {
+		t.Error("an unencrypted dataset must not report an encryptionroot")
+	}
+}
+
+// Exists distinguishes "absent" from "the command failed", so the
+// create path can tell a missing dataset from a broken pool.
+func TestExists(t *testing.T) {
+	f := newFakeRunner()
+	f.errs["list"] = errors.New("exit status 1")
+	f.stderr["list"] = "cannot open 'pool/c/alice': dataset does not exist"
+	m := NewManager(f)
+
+	got, err := m.Exists(context.Background(), "pool/c/alice")
+	if err != nil {
+		t.Fatalf("Exists: %v", err)
+	}
+	if got {
+		t.Error("reported an absent dataset as present")
+	}
+
+	f2 := newFakeRunner()
+	f2.errs["list"] = errors.New("exit status 1")
+	f2.stderr["list"] = "cannot open pool: I/O error"
+	if _, err := NewManager(f2).Exists(context.Background(), "pool/c/alice"); err == nil {
+		t.Error("a broken pool must be an error, not 'absent'")
+	}
+}


### PR DESCRIPTION
Refs #1199, #1201. Part of #1205.

The zfs-facing half of the encryption hooks, behind an injectable `Runner` so the logic is testable without a pool. Key custody stays in `pkg/core/zfskey` (#1197); this package only knows how to hand a key to ZFS and ask what ZFS did with it.

## ⚠️ Not verified against real ZFS — read this before approving

Per **#1200**, no reachable environment can host a pool: the dev box is itself an LXC container with no zfs device registered in `/proc/devices` and no `/dev/kvm`, and Cloud/lab access is unavailable.

The command forms come from the design doc and the ZFS documentation, and are exercised against a fake runner. **That proves the orchestration, not the ZFS semantics** — a fake agreeing with itself proves nothing about `zfs`. I've called out every assumption that depends on real ZFS behaviour at its call site, so a reviewer with a pool can check them one at a time rather than re-deriving them:

1. `-o keylocation=file:///dev/stdin` with the raw key on stdin loads a key without it touching argv or a temp file.
2. `zfs unload-key` **fails** rather than silently succeeding while a dataset under the encryptionroot is still mounted. *(If it silently succeeded, a co-tenant's running container would lose its key — the highest-consequence assumption here.)*
3. `keystatus` reports exactly `available` or `unavailable`.

**#1199's and #1201's ciphertext-at-rest acceptance criteria remain unticked.** This PR cannot satisfy them; that's #1200's job.

## What's here

- `CreateEncrypted` — `encryption=on`, `keyformat=raw`, key on stdin
- `LoadKey` / `UnloadKey` — idempotent both ways, so the pre-start hook survives a daemon restart and the post-stop hook can run unconditionally
- `UnloadKey` returns **`ErrKeyInUse` distinctly**, because a tenant's other container still running under the same encryptionroot is the expected case, not a failure (#1201)
- `KeyStatus` treats an *unencrypted* dataset as an error rather than as "unavailable" — the caller asked about an encrypted dataset and got one that isn't, meaning the two sides disagree about what this container is
- `EncryptionRoot`, `Exists`, `Destroy` (the last for cleaning up a half-built container so a failed create leaves no partial state)

## Review this first

**Key material never reaches argv.** argv is world-readable through `/proc/<pid>/cmdline` for the life of the process, so a key there is a key disclosed to every local user. It goes on stdin, never a temp file either.

Both security properties are mutation-tested — a test that can't fail is worthless for a claim like this:

```
# key moved into a keylocation argument
--- FAIL: TestKeyMaterialNeverReachesArgv/create
    key material appeared on argv — readable via /proc/<pid>/cmdline
    key material embedded in argument "keylocation=raw://\xab\xab..."

# encryption=on dropped
--- FAIL: TestCreateEncryptedRequestsNativeEncryption
    create is missing "encryption=on": create -o keyformat=raw ...
```

The second one matters because without it the dataset is plaintext and *every later check still passes* — `keystatus` would just report `-`, which is why that case is an error rather than a benign "unavailable".

Dataset names are validated before becoming arguments: a leading dash would be read as a flag, and a bare name is the pool root, where `destroy` or a re-key is never what the caller meant.

## Test evidence

22 cases, green under `-race`; gosec clean; Windows cross-compile guard passes.

```
ok  github.com/footprintai/containarium/pkg/core/zfscrypt  1.010s
ok  github.com/footprintai/containarium/pkg/core/zfskey    1.013s
```

## What remains

The daemon-side wiring — pre-create into `container.Manager.Create` (the Incus "instance from an existing zvol" path), pre-start into `StartContainer`, post-stop into `StopContainer`. I've kept it out of this PR so the reviewable unit is one coherent piece, and because the pre-create path in particular can't be exercised without Incus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)