### PR TITLE
refactor(gateway): type the SSE payloads instead of building maps

### DIFF
--- a/internal/gateway/events.go
+++ b/internal/gateway/events.go
@@ -161,13 +161,13 @@ func (h *EventHandler) sendProtoEvent(w http.ResponseWriter, flusher http.Flushe
 	// Add payload based on type
 	switch p := event.Payload.(type) {
 	case *pb.Event_ContainerEvent:
-		eventData["containerEvent"] = containerEventToMap(p.ContainerEvent)
+		eventData["containerEvent"] = containerEventToPayload(p.ContainerEvent)
 	case *pb.Event_AppEvent:
-		eventData["appEvent"] = appEventToMap(p.AppEvent)
+		eventData["appEvent"] = appEventToPayload(p.AppEvent)
 	case *pb.Event_RouteEvent:
-		eventData["routeEvent"] = routeEventToMap(p.RouteEvent)
+		eventData["routeEvent"] = routeEventToPayload(p.RouteEvent)
 	case *pb.Event_MetricsEvent:
-		eventData["metricsEvent"] = metricsEventToMap(p.MetricsEvent)
+		eventData["metricsEvent"] = metricsEventToPayload(p.MetricsEvent)
 	}
 
 	jsonData, err := json.Marshal(eventData)
@@ -217,104 +217,169 @@ func getEventAllowedOrigins() []string {
 
 // Helper functions to convert proto messages to maps
 
-func containerEventToMap(e *pb.ContainerEvent) map[string]interface{} {
+// The SSE payload shapes.
+//
+// These were map[string]interface{} literals, which meant a mistyped key was
+// valid Go producing valid JSON with the wrong field name. web-ui declares the
+// matching shape in src/types/events.ts, so the two agreed only by inspection
+// — nothing on either side would have caught a drift.
+//
+// Named structs so the field names are compile-checked. The JSON is
+// unchanged: same keys, same casing, and the same omit-when-empty behaviour
+// the map literals got by only assigning present fields.
+
+type ssePayloadContainer struct {
+	Name          string `json:"name"`
+	Username      string `json:"username"`
+	State         string `json:"state"`
+	IPAddress     string `json:"ipAddress"`
+	CPU           string `json:"cpu"`
+	Memory        string `json:"memory"`
+	Disk          string `json:"disk"`
+	Image         string `json:"image"`
+	PodmanEnabled bool   `json:"podmanEnabled"`
+}
+
+type ssePayloadContainerEvent struct {
+	Container     *ssePayloadContainer `json:"container,omitempty"`
+	PreviousState string               `json:"previousState,omitempty"`
+}
+
+type ssePayloadApp struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Username      string `json:"username"`
+	ContainerName string `json:"containerName"`
+	Subdomain     string `json:"subdomain"`
+	FullDomain    string `json:"fullDomain"`
+	Port          int32  `json:"port"`
+	State         string `json:"state"`
+}
+
+type ssePayloadAppEvent struct {
+	App           *ssePayloadApp `json:"app,omitempty"`
+	PreviousState string         `json:"previousState,omitempty"`
+}
+
+type ssePayloadRoute struct {
+	Subdomain   string `json:"subdomain"`
+	FullDomain  string `json:"fullDomain"`
+	ContainerIP string `json:"containerIp"`
+	Port        int32  `json:"port"`
+	Active      bool   `json:"active"`
+	AppID       string `json:"appId"`
+	AppName     string `json:"appName"`
+}
+
+type ssePayloadRouteEvent struct {
+	Route *ssePayloadRoute `json:"route,omitempty"`
+}
+
+type ssePayloadMetric struct {
+	Name             string `json:"name"`
+	CPUUsageSeconds  int64  `json:"cpuUsageSeconds"`
+	MemoryUsageBytes int64  `json:"memoryUsageBytes"`
+	MemoryPeakBytes  int64  `json:"memoryPeakBytes"`
+	DiskUsageBytes   int64  `json:"diskUsageBytes"`
+	NetworkRxBytes   int64  `json:"networkRxBytes"`
+	NetworkTxBytes   int64  `json:"networkTxBytes"`
+	ProcessCount     int32  `json:"processCount"`
+}
+
+type ssePayloadMetricsEvent struct {
+	Metrics []ssePayloadMetric `json:"metrics"`
+}
+
+func containerEventToPayload(e *pb.ContainerEvent) *ssePayloadContainerEvent {
 	if e == nil {
 		return nil
 	}
-	result := map[string]interface{}{}
-	if e.Container != nil {
-		result["container"] = containerToMap(e.Container)
-	}
+	out := &ssePayloadContainerEvent{Container: containerToPayload(e.Container)}
 	if e.PreviousState != pb.ContainerState_CONTAINER_STATE_UNSPECIFIED {
-		result["previousState"] = e.PreviousState.String()
+		out.PreviousState = e.PreviousState.String()
 	}
-	return result
+	return out
 }
 
-func containerToMap(c *pb.Container) map[string]interface{} {
+func containerToPayload(c *pb.Container) *ssePayloadContainer {
 	if c == nil {
 		return nil
 	}
-	return map[string]interface{}{
-		"name":          c.Name,
-		"username":      c.Username,
-		"state":         c.State.String(),
-		"ipAddress":     c.Network.GetIpAddress(),
-		"cpu":           c.Resources.GetCpu(),
-		"memory":        c.Resources.GetMemory(),
-		"disk":          c.Resources.GetDisk(),
-		"image":         c.Image,
-		"podmanEnabled": c.PodmanEnabled,
+	return &ssePayloadContainer{
+		Name:          c.Name,
+		Username:      c.Username,
+		State:         c.State.String(),
+		IPAddress:     c.Network.GetIpAddress(),
+		CPU:           c.Resources.GetCpu(),
+		Memory:        c.Resources.GetMemory(),
+		Disk:          c.Resources.GetDisk(),
+		Image:         c.Image,
+		PodmanEnabled: c.PodmanEnabled,
 	}
 }
 
-func appEventToMap(e *pb.AppEvent) map[string]interface{} {
+func appEventToPayload(e *pb.AppEvent) *ssePayloadAppEvent {
 	if e == nil {
 		return nil
 	}
-	result := map[string]interface{}{}
-	if e.App != nil {
-		result["app"] = appToMap(e.App)
-	}
+	out := &ssePayloadAppEvent{App: appToPayload(e.App)}
 	if e.PreviousState != pb.AppState_APP_STATE_UNSPECIFIED {
-		result["previousState"] = e.PreviousState.String()
+		out.PreviousState = e.PreviousState.String()
 	}
-	return result
+	return out
 }
 
-func appToMap(a *pb.App) map[string]interface{} {
+func appToPayload(a *pb.App) *ssePayloadApp {
 	if a == nil {
 		return nil
 	}
-	return map[string]interface{}{
-		"id":            a.Id,
-		"name":          a.Name,
-		"username":      a.Username,
-		"containerName": a.ContainerName,
-		"subdomain":     a.Subdomain,
-		"fullDomain":    a.FullDomain,
-		"port":          a.Port,
-		"state":         a.State.String(),
+	return &ssePayloadApp{
+		ID:            a.Id,
+		Name:          a.Name,
+		Username:      a.Username,
+		ContainerName: a.ContainerName,
+		Subdomain:     a.Subdomain,
+		FullDomain:    a.FullDomain,
+		Port:          a.Port,
+		State:         a.State.String(),
 	}
 }
 
-func routeEventToMap(e *pb.RouteEvent) map[string]interface{} {
+func routeEventToPayload(e *pb.RouteEvent) *ssePayloadRouteEvent {
 	if e == nil {
 		return nil
 	}
-	result := map[string]interface{}{}
+	out := &ssePayloadRouteEvent{}
 	if e.Route != nil {
-		result["route"] = map[string]interface{}{
-			"subdomain":   e.Route.Subdomain,
-			"fullDomain":  e.Route.FullDomain,
-			"containerIp": e.Route.ContainerIp,
-			"port":        e.Route.Port,
-			"active":      e.Route.Active,
-			"appId":       e.Route.AppId,
-			"appName":     e.Route.AppName,
+		out.Route = &ssePayloadRoute{
+			Subdomain:   e.Route.Subdomain,
+			FullDomain:  e.Route.FullDomain,
+			ContainerIP: e.Route.ContainerIp,
+			Port:        e.Route.Port,
+			Active:      e.Route.Active,
+			AppID:       e.Route.AppId,
+			AppName:     e.Route.AppName,
 		}
 	}
-	return result
+	return out
 }
 
-func metricsEventToMap(e *pb.MetricsEvent) map[string]interface{} {
+func metricsEventToPayload(e *pb.MetricsEvent) *ssePayloadMetricsEvent {
 	if e == nil {
 		return nil
 	}
-	metrics := make([]map[string]interface{}, len(e.Metrics))
+	metrics := make([]ssePayloadMetric, len(e.Metrics))
 	for i, m := range e.Metrics {
-		metrics[i] = map[string]interface{}{
-			"name":             m.Name,
-			"cpuUsageSeconds":  m.CpuUsageSeconds,
-			"memoryUsageBytes": m.MemoryUsageBytes,
-			"memoryPeakBytes":  m.MemoryPeakBytes,
-			"diskUsageBytes":   m.DiskUsageBytes,
-			"networkRxBytes":   m.NetworkRxBytes,
-			"networkTxBytes":   m.NetworkTxBytes,
-			"processCount":     m.ProcessCount,
+		metrics[i] = ssePayloadMetric{
+			Name:             m.Name,
+			CPUUsageSeconds:  m.CpuUsageSeconds,
+			MemoryUsageBytes: m.MemoryUsageBytes,
+			MemoryPeakBytes:  m.MemoryPeakBytes,
+			DiskUsageBytes:   m.DiskUsageBytes,
+			NetworkRxBytes:   m.NetworkRxBytes,
+			NetworkTxBytes:   m.NetworkTxBytes,
+			ProcessCount:     m.ProcessCount,
 		}
 	}
-	return map[string]interface{}{
-		"metrics": metrics,
-	}
+	return &ssePayloadMetricsEvent{Metrics: metrics}
 }

--- a/internal/gateway/events_payload_test.go
+++ b/internal/gateway/events_payload_test.go
@@ -1,0 +1,127 @@
+package gateway
+
+import (
+	"encoding/json"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// These payloads were map[string]interface{} literals. web-ui declares the
+// matching shape in src/types/events.ts, so the Go side and the TypeScript
+// side agreed only by inspection — a mistyped key was valid Go, valid JSON,
+// and wrong, with nothing on either side to catch it.
+//
+// Typing them is only safe if the emitted JSON is unchanged, so that is what
+// these assert: the exact key set, and the types the browser will see.
+
+func marshalToMap(t *testing.T, v any) map[string]json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return m
+}
+
+func assertKeys(t *testing.T, got map[string]json.RawMessage, want ...string) {
+	t.Helper()
+	for _, k := range want {
+		if _, ok := got[k]; !ok {
+			t.Errorf("payload is missing %q — web-ui's events.ts declares it", k)
+		}
+	}
+	if len(got) != len(want) {
+		keys := make([]string, 0, len(got))
+		for k := range got {
+			keys = append(keys, k)
+		}
+		t.Errorf("payload has %d keys, want %d: got %v, want %v", len(got), len(want), keys, want)
+	}
+}
+
+func TestContainerPayloadShape(t *testing.T) {
+	got := marshalToMap(t, containerToPayload(&pb.Container{
+		Name: "alice-container", Username: "alice",
+		State:     pb.ContainerState_CONTAINER_STATE_RUNNING,
+		Network:   &pb.NetworkInfo{IpAddress: "10.0.3.5"},
+		Resources: &pb.ResourceLimits{Cpu: "2", Memory: "4GB", Disk: "20GB"},
+		Image:     "ubuntu:24.04", PodmanEnabled: true,
+	}))
+	assertKeys(t, got, "name", "username", "state", "ipAddress", "cpu", "memory", "disk", "image", "podmanEnabled")
+}
+
+// previousState is omitted when unspecified — the map literal got that by
+// only assigning the key when set, and omitempty has to reproduce it.
+func TestContainerEventOmitsUnsetPreviousState(t *testing.T) {
+	got := marshalToMap(t, containerEventToPayload(&pb.ContainerEvent{
+		Container: &pb.Container{Name: "alice-container"},
+	}))
+	if _, present := got["previousState"]; present {
+		t.Error("previousState is emitted when unspecified — it was omitted before, and a " +
+			"consumer distinguishing absent from empty would now see a state change that " +
+			"did not happen")
+	}
+
+	withPrev := marshalToMap(t, containerEventToPayload(&pb.ContainerEvent{
+		Container:     &pb.Container{Name: "alice-container"},
+		PreviousState: pb.ContainerState_CONTAINER_STATE_STOPPED,
+	}))
+	if _, present := withPrev["previousState"]; !present {
+		t.Error("previousState is dropped when it IS set")
+	}
+}
+
+func TestAppPayloadShape(t *testing.T) {
+	got := marshalToMap(t, appToPayload(&pb.App{
+		Id: "app-1", Name: "web", Username: "alice", ContainerName: "alice-container",
+		Subdomain: "web", FullDomain: "web.example.com", Port: 8080,
+		State: pb.AppState_APP_STATE_RUNNING,
+	}))
+	assertKeys(t, got, "id", "name", "username", "containerName", "subdomain", "fullDomain", "port", "state")
+}
+
+func TestRoutePayloadShape(t *testing.T) {
+	ev := routeEventToPayload(&pb.RouteEvent{Route: &pb.ProxyRoute{
+		Subdomain: "web", FullDomain: "web.example.com", ContainerIp: "10.0.3.5",
+		Port: 8080, Active: true, AppId: "app-1", AppName: "web",
+	}})
+	inner := marshalToMap(t, ev.Route)
+	assertKeys(t, inner, "subdomain", "fullDomain", "containerIp", "port", "active", "appId", "appName")
+}
+
+// The metric counters are int64 in the proto and were emitted as JSON numbers
+// by the map literal. Typing them as strings would have been a silent break
+// for any consumer doing arithmetic on them.
+func TestMetricsPayloadEmitsNumbersNotStrings(t *testing.T) {
+	b, err := json.Marshal(metricsEventToPayload(&pb.MetricsEvent{
+		Metrics: []*pb.ContainerMetrics{{Name: "alice-container", CpuUsageSeconds: 42, MemoryUsageBytes: 1024}},
+	}))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var out struct {
+		Metrics []struct {
+			CPUUsageSeconds  json.RawMessage `json:"cpuUsageSeconds"`
+			MemoryUsageBytes json.RawMessage `json:"memoryUsageBytes"`
+		} `json:"metrics"`
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Metrics) != 1 {
+		t.Fatalf("want 1 metric, got %d", len(out.Metrics))
+	}
+	if string(out.Metrics[0].CPUUsageSeconds) != "42" {
+		t.Errorf("cpuUsageSeconds = %s, want the bare number 42 — a quoted string breaks any "+
+			"consumer doing arithmetic on it", out.Metrics[0].CPUUsageSeconds)
+	}
+	if string(out.Metrics[0].MemoryUsageBytes) != "1024" {
+		t.Errorf("memoryUsageBytes = %s, want 1024", out.Metrics[0].MemoryUsageBytes)
+	}
+}


### PR DESCRIPTION
Continues the `interface{}` sweep from #1309. Six event payload builders returned `map[string]interface{}` literals — the shape `CLAUDE.md` names for wire payloads specifically.

## Why it matters here in particular

`web-ui/src/types/events.ts` declares the matching shape in TypeScript. So the Go side and the browser side agreed **only by inspection** — a mistyped key was valid Go, valid JSON, and wrong, with nothing on either side to catch it.

## The JSON is unchanged

Same keys, same casing, and the same omit-when-set-only behaviour the map literals got by assigning conditionally. That is the entire risk in this change, so it is asserted rather than assumed — tests pin the exact key set of each payload.

**The metric counters are the sharp case.** They are `int64` in the proto and the maps emitted them as JSON *numbers*. I wrote the struct fields as `string` first, which would have quietly broken any consumer doing arithmetic on them — the compiler caught it, because the proto fields are `int64`. There is now a test asserting `cpuUsageSeconds` marshals as the bare number `42` rather than `"42"`.

Mutation-tested: a key typo (`ipAddress` → `ipaddress`), metrics as strings, and `previousState` losing `omitempty` each fail a test.

## A real drift found, deliberately not fixed here

`events.ts` declares `stack?: string` on the container payload, and the Go side **has never emitted it** — though `pb.Container` has the field and `client.ts` reads `apiContainer.stack`.

So the browser has been declaring, and reading, a field the SSE stream does not carry. That is exactly the drift this change makes visible. But adding a key is a behaviour change and does not belong in a refactor, so it is flagged rather than slipped in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)