### PR TITLE
fix(ci): gate every PR, not only those targeting main

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,8 +9,13 @@ name: golangci-lint
 on:
   push:
     branches: [main]
+  # No `branches:` filter here, deliberately (#1215). Filtering PRs to base
+  # `main` gives a PR targeting any other branch — i.e. every stacked PR —
+  # ZERO checks: not failing, not pending, just absent. That is
+  # indistinguishable from "CI hasn't started yet", so an ungated PR reads as
+  # ready to merge. `push` stays pinned to main so branch pushes don't
+  # double-run alongside the PR.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -5,8 +5,11 @@ on:
     branches: [main]
     paths:
       - 'charts/**'
+  # No `branches:` filter — a base filter leaves stacked PRs with no checks
+  # at all, which looks the same as checks not having started (#1215). The
+  # `paths` filter stays: scoping by what changed is intentional, scoping by
+  # base branch was not.
   pull_request:
-    branches: [main]
     paths:
       - 'charts/**'
 

--- a/.github/workflows/proxyproto-e2e.yml
+++ b/.github/workflows/proxyproto-e2e.yml
@@ -3,8 +3,9 @@ name: PROXY Protocol E2E
 on:
   push:
     branches: [main]
+  # No `branches:` filter — a base filter leaves stacked PRs with no checks
+  # at all, which looks the same as checks not having started (#1215).
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,8 +3,11 @@ name: Security Scanning
 on:
   push:
     branches: [main]
+  # No `branches:` filter — a base filter leaves stacked PRs with no checks
+  # at all, which looks the same as checks not having started (#1215). That
+  # matters most here: gosec, govulncheck and Trivy are the checks least
+  # likely to be missed by eye when they are silently absent.
   pull_request:
-    branches: [main]
   schedule:
     # Run weekly on Monday at 06:00 UTC
     - cron: '0 6 * * 1'

