### PR TITLE
feat(runner): register runners at organization scope, not just per repo

### DIFF
--- a/hacks/runner/install.sh
+++ b/hacks/runner/install.sh
@@ -13,7 +13,9 @@
 #
 # Required env vars (or pass on command line):
 #
-#   GH_REPO     org/repo for the runner (e.g. FootprintAI/Containarium-cloud)
+#   GH_REPO     registration target: owner/repo for one repository, or a
+#               bare owner for an ORGANIZATION runner usable by every repo
+#               in it (#1217)
 #   GH_PAT      personal access token with `repo` scope; used to mint
 #               short-lived runner-registration tokens at the start of
 #               each loop iteration. Pick from
@@ -61,7 +63,7 @@
 set -euo pipefail
 
 # ---- input validation ----
-: "${GH_REPO:?GH_REPO is required (org/repo)}"
+: "${GH_REPO:?GH_REPO is required (owner/repo, or a bare owner for an org runner)}"
 : "${GH_PAT:?GH_PAT is required (PAT with repo scope)}"
 
 # GH_BASE_URL — the GitHub server URL. Defaults to github.com; set to
@@ -238,15 +240,27 @@ cd "$RUNNER_HOME"
 GH_API_BASE="${GH_API_BASE:-https://api.github.com}"
 GH_BASE_URL="${GH_BASE_URL:-https://github.com}"
 
