### PR TITLE
feat(server): pre-create hook — provision the encrypted dataset (#1199)

### DIFF
--- a/internal/server/encryption_hooks.go
+++ b/internal/server/encryption_hooks.go
@@ -77,6 +77,66 @@ func (h *encryptionHooks) encryptedFor(containerName string) (dataset string, re
 	return dataset, ref, true, nil
 }
 
+// PreCreate provisions the encrypted dataset a new container will be
+// built on, and returns the ref that lets every later hook re-resolve the
+// same key.
+//
+// Order matters and is the whole of AC3. The key is resolved BEFORE
+// anything is created, so a KeyProvider outage fails the create having
+// touched nothing — there is no dataset to clean up because none was made.
+// The only window where a partial dataset can exist is between creating it
+// and persisting its ref, and that window is closed by destroying the
+// dataset if the ref cannot be stored.
+//
+// That rollback is not tidiness. A dataset with no recorded ref is
+// unopenable: nothing knows which key unlocks it, so it is neither usable
+// nor safely reusable, and the next create for the same container would
+// fail on a name that already exists. Leaking one is worse than failing.
+func (h *encryptionHooks) PreCreate(ctx context.Context, containerName, tenant string) (zfskey.KeyRef, error) {
+	if !h.enabled() {
+		return zfskey.KeyRef{}, nil
+	}
+	if tenant == "" {
+		return zfskey.KeyRef{}, fmt.Errorf("encryption: tenant is required to create %s", containerName)
+	}
+
+	dataset, err := h.datasets.DatasetFor(containerName)
+	if err != nil {
+		return zfskey.KeyRef{}, fmt.Errorf("resolve dataset for %s: %w", containerName, err)
+	}
+
+	// Wrap is per-tenant and idempotent: a tenant's containers share one
+	// encryptionroot, so the second container reuses the first's key rather
+	// than minting a second one that ZFS would treat as a separate root.
+	key, ref, err := h.provider.Wrap(ctx, tenant)
+	if err != nil {
+		// Nothing has been created, so there is nothing to undo. The
+		// create fails as Unavailable and the operator retries when key
+		// custody is back.
+		return zfskey.KeyRef{}, fmt.Errorf("cannot obtain an encryption key for %s: %w", containerName, err)
+	}
+	h.cachePut(tenant, key)
+
+	if err := h.zfs.CreateEncrypted(ctx, dataset, key); err != nil {
+		return zfskey.KeyRef{}, fmt.Errorf("cannot create the encrypted dataset for %s: %w", containerName, err)
+	}
+
+	if err := h.refs.SetKeyRef(containerName, ref); err != nil {
+		// The dataset exists but nothing records how to unlock it. Undo it.
+		if derr := h.zfs.Destroy(ctx, dataset); derr != nil {
+			// Both failed: say so plainly, because now an operator has to
+			// remove the dataset by hand before the name can be reused.
+			return zfskey.KeyRef{}, fmt.Errorf(
+				"could not record the encryption key ref for %s (%w), and rolling back its "+
+					"dataset %s also failed (%v) — that dataset is unopenable and must be "+
+					"destroyed manually before the name can be reused", containerName, err, dataset, derr)
+		}
+		return zfskey.KeyRef{}, fmt.Errorf("could not record the encryption key ref for %s: %w", containerName, err)
+	}
+
+	return ref, nil
+}
+
 // PreStart loads the container's encryption key so its dataset can be
 // mounted.
 //

--- a/internal/server/encryption_hooks_integration_test.go
+++ b/internal/server/encryption_hooks_integration_test.go
@@ -18,6 +18,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,6 +48,17 @@ func (m *memKeyRefStore) SetKeyRef(name string, ref zfskey.KeyRef) error {
 type fixedResolver struct{ datasets map[string]string }
 
 func (f fixedResolver) DatasetFor(name string) (string, error) { return f.datasets[name], nil }
+
+// unavailableKeys stands in for key custody being unreachable.
+type unavailableKeys struct{}
+
+func (unavailableKeys) Wrap(context.Context, string) (zfskey.Key, zfskey.KeyRef, error) {
+	return zfskey.Key{}, zfskey.KeyRef{}, errors.New("key custody unavailable")
+}
+
+func (unavailableKeys) Load(context.Context, zfskey.KeyRef) (zfskey.Key, error) {
+	return zfskey.Key{}, errors.New("key custody unavailable")
+}
 
 // harness wires real encryption machinery over a throwaway pool.
 type harness struct {
@@ -81,21 +93,22 @@ func newHarness(t *testing.T) *harness {
 	return h
 }
 
-// createBox mints a key, creates the encrypted dataset, and records the ref
-// the way the create path does.
+// createBox provisions a box through PreCreate — the hook the create path
+// calls — rather than reproducing its steps here.
+//
+// It used to mint the key, create the dataset and record the ref itself,
+// which meant every test below exercised a local imitation of the create
+// path instead of the path itself. A divergence between the two would have
+// left these tests passing against code production does not run.
 func (h *harness) createBox(t *testing.T, ctx context.Context, container, tenant string) string {
 	t.Helper()
-	key, ref, err := h.keys.Wrap(ctx, tenant)
-	if err != nil {
-		t.Fatalf("KeyProvider.Wrap(%s): %v", tenant, err)
-	}
+	// The resolver has to know the dataset before the hook asks for it;
+	// in production that mapping comes from the storage layout.
 	dataset := h.pool.Dataset(container)
-	if err := h.hooks.zfs.CreateEncrypted(ctx, dataset, key); err != nil {
-		t.Fatalf("CreateEncrypted(%s): %v", dataset, err)
-	}
 	h.res.datasets[container] = dataset
-	if err := h.hooks.RecordKeyRef(container, ref); err != nil {
-		t.Fatalf("RecordKeyRef: %v", err)
+
+	if _, err := h.hooks.PreCreate(ctx, container, tenant); err != nil {
+		t.Fatalf("PreCreate(%s, %s): %v", container, tenant, err)
 	}
 	return dataset
 }
@@ -252,5 +265,81 @@ func TestIntegrationEncryption_PostStopDoesNotBlockOnFailure(t *testing.T) {
 	if status, err := h.hooks.zfs.KeyStatus(ctx, dataset); err != nil || status != zfscrypt.KeyAvailable {
 		t.Errorf("keystatus = %q (err %v); a refused unload must leave the dataset as it was",
 			status, err)
+	}
+}
+
+// #1199 AC1: a container created encrypted has its own encryptionroot,
+// distinct from another tenant's.
+//
+// Only checkable against real ZFS. The unit tests can show PreCreate asks
+// for a per-tenant key, but "these two datasets are under different
+// encryptionroots" is a property ZFS computes, not one the caller asserts —
+// and it is the property the whole tenant boundary rests on. If two tenants
+// landed under one root, either tenant's key would unlock the other's data
+// and every unit test would still pass.
+func TestIntegrationEncryption_PreCreateGivesEachTenantItsOwnRoot(t *testing.T) {
+	ctx := context.Background()
+	h := newHarness(t)
+
+	aliceOne := h.createBox(t, ctx, "alice-one", "alice")
+	aliceTwo := h.createBox(t, ctx, "alice-two", "alice")
+	bobOne := h.createBox(t, ctx, "bob-one", "bob")
+
+	rootOf := func(dataset string) string {
+		t.Helper()
+		root, err := h.hooks.zfs.EncryptionRoot(ctx, dataset)
+		if err != nil {
+			t.Fatalf("EncryptionRoot(%s): %v", dataset, err)
+		}
+		return root
+	}
+
+	aliceRoot1, aliceRoot2, bobRoot := rootOf(aliceOne), rootOf(aliceTwo), rootOf(bobOne)
+
+	// Each dataset is its own encryptionroot: PreCreate creates every one
+	// with its own key material rather than inheriting a parent's.
+	if aliceRoot1 != aliceOne {
+		t.Errorf("alice-one's encryptionroot is %q, not itself (%q) — it inherited a parent's "+
+			"key, so it is not independently lockable", aliceRoot1, aliceOne)
+	}
+	if bobRoot != bobOne {
+		t.Errorf("bob-one's encryptionroot is %q, not itself (%q)", bobRoot, bobOne)
+	}
+
+	// The boundary that matters: no tenant's dataset sits under another's
+	// root.
+	if aliceRoot1 == bobRoot || aliceRoot2 == bobRoot {
+		t.Errorf("alice and bob share an encryptionroot (%q) — one tenant's key would unlock "+
+			"the other's data", bobRoot)
+	}
+}
+
+// #1199 AC3, against a real pool: the KeyProvider being down must leave no
+// dataset behind. A unit test shows no create was attempted; this shows the
+// pool is genuinely unchanged, which is what "no partial dataset" means.
+func TestIntegrationEncryption_PreCreateLeavesNothingWhenKeysAreUnavailable(t *testing.T) {
+	ctx := context.Background()
+	h := newHarness(t)
+
+	// The provider is stubbed to fail rather than misconfigured into
+	// failing: what is under test is the pool's state afterwards, and a
+	// provider that fails for an incidental reason would make the outcome
+	// depend on how it happened to break.
+	h.hooks.provider = unavailableKeys{}
+
+	dataset := h.pool.Dataset("doomed")
+	h.res.datasets["doomed"] = dataset
+
+	if _, err := h.hooks.PreCreate(ctx, "doomed", "alice"); err == nil {
+		t.Fatal("PreCreate succeeded with key custody unavailable")
+	}
+
+	exists, err := h.hooks.zfs.Exists(ctx, dataset)
+	if err != nil {
+		t.Fatalf("Exists(%s): %v", dataset, err)
+	}
+	if exists {
+		t.Errorf("dataset %s survived a failed create — it is unopenable, and the next create "+
+			"for this container fails on a name that already exists", dataset)
 	}
 }

--- a/internal/server/encryption_hooks_test.go
+++ b/internal/server/encryption_hooks_test.go
@@ -18,10 +18,25 @@ type fakeKeyProvider struct {
 	key      zfskey.Key
 	loadErr  error
 	loadCall int
+	wrapErr  error
+	wrapCall int
+	// wrapped records the tenants Wrap was called for, in order.
+	wrapped []string
 }
 
-func (f *fakeKeyProvider) Wrap(context.Context, string) (zfskey.Key, zfskey.KeyRef, error) {
-	return f.key, zfskey.KeyRef{Scheme: zfskey.SchemeFile, URI: "/keys/alice.key"}, nil
+func (f *fakeKeyProvider) Wrap(_ context.Context, tenant string) (zfskey.Key, zfskey.KeyRef, error) {
+	f.wrapCall++
+	if f.wrapErr != nil {
+		return zfskey.Key{}, zfskey.KeyRef{}, f.wrapErr
+	}
+	f.wrapped = append(f.wrapped, tenant)
+	// Per-tenant URI, matching the real contract: a tenant's containers
+	// share one key, and two tenants never do.
+	uri := "/keys/" + tenant + ".key"
+	if tenant == "" {
+		uri = "/keys/alice.key"
+	}
+	return f.key, zfskey.KeyRef{Scheme: zfskey.SchemeFile, URI: uri}, nil
 }
 
 func (f *fakeKeyProvider) Load(context.Context, zfskey.KeyRef) (zfskey.Key, error) {
@@ -35,6 +50,9 @@ func (f *fakeKeyProvider) Load(context.Context, zfskey.KeyRef) (zfskey.Key, erro
 type fakeRefStore struct {
 	refs map[string]zfskey.KeyRef
 	err  error
+	// setErr fails only writes, which is the window PreCreate has to roll
+	// back: the dataset exists but nothing records how to unlock it.
+	setErr error
 }
 
 func (f *fakeRefStore) GetKeyRef(name string) (zfskey.KeyRef, bool, error) {
@@ -46,6 +64,9 @@ func (f *fakeRefStore) GetKeyRef(name string) (zfskey.KeyRef, bool, error) {
 }
 
 func (f *fakeRefStore) SetKeyRef(name string, ref zfskey.KeyRef) error {
+	if f.setErr != nil {
+		return f.setErr
+	}
 	if f.err != nil {
 		return f.err
 	}
@@ -346,5 +367,164 @@ func TestCorruptKeyRefIsAnError(t *testing.T) {
 	}
 	if _, _, err := s.GetKeyRef("alice-container"); err == nil {
 		t.Error("a corrupt key ref must not be read as 'no encryption'")
+	}
+}
+
+// --- PreCreate (#1199) -------------------------------------------------
+
+// sameRef compares the identity of two refs. KeyRef carries a Metadata map,
+// so it is not comparable with ==; Scheme and URI are what identify the key.
+func sameRef(a, b zfskey.KeyRef) bool {
+	return a.Scheme == b.Scheme && a.URI == b.URI
+}
+
+// testHooksWith is testHooks with a ref store the caller can break.
+func testHooksWith(t *testing.T, z *zfsFake, p *fakeKeyProvider, refs *fakeRefStore) *encryptionHooks {
+	t.Helper()
+	return &encryptionHooks{
+		provider: p,
+		zfs:      zfscrypt.NewManager(z),
+		cache:    zfskey.NewCache(time.Hour),
+		refs:     refs,
+		datasets: fakeDatasets{prefix: "pool/containers"},
+	}
+}
+
+func TestPreCreate_CreatesAnEncryptedDatasetAndRecordsItsRef(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}}
+
+	ref, err := testHooksWith(t, z, p, refs).PreCreate(context.Background(), "alice-container", "alice")
+	if err != nil {
+		t.Fatalf("PreCreate: %v", err)
+	}
+
+	if !z.ran("create") || !z.ran("encryption=on") {
+		t.Errorf("no encrypted dataset was created; calls=%v", z.calls)
+	}
+	if !z.ran("pool/containers/alice-container") {
+		t.Errorf("created the wrong dataset; calls=%v", z.calls)
+	}
+	if !sameRef(refs.refs["alice-container"], ref) {
+		t.Errorf("stored ref %v, returned %v — every later hook re-resolves the key from the "+
+			"stored one, so a mismatch means the container cannot be started",
+			refs.refs["alice-container"], ref)
+	}
+}
+
+// A tenant's containers share one encryptionroot, and two tenants never do.
+// Wrap is what guarantees it, so PreCreate must ask per tenant — not per
+// container, which would mint a second key and a second root for the same
+// tenant.
+func TestPreCreate_KeysPerTenantNotPerContainer(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}}
+	h := testHooksWith(t, z, p, refs)
+	ctx := context.Background()
+
+	first, err := h.PreCreate(ctx, "alice-one", "alice")
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	second, err := h.PreCreate(ctx, "alice-two", "alice")
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	other, err := h.PreCreate(ctx, "bob-one", "bob")
+	if err != nil {
+		t.Fatalf("other tenant: %v", err)
+	}
+
+	if !sameRef(first, second) {
+		t.Errorf("the same tenant's two containers got different key refs (%v vs %v) — they "+
+			"would sit under separate encryptionroots", first, second)
+	}
+	if sameRef(other, first) {
+		t.Errorf("two tenants share a key ref (%v) — one tenant's key would unlock another's "+
+			"data, which is the whole boundary this design exists to draw", other)
+	}
+	for _, tenant := range p.wrapped {
+		if tenant != "alice" && tenant != "bob" {
+			t.Errorf("Wrap was called for %q, not a tenant", tenant)
+		}
+	}
+}
+
+// AC3: KeyProvider down at create time must leave nothing behind. The key is
+// resolved first precisely so there is nothing to clean up.
+func TestPreCreate_KeyProviderDownCreatesNothing(t *testing.T) {
+	z := newZFSFake()
+	p := &fakeKeyProvider{key: aKey(t), wrapErr: errors.New("kms unreachable")}
+	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}}
+
+	_, err := testHooksWith(t, z, p, refs).PreCreate(context.Background(), "alice-container", "alice")
+	if err == nil {
+		t.Fatal("PreCreate succeeded with the key provider down")
+	}
+	if z.ran("create") {
+		t.Errorf("a dataset was created despite having no key; calls=%v — it would be "+
+			"unopenable and would block the name on retry", z.calls)
+	}
+	if len(refs.refs) != 0 {
+		t.Errorf("a key ref was recorded for a container that was never created: %v", refs.refs)
+	}
+}
+
+// The one window where a partial dataset can exist: created, but its ref not
+// recorded. Nothing knows which key unlocks it, so it is neither usable nor
+// safely reusable — it must be destroyed.
+func TestPreCreate_RollsBackTheDatasetWhenTheRefCannotBeStored(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}, setErr: errors.New("incus unreachable")}
+
+	_, err := testHooksWith(t, z, p, refs).PreCreate(context.Background(), "alice-container", "alice")
+	if err == nil {
+		t.Fatal("PreCreate succeeded without recording the key ref")
+	}
+	if !z.ran("destroy") {
+		t.Errorf("the dataset was left behind with no recorded key; calls=%v — nothing can "+
+			"unlock it and the next create fails on a name that already exists", z.calls)
+	}
+}
+
+// When the rollback itself fails, the error has to say so — an operator now
+// has to remove the dataset by hand before the name can be reused.
+func TestPreCreate_SaysSoWhenTheRollbackAlsoFails(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	z.errs["destroy"] = errors.New("dataset busy")
+	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}, setErr: errors.New("incus unreachable")}
+
+	_, err := testHooksWith(t, z, p, refs).PreCreate(context.Background(), "alice-container", "alice")
+	if err == nil {
+		t.Fatal("PreCreate succeeded")
+	}
+	msg := err.Error()
+	for _, want := range []string{"pool/containers/alice-container", "manually"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the error does not mention %q, so an operator cannot act on it: %v", want, err)
+		}
+	}
+}
+
+// Encryption unconfigured must not fail a create — the flag defaults off and
+// existing deployments keep working.
+func TestPreCreate_NoOpWhenEncryptionIsNotConfigured(t *testing.T) {
+	var h *encryptionHooks
+	ref, err := h.PreCreate(context.Background(), "alice-container", "alice")
+	if err != nil {
+		t.Errorf("a nil hooks receiver failed the create: %v", err)
+	}
+	if ref.URI != "" || ref.Scheme != "" {
+		t.Errorf("returned a key ref with no provider configured: %v", ref)
+	}
+}
+
+func TestPreCreate_RequiresATenant(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}}
+
+	if _, err := testHooksWith(t, z, p, refs).PreCreate(context.Background(), "orphan", ""); err == nil {
+		t.Error("an empty tenant was accepted — Wrap would key the dataset under a tenant that " +
+			"does not exist, and no later hook could resolve it")
 	}
 }


