### PR TITLE
feat(runner): let provision target a backend or pool

### DIFF
--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -29,6 +29,8 @@ var (
 	runnerSSHKeyPath   string
 	runnerSentinelHost string
 	runnerSSHUser      string
+	runnerBackendID    string
+	runnerPool         string
 
 	// runner list / remove
 	runnerListFormat string
@@ -120,6 +122,8 @@ func init() {
 	runnerProvisionCmd.Flags().StringVar(&runnerSSHKeyPath, "ssh-key", "", "Path to SSH public key used when creating new boxes (default: ~/.ssh/id_rsa.pub)")
 	runnerProvisionCmd.Flags().StringVar(&runnerSentinelHost, "sentinel", os.Getenv(config.EnvSentinelHost), "Sentinel SSH host (env: CONTAINARIUM_SENTINEL_HOST). REQUIRED for the install step.")
 	runnerProvisionCmd.Flags().StringVar(&runnerSSHUser, "ssh-user", "", "SSH user to use when SSH'ing into a runner box (default: the runner name, via sshpiper)")
+	runnerProvisionCmd.Flags().StringVar(&runnerBackendID, "backend-id", "", "Place the runner boxes on a specific backend (e.g. a named BYOC host). Same semantics as `containarium create --backend-id`; empty keeps today's default placement.")
+	runnerProvisionCmd.Flags().StringVar(&runnerPool, "pool", "", "Place the runner boxes on any healthy backend in this pool. Same semantics as `containarium create --pool`; mutually exclusive with --backend-id, validated by the daemon.")
 
 	// List flags.
 	runnerListCmd.Flags().StringVar(&runnerPAT, "github-pat", os.Getenv("GH_PAT"), "GitHub PAT with `repo` scope (env: GH_PAT). REQUIRED.")
@@ -378,8 +382,8 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 				nil,  // gpus
 				ostype.OSTypeFromString("ubuntu"),
 				false,                   // monitoring
-				"",                      // pool
-				"",                      // backend-id
+				runnerPool,              // pool: steer placement like `create --pool` (#1216)
+				runnerBackendID,         // backend-id: ditto (#1216)
 				client.GitSourceOpts{},  // no git-source for runner boxes
 				0,                       // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
 				0,                       // idle-stop: runner boxes are long-lived; not auto-slept
@@ -416,9 +420,9 @@ func buildDaemonAPI() (runner.DaemonAPI, runner.DaemonCreator, error) {
 			"",  // stack
 			nil, // gpus
 			ostype.OSTypeFromString("ubuntu"),
-			false,
-			"",
-			"",
+			false,                   // monitoring
+			runnerPool,              // pool: steer placement like `create --pool` (#1216)
+			runnerBackendID,         // backend-id: ditto (#1216)
 			client.GitSourceOpts{},  // no git-source for runner boxes
 			0,                       // ttl: runner sets its own lifecycle; birth-TTL wiring is #526
 			0,                       // idle-stop: runner boxes are long-lived; not auto-slept

--- a/internal/mcp/runner_placement_test.go
+++ b/internal/mcp/runner_placement_test.go
@@ -1,0 +1,93 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+)
+
+// #1216: `runner provision` / `provision_runners` could not say WHERE the
+// runner boxes should land, while the create primitive underneath them
+// could. So the lower-level call expressed placement and the workflow built
+// on top of it could not — runners always landed on the default backend.
+//
+// The acceptance criterion this covers is deliberately about the wire, not
+// the flag: "a test asserts the placement argument reaches the create call
+// rather than being silently dropped". A flag that parses and then goes
+// nowhere is the failure mode, and it looks identical to a working one.
+
+// capturingCreateAPI records the CreateContainerRequest the runner creator
+// builds.
+type capturingCreateAPI struct {
+	API
+	got CreateContainerRequest
+}
+
+func (c *capturingCreateAPI) CreateContainer(req CreateContainerRequest) (*CreateContainerResponse, error) {
+	c.got = req
+	return &CreateContainerResponse{
+		Container: Container{Name: req.Username, Username: req.Username},
+	}, nil
+}
+
+// buildCreator extracts the creator the runner deps are wired with, by
+// building the deps and invoking the box manager's create path.
+func createWithPlacement(t *testing.T, place placement) CreateContainerRequest {
+	t.Helper()
+	api := &capturingCreateAPI{}
+
+	// withSSH=false skips the sentinel/SSH-key requirements; the creator is
+	// wired identically either way, and the creator is what is under test.
+	deps, _, err := buildMCPRunnerDeps(api, "", "", false, place)
+	if err != nil {
+		t.Fatalf("buildMCPRunnerDeps: %v", err)
+	}
+	if _, _, err := deps.Boxes.Create(context.Background(), "ci-runner-1", "ssh-ed25519 AAAA test"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	return api.got
+}
+
+func TestProvisionRunners_PlacementReachesTheCreateCall(t *testing.T) {
+	got := createWithPlacement(t, placement{BackendID: "tunnel-gpu-node-a"})
+
+	if got.BackendID != "tunnel-gpu-node-a" {
+		t.Errorf("backendId = %q, want %q — the placement was accepted and then dropped, so the "+
+			"runners land on the default backend while the caller believes otherwise (#1216)",
+			got.BackendID, "tunnel-gpu-node-a")
+	}
+}
+
+func TestProvisionRunners_PoolReachesTheCreateCall(t *testing.T) {
+	got := createWithPlacement(t, placement{Pool: "gpu-pool"})
+
+	if got.Pool != "gpu-pool" {
+		t.Errorf("pool = %q, want %q (#1216)", got.Pool, "gpu-pool")
+	}
+}
+
+// Omitting both must preserve today's placement exactly — this is an added
+// capability, not a change to existing callers.
+func TestProvisionRunners_NoPlacementLeavesTheRequestUnchanged(t *testing.T) {
+	got := createWithPlacement(t, placement{})
+
+	if got.Pool != "" || got.BackendID != "" {
+		t.Errorf("pool=%q backendId=%q, want both empty so the daemon's default placement is "+
+			"untouched for callers that never asked for one", got.Pool, got.BackendID)
+	}
+	// The rest of the runner box shape must be unaffected either way.
+	if !got.EnablePodman || got.Image != "images:ubuntu/24.04" {
+		t.Errorf("runner box shape changed: podman=%v image=%q", got.EnablePodman, got.Image)
+	}
+}
+
+// Both set is a caller error the DAEMON validates (backend must belong to the
+// pool). The tool must forward the pair rather than silently resolving it
+// itself — otherwise the CLI and MCP would disagree about what is legal.
+func TestProvisionRunners_ForwardsBothForDaemonValidation(t *testing.T) {
+	got := createWithPlacement(t, placement{Pool: "gpu-pool", BackendID: "tunnel-gpu-node-a"})
+
+	if got.Pool != "gpu-pool" || got.BackendID != "tunnel-gpu-node-a" {
+		t.Errorf("pool=%q backendId=%q — both must reach the daemon so its existing "+
+			"backend/pool consistency check is the single arbiter", got.Pool, got.BackendID)
+	}
+}

--- a/internal/mcp/runner_tools.go
+++ b/internal/mcp/runner_tools.go
@@ -80,6 +80,14 @@ func runnerTools() []Tool {
 						"type":        "string",
 						"description": "Path to the SSH public key used to create boxes and SSH into them for install. Default ~/.ssh/id_rsa.pub.",
 					},
+					"backend_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Place the runner boxes on a specific backend (e.g. a named BYOC host). Same semantics as create_container's backend_id. Omit to keep the daemon's default placement.",
+					},
+					"pool": map[string]interface{}{
+						"type":        "string",
+						"description": "Place the runner boxes on any healthy backend in this pool. Same semantics as create_container's pool. Mutually exclusive with backend_id; the daemon validates the pair.",
+					},
 				},
 				"required": []string{"repo", "github_pat"},
 			},
