### PR TITLE
feat(crew): reconcile runs stranded RUNNING by a restart (#1182 AC4)

### DIFF
--- a/internal/server/crew_run_store.go
+++ b/internal/server/crew_run_store.go
@@ -32,7 +32,22 @@ type CrewRunStore interface {
 	Put(ctx context.Context, r *pb.CrewRun) error
 	// Get returns the run and whether it was found.
 	Get(ctx context.Context, id string) (*pb.CrewRun, bool, error)
+	// FailStranded marks every run still RUNNING as FAILED with the given
+	// reason, returning how many it changed.
+	//
+	// Called once at daemon start. RunCrew records a run as RUNNING before it
+	// drives it, so a daemon that dies mid-run leaves that state behind — and
+	// with a durable store it survives, so GetCrewRun answers RUNNING forever
+	// for a run that can never finish (#1182 AC4). Nothing else reconciles
+	// them: driveCrew has no resumption point, so the honest outcome is a
+	// terminal failure that says why, not a run that claims to be working.
+	FailStranded(ctx context.Context, reason string) (int, error)
 }
+
+// StrandedByRestart is the reason recorded for a run the daemon was driving
+// when it stopped. Named so an operator reading a failed run can tell this
+// apart from a crew that genuinely failed.
+const StrandedByRestart = "daemon restarted while this run was in flight; the run was not resumed"
 
 // --- in-memory ------------------------------------------------------
 
@@ -65,6 +80,23 @@ func (s *MemCrewRunStore) Get(_ context.Context, id string) (*pb.CrewRun, bool, 
 		return nil, false, nil
 	}
 	return proto.Clone(r).(*pb.CrewRun), true, nil
+}
+
+func (s *MemCrewRunStore) FailStranded(_ context.Context, reason string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for id, r := range s.runs {
+		if r.GetState() != pb.CrewRunState_CREW_RUN_STATE_RUNNING {
+			continue
+		}
+		updated := proto.Clone(r).(*pb.CrewRun)
+		updated.State = pb.CrewRunState_CREW_RUN_STATE_FAILED
+		updated.Error = reason
+		s.runs[id] = updated
+		n++
+	}
+	return n, nil
 }
 
 // --- postgres -------------------------------------------------------
