### PR TITLE
feat(sentinel): failover/backend-health series + Cloud Monitoring push export (#1358)

### DIFF
--- a/internal/cmd/sentinel.go
+++ b/internal/cmd/sentinel.go
@@ -13,7 +13,10 @@ import (
 	"syscall"
 	"time"
 
+	"go.opentelemetry.io/otel/sdk/resource"
+
 	"github.com/footprintai/containarium/internal/config"
+	"github.com/footprintai/containarium/internal/metrics/cloudexport"
 	"github.com/footprintai/containarium/internal/sentinel"
 	"github.com/spf13/cobra"
 )
@@ -41,6 +44,9 @@ var (
 	sentinelTunnelTokenPolicies    []string
 	sentinelProxyProtocol          bool
 	sentinelAlertWebhookURL        string
+	sentinelMetricsExport          bool
+	sentinelMetricsExportProject   string
+	sentinelMetricsExportInterval  int32
 )
 
 var sentinelCmd = &cobra.Command{
@@ -89,6 +95,13 @@ func init() {
 	sentinelCmd.Flags().DurationVar(&sentinelCertSyncInterval, "cert-sync-interval", 6*time.Hour, "Interval for syncing TLS certificates from backend (0 to use default 6h)")
 	sentinelCmd.Flags().DurationVar(&sentinelKeySyncInterval, "key-sync-interval", 2*time.Minute, "Interval for syncing SSH keys from backend for sshpiper (0 to use default 2m)")
 	sentinelCmd.Flags().BoolVar(&sentinelProxyProtocol, "proxy-protocol", false, "Prepend a PROXY v2 header to forwarded HTTPS streams so the backend Caddy sees the real client IP (requires Caddy with proxy_protocol listener wrapper trusting the sentinel)")
+	sentinelCmd.Flags().BoolVar(&sentinelMetricsExport, "metrics-export", false,
+		"Push sentinel health series (state, failovers, per-backend health, RSS/goroutines/fds) to Cloud Monitoring (#1358). OFF by default: custom metrics are billed per ingested sample.")
+	sentinelCmd.Flags().StringVar(&sentinelMetricsExportProject, "metrics-export-project", "",
+		"GCP project for --metrics-export. Empty infers it from the metadata server.")
+	sentinelCmd.Flags().Int32Var(&sentinelMetricsExportInterval, "metrics-export-interval", 60,
+		"Export cadence in seconds for --metrics-export. Clamped up to the 60s billing floor.")
+
 	sentinelCmd.Flags().StringVar(&sentinelAlertWebhookURL, "alert-webhook-url", os.Getenv(config.EnvSentinelAlertWebhook), "Webhook POSTed on spot preempted/recovered (always-on alert path; the on-spot vmalert dies with the VM). Falls back to $CONTAINARIUM_SENTINEL_ALERT_WEBHOOK (#514)")
 }
 
@@ -109,6 +122,71 @@ func loadPersistedTunnelTokens(policy *sentinel.TokenPolicy) {
 		log.Printf("[sentinel] loaded %d persisted tunnel token(s) from %s", len(entries), sentinel.DefaultTunnelTokenStorePath)
 	}
 	sentinel.ApplyTunnelTokenStore(entries, policy)
+}
+
+// startSentinelMetricsExport starts the Cloud Monitoring push exporter when
+// --metrics-export is set, returning a stop func (a no-op when disabled or on
+// failure).
+//
+// Failure to export NEVER stops the sentinel. It is a traffic forwarder first
+// and a metrics source second: refusing to start the apex because Cloud
+// Monitoring credentials are missing would trade a monitoring gap for an
+// outage. Same posture as the cert/key sync failures elsewhere in this daemon
+// — log loudly, keep serving.
+func startSentinelMetricsExport(ctx context.Context, m *sentinel.Manager) func() {
+	noop := func() {}
+	if !sentinelMetricsExport {
+		return noop
+	}
+
+	id, err := os.Hostname()
+	if err != nil || id == "" {
+		id = "sentinel"
+	}
+
+	sink := cloudexport.NewGCPSink()
+	if perr := sink.Probe(ctx); perr != nil {
+		// Probe carries an actionable remediation hint; surfacing it here
+		// means the operator learns at startup rather than from silently
+		// absent dashboards.
+		log.Printf("[sentinel] WARNING: metrics export disabled — Cloud Monitoring credentials unusable: %v", perr)
+		return noop
+	}
+
+	exporter, err := sink.NewExporter(ctx, cloudexport.SinkConfig{ProjectID: sentinelMetricsExportProject})
+	if err != nil {
+		log.Printf("[sentinel] WARNING: metrics export disabled — could not build exporter: %v", err)
+		return noop
+	}
+
+	var res *resource.Resource
+	if rp, ok := sink.(cloudexport.ResourceProvider); ok {
+		if r, derr := rp.DetectResource(ctx); derr == nil {
+			res = r
+		} else {
+			log.Printf("[sentinel] metrics export: resource detection failed, using default resource: %v", derr)
+		}
+	}
+
+	stop, err := sentinel.StartMetricsExport(m, sentinel.MetricsExportOptions{
+		Exporter:        exporter,
+		Resource:        res,
+		SentinelID:      id,
+		IntervalSeconds: sentinelMetricsExportInterval,
+	})
+	if err != nil {
+		log.Printf("[sentinel] WARNING: metrics export disabled — %v", err)
+		return noop
+	}
+	log.Printf("[sentinel] metrics export ON → Cloud Monitoring as sentinel=%q every %ds", id, sentinelMetricsExportInterval)
+
+	return func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if serr := stop(shutCtx); serr != nil {
+			log.Printf("[sentinel] metrics export shutdown: %v", serr)
+		}
+	}
 }
 
 func runSentinel(cmd *cobra.Command, args []string) error {
@@ -218,6 +296,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 				}
 			}()
 
+			defer startSentinelMetricsExport(ctx, manager)()
 			return manager.Run(ctx)
 		}
 
@@ -308,6 +387,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 			}
 		}()
 
+		defer startSentinelMetricsExport(ctx, manager)()
 		return manager.Run(ctx)
 
 	default:
@@ -344,6 +424,7 @@ func runSentinel(cmd *cobra.Command, args []string) error {
 		cancel()
 	}()
 
+	defer startSentinelMetricsExport(ctx, manager)()
 	return manager.Run(ctx)
 }
 

