### PR TITLE
ci: exercise the daemon binary and its flags on the Incus lane

### DIFF
--- a/.github/workflows/incus-create.yml
+++ b/.github/workflows/incus-create.yml
@@ -223,6 +223,11 @@ jobs:
                     --expiry 24h --secret "$JWT_SECRET" | tr -d " \t" | grep -E "^ey" | head -1)
           test -n "$TOKEN" || { echo "::error::could not mint a token"; exit 1; }
           export CONTAINARIUM_TOKEN="$TOKEN"
+          # CONTAINARIUM_HTTP is what actually selects the REST surface. An
+          # http:// address alone does not: the CLI dispatches on this flag,
+          # so without it every call goes down the gRPC path and asks for a
+          # client certificate bundle that does not exist here.
+          export CONTAINARIUM_HTTP=true
           SERVER="http://localhost:8080"
 
           # Readiness: the daemon answers a real RPC. Both the daemon's log
@@ -286,6 +291,11 @@ jobs:
           TOKEN=$(/tmp/containarium token generate --username admin --roles admin \
                     --expiry 24h --secret "$JWT_SECRET" | tr -d " \t" | grep -E "^ey" | head -1)
           export CONTAINARIUM_TOKEN="$TOKEN"
+          # CONTAINARIUM_HTTP is what actually selects the REST surface. An
+          # http:// address alone does not: the CLI dispatches on this flag,
+          # so without it every call goes down the gRPC path and asks for a
+          # client certificate bundle that does not exist here.
+          export CONTAINARIUM_HTTP=true
           SERVER="http://localhost:8080"
 
           ready=""

--- a/.github/workflows/incus-create.yml
+++ b/.github/workflows/incus-create.yml
@@ -266,8 +266,14 @@ jobs:
           esac
 
           # And a stopped container is ciphertext: the key unloads.
-          /tmp/containarium --server "$SERVER" stop "$TENANT" || true
-          sleep 5
+          #
+          # `sleep` is the container-level stop; `stop` is `app stop`, for an
+          # app inside a box. Getting that wrong left the container running
+          # and the assertion below correctly reported the key as still
+          # loaded — a real-looking encryption failure caused by the wrong
+          # verb.
+          /tmp/containarium --server "$SERVER" sleep "$TENANT"
+          sleep 10
           STATUS=$(sudo zfs get -H -o value keystatus "$ROOT")
           echo "keystatus after stop: $STATUS"
           test "$STATUS" = "unavailable" || {

--- a/.github/workflows/incus-create.yml
+++ b/.github/workflows/incus-create.yml
@@ -196,35 +196,48 @@ jobs:
       # v0.66.0 unverified: flag -> KeyProvider -> encrypted create only
       # assembles on a running daemon, and nothing in CI assembled one.
       #
-      # Asserted against the HOST's ZFS state rather than the daemon's report
-      # of itself: a daemon claiming success is the thing under test.
+      # Reached over the REST surface with a JWT rather than gRPC+mTLS: the
+      # CLI looks for a client certificate bundle against a gRPC address even
+      # when the daemon has mTLS off, and generating a CA here would test the
+      # certificate tooling rather than the encrypted-create path.
+      #
+      # Asserted against the HOST's ZFS state, never the daemon's report of
+      # itself — a daemon claiming success is the thing under test.
       - name: Create an encrypted container through the daemon and its flags
+        env:
+          JWT_SECRET: lane-only-secret-not-a-credential
         run: |
           set -euo pipefail
           go build -o /tmp/containarium ./cmd/containarium
           sudo mkdir -p /etc/containarium/keys
 
           # --standalone skips the core LXCs (Postgres, Caddy). With no
-          # Postgres reachable the daemon waits ~2 minutes and then proceeds
-          # with those services disabled, which is fine here — none of them
-          # are on the encrypted-create path.
-          sudo /tmp/containarium daemon --standalone \
+          # Postgres reachable the daemon waits ~2 minutes and proceeds with
+          # those services disabled; none are on the encrypted-create path.
+          sudo /tmp/containarium daemon --standalone --rest \
+            --jwt-secret "$JWT_SECRET" \
             --zfs-keys-dir=/etc/containarium/keys \
             > /tmp/daemon.log 2>&1 &
 
-          # Readiness: the daemon answers RPCs. There is no health endpoint on
-          # the gRPC surface, so ask it something real.
+          TOKEN=$(/tmp/containarium token generate --username admin --roles admin \
+                    --expiry 24h --secret "$JWT_SECRET" | tr -d " \t" | grep -E "^ey" | head -1)
+          test -n "$TOKEN" || { echo "::error::could not mint a token"; exit 1; }
+          export CONTAINARIUM_TOKEN="$TOKEN"
+          SERVER="http://localhost:8080"
+
+          # Readiness: the daemon answers a real RPC. Both the daemon's log
+          # and the CLIENT's error are printed on failure — the first attempt
+          # at this printed only the daemon's, which said it was serving,
+          # turning "the client cannot authenticate" into "the daemon is
+          # broken". Those lead to opposite investigations.
           ready=""
           for i in $(seq 1 60); do
-            if sudo /tmp/containarium --server localhost:50051 list >/tmp/probe.log 2>&1; then
+            if /tmp/containarium --server "$SERVER" list >/tmp/probe.log 2>&1; then
               ready=yes; break
             fi
             sleep 5
           done
           if [ -z "$ready" ]; then
-            # The daemon's own log and the CLIENT's error are different
-            # stories, and the first attempt at this hid the second. Print
-            # both: "never became ready" is not a diagnosis.
             echo "::error::the daemon never answered the CLI"
             echo "--- last CLI probe ---"; cat /tmp/probe.log || true
             echo "--- daemon log tail ---"; tail -40 /tmp/daemon.log
@@ -233,13 +246,13 @@ jobs:
           grep -E "\[encryption\]" /tmp/daemon.log || true
 
           TENANT="lane$$"
-          sudo /tmp/containarium --server localhost:50051 create "$TENANT" \
+          /tmp/containarium --server "$SERVER" create "$TENANT" \
             --no-ssh-key --podman=false --disk 5GB --encrypted
 
-          # The claim, checked on the host. The instance must sit under the
+          # The claim, checked on the host: the instance sits under the
           # TENANT's encryptionroot, not the pool default.
           DS=$(sudo zfs list -H -o name -r | grep "/containers/${TENANT}-container$" | head -1)
-          test -n "$DS" || { echo "::error::no dataset for ${TENANT}-container"; exit 1; }
+          test -n "$DS" || { echo "::error::no dataset for ${TENANT}-container"; sudo zfs list -r; exit 1; }
           ROOT=$(sudo zfs get -H -o value encryptionroot "$DS")
           echo "instance $DS has encryptionroot $ROOT"
           case "$ROOT" in
@@ -247,25 +260,37 @@ jobs:
             *) echo "::error::encryptionroot is $ROOT — the container is not under its tenant's key"; exit 1 ;;
           esac
 
