### PR TITLE
fix(l4-proxy): rebuild the layer4 app after Caddy reverts to its stub

### DIFF
--- a/internal/app/route_sync.go
+++ b/internal/app/route_sync.go
@@ -29,6 +29,35 @@ type RouteSyncJob struct {
 	running bool
 	stopCh  chan struct{}
 	doneCh  chan struct{}
+
+	// l4Activated latches once the layer4 app has been brought up, and is
+	// what lets the sync tell "never needed L4" apart from "had L4 and lost
+	// it" (#1067).
+	//
+	// Caddy is configured entirely over the admin API, so a crash, restart
+	// or binary swap reverts it to the stub Caddyfile and the layer4 app
+	// disappears. The HTTP side self-heals via EnsureBaseConfig; L4 did not,
+	// because its activation is guarded by "are there passthrough routes?"
+	// — so a wipe that happened while the route set was empty left :443 as
+	// plain HTTP indefinitely, with no PROXY/SNI passthrough and nothing to
+	// notice.
+	//
+	// Guarded by mu: SyncNow can run concurrently with the ticker.
+	l4Activated bool
+}
+
+// l4WasActivated reports whether this daemon has ever had layer4 up.
+func (j *RouteSyncJob) l4WasActivated() bool {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.l4Activated
+}
+
+// markL4Activated records that layer4 is up.
+func (j *RouteSyncJob) markL4Activated() {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.l4Activated = true
 }
 
 // NewRouteSyncJob creates a new route sync job
