### PR TITLE
fix(gateway): emit the stack field the web UI already reads

### DIFF
--- a/internal/gateway/events.go
+++ b/internal/gateway/events.go
@@ -238,6 +238,11 @@ type ssePayloadContainer struct {
 	Disk          string `json:"disk"`
 	Image         string `json:"image"`
 	PodmanEnabled bool   `json:"podmanEnabled"`
+	// Stack is declared by web-ui (src/types/events.ts) and read by its
+	// client, but was never emitted here — the map literal this replaced
+	// listed nine fields and stack was not one of them (#1310). Additive, so
+	// a consumer that ignores it is unaffected.
+	Stack string `json:"stack,omitempty"`
 }
 
 type ssePayloadContainerEvent struct {
@@ -315,6 +320,7 @@ func containerToPayload(c *pb.Container) *ssePayloadContainer {
 		Disk:          c.Resources.GetDisk(),
 		Image:         c.Image,
 		PodmanEnabled: c.PodmanEnabled,
+		Stack:         c.Stack,
 	}
 }
 

--- a/internal/gateway/events_payload_test.go
+++ b/internal/gateway/events_payload_test.go
@@ -50,9 +50,20 @@ func TestContainerPayloadShape(t *testing.T) {
 		State:     pb.ContainerState_CONTAINER_STATE_RUNNING,
 		Network:   &pb.NetworkInfo{IpAddress: "10.0.3.5"},
 		Resources: &pb.ResourceLimits{Cpu: "2", Memory: "4GB", Disk: "20GB"},
-		Image:     "ubuntu:24.04", PodmanEnabled: true,
+		Image:     "ubuntu:24.04", PodmanEnabled: true, Stack: "nodejs",
 	}))
-	assertKeys(t, got, "name", "username", "state", "ipAddress", "cpu", "memory", "disk", "image", "podmanEnabled")
+	assertKeys(t, got, "name", "username", "state", "ipAddress", "cpu", "memory", "disk", "image", "podmanEnabled", "stack")
+}
+
+// stack is omitted when the container has none, so adding it does not put an
+// empty string into every event for the majority of containers that are not
+// stack-provisioned.
+func TestContainerPayloadOmitsEmptyStack(t *testing.T) {
+	got := marshalToMap(t, containerToPayload(&pb.Container{Name: "alice-container"}))
+	if _, present := got["stack"]; present {
+		t.Error("stack is emitted when empty — every event for a container without a stack " +
+			"would carry a field that means nothing")
+	}
 }
 
 // previousState is omitted when unspecified — the map literal got that by


### PR DESCRIPTION
Closes the loop #1310 opened deliberately.

`web-ui/src/types/events.ts` declares `stack?: string` on the container event payload, and `src/lib/api/client.ts` reads `apiContainer.stack`. The SSE stream has **never carried it** — the map literal #1310 replaced listed nine fields and `stack` was not among them, though `pb.Container` has the field.

So the browser has been declaring, and reading, a field that never arrives.

## Why it is a separate PR

#1310 found this while typing those payloads and left it alone on purpose: adding a key is a behaviour change and does not belong in a refactor whose entire claim was "the JSON is unchanged". This is that change, on its own, where it can be seen.

## Shape

Additive, so any consumer ignoring it is unaffected. Omitted when empty, so a container with no stack — most of them — does not carry a field that means nothing.

Mutation-tested in both directions: removing the field fails the shape test, and dropping `omitempty` fails the emptiness test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)