### PR TITLE
feat(agent-box): build the session environment from mounted secrets (#1190)

### DIFF
--- a/images/agent-box/Dockerfile
+++ b/images/agent-box/Dockerfile
@@ -35,14 +35,24 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends dropbear-bin ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --create-home --uid 1000 --shell /bin/bash agent \
-    && mkdir -p /home/agent/.ssh /etc/agent-box \
+    && mkdir -p /home/agent/.ssh /etc/agent-box /usr/local/lib/containarium \
     && chown -R agent:agent /home/agent /etc/agent-box
 
 COPY --from=build /out/agent-box /usr/local/bin/agent-box
 # Plain COPY + chmod (not COPY --chmod) so the image also builds with the
 # legacy builder, not only BuildKit.
 COPY images/agent-box/entrypoint.sh /usr/local/bin/agent-box-entrypoint.sh
-RUN chmod 0755 /usr/local/bin/agent-box-entrypoint.sh
+# Tenant secrets (#1190): the daemon mounts them at /run/secrets, and these
+# turn them into the session environment. Installed as a shared snippet with
+# two consumers, because the two session modes reach it differently — the
+# forced command sources it through the session wrapper, an interactive shell
+# through /etc/profile.d. One copy, so the two modes cannot drift.
+COPY images/agent-box/secrets-env.sh /usr/local/lib/containarium/secrets-env.sh
+COPY images/agent-box/session.sh /usr/local/bin/agent-box-session
+RUN chmod 0755 /usr/local/bin/agent-box-entrypoint.sh /usr/local/bin/agent-box-session \
+    && chmod 0644 /usr/local/lib/containarium/secrets-env.sh \
+    && printf '. /usr/local/lib/containarium/secrets-env.sh\n' \
+       > /etc/profile.d/10-containarium-secrets.sh
 
 USER agent
 ENV HOME=/home/agent

--- a/images/agent-box/entrypoint.sh
+++ b/images/agent-box/entrypoint.sh
@@ -65,7 +65,10 @@ dropbear_flags=(-F -E -s -j -k -p 2222 -r "$ED_HOSTKEY" -r "$RSA_HOSTKEY")
 #          so the shell can't reach the cluster network.
 case "${AGENTBOX_MODE:-mcp}" in
   mcp)
-    exec dropbear "${dropbear_flags[@]}" -c /usr/local/bin/agent-box
+    # agent-box-session, not agent-box: the wrapper loads the tenant's
+    # mounted secrets into the environment first, per session, so a
+    # refreshed Secret reaches the next session without a restart (#1190).
+    exec dropbear "${dropbear_flags[@]}" -c /usr/local/bin/agent-box-session
     ;;
   shell)
     echo "[agent-box-entrypoint] AGENTBOX_MODE=shell — interactive shell enabled, forced-command MCP disabled" >&2

--- a/images/agent-box/secrets-env.sh
+++ b/images/agent-box/secrets-env.sh
@@ -1,0 +1,56 @@
+# shellcheck shell=sh
+#
+# Build the session environment from the box's mounted secrets (#1190).
+#
+# The daemon materializes a tenant's secrets into a Kubernetes Secret mounted
+# at /run/secrets, one file per secret. This turns those files into
+# environment variables, so an env-delivery secret behaves the same as it does
+# on the LXC backend, where it arrives via `incus config set environment.<NAME>`.
+#
+# Sourced per session rather than once at container start, and that is the
+# point: the kubelet refreshes the mount in place when the Secret changes, so
+# a new session sees the current value without the box restarting. That is
+# also exactly what the LXC path promises — "new execs will see updated
+# values" — so the two backends agree.
+
+containarium_load_secrets() {
+	[ -d /run/secrets ] || return 0
+
+	for _cs_file in /run/secrets/*; do
+		# An unmatched glob stays literal, so check the file exists. The
+		# check follows symlinks, which matters: Kubernetes projects each
+		# key as a symlink into a ..data directory.
+		[ -f "$_cs_file" ] || continue
+
+		_cs_name=${_cs_file##*/}
+
+		# Only names that are valid shell identifiers. A secret named
+		# `foo-bar` would fail the export, and one bad name must not stop
+		# the rest loading.
+		#
+		# This also covers the compose dotenv: `secrets.env` contains a dot,
+		# so it is never a valid identifier and is never exported. It is
+		# consumed as a file by `env_file:`, and exporting it would make one
+		# variable whose value is the whole file. An explicit *.env case
+		# here would be unreachable — the check below already refuses it.
+		case "$_cs_name" in
+		[!A-Za-z_]* | *[!A-Za-z0-9_]*) continue ;;
+		esac
+
+		# PATH, LD_PRELOAD and friends are refused: a tenant secret must not
+		# be able to redirect what the session executes.
+		case "$_cs_name" in
+		PATH | LD_* | IFS | ENV | BASH_ENV | SHELL | HOME) continue ;;
+		esac
+
+		# Command substitution strips trailing newlines, which is what a
+		# consumer of an env var expects — the file has one, the variable
+		# should not.
+		_cs_value=$(cat "$_cs_file") || continue
+		export "$_cs_name=$_cs_value"
+	done
+
+	unset _cs_file _cs_name _cs_value
+}
+
+containarium_load_secrets

