### PR TITLE
ci(k8s): fail the lane if the egress-enforcement test skips (#1188)

### DIFF
--- a/scripts/k8s-e2e.sh
+++ b/scripts/k8s-e2e.sh
@@ -100,6 +100,34 @@ kubectl -n agent-sandbox-system wait --for=condition=available \
   deployment/agent-sandbox-controller --timeout=180s
 
 echo "==> running K8s agent-box e2e (reconciler vs. the kind apiserver)"
-CONTAINARIUM_K8S_E2E=1 go test -tags k8s -run TestE2E -timeout 12m -v ./pkg/core/box/k8s/
+# pipefail is already set above, so piping through tee still fails the script
+# when go test does.
+E2E_LOG="$(mktemp)"
+trap 'rm -f "$E2E_LOG"' EXIT
+CONTAINARIUM_K8S_E2E=1 go test -tags k8s -run TestE2E -timeout 12m -v \
+  ./pkg/core/box/k8s/ 2>&1 | tee "$E2E_LOG"
+
+# The enforcement test skips itself under a CNI that does not enforce
+# NetworkPolicy, which is the right behaviour — a vacuous pass is worse than
+# an honest skip (#1234). What is NOT right is the lane staying green while
+# it happens: "no NetworkPolicy assertions ran" then looks exactly like
+# "NetworkPolicy is enforced".
+#
+# So the skip is honest at the test level and fatal at the lane level. If you
+# genuinely want the fast local loop, run the script with E2E_CNI=kindnet —
+# that path is expected to skip and is not gated here.
+if [ "$E2E_CNI" = "calico" ]; then
+  if grep -q -- "--- SKIP: TestE2E_TenantEgressAllowlistIsEnforced" "$E2E_LOG"; then
+    echo "FAIL: the egress-enforcement test skipped under Calico, which enforces" >&2
+    echo "      NetworkPolicy. A green lane here would mean the one assertion" >&2
+    echo "      #1188 turns on never ran." >&2
+    exit 1
+  fi
+  if ! grep -q -- "--- PASS: TestE2E_TenantEgressAllowlistIsEnforced" "$E2E_LOG"; then
+    echo "FAIL: the egress-enforcement test did not run at all — renamed, retagged," >&2
+    echo "      or filtered out by -run. It is the test #1188 turns on." >&2
+    exit 1
+  fi
+fi
 
 echo "==> e2e passed"


### PR DESCRIPTION
## Why

`TestE2E_TenantEgressAllowlistIsEnforced` skips itself under a CNI that does not enforce NetworkPolicy. That is correct at the test level — an honest skip beats a vacuous pass, which is exactly how #1195 shipped unvalidated and became #1234.

What was not correct is that the lane stayed green while it happened. "No NetworkPolicy assertions ran" then looks identical to "NetworkPolicy is enforced" — the same shape of failure the test exists to rule out, one level up.

The lane runs Calico by default today, so the test does run and #1188's AC5 genuinely holds. This guards the property rather than relying on the default staying put: a future `E2E_CNI` change, a rename, a retag, or a `-run` filter would each turn the assertion off with no visible signal.

## What

Under Calico, the lane now fails if the enforcement test skipped, and fails if it did not run at all. `E2E_CNI=kindnet` is the documented fast local loop, is expected to skip, and is not gated.

## Verifying the guard

A guard that is never exercised is the thing it is meant to prevent, so I ran its logic against four fixtures rather than assuming:

| fixture | result |
| --- | --- |
| `--- PASS` under Calico | green |
| `--- SKIP` under Calico | **fails** |
| test absent from output | **fails** |
| `--- SKIP` under kindnet | green (deliberate escape hatch) |

This PR touches `scripts/k8s-e2e.sh`, which is in the lane's path filter, so the kind e2e runs here and exercises the change directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)