### PR TITLE
fix(peers): forward the whole create request, not a hand-copied subset

### DIFF
--- a/internal/server/peer.go
+++ b/internal/server/peer.go
@@ -23,6 +23,8 @@ import (
 	"github.com/footprintai/containarium/internal/metrics/cloudexport"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 // PeerClient represents a connection to a remote containarium daemon.
@@ -770,28 +772,37 @@ func (pc *PeerClient) fetchContainers(authToken string) ([]incus.ContainerInfo, 
 
 // ForwardCreateContainer forwards a create container request to a specific peer.
 func (pc *PeerClient) ForwardCreateContainer(authToken string, pbReq *pb.CreateContainerRequest) (*pb.CreateContainerResponse, error) {
-	// Use camelCase field names — gRPC-gateway's protojson uses camelCase,
-	// not snake_case, when unmarshaling JSON into proto messages.
-	reqBody := map[string]interface{}{
-		"username": pbReq.Username,
-		"image":    pbReq.Image,
-		"resources": map[string]string{
-			"cpu":    pbReq.Resources.GetCpu(),
-			"memory": pbReq.Resources.GetMemory(),
-			"disk":   pbReq.Resources.GetDisk(),
-		},
-		"sshKeys":         pbReq.SshKeys,
-		"enablePodman":    pbReq.EnablePodman,
-		"stack":           pbReq.Stack,
-		"stackParameters": pbReq.StackParameters,
-		"gpus":            pbReq.Gpus,
-		"staticIp":        pbReq.StaticIp,
-		"labels":          pbReq.Labels,
-		"async":           pbReq.Async,
-		"osType":          int32(pbReq.OsType),
+	// Marshal the REQUEST ITSELF rather than hand-copying a subset of its
+	// fields into a map (#1001).
+	//
+	// The map form silently dropped every field nobody remembered to add to
+	// it: monitoring, pool, the four git_* provisioning fields, ttl_seconds,
+	// idle_stop_minutes, delete_after_stopped_seconds, and — worst —
+	// encrypted and tenant_id, so `create --encrypted` against a
+	// tunnel-connected backend produced an UNENCRYPTED container and said
+	// nothing. Creating remotely and creating locally silently meant
+	// different things.
+	//
+	// Nothing catches that: a map literal missing a key compiles, passes
+	// review, and looks exactly like a complete one. Forwarding the message
+	// means the set of forwarded fields is the set of fields that exist, by
+	// construction, and a field added to the proto later is carried without
+	// anyone having to remember this function. It is also what CLAUDE.md
+	// asks for — a typed message, not map[string]interface{}, for a wire
+	// payload.
+	//
+	// protojson with UseProtoNames=false emits the camelCase names
+	// grpc-gateway unmarshals on the peer, matching what the map produced by
+	// hand.
+	fwd, ok := proto.Clone(pbReq).(*pb.CreateContainerRequest)
+	if !ok {
+		return nil, fmt.Errorf("clone create request: unexpected type")
 	}
+	// The peer IS the target. Leaving backend_id set would have it evaluate
+	// routing again and forward onwards, rather than creating locally.
+	fwd.BackendId = ""
 
-	bodyBytes, err := json.Marshal(reqBody)
+	bodyBytes, err := protojson.MarshalOptions{UseProtoNames: false}.Marshal(fwd)
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
@@ -825,47 +836,26 @@ func (pc *PeerClient) ForwardCreateContainer(authToken string, pbReq *pb.CreateC
 		return nil, fmt.Errorf("peer returned status %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	// Parse the response into proto format
-	var data struct {
-		Container struct {
-			Name     string `json:"name"`
-			Username string `json:"username"`
-			State    string `json:"state"`
-			Network  struct {
-				IPAddress string `json:"ipAddress"`
-			} `json:"network"`
-			Resources struct {
-				CPU          string `json:"cpu"`
-				Memory       string `json:"memory"`
-				Disk         string `json:"disk"`
-				StorageClass string `json:"storageClass"`
-			} `json:"resources"`
-		} `json:"container"`
-		Message    string `json:"message"`
-		SshCommand string `json:"sshCommand"`
-	}
-	if err := json.Unmarshal(respBody, &data); err != nil {
+	// Decode the RESPONSE into its proto type for the same reason (#1001).
+	//
+	// The hand-rolled struct dropped everything it did not name — created_at,
+	// ssh_host, pool, labels, os_type — and it parsed `state` into a field it
+	// then never assigned, so a container created on a peer came back
+	// reporting no state at all.
+	//
+	// DiscardUnknown so a peer running a newer daemon, and therefore sending
+	// fields this build has never heard of, is decoded rather than rejected.
+	var out pb.CreateContainerResponse
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respBody, &out); err != nil {
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
 
-	return &pb.CreateContainerResponse{
-		Container: &pb.Container{
-			Name:      data.Container.Name,
-			Username:  data.Container.Username,
-			BackendId: pc.ID,
-			Network: &pb.NetworkInfo{
-				IpAddress: data.Container.Network.IPAddress,
-			},
-			Resources: &pb.ResourceLimits{
-				Cpu:          data.Container.Resources.CPU,
-				Memory:       data.Container.Resources.Memory,
-				Disk:         data.Container.Resources.Disk,
-				StorageClass: data.Container.Resources.StorageClass,
-			},
-		},
-		Message:    data.Message,
-		SshCommand: data.SshCommand,
-	}, nil
+	// The peer does not know its own ID in this exchange; stamp it so the
+	// caller can tell which backend the container landed on.
+	if out.Container != nil {
+		out.Container.BackendId = pc.ID
+	}
+	return &out, nil
 }
 
 // ForwardRequest forwards an arbitrary HTTP request to the peer and returns the response body.

--- a/internal/server/peer_forward_create_test.go
+++ b/internal/server/peer_forward_create_test.go
@@ -1,0 +1,229 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// #1001: ForwardCreateContainer hand-copied a subset of the request into a
+// map[string]interface{}, silently dropping every field nobody remembered to
+// add. Creating on a tunnel-connected backend and creating locally quietly
+// meant different things.
+//
+// The worst of the dropped fields were `encrypted` and `tenant_id`: a
+// `create --encrypted` aimed at a remote backend produced an UNENCRYPTED
+// container and reported success.
+
+// fullCreateRequest sets every field of CreateContainerRequest to a non-zero
+// value, so "was anything dropped?" can be asked of the whole message rather
+// than of a list someone has to maintain.
+func fullCreateRequest() *pb.CreateContainerRequest {
+	return &pb.CreateContainerRequest{
+		Username:                  "alice",
+		Resources:                 &pb.ResourceLimits{Cpu: "4", Memory: "4GB", Disk: "50GB"},
+		SshKeys:                   []string{"ssh-ed25519 AAAA test"},
+		Labels:                    map[string]string{"team": "platform"},
+		Image:                     "ubuntu:24.04",
+		EnablePodman:              true,
+		Async:                     true,
+		StaticIp:                  "10.0.0.5",
+		Stack:                     "python",
+		Gpu:                       "gpu0",
+		BackendId:                 "peer-a",
+		OsType:                    pb.OSType_OS_TYPE_UBUNTU_2404,
+		StackParameters:           map[string]string{"version": "3.12"},
+		Monitoring:                true,
+		Pool:                      "gpu-pool",
+		GitSource:                 "https://example.com/repo.git",
+		GitRef:                    "main",
+		GitCredential:             "cred-1",
+		WorkspacePath:             "/workspace",
+		TtlSeconds:                3600,
+		IdleStopMinutes:           30,
+		DeleteAfterStoppedSeconds: 7200,
+		Gpus:                      []string{"gpu0"},
+		Encrypted:                 true,
+		TenantId:                  "default",
+	}
+}
+
+// capturingPeer records the forwarded body and replies with a full response.
+func capturingPeer(t *testing.T, body *string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		*body = string(b)
+		_, _ = w.Write([]byte(`{
+			"container": {
+				"name": "alice-container",
+				"username": "alice",
+				"state": "CONTAINER_STATE_RUNNING",
+				"network": {"ipAddress": "10.0.0.5"},
+				"resources": {"cpu": "4", "memory": "4GB", "disk": "50GB"},
+				"sshHost": "edge.example",
+				"pool": "gpu-pool"
+			},
+			"message": "created",
+			"sshCommand": "ssh alice@edge.example"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func peerClientFor(srv *httptest.Server) *PeerClient {
+	return &PeerClient{
+		ID:     "peer-a",
+		Addr:   strings.TrimPrefix(srv.URL, "http://"),
+		client: srv.Client(),
+	}
+}
+
+// THE test: nothing set on the request may be missing from what is forwarded.
+//
+// Asserted over the whole message rather than a hand-listed set of fields —
+// the bug WAS a hand-listed set of fields. A field added to the proto later is
+// covered by this automatically, without anyone remembering this file.
+func TestForwardCreateContainer_ForwardsEveryField(t *testing.T) {
+	var forwarded string
+	srv := capturingPeer(t, &forwarded)
+	req := fullCreateRequest()
+
+	if _, err := peerClientFor(srv).ForwardCreateContainer("token", req); err != nil {
+		t.Fatalf("ForwardCreateContainer: %v", err)
+	}
+
+	var got pb.CreateContainerRequest
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal([]byte(forwarded), &got); err != nil {
+		t.Fatalf("forwarded body is not a valid CreateContainerRequest: %v\n%s", err, forwarded)
+	}
+
+	// backend_id is intentionally cleared; everything else must survive.
+	want := proto.Clone(req).(*pb.CreateContainerRequest)
+	want.BackendId = ""
+
+	if !proto.Equal(want, &got) {
+		// Name the specific fields that went missing — a bare "not equal" on
+		// a 25-field message is not a usable failure.
+		var missing []string
+		want.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+			if !got.ProtoReflect().Has(fd) {
+				missing = append(missing, string(fd.Name()))
+			}
+			return true
+		})
+		t.Errorf("fields dropped while forwarding: %v\nsent: %v\ngot:  %v", missing, want, &got)
+	}
+}
+
+// The two that matter most, called out on their own so a regression reads as
+// a security problem rather than a diffing problem.
+func TestForwardCreateContainer_ForwardsEncryptionIntent(t *testing.T) {
+	var forwarded string
+	srv := capturingPeer(t, &forwarded)
+
+	req := &pb.CreateContainerRequest{
+		Username:  "alice",
+		Resources: &pb.ResourceLimits{Cpu: "2", Memory: "2GB", Disk: "10GB"},
+		BackendId: "peer-a",
+		Encrypted: true,
+		TenantId:  "acme",
+	}
+	if _, err := peerClientFor(srv).ForwardCreateContainer("token", req); err != nil {
+		t.Fatalf("ForwardCreateContainer: %v", err)
+	}
+
+	var got pb.CreateContainerRequest
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal([]byte(forwarded), &got); err != nil {
+		t.Fatalf("unmarshal forwarded body: %v", err)
+	}
+	if !got.Encrypted {
+		t.Error("`encrypted` was not forwarded: a --encrypted create aimed at a remote backend " +
+			"would produce an UNENCRYPTED container and report success (#1001)")
+	}
+	if got.TenantId != "acme" {
+		t.Errorf("tenant_id = %q, want \"acme\" — the wrong tenant's key would be used", got.TenantId)
+	}
+}
+
+// backend_id must NOT be forwarded: the peer is the target, and leaving it set
+// would have the peer evaluate routing again instead of creating locally.
+func TestForwardCreateContainer_ClearsBackendID(t *testing.T) {
+	var forwarded string
+	srv := capturingPeer(t, &forwarded)
+
+	req := fullCreateRequest()
+	if _, err := peerClientFor(srv).ForwardCreateContainer("token", req); err != nil {
+		t.Fatalf("ForwardCreateContainer: %v", err)
+	}
+
+	var got pb.CreateContainerRequest
+	_ = (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal([]byte(forwarded), &got)
+	if got.BackendId != "" {
+		t.Errorf("backend_id = %q was forwarded; the peer would try to route onwards", got.BackendId)
+	}
+
+	// The caller's own request must not be mutated — it is used after this
+	// returns, and clearing a field on it would be an invisible side effect.
+	if req.BackendId != "peer-a" {
+		t.Errorf("the caller's request was mutated: backend_id is now %q", req.BackendId)
+	}
+}
+
+// The response side had the same defect, and one field worse: `state` was
+// parsed into a struct field that was then never assigned, so a container
+// created on a peer came back reporting no state at all.
+func TestForwardCreateContainer_DecodesFullResponse(t *testing.T) {
+	var forwarded string
+	srv := capturingPeer(t, &forwarded)
+
+	resp, err := peerClientFor(srv).ForwardCreateContainer("token", fullCreateRequest())
+	if err != nil {
+		t.Fatalf("ForwardCreateContainer: %v", err)
+	}
+	if resp.Container == nil {
+		t.Fatal("no container in the response")
+	}
+
+	if resp.Container.State != pb.ContainerState_CONTAINER_STATE_RUNNING {
+		t.Errorf("state = %v, want RUNNING — it was parsed and then dropped on the floor", resp.Container.State)
+	}
+	if resp.Container.SshHost != "edge.example" {
+		t.Errorf("ssh_host = %q, want it preserved", resp.Container.SshHost)
+	}
+	if resp.Container.Pool != "gpu-pool" {
+		t.Errorf("pool = %q, want it preserved", resp.Container.Pool)
+	}
+	// Still stamped with which backend it landed on.
+	if resp.Container.BackendId != "peer-a" {
+		t.Errorf("backend_id = %q, want the peer's ID", resp.Container.BackendId)
+	}
+	if resp.Message != "created" || resp.SshCommand == "" {
+		t.Errorf("message/sshCommand lost: %q / %q", resp.Message, resp.SshCommand)
+	}
+}
+
+// A peer running a newer daemon sends fields this build has never heard of.
+// That must decode, not fail the create after the container already exists.
+func TestForwardCreateContainer_ToleratesUnknownResponseFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"container":{"name":"alice-container","somethingNew":true},"message":"ok","alsoNew":42}`))
+	}))
+	defer srv.Close()
+
+	resp, err := peerClientFor(srv).ForwardCreateContainer("token", fullCreateRequest())
+	if err != nil {
+		t.Fatalf("a newer peer's extra fields broke the decode: %v", err)
+	}
+	if resp.Container.GetName() != "alice-container" {
+		t.Errorf("name = %q", resp.Container.GetName())
+	}
+}


### PR DESCRIPTION
Refs #1001. **Not a full resolution of the reported 500** — see the last section.

### The bug

`ForwardCreateContainer` built its request body as a `map[string]interface{}` holding **twelve of the message's twenty-five fields**. Everything else was dropped in silence:

`monitoring`, `pool`, `git_source`, `git_ref`, `git_credential`, `workspace_path`, `ttl_seconds`, `idle_stop_minutes`, `delete_after_stopped_seconds`, and — worst — **`encrypted`** and **`tenant_id`**.

So `create --encrypted` aimed at a tunnel-connected backend produced an **UNENCRYPTED container and reported success**. Creating remotely and creating locally quietly meant different things, which is the whole premise `backend_id` rests on.

### Why forward the message instead of adding the missing keys

Adding the eleven missing keys fixes today's drift and guarantees tomorrow's: nothing catches this class of bug, because a map literal missing a key compiles, passes review, and looks exactly like a complete one.

Forwarding the message makes the set of forwarded fields *equal to the set of fields that exist*, by construction. A field added to the proto later travels without anyone remembering this function exists. It's also what `CLAUDE.md` asks for — a typed message rather than `map[string]interface{}` for a wire payload.

`backend_id` is cleared on a **clone**: the peer is the target, so leaving it set would make the peer evaluate routing again — and cloning keeps that from mutating the caller's request as an invisible side effect (there's a test for that).

### The response side had it too, and one worse

The hand-rolled struct parsed `state` into a field it then **never assigned**, so a container created on a peer came back reporting no state at all. `ssh_host`, `pool`, `labels` and `created_at` were simply absent.

Now decoded into the proto type with `DiscardUnknown`, so a peer running a newer daemon is understood rather than rejected *after the container already exists*.

### The test is shaped like the bug

The headline test asserts over the **whole message**, not a list of field names — because the bug *was* a list of field names. A field added to the proto later is covered automatically, and a failure names the fields that went missing rather than diffing 25 fields:

```
fields dropped while forwarding: [pool monitoring encrypted tenant_id]
```

Mutation-tested both ways: dropping those four fails the sweep and the encryption-specific test; leaving `backend_id` set fails its own.

### On the reported 500

The prior investigation on the issue established that the `{"code":13,...,"details":[]}` shape **does not originate in this repo** — it's grpc-gateway's default status JSON, emitted where no custom error handler is installed, while this repo's handler formats errors differently. It's most likely produced by a component fronting the daemon for BYOC hosts.

This PR fixes the confirmed in-repo bug that investigation turned up. The generic-error half needs the fronting component, so I've left the issue open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)