### PR TITLE
fix(incus): ContainerDataset named a dataset that does not exist, and #1199's design premise does not hold

### DIFF
--- a/.github/workflows/incus-create.yml
+++ b/.github/workflows/incus-create.yml
@@ -24,6 +24,9 @@ on:
       - 'pkg/core/container/**'
       - 'pkg/core/incus/**'
       - 'internal/testsupport/incusenv/**'
+      # The encrypted-create path this lane now covers (#1199).
+      - 'pkg/core/zfscrypt/**'
+      - 'pkg/core/zfskey/**'
       - '.github/workflows/incus-create.yml'
   # No `branches:` filter — a base filter leaves stacked PRs with no checks
   # at all, which looks the same as checks not having started (#1215).
@@ -33,6 +36,9 @@ on:
       - 'pkg/core/container/**'
       - 'pkg/core/incus/**'
       - 'internal/testsupport/incusenv/**'
+      # The encrypted-create path this lane now covers (#1199).
+      - 'pkg/core/zfscrypt/**'
+      - 'pkg/core/zfskey/**'
       - '.github/workflows/incus-create.yml'
 
 permissions:

--- a/internal/testsupport/incusenv/incusenv.go
+++ b/internal/testsupport/incusenv/incusenv.go
@@ -92,6 +92,27 @@ func DatasetFor(t *testing.T, instanceName string) string {
 	return ""
 }
 
+// CreateZFSPool adds an Incus storage pool sourced at an existing ZFS
+// dataset, and registers its removal.
+//
+// Shells out to the CLI because the daemon's client has no method for
+// creating an arbitrary pool — EnsureStorage only ever provisions the one
+// configured pool, which is the right production surface and the wrong one
+// for a test that needs a second pool to compare against.
+func CreateZFSPool(t *testing.T, poolName, sourceDataset string) {
+	t.Helper()
+	out, err := exec.Command("incus", "storage", "create", poolName, "zfs", // #nosec G204 -- test-controlled names
+		"source="+sourceDataset).CombinedOutput()
+	if err != nil {
+		t.Fatalf("incus storage create %s zfs source=%s: %v\n%s", poolName, sourceDataset, err, out)
+	}
+	t.Cleanup(func() {
+		if out, err := exec.Command("incus", "storage", "delete", poolName).CombinedOutput(); err != nil { // #nosec G204 -- test-controlled name
+			t.Logf("cleanup: could not delete storage pool %s: %v\n%s", poolName, err, out)
+		}
+	})
+}
+
 // DeleteInstance removes an instance, tolerating one that was never created.
 // Registered as cleanup so a failed test does not leave the runner — or a
 // developer's box — carrying a container and its dataset.