--- a/internal/sentinel/backend_metrics.go
+++ b/internal/sentinel/backend_metrics.go
@@ -1,0 +1,139 @@
+package sentinel
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Backend-failover observability (#1358).
+//
+// On 2026-08-14 09:17 UTC the primary backend went away (host reboot, ~2.5
+// min) and the sentinel failed over to a tunnel peer in under a second — the
+// multi-backend design working exactly as intended. But across that entire
+// real event the exported series read:
+//
+//	sentinel_preempted_total 0
+//	sentinel_state           1
+//
+// Neither moved. `sentinel_preempted_total` is incremented from the GCP
+// event-watcher path (handleEvent/EventPreempted), so a loss detected by the
+// health checker never touches it; `sentinel_state` only leaves 1 when the
+// sentinel enters maintenance, which a successful failover is precisely what
+// avoids. A sentinel fronting four backends could lose them one after another
+// and every series on /metrics would sit perfectly still.
+//
+// That also makes those two series the wrong marker for the #1349 capture
+// window: the allocation blowup is tied to losing a backend, and this proves a
+// backend can be lost without either series noticing.
+//
+// So two additions:
+//
+//   - sentinel_failover_total — a counter that moves on every primary switch,
+//     whether or not maintenance was ever entered.
+//   - sentinel_backend_healthy{backend="..."} — per-backend health, so "gcp
+//     went away but we stayed up on a tunnel" is visible and alertable rather
+//     than living only in the journal.
+//
+// sentinel_preempted_total is deliberately left alone. It answers a different
+// and still-useful question — "we had nowhere to fail over to" — and conflating
+// the two would lose that.
+
+// recordFailover counts one primary-backend switch. Called from the health
+// check loop; read from the /metrics HTTP goroutine, hence the atomic.
+func (m *Manager) recordFailover() {
+	m.failoverTotal.Add(1)
+}
+
+// FailoverCount returns the number of primary-backend failovers observed.
+func (m *Manager) FailoverCount() int64 {
+	return m.failoverTotal.Load()
+}
+
+// recordBackendHealth notes a backend's health transition.
+//
+// This deliberately keeps its own map rather than reading Backend.Healthy at
+// scrape time: that field is written by the health-check loop without holding
+// the pool's lock, so reading it from an HTTP goroutine is a data race. Fixing
+// that properly means reworking BackendPool's concurrency contract, which is
+// not something to change on the way past — a guarded copy here is cheap and
+// leaves the existing semantics untouched.
+func (m *Manager) recordBackendHealth(id string, healthy bool) {
+	m.backendHealthMu.Lock()
+	defer m.backendHealthMu.Unlock()
+	if m.backendHealth == nil {
+		m.backendHealth = make(map[string]bool)
+	}
+	m.backendHealth[id] = healthy
+}
+
+// BackendHealthSnapshot returns a copy of the per-backend health map. A copy,
+// not the live map — handing out the original would put the caller's range
+// loop in a race with the health-check loop's writes.
+func (m *Manager) BackendHealthSnapshot() map[string]bool {
+	m.backendHealthMu.RLock()
+	defer m.backendHealthMu.RUnlock()
+	out := make(map[string]bool, len(m.backendHealth))
+	for k, v := range m.backendHealth {
+		out[k] = v
+	}
+	return out
+}
+
+// renderBackendMetrics builds the Prometheus exposition for the failover
+// counter and per-backend health. Pure, so the label rendering and ordering
+// are testable without a Manager.
+func renderBackendMetrics(failovers int64, health map[string]bool) string {
+	var b bytes.Buffer
+
+	fmt.Fprint(&b, "# HELP sentinel_failover_total Total primary-backend failovers, including those absorbed without entering maintenance.\n")
+	fmt.Fprint(&b, "# TYPE sentinel_failover_total counter\n")
+	fmt.Fprintf(&b, "sentinel_failover_total %d\n", failovers)
+
+	// No backends registered yet (pure tunnel mode before a peer connects).
+	// Emitting a TYPE line with no samples under it is noise; omit the family.
+	if len(health) == 0 {
+		return b.String()
+	}
+
+	ids := make([]string, 0, len(health))
+	for id := range health {
+		ids = append(ids, id)
+	}
+	// Stable order: a scrape diff should reflect real change, not Go's
+	// randomised map iteration.
+	sort.Strings(ids)
+
+	// HELP/TYPE are per-family and must appear once, ahead of the samples.
+	fmt.Fprint(&b, "# HELP sentinel_backend_healthy Per-backend health as seen by the sentinel: 1 healthy, 0 unhealthy.\n")
+	fmt.Fprint(&b, "# TYPE sentinel_backend_healthy gauge\n")
+	for _, id := range ids {
+		v := 0
+		if health[id] {
+			v = 1
+		}
+		// Not %q: the value is already escaped, and %q would escape the
+		// escapes.
+		fmt.Fprintf(&b, "sentinel_backend_healthy{backend=\"%s\"} %d\n", escapeLabelValue(id), v)
+	}
+	return b.String()
+}
+
+// labelValueEscaper mirrors the Prometheus text-format rules: backslash, double
+// quote and newline must be escaped inside a label value.
+var labelValueEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`"`, `\"`,
+	"\n", `\n`,
+)
+
+// escapeLabelValue makes a backend ID safe to embed in a label.
+//
+// Backend IDs arrive from tunnel registration rather than a fixed allowlist, so
+// they are not guaranteed label-safe. One unescaped quote yields a line no
+// scraper can parse — and a parse error kills the entire scrape, not just the
+// offending series, so every other metric on this endpoint would vanish too.
+func escapeLabelValue(s string) string {
+	return labelValueEscaper.Replace(s)
+}

