### PR TITLE
fix(agent): actually construct the Postgres run stores

### DIFF
--- a/internal/server/agent_task_store.go
+++ b/internal/server/agent_task_store.go
@@ -230,3 +230,12 @@ func (p *PostgresAgentTaskQueue) Result(ctx context.Context, taskID string) (tas
 // wall-clock property, and the alternative to injecting a clock is a test that
 // sleeps for the lease duration.
 func (m *MemAgentTaskQueue) setClock(now func() time.Time) { m.q.now = now }
+
+// SetTaskQueue swaps the pull-queue store, used at daemon start to upgrade
+// from the in-memory default to Postgres. Called before grpcServer.Serve, so
+// no lease is in flight across the swap.
+func (s *AgentSkillServer) SetTaskQueue(q AgentTaskQueue) {
+	if q != nil {
+		s.queue = q
+	}
+}

--- a/internal/server/crew_run_store.go
+++ b/internal/server/crew_run_store.go
@@ -146,3 +146,13 @@ func (s *PostgresCrewRunStore) Get(ctx context.Context, id string) (*pb.CrewRun,
 	}
 	return &r, true, nil
 }
+
+// SetRunStore swaps the crew-run store, used at daemon start to upgrade from
+// the in-memory default to Postgres once the connection string is resolved.
+// Called before grpcServer.Serve, so it races with no live RPCs — the same
+// point and the same reasoning as NetworkPolicyServer.SetStore.
+func (s *CrewServer) SetRunStore(store CrewRunStore) {
+	if store != nil {
+		s.runs = store
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -407,7 +407,8 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 
 	// Register CrewService — Phase 3. Collaborating sets of skills bound to a
 	// task purpose; reuses the agent-skill server to provision each member box.
-	pb.RegisterCrewServiceServer(grpcServer, NewCrewServer(agentSkillServer))
+	crewServer := NewCrewServer(agentSkillServer)
+	pb.RegisterCrewServiceServer(grpcServer, crewServer)
 	log.Printf("Crew service enabled")
 
 	// Merge external skill/crew catalogs (#620) into the process-wide catalogs
@@ -1076,6 +1077,23 @@ skipAppHosting:
 			} else {
 				npServer.SetSignatureStore(sigStore)
 				log.Printf("NetworkPolicy signature persistence enabled (Postgres store)")
+			}
+
+			// Agent run state (#1182) shares the same pool. Same best-effort
+			// posture: on failure the in-memory store stays, so the daemon comes
+			// up either way — it just loses runs across a restart, which is the
+			// behavior that predates this.
+			if runStore, rErr := NewPostgresCrewRunStore(context.Background(), pool); rErr != nil {
+				log.Printf("Warning: Failed to create Postgres crew-run store: %v", rErr)
+			} else {
+				crewServer.SetRunStore(runStore)
+				log.Printf("Crew-run persistence enabled (Postgres store)")
+			}
+			if taskQueue, qErr := NewPostgresAgentTaskQueue(context.Background(), pool); qErr != nil {
+				log.Printf("Warning: Failed to create Postgres agent task queue: %v", qErr)
+			} else {
+				agentSkillServer.SetTaskQueue(taskQueue)
+				log.Printf("Agent task-queue persistence enabled (Postgres store)")
 			}
 		}
 	}

