### PR TITLE
fix(mcp): count what list_containers rendered, not what the daemon claimed

### DIFF
--- a/internal/mcp/list_count_test.go
+++ b/internal/mcp/list_count_test.go
@@ -1,0 +1,123 @@
+package mcp
+
+// #1214: list_containers printed "Found 0 container(s):" and then listed the
+// whole fleet. Cosmetic for a human, who sees the boxes underneath. Not
+// cosmetic for an agent: the count is the first token in the response and
+// directly contradicts the payload, and an agent that concludes a backend is
+// empty — and therefore safe to wipe — is making the "orphan" inference that
+// has already deleted a live container here once.
+//
+// The summary line is now derived from the rendered list, so it cannot
+// disagree with it whatever the daemon reports.
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// noTotalCount tells listServer to omit the totalCount field entirely, the
+// way a daemon that never populates it would.
+const noTotalCount = -1
+
+// listServer returns a stub daemon emitting n containers, with whatever
+// totalCount the caller wants to claim.
+func listServer(t *testing.T, n int, claimedTotal int) *httptest.Server {
+	t.Helper()
+	var boxes []string
+	for i := 0; i < n; i++ {
+		boxes = append(boxes, fmt.Sprintf(
+			`{"name":"box%d","username":"cld-%d","state":"CONTAINER_STATE_RUNNING"}`, i, i))
+	}
+	total := fmt.Sprintf(`,"totalCount":%d`, claimedTotal)
+	if claimedTotal == noTotalCount {
+		total = ""
+	}
+	body := fmt.Sprintf(`{"containers":[%s]%s}`, strings.Join(boxes, ","), total)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// countRendered counts the container entries actually printed.
+func countRendered(out string) int {
+	return strings.Count(out, "📦 ")
+}
+
+// summaryCount extracts N from "Found N container(s):".
+func summaryCount(t *testing.T, out string) int {
+	t.Helper()
+	const prefix = "Found "
+	i := strings.Index(out, prefix)
+	require.GreaterOrEqual(t, i, 0, "output has no summary line:\n%s", out)
+	rest := out[i+len(prefix):]
+	j := strings.Index(rest, " ")
+	require.Greater(t, j, 0, "malformed summary line")
+	n, err := strconv.Atoi(rest[:j])
+	require.NoError(t, err, "summary count is not a number: %q", rest[:j])
+	return n
+}
+
+// The acceptance criterion: summary agrees with body for a NON-EMPTY list.
+// The empty case already read correctly (its guard uses len(resp.Containers)),
+// which is exactly why the bug survived — the only covered case was the one
+// that worked.
+//
+// The stub omits totalCount rather than setting it correctly. Setting it
+// correctly would make this test pass with the bug still in place, since
+// both sides would happen to agree — a test that cannot fail, which is the
+// same shape of mistake as the bug itself.
+func TestListContainers_SummaryAgreesWithBody(t *testing.T) {
+	for _, n := range []int{1, 3, 31} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			out, err := handleListContainers(NewClient(listServer(t, n, noTotalCount).URL, "t"), map[string]interface{}{})
+			require.NoError(t, err)
+
+			assert.Equal(t, n, summaryCount(t, out), "summary line disagrees with the request")
+			assert.Equal(t, n, countRendered(out), "rendered entries disagree with the request")
+			assert.Equal(t, countRendered(out), summaryCount(t, out),
+				"summary line and body must never disagree — that is what makes this a trap for an agent")
+		})
+	}
+}
+
+// The live shape of the bug: a daemon that reports totalCount=0 while
+// returning a full fleet. The MCP server and the daemon are released and
+// upgraded separately, so an MCP build will meet daemons that populate the
+// field and daemons that don't; the summary must be right against both.
+func TestListContainers_CountIgnoresAWrongTotalCount(t *testing.T) {
+	out, err := handleListContainers(NewClient(listServer(t, 31, 0).URL, "t"), map[string]interface{}{})
+	require.NoError(t, err)
+
+	assert.NotContains(t, out, "Found 0 container(s)",
+		"reported 0 while listing a full fleet — an agent reading this can conclude the backend is empty (#1214)")
+	assert.Equal(t, 31, summaryCount(t, out))
+	assert.Equal(t, 31, countRendered(out))
+}
+
+// A daemon over-reporting is the same defect in the other direction: the
+// summary must still describe what was rendered.
+func TestListContainers_CountIgnoresAnInflatedTotalCount(t *testing.T) {
+	out, err := handleListContainers(NewClient(listServer(t, 2, 900).URL, "t"), map[string]interface{}{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, summaryCount(t, out), "summary must count what it printed, not what the daemon claimed")
+	assert.NotContains(t, out, "900")
+}
+
+// The empty case must keep its distinct message rather than falling into
+// "Found 0 container(s):" with nothing after it.
+func TestListContainers_EmptyStaysDistinct(t *testing.T) {
+	out, err := handleListContainers(NewClient(listServer(t, 0, 0).URL, "t"), map[string]interface{}{})
+	require.NoError(t, err)
+	assert.Equal(t, "No containers found.", out)
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1565,7 +1565,18 @@ func handleListContainers(client API, args map[string]interface{}) (string, erro
 		return "No containers found.", nil
 	}
 
-	result := fmt.Sprintf("Found %d container(s):\n\n", resp.TotalCount)
+	// Count what is actually rendered, not what the daemon claimed (#1214).
+	//
+	// resp.TotalCount is a separate field that can disagree with the list
+	// below — most easily against a daemon that doesn't populate it, since
+	// the MCP server and the daemon are released and upgraded separately.
+	// A summary line that contradicts its own body is a trap for an agent:
+	// "Found 0 container(s)" is the kind of thing a caller acts on, and
+	// concluding a backend is empty (and therefore safe to wipe) has already
+	// cost a live container here once.
+	//
+	// len() cannot drift from what follows it.
+	result := fmt.Sprintf("Found %d container(s):\n\n", len(resp.Containers))
 	for _, container := range resp.Containers {
 		result += fmt.Sprintf("📦 %s\n", container.Name)
 		result += fmt.Sprintf("   Username: %s\n", container.Username)


### PR DESCRIPTION
Closes #1214.

### The defect

`list_containers` printed the separate `TotalCount` field, which can disagree with the list underneath it — `Found 0 container(s):` followed by the whole fleet.

Cosmetic for a human, who sees the boxes. **Not cosmetic for an agent**: the count is the first token in the response and directly contradicts the payload. An agent that concludes a backend is empty — and therefore safe to wipe — is making the "orphan" inference that has already deleted a live container here once. Any tool whose summary line can disagree with its own body is a trap for automated callers.

### The fix

The issue's preferred option: `len(resp.Containers)`. It cannot drift from what is actually rendered, and it matches the sibling handler at `tools.go:1915`, which already counts `len(resp.Metrics)`.

### A correction to the stated cause

The issue says nothing populates `TotalCount`. That doesn't hold against current `main`:

- `ListContainers` **does** set it — `container_server.go:995`, and that's the function's **only** return, so there's no early-return path that skips it.
- The client struct tag is `json:"totalCount"`, matching the gateway's `UseProtoNames: false` lowerCamelCase output (`gateway.go:382`).
- `testdata/list_containers_response.json` already pins that decode (`totalCount: 3`).

So the field isn't simply unset in this tree. What does explain the live report is **version skew**: the MCP server and the daemon ship and upgrade separately, so any MCP build meets daemons that populate the field and daemons that don't.

That makes the fix *more* worth doing, not less — deriving the count from the rendered list is correct against every daemon version, whichever end was stale. It just means this is a robustness fix rather than the one-line oversight the issue describes.

### Acceptance criteria

- [x] Count matches the number listed.
- [x] A test asserts summary agrees with body for a **non-empty** list (1, 3, 31 containers). The empty case already read correctly — its guard uses `len(resp.Containers)` — which is precisely why the bug survived: the only covered case was the one that worked.
- [x] Sibling handlers checked — `TotalCount` has exactly **one** use in `internal/mcp`, so none share the pattern.

### On the tests themselves

The stub deliberately **omits** `totalCount` in the agreement test rather than setting it correctly. Setting it correctly makes that test pass with the bug still present, because both sides happen to agree — a test that cannot fail, which is the same shape of mistake as the bug. My first draft did exactly that; it's fixed here.

Mutation-tested: restoring `resp.TotalCount` fails all three tests and reproduces the report verbatim — `Found 0 container(s):` followed by 31 boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)