### PR TITLE
test(k8s-e2e): prove a tenant egress allowlist is actually enforced

### DIFF
--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -204,8 +204,14 @@ type DualServer struct {
 	ttlSweeperManager     *ttlsweeper.Manager    // ephemeral CI box auto-delete (#299)
 	secretsReconciler     *secretsReconciler     // Phase 4.3 Phase B-3
 	networkPolicyEnforcer *NetworkPolicyEnforcer // #315 Phase A — eBPF per-tenant net policy (off unless configured)
-	cloudClient           *cloud.Client          // #354 — cloud-actuation client (nil unless host is enrolled)
-	startTime             time.Time
+
+	// k8sNetPolicyReconciler converges tenant NetworkPolicy objects on the K8s
+	// backend from the same store the eBPF enforcer reads (#1188). Nil on
+	// every other runtime — the two are mutually exclusive by backend, not by
+	// flag.
+	k8sNetPolicyReconciler *K8sNetworkPolicyReconciler
+	cloudClient            *cloud.Client // #354 — cloud-actuation client (nil unless host is enrolled)
+	startTime              time.Time
 }
 
 // bridgeDNSRaw builds the incusbr0 `raw.dnsmasq` value for container DNS.
@@ -1624,42 +1630,54 @@ skipAppHosting:
 		}
 	}
 
+	// Tenant egress policy on the K8s backend (#1188). Constructed here, where
+	// the policy store exists; started in Start() alongside the other loops.
+	// The eBPF enforcer cannot serve this runtime — it attaches TCX to host
+	// veths that a pod does not have — so the store is the only shared piece.
+	var k8sNetPolicyReconciler *K8sNetworkPolicyReconciler
+	if containerServer != nil && containerServer.boxes().Kind() == box.KindK8s {
+		if applier, ok := containerServer.boxes().(tenantPolicyApplier); ok {
+			k8sNetPolicyReconciler = NewK8sNetworkPolicyReconciler(npServer.Store(), applier, 0)
+		}
+	}
+
 	ds := &DualServer{
-		config:                config,
-		grpcServer:            grpcServer,
-		containerServer:       containerServer,
-		appServer:             appServer,
-		networkServer:         networkServer,
-		trafficServer:         trafficServer,
-		trafficCollector:      trafficCollector,
-		gatewayServer:         gatewayServer,
-		tokenManager:          tokenManager,
-		authMiddleware:        authMiddleware,
-		routeStore:            routeStore,
-		routeSyncJob:          routeSyncJob,
-		passthroughStore:      passthroughStore,
-		passthroughSyncJob:    passthroughSyncJob,
-		collaboratorStore:     collabStore,
-		daemonConfigStore:     config.DaemonConfigStore,
-		metricsCollector:      metricsCollector,
-		securityScanner:       securityScanner,
-		securityStore:         securityStore,
-		securityServer:        securityServerInstance,
-		auditStore:            auditStore,
-		auditEventSubscriber:  auditEventSubscriber,
-		sshCollector:          sshCollector,
-		revocationStore:       revocationStoreLocal,
-		alertStore:            alertStore,
-		alertManager:          alertManager,
-		alertDeliveryStore:    containerServer.alertDeliveryStore,
-		pentestManager:        pentestManager,
-		pentestStore:          pentestStore,
-		zapManager:            zapManager,
-		zapStore:              zapStore,
-		peerPool:              NewPeerPool(config.LocalBackendID, config.SentinelURL, config.Peers, config.Pool),
-		networkPolicyEnforcer: networkPolicyEnforcer,
-		cloudClient:           cloudClient,
-		startTime:             time.Now(),
+		config:                 config,
+		grpcServer:             grpcServer,
+		containerServer:        containerServer,
+		appServer:              appServer,
+		networkServer:          networkServer,
+		trafficServer:          trafficServer,
+		trafficCollector:       trafficCollector,
+		gatewayServer:          gatewayServer,
+		tokenManager:           tokenManager,
+		authMiddleware:         authMiddleware,
+		routeStore:             routeStore,
+		routeSyncJob:           routeSyncJob,
+		passthroughStore:       passthroughStore,
+		passthroughSyncJob:     passthroughSyncJob,
+		collaboratorStore:      collabStore,
+		daemonConfigStore:      config.DaemonConfigStore,
+		metricsCollector:       metricsCollector,
+		securityScanner:        securityScanner,
+		securityStore:          securityStore,
+		securityServer:         securityServerInstance,
+		auditStore:             auditStore,
+		auditEventSubscriber:   auditEventSubscriber,
+		sshCollector:           sshCollector,
+		revocationStore:        revocationStoreLocal,
+		alertStore:             alertStore,
+		alertManager:           alertManager,
+		alertDeliveryStore:     containerServer.alertDeliveryStore,
+		pentestManager:         pentestManager,
+		pentestStore:           pentestStore,
+		zapManager:             zapManager,
+		zapStore:               zapStore,
+		peerPool:               NewPeerPool(config.LocalBackendID, config.SentinelURL, config.Peers, config.Pool),
+		networkPolicyEnforcer:  networkPolicyEnforcer,
+		k8sNetPolicyReconciler: k8sNetPolicyReconciler,
+		cloudClient:            cloudClient,
+		startTime:              time.Now(),
 	}
 
 	// Auto-sleep ticker is constructed in Start() once the traffic
