### PR TITLE
fix(sentinel): re-assert the loopback alias when a spot reconnects

### DIFF
--- a/internal/sentinel/tunnel_registry.go
+++ b/internal/sentinel/tunnel_registry.go
@@ -102,6 +102,24 @@ func (r *TunnelRegistry) Register(hs *TunnelHandshake, session *yamux.Session) (
 			}
 		}
 		delete(r.spots, spotID)
+
+		// Re-assert the loopback alias on reconnect (#1139).
+		//
+		// Reusing the IP is not the same as the IP still being on `lo`. The
+		// registry's map can outlive the alias — a host network
+		// reconfiguration, an `ip addr flush`, or anything else that clears
+		// loopback addresses leaves the entry here pointing at an address
+		// the kernel no longer has. Forwarding then targets an IP that does
+		// not exist, and nothing re-adds it, because this branch previously
+		// only ever reused the recorded address. That is the shape operators
+		// recover from by restarting the sentinel by hand.
+		//
+		// Cheap insurance: addLoopbackAlias is already idempotent — it
+		// treats "already exists" as reuse — so the normal path costs one
+		// `ip addr add` that immediately reports the alias is present.
+		if err := addLoopbackAliasFn(localIP); err != nil {
+			return "", 0, fmt.Errorf("re-assert loopback alias %s on reconnect: %w", localIP, err)
+		}
 	} else {
 		var err error
 		octet, err = r.allocateOctet(spotID)

--- a/internal/sentinel/tunnel_registry_realias_test.go
+++ b/internal/sentinel/tunnel_registry_realias_test.go
@@ -1,0 +1,118 @@
+package sentinel
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// #1139: after a backend is down for a long stretch and returns on the same
+// internal IP, the sentinel could keep stale upstream forwarding state until
+// an operator restarted the service by hand.
+//
+// One concrete gap in that class: the reconnect path reused the recorded
+// loopback IP without re-asserting it on `lo`. Reusing an address is not the
+// same as the address still existing — the registry's map outlives the alias
+// across a host network reconfiguration or an `ip addr flush` — and nothing
+// else re-adds it, so forwarding points at an address the kernel no longer
+// has.
+
+// aliasRecorder counts alias adds so a test can see whether reconnect
+// re-asserted one.
+type aliasRecorder struct {
+	added   []string
+	removed []string
+	err     error
+}
+
+func (a *aliasRecorder) add(ip string) error {
+	if a.err != nil {
+		return a.err
+	}
+	a.added = append(a.added, ip)
+	return nil
+}
+
+func (a *aliasRecorder) remove(ip string) {
+	a.removed = append(a.removed, ip)
+}
+
+// withRecordedAliases swaps in the recorder for the duration of a test.
+func withRecordedAliases(t *testing.T) *aliasRecorder {
+	t.Helper()
+	rec := &aliasRecorder{}
+	origAdd, origRemove := addLoopbackAliasFn, removeLoopbackAliasFn
+	addLoopbackAliasFn, removeLoopbackAliasFn = rec.add, rec.remove
+	t.Cleanup(func() { addLoopbackAliasFn, removeLoopbackAliasFn = origAdd, origRemove })
+	return rec
+}
+
+func TestRegister_ReassertsLoopbackAliasOnReconnect(t *testing.T) {
+	rec := withRecordedAliases(t)
+	r := NewTunnelRegistry()
+
+	ip1, _, err := r.Register(&TunnelHandshake{SpotID: "spot-a"}, nil)
+	if err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	if len(rec.added) != 1 {
+		t.Fatalf("first registration added %d aliases, want 1", len(rec.added))
+	}
+
+	// The backend returns after a long outage and re-registers under the same
+	// spot ID — the reconnect path.
+	ip2, _, err := r.Register(&TunnelHandshake{SpotID: "spot-a"}, nil)
+	if err != nil {
+		t.Fatalf("reconnect Register: %v", err)
+	}
+
+	if ip2 != ip1 {
+		t.Errorf("reconnect moved the spot from %s to %s; the IP must be stable so sshpiper's "+
+			"config does not go stale", ip1, ip2)
+	}
+	if len(rec.added) != 2 {
+		t.Errorf("reconnect added %d aliases in total, want 2 — the alias was not re-asserted, so "+
+			"a spot whose loopback address had gone would keep forwarding to an IP the kernel no "+
+			"longer has, recoverable only by restarting the sentinel (#1139)", len(rec.added))
+	}
+	if len(rec.added) == 2 && rec.added[1] != ip1 {
+		t.Errorf("re-asserted %s, want the spot's own %s", rec.added[1], ip1)
+	}
+}
+
+// A genuinely failing alias add on reconnect must fail the registration
+// rather than returning a spot that cannot be routed to. "Already exists" is
+// NOT such a failure — addLoopbackAlias absorbs it — so this only fires for
+// real errors.
+func TestRegister_ReconnectFailsWhenTheAliasCannotBeRestored(t *testing.T) {
+	rec := withRecordedAliases(t)
+	r := NewTunnelRegistry()
+
+	if _, _, err := r.Register(&TunnelHandshake{SpotID: "spot-a"}, nil); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+
+	rec.err = errors.New("RTNETLINK answers: Operation not permitted")
+	_, _, err := r.Register(&TunnelHandshake{SpotID: "spot-a"}, nil)
+	if err == nil {
+		t.Fatal("reconnect succeeded though the loopback alias could not be restored — the spot " +
+			"would be registered and unroutable, which is the silent half of this failure")
+	}
+	if !strings.Contains(err.Error(), "reconnect") {
+		t.Errorf("error should say the failure was on the reconnect path, got %v", err)
+	}
+}
+
+// The fresh-allocation path is unchanged: exactly one alias add, and a
+// failure there still aborts.
+func TestRegister_FirstRegistrationUnchanged(t *testing.T) {
+	rec := withRecordedAliases(t)
+	r := NewTunnelRegistry()
+
+	if _, _, err := r.Register(&TunnelHandshake{SpotID: "spot-a"}, nil); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if len(rec.added) != 1 {
+		t.Errorf("first registration added %d aliases, want exactly 1", len(rec.added))
+	}
+}


### PR DESCRIPTION
Partial hardening for #1139. **Does not resolve the issue** — caveat at the end.

### The gap

The reconnect path reused the spot's recorded loopback IP without re-asserting it on `lo`:

```go
if old, ok := r.spots[spotID]; ok {
    localIP = old.LocalIP     // reused, never re-added
```

Only the fresh-allocation branch called `addLoopbackAliasFn`. But reusing an address is not the same as the address still existing — the registry's in-memory map outlives the alias across a host network reconfiguration or an `ip addr flush`, and nothing else re-adds it. Forwarding then targets an address the kernel no longer has, recoverable only by restarting the sentinel, which is exactly the manual step #1139 is about removing.

### Cheap by construction

`addLoopbackAlias` is **already idempotent** — it treats "already exists" as reuse-after-crash and returns nil. So the normal path costs one `ip addr add` that immediately reports the alias is present. No new mechanism, no new state.

A *genuine* failure now aborts the registration rather than returning a spot that is registered and unroutable — the silent half of this failure, and the one an operator can't see.

The IP stays stable across reconnect (sshpiper's config depends on it), asserted alongside.

### Caveat — deliberately not overclaimed

**This does not prove it is the cause of the reported wedge.** #1139 describes a hypothesis — *"two factors likely not covered"* — rather than a diagnosis, and its AC3 wants a harness that stops a backend, waits past the connection and key lifetimes, and asserts self-heal.

That needs a real sentinel and backend: the loopback machinery involved can't even run in this sandbox without `CAP_NET_ADMIN` (`TestRegisterPropagatesPool` fails here on clean `main` for exactly that reason). Writing a speculative fix for an unconfirmed root cause is the failure mode I'd be trying to avoid, so this closes one concrete gap in the same class and **leaves the issue open**.

Mutation-tested: dropping the re-assert fails both new tests, each naming what the operator would see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)