### PR TITLE
feat(sentinel): publish process-health metrics on /metrics (#1351)

### DIFF
--- a/internal/sentinel/observability.go
+++ b/internal/sentinel/observability.go
@@ -110,6 +110,11 @@ func (m *Manager) MetricsHandler() http.HandlerFunc {
 		}
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 		fmt.Fprint(w, m.renderMetrics(state, outageSecs))
+		// Process health (#1351) — resident memory, goroutines, fds. Separate
+		// concern from the preemption signal above (that describes the
+		// BACKEND; this describes the sentinel), so it is rendered separately
+		// and simply appended to the same exposition.
+		fmt.Fprint(w, renderProcessMetrics(collectRuntimeStats(), readProcStats()))
 	}
 }
 

--- a/internal/sentinel/process_metrics.go
+++ b/internal/sentinel/process_metrics.go
@@ -1,0 +1,224 @@
+package sentinel
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/metrics"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// Sentinel process-health metrics (#1351).
+//
+// The /metrics endpoint published four sentinel_* series describing the
+// BACKEND's preemption state and nothing at all about the sentinel process
+// itself. So when #1349 leaked ~18 MB/day for 27 consecutive days on the most
+// availability-critical VM in the fleet, there was no series to graph and
+// nothing to alert on: the first signal anyone got was the OOM kill, and it
+// arrived on a hypervisor CPU graph pointing at the wrong resource.
+//
+// The argument that made preemption a sentinel-owned signal (#514 — the
+// on-spot monitoring stack dies with the spot, so the always-on sentinel is
+// the only thing that can report) applies unchanged to the sentinel's own
+// process health. It was simply never extended that far.
+//
+// Names follow the Prometheus/client_golang conventions
+// (process_resident_memory_bytes, go_goroutines, …) even though nothing here
+// imports client_golang — the repo hand-rolls its exposition, and matching the
+// standard names is what lets an off-the-shelf dashboard or alert rule work
+// against this endpoint without translation.
+//
+// RSS is first among equals: the Go heap can look flat while RSS climbs
+// (goroutine stacks, mmap'd regions, cgo), and RSS is what the OOM killer
+// scores. A rule like
+//
+//	deriv(process_resident_memory_bytes[6h]) > 0
+//
+// sustained over a day would have opened #1349 around week one instead of at
+// the outage.
+
+// runtimeStats is what the Go runtime knows about itself. Portable.
+type runtimeStats struct {
+	Goroutines     int
+	HeapAllocBytes uint64
+	SysBytes       uint64
+}
+
+// procStats is what the OS knows about the process. Requires /proc, so it is
+// Linux-only — Available is false everywhere else, and callers must then omit
+// the series entirely rather than publish zeros.
+type procStats struct {
+	Available    bool
+	RSSBytes     uint64
+	VirtualBytes uint64
+	OpenFDs      uint64
+	MaxFDs       uint64
+}
+
+// collectRuntimeStats samples the Go runtime.
+//
+// Uses runtime/metrics rather than runtime.ReadMemStats: ReadMemStats stops
+// the world, and this endpoint is on the request path of a process whose job
+// is forwarding live traffic. runtime/metrics samples without a global pause.
+func collectRuntimeStats() runtimeStats {
+	const (
+		heapObjects = "/memory/classes/heap/objects:bytes"
+		totalMapped = "/memory/classes/total:bytes"
+	)
+	samples := []metrics.Sample{{Name: heapObjects}, {Name: totalMapped}}
+	metrics.Read(samples)
+
+	rt := runtimeStats{Goroutines: runtime.NumGoroutine()}
+	for _, s := range samples {
+		// KindBad means the runtime does not know this metric name (it can be
+		// retired across Go versions). Leaving the field zero is right here:
+		// unlike RSS, a zero heap number cannot mask a leak, because RSS is
+		// the series alerts key on.
+		if s.Value.Kind() != metrics.KindUint64 {
+			continue
+		}
+		switch s.Name {
+		case heapObjects:
+			rt.HeapAllocBytes = s.Value.Uint64()
+		case totalMapped:
+			rt.SysBytes = s.Value.Uint64()
+		}
+	}
+	return rt
+}
+
+// readProcStats reads process memory and fd counts from /proc.
+//
+// Returns Available=false on any platform without /proc, or if the read fails
+// — the caller then omits those series. Deliberately not faked on non-Linux:
+// a plausible-looking zero would be worse than an absent series.
+func readProcStats() procStats {
+	rss, virt, ok := readStatm()
+	if !ok {
+		return procStats{}
+	}
+	ps := procStats{Available: true, RSSBytes: rss, VirtualBytes: virt}
+	if n, ok := countOpenFDs(); ok {
+		ps.OpenFDs = n
+	}
+	if n, ok := maxOpenFDs(); ok {
+		ps.MaxFDs = n
+	}
+	return ps
+}
+
+// readStatm parses /proc/self/statm, whose first two fields are total program
+// size and resident set size, both in pages. Returns ok=false when the file is
+// missing (any non-Linux platform) or malformed.
+//
+// No build tag: os.ReadFile simply fails on platforms without /proc, which is
+// exactly the signal we want, and keeping one implementation means the
+// non-Linux branch is the same code path in dev as in prod.
+func readStatm() (rss, virt uint64, ok bool) {
+	raw, err := os.ReadFile("/proc/self/statm")
+	if err != nil {
+		return 0, 0, false
+	}
+	// Guard the int->uint64 conversion rather than suppressing G115. A
+	// non-positive page size would wrap into an enormous multiplier and
+	// publish nonsense byte counts, which is worse than reporting nothing —
+	// the whole point of this endpoint is that its numbers can be trusted.
+	pageSize := os.Getpagesize()
+	if pageSize <= 0 {
+		return 0, 0, false
+	}
+	return parseStatm(string(raw), uint64(pageSize))
+}
+
+// parseStatm splits the statm line. Pure and separate from the file read so
+// the field order is testable on any platform — a skipped-on-macOS test would
+// leave the riskiest part of this file unexercised until production.
+//
+// Field order is (size, resident, shared, text, lib, data, dt): index 0 is
+// VIRTUAL, index 1 is RESIDENT. Transposing them would publish VSZ as
+// process_resident_memory_bytes — in #1349's numbers, 2.7 GB instead of
+// 565 MB — which points a leak hunt at the wrong quantity entirely.
+func parseStatm(raw string, pageSize uint64) (rss, virt uint64, ok bool) {
+	fields := strings.Fields(raw)
+	if len(fields) < 2 || pageSize == 0 {
+		return 0, 0, false
+	}
+	virtPages, err := strconv.ParseUint(fields[0], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	rssPages, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	return rssPages * pageSize, virtPages * pageSize, true
+}
+
+// countOpenFDs counts entries in /proc/self/fd.
+func countOpenFDs() (uint64, bool) {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return 0, false
+	}
+	// The directory handle opened by ReadDir is itself one of the entries and
+	// is already closed by the time we count; subtracting it would be wrong as
+	// often as right, so report what is there. An fd-leak alert keys on the
+	// trend, which an off-by-one does not affect.
+	return uint64(len(entries)), true
+}
+
+// maxOpenFDs reports RLIMIT_NOFILE, so `process_open_fds / process_max_fds`
+// is alertable. The unit sets LimitNOFILE=65536.
+func maxOpenFDs() (uint64, bool) {
+	var lim syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &lim); err != nil {
+		return 0, false
+	}
+	return uint64(lim.Cur), true
+}
+
+// renderProcessMetrics builds the Prometheus exposition for process health.
+// Pure — takes both snapshots as arguments so tests can drive the
+// /proc-unavailable branch on any platform.
+func renderProcessMetrics(rt runtimeStats, ps procStats) string {
+	var b bytes.Buffer
+
+	gauge := func(name, help string, value string) {
+		fmt.Fprintf(&b, "# HELP %s %s\n", name, help)
+		fmt.Fprintf(&b, "# TYPE %s gauge\n", name)
+		fmt.Fprintf(&b, "%s %s\n", name, value)
+	}
+
+	gauge("go_goroutines", "Number of goroutines that currently exist.", strconv.Itoa(rt.Goroutines))
+	gauge("go_memstats_heap_alloc_bytes", "Bytes of live heap objects.", formatMetricUint(rt.HeapAllocBytes))
+	gauge("go_memstats_sys_bytes", "Total bytes of memory mapped from the OS.", formatMetricUint(rt.SysBytes))
+
+	// Absent, not zero, when /proc is unreadable. A hard zero here would read
+	// as "this process uses no memory" and silence the very alert this exists
+	// to enable; an absent series is detectable with absent().
+	if !ps.Available {
+		fmt.Fprint(&b, "# process_* series omitted: /proc unavailable on this platform\n")
+		return b.String()
+	}
+
+	gauge("process_resident_memory_bytes", "Resident set size in bytes.", formatMetricUint(ps.RSSBytes))
+	gauge("process_virtual_memory_bytes", "Virtual memory size in bytes.", formatMetricUint(ps.VirtualBytes))
+	if ps.OpenFDs > 0 {
+		gauge("process_open_fds", "Number of open file descriptors.", formatMetricUint(ps.OpenFDs))
+	}
+	if ps.MaxFDs > 0 {
+		gauge("process_max_fds", "Maximum number of open file descriptors (RLIMIT_NOFILE).", formatMetricUint(ps.MaxFDs))
+	}
+	return b.String()
+}
+
+// formatMetricUint renders a value the way Prometheus exposition expects:
+// small integers bare ("65536"), large ones in exponent form
+// ("5.791744e+08"), which is what client_golang emits and what every scraper
+// parses as a float64 sample.
+func formatMetricUint(v uint64) string {
+	return strconv.FormatFloat(float64(v), 'g', -1, 64)
+}

