### PR TITLE
feat(audit): collect SSH sessions from K8s box pod logs (#1189)

### DIFF
--- a/internal/audit/k8s_session_source.go
+++ b/internal/audit/k8s_session_source.go
@@ -1,0 +1,220 @@
+package audit
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/footprintai/containarium/pkg/core/box/k8s/boxmeta"
+)
+
+// The K8s session source (#1189).
+//
+// A K8s box has no /var/log/auth.log to grep: it runs dropbear as PID 1's
+// child with logging to stderr, which the kubelet captures. So the session
+// record lives in the pod log, and reading it is an apiserver call rather
+// than an exec.
+//
+// This is why the collector needed a source seam at all. The LXC path
+// (exec + grep + sshd patterns) and this one (pod log + dropbear patterns)
+// share no step; what they share is everything the collector does with the
+// result.
+
+// k8sLogLookback bounds the first read of a box the collector has not seen
+// before — on startup, or when a box first appears.
+//
+// Not unbounded: a box that has been up for months would have the collector
+// pull its entire retained log on the first pass, and every record in it is
+// one the previous run already wrote. Not short either, because anything
+// older than the window on that first pass is lost rather than late. A day
+// covers a daemon restart and any plausible collection gap.
+const k8sLogLookback = 24 * time.Hour
+
+// k8sSessionSource reads dropbear's output from box pod logs.
+type k8sSessionSource struct {
+	clientset kubernetes.Interface
+	// namespace scopes the pod listing; empty means every namespace, which
+	// is the normal case since boxes get a namespace per tenant.
+	namespace string
+
+	// mu guards lastRead, which is consulted from the collector's goroutine
+	// only today but is cheap to make safe.
+	mu sync.Mutex
+	// lastRead is the point each box's log was last read up to, used as the
+	// apiserver's SinceTime so a poll transfers a poll's worth of log rather
+	// than the whole retained history.
+	//
+	// This is an efficiency bound, NOT de-duplication: the window is
+	// deliberately re-read with an overlap and the collector's high-water
+	// mark drops what it has already recorded. Using it to skip lines would
+	// mean a clock skew between the node and the daemon silently losing
+	// logins.
+	lastRead map[string]time.Time
+}
+
+// NewK8sSessionSource returns the pod-log session source.
+//
+// namespace scopes the search; pass "" to cover every namespace.
+func NewK8sSessionSource(clientset kubernetes.Interface, namespace string) SessionSource {
+	return &k8sSessionSource{
+		clientset: clientset,
+		namespace: namespace,
+		lastRead:  make(map[string]time.Time),
+	}
+}
+
+func (s *k8sSessionSource) Boxes(ctx context.Context) ([]SessionBox, error) {
+	pods, err := s.clientset.CoreV1().Pods(s.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: boxmeta.ManagedByLabel + "=" + boxmeta.ManagedByValue,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list box pods: %w", err)
+	}
+
+	var boxes []SessionBox
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		tenant := pod.Labels[boxmeta.TenantLabel]
+		if tenant == "" {
+			// Managed by this platform but not a tenant box — the gateway,
+			// for instance. Nobody logs into those as a tenant.
+			continue
+		}
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		boxes = append(boxes, SessionBox{
+			// The tenant, not the pod name: pods are replaced on restart and
+			// resize, and an audit trail whose resource ID changes underneath
+			// it cannot be queried for "who logged into this box".
+			Name:     tenant,
+			Username: tenant,
+			Ref:      pod.Namespace + "/" + pod.Name,
+		})
+	}
+	return boxes, nil
+}
+
+func (s *k8sSessionSource) ReadSessions(ctx context.Context, box SessionBox) (string, error) {
+	namespace, podName, err := splitPodRef(box.Ref)
+	if err != nil {
+		return "", err
+	}
+
+	opts := &corev1.PodLogOptions{
+		Container: boxmeta.BoxContainerName,
+		// Ask the apiserver to stamp each line. dropbear's own timestamp is
+		// absent under some runtimes, and a login recorded with the wrong
+		// time is worse than one recorded with the reader's.
+		Timestamps: true,
+	}
+	if since := s.sinceFor(box.Ref); !since.IsZero() {
+		sinceTime := metav1.NewTime(since)
+		opts.SinceTime = &sinceTime
+	}
+
+	stream, err := s.clientset.CoreV1().Pods(namespace).
+		GetLogs(podName, opts).Stream(ctx)
+	if err != nil {
+		return "", fmt.Errorf("read pod log %s: %w", box.Ref, err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	// readAt is stamped BEFORE the read, not after: anything logged while the
+	// read is in flight must fall inside the next window rather than between
+	// the two.
+	readAt := time.Now()
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		return "", fmt.Errorf("read pod log %s: %w", box.Ref, err)
+	}
+
+	// Only advance on success. A failed read must leave the window open, or
+	// the logins it failed to fetch are skipped by the next one.
+	s.markRead(box.Ref, readAt)
+	return string(data), nil
+}
+
+// ParseLine reads one pod-log line.
+//
+// With Timestamps set, the apiserver prefixes each line with an RFC3339
+// stamp. That stamp is preferred over dropbear's own even when both are
+// present: dropbear's carries neither a year nor a zone, so it has to be
+// reassembled from a guessed year, while the kubelet's is complete and is
+// what every other view of this pod's log agrees with.
+func (s *k8sSessionSource) ParseLine(line string, year int, fallback time.Time) (time.Time, string, string, string, bool) {
+	podTS, rest, hasPodTS := splitPodLogTimestamp(line)
+	if hasPodTS {
+		line, fallback = rest, podTS
+	}
+
+	ts, user, source, method, ok := parseDropbearLine(line, year, fallback)
+	if !ok {
+		return time.Time{}, "", "", "", false
+	}
+	if hasPodTS {
+		ts = podTS
+	}
+	return ts, user, source, method, true
+}
+
+// splitPodLogTimestamp peels the RFC3339 stamp the apiserver prefixes to each
+// line when PodLogOptions.Timestamps is set. Returns ok=false for a line
+// without one, since the option is best-effort per runtime.
+func splitPodLogTimestamp(line string) (ts time.Time, rest string, ok bool) {
+	stamp, remainder, found := strings.Cut(line, " ")
+	if !found {
+		return time.Time{}, line, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, stamp)
+	if err != nil {
+		return time.Time{}, line, false
+	}
+	return parsed, remainder, true
+}
+
+// sinceFor returns the SinceTime for a box's next read: the last successful
+// read, backed off by an overlap, or the initial lookback for a box not seen
+// before.
+func (s *k8sSessionSource) sinceFor(ref string) time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	last, ok := s.lastRead[ref]
+	if !ok {
+		return time.Now().Add(-k8sLogLookback)
+	}
+	// The overlap covers modest clock skew between the node writing the log
+	// and this process reading it. Re-reading costs a few duplicate lines the
+	// collector discards; reading too late loses a login for good.
+	return last.Add(-k8sLogOverlap)
+}
+
+// k8sLogOverlap is how far back each read reaches beyond the previous one.
+const k8sLogOverlap = 5 * time.Minute
+
+func (s *k8sSessionSource) markRead(ref string, at time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastRead[ref] = at
+}
+
+// splitPodRef splits the "namespace/pod" handle Boxes attached to the box.
+func splitPodRef(ref string) (namespace, pod string, err error) {
+	for i := 0; i < len(ref); i++ {
+		if ref[i] == '/' {
+			namespace, pod = ref[:i], ref[i+1:]
+			if namespace == "" || pod == "" {
+				break
+			}
+			return namespace, pod, nil
+		}
+	}
+	return "", "", fmt.Errorf("malformed pod reference %q, want namespace/pod", ref)
+}

