### PR TITLE
fix(sentinel): fast-retry a failed key/cert sync instead of waiting a full interval

### DIFF
--- a/internal/sentinel/certsync.go
+++ b/internal/sentinel/certsync.go
@@ -119,38 +119,27 @@ func (cs *CertStore) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificat
 
 // RunSyncLoop periodically syncs certificates from the backend.
 // Blocks until ctx is cancelled.
+//
+// A failed attempt is retried on the fast-retry schedule before falling
+// back to the interval. This loop is the reason that schedule exists: at a
+// 6h interval, one transient failure used to mean stale certificates for
+// most of a day (#953).
 func (cs *CertStore) RunSyncLoop(ctx context.Context, backendIP string, httpPort int, interval time.Duration) {
 	log.Printf("[certsync] starting sync loop (backend=%s:%d, interval=%s)", backendIP, httpPort, interval)
 
-	// Initial sync attempt
-	if err := cs.Sync(backendIP, httpPort); err != nil {
-		log.Printf("[certsync] initial sync failed (will retry): %v", err)
-	} else {
+	runSyncLoop(ctx, "certsync", interval, syncRetryDelays(interval), func() error {
+		if err := cs.Sync(backendIP, httpPort); err != nil {
+			log.Printf("[certsync] sync failed: %v", err)
+			return err
+		}
 		cs.mu.RLock()
 		count := cs.syncedCount
 		cs.mu.RUnlock()
-		log.Printf("[certsync] initial sync OK: %d certificates", count)
-	}
+		log.Printf("[certsync] sync OK: %d certificates", count)
+		return nil
+	})
 
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			log.Printf("[certsync] sync loop stopped")
-			return
-		case <-ticker.C:
-			if err := cs.Sync(backendIP, httpPort); err != nil {
-				log.Printf("[certsync] sync failed: %v", err)
-			} else {
-				cs.mu.RLock()
-				count := cs.syncedCount
-				cs.mu.RUnlock()
-				log.Printf("[certsync] sync OK: %d certificates", count)
-			}
-		}
-	}
+	log.Printf("[certsync] sync loop stopped")
 }
 
 // LastSync returns the time of the last successful sync.

