### PR TITLE
feat(k8s): apply a tenant egress allowlist onto the default-deny floor

### DIFF
--- a/pkg/core/box/k8s/egress_apply_test.go
+++ b/pkg/core/box/k8s/egress_apply_test.go
@@ -1,0 +1,143 @@
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+	sandboxfake "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned/fake"
+)
+
+// #1188 ACs 2-4, at the object level: a tenant egress allowlist appears
+// alongside the DNS allowance; removal reverts to the default-deny floor and
+// never to allow-all; a box with no policy is unchanged.
+
+func egressTestBackend() *Backend {
+	return NewWithClientset(fake.NewSimpleClientset(), sandboxfake.NewSimpleClientset(),
+		Config{TenantNamespacePrefix: "tenant-", GatewayNamespace: "agent-gateway"})
+}
+
+func TestApplyTenantEgress_AddsRulesAlongsideDNS(t *testing.T) {
+	b := egressTestBackend()
+	ctx := context.Background()
+
+	err := b.ApplyTenantEgress(ctx, "alice", []*pb.ACLRule{
+		allowRule("203.0.113.0/24", "443", "tcp"),
+	})
+	if err != nil {
+		t.Fatalf("ApplyTenantEgress: %v", err)
+	}
+
+	ns := "tenant-alice"
+	np, err := b.clientset.NetworkingV1().NetworkPolicies(ns).Get(ctx, "default-deny", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get networkpolicy: %v", err)
+	}
+
+	if len(np.Spec.Egress) != 2 {
+		t.Fatalf("egress has %d rules, want the DNS floor plus the tenant rule", len(np.Spec.Egress))
+	}
+	// DNS stays first and intact — a box that cannot resolve names looks like
+	// a policy bug and is not one.
+	if len(np.Spec.Egress[0].Ports) != 2 {
+		t.Errorf("the DNS allowance was disturbed: %+v", np.Spec.Egress[0])
+	}
+	if np.Spec.Egress[1].To[0].IPBlock == nil || np.Spec.Egress[1].To[0].IPBlock.CIDR != "203.0.113.0/24" {
+		t.Errorf("tenant rule = %+v, want an IPBlock for 203.0.113.0/24", np.Spec.Egress[1])
+	}
+}
+
+// THE property that matters more than the feature: removing a policy must
+// revert to the floor, never widen. A removal that opened access would be a
+// silent privilege escalation triggered by a delete.
+func TestApplyTenantEgress_RemovalRevertsToTheFloorNotAllowAll(t *testing.T) {
+	b := egressTestBackend()
+	ctx := context.Background()
+
+	if err := b.ApplyTenantEgress(ctx, "alice", []*pb.ACLRule{
+		allowRule("203.0.113.0/24", "443", "tcp"),
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// Policy removed.
+	if err := b.ApplyTenantEgress(ctx, "alice", nil); err != nil {
+		t.Fatalf("apply(empty): %v", err)
+	}
+
+	np, err := b.clientset.NetworkingV1().NetworkPolicies("tenant-alice").Get(ctx, "default-deny", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(np.Spec.Egress) != 1 {
+		t.Fatalf("after removal egress has %d rules, want only the DNS floor: %+v",
+			len(np.Spec.Egress), np.Spec.Egress)
+	}
+	// An egress rule with no `to` and no `ports` is allow-all. Reverting into
+	// that would be the worst possible outcome of a delete.
+	only := np.Spec.Egress[0]
+	if len(only.To) == 0 && len(only.Ports) == 0 {
+		t.Fatal("removal left an unrestricted egress rule — a delete widened access")
+	}
+	if len(only.Ports) != 2 {
+		t.Errorf("the remaining rule is not the DNS floor: %+v", only)
+	}
+}
+
+// A policy containing a rule that cannot be expressed must not be partially
+// applied — the applied part would permit traffic the policy denies while
+// reporting success.
+func TestApplyTenantEgress_RefusesPartialApplication(t *testing.T) {
+	b := egressTestBackend()
+	ctx := context.Background()
+
+	err := b.ApplyTenantEgress(ctx, "alice", []*pb.ACLRule{
+		allowRule("10.0.0.0/8", "443", "tcp"),
+		{Action: pb.ACLAction_ACL_ACTION_DROP, Destination: "10.1.2.0/24", Protocol: "tcp"},
+	})
+	if err == nil {
+		t.Fatal("a policy with an inexpressible deny was applied; the allow would permit " +
+			"10.1.2.0/24, which the tenant blocked")
+	}
+	if !strings.Contains(err.Error(), "10.1.2.0/24") {
+		t.Errorf("the error should name the rule it could not carry: %v", err)
+	}
+
+	// And nothing was written.
+	if _, err := b.clientset.NetworkingV1().NetworkPolicies("tenant-alice").Get(
+		ctx, "default-deny", metav1.GetOptions{}); err == nil {
+		t.Error("a refused policy still wrote an object")
+	}
+}
+
+func TestApplyTenantEgress_UpdatesInPlaceOnRepeatedApply(t *testing.T) {
+	b := egressTestBackend()
+	ctx := context.Background()
+
+	for _, cidr := range []string{"203.0.113.0/24", "198.51.100.0/24"} {
+		if err := b.ApplyTenantEgress(ctx, "alice", []*pb.ACLRule{allowRule(cidr, "443", "tcp")}); err != nil {
+			t.Fatalf("apply %s: %v", cidr, err)
+		}
+	}
+
+	list, err := b.clientset.NetworkingV1().NetworkPolicies("tenant-alice").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("repeated apply created %d policies, want 1 updated in place", len(list.Items))
+	}
+	if got := list.Items[0].Spec.Egress[1].To[0].IPBlock.CIDR; got != "198.51.100.0/24" {
+		t.Errorf("policy was not updated: egress targets %q", got)
+	}
+}
+
+func TestApplyTenantEgress_RequiresTenant(t *testing.T) {
+	if err := egressTestBackend().ApplyTenantEgress(context.Background(), "", nil); err == nil {
+		t.Error("accepted an empty tenant")
+	}
+}

--- a/pkg/core/box/k8s/egress_policy.go
+++ b/pkg/core/box/k8s/egress_policy.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
 	"net/netip"
 	"sort"
@@ -9,6 +10,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -224,4 +227,57 @@ func parsePort(s string) (int32, error) {
 		return 0, fmt.Errorf("invalid port %q", s)
 	}
 	return int32(n), nil
+}
+
+// ApplyTenantEgress reconciles a tenant namespace's NetworkPolicy so it
+// permits the tenant's egress allowlist on top of the default-deny floor
+// (#1188).
+//
+// Passing no rules is how a policy is REMOVED, and it reverts to the floor —
+// DNS only — never to allow-all. That direction matters more than the
+// feature: a removal that widened access would be a silent privilege
+// escalation triggered by a delete.
+//
+// Refuses outright when any rule cannot be faithfully expressed, rather than
+// applying the part it understood. A partially-applied egress policy permits
+// traffic the tenant asked to block, and does so while reporting success.
+func (b *Backend) ApplyTenantEgress(ctx context.Context, tenant string, rules []*pb.ACLRule) error {
+	if tenant == "" {
+		return fmt.Errorf("k8s: tenant is required")
+	}
+
+	compiled, unsupported := compileEgressRules(rules)
+	if len(unsupported) > 0 {
+		parts := make([]string, 0, len(unsupported))
+		for _, u := range unsupported {
+			parts = append(parts, u.String())
+		}
+		return fmt.Errorf("k8s: refusing to apply a partial egress policy for tenant %q — "+
+			"%d rule(s) have no NetworkPolicy expression and applying the rest would permit "+
+			"traffic the policy denies: %s", tenant, len(unsupported), strings.Join(parts, "; "))
+	}
+
+	ns := b.cfg.TenantNamespacePrefix + tenant
+	desired := networkPolicyObject(ns, tenant, b.cfg.GatewayNamespace, compiled...)
+
+	policies := b.clientset.NetworkingV1().NetworkPolicies(ns)
+	existing, err := policies.Get(ctx, desired.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			if _, err := policies.Create(ctx, desired, metav1.CreateOptions{}); err != nil {
+				return fmt.Errorf("k8s: create networkpolicy for tenant %q: %w", tenant, err)
+			}
+			return nil
+		}
+		return fmt.Errorf("k8s: read networkpolicy for tenant %q: %w", tenant, err)
+	}
+
+	// Update in place, preserving resourceVersion so a concurrent writer is
+	// detected rather than silently overwritten.
+	updated := existing.DeepCopy()
+	updated.Spec = desired.Spec
+	if _, err := policies.Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("k8s: update networkpolicy for tenant %q: %w", tenant, err)
+	}
+	return nil
 }

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -247,7 +247,11 @@ const dnsNamespace = "kube-system"
 // ingress rule falls back to port-only — routing is disabled in that
 // configuration anyway (see gateway_sshpiper.go), and emitting a selector that
 // matches nothing would make the box unreachable rather than merely unrouted.
