### PR TITLE
feat(audit): parse dropbear login lines for K8s box session audit

### DIFF
--- a/internal/audit/dropbear_parser.go
+++ b/internal/audit/dropbear_parser.go
@@ -1,0 +1,120 @@
+package audit
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Parsing dropbear's login lines (#1189).
+//
+// K8s boxes run dropbear, not OpenSSH, and the two log successful
+// authentication in completely different words. The existing sshd parser
+// matches "Accepted publickey for alice from 10.0.0.1 port 54321"; dropbear
+// never emits that string, so an sshd-shaped parser pointed at a K8s box
+// silently yields zero login records — indistinguishable from a box nobody
+// logged into.
+//
+// The formats below are taken from the dropbear binary's own format strings
+// (2022.83), not from documentation or memory:
+//
+//	Password auth succeeded for '%s' from %s
+//	Pubkey auth succeeded for '%s' with %s key %s from %s
+//	Auth succeeded with blank password for '%s' from %s
+//
+// Note the shape differences that matter for a regex: the username is
+// single-quoted, the source is host:port rather than "from IP port N", and
+// the method word comes FIRST rather than after "Accepted".
+
+var (
+	// dropbearPubkeyPattern: Pubkey auth succeeded for 'alice' with ssh-ed25519 key SHA256:... from 10.0.0.1:54321
+	dropbearPubkeyPattern = regexp.MustCompile(
+		`Pubkey auth succeeded for '([^']+)' with \S+ key \S+ from (\S+)`,
+	)
+	// dropbearPasswordPattern: Password auth succeeded for 'alice' from 10.0.0.1:54321
+	dropbearPasswordPattern = regexp.MustCompile(
+		`Password auth succeeded for '([^']+)' from (\S+)`,
+	)
+	// dropbearBlankPattern: Auth succeeded with blank password for 'alice' from 10.0.0.1:54321
+	//
+	// Worth capturing rather than ignoring: a blank-password login is the one
+	// an auditor most wants to see, and dropping it because it does not look
+	// like the other two would hide exactly the wrong event.
+	dropbearBlankPattern = regexp.MustCompile(
+		`Auth succeeded with blank password for '([^']+)' from (\S+)`,
+	)
+)
+
+// dropbearTimestampPattern matches the leading syslog-style timestamp that
+// dropbear emits when logging to stderr, e.g.
+// "[123] Mar 12 14:30:01 Pubkey auth succeeded ...". Absent when the runtime
+// strips it, which is why parsing tolerates its absence.
+var dropbearTimestampPattern = regexp.MustCompile(
+	`(?:\[\d+\]\s+)?(\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s`,
+)
+
+// parseDropbearLine extracts a successful login from one dropbear log line.
+//
+// fallback is used when the line carries no timestamp — the pod log API can
+// supply one per line, and a record with the wrong time is worse than one
+// with an approximate time clearly derived from the reader.
+func parseDropbearLine(line string, year int, fallback time.Time) (ts time.Time, user, source, method string, ok bool) {
+	switch {
+	case dropbearPubkeyPattern.MatchString(line):
+		m := dropbearPubkeyPattern.FindStringSubmatch(line)
+		user, source, method = m[1], m[2], "publickey"
+	case dropbearPasswordPattern.MatchString(line):
+		m := dropbearPasswordPattern.FindStringSubmatch(line)
+		user, source, method = m[1], m[2], "password"
+	case dropbearBlankPattern.MatchString(line):
+		m := dropbearBlankPattern.FindStringSubmatch(line)
+		user, source, method = m[1], m[2], "blank-password"
+	default:
+		return time.Time{}, "", "", "", false
+	}
+
+	// dropbear reports host:port; the audit record wants the host. Trim the
+	// port rather than storing "10.0.0.1:54321" as an address, which would
+	// break every query that groups by source.
+	source = trimSourcePort(source)
+
+	return parseDropbearTimestamp(line, year, fallback), user, source, method, true
+}
+
+// parseDropbearTimestamp reads the line's own timestamp, falling back to the
+// supplied one.
+func parseDropbearTimestamp(line string, year int, fallback time.Time) time.Time {
+	m := dropbearTimestampPattern.FindStringSubmatch(line)
+	if m == nil {
+		return fallback
+	}
+	tsStr := fmt.Sprintf("%d %s", year, m[1])
+	// Two layouts because the day is space-padded for single digits in some
+	// runtimes and not others.
+	for _, layout := range []string{"2006 Jan  2 15:04:05", "2006 Jan 2 15:04:05"} {
+		if ts, err := time.Parse(layout, tsStr); err == nil {
+			return ts
+		}
+	}
+	return fallback
+}
+
+// trimSourcePort turns "10.0.0.1:54321" into "10.0.0.1", leaving a bare
+// address (and IPv6 forms) alone.
+func trimSourcePort(source string) string {
+	// IPv6 with port is bracketed: [::1]:54321
+	if strings.HasPrefix(source, "[") {
+		if end := strings.LastIndex(source, "]"); end > 0 {
+			return source[1:end]
+		}
+		return source
+	}
+	// Exactly one colon means host:port; more means a bare IPv6 address.
+	if strings.Count(source, ":") == 1 {
+		if host, _, found := strings.Cut(source, ":"); found {
+			return host
+		}
+	}
+	return source
+}