@@ -270,15 +299,31 @@ func (j *RouteSyncJob) syncL4Routes(dbRoutes []*RouteRecord) error {
 	// behaviourally identical to the HTTP-on-:443 baseline — non-matching SNI
 	// already falls through to the HTTP fallback — but it never rewrites the
 	// listen address, so the listener is never restarted under live traffic.
+	//
+	// The same latch also covers Caddy losing its config entirely (#1067).
+	// Once L4 has been up, a later tick finding the layer4 app gone means
+	// Caddy reverted to its stub — not that we should stay lazy — so it is
+	// rebuilt regardless of how many passthrough routes currently exist.
+	// The route set being empty at that moment is exactly the case that
+	// used to leave :443 as plain HTTP forever.
 	if !j.l4ProxyManager.IsL4Active() {
-		if len(dbRoutes) == 0 {
+		healing := j.l4WasActivated()
+		if len(dbRoutes) == 0 && !healing {
 			return nil // never activated and nothing to route — stay lazy
 		}
 		if err := j.l4ProxyManager.ActivateL4(); err != nil {
 			return fmt.Errorf("failed to activate L4: %w", err)
 		}
-		log.Printf("[RouteSyncJob] L4 activated for %d passthrough route(s)", len(dbRoutes))
+		if healing {
+			log.Printf("[RouteSyncJob] layer4 app was missing though L4 had been active — Caddy "+
+				"reverted to its stub config; rebuilt L4 and reclaimed :443 for %d passthrough route(s) (#1067)",
+				len(dbRoutes))
+		} else {
+			log.Printf("[RouteSyncJob] L4 activated for %d passthrough route(s)", len(dbRoutes))
+		}
 	}
+	// L4 is up now, however it got there.
+	j.markL4Activated()
 
 	// Get current L4 routes from Caddy
 	caddyL4Routes, err := j.l4ProxyManager.ListL4Routes()

--- a/internal/app/route_sync_l4_selfheal_test.go
+++ b/internal/app/route_sync_l4_selfheal_test.go
@@ -1,0 +1,184 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// Self-heal for the layer4 app after Caddy reverts to its stub config (#1067).
+//
+// HTTP routes already self-heal: EnsureBaseConfig runs at the top of every
+// sync tick, notices the http app is gone and rebuilds it (#400). The layer4
+// app had no equivalent. A Caddy crash, restart, or binary swap wipes the
+// admin-API-only config, and on a host with PROXY protocol configured the
+// layer4 app stayed null indefinitely — :443 went back to plain HTTP with no
+// PROXY/SNI passthrough, and nothing noticed.
+//
+// syncL4Routes did contain an activation path, but it is guarded by
+// `len(dbRoutes) == 0 → return`, so it only fires while passthrough routes
+// exist. That is the gap: the observed production case had zero passthrough
+// routes at the time of the wipe, so nothing ever rebuilt layer4 — and a
+// route added later would have been the only thing to fix it.
+
+// wipeCaddyConfig simulates Caddy reverting to its stub Caddyfile: the whole
+// admin-API config is replaced, taking the layer4 app with it and putting the
+// HTTP server back on :80,:443.
+func wipeCaddyConfig(t *testing.T, adminURL string) {
+	t.Helper()
+	stub := map[string]interface{}{
+		"apps": map[string]interface{}{
+			"http": map[string]interface{}{
+				"servers": map[string]interface{}{
+					"srv0": map[string]interface{}{
+						"listen": []interface{}{":80", ":443"},
+						"routes": []interface{}{},
+					},
+				},
+			},
+		},
+	}
+	body, err := json.Marshal(stub)
+	if err != nil {
+		t.Fatalf("marshal stub: %v", err)
+	}
+	resp, err := http.Post(adminURL+"/load", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("simulate caddy wipe: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("simulate caddy wipe: status %d", resp.StatusCode)
+	}
+}
+
+func newL4SyncJob(t *testing.T) (*RouteSyncJob, *L4ProxyManager, string) {
+	t.Helper()
+	initial := map[string]interface{}{
+		"apps": map[string]interface{}{
+			"http": map[string]interface{}{
+				"servers": map[string]interface{}{
+					"srv0": map[string]interface{}{
+						"listen": []interface{}{":80", ":443"},
+						"routes": []interface{}{},
+					},
+				},
+			},
+		},
+	}
+	srv := newFakeCaddy(initial)
+	t.Cleanup(srv.Close)
+
+	m := NewL4ProxyManager(srv.URL)
+	return &RouteSyncJob{l4ProxyManager: m}, m, srv.URL
+}
+
+func passthroughRoute(domain string) *RouteRecord {
+	return &RouteRecord{
+		FullDomain: domain,
+		TargetIP:   "203.0.113.7",
+		TargetPort: 22,
+		Protocol:   string(RouteProtocolTLSPassthrough),
+		Active:     true,
+	}
+}
+
+// The reported case: L4 was active, Caddy's config got wiped, and the route
+// set is empty at the moment of the next sync. Without the self-heal the
+// zero-route early return means layer4 is never rebuilt.
+func TestSyncL4Routes_RebuildsLayer4AfterCaddyWipe_EmptyRouteSet(t *testing.T) {
+	j, m, adminURL := newL4SyncJob(t)
+
+	// L4 becomes active the normal way.
+	if err := j.syncL4Routes([]*RouteRecord{passthroughRoute("box-a.example")}); err != nil {
+		t.Fatalf("syncL4Routes(1 route): %v", err)
+	}
+	if !m.IsL4Active() {
+		t.Fatal("precondition: L4 should be active after the first passthrough route")
+	}
+
+	// Caddy restarts / is swapped: config reverts to the stub.
+	wipeCaddyConfig(t, adminURL)
+	if m.IsL4Active() {
+		t.Fatal("precondition: the wipe should have removed the layer4 app")
+	}
+
+	// The next tick, with no passthrough routes — exactly the observed case.
+	if err := j.syncL4Routes(nil); err != nil {
+		t.Fatalf("syncL4Routes(empty after wipe): %v", err)
+	}
+
+	if !m.IsL4Active() {
+		t.Fatal("layer4 was not rebuilt after Caddy reverted to its stub config: :443 stays plain " +
+			"HTTP with no PROXY/SNI passthrough, and nothing else will notice (#1067)")
+	}
+	assertHTTPOff443(t, adminURL)
+}
+
+// The same wipe with routes still present. This path already worked — the
+// activation branch fires because dbRoutes is non-empty — and must keep
+// working, including restoring the SNI routes.
+func TestSyncL4Routes_RebuildsLayer4AfterCaddyWipe_WithRoutes(t *testing.T) {
+	j, m, adminURL := newL4SyncJob(t)
+	route := passthroughRoute("box-a.example")
+
+	if err := j.syncL4Routes([]*RouteRecord{route}); err != nil {
+		t.Fatalf("syncL4Routes(1 route): %v", err)
+	}
+	wipeCaddyConfig(t, adminURL)
+
+	if err := j.syncL4Routes([]*RouteRecord{route}); err != nil {
+		t.Fatalf("syncL4Routes after wipe: %v", err)
+	}
+	if !m.IsL4Active() {
+		t.Fatal("L4 not active after a wipe with routes present")
+	}
+	if got := l4SNIs(t, m); len(got) != 1 || got[0] != "box-a.example" {
+		t.Fatalf("SNI routes not restored after the wipe: %v", got)
+	}
+}
+
+// The self-heal must not make activation eager. A daemon that has never had a
+// passthrough route must stay on plain HTTP :443 — activating rewrites the
+// :443 listen address, which restarts the listener and drops in-flight TLS
+// connections (#416). Lazy-until-needed is deliberate, and the heal only
+// restores what was already there.
+func TestSyncL4Routes_StaysLazyWhenNeverActivated(t *testing.T) {
+	j, m, adminURL := newL4SyncJob(t)
+
+	for i := 0; i < 3; i++ {
+		if err := j.syncL4Routes(nil); err != nil {
+			t.Fatalf("syncL4Routes(empty): %v", err)
+		}
+	}
+	if m.IsL4Active() {
+		t.Error("L4 activated without a passthrough route ever existing — that rewrites :443 and " +
+			"restarts the listener under live traffic (#416)")
+	}
+	assertHTTPOn443(t, adminURL)
+}
+
+// assertHTTPOn443 is the inverse of assertHTTPOff443: the HTTP server still
+// owns :443, i.e. layer4 was never activated.
+func assertHTTPOn443(t *testing.T, baseURL string) {
+	t.Helper()
+	cfg := readConfig(t, baseURL)
+	apps, _ := cfg["apps"].(map[string]interface{})
+	httpApp, _ := apps["http"].(map[string]interface{})
+	if httpApp == nil {
+		t.Fatal("no http app at all; expected srv0 still listening on :443")
+	}
+	servers, _ := httpApp["servers"].(map[string]interface{})
+	srv0, _ := servers["srv0"].(map[string]interface{})
+	if srv0 == nil {
+		t.Fatal("no srv0; expected it still listening on :443")
+	}
+	listen, _ := srv0["listen"].([]interface{})
+	for _, l := range listen {
+		if l == ":443" {
+			return
+		}
+	}
+	t.Fatalf("HTTP srv0 is not on :443 (listen=%v) — layer4 took the listener when it should not have", listen)
+}


### PR DESCRIPTION
Closes #1067.

### The gap

Caddy is configured entirely over the admin API, so a crash, restart or binary swap reverts it to the stub Caddyfile. HTTP routes already self-heal — `EnsureBaseConfig` runs at the top of every sync tick and rebuilds the http app (#400) — but the layer4 app had no equivalent. A host with PROXY protocol configured could sit on plain `:443` with no PROXY/SNI passthrough indefinitely, and nothing would notice.

### Two corrections to the issue

**1. The suggested fix would not have worked.** It proposes re-running `EnableL4ProxyProtocol` when `config/apps/layer4` is missing. But that call returns early when L4 is inactive — it only records the trusted CIDRs:

```go
if !m.IsL4Active() {
    log.Printf("[L4ProxyManager] PROXY protocol configured ...; L4 not active yet, will apply on activation")
    return nil
}
```

`ActivateL4` is the only thing that builds the layer4 app and re-splits the listen ports.

**2. The gap is narrower than described.** `syncL4Routes` already had an activation path, and it *does* heal a wipe — but only while passthrough routes exist, because of the `len(dbRoutes) == 0 → return` guard. The observed production case had **zero** passthrough routes at the moment of the wipe, which is exactly why nothing rebuilt layer4 there. A host with live routes would have recovered on the next tick.

That doesn't make it a non-bug — the topology stays wrong until a route happens to be added — but it does change what the fix has to be.

### The fix: a latch, not eager activation

Once layer4 has been up, finding it gone means Caddy reverted, so it's rebuilt regardless of the current route count.

Staying lazy until the first passthrough route is **deliberate**: activating rewrites the `:443` listen address, restarting the listener and dropping in-flight TLS connections (#416, "tls: internal error" on a concurrent container create). So a daemon that has never needed L4 must not acquire it. The latch distinguishes *"never needed it"* from *"had it and lost it"* — the only distinction that matters here.

Guarded by the existing mutex, since `SyncNow` can run concurrently with the ticker.

This also makes `EnsureBaseConfig`'s doc comment true: it claims the normal route/L4 diff "re-activates layer4" after a rebuild, which until now held only when passthrough routes happened to exist.

### Tests

Test-first — the empty-route-set case fails against the old code with the message naming the symptom. Mutation-tested **both ways**:

| mutation | fails |
| --- | --- |
| revert the self-heal | `RebuildsLayer4AfterCaddyWipe_EmptyRouteSet` |
| drop the laziness guard | `StaysLazyWhenNeverActivated` (the #416 regression) |

The second matters: the obvious over-correction — always activate when PROXY protocol is configured — reintroduces the listener bounce #416 was filed for. Also verified the pre-existing #416 latch test still passes, and the package is clean under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)