### PR TITLE
feat(sentinel): admin-gated runtime profiling endpoint + CLI (#1352)

### DIFF
--- a/internal/cmd/sentinel_pprof.go
+++ b/internal/cmd/sentinel_pprof.go
@@ -197,6 +197,13 @@ func runSentinelPprof(cmd *cobra.Command, args []string) error {
 
 	// 0600: the profile may contain tokens and key material lifted straight
 	// out of the sentinel's heap.
+	//
+	// #nosec G304 -- outPath is the operator's own --output flag on a CLI they
+	// are already running under their own uid. Choosing where the file lands
+	// is the flag's entire purpose; there is no fixed root to scope it under,
+	// and the traversal G304 warns about would only reach paths the caller can
+	// already write by hand. Same shape as internal/cmd/recover.go's config
+	// path.
 	f, err := os.OpenFile(outPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("create %s: %w", outPath, err)

--- a/internal/cmd/sentinel_pprof.go
+++ b/internal/cmd/sentinel_pprof.go
@@ -1,0 +1,219 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sentinelPprofURL     string
+	sentinelPprofProfile string
+	sentinelPprofOutput  string
+	sentinelPprofSeconds int
+	sentinelPprofDebug   int
+	sentinelPprofGC      bool
+	sentinelPprofList    bool
+	sentinelPprofSecret  string
+)
+
+var sentinelPprofCmd = &cobra.Command{
+	Use:   "pprof",
+	Short: "Capture a runtime profile from a running sentinel (#1352)",
+	Long: `Download a pprof profile from a running sentinel and write it to a file.
+
+The sentinel's profile endpoint is HMAC-gated, and ` + "`go tool pprof`" + ` cannot sign
+its own requests — so it cannot fetch the URL directly. This command signs the
+request, saves the profile, and prints the go tool pprof invocation to run next.
+
+Authenticated with CONTAINARIUM_SENTINEL_ADMIN_SECRET, NOT the cluster-wide
+CONTAINARIUM_SENTINEL_AUTH_SECRET that daemons hold for keysync/certsync. A heap
+profile is a snapshot of everything the process holds in memory — tunnel-join
+tokens, TLS key material — so it is gated like tunnel-token registration rather
+than like a routine daemon pull.
+
+Treat the downloaded file as sensitive: it belongs on an operator workstation,
+not in a bug report or a shared bucket.
+
+Examples:
+
+  # Heap profile — the one that answers "what is holding all this memory"
+  containarium sentinel pprof --url http://<sentinel-host>:8888 --profile heap -o heap.pb.gz
+
+  # Force a GC first, so inuse_space is live memory rather than uncollected garbage
+  containarium sentinel pprof --url http://<sentinel-host>:8888 --profile heap --gc
+
+  # Compare two snapshots hours apart to find what grows (the #1349 workflow)
+  go tool pprof -base heap-t0.pb.gz heap-t1.pb.gz
+
+  # Goroutine dump as readable text, no go tool pprof needed
+  containarium sentinel pprof --url http://<sentinel-host>:8888 --profile goroutine --debug 1 -o -
+
+  # What profiles does this sentinel have?
+  containarium sentinel pprof --url http://<sentinel-host>:8888 --list`,
+	RunE: runSentinelPprof,
+}
+
+func init() {
+	sentinelCmd.AddCommand(sentinelPprofCmd)
+
+	sentinelPprofCmd.Flags().StringVar(&sentinelPprofURL, "url", "", "Sentinel binary-server base URL, e.g. http://<sentinel-host>:8888 (required)")
+	sentinelPprofCmd.Flags().StringVar(&sentinelPprofProfile, "profile", "heap", "Profile to capture: heap, goroutine, allocs, threadcreate, block, mutex, or profile (CPU)")
+	sentinelPprofCmd.Flags().StringVarP(&sentinelPprofOutput, "output", "o", "", "Write to this path ('-' for stdout). Default: <profile>.pb.gz, or stdout in --debug/--list mode")
+	sentinelPprofCmd.Flags().IntVar(&sentinelPprofSeconds, "seconds", 0, "CPU profile duration in seconds (1-60, only with --profile profile)")
+	sentinelPprofCmd.Flags().IntVar(&sentinelPprofDebug, "debug", 0, "0 = binary profile for go tool pprof; 1 or 2 = human-readable text")
+	sentinelPprofCmd.Flags().BoolVar(&sentinelPprofGC, "gc", false, "Force a GC before a heap snapshot so inuse_space reflects live memory, not uncollected garbage")
+	sentinelPprofCmd.Flags().BoolVar(&sentinelPprofList, "list", false, "List the profiles this sentinel offers, with current object counts")
+	sentinelPprofCmd.Flags().StringVar(&sentinelPprofSecret, "secret", os.Getenv(config.EnvSentinelAdminSecret), "Sentinel admin secret (defaults to $CONTAINARIUM_SENTINEL_ADMIN_SECRET)")
+
+	_ = sentinelPprofCmd.MarkFlagRequired("url")
+}
+
+// buildPprofURL assembles the sentinel profile URL. Pure, so the query
+// assembly is testable without a server.
+func buildPprofURL(base, profile string, seconds, debug int, gc, list bool) (string, error) {
+	base = strings.TrimRight(strings.TrimSpace(base), "/")
+	if base == "" {
+		return "", fmt.Errorf("empty --url")
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("invalid --url %q: %w", base, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("invalid --url %q: want an http:// or https:// base URL", base)
+	}
+
+	path := "/debug/pprof/"
+	if !list {
+		if strings.TrimSpace(profile) == "" {
+			return "", fmt.Errorf("empty --profile")
+		}
+		path += profile
+	}
+
+	q := url.Values{}
+	if debug > 0 {
+		q.Set("debug", strconv.Itoa(debug))
+	}
+	if gc {
+		q.Set("gc", "1")
+	}
+	if seconds > 0 {
+		q.Set("seconds", strconv.Itoa(seconds))
+	}
+
+	out := base + path
+	if len(q) > 0 {
+		out += "?" + q.Encode()
+	}
+	return out, nil
+}
+
+// pprofOutputPath resolves where the profile lands. Text and list output go to
+// stdout by default (you want to read it); a binary profile defaults to a file
+// because dumping gzip to a terminal is never what anyone meant. Pure.
+func pprofOutputPath(explicit, profile string, debug int, list bool) string {
+	if explicit != "" {
+		return explicit
+	}
+	if list || debug > 0 {
+		return "-"
+	}
+	return profile + ".pb.gz"
+}
+
+// pprofClientTimeout leaves room for a CPU profile to run its full window plus
+// transfer, without letting a stuck sentinel hang the operator forever.
+func pprofClientTimeout(seconds int) time.Duration {
+	const slack = 30 * time.Second
+	if seconds > 0 {
+		return time.Duration(seconds)*time.Second + slack
+	}
+	return 60 * time.Second
+}
+
+func runSentinelPprof(cmd *cobra.Command, args []string) error {
+	if sentinelPprofSecret == "" {
+		return fmt.Errorf("sentinel admin secret is required — pass --secret or set %s", config.EnvSentinelAdminSecret)
+	}
+	if sentinelPprofDebug < 0 || sentinelPprofDebug > 2 {
+		return fmt.Errorf("--debug must be 0, 1, or 2")
+	}
+	if sentinelPprofSeconds != 0 && sentinelPprofProfile != "profile" {
+		return fmt.Errorf("--seconds applies only to --profile profile (the CPU profile)")
+	}
+
+	endpoint, err := buildPprofURL(sentinelPprofURL, sentinelPprofProfile, sentinelPprofSeconds, sentinelPprofDebug, sentinelPprofGC, sentinelPprofList)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	auth.SignSentinelRequest(req, []byte(sentinelPprofSecret))
+
+	if sentinelPprofSeconds > 0 {
+		fmt.Fprintf(cmd.ErrOrStderr(), "profiling CPU for %ds…\n", sentinelPprofSeconds)
+	}
+
+	client := &http.Client{Timeout: pprofClientTimeout(sentinelPprofSeconds)}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		msg := strings.TrimSpace(string(body))
+		if resp.StatusCode == http.StatusUnauthorized {
+			return fmt.Errorf("sentinel returned 401 — check %s matches the value on the sentinel host, and that both clocks are within 5 minutes (%s)",
+				config.EnvSentinelAdminSecret, msg)
+		}
+		return fmt.Errorf("sentinel returned %d: %s", resp.StatusCode, msg)
+	}
+
+	outPath := pprofOutputPath(sentinelPprofOutput, sentinelPprofProfile, sentinelPprofDebug, sentinelPprofList)
+	if outPath == "-" {
+		if _, err := io.Copy(cmd.OutOrStdout(), resp.Body); err != nil {
+			return fmt.Errorf("write to stdout: %w", err)
+		}
+		return nil
+	}
+
+	// 0600: the profile may contain tokens and key material lifted straight
+	// out of the sentinel's heap.
+	f, err := os.OpenFile(outPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", outPath, err)
+	}
+	n, copyErr := io.Copy(f, resp.Body)
+	closeErr := f.Close()
+	if copyErr != nil {
+		return fmt.Errorf("write %s: %w", outPath, copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close %s: %w", outPath, closeErr)
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "wrote %s (%d bytes, mode 0600 — contains sentinel heap contents)\n", outPath, n)
+	fmt.Fprintf(cmd.ErrOrStderr(), "inspect with: go tool pprof %s\n", outPath)
+	if sentinelPprofProfile == "heap" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "to find a leak, capture a second snapshot later and diff: go tool pprof -base %s <later>.pb.gz\n", outPath)
+	}
+	return nil
+}

--- a/internal/cmd/sentinel_pprof_test.go
+++ b/internal/cmd/sentinel_pprof_test.go
@@ -1,0 +1,238 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/internal/config"
+	"github.com/footprintai/containarium/internal/sentinel"
+	"github.com/spf13/cobra"
+)
+
+func TestBuildPprofURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    string
+		profile string
+		seconds int
+		debug   int
+		gc      bool
+		list    bool
+		want    string
+		wantErr string
+	}{
+		{
+			name: "plain heap", base: "http://sentinel.example:8888", profile: "heap",
+			want: "http://sentinel.example:8888/debug/pprof/heap",
+		},
+		{
+			name: "trailing slash on base is not doubled", base: "http://sentinel.example:8888/", profile: "heap",
+			want: "http://sentinel.example:8888/debug/pprof/heap",
+		},
+		{
+			name: "heap with forced GC", base: "https://sentinel.example:8889", profile: "heap", gc: true,
+			want: "https://sentinel.example:8889/debug/pprof/heap?gc=1",
+		},
+		{
+			name: "goroutine as text", base: "http://sentinel.example:8888", profile: "goroutine", debug: 1,
+			want: "http://sentinel.example:8888/debug/pprof/goroutine?debug=1",
+		},
+		{
+			name: "cpu with duration", base: "http://sentinel.example:8888", profile: "profile", seconds: 45,
+			want: "http://sentinel.example:8888/debug/pprof/profile?seconds=45",
+		},
+		{
+			name: "list hits the index, not a named profile", base: "http://sentinel.example:8888", profile: "heap", list: true,
+			want: "http://sentinel.example:8888/debug/pprof/",
+		},
+		{
+			name: "empty url", base: "   ", profile: "heap",
+			wantErr: "empty --url",
+		},
+		{
+			// A bare host:port is the likeliest operator slip; it must not
+			// silently produce a relative path that fails much later.
+			name: "missing scheme", base: "sentinel.example:8888", profile: "heap",
+			wantErr: "want an http:// or https:// base URL",
+		},
+		{
+			name: "empty profile", base: "http://sentinel.example:8888", profile: "  ",
+			wantErr: "empty --profile",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildPprofURL(tc.base, tc.profile, tc.seconds, tc.debug, tc.gc, tc.list)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got URL %q", tc.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %q, want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("URL = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPprofOutputPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		explicit string
+		profile  string
+		debug    int
+		list     bool
+		want     string
+	}{
+		{name: "binary profile defaults to a file", profile: "heap", want: "heap.pb.gz"},
+		{name: "explicit path always wins", explicit: "/tmp/x.pb.gz", profile: "heap", want: "/tmp/x.pb.gz"},
+		{name: "explicit dash stays stdout", explicit: "-", profile: "heap", want: "-"},
+		// Text output is meant to be read, so it goes to the terminal — but a
+		// binary profile must never default to dumping gzip into a tty.
+		{name: "text output defaults to stdout", profile: "goroutine", debug: 1, want: "-"},
+		{name: "list defaults to stdout", profile: "heap", list: true, want: "-"},
+		{name: "explicit file beats text default", explicit: "dump.txt", profile: "goroutine", debug: 2, want: "dump.txt"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pprofOutputPath(tc.explicit, tc.profile, tc.debug, tc.list); got != tc.want {
+				t.Errorf("pprofOutputPath = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The client timeout must outlast the CPU profile window, or a --seconds=60
+// capture would always be killed by its own client just before finishing.
+func TestPprofClientTimeoutOutlastsCPUWindow(t *testing.T) {
+	for _, seconds := range []int{1, 30, 60} {
+		got := pprofClientTimeout(seconds)
+		if got <= time.Duration(seconds)*time.Second {
+			t.Errorf("pprofClientTimeout(%d) = %v, must exceed the %ds profile window", seconds, got, seconds)
+		}
+	}
+	if got := pprofClientTimeout(0); got < 30*time.Second {
+		t.Errorf("default timeout = %v, want a usable floor for a large heap transfer", got)
+	}
+}
+
+// TestSentinelPprofEndToEnd drives the real operator path: the cobra command
+// signs a request, the real sentinel handler serves a real heap profile behind
+// the real HMAC middleware, and the profile lands on disk. The unit tests above
+// cover URL assembly; this one covers "does the whole thing actually work".
+func TestSentinelPprofEndToEnd(t *testing.T) {
+	const secret = "e2e-pprof-admin-secret-32-bytes-ok!!"
+
+	var mgr sentinel.Manager
+	srv := httptest.NewServer(auth.SentinelHMACMiddleware([]byte(secret), mgr.PprofHandler()))
+	t.Cleanup(srv.Close)
+
+	out := filepath.Join(t.TempDir(), "heap.pb.gz")
+	t.Cleanup(resetSentinelPprofFlags)
+	resetSentinelPprofFlags()
+	sentinelPprofURL = srv.URL
+	sentinelPprofProfile = "heap"
+	sentinelPprofOutput = out
+	sentinelPprofGC = true
+	sentinelPprofSecret = secret
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetContext(context.Background())
+	if err := runSentinelPprof(cmd, nil); err != nil {
+		t.Fatalf("runSentinelPprof: %v", err)
+	}
+
+	fi, err := os.Stat(out)
+	if err != nil {
+		t.Fatalf("profile not written: %v", err)
+	}
+	// A heap profile carries whatever the process holds in memory; it must not
+	// be group/world readable on the operator's workstation.
+	if perm := fi.Mode().Perm(); perm != 0600 {
+		t.Errorf("profile mode = %04o, want 0600 — it contains sentinel heap contents", perm)
+	}
+
+	body, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read profile: %v", err)
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("saved file is not a gzipped profile, go tool pprof cannot open it: %v", err)
+	}
+	defer func() { _ = zr.Close() }()
+	raw, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("corrupt profile: %v", err)
+	}
+	if !bytes.Contains(raw, []byte("inuse_space")) {
+		t.Error("saved heap profile has no inuse_space sample type")
+	}
+}
+
+// TestSentinelPprofRejectsWrongSecret pins the operator-facing half of the
+// gate: a bad secret must produce an actionable 401 message, not a stray file.
+func TestSentinelPprofRejectsWrongSecret(t *testing.T) {
+	var mgr sentinel.Manager
+	srv := httptest.NewServer(auth.SentinelHMACMiddleware([]byte("the-real-admin-secret-32-bytes-long!"), mgr.PprofHandler()))
+	t.Cleanup(srv.Close)
+
+	out := filepath.Join(t.TempDir(), "heap.pb.gz")
+	t.Cleanup(resetSentinelPprofFlags)
+	resetSentinelPprofFlags()
+	sentinelPprofURL = srv.URL
+	sentinelPprofProfile = "heap"
+	sentinelPprofOutput = out
+	sentinelPprofSecret = "a-different-admin-secret-32-bytes-x!"
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetContext(context.Background())
+
+	err := runSentinelPprof(cmd, nil)
+	if err == nil {
+		t.Fatal("want an error on a wrong secret, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") || !strings.Contains(err.Error(), config.EnvSentinelAdminSecret) {
+		t.Errorf("error = %q, want it to mention 401 and %s so the operator knows what to fix", err, config.EnvSentinelAdminSecret)
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Error("a rejected request still created the output file")
+	}
+}
+
+// resetSentinelPprofFlags clears the package-level flag vars between tests, so
+// one test's settings cannot leak into another's.
+func resetSentinelPprofFlags() {
+	sentinelPprofURL = ""
+	sentinelPprofProfile = "heap"
+	sentinelPprofOutput = ""
+	sentinelPprofSeconds = 0
+	sentinelPprofDebug = 0
+	sentinelPprofGC = false
+	sentinelPprofList = false
+	sentinelPprofSecret = ""
+}

--- a/internal/sentinel/binaryserver.go
+++ b/internal/sentinel/binaryserver.go
@@ -132,6 +132,17 @@ func buildBinaryServerMux(binaryPath string, manager *Manager) *http.ServeMux {
 	// every tenant's backend for anything that could reach this port.
 	mux.Handle("/peer/", auth.SentinelHMACMiddleware(manager.adminSecret, manager.PeerProxyHandler()))
 
+	// Runtime profiles (#1352). Gated by the ADMIN secret for the same reason
+	// as the routes above, and then some: a heap profile is a snapshot of
+	// everything the process holds in memory — tunnel-join tokens, TLS key
+	// material, in-flight bodies. The cluster-wide daemon secret every backend
+	// holds must not be enough to dump the sentinel's memory.
+	//
+	// Exists because #1349 leaked ~18 MB/day for 27 days and was OOM-killed
+	// having never been profiled; see PprofHandler for why this is wired from
+	// runtime/pprof rather than net/http/pprof.
+	mux.Handle(pprofPathPrefix, auth.SentinelHMACMiddleware(manager.adminSecret, manager.PprofHandler()))
+
 	// Status JSON endpoint — always available
 	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		status := StatusJSON{

--- a/internal/sentinel/pprof_handler.go
+++ b/internal/sentinel/pprof_handler.go
@@ -128,7 +128,18 @@ func servePprofNamed(w http.ResponseWriter, r *http.Request, name string) {
 	if err := p.WriteTo(w, debug); err != nil {
 		// Headers are already out; the truncated body is the only signal the
 		// client gets, so make sure the operator sees it host-side too.
-		log.Printf("[sentinel] pprof: writing %s profile failed: %v", name, err)
+		//
+		// Log p.Name(), not the request-derived `name`: they are equal by
+		// construction here (Lookup succeeded), but p.Name() comes from the
+		// runtime's own profile registry rather than the URL, so no caller
+		// can smuggle newlines into the journal.
+		//
+		// #nosec G706 -- p.Name() is a registered runtime profile name, and
+		// %q quotes it besides. gosec chases the taint back through
+		// pprof.Lookup to the request path and doesn't recognize either as a
+		// sanitizer — same false positive already annotated in
+		// binaryserver.go.
+		log.Printf("[sentinel] pprof: writing %q profile failed: %v", p.Name(), err)
 	}
 }
 

--- a/internal/sentinel/pprof_handler.go
+++ b/internal/sentinel/pprof_handler.go
@@ -1,0 +1,183 @@
+package sentinel
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"runtime"
+	"runtime/pprof"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Sentinel self-profiling (#1352).
+//
+// The sentinel had no way to produce a heap profile from a running process.
+// When #1349 OOM-killed it at 565 MB RSS — after ~27 days of ~18 MB/day growth
+// — the process was gone before anything could be captured, and the leak could
+// not be located without building an instrumented binary and waiting weeks for
+// it to reproduce in production. This endpoint is that missing diagnostic.
+//
+// Two deliberate choices:
+//
+//  1. runtime/pprof, NOT net/http/pprof. The latter's init() registers
+//     /debug/pprof/* on http.DefaultServeMux merely by being imported, blank
+//     or named. Nothing serves DefaultServeMux in this binary today, so the
+//     exposure would be invisible — right up until someone adds an
+//     http.ListenAndServe(addr, nil) for something unrelated and silently
+//     publishes an unauthenticated heap dump of the daemon, the agent-box, or
+//     the sentinel (all the same binary). Wiring runtime/pprof by hand costs
+//     ~40 lines and has no global side effects. TestPprofNotRegisteredOnDefaultServeMux
+//     fails if the import ever comes back.
+//
+//  2. Gated on the ADMIN secret, not the cluster-wide daemon HMAC secret. A
+//     heap profile contains whatever the process is holding: tunnel-join
+//     tokens, TLS private key material, in-flight request bodies. Every
+//     backend daemon in the cluster holds the daemon secret for
+//     keysync/certsync, so gating there would let any one of them dump the
+//     sentinel's memory. This is an operator/control-plane capability, gated
+//     like /sentinel/tunnel-tokens and /peer/ (#1102, #733).
+//
+// The path stays at the conventional /debug/pprof/ rather than under
+// /sentinel/*: it is what operators and `go tool pprof` expect, and it is the
+// exact path internal/pentest probes for an exposed profiler — so our own
+// scanner now validates this gate instead of missing a route it doesn't know
+// about.
+
+const (
+	// pprofDefaultCPUSeconds matches net/http/pprof's default.
+	pprofDefaultCPUSeconds = 30
+
+	// pprofMaxCPUSeconds bounds ?seconds= so a request cannot outlive the
+	// binary server's 120s WriteTimeout (which would drop the response after
+	// paying the whole profiling cost) or pin the profiler indefinitely.
+	pprofMaxCPUSeconds = 60
+
+	pprofPathPrefix = "/debug/pprof/"
+)
+
+// PprofHandler serves runtime profiles. Mount it behind the admin-secret HMAC
+// middleware — it is never safe to expose unauthenticated.
+//
+//	GET /debug/pprof/              index of available profiles
+//	GET /debug/pprof/heap          heap profile (add ?gc=1 to force GC first)
+//	GET /debug/pprof/goroutine     goroutine profile (?debug=1 for text)
+//	GET /debug/pprof/allocs        cumulative allocations
+//	GET /debug/pprof/profile       CPU profile (?seconds=1..60, default 30)
+func (m *Manager) PprofHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := strings.TrimPrefix(r.URL.Path, pprofPathPrefix)
+
+		// Profiles are never worth caching or sniffing.
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+
+		switch name {
+		case "", "index":
+			servePprofIndex(w)
+		case "profile":
+			servePprofCPU(w, r)
+		default:
+			servePprofNamed(w, r, name)
+		}
+	})
+}
+
+// servePprofIndex lists the profiles this runtime actually has, with their
+// current object counts — enough to pick one without a second round trip.
+func servePprofIndex(w http.ResponseWriter) {
+	profiles := pprof.Profiles()
+	sort.Slice(profiles, func(i, j int) bool { return profiles[i].Name() < profiles[j].Name() })
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprintf(w, "sentinel runtime profiles (%s, %d goroutines)\n\n", runtime.Version(), runtime.NumGoroutine())
+	fmt.Fprintf(w, "%-16s %s\n", "PROFILE", "COUNT")
+	for _, p := range profiles {
+		fmt.Fprintf(w, "%-16s %d\n", p.Name(), p.Count())
+	}
+	fmt.Fprintf(w, "%-16s %s\n", "profile", "(CPU; ?seconds=1..60)")
+	fmt.Fprint(w, "\nAdd ?debug=1 for text output, ?gc=1 to force a GC before a heap snapshot.\n")
+	fmt.Fprint(w, "Fetch with: containarium sentinel pprof --url <sentinel-url> --profile heap -o heap.pb.gz\n")
+}
+
+// servePprofNamed writes one of the runtime's registered profiles.
+func servePprofNamed(w http.ResponseWriter, r *http.Request, name string) {
+	p := pprof.Lookup(name)
+	if p == nil {
+		http.Error(w, fmt.Sprintf("unknown profile %q — GET %s for the list\n", name, pprofPathPrefix), http.StatusNotFound)
+		return
+	}
+
+	debug, err := pprofIntParam(r, "debug", 0)
+	if err != nil || debug < 0 || debug > 2 {
+		http.Error(w, "debug must be 0, 1, or 2\n", http.StatusBadRequest)
+		return
+	}
+
+	// A heap profile taken without a GC counts garbage that is merely
+	// unswept, which reads as a leak that isn't one. ?gc=1 forces a
+	// collection first so inuse_space reflects genuinely live memory — the
+	// distinction that matters when chasing #1349.
+	if name == "heap" && r.FormValue("gc") == "1" {
+		runtime.GC()
+	}
+
+	writePprofHeaders(w, name, debug)
+	if err := p.WriteTo(w, debug); err != nil {
+		// Headers are already out; the truncated body is the only signal the
+		// client gets, so make sure the operator sees it host-side too.
+		log.Printf("[sentinel] pprof: writing %s profile failed: %v", name, err)
+	}
+}
+
+// servePprofCPU runs a bounded CPU profile.
+func servePprofCPU(w http.ResponseWriter, r *http.Request) {
+	seconds, err := pprofIntParam(r, "seconds", pprofDefaultCPUSeconds)
+	if err != nil {
+		http.Error(w, "seconds must be an integer\n", http.StatusBadRequest)
+		return
+	}
+	if seconds < 1 || seconds > pprofMaxCPUSeconds {
+		http.Error(w, fmt.Sprintf("seconds must be between 1 and %d\n", pprofMaxCPUSeconds), http.StatusBadRequest)
+		return
+	}
+
+	writePprofHeaders(w, "profile", 0)
+	if err := pprof.StartCPUProfile(w); err != nil {
+		// The runtime allows only one CPU profile at a time process-wide.
+		// 409 rather than 500: the caller's request is fine, the resource is
+		// busy, and retrying later is the correct response.
+		http.Error(w, fmt.Sprintf("CPU profile already in progress: %v\n", err), http.StatusConflict)
+		return
+	}
+	defer pprof.StopCPUProfile()
+
+	select {
+	case <-time.After(time.Duration(seconds) * time.Second):
+	case <-r.Context().Done():
+		// Client hung up — stop early via the deferred StopCPUProfile rather
+		// than holding the profiler for the full window.
+	}
+}
+
+// writePprofHeaders sets the content type and, for binary profiles, a filename
+// so a plain `curl -O` lands something go tool pprof can open by name.
+func writePprofHeaders(w http.ResponseWriter, name string, debug int) {
+	if debug > 0 {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		return
+	}
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.pb.gz"`, name))
+}
+
+// pprofIntParam reads an integer query parameter, returning def when absent.
+func pprofIntParam(r *http.Request, key string, def int) (int, error) {
+	raw := r.FormValue(key)
+	if raw == "" {
+		return def, nil
+	}
+	return strconv.Atoi(raw)
+}

--- a/internal/sentinel/pprof_handler_test.go
+++ b/internal/sentinel/pprof_handler_test.go
@@ -1,0 +1,233 @@
+package sentinel
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/internal/auth"
+)
+
+// #1352: the sentinel had no way to produce a heap profile, so the leak in
+// #1349 was OOM-killed at 565 MB having never been profiled and could not be
+// root-caused without shipping an instrumented build to production.
+//
+// These tests pin the two halves that matter: the profile is actually usable
+// by `go tool pprof` (not just "some bytes came back"), and it is gated behind
+// the ADMIN secret — a heap dump contains whatever the process holds in
+// memory, which on a sentinel includes tunnel-join tokens and TLS key
+// material, so it is strictly more sensitive than the cluster-wide daemon
+// secret's blast radius.
+
+const (
+	testPprofAdminSecret = "pprof-admin-secret-at-least-32-bytes!!"
+	testPprofHMACSecret  = "pprof-daemon-hmac-secret-32-bytes-long!"
+)
+
+// newPprofTestServer serves the REAL binary-server route table, for the same
+// reason newPeerProxyTestServer does (#1102): which middleware a route is
+// registered behind IS the fix here, so a hand-wired mux would keep these
+// tests green through a revert of the gate.
+func newPprofTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	m := &Manager{
+		backends:    NewBackendPool(),
+		adminSecret: []byte(testPprofAdminSecret),
+		hmacSecret:  []byte(testPprofHMACSecret),
+	}
+	srv := httptest.NewServer(buildBinaryServerMux("/nonexistent/containarium", m))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// getPprof issues a GET, signing with secret when it is non-empty.
+func getPprof(t *testing.T, srv *httptest.Server, path, secret string) (int, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, srv.URL+path, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if secret != "" {
+		auth.SignSentinelRequest(req, []byte(secret))
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return resp.StatusCode, body
+}
+
+func TestPprofRequiresAdminSecret(t *testing.T) {
+	srv := newPprofTestServer(t)
+
+	// Unsigned — the state the pentest module (module_web.go) probes for.
+	if code, _ := getPprof(t, srv, "/debug/pprof/heap", ""); code != http.StatusUnauthorized {
+		t.Fatalf("unsigned /debug/pprof/heap = %d, want 401 — profile endpoint is exposed", code)
+	}
+
+	// Signed with the cluster-wide DAEMON secret. Every backend daemon holds
+	// this one for keysync/certsync; a heap dump is a bigger capability than
+	// that, so it must not be sufficient here.
+	if code, _ := getPprof(t, srv, "/debug/pprof/heap", testPprofHMACSecret); code != http.StatusUnauthorized {
+		t.Fatalf("/debug/pprof/heap signed with the daemon HMAC secret = %d, want 401 — "+
+			"gated on the wrong secret, every daemon in the cluster can dump sentinel memory", code)
+	}
+
+	// Signed with the admin secret — the one legitimate caller.
+	if code, _ := getPprof(t, srv, "/debug/pprof/heap", testPprofAdminSecret); code != http.StatusOK {
+		t.Fatalf("/debug/pprof/heap signed with the admin secret = %d, want 200", code)
+	}
+}
+
+// TestPprofHeapIsReadableByGoToolPprof is the acceptance criterion for #1352:
+// not "bytes came back" but "the bytes are a profile go tool pprof can open,
+// with the sample type you need to find a leak".
+func TestPprofHeapIsReadableByGoToolPprof(t *testing.T) {
+	srv := newPprofTestServer(t)
+
+	code, body := getPprof(t, srv, "/debug/pprof/heap", testPprofAdminSecret)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+
+	// A pprof profile on the wire is gzipped protobuf; go tool pprof rejects
+	// anything else. Decompressing here proves the framing without taking a
+	// dependency on github.com/google/pprof (which drags a readline terminal
+	// library into the module graph for a parse we can do structurally).
+	raw := gunzipOrFail(t, body)
+
+	// Sample-type names live in the profile's string table as plain UTF-8, so
+	// they are assertable on the decompressed bytes. inuse_space is what
+	// answers "what is holding 480 MB right now" — the actual question in
+	// #1349, and the one sample type this endpoint exists to deliver.
+	for _, want := range []string{"inuse_space", "inuse_objects", "space", "bytes"} {
+		if !bytes.Contains(raw, []byte(want)) {
+			t.Errorf("heap profile string table has no %q — not a usable heap profile", want)
+		}
+	}
+	if len(raw) < 128 {
+		t.Fatalf("heap profile is %d bytes decompressed — too small to contain samples", len(raw))
+	}
+}
+
+// gunzipOrFail decompresses a pprof response body, failing the test with the
+// leading bytes when it is not a valid gzip stream.
+func gunzipOrFail(t *testing.T, body []byte) []byte {
+	t.Helper()
+	zr, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("response is not gzipped protobuf, so go tool pprof cannot read it: %v (first 32 bytes: %q)",
+			err, truncBytes(body, 32))
+	}
+	defer func() { _ = zr.Close() }()
+	raw, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("truncated/corrupt gzip stream: %v", err)
+	}
+	return raw
+}
+
+func TestPprofGoroutineProfileAndDebugTextMode(t *testing.T) {
+	srv := newPprofTestServer(t)
+
+	// debug=0 (default) → parseable binary profile.
+	code, body := getPprof(t, srv, "/debug/pprof/goroutine", testPprofAdminSecret)
+	if code != http.StatusOK {
+		t.Fatalf("goroutine status = %d, want 200", code)
+	}
+	if raw := gunzipOrFail(t, body); !bytes.Contains(raw, []byte("goroutine")) {
+		t.Error("goroutine profile string table does not mention goroutines")
+	}
+
+	// debug=1 → human-readable text, for reading over SSH without go tool pprof.
+	code, body = getPprof(t, srv, "/debug/pprof/goroutine?debug=1", testPprofAdminSecret)
+	if code != http.StatusOK {
+		t.Fatalf("goroutine?debug=1 status = %d, want 200", code)
+	}
+	if !bytes.Contains(body, []byte("goroutine profile")) {
+		t.Fatalf("debug=1 output is not the text format; got first 120 bytes: %q", truncBytes(body, 120))
+	}
+}
+
+func TestPprofIndexListsProfiles(t *testing.T) {
+	srv := newPprofTestServer(t)
+
+	code, body := getPprof(t, srv, "/debug/pprof/", testPprofAdminSecret)
+	if code != http.StatusOK {
+		t.Fatalf("index status = %d, want 200", code)
+	}
+	for _, want := range []string{"heap", "goroutine", "allocs"} {
+		if !bytes.Contains(body, []byte(want)) {
+			t.Errorf("index does not mention %q; got: %s", want, truncBytes(body, 300))
+		}
+	}
+}
+
+func TestPprofUnknownProfileIs404(t *testing.T) {
+	srv := newPprofTestServer(t)
+
+	code, body := getPprof(t, srv, "/debug/pprof/not-a-real-profile", testPprofAdminSecret)
+	if code != http.StatusNotFound {
+		t.Fatalf("unknown profile = %d, want 404 (body: %s)", code, truncBytes(body, 200))
+	}
+}
+
+func TestPprofCPUSecondsIsValidatedAndBounded(t *testing.T) {
+	srv := newPprofTestServer(t)
+
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{"non-numeric", "?seconds=forever"},
+		{"zero", "?seconds=0"},
+		{"negative", "?seconds=-5"},
+		{"over the cap", "?seconds=600"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, _ := getPprof(t, srv, "/debug/pprof/profile"+tc.query, testPprofAdminSecret)
+			if code != http.StatusBadRequest {
+				t.Fatalf("seconds%s = %d, want 400", tc.query, code)
+			}
+		})
+	}
+}
+
+// TestPprofNotRegisteredOnDefaultServeMux guards the trap in this change.
+//
+// Importing net/http/pprof — blank OR named — runs its init(), which registers
+// /debug/pprof/* on http.DefaultServeMux as a side effect. Nothing serves
+// DefaultServeMux today, so that would be invisible; the day someone adds an
+// http.ListenAndServe(addr, nil) anywhere in this binary (the daemon, the
+// agent-box and the sentinel are all the same binary) it silently becomes an
+// UNAUTHENTICATED heap-dump endpoint on that port. This handler uses
+// runtime/pprof directly to avoid that, and this test fails if a future change
+// reintroduces the import.
+func TestPprofNotRegisteredOnDefaultServeMux(t *testing.T) {
+	for _, path := range []string{"/debug/pprof/", "/debug/pprof/heap", "/debug/pprof/profile"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		if _, pattern := http.DefaultServeMux.Handler(req); pattern != "" {
+			t.Fatalf("%s is registered on http.DefaultServeMux (pattern %q) — "+
+				"something imported net/http/pprof. Its init() exposes an "+
+				"unauthenticated profile endpoint on any server that uses the "+
+				"default mux; use runtime/pprof directly instead.", path, pattern)
+		}
+	}
+}
+
+func truncBytes(b []byte, n int) string {
+	s := strings.TrimSpace(string(b))
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}


