### PR TITLE
feat(box): thread an explicit storage pool through the create path

### DIFF
--- a/pkg/core/box/box.go
+++ b/pkg/core/box/box.go
@@ -71,6 +71,21 @@ type BoxSpec struct {
 	StaticIP   string // empty = DHCP
 	Monitoring bool
 
+	// StoragePool places the box's root disk on a named backend storage pool,
+	// overriding the daemon-wide default for this create only. Empty keeps
+	// today's behaviour exactly: the daemon's configured pool (#1213), or the
+	// default profile when no disk size is requested either.
+	//
+	// It exists for per-tenant encryption (#1199): each tenant's containers
+	// live on that tenant's own pool, sourced at that tenant's encrypted
+	// dataset, because Incus clones the image to build an instance and a ZFS
+	// clone inherits encryption from its origin rather than its location
+	// (#1335). Placement is therefore per-request, not per-daemon.
+	//
+	// LXC only. The K8s backend expresses the same idea as
+	// ResourceLimits.StorageClass and ignores this.
+	StoragePool string
+
 	// EnablePodman / EnablePodmanPrivileged request Docker/Podman support
 	// inside the box (the privileged variant is gated by policy at the server
 	// layer before it reaches here).

--- a/pkg/core/box/lxc/lxc.go
+++ b/pkg/core/box/lxc/lxc.go
@@ -176,6 +176,7 @@ func specToCreateOptions(spec box.BoxSpec) container.CreateOptions {
 		SSHKeys:                spec.SSHKeys,
 		Labels:                 spec.Labels,
 		StaticIP:               spec.StaticIP,
+		StoragePool:            spec.StoragePool,
 		EnablePodman:           spec.EnablePodman,
 		EnablePodmanPrivileged: spec.EnablePodmanPrivileged,
 		OSType:                 spec.OSType,

--- a/pkg/core/box/lxc/lxc_test.go
+++ b/pkg/core/box/lxc/lxc_test.go
@@ -71,6 +71,7 @@ func TestSpecToCreateOptions(t *testing.T) {
 		Stack:       "python",
 		StackParams: map[string]string{"version": "3.12"},
 		AutoStart:   true,
+		StoragePool: "containarium-tenant-alice",
 	}
 	got := specToCreateOptions(spec)
 	want := container.CreateOptions{
@@ -87,6 +88,7 @@ func TestSpecToCreateOptions(t *testing.T) {
 		Stack:           "python",
 		StackParameters: map[string]string{"version": "3.12"},
 		AutoStart:       true,
+		StoragePool:     "containarium-tenant-alice",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("specToCreateOptions mismatch\n got: %+v\nwant: %+v", got, want)

--- a/pkg/core/container/manager.go
+++ b/pkg/core/container/manager.go
@@ -28,13 +28,20 @@ type Manager struct {
 
 // CreateOptions holds options for creating a container
 type CreateOptions struct {
-	Username               string
-	Image                  string
-	CPU                    string
-	Memory                 string
-	Disk                   string   // Disk size (e.g., "20GB")
-	GPUs                   []string // GPU device IDs for passthrough — one per attached GPU ("0"/"1" or PCI address); empty = none
-	StaticIP               string   // Static IP address (e.g., "10.100.0.100") - empty for DHCP
+	Username string
+	Image    string
+	CPU      string
+	Memory   string
+	Disk     string   // Disk size (e.g., "20GB")
+	GPUs     []string // GPU device IDs for passthrough — one per attached GPU ("0"/"1" or PCI address); empty = none
+	StaticIP string   // Static IP address (e.g., "10.100.0.100") - empty for DHCP
+
+	// StoragePool overrides the daemon-wide storage pool for this create.
+	// Empty uses the configured pool (#1213). See box.BoxSpec.StoragePool for
+	// why placement is per-request: per-tenant encryption puts each tenant's
+	// containers on that tenant's own pool (#1199).
+	StoragePool string
+
 	SSHKeys                []string
 	Labels                 map[string]string // Kubernetes-style labels
 	EnablePodman           bool
@@ -188,15 +195,32 @@ func (m *Manager) Create(opts CreateOptions) (*incus.ContainerInfo, error) {
 		}
 	}
 
-	// Configure root disk device if disk size is specified
+	// Configure the root disk device when a size OR an explicit pool is
+	// requested.
+	//
+	// The pool half is not symmetry for its own sake. A root disk device used
+	// to be emitted only for an explicit size, so a create that named a pool
+	// but no size inherited the DEFAULT PROFILE's root disk instead — the
+	// daemon-wide pool. For an encrypted create that means landing outside the
+	// tenant's encryptionroot, unencrypted, while reporting success, and
+	// nothing about the request would look wrong (#1339).
+	//
+	// A create that names no pool is unaffected in either direction: same
+	// condition, same pool, same device.
 	diskSize := opts.Disk
 	if diskSize == "" && isWindows {
 		diskSize = "50GB"
 	}
-	if diskSize != "" {
+	if diskSize != "" || opts.StoragePool != "" {
+		pool := opts.StoragePool
+		if pool == "" {
+			pool = m.incus.StoragePool()
+		}
 		config.Disk = &incus.DiskDevice{
 			Path: "/",
-			Pool: m.incus.StoragePool(),
+			Pool: pool,
+			// Empty stays empty — DiskDevice.ToMap omits the size key, so the
+			// box gets the pool's own default rather than a size we invented.
 			Size: diskSize,
 		}
 	}

--- a/pkg/core/container/storage_pool_test.go
+++ b/pkg/core/container/storage_pool_test.go
@@ -71,3 +71,116 @@ func TestCreate_DefaultsToTheDefaultPool(t *testing.T) {
 		t.Errorf("root disk pool = %q, want %q", created.Disk.Pool, incus.DefaultStoragePool)
 	}
 }
+
+// Per-request storage pool (#1339), for per-tenant encrypted pools.
+//
+// #1213 made the pool a process-global so a repointed backend could not
+// un-migrate itself. Per-tenant encryption needs the opposite axis: each
+// tenant's containers land on THAT tenant's pool, so the pool becomes a
+// property of the request rather than of the daemon. The global stays as the
+// default; this overrides it per create.
+
+func TestCreate_ExplicitStoragePoolOverridesTheConfiguredOne(t *testing.T) {
+	var created incus.ContainerConfig
+	mock := &incustest.MockBackend{
+		StoragePoolName:     "tenants",
+		CreateContainerFunc: func(cfg incus.ContainerConfig) error { created = cfg; return nil },
+	}
+	m := NewWithBackend(mock)
+
+	_, _ = m.Create(CreateOptions{
+		Username:    "alice",
+		Image:       "ubuntu:24.04",
+		Disk:        "20GB",
+		StoragePool: "containarium-tenant-alice",
+	})
+
+	if created.Disk == nil {
+		t.Fatal("no root disk device configured")
+	}
+	if created.Disk.Pool != "containarium-tenant-alice" {
+		t.Errorf("root disk pool = %q, want %q — the container landed on the daemon-wide pool "+
+			"instead of the tenant's, which for an encrypted create means it is outside that "+
+			"tenant's encryptionroot and unencrypted", created.Disk.Pool, "containarium-tenant-alice")
+	}
+}
+
+// The trap this issue exists to close.
+//
+// A root disk device was only ever emitted when a disk size was requested;
+// with no size the container inherits the DEFAULT PROFILE's root disk — the
+// daemon-wide pool. So an encrypted create that simply did not ask for a disk
+// size would land outside its tenant's encryptionroot, unencrypted, and report
+// success. Nothing about the request would look wrong.
+func TestCreate_ExplicitStoragePoolEmitsARootDiskWithoutADiskSize(t *testing.T) {
+	var created incus.ContainerConfig
+	mock := &incustest.MockBackend{
+		CreateContainerFunc: func(cfg incus.ContainerConfig) error { created = cfg; return nil },
+	}
+	m := NewWithBackend(mock)
+
+	_, _ = m.Create(CreateOptions{
+		Username:    "alice",
+		Image:       "ubuntu:24.04",
+		StoragePool: "containarium-tenant-alice",
+		// No Disk on purpose.
+	})
+
+	if created.Disk == nil {
+		t.Fatal("a create naming a storage pool but no disk size emitted no root disk device — " +
+			"the container inherits the default profile's pool, silently ignoring the pool it " +
+			"was told to use")
+	}
+	if created.Disk.Pool != "containarium-tenant-alice" {
+		t.Errorf("root disk pool = %q, want %q", created.Disk.Pool, "containarium-tenant-alice")
+	}
+	if created.Disk.Size != "" {
+		t.Errorf("root disk size = %q, want empty — the caller asked for no size and one was "+
+			"invented", created.Disk.Size)
+	}
+	if created.Disk.Path != "/" {
+		t.Errorf("root disk path = %q, want /", created.Disk.Path)
+	}
+}
+
+// A create that names no pool must behave exactly as it did before this
+// change — same device, or same absence of one. This is the assertion that
+// keeps every existing deployment untouched.
+func TestCreate_WithoutAnExplicitPoolIsUnchanged(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		disk     string
+		wantDisk bool
+	}{
+		{"a disk size still emits a device on the configured pool", "20GB", true},
+		{"no disk size and no pool still emits nothing", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var created incus.ContainerConfig
+			mock := &incustest.MockBackend{
+				StoragePoolName:     "tenants",
+				CreateContainerFunc: func(cfg incus.ContainerConfig) error { created = cfg; return nil },
+			}
+			m := NewWithBackend(mock)
+
+			_, _ = m.Create(CreateOptions{Username: "bob", Image: "ubuntu:24.04", Disk: tc.disk})
+
+			if tc.wantDisk {
+				if created.Disk == nil {
+					t.Fatal("no root disk device configured")
+				}
+				if created.Disk.Pool != "tenants" {
+					t.Errorf("root disk pool = %q, want the configured %q", created.Disk.Pool, "tenants")
+				}
+				if created.Disk.Size != tc.disk {
+					t.Errorf("root disk size = %q, want %q", created.Disk.Size, tc.disk)
+				}
+				return
+			}
+			if created.Disk != nil {
+				t.Errorf("a create with neither a pool nor a size gained a root disk device %+v — "+
+					"it should still inherit the default profile, as it always has", created.Disk)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1339. Part of #1199. Design: `docs/architecture/per-tenant-encrypted-storage-pools.md` — component 4.

#1213 made the storage pool a **process-global** so a repointed backend could not silently un-migrate itself. Per-tenant encryption needs the other axis: each tenant's containers land on *that tenant's* pool, so placement becomes a property of the request. The global stays as the default; this adds a per-create override.

`BoxSpec.StoragePool` → `CreateOptions.StoragePool` → the root disk device.

## The substantive change is one condition

```go
-if diskSize != "" {
+if diskSize != "" || opts.StoragePool != "" {
```

A root disk device was only ever emitted for an explicit disk **size**. A create naming a pool but no size inherited the **default profile's** root disk instead — the daemon-wide pool. For an encrypted create that means landing outside the tenant's encryptionroot, unencrypted, reporting success, with nothing about the request looking wrong.

That is the same failure shape as #1249 (peer-forward dropped `encrypted`) and #1294 (server accepted `encrypted` and ignored it): the guarantee is dropped somewhere in the middle and no signal survives to say so. Reachable here by *omitting* a disk size, which is a thing a caller does by accident rather than by bug.

## Test evidence

CI run linked in a follow-up comment. Four tests, all in the existing `storage_pool_test.go` next to #1213's:

| Test | Pins |
| --- | --- |
| `TestCreate_ExplicitStoragePoolOverridesTheConfiguredOne` | the per-request pool wins over the daemon-wide one |
| `TestCreate_ExplicitStoragePoolEmitsARootDiskWithoutADiskSize` | **the trap** — pool without size still emits the device, with no invented size |
| `TestCreate_WithoutAnExplicitPoolIsUnchanged` | both directions of the no-pool case: a size still emits on the configured pool, neither still emits nothing |
| `TestSpecToCreateOptions` (extended) | the field survives the box seam |

**Confirmed able to fail**, in both directions — the second mutation matters as much as the first, because a change that *always* emits a device would pass the trap test while altering every existing deployment:

```
reverted to size-only  → FAIL  a create naming a storage pool but no disk size emitted no root disk
                               device — the container inherits the default profile's pool, silently
                               ignoring the pool it was told to use
always emit a device   → FAIL  a create with neither a pool nor a size gained a root disk device
                               {Path:/ Pool:tenants Size:} — it should still inherit the default
                               profile, as it always has
```

Then restored, green.

## One acceptance criterion moved to #1341, deliberately

#1339's third criterion was `TestCreateContainer_EncryptedWithoutAResolvedPoolFails` — an encrypted create resolving an empty pool must fail loudly rather than fall through to the default.

**I did not implement it here, and it would have been misleading to.** The guard needs the `encrypted` flag, which does not reach this layer until #1341 wires it. Writing it now would mean either dead code the linter rejects, or a test driven through `CreateContainer` — which **already refuses every encrypted create** for an unrelated reason (#1294). That test would pass today, keep passing if the guard were deleted, and prove nothing. A green check that cannot fail is the defect this sprint has already hit twice (#1234, and #1344's lane gap).

What this PR delivers instead is the structural half: **a pool that is set can no longer be silently dropped.** I have moved the guard onto #1341 as an explicit acceptance criterion so it is not lost.

## Reviewer notes

- Nothing sets `StoragePool` yet — #1341 is the first caller. Deliberately a leaf.
- `Size` stays empty when the caller gave none; `DiskDevice.ToMap` omits the key, so the box gets the pool's own default rather than a size invented here.
- K8s ignores the field — it expresses the same idea as `ResourceLimits.StorageClass`, and that is noted on the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)