### PR TITLE
fix(audit): the tamper-evident chain never verified, and forked under load

### DIFF
--- a/.github/workflows/store-integration.yml
+++ b/.github/workflows/store-integration.yml
@@ -70,7 +70,8 @@ jobs:
         env:
           CONTAINARIUM_TEST_DSN: postgres://containarium:test@127.0.0.1:5432/containarium?sslmode=disable
         run: |
-          go test -tags=integration -count=1 -timeout 10m -v ./internal/server/ 2>&1 | tee integration.log
+          go test -tags=integration -count=1 -timeout 10m -v \
+            ./internal/server/ ./internal/audit/ 2>&1 | tee integration.log
           rc=${PIPESTATUS[0]}
           if [ "$rc" -ne 0 ]; then exit "$rc"; fi
 
@@ -86,7 +87,9 @@ jobs:
 
           # And a run that matched nothing would also be green. Require that
           # the suite actually executed.
-          if ! grep -q -- "--- PASS: TestAgentTaskQueue_ConcurrentLeasesAreDistinct" integration.log; then
-            echo "::error::The integration suite did not run its concurrency case — renamed, retagged, or filtered out."
-            exit 1
-          fi
+          for want in TestAgentTaskQueue_ConcurrentLeasesAreDistinct TestAuditChain_ConcurrentAppendersDoNotFork; do
+            if ! grep -q -- "--- PASS: $want" integration.log; then
+              echo "::error::$want did not run — renamed, retagged, or filtered out."
+              exit 1
+            fi
+          done

