### PR TITLE
feat(server): pick the SSH session source from the box backend (#1189)

### DIFF
--- a/charts/containarium-k8s/templates/clusterrole.yaml
+++ b/charts/containarium-k8s/templates/clusterrole.yaml
@@ -25,7 +25,11 @@ rules:
   - apiGroups: [""]
     resources: [services, pods, persistentvolumeclaims]
     verbs: [get, list, watch, create, update, patch, delete]
-  # Read pod logs / exec for debug commands
+  # Read pod logs / exec for debug commands, and for SSH session audit
+  # (#1189): a K8s box logs its logins to stderr, so pods/log is the audit
+  # trail, not just a debugging convenience. Removing it does not fail
+  # loudly — the collector logs a read error per poll and the fleet records
+  # no logins, which reads exactly like a fleet nobody logged into.
   - apiGroups: [""]
     resources: [pods/log, pods/exec]
     verbs: [get, list, create]

--- a/docs/ISO27001-COMPLIANCE.md
+++ b/docs/ISO27001-COMPLIANCE.md
@@ -84,7 +84,7 @@ This document assesses Containarium against ISO 27001:2022 Annex A controls, tra
 | A.8.12 | Data leakage prevention | Partial | `.gitignore` for secrets, file-based secret storage | Gap: no DLP tooling |
 | A.8.13 | Information backup | Partial | ZFS snapshots, GCP disk persistence on STOP | Gap: no documented backup schedule or restore testing |
 | A.8.14 | Redundancy | Present | Sentinel HA with auto-recovery (`internal/sentinel/`, `docs/SENTINEL-DESIGN.md`) | ~85s recovery time |
-| A.8.15 | Logging | Partial | stdout/stderr via systemd, OpenTelemetry (`internal/metrics/otel.go`), conntrack (`internal/traffic/`), centralized audit log in PostgreSQL (`internal/audit/`) with HTTP request + event bus persistence. **Control-plane API audit covers both backends; in-box SSH session audit is LXC-only** — the collector takes an `*incus.Client` (`internal/audit/ssh_collector.go`), so boxes on the Kubernetes backend record who called the API but not who logged in (#1189). | Needs: session audit on the K8s backend |
+| A.8.15 | Logging | Partial | stdout/stderr via systemd, OpenTelemetry (`internal/metrics/otel.go`), conntrack (`internal/traffic/`), centralized audit log in PostgreSQL (`internal/audit/`) with HTTP request + event bus persistence. **Control-plane API audit and in-box SSH session audit both cover both backends** — the collector reads sessions through a backend-neutral source (`internal/audit/session_source.go`): OpenSSH `auth.log` on LXC, box pod logs on Kubernetes (#1189). Records share one store, one action, and one query surface. | Gap: no SIEM integration (see A.8.16) |
 | A.8.16 | Monitoring activities | Partial | OpenTelemetry metrics, Grafana dashboards, traffic monitoring | Gap: no SIEM integration, no alerting rules |
 | A.8.17 | Clock synchronization | Missing | No NTP configuration documented | Needs: document NTP/chrony setup on VMs |
 | A.8.20 | Network security | Present | GCP firewall rules (`terraform/modules/containarium/main.tf`), source IP restrictions, SSH jump architecture | Well implemented |
@@ -116,7 +116,7 @@ This document assesses Containarium against ISO 27001:2022 Annex A controls, tra
 | H3 | A.8.5 | Implement MFA for admin access | — | `internal/auth/` |
 | ~~H4~~ | ~~A.8.15~~ | ~~Add centralized, tamper-proof audit logging~~ | Done | `internal/audit/` (store, HTTP middleware, event subscriber) |
 | H5 | A.5.24 | Write incident response plan | — | `docs/INCIDENT-RESPONSE.md` |
-| H8 | A.8.15 | Extend in-box SSH session audit to the Kubernetes backend — H4 shipped the central store and control-plane API audit, but the session collector is incus-typed, so K8s boxes log API calls and not logins (#1189) | — | `internal/audit/ssh_collector.go`, `pkg/core/box/k8s/` |
+| ~~H8~~ | ~~A.8.15~~ | ~~Extend in-box SSH session audit to the Kubernetes backend~~ | Done | `internal/audit/session_source.go`, `internal/audit/k8s_session_source.go`, `internal/audit/dropbear_parser.go` |
 | ~~H6~~ | ~~A.8.8~~ | ~~Add automated dependency scanning to CI~~ | Done | `.github/dependabot.yml`, `.github/workflows/security.yml` (Trivy + govulncheck) |
 | ~~H7~~ | ~~A.8.25~~ | ~~Add SAST to CI pipeline~~ | Done | `.github/workflows/security.yml` (gosec with SARIF upload) |
 

--- a/docs/product/agent-substrate-roadmap-position.md
+++ b/docs/product/agent-substrate-roadmap-position.md
@@ -114,7 +114,6 @@ does not.**
 | Gap | Evidence |
 | --- | --- |
 | **eBPF network policy** | `NetworkPolicyEnforcer`'s inspector is `ListContainers() ([]incus.ContainerInfo, error)`; it resolves container-name → host veth ifindex and attaches TCX. Constructed with `networkIncusClient` (`dual_server.go:1303`). No K8s branch exists. |
-| **SSH session audit** | `audit.NewSSHCollector(incusClient *incus.Client, …)`. On K8s you get API-call audit but no in-box SSH login audit. |
 | **Tenant secret delivery** | `incus config set environment.<NAME>=…`, reconciler holds `*incus.Client`. The K8s backend mounts Secrets only for authorized_keys and host keys. |
 
 These are **type-level** dependencies on `pkg/core/incus`, not feature
@@ -146,8 +145,17 @@ idiom to bind to rather than reimplement. That is the "inherit, don't
 invent" posture this note already argues for, so the gaps are consistent
 with the strategy rather than a refutation of it.
 
-Gaps tracked as #1188 (policy-driven K8s NetworkPolicy), #1189 (in-box
-session audit on K8s), #1190 (tenant secret delivery on K8s).
+Gaps tracked as #1188 (policy-driven K8s NetworkPolicy) and #1190 (tenant
+secret delivery on K8s).
+
+#1189 (in-box session audit on K8s) is addressed: the collector now reads
+sessions through a backend-neutral source — OpenSSH `auth.log` on LXC,
+box pod logs on Kubernetes — and both land in the same store under the
+same action. It is listed here as the worked example of what porting one
+of these gaps costs: a parser for the other backend's log format, a
+source interface, and the wiring to choose between them. The type-level
+dependency was the whole of the problem, and it was three PRs of work,
+not a redesign.
 
 ## What this note deliberately does not say
 

--- a/internal/audit/k8s_session_source.go
+++ b/internal/audit/k8s_session_source.go
@@ -99,7 +99,33 @@ func (s *k8sSessionSource) Boxes(ctx context.Context) ([]SessionBox, error) {
 			Ref:      pod.Namespace + "/" + pod.Name,
 		})
 	}
