### PR TITLE
fix(ci): finish the Go 1.26.6 bump — the store lane was missed

### DIFF
--- a/.github/workflows/store-integration.yml
+++ b/.github/workflows/store-integration.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Run the store integration suite
         env:


### PR DESCRIPTION
`dffd9ef` ("fix(ci): bump Go 1.26.5 -> 1.26.6 to clear 7 reachable stdlib CVEs", merged 05:57 today) updated `go.mod` and four workflows. **`store-integration.yml` was missed** and still pins `1.26.5`:

```
go: go.mod requires go >= 1.26.6 (running go 1.26.5; GOTOOLCHAIN=local)
```

## This is latent on main, not caused by the PR that found it

The store lane has not run on `main` since the bump — its last main run was `c190bb8` on 08-13, before `dffd9ef` landed. So `main` looks green while the lane is broken, and **every PR touching the store paths fails from now on** until this merges.

Surfaced by #1361 (an encrypted-migration pre-flight), which does not touch `go.mod`, the store paths, or this workflow: https://github.com/FootprintAI/Containarium/actions/runs/31783692317/job/94714747200

## The fix

One line, completing what `dffd9ef` started. Nothing else in the lane changes — in particular the guards that make it fail rather than skip (no `--- SKIP`, and six named tests that must actually appear as `--- PASS`) are untouched.

## Worth deciding separately

This file pins a literal Go version; `containarium-daemon.yml` and the Incus lane use `go-version-file: go.mod`, which cannot drift out of step with the module. Four workflows pin literals, so switching just this one would be inconsistent, and switching all of them is a call for whoever owns these lanes. Recording the observation rather than making the change: the same missed-bump will happen again otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)