-          # And a stopped container must be ciphertext: the key unloads.
-          sudo /tmp/containarium --server localhost:50051 stop "$TENANT" || true
+          # And a stopped container is ciphertext: the key unloads.
+          /tmp/containarium --server "$SERVER" stop "$TENANT" || true
           sleep 5
           STATUS=$(sudo zfs get -H -o value keystatus "$ROOT")
           echo "keystatus after stop: $STATUS"
+          test "$STATUS" = "unavailable" || {
+            echo "::error::the tenant key is still $STATUS after its last container stopped — a stopped container is NOT ciphertext at rest"; exit 1; }
 
-          sudo /tmp/containarium --server localhost:50051 delete "$TENANT" --force || true
+          /tmp/containarium --server "$SERVER" delete "$TENANT" --force || true
           sudo pkill -f "containarium daemon" || true
+          sleep 3
 
       # The closed default is the promise every OSS daemon ships with, so it
       # gets an assertion rather than trust: without the flag, the same create
-      # must be refused.
+      # must be refused, and refused for the documented reason.
       - name: Without --zfs-keys-dir the same create is refused
+        env:
+          JWT_SECRET: lane-only-secret-not-a-credential
         run: |
           set -euo pipefail
-          sudo /tmp/containarium daemon --standalone > /tmp/daemon-nokeys.log 2>&1 &
+          sudo /tmp/containarium daemon --standalone --rest \
+            --jwt-secret "$JWT_SECRET" > /tmp/daemon-nokeys.log 2>&1 &
+
+          TOKEN=$(/tmp/containarium token generate --username admin --roles admin \
+                    --expiry 24h --secret "$JWT_SECRET" | tr -d " \t" | grep -E "^ey" | head -1)
+          export CONTAINARIUM_TOKEN="$TOKEN"
+          SERVER="http://localhost:8080"
+
           ready=""
           for i in $(seq 1 60); do
-            if sudo /tmp/containarium --server localhost:50051 list >/tmp/probe2.log 2>&1; then
+            if /tmp/containarium --server "$SERVER" list >/tmp/probe2.log 2>&1; then
               ready=yes; break
             fi
             sleep 5
@@ -276,14 +301,14 @@ jobs:
             tail -40 /tmp/daemon-nokeys.log; exit 1
           fi
 
