### PR TITLE
feat(server): wire the encrypted create — --encrypted now encrypts

### DIFF
--- a/.github/workflows/incus-create.yml
+++ b/.github/workflows/incus-create.yml
@@ -27,6 +27,10 @@ on:
       # The encrypted-create path this lane now covers (#1199).
       - 'pkg/core/zfscrypt/**'
       - 'pkg/core/zfskey/**'
+      # The server wiring that decides whether a container is encrypted at
+      # all (#1341). Without this the wiring lands untested by the lane that
+      # exists to test it.
+      - 'internal/server/**'
       - '.github/workflows/incus-create.yml'
   # No `branches:` filter — a base filter leaves stacked PRs with no checks
   # at all, which looks the same as checks not having started (#1215).
@@ -39,6 +43,10 @@ on:
       # The encrypted-create path this lane now covers (#1199).
       - 'pkg/core/zfscrypt/**'
       - 'pkg/core/zfskey/**'
+      # The server wiring that decides whether a container is encrypted at
+      # all (#1341). Without this the wiring lands untested by the lane that
+      # exists to test it.
+      - 'internal/server/**'
       - '.github/workflows/incus-create.yml'
 
 permissions:
@@ -179,7 +187,7 @@ jobs:
         run: |
           set -euo pipefail
           sudo -E env "PATH=$PATH" go test -tags=incus -v -count=1 -timeout 40m \
-            ./pkg/core/box/lxc/ ./pkg/core/incus/ -run 'TestIntegrationIncus' | tee incus-test.log
+            ./pkg/core/box/lxc/ ./pkg/core/incus/ ./internal/server/ -run 'TestIntegrationIncus' | tee incus-test.log
 
       # A skip here means the environment check above passed and the test
       # decided otherwise — a contradiction worth failing on rather than

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -58,6 +58,7 @@ var (
 	localBackendID         string
 	pool                   string
 	storagePool            string
+	zfsTenantRoot          string
 	region                 string
 	cpuOvercommitFactor    float64
 	cpuOvercommitEnforce   bool
@@ -155,6 +156,7 @@ func init() {
 	daemonCmd.Flags().StringVar(&localBackendID, "backend-id", "", "This daemon's backend ID (defaults to hostname)")
 	daemonCmd.Flags().StringVar(&pool, "pool", "", "Pool name to scope sentinel peer discovery (empty = unscoped, see all peers)")
 	daemonCmd.Flags().StringVar(&storagePool, "storage-pool", "", "Incus STORAGE pool containers are created on (default \"default\"). Unrelated to --pool, which names a sentinel-fronted cluster. Point this at a second, per-container-volume pool to migrate tenants off a shared-filesystem `dir` pool without every newly created tenant landing back on it (#1206, #1213).")
+	daemonCmd.Flags().StringVar(&zfsTenantRoot, "zfs-tenant-root", "", "ZFS dataset each tenant's encryptionroot is created under for per-tenant encryption (#1199), e.g. \"incus-local/tenants\". Empty derives it from the storage pool's source. Has no effect until key custody is configured — an encrypted create is refused without a KeyProvider.")
 	daemonCmd.Flags().StringVar(&region, "region", "", "Region this backend serves; recorded in its capability profile (containarium backends profile). Empty falls back to the --pool name.")
 	daemonCmd.Flags().StringVar(&publicHostname, "public-hostname", "", "Public hostname this primary serves (e.g. prod.example.com); enables sentinel primary registration")
 	daemonCmd.Flags().StringSliceVar(&publicAliases, "public-aliases", nil, "Additional hostnames the primary's Caddy serves (e.g. api.example.com,voice.example.com); the sentinel SNI router treats these as aliases of --public-hostname")
@@ -576,6 +578,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		ProxyProtocolTrusted: proxyProtocolTrusted,
 		OTelDropLabels:       otelDropLabels,
 		Runtime:              runtime,
+		ZFSTenantRoot:        zfsTenantRoot,
 	}
 
 	// Create dual server

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -356,23 +356,16 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	if err := validateCreateContainerBounds(req); err != nil {
 		return nil, err
 	}
-	// Refuse a request for encryption the daemon cannot actually deliver.
+	// #1294's unconditional refusal used to sit here, on the grounds that the
+	// create path did not provision an encrypted dataset. It now does
+	// (#1341), so that statement is no longer true and the blanket refusal is
+	// gone.
 	//
-	// The create path does not yet provision an encrypted dataset (#1199:
-	// the pre-create hook exists and is proven against a real pool, but
-	// wiring it needs Incus's "instance from an existing dataset" path).
-	// Until it does, honouring this flag by ignoring it hands the caller a
-	// guarantee they do not have — the container is created on the pool-wide
-	// key, and nothing says so.
-	//
-	// The proto is explicit that this must fail rather than fall back, and
-	// so is the CLI's own help text. It was the code that disagreed.
-	if req.Encrypted {
-		return nil, status.Error(codes.FailedPrecondition,
-			"per-container encryption is not available on this daemon yet: the create path "+
-				"does not provision an encrypted dataset (#1199). Refusing rather than creating "+
-				"an unencrypted container, which is what this flag is documented to do.")
-	}
+	// What has NOT changed is the promise: validateEncryption below still
+	// refuses an encrypted create on a daemon with no KeyProvider, which is
+	// every OSS daemon until an operator configures one (#1342). That refusal
+	// is the load-bearing one — it is what stops the flag being accepted and
+	// silently ignored — and it is the last thing to go.
 	// Birth TTL (#523): reject an out-of-range TTL before we provision
 	// anything — fail fast rather than create a box and then reject its
 	// death date. Same bound (7 days) as SetContainerTTL; 0 = no TTL.
@@ -398,6 +391,35 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	}
 	if err := validateEncryption(req, s.keyProvider); err != nil {
 		return nil, err
+	}
+
+	// Per-tenant encrypted storage (#1341). Resolved BEFORE anything is
+	// provisioned: EnsureTenantStorage resolves the key first, so a key
+	// custody outage fails here having created nothing.
+	//
+	// A tenant's containers share one Incus storage pool, sourced at that
+	// tenant's encrypted dataset. Everything Incus creates inside it — images
+	// and instances alike — inherits that tenant's key, which is the only way
+	// an instance can be encrypted at all: Incus builds one by cloning the
+	// image, and a ZFS clone takes its key from where it is made (#1335).
+	var encPool string
+	var encRef zfskey.KeyRef
+	if req.GetEncrypted() {
+		encPool, encRef, err = s.encryption.EnsureTenantStorage(ctx, encryptionTenantFor(req))
+		if err != nil {
+			return nil, status.Error(codes.Unavailable, err.Error())
+		}
+		// A resolved-empty pool means encryption is half-wired: a KeyProvider
+		// is configured but the hooks are not. Falling through would create
+		// the container on the daemon's default pool — unencrypted, reported
+		// as encrypted, which is precisely what #1294 refused to ship.
+		if encPool == "" {
+			return nil, status.Error(codes.FailedPrecondition,
+				"encrypted=true resolved no storage pool for this tenant: the daemon has key "+
+					"custody configured but no encryption storage wired, so the container would "+
+					"be created on the default pool without encryption. Refusing rather than "+
+					"delivering plaintext under an encryption guarantee")
+		}
 	}
 
 	// Pool resolution — if a pool is requested, either validate that
