### PR TITLE
fix(pool): verify the tunnel handshake before reporting a successful join

### DIFF
--- a/internal/cmd/pool_join.go
+++ b/internal/cmd/pool_join.go
@@ -419,6 +419,7 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 	if err := exec.Command("systemctl", "enable", "--now", "containarium").Run(); err != nil {
 		return fmt.Errorf("systemctl enable --now containarium: %w", err)
 	}
+	tunnelStartedAt := time.Now().Add(-2 * time.Second) // small skew allowance
 	if err := exec.Command("systemctl", "enable", "--now", "containarium-tunnel").Run(); err != nil {
 		return fmt.Errorf("systemctl enable --now containarium-tunnel: %w", err)
 	}
@@ -433,6 +434,34 @@ func runPoolJoin(cmd *cobra.Command, args []string) error {
 	fmt.Println("Host capability self-check (containarium doctor):")
 	if failed := printDoctor(hostDoctorChecks()); failed > 0 {
 		return fmt.Errorf("pool join: %d required capability check(s) FAILED — units were installed but this host is NOT a healthy pool member yet; fix the above and re-run", failed)
+	}
+
+	// 5b. Verify the tunnel handshake was actually ACCEPTED before claiming
+	// the host joined (#1051). Everything above is host-side: units enabled,
+	// capabilities present. None of it asks the sentinel whether it took the
+	// tunnel, which is why a host rejected on every reconnect for 11 days
+	// still saw "Joined pool" and exit 0.
+	fmt.Println()
+	fmt.Println("Verifying the sentinel accepted the tunnel...")
+	outcome, detail := waitForTunnelHandshake(readUnitJournal, "containarium-tunnel",
+		tunnelStartedAt, 20*time.Second, time.Second)
+	switch outcome {
+	case tunnelHandshakeRejected:
+		return tunnelRejectedError(sentinelAddr, spotID, detail)
+	case tunnelHandshakeRegistered:
+		fmt.Printf("  ✓ sentinel accepted the tunnel (%s)\n", detail)
+	default:
+		// Not a failure: journald may be absent, or the first handshake may
+		// still be in flight. Say so plainly rather than implying success —
+		// an unverified join is exactly what this check exists to stop being
+		// silent.
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"  ⚠ could not confirm the tunnel handshake within 20s — the units are installed, but this\n"+
+				"    host is not confirmed joined. Check with:\n"+
+				"      sudo journalctl -u containarium-tunnel -n 50\n"+
+				"    A repeating \"handshake rejected\" there means the join token needs registering on the\n"+
+				"    sentinel (`containarium sentinel register-token`); re-running `pool join` will not help,\n"+
+				"    because join tokens do not expire.\n")
 	}
 
 	fmt.Println()

