### PR TITLE
chore: anonymize concrete backend hostnames in test fixtures

### DIFF
--- a/internal/cloud/rest_test.go
+++ b/internal/cloud/rest_test.go
@@ -79,7 +79,7 @@ func TestEnrollREST(t *testing.T) {
 	defer srv.Close()
 
 	id, bearer, err := enrollREST(context.Background(), srv.URL, "host-123.secret",
-		EnrollOptions{DriverToken: "admin.jwt", OSSBackendID: "tunnel-fts-13700k"})
+		EnrollOptions{DriverToken: "admin.jwt", OSSBackendID: "tunnel-gpu-node-a"})
 	if err != nil {
 		t.Fatalf("enrollREST: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestEnrollREST(t *testing.T) {
 	if bearer != "host-123.secret" {
 		t.Errorf("bearer = %q, want host-123.secret (first enroll: response id matches the token's own id)", bearer)
 	}
-	if got.GetJoinToken() != "host-123.secret" || got.GetDriverToken() != "admin.jwt" || got.GetOssBackendId() != "tunnel-fts-13700k" {
+	if got.GetJoinToken() != "host-123.secret" || got.GetDriverToken() != "admin.jwt" || got.GetOssBackendId() != "tunnel-gpu-node-a" {
 		t.Errorf("server saw join=%q driver=%q backend=%q", got.GetJoinToken(), got.GetDriverToken(), got.GetOssBackendId())
 	}
 }

--- a/internal/mcp/backend_display_test.go
+++ b/internal/mcp/backend_display_test.go
@@ -16,13 +16,13 @@ import (
 
 func TestListContainers_ShowsBackendAndPool(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{"containers":[{"name":"box1","username":"cld-1","state":"running","backendId":"tunnel-fts-13700k","pool":"gpu-pool"}],"totalCount":1}`))
+		_, _ = w.Write([]byte(`{"containers":[{"name":"box1","username":"cld-1","state":"running","backendId":"tunnel-gpu-node-a","pool":"gpu-pool"}],"totalCount":1}`))
 	}))
 	defer server.Close()
 
 	out, err := handleListContainers(NewClient(server.URL, "t"), map[string]interface{}{})
 	require.NoError(t, err)
-	assert.Contains(t, out, "Backend: tunnel-fts-13700k")
+	assert.Contains(t, out, "Backend: tunnel-gpu-node-a")
 	assert.Contains(t, out, "Pool: gpu-pool")
 }
 
@@ -30,32 +30,32 @@ func TestCreateContainer_ShowsBackend_AndFallbackWarning(t *testing.T) {
 	// Server reports the box landed on the default GCP backend, regardless of
 	// the requested backend_id — the silent-fallback case.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{"container":{"name":"box1","username":"cld-1","state":"running","backendId":"containarium-jump-ase1-spot"},"message":"created"}`))
+		_, _ = w.Write([]byte(`{"container":{"name":"box1","username":"cld-1","state":"running","backendId":"cloud-backend-spot"},"message":"created"}`))
 	}))
 	defer server.Close()
 
 	out, err := handleCreateContainer(NewClient(server.URL, "t"), map[string]interface{}{
 		"username":   "cld-1",
-		"backend_id": "tunnel-fts-13700k", // requested
+		"backend_id": "tunnel-gpu-node-a", // requested
 	})
 	require.NoError(t, err)
-	assert.Contains(t, out, "Backend: containarium-jump-ase1-spot")
+	assert.Contains(t, out, "Backend: cloud-backend-spot")
 	assert.Contains(t, out, "⚠️", "must warn when the box landed on a different backend than requested")
