### PR TITLE
ci: lint the code behind build tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,14 @@ version: "2"
 
 run:
   timeout: 5m
+  # Lint the code behind build tags too. Without this, 13 files are invisible
+  # to every linter: the whole K8s box backend's tests, the ZFS integration
+  # tests, and internal/testsupport/zfspool (which is not even a test file).
+  # That is where the newest and least-exercised code lives, so it is the
+  # worst place to have a blind spot.
+  build-tags:
+    - k8s
+    - zfs
 
 # Mirrors the cloud repo's config. `default: standard` = errcheck, govet,
 # ineffassign, staticcheck, unused. Tighten by enabling more linters once a

--- a/pkg/core/box/k8s/e2e_egress_test.go
+++ b/pkg/core/box/k8s/e2e_egress_test.go
@@ -107,8 +107,8 @@ func TestE2E_BoxEgressPosture(t *testing.T) {
 		// Not a failure of the policy as written — but it contradicts the
 		// object, which means something else is granting egress. Worth
 		// failing on, because the isolation story depends on knowing which.
-		t.Errorf("a box-labelled pod reached the control-plane API on :443, but the NetworkPolicy "+
-			"has no egress rule permitting it. Something outside the policy is granting egress — "+
+		t.Errorf("a box-labelled pod reached the control-plane API on :443, but the NetworkPolicy " +
+			"has no egress rule permitting it. Something outside the policy is granting egress — " +
 			"investigate before trusting the deny-by-default posture (#1188).")
 	default:
 		t.Logf("OBSERVED: box egress to the control-plane API is blocked (phase %v). "+

--- a/pkg/core/box/k8s/sandbox_test.go
+++ b/pkg/core/box/k8s/sandbox_test.go
@@ -12,7 +12,7 @@ import (
 func boxContainerEnv(t *testing.T, boxMode string) map[string]string {
 	t.Helper()
 	sb := sandboxObject("tenant-x", box.BoxSpec{Ref: box.BoxRef{Tenant: "x"}, Image: "img", AutoStart: true}, false, memDefaults{}, podOptions{BoxMode: boxMode})
-	containers := sb.Spec.SandboxBlueprint.PodTemplate.Spec.Containers
+	containers := sb.Spec.PodTemplate.Spec.Containers
 	if len(containers) != 1 {
 		t.Fatalf("want 1 container, got %d", len(containers))
 	}
@@ -53,7 +53,7 @@ func TestSandboxObjectRuntimeClass(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sb := sandboxObject("tenant-x", box.BoxSpec{Ref: box.BoxRef{Tenant: "x"}, Image: "img", AutoStart: true},
 				false, memDefaults{}, podOptions{RuntimeClass: tc.runtimeClass})
-			got := sb.Spec.SandboxBlueprint.PodTemplate.Spec.RuntimeClassName
+			got := sb.Spec.PodTemplate.Spec.RuntimeClassName
 			switch {
 			case tc.want == nil && got != nil:
 				t.Errorf("RuntimeClassName = %q, want unset", *got)


### PR DESCRIPTION
golangci-lint ran without build tags, so **13 files were invisible to every linter**:

- the whole K8s box backend's tests (`pkg/core/box/k8s/*_test.go`, including all four e2e suites)
- the ZFS integration tests
- `internal/testsupport/zfspool/zfspool.go` — not even a test file

That is where the newest and least-exercised code in the tree lives, which makes it the worst place to have a blind spot.

## What it surfaced

Three issues, all fixed here:

| | |
| --- | --- |
| `e2e_egress_test.go` | gofmt |
| `sandbox_test.go` ×2 | staticcheck `QF1008` — redundant embedded-field selector |

The staticcheck rule is the interesting one: it **already gates the untagged tree**. It failed one of my own PRs (#1274) in a file one directory over, while these two instances sat unreported in the same package.

## The blind spot, as a measurement

Reintroducing the staticcheck defect:

| config | result |
| --- | --- |
| with `build-tags: [k8s, zfs]` | **2 issues** |
| without (previous behaviour) | **0 issues** |

Same code, same linter. That is the gap stated as a number rather than an argument.

## How it was found

CI caught a `gofmt` miss on #1309 that I could not reproduce locally, because I had checked with `gofmt -l` and the simplify pass is a separate flag. Running `gofmt -s -l` across the tree turned up one remaining file — and that file turned out never to have been linted at all.

CI runs `golangci-lint run` with no flags, so the config governs; no workflow change needed. Baseline was 0 issues before this and is 0 issues after, now over a larger surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)