### PR TITLE
feat(zfs): RewrapContainer — control-plane-driven key rotation

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -2595,6 +2595,47 @@
         ]
       }
     },
+    "/v1/containers/{username}/rewrap": {
+      "post": {
+        "summary": "Rotate a tenant's encryption key",
+        "description": "Rewraps the tenant's ZFS encryptionroot onto new key material supplied as a key reference. Only the wrapping key changes, so the cost is independent of dataset size. Affects every container the tenant owns, which the response lists. Admin only.",
+        "operationId": "ContainerService_RewrapContainer",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/RewrapContainerResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpc.Status"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "username",
+            "description": "The container whose tenant's key is being rotated.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RewrapContainerBody"
+            }
+          }
+        ],
+        "tags": [
+          "Container Operations"
+        ]
+      }
+    },
     "/v1/containers/{username}/ssh-keys": {
       "post": {
         "summary": "Add SSH key",
@@ -11073,6 +11114,37 @@
           "description": "Human-readable confirmation, intended for CLI output."
         }
       }
+    },
+    "RewrapContainerBody": {
+      "type": "object",
+      "properties": {
+        "newKeyRef": {
+          "type": "string",
+          "description": "The NEW key reference, JSON-encoded, already provisioned by whoever\nowns key custody. The daemon resolves it through its own KeyProvider —\nkey material never crosses this wire, exactly as at create time.\n\nRotation is control-plane-driven (design resolved decision #5): the\ndaemon exposes the primitive and holds no rotation schedule of its own."
+        }
+      },
+      "description": "RewrapContainerRequest rotates the key protecting a container's data\n(#1204), driven by the control plane during a maintenance window.\n\nIMPORTANT: rotation is per-TENANT, not per-container. A tenant's\ncontainers share one encryptionroot by design (#1199), so rewrapping the\ncontainer named here rotates the key for every container that tenant\nowns. The RPC is named for a container because that is what a caller\nholds; the response says how many containers were affected so the caller\ncannot be surprised by it."
+    },
+    "RewrapContainerResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "Human-readable summary."
+        },
+        "rewrappedContainers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Every container now protected by the new key — the whole tenant, not\njust the one named in the request."
+        },
+        "restarted": {
+          "type": "boolean",
+          "description": "Whether the named container was running before the rotation and has\nbeen started again afterwards."
+        }
+      },
+      "description": "RewrapContainerResponse reports the outcome of a rotation."
     },
     "RouteEvent": {
       "type": "object",

--- a/internal/server/encrypted_create.go
+++ b/internal/server/encrypted_create.go
@@ -99,6 +99,17 @@ func (s *ContainerServer) SetEncryptionStorage(tenantRoot string, client *incus.
 				}
 				return cfg[key], nil
 			},
+			listNames: func() ([]string, error) {
+				infos, err := client.ListContainers()
+				if err != nil {
+					return nil, err
+				}
+				names := make([]string, 0, len(infos))
+				for i := range infos {
+					names = append(names, infos[i].Name)
+				}
+				return names, nil
+			},
 		},
 		incusStoragePools{
 			createPool: client.CreateZFSPool,

--- a/internal/server/encryption_hooks.go
+++ b/internal/server/encryption_hooks.go
@@ -447,6 +447,10 @@ func tenantFromRef(ref zfskey.KeyRef, containerName string) string {
 type incusEncryptionState struct {
 	setConfig func(containerName, key, value string) error
 	getConfig func(containerName, key string) (string, error)
+	// listNames enumerates every container this daemon knows about. Only
+	// rotation needs it (#1204) — the create, start and migration paths all
+	// address one container by name.
+	listNames func() ([]string, error)
 }
 
 func (s incusEncryptionState) GetKeyRef(containerName string) (zfskey.KeyRef, bool, error) {
@@ -496,4 +500,35 @@ func (p incusStoragePools) CreateZFSPool(name, source string) error {
 
 func (p incusStoragePools) StoragePoolSource(name string) (string, bool, error) {
 	return p.poolSource(name)
+}
+
+// ListEncrypted returns the containers carrying a key ref, so a rotation can
+// be recorded against every container sharing an encryptionroot (#1204).
+//
+// Reads the ref rather than trusting a naming convention: a container is
+// encrypted if and only if it records a key, which is the same test every
+// other hook applies.
+func (s incusEncryptionState) ListEncrypted() ([]string, error) {
+	if s.listNames == nil {
+		return nil, fmt.Errorf("this daemon cannot enumerate containers")
+	}
+	names, err := s.listNames()
+	if err != nil {
+		return nil, err
+	}
+	var encrypted []string
+	for _, name := range names {
+		raw, err := s.getConfig(name, keyRefConfigKey)
+		if err != nil {
+			// One unreadable container must not hide the rest; the caller
+			// re-keys what it can see and the omission surfaces as that
+			// container failing to start, which is loud.
+			log.Printf("[encryption] could not read the key ref of %s while enumerating: %v", name, err)
+			continue
+		}
+		if raw != "" {
+			encrypted = append(encrypted, name)
+		}
+	}
+	return encrypted, nil
 }

--- a/internal/server/encryption_hooks_integration_test.go
+++ b/internal/server/encryption_hooks_integration_test.go
@@ -395,3 +395,65 @@ func TestIntegrationEncryption_EnsureTenantStorageLeavesNothingWhenKeysAreUnavai
 			"for this container fails on a name that already exists", dataset)
 	}
 }
+
+// #1204 AC1 and AC3, against a real pool: rotation completes, the new key
+// opens the dataset, and **the old key stops working**.
+//
+// The negative is the whole point. A rewrap that silently left the old key
+// valid would look identical to a successful rotation from the daemon's
+// side — same exit code, same recorded ref — while the key the control plane
+// just retired still opened the data. Only ZFS can answer whether the old
+// key was actually retired, so only a real pool can assert it.
+func TestIntegrationEncryption_RotationRetiresTheOldKey(t *testing.T) {
+	ctx := context.Background()
+	h := newHarness(t)
+
+	// A tenant with its encryptionroot, provisioned through the hook.
+	pool, _, err := h.hooks.EnsureTenantStorage(ctx, "acme")
+	if err != nil {
+		t.Fatalf("EnsureTenantStorage: %v", err)
+	}
+	root := h.pool.Dataset("acme")
+	if _, ok := h.pools.sources[pool]; !ok {
+		t.Fatalf("no pool source recorded for %s", pool)
+	}
+
+	oldKey, _, err := h.keys.Wrap(ctx, "acme")
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+
+	// Rotate onto fresh material. In production the control plane provisions
+	// this and passes only its ref; here the harness plays that part.
+	newKeys, err := zfskey.NewFileKeyProvider(filepath.Join(t.TempDir(), "rotated"))
+	if err != nil {
+		t.Fatalf("NewFileKeyProvider: %v", err)
+	}
+	newKey, _, err := newKeys.Wrap(ctx, "acme")
+	if err != nil {
+		t.Fatalf("Wrap(new): %v", err)
+	}
+
+	if err := h.hooks.zfs.ChangeKey(ctx, root, newKey); err != nil {
+		t.Fatalf("ChangeKey on %s: %v", root, err)
+	}
+
+	// Unload so the next load has to actually unwrap rather than answer from
+	// the already-loaded key.
+	zfspool.UnmountIfMounted(t, root)
+	if err := h.hooks.zfs.UnloadKey(ctx, root); err != nil {
+		t.Fatalf("UnloadKey: %v", err)
+	}
+
+	// AC3: the retired key must be refused.
+	if err := h.hooks.zfs.LoadKey(ctx, root, oldKey); err == nil {
+		t.Fatal("the OLD key still opens the dataset after rotation — the control plane would " +
+			"retire a key that still grants access, which is worse than not rotating at all")
+	}
+
+	// AC1: the new key opens it.
+	if err := h.hooks.zfs.LoadKey(ctx, root, newKey); err != nil {
+		t.Fatalf("the new key does not open the rotated dataset: %v — the tenant's data is now "+
+			"unreachable by either key, which is the one outcome rotation must never produce", err)
+	}
+}

--- a/internal/server/encryption_hooks_test.go
+++ b/internal/server/encryption_hooks_test.go
@@ -96,6 +96,19 @@ func (f *fakeRefStore) SetPool(name, pool string) error {
 	return nil
 }
 
+// ListEncrypted lets the rotation path enumerate the containers sharing an
+// encryptionroot (#1204).
+func (f *fakeRefStore) ListEncrypted() ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	names := make([]string, 0, len(f.refs))
+	for name := range f.refs {
+		names = append(names, name)
+	}
+	return names, nil
+}
+
 // fakePools stands in for the Incus storage-pool API. It records what was
 // created so a test can tell "reused an existing pool" from "made a second
 // one" — the difference between a tenant having one encryptionroot and two.

--- a/internal/server/rewrap_container.go
+++ b/internal/server/rewrap_container.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sort"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Control-plane-driven key rotation (#1204), design phase 6 / resolved
+// decision #5.
+//
+// The daemon exposes the primitive and holds no schedule: rotation cadence
+// is tenant policy (90d, 1y, on-incident) owned by whoever owns the tenancy
+// database. OSS ships no rotation scheduler.
+//
+// Rewrapping changes only the WRAPPING key. ZFS re-encrypts the dataset's
+// master key, never the data, so a rotation costs the same on a 1 TB dataset
+// as on a 1 GB one — which is what makes this a maintenance-window operation
+// rather than a migration.
+
+// RewrapContainer rotates the key protecting a container's data.
+//
+// Rotation is per-TENANT even though the RPC names a container: a tenant's
+// containers share one encryptionroot by design (#1199), so rewrapping it
+// re-keys all of them. The response lists every container affected, because
+// a caller who believes they rotated one container's key will plan their
+// next maintenance window wrongly.
+func (s *ContainerServer) RewrapContainer(ctx context.Context, req *pb.RewrapContainerRequest) (*pb.RewrapContainerResponse, error) {
+	if req.GetUsername() == "" {
+		return nil, status.Error(codes.InvalidArgument, "username is required")
+	}
+	if req.GetNewKeyRef() == "" {
+		return nil, status.Error(codes.InvalidArgument, "new_key_ref is required")
+	}
+	// Rotating a tenant's key custody is an infrastructure operation, not a
+	// tenant one — the same gate MoveContainer uses. A tenant holding their
+	// own container must not be able to re-key it.
+	if err := auth.RequireRole(ctx, auth.RoleAdmin); err != nil {
+		return nil, err
+	}
+	if err := auth.AuthorizeTenant(ctx, req.GetUsername()); err != nil {
+		return nil, err
+	}
+
+	var newRef zfskey.KeyRef
+	if err := json.Unmarshal([]byte(req.GetNewKeyRef()), &newRef); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "new_key_ref is not a decodable KeyRef: %v", err)
+	}
+
+	containerName := fmt.Sprintf("%s-container", req.GetUsername())
+	root, _, encrypted, err := s.encryption.encryptionRootFor(containerName)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "resolve encryption state for %s: %v", containerName, err)
+	}
+	if !encrypted {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"%s is not encrypted, so it has no key to rotate", containerName)
+	}
+
+	// Resolve the NEW key before touching anything. Rewrapping onto a key
+	// this daemon cannot fetch again would make the data unreachable at the
+	// next start, which is indistinguishable from having lost it.
+	newKey, err := s.encryption.provider.Load(ctx, newRef)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"cannot resolve the new key for %s, so nothing was rotated: %v", containerName, err)
+	}
+
+	// ORDER IS THE WHOLE OF #1204 AC2. The rewrap happens first and the refs
+	// are updated only once ZFS confirms it.
+	//
+	// Recording the new ref first would mean a failure between the two steps
+	// leaves the dataset wrapped by the OLD key while every container records
+	// the NEW one — and then neither key starts them. Recording afterwards
+	// means a failure leaves old-wrapped and old-recorded: still exactly one
+	// working key, which is the guarantee.
+	if err := s.encryption.zfs.ChangeKey(ctx, root, newKey); err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"rotating the key for %s failed and nothing was changed; the previous key is still the "+
+				"one that works: %v", root, err)
+	}
+
+	// From here the dataset is on the new key. Any container still recording
+	// the old ref would fail to start, so a failure below is reported loudly
+	// rather than swallowed.
+	rewrapped, err := s.encryption.recordRotation(root, newRef)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"the encryptionroot %s was rewrapped onto the new key, but recording it against every "+
+				"container failed (%v). Those containers still name the retired key and will not "+
+				"start until the ref is corrected", root, err)
+	}
+
+	log.Printf("[encryption] rotated the key for encryptionroot %s; %d container(s) now resolve the new ref",
+		root, len(rewrapped))
+	return &pb.RewrapContainerResponse{
+		Message: fmt.Sprintf(
+			"rotated the key for tenant encryptionroot %s; rotation is tenant-wide and covers %d container(s)",
+			root, len(rewrapped)),
+		RewrappedContainers: rewrapped,
+	}, nil
+}
+
+// recordRotation points every container sharing an encryptionroot at the new
+// key ref, and reports which ones.
+//
+// All of them, not just the one the caller named: they are opened by the
+// same key, so a container left recording the retired ref would try it on
+// its next start and fail.
+func (h *encryptionHooks) recordRotation(root string, newRef zfskey.KeyRef) ([]string, error) {
+	if !h.enabled() {
+		return nil, fmt.Errorf("encryption is not configured on this daemon")
+	}
+	sharing, err := h.containersUnder(root)
+	if err != nil {
+		return nil, err
+	}
+	for _, name := range sharing {
+		if err := h.refs.SetKeyRef(name, newRef); err != nil {
+			return nil, fmt.Errorf("record the new key ref for %s: %w", name, err)
+		}
+	}
+	return sharing, nil
+}
+
+// containersUnder lists the containers whose recorded pool resolves to the
+// given encryptionroot.
+func (h *encryptionHooks) containersUnder(root string) ([]string, error) {
+	lister, ok := h.refs.(encryptionStateLister)
+	if !ok {
+		return nil, fmt.Errorf("this daemon cannot enumerate encrypted containers, so a rotation " +
+			"cannot be recorded against all of them")
+	}
+	all, err := lister.ListEncrypted()
+	if err != nil {
+		return nil, fmt.Errorf("list encrypted containers: %w", err)
+	}
+
+	var sharing []string
+	for _, name := range all {
+		pool, err := h.refs.GetPool(name)
+		if err != nil || pool == "" {
+			continue
+		}
+		source, exists, err := h.pools.StoragePoolSource(pool)
+		if err != nil || !exists {
+			continue
+		}
+		if source == root {
+			sharing = append(sharing, name)
+		}
+	}
+	sort.Strings(sharing)
+	return sharing, nil
+}
+
+// encryptionStateLister is the optional half of the state store that can
+// enumerate encrypted containers.
+//
+// Optional because enumeration is only needed for rotation, and the
+// incus-backed store gets it from a container list the daemon already has —
+// while the migration and create paths need no such thing.
+type encryptionStateLister interface {
+	// ListEncrypted returns the names of containers carrying a key ref.
+	ListEncrypted() ([]string, error)
+}