### PR DESCRIPTION
Closes #1352. Unblocks #1349.

## Why

The sentinel had no way to produce a heap profile from a running process. When #1349 OOM-killed it at 565 MB RSS — after ~27 days of ~18 MB/day growth — the process was gone before anything could be captured. Root-causing the leak meant building an instrumented binary, shipping it to production, and waiting weeks for it to reproduce. This is the missing diagnostic, so #1349 can be worked on a live host.

## What

```
GET /debug/pprof/            index of available profiles + object counts
GET /debug/pprof/heap        heap profile      (?gc=1 forces a GC first)
GET /debug/pprof/goroutine   goroutine profile (?debug=1 for text)
GET /debug/pprof/allocs      cumulative allocations
GET /debug/pprof/profile     CPU profile       (?seconds=1..60, default 30)
```

Plus `containarium sentinel pprof`, because `go tool pprof` cannot sign HMAC requests and therefore cannot fetch the URL itself:

```bash
# capture, then diff two snapshots hours apart — the #1349 workflow
containarium sentinel pprof --url http://<sentinel-host>:8888 --profile heap --gc -o heap-t0.pb.gz
containarium sentinel pprof --url http://<sentinel-host>:8888 --profile heap --gc -o heap-t1.pb.gz
go tool pprof -base heap-t0.pb.gz heap-t1.pb.gz
```

