### PR TITLE
feat(server): EnsureTenantStorage replaces PreCreate

### DIFF
--- a/internal/server/encryption_hooks.go
+++ b/internal/server/encryption_hooks.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/footprintai/containarium/pkg/core/zfscrypt"
 	"github.com/footprintai/containarium/pkg/core/zfskey"
@@ -30,18 +31,39 @@ import (
 // re-resolve the same key without holding any state itself.
 const keyRefConfigKey = "user.containarium.zfs_key_ref"
 
-// keyRefStore reads and writes a container's durable KeyRef. An
+// poolConfigKey is the Incus config key recording which storage pool a
+// container was placed on.
+//
+// The pool's source dataset IS the container's encryptionroot, so this is
+// how a restarted daemon finds the dataset to unlock. It is read back rather
+// than recomputed from the tenant naming convention on purpose: recomputing
+// means the day the convention changes, every existing container resolves to
+// a dataset that is not theirs.
+const poolConfigKey = "user.containarium.zfs_pool"
+
+// encryptionStateStore reads and writes a container's durable encryption
+// state: which key unlocks it, and which storage pool it lives on. An
 // interface so the hooks are testable without Incus.
-type keyRefStore interface {
+type encryptionStateStore interface {
 	// GetKeyRef returns the stored ref and whether one was present.
 	GetKeyRef(containerName string) (zfskey.KeyRef, bool, error)
 	// SetKeyRef persists the ref on the container.
 	SetKeyRef(containerName string, ref zfskey.KeyRef) error
+	// GetPool returns the storage pool the container was placed on, or ""
+	// when none was recorded.
+	GetPool(containerName string) (string, error)
+	// SetPool persists the storage pool on the container.
+	SetPool(containerName, pool string) error
 }
 
-// datasetResolver maps a container to the ZFS dataset backing it.
-type datasetResolver interface {
-	DatasetFor(containerName string) (string, error)
+// storagePoolAPI is the slice of the Incus storage-pool surface the hooks
+// need. Narrow on purpose: the hooks provision one pool per tenant and read
+// back where it points, and nothing else.
+type storagePoolAPI interface {
+	// CreateZFSPool creates a zfs-driver pool sourced at an existing dataset.
+	CreateZFSPool(name, source string) error
+	// StoragePoolSource reports where a pool points, and whether it exists.
+	StoragePoolSource(name string) (source string, exists bool, err error)
 }
 
 // encryptionHooks carries the collaborators the lifecycle hooks need.
@@ -51,18 +73,28 @@ type encryptionHooks struct {
 	provider zfskey.KeyProvider
 	zfs      *zfscrypt.Manager
 	cache    *zfskey.Cache
-	refs     keyRefStore
-	datasets datasetResolver
+	refs     encryptionStateStore
+	pools    storagePoolAPI
+	// tenantRoot is the dataset every tenant encryptionroot is created
+	// under, e.g. "incus-local/tenants".
+	tenantRoot string
 }
 
 // enabled reports whether encryption is wired at all.
 func (h *encryptionHooks) enabled() bool {
-	return h != nil && h.provider != nil && h.zfs != nil && h.refs != nil && h.datasets != nil
+	return h != nil && h.provider != nil && h.zfs != nil && h.refs != nil &&
+		h.pools != nil && h.tenantRoot != ""
 }
 
-// encryptedFor returns the dataset and key ref for a container, and
-// false when the container is not encrypted.
-func (h *encryptionHooks) encryptedFor(containerName string) (dataset string, ref zfskey.KeyRef, ok bool, err error) {
+// encryptionRootFor resolves the dataset that is a container's
+// encryptionroot, and false when the container is not encrypted.
+//
+// The encryptionroot is the SOURCE of the storage pool the container lives
+// on, not the container's own dataset. Incus clones the image to build an
+// instance, and a clone inherits its key from the dataset it is made inside
+// (#1335) — so the container's own dataset has no key to load, and the one
+// that does is the pool's source.
+func (h *encryptionHooks) encryptionRootFor(containerName string) (root string, ref zfskey.KeyRef, ok bool, err error) {
 	if !h.enabled() {
 		return "", zfskey.KeyRef{}, false, nil
 	}
@@ -70,71 +102,204 @@ func (h *encryptionHooks) encryptedFor(containerName string) (dataset string, re
 	if err != nil || !present {
 		return "", zfskey.KeyRef{}, false, err
 	}
-	dataset, err = h.datasets.DatasetFor(containerName)
+
+	pool, err := h.refs.GetPool(containerName)
 	if err != nil {
-		return "", zfskey.KeyRef{}, false, err
+		return "", zfskey.KeyRef{}, false, fmt.Errorf("read the storage pool of %s: %w", containerName, err)
 	}
-	return dataset, ref, true, nil
+	// A ref with no pool is a half-written record. Refuse rather than treat
+	// the container as unencrypted: it IS encrypted, and starting it as
+	// though it were not would run it on storage nothing can account for.
+	if pool == "" {
+		return "", zfskey.KeyRef{}, false, fmt.Errorf(
+			"container %s records an encryption key ref but no storage pool, so its encryptionroot "+
+				"cannot be resolved; it was created by a daemon that did not record placement, or the "+
+				"record was written partially", containerName)
+	}
+
+	source, exists, err := h.pools.StoragePoolSource(pool)
+	if err != nil {
+		return "", zfskey.KeyRef{}, false, fmt.Errorf("read storage pool %s for %s: %w", pool, containerName, err)
+	}
+	if !exists {
+		return "", zfskey.KeyRef{}, false, fmt.Errorf(
+			"container %s is recorded on storage pool %s, which does not exist", containerName, pool)
+	}
+	if source == "" {
+		return "", zfskey.KeyRef{}, false, fmt.Errorf(
+			"storage pool %s (for %s) has no source dataset, so there is no encryptionroot to unlock",
+			pool, containerName)
+	}
+	return source, ref, true, nil
 }
 
-// PreCreate provisions the encrypted dataset a new container will be
-// built on, and returns the ref that lets every later hook re-resolve the
-// same key.
+// tenantPoolName is the Incus storage pool a tenant's containers live on.
+// Stable across daemon restarts — it is how the daemon finds the pool it
+// created — and tenant-scoped so `incus storage list` stays readable.
+func tenantPoolName(tenant string) string { return "containarium-tenant-" + tenant }
+
+// tenantDataset is the ZFS dataset that is a tenant's encryptionroot.
 //
-// Order matters and is the whole of AC3. The key is resolved BEFORE
-// anything is created, so a KeyProvider outage fails the create having
-// touched nothing — there is no dataset to clean up because none was made.
-// The only window where a partial dataset can exist is between creating it
-// and persisting its ref, and that window is closed by destroying the
-// dataset if the ref cannot be stored.
-//
-// That rollback is not tidiness. A dataset with no recorded ref is
-// unopenable: nothing knows which key unlocks it, so it is neither usable
-// nor safely reusable, and the next create for the same container would
-// fail on a name that already exists. Leaking one is worse than failing.
-func (h *encryptionHooks) PreCreate(ctx context.Context, containerName, tenant string) (zfskey.KeyRef, error) {
-	if !h.enabled() {
-		return zfskey.KeyRef{}, nil
+// The tenant name is interpolated into a dataset path AND an Incus pool
+// name, so it is validated rather than trusted: a name carrying a slash or
+// a ".." would name somebody else's dataset, and the caller would never
+// know because everything downstream would succeed.
+func tenantDataset(root, tenant string) (string, error) {
+	if root == "" {
+		return "", fmt.Errorf("no tenant dataset root is configured, so a tenant encryptionroot cannot be placed")
 	}
-	if tenant == "" {
-		return zfskey.KeyRef{}, fmt.Errorf("encryption: tenant is required to create %s", containerName)
+	if err := validateTenantName(tenant); err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(root, "/") + "/" + tenant, nil
+}
+
+// validateTenantName rejects anything that could name something other than a
+// single child dataset of the tenant root.
+func validateTenantName(tenant string) error {
+	switch {
+	case tenant == "":
+		return fmt.Errorf("encryption: a tenant is required")
+	case strings.ContainsAny(tenant, "/ \t\n\r"):
+		return fmt.Errorf("invalid tenant %q: it becomes a dataset path component and must not contain a separator or whitespace", tenant)
+	case strings.HasPrefix(tenant, "-"):
+		return fmt.Errorf("invalid tenant %q: a leading dash would be read as a flag by zfs", tenant)
+	case tenant == "." || tenant == "..":
+		return fmt.Errorf("invalid tenant %q: it would name the tenant root itself or its parent", tenant)
+	}
+	return nil
+}
+
+// EnsureTenantStorage makes a tenant's encrypted storage exist and reports
+// the Incus pool a container for that tenant must be created on.
+//
+// Replaces PreCreate. The old hook made a per-CONTAINER encrypted dataset
+// and pointed Incus at it; Incus will not build an instance on a dataset
+// that already exists, because it creates the instance volume by cloning the
+// image snapshot — and a clone inherits encryption from its origin, not from
+// where it is placed (#1335). The encryptionroot therefore has to sit above
+// the level Incus manages: a storage pool sourced at the tenant's encrypted
+// dataset, so images and instances alike are cloned inside it.
+//
+// Order is the whole of #1199 AC3. The key is resolved BEFORE anything is
+// created, so a KeyProvider outage fails having touched nothing.
+//
+// # Rollback is asymmetric, and that is deliberate
+//
+// PreCreate destroyed its dataset whenever a later step failed. That was
+// right when the dataset belonged to one container. It is now the TENANT's
+// encryptionroot, shared by every container they own, so destroying it
+// because an unrelated container's create failed would destroy live data.
+// Only a dataset THIS call created is rolled back; one that was already
+// there is left exactly as found.
+func (h *encryptionHooks) EnsureTenantStorage(ctx context.Context, tenant string) (pool string, ref zfskey.KeyRef, err error) {
+	if !h.enabled() {
+		return "", zfskey.KeyRef{}, nil
 	}
 
-	dataset, err := h.datasets.DatasetFor(containerName)
+	dataset, err := tenantDataset(h.tenantRoot, tenant)
 	if err != nil {
-		return zfskey.KeyRef{}, fmt.Errorf("resolve dataset for %s: %w", containerName, err)
+		return "", zfskey.KeyRef{}, err
 	}
+	pool = tenantPoolName(tenant)
 
 	// Wrap is per-tenant and idempotent: a tenant's containers share one
 	// encryptionroot, so the second container reuses the first's key rather
 	// than minting a second one that ZFS would treat as a separate root.
 	key, ref, err := h.provider.Wrap(ctx, tenant)
 	if err != nil {
-		// Nothing has been created, so there is nothing to undo. The
-		// create fails as Unavailable and the operator retries when key
-		// custody is back.
-		return zfskey.KeyRef{}, fmt.Errorf("cannot obtain an encryption key for %s: %w", containerName, err)
+		// Nothing has been created, so there is nothing to undo. The create
+		// fails as Unavailable and the operator retries when key custody is
+		// back.
+		return "", zfskey.KeyRef{}, fmt.Errorf("cannot obtain an encryption key for tenant %s: %w", tenant, err)
 	}
 	h.cachePut(tenant, key)
 
-	if err := h.zfs.CreateEncrypted(ctx, dataset, key); err != nil {
-		return zfskey.KeyRef{}, fmt.Errorf("cannot create the encrypted dataset for %s: %w", containerName, err)
+	createdDataset, err := h.ensureTenantDataset(ctx, dataset, key)
+	if err != nil {
+		return "", zfskey.KeyRef{}, err
 	}
 
-	if err := h.refs.SetKeyRef(containerName, ref); err != nil {
-		// The dataset exists but nothing records how to unlock it. Undo it.
-		if derr := h.zfs.Destroy(ctx, dataset); derr != nil {
-			// Both failed: say so plainly, because now an operator has to
-			// remove the dataset by hand before the name can be reused.
-			return zfskey.KeyRef{}, fmt.Errorf(
-				"could not record the encryption key ref for %s (%w), and rolling back its "+
-					"dataset %s also failed (%v) — that dataset is unopenable and must be "+
-					"destroyed manually before the name can be reused", containerName, err, dataset, derr)
+	if err := h.ensureTenantPool(ctx, pool, dataset, createdDataset); err != nil {
+		return "", zfskey.KeyRef{}, err
+	}
+	return pool, ref, nil
+}
+
+// ensureTenantDataset makes the tenant's encryptionroot exist, and reports
+// whether this call created it — which is what decides whether a later
+// failure may destroy it.
+//
+// An existing dataset is verified to be its own encryptionroot rather than
+// assumed. A plaintext dataset sitting at the tenant's path is the quietest
+// possible failure: the pool would be built on it, every container inside
+// would be unencrypted, and every daemon-side signal would say otherwise.
+func (h *encryptionHooks) ensureTenantDataset(ctx context.Context, dataset string, key zfskey.Key) (created bool, err error) {
+	exists, err := h.zfs.Exists(ctx, dataset)
+	if err != nil {
+		return false, fmt.Errorf("check the tenant encryptionroot %s: %w", dataset, err)
+	}
+	if !exists {
+		if err := h.zfs.CreateEncrypted(ctx, dataset, key); err != nil {
+			return false, fmt.Errorf("cannot create the tenant encryptionroot %s: %w", dataset, err)
 		}
-		return zfskey.KeyRef{}, fmt.Errorf("could not record the encryption key ref for %s: %w", containerName, err)
+		return true, nil
 	}
 
-	return ref, nil
+	root, err := h.zfs.EncryptionRoot(ctx, dataset)
+	if err != nil {
+		return false, fmt.Errorf(
+			"dataset %s already exists but its encryption state could not be read (%w) — refusing "+
+				"to place a tenant pool on a dataset that may not be encrypted", dataset, err)
+	}
+	if root != dataset {
+		return false, fmt.Errorf(
+			"dataset %s already exists and its encryptionroot is %q, not itself — a tenant pool "+
+				"placed here would not give its containers that tenant's own key", dataset, root)
+	}
+	return false, nil
+}
+
+// ensureTenantPool makes the Incus pool sourced at the tenant's
+// encryptionroot exist, rolling back a dataset this call created if it
+// cannot.
+//
+// A pool that already exists on a DIFFERENT source is refused, never
+// repointed: repointing would move the containers already on it onto another
+// encryptionroot underneath them.
+func (h *encryptionHooks) ensureTenantPool(ctx context.Context, pool, dataset string, createdDataset bool) error {
+	rollback := func(cause error) error {
+		if !createdDataset {
+			// Not ours to destroy — it is another container's encryptionroot.
+			return cause
+		}
+		if derr := h.zfs.Destroy(ctx, dataset); derr != nil {
+			return fmt.Errorf(
+				"%w, and rolling back the tenant encryptionroot %s also failed (%v) — that dataset "+
+					"is unreferenced and must be destroyed manually before the tenant can be "+
+					"provisioned again", cause, dataset, derr)
+		}
+		return cause
+	}
+
+	source, exists, err := h.pools.StoragePoolSource(pool)
+	if err != nil {
+		return rollback(fmt.Errorf("cannot read storage pool %s: %w", pool, err))
+	}
+	if exists {
+		if source != dataset {
+			return rollback(fmt.Errorf(
+				"storage pool %s already exists and is sourced at %q, not the tenant encryptionroot "+
+					"%s; refusing to reuse or repoint it, because its existing containers would be "+
+					"moved onto a different encryptionroot underneath them", pool, source, dataset))
+		}
+		return nil
+	}
+
+	if err := h.pools.CreateZFSPool(pool, dataset); err != nil {
+		return rollback(fmt.Errorf("cannot create storage pool %s on %s: %w", pool, dataset, err))
+	}
+	return nil
 }
 
 // PreStart loads the container's encryption key so its dataset can be
@@ -146,7 +311,7 @@ func (h *encryptionHooks) PreCreate(ctx context.Context, containerName, tenant s
 // refused start, which is at least legible (design §5: KeyProvider down
 // at start time → FailedPrecondition, the LXC stays stopped).
 func (h *encryptionHooks) PreStart(ctx context.Context, containerName string) error {
-	dataset, ref, ok, err := h.encryptedFor(containerName)
+	dataset, ref, ok, err := h.encryptionRootFor(containerName)
 	if err != nil {
 		return fmt.Errorf("resolve encryption state for %s: %w", containerName, err)
 	}
@@ -183,7 +348,7 @@ func (h *encryptionHooks) PreStart(ctx context.Context, containerName string) er
 // container running under the same encryptionroot — a tenant's
 // containers share one — and is not an error.
 func (h *encryptionHooks) PostStop(ctx context.Context, containerName string) {
-	dataset, ref, ok, err := h.encryptedFor(containerName)
+	dataset, ref, ok, err := h.encryptionRootFor(containerName)
 	if err != nil {
 		log.Printf("[encryption] could not resolve encryption state for %s while stopping: %v", containerName, err)
 		return
@@ -210,12 +375,31 @@ func (h *encryptionHooks) PostStop(ctx context.Context, containerName string) {
 	}
 }
 
-// RecordKeyRef persists the ref produced at create time.
-func (h *encryptionHooks) RecordKeyRef(containerName string, ref zfskey.KeyRef) error {
+// RecordPlacement persists what the create produced: the key ref, and the
+// storage pool whose source is the container's encryptionroot.
+//
+// The ref is written FIRST on purpose. A half-written record then leaves a
+// container that refuses to start — encryptionRootFor says so explicitly —
+// rather than one that reads as unencrypted. Encrypted-but-unstartable is
+// legible and recoverable; silently-unencrypted is the failure #1294 exists
+// to prevent.
+func (h *encryptionHooks) RecordPlacement(containerName string, ref zfskey.KeyRef, pool string) error {
 	if !h.enabled() {
 		return fmt.Errorf("encryption is not configured on this daemon")
 	}
-	return h.refs.SetKeyRef(containerName, ref)
+	if pool == "" {
+		return fmt.Errorf("refusing to record %s with no storage pool: its encryptionroot could not be resolved afterwards", containerName)
+	}
+	if err := h.refs.SetKeyRef(containerName, ref); err != nil {
+		return fmt.Errorf("record the encryption key ref for %s: %w", containerName, err)
+	}
+	if err := h.refs.SetPool(containerName, pool); err != nil {
+		return fmt.Errorf(
+			"recorded the encryption key ref for %s but not its storage pool %s (%w) — the "+
+				"container will refuse to start until the pool is recorded, which is deliberate: "+
+				"it is encrypted and nothing can currently name its encryptionroot", containerName, pool, err)
+	}
+	return nil
 }
 
 func (h *encryptionHooks) cacheGet(tenant string) (zfskey.Key, bool) {
@@ -249,15 +433,16 @@ func tenantFromRef(ref zfskey.KeyRef, containerName string) string {
 
 // --- concrete adapters -----------------------------------------------
 
-// incusKeyRefStore persists the KeyRef as an Incus config key on the
-// container, so it survives a daemon restart without the daemon holding
-// any state of its own.
-type incusKeyRefStore struct {
+// incusEncryptionState persists a container's encryption state as Incus
+// config keys on the container, so it survives a daemon restart — and
+// reaches a migration destination — without the daemon holding any state of
+// its own.
+type incusEncryptionState struct {
 	setConfig func(containerName, key, value string) error
 	getConfig func(containerName, key string) (string, error)
 }
 
-func (s incusKeyRefStore) GetKeyRef(containerName string) (zfskey.KeyRef, bool, error) {
+func (s incusEncryptionState) GetKeyRef(containerName string) (zfskey.KeyRef, bool, error) {
 	raw, err := s.getConfig(containerName, keyRefConfigKey)
 	if err != nil {
 		return zfskey.KeyRef{}, false, err
@@ -272,10 +457,36 @@ func (s incusKeyRefStore) GetKeyRef(containerName string) (zfskey.KeyRef, bool, 
 	return ref, true, nil
 }
 
-func (s incusKeyRefStore) SetKeyRef(containerName string, ref zfskey.KeyRef) error {
+func (s incusEncryptionState) SetKeyRef(containerName string, ref zfskey.KeyRef) error {
 	b, err := json.Marshal(ref)
 	if err != nil {
 		return fmt.Errorf("encode key ref: %w", err)
 	}
 	return s.setConfig(containerName, keyRefConfigKey, string(b))
+}
+
+func (s incusEncryptionState) GetPool(containerName string) (string, error) {
+	return s.getConfig(containerName, poolConfigKey)
+}
+
+func (s incusEncryptionState) SetPool(containerName, pool string) error {
+	return s.setConfig(containerName, poolConfigKey, pool)
+}
+
+// incusStoragePools adapts the daemon's Incus client to storagePoolAPI.
+//
+// Function values rather than a client, matching incusEncryptionState: it
+// keeps this file free of a concrete Incus dependency, and lets the caller
+// bind whichever client it already holds.
+type incusStoragePools struct {
+	createPool func(name, source string) error
+	poolSource func(name string) (source string, exists bool, err error)
+}
+
+func (p incusStoragePools) CreateZFSPool(name, source string) error {
+	return p.createPool(name, source)
+}
+
+func (p incusStoragePools) StoragePoolSource(name string) (string, bool, error) {
+	return p.poolSource(name)
 }

--- a/internal/server/encryption_hooks_integration_test.go
+++ b/internal/server/encryption_hooks_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/footprintai/containarium/internal/testsupport/zfspool"
@@ -147,6 +148,15 @@ func (h *harness) createBox(t *testing.T, ctx context.Context, container, tenant
 	return dataset
 }
 
+// mountpointOf maps a dataset under the throwaway pool to its filesystem
+// path. Derived rather than composed from the container name: a container's
+// dataset now lives under its TENANT's encryptionroot, so the two are no
+// longer the same string, and hardcoding the old shape is what made this
+// test fail on the first run of the reshape.
+func (h *harness) mountpointOf(dataset string) string {
+	return filepath.Join(h.pool.Mount, strings.TrimPrefix(dataset, h.pool.Name+"/"))
+}
+
 // AC 1 (#1201): after stopping the last container under an encryptionroot,
 // the key is unloaded and the dataset reads as ciphertext to host root.
 //
@@ -165,7 +175,7 @@ func TestIntegrationEncryption_PostStopLeavesCiphertext(t *testing.T) {
 	// control's plaintext — which sits unencrypted on this same vdev — and
 	// report the encrypted dataset as leaking when it had not.
 	encCanary := append([]byte("ENCRD-"), hookCanary...)
-	secret := filepath.Join(h.pool.Mount, "box-alice", "secret.txt")
+	secret := filepath.Join(h.mountpointOf(dataset), "secret.txt")
 	if err := os.WriteFile(secret, encCanary, 0o600); err != nil {
 		t.Fatalf("write canary: %v", err)
 	}

--- a/internal/server/encryption_hooks_integration_test.go
+++ b/internal/server/encryption_hooks_integration_test.go
@@ -31,23 +31,45 @@ import (
 // canary is the plaintext hunted for in the raw vdev.
 var hookCanary = bytes.Repeat([]byte("CONTAINARIUM-HOOK-CANARY-4e1d8a6b-"), 64)
 
-// memKeyRefStore stands in for the Incus config key the daemon really uses.
-type memKeyRefStore struct{ refs map[string]zfskey.KeyRef }
+// memEncryptionState stands in for the Incus config keys the daemon really
+// uses to record a container's key ref and storage pool.
+type memEncryptionState struct {
+	refs  map[string]zfskey.KeyRef
+	pools map[string]string
+}
 
-func (m *memKeyRefStore) GetKeyRef(name string) (zfskey.KeyRef, bool, error) {
+func (m *memEncryptionState) GetKeyRef(name string) (zfskey.KeyRef, bool, error) {
 	ref, ok := m.refs[name]
 	return ref, ok, nil
 }
 
-func (m *memKeyRefStore) SetKeyRef(name string, ref zfskey.KeyRef) error {
+func (m *memEncryptionState) SetKeyRef(name string, ref zfskey.KeyRef) error {
 	m.refs[name] = ref
 	return nil
 }
 
-// fixedResolver maps container names to datasets.
-type fixedResolver struct{ datasets map[string]string }
+func (m *memEncryptionState) GetPool(name string) (string, error) { return m.pools[name], nil }
 
-func (f fixedResolver) DatasetFor(name string) (string, error) { return f.datasets[name], nil }
+func (m *memEncryptionState) SetPool(name, pool string) error {
+	m.pools[name] = pool
+	return nil
+}
+
+// memPools stands in for Incus's storage-pool API. Incus itself is not
+// available in this lane — that is the incus lane's job (#1332) — so what is
+// under test here is the ZFS half: that the datasets the hooks create really
+// do give each tenant its own encryptionroot.
+type memPools struct{ sources map[string]string }
+
+func (m *memPools) CreateZFSPool(name, source string) error {
+	m.sources[name] = source
+	return nil
+}
+
+func (m *memPools) StoragePoolSource(name string) (string, bool, error) {
+	src, ok := m.sources[name]
+	return src, ok, nil
+}
 
 // unavailableKeys stands in for key custody being unreachable.
 type unavailableKeys struct{}
@@ -65,8 +87,8 @@ type harness struct {
 	pool  *zfspool.Pool
 	hooks *encryptionHooks
 	keys  *zfskey.FileKeyProvider
-	refs  *memKeyRefStore
-	res   fixedResolver
+	refs  *memEncryptionState
+	pools *memPools
 }
 
 func newHarness(t *testing.T) *harness {
@@ -78,37 +100,49 @@ func newHarness(t *testing.T) *harness {
 		t.Fatalf("NewFileKeyProvider: %v", err)
 	}
 	h := &harness{
-		pool: zfspool.New(t),
-		keys: keys,
-		refs: &memKeyRefStore{refs: map[string]zfskey.KeyRef{}},
-		res:  fixedResolver{datasets: map[string]string{}},
+		pool:  zfspool.New(t),
+		keys:  keys,
+		refs:  &memEncryptionState{refs: map[string]zfskey.KeyRef{}, pools: map[string]string{}},
+		pools: &memPools{sources: map[string]string{}},
 	}
 	h.hooks = &encryptionHooks{
 		provider: keys,
 		zfs:      zfscrypt.NewManager(nil), // the real zfs binary
 		cache:    zfskey.NewCache(0),
 		refs:     h.refs,
-		datasets: h.res,
+		pools:    h.pools,
+		// Tenant encryptionroots are children of the throwaway pool, so
+		// tenantDataset produces <pool>/<tenant> — the same shape production
+		// gets from --zfs-tenant-root.
+		tenantRoot: h.pool.Name,
 	}
 	return h
 }
 
-// createBox provisions a box through PreCreate — the hook the create path
-// calls — rather than reproducing its steps here.
+// createBox provisions a box through EnsureTenantStorage — the hook the
+// create path calls — rather than reproducing its steps here.
 //
 // It used to mint the key, create the dataset and record the ref itself,
 // which meant every test below exercised a local imitation of the create
 // path instead of the path itself. A divergence between the two would have
 // left these tests passing against code production does not run.
+//
+// The child dataset stands in for the one Incus would clone from the image
+// INSIDE the tenant pool. Creating it with a plain `zfs create` is faithful
+// to what matters here: it inherits the tenant's key exactly as a clone
+// would, which is the property these tests exist to check.
 func (h *harness) createBox(t *testing.T, ctx context.Context, container, tenant string) string {
 	t.Helper()
-	// The resolver has to know the dataset before the hook asks for it;
-	// in production that mapping comes from the storage layout.
-	dataset := h.pool.Dataset(container)
-	h.res.datasets[container] = dataset
+	pool, ref, err := h.hooks.EnsureTenantStorage(ctx, tenant)
+	if err != nil {
+		t.Fatalf("EnsureTenantStorage(%s): %v", tenant, err)
+	}
 
-	if _, err := h.hooks.PreCreate(ctx, container, tenant); err != nil {
-		t.Fatalf("PreCreate(%s, %s): %v", container, tenant, err)
+	dataset := h.pool.Dataset(tenant) + "/" + container
+	zfspool.Run(t, "zfs", "create", dataset)
+
+	if err := h.hooks.RecordPlacement(container, ref, pool); err != nil {
+		t.Fatalf("RecordPlacement(%s): %v", container, err)
 	}
 	return dataset
 }
@@ -184,40 +218,31 @@ func TestIntegrationEncryption_PostStopKeepsKeyForRunningCoTenant(t *testing.T) 
 	h := newHarness(t)
 
 	// One tenant, one key, one encryptionroot — a parent with two children,
-	// which is the shape the design gives a tenant's containers.
-	key, ref, err := h.keys.Wrap(ctx, "acme")
-	if err != nil {
-		t.Fatalf("KeyProvider.Wrap: %v", err)
-	}
+	// which is the shape the design gives a tenant's containers, and which
+	// EnsureTenantStorage now produces rather than the test assembling it.
 	root := h.pool.Dataset("acme")
-	if err := h.hooks.zfs.CreateEncrypted(ctx, root, key); err != nil {
-		t.Fatalf("CreateEncrypted(root): %v", err)
-	}
-
+	boxes := map[string]string{}
 	for _, box := range []string{"box-one", "box-two"} {
-		ds := root + "/" + box
-		zfspool.Run(t, "zfs", "create", ds)
-		h.res.datasets[box] = ds
-		if err := h.hooks.RecordKeyRef(box, ref); err != nil {
-			t.Fatalf("RecordKeyRef(%s): %v", box, err)
-		}
+		boxes[box] = h.createBox(t, ctx, box, "acme")
 	}
 
 	// Confirm they really do share one encryptionroot — the property the
-	// whole per-tenant isolation claim rests on.
-	for _, box := range []string{"box-one", "box-two"} {
-		got, err := h.hooks.zfs.EncryptionRoot(ctx, h.res.datasets[box])
+	// whole per-tenant isolation claim rests on. Note the direction: each
+	// box INHERITS the tenant root rather than being its own, which is
+	// exactly what makes a pool-per-tenant work at all.
+	for box, ds := range boxes {
+		got, err := h.hooks.zfs.EncryptionRoot(ctx, ds)
 		if err != nil {
 			t.Fatalf("EncryptionRoot(%s): %v", box, err)
 		}
 		if got != root {
-			t.Fatalf("%s encryptionroot = %q, want %q", box, got, root)
+			t.Fatalf("%s encryptionroot = %q, want the tenant root %q", box, got, root)
 		}
 	}
 
 	// Stop box-one while box-two is still "running" (still mounted).
-	zfspool.UnmountIfMounted(t, h.res.datasets["box-one"])
-	if !zfspool.IsMounted(t, h.res.datasets["box-two"]) {
+	zfspool.UnmountIfMounted(t, boxes["box-one"])
+	if !zfspool.IsMounted(t, boxes["box-two"]) {
 		t.Fatal("precondition: box-two should still be mounted")
 	}
 
@@ -277,7 +302,7 @@ func TestIntegrationEncryption_PostStopDoesNotBlockOnFailure(t *testing.T) {
 // and it is the property the whole tenant boundary rests on. If two tenants
 // landed under one root, either tenant's key would unlock the other's data
 // and every unit test would still pass.
-func TestIntegrationEncryption_PreCreateGivesEachTenantItsOwnRoot(t *testing.T) {
+func TestIntegrationEncryption_EnsureTenantStorageGivesEachTenantItsOwnRoot(t *testing.T) {
 	ctx := context.Background()
 	h := newHarness(t)
 
@@ -296,14 +321,19 @@ func TestIntegrationEncryption_PreCreateGivesEachTenantItsOwnRoot(t *testing.T) 
 
 	aliceRoot1, aliceRoot2, bobRoot := rootOf(aliceOne), rootOf(aliceTwo), rootOf(bobOne)
 
-	// Each dataset is its own encryptionroot: PreCreate creates every one
-	// with its own key material rather than inheriting a parent's.
-	if aliceRoot1 != aliceOne {
-		t.Errorf("alice-one's encryptionroot is %q, not itself (%q) — it inherited a parent's "+
-			"key, so it is not independently lockable", aliceRoot1, aliceOne)
+	// Each container inherits its TENANT's encryptionroot — not its own.
+	// That is the inversion #1335 forced: Incus clones the image to make an
+	// instance and a clone takes its key from where it is made, so the key
+	// has to live on the dataset the pool is sourced at.
+	if want := h.pool.Dataset("alice"); aliceRoot1 != want {
+		t.Errorf("alice-one's encryptionroot is %q, want the tenant root %q", aliceRoot1, want)
 	}
-	if bobRoot != bobOne {
-		t.Errorf("bob-one's encryptionroot is %q, not itself (%q)", bobRoot, bobOne)
+	if aliceRoot1 != aliceRoot2 {
+		t.Errorf("one tenant's two containers have encryptionroots %q and %q — they would need "+
+			"two separate load-keys and could not share a pool", aliceRoot1, aliceRoot2)
+	}
+	if want := h.pool.Dataset("bob"); bobRoot != want {
+		t.Errorf("bob-one's encryptionroot is %q, want the tenant root %q", bobRoot, want)
 	}
 
 	// The boundary that matters: no tenant's dataset sits under another's
@@ -317,7 +347,7 @@ func TestIntegrationEncryption_PreCreateGivesEachTenantItsOwnRoot(t *testing.T) 
 // #1199 AC3, against a real pool: the KeyProvider being down must leave no
 // dataset behind. A unit test shows no create was attempted; this shows the
 // pool is genuinely unchanged, which is what "no partial dataset" means.
-func TestIntegrationEncryption_PreCreateLeavesNothingWhenKeysAreUnavailable(t *testing.T) {
+func TestIntegrationEncryption_EnsureTenantStorageLeavesNothingWhenKeysAreUnavailable(t *testing.T) {
 	ctx := context.Background()
 	h := newHarness(t)
 
@@ -328,10 +358,9 @@ func TestIntegrationEncryption_PreCreateLeavesNothingWhenKeysAreUnavailable(t *t
 	h.hooks.provider = unavailableKeys{}
 
 	dataset := h.pool.Dataset("doomed")
-	h.res.datasets["doomed"] = dataset
 
-	if _, err := h.hooks.PreCreate(ctx, "doomed", "alice"); err == nil {
-		t.Fatal("PreCreate succeeded with key custody unavailable")
+	if _, _, err := h.hooks.EnsureTenantStorage(ctx, "doomed"); err == nil {
+		t.Fatal("EnsureTenantStorage succeeded with key custody unavailable")
 	}
 
 	exists, err := h.hooks.zfs.Exists(ctx, dataset)

--- a/internal/server/encryption_hooks_integration_test.go
+++ b/internal/server/encryption_hooks_integration_test.go
@@ -199,7 +199,20 @@ func TestIntegrationEncryption_PostStopLeavesCiphertext(t *testing.T) {
 	}
 
 	// "Stop the container": Incus unmounts, then the hook runs.
+	//
+	// BOTH the container's dataset and the tenant encryptionroot above it
+	// are unmounted, because `zfs unload-key` refuses while anything under
+	// the root is mounted — including the root itself. The old design had
+	// them be the same dataset, so one unmount sufficed; they are now two.
+	//
+	// The harness mounts the tenant root only because zfspool creates the
+	// throwaway pool with an inherited mountpoint. Whether a real Incus
+	// leaves its pool's SOURCE dataset mounted is a different question, and
+	// this lane has no Incus to answer it — see the note on #1341. If it
+	// does, PostStop could never unload and "a stopped container is
+	// ciphertext" would not hold in production.
 	zfspool.UnmountIfMounted(t, dataset)
+	zfspool.UnmountIfMounted(t, h.pool.Dataset("alice"))
 	h.hooks.PostStop(ctx, "box-alice")
 
 	status, err := h.hooks.zfs.KeyStatus(ctx, dataset)

--- a/internal/server/encryption_hooks_test.go
+++ b/internal/server/encryption_hooks_test.go
@@ -48,10 +48,11 @@ func (f *fakeKeyProvider) Load(context.Context, zfskey.KeyRef) (zfskey.Key, erro
 }
 
 type fakeRefStore struct {
-	refs map[string]zfskey.KeyRef
-	err  error
-	// setErr fails only writes, which is the window PreCreate has to roll
-	// back: the dataset exists but nothing records how to unlock it.
+	refs  map[string]zfskey.KeyRef
+	pools map[string]string
+	err   error
+	// setErr fails only writes, which is the window EnsureTenantStorage has
+	// to roll back: the dataset exists but nothing records how to unlock it.
 	setErr error
 }
 
@@ -74,10 +75,54 @@ func (f *fakeRefStore) SetKeyRef(name string, ref zfskey.KeyRef) error {
 	return nil
 }
 
-type fakeDatasets struct{ prefix string }
+func (f *fakeRefStore) GetPool(name string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.pools[name], nil
+}
 
-func (f fakeDatasets) DatasetFor(name string) (string, error) {
-	return f.prefix + "/" + name, nil
+func (f *fakeRefStore) SetPool(name, pool string) error {
+	if f.setErr != nil {
+		return f.setErr
+	}
+	if f.err != nil {
+		return f.err
+	}
+	if f.pools == nil {
+		f.pools = map[string]string{}
+	}
+	f.pools[name] = pool
+	return nil
+}
+
+// fakePools stands in for the Incus storage-pool API. It records what was
+// created so a test can tell "reused an existing pool" from "made a second
+// one" — the difference between a tenant having one encryptionroot and two.
+type fakePools struct {
+	sources   map[string]string
+	created   []string
+	createErr error
+	sourceErr error
+}
+
+func newFakePools() *fakePools { return &fakePools{sources: map[string]string{}} }
+
+func (f *fakePools) CreateZFSPool(name, source string) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	f.created = append(f.created, name)
+	f.sources[name] = source
+	return nil
+}
+
+func (f *fakePools) StoragePoolSource(name string) (string, bool, error) {
+	if f.sourceErr != nil {
+		return "", false, f.sourceErr
+	}
+	src, ok := f.sources[name]
+	return src, ok, nil
 }
 
 // zfsFake records commands and replays canned results, keyed by
@@ -92,9 +137,22 @@ type zfsFake struct {
 func newZFSFake() *zfsFake {
 	return &zfsFake{
 		stdout: map[string]string{"get": "unavailable"},
-		errs:   map[string]error{},
-		stderr: map[string]string{},
+		// `zfs list` fails for a dataset that is not there, which is how
+		// zfscrypt.Exists tells absent from present. Absent is the default
+		// because a tenant's FIRST encrypted container is the case that has
+		// to create everything.
+		errs:   map[string]error{"list": errors.New("exit status 1")},
+		stderr: map[string]string{"list": "cannot open 'x': dataset does not exist"},
 	}
+}
+
+// datasetPresent makes the tenant encryptionroot look already-provisioned,
+// reporting encryptionRoot as its `zfs get encryptionroot` value. Pass the
+// dataset itself for a properly encrypted root, or "-" for a plaintext one.
+func (z *zfsFake) datasetPresent(encryptionRoot string) {
+	delete(z.errs, "list")
+	z.stdout["list"] = "present"
+	z.stdout["get"] = encryptionRoot
 }
 
 func (z *zfsFake) Run(_ context.Context, _ []byte, args ...string) (string, string, error) {
@@ -117,12 +175,24 @@ func (z *zfsFake) ran(substr string) bool {
 
 func testHooks(t *testing.T, z *zfsFake, p *fakeKeyProvider, refs map[string]zfskey.KeyRef) *encryptionHooks {
 	t.Helper()
+	// Every container in refs is placed on its tenant's pool, because that
+	// is what the create path records — PreStart resolves the encryptionroot
+	// through it, and a container with a ref and no pool is a half-written
+	// record the hooks deliberately refuse (see encryptionRootFor).
+	placed := map[string]string{}
+	pools := newFakePools()
+	for name := range refs {
+		tenant := strings.TrimSuffix(name, "-container")
+		placed[name] = tenantPoolName(tenant)
+		pools.sources[tenantPoolName(tenant)] = "tank/tenants/" + tenant
+	}
 	return &encryptionHooks{
-		provider: p,
-		zfs:      zfscrypt.NewManager(z),
-		cache:    zfskey.NewCache(time.Hour),
-		refs:     &fakeRefStore{refs: refs},
-		datasets: fakeDatasets{prefix: "pool/containers"},
+		provider:   p,
+		zfs:        zfscrypt.NewManager(z),
+		cache:      zfskey.NewCache(time.Hour),
+		refs:       &fakeRefStore{refs: refs, pools: placed},
+		pools:      pools,
+		tenantRoot: "tank/tenants",
 	}
 }
 
@@ -178,7 +248,9 @@ func TestPreStartLoadsTheKey(t *testing.T) {
 	if !z.ran("load-key") {
 		t.Errorf("load-key never ran: %v", z.calls)
 	}
-	if !z.ran("pool/containers/alice-container") {
+	// The encryptionroot is the tenant's dataset — the pool's source — not
+	// the container's own, which inherits the key and has none to load.
+	if !z.ran("tank/tenants/alice") {
 		t.Errorf("acted on the wrong dataset: %v", z.calls)
 	}
 }
@@ -320,13 +392,14 @@ func TestPostStopDoesNotPropagateFailures(t *testing.T) {
 	h.PostStop(context.Background(), "alice-container")
 }
 
-// --- key ref persistence ---------------------------------------------
+// --- durable encryption state ----------------------------------------
 
-// The ref must round-trip through the store, since a restarted daemon
-// re-resolves the key from it and holds no state itself.
+// Both halves must round-trip through the store: a restarted daemon
+// re-resolves the key from the ref and the encryptionroot from the pool,
+// and holds no state itself.
 func TestKeyRefRoundTrips(t *testing.T) {
 	stored := map[string]string{}
-	s := incusKeyRefStore{
+	s := incusEncryptionState{
 		setConfig: func(_, k, v string) error { stored[k] = v; return nil },
 		getConfig: func(_, k string) (string, error) { return stored[k], nil },
 	}
@@ -348,12 +421,29 @@ func TestKeyRefRoundTrips(t *testing.T) {
 	}
 
 	// A container with no ref is simply unencrypted, not an error.
-	empty := incusKeyRefStore{
+	empty := incusEncryptionState{
 		setConfig: func(string, string, string) error { return nil },
 		getConfig: func(string, string) (string, error) { return "", nil },
 	}
 	if _, ok, err := empty.GetKeyRef("bob-container"); err != nil || ok {
 		t.Errorf("absent ref: ok=%v err=%v, want ok=false err=nil", ok, err)
+	}
+
+	// The pool travels the same way, under its own key, so the two are
+	// independently readable — a container can be found to have a ref and no
+	// pool, which encryptionRootFor refuses rather than papers over.
+	if err := s.SetPool("alice-container", "containarium-tenant-alice"); err != nil {
+		t.Fatalf("SetPool: %v", err)
+	}
+	gotPool, err := s.GetPool("alice-container")
+	if err != nil {
+		t.Fatalf("GetPool: %v", err)
+	}
+	if gotPool != "containarium-tenant-alice" {
+		t.Errorf("pool round trip = %q, want %q", gotPool, "containarium-tenant-alice")
+	}
+	if stored[keyRefConfigKey] == "" || stored[poolConfigKey] == "" {
+		t.Errorf("the two halves did not land under distinct config keys: %v", stored)
 	}
 }
 
@@ -361,7 +451,7 @@ func TestKeyRefRoundTrips(t *testing.T) {
 // otherwise a mangled config key would downgrade a tenant to plaintext
 // handling without anyone noticing.
 func TestCorruptKeyRefIsAnError(t *testing.T) {
-	s := incusKeyRefStore{
+	s := incusEncryptionState{
 		setConfig: func(string, string, string) error { return nil },
 		getConfig: func(string, string) (string, error) { return "{not json", nil },
 	}
@@ -378,70 +468,121 @@ func sameRef(a, b zfskey.KeyRef) bool {
 	return a.Scheme == b.Scheme && a.URI == b.URI
 }
 
-// testHooksWith is testHooks with a ref store the caller can break.
-func testHooksWith(t *testing.T, z *zfsFake, p *fakeKeyProvider, refs *fakeRefStore) *encryptionHooks {
+// testHooksWith is testHooks with a ref store and pool API the caller can
+// break.
+func testHooksWith(t *testing.T, z *zfsFake, p *fakeKeyProvider, refs *fakeRefStore, pools *fakePools) *encryptionHooks {
 	t.Helper()
+	if refs.pools == nil {
+		refs.pools = map[string]string{}
+	}
+	if pools == nil {
+		pools = newFakePools()
+	}
 	return &encryptionHooks{
-		provider: p,
-		zfs:      zfscrypt.NewManager(z),
-		cache:    zfskey.NewCache(time.Hour),
-		refs:     refs,
-		datasets: fakeDatasets{prefix: "pool/containers"},
+		provider:   p,
+		zfs:        zfscrypt.NewManager(z),
+		cache:      zfskey.NewCache(time.Hour),
+		refs:       refs,
+		pools:      pools,
+		tenantRoot: "tank/tenants",
 	}
 }
 
-func TestPreCreate_CreatesAnEncryptedDatasetAndRecordsItsRef(t *testing.T) {
-	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
-	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}}
+// --- EnsureTenantStorage (#1340) --------------------------------------
+//
+// PreCreate provisioned a per-CONTAINER encrypted dataset and pointed Incus
+// at it. Incus cannot use one: it builds an instance by cloning the image
+// snapshot, and a ZFS clone inherits encryption from its origin rather than
+// its location (#1335). So the hook provisions a per-TENANT encrypted dataset
+// and an Incus pool sourced at it, and the create targets that pool —
+// everything Incus makes inside it inherits the tenant's key.
+//
+// These tests pin orchestration: what runs, in what order, and what is left
+// behind when a step fails. The encryption properties they exist to protect
+// are ZFS's to compute and are asserted against a real pool.
 
-	ref, err := testHooksWith(t, z, p, refs).PreCreate(context.Background(), "alice-container", "alice")
+func TestEnsureTenantStorage_CreatesTheDatasetAndThePoolOnIt(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	pools := newFakePools()
+
+	pool, ref, err := testHooksWith(t, z, p, &fakeRefStore{refs: map[string]zfskey.KeyRef{}}, pools).
+		EnsureTenantStorage(context.Background(), "alice")
 	if err != nil {
-		t.Fatalf("PreCreate: %v", err)
+		t.Fatalf("EnsureTenantStorage: %v", err)
 	}
 
 	if !z.ran("create") || !z.ran("encryption=on") {
 		t.Errorf("no encrypted dataset was created; calls=%v", z.calls)
 	}
-	if !z.ran("pool/containers/alice-container") {
-		t.Errorf("created the wrong dataset; calls=%v", z.calls)
+	if !z.ran("tank/tenants/alice") {
+		t.Errorf("the tenant encryptionroot was not created; calls=%v", z.calls)
 	}
-	if !sameRef(refs.refs["alice-container"], ref) {
-		t.Errorf("stored ref %v, returned %v — every later hook re-resolves the key from the "+
-			"stored one, so a mismatch means the container cannot be started",
-			refs.refs["alice-container"], ref)
+	if pool == "" {
+		t.Fatal("no pool name returned — the create has nothing to place the container on")
+	}
+	if got := pools.sources[pool]; got != "tank/tenants/alice" {
+		t.Errorf("pool %q is sourced at %q, want the tenant's encryptionroot %q — a pool "+
+			"sourced anywhere else gives its containers no key at all", pool, got, "tank/tenants/alice")
+	}
+	if ref.URI == "" {
+		t.Error("no key ref returned; nothing could re-resolve the key later")
 	}
 }
 
 // A tenant's containers share one encryptionroot, and two tenants never do.
-// Wrap is what guarantees it, so PreCreate must ask per tenant — not per
-// container, which would mint a second key and a second root for the same
-// tenant.
-func TestPreCreate_KeysPerTenantNotPerContainer(t *testing.T) {
+// The second container for a tenant must reuse — not re-create, and above all
+// not re-key — what the first one made.
+func TestEnsureTenantStorage_IsIdempotentForASecondContainer(t *testing.T) {
 	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
-	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}}
-	h := testHooksWith(t, z, p, refs)
+	pools := newFakePools()
+	h := testHooksWith(t, z, p, &fakeRefStore{refs: map[string]zfskey.KeyRef{}}, pools)
 	ctx := context.Background()
 
-	first, err := h.PreCreate(ctx, "alice-one", "alice")
+	first, firstRef, err := h.EnsureTenantStorage(ctx, "alice")
 	if err != nil {
 		t.Fatalf("first: %v", err)
 	}
-	second, err := h.PreCreate(ctx, "alice-two", "alice")
+	// The dataset now exists, which is what the second call must notice.
+	z.datasetPresent("tank/tenants/alice")
+
+	second, secondRef, err := h.EnsureTenantStorage(ctx, "alice")
 	if err != nil {
 		t.Fatalf("second: %v", err)
 	}
-	other, err := h.PreCreate(ctx, "bob-one", "bob")
+
+	if second != first {
+		t.Errorf("the same tenant's two containers got pools %q and %q — they would sit under "+
+			"separate encryptionroots", first, second)
+	}
+	if !sameRef(firstRef, secondRef) {
+		t.Errorf("the same tenant got two key refs (%v vs %v)", firstRef, secondRef)
+	}
+	if len(pools.created) != 1 {
+		t.Errorf("the pool was created %d times, want 1 — a second create for a tenant that "+
+			"already has storage is how one tenant ends up with two encryptionroots", len(pools.created))
+	}
+}
+
+func TestEnsureTenantStorage_KeysPerTenantNotPerContainer(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	h := testHooksWith(t, z, p, &fakeRefStore{refs: map[string]zfskey.KeyRef{}}, nil)
+	ctx := context.Background()
+
+	alice, aliceRef, err := h.EnsureTenantStorage(ctx, "alice")
 	if err != nil {
-		t.Fatalf("other tenant: %v", err)
+		t.Fatalf("alice: %v", err)
+	}
+	bob, bobRef, err := h.EnsureTenantStorage(ctx, "bob")
+	if err != nil {
+		t.Fatalf("bob: %v", err)
 	}
 
-	if !sameRef(first, second) {
-		t.Errorf("the same tenant's two containers got different key refs (%v vs %v) — they "+
-			"would sit under separate encryptionroots", first, second)
+	if alice == bob {
+		t.Errorf("two tenants share pool %q — one tenant's key would unlock the other's data, "+
+			"which is the whole boundary this design exists to draw", alice)
 	}
-	if sameRef(other, first) {
-		t.Errorf("two tenants share a key ref (%v) — one tenant's key would unlock another's "+
-			"data, which is the whole boundary this design exists to draw", other)
+	if sameRef(aliceRef, bobRef) {
+		t.Errorf("two tenants share a key ref (%v)", aliceRef)
 	}
 	for _, tenant := range p.wrapped {
 		if tenant != "alice" && tenant != "bob" {
@@ -450,81 +591,302 @@ func TestPreCreate_KeysPerTenantNotPerContainer(t *testing.T) {
 	}
 }
 
-// AC3: KeyProvider down at create time must leave nothing behind. The key is
-// resolved first precisely so there is nothing to clean up.
-func TestPreCreate_KeyProviderDownCreatesNothing(t *testing.T) {
+// #1199 AC3. The key is resolved first precisely so a provider outage fails
+// having touched nothing — there is no dataset to clean up because none was
+// made, and no pool either.
+func TestEnsureTenantStorage_ResolvesTheKeyBeforeCreatingAnything(t *testing.T) {
 	z := newZFSFake()
 	p := &fakeKeyProvider{key: aKey(t), wrapErr: errors.New("kms unreachable")}
-	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}}
+	pools := newFakePools()
 
-	_, err := testHooksWith(t, z, p, refs).PreCreate(context.Background(), "alice-container", "alice")
+	_, _, err := testHooksWith(t, z, p, &fakeRefStore{refs: map[string]zfskey.KeyRef{}}, pools).
+		EnsureTenantStorage(context.Background(), "alice")
 	if err == nil {
-		t.Fatal("PreCreate succeeded with the key provider down")
+		t.Fatal("EnsureTenantStorage succeeded with the key provider down")
 	}
 	if z.ran("create") {
-		t.Errorf("a dataset was created despite having no key; calls=%v — it would be "+
-			"unopenable and would block the name on retry", z.calls)
+		t.Errorf("a dataset was created despite having no key; calls=%v", z.calls)
 	}
-	if len(refs.refs) != 0 {
-		t.Errorf("a key ref was recorded for a container that was never created: %v", refs.refs)
-	}
-}
-
-// The one window where a partial dataset can exist: created, but its ref not
-// recorded. Nothing knows which key unlocks it, so it is neither usable nor
-// safely reusable — it must be destroyed.
-func TestPreCreate_RollsBackTheDatasetWhenTheRefCannotBeStored(t *testing.T) {
-	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
-	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}, setErr: errors.New("incus unreachable")}
-
-	_, err := testHooksWith(t, z, p, refs).PreCreate(context.Background(), "alice-container", "alice")
-	if err == nil {
-		t.Fatal("PreCreate succeeded without recording the key ref")
-	}
-	if !z.ran("destroy") {
-		t.Errorf("the dataset was left behind with no recorded key; calls=%v — nothing can "+
-			"unlock it and the next create fails on a name that already exists", z.calls)
+	if len(pools.created) != 0 {
+		t.Errorf("a storage pool was created despite having no key: %v", pools.created)
 	}
 }
 
-// When the rollback itself fails, the error has to say so — an operator now
-// has to remove the dataset by hand before the name can be reused.
-func TestPreCreate_SaysSoWhenTheRollbackAlsoFails(t *testing.T) {
-	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
-	z.errs["destroy"] = errors.New("dataset busy")
-	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}, setErr: errors.New("incus unreachable")}
+// The rollback asymmetry, and the reason this issue carried a warning.
+//
+// PreCreate destroyed the dataset whenever the follow-up step failed, which
+// was right when the dataset belonged to one container. It is now the
+// TENANT's encryptionroot, shared by every container they own. Destroying it
+// because an unrelated container's create failed would destroy live data.
+//
+// So: roll back only what this call created.
+func TestEnsureTenantStorage_RollsBackOnlyADatasetItCreated(t *testing.T) {
+	t.Run("a dataset this call created is destroyed when the pool cannot be made", func(t *testing.T) {
+		z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+		pools := newFakePools()
+		pools.createErr = errors.New("incus unreachable")
 
-	_, err := testHooksWith(t, z, p, refs).PreCreate(context.Background(), "alice-container", "alice")
-	if err == nil {
-		t.Fatal("PreCreate succeeded")
-	}
-	msg := err.Error()
-	for _, want := range []string{"pool/containers/alice-container", "manually"} {
-		if !strings.Contains(msg, want) {
-			t.Errorf("the error does not mention %q, so an operator cannot act on it: %v", want, err)
+		_, _, err := testHooksWith(t, z, p, &fakeRefStore{refs: map[string]zfskey.KeyRef{}}, pools).
+			EnsureTenantStorage(context.Background(), "alice")
+		if err == nil {
+			t.Fatal("EnsureTenantStorage succeeded with no pool")
 		}
+		if !z.ran("destroy") {
+			t.Errorf("a dataset with no pool on it was left behind; calls=%v — nothing "+
+				"references it and the next attempt fails on a name that already exists", z.calls)
+		}
+	})
+
+	t.Run("a dataset that already existed is left alone", func(t *testing.T) {
+		z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+		// The tenant's encryptionroot is already there, from an earlier
+		// container that is very possibly running right now.
+		z.datasetPresent("tank/tenants/alice")
+		pools := newFakePools()
+		pools.createErr = errors.New("incus unreachable")
+
+		_, _, err := testHooksWith(t, z, p, &fakeRefStore{refs: map[string]zfskey.KeyRef{}}, pools).
+			EnsureTenantStorage(context.Background(), "alice")
+		if err == nil {
+			t.Fatal("EnsureTenantStorage succeeded with no pool")
+		}
+		if z.ran("destroy") {
+			t.Fatalf("the tenant's existing encryptionroot was DESTROYED because one "+
+				"container's create failed; calls=%v — every other container that tenant "+
+				"owns just lost its storage", z.calls)
+		}
+	})
+}
+
+// A pool name that is taken by a pool pointing somewhere else is not ours to
+// reuse and not ours to repoint. Repointing would move an existing pool's
+// containers onto a different encryptionroot underneath them.
+func TestEnsureTenantStorage_RefusesAPoolPointingSomewhereElse(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	pools := newFakePools()
+	h := testHooksWith(t, z, p, &fakeRefStore{refs: map[string]zfskey.KeyRef{}}, pools)
+
+	// Whatever pool name the hook derives, it is already taken by a pool on
+	// somebody else's dataset.
+	pools.sources[tenantPoolName("alice")] = "tank/somewhere/else"
+
+	if _, _, err := h.EnsureTenantStorage(context.Background(), "alice"); err == nil {
+		t.Fatal("a storage pool sourced at another dataset was silently reused — the tenant's " +
+			"containers would land outside the encryptionroot the daemon just recorded for them")
+	}
+	if pools.sources[tenantPoolName("alice")] != "tank/somewhere/else" {
+		t.Error("the existing pool was repointed; its current containers would be moved onto a " +
+			"different encryptionroot underneath them")
+	}
+}
+
+// A dataset already at the tenant's path but NOT encrypted is the quietest
+// possible failure: the pool would be built on plaintext and every container
+// on it reported as encrypted.
+func TestEnsureTenantStorage_RefusesAnExistingPlaintextDataset(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	// `zfs get encryptionroot` reports "-" for an unencrypted dataset.
+	z.datasetPresent("-")
+	pools := newFakePools()
+
+	_, _, err := testHooksWith(t, z, p, &fakeRefStore{refs: map[string]zfskey.KeyRef{}}, pools).
+		EnsureTenantStorage(context.Background(), "alice")
+	if err == nil {
+		t.Fatal("an unencrypted dataset was accepted as a tenant encryptionroot — the pool " +
+			"would be built on plaintext and its containers reported as encrypted")
+	}
+	if len(pools.created) != 0 {
+		t.Errorf("a pool was created on an unencrypted dataset: %v", pools.created)
+	}
+}
+
+func TestEnsureTenantStorage_RequiresAUsableTenantName(t *testing.T) {
+	for _, tenant := range []string{"", "../escape", "a/b", "-flag", "with space", "."} {
+		t.Run("tenant="+tenant, func(t *testing.T) {
+			z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+			pools := newFakePools()
+
+			_, _, err := testHooksWith(t, z, p, &fakeRefStore{refs: map[string]zfskey.KeyRef{}}, pools).
+				EnsureTenantStorage(context.Background(), tenant)
+			if err == nil {
+				t.Errorf("tenant %q was accepted — it is interpolated into a ZFS dataset path "+
+					"and an Incus pool name, so it must not be able to name something else", tenant)
+			}
+			if z.ran("create") || len(pools.created) != 0 {
+				t.Errorf("something was created for an invalid tenant; calls=%v pools=%v",
+					z.calls, pools.created)
+			}
+		})
 	}
 }
 
 // Encryption unconfigured must not fail a create — the flag defaults off and
 // existing deployments keep working.
-func TestPreCreate_NoOpWhenEncryptionIsNotConfigured(t *testing.T) {
+func TestEnsureTenantStorage_NoOpWhenEncryptionIsNotConfigured(t *testing.T) {
 	var h *encryptionHooks
-	ref, err := h.PreCreate(context.Background(), "alice-container", "alice")
+	pool, ref, err := h.EnsureTenantStorage(context.Background(), "alice")
 	if err != nil {
 		t.Errorf("a nil hooks receiver failed the create: %v", err)
 	}
-	if ref.URI != "" || ref.Scheme != "" {
-		t.Errorf("returned a key ref with no provider configured: %v", ref)
+	if pool != "" || ref.URI != "" {
+		t.Errorf("returned placement with no provider configured: pool=%q ref=%v", pool, ref)
 	}
 }
 
-func TestPreCreate_RequiresATenant(t *testing.T) {
+// --- placement is recorded so a restarted daemon can find the key ------
+
+func TestRecordPlacement_StoresBothTheRefAndThePool(t *testing.T) {
 	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
 	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}}
+	h := testHooksWith(t, z, p, refs, nil)
 
-	if _, err := testHooksWith(t, z, p, refs).PreCreate(context.Background(), "orphan", ""); err == nil {
-		t.Error("an empty tenant was accepted — Wrap would key the dataset under a tenant that " +
-			"does not exist, and no later hook could resolve it")
+	ref := zfskey.KeyRef{Scheme: zfskey.SchemeFile, URI: "/keys/alice.key"}
+	if err := h.RecordPlacement("alice-container", ref, "containarium-tenant-alice"); err != nil {
+		t.Fatalf("RecordPlacement: %v", err)
+	}
+
+	if !sameRef(refs.refs["alice-container"], ref) {
+		t.Errorf("stored ref %v, want %v", refs.refs["alice-container"], ref)
+	}
+	if refs.pools["alice-container"] != "containarium-tenant-alice" {
+		t.Errorf("stored pool %q, want %q — without it the daemon cannot find the container's "+
+			"encryptionroot after a restart", refs.pools["alice-container"], "containarium-tenant-alice")
+	}
+}
+
+// The ref is written before the pool, so a half-written record leaves a
+// container that REFUSES to start rather than one treated as unencrypted.
+// Encrypted-but-unstartable is legible and recoverable; silently-unencrypted
+// is the failure #1294 exists to prevent.
+func TestRecordPlacement_APartialWriteFailsClosed(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}, setErr: errors.New("incus unreachable")}
+	h := testHooksWith(t, z, p, refs, nil)
+
+	if err := h.RecordPlacement("alice-container", zfskey.KeyRef{Scheme: zfskey.SchemeFile, URI: "/k"}, "p"); err == nil {
+		t.Fatal("a failed placement write was reported as success")
+	}
+}
+
+// A container carrying a key ref but no pool cannot have its encryptionroot
+// resolved. It must refuse to start, and say why — treating it as
+// unencrypted would start it on storage nobody can account for.
+func TestPreStart_RefusesAContainerWithARefButNoPool(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	refs := &fakeRefStore{
+		refs:  map[string]zfskey.KeyRef{"alice-container": {Scheme: zfskey.SchemeFile, URI: "/k"}},
+		pools: map[string]string{}, // no pool recorded
+	}
+
+	err := testHooksWith(t, z, p, refs, nil).PreStart(context.Background(), "alice-container")
+	if err == nil {
+		t.Fatal("a container with an encryption key ref and no recorded pool was started — " +
+			"nothing knows which dataset to unlock, so it would run on storage the daemon " +
+			"cannot account for")
+	}
+	if !strings.Contains(err.Error(), "pool") {
+		t.Errorf("the error does not name the missing pool, so an operator cannot act on it: %v", err)
+	}
+}
+
+// PreStart loads the key on the tenant's encryptionroot — the pool's source
+// dataset — not on the container's own dataset, which inherits it and has no
+// key of its own to load.
+func TestPreStart_LoadsTheKeyOnThePoolRootNotTheContainer(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	refs := &fakeRefStore{
+		refs:  map[string]zfskey.KeyRef{"alice-container": {Scheme: zfskey.SchemeFile, URI: "/keys/alice.key"}},
+		pools: map[string]string{"alice-container": "containarium-tenant-alice"},
+	}
+	pools := newFakePools()
+	pools.sources["containarium-tenant-alice"] = "tank/tenants/alice"
+
+	if err := testHooksWith(t, z, p, refs, pools).PreStart(context.Background(), "alice-container"); err != nil {
+		t.Fatalf("PreStart: %v", err)
+	}
+
+	if !z.ran("load-key") {
+		t.Fatalf("no key was loaded; calls=%v", z.calls)
+	}
+	if !z.ran("tank/tenants/alice") {
+		t.Errorf("the key was loaded on the wrong dataset; calls=%v — the encryptionroot is the "+
+			"pool's source, and the container's own dataset has no key to load", z.calls)
+	}
+	if z.ran("alice-container") {
+		t.Errorf("a zfs command named the container dataset; calls=%v", z.calls)
+	}
+}
+
+// The pool adapter is bound to whichever Incus client the daemon already
+// holds, so what needs pinning is that it passes both arguments through
+// untouched — a source that arrives altered points the tenant pool at the
+// wrong dataset, which is how a container ends up unencrypted while every
+// daemon-side signal says otherwise (#1336 was that class of bug).
+func TestIncusStoragePoolsPassesItsArgumentsThrough(t *testing.T) {
+	var gotName, gotSource string
+	p := incusStoragePools{
+		createPool: func(name, source string) error { gotName, gotSource = name, source; return nil },
+		poolSource: func(name string) (string, bool, error) { return "tank/tenants/" + name, true, nil },
+	}
+
+	if err := p.CreateZFSPool("containarium-tenant-alice", "tank/tenants/alice"); err != nil {
+		t.Fatalf("CreateZFSPool: %v", err)
+	}
+	if gotName != "containarium-tenant-alice" || gotSource != "tank/tenants/alice" {
+		t.Errorf("passed through (%q, %q), want (%q, %q)",
+			gotName, gotSource, "containarium-tenant-alice", "tank/tenants/alice")
+	}
+
+	src, exists, err := p.StoragePoolSource("alice")
+	if err != nil || !exists || src != "tank/tenants/alice" {
+		t.Errorf("StoragePoolSource = (%q, %v, %v)", src, exists, err)
+	}
+}
+
+// --- naming ------------------------------------------------------------
+
+func TestTenantDataset(t *testing.T) {
+	for _, tc := range []struct {
+		name, root, tenant, want string
+		wantErr                  bool
+	}{
+		{name: "nested root", root: "tank/tenants", tenant: "alice", want: "tank/tenants/alice"},
+		{name: "trailing slash is tolerated", root: "tank/tenants/", tenant: "alice", want: "tank/tenants/alice"},
+		{name: "empty root", root: "", tenant: "alice", wantErr: true},
+		{name: "bare pool root", root: "tank", tenant: "alice", want: "tank/alice"},
+		{name: "empty tenant", root: "tank/tenants", tenant: "", wantErr: true},
+		{name: "tenant with a slash", root: "tank/tenants", tenant: "a/b", wantErr: true},
+		{name: "tenant escaping upward", root: "tank/tenants", tenant: "..", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tenantDataset(tc.root, tc.tenant)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("tenantDataset(%q, %q) = %q, want an error", tc.root, tc.tenant, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("tenantDataset(%q, %q): %v", tc.root, tc.tenant, err)
+			}
+			if got != tc.want {
+				t.Errorf("tenantDataset(%q, %q) = %q, want %q", tc.root, tc.tenant, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTenantPoolName_IsStableAndTenantScoped(t *testing.T) {
+	alice, bob := tenantPoolName("alice"), tenantPoolName("bob")
+	if alice == bob {
+		t.Fatalf("two tenants derive the same pool name %q", alice)
+	}
+	if alice != tenantPoolName("alice") {
+		t.Error("the pool name is not stable across calls — a restarted daemon would not find " +
+			"the pool it created")
+	}
+	if !strings.Contains(alice, "alice") {
+		t.Errorf("pool name %q does not identify the tenant, which makes an operator's `incus "+
+			"storage list` unreadable", alice)
 	}
 }


### PR DESCRIPTION
Closes #1340. Part of #1199. Design: `docs/architecture/per-tenant-encrypted-storage-pools.md` — component 5.

`PreCreate` provisioned a per-**container** encrypted dataset and pointed Incus at it. Incus will not build an instance on a dataset that already exists, because it creates the instance volume by cloning the image snapshot — and a ZFS clone inherits encryption from its **origin**, not from where it is placed (#1335). So the encryptionroot moves above the level Incus manages: a storage pool sourced at the tenant's encrypted dataset, with images and instances both cloned inside it.

## Review this first: the rollback rule inverts

`PreCreate` destroyed its dataset whenever a later step failed. That was correct when the dataset belonged to one container. **It is now the tenant's encryptionroot, shared by every container they own** — so destroying it because an unrelated container's create failed would destroy live data for containers that are very possibly running.

| Stage | On failure |
| --- | --- |
| `Wrap` fails | Nothing created. (unchanged) |
| `CreateEncrypted` fails | Nothing to undo — the dataset is what failed. |
| pool create fails, dataset created **by this call** | Destroy it — unreferenced and unopenable. |
| pool create fails, dataset **already existed** | **Leave it.** It is another container's encryptionroot. |

`TestEnsureTenantStorage_RollsBackOnlyADatasetItCreated` asserts both directions. Reverting to the old unconditional rule fails the second:

```
--- FAIL: .../a_dataset_that_already_existed_is_left_alone
    the tenant's existing encryptionroot was DESTROYED because one container's create failed;
    calls=[list ... get ... destroy tank/tenants/alice] — every other container that tenant owns
    just lost its storage
```

## Two more fail-closed guards, both for silent-plaintext failure modes

- **An existing dataset is verified to be its own encryptionroot, not assumed.** A plaintext dataset sitting at the tenant's path is the quietest possible failure: the pool gets built on it, every container inside is unencrypted, and every daemon-side signal says otherwise.
- **A pool already sourced elsewhere is refused, never repointed.** Repointing would move the containers already on it onto a different encryptionroot underneath them.

## Placement is recorded, not recomputed

New `user.containarium.zfs_pool` alongside the existing key ref. `PreStart`/`PostStop` resolve the encryptionroot as *the pool's source*, because the container's own dataset inherits the key and has none of its own to load.

The ref is written **first**, deliberately: a half-written record then leaves a container that refuses to start (with an error naming the missing pool) rather than one that reads as unencrypted. Encrypted-but-unstartable is legible and recoverable; silently-unencrypted is what #1294 exists to prevent.

## Test evidence

CI run linked in a follow-up comment. 15 unit tests covering the five acceptance criteria plus the naming helpers and both adapters; the ZFS integration tests were updated to the new shape and still run on the `zfs-encryption` lane.

Acceptance criteria:

- [x] `TestEnsureTenantStorage_ResolvesTheKeyBeforeCreatingAnything` — provider outage leaves zero ZFS **and** zero pool calls
- [x] `TestEnsureTenantStorage_IsIdempotentForASecondContainer` — creates nothing, same pool, pool created exactly once
- [x] `TestEnsureTenantStorage_RollsBackOnlyADatasetItCreated` — table over the asymmetry above
- [x] `TestEnsureTenantStorage_RefusesAPoolPointingSomewhereElse` — fails closed, never repoints
- [x] `TestPreStart_LoadsTheKeyOnThePoolRootNotTheContainer` — and asserts no zfs command names the container dataset

Plus `..._RefusesAnExistingPlaintextDataset`, `..._RequiresAUsableTenantName` (the tenant is interpolated into a dataset path *and* a pool name, so `../escape`, `a/b`, `-flag` are rejected), and `TestRecordPlacement_APartialWriteFailsClosed`.

**Integration tests changed meaning, on purpose.** `TestIntegrationEncryption_EnsureTenantStorageGivesEachTenantItsOwnRoot` used to assert each container's dataset was *its own* encryptionroot. It now asserts each container **inherits its tenant's** root, and that one tenant's two containers share one. That inversion is the design change, and asserting the old property would now assert the thing that cannot work.

## Note on the daemon flag

`--zfs-tenant-root` is in #1340's scope but is **not here**: nothing reads it until the hooks are constructed, which is #1341. A flag stored and never read is dead config, and the linter agrees. What landed instead is `tenantRoot` on the hooks plus a tested `tenantDataset(root, tenant)`, so #1341 wires the flag to a reader that already exists. Flagged on the issue rather than quietly dropped — this is the second AC to move to #1341, which is a sign I drew the #1340/#1341 boundary slightly wrong when scoping, not that the work is missing.

## Reviewer notes

- ~810 lines, over half of it tests. Nothing constructs these hooks yet — #1341 is the first caller.
- `incusKeyRefStore` → `incusEncryptionState` (it now stores two things); new `incusStoragePools` follows the same func-value idiom, so this file still has no concrete Incus dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)