### PR TITLE
feat(zfscrypt): rollback and snapshot accounting primitives

### DIFF
--- a/pkg/core/zfscrypt/snapshot.go
+++ b/pkg/core/zfscrypt/snapshot.go
@@ -3,6 +3,7 @@ package zfscrypt
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -123,4 +124,93 @@ func (m *Manager) EnsureInspectable(ctx context.Context, snapshot string) error 
 			snapshot, ErrKeyUnavailableForInspection, dataset, status)
 	}
 	return nil
+}
+
+// ErrNewerSnapshotsExist reports that a rollback would have to destroy
+// snapshots taken after the target.
+//
+// A distinct error because the caller's decision is a real one — losing
+// intermediate restore points — and ZFS's own message ("more recent
+// snapshots or bookmarks exist") does not say which, or that the fix is an
+// explicit flag rather than a retry.
+var ErrNewerSnapshotsExist = fmt.Errorf("rollback would destroy snapshots taken after the target")
+
+// RollbackToSnapshot returns a dataset to the state captured by a snapshot.
+//
+// DESTRUCTIVE, and destructive twice over: everything written since the
+// snapshot is discarded, and any snapshot taken after it must be destroyed
+// too. destroyNewer gates only the second: without it, a rollback that would
+// take other restore points with it is refused with
+// ErrNewerSnapshotsExist rather than silently widening its blast radius.
+//
+// The caller is responsible for the container being stopped. ZFS will refuse
+// a rollback of a busy dataset, but "the dataset is busy" is a far worse
+// message than "stop the container first", and relying on it would make the
+// safety depend on whether the filesystem happens to be mounted.
+func (m *Manager) RollbackToSnapshot(ctx context.Context, snapshot string, destroyNewer bool) error {
+	dataset, _, ok := strings.Cut(snapshot, "@")
+	if !ok {
+		return fmt.Errorf("invalid snapshot reference %q: expected <dataset>@<name>", snapshot)
+	}
+	if err := validateDataset(dataset); err != nil {
+		return err
+	}
+
+	args := []string{"rollback"}
+	if destroyNewer {
+		// -r destroys snapshots newer than the target. Deliberately opt-in.
+		args = append(args, "-r")
+	}
+	args = append(args, snapshot)
+
+	_, stderr, err := m.run.Run(ctx, nil, args...)
+	if err != nil {
+		if isNewerSnapshotsErr(stderr) {
+			return fmt.Errorf("%s: %w: %s", snapshot, ErrNewerSnapshotsExist, strings.TrimSpace(stderr))
+		}
+		return fmt.Errorf("rollback %s: %w: %s", snapshot, err, strings.TrimSpace(stderr))
+	}
+	return nil
+}
+
+// isNewerSnapshotsErr recognises ZFS refusing a rollback because later
+// snapshots exist.
+func isNewerSnapshotsErr(stderr string) bool {
+	s := strings.ToLower(stderr)
+	return strings.Contains(s, "more recent snapshots") || strings.Contains(s, "use '-r' to force")
+}
+
+// SnapshotUsage reports the space a snapshot pins.
+//
+// Used is the space that would be freed by destroying it — the number that
+// matters, because a forgotten snapshot silently holds disk that nothing
+// else accounts for. Referenced is the size of the data the snapshot points
+// at, which is mostly shared with the live dataset and so is NOT what a
+// capacity alert should watch.
+func (m *Manager) SnapshotUsage(ctx context.Context, snapshot string) (used, referenced int64, err error) {
+	dataset, _, ok := strings.Cut(snapshot, "@")
+	if !ok {
+		return 0, 0, fmt.Errorf("invalid snapshot reference %q: expected <dataset>@<name>", snapshot)
+	}
+	if err := validateDataset(dataset); err != nil {
+		return 0, 0, err
+	}
+
+	stdout, stderr, err := m.run.Run(ctx, nil,
+		"get", "-Hp", "-o", "value", "used,referenced", snapshot)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read usage for %s: %w: %s", snapshot, err, strings.TrimSpace(stderr))
+	}
+
+	fields := strings.Fields(strings.TrimSpace(stdout))
+	if len(fields) != 2 {
+		return 0, 0, fmt.Errorf("unexpected usage output for %s: %q", snapshot, strings.TrimSpace(stdout))
+	}
+	if used, err = strconv.ParseInt(fields[0], 10, 64); err != nil {
+		return 0, 0, fmt.Errorf("parse used for %s: %w", snapshot, err)
+	}
+	if referenced, err = strconv.ParseInt(fields[1], 10, 64); err != nil {
+		return 0, 0, fmt.Errorf("parse referenced for %s: %w", snapshot, err)
+	}
+	return used, referenced, nil
 }

--- a/pkg/core/zfscrypt/snapshot_test.go
+++ b/pkg/core/zfscrypt/snapshot_test.go
@@ -124,3 +124,85 @@ func TestListSnapshotsParsesAndSkipsBlanks(t *testing.T) {
 		t.Error("listing consulted keystatus; snapshot names are metadata and need no key")
 	}
 }