--- a/images/agent-box/secretsenv_test.go
+++ b/images/agent-box/secretsenv_test.go
@@ -1,0 +1,249 @@
+// Package agentbox holds tests for the agent-box image's shell helpers.
+//
+// The helpers are shell, not Go, but they are as load-bearing as any code
+// here: secrets-env.sh is what turns a mounted secret into the session
+// environment (#1190), and a mistake in it is either a secret that never
+// arrives or an environment a tenant can corrupt. Running it under `sh` in a
+// test is the only way to check either without building the image.
+package agentbox
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runWithSecrets writes the given files into a fake secrets mount, sources
+// the snippet against it, and returns the resulting environment.
+func runWithSecrets(t *testing.T, files map[string]string) map[string]string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mount := filepath.Join(dir, "secrets")
+	if err := os.MkdirAll(mount, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(mount, name), []byte(content), 0o400); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	script, err := os.ReadFile("secrets-env.sh")
+	if err != nil {
+		t.Fatalf("read snippet: %v", err)
+	}
+	// Point the snippet at the fake mount. The path is a literal in the
+	// snippet because the real one is fixed by the pod spec.
+	body := strings.ReplaceAll(string(script), "/run/secrets", mount)
+
+	// env -0 (NUL-separated), not plain env: splitting on newlines cannot
+	// distinguish "value" from "value\n", so a test for the trailing-newline
+	// strip would pass either way.
+	out, err := exec.Command("sh", "-c", body+"\nenv -0").Output()
+	if err != nil {
+		t.Fatalf("run snippet: %v", err)
+	}
+
+	env := map[string]string{}
+	for _, entry := range strings.Split(string(out), "\x00") {
+		if k, v, ok := strings.Cut(entry, "="); ok {
+			env[k] = v
+		}
+	}
+	return env
+}
+
+func TestSecretsEnv_ExportsEachSecret(t *testing.T) {
+	env := runWithSecrets(t, map[string]string{
+		"API_TOKEN": "s3cret",
+		"DB_URL":    "postgres://host/db",
+	})
+
+	if env["API_TOKEN"] != "s3cret" {
+		t.Errorf("API_TOKEN = %q, want the secret — an env-delivery secret that never reaches "+
+			"the environment is the whole of #1190", env["API_TOKEN"])
+	}
+	if env["DB_URL"] != "postgres://host/db" {
+		t.Errorf("DB_URL = %q", env["DB_URL"])
+	}
+}
+
+// A file written by the kubelet ends with whatever the value contained. A
+// consumer reading an env var does not expect a trailing newline.
+func TestSecretsEnv_StripsTheTrailingNewline(t *testing.T) {
+	env := runWithSecrets(t, map[string]string{"TOKEN": "value\n"})
+	if env["TOKEN"] != "value" {
+		t.Errorf("TOKEN = %q, want %q — a trailing newline breaks a token used in a header",
+			env["TOKEN"], "value")
+	}
+}
+
+// The compose dotenv is consumed as a file by `env_file:`. Exporting it would
+// create one variable holding the whole file. It is refused by the identifier
+// check rather than by a name-specific case, so this pins the behaviour, not
+// the mechanism.
+func TestSecretsEnv_SkipsTheComposeDotenv(t *testing.T) {
+	env := runWithSecrets(t, map[string]string{
+		"secrets.env": "A=1\nB=2\n",
+		"REAL":        "v",
+	})
+
+	if _, exported := env["secrets.env"]; exported {
+		t.Error("the compose dotenv was exported as a variable")
+	}
+	if env["REAL"] != "v" {
+		t.Error("skipping the dotenv also skipped a real secret")
+	}
+}
+
+// A tenant must not be able to redirect what the session executes by naming
+// a secret PATH.
+func TestSecretsEnv_RefusesToOverrideExecutionVariables(t *testing.T) {
+	env := runWithSecrets(t, map[string]string{
+		"PATH":       "/tmp/evil",
+		"LD_PRELOAD": "/tmp/evil.so",
+		"SAFE":       "ok",
+	})
+
+	if env["PATH"] == "/tmp/evil" {
+		t.Error("a secret named PATH replaced the session's PATH — a tenant secret would decide " +
+			"which binaries the session runs")
+	}
+	if env["LD_PRELOAD"] == "/tmp/evil.so" {
+		t.Error("a secret named LD_PRELOAD was exported — it would be injected into every " +
+			"process the session starts")
+	}
+	if env["SAFE"] != "ok" {
+		t.Error("refusing a dangerous name also dropped a legitimate secret")
+	}
+}
+
+// A name that is not a shell identifier must be skipped without stopping the
+// rest — one bad name should not cost a tenant every other secret.
+func TestSecretsEnv_SkipsInvalidNamesWithoutDroppingTheRest(t *testing.T) {
+	env := runWithSecrets(t, map[string]string{
+		"not-an-identifier": "x",
+		"1LEADING_DIGIT":    "y",
+		"GOOD":              "z",
+	})
+
+	if env["GOOD"] != "z" {
+		t.Error("an unusable secret name stopped the valid ones loading — a single bad name " +
+			"would cost the tenant every other secret")
+	}
+	if _, ok := env["not-an-identifier"]; ok {
+		t.Error("exported a name that is not a shell identifier")
+	}
+}
+
+// Kubernetes projects each key as a symlink into a ..data directory. If the
+// snippet did not follow symlinks, every secret would be skipped in the one
+// arrangement that matters — the real one.
+func TestSecretsEnv_FollowsTheKubeletsSymlinkLayout(t *testing.T) {
+	dir := t.TempDir()
+	mount := filepath.Join(dir, "secrets")
+	data := filepath.Join(mount, "..data")
+	if err := os.MkdirAll(data, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(data, "TOKEN"), []byte("v"), 0o400); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(data, "TOKEN"), filepath.Join(mount, "TOKEN")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	script, err := os.ReadFile("secrets-env.sh")
+	if err != nil {
+		t.Fatalf("read snippet: %v", err)
+	}
+	body := strings.ReplaceAll(string(script), "/run/secrets", mount)
+	out, err := exec.Command("sh", "-c", body+"\nenv").Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if !strings.Contains(string(out), "TOKEN=v") {
+		t.Errorf("a secret projected the way the kubelet actually projects it was not exported:\n%s", out)
+	}
+	// The ..data directory itself must not become a variable.
+	if strings.Contains(string(out), "..data=") {
+		t.Error("the kubelet's ..data directory was exported as a variable")
+	}
+}
+
+// An empty mount, or none at all, must not fail the session — a box whose
+// tenant has set no secrets is the common case.
+func TestSecretsEnv_EmptyMountIsFine(t *testing.T) {
+	env := runWithSecrets(t, nil)
+	if len(env) == 0 {
+		t.Fatal("the snippet produced no environment at all")
+	}
+	for k := range env {
+		if strings.HasPrefix(k, "/") || strings.Contains(k, "*") {
+			t.Errorf("an unmatched glob leaked into the environment as %q", k)
+		}
+	}
+}
+
+// --- image wiring -----------------------------------------------------
+
+func readImageFile(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// The snippet only does anything if the image installs it and both session
+// modes reach it. Dropping any one of these is silent: the box comes up, SSH
+// works, and secrets are simply absent from the environment.
+func TestImageInstallsTheSecretsSnippet(t *testing.T) {
+	dockerfile := readImageFile(t, "Dockerfile")
+
+	for _, want := range []string{
+		"secrets-env.sh /usr/local/lib/containarium/secrets-env.sh",
+		"session.sh /usr/local/bin/agent-box-session",
+		"/etc/profile.d/10-containarium-secrets.sh",
+	} {
+		if !strings.Contains(dockerfile, want) {
+			t.Errorf("the image no longer installs %q — secrets would be mounted and never "+
+				"loaded into the session environment (#1190)", want)
+		}
+	}
+}
+
+// The forced-command mode is the default, so this is the path almost every
+// session takes. Running agent-box directly would skip the secrets entirely.
+func TestEntrypointRunsTheSessionWrapper(t *testing.T) {
+	entrypoint := readImageFile(t, "entrypoint.sh")
+
+	if !strings.Contains(entrypoint, "-c /usr/local/bin/agent-box-session") {
+		t.Error("the forced command no longer goes through the session wrapper — the default " +
+			"session mode would start with no tenant secrets in its environment (#1190)")
+	}
+}
+
+// The wrapper must load secrets and then become agent-box. If it forgot the
+// exec, the MCP server would not be the session's process.
+func TestSessionWrapperLoadsSecretsThenExecs(t *testing.T) {
+	wrapper := readImageFile(t, "session.sh")
+
+	loads := strings.Index(wrapper, "secrets-env.sh")
+	execs := strings.Index(wrapper, "exec /usr/local/bin/agent-box")
+	if loads < 0 {
+		t.Fatal("the session wrapper does not load the secrets snippet")
+	}
+	if execs < 0 {
+		t.Fatal("the session wrapper does not exec agent-box")
+	}
+	if loads > execs {
+		t.Error("the wrapper execs agent-box before loading secrets — anything after an exec " +
+			"never runs, so the secrets would never be loaded")
+	}
+}

--- a/images/agent-box/session.sh
+++ b/images/agent-box/session.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# The box's forced-command session (#1190).
+#
+# dropbear runs this instead of agent-box directly, so that the tenant's
+# secrets are in the environment before the MCP server starts. Doing it here
+# rather than in the entrypoint is the point: the entrypoint runs once at pod
+# start, while this runs per session, so a refreshed Secret reaches the next
+# session without the box restarting.
+set -eu
+
+. /usr/local/lib/containarium/secrets-env.sh
+
+exec /usr/local/bin/agent-box "$@"


### PR DESCRIPTION
Part of #1190. Independent of #1274 — this is the image side, and the two can land in either order.

## Why

#1274 mounts a tenant's secrets at `/run/secrets`, but nothing turns those files into environment variables. An env-delivery secret would arrive as a file and never as an env var, which is not what it means on the LXC backend.

## Per session, not per start

This is a session wrapper plus a `/etc/profile.d` snippet rather than an entrypoint step, and that is the whole point. The kubelet refreshes the mount in place, so the next session sees a refreshed secret with no restart. Loading at container start would need a pod recreation per change — exactly what the mount was chosen to avoid.

One snippet, two consumers: the forced command reaches it through the session wrapper, an interactive shell through `profile.d`. Two copies would drift, and the drift would be invisible — secrets present in one mode, absent in the other, no error either way.

## Refusals

`PATH`, `LD_*` and friends are never exported. A tenant secret must not decide which binaries the session runs, or get injected into every process it starts.

Names that are not shell identifiers are skipped individually rather than aborting the loop, so one unusable name does not cost a tenant every other secret. That check also covers the compose dotenv — `secrets.env` contains a dot, so it is never exported. It is consumed as a file by `env_file:`; exporting it would make one variable holding the whole file.

## Tests

The snippet is shell, so it is tested by running it under `sh` against a fake mount — including the kubelet's real `..data` symlink layout. If symlinks were not followed, every secret would be skipped in the one arrangement that actually occurs. There are also guards that the image installs the snippet and that both session modes reach it, since dropping any of that is silent: the box comes up, SSH works, and secrets are simply absent.

## Mutation testing found two weak tests

Worth flagging rather than burying — three mutants initially survived, and two were my tests' fault:

- The harness split `env` output on newlines, so the trailing-newline assertion **could not fail**. Now uses `env -0`.
- The compose-dotenv test was passing via a redundant `*.env` guard that the identifier check already subsumed. The guard was unreachable; it is gone, and the test now pins the behaviour rather than the mechanism.

The third (`-f` versus `-e`) is an equivalent mutant: the glob never matches `..data` because it is a dotfile, so the two behave identically here.

## Known gap

A non-interactive command over SSH in `shell` mode (`ssh box -- cmd`) gets neither the wrapper nor `profile.d`, so it sees no secrets. On LXC that case inherits the container's env. Calling it out rather than silently accepting the asymmetry; the default `mcp` mode — which is what nearly every session uses — is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)