### PR TITLE
docs(lint): record what tightening the linter set would actually cost

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,8 +4,29 @@ run:
   timeout: 5m
 
 # Mirrors the cloud repo's config. `default: standard` = errcheck, govet,
-# ineffassign, staticcheck, unused. Tighten by enabling more linters once a
-# clean baseline holds.
+# ineffassign, staticcheck, unused.
+#
+# On "tighten by enabling more linters once a clean baseline holds": the
+# baseline is clean, and six candidates were measured against this tree
+# (2026-08-11, golangci-lint 2.12.2, build tags included). Only one was worth
+# anything, and it was already clean:
+#
+#   sqlclosecheck   0 findings — already holds; enable if it stays free
+#   makezero        3 — all the nonce||ciphertext idiom in KMS test fakes,
+#                   where make([]byte, NonceSize()) then append is correct
+#   bodyclose       6 — all responses handed to the generic parseResponse,
+#                   which does `defer drainClose(resp)`; the linter cannot
+#                   trace through it
+#   nilerr         18 — sampled: deliberate skip-and-continue, already
+#                   carrying comments saying so ("skip unreadable entries")
+#   errorlint      33 — 26 are ==/!= on errors the stdlib returns unwrapped
+#                   by contract (io.EOF from io.ReadFull), so safe here
+#   noctx         448 — overwhelmingly httptest.NewRequest and exec.Command
+#                   in tests
+#
+# Each would cost more nolint annotations than it would catch bugs. Recorded
+# so the next person does not re-measure; re-check after any large refactor
+# rather than treating this as settled forever.
 linters:
   default: standard
   enable:


### PR DESCRIPTION
`.golangci.yml` says "Tighten by enabling more linters once a clean baseline holds." The baseline holds (0 issues, and after #1313 that includes the build-tagged files). So I measured six candidates rather than leave the invitation open indefinitely.

## Result

| linter | findings | verdict |
| --- | --- | --- |
| `sqlclosecheck` | **0** | already holds — worth enabling to keep it that way |
| `makezero` | 3 | all the `nonce \|\| ciphertext` idiom in KMS test fakes, where `make([]byte, NonceSize())` then `append` is correct |
| `bodyclose` | 6 | all responses handed to the generic `parseResponse`, which does `defer drainClose(resp)` — the linter cannot trace through it |
| `nilerr` | 18 | sampled: deliberate skip-and-continue, already carrying comments saying so (`// skip unreadable entries`) |
| `errorlint` | 33 | 26 are `==`/`!=` on errors the stdlib returns **unwrapped by contract** (`io.EOF` from `io.ReadFull`), so safe here |
| `noctx` | 448 | overwhelmingly `httptest.NewRequest` and `exec.Command` in tests |

Each of the five non-zero ones would cost more `nolint` annotations than it would catch bugs, and the reasons are specific to how this code is written rather than general.

## Why in the config rather than an issue

That is where someone stands when they decide to act on the invitation. An issue is where this goes to be missed.

It is written as a measurement — dated, with the tool version — so it can be re-run rather than believed. It is a snapshot of this tree, not a permanent verdict, and the comment says to re-check after any large refactor.

## What I did not do

I did not enable `sqlclosecheck` despite it being clean. Enabling a linter is a change to what gates every future PR, and "it happens to report zero today" is an argument for it being cheap, not for it being wanted. That is a maintainer's call, and the measurement is here to make it a short one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)