### PR TITLE
fix(ci): bump Go 1.26.5 -> 1.26.6 to clear 7 reachable stdlib vulns (#1354)

### DIFF
--- a/.github/workflows/distros-go-ci.yml
+++ b/.github/workflows/distros-go-ci.yml
@@ -38,7 +38,7 @@ jobs:
           # Pinned to match the version the daemon's release workflow
           # uses; drift would mean release-built daemon and CI-tested
           # distro stop sharing a toolchain.
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Verify module hygiene
         # `go mod tidy` should be a no-op on a clean PR. If it changes

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install golangci-lint
         # Pinned to the version the config (version: "2") targets. `go install`

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
       - name: Build k8s variant
         run: go build -tags k8s ./...
       - name: Reconciler unit tests (fake clientset, no cluster)
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
       - name: Install kind
         run: |
           curl -fsSL -o ./kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64

--- a/.github/workflows/proxyproto-e2e.yml
+++ b/.github/workflows/proxyproto-e2e.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Windows client cross-compile guard
         # The release builds a client-only Windows binary (cmd/containarium for
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Cache built caddy binary
         id: cache-caddy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install buf
         # `make build-release` transitively runs `make proto`, which
@@ -224,7 +224,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install buf
         run: go install github.com/bufbuild/buf/cmd/buf@latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/footprintai/containarium
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/compute v1.65.0

--- a/images/agent-box/Dockerfile
+++ b/images/agent-box/Dockerfile
@@ -22,7 +22,7 @@
 # --- build agent-box -------------------------------------------------------
 # No `k8s` build tag here: agent-box is the in-box MCP and never imports
 # client-go, so this stays a small static binary.
-FROM golang:1.26.5-bookworm AS build
+FROM golang:1.26.6-bookworm AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/images/daemon/Dockerfile
+++ b/images/daemon/Dockerfile
@@ -16,7 +16,7 @@
 # remain the binary release (`make build-release`).
 
 # --- build the daemon ------------------------------------------------------
-FROM golang:1.26.5-bookworm AS build
+FROM golang:1.26.6-bookworm AS build
 ARG VERSION=dev
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/images/mcp-server/Dockerfile
+++ b/images/mcp-server/Dockerfile
@@ -19,7 +19,7 @@
 #     -e CONTAINARIUM_JWT_TOKEN=... \
 #     containarium-mcp-server
 
-FROM golang:1.26.5-bookworm AS build
+FROM golang:1.26.6-bookworm AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
Closes #1354. Unblocks the govulncheck check on #1353 and every other open PR.

## Why

Go 1.26.6 shipped a batch of standard-library security fixes. With `go.mod` pinned to `1.26.5`, govulncheck reports 7 reachable stdlib vulnerabilities and the **Vulnerability Check** job fails on every pull request — including PRs that touch none of the affected code.

| ID | Package | | ID | Package |
| --- | --- | --- | --- | --- |
| GO-2026-6218 | `net/url` | | GO-2026-6088 | `encoding/xml` |
| GO-2026-6091 | `html/template` | | GO-2026-5972 | `encoding/asn1` |
| GO-2026-6090 | `crypto/tls` | | GO-2026-5942 | `net` |
| GO-2026-6089 | `net/http` | | | |

`crypto/tls`, `net/http` and `net/url` sit directly on the sentinel's and gateway's request paths — the report names live call sites in `pkg/core/incus/client.go`, `internal/gateway/terminal.go` and `internal/server/dual_server.go`, so this isn't a theoretical reachability claim.

Nothing on `main` moved; the advisory database did. `main`'s last green Security Scanning run was 2026-08-13 14:50 UTC, before these published.

## What

Every pin that names a version:

- `go.mod` — `go 1.26.5` → `1.26.6`
- 9 `go-version:` entries across 6 workflows (`security`, `golangci-lint`, `release` ×2, `k8s-e2e` ×2, `proxyproto-e2e` ×2, `distros-go-ci`)
- 3 builder images — `golang:1.26.5-bookworm` → `1.26.6-bookworm`

`zfs-encryption.yml` already uses `go-version-file: go.mod`, so it follows automatically and needed no edit.

**`CHANGELOG.md` deliberately left alone.** Its `1.26.5` mention is the historical record of the #1061 bump, not a live pin — rewriting it would falsify a shipped release note.

## Verification

Under go1.26.6, locally:

- **govulncheck**: stdlib findings gone. `30 vulnerabilities from 1 module and the Go standard library` → `22 vulnerabilities from 1 module`. All 22 that remain are `github.com/lxc/incus/v6` with `Fixed in: N/A`:
  ```
  $ govulncheck ./... | grep 'Fixed in:' | sort | uniq -c
       22     Fixed in: N/A
  ```
  That is precisely the condition the workflow's gate allows through — it fails only when some finding has a fix available.
- `go vet ./...` clean
- `cmd/containarium` builds and links; `containarium version` runs
- 69 packages of tests green across `./internal/...` and `./pkg/...`

Before filing #1354 I reproduced the failure on a clean worktree at unmodified `main` (`76f21dd`) — that is what established it as the repo baseline rather than a regression from #1353.

## Note for maintainers

Worth deciding whether this should be recurring maintenance rather than rediscovered from a red PR each time a Go patch lands — #1060 was the same class of issue (`go.mod` pinned to a vulnerable Go, GO-2026-5856). A scheduled bump, or Dependabot on the toolchain, would catch it before it blocks anyone. Raised as a question on #1354 rather than assumed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
