### PR TITLE
feat(zfs): surface KEY_UNAVAILABLE on container status

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -7460,9 +7460,12 @@
             "type": "string"
           },
           "description": "All GPU devices attached to this container (device index or PCI address\nper entry). For a single-GPU container this has one entry mirroring\n`gpu_device`; empty when no GPU is attached."
+        },
+        "encryptionState": {
+          "$ref": "#/definitions/EncryptionState",
+          "description": "Whether this container's data is protected by a per-tenant ZFS key, and\nwhether that key is currently loaded (#1202).\n\nKEY_UNAVAILABLE is the one an operator has to act on: the container will\nnot start and its snapshots cannot be inspected until key custody is\nreachable. It is surfaced on status rather than only at the point of\nfailure so the condition is visible before someone trips over it."
         }
-      },
-      "title": "Container represents a complete container instance"
+      }
     },
     "ContainerEvent": {
       "type": "object",
@@ -8329,6 +8332,17 @@
           "description": "Operator-facing summary, set when there's something interesting\nto say beyond the structured fields (e.g. \"already enabled (use\nforce=true to refresh)\")."
         }
       }
+    },
+    "EncryptionState": {
+      "type": "string",
+      "enum": [
+        "ENCRYPTION_STATE_UNSPECIFIED",
+        "ENCRYPTION_STATE_NONE",
+        "ENCRYPTION_STATE_UNLOCKED",
+        "ENCRYPTION_STATE_KEY_UNAVAILABLE"
+      ],
+      "default": "ENCRYPTION_STATE_UNSPECIFIED",
+      "description": "Container represents a complete container instance\nEncryptionState reports whether a container's data is protected by a\nper-tenant ZFS key, and whether that key is currently loaded (#1202).\n\nAn enum rather than a bool or a free-text warning: \"unencrypted\" and\n\"encrypted but currently unopenable\" are different situations with\ndifferent operator responses, and a caller must be able to tell them apart\nwithout parsing prose.\n\n - ENCRYPTION_STATE_UNSPECIFIED: The daemon could not determine the state — it has no encryption wired,\nor the container's encryption state could not be read. Deliberately\ndistinct from NONE: \"we did not check\" must never be reported as\n\"there is nothing to check\".\n - ENCRYPTION_STATE_NONE: Not encrypted with a per-tenant key. Every container ships this way by\ndefault; pool-level encryption, if configured, is a separate control.\n - ENCRYPTION_STATE_UNLOCKED: Encrypted, and the key is loaded — the container's data is readable.\n - ENCRYPTION_STATE_KEY_UNAVAILABLE: Encrypted, and the key is NOT loaded. The container cannot start and its\nsnapshots cannot be inspected until key custody is reachable again.\nZFS still allows snapshots to be TAKEN in this state, which is why the\nbackup window survives a key-custody outage (design resolved decision\n#3) — but reading one back will fail until the key returns."
     },
     "EnqueueAgentTaskRequest": {
       "type": "object",

--- a/internal/server/container_server.go
+++ b/internal/server/container_server.go
@@ -1033,6 +1033,10 @@ func (s *ContainerServer) ListContainers(ctx context.Context, req *pb.ListContai
 		pc := toProtoContainer(&st)
 		pc.Pool = s.resolvePool(pc.BackendId)
 		pc.SshHost = s.sshHost
+		// Local boxes only. A peer's containers are described by the peer —
+		// asking THIS daemon's hooks about them would answer from the wrong
+		// key custody and report every remote container as unencrypted.
+		s.withEncryptionState(ctx, pc)
 		protoContainers = append(protoContainers, pc)
 	}
 
@@ -1201,6 +1205,11 @@ func (s *ContainerServer) GetContainer(ctx context.Context, req *pb.GetContainer
 	protoInfo := toProtoContainer(info)
 	protoInfo.Pool = s.resolvePool(protoInfo.BackendId)
 	protoInfo.SshHost = s.sshHost
+	// #1202: surface KEY_UNAVAILABLE before someone trips over it. ZFS lets
+	// snapshots be taken with the key unloaded and refuses only to read them
+	// back, so without this a tenant accumulates unrestorable snapshots and
+	// nothing says so until a restore is attempted.
+	s.withEncryptionState(ctx, protoInfo)
 	return &pb.GetContainerResponse{
 		Container: protoInfo,
 		// TODO: Add metrics

--- a/internal/server/encryption_status.go
+++ b/internal/server/encryption_status.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"context"
+	"log"
+
+	"github.com/footprintai/containarium/pkg/core/zfscrypt"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Encryption state on container status (#1202), design resolved decision #3.
+//
+// ZFS allows a snapshot to be TAKEN while the key is unloaded and refuses
+// only to read one back. That asymmetry is deliberate — blocking snapshot
+// creation on key-custody reachability would let a transient outage suppress
+// the backup window — but it means a tenant can accumulate snapshots that
+// cannot be restored, and nothing would say so until someone tried.
+//
+// So the condition is surfaced on status, before anyone trips over it.
+
+// encryptionStateFor reports whether a container is encrypted and whether its
+// key is currently loaded.
+//
+// Never guesses. A state that could not be read is UNSPECIFIED, not NONE:
+// an operator reading "not encrypted" would conclude there is nothing to
+// investigate, which is the opposite of what an unreadable state means.
+func (h *encryptionHooks) encryptionStateFor(ctx context.Context, containerName string) pb.EncryptionState {
+	// A daemon with no encryption wired has no encrypted containers — that is
+	// an answer, not an unknown.
+	if !h.enabled() {
+		return pb.EncryptionState_ENCRYPTION_STATE_NONE
+	}
+
+	root, _, encrypted, err := h.encryptionRootFor(containerName)
+	if err != nil {
+		log.Printf("[encryption] could not determine the encryption state of %s: %v", containerName, err)
+		return pb.EncryptionState_ENCRYPTION_STATE_UNSPECIFIED
+	}
+	if !encrypted {
+		return pb.EncryptionState_ENCRYPTION_STATE_NONE
+	}
+
+	status, err := h.zfs.KeyStatus(ctx, root)
+	if err != nil {
+		log.Printf("[encryption] could not read the key status of %s (%s): %v", containerName, root, err)
+		return pb.EncryptionState_ENCRYPTION_STATE_UNSPECIFIED
+	}
+	if status == zfscrypt.KeyAvailable {
+		return pb.EncryptionState_ENCRYPTION_STATE_UNLOCKED
+	}
+	return pb.EncryptionState_ENCRYPTION_STATE_KEY_UNAVAILABLE
+}
+
+// withEncryptionState stamps the encryption state onto a container being
+// returned to a caller.
+//
+// Tolerant by design: this is decoration on a response, and a status field
+// must never be the reason a list fails. An unreadable state is reported as
+// UNSPECIFIED by encryptionStateFor rather than raised here.
+func (s *ContainerServer) withEncryptionState(ctx context.Context, c *pb.Container) *pb.Container {
+	if c == nil {
+		return nil
+	}
+	c.EncryptionState = s.encryption.encryptionStateFor(ctx, c.Name)
+	return c
+}

--- a/internal/server/encryption_status_test.go
+++ b/internal/server/encryption_status_test.go
@@ -1,0 +1,129 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/footprintai/containarium/pkg/core/zfskey"
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// KEY_UNAVAILABLE on container status (#1202, first acceptance criterion).
+//
+// ZFS lets a snapshot be TAKEN while the key is unloaded — which is
+// deliberate, because blocking on key-custody reachability would let a
+// transient outage suppress the backup window (design resolved decision #3).
+// What it will not let you do is read one back. So the condition has to be
+// visible on status, before someone trips over it at restore time.
+//
+// The distinction the enum exists to preserve: "not encrypted" and "encrypted
+// but currently unopenable" are different situations with different operator
+// responses, and "we could not determine it" is a third.
+
+func TestEncryptionStateFor(t *testing.T) {
+	aRef := map[string]zfskey.KeyRef{
+		"alice-container": {Scheme: zfskey.SchemeFile, URI: "/keys/alice.key",
+			Metadata: map[string]string{"tenant": "alice"}},
+	}
+
+	t.Run("an unencrypted container reports NONE", func(t *testing.T) {
+		z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+		h := testHooksWith(t, z, p, &fakeRefStore{refs: map[string]zfskey.KeyRef{}}, newFakePools())
+
+		if got := h.encryptionStateFor(context.Background(), "bob-container"); got != pb.EncryptionState_ENCRYPTION_STATE_NONE {
+			t.Errorf("state = %v, want NONE", got)
+		}
+	})
+
+	t.Run("a loaded key reports UNLOCKED", func(t *testing.T) {
+		z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+		z.stdout["get"] = "available"
+		refs := &fakeRefStore{refs: aRef, pools: map[string]string{"alice-container": "containarium-tenant-alice"}}
+		pools := newFakePools()
+		pools.sources["containarium-tenant-alice"] = "tank/tenants/alice"
+		h := testHooksWith(t, z, p, refs, pools)
+
+		if got := h.encryptionStateFor(context.Background(), "alice-container"); got != pb.EncryptionState_ENCRYPTION_STATE_UNLOCKED {
+			t.Errorf("state = %v, want UNLOCKED", got)
+		}
+	})
+
+	// The one an operator has to act on.
+	t.Run("an unloaded key reports KEY_UNAVAILABLE", func(t *testing.T) {
+		z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+		z.stdout["get"] = "unavailable"
+		refs := &fakeRefStore{refs: aRef, pools: map[string]string{"alice-container": "containarium-tenant-alice"}}
+		pools := newFakePools()
+		pools.sources["containarium-tenant-alice"] = "tank/tenants/alice"
+		h := testHooksWith(t, z, p, refs, pools)
+
+		got := h.encryptionStateFor(context.Background(), "alice-container")
+		if got != pb.EncryptionState_ENCRYPTION_STATE_KEY_UNAVAILABLE {
+			t.Errorf("state = %v, want KEY_UNAVAILABLE — the container cannot start and its "+
+				"snapshots cannot be inspected, and nothing else on status says so", got)
+		}
+	})
+
+	// "We could not check" must never be reported as "there is nothing to
+	// check": an operator reading NONE would conclude the container is
+	// unencrypted and stop looking.
+	t.Run("an unreadable state reports UNSPECIFIED, not NONE", func(t *testing.T) {
+		z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+		refs := &fakeRefStore{
+			refs:  aRef,
+			pools: map[string]string{"alice-container": "containarium-tenant-alice"},
+		}
+		pools := newFakePools()
+		pools.sourceErr = errors.New("incus unreachable")
+		h := testHooksWith(t, z, p, refs, pools)
+
+		got := h.encryptionStateFor(context.Background(), "alice-container")
+		if got == pb.EncryptionState_ENCRYPTION_STATE_NONE {
+			t.Fatal("an unreadable encryption state was reported as NONE — an operator would " +
+				"read that as 'not encrypted' and stop investigating")
+		}
+		if got != pb.EncryptionState_ENCRYPTION_STATE_UNSPECIFIED {
+			t.Errorf("state = %v, want UNSPECIFIED", got)
+		}
+	})
+
+	// A daemon with no encryption wired: every container is genuinely
+	// unencrypted, which is an answer rather than an unknown.
+	t.Run("a daemon without encryption reports NONE", func(t *testing.T) {
+		var h *encryptionHooks
+		if got := h.encryptionStateFor(context.Background(), "alice-container"); got != pb.EncryptionState_ENCRYPTION_STATE_NONE {
+			t.Errorf("state = %v, want NONE", got)
+		}
+	})
+}
+
+// The state has to reach the wire, or it is a field nobody sees.
+func TestContainerStatus_CarriesTheEncryptionState(t *testing.T) {
+	z, p := newZFSFake(), &fakeKeyProvider{key: aKey(t)}
+	z.stdout["get"] = "unavailable"
+	refs := &fakeRefStore{
+		refs: map[string]zfskey.KeyRef{
+			"alice-container": {Scheme: zfskey.SchemeFile, URI: "/keys/alice.key"},
+		},
+		pools: map[string]string{"alice-container": "containarium-tenant-alice"},
+	}
+	pools := newFakePools()
+	pools.sources["containarium-tenant-alice"] = "tank/tenants/alice"
+
+	s := &ContainerServer{encryption: testHooksWith(t, z, p, refs, pools)}
+	out := s.withEncryptionState(context.Background(), &pb.Container{Name: "alice-container"})
+
+	if out.EncryptionState != pb.EncryptionState_ENCRYPTION_STATE_KEY_UNAVAILABLE {
+		t.Errorf("container status carries %v, want KEY_UNAVAILABLE", out.EncryptionState)
+	}
+}
+
+// A nil container must not panic the status path — it is decoration on a
+// response, and decoration must never be the thing that breaks a list.
+func TestContainerStatus_ToleratesANilContainer(t *testing.T) {
+	s := &ContainerServer{}
+	if got := s.withEncryptionState(context.Background(), nil); got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}

--- a/pkg/pb/containarium/v1/container.pb.go
+++ b/pkg/pb/containarium/v1/container.pb.go
@@ -259,6 +259,78 @@ func (DeletePolicy) EnumDescriptor() ([]byte, []int) {
 	return file_containarium_v1_container_proto_rawDescGZIP(), []int{3}
 }
 
+// Container represents a complete container instance
+// EncryptionState reports whether a container's data is protected by a
+// per-tenant ZFS key, and whether that key is currently loaded (#1202).
+//
+// An enum rather than a bool or a free-text warning: "unencrypted" and
+// "encrypted but currently unopenable" are different situations with
+// different operator responses, and a caller must be able to tell them apart
+// without parsing prose.
+type EncryptionState int32
+
+const (
+	// The daemon could not determine the state — it has no encryption wired,
+	// or the container's encryption state could not be read. Deliberately
+	// distinct from NONE: "we did not check" must never be reported as
+	// "there is nothing to check".
+	EncryptionState_ENCRYPTION_STATE_UNSPECIFIED EncryptionState = 0
+	// Not encrypted with a per-tenant key. Every container ships this way by
+	// default; pool-level encryption, if configured, is a separate control.
+	EncryptionState_ENCRYPTION_STATE_NONE EncryptionState = 1
+	// Encrypted, and the key is loaded — the container's data is readable.
+	EncryptionState_ENCRYPTION_STATE_UNLOCKED EncryptionState = 2
+	// Encrypted, and the key is NOT loaded. The container cannot start and its
+	// snapshots cannot be inspected until key custody is reachable again.
+	// ZFS still allows snapshots to be TAKEN in this state, which is why the
+	// backup window survives a key-custody outage (design resolved decision
+	// #3) — but reading one back will fail until the key returns.
+	EncryptionState_ENCRYPTION_STATE_KEY_UNAVAILABLE EncryptionState = 3
+)
+
+// Enum value maps for EncryptionState.
+var (
+	EncryptionState_name = map[int32]string{
+		0: "ENCRYPTION_STATE_UNSPECIFIED",
+		1: "ENCRYPTION_STATE_NONE",
+		2: "ENCRYPTION_STATE_UNLOCKED",
+		3: "ENCRYPTION_STATE_KEY_UNAVAILABLE",
+	}
+	EncryptionState_value = map[string]int32{
+		"ENCRYPTION_STATE_UNSPECIFIED":     0,
+		"ENCRYPTION_STATE_NONE":            1,
+		"ENCRYPTION_STATE_UNLOCKED":        2,
+		"ENCRYPTION_STATE_KEY_UNAVAILABLE": 3,
+	}
+)
+
+func (x EncryptionState) Enum() *EncryptionState {
+	p := new(EncryptionState)
+	*p = x
+	return p
+}
+
+func (x EncryptionState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (EncryptionState) Descriptor() protoreflect.EnumDescriptor {
+	return file_containarium_v1_container_proto_enumTypes[4].Descriptor()
+}
+
+func (EncryptionState) Type() protoreflect.EnumType {
+	return &file_containarium_v1_container_proto_enumTypes[4]
+}
+
+func (x EncryptionState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use EncryptionState.Descriptor instead.
+func (EncryptionState) EnumDescriptor() ([]byte, []int) {
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{4}
+}
+
 // CloudMetricsProvider identifies which host cloud's native monitoring
 // receives the opt-in export (#1069). Typed so the toggle can never be a
 // magic string. AWS is reserved for a future Sink implementation;
@@ -303,11 +375,11 @@ func (x CloudMetricsProvider) String() string {
 }
 
 func (CloudMetricsProvider) Descriptor() protoreflect.EnumDescriptor {
-	return file_containarium_v1_container_proto_enumTypes[4].Descriptor()
+	return file_containarium_v1_container_proto_enumTypes[5].Descriptor()
 }
 
 func (CloudMetricsProvider) Type() protoreflect.EnumType {
-	return &file_containarium_v1_container_proto_enumTypes[4]
+	return &file_containarium_v1_container_proto_enumTypes[5]
 }
 
 func (x CloudMetricsProvider) Number() protoreflect.EnumNumber {
@@ -316,7 +388,7 @@ func (x CloudMetricsProvider) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CloudMetricsProvider.Descriptor instead.
 func (CloudMetricsProvider) EnumDescriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{4}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{5}
 }
 
 // CloudMetricsGroup names an independently enableable set of exported
@@ -375,11 +447,11 @@ func (x CloudMetricsGroup) String() string {
 }
 
 func (CloudMetricsGroup) Descriptor() protoreflect.EnumDescriptor {
-	return file_containarium_v1_container_proto_enumTypes[5].Descriptor()
+	return file_containarium_v1_container_proto_enumTypes[6].Descriptor()
 }
 
 func (CloudMetricsGroup) Type() protoreflect.EnumType {
-	return &file_containarium_v1_container_proto_enumTypes[5]
+	return &file_containarium_v1_container_proto_enumTypes[6]
 }
 
 func (x CloudMetricsGroup) Number() protoreflect.EnumNumber {
@@ -388,7 +460,7 @@ func (x CloudMetricsGroup) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CloudMetricsGroup.Descriptor instead.
 func (CloudMetricsGroup) EnumDescriptor() ([]byte, []int) {
-	return file_containarium_v1_container_proto_rawDescGZIP(), []int{5}
+	return file_containarium_v1_container_proto_rawDescGZIP(), []int{6}
 }
 
 // ResourceLimits defines resource constraints for a container
@@ -564,7 +636,6 @@ func (x *NetworkInfo) GetBridge() string {
 	return ""
 }
 
-// Container represents a complete container instance
 type Container struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique container name (typically username-container)
@@ -668,9 +739,17 @@ type Container struct {
 	// All GPU devices attached to this container (device index or PCI address
 	// per entry). For a single-GPU container this has one entry mirroring
 	// `gpu_device`; empty when no GPU is attached.
-	GpuDevices    []string `protobuf:"bytes,27,rep,name=gpu_devices,json=gpuDevices,proto3" json:"gpu_devices,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	GpuDevices []string `protobuf:"bytes,27,rep,name=gpu_devices,json=gpuDevices,proto3" json:"gpu_devices,omitempty"`
+	// Whether this container's data is protected by a per-tenant ZFS key, and
+	// whether that key is currently loaded (#1202).
+	//
+	// KEY_UNAVAILABLE is the one an operator has to act on: the container will
+	// not start and its snapshots cannot be inspected until key custody is
+	// reachable. It is surfaced on status rather than only at the point of
+	// failure so the condition is visible before someone trips over it.
+	EncryptionState EncryptionState `protobuf:"varint,28,opt,name=encryption_state,json=encryptionState,proto3,enum=containarium.v1.EncryptionState" json:"encryption_state,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *Container) Reset() {
@@ -890,6 +969,13 @@ func (x *Container) GetGpuDevices() []string {
 		return x.GpuDevices
 	}
 	return nil
+}
+
+func (x *Container) GetEncryptionState() EncryptionState {
+	if x != nil {
+		return x.EncryptionState
+	}
+	return EncryptionState_ENCRYPTION_STATE_UNSPECIFIED
 }
 
 // ContainerMetrics contains runtime metrics for a container
@@ -5082,7 +5168,8 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\vmac_address\x18\x02 \x01(\tR\n" +
 	"macAddress\x12\x1c\n" +
 	"\tinterface\x18\x03 \x01(\tR\tinterface\x12\x16\n" +
-	"\x06bridge\x18\x04 \x01(\tR\x06bridge\"\xc4\t\n" +
+	"\x06bridge\x18\x04 \x01(\tR\x06bridge\"\x91\n" +
+	"\n" +
 	"\tContainer\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\busername\x18\x02 \x01(\tR\busername\x125\n" +
@@ -5119,7 +5206,8 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x1cdelete_after_stopped_seconds\x18\x19 \x01(\x03R\x19deleteAfterStoppedSeconds\x12B\n" +
 	"\rdelete_policy\x18\x1a \x01(\x0e2\x1d.containarium.v1.DeletePolicyR\fdeletePolicy\x12\x1f\n" +
 	"\vgpu_devices\x18\x1b \x03(\tR\n" +
-	"gpuDevices\x1a9\n" +
+	"gpuDevices\x12K\n" +
+	"\x10encryption_state\x18\x1c \x01(\x0e2 .containarium.v1.EncryptionStateR\x0fencryptionState\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xcf\x02\n" +
@@ -5436,7 +5524,12 @@ const file_containarium_v1_container_proto_rawDesc = "" +
 	"\x1cCONTAINER_STATE_PROVISIONING\x10\x06\x1a\x10\x8a\xb5\x18\fProvisioning*J\n" +
 	"\fDeletePolicy\x12\x1d\n" +
 	"\x19DELETE_POLICY_UNSPECIFIED\x10\x00\x12\x1b\n" +
-	"\x17DELETE_POLICY_PROTECTED\x10\x01*~\n" +
+	"\x17DELETE_POLICY_PROTECTED\x10\x01*\x93\x01\n" +
+	"\x0fEncryptionState\x12 \n" +
+	"\x1cENCRYPTION_STATE_UNSPECIFIED\x10\x00\x12\x19\n" +
+	"\x15ENCRYPTION_STATE_NONE\x10\x01\x12\x1d\n" +
+	"\x19ENCRYPTION_STATE_UNLOCKED\x10\x02\x12$\n" +
+	" ENCRYPTION_STATE_KEY_UNAVAILABLE\x10\x03*~\n" +
 	"\x14CloudMetricsProvider\x12&\n" +
 	"\"CLOUD_METRICS_PROVIDER_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aCLOUD_METRICS_PROVIDER_GCP\x10\x01\x12\x1e\n" +
@@ -5461,135 +5554,137 @@ func file_containarium_v1_container_proto_rawDescGZIP() []byte {
 	return file_containarium_v1_container_proto_rawDescData
 }
 
-var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
+var file_containarium_v1_container_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
 var file_containarium_v1_container_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
 var file_containarium_v1_container_proto_goTypes = []any{
 	(OSType)(0),                               // 0: containarium.v1.OSType
 	(AccessType)(0),                           // 1: containarium.v1.AccessType
 	(ContainerState)(0),                       // 2: containarium.v1.ContainerState
 	(DeletePolicy)(0),                         // 3: containarium.v1.DeletePolicy
-	(CloudMetricsProvider)(0),                 // 4: containarium.v1.CloudMetricsProvider
-	(CloudMetricsGroup)(0),                    // 5: containarium.v1.CloudMetricsGroup
-	(*ResourceLimits)(nil),                    // 6: containarium.v1.ResourceLimits
-	(*NetworkInfo)(nil),                       // 7: containarium.v1.NetworkInfo
-	(*Container)(nil),                         // 8: containarium.v1.Container
-	(*ContainerMetrics)(nil),                  // 9: containarium.v1.ContainerMetrics
-	(*CreateContainerRequest)(nil),            // 10: containarium.v1.CreateContainerRequest
-	(*CreateContainerResponse)(nil),           // 11: containarium.v1.CreateContainerResponse
-	(*ListContainersRequest)(nil),             // 12: containarium.v1.ListContainersRequest
-	(*ListContainersResponse)(nil),            // 13: containarium.v1.ListContainersResponse
-	(*GetContainerRequest)(nil),               // 14: containarium.v1.GetContainerRequest
-	(*GetContainerResponse)(nil),              // 15: containarium.v1.GetContainerResponse
-	(*DebugContainerRequest)(nil),             // 16: containarium.v1.DebugContainerRequest
-	(*DebugContainerResponse)(nil),            // 17: containarium.v1.DebugContainerResponse
-	(*DeleteContainerRequest)(nil),            // 18: containarium.v1.DeleteContainerRequest
-	(*DeleteContainerResponse)(nil),           // 19: containarium.v1.DeleteContainerResponse
-	(*StartContainerRequest)(nil),             // 20: containarium.v1.StartContainerRequest
-	(*StartContainerResponse)(nil),            // 21: containarium.v1.StartContainerResponse
-	(*StopContainerRequest)(nil),              // 22: containarium.v1.StopContainerRequest
-	(*StopContainerResponse)(nil),             // 23: containarium.v1.StopContainerResponse
-	(*ToggleMonitoringRequest)(nil),           // 24: containarium.v1.ToggleMonitoringRequest
-	(*ToggleMonitoringResponse)(nil),          // 25: containarium.v1.ToggleMonitoringResponse
-	(*ToggleAutoSleepRequest)(nil),            // 26: containarium.v1.ToggleAutoSleepRequest
-	(*ToggleAutoSleepResponse)(nil),           // 27: containarium.v1.ToggleAutoSleepResponse
-	(*SetContainerTTLRequest)(nil),            // 28: containarium.v1.SetContainerTTLRequest
-	(*SetContainerTTLResponse)(nil),           // 29: containarium.v1.SetContainerTTLResponse
-	(*SetContainerDeletePolicyRequest)(nil),   // 30: containarium.v1.SetContainerDeletePolicyRequest
-	(*SetContainerDeletePolicyResponse)(nil),  // 31: containarium.v1.SetContainerDeletePolicyResponse
-	(*SetContainerAttributionRequest)(nil),    // 32: containarium.v1.SetContainerAttributionRequest
-	(*SetContainerAttributionResponse)(nil),   // 33: containarium.v1.SetContainerAttributionResponse
-	(*AddSSHKeyRequest)(nil),                  // 34: containarium.v1.AddSSHKeyRequest
-	(*AddSSHKeyResponse)(nil),                 // 35: containarium.v1.AddSSHKeyResponse
-	(*RemoveSSHKeyRequest)(nil),               // 36: containarium.v1.RemoveSSHKeyRequest
-	(*RemoveSSHKeyResponse)(nil),              // 37: containarium.v1.RemoveSSHKeyResponse
-	(*GetMetricsRequest)(nil),                 // 38: containarium.v1.GetMetricsRequest
-	(*GetMetricsResponse)(nil),                // 39: containarium.v1.GetMetricsResponse
-	(*ResizeContainerRequest)(nil),            // 40: containarium.v1.ResizeContainerRequest
-	(*ResizeContainerResponse)(nil),           // 41: containarium.v1.ResizeContainerResponse
-	(*Collaborator)(nil),                      // 42: containarium.v1.Collaborator
-	(*AddCollaboratorRequest)(nil),            // 43: containarium.v1.AddCollaboratorRequest
-	(*AddCollaboratorResponse)(nil),           // 44: containarium.v1.AddCollaboratorResponse
-	(*RemoveCollaboratorRequest)(nil),         // 45: containarium.v1.RemoveCollaboratorRequest
-	(*RemoveCollaboratorResponse)(nil),        // 46: containarium.v1.RemoveCollaboratorResponse
-	(*ListCollaboratorsRequest)(nil),          // 47: containarium.v1.ListCollaboratorsRequest
-	(*ListCollaboratorsResponse)(nil),         // 48: containarium.v1.ListCollaboratorsResponse
-	(*CleanupDiskRequest)(nil),                // 49: containarium.v1.CleanupDiskRequest
-	(*CleanupDiskResponse)(nil),               // 50: containarium.v1.CleanupDiskResponse
-	(*InstallStackRequest)(nil),               // 51: containarium.v1.InstallStackRequest
-	(*InstallStackResponse)(nil),              // 52: containarium.v1.InstallStackResponse
-	(*StackParameter)(nil),                    // 53: containarium.v1.StackParameter
-	(*StackInfo)(nil),                         // 54: containarium.v1.StackInfo
-	(*ListStacksRequest)(nil),                 // 55: containarium.v1.ListStacksRequest
-	(*ListStacksResponse)(nil),                // 56: containarium.v1.ListStacksResponse
-	(*GetMonitoringInfoRequest)(nil),          // 57: containarium.v1.GetMonitoringInfoRequest
-	(*GetMonitoringInfoResponse)(nil),         // 58: containarium.v1.GetMonitoringInfoResponse
-	(*SetMetricsExportRequest)(nil),           // 59: containarium.v1.SetMetricsExportRequest
-	(*SetMetricsExportResponse)(nil),          // 60: containarium.v1.SetMetricsExportResponse
-	(*GetMetricsExportRequest)(nil),           // 61: containarium.v1.GetMetricsExportRequest
-	(*GetMetricsExportResponse)(nil),          // 62: containarium.v1.GetMetricsExportResponse
-	(*MoveContainerRequest)(nil),              // 63: containarium.v1.MoveContainerRequest
-	(*MoveContainerResponse)(nil),             // 64: containarium.v1.MoveContainerResponse
-	(*AdoptMigratedContainerRequest)(nil),     // 65: containarium.v1.AdoptMigratedContainerRequest
-	(*PrepareEncryptedMigrationRequest)(nil),  // 66: containarium.v1.PrepareEncryptedMigrationRequest
-	(*PrepareEncryptedMigrationResponse)(nil), // 67: containarium.v1.PrepareEncryptedMigrationResponse
-	(*AdoptMigratedContainerResponse)(nil),    // 68: containarium.v1.AdoptMigratedContainerResponse
-	nil,                                       // 69: containarium.v1.Container.LabelsEntry
-	nil,                                       // 70: containarium.v1.CreateContainerRequest.LabelsEntry
-	nil,                                       // 71: containarium.v1.CreateContainerRequest.StackParametersEntry
-	nil,                                       // 72: containarium.v1.ListContainersRequest.LabelFilterEntry
-	nil,                                       // 73: containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	nil,                                       // 74: containarium.v1.SetContainerAttributionResponse.LabelsEntry
-	(*timestamppb.Timestamp)(nil),             // 75: google.protobuf.Timestamp
-	(*descriptorpb.EnumValueOptions)(nil),     // 76: google.protobuf.EnumValueOptions
+	(EncryptionState)(0),                      // 4: containarium.v1.EncryptionState
+	(CloudMetricsProvider)(0),                 // 5: containarium.v1.CloudMetricsProvider
+	(CloudMetricsGroup)(0),                    // 6: containarium.v1.CloudMetricsGroup
+	(*ResourceLimits)(nil),                    // 7: containarium.v1.ResourceLimits
+	(*NetworkInfo)(nil),                       // 8: containarium.v1.NetworkInfo
+	(*Container)(nil),                         // 9: containarium.v1.Container
+	(*ContainerMetrics)(nil),                  // 10: containarium.v1.ContainerMetrics
+	(*CreateContainerRequest)(nil),            // 11: containarium.v1.CreateContainerRequest
+	(*CreateContainerResponse)(nil),           // 12: containarium.v1.CreateContainerResponse
+	(*ListContainersRequest)(nil),             // 13: containarium.v1.ListContainersRequest
+	(*ListContainersResponse)(nil),            // 14: containarium.v1.ListContainersResponse
+	(*GetContainerRequest)(nil),               // 15: containarium.v1.GetContainerRequest
+	(*GetContainerResponse)(nil),              // 16: containarium.v1.GetContainerResponse
+	(*DebugContainerRequest)(nil),             // 17: containarium.v1.DebugContainerRequest
+	(*DebugContainerResponse)(nil),            // 18: containarium.v1.DebugContainerResponse
+	(*DeleteContainerRequest)(nil),            // 19: containarium.v1.DeleteContainerRequest
+	(*DeleteContainerResponse)(nil),           // 20: containarium.v1.DeleteContainerResponse
+	(*StartContainerRequest)(nil),             // 21: containarium.v1.StartContainerRequest
+	(*StartContainerResponse)(nil),            // 22: containarium.v1.StartContainerResponse
+	(*StopContainerRequest)(nil),              // 23: containarium.v1.StopContainerRequest
+	(*StopContainerResponse)(nil),             // 24: containarium.v1.StopContainerResponse
+	(*ToggleMonitoringRequest)(nil),           // 25: containarium.v1.ToggleMonitoringRequest
+	(*ToggleMonitoringResponse)(nil),          // 26: containarium.v1.ToggleMonitoringResponse
+	(*ToggleAutoSleepRequest)(nil),            // 27: containarium.v1.ToggleAutoSleepRequest
+	(*ToggleAutoSleepResponse)(nil),           // 28: containarium.v1.ToggleAutoSleepResponse
+	(*SetContainerTTLRequest)(nil),            // 29: containarium.v1.SetContainerTTLRequest
+	(*SetContainerTTLResponse)(nil),           // 30: containarium.v1.SetContainerTTLResponse
+	(*SetContainerDeletePolicyRequest)(nil),   // 31: containarium.v1.SetContainerDeletePolicyRequest
+	(*SetContainerDeletePolicyResponse)(nil),  // 32: containarium.v1.SetContainerDeletePolicyResponse
+	(*SetContainerAttributionRequest)(nil),    // 33: containarium.v1.SetContainerAttributionRequest
+	(*SetContainerAttributionResponse)(nil),   // 34: containarium.v1.SetContainerAttributionResponse
+	(*AddSSHKeyRequest)(nil),                  // 35: containarium.v1.AddSSHKeyRequest
+	(*AddSSHKeyResponse)(nil),                 // 36: containarium.v1.AddSSHKeyResponse
+	(*RemoveSSHKeyRequest)(nil),               // 37: containarium.v1.RemoveSSHKeyRequest
+	(*RemoveSSHKeyResponse)(nil),              // 38: containarium.v1.RemoveSSHKeyResponse
+	(*GetMetricsRequest)(nil),                 // 39: containarium.v1.GetMetricsRequest
+	(*GetMetricsResponse)(nil),                // 40: containarium.v1.GetMetricsResponse
+	(*ResizeContainerRequest)(nil),            // 41: containarium.v1.ResizeContainerRequest
+	(*ResizeContainerResponse)(nil),           // 42: containarium.v1.ResizeContainerResponse
+	(*Collaborator)(nil),                      // 43: containarium.v1.Collaborator
+	(*AddCollaboratorRequest)(nil),            // 44: containarium.v1.AddCollaboratorRequest
+	(*AddCollaboratorResponse)(nil),           // 45: containarium.v1.AddCollaboratorResponse
+	(*RemoveCollaboratorRequest)(nil),         // 46: containarium.v1.RemoveCollaboratorRequest
+	(*RemoveCollaboratorResponse)(nil),        // 47: containarium.v1.RemoveCollaboratorResponse
+	(*ListCollaboratorsRequest)(nil),          // 48: containarium.v1.ListCollaboratorsRequest
+	(*ListCollaboratorsResponse)(nil),         // 49: containarium.v1.ListCollaboratorsResponse
+	(*CleanupDiskRequest)(nil),                // 50: containarium.v1.CleanupDiskRequest
+	(*CleanupDiskResponse)(nil),               // 51: containarium.v1.CleanupDiskResponse
+	(*InstallStackRequest)(nil),               // 52: containarium.v1.InstallStackRequest
+	(*InstallStackResponse)(nil),              // 53: containarium.v1.InstallStackResponse
+	(*StackParameter)(nil),                    // 54: containarium.v1.StackParameter
+	(*StackInfo)(nil),                         // 55: containarium.v1.StackInfo
+	(*ListStacksRequest)(nil),                 // 56: containarium.v1.ListStacksRequest
+	(*ListStacksResponse)(nil),                // 57: containarium.v1.ListStacksResponse
+	(*GetMonitoringInfoRequest)(nil),          // 58: containarium.v1.GetMonitoringInfoRequest
+	(*GetMonitoringInfoResponse)(nil),         // 59: containarium.v1.GetMonitoringInfoResponse
+	(*SetMetricsExportRequest)(nil),           // 60: containarium.v1.SetMetricsExportRequest
+	(*SetMetricsExportResponse)(nil),          // 61: containarium.v1.SetMetricsExportResponse
+	(*GetMetricsExportRequest)(nil),           // 62: containarium.v1.GetMetricsExportRequest
+	(*GetMetricsExportResponse)(nil),          // 63: containarium.v1.GetMetricsExportResponse
+	(*MoveContainerRequest)(nil),              // 64: containarium.v1.MoveContainerRequest
+	(*MoveContainerResponse)(nil),             // 65: containarium.v1.MoveContainerResponse
+	(*AdoptMigratedContainerRequest)(nil),     // 66: containarium.v1.AdoptMigratedContainerRequest
+	(*PrepareEncryptedMigrationRequest)(nil),  // 67: containarium.v1.PrepareEncryptedMigrationRequest
+	(*PrepareEncryptedMigrationResponse)(nil), // 68: containarium.v1.PrepareEncryptedMigrationResponse
+	(*AdoptMigratedContainerResponse)(nil),    // 69: containarium.v1.AdoptMigratedContainerResponse
+	nil,                                       // 70: containarium.v1.Container.LabelsEntry
+	nil,                                       // 71: containarium.v1.CreateContainerRequest.LabelsEntry
+	nil,                                       // 72: containarium.v1.CreateContainerRequest.StackParametersEntry
+	nil,                                       // 73: containarium.v1.ListContainersRequest.LabelFilterEntry
+	nil,                                       // 74: containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	nil,                                       // 75: containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	(*timestamppb.Timestamp)(nil),             // 76: google.protobuf.Timestamp
+	(*descriptorpb.EnumValueOptions)(nil),     // 77: google.protobuf.EnumValueOptions
 }
 var file_containarium_v1_container_proto_depIdxs = []int32{
 	2,  // 0: containarium.v1.Container.state:type_name -> containarium.v1.ContainerState
-	6,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
-	7,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
-	69, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
+	7,  // 1: containarium.v1.Container.resources:type_name -> containarium.v1.ResourceLimits
+	8,  // 2: containarium.v1.Container.network:type_name -> containarium.v1.NetworkInfo
+	70, // 3: containarium.v1.Container.labels:type_name -> containarium.v1.Container.LabelsEntry
 	0,  // 4: containarium.v1.Container.os_type:type_name -> containarium.v1.OSType
 	1,  // 5: containarium.v1.Container.access_type:type_name -> containarium.v1.AccessType
-	75, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
-	75, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
+	76, // 6: containarium.v1.Container.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	76, // 7: containarium.v1.Container.stopped_at:type_name -> google.protobuf.Timestamp
 	3,  // 8: containarium.v1.Container.delete_policy:type_name -> containarium.v1.DeletePolicy
-	6,  // 9: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
-	70, // 10: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
-	0,  // 11: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
-	71, // 12: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
-	8,  // 13: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
-	2,  // 14: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
-	72, // 15: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
-	8,  // 16: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
-	8,  // 17: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
-	9,  // 18: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
-	8,  // 19: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
-	8,  // 20: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
-	75, // 21: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
-	3,  // 22: containarium.v1.SetContainerDeletePolicyRequest.delete_policy:type_name -> containarium.v1.DeletePolicy
-	3,  // 23: containarium.v1.SetContainerDeletePolicyResponse.delete_policy:type_name -> containarium.v1.DeletePolicy
-	73, // 24: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
-	74, // 25: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
-	9,  // 26: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
-	8,  // 27: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
-	42, // 28: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
-	42, // 29: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
-	8,  // 30: containarium.v1.CleanupDiskResponse.container:type_name -> containarium.v1.Container
-	8,  // 31: containarium.v1.InstallStackResponse.container:type_name -> containarium.v1.Container
-	53, // 32: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
-	54, // 33: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
-	4,  // 34: containarium.v1.SetMetricsExportRequest.provider:type_name -> containarium.v1.CloudMetricsProvider
-	5,  // 35: containarium.v1.SetMetricsExportRequest.groups:type_name -> containarium.v1.CloudMetricsGroup
-	4,  // 36: containarium.v1.SetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
-	5,  // 37: containarium.v1.SetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
-	4,  // 38: containarium.v1.GetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
-	75, // 39: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
-	5,  // 40: containarium.v1.GetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
-	76, // 41: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
-	42, // [42:42] is the sub-list for method output_type
-	42, // [42:42] is the sub-list for method input_type
-	42, // [42:42] is the sub-list for extension type_name
-	41, // [41:42] is the sub-list for extension extendee
-	0,  // [0:41] is the sub-list for field type_name
+	4,  // 9: containarium.v1.Container.encryption_state:type_name -> containarium.v1.EncryptionState
+	7,  // 10: containarium.v1.CreateContainerRequest.resources:type_name -> containarium.v1.ResourceLimits
+	71, // 11: containarium.v1.CreateContainerRequest.labels:type_name -> containarium.v1.CreateContainerRequest.LabelsEntry
+	0,  // 12: containarium.v1.CreateContainerRequest.os_type:type_name -> containarium.v1.OSType
+	72, // 13: containarium.v1.CreateContainerRequest.stack_parameters:type_name -> containarium.v1.CreateContainerRequest.StackParametersEntry
+	9,  // 14: containarium.v1.CreateContainerResponse.container:type_name -> containarium.v1.Container
+	2,  // 15: containarium.v1.ListContainersRequest.state:type_name -> containarium.v1.ContainerState
+	73, // 16: containarium.v1.ListContainersRequest.label_filter:type_name -> containarium.v1.ListContainersRequest.LabelFilterEntry
+	9,  // 17: containarium.v1.ListContainersResponse.containers:type_name -> containarium.v1.Container
+	9,  // 18: containarium.v1.GetContainerResponse.container:type_name -> containarium.v1.Container
+	10, // 19: containarium.v1.GetContainerResponse.metrics:type_name -> containarium.v1.ContainerMetrics
+	9,  // 20: containarium.v1.StartContainerResponse.container:type_name -> containarium.v1.Container
+	9,  // 21: containarium.v1.StopContainerResponse.container:type_name -> containarium.v1.Container
+	76, // 22: containarium.v1.SetContainerTTLResponse.ttl_expires_at:type_name -> google.protobuf.Timestamp
+	3,  // 23: containarium.v1.SetContainerDeletePolicyRequest.delete_policy:type_name -> containarium.v1.DeletePolicy
+	3,  // 24: containarium.v1.SetContainerDeletePolicyResponse.delete_policy:type_name -> containarium.v1.DeletePolicy
+	74, // 25: containarium.v1.SetContainerAttributionRequest.labels:type_name -> containarium.v1.SetContainerAttributionRequest.LabelsEntry
+	75, // 26: containarium.v1.SetContainerAttributionResponse.labels:type_name -> containarium.v1.SetContainerAttributionResponse.LabelsEntry
+	10, // 27: containarium.v1.GetMetricsResponse.metrics:type_name -> containarium.v1.ContainerMetrics
+	9,  // 28: containarium.v1.ResizeContainerResponse.container:type_name -> containarium.v1.Container
+	43, // 29: containarium.v1.AddCollaboratorResponse.collaborator:type_name -> containarium.v1.Collaborator
+	43, // 30: containarium.v1.ListCollaboratorsResponse.collaborators:type_name -> containarium.v1.Collaborator
+	9,  // 31: containarium.v1.CleanupDiskResponse.container:type_name -> containarium.v1.Container
+	9,  // 32: containarium.v1.InstallStackResponse.container:type_name -> containarium.v1.Container
+	54, // 33: containarium.v1.StackInfo.parameters:type_name -> containarium.v1.StackParameter
+	55, // 34: containarium.v1.ListStacksResponse.stacks:type_name -> containarium.v1.StackInfo
+	5,  // 35: containarium.v1.SetMetricsExportRequest.provider:type_name -> containarium.v1.CloudMetricsProvider
+	6,  // 36: containarium.v1.SetMetricsExportRequest.groups:type_name -> containarium.v1.CloudMetricsGroup
+	5,  // 37: containarium.v1.SetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
+	6,  // 38: containarium.v1.SetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
+	5,  // 39: containarium.v1.GetMetricsExportResponse.provider:type_name -> containarium.v1.CloudMetricsProvider
+	76, // 40: containarium.v1.GetMetricsExportResponse.last_success_at:type_name -> google.protobuf.Timestamp
+	6,  // 41: containarium.v1.GetMetricsExportResponse.groups:type_name -> containarium.v1.CloudMetricsGroup
+	77, // 42: containarium.v1.state_name:extendee -> google.protobuf.EnumValueOptions
+	43, // [43:43] is the sub-list for method output_type
+	43, // [43:43] is the sub-list for method input_type
+	43, // [43:43] is the sub-list for extension type_name
+	42, // [42:43] is the sub-list for extension extendee
+	0,  // [0:42] is the sub-list for field type_name
 }
 
 func init() { file_containarium_v1_container_proto_init() }
@@ -5602,7 +5697,7 @@ func file_containarium_v1_container_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_containarium_v1_container_proto_rawDesc), len(file_containarium_v1_container_proto_rawDesc)),
-			NumEnums:      6,
+			NumEnums:      7,
 			NumMessages:   69,
 			NumExtensions: 1,
 			NumServices:   0,

--- a/proto/containarium/v1/container.proto
+++ b/proto/containarium/v1/container.proto
@@ -126,6 +126,35 @@ message NetworkInfo {
 }
 
 // Container represents a complete container instance
+// EncryptionState reports whether a container's data is protected by a
+// per-tenant ZFS key, and whether that key is currently loaded (#1202).
+//
+// An enum rather than a bool or a free-text warning: "unencrypted" and
+// "encrypted but currently unopenable" are different situations with
+// different operator responses, and a caller must be able to tell them apart
+// without parsing prose.
+enum EncryptionState {
+  // The daemon could not determine the state — it has no encryption wired,
+  // or the container's encryption state could not be read. Deliberately
+  // distinct from NONE: "we did not check" must never be reported as
+  // "there is nothing to check".
+  ENCRYPTION_STATE_UNSPECIFIED = 0;
+
+  // Not encrypted with a per-tenant key. Every container ships this way by
+  // default; pool-level encryption, if configured, is a separate control.
+  ENCRYPTION_STATE_NONE = 1;
+
+  // Encrypted, and the key is loaded — the container's data is readable.
+  ENCRYPTION_STATE_UNLOCKED = 2;
+
+  // Encrypted, and the key is NOT loaded. The container cannot start and its
+  // snapshots cannot be inspected until key custody is reachable again.
+  // ZFS still allows snapshots to be TAKEN in this state, which is why the
+  // backup window survives a key-custody outage (design resolved decision
+  // #3) — but reading one back will fail until the key returns.
+  ENCRYPTION_STATE_KEY_UNAVAILABLE = 3;
+}
+
 message Container {
   // Unique container name (typically username-container)
   string name = 1;
@@ -255,6 +284,15 @@ message Container {
   // per entry). For a single-GPU container this has one entry mirroring
   // `gpu_device`; empty when no GPU is attached.
   repeated string gpu_devices = 27;
+
+  // Whether this container's data is protected by a per-tenant ZFS key, and
+  // whether that key is currently loaded (#1202).
+  //
+  // KEY_UNAVAILABLE is the one an operator has to act on: the container will
+  // not start and its snapshots cannot be inspected until key custody is
+  // reachable. It is surfaced on status rather than only at the point of
+  // failure so the condition is visible before someone trips over it.
+  EncryptionState encryption_state = 28;
 }
 
 // ContainerMetrics contains runtime metrics for a container


### PR DESCRIPTION
Part of #1202 — its **first** acceptance criterion. The other two need snapshot RPCs to exist at all (#1160) and stay open; this does not close the issue.

## Why this is worth surfacing at all

ZFS lets a snapshot be **taken** while the key is unloaded, and refuses only to **read one back**. That asymmetry is deliberate (design resolved decision #3): blocking snapshot creation on key-custody reachability would let a transient outage suppress the backup window.

The consequence is that a tenant can quietly accumulate snapshots that cannot be restored, and nothing says so until someone attempts a restore — which is the worst moment to find out. So the condition goes on status, before anyone trips over it.

## A typed enum, not a bool or a warning string

| State | Meaning |
| --- | --- |
| `NONE` | Not encrypted with a per-tenant key — every container by default |
| `UNLOCKED` | Encrypted, key loaded, data readable |
| `KEY_UNAVAILABLE` | Encrypted, key **not** loaded — will not start, snapshots not inspectable |
| `UNSPECIFIED` | The daemon could not determine it |

`UNSPECIFIED` earns its place: **an unreadable state must never report as `NONE`**, because an operator reading "not encrypted" concludes there is nothing to investigate and stops. That is the one case worth a test of its own, and it is mutation-verified:

```
--- FAIL: TestEncryptionStateFor/an_unreadable_state_reports_UNSPECIFIED,_not_NONE
    an unreadable encryption state was reported as NONE — an operator would read that as
    'not encrypted' and stop investigating
```

## Scope note a reviewer should check

Stamped on `GetContainer` and on **locally-listed** containers only — deliberately not on peer-listed ones. A peer's containers are described by the peer; asking *this* daemon's hooks about them would answer from the wrong key custody and report every remote container as unencrypted, which is precisely the false-negative this field exists to prevent.

## Test evidence

CI run linked in a follow-up comment. 7 tests: the four states, a daemon with no encryption wired (genuinely `NONE`, an answer rather than an unknown), the field reaching the wire, and a nil container tolerated — status decoration must never be the reason a list fails.

Proto-first: enum and field added to `.proto`, then `make proto`.

## What is left on #1202

- **AC2** (inspecting a snapshot fails with a clear error) and **AC3** (#1160's snapshot work operates on encrypted datasets) both need a snapshot surface. `grep -rn 'rpc.*Snapshot' proto/containarium/v1/` still returns nothing, and #1160 is open and unstarted. The `zfscrypt` layer beneath them — `EnsureInspectable`, `Snapshot`, `RollbackToSnapshot` — already exists and is tested; what is missing is everything above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)