@@ -2129,6 +2147,12 @@ func (ds *DualServer) Start(ctx context.Context) error {
 	}
 
 	// Start security scanner if available
+	// Tenant egress policy on the K8s backend (#1188). Nil on every other
+	// runtime; the eBPF enforcer serves those.
+	if ds.k8sNetPolicyReconciler != nil {
+		ds.k8sNetPolicyReconciler.Start(ctx)
+	}
+
 	if ds.securityScanner != nil {
 		ds.securityScanner.Start(ctx)
 		log.Printf("Security scanner started")

--- a/internal/server/dual_server_wiring_test.go
+++ b/internal/server/dual_server_wiring_test.go
@@ -4,6 +4,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -60,12 +62,31 @@ func dualServerFuncCalls(t *testing.T, funcName string) []string {
 		if !ok {
 			return true
 		}
-		if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
-			calls = append(calls, sel.Sel.Name)
+		switch fn := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			// x.Foo()
+			calls = append(calls, fn.Sel.Name)
+		case *ast.Ident:
+			// Foo() — plain function calls, which constructors are. Without
+			// this the guards could only see method calls, so a dropped
+			// NewXxx(...) was invisible to them.
+			calls = append(calls, fn.Name)
 		}
 		return true
 	})
 	return calls
+}
+
+// dualServerSourceContains reports whether dual_server.go contains the given
+// text. Used where the call shape matters (a method on a field) rather than
+// just the callee name.
+func dualServerSourceContains(t *testing.T, want string) bool {
+	t.Helper()
+	b, err := os.ReadFile("dual_server.go")
+	if err != nil {
+		t.Fatalf("read dual_server.go: %v", err)
+	}
+	return strings.Contains(string(b), want)
 }
 
 func indexOfCall(calls []string, name string) int {
@@ -147,5 +168,33 @@ func TestStartResumesMetricsExportAfterIdentityIsWired(t *testing.T) {
 		t.Errorf("StartMetricsExportIfEnabled runs before SetCapabilityIdentity (positions %d < %d): "+
 			"the resumed collector would snapshot the placeholder identity rather than the daemon's "+
 			"real backend_id/region (#1080)", resume, identity)
+	}
+}
+
+// The K8s tenant-policy reconciler must be constructed in NewDualServer and
+// started in Start (#1188).
+//
+// Split for the same reason the metrics-export wiring is: it needs the policy
+// store, which is a local in NewDualServer, but starting a loop belongs with
+// the other loops in Start. Neither half is visible at runtime if it goes
+// missing — a dropped construction leaves the reconciler nil and every K8s
+// tenant silently running without the egress policy they configured, which is
+// the exact bug #1188 exists to fix.
+func TestNewDualServerWiresK8sNetworkPolicyReconciler(t *testing.T) {
+	newCalls := dualServerFuncCalls(t, "NewDualServer")
+	if indexOfCall(newCalls, "NewK8sNetworkPolicyReconciler") < 0 {
+		t.Error("NewDualServer no longer constructs the K8s network-policy reconciler — every K8s " +
+			"tenant would silently run without the egress policy they configured (#1188)")
+	}
+
+	startCalls := dualServerFuncCalls(t, "Start")
+	if indexOfCall(startCalls, "Start") < 0 {
+		t.Error("Start makes no Start() calls at all — the parse is wrong, not the wiring")
+	}
+	// The reconciler is started via the field, so look for the guarded call
+	// shape rather than a bare constructor name.
+	if !dualServerSourceContains(t, "ds.k8sNetPolicyReconciler.Start(ctx)") {
+		t.Error("Start no longer starts the K8s network-policy reconciler — it would be constructed " +
+			"and never run, which looks identical to a daemon with no tenant policies (#1188)")
 	}
 }

