### PR TITLE
fix(systemd): bound the restart rate; keep retrying forever

### DIFF
--- a/internal/cmd/sentinel_service.go
+++ b/internal/cmd/sentinel_service.go
@@ -81,7 +81,28 @@ ExecStart=/usr/local/bin/containarium sentinel \
   --zone %s \
   --project %s
 Restart=always
+# Keep retrying forever (StartLimitIntervalSec=0 above), but not at full
+# speed. A persistent start failure used to retry every 5s indefinitely:
+# one production host crash-looped 1655 times in ~4 hours, pinning a core
+# and — because each cycle rewrites the bundled monitoring config —
+# restarting alertmanager and vmalert every 7 seconds, so alerting could
+# not have fired during the incident, including on the incident itself
+# (#1152).
+#
+# "Never give up" and "retry at full speed" are separable. RestartSteps
+# interpolates the delay geometrically from RestartSec to
+# RestartMaxDelaySec, so a transient incus hiccup at boot still recovers
+# in seconds while a persistent failure settles to one attempt every 5
+# minutes. That same 4-hour outage would cost ~50 attempts, not 1655.
+#
+# Requires systemd 254+. The documented host floor is Ubuntu 24.04 LTS
+# ("or later", README), which ships 255. On an older host systemd warns
+# and continues, degrading to the previous fixed-interval behaviour
+# rather than failing to start — so this cannot brick a host that
+# predates the directives.
 RestartSec=5s
+RestartSteps=6
+RestartMaxDelaySec=5min
 User=root
 Group=root
 

--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -35,7 +35,28 @@ ExecStart=/usr/local/bin/containarium daemon \
   --rest \
   --jwt-secret-file /etc/containarium/jwt.secret
 Restart=on-failure
+# Keep retrying forever (StartLimitIntervalSec=0 above), but not at full
+# speed. A persistent start failure used to retry every 5s indefinitely:
+# one production host crash-looped 1655 times in ~4 hours, pinning a core
+# and — because each cycle rewrites the bundled monitoring config —
+# restarting alertmanager and vmalert every 7 seconds, so alerting could
+# not have fired during the incident, including on the incident itself
+# (#1152).
+#
+# "Never give up" and "retry at full speed" are separable. RestartSteps
+# interpolates the delay geometrically from RestartSec to
+# RestartMaxDelaySec, so a transient incus hiccup at boot still recovers
+# in seconds while a persistent failure settles to one attempt every 5
+# minutes. That same 4-hour outage would cost ~50 attempts, not 1655.
+#
+# Requires systemd 254+. The documented host floor is Ubuntu 24.04 LTS
+# ("or later", README), which ships 255. On an older host systemd warns
+# and continues, degrading to the previous fixed-interval behaviour
+# rather than failing to start — so this cannot brick a host that
+# predates the directives.
 RestartSec=5s
+RestartSteps=6
+RestartMaxDelaySec=5min
 User=root
 Group=root
 

