### PR TITLE
fix(server): stop the K8s network-policy reconciler on shutdown

### DIFF
--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -2439,6 +2439,9 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		if ds.networkPolicyEnforcer != nil {
 			ds.networkPolicyEnforcer.Stop()
 		}
+		if ds.k8sNetPolicyReconciler != nil {
+			ds.k8sNetPolicyReconciler.Stop()
+		}
 		if ds.metricsCollector != nil {
 			ds.metricsCollector.Stop()
 		}

--- a/internal/server/dual_server_wiring_test.go
+++ b/internal/server/dual_server_wiring_test.go
@@ -5,6 +5,8 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"regexp"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -223,5 +225,56 @@ func TestNewDualServerWiresTheK8sSessionSource(t *testing.T) {
 	if !dualServerSourceContains(t, "audit.NewSSHCollectorWithSource(") {
 		t.Error("the K8s branch no longer builds the collector from a source — it would fall back " +
 			"to the incus constructor, which cannot reach a K8s box (#1189)")
+	}
+}
+
+// Everything the daemon starts must also be stopped on shutdown.
+//
+// The shutdown block stops thirteen components by name. Adding a fourteenth
+// Start without the matching Stop is a one-line omission that nothing catches:
+// the daemon still boots, still serves, still passes every test, and only
+// leaks a goroutine that keeps writing to the apiserver after Start has
+// returned. That is exactly how k8sNetPolicyReconciler shipped in #1264 —
+// started, never stopped, and the only one of thirteen missing.
+//
+// Checked against the source rather than at runtime because the omission is
+// in the wiring, and the wiring is what a runtime test would have to stand up
+// in full to observe.
+func TestEverythingStartedIsAlsoStopped(t *testing.T) {
+	b, err := os.ReadFile("dual_server.go")
+	if err != nil {
+		t.Fatalf("read dual_server.go: %v", err)
+	}
+	src := string(b)
+
+	// Components with no Stop method at all, and why. A ctx-driven blocking
+	// Start needs no separate stop — it returns when the context is done.
+	noStopMethod := map[string]string{
+		"gatewayServer": "Start(ctx) blocks and returns when ctx is done; GatewayServer has no Stop",
+	}
+
+	started := regexp.MustCompile(`ds\.(\w+)\.Start\(`).FindAllStringSubmatch(src, -1)
+	if len(started) == 0 {
+		t.Fatal("found no ds.<field>.Start( calls — the pattern changed, so this guard is blind")
+	}
+
+	var missing []string
+	for _, m := range started {
+		field := m[1]
+		if reason, ok := noStopMethod[field]; ok {
+			t.Logf("%s: not stopped, by design (%s)", field, reason)
+			continue
+		}
+		if !strings.Contains(src, "ds."+field+".Stop()") {
+			missing = append(missing, field)
+		}
+	}
+
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("these components are started and never stopped on shutdown:\n  %s\n"+
+			"Each keeps its goroutines running after Start returns. Add a Stop() call to the "+
+			"ctx.Done() block, or record it in noStopMethod above with the reason.",
+			strings.Join(missing, "\n  "))
 	}
 }


### PR DESCRIPTION
`k8sNetPolicyReconciler` was the **only** component started and never stopped. Thirteen others are all named in the `ctx.Done()` block; mine, from #1264, was not.

## Why nothing caught it

The daemon still boots, still serves, and still passes every test. The reconciler's goroutine simply outlives `Start` and keeps applying NetworkPolicy objects to the apiserver after the daemon has decided to shut down. Its `Stop` also waits on the WaitGroup, so a shutdown could previously return mid-apply.

Found with `deadcode`, which reported `K8sNetworkPolicyReconciler.Stop` as unreachable. A lifecycle method nobody calls is a lifecycle that does not happen.

## The guard is the more useful half

One-line omissions like this recur. So rather than only fixing the instance, the guard reads the started set out of `dual_server.go` and requires a matching `Stop` for each — the fourteenth component cannot repeat it.

`gatewayServer` is recorded as a deliberate exception with its reason: `Start(ctx)` blocks and returns when the context is done, and the type has no `Stop` at all. Anything else without a stop has to be added there explicitly, which makes the exception a decision rather than an oversight.

It checks the source rather than the runtime because the omission is *in* the wiring — a runtime test would have to stand the whole daemon up to observe what a short parse states directly. The file already has precedent for this: `TestNewDualServerWiresK8sNetworkPolicyReconciler` and its siblings work the same way.

## Verification

Mutation-tested in both directions: removing the newly added `Stop`, and removing an unrelated component's (`autoSleepManager`), each fail the guard. The guard also fails loudly if the `ds.<field>.Start(` pattern ever stops matching, rather than silently checking nothing.

`internal/server` passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)