### PR TITLE
fix(crew): record a run while it is in flight, and clone in the store

### DIFF
--- a/internal/server/crew_run_store.go
+++ b/internal/server/crew_run_store.go
@@ -3,13 +3,20 @@ package server
 import (
 	"sync"
 
+	"google.golang.org/protobuf/proto"
+
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
 )
 
 // crewRunStore is an in-memory record of crew executions, keyed by run id.
-// Phase 3 keeps runs in memory (they don't survive a daemon restart); a
-// Postgres-backed store mirrors the network-policy store pattern when run
-// durability is needed.
+// Runs do not survive a daemon restart; a Postgres-backed store mirroring the
+// network-policy store pattern is tracked in #1182.
+//
+// Entries are cloned on the way in and on the way out, which is what makes a
+// run safe to store while it is still being driven. Handing out the same
+// pointer the caller keeps mutating would let GetCrewRun observe a run
+// mid-write — a proto message is several fields, and nothing makes updating
+// them atomic.
 type crewRunStore struct {
 	mu   sync.RWMutex
 	runs map[string]*pb.CrewRun
@@ -20,14 +27,20 @@ func newCrewRunStore() *crewRunStore {
 }
 
 func (s *crewRunStore) put(r *pb.CrewRun) {
+	if r == nil {
+		return
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.runs[r.Id] = r
+	s.runs[r.Id] = proto.Clone(r).(*pb.CrewRun)
 }
 
 func (s *crewRunStore) get(id string) (*pb.CrewRun, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	r, ok := s.runs[id]
-	return r, ok
+	if !ok {
+		return nil, false
+	}
+	return proto.Clone(r).(*pb.CrewRun), true
 }

--- a/internal/server/crew_run_store_test.go
+++ b/internal/server/crew_run_store_test.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"sync"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// The store hands out copies, not the entry it holds.
+//
+// Without this, a run stored while it is still being driven is the same
+// object the driver keeps writing to, so GetCrewRun can observe it mid-write.
+// A proto message is several fields and nothing makes updating them atomic —
+// a reader could see COMPLETED with the error text of a failure still set.
+func TestCrewRunStore_MutatingWhatYouPutDoesNotChangeWhatIsStored(t *testing.T) {
+	s := newCrewRunStore()
+	run := &pb.CrewRun{Id: "r1", State: pb.CrewRunState_CREW_RUN_STATE_RUNNING}
+	s.put(run)
+
+	run.State = pb.CrewRunState_CREW_RUN_STATE_FAILED
+	run.Error = "not yet stored"
+
+	got, ok := s.get("r1")
+	if !ok {
+		t.Fatal("run vanished")
+	}
+	if got.State != pb.CrewRunState_CREW_RUN_STATE_RUNNING {
+		t.Errorf("state = %v, want RUNNING — the caller's later writes leaked into the store",
+			got.State)
+	}
+	if got.Error != "" {
+		t.Errorf("error = %q, want empty", got.Error)
+	}
+}
+
+// The same in the other direction: what a reader gets back cannot be used to
+// corrupt the store for the next reader.
+func TestCrewRunStore_MutatingWhatYouGetDoesNotChangeWhatIsStored(t *testing.T) {
+	s := newCrewRunStore()
+	s.put(&pb.CrewRun{Id: "r1", State: pb.CrewRunState_CREW_RUN_STATE_COMPLETED})
+
+	first, _ := s.get("r1")
+	first.State = pb.CrewRunState_CREW_RUN_STATE_FAILED
+	first.Error = "scribbled by a reader"
+
+	second, _ := s.get("r1")
+	if second.State != pb.CrewRunState_CREW_RUN_STATE_COMPLETED || second.Error != "" {
+		t.Errorf("a reader's edits changed the stored run: state=%v error=%q",
+			second.State, second.Error)
+	}
+}
+
+// A later put replaces the entry, which is how a run reaches its terminal
+// state after being recorded as RUNNING.
+func TestCrewRunStore_PutReplacesTheEntry(t *testing.T) {
+	s := newCrewRunStore()
+	s.put(&pb.CrewRun{Id: "r1", State: pb.CrewRunState_CREW_RUN_STATE_RUNNING})
+	s.put(&pb.CrewRun{Id: "r1", State: pb.CrewRunState_CREW_RUN_STATE_COMPLETED, ArtifactJson: "{}"})
+
+	got, _ := s.get("r1")
+	if got.State != pb.CrewRunState_CREW_RUN_STATE_COMPLETED {
+		t.Errorf("state = %v, want COMPLETED", got.State)
+	}
+	if got.ArtifactJson != "{}" {
+		t.Errorf("artifact = %q, want the terminal one", got.ArtifactJson)
+	}
+}
+
+// The hazard the clone exists for: a run is recorded while it is still being
+// driven, so the driver goes on mutating the very object it handed the store
+// while GetCrewRun reads it.
+//
+// The writer here mutates the run it already put — not a fresh one — because
+// that is what crew_server.go does. A version of this test whose writer puts
+// new objects each time proves nothing: the map is mutex-guarded either way,
+// and the race is in the shared message, not the map. Run with -race.
+func TestCrewRunStore_DriverMutationsDoNotRaceWithReaders(t *testing.T) {
+	s := newCrewRunStore()
+	run := &pb.CrewRun{Id: "r1", State: pb.CrewRunState_CREW_RUN_STATE_RUNNING}
+	s.put(run)
+
+	// A start barrier, so readers and the writer genuinely overlap. Without
+	// one the writer's loop can finish before any reader is scheduled, and
+	// the test passes whether or not the store clones — which is the version
+	// of this test I wrote first, and it did.
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 2000; j++ {
+				if got, ok := s.get("r1"); ok {
+					_ = got.State
+					_ = got.Error
+					_ = got.ArtifactJson
+				}
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		// Exactly the crew_server.go shape: keep writing the local run, then
+		// re-put it on reaching a terminal state.
+		for j := 0; j < 2000; j++ {
+			run.State = pb.CrewRunState_CREW_RUN_STATE_COMPLETED
+			run.ArtifactJson = "{}"
+			run.Error = ""
+		}
+		s.put(run)
+	}()
+
+	close(start)
+	wg.Wait()
+}
+
+func TestCrewRunStore_NilPutIsIgnored(t *testing.T) {
+	s := newCrewRunStore()
+	s.put(nil) // must not panic
+	if _, ok := s.get(""); ok {
+		t.Error("a nil run created an entry")
+	}
+}

--- a/internal/server/crew_server.go
+++ b/internal/server/crew_server.go
@@ -94,6 +94,18 @@ func (s *CrewServer) RunCrew(ctx context.Context, req *pb.RunCrewRequest) (*pb.R
 		InputJson: req.InputJson,
 	}
 
+	// Record the run before driving it, so an in-flight run is observable.
+	//
+	// Previously the first write happened only after driveCrew returned, so
+	// GetCrewRun answered NotFound for the entire duration of a run — the one
+	// window where a caller most wants to look — and CREW_RUN_STATE_RUNNING
+	// was set on a struct that was overwritten before anyone could read it.
+	// The state existed in the proto and never in the store.
+	//
+	// Safe to store now because the store clones: the mutations below act on
+	// the local run, and each put replaces the stored copy.
+	s.runs.put(run)
+
 	// Provision each member box (scoped token + per-box allowed_peers policy)
 	// and start it in serve mode so it serves /tasks for the hops below. Members
 	// are seeded with no task input — the crew delivers per-hop input over A2A.


### PR DESCRIPTION
Found while scoping #1182 (durable agent run state). Independent of it, and worth fixing on its own.

## GetCrewRun could never see a running run

The first write to the store happened only *after* `driveCrew` returned:

```go
run := &pb.CrewRun{ State: CREW_RUN_STATE_RUNNING, ... }
// ... provision boxes, drive every A2A hop ...
run.State = COMPLETED
s.runs.put(run)   // first and only write for a successful run
```

So `GetCrewRun` answered `NotFound` for the entire duration of a run — the one window where a caller most wants to look is the one window with nothing to see.

And `CREW_RUN_STATE_RUNNING` was set on a struct that was overwritten before anyone could read it. The state existed in the proto and never in the store: nothing could reach it, nothing could observe a run as running, and #1182's acceptance criterion "a crew run left `RUNNING` across a restart reaches a terminal state" could not even be exercised, because no run is ever stored as `RUNNING`.

## Recording it early requires the store to clone

Otherwise the stored entry *is* the object `driveCrew` keeps writing to, and a concurrent `GetCrewRun` reads a message mid-write. A `CrewRun` is several fields and nothing makes updating them atomic — a reader could see `COMPLETED` carrying the error text of a failure.

The store now clones on both `put` and `get`, matching what `NetworkPolicyStore` already does for the same reason.

## The race test needed two corrections to be worth anything

Recording this because the test is the evidence for the change, and my first two versions were not evidence of anything:

1. **The writer put fresh objects each iteration.** That cannot race — the map is mutex-guarded either way, and the hazard is in the shared *message*. Fixed to mutate the run it already put, which is exactly what `crew_server.go` does.
2. **No start barrier.** The writer's loop finished before any reader was scheduled, so the test passed with the clone removed. Fixed with a barrier and more iterations.

With both corrections, removing the clone reports `DATA RACE`; with the clone it is clean. Verified in both directions rather than assumed.

Full `internal/server` suite passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)