### PR TITLE
fix(k8s): except the metadata IP instead of refusing the whole allowlist

### DIFF
--- a/pkg/core/box/k8s/egress_policy.go
+++ b/pkg/core/box/k8s/egress_policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"slices"
 	"sort"
 	"strings"
 
@@ -111,16 +112,19 @@ func compileTenantPolicy(p *pb.NetworkPolicy) ([]networkingv1.NetworkPolicyEgres
 			continue
 		}
 
-		// The metadata carve-out is deny-beats-allow and cannot be expressed:
-		// an allowlist entry covering 169.254.169.254 would hand the tenant
-		// cloud credentials the stored policy explicitly withholds.
+		// The metadata carve-out IS expressible: IPBlock.Except subtracts
+		// sub-ranges from an allow rule, which is exactly deny-beats-allow for
+		// this one address. An earlier version refused here on the belief that
+		// NetworkPolicy had no such mechanism; it does, and refusing rejected
+		// the commonest policy tenants actually write — allow a wide range,
+		// carve out metadata — leaving them on the DNS-only floor with no
+		// outbound network at all.
+		//
+		// Except entries must fall inside the peer's CIDR. That holds by
+		// construction: coversMetadataIP is true only when the CIDR contains
+		// the metadata address.
 		if !p.GetAllowMetadata() && coversMetadataIP(cidr) {
-			unsupported = append(unsupported, UnsupportedPolicyFeature{
-				Feature: "egress_cidr=" + cidr,
-				Reason: "covers the cloud metadata IP while allow_metadata is false; NetworkPolicy " +
-					"cannot carve an exception out of an allow rule",
-			})
-			continue
+			peers = withMetadataExcepted(peers)
 		}
 
 		rules = append(rules, networkingv1.NetworkPolicyEgressRule{To: peers})
@@ -132,6 +136,31 @@ func compileTenantPolicy(p *pb.NetworkPolicy) ([]networkingv1.NetworkPolicyEgres
 		return peerCIDR(rules[i]) < peerCIDR(rules[j])
 	})
 	return rules, unsupported
+}
+
+// withMetadataExcepted subtracts the cloud metadata address from every IPBlock
+// peer, so a broad allow rule stops short of the one address that hands out
+// cloud credentials.
+//
+// A peer with no IPBlock (there are none today — egressPeersFor only builds
+// IPBlocks) is passed through untouched rather than silently dropped: losing a
+// peer here would narrow the tenant's policy without saying so.
+func withMetadataExcepted(peers []networkingv1.NetworkPolicyPeer) []networkingv1.NetworkPolicyPeer {
+	out := make([]networkingv1.NetworkPolicyPeer, 0, len(peers))
+	except := netip.PrefixFrom(metadataIP, metadataIP.BitLen()).String()
+	for _, p := range peers {
+		if p.IPBlock == nil {
+			out = append(out, p)
+			continue
+		}
+		block := *p.IPBlock
+		if !slices.Contains(block.Except, except) {
+			block.Except = append(append([]string(nil), block.Except...), except)
+		}
+		p.IPBlock = &block
+		out = append(out, p)
+	}
+	return out
 }
 
 // coversMetadataIP reports whether an allowlist entry would admit the cloud