-func networkPolicyObject(ns, tenant, gatewayNS string) *networkingv1.NetworkPolicy {
+// tenantEgress, when non-empty, is appended to the DNS allowance as
+// additional permitted egress. Empty leaves the default-deny floor exactly as
+// it was — which is what a box with no tenant policy, and a box whose policy
+// was just removed, must both get (#1188).
+func networkPolicyObject(ns, tenant, gatewayNS string, tenantEgress ...networkingv1.NetworkPolicyEgressRule) *networkingv1.NetworkPolicy {
 	tcp := corev1.ProtocolTCP
 	udp := corev1.ProtocolUDP
 	dnsPort := intstr.FromInt(53)
@@ -271,6 +275,22 @@ func networkPolicyObject(ns, tenant, gatewayNS string) *networkingv1.NetworkPoli
 		}}
 	}
 
+	// The DNS allowance is the floor and always comes first: a box that
+	// cannot resolve names is broken in a way that looks like a policy bug
+	// but is not one, so it is never something a tenant rule can remove.
+	egress := []networkingv1.NetworkPolicyEgressRule{{
+		To: []networkingv1.NetworkPolicyPeer{{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{nsNameLabel: dnsNamespace},
+			},
+		}},
+		Ports: []networkingv1.NetworkPolicyPort{
+			{Protocol: &udp, Port: &dnsPort},
+			{Protocol: &tcp, Port: &dnsPort},
+		},
+	}}
+	egress = append(egress, tenantEgress...)
+
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "default-deny", Namespace: ns, Labels: boxLabels(tenant)},
 		Spec: networkingv1.NetworkPolicySpec{
@@ -280,17 +300,7 @@ func networkPolicyObject(ns, tenant, gatewayNS string) *networkingv1.NetworkPoli
 				networkingv1.PolicyTypeEgress,
 			},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{ingress},
