### PR TITLE
test(server): run the stores against a real Postgres (#1300, #1322)

### DIFF
--- a/.github/workflows/store-integration.yml
+++ b/.github/workflows/store-integration.yml
@@ -1,0 +1,92 @@
+name: Store integration (Postgres)
+
+# The Postgres store implementations had no executable test coverage (#1300):
+# every green test exercised the in-memory impl, which is the half that cannot
+# fail for the reasons the Postgres half exists. The two dedicated store tests
+# in the tree skip unconditionally and defer to "integration tests run
+# separately" — which ran nowhere.
+#
+# This is that lane. It stands up a real Postgres, runs the shared behavioural
+# suite against both implementations, and covers the properties only a database
+# can show: row-locked lease claims, sequence-backed lease tokens surviving a
+# reconnect, and a stranded-run sweep that has to update both the state column
+# and the state inside the marshalled proto.
+
+on:
+  pull_request:
+    # No `branches:` filter — a PR targeting anything but main would otherwise
+    # run none of this and show no checks at all, which reads exactly like
+    # checks that have not started (#1215).
+    paths:
+      - 'internal/server/**'
+      - 'internal/audit/**'
+      - 'internal/secrets/**'
+      - 'internal/app/**'
+      - '.github/workflows/store-integration.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'internal/server/**'
+      - 'internal/audit/**'
+      - 'internal/secrets/**'
+      - 'internal/app/**'
+      - '.github/workflows/store-integration.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  postgres:
+    name: stores against a real Postgres
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: containarium
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: containarium
+        ports:
+          - 5432:5432
+        # Without this the job races the database's startup and fails on
+        # connect rather than on anything it is testing.
+        options: >-
+          --health-cmd "pg_isready -U containarium"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.26.5'
+
+      - name: Run the store integration suite
+        env:
+          CONTAINARIUM_TEST_DSN: postgres://containarium:test@127.0.0.1:5432/containarium?sslmode=disable
+        run: |
+          go test -tags=integration -count=1 -timeout 10m -v ./internal/server/ 2>&1 | tee integration.log
+          rc=${PIPESTATUS[0]}
+          if [ "$rc" -ne 0 ]; then exit "$rc"; fi
+
+          # A skipped test here is indistinguishable from a passing one, and
+          # this lane exists because that ambiguity hid the gap for so long.
+          # The suite fails rather than skips when the DSN is missing, so a
+          # SKIP means something else went quiet — treat it as a failure.
+          if grep -q -- "--- SKIP" integration.log; then
+            echo "::error::A store integration test skipped while the database was up."
+            grep -- "--- SKIP" integration.log
+            exit 1
+          fi
+
+          # And a run that matched nothing would also be green. Require that
+          # the suite actually executed.
+          if ! grep -q -- "--- PASS: TestAgentTaskQueue_ConcurrentLeasesAreDistinct" integration.log; then
+            echo "::error::The integration suite did not run its concurrency case — renamed, retagged, or filtered out."
+            exit 1
+          fi

--- a/internal/server/store_integration_test.go
+++ b/internal/server/store_integration_test.go
@@ -1,0 +1,314 @@
+//go:build integration
+
+// Integration coverage for the Postgres store implementations (#1300, #1322).
+//
+// Everything else in this package exercises the in-memory impls, which is the
+// half that cannot fail for the reasons the Postgres half exists. These cases
+// run the SAME assertions against both, so the contract is stated once rather
+// than restated per backend — and so a divergence between them is a failure
+// rather than a discovery.
+//
+//	CONTAINARIUM_TEST_DSN=postgres://... go test -tags=integration ./internal/server/
+//
+// The DSN is required rather than defaulted: a test that silently skips is
+// indistinguishable from one that passed, which is the failure this file
+// exists to stop being possible.
+package server
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+func testPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("CONTAINARIUM_TEST_DSN")
+	if dsn == "" {
+		t.Fatal("CONTAINARIUM_TEST_DSN is unset. This build tag exists to run against a real " +
+			"database; failing rather than skipping, so a lane that loses its service container " +
+			"reports it instead of going quietly green.")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// freshSchema drops and recreates the tables so each test starts clean and
+// the migrations in the constructors are exercised every run.
+func freshSchema(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	for _, q := range []string{
+		`DROP TABLE IF EXISTS agent_task_results`,
+		`DROP TABLE IF EXISTS agent_tasks`,
+		`DROP TABLE IF EXISTS crew_runs`,
+		`DROP SEQUENCE IF EXISTS agent_lease_token_seq`,
+	} {
+		if _, err := pool.Exec(ctx, q); err != nil {
+			t.Fatalf("reset schema (%s): %v", q, err)
+		}
+	}
+}
+
+// --- crew run store, both implementations ----------------------------
+
+func crewStores(t *testing.T) map[string]CrewRunStore {
+	t.Helper()
+	pool := testPool(t)
+	freshSchema(t, pool)
+	pg, err := NewPostgresCrewRunStore(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("NewPostgresCrewRunStore: %v", err)
+	}
+	return map[string]CrewRunStore{"mem": NewMemCrewRunStore(), "postgres": pg}
+}
+
+func TestCrewRunStore_ContractHoldsForBothImpls(t *testing.T) {
+	ctx := context.Background()
+	for name, s := range crewStores(t) {
+		t.Run(name, func(t *testing.T) {
+			run := &pb.CrewRun{Id: "r1", CrewId: "crew-1", State: pb.CrewRunState_CREW_RUN_STATE_RUNNING}
+			if err := s.Put(ctx, run); err != nil {
+				t.Fatalf("put: %v", err)
+			}
+
+			got, ok, err := s.Get(ctx, "r1")
+			if err != nil || !ok {
+				t.Fatalf("get: ok=%v err=%v", ok, err)
+			}
+			if got.State != pb.CrewRunState_CREW_RUN_STATE_RUNNING || got.CrewId != "crew-1" {
+				t.Errorf("round trip lost fields: %+v", got)
+			}
+
+			// Mutating what you put must not change what is stored.
+			run.State = pb.CrewRunState_CREW_RUN_STATE_FAILED
+			again, _, _ := s.Get(ctx, "r1")
+			if again.State != pb.CrewRunState_CREW_RUN_STATE_RUNNING {
+				t.Error("the caller's later writes reached the store")
+			}
+
+			if _, ok, _ := s.Get(ctx, "missing"); ok {
+				t.Error("a missing run reported found")
+			}
+		})
+	}
+}
+
+// #1182 AC4 against a real database: the sweep has to update both the state
+// column and the state inside the marshalled proto. A row disagreeing with
+// itself reports differently depending on which one a reader trusts, and only
+// Postgres can show that.
+func TestCrewRunStore_FailStrandedForBothImpls(t *testing.T) {
+	ctx := context.Background()
+	for name, s := range crewStores(t) {
+		t.Run(name, func(t *testing.T) {
+			mustPutI(t, s, &pb.CrewRun{Id: "stuck", State: pb.CrewRunState_CREW_RUN_STATE_RUNNING})
+			mustPutI(t, s, &pb.CrewRun{Id: "done", State: pb.CrewRunState_CREW_RUN_STATE_COMPLETED, ArtifactJson: "{}"})
+
+			n, err := s.FailStranded(ctx, StrandedByRestart)
+			if err != nil {
+				t.Fatalf("FailStranded: %v", err)
+			}
+			if n != 1 {
+				t.Errorf("reconciled %d, want 1", n)
+			}
+
+			stuck, _, _ := s.Get(ctx, "stuck")
+			if stuck.State != pb.CrewRunState_CREW_RUN_STATE_FAILED {
+				t.Errorf("state = %v, want FAILED", stuck.State)
+			}
+			if stuck.Error != StrandedByRestart {
+				t.Errorf("error = %q, want the restart reason — this is the field that comes back "+
+					"from the marshalled proto, so it proves both copies were updated", stuck.Error)
+			}
+
+			done, _, _ := s.Get(ctx, "done")
+			if done.State != pb.CrewRunState_CREW_RUN_STATE_COMPLETED || done.ArtifactJson != "{}" {
+				t.Errorf("a completed run was altered: %+v", done)
+			}
+
+			if again, _ := s.FailStranded(ctx, StrandedByRestart); again != 0 {
+				t.Errorf("second sweep reconciled %d, want 0 (idempotent)", again)
+			}
+		})
+	}
+}
+
+func mustPutI(t *testing.T, s CrewRunStore, r *pb.CrewRun) {
+	t.Helper()
+	if err := s.Put(context.Background(), r); err != nil {
+		t.Fatalf("put %s: %v", r.GetId(), err)
+	}
+}
+
+// --- task queue, both implementations --------------------------------
+
+func taskQueues(t *testing.T) map[string]AgentTaskQueue {
+	t.Helper()
+	pool := testPool(t)
+	freshSchema(t, pool)
+	pg, err := NewPostgresAgentTaskQueue(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("NewPostgresAgentTaskQueue: %v", err)
+	}
+	return map[string]AgentTaskQueue{"mem": NewMemAgentTaskQueue(), "postgres": pg}
+}
+
+func TestAgentTaskQueue_ContractHoldsForBothImpls(t *testing.T) {
+	ctx := context.Background()
+	for name, q := range taskQueues(t) {
+		t.Run(name, func(t *testing.T) {
+			id, err := q.Enqueue(ctx, "skill-1", `{"in":1}`)
+			if err != nil {
+				t.Fatalf("enqueue: %v", err)
+			}
+
+			task, ok, err := q.Lease(ctx, "", time.Minute)
+			if err != nil || !ok {
+				t.Fatalf("lease: ok=%v err=%v", ok, err)
+			}
+			if task.ID != id {
+				t.Errorf("leased %q, enqueued %q", task.ID, id)
+			}
+
+			// A leased task is hidden until its lease expires.
+			if _, ok, _ := q.Lease(ctx, "", time.Minute); ok {
+				t.Error("a leased task was handed out twice — two workers would run it")
+			}
+
+			if ok, err := q.Complete(ctx, id, task.LeaseToken, `{"out":1}`, ""); err != nil || !ok {
+				t.Fatalf("complete: ok=%v err=%v", ok, err)
+			}
+			res, ok, err := q.Result(ctx, id)
+			if err != nil || !ok || res.artifactJSON != `{"out":1}` {
+				t.Errorf("result: ok=%v err=%v res=%+v", ok, err, res)
+			}
+		})
+	}
+}
+
+// The property that motivated a sequence for lease tokens rather than a
+// counter: a token issued before a restart must not be accepted afterwards.
+// An in-memory counter restarts at zero, so this is where the two impls are
+// expected to differ — and the Postgres one is the one that has to hold.
+func TestAgentTaskQueue_StaleLeaseTokenRejectedAcrossReconnect(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool(t)
+	freshSchema(t, pool)
+
+	q1, err := NewPostgresAgentTaskQueue(ctx, pool)
+	if err != nil {
+		t.Fatalf("queue: %v", err)
+	}
+	id, err := q1.Enqueue(ctx, "skill-1", "{}")
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	first, ok, err := q1.Lease(ctx, "", 50*time.Millisecond)
+	if err != nil || !ok {
+		t.Fatalf("first lease: ok=%v err=%v", ok, err)
+	}
+
+	// The lease expires while "the daemon is down".
+	time.Sleep(300 * time.Millisecond)
+
+	// A new process, new pool, same database.
+	pool2, err := pgxpool.New(ctx, os.Getenv("CONTAINARIUM_TEST_DSN"))
+	if err != nil {
+		t.Fatalf("reconnect: %v", err)
+	}
+	defer pool2.Close()
+	q2, err := NewPostgresAgentTaskQueue(ctx, pool2)
+	if err != nil {
+		t.Fatalf("queue after reconnect: %v", err)
+	}
+
+	second, ok, err := q2.Lease(ctx, "", time.Minute)
+	if err != nil || !ok {
+		t.Fatalf("redelivery after the lease expired: ok=%v err=%v", ok, err)
+	}
+	if second.ID != id {
+		t.Fatalf("redelivered %q, want %q", second.ID, id)
+	}
+	if second.LeaseToken == first.LeaseToken {
+		t.Fatal("redelivery reused the pre-restart lease token — the old holder would still be " +
+			"accepted as the current owner")
+	}
+
+	// The pre-restart holder must not be able to complete it.
+	if ok, _ := q2.Complete(ctx, id, first.LeaseToken, "{}", ""); ok {
+		t.Error("a pre-restart lease token completed a task that had been redelivered — the " +
+			"result of a run nobody is waiting on would overwrite the live one")
+	}
+	if ok, err := q2.Complete(ctx, id, second.LeaseToken, "{}", ""); err != nil || !ok {
+		t.Errorf("the current holder could not complete: ok=%v err=%v", ok, err)
+	}
+}
+
+// Row locking on the lease claim is what stops two concurrent workers being
+// handed the same task. Nothing in the memory impl can show this.
+//
+// Measured, because the obvious claim is wrong: removing the locking entirely
+// fails this test (the same task is leased three times), but removing only
+// SKIP LOCKED does NOT — plain FOR UPDATE serializes the claimants instead of
+// duplicating the row, so distinctness still holds. SKIP LOCKED is a
+// throughput choice, not the thing keeping this correct. Worth stating so the
+// next person does not read a passing run as proof of it.
+func TestAgentTaskQueue_ConcurrentLeasesAreDistinct(t *testing.T) {
+	ctx := context.Background()
+	pool := testPool(t)
+	freshSchema(t, pool)
+
+	q, err := NewPostgresAgentTaskQueue(ctx, pool)
+	if err != nil {
+		t.Fatalf("queue: %v", err)
+	}
+
+	const tasks = 12
+	for i := 0; i < tasks; i++ {
+		if _, err := q.Enqueue(ctx, "skill-1", fmt.Sprintf(`{"n":%d}`, i)); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	var mu sync.Mutex
+	seen := map[string]int{}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for w := 0; w < tasks; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			task, ok, err := q.Lease(ctx, "", time.Minute)
+			if err != nil || !ok {
+				return
+			}
+			mu.Lock()
+			seen[task.ID]++
+			mu.Unlock()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for id, n := range seen {
+		if n > 1 {
+			t.Errorf("task %s was leased %d times — two workers would run it concurrently", id, n)
+		}
+	}
+	if len(seen) == 0 {
+		t.Fatal("no worker leased anything; the test proved nothing")
+	}
+}


### PR DESCRIPTION
Closes the first half of #1322 and makes a real dent in #1300.

**I said this was blocked on infrastructure I did not have. That was wrong** — I checked for `docker`, found it unusable, and concluded there was no container runtime without testing `podman`, which is installed and works. Everything below was developed and verified against a real Postgres locally before the CI lane was written.

## What had no coverage

Every green test exercised the in-memory impl — the half that cannot fail for the reasons the Postgres half exists. The two dedicated store tests in the tree skip *unconditionally* and defer to "integration tests run separately", which ran nowhere.

## What this adds

A shared suite asserting the same contract against **both** impls, so it is stated once rather than restated per backend (#1322's second criterion), plus the properties only a database can show:

- **Concurrent leasing hands out distinct tasks.**
- **A lease token survives a reconnect**, and the pre-restart token is rejected while the new holder can complete — the property that motivated a sequence rather than a counter.
- **The stranded-run sweep from #1324** updates both the `state` column and the state inside the marshalled proto. That SQL shipped *reviewed but never executed*; it works, and the test proves it via the error text, which comes back out of the proto.

## Every case was checked by breaking what it covers — and that corrected one of your criteria

> - [ ] Concurrency: N workers leasing simultaneously each get a distinct task. **This must fail against a lease query without `SKIP LOCKED`.**

It does not, and the difference matters:

| mutation | result |
| --- | --- |
| remove row locking entirely | **fails** — the same task is leased 3 times |
| remove only `SKIP LOCKED` (leaving `FOR UPDATE`) | **passes** |

Plain `FOR UPDATE` serializes the claimants rather than duplicating the row, so distinctness still holds. `SKIP LOCKED` is a throughput choice, not what keeps this correct. The test comment says so, because a passing run is not evidence for it.

## Skips are failures here

The suite **fails** rather than skips when the DSN is unset, and the lane fails if any case skips while the database is up, or if the concurrency case does not run at all. This gap survived as long as it did precisely because a skipped test and a passing one look identical.

## Not covered

The audit store's hash chain — the A.8.15 control in #1300 — still has no persistence test. Same lane can host it; different work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)