@@ -151,6 +183,39 @@ func (s *PostgresCrewRunStore) Get(ctx context.Context, id string) (*pb.CrewRun,
 // the in-memory default to Postgres once the connection string is resolved.
 // Called before grpcServer.Serve, so it races with no live RPCs — the same
 // point and the same reasoning as NetworkPolicyServer.SetStore.
+// FailStranded marks rows still RUNNING as FAILED in one statement.
+//
+// The state column and the marshalled proto both carry the state, so both are
+// updated — a row whose column said FAILED while its body still said RUNNING
+// would report differently depending on which one a reader trusted. jsonb_set
+// keeps the rest of the run intact.
+//
+// Not covered by a test that runs: nothing in this repo can execute Postgres
+// SQL today (#1300). The memory implementation's behaviour is tested, and the
+// orchestration is guarded, but this statement itself is reviewed rather than
+// exercised.
+func (s *PostgresCrewRunStore) FailStranded(ctx context.Context, reason string) (int, error) {
+	const q = `
+		UPDATE crew_runs
+		SET state = $1,
+		    run = jsonb_set(
+		            jsonb_set(run::jsonb, '{state}', to_jsonb($2::text), true),
+		            '{error}', to_jsonb($3::text), true)::text::json,
+		    updated_at = NOW()
+		WHERE state = $4
+	`
+	tag, err := s.pool.Exec(ctx, q,
+		int32(pb.CrewRunState_CREW_RUN_STATE_FAILED),
+		pb.CrewRunState_CREW_RUN_STATE_FAILED.String(),
+		reason,
+		int32(pb.CrewRunState_CREW_RUN_STATE_RUNNING),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("fail stranded crew runs: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 func (s *CrewServer) SetRunStore(store CrewRunStore) {
 	if store != nil {
 		s.runs = store

--- a/internal/server/crew_run_store_test.go
+++ b/internal/server/crew_run_store_test.go
@@ -200,3 +200,82 @@ func TestMemCrewRunStore_DriverMutationsDoNotRaceWithReaders(t *testing.T) {
 	close(start)
 	wg.Wait()
 }
+
+// #1182 AC4: a run left RUNNING across a restart must reach a terminal state.
+//
+// RunCrew records a run as RUNNING before driving it, and the store is now
+// durable, so a daemon that stops mid-run leaves that state behind. Without
+// reconciliation GetCrewRun answers RUNNING forever for a run that can never
+// finish — a persistent lie about state, which is worse than the old
+// behaviour of losing the run entirely.
+func TestMemCrewRunStore_FailStrandedTerminatesRunningRuns(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemCrewRunStore()
+
+	mustPut(t, s, &pb.CrewRun{Id: "in-flight", State: pb.CrewRunState_CREW_RUN_STATE_RUNNING})
+	mustPut(t, s, &pb.CrewRun{Id: "done", State: pb.CrewRunState_CREW_RUN_STATE_COMPLETED, ArtifactJson: "{}"})
+	mustPut(t, s, &pb.CrewRun{Id: "already-failed", State: pb.CrewRunState_CREW_RUN_STATE_FAILED, Error: "a real failure"})
+
+	n, err := s.FailStranded(ctx, StrandedByRestart)
+	if err != nil {
+		t.Fatalf("FailStranded: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("reconciled %d runs, want 1 — only the in-flight one was stranded", n)
+	}
+
+	got, _, _ := s.Get(ctx, "in-flight")
+	if got.State != pb.CrewRunState_CREW_RUN_STATE_FAILED {
+		t.Errorf("state = %v, want FAILED — a run nothing is driving must not keep claiming to run",
+			got.State)
+	}
+	if got.Error != StrandedByRestart {
+		t.Errorf("error = %q, want the restart reason — an operator has to be able to tell this "+
+			"from a crew that genuinely failed", got.Error)
+	}
+}
+
+// Terminal runs must be left exactly as they are: overwriting a completed
+// run's artifact, or a failed run's real error, would destroy the record of
+// what actually happened.
+func TestMemCrewRunStore_FailStrandedLeavesTerminalRunsAlone(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemCrewRunStore()
+
+	mustPut(t, s, &pb.CrewRun{Id: "done", State: pb.CrewRunState_CREW_RUN_STATE_COMPLETED, ArtifactJson: "{}"})
+	mustPut(t, s, &pb.CrewRun{Id: "failed", State: pb.CrewRunState_CREW_RUN_STATE_FAILED, Error: "a real failure"})
+
+	if _, err := s.FailStranded(ctx, StrandedByRestart); err != nil {
+		t.Fatalf("FailStranded: %v", err)
+	}
+
+	done, _, _ := s.Get(ctx, "done")
+	if done.State != pb.CrewRunState_CREW_RUN_STATE_COMPLETED || done.ArtifactJson != "{}" {
+		t.Errorf("a completed run was altered: state=%v artifact=%q", done.State, done.ArtifactJson)
+	}
+	failed, _, _ := s.Get(ctx, "failed")
+	if failed.Error != "a real failure" {
+		t.Errorf("a genuine failure reason was overwritten with the restart reason: %q", failed.Error)
+	}
+}
+
+// Running it twice must not keep re-reporting the same runs, or a restart loop
+// would log a growing number of reconciliations that are not happening.
+func TestMemCrewRunStore_FailStrandedIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemCrewRunStore()
+	mustPut(t, s, &pb.CrewRun{Id: "in-flight", State: pb.CrewRunState_CREW_RUN_STATE_RUNNING})
+
+	first, _ := s.FailStranded(ctx, StrandedByRestart)
+	second, _ := s.FailStranded(ctx, StrandedByRestart)
+	if first != 1 || second != 0 {
+		t.Errorf("counts were %d then %d, want 1 then 0", first, second)
+	}
+}
+
+func mustPut(t *testing.T, s CrewRunStore, r *pb.CrewRun) {
+	t.Helper()
+	if err := s.Put(context.Background(), r); err != nil {
+		t.Fatalf("put %s: %v", r.GetId(), err)
+	}
+}

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1088,6 +1088,17 @@ skipAppHosting:
 			} else {
 				crewServer.SetRunStore(runStore)
 				log.Printf("Crew-run persistence enabled (Postgres store)")
+				// Reconcile runs the previous daemon was driving when it
+				// stopped. RunCrew records a run as RUNNING before driving it,
+				// so without this they stay RUNNING forever now that the state
+				// is durable — GetCrewRun would answer RUNNING for a run that
+				// can never finish (#1182 AC4). Best-effort: a daemon that
+				// cannot reconcile should still start.
+				if n, fErr := runStore.FailStranded(context.Background(), StrandedByRestart); fErr != nil {
+					log.Printf("Warning: could not reconcile stranded crew runs: %v", fErr)
+				} else if n > 0 {
+					log.Printf("Marked %d crew run(s) FAILED: in flight when the previous daemon stopped", n)
+				}
 			}
 			if taskQueue, qErr := NewPostgresAgentTaskQueue(context.Background(), pool); qErr != nil {
 				log.Printf("Warning: Failed to create Postgres agent task queue: %v", qErr)

--- a/internal/server/dual_server_wiring_test.go
+++ b/internal/server/dual_server_wiring_test.go
@@ -278,3 +278,22 @@ func TestEverythingStartedIsAlsoStopped(t *testing.T) {
 			strings.Join(missing, "\n  "))
 	}
 }
+
+// A reconciliation nothing calls does not happen.
+//
+// The durable crew-run store makes RUNNING survive a restart, so the daemon
+// has to clear it at start or GetCrewRun answers RUNNING forever for a run
+// that can never finish (#1182 AC4). #1320 had to fix exactly this shape for
+// these stores once already — constructed, never wired — so it is guarded
+// rather than trusted.
+func TestNewDualServerReconcilesStrandedCrewRuns(t *testing.T) {
+	if !dualServerSourceContains(t, "FailStranded(") {
+		t.Error("the daemon never reconciles stranded crew runs — a run the previous daemon was " +
+			"driving stays RUNNING in the store forever, and nothing reports it (#1182 AC4)")
+	}
+	// It has to run against the durable store, not the memory one that is
+	// empty at start anyway.
+	if !dualServerSourceContains(t, "runStore.FailStranded(") {
+		t.Error("reconciliation does not run against the Postgres store it exists for")
+	}
+}


### PR DESCRIPTION
#1182 was closed with AC 4 unmet:

> - [ ] A crew run left `RUNNING` across a restart reaches a terminal state (not stranded) — either resumed or `FAILED` with a recorded reason.

## The bug two correct changes produced

`RunCrew` records a run as `RUNNING` before driving it, and `s.runs` is now the durable store — so a daemon that stops mid-run leaves that state in Postgres, and nothing reconciles it. `GetCrewRun` answers `RUNNING` forever for a run that can never finish.

This is **worse than what it replaced**. Before durability, a crash lost the run entirely: bad, but honest. A persistent `RUNNING` row is a lie about state that survives every restart.

Neither contributing change was wrong. #1298 (mine) made in-flight runs observable; #1316 made them durable. The gap is the reconciliation that was scoped in this issue and not built.

## What it does

At startup, every run still `RUNNING` is marked `FAILED` with a reason naming the restart, so an operator can tell it from a crew that genuinely failed.

Resuming would be better and is not on offer — `driveCrew` has no resumption point — and the issue explicitly permits the terminal outcome. A run honestly failed beats one claiming to work.

- **Terminal runs are untouched.** Overwriting a completed run's artifact, or a real failure's error text, would destroy the record of what actually happened.
- **Idempotent**, so a restart loop does not report reconciliations that are not happening.
- **The startup call is guarded.** #1320 had to fix exactly this shape for these stores once already — constructed, never wired — and a reconciliation nothing calls does not happen.

## Honest limit

The Postgres statement updates both the `state` column and the state inside the marshalled proto, since a row disagreeing with itself would report differently depending on which a reader trusted. **That statement is reviewed, not executed** — nothing in this repo can run Postgres SQL today (#1300). The memory implementation's behaviour and the wiring are both tested.

Mutation-tested: clobbering terminal runs, dropping the reason, and never calling it at startup each fail a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)