--- a/internal/sentinel/process_metrics_test.go
+++ b/internal/sentinel/process_metrics_test.go
@@ -1,0 +1,274 @@
+package sentinel
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// #1351: the sentinel's /metrics published four sentinel_* series and nothing
+// about the process itself, so #1349's ~18 MB/day growth ran for 27 days with
+// no series to graph and nothing to alert on. These tests pin the series that
+// close that gap — above all resident memory, which is what the OOM killer
+// actually acts on.
+
+// fakeProcStats is a snapshot with recognisable values, so a test failure says
+// which field got mis-rendered rather than just "some number is wrong".
+func fakeProcStats() procStats {
+	return procStats{
+		Available:    true,
+		RSSBytes:     565600 * 1024, // the anon-rss from #1349's OOM line
+		VirtualBytes: 2753240 * 1024,
+		OpenFDs:      37,
+		MaxFDs:       65536, // LimitNOFILE from the unit
+	}
+}
+
+func fakeRuntimeStats() runtimeStats {
+	return runtimeStats{
+		Goroutines:     42,
+		HeapAllocBytes: 123456789,
+		SysBytes:       987654321,
+	}
+}
+
+func TestRenderProcessMetrics_PublishesLeakDetectionSeries(t *testing.T) {
+	out := renderProcessMetrics(fakeRuntimeStats(), fakeProcStats())
+
+	for _, want := range []string{
+		// The series that would have caught #1349. RSS is first among equals:
+		// the Go heap can look flat while RSS climbs (stacks, mmap, cgo), and
+		// RSS is what the OOM killer scores.
+		"# TYPE process_resident_memory_bytes gauge",
+		"process_resident_memory_bytes 5.791744e+08",
+		"# TYPE process_virtual_memory_bytes gauge",
+		"process_virtual_memory_bytes 2.81931776e+09",
+		// A goroutine leak is a common cause of a memory leak; an fd leak is
+		// the other classic way this daemon dies (LimitNOFILE=65536).
+		"# TYPE go_goroutines gauge",
+		"go_goroutines 42",
+		"# TYPE process_open_fds gauge",
+		"process_open_fds 37",
+		"# TYPE process_max_fds gauge",
+		"process_max_fds 65536",
+		// Heap detail, for telling "which kind of growth" once RSS moves.
+		"# TYPE go_memstats_heap_alloc_bytes gauge",
+		"go_memstats_heap_alloc_bytes 1.23456789e+08",
+		"# TYPE go_memstats_sys_bytes gauge",
+		"go_memstats_sys_bytes 9.87654321e+08",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("process metrics missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestRenderProcessMetrics_OmitsUnavailableProcSeries is the one that matters
+// for correctness of alerting. /proc exists on the Linux hosts the sentinel
+// runs on but not on a developer's macOS box. When the read fails the series
+// must be ABSENT, never zero: a hard-coded
+// `process_resident_memory_bytes 0` reads as "this process uses no memory",
+// which silences exactly the alert this issue exists to enable. An absent
+// series is detectable with absent(); a lying zero is not.
+func TestRenderProcessMetrics_OmitsUnavailableProcSeries(t *testing.T) {
+	out := renderProcessMetrics(fakeRuntimeStats(), procStats{Available: false})
+
+	for _, unwanted := range []string{
+		"process_resident_memory_bytes",
+		"process_virtual_memory_bytes",
+		"process_open_fds",
+		"process_max_fds",
+	} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("emitted %q with no /proc available — a zero here would silence the leak alert\n--- got ---\n%s", unwanted, out)
+		}
+	}
+
+	// Runtime series come from the Go runtime and are portable, so they must
+	// still be there — losing /proc must not cost us everything.
+	if !strings.Contains(out, "go_goroutines 42") {
+		t.Errorf("runtime series dropped along with the proc series\n--- got ---\n%s", out)
+	}
+}
+
+// TestMetricsHandler_ExposesProcessHealth checks the real endpoint, not just
+// the renderer — the series has to actually reach a scraper.
+func TestMetricsHandler_ExposesProcessHealth(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	rec := httptest.NewRecorder()
+	m.MetricsHandler()(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	// The pre-existing preemption signal must survive this change.
+	for _, want := range []string{"sentinel_preempted_total", "sentinel_state"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("regression: %q no longer served\n--- got ---\n%s", want, body)
+		}
+	}
+
+	// Runtime series are portable — required on every platform.
+	for _, want := range []string{"go_goroutines", "go_memstats_heap_alloc_bytes", "go_memstats_sys_bytes"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q\n--- got ---\n%s", want, body)
+		}
+	}
+
+	// Process series require /proc, i.e. the platform the sentinel deploys on.
+	if runtime.GOOS == "linux" {
+		for _, want := range []string{"process_resident_memory_bytes", "process_open_fds"} {
+			if !strings.Contains(body, want) {
+				t.Errorf("missing %q on linux, where the sentinel actually runs\n--- got ---\n%s", want, body)
+			}
+		}
+	}
+}
+
+// TestReadProcStats_RealProcess exercises the real /proc read on the platform
+// that has it. Skipped elsewhere rather than faked, so a green run on macOS
+// never implies this code path works.
+func TestReadProcStats_RealProcess(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("no /proc on %s — this path is only exercised on linux", runtime.GOOS)
+	}
+	ps := readProcStats()
+	if !ps.Available {
+		t.Fatal("readProcStats reported unavailable on linux")
+	}
+	if ps.RSSBytes == 0 {
+		t.Error("RSS = 0; a running Go process has resident memory")
+	}
+	if ps.VirtualBytes < ps.RSSBytes {
+		t.Errorf("virtual (%d) < resident (%d), which is impossible", ps.VirtualBytes, ps.RSSBytes)
+	}
+	if ps.OpenFDs == 0 {
+		t.Error("open fds = 0; the test process has at least stdin/stdout/stderr")
+	}
+	if ps.MaxFDs != 0 && ps.OpenFDs > ps.MaxFDs {
+		t.Errorf("open fds (%d) > max fds (%d)", ps.OpenFDs, ps.MaxFDs)
+	}
+}
+
+func TestCollectRuntimeStats_ReportsLiveValues(t *testing.T) {
+	rt := collectRuntimeStats()
+	if rt.Goroutines < 1 {
+		t.Errorf("goroutines = %d, want >= 1", rt.Goroutines)
+	}
+	if rt.HeapAllocBytes == 0 {
+		t.Error("heap alloc = 0; this test binary has allocated")
+	}
+	if rt.SysBytes < rt.HeapAllocBytes {
+		t.Errorf("sys (%d) < heap alloc (%d): total from the OS cannot be less than the live heap",
+			rt.SysBytes, rt.HeapAllocBytes)
+	}
+}
+
+// TestMetricsExpositionIsWellFormed guards the whole endpoint's format: every
+// sample line must be preceded by a declared TYPE, or a scraper drops it.
+// Cheap structural check, no parser dependency.
+func TestMetricsExpositionIsWellFormed(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	rec := httptest.NewRecorder()
+	m.MetricsHandler()(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	declared := map[string]bool{}
+	var samples []string
+	for _, line := range strings.Split(rec.Body.String(), "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case line == "":
+		case strings.HasPrefix(line, "# TYPE "):
+			f := strings.Fields(line)
+			if len(f) != 4 {
+				t.Errorf("malformed TYPE line: %q", line)
+				continue
+			}
+			declared[f[2]] = true
+		case strings.HasPrefix(line, "#"): // HELP or comment
+		default:
+			f := strings.Fields(line)
+			if len(f) != 2 {
+				t.Errorf("malformed sample line: %q", line)
+				continue
+			}
+			samples = append(samples, f[0])
+		}
+	}
+
+	if len(samples) == 0 {
+		t.Fatal("no sample lines emitted at all")
+	}
+	for _, name := range samples {
+		if !declared[name] {
+			t.Errorf("sample %q has no # TYPE declaration — scrapers will drop it", name)
+		}
+	}
+}
+
+// TestParseStatm covers the /proc parsing on every platform, so the field
+// order is not left to a linux-only test that skips on the machine where this
+// was written. Transposing the two fields is the failure that matters: it
+// would publish virtual size as resident memory, sending a leak hunt after the
+// wrong number.
+func TestParseStatm(t *testing.T) {
+	const pageSize = 4096
+
+	tests := []struct {
+		name     string
+		raw      string
+		wantRSS  uint64
+		wantVirt uint64
+		wantOK   bool
+	}{
+		{
+			// A real /proc/self/statm line: size, resident, shared, text, lib,
+			// data, dt. 2969 pages virtual, 1183 pages resident.
+			name: "real statm line", raw: "2969 1183 771 21 0 264 0\n",
+			wantVirt: 2969 * pageSize, wantRSS: 1183 * pageSize, wantOK: true,
+		},
+		{
+			// #1349's own numbers, to make the mapping unmistakable:
+			// 565600 kB resident inside 2753240 kB virtual.
+			name: "the #1349 OOM proportions", raw: "688310 141400 0 0 0 0 0",
+			wantVirt: 688310 * pageSize, wantRSS: 141400 * pageSize, wantOK: true,
+		},
+		{name: "trailing whitespace only", raw: "   \n", wantOK: false},
+		{name: "single field", raw: "2969", wantOK: false},
+		{name: "non-numeric", raw: "abc def", wantOK: false},
+		{name: "empty", raw: "", wantOK: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rss, virt, ok := parseStatm(tc.raw, pageSize)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if rss != tc.wantRSS {
+				t.Errorf("rss = %d, want %d", rss, tc.wantRSS)
+			}
+			if virt != tc.wantVirt {
+				t.Errorf("virt = %d, want %d", virt, tc.wantVirt)
+			}
+			if rss >= virt {
+				t.Errorf("rss (%d) >= virt (%d) — fields look transposed", rss, virt)
+			}
+		})
+	}
+}
+
+// A zero page size would silently render every memory series as 0, which is
+// the same lie as publishing zeros when /proc is missing.
+func TestParseStatm_RejectsZeroPageSize(t *testing.T) {
+	if _, _, ok := parseStatm("2969 1183 771 21 0 264 0", 0); ok {
+		t.Error("accepted a zero page size; every byte count would render as 0")
+	}
+}