CLI-first per `CLAUDE.md` — no agent-only escape hatch; profiles are written `0600` since they contain sentinel heap contents.

`?gc=1` matters more than it looks: a heap profile taken without a collection counts garbage that is merely unswept, which reads as a leak that isn't one. Forcing a GC first makes `inuse_space` genuinely live memory — the distinction that decides whether growth is real.

## Two design calls worth reviewing

**`runtime/pprof`, not `net/http/pprof`.** The latter's `init()` registers `/debug/pprof/*` on `http.DefaultServeMux` merely by being imported — blank or named. Nothing serves the default mux today, so the exposure would be invisible; the day someone adds an `http.ListenAndServe(addr, nil)` for something unrelated, it silently publishes an unauthenticated heap dump of the daemon, the agent-box, or the sentinel — all the same binary. Hand-wiring `runtime/pprof` costs ~40 lines and has no global side effects. `TestPprofNotRegisteredOnDefaultServeMux` fails if the import ever comes back.

**Gated on the ADMIN secret, not the cluster-wide daemon HMAC secret.** A heap profile is a snapshot of everything the process holds: tunnel-join tokens, TLS private key material, in-flight request bodies. Every backend daemon holds the daemon secret for keysync/certsync, so gating there would let any one of them dump the sentinel's memory. Gated like `/sentinel/tunnel-tokens` and `/peer/` — see #1102 and #733.

