### PR TITLE
feat(server): deliver secrets to the box the backend actually has (#1190)

### DIFF
--- a/charts/containarium-k8s/templates/clusterrole.yaml
+++ b/charts/containarium-k8s/templates/clusterrole.yaml
@@ -33,7 +33,10 @@ rules:
   - apiGroups: [""]
     resources: [pods/log, pods/exec]
     verbs: [get, list, create]
-  # Manage per-box SSH keys in tenant namespaces
+  # Manage per-box SSH keys in tenant namespaces, and the per-tenant Secret
+  # that carries delivered tenant secrets (#1190). Removing this does not
+  # fail loudly for the second: `secret set` still succeeds — the value is
+  # stored and encrypted — and only the delivery into the box is lost.
   - apiGroups: [""]
     resources: [secrets]
     verbs: [get, list, watch, create, update, patch, delete]

--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -746,6 +746,14 @@ become one file; `compose` rows are rendered into a single `secrets.env` by
 the same function the LXC path uses, so a compose app's `env_file:` reference
 differs only in directory.
 
+**Boxes created before this shipped.** The secrets volume is part of the box's
+pod template, so a box created before it existed has no mount and no amount of
+delivery will reach it — the Secret is written and nothing consumes it. Those
+boxes need recreating. This fails quietly rather than loudly: `secret refresh`
+reports success, because the delivery genuinely succeeded; it is the mount that
+is missing. Recreate a box and check for `/run/secrets` inside it if secrets
+appear to be ignored on a long-lived deployment.
+
 **Operator responsibility: encryption at rest.** A Kubernetes Secret is
 base64-encoded, not encrypted, unless the cluster has [encryption at
 rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)

--- a/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
+++ b/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md
@@ -721,6 +721,50 @@ The GPU *type* (L4, A100, etc.) is expressed via node affinity, driven by a
 node. This is deliberately different from the LXC/GCE path, where the daemon
 selects the exact machine type; on K8s, the scheduler owns that decision.
 
+### Tenant secret delivery (#1190)
+
+A tenant's secrets are materialized into a per-tenant Secret and mounted into
+the box at `/run/secrets`, one file per secret — the same path the LXC
+file-delivery mode uses. The box's session builds its environment from those
+files, so an env-delivery secret behaves the same on both backends.
+
+**Why a mount and not env vars.** A container's environment is fixed when it
+starts. Updating a Secret projected with `envFrom` does not change a running
+pod — it has to be recreated. A Secret *volume* is refreshed in place by the
+kubelet, so a new session sees the new value with no restart. That is also
+what the LXC path actually promises: its refresh message says *new execs* see
+updated values, not that running processes are re-parented. The mount is what
+makes the two backends agree.
+
+Because the mount is refreshed by the kubelet and survives a restart, the
+LXC-side secrets reconciler has no K8s counterpart and is not wired there.
+It exists because a container's tmpfs does not survive a restart; a mounted
+Secret does.
+
+All three delivery modes land in the same object. `env` and `file` rows each
+become one file; `compose` rows are rendered into a single `secrets.env` by
+the same function the LXC path uses, so a compose app's `env_file:` reference
+differs only in directory.
+
+**Operator responsibility: encryption at rest.** A Kubernetes Secret is
+base64-encoded, not encrypted, unless the cluster has [encryption at
+rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)
+configured for the `secrets` resource. Containarium's own at-rest guarantee —
+envelope encryption with a KMS-held KEK — covers the value in Postgres, and it
+still does on this backend. It does **not** extend to etcd.
+
+So a tenant moving from the LXC backend to K8s gets a *weaker* at-rest
+guarantee for the delivered copy unless the operator configures it, and the
+platform cannot detect or enforce that from inside. Stated here rather than
+left implied: a reader who assumes the KMS guarantee covers the whole path
+would be wrong, and would be wrong silently.
+
+Anyone can read a mounted secret who can `kubectl get secret` in the tenant
+namespace, `kubectl exec` into the box, or read etcd directly. The first two
+are the same trust boundary as the LXC backend (an operator with incus access
+can read a container's config and its tmpfs); the third is new, and is what
+cluster encryption at rest addresses.
+
 ## Fronting a K8s node with the fleet sentinel
 
 Everything above describes a K8s node reached at its *own* in-cluster gateway

--- a/docs/product/agent-substrate-roadmap-position.md
+++ b/docs/product/agent-substrate-roadmap-position.md
@@ -114,7 +114,6 @@ does not.**
 | Gap | Evidence |
 | --- | --- |
 | **eBPF network policy** | `NetworkPolicyEnforcer`'s inspector is `ListContainers() ([]incus.ContainerInfo, error)`; it resolves container-name → host veth ifindex and attaches TCX. Constructed with `networkIncusClient` (`dual_server.go:1303`). No K8s branch exists. |
-| **Tenant secret delivery** | `incus config set environment.<NAME>=…`, reconciler holds `*incus.Client`. The K8s backend mounts Secrets only for authorized_keys and host keys. |
 
 These are **type-level** dependencies on `pkg/core/incus`, not feature
 flags. They cannot be switched on for K8s; they'd have to be rebuilt
@@ -145,17 +144,29 @@ idiom to bind to rather than reimplement. That is the "inherit, don't
 invent" posture this note already argues for, so the gaps are consistent
 with the strategy rather than a refutation of it.
 
-Gaps tracked as #1188 (policy-driven K8s NetworkPolicy) and #1190 (tenant
-secret delivery on K8s).
+The one gap left in the table is the eBPF network policy enforcer, whose
+inspector is incus-typed at the interface level.
 
-#1189 (in-box session audit on K8s) is addressed: the collector now reads
-sessions through a backend-neutral source — OpenSSH `auth.log` on LXC,
-box pod logs on Kubernetes — and both land in the same store under the
-same action. It is listed here as the worked example of what porting one
-of these gaps costs: a parser for the other backend's log format, a
-source interface, and the wiring to choose between them. The type-level
-dependency was the whole of the problem, and it was three PRs of work,
-not a redesign.
+The other three named here are closed, and how they closed is the useful part
+of this note:
+
+- **#1188** — tenant egress policy compiles to a native `NetworkPolicy`.
+- **#1189** — session audit reads OpenSSH `auth.log` on LXC and box pod logs
+  on Kubernetes, through one backend-neutral source.
+- **#1190** — tenant secrets are materialized into a mounted Secret rather
+  than stamped into container config.
+
+Each cost the same three things: an implementation of the other backend's
+native mechanism, a seam narrow enough that the shared logic stopped naming a
+backend, and the wiring to pick between them. None needed a redesign, and none
+of the "already portable" half — identity, authz, secrets-at-rest — had to
+move. That is the evidence for the claim above rather than a restatement of it.
+
+Two of the three also turned out to have a *different* fix than first
+proposed, which is worth knowing before scoping the fourth: #1189's collector
+needed a log parser for a different SSH server, not just a client swap, and
+#1190's secrets could not be projected as env vars at all, because a running
+pod's environment cannot be updated.
 
 ## What this note deliberately does not say
 

--- a/internal/cmd/secrets.go
+++ b/internal/cmd/secrets.go
@@ -77,14 +77,21 @@ the change should reach the next exec without a container restart.`,
 
 var secretsRefreshCmd = &cobra.Command{
 	Use:   "refresh <username>",
-	Short: "Re-stamp env vars on the LXC from the current secrets store",
+	Short: "Deliver the current secrets store to the tenant's box",
 	Long: `Reads all of the tenant's secrets, decrypts them, and updates the
-container's environment.<NAME> config keys to match. Running
-processes keep their old env (POSIX inherit-at-fork); new execs
-(including a fresh 'docker compose up') see the refreshed values.
+box to match.
+
+On the LXC backend this sets the container's environment.<NAME>
+config keys and rewrites tmpfs file-mode secrets. On the Kubernetes
+backend it updates the box's mounted Secret, which the kubelet
+refreshes in place within about a minute.
+
+Either way, running processes keep their old environment (POSIX
+inherit-at-fork); new execs and new sessions — including a fresh
+'docker compose up' — see the refreshed values.
 
 Use this after rotating a secret if you want the change to land
-without restarting the whole container.`,
+without restarting the box.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runSecretsRefresh,
 }

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -798,7 +798,7 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	// failure here doesn't fail the create; secrets can always be
 	// retried via RefreshSecrets).
 	if s.secretsStore != nil {
-		if n, err := s.stampSecretsOnLXC(ctx, req.Username); err != nil {
+		if n, err := s.stampSecrets(ctx, req.Username); err != nil {
 			log.Printf("[secrets] failed to stamp on %s: %v (continuing)", info.Ref.Name, err)
 		} else if n > 0 {
 			log.Printf("[secrets] stamped %d secret(s) on %s at create time", n, info.Ref.Name)
@@ -1419,7 +1419,7 @@ func (s *ContainerServer) StartContainer(ctx context.Context, req *pb.StartConta
 		// existing processes won't see the change (POSIX inherit-at-fork),
 		// but new execs will.
 		if s.secretsStore != nil {
-			if n, err := s.stampSecretsOnLXC(ctx, req.Username); err != nil {
+			if n, err := s.stampSecrets(ctx, req.Username); err != nil {
 				log.Printf("[secrets] failed to re-stamp on start of %s-container: %v (continuing)", req.Username, err)
 			} else if n > 0 {
 				log.Printf("[secrets] re-stamped %d secret(s) on %s-container at start time", n, req.Username)

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -794,9 +794,11 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		s.stampBirthDeleteAfterStopped(info.Ref.Name, req.DeleteAfterStoppedSeconds)
 	}
 
-	// Stamp tenant secrets into the LXC's env (best-effort — a
-	// failure here doesn't fail the create; secrets can always be
-	// retried via RefreshSecrets).
+	// Deliver tenant secrets to the new box — env config on LXC, the
+	// mounted Secret on K8s (best-effort; a failure here doesn't fail the
+	// create, and RefreshSecrets is the retry). Runs after the box exists,
+	// which on K8s matters: the Secret lands in the tenant namespace, and
+	// that namespace is created with the box.
 	if s.secretsStore != nil {
 		if n, err := s.stampSecrets(ctx, req.Username); err != nil {
 			log.Printf("[secrets] failed to stamp on %s: %v (continuing)", info.Ref.Name, err)
@@ -1414,15 +1416,15 @@ func (s *ContainerServer) StartContainer(ctx context.Context, req *pb.StartConta
 			log.Printf("[ttl] failed to clear %s on %s: %v (continuing)", incus.StoppedAtKey, req.Username, err)
 		}
 
-		// Re-stamp tenant secrets from the current DB state. Picks up
-		// any rotations that happened while the container was stopped;
-		// existing processes won't see the change (POSIX inherit-at-fork),
-		// but new execs will.
+		// Re-deliver tenant secrets from the current DB state. Picks up
+		// any rotations that happened while the box was stopped; existing
+		// processes won't see the change (POSIX inherit-at-fork), but new
+		// execs and new sessions will.
 		if s.secretsStore != nil {
 			if n, err := s.stampSecrets(ctx, req.Username); err != nil {
-				log.Printf("[secrets] failed to re-stamp on start of %s-container: %v (continuing)", req.Username, err)
+				log.Printf("[secrets] failed to re-deliver on start of %s's box: %v (continuing)", req.Username, err)
 			} else if n > 0 {
-				log.Printf("[secrets] re-stamped %d secret(s) on %s-container at start time", n, req.Username)
+				log.Printf("[secrets] re-delivered %d secret(s) to %s's box at start time", n, req.Username)
 			}
 		}
 	}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -2122,7 +2122,15 @@ func (ds *DualServer) Start(ctx context.Context) error {
 	// /run/secrets files until the next daemon-driven
 	// touch. Owned alongside the autosleep manager —
 	// same shape, same lifetime.
-	if ds.containerServer != nil && ds.containerServer.secretsStore != nil {
+	//
+	// Deliberately LXC-only, and not an oversight left over from #1190.
+	// The reconciler exists because a container's tmpfs does not survive a
+	// restart, so the files have to be rewritten. A K8s box mounts its
+	// secrets from a Secret, which does survive — the kubelet repopulates
+	// the mount on its own, and a periodic re-apply would be writes to the
+	// apiserver that change nothing.
+	if ds.containerServer != nil && ds.containerServer.secretsStore != nil &&
+		ds.containerServer.boxes().Kind() != box.KindK8s {
 		if ic, err := incus.New(); err != nil {
 			log.Printf("[secrets-reconciler] incus client unavailable: %v (reconciler disabled)", err)
 		} else {

--- a/internal/server/secret_delivery.go
+++ b/internal/server/secret_delivery.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/footprintai/containarium/internal/secrets"
+	"github.com/footprintai/containarium/pkg/core/box"
+	"github.com/footprintai/containarium/pkg/core/container"
+)
+
+// Choosing how a tenant's secrets reach their box (#1190).
+//
+// The LXC path stamps `incus config set environment.<NAME>` for env rows and
+// writes the container's tmpfs for file rows. Neither exists on K8s, so
+// `secret set` succeeded there and the value never arrived — the RPC looks
+// identical on both backends.
+//
+// On K8s every delivery mode collapses to one thing: a key in the tenant's
+// mounted Secret. That is not a shortcut. The three LXC modes exist because
+// three different mechanisms were needed to get a value to three different
+// consumers; a mounted Secret serves all three, and the box's session
+// environment is built from the same files (see images/agent-box).
+
+// tenantSecretApplier is the K8s backend's secret materializer. Asserted for
+// rather than added to BoxBackend: delivering a Secret is not an operation
+// every backend has, and LXC's equivalent is a sequence of execs with no
+// single object behind it.
+type tenantSecretApplier interface {
+	ApplyTenantSecrets(ctx context.Context, tenant string, data map[string][]byte) error
+}
+
+// stampSecrets delivers a tenant's secrets to their box on whichever backend
+// is running, and is what the RPC and lifecycle call sites use.
+//
+// The LXC implementation is unchanged and still reached directly by name in
+// the paths that are LXC-only.
+func (s *ContainerServer) stampSecrets(ctx context.Context, username string) (int, error) {
+	if s.boxes().Kind() == box.KindK8s {
+		applier, ok := s.boxes().(tenantSecretApplier)
+		if !ok {
+			return 0, fmt.Errorf("secrets: the K8s box backend cannot materialize secrets; " +
+				"they would be stored and never delivered")
+		}
+		return s.deliverSecretsToK8s(ctx, applier, username)
+	}
+	return s.stampSecretsOnLXC(ctx, username)
+}
+
+// deliverSecretsToK8s materializes every secret the tenant owns into their
+// per-tenant Secret, which the box mounts.
+//
+// Deliberately delivers the whole set rather than a delta: the Secret is the
+// desired state, and a deleted secret must disappear from the box. It also
+// means delivery is idempotent, so a retry after a partial failure converges.
+func (s *ContainerServer) deliverSecretsToK8s(ctx context.Context, applier tenantSecretApplier, username string) (int, error) {
+	if s.secretsStore == nil {
+		return 0, fmt.Errorf("secrets store not configured")
+	}
+	secretMap, err := s.secretsStore.LoadAllForUserWithDelivery(ctx, username)
+	if err != nil {
+		return 0, fmt.Errorf("load secrets: %w", err)
+	}
+
+	if err := applier.ApplyTenantSecrets(ctx, username, secretsToK8sData(secretMap)); err != nil {
+		return 0, err
+	}
+	return len(secretMap), nil
+}
+
+// secretsToK8sData translates stored rows into the box's mounted files.
+//
+// Kept separate from the store read so the translation — the step where a
+// delivery mode can be silently dropped — is testable without a database.
+func secretsToK8sData(secretMap map[string]secrets.SecretValue) map[string][]byte {
+	data := make(map[string][]byte, len(secretMap)+1)
+	composeEnv := map[string]string{}
+	for name, sv := range secretMap {
+		if sv.Delivery == secrets.DeliveryCompose {
+			// Compose rows are consumed as one dotenv file, not as
+			// individual variables. Dropping them here rather than
+			// carrying the mode across would be the same silent
+			// non-delivery this issue is about, one mode narrower.
+			composeEnv[name] = sv.Value
+			continue
+		}
+		// env and file rows are the same object in the box: a file under
+		// the secrets mount. env rows differ only in that the session
+		// environment is built from them.
+		data[name] = []byte(sv.Value)
+	}
+	if len(composeEnv) > 0 {
+		// Rendered by the same function the LXC path uses, not a second
+		// renderer: a compose app must see the same file on both backends,
+		// and RenderEnvFile already sorts keys, so the bytes are stable
+		// across deliveries rather than reshuffling on every pass.
+		data[composeSecretKey] = container.RenderEnvFile(
+			container.SecretsEnvFile.Header, composeEnv)
+	}
+	return data
+}
+
+// composeSecretKey is the file the compose dotenv lands on inside the box's
+// secrets mount. Named after the LXC path's basename so a compose app's
+// `env_file:` reference differs only in directory between the backends.
+var composeSecretKey = pathBase(container.SecretsEnvFilePath)
+
+func pathBase(p string) string {
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}

--- a/internal/server/secret_delivery.go
+++ b/internal/server/secret_delivery.go
@@ -112,3 +112,20 @@ func pathBase(p string) string {
 	}
 	return p
 }
+
+// refreshSecretsMessage describes what a refresh actually did on the backend
+// it ran on.
+//
+// The old wording named `<username>-container` and "re-stamped", which is the
+// LXC mechanism and an object that does not exist on K8s. An operator there
+// would be told their secrets landed somewhere they could not find (#1190).
+func refreshSecretsMessage(kind box.BackendKind, username string, delivered int) string {
+	if kind == box.KindK8s {
+		return fmt.Sprintf(
+			"delivered %d secret(s) to %s's box; the mount refreshes within about a minute, "+
+				"and new sessions see the updated values", delivered, username)
+	}
+	return fmt.Sprintf(
+		"re-stamped %d secret(s) on %s-container; new execs will see updated values",
+		delivered, username)
+}

--- a/internal/server/secret_delivery_test.go
+++ b/internal/server/secret_delivery_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/footprintai/containarium/internal/secrets"
+	"github.com/footprintai/containarium/pkg/core/box"
 	"github.com/footprintai/containarium/pkg/core/container"
 )
 
@@ -134,4 +135,27 @@ func keysOf(m map[string][]byte) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// The refresh message is the only feedback an operator gets that delivery
+// happened. Naming the LXC mechanism and an object that does not exist on
+// K8s would tell them their secrets landed somewhere they cannot find.
+func TestRefreshMessage_DescribesTheBackendItRanOn(t *testing.T) {
+	k8s := refreshSecretsMessage(box.KindK8s, "alice", 3)
+	lxc := refreshSecretsMessage(box.KindLXC, "alice", 3)
+
+	if strings.Contains(k8s, "alice-container") {
+		t.Errorf("the K8s message names a container that does not exist there: %q", k8s)
+	}
+	if strings.Contains(k8s, "re-stamped") {
+		t.Errorf("the K8s message describes the LXC mechanism: %q", k8s)
+	}
+	if !strings.Contains(lxc, "alice-container") {
+		t.Errorf("the LXC message no longer names the container: %q", lxc)
+	}
+	for name, msg := range map[string]string{"k8s": k8s, "lxc": lxc} {
+		if !strings.Contains(msg, "3") {
+			t.Errorf("%s message does not say how many secrets were delivered: %q", name, msg)
+		}
+	}
 }

--- a/internal/server/secret_delivery_test.go
+++ b/internal/server/secret_delivery_test.go
@@ -15,13 +15,11 @@ import (
 // the step where a delivery mode can be silently dropped.
 
 type fakeApplier struct {
-	data  map[string][]byte
-	calls int
-	err   error
+	data map[string][]byte
+	err  error
 }
 
 func (f *fakeApplier) ApplyTenantSecrets(_ context.Context, _ string, data map[string][]byte) error {
-	f.calls++
 	if f.err != nil {
 		return f.err
 	}
@@ -116,16 +114,24 @@ func TestK8sDelivery_ComposeFileMatchesTheLXCRendering(t *testing.T) {
 	}
 }
 
-// A tenant with no secrets delivers an empty set, which removes the object
-// rather than leaving the last values mounted.
-func TestK8sDelivery_NoSecretsDeliversNothing(t *testing.T) {
-	applier := deliverK8s(t, map[string]secrets.SecretValue{})
-	if len(applier.data) != 0 {
-		t.Errorf("delivered %d keys for a tenant with no secrets", len(applier.data))
+// A tenant with no secrets must translate to an empty set, because that is
+// what makes the apply delete the object instead of leaving the last values
+// mounted. Deleting the last secret and having it stay readable would be a
+// deletion that reports success and does nothing.
+//
+// (Only the translation is asserted here. That an empty set actually deletes
+// the object is the applier's job and is covered in pkg/core/box/k8s. Calling
+// the fake applier and asserting it was called once would prove nothing —
+// this test calls it directly.)
+func TestK8sDelivery_NoSecretsTranslatesToAnEmptySet(t *testing.T) {
+	if got := secretsToK8sData(map[string]secrets.SecretValue{}); len(got) != 0 {
+		t.Errorf("translated a tenant with no secrets to %d key(s): %v", len(got), keysOf(got))
 	}
-	if applier.calls != 1 {
-		t.Errorf("applier called %d times, want 1 — the empty apply is what deletes the object",
-			applier.calls)
+	// A tenant whose only secrets were compose rows, all now deleted, must
+	// also land on empty — not on a lone empty dotenv that keeps the object
+	// alive.
+	if got := secretsToK8sData(nil); len(got) != 0 {
+		t.Errorf("translated a nil row set to %d key(s): %v", len(got), keysOf(got))
 	}
 }
 

--- a/internal/server/secret_delivery_test.go
+++ b/internal/server/secret_delivery_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/secrets"
+	"github.com/footprintai/containarium/pkg/core/container"
+)
+
+// #1190: on K8s, `secret set` succeeded and the value never reached the box.
+// These cover the translation from stored rows to what the box mounts —
+// the step where a delivery mode can be silently dropped.
+
+type fakeApplier struct {
+	data  map[string][]byte
+	calls int
+	err   error
+}
+
+func (f *fakeApplier) ApplyTenantSecrets(_ context.Context, _ string, data map[string][]byte) error {
+	f.calls++
+	if f.err != nil {
+		return f.err
+	}
+	f.data = data
+	return nil
+}
+
+// deliverK8s runs the K8s translation over a fixed set of stored rows,
+// without a database.
+func deliverK8s(t *testing.T, rows map[string]secrets.SecretValue) *fakeApplier {
+	t.Helper()
+	applier := &fakeApplier{}
+	if err := applier.ApplyTenantSecrets(context.Background(), "alice", secretsToK8sData(rows)); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+	return applier
+}
+
+func TestK8sDelivery_EnvAndFileRowsBothBecomeFiles(t *testing.T) {
+	applier := deliverK8s(t, map[string]secrets.SecretValue{
+		"API_TOKEN": {Value: "tok", Delivery: secrets.DeliveryEnv},
+		"TLS_KEY":   {Value: "pem", Delivery: secrets.DeliveryFile},
+	})
+
+	if string(applier.data["API_TOKEN"]) != "tok" {
+		t.Errorf("env-mode secret = %q, want its value — an env row dropped here is exactly the "+
+			"silent non-delivery #1190 is about", applier.data["API_TOKEN"])
+	}
+	if string(applier.data["TLS_KEY"]) != "pem" {
+		t.Errorf("file-mode secret = %q, want its value", applier.data["TLS_KEY"])
+	}
+}
+
+// Compose rows are consumed as one dotenv file. Carrying them across as
+// individual keys, or dropping them, would each break a compose app.
+func TestK8sDelivery_ComposeRowsBecomeOneDotenvFile(t *testing.T) {
+	applier := deliverK8s(t, map[string]secrets.SecretValue{
+		"DB_PASS": {Value: "p1", Delivery: secrets.DeliveryCompose},
+		"DB_USER": {Value: "u1", Delivery: secrets.DeliveryCompose},
+	})
+
+	dotenv, ok := applier.data[composeSecretKey]
+	if !ok {
+		t.Fatalf("no compose dotenv delivered; keys=%v — a compose app would come up with no "+
+			"credentials and no error", keysOf(applier.data))
+	}
+	body := string(dotenv)
+	if !strings.Contains(body, "DB_USER=u1") || !strings.Contains(body, "DB_PASS=p1") {
+		t.Errorf("dotenv is missing values:\n%s", body)
+	}
+	// Individual keys too would put the same secret in the box twice, under
+	// two names, and only one of them documented.
+	if _, dup := applier.data["DB_PASS"]; dup {
+		t.Error("a compose row was also delivered as its own file")
+	}
+}
+
+// The rendered dotenv must be byte-identical between deliveries, or every
+// pass looks like a change and rewrites the Secret.
+func TestK8sDelivery_DotenvIsStableAcrossDeliveries(t *testing.T) {
+	rows := map[string]secrets.SecretValue{
+		"A": {Value: "1", Delivery: secrets.DeliveryCompose},
+		"B": {Value: "2", Delivery: secrets.DeliveryCompose},
+		"C": {Value: "3", Delivery: secrets.DeliveryCompose},
+	}
+	first := string(deliverK8s(t, rows).data[composeSecretKey])
+	for i := 0; i < 8; i++ {
+		if got := string(deliverK8s(t, rows).data[composeSecretKey]); got != first {
+			t.Fatalf("dotenv differs between deliveries:\n%q\nvs\n%q\n"+
+				"map iteration order would make every reconcile look like a change", first, got)
+		}
+	}
+}
+
+// The compose file must be the same shape on both backends, so an app's
+// env_file reference differs only in directory.
+func TestK8sDelivery_ComposeFileMatchesTheLXCRendering(t *testing.T) {
+	rows := map[string]secrets.SecretValue{
+		"A": {Value: "1", Delivery: secrets.DeliveryCompose},
+		"B": {Value: "2", Delivery: secrets.DeliveryCompose},
+	}
+	got := deliverK8s(t, rows).data[composeSecretKey]
+	want := container.RenderEnvFile(container.SecretsEnvFile.Header,
+		map[string]string{"A": "1", "B": "2"})
+
+	if string(got) != string(want) {
+		t.Errorf("the K8s compose file differs from the LXC one:\n%q\nvs\n%q", got, want)
+	}
+	if composeSecretKey != "secrets.env" {
+		t.Errorf("compose file is named %q; it should match the LXC path's basename so an "+
+			"env_file: reference differs only in directory", composeSecretKey)
+	}
+}
+
+// A tenant with no secrets delivers an empty set, which removes the object
+// rather than leaving the last values mounted.
+func TestK8sDelivery_NoSecretsDeliversNothing(t *testing.T) {
+	applier := deliverK8s(t, map[string]secrets.SecretValue{})
+	if len(applier.data) != 0 {
+		t.Errorf("delivered %d keys for a tenant with no secrets", len(applier.data))
+	}
+	if applier.calls != 1 {
+		t.Errorf("applier called %d times, want 1 — the empty apply is what deletes the object",
+			applier.calls)
+	}
+}
+
+func keysOf(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/server/secrets_server.go
+++ b/internal/server/secrets_server.go
@@ -167,7 +167,7 @@ func (s *ContainerServer) RefreshSecrets(ctx context.Context, req *pb.RefreshSec
 		return nil, err
 	}
 
-	stamped, err := s.stampSecretsOnLXC(ctx, req.Username)
+	stamped, err := s.stampSecrets(ctx, req.Username)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "refresh secrets: %v", err)
 	}

--- a/internal/server/secrets_server.go
+++ b/internal/server/secrets_server.go
@@ -174,7 +174,7 @@ func (s *ContainerServer) RefreshSecrets(ctx context.Context, req *pb.RefreshSec
 
 	log.Printf("[secrets] refresh %s: stamped=%d", req.Username, stamped)
 	return &pb.RefreshSecretsResponse{
-		Message: fmt.Sprintf("re-stamped %d secret(s) on %s-container; new execs will see updated values", stamped, req.Username),
+		Message: refreshSecretsMessage(s.boxes().Kind(), req.Username, stamped),
 		Stamped: safecast.I32(stamped),
 	}, nil
 }


### PR DESCRIPTION
Completes #1190, with #1274 (the K8s-side materializer, merged) and #1275 (the box image, open).

## The bug

`containarium secret set` succeeded on a K8s box and the value never arrived. Every delivery path went through `incus config set environment.<NAME>` or a write into the container's tmpfs, and neither exists there. Same silent asymmetry as #1188 and #1189 — the RPC looks identical on both backends.

## What changes

Delivery dispatches by backend kind. The LXC path is untouched. K8s materializes the tenant's **whole** secret set into the mounted Secret, deliberately not a delta: the Secret is the desired state, so a deleted secret disappears from the box, and a retry after a partial failure converges.

All three delivery modes land in the same object and none is dropped:

| mode | on K8s |
| --- | --- |
| `env` | one file, loaded into the session environment by the image |
| `file` | one file, same path as LXC |
| `compose` | rendered into a single `secrets.env` |

The compose file uses **the same renderer the LXC path uses**, not a second one — a compose app must see the same bytes on both backends, and `RenderEnvFile` already sorts keys, so the value is stable across deliveries instead of reshuffling on every pass and making each reconcile look like a change.

## The reconciler stays LXC-only

The condition now says so rather than leaving it to look like an oversight from this issue. It exists because a container's tmpfs does not survive a restart; a mounted Secret does, and the kubelet repopulates it. A periodic re-apply on K8s would be apiserver writes that change nothing.

## The threat-model note the issue asks for

A Kubernetes Secret is base64, **not encrypted**, unless the cluster has encryption at rest configured for the `secrets` resource. Containarium's envelope encryption with a KMS-held KEK still covers the value in Postgres — it does not extend to etcd.

So a tenant moving from LXC to K8s gets a weaker at-rest guarantee for the *delivered copy*, and the platform cannot detect or enforce that from inside. The docs now state it, including who can read a mounted secret and which parts of that are a new trust boundary versus the same one LXC already had. Left implied, a reader would assume the KMS guarantee covers the whole path.

## Tests

The translation from stored rows to mounted files is extracted from the store read, so it is testable without Postgres — it is the step where a delivery mode can be silently dropped.

Mutation-tested: dropping env rows, dropping compose rows, delivering compose rows individually *as well* as in the dotenv, and hand-rolling an unsorted dotenv each fail a test.

## Acceptance criteria

- **Secrets appear in the environment of a K8s box** — this PR delivers them; #1275 loads them into the session.
- **`RefreshSecrets` updates a running box** — the kubelet refreshes the mount in place and the image loads it per session, so no restart.
- **Deletion removes the value** — the whole-set apply drops it, and emptying the set deletes the object.
- **No plaintext on the PVC or in the Sandbox CR** — the CR carries the Secret's name only.
- **KMS/envelope at rest unchanged** — nothing in `pkg/core/secrets` moved.
- **Integration test on kind** — not runnable in this lane for the same reason as #1272: box pods there run `pause`, so there is no session to observe an environment in. Tracked there rather than claimed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)