--- a/internal/sentinel/key_resync_handler.go
+++ b/internal/sentinel/key_resync_handler.go
@@ -97,10 +97,10 @@ func (m *Manager) KeyResyncHandler() http.HandlerFunc {
 
 		coalesced := m.resyncBackendKeys(backend)
 
-		// Report what actually happened, not merely that we tried:
-		// syncAndApply swallows a failed pull (it logs and lets the next
-		// tick retry), so without this the daemon would log "key is live"
-		// for a backend whose keys never arrived — the exact false
+		// Report what actually happened, not merely that we tried: this
+		// path does not retry a failed pull (it logs and leaves recovery to
+		// the periodic loop), so without this the daemon would log "key is
+		// live" for a backend whose keys never arrived — the exact false
 		// confidence this endpoint exists to remove.
 		users, syncErr := m.keyStore.lastSyncResult(backend.ID)
 		log.Printf("[keysync] event-driven resync for backend %s: %d users (coalesced=%v, ok=%v, reason=%q)",
@@ -159,7 +159,9 @@ func (m *Manager) resyncBackendKeys(b *Backend) bool {
 		return true
 	}
 	gate.lastStart = time.Now()
-	m.keyStore.syncAndApply(b.ID, b.IP, m.config.HealthPort)
+	// The error is read back via lastSyncResult below rather than here, so
+	// the handler reports the user count alongside it.
+	_ = m.keyStore.syncAndApply(b.ID, b.IP, m.config.HealthPort)
 	return false
 }
 

--- a/internal/sentinel/key_resync_handler_test.go
+++ b/internal/sentinel/key_resync_handler_test.go
@@ -118,7 +118,10 @@ func TestKeyResyncHandler_SyncsNewBoxWithoutWaitingForTick(t *testing.T) {
 	m := managerWithBackend(t, "backend-a", backend)
 
 	// The state after the last periodic tick: only the pre-existing box.
-	m.keyStore.syncAndApply("backend-a", mustIP(t, backend), m.config.HealthPort)
+	// The error is ignored on purpose: this test asserts on the in-memory
+	// key state (next line), not on the sshpiper config write, which needs
+	// /etc/sshpiper and so depends on how the test host is set up.
+	_ = m.keyStore.syncAndApply("backend-a", mustIP(t, backend), m.config.HealthPort)
 	if got := syncedUsers(m.keyStore, "backend-a"); len(got) != 1 {
 		t.Fatalf("precondition: synced users = %v, want 1", got)
 	}

--- a/internal/sentinel/keysync.go
+++ b/internal/sentinel/keysync.go
@@ -277,23 +277,17 @@ func (ks *KeyStore) PushSentinelKey(backendIP string, httpPort int) error {
 
 // RunSyncLoop periodically syncs keys from a specific backend.
 // Blocks until ctx is cancelled.
+// A failed attempt is retried on the fast-retry schedule before falling
+// back to the interval (#953), so a blip costs seconds of stale sshpiper
+// routing rather than a full interval.
 func (ks *KeyStore) RunSyncLoop(ctx context.Context, backendID, backendIP string, httpPort int, interval time.Duration) {
 	log.Printf("[keysync] starting sync loop for backend %s (%s:%d, interval=%s)", backendID, backendIP, httpPort, interval)
 
-	ks.syncAndApply(backendID, backendIP, httpPort)
+	runSyncLoop(ctx, "keysync", interval, syncRetryDelays(interval), func() error {
+		return ks.syncAndApply(backendID, backendIP, httpPort)
+	})
 
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			log.Printf("[keysync] sync loop stopped for backend %s", backendID)
-			return
-		case <-ticker.C:
-			ks.syncAndApply(backendID, backendIP, httpPort)
-		}
-	}
+	log.Printf("[keysync] sync loop stopped for backend %s", backendID)
 }
 
 // RunSyncLoopLegacy is backward-compatible: uses "default" as backend ID.
@@ -301,7 +295,14 @@ func (ks *KeyStore) RunSyncLoopLegacy(ctx context.Context, backendIP string, htt
 	ks.RunSyncLoop(ctx, "default", backendIP, httpPort, interval)
 }
 
-func (ks *KeyStore) syncAndApply(backendID, backendIP string, httpPort int) {
+// syncAndApply pulls a backend's keys and rewrites the sshpiper config.
+//
+// The returned error reports whether this cycle fully succeeded, so the
+// periodic loop can fast-retry a transient failure (#953). It deliberately
+// does NOT retry internally: the event-driven resync endpoint calls this
+// synchronously from an HTTP handler, and a retry burst there would block
+// the response for minutes.
+func (ks *KeyStore) syncAndApply(backendID, backendIP string, httpPort int) error {
 	if err := ks.Sync(backendID, backendIP, httpPort); err != nil {
 		log.Printf("[keysync] sync failed for %s: %v", backendID, err)
 		if strings.Contains(err.Error(), "unexpected status 401") {
@@ -311,7 +312,7 @@ func (ks *KeyStore) syncAndApply(backendID, backendIP string, httpPort int) {
 				"fails with 'no matching pipe' (#687). Fix: set matching CONTAINARIUM_SENTINEL_AUTH_SECRET on both ends "+
 				"(BYOC hosts: `pool join --sentinel-auth-secret ...`).", backendID)
 		}
-		return
+		return err
 	}
 
 	ks.mu.RLock()
@@ -322,13 +323,17 @@ func (ks *KeyStore) syncAndApply(backendID, backendIP string, httpPort int) {
 	ks.mu.RUnlock()
 	log.Printf("[keysync] sync OK for %s: %d users", backendID, count)
 
-	if err := ks.PushSentinelKey(backendIP, httpPort); err != nil {
-		log.Printf("[keysync] push sentinel key failed for %s: %v", backendID, err)
+	// A failed push is worth retrying but must not abort the cycle: the
+	// pull already succeeded, and applying it is what keeps SSH working.
+	// Reported at the end so the loop still sees the cycle as incomplete.
+	pushErr := ks.PushSentinelKey(backendIP, httpPort)
+	if pushErr != nil {
+		log.Printf("[keysync] push sentinel key failed for %s: %v", backendID, pushErr)
 	}
 
 	if err := ks.Apply(); err != nil {
 		log.Printf("[keysync] apply failed: %v", err)
-		return
+		return err
 	}
 
 	ks.mu.RLock()
@@ -344,6 +349,7 @@ func (ks *KeyStore) syncAndApply(backendID, backendIP string, httpPort int) {
 	if changed {
 		log.Printf("[keysync] sshpiper routing table updated; new connections pick it up on next connect (no restart)")
 	}
+	return pushErr
 }
 
 func (ks *KeyStore) ensureBackendLocked(backendID, backendIP string) *backendKeys {

--- a/internal/sentinel/syncloop.go
+++ b/internal/sentinel/syncloop.go
@@ -1,0 +1,118 @@
+package sentinel
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// Fast retry after a failed sync (#953).
+//
+// Both sentinel sync loops used to drive their attempts off a plain
+// time.Ticker, so a single transient failure — a "connection refused"
+// landing in the daemon's restart window, a network blip, anything — cost a
+// FULL interval of staleness with no attempt in between.
+//
+// For keysync (2m interval) that is a minor delay. For certsync it is 6h:
+// one momentarily-closed listener could leave certificates stale for most
+// of a day. Hosts carrying the incus#755 restart-timer mitigation restart
+// the daemon every 3h, so they take that dice-roll repeatedly.
+//
+// The fix is a bounded burst of retries after a failure, deliberately NOT a
+// shorter steady-state interval. Those are different jobs: the interval
+// bounds normal-case request volume, while this bounds recovery time from a
+// failure we already know is usually transient. Shortening the interval
+// would pay for recovery with permanent extra load.
+const (
+	// syncRetryInitial is the first retry delay. Long enough that a daemon
+	// restart has a real chance to finish before we try again (so the retry
+	// is not simply spent hitting the same closed listener), short enough
+	// that recovery still feels immediate.
+	syncRetryInitial = 15 * time.Second
+
+	// syncRetryMax caps the delay growth, matching the RecoveryBackoffMax
+	// precedent in manager.go.
+	syncRetryMax = 5 * time.Minute
+
+	// maxSyncFastRetries bounds the burst. With the doubling schedule this
+	// is ~13 minutes of retrying for certsync, after which the regular
+	// interval takes over — an outage longer than the burst is no longer
+	// the transient blip this exists to absorb.
+	maxSyncFastRetries = 6
+)
+
+// syncRetryDelays returns the fast-retry schedule for a loop running at the
+// given interval: doubling from syncRetryInitial, capped per-delay at
+// syncRetryMax and in count at maxSyncFastRetries.
+//
+// It also truncates the schedule so no retry is scheduled at or after the
+// next regular tick — past that point the ticker does the same work anyway,
+// and a burst that outlived its own interval would stack attempts on top of
+// each other. That truncation is what keeps this safe for the 2m keysync
+// loop and useful for the 6h certsync loop with one shared schedule.
+func syncRetryDelays(interval time.Duration) []time.Duration {
+	var (
+		delays  []time.Duration
+		elapsed time.Duration
+	)
+	for d := syncRetryInitial; len(delays) < maxSyncFastRetries; d *= 2 {
+		if d > syncRetryMax {
+			d = syncRetryMax
+		}
+		if elapsed+d >= interval {
+			break
+		}
+		delays = append(delays, d)
+		elapsed += d
+	}
+	return delays
+}
+
+// runSyncLoop calls attempt every interval, and after any failed attempt
+// retries on the supplied schedule until one succeeds or the schedule is
+// exhausted. Blocks until ctx is done.
+//
+// attempt does its own success/failure logging (the two callers report
+// different things); the error is used only to decide whether to retry.
+//
+// The regular ticker is independent of the retry burst, so a recovered
+// failure does not shift the steady-state cadence — on the success path
+// this is byte-for-byte the old behaviour.
+func runSyncLoop(ctx context.Context, name string, interval time.Duration, delays []time.Duration, attempt func() error) {
+	runOnce := func() {
+		if err := attempt(); err == nil {
+			return
+		}
+		for i, d := range delays {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(d):
+			}
+			log.Printf("[%s] retrying after a failed sync (fast retry %d/%d, waited %s)",
+				name, i+1, len(delays), d)
+			if err := attempt(); err == nil {
+				log.Printf("[%s] recovered on fast retry %d — without this the next attempt "+
+					"would have been up to %s away", name, i+1, interval)
+				return
+			}
+		}
+		if len(delays) > 0 {
+			log.Printf("[%s] %d fast retries did not recover; falling back to the regular %s interval",
+				name, len(delays), interval)
+		}
+	}
+
+	runOnce()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			runOnce()
+		}
+	}
+}

--- a/internal/sentinel/syncloop_test.go
+++ b/internal/sentinel/syncloop_test.go
@@ -1,0 +1,221 @@
+package sentinel
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// #953: both sync loops drove attempts off a plain ticker, so one transient
+// failure cost a full interval of staleness — up to 6h for certsync.
+//
+// The schedule tests below are the load-bearing ones: they pin the two
+// properties that make a single shared schedule safe for a 2m loop and
+// useful for a 6h one.
+
+func TestSyncRetryDelays_KeysyncBurstFitsInsideItsInterval(t *testing.T) {
+	const interval = 2 * time.Minute
+	delays := syncRetryDelays(interval)
+
+	if len(delays) == 0 {
+		t.Fatal("no fast retries for the 2m keysync loop: a transient failure would " +
+			"still cost a full interval, which is the bug (#953)")
+	}
+
+	var total time.Duration
+	for _, d := range delays {
+		total += d
+	}
+	// The burst must finish before the next regular tick. Otherwise
+	// attempts stack on top of each other and the loop runs two
+	// overlapping sync schedules.
+	if total >= interval {
+		t.Errorf("retry burst totals %s for a %s interval — it would outlive its own "+
+			"interval and stack attempts; delays=%v", total, interval, delays)
+	}
+}
+
+func TestSyncRetryDelays_CertsyncRecoversInMinutesNotHours(t *testing.T) {
+	const interval = 6 * time.Hour
+	delays := syncRetryDelays(interval)
+
+	if len(delays) != maxSyncFastRetries {
+		t.Errorf("got %d retries for a %s interval, want the full %d — a long interval "+
+			"is precisely where the burst matters", len(delays), interval, maxSyncFastRetries)
+	}
+
+	var total time.Duration
+	for _, d := range delays {
+		total += d
+	}
+	// The point of the issue: a blip must not cost most of a day.
+	if total > 30*time.Minute {
+		t.Errorf("retry burst spans %s; that is too close to just waiting for the tick", total)
+	}
+	if total < time.Minute {
+		t.Errorf("retry burst spans only %s — too short to survive a daemon restart, "+
+			"which is the failure this exists to absorb", total)
+	}
+}
+
+// Delays must grow. A flat schedule either hammers a down backend or gives
+// up too soon; the doubling is what lets one schedule serve both loops.
+func TestSyncRetryDelays_AreNonDecreasingAndCapped(t *testing.T) {
+	delays := syncRetryDelays(6 * time.Hour)
+	for i := 1; i < len(delays); i++ {
+		if delays[i] < delays[i-1] {
+			t.Errorf("delay %d (%s) is shorter than delay %d (%s); the schedule must back off",
+				i, delays[i], i-1, delays[i-1])
+		}
+	}
+	for i, d := range delays {
+		if d > syncRetryMax {
+			t.Errorf("delay %d is %s, above the %s cap", i, d, syncRetryMax)
+		}
+	}
+	if len(delays) > 0 && delays[0] != syncRetryInitial {
+		t.Errorf("first retry is %s, want %s", delays[0], syncRetryInitial)
+	}
+}
+
+// An interval shorter than the first retry gets no burst at all, rather
+// than a retry scheduled after the next tick would already have run.
+func TestSyncRetryDelays_ShortIntervalGetsNoBurst(t *testing.T) {
+	if got := syncRetryDelays(time.Second); len(got) != 0 {
+		t.Errorf("got %v for a 1s interval, want none — the tick is sooner than any retry", got)
+	}
+}
+
+// recordingAttempt returns an attempt func that fails the first failures
+// times, then succeeds, recording how many times it ran.
+func recordingAttempt(failures int) (func() error, func() int) {
+	var (
+		mu sync.Mutex
+		n  int
+	)
+	return func() error {
+			mu.Lock()
+			defer mu.Unlock()
+			n++
+			if n <= failures {
+				return errors.New("transient")
+			}
+			return nil
+		}, func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return n
+		}
+}
+
+// The behaviour the issue asks for: a failed attempt is retried promptly
+// instead of waiting for the next tick.
+func TestRunSyncLoop_RetriesAfterAFailure(t *testing.T) {
+	attempt, count := recordingAttempt(2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// A long interval so a passing test cannot be explained by the
+		// regular tick firing — only retries can produce >1 attempt here.
+		runSyncLoop(ctx, "test", time.Hour,
+			[]time.Duration{time.Millisecond, time.Millisecond, time.Millisecond}, attempt)
+	}()
+
+	waitFor(t, func() bool { return count() == 3 })
+	cancel()
+	<-done
+
+	if got := count(); got != 3 {
+		t.Errorf("attempts = %d, want 3 (initial + 2 retries)", got)
+	}
+}
+
+// Steady state must be untouched: on success there are no extra requests.
+// A regression here would multiply request volume against every backend.
+func TestRunSyncLoop_SuccessCostsExactlyOneAttempt(t *testing.T) {
+	attempt, count := recordingAttempt(0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runSyncLoop(ctx, "test", time.Hour,
+			[]time.Duration{time.Millisecond, time.Millisecond}, attempt)
+	}()
+
+	waitFor(t, func() bool { return count() >= 1 })
+	time.Sleep(50 * time.Millisecond) // long enough for the retries to have fired
+	cancel()
+	<-done
+
+	if got := count(); got != 1 {
+		t.Errorf("attempts = %d, want exactly 1 — a successful sync must not retry", got)
+	}
+}
+
+// The burst is bounded. An unreachable backend must not become an infinite
+// retry loop hammering it.
+func TestRunSyncLoop_BurstIsBounded(t *testing.T) {
+	attempt, count := recordingAttempt(1000) // never succeeds
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runSyncLoop(ctx, "test", time.Hour,
+			[]time.Duration{time.Millisecond, time.Millisecond}, attempt)
+	}()
+
+	waitFor(t, func() bool { return count() == 3 })
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := count(); got != 3 {
+		t.Errorf("attempts = %d, want 3 (initial + 2 retries, then stop)", got)
+	}
+}
+
+// A cancelled context must abandon the burst promptly — the sentinel should
+// not linger for minutes on shutdown waiting out a retry delay.
+func TestRunSyncLoop_CancelInterruptsTheRetryWait(t *testing.T) {
+	attempt, count := recordingAttempt(1000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runSyncLoop(ctx, "test", time.Hour, []time.Duration{time.Hour, time.Hour}, attempt)
+	}()
+
+	waitFor(t, func() bool { return count() >= 1 })
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSyncLoop did not return after cancel: it is blocked on a retry delay")
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("timed out waiting for condition")
+}

--- a/internal/sentinel/syncloop_test.go
+++ b/internal/sentinel/syncloop_test.go
@@ -80,6 +80,31 @@ func TestSyncRetryDelays_AreNonDecreasingAndCapped(t *testing.T) {
 	}
 }
 
