### PR TITLE
docs(k8s): record which egress capabilities are LXC-only, and why

### DIFF
--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -203,10 +203,36 @@ as a positive control that runs first — a pod in `agent-gateway` carrying the
 sshpiper label can. Without that control, "connection refused" would prove
 nothing.
 
-This is still **not** the K8s expression of the eBPF egress allowlist: it is a
-static object written once at box-create and never reconciled against
-`NetworkPolicyService`. Tenant egress policy is not driven by that service on
-this backend — see #1188.
+### Tenant egress policy on this backend
+
+`NetworkPolicyService` now drives this backend (#1188): a reconciler reads the
+same policy store the eBPF enforcer reads and converges each tenant
+namespace's NetworkPolicy with it. A tenant's egress allowlist appears as
+egress rules alongside the DNS allowance, and removing a policy reverts to the
+default-deny floor — never to allow-all, because a delete must not widen
+access. `TestE2E_TenantEgressAllowlistIsEnforced` proves the enforcement with
+packets rather than by inspecting the object: a destination inside the
+allowlist is reachable, one outside it is not.
+
+#### What is LXC-only, and why
+
+Some of the eBPF path's capabilities have no Kubernetes NetworkPolicy
+equivalent. These are **not** cross-backend, and the compiler REFUSES a policy
+containing them rather than applying the part it understood — every one of
+them fails in the same direction, more permissive than the tenant configured,
+so quietly dropping any would be worse than not supporting the backend at all.
+
+| Capability | Why NetworkPolicy cannot express it |
+|---|---|
+| `LOG_ONLY` mode | NetworkPolicy always enforces. Compiling a tenant's dry run would start dropping their traffic. `UNSPECIFIED` is treated as `LOG_ONLY`, so this is the default case. |
+| Metadata carve-out (`allow_metadata=false`) | Denies 169.254.169.254 *even when* the allowlist covers it — deny-beats-allow. An allow-only policy cannot carve an exception out of an allow rule, and the exception guards cloud credentials. |
+| `egress_domains` | NetworkPolicy matches IPs, not names. The eBPF path re-resolves on a refresh loop; a resolved snapshot baked into a static object goes stale silently. |
+| Virtual-patch deny rules (#660) | Payload-signature matches in the BPF program. NetworkPolicy is L3/L4 only. |
+| Traffic-flow accounting (#627) | NetworkPolicy has no counters. Needs Hubble/Cilium or equivalent. |
+
+A tenant policy using any of these is rejected for the K8s backend with the
+feature named, so the asymmetry surfaces at configuration time rather than as
+a silent difference in what is enforced.
 
 ## Mapping to the existing (LXC) architecture
 


### PR DESCRIPTION
#1188's last requirement — the one that isn't a checkbox. The issue asks that its deferred items *"be documented as LXC-only capabilities rather than quietly assumed cross-backend."*

### The stale claim

The section saying tenant egress policy *"is not driven by that service on this backend"* is now false — #1263/#1264 wired the reconciler and #1265 proved enforcement with packets. Replaced with what actually ships.

### The part that matters more

A table of the five capabilities the eBPF path has that NetworkPolicy cannot express, each with its reason — because the reasons aren't interchangeable, and one is a security control rather than a feature:

- **`LOG_ONLY`** — NetworkPolicy always enforces, so compiling a tenant's dry run would start dropping their traffic. `UNSPECIFIED` means `LOG_ONLY`, so this is the **default** case, not an edge one.
- **Metadata carve-out** — denies `169.254.169.254` even when the allowlist covers it. An allow-only policy can't carve an exception out of an allow rule, and that exception is what withholds **cloud credentials**.
- **`egress_domains`** — NetworkPolicy matches IPs, not names; a resolved snapshot in a static object goes stale silently.
- **Virtual-patch deny rules (#660)** — payload-signature matches; NetworkPolicy is L3/L4 only.
- **Traffic-flow accounting (#627)** — NetworkPolicy has no counters.

It also records that the compiler **refuses** a policy containing any of them rather than applying the understood part, and why that isn't just conservatism: all five fail in the *same direction* — more permissive than the tenant configured — so a silent partial application is strictly worse than declining the backend. The asymmetry surfaces at configuration time instead of as a quiet difference in what's enforced.

### #1188 after this

All five first-cut criteria are done, the last proven in a Calico-enforcing cluster, and the deferred items are now documented rather than assumed. I've left the issue open for you to close — it's your scoping call whether the first cut closes it or whether #660/#627 stay attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)