### PR TITLE
feat(k8s): wire the tenant-policy reconciler into the daemon

### DIFF
--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -204,8 +204,14 @@ type DualServer struct {
 	ttlSweeperManager     *ttlsweeper.Manager    // ephemeral CI box auto-delete (#299)
 	secretsReconciler     *secretsReconciler     // Phase 4.3 Phase B-3
 	networkPolicyEnforcer *NetworkPolicyEnforcer // #315 Phase A — eBPF per-tenant net policy (off unless configured)
-	cloudClient           *cloud.Client          // #354 — cloud-actuation client (nil unless host is enrolled)
-	startTime             time.Time
+
+	// k8sNetPolicyReconciler converges tenant NetworkPolicy objects on the K8s
+	// backend from the same store the eBPF enforcer reads (#1188). Nil on
+	// every other runtime — the two are mutually exclusive by backend, not by
+	// flag.
+	k8sNetPolicyReconciler *K8sNetworkPolicyReconciler
+	cloudClient            *cloud.Client // #354 — cloud-actuation client (nil unless host is enrolled)
+	startTime              time.Time
 }
 
 // bridgeDNSRaw builds the incusbr0 `raw.dnsmasq` value for container DNS.
@@ -1624,42 +1630,54 @@ skipAppHosting:
 		}
 	}
 
+	// Tenant egress policy on the K8s backend (#1188). Constructed here, where
+	// the policy store exists; started in Start() alongside the other loops.
+	// The eBPF enforcer cannot serve this runtime — it attaches TCX to host
+	// veths that a pod does not have — so the store is the only shared piece.
+	var k8sNetPolicyReconciler *K8sNetworkPolicyReconciler
+	if containerServer != nil && containerServer.boxes().Kind() == box.KindK8s {
+		if applier, ok := containerServer.boxes().(tenantPolicyApplier); ok {
+			k8sNetPolicyReconciler = NewK8sNetworkPolicyReconciler(npServer.Store(), applier, 0)
+		}
+	}
+
 	ds := &DualServer{
-		config:                config,
-		grpcServer:            grpcServer,
-		containerServer:       containerServer,
-		appServer:             appServer,
-		networkServer:         networkServer,
-		trafficServer:         trafficServer,
-		trafficCollector:      trafficCollector,
-		gatewayServer:         gatewayServer,
-		tokenManager:          tokenManager,
-		authMiddleware:        authMiddleware,
-		routeStore:            routeStore,
-		routeSyncJob:          routeSyncJob,
-		passthroughStore:      passthroughStore,
-		passthroughSyncJob:    passthroughSyncJob,
-		collaboratorStore:     collabStore,
-		daemonConfigStore:     config.DaemonConfigStore,
-		metricsCollector:      metricsCollector,
-		securityScanner:       securityScanner,
-		securityStore:         securityStore,
-		securityServer:        securityServerInstance,
-		auditStore:            auditStore,
-		auditEventSubscriber:  auditEventSubscriber,
-		sshCollector:          sshCollector,
-		revocationStore:       revocationStoreLocal,
-		alertStore:            alertStore,
-		alertManager:          alertManager,
-		alertDeliveryStore:    containerServer.alertDeliveryStore,
-		pentestManager:        pentestManager,
-		pentestStore:          pentestStore,
-		zapManager:            zapManager,
-		zapStore:              zapStore,
-		peerPool:              NewPeerPool(config.LocalBackendID, config.SentinelURL, config.Peers, config.Pool),
-		networkPolicyEnforcer: networkPolicyEnforcer,
-		cloudClient:           cloudClient,
-		startTime:             time.Now(),
+		config:                 config,
+		grpcServer:             grpcServer,
+		containerServer:        containerServer,
+		appServer:              appServer,
+		networkServer:          networkServer,
+		trafficServer:          trafficServer,
+		trafficCollector:       trafficCollector,
+		gatewayServer:          gatewayServer,
+		tokenManager:           tokenManager,
+		authMiddleware:         authMiddleware,
+		routeStore:             routeStore,
+		routeSyncJob:           routeSyncJob,
+		passthroughStore:       passthroughStore,
+		passthroughSyncJob:     passthroughSyncJob,
+		collaboratorStore:      collabStore,
+		daemonConfigStore:      config.DaemonConfigStore,
+		metricsCollector:       metricsCollector,
+		securityScanner:        securityScanner,
+		securityStore:          securityStore,
+		securityServer:         securityServerInstance,
+		auditStore:             auditStore,
+		auditEventSubscriber:   auditEventSubscriber,
+		sshCollector:           sshCollector,
+		revocationStore:        revocationStoreLocal,
+		alertStore:             alertStore,
+		alertManager:           alertManager,
+		alertDeliveryStore:     containerServer.alertDeliveryStore,
+		pentestManager:         pentestManager,
+		pentestStore:           pentestStore,
+		zapManager:             zapManager,
+		zapStore:               zapStore,
+		peerPool:               NewPeerPool(config.LocalBackendID, config.SentinelURL, config.Peers, config.Pool),
+		networkPolicyEnforcer:  networkPolicyEnforcer,
+		k8sNetPolicyReconciler: k8sNetPolicyReconciler,
+		cloudClient:            cloudClient,
+		startTime:              time.Now(),
 	}
 
 	// Auto-sleep ticker is constructed in Start() once the traffic
