### PR TITLE
feat(backup): make the engine a typed enum, not a magic string (#1157)

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -6617,6 +6617,15 @@
       "default": "BACKUP_DESTINATION_UNSPECIFIED",
       "description": "BackupDestination is where a logical dump is stored *off* the database\nhost. The whole point of the feature is getting the data off-box, so a\ndestination is always required — there is no \"stay on the same disk\"\noption (a dump that shares a failure domain with the database it came\nfrom is not a backup; see docs/DB-BACKUP-OPERATIONS.md).\n\n - BACKUP_DESTINATION_UNSPECIFIED: Unset — the daemon rejects a create with this value.\n - BACKUP_DESTINATION_LOCAL: A backup directory on the daemon host, distinct from the container's\nown data disk. Survives container/disk loss but NOT host loss — use\nfor dev or as a staging tier in front of an off-host copy.\n - BACKUP_DESTINATION_GCS: A Google Cloud Storage bucket, written via the host's `gcloud`\n(`gcloud storage cp`). True off-host durability; the recommended\nproduction destination."
     },
+    "BackupEngine": {
+      "type": "string",
+      "enum": [
+        "BACKUP_ENGINE_UNSPECIFIED",
+        "BACKUP_ENGINE_POSTGRES"
+      ],
+      "default": "BACKUP_ENGINE_UNSPECIFIED",
+      "description": "BackupEngine identifies the database engine a backup was taken from.\n\nPostgres is the only engine implemented today; the enum exists so that a\nsecond one has somewhere to be named, and so that the engine a record was\ntaken with is a typed value rather than a string the reader has to trust.\n\n - BACKUP_ENGINE_UNSPECIFIED: Unset, or a record written by a daemon that predates this enum.\nRejected wherever an engine has to be chosen — never treated as\nPostgres by default, because guessing the engine of a dump is how a\nrestore silently targets the wrong one."
+    },
     "BackupRecord": {
       "type": "object",
       "properties": {
@@ -6654,8 +6663,8 @@
           "description": "Concrete location of the dump: a host path for LOCAL, a gs:// URI\nfor GCS."
         },
         "engine": {
-          "type": "string",
-          "description": "Database engine. \"postgres\" is the only engine in v1."
+          "$ref": "#/definitions/BackupEngine",
+          "description": "Database engine the dump was taken with.\n\nAn enum rather than a string because the valid values are an\nenumerated set, so the compiler should be the thing that rejects a\ntypo rather than a driver lookup failing at dump time (#1157)."
         },
         "lastVerification": {
           "$ref": "#/definitions/BackupVerification",

--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -70,6 +70,21 @@ func parseDestination(s string) (pb.BackupDestination, error) {
 }
 
 // destLabel renders a destination enum for human output.
+// engineLabel renders the engine the way it read before it became an enum
+// (#1157). The wire value is now BACKUP_ENGINE_POSTGRES; a human running
+// `backup get` should still see "postgres".
+func engineLabel(e pb.BackupEngine) string {
+	switch e {
+	case pb.BackupEngine_BACKUP_ENGINE_POSTGRES:
+		return "postgres"
+	default:
+		// Covers a record written before the enum existed, and one whose
+		// engine this build does not know. Both are genuinely unknown to
+		// the reader, and saying so beats naming an engine on a guess.
+		return "unspecified"
+	}
+}
+
 func destLabel(d pb.BackupDestination) string {
 	switch d {
 	case pb.BackupDestination_BACKUP_DESTINATION_LOCAL:

--- a/internal/cmd/backup_engine_label_test.go
+++ b/internal/cmd/backup_engine_label_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// `backup get` printed "postgres" before the engine became an enum (#1157).
+// Printing the raw enum would show BACKUP_ENGINE_POSTGRES to a human for no
+// reason — the type change is for the contract, not the console.
+func TestEngineLabel(t *testing.T) {
+	if got := engineLabel(pb.BackupEngine_BACKUP_ENGINE_POSTGRES); got != "postgres" {
+		t.Errorf("engineLabel(POSTGRES) = %q, want %q — the CLI's output should not change "+
+			"because the wire type did", got, "postgres")
+	}
+	if got := engineLabel(pb.BackupEngine_BACKUP_ENGINE_UNSPECIFIED); got != "unspecified" {
+		t.Errorf("engineLabel(UNSPECIFIED) = %q, want %q", got, "unspecified")
+	}
+}

--- a/internal/cmd/backup_get.go
+++ b/internal/cmd/backup_get.go
@@ -31,7 +31,7 @@ func runBackupGet(cmd *cobra.Command, args []string) error {
 	fmt.Printf("ID:          %s\n", r.Id)
 	fmt.Printf("User:        %s\n", r.Username)
 	fmt.Printf("Database:    %s\n", r.Database)
-	fmt.Printf("Engine:      %s\n", r.Engine)
+	fmt.Printf("Engine:      %s\n", engineLabel(r.Engine))
 	fmt.Printf("Created:     %s\n", r.CreatedAt)
 	fmt.Printf("Size:        %s\n", humanBytes(r.SizeBytes))
 	fmt.Printf("SHA-256:     %s\n", r.Sha256)

--- a/internal/server/backup_engine_test.go
+++ b/internal/server/backup_engine_test.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/backup"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// #1157: engine was a string on the wire, so "postgres", "postgress" and ""
+// were all equally valid values of the contract and only a driver lookup at
+// dump time could tell them apart. The manifest still stores a string, so
+// this boundary is where an unrecognised one has to be caught.
+func TestEngineToProto(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		stored string
+		want   pb.BackupEngine
+	}{
+		{"the engine we support", backup.EnginePostgres, pb.BackupEngine_BACKUP_ENGINE_POSTGRES},
+		{"a record predating the enum", "", pb.BackupEngine_BACKUP_ENGINE_UNSPECIFIED},
+		{"an engine this build does not know", "mongodb", pb.BackupEngine_BACKUP_ENGINE_UNSPECIFIED},
+		{"a near miss", "postgress", pb.BackupEngine_BACKUP_ENGINE_UNSPECIFIED},
+		{"differing case is not the same value", "Postgres", pb.BackupEngine_BACKUP_ENGINE_UNSPECIFIED},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := engineToProto(tc.stored); got != tc.want {
+				t.Errorf("engineToProto(%q) = %v, want %v", tc.stored, got, tc.want)
+			}
+		})
+	}
+}
+
+// The failure the enum exists to make impossible: an engine nobody recognises
+// must never present itself as Postgres. A caller reading POSTGRES will hand
+// the dump to pg_restore.
+func TestEngineToProto_NeverGuessesPostgres(t *testing.T) {
+	for _, stored := range []string{"", "mongodb", "mysql", "unknown", "POSTGRES", " postgres"} {
+		if got := engineToProto(stored); got == pb.BackupEngine_BACKUP_ENGINE_POSTGRES {
+			t.Errorf("engineToProto(%q) reported POSTGRES — a caller would hand this dump to "+
+				"pg_restore on the strength of a guess", stored)
+		}
+	}
+}
+
+// The constant the manifest writes and the case this maps must not drift
+// apart: if EnginePostgres changed, every existing record would start
+// reading as UNSPECIFIED and nothing else would notice.
+func TestEngineToProto_MatchesWhatTheManifestWrites(t *testing.T) {
+	if engineToProto(backup.EnginePostgres) != pb.BackupEngine_BACKUP_ENGINE_POSTGRES {
+		t.Fatalf("the mapping does not recognise backup.EnginePostgres (%q) — every record "+
+			"written by this daemon would read as UNSPECIFIED", backup.EnginePostgres)
+	}
+}

--- a/internal/server/backup_server.go
+++ b/internal/server/backup_server.go
@@ -328,6 +328,22 @@ func destToProto(d backup.Destination) pb.BackupDestination {
 	}
 }
 
+// engineToProto maps a stored record's engine to the wire enum.
+//
+// The manifest keeps engine as a string, so records written before the enum
+// existed — and any record whose engine this daemon does not recognise — map
+// to UNSPECIFIED rather than to Postgres. Defaulting an unknown engine to
+// Postgres would present a dump as restorable by pg_restore on the strength
+// of a guess, which is the failure the enum exists to make impossible.
+func engineToProto(engine string) pb.BackupEngine {
+	switch engine {
+	case backup.EnginePostgres:
+		return pb.BackupEngine_BACKUP_ENGINE_POSTGRES
+	default:
+		return pb.BackupEngine_BACKUP_ENGINE_UNSPECIFIED
+	}
+}
+
 func connFromProto(c *pb.PgConnection) backup.PgConn {
 	if c == nil {
 		return backup.PgConn{}
@@ -385,7 +401,7 @@ func recordToProto(r *backup.Record) *pb.BackupRecord {
 		Sha256:      r.SHA256,
 		Destination: destToProto(r.Destination),
 		Location:    r.Location,
-		Engine:      r.Engine,
+		Engine:      engineToProto(r.Engine),
 
 		LastVerification: verificationToProto(r.LastVerification),
 		RelationCount:    r.RelationCount,

--- a/pkg/pb/containarium/v1/backup.pb.go
+++ b/pkg/pb/containarium/v1/backup.pb.go
@@ -84,6 +84,61 @@ func (BackupDestination) EnumDescriptor() ([]byte, []int) {
 	return file_containarium_v1_backup_proto_rawDescGZIP(), []int{0}
 }
 
+// BackupEngine identifies the database engine a backup was taken from.
+//
+// Postgres is the only engine implemented today; the enum exists so that a
+// second one has somewhere to be named, and so that the engine a record was
+// taken with is a typed value rather than a string the reader has to trust.
+type BackupEngine int32
+
+const (
+	// Unset, or a record written by a daemon that predates this enum.
+	// Rejected wherever an engine has to be chosen — never treated as
+	// Postgres by default, because guessing the engine of a dump is how a
+	// restore silently targets the wrong one.
+	BackupEngine_BACKUP_ENGINE_UNSPECIFIED BackupEngine = 0
+	BackupEngine_BACKUP_ENGINE_POSTGRES    BackupEngine = 1
+)
+
+// Enum value maps for BackupEngine.
+var (
+	BackupEngine_name = map[int32]string{
+		0: "BACKUP_ENGINE_UNSPECIFIED",
+		1: "BACKUP_ENGINE_POSTGRES",
+	}
+	BackupEngine_value = map[string]int32{
+		"BACKUP_ENGINE_UNSPECIFIED": 0,
+		"BACKUP_ENGINE_POSTGRES":    1,
+	}
+)
+
+func (x BackupEngine) Enum() *BackupEngine {
+	p := new(BackupEngine)
+	*p = x
+	return p
+}
+
+func (x BackupEngine) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (BackupEngine) Descriptor() protoreflect.EnumDescriptor {
+	return file_containarium_v1_backup_proto_enumTypes[1].Descriptor()
+}
+
+func (BackupEngine) Type() protoreflect.EnumType {
+	return &file_containarium_v1_backup_proto_enumTypes[1]
+}
+
+func (x BackupEngine) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use BackupEngine.Descriptor instead.
+func (BackupEngine) EnumDescriptor() ([]byte, []int) {
+	return file_containarium_v1_backup_proto_rawDescGZIP(), []int{1}
+}
+
 // VerificationResult is the outcome of a restore test. A backup whose
 // bytes are intact but which cannot be loaded by the engine is FAILED —
 // that distinction is the whole point of verification (see #1159).
@@ -125,11 +180,11 @@ func (x VerificationResult) String() string {
 }
 
 func (VerificationResult) Descriptor() protoreflect.EnumDescriptor {
-	return file_containarium_v1_backup_proto_enumTypes[1].Descriptor()
+	return file_containarium_v1_backup_proto_enumTypes[2].Descriptor()
 }
 
 func (VerificationResult) Type() protoreflect.EnumType {
-	return &file_containarium_v1_backup_proto_enumTypes[1]
+	return &file_containarium_v1_backup_proto_enumTypes[2]
 }
 
 func (x VerificationResult) Number() protoreflect.EnumNumber {
@@ -138,7 +193,7 @@ func (x VerificationResult) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use VerificationResult.Descriptor instead.
 func (VerificationResult) EnumDescriptor() ([]byte, []int) {
-	return file_containarium_v1_backup_proto_rawDescGZIP(), []int{1}
+	return file_containarium_v1_backup_proto_rawDescGZIP(), []int{2}
 }
 
 // BackupRecord is the metadata index entry for one stored dump. The dump
@@ -165,8 +220,12 @@ type BackupRecord struct {
 	// Concrete location of the dump: a host path for LOCAL, a gs:// URI
 	// for GCS.
 	Location string `protobuf:"bytes,8,opt,name=location,proto3" json:"location,omitempty"`
-	// Database engine. "postgres" is the only engine in v1.
-	Engine string `protobuf:"bytes,9,opt,name=engine,proto3" json:"engine,omitempty"`
+	// Database engine the dump was taken with.
+	//
+	// An enum rather than a string because the valid values are an
+	// enumerated set, so the compiler should be the thing that rejects a
+	// typo rather than a driver lookup failing at dump time (#1157).
+	Engine BackupEngine `protobuf:"varint,9,opt,name=engine,proto3,enum=containarium.v1.BackupEngine" json:"engine,omitempty"`
 	// Outcome of the most recent restore test, unset until the backup has
 	// been verified. A recorded sha256 proves the bytes are intact; only
 	// this proves the dump is restorable (#1159).
@@ -270,11 +329,11 @@ func (x *BackupRecord) GetLocation() string {
 	return ""
 }
 
-func (x *BackupRecord) GetEngine() string {
+func (x *BackupRecord) GetEngine() BackupEngine {
 	if x != nil {
 		return x.Engine
 	}
-	return ""
+	return BackupEngine_BACKUP_ENGINE_UNSPECIFIED
 }
 
 func (x *BackupRecord) GetLastVerification() *BackupVerification {
@@ -1253,7 +1312,7 @@ var File_containarium_v1_backup_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_backup_proto_rawDesc = "" +
 	"\n" +
-	"\x1ccontainarium/v1/backup.proto\x12\x0fcontainarium.v1\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"\xb7\x03\n" +
+	"\x1ccontainarium/v1/backup.proto\x12\x0fcontainarium.v1\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\"\xd6\x03\n" +
 	"\fBackupRecord\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x12\x1a\n" +
@@ -1264,8 +1323,8 @@ const file_containarium_v1_backup_proto_rawDesc = "" +
 	"size_bytes\x18\x05 \x01(\x03R\tsizeBytes\x12\x16\n" +
 	"\x06sha256\x18\x06 \x01(\tR\x06sha256\x12D\n" +
 	"\vdestination\x18\a \x01(\x0e2\".containarium.v1.BackupDestinationR\vdestination\x12\x1a\n" +
-	"\blocation\x18\b \x01(\tR\blocation\x12\x16\n" +
-	"\x06engine\x18\t \x01(\tR\x06engine\x12P\n" +
+	"\blocation\x18\b \x01(\tR\blocation\x125\n" +
+	"\x06engine\x18\t \x01(\x0e2\x1d.containarium.v1.BackupEngineR\x06engine\x12P\n" +
 	"\x11last_verification\x18\n" +
 	" \x01(\v2#.containarium.v1.BackupVerificationR\x10lastVerification\x12*\n" +
 	"\x0erelation_count\x18\v \x01(\x03H\x00R\rrelationCount\x88\x01\x01B\x11\n" +
@@ -1338,7 +1397,10 @@ const file_containarium_v1_backup_proto_rawDesc = "" +
 	"\x11BackupDestination\x12\"\n" +
 	"\x1eBACKUP_DESTINATION_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18BACKUP_DESTINATION_LOCAL\x10\x01\x12\x1a\n" +
-	"\x16BACKUP_DESTINATION_GCS\x10\x02*y\n" +
+	"\x16BACKUP_DESTINATION_GCS\x10\x02*I\n" +
+	"\fBackupEngine\x12\x1d\n" +
+	"\x19BACKUP_ENGINE_UNSPECIFIED\x10\x00\x12\x1a\n" +
+	"\x16BACKUP_ENGINE_POSTGRES\x10\x01*y\n" +
 	"\x12VerificationResult\x12#\n" +
 	"\x1fVERIFICATION_RESULT_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aVERIFICATION_RESULT_PASSED\x10\x01\x12\x1e\n" +
@@ -1369,60 +1431,62 @@ func file_containarium_v1_backup_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_backup_proto_rawDescData
 }
 
-var file_containarium_v1_backup_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_containarium_v1_backup_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_containarium_v1_backup_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_containarium_v1_backup_proto_goTypes = []any{
 	(BackupDestination)(0),        // 0: containarium.v1.BackupDestination
-	(VerificationResult)(0),       // 1: containarium.v1.VerificationResult
-	(*BackupRecord)(nil),          // 2: containarium.v1.BackupRecord
-	(*VerificationCheck)(nil),     // 3: containarium.v1.VerificationCheck
-	(*BackupVerification)(nil),    // 4: containarium.v1.BackupVerification
-	(*PgConnection)(nil),          // 5: containarium.v1.PgConnection
-	(*CreateBackupRequest)(nil),   // 6: containarium.v1.CreateBackupRequest
-	(*CreateBackupResponse)(nil),  // 7: containarium.v1.CreateBackupResponse
-	(*ListBackupsRequest)(nil),    // 8: containarium.v1.ListBackupsRequest
-	(*ListBackupsResponse)(nil),   // 9: containarium.v1.ListBackupsResponse
-	(*GetBackupRequest)(nil),      // 10: containarium.v1.GetBackupRequest
-	(*GetBackupResponse)(nil),     // 11: containarium.v1.GetBackupResponse
-	(*RestoreBackupRequest)(nil),  // 12: containarium.v1.RestoreBackupRequest
-	(*RestoreBackupResponse)(nil), // 13: containarium.v1.RestoreBackupResponse
-	(*VerifyBackupRequest)(nil),   // 14: containarium.v1.VerifyBackupRequest
-	(*VerifyBackupResponse)(nil),  // 15: containarium.v1.VerifyBackupResponse
-	(*DeleteBackupRequest)(nil),   // 16: containarium.v1.DeleteBackupRequest
-	(*DeleteBackupResponse)(nil),  // 17: containarium.v1.DeleteBackupResponse
+	(BackupEngine)(0),             // 1: containarium.v1.BackupEngine
+	(VerificationResult)(0),       // 2: containarium.v1.VerificationResult
+	(*BackupRecord)(nil),          // 3: containarium.v1.BackupRecord
+	(*VerificationCheck)(nil),     // 4: containarium.v1.VerificationCheck
+	(*BackupVerification)(nil),    // 5: containarium.v1.BackupVerification
+	(*PgConnection)(nil),          // 6: containarium.v1.PgConnection
+	(*CreateBackupRequest)(nil),   // 7: containarium.v1.CreateBackupRequest
+	(*CreateBackupResponse)(nil),  // 8: containarium.v1.CreateBackupResponse
+	(*ListBackupsRequest)(nil),    // 9: containarium.v1.ListBackupsRequest
+	(*ListBackupsResponse)(nil),   // 10: containarium.v1.ListBackupsResponse
+	(*GetBackupRequest)(nil),      // 11: containarium.v1.GetBackupRequest
+	(*GetBackupResponse)(nil),     // 12: containarium.v1.GetBackupResponse
+	(*RestoreBackupRequest)(nil),  // 13: containarium.v1.RestoreBackupRequest
+	(*RestoreBackupResponse)(nil), // 14: containarium.v1.RestoreBackupResponse
+	(*VerifyBackupRequest)(nil),   // 15: containarium.v1.VerifyBackupRequest
+	(*VerifyBackupResponse)(nil),  // 16: containarium.v1.VerifyBackupResponse
+	(*DeleteBackupRequest)(nil),   // 17: containarium.v1.DeleteBackupRequest
+	(*DeleteBackupResponse)(nil),  // 18: containarium.v1.DeleteBackupResponse
 }
 var file_containarium_v1_backup_proto_depIdxs = []int32{
 	0,  // 0: containarium.v1.BackupRecord.destination:type_name -> containarium.v1.BackupDestination
-	4,  // 1: containarium.v1.BackupRecord.last_verification:type_name -> containarium.v1.BackupVerification
-	1,  // 2: containarium.v1.BackupVerification.result:type_name -> containarium.v1.VerificationResult
-	3,  // 3: containarium.v1.BackupVerification.checks:type_name -> containarium.v1.VerificationCheck
-	5,  // 4: containarium.v1.CreateBackupRequest.connection:type_name -> containarium.v1.PgConnection
-	0,  // 5: containarium.v1.CreateBackupRequest.destination:type_name -> containarium.v1.BackupDestination
-	2,  // 6: containarium.v1.CreateBackupResponse.record:type_name -> containarium.v1.BackupRecord
-	2,  // 7: containarium.v1.CreateBackupResponse.records:type_name -> containarium.v1.BackupRecord
-	2,  // 8: containarium.v1.ListBackupsResponse.records:type_name -> containarium.v1.BackupRecord
-	2,  // 9: containarium.v1.GetBackupResponse.record:type_name -> containarium.v1.BackupRecord
-	5,  // 10: containarium.v1.RestoreBackupRequest.connection:type_name -> containarium.v1.PgConnection
-	5,  // 11: containarium.v1.VerifyBackupRequest.connection:type_name -> containarium.v1.PgConnection
-	4,  // 12: containarium.v1.VerifyBackupResponse.verification:type_name -> containarium.v1.BackupVerification
-	2,  // 13: containarium.v1.VerifyBackupResponse.record:type_name -> containarium.v1.BackupRecord
-	6,  // 14: containarium.v1.BackupService.CreateBackup:input_type -> containarium.v1.CreateBackupRequest
-	8,  // 15: containarium.v1.BackupService.ListBackups:input_type -> containarium.v1.ListBackupsRequest
-	10, // 16: containarium.v1.BackupService.GetBackup:input_type -> containarium.v1.GetBackupRequest
-	12, // 17: containarium.v1.BackupService.RestoreBackup:input_type -> containarium.v1.RestoreBackupRequest
-	14, // 18: containarium.v1.BackupService.VerifyBackup:input_type -> containarium.v1.VerifyBackupRequest
-	16, // 19: containarium.v1.BackupService.DeleteBackup:input_type -> containarium.v1.DeleteBackupRequest
-	7,  // 20: containarium.v1.BackupService.CreateBackup:output_type -> containarium.v1.CreateBackupResponse
-	9,  // 21: containarium.v1.BackupService.ListBackups:output_type -> containarium.v1.ListBackupsResponse
-	11, // 22: containarium.v1.BackupService.GetBackup:output_type -> containarium.v1.GetBackupResponse
-	13, // 23: containarium.v1.BackupService.RestoreBackup:output_type -> containarium.v1.RestoreBackupResponse
-	15, // 24: containarium.v1.BackupService.VerifyBackup:output_type -> containarium.v1.VerifyBackupResponse
-	17, // 25: containarium.v1.BackupService.DeleteBackup:output_type -> containarium.v1.DeleteBackupResponse
-	20, // [20:26] is the sub-list for method output_type
-	14, // [14:20] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	1,  // 1: containarium.v1.BackupRecord.engine:type_name -> containarium.v1.BackupEngine
+	5,  // 2: containarium.v1.BackupRecord.last_verification:type_name -> containarium.v1.BackupVerification
+	2,  // 3: containarium.v1.BackupVerification.result:type_name -> containarium.v1.VerificationResult
+	4,  // 4: containarium.v1.BackupVerification.checks:type_name -> containarium.v1.VerificationCheck
+	6,  // 5: containarium.v1.CreateBackupRequest.connection:type_name -> containarium.v1.PgConnection
+	0,  // 6: containarium.v1.CreateBackupRequest.destination:type_name -> containarium.v1.BackupDestination
+	3,  // 7: containarium.v1.CreateBackupResponse.record:type_name -> containarium.v1.BackupRecord
+	3,  // 8: containarium.v1.CreateBackupResponse.records:type_name -> containarium.v1.BackupRecord
+	3,  // 9: containarium.v1.ListBackupsResponse.records:type_name -> containarium.v1.BackupRecord
+	3,  // 10: containarium.v1.GetBackupResponse.record:type_name -> containarium.v1.BackupRecord
+	6,  // 11: containarium.v1.RestoreBackupRequest.connection:type_name -> containarium.v1.PgConnection
+	6,  // 12: containarium.v1.VerifyBackupRequest.connection:type_name -> containarium.v1.PgConnection
+	5,  // 13: containarium.v1.VerifyBackupResponse.verification:type_name -> containarium.v1.BackupVerification
+	3,  // 14: containarium.v1.VerifyBackupResponse.record:type_name -> containarium.v1.BackupRecord
+	7,  // 15: containarium.v1.BackupService.CreateBackup:input_type -> containarium.v1.CreateBackupRequest
+	9,  // 16: containarium.v1.BackupService.ListBackups:input_type -> containarium.v1.ListBackupsRequest
+	11, // 17: containarium.v1.BackupService.GetBackup:input_type -> containarium.v1.GetBackupRequest
+	13, // 18: containarium.v1.BackupService.RestoreBackup:input_type -> containarium.v1.RestoreBackupRequest
+	15, // 19: containarium.v1.BackupService.VerifyBackup:input_type -> containarium.v1.VerifyBackupRequest
+	17, // 20: containarium.v1.BackupService.DeleteBackup:input_type -> containarium.v1.DeleteBackupRequest
+	8,  // 21: containarium.v1.BackupService.CreateBackup:output_type -> containarium.v1.CreateBackupResponse
+	10, // 22: containarium.v1.BackupService.ListBackups:output_type -> containarium.v1.ListBackupsResponse
+	12, // 23: containarium.v1.BackupService.GetBackup:output_type -> containarium.v1.GetBackupResponse
+	14, // 24: containarium.v1.BackupService.RestoreBackup:output_type -> containarium.v1.RestoreBackupResponse
+	16, // 25: containarium.v1.BackupService.VerifyBackup:output_type -> containarium.v1.VerifyBackupResponse
+	18, // 26: containarium.v1.BackupService.DeleteBackup:output_type -> containarium.v1.DeleteBackupResponse
+	21, // [21:27] is the sub-list for method output_type
+	15, // [15:21] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_backup_proto_init() }
@@ -1436,7 +1500,7 @@ func file_containarium_v1_backup_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_backup_proto_rawDesc), len(file_containarium_v1_backup_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      3,
 			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/proto/containarium/v1/backup.proto
+++ b/proto/containarium/v1/backup.proto
@@ -27,6 +27,21 @@ enum BackupDestination {
   BACKUP_DESTINATION_GCS = 2;
 }
 
+// BackupEngine identifies the database engine a backup was taken from.
+//
+// Postgres is the only engine implemented today; the enum exists so that a
+// second one has somewhere to be named, and so that the engine a record was
+// taken with is a typed value rather than a string the reader has to trust.
+enum BackupEngine {
+  // Unset, or a record written by a daemon that predates this enum.
+  // Rejected wherever an engine has to be chosen — never treated as
+  // Postgres by default, because guessing the engine of a dump is how a
+  // restore silently targets the wrong one.
+  BACKUP_ENGINE_UNSPECIFIED = 0;
+
+  BACKUP_ENGINE_POSTGRES = 1;
+}
+
 // BackupRecord is the metadata index entry for one stored dump. The dump
 // itself lives at `location`; this record is persisted as a small JSON
 // sidecar in the daemon's backup directory so `ListBackups` works without
@@ -58,8 +73,12 @@ message BackupRecord {
   // for GCS.
   string location = 8;
 
-  // Database engine. "postgres" is the only engine in v1.
-  string engine = 9;
+  // Database engine the dump was taken with.
+  //
+  // An enum rather than a string because the valid values are an
+  // enumerated set, so the compiler should be the thing that rejects a
+  // typo rather than a driver lookup failing at dump time (#1157).
+  BackupEngine engine = 9;
 
   // Outcome of the most recent restore test, unset until the backup has
   // been verified. A recorded sha256 proves the bytes are intact; only


### PR DESCRIPTION
Step 1 of #1157. The issue notes this step stands alone — it improves the Postgres path by removing the magic string, with the `oneof connection` and the driver interface to follow.

## The problem

`BackupRecord.engine` was a `string` documented as *"postgres is the only engine in v1"* — the exact anti-pattern `CLAUDE.md` names:

> A string field with a comment listing the allowed values.

So `"postgres"`, `"postgress"` and `""` were all equally valid values of the *contract*, and only a driver lookup at dump time could tell them apart.

## What changes, and what doesn't

The manifest still stores `engine` as a JSON string, so **nothing about existing records changes on disk**. The mapping happens at the wire boundary.

A record written before the enum existed, or one whose engine this build does not recognise, maps to `UNSPECIFIED` — never to `POSTGRES`. Guessing there would present a dump as restorable by `pg_restore` on no evidence, which is the failure the enum exists to make impossible. There is a test asserting no input can produce `POSTGRES` except the one the manifest actually writes, and another pinning the mapping to `backup.EnginePostgres` so the two cannot drift apart silently.

`backup get` still prints `postgres`. The type change is for the contract, not the console.

## Two notes for review

**The generated swagger caught a mistake.** My first placement put the enum between `BackupRecord`'s doc comment and its `message`, so the generated docs showed both descriptions concatenated onto `BackupRecord` and left the enum's own entry undocumented. Found by reading the generated output rather than assuming the proto edit was self-evidently fine.

**This is the first proto change since the plugins were pinned** (#1297). `make proto` regenerates idempotently, so the diff here is exactly the contract change and nothing else — which is precisely what the pinning was for, and a useful confirmation that it works.

## REST shape

`engine` moves from `"postgres"` to `"BACKUP_ENGINE_POSTGRES"` in REST responses. That is the intended consequence of the enum and is what the issue asks for; the CLI and MCP paths still decode and display correctly. Flagging it explicitly since it is a visible contract change.

Mutation-tested: defaulting an unknown engine to `POSTGRES`, and printing the raw enum in the CLI, each fail a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)