### PR TITLE
refactor(cmd): type the container list instead of erasing it

### DIFF
--- a/internal/cmd/label_test.go
+++ b/internal/cmd/label_test.go
@@ -116,27 +116,27 @@ func TestFormatLabels(t *testing.T) {
 
 func TestGroupContainersByLabel(t *testing.T) {
 	containers := []incus.ContainerInfo{
-		incus.ContainerInfo{
+		{
 			Name:   "alice-container",
 			State:  "Running",
 			Labels: map[string]string{"team": "backend", "env": "prod"},
 		},
-		incus.ContainerInfo{
+		{
 			Name:   "bob-container",
 			State:  "Running",
 			Labels: map[string]string{"team": "backend", "env": "staging"},
 		},
-		incus.ContainerInfo{
+		{
 			Name:   "charlie-container",
 			State:  "Stopped",
 			Labels: map[string]string{"team": "frontend", "env": "prod"},
 		},
-		incus.ContainerInfo{
+		{
 			Name:   "dave-container",
 			State:  "Running",
 			Labels: nil,
 		},
-		incus.ContainerInfo{
+		{
 			Name:   "eve-container",
 			State:  "Running",
 			Labels: map[string]string{"env": "dev"}, // no team label
@@ -256,13 +256,13 @@ func TestGetSortedGroupKeys(t *testing.T) {
 
 func TestGroupedJSONOutput(t *testing.T) {
 	containers := []incus.ContainerInfo{
-		incus.ContainerInfo{
+		{
 			Name:      "alice-container",
 			State:     "Running",
 			IPAddress: "10.0.0.1",
 			Labels:    map[string]string{"team": "backend"},
 		},
-		incus.ContainerInfo{
+		{
 			Name:      "bob-container",
 			State:     "Stopped",
 			IPAddress: "10.0.0.2",

--- a/internal/cmd/label_test.go
+++ b/internal/cmd/label_test.go
@@ -115,7 +115,7 @@ func TestFormatLabels(t *testing.T) {
 }
 
 func TestGroupContainersByLabel(t *testing.T) {
-	containers := []interface{}{
+	containers := []incus.ContainerInfo{
 		incus.ContainerInfo{
 			Name:   "alice-container",
 			State:  "Running",
@@ -255,7 +255,7 @@ func TestGetSortedGroupKeys(t *testing.T) {
 }
 
 func TestGroupedJSONOutput(t *testing.T) {
-	containers := []interface{}{
+	containers := []incus.ContainerInfo{
 		incus.ContainerInfo{
 			Name:      "alice-container",
 			State:     "Running",
@@ -313,7 +313,7 @@ func BenchmarkParseLabelFilter(b *testing.B) {
 }
 
 func BenchmarkGroupContainersByLabel(b *testing.B) {
-	containers := make([]interface{}, 100)
+	containers := make([]incus.ContainerInfo, 100)
 	teams := []string{"backend", "frontend", "devops", "data"}
 	for i := 0; i < 100; i++ {
 		containers[i] = incus.ContainerInfo{

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -94,7 +94,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	labelFilter := parseLabelFilter(filterLabels)
 
 	// Apply filters
-	var filtered []interface{}
+	var filtered []incus.ContainerInfo
 	runningCount := 0
 	stoppedCount := 0
 
@@ -161,7 +161,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func printTableFormat(containers []interface{}, running, stopped int, withLabels bool) {
+func printTableFormat(containers []incus.ContainerInfo, running, stopped int, withLabels bool) {
 	// MON column: ✓ when the container has app-emitted OTel
 	// stamped in (environment.OTEL_EXPORTER_OTLP_ENDPOINT
 	// non-empty). 3-char column keeps the table compact.
@@ -179,8 +179,7 @@ func printTableFormat(containers []interface{}, running, stopped int, withLabels
 	}
 
 	monCount := 0
-	for _, item := range containers {
-		c := item.(incus.ContainerInfo)
+	for _, c := range containers {
 		ip := c.IPAddress
 		if ip == "" {
 			ip = "-"
@@ -237,11 +236,17 @@ func parseLabelFilter(labelSlice []string) map[string]string {
 	return result
 }
 
-func printJSONFormat(containers []interface{}) error {
-	output := map[string]interface{}{
-		"containers":  containers,
-		"total_count": len(containers),
-	}
+// listJSON is the shape `containarium list --json` emits. A named struct
+// rather than a map so the field names are checked at compile time — a typo
+// in a map key produces valid JSON with the wrong shape, and the first thing
+// to notice is whatever is parsing it.
+type listJSON struct {
+	Containers []incus.ContainerInfo `json:"containers"`
+	TotalCount int                   `json:"total_count"`
+}
+
+func printJSONFormat(containers []incus.ContainerInfo) error {
+	output := listJSON{Containers: containers, TotalCount: len(containers)}
 
 	data, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
@@ -252,10 +257,9 @@ func printJSONFormat(containers []interface{}) error {
 	return nil
 }
 
-func printYAMLFormat(containers []interface{}) {
+func printYAMLFormat(containers []incus.ContainerInfo) {
 	fmt.Println("containers:")
-	for _, item := range containers {
-		c := item.(incus.ContainerInfo)
+	for _, c := range containers {
 		fmt.Printf("  - name: %s\n", c.Name)
 		fmt.Printf("    state: %s\n", c.State)
 		fmt.Printf("    ip_address: %s\n", c.IPAddress)
@@ -277,10 +281,9 @@ func printYAMLFormat(containers []interface{}) {
 }
 
 // groupContainersByLabel groups containers by a specific label key
-func groupContainersByLabel(containers []interface{}, labelKey string) map[string][]incus.ContainerInfo {
+func groupContainersByLabel(containers []incus.ContainerInfo, labelKey string) map[string][]incus.ContainerInfo {
 	groups := make(map[string][]incus.ContainerInfo)
-	for _, item := range containers {
-		c := item.(incus.ContainerInfo)
+	for _, c := range containers {
 		labelValue := "(no label)"
 		if c.Labels != nil {
 			if val, ok := c.Labels[labelKey]; ok {
@@ -310,7 +313,7 @@ func getSortedGroupKeys(groups map[string][]incus.ContainerInfo) []string {
 	return keys
 }
 
-func printGroupedTableFormat(containers []interface{}, labelKey string, withLabels bool) {
+func printGroupedTableFormat(containers []incus.ContainerInfo, labelKey string, withLabels bool) {
 	groups := groupContainersByLabel(containers, labelKey)
 	sortedKeys := getSortedGroupKeys(groups)
 
@@ -364,14 +367,22 @@ func printGroupedTableFormat(containers []interface{}, labelKey string, withLabe
 	fmt.Printf("Total: %d containers in %d groups (%d running, %d stopped)\n", totalCount, len(groups), totalRunning, totalStopped)
 }
 
-func printGroupedJSONFormat(containers []interface{}, labelKey string) error {
+// groupedListJSON is the shape `containarium list --group-by --json` emits.
+type groupedListJSON struct {
+	GroupBy    string                           `json:"group_by"`
+	Groups     map[string][]incus.ContainerInfo `json:"groups"`
+	GroupCount int                              `json:"group_count"`
+	TotalCount int                              `json:"total_count"`
+}
+
+func printGroupedJSONFormat(containers []incus.ContainerInfo, labelKey string) error {
 	groups := groupContainersByLabel(containers, labelKey)
 
-	output := map[string]interface{}{
-		"group_by":    labelKey,
-		"groups":      groups,
-		"group_count": len(groups),
-		"total_count": len(containers),
+	output := groupedListJSON{
+		GroupBy:    labelKey,
+		Groups:     groups,
+		GroupCount: len(groups),
+		TotalCount: len(containers),
 	}
 
 	data, err := json.MarshalIndent(output, "", "  ")
@@ -383,7 +394,7 @@ func printGroupedJSONFormat(containers []interface{}, labelKey string) error {
 	return nil
 }
 
-func printGroupedYAMLFormat(containers []interface{}, labelKey string) {
+func printGroupedYAMLFormat(containers []incus.ContainerInfo, labelKey string) {
 	groups := groupContainersByLabel(containers, labelKey)
 	sortedKeys := getSortedGroupKeys(groups)
 

--- a/internal/cmd/list_json_test.go
+++ b/internal/cmd/list_json_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// list.go carried its containers as []interface{} and asserted each element
+// back to incus.ContainerInfo in three places, and built its --json output
+// from map[string]interface{}. Both are the shapes CLAUDE.md names: type
+// erasure with no second type behind it, and a wire payload as a map.
+//
+// The risk in typing them is changing what `--json` emits, so these pin the
+// shape rather than the implementation.
+func TestListJSONShape(t *testing.T) {
+	out := listJSON{
+		Containers: []incus.ContainerInfo{{Name: "alice-container", State: "Running"}},
+		TotalCount: 1,
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"containers", "total_count"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("`list --json` no longer emits %q — anything parsing this output breaks, "+
+				"and a struct-tag typo produces valid JSON with the wrong shape", key)
+		}
+	}
+	if len(got) != 2 {
+		t.Errorf("`list --json` emits %d keys, want exactly 2: %v", len(got), keysOfRaw(got))
+	}
+}
+
+func TestGroupedListJSONShape(t *testing.T) {
+	out := groupedListJSON{
+		GroupBy:    "env",
+		Groups:     map[string][]incus.ContainerInfo{"prod": {{Name: "alice-container"}}},
+		GroupCount: 1,
+		TotalCount: 1,
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"group_by", "groups", "group_count", "total_count"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("`list --group-by --json` no longer emits %q", key)
+		}
+	}
+	if len(got) != 4 {
+		t.Errorf("emits %d keys, want exactly 4: %v", len(got), keysOfRaw(got))
+	}
+}
+
+func keysOfRaw(m map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Found by sweeping for the `interface{}` anti-pattern after #1308 turned one up by accident.

## What was there

`containarium list` carried its containers as `[]interface{}` through **six** functions and asserted each element back to `incus.ContainerInfo` in three of them:

```go
func groupContainersByLabel(containers []interface{}, labelKey string) map[string][]incus.ContainerInfo {
	for _, item := range containers {
		c := item.(incus.ContainerInfo)
```

The return type names the element type the parameter refuses to.

There was never a second type: all three sources — `listLocal`, `listRemote`, `listRemoteHTTP` — return `[]incus.ContainerInfo`, and a single append site fills the slice. The erasure bought nothing and cost a runtime assertion per consumer.

The `--json` output was built from `map[string]interface{}`, which `CLAUDE.md` calls out for wire payloads specifically.

## What it is now

Concrete types throughout, zero `interface{}` left in the file, and two named output structs — so a mistyped field is a compile error rather than valid JSON with the wrong keys, which is the kind of mistake whose first symptom appears in whatever parses the output.

## The risk is the output shape, so that is what is pinned

Tests assert the exact key set each mode emits. Mutation-tested: renaming a struct tag (`total_count` → `totalCount`) and adding a stray field each fail them.

An existing test built its fixtures as `[]interface{}` to match the old signature. Typing the fixtures is the whole of that change — and the assertions it already made are what protected this refactor.

## Note on the sweep

1045 mentions of `interface{}`/`any` across 250 non-generated files, 130 in function signatures. The large majority are legitimate under `CLAUDE.md` — JSON marshal/unmarshal helpers taking `out any`, and similar type-erasing boundaries. This file stood out because a sibling signature named the concrete element type while the parameter erased it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)