### PR TITLE
feat(k8s): compile a tenant egress ACL to NetworkPolicy, refusing what it cannot express

### DIFF
--- a/pkg/core/box/k8s/egress_policy.go
+++ b/pkg/core/box/k8s/egress_policy.go
@@ -1,0 +1,227 @@
+package k8s
+
+import (
+	"fmt"
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Compiling a tenant's egress ACL down to Kubernetes NetworkPolicy (#1188).
+//
+// On the LXC path a tenant's policy becomes eBPF: an egress allowlist, deny
+// CIDRs, virtual-patch rules. On K8s none of it was expressed — a tenant who
+// set an egress allowlist got it enforced on LXC and silently ignored on K8s,
+// with the same SetNetworkPolicy call succeeding either way.
+//
+// # What cannot be carried across, and why that must be loud
+//
+// Kubernetes NetworkPolicy is ALLOW-ONLY. There is no deny rule: a policy is
+// a set of permitted flows, and everything unlisted is denied by the presence
+// of the policy itself. So an explicit DROP/REJECT rule has no equivalent.
+//
+// Dropping such a rule on the floor would reproduce exactly the bug this
+// exists to fix — a tenant's stated intent honoured on one backend and
+// quietly ignored on the other. So the compiler REFUSES to compile a policy
+// it cannot express faithfully, and names the rules it could not carry. A
+// caller can then reject the policy, or record the asymmetry, but it cannot
+// fail to notice it.
+//
+// The narrower reading — "a deny rule is redundant under default-deny, so it
+// is safe to skip" — is true only when the denied destination is not also
+// matched by an allow rule. It is precisely wrong for the case tenants
+// actually write: allow a wide range, then carve an exception out of it.
+
+// UnsupportedEgressRule is a rule that has no faithful NetworkPolicy
+// expression.
+type UnsupportedEgressRule struct {
+	Rule   *pb.ACLRule
+	Reason string
+}
+
+func (u UnsupportedEgressRule) String() string {
+	dst := u.Rule.GetDestination()
+	if dst == "" {
+		dst = "*"
+	}
+	return fmt.Sprintf("%s %s (%s)", u.Rule.GetAction(), dst, u.Reason)
+}
+
+// compileEgressRules turns a tenant's egress ACL into NetworkPolicy egress
+// rules, returning any rule that could not be expressed.
+//
+// A non-empty unsupported list means the policy MUST NOT be applied as-is:
+// the result would permit traffic the tenant asked to block.
+func compileEgressRules(rules []*pb.ACLRule) ([]networkingv1.NetworkPolicyEgressRule, []UnsupportedEgressRule) {
+	var (
+		out         []networkingv1.NetworkPolicyEgressRule
+		unsupported []UnsupportedEgressRule
+	)
+
+	// Deterministic order: NetworkPolicy semantics do not depend on rule
+	// order (it is a union of permitted flows), but a config that reshuffles
+	// on every reconcile churns the API server and makes diffs unreadable.
+	sorted := make([]*pb.ACLRule, len(rules))
+	copy(sorted, rules)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].GetPriority() != sorted[j].GetPriority() {
+			return sorted[i].GetPriority() < sorted[j].GetPriority()
+		}
+		return sorted[i].GetDestination() < sorted[j].GetDestination()
+	})
+
+	for _, r := range sorted {
+		switch r.GetAction() {
+		case pb.ACLAction_ACL_ACTION_ALLOW:
+			// carry on below
+		case pb.ACLAction_ACL_ACTION_DROP, pb.ACLAction_ACL_ACTION_REJECT:
+			unsupported = append(unsupported, UnsupportedEgressRule{
+				Rule:   r,
+				Reason: "Kubernetes NetworkPolicy is allow-only and cannot express a deny",
+			})
+			continue
+		default:
+			unsupported = append(unsupported, UnsupportedEgressRule{
+				Rule:   r,
+				Reason: "unspecified action",
+			})
+			continue
+		}
+
+		peers, err := egressPeersFor(r.GetDestination())
+		if err != nil {
+			unsupported = append(unsupported, UnsupportedEgressRule{Rule: r, Reason: err.Error()})
+			continue
+		}
+		ports, err := egressPortsFor(r.GetDestinationPort(), r.GetProtocol())
+		if err != nil {
+			unsupported = append(unsupported, UnsupportedEgressRule{Rule: r, Reason: err.Error()})
+			continue
+		}
+
+		out = append(out, networkingv1.NetworkPolicyEgressRule{To: peers, Ports: ports})
+	}
+
+	return out, unsupported
+}
+
+// egressPeersFor turns an ACL destination into NetworkPolicy peers.
+//
+// Returns nil peers for "*" — in NetworkPolicy an empty `to` means every
+// destination, which is what the tenant asked for. That is deliberate and
+// distinct from the DEFAULT, which stays deny: an allow-all rule only exists
+// here because someone wrote one.
+func egressPeersFor(destination string) ([]networkingv1.NetworkPolicyPeer, error) {
+	dst := strings.TrimSpace(destination)
+	switch dst {
+	case "", "*":
+		return nil, nil
+	case "@internal", "@external":
+		// These are resolved against the host's own networks on the LXC
+		// path. There is no equivalent notion inside a cluster, and guessing
+		// one (pod CIDR? node CIDR? service CIDR?) would silently mean
+		// something different from what the tenant configured.
+		return nil, fmt.Errorf("destination %q has no cluster equivalent; use an explicit CIDR", dst)
+	}
+
+	prefix, err := netip.ParsePrefix(dst)
+	if err != nil {
+		// A bare address is a valid ACL destination; widen it to a host route.
+		addr, addrErr := netip.ParseAddr(dst)
+		if addrErr != nil {
+			return nil, fmt.Errorf("destination %q is neither a CIDR nor an IP address", dst)
+		}
+		prefix = netip.PrefixFrom(addr, addr.BitLen())
+	}
+	return []networkingv1.NetworkPolicyPeer{
+		{IPBlock: &networkingv1.IPBlock{CIDR: prefix.String()}},
+	}, nil
+}
+
+// egressPortsFor turns an ACL port/protocol pair into NetworkPolicy ports.
+//
+// "*" on either side means "unrestricted", which NetworkPolicy expresses as
+// no port entries at all.
+func egressPortsFor(portSpec, protocol string) ([]networkingv1.NetworkPolicyPort, error) {
+	proto, err := egressProtocolFor(protocol)
+	if err != nil {
+		return nil, err
+	}
+
+	spec := strings.TrimSpace(portSpec)
+	if spec == "" || spec == "*" {
+		if proto == nil {
+			return nil, nil
+		}
+		// A protocol with no port still narrows the rule.
+		return []networkingv1.NetworkPolicyPort{{Protocol: proto}}, nil
+	}
+
+	var ports []networkingv1.NetworkPolicyPort
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		if lo, hi, ok := strings.Cut(part, "-"); ok {
+			start, err := parsePort(lo)
+			if err != nil {
+				return nil, err
+			}
+			end, err := parsePort(hi)
+			if err != nil {
+				return nil, err
+			}
+			if end < start {
+				return nil, fmt.Errorf("port range %q ends before it starts", part)
+			}
+			p := intstr.FromInt(int(start))
+			endPort := end
+			ports = append(ports, networkingv1.NetworkPolicyPort{
+				Protocol: proto, Port: &p, EndPort: &endPort,
+			})
+			continue
+		}
+		n, err := parsePort(part)
+		if err != nil {
+			return nil, err
+		}
+		p := intstr.FromInt(int(n))
+		ports = append(ports, networkingv1.NetworkPolicyPort{Protocol: proto, Port: &p})
+	}
+	return ports, nil
+}
+
+// egressProtocolFor maps the ACL protocol onto the K8s one. Nil means "any",
+// which NetworkPolicy spells as an unset Protocol.
+func egressProtocolFor(protocol string) (*corev1.Protocol, error) {
+	switch strings.ToLower(strings.TrimSpace(protocol)) {
+	case "", "*", "any":
+		return nil, nil
+	case "tcp":
+		p := corev1.ProtocolTCP
+		return &p, nil
+	case "udp":
+		p := corev1.ProtocolUDP
+		return &p, nil
+	case "icmp":
+		// NetworkPolicy has no ICMP: its ports are TCP/UDP/SCTP only. An ICMP
+		// allow silently becoming "no restriction" would be the wrong
+		// direction to fail in.
+		return nil, fmt.Errorf("protocol icmp cannot be expressed by NetworkPolicy")
+	default:
+		return nil, fmt.Errorf("unknown protocol %q", protocol)
+	}
+}
+
+func parsePort(s string) (int32, error) {
+	n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 32)
+	if err != nil || n < 1 || n > 65535 {
+		return 0, fmt.Errorf("invalid port %q", s)
+	}
+	return int32(n), nil
+}