@@ -2129,6 +2147,12 @@ func (ds *DualServer) Start(ctx context.Context) error {
 	}
 
 	// Start security scanner if available
+	// Tenant egress policy on the K8s backend (#1188). Nil on every other
+	// runtime; the eBPF enforcer serves those.
+	if ds.k8sNetPolicyReconciler != nil {
+		ds.k8sNetPolicyReconciler.Start(ctx)
+	}
+
 	if ds.securityScanner != nil {
 		ds.securityScanner.Start(ctx)
 		log.Printf("Security scanner started")

--- a/internal/server/dual_server_wiring_test.go
+++ b/internal/server/dual_server_wiring_test.go
@@ -4,6 +4,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -60,12 +62,31 @@ func dualServerFuncCalls(t *testing.T, funcName string) []string {
 		if !ok {
 			return true
 		}
-		if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
-			calls = append(calls, sel.Sel.Name)
+		switch fn := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			// x.Foo()
+			calls = append(calls, fn.Sel.Name)
+		case *ast.Ident:
+			// Foo() — plain function calls, which constructors are. Without
+			// this the guards could only see method calls, so a dropped
+			// NewXxx(...) was invisible to them.
+			calls = append(calls, fn.Name)
 		}
 		return true
 	})
 	return calls
+}
+
+// dualServerSourceContains reports whether dual_server.go contains the given
+// text. Used where the call shape matters (a method on a field) rather than
+// just the callee name.
+func dualServerSourceContains(t *testing.T, want string) bool {
+	t.Helper()
+	b, err := os.ReadFile("dual_server.go")
+	if err != nil {
+		t.Fatalf("read dual_server.go: %v", err)
+	}
+	return strings.Contains(string(b), want)
 }
 
 func indexOfCall(calls []string, name string) int {
@@ -147,5 +168,33 @@ func TestStartResumesMetricsExportAfterIdentityIsWired(t *testing.T) {
 		t.Errorf("StartMetricsExportIfEnabled runs before SetCapabilityIdentity (positions %d < %d): "+
 			"the resumed collector would snapshot the placeholder identity rather than the daemon's "+
 			"real backend_id/region (#1080)", resume, identity)
+	}
+}
+
+// The K8s tenant-policy reconciler must be constructed in NewDualServer and
+// started in Start (#1188).
+//
+// Split for the same reason the metrics-export wiring is: it needs the policy
+// store, which is a local in NewDualServer, but starting a loop belongs with
+// the other loops in Start. Neither half is visible at runtime if it goes
+// missing — a dropped construction leaves the reconciler nil and every K8s
+// tenant silently running without the egress policy they configured, which is
+// the exact bug #1188 exists to fix.
+func TestNewDualServerWiresK8sNetworkPolicyReconciler(t *testing.T) {
+	newCalls := dualServerFuncCalls(t, "NewDualServer")
+	if indexOfCall(newCalls, "NewK8sNetworkPolicyReconciler") < 0 {
+		t.Error("NewDualServer no longer constructs the K8s network-policy reconciler — every K8s " +
+			"tenant would silently run without the egress policy they configured (#1188)")
+	}
+
+	startCalls := dualServerFuncCalls(t, "Start")
+	if indexOfCall(startCalls, "Start") < 0 {
+		t.Error("Start makes no Start() calls at all — the parse is wrong, not the wiring")
+	}
+	// The reconciler is started via the field, so look for the guarded call
+	// shape rather than a bare constructor name.
+	if !dualServerSourceContains(t, "ds.k8sNetPolicyReconciler.Start(ctx)") {
+		t.Error("Start no longer starts the K8s network-policy reconciler — it would be constructed " +
+			"and never run, which looks identical to a daemon with no tenant policies (#1188)")
 	}
 }

