### PR TITLE
fix(sentinel): bound the unit's memory so a leak restarts one process (#1350)

### DIFF
--- a/internal/cmd/sentinel_service.go
+++ b/internal/cmd/sentinel_service.go
@@ -14,9 +14,11 @@ import (
 const sentinelSystemdServicePath = "/etc/systemd/system/containarium-sentinel.service"
 
 var (
-	sentinelSvcSpotVM  string
-	sentinelSvcZone    string
-	sentinelSvcProject string
+	sentinelSvcSpotVM     string
+	sentinelSvcZone       string
+	sentinelSvcProject    string
+	sentinelSvcMemoryHigh string
+	sentinelSvcMemoryMax  string
 )
 
 var sentinelServiceCmd = &cobra.Command{
@@ -57,6 +59,10 @@ func init() {
 	sentinelServiceInstallCmd.Flags().StringVar(&sentinelSvcSpotVM, "spot-vm", "", "Name of the backend spot VM instance (required)")
 	sentinelServiceInstallCmd.Flags().StringVar(&sentinelSvcZone, "zone", "", "GCP zone (required)")
 	sentinelServiceInstallCmd.Flags().StringVar(&sentinelSvcProject, "project", "", "GCP project ID (required)")
+	sentinelServiceInstallCmd.Flags().StringVar(&sentinelSvcMemoryHigh, "memory-high", defaultSentinelMemoryHigh,
+		"Soft memory limit; past it the kernel reclaims inside the sentinel's cgroup instead of stalling the host (#1350). Percentage of RAM or a size like 512M.")
+	sentinelServiceInstallCmd.Flags().StringVar(&sentinelSvcMemoryMax, "memory-max", defaultSentinelMemoryMax,
+		"Hard memory limit; exceeding it restarts the sentinel (Restart=always) rather than letting the OOM killer take the host down (#1350).")
 }
 
 func runSentinelServiceInstall(cmd *cobra.Command, args []string) error {
@@ -68,53 +74,16 @@ func runSentinelServiceInstall(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--spot-vm, --zone, and --project are required")
 	}
 
-	serviceContent := fmt.Sprintf(`[Unit]
-Description=Containarium Sentinel (HA Proxy)
-Documentation=https://github.com/footprintai/Containarium
-After=network.target
-StartLimitIntervalSec=0
-
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/containarium sentinel \
-  --spot-vm %s \
-  --zone %s \
-  --project %s
-Restart=always
-# Keep retrying forever (StartLimitIntervalSec=0 above), but not at full
-# speed. A persistent start failure used to retry every 5s indefinitely:
-# one production host crash-looped 1655 times in ~4 hours, pinning a core
-# and — because each cycle rewrites the bundled monitoring config —
-# restarting alertmanager and vmalert every 7 seconds, so alerting could
-# not have fired during the incident, including on the incident itself
-# (#1152).
-#
-# "Never give up" and "retry at full speed" are separable. RestartSteps
-# interpolates the delay geometrically from RestartSec to
-# RestartMaxDelaySec, so a transient incus hiccup at boot still recovers
-# in seconds while a persistent failure settles to one attempt every 5
-# minutes. That same 4-hour outage would cost ~50 attempts, not 1655.
-#
-# Requires systemd 254+. The documented host floor is Ubuntu 24.04 LTS
-# ("or later", README), which ships 255. On an older host systemd warns
-# and continues, degrading to the previous fixed-interval behaviour
-# rather than failing to start — so this cannot brick a host that
-# predates the directives.
-RestartSec=5s
-RestartSteps=6
-RestartMaxDelaySec=5min
-User=root
-Group=root
-
-StandardOutput=journal
-StandardError=journal
-SyslogIdentifier=containarium-sentinel
-
-LimitNOFILE=65536
-
-[Install]
-WantedBy=multi-user.target
-`, sentinelSvcSpotVM, sentinelSvcZone, sentinelSvcProject)
+	serviceContent, err := buildSentinelUnit(sentinelUnitConfig{
+		SpotVM:     sentinelSvcSpotVM,
+		Zone:       sentinelSvcZone,
+		Project:    sentinelSvcProject,
+		MemoryHigh: sentinelSvcMemoryHigh,
+		MemoryMax:  sentinelSvcMemoryMax,
+	})
+	if err != nil {
+		return err
+	}
 
 	if err := os.WriteFile(sentinelSystemdServicePath, []byte(serviceContent), 0644); err != nil {
 		return fmt.Errorf("failed to write service file: %w", err)

--- a/internal/cmd/sentinel_unit.go
+++ b/internal/cmd/sentinel_unit.go
@@ -1,0 +1,237 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Sentinel unit memory bounds (#1350).
+//
+// #1349 leaked ~18 MB/day until the sentinel held 565 MB anon-RSS on a 1 GB
+// host. Nothing bounded it, so the KERNEL resolved it — 36 minutes into a
+// full-host stall (73.91% iowait, load 32.46, 12 tasks blocked in D), long
+// after the box had stopped serving usefully. `Restart=always` did its job and
+// the sentinel came back; what was missing was anything that acts on memory
+// pressure BEFORE the host is thrashing.
+//
+// MemoryHigh is the directive that changes the outcome. Past it, reclaim
+// pressure is applied inside the sentinel's own cgroup rather than by global
+// reclaim evicting the host's page cache — the failure stays local and the box
+// stays responsive. MemoryMax is the hard stop; paired with Restart=always it
+// costs a restart measured in seconds instead of a 36-minute apex outage. The
+// kernel's OOM killer picked `containarium` last time because it was the
+// biggest process, which was luck rather than policy: sshpiperd invoked the
+// killer, and SSH could as easily have been the casualty.
+//
+// Defaults are PERCENTAGES so one value works across the 1 GB (e2-micro) and
+// 2 GB (e2-small, per #770) sentinel hosts without per-host tuning. They are
+// overridable because BYOC and larger sentinels exist.
+
+const (
+	// defaultSentinelMemoryHigh throttles at ~358 MB on a 1 GB host — roughly
+	// 4x the 82 MB cold start observed while diagnosing #1349, so a busy
+	// sentinel is not throttled in normal operation.
+	defaultSentinelMemoryHigh = "35%"
+
+	// defaultSentinelMemoryMax caps at ~512 MB on a 1 GB host, deliberately
+	// BELOW the 565 MB the #1349 leak reached — a ceiling above that would
+	// never have fired and would be decoration.
+	defaultSentinelMemoryMax = "50%"
+)
+
+// sentinelUnitConfig is everything that varies in the generated unit.
+type sentinelUnitConfig struct {
+	SpotVM     string
+	Zone       string
+	Project    string
+	MemoryHigh string
+	MemoryMax  string
+}
+
+// systemdMemoryPattern matches the value forms systemd accepts for
+// MemoryHigh=/MemoryMax=: a percentage, or a byte count with an optional
+// binary suffix. Note "M" not "MB" — systemd rejects the latter.
+var systemdMemoryPattern = regexp.MustCompile(`^(\d+)(%|K|M|G|T|)$`)
+
+// validateSystemdMemoryValue rejects anything systemd would refuse, so a typo
+// surfaces at install time rather than as a unit that will not start.
+func validateSystemdMemoryValue(v string) error {
+	if v == "" {
+		return fmt.Errorf("empty memory value")
+	}
+	if v == "infinity" {
+		return nil
+	}
+	m := systemdMemoryPattern.FindStringSubmatch(v)
+	if m == nil {
+		return fmt.Errorf("invalid memory value %q: want a percentage (\"35%%\"), a size (\"512M\", \"1G\"), or \"infinity\"", v)
+	}
+	if m[2] == "%" {
+		pct, err := strconv.Atoi(m[1])
+		if err != nil {
+			return fmt.Errorf("invalid memory value %q", v)
+		}
+		if pct < 1 || pct > 100 {
+			return fmt.Errorf("memory percentage %q must be between 1%% and 100%%", v)
+		}
+	}
+	return nil
+}
+
+// percentValue returns the numeric part of a percentage value, erroring if v
+// is not one.
+func percentValue(v string) (int, error) {
+	m := systemdMemoryPattern.FindStringSubmatch(v)
+	if m == nil || m[2] != "%" {
+		return 0, fmt.Errorf("%q is not a percentage", v)
+	}
+	return strconv.Atoi(m[1])
+}
+
+// comparableBytes converts an absolute systemd size to bytes. Returns ok=false
+// for percentages and "infinity", which cannot be compared without knowing the
+// host's physical memory.
+func comparableBytes(v string) (uint64, bool) {
+	m := systemdMemoryPattern.FindStringSubmatch(v)
+	if m == nil || m[2] == "%" {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(m[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	switch m[2] {
+	case "K":
+		return n * 1024, true
+	case "M":
+		return n * 1024 * 1024, true
+	case "G":
+		return n * 1024 * 1024 * 1024, true
+	case "T":
+		return n * 1024 * 1024 * 1024 * 1024, true
+	default:
+		return n, true
+	}
+}
+
+// validateMemoryBounds checks that the throttle sits below the hard cap.
+//
+// A MemoryHigh at or above MemoryMax is the no-throttle behaviour with extra
+// words: the cgroup reaches the hard cap without ever having been reclaimed
+// under pressure first, which is precisely the #1349 shape this is meant to
+// prevent. Mixed forms (a percentage against an absolute size) cannot be
+// ordered without knowing physical RAM, so they pass rather than being guessed
+// at — systemd will still enforce whichever binds first.
+func validateMemoryBounds(high, max string) error {
+	if hp, herr := percentValue(high); herr == nil {
+		if mp, merr := percentValue(max); merr == nil {
+			if hp >= mp {
+				return fmt.Errorf("MemoryHigh (%s) must be below MemoryMax (%s), otherwise the cgroup "+
+					"hits the hard cap without ever being reclaimed under pressure first", high, max)
+			}
+		}
+		return nil
+	}
+	hb, hok := comparableBytes(high)
+	mb, mok := comparableBytes(max)
+	if hok && mok && hb >= mb {
+		return fmt.Errorf("MemoryHigh (%s) must be below MemoryMax (%s), otherwise the cgroup "+
+			"hits the hard cap without ever being reclaimed under pressure first", high, max)
+	}
+	return nil
+}
+
+// buildSentinelUnit renders the systemd unit. Pure and separate from the
+// install path so the directives are testable without root, systemd, or a
+// filesystem — the install command only writes what this returns.
+func buildSentinelUnit(cfg sentinelUnitConfig) (string, error) {
+	if strings.TrimSpace(cfg.SpotVM) == "" || strings.TrimSpace(cfg.Zone) == "" || strings.TrimSpace(cfg.Project) == "" {
+		return "", fmt.Errorf("--spot-vm, --zone, and --project are required")
+	}
+	if err := validateSystemdMemoryValue(cfg.MemoryHigh); err != nil {
+		return "", fmt.Errorf("--memory-high: %w", err)
+	}
+	if err := validateSystemdMemoryValue(cfg.MemoryMax); err != nil {
+		return "", fmt.Errorf("--memory-max: %w", err)
+	}
+	if err := validateMemoryBounds(cfg.MemoryHigh, cfg.MemoryMax); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(`[Unit]
+Description=Containarium Sentinel (HA Proxy)
+Documentation=https://github.com/footprintai/Containarium
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/containarium sentinel \
+  --spot-vm %s \
+  --zone %s \
+  --project %s
+Restart=always
+# Keep retrying forever (StartLimitIntervalSec=0 above), but not at full
+# speed. A persistent start failure used to retry every 5s indefinitely:
+# one production host crash-looped 1655 times in ~4 hours, pinning a core
+# and — because each cycle rewrites the bundled monitoring config —
+# restarting alertmanager and vmalert every 7 seconds, so alerting could
+# not have fired during the incident, including on the incident itself
+# (#1152).
+#
+# "Never give up" and "retry at full speed" are separable. RestartSteps
+# interpolates the delay geometrically from RestartSec to
+# RestartMaxDelaySec, so a transient incus hiccup at boot still recovers
+# in seconds while a persistent failure settles to one attempt every 5
+# minutes. That same 4-hour outage would cost ~50 attempts, not 1655.
+#
+# Requires systemd 254+. The documented host floor is Ubuntu 24.04 LTS
+# ("or later", README), which ships 255. On an older host systemd warns
+# and continues, degrading to the previous fixed-interval behaviour
+# rather than failing to start — so this cannot brick a host that
+# predates the directives.
+RestartSec=5s
+RestartSteps=6
+RestartMaxDelaySec=5min
+User=root
+Group=root
+
+# Memory bounds (#1350). #1349 leaked ~18 MB/day until this process held
+# 565 MB on a 1 GB host; with nothing bounding it, the kernel's OOM killer
+# resolved it 36 minutes into a full-host stall (73.91%% iowait, load
+# 32.46) rather than systemd restarting one process in seconds.
+#
+# MemoryHigh is the directive that changes the outcome: past it, reclaim
+# pressure applies inside THIS cgroup instead of global reclaim evicting
+# the whole host's page cache, so the failure stays local and the box
+# keeps serving. MemoryMax is the hard stop, and with Restart=always
+# above it costs a restart rather than an outage.
+#
+# Percentages so one value fits both the 1 GB (e2-micro) and 2 GB
+# (e2-small, #770) sentinel hosts. Defaults are ~358 MB / ~512 MB on a
+# 1 GB host: roughly 4x the observed 82 MB cold start, and deliberately
+# below the 565 MB the leak actually reached — a cap above that would
+# never have fired. Override with --memory-high / --memory-max on
+# "containarium sentinel service install" for a larger host.
+MemoryAccounting=yes
+MemoryHigh=%s
+MemoryMax=%s
+# Explicit rather than inherited, so the interaction with Restart=always
+# is readable here: on an OOM kill systemd stops the unit, and
+# Restart=always brings it straight back.
+OOMPolicy=stop
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=containarium-sentinel
+
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
+`, cfg.SpotVM, cfg.Zone, cfg.Project, cfg.MemoryHigh, cfg.MemoryMax), nil
+}

--- a/internal/cmd/service.go
+++ b/internal/cmd/service.go
@@ -60,6 +60,21 @@ RestartMaxDelaySec=5min
 User=root
 Group=root
 
+# Memory accounting only — deliberately no MemoryMax here (#1350).
+#
+# The sentinel unit caps its memory, because it is a pure forwarder whose
+# working set is small and well understood (~82 MB) and whose host is 1-2 GB.
+# The daemon is not that: it manages containers, ZFS datasets and gRPC traffic,
+# and its legitimate peak is workload-dependent. A guessed cap on the busiest
+# component risks restart loops under normal load, which is a worse failure
+# than the slow leak a cap guards against.
+#
+# Accounting is the prerequisite either way: it costs nothing, exposes the
+# cgroup memory statistics, and is what makes the working set measurable so a
+# cap can later be chosen from data instead of guessed. #1349 went unnoticed
+# for 27 days precisely because nothing was measuring.
+MemoryAccounting=yes
+
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict

--- a/internal/cmd/service_backoff_test.go
+++ b/internal/cmd/service_backoff_test.go
@@ -42,10 +42,27 @@ func unitSources(t *testing.T) map[string]string {
 		return string(raw)
 	}
 
+	// The sentinel entry is the GENERATED unit, not its source text. It used
+	// to be read("sentinel_service.go"); when #1350 moved the template into
+	// sentinel_unit.go, that read kept succeeding against a file that no
+	// longer held a unit, and every guard below silently stopped covering the
+	// sentinel. Rendering it makes these tests immune to where the template
+	// lives — and is closer to what actually ships anyway.
+	sentinelUnit, err := buildSentinelUnit(sentinelUnitConfig{
+		SpotVM:     "spot-vm",
+		Zone:       "zone",
+		Project:    "project",
+		MemoryHigh: defaultSentinelMemoryHigh,
+		MemoryMax:  defaultSentinelMemoryMax,
+	})
+	if err != nil {
+		t.Fatalf("buildSentinelUnit: %v", err)
+	}
+
 	return map[string]string{
 		"daemon (systemdServiceTemplate)":       systemdServiceTemplate,
 		"daemon (scripts/containarium.service)": read("..", "..", "scripts", "containarium.service"),
-		"sentinel (sentinel_service.go)":        read("sentinel_service.go"),
+		"sentinel (generated unit)":             sentinelUnit,
 	}
 }
 

--- a/internal/cmd/service_memory_test.go
+++ b/internal/cmd/service_memory_test.go
@@ -1,0 +1,204 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// Memory bounds on the unit templates (#1350).
+//
+// The incident: #1349 leaked ~18 MB/day until the sentinel held 565 MB on a
+// 1 GB host. Nothing bounded it, so the KERNEL resolved it — 36 minutes into a
+// full-host stall (73.91% iowait, load 32.46, 12 tasks in D), after global
+// reclaim had already made the box useless. `Restart=always` worked fine; what
+// was missing was anything acting on memory pressure BEFORE the host was
+// thrashing.
+//
+// The distinction these tests protect: with MemoryHigh, reclaim pressure stays
+// inside the sentinel's own cgroup instead of evicting the host's page cache.
+// The failure becomes local and survivable rather than taking the apex down.
+
+func sentinelUnitForTest(t *testing.T) string {
+	t.Helper()
+	unit, err := buildSentinelUnit(sentinelUnitConfig{
+		SpotVM:     "vm",
+		Zone:       "zone",
+		Project:    "proj",
+		MemoryHigh: defaultSentinelMemoryHigh,
+		MemoryMax:  defaultSentinelMemoryMax,
+	})
+	if err != nil {
+		t.Fatalf("buildSentinelUnit: %v", err)
+	}
+	return unit
+}
+
+func TestSentinelUnitBoundsMemory(t *testing.T) {
+	unit := sentinelUnitForTest(t)
+
+	for _, want := range []string{
+		// Without accounting the other two directives are inert on some
+		// configurations, and no cgroup memory stats exist to look at either.
+		"MemoryAccounting=yes",
+		// The one that matters: throttle-and-reclaim inside this cgroup
+		// before the host as a whole is under pressure.
+		"MemoryHigh=" + defaultSentinelMemoryHigh,
+		// The hard stop. With Restart=always this is a restart, not a death.
+		"MemoryMax=" + defaultSentinelMemoryMax,
+		// Explicit rather than inherited, so the interaction with
+		// Restart=always is readable in the unit itself.
+		"OOMPolicy=stop",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("sentinel unit missing %q — a leak would again stall the whole VM "+
+				"instead of restarting one process\n--- got ---\n%s", want, unit)
+		}
+	}
+}
+
+// Restart=always is what turns MemoryMax from "the sentinel dies" into "the
+// sentinel restarts". Capping memory without it would be a regression, so the
+// pairing is pinned.
+func TestSentinelUnitStillRestartsAfterAnOOMKill(t *testing.T) {
+	unit := sentinelUnitForTest(t)
+	if !strings.Contains(unit, "Restart=always") {
+		t.Error("sentinel unit lost Restart=always; with MemoryMax set, that turns a bounded " +
+			"leak into a permanently dead apex forwarder")
+	}
+}
+
+// Every unit should at least ACCOUNT for its memory, even where we decline to
+// cap it — that is what makes the working set measurable, and #1349 was
+// invisible for 27 days precisely because nothing measured it.
+func TestAllUnitsHaveMemoryAccounting(t *testing.T) {
+	for name, unit := range unitSources(t) {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(unit, "MemoryAccounting=yes") {
+				t.Errorf("%s does not enable MemoryAccounting — its working set cannot be "+
+					"measured, so no one can tell a leak from normal growth", name)
+			}
+		})
+	}
+}
+
+func TestParseSystemdMemoryValue(t *testing.T) {
+	tests := []struct {
+		in      string
+		wantErr string
+	}{
+		// Percentages: relative to installed RAM, which is what lets one
+		// default work on both the 1 GB and 2 GB sentinel hosts.
+		{in: "35%"}, {in: "50%"}, {in: "100%"}, {in: "1%"},
+		// Absolute sizes.
+		{in: "512M"}, {in: "1G"}, {in: "1024K"}, {in: "2000000"}, {in: "4T"},
+		{in: "infinity"},
+
+		{in: "", wantErr: "empty"},
+		{in: "abc", wantErr: "invalid"},
+		{in: "-5M", wantErr: "invalid"},
+		{in: "0%", wantErr: "between 1% and 100%"},
+		{in: "101%", wantErr: "between 1% and 100%"},
+		{in: "50 %", wantErr: "invalid"},
+		{in: "50MB", wantErr: "invalid"}, // systemd wants M, not MB
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			err := validateSystemdMemoryValue(tc.in)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateSystemdMemoryValue(%q) = %v, want nil", tc.in, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateSystemdMemoryValue(%q) = nil, want error containing %q", tc.in, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// A MemoryHigh at or above MemoryMax is the no-throttle behaviour with extra
+// words: the cgroup would hit the hard cap without ever having been reclaimed
+// under pressure first, which is exactly the #1349 failure shape.
+func TestSentinelUnitRejectsHighAtOrAboveMax(t *testing.T) {
+	tests := []struct {
+		name, high, max, wantErr string
+	}{
+		{name: "equal percentages", high: "50%", max: "50%", wantErr: "must be below"},
+		{name: "high above max, percent", high: "80%", max: "50%", wantErr: "must be below"},
+		{name: "equal sizes", high: "512M", max: "512M", wantErr: "must be below"},
+		{name: "high above max, sizes", high: "1G", max: "512M", wantErr: "must be below"},
+		{name: "valid percentages", high: "35%", max: "50%"},
+		{name: "valid sizes", high: "256M", max: "512M"},
+		// Mixed units cannot be compared without knowing physical RAM, so they
+		// are allowed through rather than guessed at.
+		{name: "mixed units pass validation", high: "35%", max: "512M"},
+		{name: "infinity max is always above", high: "35%", max: "infinity"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildSentinelUnit(sentinelUnitConfig{
+				SpotVM: "vm", Zone: "z", Project: "p",
+				MemoryHigh: tc.high, MemoryMax: tc.max,
+			})
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// The defaults have to leave real headroom over the sentinel's actual working
+// set, or the cap causes restart loops — a worse failure than the slow leak it
+// guards against. Cold start was 82 MB when #1349 was diagnosed; on the 1 GB
+// host these percentages must sit several times above that.
+func TestSentinelMemoryDefaultsLeaveHeadroom(t *testing.T) {
+	const (
+		oneGiB            = 1024 * 1024 * 1024
+		observedColdStart = 82 * 1024 * 1024
+		observedLeakPeak  = 565 * 1024 * 1024 // RSS at the OOM kill
+	)
+
+	highPct, err := percentValue(defaultSentinelMemoryHigh)
+	if err != nil {
+		t.Fatalf("default MemoryHigh is not a percentage: %v", err)
+	}
+	maxPct, err := percentValue(defaultSentinelMemoryMax)
+	if err != nil {
+		t.Fatalf("default MemoryMax is not a percentage: %v", err)
+	}
+
+	highBytes := oneGiB * highPct / 100
+	maxBytes := oneGiB * maxPct / 100
+
+	if highBytes < 3*observedColdStart {
+		t.Errorf("MemoryHigh default (%s = %d bytes on a 1 GB host) is under 3x the observed "+
+			"82 MB cold start; a busy sentinel would be throttled in normal operation",
+			defaultSentinelMemoryHigh, highBytes)
+	}
+	// The whole point: both bounds must engage below where #1349 actually got
+	// to, or they would not have changed that outcome at all.
+	if maxBytes >= observedLeakPeak {
+		t.Errorf("MemoryMax default (%s = %d bytes on a 1 GB host) is at or above the 565 MB the "+
+			"#1349 leak reached — the cap would never have fired", defaultSentinelMemoryMax, maxBytes)
+	}
+	if highBytes >= maxBytes {
+		t.Errorf("MemoryHigh (%d) must be below MemoryMax (%d)", highBytes, maxBytes)
+	}
+}

--- a/scripts/containarium.service
+++ b/scripts/containarium.service
@@ -39,6 +39,21 @@ RestartMaxDelaySec=5min
 User=root
 Group=root
 
+# Memory accounting only — deliberately no MemoryMax here (#1350).
+#
+# The sentinel unit caps its memory, because it is a pure forwarder whose
+# working set is small and well understood (~82 MB) and whose host is 1-2 GB.
+# The daemon is not that: it manages containers, ZFS datasets and gRPC traffic,
+# and its legitimate peak is workload-dependent. A guessed cap on the busiest
+# component risks restart loops under normal load, which is a worse failure
+# than the slow leak a cap guards against.
+#
+# Accounting is the prerequisite either way: it costs nothing, exposes the
+# cgroup memory statistics, and is what makes the working set measurable so a
+# cap can later be chosen from data instead of guessed. #1349 went unnoticed
+# for 27 days precisely because nothing was measuring.
+MemoryAccounting=yes
+
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict


### PR DESCRIPTION
Closes #1350. Last of the three #1349 follow-ups, after #1353 (profiling) and #1356 (metrics).

## Why

#1349 leaked ~18 MB/day until the sentinel held 565 MB anon-RSS on a 1 GB host. Nothing bounded it, so the **kernel** resolved it — 36 minutes into a full-host stall (73.91% iowait, load 32.46, 12 tasks blocked in `D`), long after the box had stopped serving usefully.

`Restart=always` was never the problem; it worked, and the sentinel came back on its own. What was missing was anything that acts on memory pressure **before** the host is thrashing.

`MemoryHigh` is the directive that changes the outcome. Past it, reclaim pressure applies inside the sentinel's own cgroup instead of global reclaim evicting the whole host's page cache — the failure stays local and the box keeps serving. `MemoryMax` is the hard stop, and paired with `Restart=always` it costs a restart measured in seconds instead of a 36-minute apex outage.

Worth noting what we got away with last time: the OOM killer chose `containarium` because it was the biggest process. That was luck, not policy — `sshpiperd` invoked the killer, and SSH could as easily have been the casualty.

## What

```ini
MemoryAccounting=yes
MemoryHigh=35%
MemoryMax=50%
OOMPolicy=stop
```

Percentages, so one default fits both the 1 GB (e2-micro) and 2 GB (e2-small, per #770) sentinel hosts without per-host tuning. On a 1 GB host that is ~358 MB and ~512 MB.

Those numbers are chosen against the incident's own measurements, and both bounds are pinned by a test:

- **~4x the observed 82 MB cold start** before the throttle engages — a cap that fires under normal load would cause restart loops, which is a *worse* failure than the slow leak it guards against.
- **The hard cap sits below the 565 MB the leak actually reached.** A ceiling above that would never have fired and would be decoration.

Overridable via `--memory-high` / `--memory-max` on `containarium sentinel service install`, since BYOC and larger sentinels exist. Values are validated at install time, so a typo surfaces there rather than as a unit that will not start.

## The daemon units get accounting and no cap — deliberately

`internal/cmd/service.go` and `scripts/containarium.service` get `MemoryAccounting=yes` only.

The sentinel is a pure forwarder with a small, well-understood working set on a 1–2 GB host. The daemon is not: it manages containers, ZFS datasets and gRPC traffic, and its legitimate peak is workload-dependent. Shipping a guessed cap on the busiest component risks restart loops under normal load, which would be a self-inflicted outage in exchange for a hypothetical one.

Accounting is the prerequisite either way — it costs nothing, exposes the cgroup memory statistics, and is what makes the working set measurable so a cap can later be chosen from data instead of guessed. #1349 went unnoticed for 27 days precisely because nothing was measuring.

## Refactor, and a latent hole it exposed

The unit template moves out of the install path into a pure `buildSentinelUnit()`, so the directives are testable without root, systemd, or a filesystem.

That move exposed something worth flagging: `unitSources()` in `service_backoff_test.go` read `sentinel_service.go` **as text**. Relocating the template left those tests passing against a file that no longer contained a unit — silently dropping the sentinel from every #1152 restart-backoff assertion. The existing tests caught it immediately (three failures the moment the template moved), and they now render the unit instead of reading source, which is both immune to file moves and closer to what actually ships.

## Verification

**Mutation-tested:**

| Mutation | Caught by |
| --- | --- |
| Remove `MemoryHigh` from the unit | `sentinel unit missing "MemoryHigh=35%"` |
| Raise `MemoryMax` default to 70% | `70% = 751619276 bytes on a 1 GB host is at or above the 565 MB the #1349 leak reached — the cap would never have fired` |

Also covered: `Restart=always` must survive alongside `MemoryMax` (capping memory without it would turn a bounded leak into a permanently dead apex forwarder); all three units carry `MemoryAccounting`; `MemoryHigh` must be below `MemoryMax` (equal values are the no-throttle behaviour with extra words); and the systemd value validator accepts percentages/sizes/`infinity` while rejecting `0%`, `101%`, `50MB` (systemd wants `M`) and `50 %`.

`go vet` clean, gosec clean on the changed lines, `internal/cmd` and `internal/sentinel` suites pass.

**One pre-existing alert I did not touch:** gosec G306 on the unit-file `os.WriteFile(..., 0644)`. It is on `main` today (line 119 there) and my diff does not touch that line — it only moved within a file I edited. 0644 is also the correct convention for `/etc/systemd/system/*.service`; changing it to 0600 to satisfy a linter would deviate from convention for no security gain, since the unit contains flags rather than secrets.

## Deployment note

This only affects units written by a *future* `sentinel service install`. Existing hosts keep their current unit until it is regenerated — so landing this does not retroactively bound the sentinel that OOMed in #1349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