+
+// Rollback is destructive twice over — it discards everything written since
+// the snapshot, AND must destroy any snapshot taken after it. The second is
+// gated (#1160).
+func TestRollbackDoesNotDestroyNewerSnapshotsByDefault(t *testing.T) {
+	f := newFakeRunner()
+	m := NewManager(f)
+
+	if err := m.RollbackToSnapshot(context.Background(), "pool/c/alice@snap", false); err != nil {
+		t.Fatalf("RollbackToSnapshot: %v", err)
+	}
+	if strings.Contains(f.allArgs(), "-r") {
+		t.Error("rollback passed -r without being asked to: that silently destroys every restore " +
+			"point taken after the target, which is a wider blast radius than the caller requested")
+	}
+}
+
+func TestRollbackDestroysNewerOnlyWhenAsked(t *testing.T) {
+	f := newFakeRunner()
+	m := NewManager(f)
+
+	if err := m.RollbackToSnapshot(context.Background(), "pool/c/alice@snap", true); err != nil {
+		t.Fatalf("RollbackToSnapshot: %v", err)
+	}
+	if !strings.Contains(f.allArgs(), "rollback -r pool/c/alice@snap") {
+		t.Errorf("expected an explicit -r rollback, got: %s", f.allArgs())
+	}
+}
+
+// ZFS's own refusal does not say which snapshots are in the way, or that the
+// remedy is a deliberate flag rather than a retry.
+func TestRollbackReportsNewerSnapshotsDistinctly(t *testing.T) {
+	f := newFakeRunner()
+	f.errs["rollback"] = errors.New("exit status 1")
+	f.stderr["rollback"] = "cannot rollback to 'pool/c/alice@snap': more recent snapshots or bookmarks exist\nuse '-r' to force deletion of the following snapshots and bookmarks:\npool/c/alice@later"
+	m := NewManager(f)
+
+	err := m.RollbackToSnapshot(context.Background(), "pool/c/alice@snap", false)
+	if !errors.Is(err, ErrNewerSnapshotsExist) {
+		t.Fatalf("err = %v, want ErrNewerSnapshotsExist", err)
+	}
+	if !strings.Contains(err.Error(), "pool/c/alice@later") {
+		t.Errorf("the error should name what stands in the way, got %q", err)
+	}
+}
+
+func TestRollbackRejectsANonSnapshot(t *testing.T) {
+	f := newFakeRunner()
+	if err := NewManager(f).RollbackToSnapshot(context.Background(), "pool/c/alice", false); err == nil {
+		t.Error("accepted a dataset where a snapshot reference was required")
+	}
+	if len(f.calls) != 0 {
+		t.Error("a rejected reference must not reach zfs")
+	}
+}
+
+// A forgotten snapshot silently pins disk, so the number a caller needs is
+// `used` — what destroying it would free — not `referenced`, which is mostly
+// shared with the live dataset.
+func TestSnapshotUsageParsesBothNumbers(t *testing.T) {
+	f := newFakeRunner()
+	f.stdout["get"] = "1048576\t5242880\n"
+	used, referenced, err := NewManager(f).SnapshotUsage(context.Background(), "pool/c/alice@snap")
+	if err != nil {
+		t.Fatalf("SnapshotUsage: %v", err)
+	}
+	if used != 1048576 || referenced != 5242880 {
+		t.Errorf("used=%d referenced=%d", used, referenced)
+	}
+	// -p is what makes these exact bytes rather than "1M".
+	if !strings.Contains(f.allArgs(), "-Hp") {
+		t.Errorf("usage must be read in parseable bytes (-p), got: %s", f.allArgs())
+	}
+}
+
+func TestSnapshotUsageRejectsUnparseableOutput(t *testing.T) {
+	f := newFakeRunner()
+	f.stdout["get"] = "1M\t5M\n" // human-readable: what -p exists to prevent
+	if _, _, err := NewManager(f).SnapshotUsage(context.Background(), "pool/c/alice@snap"); err == nil {
+		t.Error("accepted human-readable sizes as byte counts")
+	}
+}

--- a/pkg/core/zfscrypt/zfscrypt_integration_test.go
+++ b/pkg/core/zfscrypt/zfscrypt_integration_test.go
@@ -373,3 +373,80 @@ func TestIntegration_SnapshotsWorkWithTheKeyUnloaded(t *testing.T) {
 			"unbounded-growth incident.", err)
 	}
 }
