### PR TITLE
test(sentinel): stop two host-mutating tests from passing by accident

### DIFF
--- a/internal/sentinel/iptables.go
+++ b/internal/sentinel/iptables.go
@@ -19,6 +19,16 @@ const sshPiperPort = 22
 // It creates a custom chain, adds DNAT rules for each port, and enables MASQUERADE.
 // Port 22 is excluded from forwarding — it is handled by sshpiper on the sentinel.
 // On non-Linux systems or when iptables is unavailable, it logs a warning and returns nil.
+// hostGOOS is runtime.GOOS, indirected so the non-Linux early returns below
+// are testable on any platform.
+//
+// Without it, the tests that cover those returns run the real iptables path
+// when the test host is Linux — which is every CI runner. They passed by
+// actually writing DNAT rules into the runner's nat table, and failed on any
+// Linux machine without the privilege to do so. Neither outcome had anything
+// to do with the behaviour they claim to check.
+var hostGOOS = runtime.GOOS
+
 func enableForwarding(spotIP string, ports []int) error {
 	// Filter out port 22 — handled by sshpiper, not DNAT
 	filtered := make([]int, 0, len(ports))
@@ -30,8 +40,8 @@ func enableForwarding(spotIP string, ports []int) error {
 		filtered = append(filtered, p)
 	}
 	ports = filtered
-	if runtime.GOOS != "linux" {
-		log.Printf("[sentinel] iptables: skipping on %s (non-Linux)", runtime.GOOS)
+	if hostGOOS != "linux" {
+		log.Printf("[sentinel] iptables: skipping on %s (non-Linux)", hostGOOS)
 		return nil
 	}
 
@@ -149,7 +159,7 @@ func detectBridgeCIDR() string {
 // disableForwarding removes all sentinel iptables rules.
 // Safe to call even if no rules exist.
 func disableForwarding() error {
-	if runtime.GOOS != "linux" {
+	if hostGOOS != "linux" {
 		return nil
 	}
 

--- a/internal/sentinel/iptables_test.go
+++ b/internal/sentinel/iptables_test.go
@@ -1,6 +1,7 @@
 package sentinel
 
 import (
+	"runtime"
 	"testing"
 )
 
@@ -78,8 +79,27 @@ func TestPort22FilteringNoPort22(t *testing.T) {
 	}
 }
 
+// onNonLinuxHost makes the code under test believe it is running somewhere
+// without iptables, and restores the real value afterwards.
+//
+// The two tests below are named "OnNonLinux" but had no such control, so on a
+// Linux host — which is every CI runner — they fell through to the real
+// iptables path. They passed by writing actual DNAT rules into the runner's
+// nat table, and failed outright on a Linux machine without the privilege to
+// do it. Neither result said anything about the early return they exist to
+// cover.
+func onNonLinuxHost(t *testing.T) {
+	t.Helper()
+	real := hostGOOS
+	hostGOOS = "darwin"
+	t.Cleanup(func() { hostGOOS = real })
+}
+
 func TestEnableForwardingOnNonLinux(t *testing.T) {
-	// On non-Linux (macOS, etc.), enableForwarding should return nil without error
+	onNonLinuxHost(t)
+
+	// On non-Linux (macOS, etc.), enableForwarding should return nil without
+	// error and touch nothing.
 	err := enableForwarding("10.0.0.1", []int{80, 443})
 	if err != nil {
 		t.Errorf("expected nil error on non-Linux, got: %v", err)
@@ -87,9 +107,28 @@ func TestEnableForwardingOnNonLinux(t *testing.T) {
 }
 
 func TestDisableForwardingOnNonLinux(t *testing.T) {
-	// On non-Linux, disableForwarding should return nil
+	onNonLinuxHost(t)
+
+	// On non-Linux, disableForwarding should return nil and touch nothing.
 	err := disableForwarding()
 	if err != nil {
 		t.Errorf("expected nil error on non-Linux, got: %v", err)
 	}
+}
+
+// The control has to actually control something. If hostGOOS stopped being
+// what the early returns read, the two tests above would go back to running
+// the real iptables path on every CI runner and would still report a pass.
+func TestNonLinuxControlActuallyDivertsTheHostCheck(t *testing.T) {
+	if hostGOOS != runtime.GOOS {
+		t.Fatalf("hostGOOS = %q before any override, want the real %q", hostGOOS, runtime.GOOS)
+	}
+
+	func() {
+		onNonLinuxHost(t)
+		if hostGOOS == runtime.GOOS && runtime.GOOS == "linux" {
+			t.Error("the override did not change what the code under test reads — the " +
+				"non-Linux tests would run the real iptables path against the host")
+		}
+	}()
 }

--- a/internal/sentinel/pool_test.go
+++ b/internal/sentinel/pool_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testPeer struct {
@@ -149,19 +150,31 @@ func TestOnTunnelConnect_PeerOnlyDoesNotPromote(t *testing.T) {
 
 // TestRegisterPropagatesPool confirms the pool tag flows from Register()
 // into the TunnelSpot.
+// require, not assert, on everything a later line dereferences.
+//
+// Register adds a loopback alias, so it fails without CAP_NET_ADMIN. With
+// assert the test carried on from that failure, r.Get returned nil, and the
+// next line dereferenced it — a SIGSEGV that takes down the whole test binary,
+// so every other test in the package is reported as failed too. The real
+// cause was then three screens up, under a stack trace.
+//
+// Failing cleanly here does not make the test pass unprivileged; it makes the
+// one real failure legible instead of burying the package.
 func TestRegisterPropagatesPool(t *testing.T) {
 	r := NewTunnelRegistry()
 	_, _, err := r.Register(&TunnelHandshake{SpotID: "spot-1", Ports: []int{8080}, Pool: "prod"}, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	spot := r.Get("spot-1")
-	assert.NotNil(t, spot)
+	require.NotNil(t, spot)
 	assert.Equal(t, Pool("prod"), spot.Pool)
 
 	// Empty pool stays empty (back-compat).
 	_, _, err = r.Register(&TunnelHandshake{SpotID: "spot-2", Ports: []int{8080}}, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, Pool(""), r.Get("spot-2").Pool)
+	require.NoError(t, err)
+	spot2 := r.Get("spot-2")
+	require.NotNil(t, spot2)
+	assert.Equal(t, Pool(""), spot2.Pool)
 }
 
 func idsOf(peers []testPeer) []string {


### PR DESCRIPTION
Found by running the suite on a Linux machine without `CAP_NET_ADMIN` — which is not what CI runs on. Both tests pass in CI, and both pass for the wrong reason.

## `TestEnableForwardingOnNonLinux` (and its Disable twin)

Named for the non-Linux early return, but nothing made the code take it. On a Linux host — every CI runner — they fell straight through to the real iptables path:

```go
func TestEnableForwardingOnNonLinux(t *testing.T) {
    // On non-Linux (macOS, etc.), enableForwarding should return nil without error
    err := enableForwarding("10.0.0.1", []int{80, 443})
    ...
```

So in CI they pass **by writing actual DNAT rules into the runner's nat table**, and anywhere without that privilege they fail outright. Neither result says anything about the branch they exist to cover.

The `runtime.GOOS` those early returns read is now indirected through a package variable the tests override, so the branch is exercised on any host and nothing is touched. A third test asserts the override actually diverts what the code reads — without it, a refactor could quietly put both tests back to running iptables against the host and they would still report a pass.

## `TestRegisterPropagatesPool`

Used `assert` where the next line dereferenced the result. `Register` adds a loopback alias, so unprivileged it failed, carried on, and segfaulted:

```
add loopback alias 127.0.0.241: exit status 2: RTNETLINK answers: Operation not permitted
panic: runtime error: invalid memory address or nil pointer dereference
```

A panic takes down the whole test binary, so every other test in the package is reported as failed and the real cause is three screens up under a stack trace. **Three genuine failures were hidden behind it** — `TestTunnelIntegration`, `TestTunnelEndToEnd`, `TestConnMuxWithTunnelClient` — all with the same root cause, all visible now.

`require` instead of `assert` does not make the test pass unprivileged. It makes the one real failure legible instead of burying the package.

## Scope

No production behaviour changes. The `hostGOOS` variable is read exactly where `runtime.GOOS` was, and is only written by tests.

Worth a follow-up, not done here: a unit test asserting that a pool tag flows from `Register` into `TunnelSpot` has no business configuring host networking to do it. That is a dependency worth breaking, but it is a bigger change than making the failure honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)