@@ -503,6 +525,9 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		GitRef:        req.GitRef,
 		GitCredential: req.GitCredential,
 		WorkspacePath: req.WorkspacePath,
+		// Empty for an unencrypted create, which leaves placement exactly as
+		// it was: the daemon-wide pool, or the default profile (#1339).
+		StoragePool: encPool,
 	}
 	// Phase 2.5 follow-up — load the OTel bearer for
 	// monitoring=true containers. Best-effort: an error
@@ -638,6 +663,16 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 		asyncHandledInline = true
 		go func() {
 			info, err := s.boxes().Create(context.Background(), spec)
+			// Same contract as the sync path: an encrypted box whose
+			// placement cannot be recorded is removed rather than left
+			// unopenable. The caller already has its CREATING response, so
+			// this surfaces through the pending state like every other
+			// async failure.
+			if err == nil {
+				if rerr := s.recordEncryptedPlacement(req, info.Ref.Name, encRef, encPool); rerr != nil {
+					err, info = rerr, nil
+				}
+			}
 
 			// Phase 3.1 Phase-C: post-pull verification.
 			// In async mode the HTTP response has already
@@ -763,6 +798,14 @@ func (s *ContainerServer) CreateContainer(ctx context.Context, req *pb.CreateCon
 	info, err := s.boxes().Create(ctx, spec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create container: %w", err)
+	}
+
+	// Record which key unlocks this container and which pool it lives on,
+	// before anything else touches it. See recordEncryptedPlacement: a
+	// container whose placement cannot be recorded is deleted, because it is
+	// encrypted and nothing can name its encryptionroot.
+	if err := s.recordEncryptedPlacement(req, info.Ref.Name, encRef, encPool); err != nil {
+		return nil, err
 	}
 
 	// Phase 3.1 Phase-C: post-pull defense-in-depth.

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -288,11 +288,10 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 		if tenantRoot == "" {
 			tenantRoot, derived = DefaultTenantRoot(encClient), true
 		}
-		switch {
-		case tenantRoot == "":
+		if tenantRoot == "" {
 			log.Printf("[encryption] per-tenant dataset root could not be derived from storage pool %q; "+
 				"encrypted creates will be refused until --zfs-tenant-root is set", encClient.StoragePool())
-		default:
+		} else {
 			containerServer.SetEncryptionStorage(tenantRoot, encClient)
 			how := "--zfs-tenant-root"
 			if derived {

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -145,6 +145,11 @@ type DualServerConfig struct {
 	// Runtime selects the box-lifecycle backend: "lxc" (default) or "k8s".
 	// Set via CONTAINARIUM_RUNTIME env or --runtime flag on daemon start.
 	Runtime string
+
+	// ZFSTenantRoot is the ZFS dataset each tenant's encryptionroot is
+	// created under (--zfs-tenant-root). Empty derives it from the daemon's
+	// storage pool; see DefaultTenantRoot.
+	ZFSTenantRoot string
 }
 
 // managementRouteDomains returns the domains the daemon serves its own
@@ -268,6 +273,34 @@ func NewDualServer(config *DualServerConfig) (*DualServer, error) {
 	// default and resume-on-restart silently never fired (caught live
 	// on a GCP backend while validating #1070).
 	containerServer.SetDaemonConfigStore(config.DaemonConfigStore)
+
+	// Per-tenant encrypted storage (#1341). Wired here so the create path can
+	// place an encrypted container on its tenant's pool; INERT until a
+	// KeyProvider is also configured (#1342), because encryptionHooks.enabled()
+	// is false without one. Nothing an operator can observe changes today.
+	//
+	// Failing to reach Incus (the k8s runtime, or a daemon with no local
+	// Incus) leaves encryption unwired, which makes an encrypted create fail
+	// loudly rather than land somewhere arbitrary.
+	if encClient, err := incus.New(); err == nil {
+		tenantRoot := config.ZFSTenantRoot
+		derived := false
+		if tenantRoot == "" {
+			tenantRoot, derived = DefaultTenantRoot(encClient), true
+		}
+		switch {
+		case tenantRoot == "":
+			log.Printf("[encryption] per-tenant dataset root could not be derived from storage pool %q; "+
+				"encrypted creates will be refused until --zfs-tenant-root is set", encClient.StoragePool())
+		default:
+			containerServer.SetEncryptionStorage(tenantRoot, encClient)
+			how := "--zfs-tenant-root"
+			if derived {
+				how = "derived from the storage pool"
+			}
+			log.Printf("[encryption] per-tenant dataset root: %s (%s)", tenantRoot, how)
+		}
+	}
 	// NOTE: metrics-export resume (StartMetricsExportIfEnabled) is
 	// deliberately NOT called here. The resumed collector snapshots the
 	// daemon's backend_id/region at build time, and neither is populated

--- a/internal/server/encrypted_create.go
+++ b/internal/server/encrypted_create.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"log"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Wiring for the encrypted create path (#1341), per
+// docs/architecture/per-tenant-encrypted-storage-pools.md.
+
+// zfsKeyCacheTTL bounds how long a tenant's key stays resident after its last
+// use. Long enough that a stop/start cycle does not re-hit key custody, short
+// enough that an idle tenant's key does not sit in daemon memory forever.
+const zfsKeyCacheTTL = 30 * time.Minute
+
+// encryptionTenantFor decides whose key a container is encrypted with.
+//
+// On this build the username IS the tenant: validateTenantID rejects any
+// tenant_id other than unset or "default", so there is no other tenancy to
+// scope a key by — and scoping by "default" would put every user of the
+// daemon under one encryptionroot. No isolation at all, and silently.
+//
+// A real tenant_id wins where one exists (the cloud build's org-scoped
+// tenancy), because an org's several users must share one encryptionroot or
+// they cannot share datasets.
+func encryptionTenantFor(req *pb.CreateContainerRequest) string {
+	if id := req.GetTenantId(); id != "" && id != defaultTenantID {
+		return id
+	}
+	return req.GetUsername()
+}
+
+// recordEncryptedPlacement stores the key ref and storage pool on a
+// just-created container, and removes the container if it cannot.
+//
+// Deleting is the right failure mode, not tidiness. The container's data is
+// already encrypted under the tenant's key; without a recorded placement
+// nothing can name its encryptionroot, so it can never be started and never
+// safely reused — and its name would block the next create. Leaving one
+// behind is worse than failing the create.
+//
+// A no-op for an unencrypted create, which is every container today.
+func (s *ContainerServer) recordEncryptedPlacement(req *pb.CreateContainerRequest, containerName string, ref zfskey.KeyRef, pool string) error {
+	if !req.GetEncrypted() {
+		return nil
+	}
+
+	err := s.encryption.RecordPlacement(containerName, ref, pool)
+	if err == nil {
+		return nil
+	}
+
+	log.Printf("[encryption] could not record placement for %s (pool %s): %v — removing the container, "+
+		"because nothing could name its encryptionroot afterwards", containerName, pool, err)
+
+	if delErr := s.manager.Delete(req.GetUsername(), true); delErr != nil {
+		return status.Errorf(codes.Internal,
+			"created %s but could not record its encryption placement (%v), and removing it also "+
+				"failed (%v) — the container is encrypted under tenant %q with nothing recording "+
+				"which key unlocks it, and must be deleted by hand before the name can be reused",
+			containerName, err, delErr, encryptionTenantFor(req))
+	}
+	return status.Errorf(codes.Internal,
+		"created %s but could not record its encryption placement (%v); the container was removed "+
+			"rather than left unopenable", containerName, err)
+}
+
+// SetEncryptionStorage wires the per-tenant encryption hooks onto the server.
+//
+// Called once at daemon startup with the tenant dataset root and the Incus
+// client the daemon already holds. The hooks stay inert until a KeyProvider
+// is also configured (#1342) — encryptionHooks.enabled() is false without one
+// — so wiring this early changes nothing an operator can observe.
+//
+// That ordering is deliberate and load-bearing: a KeyProvider configured
+// before the create path could genuinely encrypt would make
+// validateEncryption start PASSING while the daemon handed back plaintext.
+func (s *ContainerServer) SetEncryptionStorage(tenantRoot string, client *incus.Client) {
+	if tenantRoot == "" || client == nil {
+		return
+	}
+	s.encryption = &encryptionHooks{
+		provider: s.keyProvider, // nil until #1342, which keeps the hooks inert
+		zfs:      zfscrypt.NewManager(nil),
+		cache:    zfskey.NewCache(zfsKeyCacheTTL),
+		refs: incusEncryptionState{
+			setConfig: client.UpdateContainerConfig,
+			getConfig: func(containerName, key string) (string, error) {
+				cfg, _, err := client.GetRawInstance(containerName)
+				if err != nil {
+					return "", err
+				}
+				return cfg[key], nil
+			},
+		},
+		pools: incusStoragePools{
+			createPool: client.CreateZFSPool,
+			poolSource: client.StoragePoolSource,
+		},
+		tenantRoot: tenantRoot,
+	}
+}
+
+// DefaultTenantRoot derives the tenant dataset root from the daemon's own
+// storage pool, for when --zfs-tenant-root is not set.
+//
+// Tenant encryptionroots are siblings of the default pool's source, not
+// children of it: a child would sit inside the dataset Incus manages, where
+// Incus's housekeeping does not expect datasets it did not create.
+//
+// Returns "" when the pool cannot be read or is not ZFS-backed, which leaves
+// encryption unwired rather than guessing at a path — an encrypted create
+// then fails loudly instead of provisioning somewhere arbitrary.
+func DefaultTenantRoot(client *incus.Client) string {
+	if client == nil {
+		return ""
+	}
+	source, exists, err := client.StoragePoolSource(client.StoragePool())
+	if err != nil || !exists || source == "" {
+		return ""
+	}
+	return zpoolOf(source) + "/tenants"
+}
+
+// zpoolOf returns the ZFS pool a dataset path belongs to.
+func zpoolOf(dataset string) string {
+	if i := strings.Index(dataset, "/"); i >= 0 {
+		return dataset[:i]
+	}
+	return dataset
+}

--- a/internal/server/encrypted_create_integration_test.go
+++ b/internal/server/encrypted_create_integration_test.go
@@ -1,0 +1,315 @@
+//go:build incus
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/metrics/platformstats"
+	"github.com/footprintai/containarium/internal/testsupport/incusenv"
+	"github.com/footprintai/containarium/pkg/core/box"
+	boxlxc "github.com/footprintai/containarium/pkg/core/box/lxc"
+	"github.com/footprintai/containarium/pkg/core/container"
+	"github.com/footprintai/containarium/pkg/core/incus"
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// #1199 AC1, end to end: a container created with encrypted=true lands under
+// its own tenant's encryptionroot, and another tenant's key will not open it.
+//
+// Driven through ContainerServer.CreateContainer — the gRPC method a real
+// caller reaches — against a real Incus on a real ZFS pool. Everything below
+// it (EnsureTenantStorage, the pool placement, the placement record) is
+// production code; only the KeyProvider is injected, because configuring one
+// on the daemon is #1342 and deliberately comes last.
+
+// encTestServer builds a ContainerServer wired for encryption over a real
+// Incus, with a file-backed KeyProvider under the test's temp dir.
+func encTestServer(t *testing.T, client *incus.Client, tenantRoot string) *ContainerServer {
+	t.Helper()
+
+	keys, err := zfskey.NewFileKeyProvider(filepath.Join(t.TempDir(), "keys"))
+	if err != nil {
+		t.Fatalf("NewFileKeyProvider: %v", err)
+	}
+	mgr := container.NewWithBackend(client)
+	s := &ContainerServer{
+		manager:          mgr,
+		boxBackend:       boxlxc.New(mgr),
+		keyProvider:      keys,
+		pendingCreations: map[string]*PendingCreation{},
+		platformStats:    platformstats.New(),
+	}
+	// The production wiring, then the provider on top — SetEncryptionStorage
+	// reads s.keyProvider, which is set above.
+	s.SetEncryptionStorage(tenantRoot, client)
+	return s
+}
+
+// encTestEnv prepares the daemon's infrastructure and returns a wired server
+// plus the tenant dataset root everything is created under.
+func encTestEnv(t *testing.T) (*ContainerServer, *incus.Client, string) {
+	t.Helper()
+	client := incusenv.Require(t)
+	if err := client.InitializeInfrastructure(incus.DefaultNetworkConfig()); err != nil {
+		t.Fatalf("the daemon's own infrastructure init failed: %v", err)
+	}
+	// Derived exactly as the daemon derives it at startup, so the test does
+	// not invent a layout the daemon would not use.
+	tenantRoot := DefaultTenantRoot(client)
+	if tenantRoot == "" {
+		t.Fatalf("could not derive a tenant dataset root from storage pool %q", client.StoragePool())
+	}
+	return encTestServer(t, client, tenantRoot), client, tenantRoot
+}
+
+// createEncrypted drives the real gRPC method and cleans up after itself.
+func createEncrypted(t *testing.T, s *ContainerServer, tenant string) string {
+	t.Helper()
+	instance := tenant + "-container"
+	t.Cleanup(func() { incusenv.DeleteInstance(t, instance) })
+
+	ctx, cancel := context.WithTimeout(
+		tenantWithScopes(tenant, auth.ScopeContainersWrite), 25*time.Minute)
+	defer cancel()
+
+	if _, err := s.CreateContainer(ctx, &pb.CreateContainerRequest{
+		Username:  tenant,
+		Image:     "images:ubuntu/24.04",
+		OsType:    pb.OSType_OS_TYPE_UBUNTU_2404,
+		Encrypted: true,
+		Resources: &pb.ResourceLimits{Disk: "5GB"},
+	}); err != nil {
+		t.Fatalf("encrypted CreateContainer(%s): %v", tenant, err)
+	}
+	return instance
+}
+
+func TestIntegrationIncus_EncryptedCreateLandsUnderTheTenantEncryptionroot(t *testing.T) {
+	s, _, tenantRoot := encTestEnv(t)
+	zfs := zfscrypt.NewManager(zfscrypt.ExecRunner{})
+	ctx := context.Background()
+
+	tenant := fmt.Sprintf("enc%d", os.Getpid())
+	t.Cleanup(func() { _ = zfs.Destroy(context.Background(), tenantRoot+"/"+tenant) })
+
+	instance := createEncrypted(t, s, tenant)
+
+	dataset := incusenv.DatasetFor(t, instance)
+	if dataset == "" {
+		t.Fatalf("instance %s has no ZFS dataset", instance)
+	}
+	root, err := zfs.EncryptionRoot(ctx, dataset)
+	if err != nil {
+		t.Fatalf("read encryptionroot of %s: %v — an unencrypted dataset has none, which would "+
+			"mean the create reported encryption it did not deliver", dataset, err)
+	}
+	want := tenantRoot + "/" + tenant
+	if root != want {
+		t.Fatalf("instance dataset %s has encryptionroot %q, want the tenant's %q", dataset, root, want)
+	}
+	t.Logf("encrypted create landed on %s under encryptionroot %s", dataset, root)
+}
+
+// The assertion that actually draws the boundary.
+//
+// Two datasets reporting different encryptionroot STRINGS would still pass a
+// string comparison while sharing key material. Only a failed unlock rules
+// that out, so this loads one tenant's key and tries it against the other's
+// dataset.
+func TestIntegrationIncus_TwoTenantsCannotUnlockEachOther(t *testing.T) {
+	s, _, tenantRoot := encTestEnv(t)
+	zfs := zfscrypt.NewManager(zfscrypt.ExecRunner{})
+	ctx := context.Background()
+
+	alice := fmt.Sprintf("alc%d", os.Getpid())
+	bob := fmt.Sprintf("bob%d", os.Getpid())
+	for _, tn := range []string{alice, bob} {
+		tenant := tn
+		t.Cleanup(func() { _ = zfs.Destroy(context.Background(), tenantRoot+"/"+tenant) })
+	}
+
+	aliceDS := incusenv.DatasetFor(t, createEncrypted(t, s, alice))
+	bobDS := incusenv.DatasetFor(t, createEncrypted(t, s, bob))
+
+	aliceRoot, err := zfs.EncryptionRoot(ctx, aliceDS)
+	if err != nil {
+		t.Fatalf("EncryptionRoot(%s): %v", aliceDS, err)
+	}
+	bobRoot, err := zfs.EncryptionRoot(ctx, bobDS)
+	if err != nil {
+		t.Fatalf("EncryptionRoot(%s): %v", bobDS, err)
+	}
+	if aliceRoot == bobRoot {
+		t.Fatalf("both tenants are under encryptionroot %q — one tenant's key unlocks the "+
+			"other's data", aliceRoot)
+	}
+
+	// Now the part a string comparison cannot do. Unload bob's key, then
+	// offer alice's key material to bob's encryptionroot.
+	if err := zfs.UnloadKey(ctx, bobRoot); err != nil {
+		t.Skipf("could not unload %s to test cross-tenant unlock: %v", bobRoot, err)
+	}
+	keys, err := zfskey.NewFileKeyProvider(filepath.Join(t.TempDir(), "unused"))
+	if err != nil {
+		t.Fatalf("NewFileKeyProvider: %v", err)
+	}
+	aliceKey, _, err := keys.Wrap(ctx, alice)
+	if err != nil {
+		t.Fatalf("Wrap(%s): %v", alice, err)
+	}
+	if err := zfs.LoadKey(ctx, bobRoot, aliceKey); err == nil {
+		t.Fatalf("alice's key unlocked bob's encryptionroot %s — the tenants share key material "+
+			"despite reporting different roots, which is the failure a string comparison misses", bobRoot)
+	}
+}
+
+func TestIntegrationIncus_SecondContainerForATenantSharesItsEncryptionroot(t *testing.T) {
+	s, _, tenantRoot := encTestEnv(t)
+	zfs := zfscrypt.NewManager(zfscrypt.ExecRunner{})
+	ctx := context.Background()
+
+	tenant := fmt.Sprintf("two%d", os.Getpid())
+	t.Cleanup(func() { _ = zfs.Destroy(context.Background(), tenantRoot+"/"+tenant) })
+
+	first := incusenv.DatasetFor(t, createEncrypted(t, s, tenant))
+
+	// A tenant's second container. The daemon names containers
+	// "<username>-container", so a second one needs its own username under
+	// the same tenant — which is what tenant_id expresses on a multi-tenant
+	// build. Here the second create simply re-runs EnsureTenantStorage for
+	// the same tenant, which must reuse the pool rather than mint a second
+	// encryptionroot.
+	pool, ref, err := s.encryption.EnsureTenantStorage(ctx, tenant)
+	if err != nil {
+		t.Fatalf("second EnsureTenantStorage(%s): %v", tenant, err)
+	}
+	if ref.URI == "" {
+		t.Error("the second call returned no key ref")
+	}
+
+	source, exists, err := s.encryption.pools.StoragePoolSource(pool)
+	if err != nil || !exists {
+		t.Fatalf("StoragePoolSource(%s) = (%q, %v, %v)", pool, source, exists, err)
+	}
+	firstRoot, err := zfs.EncryptionRoot(ctx, first)
+	if err != nil {
+		t.Fatalf("EncryptionRoot(%s): %v", first, err)
+	}
+	if source != firstRoot {
+		t.Errorf("the tenant's second container would be placed on a pool sourced at %q, but "+
+			"their first container is under encryptionroot %q — the tenant would end up with two "+
+			"keys and their containers could not share datasets", source, firstRoot)
+	}
+}
+
+// The load-bearing negative. Everything above could pass while an ORDINARY
+// create had quietly changed — landing on a tenant pool, or gaining an
+// encryptionroot it should not have.
+func TestIntegrationIncus_UnencryptedCreateIsUnchanged(t *testing.T) {
+	s, client, tenantRoot := encTestEnv(t)
+	zfs := zfscrypt.NewManager(zfscrypt.ExecRunner{})
+	ctx := context.Background()
+
+	tenant := fmt.Sprintf("plain%d", os.Getpid())
+	instance := tenant + "-container"
+	t.Cleanup(func() { incusenv.DeleteInstance(t, instance) })
+
+	rpcCtx, cancel := context.WithTimeout(
+		tenantWithScopes(tenant, auth.ScopeContainersWrite), 25*time.Minute)
+	defer cancel()
+
+	if _, err := s.CreateContainer(rpcCtx, &pb.CreateContainerRequest{
+		Username:  tenant,
+		Image:     "images:ubuntu/24.04",
+		OsType:    pb.OSType_OS_TYPE_UBUNTU_2404,
+		Resources: &pb.ResourceLimits{Disk: "5GB"},
+		// Encrypted deliberately unset.
+	}); err != nil {
+		t.Fatalf("unencrypted CreateContainer: %v", err)
+	}
+
+	dataset := incusenv.DatasetFor(t, instance)
+	if dataset == "" {
+		t.Fatalf("instance %s has no ZFS dataset", instance)
+	}
+
+	// It must be on the daemon's default pool, not a tenant pool.
+	defaultSource, _, err := client.StoragePoolSource(client.StoragePool())
+	if err != nil {
+		t.Fatalf("StoragePoolSource(%s): %v", client.StoragePool(), err)
+	}
+	if want := defaultSource + "/containers/" + instance; dataset != want {
+		t.Errorf("an unencrypted container landed on %q, want %q — the default placement changed",
+			dataset, want)
+	}
+
+	// And it must have no encryptionroot at all. EncryptionRoot errors for an
+	// unencrypted dataset, which is the expected outcome here.
+	if root, err := zfs.EncryptionRoot(ctx, dataset); err == nil {
+		t.Errorf("an unencrypted create produced a dataset with encryptionroot %q — encryption "+
+			"is leaking into the default path", root)
+	}
+
+	// No tenant storage should have been provisioned for it either.
+	if _, exists, err := client.StoragePoolSource(tenantPoolName(tenant)); err == nil && exists {
+		t.Errorf("a tenant storage pool was created for an unencrypted create")
+	}
+	if exists, err := zfs.Exists(ctx, tenantRoot+"/"+tenant); err == nil && exists {
+		t.Errorf("a tenant encryptionroot was created for an unencrypted create")
+		_ = zfs.Destroy(ctx, tenantRoot+"/"+tenant)
+	}
+}
+
+// The question #1340 could not answer without an Incus: does Incus keep its
+// pool's SOURCE dataset mounted?
+//
+// If it does, PostStop can never `zfs unload-key` the tenant encryptionroot,
+// and "a stopped container's dataset is ciphertext, including to host root" —
+// the claim the whole feature exists to make — would not hold in production,
+// while every ZFS-lane test still passed.
+func TestIntegrationIncus_StoppingTheLastContainerUnloadsTheTenantKey(t *testing.T) {
+	s, _, tenantRoot := encTestEnv(t)
+	zfs := zfscrypt.NewManager(zfscrypt.ExecRunner{})
+	ctx := context.Background()
+
+	tenant := fmt.Sprintf("stp%d", os.Getpid())
+	t.Cleanup(func() { _ = zfs.Destroy(context.Background(), tenantRoot+"/"+tenant) })
+
+	instance := createEncrypted(t, s, tenant)
+	root := tenantRoot + "/" + tenant
+
+	if status, err := zfs.KeyStatus(ctx, root); err != nil {
+		t.Fatalf("KeyStatus(%s): %v", root, err)
+	} else if status != zfscrypt.KeyAvailable {
+		t.Fatalf("precondition: the running container's key is %q, want %q", status, zfscrypt.KeyAvailable)
+	}
+
+	// Stop it the way the daemon does, then run the hook the daemon runs.
+	if err := s.boxes().Stop(ctx, box.BoxRef{Tenant: tenant}, true); err != nil {
+		t.Fatalf("stopping %s: %v", instance, err)
+	}
+	s.encryption.PostStop(ctx, instance)
+
+	status, err := zfs.KeyStatus(ctx, root)
+	if err != nil {
+		t.Fatalf("KeyStatus(%s) after stop: %v", root, err)
+	}
+	if status != zfscrypt.KeyUnavailable {
+		t.Fatalf("the tenant encryptionroot %s still has its key loaded (%q) after its last "+
+			"container stopped.\n\nIf Incus keeps the pool's source dataset mounted, "+
+			"`zfs unload-key` can never succeed and a stopped container is NOT ciphertext at "+
+			"rest — the central claim of #1199. This is the question #1340 could not answer "+
+			"without an Incus; if it fails here, that is the answer and the design needs a "+
+			"way to release the pool's mount before unloading.", root, status)
+	}
+	t.Logf("the tenant key is unloaded after the last container stops; %s is ciphertext at rest", root)
+}

--- a/internal/server/encrypted_create_integration_test.go
+++ b/internal/server/encrypted_create_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/events"
 	"github.com/footprintai/containarium/internal/metrics/platformstats"
 	"github.com/footprintai/containarium/internal/testsupport/incusenv"
 	"github.com/footprintai/containarium/pkg/core/box"
@@ -47,6 +48,10 @@ func encTestServer(t *testing.T, client *incus.Client, tenantRoot string) *Conta
 		keyProvider:      keys,
 		pendingCreations: map[string]*PendingCreation{},
 		platformStats:    platformstats.New(),
+		// NewContainerServer always sets this; a directly-constructed server
+		// must too, or the create panics on a nil *Emitter after the box is
+		// already built.
+		emitter: events.NewEmitter(events.GetBus()),
 	}
 	// The production wiring, then the provider on top — SetEncryptionStorage
 	// reads s.keyProvider, which is set above.

--- a/internal/server/encrypted_create_integration_test.go
+++ b/internal/server/encrypted_create_integration_test.go
@@ -158,23 +158,42 @@ func TestIntegrationIncus_TwoTenantsCannotUnlockEachOther(t *testing.T) {
 			"other's data", aliceRoot)
 	}
 
-	// Now the part a string comparison cannot do. Unload bob's key, then
-	// offer alice's key material to bob's encryptionroot.
-	if err := zfs.UnloadKey(ctx, bobRoot); err != nil {
-		t.Skipf("could not unload %s to test cross-tenant unlock: %v", bobRoot, err)
-	}
-	keys, err := zfskey.NewFileKeyProvider(filepath.Join(t.TempDir(), "unused"))
+	// Now the part a string comparison cannot do: offer ALICE'S ACTUAL KEY
+	// to bob's encryptionroot and require ZFS to refuse it.
+	//
+	// The key comes from the server's own provider, not a fresh one. A
+	// second FileKeyProvider under a different directory would mint
+	// different material for the same tenant, and the unlock would fail
+	// because the key was wrong rather than because the tenants are
+	// isolated — the test would pass no matter how broken the boundary was.
+	aliceKey, _, err := s.encryption.provider.Wrap(ctx, alice)
 	if err != nil {
-		t.Fatalf("NewFileKeyProvider: %v", err)
+		t.Fatalf("Wrap(%s) from the server's own provider: %v", alice, err)
 	}
-	aliceKey, _, err := keys.Wrap(ctx, alice)
-	if err != nil {
-		t.Fatalf("Wrap(%s): %v", alice, err)
+
+	// Bob's key is loaded while his container runs, and ZFS will not unload
+	// a key that a mounted dataset is using. Stop his container the way the
+	// daemon does, then drop the key through the hook that production runs.
+	// Deliberately NOT a t.Skip: a skipped cross-tenant check is the one
+	// result that must never be mistaken for a pass.
+	if err := s.boxes().Stop(ctx, box.BoxRef{Tenant: bob}, true); err != nil {
+		t.Fatalf("stopping bob's container: %v", err)
 	}
+	s.encryption.PostStop(ctx, bob+"-container")
+
+	if status, err := zfs.KeyStatus(ctx, bobRoot); err != nil {
+		t.Fatalf("KeyStatus(%s): %v", bobRoot, err)
+	} else if status != zfscrypt.KeyUnavailable {
+		t.Fatalf("bob's key is still %q after his last container stopped, so the unlock below "+
+			"would be answered from the loaded key rather than tested", status)
+	}
+
 	if err := zfs.LoadKey(ctx, bobRoot, aliceKey); err == nil {
 		t.Fatalf("alice's key unlocked bob's encryptionroot %s — the tenants share key material "+
-			"despite reporting different roots, which is the failure a string comparison misses", bobRoot)
+			"despite reporting different roots, which is exactly the failure a comparison of "+
+			"encryptionroot strings cannot see", bobRoot)
 	}
+	t.Logf("alice's key is refused against bob's encryptionroot %s", bobRoot)
 }
 
 func TestIntegrationIncus_SecondContainerForATenantSharesItsEncryptionroot(t *testing.T) {

--- a/internal/server/encrypted_create_test.go
+++ b/internal/server/encrypted_create_test.go
@@ -1,0 +1,133 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Wiring the encrypted create (#1341): CreateContainer resolves the tenant's
+// storage before provisioning anything, places the container on it, and
+// records where it went.
+//
+// These pin the wiring and its refusals. Whether the resulting container is
+// actually encrypted is a property ZFS computes, asserted on the incus lane.
+
+// encryptedTenantOf is the decision about WHOSE key a container is encrypted
+// with. Getting it wrong does not fail — it silently puts two tenants under
+// one encryptionroot, which is the boundary the whole feature exists to draw.
+func TestEncryptionTenantFor(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		req     *pb.CreateContainerRequest
+		want    string
+		wantWhy string
+	}{
+		{
+			name: "the username is the tenant on an OSS daemon",
+			req:  &pb.CreateContainerRequest{Username: "alice"},
+			want: "alice",
+			wantWhy: "validateTenantID forbids any real tenant_id here, so the username is the " +
+				"only tenancy this build has",
+		},
+		{
+			// "default" is what a single-tenant daemon accepts as a synonym
+			// for unset. Treating it as the key scope would put EVERY user on
+			// one encryptionroot — no isolation at all, silently.
+			name:    "tenant_id=default is not a tenant",
+			req:     &pb.CreateContainerRequest{Username: "alice", TenantId: "default"},
+			want:    "alice",
+			wantWhy: "every user would share one key",
+		},
+		{
+			// The cloud build's org-scoped tenancy: a real tenant_id wins,
+			// because a tenant's several users must share one encryptionroot.
+			name:    "a real tenant_id wins",
+			req:     &pb.CreateContainerRequest{Username: "alice", TenantId: "org-acme"},
+			want:    "org-acme",
+			wantWhy: "one org's containers share one key",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := encryptionTenantFor(tc.req); got != tc.want {
+				t.Errorf("encryptionTenantFor = %q, want %q — otherwise %s", got, tc.want, tc.wantWhy)
+			}
+		})
+	}
+}
+
+// The guard inherited from #1339.
+//
+// #1339 made a storage pool that IS set impossible to drop silently. This is
+// the other half: an encrypted create whose pool could not be resolved must
+// fail loudly rather than fall through to the daemon default, where the
+// container would be created unencrypted and reported as a success.
+//
+// Reachable only through a misconfigured daemon — a KeyProvider wired with no
+// encryption hooks — which is exactly the shape a future wiring change could
+// produce by accident.
+func TestCreateContainer_EncryptedWithoutAResolvedPoolFails(t *testing.T) {
+	s := &ContainerServer{
+		// A provider is present, so validateEncryption lets the request
+		// through...
+		keyProvider: stubProvider{},
+		// ...but the hooks are not wired, so no pool can be resolved.
+		encryption: nil,
+	}
+
+	_, err := s.CreateContainer(tenantWithScopes("alice", auth.ScopeContainersWrite),
+		&pb.CreateContainerRequest{Username: "alice", Encrypted: true})
+	if err == nil {
+		t.Fatal("an encrypted create with no resolvable storage pool succeeded — the container " +
+			"would land on the daemon's default pool, unencrypted, and be reported as encrypted")
+	}
+	if got := status.Code(err); got != codes.FailedPrecondition && got != codes.Internal {
+		t.Errorf("code = %v, want FailedPrecondition or Internal", got)
+	}
+	// The operator has to be able to tell this from a caller error.
+	if !strings.Contains(err.Error(), "pool") {
+		t.Errorf("the error does not mention the storage pool, so nobody can act on it: %v", err)
+	}
+}
+
+// A create that asks for encryption on a daemon with no key custody is still
+// refused, and still with FAILED_PRECONDITION — the OSS default is unchanged
+// by this wiring. #1294's unconditional refusal is gone because the create
+// path now does provision encrypted storage; validateEncryption's
+// provider-nil refusal is what keeps the promise honest until #1342.
+func TestCreateContainer_StillRefusesEncryptedWithNoKeyProvider(t *testing.T) {
+	s := &ContainerServer{}
+
+	_, err := s.CreateContainer(tenantWithScopes("alice", auth.ScopeContainersWrite),
+		&pb.CreateContainerRequest{Username: "alice", Encrypted: true})
+	if err == nil {
+		t.Fatal("an encrypted create succeeded on a daemon with no KeyProvider")
+	}
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition — a client distinguishes 'not available "+
+			"here' from 'your request was malformed' by this code", got)
+	}
+	if !strings.Contains(err.Error(), "KeyProvider") {
+		t.Errorf("the error does not name the missing capability: %v", err)
+	}
+}
+
+// stubProvider is a KeyProvider that exists but is never expected to be
+// called — it is here to get past validateEncryption, not to mint keys.
+type stubProvider struct{}
+
+func (stubProvider) Wrap(context.Context, string) (zfskey.Key, zfskey.KeyRef, error) {
+	return zfskey.Key{}, zfskey.KeyRef{}, errors.New("stubProvider.Wrap should not be reached")
+}
+
+func (stubProvider) Load(context.Context, zfskey.KeyRef) (zfskey.Key, error) {
+	return zfskey.Key{}, errors.New("stubProvider.Load should not be reached")
+}

--- a/internal/server/encrypted_flag_test.go
+++ b/internal/server/encrypted_flag_test.go
@@ -22,6 +22,17 @@ import (
 // That is worse than an unimplemented feature. An operator who runs
 // `containarium create --encrypted` gets a container they believe is
 // tenant-encrypted, and nothing anywhere tells them otherwise.
+//
+// #1341 UPDATE. The blanket refusal this test was written against is gone,
+// because the reason for it is gone: the create path now does provision
+// encrypted storage. What survives — and what this test now asserts — is the
+// refusal that actually keeps the promise: no KeyProvider, no encrypted
+// create. Every OSS daemon is in that state until an operator configures one
+// (#1342), so the externally visible behaviour here is unchanged.
+//
+// The assertion moved off the phrase "not available", which no longer appears
+// anywhere, and onto the guarantee: FAILED_PRECONDITION, and a message that
+// identifies a daemon capability gap rather than a caller mistake.
 func TestCreateContainer_RefusesEncryptedRatherThanIgnoringIt(t *testing.T) {
 	s := &ContainerServer{}
 
@@ -40,8 +51,13 @@ func TestCreateContainer_RefusesEncryptedRatherThanIgnoringIt(t *testing.T) {
 	}
 	// The caller has to be able to act on this, which means knowing it is a
 	// daemon capability gap rather than something they got wrong.
-	if !strings.Contains(err.Error(), "not available") {
-		t.Errorf("the error does not say the capability is missing: %v", err)
+	msg := err.Error()
+	if !strings.Contains(msg, "KeyProvider") || !strings.Contains(msg, "none is configured") {
+		t.Errorf("the error does not identify the missing daemon capability: %v", err)
+	}
+	// And it must still promise the thing #1294 was filed for.
+	if !strings.Contains(msg, "refusing rather than creating an unencrypted container") {
+		t.Errorf("the error no longer says it refuses rather than falling back to plaintext: %v", err)
 	}
 }
 
@@ -61,7 +77,10 @@ func TestCreateContainer_EncryptionRefusalDoesNotPreemptValidation(t *testing.T)
 	if err == nil {
 		t.Fatal("a request with no username succeeded")
 	}
-	if strings.Contains(err.Error(), "per-container encryption") {
+	// Assert against the refusal that actually exists. The old assertion
+	// looked for "per-container encryption", a phrase #1341 deleted — it
+	// could no longer fail, so it proved nothing about ordering.
+	if strings.Contains(err.Error(), "KeyProvider") {
 		t.Errorf("a request missing its username was refused for encryption instead: %v — the "+
 			"caller would go looking at daemon capabilities for a typo", err)
 	}

--- a/internal/server/encryption_hooks.go
+++ b/internal/server/encryption_hooks.go
@@ -240,6 +240,13 @@ func (h *encryptionHooks) ensureTenantDataset(ctx context.Context, dataset strin
 		return false, fmt.Errorf("check the tenant encryptionroot %s: %w", dataset, err)
 	}
 	if !exists {
+		// The root the tenant datasets sit under is derived from the storage
+		// pool and may never have existed on this host. `zfs create` does not
+		// make intermediates, so without this every encrypted create on a
+		// fresh host fails with "parent does not exist" (#1341).
+		if err := h.zfs.EnsureParent(ctx, dataset); err != nil {
+			return false, fmt.Errorf("cannot prepare the tenant dataset root for %s: %w", dataset, err)
+		}
 		if err := h.zfs.CreateEncrypted(ctx, dataset, key); err != nil {
 			return false, fmt.Errorf("cannot create the tenant encryptionroot %s: %w", dataset, err)
 		}

--- a/pkg/core/zfscrypt/zfscrypt.go
+++ b/pkg/core/zfscrypt/zfscrypt.go
@@ -282,6 +282,46 @@ func (m *Manager) Exists(ctx context.Context, dataset string) (bool, error) {
 	return true, nil
 }
 
+// EnsureParent makes the parent of a dataset exist, creating the whole chain
+// if it does not.
+//
+// `zfs create` does not make intermediate datasets, and a tenant
+// encryptionroot is created at <root>/<tenant> where <root> is derived from
+// the daemon's storage pool. On a host that has never had an encrypted
+// container, that intermediate does not exist, and every encrypted create
+// fails with "parent does not exist" (#1341).
+//
+// The parent is deliberately created UNencrypted: it is a container for
+// datasets, not a dataset that holds data, and each tenant encryptionroot
+// below it carries its own key. Making it an encryptionroot instead would put
+// every tenant under one key — the opposite of the point.
+//
+// A parent that is a bare pool root is a no-op: pools always exist, and
+// `zfs create tank` would fail.
+func (m *Manager) EnsureParent(ctx context.Context, dataset string) error {
+	if err := validateDataset(dataset); err != nil {
+		return err
+	}
+	parent := dataset[:strings.LastIndex(dataset, "/")]
+	if !strings.Contains(parent, "/") {
+		return nil // a pool root, which always exists
+	}
+
+	exists, err := m.Exists(ctx, parent)
+	if err != nil {
+		return fmt.Errorf("check parent dataset %s: %w", parent, err)
+	}
+	if exists {
+		return nil
+	}
+
+	_, stderr, err := m.run.Run(ctx, nil, "create", "-p", parent)
+	if err != nil {
+		return fmt.Errorf("create parent dataset %s: %w: %s", parent, err, strings.TrimSpace(stderr))
+	}
+	return nil
+}
+
 // Destroy removes a dataset. Used to clean up a half-built container so
 // a failed encrypted create leaves no partial state behind.
 func (m *Manager) Destroy(ctx context.Context, dataset string) error {

--- a/pkg/core/zfscrypt/zfscrypt_test.go
+++ b/pkg/core/zfscrypt/zfscrypt_test.go
@@ -54,6 +54,11 @@ func (f *fakeRunner) lastCall() []string {
 	return f.calls[len(f.calls)-1]
 }
 
+// ran reports whether any invocation's joined args contain the substring.
+func (f *fakeRunner) ran(substr string) bool {
+	return strings.Contains(f.allArgs(), substr)
+}
+
 func (f *fakeRunner) allArgs() string {
 	var b strings.Builder
 	for _, c := range f.calls {
@@ -329,4 +334,51 @@ func TestExists(t *testing.T) {
 	if _, err := NewManager(f2).Exists(context.Background(), "pool/c/alice"); err == nil {
 		t.Error("a broken pool must be an error, not 'absent'")
 	}
+}
+
+// EnsureParent exists because a tenant encryptionroot is created at
+// <root>/<tenant>, and `zfs create` does not make intermediate datasets.
+// The daemon derives that root from its storage pool, so on a fresh host the
+// intermediate does not exist and every encrypted create failed with "parent
+// does not exist" — caught by the incus lane in #1341, not by any unit test.
+func TestEnsureParent(t *testing.T) {
+	t.Run("creates the chain when the parent is absent", func(t *testing.T) {
+		r := newFakeRunner()
+		r.errs["list"] = errors.New("exit status 1")
+		r.stderr["list"] = "cannot open 'tank/tenants': dataset does not exist"
+		m := NewManager(r)
+
+		if err := m.EnsureParent(context.Background(), "tank/tenants/alice"); err != nil {
+			t.Fatalf("EnsureParent: %v", err)
+		}
+		if !r.ran("create -p tank/tenants") {
+			t.Errorf("the parent chain was not created; calls=%v", r.calls)
+		}
+	})
+
+	t.Run("an existing parent is left alone", func(t *testing.T) {
+		r := newFakeRunner()
+		m := NewManager(r)
+
+		if err := m.EnsureParent(context.Background(), "tank/tenants/alice"); err != nil {
+			t.Fatalf("EnsureParent: %v", err)
+		}
+		if r.ran("create") {
+			t.Errorf("an existing parent was re-created; calls=%v", r.calls)
+		}
+	})
+
+	// A pool root always exists — creating it is neither possible nor
+	// meaningful, and `zfs create tank` would fail.
+	t.Run("a bare pool parent is a no-op", func(t *testing.T) {
+		r := newFakeRunner()
+		m := NewManager(r)
+
+		if err := m.EnsureParent(context.Background(), "tank/alice"); err != nil {
+			t.Fatalf("EnsureParent: %v", err)
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("zfs was invoked for a pool root; calls=%v", r.calls)
+		}
+	})
 }


### PR DESCRIPTION
Closes #1341. Part of #1199 — this is the step the whole sprint was for. Design: `docs/architecture/per-tenant-encrypted-storage-pools.md`.

`CreateContainer` resolves the tenant's encrypted storage **before** it provisions anything, places the container on that tenant's pool, and records where it went.

## What changes for a caller

| Daemon state | `create --encrypted` | Why |
| --- | --- | --- |
| No KeyProvider (**every OSS daemon today**) | Refused, `FAILED_PRECONDITION` | Unchanged. `validateEncryption` still refuses; #1342 is what configures custody. |
| KeyProvider + encryption wired | Container on the tenant's encryptionroot | The feature, working. |
| KeyProvider but encryption half-wired | Refused, loudly | The guard inherited from #1339. |

**#1294's unconditional refusal is gone**, because its stated reason — *"the create path does not provision an encrypted dataset"* — is no longer true. What survives is the refusal that actually keeps the promise: no key custody, no encrypted create. Externally, an OSS daemon behaves exactly as before.

## Two existing assertions changed, and one of them could no longer fail

`encrypted_flag_test.go` asserted the *wording* of the removed refusal. Changing a test to make a change pass is normally the wrong move, so, explicitly:

- `TestCreateContainer_RefusesEncryptedRatherThanIgnoringIt` looked for `"not available"`. It now asserts the surviving guarantee — `FAILED_PRECONDITION`, an error naming `KeyProvider` and `none is configured`, and still promising *"refusing rather than creating an unencrypted container"*. Same contract, asserted on what the daemon actually says.
- `TestCreateContainer_EncryptionRefusalDoesNotPreemptValidation` checked that a malformed request is not refused for encryption — by looking for the phrase `"per-container encryption"`, **which this PR deletes from the codebase**. It would have passed forever, proving nothing about ordering. Re-pointed at the refusal that exists.

The second one is the more interesting find: it was already a check that could not fail the moment the phrase changed, and only a grep for the deleted string surfaced it.

## Failure handling worth a look

`recordEncryptedPlacement` **deletes the container** when the placement record cannot be written. That is not tidiness: the container's data is already encrypted under the tenant's key, and without the record nothing can name its encryptionroot — it can never be started, never safely reused, and its name blocks the next create. The both-failed case says exactly what an operator must clean up by hand. Applied identically on the sync and async paths.

## Test evidence

CI run linked in a follow-up comment.

**Unit** — `TestEncryptionTenantFor` (3 cases, including that `tenant_id="default"` must **not** become the key scope, or every user of a daemon shares one encryptionroot — silently), `TestCreateContainer_EncryptedWithoutAResolvedPoolFails`, `TestCreateContainer_StillRefusesEncryptedWithNoKeyProvider`.

**Integration, on the incus lane, driven through the real gRPC method:**

- `TestIntegrationIncus_EncryptedCreateLandsUnderTheTenantEncryptionroot` — #1199 AC1.
- `TestIntegrationIncus_TwoTenantsCannotUnlockEachOther` — distinct roots **and** alice's key is *refused* against bob's encryptionroot. The refusal is the real assertion: two datasets reporting different `encryptionroot` strings can still share key material, and a string comparison would pass.
- `TestIntegrationIncus_SecondContainerForATenantSharesItsEncryptionroot`.
- `TestIntegrationIncus_UnencryptedCreateIsUnchanged` — the load-bearing negative: default pool, no encryptionroot, and no tenant pool or dataset created.

**Plus the question #1340 could not answer**, now that there is an Incus to ask: `TestIntegrationIncus_StoppingTheLastContainerUnloadsTheTenantKey`. If Incus keeps its pool's *source* dataset mounted, `PostStop` can never `zfs unload-key` and *"a stopped container's dataset is ciphertext"* would not hold in production — while every ZFS-lane test still passed. Its failure message says so, because if it goes red that is a design finding, not a flaky test.

## Reviewer notes

- `internal/server/**` joins the lane's path filters **and its explicit package list**. #1344 shipped green for one commit with its integration test never selected; that is why both are changed.
- `SetEncryptionStorage` is called at startup with `s.keyProvider` still nil, so the hooks are inert (`enabled()` is false). That ordering is load-bearing: a KeyProvider configured before the create path could genuinely encrypt would make `validateEncryption` start *passing* while the daemon returned plaintext.
- `DefaultTenantRoot` returns `""` when the pool cannot be read, which leaves encryption unwired so an encrypted create fails loudly rather than provisioning somewhere arbitrary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)