### PR TITLE
refactor(incus): expose the container→ZFS-dataset resolution that already existed

### DIFF
--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -1798,6 +1798,47 @@ func (c *Client) SetDeviceSize(containerName, deviceName, size string) error {
 	return nil
 }
 
+// ContainerDataset resolves the ZFS dataset backing a container's rootfs.
+//
+// Extracted from the quota-headroom path, which has computed this on real
+// hosts since long before it was needed elsewhere — so this is the daemon's
+// existing, exercised understanding of the layout rather than a fresh guess
+// at it. Anything that needs to name a container's dataset (per-tenant
+// encryption's dataset resolver, snapshot/rollback RPCs) should use this
+// rather than rebuild the string.
+//
+// Empty pool uses the configured storage pool.
+func (c *Client) ContainerDataset(containerName, pool string) (string, error) {
+	if containerName == "" {
+		return "", fmt.Errorf("container name is required")
+	}
+	if pool == "" {
+		pool = c.StoragePool()
+	}
+
+	poolConfig, _, err := c.server.GetStoragePool(pool)
+	if err != nil {
+		return "", fmt.Errorf("failed to get storage pool %s: %w", pool, err)
+	}
+	return buildContainerDataset(poolConfig.Config["source"], poolConfig.Name, containerName), nil
+}
+
+// buildContainerDataset is the pure half, so the layout can be tested without
+// an Incus server.
+//
+// The doubled "containers/containers" is not a typo: incus nests its instance
+// datasets under a `containers` child of the pool's own `containers` dataset.
+// It is preserved exactly as the quota path has always produced it — changing
+// it would silently point every caller at a dataset that does not exist.
+func buildContainerDataset(poolSource, poolName, containerName string) string {
+	zfsPool := poolSource
+	if zfsPool == "" {
+		// A pool created without an explicit source uses its own name.
+		zfsPool = poolName
+	}
+	return fmt.Sprintf("%s/containers/containers/%s", zfsPool, containerName)
+}
+
 // ensureZFSQuotaHeadroom checks if the container's ZFS dataset is at quota and
 // temporarily expands it to the target size so Incus can write its backup.yaml.
 func (c *Client) ensureZFSQuotaHeadroom(containerName, pool, targetSize string) error {
@@ -1805,20 +1846,10 @@ func (c *Client) ensureZFSQuotaHeadroom(containerName, pool, targetSize string) 
 		pool = c.StoragePool()
 	}
 
-	// Determine the ZFS dataset name: <zfs-pool>/containers/containers/<name>
-	// Get the ZFS pool name from the Incus storage pool source
-	poolConfig, _, err := c.server.GetStoragePool(pool)
+	dataset, err := c.ContainerDataset(containerName, pool)
 	if err != nil {
-		return fmt.Errorf("failed to get storage pool %s: %w", pool, err)
+		return err
 	}
-
-	zfsPool := poolConfig.Config["source"]
-	if zfsPool == "" {
-		// Try pool name as ZFS pool name
-		zfsPool = poolConfig.Name
-	}
-
-	dataset := fmt.Sprintf("%s/containers/containers/%s", zfsPool, containerName)
 
 	// Set the ZFS quota to the target size directly
 	cmd := exec.Command("zfs", "set", fmt.Sprintf("quota=%s", targetSize), dataset)

--- a/pkg/core/incus/storage_pool_test.go
+++ b/pkg/core/incus/storage_pool_test.go
@@ -1,6 +1,9 @@
 package incus
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // #1213: every root-disk construction hardcoded the pool literally named
 // "default", so a backend migrated onto an isolated storage pool silently
@@ -126,4 +129,55 @@ func TestRootDiskForPool(t *testing.T) {
 			t.Errorf("the existing device map was mutated in place: %v", existing)
 		}
 	})
