### PR TITLE
feat(k8s): reconcile tenant NetworkPolicy objects from the policy store

### DIFF
--- a/internal/server/k8s_netpolicy_reconciler.go
+++ b/internal/server/k8s_netpolicy_reconciler.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Converging tenant NetworkPolicy objects on the K8s backend (#1188).
+//
+// The eBPF enforcer drives the LXC path from the same store, re-reading it on
+// a ticker so a dropped event cannot leave the world diverged. This mirrors
+// that: the store is the source of truth on every pass, and the K8s objects
+// are made to match it.
+//
+// It is a separate type rather than a mode of NetworkPolicyEnforcer because
+// the enforcer is type-coupled to incus — its inspector returns
+// []incus.ContainerInfo and it attaches TCX to host veths. Pods have neither.
+// Only the store is shared, which is why the store interface is the seam.
+
+// tenantPolicyApplier applies a tenant's policy to a backend. Satisfied by
+// the K8s box backend; an interface so the reconcile logic is testable
+// without a cluster.
+type tenantPolicyApplier interface {
+	ApplyTenantPolicy(ctx context.Context, tenant string, policy *pb.NetworkPolicy) error
+}
+
+// defaultK8sNetPolicyInterval matches the eBPF enforcer's cadence. The store
+// is re-read each pass, so a missed change costs at most one interval.
+const defaultK8sNetPolicyInterval = 10 * time.Second
+
+// K8sNetworkPolicyReconciler converges each tenant's NetworkPolicy object
+// with the tenant policy held in the store.
+type K8sNetworkPolicyReconciler struct {
+	store    NetworkPolicyStore
+	applier  tenantPolicyApplier
+	interval time.Duration
+
+	// applied is the set of tenants this reconciler has written a policy for.
+	//
+	// Load-bearing: a tenant whose policy is DELETED simply stops appearing
+	// in the store, so without remembering that we wrote one, nothing would
+	// ever revert their namespace to the default-deny floor and the last
+	// applied allowlist would persist indefinitely. A stale allowlist
+	// outliving its policy is a permission that was revoked and kept working.
+	mu      sync.Mutex
+	applied map[string]struct{}
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewK8sNetworkPolicyReconciler builds a reconciler. A zero interval uses the
+// default.
+func NewK8sNetworkPolicyReconciler(store NetworkPolicyStore, applier tenantPolicyApplier, interval time.Duration) *K8sNetworkPolicyReconciler {
+	if interval <= 0 {
+		interval = defaultK8sNetPolicyInterval
+	}
+	return &K8sNetworkPolicyReconciler{
+		store:    store,
+		applier:  applier,
+		interval: interval,
+		applied:  map[string]struct{}{},
+	}
+}
+
+// Start begins the reconcile loop. Safe to call once.
+func (r *K8sNetworkPolicyReconciler) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		tick := time.NewTicker(r.interval)
+		defer tick.Stop()
+		for {
+			// Reconcile immediately, then on each tick, so a daemon restart
+			// converges without waiting out an interval.
+			if err := r.Reconcile(ctx); err != nil {
+				log.Printf("[k8s-netpolicy] reconcile: %v", err)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+			}
+		}
+	}()
+	log.Printf("[k8s-netpolicy] reconciler started (interval=%s)", r.interval)
+}
+
+// Stop ends the loop and waits for it.
+func (r *K8sNetworkPolicyReconciler) Stop() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.wg.Wait()
+}
+
+// Reconcile makes every tenant's NetworkPolicy match the store once.
+//
+// One tenant's failure never stops the others. A policy the backend refuses
+// — because it contains something NetworkPolicy cannot express — is a
+// standing condition, not a transient one, so it is logged on every pass
+// rather than once: an operator who has not noticed yet should keep being
+// told, and the alternative is a tenant silently running without the policy
+// they configured.
+func (r *K8sNetworkPolicyReconciler) Reconcile(ctx context.Context) error {
+	policies, err := r.store.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	seen := make(map[string]struct{}, len(policies))
+	for _, p := range policies {
+		tenant := p.GetTenant()
+		if tenant == "" {
+			continue
+		}
+		seen[tenant] = struct{}{}
+
+		if err := r.applier.ApplyTenantPolicy(ctx, tenant, p); err != nil {
+			// Deliberately still marked applied: the tenant's namespace may
+			// hold an earlier policy of ours, and forgetting it here would
+			// mean never reverting it when the policy is later deleted.
+			r.markApplied(tenant)
+			log.Printf("[k8s-netpolicy] tenant %q: %v", tenant, err)
+			continue
+		}
+		r.markApplied(tenant)
+	}
+
+	// Tenants we wrote a policy for that no longer have one: revert to the
+	// default-deny floor. Not to allow-all — a delete must never widen.
+	for _, tenant := range r.appliedNotIn(seen) {
+		if err := r.applier.ApplyTenantPolicy(ctx, tenant, nil); err != nil {
+			log.Printf("[k8s-netpolicy] tenant %q: reverting to the default-deny floor failed, so "+
+				"its previous allowlist is still in force: %v", tenant, err)
+			continue
+		}
+		r.forget(tenant)
+		log.Printf("[k8s-netpolicy] tenant %q policy removed; reverted to the default-deny floor", tenant)
+	}
+	return nil
+}
+
+func (r *K8sNetworkPolicyReconciler) markApplied(tenant string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.applied[tenant] = struct{}{}
+}
+
+func (r *K8sNetworkPolicyReconciler) forget(tenant string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.applied, tenant)
+}
+
+// appliedNotIn returns tenants we have written a policy for that are absent
+// from the given set.
+func (r *K8sNetworkPolicyReconciler) appliedNotIn(seen map[string]struct{}) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var gone []string
+	for tenant := range r.applied {
+		if _, ok := seen[tenant]; !ok {
+			gone = append(gone, tenant)
+		}
+	}
+	return gone
+}