--- a/internal/server/k8s_netpolicy_reconciler.go
+++ b/internal/server/k8s_netpolicy_reconciler.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Converging tenant NetworkPolicy objects on the K8s backend (#1188).
+//
+// The eBPF enforcer drives the LXC path from the same store, re-reading it on
+// a ticker so a dropped event cannot leave the world diverged. This mirrors
+// that: the store is the source of truth on every pass, and the K8s objects
+// are made to match it.
+//
+// It is a separate type rather than a mode of NetworkPolicyEnforcer because
+// the enforcer is type-coupled to incus — its inspector returns
+// []incus.ContainerInfo and it attaches TCX to host veths. Pods have neither.
+// Only the store is shared, which is why the store interface is the seam.
+
+// tenantPolicyApplier applies a tenant's policy to a backend. Satisfied by
+// the K8s box backend; an interface so the reconcile logic is testable
+// without a cluster.
+type tenantPolicyApplier interface {
+	ApplyTenantPolicy(ctx context.Context, tenant string, policy *pb.NetworkPolicy) error
+}
+
+// defaultK8sNetPolicyInterval matches the eBPF enforcer's cadence. The store
+// is re-read each pass, so a missed change costs at most one interval.
+const defaultK8sNetPolicyInterval = 10 * time.Second
+
+// K8sNetworkPolicyReconciler converges each tenant's NetworkPolicy object
+// with the tenant policy held in the store.
+type K8sNetworkPolicyReconciler struct {
+	store    NetworkPolicyStore
+	applier  tenantPolicyApplier
+	interval time.Duration
+
+	// applied is the set of tenants this reconciler has written a policy for.
+	//
+	// Load-bearing: a tenant whose policy is DELETED simply stops appearing
+	// in the store, so without remembering that we wrote one, nothing would
+	// ever revert their namespace to the default-deny floor and the last
+	// applied allowlist would persist indefinitely. A stale allowlist
+	// outliving its policy is a permission that was revoked and kept working.
+	mu      sync.Mutex
+	applied map[string]struct{}
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewK8sNetworkPolicyReconciler builds a reconciler. A zero interval uses the
+// default.
+func NewK8sNetworkPolicyReconciler(store NetworkPolicyStore, applier tenantPolicyApplier, interval time.Duration) *K8sNetworkPolicyReconciler {
+	if interval <= 0 {
+		interval = defaultK8sNetPolicyInterval
+	}
+	return &K8sNetworkPolicyReconciler{
+		store:    store,
+		applier:  applier,
+		interval: interval,
+		applied:  map[string]struct{}{},
+	}
+}
+
+// Start begins the reconcile loop. Safe to call once.
+func (r *K8sNetworkPolicyReconciler) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	r.cancel = cancel
+
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		tick := time.NewTicker(r.interval)
+		defer tick.Stop()
+		for {
+			// Reconcile immediately, then on each tick, so a daemon restart
+			// converges without waiting out an interval.
+			if err := r.Reconcile(ctx); err != nil {
+				log.Printf("[k8s-netpolicy] reconcile: %v", err)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+			}
+		}
+	}()
+	log.Printf("[k8s-netpolicy] reconciler started (interval=%s)", r.interval)
+}
+
+// Stop ends the loop and waits for it.
+func (r *K8sNetworkPolicyReconciler) Stop() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	r.wg.Wait()
+}
+
+// Reconcile makes every tenant's NetworkPolicy match the store once.
+//
+// One tenant's failure never stops the others. A policy the backend refuses
+// — because it contains something NetworkPolicy cannot express — is a
+// standing condition, not a transient one, so it is logged on every pass
+// rather than once: an operator who has not noticed yet should keep being
+// told, and the alternative is a tenant silently running without the policy
+// they configured.
+func (r *K8sNetworkPolicyReconciler) Reconcile(ctx context.Context) error {
+	policies, err := r.store.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	seen := make(map[string]struct{}, len(policies))
+	for _, p := range policies {
+		tenant := p.GetTenant()
+		if tenant == "" {
+			continue
+		}
+		seen[tenant] = struct{}{}
+
+		if err := r.applier.ApplyTenantPolicy(ctx, tenant, p); err != nil {
+			// Deliberately still marked applied: the tenant's namespace may
+			// hold an earlier policy of ours, and forgetting it here would
+			// mean never reverting it when the policy is later deleted.
+			r.markApplied(tenant)
+			log.Printf("[k8s-netpolicy] tenant %q: %v", tenant, err)
+			continue
+		}
+		r.markApplied(tenant)
+	}
+
+	// Tenants we wrote a policy for that no longer have one: revert to the
+	// default-deny floor. Not to allow-all — a delete must never widen.
+	for _, tenant := range r.appliedNotIn(seen) {
+		if err := r.applier.ApplyTenantPolicy(ctx, tenant, nil); err != nil {
+			log.Printf("[k8s-netpolicy] tenant %q: reverting to the default-deny floor failed, so "+
+				"its previous allowlist is still in force: %v", tenant, err)
+			continue
+		}
+		r.forget(tenant)
+		log.Printf("[k8s-netpolicy] tenant %q policy removed; reverted to the default-deny floor", tenant)
+	}
+	return nil
+}
+
+func (r *K8sNetworkPolicyReconciler) markApplied(tenant string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.applied[tenant] = struct{}{}
+}
+
+func (r *K8sNetworkPolicyReconciler) forget(tenant string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.applied, tenant)
+}
+
+// appliedNotIn returns tenants we have written a policy for that are absent
+// from the given set.
+func (r *K8sNetworkPolicyReconciler) appliedNotIn(seen map[string]struct{}) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var gone []string
+	for tenant := range r.applied {
+		if _, ok := seen[tenant]; !ok {
+			gone = append(gone, tenant)
+		}
+	}
+	return gone
+}

