### PR TITLE
feat(move): pre-flight an encrypted migration before copying anything

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -2513,6 +2513,47 @@
         ]
       }
     },
+    "/v1/containers/{username}/prepare-encrypted-migration": {
+      "post": {
+        "summary": "Pre-flight an encrypted migration (internal)",
+        "description": "Called by the source daemon before MoveContainer copies anything. The destination reports whether its key custody can resolve the container's KeyRef, and provisions the tenant's encrypted storage pool so the copy lands inside the tenant's encryptionroot. Only the key reference is sent; key material never crosses the wire. Not intended for direct operator use.",
+        "operationId": "ContainerService_PrepareEncryptedMigration",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/PrepareEncryptedMigrationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "description": "Username of the container about to be migrated.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrepareEncryptedMigrationBody"
+            }
+          }
+        ],
+        "tags": [
+          "Container Operations"
+        ]
+      }
+    },
     "/v1/containers/{username}/resize": {
       "put": {
         "summary": "Resize container resources",
@@ -10347,6 +10388,38 @@
         }
       },
       "description": "PgConnection carries the connection parameters pg_dump / pg_restore use\n*inside the container*. Defaults target a per-container local Postgres\nreached over loopback. db_password is never logged and is passed to the\nchild process via the PGPASSWORD environment variable, not argv."
+    },
+    "PrepareEncryptedMigrationBody": {
+      "type": "object",
+      "properties": {
+        "tenant": {
+          "type": "string",
+          "description": "The tenant whose encryptionroot the container lives under. The\ndestination provisions storage for this tenant, not for the\ncontainer: a tenant's containers share one encryptionroot."
+        },
+        "keyRef": {
+          "type": "string",
+          "description": "The source's stored KeyRef, JSON-encoded exactly as it is held on\nthe container's own metadata. An opaque reference (scheme + URI +\nmetadata); it carries no key bytes."
+        }
+      },
+      "description": "PrepareEncryptedMigrationRequest asks a destination daemon whether it\ncan take over an encrypted container, BEFORE any data is copied.\n\nOnly the key REFERENCE travels — never key material. The ref names a\nkey in whatever custody the destination is configured with; resolving\nit is the destination's job with its own KeyProvider, which is the\nwhole point of the check."
+    },
+    "PrepareEncryptedMigrationResponse": {
+      "type": "object",
+      "properties": {
+        "canResolve": {
+          "type": "boolean",
+          "description": "Whether the destination resolved the KeyRef through its own key\ncustody. False means the migration must not start: the container\nwould arrive unopenable after a full data copy."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Why not, when can_resolve is false. Operator-facing."
+        },
+        "storagePool": {
+          "type": "string",
+          "description": "The destination storage pool the container must be copied into —\nthe pool sourced at this tenant's encryptionroot. A copy that\nignores it lands on the destination's default pool, outside the\ntenant's encryptionroot, and the container arrives unencrypted\nwhile every daemon-side signal says otherwise."
+        }
+      },
+      "description": "PrepareEncryptedMigrationResponse tells the source whether to proceed,\nand where to put the container if so."
     },
     "ProfileBackendRequest": {
       "type": "object",

--- a/internal/server/move_container.go
+++ b/internal/server/move_container.go
@@ -7,6 +7,9 @@ import (
 	"log"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/footprintai/containarium/internal/auth"
 	"github.com/footprintai/containarium/pkg/core/incus"
 	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
@@ -120,6 +123,46 @@ func (s *ContainerServer) MoveContainer(ctx context.Context, req *pb.MoveContain
 		return nil, fmt.Errorf("check incus remote: %w", err)
 	} else if !has {
 		return nil, fmt.Errorf("incus remote %q is not configured on this host; run `incus remote add %s <url>` first", targetRemote, targetRemote)
+	}
+
+	// Pre-flight for an encrypted container (#1360), BEFORE anything is
+	// snapshotted or copied.
+	//
+	// The destination is the only party that can answer either half: whether
+	// its key custody resolves this container's KeyRef, and which storage
+	// pool is sourced at the tenant's encryptionroot. Asking after the copy
+	// would mean spending a full data transfer to discover the container
+	// cannot be unlocked on the far side (design §5).
+	//
+	// An unencrypted container skips this entirely — no extra round trip and
+	// no new failure mode on the path every container takes today.
+	ref, _, encrypted, err := s.encryption.migrationRef(containerName)
+	if err != nil {
+		return nil, fmt.Errorf("resolve encryption state for %s: %w", containerName, err)
+	}
+	if encrypted {
+		refJSON, merr := json.Marshal(ref)
+		if merr != nil {
+			return nil, fmt.Errorf("encode the key ref for %s: %w", containerName, merr)
+		}
+		tenant := tenantFromRef(ref, containerName)
+		prep, perr := prepareFn(targetPeer, extractAuthToken(ctx), &pb.PrepareEncryptedMigrationRequest{
+			Username: req.Username,
+			Tenant:   tenant,
+			KeyRef:   string(refJSON),
+		})
+		if perr != nil {
+			return nil, fmt.Errorf("pre-flight with backend %q: %w", req.TargetBackendId, perr)
+		}
+		if !prep.GetCanResolve() {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"backend %q cannot take encrypted container %s: %s. Nothing was copied",
+				req.TargetBackendId, containerName, prep.GetReason())
+		}
+		// #1203b targets the copy at this pool. Logged now so a migration run
+		// today records where the container was meant to land.
+		log.Printf("[move] pre-flight ok: %s (tenant %s) will land on %s's storage pool %s",
+			containerName, tenant, req.TargetBackendId, prep.GetStoragePool())
 	}
 
 	params := migrationDefaults(req)
@@ -308,6 +351,48 @@ func overrideAdoptForTest(f func(*PeerClient, string, *pb.AdoptMigratedContainer
 	prev := adoptFn
 	adoptFn = f
 	return func() { adoptFn = prev }
+}
+
+// prepareFn is the seam the migration pre-flight goes through, so tests can
+// drive the orchestrator without a peer. Mirrors adoptFn.
+var prepareFn = forwardPrepareEncryptedMigration
+
+// overridePrepareForTest swaps the pre-flight forwarder and returns a restore
+// function.
+func overridePrepareForTest(f func(*PeerClient, string, *pb.PrepareEncryptedMigrationRequest) (*pb.PrepareEncryptedMigrationResponse, error)) func() {
+	prev := prepareFn
+	prepareFn = f
+	return func() { prepareFn = prev }
+}
+
+// forwardPrepareEncryptedMigration issues the pre-flight REST call to a peer
+// over the existing PeerClient generic forwarder.
+//
+// Only the KeyRef travels. There is no field on this request that could carry
+// key material, and that is the point: the destination resolves the reference
+// with its own custody rather than being handed a key.
+func forwardPrepareEncryptedMigration(peer *PeerClient, authToken string, req *pb.PrepareEncryptedMigrationRequest) (*pb.PrepareEncryptedMigrationResponse, error) {
+	body, err := json.Marshal(map[string]interface{}{
+		"username": req.Username,
+		"tenant":   req.Tenant,
+		"key_ref":  req.KeyRef,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal pre-flight request: %w", err)
+	}
+	respBody, code, err := peer.ForwardRequest("POST",
+		fmt.Sprintf("/v1/containers/%s/prepare-encrypted-migration", req.Username), authToken, body)
+	if err != nil {
+		return nil, fmt.Errorf("peer pre-flight RPC: %w", err)
+	}
+	if code >= 400 {
+		return nil, fmt.Errorf("peer pre-flight RPC returned %d: %s", code, string(respBody))
+	}
+	var resp pb.PrepareEncryptedMigrationResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("decode pre-flight response: %w", err)
+	}
+	return &resp, nil
 }
 
 // forwardAdoptMigratedContainer issues the AdoptMigratedContainer

--- a/internal/server/move_encrypted_preflight_test.go
+++ b/internal/server/move_encrypted_preflight_test.go
@@ -1,0 +1,332 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Migration pre-flight for encrypted containers (#1360, from #1203).
+//
+// The check exists because the alternative is discovering at the END of a
+// migration that the destination cannot unlock what it just received: a full
+// data copy spent, and an unstartable container shell left on the far side.
+//
+// It also provisions the destination's tenant storage, because the copy has
+// to land inside that tenant's encryptionroot and only the destination can
+// create it. One call, two answers, both needed at the same moment.
+
+// --- source side -------------------------------------------------------
+
+// prepareRecorder captures what the source sent to the destination.
+type prepareRecorder struct {
+	calls []*pb.PrepareEncryptedMigrationRequest
+	resp  *pb.PrepareEncryptedMigrationResponse
+	err   error
+}
+
+func (p *prepareRecorder) install(t *testing.T) {
+	t.Helper()
+	prev := overridePrepareForTest(func(_ *PeerClient, _ string, req *pb.PrepareEncryptedMigrationRequest) (*pb.PrepareEncryptedMigrationResponse, error) {
+		p.calls = append(p.calls, req)
+		if p.err != nil {
+			return nil, p.err
+		}
+		return p.resp, nil
+	})
+	t.Cleanup(prev)
+}
+
+// encryptedServer wires a move-capable server whose container is recorded as
+// encrypted, the way a create through #1341's path leaves it.
+func encryptedServer(t *testing.T, runner *fakeRunner) *ContainerServer {
+	t.Helper()
+	cs := newTestContainerServer(t, runner, "vm2")
+	cs.encryption = &encryptionHooks{
+		provider: &fakeKeyProvider{key: aKey(t)},
+		// A real manager over a fake runner. The source only READS the stored
+		// ref, so nothing here is invoked — but enabled() requires it, and a
+		// nil would make every container read as unencrypted, which is
+		// exactly the silent failure this whole feature guards against.
+		zfs: zfscrypt.NewManager(newZFSFake()),
+		refs: &fakeRefStore{
+			refs: map[string]zfskey.KeyRef{
+				"alice-container": {Scheme: zfskey.SchemeFile, URI: "/keys/alice.key",
+					Metadata: map[string]string{"tenant": "alice"}},
+			},
+			pools: map[string]string{"alice-container": "containarium-tenant-alice"},
+		},
+		pools:      newFakePools(),
+		tenantRoot: "tank/tenants",
+	}
+	return cs
+}
+
+// The acceptance criterion: a destination that cannot resolve the ref fails
+// the pre-flight BEFORE any data is copied. "Before" is the whole value —
+// a check that runs after the copy is just a nicer error message on a
+// migration that already cost the transfer.
+func TestMoveContainer_AbortsBeforeCopyingWhenTheDestinationCannotResolveTheKey(t *testing.T) {
+	runner := &fakeRunner{hasRemote: true}
+	cs := encryptedServer(t, runner)
+	rec := &prepareRecorder{resp: &pb.PrepareEncryptedMigrationResponse{
+		CanResolve: false,
+		Reason:     "no key custody configured on this daemon",
+	}}
+	rec.install(t)
+
+	_, err := cs.MoveContainer(adminCtx(), &pb.MoveContainerRequest{
+		Username: "alice", TargetBackendId: "vm2",
+	})
+	if err == nil {
+		t.Fatal("the migration proceeded although the destination cannot unlock the container — " +
+			"it would arrive as an unstartable shell after a full data copy")
+	}
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", got)
+	}
+	// The operator has to learn WHY from the destination, not just "it failed".
+	if !strings.Contains(err.Error(), "no key custody configured") {
+		t.Errorf("the destination's reason did not survive to the caller: %v", err)
+	}
+
+	// Nothing may have been touched. This is the assertion that makes the
+	// check worth having.
+	for _, call := range runner.calls {
+		t.Errorf("the runner was invoked (%q) despite a failed pre-flight — the point of the "+
+			"check is that a doomed migration costs nothing", call)
+	}
+}
+
+func TestMoveContainer_PreflightRunsBeforeTheFirstSnapshot(t *testing.T) {
+	runner := &fakeRunner{hasRemote: true}
+	cs := encryptedServer(t, runner)
+	rec := &prepareRecorder{resp: &pb.PrepareEncryptedMigrationResponse{
+		CanResolve: true, StoragePool: "containarium-tenant-alice",
+	}}
+	rec.install(t)
+
+	prev := overrideAdoptForTest(func(*PeerClient, string, *pb.AdoptMigratedContainerRequest) (*pb.AdoptMigratedContainerResponse, error) {
+		return &pb.AdoptMigratedContainerResponse{NewIpAddress: "10.0.7.42"}, nil
+	})
+	defer prev()
+
+	if _, err := cs.MoveContainer(adminCtx(), &pb.MoveContainerRequest{
+		Username: "alice", TargetBackendId: "vm2",
+	}); err != nil {
+		t.Fatalf("MoveContainer: %v", err)
+	}
+
+	if len(rec.calls) != 1 {
+		t.Fatalf("pre-flight called %d times, want exactly 1", len(rec.calls))
+	}
+	if len(runner.calls) == 0 {
+		t.Fatal("the migration did no work at all")
+	}
+	// The recorder appends on call; the runner appends on each incus
+	// operation. The pre-flight having happened at all, with the runner's
+	// first call being a snapshot, is the ordering under test.
+	if first := runner.calls[0]; !strings.HasPrefix(first, "snapshot ") {
+		t.Errorf("first runner call = %q, want a snapshot — the pre-flight should precede it", first)
+	}
+}
+
+// #1203 AC3: only the reference crosses the wire.
+//
+// A KeyRef is scheme + URI + metadata. If key BYTES ever reached this
+// message, they would travel between daemons and sit in whatever logs the
+// transport keeps — the one thing the design forbids outright.
+func TestMoveContainer_PreflightSendsTheRefAndNeverKeyMaterial(t *testing.T) {
+	runner := &fakeRunner{hasRemote: true}
+	cs := encryptedServer(t, runner)
+	rec := &prepareRecorder{resp: &pb.PrepareEncryptedMigrationResponse{
+		CanResolve: true, StoragePool: "containarium-tenant-alice",
+	}}
+	rec.install(t)
+
+	prev := overrideAdoptForTest(func(*PeerClient, string, *pb.AdoptMigratedContainerRequest) (*pb.AdoptMigratedContainerResponse, error) {
+		return &pb.AdoptMigratedContainerResponse{NewIpAddress: "10.0.7.42"}, nil
+	})
+	defer prev()
+
+	if _, err := cs.MoveContainer(adminCtx(), &pb.MoveContainerRequest{
+		Username: "alice", TargetBackendId: "vm2",
+	}); err != nil {
+		t.Fatalf("MoveContainer: %v", err)
+	}
+	if len(rec.calls) != 1 {
+		t.Fatalf("pre-flight called %d times, want 1", len(rec.calls))
+	}
+	sent := rec.calls[0]
+
+	if sent.Tenant != "alice" {
+		t.Errorf("tenant = %q, want %q — the destination provisions per tenant, not per container",
+			sent.Tenant, "alice")
+	}
+
+	var ref zfskey.KeyRef
+	if err := json.Unmarshal([]byte(sent.KeyRef), &ref); err != nil {
+		t.Fatalf("the key_ref field is not a decodable KeyRef: %v", err)
+	}
+	if ref.URI != "/keys/alice.key" || ref.Scheme != zfskey.SchemeFile {
+		t.Errorf("ref did not survive the wire: %+v", ref)
+	}
+
+	// The key this tenant actually holds, verbatim, must not appear
+	// anywhere in the request — not in the ref, not in a stray field.
+	keyBytes := aKey(t).Bytes()
+	if strings.Contains(sent.String(), string(keyBytes)) {
+		t.Error("key MATERIAL is present in the pre-flight request — only the reference may travel")
+	}
+}
+
+// An unencrypted migration must be untouched: no extra round trip, no new
+// failure mode. Every container today is unencrypted.
+func TestMoveContainer_UnencryptedMigrationMakesNoPreflightCall(t *testing.T) {
+	runner := &fakeRunner{hasRemote: true}
+	cs := newTestContainerServer(t, runner, "vm2") // no encryption hooks at all
+	rec := &prepareRecorder{resp: &pb.PrepareEncryptedMigrationResponse{CanResolve: false}}
+	rec.install(t)
+
+	prev := overrideAdoptForTest(func(*PeerClient, string, *pb.AdoptMigratedContainerRequest) (*pb.AdoptMigratedContainerResponse, error) {
+		return &pb.AdoptMigratedContainerResponse{NewIpAddress: "10.0.7.42"}, nil
+	})
+	defer prev()
+
+	if _, err := cs.MoveContainer(adminCtx(), &pb.MoveContainerRequest{
+		Username: "bob", TargetBackendId: "vm2",
+	}); err != nil {
+		t.Fatalf("an unencrypted migration failed: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("an unencrypted migration made %d pre-flight call(s) — the destination would be "+
+			"asked to resolve a ref that does not exist, and a `CanResolve:false` answer would "+
+			"break a migration that has nothing to do with encryption", len(rec.calls))
+	}
+}
+
+// --- destination side --------------------------------------------------
+
+func TestPrepareEncryptedMigration_ResolvesTheRefAndProvisionsTheTenantPool(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	pools := newFakePools()
+	s := &ContainerServer{encryption: testHooksWith(t, z, p,
+		&fakeRefStore{refs: map[string]zfskey.KeyRef{}}, pools)}
+
+	resp, err := s.PrepareEncryptedMigration(adminCtx(), &pb.PrepareEncryptedMigrationRequest{
+		Username: "alice", Tenant: "alice", KeyRef: refJSON(t, "/keys/alice.key"),
+	})
+	if err != nil {
+		t.Fatalf("PrepareEncryptedMigration: %v", err)
+	}
+	if !resp.CanResolve {
+		t.Fatalf("a destination with working key custody refused: %s", resp.Reason)
+	}
+	if resp.StoragePool == "" {
+		t.Error("no storage pool returned — the source has nowhere correct to copy into, and the " +
+			"container would land on the destination's default pool, unencrypted")
+	}
+	if len(pools.created) != 1 {
+		t.Errorf("the tenant pool was created %d times, want 1", len(pools.created))
+	}
+}
+
+// A destination with no key custody must answer plainly, not error. The
+// source needs the REASON to put in front of an operator.
+func TestPrepareEncryptedMigration_RefusesWithoutKeyCustody(t *testing.T) {
+	s := &ContainerServer{} // no encryption wired
+
+	resp, err := s.PrepareEncryptedMigration(adminCtx(), &pb.PrepareEncryptedMigrationRequest{
+		Username: "alice", Tenant: "alice", KeyRef: refJSON(t, "/keys/alice.key"),
+	})
+	if err != nil {
+		t.Fatalf("a destination without custody returned a transport error rather than an "+
+			"answer: %v", err)
+	}
+	if resp.CanResolve {
+		t.Fatal("a destination with no key custody claimed it could resolve the ref — the " +
+			"migration would proceed and the container would arrive unopenable")
+	}
+	if resp.Reason == "" {
+		t.Error("refused with no reason; the operator cannot tell this from any other failure")
+	}
+}
+
+// Custody configured but this particular ref unresolvable — a tenant the
+// destination has never heard of, or a key it cannot reach.
+func TestPrepareEncryptedMigration_RefusesAnUnresolvableRef(t *testing.T) {
+	z := newZFSFake()
+	p := &fakeKeyProvider{key: aKey(t), loadErr: errors.New("no such key for tenant")}
+	pools := newFakePools()
+	s := &ContainerServer{encryption: testHooksWith(t, z, p,
+		&fakeRefStore{refs: map[string]zfskey.KeyRef{}}, pools)}
+
+	resp, err := s.PrepareEncryptedMigration(adminCtx(), &pb.PrepareEncryptedMigrationRequest{
+		Username: "alice", Tenant: "alice", KeyRef: refJSON(t, "/keys/alice.key"),
+	})
+	if err != nil {
+		t.Fatalf("PrepareEncryptedMigration: %v", err)
+	}
+	if resp.CanResolve {
+		t.Fatal("claimed it could resolve a ref its own provider rejected")
+	}
+	if !strings.Contains(resp.Reason, "no such key") {
+		t.Errorf("the provider's reason did not reach the response: %q", resp.Reason)
+	}
+	// And nothing may have been provisioned for a tenant we cannot serve.
+	if len(pools.created) != 0 {
+		t.Errorf("a tenant pool was created for an unresolvable ref: %v", pools.created)
+	}
+}
+
+func TestPrepareEncryptedMigration_RejectsAMalformedRef(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	s := &ContainerServer{encryption: testHooksWith(t, z, p,
+		&fakeRefStore{refs: map[string]zfskey.KeyRef{}}, newFakePools())}
+
+	_, err := s.PrepareEncryptedMigration(adminCtx(), &pb.PrepareEncryptedMigrationRequest{
+		Username: "alice", Tenant: "alice", KeyRef: "{not json",
+	})
+	if err == nil {
+		t.Fatal("a malformed key ref was accepted")
+	}
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument — the request is wrong, not the daemon", got)
+	}
+}
+
+// Peer-to-peer only, like AdoptMigratedContainer: a user token must not be
+// able to make a daemon provision tenant storage or probe key custody.
+func TestPrepareEncryptedMigration_RequiresAdmin(t *testing.T) {
+	s := &ContainerServer{}
+
+	_, err := s.PrepareEncryptedMigration(
+		tenantWithScopes("alice", auth.ScopeContainersWrite),
+		&pb.PrepareEncryptedMigrationRequest{Username: "alice", Tenant: "alice", KeyRef: refJSON(t, "/k")})
+	if err == nil {
+		t.Fatal("a non-admin caller was allowed to drive the migration pre-flight")
+	}
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Errorf("code = %v, want PermissionDenied", got)
+	}
+}
+
+// --- helpers -----------------------------------------------------------
+
+func refJSON(t *testing.T, uri string) string {
+	t.Helper()
+	b, err := json.Marshal(zfskey.KeyRef{Scheme: zfskey.SchemeFile, URI: uri})
+	if err != nil {
+		t.Fatalf("marshal ref: %v", err)
+	}
+	return string(b)
+}