--- a/internal/cmd/pool_join_handshake.go
+++ b/internal/cmd/pool_join_handshake.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -91,8 +92,23 @@ func classifyTunnelJournal(journal string) (tunnelHandshakeOutcome, string) {
 // loop is testable without systemd.
 type journalReader func(unit string, since time.Time) (string, error)
 
+// validUnitName matches the systemd unit names this package is allowed to
+// read. Deliberately strict: the name becomes a command argument, and a
+// leading dash would be parsed as a flag.
+var validUnitName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9@._-]*$`)
+
 // readUnitJournal is the real reader.
 func readUnitJournal(unit string, since time.Time) (string, error) {
+	// The unit name is a package constant at the only call site, but it is a
+	// parameter for testability — so validate rather than assume, and keep
+	// the check next to the exec that depends on it.
+	if !validUnitName.MatchString(unit) {
+		return "", fmt.Errorf("refusing to read the journal for %q: not a valid unit name", unit)
+	}
+
+	// #nosec G204 -- the binary is the literal "journalctl"; the only
+	// non-literal argument is the unit name, which is validated immediately
+	// above and never reaches a shell (exec.Command does not use one).
 	out, err := exec.Command("journalctl",
 		"-u", unit,
 		"--since", since.Format("2006-01-02 15:04:05"),

--- a/internal/cmd/pool_join_handshake.go
+++ b/internal/cmd/pool_join_handshake.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Post-join verification that the tunnel handshake actually succeeded (#1051).
+//
+// `pool join` used to print `Joined pool ...` and exit 0 as soon as the units
+// were enabled and the host-side capability check passed. Both are host-side
+// facts. Nothing asked the sentinel whether the tunnel had been accepted, so a
+// tunnel being rejected on every reconnect looked exactly like a healthy join.
+//
+// A live BYOC host accumulated 9,423 consecutive `handshake rejected: invalid
+// token` rejections over 11 days that way, with `systemctl is-active` cheerful
+// throughout. The operator's only signal was a journal they had no reason to
+// open.
+//
+// The non-obvious part, and the reason a bare "check the logs" hint is not
+// enough: tunnel-join tokens DO NOT EXPIRE. Re-joining mints another token
+// that is unregistered in exactly the same way, so the intuitive remedy
+// reproduces the identical failure. The sentinel builds its token policy once
+// at startup, so any token minted afterwards — which is every token the cloud
+// BYOC flow issues — needs `sentinel register-token` before it can ever work.
+// That is what the failure message has to say.
+
+// tunnelHandshakeOutcome is what the tunnel unit's journal shows about the
+// most recent handshake attempt.
+type tunnelHandshakeOutcome int
+
+const (
+	// tunnelHandshakeUnknown: nothing decisive in the journal yet. Not a
+	// failure — the unit may still be starting, or journald may be
+	// unavailable — but not a success either.
+	tunnelHandshakeUnknown tunnelHandshakeOutcome = iota
+	// tunnelHandshakeRegistered: the sentinel accepted the tunnel.
+	tunnelHandshakeRegistered
+	// tunnelHandshakeRejected: the sentinel refused the handshake.
+	tunnelHandshakeRejected
+)
+
+func (o tunnelHandshakeOutcome) String() string {
+	switch o {
+	case tunnelHandshakeRegistered:
+		return "registered"
+	case tunnelHandshakeRejected:
+		return "rejected"
+	default:
+		return "unknown"
+	}
+}
+
+// Markers emitted by internal/sentinel/tunnel_client.go.
+//
+// registeredMarker is deliberately NOT "connected to sentinel": that is
+// logged when the TCP connection is established, BEFORE the handshake is
+// evaluated, so a host being rejected on every attempt logs it every time.
+// Treating it as success would reproduce the very bug this check exists to
+// catch. "registered as" is logged only after the sentinel accepts.
+const (
+	tunnelRegisteredMarker = "registered as"
+	tunnelRejectedMarker   = "handshake rejected"
+)
+
+// classifyTunnelJournal reports the outcome of the LAST decisive handshake
+// line in a journal excerpt, along with that line for context.
+//
+// Last-wins because the journal is chronological and both markers can appear
+// in one window: a host rejected on its first attempt and accepted after a
+// token was registered mid-poll has genuinely joined, and must not be
+// reported as broken.
+func classifyTunnelJournal(journal string) (tunnelHandshakeOutcome, string) {
+	outcome := tunnelHandshakeUnknown
+	var detail string
+
+	for _, line := range strings.Split(journal, "\n") {
+		switch {
+		case strings.Contains(line, tunnelRejectedMarker):
+			outcome, detail = tunnelHandshakeRejected, strings.TrimSpace(line)
+		case strings.Contains(line, tunnelRegisteredMarker):
+			outcome, detail = tunnelHandshakeRegistered, strings.TrimSpace(line)
+		}
+	}
+	return outcome, detail
+}
+
+// journalReader returns recent log text for a unit. Injectable so the wait
+// loop is testable without systemd.
+type journalReader func(unit string, since time.Time) (string, error)
+
+// readUnitJournal is the real reader.
+func readUnitJournal(unit string, since time.Time) (string, error) {
+	out, err := exec.Command("journalctl",
+		"-u", unit,
+		"--since", since.Format("2006-01-02 15:04:05"),
+		"--no-pager", "-n", "200",
+	).CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("read journal for %s: %w", unit, err)
+	}
+	return string(out), nil
+}
+
+// waitForTunnelHandshake polls the unit journal until the handshake is
+// decisively registered or rejected, or the timeout elapses.
+//
+// Returns Unknown rather than an error when the journal is unreadable: a host
+// without journald must still be able to join. Reporting "could not confirm"
+// is honest; failing the join would be a regression for those hosts.
+func waitForTunnelHandshake(read journalReader, unit string, since time.Time, timeout, poll time.Duration) (tunnelHandshakeOutcome, string) {
+	if poll <= 0 {
+		poll = 500 * time.Millisecond
+	}
+	deadline := time.Now().Add(timeout)
+
+	var lastOutcome = tunnelHandshakeUnknown
+	var lastDetail string
+	for {
+		journal, err := read(unit, since)
+		if err == nil {
+			if outcome, detail := classifyTunnelJournal(journal); outcome != tunnelHandshakeUnknown {
+				// A rejection can be followed by a success once a token is
+				// registered, but not the other way round within one join, so
+				// a registration is final. Keep polling through a rejection
+				// until the deadline in case it recovers.
+				lastOutcome, lastDetail = outcome, detail
+				if outcome == tunnelHandshakeRegistered {
+					return outcome, detail
+				}
+			}
+		}
+		if !time.Now().Before(deadline) {
+			return lastOutcome, lastDetail
+		}
+		time.Sleep(poll)
+	}
+}
+
+// tunnelRejectedError builds the failure the operator needs, naming the
+// remedy rather than the symptom.
+func tunnelRejectedError(sentinelAddr, spotID, detail string) error {
+	return fmt.Errorf(`pool join: the sentinel REJECTED this host's tunnel handshake — the units are installed but this host is NOT joined
+
+  %s
+
+Re-running `+"`pool join`"+` will NOT fix this: tunnel-join tokens do not expire, so a
+fresh token fails in exactly the same way. The sentinel builds its token policy
+once at startup, so a token minted afterwards (which is every token a cloud BYOC
+join issues) has to be registered with the running sentinel first:
+
+  containarium sentinel register-token --url https://%s --token <the join token>
+
+That call is gated on the sentinel's admin secret. If the sentinel was started
+without CONTAINARIUM_SENTINEL_ADMIN_SECRET, token registration is disabled
+entirely and the sentinel must be restarted with --tunnel-token-policy instead.
+
+  Tunnel logs: sudo journalctl -u containarium-tunnel -n 50
+  Spot ID:     %s`, detail, sentinelAddr, spotID)
+}