### PR DESCRIPTION
Advances #1199. `CreateEncrypted` has existed since #1230 and **nothing called it** — this adds the hook that does.

## Scope, stated up front

This covers the create-side acceptance criteria (AC1–AC3). It does **not** wire `PreCreate` into `Create()`, because that needs Incus's "instance from an existing dataset" path, which I cannot exercise in this environment. Guessing at an external API I can't run is how a previous pair of PRs here shipped against a type no caller could produce, so I'd rather leave that step explicitly open than pretend.

AC4 and AC5 (start-time `FailedPrecondition`, daemon restart) were already met by `PreStart` in #1232.

## Ordering is the requirement, and it is structural

"KeyProvider down at create time leaves no partial dataset" is enforced by data dependency, not discipline: an encrypted dataset cannot be created without a key, so resolving the key first means an outage fails having touched nothing.

`Wrap` is asked **per tenant, not per container**. A tenant's containers share one encryptionroot; asking per container would mint a second key and split them across two roots.

## The one real window

Between creating the dataset and persisting its ref. Closed by destroying the dataset if the ref cannot be stored.

That rollback is not tidiness. A dataset with no recorded ref is unopenable — nothing knows which key unlocks it, so it is neither usable nor safely reusable, and the next create for that container fails on a name that already exists. When the rollback *itself* fails, the error names the dataset that needs removing by hand, because at that point an operator has to do it.

## The harness was testing an imitation

`createBox` had been minting the key, creating the dataset and recording the ref itself. So every test in that file exercised a local reproduction of the create path rather than the path itself, and a divergence between them would have left those tests passing against code production does not run. It now provisions through `PreCreate`.

## Why two tests need a real pool

- **Distinct encryptionroot per tenant** is a property ZFS computes, not one the caller asserts. If two tenants landed under one root, either tenant's key would unlock the other's data — and every unit test would still pass.
- **"No partial dataset"** means the pool is genuinely unchanged, which only the pool can confirm.

Both run in the existing `zfs-encryption` lane against a real pool.

## Mutation testing

Creating the dataset before resolving the key, dropping the rollback, and keying per container each fail a test.

The first mutation **initially survived**, and it was my mutation that was wrong, not the test: I passed a zero key, which `CreateEncrypted` rejects before running anything, so nothing was created and the assertion held. Redone with a valid key, it fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)