### PR TITLE
feat(k8s): materialize tenant secrets into the box (#1190)

### DIFF
--- a/pkg/core/box/k8s/objects.go
+++ b/pkg/core/box/k8s/objects.go
@@ -178,6 +178,7 @@ func normalizeIncusDiskSuffix(disk string) (normalized string, ok bool) {
 
 func int64p(i int64) *int64 { return &i }
 func boolp(b bool) *bool    { return &b }
+func int32p(i int32) *int32 { return &i }
 
 // boxLabels are the identity labels shared by all of a tenant box's objects;
 // the pod selector and the cross-namespace List selector both key off them.

--- a/pkg/core/box/k8s/sandbox.go
+++ b/pkg/core/box/k8s/sandbox.go
@@ -54,6 +54,10 @@ func sandboxObject(ns string, spec box.BoxSpec, withPVC bool, def memDefaults, o
 	// all capabilities dropped, default seccomp. The box image (dropbear on
 	// :2222) is built to run under exactly this.
 	gpuCount := len(spec.GPUs)
+	// Tenant secrets (#1190): mounted rather than projected as env vars,
+	// because a Secret update does not reach a running pod's environment but
+	// does reach its volumes. Optional, so a box with no secrets still starts.
+	secretsVolume, secretsMount := tenantSecretsVolumeFor(spec.Ref.Tenant)
 	container := corev1.Container{
 		Name:  boxContainerName,
 		Image: spec.Image,
@@ -71,6 +75,7 @@ func sandboxObject(ns string, spec box.BoxSpec, withPVC bool, def memDefaults, o
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: authorizedKeysVolume, MountPath: authorizedKeysMount, ReadOnly: true},
 			{Name: hostKeyVolume, MountPath: hostKeyMount, ReadOnly: true},
+			secretsMount,
 		},
 	}
 	if res := resourceRequirements(spec.Resources, gpuCount, def); res != nil {
@@ -85,6 +90,7 @@ func sandboxObject(ns string, spec box.BoxSpec, withPVC bool, def memDefaults, o
 	}
 
 	volumes := []corev1.Volume{
+		secretsVolume,
 		{
 			Name: authorizedKeysVolume,
 			VolumeSource: corev1.VolumeSource{

--- a/pkg/core/box/k8s/tenant_secrets.go
+++ b/pkg/core/box/k8s/tenant_secrets.go
@@ -1,0 +1,147 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Delivering tenant secrets to a K8s box (#1190).
+//
+// On LXC a secret is delivered by `incus config set environment.<NAME>` (env
+// mode) or by writing /run/secrets/<NAME> into the container's tmpfs (file
+// mode). Neither has a K8s equivalent, so `containarium secret set` succeeded
+// and the value never reached the box — the API call looks identical on both
+// backends.
+//
+// The delivery here is a per-tenant Secret mounted into the box, and the
+// choice of a mount over env vars is forced rather than stylistic:
+//
+//   - A container's environment is fixed when it starts. Updating a Secret
+//     that was projected with envFrom does NOT change a running pod; the pod
+//     has to be recreated. That fails the requirement that RefreshSecrets
+//     update a running box.
+//   - A Secret *volume* is refreshed in place by the kubelet, so a new
+//     session sees the new value with no restart. That is also what the LXC
+//     path actually promises — its own RefreshSecrets message says "new execs
+//     will see updated values", not that running processes are re-parented.
+//
+// So the mount is what makes the two backends agree, and env projection is
+// what would have made them differ while looking correct.
+//
+// The mount is tmpfs (Kubernetes backs Secret volumes with memory), which
+// preserves the ephemeral-disposal property file-mode secrets have on LXC:
+// when the pod goes, the plaintext goes with it. Nothing is written to the
+// box's PVC or into the Sandbox CR — the CR carries the Secret's name, never
+// its contents.
+
+const (
+	// tenantSecretsVolume is the pod volume carrying the tenant's secrets.
+	tenantSecretsVolume = "tenant-secrets"
+	// TenantSecretsMount is where the box sees them, one file per secret.
+	// Same path as the LXC file-delivery mode, so anything reading secrets
+	// from disk works unchanged on both backends.
+	TenantSecretsMount = "/run/secrets"
+)
+
+// tenantSecretsName is the per-tenant Secret holding delivered secrets.
+//
+// Distinct from the authorized-keys and host-key Secrets: those are SSH
+// plumbing the platform owns, this is tenant data. Mixing them would mean a
+// tenant secret named `authorized_keys` could lock a box out.
+func tenantSecretsName(tenant string) string { return tenant + "-secrets" }
+
+// tenantSecretsObject builds the per-tenant secrets object.
+func tenantSecretsObject(ns, tenant string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tenantSecretsName(tenant),
+			Namespace: ns,
+			Labels:    boxLabels(tenant),
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+}
+
+// ApplyTenantSecrets materializes a tenant's secrets into their box.
+//
+// An empty map deletes the Secret rather than leaving an empty one: a
+// deleted secret must stop being readable in the box, and an empty-but-present
+// Secret keeps the mount alive with stale files until the kubelet resyncs.
+func (b *Backend) ApplyTenantSecrets(ctx context.Context, tenant string, data map[string][]byte) error {
+	if tenant == "" {
+		return fmt.Errorf("k8s: tenant is required")
+	}
+
+	ns := b.cfg.TenantNamespacePrefix + tenant
+	secrets := b.clientset.CoreV1().Secrets(ns)
+	name := tenantSecretsName(tenant)
+
+	if len(data) == 0 {
+		err := secrets.Delete(ctx, name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("k8s: delete tenant secrets for %q: %w", tenant, err)
+		}
+		return nil
+	}
+
+	desired := tenantSecretsObject(ns, tenant, data)
+	existing, err := secrets.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			if _, err := secrets.Create(ctx, desired, metav1.CreateOptions{}); err != nil {
+				return fmt.Errorf("k8s: create tenant secrets for %q: %w", tenant, err)
+			}
+			return nil
+		}
+		return fmt.Errorf("k8s: read tenant secrets for %q: %w", tenant, err)
+	}
+
+	// Update carries the whole Data map, so a secret deleted upstream
+	// disappears here. Merging instead would leave a deleted secret readable
+	// in the box for as long as the box lives.
+	updated := existing.DeepCopy()
+	updated.Data = data
+	updated.Type = corev1.SecretTypeOpaque
+	if updated.Labels == nil {
+		updated.Labels = map[string]string{}
+	}
+	for k, v := range boxLabels(tenant) {
+		updated.Labels[k] = v
+	}
+	if _, err := secrets.Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("k8s: update tenant secrets for %q: %w", tenant, err)
+	}
+	return nil
+}
+
+// tenantSecretsVolumeFor builds the pod volume and its mount.
+//
+// Optional, because a box with no secrets must still start. A required volume
+// whose Secret does not exist leaves the pod in ContainerCreating forever —
+// so the common case (a tenant who has set no secrets) would be a box that
+// never comes up. The kubelet populates the mount if the Secret appears
+// later, which is exactly the first `secret set` on a running box.
+func tenantSecretsVolumeFor(tenant string) (corev1.Volume, corev1.VolumeMount) {
+	optional := true
+	return corev1.Volume{
+			Name: tenantSecretsVolume,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: tenantSecretsName(tenant),
+					Optional:   &optional,
+					// 0400: readable by the box's user, by nobody else, and
+					// never executable.
+					DefaultMode: int32p(0o400),
+				},
+			},
+		}, corev1.VolumeMount{
+			Name:      tenantSecretsVolume,
+			MountPath: TenantSecretsMount,
+			ReadOnly:  true,
+		}
+}

--- a/pkg/core/box/k8s/tenant_secrets_test.go
+++ b/pkg/core/box/k8s/tenant_secrets_test.go
@@ -1,0 +1,213 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/footprintai/containarium/pkg/core/box"
+)
+
+// sandboxPodSpecForTest returns the pod spec the backend would create.
+func sandboxPodSpecForTest(t *testing.T, spec box.BoxSpec) corev1.PodSpec {
+	t.Helper()
+	sb := sandboxObject("tenant-"+spec.Ref.Tenant, spec, false, memDefaults{}, podOptions{})
+	podSpec := sb.Spec.SandboxBlueprint.PodTemplate.Spec
+	if len(podSpec.Containers) != 1 {
+		t.Fatalf("want 1 container, got %d", len(podSpec.Containers))
+	}
+	return podSpec
+}
+
+func secretsBackend() *Backend {
+	return NewWithClientset(fake.NewSimpleClientset(), nil, Config{TenantNamespacePrefix: "tenant-"})
+}
+
+func getTenantSecret(t *testing.T, b *Backend, tenant string) (*corev1.Secret, error) {
+	t.Helper()
+	return b.clientset.CoreV1().Secrets("tenant-"+tenant).
+		Get(context.Background(), tenantSecretsName(tenant), metav1.GetOptions{})
+}
+
+func TestApplyTenantSecrets_CreatesTheSecret(t *testing.T) {
+	b := secretsBackend()
+	err := b.ApplyTenantSecrets(context.Background(), "alice", map[string][]byte{
+		"API_TOKEN": []byte("s3cret"),
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	got, err := getTenantSecret(t, b, "alice")
+	if err != nil {
+		t.Fatalf("secret was not created: %v", err)
+	}
+	if string(got.Data["API_TOKEN"]) != "s3cret" {
+		t.Errorf("value = %q, want the secret — `secret set` succeeding while the value never "+
+			"reaches the box is the whole of #1190", got.Data["API_TOKEN"])
+	}
+}
+
+// A changed value must replace the old one. This is what RefreshSecrets
+// depends on, and the kubelet propagates it into a running pod's mount.
+func TestApplyTenantSecrets_UpdatesAnExistingValue(t *testing.T) {
+	b := secretsBackend()
+	ctx := context.Background()
+	if err := b.ApplyTenantSecrets(ctx, "alice", map[string][]byte{"TOKEN": []byte("old")}); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if err := b.ApplyTenantSecrets(ctx, "alice", map[string][]byte{"TOKEN": []byte("new")}); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+
+	got, _ := getTenantSecret(t, b, "alice")
+	if string(got.Data["TOKEN"]) != "new" {
+		t.Errorf("value = %q, want the updated one", got.Data["TOKEN"])
+	}
+}
+
+// A secret deleted upstream must stop being readable in the box. Merging into
+// the existing Data would leave it there for the life of the box.
+func TestApplyTenantSecrets_RemovesADeletedSecret(t *testing.T) {
+	b := secretsBackend()
+	ctx := context.Background()
+	if err := b.ApplyTenantSecrets(ctx, "alice", map[string][]byte{
+		"KEEP": []byte("a"), "DROP": []byte("b"),
+	}); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	if err := b.ApplyTenantSecrets(ctx, "alice", map[string][]byte{"KEEP": []byte("a")}); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+
+	got, _ := getTenantSecret(t, b, "alice")
+	if _, still := got.Data["DROP"]; still {
+		t.Error("a deleted secret is still readable in the box — deletion that leaves the value " +
+			"in place is worse than deletion that fails, because it reports success")
+	}
+	if string(got.Data["KEEP"]) != "a" {
+		t.Error("deleting one secret removed another")
+	}
+}
+
+// Deleting the last secret removes the object rather than leaving an empty
+// one, so nothing stale remains mounted.
+func TestApplyTenantSecrets_DeletingTheLastSecretRemovesTheObject(t *testing.T) {
+	b := secretsBackend()
+	ctx := context.Background()
+	if err := b.ApplyTenantSecrets(ctx, "alice", map[string][]byte{"TOKEN": []byte("v")}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if err := b.ApplyTenantSecrets(ctx, "alice", nil); err != nil {
+		t.Fatalf("apply empty: %v", err)
+	}
+
+	if _, err := getTenantSecret(t, b, "alice"); !apierrors.IsNotFound(err) {
+		t.Errorf("the secret object survived with no secrets in it (err=%v)", err)
+	}
+}
+
+// Applying nothing to a tenant that never had secrets is a no-op, not an
+// error — the reconciler runs this path on every pass for every tenant.
+func TestApplyTenantSecrets_EmptyForAnUnknownTenantIsNotAnError(t *testing.T) {
+	if err := secretsBackend().ApplyTenantSecrets(context.Background(), "nobody", nil); err != nil {
+		t.Errorf("apply: %v — the reconciler would log an error per tenant per pass", err)
+	}
+}
+
+func TestApplyTenantSecrets_RequiresATenant(t *testing.T) {
+	if err := secretsBackend().ApplyTenantSecrets(context.Background(), "", map[string][]byte{
+		"A": []byte("b"),
+	}); err == nil {
+		t.Error("an empty tenant was accepted — the secret would land in a namespace built from " +
+			"an empty name")
+	}
+}
+
+// The tenant's secrets must not share an object with the platform's SSH
+// plumbing: a tenant secret named `authorized_keys` would otherwise be able
+// to overwrite the box's keys.
+func TestTenantSecretsAreSeparateFromTheSSHPlumbing(t *testing.T) {
+	tenant := "alice"
+	if tenantSecretsName(tenant) == secretName(tenant) {
+		t.Error("tenant secrets share the authorized-keys object — a secret named " +
+			"authorized_keys could lock the box out or let anyone in")
+	}
+	if tenantSecretsName(tenant) == hostKeySecretName(tenant) {
+		t.Error("tenant secrets share the host-key object")
+	}
+}
+
+// --- pod wiring -------------------------------------------------------
+
+// The mount, not env projection, is what makes RefreshSecrets reach a running
+// box: a Secret update never changes a running container's environment, but
+// the kubelet does refresh its volumes.
+func TestBoxPodMountsTenantSecretsAsAVolume(t *testing.T) {
+	spec := box.BoxSpec{Ref: box.BoxRef{Tenant: "alice"}, Image: "img"}
+	pod := sandboxPodSpecForTest(t, spec)
+
+	var mount *corev1.VolumeMount
+	for i := range pod.Containers[0].VolumeMounts {
+		if pod.Containers[0].VolumeMounts[i].Name == tenantSecretsVolume {
+			mount = &pod.Containers[0].VolumeMounts[i]
+		}
+	}
+	if mount == nil {
+		t.Fatal("the box mounts no tenant-secrets volume — secrets set through the API would " +
+			"never reach it (#1190)")
+	}
+	if mount.MountPath != TenantSecretsMount {
+		t.Errorf("mount path = %q, want %q to match the LXC file-delivery path", mount.MountPath, TenantSecretsMount)
+	}
+	if !mount.ReadOnly {
+		t.Error("the secrets mount is writable — the box could rewrite its own secrets")
+	}
+
+	var vol *corev1.Volume
+	for i := range pod.Volumes {
+		if pod.Volumes[i].Name == tenantSecretsVolume {
+			vol = &pod.Volumes[i]
+		}
+	}
+	if vol == nil || vol.Secret == nil {
+		t.Fatal("the tenant-secrets volume is not backed by a Secret")
+	}
+	if vol.Secret.SecretName != tenantSecretsName("alice") {
+		t.Errorf("volume references %q, want the tenant's secrets object", vol.Secret.SecretName)
+	}
+	// A required volume whose Secret does not exist leaves the pod in
+	// ContainerCreating forever — so every box belonging to a tenant who has
+	// set no secrets would never start.
+	if vol.Secret.Optional == nil || !*vol.Secret.Optional {
+		t.Error("the secrets volume is required — a tenant with no secrets would get a box that " +
+			"never leaves ContainerCreating")
+	}
+	if vol.Secret.DefaultMode == nil || *vol.Secret.DefaultMode != 0o400 {
+		t.Errorf("secret file mode = %v, want 0400", vol.Secret.DefaultMode)
+	}
+}
+
+// Secrets must not be projected into the container's environment from the
+// pod spec: that is the path that cannot be refreshed without a restart, and
+// it puts the values where `kubectl describe pod` shows them.
+func TestBoxPodDoesNotProjectSecretsIntoTheEnvironment(t *testing.T) {
+	spec := box.BoxSpec{Ref: box.BoxRef{Tenant: "alice"}, Image: "img"}
+	pod := sandboxPodSpecForTest(t, spec)
+
+	c := pod.Containers[0]
+	if len(c.EnvFrom) > 0 {
+		t.Errorf("the container uses envFrom (%d source(s)) — env projection cannot be refreshed "+
+			"without recreating the pod, which is what #1190 AC2 rules out", len(c.EnvFrom))
+	}
+	for _, e := range c.Env {
+		if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+			t.Errorf("env %q is projected from a Secret — it would be fixed at container start "+
+				"and stale after any refresh", e.Name)
+		}
+	}
+}

--- a/pkg/core/box/k8s/tenant_secrets_test.go
+++ b/pkg/core/box/k8s/tenant_secrets_test.go
@@ -16,7 +16,7 @@ import (
 func sandboxPodSpecForTest(t *testing.T, spec box.BoxSpec) corev1.PodSpec {
 	t.Helper()
 	sb := sandboxObject("tenant-"+spec.Ref.Tenant, spec, false, memDefaults{}, podOptions{})
-	podSpec := sb.Spec.SandboxBlueprint.PodTemplate.Spec
+	podSpec := sb.Spec.PodTemplate.Spec
 	if len(podSpec.Containers) != 1 {
 		t.Fatalf("want 1 container, got %d", len(podSpec.Containers))
 	}


### PR DESCRIPTION
First of three for #1190. This is the K8s-side delivery mechanism; the daemon wiring and the session-environment piece follow.

## The bug

`containarium secret set` succeeds on a K8s box and the value never arrives. Delivery is incus-native — `incus config set environment.<NAME>` for env-mode rows, a tmpfs write for file-mode ones — and neither has a K8s equivalent. Same silent asymmetry as #1188 and #1189: the API call looks identical on both backends.

## Why a mount and not env vars

The issue proposes projecting secrets as env vars. That does not satisfy AC2, so this takes the other route:

- A container's environment is **fixed when it starts**. Updating a Secret projected with `envFrom` does not change a running pod — it has to be recreated. `RefreshSecrets` could not reach a running box.
- A Secret **volume** is refreshed in place by the kubelet, so a new session sees the new value with no restart.

That second behaviour is also what the LXC path actually promises. Its own refresh message says *"new execs will see updated values"* — not that already-running processes are re-parented. So the mount is what makes the two backends agree; env projection is what would have made them differ while looking correct.

Two tests pin this: one asserts the mount exists, the other asserts nothing is projected into the environment from the pod spec — including `envFrom`, since that is the shape that silently reintroduces the problem.

## Details worth review

**The volume is optional.** A required volume whose Secret does not exist leaves the pod in `ContainerCreating` forever, so every box belonging to a tenant who has set no secrets would never start. The kubelet populates the mount if the Secret appears later, which is the first `secret set` on a running box.

**An update carries the whole `Data` map**, and emptying it deletes the object rather than leaving an empty one. Merging would leave a deleted secret readable for the life of the box — a deletion that reports success while the value stays put is worse than one that fails.

**Tenant secrets get their own object**, not a shared one with the authorized-keys and host-key Secrets. Sharing would let a tenant secret named `authorized_keys` lock the box out, or let anyone in.

**Mount path is `/run/secrets`**, matching LXC file-delivery, so anything reading secrets from disk works unchanged on both backends. Kubernetes backs Secret volumes with tmpfs, which preserves the ephemeral-disposal property file mode has on LXC. Nothing lands on the PVC or in the Sandbox CR (AC4) — the CR carries the Secret's name, never its contents.

Mutation-tested: merging instead of replacing, leaving an empty Secret, making the volume required, and dropping the mount entirely each fail a test.

## Still to come

- Daemon wiring: a delivery seam so `SecretsService` and the reconciler drive this on K8s instead of `*incus.Client` (AC1, AC2, AC3).
- The box image sourcing `/run/secrets` per session, so env-mode secrets appear in the session environment rather than only as files (AC1).
- The threat-model note the issue asks for: a K8s Secret is base64, not encrypted, unless the cluster has encryption at rest configured. That is weaker than the KMS at-rest guarantee and belongs in the docs as an operator responsibility rather than silently assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)