-	assert.Contains(t, out, "tunnel-fts-13700k", "warning should name the requested backend")
+	assert.Contains(t, out, "tunnel-gpu-node-a", "warning should name the requested backend")
 }
 
 func TestCreateContainer_NoWarningWhenBackendMatches(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{"container":{"name":"box1","username":"cld-1","state":"running","backendId":"tunnel-fts-13700k"},"message":"created"}`))
+		_, _ = w.Write([]byte(`{"container":{"name":"box1","username":"cld-1","state":"running","backendId":"tunnel-gpu-node-a"},"message":"created"}`))
 	}))
 	defer server.Close()
 
 	out, err := handleCreateContainer(NewClient(server.URL, "t"), map[string]interface{}{
 		"username":   "cld-1",
-		"backend_id": "tunnel-fts-13700k",
+		"backend_id": "tunnel-gpu-node-a",
 	})
 	require.NoError(t, err)
-	assert.Contains(t, out, "Backend: tunnel-fts-13700k")
+	assert.Contains(t, out, "Backend: tunnel-gpu-node-a")
 	assert.NotContains(t, out, "⚠️", "no warning when landed backend == requested")
 }
 
@@ -63,7 +63,7 @@ func TestDeleteContainer_ShowsBackend(t *testing.T) {
 	// Delete pre-fetches the box (GET) to learn its backend, then deletes.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			_, _ = w.Write([]byte(`{"container":{"name":"box1","username":"cld-1","state":"running","backendId":"tunnel-fts-13700k"}}`))
+			_, _ = w.Write([]byte(`{"container":{"name":"box1","username":"cld-1","state":"running","backendId":"tunnel-gpu-node-a"}}`))
 			return
 		}
 		_, _ = w.Write([]byte(`{"message":"container cld-1 deleted","containerName":"cld-1"}`))
@@ -73,7 +73,7 @@ func TestDeleteContainer_ShowsBackend(t *testing.T) {
 	out, err := handleDeleteContainer(NewClient(server.URL, "t"), map[string]interface{}{"username": "cld-1"})
 	require.NoError(t, err)
 	assert.Contains(t, out, "deleted")
-	assert.Contains(t, out, "Backend: tunnel-fts-13700k")
+	assert.Contains(t, out, "Backend: tunnel-gpu-node-a")
 }
 
 // The GET pre-fetch is best-effort: if it fails, delete still succeeds (just

--- a/internal/mcp/backends_decode_test.go
+++ b/internal/mcp/backends_decode_test.go
@@ -15,7 +15,7 @@ func TestListBackends_DecodesProtoJSONStringInts(t *testing.T) {
 	wire := `{
 	  "backends": [
 	    {
-	      "id": "tunnel-fts-13700k-gpu",
+	      "id": "tunnel-gpu-node-a-gpu",
 	      "type": "tunnel",
 	      "healthy": true,
 	      "uptimeSeconds": "123456",

--- a/internal/mcp/testdata/list_backends_response.json
+++ b/internal/mcp/testdata/list_backends_response.json
@@ -12,11 +12,11 @@
       "containerCount": 16
     },
     {
-      "id": "tunnel-fts-13700k-gpu",
+      "id": "tunnel-gpu-node-a-gpu",
       "type": "tunnel",
       "healthy": true,
       "lastSeenAt": "2026-05-10T18:59:42Z",
-      "hostname": "fts-13700k",
+      "hostname": "gpu-node-a",
       "os": "Ubuntu 24.04.1 LTS",
       "containerCount": 4,
       "gpus": [
@@ -24,11 +24,11 @@
       ]
     },
     {
-      "id": "tunnel-fts-5900x-gpu",
+      "id": "tunnel-gpu-node-b-gpu",
       "type": "tunnel",
       "healthy": false,
       "lastSeenAt": "2026-05-10T18:42:00Z",
-      "hostname": "fts-5900x",
+      "hostname": "gpu-node-b",
       "os": "Ubuntu 24.04.1 LTS",
       "containerCount": 0,
       "gpus": [


### PR DESCRIPTION
### Why

`CLAUDE.md` requires anonymizing anything naming a specific deployment in files that ship with the repo, and lists **"concrete backend / lab node hostnames"** first in its table. `internal/mcp/wire_format_test.go` says the same in its own words:

> To refresh a fixture, capture a real response with curl, scrub hostnames / IPs / customer container names down to demo values (alice/bob), and replace it. **Don't check in raw production data.**

Four files carried names that read as real machines rather than demo values — CPU-model lab nodes, and what looks like a cloud instance name carrying its region and provisioning model.

### What changed

| before | after |
| --- | --- |
| `tunnel-fts-13700k` / `fts-13700k` | `tunnel-gpu-node-a` / `gpu-node-a` |
| `tunnel-fts-5900x` / `fts-5900x` | `tunnel-gpu-node-b` / `gpu-node-b` |
| `containarium-jump-ase1-spot` | `cloud-backend-spot` |

Test-only: `internal/cloud/rest_test.go`, `internal/mcp/backend_display_test.go`, `internal/mcp/backends_decode_test.go`, `internal/mcp/testdata/list_backends_response.json`.

### The tell

The scrub had been **started and then stopped**. In `list_backends_response.json` the first entry is already `demo-backend-local` under `example-project` — deliberately anonymized — while the two tunnel entries directly beneath it kept their original hostnames. That's exactly the failure the policy's "grep the diff before pushing" step exists to catch.

### On not weakening the tests

The substitutes preserve everything the tests assert on: a healthy tunnel GPU backend, a second unhealthy one, and a **distinct** cloud backend id (the silent-fallback warning test needs the landed backend to differ from the requested one). No assertion was relaxed to make this pass. GPU models are left alone — plausible demo data, and they name no host.

### Caveat

I can't confirm from here whether these are live hosts. That's precisely the case the policy addresses — *"if you're not sure, anonymize."* The cost is a `sed`; the cost of leaving them is that a public repo keeps telling readers which machines exist and what runs on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)