+
+// Rollback and snapshot accounting against a real pool (#1160).
+//
+// Rollback is the most destructive operation in this package, and its
+// safety story is entirely about what ZFS does when snapshots exist after
+// the target. Asserting that against a fake would be asserting my own
+// reading of the manual — which the two corrections this lane has already
+// produced (load-key does not remount; unload-key does refuse while
+// mounted) suggest is not good enough for a destructive operation.
+func TestIntegration_RollbackAndSnapshotAccounting(t *testing.T) {
+	zfspool.Require(t)
+	ctx := context.Background()
+	p := zfspool.New(t)
+	m := NewManager(nil)
+
+	ds := p.Dataset("rollback")
+	key := testKey(t, 0x5C)
+	if err := m.CreateEncrypted(ctx, ds, key); err != nil {
+		t.Fatalf("CreateEncrypted: %v", err)
+	}
+	zfspool.Run(t, "zfs", "set", "compression=off", ds)
+
+	dir := filepath.Join(p.Mount, "rollback")
+	before := filepath.Join(dir, "before.txt")
+	if err := os.WriteFile(before, []byte("state at snapshot time"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	snap, err := m.Snapshot(ctx, ds, "good")
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	// Write something AFTER the snapshot; rollback must discard it.
+	after := filepath.Join(dir, "after.txt")
+	if err := os.WriteFile(after, []byte("written after the snapshot"), 0o600); err != nil {
+		t.Fatalf("write after: %v", err)
+	}
+
+	// A snapshot taken later is what makes an unqualified rollback refuse.
+	later, err := m.Snapshot(ctx, ds, "later")
+	if err != nil {
+		t.Fatalf("Snapshot(later): %v", err)
+	}
+
+	// THE safety property: rolling back past a newer snapshot is refused,
+	// and recognised as that specific condition rather than a generic error.
+	err = m.RollbackToSnapshot(ctx, snap, false)
+	if !errors.Is(err, ErrNewerSnapshotsExist) {
+		t.Fatalf("rollback with a newer snapshot present = %v, want ErrNewerSnapshotsExist. "+
+			"If ZFS no longer refuses, an unqualified rollback would destroy restore points "+
+			"the caller never named.", err)
+	}
+
+	// Accounting: the snapshot pins space, and `used` is the number that
+	// would be freed by destroying it.
+	if _, _, err := m.SnapshotUsage(ctx, snap); err != nil {
+		t.Errorf("SnapshotUsage: %v", err)
+	}
+
+	// With the newer snapshot destroyed, the rollback proceeds.
+	if err := m.DestroySnapshot(ctx, later); err != nil {
+		t.Fatalf("DestroySnapshot(later): %v", err)
+	}
+	if err := m.RollbackToSnapshot(ctx, snap, false); err != nil {
+		t.Fatalf("rollback after clearing newer snapshots: %v", err)
+	}
+
+	// The dataset really is back: the post-snapshot write is gone, the
+	// pre-snapshot one remains.
+	if _, err := os.Stat(after); !os.IsNotExist(err) {
+		t.Errorf("after.txt survived the rollback (stat err = %v)", err)
+	}
+	if _, err := os.Stat(before); err != nil {
+		t.Errorf("before.txt did not survive the rollback: %v", err)
+	}
+}


### PR DESCRIPTION
Toward #1160 — **the ZFS layer only**, see the scope note at the end.

### What's added

`RollbackToSnapshot` and `SnapshotUsage`, alongside the snapshot create/list/destroy ops from #1202. Together these are the primitives #1160's acceptance criteria need underneath any RPC.

### Rollback's blast radius is gated, not assumed

Rollback is destructive twice over: it discards everything written since the snapshot, **and** any snapshot taken after it must be destroyed too.

Only the second is gated. Without `destroyNewer`, a rollback that would take other restore points with it is refused with `ErrNewerSnapshotsExist` rather than silently widening its scope. ZFS's own message doesn't convey that the remedy is a *deliberate flag* rather than a retry, so the error names both the condition and the snapshots standing in the way.

### `used` vs `referenced`

They answer different questions, and the AC asks for the one that matters:

- **`used`** — what destroying the snapshot would free. This is what a forgotten snapshot silently grows, and what "a forgotten snapshot pins disk" means.
- **`referenced`** — mostly shared with the live dataset. A capacity alert watching this would fire on nothing.

Read with `-p` so they're bytes, not `"1M"`. A test rejects human-readable output — that's the failure that would otherwise parse as a plausible small number rather than erroring.

### Verified against a real pool

Rollback is the most destructive operation in the package, and its entire safety story is *what ZFS does when later snapshots exist*. Asserting that against a fake would be asserting my reading of the manual — and this lane has already corrected that reading twice (`load-key` does **not** remount; `unload-key` **does** refuse while mounted).

The integration test writes before and after a snapshot, confirms the unqualified rollback is refused while a newer snapshot exists, then confirms the post-snapshot file is gone and the pre-snapshot one survives.

### Scope — and a finding for whoever takes #1160 further

This is deliberately the ZFS layer only. The RPC/CLI/MCP surface needs to resolve **a container to its ZFS dataset**, and that path does not exist in the daemon:

- `datasetResolver` (`encryption_hooks.go:43`) has **no production implementation** — nothing constructs it outside tests.
- `containerRootfsPath` resolves a *filesystem path*, not a dataset name.

It's the same missing piece that blocks #1199's pre-create wiring. Building the RPCs now would put them on an absent foundation, so I've reported it on the issue instead of working around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)