### PR TITLE
fix(peer): give FetchPeerPKI a real context instead of interface{}

### DIFF
--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1951,7 +1951,7 @@ func (ds *DualServer) Start(ctx context.Context) error {
 		// HTTPS pinned to the sentinel-issued CA. Failure here is
 		// not fatal — the daemon stays on plain HTTP (pre-0.5
 		// behavior) and logs the reason.
-		if err := ds.peerPool.BootstrapPKI(); err != nil {
+		if err := ds.peerPool.BootstrapPKI(ctx); err != nil {
 			log.Printf("[peer-pki] bootstrap failed (%v) — staying on HTTP for peer-to-peer (audit C-CRIT-1 still open until configured)", err)
 		} else {
 			ds.peerPool.StartCertRenewal(ctx)

--- a/internal/server/peer.go
+++ b/internal/server/peer.go
@@ -163,7 +163,7 @@ func NewPeerPool(localBackendID string, sentinelURL string, staticPeers []string
 // Errors are NOT fatal; the caller (dual_server.go) logs them and
 // falls back to HTTP. Operators see the message clearly in the
 // startup log.
-func (p *PeerPool) BootstrapPKI() error {
+func (p *PeerPool) BootstrapPKI(ctx context.Context) error {
 	if p.sentinelURL == "" {
 		return nil
 	}
@@ -177,7 +177,7 @@ func (p *PeerPool) BootstrapPKI() error {
 		return fmt.Errorf("local backend ID is empty; cannot request peer cert")
 	}
 
-	pki, err := FetchPeerPKI(nil, p.sentinelURL, p.localBackendID, secret)
+	pki, err := FetchPeerPKI(ctx, p.sentinelURL, p.localBackendID, secret)
 	if err != nil {
 		return fmt.Errorf("fetch peer PKI from sentinel: %w", err)
 	}
@@ -256,7 +256,7 @@ func (p *PeerPool) StartCertRenewal(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := p.maybeRenewCert(); err != nil {
+				if err := p.maybeRenewCert(ctx); err != nil {
 					log.Printf("[peer-pki] renewal failed (will retry): %v", err)
 				}
 			}
@@ -269,7 +269,7 @@ func (p *PeerPool) StartCertRenewal(ctx context.Context) {
 // Idempotent: if the cert isn't due for renewal yet, this is a
 // no-op. Returns an error only when the sentinel call itself
 // fails — the caller's retry loop handles transient failures.
-func (p *PeerPool) maybeRenewCert() error {
+func (p *PeerPool) maybeRenewCert(ctx context.Context) error {
 	if p.pki == nil {
 		return nil
 	}
@@ -293,7 +293,7 @@ func (p *PeerPool) maybeRenewCert() error {
 	if len(secret) < auth.SentinelMinSecretLen {
 		return fmt.Errorf("HMAC secret unavailable")
 	}
-	fresh, err := FetchPeerPKI(nil, p.sentinelURL, p.localBackendID, secret)
+	fresh, err := FetchPeerPKI(ctx, p.sentinelURL, p.localBackendID, secret)
 	if err != nil {
 		return err
 	}

--- a/internal/server/peer_pki.go
+++ b/internal/server/peer_pki.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
@@ -134,7 +135,7 @@ func (p *peerPKI) replace(cert tls.Certificate, caPool *x509.CertPool, caPEM []b
 // authenticated regardless. (We still recommend HTTPS for the
 // bootstrap call too, since the leaf private key travels in the
 // body.)
-func FetchPeerPKI(ctx interface{}, sentinelBaseURL, peerID string, hmacSecret []byte) (*peerPKI, error) {
+func FetchPeerPKI(ctx context.Context, sentinelBaseURL, peerID string, hmacSecret []byte) (*peerPKI, error) {
 	if len(hmacSecret) < auth.SentinelMinSecretLen {
 		return nil, fmt.Errorf("sentinel HMAC secret is missing or too short — Phase 0.5 bootstrap requires CONTAINARIUM_SENTINEL_AUTH_SECRET")
 	}
@@ -147,7 +148,7 @@ func FetchPeerPKI(ctx interface{}, sentinelBaseURL, peerID string, hmacSecret []
 		return nil, fmt.Errorf("marshal cert request: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, sentinelBaseURL+"/sentinel/peer-cert", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, sentinelBaseURL+"/sentinel/peer-cert", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("build peer-cert request: %w", err)
 	}

--- a/internal/server/peer_pki_context_test.go
+++ b/internal/server/peer_pki_context_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+// FetchPeerPKI took `ctx interface{}`, both callers passed nil, and the
+// request was built with http.NewRequest — so the parameter was untyped,
+// unused, and unusable all at once.
+//
+// The consequence was not hypothetical: a daemon shutting down during the
+// bootstrap fetch waited for the client's 15s timeout, because nothing could
+// cancel the request. This asserts the context is now honoured.
+func TestFetchPeerPKI_HonoursContextCancellation(t *testing.T) {
+	// A sentinel that never answers, so only cancellation ends the call.
+	blocked := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked
+	}))
+	defer func() { close(blocked); srv.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	secret := make([]byte, auth.SentinelMinSecretLen)
+	for i := range secret {
+		secret[i] = 'x'
+	}
+
+	start := time.Now()
+	_, err := FetchPeerPKI(ctx, srv.URL, "peer-1", secret)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected the cancelled fetch to fail")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error is not a cancellation: %v", err)
+	}
+	// The client's own timeout is 15s. Returning anywhere near that means the
+	// context was ignored and only the timeout ended the call.
+	if elapsed > 5*time.Second {
+		t.Errorf("fetch took %v — the context was not what ended it", elapsed)
+	}
+}


### PR DESCRIPTION
```go
func FetchPeerPKI(ctx interface{}, sentinelBaseURL, peerID string, hmacSecret []byte) (*peerPKI, error) {
```

Both call sites passed `nil`, and the request was built with `http.NewRequest`. So the parameter was untyped, unused, and unusable at once — it *looked* like the function took a context and it did not.

This is the anti-pattern `CLAUDE.md` calls out directly: use the type system rather than `interface{}`.

## The consequence, measured

Nothing could cancel the bootstrap or renewal fetch, so a daemon shutting down mid-request waited out the client's 15s timeout.

Not assumed — mutating the fix away and re-running the new test:

| | time to return from a cancelled fetch |
| --- | --- |
| with the context honoured | **0.05s** |
| reverted to `http.NewRequest` | **15.01s** |

## No new plumbing was needed

Both call sites already had a context in scope. `StartCertRenewal(ctx)` took one and dropped it before calling `maybeRenewCert`; `dual_server` has one at the `BootstrapPKI` call. Nothing had to be threaded from anywhere new — which is the tell that the `interface{}` was a shortcut rather than a constraint someone worked around.

## Found, and one thing deliberately left

`deadcode` reported `PersistPeerPKI` as unreachable, and I read the file around it.

That one is a **separate, real issue** I have not fixed here: it genuinely has no callers, so a restart re-fetches a leaf cert rather than loading a persisted one — which its own doc says is what operators want ("so a restart doesn't burn an issuance"). Wiring it is a behaviour change with a decision attached (where the directory lives, what happens when the on-disk copy is stale), not a type fix, so it does not belong in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)