-          if sudo /tmp/containarium --server localhost:50051 create "nokeys$$" \
+          if /tmp/containarium --server "$SERVER" create "nokeys$$" \
                --no-ssh-key --podman=false --disk 5GB --encrypted > /tmp/refusal.log 2>&1; then
             echo "::error::an encrypted create SUCCEEDED on a daemon with no key custody — the closed default regressed"
             exit 1
           fi
           grep -qi "keyprovider" /tmp/refusal.log || {
             echo "::error::refused, but not for the documented reason:"; cat /tmp/refusal.log; exit 1; }
-          echo "closed default holds: $(head -2 /tmp/refusal.log)"
+          echo "closed default holds: $(head -3 /tmp/refusal.log)"
           sudo pkill -f "containarium daemon" || true
 
       # A skip here means the environment check above passed and the test

--- a/.github/workflows/incus-create.yml
+++ b/.github/workflows/incus-create.yml
@@ -216,14 +216,18 @@ jobs:
           # the gRPC surface, so ask it something real.
           ready=""
           for i in $(seq 1 60); do
-            if sudo /tmp/containarium --server localhost:50051 list >/dev/null 2>&1; then
+            if sudo /tmp/containarium --server localhost:50051 list >/tmp/probe.log 2>&1; then
               ready=yes; break
             fi
             sleep 5
           done
           if [ -z "$ready" ]; then
-            echo "::error::the daemon never became ready"
-            tail -50 /tmp/daemon.log
+            # The daemon's own log and the CLIENT's error are different
+            # stories, and the first attempt at this hid the second. Print
+            # both: "never became ready" is not a diagnosis.
+            echo "::error::the daemon never answered the CLI"
+            echo "--- last CLI probe ---"; cat /tmp/probe.log || true
+            echo "--- daemon log tail ---"; tail -40 /tmp/daemon.log
             exit 1
           fi
           grep -E "\[encryption\]" /tmp/daemon.log || true
@@ -261,13 +265,15 @@ jobs:
           sudo /tmp/containarium daemon --standalone > /tmp/daemon-nokeys.log 2>&1 &
           ready=""
           for i in $(seq 1 60); do
-            if sudo /tmp/containarium --server localhost:50051 list >/dev/null 2>&1; then
+            if sudo /tmp/containarium --server localhost:50051 list >/tmp/probe2.log 2>&1; then
               ready=yes; break
             fi
             sleep 5
           done
           if [ -z "$ready" ]; then
-            echo "::error::the daemon never became ready"; tail -50 /tmp/daemon-nokeys.log; exit 1
+            echo "::error::the daemon never answered the CLI"
+            echo "--- last CLI probe ---"; cat /tmp/probe2.log || true
+            tail -40 /tmp/daemon-nokeys.log; exit 1
           fi
 
           if sudo /tmp/containarium --server localhost:50051 create "nokeys$$" \

--- a/.github/workflows/incus-create.yml
+++ b/.github/workflows/incus-create.yml
@@ -189,6 +189,97 @@ jobs:
           sudo -E env "PATH=$PATH" go test -tags=incus -v -count=1 -timeout 40m \
             ./pkg/core/box/lxc/ ./pkg/core/incus/ ./internal/server/ -run 'TestIntegrationIncus' | tee incus-test.log
 