--- a/internal/server/rewrap_container_test.go
+++ b/internal/server/rewrap_container_test.go
@@ -1,0 +1,205 @@
+package server
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/footprintai/containarium/internal/auth"
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Control-plane-driven key rotation (#1204).
+//
+// Rewrapping changes only the wrapping key: ZFS re-encrypts the dataset's
+// master key, never the data, so the cost is independent of dataset size.
+// The daemon exposes the primitive and holds no schedule — cadence is tenant
+// policy owned by the control plane (design resolved decision #5).
+//
+// The property these tests exist to protect is #1204's second criterion: an
+// interrupted rotation must leave the container startable on exactly one of
+// the two keys, never on neither. That is why the new ref is recorded only
+// AFTER `zfs change-key` reports success — a ref recorded first would name a
+// key the dataset is not yet wrapped by, and the container would refuse to
+// start on either.
+
+func rewrapServer(t *testing.T, z *zfsFake, p *fakeKeyProvider) (*ContainerServer, *fakeRefStore, *fakePools) {
+	t.Helper()
+	refs := &fakeRefStore{
+		refs: map[string]zfskey.KeyRef{
+			"alice-container": {Scheme: zfskey.SchemeFile, URI: "/keys/alice.key",
+				Metadata: map[string]string{"tenant": "alice"}},
+		},
+		pools: map[string]string{"alice-container": "containarium-tenant-alice"},
+	}
+	pools := newFakePools()
+	pools.sources["containarium-tenant-alice"] = "tank/tenants/alice"
+	return &ContainerServer{encryption: testHooksWith(t, z, p, refs, pools)}, refs, pools
+}
+
+func TestRewrapContainer_RotatesTheTenantEncryptionrootAndRecordsTheNewRef(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	s, refs, _ := rewrapServer(t, z, p)
+
+	resp, err := s.RewrapContainer(adminCtx(), &pb.RewrapContainerRequest{
+		Username:  "alice",
+		NewKeyRef: refJSON(t, "/keys/alice-v2.key"),
+	})
+	if err != nil {
+		t.Fatalf("RewrapContainer: %v", err)
+	}
+
+	if !z.ran("change-key") {
+		t.Fatalf("no rewrap happened; calls=%v", z.calls)
+	}
+	// On the tenant's encryptionroot — the pool's source — not the
+	// container's own dataset, which has no key of its own to change.
+	if !z.ran("tank/tenants/alice") {
+		t.Errorf("rewrapped the wrong dataset; calls=%v", z.calls)
+	}
+	if got := refs.refs["alice-container"].URI; got != "/keys/alice-v2.key" {
+		t.Errorf("stored ref = %q, want the NEW key — every later start resolves the key from "+
+			"this, so a stale ref means the container opens with a key the dataset no longer has", got)
+	}
+	if len(resp.RewrappedContainers) == 0 {
+		t.Error("the response does not say which containers were affected; rotation hits the " +
+			"whole tenant and a caller must not have to discover that themselves")
+	}
+}
+
+// #1204 AC2, the ordering that makes an interrupted rotation survivable.
+//
+// If the ref were recorded before the rewrap, a failure between the two
+// would leave the dataset wrapped by the OLD key while the daemon believed
+// the NEW one — so neither key would start the container. Recording after
+// means a failure leaves the old key both wrapped and recorded: still
+// exactly one working key.
+func TestRewrapContainer_AFailedRewrapLeavesTheOldKeyRecorded(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	z.errs["change-key"] = errors.New("exit status 1")
+	z.stderr["change-key"] = "Key must be loaded"
+	s, refs, _ := rewrapServer(t, z, p)
+
+	_, err := s.RewrapContainer(adminCtx(), &pb.RewrapContainerRequest{
+		Username:  "alice",
+		NewKeyRef: refJSON(t, "/keys/alice-v2.key"),
+	})
+	if err == nil {
+		t.Fatal("a failed rewrap was reported as success — the control plane would retire a key " +
+			"that is still the only one that works")
+	}
+	if got := refs.refs["alice-container"].URI; got != "/keys/alice.key" {
+		t.Errorf("stored ref = %q, want the OLD key still — the dataset is wrapped by it, and a "+
+			"ref naming the new key would leave the container startable on neither", got)
+	}
+}
+
+// The new key must be resolvable BEFORE anything is rotated. Rewrapping onto
+// a key the daemon cannot fetch again would destroy access to the data on
+// the next start.
+func TestRewrapContainer_RefusesAKeyItCannotResolve(t *testing.T) {
+	z := newZFSFake()
+	p := &fakeKeyProvider{key: aKey(t), loadErr: errors.New("no such key")}
+	s, refs, _ := rewrapServer(t, z, p)
+
+	_, err := s.RewrapContainer(adminCtx(), &pb.RewrapContainerRequest{
+		Username:  "alice",
+		NewKeyRef: refJSON(t, "/keys/missing.key"),
+	})
+	if err == nil {
+		t.Fatal("rotated onto a key the daemon cannot resolve — the data becomes unreachable at " +
+			"the next start, which is indistinguishable from losing it")
+	}
+	if z.ran("change-key") {
+		t.Errorf("the dataset was rewrapped anyway; calls=%v", z.calls)
+	}
+	if got := refs.refs["alice-container"].URI; got != "/keys/alice.key" {
+		t.Errorf("the recorded ref changed to %q despite the failure", got)
+	}
+}
+
+func TestRewrapContainer_RefusesAnUnencryptedContainer(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	s := &ContainerServer{encryption: testHooksWith(t, z, p,
+		&fakeRefStore{refs: map[string]zfskey.KeyRef{}}, newFakePools())}
+
+	_, err := s.RewrapContainer(adminCtx(), &pb.RewrapContainerRequest{
+		Username: "bob", NewKeyRef: refJSON(t, "/keys/bob.key"),
+	})
+	if err == nil {
+		t.Fatal("rotated a key for a container that has none")
+	}
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", got)
+	}
+}
+
+func TestRewrapContainer_RejectsAMalformedRef(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	s, _, _ := rewrapServer(t, z, p)
+
+	_, err := s.RewrapContainer(adminCtx(), &pb.RewrapContainerRequest{
+		Username: "alice", NewKeyRef: "{not json",
+	})
+	if err == nil {
+		t.Fatal("a malformed key ref was accepted")
+	}
+	if got := status.Code(err); got != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", got)
+	}
+}
+
+// Rotation is an infrastructure operation on a tenant's key custody, not a
+// tenant operation — same gate as MoveContainer.
+func TestRewrapContainer_RequiresAdmin(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	s, _, _ := rewrapServer(t, z, p)
+
+	_, err := s.RewrapContainer(
+		tenantWithScopes("alice", auth.ScopeContainersWrite),
+		&pb.RewrapContainerRequest{Username: "alice", NewKeyRef: refJSON(t, "/k")})
+	if err == nil {
+		t.Fatal("a non-admin rotated a tenant's encryption key")
+	}
+	if got := status.Code(err); got != codes.PermissionDenied {
+		t.Errorf("code = %v, want PermissionDenied", got)
+	}
+}
+
+// The response has to name the blast radius. A caller who thinks they
+// rotated one container's key, when they rotated their whole tenant's, will
+// schedule the next maintenance window wrongly.
+func TestRewrapContainer_SaysRotationCoversTheWholeTenant(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	s, refs, _ := rewrapServer(t, z, p)
+	// A second container for the same tenant, on the same pool.
+	refs.refs["alice-two"] = zfskey.KeyRef{Scheme: zfskey.SchemeFile, URI: "/keys/alice.key",
+		Metadata: map[string]string{"tenant": "alice"}}
+	refs.pools["alice-two"] = "containarium-tenant-alice"
+
+	resp, err := s.RewrapContainer(adminCtx(), &pb.RewrapContainerRequest{
+		Username: "alice", NewKeyRef: refJSON(t, "/keys/alice-v2.key"),
+	})
+	if err != nil {
+		t.Fatalf("RewrapContainer: %v", err)
+	}
+
+	if len(resp.RewrappedContainers) < 2 {
+		t.Errorf("reported %v — the tenant's other container shares this encryptionroot and is "+
+			"equally affected; a caller reading this list decides their maintenance window from it",
+			resp.RewrappedContainers)
+	}
+	if !strings.Contains(resp.Message, "tenant") {
+		t.Errorf("the message does not say rotation is tenant-wide: %q", resp.Message)
+	}
+	// And every one of them must now resolve the new key.
+	for _, name := range []string{"alice-container", "alice-two"} {
+		if got := refs.refs[name].URI; got != "/keys/alice-v2.key" {
+			t.Errorf("%s still records %q — it would try the retired key on its next start", name, got)
+		}
+	}
+}

--- a/pkg/core/zfscrypt/zfscrypt.go
+++ b/pkg/core/zfscrypt/zfscrypt.go
@@ -152,6 +152,40 @@ func (m *Manager) CreateEncrypted(ctx context.Context, dataset string, key zfske
 	return nil
 }
 
+// ChangeKey rewraps an encryptionroot onto new key material (#1204).
+//
+// Only the wrapping key changes: ZFS re-encrypts the dataset's master key,
+// not the data, so rotation costs the same on a 1 GB dataset as on a 1 TB
+// one. The data itself is never rewritten, which is what makes rotation a
+// maintenance-window operation rather than a migration.
+//
+// The dataset's key must already be loaded — ZFS cannot rewrap what it
+// cannot open — so callers rotate a running-or-just-loaded encryptionroot,
+// not a cold one.
+//
+// The new key travels on stdin for the same reason every other key does:
+// argv is world-readable through /proc/<pid>/cmdline for the life of the
+// process, and a temp file leaves key material on disk.
+func (m *Manager) ChangeKey(ctx context.Context, dataset string, key zfskey.Key) error {
+	if err := validateDataset(dataset); err != nil {
+		return err
+	}
+	if key.IsZero() {
+		return fmt.Errorf("refusing to rewrap %s with an empty key", dataset)
+	}
+
+	_, stderr, err := m.run.Run(ctx, key.Bytes(),
+		"change-key",
+		"-o", "keyformat=raw",
+		"-o", "keylocation=file:///dev/stdin",
+		dataset,
+	)
+	if err != nil {
+		return fmt.Errorf("change key for %s: %w: %s", dataset, err, strings.TrimSpace(stderr))
+	}
+	return nil
+}
+
 // LoadKey makes an encrypted dataset readable. It is a no-op when the
 // key is already loaded, so a restarted daemon re-running the pre-start
 // hook does not fail.

