### PR TITLE
test(sentinel): the other two named ports #1306 missed

### DIFF
--- a/internal/sentinel/tunnel_reregister_test.go
+++ b/internal/sentinel/tunnel_reregister_test.go
@@ -318,7 +318,13 @@ func TestStartProxiesRefusesToClobberANewerGeneration(t *testing.T) {
 	session, closeSession := newSessionPair(t)
 	defer closeSession()
 
-	ts.startProxies(ctx, "spot-1", 7, "127.0.0.1", 0, []int{9090}, session)
+	// Picked at run time, not named: 9090 is Prometheus's default and is
+	// plausibly in use on a developer machine. Both calls share it because the
+	// point is that the second, staler one must not take over the first's
+	// listener on the same port.
+	proxyPort := freeLoopbackPort(t)
+
+	ts.startProxies(ctx, "spot-1", 7, "127.0.0.1", 0, []int{proxyPort}, session)
 	ts.mu.Lock()
 	current := ts.proxies["spot-1"]
 	ts.mu.Unlock()
@@ -326,7 +332,7 @@ func TestStartProxiesRefusesToClobberANewerGeneration(t *testing.T) {
 	require.NotEmpty(t, current.listeners)
 
 	// An older registration's call arriving late must be ignored outright.
-	ts.startProxies(ctx, "spot-1", 3, "127.0.0.1", 0, []int{9090}, session)
+	ts.startProxies(ctx, "spot-1", 3, "127.0.0.1", 0, []int{proxyPort}, session)
 
 	ts.mu.Lock()
 	after := ts.proxies["spot-1"]


### PR DESCRIPTION
`TestStartProxiesRefusesToClobberANewerGeneration` binds **9090** twice — Prometheus's default port, and as likely to be taken on a developer machine as the 8080 that #1306 fixed. Both calls now share one port picked at run time, since the point of the test is that the staler call must not take over the live listener *on the same port*.

## How they were found, and why the first attempts were worthless

I scanned for the shape rather than waiting to trip over it. The first two patterns returned **zero** and meant nothing — both looked for a port inside an address string like `"127.0.0.1:8080"`, while the actual bug is a port passed as a separate `[]int{8080}` argument.

Testing each pattern against the line I had just fixed in #1306 showed neither could match it:

```
scan 1 finds the known bug: False
scan 2 finds the known bug: False
```

A search that cannot find a known instance says nothing when it finds none. That is the same mistake as grepping for the wrong field name and reading the silence as proof — which I made earlier today and nearly filed an issue on.

The third pattern, validated against that known line *first*, found both 9090 sites immediately.

## Remaining site is fine

`enableForwarding("10.0.0.1", []int{80, 443})` in `iptables_test.go` runs under `onNonLinuxHost`, so it returns before touching the network and never binds. Checked rather than assumed.

## Verification

Occupied 9090 from a helper process and confirmed the test fails with the port named and passes with it picked at run time. Full package clean under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)