--- a/pkg/core/box/k8s/egress_policy_test.go
+++ b/pkg/core/box/k8s/egress_policy_test.go
@@ -1,0 +1,201 @@
+package k8s
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// #1188: a tenant's egress ACL is enforced on LXC and was silently ignored on
+// K8s, with the same SetNetworkPolicy call succeeding either way.
+//
+// The compiler's job is to carry what it can and REFUSE what it cannot,
+// because quietly dropping a rule is the bug being fixed, not a smaller
+// version of it.
+
+func allowRule(dst, port, proto string) *pb.ACLRule {
+	return &pb.ACLRule{
+		Action:          pb.ACLAction_ACL_ACTION_ALLOW,
+		Destination:     dst,
+		DestinationPort: port,
+		Protocol:        proto,
+	}
+}
+
+// THE property. Kubernetes NetworkPolicy is allow-only, so an explicit deny
+// has no expression. Skipping it would honour the tenant's intent on LXC and
+// ignore it on K8s — exactly the asymmetry #1188 is about.
+//
+// The tempting shortcut is "a deny is redundant under default-deny". That is
+// true only when nothing else allows the destination, and false for the
+// pattern tenants actually write: allow a wide range, carve out an exception.
+func TestCompileEgressRules_RefusesDenyRatherThanDroppingThem(t *testing.T) {
+	rules := []*pb.ACLRule{
+		allowRule("10.0.0.0/8", "443", "tcp"),
+		{
+			Action:      pb.ACLAction_ACL_ACTION_DROP,
+			Destination: "10.1.2.0/24", // an exception carved out of the allow above
+			Protocol:    "tcp",
+		},
+	}
+
+	compiled, unsupported := compileEgressRules(rules)
+
+	if len(unsupported) != 1 {
+		t.Fatalf("unsupported = %v, want exactly the deny rule — dropping it would permit "+
+			"10.1.2.0/24, which the tenant explicitly blocked", unsupported)
+	}
+	if got := unsupported[0].Rule.GetDestination(); got != "10.1.2.0/24" {
+		t.Errorf("unsupported rule = %q, want the deny", got)
+	}
+	// The allow still compiles; the caller decides what to do with a policy
+	// that cannot be fully expressed.
+	if len(compiled) != 1 {
+		t.Errorf("compiled %d rules, want the allow to still compile", len(compiled))
+	}
+}
+
+func TestCompileEgressRules_RejectAlsoUnsupported(t *testing.T) {
+	_, unsupported := compileEgressRules([]*pb.ACLRule{
+		{Action: pb.ACLAction_ACL_ACTION_REJECT, Destination: "10.0.0.0/8"},
+	})
+	if len(unsupported) != 1 {
+		t.Fatalf("REJECT must be reported as unsupported, got %v", unsupported)
+	}
+}
+
+func TestCompileEgressRules_CIDRAndPorts(t *testing.T) {
+	compiled, unsupported := compileEgressRules([]*pb.ACLRule{
+		allowRule("203.0.113.0/24", "443", "tcp"),
+	})
+	if len(unsupported) != 0 {
+		t.Fatalf("unexpected unsupported: %v", unsupported)
+	}
+	if len(compiled) != 1 {
+		t.Fatalf("compiled %d rules, want 1", len(compiled))
+	}
+	rule := compiled[0]
+	if len(rule.To) != 1 || rule.To[0].IPBlock == nil || rule.To[0].IPBlock.CIDR != "203.0.113.0/24" {
+		t.Errorf("peer = %+v, want an IPBlock for 203.0.113.0/24", rule.To)
+	}
+	if len(rule.Ports) != 1 || rule.Ports[0].Port.IntValue() != 443 {
+		t.Errorf("ports = %+v, want 443", rule.Ports)
+	}
+	if rule.Ports[0].Protocol == nil || *rule.Ports[0].Protocol != corev1.ProtocolTCP {
+		t.Errorf("protocol = %v, want TCP", rule.Ports[0].Protocol)
+	}
+}
+
+func TestCompileEgressRules_PortListAndRange(t *testing.T) {
+	compiled, unsupported := compileEgressRules([]*pb.ACLRule{
+		allowRule("10.0.0.0/8", "80,443", "tcp"),
+		allowRule("10.0.0.0/8", "8000-8100", "tcp"),
+	})
+	if len(unsupported) != 0 {
+		t.Fatalf("unexpected unsupported: %v", unsupported)
+	}
+	if len(compiled[0].Ports) != 2 {
+		t.Errorf("a comma list must become two port entries, got %+v", compiled[0].Ports)
+	}
+	rangeRule := compiled[1].Ports[0]
+	if rangeRule.Port.IntValue() != 8000 || rangeRule.EndPort == nil || *rangeRule.EndPort != 8100 {
+		t.Errorf("range compiled to %+v, want 8000-8100", rangeRule)
+	}
+}
+
+// A bare IP is a valid ACL destination; it must become a host route rather
+// than being refused or, worse, widened.
+func TestCompileEgressRules_BareAddressBecomesHostRoute(t *testing.T) {
+	compiled, unsupported := compileEgressRules([]*pb.ACLRule{allowRule("203.0.113.7", "53", "udp")})
+	if len(unsupported) != 0 {
+		t.Fatalf("unexpected unsupported: %v", unsupported)
+	}
+	if got := compiled[0].To[0].IPBlock.CIDR; got != "203.0.113.7/32" {
+		t.Errorf("CIDR = %q, want a /32 host route", got)
+	}
+}
+
+// "*" means the tenant asked for unrestricted egress. NetworkPolicy spells
+// that as an empty peer list. It is deliberate, and distinct from the default,
+// which stays deny — an allow-all only exists here because someone wrote one.
+func TestCompileEgressRules_WildcardIsUnrestricted(t *testing.T) {
+	compiled, unsupported := compileEgressRules([]*pb.ACLRule{allowRule("*", "*", "*")})
+	if len(unsupported) != 0 {
+		t.Fatalf("unexpected unsupported: %v", unsupported)
+	}
+	if len(compiled) != 1 || len(compiled[0].To) != 0 || len(compiled[0].Ports) != 0 {
+		t.Errorf("wildcard compiled to %+v, want an unrestricted rule", compiled[0])
+	}
+}
+
+// Things with no cluster meaning must be refused rather than guessed at. Pod
+// CIDR, node CIDR and service CIDR are all plausible readings of "@internal",
+// and picking one silently means something the tenant did not configure.
+func TestCompileEgressRules_RefusesHostRelativeDestinations(t *testing.T) {
+	for _, dst := range []string{"@internal", "@external"} {
+		_, unsupported := compileEgressRules([]*pb.ACLRule{allowRule(dst, "*", "tcp")})
+		if len(unsupported) != 1 {
+			t.Errorf("destination %q was accepted; it has no cluster equivalent", dst)
+		}
+	}
+}
+
+// ICMP has no NetworkPolicy expression. Silently producing an unrestricted
+// rule would fail in the permissive direction.
+func TestCompileEgressRules_RefusesICMP(t *testing.T) {
+	_, unsupported := compileEgressRules([]*pb.ACLRule{allowRule("10.0.0.0/8", "*", "icmp")})
+	if len(unsupported) != 1 {
+		t.Fatalf("icmp must be reported as unsupported, got %v", unsupported)
+	}
+}
+
+func TestCompileEgressRules_RejectsMalformedInput(t *testing.T) {
+	for _, tc := range []struct{ name, dst, port, proto string }{
+		{"bad cidr", "not-an-address", "443", "tcp"},
+		{"bad port", "10.0.0.0/8", "99999", "tcp"},
+		{"inverted range", "10.0.0.0/8", "500-100", "tcp"},
+		{"unknown protocol", "10.0.0.0/8", "443", "sctp-ish"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, unsupported := compileEgressRules([]*pb.ACLRule{allowRule(tc.dst, tc.port, tc.proto)})
+			if len(unsupported) != 1 {
+				t.Errorf("malformed rule was accepted: %+v", tc)
+			}
+		})
+	}
+}
+
+// Output order must not depend on input order, or every reconcile rewrites the
+// object and the diff is unreadable.
+func TestCompileEgressRules_DeterministicOrder(t *testing.T) {
+	a := allowRule("10.0.0.0/8", "443", "tcp")
+	a.Priority = 2
+	b := allowRule("192.168.0.0/16", "443", "tcp")
+	b.Priority = 1
+
+	first, _ := compileEgressRules([]*pb.ACLRule{a, b})
+	second, _ := compileEgressRules([]*pb.ACLRule{b, a})
+
+	if len(first) != 2 || len(second) != 2 {
+		t.Fatalf("expected 2 rules each, got %d and %d", len(first), len(second))
+	}
+	if first[0].To[0].IPBlock.CIDR != second[0].To[0].IPBlock.CIDR {
+		t.Errorf("order depends on input: %q vs %q",
+			first[0].To[0].IPBlock.CIDR, second[0].To[0].IPBlock.CIDR)
+	}
+	// Lower priority number sorts first, matching the ACL's own semantics.
+	if first[0].To[0].IPBlock.CIDR != "192.168.0.0/16" {
+		t.Errorf("priority 1 should sort before priority 2, got %q", first[0].To[0].IPBlock.CIDR)
+	}
+}
+
+// An empty policy compiles to nothing — the caller keeps the default-deny
+// floor rather than receiving an allow-all.
+func TestCompileEgressRules_EmptyIsEmpty(t *testing.T) {
+	compiled, unsupported := compileEgressRules(nil)
+	if len(compiled) != 0 || len(unsupported) != 0 {
+		t.Errorf("empty policy compiled to %+v / %v, want nothing at all", compiled, unsupported)
+	}
+}


