### PR TITLE
test(server): prove PostStop leaves ciphertext, against a real pool

### DIFF
--- a/.github/workflows/zfs-encryption.yml
+++ b/.github/workflows/zfs-encryption.yml
@@ -76,11 +76,16 @@ jobs:
       - name: Run the ZFS encryption integration tests
         run: |
           set -euo pipefail
+          # Two invocations because the -run patterns differ: internal/server
+          # has unrelated TestIntegration_* tests that this lane should not
+          # be responsible for, so it is scoped to the encryption ones.
+          #
           # pkg/core/zfscrypt: the ZFS semantics the package assumes.
-          # internal/server:   the lifecycle hooks that production calls.
           sudo -E env "PATH=$PATH" go test -tags=zfs -v -count=1 -timeout 10m \
-            ./pkg/core/zfscrypt/ ./internal/server/ \
-            -run 'TestIntegration' | tee zfs-test.log
+            ./pkg/core/zfscrypt/ -run 'TestIntegration' | tee zfs-test.log
+          # internal/server: the lifecycle hooks production actually calls.
+          sudo -E env "PATH=$PATH" go test -tags=zfs -v -count=1 -timeout 10m \
+            ./internal/server/ -run 'TestIntegrationEncryption' | tee -a zfs-test.log
 
       # A skip here means the environment check above passed but the test
       # decided otherwise — a contradiction worth failing on rather than

--- a/.github/workflows/zfs-encryption.yml
+++ b/.github/workflows/zfs-encryption.yml
@@ -14,6 +14,8 @@ on:
     paths:
       - 'pkg/core/zfscrypt/**'
       - 'pkg/core/zfskey/**'
+      - 'internal/server/encryption_hooks*.go'
+      - 'internal/testsupport/zfspool/**'
       - '.github/workflows/zfs-encryption.yml'
   # No `branches:` filter — a base filter leaves stacked PRs with no checks
   # at all, which looks the same as checks not having started (#1215).
@@ -21,6 +23,8 @@ on:
     paths:
       - 'pkg/core/zfscrypt/**'
       - 'pkg/core/zfskey/**'
+      - 'internal/server/encryption_hooks*.go'
+      - 'internal/testsupport/zfspool/**'
       - '.github/workflows/zfs-encryption.yml'
 
 permissions:
@@ -72,8 +76,11 @@ jobs:
       - name: Run the ZFS encryption integration tests
         run: |
           set -euo pipefail
+          # pkg/core/zfscrypt: the ZFS semantics the package assumes.
+          # internal/server:   the lifecycle hooks that production calls.
           sudo -E env "PATH=$PATH" go test -tags=zfs -v -count=1 -timeout 10m \
-            ./pkg/core/zfscrypt/ -run TestIntegration | tee zfs-test.log
+            ./pkg/core/zfscrypt/ ./internal/server/ \
+            -run 'TestIntegration' | tee zfs-test.log
 
       # A skip here means the environment check above passed but the test
       # decided otherwise — a contradiction worth failing on rather than

