### PR TITLE
feat(storage): make the incus storage pool configurable

### DIFF
--- a/docs/BACKEND-STORAGE-DRIVER.md
+++ b/docs/BACKEND-STORAGE-DRIVER.md
@@ -119,15 +119,43 @@ Run two pools side by side and move tenants across one at a time, so there
 is no fleet-wide outage and rollback is per tenant:
 
 ```bash
+# 1. Create the isolated pool alongside the existing one.
 incus storage create isolated zfs source=<dataset>
-incus move <container> --storage isolated     # per tenant
+
+# 2. Point the daemon at it BEFORE moving anything, so tenants created
+#    during the migration land on the new pool rather than the old one.
+#    (--storage-pool is the incus STORAGE pool; --pool is a
+#    sentinel-fronted cluster and is unrelated. See MULTI-POOL.md.)
+containarium daemon --storage-pool isolated ...     # then restart the daemon
+
+# 3. Move tenants across one at a time. Rollback is per tenant:
+#    `incus move <container> --storage default`.
+incus move <container> --storage isolated
 ```
 
-This currently needs the storage pool name to be configurable, which it is
-not yet — every container-creation path is pinned to the pool literally
-named `default`, so newly created tenants would land back on `dir` and the
-migration would silently undo itself. Tracked as issue #1213; do not use
-Path B until it lands.
+Step 2 is what stops the migration undoing itself. Until #1213 every
+container-creation path was pinned to the pool literally named `default`,
+so newly created tenants landed back on `dir` — the contention probe went
+clean right after the migration and regressed weeks later as tenants
+arrived, with nothing connecting the two.
+
+Restarting the daemon with `--storage-pool` also **repoints the default
+profile's root disk**. That matters because a container created without an
+explicit disk size has no root device of its own and inherits the profile's
+— so a stale profile would send exactly those containers back to the old
+pool regardless of step 2. The daemon logs the move:
+
+```
+[incus] default profile root disk moves from storage pool "default" to "isolated";
+        containers created from now on land on "isolated" (#1213)
+```
+
+Verify placement after the change:
+
+```bash
+incus config device get <new-container> root pool     # expect: isolated
+containarium backends list                            # STORAGE column
+```
 
 ### Verifying, either way
 

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -57,6 +57,7 @@ var (
 	peerAddrs              []string
 	localBackendID         string
 	pool                   string
+	storagePool            string
 	region                 string
 	cpuOvercommitFactor    float64
 	cpuOvercommitEnforce   bool
@@ -153,6 +154,7 @@ func init() {
 	daemonCmd.Flags().StringSliceVar(&peerAddrs, "peers", nil, "Static peer daemon addresses (e.g., 10.128.0.5:18001)")
 	daemonCmd.Flags().StringVar(&localBackendID, "backend-id", "", "This daemon's backend ID (defaults to hostname)")
 	daemonCmd.Flags().StringVar(&pool, "pool", "", "Pool name to scope sentinel peer discovery (empty = unscoped, see all peers)")
+	daemonCmd.Flags().StringVar(&storagePool, "storage-pool", "", "Incus STORAGE pool containers are created on (default \"default\"). Unrelated to --pool, which names a sentinel-fronted cluster. Point this at a second, per-container-volume pool to migrate tenants off a shared-filesystem `dir` pool without every newly created tenant landing back on it (#1206, #1213).")
 	daemonCmd.Flags().StringVar(&region, "region", "", "Region this backend serves; recorded in its capability profile (containarium backends profile). Empty falls back to the --pool name.")
 	daemonCmd.Flags().StringVar(&publicHostname, "public-hostname", "", "Public hostname this primary serves (e.g. prod.example.com); enables sentinel primary registration")
 	daemonCmd.Flags().StringSliceVar(&publicAliases, "public-aliases", nil, "Additional hostnames the primary's Caddy serves (e.g. api.example.com,voice.example.com); the sentinel SNI router treats these as aliases of --public-hostname")
@@ -234,6 +236,14 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 
 	// Initialize infrastructure (storage, network, profile) unless skipped or
 	// running on a host without incus (k8s runtime).
+	// Set the storage pool before ANY container is created. Process-wide
+	// because several subsystems build their own incus client and none of
+	// them thread daemon config; see incus.SetDefaultStoragePool.
+	incus.SetDefaultStoragePool(storagePool)
+	if storagePool != "" {
+		log.Printf("[storage] containers will be created on incus storage pool %q (--storage-pool)", storagePool)
+	}
+
 	if !skipInfraInit && incusClient != nil {
 		log.Printf("Initializing infrastructure...")
 		// Decide up front what happens if the storage pool doesn't isolate

--- a/internal/server/cloud_container_actuator.go
+++ b/internal/server/cloud_container_actuator.go
@@ -119,7 +119,7 @@ func (a *cloudContainerActuator) EnsureDeleted(ctx context.Context, localName st
 
 // create makes the instance (stopped) and stamps the tenant label before start.
 func (a *cloudContainerActuator) create(spec cloud.ContainerSpec) error {
-	if err := a.incus.CreateContainer(buildContainerConfig(spec)); err != nil {
+	if err := a.incus.CreateContainer(buildContainerConfig(spec, a.incus.StoragePool())); err != nil {
 		return fmt.Errorf("create %s: %w", spec.LocalName, err)
 	}
 	// Stamp the owning org as the tenant label so the network-policy enforcer
@@ -139,13 +139,13 @@ func (a *cloudContainerActuator) create(spec cloud.ContainerSpec) error {
 // GPU inventory the assignment doesn't carry). CPU isn't in the assignment;
 // routes/secrets aren't in the actuation contract, so they're not set here.
 // Pure (no Incus calls) so the mapping is unit-testable.
-func buildContainerConfig(spec cloud.ContainerSpec) incus.ContainerConfig {
+func buildContainerConfig(spec cloud.ContainerSpec, storagePool string) incus.ContainerConfig {
 	cfg := incus.ContainerConfig{Name: spec.LocalName, Image: spec.Image}
 	if spec.RAMMB > 0 {
 		cfg.Memory = fmt.Sprintf("%dMB", spec.RAMMB)
 	}
 	if spec.DiskGB > 0 {
-		cfg.Disk = &incus.DiskDevice{Path: "/", Pool: "default", Size: fmt.Sprintf("%dGB", spec.DiskGB)}
+		cfg.Disk = &incus.DiskDevice{Path: "/", Pool: storagePool, Size: fmt.Sprintf("%dGB", spec.DiskGB)}
 	}
 	if spec.GPUCount > 0 {
 		// A single empty GPU device means "pass through all GPUs" (no PCI

--- a/internal/server/cloud_container_actuator_test.go
+++ b/internal/server/cloud_container_actuator_test.go
@@ -11,7 +11,7 @@ func TestBuildContainerConfig(t *testing.T) {
 		LocalName: "cld-abc", Image: "ubuntu:24.04",
 		RAMMB: 2048, DiskGB: 40, GPUCount: 1,
 		SecretEnv: map[string]string{"API_TOKEN": "shh"},
-	})
+	}, "default")
 	if cfg.Env["API_TOKEN"] != "shh" {
 		t.Errorf("secret_env not injected as container env: %v", cfg.Env)
 	}
@@ -81,7 +81,7 @@ func TestTenantLabelStale(t *testing.T) {
 }
 
 func TestBuildContainerConfig_MinimalOmitsDevices(t *testing.T) {
-	cfg := buildContainerConfig(cloud.ContainerSpec{LocalName: "cld-x", Image: "alpine"})
+	cfg := buildContainerConfig(cloud.ContainerSpec{LocalName: "cld-x", Image: "alpine"}, "default")
 	if cfg.Memory != "" {
 		t.Errorf("no RAM → memory unset, got %q", cfg.Memory)
 	}

--- a/internal/server/core_otel_collector.go
+++ b/internal/server/core_otel_collector.go
@@ -109,7 +109,7 @@ func (cs *CoreServices) EnsureOTelCollector(ctx context.Context, victoriaMetrics
 		AutoStart: true,
 		Disk: &incus.DiskDevice{
 			Path: "/",
-			Pool: "default",
+			Pool: cs.incusClient.StoragePool(),
 			Size: "3GB",
 		},
 	}

--- a/internal/server/core_services.go
+++ b/internal/server/core_services.go
@@ -225,7 +225,7 @@ func (cs *CoreServices) EnsurePostgres(ctx context.Context) (string, error) {
 		AutoStart: true,
 		Disk: &incus.DiskDevice{
 			Path: "/",
-			Pool: "default",
+			Pool: cs.incusClient.StoragePool(),
 			Size: "10GB",
 		},
 	}
@@ -428,7 +428,7 @@ func (cs *CoreServices) EnsureCaddy(ctx context.Context, baseDomain string) (str
 		AutoStart: true,
 		Disk: &incus.DiskDevice{
 			Path: "/",
-			Pool: "default",
+			Pool: cs.incusClient.StoragePool(),
 			Size: "5GB",
 		},
 	}
@@ -657,7 +657,7 @@ func (cs *CoreServices) EnsureVictoriaMetrics(ctx context.Context, postgresIP st
 		AutoStart: true,
 		Disk: &incus.DiskDevice{
 			Path: "/",
-			Pool: "default",
+			Pool: cs.incusClient.StoragePool(),
 			Size: "10GB",
 		},
 	}
@@ -1325,7 +1325,7 @@ func (cs *CoreServices) EnsureSecurity(ctx context.Context) error {
 		AutoStart: true,
 		Disk: &incus.DiskDevice{
 			Path: "/",
-			Pool: "default",
+			Pool: cs.incusClient.StoragePool(),
 			Size: "5GB",
 		},
 	}

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -196,7 +196,7 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 	if diskSize != "" {
 		config.Disk = &incus.DiskDevice{
 			Path: "/",
-			Pool: "default",
+			Pool: m.incus.StoragePool(),
 			Size: diskSize,
 		}
 	}

--- a/pkg/core/container/storage_pool_test.go
+++ b/pkg/core/container/storage_pool_test.go
@@ -1,0 +1,73 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/incus/incustest"
+)
+
+// #1213 AC2: a container created after the storage pool is changed must land
+// on the configured pool.
+//
+// The failure this guards is quiet by construction. An operator migrating a
+// backend off a shared-filesystem `dir` pool moves existing tenants across
+// with `incus move --storage`, sees the contention probe go clean, and is
+// done. Meanwhile every NEW tenant keeps being created on the pool named
+// literally "default" — the one they migrated away from — so the exposure
+// returns as tenants arrive, weeks later, with nothing connecting it to the
+// migration.
+
+func TestCreate_UsesTheConfiguredStoragePool(t *testing.T) {
+	var created incus.ContainerConfig
+	mock := &incustest.MockBackend{
+		StoragePoolName:     "tenants",
+		CreateContainerFunc: func(cfg incus.ContainerConfig) error { created = cfg; return nil },
+	}
+	m := NewWithBackend(mock)
+
+	// A disk size is what triggers an explicit root-disk device; without one
+	// the container inherits the default profile, which EnsureDefaultProfile
+	// repoints separately.
+	_, err := m.Create(CreateOptions{
+		Username: "alice",
+		Image:    "ubuntu:24.04",
+		Disk:     "20GB",
+	})
+	// The create goes on to do host-account work that a unit test host cannot
+	// perform; the assertion is on what was handed to incus, which happens
+	// first.
+	_ = err
+
+	if created.Disk == nil {
+		t.Fatal("no root disk device was configured for a create with an explicit disk size")
+	}
+	if created.Disk.Pool != "tenants" {
+		t.Errorf("root disk pool = %q, want %q — a container created after the backend was "+
+			"repointed still landed on the old pool, which is how a storage migration "+
+			"silently undoes itself (#1213)", created.Disk.Pool, "tenants")
+	}
+}
+
+// With nothing configured the behaviour is exactly what it always was, so
+// this cannot change any existing deployment.
+func TestCreate_DefaultsToTheDefaultPool(t *testing.T) {
+	var created incus.ContainerConfig
+	mock := &incustest.MockBackend{
+		CreateContainerFunc: func(cfg incus.ContainerConfig) error { created = cfg; return nil },
+	}
+	m := NewWithBackend(mock)
+
+	_, _ = m.Create(CreateOptions{
+		Username: "bob",
+		Image:    "ubuntu:24.04",
+		Disk:     "10GB",
+	})
+
+	if created.Disk == nil {
+		t.Fatal("no root disk device configured")
+	}
+	if created.Disk.Pool != incus.DefaultStoragePool {
+		t.Errorf("root disk pool = %q, want %q", created.Disk.Pool, incus.DefaultStoragePool)
+	}
+}

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/footprintai/containarium/internal/safecast"
@@ -37,6 +38,69 @@ type Client struct {
 	// storageProbe overrides host detection during driver selection. Nil uses
 	// DefaultStorageProbe.
 	storageProbe *StorageProbe
+
+	// storagePool is the incus storage pool containers are created on.
+	// Empty means DefaultStoragePool (#1213).
+	//
+	// NOT the daemon's --pool, which names an independent cluster fronted by
+	// the sentinel. These are unrelated concepts that share a word; see
+	// docs/MULTI-POOL.md.
+	storagePool string
+}
+
+// DefaultStoragePool is the incus storage pool used when none is configured.
+const DefaultStoragePool = "default"
+
+// configuredStoragePool is the process-wide storage pool, set once from the
+// daemon's --storage-pool flag.
+//
+// Process-wide because incus.New() is called from a dozen places that each
+// build their own client — the cloud actuator, several container_server
+// helpers — and none of them thread daemon configuration. A per-client
+// setting alone would therefore be honoured on the daemon's own client and
+// silently ignored by every other one, which is the same shape of bug this
+// change exists to remove.
+var configuredStoragePool atomic.Value // string
+
+// SetDefaultStoragePool sets the process-wide incus storage pool. Called once
+// during daemon startup, before any container is created. Empty is ignored.
+//
+// NOT the daemon's --pool, which names an independent cluster fronted by the
+// sentinel; see docs/MULTI-POOL.md. These are unrelated concepts sharing a
+// word, which is why the flag is --storage-pool.
+func SetDefaultStoragePool(name string) {
+	if name != "" {
+		configuredStoragePool.Store(name)
+	}
+}
+
+// defaultPool reports the process-wide pool.
+func defaultPool() string {
+	if v, ok := configuredStoragePool.Load().(string); ok && v != "" {
+		return v
+	}
+	return DefaultStoragePool
+}
+
+// SetStoragePool selects the incus storage pool containers are created on.
+// Empty resets to DefaultStoragePool. See #1213.
+func (c *Client) SetStoragePool(name string) {
+	c.storagePool = name
+}
+
+// StoragePool returns the configured incus storage pool.
+//
+// Every root-disk device construction goes through this rather than a literal
+// "default". A literal is how a backend migrated onto an isolated pool
+// silently un-migrated itself: existing tenants stayed put while every NEW
+// tenant landed back on the shared-filesystem pool, so the contention probe
+// went clean right after the migration and regressed weeks later with nothing
+// in the product explaining why (#1206, #1213).
+func (c *Client) StoragePool() string {
+	if c.storagePool != "" {
+		return c.storagePool
+	}
+	return defaultPool()
 }
 
 // SetStoragePolicy sets what EnsureStorage does when a storage pool does not
@@ -56,6 +120,12 @@ func (c *Client) probe() StorageProbe {
 // Backend is the interface satisfied by *Client. Consumers depend on it (or a
 // narrower subset declared at the call site) so they can be mocked in tests.
 type Backend interface {
+	// StoragePool is the incus storage pool containers are created on.
+	// Read-only here: it is configured on the concrete client at daemon
+	// startup, and every root-disk construction reads it rather than
+	// hardcoding "default" (#1213).
+	StoragePool() string
+
 	// Lifecycle
 	CreateContainer(config ContainerConfig) error
 	StartContainer(name string) error
@@ -1732,7 +1802,7 @@ func (c *Client) SetDeviceSize(containerName, deviceName, size string) error {
 // temporarily expands it to the target size so Incus can write its backup.yaml.
 func (c *Client) ensureZFSQuotaHeadroom(containerName, pool, targetSize string) error {
 	if pool == "" {
-		pool = "default"
+		pool = c.StoragePool()
 	}
 
 	// Determine the ZFS dataset name: <zfs-pool>/containers/containers/<name>
@@ -1915,7 +1985,7 @@ func (c *Client) EnsureNetwork(config NetworkConfig) (string, error) {
 // Returns the storage pool name.
 func (c *Client) EnsureStorage(name string) (string, error) {
 	if name == "" {
-		name = "default"
+		name = c.StoragePool()
 	}
 
 	// Check if storage pool already exists
@@ -2004,6 +2074,30 @@ func (c *Client) GetStorageDriver(name string) string {
 }
 
 // EnsureDefaultProfile configures the default profile with network and storage
+// rootDiskForPool returns the default profile's root-disk device for the given
+// storage pool, the pool it is moving away from (empty when there was no
+// device), and whether anything changed.
+//
+// Pure so the repoint decision is testable without an Incus server — the
+// decision is the part that was wrong (#1213), not the API call.
+func rootDiskForPool(existing map[string]string, storageName string) (device map[string]string, movedFrom string, changed bool) {
+	if existing == nil {
+		return map[string]string{"type": "disk", "path": "/", "pool": storageName}, "", true
+	}
+	if existing["pool"] == storageName {
+		return existing, "", false
+	}
+	// Repoint in place, preserving anything else the operator set on the
+	// device (size, io limits) — only the pool is ours to change.
+	from := existing["pool"]
+	updated := make(map[string]string, len(existing))
+	for k, v := range existing {
+		updated[k] = v
+	}
+	updated["pool"] = storageName
+	return updated, from, true
+}
+
 func (c *Client) EnsureDefaultProfile(networkName, storageName string) error {
 	// Get current default profile
 	profile, _, err := c.server.GetProfile("default")
@@ -2018,13 +2112,22 @@ func (c *Client) EnsureDefaultProfile(networkName, storageName string) error {
 
 	needsUpdate := false
 
-	// Add root disk device if not present
-	if _, ok := profile.Devices["root"]; !ok {
-		profile.Devices["root"] = map[string]string{
-			"type": "disk",
-			"path": "/",
-			"pool": storageName,
+	// Add the root disk device, or REPOINT it when the configured storage
+	// pool has changed (#1213).
+	//
+	// Setting it only when absent is what made a storage migration undo
+	// itself: an operator repointing the backend at an isolated pool kept a
+	// default profile whose root disk still named the old one, so every
+	// container inheriting the profile — which is every container created
+	// without an explicit disk size — landed back on the pool they were
+	// migrating away from. The contention probe went clean right after the
+	// migration and regressed as new tenants arrived.
+	if device, from, changed := rootDiskForPool(profile.Devices["root"], storageName); changed {
+		if from != "" {
+			log.Printf("[incus] default profile root disk moves from storage pool %q to %q; "+
+				"containers created from now on land on %q (#1213)", from, storageName, storageName)
 		}
+		profile.Devices["root"] = device
 		needsUpdate = true
 	}
 
@@ -2051,7 +2154,7 @@ func (c *Client) EnsureDefaultProfile(networkName, storageName string) error {
 // This should be called once during daemon startup
 func (c *Client) InitializeInfrastructure(networkConfig NetworkConfig) error {
 	// 1. Ensure storage pool exists
-	storageName, err := c.EnsureStorage("default")
+	storageName, err := c.EnsureStorage(c.StoragePool())
 	if err != nil {
 		return fmt.Errorf("failed to ensure storage: %w", err)
 	}
@@ -2348,7 +2451,7 @@ func (c *Client) containerRootfsPath(containerName string) string {
 		pool = rootDev["pool"]
 	}
 	if pool == "" {
-		pool = "default"
+		pool = c.StoragePool()
 	}
 	poolCfg, _, err := c.server.GetStoragePool(pool)
 	if err != nil {

--- a/pkg/core/incus/incustest/mock.go
+++ b/pkg/core/incus/incustest/mock.go
@@ -21,6 +21,11 @@ type MockBackend struct {
 	// the container's IPAddress field.
 	WaitNetworkIP string
 
+	// StoragePoolName, if set, is what StoragePool reports. Empty yields
+	// incus.DefaultStoragePool, so existing tests see what they always did
+	// while a test that cares can point the mock at another pool (#1213).
+	StoragePoolName string
+
 	// Override hooks. If non-nil, the method delegates to the function and
 	// the default behavior is skipped.
 	CreateContainerFunc       func(config incus.ContainerConfig) error
@@ -287,6 +292,15 @@ func (m *MockBackend) GetRawInstance(name string) (map[string]string, string, er
 		return m.GetRawInstanceFunc(name)
 	}
 	return nil, "", nil
+}
+
+// StoragePool reports the configured pool, defaulting to incus's own default
+// so existing tests see exactly what they always did (#1213).
+func (m *MockBackend) StoragePool() string {
+	if m.StoragePoolName == "" {
+		return incus.DefaultStoragePool
+	}
+	return m.StoragePoolName
 }
 
 // Compile-time assertion that *MockBackend satisfies incus.Backend.

--- a/pkg/core/incus/storage_pool_test.go
+++ b/pkg/core/incus/storage_pool_test.go
@@ -1,0 +1,129 @@
+package incus
+
+import "testing"
+
+// #1213: every root-disk construction hardcoded the pool literally named
+// "default", so a backend migrated onto an isolated storage pool silently
+// un-migrated itself — existing tenants stayed put while every NEW tenant
+// landed back on the shared-filesystem pool. The contention probe went clean
+// right after the migration and regressed weeks later as tenants arrived,
+// with nothing in the product explaining why.
+
+func TestStoragePool_DefaultsWhenUnset(t *testing.T) {
+	t.Cleanup(func() { configuredStoragePool.Store("") })
+	configuredStoragePool.Store("")
+
+	c := &Client{}
+	if got := c.StoragePool(); got != DefaultStoragePool {
+		t.Errorf("StoragePool() = %q, want %q", got, DefaultStoragePool)
+	}
+}
+
+// The process-wide setting is what reaches the clients built by subsystems
+// that never see daemon config — the cloud actuator and several
+// container_server helpers each call incus.New() for themselves. A
+// per-client-only setting would be honoured on the daemon's client and
+// ignored by all of those, which is the same silent divergence being fixed.
+func TestStoragePool_ProcessWideSettingReachesFreshClients(t *testing.T) {
+	t.Cleanup(func() { configuredStoragePool.Store("") })
+
+	SetDefaultStoragePool("tenants")
+
+	// A client built with no knowledge of the daemon's configuration.
+	if got := (&Client{}).StoragePool(); got != "tenants" {
+		t.Errorf("a freshly built client reports pool %q, want %q — it would create containers "+
+			"on the pool the operator migrated away from (#1213)", got, "tenants")
+	}
+}
+
+// A per-client override still wins, so a test (or a future per-placement
+// caller) can target one pool without disturbing the process default.
+func TestStoragePool_PerClientOverrideWins(t *testing.T) {
+	t.Cleanup(func() { configuredStoragePool.Store("") })
+	SetDefaultStoragePool("tenants")
+
+	c := &Client{}
+	c.SetStoragePool("scratch")
+	if got := c.StoragePool(); got != "scratch" {
+		t.Errorf("StoragePool() = %q, want the per-client override %q", got, "scratch")
+	}
+}
+
+// Empty must not clobber a configured pool — otherwise a subsystem that
+// calls the setter with an unset flag would quietly reset every later
+// client back to "default".
+func TestSetDefaultStoragePool_EmptyIsIgnored(t *testing.T) {
+	t.Cleanup(func() { configuredStoragePool.Store("") })
+
+	SetDefaultStoragePool("tenants")
+	SetDefaultStoragePool("")
+
+	if got := (&Client{}).StoragePool(); got != "tenants" {
+		t.Errorf("an empty SetDefaultStoragePool reset the configured pool to %q", got)
+	}
+}
+
+// #1213 AC3: changing the configured pool must REPOINT the default profile's
+// root disk, not silently leave it.
+//
+// Setting the device only when absent is the other half of how a storage
+// migration undoes itself: every container created without an explicit disk
+// size inherits the default profile, so a stale root disk there sends them
+// all back to the old pool no matter what the create path does.
+func TestRootDiskForPool(t *testing.T) {
+	t.Run("absent device is created", func(t *testing.T) {
+		device, from, changed := rootDiskForPool(nil, "tenants")
+		if !changed {
+			t.Fatal("no device and no change reported")
+		}
+		if from != "" {
+			t.Errorf("movedFrom = %q, want empty when there was no device", from)
+		}
+		if device["pool"] != "tenants" || device["path"] != "/" || device["type"] != "disk" {
+			t.Errorf("device = %v", device)
+		}
+	})
+
+	t.Run("stale pool is repointed", func(t *testing.T) {
+		existing := map[string]string{"type": "disk", "path": "/", "pool": "default"}
+		device, from, changed := rootDiskForPool(existing, "tenants")
+		if !changed {
+			t.Fatal("a root disk still naming the OLD pool was left alone; every container " +
+				"inheriting the default profile would land back on it (#1213)")
+		}
+		if from != "default" {
+			t.Errorf("movedFrom = %q, want %q so the move can be logged", from, "default")
+		}
+		if device["pool"] != "tenants" {
+			t.Errorf("pool = %q, want %q", device["pool"], "tenants")
+		}
+	})
+
+	t.Run("matching pool is left alone", func(t *testing.T) {
+		existing := map[string]string{"type": "disk", "path": "/", "pool": "tenants"}
+		if _, _, changed := rootDiskForPool(existing, "tenants"); changed {
+			t.Error("an already-correct root disk was rewritten; that is a needless profile update " +
+				"on every daemon start")
+		}
+	})
+
+	// Only the pool is ours to change. An operator who set a size or IO limit
+	// on the root device must not lose it to a repoint.
+	t.Run("other device settings survive a repoint", func(t *testing.T) {
+		existing := map[string]string{
+			"type": "disk", "path": "/", "pool": "default",
+			"size": "50GB", "limits.read": "100MB",
+		}
+		device, _, changed := rootDiskForPool(existing, "tenants")
+		if !changed {
+			t.Fatal("expected a repoint")
+		}
+		if device["size"] != "50GB" || device["limits.read"] != "100MB" {
+			t.Errorf("operator settings lost in the repoint: %v", device)
+		}
+		// And the caller's map must not be mutated underneath them.
+		if existing["pool"] != "default" {
+			t.Errorf("the existing device map was mutated in place: %v", existing)
+		}
+	})
+}

--- a/pkg/core/incus/unavailable.go
+++ b/pkg/core/incus/unavailable.go
@@ -28,6 +28,11 @@ func NewUnavailableBackend() *UnavailableBackend { return &UnavailableBackend{} 
 // Compile-time assertion.
 var _ Backend = (*UnavailableBackend)(nil)
 
+// StoragePool returns the default name rather than an error: it has no
+// signature to fail through, and a caller on a host with no incus never
+// reaches a create path where the value is used.
+func (*UnavailableBackend) StoragePool() string { return DefaultStoragePool }
+
 func (*UnavailableBackend) CreateContainer(ContainerConfig) error       { return ErrUnavailable }
 func (*UnavailableBackend) StartContainer(string) error                 { return ErrUnavailable }
 func (*UnavailableBackend) StopContainer(string, bool) error            { return ErrUnavailable }


### PR DESCRIPTION
Fixes #1213.

### The failure it removes

Every container-creation path was pinned to the pool literally named `default` — twelve sites across the client, the container manager, core services and the cloud actuator.

So a backend migrated onto an isolated pool **silently un-migrated itself**: existing tenants stayed put, every *new* tenant landed back on the shared-filesystem pool. The contention probe went clean right after the migration and regressed weeks later as tenants arrived, with nothing connecting the two.

### The flag is `--storage-pool`, not `--pool`

"Pool" is overloaded in this repo — `--pool` already names an independent sentinel-fronted cluster (`docs/MULTI-POOL.md`), which is unrelated. Both the flag help and the package docs say so explicitly, because these are easy to confuse and impossible to confuse *safely*.

### Process-wide, not just per-client

`incus.New()` is called from a dozen places that each build their own client — the cloud actuator, several `container_server` helpers — and none of them thread daemon configuration.

A per-client setting alone would be honoured on the daemon's own client and **silently ignored by every other one**, which is the same shape of bug this change exists to remove. So the pool is process-wide, with the per-client field kept as an override for tests and future per-placement work.

### The profile repoint is the other half

`EnsureDefaultProfile` now **repoints** an existing root disk rather than only setting it when absent.

A container created without an explicit disk size has no root device of its own and inherits the profile's — so a stale profile would send exactly those containers back to the old pool no matter what the create path did. The repoint preserves any other device settings an operator has made (size, IO limits) and doesn't mutate the caller's map; both have tests.

### Blast radius

Adding `StoragePool()` to the `Backend` interface broke exactly **two** implementations — `UnavailableBackend` and the test mock — both trivial. The mock defaults to incus's own default, so existing tests see precisely what they always did, and with nothing configured the behaviour is byte-for-byte what it was.

### Acceptance criteria

- [x] Configurable at the daemon level and threaded everywhere — no literal `"default"` left in root-disk construction
- [x] A container created after the pool changes lands on the configured pool *(test)*
- [x] Changing the pool repoints the default profile's root disk *(test)*
- [x] Documented in `BACKEND-STORAGE-DRIVER.md` — whose Path B previously read *"do not use Path B until #1213 lands"* and is now the procedure, with the ordering that matters spelled out: set `--storage-pool` **before** moving tenants, or the containers created during the migration are the ones that land wrong

Mutation-tested: restoring the literal in the create path, and reverting the profile to set-only-when-absent, each fail a test that names the consequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)