--- a/internal/server/k8s_netpolicy_reconciler_test.go
+++ b/internal/server/k8s_netpolicy_reconciler_test.go
@@ -1,0 +1,183 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// #1188 AC1 and AC3: NetworkPolicyService changes reach the K8s backend, and
+// a removed policy reverts to the default-deny floor.
+
+// recordingApplier captures what the reconciler asked the backend to apply.
+type recordingApplier struct {
+	mu    sync.Mutex
+	calls []applyCall
+	err   error
+}
+
+type applyCall struct {
+	tenant string
+	policy *pb.NetworkPolicy
+}
+
+func (a *recordingApplier) ApplyTenantPolicy(_ context.Context, tenant string, p *pb.NetworkPolicy) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.calls = append(a.calls, applyCall{tenant: tenant, policy: p})
+	return a.err
+}
+
+func (a *recordingApplier) since(n int) []applyCall {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if n >= len(a.calls) {
+		return nil
+	}
+	return append([]applyCall(nil), a.calls[n:]...)
+}
+
+// listStore is a NetworkPolicyStore whose List is all the reconciler uses.
+type listStore struct {
+	policies []*pb.NetworkPolicy
+	err      error
+}
+
+func (s *listStore) List(context.Context) ([]*pb.NetworkPolicy, error) {
+	return s.policies, s.err
+}
+func (s *listStore) Set(context.Context, *pb.NetworkPolicy) error { return nil }
+func (s *listStore) Get(context.Context, string) (*pb.NetworkPolicy, error) {
+	return nil, errors.New("not used")
+}
+func (s *listStore) Delete(context.Context, string) error { return nil }
+func (s *listStore) MutateDenyRules(context.Context, string,
+	func([]*pb.NetworkPolicyDenyRule) ([]*pb.NetworkPolicyDenyRule, error)) (*pb.NetworkPolicy, error) {
+	return nil, errors.New("not used")
+}
+
+func TestK8sNetPolicyReconcile_AppliesEachTenantsPolicy(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{
+		{Tenant: "alice", EgressCidrs: []string{"10.0.0.0/8"}},
+		{Tenant: "bob", EgressCidrs: []string{"192.168.0.0/16"}},
+	}}
+	applier := &recordingApplier{}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if len(applier.calls) != 2 {
+		t.Fatalf("applied %d policies, want 2", len(applier.calls))
+	}
+}
+
+// THE property that needs the applied-set. A deleted policy simply stops
+// appearing in the store — nothing announces it. Without remembering that we
+// wrote one, the tenant's last allowlist would persist forever: a permission
+// that was revoked and kept working.
+func TestK8sNetPolicyReconcile_RemovedPolicyRevertsToTheFloor(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{
+		{Tenant: "alice", EgressCidrs: []string{"10.0.0.0/8"}},
+	}}
+	applier := &recordingApplier{}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+
+	ctx := context.Background()
+	if err := r.Reconcile(ctx); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	before := len(applier.calls)
+
+	// The policy is deleted.
+	store.policies = nil
+	if err := r.Reconcile(ctx); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	reverts := applier.since(before)
+	if len(reverts) != 1 {
+		t.Fatalf("after deletion the reconciler made %d calls, want 1 revert: %+v", len(reverts), reverts)
+	}
+	if reverts[0].tenant != "alice" {
+		t.Errorf("reverted tenant %q, want alice", reverts[0].tenant)
+	}
+	// A nil policy is how the backend is told to fall back to the floor.
+	if reverts[0].policy != nil {
+		t.Errorf("revert passed a policy (%+v); nil is what reverts to the default-deny floor",
+			reverts[0].policy)
+	}
+}
+
+// And once reverted, it must not be reverted again on every subsequent pass —
+// that would rewrite the object forever.
+func TestK8sNetPolicyReconcile_RevertHappensOnce(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{{Tenant: "alice"}}}
+	applier := &recordingApplier{}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+	ctx := context.Background()
+
+	_ = r.Reconcile(ctx)
+	store.policies = nil
+	_ = r.Reconcile(ctx)
+	after := len(applier.calls)
+	_ = r.Reconcile(ctx)
+
+	if len(applier.calls) != after {
+		t.Errorf("a tenant with no policy was reverted again (%d extra calls); the object would be "+
+			"rewritten on every pass", len(applier.calls)-after)
+	}
+}
+
+// A refused policy must not stop the other tenants converging, and must not
+// be forgotten — the tenant may still be carrying an earlier policy of ours
+// that has to be reverted when theirs is deleted.
+func TestK8sNetPolicyReconcile_OneFailureDoesNotBlockOthers(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{
+		{Tenant: "alice"}, {Tenant: "bob"}, {Tenant: "carol"},
+	}}
+	applier := &recordingApplier{err: errors.New("cannot express deny_rules")}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("a per-tenant failure aborted the whole reconcile: %v", err)
+	}
+	if len(applier.calls) != 3 {
+		t.Errorf("attempted %d tenants, want all 3 despite failures", len(applier.calls))
+	}
+
+	// The failing tenant is still tracked, so a later deletion still reverts.
+	applier.err = nil
+	store.policies = nil
+	before := len(applier.calls)
+	_ = r.Reconcile(context.Background())
+	if got := len(applier.since(before)); got != 3 {
+		t.Errorf("reverted %d tenants, want 3 — a tenant whose apply failed was forgotten, so its "+
+			"namespace would keep whatever policy it had", got)
+	}
+}
+
+// A tenant with an empty name cannot be mapped to a namespace; skipping it is
+// right, applying it to "" would be a namespace nobody owns.
+func TestK8sNetPolicyReconcile_SkipsAnEmptyTenant(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{{Tenant: ""}}}
+	applier := &recordingApplier{}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+
+	_ = r.Reconcile(context.Background())
+	if len(applier.calls) != 0 {
+		t.Errorf("applied a policy with no tenant: %+v", applier.calls)
+	}
+}
+
+func TestK8sNetPolicyReconcile_StoreFailureIsReported(t *testing.T) {
+	store := &listStore{err: errors.New("postgres down")}
+	r := NewK8sNetworkPolicyReconciler(store, &recordingApplier{}, 0)
+
+	if err := r.Reconcile(context.Background()); err == nil {
+		t.Error("a store failure was swallowed; the reconciler would look healthy while diverged")
+	}
+}


