### PR TITLE
feat(move): land a migrated encrypted container in its tenant's pool

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -6146,6 +6146,14 @@
             "type": "string"
           },
           "description": "The source daemon's record of which routes belonged to this\ncontainer, so the destination can recreate them at its own\ncontainer IP. Each entry is \"\u003cfull-domain\u003e|\u003cport\u003e|\u003cprotocol\u003e\".\nEmpty for stateless containers with no exposed ports."
+        },
+        "zfsKeyRef": {
+          "type": "string",
+          "description": "The source's stored KeyRef for an encrypted container, JSON-encoded.\nThe destination records it so it can re-resolve the key on every\nlater start, exactly as the source did. Empty for an unencrypted\ncontainer, which is every container by default.\n\nA reference only — it carries no key bytes. The destination already\nproved it can resolve this ref during the pre-flight."
+        },
+        "zfsPool": {
+          "type": "string",
+          "description": "The destination storage pool the container was copied into — the one\nthe pre-flight returned, sourced at this tenant's encryptionroot.\nThe destination records it because the pool's source IS the\ncontainer's encryptionroot, and every later start has to find it.\nEmpty for an unencrypted container."
         }
       },
       "description": "AdoptMigratedContainerRequest is sent by the source daemon's\nMoveContainer to the destination daemon AFTER `incus copy` has\ncompleted and the LXC exists on the destination's incusd. The\ndestination then registers the container with its own Containarium\nstate (host user account, route record at the new IP).\n\nInternal use only — exposed via REST for daemon-to-daemon coordination\nover the same PeerPool channel used by other forwarding RPCs."

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -1950,6 +1950,12 @@ func (s *ContainerServer) AdoptMigratedContainer(ctx context.Context, req *pb.Ad
 
 	containerName := fmt.Sprintf("%s-container", req.Username)
 
+	// Encryption placement first: a container this daemon cannot unlock must
+	// be refused before any host-side state is created for it (#1203).
+	if err := s.recordAdoptedPlacement(req); err != nil {
+		return nil, err
+	}
+
 	// Host-side jump-server account. EnsureJumpServerAccount handles
 	// the idempotent case so re-running this RPC won't error.
 	if err := container.EnsureJumpServerAccount(req.Username); err != nil {

--- a/internal/server/move_container.go
+++ b/internal/server/move_container.go
@@ -136,6 +136,7 @@ func (s *ContainerServer) MoveContainer(ctx context.Context, req *pb.MoveContain
 	//
 	// An unencrypted container skips this entirely — no extra round trip and
 	// no new failure mode on the path every container takes today.
+	var encStoragePool, encRefJSON string
 	ref, _, encrypted, err := s.encryption.migrationRef(containerName)
 	if err != nil {
 		return nil, fmt.Errorf("resolve encryption state for %s: %w", containerName, err)
@@ -145,6 +146,7 @@ func (s *ContainerServer) MoveContainer(ctx context.Context, req *pb.MoveContain
 		if merr != nil {
 			return nil, fmt.Errorf("encode the key ref for %s: %w", containerName, merr)
 		}
+		encRefJSON = string(refJSON)
 		tenant := tenantFromRef(ref, containerName)
 		prep, perr := prepareFn(targetPeer, extractAuthToken(ctx), &pb.PrepareEncryptedMigrationRequest{
 			Username: req.Username,
@@ -159,10 +161,19 @@ func (s *ContainerServer) MoveContainer(ctx context.Context, req *pb.MoveContain
 				"backend %q cannot take encrypted container %s: %s. Nothing was copied",
 				req.TargetBackendId, containerName, prep.GetReason())
 		}
-		// #1203b targets the copy at this pool. Logged now so a migration run
-		// today records where the container was meant to land.
-		log.Printf("[move] pre-flight ok: %s (tenant %s) will land on %s's storage pool %s",
-			containerName, tenant, req.TargetBackendId, prep.GetStoragePool())
+		// Every copy below targets this pool. Without it the container lands
+		// on the destination's default pool — outside the tenant's
+		// encryptionroot, unencrypted — while the pre-flight just said the
+		// migration was safe, which is the more dangerous of the two.
+		encStoragePool = prep.GetStoragePool()
+		if encStoragePool == "" {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"backend %q accepted encrypted container %s but named no storage pool to copy it "+
+					"into; refusing rather than landing it outside its tenant's encryptionroot",
+				req.TargetBackendId, containerName)
+		}
+		log.Printf("[move] pre-flight ok: %s (tenant %s) lands on %s's storage pool %s",
+			containerName, tenant, req.TargetBackendId, encStoragePool)
 	}
 
 	params := migrationDefaults(req)
@@ -193,7 +204,7 @@ func (s *ContainerServer) MoveContainer(ctx context.Context, req *pb.MoveContain
 	createdSnaps = append(createdSnaps, syncName)
 
 	log.Printf("[move] phase 1: initial copy of %s/%s to %s ...", containerName, syncName, targetRemote)
-	if err := s.moveRunner.CopyInitial(containerName, syncName, targetRemote); err != nil {
+	if err := s.moveRunner.CopyInitial(containerName, syncName, targetRemote, encStoragePool); err != nil {
 		cleanupSnaps()
 		return nil, fmt.Errorf("phase 1: initial copy: %w", err)
 	}
@@ -211,7 +222,7 @@ func (s *ContainerServer) MoveContainer(ctx context.Context, req *pb.MoveContain
 		createdSnaps = append(createdSnaps, syncName)
 
 		log.Printf("[move] phase 2 iter %d: delta refresh of %s/%s ...", i, containerName, syncName)
-		if err := s.moveRunner.CopyRefresh(containerName, syncName, targetRemote); err != nil {
+		if err := s.moveRunner.CopyRefresh(containerName, syncName, targetRemote, encStoragePool); err != nil {
 			cleanupSnaps()
 			return nil, fmt.Errorf("phase 2 iter %d: refresh: %w", i, err)
 		}
@@ -255,7 +266,7 @@ func (s *ContainerServer) MoveContainer(ctx context.Context, req *pb.MoveContain
 	}
 	createdSnaps = append(createdSnaps, finalSnap)
 
-	if err := s.moveRunner.CopyRefresh(containerName, finalSnap, targetRemote); err != nil {
+	if err := s.moveRunner.CopyRefresh(containerName, finalSnap, targetRemote, encStoragePool); err != nil {
 		rollback()
 		cleanupSnaps()
 		return nil, fmt.Errorf("phase 3: final delta copy: %w", err)
@@ -282,6 +293,11 @@ func (s *ContainerServer) MoveContainer(ctx context.Context, req *pb.MoveContain
 	adoptReq := &pb.AdoptMigratedContainerRequest{
 		Username:     req.Username,
 		SourceRoutes: sourceRoutes,
+		// Empty for an unencrypted container. The destination needs both to
+		// find the encryptionroot on every later start; it already proved
+		// during the pre-flight that it can resolve this ref.
+		ZfsKeyRef: encRefJSON,
+		ZfsPool:   encStoragePool,
 	}
 	adoptResp, err := adoptFn(targetPeer, authToken, adoptReq)
 	if err != nil {
@@ -403,6 +419,8 @@ func forwardAdoptMigratedContainer(peer *PeerClient, authToken string, req *pb.A
 	body, err := json.Marshal(map[string]interface{}{
 		"username":      req.Username,
 		"source_routes": req.SourceRoutes,
+		"zfs_key_ref":   req.ZfsKeyRef,
+		"zfs_pool":      req.ZfsPool,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal adopt request: %w", err)

--- a/internal/server/move_container_test.go
+++ b/internal/server/move_container_test.go
@@ -27,6 +27,17 @@ type fakeRunner struct {
 	hasRemote       bool
 }
 
+// copyDesc mirrors what the real runner does with the pool: `--storage` is
+// appended only when one is given, so an unencrypted migration's command is
+// byte-identical to what it always was.
+func copyDesc(container, snap, remote, pool string) string {
+	desc := fmt.Sprintf("%s/%s -> %s", container, snap, remote)
+	if pool != "" {
+		desc += " storage=" + pool
+	}
+	return desc
+}
+
 func (f *fakeRunner) log(s string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -41,12 +52,12 @@ func (f *fakeRunner) DeleteSnapshot(c, s string) error {
 	f.log(fmt.Sprintf("delsnap %s/%s", c, s))
 	return nil
 }
-func (f *fakeRunner) CopyInitial(c, s, r string) error {
-	f.log(fmt.Sprintf("copyinit %s/%s -> %s", c, s, r))
+func (f *fakeRunner) CopyInitial(c, s, r, pool string) error {
+	f.log("copyinit " + copyDesc(c, s, r, pool))
 	return f.failCopyInit
 }
-func (f *fakeRunner) CopyRefresh(c, s, r string) error {
-	f.log(fmt.Sprintf("refresh %s/%s -> %s", c, s, r))
+func (f *fakeRunner) CopyRefresh(c, s, r, pool string) error {
+	f.log("refresh " + copyDesc(c, s, r, pool))
 	n := f.copyRefreshN
 	f.copyRefreshN++
 	if err, ok := f.failCopyRefresh[n]; ok {

--- a/internal/server/move_encrypted_placement_test.go
+++ b/internal/server/move_encrypted_placement_test.go
@@ -1,0 +1,216 @@
+package server
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Placement for a migrated encrypted container (#1203b, the half #1360 left).
+//
+// #1360 made the destination provision the tenant's pool and hand back its
+// name. Nothing consumed it: `incus copy` still ran with no `--storage`, so
+// the container landed on the destination's DEFAULT pool — outside the
+// tenant's encryptionroot, unencrypted — while the pre-flight had just said
+// the migration was safe. That combination is worse than no pre-flight at
+// all, because the reassuring signal is the false one.
+//
+// These tests pin the copy going where the pre-flight said, and the
+// destination recording enough to unlock it again afterwards.
+
+// preflightOK installs a destination that accepts and names a pool.
+func preflightOK(t *testing.T, pool string) {
+	t.Helper()
+	prev := overridePrepareForTest(func(*PeerClient, string, *pb.PrepareEncryptedMigrationRequest) (*pb.PrepareEncryptedMigrationResponse, error) {
+		return &pb.PrepareEncryptedMigrationResponse{CanResolve: true, StoragePool: pool}, nil
+	})
+	t.Cleanup(prev)
+}
+
+// Every copy in the migration must target the tenant pool — not just the
+// first. The final cutover copy is the one that carries the last delta, so a
+// copy that forgot the pool there would leave the container's freshest state
+// on the wrong dataset.
+func TestMoveContainer_EveryCopyTargetsTheTenantPool(t *testing.T) {
+	runner := &fakeRunner{hasRemote: true}
+	cs := encryptedServer(t, runner)
+	preflightOK(t, "containarium-tenant-alice")
+
+	var adopted *pb.AdoptMigratedContainerRequest
+	prev := overrideAdoptForTest(func(_ *PeerClient, _ string, req *pb.AdoptMigratedContainerRequest) (*pb.AdoptMigratedContainerResponse, error) {
+		adopted = req
+		return &pb.AdoptMigratedContainerResponse{NewIpAddress: "10.0.7.42"}, nil
+	})
+	defer prev()
+
+	if _, err := cs.MoveContainer(adminCtx(), &pb.MoveContainerRequest{
+		Username: "alice", TargetBackendId: "vm2",
+	}); err != nil {
+		t.Fatalf("MoveContainer: %v", err)
+	}
+
+	copies := 0
+	for _, call := range runner.calls {
+		if !strings.HasPrefix(call, "copyinit ") && !strings.HasPrefix(call, "refresh ") {
+			continue
+		}
+		copies++
+		if !strings.Contains(call, "storage=containarium-tenant-alice") {
+			t.Errorf("copy %q did not target the tenant pool — the container lands on the "+
+				"destination's default pool, outside its encryptionroot, and arrives unencrypted "+
+				"while the pre-flight said the migration was safe", call)
+		}
+	}
+	if copies == 0 {
+		t.Fatal("no copies happened at all")
+	}
+
+	// And the destination must be told what it received, or it cannot
+	// unlock the container on any later start.
+	if adopted == nil {
+		t.Fatal("adopt was never called")
+	}
+	if adopted.ZfsPool != "containarium-tenant-alice" {
+		t.Errorf("adopt request pool = %q, want the tenant pool", adopted.ZfsPool)
+	}
+	var ref zfskey.KeyRef
+	if err := json.Unmarshal([]byte(adopted.ZfsKeyRef), &ref); err != nil {
+		t.Fatalf("adopt request carries no decodable key ref: %v", err)
+	}
+	if ref.URI != "/keys/alice.key" {
+		t.Errorf("adopt ref = %+v, want alice's", ref)
+	}
+}
+
+// The unencrypted path must be byte-identical: no --storage, no placement
+// fields. Every container today takes this path.
+func TestMoveContainer_UnencryptedCopiesCarryNoStorageOverride(t *testing.T) {
+	runner := &fakeRunner{hasRemote: true}
+	cs := newTestContainerServer(t, runner, "vm2")
+
+	var adopted *pb.AdoptMigratedContainerRequest
+	prev := overrideAdoptForTest(func(_ *PeerClient, _ string, req *pb.AdoptMigratedContainerRequest) (*pb.AdoptMigratedContainerResponse, error) {
+		adopted = req
+		return &pb.AdoptMigratedContainerResponse{NewIpAddress: "10.0.7.42"}, nil
+	})
+	defer prev()
+
+	if _, err := cs.MoveContainer(adminCtx(), &pb.MoveContainerRequest{
+		Username: "bob", TargetBackendId: "vm2",
+	}); err != nil {
+		t.Fatalf("MoveContainer: %v", err)
+	}
+
+	for _, call := range runner.calls {
+		if strings.Contains(call, "storage=") {
+			t.Errorf("an unencrypted migration passed a storage override (%q) — it would be "+
+				"pinned to a pool it never asked for", call)
+		}
+	}
+	if adopted == nil {
+		t.Fatal("adopt was never called")
+	}
+	if adopted.ZfsKeyRef != "" || adopted.ZfsPool != "" {
+		t.Errorf("an unencrypted adopt carried placement fields: ref=%q pool=%q",
+			adopted.ZfsKeyRef, adopted.ZfsPool)
+	}
+}
+
+// --- destination side --------------------------------------------------
+
+// The destination records what it was told, so a restarted daemon — or any
+// later start — can find the encryptionroot. Without this the container is
+// running but unopenable the moment it stops.
+func TestAdoptMigratedContainer_RecordsThePlacementItWasGiven(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}, pools: map[string]string{}}
+	s := &ContainerServer{encryption: testHooksWith(t, z, p, refs, newFakePools())}
+
+	err := s.recordAdoptedPlacement(&pb.AdoptMigratedContainerRequest{
+		Username:  "alice",
+		ZfsKeyRef: refJSON(t, "/keys/alice.key"),
+		ZfsPool:   "containarium-tenant-alice",
+	})
+	if err != nil {
+		t.Fatalf("recordAdoptedPlacement: %v", err)
+	}
+
+	if got := refs.refs["alice-container"]; got.URI != "/keys/alice.key" {
+		t.Errorf("stored ref = %+v, want alice's", got)
+	}
+	if got := refs.pools["alice-container"]; got != "containarium-tenant-alice" {
+		t.Errorf("stored pool = %q, want the tenant pool", got)
+	}
+}
+
+// An unencrypted adoption must not touch encryption state at all.
+func TestAdoptMigratedContainer_UnencryptedRecordsNothing(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}, pools: map[string]string{}}
+	s := &ContainerServer{encryption: testHooksWith(t, z, p, refs, newFakePools())}
+
+	if err := s.recordAdoptedPlacement(&pb.AdoptMigratedContainerRequest{Username: "bob"}); err != nil {
+		t.Fatalf("recordAdoptedPlacement: %v", err)
+	}
+	if len(refs.refs) != 0 || len(refs.pools) != 0 {
+		t.Errorf("an unencrypted adoption recorded encryption state: refs=%v pools=%v",
+			refs.refs, refs.pools)
+	}
+}
+
+// A ref that arrives without a pool (or the reverse) is a half-message. It
+// must fail rather than be recorded, because a container with a ref and no
+// pool refuses to start — and one with a pool and no ref reads as
+// unencrypted, which is the dangerous direction.
+//
+// NOTE, so this is not mistaken for a unit test of the explicit check in
+// recordAdoptedPlacement: it is not. Deleting that check leaves this test
+// passing, because both halves are refused anyway — a missing pool by
+// RecordPlacement (#1340), a missing ref by the JSON decode. What is asserted
+// here is the GUARANTEE, which is upheld by three independent mechanisms. The
+// explicit check earns its place only by naming which half is missing, which
+// the other two cannot.
+func TestAdoptMigratedContainer_RejectsAHalfMessage(t *testing.T) {
+	for _, tc := range []struct{ name, ref, pool string }{
+		{"ref without pool", `{"scheme":"file","uri":"/k"}`, ""},
+		{"pool without ref", "", "containarium-tenant-alice"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+			refs := &fakeRefStore{refs: map[string]zfskey.KeyRef{}, pools: map[string]string{}}
+			s := &ContainerServer{encryption: testHooksWith(t, z, p, refs, newFakePools())}
+
+			err := s.recordAdoptedPlacement(&pb.AdoptMigratedContainerRequest{
+				Username: "alice", ZfsKeyRef: tc.ref, ZfsPool: tc.pool,
+			})
+			if err == nil {
+				t.Fatal("a half-specified placement was accepted")
+			}
+			if len(refs.refs) != 0 || len(refs.pools) != 0 {
+				t.Errorf("state was recorded anyway: refs=%v pools=%v", refs.refs, refs.pools)
+			}
+		})
+	}
+}
+
+// A destination with no encryption wired that is handed an encrypted
+// container must refuse loudly. The pre-flight should have stopped this, so
+// reaching here means the source skipped it or the daemon changed underneath
+// — either way, recording nothing and reporting success would leave a
+// container nobody can unlock.
+func TestAdoptMigratedContainer_RefusesEncryptedWithoutEncryptionWired(t *testing.T) {
+	s := &ContainerServer{} // no hooks
+
+	err := s.recordAdoptedPlacement(&pb.AdoptMigratedContainerRequest{
+		Username:  "alice",
+		ZfsKeyRef: refJSON(t, "/keys/alice.key"),
+		ZfsPool:   "containarium-tenant-alice",
+	})
+	if err == nil {
+		t.Fatal("a daemon with no key custody accepted an encrypted container — it would run " +
+			"until its first stop and then never start again, with nothing recording why")
+	}
+}

--- a/internal/server/prepare_encrypted_migration.go
+++ b/internal/server/prepare_encrypted_migration.go
@@ -124,3 +124,50 @@ func (h *encryptionHooks) migrationRef(containerName string) (ref zfskey.KeyRef,
 	}
 	return ref, pool, true, nil
 }
+
+// recordAdoptedPlacement stores the encryption placement a migrated
+// container arrived with, so the destination can find its encryptionroot on
+// every later start.
+//
+// The source proved during the pre-flight that this daemon can resolve the
+// ref; what is recorded here is where the container actually landed. Without
+// it the container runs until its first stop and then never starts again,
+// with nothing on the container saying why.
+//
+// A no-op for an unencrypted migration, which is every migration today.
+func (s *ContainerServer) recordAdoptedPlacement(req *pb.AdoptMigratedContainerRequest) error {
+	refJSON, pool := req.GetZfsKeyRef(), req.GetZfsPool()
+	if refJSON == "" && pool == "" {
+		return nil // unencrypted; nothing to record
+	}
+	// Half a message is not something to record "as much as possible" of. A
+	// ref with no pool leaves a container that refuses to start; a pool with
+	// no ref reads as UNENCRYPTED, which is the direction that loses data
+	// silently rather than loudly.
+	if refJSON == "" || pool == "" {
+		return status.Errorf(codes.InvalidArgument,
+			"encrypted adoption of %s is missing half its placement (key_ref set: %t, pool set: %t); "+
+				"refusing rather than recording a container that cannot be unlocked or, worse, one "+
+				"that reads as unencrypted", req.GetUsername(), refJSON != "", pool != "")
+	}
+
+	if !s.encryption.enabled() {
+		return status.Errorf(codes.FailedPrecondition,
+			"this daemon has no key custody configured but was handed encrypted container %s; the "+
+				"migration pre-flight should have prevented this. Refusing rather than adopting a "+
+				"container nobody here can unlock", req.GetUsername())
+	}
+
+	var ref zfskey.KeyRef
+	if err := json.Unmarshal([]byte(refJSON), &ref); err != nil {
+		return status.Errorf(codes.InvalidArgument, "adopted key_ref is not a decodable KeyRef: %v", err)
+	}
+
+	containerName := fmt.Sprintf("%s-container", req.GetUsername())
+	if err := s.encryption.RecordPlacement(containerName, ref, pool); err != nil {
+		return fmt.Errorf("record the encryption placement of adopted container %s: %w", containerName, err)
+	}
+	log.Printf("[move] adopted %s under storage pool %s; its encryptionroot is that pool's source",
+		containerName, pool)
+	return nil
+}

--- a/pkg/core/incus/migration.go
+++ b/pkg/core/incus/migration.go
@@ -31,8 +31,14 @@ type MigrationRunner interface {
 	// up once via `incus remote add` on the source. The destination
 	// container takes the same name.
 	//
-	// Equivalent to: `incus copy <container>/<fromSnap> <remote>:<container> --instance-only`
-	CopyInitial(container, fromSnap, targetRemote string) error
+	// storagePool, when non-empty, pins the destination pool the copy
+	// lands in (`--storage`). Empty keeps Incus's own choice, which is the
+	// destination's default pool — correct for an unencrypted container and
+	// wrong for an encrypted one, whose data must land inside its tenant's
+	// encryptionroot (#1203).
+	//
+	// Equivalent to: `incus copy <container>/<fromSnap> <remote>:<container> --instance-only [--storage <pool>]`
+	CopyInitial(container, fromSnap, targetRemote, storagePool string) error
 
 	// CopyRefresh syncs the delta from the source's previous-state
 	// snapshot to `targetRemote`. Equivalent to:
@@ -40,7 +46,7 @@ type MigrationRunner interface {
 	// With ZFS/btrfs storage on both ends, this is a fast incremental
 	// (zfs-send-style); with dir-pool storage it falls back to file
 	// rsync, which works but isn't sub-second.
-	CopyRefresh(container, fromSnap, targetRemote string) error
+	CopyRefresh(container, fromSnap, targetRemote, storagePool string) error
 
 	// Stop stops a container. Used at the very start of cutover; any
 	// final state changes after this point are caught by the post-stop
@@ -109,16 +115,24 @@ func (e *ExecRunner) DeleteSnapshot(container, snapshot string) error {
 	return err
 }
 
-func (e *ExecRunner) CopyInitial(container, fromSnap, targetRemote string) error {
+func (e *ExecRunner) CopyInitial(container, fromSnap, targetRemote, storagePool string) error {
 	src := fmt.Sprintf("%s/%s", container, fromSnap)
 	dst := fmt.Sprintf("%s:%s", targetRemote, container)
-	return e.incus("copy", src, dst, "--instance-only")
+	args := []string{"copy", src, dst, "--instance-only"}
+	if storagePool != "" {
+		args = append(args, "--storage", storagePool)
+	}
+	return e.incus(args...)
 }
 
-func (e *ExecRunner) CopyRefresh(container, fromSnap, targetRemote string) error {
+func (e *ExecRunner) CopyRefresh(container, fromSnap, targetRemote, storagePool string) error {
 	src := fmt.Sprintf("%s/%s", container, fromSnap)
 	dst := fmt.Sprintf("%s:%s", targetRemote, container)
-	return e.incus("copy", src, dst, "--refresh")
+	args := []string{"copy", src, dst, "--refresh"}
+	if storagePool != "" {
+		args = append(args, "--storage", storagePool)
+	}
+	return e.incus(args...)
 }
 
 func (e *ExecRunner) Stop(container string) error {

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -4768,7 +4768,21 @@ type AdoptMigratedContainerRequest struct {
 	// container, so the destination can recreate them at its own
 	// container IP. Each entry is "<full-domain>|<port>|<protocol>".
 	// Empty for stateless containers with no exposed ports.
-	SourceRoutes  []string `protobuf:"bytes,2,rep,name=source_routes,json=sourceRoutes,proto3" json:"source_routes,omitempty"`
+	SourceRoutes []string `protobuf:"bytes,2,rep,name=source_routes,json=sourceRoutes,proto3" json:"source_routes,omitempty"`
+	// The source's stored KeyRef for an encrypted container, JSON-encoded.
+	// The destination records it so it can re-resolve the key on every
+	// later start, exactly as the source did. Empty for an unencrypted
+	// container, which is every container by default.
+	//
+	// A reference only — it carries no key bytes. The destination already
+	// proved it can resolve this ref during the pre-flight.
+	ZfsKeyRef string `protobuf:"bytes,3,opt,name=zfs_key_ref,json=zfsKeyRef,proto3" json:"zfs_key_ref,omitempty"`
+	// The destination storage pool the container was copied into — the one
+	// the pre-flight returned, sourced at this tenant's encryptionroot.
+	// The destination records it because the pool's source IS the
+	// container's encryptionroot, and every later start has to find it.
+	// Empty for an unencrypted container.
+	ZfsPool       string `protobuf:"bytes,4,opt,name=zfs_pool,json=zfsPool,proto3" json:"zfs_pool,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4815,6 +4829,20 @@ func (x *AdoptMigratedContainerRequest) GetSourceRoutes() []string {
 		return x.SourceRoutes
 	}
 	return nil
+}
+
+func (x *AdoptMigratedContainerRequest) GetZfsKeyRef() string {
+	if x != nil {
+		return x.ZfsKeyRef
+	}
+	return ""
+}
+
+func (x *AdoptMigratedContainerRequest) GetZfsPool() string {
+	if x != nil {
+		return x.ZfsPool
+	}
+	return ""
 }
 
 // PrepareEncryptedMigrationRequest asks a destination daemon whether it
@@ -5369,10 +5397,12 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x0enew_ip_address\x18\x02 \x01(\tR\fnewIpAddress\x12*\n" +
 	"\x11target_backend_id\x18\x03 \x01(\tR\x0ftargetBackendId\x12%\n" +
 	"\x0eiterations_run\x18\x04 \x01(\x05R\riterationsRun\x12)\n" +
-	"\x10downtime_seconds\x18\x05 \x01(\x05R\x0fdowntimeSeconds\"`\n" +
+	"\x10downtime_seconds\x18\x05 \x01(\x05R\x0fdowntimeSeconds\"\x9b\x01\n" +
 	"\x1dAdoptMigratedContainerRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12#\n" +
-	"\rsource_routes\x18\x02 \x03(\tR\fsourceRoutes\"o\n" +
+	"\rsource_routes\x18\x02 \x03(\tR\fsourceRoutes\x12\x1e\n" +
+	"\vzfs_key_ref\x18\x03 \x01(\tR\tzfsKeyRef\x12\x19\n" +
+	"\bzfs_pool\x18\x04 \x01(\tR\azfsPool\"o\n" +
 	" PrepareEncryptedMigrationRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x16\n" +
 	"\x06tenant\x18\x02 \x01(\tR\x06tenant\x12\x17\n" +

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -1194,6 +1194,22 @@ message AdoptMigratedContainerRequest {
   // container IP. Each entry is "<full-domain>|<port>|<protocol>".
   // Empty for stateless containers with no exposed ports.
   repeated string source_routes = 2;
+
+  // The source's stored KeyRef for an encrypted container, JSON-encoded.
+  // The destination records it so it can re-resolve the key on every
+  // later start, exactly as the source did. Empty for an unencrypted
+  // container, which is every container by default.
+  //
+  // A reference only — it carries no key bytes. The destination already
+  // proved it can resolve this ref during the pre-flight.
+  string zfs_key_ref = 3;
+
+  // The destination storage pool the container was copied into — the one
+  // the pre-flight returned, sourced at this tenant's encryptionroot.
+  // The destination records it because the pool's source IS the
+  // container's encryptionroot, and every later start has to find it.
+  // Empty for an unencrypted container.
+  string zfs_pool = 4;
 }
 
 // PrepareEncryptedMigrationRequest asks a destination daemon whether it


### PR DESCRIPTION
Closes #1203 — the half #1360 left. Design: `docs/architecture/per-tenant-encrypted-storage-pools.md`.

## This closes a gap #1360 opened

#1360 made the destination provision the tenant's pool and hand back its name. **Nothing consumed it.** `incus copy` still ran without `--storage`, so the container landed on the destination's *default* pool — outside the tenant's encryptionroot, unencrypted — while the pre-flight had just reported the migration safe.

The outcome was no worse than before #1360 (an encrypted container always arrived unencrypted). What was new is the **false reassurance**: a green pre-flight in front of a migration that still lands wrong. That is the shape of failure this whole feature exists to prevent, so it should not sit on `main` between two PRs.

## What changes

- **Every copy targets the pool the pre-flight named** — including the *final cutover copy*, which carries the last delta. A copy that forgot the pool there would leave the container's freshest state on the wrong dataset.
- **A destination that accepts an encrypted container but names no pool is refused**, rather than copied to the default.
- **The adopt request carries the `KeyRef` and the pool**, and the destination records both — otherwise the container runs until its first stop and then never starts again, with nothing on it saying why. Recording happens **before** any host-side state is created, so a refusal leaves nothing behind.
- **Unencrypted migrations are untouched**: no `--storage`, no placement fields.

## Test evidence

CI run linked in a follow-up comment. 20 move/adopt/pre-flight tests green, including the 5 pre-existing orchestration tests.

The `--storage` assertion is on the command that would actually run: the fake runner appends `storage=` **only when a pool is given**, mirroring the real flag, so "unencrypted is byte-identical" is asserted rather than assumed.

**Mutation-verified** — the final cutover copy dropping the pool:

```
copy "refresh alice-container/containarium-move-final -> vm2" did not target the tenant pool
  — the container lands on the destination's default pool, outside its encryptionroot, and
    arrives unencrypted while the pre-flight said the migration was safe
```

## Two things about my own testing, since neither is visible in the diff

**A mutation that reported a false negative.** My first attempt appended `// BREAK` inside an `if err := …;` statement, which broke the build; `go test` printed a compile error that my grep filtered out, so the mutation looked like "the test cannot fail". It can — shown above. A mutation that doesn't compile proves nothing, and looks exactly like a mutation that proves the test is weak.

**One guard is redundant, and the test does not isolate it.** `TestAdoptMigratedContainer_RejectsAHalfMessage` passes even with the explicit half-message check deleted, because both halves are already refused — a missing pool by `RecordPlacement` (#1340), a missing ref by the JSON decode. The guarantee holds three ways; the explicit check earns its place only by naming *which* half is missing. That is now written into the test so the next reader does not mistake it for a unit test of that branch.

## AC1 still needs a deployed environment

*"MoveContainer works end-to-end for an encrypted dataset"* needs two daemons, two Incus instances and an `incus remote` between them. The lane builds one Incus per run. #1203 carries `needs-verification` with the steps:

**Verify on dev:** two backends with an `incus remote` between them; `create alice --encrypted` on A; `move alice --target-backend B`; on B, `zfs get encryptionroot <pool>/tenants/alice/containers/alice-container` → alice's tenant root, **not** B's default pool; then stop it and confirm `keystatus` is `unavailable`. Negative: point A at a B with no key custody and confirm the pre-flight refuses before any data moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)