--- a/pkg/core/box/lxc/encrypted_create_integration_test.go
+++ b/pkg/core/box/lxc/encrypted_create_integration_test.go
@@ -1,0 +1,192 @@
+//go:build incus
+
+package lxc
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/testsupport/incusenv"
+	"github.com/footprintai/containarium/pkg/core/box"
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// The two questions #1199 could not answer without an Incus (#1332).
+//
+// #1199's remaining step — calling PreCreate from the create path — rests on
+// two premises that were taken from documentation rather than from a running
+// system, and the issue's own history says so: the assignee declined three
+// times to write the wiring blind, citing a previous pair of PRs here that
+// shipped code against a type no caller could produce. That was the right
+// call, and these tests are the way to stop guessing.
+//
+// Premise 1: the daemon can name the dataset a container will live on.
+// Premise 2: Incus will build an instance ON a dataset that already exists
+//            (design §3, hook row 1: "tells Incus to use that pre-existing
+//            dataset (Incus's 'instance from an existing zvol' path)").
+//
+// Premise 2 is the load-bearing one. If it does not hold, #1199 is not a
+// wiring task at all and the design needs revisiting — which is a finding
+// worth having as a red CI run rather than as a fourth sprint of "blocked".
+
+// newTestKey returns 32 random bytes as a key. Synthetic, per-run, and never
+// written anywhere but the throwaway pool on the runner.
+func newTestKey(t *testing.T) zfskey.Key {
+	t.Helper()
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	key, err := zfskey.NewKey(b)
+	if err != nil {
+		t.Fatalf("wrap key: %v", err)
+	}
+	return key
+}
+
+// TestIntegrationIncus_ContainerDatasetNamesTheRealDataset checks premise 1
+// against a container Incus actually created.
+//
+// This is the production resolver — incus.ContainerDataset, which #1259
+// extracted from the quota-headroom path precisely so per-tenant encryption
+// could use it. It has always been exercised on hosts whose pool was
+// provisioned one particular way; a CI pool is provisioned by the daemon's
+// own EnsureStorage, so this is the first time the two are compared.
+//
+// It matters because encryptionHooks.datasetResolver has to return this
+// string BEFORE the instance exists. A resolver that is off by one level
+// would create the encrypted dataset somewhere harmless, let Incus create an
+// ordinary unencrypted one, and report a successful encrypted create.
+func TestIntegrationIncus_ContainerDatasetNamesTheRealDataset(t *testing.T) {
+	client := incusenv.Require(t)
+	if err := client.InitializeInfrastructure(incus.DefaultNetworkConfig()); err != nil {
+		t.Fatalf("the daemon's own infrastructure init failed: %v", err)
+	}
+
+	name := fmt.Sprintf("dsr%d", os.Getpid())
+	instance := name + "-container"
+	t.Cleanup(func() { incusenv.DeleteInstance(t, instance) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
+	defer cancel()
+
+	if _, err := New(container.NewWithBackend(client)).Create(ctx, box.BoxSpec{
+		Ref:       box.BoxRef{Tenant: name},
+		Image:     "images:ubuntu/24.04",
+		OSType:    pb.OSType_OS_TYPE_UBUNTU_2404,
+		AutoStart: true,
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	actual := incusenv.DatasetFor(t, instance)
+	if actual == "" {
+		t.Fatalf("instance %s has no ZFS dataset", instance)
+	}
+
+	resolved, err := client.ContainerDataset(instance, "")
+	if err != nil {
+		t.Fatalf("ContainerDataset(%s): %v", instance, err)
+	}
+	if resolved != actual {
+		t.Errorf("ContainerDataset(%s) = %q, but Incus put the instance on %q.\n"+
+			"The daemon cannot name the dataset it is about to encrypt, so #1199's PreCreate "+
+			"would encrypt a dataset nothing uses while Incus creates an ordinary one alongside it — "+
+			"an encrypted create that reports success and delivers plaintext.",
+			instance, resolved, actual)
+	}
+}
+
+// TestIntegrationIncus_InstanceOnAPreExistingEncryptedDataset is premise 2,
+// and the whole of what #1199 has been blocked on.
+//
+// The design's pre-create hook says: make the dataset with encryption=on,
+// then tell Incus to use it. Nobody in the issue's history could run that.
+// So: pre-create the dataset at exactly the path the daemon resolves, with
+// the production CreateEncrypted, then drive the daemon's own create and see
+// what Incus does with it.
+//
+// A failure here is not a broken test — it is the answer, and it says the
+// remaining work on #1199 is a design question rather than a wiring task.
+func TestIntegrationIncus_InstanceOnAPreExistingEncryptedDataset(t *testing.T) {
+	client := incusenv.Require(t)
+	if err := client.InitializeInfrastructure(incus.DefaultNetworkConfig()); err != nil {
+		t.Fatalf("the daemon's own infrastructure init failed: %v", err)
+	}
+
+	zfs := zfscrypt.NewManager(zfscrypt.ExecRunner{})
+	name := fmt.Sprintf("enc%d", os.Getpid())
+	instance := name + "-container"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
+	defer cancel()
+
+	dataset, err := client.ContainerDataset(instance, "")
+	if err != nil {
+		t.Fatalf("ContainerDataset(%s): %v", instance, err)
+	}
+	t.Logf("pre-creating encrypted dataset %s for instance %s", dataset, instance)
+
+	t.Cleanup(func() {
+		incusenv.DeleteInstance(t, instance)
+		// After the instance is gone the dataset may survive (if Incus never
+		// adopted it) or not (if it did). Either way, leave nothing behind.
+		_ = zfs.Destroy(context.Background(), dataset)
+	})
+
+	// This is PreCreate's ZFS half, running the production code path.
+	if err := zfs.CreateEncrypted(ctx, dataset, newTestKey(t)); err != nil {
+		t.Fatalf("could not pre-create the encrypted dataset %s: %v", dataset, err)
+	}
+	root, err := zfs.EncryptionRoot(ctx, dataset)
+	if err != nil {
+		t.Fatalf("read encryptionroot of %s: %v", dataset, err)
+	}
+	if root != dataset {
+		t.Fatalf("pre-created %s but its encryptionroot is %q — it is not its own root", dataset, root)
+	}
+
+	// Now the daemon's own create, onto a dataset that already exists.
+	_, createErr := New(container.NewWithBackend(client)).Create(ctx, box.BoxSpec{
+		Ref:       box.BoxRef{Tenant: name},
+		Image:     "images:ubuntu/24.04",
+		OSType:    pb.OSType_OS_TYPE_UBUNTU_2404,
+		AutoStart: true,
+	})
+	if createErr != nil {
+		t.Fatalf("Incus will not build an instance on a pre-existing dataset: %v\n\n"+
+			"This is design §3 hook row 1's premise — 'tells Incus to use that pre-existing dataset "+
+			"(Incus's instance from an existing zvol path)' — and it does not hold as written. "+
+			"#1199's remaining step is therefore not a wiring task; see the issue comment for the "+
+			"alternatives this leaves open.", createErr)
+	}
+
+	// It succeeded. Now the part that decides whether it succeeded for the
+	// right reason: Incus must have ADOPTED the encrypted dataset, not
+	// created its own alongside it. A create that quietly lands on a
+	// different, unencrypted dataset is the exact failure #1294 refuses to
+	// ship — success reported, plaintext delivered.
+	landed := incusenv.DatasetFor(t, instance)
+	if landed != dataset {
+		t.Fatalf("the create succeeded but the instance is on %q, not the encrypted dataset %q "+
+			"that was pre-created for it — Incus ignored it rather than adopting it, so the "+
+			"container is unencrypted while every daemon-side signal says otherwise", landed, dataset)
+	}
+	gotRoot, err := zfs.EncryptionRoot(ctx, landed)
+	if err != nil {
+		t.Fatalf("read encryptionroot of %s after the create: %v", landed, err)
+	}
+	if gotRoot != dataset {
+		t.Fatalf("instance dataset %s has encryptionroot %q, want %q", landed, gotRoot, dataset)
+	}
+	t.Logf("Incus adopted the pre-existing encrypted dataset; instance %s is under encryptionroot %s",
+		instance, gotRoot)
+}

--- a/pkg/core/box/lxc/encrypted_create_integration_test.go
+++ b/pkg/core/box/lxc/encrypted_create_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -161,32 +162,111 @@ func TestIntegrationIncus_InstanceOnAPreExistingEncryptedDataset(t *testing.T) {
 		OSType:    pb.OSType_OS_TYPE_UBUNTU_2404,
 		AutoStart: true,
 	})
-	if createErr != nil {
-		t.Fatalf("Incus will not build an instance on a pre-existing dataset: %v\n\n"+
-			"This is design §3 hook row 1's premise — 'tells Incus to use that pre-existing dataset "+
-			"(Incus's instance from an existing zvol path)' — and it does not hold as written. "+
-			"#1199's remaining step is therefore not a wiring task; see the issue comment for the "+
-			"alternatives this leaves open.", createErr)
+
+	// The answer, recorded as an executable fact rather than a hypothesis.
+	//
+	// Incus 6.0.0 refuses, and the error names the mechanism: it builds an
+	// instance volume with `zfs clone <image>@readonly <instance dataset>`.
+	// A clone is created BY the clone operation, so there is no dataset for
+	// it to adopt — and a clone's encryption is inherited from its origin
+	// snapshot, not from where it is placed. Pre-creating the dataset cannot
+	// make the instance encrypted even in principle.
+	//
+	// This test asserts the refusal on purpose. If it ever starts failing,
+	// Incus has changed and design §3's premise may have become available —
+	// which is worth being told about loudly rather than discovering by
+	// re-running this investigation from scratch.
+	if createErr == nil {
+		t.Fatalf("Incus accepted a create onto a pre-existing dataset. That contradicts the "+
+			"behaviour recorded here against Incus 6.0.0 (#1199), and would mean design §3 hook "+
+			"row 1's 'instance from an existing zvol' path is now real. Re-check what landed on %s "+
+			"and revisit the issue.", dataset)
+	}
+	if !strings.Contains(createErr.Error(), "dataset already exists") {
+		t.Fatalf("create failed, but not with the refusal this test records: %v\n"+
+			"Expected Incus's zfs clone to refuse the existing dataset. A different failure means "+
+			"the environment broke rather than the premise being retested.", createErr)
+	}
+	t.Logf("recorded: Incus will not adopt a pre-existing dataset — %v", createErr)
+}
+
+// TestIntegrationIncus_InstanceInheritsEncryptionFromThePoolRoot tests the
+// alternative the refusal above leaves open, so #1199's design question
+// arrives with evidence attached rather than as a dead end.
+//
+// If Incus makes every instance a clone of the image, then the only way an
+// instance can be encrypted is for the dataset it is cloned WITHIN to be
+// encrypted — i.e. the pool's own root dataset is the encryptionroot. Incus
+// supports a pool sourced at an arbitrary dataset, so "one storage pool per
+// tenant, sourced at that tenant's encrypted dataset" is expressible today
+// with no new Incus capability.
+//
+// This test does not implement that design. It answers whether it works,
+// which is what the design decision needs and what nobody has been able to
+// check.
+func TestIntegrationIncus_InstanceInheritsEncryptionFromThePoolRoot(t *testing.T) {
+	client := incusenv.Require(t)
+	if err := client.InitializeInfrastructure(incus.DefaultNetworkConfig()); err != nil {
+		t.Fatalf("the daemon's own infrastructure init failed: %v", err)
 	}
 
-	// It succeeded. Now the part that decides whether it succeeded for the
-	// right reason: Incus must have ADOPTED the encrypted dataset, not
-	// created its own alongside it. A create that quietly lands on a
-	// different, unencrypted dataset is the exact failure #1294 refuses to
-	// ship — success reported, plaintext delivered.
-	landed := incusenv.DatasetFor(t, instance)
-	if landed != dataset {
-		t.Fatalf("the create succeeded but the instance is on %q, not the encrypted dataset %q "+
-			"that was pre-created for it — Incus ignored it rather than adopting it, so the "+
-			"container is unencrypted while every daemon-side signal says otherwise", landed, dataset)
+	zfs := zfscrypt.NewManager(zfscrypt.ExecRunner{})
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
+	defer cancel()
+
+	// The tenant's encryptionroot, created by the production CreateEncrypted
+	// exactly as PreCreate would.
+	tenantRoot := fmt.Sprintf("incus-local/tenant%d", os.Getpid())
+	if err := zfs.CreateEncrypted(ctx, tenantRoot, newTestKey(t)); err != nil {
+		t.Fatalf("create the tenant encryptionroot %s: %v", tenantRoot, err)
 	}
-	gotRoot, err := zfs.EncryptionRoot(ctx, landed)
+	t.Cleanup(func() { _ = zfs.Destroy(context.Background(), tenantRoot) })
+
+	// A storage pool sourced at it. Everything Incus creates for this pool —
+	// images and instances alike — lands under the encryptionroot.
+	pool := fmt.Sprintf("tenantpool%d", os.Getpid())
+	incusenv.CreateZFSPool(t, pool, tenantRoot)
+
+	name := fmt.Sprintf("tnt%d", os.Getpid())
+	instance := name + "-container"
+	t.Cleanup(func() { incusenv.DeleteInstance(t, instance) })
+
+	// Point the daemon's create at that pool. A disk size is required for
+	// the root device to name a pool at all — without one the container
+	// inherits the default profile's root disk.
+	client.SetStoragePool(pool)
+	t.Cleanup(func() { client.SetStoragePool(incus.DefaultStoragePool) })
+
+	st, err := New(container.NewWithBackend(client)).Create(ctx, box.BoxSpec{
+		Ref:       box.BoxRef{Tenant: name},
+		Image:     "images:ubuntu/24.04",
+		OSType:    pb.OSType_OS_TYPE_UBUNTU_2404,
+		AutoStart: true,
+		Resources: box.ResourceLimits{Disk: "5GB"},
+	})
 	if err != nil {
-		t.Fatalf("read encryptionroot of %s after the create: %v", landed, err)
+		t.Fatalf("create on a pool rooted at an encrypted dataset: %v\n"+
+			"If this is where per-tenant encryption fails, the pool-per-tenant alternative is "+
+			"out too and #1199 needs a different approach entirely.", err)
 	}
-	if gotRoot != dataset {
-		t.Fatalf("instance dataset %s has encryptionroot %q, want %q", landed, gotRoot, dataset)
+	if st.State != pb.ContainerState_CONTAINER_STATE_RUNNING {
+		t.Fatalf("container state = %v, want RUNNING", st.State)
 	}
-	t.Logf("Incus adopted the pre-existing encrypted dataset; instance %s is under encryptionroot %s",
-		instance, gotRoot)
+
+	landed := incusenv.DatasetFor(t, instance)
+	if landed == "" {
+		t.Fatalf("instance %s has no dataset", instance)
+	}
+	root, err := zfs.EncryptionRoot(ctx, landed)
+	if err != nil {
+		t.Fatalf("read encryptionroot of %s: %v", landed, err)
+	}
+	if root != tenantRoot {
+		t.Fatalf("instance dataset %s has encryptionroot %q, want the tenant's root %q — "+
+			"the container is NOT under the tenant key, so a pool per tenant would not deliver "+
+			"per-tenant encryption either", landed, root, tenantRoot)
+	}
+	t.Logf("a container created through the daemon's own path on a pool rooted at %s is encrypted "+
+		"under that tenant's encryptionroot: instance dataset %s, encryptionroot %s",
+		tenantRoot, landed, root)
 }

--- a/pkg/core/incus/client.go
+++ b/pkg/core/incus/client.go
@@ -1826,17 +1826,25 @@ func (c *Client) ContainerDataset(containerName, pool string) (string, error) {
 // buildContainerDataset is the pure half, so the layout can be tested without
 // an Incus server.
 //
-// The doubled "containers/containers" is not a typo: incus nests its instance
-// datasets under a `containers` child of the pool's own `containers` dataset.
-// It is preserved exactly as the quota path has always produced it — changing
-// it would silently point every caller at a dataset that does not exist.
+// Incus's rule is one segment: an instance's dataset is a `containers` child
+// of the pool's ROOT dataset, and the pool's `source` is that root dataset.
+//
+// This used to append `/containers/containers/`, and the doubling was
+// defended in a test as "incus's actual layout, not a typo". It was a typo of
+// a kind — read off a real host's dataset name without noticing that the
+// source already ended in `/containers`. On a daemon-provisioned pool
+// (EnsureStorage sets source to incus-local/containers) the correct answer
+// still READS as `incus-local/containers/containers/<name>`, which is how the
+// extra segment survived review and got pinned by unit tests. A real pool
+// settled it: #1336, and pkg/core/box/lxc's incus-tagged integration test is
+// the assertion that can actually tell the two apart.
 func buildContainerDataset(poolSource, poolName, containerName string) string {
 	zfsPool := poolSource
 	if zfsPool == "" {
 		// A pool created without an explicit source uses its own name.
 		zfsPool = poolName
 	}
-	return fmt.Sprintf("%s/containers/containers/%s", zfsPool, containerName)
+	return fmt.Sprintf("%s/containers/%s", zfsPool, containerName)
 }
 
 // ensureZFSQuotaHeadroom checks if the container's ZFS dataset is at quota and

--- a/pkg/core/incus/storage_pool_test.go
+++ b/pkg/core/incus/storage_pool_test.go
@@ -132,11 +132,17 @@ func TestRootDiskForPool(t *testing.T) {
 }
 
 // buildContainerDataset is the daemon's understanding of where incus puts a
-// container's ZFS dataset. It is extracted from the quota-headroom path
-// rather than newly derived, because that path has computed this string on
-// real hosts for a long time — the value of pinning it here is that the next
-// caller (per-tenant encryption's dataset resolver, snapshot/rollback RPCs)
-// reuses the exercised version instead of rebuilding it from the docs.
+// container's ZFS dataset: a `containers` child of the pool's ROOT dataset,
+// which is what the pool's `source` names.
+//
+// These cases previously asserted one segment too many, and were corrected in
+// #1336 against a real pool. The rule is worth stating rather than pattern-
+// matching, because the wrong version was derived by pattern-matching a real
+// host's dataset name: on a daemon-provisioned pool the source already ends
+// in `/containers`, so the right answer LOOKS doubled and the doubling got
+// appended a second time. Only a real Incus can tell those two apart, so the
+// authority for this layout is the incus-tagged integration test in
+// pkg/core/box/lxc — these cases pin the arithmetic, not the truth.
 func TestBuildContainerDataset(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
@@ -148,17 +154,24 @@ func TestBuildContainerDataset(t *testing.T) {
 		{
 			// The normal case: the incus pool records the ZFS pool it sits on.
 			name: "pool with an explicit source", poolSource: "tank", poolName: "default",
-			container: "alice-container", want: "tank/containers/containers/alice-container",
+			container: "alice-container", want: "tank/containers/alice-container",
 		},
 		{
 			// A pool created without an explicit source uses its own name.
 			name: "pool without a source falls back to its name", poolSource: "", poolName: "default",
-			container: "alice-container", want: "default/containers/containers/alice-container",
+			container: "alice-container", want: "default/containers/alice-container",
 		},
 		{
 			// A source that is itself a nested dataset is used verbatim.
 			name: "nested source", poolSource: "tank/incus", poolName: "default",
-			container: "bob", want: "tank/incus/containers/containers/bob",
+			container: "bob", want: "tank/incus/containers/bob",
+		},
+		{
+			// The shape EnsureStorage provisions, and the one that caused
+			// #1336: the source already ends in /containers, so the correct
+			// answer reads as doubled without the code doubling anything.
+			name: "daemon-provisioned pool", poolSource: "incus-local/containers", poolName: "default",
+			container: "alice-container", want: "incus-local/containers/containers/alice-container",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -170,14 +183,19 @@ func TestBuildContainerDataset(t *testing.T) {
 	}
 }
 
-// The doubled segment is load-bearing and looks like a typo, so it gets its
-// own assertion: incus nests instance datasets under a `containers` child of
-// the pool's own `containers` dataset. "Simplifying" it would point every
-// caller at a dataset that does not exist.
-func TestBuildContainerDataset_KeepsTheDoubledContainersSegment(t *testing.T) {
+// Exactly one `containers` segment is appended, whatever the source looks
+// like. This replaces an assertion that required the segment to be DOUBLED —
+// that test passed for four months and was wrong, because it asserted the
+// implementation back to itself. Framed here as "append one, never two", so
+// re-introducing the bug fails rather than looking like the layout.
+func TestBuildContainerDataset_AppendsExactlyOneContainersSegment(t *testing.T) {
 	got := buildContainerDataset("tank", "default", "alice")
-	if !strings.Contains(got, "/containers/containers/") {
-		t.Errorf("dataset = %q — the doubled segment is incus's actual layout, not a typo; "+
-			"removing it names a dataset that does not exist", got)
+	if strings.Contains(got, "/containers/containers/") {
+		t.Errorf("dataset = %q — two `containers` segments were appended to a source that had "+
+			"none. Incus puts an instance at <pool root>/containers/<name>; the extra level names "+
+			"a dataset that does not exist (#1336)", got)
+	}
+	if want := "tank/containers/alice"; got != want {
+		t.Errorf("dataset = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
Closes #1336. Part of #1199 — and it changes what #1199 is.

This started as "wire `PreCreate` into `Create()`". Running that wiring's premises against the real Incus #1332 landed produced a bug and a design finding, so this PR ships the bug fix and the evidence, and does **not** improvise a new architecture in a feature PR.

## 1. The bug — `ContainerDataset` named a dataset that does not exist

```
ContainerDataset("dsr8336-container") = "incus-local/containers/containers/containers/dsr8336-container"
Incus put the instance on             = "incus-local/containers/containers/dsr8336-container"
```

`buildContainerDataset` appended a hardcoded `/containers/containers/` to the pool's `source`. Incus's rule is one segment — an instance lives at `<pool root>/containers/<name>`, and `source` **is** that root. The doubling came from reading a real host's dataset name without noticing the source already ended in `/containers`, so the correct answer *reads* as doubled.

**Why unit tests could not catch it.** They asserted the buggy string, and `TestBuildContainerDataset_KeepsTheDoubledContainersSegment` explicitly guarded the extra segment against being "simplified". I have changed both — flagging that plainly, since correcting an existing test needs to be a deliberate, visible act. The authority for the change is the real-pool test, not my reading; the replacement is framed as *append one, never two*, so re-introducing the bug fails instead of looking like the layout.

**Impact.** The only production caller is `SetDeviceSize`'s quota headroom, and it swallows the error as `Warning: ZFS quota pre-expand failed (non-fatal)`. So it has been failing on every host and continuing. For #1199 it was worse than that: `datasetResolver` would have encrypted a dataset nothing uses while Incus created an ordinary one — a successful-looking encrypted create that delivers plaintext, which is what #1294 exists to prevent.

## 2. The design finding — §3 hook row 1 cannot work

Design §3 says the pre-create hook "tells Incus to use that pre-existing dataset (Incus's *instance from an existing zvol* path)". Incus 6.0.0 refuses, and the error names the mechanism:

```
Failed creating instance from image: Failed to run: zfs clone \
  incus-local/containers/images/343e93...@readonly \
  incus-local/containers/containers/enc8375-container: dataset already exists
```

Incus builds an instance volume by **cloning the image snapshot**. A clone is created *by* the clone operation, so there is no dataset to adopt — and a clone inherits encryption from its **origin**, not from where it is placed. Pre-creating an encrypted dataset cannot make the instance encrypted even in principle. This is not a wiring gap; the premise is wrong.

That refusal is now an **asserted fact** rather than a hypothesis. If Incus ever gains the capability, the lane says so loudly instead of the question being re-investigated from scratch.

## 3. The alternative, tested — pool per tenant works

If every instance is a clone of the image, the only way an instance can be encrypted is for the dataset it is cloned *within* to be encrypted. Incus supports a pool sourced at an arbitrary dataset, so "one storage pool per tenant, sourced at that tenant's encrypted dataset" needs no new Incus capability. It works:

```
a container created through the daemon's own path on a pool rooted at incus-local/tenant8194
is encrypted under that tenant's encryptionroot:
  instance dataset incus-local/tenant8194/containers/tnt8194-container
  encryptionroot   incus-local/tenant8194
```

Created through `box.BoxBackend.Create` → `container.Manager.Create`, using the production `CreateEncrypted` to make the tenant root. **This PR does not implement that design** — it answers the question the design decision needs. Handing it to `/architect:design` is #1199's next step, not a feature PR's.

## Test evidence

Lane: https://github.com/FootprintAI/Containarium/actions/runs/31664231328/job/94335277190 — all four green.

```
--- PASS: TestIntegrationIncus_CreateThroughTheDaemonsOwnPath (37.63s)
--- PASS: TestIntegrationIncus_ContainerDatasetNamesTheRealDataset (25.48s)
--- PASS: TestIntegrationIncus_InstanceOnAPreExistingEncryptedDataset (0.25s)
--- PASS: TestIntegrationIncus_InstanceInheritsEncryptionFromThePoolRoot (32.51s)
```

All 11 PR checks green. The corrected unit tests were confirmed able to fail by restoring the doubled segment once — they go red on all four cases plus the anti-regression assertion.

Trail of red→green, since a green Incus lane is exactly what is easy to fake:
1. `ContainerDatasetNamesTheRealDataset` failed with the mismatch above → fix → passes.
2. `InstanceOnAPreExistingEncryptedDataset` failed first with `parent does not exist` (a consequence of bug 1), then with `dataset already exists` (the real answer) → now asserts that answer.

## Reviewer notes

- **Read the test-file changes to `storage_pool_test.go` first.** Changing an existing test to make a change pass is normally the wrong move; here the test asserted the implementation back to itself and a real pool disproved both.
- The `dataset already exists` assertion is deliberately narrow: any *other* failure fails the test, so an environment break cannot masquerade as the premise being re-confirmed.
- `pkg/core/zfscrypt/**` and `pkg/core/zfskey/**` joined the lane's path filters now that it covers the encrypted create path.
- #1199 stays open and is **not** closed by this PR. Its remaining step is now a design question with evidence attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