--- a/internal/audit/store.go
+++ b/internal/audit/store.go
@@ -96,11 +96,28 @@ func (s *Store) initSchema(ctx context.Context) error {
 // the tail row serializes concurrent writers so the chain
 // stays well-ordered. Without the lock, two concurrent inserts
 // could both reference the same prev_hash and produce a fork.
+// auditChainLockKey is the advisory-lock key appends serialize on. An
+// arbitrary constant; it only has to be unique among this database's advisory
+// locks.
+const auditChainLockKey int64 = 0x0A0D17C4A1
+
 func (s *Store) Log(ctx context.Context, entry *AuditEntry) error {
 	ts := entry.Timestamp
 	if ts.IsZero() {
 		ts = time.Now()
 	}
+	// Truncate to what Postgres can store before hashing.
+	//
+	// computeRowHash feeds Timestamp.UnixNano() into the digest, and the
+	// column is `timestamp with time zone` — microsecond precision. So a
+	// nanosecond-precision time hashed here comes back truncated, the
+	// recomputed hash differs, and VerifyChainSinceID reports the row as
+	// modified. Every row, always: the chain could never verify, so the
+	// tamper-evidence it exists for could not distinguish a tampered log
+	// from an intact one.
+	//
+	// Truncating first makes the hashed value identical to the stored one.
+	ts = ts.Truncate(time.Microsecond)
 	entry.Timestamp = ts
 
 	tx, err := s.pool.Begin(ctx)
@@ -109,11 +126,30 @@ func (s *Store) Log(ctx context.Context, entry *AuditEntry) error {
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // best-effort cleanup; Commit() supersedes
 
-	// Get prev_hash from the chain tail. FOR UPDATE serializes
-	// concurrent appenders; the lock releases on Commit.
+	// Serialize appenders on the chain itself.
+	//
+	// `SELECT ... ORDER BY id DESC LIMIT 1 FOR UPDATE` does not do this,
+	// though it reads as if it should. It locks the row that is the tail
+	// *now*; it cannot lock a row that does not exist yet. Two transactions
+	// therefore both read tail N, both insert, and both claim N as
+	// predecessor — a fork. On an empty table it is worse: there is no row to
+	// lock at all, so every concurrent first write claims genesis.
+	//
+	// An advisory lock has no such gap: it is taken on a constant, not on a
+	// row, so it serializes writers regardless of what the table contains.
+	// It releases on commit or rollback with the transaction.
+	//
+	// This serializes all audit appends against each other. That is the point
+	// — a hash chain is inherently sequential, and a chain that forks under
+	// load is not tamper-evident, only tamper-suggestive.
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, auditChainLockKey); err != nil {
+		return fmt.Errorf("audit: lock chain: %w", err)
+	}
+
+	// Get prev_hash from the chain tail.
 	var prevHash string
 	err = tx.QueryRow(ctx,
-		`SELECT row_hash FROM audit_logs ORDER BY id DESC LIMIT 1 FOR UPDATE`,
+		`SELECT row_hash FROM audit_logs ORDER BY id DESC LIMIT 1`,
 	).Scan(&prevHash)
 	if err != nil {
 		// First row in the table — no predecessor.

--- a/internal/audit/store_integration_test.go
+++ b/internal/audit/store_integration_test.go
@@ -1,0 +1,167 @@
+//go:build integration
+
+// Integration coverage for the audit hash chain's persistence (#1300).
+//
+// docs/ISO27001-COMPLIANCE.md cites internal/audit as the evidence for
+// A.8.15. The chain's *computation* is well covered — hash_chain_test.go
+// exercises computeRowHash and VerifyChain as pure functions. Its
+// *persistence* was covered nowhere: whether rows are written in order,
+// whether prev_hash is threaded correctly across real inserts, whether
+// concurrent appenders fork the chain, and whether tampering is actually
+// detected by the query that reads it back.
+//
+// That is the half an auditor cares about, and the half the control is
+// claimed on.
+//
+//	CONTAINARIUM_TEST_DSN=postgres://... go test -tags=integration ./internal/audit/
+package audit
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func auditTestStore(t *testing.T) *Store {
+	t.Helper()
+	dsn := os.Getenv("CONTAINARIUM_TEST_DSN")
+	if dsn == "" {
+		t.Fatal("CONTAINARIUM_TEST_DSN is unset. Failing rather than skipping: a skipped test " +
+			"and a passing one are indistinguishable, which is how this gap survived.")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	// Each test starts from an empty chain, so the first row's prev_hash is
+	// the genesis value rather than whatever a previous test left.
+	if _, err := pool.Exec(context.Background(), `DROP TABLE IF EXISTS audit_logs`); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	s, err := NewStore(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
+func logN(t *testing.T, s *Store, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		err := s.Log(context.Background(), &AuditEntry{
+			Username:     "alice",
+			Action:       "container_create",
+			ResourceType: "container",
+			ResourceID:   fmt.Sprintf("alice-%d", i),
+			SourceIP:     "10.0.0.1",
+			StatusCode:   200,
+		})
+		if err != nil {
+			t.Fatalf("log %d: %v", i, err)
+		}
+	}
+}
+
+// The chain a real sequence of writes produces must verify. This is the
+// baseline the other cases are measured against — if it does not hold,
+// nothing below means anything.
+func TestAuditChain_WrittenRowsVerify(t *testing.T) {
+	s := auditTestStore(t)
+	logN(t, s, 25)
+
+	firstBad, err := s.VerifyChainSinceID(context.Background(), 0, 1000)
+	if err != nil {
+		t.Fatalf("chain does not verify after %d ordinary writes: firstBad=%d err=%v", 25, firstBad, err)
+	}
+	if firstBad != 0 {
+		t.Errorf("firstBad = %d, want 0 for an intact chain", firstBad)
+	}
+}
+
+// Log takes SELECT ... FOR UPDATE on the chain tail so two appenders cannot
+// read the same prev_hash and fork. Only a real database can show that;
+// nothing about the hash function is involved.
+func TestAuditChain_ConcurrentAppendersDoNotFork(t *testing.T) {
+	s := auditTestStore(t)
+
+	const writers, each = 8, 6
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			<-start
+			for i := 0; i < each; i++ {
+				_ = s.Log(context.Background(), &AuditEntry{
+					Username:     fmt.Sprintf("user-%d", w),
+					Action:       "container_create",
+					ResourceType: "container",
+					ResourceID:   fmt.Sprintf("c-%d-%d", w, i),
+					StatusCode:   200,
+				})
+			}
+		}(w)
+	}
+	close(start)
+	wg.Wait()
+
+	firstBad, err := s.VerifyChainSinceID(context.Background(), 0, 1000)
+	if err != nil {
+		t.Fatalf("concurrent appends forked the chain at row %d: %v\n"+
+			"Each row's prev_hash must be the previous row's row_hash; two appenders reading the "+
+			"same tail produce two rows claiming the same predecessor.", firstBad, err)
+	}
+}
+
+// The point of the chain: an edited row is detectable. If tampering does not
+// fail verification, the control is decorative.
+func TestAuditChain_TamperedRowIsDetected(t *testing.T) {
+	ctx := context.Background()
+	s := auditTestStore(t)
+	logN(t, s, 10)
+
+	// Change a field that is inside the hash, leaving row_hash alone — what
+	// an edit through SQL looks like.
+	var victim int64
+	if err := s.pool.QueryRow(ctx,
+		`UPDATE audit_logs SET username = 'mallory' WHERE id = (SELECT id FROM audit_logs ORDER BY id ASC OFFSET 4 LIMIT 1) RETURNING id`,
+	).Scan(&victim); err != nil {
+		t.Fatalf("tamper: %v", err)
+	}
+
+	firstBad, err := s.VerifyChainSinceID(ctx, 0, 1000)
+	if err == nil {
+		t.Fatal("an edited audit row verified clean — the tamper-evidence this control is " +
+			"claimed on does not hold")
+	}
+	if firstBad != victim {
+		t.Errorf("reported row %d as first bad, want the edited row %d", firstBad, victim)
+	}
+}
+
+// Deleting a row breaks the linkage even though every surviving row is
+// internally consistent — the case a per-row checksum would miss and a chain
+// is supposed to catch.
+func TestAuditChain_DeletedRowIsDetected(t *testing.T) {
+	ctx := context.Background()
+	s := auditTestStore(t)
+	logN(t, s, 10)
+
+	if _, err := s.pool.Exec(ctx,
+		`DELETE FROM audit_logs WHERE id = (SELECT id FROM audit_logs ORDER BY id ASC OFFSET 5 LIMIT 1)`,
+	); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	if _, err := s.VerifyChainSinceID(ctx, 0, 1000); err == nil {
+		t.Fatal("removing an audit row left the chain verifying clean — an operator could delete " +
+			"the record of an action and nothing would show it")
+	}
+}


### PR DESCRIPTION
Two real bugs in the audit hash chain, both found by running it against a real database for the first time (#1300, unblocked by #1325).

`docs/ISO27001-COMPLIANCE.md` cites this store as the evidence for **A.8.15 (Logging)**.

## 1. `VerifyChainSinceID` could never succeed

`computeRowHash` feeds `Timestamp.UnixNano()` into the digest. The column is `timestamp with time zone` — **microsecond** precision. So the value comes back truncated, the recomputed hash differs, and every row reads as `modified after insert`.

A verifier that always fails cannot distinguish a tampered log from an intact one. The tamper-evidence was inoperative in both directions.

Proved before fixing: a chain written with timestamps truncated to microseconds verifies; the same chain with nanosecond timestamps does not.

## 2. Concurrent appends forked the chain

```sql
SELECT row_hash FROM audit_logs ORDER BY id DESC LIMIT 1 FOR UPDATE
```

The comment beside it said this serializes appenders. It does not. It locks the row that is the tail *now*, and cannot lock a row that does not exist yet — so two transactions both read tail N, both insert, and both claim N as predecessor. On an empty table there is no row to lock at all, and every concurrent first write claims genesis.

Observed directly rather than reasoned about:

```
 prev_hash                          | count
 73429d2257f99956d31ea1fa0dc9790a…  |     2
 129342b804e63988faa59c3178f8aed0…  |     2
 (empty)                            |     2
```

An advisory lock on a constant has no such gap — it does not depend on a row existing.

## The order mattered

Fixing the precision is what made the fork *visible*. While verification failed at row 1 for everyone, nothing downstream of it could be observed at all. One bug was hiding the other.

## Tests

Covering what the pure-Go tests structurally cannot: rows written in sequence verify, concurrent appenders do not fork, an edited row is detected **and named**, and a deleted row breaks the linkage even though every surviving row is internally consistent — the case a per-row checksum would miss and a chain is supposed to catch.

Both fixes are load-bearing: reverting either fails its test.

## Existing rows

Rows written before this **cannot be repaired**. Their stored hashes were computed over a nanosecond timestamp that was never persisted, so the input is gone. A chain spanning the upgrade will report its first pre-fix row as broken — correctly, since those rows were never verifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)