+
+	// Drop windows for pods that no longer exist. The key is the pod, and a
+	// pod is replaced on every restart and resize — so without this the map
+	// gains an entry per box lifetime and never loses one, in a process meant
+	// to run for months.
+	//
+	// Only on a successful list: pruning on a transient empty result would
+	// reset every window to the initial lookback, making the next pass re-read
+	// a day of logs for the whole fleet.
+	s.retainWindows(boxes)
+
 	return boxes, nil
+}
+
+// retainWindows forgets the read window of every box not in the current list.
+func (s *k8sSessionSource) retainWindows(boxes []SessionBox) {
+	live := make(map[string]struct{}, len(boxes))
+	for _, b := range boxes {
+		live[b.Ref] = struct{}{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for ref := range s.lastRead {
+		if _, ok := live[ref]; !ok {
+			delete(s.lastRead, ref)
+		}
+	}
 }
 
 func (s *k8sSessionSource) ReadSessions(ctx context.Context, box SessionBox) (string, error) {

--- a/internal/audit/k8s_session_source_test.go
+++ b/internal/audit/k8s_session_source_test.go
@@ -2,8 +2,12 @@ package audit
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -202,5 +206,54 @@ func TestK8sSource_FailedReadDoesNotAdvanceTheWindow(t *testing.T) {
 	if after.Sub(before) > time.Second {
 		t.Errorf("the window moved from %v to %v despite the read failing — the logins that "+
 			"read missed would never be collected", before, after)
+	}
+}
+
+// The window map is keyed by pod, and a pod is replaced on every restart and
+// resize. Without pruning it gains an entry per box lifetime and never loses
+// one, in a process meant to run for months.
+func TestK8sSource_ForgetsWindowsOfPodsThatAreGone(t *testing.T) {
+	cs := fake.NewSimpleClientset(boxPod("tenant-alice", "alice-new", "alice", corev1.PodRunning))
+	src := NewK8sSessionSource(cs, "").(*k8sSessionSource)
+
+	// A window left behind by a pod that has since been replaced.
+	src.markRead("tenant-alice/alice-old", time.Now())
+	src.markRead("tenant-alice/alice-new", time.Now())
+
+	if _, err := src.Boxes(context.Background()); err != nil {
+		t.Fatalf("boxes: %v", err)
+	}
+
+	src.mu.Lock()
+	defer src.mu.Unlock()
+	if _, stale := src.lastRead["tenant-alice/alice-old"]; stale {
+		t.Error("kept the window of a pod that no longer exists — one entry per box lifetime, " +
+			"never released, in a daemon that runs for months")
+	}
+	if _, live := src.lastRead["tenant-alice/alice-new"]; !live {
+		t.Error("dropped the window of a pod that still exists — the next read would pull the " +
+			"full lookback again for every box on every pass")
+	}
+}
+
+// A failed listing must not prune: resetting every window to the initial
+// lookback makes the next pass re-read a day of logs for the whole fleet.
+func TestK8sSource_KeepsWindowsWhenListingFails(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("apiserver down")
+	})
+	src := NewK8sSessionSource(cs, "").(*k8sSessionSource)
+	src.markRead("tenant-alice/alice-abc", time.Now())
+
+	if _, err := src.Boxes(context.Background()); err == nil {
+		t.Fatal("expected the listing to fail")
+	}
+
+	src.mu.Lock()
+	defer src.mu.Unlock()
+	if _, ok := src.lastRead["tenant-alice/alice-abc"]; !ok {
+		t.Error("a failed listing dropped every read window — the next pass would re-read the " +
+			"full lookback for the whole fleet")
 	}
 }

--- a/internal/audit/session_source_test.go
+++ b/internal/audit/session_source_test.go
@@ -176,3 +176,72 @@ func TestCollector_BoxListFailureIsSurvivable(t *testing.T) {
 		t.Errorf("recorded %d entries despite being unable to list boxes", len(entries))
 	}
 }