--- a/internal/server/k8s_netpolicy_reconciler.go
+++ b/internal/server/k8s_netpolicy_reconciler.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Converging tenant NetworkPolicy objects on the K8s backend (#1188).
+//
+// The eBPF enforcer drives the LXC path from the same store, re-reading it on
+// a ticker so a dropped event cannot leave the world diverged. This mirrors
+// that: the store is the source of truth on every pass, and the K8s objects
+// are made to match it.
+//
+// It is a separate type rather than a mode of NetworkPolicyEnforcer because
+// the enforcer is type-coupled to incus — its inspector returns
+// []incus.ContainerInfo and it attaches TCX to host veths. Pods have neither.
+// Only the store is shared, which is why the store interface is the seam.
+
+// tenantPolicyApplier applies a tenant's policy to a backend. Satisfied by
+// the K8s box backend; an interface so the reconcile logic is testable
+// without a cluster.
+type tenantPolicyApplier interface {
+	ApplyTenantPolicy(ctx context.Context, tenant string, policy *pb.NetworkPolicy) error
+}
+
+// defaultK8sNetPolicyInterval matches the eBPF enforcer's cadence. The store
+// is re-read each pass, so a missed change costs at most one interval.
+const defaultK8sNetPolicyInterval = 10 * time.Second
+
+// K8sNetworkPolicyReconciler converges each tenant's NetworkPolicy object
+// with the tenant policy held in the store.
+type K8sNetworkPolicyReconciler struct {
+	store    NetworkPolicyStore
+	applier  tenantPolicyApplier
+	interval time.Duration
+
+	// applied is the set of tenants this reconciler has written a policy for.
+	//
+	// Load-bearing: a tenant whose policy is DELETED simply stops appearing
+	// in the store, so without remembering that we wrote one, nothing would
+	// ever revert their namespace to the default-deny floor and the last
+	// applied allowlist would persist indefinitely. A stale allowlist
+	// outliving its policy is a permission that was revoked and kept working.
+	mu      sync.Mutex
+	applied map[string]struct{}
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewK8sNetworkPolicyReconciler builds a reconciler. A zero interval uses the
+// default.
+func NewK8sNetworkPolicyReconciler(store NetworkPolicyStore, applier tenantPolicyApplier, interval time.Duration) *K8sNetworkPolicyReconciler {
+	if interval <= 0 {
+		interval = defaultK8sNetPolicyInterval
+	}
+	return &K8sNetworkPolicyReconciler{
+		store:    store,
+		applier:  applier,
+		interval: interval,
+		applied:  map[string]struct{}{},
+	}
+}
+
+// Start begins the reconcile loop. Safe to call once.
+func (r *K8sNetworkPolicyReconciler) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		tick := time.NewTicker(r.interval)
+		defer tick.Stop()
+		for {
+			// Reconcile immediately, then on each tick, so a daemon restart
+			// converges without waiting out an interval.
+			if err := r.Reconcile(ctx); err != nil {
+				log.Printf("[k8s-netpolicy] reconcile: %v", err)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+			}
+		}
+	}()
+	log.Printf("[k8s-netpolicy] reconciler started (interval=%s)", r.interval)
+}
+
+// Stop ends the loop and waits for it.
+func (r *K8sNetworkPolicyReconciler) Stop() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.wg.Wait()
+}
+
+// Reconcile makes every tenant's NetworkPolicy match the store once.
+//
+// One tenant's failure never stops the others. A policy the backend refuses
+// — because it contains something NetworkPolicy cannot express — is a
+// standing condition, not a transient one, so it is logged on every pass
+// rather than once: an operator who has not noticed yet should keep being
+// told, and the alternative is a tenant silently running without the policy
+// they configured.
+func (r *K8sNetworkPolicyReconciler) Reconcile(ctx context.Context) error {
+	policies, err := r.store.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	seen := make(map[string]struct{}, len(policies))
+	for _, p := range policies {
+		tenant := p.GetTenant()
+		if tenant == "" {
+			continue
+		}
+		seen[tenant] = struct{}{}
+
+		if err := r.applier.ApplyTenantPolicy(ctx, tenant, p); err != nil {
+			// Deliberately still marked applied: the tenant's namespace may
+			// hold an earlier policy of ours, and forgetting it here would
+			// mean never reverting it when the policy is later deleted.
+			r.markApplied(tenant)
+			log.Printf("[k8s-netpolicy] tenant %q: %v", tenant, err)
+			continue
+		}
+		r.markApplied(tenant)
+	}
+
+	// Tenants we wrote a policy for that no longer have one: revert to the
+	// default-deny floor. Not to allow-all — a delete must never widen.
+	for _, tenant := range r.appliedNotIn(seen) {
+		if err := r.applier.ApplyTenantPolicy(ctx, tenant, nil); err != nil {
+			log.Printf("[k8s-netpolicy] tenant %q: reverting to the default-deny floor failed, so "+
+				"its previous allowlist is still in force: %v", tenant, err)
+			continue
+		}
+		r.forget(tenant)
+		log.Printf("[k8s-netpolicy] tenant %q policy removed; reverted to the default-deny floor", tenant)
+	}
+	return nil
+}
+
+func (r *K8sNetworkPolicyReconciler) markApplied(tenant string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.applied[tenant] = struct{}{}
+}
+
+func (r *K8sNetworkPolicyReconciler) forget(tenant string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.applied, tenant)
+}
+
+// appliedNotIn returns tenants we have written a policy for that are absent
+// from the given set.
+func (r *K8sNetworkPolicyReconciler) appliedNotIn(seen map[string]struct{}) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var gone []string
+	for tenant := range r.applied {
+		if _, ok := seen[tenant]; !ok {
+			gone = append(gone, tenant)
+		}
+	}
+	return gone
+}

