### PR TITLE
fix(alert): reject a severity that routes nowhere (#1304)

### DIFF
--- a/internal/alert/severity.go
+++ b/internal/alert/severity.go
@@ -1,0 +1,34 @@
+package alert
+
+import "fmt"
+
+// The severities an alert rule may carry.
+//
+// These are not decoration. The manager writes the value straight into the
+// generated Prometheus rule as a `severity` label, and Alertmanager routes on
+// that label. A rule stored with "warnning" is therefore a rule that fires and
+// matches no route — it reaches nobody, and nothing anywhere reports an error.
+// That is the failure this set exists to make impossible.
+const (
+	SeverityCritical = "critical"
+	SeverityWarning  = "warning"
+	SeverityInfo     = "info"
+)
+
+// ValidateSeverity rejects a severity that is not one of the known set.
+//
+// Deliberately strict rather than normalising: "Warning" and " warning" are
+// refused instead of being coerced, because a caller that sent either is
+// working from a different idea of the contract, and silently repairing it
+// hides that until the routing they expect does not happen.
+func ValidateSeverity(severity string) error {
+	switch severity {
+	case SeverityCritical, SeverityWarning, SeverityInfo:
+		return nil
+	default:
+		return fmt.Errorf(
+			"severity %q is not one of %q, %q, %q — Alertmanager routes on this label, so an "+
+				"unrecognised value produces a rule that fires and reaches nobody",
+			severity, SeverityCritical, SeverityWarning, SeverityInfo)
+	}
+}

--- a/internal/alert/severity_test.go
+++ b/internal/alert/severity_test.go
@@ -1,0 +1,48 @@
+package alert
+
+import (
+	"strings"
+	"testing"
+)
+
+// The severity is written into the generated Prometheus rule as a label, and
+// Alertmanager routes on that label. An unrecognised value produces a rule
+// that fires and matches no route — the alert reaches nobody, and nothing
+// reports an error. Silence is the same observable outcome as "nothing is
+// wrong", which is why this is worth refusing at the API rather than
+// discovering during an incident.
+func TestValidateSeverity(t *testing.T) {
+	for _, ok := range []string{SeverityCritical, SeverityWarning, SeverityInfo} {
+		if err := ValidateSeverity(ok); err != nil {
+			t.Errorf("ValidateSeverity(%q) rejected a documented severity: %v", ok, err)
+		}
+	}
+
+	for _, bad := range []string{
+		"",          // an explicitly empty severity is not the same as unset
+		"warnning",  // the typo this exists for
+		"Warning",   // case matters to Alertmanager's matcher
+		" warning",  // as does whitespace
+		"page",      // a plausible-sounding severity from another system
+		"emergency", // syslog's vocabulary, not Prometheus's
+	} {
+		if err := ValidateSeverity(bad); err == nil {
+			t.Errorf("ValidateSeverity(%q) was accepted — it would be written into the rule and "+
+				"route nowhere", bad)
+		}
+	}
+}
+
+// The error has to tell the caller what to send instead. "invalid severity"
+// leaves them guessing at a closed set they cannot see.
+func TestValidateSeverity_ErrorNamesTheValidValues(t *testing.T) {
+	err := ValidateSeverity("warnning")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	for _, want := range []string{"critical", "warning", "info", "warnning"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error does not mention %q, so the caller cannot act on it: %v", want, err)
+		}
+	}
+}

--- a/internal/server/alert_server.go
+++ b/internal/server/alert_server.go
@@ -72,7 +72,10 @@ func (s *ContainerServer) CreateAlertRule(ctx context.Context, req *pb.CreateAle
 
 	severity := req.Severity
 	if severity == "" {
-		severity = "warning"
+		severity = alert.SeverityWarning
+	}
+	if err := alert.ValidateSeverity(severity); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	duration := req.Duration
 	if duration == "" {
@@ -196,6 +199,9 @@ func (s *ContainerServer) UpdateAlertRule(ctx context.Context, req *pb.UpdateAle
 		existing.Duration = req.Duration
 	}
 	if req.Severity != "" {
+		if err := alert.ValidateSeverity(req.Severity); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 		existing.Severity = req.Severity
 	}
 	if req.Description != "" {

--- a/internal/server/alert_severity_wiring_test.go
+++ b/internal/server/alert_severity_wiring_test.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// A validator nothing calls is a validator that does not run. Both write
+// paths have to use it: Create defaults an empty severity and then checks,
+// Update checks only when the caller supplied one.
+//
+// Checked against the source because reaching these RPCs needs a wired store,
+// and what is being asserted is the wiring itself — the same reason the
+// dual_server guards in this package read source rather than standing the
+// daemon up.
+func TestAlertSeverityIsValidatedOnEveryWritePath(t *testing.T) {
+	b, err := os.ReadFile("alert_server.go")
+	if err != nil {
+		t.Fatalf("read alert_server.go: %v", err)
+	}
+	src := string(b)
+
+	// Every place the stored severity is assigned from a request.
+	writes := strings.Count(src, "Severity:    severity,") +
+		strings.Count(src, "existing.Severity = req.Severity")
+	if writes == 0 {
+		t.Fatal("found no severity write sites — the pattern changed, so this guard is blind")
+	}
+
+	checks := strings.Count(src, "alert.ValidateSeverity(")
+	if checks < 2 {
+		t.Errorf("severity is validated on %d write path(s), want both Create and Update — an "+
+			"unvalidated path stores a value that routes nowhere and never errors", checks)
+	}
+}


### PR DESCRIPTION
The sharpest case from the #1304 inventory, fixed without waiting on the enum conversion.

## The failure

An alert rule's `severity` was taken verbatim, with only an empty-string default:

```go
severity := req.Severity
if severity == "" {
    severity = "warning"
}
```

The manager writes it straight into the generated Prometheus rule as a `severity` label, and Alertmanager routes on that label. So a rule stored with `"warnning"` fires and **matches no route**. It reaches nobody, and nothing anywhere reports an error.

The observable outcome of a mistyped severity is silence — which is also the observable outcome of nothing being wrong. That is the worst possible pair to be unable to distinguish, and you find out during an incident.

## What changes

Both write paths validate: `CreateAlertRule` after defaulting, `UpdateAlertRule` only when the caller supplied one. A guard asserts both, because a validator one path skips is a validator that does not run for that path. The guard also fails loudly if the write sites are renamed, rather than silently checking nothing.

**Deliberately strict rather than normalising.** `"Warning"` and `" warning"` are refused, not coerced. A caller sending either is working from a different idea of the contract, and quietly repairing it hides that until the routing they expected does not happen. Same fail-closed posture as #1198 and #1294.

The error names the valid values and echoes what was sent — `"invalid severity"` would leave the caller guessing at a closed set they cannot see.

## Scope

This does **not** close #1304. The typed fix is an enum, which changes the REST shape; validation is what can be added without that, and it removes the failure mode today. `severity` is one of ~25 fields in that inventory.

Mutation-tested: accepting anything, normalising case instead of rejecting, and dropping the check from the Update path each fail a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)