+
+// #1189 AC1/AC3: a K8s login must produce a record "equivalent in shape to
+// the LXC path" and be "indistinguishable by consumer".
+//
+// Shape equivalence is the claim that is easy to believe and easy to get
+// wrong — two sources, two log formats, two parsers, one record type. A
+// consumer filtering on Action, or grouping by SourceIP, must not be able to
+// tell which backend a record came from.
+func TestCollector_BothBackendsProduceTheSameRecordShape(t *testing.T) {
+	// An sshd line as the LXC path reads it.
+	lxcStore := newAuditStore(t)
+	lxcSrc := &fakeSource{
+		boxes: []SessionBox{{Name: "alice-container", Username: "alice"}},
+		logs: map[string]string{
+			"alice-container": `Mar 12 14:30:01 host sshd[123]: Accepted publickey for alice from 10.0.0.7 port 54321 ssh2: ED25519 SHA256:abc`,
+		},
+		parse: func(line string, year int, _ time.Time) (time.Time, string, string, string, bool) {
+			return parseAuthLogLine(line, year)
+		},
+	}
+	NewSSHCollectorWithSource(lxcSrc, lxcStore).collectAll(context.Background())
+
+	// The same login as the K8s path reads it: a stamped pod-log line.
+	k8sStore := newAuditStore(t)
+	k8sSrc := &fakeSource{
+		boxes: []SessionBox{{Name: "alice", Username: "alice", Ref: "tenant-alice/alice-abc"}},
+		logs: map[string]string{
+			"alice": time.Date(2026, time.March, 12, 14, 30, 1, 0, time.UTC).Format(time.RFC3339Nano) +
+				` Pubkey auth succeeded for 'alice' with ssh-ed25519 key SHA256:abc from 10.0.0.7:54321`,
+		},
+		parse: NewK8sSessionSource(nil, "").ParseLine,
+	}
+	NewSSHCollectorWithSource(k8sSrc, k8sStore).collectAll(context.Background())
+
+	if len(lxcStore.entries) != 1 || len(k8sStore.entries) != 1 {
+		t.Fatalf("recorded %d LXC and %d K8s entries, want one each",
+			len(lxcStore.entries), len(k8sStore.entries))
+	}
+	lxc, k8s := lxcStore.entries[0], k8sStore.entries[0]
+
+	// Action and principal come from the collector, not from either source,
+	// so comparing them across backends could never fail. What is worth
+	// pinning is the value itself: it is what a consumer filters on, and
+	// changing it would break the query for both backends at once.
+	for name, e := range map[string]*AuditEntry{"LXC": lxc, "K8s": k8s} {
+		if e.Action != "ssh_login" {
+			t.Errorf("%s action = %q, want ssh_login — the value /v1/audit/logs consumers "+
+				"filter on", name, e.Action)
+		}
+		if e.Username != "alice" {
+			t.Errorf("%s principal = %q, want the tenant", name, e.Username)
+		}
+	}
+	// Source is what a consumer groups by. host:port on one side and host on
+	// the other would split one client across two buckets.
+	if lxc.SourceIP != k8s.SourceIP {
+		t.Errorf("source differs by backend: %q vs %q — grouping by source would split one "+
+			"client into two", lxc.SourceIP, k8s.SourceIP)
+	}
+	if !lxc.Timestamp.Equal(k8s.Timestamp) {
+		t.Errorf("timestamp differs for the same login: %v vs %v", lxc.Timestamp, k8s.Timestamp)
+	}
+	// The box identifier is legitimately different — one names a container,
+	// the other a tenant — but neither may be empty, or the record cannot say
+	// which box was accessed.
+	if lxc.ResourceID == "" || k8s.ResourceID == "" {
+		t.Errorf("a record does not name its box: LXC %q, K8s %q", lxc.ResourceID, k8s.ResourceID)
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"k8s.io/client-go/kubernetes"
 	"log"
 	"net"
 	"net/http"
@@ -1265,15 +1266,27 @@ skipAppHosting:
 		}
 	}
 