--- a/internal/server/encryption_hooks_integration_test.go
+++ b/internal/server/encryption_hooks_integration_test.go
@@ -113,8 +113,13 @@ func TestIntegrationEncryption_PostStopLeavesCiphertext(t *testing.T) {
 	dataset := h.createBox(t, ctx, "box-alice", "alice")
 	zfspool.Run(t, "zfs", "set", "compression=off", dataset)
 
+	// Distinct prefixes, and the search uses the FULL prefixed string.
+	// Searching for the bare shared suffix would find it inside the
+	// control's plaintext — which sits unencrypted on this same vdev — and
+	// report the encrypted dataset as leaking when it had not.
+	encCanary := append([]byte("ENCRD-"), hookCanary...)
 	secret := filepath.Join(h.pool.Mount, "box-alice", "secret.txt")
-	if err := os.WriteFile(secret, hookCanary, 0o600); err != nil {
+	if err := os.WriteFile(secret, encCanary, 0o600); err != nil {
 		t.Fatalf("write canary: %v", err)
 	}
 
@@ -149,7 +154,7 @@ func TestIntegrationEncryption_PostStopLeavesCiphertext(t *testing.T) {
 			status, zfscrypt.KeyUnavailable)
 	}
 
-	if h.pool.ContainsPlaintext(t, hookCanary) {
+	if h.pool.ContainsPlaintext(t, encCanary) {
 		t.Error("the stopped container's data was found verbatim in the raw vdev — PostStop did " +
 			"not leave it as ciphertext (#1201)")
 	}

--- a/internal/server/encryption_hooks_integration_test.go
+++ b/internal/server/encryption_hooks_integration_test.go
@@ -1,0 +1,251 @@
+//go:build zfs
+
+// Integration coverage for the container lifecycle hooks against a REAL
+// ZFS pool (#1201, proof enabled by #1200).
+//
+// encryption_hooks_test.go drives these with a fake zfscrypt runner and
+// proves the orchestration: what runs, in what order, what is tolerated.
+// It cannot show that PostStop actually leaves a stopped container's
+// dataset as ciphertext, which is the entire point of the hook.
+//
+//	sudo go test -tags=zfs ./internal/server/ -run TestIntegrationEncryption -v
+//
+// Only the Incus-side plumbing is faked here — the key-ref store and the
+// dataset resolver. The KeyProvider, the zfscrypt Manager and the pool are
+// all real.
+package server
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/testsupport/zfspool"
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+)
+
+// canary is the plaintext hunted for in the raw vdev.
+var hookCanary = bytes.Repeat([]byte("CONTAINARIUM-HOOK-CANARY-4e1d8a6b-"), 64)
+
+// memKeyRefStore stands in for the Incus config key the daemon really uses.
+type memKeyRefStore struct{ refs map[string]zfskey.KeyRef }
+
+func (m *memKeyRefStore) GetKeyRef(name string) (zfskey.KeyRef, bool, error) {
+	ref, ok := m.refs[name]
+	return ref, ok, nil
+}
+
+func (m *memKeyRefStore) SetKeyRef(name string, ref zfskey.KeyRef) error {
+	m.refs[name] = ref
+	return nil
+}
+
+// fixedResolver maps container names to datasets.
+type fixedResolver struct{ datasets map[string]string }
+
+func (f fixedResolver) DatasetFor(name string) (string, error) { return f.datasets[name], nil }
+
+// harness wires real encryption machinery over a throwaway pool.
+type harness struct {
+	pool  *zfspool.Pool
+	hooks *encryptionHooks
+	keys  *zfskey.FileKeyProvider
+	refs  *memKeyRefStore
+	res   fixedResolver
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	zfspool.Require(t)
+
+	keys, err := zfskey.NewFileKeyProvider(filepath.Join(t.TempDir(), "keys"))
+	if err != nil {
+		t.Fatalf("NewFileKeyProvider: %v", err)
+	}
+	h := &harness{
+		pool: zfspool.New(t),
+		keys: keys,
+		refs: &memKeyRefStore{refs: map[string]zfskey.KeyRef{}},
+		res:  fixedResolver{datasets: map[string]string{}},
+	}
+	h.hooks = &encryptionHooks{
+		provider: keys,
+		zfs:      zfscrypt.NewManager(nil), // the real zfs binary
+		cache:    zfskey.NewCache(0),
+		refs:     h.refs,
+		datasets: h.res,
+	}
+	return h
+}
+
+// createBox mints a key, creates the encrypted dataset, and records the ref
+// the way the create path does.
+func (h *harness) createBox(t *testing.T, ctx context.Context, container, tenant string) string {
+	t.Helper()
+	key, ref, err := h.keys.Wrap(ctx, tenant)
+	if err != nil {
+		t.Fatalf("KeyProvider.Wrap(%s): %v", tenant, err)
+	}
+	dataset := h.pool.Dataset(container)
+	if err := h.hooks.zfs.CreateEncrypted(ctx, dataset, key); err != nil {
+		t.Fatalf("CreateEncrypted(%s): %v", dataset, err)
+	}
+	h.res.datasets[container] = dataset
+	if err := h.hooks.RecordKeyRef(container, ref); err != nil {
+		t.Fatalf("RecordKeyRef: %v", err)
+	}
+	return dataset
+}
+
+// AC 1 (#1201): after stopping the last container under an encryptionroot,
+// the key is unloaded and the dataset reads as ciphertext to host root.
+//
+// Driven through PostStop itself, not through zfscrypt.Manager — the hook
+// is what production calls, and the hook is what has to leave the data
+// unreadable.
+func TestIntegrationEncryption_PostStopLeavesCiphertext(t *testing.T) {
+	ctx := context.Background()
+	h := newHarness(t)
+
+	dataset := h.createBox(t, ctx, "box-alice", "alice")
+	zfspool.Run(t, "zfs", "set", "compression=off", dataset)
+
+	secret := filepath.Join(h.pool.Mount, "box-alice", "secret.txt")
+	if err := os.WriteFile(secret, hookCanary, 0o600); err != nil {
+		t.Fatalf("write canary: %v", err)
+	}
+
+	// Positive control. Without it, "the canary is absent" would prove
+	// nothing: ZFS compresses by default, so an absent canary could just
+	// mean lz4 rearranged the bytes, and this test would pass just as
+	// happily against a dataset that was never encrypted. A sibling
+	// UNENCRYPTED dataset, compression off, establishes that the search can
+	// find plaintext at all.
+	plain := h.pool.Dataset("plain-control")
+	zfspool.Run(t, "zfs", "create", "-o", "compression=off", plain)
+	plainCanary := append([]byte("CTRL-"), hookCanary...)
+	if err := os.WriteFile(filepath.Join(h.pool.Mount, "plain-control", "secret.txt"), plainCanary, 0o600); err != nil {
+		t.Fatalf("write control canary: %v", err)
+	}
+	zfspool.UnmountIfMounted(t, plain)
+	if !h.pool.ContainsPlaintext(t, plainCanary) {
+		t.Fatal("POSITIVE CONTROL FAILED: plaintext on an unencrypted dataset was not found in the " +
+			"raw vdev, so the check below cannot detect plaintext and would pass for the wrong reason")
+	}
+
+	// "Stop the container": Incus unmounts, then the hook runs.
+	zfspool.UnmountIfMounted(t, dataset)
+	h.hooks.PostStop(ctx, "box-alice")
+
+	status, err := h.hooks.zfs.KeyStatus(ctx, dataset)
+	if err != nil {
+		t.Fatalf("KeyStatus: %v", err)
+	}
+	if status != zfscrypt.KeyUnavailable {
+		t.Errorf("keystatus after PostStop = %q, want %q — the hook did not drop the key",
+			status, zfscrypt.KeyUnavailable)
+	}
+
+	if h.pool.ContainsPlaintext(t, hookCanary) {
+		t.Error("the stopped container's data was found verbatim in the raw vdev — PostStop did " +
+			"not leave it as ciphertext (#1201)")
+	}
+}
+
+// AC 2 (#1201): stopping one of several containers under the same
+// encryptionroot must NOT unload the key, and the others keep running.
+//
+// This is the case the hook's ErrKeyInUse branch exists for. Here it is
+// exercised against real ZFS: two datasets share an encryptionroot, one is
+// unmounted, and the co-tenant's must stay readable.
+func TestIntegrationEncryption_PostStopKeepsKeyForRunningCoTenant(t *testing.T) {
+	ctx := context.Background()
+	h := newHarness(t)
+
+	// One tenant, one key, one encryptionroot — a parent with two children,
+	// which is the shape the design gives a tenant's containers.
+	key, ref, err := h.keys.Wrap(ctx, "acme")
+	if err != nil {
+		t.Fatalf("KeyProvider.Wrap: %v", err)
+	}
+	root := h.pool.Dataset("acme")
+	if err := h.hooks.zfs.CreateEncrypted(ctx, root, key); err != nil {
+		t.Fatalf("CreateEncrypted(root): %v", err)
+	}
+
+	for _, box := range []string{"box-one", "box-two"} {
+		ds := root + "/" + box
+		zfspool.Run(t, "zfs", "create", ds)
+		h.res.datasets[box] = ds
+		if err := h.hooks.RecordKeyRef(box, ref); err != nil {
+			t.Fatalf("RecordKeyRef(%s): %v", box, err)
+		}
+	}
+
+	// Confirm they really do share one encryptionroot — the property the
+	// whole per-tenant isolation claim rests on.
+	for _, box := range []string{"box-one", "box-two"} {
+		got, err := h.hooks.zfs.EncryptionRoot(ctx, h.res.datasets[box])
+		if err != nil {
+			t.Fatalf("EncryptionRoot(%s): %v", box, err)
+		}
+		if got != root {
+			t.Fatalf("%s encryptionroot = %q, want %q", box, got, root)
+		}
+	}
+
+	// Stop box-one while box-two is still "running" (still mounted).
+	zfspool.UnmountIfMounted(t, h.res.datasets["box-one"])
+	if !zfspool.IsMounted(t, h.res.datasets["box-two"]) {
+		t.Fatal("precondition: box-two should still be mounted")
+	}
+
+	// AC 3: the hook must not panic or block on this path — it returns
+	// nothing, because the container has already stopped.
+	h.hooks.PostStop(ctx, "box-one")
+
+	// The key must still be loaded: box-two is using it.
+	status, err := h.hooks.zfs.KeyStatus(ctx, root)
+	if err != nil {
+		t.Fatalf("KeyStatus(root): %v", err)
+	}
+	if status != zfscrypt.KeyAvailable {
+		t.Fatalf("keystatus = %q, want %q — stopping one container took the key away from its "+
+			"co-tenant, which would break a running box (#1201)", status, zfscrypt.KeyAvailable)
+	}
+
+	// And box-two must still be usable, not merely nominally keyed.
+	probe := filepath.Join(h.pool.Mount, "acme", "box-two", "still-alive.txt")
+	if err := os.WriteFile(probe, []byte("co-tenant still running"), 0o600); err != nil {
+		t.Errorf("co-tenant's dataset became unusable after its neighbour stopped: %v", err)
+	}
+}
+
+// AC 3 (#1201): a failed unload is logged and does not fail the stop.
+//
+// The container has already stopped; the operator needs to know, not to be
+// blocked. Exercised here with a dataset that is still mounted — the
+// realistic cause of a refusal — and asserted by the hook returning
+// normally rather than by reading logs.
+func TestIntegrationEncryption_PostStopDoesNotBlockOnFailure(t *testing.T) {
+	ctx := context.Background()
+	h := newHarness(t)
+
+	dataset := h.createBox(t, ctx, "box-busy", "busy")
+	if !zfspool.IsMounted(t, dataset) {
+		t.Skip("dataset is not mounted, so a refusal cannot be provoked")
+	}
+
+	// Deliberately do NOT unmount: unload-key will refuse.
+	h.hooks.PostStop(ctx, "box-busy")
+
+	// The hook returns nothing, so the assertion is that the stop was not
+	// impeded and the dataset is still intact and usable.
+	if status, err := h.hooks.zfs.KeyStatus(ctx, dataset); err != nil || status != zfscrypt.KeyAvailable {
+		t.Errorf("keystatus = %q (err %v); a refused unload must leave the dataset as it was",
+			status, err)
+	}
+}

--- a/internal/testsupport/zfspool/zfspool.go
+++ b/internal/testsupport/zfspool/zfspool.go
@@ -1,0 +1,130 @@
+//go:build zfs
+
+// Package zfspool builds throwaway ZFS pools for integration tests (#1200).
+//
+// Kept out of normal builds by the `zfs` build tag, and out of production
+// code entirely: nothing here is imported by anything that ships.
+//
+// Pools are file-backed — a sparse image under the test's temp dir, no real
+// disks — and named after the test binary's PID so they can never collide
+// with a pool on the host. They are destroyed on teardown, including when
+// the test fails.
+package zfspool
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// vdevSize is comfortably above ZFS's 64 MiB minimum.
+const vdevSize = 512 << 20
+
+// Require skips the test unless a usable ZFS is present.
+//
+// Skips rather than fails on purpose: a developer's laptop or a container
+// dev box legitimately has no ZFS. The CI lane that exists to demonstrate
+// the encryption claim asserts the environment separately and fails on a
+// skip, so this cannot quietly turn that lane into a no-op.
+func Require(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("ZFS pool operations need root; run with sudo -E")
+	}
+	for _, bin := range []string{"zfs", "zpool"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH; install zfsutils-linux", bin)
+		}
+	}
+	if _, err := os.Stat("/dev/zfs"); err != nil {
+		t.Skipf("/dev/zfs is absent, so the kernel module cannot be driven: %v", err)
+	}
+}
+
+// Run executes a command and fails the test on error.
+func Run(t *testing.T, name string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command(name, args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+// Pool is a throwaway file-backed pool.
+type Pool struct {
+	Name  string // the ZFS pool name
+	Mount string // its mountpoint
+	Image string // the backing file
+}
+
+// New creates a pool and registers its teardown.
+func New(t *testing.T) *Pool {
+	t.Helper()
+	dir := t.TempDir()
+	p := &Pool{
+		Name:  fmt.Sprintf("containarium-zfstest-%d", os.Getpid()),
+		Mount: filepath.Join(dir, "mnt"),
+		Image: filepath.Join(dir, "vdev.img"),
+	}
+
+	if err := os.MkdirAll(p.Mount, 0o755); err != nil {
+		t.Fatalf("mkdir mountpoint: %v", err)
+	}
+	f, err := os.Create(p.Image)
+	if err != nil {
+		t.Fatalf("create vdev: %v", err)
+	}
+	if err := f.Truncate(vdevSize); err != nil {
+		t.Fatalf("truncate vdev: %v", err)
+	}
+	_ = f.Close()
+
+	Run(t, "zpool", "create", "-m", p.Mount, p.Name, p.Image)
+	t.Cleanup(func() {
+		// -f because a failed test may have left a dataset mounted.
+		_ = exec.Command("zpool", "destroy", "-f", p.Name).Run()
+	})
+	return p
+}
+
+// Dataset returns a child dataset name under the pool.
+func (p *Pool) Dataset(name string) string { return p.Name + "/" + name }
+
+// ContainsPlaintext reports whether the pool's backing file contains the
+// needle. The pool is synced first so writes have reached the vdev.
+func (p *Pool) ContainsPlaintext(t *testing.T, needle []byte) bool {
+	t.Helper()
+	_ = exec.Command("zpool", "sync", p.Name).Run()
+
+	data, err := os.ReadFile(p.Image)
+	if err != nil {
+		t.Fatalf("read vdev image: %v", err)
+	}
+	return bytes.Contains(data, needle)
+}
+
+// UnmountIfMounted unmounts a dataset, tolerating "not currently mounted".
+//
+// Needed because `zfs load-key` makes a dataset readable but does NOT
+// remount it, so after an unload/load cycle a dataset has its key available
+// and no mount. In production the mount is Incus's job, which is why the
+// pre-start hook only loads the key.
+func UnmountIfMounted(t *testing.T, dataset string) {
+	t.Helper()
+	out, err := exec.Command("zfs", "unmount", dataset).CombinedOutput()
+	if err != nil && !strings.Contains(string(out), "not currently mounted") {
+		t.Fatalf("zfs unmount %s: %v\n%s", dataset, err, out)
+	}
+}
+
+// IsMounted reports the dataset's `mounted` property.
+func IsMounted(t *testing.T, dataset string) bool {
+	t.Helper()
+	out := Run(t, "zfs", "get", "-H", "-o", "value", "mounted", dataset)
+	return strings.TrimSpace(out) == "yes"
+}

--- a/pkg/core/zfscrypt/zfscrypt_integration_test.go
+++ b/pkg/core/zfscrypt/zfscrypt_integration_test.go
@@ -20,12 +20,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/footprintai/containarium/internal/testsupport/zfspool"
 )
 
 // canary is the plaintext we hunt for in the raw vdev. Distinctive enough
@@ -33,105 +34,7 @@ import (
 // survive block alignment.
 var canary = bytes.Repeat([]byte("CONTAINARIUM-PLAINTEXT-CANARY-7f3a9b2c-"), 64)
 
-func requireZFS(t *testing.T) {
-	t.Helper()
-	if os.Geteuid() != 0 {
-		t.Skip("ZFS pool operations need root; run with sudo -E")
-	}
-	for _, bin := range []string{"zfs", "zpool"} {
-		if _, err := exec.LookPath(bin); err != nil {
-			t.Skipf("%s not on PATH; install zfsutils-linux", bin)
-		}
-	}
-	if _, err := os.Stat("/dev/zfs"); err != nil {
-		t.Skipf("/dev/zfs is absent, so the kernel module cannot be driven: %v", err)
-	}
-}
-
-func run(t *testing.T, name string, args ...string) string {
-	t.Helper()
-	out, err := exec.Command(name, args...).CombinedOutput()
-	if err != nil {
-		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, out)
-	}
-	return string(out)
-}
-
-// testPool creates a throwaway file-backed pool and returns its name and
-// mountpoint. Destroyed on teardown, including on failure.
-func testPool(t *testing.T) (pool, mnt string) {
-	t.Helper()
-	dir := t.TempDir()
-	img := filepath.Join(dir, "vdev.img")
-	mnt = filepath.Join(dir, "mnt")
-
-	if err := os.MkdirAll(mnt, 0o755); err != nil {
-		t.Fatalf("mkdir mnt: %v", err)
-	}
-	f, err := os.Create(img)
-	if err != nil {
-		t.Fatalf("create vdev: %v", err)
-	}
-	// 512 MiB — comfortably above ZFS's 64 MiB minimum vdev.
-	if err := f.Truncate(512 << 20); err != nil {
-		t.Fatalf("truncate vdev: %v", err)
-	}
-	_ = f.Close()
-
-	// A name unique to this test binary, so a stray pool can never collide
-	// with a real one on the host.
-	pool = fmt.Sprintf("containarium-zfstest-%d", os.Getpid())
-	run(t, "zpool", "create", "-m", mnt, pool, img)
-	t.Cleanup(func() {
-		// -f because a failed test may have left a dataset mounted.
-		_ = exec.Command("zpool", "destroy", "-f", pool).Run()
-	})
-	return pool, mnt
-}
-
 // testKey is shared with the unit tests in zfscrypt_test.go.
-
-// vdevContains reports whether the pool's backing file contains the needle.
-// The pool is synced first so writes have reached the vdev.
-func vdevContains(t *testing.T, pool, img string, needle []byte) bool {
-	t.Helper()
-	_ = exec.Command("zpool", "sync", pool).Run()
-
-	data, err := os.ReadFile(img)
-	if err != nil {
-		t.Fatalf("read vdev image: %v", err)
-	}
-	return bytes.Contains(data, needle)
-}
-
-// unmountIfMounted unmounts a dataset, tolerating "not currently mounted".
-//
-// Needed because `zfs load-key` makes a dataset readable but does NOT remount
-// it — so after an unload/load cycle the dataset has its key available and no
-// mount. (Confirmed on a real pool; the first version of this test assumed
-// load-key remounted and failed with "not currently mounted".) In production
-// the mount is Incus's job, which is why the pre-start hook only loads the
-// key.
-func unmountIfMounted(t *testing.T, dataset string) {
-	t.Helper()
-	out, err := exec.Command("zfs", "unmount", dataset).CombinedOutput()
-	if err != nil && !strings.Contains(string(out), "not currently mounted") {
-		t.Fatalf("zfs unmount %s: %v\n%s", dataset, err, out)
-	}
-}
-
-// poolImage returns the backing file for a pool created by testPool.
-func poolImage(t *testing.T, pool string) string {
-	t.Helper()
-	out := run(t, "zpool", "status", "-P", pool)
-	for _, line := range strings.Fields(out) {
-		if strings.HasSuffix(line, "vdev.img") {
-			return line
-		}
-	}
-	t.Fatalf("could not find the vdev path in:\n%s", out)
-	return ""
-}
 
 // THE security claim (#1168, #1201): a stopped container's dataset is
 // ciphertext, including to host root.
@@ -144,42 +47,41 @@ func poolImage(t *testing.T, pool string) string {
 // that was never encrypted at all. Both datasets set compression=off so the
 // only difference between them is encryption.
 func TestIntegration_StoppedDatasetIsCiphertextAtRest(t *testing.T) {
-	requireZFS(t)
+	zfspool.Require(t)
 	ctx := context.Background()
-	pool, mnt := testPool(t)
-	img := poolImage(t, pool)
+	p := zfspool.New(t)
 	m := NewManager(nil) // the real zfs binary
 
-	plainDS := pool + "/plain"
+	plainDS := p.Dataset("plain")
 	plainCanary := append([]byte("PLAIN-"), canary...)
-	run(t, "zfs", "create", "-o", "compression=off", plainDS)
-	if err := os.WriteFile(filepath.Join(mnt, "plain", "secret.txt"), plainCanary, 0o600); err != nil {
+	zfspool.Run(t, "zfs", "create", "-o", "compression=off", plainDS)
+	if err := os.WriteFile(filepath.Join(p.Mount, "plain", "secret.txt"), plainCanary, 0o600); err != nil {
 		t.Fatalf("write plaintext canary: %v", err)
 	}
-	run(t, "zfs", "unmount", plainDS)
+	zfspool.Run(t, "zfs", "unmount", plainDS)
 
-	if !vdevContains(t, pool, img, plainCanary) {
+	if !p.ContainsPlaintext(t, plainCanary) {
 		t.Fatal("POSITIVE CONTROL FAILED: the canary written to an UNENCRYPTED dataset was not " +
 			"found in the raw vdev. The search cannot detect plaintext at all, so the " +
 			"encrypted case below would 'pass' for the wrong reason. Failing loudly instead.")
 	}
 	t.Log("positive control OK: plaintext on an unencrypted dataset IS visible in the raw vdev")
 
-	encDS := pool + "/encrypted"
+	encDS := p.Dataset("encrypted")
 	key := testKey(t, 0xA5)
 	if err := m.CreateEncrypted(ctx, encDS, key); err != nil {
 		t.Fatalf("CreateEncrypted (assumption: keylocation=file:///dev/stdin with the raw key "+
 			"on stdin is accepted by zfs create): %v", err)
 	}
-	run(t, "zfs", "set", "compression=off", encDS)
+	zfspool.Run(t, "zfs", "set", "compression=off", encDS)
 
 	encCanary := append([]byte("ENCRD-"), canary...)
-	if err := os.WriteFile(filepath.Join(mnt, "encrypted", "secret.txt"), encCanary, 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(p.Mount, "encrypted", "secret.txt"), encCanary, 0o600); err != nil {
 		t.Fatalf("write encrypted canary: %v", err)
 	}
 
 	// Stop the "container": unmount, then drop the key.
-	run(t, "zfs", "unmount", encDS)
+	zfspool.Run(t, "zfs", "unmount", encDS)
 	if err := m.UnloadKey(ctx, encDS); err != nil {
 		t.Fatalf("UnloadKey after unmount: %v", err)
 	}
@@ -200,7 +102,7 @@ func TestIntegration_StoppedDatasetIsCiphertextAtRest(t *testing.T) {
 	}
 
 	// AC: and the plaintext genuinely is not on the disk.
-	if vdevContains(t, pool, img, encCanary) {
+	if p.ContainsPlaintext(t, encCanary) {
 		t.Error("the canary written to the ENCRYPTED dataset was found verbatim in the raw vdev — " +
 			"the data is not encrypted at rest (#1168)")
 	}
@@ -210,18 +112,18 @@ func TestIntegration_StoppedDatasetIsCiphertextAtRest(t *testing.T) {
 // written anywhere. Here that is checked against the real binary — the unit
 // test can only show what we passed to a fake.
 func TestIntegration_KeyRoundTripsThroughStdin(t *testing.T) {
-	requireZFS(t)
+	zfspool.Require(t)
 	ctx := context.Background()
-	pool, _ := testPool(t)
+	p := zfspool.New(t)
 	m := NewManager(nil)
 
-	ds := pool + "/roundtrip"
+	ds := p.Dataset("roundtrip")
 	key := testKey(t, 0x5A)
 	if err := m.CreateEncrypted(ctx, ds, key); err != nil {
 		t.Fatalf("CreateEncrypted: %v", err)
 	}
 
-	unmountIfMounted(t, ds)
+	zfspool.UnmountIfMounted(t, ds)
 	if err := m.UnloadKey(ctx, ds); err != nil {
 		t.Fatalf("UnloadKey: %v", err)
 	}
@@ -241,7 +143,7 @@ func TestIntegration_KeyRoundTripsThroughStdin(t *testing.T) {
 	}
 
 	// A wrong key must be refused rather than silently accepted.
-	unmountIfMounted(t, ds)
+	zfspool.UnmountIfMounted(t, ds)
 	if err := m.UnloadKey(ctx, ds); err != nil {
 		t.Fatalf("UnloadKey before the wrong-key check: %v", err)
 	}
@@ -259,17 +161,17 @@ func TestIntegration_KeyRoundTripsThroughStdin(t *testing.T) {
 // instead refused for the mundane reason that this dataset is still mounted,
 // the hook would log the wrong explanation AND leave the data readable.
 func TestIntegration_UnloadKeyRefusesWhileMounted(t *testing.T) {
-	requireZFS(t)
+	zfspool.Require(t)
 	ctx := context.Background()
-	pool, _ := testPool(t)
+	p := zfspool.New(t)
 	m := NewManager(nil)
 
-	ds := pool + "/mounted"
+	ds := p.Dataset("mounted")
 	if err := m.CreateEncrypted(ctx, ds, testKey(t, 0x33)); err != nil {
 		t.Fatalf("CreateEncrypted: %v", err)
 	}
 	// Freshly created and still mounted.
-	if out := run(t, "zfs", "get", "-H", "-o", "value", "mounted", ds); strings.TrimSpace(out) != "yes" {
+	if out := zfspool.Run(t, "zfs", "get", "-H", "-o", "value", "mounted", ds); strings.TrimSpace(out) != "yes" {
 		t.Skipf("dataset is not mounted (%q), so this assumption cannot be exercised", strings.TrimSpace(out))
 	}
 
@@ -288,21 +190,21 @@ func TestIntegration_UnloadKeyRefusesWhileMounted(t *testing.T) {
 // Assumption 3: keystatus reports exactly "available"/"unavailable", and an
 // unencrypted dataset reports "-" (which the package treats as an error).
 func TestIntegration_KeyStatusVocabulary(t *testing.T) {
-	requireZFS(t)
+	zfspool.Require(t)
 	ctx := context.Background()
-	pool, _ := testPool(t)
+	p := zfspool.New(t)
 	m := NewManager(nil)
 
-	enc := pool + "/enc"
+	enc := p.Dataset("enc")
 	if err := m.CreateEncrypted(ctx, enc, testKey(t, 0x77)); err != nil {
 		t.Fatalf("CreateEncrypted: %v", err)
 	}
-	if got := strings.TrimSpace(run(t, "zfs", "get", "-H", "-o", "value", "keystatus", enc)); got != "available" {
+	if got := strings.TrimSpace(zfspool.Run(t, "zfs", "get", "-H", "-o", "value", "keystatus", enc)); got != "available" {
 		t.Errorf("raw keystatus = %q, want \"available\" — the package parses this string exactly", got)
 	}
 
-	plain := pool + "/plain"
-	run(t, "zfs", "create", plain)
+	plain := p.Dataset("plain")
+	zfspool.Run(t, "zfs", "create", plain)
 	if _, err := m.KeyStatus(ctx, plain); err == nil {
 		t.Error("KeyStatus accepted an unencrypted dataset; the caller and the dataset disagree " +
 			"about what this container is, which must be an error")
@@ -310,7 +212,7 @@ func TestIntegration_KeyStatusVocabulary(t *testing.T) {
 
 	// EncryptionRoot is what the per-tenant isolation claim rests on.
 	child := enc + "/child"
-	run(t, "zfs", "create", child)
+	zfspool.Run(t, "zfs", "create", child)
 	root, err := m.EncryptionRoot(ctx, child)
 	if err != nil {
 		t.Fatalf("EncryptionRoot: %v", err)


### PR DESCRIPTION
Closes #1201.

#1201's first acceptance criterion was *"verified by test, per #1200"*. #1200 landed, so it can now be met.

### Why #1241 wasn't already enough

#1241 proved the ZFS semantics through `zfscrypt.Manager`. That's not quite the claim: production calls the **PostStop hook**, and the hook is what has to leave a stopped container's data unreadable. These tests drive the hook itself over a real pool.

Only the Incus-side plumbing is faked — the key-ref store and the dataset resolver. The `KeyProvider`, the `zfscrypt.Manager` and the pool are all real.

### One test per acceptance criterion

- **AC1** — `PostStop` on the last container leaves the dataset as ciphertext. Same positive control as #1241: a sibling **unencrypted** dataset whose canary must be findable in the raw vdev *first*, or "canary absent" would only mean lz4 rearranged the bytes.
- **AC2** — stopping one of two containers under a **shared encryptionroot** does not take the key away, and the co-tenant stays usable. Asserted by *writing to it afterwards*, not merely by reading `keystatus` — nominally-keyed and actually-usable are different claims. This is the case the hook's `ErrKeyInUse` branch exists for, and the first time it's been exercised against real ZFS rather than a fake that was *told* to return that error.
- **AC3** — a refused unload doesn't impede the stop and leaves the dataset as it was.

The test also confirms the two children really do share one encryptionroot before relying on it — the property the whole per-tenant isolation claim rests on.

### Shared pool helper

Pool setup moves to `internal/testsupport/zfspool` so both lanes share one implementation rather than growing two that drift, and #1202–#1204 will want it. It carries the `zfs` build tag, so it's absent from normal builds and imported only by tagged tests.

The `internal/ci` guards from #1237 confirm the extended workflow is still correctly gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)