--- a/pkg/core/box/k8s/tenant_policy_test.go
+++ b/pkg/core/box/k8s/tenant_policy_test.go
@@ -2,7 +2,7 @@ package k8s
 
 import (
 	"context"
-	"strings"
+	"slices"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,21 +51,63 @@ func TestCompileTenantPolicy_RefusesLogOnlyMode(t *testing.T) {
 }
 
 // The metadata carve-out is deny-beats-allow and guards cloud credentials.
-// An allowlist entry covering 169.254.169.254 cannot be narrowed by an
-// allow-only policy, so it must be refused rather than admitted.
-func TestCompileTenantPolicy_RefusesAllowlistCoveringMetadataIP(t *testing.T) {
-	_, unsupported := compileTenantPolicy(enforcing(&pb.NetworkPolicy{
+//
+// This used to be REFUSED, on the belief that an allow-only policy could not
+// narrow a rule. It can: IPBlock.Except subtracts sub-ranges from a peer, which
+// is exactly deny-beats-allow for one address. Refusing rejected the commonest
+// policy tenants write — allow a wide range, carve out metadata — and left
+// them on the DNS-only floor with no outbound network at all.
+//
+// The security property is unchanged and the assertion below is the same one:
+// the tenant must not reach 169.254.169.254. What changed is that the rest of
+// their allowlist now works.
+func TestCompileTenantPolicy_ExceptsMetadataIPFromCoveringAllowlist(t *testing.T) {
+	compiled, unsupported := compileTenantPolicy(enforcing(&pb.NetworkPolicy{
 		Tenant:      "alice",
 		EgressCidrs: []string{"169.254.0.0/16"}, // covers the metadata service
 		// AllowMetadata false — the default, and the whole point
 	}))
-	if len(unsupported) == 0 {
-		t.Fatal("an allowlist covering 169.254.169.254 was accepted while allow_metadata is " +
-			"false — the tenant would reach the cloud metadata service, and its credentials, " +
-			"which the stored policy explicitly withholds")
+	if len(unsupported) != 0 {
+		t.Fatalf("the allowlist was refused rather than narrowed: %v", unsupported)
 	}
-	if !strings.Contains(unsupported[0].Reason, "metadata") {
-		t.Errorf("reason should name the metadata carve-out: %v", unsupported[0])
+	if len(compiled) != 1 {
+		t.Fatalf("compiled %d rules, want 1", len(compiled))
+	}
+
+	var excepted bool
+	for _, peer := range compiled[0].To {
+		if peer.IPBlock == nil {
+			continue
+		}
+		if slices.Contains(peer.IPBlock.Except, "169.254.169.254/32") {
+			excepted = true
+		}
+	}
+	if !excepted {
+		t.Errorf("the compiled rule admits 169.254.169.254 — the tenant would reach the cloud "+
+			"metadata service, and its credentials, which the stored policy explicitly "+
+			"withholds. Rule: %+v", compiled[0])
+	}
+}
+
+// The exception must not be added when the tenant has NOT opted in but the
+// allowlist doesn't reach metadata anyway — an Except entry outside its
+// IPBlock's CIDR is invalid and some CNIs reject the whole object.
+func TestCompileTenantPolicy_NoMetadataExceptWhenAllowlistDoesNotCoverIt(t *testing.T) {
+	compiled, unsupported := compileTenantPolicy(enforcing(&pb.NetworkPolicy{
+		Tenant: "alice", EgressCidrs: []string{"10.0.0.0/8"},
+	}))
+	if len(unsupported) != 0 {
+		t.Fatalf("unexpected refusal: %v", unsupported)
+	}
+	if len(compiled) != 1 {
+		t.Fatalf("compiled %d rules, want 1", len(compiled))
+	}
+	for _, peer := range compiled[0].To {
+		if peer.IPBlock != nil && len(peer.IPBlock.Except) != 0 {
+			t.Errorf("added Except %v to 10.0.0.0/8, which does not contain the metadata IP; "+
+				"an Except outside its CIDR is invalid", peer.IPBlock.Except)
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up on #1188 (closed by #1260/#1261/#1262). I went to implement the egress allowlist, found it already shipped, and reviewed it instead — this is the one thing I'd change.

### The claim that isn't true

`compileTenantPolicy` refuses any `egress_cidrs` entry covering `169.254.169.254` while `allow_metadata` is false, with the reason:

> covers the cloud metadata IP while allow_metadata is false; **NetworkPolicy cannot carve an exception out of an allow rule**

It can. `IPBlock.Except` subtracts sub-ranges from a peer — precisely deny-beats-allow for one address. Verified against the `k8s.io/api` version this repo builds on:

```
IPBlock.Except IS available: {CIDR:0.0.0.0/0 Except:[169.254.169.254/32]}
```

### Why it matters more than it looks

`compileTenantPolicy` refuses **all-or-nothing** — by design, and that design is right. But it means one covering CIDR discards the *entire* policy, dropping the tenant back to the DNS-only floor with **no outbound network at all**.

And *"allow a wide range, carve out metadata"* is the commonest policy anyone actually writes. So the feature that shipped to fix "boxes have no outbound network" still left the most common configuration with exactly that.

### What changed, and what didn't

**The security property is unchanged.** The tenant still cannot reach the metadata service. It's now enforced by **narrowing the rule** rather than by **discarding the policy containing it** — strictly better, since the rest of the allowlist survives.

I rewrote `TestCompileTenantPolicy_RefusesAllowlistCoveringMetadataIP` rather than deleting it: same assertion (the tenant must not reach 169.254.169.254), now checked on the compiled rule. Its comment carried the same factual error, so that's corrected too — I didn't want to silently flip a deliberate security assertion.

Added a converse test: an allowlist that *doesn't* reach metadata gets **no** `Except`, since an out-of-range `Except` is invalid and some CNIs reject the whole object.

### Validation

Full `pkg/core/box/k8s` suite green, `go vet` clean. All 8 `TestCompileTenantPolicy_*` cases pass, including the pre-existing refusals for `egress_domains`, `deny_rules`, and LOG_ONLY mode — which remain correctly unexpressible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)