-			Egress: []networkingv1.NetworkPolicyEgressRule{{
-				To: []networkingv1.NetworkPolicyPeer{{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{nsNameLabel: dnsNamespace},
-					},
-				}},
-				Ports: []networkingv1.NetworkPolicyPort{
-					{Protocol: &udp, Port: &dnsPort},
-					{Protocol: &tcp, Port: &dnsPort},
-				},
-			}},
+			Egress:  egress,
 		},
 	}
 }


### PR DESCRIPTION
Continues #1188 from #1260 (the compiler). This is the apply path — ACs 2–4 at the object level.

### What it does

`networkPolicyObject` now takes optional tenant egress rules and appends them **after** the DNS allowance, which stays first and untouched. A box that cannot resolve names is broken in a way that *looks* like a policy bug and isn't one, so DNS is never something a tenant rule can displace.

`ApplyTenantEgress` creates or updates the tenant namespace's policy in place, preserving `resourceVersion` so a concurrent writer is detected rather than silently overwritten.

### Two safety properties carry the weight

**Removal reverts to the floor, never to allow-all.** Passing no rules is how a policy is *removed*, and an egress rule with neither `to` nor `ports` is unrestricted. Reverting into that would make a **delete widen access** — a silent privilege escalation triggered by a removal, which is a worse outcome than the feature is worth.

**A policy with an inexpressible rule is refused outright, not partially applied.** Applying only the understood part permits exactly the traffic the tenant blocked, while reporting success — this issue's own bug, one layer down. The error names the rules it couldn't carry.

Both are mutation-tested, and both failures name the consequence rather than the assertion:

```
removal left an unrestricted egress rule — a delete widened access
a policy with an inexpressible deny was applied; the allow would permit
10.1.2.0/24, which the tenant blocked
```

### Remaining on #1188

- Reconciliation from `NetworkPolicyService` (AC 1) — needs a K8s-native reconciler reading the same `NetworkPolicyStore` the LXC enforcer uses; the store interface is already abstract, the enforcer's *inspector* is what's incus-typed.
- The kind integration test asserting a denied destination is genuinely unreachable (AC 5) — now possible because the lane enforces policy since #1235.

### Note

This was committed to #1260's branch a moment after that PR merged, so it's cherry-picked onto a fresh branch rather than lost. Same content, reviewed as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)