--- a/internal/server/k8s_netpolicy_reconciler_test.go
+++ b/internal/server/k8s_netpolicy_reconciler_test.go
@@ -1,0 +1,183 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// #1188 AC1 and AC3: NetworkPolicyService changes reach the K8s backend, and
+// a removed policy reverts to the default-deny floor.
+
+// recordingApplier captures what the reconciler asked the backend to apply.
+type recordingApplier struct {
+	mu    sync.Mutex
+	calls []applyCall
+	err   error
+}
+
+type applyCall struct {
+	tenant string
+	policy *pb.NetworkPolicy
+}
+
+func (a *recordingApplier) ApplyTenantPolicy(_ context.Context, tenant string, p *pb.NetworkPolicy) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.calls = append(a.calls, applyCall{tenant: tenant, policy: p})
+	return a.err
+}
+
+func (a *recordingApplier) since(n int) []applyCall {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if n >= len(a.calls) {
+		return nil
+	}
+	return append([]applyCall(nil), a.calls[n:]...)
+}
+
+// listStore is a NetworkPolicyStore whose List is all the reconciler uses.
+type listStore struct {
+	policies []*pb.NetworkPolicy
+	err      error
+}
+
+func (s *listStore) List(context.Context) ([]*pb.NetworkPolicy, error) {
+	return s.policies, s.err
+}
+func (s *listStore) Set(context.Context, *pb.NetworkPolicy) error { return nil }
+func (s *listStore) Get(context.Context, string) (*pb.NetworkPolicy, error) {
+	return nil, errors.New("not used")
+}
+func (s *listStore) Delete(context.Context, string) error { return nil }
+func (s *listStore) MutateDenyRules(context.Context, string,
+	func([]*pb.NetworkPolicyDenyRule) ([]*pb.NetworkPolicyDenyRule, error)) (*pb.NetworkPolicy, error) {
+	return nil, errors.New("not used")
+}
+
+func TestK8sNetPolicyReconcile_AppliesEachTenantsPolicy(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{
+		{Tenant: "alice", EgressCidrs: []string{"10.0.0.0/8"}},
+		{Tenant: "bob", EgressCidrs: []string{"192.168.0.0/16"}},
+	}}
+	applier := &recordingApplier{}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if len(applier.calls) != 2 {
+		t.Fatalf("applied %d policies, want 2", len(applier.calls))
+	}
+}
+
+// THE property that needs the applied-set. A deleted policy simply stops
+// appearing in the store — nothing announces it. Without remembering that we
+// wrote one, the tenant's last allowlist would persist forever: a permission
+// that was revoked and kept working.
+func TestK8sNetPolicyReconcile_RemovedPolicyRevertsToTheFloor(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{
+		{Tenant: "alice", EgressCidrs: []string{"10.0.0.0/8"}},
+	}}
+	applier := &recordingApplier{}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+
+	ctx := context.Background()
+	if err := r.Reconcile(ctx); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	before := len(applier.calls)
+
+	// The policy is deleted.
+	store.policies = nil
+	if err := r.Reconcile(ctx); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	reverts := applier.since(before)
+	if len(reverts) != 1 {
+		t.Fatalf("after deletion the reconciler made %d calls, want 1 revert: %+v", len(reverts), reverts)
+	}
+	if reverts[0].tenant != "alice" {
+		t.Errorf("reverted tenant %q, want alice", reverts[0].tenant)
+	}
+	// A nil policy is how the backend is told to fall back to the floor.
+	if reverts[0].policy != nil {
+		t.Errorf("revert passed a policy (%+v); nil is what reverts to the default-deny floor",
+			reverts[0].policy)
+	}
+}
+
+// And once reverted, it must not be reverted again on every subsequent pass —
+// that would rewrite the object forever.
+func TestK8sNetPolicyReconcile_RevertHappensOnce(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{{Tenant: "alice"}}}
+	applier := &recordingApplier{}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+	ctx := context.Background()
+
+	_ = r.Reconcile(ctx)
+	store.policies = nil
+	_ = r.Reconcile(ctx)
+	after := len(applier.calls)
+	_ = r.Reconcile(ctx)
+
+	if len(applier.calls) != after {
+		t.Errorf("a tenant with no policy was reverted again (%d extra calls); the object would be "+
+			"rewritten on every pass", len(applier.calls)-after)
+	}
+}
+
+// A refused policy must not stop the other tenants converging, and must not
+// be forgotten — the tenant may still be carrying an earlier policy of ours
+// that has to be reverted when theirs is deleted.
+func TestK8sNetPolicyReconcile_OneFailureDoesNotBlockOthers(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{
+		{Tenant: "alice"}, {Tenant: "bob"}, {Tenant: "carol"},
+	}}
+	applier := &recordingApplier{err: errors.New("cannot express deny_rules")}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("a per-tenant failure aborted the whole reconcile: %v", err)
+	}
+	if len(applier.calls) != 3 {
+		t.Errorf("attempted %d tenants, want all 3 despite failures", len(applier.calls))
+	}
+
+	// The failing tenant is still tracked, so a later deletion still reverts.
+	applier.err = nil
+	store.policies = nil
+	before := len(applier.calls)
+	_ = r.Reconcile(context.Background())
+	if got := len(applier.since(before)); got != 3 {
+		t.Errorf("reverted %d tenants, want 3 — a tenant whose apply failed was forgotten, so its "+
+			"namespace would keep whatever policy it had", got)
+	}
+}
+
+// A tenant with an empty name cannot be mapped to a namespace; skipping it is
+// right, applying it to "" would be a namespace nobody owns.
+func TestK8sNetPolicyReconcile_SkipsAnEmptyTenant(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{{Tenant: ""}}}
+	applier := &recordingApplier{}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+
+	_ = r.Reconcile(context.Background())
+	if len(applier.calls) != 0 {
+		t.Errorf("applied a policy with no tenant: %+v", applier.calls)
+	}
+}
+
+func TestK8sNetPolicyReconcile_StoreFailureIsReported(t *testing.T) {
+	store := &listStore{err: errors.New("postgres down")}
+	r := NewK8sNetworkPolicyReconciler(store, &recordingApplier{}, 0)
+
+	if err := r.Reconcile(context.Background()); err == nil {
+		t.Error("a store failure was swallowed; the reconciler would look healthy while diverged")
+	}
+}