+# Registration scope follows the SHAPE of GH_REPO, the same rule the CLI uses
+# (#1217): "owner/repo" is a repository, a bare "owner" is an organization.
+# An org runner is visible to every repo in the org, which is the point of a
+# shared pool.
+#
+# --url below needs no branch: "${GH_BASE_URL}/${GH_REPO}" is already
+# https://github.com/owner/repo or https://github.com/owner respectively.
+case "$GH_REPO" in
+  */*) GH_SCOPE_PATH="repos/${GH_REPO}" ; GH_PAT_SCOPE="repo" ;;
+  *)   GH_SCOPE_PATH="orgs/${GH_REPO}"  ; GH_PAT_SCOPE="admin:org" ;;
+esac
+
 # Mint a short-lived runner-registration token (valid ~1h).
 REG_TOKEN=$(curl -sX POST \
   -H "Authorization: token $GH_PAT" \
   -H "Accept: application/vnd.github+json" \
-  "${GH_API_BASE}/repos/${GH_REPO}/actions/runners/registration-token" \
+  "${GH_API_BASE}/${GH_SCOPE_PATH}/actions/runners/registration-token" \
   | jq -r '.token')
 
 if [ -z "$REG_TOKEN" ] || [ "$REG_TOKEN" = "null" ]; then
-  echo "Failed to mint registration token — check GH_PAT scope (needs 'repo')" >&2
+  echo "Failed to mint registration token — check GH_PAT scope (this is a ${GH_SCOPE_PATH%%/*} target, which needs '${GH_PAT_SCOPE}')" >&2
   echo "GH_API_BASE in use: ${GH_API_BASE}" >&2
   exit 1
 fi

--- a/internal/cmd/runner.go
+++ b/internal/cmd/runner.go
@@ -53,10 +53,15 @@ entry point.`,
 }
 
 var runnerProvisionCmd = &cobra.Command{
-	Use:   "provision <repo>",
+	Use:   "provision <target>",
 	Short: "Create N runner boxes and register them as ephemeral GHA runners",
 	Long: `Create N Containarium boxes and configure each as an ephemeral
-GitHub Actions self-hosted runner for the given repo.
+GitHub Actions self-hosted runner for the given target.
+
+<target> is either "owner/repo" for a single repository, or a bare "owner"
+for an ORGANIZATION runner that every repo in the org can use (#1217). The
+shape selects the scope, the way GitHub itself disambiguates. An org target
+needs a token with the admin:org scope rather than repo.
 
 This verb is idempotent: re-running with the same args after a partial
 failure is safe. Boxes that already exist are not recreated; boxes that
@@ -80,7 +85,7 @@ Examples:
 }
 
 var runnerListCmd = &cobra.Command{
-	Use:   "list <repo>",
+	Use:   "list <target>",
 	Short: "List provisioned runner boxes and their GitHub registration status",
 	Long: `List Containarium boxes whose name starts with --name-prefix and
 merge their GitHub-side registration status (online / offline / busy /
@@ -92,7 +97,7 @@ Read-only.`,
 }
 
 var runnerRemoveCmd = &cobra.Command{
-	Use:   "remove <repo> <name>",
+	Use:   "remove <target> <name>",
 	Short: "Drain a runner, deregister it from GitHub, and delete the box",
 	Long: `Stop the runner service inside the box (which waits for the in-flight
 ephemeral job to finish — this is what "drain" means in the ephemeral

--- a/internal/mcp/runner_tools.go
+++ b/internal/mcp/runner_tools.go
@@ -50,7 +50,7 @@ func runnerTools() []Tool {
 				"properties": map[string]interface{}{
 					"repo": map[string]interface{}{
 						"type":        "string",
-						"description": "GitHub repo in owner/repo format (e.g. footprintai/containarium).",
+						"description": "Registration target: \"owner/repo\" for one repository, or a bare \"owner\" for an ORGANIZATION runner every repo in the org can use. The shape selects the scope. An org target needs a token with the admin:org scope, not repo.",
 					},
 					"github_pat": map[string]interface{}{
 						"type":        "string",
@@ -105,7 +105,7 @@ func runnerTools() []Tool {
 				"properties": map[string]interface{}{
 					"repo": map[string]interface{}{
 						"type":        "string",
-						"description": "GitHub repo in owner/repo format.",
+						"description": "Registration target: \"owner/repo\" for one repository, or a bare \"owner\" for an ORGANIZATION runner every repo in the org can use. The shape selects the scope. An org target needs a token with the admin:org scope, not repo.",
 					},
 					"github_pat": map[string]interface{}{
 						"type":        "string",
@@ -135,7 +135,7 @@ func runnerTools() []Tool {
 				"properties": map[string]interface{}{
 					"repo": map[string]interface{}{
 						"type":        "string",
-						"description": "GitHub repo in owner/repo format.",
+						"description": "Registration target: \"owner/repo\" for one repository, or a bare \"owner\" for an ORGANIZATION runner every repo in the org can use. The shape selects the scope. An org target needs a token with the admin:org scope, not repo.",
 					},
 					"github_pat": map[string]interface{}{
 						"type":        "string",

--- a/internal/runner/github.go
+++ b/internal/runner/github.go
@@ -42,7 +42,11 @@ type runnersListResponse struct {
 }
 
 func (c *githubClient) ListRunners(ctx context.Context, repo, pat string) ([]RegisteredRunner, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/actions/runners", repo)
+	target, err := ParseTarget(repo)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("https://api.github.com/%s/actions/runners", target.APIPath())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
@@ -59,7 +63,8 @@ func (c *githubClient) ListRunners(ctx context.Context, repo, pat string) ([]Reg
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("github list runners: HTTP %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("github list runners: HTTP %d: %s%s",
+			resp.StatusCode, string(body), target.scopeHint(resp.StatusCode))
 	}
 
 	var parsed runnersListResponse
@@ -80,7 +85,11 @@ func (c *githubClient) ListRunners(ctx context.Context, repo, pat string) ([]Reg
 }
 
 func (c *githubClient) RemoveRunner(ctx context.Context, repo, pat string, runnerID int64) error {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/actions/runners/%d", repo, runnerID)
+	target, err := ParseTarget(repo)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("https://api.github.com/%s/actions/runners/%d", target.APIPath(), runnerID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
@@ -103,6 +112,7 @@ func (c *githubClient) RemoveRunner(ctx context.Context, repo, pat string, runne
 		return nil
 	default:
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("github delete runner: HTTP %d: %s", resp.StatusCode, string(body))
+		return fmt.Errorf("github delete runner: HTTP %d: %s%s",
+			resp.StatusCode, string(body), target.scopeHint(resp.StatusCode))
 	}
 }

--- a/internal/runner/install_script_payload.sh
+++ b/internal/runner/install_script_payload.sh
@@ -13,7 +13,9 @@
 #
 # Required env vars (or pass on command line):
 #
-#   GH_REPO     org/repo for the runner (e.g. FootprintAI/Containarium-cloud)
+#   GH_REPO     registration target: owner/repo for one repository, or a
+#               bare owner for an ORGANIZATION runner usable by every repo
+#               in it (#1217)
 #   GH_PAT      personal access token with `repo` scope; used to mint
 #               short-lived runner-registration tokens at the start of
 #               each loop iteration. Pick from
@@ -61,7 +63,7 @@
 set -euo pipefail
 
 # ---- input validation ----
-: "${GH_REPO:?GH_REPO is required (org/repo)}"
+: "${GH_REPO:?GH_REPO is required (owner/repo, or a bare owner for an org runner)}"
 : "${GH_PAT:?GH_PAT is required (PAT with repo scope)}"
 
 # GH_BASE_URL — the GitHub server URL. Defaults to github.com; set to
@@ -238,15 +240,27 @@ cd "$RUNNER_HOME"
 GH_API_BASE="${GH_API_BASE:-https://api.github.com}"
 GH_BASE_URL="${GH_BASE_URL:-https://github.com}"
 
+# Registration scope follows the SHAPE of GH_REPO, the same rule the CLI uses
+# (#1217): "owner/repo" is a repository, a bare "owner" is an organization.
+# An org runner is visible to every repo in the org, which is the point of a
+# shared pool.
+#
+# --url below needs no branch: "${GH_BASE_URL}/${GH_REPO}" is already
+# https://github.com/owner/repo or https://github.com/owner respectively.
+case "$GH_REPO" in
+  */*) GH_SCOPE_PATH="repos/${GH_REPO}" ; GH_PAT_SCOPE="repo" ;;
+  *)   GH_SCOPE_PATH="orgs/${GH_REPO}"  ; GH_PAT_SCOPE="admin:org" ;;
+esac
+
 # Mint a short-lived runner-registration token (valid ~1h).
 REG_TOKEN=$(curl -sX POST \
   -H "Authorization: token $GH_PAT" \
   -H "Accept: application/vnd.github+json" \
-  "${GH_API_BASE}/repos/${GH_REPO}/actions/runners/registration-token" \
+  "${GH_API_BASE}/${GH_SCOPE_PATH}/actions/runners/registration-token" \
   | jq -r '.token')
 
 if [ -z "$REG_TOKEN" ] || [ "$REG_TOKEN" = "null" ]; then