--- a/pkg/core/zfscrypt/zfscrypt_test.go
+++ b/pkg/core/zfscrypt/zfscrypt_test.go
@@ -382,3 +382,81 @@ func TestEnsureParent(t *testing.T) {
 		}
 	})
 }
+
+// ChangeKey is the primitive behind control-plane-driven rotation (#1204).
+//
+// It rewraps an existing encryptionroot onto new key material without
+// touching the data: ZFS re-encrypts only the wrapping key, so rotation is
+// O(1) rather than O(dataset).
+func TestChangeKey(t *testing.T) {
+	t.Run("passes the new key on stdin and never on argv", func(t *testing.T) {
+		r := newFakeRunner()
+		m := NewManager(r)
+		newKey := testKey(t, 0x9)
+
+		if err := m.ChangeKey(context.Background(), "tank/tenants/alice", newKey); err != nil {
+			t.Fatalf("ChangeKey: %v", err)
+		}
+
+		call := r.lastCall()
+		if len(call) == 0 || call[0] != "change-key" {
+			t.Fatalf("ran %v, want a change-key", call)
+		}
+		// The rule the whole design rests on: key material travels on stdin.
+		// argv is world-readable through /proc/<pid>/cmdline for the life of
+		// the process.
+		for _, arg := range call {
+			if strings.Contains(arg, string(newKey.Bytes())) {
+				t.Fatalf("key material appeared on argv: %v", call)
+			}
+		}
+		if len(r.stdins) == 0 || !bytes.Equal(r.stdins[len(r.stdins)-1], newKey.Bytes()) {
+			t.Error("the new key did not reach stdin")
+		}
+		if !strings.Contains(r.allArgs(), "keylocation=file:///dev/stdin") {
+			t.Errorf("change-key did not read from stdin: %v", call)
+		}
+	})
+
+	t.Run("refuses an empty key", func(t *testing.T) {
+		r := newFakeRunner()
+		m := NewManager(r)
+
+		if err := m.ChangeKey(context.Background(), "tank/tenants/alice", zfskey.Key{}); err == nil {
+			t.Fatal("an empty key was accepted — the dataset would be left wrapped by nothing")
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("zfs was invoked with an empty key: %v", r.calls)
+		}
+	})
+
+	t.Run("refuses a dataset name that is not one", func(t *testing.T) {
+		r := newFakeRunner()
+		m := NewManager(r)
+
+		if err := m.ChangeKey(context.Background(), "-rf", testKey(t, 0x9)); err == nil {
+			t.Fatal("a flag-shaped dataset name was accepted")
+		}
+		if len(r.calls) != 0 {
+			t.Errorf("zfs was invoked: %v", r.calls)
+		}
+	})
+
+	// A failed rotation must say so. Reporting success would leave the
+	// control plane believing the old key is dead when it is still the only
+	// one that works.
+	t.Run("surfaces the zfs error", func(t *testing.T) {
+		r := newFakeRunner()
+		r.errs["change-key"] = errors.New("exit status 1")
+		r.stderr["change-key"] = "Key must be loaded"
+		m := NewManager(r)
+
+		err := m.ChangeKey(context.Background(), "tank/tenants/alice", testKey(t, 0x9))
+		if err == nil {
+			t.Fatal("a failed change-key was reported as success")
+		}
+		if !strings.Contains(err.Error(), "Key must be loaded") {
+			t.Errorf("zfs's reason was lost: %v", err)
+		}
+	})
+}

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -4931,6 +4931,140 @@ func (x *AdoptMigratedContainerRequest) GetZfsPool() string {
 	return ""
 }
 