--- a/internal/cmd/service_backoff_test.go
+++ b/internal/cmd/service_backoff_test.go
@@ -1,0 +1,114 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Restart-backoff guards for the three unit templates (#1152).
+//
+// The incident: a production backend crash-looped 1655 times in ~4 hours —
+// one restart every ~7 seconds — until an operator noticed the host's CPU
+// was pinned. `StartLimitIntervalSec=0` disables systemd's rate limiting
+// entirely, and with a flat `RestartSec=5s` a persistent start failure
+// retries forever at full speed.
+//
+// The collateral damage was worse than the CPU: each cycle rewrote the
+// bundled monitoring stack's config, so alertmanager and vmalert were
+// restarted every 7 seconds for 4 hours. Alerting could not have fired
+// during the incident — including on the incident itself.
+//
+// The fix keeps infinite retry (that part was deliberate: a pool member
+// that stays dead is worse than one that retries) and adds geometric
+// backoff, so the two properties stop being conflated.
+
+// unitSources returns each unit template with a label. The daemon
+// template is a package const; the sibling shipped as a plain file and
+// the sentinel's inline template are read from source, because nothing
+// else in the build would notice them regressing.
+func unitSources(t *testing.T) map[string]string {
+	t.Helper()
+
+	read := func(parts ...string) string {
+		t.Helper()
+		raw, err := os.ReadFile(filepath.Join(parts...))
+		if err != nil {
+			t.Fatalf("read %v: %v", parts, err)
+		}
+		return string(raw)
+	}
+
+	return map[string]string{
+		"daemon (systemdServiceTemplate)":       systemdServiceTemplate,
+		"daemon (scripts/containarium.service)": read("..", "..", "scripts", "containarium.service"),
+		"sentinel (sentinel_service.go)":        read("sentinel_service.go"),
+	}
+}
+
+// Every unit must bound its retry rate. Without these, a persistent
+// failure retries 12 times a minute forever.
+func TestUnitsHaveRestartBackoff(t *testing.T) {
+	for name, unit := range unitSources(t) {
+		t.Run(name, func(t *testing.T) {
+			for _, directive := range []string{"RestartSteps=", "RestartMaxDelaySec="} {
+				if !strings.Contains(unit, directive) {
+					t.Errorf("%s is missing %s — a persistent start failure would retry at a flat "+
+						"interval forever, which is #1152 (1655 restarts in 4 hours)", name, directive)
+				}
+			}
+			// The floor must survive too: without RestartSec the
+			// geometric series has nothing to start from.
+			if !strings.Contains(unit, "RestartSec=") {
+				t.Errorf("%s lost RestartSec", name)
+			}
+		})
+	}
+}
+
+// Infinite retry must be preserved. This is the half of the original
+// design that was correct and is easy to "fix" by mistake: a
+// StartLimitBurst that gives up leaves a pool member silently dead,
+// which is worse than one retrying slowly.
+func TestUnitsStillRetryForever(t *testing.T) {
+	for name, unit := range unitSources(t) {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(unit, "StartLimitIntervalSec=0") {
+				t.Errorf("%s no longer disables the start rate limit: a unit that gives up leaves "+
+					"a pool member dead until someone notices, which is what the 0 was for", name)
+			}
+			// systemd's rate limiter is what makes a unit enter
+			// "failed" and stop retrying. Reintroducing a burst limit
+			// alongside the backoff would undo that deliberately-kept
+			// property.
+			if strings.Contains(unit, "StartLimitBurst=") {
+				t.Errorf("%s sets StartLimitBurst — combined with a start limit that would make the "+
+					"unit give up permanently; backoff is the mechanism here, not a cap", name)
+			}
+		})
+	}
+}
+
+// The backoff has to actually widen: a max delay at or below the initial
+// delay is the flat-retry behaviour with extra words.
+func TestBackoffCeilingIsAboveTheFloor(t *testing.T) {
+	for name, unit := range unitSources(t) {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(unit, "RestartSec=5s") {
+				t.Errorf("%s: expected a 5s floor", name)
+			}
+			if !strings.Contains(unit, "RestartMaxDelaySec=5min") {
+				t.Errorf("%s: expected a 5min ceiling, well above the 5s floor", name)
+			}
+			// RestartSteps interpolates between them; 1 step would be
+			// a single jump rather than a ramp, defeating the "a
+			// transient hiccup still recovers in seconds" property.
+			if strings.Contains(unit, "RestartSteps=1\n") || strings.Contains(unit, "RestartSteps=0") {
+				t.Errorf("%s: RestartSteps must ramp, so an early transient failure still retries fast", name)
+			}
+		})
+	}
+}

--- a/scripts/containarium.service
+++ b/scripts/containarium.service
@@ -14,7 +14,28 @@ ExecStart=/usr/local/bin/containarium daemon \
   --rest \
   --jwt-secret-file /etc/containarium/jwt.secret
 Restart=on-failure
+# Keep retrying forever (StartLimitIntervalSec=0 above), but not at full
+# speed. A persistent start failure used to retry every 5s indefinitely:
+# one production host crash-looped 1655 times in ~4 hours, pinning a core
+# and — because each cycle rewrites the bundled monitoring config —
+# restarting alertmanager and vmalert every 7 seconds, so alerting could
+# not have fired during the incident, including on the incident itself
+# (#1152).
+#
+# "Never give up" and "retry at full speed" are separable. RestartSteps
+# interpolates the delay geometrically from RestartSec to
+# RestartMaxDelaySec, so a transient incus hiccup at boot still recovers
+# in seconds while a persistent failure settles to one attempt every 5
+# minutes. That same 4-hour outage would cost ~50 attempts, not 1655.
+#
+# Requires systemd 254+. The documented host floor is Ubuntu 24.04 LTS
+# ("or later", README), which ships 255. On an older host systemd warns
+# and continues, degrading to the previous fixed-interval behaviour
+# rather than failing to start — so this cannot brick a host that
+# predates the directives.
 RestartSec=5s
