### PR TITLE
ci: stand up an Incus-exercisable lane for the daemon's Create() path

### DIFF
--- a/.github/workflows/incus-create.yml
+++ b/.github/workflows/incus-create.yml
@@ -97,7 +97,12 @@ jobs:
       - name: Install Incus
         run: |
           set -euo pipefail
-          sudo apt-get install -y --no-install-recommends incus
+          # dnsmasq-base is explicit because --no-install-recommends drops it,
+          # and Incus needs it to bring up incusbr0's DHCP/DNS. Without it the
+          # daemon's own EnsureNetwork fails with "Failed to check dnsmasq
+          # version: executable file not found", which is a runner-provisioning
+          # gap wearing the costume of a daemon bug.
+          sudo apt-get install -y --no-install-recommends incus dnsmasq-base
           # Socket-activated: this both proves the client works and brings the
           # daemon up, so the socket the test connects to exists.
           sudo incus version
@@ -137,6 +142,12 @@ jobs:
             exit 1
           }
           sudo incus info | head -30
+          # Asserted here rather than discovered inside EnsureNetwork, where it
+          # surfaces as a daemon error rather than a missing package.
+          command -v dnsmasq >/dev/null || {
+            echo "::error::dnsmasq is absent — Incus cannot bring up incusbr0"
+            exit 1
+          }
           sudo zfs list incus-local/containers >/dev/null || {
             echo "::error::incus-local/containers is absent — the daemon would select the dir driver"
             exit 1

--- a/.github/workflows/incus-create.yml
+++ b/.github/workflows/incus-create.yml
@@ -1,0 +1,192 @@
+name: Incus create path
+
+# Stands up the environment #1199 has been blocked on (#1332).
+#
+# #1199 — wiring the per-tenant encryption PreCreate hook into the create
+# path — was reported blocked for a sprint on "there is nowhere to run the
+# daemon's Incus-backed Create()". Nobody had tried constructing that
+# somewhere. This lane is that attempt: a plain ubuntu-latest runner with a
+# real ZFS pool and a real Incus, driving the daemon's own create path.
+#
+# It follows the precedent of zfs-encryption.yml, which cleared the same
+# shape of blocker for #1200 in a day. It is a SEPARATE workflow rather than
+# more steps on that one because the two have different costs and different
+# triggers: the ZFS lane is a pool plus `go test` and gates every encryption
+# change, while this one installs Incus and pulls a distro image, and gates
+# the create path. Merging them would make every encryption change wait on an
+# image pull.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pkg/core/box/lxc/**'
+      - 'pkg/core/container/**'
+      - 'pkg/core/incus/**'
+      - 'internal/testsupport/incusenv/**'
+      - '.github/workflows/incus-create.yml'
+  # No `branches:` filter — a base filter leaves stacked PRs with no checks
+  # at all, which looks the same as checks not having started (#1215).
+  pull_request:
+    paths:
+      - 'pkg/core/box/lxc/**'
+      - 'pkg/core/container/**'
+      - 'pkg/core/incus/**'
+      - 'internal/testsupport/incusenv/**'
+      - '.github/workflows/incus-create.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  incus-create:
+    name: Daemon Create() against real Incus on ZFS
+    runs-on: ubuntu-latest
+    # Generous: the create path pulls a distro image and then runs a real
+    # in-container package install, which is the work it does in production.
+    timeout-minutes: 45
+    env:
+      # Turns "no usable Incus here" from a skip into a failure — AC3. The
+      # switch itself is unit-tested in internal/testsupport/incusenv, so a
+      # lane that stopped exercising Incus cannot report green by not running.
+      CONTAINARIUM_REQUIRE_INCUS: '1'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Install ZFS
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends zfsutils-linux
+          # The module ships in linux-modules-extra on Ubuntu; usually already
+          # present on the runner image, so only fetch it if needed.
+          if ! sudo modprobe zfs 2>/dev/null; then
+            echo "zfs module not loadable yet; installing linux-modules-extra-$(uname -r)"
+            sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+            sudo modprobe zfs
+          fi
+          zfs version
+          test -e /dev/zfs || { echo "::error::/dev/zfs absent — the module cannot be driven"; exit 1; }
+
+      # The pool is named incus-local with a `containers` dataset because that
+      # is what the daemon's OWN storage detection probes for
+      # (detectZFSContainersDataset / SelectStorageDriver). Creating the pool
+      # under any other name would make the daemon fall back to the `dir`
+      # driver, and a dir-backed lane cannot exercise per-container datasets
+      # at all — which is the thing #1199 needs.
+      - name: Create the ZFS pool the daemon detects
+        run: |
+          set -euo pipefail
+          # /mnt is the runner's large scratch disk; the image is sparse.
+          sudo truncate -s 20G /mnt/incus-zfs.img
+          sudo zpool create -f -m /mnt/incus-local incus-local /mnt/incus-zfs.img
+          sudo zfs create incus-local/containers
+          sudo zpool list
+          sudo zfs list
+
+      - name: Install Incus
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y --no-install-recommends incus
+          # Socket-activated: this both proves the client works and brings the
+          # daemon up, so the socket the test connects to exists.
+          sudo incus version
+
+      # Two runner-specific facts that would otherwise show up as a mystifying
+      # failure several minutes into the create:
+      #
+      # 1. Ubuntu 24.04 restricts unprivileged user namespaces via AppArmor,
+      #    which is what an unprivileged Incus container needs.
+      # 2. Docker is installed and running on GitHub runners, and it sets the
+      #    iptables FORWARD policy to DROP. That silently kills incusbr0's
+      #    NAT, so the container boots with no route out and the create fails
+      #    minutes later inside `apt-get update` rather than here.
+      - name: Make the runner able to host containers
+        run: |
+          set -euo pipefail
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+          sudo iptables -P FORWARD ACCEPT
+          # Incus needs a subuid/subgid range for root to map an unprivileged
+          # container into. The package normally provides it; assert rather
+          # than assume, since a missing range fails at instance start.
+          grep -q '^root:' /etc/subuid || echo 'root:1000000:1000000000' | sudo tee -a /etc/subuid
+          grep -q '^root:' /etc/subgid || echo 'root:1000000:1000000000' | sudo tee -a /etc/subgid
+
+      # Assert the environment before trusting any result from it. The Go
+      # helper does the same check and fails on it (CONTAINARIUM_REQUIRE_INCUS
+      # above); this step exists so an unusable runner is named at the step
+      # that set it up, which is what #1332's timebox asks for if the answer
+      # turns out to be "Incus cannot run here".
+      - name: Verify Incus is actually usable (fail, don't skip)
+        run: |
+          set -euo pipefail
+          test -S /var/lib/incus/unix.socket || {
+            echo "::error::no Incus socket at /var/lib/incus/unix.socket — the daemon did not come up"
+            sudo systemctl status incus.service --no-pager || true
+            sudo journalctl -u incus.service --no-pager -n 100 || true
+            exit 1
+          }
+          sudo incus info | head -30
+          sudo zfs list incus-local/containers >/dev/null || {
+            echo "::error::incus-local/containers is absent — the daemon would select the dir driver"
+            exit 1
+          }
+          echo "Incus and ZFS are usable; the lane will not skip."
+
+      # NOT `incus launch`. The test drives box.BoxBackend.Create →
+      # container.Manager.Create → the daemon's Incus client, because the
+      # claim being made is that OUR create path runs here — that is the API
+      # #1199 has to call.
+      #
+      # Storage pool, network and default profile are set up by the test
+      # through the daemon's own InitializeInfrastructure, not by
+      # `incus admin init`, so the lane exercises the daemon's selection
+      # instead of a preseed we wrote to make it pass.
+      - name: Create a container through the daemon's own Create()
+        run: |
+          set -euo pipefail
+          sudo -E env "PATH=$PATH" go test -tags=incus -v -count=1 -timeout 40m \
+            ./pkg/core/box/lxc/ -run 'TestIntegrationIncus' | tee incus-test.log
+
+      # A skip here means the environment check above passed and the test
+      # decided otherwise — a contradiction worth failing on rather than
+      # quietly reporting green (#1234).
+      - name: Assert nothing was skipped
+        if: always()
+        run: |
+          set -euo pipefail
+          test -f incus-test.log || { echo "::error::no test log — the test step never produced output"; exit 1; }
+          if grep -q -- "--- SKIP" incus-test.log; then
+            echo "::error::An Incus integration test SKIPPED on a runner where Incus is available."
+            grep -- "--- SKIP" incus-test.log
+            exit 1
+          fi
+          echo "No skips — the create path actually ran."
+
+      # #1332 is timeboxed with a defined failure mode: if Incus cannot run in
+      # a GitHub-hosted runner, the issue closes with the SPECIFIC failure
+      # recorded. Collect it here so that outcome arrives as evidence rather
+      # than as "it went red".
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          sudo incus list --format compact || true
+          # The instance name embeds the test binary's PID, so ask Incus which
+          # instances exist rather than trying to reconstruct it.
+          for i in $(sudo incus list --format csv -c n || true); do
+            echo "--- incus info --show-log $i ---"
+            sudo incus info --show-log "$i" || true
+          done
+          sudo journalctl -u incus.service --no-pager -n 200 || true
+          sudo zfs list -r -t all || true
+          sudo dmesg | tail -50 || true

--- a/internal/testsupport/incusenv/disposition.go
+++ b/internal/testsupport/incusenv/disposition.go
@@ -1,0 +1,59 @@
+// Package incusenv asserts that a real, usable Incus is present before an
+// Incus-backed integration test runs, and decides what to do when one is not
+// (#1332).
+//
+// The decision is the whole point of the package. On a developer's laptop or
+// a container dev box there is legitimately no Incus, and skipping is right.
+// In the CI lane that exists to *demonstrate* the daemon's create path, a
+// skip is the failure mode: the job reports green having proven nothing,
+// which is exactly what let #1195 merge on a check that could not fail
+// (#1234). So the lane sets CONTAINARIUM_REQUIRE_INCUS and the same missing
+// environment becomes a hard failure naming the step that was missing.
+//
+// This file carries no build tag on purpose: the switch itself is testable —
+// and provably able to fail — in the ordinary unit suite, without an Incus
+// anywhere. The code that touches a real Incus lives behind the `incus` tag.
+package incusenv
+
+import "strings"
+
+// RequireEnv is the environment variable that turns "no usable Incus here"
+// from a skip into a failure. Set it in any lane whose job is to prove the
+// Incus path actually runs.
+const RequireEnv = "CONTAINARIUM_REQUIRE_INCUS"
+
+// Disposition is what a test should do when the Incus environment turns out
+// to be unusable.
+type Disposition int
+
+const (
+	// Skip leaves the test unrun — the honest outcome on a machine that was
+	// never expected to have Incus.
+	Skip Disposition = iota
+
+	// Fail treats the missing environment as the defect under test.
+	Fail
+)
+
+func (d Disposition) String() string {
+	if d == Fail {
+		return "fail"
+	}
+	return "skip"
+}
+
+// DispositionFor maps the value of RequireEnv onto what an unusable
+// environment means.
+//
+// Only an affirmative value opts in. "0" and "false" are read as the operator
+// saying no, not as "the variable is set, so require it" — a lane that
+// disables the requirement by setting it to 0 must not get the opposite of
+// what it asked for.
+func DispositionFor(value string) Disposition {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "y", "on":
+		return Fail
+	default:
+		return Skip
+	}
+}

--- a/internal/testsupport/incusenv/disposition_test.go
+++ b/internal/testsupport/incusenv/disposition_test.go
@@ -1,0 +1,44 @@
+package incusenv
+
+import "testing"
+
+// The lane's whole value rests on this switch. If DispositionFor ever
+// answered Skip where the lane asked for Fail, the Incus job would go green
+// on a runner with no Incus — the same shape of check-that-cannot-fail that
+// #1234 was filed for, one layer up.
+//
+// Deliberately untagged, so it runs in the ordinary unit suite: the guarantee
+// is worth nothing if it can only be verified on a machine that already has
+// the environment it is guarding.
+func TestDispositionFor(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  Disposition
+	}{
+		{"unset is a developer laptop", "", Skip},
+		{"the lane sets 1", "1", Fail},
+		{"true", "true", Fail},
+		{"TRUE is the same answer", "TRUE", Fail},
+		{"yes", "yes", Fail},
+		{"on", "on", Fail},
+		{"surrounding whitespace does not change the answer", " 1 ", Fail},
+		// An explicit negative must not be read as "the variable is set,
+		// therefore require it" — a lane opting out would otherwise get
+		// exactly the opposite of what it asked for.
+		{"0 means the operator said no", "0", Skip},
+		{"false means the operator said no", "false", Skip},
+		// Anything we do not recognise is not an opt-in. Requiring Incus is
+		// the stricter behaviour, and guessing a caller into it on a typo
+		// turns a laptop run red for no reason.
+		{"an unrecognised value is not an opt-in", "maybe", Skip},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DispositionFor(tc.value); got != tc.want {
+				t.Errorf("DispositionFor(%q) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/testsupport/incusenv/incusenv.go
+++ b/internal/testsupport/incusenv/incusenv.go
@@ -1,0 +1,105 @@
+//go:build incus
+
+package incusenv
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+)
+
+// SocketPath is where the daemon's own client looks for Incus. Kept here
+// rather than reaching into incus.New's default so a test failure names the
+// path the environment was checked at.
+const SocketPath = "/var/lib/incus/unix.socket"
+
+// Require returns a client connected to the local Incus, having checked that
+// one is actually usable.
+//
+// What happens when it is not usable is DispositionFor's call: a skip on a
+// machine that never had Incus, a failure in the lane that set RequireEnv.
+// Either way the reason is spelled out — "which step, which error" is what
+// #1332's timebox asks for if the environment turns out to be impossible.
+func Require(t *testing.T) *incus.Client {
+	t.Helper()
+
+	if os.Geteuid() != 0 {
+		unusable(t, "Incus operations need root; run with sudo -E")
+		return nil
+	}
+	if _, err := os.Stat(SocketPath); err != nil {
+		unusable(t, "no Incus socket at %s, so the daemon's create path cannot be driven: %v", SocketPath, err)
+		return nil
+	}
+
+	client, err := incus.NewWithSocket(SocketPath)
+	if err != nil {
+		unusable(t, "cannot connect to Incus at %s: %v", SocketPath, err)
+		return nil
+	}
+	info, err := client.GetServerInfo()
+	if err != nil {
+		unusable(t, "connected to Incus at %s but it does not answer: %v", SocketPath, err)
+		return nil
+	}
+	t.Logf("Incus %s on kernel %s", info.Environment.ServerVersion, info.Environment.KernelVersion)
+	return client
+}
+
+// unusable reports an unusable environment as whatever RequireEnv says it is.
+//
+// Never Skipf without consulting DispositionFor: a lane whose entire purpose
+// is to run this code must not be able to report green by not running it.
+func unusable(t *testing.T, format string, args ...any) {
+	t.Helper()
+	msg := fmt.Sprintf(format, args...)
+	if DispositionFor(os.Getenv(RequireEnv)) == Fail {
+		t.Fatalf("%s (%s is set, so this is a failure and not a skip)", msg, RequireEnv)
+		return
+	}
+	t.Skipf("%s (set %s=1 to make this a failure instead)", msg, RequireEnv)
+}
+
+// DatasetFor returns the ZFS dataset backing an Incus instance, and "" when
+// the instance has no dataset of its own.
+//
+// It searches by suffix rather than composing the name from the pool's
+// source, because the layout is Incus's to choose: a pool sourced at
+// `incus-local/containers` puts an instance at
+// `incus-local/containers/containers/<name>`, and asserting that shape here
+// would test our arithmetic instead of what Incus did.
+//
+// This lookup is also the shape #1199's datasetResolver needs — the hook has
+// to name the dataset a container will live on before Incus creates the
+// instance — which is why the lane proves it can be answered at all.
+func DatasetFor(t *testing.T, instanceName string) string {
+	t.Helper()
+
+	out, err := exec.Command("zfs", "list", "-H", "-o", "name", "-r").CombinedOutput() // #nosec G204 -- no caller input
+	if err != nil {
+		t.Fatalf("zfs list: %v\n%s", err, out)
+	}
+	suffix := "/containers/" + instanceName
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if name := strings.TrimSpace(line); strings.HasSuffix(name, suffix) {
+			return name
+		}
+	}
+	return ""
+}
+
+// DeleteInstance removes an instance, tolerating one that was never created.
+// Registered as cleanup so a failed test does not leave the runner — or a
+// developer's box — carrying a container and its dataset.
+func DeleteInstance(t *testing.T, name string) {
+	t.Helper()
+	if out, err := exec.Command("incus", "delete", "--force", name).CombinedOutput(); err != nil { // #nosec G204 -- test-controlled name
+		if !strings.Contains(string(out), "not found") {
+			t.Logf("cleanup: could not delete instance %s: %v\n%s", name, err, out)
+		}
+	}
+}

--- a/pkg/core/box/lxc/create_integration_test.go
+++ b/pkg/core/box/lxc/create_integration_test.go
@@ -1,0 +1,126 @@
+//go:build incus
+
+package lxc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/testsupport/incusenv"
+	"github.com/footprintai/containarium/pkg/core/box"
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// The environment #1199 has been blocked on (#1332).
+//
+// Every other piece of per-tenant ZFS encryption is proven: the zfscrypt
+// semantics against a real pool (#1200), the hooks' orchestration in unit
+// tests, and PreCreate itself against a real pool. The one step left —
+// wiring PreCreate into the create path — had nowhere to run, because
+// nothing in CI could create a container through the daemon's own code
+// against a real Incus on a real ZFS pool.
+//
+// This test is that environment. It deliberately drives the box seam
+// (box.BoxBackend.Create → container.Manager.Create → the daemon's Incus
+// client) rather than `incus launch`: the point is not that a container can
+// exist on the runner, it is that OUR create path runs there. Driving Incus
+// directly would prove the runner works and leave #1199 exactly as blocked
+// as it was.
+
+// tenant is a per-process name so a rerun on a dirty machine cannot collide
+// with a leftover from a previous one. The daemon derives the instance name
+// from it as "<tenant>-container".
+func tenant() string { return fmt.Sprintf("ci%d", os.Getpid()) }
+
+// TestIntegrationIncus_CreateThroughTheDaemonsOwnPath is #1332's acceptance
+// criteria 1 and 2, in order: the daemon initialises Incus against a ZFS
+// storage pool, then creates a container through its own Create() and the
+// container is running.
+func TestIntegrationIncus_CreateThroughTheDaemonsOwnPath(t *testing.T) {
+	client := incusenv.Require(t)
+
+	// AC1 — initialise through InitializeInfrastructure, which is what the
+	// daemon itself calls at startup, not a hand-written preseed. If the
+	// daemon's own storage selection cannot land on ZFS here, that is a
+	// finding about the daemon and we want to see it as a failure.
+	if err := client.InitializeInfrastructure(incus.DefaultNetworkConfig()); err != nil {
+		t.Fatalf("the daemon's own infrastructure init failed: %v", err)
+	}
+
+	driver, err := client.PoolDriver(client.StoragePool())
+	if err != nil {
+		t.Fatalf("could not read the storage pool %q the daemon just ensured: %v", client.StoragePool(), err)
+	}
+	if driver != incus.StorageDriverZFS {
+		// Not a cosmetic assertion. On the `dir` driver there is no
+		// per-container dataset, so there is nothing for #1199 to encrypt
+		// and the lane would prove nothing about the encrypted path while
+		// still going green.
+		t.Fatalf("storage pool %q is on the %q driver, want %q — an Incus lane on a non-ZFS pool "+
+			"cannot exercise the encrypted create path #1199 needs",
+			client.StoragePool(), driver, incus.StorageDriverZFS)
+	}
+
+	// AC2 — through the daemon's Create(), not `incus launch`.
+	backend := New(container.NewWithBackend(client))
+	name := tenant()
+	instance := name + "-container"
+	t.Cleanup(func() { incusenv.DeleteInstance(t, instance) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
+	defer cancel()
+
+	st, err := backend.Create(ctx, box.BoxSpec{
+		Ref:       box.BoxRef{Tenant: name},
+		Image:     "images:ubuntu/24.04",
+		OSType:    pb.OSType_OS_TYPE_UBUNTU_2404,
+		AutoStart: true,
+		// No SSH keys on purpose: seeding them creates a jump-server
+		// account on the HOST, which is a side effect this lane has no
+		// business having and which #1199 does not need.
+	})
+	if err != nil {
+		t.Fatalf("the daemon's create path failed against a real Incus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("create reported success and returned no status")
+	}
+	if st.State != pb.ContainerState_CONTAINER_STATE_RUNNING {
+		t.Fatalf("container state = %v, want RUNNING — #1199's hooks run around a create that "+
+			"actually starts the box, so a created-but-not-running container is not the path it wires into",
+			st.State)
+	}
+	if st.Ref.Name != instance {
+		t.Errorf("instance name = %q, want %q", st.Ref.Name, instance)
+	}
+
+	// The box seam has to agree with Incus after the fact, not only in the
+	// value Create happened to return.
+	got, err := backend.Get(ctx, box.BoxRef{Tenant: name})
+	if err != nil {
+		t.Fatalf("reading back the container the daemon just created: %v", err)
+	}
+	if got == nil {
+		t.Fatal("the container the daemon reported creating is not there when read back")
+	}
+	if got.State != pb.ContainerState_CONTAINER_STATE_RUNNING {
+		t.Errorf("read-back state = %v, want RUNNING", got.State)
+	}
+
+	// The answer #1199 needs from this lane: the container has a ZFS dataset
+	// of its own, and it is nameable from the container's name. That mapping
+	// is exactly what encryptionHooks' datasetResolver has to provide before
+	// the instance exists, so a lane where it cannot be resolved would not
+	// unblock #1199 even with a green create above.
+	dataset := incusenv.DatasetFor(t, instance)
+	if dataset == "" {
+		t.Fatalf("no ZFS dataset for instance %s — the pool reports the zfs driver but the "+
+			"container did not get a dataset of its own, so there is nothing for #1199 to encrypt", instance)
+	}
+	t.Logf("instance %s is backed by dataset %s", instance, dataset)
+}


### PR DESCRIPTION
Closes #1332

## What this does

#1199 — wiring the per-tenant encryption `PreCreate` hook into the create path — has been recorded as blocked for a sprint on *"there is nowhere to run the daemon's Incus-backed `Create()`"*. That assumption had never been tested. This is the timeboxed attempt at constructing that somewhere, following the precedent `zfs-encryption.yml` set when it cleared the same shape of blocker for #1200 in a day.

- **New lane `.github/workflows/incus-create.yml`** — installs Incus on a plain `ubuntu-latest` runner next to a real file-backed ZFS pool. The pool is named `incus-local` with a `containers` dataset **because that is what the daemon's own `detectZFSContainersDataset` / `SelectStorageDriver` probes for** — any other name and the daemon silently falls back to the `dir` driver, where there are no per-container datasets and the lane would prove nothing about the encrypted path.
- **`TestIntegrationIncus_CreateThroughTheDaemonsOwnPath`** — drives `box.BoxBackend.Create` → `container.Manager.Create` → the daemon's Incus client. Not `incus launch`: the claim being made is that *our* create path runs there. Storage/network/profile come from the daemon's own `InitializeInfrastructure`, not an `incus admin init` preseed we wrote to make it pass.
- **`internal/testsupport/incusenv`** — asserts a usable Incus, and decides skip-vs-fail from `CONTAINARIUM_REQUIRE_INCUS`. Set in the lane, so a runner without Incus turns the job red instead of green-and-empty.

Separate workflow rather than more steps on `zfs-encryption.yml`: that lane is a pool plus `go test` and gates every encryption change; this one installs Incus and pulls a distro image. Merging them would make every encryption change wait on an image pull. The issue left this as an implementation call.

## Acceptance criteria

| AC | Covered by |
| --- | --- |
| A CI lane installs Incus and initialises it against a ZFS storage pool | `incus-create.yml` steps *Create the ZFS pool the daemon detects* / *Install Incus*; asserted in-test by `client.PoolDriver(...) == StorageDriverZFS` |
| Creates a container through the daemon's own `Create()`, not `incus launch`, and asserts it started | `TestIntegrationIncus_CreateThroughTheDaemonsOwnPath` — `backend.Create(...)` then `st.State == RUNNING`, plus a read-back through `backend.Get` |
| Fails loudly if Incus is unavailable rather than skipping | `TestDispositionFor` (untagged, runs in the normal suite) + `CONTAINARIUM_REQUIRE_INCUS: '1'` in the lane + the *Verify Incus is actually usable* and *Assert nothing was skipped* steps |
| #1199 can be unblocked, or the timebox produces evidence it cannot | This lane's result. The test additionally resolves the per-instance ZFS dataset, which is the mapping `encryptionHooks`' `datasetResolver` has to answer before the instance exists |

## Test evidence

The fail-loud switch was verified in both directions locally — a check that cannot fail proves nothing:

```
--- without the env var ---
    create_integration_test.go:45: Incus operations need root ... (set CONTAINARIUM_REQUIRE_INCUS=1 to make this a failure instead)
--- SKIP: TestIntegrationIncus_CreateThroughTheDaemonsOwnPath (0.00s)
ok  	github.com/footprintai/containarium/pkg/core/box/lxc	0.003s

--- with CONTAINARIUM_REQUIRE_INCUS=1 ---
    create_integration_test.go:45: Incus operations need root ... (CONTAINARIUM_REQUIRE_INCUS is set, so this is a failure and not a skip)
--- FAIL: TestIntegrationIncus_CreateThroughTheDaemonsOwnPath (0.00s)
FAIL
```

`TestDispositionFor` was likewise confirmed red by inverting `DispositionFor` once, then restored.

The lane itself is the real evidence and runs on this PR — CI run linked in a follow-up comment once it completes. **The `Incus create path` job is the check to read first**; it is new, so a red result here is a finding about the environment, which is the outcome #1332 explicitly budgets for.

## Reviewer notes

- Two runner-specific facts are handled explicitly in *Make the runner able to host containers*, both of which would otherwise surface minutes into the create as something unrelated: Ubuntu 24.04's AppArmor restriction on unprivileged user namespaces, and Docker setting the iptables `FORWARD` policy to `DROP` on GitHub runners (which silently kills `incusbr0` NAT, so the container boots with no route out and fails inside `apt-get update`).
- The test passes no SSH keys on purpose — seeding them creates a jump-server account on the **host**, a side effect this lane has no business having and which #1199 does not need.
- No production code changed; everything here is a workflow, a `//go:build incus` test, and a test-support package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)