### PR TITLE
refactor(audit): give the SSH collector a backend-neutral session source (#1189)

### DIFF
--- a/internal/audit/dropbear_parser.go
+++ b/internal/audit/dropbear_parser.go
@@ -1,0 +1,120 @@
+package audit
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Parsing dropbear's login lines (#1189).
+//
+// K8s boxes run dropbear, not OpenSSH, and the two log successful
+// authentication in completely different words. The existing sshd parser
+// matches "Accepted publickey for alice from 10.0.0.1 port 54321"; dropbear
+// never emits that string, so an sshd-shaped parser pointed at a K8s box
+// silently yields zero login records — indistinguishable from a box nobody
+// logged into.
+//
+// The formats below are taken from the dropbear binary's own format strings
+// (2022.83), not from documentation or memory:
+//
+//	Password auth succeeded for '%s' from %s
+//	Pubkey auth succeeded for '%s' with %s key %s from %s
+//	Auth succeeded with blank password for '%s' from %s
+//
+// Note the shape differences that matter for a regex: the username is
+// single-quoted, the source is host:port rather than "from IP port N", and
+// the method word comes FIRST rather than after "Accepted".
+
+var (
+	// dropbearPubkeyPattern: Pubkey auth succeeded for 'alice' with ssh-ed25519 key SHA256:... from 10.0.0.1:54321
+	dropbearPubkeyPattern = regexp.MustCompile(
+		`Pubkey auth succeeded for '([^']+)' with \S+ key \S+ from (\S+)`,
+	)
+	// dropbearPasswordPattern: Password auth succeeded for 'alice' from 10.0.0.1:54321
+	dropbearPasswordPattern = regexp.MustCompile(
+		`Password auth succeeded for '([^']+)' from (\S+)`,
+	)
+	// dropbearBlankPattern: Auth succeeded with blank password for 'alice' from 10.0.0.1:54321
+	//
+	// Worth capturing rather than ignoring: a blank-password login is the one
+	// an auditor most wants to see, and dropping it because it does not look
+	// like the other two would hide exactly the wrong event.
+	dropbearBlankPattern = regexp.MustCompile(
+		`Auth succeeded with blank password for '([^']+)' from (\S+)`,
+	)
+)
+
+// dropbearTimestampPattern matches the leading syslog-style timestamp that
+// dropbear emits when logging to stderr, e.g.
+// "[123] Mar 12 14:30:01 Pubkey auth succeeded ...". Absent when the runtime
+// strips it, which is why parsing tolerates its absence.
+var dropbearTimestampPattern = regexp.MustCompile(
+	`(?:\[\d+\]\s+)?(\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s`,
+)
+
+// parseDropbearLine extracts a successful login from one dropbear log line.
+//
+// fallback is used when the line carries no timestamp — the pod log API can
+// supply one per line, and a record with the wrong time is worse than one
+// with an approximate time clearly derived from the reader.
+func parseDropbearLine(line string, year int, fallback time.Time) (ts time.Time, user, source, method string, ok bool) {
+	switch {
+	case dropbearPubkeyPattern.MatchString(line):
+		m := dropbearPubkeyPattern.FindStringSubmatch(line)
+		user, source, method = m[1], m[2], "publickey"
+	case dropbearPasswordPattern.MatchString(line):
+		m := dropbearPasswordPattern.FindStringSubmatch(line)
+		user, source, method = m[1], m[2], "password"
+	case dropbearBlankPattern.MatchString(line):
+		m := dropbearBlankPattern.FindStringSubmatch(line)
+		user, source, method = m[1], m[2], "blank-password"
+	default:
+		return time.Time{}, "", "", "", false
+	}
+
+	// dropbear reports host:port; the audit record wants the host. Trim the
+	// port rather than storing "10.0.0.1:54321" as an address, which would
+	// break every query that groups by source.
+	source = trimSourcePort(source)
+
+	return parseDropbearTimestamp(line, year, fallback), user, source, method, true
+}
+
+// parseDropbearTimestamp reads the line's own timestamp, falling back to the
+// supplied one.
+func parseDropbearTimestamp(line string, year int, fallback time.Time) time.Time {
+	m := dropbearTimestampPattern.FindStringSubmatch(line)
+	if m == nil {
+		return fallback
+	}
+	tsStr := fmt.Sprintf("%d %s", year, m[1])
+	// Two layouts because the day is space-padded for single digits in some
+	// runtimes and not others.
+	for _, layout := range []string{"2006 Jan  2 15:04:05", "2006 Jan 2 15:04:05"} {
+		if ts, err := time.Parse(layout, tsStr); err == nil {
+			return ts
+		}
+	}
+	return fallback
+}
+
+// trimSourcePort turns "10.0.0.1:54321" into "10.0.0.1", leaving a bare
+// address (and IPv6 forms) alone.
+func trimSourcePort(source string) string {
+	// IPv6 with port is bracketed: [::1]:54321
+	if strings.HasPrefix(source, "[") {
+		if end := strings.LastIndex(source, "]"); end > 0 {
+			return source[1:end]
+		}
+		return source
+	}
+	// Exactly one colon means host:port; more means a bare IPv6 address.
+	if strings.Count(source, ":") == 1 {
+		if host, _, found := strings.Cut(source, ":"); found {
+			return host
+		}
+	}
+	return source
+}

--- a/internal/audit/dropbear_parser_test.go
+++ b/internal/audit/dropbear_parser_test.go
@@ -1,0 +1,144 @@
+package audit
+
+import (
+	"testing"
+	"time"
+)
+
+// #1189: in-box SSH session audit is incus-only. K8s boxes run dropbear, and
+// the existing sshd parser cannot match a single line dropbear emits — so a
+// K8s box yields zero login records, which reads identically to a box nobody
+// logged into. For a compliance reader that is the difference between "no
+// access occurred" and "access is not recorded".
+//
+// Every format below is taken from the dropbear 2022.83 binary's own format
+// strings, not from documentation:
+//
+//	Password auth succeeded for '%s' from %s
+//	Pubkey auth succeeded for '%s' with %s key %s from %s
+//	Auth succeeded with blank password for '%s' from %s
+
+const parseYear = 2026
+
+// THE reason this parser exists: the sshd pattern matches nothing dropbear
+// writes. If this ever stops being true, the second parser is dead weight.
+func TestSSHDPatternCannotMatchDropbearOutput(t *testing.T) {
+	for _, line := range []string{
+		`Mar 12 14:30:01 box dropbear[42]: Pubkey auth succeeded for 'alice' with ssh-ed25519 key SHA256:abc from 10.0.0.1:54321`,
+		`Mar 12 14:30:01 box dropbear[42]: Password auth succeeded for 'alice' from 10.0.0.1:54321`,
+	} {
+		if _, _, _, _, ok := parseAuthLogLine(line, parseYear); ok {
+			t.Errorf("the sshd parser matched a dropbear line — if it genuinely handles both, this "+
+				"second parser is unnecessary:\n%s", line)
+		}
+	}
+}
+
+func TestParseDropbearLine_Pubkey(t *testing.T) {
+	line := `Mar 12 14:30:01 Pubkey auth succeeded for 'cld-alice' with ssh-ed25519 key SHA256:abc123 from 10.0.0.7:54321`
+
+	ts, user, source, method, ok := parseDropbearLine(line, parseYear, time.Time{})
+	if !ok {
+		t.Fatal("failed to parse a pubkey login — the most common case on this platform, since " +
+			"boxes are key-only")
+	}
+	if user != "cld-alice" {
+		t.Errorf("user = %q, want cld-alice (dropbear single-quotes it, unlike sshd)", user)
+	}
+	if source != "10.0.0.7" {
+		t.Errorf("source = %q, want the host without the port — storing \"10.0.0.7:54321\" as an "+
+			"address breaks every query that groups by source", source)
+	}
+	if method != "publickey" {
+		t.Errorf("method = %q, want publickey to match the sshd path's vocabulary", method)
+	}
+	if ts.Year() != parseYear || ts.Month() != time.March || ts.Day() != 12 {
+		t.Errorf("timestamp = %v, want 2026-03-12", ts)
+	}
+}
+
+func TestParseDropbearLine_Password(t *testing.T) {
+	line := `Mar 12 14:30:01 Password auth succeeded for 'cld-bob' from 10.0.0.8:1234`
+	_, user, source, method, ok := parseDropbearLine(line, parseYear, time.Time{})
+	if !ok {
+		t.Fatal("failed to parse a password login")
+	}
+	if user != "cld-bob" || source != "10.0.0.8" || method != "password" {
+		t.Errorf("got user=%q source=%q method=%q", user, source, method)
+	}
+}
+
+// A blank-password login is the single event an auditor most wants to see.
+// Dropping it because its wording differs from the other two would hide
+// exactly the wrong thing.
+func TestParseDropbearLine_BlankPasswordIsCaptured(t *testing.T) {
+	line := `Mar 12 14:30:01 Auth succeeded with blank password for 'cld-carol' from 10.0.0.9:2222`
+	_, user, source, method, ok := parseDropbearLine(line, parseYear, time.Time{})
+	if !ok {
+		t.Fatal("a blank-password login was not recorded — the one login an auditor most needs")
+	}
+	if user != "cld-carol" || source != "10.0.0.9" {
+		t.Errorf("got user=%q source=%q", user, source)
+	}
+	if method != "blank-password" {
+		t.Errorf("method = %q; it must be distinguishable from a real password login", method)
+	}
+}
+
+// Lines that are not successful logins must not produce records. A failed
+// signature recorded as a login would be worse than no record at all.
+func TestParseDropbearLine_IgnoresNonLogins(t *testing.T) {
+	for _, line := range []string{
+		`Mar 12 14:30:01 Pubkey auth bad signature for 'alice' with key SHA256:abc from 10.0.0.1:54321`,
+		`Mar 12 14:30:01 Exit before auth: Disconnect received`,
+		`Mar 12 14:30:01 Child connection from 10.0.0.1:54321`,
+		``,
+		`random noise`,
+	} {
+		if _, _, _, _, ok := parseDropbearLine(line, parseYear, time.Time{}); ok {
+			t.Errorf("recorded a login for a line that is not one:\n%s", line)
+		}
+	}
+}
+
+// The pod log API can supply a timestamp per line, and dropbear's own stamp
+// is absent in some runtimes. A record with the wrong time is worse than one
+// with a time clearly derived from the reader.
+func TestParseDropbearLine_FallsBackToTheReadersTimestamp(t *testing.T) {
+	fallback := time.Date(2026, time.August, 9, 12, 0, 0, 0, time.UTC)
+	line := `Pubkey auth succeeded for 'alice' with ssh-ed25519 key SHA256:abc from 10.0.0.1:54321`
+
+	ts, _, _, _, ok := parseDropbearLine(line, parseYear, fallback)
+	if !ok {
+		t.Fatal("a line without a timestamp should still parse")
+	}
+	if !ts.Equal(fallback) {
+		t.Errorf("timestamp = %v, want the supplied fallback %v", ts, fallback)
+	}
+}
+
+// dropbear prefixes a pid in some configurations.
+func TestParseDropbearLine_ToleratesThePidPrefix(t *testing.T) {
+	line := `[123] Mar 12 14:30:01 Pubkey auth succeeded for 'alice' with ssh-rsa key SHA256:abc from 10.0.0.1:54321`
+	ts, user, _, _, ok := parseDropbearLine(line, parseYear, time.Time{})
+	if !ok || user != "alice" {
+		t.Fatalf("pid-prefixed line did not parse: ok=%v user=%q", ok, user)
+	}
+	if ts.Day() != 12 {
+		t.Errorf("timestamp = %v, want the line's own", ts)
+	}
+}
+
+func TestTrimSourcePort(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"10.0.0.1:54321", "10.0.0.1"},
+		{"10.0.0.1", "10.0.0.1"},
+		{"[2001:db8::1]:54321", "2001:db8::1"},
+		// A bare IPv6 address has several colons and no port to trim.
+		{"2001:db8::1", "2001:db8::1"},
+	} {
+		if got := trimSourcePort(tc.in); got != tc.want {
+			t.Errorf("trimSourcePort(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/audit/session_source.go
+++ b/internal/audit/session_source.go
@@ -1,0 +1,95 @@
+package audit
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// Backend-neutral session collection (#1189).
+//
+// The collector's own job is scheduling, de-duplication and writing audit
+// entries — none of which is backend-specific. What IS backend-specific is
+// three things that travel together, and the interface groups them for that
+// reason rather than for tidiness:
+//
+//   - which boxes to read
+//   - how to read a box's session log
+//   - how to parse a line of it
+//
+// They cannot be mixed and matched. Reading incus's /var/log/auth.log and
+// parsing it with the dropbear patterns yields nothing; reading a K8s pod's
+// log and parsing it as sshd yields nothing. Both failures are silent — an
+// empty result reads exactly like a box nobody logged into — so the pairing
+// belongs in one type where it cannot be split by accident.
+
+// SessionBox is a box the collector should read sessions from.
+type SessionBox struct {
+	// Name is the backend's own identifier, recorded as the audit
+	// ResourceID.
+	Name string
+	// Username is the tenant the box belongs to.
+	Username string
+}
+
+// SessionSource supplies session-log lines for one backend.
+type SessionSource interface {
+	// Boxes returns the running boxes whose sessions should be collected.
+	Boxes(ctx context.Context) ([]SessionBox, error)
+	// ReadSessions returns raw session-log text for a box.
+	ReadSessions(ctx context.Context, box SessionBox) (string, error)
+	// ParseLine extracts a successful login from a single line. fallback is
+	// used when the line carries no timestamp of its own.
+	ParseLine(line string, year int, fallback time.Time) (ts time.Time, user, source, method string, ok bool)
+}
+
+// --- incus -----------------------------------------------------------
+
+// incusSessionSource reads OpenSSH's auth.log out of an incus container.
+type incusSessionSource struct {
+	client *incus.Client
+}
+
+// NewIncusSessionSource returns the LXC session source.
+func NewIncusSessionSource(client *incus.Client) SessionSource {
+	return &incusSessionSource{client: client}
+}
+
+func (s *incusSessionSource) Boxes(context.Context) ([]SessionBox, error) {
+	containers, err := s.client.ListContainers()
+	if err != nil {
+		return nil, err
+	}
+	var boxes []SessionBox
+	for _, c := range containers {
+		if c.State != "Running" || c.Role.IsCoreRole() {
+			continue
+		}
+		username := c.Name
+		if strings.HasSuffix(c.Name, "-container") {
+			username = strings.TrimSuffix(c.Name, "-container")
+		}
+		boxes = append(boxes, SessionBox{Name: c.Name, Username: username})
+	}
+	return boxes, nil
+}
+
+func (s *incusSessionSource) ReadSessions(_ context.Context, box SessionBox) (string, error) {
+	stdout, _, err := s.client.ExecWithOutput(box.Name, []string{
+		"grep", "Accepted", "/var/log/auth.log",
+	})
+	if err != nil {
+		// grep exits 1 when there are no matches, which is not an error.
+		if strings.Contains(err.Error(), "exited with code 1") {
+			return "", nil
+		}
+		return "", err
+	}
+	return stdout, nil
+}
+
+func (s *incusSessionSource) ParseLine(line string, year int, _ time.Time) (time.Time, string, string, string, bool) {
+	return parseAuthLogLine(line, year)
+}

--- a/internal/audit/session_source_test.go
+++ b/internal/audit/session_source_test.go
@@ -1,0 +1,178 @@
+package audit
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// #1189 AC2: the collector abstraction is backend-neutral — no *incus.Client
+// in the shared type, each backend supplying its own source.
+//
+// The test that matters is not "the interface exists" but that the collector
+// produces correct audit records driven by a source with NOTHING incus about
+// it — a different log format, a different reading strategy, and lines with
+// no timestamp of their own.
+
+// fakeSource is a session source with no incus in it at all.
+type fakeSource struct {
+	boxes    []SessionBox
+	logs     map[string]string
+	boxesErr error
+	readErr  error
+	parse    func(line string, year int, fallback time.Time) (time.Time, string, string, string, bool)
+	reads    int
+}
+
+func (f *fakeSource) Boxes(context.Context) ([]SessionBox, error) {
+	return f.boxes, f.boxesErr
+}
+
+func (f *fakeSource) ReadSessions(_ context.Context, box SessionBox) (string, error) {
+	f.reads++
+	if f.readErr != nil {
+		return "", f.readErr
+	}
+	return f.logs[box.Name], nil
+}
+
+func (f *fakeSource) ParseLine(line string, year int, fallback time.Time) (time.Time, string, string, string, bool) {
+	return f.parse(line, year, fallback)
+}
+
+// recordingStore captures what the collector wrote.
+type recordingStore struct{ entries []*AuditEntry }
+
+func (r *recordingStore) Log(_ context.Context, e *AuditEntry) error {
+	r.entries = append(r.entries, e)
+	return nil
+}
+
+func newAuditStore(t *testing.T) *recordingStore {
+	t.Helper()
+	return &recordingStore{}
+}
+
+// The collector drives a dropbear-shaped source end to end. Nothing here is
+// incus, which is the whole point of the abstraction.
+func TestCollector_WorksWithANonIncusSource(t *testing.T) {
+	store := newAuditStore(t)
+	src := &fakeSource{
+		boxes: []SessionBox{{Name: "alice-box", Username: "alice"}},
+		logs: map[string]string{
+			"alice-box": `Mar 12 14:30:01 Pubkey auth succeeded for 'cld-alice' with ssh-ed25519 key SHA256:abc from 10.0.0.7:54321`,
+		},
+		parse: parseDropbearLine,
+	}
+
+	sc := NewSSHCollectorWithSource(src, store)
+	sc.collectAll(context.Background())
+
+	entries := store.entries
+	if len(entries) != 1 {
+		t.Fatalf("recorded %d entries, want 1 — a K8s box producing no records is "+
+			"indistinguishable from one nobody logged into (#1189)", len(entries))
+	}
+	e := entries[0]
+	if e.Action != "ssh_login" {
+		t.Errorf("action = %q, want ssh_login so it is queryable identically to the LXC path", e.Action)
+	}
+	if e.Username != "alice" {
+		t.Errorf("username = %q, want the box's tenant", e.Username)
+	}
+	if e.SourceIP != "10.0.0.7" {
+		t.Errorf("source = %q, want the host without its port", e.SourceIP)
+	}
+	if e.ResourceID != "alice-box" {
+		t.Errorf("resource = %q, want the box name", e.ResourceID)
+	}
+}
+
+// The high-water mark is what stops every poll re-recording the same logins.
+// It is shared logic, so it must work for any source.
+func TestCollector_DoesNotReRecordSeenLogins(t *testing.T) {
+	store := newAuditStore(t)
+	src := &fakeSource{
+		boxes: []SessionBox{{Name: "alice-box", Username: "alice"}},
+		logs: map[string]string{
+			"alice-box": `Mar 12 14:30:01 Pubkey auth succeeded for 'cld-alice' with ssh-ed25519 key SHA256:abc from 10.0.0.7:54321`,
+		},
+		parse: parseDropbearLine,
+	}
+	sc := NewSSHCollectorWithSource(src, store)
+
+	sc.collectAll(context.Background())
+	sc.collectAll(context.Background())
+	sc.collectAll(context.Background())
+
+	entries := store.entries
+	if len(entries) != 1 {
+		t.Errorf("recorded %d entries for one login across three polls — the audit trail would "+
+			"grow without bound and every login would appear to happen repeatedly", len(entries))
+	}
+	if src.reads != 3 {
+		t.Errorf("read the log %d times, want 3 — dedup must happen on the records, not by "+
+			"skipping the read", src.reads)
+	}
+}
+
+// A new login after the high-water mark is recorded.
+func TestCollector_RecordsLoginsAfterTheHighWaterMark(t *testing.T) {
+	store := newAuditStore(t)
+	src := &fakeSource{
+		boxes: []SessionBox{{Name: "alice-box", Username: "alice"}},
+		logs: map[string]string{
+			"alice-box": `Mar 12 14:30:01 Pubkey auth succeeded for 'a' with ssh-ed25519 key SHA256:x from 10.0.0.1:1`,
+		},
+		parse: parseDropbearLine,
+	}
+	sc := NewSSHCollectorWithSource(src, store)
+	sc.collectAll(context.Background())
+
+	src.logs["alice-box"] += "\n" +
+		`Mar 12 15:00:00 Pubkey auth succeeded for 'a' with ssh-ed25519 key SHA256:x from 10.0.0.2:2`
+	sc.collectAll(context.Background())
+
+	entries := store.entries
+	if len(entries) != 2 {
+		t.Errorf("recorded %d entries, want 2 — a later login must not be swallowed by the "+
+			"high-water mark", len(entries))
+	}
+}
+
+// One box failing to read must not stop the others being collected.
+func TestCollector_BoxReadFailureDoesNotStopOthers(t *testing.T) {
+	store := newAuditStore(t)
+	src := &fakeSource{
+		boxes: []SessionBox{
+			{Name: "broken", Username: "a"},
+			{Name: "fine", Username: "b"},
+		},
+		logs:  map[string]string{},
+		parse: parseDropbearLine,
+	}
+	// Fail only for the first box by making the read error unconditional and
+	// then checking both were attempted.
+	src.readErr = errors.New("pod is gone")
+
+	sc := NewSSHCollectorWithSource(src, store)
+	sc.collectAll(context.Background())
+
+	if src.reads != 2 {
+		t.Errorf("attempted %d reads, want both boxes — one unreadable box must not stop the "+
+			"rest of the fleet being audited", src.reads)
+	}
+}
+
+func TestCollector_BoxListFailureIsSurvivable(t *testing.T) {
+	store := newAuditStore(t)
+	src := &fakeSource{boxesErr: errors.New("apiserver down"), parse: parseDropbearLine}
+
+	sc := NewSSHCollectorWithSource(src, store)
+	sc.collectAll(context.Background()) // must not panic
+
+	if entries := store.entries; len(entries) != 0 {
+		t.Errorf("recorded %d entries despite being unable to list boxes", len(entries))
+	}
+}

--- a/internal/audit/ssh_collector.go
+++ b/internal/audit/ssh_collector.go
@@ -12,23 +12,44 @@ import (
 	"github.com/footprintai/containarium/pkg/core/incus"
 )
 
-// SSHCollector periodically reads auth.log from containers to capture SSH login events.
+// SSHCollector periodically reads each box's session log to capture SSH
+// login events.
+//
+// Backend-neutral since #1189: it holds a SessionSource rather than an
+// *incus.Client, because K8s boxes keep their session log somewhere else
+// (a pod's stderr, not /var/log/auth.log) and write it in a different
+// format (dropbear, not OpenSSH).
 type SSHCollector struct {
-	incusClient *incus.Client
-	store       *Store
-	interval    time.Duration
-	lastSeen    map[string]time.Time // per-container high-water mark
-	mu          sync.Mutex
-	cancel      context.CancelFunc
+	source   SessionSource
+	store    entryLogger
+	interval time.Duration
+	lastSeen map[string]time.Time // per-box high-water mark
+	mu       sync.Mutex
+	cancel   context.CancelFunc
 }
 
-// NewSSHCollector creates a new SSH login collector.
+// NewSSHCollector creates a collector over the LXC session source.
+//
+// Kept for the existing call site; NewSSHCollectorWithSource is the general
+// form.
+// entryLogger is the only thing the collector needs from the audit store.
+// Narrowed so the collection logic is testable without Postgres — *Store
+// satisfies it, so no call site changes.
+type entryLogger interface {
+	Log(ctx context.Context, entry *AuditEntry) error
+}
+
 func NewSSHCollector(incusClient *incus.Client, store *Store) *SSHCollector {
+	return NewSSHCollectorWithSource(NewIncusSessionSource(incusClient), store)
+}
+
+// NewSSHCollectorWithSource creates a collector over any session source.
+func NewSSHCollectorWithSource(source SessionSource, store entryLogger) *SSHCollector {
 	return &SSHCollector{
-		incusClient: incusClient,
-		store:       store,
-		interval:    2 * time.Minute,
-		lastSeen:    make(map[string]time.Time),
+		source:   source,
+		store:    store,
+		interval: 2 * time.Minute,
+		lastSeen: make(map[string]time.Time),
 	}
 }
 
@@ -63,41 +84,28 @@ func (sc *SSHCollector) Stop() {
 	log.Printf("SSH login collector stopped")
 }
 
-// collectAll iterates all running user containers and collects SSH login entries.
+// collectAll iterates every box the source reports and collects its logins.
 func (sc *SSHCollector) collectAll(ctx context.Context) {
-	containers, err := sc.incusClient.ListContainers()
+	boxes, err := sc.source.Boxes(ctx)
 	if err != nil {
-		log.Printf("SSH collector: failed to list containers: %v", err)
+		log.Printf("SSH collector: failed to list boxes: %v", err)
 		return
 	}
 
-	for _, c := range containers {
-		if c.State != "Running" || c.Role.IsCoreRole() {
-			continue
-		}
-
-		username := c.Name
-		if strings.HasSuffix(c.Name, "-container") {
-			username = strings.TrimSuffix(c.Name, "-container")
-		}
-
-		if err := sc.collectFromContainer(ctx, c.Name, username); err != nil {
-			log.Printf("SSH collector: %s: %v", c.Name, err)
+	for _, b := range boxes {
+		if err := sc.collectFromBox(ctx, b); err != nil {
+			log.Printf("SSH collector: %s: %v", b.Name, err)
 		}
 	}
 }
 
-// collectFromContainer reads auth.log from a single container and writes audit entries.
-func (sc *SSHCollector) collectFromContainer(ctx context.Context, containerName, username string) error {
-	stdout, _, err := sc.incusClient.ExecWithOutput(containerName, []string{
-		"grep", "Accepted", "/var/log/auth.log",
-	})
+// collectFromBox reads one box's session log and writes audit entries.
+func (sc *SSHCollector) collectFromBox(ctx context.Context, box SessionBox) error {
+	containerName, username := box.Name, box.Username
+
+	stdout, err := sc.source.ReadSessions(ctx, box)
 	if err != nil {
-		// grep exits 1 when no matches — not an error
-		if strings.Contains(err.Error(), "exited with code 1") {
-			return nil
-		}
-		return fmt.Errorf("failed to read auth.log: %w", err)
+		return fmt.Errorf("read session log: %w", err)
 	}
 
 	if strings.TrimSpace(stdout) == "" {
@@ -109,11 +117,13 @@ func (sc *SSHCollector) collectFromContainer(ctx context.Context, containerName,
 	sc.mu.Unlock()
 
 	year := time.Now().Year()
+	// Used for sources whose lines carry no timestamp of their own.
+	readAt := time.Now()
 	var maxTS time.Time
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
 
 	for _, line := range lines {
-		ts, sshUser, sourceIP, method, ok := parseAuthLogLine(line, year)
+		ts, sshUser, sourceIP, method, ok := sc.source.ParseLine(line, year, readAt)
 		if !ok {
 			continue
 		}


### PR DESCRIPTION
## Why

The SSH session collector held an `*incus.Client` directly, so the only way it could audit a login was to exec into an LXC container and read `/var/log/auth.log`. A K8s box keeps its session record somewhere else entirely, so it produced no login records at all — and a box with no records reads identically to a box nobody logged into. For a compliance reader that is the difference between "no access occurred" and "access is not recorded".

This is AC2 of #1189. #1267 landed the dropbear parser (AC1); this lands the seam that lets a second backend use it.

## What

A `SessionSource` interface — list the boxes, read a box's session log, parse a line. The incus implementation is the existing behaviour moved behind the interface. The shared logic that both backends need (dedup, per-box high-water mark, writing records) stays in the collector.

`NewSSHCollector(client, store)` keeps its signature, so the live call site is untouched.

The store dependency is narrowed to the single method the collector calls. That is what makes the collection logic testable without Postgres; `*Store` satisfies it, so no call site changes there either.

## Tests

The tests drive the collector from a source with nothing incus in it — which is the only way to show the abstraction actually holds. They cover what a second backend depends on:

- a record lands with the right identity, source host, and box
- a login is not re-recorded on every poll
- a later login is not swallowed by the high-water mark
- one unreadable box does not stop the rest of the fleet being audited
- being unable to list boxes at all is survivable

Mutation-tested — each of these fails a test: never advancing the high-water mark, aborting the pass on one box's error, recording the box name as the username, dropping the source-port trim.

## Scope

The K8s source itself is not here. Dropbear logs to stderr rather than to a file, so the natural source is the pod log API, and that is a separate change. AC4 (an end-to-end kind test with a real session) is still not runnable in this lane — the box pods run `pause`, so there is no sshd to log into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)