### PR TITLE
fix(app-hosting): give an appended wildcard subject issuers that can issue it

### DIFF
--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -332,6 +332,67 @@ func (p *ProxyManager) RemoveTLSSubject(domain string) error {
 
 // ProvisionTLS provisions a TLS certificate for the given domain via Caddy's on-demand TLS
 // or by adding it to the TLS automation policy
+// ensureDNSIssuers gives a policy's issuers the configured DNS-01 challenge
+// config, reporting whether it changed anything.
+//
+// Wildcard subjects (`*.example.com`) can ONLY be issued via DNS-01 —
+// HTTP-01 and TLS-ALPN-01 categorically cannot solve them. A policy created
+// before DNS-01 was configured keeps its original issuers, so appending a
+// wildcard to it produces a subject Caddy never attempts: no certificate, no
+// error, nothing in the log to notice (#1066).
+//
+// A no-op when DNS-01 isn't configured (nothing to add) or when every issuer
+// already carries it, so this is safe to call on every provision.
+func (p *ProxyManager) ensureDNSIssuers(policy *CaddyTLSAutomationPolicy) bool {
+	if p.dnsChallenge == nil {
+		return false
+	}
+	if len(policy.Issuers) > 0 && policyHasDNSChallenge(*policy) {
+		return false
+	}
+	policy.Issuers = issuersFor(p.dnsChallenge)
+	return true
+}
+
+// policyHasDNSChallenge reports whether EVERY issuer can solve DNS-01.
+//
+// Every, not any: Caddy tries issuers in order, and one that cannot solve the
+// challenge is a failed attempt for the wildcard rather than a skipped one.
+func policyHasDNSChallenge(policy CaddyTLSAutomationPolicy) bool {
+	for _, issuer := range policy.Issuers {
+		if issuer.Challenges == nil || issuer.Challenges.DNS == nil {
+			return false
+		}
+	}
+	return true
+}
+
+// patchTLSPolicies writes the policy array back to Caddy.
+func (p *ProxyManager) patchTLSPolicies(url string, policies []CaddyTLSAutomationPolicy) error {
+	policyJSON, err := json.Marshal(policies)
+	if err != nil {
+		return fmt.Errorf("failed to marshal policies: %w", err)
+	}
+
+	req, err := http.NewRequest("PATCH", url, bytes.NewReader(policyJSON))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to update TLS policy: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("caddy returned error updating TLS policy (status %d): %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
 func (p *ProxyManager) ProvisionTLS(domain string) error {
 	// Caddy's admin API returns 400 "invalid traversal path" when you
 	// PATCH/POST a sub-path whose parent doesn't exist yet. On a fresh
@@ -363,10 +424,25 @@ func (p *ProxyManager) ProvisionTLS(domain string) error {
 	}
 
 	// Check if domain is already in a policy
-	for _, policy := range policies {
-		for _, subject := range policy.Subjects {
+	for i := range policies {
+		for _, subject := range policies[i].Subjects {
 			if subject == domain {
-				// Domain already has a policy, no need to add
+				// Present — but presence is not enough (#1066). A policy that
+				// predates DNS-01 being configured still carries HTTP-01 /
+				// TLS-ALPN-01 issuers, and those categorically cannot solve a
+				// wildcard subject, so Caddy never even attempts the
+				// certificate: the subject just sits there with no cert and
+				// no error.
+				//
+				// Repairing here rather than only on append is what reaches a
+				// host that ALREADY hit the bug. Such a host has the subject
+				// in the array from a previous run, so an append-only fix
+				// would return early every time and never heal it.
+				if p.ensureDNSIssuers(&policies[i]) {
+					log.Printf("[ProxyManager] policy for %s had no DNS-01 issuers; adding them so the "+
+						"wildcard subject can actually be issued (#1066)", domain)
+					return p.patchTLSPolicies(url, policies)
+				}
 				return nil
 			}
 		}
@@ -378,30 +454,13 @@ func (p *ProxyManager) ProvisionTLS(domain string) error {
 		// Add domain to the first policy's subjects
 		policies[0].Subjects = append(policies[0].Subjects, domain)
 
-		// Update the policy
-		policyJSON, err := json.Marshal(policies)
-		if err != nil {
-			return fmt.Errorf("failed to marshal policies: %w", err)
-		}
+		// The policy we are appending to may predate DNS-01 being configured,
+		// in which case its issuers cannot satisfy a wildcard subject (#1066).
+		// The create-new-policy branch below gets this right via
+		// NewTLSPolicyWithDNS; this branch has to do the same explicitly.
+		p.ensureDNSIssuers(&policies[0])
 
-		req, err := http.NewRequest("PATCH", url, bytes.NewReader(policyJSON))
-		if err != nil {
-			return fmt.Errorf("failed to create request: %w", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
-
-		resp, err := p.httpClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("failed to update TLS policy: %w", err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			return fmt.Errorf("caddy returned error updating TLS policy (status %d): %s", resp.StatusCode, string(body))
-		}
-
-		return nil
+		return p.patchTLSPolicies(url, policies)
 	}
 
 	// No existing policies, create a new one with ACME issuers (DNS-01 when

--- a/internal/app/proxy_selfheal_test.go
+++ b/internal/app/proxy_selfheal_test.go
@@ -29,7 +29,9 @@ func newRWFakeCaddy(initial map[string]interface{}) (*httptest.Server, *rwFakeCa
 		path := strings.TrimPrefix(r.URL.Path, "/config/")
 		path = strings.TrimSuffix(path, "/")
 
-		if r.Method == http.MethodPut {
+		// PATCH is treated like PUT: ProvisionTLS writes the policy array back
+		// with PATCH, and for a whole-node replacement the two are equivalent.
+		if r.Method == http.MethodPut || r.Method == http.MethodPatch {
 			body, _ := io.ReadAll(r.Body)
 			var val interface{}
 			if err := json.Unmarshal(body, &val); err != nil {

--- a/internal/app/proxy_tls_dns_issuers_test.go
+++ b/internal/app/proxy_tls_dns_issuers_test.go
@@ -1,0 +1,186 @@
+package app
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// #1066: ProvisionTLS appended a subject to an existing TLS automation policy
+// without touching that policy's issuers. A policy created before DNS-01 was
+// configured carries HTTP-01 / TLS-ALPN-01 issuers, and those categorically
+// CANNOT solve a wildcard subject — so `*.<domain>` landed in the subjects
+// array and Caddy never even attempted the certificate. No error, no log line,
+// no certificate: the subject just sat there indefinitely.
+
+// dnsChallenge builds a DNS-01 challenge config for tests.
+func testDNSChallenge() *CaddyACMEChallenges {
+	return &CaddyACMEChallenges{
+		DNS: &CaddyDNSChallenge{Provider: map[string]interface{}{"name": "cloudflare"}},
+	}
+}
+
+// tlsConfigWithPolicy returns a Caddy config whose TLS app already has one
+// automation policy — the common case, since any host already serving a
+// hostname has one.
+func tlsConfigWithPolicy(subjects []string, issuers []CaddyTLSIssuer) map[string]interface{} {
+	policy := CaddyTLSAutomationPolicy{Subjects: subjects, Issuers: issuers}
+	raw, _ := json.Marshal([]CaddyTLSAutomationPolicy{policy})
+	var policiesAny []interface{}
+	_ = json.Unmarshal(raw, &policiesAny)
+
+	return map[string]interface{}{
+		"apps": map[string]interface{}{
+			"tls": map[string]interface{}{
+				"automation": map[string]interface{}{"policies": policiesAny},
+			},
+		},
+	}
+}
+
+// readPolicies pulls the policy array back out of the fake.
+func readPolicies(t *testing.T, fc *rwFakeCaddy) []CaddyTLSAutomationPolicy {
+	t.Helper()
+	apps, _ := fc.config["apps"].(map[string]interface{})
+	tls, _ := apps["tls"].(map[string]interface{})
+	automation, _ := tls["automation"].(map[string]interface{})
+	raw, err := json.Marshal(automation["policies"])
+	if err != nil {
+		t.Fatalf("marshal policies: %v", err)
+	}
+	var policies []CaddyTLSAutomationPolicy
+	if err := json.Unmarshal(raw, &policies); err != nil {
+		t.Fatalf("unmarshal policies: %v", err)
+	}
+	return policies
+}
+
+func assertAllIssuersSolveDNS(t *testing.T, policy CaddyTLSAutomationPolicy) {
+	t.Helper()
+	if len(policy.Issuers) == 0 {
+		t.Fatal("policy has no issuers at all")
+	}
+	for i, issuer := range policy.Issuers {
+		if issuer.Challenges == nil || issuer.Challenges.DNS == nil {
+			t.Errorf("issuer %d (%s) cannot solve DNS-01, so a wildcard subject in this policy "+
+				"will never be issued — no cert, no error (#1066)", i, issuer.Module)
+		}
+	}
+}
+
+// Appending a wildcard to a policy whose issuers predate DNS-01 must also fix
+// the issuers.
+func TestProvisionTLS_AddsDNSIssuersWhenAppendingToExistingPolicy(t *testing.T) {
+	// A policy as it exists on a host that was already serving a hostname:
+	// default issuers, no challenges config.
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"app.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer(), NewZeroSSLIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com").WithDNSChallenge(testDNSChallenge())
+
+	if err := p.ProvisionTLS("*.example.com"); err != nil {
+		t.Fatalf("ProvisionTLS: %v", err)
+	}
+
+	policies := readPolicies(t, fc)
+	if len(policies) != 1 {
+		t.Fatalf("want 1 policy, got %d", len(policies))
+	}
+
+	var sawWildcard bool
+	for _, s := range policies[0].Subjects {
+		if s == "*.example.com" {
+			sawWildcard = true
+		}
+	}
+	if !sawWildcard {
+		t.Fatalf("wildcard subject was not added: %v", policies[0].Subjects)
+	}
+	assertAllIssuersSolveDNS(t, policies[0])
+}
+
+// THE case an append-only fix misses, and the state the reported host is
+// already in: the wildcard subject is ALREADY in the policy from a previous
+// run, so ProvisionTLS returns early. If the repair only happened on append,
+// that host would stay broken forever — the fix would help only hosts that
+// had not yet hit the bug.
+func TestProvisionTLS_RepairsIssuersWhenSubjectAlreadyPresent(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"app.example.com", "*.example.com"},          // wildcard already there
+		[]CaddyTLSIssuer{NewACMEIssuer(), NewZeroSSLIssuer()}, // but no DNS-01
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com").WithDNSChallenge(testDNSChallenge())
+
+	if err := p.ProvisionTLS("*.example.com"); err != nil {
+		t.Fatalf("ProvisionTLS: %v", err)
+	}
+
+	policies := readPolicies(t, fc)
+	assertAllIssuersSolveDNS(t, policies[0])
+}
+
+// Idempotent: a policy that already solves DNS-01 must not be rewritten. A
+// needless PATCH on every route sync would churn Caddy's config for nothing.
+func TestProvisionTLS_NoWriteWhenIssuersAlreadySolveDNS(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"*.example.com"},
+		issuersFor(testDNSChallenge()),
+	))
+	defer srv.Close()
+
+	before := fc.puts
+	p := NewProxyManager(srv.URL, "example.com").WithDNSChallenge(testDNSChallenge())
+	if err := p.ProvisionTLS("*.example.com"); err != nil {
+		t.Fatalf("ProvisionTLS: %v", err)
+	}
+	if fc.puts != before {
+		t.Errorf("policy was rewritten though its issuers already solved DNS-01 (%d writes)", fc.puts-before)
+	}
+}
+
+// Without DNS-01 configured there is nothing to add, and an existing HTTP-01
+// setup must not be clobbered — the repair only ever ADDS a capability.
+func TestProvisionTLS_LeavesIssuersAloneWithoutDNSChallenge(t *testing.T) {
+	srv, fc := newRWFakeCaddy(tlsConfigWithPolicy(
+		[]string{"app.example.com"},
+		[]CaddyTLSIssuer{NewACMEIssuer()},
+	))
+	defer srv.Close()
+
+	p := NewProxyManager(srv.URL, "example.com") // no WithDNSChallenge
+
+	if err := p.ProvisionTLS("second.example.com"); err != nil {
+		t.Fatalf("ProvisionTLS: %v", err)
+	}
+
+	policies := readPolicies(t, fc)
+	for _, issuer := range policies[0].Issuers {
+		if issuer.Challenges != nil {
+			t.Error("DNS-01 challenges were added though none are configured — that would point " +
+				"Caddy at a provider that does not exist")
+		}
+	}
+}
+
+// Every issuer must solve DNS-01, not merely one. Caddy tries issuers in
+// order, so one that cannot solve the challenge is a failed attempt for the
+// wildcard rather than a skipped one.
+func TestPolicyHasDNSChallengeRequiresEveryIssuer(t *testing.T) {
+	dns := testDNSChallenge()
+	withDNS := NewACMEIssuer()
+	withDNS.Challenges = dns
+
+	mixed := CaddyTLSAutomationPolicy{Issuers: []CaddyTLSIssuer{withDNS, NewZeroSSLIssuer()}}
+	if policyHasDNSChallenge(mixed) {
+		t.Error("a policy where only SOME issuers solve DNS-01 was reported as covered")
+	}
+
+	all := CaddyTLSAutomationPolicy{Issuers: issuersFor(dns)}
+	if !policyHasDNSChallenge(all) {
+		t.Error("a policy where every issuer solves DNS-01 was reported as not covered")
+	}
+}


### PR DESCRIPTION
Fixes #1066.

### The gap

`ProvisionTLS` appended a subject to an existing TLS automation policy without touching that policy's **issuers**. A policy created before DNS-01 was configured carries HTTP-01 / TLS-ALPN-01 issuers, and those **categorically cannot solve a wildcard subject** — so `*.<domain>` landed in the subjects array and Caddy never even attempted the certificate. No error, no log line, no certificate file. The subject just sat there.

The create-new-policy branch was always correct (it goes through `NewTLSPolicyWithDNS`). Only the append-to-existing branch was missing it — and that's the common branch, since any host already serving one hostname has a policy.

### Beyond the suggested fix: repairing hosts already broken

`ProvisionTLS` returns early when the subject is already present. That is **exactly the state a host that hit this bug is in** — the wildcard was appended by an earlier run.

So an append-only fix would hit that early return every time and never heal it: it would help only hosts that hadn't yet hit the bug, while the reported host stayed broken indefinitely. This repairs the issuers on that path too, and the case has its own test — the append-only variant fails it.

### Every issuer, not any

`policyHasDNSChallenge` requires **every** issuer to solve DNS-01. Caddy tries issuers in order, so one that can't solve the challenge is a *failed attempt* for the wildcard rather than a skipped one.

### Narrow by construction

- No-op when DNS-01 isn't configured, so an existing HTTP-01 setup is never clobbered — the repair only ever **adds** a capability.
- No-op when the issuers already carry DNS-01, so the 5s route-sync tick doesn't churn Caddy's config.

### Test harness

`rwFakeCaddy` gained PATCH handling — `ProvisionTLS` writes policy updates with PATCH and the fake only understood PUT, so these paths were previously unreachable in tests.

### Mutation-tested three ways

| mutation | fails |
| --- | --- |
| revert the repair | both append and already-present tests |
| append-only (skip the early-return repair) | `RepairsIssuersWhenSubjectAlreadyPresent` |
| "any issuer" instead of "every issuer" | `PolicyHasDNSChallengeRequiresEveryIssuer` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)