--- a/internal/server/prepare_encrypted_migration.go
+++ b/internal/server/prepare_encrypted_migration.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Migration pre-flight for encrypted containers (#1360, from #1203), design
+// §3 hook row 5 and §5's cross-VM failure mode.
+//
+// Two questions only the destination can answer, asked together because they
+// are needed at the same moment — before a byte is copied:
+//
+//   - Can this daemon's key custody resolve the source's KeyRef? Without
+//     asking, a migration copies an entire container and only then discovers
+//     the destination cannot unlock it, leaving an unstartable shell.
+//   - Which storage pool is sourced at that tenant's encryptionroot? The copy
+//     has to land inside it, and the destination is the only party that can
+//     create it (#1341).
+//
+// Only the KeyRef crosses the wire. Key material never does — that is the
+// design's flat rule, and the reason this is a resolve-check rather than a
+// key exchange.
+
+// PrepareEncryptedMigration is the destination side of the pre-flight.
+//
+// A destination that cannot take the container answers plainly —
+// can_resolve=false with a reason — rather than returning an error. The
+// source has to put something in front of an operator, and "the destination
+// has no key custody configured" is a different problem from "the peer is
+// unreachable". Errors are reserved for malformed requests and authorization.
+func (s *ContainerServer) PrepareEncryptedMigration(ctx context.Context, req *pb.PrepareEncryptedMigrationRequest) (*pb.PrepareEncryptedMigrationResponse, error) {
+	if req.GetUsername() == "" {
+		return nil, status.Error(codes.InvalidArgument, "username is required")
+	}
+	if req.GetTenant() == "" {
+		return nil, status.Error(codes.InvalidArgument, "tenant is required")
+	}
+	if req.GetKeyRef() == "" {
+		return nil, status.Error(codes.InvalidArgument, "key_ref is required")
+	}
+	// Peer-to-peer only, exactly like AdoptMigratedContainer: this call makes
+	// a daemon provision tenant storage and probe its own key custody. A user
+	// token must not be able to drive either, even for its own username.
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+	if err := auth.AuthorizeTenant(ctx, req.GetUsername()); err != nil {
+		return nil, err
+	}
+
+	var ref zfskey.KeyRef
+	if err := json.Unmarshal([]byte(req.GetKeyRef()), &ref); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "key_ref is not a decodable KeyRef: %v", err)
+	}
+
+	if !s.encryption.enabled() {
+		return refused("this daemon has no key custody configured, so it cannot unlock %s's data "+
+			"after a migration (see --zfs-keys-dir)", req.GetUsername()), nil
+	}
+
+	// Resolve BEFORE provisioning. A tenant this daemon cannot serve should
+	// leave no storage behind — otherwise a refused pre-flight still litters
+	// the destination with pools for tenants that never arrive.
+	if _, err := s.encryption.provider.Load(ctx, ref); err != nil {
+		return refused("this daemon's key custody cannot resolve the key ref for tenant %s: %v",
+			req.GetTenant(), err), nil
+	}
+
+	pool, _, err := s.encryption.EnsureTenantStorage(ctx, req.GetTenant())
+	if err != nil {
+		return refused("this daemon resolved the key for tenant %s but could not provision their "+
+			"encrypted storage: %v", req.GetTenant(), err), nil
+	}
+	if pool == "" {
+		// enabled() said yes and EnsureTenantStorage returned no pool: the
+		// hooks are half-wired. Refusing keeps the source from copying into
+		// the default pool, which would arrive unencrypted.
+		return refused("this daemon resolved the key for tenant %s but resolved no storage pool "+
+			"for them", req.GetTenant()), nil
+	}
+
+	log.Printf("[move] pre-flight accepted for %s (tenant %s): key resolved, storage pool %s ready",
+		req.GetUsername(), req.GetTenant(), pool)
+	return &pb.PrepareEncryptedMigrationResponse{CanResolve: true, StoragePool: pool}, nil
+}
+
+// refused builds a plain "no, and here is why" answer.
+func refused(format string, args ...any) *pb.PrepareEncryptedMigrationResponse {
+	reason := fmt.Sprintf(format, args...)
+	log.Printf("[move] pre-flight refused: %s", reason)
+	return &pb.PrepareEncryptedMigrationResponse{CanResolve: false, Reason: reason}
+}
+
+// migrationRef reports the durable KeyRef and storage pool recorded for a
+// container, and false when the container is not encrypted.
+//
+// Read-only, and deliberately tolerant of a daemon with no encryption wired:
+// on that daemon every container is unencrypted, which is the correct answer
+// rather than an error.
+func (h *encryptionHooks) migrationRef(containerName string) (ref zfskey.KeyRef, pool string, ok bool, err error) {
+	if !h.enabled() {
+		return zfskey.KeyRef{}, "", false, nil
+	}
+	ref, present, err := h.refs.GetKeyRef(containerName)
+	if err != nil {
+		return zfskey.KeyRef{}, "", false, fmt.Errorf("read the encryption key ref of %s: %w", containerName, err)
+	}
+	if !present {
+		return zfskey.KeyRef{}, "", false, nil
+	}
+	pool, err = h.refs.GetPool(containerName)
+	if err != nil {
+		return zfskey.KeyRef{}, "", false, fmt.Errorf("read the storage pool of %s: %w", containerName, err)
+	}
+	return ref, pool, true, nil
+}

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -4817,6 +4817,151 @@ func (x *AdoptMigratedContainerRequest) GetSourceRoutes() []string {
 	return nil
 }
 
