### PR TITLE
docs: scope the ephemeral-sandbox design to the LXC backend

### DIFF
--- a/docs/EPHEMERAL-SANDBOX-DESIGN.md
+++ b/docs/EPHEMERAL-SANDBOX-DESIGN.md
@@ -4,6 +4,16 @@
 > the CubeSandbox comparison ([readme](https://github.com/TencentCloud/CubeSandbox))
 > — their `<60ms` MicroVM cold-start exposes a workload Containarium
 > doesn't serve today: short-lived per-task agent sandboxes.
+>
+> **Scope: the LXC backend only** (clarified 2026-08-09). This note predates
+> the Kubernetes backend and its warm-pool machinery. On K8s the equivalent
+> already exists upstream — `kubernetes-sigs/agent-sandbox` ships warm pools,
+> pod snapshots, and over-creation guards, and adopting them is tracked as
+> #1226. Per the "inherit, don't invent" split in
+> [`product/agent-substrate-roadmap-position.md`](product/agent-substrate-roadmap-position.md),
+> we should not design a second warm-pool mechanism for K8s. What this note
+> covers — a warm pool on bare LXC hosts with no cluster — is the substrate
+> nobody else serves, and is the part still worth building ourselves.
 
 ## Where we are today
 


### PR DESCRIPTION
Follow-up from the #1186 capability evaluation, which found that agent-sandbox 0.5.4 covers the K8s half of this design.

`EPHEMERAL-SANDBOX-DESIGN.md` predates the Kubernetes backend. It never claimed to cover K8s — it says *"stays LXC-based for v1"* — but it never said it **doesn't**, and it's the obvious place someone would look for a warm-pool design before writing one.

Upstream already ships warm pools, pod snapshots, and over-creation guards for K8s; adopting them is #1226. Designing a second mechanism for that backend is precisely what `product/agent-substrate-roadmap-position.md` argues against.

So this adds a scope note, not a rewrite. What remains in the design — a warm pool on **bare LXC hosts with no cluster** — is the substrate nobody else serves, and is still worth building ourselves.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)