@@ -184,7 +192,14 @@ func (a *mcpDaemonAPI) DeleteContainer(username string, force bool) error {
 // Per CLAUDE.md: this is the same shape of dependency graph the
 // CLI builds in internal/cmd/runner.go — both call into
 // internal/runner with the same orchestrator.
-func buildMCPRunnerDeps(client API, sentinel, sshKeyPath string, withSSH bool) (runner.Deps, string, error) {
+// placement steers where runner boxes land, mirroring `containarium create`
+// (#1216). Zero value keeps today's default placement.
+type placement struct {
+	Pool      string
+	BackendID string
+}
+
+func buildMCPRunnerDeps(client API, sentinel, sshKeyPath string, withSSH bool, place placement) (runner.Deps, string, error) {
 	api := &mcpDaemonAPI{c: client}
 	creator := func(_ context.Context, name, sshPubKey string) (string, string, error) {
 		req := CreateContainerRequest{
@@ -197,6 +212,10 @@ func buildMCPRunnerDeps(client API, sentinel, sshKeyPath string, withSSH bool) (
 			Image:        "images:ubuntu/24.04",
 			EnablePodman: true,
 			SSHKeys:      splitMCPKey(sshPubKey),
+			// Placement, same semantics as create_container. Empty leaves
+			// the daemon's default placement untouched (#1216).
+			Pool:      place.Pool,
+			BackendID: place.BackendID,
 		}
 		resp, err := client.CreateContainer(req)
 		if err != nil {
@@ -368,7 +387,10 @@ func handleProvisionRunners(client API, args map[string]interface{}) (string, er
 
 	sentinel := getStringArg(args, "sentinel", "")
 	sshKeyPath := getStringArg(args, "ssh_key_path", "")
-	deps, sshPubKey, err := buildMCPRunnerDeps(client, sentinel, sshKeyPath, true)
+	deps, sshPubKey, err := buildMCPRunnerDeps(client, sentinel, sshKeyPath, true, placement{
+		Pool:      getStringArg(args, "pool", ""),
+		BackendID: getStringArg(args, "backend_id", ""),
+	})
 	if err != nil {
 		return "", err
 	}
@@ -387,7 +409,7 @@ func handleListRunners(client API, args map[string]interface{}) (string, error) 
 	if repo == "" || pat == "" {
 		return "", fmt.Errorf("repo and github_pat are required")
 	}
-	deps, _, err := buildMCPRunnerDeps(client, "", "", false)
+	deps, _, err := buildMCPRunnerDeps(client, "", "", false, placement{})
 	if err != nil {
 		return "", err
 	}
@@ -409,7 +431,7 @@ func handleRemoveRunner(client API, args map[string]interface{}) (string, error)
 	if repo == "" || pat == "" || name == "" {
 		return "", fmt.Errorf("repo, github_pat, and name are required")
 	}
-	deps, _, err := buildMCPRunnerDeps(client, "", "", false)
+	deps, _, err := buildMCPRunnerDeps(client, "", "", false, placement{})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #1216.

### The gap

`runner provision` and the `provision_runners` MCP tool had no way to say *where* the runner boxes should land, while the create primitive underneath them accepts both `backend_id` and `pool`. The lower-level call could express placement; the workflow built on top of it could not.

That's the workload operators most want to steer — refilling a specific host after maintenance (e.g. the storage migration in #1206), pinning a build to GPU or high-disk hardware, or running your own workloads on your own BYOC machine. The last one is the entire point of a BYOC host, and runners are the most common such workload.

The workaround was to call `create_container` with `backend_id` and hand-install the runner service, which reimplements exactly what `runner provision` exists to do.

### The fix

Both flags pass straight through to the existing create call, so the semantics — including the daemon's backend/pool consistency validation — are identical to `containarium create`.

The tool deliberately does **not** resolve the pair itself. Forwarding both keeps the daemon the single arbiter of what's legal, so the CLI and MCP can't drift into disagreeing about it.

Mirrored on the MCP tool per the CLI-first convention, with the same two field names as `create_container`.

### Why this was easy to miss

The CLI call sites already had `""` placeholders in the pool and backend-id positions:

```go
"",   // pool
"",   // backend-id
```

The argument existed, was commented, and was empty — so the code reads as if placement were handled.

### The test targets the wire, not the flag

The acceptance criterion asks for a test that the placement *reaches the create call rather than being silently dropped*, and that's the right thing to assert: a flag that parses and then goes nowhere is the failure mode here, and from the outside it looks identical to a working one.

Mutation-tested — accepting the flags and dropping them before the create fails three of the four tests.

### Acceptance criteria

- [x] `--backend-id` creates the boxes on that backend
- [x] `--pool` behaves as it does for container create, including the existing consistency validation (forwarded, daemon-enforced)
- [x] Omitting both preserves today's placement exactly — asserted separately, including that the rest of the runner box shape is unaffected
- [x] The MCP tool exposes the same two fields
- [x] Test asserts the placement argument reaches the create call

🤖 Generated with [Claude Code](https://claude.com/claude-code)