--- a/internal/audit/k8s_session_source_test.go
+++ b/internal/audit/k8s_session_source_test.go
@@ -1,0 +1,206 @@
+package audit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/footprintai/containarium/pkg/core/box/k8s/boxmeta"
+)
+
+func boxPod(namespace, name, tenant string, phase corev1.PodPhase) *corev1.Pod {
+	labels := map[string]string{boxmeta.ManagedByLabel: boxmeta.ManagedByValue}
+	if tenant != "" {
+		labels[boxmeta.TenantLabel] = tenant
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+		Status:     corev1.PodStatus{Phase: phase},
+	}
+}
+
+func TestK8sSource_FindsRunningTenantBoxes(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		boxPod("tenant-alice", "alice-abc123", "alice", corev1.PodRunning),
+		boxPod("tenant-bob", "bob-def456", "bob", corev1.PodRunning),
+	)
+
+	boxes, err := NewK8sSessionSource(cs, "").Boxes(context.Background())
+	if err != nil {
+		t.Fatalf("boxes: %v", err)
+	}
+	if len(boxes) != 2 {
+		t.Fatalf("found %d boxes, want 2 — a box the collector never lists produces no login "+
+			"records, which reads as if nobody logged in", len(boxes))
+	}
+
+	byName := map[string]SessionBox{}
+	for _, b := range boxes {
+		byName[b.Name] = b
+	}
+	alice, ok := byName["alice"]
+	if !ok {
+		t.Fatalf("boxes are not keyed by tenant: %+v", boxes)
+	}
+	if alice.Username != "alice" {
+		t.Errorf("username = %q, want the tenant", alice.Username)
+	}
+	// The pod name must survive to ReadSessions, but must NOT become the
+	// audit resource ID: pods are replaced on restart and resize.
+	if alice.Ref != "tenant-alice/alice-abc123" {
+		t.Errorf("ref = %q, want namespace/pod so the log can be located", alice.Ref)
+	}
+}
+
+// A pod this platform owns but that is not a tenant's box — the gateway —
+// has no tenant to attribute a login to.
+func TestK8sSource_SkipsNonTenantPods(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		boxPod("containarium", "sshpiper-xyz", "", corev1.PodRunning),
+		boxPod("tenant-alice", "alice-abc", "alice", corev1.PodRunning),
+	)
+
+	boxes, _ := NewK8sSessionSource(cs, "").Boxes(context.Background())
+	if len(boxes) != 1 || boxes[0].Name != "alice" {
+		t.Errorf("got %+v, want only the tenant box", boxes)
+	}
+}
+
+// Reading the log of a pod that is not up yet fails the read and would be
+// logged as a collection error on every pass.
+func TestK8sSource_SkipsPodsThatAreNotRunning(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		boxPod("tenant-alice", "alice-abc", "alice", corev1.PodPending),
+		boxPod("tenant-bob", "bob-old", "bob", corev1.PodSucceeded),
+	)
+
+	boxes, _ := NewK8sSessionSource(cs, "").Boxes(context.Background())
+	if len(boxes) != 0 {
+		t.Errorf("got %+v, want none — neither pod can serve a log", boxes)
+	}
+}
+
+func TestK8sSource_ReadsThePodLog(t *testing.T) {
+	cs := fake.NewSimpleClientset(boxPod("tenant-alice", "alice-abc", "alice", corev1.PodRunning))
+	src := NewK8sSessionSource(cs, "")
+
+	out, err := src.ReadSessions(context.Background(), SessionBox{
+		Name: "alice", Username: "alice", Ref: "tenant-alice/alice-abc",
+	})
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if out == "" {
+		t.Error("read returned nothing from the pod log")
+	}
+}
+
+func TestK8sSource_RejectsAMalformedRef(t *testing.T) {
+	src := NewK8sSessionSource(fake.NewSimpleClientset(), "")
+	for _, ref := range []string{"", "no-slash", "/pod", "ns/"} {
+		if _, err := src.ReadSessions(context.Background(), SessionBox{Ref: ref}); err == nil {
+			t.Errorf("ref %q was accepted; a bad reference must be an error, not a silent "+
+				"empty log that reads as no logins", ref)
+		}
+	}
+}
+
+// The apiserver's stamp is complete; dropbear's has neither a year nor a
+// zone. When both are present the apiserver's must win.
+func TestK8sSource_PrefersTheApiserverTimestamp(t *testing.T) {
+	src := NewK8sSessionSource(fake.NewSimpleClientset(), "")
+	podTS := time.Date(2026, time.August, 9, 12, 34, 56, 0, time.UTC)
+	line := podTS.Format(time.RFC3339Nano) +
+		` Mar 12 14:30:01 Pubkey auth succeeded for 'alice' with ssh-ed25519 key SHA256:abc from 10.0.0.1:54321`
+
+	ts, user, source, method, ok := src.ParseLine(line, 2026, time.Time{})
+	if !ok {
+		t.Fatal("a stamped pod-log line did not parse")
+	}
+	if !ts.Equal(podTS) {
+		t.Errorf("timestamp = %v, want the apiserver's %v — dropbear's has no year or zone, so "+
+			"a record built from it disagrees with every other view of this log", ts, podTS)
+	}
+	if user != "alice" || source != "10.0.0.1" || method != "publickey" {
+		t.Errorf("got user=%q source=%q method=%q", user, source, method)
+	}
+}
+
+// Timestamps are best-effort per runtime; an unstamped line must still parse.
+func TestK8sSource_ParsesAnUnstampedLine(t *testing.T) {
+	src := NewK8sSessionSource(fake.NewSimpleClientset(), "")
+	line := `Mar 12 14:30:01 Pubkey auth succeeded for 'alice' with ssh-ed25519 key SHA256:abc from 10.0.0.1:54321`
+
+	ts, user, _, _, ok := src.ParseLine(line, 2026, time.Time{})
+	if !ok || user != "alice" {
+		t.Fatalf("unstamped line did not parse: ok=%v user=%q", ok, user)
+	}
+	if ts.Day() != 12 || ts.Month() != time.March {
+		t.Errorf("timestamp = %v, want dropbear's own when the apiserver supplied none", ts)
+	}
+}
+
+func TestK8sSource_NonLoginLinesAreIgnored(t *testing.T) {
+	src := NewK8sSessionSource(fake.NewSimpleClientset(), "")
+	stamp := time.Now().UTC().Format(time.RFC3339Nano)
+	for _, line := range []string{
+		stamp + " Child connection from 10.0.0.1:54321",
+		stamp + " Exit before auth: Disconnect received",
+		stamp + " Not a log line at all",
+	} {
+		if _, _, _, _, ok := src.ParseLine(line, 2026, time.Time{}); ok {
+			t.Errorf("recorded a login for a line that is not one:\n%s", line)
+		}
+	}
+}
+
+// The read window is an efficiency bound. A box read for the first time gets
+// the lookback; afterwards each read reaches back past the previous one, so a
+// modest clock skew between the node and this process cannot drop a login.
+func TestK8sSource_ReadWindowOverlapsThePreviousRead(t *testing.T) {
+	src := NewK8sSessionSource(fake.NewSimpleClientset(), "").(*k8sSessionSource)
+
+	first := src.sinceFor("ns/pod")
+	if age := time.Since(first); age < k8sLogLookback-time.Minute || age > k8sLogLookback+time.Minute {
+		t.Errorf("first read window is %v back, want ~%v — an unbounded first read pulls a "+
+			"box's whole retained log, and a short one loses what predates it", age, k8sLogLookback)
+	}
+
+	readAt := time.Now()
+	src.markRead("ns/pod", readAt)
+	next := src.sinceFor("ns/pod")
+	if !next.Before(readAt) {
+		t.Errorf("next window starts at %v, not before the last read at %v — with no overlap, "+
+			"clock skew between the node and this process silently drops logins", next, readAt)
+	}
+	if readAt.Sub(next) != k8sLogOverlap {
+		t.Errorf("overlap = %v, want %v", readAt.Sub(next), k8sLogOverlap)
+	}
+}
+
+// A failed read must leave the window open, or the logins it could not fetch
+// are skipped by the read that follows.
+func TestK8sSource_FailedReadDoesNotAdvanceTheWindow(t *testing.T) {
+	src := NewK8sSessionSource(fake.NewSimpleClientset(), "").(*k8sSessionSource)
+
+	// The window checked has to be the one the failing read touched, or the
+	// test passes no matter where the window is advanced.
+	const ref = "malformed"
+
+	before := src.sinceFor(ref)
+	// A malformed ref fails before any apiserver call — the earliest failure
+	// there is, and the one most likely to be mishandled.
+	if _, err := src.ReadSessions(context.Background(), SessionBox{Ref: ref}); err == nil {
+		t.Fatal("expected the malformed ref to fail")
+	}
+	after := src.sinceFor(ref)
+
+	if after.Sub(before) > time.Second {
+		t.Errorf("the window moved from %v to %v despite the read failing — the logins that "+
+			"read missed would never be collected", before, after)
+	}
+}