--- a/internal/cmd/pool_join_handshake_test.go
+++ b/internal/cmd/pool_join_handshake_test.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #1051: `pool join` printed "Joined pool" and exited 0 while the sentinel was
+// rejecting the tunnel on every reconnect — 9,423 consecutive rejections over
+// 11 days on a live BYOC host, with systemctl reporting the unit active
+// throughout.
+
+// Real log lines from internal/sentinel/tunnel_client.go.
+const (
+	lineConnected  = `Aug 09 12:00:01 host containarium-tunnel[1]: [tunnel-client] connected to sentinel edge.example:9443`
+	lineRejected   = `Aug 09 12:00:01 host containarium-tunnel[1]: [tunnel-client] connection lost: handshake rejected: invalid token`
+	lineRegistered = `Aug 09 12:00:02 host containarium-tunnel[1]: [tunnel-client] registered as "tunnel-abc", assigned IP 127.0.0.11`
+	lineReconnect  = `Aug 09 12:00:03 host containarium-tunnel[1]: [tunnel-client] reconnecting to edge.example:9443 (backoff: 2s)...`
+)
+
+// THE trap. "connected to sentinel" is logged when the TCP connection is
+// established, BEFORE the handshake is evaluated — so a host that is rejected
+// every time logs it every time. Treating it as the success marker reproduces
+// the exact bug this check exists to catch, while looking correct.
+//
+// The dangerous window is a poll landing between the connect and the
+// rejection: the journal then contains ONLY the connect line. A marker of
+// "connected to sentinel" reports that as joined; the real marker reports it
+// as undecided and keeps waiting.
+func TestClassifyTunnelJournal_ConnectedAloneIsNotSuccess(t *testing.T) {
+	outcome, _ := classifyTunnelJournal(lineConnected)
+	if outcome == tunnelHandshakeRegistered {
+		t.Fatal("'connected to sentinel' was treated as a successful handshake. It is logged before " +
+			"the handshake is evaluated, so a host about to be rejected looks joined — #1051 exactly")
+	}
+	if outcome != tunnelHandshakeUnknown {
+		t.Errorf("outcome = %v, want unknown while the handshake is still undecided", outcome)
+	}
+}
+
+// A full reject cycle still classifies as rejected, and quotes the reason.
+func TestClassifyTunnelJournal_RejectCycle(t *testing.T) {
+	journal := strings.Join([]string{lineConnected, lineRejected, lineReconnect}, "\n")
+
+	outcome, detail := classifyTunnelJournal(journal)
+	if outcome != tunnelHandshakeRejected {
+		t.Fatalf("outcome = %v, want rejected", outcome)
+	}
+	if !strings.Contains(detail, "invalid token") {
+		t.Errorf("detail should quote the rejection, got %q", detail)
+	}
+}
+
+func TestClassifyTunnelJournal_RegisteredIsSuccess(t *testing.T) {
+	journal := strings.Join([]string{lineConnected, lineRegistered}, "\n")
+	if outcome, _ := classifyTunnelJournal(journal); outcome != tunnelHandshakeRegistered {
+		t.Errorf("outcome = %v, want registered", outcome)
+	}
+}
+
+// Nothing decisive must NOT read as success — an empty journal is the state
+// right after the unit starts.
+func TestClassifyTunnelJournal_EmptyIsUnknown(t *testing.T) {
+	for _, j := range []string{"", "\n", lineConnected, lineReconnect} {
+		if outcome, _ := classifyTunnelJournal(j); outcome != tunnelHandshakeUnknown {
+			t.Errorf("journal %q → %v, want unknown", j, outcome)
+		}
+	}
+}
+
+// Last decisive line wins: a host rejected on its first attempt and accepted
+// after a token was registered mid-poll has genuinely joined.
+func TestClassifyTunnelJournal_LastDecisiveWins(t *testing.T) {
+	recovered := strings.Join([]string{lineConnected, lineRejected, lineReconnect, lineRegistered}, "\n")
+	if outcome, _ := classifyTunnelJournal(recovered); outcome != tunnelHandshakeRegistered {
+		t.Errorf("a rejection followed by a registration = %v, want registered", outcome)
+	}
+
+	broke := strings.Join([]string{lineRegistered, lineRejected}, "\n")
+	if outcome, _ := classifyTunnelJournal(broke); outcome != tunnelHandshakeRejected {
+		t.Errorf("a registration followed by a rejection = %v, want rejected", outcome)
+	}
+}
+
+// The wait loop returns as soon as registration appears, rather than burning
+// the full timeout on a healthy join.
+func TestWaitForTunnelHandshake_ReturnsEarlyOnSuccess(t *testing.T) {
+	calls := 0
+	read := func(string, time.Time) (string, error) {
+		calls++
+		if calls < 3 {
+			return lineConnected, nil
+		}
+		return lineConnected + "\n" + lineRegistered, nil
+	}
+
+	start := time.Now()
+	outcome, _ := waitForTunnelHandshake(read, "u", time.Now(), 10*time.Second, time.Millisecond)
+	if outcome != tunnelHandshakeRegistered {
+		t.Fatalf("outcome = %v, want registered", outcome)
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Error("waited far longer than needed after registration appeared")
+	}
+}
+
+// A rejection keeps polling to the deadline: registering the token on the
+// sentinel while the join is still running should be picked up.
+func TestWaitForTunnelHandshake_RejectionCanRecover(t *testing.T) {
+	calls := 0
+	read := func(string, time.Time) (string, error) {
+		calls++
+		if calls < 3 {
+			return lineRejected, nil
+		}
+		return lineRejected + "\n" + lineRegistered, nil
+	}
+
+	outcome, _ := waitForTunnelHandshake(read, "u", time.Now(), 2*time.Second, time.Millisecond)
+	if outcome != tunnelHandshakeRegistered {
+		t.Errorf("outcome = %v, want registered — a rejection that later succeeds is a join", outcome)
+	}
+}
+
+// A persistent rejection is reported as such.
+func TestWaitForTunnelHandshake_PersistentRejection(t *testing.T) {
+	read := func(string, time.Time) (string, error) { return lineRejected, nil }
+	outcome, detail := waitForTunnelHandshake(read, "u", time.Now(), 30*time.Millisecond, time.Millisecond)
+	if outcome != tunnelHandshakeRejected {
+		t.Fatalf("outcome = %v, want rejected", outcome)
+	}
+	if !strings.Contains(detail, "invalid token") {
+		t.Errorf("detail = %q", detail)
+	}
+}
+
+// An unreadable journal must not fail the join. Hosts without journald have to
+// stay joinable; "could not confirm" is the honest outcome, not an error.
+func TestWaitForTunnelHandshake_UnreadableJournalIsUnknown(t *testing.T) {
+	read := func(string, time.Time) (string, error) { return "", errors.New("journalctl: not found") }
+	outcome, _ := waitForTunnelHandshake(read, "u", time.Now(), 20*time.Millisecond, time.Millisecond)
+	if outcome != tunnelHandshakeUnknown {
+		t.Errorf("outcome = %v, want unknown — a host without journald must still be able to join", outcome)
+	}
+}
+
+// The failure message has to carry the remedy. The reason this bug cost 11
+// days is that the obvious remedy (mint a new token, re-join) reproduces the
+// identical failure, so an error that only reports the symptom sends the
+// operator round the same loop.
+func TestTunnelRejectedErrorNamesTheRemedy(t *testing.T) {
+	err := tunnelRejectedError("edge.example:9443", "tunnel-abc", "handshake rejected: invalid token")
+	msg := err.Error()
+
+	for _, want := range []struct{ text, why string }{
+		{"register-token", "the actual fix"},
+		{"do not expire", "why re-joining will not help — the whole trap"},
+		{"admin secret", "register-token is gated, and a sentinel without the secret cannot do it at all"},
+		{"journalctl -u containarium-tunnel", "where to look"},
+		{"edge.example:9443", "which sentinel"},
+		{"tunnel-abc", "which host"},
+		{"invalid token", "the observed rejection"},
+	} {
+		if !strings.Contains(msg, want.text) {
+			t.Errorf("error message is missing %q (%s):\n%s", want.text, want.why, msg)
+		}
+	}
+
+	if strings.Contains(msg, "Joined pool") {
+		t.Error("the failure must not also claim the pool was joined")
+	}
+}