+// PrepareEncryptedMigrationRequest asks a destination daemon whether it
+// can take over an encrypted container, BEFORE any data is copied.
+//
+// Only the key REFERENCE travels — never key material. The ref names a
+// key in whatever custody the destination is configured with; resolving
+// it is the destination's job with its own KeyProvider, which is the
+// whole point of the check.
+type PrepareEncryptedMigrationRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Username of the container about to be migrated.
+	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
+	// The tenant whose encryptionroot the container lives under. The
+	// destination provisions storage for this tenant, not for the
+	// container: a tenant's containers share one encryptionroot.
+	Tenant string `protobuf:"bytes,2,opt,name=tenant,proto3" json:"tenant,omitempty"`
+	// The source's stored KeyRef, JSON-encoded exactly as it is held on
+	// the container's own metadata. An opaque reference (scheme + URI +
+	// metadata); it carries no key bytes.
+	KeyRef        string `protobuf:"bytes,3,opt,name=key_ref,json=keyRef,proto3" json:"key_ref,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareEncryptedMigrationRequest) Reset() {
+	*x = PrepareEncryptedMigrationRequest{}
+	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareEncryptedMigrationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareEncryptedMigrationRequest) ProtoMessage() {}
+
+func (x *PrepareEncryptedMigrationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareEncryptedMigrationRequest.ProtoReflect.Descriptor instead.
+func (*PrepareEncryptedMigrationRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *PrepareEncryptedMigrationRequest) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *PrepareEncryptedMigrationRequest) GetTenant() string {
+	if x != nil {
+		return x.Tenant
+	}
+	return ""
+}
+
+func (x *PrepareEncryptedMigrationRequest) GetKeyRef() string {
+	if x != nil {
+		return x.KeyRef
+	}
+	return ""
+}
+
+// PrepareEncryptedMigrationResponse tells the source whether to proceed,
+// and where to put the container if so.
+type PrepareEncryptedMigrationResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Whether the destination resolved the KeyRef through its own key
+	// custody. False means the migration must not start: the container
+	// would arrive unopenable after a full data copy.
+	CanResolve bool `protobuf:"varint,1,opt,name=can_resolve,json=canResolve,proto3" json:"can_resolve,omitempty"`
+	// Why not, when can_resolve is false. Operator-facing.
+	Reason string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	// The destination storage pool the container must be copied into —
+	// the pool sourced at this tenant's encryptionroot. A copy that
+	// ignores it lands on the destination's default pool, outside the
+	// tenant's encryptionroot, and the container arrives unencrypted
+	// while every daemon-side signal says otherwise.
+	StoragePool   string `protobuf:"bytes,3,opt,name=storage_pool,json=storagePool,proto3" json:"storage_pool,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareEncryptedMigrationResponse) Reset() {
+	*x = PrepareEncryptedMigrationResponse{}
+	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareEncryptedMigrationResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareEncryptedMigrationResponse) ProtoMessage() {}
+
+func (x *PrepareEncryptedMigrationResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareEncryptedMigrationResponse.ProtoReflect.Descriptor instead.
+func (*PrepareEncryptedMigrationResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{61}
+}
+
+func (x *PrepareEncryptedMigrationResponse) GetCanResolve() bool {
+	if x != nil {
+		return x.CanResolve
+	}
+	return false
+}
+
+func (x *PrepareEncryptedMigrationResponse) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+func (x *PrepareEncryptedMigrationResponse) GetStoragePool() string {
+	if x != nil {
+		return x.StoragePool
+	}
+	return ""
+}
+
 // AdoptMigratedContainerResponse confirms the destination registered
 // the container and returns its IP for the source's route swap.
 type AdoptMigratedContainerResponse struct {
@@ -4832,7 +4977,7 @@ type AdoptMigratedContainerResponse struct {
 
 func (x *AdoptMigratedContainerResponse) Reset() {
 	*x = AdoptMigratedContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	mi := &file_containarium_v1_container_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4844,7 +4989,7 @@ func (x *AdoptMigratedContainerResponse) String() string {
 func (*AdoptMigratedContainerResponse) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	mi := &file_containarium_v1_container_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4857,7 +5002,7 @@ func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerResponse.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{60}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *AdoptMigratedContainerResponse) GetMessage() string {
@@ -5227,7 +5372,16 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x10downtime_seconds\x18\x05 \x01(\x05R\x0fdowntimeSeconds\"`\n" +
 	"\x1dAdoptMigratedContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12#\n" +
-	"\rsource_routes\x18\x02 \x03(\tR\fsourceRoutes\"`\n" +
+	"\rsource_routes\x18\x02 \x03(\tR\fsourceRoutes\"o\n" +
+	" PrepareEncryptedMigrationRequest\x12\x1a\n" +
+	"\busername\x18\x01 \x01(\tR\busername\x12\x16\n" +
+	"\x06tenant\x18\x02 \x01(\tR\x06tenant\x12\x17\n" +
+	"\akey_ref\x18\x03 \x01(\tR\x06keyRef\"\x7f\n" +
+	"!PrepareEncryptedMigrationResponse\x12\x1f\n" +
+	"\vcan_resolve\x18\x01 \x01(\bR\n" +
+	"canResolve\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\x12!\n" +
+	"\fstorage_pool\x18\x03 \x01(\tR\vstoragePool\"`\n" +
 	"\x1eAdoptMigratedContainerResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12$\n" +
 	"\x0enew_ip_address\x18\x02 \x01(\tR\fnewIpAddress*}\n" +
@@ -5278,111 +5432,113 @@ func file_containarium_v1_container_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
+var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
 var file_containarium_v1_container_proto_goTypes = []any{
-	(OSType)(0),                              // 0: containarium.v1.OSType
-	(AccessType)(0),                          // 1: containarium.v1.AccessType
-	(ContainerState)(0),                      // 2: containarium.v1.ContainerState
-	(DeletePolicy)(0),                        // 3: containarium.v1.DeletePolicy
-	(CloudMetricsProvider)(0),                // 4: containarium.v1.CloudMetricsProvider
-	(CloudMetricsGroup)(0),                   // 5: containarium.v1.CloudMetricsGroup
-	(*ResourceLimits)(nil),                   // 6: containarium.v1.ResourceLimits
-	(*NetworkInfo)(nil),                      // 7: containarium.v1.NetworkInfo
-	(*Container)(nil),                        // 8: containarium.v1.Container
-	(*ContainerMetrics)(nil),                 // 9: containarium.v1.ContainerMetrics
-	(*CreateContainerRequest)(nil),           // 10: containarium.v1.CreateContainerRequest
-	(*CreateContainerResponse)(nil),          // 11: containarium.v1.CreateContainerResponse
-	(*ListContainersRequest)(nil),            // 12: containarium.v1.ListContainersRequest
-	(*ListContainersResponse)(nil),           // 13: containarium.v1.ListContainersResponse
-	(*GetContainerRequest)(nil),              // 14: containarium.v1.GetContainerRequest
-	(*GetContainerResponse)(nil),             // 15: containarium.v1.GetContainerResponse
-	(*DebugContainerRequest)(nil),            // 16: containarium.v1.DebugContainerRequest
-	(*DebugContainerResponse)(nil),           // 17: containarium.v1.DebugContainerResponse
-	(*DeleteContainerRequest)(nil),           // 18: containarium.v1.DeleteContainerRequest
-	(*DeleteContainerResponse)(nil),          // 19: containarium.v1.DeleteContainerResponse
-	(*StartContainerRequest)(nil),            // 20: containarium.v1.StartContainerRequest
-	(*StartContainerResponse)(nil),           // 21: containarium.v1.StartContainerResponse
-	(*StopContainerRequest)(nil),             // 22: containarium.v1.StopContainerRequest
-	(*StopContainerResponse)(nil),            // 23: containarium.v1.StopContainerResponse
-	(*ToggleMonitoringRequest)(nil),          // 24: containarium.v1.ToggleMonitoringRequest
-	(*ToggleMonitoringResponse)(nil),         // 25: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepRequest)(nil),           // 26: containarium.v1.ToggleAutoSleepRequest
-	(*ToggleAutoSleepResponse)(nil),          // 27: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLRequest)(nil),           // 28: containarium.v1.SetContainerTTLRequest
-	(*SetContainerTTLResponse)(nil),          // 29: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyRequest)(nil),  // 30: containarium.v1.SetContainerDeletePolicyRequest
-	(*SetContainerDeletePolicyResponse)(nil), // 31: containarium.v1.SetContainerDeletePolicyResponse
-	(*SetContainerAttributionRequest)(nil),   // 32: containarium.v1.SetContainerAttributionRequest
-	(*SetContainerAttributionResponse)(nil),  // 33: containarium.v1.SetContainerAttributionResponse
-	(*AddSSHKeyRequest)(nil),                 // 34: containarium.v1.AddSSHKeyRequest
-	(*AddSSHKeyResponse)(nil),                // 35: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyRequest)(nil),              // 36: containarium.v1.RemoveSSHKeyRequest
-	(*RemoveSSHKeyResponse)(nil),             // 37: containarium.v1.RemoveSSHKeyResponse
-	(*GetMetricsRequest)(nil),                // 38: containarium.v1.GetMetricsRequest
-	(*GetMetricsResponse)(nil),               // 39: containarium.v1.GetMetricsResponse
-	(*ResizeContainerRequest)(nil),           // 40: containarium.v1.ResizeContainerRequest
-	(*ResizeContainerResponse)(nil),          // 41: containarium.v1.ResizeContainerResponse
-	(*Collaborator)(nil),                     // 42: containarium.v1.Collaborator
-	(*AddCollaboratorRequest)(nil),           // 43: containarium.v1.AddCollaboratorRequest
-	(*AddCollaboratorResponse)(nil),          // 44: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorRequest)(nil),        // 45: containarium.v1.RemoveCollaboratorRequest
-	(*RemoveCollaboratorResponse)(nil),       // 46: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsRequest)(nil),         // 47: containarium.v1.ListCollaboratorsRequest
-	(*ListCollaboratorsResponse)(nil),        // 48: containarium.v1.ListCollaboratorsResponse
-	(*CleanupDiskRequest)(nil),               // 49: containarium.v1.CleanupDiskRequest
-	(*CleanupDiskResponse)(nil),              // 50: containarium.v1.CleanupDiskResponse
-	(*InstallStackRequest)(nil),              // 51: containarium.v1.InstallStackRequest
-	(*InstallStackResponse)(nil),             // 52: containarium.v1.InstallStackResponse
-	(*StackParameter)(nil),                   // 53: containarium.v1.StackParameter
-	(*StackInfo)(nil),                        // 54: containarium.v1.StackInfo
-	(*ListStacksRequest)(nil),                // 55: containarium.v1.ListStacksRequest
-	(*ListStacksResponse)(nil),               // 56: containarium.v1.ListStacksResponse
-	(*GetMonitoringInfoRequest)(nil),         // 57: containarium.v1.GetMonitoringInfoRequest
-	(*GetMonitoringInfoResponse)(nil),        // 58: containarium.v1.GetMonitoringInfoResponse
-	(*SetMetricsExportRequest)(nil),          // 59: containarium.v1.SetMetricsExportRequest
-	(*SetMetricsExportResponse)(nil),         // 60: containarium.v1.SetMetricsExportResponse
-	(*GetMetricsExportRequest)(nil),          // 61: containarium.v1.GetMetricsExportRequest
-	(*GetMetricsExportResponse)(nil),         // 62: containarium.v1.GetMetricsExportResponse
-	(*MoveContainerRequest)(nil),             // 63: containarium.v1.MoveContainerRequest
-	(*MoveContainerResponse)(nil),            // 64: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerRequest)(nil),    // 65: containarium.v1.AdoptMigratedContainerRequest
-	(*AdoptMigratedContainerResponse)(nil),   // 66: containarium.v1.AdoptMigratedContainerResponse
-	nil,                                      // 67: containarium.v1.Container.LabelsEntry
-	nil,                                      // 68: containarium.v1.CreateContainerRequest.LabelsEntry
-	nil,                                      // 69: containarium.v1.CreateContainerRequest.StackParametersEntry
-	nil,                                      // 70: containarium.v1.ListContainersRequest.LabelFilterEntry
-	nil,                                      // 71: containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	nil,                                      // 72: containarium.v1.SetContainerAttributionResponse.LabelsEntry
-	(*timestamppb.Timestamp)(nil),            // 73: google.protobuf.Timestamp
-	(*descriptorpb.EnumValueOptions)(nil),    // 74: google.protobuf.EnumValueOptions
+	(OSType)(0),                               // 0: containarium.v1.OSType
+	(AccessType)(0),                           // 1: containarium.v1.AccessType
+	(ContainerState)(0),                       // 2: containarium.v1.ContainerState
+	(DeletePolicy)(0),                         // 3: containarium.v1.DeletePolicy
+	(CloudMetricsProvider)(0),                 // 4: containarium.v1.CloudMetricsProvider
+	(CloudMetricsGroup)(0),                    // 5: containarium.v1.CloudMetricsGroup
+	(*ResourceLimits)(nil),                    // 6: containarium.v1.ResourceLimits
+	(*NetworkInfo)(nil),                       // 7: containarium.v1.NetworkInfo
+	(*Container)(nil),                         // 8: containarium.v1.Container
+	(*ContainerMetrics)(nil),                  // 9: containarium.v1.ContainerMetrics
+	(*CreateContainerRequest)(nil),            // 10: containarium.v1.CreateContainerRequest
+	(*CreateContainerResponse)(nil),           // 11: containarium.v1.CreateContainerResponse
+	(*ListContainersRequest)(nil),             // 12: containarium.v1.ListContainersRequest
+	(*ListContainersResponse)(nil),            // 13: containarium.v1.ListContainersResponse
+	(*GetContainerRequest)(nil),               // 14: containarium.v1.GetContainerRequest
+	(*GetContainerResponse)(nil),              // 15: containarium.v1.GetContainerResponse
+	(*DebugContainerRequest)(nil),             // 16: containarium.v1.DebugContainerRequest
+	(*DebugContainerResponse)(nil),            // 17: containarium.v1.DebugContainerResponse
+	(*DeleteContainerRequest)(nil),            // 18: containarium.v1.DeleteContainerRequest
+	(*DeleteContainerResponse)(nil),           // 19: containarium.v1.DeleteContainerResponse
+	(*StartContainerRequest)(nil),             // 20: containarium.v1.StartContainerRequest
+	(*StartContainerResponse)(nil),            // 21: containarium.v1.StartContainerResponse
+	(*StopContainerRequest)(nil),              // 22: containarium.v1.StopContainerRequest
+	(*StopContainerResponse)(nil),             // 23: containarium.v1.StopContainerResponse
+	(*ToggleMonitoringRequest)(nil),           // 24: containarium.v1.ToggleMonitoringRequest
+	(*ToggleMonitoringResponse)(nil),          // 25: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepRequest)(nil),            // 26: containarium.v1.ToggleAutoSleepRequest
+	(*ToggleAutoSleepResponse)(nil),           // 27: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLRequest)(nil),            // 28: containarium.v1.SetContainerTTLRequest
+	(*SetContainerTTLResponse)(nil),           // 29: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyRequest)(nil),   // 30: containarium.v1.SetContainerDeletePolicyRequest
+	(*SetContainerDeletePolicyResponse)(nil),  // 31: containarium.v1.SetContainerDeletePolicyResponse
+	(*SetContainerAttributionRequest)(nil),    // 32: containarium.v1.SetContainerAttributionRequest
+	(*SetContainerAttributionResponse)(nil),   // 33: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyRequest)(nil),                  // 34: containarium.v1.AddSSHKeyRequest
+	(*AddSSHKeyResponse)(nil),                 // 35: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyRequest)(nil),               // 36: containarium.v1.RemoveSSHKeyRequest
+	(*RemoveSSHKeyResponse)(nil),              // 37: containarium.v1.RemoveSSHKeyResponse
+	(*GetMetricsRequest)(nil),                 // 38: containarium.v1.GetMetricsRequest
+	(*GetMetricsResponse)(nil),                // 39: containarium.v1.GetMetricsResponse
+	(*ResizeContainerRequest)(nil),            // 40: containarium.v1.ResizeContainerRequest
+	(*ResizeContainerResponse)(nil),           // 41: containarium.v1.ResizeContainerResponse
+	(*Collaborator)(nil),                      // 42: containarium.v1.Collaborator
+	(*AddCollaboratorRequest)(nil),            // 43: containarium.v1.AddCollaboratorRequest
+	(*AddCollaboratorResponse)(nil),           // 44: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorRequest)(nil),         // 45: containarium.v1.RemoveCollaboratorRequest
+	(*RemoveCollaboratorResponse)(nil),        // 46: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsRequest)(nil),          // 47: containarium.v1.ListCollaboratorsRequest
+	(*ListCollaboratorsResponse)(nil),         // 48: containarium.v1.ListCollaboratorsResponse
+	(*CleanupDiskRequest)(nil),                // 49: containarium.v1.CleanupDiskRequest
+	(*CleanupDiskResponse)(nil),               // 50: containarium.v1.CleanupDiskResponse
+	(*InstallStackRequest)(nil),               // 51: containarium.v1.InstallStackRequest
+	(*InstallStackResponse)(nil),              // 52: containarium.v1.InstallStackResponse
+	(*StackParameter)(nil),                    // 53: containarium.v1.StackParameter
+	(*StackInfo)(nil),                         // 54: containarium.v1.StackInfo
+	(*ListStacksRequest)(nil),                 // 55: containarium.v1.ListStacksRequest
+	(*ListStacksResponse)(nil),                // 56: containarium.v1.ListStacksResponse
+	(*GetMonitoringInfoRequest)(nil),          // 57: containarium.v1.GetMonitoringInfoRequest
+	(*GetMonitoringInfoResponse)(nil),         // 58: containarium.v1.GetMonitoringInfoResponse
+	(*SetMetricsExportRequest)(nil),           // 59: containarium.v1.SetMetricsExportRequest
+	(*SetMetricsExportResponse)(nil),          // 60: containarium.v1.SetMetricsExportResponse
+	(*GetMetricsExportRequest)(nil),           // 61: containarium.v1.GetMetricsExportRequest
+	(*GetMetricsExportResponse)(nil),          // 62: containarium.v1.GetMetricsExportResponse
+	(*MoveContainerRequest)(nil),              // 63: containarium.v1.MoveContainerRequest
+	(*MoveContainerResponse)(nil),             // 64: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerRequest)(nil),     // 65: containarium.v1.AdoptMigratedContainerRequest
+	(*PrepareEncryptedMigrationRequest)(nil),  // 66: containarium.v1.PrepareEncryptedMigrationRequest
+	(*PrepareEncryptedMigrationResponse)(nil), // 67: containarium.v1.PrepareEncryptedMigrationResponse
+	(*AdoptMigratedContainerResponse)(nil),    // 68: containarium.v1.AdoptMigratedContainerResponse
+	nil,                                       // 69: containarium.v1.Container.LabelsEntry
+	nil,                                       // 70: containarium.v1.CreateContainerRequest.LabelsEntry
+	nil,                                       // 71: containarium.v1.CreateContainerRequest.StackParametersEntry
+	nil,                                       // 72: containarium.v1.ListContainersRequest.LabelFilterEntry
+	nil,                                       // 73: containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	nil,                                       // 74: containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	(*timestamppb.Timestamp)(nil),             // 75: google.protobuf.Timestamp
+	(*descriptorpb.EnumValueOptions)(nil),     // 76: google.protobuf.EnumValueOptions
 }
 var file_containarium_v1_container_proto_depIdxs = []int32{
 	2,  // 0: containarium.v1.Container.state:type_name -> containarium.v1.ContainerState
 	6,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
 	7,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
-	67, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
+	69, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
 	0,  // 4: containarium.v1.Container.os_type:type_name -> containarium.v1.OSType
 	1,  // 5: containarium.v1.Container.access_type:type_name -> containarium.v1.AccessType
-	73, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
-	73, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
+	75, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	75, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
 	3,  // 8: containarium.v1.Container.delete_policy:type_name -> containarium.v1.DeletePolicy
 	6,  // 9: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
-	68, // 10: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
+	70, // 10: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
 	0,  // 11: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
-	69, // 12: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
+	71, // 12: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
 	8,  // 13: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
 	2,  // 14: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
-	70, // 15: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
+	72, // 15: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
 	8,  // 16: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
 	8,  // 17: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
 	9,  // 18: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	8,  // 19: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
 	8,  // 20: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
-	73, // 21: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	75, // 21: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
 	3,  // 22: containarium.v1.SetContainerDeletePolicyRequest.delete_policy:type_name -> containarium.v1.DeletePolicy
 	3,  // 23: containarium.v1.SetContainerDeletePolicyResponse.delete_policy:type_name -> containarium.v1.DeletePolicy
-	71, // 24: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	72, // 25: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	73, // 24: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	74, // 25: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
 	9,  // 26: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	8,  // 27: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
 	42, // 28: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
@@ -5396,9 +5552,9 @@ var file_containarium_v1_container_proto_depIdxs = []int32{
 	4,  // 36: containarium.v1.SetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
 	5,  // 37: containarium.v1.SetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
 	4,  // 38: containarium.v1.GetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
-	73, // 39: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
+	75, // 39: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
 	5,  // 40: containarium.v1.GetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
-	74, // 41: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
+	76, // 41: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
 	42, // [42:42] is the sub-list for method output_type
 	42, // [42:42] is the sub-list for method input_type
 	42, // [42:42] is the sub-list for extension type_name
@@ -5417,7 +5573,7 @@ func file_containarium_v1_container_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_container_proto_rawDesc), len(file_containarium_v1_container_proto_rawDesc)),
 			NumEnums:      6,
-			NumMessages:   67,
+			NumMessages:   69,
 			NumExtensions: 1,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xac\x92\x01\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xa8\x97\x01\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -50,7 +50,9 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x0fResizeContainer\x12'.containarium.v1.ResizeContainerRequest\x1a(.containarium.v1.ResizeContainerResponse\"\xdc\x01\x92A\xad\x01\n" +
 	"\x14Container Operations\x12\x1aResize container resources\x1ayDynamically adjusts CPU, memory, and disk resources without container restart. Disk can only be increased, not decreased.\x82\xd3\xe4\x93\x02%:\x01*\x1a /v1/containers/{username}/resize\x12\xc8\x03\n" +
 	"\rMoveContainer\x12%.containarium.v1.MoveContainerRequest\x1a&.containarium.v1.MoveContainerResponse\"\xe7\x02\x92A\xba\x02\n" +
-	"\x14Container Operations\x12 Migrate container to peer daemon\x1a\xff\x01Pre-copy snapshot-based migration to a peer daemon. Sub-second downtime on ZFS/btrfs storage with low write rate; up to minutes on dir-pool or active workloads. Caller must have incus remotes configured both directions between the source and target hosts.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/containers/{username}/move\x12\xdc\x03\n" +
+	"\x14Container Operations\x12 Migrate container to peer daemon\x1a\xff\x01Pre-copy snapshot-based migration to a peer daemon. Sub-second downtime on ZFS/btrfs storage with low write rate; up to minutes on dir-pool or active workloads. Caller must have incus remotes configured both directions between the source and target hosts.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/containers/{username}/move\x12\xf9\x04\n" +
+	"\x19PrepareEncryptedMigration\x121.containarium.v1.PrepareEncryptedMigrationRequest\x1a2.containarium.v1.PrepareEncryptedMigrationResponse\"\xf4\x03\x92A\xb0\x03\n" +
+	"\x14Container Operations\x12,Pre-flight an encrypted migration (internal)\x1a\xe9\x02Called by the source daemon before MoveContainer copies anything. The destination reports whether its key custody can resolve the container's KeyRef, and provisions the tenant's encrypted storage pool so the copy lands inside the tenant's encryptionroot. Only the key reference is sent; key material never crosses the wire. Not intended for direct operator use.\x82\xd3\xe4\x93\x02::\x01*\"5/v1/containers/{username}/prepare-encrypted-migration\x12\xdc\x03\n" +
 	"\x16AdoptMigratedContainer\x12..containarium.v1.AdoptMigratedContainerRequest\x1a/.containarium.v1.AdoptMigratedContainerResponse\"\xe0\x02\x92A\xb2\x02\n" +
 	"\x14Container Operations\x12%Adopt a migrated container (internal)\x1a\xf2\x01Called by the source daemon during MoveContainer after the LXC has been Incus-copied to this host. Registers the container's host-side accounts and route record so it's fully under Containarium's control. Not intended for direct operator use.\x82\xd3\xe4\x93\x02$:\x01*\"\x1f/v1/containers/{username}/adopt\x12\xd6\x03\n" +
 	"\x10ToggleMonitoring\x12(.containarium.v1.ToggleMonitoringRequest\x1a).containarium.v1.ToggleMonitoringResponse\"\xec\x02\x92A\xb9\x02\n" +
@@ -161,114 +163,116 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x06bearer\x12\x00ZIgithub.com/footprintai/containarium/pkg/pb/containarium/v1;containariumv1b\x06proto3"
 
 var file_containarium_v1_service_proto_goTypes = []any{
-	(*CreateContainerRequest)(nil),           // 0: containarium.v1.CreateContainerRequest
-	(*ListContainersRequest)(nil),            // 1: containarium.v1.ListContainersRequest
-	(*GetContainerRequest)(nil),              // 2: containarium.v1.GetContainerRequest
-	(*DebugContainerRequest)(nil),            // 3: containarium.v1.DebugContainerRequest
-	(*DeleteContainerRequest)(nil),           // 4: containarium.v1.DeleteContainerRequest
-	(*StartContainerRequest)(nil),            // 5: containarium.v1.StartContainerRequest
-	(*StopContainerRequest)(nil),             // 6: containarium.v1.StopContainerRequest
-	(*ResizeContainerRequest)(nil),           // 7: containarium.v1.ResizeContainerRequest
-	(*MoveContainerRequest)(nil),             // 8: containarium.v1.MoveContainerRequest
-	(*AdoptMigratedContainerRequest)(nil),    // 9: containarium.v1.AdoptMigratedContainerRequest
-	(*ToggleMonitoringRequest)(nil),          // 10: containarium.v1.ToggleMonitoringRequest
-	(*ToggleAutoSleepRequest)(nil),           // 11: containarium.v1.ToggleAutoSleepRequest
-	(*SetContainerTTLRequest)(nil),           // 12: containarium.v1.SetContainerTTLRequest
-	(*SetContainerDeletePolicyRequest)(nil),  // 13: containarium.v1.SetContainerDeletePolicyRequest
-	(*SetContainerAttributionRequest)(nil),   // 14: containarium.v1.SetContainerAttributionRequest
-	(*AddSSHKeyRequest)(nil),                 // 15: containarium.v1.AddSSHKeyRequest
-	(*RemoveSSHKeyRequest)(nil),              // 16: containarium.v1.RemoveSSHKeyRequest
-	(*AddCollaboratorRequest)(nil),           // 17: containarium.v1.AddCollaboratorRequest
-	(*RemoveCollaboratorRequest)(nil),        // 18: containarium.v1.RemoveCollaboratorRequest
-	(*ListCollaboratorsRequest)(nil),         // 19: containarium.v1.ListCollaboratorsRequest
-	(*GetMetricsRequest)(nil),                // 20: containarium.v1.GetMetricsRequest
-	(*CleanupDiskRequest)(nil),               // 21: containarium.v1.CleanupDiskRequest
-	(*InstallStackRequest)(nil),              // 22: containarium.v1.InstallStackRequest
-	(*ListStacksRequest)(nil),                // 23: containarium.v1.ListStacksRequest
-	(*GetSystemInfoRequest)(nil),             // 24: containarium.v1.GetSystemInfoRequest
-	(*ListBackendsRequest)(nil),              // 25: containarium.v1.ListBackendsRequest
-	(*AdvertiseCapacityRequest)(nil),         // 26: containarium.v1.AdvertiseCapacityRequest
-	(*WithdrawCapacityRequest)(nil),          // 27: containarium.v1.WithdrawCapacityRequest
-	(*GetCapacityHeadroomRequest)(nil),       // 28: containarium.v1.GetCapacityHeadroomRequest
-	(*ProfileBackendRequest)(nil),            // 29: containarium.v1.ProfileBackendRequest
-	(*GetCapabilityProfileRequest)(nil),      // 30: containarium.v1.GetCapabilityProfileRequest
-	(*GetSelfMeasurementRequest)(nil),        // 31: containarium.v1.GetSelfMeasurementRequest
-	(*GetLatestReleaseRequest)(nil),          // 32: containarium.v1.GetLatestReleaseRequest
-	(*ValidateGPURequest)(nil),               // 33: containarium.v1.ValidateGPURequest
-	(*TriggerUpgradeRequest)(nil),            // 34: containarium.v1.TriggerUpgradeRequest
-	(*GetUpgradeStatusRequest)(nil),          // 35: containarium.v1.GetUpgradeStatusRequest
-	(*GetMonitoringInfoRequest)(nil),         // 36: containarium.v1.GetMonitoringInfoRequest
-	(*SetMetricsExportRequest)(nil),          // 37: containarium.v1.SetMetricsExportRequest
-	(*GetMetricsExportRequest)(nil),          // 38: containarium.v1.GetMetricsExportRequest
-	(*CreateAlertRuleRequest)(nil),           // 39: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),            // 40: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),              // 41: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),           // 42: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),           // 43: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),           // 44: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),     // 45: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),      // 46: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),               // 47: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),     // 48: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),                 // 49: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),                 // 50: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),               // 51: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),              // 52: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),            // 53: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),          // 54: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),           // 55: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),             // 56: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),           // 57: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),          // 58: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),           // 59: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),            // 60: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),          // 61: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),            // 62: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerResponse)(nil),   // 63: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),         // 64: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),          // 65: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),          // 66: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyResponse)(nil), // 67: containarium.v1.SetContainerDeletePolicyResponse
-	(*SetContainerAttributionResponse)(nil),  // 68: containarium.v1.SetContainerAttributionResponse
-	(*AddSSHKeyResponse)(nil),                // 69: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),             // 70: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),          // 71: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),       // 72: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),        // 73: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),               // 74: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),              // 75: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),             // 76: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),               // 77: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),            // 78: containarium.v1.GetSystemInfoResponse
-	(*ListBackendsResponse)(nil),             // 79: containarium.v1.ListBackendsResponse
-	(*AdvertiseCapacityResponse)(nil),        // 80: containarium.v1.AdvertiseCapacityResponse
-	(*WithdrawCapacityResponse)(nil),         // 81: containarium.v1.WithdrawCapacityResponse
-	(*GetCapacityHeadroomResponse)(nil),      // 82: containarium.v1.GetCapacityHeadroomResponse
-	(*ProfileBackendResponse)(nil),           // 83: containarium.v1.ProfileBackendResponse
-	(*GetCapabilityProfileResponse)(nil),     // 84: containarium.v1.GetCapabilityProfileResponse
-	(*GetSelfMeasurementResponse)(nil),       // 85: containarium.v1.GetSelfMeasurementResponse
-	(*GetLatestReleaseResponse)(nil),         // 86: containarium.v1.GetLatestReleaseResponse
-	(*ValidateGPUResponse)(nil),              // 87: containarium.v1.ValidateGPUResponse
-	(*TriggerUpgradeResponse)(nil),           // 88: containarium.v1.TriggerUpgradeResponse
-	(*GetUpgradeStatusResponse)(nil),         // 89: containarium.v1.GetUpgradeStatusResponse
-	(*GetMonitoringInfoResponse)(nil),        // 90: containarium.v1.GetMonitoringInfoResponse
-	(*SetMetricsExportResponse)(nil),         // 91: containarium.v1.SetMetricsExportResponse
-	(*GetMetricsExportResponse)(nil),         // 92: containarium.v1.GetMetricsExportResponse
-	(*CreateAlertRuleResponse)(nil),          // 93: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),           // 94: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),             // 95: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),          // 96: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),          // 97: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),          // 98: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),    // 99: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),     // 100: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),              // 101: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),    // 102: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),                // 103: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),                // 104: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),              // 105: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),             // 106: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),           // 107: containarium.v1.RefreshSecretsResponse
+	(*CreateContainerRequest)(nil),            // 0: containarium.v1.CreateContainerRequest
+	(*ListContainersRequest)(nil),             // 1: containarium.v1.ListContainersRequest
+	(*GetContainerRequest)(nil),               // 2: containarium.v1.GetContainerRequest
+	(*DebugContainerRequest)(nil),             // 3: containarium.v1.DebugContainerRequest
+	(*DeleteContainerRequest)(nil),            // 4: containarium.v1.DeleteContainerRequest
+	(*StartContainerRequest)(nil),             // 5: containarium.v1.StartContainerRequest
+	(*StopContainerRequest)(nil),              // 6: containarium.v1.StopContainerRequest
+	(*ResizeContainerRequest)(nil),            // 7: containarium.v1.ResizeContainerRequest
+	(*MoveContainerRequest)(nil),              // 8: containarium.v1.MoveContainerRequest
+	(*PrepareEncryptedMigrationRequest)(nil),  // 9: containarium.v1.PrepareEncryptedMigrationRequest
+	(*AdoptMigratedContainerRequest)(nil),     // 10: containarium.v1.AdoptMigratedContainerRequest
+	(*ToggleMonitoringRequest)(nil),           // 11: containarium.v1.ToggleMonitoringRequest
+	(*ToggleAutoSleepRequest)(nil),            // 12: containarium.v1.ToggleAutoSleepRequest
+	(*SetContainerTTLRequest)(nil),            // 13: containarium.v1.SetContainerTTLRequest
+	(*SetContainerDeletePolicyRequest)(nil),   // 14: containarium.v1.SetContainerDeletePolicyRequest
+	(*SetContainerAttributionRequest)(nil),    // 15: containarium.v1.SetContainerAttributionRequest
+	(*AddSSHKeyRequest)(nil),                  // 16: containarium.v1.AddSSHKeyRequest
+	(*RemoveSSHKeyRequest)(nil),               // 17: containarium.v1.RemoveSSHKeyRequest
+	(*AddCollaboratorRequest)(nil),            // 18: containarium.v1.AddCollaboratorRequest
+	(*RemoveCollaboratorRequest)(nil),         // 19: containarium.v1.RemoveCollaboratorRequest
+	(*ListCollaboratorsRequest)(nil),          // 20: containarium.v1.ListCollaboratorsRequest
+	(*GetMetricsRequest)(nil),                 // 21: containarium.v1.GetMetricsRequest
+	(*CleanupDiskRequest)(nil),                // 22: containarium.v1.CleanupDiskRequest
+	(*InstallStackRequest)(nil),               // 23: containarium.v1.InstallStackRequest
+	(*ListStacksRequest)(nil),                 // 24: containarium.v1.ListStacksRequest
+	(*GetSystemInfoRequest)(nil),              // 25: containarium.v1.GetSystemInfoRequest
+	(*ListBackendsRequest)(nil),               // 26: containarium.v1.ListBackendsRequest
+	(*AdvertiseCapacityRequest)(nil),          // 27: containarium.v1.AdvertiseCapacityRequest
+	(*WithdrawCapacityRequest)(nil),           // 28: containarium.v1.WithdrawCapacityRequest
+	(*GetCapacityHeadroomRequest)(nil),        // 29: containarium.v1.GetCapacityHeadroomRequest
+	(*ProfileBackendRequest)(nil),             // 30: containarium.v1.ProfileBackendRequest
+	(*GetCapabilityProfileRequest)(nil),       // 31: containarium.v1.GetCapabilityProfileRequest
+	(*GetSelfMeasurementRequest)(nil),         // 32: containarium.v1.GetSelfMeasurementRequest
+	(*GetLatestReleaseRequest)(nil),           // 33: containarium.v1.GetLatestReleaseRequest
+	(*ValidateGPURequest)(nil),                // 34: containarium.v1.ValidateGPURequest
+	(*TriggerUpgradeRequest)(nil),             // 35: containarium.v1.TriggerUpgradeRequest
+	(*GetUpgradeStatusRequest)(nil),           // 36: containarium.v1.GetUpgradeStatusRequest
+	(*GetMonitoringInfoRequest)(nil),          // 37: containarium.v1.GetMonitoringInfoRequest
+	(*SetMetricsExportRequest)(nil),           // 38: containarium.v1.SetMetricsExportRequest
+	(*GetMetricsExportRequest)(nil),           // 39: containarium.v1.GetMetricsExportRequest
+	(*CreateAlertRuleRequest)(nil),            // 40: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),             // 41: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),               // 42: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),            // 43: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),            // 44: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),            // 45: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),      // 46: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),       // 47: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),                // 48: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),      // 49: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),                  // 50: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),                  // 51: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),                // 52: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),               // 53: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),             // 54: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),           // 55: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),            // 56: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),              // 57: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),            // 58: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),           // 59: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),            // 60: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),             // 61: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),           // 62: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),             // 63: containarium.v1.MoveContainerResponse
+	(*PrepareEncryptedMigrationResponse)(nil), // 64: containarium.v1.PrepareEncryptedMigrationResponse
+	(*AdoptMigratedContainerResponse)(nil),    // 65: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),          // 66: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),           // 67: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),           // 68: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyResponse)(nil),  // 69: containarium.v1.SetContainerDeletePolicyResponse
+	(*SetContainerAttributionResponse)(nil),   // 70: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyResponse)(nil),                 // 71: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),              // 72: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),           // 73: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),        // 74: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),         // 75: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),                // 76: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),               // 77: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),              // 78: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),                // 79: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),             // 80: containarium.v1.GetSystemInfoResponse
+	(*ListBackendsResponse)(nil),              // 81: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityResponse)(nil),         // 82: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityResponse)(nil),          // 83: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomResponse)(nil),       // 84: containarium.v1.GetCapacityHeadroomResponse
+	(*ProfileBackendResponse)(nil),            // 85: containarium.v1.ProfileBackendResponse
+	(*GetCapabilityProfileResponse)(nil),      // 86: containarium.v1.GetCapabilityProfileResponse
+	(*GetSelfMeasurementResponse)(nil),        // 87: containarium.v1.GetSelfMeasurementResponse
+	(*GetLatestReleaseResponse)(nil),          // 88: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),               // 89: containarium.v1.ValidateGPUResponse
+	(*TriggerUpgradeResponse)(nil),            // 90: containarium.v1.TriggerUpgradeResponse
+	(*GetUpgradeStatusResponse)(nil),          // 91: containarium.v1.GetUpgradeStatusResponse
+	(*GetMonitoringInfoResponse)(nil),         // 92: containarium.v1.GetMonitoringInfoResponse
+	(*SetMetricsExportResponse)(nil),          // 93: containarium.v1.SetMetricsExportResponse
+	(*GetMetricsExportResponse)(nil),          // 94: containarium.v1.GetMetricsExportResponse
+	(*CreateAlertRuleResponse)(nil),           // 95: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),            // 96: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),              // 97: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),           // 98: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),           // 99: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),           // 100: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),     // 101: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),      // 102: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),               // 103: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),     // 104: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),                 // 105: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),                 // 106: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),               // 107: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),              // 108: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),            // 109: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,   // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -280,107 +284,109 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	6,   // 6: containarium.v1.ContainerService.StopContainer:input_type -> containarium.v1.StopContainerRequest
 	7,   // 7: containarium.v1.ContainerService.ResizeContainer:input_type -> containarium.v1.ResizeContainerRequest
 	8,   // 8: containarium.v1.ContainerService.MoveContainer:input_type -> containarium.v1.MoveContainerRequest
-	9,   // 9: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
-	10,  // 10: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
-	11,  // 11: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
-	12,  // 12: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
-	13,  // 13: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
-	14,  // 14: containarium.v1.ContainerService.SetContainerAttribution:input_type -> containarium.v1.SetContainerAttributionRequest
-	15,  // 15: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
-	16,  // 16: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
-	17,  // 17: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
-	18,  // 18: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
-	19,  // 19: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
-	20,  // 20: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
-	21,  // 21: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
-	22,  // 22: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
-	23,  // 23: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
-	24,  // 24: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
-	25,  // 25: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
-	26,  // 26: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
-	27,  // 27: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
-	28,  // 28: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
-	29,  // 29: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
-	30,  // 30: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
-	31,  // 31: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
-	32,  // 32: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
-	33,  // 33: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
-	34,  // 34: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
-	35,  // 35: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
-	36,  // 36: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	37,  // 37: containarium.v1.ContainerService.SetMetricsExport:input_type -> containarium.v1.SetMetricsExportRequest
-	38,  // 38: containarium.v1.ContainerService.GetMetricsExport:input_type -> containarium.v1.GetMetricsExportRequest
-	39,  // 39: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	40,  // 40: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	41,  // 41: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	42,  // 42: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	43,  // 43: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	44,  // 44: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	45,  // 45: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	46,  // 46: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	47,  // 47: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	48,  // 48: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	49,  // 49: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	50,  // 50: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	51,  // 51: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	52,  // 52: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	53,  // 53: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	54,  // 54: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	55,  // 55: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	56,  // 56: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	57,  // 57: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	58,  // 58: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	59,  // 59: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	60,  // 60: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	61,  // 61: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	62,  // 62: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	63,  // 63: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	64,  // 64: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	65,  // 65: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	66,  // 66: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	67,  // 67: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
-	68,  // 68: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
-	69,  // 69: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	70,  // 70: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	71,  // 71: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	72,  // 72: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	73,  // 73: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	74,  // 74: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	75,  // 75: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	76,  // 76: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	77,  // 77: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	78,  // 78: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	79,  // 79: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
-	80,  // 80: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
-	81,  // 81: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
-	82,  // 82: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
-	83,  // 83: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
-	84,  // 84: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
-	85,  // 85: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
-	86,  // 86: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	87,  // 87: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
-	88,  // 88: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
-	89,  // 89: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
-	90,  // 90: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	91,  // 91: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
-	92,  // 92: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
-	93,  // 93: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	94,  // 94: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	95,  // 95: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	96,  // 96: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	97,  // 97: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	98,  // 98: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	99,  // 99: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	100, // 100: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	101, // 101: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	102, // 102: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	103, // 103: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	104, // 104: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	105, // 105: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	106, // 106: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	107, // 107: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	54,  // [54:108] is the sub-list for method output_type
-	0,   // [0:54] is the sub-list for method input_type
+	9,   // 9: containarium.v1.ContainerService.PrepareEncryptedMigration:input_type -> containarium.v1.PrepareEncryptedMigrationRequest
+	10,  // 10: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
+	11,  // 11: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
+	12,  // 12: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
+	13,  // 13: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
+	14,  // 14: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
+	15,  // 15: containarium.v1.ContainerService.SetContainerAttribution:input_type -> containarium.v1.SetContainerAttributionRequest
+	16,  // 16: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
+	17,  // 17: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
+	18,  // 18: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
+	19,  // 19: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
+	20,  // 20: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
+	21,  // 21: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
+	22,  // 22: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
+	23,  // 23: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
+	24,  // 24: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
+	25,  // 25: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
+	26,  // 26: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
+	27,  // 27: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
+	28,  // 28: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
+	29,  // 29: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
+	30,  // 30: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
+	31,  // 31: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
+	32,  // 32: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
+	33,  // 33: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
+	34,  // 34: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
+	35,  // 35: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
+	36,  // 36: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
+	37,  // 37: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	38,  // 38: containarium.v1.ContainerService.SetMetricsExport:input_type -> containarium.v1.SetMetricsExportRequest
+	39,  // 39: containarium.v1.ContainerService.GetMetricsExport:input_type -> containarium.v1.GetMetricsExportRequest
+	40,  // 40: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	41,  // 41: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	42,  // 42: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	43,  // 43: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	44,  // 44: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	45,  // 45: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	46,  // 46: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	47,  // 47: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	48,  // 48: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	49,  // 49: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	50,  // 50: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	51,  // 51: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	52,  // 52: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	53,  // 53: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	54,  // 54: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	55,  // 55: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	56,  // 56: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	57,  // 57: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	58,  // 58: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	59,  // 59: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	60,  // 60: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	61,  // 61: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	62,  // 62: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	63,  // 63: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	64,  // 64: containarium.v1.ContainerService.PrepareEncryptedMigration:output_type -> containarium.v1.PrepareEncryptedMigrationResponse
+	65,  // 65: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	66,  // 66: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	67,  // 67: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	68,  // 68: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	69,  // 69: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
+	70,  // 70: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
+	71,  // 71: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	72,  // 72: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	73,  // 73: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	74,  // 74: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	75,  // 75: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	76,  // 76: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	77,  // 77: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	78,  // 78: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	79,  // 79: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	80,  // 80: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	81,  // 81: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
+	82,  // 82: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
+	83,  // 83: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
+	84,  // 84: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
+	85,  // 85: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
+	86,  // 86: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
+	87,  // 87: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
+	88,  // 88: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	89,  // 89: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	90,  // 90: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
+	91,  // 91: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
+	92,  // 92: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	93,  // 93: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
+	94,  // 94: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
+	95,  // 95: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	96,  // 96: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	97,  // 97: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	98,  // 98: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	99,  // 99: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	100, // 100: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	101, // 101: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	102, // 102: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	103, // 103: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	104, // 104: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	105, // 105: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	106, // 106: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	107, // 107: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	108, // 108: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	109, // 109: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	55,  // [55:110] is the sub-list for method output_type
+	0,   // [0:55] is the sub-list for method input_type
 	0,   // [0:0] is the sub-list for extension type_name
 	0,   // [0:0] is the sub-list for extension extendee
 	0,   // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -408,6 +408,51 @@ func local_request_ContainerService_MoveContainer_0(ctx context.Context, marshal
 	return msg, metadata, err
 }
 
+func request_ContainerService_PrepareEncryptedMigration_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PrepareEncryptedMigrationRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.PrepareEncryptedMigration(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_PrepareEncryptedMigration_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq PrepareEncryptedMigrationRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	msg, err := server.PrepareEncryptedMigration(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_AdoptMigratedContainer_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq AdoptMigratedContainerRequest
@@ -2216,6 +2261,26 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_MoveContainer_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_PrepareEncryptedMigration_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/PrepareEncryptedMigration", runtime.WithHTTPPathPattern("/v1/containers/{username}/prepare-encrypted-migration"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_PrepareEncryptedMigration_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_PrepareEncryptedMigration_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_AdoptMigratedContainer_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3329,6 +3394,23 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_MoveContainer_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_PrepareEncryptedMigration_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/PrepareEncryptedMigration", runtime.WithHTTPPathPattern("/v1/containers/{username}/prepare-encrypted-migration"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_PrepareEncryptedMigration_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_PrepareEncryptedMigration_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_AdoptMigratedContainer_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -4115,117 +4197,119 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 }
 
 var (
-	pattern_ContainerService_CreateContainer_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "containers"}, ""))
-	pattern_ContainerService_ListContainers_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "containers"}, ""))
-	pattern_ContainerService_GetContainer_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "containers", "username"}, ""))
-	pattern_ContainerService_DebugContainer_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "debug"}, ""))
-	pattern_ContainerService_DeleteContainer_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "containers", "username"}, ""))
-	pattern_ContainerService_StartContainer_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "start"}, ""))
-	pattern_ContainerService_StopContainer_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "stop"}, ""))
-	pattern_ContainerService_ResizeContainer_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "resize"}, ""))
-	pattern_ContainerService_MoveContainer_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "move"}, ""))
-	pattern_ContainerService_AdoptMigratedContainer_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "adopt"}, ""))
-	pattern_ContainerService_ToggleMonitoring_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "monitoring"}, ""))
-	pattern_ContainerService_ToggleAutoSleep_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "auto-sleep"}, ""))
-	pattern_ContainerService_SetContainerTTL_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "name", "ttl"}, ""))
-	pattern_ContainerService_SetContainerDeletePolicy_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "name", "delete-policy"}, ""))
-	pattern_ContainerService_SetContainerAttribution_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "name", "attribution"}, ""))
-	pattern_ContainerService_AddSSHKey_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "ssh-keys"}, ""))
-	pattern_ContainerService_RemoveSSHKey_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"v1", "containers", "username", "ssh-keys", "ssh_public_key"}, ""))
-	pattern_ContainerService_AddCollaborator_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "owner_username", "collaborators"}, ""))
-	pattern_ContainerService_RemoveCollaborator_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"v1", "containers", "owner_username", "collaborators", "collaborator_username"}, ""))
-	pattern_ContainerService_ListCollaborators_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "owner_username", "collaborators"}, ""))
-	pattern_ContainerService_GetMetrics_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "metrics"}, ""))
-	pattern_ContainerService_GetMetrics_1               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "metrics", "username"}, ""))
-	pattern_ContainerService_CleanupDisk_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "cleanup-disk"}, ""))
-	pattern_ContainerService_InstallStack_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "install-stack"}, ""))
-	pattern_ContainerService_ListStacks_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "stacks"}, ""))
-	pattern_ContainerService_GetSystemInfo_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "info"}, ""))
-	pattern_ContainerService_ListBackends_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "backends"}, ""))
-	pattern_ContainerService_AdvertiseCapacity_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
-	pattern_ContainerService_WithdrawCapacity_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
-	pattern_ContainerService_GetCapacityHeadroom_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
-	pattern_ContainerService_ProfileBackend_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capabilities", "profile"}, ""))
-	pattern_ContainerService_GetCapabilityProfile_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capabilities", "profile"}, ""))
-	pattern_ContainerService_GetSelfMeasurement_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "integrity", "self-measurement"}, ""))
-	pattern_ContainerService_GetLatestRelease_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "releases", "latest"}, ""))
-	pattern_ContainerService_ValidateGPU_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "validate-gpu"}, ""))
-	pattern_ContainerService_TriggerUpgrade_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "backends", "upgrade"}, ""))
-	pattern_ContainerService_GetUpgradeStatus_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "upgrades", "upgrade_id"}, ""))
-	pattern_ContainerService_GetMonitoringInfo_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "monitoring"}, ""))
-	pattern_ContainerService_SetMetricsExport_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "metrics-export"}, ""))
-	pattern_ContainerService_GetMetricsExport_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "metrics-export"}, ""))
-	pattern_ContainerService_CreateAlertRule_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "alerts"}, ""))
-	pattern_ContainerService_ListAlertRules_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "alerts"}, ""))
-	pattern_ContainerService_GetAlertRule_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "alerts", "id"}, ""))
-	pattern_ContainerService_UpdateAlertRule_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "alerts", "id"}, ""))
-	pattern_ContainerService_DeleteAlertRule_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "alerts", "id"}, ""))
-	pattern_ContainerService_GetAlertingInfo_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "alerting"}, ""))
-	pattern_ContainerService_ListDefaultAlertRules_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "alerts", "defaults"}, ""))
-	pattern_ContainerService_UpdateAlertingConfig_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "alerting"}, ""))
-	pattern_ContainerService_TestWebhook_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "system", "alerting", "test"}, ""))
-	pattern_ContainerService_ListWebhookDeliveries_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "system", "alerting", "deliveries"}, ""))
-	pattern_ContainerService_SetSecret_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "secrets"}, ""))
-	pattern_ContainerService_GetSecret_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "secrets", "username", "name"}, ""))
-	pattern_ContainerService_ListSecrets_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "secrets", "username"}, ""))
-	pattern_ContainerService_DeleteSecret_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "secrets", "username", "name"}, ""))
-	pattern_ContainerService_RefreshSecrets_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "secrets", "username", "refresh"}, ""))
+	pattern_ContainerService_CreateContainer_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "containers"}, ""))
+	pattern_ContainerService_ListContainers_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "containers"}, ""))
+	pattern_ContainerService_GetContainer_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "containers", "username"}, ""))
+	pattern_ContainerService_DebugContainer_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "debug"}, ""))
+	pattern_ContainerService_DeleteContainer_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "containers", "username"}, ""))
+	pattern_ContainerService_StartContainer_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "start"}, ""))
+	pattern_ContainerService_StopContainer_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "stop"}, ""))
+	pattern_ContainerService_ResizeContainer_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "resize"}, ""))
+	pattern_ContainerService_MoveContainer_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "move"}, ""))
+	pattern_ContainerService_PrepareEncryptedMigration_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "prepare-encrypted-migration"}, ""))
+	pattern_ContainerService_AdoptMigratedContainer_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "adopt"}, ""))
+	pattern_ContainerService_ToggleMonitoring_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "monitoring"}, ""))
+	pattern_ContainerService_ToggleAutoSleep_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "auto-sleep"}, ""))
+	pattern_ContainerService_SetContainerTTL_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "name", "ttl"}, ""))
+	pattern_ContainerService_SetContainerDeletePolicy_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "name", "delete-policy"}, ""))
+	pattern_ContainerService_SetContainerAttribution_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "name", "attribution"}, ""))
+	pattern_ContainerService_AddSSHKey_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "ssh-keys"}, ""))
+	pattern_ContainerService_RemoveSSHKey_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"v1", "containers", "username", "ssh-keys", "ssh_public_key"}, ""))
+	pattern_ContainerService_AddCollaborator_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "owner_username", "collaborators"}, ""))
+	pattern_ContainerService_RemoveCollaborator_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"v1", "containers", "owner_username", "collaborators", "collaborator_username"}, ""))
+	pattern_ContainerService_ListCollaborators_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "owner_username", "collaborators"}, ""))
+	pattern_ContainerService_GetMetrics_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "metrics"}, ""))
+	pattern_ContainerService_GetMetrics_1                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "metrics", "username"}, ""))
+	pattern_ContainerService_CleanupDisk_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "cleanup-disk"}, ""))
+	pattern_ContainerService_InstallStack_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "install-stack"}, ""))
+	pattern_ContainerService_ListStacks_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "stacks"}, ""))
+	pattern_ContainerService_GetSystemInfo_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "info"}, ""))
+	pattern_ContainerService_ListBackends_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "backends"}, ""))
+	pattern_ContainerService_AdvertiseCapacity_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
+	pattern_ContainerService_WithdrawCapacity_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
+	pattern_ContainerService_GetCapacityHeadroom_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capacity", "headroom"}, ""))
+	pattern_ContainerService_ProfileBackend_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capabilities", "profile"}, ""))
+	pattern_ContainerService_GetCapabilityProfile_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "capabilities", "profile"}, ""))
+	pattern_ContainerService_GetSelfMeasurement_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "integrity", "self-measurement"}, ""))
+	pattern_ContainerService_GetLatestRelease_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "releases", "latest"}, ""))
+	pattern_ContainerService_ValidateGPU_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "validate-gpu"}, ""))
+	pattern_ContainerService_TriggerUpgrade_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "backends", "upgrade"}, ""))
+	pattern_ContainerService_GetUpgradeStatus_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "upgrades", "upgrade_id"}, ""))
+	pattern_ContainerService_GetMonitoringInfo_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "monitoring"}, ""))
+	pattern_ContainerService_SetMetricsExport_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "metrics-export"}, ""))
+	pattern_ContainerService_GetMetricsExport_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "metrics-export"}, ""))
+	pattern_ContainerService_CreateAlertRule_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "alerts"}, ""))
+	pattern_ContainerService_ListAlertRules_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "alerts"}, ""))
+	pattern_ContainerService_GetAlertRule_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "alerts", "id"}, ""))
+	pattern_ContainerService_UpdateAlertRule_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "alerts", "id"}, ""))
+	pattern_ContainerService_DeleteAlertRule_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "alerts", "id"}, ""))
+	pattern_ContainerService_GetAlertingInfo_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "alerting"}, ""))
+	pattern_ContainerService_ListDefaultAlertRules_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "alerts", "defaults"}, ""))
+	pattern_ContainerService_UpdateAlertingConfig_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "system", "alerting"}, ""))
+	pattern_ContainerService_TestWebhook_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "system", "alerting", "test"}, ""))
+	pattern_ContainerService_ListWebhookDeliveries_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "system", "alerting", "deliveries"}, ""))
+	pattern_ContainerService_SetSecret_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "secrets"}, ""))
+	pattern_ContainerService_GetSecret_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "secrets", "username", "name"}, ""))
+	pattern_ContainerService_ListSecrets_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "secrets", "username"}, ""))
+	pattern_ContainerService_DeleteSecret_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "secrets", "username", "name"}, ""))
+	pattern_ContainerService_RefreshSecrets_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "secrets", "username", "refresh"}, ""))
 )
 
 var (
-	forward_ContainerService_CreateContainer_0          = runtime.ForwardResponseMessage
-	forward_ContainerService_ListContainers_0           = runtime.ForwardResponseMessage
-	forward_ContainerService_GetContainer_0             = runtime.ForwardResponseMessage
-	forward_ContainerService_DebugContainer_0           = runtime.ForwardResponseMessage
-	forward_ContainerService_DeleteContainer_0          = runtime.ForwardResponseMessage
-	forward_ContainerService_StartContainer_0           = runtime.ForwardResponseMessage
-	forward_ContainerService_StopContainer_0            = runtime.ForwardResponseMessage
-	forward_ContainerService_ResizeContainer_0          = runtime.ForwardResponseMessage
-	forward_ContainerService_MoveContainer_0            = runtime.ForwardResponseMessage
-	forward_ContainerService_AdoptMigratedContainer_0   = runtime.ForwardResponseMessage
-	forward_ContainerService_ToggleMonitoring_0         = runtime.ForwardResponseMessage
-	forward_ContainerService_ToggleAutoSleep_0          = runtime.ForwardResponseMessage
-	forward_ContainerService_SetContainerTTL_0          = runtime.ForwardResponseMessage
-	forward_ContainerService_SetContainerDeletePolicy_0 = runtime.ForwardResponseMessage
-	forward_ContainerService_SetContainerAttribution_0  = runtime.ForwardResponseMessage
-	forward_ContainerService_AddSSHKey_0                = runtime.ForwardResponseMessage
-	forward_ContainerService_RemoveSSHKey_0             = runtime.ForwardResponseMessage
-	forward_ContainerService_AddCollaborator_0          = runtime.ForwardResponseMessage
-	forward_ContainerService_RemoveCollaborator_0       = runtime.ForwardResponseMessage
-	forward_ContainerService_ListCollaborators_0        = runtime.ForwardResponseMessage
-	forward_ContainerService_GetMetrics_0               = runtime.ForwardResponseMessage
-	forward_ContainerService_GetMetrics_1               = runtime.ForwardResponseMessage
-	forward_ContainerService_CleanupDisk_0              = runtime.ForwardResponseMessage
-	forward_ContainerService_InstallStack_0             = runtime.ForwardResponseMessage
-	forward_ContainerService_ListStacks_0               = runtime.ForwardResponseMessage
-	forward_ContainerService_GetSystemInfo_0            = runtime.ForwardResponseMessage
-	forward_ContainerService_ListBackends_0             = runtime.ForwardResponseMessage
-	forward_ContainerService_AdvertiseCapacity_0        = runtime.ForwardResponseMessage
-	forward_ContainerService_WithdrawCapacity_0         = runtime.ForwardResponseMessage
-	forward_ContainerService_GetCapacityHeadroom_0      = runtime.ForwardResponseMessage
-	forward_ContainerService_ProfileBackend_0           = runtime.ForwardResponseMessage
-	forward_ContainerService_GetCapabilityProfile_0     = runtime.ForwardResponseMessage
-	forward_ContainerService_GetSelfMeasurement_0       = runtime.ForwardResponseMessage
-	forward_ContainerService_GetLatestRelease_0         = runtime.ForwardResponseMessage
-	forward_ContainerService_ValidateGPU_0              = runtime.ForwardResponseMessage
-	forward_ContainerService_TriggerUpgrade_0           = runtime.ForwardResponseMessage
-	forward_ContainerService_GetUpgradeStatus_0         = runtime.ForwardResponseMessage
-	forward_ContainerService_GetMonitoringInfo_0        = runtime.ForwardResponseMessage
-	forward_ContainerService_SetMetricsExport_0         = runtime.ForwardResponseMessage
-	forward_ContainerService_GetMetricsExport_0         = runtime.ForwardResponseMessage
-	forward_ContainerService_CreateAlertRule_0          = runtime.ForwardResponseMessage
-	forward_ContainerService_ListAlertRules_0           = runtime.ForwardResponseMessage
-	forward_ContainerService_GetAlertRule_0             = runtime.ForwardResponseMessage
-	forward_ContainerService_UpdateAlertRule_0          = runtime.ForwardResponseMessage
-	forward_ContainerService_DeleteAlertRule_0          = runtime.ForwardResponseMessage
-	forward_ContainerService_GetAlertingInfo_0          = runtime.ForwardResponseMessage
-	forward_ContainerService_ListDefaultAlertRules_0    = runtime.ForwardResponseMessage
-	forward_ContainerService_UpdateAlertingConfig_0     = runtime.ForwardResponseMessage
-	forward_ContainerService_TestWebhook_0              = runtime.ForwardResponseMessage
-	forward_ContainerService_ListWebhookDeliveries_0    = runtime.ForwardResponseMessage
-	forward_ContainerService_SetSecret_0                = runtime.ForwardResponseMessage
-	forward_ContainerService_GetSecret_0                = runtime.ForwardResponseMessage
-	forward_ContainerService_ListSecrets_0              = runtime.ForwardResponseMessage
-	forward_ContainerService_DeleteSecret_0             = runtime.ForwardResponseMessage
-	forward_ContainerService_RefreshSecrets_0           = runtime.ForwardResponseMessage
+	forward_ContainerService_CreateContainer_0           = runtime.ForwardResponseMessage
+	forward_ContainerService_ListContainers_0            = runtime.ForwardResponseMessage
+	forward_ContainerService_GetContainer_0              = runtime.ForwardResponseMessage
+	forward_ContainerService_DebugContainer_0            = runtime.ForwardResponseMessage
+	forward_ContainerService_DeleteContainer_0           = runtime.ForwardResponseMessage
+	forward_ContainerService_StartContainer_0            = runtime.ForwardResponseMessage
+	forward_ContainerService_StopContainer_0             = runtime.ForwardResponseMessage
+	forward_ContainerService_ResizeContainer_0           = runtime.ForwardResponseMessage
+	forward_ContainerService_MoveContainer_0             = runtime.ForwardResponseMessage
+	forward_ContainerService_PrepareEncryptedMigration_0 = runtime.ForwardResponseMessage
+	forward_ContainerService_AdoptMigratedContainer_0    = runtime.ForwardResponseMessage
+	forward_ContainerService_ToggleMonitoring_0          = runtime.ForwardResponseMessage
+	forward_ContainerService_ToggleAutoSleep_0           = runtime.ForwardResponseMessage
+	forward_ContainerService_SetContainerTTL_0           = runtime.ForwardResponseMessage
+	forward_ContainerService_SetContainerDeletePolicy_0  = runtime.ForwardResponseMessage
+	forward_ContainerService_SetContainerAttribution_0   = runtime.ForwardResponseMessage
+	forward_ContainerService_AddSSHKey_0                 = runtime.ForwardResponseMessage
+	forward_ContainerService_RemoveSSHKey_0              = runtime.ForwardResponseMessage
+	forward_ContainerService_AddCollaborator_0           = runtime.ForwardResponseMessage
+	forward_ContainerService_RemoveCollaborator_0        = runtime.ForwardResponseMessage
+	forward_ContainerService_ListCollaborators_0         = runtime.ForwardResponseMessage
+	forward_ContainerService_GetMetrics_0                = runtime.ForwardResponseMessage
+	forward_ContainerService_GetMetrics_1                = runtime.ForwardResponseMessage
+	forward_ContainerService_CleanupDisk_0               = runtime.ForwardResponseMessage
+	forward_ContainerService_InstallStack_0              = runtime.ForwardResponseMessage
+	forward_ContainerService_ListStacks_0                = runtime.ForwardResponseMessage
+	forward_ContainerService_GetSystemInfo_0             = runtime.ForwardResponseMessage
+	forward_ContainerService_ListBackends_0              = runtime.ForwardResponseMessage
+	forward_ContainerService_AdvertiseCapacity_0         = runtime.ForwardResponseMessage
+	forward_ContainerService_WithdrawCapacity_0          = runtime.ForwardResponseMessage
+	forward_ContainerService_GetCapacityHeadroom_0       = runtime.ForwardResponseMessage
+	forward_ContainerService_ProfileBackend_0            = runtime.ForwardResponseMessage
+	forward_ContainerService_GetCapabilityProfile_0      = runtime.ForwardResponseMessage
+	forward_ContainerService_GetSelfMeasurement_0        = runtime.ForwardResponseMessage
+	forward_ContainerService_GetLatestRelease_0          = runtime.ForwardResponseMessage
+	forward_ContainerService_ValidateGPU_0               = runtime.ForwardResponseMessage
+	forward_ContainerService_TriggerUpgrade_0            = runtime.ForwardResponseMessage
+	forward_ContainerService_GetUpgradeStatus_0          = runtime.ForwardResponseMessage
+	forward_ContainerService_GetMonitoringInfo_0         = runtime.ForwardResponseMessage
+	forward_ContainerService_SetMetricsExport_0          = runtime.ForwardResponseMessage
+	forward_ContainerService_GetMetricsExport_0          = runtime.ForwardResponseMessage
+	forward_ContainerService_CreateAlertRule_0           = runtime.ForwardResponseMessage
+	forward_ContainerService_ListAlertRules_0            = runtime.ForwardResponseMessage
+	forward_ContainerService_GetAlertRule_0              = runtime.ForwardResponseMessage
+	forward_ContainerService_UpdateAlertRule_0           = runtime.ForwardResponseMessage
+	forward_ContainerService_DeleteAlertRule_0           = runtime.ForwardResponseMessage
+	forward_ContainerService_GetAlertingInfo_0           = runtime.ForwardResponseMessage
+	forward_ContainerService_ListDefaultAlertRules_0     = runtime.ForwardResponseMessage
+	forward_ContainerService_UpdateAlertingConfig_0      = runtime.ForwardResponseMessage
+	forward_ContainerService_TestWebhook_0               = runtime.ForwardResponseMessage
+	forward_ContainerService_ListWebhookDeliveries_0     = runtime.ForwardResponseMessage
+	forward_ContainerService_SetSecret_0                 = runtime.ForwardResponseMessage
+	forward_ContainerService_GetSecret_0                 = runtime.ForwardResponseMessage
+	forward_ContainerService_ListSecrets_0               = runtime.ForwardResponseMessage
+	forward_ContainerService_DeleteSecret_0              = runtime.ForwardResponseMessage
+	forward_ContainerService_RefreshSecrets_0            = runtime.ForwardResponseMessage
 )

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -19,60 +19,61 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ContainerService_CreateContainer_FullMethodName          = "/containarium.v1.ContainerService/CreateContainer"
-	ContainerService_ListContainers_FullMethodName           = "/containarium.v1.ContainerService/ListContainers"
-	ContainerService_GetContainer_FullMethodName             = "/containarium.v1.ContainerService/GetContainer"
-	ContainerService_DebugContainer_FullMethodName           = "/containarium.v1.ContainerService/DebugContainer"
-	ContainerService_DeleteContainer_FullMethodName          = "/containarium.v1.ContainerService/DeleteContainer"
-	ContainerService_StartContainer_FullMethodName           = "/containarium.v1.ContainerService/StartContainer"
-	ContainerService_StopContainer_FullMethodName            = "/containarium.v1.ContainerService/StopContainer"
-	ContainerService_ResizeContainer_FullMethodName          = "/containarium.v1.ContainerService/ResizeContainer"
-	ContainerService_MoveContainer_FullMethodName            = "/containarium.v1.ContainerService/MoveContainer"
-	ContainerService_AdoptMigratedContainer_FullMethodName   = "/containarium.v1.ContainerService/AdoptMigratedContainer"
-	ContainerService_ToggleMonitoring_FullMethodName         = "/containarium.v1.ContainerService/ToggleMonitoring"
-	ContainerService_ToggleAutoSleep_FullMethodName          = "/containarium.v1.ContainerService/ToggleAutoSleep"
-	ContainerService_SetContainerTTL_FullMethodName          = "/containarium.v1.ContainerService/SetContainerTTL"
-	ContainerService_SetContainerDeletePolicy_FullMethodName = "/containarium.v1.ContainerService/SetContainerDeletePolicy"
-	ContainerService_SetContainerAttribution_FullMethodName  = "/containarium.v1.ContainerService/SetContainerAttribution"
-	ContainerService_AddSSHKey_FullMethodName                = "/containarium.v1.ContainerService/AddSSHKey"
-	ContainerService_RemoveSSHKey_FullMethodName             = "/containarium.v1.ContainerService/RemoveSSHKey"
-	ContainerService_AddCollaborator_FullMethodName          = "/containarium.v1.ContainerService/AddCollaborator"
-	ContainerService_RemoveCollaborator_FullMethodName       = "/containarium.v1.ContainerService/RemoveCollaborator"
-	ContainerService_ListCollaborators_FullMethodName        = "/containarium.v1.ContainerService/ListCollaborators"
-	ContainerService_GetMetrics_FullMethodName               = "/containarium.v1.ContainerService/GetMetrics"
-	ContainerService_CleanupDisk_FullMethodName              = "/containarium.v1.ContainerService/CleanupDisk"
-	ContainerService_InstallStack_FullMethodName             = "/containarium.v1.ContainerService/InstallStack"
-	ContainerService_ListStacks_FullMethodName               = "/containarium.v1.ContainerService/ListStacks"
-	ContainerService_GetSystemInfo_FullMethodName            = "/containarium.v1.ContainerService/GetSystemInfo"
-	ContainerService_ListBackends_FullMethodName             = "/containarium.v1.ContainerService/ListBackends"
-	ContainerService_AdvertiseCapacity_FullMethodName        = "/containarium.v1.ContainerService/AdvertiseCapacity"
-	ContainerService_WithdrawCapacity_FullMethodName         = "/containarium.v1.ContainerService/WithdrawCapacity"
-	ContainerService_GetCapacityHeadroom_FullMethodName      = "/containarium.v1.ContainerService/GetCapacityHeadroom"
-	ContainerService_ProfileBackend_FullMethodName           = "/containarium.v1.ContainerService/ProfileBackend"
-	ContainerService_GetCapabilityProfile_FullMethodName     = "/containarium.v1.ContainerService/GetCapabilityProfile"
-	ContainerService_GetSelfMeasurement_FullMethodName       = "/containarium.v1.ContainerService/GetSelfMeasurement"
-	ContainerService_GetLatestRelease_FullMethodName         = "/containarium.v1.ContainerService/GetLatestRelease"
-	ContainerService_ValidateGPU_FullMethodName              = "/containarium.v1.ContainerService/ValidateGPU"
-	ContainerService_TriggerUpgrade_FullMethodName           = "/containarium.v1.ContainerService/TriggerUpgrade"
-	ContainerService_GetUpgradeStatus_FullMethodName         = "/containarium.v1.ContainerService/GetUpgradeStatus"
-	ContainerService_GetMonitoringInfo_FullMethodName        = "/containarium.v1.ContainerService/GetMonitoringInfo"
-	ContainerService_SetMetricsExport_FullMethodName         = "/containarium.v1.ContainerService/SetMetricsExport"
-	ContainerService_GetMetricsExport_FullMethodName         = "/containarium.v1.ContainerService/GetMetricsExport"
-	ContainerService_CreateAlertRule_FullMethodName          = "/containarium.v1.ContainerService/CreateAlertRule"
-	ContainerService_ListAlertRules_FullMethodName           = "/containarium.v1.ContainerService/ListAlertRules"
-	ContainerService_GetAlertRule_FullMethodName             = "/containarium.v1.ContainerService/GetAlertRule"
-	ContainerService_UpdateAlertRule_FullMethodName          = "/containarium.v1.ContainerService/UpdateAlertRule"
-	ContainerService_DeleteAlertRule_FullMethodName          = "/containarium.v1.ContainerService/DeleteAlertRule"
-	ContainerService_GetAlertingInfo_FullMethodName          = "/containarium.v1.ContainerService/GetAlertingInfo"
-	ContainerService_ListDefaultAlertRules_FullMethodName    = "/containarium.v1.ContainerService/ListDefaultAlertRules"
-	ContainerService_UpdateAlertingConfig_FullMethodName     = "/containarium.v1.ContainerService/UpdateAlertingConfig"
-	ContainerService_TestWebhook_FullMethodName              = "/containarium.v1.ContainerService/TestWebhook"
-	ContainerService_ListWebhookDeliveries_FullMethodName    = "/containarium.v1.ContainerService/ListWebhookDeliveries"
-	ContainerService_SetSecret_FullMethodName                = "/containarium.v1.ContainerService/SetSecret"
-	ContainerService_GetSecret_FullMethodName                = "/containarium.v1.ContainerService/GetSecret"
-	ContainerService_ListSecrets_FullMethodName              = "/containarium.v1.ContainerService/ListSecrets"
-	ContainerService_DeleteSecret_FullMethodName             = "/containarium.v1.ContainerService/DeleteSecret"
-	ContainerService_RefreshSecrets_FullMethodName           = "/containarium.v1.ContainerService/RefreshSecrets"
+	ContainerService_CreateContainer_FullMethodName           = "/containarium.v1.ContainerService/CreateContainer"
+	ContainerService_ListContainers_FullMethodName            = "/containarium.v1.ContainerService/ListContainers"
+	ContainerService_GetContainer_FullMethodName              = "/containarium.v1.ContainerService/GetContainer"
+	ContainerService_DebugContainer_FullMethodName            = "/containarium.v1.ContainerService/DebugContainer"
+	ContainerService_DeleteContainer_FullMethodName           = "/containarium.v1.ContainerService/DeleteContainer"
+	ContainerService_StartContainer_FullMethodName            = "/containarium.v1.ContainerService/StartContainer"
+	ContainerService_StopContainer_FullMethodName             = "/containarium.v1.ContainerService/StopContainer"
+	ContainerService_ResizeContainer_FullMethodName           = "/containarium.v1.ContainerService/ResizeContainer"
+	ContainerService_MoveContainer_FullMethodName             = "/containarium.v1.ContainerService/MoveContainer"
+	ContainerService_PrepareEncryptedMigration_FullMethodName = "/containarium.v1.ContainerService/PrepareEncryptedMigration"
+	ContainerService_AdoptMigratedContainer_FullMethodName    = "/containarium.v1.ContainerService/AdoptMigratedContainer"
+	ContainerService_ToggleMonitoring_FullMethodName          = "/containarium.v1.ContainerService/ToggleMonitoring"
+	ContainerService_ToggleAutoSleep_FullMethodName           = "/containarium.v1.ContainerService/ToggleAutoSleep"
+	ContainerService_SetContainerTTL_FullMethodName           = "/containarium.v1.ContainerService/SetContainerTTL"
+	ContainerService_SetContainerDeletePolicy_FullMethodName  = "/containarium.v1.ContainerService/SetContainerDeletePolicy"
+	ContainerService_SetContainerAttribution_FullMethodName   = "/containarium.v1.ContainerService/SetContainerAttribution"
+	ContainerService_AddSSHKey_FullMethodName                 = "/containarium.v1.ContainerService/AddSSHKey"
+	ContainerService_RemoveSSHKey_FullMethodName              = "/containarium.v1.ContainerService/RemoveSSHKey"
+	ContainerService_AddCollaborator_FullMethodName           = "/containarium.v1.ContainerService/AddCollaborator"
+	ContainerService_RemoveCollaborator_FullMethodName        = "/containarium.v1.ContainerService/RemoveCollaborator"
+	ContainerService_ListCollaborators_FullMethodName         = "/containarium.v1.ContainerService/ListCollaborators"
+	ContainerService_GetMetrics_FullMethodName                = "/containarium.v1.ContainerService/GetMetrics"
+	ContainerService_CleanupDisk_FullMethodName               = "/containarium.v1.ContainerService/CleanupDisk"
+	ContainerService_InstallStack_FullMethodName              = "/containarium.v1.ContainerService/InstallStack"
+	ContainerService_ListStacks_FullMethodName                = "/containarium.v1.ContainerService/ListStacks"
+	ContainerService_GetSystemInfo_FullMethodName             = "/containarium.v1.ContainerService/GetSystemInfo"
+	ContainerService_ListBackends_FullMethodName              = "/containarium.v1.ContainerService/ListBackends"
+	ContainerService_AdvertiseCapacity_FullMethodName         = "/containarium.v1.ContainerService/AdvertiseCapacity"
+	ContainerService_WithdrawCapacity_FullMethodName          = "/containarium.v1.ContainerService/WithdrawCapacity"
+	ContainerService_GetCapacityHeadroom_FullMethodName       = "/containarium.v1.ContainerService/GetCapacityHeadroom"
+	ContainerService_ProfileBackend_FullMethodName            = "/containarium.v1.ContainerService/ProfileBackend"
+	ContainerService_GetCapabilityProfile_FullMethodName      = "/containarium.v1.ContainerService/GetCapabilityProfile"
+	ContainerService_GetSelfMeasurement_FullMethodName        = "/containarium.v1.ContainerService/GetSelfMeasurement"
+	ContainerService_GetLatestRelease_FullMethodName          = "/containarium.v1.ContainerService/GetLatestRelease"
+	ContainerService_ValidateGPU_FullMethodName               = "/containarium.v1.ContainerService/ValidateGPU"
+	ContainerService_TriggerUpgrade_FullMethodName            = "/containarium.v1.ContainerService/TriggerUpgrade"
+	ContainerService_GetUpgradeStatus_FullMethodName          = "/containarium.v1.ContainerService/GetUpgradeStatus"
+	ContainerService_GetMonitoringInfo_FullMethodName         = "/containarium.v1.ContainerService/GetMonitoringInfo"
+	ContainerService_SetMetricsExport_FullMethodName          = "/containarium.v1.ContainerService/SetMetricsExport"
+	ContainerService_GetMetricsExport_FullMethodName          = "/containarium.v1.ContainerService/GetMetricsExport"
+	ContainerService_CreateAlertRule_FullMethodName           = "/containarium.v1.ContainerService/CreateAlertRule"
+	ContainerService_ListAlertRules_FullMethodName            = "/containarium.v1.ContainerService/ListAlertRules"
+	ContainerService_GetAlertRule_FullMethodName              = "/containarium.v1.ContainerService/GetAlertRule"
+	ContainerService_UpdateAlertRule_FullMethodName           = "/containarium.v1.ContainerService/UpdateAlertRule"
+	ContainerService_DeleteAlertRule_FullMethodName           = "/containarium.v1.ContainerService/DeleteAlertRule"
+	ContainerService_GetAlertingInfo_FullMethodName           = "/containarium.v1.ContainerService/GetAlertingInfo"
+	ContainerService_ListDefaultAlertRules_FullMethodName     = "/containarium.v1.ContainerService/ListDefaultAlertRules"
+	ContainerService_UpdateAlertingConfig_FullMethodName      = "/containarium.v1.ContainerService/UpdateAlertingConfig"
+	ContainerService_TestWebhook_FullMethodName               = "/containarium.v1.ContainerService/TestWebhook"
+	ContainerService_ListWebhookDeliveries_FullMethodName     = "/containarium.v1.ContainerService/ListWebhookDeliveries"
+	ContainerService_SetSecret_FullMethodName                 = "/containarium.v1.ContainerService/SetSecret"
+	ContainerService_GetSecret_FullMethodName                 = "/containarium.v1.ContainerService/GetSecret"
+	ContainerService_ListSecrets_FullMethodName               = "/containarium.v1.ContainerService/ListSecrets"
+	ContainerService_DeleteSecret_FullMethodName              = "/containarium.v1.ContainerService/DeleteSecret"
+	ContainerService_RefreshSecrets_FullMethodName            = "/containarium.v1.ContainerService/RefreshSecrets"
 )
 
 // ContainerServiceClient is the client API for ContainerService service.