--- a/internal/server/k8s_netpolicy_reconciler_test.go
+++ b/internal/server/k8s_netpolicy_reconciler_test.go
@@ -1,0 +1,183 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// #1188 AC1 and AC3: NetworkPolicyService changes reach the K8s backend, and
+// a removed policy reverts to the default-deny floor.
+
+// recordingApplier captures what the reconciler asked the backend to apply.
+type recordingApplier struct {
+	mu    sync.Mutex
+	calls []applyCall
+	err   error
+}
+
+type applyCall struct {
+	tenant string
+	policy *pb.NetworkPolicy
+}
+
+func (a *recordingApplier) ApplyTenantPolicy(_ context.Context, tenant string, p *pb.NetworkPolicy) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.calls = append(a.calls, applyCall{tenant: tenant, policy: p})
+	return a.err
+}
+
+func (a *recordingApplier) since(n int) []applyCall {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if n >= len(a.calls) {
+		return nil
+	}
+	return append([]applyCall(nil), a.calls[n:]...)
+}
+
+// listStore is a NetworkPolicyStore whose List is all the reconciler uses.
+type listStore struct {
+	policies []*pb.NetworkPolicy
+	err      error
+}
+
+func (s *listStore) List(context.Context) ([]*pb.NetworkPolicy, error) {
+	return s.policies, s.err
+}
+func (s *listStore) Set(context.Context, *pb.NetworkPolicy) error { return nil }
+func (s *listStore) Get(context.Context, string) (*pb.NetworkPolicy, error) {
+	return nil, errors.New("not used")
+}
+func (s *listStore) Delete(context.Context, string) error { return nil }
+func (s *listStore) MutateDenyRules(context.Context, string,
+	func([]*pb.NetworkPolicyDenyRule) ([]*pb.NetworkPolicyDenyRule, error)) (*pb.NetworkPolicy, error) {
+	return nil, errors.New("not used")
+}
+
+func TestK8sNetPolicyReconcile_AppliesEachTenantsPolicy(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{
+		{Tenant: "alice", EgressCidrs: []string{"10.0.0.0/8"}},
+		{Tenant: "bob", EgressCidrs: []string{"192.168.0.0/16"}},
+	}}
+	applier := &recordingApplier{}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if len(applier.calls) != 2 {
+		t.Fatalf("applied %d policies, want 2", len(applier.calls))
+	}
+}
+
+// THE property that needs the applied-set. A deleted policy simply stops
+// appearing in the store — nothing announces it. Without remembering that we
+// wrote one, the tenant's last allowlist would persist forever: a permission
+// that was revoked and kept working.
+func TestK8sNetPolicyReconcile_RemovedPolicyRevertsToTheFloor(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{
+		{Tenant: "alice", EgressCidrs: []string{"10.0.0.0/8"}},
+	}}
+	applier := &recordingApplier{}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+
+	ctx := context.Background()
+	if err := r.Reconcile(ctx); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	before := len(applier.calls)
+
+	// The policy is deleted.
+	store.policies = nil
+	if err := r.Reconcile(ctx); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	reverts := applier.since(before)
+	if len(reverts) != 1 {
+		t.Fatalf("after deletion the reconciler made %d calls, want 1 revert: %+v", len(reverts), reverts)
+	}
+	if reverts[0].tenant != "alice" {
+		t.Errorf("reverted tenant %q, want alice", reverts[0].tenant)
+	}
+	// A nil policy is how the backend is told to fall back to the floor.
+	if reverts[0].policy != nil {
+		t.Errorf("revert passed a policy (%+v); nil is what reverts to the default-deny floor",
+			reverts[0].policy)
+	}
+}
+
+// And once reverted, it must not be reverted again on every subsequent pass —
+// that would rewrite the object forever.
+func TestK8sNetPolicyReconcile_RevertHappensOnce(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{{Tenant: "alice"}}}
+	applier := &recordingApplier{}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+	ctx := context.Background()
+
+	_ = r.Reconcile(ctx)
+	store.policies = nil
+	_ = r.Reconcile(ctx)
+	after := len(applier.calls)
+	_ = r.Reconcile(ctx)
+
+	if len(applier.calls) != after {
+		t.Errorf("a tenant with no policy was reverted again (%d extra calls); the object would be "+
+			"rewritten on every pass", len(applier.calls)-after)
+	}
+}
+
+// A refused policy must not stop the other tenants converging, and must not
+// be forgotten — the tenant may still be carrying an earlier policy of ours
+// that has to be reverted when theirs is deleted.
+func TestK8sNetPolicyReconcile_OneFailureDoesNotBlockOthers(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{
+		{Tenant: "alice"}, {Tenant: "bob"}, {Tenant: "carol"},
+	}}
+	applier := &recordingApplier{err: errors.New("cannot express deny_rules")}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("a per-tenant failure aborted the whole reconcile: %v", err)
+	}
+	if len(applier.calls) != 3 {
+		t.Errorf("attempted %d tenants, want all 3 despite failures", len(applier.calls))
+	}
+
+	// The failing tenant is still tracked, so a later deletion still reverts.
+	applier.err = nil
+	store.policies = nil
+	before := len(applier.calls)
+	_ = r.Reconcile(context.Background())
+	if got := len(applier.since(before)); got != 3 {
+		t.Errorf("reverted %d tenants, want 3 — a tenant whose apply failed was forgotten, so its "+
+			"namespace would keep whatever policy it had", got)
+	}
+}
+
+// A tenant with an empty name cannot be mapped to a namespace; skipping it is
+// right, applying it to "" would be a namespace nobody owns.
+func TestK8sNetPolicyReconcile_SkipsAnEmptyTenant(t *testing.T) {
+	store := &listStore{policies: []*pb.NetworkPolicy{{Tenant: ""}}}
+	applier := &recordingApplier{}
+	r := NewK8sNetworkPolicyReconciler(store, applier, 0)
+
+	_ = r.Reconcile(context.Background())
+	if len(applier.calls) != 0 {
+		t.Errorf("applied a policy with no tenant: %+v", applier.calls)
+	}
+}
+
+func TestK8sNetPolicyReconcile_StoreFailureIsReported(t *testing.T) {
+	store := &listStore{err: errors.New("postgres down")}
+	r := NewK8sNetworkPolicyReconciler(store, &recordingApplier{}, 0)
+
+	if err := r.Reconcile(context.Background()); err == nil {
+		t.Error("a store failure was swallowed; the reconciler would look healthy while diverged")
+	}
+}