--- a/internal/server/store_wiring_test.go
+++ b/internal/server/store_wiring_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// #1182 shipped CrewRunStore/AgentTaskQueue with Postgres impls in #1316 and
+// #1318 — and nothing constructed them. The interfaces existed, the SQL
+// existed, and the daemon kept using the in-memory defaults, so a restart
+// still lost every run. The durability was unreachable.
+//
+// These pin the swap seam the daemon relies on. They can't prove dual_server
+// calls it (that needs a live Postgres), but they do prove the setters exist
+// and take effect — the part that was missing.
+
+func TestCrewServer_SetRunStoreTakesEffect(t *testing.T) {
+	s := NewCrewServer(nil)
+	swapped := NewMemCrewRunStore()
+	s.SetRunStore(swapped)
+	if s.runs != CrewRunStore(swapped) {
+		t.Fatal("SetRunStore did not replace the store")
+	}
+}
+
+// A nil store must not blank out a working one: the daemon calls the setter
+// from a best-effort branch, and losing the in-memory fallback would leave the
+// server with no store at all.
+func TestCrewServer_SetRunStoreIgnoresNil(t *testing.T) {
+	s := NewCrewServer(nil)
+	before := s.runs
+	s.SetRunStore(nil)
+	if s.runs == nil || s.runs != before {
+		t.Error("SetRunStore(nil) cleared the existing store")
+	}
+}
+
+func TestAgentSkillServer_SetTaskQueueTakesEffect(t *testing.T) {
+	s := &AgentSkillServer{queue: NewMemAgentTaskQueue()}
+	swapped := NewMemAgentTaskQueue()
+	s.SetTaskQueue(swapped)
+	if s.queue != AgentTaskQueue(swapped) {
+		t.Fatal("SetTaskQueue did not replace the queue")
+	}
+
+	// And the swapped queue is the one actually used.
+	if _, err := s.queue.Enqueue(context.Background(), "s", ""); err != nil {
+		t.Fatalf("Enqueue on swapped queue: %v", err)
+	}
+	if d, _ := swapped.Depth(context.Background()); d != 1 {
+		t.Errorf("swapped queue depth = %d, want 1 — writes went elsewhere", d)
+	}
+	if _, ok, _ := swapped.Lease(context.Background(), "", time.Minute); !ok {
+		t.Error("swapped queue had nothing leasable")
+	}
+}
+
+func TestAgentSkillServer_SetTaskQueueIgnoresNil(t *testing.T) {
+	s := &AgentSkillServer{queue: NewMemAgentTaskQueue()}
+	before := s.queue
+	s.SetTaskQueue(nil)
+	if s.queue == nil || s.queue != before {
+		t.Error("SetTaskQueue(nil) cleared the existing queue")
+	}
+}


### PR DESCRIPTION
Found while checking whether #1182 could be closed. It can't yet — and this is my omission across both prior PRs.

### The gap

#1316 and #1318 added `CrewRunStore` and `AgentTaskQueue` with Postgres implementations. **Nothing constructed them.**

```
grep -rn 'NewPostgresCrewRunStore|NewPostgresAgentTaskQueue' internal/ cmd/
→ only the definitions
```

The daemon kept calling `NewMemCrewRunStore` and `NewMemAgentTaskQueue` unconditionally, so a restart still lost every run and every queued task. Two merged PRs claiming to close a durability gap, with zero behavior change. Everything compiled and every test passed, because the tests exercised the stores directly and never asked which one the daemon picks.

### The fix

Wires both onto the pool the network-policy store already opens — same block, same best-effort posture: if the store can't be created, the in-memory one stays and the daemon still comes up, losing runs across a restart exactly as before.

`CrewServer` was constructed inline inside its register call, so there was no handle to swap later; it's now held in a variable like the others.

`SetRunStore` / `SetTaskQueue` mirror `NetworkPolicyServer.SetStore` — called before `grpcServer.Serve`, so the swap races with no live RPC and no in-flight lease. Both **ignore nil** rather than blanking a working store, since the caller is a best-effort branch and clearing the fallback would leave the server with no store at all.

### Tests

Four cases pinning the seam that was missing: each setter takes effect, writes land in the swapped instance, and nil is ignored.

They can't prove `dual_server` calls them — that needs a live Postgres, which belongs in the integration lane — but they'd have caught the setters not existing, which is the actual failure here.

### Worth noting

The Postgres impls still have no tests of their own. Both PRs said so, and it stands: the behavioral suite runs against the in-memory impl, and the SQL paths (`FOR UPDATE SKIP LOCKED`, the sequence-backed tokens, the transactional complete) are unexercised until there's an integration lane with a real database. That's the remaining honest gap on #1182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)