--- a/internal/sentinel/backend_metrics_test.go
+++ b/internal/sentinel/backend_metrics_test.go
@@ -1,0 +1,277 @@
+package sentinel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// #1358: on 2026-08-14 09:17 UTC the primary backend was lost (host reboot,
+// ~2.5 min) and the sentinel failed over to a tunnel peer in under a second.
+// Across that entire real event:
+//
+//	sentinel_preempted_total 0
+//	sentinel_state           1
+//
+// Neither moved, because `preempted_total` is incremented from the GCP
+// event-watcher path (handleEvent/EventPreempted) and `state` only leaves 1
+// when the sentinel enters maintenance — which a successful failover avoids.
+// So a multi-backend sentinel could lose backends all day and every existing
+// series would sit still. These tests pin the two series that make that
+// visible.
+
+func TestRenderBackendMetrics_FailoverCounterAndPerBackendHealth(t *testing.T) {
+	out := renderBackendMetrics(7, map[string]bool{
+		"gcp":               false,
+		"tunnel-fts-13700k": true,
+		"tunnel-byoc-1":     true,
+	})
+
+	for _, want := range []string{
+		"# TYPE sentinel_failover_total counter",
+		"sentinel_failover_total 7",
+		"# TYPE sentinel_backend_healthy gauge",
+		`sentinel_backend_healthy{backend="gcp"} 0`,
+		`sentinel_backend_healthy{backend="tunnel-byoc-1"} 1`,
+		`sentinel_backend_healthy{backend="tunnel-fts-13700k"} 1`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+
+	// HELP/TYPE are per-family, not per-sample; repeating them for each
+	// labelled series is malformed exposition.
+	if n := strings.Count(out, "# TYPE sentinel_backend_healthy"); n != 1 {
+		t.Errorf("emitted %d TYPE lines for sentinel_backend_healthy, want exactly 1\n--- got ---\n%s", n, out)
+	}
+}
+
+// Deterministic ordering keeps a scrape diff readable and keeps these tests
+// from depending on Go's randomised map iteration.
+func TestRenderBackendMetrics_SortsByBackendName(t *testing.T) {
+	out := renderBackendMetrics(0, map[string]bool{
+		"zulu": true, "alpha": true, "mike": false,
+	})
+	ai := strings.Index(out, `backend="alpha"`)
+	mi := strings.Index(out, `backend="mike"`)
+	zi := strings.Index(out, `backend="zulu"`)
+	if ai < 0 || ai >= mi || mi >= zi {
+		t.Errorf("backends not in sorted order (alpha=%d mike=%d zulu=%d)\n--- got ---\n%s", ai, mi, zi, out)
+	}
+}
+
+// A TYPE line with no samples under it is noise for a scraper. With no
+// backends registered (pure tunnel mode before any peer connects) the family
+// should be absent entirely — while the counter, which is always meaningful,
+// stays.
+func TestRenderBackendMetrics_OmitsEmptyBackendFamily(t *testing.T) {
+	out := renderBackendMetrics(2, map[string]bool{})
+	if strings.Contains(out, "sentinel_backend_healthy") {
+		t.Errorf("emitted an empty sentinel_backend_healthy family\n--- got ---\n%s", out)
+	}
+	if !strings.Contains(out, "sentinel_failover_total 2") {
+		t.Errorf("dropped the failover counter along with the empty family\n--- got ---\n%s", out)
+	}
+}
+
+// Backend IDs reach this from tunnel registration, so they are not guaranteed
+// to be label-safe. An unescaped quote produces a line no scraper can parse,
+// silently killing the whole scrape rather than just one series.
+func TestRenderBackendMetrics_EscapesLabelValues(t *testing.T) {
+	out := renderBackendMetrics(0, map[string]bool{`we"ird\one` + "\n": true})
+	if !strings.Contains(out, `sentinel_backend_healthy{backend="we\"ird\\one\n"} 1`) {
+		t.Errorf("label value not escaped\n--- got ---\n%s", out)
+	}
+}
+
+func TestManagerRecordsFailoversAndBackendHealth(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+
+	if got := m.FailoverCount(); got != 0 {
+		t.Fatalf("fresh manager FailoverCount = %d, want 0", got)
+	}
+
+	m.recordBackendHealth("gcp", true)
+	m.recordBackendHealth("tunnel-a", true)
+	// The shape of the 2026-08-14 09:17 event: primary goes unhealthy, we
+	// move to a peer.
+	m.recordBackendHealth("gcp", false)
+	m.recordFailover()
+
+	if got := m.FailoverCount(); got != 1 {
+		t.Errorf("FailoverCount = %d, want 1", got)
+	}
+	snap := m.BackendHealthSnapshot()
+	if snap["gcp"] != false || snap["tunnel-a"] != true {
+		t.Errorf("snapshot = %v, want gcp:false tunnel-a:true", snap)
+	}
+
+	// This is the regression the issue is about: the pre-existing series must
+	// still read as "nothing happened" for a health-detected loss, so the new
+	// ones are genuinely carrying the signal rather than duplicating it.
+	if m.PreemptCount() != 0 {
+		t.Errorf("PreemptCount = %d, want 0 — a health-detected backend loss is not a GCP preemption event", m.PreemptCount())
+	}
+	// Deliberately no assertion on CurrentState here: a freshly constructed
+	// Manager starts in maintenance until a backend proves healthy, so its
+	// state says nothing about failover. The point being pinned is that the
+	// pre-existing COUNTER stays still while the new one moves.
+}
+
+// The snapshot must be a copy. Handing out the live map would let an HTTP
+// scrape goroutine read it while the event loop mutates it — a data race the
+// -race build would fail on, intermittently and in CI rather than here.
+func TestBackendHealthSnapshotIsACopy(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	m.recordBackendHealth("gcp", true)
+
+	snap := m.BackendHealthSnapshot()
+	snap["gcp"] = false
+	snap["injected"] = true
+
+	fresh := m.BackendHealthSnapshot()
+	if fresh["gcp"] != true {
+		t.Error("mutating the returned snapshot changed the manager's state")
+	}
+	if _, ok := fresh["injected"]; ok {
+		t.Error("key injected into the returned snapshot reached the manager")
+	}
+}
+
+// Recording happens on the health-check loop while /metrics is scraped from an
+// HTTP goroutine. Run under -race (CI does) this fails if the accessors are
+// not properly guarded.
+func TestBackendMetricsConcurrentAccess(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				m.recordBackendHealth(fmt.Sprintf("backend-%d", i), j%2 == 0)
+				m.recordFailover()
+			}
+		}(i)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_ = renderBackendMetrics(m.FailoverCount(), m.BackendHealthSnapshot())
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := m.FailoverCount(); got != 800 {
+		t.Errorf("FailoverCount = %d, want 800 — increments were lost", got)
+	}
+}
+
+// The endpoint must carry the new series, not just the renderer.
+func TestMetricsHandlerServesBackendSeries(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	m.recordBackendHealth("gcp", true)
+	m.recordFailover()
+
+	body := scrapeMetrics(t, m)
+	for _, want := range []string{
+		"sentinel_failover_total 1",
+		`sentinel_backend_healthy{backend="gcp"} 1`,
+		// the pre-existing families must survive
+		"sentinel_preempted_total",
+		"sentinel_state",
+		// go_goroutines, not process_resident_memory_bytes: the process_*
+		// family is correctly ABSENT where /proc is unavailable (#1351), so
+		// asserting it here would fail on a macOS dev box for the right
+		// reason. The runtime series are portable.
+		"go_goroutines",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("/metrics missing %q\n--- got ---\n%s", want, body)
+		}
+	}
+}
+
+// scrapeMetrics drives the real /metrics handler and returns its body.
+func scrapeMetrics(t *testing.T, m *Manager) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	m.MetricsHandler()(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/metrics status = %d, want 200", rec.Code)
+	}
+	return rec.Body.String()
+}
+
+// TestFailoverPrimaryCountsTheRealPath exercises failoverPrimary itself, not
+// just the recorder.
+//
+// Without this, deleting m.recordFailover() from failoverPrimary left every
+// test in this file green — the same failure mode peer_proxy_handler_test.go
+// documents for #1102. switchToProxy syncs certs and keys over the network and
+// rewrites iptables, so it is stubbed via the seam; everything else is the
+// real control flow.
+func TestFailoverPrimaryCountsTheRealPath(t *testing.T) {
+	newMgr := func() (*Manager, *int) {
+		m := NewManager(Config{}, &fakeRecoveryProvider{})
+		calls := 0
+		m.switchToProxyFn = func(*Backend) error { calls++; return nil }
+		return m, &calls
+	}
+
+	t.Run("successful switch counts once", func(t *testing.T) {
+		m, calls := newMgr()
+		failed := &Backend{ID: "gcp", IP: "10.0.0.1", Healthy: false, Priority: 0}
+		peer := &Backend{ID: "tunnel-a", IP: "10.0.0.2", Healthy: true, Priority: 10}
+		m.backends.Add(failed)
+		m.backends.Add(peer)
+
+		m.failoverPrimary(context.Background(), failed)
+
+		if *calls != 1 {
+			t.Fatalf("switchToProxy called %d times, want 1", *calls)
+		}
+		if got := m.FailoverCount(); got != 1 {
+			t.Errorf("FailoverCount = %d, want 1 — the counter is not wired into failoverPrimary", got)
+		}
+	})
+
+	t.Run("failed switch is not counted", func(t *testing.T) {
+		m, _ := newMgr()
+		m.switchToProxyFn = func(*Backend) error { return errors.New("iptables refused") }
+		failed := &Backend{ID: "gcp", IP: "10.0.0.1", Healthy: false, Priority: 0}
+		peer := &Backend{ID: "tunnel-a", IP: "10.0.0.2", Healthy: true, Priority: 10}
+		m.backends.Add(failed)
+		m.backends.Add(peer)
+
+		m.failoverPrimary(context.Background(), failed)
+
+		if got := m.FailoverCount(); got != 0 {
+			t.Errorf("FailoverCount = %d, want 0 — a switch that errored left the primary unchanged, "+
+				"so reporting a failover would be a lie", got)
+		}
+	})
+
+	t.Run("no healthy peer means maintenance, not a failover", func(t *testing.T) {
+		m, calls := newMgr()
+		failed := &Backend{ID: "gcp", IP: "10.0.0.1", Healthy: false, Priority: 0}
+		m.backends.Add(failed)
+
+		m.failoverPrimary(context.Background(), failed)
+
+		if *calls != 0 {
+			t.Errorf("switchToProxy called %d times with no healthy peer, want 0", *calls)
+		}
+		if got := m.FailoverCount(); got != 0 {
+			t.Errorf("FailoverCount = %d, want 0 — this is the #1349 shape (nowhere to go), "+
+				"which sentinel_state/outage_seconds already report", got)
+		}
+	})
+}