--- a/internal/ci/workflow_gating_test.go
+++ b/internal/ci/workflow_gating_test.go
@@ -1,0 +1,176 @@
+// Package ci holds guards over this repo's CI configuration itself.
+//
+// The workflows decide whether anything else in the repo is checked at all,
+// so a mistake in them is invisible in exactly the way a mistake in normal
+// code is not: nothing goes red, a check simply stops existing.
+package ci
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const workflowDir = "../../.github/workflows"
+
+// workflowFile models only the trigger section — the rest of a workflow is
+// not this test's business.
+//
+// `on` is decoded as raw nodes rather than a struct because the distinction
+// this whole file turns on is *key present but empty* vs *key absent*:
+//
+//	pull_request:              # present, unfiltered — gates every PR
+//	pull_request:              # present, filtered — gates only some
+//	  branches: [main]
+//	(no pull_request key)      # absent — gates nothing
+//
+// A bare `pull_request:` is YAML null, so decoding into a *struct pointer
+// yields nil and makes the first case indistinguishable from the third. The
+// first draft of this test did exactly that and passed vacuously for the
+// three workflows it was written to protect.
+type workflowFile struct {
+	Name string               `yaml:"name"`
+	On   map[string]yaml.Node `yaml:"on"`
+}
+
+type triggerFilter struct {
+	Branches []string `yaml:"branches"`
+	Paths    []string `yaml:"paths"`
+	Tags     []string `yaml:"tags"`
+	Types    []string `yaml:"types"`
+}
+
+// trigger returns the named trigger's filters and whether the key is present
+// at all. A present-but-empty trigger returns a zero filter and true.
+func (w workflowFile) trigger(t *testing.T, name string) (triggerFilter, bool) {
+	t.Helper()
+	node, ok := w.On[name]
+	if !ok {
+		return triggerFilter{}, false
+	}
+	// Null (bare `pull_request:`) — present, no filters, gates everything.
+	if node.Kind == 0 || node.Tag == "!!null" {
+		return triggerFilter{}, true
+	}
+	var f triggerFilter
+	if err := node.Decode(&f); err != nil {
+		t.Fatalf("decode %s trigger in %s: %v", name, w.Name, err)
+	}
+	return f, true
+}
+
+func loadWorkflows(t *testing.T) map[string]workflowFile {
+	t.Helper()
+	entries, err := os.ReadDir(workflowDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", workflowDir, err)
+	}
+
+	out := map[string]workflowFile{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || (!strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".yaml")) {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(workflowDir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		var wf workflowFile
+		if err := yaml.Unmarshal(b, &wf); err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		out[name] = wf
+	}
+	if len(out) == 0 {
+		t.Fatal("no workflow files found — this guard would pass vacuously")
+	}
+	return out
+}
+
+// A base-branch filter on pull_request means a PR targeting anything other
+// than main gets ZERO checks — not failing, not pending, absent. `gh pr
+// checks` reports "no checks reported on the branch" and the PR page shows
+// no status section at all.
+//
+// That is the dangerous shape: an unchecked PR is visually identical to one
+// whose checks haven't started, so the natural reading is "wait a moment"
+// and the natural next step is to merge. Main-branch protection is no
+// backstop, because a stacked PR by definition doesn't merge into main, so
+// the required-checks rule never engages for it (#1215).
+//
+// Retargeting the PR at main afterwards does not help either: changing a
+// PR's base does not re-fire `pull_request` (the `edited` activity type
+// isn't in the default trigger set), so a retargeted PR stays ungated until
+// it is closed and reopened.
+func TestPullRequestTriggersAreNotBaseFiltered(t *testing.T) {
+	var offenders []string
+
+	for name, wf := range loadWorkflows(t) {
+		pr, present := wf.trigger(t, "pull_request")
+		if !present {
+			continue // not a PR-gating workflow; push/tag/schedule only
+		}
+		if len(pr.Branches) > 0 {
+			offenders = append(offenders,
+				name+" (branches: "+strings.Join(pr.Branches, ", ")+")")
+		}
+	}
+
+	sort.Strings(offenders)
+	if len(offenders) > 0 {
+		t.Errorf("these workflows filter pull_request by base branch, so any PR not targeting "+
+			"that branch runs NONE of them and shows no checks at all (#1215):\n  %s\n"+
+			"Drop the `branches:` filter under `pull_request:`. Keep it under `push:` — "+
+			"that one is what stops branch pushes double-running alongside the PR.",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+// The counterpart: `push` SHOULD stay pinned, otherwise every push to every
+// branch runs the full suite a second time alongside the PR's own run. The
+// fix for #1215 is to unfilter one trigger, not both.
+func TestPushTriggersStayPinnedToMain(t *testing.T) {
+	for name, wf := range loadWorkflows(t) {
+		push, present := wf.trigger(t, "push")
+		if !present {
+			continue
+		}
+		// Tag-triggered release workflows legitimately have no branch filter.
+		if len(push.Tags) > 0 {
+			continue
+		}
+		if len(push.Branches) == 0 {
+			t.Errorf("%s: `push` has no branches filter, so every push to every branch "+
+				"runs it again alongside the PR's own run", name)
+		}
+	}
+}
+
+// A workflow with no pull_request trigger at all contributes nothing to PR
+// gating. That can be correct (release/tag workflows), so this only reports
+// what the set is — it exists so a reviewer can see at a glance which
+// workflows do and don't gate a PR, rather than inferring it from 13 files.
+func TestReportWorkflowGatingCoverage(t *testing.T) {
+	var gating, notGating []string
+	for name, wf := range loadWorkflows(t) {
+		pr, present := wf.trigger(t, "pull_request")
+		if !present {
+			notGating = append(notGating, name)
+			continue
+		}
+		suffix := ""
+		if len(pr.Paths) > 0 {
+			suffix = " (path-scoped)"
+		}
+		gating = append(gating, name+suffix)
+	}
+	sort.Strings(gating)
+	sort.Strings(notGating)
+	t.Logf("gate PRs (%d): %s", len(gating), strings.Join(gating, ", "))
+	t.Logf("do not gate PRs (%d): %s", len(notGating), strings.Join(notGating, ", "))
+}


### PR DESCRIPTION
Closes #1215.

### The gap

Four workflows filtered `pull_request` to base `main` — `golangci-lint`, `helm-lint`, `proxyproto-e2e`, and `security`. A PR targeting any other branch, i.e. **every stacked PR**, ran none of them.

The danger isn't the missing coverage, it's how it presents: not failing, not pending, **absent**. `gh pr checks` reports "no checks reported on the branch" and the PR page shows no status section at all — which is exactly what a PR whose checks haven't started yet looks like. The natural reading is "wait a moment"; the natural next step is to merge, because nothing is objecting.

Branch protection is no backstop: a stacked PR by definition doesn't merge into `main`, so the required-checks rule never engages for it.

`security.yml` mattered most here — gosec, govulncheck and Trivy are the checks least likely to be missed by eye when they're silently absent.

### The fix

The issue's **option 1**: drop the `branches:` filter under `pull_request:`.

- `push:` stays pinned to `main` — that's what stops branch pushes double-running alongside the PR's own run.
- `helm-lint` keeps its `paths:` filter. Scoping by *what changed* was intentional; scoping by *base branch* was not.

Verified after the change — all 13 workflows still parse, and the gating set is now:

```
gate PRs (9):        agent-box-image, distros-go-ci, distros-py-ci, golangci-lint,
                     helm-lint, k8s-e2e, proxyproto-e2e, security, sshpiper-image
do not gate PRs (4): containarium-daemon, distros-py-release, release, sidecars
```

Those four are all tag/`workflow_dispatch` release workflows, legitimately not PR-gating.

### Guard

`internal/ci` pins it, plus the **inverse** guard so the fix isn't over-applied — `push` must stay pinned, or every branch push runs the suite a second time. Mutation-tested both ways.

### The guard's own first draft was vacuous

Worth recording, because it's the same failure mode: a bare `pull_request:` key is YAML **null**, so decoding it into a struct pointer yields `nil` and makes "gates every PR" indistinguishable from "gates nothing". The first draft passed for all three workflows it was written to protect, no matter what I did to them.

What caught it was the coverage report — added only so a reviewer could see the gating set at a glance — which listed the just-fixed files under "do not gate PRs". The loader now distinguishes key-absent from key-present-and-empty.

### Note

This PR can't demonstrate the fix on itself: it targets `main`, so it was gated either way. The evidence is the parse output above plus the mutation tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)