--- a/internal/audit/dropbear_parser_test.go
+++ b/internal/audit/dropbear_parser_test.go
@@ -1,0 +1,144 @@
+package audit
+
+import (
+	"testing"
+	"time"
+)
+
+// #1189: in-box SSH session audit is incus-only. K8s boxes run dropbear, and
+// the existing sshd parser cannot match a single line dropbear emits — so a
+// K8s box yields zero login records, which reads identically to a box nobody
+// logged into. For a compliance reader that is the difference between "no
+// access occurred" and "access is not recorded".
+//
+// Every format below is taken from the dropbear 2022.83 binary's own format
+// strings, not from documentation:
+//
+//	Password auth succeeded for '%s' from %s
+//	Pubkey auth succeeded for '%s' with %s key %s from %s
+//	Auth succeeded with blank password for '%s' from %s
+
+const parseYear = 2026
+
+// THE reason this parser exists: the sshd pattern matches nothing dropbear
+// writes. If this ever stops being true, the second parser is dead weight.
+func TestSSHDPatternCannotMatchDropbearOutput(t *testing.T) {
+	for _, line := range []string{
+		`Mar 12 14:30:01 box dropbear[42]: Pubkey auth succeeded for 'alice' with ssh-ed25519 key SHA256:abc from 10.0.0.1:54321`,
+		`Mar 12 14:30:01 box dropbear[42]: Password auth succeeded for 'alice' from 10.0.0.1:54321`,
+	} {
+		if _, _, _, _, ok := parseAuthLogLine(line, parseYear); ok {
+			t.Errorf("the sshd parser matched a dropbear line — if it genuinely handles both, this "+
+				"second parser is unnecessary:\n%s", line)
+		}
+	}
+}
+
+func TestParseDropbearLine_Pubkey(t *testing.T) {
+	line := `Mar 12 14:30:01 Pubkey auth succeeded for 'cld-alice' with ssh-ed25519 key SHA256:abc123 from 10.0.0.7:54321`
+
+	ts, user, source, method, ok := parseDropbearLine(line, parseYear, time.Time{})
+	if !ok {
+		t.Fatal("failed to parse a pubkey login — the most common case on this platform, since " +
+			"boxes are key-only")
+	}
+	if user != "cld-alice" {
+		t.Errorf("user = %q, want cld-alice (dropbear single-quotes it, unlike sshd)", user)
+	}
+	if source != "10.0.0.7" {
+		t.Errorf("source = %q, want the host without the port — storing \"10.0.0.7:54321\" as an "+
+			"address breaks every query that groups by source", source)
+	}
+	if method != "publickey" {
+		t.Errorf("method = %q, want publickey to match the sshd path's vocabulary", method)
+	}
+	if ts.Year() != parseYear || ts.Month() != time.March || ts.Day() != 12 {
+		t.Errorf("timestamp = %v, want 2026-03-12", ts)
+	}
+}
+
+func TestParseDropbearLine_Password(t *testing.T) {
+	line := `Mar 12 14:30:01 Password auth succeeded for 'cld-bob' from 10.0.0.8:1234`
+	_, user, source, method, ok := parseDropbearLine(line, parseYear, time.Time{})
+	if !ok {
+		t.Fatal("failed to parse a password login")
+	}
+	if user != "cld-bob" || source != "10.0.0.8" || method != "password" {
+		t.Errorf("got user=%q source=%q method=%q", user, source, method)
+	}
+}
+
+// A blank-password login is the single event an auditor most wants to see.
+// Dropping it because its wording differs from the other two would hide
+// exactly the wrong thing.
+func TestParseDropbearLine_BlankPasswordIsCaptured(t *testing.T) {
+	line := `Mar 12 14:30:01 Auth succeeded with blank password for 'cld-carol' from 10.0.0.9:2222`
+	_, user, source, method, ok := parseDropbearLine(line, parseYear, time.Time{})
+	if !ok {
+		t.Fatal("a blank-password login was not recorded — the one login an auditor most needs")
+	}
+	if user != "cld-carol" || source != "10.0.0.9" {
+		t.Errorf("got user=%q source=%q", user, source)
+	}
+	if method != "blank-password" {
+		t.Errorf("method = %q; it must be distinguishable from a real password login", method)
+	}
+}
+
+// Lines that are not successful logins must not produce records. A failed
+// signature recorded as a login would be worse than no record at all.
+func TestParseDropbearLine_IgnoresNonLogins(t *testing.T) {
+	for _, line := range []string{
+		`Mar 12 14:30:01 Pubkey auth bad signature for 'alice' with key SHA256:abc from 10.0.0.1:54321`,
+		`Mar 12 14:30:01 Exit before auth: Disconnect received`,
+		`Mar 12 14:30:01 Child connection from 10.0.0.1:54321`,
+		``,
+		`random noise`,
+	} {
+		if _, _, _, _, ok := parseDropbearLine(line, parseYear, time.Time{}); ok {
+			t.Errorf("recorded a login for a line that is not one:\n%s", line)
+		}
+	}
+}
+
+// The pod log API can supply a timestamp per line, and dropbear's own stamp
+// is absent in some runtimes. A record with the wrong time is worse than one
+// with a time clearly derived from the reader.
+func TestParseDropbearLine_FallsBackToTheReadersTimestamp(t *testing.T) {
+	fallback := time.Date(2026, time.August, 9, 12, 0, 0, 0, time.UTC)
+	line := `Pubkey auth succeeded for 'alice' with ssh-ed25519 key SHA256:abc from 10.0.0.1:54321`
+
+	ts, _, _, _, ok := parseDropbearLine(line, parseYear, fallback)
+	if !ok {
+		t.Fatal("a line without a timestamp should still parse")
+	}
+	if !ts.Equal(fallback) {
+		t.Errorf("timestamp = %v, want the supplied fallback %v", ts, fallback)
+	}
+}
+
+// dropbear prefixes a pid in some configurations.
+func TestParseDropbearLine_ToleratesThePidPrefix(t *testing.T) {
+	line := `[123] Mar 12 14:30:01 Pubkey auth succeeded for 'alice' with ssh-rsa key SHA256:abc from 10.0.0.1:54321`
+	ts, user, _, _, ok := parseDropbearLine(line, parseYear, time.Time{})
+	if !ok || user != "alice" {
+		t.Fatalf("pid-prefixed line did not parse: ok=%v user=%q", ok, user)
+	}
+	if ts.Day() != 12 {
+		t.Errorf("timestamp = %v, want the line's own", ts)
+	}
+}
+
+func TestTrimSourcePort(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"10.0.0.1:54321", "10.0.0.1"},
+		{"10.0.0.1", "10.0.0.1"},
+		{"[2001:db8::1]:54321", "2001:db8::1"},
+		// A bare IPv6 address has several colons and no port to trim.
+		{"2001:db8::1", "2001:db8::1"},
+	} {
+		if got := trimSourcePort(tc.in); got != tc.want {
+			t.Errorf("trimSourcePort(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Toward #1189 — the parser. Scope note at the end.

### The gap is more specific than "no K8s collector"

On K8s we record API-call audit but no record of who logged into a box. For a compliance reader that's the difference between *"no access occurred"* and *"access is not recorded"*.

The mechanism detail that matters: **K8s boxes run dropbear, not OpenSSH**, and the two describe a successful login in completely different words. The existing sshd pattern matches `Accepted publickey for alice from 10.0.0.1 port 54321`. Dropbear never emits that string — so an sshd-shaped collector pointed at a K8s box yields **zero records and looks like it's working**.

### Formats taken from the binary, not from memory

```
$ strings $(which dropbear) | grep -i 'auth succeeded'
Auth succeeded with blank password for '%s' from %s
Password auth succeeded for '%s' from %s
Pubkey auth succeeded for '%s' with %s key %s from %s
```

Three shape differences matter for a regex: the username is **single-quoted**, the source is **host:port** rather than `from IP port N`, and the method word comes **first** rather than after `Accepted`.

There's a test asserting the sshd parser matches none of them — if that ever stops being true, this second parser is dead weight and should go.

### Two deliberate choices

**Blank-password logins are captured separately**, not folded in with the rest. It's the single login an auditor most wants to see, and dropping it because its wording differs would hide exactly the wrong event. It reports its own method so it stays distinguishable from a real password login.

**Source is trimmed to the host.** Storing `10.0.0.7:54321` as an address would break every query that groups by source, and the port is per-session noise.

### Mutation-tested on the three that would quietly corrupt an audit trail

| mutation | consequence the test names |
| --- | --- |
| drop blank-password | "the one login an auditor most needs" |
| keep the port in source | "breaks every query that groups by source" |
| widen the pubkey pattern | `bad signature` parses as a successful login |

### Scope

The parser only. Still to do:

- **AC2** the collector abstraction — no `*incus.Client` in the shared type.
- **The K8s source** — the natural one is the **pod log API**, because dropbear logs to stderr rather than a file: there's no `/var/log/auth.log` in that image to exec-and-grep, so the LXC read strategy doesn't port either.
- **AC4** the kind test asserting a real session produces a record — not runnable in the current lane: box pods there are `registry.k8s.io/pause`, with no dropbear and no shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)