### PR TITLE
feat(zfscrypt): snapshot operations under encryption, and verify the premise

### DIFF
--- a/pkg/core/zfscrypt/snapshot.go
+++ b/pkg/core/zfscrypt/snapshot.go
@@ -1,0 +1,126 @@
+package zfscrypt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Snapshot operations under encryption (#1202).
+//
+// The design's resolved decision #3: snapshot CREATION is allowed while the
+// key is unavailable, and the inspection-time read is what fails. Blocking
+// creation on key custody would let a transient KMS outage silently suppress
+// a backup window — losing the backup is worse than having one that cannot
+// be read until custody recovers.
+//
+// That split rests on a claim about ZFS: snapshots of an encrypted dataset
+// can be taken, listed and destroyed with the key unloaded, because those
+// operate on metadata rather than on the encrypted contents. It is verified
+// against a real pool in zfscrypt_integration_test.go rather than assumed.
+
+// ErrKeyUnavailableForInspection reports that a snapshot exists but cannot
+// be read because its dataset's key is not loaded.
+//
+// A distinct error because the caller's remedy is specific and the raw ZFS
+// message is not: the snapshot is intact, nothing is lost, and the fix is to
+// restore key custody and retry (#1202 AC2).
+var ErrKeyUnavailableForInspection = fmt.Errorf("snapshot contents cannot be read: the dataset's encryption key is not loaded")
+
+// validateSnapshotName rejects names that would change which object a
+// command acts on. `@` in particular would turn one snapshot reference into
+// another.
+func validateSnapshotName(name string) error {
+	switch {
+	case name == "":
+		return fmt.Errorf("snapshot name is required")
+	case strings.HasPrefix(name, "-"):
+		return fmt.Errorf("invalid snapshot name %q: leading dash would be read as a flag", name)
+	case strings.ContainsAny(name, " \t\n\r@/"):
+		return fmt.Errorf("invalid snapshot name %q: must not contain whitespace, '@' or '/'", name)
+	}
+	return nil
+}
+
+// Snapshot creates <dataset>@<name> and returns the full snapshot name.
+//
+// Deliberately does NOT require the key. See the package-level note above:
+// a backup that cannot be read yet beats no backup at all.
+func (m *Manager) Snapshot(ctx context.Context, dataset, name string) (string, error) {
+	if err := validateDataset(dataset); err != nil {
+		return "", err
+	}
+	if err := validateSnapshotName(name); err != nil {
+		return "", err
+	}
+
+	full := dataset + "@" + name
+	_, stderr, err := m.run.Run(ctx, nil, "snapshot", full)
+	if err != nil {
+		return "", fmt.Errorf("create snapshot %s: %w: %s", full, err, strings.TrimSpace(stderr))
+	}
+	return full, nil
+}
+
+// ListSnapshots returns the snapshots of a dataset, newest last.
+//
+// Works with the key unloaded: snapshot names are metadata, not contents.
+func (m *Manager) ListSnapshots(ctx context.Context, dataset string) ([]string, error) {
+	if err := validateDataset(dataset); err != nil {
+		return nil, err
+	}
+	stdout, stderr, err := m.run.Run(ctx, nil,
+		"list", "-H", "-t", "snapshot", "-o", "name", "-s", "creation", "-r", dataset)
+	if err != nil {
+		return nil, fmt.Errorf("list snapshots of %s: %w: %s", dataset, err, strings.TrimSpace(stderr))
+	}
+
+	var out []string
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			out = append(out, line)
+		}
+	}
+	return out, nil
+}
+
+// DestroySnapshot removes a snapshot. Like creation, it does not need the
+// key — retention must keep working while custody is down, or a KMS outage
+// would silently become an unbounded-growth incident.
+func (m *Manager) DestroySnapshot(ctx context.Context, snapshot string) error {
+	dataset, _, ok := strings.Cut(snapshot, "@")
+	if !ok {
+		return fmt.Errorf("invalid snapshot reference %q: expected <dataset>@<name>", snapshot)
+	}
+	if err := validateDataset(dataset); err != nil {
+		return err
+	}
+	if _, stderr, err := m.run.Run(ctx, nil, "destroy", snapshot); err != nil {
+		return fmt.Errorf("destroy snapshot %s: %w: %s", snapshot, err, strings.TrimSpace(stderr))
+	}
+	return nil
+}
+
+// EnsureInspectable reports whether a snapshot's CONTENTS can be read,
+// returning ErrKeyUnavailableForInspection when they cannot.
+//
+// Called before an inspection so the caller gets a specific, actionable
+// error instead of whatever ZFS says when a read hits an unkeyed dataset —
+// which reads like corruption and sends an operator hunting the wrong
+// problem (#1202 AC2).
+func (m *Manager) EnsureInspectable(ctx context.Context, snapshot string) error {
+	dataset, _, ok := strings.Cut(snapshot, "@")
+	if !ok {
+		return fmt.Errorf("invalid snapshot reference %q: expected <dataset>@<name>", snapshot)
+	}
+
+	status, err := m.KeyStatus(ctx, dataset)
+	if err != nil {
+		return err
+	}
+	if status != KeyAvailable {
+		return fmt.Errorf("%s: %w (dataset %s, keystatus %q)",
+			snapshot, ErrKeyUnavailableForInspection, dataset, status)
+	}
+	return nil
+}

