### PR TITLE
build: pin the buf remote plugin versions

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,20 +2,20 @@ version: v2
 managed:
   enabled: false
 plugins:
-  - remote: buf.build/protocolbuffers/go
+  - remote: buf.build/protocolbuffers/go:v1.36.11
     out: pkg/pb
     opt:
       - paths=source_relative
-  - remote: buf.build/grpc/go
+  - remote: buf.build/grpc/go:v1.6.2
     out: pkg/pb
     opt:
       - paths=source_relative
-  - remote: buf.build/grpc-ecosystem/gateway
+  - remote: buf.build/grpc-ecosystem/gateway:v2.31.0
     out: pkg/pb
     opt:
       - paths=source_relative
       - generate_unbound_methods=true
-  - remote: buf.build/grpc-ecosystem/openapiv2
+  - remote: buf.build/grpc-ecosystem/openapiv2:v2.31.0
     out: api/swagger
     opt:
       - allow_merge=true


### PR DESCRIPTION
The four plugins in `buf.gen.yaml` were declared without versions, so `buf generate` resolves whatever is latest whenever it runs. Running `make proto` on an unchanged tree today rewrites **279 lines across 15 files**, none of it from a proto change.

## The churn is behavioural, not cosmetic

The gateway plugin moved where the request body is drained relative to path-parameter parsing:

```diff
-	if req.Body != nil {
-		_, _ = io.Copy(io.Discard, req.Body)
-	}
 	val, ok := pathParams["id"]
 	...
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
```

So regenerating silently changes when the body is consumed on a parse error.

## Two consequences, the second worse

Locally, anyone touching a `.proto` gets an unrelated 15-file diff mixed into their change.

More importantly, `release.yml` runs `make proto` transitively through `make build-release` (its own comment says so). So a **release** could be built from generated code nobody reviewed — whatever the plugins happened to resolve to that morning.

## The tree had already drifted

`backup.pb.gw.go` was generated by a different gateway version than its siblings. That is what unpinned plugins look like after two people regenerate months apart, and it is why this is worth fixing rather than living with.

## Choosing the versions

Pinned to what reproduces the committed output **exactly**, not to the newest available:

| plugin | version | how it was determined |
| --- | --- | --- |
| `protocolbuffers/go` | v1.36.11 | recorded in the files it emits |
| `grpc/go` | v1.6.2 | recorded in the files it emits |
| `grpc-ecosystem/gateway` | v2.31.0 | found by regenerating against candidates until the diff was empty |
| `grpc-ecosystem/openapiv2` | v2.31.0 | same |

The gateway pair does not stamp its version into its output, so those had to be searched for. v2.29.0 — matching the runtime in `go.mod` — was the obvious first guess and is **wrong**: its openapiv2 drops every service description from the swagger tags, which would quietly regress the API docs. v2.30.0 does not reproduce either. v2.31.0 and v2.32.0 both do; the earlier is pinned.

## Verification

`make proto` is now a no-op on a clean tree — zero files differ. That is what makes these pins checkable rather than asserted; a wrong pin shows up immediately as a diff.

## Noted, not fixed here

The generated gateway code comes from v2.31.0 while `go.mod` pins the runtime at v2.29.0. They are compatible today — this is what has been building and passing all along — but the two want to move together. That is a dependency change rather than a build one, so it is not in this PR.

There is also no CI check that `make proto` leaves the tree clean. Pinning makes such a check meaningful for the first time, since before this it would have failed on generator releases rather than on real drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)