### PR DESCRIPTION
Toward #1188 — the compiler. Scope note at the end.

### The problem

A tenant's egress allowlist is enforced on LXC and **silently ignored** on K8s, with the same `SetNetworkPolicy` call succeeding either way. This adds the piece that turns an ACL into NetworkPolicy egress rules: CIDRs and bare addresses into `IPBlock` peers, port lists and ranges into ports, tcp/udp into protocols.

### The load-bearing decision: what happens to rules that can't be carried

Kubernetes NetworkPolicy is **allow-only**. A policy is a set of permitted flows; everything unlisted is denied by the policy existing. So an explicit `DROP`/`REJECT` has no equivalent.

The compiler **refuses** those rather than dropping them, and names them.

The tempting shortcut is *"a deny is redundant under default-deny, so skipping it is safe."* That holds only when nothing else allows the destination — and it's precisely wrong for the pattern tenants actually write:

```
allow  10.0.0.0/8      tcp/443
deny   10.1.2.0/24     tcp        ← an exception carved out of the allow
```

Skip the carve-out and you permit exactly the traffic the tenant blocked. That is **this issue's own bug, reintroduced one layer down**, so it has the most prominent test in the file.

Same reasoning for the other unrepresentable inputs:

- **`@internal` / `@external`** — resolved against the host's networks on the LXC path, with no cluster equivalent. Pod CIDR, node CIDR and service CIDR are all plausible readings; picking one silently means something the tenant never configured.
- **ICMP** — no NetworkPolicy expression at all. Compiling it to "no port restriction" would fail in the permissive direction.

### `*` is different, and is carried

Unrestricted egress is something a tenant can legitimately ask for, and NetworkPolicy spells it as an empty peer list. That's distinct from the **default**, which stays deny — an allow-all exists only because someone wrote one.

### Determinism

Output is ordered by ACL priority, so a reconcile doesn't rewrite the object every pass and leave an unreadable diff.

### Scope

The compiler only. Reconciliation from `NetworkPolicyService`, and the kind integration test asserting a denied destination is genuinely unreachable, are the next slice — the latter is now *possible* because the kind lane enforces policy since #1235.

Mutation-tested on the two paths that would fail permissively: silently skipping deny rules, and treating ICMP as unrestricted. Both fail with the consequence named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)