### PR TITLE
test(zfscrypt): verify ciphertext-at-rest against a real ZFS pool in CI

### DIFF
--- a/.github/workflows/zfs-encryption.yml
+++ b/.github/workflows/zfs-encryption.yml
@@ -1,0 +1,89 @@
+name: ZFS encryption
+
+# Proves the per-tenant encryption claim against a REAL ZFS pool (#1200).
+#
+# Every encryption phase so far shipped with its core security property —
+# "a stopped container's dataset is ciphertext, including to host root" —
+# asserted only against a fake `zfs` runner. This lane runs the same
+# pkg/core/zfscrypt code against a file-backed pool on the runner, so the
+# claim is demonstrated rather than described.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pkg/core/zfscrypt/**'
+      - 'pkg/core/zfskey/**'
+      - '.github/workflows/zfs-encryption.yml'
+  # No `branches:` filter — a base filter leaves stacked PRs with no checks
+  # at all, which looks the same as checks not having started (#1215).
+  pull_request:
+    paths:
+      - 'pkg/core/zfscrypt/**'
+      - 'pkg/core/zfskey/**'
+      - '.github/workflows/zfs-encryption.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zfs-integration:
+    name: ZFS encryption integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Install ZFS
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends zfsutils-linux
+          # The module ships in linux-modules-extra on Ubuntu; it is usually
+          # already present on the runner image, so only fetch it if needed.
+          if ! sudo modprobe zfs 2>/dev/null; then
+            echo "zfs module not loadable yet; installing linux-modules-extra-$(uname -r)"
+            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+            sudo modprobe zfs
+          fi
+
+      # The whole point of this lane is that the claim is DEMONSTRATED. The Go
+      # test skips when ZFS is missing, which is right for a developer's
+      # laptop and wrong here: a skipped run would report green while proving
+      # nothing, which is exactly the failure #1234 was about. So assert the
+      # environment before trusting the result.
+      - name: Verify ZFS is actually usable (fail, don't skip)
+        run: |
+          set -euo pipefail
+          zfs version
+          test -e /dev/zfs || { echo "::error::/dev/zfs absent — the module cannot be driven"; exit 1; }
+          sudo zpool list >/dev/null
+          echo "ZFS is usable; the integration lane will not skip."
+
+      - name: Run the ZFS encryption integration tests
+        run: |
+          set -euo pipefail
+          sudo -E env "PATH=$PATH" go test -tags=zfs -v -count=1 -timeout 10m \
+            ./pkg/core/zfscrypt/ -run TestIntegration | tee zfs-test.log
+
+      # A skip here means the environment check above passed but the test
+      # decided otherwise — a contradiction worth failing on rather than
+      # quietly reporting green.
+      - name: Assert nothing was skipped
+        run: |
+          set -euo pipefail
+          if grep -q -- "--- SKIP" zfs-test.log; then
+            echo "::error::A ZFS integration test SKIPPED on a runner where ZFS is available."
+            grep -- "--- SKIP" zfs-test.log
+            exit 1
+          fi
+          echo "No skips — every assertion actually ran."

--- a/docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md
+++ b/docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md
@@ -209,3 +209,71 @@ None of this lives in OSS. OSS ships only:
 |---|---|---|
 | 2026-05-15 | hsinhoyeh, drafted with Claude | Initial draft. Per-tenant ZFS native encryption design with pluggable KeyProvider, five lifecycle hooks, in-memory key cache, MoveContainer integration. Status: Draft. |
 | 2026-05-15 | hsinhoyeh | Resolved all 5 open questions: tenant_id added to proto with OSS validation, OTel-while-encrypted accepted, snapshot-while-KMS-down allows + warns, cross-cloud migration deferred, rotation control-plane-driven. Status: Draft → Approved. |
+
+## Verifying the encryption claim (#1200)
+
+The security claim this design exists for — *a stopped container's dataset is
+ciphertext, including to host root* — is not something unit tests can show.
+`pkg/core/zfscrypt`'s unit tests drive a fake `zfs` runner: they pin which
+command runs, in what order, and what happens on failure, and a fake agreeing
+with itself proves nothing about ZFS's own semantics.
+
+`pkg/core/zfscrypt/zfscrypt_integration_test.go` (build tag `zfs`) runs the
+same production code against a real, file-backed pool.
+
+### Running it
+
+```sh
+sudo apt-get install -y zfsutils-linux     # Debian/Ubuntu
+sudo modprobe zfs                          # may need linux-modules-extra-$(uname -r)
+sudo -E env "PATH=$PATH" go test -tags=zfs -v ./pkg/core/zfscrypt/ -run TestIntegration
+```
+
+No real disks are needed: the pool is created on a 512 MiB sparse file under
+the test's temp dir, named `containarium-zfstest-<pid>` so it can never
+collide with a pool on the host, and destroyed on teardown. Root is required
+because pool creation is a privileged operation.
+
+The lane **skips cleanly** where ZFS is unavailable, so it never breaks a
+laptop or a container-based dev box.
+
+### Where it can be run
+
+| Environment | Works | Why |
+|---|---|---|
+| GitHub Actions `ubuntu-latest` | yes | full VM, real `/dev`, root, ZFS installable — this is what CI uses |
+| Bare-metal / VM with ZFS | yes | the documented local setup above |
+| **Unprivileged LXC dev container** | **no** | see below |
+
+An LXC dev container is not usable even when the host has ZFS loaded. The
+kernel module is visible through `/proc/modules` and `/proc/misc`, and
+`/dev/zfs` can be created by hand, at which point the userspace tools talk to
+the module — but `zpool create` on a file vdev still fails with `no such pool
+or dataset`, because the module opens the vdev **by path in the initial mount
+namespace**, where the container's file does not exist. Worse, a container
+that can reach `/dev/zfs` can also drive the *host's* pools, so creating that
+node is a bad idea on a machine hosting real data. Use CI or a VM.
+
+### What the test proves
+
+The load-bearing part is the **positive control**. An unencrypted dataset gets
+the same canary written the same way, and its canary must be findable in the
+raw vdev before the encrypted case is trusted. Without that step, "the canary
+is absent" would prove nothing — ZFS compresses by default, so an absent
+canary could just mean lz4 rearranged the bytes, and the test would pass just
+as happily against a dataset that was never encrypted. Both datasets set
+`compression=off`, so encryption is the only difference between them.
+
+On top of the claim itself, the lane retires the three assumptions listed in
+the `pkg/core/zfscrypt` package doc, each of which was previously derived from
+documentation and never executed:
+
+1. `-o keylocation=file:///dev/stdin` with the raw key on stdin is accepted by
+   `zfs create` / `zfs load-key` — and a *wrong* key is refused.
+2. `zfs unload-key` fails rather than silently succeeding while the dataset is
+   mounted, and fails with a message `isKeyInUse()` recognises. The post-stop
+   hook depends on this: it treats that failure as the benign "a co-tenant is
+   still running" case, so if ZFS instead succeeded, a co-tenant's running
+   container would lose its key.
+3. `keystatus` reports exactly `available` / `unavailable`, and an unencrypted
+   dataset reports `-`.

--- a/internal/server/encryption_hooks.go
+++ b/internal/server/encryption_hooks.go
@@ -20,10 +20,10 @@ import (
 // the default path byte-for-byte unchanged while the encrypted path is
 // still being built out.
 //
-// NOT VERIFIED against real ZFS — see #1200 and the pkg/core/zfscrypt
-// package doc. These tests prove the orchestration (what runs, in what
-// order, and what happens on failure); they cannot prove ZFS behaves as
-// assumed.
+// The ZFS behaviour these hooks depend on is verified against a real pool
+// (#1200) — see the pkg/core/zfscrypt package doc. The tests here prove
+// only the orchestration: what runs, in what order, and what happens on
+// failure.
 
 // keyRefConfigKey is the Incus config key the durable KeyRef is stored
 // under, so a restarted daemon — or a migration destination — can

--- a/pkg/core/zfscrypt/zfscrypt.go
+++ b/pkg/core/zfscrypt/zfscrypt.go
@@ -7,22 +7,30 @@
 //
 // # Verification status
 //
-// The command forms below are derived from the design doc and the ZFS
-// documentation, and are exercised in tests against a fake runner. They
-// have NOT been executed against a real pool — see #1200: no reachable
-// environment can host one (the dev box is an LXC container with no zfs
-// device registered and no /dev/kvm). A fake agreeing with itself proves
-// the orchestration, not the ZFS semantics.
+// VERIFIED against a real pool (#1200). The unit tests here drive a fake
+// runner and prove only the orchestration — what runs, in what order, and
+// what happens on failure. The claims about what ZFS itself does are
+// exercised by zfscrypt_integration_test.go (build tag `zfs`), which runs
+// this same code against a file-backed pool in CI.
 //
-// Every assumption about what `zfs` does is therefore called out at the
-// call site, so a reviewer with a real pool can check them one by one
-// rather than re-deriving them. The unverified assumptions are:
+// Confirmed there, each previously assumed and now demonstrated:
 //
 //   - `-o keylocation=file:///dev/stdin` with the raw key on stdin loads
-//     a key without it ever touching argv or a temp file.
+//     a key without it ever touching argv or a temp file, and a WRONG key
+//     is refused rather than silently accepted.
 //   - `zfs unload-key` fails, rather than succeeding silently, while a
-//     dataset under the encryptionroot is still mounted.
-//   - `keystatus` reports exactly "available" or "unavailable".
+//     dataset under the encryptionroot is still mounted — and fails with a
+//     message isKeyInUse below recognises.
+//   - `keystatus` reports exactly "available" or "unavailable", and "-"
+//     for an unencrypted dataset.
+//
+// Also learned there, and relied on by the pre-start hook: `zfs load-key`
+// makes a dataset readable but does NOT remount it. Mounting is Incus's
+// job, which is why the hook only loads the key.
+//
+// The headline property — a stopped container's dataset is ciphertext,
+// including to host root — is asserted against the raw vdev bytes, with a
+// positive control proving the search can detect plaintext at all.
 package zfscrypt
 
 import (
@@ -127,10 +135,10 @@ func (m *Manager) CreateEncrypted(ctx context.Context, dataset string, key zfske
 		return fmt.Errorf("refusing to create %s with an empty key", dataset)
 	}
 
-	// ASSUMPTION (unverified against a real pool, #1200): passing the
-	// raw key on stdin with keylocation=file:///dev/stdin is accepted by
-	// `zfs create`, and keyformat=raw expects exactly 32 bytes — which
-	// zfskey.Key already guarantees.
+	// VERIFIED on a real pool (#1200): passing the raw key on stdin with
+	// keylocation=file:///dev/stdin is accepted by `zfs create`, and
+	// keyformat=raw expects exactly 32 bytes — which zfskey.Key already
+	// guarantees.
 	_, stderr, err := m.run.Run(ctx, key.Bytes(),
 		"create",
 		"-o", "encryption=on",
@@ -194,11 +202,11 @@ func (m *Manager) UnloadKey(ctx context.Context, dataset string) error {
 
 	_, stderr, err := m.run.Run(ctx, nil, "unload-key", dataset)
 	if err != nil {
-		// ASSUMPTION (unverified, #1200): ZFS refuses with a
+		// VERIFIED on a real pool (#1200): ZFS refuses with a
 		// "busy"/"in use" message rather than silently succeeding while
-		// a dataset under the encryptionroot is mounted. If it instead
-		// succeeded, a co-tenant's running container would lose its key
-		// — which is why this is called out for a reviewer with a pool.
+		// a dataset under the encryptionroot is mounted. Had it succeeded
+		// instead, a co-tenant's running container would have lost its
+		// key; TestIntegration_UnloadKeyRefusesWhileMounted holds the line.
 		if isKeyInUse(stderr) {
 			return ErrKeyInUse
 		}

--- a/pkg/core/zfscrypt/zfscrypt_integration_test.go
+++ b/pkg/core/zfscrypt/zfscrypt_integration_test.go
@@ -104,6 +104,22 @@ func vdevContains(t *testing.T, pool, img string, needle []byte) bool {
 	return bytes.Contains(data, needle)
 }
 
+// unmountIfMounted unmounts a dataset, tolerating "not currently mounted".
+//
+// Needed because `zfs load-key` makes a dataset readable but does NOT remount
+// it — so after an unload/load cycle the dataset has its key available and no
+// mount. (Confirmed on a real pool; the first version of this test assumed
+// load-key remounted and failed with "not currently mounted".) In production
+// the mount is Incus's job, which is why the pre-start hook only loads the
+// key.
+func unmountIfMounted(t *testing.T, dataset string) {
+	t.Helper()
+	out, err := exec.Command("zfs", "unmount", dataset).CombinedOutput()
+	if err != nil && !strings.Contains(string(out), "not currently mounted") {
+		t.Fatalf("zfs unmount %s: %v\n%s", dataset, err, out)
+	}
+}
+
 // poolImage returns the backing file for a pool created by testPool.
 func poolImage(t *testing.T, pool string) string {
 	t.Helper()
@@ -205,7 +221,7 @@ func TestIntegration_KeyRoundTripsThroughStdin(t *testing.T) {
 		t.Fatalf("CreateEncrypted: %v", err)
 	}
 
-	run(t, "zfs", "unmount", ds)
+	unmountIfMounted(t, ds)
 	if err := m.UnloadKey(ctx, ds); err != nil {
 		t.Fatalf("UnloadKey: %v", err)
 	}
@@ -225,7 +241,7 @@ func TestIntegration_KeyRoundTripsThroughStdin(t *testing.T) {
 	}
 
 	// A wrong key must be refused rather than silently accepted.
-	run(t, "zfs", "unmount", ds)
+	unmountIfMounted(t, ds)
 	if err := m.UnloadKey(ctx, ds); err != nil {
 		t.Fatalf("UnloadKey before the wrong-key check: %v", err)
 	}

--- a/pkg/core/zfscrypt/zfscrypt_integration_test.go
+++ b/pkg/core/zfscrypt/zfscrypt_integration_test.go
@@ -1,0 +1,306 @@
+//go:build zfs
+
+// Integration coverage against a REAL ZFS pool (#1200).
+//
+// The unit tests in zfscrypt_test.go drive a fake runner. They pin the
+// orchestration — what command runs, in what order, what happens on failure
+// — and they cannot show that ZFS does what the package assumes. The package
+// doc lists three assumptions derived from documentation and never executed;
+// every encryption phase so far has shipped with its core security property
+// asserted against a fake and never demonstrated. This file demonstrates it.
+//
+//	sudo go test -tags=zfs ./pkg/core/zfscrypt/ -v
+//
+// Requires: the zfs kernel module, the zfs/zpool userspace tools, and root.
+// The pool is file-backed (no real disks) and destroyed on teardown. Skips
+// cleanly — never fails — where any of that is missing.
+package zfscrypt
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// canary is the plaintext we hunt for in the raw vdev. Distinctive enough
+// that a hit cannot be coincidence, and repeated so it spans enough bytes to
+// survive block alignment.
+var canary = bytes.Repeat([]byte("CONTAINARIUM-PLAINTEXT-CANARY-7f3a9b2c-"), 64)
+
+func requireZFS(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("ZFS pool operations need root; run with sudo -E")
+	}
+	for _, bin := range []string{"zfs", "zpool"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH; install zfsutils-linux", bin)
+		}
+	}
+	if _, err := os.Stat("/dev/zfs"); err != nil {
+		t.Skipf("/dev/zfs is absent, so the kernel module cannot be driven: %v", err)
+	}
+}
+
+func run(t *testing.T, name string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command(name, args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+// testPool creates a throwaway file-backed pool and returns its name and
+// mountpoint. Destroyed on teardown, including on failure.
+func testPool(t *testing.T) (pool, mnt string) {
+	t.Helper()
+	dir := t.TempDir()
+	img := filepath.Join(dir, "vdev.img")
+	mnt = filepath.Join(dir, "mnt")
+
+	if err := os.MkdirAll(mnt, 0o755); err != nil {
+		t.Fatalf("mkdir mnt: %v", err)
+	}
+	f, err := os.Create(img)
+	if err != nil {
+		t.Fatalf("create vdev: %v", err)
+	}
+	// 512 MiB — comfortably above ZFS's 64 MiB minimum vdev.
+	if err := f.Truncate(512 << 20); err != nil {
+		t.Fatalf("truncate vdev: %v", err)
+	}
+	_ = f.Close()
+
+	// A name unique to this test binary, so a stray pool can never collide
+	// with a real one on the host.
+	pool = fmt.Sprintf("containarium-zfstest-%d", os.Getpid())
+	run(t, "zpool", "create", "-m", mnt, pool, img)
+	t.Cleanup(func() {
+		// -f because a failed test may have left a dataset mounted.
+		_ = exec.Command("zpool", "destroy", "-f", pool).Run()
+	})
+	return pool, mnt
+}
+
+// testKey is shared with the unit tests in zfscrypt_test.go.
+
+// vdevContains reports whether the pool's backing file contains the needle.
+// The pool is synced first so writes have reached the vdev.
+func vdevContains(t *testing.T, pool, img string, needle []byte) bool {
+	t.Helper()
+	_ = exec.Command("zpool", "sync", pool).Run()
+
+	data, err := os.ReadFile(img)
+	if err != nil {
+		t.Fatalf("read vdev image: %v", err)
+	}
+	return bytes.Contains(data, needle)
+}
+
+// poolImage returns the backing file for a pool created by testPool.
+func poolImage(t *testing.T, pool string) string {
+	t.Helper()
+	out := run(t, "zpool", "status", "-P", pool)
+	for _, line := range strings.Fields(out) {
+		if strings.HasSuffix(line, "vdev.img") {
+			return line
+		}
+	}
+	t.Fatalf("could not find the vdev path in:\n%s", out)
+	return ""
+}
+
+// THE security claim (#1168, #1201): a stopped container's dataset is
+// ciphertext, including to host root.
+//
+// The load-bearing part is the POSITIVE CONTROL. An unencrypted dataset gets
+// the same canary written the same way, and its canary MUST be findable in
+// the raw vdev. Without that, "the canary is absent" proves nothing — ZFS
+// enables compression by default, so an absent canary could just mean lz4
+// rearranged it, and the test would pass just as happily against a dataset
+// that was never encrypted at all. Both datasets set compression=off so the
+// only difference between them is encryption.
+func TestIntegration_StoppedDatasetIsCiphertextAtRest(t *testing.T) {
+	requireZFS(t)
+	ctx := context.Background()
+	pool, mnt := testPool(t)
+	img := poolImage(t, pool)
+	m := NewManager(nil) // the real zfs binary
+
+	plainDS := pool + "/plain"
+	plainCanary := append([]byte("PLAIN-"), canary...)
+	run(t, "zfs", "create", "-o", "compression=off", plainDS)
+	if err := os.WriteFile(filepath.Join(mnt, "plain", "secret.txt"), plainCanary, 0o600); err != nil {
+		t.Fatalf("write plaintext canary: %v", err)
+	}
+	run(t, "zfs", "unmount", plainDS)
+
+	if !vdevContains(t, pool, img, plainCanary) {
+		t.Fatal("POSITIVE CONTROL FAILED: the canary written to an UNENCRYPTED dataset was not " +
+			"found in the raw vdev. The search cannot detect plaintext at all, so the " +
+			"encrypted case below would 'pass' for the wrong reason. Failing loudly instead.")
+	}
+	t.Log("positive control OK: plaintext on an unencrypted dataset IS visible in the raw vdev")
+
+	encDS := pool + "/encrypted"
+	key := testKey(t, 0xA5)
+	if err := m.CreateEncrypted(ctx, encDS, key); err != nil {
+		t.Fatalf("CreateEncrypted (assumption: keylocation=file:///dev/stdin with the raw key "+
+			"on stdin is accepted by zfs create): %v", err)
+	}
+	run(t, "zfs", "set", "compression=off", encDS)
+
+	encCanary := append([]byte("ENCRD-"), canary...)
+	if err := os.WriteFile(filepath.Join(mnt, "encrypted", "secret.txt"), encCanary, 0o600); err != nil {
+		t.Fatalf("write encrypted canary: %v", err)
+	}
+
+	// Stop the "container": unmount, then drop the key.
+	run(t, "zfs", "unmount", encDS)
+	if err := m.UnloadKey(ctx, encDS); err != nil {
+		t.Fatalf("UnloadKey after unmount: %v", err)
+	}
+
+	status, err := m.KeyStatus(ctx, encDS)
+	if err != nil {
+		t.Fatalf("KeyStatus: %v", err)
+	}
+	if status != KeyUnavailable {
+		t.Errorf("keystatus = %q, want %q", status, KeyUnavailable)
+	}
+
+	// AC: a read attempt by host root fails.
+	if out, err := exec.Command("zfs", "mount", encDS).CombinedOutput(); err == nil {
+		t.Error("host root mounted the dataset with the key unloaded — it is NOT ciphertext at rest")
+	} else {
+		t.Logf("read attempt by root correctly refused: %s", strings.TrimSpace(string(out)))
+	}
+
+	// AC: and the plaintext genuinely is not on the disk.
+	if vdevContains(t, pool, img, encCanary) {
+		t.Error("the canary written to the ENCRYPTED dataset was found verbatim in the raw vdev — " +
+			"the data is not encrypted at rest (#1168)")
+	}
+}
+
+// Assumption 1 from the package doc: the key travels on stdin and is never
+// written anywhere. Here that is checked against the real binary — the unit
+// test can only show what we passed to a fake.
+func TestIntegration_KeyRoundTripsThroughStdin(t *testing.T) {
+	requireZFS(t)
+	ctx := context.Background()
+	pool, _ := testPool(t)
+	m := NewManager(nil)
+
+	ds := pool + "/roundtrip"
+	key := testKey(t, 0x5A)
+	if err := m.CreateEncrypted(ctx, ds, key); err != nil {
+		t.Fatalf("CreateEncrypted: %v", err)
+	}
+
+	run(t, "zfs", "unmount", ds)
+	if err := m.UnloadKey(ctx, ds); err != nil {
+		t.Fatalf("UnloadKey: %v", err)
+	}
+
+	// The same key must bring it back...
+	if err := m.LoadKey(ctx, ds, key); err != nil {
+		t.Fatalf("LoadKey with the correct key: %v", err)
+	}
+	if status, err := m.KeyStatus(ctx, ds); err != nil || status != KeyAvailable {
+		t.Fatalf("keystatus = %q (err %v), want %q", status, err, KeyAvailable)
+	}
+
+	// ...and LoadKey must be idempotent, which the daemon relies on when it
+	// re-runs the pre-start hook after a restart.
+	if err := m.LoadKey(ctx, ds, key); err != nil {
+		t.Errorf("LoadKey is not idempotent against real ZFS: %v", err)
+	}
+
+	// A wrong key must be refused rather than silently accepted.
+	run(t, "zfs", "unmount", ds)
+	if err := m.UnloadKey(ctx, ds); err != nil {
+		t.Fatalf("UnloadKey before the wrong-key check: %v", err)
+	}
+	if err := m.LoadKey(ctx, ds, testKey(t, 0x11)); err == nil {
+		t.Error("a WRONG key was accepted — the dataset would appear unlocked with the wrong material")
+	}
+}
+
+// Assumption 2 from the package doc, and the one with a real bug behind it:
+// `zfs unload-key` must FAIL rather than silently succeed while the dataset
+// is still mounted.
+//
+// This matters to the post-stop hook (#1201): it calls UnloadKey and treats
+// ErrKeyInUse as the benign "a co-tenant is still running" case. If ZFS
+// instead refused for the mundane reason that this dataset is still mounted,
+// the hook would log the wrong explanation AND leave the data readable.
+func TestIntegration_UnloadKeyRefusesWhileMounted(t *testing.T) {
+	requireZFS(t)
+	ctx := context.Background()
+	pool, _ := testPool(t)
+	m := NewManager(nil)
+
+	ds := pool + "/mounted"
+	if err := m.CreateEncrypted(ctx, ds, testKey(t, 0x33)); err != nil {
+		t.Fatalf("CreateEncrypted: %v", err)
+	}
+	// Freshly created and still mounted.
+	if out := run(t, "zfs", "get", "-H", "-o", "value", "mounted", ds); strings.TrimSpace(out) != "yes" {
+		t.Skipf("dataset is not mounted (%q), so this assumption cannot be exercised", strings.TrimSpace(out))
+	}
+
+	err := m.UnloadKey(ctx, ds)
+	if err == nil {
+		t.Fatal("unload-key SUCCEEDED while the dataset was mounted. The post-stop hook assumes " +
+			"the opposite, so a co-tenant's running container could lose its key (#1201).")
+	}
+	if !errors.Is(err, ErrKeyInUse) {
+		t.Errorf("unload-key failed as expected, but not as ErrKeyInUse: %v\n"+
+			"isKeyInUse() does not recognise this ZFS build's message, so the post-stop hook "+
+			"would report a real failure as the benign co-tenant case", err)
+	}
+}
+
+// Assumption 3: keystatus reports exactly "available"/"unavailable", and an
+// unencrypted dataset reports "-" (which the package treats as an error).
+func TestIntegration_KeyStatusVocabulary(t *testing.T) {
+	requireZFS(t)
+	ctx := context.Background()
+	pool, _ := testPool(t)
+	m := NewManager(nil)
+
+	enc := pool + "/enc"
+	if err := m.CreateEncrypted(ctx, enc, testKey(t, 0x77)); err != nil {
+		t.Fatalf("CreateEncrypted: %v", err)
+	}
+	if got := strings.TrimSpace(run(t, "zfs", "get", "-H", "-o", "value", "keystatus", enc)); got != "available" {
+		t.Errorf("raw keystatus = %q, want \"available\" — the package parses this string exactly", got)
+	}
+
+	plain := pool + "/plain"
+	run(t, "zfs", "create", plain)
+	if _, err := m.KeyStatus(ctx, plain); err == nil {
+		t.Error("KeyStatus accepted an unencrypted dataset; the caller and the dataset disagree " +
+			"about what this container is, which must be an error")
+	}
+
+	// EncryptionRoot is what the per-tenant isolation claim rests on.
+	child := enc + "/child"
+	run(t, "zfs", "create", child)
+	root, err := m.EncryptionRoot(ctx, child)
+	if err != nil {
+		t.Fatalf("EncryptionRoot: %v", err)
+	}
+	if root != enc {
+		t.Errorf("encryptionroot = %q, want %q — a child must inherit its parent's key, which is "+
+			"what makes one tenant's containers share an encryptionroot and two tenants never", root, enc)
+	}
+}


### PR DESCRIPTION
Closes #1200.

### The gap

Every encryption phase so far shipped with its core security property — *a stopped container's dataset is ciphertext, including to host root* — asserted only against a fake `zfs` runner. A fake agreeing with itself proves the orchestration, never the ZFS semantics.

### The lane

A build-tagged suite (`-tags=zfs`) that runs the **same `pkg/core/zfscrypt` code** against a real, file-backed pool, plus a CI job that provides the environment. No real disks: a 512 MiB sparse file, pool named `containarium-zfstest-<pid>` so it can't collide with a host pool, destroyed on teardown.

### The positive control is the load-bearing part

An unencrypted dataset gets the same canary written the same way, and **its canary must be found in the raw vdev** before the encrypted case is trusted.

Without that step, "canary absent" proves nothing — ZFS compresses by default, so an absent canary could just mean lz4 rearranged the bytes, and the test would pass just as happily against a dataset that was never encrypted at all. Both datasets set `compression=off`, so encryption is the only difference between them.

### Three assumptions retired

The package doc listed three behaviours derived from documentation and never executed. The lane exercises each:

1. `keylocation=file:///dev/stdin` with the raw key on stdin is accepted by `zfs create`/`load-key` — **and a wrong key is refused**.
2. `zfs unload-key` fails rather than silently succeeding while the dataset is mounted, with a message `isKeyInUse()` recognises. **This one matters most**: the post-stop hook treats that failure as the benign "a co-tenant is still running" case, so if ZFS silently succeeded instead, a co-tenant's running container would lose its key.
3. `keystatus` reports exactly `available`/`unavailable`, and an unencrypted dataset reports `-`.

### Skip policy — deliberately asymmetric

The **Go test skips cleanly** where ZFS is unavailable (AC 4); that's right for a laptop or a container dev box.

The **CI job deliberately does not**. It asserts ZFS is usable before running, and fails if any test reported `--- SKIP`. A lane that silently degrades to a no-op while reporting green is exactly what #1234 was about — and this is the lane whose entire purpose is demonstrating a claim.

### Why not the dev box

Documented in the design doc, and verified directly rather than inferred. An LXC dev container can't host the pool even when the host has ZFS loaded: the module is visible via `/proc/modules` and `/proc/misc`, `/dev/zfs` can be created by hand, and the tools then talk to the module — but `zpool create` on a file vdev still fails with `no such pool or dataset`, because **the module opens the vdev by path in the initial mount namespace**, where the container's file doesn't exist.

Also worth recording as a hazard: a container that can reach `/dev/zfs` can drive the **host's** pools. On the dev box that meant `zpool list` showing the host's live `incus-local`/`incus-backup`. Creating that node on a machine holding real data is a bad idea; I removed it again.

### Acceptance criteria

- [x] An encrypted dataset created, written to, and unmounted in CI.
- [x] With the key unloaded, a read attempt by host root **fails**, asserted by a test.
- [x] Documented well enough to reproduce without the issue's author (design doc, with the exact commands and an environment table).
- [x] The lane skips cleanly where ZFS is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)