--- a/pkg/core/zfscrypt/snapshot_test.go
+++ b/pkg/core/zfscrypt/snapshot_test.go
@@ -1,0 +1,126 @@
+package zfscrypt
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Unit coverage for the snapshot operations (#1202). These pin the
+// orchestration; whether ZFS really permits snapshotting an unkeyed dataset
+// is verified against a real pool in zfscrypt_integration_test.go.
+
+// The resolved design decision: creation must NOT consult the key. A
+// transient KMS outage suppressing the backup window is worse than a backup
+// that cannot be read until custody recovers.
+func TestSnapshotDoesNotRequireTheKey(t *testing.T) {
+	f := newFakeRunner()
+	m := NewManager(f)
+
+	full, err := m.Snapshot(context.Background(), "pool/c/alice", "pre-upgrade")
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if full != "pool/c/alice@pre-upgrade" {
+		t.Errorf("returned %q", full)
+	}
+
+	args := f.allArgs()
+	if strings.Contains(args, "keystatus") {
+		t.Error("snapshot creation consulted keystatus — a KMS outage would then suppress the " +
+			"backup window, which decision #3 explicitly rejects")
+	}
+	if !strings.Contains(args, "snapshot pool/c/alice@pre-upgrade") {
+		t.Errorf("unexpected command: %s", args)
+	}
+}
+
+// Retention must keep working while custody is down, or an outage becomes an
+// unbounded-growth incident.
+func TestDestroySnapshotDoesNotRequireTheKey(t *testing.T) {
+	f := newFakeRunner()
+	m := NewManager(f)
+
+	if err := m.DestroySnapshot(context.Background(), "pool/c/alice@old"); err != nil {
+		t.Fatalf("DestroySnapshot: %v", err)
+	}
+	if strings.Contains(f.allArgs(), "keystatus") {
+		t.Error("snapshot destruction consulted keystatus; retention must survive a key outage")
+	}
+}
+
+// A snapshot name must not be able to redirect the command at another
+// object — '@' is the separator, so a name containing one would.
+func TestSnapshotNameValidation(t *testing.T) {
+	for _, name := range []string{"", "-o", "has space", "has@at", "has/slash", "has\nnewline"} {
+		t.Run("name="+name, func(t *testing.T) {
+			f := newFakeRunner()
+			if _, err := NewManager(f).Snapshot(context.Background(), "pool/c/alice", name); err == nil {
+				t.Errorf("accepted snapshot name %q", name)
+			}
+			if len(f.calls) != 0 {
+				t.Error("a rejected name must not reach zfs")
+			}
+		})
+	}
+}
+
+func TestSnapshotRejectsABadDataset(t *testing.T) {
+	f := newFakeRunner()
+	if _, err := NewManager(f).Snapshot(context.Background(), "pool", "snap"); err == nil {
+		t.Error("accepted a bare pool name")
+	}
+	if len(f.calls) != 0 {
+		t.Error("a rejected dataset must not reach zfs")
+	}
+}
+
+// AC2: inspection must fail with a specific error, not an opaque ZFS one.
+func TestEnsureInspectableReportsKeyUnavailableDistinctly(t *testing.T) {
+	f := newFakeRunner()
+	f.stdout["get"] = "unavailable"
+	m := NewManager(f)
+
+	err := m.EnsureInspectable(context.Background(), "pool/c/alice@snap")
+	if !errors.Is(err, ErrKeyUnavailableForInspection) {
+		t.Fatalf("err = %v, want ErrKeyUnavailableForInspection — the caller's remedy is specific "+
+			"(restore key custody and retry) and a raw ZFS read error does not convey it", err)
+	}
+	// The message has to name what to look at.
+	for _, want := range []string{"pool/c/alice@snap", "pool/c/alice", "unavailable"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message is missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestEnsureInspectablePassesWhenKeyLoaded(t *testing.T) {
+	f := newFakeRunner()
+	f.stdout["get"] = "available"
+	if err := NewManager(f).EnsureInspectable(context.Background(), "pool/c/alice@snap"); err != nil {
+		t.Errorf("EnsureInspectable with the key loaded: %v", err)
+	}
+}
+
+func TestEnsureInspectableRejectsANonSnapshot(t *testing.T) {
+	f := newFakeRunner()
+	if err := NewManager(f).EnsureInspectable(context.Background(), "pool/c/alice"); err == nil {
+		t.Error("accepted a dataset where a snapshot reference was required")
+	}
+}
+
+func TestListSnapshotsParsesAndSkipsBlanks(t *testing.T) {
+	f := newFakeRunner()
+	f.stdout["list"] = "pool/c/alice@a\npool/c/alice@b\n\n"
+	got, err := NewManager(f).ListSnapshots(context.Background(), "pool/c/alice")
+	if err != nil {
+		t.Fatalf("ListSnapshots: %v", err)
+	}
+	if len(got) != 2 || got[0] != "pool/c/alice@a" || got[1] != "pool/c/alice@b" {
+		t.Errorf("got %v", got)
+	}
+	if strings.Contains(f.allArgs(), "keystatus") {
+		t.Error("listing consulted keystatus; snapshot names are metadata and need no key")
+	}
+}

--- a/pkg/core/zfscrypt/zfscrypt_integration_test.go
+++ b/pkg/core/zfscrypt/zfscrypt_integration_test.go
@@ -289,3 +289,87 @@ func TestIntegration_TenantsCannotUnlockEachOther(t *testing.T) {
 			status, err, KeyAvailable)
 	}
 }
+
+// The premise behind resolved decision #3 (#1202): snapshots of an encrypted
+// dataset can be taken, listed and destroyed with the key UNLOADED, because
+// those touch metadata rather than contents.
+//
+// The design chose "allow creation, fail the read" on the strength of that
+// claim — blocking creation on key custody would let a transient KMS outage
+// silently suppress a backup window. If ZFS actually refused to snapshot an
+// unkeyed dataset, that decision would be unimplementable and the sprint's
+// backup story would need rethinking, so it is worth demonstrating rather
+// than believing.
+func TestIntegration_SnapshotsWorkWithTheKeyUnloaded(t *testing.T) {
+	zfspool.Require(t)
+	ctx := context.Background()
+	p := zfspool.New(t)
+	m := NewManager(nil)
+
+	ds := p.Dataset("snapme")
+	key := testKey(t, 0xC3)
+	if err := m.CreateEncrypted(ctx, ds, key); err != nil {
+		t.Fatalf("CreateEncrypted: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(p.Mount, "snapme", "data.txt"), []byte("tenant data"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Stop the container: unmount and drop the key.
+	zfspool.UnmountIfMounted(t, ds)
+	if err := m.UnloadKey(ctx, ds); err != nil {
+		t.Fatalf("UnloadKey: %v", err)
+	}
+	if status, err := m.KeyStatus(ctx, ds); err != nil || status != KeyUnavailable {
+		t.Fatalf("precondition: keystatus = %q (err %v), want %q", status, err, KeyUnavailable)
+	}
+
+	// THE premise: creation succeeds anyway.
+	snap, err := m.Snapshot(ctx, ds, "backup-window")
+	if err != nil {
+		t.Fatalf("snapshot of an unkeyed dataset FAILED: %v\n"+
+			"Decision #3 (allow creation while the key is unavailable) assumes this works. "+
+			"If ZFS refuses, the design's backup story needs rethinking, not a workaround.", err)
+	}
+
+	// Listing is metadata, so it must work too.
+	snaps, err := m.ListSnapshots(ctx, ds)
+	if err != nil {
+		t.Fatalf("ListSnapshots with the key unloaded: %v", err)
+	}
+	var found bool
+	for _, s := range snaps {
+		if s == snap {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("snapshot %q not listed; got %v", snap, snaps)
+	}
+
+	// AC2: inspection is refused, and specifically.
+	err = m.EnsureInspectable(ctx, snap)
+	if !errors.Is(err, ErrKeyUnavailableForInspection) {
+		t.Errorf("EnsureInspectable = %v, want ErrKeyUnavailableForInspection", err)
+	}
+
+	// Once custody is back, the same snapshot becomes inspectable — the
+	// snapshot was never damaged, only unreadable.
+	if err := m.LoadKey(ctx, ds, key); err != nil {
+		t.Fatalf("LoadKey: %v", err)
+	}
+	if err := m.EnsureInspectable(ctx, snap); err != nil {
+		t.Errorf("snapshot still not inspectable after the key came back: %v", err)
+	}
+
+	// And retention works without the key: drop it again, then destroy.
+	zfspool.UnmountIfMounted(t, ds)
+	if err := m.UnloadKey(ctx, ds); err != nil {
+		t.Fatalf("UnloadKey (second): %v", err)
+	}
+	if err := m.DestroySnapshot(ctx, snap); err != nil {
+		t.Errorf("DestroySnapshot with the key unloaded failed: %v\n"+
+			"Retention has to survive a key outage, or an outage becomes an "+
+			"unbounded-growth incident.", err)
+	}
+}


### PR DESCRIPTION
Toward #1202. **Does not close it** — see the last section.

### The claim the design rests on

Resolved decision #3 allows snapshot **creation** while the key is unavailable and lets the inspection-time read fail instead. The reasoning: blocking creation on key custody would let a transient KMS outage silently suppress a backup window, and losing the backup is worse than having one that can't be read until custody recovers.

That decision rests on a claim about ZFS — snapshots of an encrypted dataset can be taken, listed and destroyed with the key **unloaded**, because those touch metadata rather than contents.

Now that #1200 gives us a real pool, that claim is **demonstrated rather than believed**. Had ZFS refused, decision #3 would be unimplementable and the sprint's backup story would need rethinking, not a workaround — which is exactly why it's worth a test rather than a paragraph.

### What's added

`Snapshot`, `ListSnapshots`, `DestroySnapshot`, `EnsureInspectable`.

Creation, listing and destruction **deliberately never consult `keystatus`**, and unit tests assert they don't. Consulting it is precisely how a key outage would turn into a suppressed backup window — or, for retention, into an unbounded-growth incident when cleanup stops running.

### AC2's specific error

A raw ZFS read against an unkeyed dataset reads like corruption and sends an operator hunting the wrong problem. `ErrKeyUnavailableForInspection` says what's actually true: the snapshot is intact, nothing is lost, and the remedy is to restore key custody and retry.

The integration test shows exactly that arc — snapshot taken while unkeyed, inspection refused with the specific error, and **the same snapshot becomes inspectable once the key returns**. Then the key is dropped again and the snapshot is destroyed, proving retention survives an outage.

### Acceptance criteria

- [x] Snapshot creation succeeds with the key unloaded *(verified against a real pool)* — **but see below for the status-warning half**
- [x] Inspecting such a snapshot fails with a clear, specific error rather than an opaque ZFS message
- [ ] #1160's snapshot work operates on encrypted datasets without the key — #1160 is a separate open issue; this provides the layer it would sit on

### Why this doesn't close #1202

AC1's second half wants a `KEY_UNAVAILABLE` warning on **container status**. There's no warning surface on the container proto today, and the warning is only reachable once containers can actually be encrypted — which needs the pre-create wiring in #1199, still blocked on Incus.

Building that proto surface now would ship a field nothing can set and no test can exercise end to end. I'd rather leave the AC honestly unticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)