### PR TITLE
test(sentinel): stop naming a port the machine may already be using

### DIFF
--- a/internal/sentinel/tunnel_reregister_test.go
+++ b/internal/sentinel/tunnel_reregister_test.go
@@ -57,6 +57,45 @@ func newSessionPair(t *testing.T) (sentinelSide *yamux.Session, cleanup func()) 
 	}
 }
 
+// freeLoopbackPort returns a loopback port that is free right now.
+//
+// TestMonitorSessionCleansUpCurrentGeneration named port 8080, which
+// startProxies binds as-is. Anything else on the machine holding 8080 — a
+// container port-forward, a dev server — made it fail with "Should NOT be
+// empty, but was []", an assertion about listeners that reads as a bug in the
+// code under test rather than as a busy port.
+//
+// There is a small window between closing this listener and the code under
+// test binding the port, which is unavoidable without threading a listener
+// through. It is a much smaller risk than naming a port something else is
+// probably using.
+func freeLoopbackPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+// requireListeners fails if the spot has no proxy listeners.
+//
+// TestMonitorSessionIgnoresSupersededGeneration asserted nothing about
+// listeners, so a future failure to bind would leave it exercising the
+// no-listeners path and still passing. It was not doing so before this
+// change — its ports are remapped out of the privileged range — but nothing
+// was stopping it.
+func requireListeners(t *testing.T, ts *TunnelServer, spotID string) {
+	t.Helper()
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	p, ok := ts.proxies[spotID]
+	require.True(t, ok, "no proxies recorded for %s — startProxies bound nothing", spotID)
+	require.NotEmpty(t, p.listeners,
+		"%s has no listeners: the port was busy, so this test would exercise the "+
+			"no-listeners path rather than the one it is written for", spotID)
+}
+
 func handshake(spotID string) *TunnelHandshake {
 	return &TunnelHandshake{SpotID: spotID, Ports: []int{22, 8080}, Pool: "prod"}
 }
@@ -157,8 +196,14 @@ func TestMonitorSessionIgnoresSupersededGeneration(t *testing.T) {
 	defer closeFirst()
 	_, firstGen, err := registry.Register(handshake("spot-1"), firstSession)
 	require.NoError(t, err)
-	// Bind on 127.0.0.1 rather than the (stubbed, non-existent) alias.
-	ts.startProxies(ctx, "spot-1", firstGen, "127.0.0.1", 0, []int{22}, firstSession)
+	// Bind on 127.0.0.1 rather than the (stubbed, non-existent) alias, and on
+	// a port picked at run time rather than named here. A privileged remote
+	// port is remapped by startProxies (22 becomes 20022), but an unprivileged
+	// one is bound as-is — so naming a port means the test fails whenever a
+	// developer happens to be running anything on it.
+	proxyPort := freeLoopbackPort(t)
+	ts.startProxies(ctx, "spot-1", firstGen, "127.0.0.1", 0, []int{proxyPort}, firstSession)
+	requireListeners(t, ts, "spot-1")
 
 	monitorDone := make(chan struct{})
 	go func() {
@@ -171,7 +216,9 @@ func TestMonitorSessionIgnoresSupersededGeneration(t *testing.T) {
 	defer closeSecond()
 	_, secondGen, err := registry.Register(handshake("spot-1"), secondSession)
 	require.NoError(t, err)
-	ts.startProxies(ctx, "spot-1", secondGen, "127.0.0.1", 0, []int{22}, secondSession)
+	// The same port as the first registration: a reconnect rebinds what the
+	// superseded generation had.
+	ts.startProxies(ctx, "spot-1", secondGen, "127.0.0.1", 0, []int{proxyPort}, secondSession)
 
 	select {
 	case <-monitorDone:
@@ -224,7 +271,7 @@ func TestMonitorSessionCleansUpCurrentGeneration(t *testing.T) {
 	defer closeSession()
 	_, gen, err := registry.Register(handshake("spot-1"), session)
 	require.NoError(t, err)
-	ts.startProxies(ctx, "spot-1", gen, "127.0.0.1", 0, []int{8080}, session)
+	ts.startProxies(ctx, "spot-1", gen, "127.0.0.1", 0, []int{freeLoopbackPort(t)}, session)
 
 	ts.mu.Lock()
 	listeners := append([]net.Listener(nil), ts.proxies["spot-1"].listeners...)


### PR DESCRIPTION
`TestMonitorSessionCleansUpCurrentGeneration` bound `127.0.0.1:8080` by name. Anything else holding 8080 — a container port-forward, a dev server — makes it fail with:

```
Error: Should NOT be empty, but was []
```

An assertion about listeners, which reads as a bug in the code under test rather than as a busy port. It fails that way on my machine today, where a rootless container port-forward holds 8080. CI runners are usually clear, which is why nobody has hit it.

The port is now picked at run time.

## Also: an assertion that was missing

`TestMonitorSessionIgnoresSupersededGeneration` asserted nothing about listeners, so a future failure to bind would leave it exercising the no-listeners path and still passing. It was **not** doing that — its ports are remapped out of the privileged range — but nothing stopped it. It now checks.

## How the second half nearly went wrong

Worth recording, because the mutation run is what caught it.

I first concluded that test was *already* vacuous, reasoning that sshd holds port 22 so `startProxies` bound nothing — and I wrote that into a code comment. Then mutating the port back to 22 **passed**, which contradicted the story.

Two things were wrong with it. Binding `127.0.0.1:22` here fails with `permission denied` (a privileged port under an unprivileged user), not `address already in use`. And `startProxies` remaps a privileged remote port anyway — 22 becomes `127.0.0.1:20022` — so the bind succeeds and the test was fine all along.

A plausible explanation that the code disagreed with, about to ship as an authoritative comment. The check that caught it cost one command.

## Verification

Mutation-tested: naming 8080 again fails the first test, and pointing the second at a busy port fails its new assertion with the message it was written to give. Full package passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)