+}
+
+// buildContainerDataset is the daemon's understanding of where incus puts a
+// container's ZFS dataset. It is extracted from the quota-headroom path
+// rather than newly derived, because that path has computed this string on
+// real hosts for a long time — the value of pinning it here is that the next
+// caller (per-tenant encryption's dataset resolver, snapshot/rollback RPCs)
+// reuses the exercised version instead of rebuilding it from the docs.
+func TestBuildContainerDataset(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		poolSource string
+		poolName   string
+		container  string
+		want       string
+	}{
+		{
+			// The normal case: the incus pool records the ZFS pool it sits on.
+			name: "pool with an explicit source", poolSource: "tank", poolName: "default",
+			container: "alice-container", want: "tank/containers/containers/alice-container",
+		},
+		{
+			// A pool created without an explicit source uses its own name.
+			name: "pool without a source falls back to its name", poolSource: "", poolName: "default",
+			container: "alice-container", want: "default/containers/containers/alice-container",
+		},
+		{
+			// A source that is itself a nested dataset is used verbatim.
+			name: "nested source", poolSource: "tank/incus", poolName: "default",
+			container: "bob", want: "tank/incus/containers/containers/bob",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := buildContainerDataset(tc.poolSource, tc.poolName, tc.container); got != tc.want {
+				t.Errorf("buildContainerDataset(%q, %q, %q) = %q, want %q",
+					tc.poolSource, tc.poolName, tc.container, got, tc.want)
+			}
+		})
+	}
+}
+
+// The doubled segment is load-bearing and looks like a typo, so it gets its
+// own assertion: incus nests instance datasets under a `containers` child of
+// the pool's own `containers` dataset. "Simplifying" it would point every
+// caller at a dataset that does not exist.
+func TestBuildContainerDataset_KeepsTheDoubledContainersSegment(t *testing.T) {
+	got := buildContainerDataset("tank", "default", "alice")
+	if !strings.Contains(got, "/containers/containers/") {
+		t.Errorf("dataset = %q — the doubled segment is incus's actual layout, not a typo; "+
+			"removing it names a dataset that does not exist", got)
+	}
 }


### PR DESCRIPTION
### The finding

Four issues are gated on resolving a container to its ZFS dataset:

- **#1199** — `datasetResolver` has no production implementation, so the encryption hooks are constructed nowhere
- **#1202** — its `KEY_UNAVAILABLE` status half
- **#1160** — snapshot/rollback RPCs
- parts of **#1203/#1204**

I had been treating that as needing a live Incus to work out, and said so repeatedly on those issues. **It doesn't.** The daemon has computed this string on real hosts for a long time, inline in `ensureZFSQuotaHeadroom`, to expand a ZFS quota before Incus writes `backup.yaml`:

```go
// Determine the ZFS dataset name: <zfs-pool>/containers/containers/<name>
zfsPool := poolConfig.Config["source"]
if zfsPool == "" { zfsPool = poolConfig.Name }
dataset := fmt.Sprintf("%s/containers/containers/%s", zfsPool, containerName)
```

That's the daemon's existing, *exercised* understanding of the layout — not a fresh guess at it. This extracts it as `ContainerDataset` so the next caller reuses it instead of rebuilding it from the Incus docs and getting a subtly different answer.

### Behaviour-preserving

The quota path now calls the extracted function; the string it produces is unchanged.

### The doubled segment gets its own test

`containers/containers` reads like a typo — incus nests instance datasets under a `containers` child of the pool's own `containers` dataset. It has a dedicated assertion saying so, because "simplifying" it would name a dataset that does not exist, and every caller would then fail identically and confusingly.

Mutation-tested: dropping one segment fails with the exact strings side by side.

Also covered: the fallback where a pool has no explicit `source` and uses its own name, and a `source` that is itself a nested dataset.

### What this does and doesn't unblock

It does **not** unblock #1199's *pre-create*, which still needs Incus's "instance from an existing zvol" path — I can't derive that from anything already in the repo.

It removes the **other** blocker, which I had wrongly bundled with it: pre-*start*, the status half of #1202, and #1160's RPCs all need only to name an existing container's dataset, and that's now available and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)