### PR TITLE
docs(k8s): the per-tenant egress allowlist shipped, correcting #1311

### DIFF
--- a/docs/EKS-GKE-DEPLOY.md
+++ b/docs/EKS-GKE-DEPLOY.md
@@ -236,22 +236,32 @@ so the CLI and GitOps drive one reconcile loop. The operator is opt-in
   `CONTAINARIUM_K8S_INSECURE_IGNORE_HOST_KEY=1` for out-of-the-box dev. In
   production, unset it and distribute the gateway host key so clients use
   `StrictHostKeyChecking=yes` against a known `known_hosts` entry.
-- **Default-deny NetworkPolicy — and it means boxes have _no_ outbound
-  network today.** You don't add this: the daemon already creates a
-  `default-deny` NetworkPolicy in each box namespace. What it currently
-  permits is exactly one thing — DNS (UDP/TCP 53) to `kube-system`. Nothing
-  else. So a box on this backend can resolve names and **connect to nothing**:
-  no `pip install`, no `apt-get`, no outbound HTTP, no control-plane API.
+- **Default-deny NetworkPolicy — a box with no egress policy has _no_
+  outbound network.** You don't add this: the daemon already creates a
+  `default-deny` NetworkPolicy in each box namespace. On its own it permits
+  exactly one thing — DNS (UDP/TCP 53) to `kube-system`. Nothing else. So a
+  box with no policy set can resolve names and **connect to nothing**: no
+  `pip install`, no `apt-get`, no outbound HTTP, no control-plane API.
 
   This is measured, not inferred — `TestE2E_BoxEgressPosture` observes it on a
   Calico cluster in CI, with a DNS positive control to prove the probe itself
-  works. It is the deliberate "v1 floor"; a per-tenant egress **allowlist**
-  driven by `NetworkPolicyService` is [#1188] and is not built yet.
+  works.
+
+  That floor is the *starting* posture, not the ceiling. A per-tenant egress
+  **allowlist** driven by `NetworkPolicyService` shipped in [#1188]: a
+  reconciler converges each tenant's namespace NetworkPolicy with the stored
+  policy, so an allowlist appears as egress rules alongside the DNS
+  allowance, and removing a policy reverts to this floor rather than to
+  allow-all. `TestE2E_TenantEgressAllowlistIsEnforced` proves it with packets
+  on Calico — a destination inside the allowlist is reachable, one outside it
+  is not.
 
   Two practical consequences:
 
-  - If your agents need to install packages or reach the internet, the LXC
-    backend is the one that supports that today. Plan around it.
+  - If your agents need to install packages or reach the internet, set an
+    egress policy for that tenant. Until you do, the floor above is what they
+    get — which is the point, but it surprises people who expected the LXC
+    backend's open-by-default posture.
   - Enforcement is the CNI's job (Calico on EKS, Dataplane V2 / Cilium on
     GKE). On a CNI that ignores NetworkPolicy the object is inert and boxes
     have *unrestricted* egress — the opposite posture, silently. Verify which


### PR DESCRIPTION
#1311 landed while #1188 was merging, so the passage it added says the per-tenant egress allowlist:

> is [#1188] and **is not built yet**

It is on `main`. Verified rather than remembered:

- `internal/server/k8s_netpolicy_reconciler.go` — constructed and started (`dual_server.go:2174`)
- `pkg/core/box/k8s/egress_policy.go` — compiles a stored policy into NetworkPolicy egress rules
- `TestE2E_TenantEgressAllowlistIsEnforced` — proves it with packets on Calico
- #1188 is closed

## Why this one matters beyond accuracy

The passage draws a conclusion from it:

> If your agents need to install packages or reach the internet, **the LXC backend is the one that supports that today**. Plan around it.

So an operator reading this picks a different backend to get a capability this one has. That is a worse outcome than a stale sentence.

## What is kept

Everything else in that section is right, and it is a genuinely good piece of writing — the default-deny floor, the DNS-only allowance, `TestE2E_BoxEgressPosture` as the evidence, and the warning that a CNI ignoring NetworkPolicy silently inverts the posture. All unchanged.

The correction is scoped to the "not built yet" claim and the advice that followed from it: the floor is the *starting* posture, not the ceiling. The replacement advice keeps the useful warning — a box with no policy really does get nothing, which surprises people expecting the LXC backend's open-by-default behaviour.

Not a criticism of #1311; the two PRs were simply in flight at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)