### PR DESCRIPTION
#1188 AC1 and AC3. Completes the K8s side apart from the kind test.

### Mirrors the enforcer's model, verified rather than assumed

The store is the source of truth and is re-read on every pass, so a missed change costs one interval instead of leaving the world diverged.

I checked that this *is* the eBPF enforcer's actual model before copying it: its bus subscription is `Subscribe(nil)` for **container**-change events ("converge sooner"), and policy edits are picked up by the same 10s poll. Nothing publishes a policy-changed event, so a reconciler that waited for one would never fire.

A separate type rather than a mode of `NetworkPolicyEnforcer`, because that enforcer is type-coupled to incus — its inspector returns `[]incus.ContainerInfo` and it attaches TCX to host veths, neither of which a pod has. The store interface is the only shared seam, which is exactly where this splits.

### The applied-set is the load-bearing part

A deleted policy simply **stops appearing** in the store — nothing announces it. Without remembering which tenants we wrote a policy for, a deletion would leave the last allowlist in place forever: *a permission that was revoked and kept working*. That's worse than never having supported the backend, because it looks fine.

Two smaller decisions share that shape:

- **A tenant whose apply failed stays tracked.** Its namespace may hold an earlier policy of ours, and forgetting it would mean never reverting that when the tenant's policy is later deleted.
- **One tenant's failure never aborts the pass.** A policy the backend refuses is a *standing* condition, so one tenant with an inexpressible rule would otherwise stop every other tenant converging — indefinitely.

A refused policy is logged every pass rather than once. An operator who hasn't noticed should keep being told; the alternative is a tenant silently running without the policy they configured.

### Mutation-tested

| mutation | fails |
| --- | --- |
| drop the applied-set | `RemovedPolicyRevertsToTheFloor` |
| forget a tenant whose apply failed | `OneFailureDoesNotBlockOthers` |
| abort the pass on first failure | `OneFailureDoesNotBlockOthers` |

### Remaining on #1188

- Wiring into `NewDualServer` — there's a precedent at `dual_server.go:2049` for constructing K8s-specific components behind `boxes().Kind() == box.KindK8s`.
- The kind integration test asserting a denied destination is genuinely unreachable (AC 5), now possible because the lane enforces policy since #1235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)