-	// Setup SSH login collector (requires audit store + incus client)
+	// Setup SSH login collector. Which source it reads depends on the box
+	// backend: an LXC box keeps sessions in /var/log/auth.log and is read by
+	// exec, a K8s box logs them to stderr and is read from the pod log
+	// (#1189). Before this, the collector was built only when an incus client
+	// could be created, so a K8s deployment recorded no logins at all — which
+	// reads exactly like a fleet nobody logged into.
 	var sshCollector *audit.SSHCollector
 	if auditStore != nil {
-		sshIncusClient, incusErr := incus.New()
-		if incusErr != nil {
+		if containerServer != nil && containerServer.boxes().Kind() == box.KindK8s {
+			if backend, ok := containerServer.boxes().(k8sClientsetProvider); ok {
+				sshCollector = audit.NewSSHCollectorWithSource(
+					audit.NewK8sSessionSource(backend.Clientset(), ""), auditStore)
+				log.Printf("SSH login collector configured (K8s pod logs)")
+			} else {
+				log.Printf("Warning: K8s box backend exposes no clientset; SSH logins will not be audited")
+			}
+		} else if sshIncusClient, incusErr := incus.New(); incusErr != nil {
 			log.Printf("Warning: Failed to create incus client for SSH collector: %v", incusErr)
 		} else {
 			sshCollector = audit.NewSSHCollector(sshIncusClient, auditStore)
-			log.Printf("SSH login collector configured")
+			log.Printf("SSH login collector configured (LXC auth.log)")
 		}
 	}
 
@@ -2542,4 +2555,11 @@ func envTruthy(v string) bool {
 		return true
 	}
 	return false
+}
+
+// k8sClientsetProvider is the K8s box backend's clientset accessor, asserted
+// for rather than added to the BoxBackend contract — reading a pod log is not
+// an operation every backend has (#1189).
+type k8sClientsetProvider interface {
+	Clientset() kubernetes.Interface
 }

--- a/internal/server/dual_server_wiring_test.go
+++ b/internal/server/dual_server_wiring_test.go
@@ -198,3 +198,30 @@ func TestNewDualServerWiresK8sNetworkPolicyReconciler(t *testing.T) {
 			"and never run, which looks identical to a daemon with no tenant policies (#1188)")
 	}
 }