--- a/internal/cmd/pool_join_handshake_test.go
+++ b/internal/cmd/pool_join_handshake_test.go
@@ -172,3 +172,28 @@ func TestTunnelRejectedErrorNamesTheRemedy(t *testing.T) {
 		t.Error("the failure must not also claim the pool was joined")
 	}
 }
+
+// The unit name becomes a command argument, so it is validated before the
+// exec rather than trusted. A leading dash would be parsed as a flag by
+// journalctl; the rest keeps the #nosec annotation on readUnitJournal
+// truthful rather than merely quiet.
+func TestReadUnitJournalRejectsUnsafeUnitNames(t *testing.T) {
+	for _, unit := range []string{"", "-u", "--since", "unit name", "unit;rm -rf /", "unit\nname", "/etc/passwd"} {
+		t.Run("unit="+unit, func(t *testing.T) {
+			if _, err := readUnitJournal(unit, time.Now()); err == nil {
+				t.Errorf("accepted unsafe unit name %q", unit)
+			}
+		})
+	}
+}
+
+func TestReadUnitJournalAcceptsRealUnitNames(t *testing.T) {
+	// Not asserting on the output — journalctl may be absent here. The point
+	// is that a legitimate name is not refused by the validator.
+	for _, unit := range []string{"containarium-tunnel", "containarium.service", "user@1000.service"} {
+		if _, err := readUnitJournal(unit, time.Now()); err != nil &&
+			strings.Contains(err.Error(), "not a valid unit name") {
+			t.Errorf("rejected legitimate unit name %q", unit)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1051.

### The gap

`pool join` printed `Joined pool ...` and exited 0 as soon as the units were enabled and the host-side capability check passed. Both are **host-side** facts. Nothing asked the sentinel whether it had accepted the tunnel, so a host being rejected on every reconnect was indistinguishable from a healthy join.

A live BYOC host accumulated **9,423 consecutive `handshake rejected: invalid token` rejections over 11 days** that way, with `systemctl is-active` cheerful throughout.

The join now waits (up to 20s) for the tunnel unit's journal to show a decisive outcome and refuses to claim success on a rejection.

### The marker choice is the whole fix

Success is `registered as`, **not** `connected to sentinel`.

That distinction is load-bearing. `connected to sentinel` is logged when the TCP connection is established — *before* the handshake is evaluated — so a host rejected every time logs it every time. A poll landing between the connect and the rejection would report a doomed host as joined, **reproducing this exact bug while looking correct**.

There's a test for precisely that window (`ConnectedAloneIsNotSuccess`), and swapping the marker fails it.

### The error message carries the remedy, not the symptom

This is why the original investigation cost days: the obvious remedy makes it worse. **Tunnel-join tokens do not expire**, so minting a fresh token and re-joining reproduces the identical rejection.

The sentinel builds its token policy once at startup, so any token issued afterwards — which is every token a cloud BYOC join mints — needs `sentinel register-token` first. The failure message says that, notes the call is admin-secret-gated, and notes that a sentinel started without `CONTAINARIUM_SENTINEL_ADMIN_SECRET` can't register tokens at all (the issue's "two invisible walls stacked").

### Not confirmed ≠ failed

An unreadable journal reports "could not confirm", not failure — a host without journald must stay joinable. Saying so plainly is the point: an unverified join should not read as a verified one.

### Scope

This is the issue's **suggested fix 1**. Fix 2 (have the control plane register the token it minted with the sentinel it belongs to) is cloud-side and belongs in that repo — worth doing, since it removes the manual step entirely rather than just reporting when it's missing.

### Mutation-tested

| mutation | fails |
| --- | --- |
| success marker → `connected to sentinel` | `ConnectedAloneIsNotSuccess` |
| unreadable journal treated as failure | `UnreadableJournalIsUnknown` |
| drop the "do not expire" explanation | `TunnelRejectedErrorNamesTheRemedy` |

One note on process: my first version of the trap test asserted on a journal where the rejection *followed* the connect — under last-wins that still classifies as rejected, so it passed with the marker swapped. Its comment claimed to catch the trap and it didn't. Rewritten to assert the actual dangerous window; it now fails under that mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)