### PR TITLE
test(storageprobe): assert the load mode removes its scratch file

### DIFF
--- a/internal/storageprobe/probe_test.go
+++ b/internal/storageprobe/probe_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -263,5 +264,58 @@ func TestClassify_SevereRequiresAbsoluteLatencyNotJustRatio(t *testing.T) {
 					got.Verdict, tt.wantVerdict, got.Ratio, tt.underLoad.PerOp())
 			}
 		})
+	}
+}
+
+// The load mode's half of "both modes clean up their temp files even when
+// interrupted" (#1210).
+//
+// TestRunLoad_StopsOnContextCancel above drives runLoad with a fake writer, so
+// it proves the loop honours cancellation but says nothing about the file.
+// Load is the exported entry point that actually creates one, and it runs
+// inside a tenant's box: a load generator that leaves a multi-gigabyte scratch
+// file behind every time it is interrupted is worse than one nobody runs.
+func TestLoad_RemovesItsScratchFileWhenInterrupted(t *testing.T) {
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // interrupted before the first cycle
+
+	cfg := DefaultLoadConfig()
+	cfg.Cycles = 1_000_000
+
+	if err := Load(ctx, dir, cfg); err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Load returned %v, want nil or context.Canceled", err)
+	}
+
+	assertNoScratchFiles(t, dir)
+}
+
+// And on the ordinary path too, so the cleanup is not merely a cancellation
+// side effect.
+func TestLoad_RemovesItsScratchFileOnCompletion(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := DefaultLoadConfig()
+	cfg.Cycles = 1 // finish immediately
+
+	if err := Load(context.Background(), dir, cfg); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	assertNoScratchFiles(t, dir)
+}
+
+func assertNoScratchFiles(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "containarium-storage-") {
+			t.Errorf("scratch file %q was left behind; the probe runs inside a tenant's box "+
+				"and one that leaks a file per invocation is one operators stop running", e.Name())
+		}
 	}
 }


### PR DESCRIPTION
Completes the last unproven acceptance criterion on #1210 — *"both modes clean up their temp files even when interrupted"*.

The probe half was already covered. The load half was not: the existing `TestRunLoad_StopsOnContextCancel` drives `runLoad` with a **fake writer**, so it proves the loop honours cancellation and says nothing about the file. `Load` is the exported entry point that actually creates one.

The behaviour was already correct — `Load` defers the remove — but an untested cleanup on the path that matters is a cleanup waiting to be refactored away. It runs inside a tenant's box, and the load generator writes by **volume** by design, so an interrupted run that leaks its scratch file leaks a large one.

Covers both the interrupted and the ordinary path, so the removal isn't merely a cancellation side effect. Mutation-tested: dropping the deferred remove fails both, naming the file left behind.

### Everything else on #1210 is already done

I checked each AC against the code rather than assuming, and ran the suite (14 tests, all passing):

- [x] Probe mode measuring N × (4 KiB write + `fsync`), reporting total and per-op
- [x] Load mode generating dirty pages by volume, with `TestRunLoad_GeneratesVolumeNotFsyncFrequency` asserting it doesn't degenerate into the tight-fsync pattern that failed to reproduce the stall
- [x] `Classify` returns ratio + verdict, calibrated against #1206's measurements — 17→11,885 severe, 17→32 not
- [x] Both modes clean up even when interrupted — **this PR**
- [x] Docs state plainly that a single idle number is not a health signal

And both criteria added later from real measurement:

- [x] High-ratio, low-absolute must NOT be severe — `severeMinPerOp` requires an absolute floor as well as a ratio, with the measured 15.6 ms → 318 ms case as a named test
- [x] Docs state a single 3-sample run is insufficient — the "Take enough samples" section records the non-monotonic result that three samples produced

So #1210 can be closed once this lands. I'd rather leave that to you than close another issue on your behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)