+      # #1368 — the daemon BINARY, with its flags.
+      #
+      # Everything above drives Go packages. That is why #1342
+      # (--zfs-keys-dir) had to be labelled needs-verification and shipped in
+      # v0.66.0 unverified: flag -> KeyProvider -> encrypted create only
+      # assembles on a running daemon, and nothing in CI assembled one.
+      #
+      # Asserted against the HOST's ZFS state rather than the daemon's report
+      # of itself: a daemon claiming success is the thing under test.
+      - name: Create an encrypted container through the daemon and its flags
+        run: |
+          set -euo pipefail
+          go build -o /tmp/containarium ./cmd/containarium
+          sudo mkdir -p /etc/containarium/keys
+
+          # --standalone skips the core LXCs (Postgres, Caddy). With no
+          # Postgres reachable the daemon waits ~2 minutes and then proceeds
+          # with those services disabled, which is fine here — none of them
+          # are on the encrypted-create path.
+          sudo /tmp/containarium daemon --standalone \
+            --zfs-keys-dir=/etc/containarium/keys \
+            > /tmp/daemon.log 2>&1 &
+
+          # Readiness: the daemon answers RPCs. There is no health endpoint on
+          # the gRPC surface, so ask it something real.
+          ready=""
+          for i in $(seq 1 60); do
+            if sudo /tmp/containarium --server localhost:50051 list >/dev/null 2>&1; then
+              ready=yes; break
+            fi
+            sleep 5
+          done
+          if [ -z "$ready" ]; then
+            echo "::error::the daemon never became ready"
+            tail -50 /tmp/daemon.log
+            exit 1
+          fi
+          grep -E "\[encryption\]" /tmp/daemon.log || true
+
+          TENANT="lane$$"
+          sudo /tmp/containarium --server localhost:50051 create "$TENANT" \
+            --no-ssh-key --podman=false --disk 5GB --encrypted
+
+          # The claim, checked on the host. The instance must sit under the
+          # TENANT's encryptionroot, not the pool default.
+          DS=$(sudo zfs list -H -o name -r | grep "/containers/${TENANT}-container$" | head -1)
+          test -n "$DS" || { echo "::error::no dataset for ${TENANT}-container"; exit 1; }
+          ROOT=$(sudo zfs get -H -o value encryptionroot "$DS")
+          echo "instance $DS has encryptionroot $ROOT"
+          case "$ROOT" in
+            */tenants/"$TENANT") ;;
+            *) echo "::error::encryptionroot is $ROOT — the container is not under its tenant's key"; exit 1 ;;
+          esac
+
+          # And a stopped container must be ciphertext: the key unloads.
+          sudo /tmp/containarium --server localhost:50051 stop "$TENANT" || true
+          sleep 5
+          STATUS=$(sudo zfs get -H -o value keystatus "$ROOT")
+          echo "keystatus after stop: $STATUS"
+
+          sudo /tmp/containarium --server localhost:50051 delete "$TENANT" --force || true
+          sudo pkill -f "containarium daemon" || true
+
+      # The closed default is the promise every OSS daemon ships with, so it
+      # gets an assertion rather than trust: without the flag, the same create
+      # must be refused.
+      - name: Without --zfs-keys-dir the same create is refused
+        run: |
+          set -euo pipefail
+          sudo /tmp/containarium daemon --standalone > /tmp/daemon-nokeys.log 2>&1 &
+          ready=""
+          for i in $(seq 1 60); do
+            if sudo /tmp/containarium --server localhost:50051 list >/dev/null 2>&1; then
+              ready=yes; break
+            fi
+            sleep 5
+          done
+          if [ -z "$ready" ]; then
+            echo "::error::the daemon never became ready"; tail -50 /tmp/daemon-nokeys.log; exit 1
+          fi
+
+          if sudo /tmp/containarium --server localhost:50051 create "nokeys$$" \
+               --no-ssh-key --podman=false --disk 5GB --encrypted > /tmp/refusal.log 2>&1; then
+            echo "::error::an encrypted create SUCCEEDED on a daemon with no key custody — the closed default regressed"
+            exit 1
+          fi
+          grep -qi "keyprovider" /tmp/refusal.log || {
+            echo "::error::refused, but not for the documented reason:"; cat /tmp/refusal.log; exit 1; }
+          echo "closed default holds: $(head -2 /tmp/refusal.log)"
+          sudo pkill -f "containarium daemon" || true
+
       # A skip here means the environment check above passed and the test
       # decided otherwise — a contradiction worth failing on rather than
       # quietly reporting green (#1234).


### PR DESCRIPTION
Closes #1368. **Draft** — this is a timeboxed attempt, and its CI result is the deliverable either way.

## The gap it closes

Everything on this lane drives Go packages. That is exactly why #1342 (`--zfs-keys-dir`) carries `needs-verification`, and why it **shipped in v0.66.0 unverified**: flag → `KeyProvider` → encrypted create only assembles on a running daemon, and nothing in CI assembled one.

That gap is not specific to #1342. Every future daemon flag lands in the same queue — a queue that has been ⏳ since 08-13 because the deploy that clears it cannot be run from the engineering environment.

## Feasibility was checked before writing

| Concern | Reality |
| --- | --- |
| Needs Postgres | Optional — with no DSN the daemon waits ~2 min, then proceeds with those services disabled. None are on the encrypted-create path. |
| Needs core LXCs | `--standalone` skips them. |
| Needs mTLS/tokens | mTLS is off by default; the CLI takes `--server`. |

The hard part — a real Incus on a real ZFS pool — already exists, from #1332.

## What it asserts

1. **The daemon with `--zfs-keys-dir`** creates an encrypted container *through the CLI*, and the instance's `encryptionroot` is checked **on the host** — a daemon reporting its own success is the thing under test, so it does not get to be the witness.
2. **Without the flag, the same create is refused** — and refused *for the documented reason* (the message must name the `KeyProvider`), not merely non-zero. The closed default is the promise every OSS daemon ships with; it should not be able to regress quietly.

## Timebox

**One day**, per #1368. If the daemon cannot be brought up in a hosted runner, I close it with the specific failure recorded — which step, which error — and #1342's operator-verification requirement becomes evidence-backed rather than a default assumption. That outcome is a success for the issue: it is the bargain #1332 made, and #1332 paid for itself several times over in this sprint.

Draft until the lane reports, because a red run here is a finding rather than a broken PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)