### PR DESCRIPTION
Closes #1351. Third of the three #1349 follow-ups — after #1353 (profiling) and #1355 (toolchain).

## Why

`/metrics` served four `sentinel_*` series describing the **backend's** preemption state and nothing about the **sentinel process** itself. So #1349's ~18 MB/day growth ran for 27 consecutive days on the most availability-critical VM in the fleet with no series to graph and nothing to alert on. The first signal anyone got was the OOM kill — and it arrived on a hypervisor CPU graph pointing at the wrong resource.

The reasoning that made preemption a sentinel-owned signal (#514 — the on-spot monitoring stack dies with the spot, so the always-on sentinel is the only thing that can report) applies unchanged to the sentinel's own process health. It was just never extended that far.

## What

```
# HELP process_resident_memory_bytes Resident set size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 5.791744e+08
…
go_goroutines 42
go_memstats_heap_alloc_bytes 1.23456789e+08
go_memstats_sys_bytes 9.87654321e+08
process_virtual_memory_bytes 2.81931776e+09
process_open_fds 37
process_max_fds 65536
```

Conventional `client_golang` names, so an off-the-shelf dashboard or alert rule works against this endpoint without translation.

**RSS is first among equals.** The Go heap can look flat while RSS climbs — goroutine stacks, mmap'd regions, cgo — and RSS is what the OOM killer scores. A rule like `deriv(process_resident_memory_bytes[6h]) > 0` sustained over a day would have opened #1349 around week one instead of at the outage. `process_open_fds` / `process_max_fds` covers the other classic way this daemon dies (the unit sets `LimitNOFILE=65536`).

## Design notes

**No new dependency.** `client_golang` is indirect-only and used nowhere in repo code; the sentinel hand-rolls its exposition. This matches the existing `renderMetrics` shape rather than dragging in a registry and a `promhttp` handler for seven gauges.

**`runtime/metrics`, not `runtime.ReadMemStats`.** ReadMemStats stops the world. This endpoint is in a process whose entire job is forwarding live traffic, so the non-pausing API is the right one even at a 15s scrape interval.

**Absent, not zero, when `/proc` is unreadable.** This is the one that matters for correctness of alerting. On any non-Linux platform the `process_*` series are omitted entirely:

```
# process_* series omitted: /proc unavailable on this platform
```

A hard-coded `process_resident_memory_bytes 0` would read as "this process uses no memory" and silence the exact alert this issue exists to enable. An absent series is detectable with `absent()`; a lying zero is not. Pinned by a test.

## Verification

**Mutation-tested**, both on the assertions that carry the weight:

| Mutation | Caught by |
| --- | --- |
| Transpose statm fields 0/1 | `rss (12161024) >= virt (4845568) — fields look transposed` |
| Publish zeros instead of omitting | `emitted "process_resident_memory_bytes" with no /proc available — a zero here would silence the leak alert` |

That first one is why `parseStatm` is split out pure and tested cross-platform. statm field 0 is *virtual* and field 1 is *resident*; transposing them publishes VSZ as `process_resident_memory_bytes` — 2.7 GB instead of 565 MB in #1349's own numbers — pointing a leak hunt at the wrong quantity. Leaving that to a Linux-only test would mean it went unexercised on the machine this was written on. One of the parse cases uses #1349's actual proportions.

Also covered: exposition well-formedness (every sample line has a preceding `# TYPE`, or scrapers drop it), and a regression check that the four pre-existing `sentinel_*` series survive.

`go vet` clean, `golangci-lint` 0 issues, gosec clean, full `internal/sentinel` suite passes.

**One gap to be honest about:** `TestReadProcStats_RealProcess` and the Linux branch of `TestMetricsHandler_ExposesProcessHealth` **skip on macOS**, where this was developed — so the real `/proc` read, `/proc/self/fd` count and `getrlimit` are first exercised by CI on ubuntu. They're deliberately skipped rather than faked, so a green local run never implies that path works. The parsing logic underneath them is covered everywhere.

A gosec G115 (`int -> uint64` on `os.Getpagesize()`) is fixed by guarding rather than suppressing — a non-positive page size would wrap into an enormous multiplier and publish nonsense byte counts, which is worse than reporting nothing.

## Not in scope

Wiring an external scraper to this endpoint. The series now exist; pointing something at `:8888/metrics` and writing the alert rule is a deployment change, and the sentinel is also absent from `internal/metrics/cloudexport/` — worth a separate issue if the team wants it in Cloud Monitoring alongside the backend host series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