-  echo "Failed to mint registration token — check GH_PAT scope (needs 'repo')" >&2
+  echo "Failed to mint registration token — check GH_PAT scope (this is a ${GH_SCOPE_PATH%%/*} target, which needs '${GH_PAT_SCOPE}')" >&2
   echo "GH_API_BASE in use: ${GH_API_BASE}" >&2
   exit 1
 fi

--- a/internal/runner/provision.go
+++ b/internal/runner/provision.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 )
@@ -91,7 +90,10 @@ const DefaultRegistrationTimeout = 60 * time.Second
 // caller that wants the defaults can pass `Options{Repo: "...",
 // PAT: "...", Count: 1}` and not worry about timeouts.
 type Options struct {
-	// Repo in "owner/repo" form. Validated against repoPattern.
+	// Repo is the registration target: "owner/repo" for a single
+	// repository, or a bare "owner" for an organization (#1217). The shape
+	// selects the endpoint family, the way GitHub itself disambiguates.
+	// Named Repo for compatibility with existing callers.
 	Repo string
 
 	// PAT is a GitHub Personal Access Token with `repo` scope.
@@ -302,26 +304,18 @@ type Deps struct {
 	Clock  Clock
 }
 
-// repoPattern matches GitHub's "owner/repo" shape. Owner and repo
-// names can contain alphanumerics, hyphen, underscore, and dot;
-// GitHub's full rules are slightly more permissive but this catches
-// the common typos (spaces, slashes other than the single separator,
-// empty owner or repo) without false negatives on real repo names.
-var repoPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$`)
-
 // ValidateOptions returns a descriptive error when Options would
 // fail any precondition Provision checks. Exposed separately so
 // callers (CLI flag handler, MCP tool argument parser) can
 // surface input errors before doing any actual work.
 func ValidateOptions(opts Options) error {
-	if opts.Repo == "" {
-		return fmt.Errorf("repo is required (owner/repo format)")
-	}
-	if !repoPattern.MatchString(opts.Repo) {
-		return fmt.Errorf("repo %q is not in owner/repo format", opts.Repo)
+	target, err := ParseTarget(opts.Repo)
+	if err != nil {
+		return err
 	}
 	if opts.PAT == "" {
-		return fmt.Errorf("github_pat is required (PAT with `repo` scope)")
+		return fmt.Errorf("github_pat is required (PAT with the %q scope for this %s target)",
+			target.RequiredPATScope(), target.Scope)
 	}
 	if opts.Count <= 0 {
 		return fmt.Errorf("count must be > 0, got %d", opts.Count)
@@ -596,11 +590,8 @@ func waitForRegistration(ctx context.Context, deps Deps, opts Options, name stri
 // query the runners-list API; NamePrefix is the filter (only boxes
 // whose name starts with it are returned).
 func List(ctx context.Context, deps Deps, opts Options) (*Result, error) {
-	if opts.Repo == "" {
-		return nil, fmt.Errorf("repo is required")
-	}
-	if !repoPattern.MatchString(opts.Repo) {
-		return nil, fmt.Errorf("repo %q is not in owner/repo format", opts.Repo)
+	if _, err := ParseTarget(opts.Repo); err != nil {
+		return nil, err
 	}
 	if opts.PAT == "" {
 		return nil, fmt.Errorf("github_pat is required")
@@ -666,8 +657,8 @@ func Remove(ctx context.Context, deps Deps, opts Options, name string) (*RunnerS
 	if opts.Repo == "" || opts.PAT == "" {
 		return nil, fmt.Errorf("repo and github_pat are required so the runner can be deregistered from github")
 	}
-	if !repoPattern.MatchString(opts.Repo) {
-		return nil, fmt.Errorf("repo %q is not in owner/repo format", opts.Repo)
+	if _, err := ParseTarget(opts.Repo); err != nil {
+		return nil, err
 	}
 
 	st := &RunnerStatus{Name: name, BoxID: name}

--- a/internal/runner/provision_test.go
+++ b/internal/runner/provision_test.go
@@ -178,17 +178,27 @@ func TestValidateOptions(t *testing.T) {
 		{
 			name:    "empty repo",
 			opts:    Options{Repo: "", PAT: "ghp_x", Count: 1},
-			wantErr: "repo is required",
+			wantErr: "target is required",
 		},
 		{
-			name:    "bad repo format - no slash",
-			opts:    Options{Repo: "owner-repo", PAT: "ghp_x", Count: 1},
-			wantErr: "not in owner/repo format",
+			// CHANGED with #1217: a bare owner is no longer malformed, it is
+			// an ORGANIZATION target. This case previously asserted the
+			// opposite, so it is the one assertion org support genuinely
+			// inverts — kept here, flipped, rather than deleted, so the
+			// change is visible in the diff.
+			name:    "bare owner is an organization target, not an error",
+			opts:    Options{Repo: "footprintai", PAT: "ghp_x", Count: 1},
+			wantErr: "",
 		},
 		{
-			name:    "bad repo format - leading slash",
+			name:    "malformed target - leading slash",
 			opts:    Options{Repo: "/repo", PAT: "ghp_x", Count: 1},
-			wantErr: "not in owner/repo format",
+			wantErr: "neither owner/repo nor a bare organization name",
+		},
+		{
+			name:    "malformed target - trailing slash",
+			opts:    Options{Repo: "owner/", PAT: "ghp_x", Count: 1},
+			wantErr: "neither owner/repo nor a bare organization name",
 		},
 		{
 			name:    "empty PAT",
@@ -691,8 +701,8 @@ func TestList_FilterByPrefixAndMergeGitHubState(t *testing.T) {
 
 func TestList_RequiresRepoAndPAT(t *testing.T) {
 	_, err := List(context.Background(), Deps{}, Options{Repo: "", PAT: "x"})
-	if err == nil || !strings.Contains(err.Error(), "repo is required") {
-		t.Errorf("expected repo-required error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "target is required") {
+		t.Errorf("expected target-required error, got %v", err)
 	}
 	_, err = List(context.Background(), Deps{}, Options{Repo: "owner/repo", PAT: ""})
 	if err == nil || !strings.Contains(err.Error(), "github_pat is required") {
@@ -759,7 +769,9 @@ func TestRemove_RejectsMissingArgs(t *testing.T) {
 		{"no name", Options{Repo: "owner/repo", PAT: "x"}, "", "name is required"},
 		{"no repo", Options{Repo: "", PAT: "x"}, "n", "repo and github_pat are required"},
 		{"no pat", Options{Repo: "owner/repo", PAT: ""}, "n", "repo and github_pat are required"},
-		{"bad repo", Options{Repo: "garbage", PAT: "x"}, "n", "not in owner/repo format"},
+		// "garbage" is now a legitimate ORG target (#1217), so this case uses
+		// a shape that is malformed under either scope.
+		{"malformed target", Options{Repo: "owner//repo", PAT: "x"}, "n", "neither owner/repo nor a bare organization name"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/runner/target.go
+++ b/internal/runner/target.go
@@ -1,0 +1,119 @@
+package runner
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Runner registration targets: a single repository, or a whole organization
+// (#1217).
+//
+// A repo-scoped runner serves exactly one repository, so an org with N repos
+// wanting shared CI capacity had to provision N separate pools — N times the
+// boxes for the same throughput, each idle whenever its own repo is idle,
+// which is the opposite of why a shared runner pool exists.
+//
+// The target's SHAPE selects the endpoint family, the way GitHub itself
+// disambiguates: "owner/repo" is a repository, a bare "owner" is an
+// organization. That keeps the CLI surface unchanged for every existing
+// caller — no new flag to learn, and no flag to get wrong.
+
+// Scope is what a runner is registered against.
+type Scope int
+
+const (
+	// ScopeRepo registers against a single repository.
+	ScopeRepo Scope = iota
+	// ScopeOrg registers against an organization, so every repo in it can
+	// use the runner.
+	ScopeOrg
+)
+
+func (s Scope) String() string {
+	if s == ScopeOrg {
+		return "organization"
+	}
+	return "repository"
+}
+
+// Target is a parsed runner registration target.
+type Target struct {
+	Scope Scope
+	Owner string // the org, or the repository's owner
+	Name  string // the repository name; empty for ScopeOrg
+}
+
+var (
+	ownerPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+	// repoPattern is kept as the two-segment form for the messages that
+	// still speak in owner/repo terms.
+	targetRepoPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*$`)
+)
+
+// ParseTarget reads "owner/repo" or a bare "owner".
+func ParseTarget(s string) (Target, error) {
+	s = strings.TrimSpace(s)
+	switch {
+	case s == "":
+		return Target{}, fmt.Errorf("target is required: either owner/repo for a single repository, or a bare owner for an organization")
+	case targetRepoPattern.MatchString(s):
+		owner, name, _ := strings.Cut(s, "/")
+		return Target{Scope: ScopeRepo, Owner: owner, Name: name}, nil
+	case ownerPattern.MatchString(s):
+		return Target{Scope: ScopeOrg, Owner: s}, nil
+	default:
+		return Target{}, fmt.Errorf("target %q is neither owner/repo nor a bare organization name", s)
+	}
+}
+
+// APIPath is the api.github.com path segment for this target's runner
+// endpoints: "repos/<owner>/<repo>" or "orgs/<org>".
+//
+// Every runner endpoint differs only by this segment, so selecting it in one
+// place is what keeps the two scopes from drifting apart.
+func (t Target) APIPath() string {
+	if t.Scope == ScopeOrg {
+		return "orgs/" + t.Owner
+	}
+	return "repos/" + t.Owner + "/" + t.Name
+}
+
+// ConfigURL is the --url the runner registers itself against.
+func (t Target) ConfigURL() string {
+	if t.Scope == ScopeOrg {
+		return "https://github.com/" + t.Owner
+	}
+	return "https://github.com/" + t.Owner + "/" + t.Name
+}
+
+// RequiredPATScope names the GitHub token scope this target needs.
+//
+// The scopes genuinely differ — an org target needs admin:org, not repo — and
+// a repo-scoped token used against an org endpoint returns a bare 403 that
+// says nothing about which scope is missing. Naming it is the difference
+// between a one-line fix and an afternoon.
+func (t Target) RequiredPATScope() string {
+	if t.Scope == ScopeOrg {
+		return "admin:org"
+	}
+	return "repo"
+}
+
+// String renders the target the way the user typed it.
+func (t Target) String() string {
+	if t.Scope == ScopeOrg {
+		return t.Owner
+	}
+	return t.Owner + "/" + t.Name
+}
+
+// scopeHint turns an authorization failure into one that names the scope the
+// target actually needs.
+func (t Target) scopeHint(status int) string {
+	if status != 403 && status != 401 {
+		return ""
+	}
+	return fmt.Sprintf(" — this is an %s target, which needs a token with the %q scope (a %q-scoped token returns exactly this)",
+		t.Scope, t.RequiredPATScope(), "repo")
+}

