### PR TITLE
feat(server): wire the pre-start and post-stop encryption hooks

### DIFF
--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -87,7 +87,11 @@ type ContainerServer struct {
 	// today — in which case an encrypted create is refused rather than
 	// silently producing plaintext (#1198). The lifecycle hooks that
 	// consume it land in #1199/#1201.
-	keyProvider         zfskey.KeyProvider
+	keyProvider zfskey.KeyProvider
+	// encryption carries the per-tenant dataset hooks (#1199/#1201). A
+	// nil value is a valid no-op receiver, so the lifecycle paths do not
+	// branch on whether encryption is configured.
+	encryption          *encryptionHooks
 	collaboratorManager *container.CollaboratorManager
 	emitter             *events.Emitter
 	pendingCreations    map[string]*PendingCreation
@@ -1365,6 +1369,12 @@ func (s *ContainerServer) StartContainer(ctx context.Context, req *pb.StartConta
 			return nil, fmt.Errorf("failed to start container: %w", err)
 		}
 	} else {
+		// Pre-start hook (#1199): unlock the dataset before the LXC
+		// boots. A failure stops the start — a container whose storage
+		// is unreadable is worse than one that refused to come up.
+		if err := s.encryption.PreStart(ctx, req.Username+"-container"); err != nil {
+			return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+		}
 		if err := s.manager.Start(req.Username); err != nil {
 			// Try peer
 			if s.peerPool != nil {
@@ -1537,6 +1547,17 @@ func (s *ContainerServer) StopContainer(ctx context.Context, req *pb.StopContain
 		}
 		return nil, fmt.Errorf("failed to stop container: %w", err)
 	}
+
+	// Post-stop hook (#1201): drop the encryption key so the stopped
+	// container's dataset is ciphertext, including to host root. Runs
+	// only once the LXC is actually down — unloading a key under a
+	// running container would pull its storage away.
+	//
+	// Best-effort by design: the container has already stopped, so a
+	// failed unload cannot be reported as a failed stop. The operator
+	// learns from the log, and "key still in use" (a co-tenant still
+	// running under the same encryptionroot) is the expected case.
+	s.encryption.PostStop(ctx, req.Username+"-container")
 
 	info, err := s.boxes().Get(ctx, box.BoxRef{Tenant: req.Username})
 	if err != nil {

--- a/internal/server/encryption_hooks.go
+++ b/internal/server/encryption_hooks.go
@@ -1,0 +1,221 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+)
+
+// Container lifecycle hooks for per-tenant ZFS encryption (#1199, #1201),
+// phases 3 and 4 of docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md.
+//
+// The hooks are deliberately no-ops for unencrypted containers, which is
+// every container today: a container carries a KeyRef only if it was
+// created encrypted, and without one these do nothing at all. That keeps
+// the default path byte-for-byte unchanged while the encrypted path is
+// still being built out.
+//
+// NOT VERIFIED against real ZFS — see #1200 and the pkg/core/zfscrypt
+// package doc. These tests prove the orchestration (what runs, in what
+// order, and what happens on failure); they cannot prove ZFS behaves as
+// assumed.
+
+// keyRefConfigKey is the Incus config key the durable KeyRef is stored
+// under, so a restarted daemon — or a migration destination — can
+// re-resolve the same key without holding any state itself.
+const keyRefConfigKey = "user.containarium.zfs_key_ref"
+
+// keyRefStore reads and writes a container's durable KeyRef. An
+// interface so the hooks are testable without Incus.
+type keyRefStore interface {
+	// GetKeyRef returns the stored ref and whether one was present.
+	GetKeyRef(containerName string) (zfskey.KeyRef, bool, error)
+	// SetKeyRef persists the ref on the container.
+	SetKeyRef(containerName string, ref zfskey.KeyRef) error
+}
+
+// datasetResolver maps a container to the ZFS dataset backing it.
+type datasetResolver interface {
+	DatasetFor(containerName string) (string, error)
+}
+
+// encryptionHooks carries the collaborators the lifecycle hooks need.
+// A nil *encryptionHooks is a valid no-op receiver, so call sites do not
+// need to branch on whether encryption is configured.
+type encryptionHooks struct {
+	provider zfskey.KeyProvider
+	zfs      *zfscrypt.Manager
+	cache    *zfskey.Cache
+	refs     keyRefStore
+	datasets datasetResolver
+}
+
+// enabled reports whether encryption is wired at all.
+func (h *encryptionHooks) enabled() bool {
+	return h != nil && h.provider != nil && h.zfs != nil && h.refs != nil && h.datasets != nil
+}
+
+// encryptedFor returns the dataset and key ref for a container, and
+// false when the container is not encrypted.
+func (h *encryptionHooks) encryptedFor(containerName string) (dataset string, ref zfskey.KeyRef, ok bool, err error) {
+	if !h.enabled() {
+		return "", zfskey.KeyRef{}, false, nil
+	}
+	ref, present, err := h.refs.GetKeyRef(containerName)
+	if err != nil || !present {
+		return "", zfskey.KeyRef{}, false, err
+	}
+	dataset, err = h.datasets.DatasetFor(containerName)
+	if err != nil {
+		return "", zfskey.KeyRef{}, false, err
+	}
+	return dataset, ref, true, nil
+}
+
+// PreStart loads the container's encryption key so its dataset can be
+// mounted.
+//
+// A failure here must prevent the start. The container's data is
+// unreadable without the key, so letting it boot would produce a
+// container whose storage silently is not there — far worse than a
+// refused start, which is at least legible (design §5: KeyProvider down
+// at start time → FailedPrecondition, the LXC stays stopped).
+func (h *encryptionHooks) PreStart(ctx context.Context, containerName string) error {
+	dataset, ref, ok, err := h.encryptedFor(containerName)
+	if err != nil {
+		return fmt.Errorf("resolve encryption state for %s: %w", containerName, err)
+	}
+	if !ok {
+		return nil // not an encrypted container
+	}
+
+	tenant := tenantFromRef(ref, containerName)
+	key, cached := h.cacheGet(tenant)
+	if !cached {
+		key, err = h.provider.Load(ctx, ref)
+		if err != nil {
+			// The container stays stopped, by design: it is
+			// unreadable until key custody recovers.
+			return fmt.Errorf("cannot load the encryption key for %s: %w", containerName, err)
+		}
+		h.cachePut(tenant, key)
+	}
+
+	if err := h.zfs.LoadKey(ctx, dataset, key); err != nil {
+		return fmt.Errorf("cannot unlock the dataset for %s: %w", containerName, err)
+	}
+	return nil
+}
+
+// PostStop drops the key so a stopped container's dataset is ciphertext,
+// including to host root (#1201).
+//
+// Best-effort by design: the container has already stopped, so failing
+// the RPC would report a stop that did happen as a failure. The operator
+// still needs to know, so every non-trivial outcome is logged.
+//
+// "Key still in use" is the expected case when the tenant has another
+// container running under the same encryptionroot — a tenant's
+// containers share one — and is not an error.
+func (h *encryptionHooks) PostStop(ctx context.Context, containerName string) {
+	dataset, ref, ok, err := h.encryptedFor(containerName)
+	if err != nil {
+		log.Printf("[encryption] could not resolve encryption state for %s while stopping: %v", containerName, err)
+		return
+	}
+	if !ok {
+		return
+	}
+
+	switch err := h.zfs.UnloadKey(ctx, dataset); {
+	case err == nil:
+		// The dataset is now ciphertext. Evict the cached key too:
+		// leaving it resident would keep tenant key material in daemon
+		// memory for a container that is no longer running.
+		h.cacheEvict(tenantFromRef(ref, containerName))
+		log.Printf("[encryption] unloaded the key for %s; its dataset is now ciphertext at rest", containerName)
+	case errors.Is(err, zfscrypt.ErrKeyInUse):
+		// Another container under the same encryptionroot is still
+		// running. Its key must stay loaded, and the cache entry stays
+		// with it.
+		log.Printf("[encryption] key for %s stays loaded: another container under the same encryptionroot is still running", containerName)
+	default:
+		log.Printf("[encryption] WARNING: could not unload the key for %s, so its dataset remains readable while stopped: %v",
+			containerName, err)
+	}
+}
+
+// RecordKeyRef persists the ref produced at create time.
+func (h *encryptionHooks) RecordKeyRef(containerName string, ref zfskey.KeyRef) error {
+	if !h.enabled() {
+		return fmt.Errorf("encryption is not configured on this daemon")
+	}
+	return h.refs.SetKeyRef(containerName, ref)
+}
+
+func (h *encryptionHooks) cacheGet(tenant string) (zfskey.Key, bool) {
+	if h.cache == nil {
+		return zfskey.Key{}, false
+	}
+	return h.cache.Get(tenant)
+}
+
+func (h *encryptionHooks) cachePut(tenant string, k zfskey.Key) {
+	if h.cache != nil {
+		h.cache.Put(tenant, k)
+	}
+}
+
+func (h *encryptionHooks) cacheEvict(tenant string) {
+	if h.cache != nil {
+		h.cache.Evict(tenant)
+	}
+}
+
+// tenantFromRef derives the cache key for a ref. Falls back to the
+// container name so a ref without tenant metadata still caches
+// correctly, just less sharedly.
+func tenantFromRef(ref zfskey.KeyRef, containerName string) string {
+	if t := ref.Metadata["tenant"]; t != "" {
+		return t
+	}
+	return containerName
+}
+
+// --- concrete adapters -----------------------------------------------
+
+// incusKeyRefStore persists the KeyRef as an Incus config key on the
+// container, so it survives a daemon restart without the daemon holding
+// any state of its own.
+type incusKeyRefStore struct {
+	setConfig func(containerName, key, value string) error
+	getConfig func(containerName, key string) (string, error)
+}
+
+func (s incusKeyRefStore) GetKeyRef(containerName string) (zfskey.KeyRef, bool, error) {
+	raw, err := s.getConfig(containerName, keyRefConfigKey)
+	if err != nil {
+		return zfskey.KeyRef{}, false, err
+	}
+	if raw == "" {
+		return zfskey.KeyRef{}, false, nil
+	}
+	var ref zfskey.KeyRef
+	if err := json.Unmarshal([]byte(raw), &ref); err != nil {
+		return zfskey.KeyRef{}, false, fmt.Errorf("corrupt key ref on %s: %w", containerName, err)
+	}
+	return ref, true, nil
+}
+
+func (s incusKeyRefStore) SetKeyRef(containerName string, ref zfskey.KeyRef) error {
+	b, err := json.Marshal(ref)
+	if err != nil {
+		return fmt.Errorf("encode key ref: %w", err)
+	}
+	return s.setConfig(containerName, keyRefConfigKey, string(b))
+}

--- a/internal/server/encryption_hooks_test.go
+++ b/internal/server/encryption_hooks_test.go
@@ -1,0 +1,350 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+)
+
+// --- fakes -----------------------------------------------------------
+
+type fakeKeyProvider struct {
+	key      zfskey.Key
+	loadErr  error
+	loadCall int
+}
+
+func (f *fakeKeyProvider) Wrap(context.Context, string) (zfskey.Key, zfskey.KeyRef, error) {
+	return f.key, zfskey.KeyRef{Scheme: zfskey.SchemeFile, URI: "/keys/alice.key"}, nil
+}
+
+func (f *fakeKeyProvider) Load(context.Context, zfskey.KeyRef) (zfskey.Key, error) {
+	f.loadCall++
+	if f.loadErr != nil {
+		return zfskey.Key{}, f.loadErr
+	}
+	return f.key, nil
+}
+
+type fakeRefStore struct {
+	refs map[string]zfskey.KeyRef
+	err  error
+}
+
+func (f *fakeRefStore) GetKeyRef(name string) (zfskey.KeyRef, bool, error) {
+	if f.err != nil {
+		return zfskey.KeyRef{}, false, f.err
+	}
+	ref, ok := f.refs[name]
+	return ref, ok, nil
+}
+
+func (f *fakeRefStore) SetKeyRef(name string, ref zfskey.KeyRef) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.refs[name] = ref
+	return nil
+}
+
+type fakeDatasets struct{ prefix string }
+
+func (f fakeDatasets) DatasetFor(name string) (string, error) {
+	return f.prefix + "/" + name, nil
+}
+
+// zfsFake records commands and replays canned results, keyed by
+// subcommand.
+type zfsFake struct {
+	calls  []string
+	stdout map[string]string
+	errs   map[string]error
+	stderr map[string]string
+}
+
+func newZFSFake() *zfsFake {
+	return &zfsFake{
+		stdout: map[string]string{"get": "unavailable"},
+		errs:   map[string]error{},
+		stderr: map[string]string{},
+	}
+}
+
+func (z *zfsFake) Run(_ context.Context, _ []byte, args ...string) (string, string, error) {
+	z.calls = append(z.calls, strings.Join(args, " "))
+	sub := ""
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	return z.stdout[sub], z.stderr[sub], z.errs[sub]
+}
+
+func (z *zfsFake) ran(substr string) bool {
+	for _, c := range z.calls {
+		if strings.Contains(c, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func testHooks(t *testing.T, z *zfsFake, p *fakeKeyProvider, refs map[string]zfskey.KeyRef) *encryptionHooks {
+	t.Helper()
+	return &encryptionHooks{
+		provider: p,
+		zfs:      zfscrypt.NewManager(z),
+		cache:    zfskey.NewCache(time.Hour),
+		refs:     &fakeRefStore{refs: refs},
+		datasets: fakeDatasets{prefix: "pool/containers"},
+	}
+}
+
+func aKey(t *testing.T) zfskey.Key {
+	t.Helper()
+	k, err := zfskey.NewKey(bytes.Repeat([]byte{7}, zfskey.KeyLen))
+	if err != nil {
+		t.Fatalf("NewKey: %v", err)
+	}
+	return k
+}
+
+// --- unencrypted containers are untouched ----------------------------
+
+// The default path must be completely unchanged: today every container
+// is unencrypted, and the hooks must not run a single zfs command
+// against them.
+func TestHooksAreNoOpsForUnencryptedContainers(t *testing.T) {
+	z := newZFSFake()
+	h := testHooks(t, z, &fakeKeyProvider{key: aKey(t)}, map[string]zfskey.KeyRef{})
+
+	if err := h.PreStart(context.Background(), "alice-container"); err != nil {
+		t.Fatalf("PreStart on an unencrypted container: %v", err)
+	}
+	h.PostStop(context.Background(), "alice-container")
+
+	if len(z.calls) != 0 {
+		t.Errorf("zfs was invoked for an unencrypted container: %v", z.calls)
+	}
+}
+
+// A daemon with no encryption configured at all must behave the same.
+func TestNilHooksAreSafe(t *testing.T) {
+	var h *encryptionHooks
+	if err := h.PreStart(context.Background(), "alice-container"); err != nil {
+		t.Errorf("PreStart on a nil hooks receiver: %v", err)
+	}
+	h.PostStop(context.Background(), "alice-container") // must not panic
+}
+
+// --- pre-start (#1199) -----------------------------------------------
+
+func TestPreStartLoadsTheKey(t *testing.T) {
+	z := newZFSFake()
+	p := &fakeKeyProvider{key: aKey(t)}
+	h := testHooks(t, z, p, map[string]zfskey.KeyRef{
+		"alice-container": {Scheme: zfskey.SchemeFile, URI: "/keys/alice.key"},
+	})
+
+	if err := h.PreStart(context.Background(), "alice-container"); err != nil {
+		t.Fatalf("PreStart: %v", err)
+	}
+	if !z.ran("load-key") {
+		t.Errorf("load-key never ran: %v", z.calls)
+	}
+	if !z.ran("pool/containers/alice-container") {
+		t.Errorf("acted on the wrong dataset: %v", z.calls)
+	}
+}
+
+// AC (#1199): KeyProvider down at start time → the start fails and the
+// container stays stopped.
+//
+// Booting anyway would give the tenant a container whose storage
+// silently is not there, which is worse than a refused start.
+func TestPreStartFailsWhenTheKeyCannotBeLoaded(t *testing.T) {
+	z := newZFSFake()
+	p := &fakeKeyProvider{key: aKey(t), loadErr: errors.New("KMS unreachable")}
+	h := testHooks(t, z, p, map[string]zfskey.KeyRef{
+		"alice-container": {Scheme: zfskey.SchemeFile, URI: "/keys/alice.key"},
+	})
+
+	err := h.PreStart(context.Background(), "alice-container")
+	if err == nil {
+		t.Fatal("PreStart succeeded with no key — the container would boot with unreadable storage")
+	}
+	if !strings.Contains(err.Error(), "KMS unreachable") {
+		t.Errorf("the custody error should survive, got %q", err)
+	}
+	if z.ran("load-key") {
+		t.Error("load-key ran despite having no key")
+	}
+}
+
+// A daemon restart re-runs pre-start; the cache is empty then, so the
+// key is re-fetched from the provider rather than the start failing.
+func TestPreStartRefetchesAfterARestart(t *testing.T) {
+	refs := map[string]zfskey.KeyRef{
+		"alice-container": {Scheme: zfskey.SchemeFile, URI: "/keys/alice.key"},
+	}
+	p := &fakeKeyProvider{key: aKey(t)}
+
+	h1 := testHooks(t, newZFSFake(), p, refs)
+	if err := h1.PreStart(context.Background(), "alice-container"); err != nil {
+		t.Fatalf("first start: %v", err)
+	}
+	if p.loadCall != 1 {
+		t.Fatalf("provider Load calls = %d, want 1", p.loadCall)
+	}
+
+	// Same hooks instance: the cache should serve the second start.
+	if err := h1.PreStart(context.Background(), "alice-container"); err != nil {
+		t.Fatalf("second start: %v", err)
+	}
+	if p.loadCall != 1 {
+		t.Errorf("provider was re-queried despite a warm cache (calls=%d)", p.loadCall)
+	}
+
+	// A fresh process (new hooks, new cache) must go back to the provider.
+	h2 := testHooks(t, newZFSFake(), p, refs)
+	if err := h2.PreStart(context.Background(), "alice-container"); err != nil {
+		t.Fatalf("after restart: %v", err)
+	}
+	if p.loadCall != 2 {
+		t.Errorf("a restarted daemon must re-fetch from the provider, calls=%d", p.loadCall)
+	}
+}
+
+// --- post-stop (#1201) -----------------------------------------------
+
+// The headline behaviour of #1201: stopping unloads the key, so the
+// dataset is ciphertext at rest.
+func TestPostStopUnloadsTheKey(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["get"] = "available"
+	h := testHooks(t, z, &fakeKeyProvider{key: aKey(t)}, map[string]zfskey.KeyRef{
+		"alice-container": {Scheme: zfskey.SchemeFile, URI: "/keys/alice.key"},
+	})
+
+	h.PostStop(context.Background(), "alice-container")
+
+	if !z.ran("unload-key") {
+		t.Errorf("unload-key never ran — a stopped container's dataset stays readable: %v", z.calls)
+	}
+}
+
+// AC (#1201): stopping one of several containers under the same
+// encryptionroot must NOT unload the key, and must not be treated as a
+// failure.
+func TestPostStopToleratesAKeyStillInUse(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["get"] = "available"
+	z.errs["unload-key"] = errors.New("exit status 1")
+	z.stderr["unload-key"] = "cannot unload key: dataset is busy"
+
+	h := testHooks(t, z, &fakeKeyProvider{key: aKey(t)}, map[string]zfskey.KeyRef{
+		"alice-container": {Scheme: zfskey.SchemeFile, URI: "/keys/alice.key",
+			Metadata: map[string]string{"tenant": "alice"}},
+	})
+
+	// Warm the cache so we can assert it is NOT evicted.
+	h.cachePut("alice", aKey(t))
+
+	h.PostStop(context.Background(), "alice-container") // must not panic or block
+
+	if _, ok := h.cacheGet("alice"); !ok {
+		t.Error("the tenant's cached key was evicted while another of their containers is still running")
+	}
+}
+
+// A successful unload evicts the cached key: leaving it resident would
+// keep tenant key material in daemon memory for a container that is no
+// longer running.
+func TestPostStopEvictsTheCachedKeyOnSuccess(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["get"] = "available"
+	h := testHooks(t, z, &fakeKeyProvider{key: aKey(t)}, map[string]zfskey.KeyRef{
+		"alice-container": {Scheme: zfskey.SchemeFile, URI: "/keys/alice.key",
+			Metadata: map[string]string{"tenant": "alice"}},
+	})
+	h.cachePut("alice", aKey(t))
+
+	h.PostStop(context.Background(), "alice-container")
+
+	if _, ok := h.cacheGet("alice"); ok {
+		t.Error("key stayed cached after a successful unload")
+	}
+}
+
+// PostStop never fails the RPC: the container has already stopped, so
+// reporting a failure would call a stop that happened a failure.
+func TestPostStopDoesNotPropagateFailures(t *testing.T) {
+	z := newZFSFake()
+	z.stdout["get"] = "available"
+	z.errs["unload-key"] = errors.New("exit status 1")
+	z.stderr["unload-key"] = "permission denied"
+
+	h := testHooks(t, z, &fakeKeyProvider{key: aKey(t)}, map[string]zfskey.KeyRef{
+		"alice-container": {Scheme: zfskey.SchemeFile, URI: "/keys/alice.key"},
+	})
+
+	// Signature returns nothing: a stop cannot be undone by a failed
+	// unload, so there is no error for the caller to act on. The
+	// operator learns from the log.
+	h.PostStop(context.Background(), "alice-container")
+}
+
+// --- key ref persistence ---------------------------------------------
+
+// The ref must round-trip through the store, since a restarted daemon
+// re-resolves the key from it and holds no state itself.
+func TestKeyRefRoundTrips(t *testing.T) {
+	stored := map[string]string{}
+	s := incusKeyRefStore{
+		setConfig: func(_, k, v string) error { stored[k] = v; return nil },
+		getConfig: func(_, k string) (string, error) { return stored[k], nil },
+	}
+
+	want := zfskey.KeyRef{
+		Scheme:   zfskey.SchemeFile,
+		URI:      "/etc/containarium/keys/alice.key",
+		Metadata: map[string]string{"tenant": "alice"},
+	}
+	if err := s.SetKeyRef("alice-container", want); err != nil {
+		t.Fatalf("SetKeyRef: %v", err)
+	}
+	got, ok, err := s.GetKeyRef("alice-container")
+	if err != nil || !ok {
+		t.Fatalf("GetKeyRef: %v ok=%v", err, ok)
+	}
+	if got.Scheme != want.Scheme || got.URI != want.URI || got.Metadata["tenant"] != "alice" {
+		t.Errorf("round trip lost data: %+v", got)
+	}
+
+	// A container with no ref is simply unencrypted, not an error.
+	empty := incusKeyRefStore{
+		setConfig: func(string, string, string) error { return nil },
+		getConfig: func(string, string) (string, error) { return "", nil },
+	}
+	if _, ok, err := empty.GetKeyRef("bob-container"); err != nil || ok {
+		t.Errorf("absent ref: ok=%v err=%v, want ok=false err=nil", ok, err)
+	}
+}
+
+// A corrupt ref is an error, not a silently unencrypted container —
+// otherwise a mangled config key would downgrade a tenant to plaintext
+// handling without anyone noticing.
+func TestCorruptKeyRefIsAnError(t *testing.T) {
+	s := incusKeyRefStore{
+		setConfig: func(string, string, string) error { return nil },
+		getConfig: func(string, string) (string, error) { return "{not json", nil },
+	}
+	if _, _, err := s.GetKeyRef("alice-container"); err == nil {
+		t.Error("a corrupt key ref must not be read as 'no encryption'")
+	}
+}


### PR DESCRIPTION
Refs #1199, #1201. Part of #1205. Builds on #1230 (`pkg/core/zfscrypt`) and #1207 (`pkg/core/zfskey`).

## ⚠️ Still not verified against real ZFS

Per **#1200**, unchanged: no reachable environment has a pool. These tests prove the **orchestration** — what runs, in what order, and what happens on each failure — and cannot prove ZFS behaves as assumed. **Both issues' ciphertext-at-rest acceptance criteria remain unticked.**

The riskiest assumption is still the one from #1230: that `zfs unload-key` *fails* rather than silently succeeding while a dataset under the encryptionroot is mounted. If it silently succeeded, `PostStop` would pull the key out from under a co-tenant's running container.

## What's wired

- **`PreStart`** unlocks the dataset before the LXC boots. A failure **stops the start** (`FailedPrecondition`). Booting anyway would hand the tenant a container whose storage silently isn't there — worse than a refused start, because it's illegible.
- **`PostStop`** drops the key once the LXC is down, so a stopped container's dataset is ciphertext including to host root — the property #1168 was filed about. It runs strictly *after* the stop: unloading under a running container would pull its storage away.

## Review this first — three deliberate asymmetries

**`PostStop` returns nothing and cannot fail the RPC.** The container has already stopped; reporting a failed unload as a failed stop would be a lie about what happened. The operator learns from the log instead. I'd rather you disagree with this explicitly than have it slip through.

**"Key still in use" is a normal outcome, not an error.** A tenant's containers share one encryptionroot, so stopping one while another runs *must* leave the key loaded. It's logged as routine, and the cached key deliberately survives.

**A corrupt KeyRef is an error, not "no encryption".** Reading a mangled config key as absent would silently downgrade a tenant to plaintext handling with nobody noticing — the same silent-downgrade class as the `--encrypted` fail-closed rule in #1224.

A successful unload also evicts the cached key: leaving it resident keeps tenant key material in daemon memory for a container that's no longer running.

## Unencrypted containers are untouched

Today every container is unencrypted, and the hooks run **zero** zfs commands against them — a container carries a KeyRef only if it was created encrypted. A nil `*encryptionHooks` is a valid no-op receiver, so lifecycle paths don't branch on whether encryption is configured. `TestHooksAreNoOpsForUnencryptedContainers` and `TestNilHooksAreSafe` pin both.

## Test evidence

11 cases covering the ACs each issue names:

| AC | Test |
|---|---|
| #1199 — KeyProvider down at start → container stays stopped | `TestPreStartFailsWhenTheKeyCannotBeLoaded` |
| #1199 — daemon restart re-fetches the key | `TestPreStartRefetchesAfterARestart` |
| #1201 — stopping unloads the key | `TestPostStopUnloadsTheKey` |
| #1201 — co-tenant still running → key stays loaded | `TestPostStopToleratesAKeyStillInUse` |
| default path unchanged | `TestHooksAreNoOpsForUnencryptedContainers`, `TestNilHooksAreSafe` |

```
ok  github.com/footprintai/containarium/internal/server  7.717s
```

gosec: 31 on `main`, 31 here. Windows cross-compile guard passes.

## What still isn't wired

**Pre-create** — creating the encrypted dataset and pointing Incus at it via the "instance from an existing zvol" path. It can't be exercised without Incus, so it isn't in this PR. #1199 is therefore *not* complete; #1201 is complete modulo verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)