--- a/internal/audit/session_source.go
+++ b/internal/audit/session_source.go
@@ -32,6 +32,11 @@ type SessionBox struct {
 	Name string
 	// Username is the tenant the box belongs to.
 	Username string
+	// Ref is a handle private to the source that produced this box — a pod
+	// reference, say. Opaque to the collector, which only ever hands it back
+	// to the same source; a backend whose Name is enough to locate the box
+	// leaves it empty.
+	Ref string
 }
 
 // SessionSource supplies session-log lines for one backend.

--- a/pkg/core/box/k8s/boxmeta/boxmeta.go
+++ b/pkg/core/box/k8s/boxmeta/boxmeta.go
@@ -1,0 +1,26 @@
+// Package boxmeta holds the labels and names that identify a K8s box's
+// Kubernetes objects.
+//
+// It is a leaf package on purpose. The daemon creates box pods (pkg/core/box/k8s)
+// and the SSH session collector finds them again (internal/audit), and those two
+// cannot import each other — the box backend reaches the gateway, which reaches
+// the audit store. Without a shared leaf, the collector would have to restate
+// the labels, and a drift between the two copies would show up as the collector
+// finding no boxes at all: a backend reporting no logins is indistinguishable
+// from one nobody logged into, which is the exact failure #1189 exists to fix.
+package boxmeta
+
+const (
+	// ManagedByLabel / ManagedByValue mark every object the K8s box backend
+	// owns.
+	ManagedByLabel = "app.kubernetes.io/managed-by"
+	ManagedByValue = "containarium"
+
+	// TenantLabel carries the tenant a box belongs to. Objects the backend
+	// owns that are not a tenant's box — the gateway, for one — do not have it.
+	TenantLabel = "containarium.dev/tenant"
+
+	// BoxContainerName is the box container inside the pod: the one running
+	// dropbear, and so the one whose log carries the session records.
+	BoxContainerName = "agent-box"
+)