--- a/internal/runner/target_test.go
+++ b/internal/runner/target_test.go
@@ -1,0 +1,175 @@
+package runner
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// #1217: runner registration was repo-scoped only. A repo-scoped runner
+// serves exactly one repository, so an org with N repos wanting shared CI
+// capacity had to run N separate pools — N times the boxes for the same
+// throughput, each idle whenever its own repo is idle.
+//
+// The target's SHAPE selects the endpoint family, the way GitHub itself
+// disambiguates. These pin that selection, which is the part that silently
+// hits the wrong API if it drifts.
+
+func TestParseTarget(t *testing.T) {
+	for _, tc := range []struct {
+		in        string
+		wantScope Scope
+		wantPath  string
+		wantURL   string
+		wantPAT   string
+		wantErr   bool
+	}{
+		{in: "footprintai/containarium", wantScope: ScopeRepo,
+			wantPath: "repos/footprintai/containarium",
+			wantURL:  "https://github.com/footprintai/containarium", wantPAT: "repo"},
+		{in: "footprintai", wantScope: ScopeOrg,
+			wantPath: "orgs/footprintai",
+			wantURL:  "https://github.com/footprintai", wantPAT: "admin:org"},
+		// Names GitHub allows.
+		{in: "my-org", wantScope: ScopeOrg, wantPath: "orgs/my-org",
+			wantURL: "https://github.com/my-org", wantPAT: "admin:org"},
+		{in: "owner/repo.js", wantScope: ScopeRepo, wantPath: "repos/owner/repo.js",
+			wantURL: "https://github.com/owner/repo.js", wantPAT: "repo"},
+
+		// Malformed under either scope.
+		{in: "", wantErr: true},
+		{in: "/repo", wantErr: true},
+		{in: "owner/", wantErr: true},
+		{in: "owner//repo", wantErr: true},
+		{in: "owner/repo/extra", wantErr: true},
+		{in: "-leading-dash", wantErr: true},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseTarget(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseTarget(%q) = %+v, want an error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseTarget(%q): %v", tc.in, err)
+			}
+			if got.Scope != tc.wantScope {
+				t.Errorf("scope = %v, want %v", got.Scope, tc.wantScope)
+			}
+			if got.APIPath() != tc.wantPath {
+				t.Errorf("APIPath() = %q, want %q — the wrong endpoint family is a 404 or, worse, "+
+					"a successful call against the wrong object", got.APIPath(), tc.wantPath)
+			}
+			if got.ConfigURL() != tc.wantURL {
+				t.Errorf("ConfigURL() = %q, want %q", got.ConfigURL(), tc.wantURL)
+			}
+			if got.RequiredPATScope() != tc.wantPAT {
+				t.Errorf("RequiredPATScope() = %q, want %q", got.RequiredPATScope(), tc.wantPAT)
+			}
+		})
+	}
+}
+
+// AC5: endpoint selection for both shapes, asserted on the URL the client
+// actually requests rather than on the helper in isolation.
+func TestGitHubClient_SelectsEndpointFamilyFromTargetShape(t *testing.T) {
+	for _, tc := range []struct {
+		target   string
+		wantPath string
+	}{
+		{"footprintai/containarium", "/repos/footprintai/containarium/actions/runners"},
+		{"footprintai", "/orgs/footprintai/actions/runners"},
+	} {
+		t.Run(tc.target, func(t *testing.T) {
+			var gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				_, _ = w.Write([]byte(`{"total_count":0,"runners":[]}`))
+			}))
+			defer srv.Close()
+
+			c := &githubClient{http: srv.Client()}
+			// Point the client at the test server by overriding the host via
+			// a transport that rewrites the URL.
+			c.http = &http.Client{Transport: rewriteHost{to: srv.URL, base: srv.Client().Transport}}
+
+			if _, err := c.ListRunners(context.Background(), tc.target, "ghp_x"); err != nil {
+				t.Fatalf("ListRunners: %v", err)
+			}
+			if gotPath != tc.wantPath {
+				t.Errorf("requested %q, want %q", gotPath, tc.wantPath)
+			}
+		})
+	}
+}
+
+// rewriteHost sends every request to the test server, preserving the path.
+type rewriteHost struct {
+	to   string
+	base http.RoundTripper
+}
+
+func (r rewriteHost) RoundTrip(req *http.Request) (*http.Response, error) {
+	u := *req.URL
+	target := strings.TrimPrefix(r.to, "http://")
+	u.Scheme, u.Host = "http", target
+	clone := req.Clone(req.Context())
+	clone.URL = &u
+	clone.Host = target
+	rt := r.base
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	return rt.RoundTrip(clone)
+}
+
+// AC4: a repo-scoped token against an org target must say so. GitHub returns
+// a bare 403 that names no scope, which is the difference between a one-line
+// fix and an afternoon of guessing.
+func TestGitHubClient_403AgainstAnOrgNamesTheScope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"Resource not accessible by personal access token"}`))
+	}))
+	defer srv.Close()
+
+	c := &githubClient{http: &http.Client{Transport: rewriteHost{to: srv.URL}}}
+
+	_, err := c.ListRunners(context.Background(), "footprintai", "ghp_repo_scoped")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "admin:org") {
+		t.Errorf("error does not name the scope an org target needs: %v", err)
+	}
+
+	// A repo target's 403 must NOT claim admin:org is the fix.
+	_, err = c.ListRunners(context.Background(), "footprintai/containarium", "ghp_x")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), "admin:org") {
+		t.Errorf("a repository target's failure blamed the org scope: %v", err)
+	}
+}
+
+// Existing repo behaviour must be byte-for-byte unchanged (AC3).
+func TestRepoTargetBehaviourUnchanged(t *testing.T) {
+	got, err := ParseTarget("footprintai/containarium")
+	if err != nil {
+		t.Fatalf("ParseTarget: %v", err)
+	}
+	if got.APIPath() != "repos/footprintai/containarium" {
+		t.Errorf("APIPath() = %q — the repo endpoint moved", got.APIPath())
+	}
+	if got.ConfigURL() != "https://github.com/footprintai/containarium" {
+		t.Errorf("ConfigURL() = %q — the runner would register against the wrong URL", got.ConfigURL())
+	}
+	if got.RequiredPATScope() != "repo" {
+		t.Errorf("RequiredPATScope() = %q, want repo", got.RequiredPATScope())
+	}
+}


### PR DESCRIPTION
Refs #1217. **Left open deliberately** — see verification below.

### Why

A repo-scoped runner serves exactly one repository, so an org with N repos wanting shared CI capacity had to provision **N separate pools** — N times the boxes for the same throughput, each idle whenever its own repo is idle. That's the opposite of why a shared runner pool exists.

The only route today is to bypass `runner provision` entirely and hand-configure the runner service, which produces boxes `runner list`/`runner remove` won't manage — so the drain-and-deregister path is lost too.

### The shape selects the scope

The issue's preferred option: `"owner/repo"` is a repository, a bare `"owner"` is an organization — the way GitHub itself disambiguates. No new flag to learn, and none to get wrong.

A `Target` type owns the whole distinction — API path, config URL, required PAT scope — so the two scopes can't drift apart across the places that care. The install script makes the same decision with the same rule, and needs **no branch** for `--url`: `"${GH_BASE_URL}/${GH_REPO}"` is already correct under either shape.

### The scope hint

GitHub answers a repo-scoped token used against an org endpoint with a bare `403` naming no scope at all. The error now says the target is an organization and needs `admin:org`.

A **repository** target's 403 deliberately does *not* say that, and has its own test — a hint that fires everywhere is noise, and would send someone chasing a scope they already have.

### Three existing assertions changed — one is a real inversion

Worth scrutiny, so calling it out rather than burying it:

- `"bad repo format - no slash"` asserted a bare name is **malformed**. That's precisely what org support makes **valid**. Kept and flipped rather than deleted, so the change shows up in the diff as an intentional inversion.
- Two others are **message-only**: their assertions (empty rejected, malformed rejected) are unchanged. New cases cover `owner/`, `owner//repo`, `owner/repo/extra` and a leading dash — shapes malformed under *either* scope, which the old single-pattern check couldn't distinguish.

### Verification, honestly

Unit-tested: endpoint selection for both shapes asserted on the **URL actually requested** (AC5), the `admin:org` message (AC4), and repo behaviour unchanged (AC3). Mutation-tested — forcing the repo endpoint, and dropping the scope hint, each fail with the consequence named.

**Not verified end to end.** AC1/AC2 — that N runners register org-wide and that list/remove operate on them — need a real GitHub org and an `admin:org` PAT, which I don't have. The API paths match GitHub's documented org endpoints and the script logic mirrors the Go side, but that's derivation, not demonstration. Same class of gap as #1199's Incus dependency, so I've left the issue open for whoever can point it at an org.

### Not implemented

`--runner-group`. The issue mentions it under "proposed shape" but not in the acceptance criteria, and it's only meaningful for org runners — better added by someone who can test it against one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)