### PR TITLE
test: run the two Postgres tests that skipped unconditionally (#1300)

### DIFF
--- a/.github/workflows/store-integration.yml
+++ b/.github/workflows/store-integration.yml
@@ -72,6 +72,13 @@ jobs:
         run: |
           go test -tags=integration -count=1 -timeout 10m -v \
             ./internal/server/ ./internal/audit/ 2>&1 | tee integration.log
+
+          # internal/secrets and internal/app carry their Postgres tests
+          # without a build tag, gated on the DSN. Run them here too — they
+          # skipped unconditionally until now, deferring to "integration tests
+          # run separately", which meant nowhere.
+          go test -count=1 -timeout 5m -v \
+            ./internal/secrets/ ./internal/app/ 2>&1 | tee -a integration.log
           rc=${PIPESTATUS[0]}
           if [ "$rc" -ne 0 ]; then exit "$rc"; fi
 
@@ -87,7 +94,7 @@ jobs:
 
           # And a run that matched nothing would also be green. Require that
           # the suite actually executed.
-          for want in TestAgentTaskQueue_ConcurrentLeasesAreDistinct TestAuditChain_ConcurrentAppendersDoNotFork; do
+          for want in TestAgentTaskQueue_ConcurrentLeasesAreDistinct TestAuditChain_ConcurrentAppendersDoNotFork TestSecretsStore_Roundtrip TestStoreOperations; do
             if ! grep -q -- "--- PASS: $want" integration.log; then
               echo "::error::$want did not run — renamed, retagged, or filtered out."
               exit 1

--- a/internal/app/store_test.go
+++ b/internal/app/store_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -34,12 +35,15 @@ func createTestApp(username, name string) *v1.App {
 }
 
 func TestStoreOperations(t *testing.T) {
-	// Skip if no PostgreSQL available
-	// In real tests, we'd use testcontainers or similar
-	t.Skip("Requires PostgreSQL - run integration tests separately")
+	// Gated on the DSN rather than skipped unconditionally. "Run integration
+	// tests separately" deferred to a lane that did not exist, so these never
+	// ran anywhere (#1300). The store-integration lane sets this.
+	connString := os.Getenv("CONTAINARIUM_TEST_DSN")
+	if connString == "" {
+		t.Skip("set CONTAINARIUM_TEST_DSN to run this against Postgres (the store-integration lane does)")
+	}
 
 	ctx := context.Background()
-	connString := "postgres://containarium:test@localhost:5432/containarium?sslmode=disable"
 
 	store, err := NewStore(ctx, connString)
 	if err != nil {
@@ -102,10 +106,12 @@ func TestStoreOperations(t *testing.T) {
 }
 
 func TestStoreErrors(t *testing.T) {
-	t.Skip("Requires PostgreSQL - run integration tests separately")
+	connString := os.Getenv("CONTAINARIUM_TEST_DSN")
+	if connString == "" {
+		t.Skip("set CONTAINARIUM_TEST_DSN to run this against Postgres (the store-integration lane does)")
+	}
 
 	ctx := context.Background()
-	connString := "postgres://containarium:test@localhost:5432/containarium?sslmode=disable"
 
 	store, err := NewStore(ctx, connString)
 	if err != nil {

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	corecrypto "github.com/footprintai/containarium/pkg/core/secrets"
@@ -23,10 +24,16 @@ import (
 // this test exercises the SQL roundtrip + AAD binding through
 // the full Store API.
 func TestSecretsStore_Roundtrip(t *testing.T) {
-	t.Skip("requires Postgres at localhost:5432 — see comment for run instructions")
+	// Gated on the DSN rather than skipped unconditionally. It skipped for
+	// everyone, everywhere, including the lane that was supposed to run it —
+	// so the SQL roundtrip and AAD binding below had never executed (#1300).
+	dsn := os.Getenv("CONTAINARIUM_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set CONTAINARIUM_TEST_DSN to run this against Postgres (the store-integration lane does)")
+	}
 
 	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, "postgres://containarium:test@localhost:5432/containarium?sslmode=disable")
+	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
 		t.Fatalf("connect Postgres: %v", err)
 	}


### PR DESCRIPTION
Follows #1325 and #1326, which built the lane these can now run in.

## What was skipped

Both files began with `t.Skip` and **no condition**:

```go
// internal/app/store_test.go
t.Skip("Requires PostgreSQL - run integration tests separately")

// internal/secrets/store_test.go
t.Skip("requires Postgres at localhost:5432 — see comment for run instructions")
```

They deferred to integration tests that ran nowhere — not in CI, and not locally without a hand-built database. So the secrets SQL roundtrip **with its AAD binding**, and the app store's save/get/list/delete and not-found paths, had never executed.

## What changed

Both gated on `CONTAINARIUM_TEST_DSN`, which the store-integration lane sets. Both pass against a real Postgres.

**Nothing needed fixing.** Worth stating plainly: the value here is coverage becoming real, not a defect found. The audit chain in #1326 was the opposite case, and the difference is only visible once the tests actually run.

The lane requires these test names in its output, so a rename or a `-run` filter cannot leave it green having executed nothing.

## Remaining

One unconditional skip is left in the tree — a repo-root locator fallback in `pkg/core/stacks` — which is a legitimate one.

Still uncovered, and noted on #1300: the alert, pentest, zap, traffic, collaborator and revocation stores. The lane exists; extending it is mechanical now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)