+RestartSteps=6
+RestartMaxDelaySec=5min
 User=root
 Group=root
 


### PR DESCRIPTION
Closes #1152.

## The incident

A production backend crash-looped **1655 times in ~4 hours** — one restart every ~7 seconds — until an operator noticed the host's CPU was pinned. `StartLimitIntervalSec=0` disables systemd's rate limiting entirely, and with a flat `RestartSec=5s` a persistent start failure retries forever at full speed.

The collateral damage was worse than the CPU: each cycle rewrote the bundled monitoring stack's config, so **alertmanager and vmalert were restarted every ~7 seconds for four hours**. Alerting could not have fired during the incident — including on the incident itself.

## The `0` stays

It was deliberate and it was right. A pool member that gives up is worse than one that retries, which is the same instinct behind `Wants=` rather than `Requires=` on `incus.service`. The bug is that *"never give up"* had been implemented as *"retry at full speed forever"*, and those are separable.

`RestartSteps` interpolates the delay geometrically from `RestartSec` to `RestartMaxDelaySec`, so a transient incus hiccup at boot still recovers in seconds while a persistent failure settles to one attempt every five minutes. The same outage would have cost ~50 attempts instead of 1655, and ~50 monitoring-stack rewrites instead of ~2000.

Applied to all three templates: `internal/cmd/service.go`, `scripts/containarium.service`, `internal/cmd/sentinel_service.go`.

## The version constraint the issue asked to confirm — verified, not assumed

`RestartSteps`/`RestartMaxDelaySec` need **systemd 254+**. The documented host floor is Ubuntu 24.04 LTS "or later" (README:617), which ships systemd 255.

Rather than take that on trust, I checked against real systemd:

```
$ systemd-analyze verify scripts/containarium.service
containarium.service: Command /usr/local/bin/containarium is not executable...
```

— no complaint about the directives. And a **negative control**, to prove the tool would have caught an unsupported one:

```
$ systemd-analyze verify bogus.service     # RestartSteps -> RestartStepsBogus
bogus.service:37: Unknown key name 'RestartStepsBogus' in section 'Service', ignoring.
bogus.service: Service has RestartMaxDelaySec= but no RestartSteps= setting. Ignoring.
```

All three units pass. On a hypothetical older host, systemd warns and continues — degrading to today's fixed-interval behaviour rather than failing to start, so this cannot brick a host that predates the directives.

**That check also surfaced a coupling worth knowing:** with `RestartMaxDelaySec` but no `RestartSteps`, systemd reports *"Ignoring"* — the ceiling alone does nothing. Both are set, in all three.

I could verify the documented target; I could **not** verify what the actual fleet runs, which the issue also flagged. If any host predates 24.04 it silently keeps the old behaviour, which is the safe direction but worth knowing.

## Review this first

The tests guard **both** halves, and the second matters more than it looks:

- `TestUnitsHaveRestartBackoff` — the directives are present
- `TestUnitsStillRetryForever` — `StartLimitIntervalSec=0` intact **and no `StartLimitBurst`**

A well-meaning later "fix" that adds a burst limit would make the unit enter `failed` and stop retrying, reintroducing exactly the silent-death failure mode the `0` exists to prevent. Backoff is the mechanism here; a cap is not.

Mutation-tested — reverting the backoff reproduces the #1152 state and fails with the incident named:

```
--- FAIL: TestUnitsHaveRestartBackoff/daemon_(scripts/containarium.service)
    is missing RestartSteps= — a persistent start failure would retry at a
    flat interval forever, which is #1152 (1655 restarts in 4 hours)
```

```
ok  github.com/footprintai/containarium/internal/cmd  0.180s
```

Windows cross-compile guard passes. No production Go code changes — unit templates and tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)