--- a/pkg/core/box/k8s/e2e_netpol_test.go
+++ b/pkg/core/box/k8s/e2e_netpol_test.go
@@ -213,6 +213,12 @@ func startPolicySelectedListener(ctx context.Context, t *testing.T, b *Backend, 
 		_ = b.clientset.CoreV1().Pods(ns).Delete(context.Background(), name, metav1.DeleteOptions{})
 	})
 
+	return waitForPodIP(ctx, t, b, ns, name)
+}
+
+// waitForPodIP blocks until a pod is Running with an IP, and returns it.
+func waitForPodIP(ctx context.Context, t *testing.T, b *Backend, ns, name string) string {
+	t.Helper()
 	deadline := time.Now().Add(3 * time.Minute)
 	for time.Now().Before(deadline) {
 		got, err := b.clientset.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
@@ -221,7 +227,7 @@ func startPolicySelectedListener(ctx context.Context, t *testing.T, b *Backend, 
 		}
 		time.Sleep(2 * time.Second)
 	}
-	t.Fatal("listener pod never reached Running with an IP")
+	t.Fatalf("pod %s/%s never reached Running with an IP", ns, name)
 	return ""
 }
 

--- a/pkg/core/box/k8s/e2e_tenant_egress_test.go
+++ b/pkg/core/box/k8s/e2e_tenant_egress_test.go
@@ -1,0 +1,150 @@
+//go:build k8s
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// #1188 AC5: a tenant egress allowlist is ENFORCED on the K8s backend — a
+// destination outside it is genuinely unreachable, not merely absent from a
+// YAML object.
+//
+// This is the assertion the whole issue turns on. A tenant who sets an egress
+// allowlist gets it enforced on LXC and, until now, silently ignored here.
+// Checking that the NetworkPolicy object has the right shape would not
+// distinguish "enforced" from "written and ignored" — which is exactly how
+// #1195 shipped unvalidated and became #1234.
+//
+// The test therefore asserts both directions, and the ALLOWED probe runs
+// first. Without it, "the denied destination was unreachable" is equally
+// consistent with the CNI dropping everything, the listener never starting,
+// or the wrong port — and the test would pass while proving nothing.
+func TestE2E_TenantEgressAllowlistIsEnforced(t *testing.T) {
+	if os.Getenv("CONTAINARIUM_K8S_E2E") == "" {
+		t.Skip("set CONTAINARIUM_K8S_E2E=1 (and KUBECONFIG) to run the kind e2e")
+	}
+	if cni := os.Getenv("E2E_CNI"); cni == "kindnet" {
+		t.Skip("E2E_CNI=kindnet does not enforce NetworkPolicy; skipping rather than passing vacuously (#1234)")
+	}
+
+	const gatewayNS = "agent-gateway"
+	kubeconfig := os.Getenv("KUBECONFIG")
+
+	restCfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("rest config: %v", err)
+	}
+	dyn, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		t.Fatalf("dynamic client: %v", err)
+	}
+	// Create() programs an sshpiper Pipe when a gateway namespace is set.
+	installPipeCRD(t, dyn)
+
+	b, err := New(Config{
+		Kubeconfig:       kubeconfig,
+		BoxImage:         "registry.k8s.io/pause:3.9",
+		GatewayHost:      "gateway.example.com",
+		GatewayNamespace: gatewayNS,
+	})
+	if err != nil {
+		t.Fatalf("New (is the cluster reachable?): %v", err)
+	}
+
+	ctx := context.Background()
+	ensureNamespace(ctx, t, b, gatewayNS)
+
+	ref := box.BoxRef{Tenant: "egresspol"}
+	t.Cleanup(func() { _ = b.Delete(context.Background(), ref, true) })
+	if _, err := b.Create(ctx, box.BoxSpec{Ref: ref}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	boxNS := b.cfg.TenantNamespacePrefix + ref.Tenant
+
+	// Two identical listeners in a neutral namespace. The only thing that
+	// will differ between them is whether the tenant's allowlist names them.
+	const targetNS = "egress-targets"
+	ensureNamespace(ctx, t, b, targetNS)
+	allowedIP := startTargetListener(ctx, t, b, targetNS, "allowed-target")
+	deniedIP := startTargetListener(ctx, t, b, targetNS, "denied-target")
+
+	// The tenant's policy permits exactly one of them.
+	policy := &pb.NetworkPolicy{
+		Tenant:      ref.Tenant,
+		Mode:        pb.NetworkPolicyMode_NETWORK_POLICY_MODE_ENFORCE,
+		EgressCidrs: []string{allowedIP + "/32"},
+	}
+	if err := b.ApplyTenantPolicy(ctx, ref.Tenant, policy); err != nil {
+		t.Fatalf("ApplyTenantPolicy: %v", err)
+	}
+
+	// POSITIVE CONTROL, first. It proves the listeners are up, the port is
+	// right, and the CNI is not simply dropping everything — every way the
+	// denial assertion below could pass for a wrong reason.
+	allowed := runProbe(ctx, t, b, probeSpec{
+		ns:     boxNS,
+		name:   "egress-allowed-probe",
+		labels: boxLabels(ref.Tenant), // selected by the tenant's policy
+		script: fmt.Sprintf("nc -z -w 5 %s %d", allowedIP, targetPort),
+	})
+	if allowed != corev1.PodSucceeded {
+		t.Fatalf("positive control FAILED: the tenant could not reach %s:%d, which its own "+
+			"allowlist permits (phase %v). The denial check below would prove nothing, so this "+
+			"fails loudly instead of reporting a pass.", allowedIP, targetPort, allowed)
+	}
+
+	// THE assertion: same port, same image, same namespace — the only
+	// difference is that this destination is outside the allowlist.
+	denied := runProbe(ctx, t, b, probeSpec{
+		ns:     boxNS,
+		name:   "egress-denied-probe",
+		labels: boxLabels(ref.Tenant),
+		script: fmt.Sprintf("nc -z -w 5 %s %d", deniedIP, targetPort),
+	})
+	if denied == corev1.PodSucceeded {
+		t.Errorf("the tenant reached %s:%d, which is OUTSIDE its egress allowlist — the policy is "+
+			"not enforced on this backend (#1188). The positive control passed, so this is a "+
+			"policy failure, not a broken probe.", deniedIP, targetPort)
+	}
+}
+
+// targetPort is the port the egress targets listen on.
+const targetPort = 8080
+
+// startTargetListener runs a pod that accepts TCP connections and returns its
+// pod IP. httpd rather than `nc -l` because it serves continuously — a
+// one-shot listener would race the second probe and fail for a reason
+// unrelated to policy.
+func startTargetListener(ctx context.Context, t *testing.T, b *Backend, ns, name string) string {
+	t.Helper()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "listener",
+				Image:   "busybox:1.36",
+				Command: []string{"sh", "-c", fmt.Sprintf("httpd -f -p %d -h /tmp", targetPort)},
+			}},
+		},
+	}
+	if _, err := b.clientset.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create target %s: %v", name, err)
+	}
+	t.Cleanup(func() {
+		_ = b.clientset.CoreV1().Pods(ns).Delete(context.Background(), name, metav1.DeleteOptions{})
+	})
+
+	return waitForPodIP(ctx, t, b, ns, name)
+}