+// RewrapContainerRequest rotates the key protecting a container's data
+// (#1204), driven by the control plane during a maintenance window.
+//
+// IMPORTANT: rotation is per-TENANT, not per-container. A tenant's
+// containers share one encryptionroot by design (#1199), so rewrapping the
+// container named here rotates the key for every container that tenant
+// owns. The RPC is named for a container because that is what a caller
+// holds; the response says how many containers were affected so the caller
+// cannot be surprised by it.
+type RewrapContainerRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The container whose tenant's key is being rotated.
+	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
+	// The NEW key reference, JSON-encoded, already provisioned by whoever
+	// owns key custody. The daemon resolves it through its own KeyProvider —
+	// key material never crosses this wire, exactly as at create time.
+	//
+	// Rotation is control-plane-driven (design resolved decision #5): the
+	// daemon exposes the primitive and holds no rotation schedule of its own.
+	NewKeyRef     string `protobuf:"bytes,2,opt,name=new_key_ref,json=newKeyRef,proto3" json:"new_key_ref,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RewrapContainerRequest) Reset() {
+	*x = RewrapContainerRequest{}
+	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RewrapContainerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RewrapContainerRequest) ProtoMessage() {}
+
+func (x *RewrapContainerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RewrapContainerRequest.ProtoReflect.Descriptor instead.
+func (*RewrapContainerRequest) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *RewrapContainerRequest) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *RewrapContainerRequest) GetNewKeyRef() string {
+	if x != nil {
+		return x.NewKeyRef
+	}
+	return ""
+}
+
+// RewrapContainerResponse reports the outcome of a rotation.
+type RewrapContainerResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Human-readable summary.
+	Message string `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	// Every container now protected by the new key — the whole tenant, not
+	// just the one named in the request.
+	RewrappedContainers []string `protobuf:"bytes,2,rep,name=rewrapped_containers,json=rewrappedContainers,proto3" json:"rewrapped_containers,omitempty"`
+	// Whether the named container was running before the rotation and has
+	// been started again afterwards.
+	Restarted     bool `protobuf:"varint,3,opt,name=restarted,proto3" json:"restarted,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RewrapContainerResponse) Reset() {
+	*x = RewrapContainerResponse{}
+	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RewrapContainerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RewrapContainerResponse) ProtoMessage() {}
+
+func (x *RewrapContainerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RewrapContainerResponse.ProtoReflect.Descriptor instead.
+func (*RewrapContainerResponse) Descriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{61}
+}
+
+func (x *RewrapContainerResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *RewrapContainerResponse) GetRewrappedContainers() []string {
+	if x != nil {
+		return x.RewrappedContainers
+	}
+	return nil
+}
+
+func (x *RewrapContainerResponse) GetRestarted() bool {
+	if x != nil {
+		return x.Restarted
+	}
+	return false
+}
+
 // PrepareEncryptedMigrationRequest asks a destination daemon whether it
 // can take over an encrypted container, BEFORE any data is copied.
 //
@@ -4956,7 +5090,7 @@ type PrepareEncryptedMigrationRequest struct {
 
 func (x *PrepareEncryptedMigrationRequest) Reset() {
 	*x = PrepareEncryptedMigrationRequest{}
-	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	mi := &file_containarium_v1_container_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4968,7 +5102,7 @@ func (x *PrepareEncryptedMigrationRequest) String() string {
 func (*PrepareEncryptedMigrationRequest) ProtoMessage() {}
 
 func (x *PrepareEncryptedMigrationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[60]
+	mi := &file_containarium_v1_container_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4981,7 +5115,7 @@ func (x *PrepareEncryptedMigrationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareEncryptedMigrationRequest.ProtoReflect.Descriptor instead.
 func (*PrepareEncryptedMigrationRequest) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{60}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *PrepareEncryptedMigrationRequest) GetUsername() string {
@@ -5027,7 +5161,7 @@ type PrepareEncryptedMigrationResponse struct {
 
 func (x *PrepareEncryptedMigrationResponse) Reset() {
 	*x = PrepareEncryptedMigrationResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	mi := &file_containarium_v1_container_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5039,7 +5173,7 @@ func (x *PrepareEncryptedMigrationResponse) String() string {
 func (*PrepareEncryptedMigrationResponse) ProtoMessage() {}
 
 func (x *PrepareEncryptedMigrationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[61]
+	mi := &file_containarium_v1_container_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5052,7 +5186,7 @@ func (x *PrepareEncryptedMigrationResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use PrepareEncryptedMigrationResponse.ProtoReflect.Descriptor instead.
 func (*PrepareEncryptedMigrationResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{61}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *PrepareEncryptedMigrationResponse) GetCanResolve() bool {
@@ -5091,7 +5225,7 @@ type AdoptMigratedContainerResponse struct {
 
 func (x *AdoptMigratedContainerResponse) Reset() {
 	*x = AdoptMigratedContainerResponse{}
-	mi := &file_containarium_v1_container_proto_msgTypes[62]
+	mi := &file_containarium_v1_container_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5103,7 +5237,7 @@ func (x *AdoptMigratedContainerResponse) String() string {
 func (*AdoptMigratedContainerResponse) ProtoMessage() {}
 
 func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_containarium_v1_container_proto_msgTypes[62]
+	mi := &file_containarium_v1_container_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5116,7 +5250,7 @@ func (x *AdoptMigratedContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdoptMigratedContainerResponse.ProtoReflect.Descriptor instead.
 func (*AdoptMigratedContainerResponse) Descriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{62}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *AdoptMigratedContainerResponse) GetMessage() string {
@@ -5490,7 +5624,14 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\busername\x18\x01 \x01(\tR\busername\x12#\n" +
 	"\rsource_routes\x18\x02 \x03(\tR\fsourceRoutes\x12\x1e\n" +
 	"\vzfs_key_ref\x18\x03 \x01(\tR\tzfsKeyRef\x12\x19\n" +
-	"\bzfs_pool\x18\x04 \x01(\tR\azfsPool\"o\n" +
+	"\bzfs_pool\x18\x04 \x01(\tR\azfsPool\"T\n" +
+	"\x16RewrapContainerRequest\x12\x1a\n" +
+	"\busername\x18\x01 \x01(\tR\busername\x12\x1e\n" +
+	"\vnew_key_ref\x18\x02 \x01(\tR\tnewKeyRef\"\x84\x01\n" +
+	"\x17RewrapContainerResponse\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x121\n" +
+	"\x14rewrapped_containers\x18\x02 \x03(\tR\x13rewrappedContainers\x12\x1c\n" +
+	"\trestarted\x18\x03 \x01(\bR\trestarted\"o\n" +
 	" PrepareEncryptedMigrationRequest\x12\x1a\n" +
 	"\busername\x18\x01 \x01(\tR\busername\x12\x16\n" +
 	"\x06tenant\x18\x02 \x01(\tR\x06tenant\x12\x17\n" +
@@ -5555,7 +5696,7 @@ func file_containarium_v1_container_proto_rawDescGZIP() []byte {
 }
 
 var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
+var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 71)
 var file_containarium_v1_container_proto_goTypes = []any{
 	(OSType)(0),                               // 0: containarium.v1.OSType
 	(AccessType)(0),                           // 1: containarium.v1.AccessType
@@ -5624,46 +5765,48 @@ var file_containarium_v1_container_proto_goTypes = []any{
 	(*MoveContainerRequest)(nil),              // 64: containarium.v1.MoveContainerRequest
 	(*MoveContainerResponse)(nil),             // 65: containarium.v1.MoveContainerResponse
 	(*AdoptMigratedContainerRequest)(nil),     // 66: containarium.v1.AdoptMigratedContainerRequest
-	(*PrepareEncryptedMigrationRequest)(nil),  // 67: containarium.v1.PrepareEncryptedMigrationRequest
-	(*PrepareEncryptedMigrationResponse)(nil), // 68: containarium.v1.PrepareEncryptedMigrationResponse
-	(*AdoptMigratedContainerResponse)(nil),    // 69: containarium.v1.AdoptMigratedContainerResponse
-	nil,                                       // 70: containarium.v1.Container.LabelsEntry
-	nil,                                       // 71: containarium.v1.CreateContainerRequest.LabelsEntry
-	nil,                                       // 72: containarium.v1.CreateContainerRequest.StackParametersEntry
-	nil,                                       // 73: containarium.v1.ListContainersRequest.LabelFilterEntry
-	nil,                                       // 74: containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	nil,                                       // 75: containarium.v1.SetContainerAttributionResponse.LabelsEntry
-	(*timestamppb.Timestamp)(nil),             // 76: google.protobuf.Timestamp
-	(*descriptorpb.EnumValueOptions)(nil),     // 77: google.protobuf.EnumValueOptions
+	(*RewrapContainerRequest)(nil),            // 67: containarium.v1.RewrapContainerRequest
+	(*RewrapContainerResponse)(nil),           // 68: containarium.v1.RewrapContainerResponse
+	(*PrepareEncryptedMigrationRequest)(nil),  // 69: containarium.v1.PrepareEncryptedMigrationRequest
+	(*PrepareEncryptedMigrationResponse)(nil), // 70: containarium.v1.PrepareEncryptedMigrationResponse
+	(*AdoptMigratedContainerResponse)(nil),    // 71: containarium.v1.AdoptMigratedContainerResponse
+	nil,                                       // 72: containarium.v1.Container.LabelsEntry
+	nil,                                       // 73: containarium.v1.CreateContainerRequest.LabelsEntry
+	nil,                                       // 74: containarium.v1.CreateContainerRequest.StackParametersEntry
+	nil,                                       // 75: containarium.v1.ListContainersRequest.LabelFilterEntry
+	nil,                                       // 76: containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	nil,                                       // 77: containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	(*timestamppb.Timestamp)(nil),             // 78: google.protobuf.Timestamp
+	(*descriptorpb.EnumValueOptions)(nil),     // 79: google.protobuf.EnumValueOptions
 }
 var file_containarium_v1_container_proto_depIdxs = []int32{
 	2,  // 0: containarium.v1.Container.state:type_name -> containarium.v1.ContainerState
 	7,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
 	8,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
-	70, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
+	72, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
 	0,  // 4: containarium.v1.Container.os_type:type_name -> containarium.v1.OSType
 	1,  // 5: containarium.v1.Container.access_type:type_name -> containarium.v1.AccessType
-	76, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
-	76, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
+	78, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	78, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
 	3,  // 8: containarium.v1.Container.delete_policy:type_name -> containarium.v1.DeletePolicy
 	4,  // 9: containarium.v1.Container.encryption_state:type_name -> containarium.v1.EncryptionState
 	7,  // 10: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
-	71, // 11: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
+	73, // 11: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
 	0,  // 12: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
-	72, // 13: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
+	74, // 13: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
 	9,  // 14: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
 	2,  // 15: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
-	73, // 16: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
+	75, // 16: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
 	9,  // 17: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
 	9,  // 18: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
 	10, // 19: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	9,  // 20: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
 	9,  // 21: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
-	76, // 22: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	78, // 22: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
 	3,  // 23: containarium.v1.SetContainerDeletePolicyRequest.delete_policy:type_name -> containarium.v1.DeletePolicy
 	3,  // 24: containarium.v1.SetContainerDeletePolicyResponse.delete_policy:type_name -> containarium.v1.DeletePolicy
-	74, // 25: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	75, // 26: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	76, // 25: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	77, // 26: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
 	10, // 27: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
 	9,  // 28: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
 	43, // 29: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
@@ -5677,9 +5820,9 @@ var file_containarium_v1_container_proto_depIdxs = []int32{
 	5,  // 37: containarium.v1.SetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
 	6,  // 38: containarium.v1.SetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
 	5,  // 39: containarium.v1.GetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
-	76, // 40: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
+	78, // 40: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
 	6,  // 41: containarium.v1.GetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
-	77, // 42: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
+	79, // 42: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
 	43, // [43:43] is the sub-list for method output_type
 	43, // [43:43] is the sub-list for method input_type
 	43, // [43:43] is the sub-list for extension type_name
@@ -5698,7 +5841,7 @@ func file_containarium_v1_container_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_container_proto_rawDesc), len(file_containarium_v1_container_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   69,
+			NumMessages:   71,
 			NumExtensions: 1,
 			NumServices:   0,
 		},

--- a/pkg/pb/containarium/v1/service.pb.go
+++ b/pkg/pb/containarium/v1/service.pb.go
@@ -26,7 +26,7 @@ var File_containarium_v1_service_proto protoreflect.FileDescriptor
 
 const file_containarium_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xa8\x97\x01\n" +
+	"\x1dcontainarium/v1/service.proto\x12\x0fcontainarium.v1\x1a\x1fcontainarium/v1/container.proto\x1a\x1ccontainarium/v1/config.proto\x1a\x19containarium/v1/app.proto\x1a\x1dcontainarium/v1/network.proto\x1a\x1bcontainarium/v1/alert.proto\x1a\x1dcontainarium/v1/secrets.proto\x1a\x1cgoogle/api/annotations.proto\x1a.protoc-gen-openapiv2/options/annotations.proto2\xf0\x9a\x01\n" +
 	"\x10ContainerService\x12\xae\x02\n" +
 	"\x0fCreateContainer\x12'.containarium.v1.CreateContainerRequest\x1a(.containarium.v1.CreateContainerResponse\"\xc7\x01\x92A\xaa\x01\n" +
 	"\n" +
@@ -50,7 +50,9 @@ const file_containarium_v1_service_proto_rawDesc = "" +
 	"\x0fResizeContainer\x12'.containarium.v1.ResizeContainerRequest\x1a(.containarium.v1.ResizeContainerResponse\"\xdc\x01\x92A\xad\x01\n" +
 	"\x14Container Operations\x12\x1aResize container resources\x1ayDynamically adjusts CPU, memory, and disk resources without container restart. Disk can only be increased, not decreased.\x82\xd3\xe4\x93\x02%:\x01*\x1a /v1/containers/{username}/resize\x12\xc8\x03\n" +
 	"\rMoveContainer\x12%.containarium.v1.MoveContainerRequest\x1a&.containarium.v1.MoveContainerResponse\"\xe7\x02\x92A\xba\x02\n" +
-	"\x14Container Operations\x12 Migrate container to peer daemon\x1a\xff\x01Pre-copy snapshot-based migration to a peer daemon. Sub-second downtime on ZFS/btrfs storage with low write rate; up to minutes on dir-pool or active workloads. Caller must have incus remotes configured both directions between the source and target hosts.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/containers/{username}/move\x12\xf9\x04\n" +
+	"\x14Container Operations\x12 Migrate container to peer daemon\x1a\xff\x01Pre-copy snapshot-based migration to a peer daemon. Sub-second downtime on ZFS/btrfs storage with low write rate; up to minutes on dir-pool or active workloads. Caller must have incus remotes configured both directions between the source and target hosts.\x82\xd3\xe4\x93\x02#:\x01*\"\x1e/v1/containers/{username}/move\x12\xc5\x03\n" +
+	"\x0fRewrapContainer\x12'.containarium.v1.RewrapContainerRequest\x1a(.containarium.v1.RewrapContainerResponse\"\xde\x02\x92A\xaf\x02\n" +
+	"\x14Container Operations\x12 Rotate a tenant's encryption key\x1a\xf4\x01Rewraps the tenant's ZFS encryptionroot onto new key material supplied as a key reference. Only the wrapping key changes, so the cost is independent of dataset size. Affects every container the tenant owns, which the response lists. Admin only.\x82\xd3\xe4\x93\x02%:\x01*\" /v1/containers/{username}/rewrap\x12\xf9\x04\n" +
 	"\x19PrepareEncryptedMigration\x121.containarium.v1.PrepareEncryptedMigrationRequest\x1a2.containarium.v1.PrepareEncryptedMigrationResponse\"\xf4\x03\x92A\xb0\x03\n" +
 	"\x14Container Operations\x12,Pre-flight an encrypted migration (internal)\x1a\xe9\x02Called by the source daemon before MoveContainer copies anything. The destination reports whether its key custody can resolve the container's KeyRef, and provisions the tenant's encrypted storage pool so the copy lands inside the tenant's encryptionroot. Only the key reference is sent; key material never crosses the wire. Not intended for direct operator use.\x82\xd3\xe4\x93\x02::\x01*\"5/v1/containers/{username}/prepare-encrypted-migration\x12\xdc\x03\n" +
 	"\x16AdoptMigratedContainer\x12..containarium.v1.AdoptMigratedContainerRequest\x1a/.containarium.v1.AdoptMigratedContainerResponse\"\xe0\x02\x92A\xb2\x02\n" +
@@ -172,107 +174,109 @@ var file_containarium_v1_service_proto_goTypes = []any{
 	(*StopContainerRequest)(nil),              // 6: containarium.v1.StopContainerRequest
 	(*ResizeContainerRequest)(nil),            // 7: containarium.v1.ResizeContainerRequest
 	(*MoveContainerRequest)(nil),              // 8: containarium.v1.MoveContainerRequest
-	(*PrepareEncryptedMigrationRequest)(nil),  // 9: containarium.v1.PrepareEncryptedMigrationRequest
-	(*AdoptMigratedContainerRequest)(nil),     // 10: containarium.v1.AdoptMigratedContainerRequest
-	(*ToggleMonitoringRequest)(nil),           // 11: containarium.v1.ToggleMonitoringRequest
-	(*ToggleAutoSleepRequest)(nil),            // 12: containarium.v1.ToggleAutoSleepRequest
-	(*SetContainerTTLRequest)(nil),            // 13: containarium.v1.SetContainerTTLRequest
-	(*SetContainerDeletePolicyRequest)(nil),   // 14: containarium.v1.SetContainerDeletePolicyRequest
-	(*SetContainerAttributionRequest)(nil),    // 15: containarium.v1.SetContainerAttributionRequest
-	(*AddSSHKeyRequest)(nil),                  // 16: containarium.v1.AddSSHKeyRequest
-	(*RemoveSSHKeyRequest)(nil),               // 17: containarium.v1.RemoveSSHKeyRequest
-	(*AddCollaboratorRequest)(nil),            // 18: containarium.v1.AddCollaboratorRequest
-	(*RemoveCollaboratorRequest)(nil),         // 19: containarium.v1.RemoveCollaboratorRequest
-	(*ListCollaboratorsRequest)(nil),          // 20: containarium.v1.ListCollaboratorsRequest
-	(*GetMetricsRequest)(nil),                 // 21: containarium.v1.GetMetricsRequest
-	(*CleanupDiskRequest)(nil),                // 22: containarium.v1.CleanupDiskRequest
-	(*InstallStackRequest)(nil),               // 23: containarium.v1.InstallStackRequest
-	(*ListStacksRequest)(nil),                 // 24: containarium.v1.ListStacksRequest
-	(*GetSystemInfoRequest)(nil),              // 25: containarium.v1.GetSystemInfoRequest
-	(*ListBackendsRequest)(nil),               // 26: containarium.v1.ListBackendsRequest
-	(*AdvertiseCapacityRequest)(nil),          // 27: containarium.v1.AdvertiseCapacityRequest
-	(*WithdrawCapacityRequest)(nil),           // 28: containarium.v1.WithdrawCapacityRequest
-	(*GetCapacityHeadroomRequest)(nil),        // 29: containarium.v1.GetCapacityHeadroomRequest
-	(*ProfileBackendRequest)(nil),             // 30: containarium.v1.ProfileBackendRequest
-	(*GetCapabilityProfileRequest)(nil),       // 31: containarium.v1.GetCapabilityProfileRequest
-	(*GetSelfMeasurementRequest)(nil),         // 32: containarium.v1.GetSelfMeasurementRequest
-	(*GetLatestReleaseRequest)(nil),           // 33: containarium.v1.GetLatestReleaseRequest
-	(*ValidateGPURequest)(nil),                // 34: containarium.v1.ValidateGPURequest
-	(*TriggerUpgradeRequest)(nil),             // 35: containarium.v1.TriggerUpgradeRequest
-	(*GetUpgradeStatusRequest)(nil),           // 36: containarium.v1.GetUpgradeStatusRequest
-	(*GetMonitoringInfoRequest)(nil),          // 37: containarium.v1.GetMonitoringInfoRequest
-	(*SetMetricsExportRequest)(nil),           // 38: containarium.v1.SetMetricsExportRequest
-	(*GetMetricsExportRequest)(nil),           // 39: containarium.v1.GetMetricsExportRequest
-	(*CreateAlertRuleRequest)(nil),            // 40: containarium.v1.CreateAlertRuleRequest
-	(*ListAlertRulesRequest)(nil),             // 41: containarium.v1.ListAlertRulesRequest
-	(*GetAlertRuleRequest)(nil),               // 42: containarium.v1.GetAlertRuleRequest
-	(*UpdateAlertRuleRequest)(nil),            // 43: containarium.v1.UpdateAlertRuleRequest
-	(*DeleteAlertRuleRequest)(nil),            // 44: containarium.v1.DeleteAlertRuleRequest
-	(*GetAlertingInfoRequest)(nil),            // 45: containarium.v1.GetAlertingInfoRequest
-	(*ListDefaultAlertRulesRequest)(nil),      // 46: containarium.v1.ListDefaultAlertRulesRequest
-	(*UpdateAlertingConfigRequest)(nil),       // 47: containarium.v1.UpdateAlertingConfigRequest
-	(*TestWebhookRequest)(nil),                // 48: containarium.v1.TestWebhookRequest
-	(*ListWebhookDeliveriesRequest)(nil),      // 49: containarium.v1.ListWebhookDeliveriesRequest
-	(*SetSecretRequest)(nil),                  // 50: containarium.v1.SetSecretRequest
-	(*GetSecretRequest)(nil),                  // 51: containarium.v1.GetSecretRequest
-	(*ListSecretsRequest)(nil),                // 52: containarium.v1.ListSecretsRequest
-	(*DeleteSecretRequest)(nil),               // 53: containarium.v1.DeleteSecretRequest
-	(*RefreshSecretsRequest)(nil),             // 54: containarium.v1.RefreshSecretsRequest
-	(*CreateContainerResponse)(nil),           // 55: containarium.v1.CreateContainerResponse
-	(*ListContainersResponse)(nil),            // 56: containarium.v1.ListContainersResponse
-	(*GetContainerResponse)(nil),              // 57: containarium.v1.GetContainerResponse
-	(*DebugContainerResponse)(nil),            // 58: containarium.v1.DebugContainerResponse
-	(*DeleteContainerResponse)(nil),           // 59: containarium.v1.DeleteContainerResponse
-	(*StartContainerResponse)(nil),            // 60: containarium.v1.StartContainerResponse
-	(*StopContainerResponse)(nil),             // 61: containarium.v1.StopContainerResponse
-	(*ResizeContainerResponse)(nil),           // 62: containarium.v1.ResizeContainerResponse
-	(*MoveContainerResponse)(nil),             // 63: containarium.v1.MoveContainerResponse
-	(*PrepareEncryptedMigrationResponse)(nil), // 64: containarium.v1.PrepareEncryptedMigrationResponse
-	(*AdoptMigratedContainerResponse)(nil),    // 65: containarium.v1.AdoptMigratedContainerResponse
-	(*ToggleMonitoringResponse)(nil),          // 66: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepResponse)(nil),           // 67: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLResponse)(nil),           // 68: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyResponse)(nil),  // 69: containarium.v1.SetContainerDeletePolicyResponse
-	(*SetContainerAttributionResponse)(nil),   // 70: containarium.v1.SetContainerAttributionResponse
-	(*AddSSHKeyResponse)(nil),                 // 71: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyResponse)(nil),              // 72: containarium.v1.RemoveSSHKeyResponse
-	(*AddCollaboratorResponse)(nil),           // 73: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorResponse)(nil),        // 74: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsResponse)(nil),         // 75: containarium.v1.ListCollaboratorsResponse
-	(*GetMetricsResponse)(nil),                // 76: containarium.v1.GetMetricsResponse
-	(*CleanupDiskResponse)(nil),               // 77: containarium.v1.CleanupDiskResponse
-	(*InstallStackResponse)(nil),              // 78: containarium.v1.InstallStackResponse
-	(*ListStacksResponse)(nil),                // 79: containarium.v1.ListStacksResponse
-	(*GetSystemInfoResponse)(nil),             // 80: containarium.v1.GetSystemInfoResponse
-	(*ListBackendsResponse)(nil),              // 81: containarium.v1.ListBackendsResponse
-	(*AdvertiseCapacityResponse)(nil),         // 82: containarium.v1.AdvertiseCapacityResponse
-	(*WithdrawCapacityResponse)(nil),          // 83: containarium.v1.WithdrawCapacityResponse
-	(*GetCapacityHeadroomResponse)(nil),       // 84: containarium.v1.GetCapacityHeadroomResponse
-	(*ProfileBackendResponse)(nil),            // 85: containarium.v1.ProfileBackendResponse
-	(*GetCapabilityProfileResponse)(nil),      // 86: containarium.v1.GetCapabilityProfileResponse
-	(*GetSelfMeasurementResponse)(nil),        // 87: containarium.v1.GetSelfMeasurementResponse
-	(*GetLatestReleaseResponse)(nil),          // 88: containarium.v1.GetLatestReleaseResponse
-	(*ValidateGPUResponse)(nil),               // 89: containarium.v1.ValidateGPUResponse
-	(*TriggerUpgradeResponse)(nil),            // 90: containarium.v1.TriggerUpgradeResponse
-	(*GetUpgradeStatusResponse)(nil),          // 91: containarium.v1.GetUpgradeStatusResponse
-	(*GetMonitoringInfoResponse)(nil),         // 92: containarium.v1.GetMonitoringInfoResponse
-	(*SetMetricsExportResponse)(nil),          // 93: containarium.v1.SetMetricsExportResponse
-	(*GetMetricsExportResponse)(nil),          // 94: containarium.v1.GetMetricsExportResponse
-	(*CreateAlertRuleResponse)(nil),           // 95: containarium.v1.CreateAlertRuleResponse
-	(*ListAlertRulesResponse)(nil),            // 96: containarium.v1.ListAlertRulesResponse
-	(*GetAlertRuleResponse)(nil),              // 97: containarium.v1.GetAlertRuleResponse
-	(*UpdateAlertRuleResponse)(nil),           // 98: containarium.v1.UpdateAlertRuleResponse
-	(*DeleteAlertRuleResponse)(nil),           // 99: containarium.v1.DeleteAlertRuleResponse
-	(*GetAlertingInfoResponse)(nil),           // 100: containarium.v1.GetAlertingInfoResponse
-	(*ListDefaultAlertRulesResponse)(nil),     // 101: containarium.v1.ListDefaultAlertRulesResponse
-	(*UpdateAlertingConfigResponse)(nil),      // 102: containarium.v1.UpdateAlertingConfigResponse
-	(*TestWebhookResponse)(nil),               // 103: containarium.v1.TestWebhookResponse
-	(*ListWebhookDeliveriesResponse)(nil),     // 104: containarium.v1.ListWebhookDeliveriesResponse
-	(*SetSecretResponse)(nil),                 // 105: containarium.v1.SetSecretResponse
-	(*GetSecretResponse)(nil),                 // 106: containarium.v1.GetSecretResponse
-	(*ListSecretsResponse)(nil),               // 107: containarium.v1.ListSecretsResponse
-	(*DeleteSecretResponse)(nil),              // 108: containarium.v1.DeleteSecretResponse
-	(*RefreshSecretsResponse)(nil),            // 109: containarium.v1.RefreshSecretsResponse
+	(*RewrapContainerRequest)(nil),            // 9: containarium.v1.RewrapContainerRequest
+	(*PrepareEncryptedMigrationRequest)(nil),  // 10: containarium.v1.PrepareEncryptedMigrationRequest
+	(*AdoptMigratedContainerRequest)(nil),     // 11: containarium.v1.AdoptMigratedContainerRequest
+	(*ToggleMonitoringRequest)(nil),           // 12: containarium.v1.ToggleMonitoringRequest
+	(*ToggleAutoSleepRequest)(nil),            // 13: containarium.v1.ToggleAutoSleepRequest
+	(*SetContainerTTLRequest)(nil),            // 14: containarium.v1.SetContainerTTLRequest
+	(*SetContainerDeletePolicyRequest)(nil),   // 15: containarium.v1.SetContainerDeletePolicyRequest
+	(*SetContainerAttributionRequest)(nil),    // 16: containarium.v1.SetContainerAttributionRequest
+	(*AddSSHKeyRequest)(nil),                  // 17: containarium.v1.AddSSHKeyRequest
+	(*RemoveSSHKeyRequest)(nil),               // 18: containarium.v1.RemoveSSHKeyRequest
+	(*AddCollaboratorRequest)(nil),            // 19: containarium.v1.AddCollaboratorRequest
+	(*RemoveCollaboratorRequest)(nil),         // 20: containarium.v1.RemoveCollaboratorRequest
+	(*ListCollaboratorsRequest)(nil),          // 21: containarium.v1.ListCollaboratorsRequest
+	(*GetMetricsRequest)(nil),                 // 22: containarium.v1.GetMetricsRequest
+	(*CleanupDiskRequest)(nil),                // 23: containarium.v1.CleanupDiskRequest
+	(*InstallStackRequest)(nil),               // 24: containarium.v1.InstallStackRequest
+	(*ListStacksRequest)(nil),                 // 25: containarium.v1.ListStacksRequest
+	(*GetSystemInfoRequest)(nil),              // 26: containarium.v1.GetSystemInfoRequest
+	(*ListBackendsRequest)(nil),               // 27: containarium.v1.ListBackendsRequest
+	(*AdvertiseCapacityRequest)(nil),          // 28: containarium.v1.AdvertiseCapacityRequest
+	(*WithdrawCapacityRequest)(nil),           // 29: containarium.v1.WithdrawCapacityRequest
+	(*GetCapacityHeadroomRequest)(nil),        // 30: containarium.v1.GetCapacityHeadroomRequest
+	(*ProfileBackendRequest)(nil),             // 31: containarium.v1.ProfileBackendRequest
+	(*GetCapabilityProfileRequest)(nil),       // 32: containarium.v1.GetCapabilityProfileRequest
+	(*GetSelfMeasurementRequest)(nil),         // 33: containarium.v1.GetSelfMeasurementRequest
+	(*GetLatestReleaseRequest)(nil),           // 34: containarium.v1.GetLatestReleaseRequest
+	(*ValidateGPURequest)(nil),                // 35: containarium.v1.ValidateGPURequest
+	(*TriggerUpgradeRequest)(nil),             // 36: containarium.v1.TriggerUpgradeRequest
+	(*GetUpgradeStatusRequest)(nil),           // 37: containarium.v1.GetUpgradeStatusRequest
+	(*GetMonitoringInfoRequest)(nil),          // 38: containarium.v1.GetMonitoringInfoRequest
+	(*SetMetricsExportRequest)(nil),           // 39: containarium.v1.SetMetricsExportRequest
+	(*GetMetricsExportRequest)(nil),           // 40: containarium.v1.GetMetricsExportRequest
+	(*CreateAlertRuleRequest)(nil),            // 41: containarium.v1.CreateAlertRuleRequest
+	(*ListAlertRulesRequest)(nil),             // 42: containarium.v1.ListAlertRulesRequest
+	(*GetAlertRuleRequest)(nil),               // 43: containarium.v1.GetAlertRuleRequest
+	(*UpdateAlertRuleRequest)(nil),            // 44: containarium.v1.UpdateAlertRuleRequest
+	(*DeleteAlertRuleRequest)(nil),            // 45: containarium.v1.DeleteAlertRuleRequest
+	(*GetAlertingInfoRequest)(nil),            // 46: containarium.v1.GetAlertingInfoRequest
+	(*ListDefaultAlertRulesRequest)(nil),      // 47: containarium.v1.ListDefaultAlertRulesRequest
+	(*UpdateAlertingConfigRequest)(nil),       // 48: containarium.v1.UpdateAlertingConfigRequest
+	(*TestWebhookRequest)(nil),                // 49: containarium.v1.TestWebhookRequest
+	(*ListWebhookDeliveriesRequest)(nil),      // 50: containarium.v1.ListWebhookDeliveriesRequest
+	(*SetSecretRequest)(nil),                  // 51: containarium.v1.SetSecretRequest
+	(*GetSecretRequest)(nil),                  // 52: containarium.v1.GetSecretRequest
+	(*ListSecretsRequest)(nil),                // 53: containarium.v1.ListSecretsRequest
+	(*DeleteSecretRequest)(nil),               // 54: containarium.v1.DeleteSecretRequest
+	(*RefreshSecretsRequest)(nil),             // 55: containarium.v1.RefreshSecretsRequest
+	(*CreateContainerResponse)(nil),           // 56: containarium.v1.CreateContainerResponse
+	(*ListContainersResponse)(nil),            // 57: containarium.v1.ListContainersResponse
+	(*GetContainerResponse)(nil),              // 58: containarium.v1.GetContainerResponse
+	(*DebugContainerResponse)(nil),            // 59: containarium.v1.DebugContainerResponse
+	(*DeleteContainerResponse)(nil),           // 60: containarium.v1.DeleteContainerResponse
+	(*StartContainerResponse)(nil),            // 61: containarium.v1.StartContainerResponse
+	(*StopContainerResponse)(nil),             // 62: containarium.v1.StopContainerResponse
+	(*ResizeContainerResponse)(nil),           // 63: containarium.v1.ResizeContainerResponse
+	(*MoveContainerResponse)(nil),             // 64: containarium.v1.MoveContainerResponse
+	(*RewrapContainerResponse)(nil),           // 65: containarium.v1.RewrapContainerResponse
+	(*PrepareEncryptedMigrationResponse)(nil), // 66: containarium.v1.PrepareEncryptedMigrationResponse
+	(*AdoptMigratedContainerResponse)(nil),    // 67: containarium.v1.AdoptMigratedContainerResponse
+	(*ToggleMonitoringResponse)(nil),          // 68: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepResponse)(nil),           // 69: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLResponse)(nil),           // 70: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyResponse)(nil),  // 71: containarium.v1.SetContainerDeletePolicyResponse
+	(*SetContainerAttributionResponse)(nil),   // 72: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyResponse)(nil),                 // 73: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyResponse)(nil),              // 74: containarium.v1.RemoveSSHKeyResponse
+	(*AddCollaboratorResponse)(nil),           // 75: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorResponse)(nil),        // 76: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsResponse)(nil),         // 77: containarium.v1.ListCollaboratorsResponse
+	(*GetMetricsResponse)(nil),                // 78: containarium.v1.GetMetricsResponse
+	(*CleanupDiskResponse)(nil),               // 79: containarium.v1.CleanupDiskResponse
+	(*InstallStackResponse)(nil),              // 80: containarium.v1.InstallStackResponse
+	(*ListStacksResponse)(nil),                // 81: containarium.v1.ListStacksResponse
+	(*GetSystemInfoResponse)(nil),             // 82: containarium.v1.GetSystemInfoResponse
+	(*ListBackendsResponse)(nil),              // 83: containarium.v1.ListBackendsResponse
+	(*AdvertiseCapacityResponse)(nil),         // 84: containarium.v1.AdvertiseCapacityResponse
+	(*WithdrawCapacityResponse)(nil),          // 85: containarium.v1.WithdrawCapacityResponse
+	(*GetCapacityHeadroomResponse)(nil),       // 86: containarium.v1.GetCapacityHeadroomResponse
+	(*ProfileBackendResponse)(nil),            // 87: containarium.v1.ProfileBackendResponse
+	(*GetCapabilityProfileResponse)(nil),      // 88: containarium.v1.GetCapabilityProfileResponse
+	(*GetSelfMeasurementResponse)(nil),        // 89: containarium.v1.GetSelfMeasurementResponse
+	(*GetLatestReleaseResponse)(nil),          // 90: containarium.v1.GetLatestReleaseResponse
+	(*ValidateGPUResponse)(nil),               // 91: containarium.v1.ValidateGPUResponse
+	(*TriggerUpgradeResponse)(nil),            // 92: containarium.v1.TriggerUpgradeResponse
+	(*GetUpgradeStatusResponse)(nil),          // 93: containarium.v1.GetUpgradeStatusResponse
+	(*GetMonitoringInfoResponse)(nil),         // 94: containarium.v1.GetMonitoringInfoResponse
+	(*SetMetricsExportResponse)(nil),          // 95: containarium.v1.SetMetricsExportResponse
+	(*GetMetricsExportResponse)(nil),          // 96: containarium.v1.GetMetricsExportResponse
+	(*CreateAlertRuleResponse)(nil),           // 97: containarium.v1.CreateAlertRuleResponse
+	(*ListAlertRulesResponse)(nil),            // 98: containarium.v1.ListAlertRulesResponse
+	(*GetAlertRuleResponse)(nil),              // 99: containarium.v1.GetAlertRuleResponse
+	(*UpdateAlertRuleResponse)(nil),           // 100: containarium.v1.UpdateAlertRuleResponse
+	(*DeleteAlertRuleResponse)(nil),           // 101: containarium.v1.DeleteAlertRuleResponse
+	(*GetAlertingInfoResponse)(nil),           // 102: containarium.v1.GetAlertingInfoResponse
+	(*ListDefaultAlertRulesResponse)(nil),     // 103: containarium.v1.ListDefaultAlertRulesResponse
+	(*UpdateAlertingConfigResponse)(nil),      // 104: containarium.v1.UpdateAlertingConfigResponse
+	(*TestWebhookResponse)(nil),               // 105: containarium.v1.TestWebhookResponse
+	(*ListWebhookDeliveriesResponse)(nil),     // 106: containarium.v1.ListWebhookDeliveriesResponse
+	(*SetSecretResponse)(nil),                 // 107: containarium.v1.SetSecretResponse
+	(*GetSecretResponse)(nil),                 // 108: containarium.v1.GetSecretResponse
+	(*ListSecretsResponse)(nil),               // 109: containarium.v1.ListSecretsResponse
+	(*DeleteSecretResponse)(nil),              // 110: containarium.v1.DeleteSecretResponse
+	(*RefreshSecretsResponse)(nil),            // 111: containarium.v1.RefreshSecretsResponse
 }
 var file_containarium_v1_service_proto_depIdxs = []int32{
 	0,   // 0: containarium.v1.ContainerService.CreateContainer:input_type -> containarium.v1.CreateContainerRequest
@@ -284,109 +288,111 @@ var file_containarium_v1_service_proto_depIdxs = []int32{
 	6,   // 6: containarium.v1.ContainerService.StopContainer:input_type -> containarium.v1.StopContainerRequest
 	7,   // 7: containarium.v1.ContainerService.ResizeContainer:input_type -> containarium.v1.ResizeContainerRequest
 	8,   // 8: containarium.v1.ContainerService.MoveContainer:input_type -> containarium.v1.MoveContainerRequest
-	9,   // 9: containarium.v1.ContainerService.PrepareEncryptedMigration:input_type -> containarium.v1.PrepareEncryptedMigrationRequest
-	10,  // 10: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
-	11,  // 11: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
-	12,  // 12: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
-	13,  // 13: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
-	14,  // 14: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
-	15,  // 15: containarium.v1.ContainerService.SetContainerAttribution:input_type -> containarium.v1.SetContainerAttributionRequest
-	16,  // 16: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
-	17,  // 17: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
-	18,  // 18: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
-	19,  // 19: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
-	20,  // 20: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
-	21,  // 21: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
-	22,  // 22: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
-	23,  // 23: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
-	24,  // 24: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
-	25,  // 25: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
-	26,  // 26: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
-	27,  // 27: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
-	28,  // 28: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
-	29,  // 29: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
-	30,  // 30: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
-	31,  // 31: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
-	32,  // 32: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
-	33,  // 33: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
-	34,  // 34: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
-	35,  // 35: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
-	36,  // 36: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
-	37,  // 37: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
-	38,  // 38: containarium.v1.ContainerService.SetMetricsExport:input_type -> containarium.v1.SetMetricsExportRequest
-	39,  // 39: containarium.v1.ContainerService.GetMetricsExport:input_type -> containarium.v1.GetMetricsExportRequest
-	40,  // 40: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
-	41,  // 41: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
-	42,  // 42: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
-	43,  // 43: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
-	44,  // 44: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
-	45,  // 45: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
-	46,  // 46: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
-	47,  // 47: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
-	48,  // 48: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
-	49,  // 49: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
-	50,  // 50: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
-	51,  // 51: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
-	52,  // 52: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
-	53,  // 53: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
-	54,  // 54: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
-	55,  // 55: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
-	56,  // 56: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
-	57,  // 57: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
-	58,  // 58: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
-	59,  // 59: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
-	60,  // 60: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
-	61,  // 61: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
-	62,  // 62: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
-	63,  // 63: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
-	64,  // 64: containarium.v1.ContainerService.PrepareEncryptedMigration:output_type -> containarium.v1.PrepareEncryptedMigrationResponse
-	65,  // 65: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
-	66,  // 66: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
-	67,  // 67: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
-	68,  // 68: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
-	69,  // 69: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
-	70,  // 70: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
-	71,  // 71: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
-	72,  // 72: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
-	73,  // 73: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
-	74,  // 74: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
-	75,  // 75: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
-	76,  // 76: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
-	77,  // 77: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
-	78,  // 78: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
-	79,  // 79: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
-	80,  // 80: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
-	81,  // 81: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
-	82,  // 82: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
-	83,  // 83: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
-	84,  // 84: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
-	85,  // 85: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
-	86,  // 86: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
-	87,  // 87: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
-	88,  // 88: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
-	89,  // 89: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
-	90,  // 90: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
-	91,  // 91: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
-	92,  // 92: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
-	93,  // 93: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
-	94,  // 94: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
-	95,  // 95: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
-	96,  // 96: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
-	97,  // 97: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
-	98,  // 98: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
-	99,  // 99: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
-	100, // 100: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
-	101, // 101: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
-	102, // 102: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
-	103, // 103: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
-	104, // 104: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
-	105, // 105: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
-	106, // 106: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
-	107, // 107: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
-	108, // 108: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
-	109, // 109: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
-	55,  // [55:110] is the sub-list for method output_type
-	0,   // [0:55] is the sub-list for method input_type
+	9,   // 9: containarium.v1.ContainerService.RewrapContainer:input_type -> containarium.v1.RewrapContainerRequest
+	10,  // 10: containarium.v1.ContainerService.PrepareEncryptedMigration:input_type -> containarium.v1.PrepareEncryptedMigrationRequest
+	11,  // 11: containarium.v1.ContainerService.AdoptMigratedContainer:input_type -> containarium.v1.AdoptMigratedContainerRequest
+	12,  // 12: containarium.v1.ContainerService.ToggleMonitoring:input_type -> containarium.v1.ToggleMonitoringRequest
+	13,  // 13: containarium.v1.ContainerService.ToggleAutoSleep:input_type -> containarium.v1.ToggleAutoSleepRequest
+	14,  // 14: containarium.v1.ContainerService.SetContainerTTL:input_type -> containarium.v1.SetContainerTTLRequest
+	15,  // 15: containarium.v1.ContainerService.SetContainerDeletePolicy:input_type -> containarium.v1.SetContainerDeletePolicyRequest
+	16,  // 16: containarium.v1.ContainerService.SetContainerAttribution:input_type -> containarium.v1.SetContainerAttributionRequest
+	17,  // 17: containarium.v1.ContainerService.AddSSHKey:input_type -> containarium.v1.AddSSHKeyRequest
+	18,  // 18: containarium.v1.ContainerService.RemoveSSHKey:input_type -> containarium.v1.RemoveSSHKeyRequest
+	19,  // 19: containarium.v1.ContainerService.AddCollaborator:input_type -> containarium.v1.AddCollaboratorRequest
+	20,  // 20: containarium.v1.ContainerService.RemoveCollaborator:input_type -> containarium.v1.RemoveCollaboratorRequest
+	21,  // 21: containarium.v1.ContainerService.ListCollaborators:input_type -> containarium.v1.ListCollaboratorsRequest
+	22,  // 22: containarium.v1.ContainerService.GetMetrics:input_type -> containarium.v1.GetMetricsRequest
+	23,  // 23: containarium.v1.ContainerService.CleanupDisk:input_type -> containarium.v1.CleanupDiskRequest
+	24,  // 24: containarium.v1.ContainerService.InstallStack:input_type -> containarium.v1.InstallStackRequest
+	25,  // 25: containarium.v1.ContainerService.ListStacks:input_type -> containarium.v1.ListStacksRequest
+	26,  // 26: containarium.v1.ContainerService.GetSystemInfo:input_type -> containarium.v1.GetSystemInfoRequest
+	27,  // 27: containarium.v1.ContainerService.ListBackends:input_type -> containarium.v1.ListBackendsRequest
+	28,  // 28: containarium.v1.ContainerService.AdvertiseCapacity:input_type -> containarium.v1.AdvertiseCapacityRequest
+	29,  // 29: containarium.v1.ContainerService.WithdrawCapacity:input_type -> containarium.v1.WithdrawCapacityRequest
+	30,  // 30: containarium.v1.ContainerService.GetCapacityHeadroom:input_type -> containarium.v1.GetCapacityHeadroomRequest
+	31,  // 31: containarium.v1.ContainerService.ProfileBackend:input_type -> containarium.v1.ProfileBackendRequest
+	32,  // 32: containarium.v1.ContainerService.GetCapabilityProfile:input_type -> containarium.v1.GetCapabilityProfileRequest
+	33,  // 33: containarium.v1.ContainerService.GetSelfMeasurement:input_type -> containarium.v1.GetSelfMeasurementRequest
+	34,  // 34: containarium.v1.ContainerService.GetLatestRelease:input_type -> containarium.v1.GetLatestReleaseRequest
+	35,  // 35: containarium.v1.ContainerService.ValidateGPU:input_type -> containarium.v1.ValidateGPURequest
+	36,  // 36: containarium.v1.ContainerService.TriggerUpgrade:input_type -> containarium.v1.TriggerUpgradeRequest
+	37,  // 37: containarium.v1.ContainerService.GetUpgradeStatus:input_type -> containarium.v1.GetUpgradeStatusRequest
+	38,  // 38: containarium.v1.ContainerService.GetMonitoringInfo:input_type -> containarium.v1.GetMonitoringInfoRequest
+	39,  // 39: containarium.v1.ContainerService.SetMetricsExport:input_type -> containarium.v1.SetMetricsExportRequest
+	40,  // 40: containarium.v1.ContainerService.GetMetricsExport:input_type -> containarium.v1.GetMetricsExportRequest
+	41,  // 41: containarium.v1.ContainerService.CreateAlertRule:input_type -> containarium.v1.CreateAlertRuleRequest
+	42,  // 42: containarium.v1.ContainerService.ListAlertRules:input_type -> containarium.v1.ListAlertRulesRequest
+	43,  // 43: containarium.v1.ContainerService.GetAlertRule:input_type -> containarium.v1.GetAlertRuleRequest
+	44,  // 44: containarium.v1.ContainerService.UpdateAlertRule:input_type -> containarium.v1.UpdateAlertRuleRequest
+	45,  // 45: containarium.v1.ContainerService.DeleteAlertRule:input_type -> containarium.v1.DeleteAlertRuleRequest
+	46,  // 46: containarium.v1.ContainerService.GetAlertingInfo:input_type -> containarium.v1.GetAlertingInfoRequest
+	47,  // 47: containarium.v1.ContainerService.ListDefaultAlertRules:input_type -> containarium.v1.ListDefaultAlertRulesRequest
+	48,  // 48: containarium.v1.ContainerService.UpdateAlertingConfig:input_type -> containarium.v1.UpdateAlertingConfigRequest
+	49,  // 49: containarium.v1.ContainerService.TestWebhook:input_type -> containarium.v1.TestWebhookRequest
+	50,  // 50: containarium.v1.ContainerService.ListWebhookDeliveries:input_type -> containarium.v1.ListWebhookDeliveriesRequest
+	51,  // 51: containarium.v1.ContainerService.SetSecret:input_type -> containarium.v1.SetSecretRequest
+	52,  // 52: containarium.v1.ContainerService.GetSecret:input_type -> containarium.v1.GetSecretRequest
+	53,  // 53: containarium.v1.ContainerService.ListSecrets:input_type -> containarium.v1.ListSecretsRequest
+	54,  // 54: containarium.v1.ContainerService.DeleteSecret:input_type -> containarium.v1.DeleteSecretRequest
+	55,  // 55: containarium.v1.ContainerService.RefreshSecrets:input_type -> containarium.v1.RefreshSecretsRequest
+	56,  // 56: containarium.v1.ContainerService.CreateContainer:output_type -> containarium.v1.CreateContainerResponse
+	57,  // 57: containarium.v1.ContainerService.ListContainers:output_type -> containarium.v1.ListContainersResponse
+	58,  // 58: containarium.v1.ContainerService.GetContainer:output_type -> containarium.v1.GetContainerResponse
+	59,  // 59: containarium.v1.ContainerService.DebugContainer:output_type -> containarium.v1.DebugContainerResponse
+	60,  // 60: containarium.v1.ContainerService.DeleteContainer:output_type -> containarium.v1.DeleteContainerResponse
+	61,  // 61: containarium.v1.ContainerService.StartContainer:output_type -> containarium.v1.StartContainerResponse
+	62,  // 62: containarium.v1.ContainerService.StopContainer:output_type -> containarium.v1.StopContainerResponse
+	63,  // 63: containarium.v1.ContainerService.ResizeContainer:output_type -> containarium.v1.ResizeContainerResponse
+	64,  // 64: containarium.v1.ContainerService.MoveContainer:output_type -> containarium.v1.MoveContainerResponse
+	65,  // 65: containarium.v1.ContainerService.RewrapContainer:output_type -> containarium.v1.RewrapContainerResponse
+	66,  // 66: containarium.v1.ContainerService.PrepareEncryptedMigration:output_type -> containarium.v1.PrepareEncryptedMigrationResponse
+	67,  // 67: containarium.v1.ContainerService.AdoptMigratedContainer:output_type -> containarium.v1.AdoptMigratedContainerResponse
+	68,  // 68: containarium.v1.ContainerService.ToggleMonitoring:output_type -> containarium.v1.ToggleMonitoringResponse
+	69,  // 69: containarium.v1.ContainerService.ToggleAutoSleep:output_type -> containarium.v1.ToggleAutoSleepResponse
+	70,  // 70: containarium.v1.ContainerService.SetContainerTTL:output_type -> containarium.v1.SetContainerTTLResponse
+	71,  // 71: containarium.v1.ContainerService.SetContainerDeletePolicy:output_type -> containarium.v1.SetContainerDeletePolicyResponse
+	72,  // 72: containarium.v1.ContainerService.SetContainerAttribution:output_type -> containarium.v1.SetContainerAttributionResponse
+	73,  // 73: containarium.v1.ContainerService.AddSSHKey:output_type -> containarium.v1.AddSSHKeyResponse
+	74,  // 74: containarium.v1.ContainerService.RemoveSSHKey:output_type -> containarium.v1.RemoveSSHKeyResponse
+	75,  // 75: containarium.v1.ContainerService.AddCollaborator:output_type -> containarium.v1.AddCollaboratorResponse
+	76,  // 76: containarium.v1.ContainerService.RemoveCollaborator:output_type -> containarium.v1.RemoveCollaboratorResponse
+	77,  // 77: containarium.v1.ContainerService.ListCollaborators:output_type -> containarium.v1.ListCollaboratorsResponse
+	78,  // 78: containarium.v1.ContainerService.GetMetrics:output_type -> containarium.v1.GetMetricsResponse
+	79,  // 79: containarium.v1.ContainerService.CleanupDisk:output_type -> containarium.v1.CleanupDiskResponse
+	80,  // 80: containarium.v1.ContainerService.InstallStack:output_type -> containarium.v1.InstallStackResponse
+	81,  // 81: containarium.v1.ContainerService.ListStacks:output_type -> containarium.v1.ListStacksResponse
+	82,  // 82: containarium.v1.ContainerService.GetSystemInfo:output_type -> containarium.v1.GetSystemInfoResponse
+	83,  // 83: containarium.v1.ContainerService.ListBackends:output_type -> containarium.v1.ListBackendsResponse
+	84,  // 84: containarium.v1.ContainerService.AdvertiseCapacity:output_type -> containarium.v1.AdvertiseCapacityResponse
+	85,  // 85: containarium.v1.ContainerService.WithdrawCapacity:output_type -> containarium.v1.WithdrawCapacityResponse
+	86,  // 86: containarium.v1.ContainerService.GetCapacityHeadroom:output_type -> containarium.v1.GetCapacityHeadroomResponse
+	87,  // 87: containarium.v1.ContainerService.ProfileBackend:output_type -> containarium.v1.ProfileBackendResponse
+	88,  // 88: containarium.v1.ContainerService.GetCapabilityProfile:output_type -> containarium.v1.GetCapabilityProfileResponse
+	89,  // 89: containarium.v1.ContainerService.GetSelfMeasurement:output_type -> containarium.v1.GetSelfMeasurementResponse
+	90,  // 90: containarium.v1.ContainerService.GetLatestRelease:output_type -> containarium.v1.GetLatestReleaseResponse
+	91,  // 91: containarium.v1.ContainerService.ValidateGPU:output_type -> containarium.v1.ValidateGPUResponse
+	92,  // 92: containarium.v1.ContainerService.TriggerUpgrade:output_type -> containarium.v1.TriggerUpgradeResponse
+	93,  // 93: containarium.v1.ContainerService.GetUpgradeStatus:output_type -> containarium.v1.GetUpgradeStatusResponse
+	94,  // 94: containarium.v1.ContainerService.GetMonitoringInfo:output_type -> containarium.v1.GetMonitoringInfoResponse
+	95,  // 95: containarium.v1.ContainerService.SetMetricsExport:output_type -> containarium.v1.SetMetricsExportResponse
+	96,  // 96: containarium.v1.ContainerService.GetMetricsExport:output_type -> containarium.v1.GetMetricsExportResponse
+	97,  // 97: containarium.v1.ContainerService.CreateAlertRule:output_type -> containarium.v1.CreateAlertRuleResponse
+	98,  // 98: containarium.v1.ContainerService.ListAlertRules:output_type -> containarium.v1.ListAlertRulesResponse
+	99,  // 99: containarium.v1.ContainerService.GetAlertRule:output_type -> containarium.v1.GetAlertRuleResponse
+	100, // 100: containarium.v1.ContainerService.UpdateAlertRule:output_type -> containarium.v1.UpdateAlertRuleResponse
+	101, // 101: containarium.v1.ContainerService.DeleteAlertRule:output_type -> containarium.v1.DeleteAlertRuleResponse
+	102, // 102: containarium.v1.ContainerService.GetAlertingInfo:output_type -> containarium.v1.GetAlertingInfoResponse
+	103, // 103: containarium.v1.ContainerService.ListDefaultAlertRules:output_type -> containarium.v1.ListDefaultAlertRulesResponse
+	104, // 104: containarium.v1.ContainerService.UpdateAlertingConfig:output_type -> containarium.v1.UpdateAlertingConfigResponse
+	105, // 105: containarium.v1.ContainerService.TestWebhook:output_type -> containarium.v1.TestWebhookResponse
+	106, // 106: containarium.v1.ContainerService.ListWebhookDeliveries:output_type -> containarium.v1.ListWebhookDeliveriesResponse
+	107, // 107: containarium.v1.ContainerService.SetSecret:output_type -> containarium.v1.SetSecretResponse
+	108, // 108: containarium.v1.ContainerService.GetSecret:output_type -> containarium.v1.GetSecretResponse
+	109, // 109: containarium.v1.ContainerService.ListSecrets:output_type -> containarium.v1.ListSecretsResponse
+	110, // 110: containarium.v1.ContainerService.DeleteSecret:output_type -> containarium.v1.DeleteSecretResponse
+	111, // 111: containarium.v1.ContainerService.RefreshSecrets:output_type -> containarium.v1.RefreshSecretsResponse
+	56,  // [56:112] is the sub-list for method output_type
+	0,   // [0:56] is the sub-list for method input_type
 	0,   // [0:0] is the sub-list for extension type_name
 	0,   // [0:0] is the sub-list for extension extendee
 	0,   // [0:0] is the sub-list for field type_name

--- a/pkg/pb/containarium/v1/service.pb.gw.go
+++ b/pkg/pb/containarium/v1/service.pb.gw.go
@@ -408,6 +408,51 @@ func local_request_ContainerService_MoveContainer_0(ctx context.Context, marshal
 	return msg, metadata, err
 }
 
+func request_ContainerService_RewrapContainer_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RewrapContainerRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.RewrapContainer(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ContainerService_RewrapContainer_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq RewrapContainerRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["username"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "username")
+	}
+	protoReq.Username, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "username", err)
+	}
+	msg, err := server.RewrapContainer(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_ContainerService_PrepareEncryptedMigration_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq PrepareEncryptedMigrationRequest
@@ -2261,6 +2306,26 @@ func RegisterContainerServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_MoveContainer_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_RewrapContainer_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/containarium.v1.ContainerService/RewrapContainer", runtime.WithHTTPPathPattern("/v1/containers/{username}/rewrap"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ContainerService_RewrapContainer_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_RewrapContainer_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_PrepareEncryptedMigration_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -3394,6 +3459,23 @@ func RegisterContainerServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_ContainerService_MoveContainer_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_ContainerService_RewrapContainer_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/containarium.v1.ContainerService/RewrapContainer", runtime.WithHTTPPathPattern("/v1/containers/{username}/rewrap"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ContainerService_RewrapContainer_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ContainerService_RewrapContainer_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_ContainerService_PrepareEncryptedMigration_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -4206,6 +4288,7 @@ var (
 	pattern_ContainerService_StopContainer_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "stop"}, ""))
 	pattern_ContainerService_ResizeContainer_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "resize"}, ""))
 	pattern_ContainerService_MoveContainer_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "move"}, ""))
+	pattern_ContainerService_RewrapContainer_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "rewrap"}, ""))
 	pattern_ContainerService_PrepareEncryptedMigration_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "prepare-encrypted-migration"}, ""))
 	pattern_ContainerService_AdoptMigratedContainer_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "adopt"}, ""))
 	pattern_ContainerService_ToggleMonitoring_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "containers", "username", "monitoring"}, ""))
@@ -4265,6 +4348,7 @@ var (
 	forward_ContainerService_StopContainer_0             = runtime.ForwardResponseMessage
 	forward_ContainerService_ResizeContainer_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_MoveContainer_0             = runtime.ForwardResponseMessage
+	forward_ContainerService_RewrapContainer_0           = runtime.ForwardResponseMessage
 	forward_ContainerService_PrepareEncryptedMigration_0 = runtime.ForwardResponseMessage
 	forward_ContainerService_AdoptMigratedContainer_0    = runtime.ForwardResponseMessage
 	forward_ContainerService_ToggleMonitoring_0          = runtime.ForwardResponseMessage

--- a/pkg/pb/containarium/v1/service_grpc.pb.go
+++ b/pkg/pb/containarium/v1/service_grpc.pb.go
@@ -28,6 +28,7 @@ const (
 	ContainerService_StopContainer_FullMethodName             = "/containarium.v1.ContainerService/StopContainer"
 	ContainerService_ResizeContainer_FullMethodName           = "/containarium.v1.ContainerService/ResizeContainer"
 	ContainerService_MoveContainer_FullMethodName             = "/containarium.v1.ContainerService/MoveContainer"
+	ContainerService_RewrapContainer_FullMethodName           = "/containarium.v1.ContainerService/RewrapContainer"
 	ContainerService_PrepareEncryptedMigration_FullMethodName = "/containarium.v1.ContainerService/PrepareEncryptedMigration"
 	ContainerService_AdoptMigratedContainer_FullMethodName    = "/containarium.v1.ContainerService/AdoptMigratedContainer"
 	ContainerService_ToggleMonitoring_FullMethodName          = "/containarium.v1.ContainerService/ToggleMonitoring"
@@ -108,6 +109,18 @@ type ContainerServiceClient interface {
 	// for active workloads on dir-pool. Prereq: incus remotes
 	// configured both ways between the source and target VMs.
 	MoveContainer(ctx context.Context, in *MoveContainerRequest, opts ...grpc.CallOption) (*MoveContainerResponse, error)
+	// RewrapContainer rotates the key protecting a container's data onto
+	// new key material, without rewriting the data (#1204).
+	//
+	// Rotation is per-TENANT: a tenant's containers share one encryptionroot,
+	// so this rotates the key for every container that tenant owns. The
+	// response lists them.
+	//
+	// The caller supplies the NEW key reference; the daemon resolves it with
+	// its own KeyProvider and never receives key material. OSS ships no
+	// rotation scheduler — cadence is tenant policy owned by the control
+	// plane (design resolved decision #5).
+	RewrapContainer(ctx context.Context, in *RewrapContainerRequest, opts ...grpc.CallOption) (*RewrapContainerResponse, error)
 	// PrepareEncryptedMigration asks this daemon, as a migration
 	// DESTINATION, whether it can take over an encrypted container before
 	// any data is copied — and provisions the tenant's encrypted storage
@@ -416,6 +429,16 @@ func (c *containerServiceClient) MoveContainer(ctx context.Context, in *MoveCont
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(MoveContainerResponse)
 	err := c.cc.Invoke(ctx, ContainerService_MoveContainer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *containerServiceClient) RewrapContainer(ctx context.Context, in *RewrapContainerRequest, opts ...grpc.CallOption) (*RewrapContainerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RewrapContainerResponse)
+	err := c.cc.Invoke(ctx, ContainerService_RewrapContainer_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -914,6 +937,18 @@ type ContainerServiceServer interface {
 	// for active workloads on dir-pool. Prereq: incus remotes
 	// configured both ways between the source and target VMs.
 	MoveContainer(context.Context, *MoveContainerRequest) (*MoveContainerResponse, error)
+	// RewrapContainer rotates the key protecting a container's data onto
+	// new key material, without rewriting the data (#1204).
+	//
+	// Rotation is per-TENANT: a tenant's containers share one encryptionroot,
+	// so this rotates the key for every container that tenant owns. The
+	// response lists them.
+	//
+	// The caller supplies the NEW key reference; the daemon resolves it with
+	// its own KeyProvider and never receives key material. OSS ships no
+	// rotation scheduler — cadence is tenant policy owned by the control
+	// plane (design resolved decision #5).
+	RewrapContainer(context.Context, *RewrapContainerRequest) (*RewrapContainerResponse, error)
 	// PrepareEncryptedMigration asks this daemon, as a migration
 	// DESTINATION, whether it can take over an encrypted container before
 	// any data is copied — and provisions the tenant's encrypted storage
@@ -1164,6 +1199,9 @@ func (UnimplementedContainerServiceServer) ResizeContainer(context.Context, *Res
 }
 func (UnimplementedContainerServiceServer) MoveContainer(context.Context, *MoveContainerRequest) (*MoveContainerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method MoveContainer not implemented")
+}
+func (UnimplementedContainerServiceServer) RewrapContainer(context.Context, *RewrapContainerRequest) (*RewrapContainerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RewrapContainer not implemented")
 }
 func (UnimplementedContainerServiceServer) PrepareEncryptedMigration(context.Context, *PrepareEncryptedMigrationRequest) (*PrepareEncryptedMigrationResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PrepareEncryptedMigration not implemented")
@@ -1482,6 +1520,24 @@ func _ContainerService_MoveContainer_Handler(srv interface{}, ctx context.Contex
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ContainerServiceServer).MoveContainer(ctx, req.(*MoveContainerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ContainerService_RewrapContainer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RewrapContainerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServiceServer).RewrapContainer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ContainerService_RewrapContainer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServiceServer).RewrapContainer(ctx, req.(*RewrapContainerRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2356,6 +2412,10 @@ var ContainerService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "MoveContainer",
 			Handler:    _ContainerService_MoveContainer_Handler,
+		},
+		{
+			MethodName: "RewrapContainer",
+			Handler:    _ContainerService_RewrapContainer_Handler,
 		},
 		{
 			MethodName: "PrepareEncryptedMigration",

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -1250,6 +1250,42 @@ message AdoptMigratedContainerRequest {
   string zfs_pool = 4;
 }
 
+// RewrapContainerRequest rotates the key protecting a container's data
+// (#1204), driven by the control plane during a maintenance window.
+//
+// IMPORTANT: rotation is per-TENANT, not per-container. A tenant's
+// containers share one encryptionroot by design (#1199), so rewrapping the
+// container named here rotates the key for every container that tenant
+// owns. The RPC is named for a container because that is what a caller
+// holds; the response says how many containers were affected so the caller
+// cannot be surprised by it.
+message RewrapContainerRequest {
+  // The container whose tenant's key is being rotated.
+  string username = 1;
+
+  // The NEW key reference, JSON-encoded, already provisioned by whoever
+  // owns key custody. The daemon resolves it through its own KeyProvider —
+  // key material never crosses this wire, exactly as at create time.
+  //
+  // Rotation is control-plane-driven (design resolved decision #5): the
+  // daemon exposes the primitive and holds no rotation schedule of its own.
+  string new_key_ref = 2;
+}
+
+// RewrapContainerResponse reports the outcome of a rotation.
+message RewrapContainerResponse {
+  // Human-readable summary.
+  string message = 1;
+
+  // Every container now protected by the new key — the whole tenant, not
+  // just the one named in the request.
+  repeated string rewrapped_containers = 2;
+
+  // Whether the named container was running before the rotation and has
+  // been started again afterwards.
+  bool restarted = 3;
+}
+
 // PrepareEncryptedMigrationRequest asks a destination daemon whether it
 // can take over an encrypted container, BEFORE any data is copied.
 //

--- a/proto/containarium/v1/service.proto
+++ b/proto/containarium/v1/service.proto
@@ -173,6 +173,29 @@ service ContainerService {
     };
   }
 
+  // RewrapContainer rotates the key protecting a container's data onto
+  // new key material, without rewriting the data (#1204).
+  //
+  // Rotation is per-TENANT: a tenant's containers share one encryptionroot,
+  // so this rotates the key for every container that tenant owns. The
+  // response lists them.
+  //
+  // The caller supplies the NEW key reference; the daemon resolves it with
+  // its own KeyProvider and never receives key material. OSS ships no
+  // rotation scheduler — cadence is tenant policy owned by the control
+  // plane (design resolved decision #5).
+  rpc RewrapContainer(RewrapContainerRequest) returns (RewrapContainerResponse) {
+    option (google.api.http) = {
+      post: "/v1/containers/{username}/rewrap"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Rotate a tenant's encryption key";
+      description: "Rewraps the tenant's ZFS encryptionroot onto new key material supplied as a key reference. Only the wrapping key changes, so the cost is independent of dataset size. Affects every container the tenant owns, which the response lists. Admin only.";
+      tags: "Container Operations";
+    };
+  }
+
   // PrepareEncryptedMigration asks this daemon, as a migration
   // DESTINATION, whether it can take over an encrypted container before
   // any data is copied — and provisions the tenant's encrypted storage


### PR DESCRIPTION
Closes #1204. Design phase 6 / resolved decision #5.

Rewrapping changes only the **wrapping** key — ZFS re-encrypts the dataset's master key, never the data — so a rotation costs the same on a 1 TB dataset as on a 1 GB one. That is what makes it a maintenance-window operation rather than a migration.

The daemon exposes the primitive and holds **no schedule**. Cadence is tenant policy (90d, 1y, on-incident) owned by whoever owns the tenancy database; OSS ships no rotation scheduler.

## Rotation is per-tenant, and the API says so

A tenant's containers share one encryptionroot (#1199), so rewrapping re-keys **all of them**. The RPC is named for a container because that is what a caller holds, but the response lists every container affected — a caller who believes they rotated one container's key will plan their next maintenance window wrongly. That is asserted, not just documented.

## AC2 is an ordering property, and the order *is* the implementation

> A rotation interrupted midway leaves the container startable on exactly one of the two keys — never in a state where neither works.

The rewrap happens first; refs are updated only once ZFS confirms it.

- **Record-then-rewrap** (wrong): a failure between the steps leaves the dataset wrapped by the OLD key while every container names the NEW one → neither key starts them.
- **Rewrap-then-record** (this): a failure leaves old-wrapped and old-recorded → exactly one working key.

Confirmed by inverting the order:

```
--- FAIL: TestRewrapContainer_AFailedRewrapLeavesTheOldKeyRecorded
    stored ref = "/keys/alice-v2.key", want the OLD key still — the dataset is wrapped by it,
    and a ref naming the new key would leave the container startable on neither