+
+// #1189: on a K8s deployment the SSH collector used to be built only if an
+// incus client could be created — which on a K8s host it cannot. The result
+// was a fleet that recorded no logins at all, indistinguishable from one
+// nobody logged into. The guard is that the K8s branch exists and picks the
+// pod-log source.
+func TestNewDualServerWiresTheK8sSessionSource(t *testing.T) {
+	newCalls := dualServerFuncCalls(t, "NewDualServer")
+	if indexOfCall(newCalls, "NewK8sSessionSource") < 0 {
+		t.Error("NewDualServer never constructs the K8s session source — a K8s deployment would " +
+			"record no SSH logins, which reads exactly like a fleet nobody logged into (#1189)")
+	}
+	if indexOfCall(newCalls, "NewSSHCollector") < 0 {
+		t.Error("NewDualServer no longer constructs the LXC SSH collector — the incus path would " +
+			"stop auditing logins (#1189)")
+	}
+
+	// Both sources must remain reachable: a single collector built from
+	// whichever source happens to be first would leave one backend unaudited.
+	if !dualServerSourceContains(t, "containerServer.boxes().Kind() == box.KindK8s") {
+		t.Error("the SSH collector no longer selects its source by backend kind")
+	}
+	if !dualServerSourceContains(t, "audit.NewSSHCollectorWithSource(") {
+		t.Error("the K8s branch no longer builds the collector from a source — it would fall back " +
+			"to the incus constructor, which cannot reach a K8s box (#1189)")
+	}
+}

--- a/pkg/core/box/k8s/k8s.go
+++ b/pkg/core/box/k8s/k8s.go
@@ -227,6 +227,14 @@ func buildRestConfig(kubeconfig string) (*rest.Config, error) {
 
 func (b *Backend) Kind() box.BackendKind { return box.KindK8s }
 
+// Clientset exposes the backend's Kubernetes client.
+//
+// Narrow on purpose: the SSH session collector (#1189) has to read box pod
+// logs, which is an apiserver call and not something the BoxBackend contract
+// covers. Rather than widen that contract with a method only one caller
+// wants, the daemon type-asserts for this when the backend is K8s.
+func (b *Backend) Clientset() kubernetes.Interface { return b.clientset }
+
 func (b *Backend) namespaceFor(tenant string) string {
 	return b.cfg.TenantNamespacePrefix + tenant
 }


### PR DESCRIPTION
Completes #1189, after #1267 (dropbear parser), #1268 (source seam) and #1270 (the K8s source).

## The bug this closes

The collector was built only when an incus client could be created:

```go
sshIncusClient, incusErr := incus.New()
if incusErr != nil {
    log.Printf("Warning: Failed to create incus client for SSH collector: %v", incusErr)
} else { ... }
```

On a K8s host that client cannot be created, so the daemon logged a warning and carried on with **no collector at all**. The fleet recorded zero SSH logins — which in the audit trail is indistinguishable from a fleet nobody logged into. Every piece landed so far was unreachable until this.

Now the source is chosen by backend kind: pod logs for K8s, `auth.log` over exec for LXC. The LXC path is unchanged.

The clientset is reached by asserting for a narrow accessor rather than by widening `BoxBackend`. Reading a pod log is not an operation every backend has, and one caller does not justify the contract change.

## Tests

A wiring guard covering **both** branches — a change leaving only one source reachable would leave the other backend unaudited, and nothing about that failure is visible at runtime. Mutation-tested: reverting to the incus-only construction (the original bug) and having the K8s branch fall back to the incus constructor each fail it.

Also a cross-backend equivalence test for AC1/AC3. The assertions that can actually fail are the source-derived ones — K8s keeping dropbear's `host:port` would split one client into two buckets when grouping by source, and ignoring the apiserver's stamp would date the same login differently on each backend. Both fail the test. Action and principal are set by the collector for both paths, so comparing them across backends could never fail; they pin the value instead, since that is what `/v1/audit/logs` consumers filter on.

## Docs

A.8.15 said session audit was LXC-only and the roadmap note listed it among the incus-typed pieces that do not port. Both were true when written and are not after this. The A.8.15 gap column moves to what is still missing there (SIEM integration) rather than restating a control that now holds.

The roadmap note keeps #1189 rather than deleting it, as the worked example of what porting one of these gaps costs — a parser, a source interface, and the wiring to choose between them. A reader deciding whether the remaining two are tractable is better served by one worked case than by a shorter list.

## What is still open

AC4 — an end-to-end kind test asserting a real session produces a record — is not runnable in this lane: the kind box pods run `pause`, so there is nothing to SSH into. That needs the real box image in CI and is worth its own issue rather than being quietly dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)