### PR DESCRIPTION
#1188 AC 5 — the last one. Completes the issue's first cut.

### Why this test and not an object assertion

This is the assertion the whole issue turns on: a destination outside a tenant's allowlist must be **genuinely unreachable**, not merely absent from a YAML object.

Checking the NetworkPolicy's *shape* cannot distinguish "enforced" from "written and ignored" — which is exactly how #1195 shipped unvalidated and became #1234. So this test moves packets.

### The positive control is the design

Two listeners in a neutral namespace, identical in every respect, and a tenant policy naming exactly one of them.

The **allowed** probe runs first. It proves the listeners are up, the port is right, and the CNI isn't simply dropping everything. Without it, *"the denied destination was unreachable"* is equally consistent with a broken listener, the wrong port, or a CNI that drops all egress — and the test would pass while proving nothing. If the control fails, the test fails loudly rather than reporting a pass.

Only then does the denied probe run: same port, same image, same namespace, same labels. **The single variable is whether the destination is in the allowlist.**

### Notes

- Skips (rather than passes) on `E2E_CNI=kindnet`, which doesn't enforce NetworkPolicy — a vacuous pass is the failure mode being guarded against.
- `waitForPodIP` is extracted from `startPolicySelectedListener` rather than copied, so both listeners wait identically.
- `httpd` rather than `nc -l` for the targets: it serves continuously, where a one-shot listener would race the second probe and fail for a reason unrelated to policy.

### #1188 after this

The first cut is complete: compiler (#1262), apply path, reconciler (#1263), daemon wiring (#1264), and this enforcement proof. The issue's two explicitly-deferred items remain out of scope by design — virtual-patch deny rules (#660) and traffic-flow accounting (#627), both of which NetworkPolicy cannot express at all and which the compiler now *refuses* rather than silently dropping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)