--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"fmt"
+	"github.com/footprintai/containarium/pkg/core/box/k8s/boxmeta"
 	"log"
 	"strings"
 
@@ -69,15 +70,18 @@ const (
 	// enforced at the gateway, not by per-tenant box users.
 	boxSSHUser = "agent"
 
-	managedByLabel       = "app.kubernetes.io/managed-by"
-	managedByValue       = "containarium"
-	tenantLabel          = "containarium.dev/tenant"
+	managedByLabel       = boxmeta.ManagedByLabel
+	managedByValue       = boxmeta.ManagedByValue
+	tenantLabel          = boxmeta.TenantLabel
 	metaAnnotationPrefix = "containarium.dev/meta."
 	gpuCountAnnotation   = "containarium.dev/gpu-count"
 
 	// nvidiaGPUResource is the K8s extended-resource name for NVIDIA GPUs.
 	// A non-zero limit causes the cluster autoscaler to scale up a GPU node pool.
 	nvidiaGPUResource = corev1.ResourceName("nvidia.com/gpu")
+
+	// boxContainerName is the box container in the pod.
+	boxContainerName = boxmeta.BoxContainerName
 
 	authorizedKeysKey = "authorized_keys"
 	// authorizedKeysMount is where the box image (dropbear entrypoint) reads

--- a/pkg/core/box/k8s/sandbox.go
+++ b/pkg/core/box/k8s/sandbox.go
@@ -55,7 +55,7 @@ func sandboxObject(ns string, spec box.BoxSpec, withPVC bool, def memDefaults, o
 	// :2222) is built to run under exactly this.
 	gpuCount := len(spec.GPUs)
 	container := corev1.Container{
-		Name:  "agent-box",
+		Name:  boxContainerName,
 		Image: spec.Image,
 		Ports: []corev1.ContainerPort{{Name: sshPortName, ContainerPort: sshPort, Protocol: corev1.ProtocolTCP}},
 		SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
Stacked on #1268 — review that first; this PR's diff is the second commit.

## Why

A K8s box has no `/var/log/auth.log` to grep. It runs dropbear with logging to stderr, so its session record lives in the pod log and reading it is an apiserver call, not an exec. With no source that knows this, a K8s deployment collected no logins at all — and since the daemon only builds the collector when an incus client is available, it did not even try.

#1267 landed the dropbear parser, #1268 the seam. This is the source that uses both.

## What

Lists pods by the labels the box backend sets, keys each box by **tenant** rather than by pod name, and parses with the dropbear patterns. Pods are replaced on restart and resize; an audit trail whose resource ID moves underneath it cannot answer "who logged into this box".

Two decisions worth calling out:

**The apiserver's timestamp wins.** Each line is requested stamped, and that stamp is preferred over dropbear's own when both are present — dropbear's carries neither a year nor a zone, so a record built from it is reassembled from a guessed year and disagrees with every other view of the same log.

**The read window is an efficiency bound, not de-duplication.** Each read asks for a window rather than the whole retained log, but consecutive windows overlap and a failed read does not advance the mark. De-dup stays in the collector's high-water mark. Using the window to skip lines instead would let clock skew between the node and this process drop a login with no trace.

## boxmeta

The labels and container name move to a leaf package. The backend that creates box pods and the collector that finds them again cannot import each other — the backend reaches the gateway, which reaches the audit store. Without a shared leaf the collector would restate the labels, and drift between the two copies would surface as the collector finding no boxes: indistinguishable from nobody having logged in, which is the failure this issue is about.

## Tests

Driven by the fake clientset: running tenant boxes are found with a usable pod reference, platform-owned pods with no tenant are skipped, pods that cannot serve a log are skipped, a malformed reference is an error rather than a silent empty log, the apiserver stamp is preferred, an unstamped line still parses, and the read window overlaps and does not advance on failure.

Mutation-tested — each of these fails a test: dropping the pod-phase filter, dropping the tenant filter, keying boxes by pod name, preferring dropbear's stamp, removing the window overlap, advancing the window before the read succeeds.

One of these tests was initially vacuous: it checked the window for a different reference than the failing read touched, so it passed under the mutation. Caught by the mutation run and fixed.

## Scope

Wiring — choosing this source when the backend is K8s — is a follow-up, as with the netpolicy reconciler. AC4 (an end-to-end kind test with a real session) is still not runnable in this lane: the box pods there run `pause`, so there is nothing to log into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)