```

The new key is also resolved **before** anything is rotated: rewrapping onto a key this daemon cannot fetch again makes the data unreachable at the next start, which is indistinguishable from having lost it.

## Test evidence

CI run linked in a follow-up comment.

**Unit (7)** — the rotation and its refusals: unresolvable new key, unencrypted container, malformed ref, non-admin, and the tenant-wide blast radius (a second container sharing the encryptionroot must end up on the new ref too).

**`pkg/core/zfscrypt` (4)** — `ChangeKey` passes the key on **stdin, never argv**, refuses an empty key and a flag-shaped dataset name, and surfaces ZFS's own error rather than reporting a failed rotation as success.

**Integration, real pool (#1204 AC1 + AC3)** — `TestIntegrationEncryption_RotationRetiresTheOldKey`. The negative is the point: a rewrap that silently left the old key valid looks *identical* to a successful rotation from the daemon's side — same exit code, same recorded ref — while the key the control plane just retired still opens the data. Only ZFS can answer that, so only a real pool asserts it.

## Reviewer notes

- Proto-first: RPC and messages in `.proto`, then `make proto`.
- `ListEncrypted` is an **optional** half of the state store: only rotation needs to enumerate containers, and the create/start/migration paths all address one by name. The Incus-backed implementation reads the key ref rather than trusting a naming convention, and skips (loudly) a container it cannot read rather than letting one unreadable instance hide the rest.
- Admin-only, like `MoveContainer` — rotating a tenant's key custody is an infrastructure operation, not a tenant one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)