+// The invariant the whole design rests on, checked across the range of
+// intervals a loop could plausibly be configured with rather than just the
+// two in use today.
+//
+// If a burst ever outlived its interval, time.Ticker would buffer a tick
+// (its channel holds one) and fire it the instant the burst returned —
+// stacking a fresh cycle straight onto the previous one and running two
+// overlapping schedules against the same backend.
+func TestSyncRetryDelays_BurstNeverExceedsInterval(t *testing.T) {
+	for _, interval := range []time.Duration{
+		time.Second, 10 * time.Second, 30 * time.Second, time.Minute,
+		2 * time.Minute, 5 * time.Minute, 15 * time.Minute, time.Hour,
+		3 * time.Hour, 6 * time.Hour, 24 * time.Hour,
+	} {
+		var total time.Duration
+		for _, d := range syncRetryDelays(interval) {
+			total += d
+		}
+		if total >= interval {
+			t.Errorf("interval=%s burst=%s — the burst must stay strictly under the interval, "+
+				"or ticks buffer and cycles stack", interval, total)
+		}
+	}
+}
+
 // An interval shorter than the first retry gets no burst at all, rather
 // than a retry scheduled after the next tick would already have run.
 func TestSyncRetryDelays_ShortIntervalGetsNoBurst(t *testing.T) {


### PR DESCRIPTION
Closes #953.

### The gap

Both sentinel sync loops drove their attempts off a plain `time.Ticker`, so a single transient failure — the "connection refused" the issue reports, a network blip, anything — cost a **full interval** of staleness with no attempt in between.

- **keysync** (2m): sshpiper's routing table stale for up to ~2 min. Minor.
- **certsync** (6h): certificates stale for **most of a day** because of one momentarily-closed listener. This is the consequential half, and hosts carrying the incus#755 restart-timer mitigation restart the daemon every 3h — so they take that dice-roll repeatedly.

### The fix

A bounded burst of retries after a failure, deliberately **not** a shorter steady-state interval. Those are different jobs: the interval bounds normal-case request volume, while this bounds recovery time from a failure we already know is usually transient. Shortening the interval would pay for recovery with permanent extra load.

One schedule serves both loops because it's derived from the interval — delays double from 15s, capped at 5m (matching the `RecoveryBackoffMax` precedent in `manager.go`) and at 6 retries, then **truncated so no retry is scheduled at or after the next regular tick**. That truncation is what makes a single schedule safe for the 2m loop and useful for the 6h one:

| loop | interval | schedule | burst | worst-case staleness |
| --- | --- | --- | --- | --- |
| keysync | 2m | `15s 30s 1m` | 1m45s | 2m → **1m45s** |
| certsync | 6h | `15s 30s 1m 2m 4m 5m` | 12m45s | 6h → **~13m** |

### Where the retry does *not* go

`syncAndApply` now returns an error so the loop can see a failed cycle, but it does **not** retry internally: the event-driven resync endpoint calls it synchronously from an HTTP handler, and a retry burst there would block the response for minutes.

A failed sentinel-key push no longer aborts the cycle either — the pull already succeeded, and applying it is what keeps SSH working — but it's still reported, so the loop treats the cycle as incomplete and retries it.

### Tests

Schedule: fits inside its own interval (otherwise attempts stack); recovers in minutes not hours; non-decreasing and capped; no burst at all when the tick is sooner than any retry.

Loop: retries after a failure; **a success costs exactly one attempt** (a regression here would multiply request volume against every backend); the burst is bounded so an unreachable backend isn't hammered forever; cancel interrupts a pending retry so shutdown isn't held up.

Mutation-tested: removing the schedule and reverting the loop to a plain ticker each fail, naming the defect.

### Note on local verification

`internal/sentinel` has 5 tests that need `CAP_NET_ADMIN`/root (loopback aliases, `/etc/sshpiper`) and fail in my unprivileged sandbox **on clean `main` too** — verified before and after. Everything else passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)