The path stays at the conventional `/debug/pprof/` rather than under `/sentinel/*`: it is what operators and `go tool pprof` expect, and it is the exact path `internal/pentest/module_web.go` probes for an exposed profiler — so our own scanner now validates this gate (401) instead of missing a route it doesn't know about.

## Verification

**The gate is mutation-checked**, against the real route table via `buildBinaryServerMux` rather than a hand-wired mux — the failure mode `peer_proxy_handler_test.go` documents from #1102:

| Mutation | Result |
| --- | --- |
| Remove the HMAC middleware | `unsigned /debug/pprof/heap = 200, want 401 — profile endpoint is exposed` |
| Gate on `hmacSecret` instead of `adminSecret` | `signed with the daemon HMAC secret = 200, want 401 — every daemon in the cluster can dump sentinel memory` |

Neither can go green through a revert of the gate.

**End-to-end**, driving the real operator path — CLI signs, real handler serves behind real middleware, profile lands on disk `0600` and gunzips to a string table containing `inuse_space`. Plus a wrong-secret case asserting an actionable 401 and no stray file.

**Live smoke** against a real HTTP server with a planted 100 MB leak:

```
unsigned  GET /debug/pprof/heap -> 401
signed    GET /debug/pprof/heap -> 200 (attachment; filename="heap.pb.gz")

$ go tool pprof -top -nodecount=5 heap.pb.gz
Type: inuse_space
      flat  flat%   sum%        cum   cum%
  100.03MB 91.68% 91.68%   100.03MB 91.68%  main.leakLikeASentinel
```

That is the output #1349 needs: the leak attributed to a named function.

`go vet` clean, `golangci-lint` 0 issues, full `internal/sentinel` and `internal/cmd` suites pass.

## Notes for the reviewer

- **No new dependencies.** I initially added `github.com/google/pprof` to parse profiles in tests, then reverted it — it drags `chzyer/readline` and a demangler into the module graph, and a terminal library in this binary's dependency tree is a bad trade for a test assertion. Tests gunzip and assert on the profile's string table instead, which proves the same wire framing.
- **CPU profile bounds:** `?seconds` is capped at 60 so a request cannot outlive the binary server's 120s `WriteTimeout`. Concurrent CPU profiles return 409, not 500 — the caller's request is fine, the resource is busy.
- **Follow-ups, not in scope here:** #1351 (sentinel `/metrics` publishes no process/runtime series, so the growth was invisible for 27 days) and #1350 (no `MemoryHigh`/`MemoryMax` on the unit, which is why #1349 cost ~36 minutes rather than a process restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
