### PR TITLE
fix(crew): scope stranded-run reconciliation to the daemon that owns them

### DIFF
--- a/api/swagger/containarium.swagger.json
+++ b/api/swagger/containarium.swagger.json
@@ -7906,6 +7906,10 @@
         "error": {
           "type": "string",
           "description": "Human-readable error when state is FAILED."
+        },
+        "owner": {
+          "type": "string",
+          "description": "The daemon driving this run — its backend id (#1322).\n\nStartup reconciliation marks in-flight runs FAILED because they have no\nresumption point. On a deployment where several daemons share one\ndatabase, a restart must only reconcile ITS OWN runs: a peer's run is\nthat peer's to fail, on its own restart. Without this, one daemon\nrestarting fails every other daemon's live runs.\n\nEmpty on runs written before ownership existed; those are deliberately\nleft alone rather than guessed at."
         }
       },
       "description": "CrewRun is one execution of a crew. Every A2A hop and MCP call made by any\nagent in the run is audit-logged under this run's trace_id, so a run is\nitself an evidence artifact."

--- a/internal/server/crew_run_owner_test.go
+++ b/internal/server/crew_run_owner_test.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/footprintai/containarium/pkg/pb/containarium/v1"
+)
+
+// Ownership of stranded-run reconciliation (#1322, part 2's third criterion).
+//
+// The sweep marks every RUNNING run FAILED at daemon start, because a run the
+// previous daemon was driving has no resumption point. That is right for a
+// single daemon and wrong the moment two share one Postgres — which the peer
+// pool makes a real topology: daemon B restarting would mark daemon A's
+// in-flight runs FAILED while A is still driving them.
+//
+// #1322 named this and asked for the design decision to be written down
+// before code. It is: a run records the daemon that owns it, and the sweep
+// fails runs that are THIS daemon's or unowned — never a peer's. A peer's run
+// is that peer's to reconcile, on its own restart.
+//
+// Deliberately NOT a heartbeat. A heartbeat would additionally reap runs whose
+// owner died permanently, at the cost of a liveness protocol and a timeout to
+// tune wrongly. Owner-scoping is strictly better than today and cannot fail a
+// peer's live run; the permanently-dead-owner case stays visible as a run that
+// never terminates, rather than being guessed at.
+
+func TestMemCrewRunStore_FailStrandedOnlyFailsItsOwnRuns(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemCrewRunStore()
+
+	mine := &pb.CrewRun{Id: "mine", State: pb.CrewRunState_CREW_RUN_STATE_RUNNING, Owner: "vm-a"}
+	theirs := &pb.CrewRun{Id: "theirs", State: pb.CrewRunState_CREW_RUN_STATE_RUNNING, Owner: "vm-b"}
+	for _, r := range []*pb.CrewRun{mine, theirs} {
+		if err := s.Put(ctx, r); err != nil {
+			t.Fatalf("Put(%s): %v", r.Id, err)
+		}
+	}
+
+	n, err := s.FailStranded(ctx, "vm-a", StrandedByRestart)
+	if err != nil {
+		t.Fatalf("FailStranded: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("failed %d run(s), want 1", n)
+	}
+
+	got, _, err := s.Get(ctx, "theirs")
+	if err != nil {
+		t.Fatalf("Get(theirs): %v", err)
+	}
+	if got.State != pb.CrewRunState_CREW_RUN_STATE_RUNNING {
+		t.Errorf("a peer's in-flight run was marked %v by THIS daemon's restart — vm-b is still "+
+			"driving it, and its caller now sees a failure that did not happen", got.State)
+	}
+
+	own, _, err := s.Get(ctx, "mine")
+	if err != nil {
+		t.Fatalf("Get(mine): %v", err)
+	}
+	if own.State != pb.CrewRunState_CREW_RUN_STATE_FAILED {
+		t.Errorf("this daemon's own stranded run is %v, want FAILED — it has no resumption point "+
+			"and would answer RUNNING forever", own.State)
+	}
+}
+
+// A run with no recorded owner predates ownership, and is still swept.
+//
+// This is the deliberate half of the design. Leaving them would strand every
+// pre-upgrade run forever, reintroducing #1182 for exactly the rows the
+// reconciliation exists for — and on the single-daemon deployment that is the
+// default, an unowned run is always this daemon's own. The bounded risk is a
+// multi-daemon deployment's FIRST restart after upgrade, where a peer's
+// pre-upgrade run could be swept once; after that every run carries an owner
+// and peers are protected permanently.
+func TestMemCrewRunStore_FailStrandedStillSweepsUnownedRuns(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemCrewRunStore()
+
+	if err := s.Put(ctx, &pb.CrewRun{Id: "legacy", State: pb.CrewRunState_CREW_RUN_STATE_RUNNING}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	n, err := s.FailStranded(ctx, "vm-a", StrandedByRestart)
+	if err != nil {
+		t.Fatalf("FailStranded: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("failed %d run(s), want 1 — a run written before ownership existed would "+
+			"otherwise answer RUNNING forever, which is the bug reconciliation exists to fix", n)
+	}
+}

--- a/internal/server/crew_run_store.go
+++ b/internal/server/crew_run_store.go
@@ -32,8 +32,16 @@ type CrewRunStore interface {
 	Put(ctx context.Context, r *pb.CrewRun) error
 	// Get returns the run and whether it was found.
 	Get(ctx context.Context, id string) (*pb.CrewRun, bool, error)
-	// FailStranded marks every run still RUNNING as FAILED with the given
-	// reason, returning how many it changed.
+	// FailStranded marks runs still RUNNING as FAILED with the given reason,
+	// returning how many it changed.
+	//
+	// Scoped to `owner` — this daemon's backend id — plus runs with no
+	// recorded owner. A run owned by a PEER is never touched: several daemons
+	// can share one database, and one restarting must not fail another's
+	// in-flight runs (#1322). Unowned runs predate ownership and are still
+	// swept, because on the single-daemon deployment that is the default they
+	// are always this daemon's own, and leaving them would strand every
+	// pre-upgrade run forever.
 	//
 	// Called once at daemon start. RunCrew records a run as RUNNING before it
 	// drives it, so a daemon that dies mid-run leaves that state behind — and
@@ -41,7 +49,7 @@ type CrewRunStore interface {
 	// for a run that can never finish (#1182 AC4). Nothing else reconciles
 	// them: driveCrew has no resumption point, so the honest outcome is a
 	// terminal failure that says why, not a run that claims to be working.
-	FailStranded(ctx context.Context, reason string) (int, error)
+	FailStranded(ctx context.Context, owner, reason string) (int, error)
 }
 
 // StrandedByRestart is the reason recorded for a run the daemon was driving
@@ -82,12 +90,15 @@ func (s *MemCrewRunStore) Get(_ context.Context, id string) (*pb.CrewRun, bool, 
 	return proto.Clone(r).(*pb.CrewRun), true, nil
 }
 
-func (s *MemCrewRunStore) FailStranded(_ context.Context, reason string) (int, error) {
+func (s *MemCrewRunStore) FailStranded(_ context.Context, owner, reason string) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	n := 0
 	for id, r := range s.runs {
 		if r.GetState() != pb.CrewRunState_CREW_RUN_STATE_RUNNING {
+			continue
+		}
+		if !ownedForReconciliation(r.GetOwner(), owner) {
 			continue
 		}
 		updated := proto.Clone(r).(*pb.CrewRun)
@@ -125,6 +136,10 @@ func NewPostgresCrewRunStore(ctx context.Context, pool *pgxpool.Pool) (*Postgres
 			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		);
 		CREATE INDEX IF NOT EXISTS crew_runs_state_idx ON crew_runs (state);
+		-- #1322: which daemon is driving the run. Added separately so an
+		-- existing deployment picks it up without a migration step; existing
+		-- rows default to '' and are treated as unowned.
+		ALTER TABLE crew_runs ADD COLUMN IF NOT EXISTS owner TEXT NOT NULL DEFAULT '';
 	`
 	if _, err := pool.Exec(ctx, schema); err != nil {
 		return nil, fmt.Errorf("init crew_runs schema: %w", err)
@@ -147,15 +162,19 @@ func (s *PostgresCrewRunStore) Put(ctx context.Context, r *pb.CrewRun) error {
 		return fmt.Errorf("marshal crew run %s: %w", r.GetId(), err)
 	}
 	const q = `
-		INSERT INTO crew_runs (id, crew_id, state, run, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, NOW(), NOW())
+		INSERT INTO crew_runs (id, crew_id, state, run, owner, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
 		ON CONFLICT (id) DO UPDATE SET
 			crew_id = EXCLUDED.crew_id,
 			state = EXCLUDED.state,
 			run = EXCLUDED.run,
+			owner = EXCLUDED.owner,
 			updated_at = NOW()
 	`
-	if _, err := s.pool.Exec(ctx, q, r.GetId(), r.GetCrewId(), int32(r.GetState()), body); err != nil {
+	// owner is stored in its own column as well as inside the JSON body: the
+	// reconciliation sweep filters on it in SQL, and filtering on a JSON field
+	// would cost an index this table does not have.
+	if _, err := s.pool.Exec(ctx, q, r.GetId(), r.GetCrewId(), int32(r.GetState()), body, r.GetOwner()); err != nil {
 		return fmt.Errorf("put crew run %s: %w", r.GetId(), err)
 	}
 	return nil
@@ -194,7 +213,10 @@ func (s *PostgresCrewRunStore) Get(ctx context.Context, id string) (*pb.CrewRun,
 // SQL today (#1300). The memory implementation's behaviour is tested, and the
 // orchestration is guarded, but this statement itself is reviewed rather than
 // exercised.
-func (s *PostgresCrewRunStore) FailStranded(ctx context.Context, reason string) (int, error) {
+func (s *PostgresCrewRunStore) FailStranded(ctx context.Context, owner, reason string) (int, error) {
+	// owner = $5 OR owner = '' — this daemon's runs and pre-ownership ones.
+	// A peer's run is deliberately excluded: several daemons share this table
+	// and one restarting must not fail another's in-flight runs (#1322).
 	const q = `
 		UPDATE crew_runs
 		SET state = $1,
@@ -202,13 +224,14 @@ func (s *PostgresCrewRunStore) FailStranded(ctx context.Context, reason string) 
 		            jsonb_set(run::jsonb, '{state}', to_jsonb($2::text), true),
 		            '{error}', to_jsonb($3::text), true)::text::json,
 		    updated_at = NOW()
-		WHERE state = $4
+		WHERE state = $4 AND (owner = $5 OR owner = '')
 	`
 	tag, err := s.pool.Exec(ctx, q,
 		int32(pb.CrewRunState_CREW_RUN_STATE_FAILED),
 		pb.CrewRunState_CREW_RUN_STATE_FAILED.String(),
 		reason,
 		int32(pb.CrewRunState_CREW_RUN_STATE_RUNNING),
+		owner,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("fail stranded crew runs: %w", err)
@@ -220,4 +243,16 @@ func (s *CrewServer) SetRunStore(store CrewRunStore) {
 	if store != nil {
 		s.runs = store
 	}
+}
+
+// ownedForReconciliation reports whether a stranded run is this daemon's to
+// fail.
+//
+// True for its own runs and for runs with no recorded owner; false for a
+// peer's. The unowned case is the deliberate compromise: on the single-daemon
+// deployment that is the default they are always this daemon's own, and
+// excluding them would leave every pre-ownership run RUNNING forever — the
+// exact bug reconciliation exists to fix.
+func ownedForReconciliation(runOwner, daemonOwner string) bool {
+	return runOwner == "" || runOwner == daemonOwner
 }

--- a/internal/server/crew_run_store_test.go
+++ b/internal/server/crew_run_store_test.go
@@ -216,7 +216,7 @@ func TestMemCrewRunStore_FailStrandedTerminatesRunningRuns(t *testing.T) {
 	mustPut(t, s, &pb.CrewRun{Id: "done", State: pb.CrewRunState_CREW_RUN_STATE_COMPLETED, ArtifactJson: "{}"})
 	mustPut(t, s, &pb.CrewRun{Id: "already-failed", State: pb.CrewRunState_CREW_RUN_STATE_FAILED, Error: "a real failure"})
 
-	n, err := s.FailStranded(ctx, StrandedByRestart)
+	n, err := s.FailStranded(ctx, "", StrandedByRestart)
 	if err != nil {
 		t.Fatalf("FailStranded: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestMemCrewRunStore_FailStrandedLeavesTerminalRunsAlone(t *testing.T) {
 	mustPut(t, s, &pb.CrewRun{Id: "done", State: pb.CrewRunState_CREW_RUN_STATE_COMPLETED, ArtifactJson: "{}"})
 	mustPut(t, s, &pb.CrewRun{Id: "failed", State: pb.CrewRunState_CREW_RUN_STATE_FAILED, Error: "a real failure"})
 
-	if _, err := s.FailStranded(ctx, StrandedByRestart); err != nil {
+	if _, err := s.FailStranded(ctx, "", StrandedByRestart); err != nil {
 		t.Fatalf("FailStranded: %v", err)
 	}
 
@@ -266,8 +266,8 @@ func TestMemCrewRunStore_FailStrandedIsIdempotent(t *testing.T) {
 	s := NewMemCrewRunStore()
 	mustPut(t, s, &pb.CrewRun{Id: "in-flight", State: pb.CrewRunState_CREW_RUN_STATE_RUNNING})
 
-	first, _ := s.FailStranded(ctx, StrandedByRestart)
-	second, _ := s.FailStranded(ctx, StrandedByRestart)
+	first, _ := s.FailStranded(ctx, "", StrandedByRestart)
+	second, _ := s.FailStranded(ctx, "", StrandedByRestart)
 	if first != 1 || second != 0 {
 		t.Errorf("counts were %d then %d, want 1 then 0", first, second)
 	}

--- a/internal/server/crew_server.go
+++ b/internal/server/crew_server.go
@@ -29,7 +29,15 @@ type CrewServer struct {
 	skills  *skills.Manager
 	agents  *AgentSkillServer // reuse RunAgentSkill: provision + scoped token + per-box net policy
 	runs    CrewRunStore
+	// owner identifies this daemon on the runs it drives, so startup
+	// reconciliation can tell its own stranded runs from a peer's live ones
+	// (#1322). Empty on a daemon with no backend id configured, which reads
+	// as unowned — the single-daemon case, where that is correct.
+	owner string
 }
+
+// SetOwner records which daemon this server drives runs as.
+func (s *CrewServer) SetOwner(id string) { s.owner = id }
 
 // NewCrewServer wires the crew service to the agent-skill server (for box
 // provisioning) and the embedded crew + skill catalogs.
@@ -93,6 +101,11 @@ func (s *CrewServer) RunCrew(ctx context.Context, req *pb.RunCrewRequest) (*pb.R
 		TraceId:   trace,
 		State:     pb.CrewRunState_CREW_RUN_STATE_RUNNING,
 		InputJson: req.InputJson,
+		// Which daemon is driving it (#1322). Startup reconciliation fails
+		// runs that are its own or unowned and leaves a peer's alone; without
+		// this every run is unowned and a restart fails all of them, on every
+		// daemon sharing the database.
+		Owner: s.owner,
 	}
 
 	// Record the run before driving it, so an in-flight run is observable.

--- a/internal/server/dual_server.go
+++ b/internal/server/dual_server.go
@@ -1141,6 +1141,7 @@ skipAppHosting:
 				log.Printf("Warning: Failed to create Postgres crew-run store: %v", rErr)
 			} else {
 				crewServer.SetRunStore(runStore)
+				crewServer.SetOwner(config.LocalBackendID)
 				log.Printf("Crew-run persistence enabled (Postgres store)")
 				// Reconcile runs the previous daemon was driving when it
 				// stopped. RunCrew records a run as RUNNING before driving it,
@@ -1148,7 +1149,7 @@ skipAppHosting:
 				// is durable — GetCrewRun would answer RUNNING for a run that
 				// can never finish (#1182 AC4). Best-effort: a daemon that
 				// cannot reconcile should still start.
-				if n, fErr := runStore.FailStranded(context.Background(), StrandedByRestart); fErr != nil {
+				if n, fErr := runStore.FailStranded(context.Background(), config.LocalBackendID, StrandedByRestart); fErr != nil {
 					log.Printf("Warning: could not reconcile stranded crew runs: %v", fErr)
 				} else if n > 0 {
 					log.Printf("Marked %d crew run(s) FAILED: in flight when the previous daemon stopped", n)

--- a/internal/server/store_integration_test.go
+++ b/internal/server/store_integration_test.go
@@ -116,7 +116,7 @@ func TestCrewRunStore_FailStrandedForBothImpls(t *testing.T) {
 			mustPutI(t, s, &pb.CrewRun{Id: "stuck", State: pb.CrewRunState_CREW_RUN_STATE_RUNNING})
 			mustPutI(t, s, &pb.CrewRun{Id: "done", State: pb.CrewRunState_CREW_RUN_STATE_COMPLETED, ArtifactJson: "{}"})
 
-			n, err := s.FailStranded(ctx, StrandedByRestart)
+			n, err := s.FailStranded(ctx, "", StrandedByRestart)
 			if err != nil {
 				t.Fatalf("FailStranded: %v", err)
 			}
@@ -138,7 +138,7 @@ func TestCrewRunStore_FailStrandedForBothImpls(t *testing.T) {
 				t.Errorf("a completed run was altered: %+v", done)
 			}
 
-			if again, _ := s.FailStranded(ctx, StrandedByRestart); again != 0 {
+			if again, _ := s.FailStranded(ctx, "", StrandedByRestart); again != 0 {
 				t.Errorf("second sweep reconciled %d, want 0 (idempotent)", again)
 			}
 		})

--- a/pkg/pb/containarium/v1/agent.pb.go
+++ b/pkg/pb/containarium/v1/agent.pb.go
@@ -1609,7 +1609,18 @@ type CrewRun struct {
 	// JSON artifact produced by the crew. Populated when state is COMPLETED.
 	ArtifactJson string `protobuf:"bytes,6,opt,name=artifact_json,json=artifactJson,proto3" json:"artifact_json,omitempty"`
 	// Human-readable error when state is FAILED.
-	Error         string `protobuf:"bytes,7,opt,name=error,proto3" json:"error,omitempty"`
+	Error string `protobuf:"bytes,7,opt,name=error,proto3" json:"error,omitempty"`
+	// The daemon driving this run — its backend id (#1322).
+	//
+	// Startup reconciliation marks in-flight runs FAILED because they have no
+	// resumption point. On a deployment where several daemons share one
+	// database, a restart must only reconcile ITS OWN runs: a peer's run is
+	// that peer's to fail, on its own restart. Without this, one daemon
+	// restarting fails every other daemon's live runs.
+	//
+	// Empty on runs written before ownership existed; those are deliberately
+	// left alone rather than guessed at.
+	Owner         string `protobuf:"bytes,8,opt,name=owner,proto3" json:"owner,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1689,6 +1700,13 @@ func (x *CrewRun) GetArtifactJson() string {
 func (x *CrewRun) GetError() string {
 	if x != nil {
 		return x.Error
+	}
+	return ""
+}
+
+func (x *CrewRun) GetOwner() string {
+	if x != nil {
+		return x.Owner
 	}
 	return ""
 }
@@ -2166,7 +2184,7 @@ const file_containarium_v1_agent_proto_rawDesc = "" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x03 \x01(\tR\vdescription\x129\n" +
 	"\btopology\x18\x04 \x01(\x0e2\x1d.containarium.v1.CrewTopologyR\btopology\x12\x1b\n" +
-	"\tskill_ids\x18\x05 \x03(\tR\bskillIds\"\xdc\x01\n" +
+	"\tskill_ids\x18\x05 \x03(\tR\bskillIds\"\xf2\x01\n" +
 	"\aCrewRun\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x17\n" +
 	"\acrew_id\x18\x02 \x01(\tR\x06crewId\x12\x19\n" +
@@ -2175,7 +2193,8 @@ const file_containarium_v1_agent_proto_rawDesc = "" +
 	"\n" +
 	"input_json\x18\x05 \x01(\tR\tinputJson\x12#\n" +
 	"\rartifact_json\x18\x06 \x01(\tR\fartifactJson\x12\x14\n" +
-	"\x05error\x18\a \x01(\tR\x05error\"\x12\n" +
+	"\x05error\x18\a \x01(\tR\x05error\x12\x14\n" +
+	"\x05owner\x18\b \x01(\tR\x05owner\"\x12\n" +
 	"\x10ListCrewsRequest\"@\n" +
 	"\x11ListCrewsResponse\x12+\n" +
 	"\x05crews\x18\x01 \x03(\v2\x15.containarium.v1.CrewR\x05crews\" \n" +

--- a/proto/containarium/v1/agent.proto
+++ b/proto/containarium/v1/agent.proto
@@ -456,6 +456,18 @@ message CrewRun {
   string artifact_json = 6;
   // Human-readable error when state is FAILED.
   string error = 7;
+
+  // The daemon driving this run — its backend id (#1322).
+  //
+  // Startup reconciliation marks in-flight runs FAILED because they have no
+  // resumption point. On a deployment where several daemons share one
+  // database, a restart must only reconcile ITS OWN runs: a peer's run is
+  // that peer's to fail, on its own restart. Without this, one daemon
+  // restarting fails every other daemon's live runs.
+  //
+  // Empty on runs written before ownership existed; those are deliberately
+  // left alone rather than guessed at.
+  string owner = 8;
 }
 
 message ListCrewsRequest {}


### PR DESCRIPTION
Closes #1322's one unmet criterion. Found while auditing #1333's out-of-sprint issues — the rest of #1322 is already done, which the umbrella did not reflect.

## The bug

Startup reconciliation marked **every** run still `RUNNING` as `FAILED`:

```sql
WHERE state = $4      -- RUNNING. No owner scoping.
```

Right for a single daemon. Wrong the moment two share a database — which the peer pool makes a real topology. Daemon B restarting marked daemon A's **in-flight** runs `FAILED` while A was still driving them, and A's callers saw failures that had not happened. It recurs on every restart, of every daemon.

## The design decision, written down as #1322 asked

> It cannot race a run that started moments earlier — needs a started-at/heartbeat notion, or a marker that survives the restart. **The design decision here is the interesting part and should be written down before code.**

A run records the daemon driving it, and the sweep fails runs that are **this daemon's or unowned** — never a peer's.

**Why unowned runs are still swept.** On the single-daemon deployment that is the default, an unowned run is always this daemon's own; excluding them would leave every pre-ownership run `RUNNING` forever, which is the exact bug reconciliation exists to fix. The bounded cost is a multi-daemon deployment's *first* restart after upgrade, where a peer's pre-upgrade run could be swept once. After that every run carries an owner and peers are protected permanently.

**Why not a heartbeat.** It would additionally reap runs whose owner died permanently — at the cost of a liveness protocol and a timeout that will be tuned wrongly. Owner-scoping cannot fail a peer's live run, and the dead-owner case stays *visible* as a run that never terminates rather than being guessed at. If that case turns out to matter, a heartbeat is a strictly additive follow-up.

## Test evidence

CI run linked in a follow-up comment.

- `TestMemCrewRunStore_FailStrandedOnlyFailsItsOwnRuns` — a peer's `RUNNING` run survives this daemon's sweep; this daemon's own is failed.
- `TestMemCrewRunStore_FailStrandedStillSweepsUnownedRuns` — the deliberate half, so the compromise is asserted rather than assumed.
- Every pre-existing `FailStranded` test still passes, including the store lane's `TestCrewRunStore_FailStrandedForBothImpls`, which runs against **real Postgres**. Their expectations are unchanged — they pass `""` as the owner, which is the single-daemon case they were always describing.

**Mutation-verified**, restoring today's behaviour:

```
--- FAIL: TestMemCrewRunStore_FailStrandedOnlyFailsItsOwnRuns
    a peer's in-flight run was marked CREW_RUN_STATE_FAILED by THIS daemon's restart —
    vm-b is still driving it, and its caller now sees a failure that did not happen
```

## Reviewer notes

- `owner` is stored **both** in the JSON body and in its own column: the sweep filters on it in SQL, and filtering on a JSON field would need an index this table does not have.
- `ADD COLUMN IF NOT EXISTS` so an existing deployment picks it up with no migration step; existing rows default to `''` and read as unowned.
- Proto-first — `CrewRun.owner` added to `.proto`, then `make proto`.
- `CrewServer.SetOwner` is called from `NewDualServer` with `config.LocalBackendID`, alongside `SetRunStore`. A daemon with no backend id configured writes unowned runs, which is the single-daemon case and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)