--- a/internal/sentinel/manager.go
+++ b/internal/sentinel/manager.go
@@ -147,6 +147,24 @@ type Manager struct {
 	recoveryBackoff     time.Duration
 	nextRecoveryAttempt time.Time
 
+	// Backend-failover observability (#1358). failoverTotal is atomic and
+	// backendHealth is mutex-guarded because both are written by the
+	// health-check loop and read by the /metrics HTTP goroutine. The older
+	// preemptCount/recoveredCount above are plain ints on the "single event
+	// loop writes" convention; these are new, so they use the safe form
+	// rather than extending that assumption to a concurrently-read map.
+	failoverTotal   atomic.Int64
+	backendHealthMu sync.RWMutex
+	backendHealth   map[string]bool
+
+	// switchToProxyFn is the seam over switchToProxy so failoverPrimary's
+	// wiring is testable. The real implementation syncs certs/keys over the
+	// network and rewrites iptables, none of which a unit test can do — which
+	// previously meant the failover COUNTER could be deleted without a single
+	// test failing. Same injection pattern as byocDial below. nil = the real
+	// method; tests substitute a stub.
+	switchToProxyFn func(*Backend) error
+
 	// hmacSecret is the shared HMAC secret used to sign
 	// /sentinel/peers responses (and reused for keysync/certsync
 	// request auth via loadSentinelSecret). Held per-Manager so
@@ -746,6 +764,7 @@ func (m *Manager) healthCheckAll(ctx context.Context) {
 			b.healthyCount++
 			if b.healthyCount >= m.config.HealthyThreshold && !b.Healthy {
 				b.Healthy = true
+				m.recordBackendHealth(b.ID, true)
 				log.Printf("[sentinel] backend %s (%s) is healthy", b.ID, b.IP)
 			}
 		} else {
@@ -753,6 +772,7 @@ func (m *Manager) healthCheckAll(ctx context.Context) {
 			b.unhealthyCount++
 			if b.unhealthyCount >= m.config.UnhealthyThreshold && b.Healthy {
 				b.Healthy = false
+				m.recordBackendHealth(b.ID, false)
 				log.Printf("[sentinel] backend %s (%s) is unhealthy", b.ID, b.IP)
 
 				// If this was the primary, try failover
@@ -808,13 +828,27 @@ func (m *Manager) healthCheckAll(ctx context.Context) {
 	}
 }
 
+// doSwitchToProxy calls the injected seam when one is set, else the real
+// switchToProxy. Keeps failoverPrimary's control flow exercisable in tests.
+func (m *Manager) doSwitchToProxy(b *Backend) error {
+	if m.switchToProxyFn != nil {
+		return m.switchToProxyFn(b)
+	}
+	return m.switchToProxy(b)
+}
+
 // failoverPrimary switches HTTP forwarding to the next healthy backend.
 func (m *Manager) failoverPrimary(ctx context.Context, failed *Backend) {
 	next := m.backends.SelectPrimary()
 	if next != nil && next != failed {
 		log.Printf("[sentinel] failover: %s → %s (%s)", failed.ID, next.ID, next.IP)
-		if err := m.switchToProxy(next); err != nil {
+		if err := m.doSwitchToProxy(next); err != nil {
 			log.Printf("[sentinel] failover failed: %v", err)
+		} else {
+			// Counted only on a switch that actually took effect. A failed
+			// switch is already logged and leaves the primary unchanged, so
+			// counting it would report a failover that never happened.
+			m.recordFailover()
 		}
 	} else {
 		log.Printf("[sentinel] no healthy backend for failover, switching to maintenance")

--- a/internal/sentinel/metricsexport.go
+++ b/internal/sentinel/metricsexport.go
@@ -1,0 +1,223 @@
+package sentinel
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+
+	"github.com/footprintai/containarium/internal/metrics/cloudexport"
+)
+
+// Sentinel metrics export (#1358).
+//
+// #1351 put process-health series on /metrics and #1358's first half added the
+// failover series, but nothing scrapes that endpoint — and nothing on the spot
+// VM can. The bundled monitoring stack (VictoriaMetrics + vmalert +
+// Alertmanager) runs in a container ON the backend, so it dies with the very
+// outage worth observing. That is the same argument observability.go already
+// makes for why the sentinel owns the preemption signal; it applies just as
+// well to the sentinel's own health.
+//
+// So the always-on sentinel pushes to Cloud Monitoring itself. Push, not
+// scrape: it needs no inbound firewall rule for the internal-only binary-server
+// port, and it keeps reporting while the backend is gone.
+//
+// Only the Sink is reused from the daemon's export path. The
+// CloudExportCollector itself is daemon-shaped — its Sources interface wants
+// per-container metrics and container counts, it is constructed from
+// ContainerServer config the sentinel has no equivalent of, and its instrument
+// names are a deliberately allowlisted set gated by a golden test. Threading
+// the sentinel through all of that would mean a proto enum change and a much
+// larger blast radius than a self-contained meter here.
+//
+// COST SURFACE. Custom metrics are billed per ingested sample. At the 60s
+// floor this is 7 fixed series per sentinel plus one per backend
+// (backend_healthy) — roughly 11 series/minute on a sentinel fronting four
+// backends. Additions belong in this list, deliberately, for the same
+// review-gate reason the daemon's allowlist exists.
+
+const (
+	metricSentinelState          = "containarium.sentinel.state"
+	metricSentinelPreempted      = "containarium.sentinel.preempted_total"
+	metricSentinelRecovered      = "containarium.sentinel.recovered_total"
+	metricSentinelFailover       = "containarium.sentinel.failover_total"
+	metricSentinelBackendHealthy = "containarium.sentinel.backend_healthy"
+	metricSentinelRSS            = "containarium.sentinel.process.resident_memory_bytes"
+	metricSentinelGoroutines     = "containarium.sentinel.process.goroutines"
+	metricSentinelOpenFDs        = "containarium.sentinel.process.open_fds"
+
+	// sentinelMeterName is the instrumentation scope for these series.
+	sentinelMeterName = "github.com/footprintai/containarium/internal/sentinel"
+)
+
+// MetricsExportOptions configures the sentinel's push exporter.
+type MetricsExportOptions struct {
+	// Exporter is the OTel SDK exporter to push through — in production a
+	// cloudexport Sink's NewExporter result. Required.
+	Exporter sdkmetric.Exporter
+
+	// Resource tags every series with the provider's monitored-resource
+	// identity (gce_instance on GCP). Optional; nil falls back to the SDK
+	// default, which still exports but loses the per-instance association.
+	Resource *resource.Resource
+
+	// SentinelID distinguishes one sentinel's series from another's. Without
+	// it two sentinels' timeseries collide into one meaningless line.
+	SentinelID string
+
+	// IntervalSeconds is the requested cadence, clamped up to the billing
+	// floor.
+	IntervalSeconds int32
+}
+
+// clampExportInterval enforces the same per-sample billing floor the daemon's
+// collector uses. One policy, not two.
+func clampExportInterval(seconds int32) int32 {
+	if seconds < cloudexport.MinIntervalSeconds {
+		return cloudexport.MinIntervalSeconds
+	}
+	return seconds
+}
+
+// StartMetricsExport begins pushing the sentinel's series and returns a stop
+// function that flushes and shuts the pipeline down.
+func StartMetricsExport(m *Manager, opts MetricsExportOptions) (func(context.Context) error, error) {
+	if m == nil {
+		return nil, fmt.Errorf("metrics export: nil manager")
+	}
+	if opts.Exporter == nil {
+		return nil, fmt.Errorf("metrics export: no exporter configured — nothing to push to")
+	}
+
+	interval := time.Duration(clampExportInterval(opts.IntervalSeconds)) * time.Second
+	reader := sdkmetric.NewPeriodicReader(opts.Exporter, sdkmetric.WithInterval(interval))
+
+	providerOpts := []sdkmetric.Option{sdkmetric.WithReader(reader)}
+	if opts.Resource != nil {
+		providerOpts = append(providerOpts, sdkmetric.WithResource(opts.Resource))
+	}
+	provider := sdkmetric.NewMeterProvider(providerOpts...)
+
+	if err := registerSentinelInstruments(provider.Meter(sentinelMeterName), m, opts.SentinelID); err != nil {
+		// Shut the provider down rather than leaking its reader goroutine on
+		// a registration failure.
+		_ = provider.Shutdown(context.Background())
+		return nil, fmt.Errorf("metrics export: %w", err)
+	}
+
+	return provider.Shutdown, nil
+}
+
+// registerSentinelInstruments wires the observable instruments to the
+// Manager. Split out so tests can drive the real registration through a
+// ManualReader without an exporter or a network.
+//
+// All instruments are observable (async): every value is "read the current
+// state at collection time", which is exactly what an async callback is for,
+// and it keeps the hot paths (health checks, failover) free of metric writes.
+func registerSentinelInstruments(meter metric.Meter, m *Manager, sentinelID string) error {
+	state, err := meter.Int64ObservableGauge(metricSentinelState,
+		metric.WithDescription("Backend serving state: 1 proxy (up), 0 maintenance (down)."))
+	if err != nil {
+		return err
+	}
+	preempted, err := meter.Int64ObservableCounter(metricSentinelPreempted,
+		metric.WithDescription("Total spot-VM preemption events observed."))
+	if err != nil {
+		return err
+	}
+	recovered, err := meter.Int64ObservableCounter(metricSentinelRecovered,
+		metric.WithDescription("Total returns to proxy after an outage."))
+	if err != nil {
+		return err
+	}
+	failover, err := meter.Int64ObservableCounter(metricSentinelFailover,
+		metric.WithDescription("Total primary-backend failovers, including those absorbed without entering maintenance."))
+	if err != nil {
+		return err
+	}
+	backendHealthy, err := meter.Int64ObservableGauge(metricSentinelBackendHealthy,
+		metric.WithDescription("Per-backend health as seen by the sentinel: 1 healthy, 0 unhealthy."))
+	if err != nil {
+		return err
+	}
+	rss, err := meter.Int64ObservableGauge(metricSentinelRSS,
+		metric.WithDescription("Sentinel process resident set size."),
+		metric.WithUnit("By"))
+	if err != nil {
+		return err
+	}
+	goroutines, err := meter.Int64ObservableGauge(metricSentinelGoroutines,
+		metric.WithDescription("Goroutines in the sentinel process."))
+	if err != nil {
+		return err
+	}
+	openFDs, err := meter.Int64ObservableGauge(metricSentinelOpenFDs,
+		metric.WithDescription("Open file descriptors in the sentinel process."))
+	if err != nil {
+		return err
+	}
+
+	base := []attribute.KeyValue{attribute.String("sentinel", sentinelID)}
+	baseSet := metric.WithAttributes(base...)
+
+	_, err = meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		stateVal := int64(0)
+		if m.CurrentState() == StateProxy {
+			stateVal = 1
+		}
+		o.ObserveInt64(state, stateVal, baseSet)
+		o.ObserveInt64(preempted, int64(m.PreemptCount()), baseSet)
+		o.ObserveInt64(recovered, int64(m.RecoveredCount()), baseSet)
+		o.ObserveInt64(failover, m.FailoverCount(), baseSet)
+
+		for id, healthy := range m.BackendHealthSnapshot() {
+			v := int64(0)
+			if healthy {
+				v = 1
+			}
+			o.ObserveInt64(backendHealthy, v, metric.WithAttributes(
+				append(append([]attribute.KeyValue{}, base...), attribute.String("backend", id))...))
+		}
+
+		rt := collectRuntimeStats()
+		o.ObserveInt64(goroutines, int64(rt.Goroutines), baseSet)
+
+		// Absent, not zero, when /proc is unreadable — the same rule as the
+		// /metrics rendering (#1351). A zero would read as "this process uses
+		// no memory" and silence the alert this exists to enable, and unlike
+		// the text endpoint that zero would be persisted in Cloud Monitoring
+		// forever.
+		if ps := readProcStats(); ps.Available {
+			o.ObserveInt64(rss, safeInt64(ps.RSSBytes), baseSet)
+			if ps.OpenFDs > 0 {
+				o.ObserveInt64(openFDs, safeInt64(ps.OpenFDs), baseSet)
+			}
+		}
+		return nil
+	}, state, preempted, recovered, failover, backendHealthy, rss, goroutines, openFDs)
+
+	return err
+}
+
+// safeInt64 converts a uint64 counter to the int64 the OTel API takes,
+// saturating rather than wrapping.
+//
+// Guarded rather than suppressing gosec's G115: a value above 2^63 would wrap
+// to a NEGATIVE observation, and a negative resident-memory datapoint
+// persisted in Cloud Monitoring is worse than a clamped one — it would break
+// any alert expression built on the series. Real RSS and fd counts are nowhere
+// near this, which is exactly why the wrap would be baffling if it ever
+// happened.
+func safeInt64(v uint64) int64 {
+	if v > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(v)
+}

--- a/internal/sentinel/metricsexport_test.go
+++ b/internal/sentinel/metricsexport_test.go
@@ -1,0 +1,278 @@
+package sentinel
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/footprintai/containarium/internal/metrics/cloudexport"
+)
+
+// #1358, part two: the series exist on /metrics but nothing scrapes them, and
+// nothing can — the bundled monitoring stack runs ON the spot VM, so it is
+// gone during exactly the outage worth observing. This pushes them to Cloud
+// Monitoring from the always-on sentinel instead.
+//
+// These tests drive the real instrument registration through a ManualReader,
+// so the names, values and attributes are asserted without a network. The
+// GCP wire path itself is already covered by cloudexport's own
+// TestGCPSink_NewExporter_PushesToFakeMonitoring.
+
+// collectOnce registers the sentinel instruments against a ManualReader and
+// returns the single collected scope's metrics.
+func collectOnce(t *testing.T, m *Manager, sentinelID string) []metricdata.Metrics {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	if err := registerSentinelInstruments(provider.Meter("test"), m, sentinelID); err != nil {
+		t.Fatalf("registerSentinelInstruments: %v", err)
+	}
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(rm.ScopeMetrics) == 0 {
+		t.Fatal("no scope metrics collected — nothing was registered")
+	}
+	return rm.ScopeMetrics[0].Metrics
+}
+
+func findMetric(ms []metricdata.Metrics, name string) *metricdata.Metrics {
+	for i := range ms {
+		if ms[i].Name == name {
+			return &ms[i]
+		}
+	}
+	return nil
+}
+
+// gaugeValue returns the single int64 gauge datapoint's value.
+func gaugeValue(t *testing.T, md *metricdata.Metrics) int64 {
+	t.Helper()
+	g, ok := md.Data.(metricdata.Gauge[int64])
+	if !ok {
+		t.Fatalf("%s is %T, want Gauge[int64]", md.Name, md.Data)
+	}
+	if len(g.DataPoints) != 1 {
+		t.Fatalf("%s has %d datapoints, want 1", md.Name, len(g.DataPoints))
+	}
+	return g.DataPoints[0].Value
+}
+
+func sumValue(t *testing.T, md *metricdata.Metrics) int64 {
+	t.Helper()
+	s, ok := md.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("%s is %T, want Sum[int64]", md.Name, md.Data)
+	}
+	if !s.IsMonotonic {
+		t.Errorf("%s is not monotonic; a _total counter must be", md.Name)
+	}
+	if len(s.DataPoints) != 1 {
+		t.Fatalf("%s has %d datapoints, want 1", md.Name, len(s.DataPoints))
+	}
+	return s.DataPoints[0].Value
+}
+
+func TestSentinelInstrumentsExportTheLeakDetectionSeries(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	m.state.Store(StateProxy)
+	m.preemptCount = 2
+	m.recoveredCount = 1
+	m.recordFailover()
+	m.recordFailover()
+	m.recordFailover()
+
+	ms := collectOnce(t, m, "sentinel-test")
+
+	// state: 1 = proxy (serving), 0 = maintenance.
+	if md := findMetric(ms, metricSentinelState); md == nil {
+		t.Errorf("missing %s", metricSentinelState)
+	} else if got := gaugeValue(t, md); got != 1 {
+		t.Errorf("%s = %d, want 1 (proxy)", metricSentinelState, got)
+	}
+
+	for _, tc := range []struct {
+		name string
+		want int64
+	}{
+		{metricSentinelPreempted, 2},
+		{metricSentinelRecovered, 1},
+		// The series that would have made the 09:17 backend loss visible.
+		{metricSentinelFailover, 3},
+	} {
+		md := findMetric(ms, tc.name)
+		if md == nil {
+			t.Errorf("missing %s", tc.name)
+			continue
+		}
+		if got := sumValue(t, md); got != tc.want {
+			t.Errorf("%s = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+
+	// Goroutines are portable; RSS/fds need /proc (see the omission test).
+	if md := findMetric(ms, metricSentinelGoroutines); md == nil {
+		t.Errorf("missing %s", metricSentinelGoroutines)
+	} else if got := gaugeValue(t, md); got < 1 {
+		t.Errorf("%s = %d, want >= 1", metricSentinelGoroutines, got)
+	}
+}
+
+// Resident memory is the whole point of exporting: it is what the OOM killer
+// scores, and the series an alert on #1349 would key off.
+func TestResidentMemoryIsExportedWhereProcExists(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("no /proc on %s — this is exercised on linux, where the sentinel runs", runtime.GOOS)
+	}
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	ms := collectOnce(t, m, "sentinel-test")
+
+	md := findMetric(ms, metricSentinelRSS)
+	if md == nil {
+		t.Fatalf("missing %s", metricSentinelRSS)
+	}
+	if got := gaugeValue(t, md); got <= 0 {
+		t.Errorf("%s = %d, want > 0", metricSentinelRSS, got)
+	}
+	if findMetric(ms, metricSentinelOpenFDs) == nil {
+		t.Errorf("missing %s", metricSentinelOpenFDs)
+	}
+}
+
+// Same rule as #1351's /metrics rendering: where /proc is unreadable the
+// process series must be ABSENT, never reported as zero. A zero here would
+// read as "this process uses no memory" and silence the alert this exists to
+// enable — and unlike the text endpoint, a zero datapoint would also be
+// persisted forever in Cloud Monitoring.
+func TestProcessSeriesOmittedWithoutProc(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("this asserts the no-/proc branch; linux has /proc")
+	}
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	ms := collectOnce(t, m, "sentinel-test")
+
+	for _, name := range []string{metricSentinelRSS, metricSentinelOpenFDs} {
+		if md := findMetric(ms, name); md != nil {
+			t.Errorf("%s was exported with no /proc available — a zero would silence the leak alert", name)
+		}
+	}
+	// The portable series must survive: losing /proc must not cost everything.
+	if findMetric(ms, metricSentinelGoroutines) == nil {
+		t.Error("runtime series dropped along with the proc series")
+	}
+}
+
+func TestBackendHealthCarriesAPerBackendAttribute(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	m.recordBackendHealth("gcp", false)
+	m.recordBackendHealth("tunnel-fts", true)
+
+	ms := collectOnce(t, m, "sentinel-test")
+	md := findMetric(ms, metricSentinelBackendHealthy)
+	if md == nil {
+		t.Fatalf("missing %s", metricSentinelBackendHealthy)
+	}
+	g, ok := md.Data.(metricdata.Gauge[int64])
+	if !ok {
+		t.Fatalf("%s is %T, want Gauge[int64]", md.Name, md.Data)
+	}
+	if len(g.DataPoints) != 2 {
+		t.Fatalf("got %d datapoints, want one per backend (2)", len(g.DataPoints))
+	}
+
+	got := map[string]int64{}
+	for _, dp := range g.DataPoints {
+		v, ok := dp.Attributes.Value("backend")
+		if !ok {
+			t.Fatalf("datapoint has no 'backend' attribute: %v", dp.Attributes)
+		}
+		got[v.AsString()] = dp.Value
+	}
+	if got["gcp"] != 0 || got["tunnel-fts"] != 1 {
+		t.Errorf("per-backend values = %v, want gcp:0 tunnel-fts:1", got)
+	}
+}
+
+// Every datapoint must carry the sentinel's identity, or two sentinels'
+// series collide into one meaningless line in Cloud Monitoring.
+func TestSeriesCarrySentinelIdentity(t *testing.T) {
+	ms := collectOnce(t, NewManager(Config{}, &fakeRecoveryProvider{}), "asia-sentinel")
+
+	md := findMetric(ms, metricSentinelState)
+	if md == nil {
+		t.Fatal("missing state metric")
+	}
+	g := md.Data.(metricdata.Gauge[int64])
+	v, ok := g.DataPoints[0].Attributes.Value("sentinel")
+	if !ok {
+		t.Fatalf("no 'sentinel' attribute on the datapoint: %v", g.DataPoints[0].Attributes)
+	}
+	if v.AsString() != "asia-sentinel" {
+		t.Errorf("sentinel attribute = %q, want %q", v.AsString(), "asia-sentinel")
+	}
+}
+
+// Custom metrics are billed per ingested sample, so a misconfigured (or
+// hostile) sub-minute interval must not be honoured. Mirrors the daemon's
+// existing clamp rather than inventing a second policy.
+func TestExportIntervalClampedToBillingFloor(t *testing.T) {
+	for _, tc := range []struct{ in, want int32 }{
+		{0, cloudexport.MinIntervalSeconds},
+		{-30, cloudexport.MinIntervalSeconds},
+		{1, cloudexport.MinIntervalSeconds},
+		{59, cloudexport.MinIntervalSeconds},
+		{60, 60},
+		{300, 300},
+	} {
+		if got := clampExportInterval(tc.in); got != tc.want {
+			t.Errorf("clampExportInterval(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestStartMetricsExportRequiresAnExporter(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	if _, err := StartMetricsExport(m, MetricsExportOptions{}); err == nil {
+		t.Error("StartMetricsExport with no exporter returned nil error; it cannot push anywhere")
+	}
+}
+
+// Start must hand back a working stop so the sentinel can shut the exporter
+// down without leaking its periodic reader goroutine.
+func TestStartMetricsExportStops(t *testing.T) {
+	m := NewManager(Config{}, &fakeRecoveryProvider{})
+	stop, err := StartMetricsExport(m, MetricsExportOptions{
+		Exporter:        &noopExporter{},
+		SentinelID:      "test",
+		IntervalSeconds: 60,
+	})
+	if err != nil {
+		t.Fatalf("StartMetricsExport: %v", err)
+	}
+	if stop == nil {
+		t.Fatal("nil stop func")
+	}
+	if err := stop(context.Background()); err != nil {
+		t.Errorf("stop: %v", err)
+	}
+}
+
+// noopExporter is a minimal sdkmetric.Exporter for lifecycle tests.
+type noopExporter struct{}
+
+func (n *noopExporter) Temporality(k sdkmetric.InstrumentKind) metricdata.Temporality {
+	return sdkmetric.DefaultTemporalitySelector(k)
+}
+func (n *noopExporter) Aggregation(k sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return sdkmetric.DefaultAggregationSelector(k)
+}
+func (n *noopExporter) Export(context.Context, *metricdata.ResourceMetrics) error { return nil }
+func (n *noopExporter) ForceFlush(context.Context) error                          { return nil }
+func (n *noopExporter) Shutdown(context.Context) error                            { return nil }

--- a/internal/sentinel/observability.go
+++ b/internal/sentinel/observability.go
@@ -115,6 +115,10 @@ func (m *Manager) MetricsHandler() http.HandlerFunc {
 		// BACKEND; this describes the sentinel), so it is rendered separately
 		// and simply appended to the same exposition.
 		fmt.Fprint(w, renderProcessMetrics(collectRuntimeStats(), readProcStats()))
+		// Backend failover + per-backend health (#1358). The preemption
+		// counters above miss a loss that failover absorbs — see
+		// backend_metrics.go for the event that proved it.
+		fmt.Fprint(w, renderBackendMetrics(m.FailoverCount(), m.BackendHealthSnapshot()))
 	}
 }
 

--- a/internal/sentinel/process_metrics_test.go
+++ b/internal/sentinel/process_metrics_test.go
@@ -196,7 +196,17 @@ func TestMetricsExpositionIsWellFormed(t *testing.T) {
 				t.Errorf("malformed sample line: %q", line)
 				continue
 			}
-			samples = append(samples, f[0])
+			// Strip any label set: sentinel_backend_healthy{backend="gcp"}
+			// declares its TYPE under the bare family name (#1358).
+			name := f[0]
+			if i := strings.IndexByte(name, '{'); i >= 0 {
+				if !strings.HasSuffix(name, "}") {
+					t.Errorf("unterminated label set in sample line: %q", line)
+					continue
+				}
+				name = name[:i]
+			}
+			samples = append(samples, name)
 		}
 	}
 


### PR DESCRIPTION
Refs #1358 — **the series half.** The push-export half is scoped at the bottom and not in here; you cannot export what is not measured, and today proved the measurement itself was the gap.

## Why

At 09:17 UTC today the asia sentinel lost its primary backend (host reboot, ~2.5 min) and failed over to a tunnel peer in under a second — the multi-backend design working exactly as designed. Across that entire real event:

```
sentinel_preempted_total 0
sentinel_state           1
```

**Neither moved.** `sentinel_preempted_total` is incremented from the GCP event-watcher path (`handleEvent`/`EventPreempted`), so a loss detected by the *health checker* never touches it. `sentinel_state` only leaves `1` when the sentinel enters maintenance — which a successful failover is precisely what avoids.

So a sentinel fronting four backends could lose them one after another and every series on `/metrics` would sit perfectly still. The event existed only in the journal:

```
09:17:33 [sentinel] backend gcp (10.140.0.51) is unhealthy
09:17:33 [sentinel] failover: gcp → tunnel-fts-13700k
09:20:15 [sentinel] backend gcp (10.140.0.51) is healthy
```

This also retires a claim I put on #1349: `sentinel_preempted_total` is **not** a usable marker for the blowup's capture window, because a backend can be lost without it moving.

## What

```
# TYPE sentinel_failover_total counter
sentinel_failover_total 3
# TYPE sentinel_backend_healthy gauge
sentinel_backend_healthy{backend="gcp"} 0
sentinel_backend_healthy{backend="tunnel-fts-13700k"} 1
```

`sentinel_preempted_total` is deliberately untouched — it answers a different and still-useful question ("we had nowhere to fail over to"), and folding the two together would lose that.

## Design notes

**Health is kept in a guarded map on the Manager, not read from `Backend.Healthy` at scrape time.** That field is written by the health-check loop *without* holding the pool's lock, so reading it from the HTTP goroutine is a real data race. Reworking `BackendPool`'s concurrency contract is not something to do on the way past; a guarded copy is cheap and leaves existing semantics alone. The counter is atomic for the same reason — the older `preemptCount`/`recoveredCount` ride on a "single event loop writes" convention that these new, concurrently-read values shouldn't extend.

**Label values are escaped.** Backend IDs arrive from tunnel registration, not a fixed allowlist. One unescaped quote yields a line no scraper can parse — and a parse error kills the *entire* scrape, so every other metric on the endpoint would vanish with it.

**Empty families are omitted**, consistent with #1351: in pure tunnel mode before a peer connects, a `TYPE` line with no samples under it is noise.

## The seam, and why it is here

`failoverPrimary` now calls `switchToProxy` through an injectable seam (the `byocDial` pattern already used in this package).

That is not cosmetic. Mutation testing caught this: **deleting `m.recordFailover()` from `failoverPrimary` left every test in the file green**, because they exercised the recorder directly and nothing exercised the wiring — `switchToProxy` syncs certs and keys over the network and rewrites iptables, so no unit test could reach it. That is exactly the failure mode `peer_proxy_handler_test.go` documents for #1102 ("a test that builds its own mux proves only that the handler works when someone remembers to gate it").

With the seam, the same mutation now fails:

```
--- FAIL: TestFailoverPrimaryCountsTheRealPath
    FailoverCount = 0, want 1 — the counter is not wired into failoverPrimary
```

## Verification

Mutation-tested, both surviving:

| Mutation | Caught by |
| --- | --- |
| Remove `recordFailover()` from `failoverPrimary` | `the counter is not wired into failoverPrimary` |
| `BackendHealthSnapshot` returns the live map | copy test **and** a `WARNING: DATA RACE` under `-race` |

Also covered: sorted output (no dependence on Go's randomised map iteration), label escaping, empty-family omission, single `HELP`/`TYPE` per family, the three `failoverPrimary` branches (success counts / errored switch does not / no healthy peer goes to maintenance instead), and concurrent record-vs-scrape under `-race`.

`TestMetricsExpositionIsWellFormed` from #1351 is updated to strip label sets before matching a sample against its declared `TYPE`.

Full `internal/sentinel` suite green under `-race`, `go vet` clean, `golangci-lint` 0 issues. The two gosec hits in `manager.go` (G114, G706) are pre-existing — verified present on `main`; my diff only shifted their line numbers.

**Two of my own test assumptions were wrong and are worth flagging**, since both were caught by existing work rather than by me: a freshly constructed `Manager` legitimately starts in `StateMaintenance` (so asserting on state proved nothing about failover), and `process_resident_memory_bytes` is correctly *absent* on a macOS dev box — the `/proc`-unavailable behaviour #1351 deliberately implements. The tests assert on portable series instead.

## Still open on #1358 — the push export

Nothing scrapes this endpoint yet, so these series are visible but not yet alertable. Scoping notes from digging into it:

- **The bundled monitoring stack runs on the spot VM**, so it structurally cannot scrape the sentinel during the outage that matters — the same argument `observability.go` already makes for why the sentinel owns the preemption signal. It must be an off-spot collector.
- **`internal/metrics/cloudexport` is daemon-shaped.** Its `Sources` interface wants `AllContainerMetrics` and container counts, and it is constructed from `ContainerServer` config the sentinel has no equivalent of. Its instrument names are also a deliberately allowlisted set with a golden test, so sentinel-specific series are a reviewable addition to that allowlist rather than a drop-in.
- **Credentials are not a blocker**: the sentinel VM's service account carries the `cloud-platform` scope, so pushing to Cloud Monitoring is feasible without an infra change.

Suggested shape: a small sentinel-side exporter reusing `cloudexport.NewGCPSink()`, configured by CLI flags rather than the daemon's proto/store path. Happy to take that next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