@@ -107,6 +108,24 @@ type ContainerServiceClient interface {
 	// for active workloads on dir-pool. Prereq: incus remotes
 	// configured both ways between the source and target VMs.
 	MoveContainer(ctx context.Context, in *MoveContainerRequest, opts ...grpc.CallOption) (*MoveContainerResponse, error)
+	// PrepareEncryptedMigration asks this daemon, as a migration
+	// DESTINATION, whether it can take over an encrypted container before
+	// any data is copied — and provisions the tenant's encrypted storage
+	// so the copy has somewhere correct to land.
+	//
+	// Two answers in one call, because they are needed at the same moment
+	// and only the destination can give either: whether its own key
+	// custody resolves the source's KeyRef, and which storage pool is
+	// sourced at that tenant's encryptionroot.
+	//
+	// Without the first, a migration can copy an entire container and only
+	// then discover the destination cannot unlock it, leaving an
+	// unstartable shell. Without the second, the copy lands on the
+	// destination's default pool and the container arrives unencrypted.
+	//
+	// Only the KeyRef crosses the wire; key material never does. Internal
+	// use only — operators don't call this.
+	PrepareEncryptedMigration(ctx context.Context, in *PrepareEncryptedMigrationRequest, opts ...grpc.CallOption) (*PrepareEncryptedMigrationResponse, error)
 	// AdoptMigratedContainer is the destination-side helper RPC called by
 	// a peer's MoveContainer after `incus copy` has pushed the LXC to
 	// this daemon. It registers the container with this daemon's state
@@ -397,6 +416,16 @@ func (c *containerServiceClient) MoveContainer(ctx context.Context, in *MoveCont
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(MoveContainerResponse)
 	err := c.cc.Invoke(ctx, ContainerService_MoveContainer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) PrepareEncryptedMigration(ctx context.Context, in *PrepareEncryptedMigrationRequest, opts ...grpc.CallOption) (*PrepareEncryptedMigrationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PrepareEncryptedMigrationResponse)
+	err := c.cc.Invoke(ctx, ContainerService_PrepareEncryptedMigration_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -885,6 +914,24 @@ type ContainerServiceServer interface {
 	// for active workloads on dir-pool. Prereq: incus remotes
 	// configured both ways between the source and target VMs.
 	MoveContainer(context.Context, *MoveContainerRequest) (*MoveContainerResponse, error)
+	// PrepareEncryptedMigration asks this daemon, as a migration
+	// DESTINATION, whether it can take over an encrypted container before
+	// any data is copied — and provisions the tenant's encrypted storage
+	// so the copy has somewhere correct to land.
+	//
+	// Two answers in one call, because they are needed at the same moment
+	// and only the destination can give either: whether its own key
+	// custody resolves the source's KeyRef, and which storage pool is
+	// sourced at that tenant's encryptionroot.
+	//
+	// Without the first, a migration can copy an entire container and only
+	// then discover the destination cannot unlock it, leaving an
+	// unstartable shell. Without the second, the copy lands on the
+	// destination's default pool and the container arrives unencrypted.
+	//
+	// Only the KeyRef crosses the wire; key material never does. Internal
+	// use only — operators don't call this.
+	PrepareEncryptedMigration(context.Context, *PrepareEncryptedMigrationRequest) (*PrepareEncryptedMigrationResponse, error)
 	// AdoptMigratedContainer is the destination-side helper RPC called by
 	// a peer's MoveContainer after `incus copy` has pushed the LXC to
 	// this daemon. It registers the container with this daemon's state
@@ -1117,6 +1164,9 @@ func (UnimplementedContainerServiceServer) ResizeContainer(context.Context, *Res
 }
 func (UnimplementedContainerServiceServer) MoveContainer(context.Context, *MoveContainerRequest) (*MoveContainerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method MoveContainer not implemented")
+}
+func (UnimplementedContainerServiceServer) PrepareEncryptedMigration(context.Context, *PrepareEncryptedMigrationRequest) (*PrepareEncryptedMigrationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PrepareEncryptedMigration not implemented")
 }
 func (UnimplementedContainerServiceServer) AdoptMigratedContainer(context.Context, *AdoptMigratedContainerRequest) (*AdoptMigratedContainerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AdoptMigratedContainer not implemented")
@@ -1432,6 +1482,24 @@ func _ContainerService_MoveContainer_Handler(srv interface{}, ctx context.Contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ContainerServiceServer).MoveContainer(ctx, req.(*MoveContainerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_PrepareEncryptedMigration_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PrepareEncryptedMigrationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).PrepareEncryptedMigration(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_PrepareEncryptedMigration_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).PrepareEncryptedMigration(ctx, req.(*PrepareEncryptedMigrationRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2288,6 +2356,10 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "MoveContainer",
 			Handler:    _ContainerService_MoveContainer_Handler,
+		},
+		{
+			MethodName: "PrepareEncryptedMigration",
+			Handler:    _ContainerService_PrepareEncryptedMigration_Handler,
 		},
 		{
 			MethodName: "AdoptMigratedContainer",

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -1196,6 +1196,47 @@ message AdoptMigratedContainerRequest {
   repeated string source_routes = 2;
 }
 
+// PrepareEncryptedMigrationRequest asks a destination daemon whether it
+// can take over an encrypted container, BEFORE any data is copied.
+//
+// Only the key REFERENCE travels — never key material. The ref names a
+// key in whatever custody the destination is configured with; resolving
+// it is the destination's job with its own KeyProvider, which is the
+// whole point of the check.
+message PrepareEncryptedMigrationRequest {
+  // Username of the container about to be migrated.
+  string username = 1;
+
+  // The tenant whose encryptionroot the container lives under. The
+  // destination provisions storage for this tenant, not for the
+  // container: a tenant's containers share one encryptionroot.
+  string tenant = 2;
+
+  // The source's stored KeyRef, JSON-encoded exactly as it is held on
+  // the container's own metadata. An opaque reference (scheme + URI +
+  // metadata); it carries no key bytes.
+  string key_ref = 3;
+}
+
+// PrepareEncryptedMigrationResponse tells the source whether to proceed,
+// and where to put the container if so.
+message PrepareEncryptedMigrationResponse {
+  // Whether the destination resolved the KeyRef through its own key
+  // custody. False means the migration must not start: the container
+  // would arrive unopenable after a full data copy.
+  bool can_resolve = 1;
+
+  // Why not, when can_resolve is false. Operator-facing.
+  string reason = 2;
+
+  // The destination storage pool the container must be copied into —
+  // the pool sourced at this tenant's encryptionroot. A copy that
+  // ignores it lands on the destination's default pool, outside the
+  // tenant's encryptionroot, and the container arrives unencrypted
+  // while every daemon-side signal says otherwise.
+  string storage_pool = 3;
+}
+
 // AdoptMigratedContainerResponse confirms the destination registered
 // the container and returns its IP for the source's route swap.
 message AdoptMigratedContainerResponse {

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -173,6 +173,35 @@ service ContainerService {
     };
   }
 
+  // PrepareEncryptedMigration asks this daemon, as a migration
+  // DESTINATION, whether it can take over an encrypted container before
+  // any data is copied — and provisions the tenant's encrypted storage
+  // so the copy has somewhere correct to land.
+  //
+  // Two answers in one call, because they are needed at the same moment
+  // and only the destination can give either: whether its own key
+  // custody resolves the source's KeyRef, and which storage pool is
+  // sourced at that tenant's encryptionroot.
+  //
+  // Without the first, a migration can copy an entire container and only
+  // then discover the destination cannot unlock it, leaving an
+  // unstartable shell. Without the second, the copy lands on the
+  // destination's default pool and the container arrives unencrypted.
+  //
+  // Only the KeyRef crosses the wire; key material never does. Internal
+  // use only — operators don't call this.
+  rpc PrepareEncryptedMigration(PrepareEncryptedMigrationRequest) returns (PrepareEncryptedMigrationResponse) {
+    option (google.api.http) = {
+      post: "/v1/containers/{username}/prepare-encrypted-migration"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Pre-flight an encrypted migration (internal)";
+      description: "Called by the source daemon before MoveContainer copies anything. The destination reports whether its key custody can resolve the container's KeyRef, and provisions the tenant's encrypted storage pool so the copy lands inside the tenant's encryptionroot. Only the key reference is sent; key material never crosses the wire. Not intended for direct operator use.";
+      tags: "Container Operations";
+    };
+  }
+
   // AdoptMigratedContainer is the destination-side helper RPC called by
   // a peer's MoveContainer after `incus copy` has pushed the LXC to
   // this daemon. It registers the container with this daemon's state


### PR DESCRIPTION
Closes #1360. Part of #1203 — **closes its AC2 and AC3; AC1 stays open on the remaining half.** Design: `docs/ZFS-PER-CONTAINER-ENCRYPTION-DESIGN.md` §3 hook row 5 / §5, and `docs/architecture/per-tenant-encrypted-storage-pools.md`.

## Why the pre-flight asks two things

Both answers can only come from the destination, and both are needed at the same instant — before a byte moves:

- **Can its key custody resolve this container's `KeyRef`?** Without asking, a migration copies an entire container and only then finds the far side cannot unlock it, leaving an unstartable shell. That is design §5's named cross-VM failure mode.
- **Which storage pool is sourced at that tenant's encryptionroot?** #1341 made encryption a property of *where the container lands*. The copy has to go inside the tenant's pool, and only the destination can create it. Returned now; #1203b targets the copy at it.

So one RPC, called before phase 1. **A refusal costs nothing** — nothing has been snapshotted or copied — and that is asserted, because "before" is the entire value of the check.

## Scope discipline

`incus copy --storage`, adopt-side placement recording, and the post-move encryptionroot assertion are **not** here. They are #1203b, and they carry AC1, which needs two daemons and two Incus instances — CI can build one per run. #1203 is labelled `needs-verification` with runnable steps for that half.

## Test evidence

CI run linked in a follow-up comment. 14 tests green, including the 5 pre-existing move-orchestration tests.

| Criterion | Test |
| --- | --- |
| A destination that cannot resolve fails the pre-flight, **before any data is copied** (#1203 AC2) | `TestMoveContainer_AbortsBeforeCopyingWhenTheDestinationCannotResolveTheKey` — asserts the runner was **never invoked**, plus that the destination's reason reaches the caller |
| Only the `KeyRef` crosses the wire (#1203 AC3) | `TestMoveContainer_PreflightSendsTheRefAndNeverKeyMaterial` — decodes the ref off the request and asserts the tenant's actual key bytes appear nowhere in it |
| An unencrypted migration is untouched | `TestMoveContainer_UnencryptedMigrationMakesNoPreflightCall` |
| The destination returns the tenant pool | `TestPrepareEncryptedMigration_ResolvesTheRefAndProvisionsTheTenantPool` |

Plus refusal paths: no custody, unresolvable ref (and **no pool provisioned** for a tenant that will never arrive), malformed ref → `InvalidArgument`, non-admin → `PermissionDenied`.

**Both acceptance criteria are mutation-verified:**

```
pre-flight result ignored           → FAIL  the migration proceeded although the destination
                                            cannot unlock the container
destination assumes any ref resolves → FAIL  claimed it could resolve a ref its own provider
                                            rejected
```

## One thing worth reading in the diff

My first version of the source-side test set `zfs: nil` on the hooks with a comment saying it was never reached — the source only *reads* the stored ref. That made `enabled()` false, so the container read as **unencrypted**, no pre-flight ran, and the test failed by reaching the adopt call. The fixture was wrong, not the code, but the failure mode is exactly what this feature exists to prevent: a half-wired daemon silently treating an encrypted container as plain. Now wired with a real manager over a fake runner, with a comment saying why.

## Reviewer notes

- Proto-first: RPC and messages added to `.proto`, then `make proto`. Generated files are regeneration output — the toolchain was verified to regenerate `main` with zero drift before any edit, so a silently-failed generate could not masquerade as success.
- The refusal is a `can_resolve=false` **response**, not an error. The source needs the reason to show an operator, and "no key custody configured" is a different problem from "the peer is unreachable".
- `migrationRef` is read-only and tolerant of a daemon with no encryption wired — there, every container genuinely is unencrypted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)