### PR TITLE
Revert "build: pin the buf remote plugin versions (#1282)"

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,20 +2,20 @@ version: v2
 managed:
   enabled: false
 plugins:
-  - remote: buf.build/protocolbuffers/go:v1.36.11
+  - remote: buf.build/protocolbuffers/go
     out: pkg/pb
     opt:
       - paths=source_relative
-  - remote: buf.build/grpc/go:v1.6.2
+  - remote: buf.build/grpc/go
     out: pkg/pb
     opt:
       - paths=source_relative
-  - remote: buf.build/grpc-ecosystem/gateway:v2.31.0
+  - remote: buf.build/grpc-ecosystem/gateway
     out: pkg/pb
     opt:
       - paths=source_relative
       - generate_unbound_methods=true
-  - remote: buf.build/grpc-ecosystem/openapiv2:v2.31.0
+  - remote: buf.build/grpc-ecosystem/openapiv2
     out: api/swagger
     opt:
       - allow_merge=true


### PR DESCRIPTION
**`make proto` is broken on `main` right now, and #1282 is why.** This reverts it.

```
Failure: not_found: plugin version "v2.31.0" was not found for existing
plugin "buf.build/grpc-ecosystem/gateway" with latest version "v2.30.0"
```

v2.31.0 does not exist. `release.yml` runs `make proto` transitively through `make build-release`, so a release build would fail on this too.

## How I got it wrong

The pin values came from a version search that measured the wrong thing. It ran:

```bash
make proto >/dev/null 2>&1
n=$(git status --short -- pkg/pb api/swagger | wc -l)
```

A run that **failed** — nonexistent plugin version, or BSR rate limiting, which I hit while re-checking just now — changes no files and scores as a perfect reproduction. The two versions I concluded "reproduce the committed output exactly" (v2.31.0, v2.32.0) were the two that never ran at all. The one real signal in that table was v2.30.0's 15-file diff, which I read as the wrong answer when it was the only measured one.

The irony is that #1283's proto check caught this within minutes of the pin landing — a guard I wrote, failing on the change I wrote it alongside. It did its job; I had merged the pin before its own guard was in place to check it.

## Revert rather than re-pin

A wrong pin breaks the build outright. Unpinned merely makes regeneration non-reproducible, which is the pre-existing state and not an outage. And I cannot re-measure reliably at the moment without hitting the rate limit that caused half the confusion.

## What still stands

The underlying observation is real and worth redoing properly: unpinned plugins mean `make proto` is not reproducible, `backup.pb.gw.go` is already generated by a different version than its siblings, and release builds regenerate from whatever resolves that morning.

Redoing it needs three things I did not do:
- check the exit code of every `make proto`, not just the resulting diff
- account for BSR rate limiting producing the same silent no-op
- verify the chosen version actually exists before concluding it reproduces anything

#1283 (the proto-drift check) is blocked behind that: with unpinned plugins it fails on upstream plugin releases rather than real drift, which is exactly why I sequenced pinning first. I will hold it rather than merge a guard that cries wolf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)