### PR TITLE
fix(scripts): drop the sshd Match block that makes sshd refuse to start

### DIFF
--- a/internal/cmd/sshd_dropin_test.go
+++ b/internal/cmd/sshd_dropin_test.go
@@ -1,0 +1,170 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Guards over the sshd settings setup-ssh-container-proxy.sh installs (#1137).
+//
+// The incident shape: the script wrote PrintMotd/PrintLastLog inside a
+// `Match` block. Those directives are not permitted inside Match, so the
+// whole sshd config became unparseable and sshd refused to start on its next
+// restart — taking SSH to the backend host down, and with it every box on
+// that backend, since sshpiper's upstream is that host's sshd.
+//
+// Everything else kept running and the backend still reported healthy, so
+// nothing surfaced the outage until someone tried to connect; recovery
+// needed the machine's console. The trigger was whatever restarted sshd
+// next, in practice an unattended-upgrades openssh update at an arbitrary
+// later time — which is why this must be caught at build time and not left
+// to "it worked when we ran it".
+
+const sshProxyScript = "../../scripts/setup-ssh-container-proxy.sh"
+
+func readSSHProxyScript(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(sshProxyScript)
+	if err != nil {
+		t.Fatalf("read %s: %v", sshProxyScript, err)
+	}
+	return string(b)
+}
+
+// sshdConfigBlocks returns the SSHDEOF heredoc bodies the script writes into
+// sshd configuration — the exact text that lands on a host.
+func sshdConfigBlocks(t *testing.T) []string {
+	t.Helper()
+	// Non-greedy so each heredoc is captured separately.
+	re := regexp.MustCompile(`(?s)<< 'SSHDEOF'\n(.*?)\nSSHDEOF`)
+	matches := re.FindAllStringSubmatch(readSSHProxyScript(t), -1)
+
+	var blocks []string
+	for _, m := range matches {
+		// Only the sshd_config ones; the script has other heredocs.
+		if strings.Contains(m[1], "PrintMotd") || strings.Contains(m[1], "PrintLastLog") {
+			blocks = append(blocks, m[1])
+		}
+	}
+	if len(blocks) == 0 {
+		t.Fatal("found no sshd config blocks in the script — this guard would pass vacuously")
+	}
+	return blocks
+}
+
+// The cheap guard, and the one that runs everywhere: no Match block.
+//
+// PrintMotd/PrintLastLog inside Match is rejected wherever the file lives —
+// the restriction is on Match, not on the drop-in directory. So "move it to
+// the main sshd_config" is not a fix, and this check deliberately does not
+// care which branch of the script wrote the block.
+func TestSSHDDropInHasNoMatchBlock(t *testing.T) {
+	for i, block := range sshdConfigBlocks(t) {
+		for _, line := range strings.Split(block, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "Match ") {
+				t.Errorf("sshd config block %d contains a Match block:\n\t%s\n"+
+					"PrintMotd/PrintLastLog are not permitted inside Match — this makes the "+
+					"entire sshd config unparseable, so sshd refuses to start on its next "+
+					"restart and SSH to the host (and every box on it) is lost (#1137).",
+					i, strings.TrimSpace(line))
+			}
+		}
+	}
+}
+
+// The real check: hand the block to the actual sshd parser.
+//
+// A hand-rolled "does it look right" assertion would have missed the
+// original bug too — the block looked entirely reasonable. Only the parser
+// knows which directives Match accepts.
+func TestSSHDDropInParsesUnderRealSSHD(t *testing.T) {
+	sshd := findSSHD()
+	if sshd == "" {
+		t.Skip("sshd not installed; the Match guard above still applies")
+	}
+	keygen, err := exec.LookPath("ssh-keygen")
+	if err != nil {
+		t.Skip("ssh-keygen not installed, cannot mint a host key for sshd -t")
+	}
+
+	dir := t.TempDir()
+	hostKey := filepath.Join(dir, "hostkey")
+	if out, err := exec.Command(keygen, "-q", "-t", "ed25519", "-f", hostKey, "-N", "").CombinedOutput(); err != nil {
+		t.Skipf("ssh-keygen failed (%v): %s", err, out)
+	}
+
+	for i, block := range sshdConfigBlocks(t) {
+		t.Run(fmt.Sprintf("block%d", i), func(t *testing.T) {
+			dropInDir := filepath.Join(dir, fmt.Sprintf("sshd_config.d.%d", i))
+			if err := os.MkdirAll(dropInDir, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dropInDir, "containarium-motd.conf"), []byte(block+"\n"), 0o644); err != nil {
+				t.Fatalf("write drop-in: %v", err)
+			}
+
+			// Stock-Ubuntu shape: the Include comes FIRST, global directives
+			// after it. Some of those globals (Subsystem, UsePAM) are
+			// themselves illegal inside Match, so this layout is what turns a
+			// bad drop-in into a whole-config parse failure.
+			main := filepath.Join(dir, fmt.Sprintf("sshd_config.%d", i))
+			cfg := fmt.Sprintf("Include %s/*.conf\nHostKey %s\nSubsystem sftp /usr/lib/openssh/sftp-server\nUsePAM yes\n",
+				dropInDir, hostKey)
+			if err := os.WriteFile(main, []byte(cfg), 0o600); err != nil {
+				t.Fatalf("write sshd_config: %v", err)
+			}
+
+			out, err := exec.Command(sshd, "-t", "-f", main).CombinedOutput()
+			if err != nil {
+				t.Errorf("sshd rejected the config this script installs (#1137):\n%s\n"+
+					"A host that applies this loses sshd on its next restart.", out)
+			}
+		})
+	}
+}
+
+// The other half of the incident: the failure was invisible because the
+// reload discarded its own output and exit status, so the host looked
+// healthy while carrying a config that would not survive a restart.
+func TestSSHDReloadIsValidatedNotSuppressed(t *testing.T) {
+	script := readSSHProxyScript(t)
+
+	// Comments are stripped first: the fix's own comment quotes the old
+	// `systemctl reload sshd 2>/dev/null || true` line to explain what went
+	// wrong, and a naive scan matches that and fails on the explanation.
+	suppressed := regexp.MustCompile(`systemctl reload sshd[^\n]*\|\|\s*true`)
+	for i, line := range strings.Split(script, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		if suppressed.MatchString(line) {
+			t.Errorf("line %d: `systemctl reload sshd ... || true` discards the exit status, so an "+
+				"invalid config installs silently: the running sshd keeps serving its "+
+				"already-loaded config and the host looks fine until something restarts "+
+				"ssh (#1137)\n\t%s", i+1, strings.TrimSpace(line))
+		}
+	}
+	if !strings.Contains(script, `-t`) || !strings.Contains(script, "SSHD_BIN") {
+		t.Error("the script must validate with `sshd -t` before reloading, so a bad config " +
+			"fails the install instead of waiting to take the host down later (#1137)")
+	}
+}
+
+func findSSHD() string {
+	if p, err := exec.LookPath("sshd"); err == nil {
+		return p
+	}
+	for _, p := range []string{"/usr/sbin/sshd", "/sbin/sshd"} {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}

--- a/scripts/setup-ssh-container-proxy.sh
+++ b/scripts/setup-ssh-container-proxy.sh
@@ -153,28 +153,85 @@ echo "  Created $SUDOERS_FILE"
 # 3. sshd config — suppress host MOTD for containarium users
 # ============================================================
 SSHD_MATCH_FILE="/etc/ssh/sshd_config.d/containarium-motd.conf"
-if [ -d /etc/ssh/sshd_config.d ]; then
+SSHD_BIN="$(command -v sshd || echo /usr/sbin/sshd)"
+
+# NO `Match` BLOCK HERE — this is load-bearing (#1137).
+#
+# PrintMotd and PrintLastLog are not permitted inside a Match block. Wrapping
+# them in one makes the ENTIRE sshd config unparseable, so sshd refuses to
+# start on its next restart:
+#
+#   sshd_config.d/containarium-motd.conf line 2: Directive 'PrintMotd' is
+#   not allowed within a Match block
+#
+# That takes SSH to the host down, and with it every box on the backend
+# (sshpiper's upstream is this host's sshd) — while the daemon, the tunnel
+# and the containers all keep running and the backend still reports healthy.
+# Nothing surfaces it until someone tries to connect, and recovery needs the
+# machine's console. It is not restricted to the drop-in either: the same
+# block appended to the main sshd_config is equally invalid, because the
+# restriction is on Match, not on where the file lives.
+#
+# Global scope is therefore the only option — the directives cannot be
+# per-user. In practice the cost is nil on Ubuntu, which already sets
+# `PrintMotd no` globally in its stock sshd_config and prints the MOTD from
+# pam_motd rather than sshd; the one real change is that admin logins lose
+# the "Last login:" line. On rocky9/rhel9, where PrintMotd defaults to yes,
+# the setting does the job it was written for.
+write_sshd_dropin() {
     cat > "$SSHD_MATCH_FILE" << 'SSHDEOF'
-# Suppress host MOTD for containarium container users
-# containarium-shell shows its own banner with container info
-Match User *,!ubuntu,!root
-    PrintMotd no
-    PrintLastLog no
+# Suppress host MOTD/last-login for containarium container users.
+# containarium-shell shows its own banner with container info.
+#
+# Global, NOT inside a Match block: PrintMotd/PrintLastLog are rejected
+# inside Match and would make sshd_config unparseable (#1137).
+PrintMotd no
+PrintLastLog no
 SSHDEOF
+}
+
+# Validate before reloading, and fail loudly.
+#
+# `sshd -t` parses the whole config, drop-ins included. Previously this was
+# `systemctl reload sshd 2>/dev/null || true`, which discarded both the
+# output and the exit status — and since the running sshd keeps serving its
+# already-loaded config, the host looked healthy for hours or days. The
+# breakage landed at the next restart, in practice an unattended-upgrades
+# openssh update at an arbitrary time. Checking here turns a delayed,
+# console-only outage into an immediate install failure.
+reload_sshd_or_revert() {
+    local revert_cmd="$1"
+    if ! "$SSHD_BIN" -t 2>&1; then
+        echo "ERROR: sshd config is invalid after writing the containarium MOTD settings." >&2
+        echo "       Reverting so sshd keeps starting; SSH to this host is not at risk." >&2
+        eval "$revert_cmd"
+        if "$SSHD_BIN" -t 2>/dev/null; then
+            echo "       Revert succeeded — the config is valid again." >&2
+        else
+            echo "       WARNING: config is STILL invalid after revert; do not restart sshd." >&2
+        fi
+        exit 1
+    fi
+    systemctl reload sshd
+}
+
+if [ -d /etc/ssh/sshd_config.d ]; then
+    write_sshd_dropin
     echo "  Created $SSHD_MATCH_FILE"
-    systemctl reload sshd 2>/dev/null || true
+    reload_sshd_or_revert "rm -f '$SSHD_MATCH_FILE'"
 else
-    # Fallback: append to main sshd_config if .d directory doesn't exist
+    # Fallback: append to main sshd_config if the .d directory doesn't exist.
     if ! grep -q "containarium-motd" /etc/ssh/sshd_config 2>/dev/null; then
+        cp /etc/ssh/sshd_config /etc/ssh/sshd_config.containarium-bak
         cat >> /etc/ssh/sshd_config << 'SSHDEOF'
 
-# containarium-motd: suppress host MOTD for container users
-Match User *,!ubuntu,!root
-    PrintMotd no
-    PrintLastLog no
+# containarium-motd: suppress host MOTD/last-login for container users.
+# Global, NOT inside a Match block — see #1137.
+PrintMotd no
+PrintLastLog no
 SSHDEOF
         echo "  Updated /etc/ssh/sshd_config"
-        systemctl reload sshd 2>/dev/null || true
+        reload_sshd_or_revert "mv -f /etc/ssh/sshd_config.containarium-bak /etc/ssh/sshd_config"
     fi
 fi
 


### PR DESCRIPTION
Closes #1137.

### The bug, reproduced

`setup-ssh-container-proxy.sh` wrote `PrintMotd`/`PrintLastLog` inside a `Match` block. Verified against real sshd — **OpenSSH 9.6p1 Ubuntu**, the reported platform — rather than taken on faith:

```
$ sshd -t -f sshd_config
sshd_config.d/containarium-motd.conf line 2: Directive 'PrintMotd' is not allowed
within a Match block
exit=255
```

sshd then refuses to start on its next restart, taking SSH to the backend host down and with it every box on that backend (sshpiper's upstream is that host's sshd) — while the daemon, tunnel and containers keep running and the backend still reports healthy.

### Two corrections to the analysis, both of which change the fix

**1. It is not Match-scope leakage.** The issue attributes it to a `Match` block staying in effect past the end of the included file, swallowing `Subsystem`/`UsePAM`. Tested directly — that doesn't happen:

| config | result |
| --- | --- |
| current script output (`Match` + `PrintMotd`) | **INVALID** — `'PrintMotd' is not allowed within a Match block` |
| proposed fix (global, no `Match`) | VALID |
| trailing `Match` in a drop-in with a Match-**legal** directive | **VALID** — later globals are *not* swallowed |

The restriction is simply that `PrintMotd`/`PrintLastLog` may not appear inside `Match` at all.

**2. The fallback branch is therefore not safe.** The issue says that branch (appending the `Match` to the main `sshd_config`) "is safe", and offers option 2 — keep `Match`, move it out of `sshd_config.d`. Tested:

```
fallback branch (Match appended to main config)   INVALID(rc=255):
  sshd_config line 7: Directive 'PrintMotd' is not allowed within a Match block
```

So **option 2 would have left the bug in place while appearing to fix it.** The restriction is on `Match`, not on where the file lives. Both branches are fixed here.

### The behaviour trade, stated precisely

The directives can't be scoped per-user, so they must be global. On **Ubuntu** the cost is nil: its stock `sshd_config` already sets `PrintMotd no` globally (line 103) and the MOTD is printed by `pam_motd`, not sshd — the only real change is that admin logins lose the `Last login:` line. On **rocky9/rhel9**, where `PrintMotd` defaults to `yes`, the setting does the job it was written for.

### The silent-failure half

The reload was `systemctl reload sshd 2>/dev/null || true` — discarding both output and exit status. Since the running sshd keeps serving its already-loaded config, the host looked healthy for hours or days; the breakage landed whenever something next restarted ssh, in practice an unattended-upgrades openssh update at an arbitrary time.

Now `sshd -t` gates the reload, and on failure the change is reverted (drop-in removed, or main config restored from a backup) and the install fails loudly.

### Guards

Three, in `internal/cmd/sshd_dropin_test.go`: no `Match` in any sshd block the script writes; the blocks **parse under the real sshd binary**; and the reload isn't suppressed. The parser check is the one that matters — a "looks right" assertion would have passed the original too, since only the parser knows what `Match` accepts. It skips cleanly where sshd/ssh-keygen aren't installed, with the Match guard still applying.

Mutation-tested: restoring the `Match` block fails the first two (quoting sshd's own rejection), restoring `|| true` fails the third.

🤖 Generated with [Claude Code](https://claude.com/claude-code)