### PR DESCRIPTION
#1188 — the reconciler from #1263 now actually runs.

### The wiring

Constructed in `NewDualServer`, where the policy store is in scope; started in `Start` alongside the other loops. Same split as the metrics-export wiring, for the same reason.

Only on the K8s backend: `boxes().Kind() == box.KindK8s` plus a type assertion for the applier. Every other runtime gets nil and the eBPF enforcer continues to serve them. The two are mutually exclusive **by backend rather than by flag**, so there's no configuration that runs both or neither.

### Preconditions verified before writing, not after

Given I compiled the wrong model earlier in this issue, I checked each assumption first:

- The k8s package is **not** build-tagged (only its e2e tests are), and `internal/server/boxbackend_factory.go` already imports it — so the type assertion is legal.
- `containerServer` (line 248) and `npServer` (387) are both in scope well before the `DualServer` literal (1627).
- `boxes()` falls back to LXC when `boxBackend` is nil, so the `Kind` check is safe on a daemon with no box backend.

### Guarded, because this failure is invisible

A dropped wiring call here doesn't fail at startup — a nil reconciler looks exactly like a daemon with no tenant policies. Both halves are covered by an AST guard and mutation-tested:

```
NewDualServer no longer constructs the K8s network-policy reconciler — every
K8s tenant would silently run without the egress policy they configured

Start no longer starts the K8s network-policy reconciler — it would be
constructed and never run, which looks identical to a daemon with no tenant
policies
```

### The guard needed fixing to be capable of catching this

Worth flagging on its own: `dualServerFuncCalls` only recorded **method** calls (`SelectorExpr`). A dropped *constructor* — a plain identifier call, which every `NewXxx` is — was invisible to it. So the existing wiring guards could never have caught a missing `NewFoo(...)`, only a missing `x.Foo()`.

It now records both. The existing guards are unaffected: they assert on method names, and the one that asserts an **absence** (`StartMetricsExportIfEnabled` must not be in `NewDualServer`) is also a method call, so widening the extractor can't make it pass spuriously.

### Remaining on #1188

Only AC 5: the kind test asserting a denied destination is genuinely unreachable — possible because the lane enforces policy since #1235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)